### PR TITLE
Add Graph Lens feature for post-analysis canvas filtering

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -49,6 +49,7 @@ import { useResultsRun } from './hooks/useResultsRun'
 import { HighlightLayer } from './highlight/HighlightLayer'
 import { registerFocusHelpers, unregisterFocusHelpers } from './utils/focusHelpers'
 import { usePathHighlight } from './hooks/usePathHighlight'
+import { useLensFilter } from './hooks/useLensFilter'
 import { useGuidancePulseHighlight } from './hooks/useGuidancePulseHighlight'
 import { loadRuns, generateGraphHash } from './store/runHistory'
 // HealthStatusBar removed - validation consolidated into OutputsDock panel
@@ -874,6 +875,9 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   // Graph Interaction P1: Enable path highlighting based on node selection
   // Highlights causal paths from selected factor to goal, dims unrelated nodes
   usePathHighlight()
+
+  // Graph Lens: Compute lens visuals and push to store
+  useLensFilter()
 
   // A.2: Guidance pulse highlight for active GuidanceItem target
   useGuidancePulseHighlight()

--- a/src/canvas/components/LensDropdown.tsx
+++ b/src/canvas/components/LensDropdown.tsx
@@ -32,41 +32,35 @@ function LensChip({ isActive, onClick, chipRef }: LensChipProps) {
       aria-haspopup="true"
       aria-label="Graph lens"
       title="Graph lens (L)"
-      className="top-bar-chip cursor-pointer"
+      className="top-bar-chip cursor-pointer inline-flex items-center border border-panel-border bg-transparent rounded-full relative"
       style={{
-        display: 'inline-flex',
-        alignItems: 'center',
         gap: 4,
         height: 30,
         padding: '0 8px',
-        borderRadius: 999,
-        background: 'transparent',
-        border: '1px solid var(--border-default, #EEE6D8)',
         color: isActive ? 'var(--semantic-info, #3b82f6)' : 'var(--text-light, #908D8D)',
         fontSize: 13,
         fontWeight: 500,
         whiteSpace: 'nowrap' as const,
         transition: 'color 200ms ease',
-        position: 'relative',
       }}
       data-testid="lens-chip"
     >
       <Layers size={16} strokeWidth={1.8} aria-hidden="true" />
-      {/* Active indicator dot */}
-      {isActive && (
-        <span
-          style={{
-            position: 'absolute',
-            top: 3,
-            right: 3,
-            width: 6,
-            height: 6,
-            borderRadius: '50%',
-            background: 'var(--semantic-info, #3b82f6)',
-          }}
-          aria-hidden="true"
-        />
-      )}
+      {/* Active indicator dot — always rendered, fades via opacity for smooth transition */}
+      <span
+        style={{
+          position: 'absolute',
+          top: 3,
+          right: 3,
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          background: 'var(--semantic-info, #3b82f6)',
+          opacity: isActive ? 1 : 0,
+          transition: 'opacity 200ms ease',
+        }}
+        aria-hidden="true"
+      />
       <ChevronDown size={14} strokeWidth={1.8} aria-hidden="true" />
     </button>
   )
@@ -99,13 +93,32 @@ export function LensDropdown({ isOpen, onClose, onToggle }: LensDropdownProps) {
   const isActive = lensMode !== 'full'
   const isVisible = resultsStatus === 'complete' && !comparisonActive
 
-  // Position dropdown below the chip
+  // Position dropdown below the chip, clamped to viewport
   useEffect(() => {
     if (!isOpen || !chipRef.current) return
     const r = chipRef.current.getBoundingClientRect()
-    setPos({
-      top: r.bottom + 6,
-      left: r.left,
+    const dropdownHeight = 280 // approximate max height
+    const dropdownWidth = 200  // minWidth from style
+
+    let top = r.bottom + 6
+    let left = r.left
+
+    // Flip above if it would overflow bottom
+    if (top + dropdownHeight > window.innerHeight) {
+      top = r.top - dropdownHeight - 6
+    }
+    // Clamp right edge
+    if (left + dropdownWidth > window.innerWidth) {
+      left = window.innerWidth - dropdownWidth - 8
+    }
+
+    setPos({ top, left })
+
+    // Auto-focus the active (or first) menu item for keyboard navigation
+    requestAnimationFrame(() => {
+      const active = popoverRef.current?.querySelector('[role="menuitem"][data-active="true"]') as HTMLElement | null
+      const first = popoverRef.current?.querySelector('[role="menuitem"]') as HTMLElement | null
+      ;(active ?? first)?.focus()
     })
   }, [isOpen])
 
@@ -151,6 +164,20 @@ export function LensDropdown({ isOpen, onClose, onToggle }: LensDropdownProps) {
           ref={popoverRef}
           role="menu"
           aria-label="Graph lens"
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+              e.preventDefault()
+              const items = popoverRef.current?.querySelectorAll('[role="menuitem"]')
+              if (!items?.length) return
+              const focused = document.activeElement
+              const idx = Array.from(items).indexOf(focused as Element)
+              const next = e.key === 'ArrowDown'
+                ? (idx + 1) % items.length
+                : (idx - 1 + items.length) % items.length
+              ;(items[next] as HTMLElement).focus()
+            }
+          }}
+          className="border border-panel-border bg-panel shadow-2 rounded-xl"
           style={{
             position: 'fixed',
             top: pos.top,
@@ -158,10 +185,6 @@ export function LensDropdown({ isOpen, onClose, onToggle }: LensDropdownProps) {
             zIndex: 9000,
             padding: '4px 0',
             minWidth: 200,
-            borderRadius: 12,
-            border: '1px solid var(--border-default, #EEE6D8)',
-            boxShadow: '0 8px 24px rgba(38,38,38,0.14)',
-            background: 'var(--bg-panel, #FEFEFE)',
             animation: 'thinkingModeIn 150ms cubic-bezier(0.0, 0, 0.2, 1) both',
           }}
           data-testid="lens-dropdown"
@@ -175,7 +198,7 @@ export function LensDropdown({ isOpen, onClose, onToggle }: LensDropdownProps) {
 
           {/* Separator */}
           {options && options.length >= 2 && (
-            <div style={{ height: 1, margin: '4px 0', background: 'var(--border-default, #EEE6D8)' }} />
+            <div className="h-px my-1" style={{ background: 'var(--border-default, #EEE6D8)' }} />
           )}
 
           {/* Option items */}
@@ -190,7 +213,7 @@ export function LensDropdown({ isOpen, onClose, onToggle }: LensDropdownProps) {
           ))}
 
           {/* Separator */}
-          <div style={{ height: 1, margin: '4px 0', background: 'var(--border-default, #EEE6D8)' }} />
+          <div className="h-px my-1" style={{ background: 'var(--border-default, #EEE6D8)' }} />
 
           {/* Sensitivity */}
           <LensMenuItem
@@ -244,6 +267,7 @@ function LensMenuItem({ label, isActive, onClick, dotColor }: LensMenuItemProps)
       }}
       className="hover:bg-panel-hover"
       data-testid={`lens-item-${label.toLowerCase().replace(/\s+/g, '-')}`}
+      data-active={isActive ? 'true' : undefined}
     >
       {dotColor && (
         <span

--- a/src/canvas/components/LensDropdown.tsx
+++ b/src/canvas/components/LensDropdown.tsx
@@ -1,0 +1,264 @@
+/**
+ * LensDropdown — Graph Lens mode selector.
+ *
+ * Displays in the TopBar as an outlined pill chip (icon-only at rest).
+ * Opens a dropdown with lens modes: Full model, option isolation (per option),
+ * sensitivity, and fragile edges.
+ *
+ * Design system: Lucide icons only, bg-panel dropdown, outlined pill,
+ * sentence case, neutral backgrounds. No emoji.
+ */
+
+import { useRef, useEffect, useState, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { Layers, Check, ChevronDown } from 'lucide-react'
+import { useCanvasStore, selectResultsStatus, selectReport } from '../store'
+import type { LensMode } from '../store'
+
+// ─── Dropdown trigger chip ───────────────────────────────────────────────────
+
+interface LensChipProps {
+  isActive: boolean
+  onClick: () => void
+  chipRef: React.RefObject<HTMLButtonElement | null>
+}
+
+function LensChip({ isActive, onClick, chipRef }: LensChipProps) {
+  return (
+    <button
+      ref={chipRef}
+      type="button"
+      onClick={onClick}
+      aria-haspopup="true"
+      aria-label="Graph lens"
+      title="Graph lens (L)"
+      className="top-bar-chip cursor-pointer"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        height: 30,
+        padding: '0 8px',
+        borderRadius: 999,
+        background: 'transparent',
+        border: '1px solid var(--border-default, #EEE6D8)',
+        color: isActive ? 'var(--semantic-info, #3b82f6)' : 'var(--text-light, #908D8D)',
+        fontSize: 13,
+        fontWeight: 500,
+        whiteSpace: 'nowrap' as const,
+        transition: 'color 200ms ease',
+        position: 'relative',
+      }}
+      data-testid="lens-chip"
+    >
+      <Layers size={16} strokeWidth={1.8} aria-hidden="true" />
+      {/* Active indicator dot */}
+      {isActive && (
+        <span
+          style={{
+            position: 'absolute',
+            top: 3,
+            right: 3,
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: 'var(--semantic-info, #3b82f6)',
+          }}
+          aria-hidden="true"
+        />
+      )}
+      <ChevronDown size={14} strokeWidth={1.8} aria-hidden="true" />
+    </button>
+  )
+}
+
+// ─── Dropdown panel ──────────────────────────────────────────────────────────
+
+interface LensDropdownProps {
+  isOpen: boolean
+  onClose: () => void
+  onToggle: () => void
+}
+
+export function LensDropdown({ isOpen, onClose, onToggle }: LensDropdownProps) {
+  const chipRef = useRef<HTMLButtonElement | null>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState({ top: 0, left: 0 })
+
+  const lensMode = useCanvasStore(s => s.lens.active)
+  const lensOptionId = useCanvasStore(s => s.lens.selectedOptionId)
+  const setLens = useCanvasStore(s => s.setLens)
+  const resultsStatus = useCanvasStore(selectResultsStatus)
+  const report = useCanvasStore(selectReport)
+  const comparisonActive = useCanvasStore(s => s.comparisonMode.active)
+
+  // Get options from report
+  const options = (report as Record<string, unknown> | null | undefined)
+    ?.option_comparison as Array<{ option_id: string; option_label: string }> | undefined
+
+  const isActive = lensMode !== 'full'
+  const isVisible = resultsStatus === 'complete' && !comparisonActive
+
+  // Position dropdown below the chip
+  useEffect(() => {
+    if (!isOpen || !chipRef.current) return
+    const r = chipRef.current.getBoundingClientRect()
+    setPos({
+      top: r.bottom + 6,
+      left: r.left,
+    })
+  }, [isOpen])
+
+  // Outside click + Escape
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (
+        popoverRef.current && !popoverRef.current.contains(e.target as Node) &&
+        chipRef.current && !chipRef.current.contains(e.target as Node)
+      ) {
+        onClose()
+      }
+    }
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+        chipRef.current?.focus()
+      }
+    }
+    const tid = setTimeout(() => document.addEventListener('mousedown', handleClick), 0)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      clearTimeout(tid)
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isOpen, onClose])
+
+  const handleSelect = useCallback((mode: LensMode, optionId?: string) => {
+    setLens(mode, optionId)
+    onClose()
+  }, [setLens, onClose])
+
+  if (!isVisible) return null
+
+  return (
+    <>
+      <LensChip isActive={isActive} onClick={isOpen ? onClose : onToggle} chipRef={chipRef} />
+
+      {isOpen && createPortal(
+        <div
+          ref={popoverRef}
+          role="menu"
+          aria-label="Graph lens"
+          style={{
+            position: 'fixed',
+            top: pos.top,
+            left: pos.left,
+            zIndex: 9000,
+            padding: '4px 0',
+            minWidth: 200,
+            borderRadius: 12,
+            border: '1px solid var(--border-default, #EEE6D8)',
+            boxShadow: '0 8px 24px rgba(38,38,38,0.14)',
+            background: 'var(--bg-panel, #FEFEFE)',
+            animation: 'thinkingModeIn 150ms cubic-bezier(0.0, 0, 0.2, 1) both',
+          }}
+          data-testid="lens-dropdown"
+        >
+          {/* Full model */}
+          <LensMenuItem
+            label="Full model"
+            isActive={lensMode === 'full'}
+            onClick={() => handleSelect('full')}
+          />
+
+          {/* Separator */}
+          {options && options.length >= 2 && (
+            <div style={{ height: 1, margin: '4px 0', background: 'var(--border-default, #EEE6D8)' }} />
+          )}
+
+          {/* Option items */}
+          {options && options.length >= 2 && options.map(opt => (
+            <LensMenuItem
+              key={opt.option_id}
+              label={opt.option_label}
+              isActive={lensMode === 'option' && lensOptionId === opt.option_id}
+              onClick={() => handleSelect('option', opt.option_id)}
+              dotColor="var(--semantic-option, #8b5cf6)"
+            />
+          ))}
+
+          {/* Separator */}
+          <div style={{ height: 1, margin: '4px 0', background: 'var(--border-default, #EEE6D8)' }} />
+
+          {/* Sensitivity */}
+          <LensMenuItem
+            label="Sensitivity"
+            isActive={lensMode === 'sensitivity'}
+            onClick={() => handleSelect('sensitivity')}
+          />
+
+          {/* Fragile edges */}
+          <LensMenuItem
+            label="Fragile edges"
+            isActive={lensMode === 'fragile'}
+            onClick={() => handleSelect('fragile')}
+          />
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}
+
+// ─── Menu item ───────────────────────────────────────────────────────────────
+
+interface LensMenuItemProps {
+  label: string
+  isActive: boolean
+  onClick: () => void
+  dotColor?: string
+}
+
+function LensMenuItem({ label, isActive, onClick, dotColor }: LensMenuItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        width: '100%',
+        padding: '8px 12px',
+        background: 'transparent',
+        border: 'none',
+        cursor: 'pointer',
+        fontSize: 12,
+        fontWeight: isActive ? 500 : 400,
+        color: isActive ? 'var(--semantic-info, #3b82f6)' : 'var(--text-body, #3F3F3E)',
+        textAlign: 'left',
+        transition: 'background 100ms ease',
+      }}
+      className="hover:bg-panel-hover"
+      data-testid={`lens-item-${label.toLowerCase().replace(/\s+/g, '-')}`}
+    >
+      {dotColor && (
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: dotColor,
+            flexShrink: 0,
+          }}
+          aria-hidden="true"
+        />
+      )}
+      <span style={{ flex: 1 }}>{label}</span>
+      {isActive && <Check size={16} strokeWidth={2} aria-hidden="true" />}
+    </button>
+  )
+}

