### PR TITLE
fix(test): batch-stub VITE_PLOT_PROXY_BASE in 5 MSW specs (env-drift)

### DIFF
--- a/src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts
+++ b/src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts
@@ -17,20 +17,14 @@ import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { autoDetectAdapter, reprobeCapability } from '../autoDetectAdapter'
 import type { RunRequest, ReportV1, ErrorV1 } from '../types'
+import { pinPlotProxyBase, PLOT_PROXY_BASE as PROXY_BASE } from '../../../../tests/setup/msw-env'
 
 // Setup MSW server
 const server = setupServer()
 
-const PROXY_BASE = '/api/plot'
+pinPlotProxyBase()
 
-// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
-// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
-// registered under '/api/plot' never match. Explicit stub + unstub keeps the
-// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
-beforeAll(() => {
-  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
-  server.listen({ onUnhandledRequest: 'warn' })
-})
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => {
   vi.unstubAllEnvs()

--- a/src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts
+++ b/src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts
@@ -21,11 +21,21 @@ import type { RunRequest, ReportV1, ErrorV1 } from '../types'
 // Setup MSW server
 const server = setupServer()
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
-
 const PROXY_BASE = '/api/plot'
+
+// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
+// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
+// registered under '/api/plot' never match. Explicit stub + unstub keeps the
+// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
+beforeAll(() => {
+  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
+  server.listen({ onUnhandledRequest: 'warn' })
+})
+afterEach(() => server.resetHandlers())
+afterAll(() => {
+  vi.unstubAllEnvs()
+  server.close()
+})
 
 // Check if streaming is available (requires VITE_FEATURE_PLOT_STREAM=1)
 const hasStreaming = !!(autoDetectAdapter as any).stream

--- a/src/adapters/plot/__tests__/determinism.test.ts
+++ b/src/adapters/plot/__tests__/determinism.test.ts
@@ -19,11 +19,21 @@ import type { RunRequest, ReportV1 } from '../types'
 // Setup MSW server
 const server = setupServer()
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
-
 const PROXY_BASE = '/api/plot'
+
+// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
+// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
+// registered under '/api/plot' never match. Explicit stub + unstub keeps the
+// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
+beforeAll(() => {
+  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
+  server.listen({ onUnhandledRequest: 'warn' })
+})
+afterEach(() => server.resetHandlers())
+afterAll(() => {
+  vi.unstubAllEnvs()
+  server.close()
+})
 
 // Check if streaming is available
 const hasStreaming = !!(httpV1Adapter as any).stream

--- a/src/adapters/plot/__tests__/determinism.test.ts
+++ b/src/adapters/plot/__tests__/determinism.test.ts
@@ -23,11 +23,13 @@ const PROXY_BASE = '/api/plot'
 
 // The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
 // `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
-// registered under '/api/plot' never match. Explicit stub + unstub keeps the
-// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
-beforeAll(() => {
+// registered under '/api/plot' never match. Re-stub in beforeEach so tests
+// below that call vi.unstubAllEnvs() (e.g. the debug-flag test that stubs
+// VITE_FEATURE_COMPARE_DEBUG and cleans up with unstubAllEnvs) do not leave
+// subsequent tests without proxy-base pinning.
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
+beforeEach(() => {
   vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
-  server.listen({ onUnhandledRequest: 'warn' })
 })
 afterEach(() => server.resetHandlers())
 afterAll(() => {

--- a/src/adapters/plot/__tests__/determinism.test.ts
+++ b/src/adapters/plot/__tests__/determinism.test.ts
@@ -15,22 +15,14 @@ import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { httpV1Adapter } from '../httpV1Adapter'
 import type { RunRequest, ReportV1 } from '../types'
+import { pinPlotProxyBase, PLOT_PROXY_BASE as PROXY_BASE } from '../../../../tests/setup/msw-env'
 
 // Setup MSW server
 const server = setupServer()
 
-const PROXY_BASE = '/api/plot'
+pinPlotProxyBase()
 
-// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
-// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
-// registered under '/api/plot' never match. Re-stub in beforeEach so tests
-// below that call vi.unstubAllEnvs() (e.g. the debug-flag test that stubs
-// VITE_FEATURE_COMPARE_DEBUG and cleans up with unstubAllEnvs) do not leave
-// subsequent tests without proxy-base pinning.
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
-beforeEach(() => {
-  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
-})
 afterEach(() => server.resetHandlers())
 afterAll(() => {
   vi.unstubAllEnvs()

--- a/src/adapters/plot/__tests__/httpV1Adapter.contract.test.ts
+++ b/src/adapters/plot/__tests__/httpV1Adapter.contract.test.ts
@@ -14,11 +14,12 @@ import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { httpV1Adapter } from '../httpV1Adapter'
 import type { RunRequest } from '../types'
+import { pinPlotProxyBase, PLOT_PROXY_BASE as PROXY_BASE } from '../../../../tests/setup/msw-env'
 
 // Setup MSW server with default /version handler for capability negotiation
 const server = setupServer(
   // Sprint N P1: Default handler for capability negotiation endpoint
-  http.get(`/api/plot/version`, () => {
+  http.get(`${PROXY_BASE}/version`, () => {
     return HttpResponse.json({
       version: '1.5.0',
       build: 'test',
@@ -30,16 +31,9 @@ const server = setupServer(
   })
 )
 
-const PROXY_BASE = '/api/plot'
+pinPlotProxyBase()
 
-// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
-// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
-// registered under '/api/plot' never match. Explicit stub + unstub keeps the
-// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
-beforeAll(() => {
-  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
-  server.listen({ onUnhandledRequest: 'error' })
-})
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => {
   vi.unstubAllEnvs()

--- a/src/adapters/plot/__tests__/httpV1Adapter.contract.test.ts
+++ b/src/adapters/plot/__tests__/httpV1Adapter.contract.test.ts
@@ -9,7 +9,7 @@
  * - Error handling (BAD_INPUT, LIMIT_EXCEEDED, RATE_LIMITED, SERVER_ERROR)
  */
 
-import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { httpV1Adapter } from '../httpV1Adapter'
@@ -30,11 +30,21 @@ const server = setupServer(
   })
 )
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
-
 const PROXY_BASE = '/api/plot'
+
+// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
+// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
+// registered under '/api/plot' never match. Explicit stub + unstub keeps the
+// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
+beforeAll(() => {
+  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
+  server.listen({ onUnhandledRequest: 'error' })
+})
+afterEach(() => server.resetHandlers())
+afterAll(() => {
+  vi.unstubAllEnvs()
+  server.close()
+})
 
 describe('httpV1Adapter MSW Contract Tests', () => {
   describe('Health (GET /v1/health)', () => {

--- a/src/adapters/plot/__tests__/httpV1Adapter.limits.spec.ts
+++ b/src/adapters/plot/__tests__/httpV1Adapter.limits.spec.ts
@@ -7,27 +7,20 @@
  * - PROD mode failure → {ok: false, error, fetchedAt}
  */
 
-import { describe, it, expect, beforeAll, afterEach, afterAll, vi, beforeEach } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { httpV1Adapter } from '../httpV1Adapter'
 import { V1_LIMITS } from '../v1/types'
 import type { LimitsFetch } from '../types'
+import { pinPlotProxyBase, PLOT_PROXY_BASE as PROXY_BASE } from '../../../../tests/setup/msw-env'
 
 // Setup MSW server
 const server = setupServer()
 
-const PROXY_BASE = '/api/plot'
+pinPlotProxyBase()
 
-// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
-// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
-// registered under '/api/plot' never match. Stubbed in beforeEach so tests
-// that stub additional env vars (DEV/PROD) can rely on afterEach's
-// vi.unstubAllEnvs() without losing the proxy-base pin between tests.
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-beforeEach(() => {
-  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
-})
 afterEach(() => {
   server.resetHandlers()
   vi.unstubAllEnvs()

--- a/src/adapters/plot/__tests__/httpV1Adapter.limits.spec.ts
+++ b/src/adapters/plot/__tests__/httpV1Adapter.limits.spec.ts
@@ -17,14 +17,22 @@ import type { LimitsFetch } from '../types'
 // Setup MSW server
 const server = setupServer()
 
+const PROXY_BASE = '/api/plot'
+
+// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
+// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
+// registered under '/api/plot' never match. Stubbed in beforeEach so tests
+// that stub additional env vars (DEV/PROD) can rely on afterEach's
+// vi.unstubAllEnvs() without losing the proxy-base pin between tests.
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+beforeEach(() => {
+  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
+})
 afterEach(() => {
   server.resetHandlers()
   vi.unstubAllEnvs()
 })
 afterAll(() => server.close())
-
-const PROXY_BASE = '/api/plot'
 
 describe('httpV1Adapter.limits() - LimitsFetch contract', () => {
   describe('Live endpoint success', () => {

--- a/src/adapters/plot/__tests__/v1_1_contract.spec.ts
+++ b/src/adapters/plot/__tests__/v1_1_contract.spec.ts
@@ -8,7 +8,7 @@
  * - Provenance summary
  */
 
-import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { httpV1Adapter } from '../httpV1Adapter'
@@ -37,11 +37,21 @@ const server = setupServer(
   })
 )
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
-
 const PROXY_BASE = '/api/plot'
+
+// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
+// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
+// registered under '/api/plot' never match. Explicit stub + unstub keeps the
+// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
+beforeAll(() => {
+  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
+  server.listen({ onUnhandledRequest: 'error' })
+})
+afterEach(() => server.resetHandlers())
+afterAll(() => {
+  vi.unstubAllEnvs()
+  server.close()
+})
 
 // Helper to setup run handlers
 function setupRunHandlers(response: object) {

--- a/src/adapters/plot/__tests__/v1_1_contract.spec.ts
+++ b/src/adapters/plot/__tests__/v1_1_contract.spec.ts
@@ -21,11 +21,12 @@ import {
   getBlockers,
   isBlocked,
 } from '../__fixtures__/v1_1_responses'
+import { pinPlotProxyBase, PLOT_PROXY_BASE as PROXY_BASE } from '../../../../tests/setup/msw-env'
 
 // Setup MSW server
 const server = setupServer(
   // Default version handler
-  http.get('/api/plot/version', () => {
+  http.get(`${PROXY_BASE}/version`, () => {
     return HttpResponse.json({
       version: '1.5.0',
       build: 'test',
@@ -37,16 +38,9 @@ const server = setupServer(
   })
 )
 
-const PROXY_BASE = '/api/plot'
+pinPlotProxyBase()
 
-// The adapter reads VITE_PLOT_PROXY_BASE (fallback '/bff/engine'). Locally
-// `.env.local` sets it to '/api/plot'; in CI it is unset and MSW handlers
-// registered under '/api/plot' never match. Explicit stub + unstub keeps the
-// spec env-independent. Mirrors probe.test.ts and httpV1Adapter.stream.test.ts.
-beforeAll(() => {
-  vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)
-  server.listen({ onUnhandledRequest: 'error' })
-})
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => {
   vi.unstubAllEnvs()

--- a/tests/setup/msw-env.ts
+++ b/tests/setup/msw-env.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared setup helper for MSW specs that exercise the PLoT adapter.
+ *
+ * The adapter reads `VITE_PLOT_PROXY_BASE` (fallback `/bff/engine`). Locally
+ * `.env.local` sets it to `/api/plot`; in CI it is unset. Specs must therefore
+ * pin the value explicitly so MSW handlers registered under `/api/plot` match
+ * the adapter's outgoing URLs in both environments.
+ *
+ * Call `pinPlotProxyBase()` at module scope once per spec file:
+ *
+ *   import { pinPlotProxyBase, PLOT_PROXY_BASE as PROXY_BASE } from '../../../../tests/setup/msw-env'
+ *   pinPlotProxyBase()
+ *
+ * The helper re-stubs in `beforeEach` (not just `beforeAll`) so later tests
+ * that call `vi.unstubAllEnvs()` (e.g. cleanup after stubbing a different
+ * feature flag) do not lose proxy-base pinning for subsequent tests in the
+ * same file.
+ *
+ * Discovered via ChatGPT review P0.1 on 2026-04-18:
+ * `src/adapters/plot/__tests__/determinism.test.ts` had this exact failure
+ * mode before the fix was centralised here.
+ */
+
+import { beforeEach, vi } from 'vitest'
+
+export const PLOT_PROXY_BASE = '/api/plot'
+
+export function pinPlotProxyBase(base: string = PLOT_PROXY_BASE): void {
+  beforeEach(() => {
+    vi.stubEnv('VITE_PLOT_PROXY_BASE', base)
+  })
+}


### PR DESCRIPTION
## Summary

Batch-fix the 5 MSW-based test files that fail in CI because `VITE_PLOT_PROXY_BASE` is unset. Each file gets `vi.stubEnv('VITE_PLOT_PROXY_BASE', PROXY_BASE)` in `beforeEach`, matching the established pattern (e.g. sibling file `httpV1Adapter.stream.test.ts`, fixed in commit `9e4036a6` and already on main).

**Test-only change.** No production code modified.

## Context

Per [`docs/ui/ci-test-coverage-audit.md`](https://github.com/Talchain/DecisionGuideAI/blob/ui/overnight-ci-and-tests/docs/ui/ci-test-coverage-audit.md) §6 and [`docs/ui/test-cascade-findings-v1.md`](https://github.com/Talchain/DecisionGuideAI/blob/ui/test-cascade-enumeration/docs/ui/test-cascade-findings-v1.md) §3.2:

- Local dev's `.env.local` sets `VITE_PLOT_PROXY_BASE=/api/plot`.
- CI has no `.env.local`, so MSW handlers registered on `/api/plot` never match the adapter's real fetch URLs.
- `vi.stubEnv` in each test file pins the value per-test, independent of the surrounding environment, so tests pass in both contexts.

## Cherry-pick provenance

All 5 files come from an existing local branch `ui/msw-env-drift-batch-fix`:

- Cherry-picked `07b7a971` (`fix(test): batch-stub VITE_PLOT_PROXY_BASE in 5 MSW specs (env-drift class)`) → `18b42938` on this v2 branch.

Files touched:
- `src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts`
- `src/adapters/plot/__tests__/determinism.test.ts`
- `src/adapters/plot/__tests__/httpV1Adapter.contract.test.ts`
- `src/adapters/plot/__tests__/httpV1Adapter.limits.spec.ts`
- `src/adapters/plot/__tests__/v1_1_contract.spec.ts`

Rationale: matches the env-drift cluster §3.2 from the cascade findings; pattern proven by the already-merged sibling `9e4036a6`.

## Local validation

```
# The 5 fixed files
$ npx vitest run <5 files> --reporter=verbose
 Test Files  4 passed | 1 skipped (5)
      Tests  49 passed | 3 skipped (52)

# Full adjacent directory to check for cross-test leakage
$ npx vitest run src/adapters/plot/__tests__/
 Test Files  8 passed | 1 skipped (9)
      Tests  139 passed | 4 skipped (143)
```

Green both times.

## Merge gating

**Do NOT merge until PR #125 (remove `--bail=1`) lands first.** This PR's full correctness can only be verified in CI after #125 exposes the previously masked failures. Expected sequence:

1. Paul reviews and merges #125 (removes bail; CI starts showing 60-test cascade).
2. Then merges this PR (expected to reduce cascade by ~20 tests across 5 files).
3. Remaining cascade is handled by morning plan (see overnight evidence pack).

## Test plan

- [ ] CI passes for this PR (after #125 merges).
- [ ] CI test-failure count drops by ~20 tests (5 files × ~4 tests each).
- [ ] No new test failures introduced.
- [ ] Sibling `httpV1Adapter.stream.test.ts` (already fixed) remains green.

## Related

- Overnight brief (mossy-shore) — CI audit + test cascade resolution
- Depends on: https://github.com/Talchain/DecisionGuideAI/pull/125 (D2, remove `--bail=1`)
- Findings: `docs/ui/test-cascade-findings-v1.md` §3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
