### PR TITLE
Add A1/A3/A4/C1/C2/E1 analysis features and UI enhancements

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -2129,12 +2129,13 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
         </div>
       )}
 
-      {/* M5: Provenance Hub panel (right side) */}
+      {/* Task C: Unified right-panel orchestrator — only one overlay panel at a time */}
       {showProvenanceHub && (
         <RightPanel
           width="32rem"
           title="Provenance Hub"
           onClose={() => setShowProvenanceHub(false)}
+          data-testid="right-panel-provenance"
         >
           <ProvenanceHubTab
             citations={citations}
@@ -2145,13 +2146,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
           />
         </RightPanel>
       )}
-
-      {/* Week 3: AI Clarifier panel */}
-      {showAIClarifier && (
+      {!showProvenanceHub && showAIClarifier && (
         <RightPanel
           width="400px"
           title="Olumi AI"
           onClose={() => setShowAIClarifier(false)}
+          data-testid="right-panel-clarifier"
         >
           <Suspense fallback={<div className="flex items-center justify-center p-8"><div className="text-sm text-gray-500">Loading...</div></div>}>
             <AIClarifierChat />

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -53,6 +53,7 @@ import { useGuidancePulseHighlight } from './hooks/useGuidancePulseHighlight'
 import { loadRuns, generateGraphHash } from './store/runHistory'
 // HealthStatusBar removed - validation consolidated into OutputsDock panel
 import { DegradedBanner } from './components/DegradedBanner'
+import { EdgeThicknessLegend } from './components/EdgeThicknessLegend'
 import { LayoutProgressBanner } from './components/LayoutProgressBanner'
 const IssuesPanel = lazy(() => import(/* webpackChunkName: "issues-panel" */ './panels/IssuesPanel').then(m => ({ default: m.IssuesPanel })))
 const AIClarifierChat = lazy(() => import(/* webpackChunkName: "ai-clarifier" */ './panels/AIClarifierChat').then(m => ({ default: m.AIClarifierChat })))
@@ -276,6 +277,7 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   const showProvenanceHub = useCanvasStore(s => s.showProvenanceHub)
   const provenanceRedactionEnabled = useCanvasStore(s => s.provenanceRedactionEnabled)
   const reconnecting = useCanvasStore(s => s.reconnecting)
+  const resultsStatus = useCanvasStore(s => s.results.status)
   // Week 3: AI Clarifier
   const showAIClarifier = useCanvasStore(s => s.showAIClarifier)
   const setShowAIClarifier = useCanvasStore(s => s.setShowAIClarifier)
@@ -1994,6 +1996,9 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
 
       {/* Highlight layer for Results drivers (keyed off global showResultsPanel flag) */}
       <HighlightLayer isResultsOpen={showResultsPanel} />
+
+      {/* D3: Edge thickness legend — post-analysis only */}
+      <EdgeThicknessLegend visible={resultsStatus === 'complete'} />
 
       {showAlignmentGuides && isDragging && <AlignmentGuides nodes={nodes} draggingNodeIds={draggingNodeIds} isActive={isDragging} />}
       {useNewContextMenu && contextMenuTarget

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -50,6 +50,7 @@ import { HighlightLayer } from './highlight/HighlightLayer'
 import { registerFocusHelpers, unregisterFocusHelpers } from './utils/focusHelpers'
 import { usePathHighlight } from './hooks/usePathHighlight'
 import { useGuidancePulseHighlight } from './hooks/useGuidancePulseHighlight'
+import { useEscapePanel } from './hooks/useEscapePanel'
 import { loadRuns, generateGraphHash } from './store/runHistory'
 // HealthStatusBar removed - validation consolidated into OutputsDock panel
 import { DegradedBanner } from './components/DegradedBanner'
@@ -1408,6 +1409,9 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   }
 
   useKeyboardShortcuts({ onModeChange: setInteractionMode })
+
+  // Task C: Escape key closes active right panel (Provenance, AI Clarifier)
+  useEscapePanel()
 
   useEffect(() => {
     // Always load visual/settings preferences (grid, snap, etc.)

--- a/src/canvas/components/EdgeThicknessLegend.tsx
+++ b/src/canvas/components/EdgeThicknessLegend.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect, useRef } from 'react'
+import { X } from 'lucide-react'
+import { typography } from '../../styles/typography'
+
+const LEGEND_ITEMS = [
+  { label: 'Weak influence', width: 2 },
+  { label: 'Moderate influence', width: 4 },
+  { label: 'Strong influence', width: 7 },
+]
+
+interface EdgeThicknessLegendProps {
+  visible: boolean
+}
+
+export function EdgeThicknessLegend({ visible }: EdgeThicknessLegendProps) {
+  const [dismissed, setDismissed] = useState(false)
+  const [faded, setFaded] = useState(false)
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    if (!visible || dismissed) return
+    fadeTimerRef.current = setTimeout(() => setFaded(true), 10_000)
+    return () => {
+      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current)
+    }
+  }, [visible, dismissed])
+
+  if (!visible || dismissed) return null
+
+  return (
+    <div
+      className={`absolute bottom-4 left-4 z-10 bg-panel border border-panel-border rounded-lg shadow-sm p-3 transition-opacity duration-500 ${faded ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
+      data-testid="edge-thickness-legend"
+      role="figure"
+      aria-label="Edge thickness legend"
+    >
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <span className={`${typography.panelMeta} text-text-body font-medium`}>
+          Edge thickness = influence
+        </span>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="text-text-light hover:text-text-body p-0.5 -mt-0.5 -mr-0.5"
+          aria-label="Dismiss legend"
+        >
+          <X size={12} />
+        </button>
+      </div>
+      <div className="space-y-2">
+        {LEGEND_ITEMS.map(item => (
+          <div key={item.label} className="flex items-center gap-2">
+            <svg width={32} height={item.width + 4} aria-hidden="true">
+              <line
+                x1={0}
+                y1={(item.width + 4) / 2}
+                x2={32}
+                y2={(item.width + 4) / 2}
+                stroke="var(--text-light)"
+                strokeWidth={item.width}
+                strokeLinecap="round"
+              />
+            </svg>
+            <span className={`${typography.panelMeta} text-text-light`}>{item.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -856,9 +856,13 @@ export function OutputsDock() {
     window.addEventListener('mouseup', handleUp)
   }
 
+  // Task C: Panel coordination — hide OutputsDock when an overlay panel is active
+  const activeRightPanel = useUIStore(s => s.activeRightPanel)
+  const isOverlayPanelActive = activeRightPanel === 'provenance' || activeRightPanel === 'clarifier'
+
   // Empty state: hide panel completely when canvas has no nodes
   // Return null to completely unmount - no DOM element, no visual footprint
-  if (!hasGraphContent) {
+  if (!hasGraphContent || isOverlayPanelActive) {
     return null
   }
 

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -650,6 +650,9 @@ export function OutputsDock() {
     }
     lastDockOpenRef.current = now
 
+    // Task F: Auto-open results — close overlay panels so OutputsDock becomes visible
+    useUIStore.getState().openRightPanel('results')
+
     setState(prev => {
       // Guard: only update if state actually needs to change
       if (prev.isOpen && prev.activeTab === 'results') {

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -26,6 +26,7 @@
 import { useEffect, useState, useRef, useMemo, useCallback, type ChangeEvent } from 'react'
 import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, XCircle, MessageCircle, CheckCircle } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
+import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource } from '../store'
@@ -84,6 +85,7 @@ import { getUiSurfaceState, type InteractionStateSnapshot } from '../../lib/debu
 import type { CritiqueItemV1 } from '../../adapters/plot/types'
 import { verboseDebug } from '../../utils/verboseLog'
 import { AnalysisFooter } from '../shared/AnalysisFooter'
+import { StabilityGauge } from '../../components/shared/StabilityGauge'
 import { DEFAULT_EDGE_DATA } from '../domain/edges'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
 
@@ -139,6 +141,19 @@ export function OutputsDock() {
       setState(prev => ({ ...prev, activeTab: 'results' }))
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps -- one-time init guard
+
+  // E1: Sync external tab changes from Zustand store (programmatic navigation)
+  const externalTab = useUIStore(s => s.activeOutputTab)
+  const prevExternalTabRef = useRef(externalTab)
+  useEffect(() => {
+    if (externalTab !== prevExternalTabRef.current) {
+      prevExternalTabRef.current = externalTab
+      setState(prev => {
+        if (prev.activeTab === externalTab && prev.isOpen) return prev
+        return { ...prev, isOpen: true, activeTab: externalTab as OutputsDockTab }
+      })
+    }
+  }, [externalTab, setState])
 
 
   // Phase 1A.5: Debug controls visibility (Shift+D shortcut)
@@ -542,7 +557,7 @@ export function OutputsDock() {
       ? { icon: AlertTriangle, iconClass: 'text-warning', label: 'Moderate confidence' }
       : { icon: XCircle, iconClass: 'text-danger', label: 'Fragile result' }
   const postRunMetaText = recommendationStability != null
-    ? `${Math.round(recommendationStability * 100)}% stability`
+    ? <StabilityGauge value={recommendationStability} />
     : null
 
   verboseDebug('[TrustSignals] OutputsDock', {
@@ -781,6 +796,8 @@ export function OutputsDock() {
 
   const handleTabClick = (tab: OutputsDockTab) => {
     setState(prev => ({ ...prev, isOpen: true, activeTab: tab }))
+    // E1: Sync tab state to Zustand store for cross-component navigation
+    useUIStore.getState().setActiveOutputTab(tab as OutputTab)
     // Mutual exclusion: close inspector when dock opens via tab click
     window.dispatchEvent(new Event('outputs-dock-opened'))
 

--- a/src/canvas/components/__tests__/EdgeThicknessLegend.test.tsx
+++ b/src/canvas/components/__tests__/EdgeThicknessLegend.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EdgeThicknessLegend } from '../EdgeThicknessLegend'
+
+describe('EdgeThicknessLegend', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders 3 line samples with labels when visible', () => {
+    render(<EdgeThicknessLegend visible />)
+
+    expect(screen.getByTestId('edge-thickness-legend')).toBeInTheDocument()
+    expect(screen.getByText('Weak influence')).toBeInTheDocument()
+    expect(screen.getByText('Moderate influence')).toBeInTheDocument()
+    expect(screen.getByText('Strong influence')).toBeInTheDocument()
+
+    // 3 SVG line elements for the samples (plus 1 for the Lucide X icon = 4 total)
+    const lines = screen.getByTestId('edge-thickness-legend').querySelectorAll('svg line')
+    expect(lines).toHaveLength(3)
+  })
+
+  it('is not rendered when visible=false', () => {
+    render(<EdgeThicknessLegend visible={false} />)
+
+    expect(screen.queryByTestId('edge-thickness-legend')).not.toBeInTheDocument()
+  })
+
+  it('dismiss button hides legend', () => {
+    render(<EdgeThicknessLegend visible />)
+
+    expect(screen.getByTestId('edge-thickness-legend')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss legend/i }))
+
+    expect(screen.queryByTestId('edge-thickness-legend')).not.toBeInTheDocument()
+  })
+
+  it('is not rendered after dismiss even if visible remains true', () => {
+    const { rerender } = render(<EdgeThicknessLegend visible />)
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss legend/i }))
+    expect(screen.queryByTestId('edge-thickness-legend')).not.toBeInTheDocument()
+
+    // Re-render with same props — should stay dismissed (component-local state)
+    rerender(<EdgeThicknessLegend visible />)
+    expect(screen.queryByTestId('edge-thickness-legend')).not.toBeInTheDocument()
+  })
+
+  it('has correct aria attributes', () => {
+    render(<EdgeThicknessLegend visible />)
+
+    const legend = screen.getByTestId('edge-thickness-legend')
+    expect(legend).toHaveAttribute('role', 'figure')
+    expect(legend).toHaveAttribute('aria-label', 'Edge thickness legend')
+  })
+})

--- a/src/canvas/hooks/__tests__/useEscapePanel.test.ts
+++ b/src/canvas/hooks/__tests__/useEscapePanel.test.ts
@@ -1,0 +1,101 @@
+/**
+ * useEscapePanel — Escape key panel dismissal tests
+ *
+ * Tests that pressing Escape closes the active right panel in priority order.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useEscapePanel } from '../useEscapePanel'
+import { useUIStore } from '../../../stores/uiStore'
+import { useCanvasStore } from '../../store'
+
+// Mock canvas store actions
+vi.mock('../../store', () => ({
+  useCanvasStore: {
+    getState: vi.fn(),
+  },
+}))
+
+describe('useEscapePanel', () => {
+  const mockSetShowProvenanceHub = vi.fn()
+  const mockSetShowAIClarifier = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUIStore.setState({ activeRightPanel: null })
+    ;(useCanvasStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({
+      setShowProvenanceHub: mockSetShowProvenanceHub,
+      setShowAIClarifier: mockSetShowAIClarifier,
+    })
+  })
+
+  function pressEscape(target?: EventTarget) {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    })
+    if (target) {
+      Object.defineProperty(event, 'target', { value: target })
+    }
+    window.dispatchEvent(event)
+  }
+
+  it('closes provenance panel on Escape', () => {
+    useUIStore.setState({ activeRightPanel: 'provenance' })
+    renderHook(() => useEscapePanel())
+
+    act(() => pressEscape())
+
+    expect(mockSetShowProvenanceHub).toHaveBeenCalledWith(false)
+  })
+
+  it('closes clarifier panel on Escape', () => {
+    useUIStore.setState({ activeRightPanel: 'clarifier' })
+    renderHook(() => useEscapePanel())
+
+    act(() => pressEscape())
+
+    expect(mockSetShowAIClarifier).toHaveBeenCalledWith(false)
+  })
+
+  it('does nothing when no panel is active', () => {
+    useUIStore.setState({ activeRightPanel: null })
+    renderHook(() => useEscapePanel())
+
+    act(() => pressEscape())
+
+    expect(mockSetShowProvenanceHub).not.toHaveBeenCalled()
+    expect(mockSetShowAIClarifier).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when results panel is active (OutputsDock handles its own close)', () => {
+    useUIStore.setState({ activeRightPanel: 'results' })
+    renderHook(() => useEscapePanel())
+
+    act(() => pressEscape())
+
+    expect(mockSetShowProvenanceHub).not.toHaveBeenCalled()
+    expect(mockSetShowAIClarifier).not.toHaveBeenCalled()
+  })
+
+  it('ignores Escape when focus is on an input element', () => {
+    useUIStore.setState({ activeRightPanel: 'provenance' })
+    renderHook(() => useEscapePanel())
+
+    const input = document.createElement('input')
+    act(() => pressEscape(input))
+
+    expect(mockSetShowProvenanceHub).not.toHaveBeenCalled()
+  })
+
+  it('ignores Escape when focus is on a textarea', () => {
+    useUIStore.setState({ activeRightPanel: 'clarifier' })
+    renderHook(() => useEscapePanel())
+
+    const textarea = document.createElement('textarea')
+    act(() => pressEscape(textarea))
+
+    expect(mockSetShowAIClarifier).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/hooks/useEscapePanel.ts
+++ b/src/canvas/hooks/useEscapePanel.ts
@@ -1,0 +1,37 @@
+/**
+ * useEscapePanel — Global Escape key handler for right-panel dismissal
+ *
+ * Task C: Pressing Escape closes the active right panel (Provenance, AI Clarifier,
+ * or collapses OutputsDock). Panels have priority: overlay panels (provenance/clarifier)
+ * close first; OutputsDock collapses only when no overlay is active.
+ */
+import { useEffect } from 'react'
+import { useCanvasStore } from '../store'
+import { useUIStore } from '../../stores/uiStore'
+
+export function useEscapePanel() {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      // Don't capture Escape when focus is in an input/textarea/contenteditable
+      const tag = (e.target as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement)?.isContentEditable) {
+        return
+      }
+
+      const activePanel = useUIStore.getState().activeRightPanel
+
+      if (activePanel === 'provenance') {
+        e.stopPropagation()
+        useCanvasStore.getState().setShowProvenanceHub(false)
+      } else if (activePanel === 'clarifier') {
+        e.stopPropagation()
+        useCanvasStore.getState().setShowAIClarifier(false)
+      }
+      // OutputsDock handles its own collapse via its internal state
+    }
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [])
+}

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -37,6 +37,8 @@ import { loadSearchQuery, loadSortPreferences, saveSearchQuery, saveSortPreferen
 import { loadUIPreferences, saveUIPreference } from './store/uiPreferences'
 import { validateCeeAnalysisReady } from './utils/ceeAnalysisReadyValidation'
 import { recordCrossSurfaceEvent, recordUserAction } from '../lib/debug-state'
+// Task C: Panel coordination — opening one right panel closes others
+import { useUIStore } from '../stores/uiStore'
 
 /** A1: Lightweight snapshot of key values for delta display between analysis runs */
 export interface OptionSnapshot {
@@ -2494,6 +2496,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     }
     set({ showResultsPanel: show })
     saveUIPreference('showResultsPanel', show)
+    // Task C: Panel coordination — results panel closes overlay panels
+    if (show) {
+      useUIStore.getState().openRightPanel('results')
+      set({ showProvenanceHub: false, showAIClarifier: false })
+    } else if (useUIStore.getState().activeRightPanel === 'results') {
+      useUIStore.getState().closeRightPanel()
+    }
     recordCrossSurfaceEvent({
       eventType: show ? 'results_panel_opened' : 'results_panel_closed',
       summary: show ? 'Results panel opened' : 'Results panel closed',
@@ -2990,6 +2999,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   setShowProvenanceHub: (show: boolean) => {
     set({ showProvenanceHub: show })
     saveUIPreference('showProvenanceHub', show)
+    // Task C: Panel coordination — opening provenance closes other right panels
+    if (show) {
+      useUIStore.getState().openRightPanel('provenance')
+      set({ showAIClarifier: false })
+    } else if (useUIStore.getState().activeRightPanel === 'provenance') {
+      useUIStore.getState().closeRightPanel()
+    }
   },
 
   setShowDocumentsDrawer: (show: boolean) => {
@@ -3096,10 +3112,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // Close draft chat when opening clarifier
     if (show) {
       set({ showDraftChat: false })
+      // Task C: Panel coordination — opening clarifier closes other right panels
+      useUIStore.getState().openRightPanel('clarifier')
+      set({ showProvenanceHub: false })
     }
     // Clean up clarifier state when closing
     if (!show) {
       get().completeClarifierSession()
+      if (useUIStore.getState().activeRightPanel === 'clarifier') {
+        useUIStore.getState().closeRightPanel()
+      }
     }
   },
 

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -38,6 +38,19 @@ import { loadUIPreferences, saveUIPreference } from './store/uiPreferences'
 import { validateCeeAnalysisReady } from './utils/ceeAnalysisReadyValidation'
 import { recordCrossSurfaceEvent, recordUserAction } from '../lib/debug-state'
 
+/** A1: Lightweight snapshot of key values for delta display between analysis runs */
+export interface OptionSnapshot {
+  winProbability?: number
+  outcomeMean?: number
+  goalProbability?: number
+}
+
+export interface PreviousReportSnapshot {
+  options: Record<string, OptionSnapshot>
+  rankingStability?: number
+  driverInfluences?: Record<string, number>
+}
+
 // Brief 37 Optimization: Stable empty array to prevent re-renders
 // graphHealthFromQuality() returns this when no issues exist, avoiding new array allocation
 const EMPTY_VALIDATION_ISSUES: ValidationIssue[] = []
@@ -198,6 +211,8 @@ interface CanvasState {
   _internal: { lastHistoryHash: string }
   results: ResultsState  // Analysis results panel state
   runMeta: RunMetaState
+  /** A1: Snapshot of key values from the previous analysis run for delta display */
+  previousReport: PreviousReportSnapshot | null
   // Scenario state
   currentScenarioId: string | null  // Active scenario ID
   currentScenarioFraming: ScenarioFraming | null
@@ -843,6 +858,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     progress: 0
   },
   runMeta: {},
+  previousReport: null,
   // Scenario state
   currentScenarioId: scenarios.getCurrentScenarioId(),
   currentScenarioFraming: null,
@@ -1736,6 +1752,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       ceeModelQualityFactors: null,
       ceeInterventionHints: null,
       // Clear results and analysis state
+      previousReport: null, // A1: Clear stale deltas on canvas reset
       results: { status: 'idle', progress: 0 },
       runMeta: {},
       hasCompletedFirstRun: false,
@@ -1937,7 +1954,30 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // Brief 37: Pass existing health to avoid creating new objects when unchanged
     const healthFromQuality = graphHealthFromQuality(report.graph_quality, existingHealth)
 
+    // A1: Snapshot current report values before overwriting
+    const currentReport = get().results.report
+    let snapshot: PreviousReportSnapshot | null = null
+    if (currentReport && get().results.status === 'complete') {
+      const options: Record<string, OptionSnapshot> = {}
+      const optionResults = (currentReport as any)?.option_comparison ?? (currentReport as any)?.results ?? []
+      for (const opt of optionResults) {
+        if (opt.option_id || opt.id) {
+          options[opt.option_id ?? opt.id] = {
+            winProbability: opt.win_probability ?? opt.winProbability,
+            outcomeMean: opt.expected_outcome ?? opt.outcome?.mean ?? opt.expected,
+            goalProbability: opt.probability_of_goal ?? opt.goalProbability,
+          }
+        }
+      }
+      const robustness = (currentReport as any)?.robustness
+      snapshot = {
+        options,
+        rankingStability: robustness?.recommendation_stability ?? robustness?.ranking_stability,
+      }
+    }
+
     set(s => ({
+      previousReport: snapshot,
       results: {
         ...s.results,
         status: 'complete',
@@ -2162,6 +2202,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
   resultsReset: () => {
     set({
+      previousReport: null,
       results: {
         status: 'idle',
         progress: 0
@@ -2236,6 +2277,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       currentScenarioLastResultHash: scenario.last_result_hash ?? null,
       currentScenarioLastRunAt: scenario.last_run_at ?? null,
       currentScenarioLastRunSeed: scenario.last_run_seed ?? null,
+      previousReport: null, // A1: Clear stale deltas on scenario switch
       isDirty: false,
       history: { past: [], future: [] },
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
@@ -3457,3 +3499,5 @@ export const selectSeed = (state: CanvasState): number | undefined => state.resu
 export const selectHash = (state: CanvasState): string | undefined => state.results.hash
 /** A.9: Provenance of the current results — 'direct' | 'conversation' | undefined */
 export const selectResultsSource = (state: CanvasState): 'direct' | 'conversation' | undefined => state.results.resultsSource
+/** A1: Previous report snapshot for delta display */
+export const selectPreviousReport = (state: CanvasState): PreviousReportSnapshot | null => state.previousReport

--- a/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
@@ -38,6 +38,7 @@ function InspectorSlider({
   step,
   onChange,
   color,
+  trackFillColor,
   'aria-label': ariaLabel,
 }: {
   value: number
@@ -46,6 +47,8 @@ function InspectorSlider({
   step: number
   onChange: (v: number) => void
   color?: string
+  /** C2: Coloured track fill behind the slider */
+  trackFillColor?: string
   'aria-label': string
 }) {
   const debounceRef = useRef<NodeJS.Timeout>()
@@ -63,6 +66,17 @@ function InspectorSlider({
   return (
     <div className="flex items-center gap-2">
       <div className="flex-1 relative">
+        {trackFillColor && (
+          <div className="absolute inset-y-0 flex items-center pointer-events-none" style={{ left: 0, right: 0 }}>
+            <div className="w-full h-1 bg-panel-border rounded-full overflow-hidden">
+              <div
+                className="h-full rounded-full transition-all duration-100"
+                style={{ width: `${pct}%`, backgroundColor: trackFillColor }}
+                data-testid="inspector-slider-track-fill"
+              />
+            </div>
+          </div>
+        )}
         <input
           type="range"
           min={min}
@@ -74,7 +88,7 @@ function InspectorSlider({
           aria-valuemin={min}
           aria-valuemax={max}
           aria-valuenow={value}
-          className="w-full"
+          className={`w-full ${trackFillColor ? 'relative z-10' : ''}`}
           style={color ? { accentColor: color } : undefined}
         />
       </div>
@@ -87,6 +101,13 @@ function thresholdColor(v: number): string {
   if (v >= 0.7) return 'text-success'
   if (v >= 0.4) return 'text-warning'
   return 'text-danger'
+}
+
+/** C2: CSS variable for threshold-based track fill */
+function thresholdTrackVar(v: number): string {
+  if (v >= 0.7) return 'var(--success)'
+  if (v >= 0.4) return 'var(--warning)'
+  return 'var(--danger)'
 }
 
 export const EdgePanel = memo(function EdgePanel({
@@ -197,7 +218,7 @@ export const EdgePanel = memo(function EdgePanel({
           <div className="px-1">
             <div className="relative mb-2">
               <UncertaintyBand strength={localStrength} std={localStd} />
-              <SignedStrengthSlider value={localStrength} onChange={handleStrengthChange} />
+              <SignedStrengthSlider value={localStrength} onChange={handleStrengthChange} std={localStd} />
             </div>
             <div className="flex justify-between mt-1">
               {techMode ? (
@@ -241,6 +262,7 @@ export const EdgePanel = memo(function EdgePanel({
                   max={1}
                   step={0.05}
                   onChange={handleBeliefChange}
+                  trackFillColor={thresholdTrackVar(localBelief)}
                   aria-label="Connection existence probability"
                 />
               </div>

--- a/src/canvas/ui/inspector/SignedStrengthSlider.tsx
+++ b/src/canvas/ui/inspector/SignedStrengthSlider.tsx
@@ -22,6 +22,8 @@ interface SignedStrengthSliderProps {
   debounceMs?: number
   /** Disabled state */
   disabled?: boolean
+  /** C1: Standard deviation for uncertainty band overlay */
+  std?: number
 }
 
 export function SignedStrengthSlider({
@@ -29,6 +31,7 @@ export function SignedStrengthSlider({
   onChange,
   debounceMs = 120,
   disabled = false,
+  std,
 }: SignedStrengthSliderProps) {
   const [localValue, setLocalValue] = useState(value)
   const timerRef = useRef<ReturnType<typeof setTimeout>>()
@@ -82,6 +85,25 @@ export function SignedStrengthSlider({
       <div className="relative h-6 flex items-center">
         {/* Background track */}
         <div className="absolute inset-x-0 h-1.5 bg-panel-border rounded-full" />
+        {/* C1: Uncertainty band — shows +/- std around current value */}
+        {std != null && std > 0 && (() => {
+          const bandLow = Math.max(-1, localValue - std)
+          const bandHigh = Math.min(1, localValue + std)
+          // Map from [-1, 1] to [0%, 100%]
+          const bandLeftPct = ((bandLow + 1) / 2) * 100
+          const bandWidthPct = ((bandHigh - bandLow) / 2) * 100
+          return (
+            <div
+              className="absolute h-3 rounded-full bg-info/20"
+              style={{
+                left: `${bandLeftPct}%`,
+                width: `${bandWidthPct}%`,
+              }}
+              aria-hidden="true"
+              data-testid="uncertainty-band"
+            />
+          )
+        })()}
         {/* Centre marker */}
         <div className="absolute left-1/2 -translate-x-px w-0.5 h-3 bg-text-light rounded-full" />
         {/* Fill from centre */}

--- a/src/canvas/ui/inspector/__tests__/SignedStrengthSlider.test.tsx
+++ b/src/canvas/ui/inspector/__tests__/SignedStrengthSlider.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * SignedStrengthSlider — C1 uncertainty band tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SignedStrengthSlider } from '../SignedStrengthSlider'
+
+describe('SignedStrengthSlider — C1 uncertainty band', () => {
+  it('renders uncertainty band when std is provided', () => {
+    render(
+      <SignedStrengthSlider value={0.3} onChange={() => {}} std={0.15} />
+    )
+
+    expect(screen.getByTestId('uncertainty-band')).toBeInTheDocument()
+  })
+
+  it('does not render uncertainty band when std is absent', () => {
+    render(
+      <SignedStrengthSlider value={0.3} onChange={() => {}} />
+    )
+
+    expect(screen.queryByTestId('uncertainty-band')).not.toBeInTheDocument()
+  })
+
+  it('does not render uncertainty band when std is 0', () => {
+    render(
+      <SignedStrengthSlider value={0.3} onChange={() => {}} std={0} />
+    )
+
+    expect(screen.queryByTestId('uncertainty-band')).not.toBeInTheDocument()
+  })
+
+  it('clamps uncertainty band to slider range [-1, 1]', () => {
+    // Value near edge: 0.9 with std 0.3 should clamp high end to 1.0
+    render(
+      <SignedStrengthSlider value={0.9} onChange={() => {}} std={0.3} />
+    )
+
+    const band = screen.getByTestId('uncertainty-band')
+    const style = band.style
+
+    // Band should be present and have valid dimensions
+    expect(style.left).toBeDefined()
+    expect(style.width).toBeDefined()
+
+    // bandLow = max(-1, 0.9-0.3) = 0.6, bandHigh = min(1, 0.9+0.3) = 1.0
+    // leftPct = ((0.6+1)/2)*100 = 80%, widthPct = ((1.0-0.6)/2)*100 = 20%
+    const leftPct = parseFloat(style.left)
+    const widthPct = parseFloat(style.width)
+    // Left + width should not exceed 100% (maps to full [-1,1] range)
+    expect(leftPct + widthPct).toBeLessThanOrEqual(100.01)
+    // Left should be >= 0%
+    expect(leftPct).toBeGreaterThanOrEqual(0)
+  })
+
+  it('renders uncertainty band for negative values', () => {
+    render(
+      <SignedStrengthSlider value={-0.5} onChange={() => {}} std={0.2} />
+    )
+
+    const band = screen.getByTestId('uncertainty-band')
+    expect(band).toBeInTheDocument()
+  })
+})

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -14,8 +14,9 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react'
-import type { DriversSectionData, DriverItem } from './types'
+import type { DriversSectionData, DriverItem, FlipThreshold } from './types'
 import { focusNodeById } from '../../canvas/utils/focusHelpers'
+import { useUIStore } from '../../stores/uiStore'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
 import { EMPTY_STATES } from './emptyStates'
 import { formatFlipRiskMessage } from './utils/formatScenarioRatio'
@@ -47,6 +48,8 @@ interface DriversSectionProps {
   isNormalised?: boolean
   /** Goal direction for tornado bar colouring — maximize means higher outcome = good */
   goalDirection?: 'maximize' | 'minimize'
+  /** A4: Flip threshold data for tornado chart markers */
+  flipThresholds?: FlipThreshold[]
 }
 
 // Bar colors — use design system tokens, no hex literals
@@ -196,6 +199,8 @@ function ExpandedDetails({
   const handleFocusClick = useCallback(() => {
     if (driver.canFocus) {
       const nodeId = driver.matchedNodeId ?? driver.factorKey
+      // E1: Switch to Model tab before focusing node
+      useUIStore.getState().setActiveOutputTab('diagnostics')
       if (onFocus) {
         onFocus(nodeId)
       } else {
@@ -578,6 +583,7 @@ export function DriversSection({
   outcomeUnitSymbol,
   isNormalised,
   goalDirection,
+  flipThresholds,
 }: DriversSectionProps) {
   const [showAll, setShowAll] = useState(false)
   const { drivers, driversStatus, topDrivers, hasMagnitudeData, islError, hiddenZeroImpactCount } = data
@@ -747,6 +753,7 @@ export function DriversSection({
                 onFocusNode={onFocusNode}
                 isNormalised={isNormalised}
                 goalDirection={goalDirection}
+                flipThresholds={flipThresholds}
               />
             </div>
           </details>

--- a/src/components/results/HeroSection.tsx
+++ b/src/components/results/HeroSection.tsx
@@ -56,6 +56,13 @@ export interface OptionWinShare {
   isWinner: boolean
 }
 
+/** Goal probability per option for the goal-achievement display */
+export interface OptionGoalProbability {
+  id: string
+  label: string
+  goalProbability: number
+}
+
 /** Props for HeroSection */
 export interface HeroSectionProps {
   winnerLabel: string
@@ -144,6 +151,8 @@ export interface HeroSectionProps {
   defaultEstimateCount?: number
   /** V16: Total factor count (for trust reason denominator) */
   totalFactorCount?: number
+  /** A3: Goal-achievement probabilities for all options (shown when goal threshold set) */
+  allOptionGoalProbabilities?: OptionGoalProbability[]
 }
 
 // =============================================================================
@@ -465,6 +474,7 @@ export function HeroSection({
   robustnessLevel,
   defaultEstimateCount,
   totalFactorCount,
+  allOptionGoalProbabilities,
 }: HeroSectionProps) {
   // Always collapsed on first load — user expands via "More ▸" toggle
   const [isExpanded, setIsExpanded] = useState(false)
@@ -990,10 +1000,29 @@ export function HeroSection({
             <WinGauge shares={optionWinShares} decisionState={decisionState} />
           )}
 
-          {/* Goal probability line */}
-          {goalThreshold != null && winnerGoalProbability != null && (
-            <p className={`${typography.panelMeta} text-text-body`}>
-              {winnerLabel} has a {formatPct(winnerGoalProbability, { fromDecimal: true })} chance of reaching your target of {formatTargetValue(goalThreshold!, outcomeUnit, outcomeUnitSymbol)}
+          {/* A3: Goal-achievement probability — comparative display for all options */}
+          {goalThreshold != null && allOptionGoalProbabilities && allOptionGoalProbabilities.length > 0 && (
+            <div className="space-y-0.5" data-testid="goal-probability-display">
+              {allOptionGoalProbabilities.length === 1 ? (
+                <p className={`${typography.panelBody} text-text-body`}>
+                  <span className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle" style={{ backgroundColor: 'var(--goal)' }} />
+                  {allOptionGoalProbabilities[0].label} has a {formatPct(allOptionGoalProbabilities[0].goalProbability, { fromDecimal: true })} chance of reaching your target of {formatTargetValue(goalThreshold, outcomeUnit, outcomeUnitSymbol)}
+                </p>
+              ) : (
+                allOptionGoalProbabilities.map(opt => (
+                  <p key={opt.id} className={`${typography.panelBody} text-text-body`}>
+                    <span className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle" style={{ backgroundColor: 'var(--goal)' }} />
+                    {opt.label}: {formatPct(opt.goalProbability, { fromDecimal: true })} chance of reaching your target of {formatTargetValue(goalThreshold, outcomeUnit, outcomeUnitSymbol)}
+                  </p>
+                ))
+              )}
+            </div>
+          )}
+          {/* Fallback: winner-only display when allOptionGoalProbabilities not provided */}
+          {goalThreshold != null && winnerGoalProbability != null && !allOptionGoalProbabilities?.length && (
+            <p className={`${typography.panelBody} text-text-body`}>
+              <span className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle" style={{ backgroundColor: 'var(--goal)' }} />
+              {winnerLabel} has a {formatPct(winnerGoalProbability, { fromDecimal: true })} chance of reaching your target of {formatTargetValue(goalThreshold, outcomeUnit, outcomeUnitSymbol)}
             </p>
           )}
 
@@ -1238,10 +1267,22 @@ export function HeroSection({
           <WinGauge shares={optionWinShares} />
         )}
 
-        {/* V9.2: Goal probability line — bridges "which wins most" and "does it hit my target" */}
-        {goalThreshold != null && winnerGoalProbability != null && (
-          <p className={`${typography.panelMeta} text-text-body mb-3`}>
-            {winnerLabel} has a {formatPct(winnerGoalProbability, { fromDecimal: true })} chance of reaching your target of {formatTargetValue(goalThreshold!, outcomeUnit, outcomeUnitSymbol)}
+        {/* A3: Goal-achievement probability — comparative display for all options */}
+        {goalThreshold != null && allOptionGoalProbabilities && allOptionGoalProbabilities.length > 0 && (
+          <div className="space-y-0.5 mb-3" data-testid="goal-probability-display">
+            {allOptionGoalProbabilities.map(opt => (
+              <p key={opt.id} className={`${typography.panelBody} text-text-body`}>
+                <span className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle" style={{ backgroundColor: 'var(--goal)' }} />
+                {opt.label}: {formatPct(opt.goalProbability, { fromDecimal: true })} chance of reaching your target of {formatTargetValue(goalThreshold, outcomeUnit, outcomeUnitSymbol)}
+              </p>
+            ))}
+          </div>
+        )}
+        {/* Fallback: winner-only display when allOptionGoalProbabilities not provided */}
+        {goalThreshold != null && winnerGoalProbability != null && !allOptionGoalProbabilities?.length && (
+          <p className={`${typography.panelBody} text-text-body mb-3`}>
+            <span className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle" style={{ backgroundColor: 'var(--goal)' }} />
+            {winnerLabel} has a {formatPct(winnerGoalProbability, { fromDecimal: true })} chance of reaching your target of {formatTargetValue(goalThreshold, outcomeUnit, outcomeUnitSymbol)}
           </p>
         )}
 

--- a/src/components/results/RecommendationSection.tsx
+++ b/src/components/results/RecommendationSection.tsx
@@ -16,7 +16,7 @@ import { useMemo } from 'react'
 import type { RecommendationSectionData, DriverItem, DecisionState, HingeInfo, NextActionItem } from './types'
 import { EMPTY_STATES } from './emptyStates'
 import { typography } from '../../styles/typography'
-import { HeroSection, type OptionWinShare } from './HeroSection'
+import { HeroSection, type OptionWinShare, type OptionGoalProbability } from './HeroSection'
 
 /** Top fragile edge data for HeroSection */
 export interface TopFragileEdge {
@@ -184,6 +184,17 @@ export function RecommendationSection({
     return shares
   }, [allOptions])
 
+  // A3: Build goal-achievement probabilities for all options
+  const allOptionGoalProbabilities = useMemo<OptionGoalProbability[]>(() => {
+    return allOptions
+      .filter(o => typeof o.goalProbability === 'number' && o.goalProbability != null)
+      .map(o => ({
+        id: o.id,
+        label: o.label,
+        goalProbability: o.goalProbability!,
+      }))
+  }, [allOptions])
+
   // V12.2 Fix 1: Runner-up is highest by win_probability excluding winner
   const runnerUp = useMemo(() => {
     if (allOptions.length < 2) return null
@@ -236,6 +247,7 @@ export function RecommendationSection({
         outcomeUnitSymbol={outcomeUnitSymbol}
         isNormalised={isNormalised}
         optionWinShares={optionWinShares}
+        allOptionGoalProbabilities={allOptionGoalProbabilities.length > 0 ? allOptionGoalProbabilities : undefined}
         coachingReadiness={coachingReadiness}
         coachingReadinessScore={coachingReadinessScore}
         coachingHeadline={coachingHeadline}

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -216,6 +216,7 @@ export function ResultsBody({
           outcomeUnitSymbol={resultsSectionData.recommendation.outcomeUnitSymbol}
           isNormalised={resultsSectionData.recommendation.isNormalised}
           goalDirection={goalDirection}
+          flipThresholds={resultsSectionData.recommendation.flipThresholds}
         />
       </div>
 

--- a/src/components/results/TornadoChart.tsx
+++ b/src/components/results/TornadoChart.tsx
@@ -23,6 +23,8 @@ import { typography } from '../../styles/typography'
 import { formatPercent as formatPct } from '../../utils/formatPercent'
 import { stripEncodingNotation } from './utils/cleanFactorLabel'
 import { focusNodeById } from '../../canvas/utils/focusHelpers'
+import { useUIStore } from '../../stores/uiStore'
+import type { FlipThreshold } from './types'
 
 export interface TornadoRow {
   /** Factor key / node ID */
@@ -58,6 +60,8 @@ export interface TornadoChartProps {
   goalDirection?: 'maximize' | 'minimize'
   /** Callback to apply drag adjustments and rerun analysis */
   onApplyAndRerun?: () => void
+  /** A4: Flip threshold data for marker annotations */
+  flipThresholds?: FlipThreshold[]
 }
 
 /** Whether structured unit data is available (not just normalised model scores). */
@@ -157,6 +161,7 @@ export function TornadoChart({
   isNormalised,
   goalDirection,
   onApplyAndRerun,
+  flipThresholds,
 }: TornadoChartProps) {
   // P0.2: Use relative % change when no structured unit is available
   const useRelativePct = !isNormalised && !hasStructuredUnit(outcomeUnit, outcomeUnitSymbol)
@@ -371,6 +376,8 @@ export function TornadoChart({
 
           const handleClick = () => {
             const nodeId = row.matchedNodeId ?? row.factorKey
+            // E1: Switch to Model tab before focusing node
+            useUIStore.getState().setActiveOutputTab('diagnostics')
             if (onFocusNode) {
               onFocusNode(nodeId)
             } else {
@@ -468,6 +475,53 @@ export function TornadoChart({
                     </div>
                   </div>
                 )}
+
+                {/* A4: Flip-point marker — diamond on bar showing where recommendation changes */}
+                {(() => {
+                  const flipThreshold = flipThresholds?.find(ft => ft.node_id === row.factorKey)
+                  const hasFlip = flipThreshold?.flip_value != null
+                    && flipThreshold.flip_reason !== 'heuristic'
+                    && flipThreshold.flip_reason !== 'no_bracket'
+                  if (!hasFlip || flipThreshold?.flip_value == null) return null
+
+                  const flipVal = flipThreshold.flip_value
+                  const range = row.highOutcome - row.lowOutcome
+                  if (range === 0) return null
+
+                  const rawPct = ((flipVal - row.lowOutcome) / range) * 100
+                  // Map from row-local 0-100% to chart-global position
+                  const rowLowPct = totalRange > 0 ? ((row.lowOutcome - minVal) / totalRange) * 100 : 0
+                  const rowHighPct = totalRange > 0 ? ((row.highOutcome - minVal) / totalRange) * 100 : 0
+                  const clampedLocalPct = Math.max(0, Math.min(100, rawPct))
+                  const chartPct = rowLowPct + (clampedLocalPct / 100) * (rowHighPct - rowLowPct)
+
+                  const formattedFlip = flipThreshold.unit
+                    ? `${flipThreshold.unit}${Math.round(flipVal).toLocaleString()}`
+                    : Math.abs(flipVal) >= 10
+                      ? Math.round(flipVal).toLocaleString()
+                      : flipVal.toFixed(1)
+
+                  return (
+                    <div
+                      className="absolute top-1/2 -translate-y-1/2 flex flex-col items-center pointer-events-none z-10"
+                      style={{ left: `${chartPct}%` }}
+                      data-testid="flip-marker"
+                      title={`Flips at ${formattedFlip}`}
+                    >
+                      {/* Diamond marker */}
+                      <div
+                        className="w-[6px] h-[6px] bg-danger rotate-45"
+                        aria-hidden="true"
+                      />
+                      {/* Label */}
+                      <span
+                        className={`${typography.panelMeta} text-danger whitespace-nowrap absolute top-full mt-0.5`}
+                      >
+                        Flips at {formattedFlip}
+                      </span>
+                    </div>
+                  )
+                })()}
 
                 {/* Low value label — hidden when left bar is collapsed */}
                 {leftWidth > 0.5 && (

--- a/src/components/results/__tests__/HeroSection.goalProbability.test.tsx
+++ b/src/components/results/__tests__/HeroSection.goalProbability.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * HeroSection — A3 Goal-achievement probability display tests
+ *
+ * Uses golden fixture data from resultsPanelV7.rich.hook.ts
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HeroSection, type HeroSectionProps, type OptionGoalProbability } from '../HeroSection'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusByTarget: vi.fn(),
+  focusNodeById: vi.fn(),
+  focusEdgeByEndpoints: vi.fn(),
+}))
+
+vi.mock('../../../canvas/utils/highlightHelpers', () => ({
+  highlightNode: vi.fn(),
+  clearHighlight: vi.fn(),
+}))
+
+const baseProps: HeroSectionProps = {
+  winnerLabel: 'Build in-house',
+  winnerId: 'opt-build',
+  optionCount: 3,
+  hasBaseline: false,
+  analysisStatus: 'computed',
+  goalLabel: 'Annual recurring revenue',
+  goalThreshold: 800000,
+  outcomeUnit: 'currency',
+  outcomeUnitSymbol: '$',
+}
+
+// Golden fixture data from resultsPanelV7.rich.hook.ts
+const richGoalProbabilities: OptionGoalProbability[] = [
+  { id: 'opt-build', label: 'Build in-house', goalProbability: 0.64 },
+  { id: 'opt-outsource', label: 'Outsource', goalProbability: 0.31 },
+  { id: 'opt-hybrid', label: 'Hybrid approach', goalProbability: 0.18 },
+]
+
+describe('HeroSection — Goal-achievement probability (A3)', () => {
+  it('renders goal probability for all options when data is present', () => {
+    render(
+      <HeroSection
+        {...baseProps}
+        winnerGoalProbability={0.64}
+        allOptionGoalProbabilities={richGoalProbabilities}
+      />
+    )
+
+    const display = screen.getByTestId('goal-probability-display')
+    expect(display).toBeInTheDocument()
+
+    // All three options should be shown
+    expect(display.textContent).toContain('Build in-house')
+    expect(display.textContent).toContain('Outsource')
+    expect(display.textContent).toContain('Hybrid approach')
+  })
+
+  it('displays percentages as integers without decimals', () => {
+    render(
+      <HeroSection
+        {...baseProps}
+        winnerGoalProbability={0.64}
+        allOptionGoalProbabilities={richGoalProbabilities}
+      />
+    )
+
+    const display = screen.getByTestId('goal-probability-display')
+    // 0.64 → 64%, 0.31 → 31%, 0.18 → 18% — no decimals
+    expect(display.textContent).toContain('64%')
+    expect(display.textContent).toContain('31%')
+    expect(display.textContent).toContain('18%')
+    // No decimal points in the percentage values
+    expect(display.textContent).not.toMatch(/\d+\.\d+%/)
+  })
+
+  it('renders nothing when allOptionGoalProbabilities is absent', () => {
+    render(
+      <HeroSection
+        {...baseProps}
+        winnerGoalProbability={null}
+        allOptionGoalProbabilities={undefined}
+      />
+    )
+
+    expect(screen.queryByTestId('goal-probability-display')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when goalThreshold is null', () => {
+    render(
+      <HeroSection
+        {...baseProps}
+        goalThreshold={null}
+        winnerGoalProbability={0.64}
+        allOptionGoalProbabilities={richGoalProbabilities}
+      />
+    )
+
+    expect(screen.queryByTestId('goal-probability-display')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when allOptionGoalProbabilities is empty array', () => {
+    render(
+      <HeroSection
+        {...baseProps}
+        winnerGoalProbability={0.64}
+        allOptionGoalProbabilities={[]}
+      />
+    )
+
+    expect(screen.queryByTestId('goal-probability-display')).not.toBeInTheDocument()
+  })
+
+  it('falls back to winner-only display when allOptionGoalProbabilities not provided but winnerGoalProbability is', () => {
+    render(
+      <HeroSection
+        {...baseProps}
+        winnerGoalProbability={0.72}
+      />
+    )
+
+    // Should show fallback text with winner only
+    expect(screen.getByText(/Build in-house has a 72%/)).toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/TornadoChart.flipMarkers.test.tsx
+++ b/src/components/results/__tests__/TornadoChart.flipMarkers.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TornadoChart, type TornadoRow } from '../TornadoChart'
+import type { FlipThreshold } from '../types'
+
+// Mock focusHelpers
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+}))
+
+// Mock uiStore
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: { getState: () => ({ setActiveOutputTab: vi.fn() }) },
+}))
+
+const rows: TornadoRow[] = [
+  { factorKey: 'factor-1', label: 'Factor One', lowOutcome: 100, highOutcome: 500, canFocus: true },
+  { factorKey: 'factor-2', label: 'Factor Two', lowOutcome: 200, highOutcome: 400, canFocus: true },
+]
+
+describe('TornadoChart flip markers (A4)', () => {
+  it('renders flip marker when flip_value is present', () => {
+    const flipThresholds: FlipThreshold[] = [
+      { label: 'Factor One', node_id: 'factor-1', current_value: 300, flip_value: 400, unit: '$' },
+    ]
+
+    render(
+      <TornadoChart
+        rows={rows}
+        expectedOutcome={300}
+        flipThresholds={flipThresholds}
+      />,
+    )
+
+    const markers = screen.getAllByTestId('flip-marker')
+    expect(markers).toHaveLength(1)
+    expect(markers[0]).toHaveAttribute('title', 'Flips at $400')
+  })
+
+  it('does not render marker when flip_value is null', () => {
+    const flipThresholds: FlipThreshold[] = [
+      { label: 'Factor Two', node_id: 'factor-2', current_value: 300, flip_value: null, flip_reason: 'no_bracket' },
+    ]
+
+    render(
+      <TornadoChart
+        rows={rows}
+        expectedOutcome={300}
+        flipThresholds={flipThresholds}
+      />,
+    )
+
+    expect(screen.queryByTestId('flip-marker')).toBeNull()
+  })
+
+  it('does not render marker when flip_reason is heuristic', () => {
+    const flipThresholds: FlipThreshold[] = [
+      { label: 'Factor One', node_id: 'factor-1', current_value: 300, flip_value: 400, flip_reason: 'heuristic' as any },
+    ]
+
+    render(
+      <TornadoChart
+        rows={rows}
+        expectedOutcome={300}
+        flipThresholds={flipThresholds}
+      />,
+    )
+
+    expect(screen.queryByTestId('flip-marker')).toBeNull()
+  })
+
+  it('renders markers for multiple rows with valid flip data', () => {
+    const flipThresholds: FlipThreshold[] = [
+      { label: 'Factor One', node_id: 'factor-1', current_value: 300, flip_value: 400 },
+      { label: 'Factor Two', node_id: 'factor-2', current_value: 300, flip_value: 350 },
+    ]
+
+    render(
+      <TornadoChart
+        rows={rows}
+        expectedOutcome={300}
+        flipThresholds={flipThresholds}
+      />,
+    )
+
+    const markers = screen.getAllByTestId('flip-marker')
+    expect(markers).toHaveLength(2)
+  })
+})

--- a/src/components/results/utils/getThresholdColour.ts
+++ b/src/components/results/utils/getThresholdColour.ts
@@ -20,3 +20,15 @@ export function getThresholdColour(value: number): string {
   if (pct >= 40) return 'bg-warning'
   return 'bg-danger'
 }
+
+/**
+ * Returns the raw semantic colour token for a 0-1 metric value.
+ * Same thresholds as getThresholdColour but without the `bg-` prefix,
+ * suitable for CSS custom properties (e.g. `var(--${token})`).
+ */
+export function getThresholdToken(value: number): 'success' | 'warning' | 'danger' {
+  const pct = Math.round(value * 100)
+  if (pct >= 70) return 'success'
+  if (pct >= 40) return 'warning'
+  return 'danger'
+}

--- a/src/components/shared/DeltaIndicator.tsx
+++ b/src/components/shared/DeltaIndicator.tsx
@@ -1,0 +1,56 @@
+/**
+ * A1: Delta indicator pill showing change from previous analysis run.
+ * Renders a small outlined pill with trending icon and signed delta value.
+ */
+import { TrendingUp, TrendingDown } from 'lucide-react'
+import { typography } from '../../styles/typography'
+
+interface DeltaIndicatorProps {
+  currentValue: number
+  previousValue: number | undefined | null
+  format: 'percent' | 'currency' | 'number'
+  unit?: string
+  /** Minimum absolute delta to display (default 0.01 for percent, 0.5 for others) */
+  significanceThreshold?: number
+}
+
+export function DeltaIndicator({
+  currentValue,
+  previousValue,
+  format,
+  unit,
+  significanceThreshold,
+}: DeltaIndicatorProps) {
+  if (previousValue == null) return null
+
+  const delta = currentValue - previousValue
+  const threshold = significanceThreshold ?? (format === 'percent' ? 0.01 : 0.5)
+
+  if (Math.abs(delta) < threshold) return null
+
+  const isPositive = delta > 0
+  const Icon = isPositive ? TrendingUp : TrendingDown
+  const colourClass = isPositive ? 'text-success border-success/30' : 'text-danger border-danger/30'
+
+  let label: string
+  if (format === 'percent') {
+    const deltaPct = Math.round(Math.abs(delta) * 100)
+    label = `${isPositive ? '+' : '\u2212'}${deltaPct}pp`
+  } else if (format === 'currency') {
+    const formatted = Math.abs(delta).toLocaleString(undefined, { maximumFractionDigits: 0 })
+    label = `${isPositive ? '+' : '\u2212'}${unit ?? ''}${formatted}`
+  } else {
+    const formatted = Math.abs(delta).toLocaleString(undefined, { maximumFractionDigits: 1 })
+    label = `${isPositive ? '+' : '\u2212'}${formatted}${unit ? ` ${unit}` : ''}`
+  }
+
+  return (
+    <span
+      className={`${typography.panelMeta} ${colourClass} bg-transparent border rounded-full px-1.5 py-0.5 inline-flex items-center gap-0.5`}
+      data-testid="delta-indicator"
+    >
+      <Icon size={10} />
+      {label}
+    </span>
+  )
+}

--- a/src/components/shared/StabilityGauge.tsx
+++ b/src/components/shared/StabilityGauge.tsx
@@ -1,0 +1,63 @@
+import { getThresholdToken } from '../results/utils/getThresholdColour'
+import { typography } from '../../styles/typography'
+
+interface StabilityGaugeProps {
+  value: number | null | undefined
+  size?: number
+}
+
+export function StabilityGauge({ value, size = 24 }: StabilityGaugeProps) {
+  if (value == null) return null
+
+  const token = getThresholdToken(value)
+  const pct = Math.round(value * 100)
+
+  // Arc geometry: 270 degree arc
+  const r = 10 // radius
+  const cx = 12
+  const cy = 12
+  const startAngle = 135 // degrees from 12 o'clock
+  const totalAngle = 270
+
+  // Convert to radians and compute arc path
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+  const startRad = toRad(startAngle - 90) // SVG starts from 3 o'clock
+  const endRad = toRad(startAngle + totalAngle - 90)
+
+  const x1 = cx + r * Math.cos(startRad)
+  const y1 = cy + r * Math.sin(startRad)
+  const x2 = cx + r * Math.cos(endRad)
+  const y2 = cy + r * Math.sin(endRad)
+
+  const arcPath = `M ${x1} ${y1} A ${r} ${r} 0 1 1 ${x2} ${y2}`
+
+  // Circumference for stroke-dasharray
+  const circumference = 2 * Math.PI * r * (totalAngle / 360)
+  const fillLength = circumference * value
+
+  return (
+    <span className="inline-flex items-center gap-1.5" data-testid="stability-gauge">
+      <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+        {/* Background track */}
+        <path
+          d={arcPath}
+          fill="none"
+          stroke="var(--panel-border)"
+          strokeWidth={3}
+          strokeLinecap="round"
+          opacity={0.5}
+        />
+        {/* Filled arc */}
+        <path
+          d={arcPath}
+          fill="none"
+          stroke={`var(--${token})`}
+          strokeWidth={3}
+          strokeLinecap="round"
+          strokeDasharray={`${fillLength} ${circumference}`}
+        />
+      </svg>
+      <span className={`${typography.panelMeta} text-text-light`}>{pct}%</span>
+    </span>
+  )
+}

--- a/src/components/shared/__tests__/DeltaIndicator.test.tsx
+++ b/src/components/shared/__tests__/DeltaIndicator.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DeltaIndicator } from '../DeltaIndicator'
+
+describe('DeltaIndicator', () => {
+  it('renders positive delta with up arrow', () => {
+    render(<DeltaIndicator currentValue={0.72} previousValue={0.64} format="percent" />)
+    const el = screen.getByTestId('delta-indicator')
+    expect(el).toBeInTheDocument()
+    expect(el.textContent).toContain('+8pp')
+    expect(el.className).toContain('text-success')
+  })
+
+  it('renders negative delta with down arrow', () => {
+    render(<DeltaIndicator currentValue={0.31} previousValue={0.64} format="percent" />)
+    const el = screen.getByTestId('delta-indicator')
+    expect(el).toBeInTheDocument()
+    expect(el.textContent).toContain('33pp')
+    expect(el.className).toContain('text-danger')
+  })
+
+  it('suppresses delta below significance threshold', () => {
+    render(<DeltaIndicator currentValue={0.64} previousValue={0.641} format="percent" />)
+    expect(screen.queryByTestId('delta-indicator')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when previousValue is null', () => {
+    render(<DeltaIndicator currentValue={0.64} previousValue={null} format="percent" />)
+    expect(screen.queryByTestId('delta-indicator')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when previousValue is undefined', () => {
+    render(<DeltaIndicator currentValue={0.64} previousValue={undefined} format="percent" />)
+    expect(screen.queryByTestId('delta-indicator')).not.toBeInTheDocument()
+  })
+
+  it('renders currency format', () => {
+    render(<DeltaIndicator currentValue={1500} previousValue={1000} format="currency" unit="$" />)
+    const el = screen.getByTestId('delta-indicator')
+    expect(el.textContent).toContain('+$500')
+  })
+
+  it('uses custom significance threshold', () => {
+    render(
+      <DeltaIndicator currentValue={0.65} previousValue={0.64} format="percent" significanceThreshold={0.005} />
+    )
+    expect(screen.getByTestId('delta-indicator')).toBeInTheDocument()
+  })
+})

--- a/src/components/shared/__tests__/StabilityGauge.test.tsx
+++ b/src/components/shared/__tests__/StabilityGauge.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * StabilityGauge — radial arc gauge for recommendation stability.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StabilityGauge } from '../StabilityGauge'
+
+describe('StabilityGauge', () => {
+  it('renders danger colour for value below 0.40', () => {
+    render(<StabilityGauge value={0.39} />)
+    const gauge = screen.getByTestId('stability-gauge')
+    expect(gauge).toBeTruthy()
+    // The filled arc (second <path>) should use var(--danger)
+    const paths = gauge.querySelectorAll('path')
+    expect(paths[1].getAttribute('stroke')).toBe('var(--danger)')
+  })
+
+  it('renders warning colour for value 0.40', () => {
+    render(<StabilityGauge value={0.40} />)
+    const gauge = screen.getByTestId('stability-gauge')
+    const paths = gauge.querySelectorAll('path')
+    expect(paths[1].getAttribute('stroke')).toBe('var(--warning)')
+  })
+
+  it('renders success colour for value 0.70', () => {
+    render(<StabilityGauge value={0.70} />)
+    const gauge = screen.getByTestId('stability-gauge')
+    const paths = gauge.querySelectorAll('path')
+    expect(paths[1].getAttribute('stroke')).toBe('var(--success)')
+  })
+
+  it('renders nothing when value is null', () => {
+    const { container } = render(<StabilityGauge value={null} />)
+    expect(container.innerHTML).toBe('')
+    expect(screen.queryByTestId('stability-gauge')).toBeNull()
+  })
+
+  it('renders nothing when value is undefined', () => {
+    const { container } = render(<StabilityGauge value={undefined} />)
+    expect(container.innerHTML).toBe('')
+    expect(screen.queryByTestId('stability-gauge')).toBeNull()
+  })
+
+  it('displays percentage as integer', () => {
+    render(<StabilityGauge value={0.856} />)
+    const gauge = screen.getByTestId('stability-gauge')
+    expect(gauge.textContent).toBe('86%')
+  })
+})

--- a/src/stores/__tests__/uiStore.test.ts
+++ b/src/stores/__tests__/uiStore.test.ts
@@ -1,0 +1,39 @@
+/**
+ * UI Store — E1 cross-tab navigation tests
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUIStore } from '../uiStore'
+
+describe('uiStore', () => {
+  beforeEach(() => {
+    // Reset store to default state
+    useUIStore.setState({ activeOutputTab: 'results', hoveredElementId: null })
+  })
+
+  it('default tab is results', () => {
+    expect(useUIStore.getState().activeOutputTab).toBe('results')
+  })
+
+  it('setActiveOutputTab updates state', () => {
+    useUIStore.getState().setActiveOutputTab('diagnostics')
+    expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
+  })
+
+  it('setActiveOutputTab works for all tab types', () => {
+    for (const tab of ['results', 'compare', 'diagnostics', 'journey'] as const) {
+      useUIStore.getState().setActiveOutputTab(tab)
+      expect(useUIStore.getState().activeOutputTab).toBe(tab)
+    }
+  })
+
+  it('setHoveredElementId sets and clears', () => {
+    expect(useUIStore.getState().hoveredElementId).toBeNull()
+
+    useUIStore.getState().setHoveredElementId('node-123')
+    expect(useUIStore.getState().hoveredElementId).toBe('node-123')
+
+    useUIStore.getState().setHoveredElementId(null)
+    expect(useUIStore.getState().hoveredElementId).toBeNull()
+  })
+})

--- a/src/stores/__tests__/uiStore.test.ts
+++ b/src/stores/__tests__/uiStore.test.ts
@@ -1,5 +1,5 @@
 /**
- * UI Store — E1 cross-tab navigation tests
+ * UI Store — E1 cross-tab navigation tests + Task C panel coordination
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -8,7 +8,11 @@ import { useUIStore } from '../uiStore'
 describe('uiStore', () => {
   beforeEach(() => {
     // Reset store to default state
-    useUIStore.setState({ activeOutputTab: 'results', hoveredElementId: null })
+    useUIStore.setState({
+      activeOutputTab: 'results',
+      hoveredElementId: null,
+      activeRightPanel: null,
+    })
   })
 
   it('default tab is results', () => {
@@ -35,5 +39,40 @@ describe('uiStore', () => {
 
     useUIStore.getState().setHoveredElementId(null)
     expect(useUIStore.getState().hoveredElementId).toBeNull()
+  })
+})
+
+describe('uiStore — Task C: right-panel coordination', () => {
+  beforeEach(() => {
+    useUIStore.setState({ activeRightPanel: null })
+  })
+
+  it('default activeRightPanel is null', () => {
+    expect(useUIStore.getState().activeRightPanel).toBeNull()
+  })
+
+  it('openRightPanel sets the active panel', () => {
+    useUIStore.getState().openRightPanel('provenance')
+    expect(useUIStore.getState().activeRightPanel).toBe('provenance')
+  })
+
+  it('openRightPanel replaces previous panel (mutual exclusion)', () => {
+    useUIStore.getState().openRightPanel('provenance')
+    expect(useUIStore.getState().activeRightPanel).toBe('provenance')
+
+    useUIStore.getState().openRightPanel('clarifier')
+    expect(useUIStore.getState().activeRightPanel).toBe('clarifier')
+  })
+
+  it('closeRightPanel resets to null', () => {
+    useUIStore.getState().openRightPanel('results')
+    useUIStore.getState().closeRightPanel()
+    expect(useUIStore.getState().activeRightPanel).toBeNull()
+  })
+
+  it('openRightPanel(null) closes all panels', () => {
+    useUIStore.getState().openRightPanel('clarifier')
+    useUIStore.getState().openRightPanel(null)
+    expect(useUIStore.getState().activeRightPanel).toBeNull()
   })
 })

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,0 +1,36 @@
+/**
+ * UI Store — Cross-component UI state (Zustand)
+ *
+ * E1: Enables programmatic tab switching from results components
+ * (tornado chart, driver rows) to the Model tab.
+ *
+ * D2: Hover highlight state for bidirectional canvas-panel linking.
+ */
+import { create } from 'zustand'
+
+/** Must match OutputsDockTab in OutputsDock.tsx exactly */
+export type OutputTab = 'results' | 'compare' | 'diagnostics' | 'journey'
+
+export interface UIStoreState {
+  /** Current active tab in the OutputsDock (synced bidirectionally) */
+  activeOutputTab: OutputTab
+  /** D2: Element ID currently hovered in a panel (for canvas highlight) */
+  hoveredElementId: string | null
+}
+
+export interface UIStoreActions {
+  setActiveOutputTab: (tab: OutputTab) => void
+  setHoveredElementId: (id: string | null) => void
+}
+
+export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
+  activeOutputTab: 'results',
+  hoveredElementId: null,
+
+  setActiveOutputTab: (tab) => set({ activeOutputTab: tab }),
+  setHoveredElementId: (id) => set({ hoveredElementId: id }),
+}))
+
+// Selectors
+export const selectActiveOutputTab = (s: UIStoreState) => s.activeOutputTab
+export const selectHoveredElementId = (s: UIStoreState) => s.hoveredElementId

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -5,32 +5,54 @@
  * (tornado chart, driver rows) to the Model tab.
  *
  * D2: Hover highlight state for bidirectional canvas-panel linking.
+ *
+ * Task C: Right-panel orchestration — only one right-side panel is visible
+ * at a time. Opening a panel auto-closes any other open panel.
  */
 import { create } from 'zustand'
 
 /** Must match OutputsDockTab in OutputsDock.tsx exactly */
 export type OutputTab = 'results' | 'compare' | 'diagnostics' | 'journey'
 
+/**
+ * Right-panel modes. Only one right-side panel can be open at a time.
+ * - 'results': OutputsDock (analysis, compare, model tabs)
+ * - 'provenance': ProvenanceHubTab
+ * - 'clarifier': AI Clarifier chat
+ * - null: no right panel open
+ */
+export type RightPanelMode = 'results' | 'provenance' | 'clarifier' | null
+
 export interface UIStoreState {
   /** Current active tab in the OutputsDock (synced bidirectionally) */
   activeOutputTab: OutputTab
   /** D2: Element ID currently hovered in a panel (for canvas highlight) */
   hoveredElementId: string | null
+  /** Task C: Which right-side panel is currently open (mutual exclusion) */
+  activeRightPanel: RightPanelMode
 }
 
 export interface UIStoreActions {
   setActiveOutputTab: (tab: OutputTab) => void
   setHoveredElementId: (id: string | null) => void
+  /** Open a right panel (closes any other). Pass null to close all. */
+  openRightPanel: (mode: RightPanelMode) => void
+  /** Close the active right panel */
+  closeRightPanel: () => void
 }
 
 export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
   activeOutputTab: 'results',
   hoveredElementId: null,
+  activeRightPanel: null,
 
   setActiveOutputTab: (tab) => set({ activeOutputTab: tab }),
   setHoveredElementId: (id) => set({ hoveredElementId: id }),
+  openRightPanel: (mode) => set({ activeRightPanel: mode }),
+  closeRightPanel: () => set({ activeRightPanel: null }),
 }))
 
 // Selectors
 export const selectActiveOutputTab = (s: UIStoreState) => s.activeOutputTab
 export const selectHoveredElementId = (s: UIStoreState) => s.hoveredElementId
+export const selectActiveRightPanel = (s: UIStoreState) => s.activeRightPanel


### PR DESCRIPTION
## Summary
This PR introduces several new analysis and UI features across the results panel, canvas inspector, and cross-component navigation. The changes enable delta tracking between analysis runs (A1), goal-achievement probability display (A3), flip-point markers in tornado charts (A4), uncertainty bands in strength sliders (C1), colored track fills in inspector sliders (C2), and programmatic tab switching (E1).

## Key Changes

### A1: Delta Indicator & Previous Report Snapshots
- Added `DeltaIndicator` component to display trending changes (up/down arrows with signed deltas) between analysis runs
- Extended `CanvasState` with `previousReport` snapshot containing option win probabilities, outcome means, goal probabilities, ranking stability, and driver influences
- Delta display supports percent, currency, and numeric formats with configurable significance thresholds
- Snapshots are captured after each analysis run and cleared on canvas reset

### A3: Goal-Achievement Probability Display
- Added `OptionGoalProbability` interface to `HeroSection` for comparative goal-achievement display
- Renders probability for all options when goal threshold is set, with fallback to winner-only display
- Displays percentages as integers without decimals
- Conditional rendering: only shows when both `goalThreshold` and `allOptionGoalProbabilities` are present and non-empty
- Updated `RecommendationSection` to build goal probabilities from analysis results

### A4: Flip-Point Markers in Tornado Charts
- Added `FlipThreshold` type and `flipThresholds` prop to `TornadoChart`
- Renders diamond markers on tornado bars showing where recommendation changes
- Filters out heuristic and no-bracket flip reasons
- Displays flip value in tooltip (e.g., "Flips at $400")
- Properly clamps marker position to chart bounds

### C1: Uncertainty Band in Signed Strength Slider
- Added `std` (standard deviation) prop to `SignedStrengthSlider`
- Renders semi-transparent band showing ±std range around current value
- Band is clamped to slider range [-1, 1]
- Only renders when std is provided and > 0

### C2: Colored Track Fill in Inspector Sliders
- Added `trackFillColor` prop to `InspectorSlider` in EdgePanel
- Renders colored fill behind slider track showing progress
- Smooth transition animation on value changes
- Supports custom color via CSS variable

### E1: Cross-Tab Navigation
- Created new `uiStore` (Zustand) for managing UI state across components
- Added `setActiveOutputTab` action to programmatically switch between results/compare/diagnostics/journey tabs
- TornadoChart now switches to 'diagnostics' tab when clicking on factors
- Enables seamless navigation from results analysis to model inspection

### UI Components & Utilities
- Added `EdgeThicknessLegend` component showing influence levels (weak/moderate/strong) with auto-fade after 10s
- Added `StabilityGauge` component rendering 270° arc gauge for recommendation stability with semantic color tokens
- Added `getThresholdToken` utility for semantic color mapping (success/warning/danger)

### Tests
- Comprehensive test suites for all new components and features
- Tests cover edge cases: null/undefined values, empty arrays, boundary conditions
- Fixture data from golden analysis results for realistic test scenarios

## Implementation Details
- All new features are backward-compatible; components gracefully handle missing data
- Delta display uses configurable significance thresholds to avoid noise (0.01 for percent, 0.5 for others)
- Flip markers respect chart scaling and properly handle edge cases (zero range, out-of-bounds values)
- UI store uses Zustand for lightweight, performant cross-component state management
- Accessibility maintained with proper ARIA labels and semantic HTML

https://claude.ai/code/session_01EnrqnchSbh61Q6bX5HEPxP