--- a/src/canvas/contextMenu/useMenuItems.ts
+++ b/src/canvas/contextMenu/useMenuItems.ts
@@ -14,6 +14,7 @@ import {
 import type { ComponentType } from 'react'
 import { useCanvasStore, selectResultsStatus, selectReport } from '../store'
 import { isGraphLensEnabled } from '../../flags'
+import { isEdgeFragile as isEdgeFragileFn } from '../utils/fragileEdgeMatch'
 import type { ContextTarget, MenuEntry, MenuItemDef } from './types'
 import type { NodeType } from '../domain/nodes'
 import {
@@ -480,12 +481,9 @@ function buildEdgeMenu(
 
     if (resultsComplete) {
       const report = selectReport(state) as Record<string, unknown> | null | undefined
-      const robustness = report?.robustness as { fragile_edges?: Array<{ edge_id?: string; from_id?: string; to_id?: string }> } | undefined
-      const fragileEdges = robustness?.fragile_edges
-      const isFragile = fragileEdges?.some(fe =>
-        fe.edge_id === target.edgeId ||
-        (fe.from_id === target.edge.source && fe.to_id === target.edge.target)
-      )
+      const robustness = report?.robustness as { fragile_edges?: Array<Record<string, unknown>> } | undefined
+      const fragileEdges = robustness?.fragile_edges ?? []
+      const isFragile = isEdgeFragileFn(target.edgeId, target.edge.source, target.edge.target, fragileEdges)
 
       if (isFragile) {
         items.push({

--- a/src/canvas/contextMenu/useMenuItems.ts
+++ b/src/canvas/contextMenu/useMenuItems.ts
@@ -9,10 +9,11 @@ import { useMemo } from 'react'
 import {
   Sparkles, Zap, Crosshair, SlidersHorizontal, ArrowUpToLine, ArrowDownToLine,
   RotateCcw, Pencil, Plus, Flag, Scissors, Copy, ClipboardPaste, CopyPlus,
-  Trash2, MessageSquare,
+  Trash2, MessageSquare, Layers,
 } from 'lucide-react'
 import type { ComponentType } from 'react'
-import { useCanvasStore } from '../store'
+import { useCanvasStore, selectResultsStatus, selectReport } from '../store'
+import { isGraphLensEnabled } from '../../flags'
 import type { ContextTarget, MenuEntry, MenuItemDef } from './types'
 import type { NodeType } from '../domain/nodes'
 import {
@@ -332,6 +333,40 @@ function buildNodeMenu(
     })
   }
 
+  // --- Graph Lens items (post-analysis only) ---
+  if (isGraphLensEnabled()) {
+    const state = useCanvasStore.getState()
+    const resultsComplete = selectResultsStatus(state) === 'complete'
+
+    if (resultsComplete && kind === 'option') {
+      items.push({
+        id: 'lens-isolate-option',
+        label: "Isolate this option's paths",
+        icon: Layers,
+        tooltip: 'Show only the causal paths for this option',
+        enabled: true,
+        action: wrap(() => state.setLens('option', target.nodeId)),
+      })
+    }
+
+    if (resultsComplete && kind === 'factor') {
+      const report = selectReport(state) as Record<string, unknown> | null | undefined
+      const factorSensitivity = report?.factor_sensitivity as Array<{ node_id: string }> | undefined
+      const hasSensitivity = factorSensitivity?.some(f => f.node_id === target.nodeId)
+
+      if (hasSensitivity) {
+        items.push({
+          id: 'lens-sensitivity',
+          label: 'Show sensitivity view',
+          icon: Layers,
+          tooltip: 'Highlight edges by sensitivity weight',
+          enabled: true,
+          action: wrap(() => state.setLens('sensitivity')),
+        })
+      }
+    }
+  }
+
   items.push(DIV)
 
   // --- Standard clipboard + delete ---
@@ -436,6 +471,33 @@ function buildEdgeMenu(
       enabled: true,
       action: wrap(() => markAsAssumption(target.edgeId, 'edge', showToast)),
     })
+  }
+
+  // --- Graph Lens: fragile edge item (post-analysis only) ---
+  if (isGraphLensEnabled()) {
+    const state = useCanvasStore.getState()
+    const resultsComplete = selectResultsStatus(state) === 'complete'
+
+    if (resultsComplete) {
+      const report = selectReport(state) as Record<string, unknown> | null | undefined
+      const robustness = report?.robustness as { fragile_edges?: Array<{ edge_id?: string; from_id?: string; to_id?: string }> } | undefined
+      const fragileEdges = robustness?.fragile_edges
+      const isFragile = fragileEdges?.some(fe =>
+        fe.edge_id === target.edgeId ||
+        (fe.from_id === target.edge.source && fe.to_id === target.edge.target)
+      )
+
+      if (isFragile) {
+        items.push({
+          id: 'lens-fragile',
+          label: 'Show all fragile edges',
+          icon: Layers,
+          tooltip: 'Highlight all edges that could flip the recommendation',
+          enabled: true,
+          action: wrap(() => state.setLens('fragile')),
+        })
+      }
+    }
   }
 
   // Delete

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -27,6 +27,7 @@ import { useEdgeLabelMode } from '../store/edgeLabelMode'
 import { EdgeEditPopover } from './EdgeEditPopover'
 import { useCanvasStore } from '../store'
 import { isGraphLensEnabled } from '../../flags'
+import { isEdgeFragile as isEdgeFragileFn } from '../utils/fragileEdgeMatch'
 import { existenceCertaintyToLineStyle, calculateEdgeImportance, importanceToStrokeWidth, weightMagnitudeToStrokeWidth } from '../utils/graphDisplayCalculations'
 import { typography } from '../../styles/typography'
 import { useEdgeEditHint } from '../hooks/useFirstTimeHints'
@@ -79,9 +80,13 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     if (!isGraphLensEnabled() || s.lens.active !== 'sensitivity') return null
     return s.lens._sensitivityWeights.get(id) ?? null
   })
-  const lensQuartiles = useCanvasStore(s => {
+  const lensQ25 = useCanvasStore(s => {
     if (!isGraphLensEnabled() || s.lens.active !== 'sensitivity') return null
-    return s.lens._sensitivityQuartiles
+    return s.lens._sensitivityQuartiles?.q25 ?? null
+  })
+  const lensQ75 = useCanvasStore(s => {
+    if (!isGraphLensEnabled() || s.lens.active !== 'sensitivity') return null
+    return s.lens._sensitivityQuartiles?.q75 ?? null
   })
   const isLensFragile = useCanvasStore(s =>
     isGraphLensEnabled() && s.lens.active === 'fragile' && s.lens._fragileEdgeIds.has(id)
@@ -106,24 +111,11 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   }, [isLensFragile, report, id, source, target])
 
   // Check if this edge is fragile (switch_probability > 0.3)
-  // P0 Fix: Match by from_id/to_id (source/target) OR edge_id
-  // API returns from_id/to_id pairs, not edge_id in most cases
+  // Uses shared utility for consistent matching across StyledEdge, useMenuItems, useLensFilter
   const isFragileEdge = useMemo(() => {
     if (!isResultsMode || !report?.robustness) return false
     const fragileEdges = report.robustness.fragile_edges || []
-    return fragileEdges.some((fe: any) => {
-      const switchProb = fe.switch_probability ?? fe.switchProbability ?? fe.marginal_switch_probability ?? fe.marginalSwitchProbability
-      if (typeof switchProb !== 'number' || switchProb <= 0.3) return false
-
-      // Try matching by edge_id first
-      const edgeId = fe.edge_id || fe.edgeId
-      if (edgeId === id) return true
-
-      // P0 Fix: Match by from_id/to_id (source/target) - primary matching method
-      const fromId = fe.from_id ?? fe.fromId ?? fe.source
-      const toId = fe.to_id ?? fe.toId ?? fe.target
-      return fromId === source && toId === target
-    })
+    return isEdgeFragileFn(id, source, target, fragileEdges)
   }, [isResultsMode, report, id, source, target])
 
   // Extract edge data with defaults
@@ -348,9 +340,9 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           // Graph Interaction P1: Highlighted edges get thicker stroke
           strokeWidth: (() => {
             // Graph Lens: sensitivity mode adjusts stroke width by quartile
-            if (lensMode === 'sensitivity' && lensSensWeight !== null && lensQuartiles) {
-              if (lensSensWeight >= lensQuartiles.q75) return 3
-              if (lensSensWeight <= lensQuartiles.q25) return 1
+            if (lensMode === 'sensitivity' && lensSensWeight !== null && lensQ25 !== null && lensQ75 !== null) {
+              if (lensSensWeight >= lensQ75) return 3
+              if (lensSensWeight <= lensQ25) return 1
               return 1.5
             }
             // Graph Lens: fragile mode thickens fragile edges
@@ -366,10 +358,10 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           stroke: isHighlightedEdge ? 'var(--semantic-info)' : (directionStroke ?? visualProps.stroke),
           // Graph Lens: opacity for dimmed edges
           opacity: isLensDimmed ? 0.2
-            : (lensMode === 'sensitivity' && lensSensWeight !== null && lensQuartiles && lensSensWeight <= lensQuartiles.q25) ? 0.4
+            : (lensMode === 'sensitivity' && lensSensWeight !== null && lensQ25 !== null && lensSensWeight <= lensQ25) ? 0.4
             : undefined,
           // Graph Lens: subtle glow for high-sensitivity edges
-          filter: (lensMode === 'sensitivity' && lensSensWeight !== null && lensQuartiles && lensSensWeight >= lensQuartiles.q75)
+          filter: (lensMode === 'sensitivity' && lensSensWeight !== null && lensQ75 !== null && lensSensWeight >= lensQ75)
             ? 'drop-shadow(0 0 2px var(--semantic-info, #3b82f6))'
             : undefined,
           // Performance: use will-change for frequent updates

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -26,6 +26,7 @@ import { getEdgeLabel } from '../domain/edgeLabels'
 import { useEdgeLabelMode } from '../store/edgeLabelMode'
 import { EdgeEditPopover } from './EdgeEditPopover'
 import { useCanvasStore } from '../store'
+import { isGraphLensEnabled } from '../../flags'
 import { existenceCertaintyToLineStyle, calculateEdgeImportance, importanceToStrokeWidth, weightMagnitudeToStrokeWidth } from '../utils/graphDisplayCalculations'
 import { typography } from '../../styles/typography'
 import { useEdgeEditHint } from '../hooks/useFirstTimeHints'
@@ -68,6 +69,41 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // Graph Interaction P1: Path highlighting for selected node
   // React #185 FIX: Use primitive boolean selector to prevent infinite re-renders
   const isHighlightedEdge = useCanvasStore(state => state.highlightedEdges.has(id))
+
+  // Graph Lens: edge dimming and styling
+  const isLensDimmed = useCanvasStore(s =>
+    isGraphLensEnabled() && s.lens._dimmedEdgeIds.has(id)
+  )
+  const lensMode = useCanvasStore(s => isGraphLensEnabled() ? s.lens.active : 'full')
+  const lensSensWeight = useCanvasStore(s => {
+    if (!isGraphLensEnabled() || s.lens.active !== 'sensitivity') return null
+    return s.lens._sensitivityWeights.get(id) ?? null
+  })
+  const lensQuartiles = useCanvasStore(s => {
+    if (!isGraphLensEnabled() || s.lens.active !== 'sensitivity') return null
+    return s.lens._sensitivityQuartiles
+  })
+  const isLensFragile = useCanvasStore(s =>
+    isGraphLensEnabled() && s.lens.active === 'fragile' && s.lens._fragileEdgeIds.has(id)
+  )
+
+  // Graph Lens: alternative winner label for fragile edge hover
+  const lensFragileLabel = useMemo(() => {
+    if (!isLensFragile || !report) return ''
+    const reportAny = report as Record<string, unknown>
+    const robustness = reportAny.robustness as Record<string, unknown> | undefined
+    const fragileEdges = (robustness?.fragile_edges ?? []) as Array<Record<string, unknown>>
+    for (const fe of fragileEdges) {
+      const feEdgeId = (fe.edge_id ?? fe.edgeId) as string | undefined
+      const fromId = (fe.from_id ?? fe.fromId ?? fe.source) as string | undefined
+      const toId = (fe.to_id ?? fe.toId ?? fe.target) as string | undefined
+      if (feEdgeId === id || (fromId === source && toId === target)) {
+        const altLabel = (fe.alternative_winner_label ?? fe.alternativeWinnerLabel) as string | undefined
+        return altLabel ? `If wrong → ${altLabel}` : 'Fragile'
+      }
+    }
+    return 'Fragile'
+  }, [isLensFragile, report, id, source, target])
 
   // Check if this edge is fragile (switch_probability > 0.3)
   // P0 Fix: Match by from_id/to_id (source/target) OR edge_id
@@ -310,7 +346,17 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         path={edgePath}
         style={{
           // Graph Interaction P1: Highlighted edges get thicker stroke
-          strokeWidth: isHighlightedEdge ? Math.max(edgeStrokeWidth, 3) : edgeStrokeWidth,
+          strokeWidth: (() => {
+            // Graph Lens: sensitivity mode adjusts stroke width by quartile
+            if (lensMode === 'sensitivity' && lensSensWeight !== null && lensQuartiles) {
+              if (lensSensWeight >= lensQuartiles.q75) return 3
+              if (lensSensWeight <= lensQuartiles.q25) return 1
+              return 1.5
+            }
+            // Graph Lens: fragile mode thickens fragile edges
+            if (isLensFragile) return 3
+            return isHighlightedEdge ? Math.max(edgeStrokeWidth, 3) : edgeStrokeWidth
+          })(),
           // Fix 1: Use existence certainty for line style, fallback to visual props
           // B.I.10: Pre-run incomplete edges get dashed stroke to indicate "needs attention"
           strokeDasharray: isPreRunIncompleteEdge ? '6 3' : (dashArray ?? visualProps.strokeDasharray),
@@ -318,12 +364,20 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           // F.2: Direction colour always applies — yellow only for truly uninitialised edges
           // Pre-run overlay controls dash pattern only, not colour
           stroke: isHighlightedEdge ? 'var(--semantic-info)' : (directionStroke ?? visualProps.stroke),
+          // Graph Lens: opacity for dimmed edges
+          opacity: isLensDimmed ? 0.2
+            : (lensMode === 'sensitivity' && lensSensWeight !== null && lensQuartiles && lensSensWeight <= lensQuartiles.q25) ? 0.4
+            : undefined,
+          // Graph Lens: subtle glow for high-sensitivity edges
+          filter: (lensMode === 'sensitivity' && lensSensWeight !== null && lensQuartiles && lensSensWeight >= lensQuartiles.q75)
+            ? 'drop-shadow(0 0 2px var(--semantic-info, #3b82f6))'
+            : undefined,
           // Performance: use will-change for frequent updates
           willChange: selected || isHighlightedEdge ? 'stroke, stroke-width, stroke-dasharray' : undefined,
           // D.1: Smooth transitions for live styling; respect prefers-reduced-motion (§7.4)
           transition: prefersReducedMotion
             ? 'none'
-            : 'stroke 200ms ease, stroke-width 200ms ease, stroke-dasharray 200ms ease',
+            : 'stroke 200ms ease, stroke-width 200ms ease, stroke-dasharray 200ms ease, opacity 300ms ease',
         }}
       />
       
@@ -370,6 +424,28 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
             <span style={{ fontSize: '10px', fontWeight: 600 }}>
               Fragile
             </span>
+          </div>
+        </EdgeLabelRenderer>
+      )}
+
+      {/* Graph Lens: Alternative winner label on fragile edges (hover/selection only) */}
+      {/* Correction #2: component-local state, no store update, no rerender of other edges */}
+      {isLensFragile && (isHovered || selected) && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY + 20}px)`,
+              pointerEvents: 'none',
+              padding: '2px 8px',
+              borderRadius: '4px',
+              fontSize: '11px',
+              fontWeight: 500,
+              whiteSpace: 'nowrap',
+            }}
+            className="bg-panel text-text-body border border-warning/30 shadow-sm"
+          >
+            {lensFragileLabel}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/src/canvas/hooks/__tests__/useLensFilter.spec.ts
+++ b/src/canvas/hooks/__tests__/useLensFilter.spec.ts
@@ -84,6 +84,30 @@ describe('buildFragileEdgeSet', () => {
     expect(result.has('e3')).toBe(true)
   })
 
+  it('excludes edges with switch_probability exactly 0.3 (boundary)', () => {
+    const fragile = [
+      { edge_id: 'e1', switch_probability: 0.3 },
+    ]
+    const result = buildFragileEdgeSet(fragile, graphEdges)
+    expect(result.size).toBe(0)
+  })
+
+  it('includes edges with switch_probability just above 0.3', () => {
+    const fragile = [
+      { edge_id: 'e1', switch_probability: 0.31 },
+    ]
+    const result = buildFragileEdgeSet(fragile, graphEdges)
+    expect(result.has('e1')).toBe(true)
+  })
+
+  it('matches via marginalSwitchProbability (camelCase fallback)', () => {
+    const fragile = [
+      { edgeId: 'e2', marginalSwitchProbability: 0.65 },
+    ]
+    const result = buildFragileEdgeSet(fragile, graphEdges)
+    expect(result.has('e2')).toBe(true)
+  })
+
   it('returns empty set for empty fragile edges', () => {
     const result = buildFragileEdgeSet([], graphEdges)
     expect(result.size).toBe(0)

--- a/src/canvas/hooks/__tests__/useLensFilter.spec.ts
+++ b/src/canvas/hooks/__tests__/useLensFilter.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import {
+  _computeQuartiles as computeQuartiles,
+  _getSensitivityValue as getSensitivityValue,
+  _buildFragileEdgeSet as buildFragileEdgeSet,
+} from '../useLensFilter'
+
+describe('getSensitivityValue', () => {
+  it('prioritises elasticity over other fields', () => {
+    expect(getSensitivityValue({ elasticity: 0.8, sensitivity_score: 0.5 })).toBe(0.8)
+  })
+
+  it('falls back through sensitivity_score > sensitivity > importance_score', () => {
+    expect(getSensitivityValue({ sensitivity_score: 0.6 })).toBe(0.6)
+    expect(getSensitivityValue({ sensitivity: 0.4 })).toBe(0.4)
+    expect(getSensitivityValue({ importance_score: 0.3 })).toBe(0.3)
+  })
+
+  it('returns 0 when all fields are missing', () => {
+    expect(getSensitivityValue({})).toBe(0)
+  })
+})
+
+describe('computeQuartiles', () => {
+  it('computes quartile boundaries for sorted values', () => {
+    const values = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    const { q25, q75 } = computeQuartiles(values)
+    expect(q25).toBe(0.3) // index 2
+    expect(q75).toBe(0.7) // index 6
+  })
+
+  it('handles empty array', () => {
+    const { q25, q75 } = computeQuartiles([])
+    expect(q25).toBe(0)
+    expect(q75).toBe(0)
+  })
+
+  it('handles single value', () => {
+    const { q25, q75 } = computeQuartiles([0.5])
+    expect(q25).toBe(0.5)
+    expect(q75).toBe(0.5)
+  })
+})
+
+describe('buildFragileEdgeSet', () => {
+  const graphEdges = [
+    { id: 'e1', source: 'a', target: 'b' },
+    { id: 'e2', source: 'b', target: 'c' },
+    { id: 'e3', source: 'c', target: 'd' },
+  ]
+
+  it('matches fragile edges by edge_id', () => {
+    const fragile = [
+      { edge_id: 'e1', switch_probability: 0.7 },
+      { edge_id: 'e2', switch_probability: 0.5 },
+    ]
+    const result = buildFragileEdgeSet(fragile, graphEdges)
+    expect(result.has('e1')).toBe(true)
+    expect(result.has('e2')).toBe(true)
+    expect(result.has('e3')).toBe(false)
+  })
+
+  it('matches fragile edges by from_id/to_id when edge_id not in graph', () => {
+    const fragile = [
+      { edge_id: 'unknown', from_id: 'a', to_id: 'b', switch_probability: 0.6 },
+    ]
+    const result = buildFragileEdgeSet(fragile, graphEdges)
+    expect(result.has('e1')).toBe(true) // matched by source/target
+  })
+
+  it('excludes edges with switch_probability <= 0.3', () => {
+    const fragile = [
+      { edge_id: 'e1', switch_probability: 0.2 },
+    ]
+    const result = buildFragileEdgeSet(fragile, graphEdges)
+    expect(result.size).toBe(0)
+  })
+
+  it('handles camelCase field names', () => {
+    const fragile = [
+      { edgeId: 'e3', switchProbability: 0.8 },
+    ]
+    const result = buildFragileEdgeSet(fragile, graphEdges)
+    expect(result.has('e3')).toBe(true)
+  })
+
+  it('returns empty set for empty fragile edges', () => {
+    const result = buildFragileEdgeSet([], graphEdges)
+    expect(result.size).toBe(0)
+  })
+})

--- a/src/canvas/hooks/useCanvasKeyboardShortcuts.ts
+++ b/src/canvas/hooks/useCanvasKeyboardShortcuts.ts
@@ -189,13 +189,14 @@ export function useCanvasKeyboardShortcuts({
     }
 
     // ArrowLeft/ArrowRight: Cycle lens option (when option isolation is active)
+    // Only consume the event when lens actually handles it — otherwise let React Flow process arrows
     if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
       const state = useCanvasStore.getState()
       if (isGraphLensEnabled() && state.lens.active === 'option') {
         e.preventDefault()
         state.cycleLensOption(e.key === 'ArrowLeft' ? 'prev' : 'next')
+        return
       }
-      return
     }
 
     // Shift+F10: Open context menu at selected element position

--- a/src/canvas/hooks/useCanvasKeyboardShortcuts.ts
+++ b/src/canvas/hooks/useCanvasKeyboardShortcuts.ts
@@ -4,6 +4,8 @@
  * Shortcuts:
  * - P: Focus inline probabilities editor for selected decision
  * - T: Open Templates panel
+ * - L: Toggle Graph Lens dropdown
+ * - ArrowLeft/ArrowRight: Cycle lens option (when option isolation active)
  * - Alt+V: Cycle through validation errors
  * - Cmd/Ctrl+Enter: Run simulation
  * - Cmd/Ctrl+3: Open Results view in Outputs dock
@@ -14,6 +16,10 @@
 
 import { useEffect, useCallback } from 'react'
 import { useCanvasStore, getNextInvalidNode } from '../store'
+import { isGraphLensEnabled } from '../../flags'
+
+/** Custom event dispatched by L key — TopBar listens to toggle the lens dropdown */
+export const LENS_TOGGLE_EVENT = 'topbar:toggle-lens'
 
 interface UseCanvasKeyboardShortcutsOptions {
   onFocusNode?: (nodeId: string) => void
@@ -170,6 +176,25 @@ export function useCanvasKeyboardShortcuts({
         onToggleDocuments()
       }
 
+      return
+    }
+
+    // L: Toggle Graph Lens dropdown
+    if (e.key === 'l' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+      if (isGraphLensEnabled()) {
+        e.preventDefault()
+        window.dispatchEvent(new CustomEvent(LENS_TOGGLE_EVENT))
+      }
+      return
+    }
+
+    // ArrowLeft/ArrowRight: Cycle lens option (when option isolation is active)
+    if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+      const state = useCanvasStore.getState()
+      if (isGraphLensEnabled() && state.lens.active === 'option') {
+        e.preventDefault()
+        state.cycleLensOption(e.key === 'ArrowLeft' ? 'prev' : 'next')
+      }
       return
     }
 

--- a/src/canvas/hooks/useLensFilter.ts
+++ b/src/canvas/hooks/useLensFilter.ts
@@ -39,7 +39,7 @@ function computeQuartiles(values: number[]): { q25: number; q75: number } {
   const q25Idx = Math.floor(sorted.length * 0.25)
   const q75Idx = Math.floor(sorted.length * 0.75)
   return {
-    q25: sorted[q25Idx],
+    q25: sorted[Math.min(q25Idx, sorted.length - 1)],
     q75: sorted[Math.min(q75Idx, sorted.length - 1)],
   }
 }
@@ -159,11 +159,11 @@ export function useLensFilter(): void {
       const reportAny = report as Record<string, unknown>
       const enrichment = reportAny.enrichment as Record<string, unknown> | undefined
       const sensitivityAnalysis = enrichment?.sensitivity_analysis as Record<string, unknown> | undefined
-      const factorSensitivity: FactorSensitivityEntry[] = (
-        (sensitivityAnalysis?.factors as FactorSensitivityEntry[]) ??
-        (reportAny.factor_sensitivity as FactorSensitivityEntry[]) ??
+      const rawFactors = sensitivityAnalysis?.factors
+      const factorSensitivity: FactorSensitivityEntry[] =
+        Array.isArray(rawFactors) ? rawFactors :
+        Array.isArray(reportAny.factor_sensitivity) ? (reportAny.factor_sensitivity as FactorSensitivityEntry[]) :
         []
-      )
 
       const factorSensMap = new Map<string, number>()
       for (const f of factorSensitivity) {
@@ -193,7 +193,8 @@ export function useLensFilter(): void {
     if (lensActive === 'fragile') {
       const reportAny = report as Record<string, unknown>
       const robustness = reportAny.robustness as Record<string, unknown> | undefined
-      const fragileEdgesData: FragileEdgeEntry[] = (robustness?.fragile_edges as FragileEdgeEntry[]) ?? []
+      const rawFragile = robustness?.fragile_edges
+      const fragileEdgesData: FragileEdgeEntry[] = Array.isArray(rawFragile) ? rawFragile : []
       const graphEdges = edges.map(e => ({ id: e.id, source: e.source, target: e.target }))
 
       const fragileIds = buildFragileEdgeSet(fragileEdgesData, graphEdges)

--- a/src/canvas/hooks/useLensFilter.ts
+++ b/src/canvas/hooks/useLensFilter.ts
@@ -1,0 +1,225 @@
+/**
+ * useLensFilter — Core hook for the Graph Lens feature.
+ *
+ * Computes lens visual state and pushes dimmed/highlighted sets into the store.
+ * BaseNode and StyledEdge read these via primitive boolean selectors on the store.
+ *
+ * Called once from ReactFlowGraph — not from individual node/edge components.
+ */
+
+import { useMemo, useEffect, useRef } from 'react'
+import { useCanvasStore } from '../store'
+import { computeOptionPaths } from '../utils/computeOptionPaths'
+
+// ─── Sensitivity helpers ─────────────────────────────────────────────────────
+
+interface FactorSensitivityEntry {
+  factor_id?: string
+  factorId?: string
+  node_id?: string
+  nodeId?: string
+  elasticity?: number
+  sensitivity_score?: number
+  sensitivity?: number
+  importance_score?: number
+}
+
+function getFactorId(f: FactorSensitivityEntry): string | undefined {
+  return f.factor_id ?? f.factorId ?? f.node_id ?? f.nodeId
+}
+
+/** Field priority: elasticity > sensitivity_score > sensitivity > importance_score */
+function getSensitivityValue(f: FactorSensitivityEntry): number {
+  return f.elasticity ?? f.sensitivity_score ?? f.sensitivity ?? f.importance_score ?? 0
+}
+
+function computeQuartiles(values: number[]): { q25: number; q75: number } {
+  if (values.length === 0) return { q25: 0, q75: 0 }
+  const sorted = [...values].sort((a, b) => a - b)
+  const q25Idx = Math.floor(sorted.length * 0.25)
+  const q75Idx = Math.floor(sorted.length * 0.75)
+  return {
+    q25: sorted[q25Idx],
+    q75: sorted[Math.min(q75Idx, sorted.length - 1)],
+  }
+}
+
+// ─── Fragile edge helpers ────────────────────────────────────────────────────
+
+interface FragileEdgeEntry {
+  edge_id?: string
+  edgeId?: string
+  from_id?: string
+  fromId?: string
+  source?: string
+  to_id?: string
+  toId?: string
+  target?: string
+  switch_probability?: number
+  switchProbability?: number
+  marginal_switch_probability?: number
+  marginalSwitchProbability?: number
+}
+
+function buildFragileEdgeSet(
+  fragileEdges: FragileEdgeEntry[],
+  graphEdges: Array<{ id: string; source: string; target: string }>,
+): Set<string> {
+  const fragileIds = new Set<string>()
+
+  for (const fe of fragileEdges) {
+    const switchProb = fe.switch_probability ?? fe.switchProbability ??
+                       fe.marginal_switch_probability ?? fe.marginalSwitchProbability
+    if (typeof switchProb !== 'number' || switchProb <= 0.3) continue
+
+    const edgeId = fe.edge_id ?? fe.edgeId
+    if (edgeId) {
+      if (graphEdges.some(e => e.id === edgeId)) {
+        fragileIds.add(edgeId)
+        continue
+      }
+    }
+
+    const fromId = fe.from_id ?? fe.fromId ?? fe.source
+    const toId = fe.to_id ?? fe.toId ?? fe.target
+    if (fromId && toId) {
+      const match = graphEdges.find(e => e.source === fromId && e.target === toId)
+      if (match) {
+        fragileIds.add(match.id)
+      }
+    }
+  }
+
+  return fragileIds
+}
+
+// ─── Computed visuals interface ──────────────────────────────────────────────
+
+interface LensVisuals {
+  dimmedNodeIds: Set<string>
+  dimmedEdgeIds: Set<string>
+  sensitivityWeights: Map<string, number>
+  sensitivityQuartiles: { q25: number; q75: number } | null
+  fragileEdgeIds: Set<string>
+}
+
+const EMPTY_SET = new Set<string>()
+const EMPTY_MAP = new Map<string, number>()
+const EMPTY_VISUALS: LensVisuals = {
+  dimmedNodeIds: EMPTY_SET,
+  dimmedEdgeIds: EMPTY_SET,
+  sensitivityWeights: EMPTY_MAP,
+  sensitivityQuartiles: null,
+  fragileEdgeIds: EMPTY_SET,
+}
+
+// ─── Main hook ───────────────────────────────────────────────────────────────
+
+export function useLensFilter(): void {
+  const lensActive = useCanvasStore(s => s.lens.active)
+  const lensOptionId = useCanvasStore(s => s.lens.selectedOptionId)
+  const resultsStatus = useCanvasStore(s => s.results.status)
+  const report = useCanvasStore(s => s.results.report)
+  const nodes = useCanvasStore(s => s.nodes)
+  const edges = useCanvasStore(s => s.edges)
+  const ceeAnalysisReady = useCanvasStore(s => s.ceeAnalysisReady)
+  const setLensVisuals = useCanvasStore(s => s.setLensVisuals)
+
+  const visuals = useMemo((): LensVisuals => {
+    if (lensActive === 'full' || resultsStatus !== 'complete' || !report) {
+      return EMPTY_VISUALS
+    }
+
+    const allNodeIds = new Set(nodes.map(n => n.id))
+    const allEdgeIds = new Set(edges.map(e => e.id))
+
+    // ── Option Isolation ──
+    if (lensActive === 'option' && lensOptionId) {
+      const ceeOptions = ceeAnalysisReady?.options ?? []
+      const graphNodes = nodes.map(n => ({ id: n.id, type: n.type }))
+      const graphEdges = edges.map(e => ({ id: e.id, source: e.source, target: e.target }))
+
+      const paths = computeOptionPaths(graphNodes, graphEdges, lensOptionId, ceeOptions)
+
+      // Dimmed = all nodes/edges NOT in the active set
+      const dimmedNodeIds = new Set<string>()
+      for (const id of allNodeIds) {
+        if (!paths.activeNodeIds.has(id)) dimmedNodeIds.add(id)
+      }
+      const dimmedEdgeIds = new Set<string>()
+      for (const id of allEdgeIds) {
+        if (!paths.activeEdgeKeys.has(id)) dimmedEdgeIds.add(id)
+      }
+
+      return { dimmedNodeIds, dimmedEdgeIds, sensitivityWeights: EMPTY_MAP, sensitivityQuartiles: null, fragileEdgeIds: EMPTY_SET }
+    }
+
+    // ── Sensitivity ──
+    if (lensActive === 'sensitivity') {
+      const reportAny = report as Record<string, unknown>
+      const enrichment = reportAny.enrichment as Record<string, unknown> | undefined
+      const sensitivityAnalysis = enrichment?.sensitivity_analysis as Record<string, unknown> | undefined
+      const factorSensitivity: FactorSensitivityEntry[] = (
+        (sensitivityAnalysis?.factors as FactorSensitivityEntry[]) ??
+        (reportAny.factor_sensitivity as FactorSensitivityEntry[]) ??
+        []
+      )
+
+      const factorSensMap = new Map<string, number>()
+      for (const f of factorSensitivity) {
+        const fid = getFactorId(f)
+        if (fid) factorSensMap.set(fid, Math.abs(getSensitivityValue(f)))
+      }
+
+      // Correction #3: Only style edges where edge.source matches a factor in factor_sensitivity.
+      // Non-factor-originating edges retain normal styling.
+      const sensitivityWeights = new Map<string, number>()
+      const values: number[] = []
+      for (const edge of edges) {
+        const factorSens = factorSensMap.get(edge.source)
+        if (factorSens !== undefined) {
+          sensitivityWeights.set(edge.id, factorSens)
+          values.push(factorSens)
+        }
+      }
+
+      const quartiles = computeQuartiles(values)
+
+      // No node/edge dimming in sensitivity mode — all visible
+      return { dimmedNodeIds: EMPTY_SET, dimmedEdgeIds: EMPTY_SET, sensitivityWeights, sensitivityQuartiles: quartiles, fragileEdgeIds: EMPTY_SET }
+    }
+
+    // ── Fragile Edges ──
+    if (lensActive === 'fragile') {
+      const reportAny = report as Record<string, unknown>
+      const robustness = reportAny.robustness as Record<string, unknown> | undefined
+      const fragileEdgesData: FragileEdgeEntry[] = (robustness?.fragile_edges as FragileEdgeEntry[]) ?? []
+      const graphEdges = edges.map(e => ({ id: e.id, source: e.source, target: e.target }))
+
+      const fragileIds = buildFragileEdgeSet(fragileEdgesData, graphEdges)
+
+      // Dim non-fragile edges (not nodes)
+      const dimmedEdgeIds = new Set<string>()
+      for (const id of allEdgeIds) {
+        if (!fragileIds.has(id)) dimmedEdgeIds.add(id)
+      }
+
+      return { dimmedNodeIds: EMPTY_SET, dimmedEdgeIds, sensitivityWeights: EMPTY_MAP, sensitivityQuartiles: null, fragileEdgeIds: fragileIds }
+    }
+
+    return EMPTY_VISUALS
+  }, [lensActive, lensOptionId, resultsStatus, report, nodes, edges, ceeAnalysisReady])
+
+  // Push computed visuals to store so BaseNode/StyledEdge can read with primitive selectors
+  const prevVisualsRef = useRef(visuals)
+  useEffect(() => {
+    if (visuals !== prevVisualsRef.current) {
+      prevVisualsRef.current = visuals
+      setLensVisuals(visuals)
+    }
+  }, [visuals, setLensVisuals])
+}
+
+// ─── Exported pure functions for testing ─────────────────────────────────────
+
+export { computeQuartiles as _computeQuartiles, getSensitivityValue as _getSensitivityValue, buildFragileEdgeSet as _buildFragileEdgeSet }

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -24,6 +24,7 @@ import { typography } from '../../styles/typography'
 import { getControllabilityBorderStyle } from '../utils/graphDisplayCalculations'
 import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { isGoalDefined } from '../../utils/isGoalDefined'
+import { isGraphLensEnabled } from '../../flags'
 import { NodeShapeIndicator } from './NodeShapeIndicator'
 import { NODE_REGISTRY } from '../domain/nodes'
 
@@ -66,6 +67,12 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
   // Graph Interaction P1: Node dimming for path highlighting
   // Nodes not on the highlighted path are dimmed (opacity ~0.4)
   const isDimmed = useCanvasStore(s => s.dimmedNodeIds.has(id))
+
+  // Graph Lens: lens-mode dimming (20% opacity for inactive nodes in option mode)
+  // Uses primitive boolean selector (React #185 pattern) to avoid re-render loops
+  const isLensDimmed = useCanvasStore(s =>
+    isGraphLensEnabled() && s.lens._dimmedNodeIds.has(id)
+  )
 
   // Decision Graph Display v2: Get Results-mode display metadata
   const displayMetadata = useNodeDisplayMetadata(id, nodeType)
@@ -181,7 +188,7 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         cursor-default
         ${selected ? 'ring-2 ring-info ring-offset-2' : ''}
         ${isHighlighted ? 'ring-4 ring-goal/50' : ''}
-        ${isDimmed ? 'opacity-40' : ''}
+        ${isLensDimmed ? 'opacity-20' : isDimmed ? 'opacity-40' : ''}
       `}
       style={{
         backgroundColor: '#FEFEFE', // Panel background color

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -53,12 +53,13 @@ vi.mock('../../../hooks/useISLValidation', () => ({
   useISLValidation: vi.fn(() => ({ data: null })),
 }))
 
-// Default: graph badges OFF. Individual tests override as needed.
+// Default: graph badges OFF, lens OFF. Individual tests override as needed.
 vi.mock('../../../flags', () => ({
   isGraphBadgesEnabled: vi.fn(() => false),
   isNodeIntelligenceEnabled: vi.fn(() => false),
   isCrossHighlightEnabled: vi.fn(() => false),
   isContextMenuEnabled: vi.fn(() => false),
+  isGraphLensEnabled: vi.fn(() => false),
 }))
 
 import { useCanvasStore } from '../../store'

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -42,6 +42,17 @@ import { recordCrossSurfaceEvent, recordUserAction } from '../lib/debug-state'
 // graphHealthFromQuality() returns this when no issues exist, avoiding new array allocation
 const EMPTY_VALIDATION_ISSUES: ValidationIssue[] = []
 
+// Graph Lens: Default (reset) lens state constant
+const DEFAULT_LENS_STATE = {
+  active: 'full' as const,
+  selectedOptionId: null,
+  _dimmedNodeIds: new Set<string>(),
+  _dimmedEdgeIds: new Set<string>(),
+  _sensitivityWeights: new Map<string, number>(),
+  _sensitivityQuartiles: null,
+  _fragileEdgeIds: new Set<string>(),
+}
+
 /**
  * Generate deterministic content hash using FNV-1a algorithm
  * Fast, simple, and produces consistent hashes for content integrity checks
@@ -273,6 +284,17 @@ interface CanvasState {
   confirmedNodeIds: Set<string>
   // Decision Graph Display v2 Task 11: Option hover state for intervention highlighting
   hoveredOptionId: string | null
+  // Graph Lens: ephemeral canvas filtering state (post-analysis only)
+  lens: {
+    active: 'full' | 'option' | 'sensitivity' | 'fragile'
+    selectedOptionId: string | null
+    // Computed sets — written by useLensFilter, read by BaseNode/StyledEdge
+    _dimmedNodeIds: Set<string>
+    _dimmedEdgeIds: Set<string>
+    _sensitivityWeights: Map<string, number>
+    _sensitivityQuartiles: { q25: number; q75: number } | null
+    _fragileEdgeIds: Set<string>
+  }
   // M5: Grounding & Provenance
   documents: Document[]
   citations: Citation[]
@@ -476,6 +498,18 @@ interface CanvasState {
   toggleConfirmedNode: (nodeId: string) => void
   // Decision Graph Display v2 Task 11: Option hover for intervention highlighting
   setHoveredOption: (optionId: string | null) => void
+  // Graph Lens actions
+  setLens: (mode: 'full' | 'option' | 'sensitivity' | 'fragile', optionId?: string | null) => void
+  cycleLensOption: (direction: 'next' | 'prev') => void
+  resetLens: () => void
+  /** Update computed lens visuals (called by useLensFilter effect) */
+  setLensVisuals: (visuals: {
+    dimmedNodeIds: Set<string>
+    dimmedEdgeIds: Set<string>
+    sensitivityWeights: Map<string, number>
+    sensitivityQuartiles: { q25: number; q75: number } | null
+    fragileEdgeIds: Set<string>
+  }) => void
   // M5: Provenance actions
   addDocument: (document: Omit<Document, 'id' | 'uploadedAt'>) => string
   removeDocument: (id: string) => void
@@ -607,6 +641,8 @@ function pushToHistory(get: () => CanvasState, set: (fn: (s: CanvasState) => Par
     history: { past, future: [] },
     _internal: { lastHistoryHash: h },
     graphEditedSinceLastRun: true,
+    // Graph Lens: auto-reset on graph edit
+    lens: { ...DEFAULT_LENS_STATE },
   }))
 }
 
@@ -914,6 +950,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   dimmedNodeIds: new Set<string>(),
   confirmedNodeIds: new Set<string>(),
   hoveredOptionId: null,
+  // Graph Lens: ephemeral canvas filtering state
+  lens: {
+    active: 'full' as const,
+    selectedOptionId: null,
+    _dimmedNodeIds: new Set<string>(),
+    _dimmedEdgeIds: new Set<string>(),
+    _sensitivityWeights: new Map<string, number>(),
+    _sensitivityQuartiles: null,
+    _fragileEdgeIds: new Set<string>(),
+  },
   // M5: Grounding & Provenance
   documents: [],
   citations: [],
@@ -1764,6 +1810,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       lastAnalysisSeed: null,
       lastQualityMode: null,
       repairsApplied: null,
+      // Graph Lens: reset on canvas clear
+      lens: { ...DEFAULT_LENS_STATE },
     })
   },
 
