### PR TITLE
fix(test): cascade triage v3 follow-ups — doc + guard + contract assertions

### DIFF
--- a/src/__tests__/wave2-replay-gate.spec.ts
+++ b/src/__tests__/wave2-replay-gate.spec.ts
@@ -3,7 +3,9 @@
  *
  * Validates cross-cutting UI contracts that must hold after Wave 2 remediation:
  * 1. Formatter behaviour (formatTargetValue, formatPercent)
- * 2. Trust-boundary cast budget (useResultsSectionData.ts ≤ 6 debug-only casts)
+ * 2. Trust-boundary cast budget (useResultsSectionData.ts ≤ 14 casts —
+ *    debug-only window access plus approved PLoT-adapter boundary reads;
+ *    see Packet A in docs/ui/cascade-triage-v3.md for rationale)
  * 3. ESLint rule activation (dangerouslySetInnerHTML)
  * 4. British English pass (customize/customise family present)
  * 5. No technical-string leakage in results surface helpers
@@ -89,6 +91,11 @@ describe('Trust boundary — cast budget', () => {
   it('all remaining "as any" casts are debug window access OR PLoT-adapter boundary reads', () => {
     // Packet A (2026-04-19): allowlist for the 5 PLoT-adapter boundary sites.
     // See preceding test for technical debt reference.
+    //
+    // Each boundary field must appear as a whole-word token on the same line
+    // as the `as any` cast — not as a substring. This prevents coincidental
+    // bypasses where a future field like `probability_of_joint_goal_xyz` or
+    // `nonZeroImpactDriversLegacy` would piggyback on the allowlist.
     const PLOT_BOUNDARY_FIELDS = [
       'probability_of_joint_goal',
       'nonZeroImpactDrivers',
@@ -100,7 +107,9 @@ describe('Trust boundary — cast budget', () => {
     const castLines = lines.filter(line => line.includes('as any'))
     for (const line of castLines) {
       const isDebugGuard = line.includes('__OLUMI_DEBUG')
-      const isPlotBoundary = PLOT_BOUNDARY_FIELDS.some(field => line.includes(field))
+      const isPlotBoundary = PLOT_BOUNDARY_FIELDS.some(field =>
+        new RegExp(`\\b${field}\\b`).test(line),
+      )
       expect(
         isDebugGuard || isPlotBoundary,
         `cast lacks both __OLUMI_DEBUG guard and PLoT-adapter boundary field: ${line.trim()}`

--- a/src/lib/__tests__/sse-params.test.tsx
+++ b/src/lib/__tests__/sse-params.test.tsx
@@ -117,6 +117,11 @@ describe('SandboxStreamPanel with params', () => {
     // Allow any microtasks to settle
     await vi.advanceTimersByTimeAsync(0)
 
+    // Packet B contract: SSE 'done' alone must NOT trigger a report fetch.
+    // RunReportDrawer is user-action-gated; locking this invariant here
+    // prevents a regression back to an implicit auto-fetch-on-done path.
+    expect(reportSpy).toHaveBeenCalledTimes(0)
+
     // Packet B (2026-04-19): RunReportDrawer doesn't auto-fetch on SSE 'done' —
     // the drawer is user-action-gated (SandboxStreamPanel.tsx:1181 view-report-btn,
     // disabled until status is done|aborted|error|limited). Click simulates the

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -129,7 +129,12 @@ describe('ScenarioListPage', () => {
       expect(screen.getByTestId('first-run')).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByText('Start a new decision'))
+    // Role-based query: stable against copy changes. The dedicated copy
+    // assertion at line 97 (`'Welcome to Olumi'`) is the single intentional
+    // copy-coupling in this spec.
+    fireEvent.click(
+      screen.getByRole('button', { name: /start a new decision/i }),
+    )
 
     await waitFor(() => {
       expect(mockCreateScenario).toHaveBeenCalled()


### PR DESCRIPTION
## Summary

Four test-file-only follow-ups to [PR #129](https://github.com/Talchain/DecisionGuideAI/pull/129) (merged as `44f2cae7`). Single commit, all scoped to 3 test files; no product code touched; no behaviour change.

## Changes

- **P1.1** — `wave2-replay-gate.spec.ts` line 6: header docstring said "≤ 6 debug-only casts" after Packet A raised the active budget to 14. Updated to match the enforced rule and point to the cascade triage doc for rationale.
- **P1.2** — `wave2-replay-gate.spec.ts` cast guard: tightened the Packet A allowlist from substring-match (`line.includes(field)`) to whole-word regex (`\bfield\b`). Prevents coincidental-substring bypass where e.g. a future `nonZeroImpactDriversLegacy as any` cast would piggyback on the allowlist.
- **Imp.1** — `sse-params.test.tsx`: added explicit pre-click negative assertion `expect(reportSpy).toHaveBeenCalledTimes(0)` between `es.emit('done')` and `fireEvent.click(view-report-btn)`. Locks in Packet B's integration contract (SSE 'done' alone must NOT trigger report fetch). Regression-proof against silent auto-fetch reintroduction.
- **Imp.2** — `ScenarioListPage.spec.tsx` line 132: swapped `getByText('Start a new decision')` for `getByRole('button', { name: /start a new decision/i })`. Flow assertion decoupled from exact copy. Dedicated copy assertion at line 97 (`'Welcome to Olumi'`) remains as single intentional copy-coupling.

## Test plan

- [x] All 3 affected files pass in isolation (28 tests across 3 files)
- [x] Typecheck clean (`npm run typecheck`)
- [x] Pre-push hook passed (FAST mode — smoke + 6 static checks)
- [ ] CI full suite green (GitHub Actions)
- [ ] CEE Contract Validation green

## Autonomous merge authority

Per PRs #125–#129 pattern: merge directly once `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`, and all CI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)