### PR TITLE
fix(test): stub VITE_PLOT_PROXY_BASE in httpV1Adapter.stream.test.ts

### DIFF
--- a/src/adapters/plot/__tests__/httpV1Adapter.stream.test.ts
+++ b/src/adapters/plot/__tests__/httpV1Adapter.stream.test.ts
@@ -18,11 +18,28 @@ import type { RunRequest, ReportV1, ErrorV1 } from '../types'
 // Setup MSW server
 const server = setupServer()
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
-
 const PROXY_BASE = '/api/plot'
+
+// The adapter reads the proxy base from VITE_PLOT_PROXY_BASE, falling back to
+// '/bff/engine' (see getProxyBase() in src/adapters/plot/v1/sseClient.ts). The
+// MSW handlers below are registered under `${PROXY_BASE}/v1/*`; without an
+// explicit stub, CI (no .env.local) resolves the env to undefined, the adapter
+// fetches /bff/engine/v1/stream, MSW doesn't match → "intercepted a request
+// without a matching request handler" + onHello spy called 0 times.
+//
+// Locally masked by `.env.local: VITE_PLOT_PROXY_BASE=/api/plot`.
+//
+// Mirrors the pattern in src/adapters/plot/v1/__tests__/probe.test.ts
+// (vi.stubEnv at test-time, vi.unstubAllEnvs on teardown).
+beforeAll(() => {
+  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
+  server.listen({ onUnhandledRequest: 'error' })
+})
+afterEach(() => server.resetHandlers())
+afterAll(() => {
+  vi.unstubAllEnvs()
+  server.close()
+})
 
 describe('httpV1Adapter Streaming Tests', () => {
   const runRequest: RunRequest = {


### PR DESCRIPTION
## Summary

Follow-up to PR #123. That PR fixed the `useConversation` system-event test, which had been bailing the Full Test Suite early. With it resolved, the runner now reaches `httpV1Adapter.stream.test.ts` and exposes a **pre-existing** env-dependency that has been silently broken on CI since at least commit `8d699ead`. Hidden for weeks behind earlier failures.

## Root cause

- [`src/adapters/plot/v1/sseClient.ts:17-19`](src/adapters/plot/v1/sseClient.ts#L17-L19) reads `VITE_PLOT_PROXY_BASE` with a fallback of `/bff/engine`.
- [`src/adapters/plot/__tests__/httpV1Adapter.stream.test.ts`](src/adapters/plot/__tests__/httpV1Adapter.stream.test.ts) registers MSW handlers under `/api/plot/v1/*`.
- Locally the spec passes because `.env.local` carries `VITE_PLOT_PROXY_BASE=/api/plot`.
- In CI (no `.env.local`) the env resolves to `undefined`, the adapter fetches `/bff/engine/v1/stream`, MSW doesn't match, `onHello` spy is never called, test fails with `AssertionError: expected "spy" to be called with arguments: [ { response_id: 'run-123' } ]` plus `[MSW] Error: intercepted a request without a matching request handler`.

## Fix (test-only, no production code touched)

Add `vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)` in `beforeAll`; `vi.unstubAllEnvs()` in `afterAll`. Mirrors the pattern in [`src/adapters/plot/v1/__tests__/probe.test.ts`](src/adapters/plot/v1/__tests__/probe.test.ts) (the only other spec that stubs this env).

Preamble comment explains the `.env.local` local-mask mechanism so future readers don't repeat the mistake.

No adapter changes. The adapter's `getProxyBase()` pattern (env var with sensible default) is correct; the test was relying on dev-local env without stubbing.

## Verification

- `env -u VITE_PLOT_PROXY_BASE pnpm exec vitest run httpV1Adapter.stream.test.ts` (simulates CI): **6 passed + 1 skipped**
- `VITE_PLOT_PROXY_BASE=/api/plot pnpm exec vitest run httpV1Adapter.stream.test.ts` (local): **6 passed + 1 skipped**
- `pnpm exec tsc -p tsconfig.ci.json --noEmit`: clean

Spec is now env-independent.

## Blast radius

Full Test Suite on previous merge commit `2b512f2b` ran to completion with **96/96 test files executed** and **1 failed of 4181 tests**. This test is the sole surviving failure; no hidden cascade waiting behind it.

## Context

Part of the ongoing Staging Tests unblock sequence:
- PR #122: fixed 20 tests in useConversation.hook.spec (streaming flag)
- PR #123: fixed the 21st in same file (V2 flag for system-event path)
- **PR #124 (this)**: fixes httpV1Adapter.stream MSW env dependency

After this lands, Staging Tests should be fully green on staging for the first time in weeks.