@@ -1901,7 +1949,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         runId: undefined,
         finishedAt: undefined,
         isDuplicateRun: undefined
-      }
+      },
+      // Graph Lens: auto-reset on new analysis run
+      lens: { ...DEFAULT_LENS_STATE },
     })
   },
 
@@ -2840,7 +2890,79 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   },
   // Decision Graph Display v2 Task 11: Option hover for intervention highlighting
   setHoveredOption: (optionId: string | null) => {
+    // Correction #1: When lens option isolation is active, suppress hover updates
+    // so the panel highlight stays on the lens-selected option.
+    const { lens } = get()
+    if (lens.active === 'option' && lens.selectedOptionId && optionId !== null) {
+      return
+    }
     set({ hoveredOptionId: optionId })
+  },
+
+  // Graph Lens actions
+  setLens: (mode, optionId) => {
+    const { lens: prev } = get()
+    const updates: Partial<CanvasState> = {
+      lens: { ...prev, active: mode, selectedOptionId: optionId ?? null },
+    }
+    // Panel sync: when selecting an option lens, update hoveredOptionId
+    if (mode === 'option' && optionId) {
+      updates.hoveredOptionId = optionId
+    }
+    // When switching away from option mode, clear hoveredOptionId
+    if (mode !== 'option') {
+      updates.hoveredOptionId = null
+    }
+    set(updates)
+  },
+
+  cycleLensOption: (direction) => {
+    const state = get()
+    if (state.lens.active !== 'option') return
+    const options = state.results.report?.option_comparison
+    if (!options || options.length === 0) return
+
+    const currentId = state.lens.selectedOptionId
+    const currentIndex = currentId
+      ? options.findIndex((o: { option_id: string }) => o.option_id === currentId)
+      : -1
+    const len = options.length
+    const nextIndex = direction === 'next'
+      ? (currentIndex + 1) % len
+      : (currentIndex - 1 + len) % len
+    const nextOption = options[nextIndex] as { option_id: string }
+    set({
+      lens: { ...state.lens, active: 'option', selectedOptionId: nextOption.option_id },
+      hoveredOptionId: nextOption.option_id,
+    })
+  },
+
+  resetLens: () => {
+    const { lens } = get()
+    if (lens.active === 'full' && lens.selectedOptionId === null) return
+    set({ lens: { ...DEFAULT_LENS_STATE } })
+  },
+
+  setLensVisuals: (visuals) => {
+    const { lens } = get()
+    // Skip no-op updates to avoid re-renders (use setsEqual for Set comparison)
+    if (
+      setsEqual(lens._dimmedNodeIds, visuals.dimmedNodeIds) &&
+      setsEqual(lens._dimmedEdgeIds, visuals.dimmedEdgeIds) &&
+      setsEqual(lens._fragileEdgeIds, visuals.fragileEdgeIds)
+    ) {
+      return
+    }
+    set({
+      lens: {
+        ...lens,
+        _dimmedNodeIds: visuals.dimmedNodeIds,
+        _dimmedEdgeIds: visuals.dimmedEdgeIds,
+        _sensitivityWeights: visuals.sensitivityWeights,
+        _sensitivityQuartiles: visuals.sensitivityQuartiles,
+        _fragileEdgeIds: visuals.fragileEdgeIds,
+      },
+    })
   },
 
   // M5: Provenance actions
