### PR TITLE
fix(test): pin isOrchestratorV2Enabled in useConversation.hook.spec system-event test

### DIFF
--- a/docs/ui/useconversation-spec-diagnosis.md
+++ b/docs/ui/useconversation-spec-diagnosis.md
@@ -171,3 +171,33 @@ $ VITE_FEATURE_ORCHESTRATOR_STREAMING=0 npx vitest run src/canvas/conversation/_
 $ VITE_FEATURE_ORCHESTRATOR_STREAMING=0 npx vitest run src/canvas/conversation/__tests__/useConversation.hook.spec.ts -t "buildRequest payload"
 Tests  21 failed | 34 skipped (55)
 ```
+
+---
+
+## 7. Amendment (2026-04-17, post-PR-#122-merge)
+
+PR #122 landed commit `331c972a` which pinned **only** `isOrchestratorStreamingEnabled`. That made 20 of the 21 originally-failing tests pass. CI on the merge commit (`a656bd1a`) then surfaced a 21st failure with the same "spy called 0 times" symptom but a distinct root cause — different enough that the original diagnosis missed it.
+
+**Why the original fix was incomplete:**
+
+- **`sendMessage`** (used by the 20 tests that passed) delegates straight to `sendTurn` at [`useConversation.ts:2959`](../../src/canvas/conversation/useConversation.ts#L2959) — no V2 guard. Streaming flag pin alone is sufficient.
+- **`sendSystemEvent`** (used by `system event turn also transforms graph_state correctly`) guards on `isOrchestratorV2Enabled()` at [`useConversation.ts:2984`](../../src/canvas/conversation/useConversation.ts#L2984) and early-returns if false. `sendTurn` is never reached; streaming branch never fires; `mockStreamTurn.mock.calls[0]` is `undefined`.
+
+The PR #122 mock used `importOriginal` + override, which preserved the real `isOrchestratorV2Enabled`. In CI without `VITE_ENABLE_ORCHESTRATOR_V2=1`, that flag resolves `false` → system-event test bypasses the asserted path.
+
+**Amended fix** (PR #123, branch `ui/useconversation-hook-spec-system-event-fix`): pin both flags. Mirrors the pattern already used in sibling specs [`useConversation.systemEvents.spec.ts:37-40`](../../src/canvas/conversation/__tests__/useConversation.systemEvents.spec.ts#L37-L40) and [`streamingLifecycle.spec.ts:41-45`](../../src/canvas/conversation/__tests__/streamingLifecycle.spec.ts#L41-L45).
+
+```ts
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isOrchestratorStreamingEnabled: () => true,
+    isOrchestratorV2Enabled: () => true,
+  }
+})
+```
+
+Verified locally: 54 passed + 1 skipped with `VITE_FEATURE_ORCHESTRATOR_STREAMING=0` **AND** `=1`. The spec is now fully env-independent for both `sendMessage` and `sendSystemEvent` paths.
+
+**Lesson to carry forward:** when fixing a whole `describe` block that failed with a single symptom, don't assume every test in the block uses the same code path. The 21st test's assertion looked identical but the function under test (`sendSystemEvent`) has a distinct guard that `sendMessage` doesn't. Targeted mock pinning needs to cover every guard on every code path the tests exercise.

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -51,14 +51,27 @@ vi.mock('../turnService', () => ({
   },
 }))
 
-// Pin the orchestrator-streaming flag ON: the buildRequest payload block
-// asserts against mockStreamTurn (streaming path). Without this, the flag
-// resolves from env/localStorage and the non-streaming branch runs on any
-// machine without VITE_FEATURE_ORCHESTRATOR_STREAMING=1, making 21 tests
-// env-dependent. See docs/ui/useconversation-spec-diagnosis.md.
+// Pin both flags ON:
+//   - isOrchestratorStreamingEnabled: the buildRequest payload block asserts
+//     against mockStreamTurn (streaming path). Without this, the flag
+//     resolves from env/localStorage and the non-streaming branch runs on
+//     any machine without VITE_FEATURE_ORCHESTRATOR_STREAMING=1, making 20
+//     sendMessage tests env-dependent.
+//   - isOrchestratorV2Enabled: sendSystemEvent guards on this flag at
+//     useConversation.ts:2984 and early-returns if it's false. Without
+//     pinning, the "system event turn also transforms graph_state correctly"
+//     test exits sendSystemEvent before the streaming path and
+//     mockStreamTurn is never called. sendMessage has no V2 guard, which is
+//     why the 20 user-message tests passed with streaming alone.
+// Mirrors the pattern in sibling specs (streamingLifecycle, systemEvents).
+// See docs/ui/useconversation-spec-diagnosis.md.
 vi.mock('../../../flags', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../flags')>()
-  return { ...actual, isOrchestratorStreamingEnabled: () => true }
+  return {
+    ...actual,
+    isOrchestratorStreamingEnabled: () => true,
+    isOrchestratorV2Enabled: () => true,
+  }
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Follow-up to PR #122. That PR pinned `isOrchestratorStreamingEnabled` in `useConversation.hook.spec.ts`, resolving 20 of 21 originally-failing tests. CI on merge commit `a656bd1a` surfaced a 21st failure in `system event turn also transforms graph_state correctly` — same "spy called 0 times" symptom, distinct root cause.
- This PR pins `isOrchestratorV2Enabled` as well, matching the sibling-spec pattern.

## Root cause (why the original fix was incomplete)

- **`sendMessage`** (used by the 20 passing tests) delegates straight to `sendTurn` — no V2 guard. Streaming flag alone suffices.
- **`sendSystemEvent`** (used by this test) guards on `isOrchestratorV2Enabled()` at [`useConversation.ts:2984`](src/canvas/conversation/useConversation.ts#L2984) and early-returns if false. `sendTurn` never runs, streaming branch never fires, `mockStreamTurn.mock.calls[0]` is `undefined`.

PR #122's `vi.mock` used `importOriginal` + override, preserving the real `isOrchestratorV2Enabled`. In CI without `VITE_ENABLE_ORCHESTRATOR_V2=1` that flag resolves `false` — system-event test bypasses the asserted path.

## Fix

```ts
vi.mock('../../../flags', async (importOriginal) => {
  const actual = await importOriginal<typeof import('../../../flags')>()
  return {
    ...actual,
    isOrchestratorStreamingEnabled: () => true,
    isOrchestratorV2Enabled: () => true,
  }
})
```

Mirrors the pattern already established in sibling specs `useConversation.systemEvents.spec.ts:37-40` and `streamingLifecycle.spec.ts:41-45`.

## Verification

- `pnpm exec vitest run useConversation.hook.spec.ts` with `VITE_FEATURE_ORCHESTRATOR_STREAMING=0`: **54 passed + 1 skipped**.
- Same run with `VITE_FEATURE_ORCHESTRATOR_STREAMING=1`: **54 passed + 1 skipped**. Spec is now env-independent for both `sendMessage` and `sendSystemEvent` paths.
- `pnpm exec tsc -p tsconfig.ci.json --noEmit`: clean.

## Diagnosis doc

Amendment §7 in [`docs/ui/useconversation-spec-diagnosis.md`](docs/ui/useconversation-spec-diagnosis.md) documents why the original fix was incomplete and carries forward the lesson: same-block tests can exercise distinct code paths with distinct guards. Targeted mock pinning must cover every guard on every code path.