@@ -3004,6 +3126,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         comparison,
         apiResponse,
       },
+      // Graph Lens: auto-reset on comparison mode entry
+      lens: { ...DEFAULT_LENS_STATE },
     })
   },
 
@@ -3457,3 +3581,10 @@ export const selectSeed = (state: CanvasState): number | undefined => state.resu
 export const selectHash = (state: CanvasState): string | undefined => state.results.hash
 /** A.9: Provenance of the current results — 'direct' | 'conversation' | undefined */
 export const selectResultsSource = (state: CanvasState): 'direct' | 'conversation' | undefined => state.results.resultsSource
+
+/**
+ * Graph Lens selectors
+ */
+export type LensMode = 'full' | 'option' | 'sensitivity' | 'fragile'
+export const selectLensMode = (state: CanvasState): LensMode => state.lens.active
+export const selectLensOptionId = (state: CanvasState): string | null => state.lens.selectedOptionId

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -2,7 +2,7 @@
 import { create } from 'zustand'
 import { Node, Edge, applyNodeChanges, applyEdgeChanges, NodeChange, EdgeChange } from '@xyflow/react'
 import { saveSnapshot as persistSnapshot, importCanvas as persistImport, exportCanvas as persistExport } from './persist'
-import { setsEqual } from './store/utils'
+import { setsEqual, mapsEqual } from './store/utils'
 import { DEFAULT_EDGE_DATA, type EdgeData } from './domain/edges'
 import { NODE_REGISTRY, type NodeType } from './domain/nodes'
 import { applyLayout, applyLayoutWithPolicy } from './layout'
@@ -2939,17 +2939,20 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
   resetLens: () => {
     const { lens } = get()
-    if (lens.active === 'full' && lens.selectedOptionId === null) return
+    if (lens.active === 'full' && lens.selectedOptionId === null && lens._dimmedNodeIds.size === 0) return
     set({ lens: { ...DEFAULT_LENS_STATE } })
   },
 
   setLensVisuals: (visuals) => {
     const { lens } = get()
-    // Skip no-op updates to avoid re-renders (use setsEqual for Set comparison)
+    // Skip no-op updates to avoid re-renders (use setsEqual/mapsEqual for collection comparison)
     if (
       setsEqual(lens._dimmedNodeIds, visuals.dimmedNodeIds) &&
       setsEqual(lens._dimmedEdgeIds, visuals.dimmedEdgeIds) &&
-      setsEqual(lens._fragileEdgeIds, visuals.fragileEdgeIds)
+      setsEqual(lens._fragileEdgeIds, visuals.fragileEdgeIds) &&
+      mapsEqual(lens._sensitivityWeights, visuals.sensitivityWeights) &&
+      lens._sensitivityQuartiles?.q25 === visuals.sensitivityQuartiles?.q25 &&
+      lens._sensitivityQuartiles?.q75 === visuals.sensitivityQuartiles?.q75
     ) {
       return
     }
@@ -3152,6 +3155,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         comparison: null,
         apiResponse: null,
       },
+      // Graph Lens: reset on comparison mode exit (mirrors enterComparisonMode reset)
+      lens: { ...DEFAULT_LENS_STATE },
     })
   },
 

--- a/src/canvas/store/utils.ts
+++ b/src/canvas/store/utils.ts
@@ -16,6 +16,18 @@ export function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
 }
 
 /**
+ * Compare two Maps by value (not reference)
+ * @returns true if Maps contain the same key-value pairs
+ */
+export function mapsEqual<K, V>(a: Map<K, V>, b: Map<K, V>): boolean {
+  if (a.size !== b.size) return false
+  for (const [k, v] of a) {
+    if (!Object.is(b.get(k), v)) return false
+  }
+  return true
+}
+
+/**
  * Compare two arrays by value (shallow comparison)
  * @returns true if arrays have same length and same values in same order
  */

--- a/src/canvas/utils/__tests__/computeOptionPaths.spec.ts
+++ b/src/canvas/utils/__tests__/computeOptionPaths.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { computeOptionPaths } from '../computeOptionPaths'
+
+/*
+ * Test graph topology:
+ *
+ *   decision ──→ optionA ──→ factorX ──→ outcome ──→ goal
+ *             └─→ optionB ──→ factorY ──→ outcome
+ *                               └──→ riskR ──→ goal
+ *   constraint ──→ outcome
+ */
+
+const nodes = [
+  { id: 'decision', type: 'decision' },
+  { id: 'optionA', type: 'option' },
+  { id: 'optionB', type: 'option' },
+  { id: 'factorX', type: 'factor' },
+  { id: 'factorY', type: 'factor' },
+  { id: 'outcome', type: 'outcome' },
+  { id: 'goal', type: 'goal' },
+  { id: 'riskR', type: 'risk' },
+  { id: 'constraint', type: 'constraint' },
+  { id: 'disconnected', type: 'factor' },
+]
+
+const edges = [
+  { id: 'e-dec-a', source: 'decision', target: 'optionA' },
+  { id: 'e-dec-b', source: 'decision', target: 'optionB' },
+  { id: 'e-a-x', source: 'optionA', target: 'factorX' },
+  { id: 'e-b-y', source: 'optionB', target: 'factorY' },
+  { id: 'e-x-out', source: 'factorX', target: 'outcome' },
+  { id: 'e-y-out', source: 'factorY', target: 'outcome' },
+  { id: 'e-out-goal', source: 'outcome', target: 'goal' },
+  { id: 'e-y-risk', source: 'factorY', target: 'riskR' },
+  { id: 'e-risk-goal', source: 'riskR', target: 'goal' },
+  { id: 'e-con-out', source: 'constraint', target: 'outcome' },
+]
+
+const ceeOptions = [
+  { id: 'optionA', interventions: { factorX: 1.0 } },
+  { id: 'optionB', interventions: { factorY: 0.8 } },
+]
+
+describe('computeOptionPaths', () => {
+  it('includes the full structural path: decision → option → target → downstream → goal', () => {
+    const result = computeOptionPaths(nodes, edges, 'optionA', ceeOptions)
+
+    // Decision node
+    expect(result.activeNodeIds.has('decision')).toBe(true)
+    // Option node
+    expect(result.activeNodeIds.has('optionA')).toBe(true)
+    // Intervention target
+    expect(result.activeNodeIds.has('factorX')).toBe(true)
+    // Downstream
+    expect(result.activeNodeIds.has('outcome')).toBe(true)
+    expect(result.activeNodeIds.has('goal')).toBe(true)
+
+    // Structural edges
+    expect(result.activeEdgeKeys.has('e-dec-a')).toBe(true)  // decision → optionA
+    expect(result.activeEdgeKeys.has('e-a-x')).toBe(true)    // optionA → factorX
+    expect(result.activeEdgeKeys.has('e-x-out')).toBe(true)  // factorX → outcome
+    expect(result.activeEdgeKeys.has('e-out-goal')).toBe(true) // outcome → goal
+  })
+
+  it('excludes the other option and its exclusive paths', () => {
+    const result = computeOptionPaths(nodes, edges, 'optionA', ceeOptions)
+
+    // optionB is NOT in the active set (it is a sibling, not on optionA's path)
+    expect(result.activeNodeIds.has('optionB')).toBe(false)
+    // decision → optionB edge excluded
+    expect(result.activeEdgeKeys.has('e-dec-b')).toBe(false)
+    // optionB → factorY edge excluded
+    expect(result.activeEdgeKeys.has('e-b-y')).toBe(false)
+  })
+
+  it('includes risk nodes downstream of intervention targets', () => {
+    const result = computeOptionPaths(nodes, edges, 'optionB', ceeOptions)
+
+    // factorY → riskR → goal
+    expect(result.activeNodeIds.has('riskR')).toBe(true)
+    expect(result.activeEdgeKeys.has('e-y-risk')).toBe(true)
+    expect(result.activeEdgeKeys.has('e-risk-goal')).toBe(true)
+  })
+
+  it('includes constraint nodes connected to visible paths', () => {
+    const result = computeOptionPaths(nodes, edges, 'optionA', ceeOptions)
+
+    // constraint → outcome (outcome is active, constraint should be included)
+    expect(result.activeNodeIds.has('constraint')).toBe(true)
+    expect(result.activeEdgeKeys.has('e-con-out')).toBe(true)
+  })
+
+  it('excludes disconnected nodes', () => {
+    const result = computeOptionPaths(nodes, edges, 'optionA', ceeOptions)
+
+    expect(result.activeNodeIds.has('disconnected')).toBe(false)
+  })
+
+  it('handles shared factors on paths for multiple options', () => {
+    // Both optionA and optionB paths converge at outcome → goal
+    const resultA = computeOptionPaths(nodes, edges, 'optionA', ceeOptions)
+    const resultB = computeOptionPaths(nodes, edges, 'optionB', ceeOptions)
+
+    // Both should include outcome and goal
+    expect(resultA.activeNodeIds.has('outcome')).toBe(true)
+    expect(resultB.activeNodeIds.has('outcome')).toBe(true)
+    expect(resultA.activeNodeIds.has('goal')).toBe(true)
+    expect(resultB.activeNodeIds.has('goal')).toBe(true)
+  })
+
+  it('handles option with no interventions gracefully', () => {
+    const result = computeOptionPaths(
+      nodes,
+      edges,
+      'optionA',
+      [{ id: 'optionA' }],  // no interventions field
+    )
+
+    // Still includes decision and option node
+    expect(result.activeNodeIds.has('decision')).toBe(true)
+    expect(result.activeNodeIds.has('optionA')).toBe(true)
+    expect(result.activeEdgeKeys.has('e-dec-a')).toBe(true)
+  })
+
+  it('handles unknown optionId gracefully', () => {
+    const result = computeOptionPaths(nodes, edges, 'nonexistent', ceeOptions)
+
+    // Should still include the optionId itself
+    expect(result.activeNodeIds.has('nonexistent')).toBe(true)
+    // But nothing else significant
+    expect(result.activeNodeIds.size).toBe(1)
+  })
+})

--- a/src/canvas/utils/computeOptionPaths.ts
+++ b/src/canvas/utils/computeOptionPaths.ts
@@ -1,0 +1,143 @@
+/**
+ * Compute the set of active nodes and edges for Option Isolation lens mode.
+ *
+ * Given a selected option, computes the full structural path:
+ * decision node → option node → intervention targets → all downstream nodes → goal
+ *
+ * This is a pure utility with no store or React dependencies.
+ */
+
+import { getInterventionTargets } from './pathFinding'
+
+interface GraphNode {
+  id: string
+  type?: string
+}
+
+interface GraphEdge {
+  id: string
+  source: string
+  target: string
+}
+
+interface CeeOption {
+  id: string
+  interventions?: Record<string, number>
+}
+
+export interface OptionPathsResult {
+  activeNodeIds: Set<string>
+  activeEdgeKeys: Set<string>
+}
+
+/**
+ * BFS forward traversal: collect all nodes reachable from a set of start nodes.
+ * Follows edge direction (source → target).
+ */
+function getReachableNodeIds(
+  startNodeIds: string[],
+  edges: GraphEdge[],
+): Set<string> {
+  // Build adjacency list
+  const outgoing = new Map<string, GraphEdge[]>()
+  for (const edge of edges) {
+    const existing = outgoing.get(edge.source) ?? []
+    existing.push(edge)
+    outgoing.set(edge.source, existing)
+  }
+
+  const reachable = new Set<string>()
+  const queue = [...startNodeIds]
+
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    if (reachable.has(current)) continue
+    reachable.add(current)
+
+    const children = outgoing.get(current) ?? []
+    for (const edge of children) {
+      if (!reachable.has(edge.target)) {
+        queue.push(edge.target)
+      }
+    }
+  }
+
+  return reachable
+}
+
+/**
+ * Compute active node and edge sets for the Option Isolation lens.
+ *
+ * Algorithm:
+ * 1. Find the decision node that parents the selected option
+ * 2. Include decision node + option node
+ * 3. Get intervention targets from ceeOptions
+ * 4. Include decision→option and option→target edges
+ * 5. BFS downstream from intervention targets collecting all reachable nodes
+ * 6. Collect all edges where both source and target are in the active set
+ */
+export function computeOptionPaths(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  optionId: string,
+  ceeOptions: CeeOption[],
+): OptionPathsResult {
+  const activeNodeIds = new Set<string>()
+  const activeEdgeKeys = new Set<string>()
+
+  // 1. Find the decision node that parents the selected option
+  const parentEdge = edges.find(e => e.target === optionId)
+  if (parentEdge) {
+    activeNodeIds.add(parentEdge.source) // decision node
+    activeEdgeKeys.add(parentEdge.id)    // decision → option edge
+  }
+
+  // 2. Include the option node itself
+  activeNodeIds.add(optionId)
+
+  // 3. Get intervention targets
+  const interventionTargetIds = getInterventionTargets(optionId, ceeOptions)
+
+  // 4. Add option → target edges
+  for (const targetId of interventionTargetIds) {
+    const optionToTarget = edges.find(
+      e => e.source === optionId && e.target === targetId
+    )
+    if (optionToTarget) {
+      activeEdgeKeys.add(optionToTarget.id)
+    }
+    activeNodeIds.add(targetId)
+  }
+
+  // 5. BFS downstream from intervention targets
+  const downstreamNodes = getReachableNodeIds(interventionTargetIds, edges)
+  for (const nodeId of downstreamNodes) {
+    activeNodeIds.add(nodeId)
+  }
+
+  // 6. Collect all edges where both source and target are active
+  for (const edge of edges) {
+    if (activeNodeIds.has(edge.source) && activeNodeIds.has(edge.target)) {
+      activeEdgeKeys.add(edge.id)
+    }
+  }
+
+  // Also include constraint nodes connected to any active node
+  // (constraints have edges to/from active nodes)
+  const nodeTypeMap = new Map(nodes.map(n => [n.id, n.type]))
+  for (const edge of edges) {
+    const sourceType = nodeTypeMap.get(edge.source)
+    const targetType = nodeTypeMap.get(edge.target)
+
+    if (sourceType === 'constraint' && activeNodeIds.has(edge.target)) {
+      activeNodeIds.add(edge.source)
+      activeEdgeKeys.add(edge.id)
+    }
+    if (targetType === 'constraint' && activeNodeIds.has(edge.source)) {
+      activeNodeIds.add(edge.target)
+      activeEdgeKeys.add(edge.id)
+    }
+  }
+
+  return { activeNodeIds, activeEdgeKeys }
+}

--- a/src/canvas/utils/fragileEdgeMatch.ts
+++ b/src/canvas/utils/fragileEdgeMatch.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared fragile edge matching utility.
+ *
+ * Used by StyledEdge (per-edge memo), useMenuItems (context menu), and useLensFilter.
+ * Centralises the dual-format matching logic (edge_id vs from_id/to_id) and the
+ * 0.3 switch_probability threshold. See UI-SEM-013.
+ */
+
+interface FragileEdgeCandidate {
+  edge_id?: string
+  edgeId?: string
+  from_id?: string
+  fromId?: string
+  source?: string
+  to_id?: string
+  toId?: string
+  target?: string
+  switch_probability?: number
+  switchProbability?: number
+  marginal_switch_probability?: number
+  marginalSwitchProbability?: number
+}
+
+/**
+ * Check whether a single edge matches any fragile edge entry with switch_probability > 0.3.
+ * Matches by edge_id first, then falls back to from_id/to_id (source/target) pair.
+ */
+export function isEdgeFragile(
+  edgeId: string,
+  edgeSource: string,
+  edgeTarget: string,
+  fragileEdges: FragileEdgeCandidate[],
+): boolean {
+  return fragileEdges.some(fe => {
+    const switchProb = fe.switch_probability ?? fe.switchProbability ??
+                       fe.marginal_switch_probability ?? fe.marginalSwitchProbability
+    if (typeof switchProb !== 'number' || switchProb <= 0.3) return false
+
+    // Try matching by edge_id first
+    const feEdgeId = fe.edge_id ?? fe.edgeId
+    if (feEdgeId === edgeId) return true
+
+    // Fallback: match by source/target pair
+    const from = fe.from_id ?? fe.fromId ?? fe.source
+    const to = fe.to_id ?? fe.toId ?? fe.target
+    return from === edgeSource && to === edgeTarget
+  })
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '../Spinner'
 import styles from './TopBar.module.css'
 import { useAnalysisMetadata } from '../../canvas/hooks/useAnalysisMetadata'
 import { isGraphLensEnabled } from '../../flags'
+import { useCanvasStore } from '../../canvas/store'
 import { LensDropdown } from '../../canvas/components/LensDropdown'
 import { LENS_TOGGLE_EVENT } from '../../canvas/hooks/useCanvasKeyboardShortcuts'
 import { useStagePill } from '../../canvas/hooks/useStagePill'
@@ -58,6 +59,12 @@ export const TopBar = ({
     window.addEventListener(LENS_TOGGLE_EVENT, handler)
     return () => window.removeEventListener(LENS_TOGGLE_EVENT, handler)
   }, [])
+
+  // Close lens dropdown when comparison mode hides the chip
+  const comparisonActive = useCanvasStore(s => s.comparisonMode.active)
+  useEffect(() => {
+    if (comparisonActive) setLensOpen(false)
+  }, [comparisonActive])
 
   const menuRef = useRef<HTMLDivElement | null>(null)
 

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -5,6 +5,9 @@ import Tooltip from '../Tooltip'
 import { Spinner } from '../Spinner'
 import styles from './TopBar.module.css'
 import { useAnalysisMetadata } from '../../canvas/hooks/useAnalysisMetadata'
+import { isGraphLensEnabled } from '../../flags'
+import { LensDropdown } from '../../canvas/components/LensDropdown'
+import { LENS_TOGGLE_EVENT } from '../../canvas/hooks/useCanvasKeyboardShortcuts'
 import { useStagePill } from '../../canvas/hooks/useStagePill'
 import { useSettingsStore } from '../../canvas/settingsStore'
 import { UserAvatarMenu } from './UserAvatarMenu'
@@ -47,6 +50,15 @@ export const TopBar = ({
   const [showMenu, setShowMenu] = useState(false)
   const [settingsExpanded, setSettingsExpanded] = useState(false)
   const [showSavedPill, setShowSavedPill] = useState(false)
+  const [lensOpen, setLensOpen] = useState(false)
+
+  // Listen for L key toggle event from useCanvasKeyboardShortcuts
+  useEffect(() => {
+    const handler = () => setLensOpen(v => !v)
+    window.addEventListener(LENS_TOGGLE_EVENT, handler)
+    return () => window.removeEventListener(LENS_TOGGLE_EVENT, handler)
+  }, [])
+
   const menuRef = useRef<HTMLDivElement | null>(null)
 
   // C.1a: Auto-fade "Saved" pill after 2s
@@ -327,6 +339,15 @@ export const TopBar = ({
               </span>
             </div>
           </Tooltip>
+        )}
+
+        {/* Graph Lens dropdown (post-analysis only) */}
+        {isGraphLensEnabled() && (
+          <LensDropdown
+            isOpen={lensOpen}
+            onClose={() => setLensOpen(false)}
+            onToggle={() => setLensOpen(v => !v)}
+          />
         )}
       </div>
 

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -14,11 +14,13 @@
  * Design rules: no background fills on cards (full borders only, no left-accent).
  */
 
-import { useRef, useState, type RefObject } from 'react'
+import { useRef, useState, useCallback, type RefObject } from 'react'
 import { typography } from '../../styles/typography'
 import { formatPercent as formatPct } from '../../utils/formatPercent'
 import { stripEncodingNotation } from './utils/cleanFactorLabel'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
+import { useCanvasStore, selectResultsStatus } from '../../canvas/store'
+import { isGraphLensEnabled } from '../../flags'
 import type { OptionResult, DecisionState, HingeInfo } from './types'
 import {
   constraintConfidenceColour,
@@ -148,6 +150,7 @@ function OptionCard({
   neutralised = false,
   sortedRank,
   segmentBorderClass,
+  onClick,
 }: {
   option: OptionResult
   isWinner: boolean
@@ -161,6 +164,7 @@ function OptionCard({
   sortedRank?: number
   /** Ordinal border class matching this option's WinGauge segment colour */
   segmentBorderClass?: string
+  onClick?: () => void
 }) {
   const borderClass = neutralised
     ? 'border-panel-border'
@@ -188,6 +192,8 @@ function OptionCard({
       data-option-id={option.id}
       onMouseEnter={() => highlightNode(option.id)}
       onMouseLeave={clearHighlight}
+      onClick={onClick}
+      style={onClick ? { cursor: 'pointer' } : undefined}
     >
       {/* Header: name + rank badge + win percentage */}
       <div className="flex items-center gap-2">
@@ -287,6 +293,22 @@ export function OptionCards({
   const visibleOptions = shouldTruncate && !showAllOptions ? sorted.slice(0, TOP_N) : sorted
   const hiddenCount = sorted.length - TOP_N
 
+  // Graph Lens: reverse panel sync — click option card to toggle lens isolation
+  const lensEnabled = isGraphLensEnabled()
+  const resultsComplete = useCanvasStore(s => selectResultsStatus(s) === 'complete')
+  const lensSelectedOptionId = useCanvasStore(s => s.lens.selectedOptionId)
+  const setLens = useCanvasStore(s => s.setLens)
+  const resetLens = useCanvasStore(s => s.resetLens)
+
+  const handleLensClick = useCallback((optionId: string) => {
+    if (!lensEnabled || !resultsComplete) return
+    if (lensSelectedOptionId === optionId) {
+      resetLens()
+    } else {
+      setLens('option', optionId)
+    }
+  }, [lensEnabled, resultsComplete, lensSelectedOptionId, setLens, resetLens])
+
   if (sorted.length === 0) return null
 
   return (
@@ -317,6 +339,7 @@ export function OptionCards({
             neutralised={neutralised}
             sortedRank={index + 1}
             segmentBorderClass={segmentBorderClass}
+            onClick={lensEnabled && resultsComplete ? () => handleLensClick(option.id) : undefined}
             cardRef={(el) => {
               const currentMap = refMap.current
               if (!currentMap) return

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -193,6 +193,9 @@ function OptionCard({
       onMouseEnter={() => highlightNode(option.id)}
       onMouseLeave={clearHighlight}
       onClick={onClick}
+      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
       style={onClick ? { cursor: 'pointer' } : undefined}
     >
       {/* Header: name + rank badge + win percentage */}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -359,6 +359,11 @@ const FLAGS_CONFIG = {
     envKey: 'VITE_FEATURE_CROSS_HIGHLIGHT',
     storageKey: 'feature.crossHighlight',
   },
+  // Graph Lens: post-analysis canvas filtering modes (option isolation, sensitivity, fragile edges)
+  graphLens: {
+    envKey: 'VITE_FEATURE_GRAPH_LENS',
+    storageKey: 'feature.graphLens',
+  },
 } as const
 
 // ============================================================================
@@ -439,6 +444,7 @@ const flags = {
   graphBadges: makeFlag(FLAGS_CONFIG.graphBadges),
   nodeIntelligence: makeFlag(FLAGS_CONFIG.nodeIntelligence),
   crossHighlight: makeFlag(FLAGS_CONFIG.crossHighlight),
+  graphLens: makeFlag(FLAGS_CONFIG.graphLens),
 }
 
 // Export with original naming convention for backward compatibility
@@ -514,6 +520,7 @@ export const isCausalClaimsEnabled = flags.causalClaims
 export const isGraphBadgesEnabled = flags.graphBadges
 export const isNodeIntelligenceEnabled = flags.nodeIntelligence
 export const isCrossHighlightEnabled = flags.crossHighlight
+export const isGraphLensEnabled = flags.graphLens
 
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements the Graph Lens feature, a post-analysis canvas filtering system that allows users to focus on specific aspects of the decision graph after running an analysis. The feature provides four lens modes: Full model (default), Option Isolation (per-option causal paths), Sensitivity (edge weighting by factor sensitivity), and Fragile Edges (highlighting decision-critical edges).

## Key Changes

### New Components & Hooks
- **LensDropdown** (`src/canvas/components/LensDropdown.tsx`): Dropdown UI component in TopBar displaying lens modes with keyboard navigation and portal-based positioning
- **useLensFilter** (`src/canvas/hooks/useLensFilter.ts`): Core hook computing lens visual state (dimmed nodes/edges, sensitivity weights, fragile edge sets) and pushing to store for consumption by BaseNode/StyledEdge
- **computeOptionPaths** (`src/canvas/utils/computeOptionPaths.ts`): Pure utility computing active node/edge sets for Option Isolation mode via BFS traversal of decision→option→target→downstream→goal paths
- **fragileEdgeMatch** (`src/canvas/utils/fragileEdgeMatch.ts`): Shared utility for consistent fragile edge matching (edge_id vs from_id/to_id pairs, >0.3 switch_probability threshold) across StyledEdge, useMenuItems, and useLensFilter

### Store Updates
- Extended `CanvasState` with `lens` object containing:
  - Active mode and selected option ID
  - Computed sets: `_dimmedNodeIds`, `_dimmedEdgeIds`, `_sensitivityWeights`, `_sensitivityQuartiles`, `_fragileEdgeIds`
- Added actions: `setLens()`, `cycleLensOption()`, `resetLens()`, `setLensVisuals()`
- Auto-reset lens on graph edit, canvas clear, and new analysis run
- Added `mapsEqual()` utility for Map comparison in store equality checks

### UI Integration
- **TopBar**: Integrated LensDropdown with L key toggle event listener
- **StyledEdge**: Added lens dimming, sensitivity edge weighting (quartile-based coloring), and fragile edge alternative winner labels
- **BaseNode**: Added lens dimming via primitive boolean selector
- **OptionCards**: Added click handler for option isolation lens activation
- **useMenuItems**: Added context menu items for "Isolate this option's paths" and "Show sensitivity view"
- **useCanvasKeyboardShortcuts**: Added L key toggle and ArrowLeft/ArrowRight cycling for option isolation

### Feature Flags
- Added `graphLens` feature flag (default: true) to gate the entire feature

### Testing
- Comprehensive unit tests for `computeOptionPaths` (path traversal, constraint inclusion, edge cases)
- Unit tests for `useLensFilter` helpers (sensitivity value prioritization, quartile computation, fragile edge matching)

## Implementation Details

- **Lens visibility**: Only visible when analysis is complete and comparison mode is inactive
- **Dimming strategy**: Option Isolation and Fragile Edges dim non-active elements; Sensitivity mode shows all nodes but weights edges
- **Sensitivity weighting**: Only edges originating from factors in factor_sensitivity are styled; others retain normal appearance
- **Fragile edge threshold**: switch_probability > 0.3 (boundary exclusive)
- **Constraint handling**: Constraint nodes are included when connected to active paths
- **Keyboard navigation**: Arrow keys cycle through menu items; Escape closes dropdown
- **Hover suppression**: When option isolation is active, panel hover updates are suppressed to maintain lens-selected option highlight
- **Portal rendering**: Dropdown uses React portal with viewport-aware positioning (flips above if overflow bottom, clamps right edge)

https://claude.ai/code/session_01SQAovqThDhSU6EJto4qXBf