### PR TITLE
ci(pnpm): migrate GitHub Actions workflows from npm to pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,23 +46,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: https://npm.pkg.github.com
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache node_modules
         id: cache-nm
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
-        run: npm ci
+        run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
 
@@ -90,20 +96,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Audit for high/critical vulnerabilities
-        run: npm run security:audit
+        run: pnpm run security:audit
 
   # ── Static analysis ────────────────────────────────────────────────────
   tsc:
@@ -114,17 +126,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
 
       - name: Schema contract gate
@@ -162,7 +180,7 @@ jobs:
           echo "All schema contract checks passed."
 
       - name: Lint
-        run: npm run lint
+        run: pnpm run lint
 
       - name: Check for legacy Olumi tokens
         run: |
@@ -182,17 +200,17 @@ jobs:
 
           echo "✅ No legacy --olumi-* tokens found."
           echo ""
-          echo "ℹ️  Note: Hard-coded color enforcement is handled by ESLint (npm run lint)."
+          echo "ℹ️  Note: Hard-coded color enforcement is handled by ESLint (pnpm run lint)."
           echo "   The ESLint rule 'brand-tokens/no-raw-colors' checks for hard-coded hex/rgb/hsl colors."
 
       - name: Type check (no emit)
-        run: npm run typecheck
+        run: pnpm run typecheck
 
       - name: React 185 guard (Zustand selectors)
-        run: npm run ci:guard:zustand
+        run: pnpm run ci:guard:zustand
 
       - name: Duplicate-suffix guard
-        run: npm run ci:guard:duplicates
+        run: pnpm run ci:guard:duplicates
 
   # ── Unit tests + coverage (merged — was two separate jobs running tests twice) ──
   vitest:
@@ -203,21 +221,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
 
       - name: Run unit tests with coverage
-        run: npm run test:coverage
+        run: pnpm run test:coverage
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
 
@@ -244,20 +268,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Verify backend contract
-        run: npm run ci:verify-contract
+        run: pnpm run ci:verify-contract
         env:
           VITE_PLOT_LITE_BASE_URL: https://plot-lite-service.onrender.com
         continue-on-error: false
@@ -273,29 +303,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
 
       - name: Build (with PLC assertion + bundle budget)
-        run: npm run build:ci
+        run: pnpm run build:ci
 
       - name: Scan dist for console/debugger and E2E toggles
         run: |
-          npm run ci:no-console
-          npm run ci:scan-dist
+          pnpm run ci:no-console
+          pnpm run ci:scan-dist
 
       - name: Bundle Policy (safe chunks React-free)
-        run: npm run ci:bundle-policy
+        run: pnpm run ci:bundle-policy
 
   # ── E2E Chromium (sharded across 4 runners) ───────────────────────────
   e2e-chromium:
@@ -314,17 +350,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
 
@@ -332,13 +374,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Chromium (Playwright)
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E (Chromium, shard ${{ matrix.shard }})
-        run: npx playwright test --project=chromium -c playwright.config.ts --retries=1 --shard=${{ matrix.shard }}
+        run: pnpm exec playwright test --project=chromium -c playwright.config.ts --retries=1 --shard=${{ matrix.shard }}
 
       - name: Upload Playwright test-results on failure
         if: failure()
@@ -368,21 +410,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Firefox (Playwright)
-        run: npx playwright install --with-deps firefox
+        run: pnpm exec playwright install --with-deps firefox
       - name: Run smoke + summary-v2 on Firefox
         run: >-
-          npx playwright test
+          pnpm exec playwright test
           e2e/flags-off.smoke.spec.ts
           e2e/summary-v2.spec.ts
           --project=firefox -c playwright.config.ts
@@ -396,21 +443,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install WebKit (Playwright)
-        run: npx playwright install --with-deps webkit
+        run: pnpm exec playwright install --with-deps webkit
       - name: Run smoke + summary-v2 on WebKit
         run: >-
-          npx playwright test
+          pnpm exec playwright test
           e2e/flags-off.smoke.spec.ts
           e2e/summary-v2.spec.ts
           --project=webkit -c playwright.config.ts
@@ -423,28 +475,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Chromium (Playwright)
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
       - name: Perf probe (worker layout, p95)
-        run: npx playwright test e2e/perf-worker-20-nodes.spec.ts --project=chromium -c playwright.config.ts
+        run: pnpm exec playwright test e2e/perf-worker-20-nodes.spec.ts --project=chromium -c playwright.config.ts
       - name: Vendored a11y (axe)
-        run: npm run evidence:a11y
+        run: pnpm run evidence:a11y
       - name: UI evidence pack
-        run: npm run evidence:ui-pack
+        run: pnpm run evidence:ui-pack
       - name: Share-link cap evidence
-        run: npm run evidence:share-cap
+        run: pnpm run evidence:share-cap
       - name: Immutability unit test (report.json hash)
-        run: npm run test -- src/lib/__tests__/evidence.immutability.test.ts
+        run: pnpm run test -- src/lib/__tests__/evidence.immutability.test.ts
       - name: Upload evidence artefacts
         uses: actions/upload-artifact@v4
         with:
@@ -472,17 +529,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
 
@@ -490,16 +553,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Chromium (Playwright)
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Build (production)
-        run: npm run build:prod
+        run: pnpm run build:prod
 
       - name: E2E (production safe-screen)
-        run: npm run e2e:prod-safe
+        run: pnpm run e2e:prod-safe
 
       - name: Upload Playwright test-results on failure
         if: failure()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,14 +52,20 @@ jobs:
             **/test-results/**
             **/*.d.ts
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -55,23 +55,29 @@ jobs:
             schemas/
         continue-on-error: true
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: https://npm.pkg.github.com
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache node_modules
         id: cache-nm
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
-        run: npm ci
+        run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
 
@@ -91,6 +97,6 @@ jobs:
           fi
 
       - name: Run contract tests
-        run: npx vitest run tests/contracts/ --reporter=verbose --bail=1
+        run: pnpm exec vitest run tests/contracts/ --reporter=verbose --bail=1
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,13 +92,17 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.apply.outputs.branch }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
-      - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test --if-present
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run --if-present build
+      - run: pnpm run --if-present test
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
       - name: Ensure tests.json (non-blocking if file missing)

--- a/.github/workflows/poc-pr.yml
+++ b/.github/workflows/poc-pr.yml
@@ -10,12 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: https://npm.pkg.github.com
-      - run: npm ci
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+      - run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
-      - run: npx playwright install --with-deps
-      - run: npx playwright test "e2e/sandbox.*.spec.ts" --retries=1 --reporter=line
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm exec playwright test "e2e/sandbox.*.spec.ts" --retries=1 --reporter=line

--- a/.github/workflows/poc-sweep.yml
+++ b/.github/workflows/poc-sweep.yml
@@ -15,19 +15,23 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Install deps
         env:
           NPM_CONFIG_ENGINE_STRICT: 'false'
         run: |
-          npm ci --no-audit --no-fund --ignore-scripts --legacy-peer-deps
+          pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Verify lockfile unchanged
         run: |
-          git diff --exit-code -- package-lock.json
+          git diff --exit-code -- pnpm-lock.yaml
 
       - name: Capture npm debug (on fail)
         if: failure()
@@ -37,13 +41,13 @@ jobs:
           tail -n 200 npm-debug.log 2>/dev/null || true
 
       - name: Typecheck
-        run: npm run typecheck
+        run: pnpm run typecheck
       - name: Lint (temporary JS-only)
-        run: npm run lint
+        run: pnpm run lint
       - name: Build
-        run: npm run build
+        run: pnpm run build
       - name: Console-free
-        run: npm run ci:no-console
+        run: pnpm run ci:no-console
 
       - name: Bundle budget (gzipped)
         run: |
@@ -54,37 +58,37 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium firefox webkit
+        run: pnpm exec playwright install chromium firefox webkit
 
       - name: Unit tests
         env:
           TZ: UTC
           LANG: en_GB.UTF-8
           LC_ALL: en_GB.UTF-8
-        run: npm run test:unit
+        run: pnpm run test:unit
 
       - name: E2E Chromium (full)
-        run: npm run test:e2e:chromium -- --grep-invert @flaky --retries=2
+        run: pnpm run test:e2e:chromium -- --grep-invert @flaky --retries=2
 
       - name: E2E Firefox smoke
-        run: npm run test:e2e:firefox  -- e2e/flags-off.smoke.spec.ts
+        run: pnpm run test:e2e:firefox  -- e2e/flags-off.smoke.spec.ts
 
       - name: E2E WebKit smoke
-        run: npm run test:e2e:webkit   -- e2e/flags-off.smoke.spec.ts
+        run: pnpm run test:e2e:webkit   -- e2e/flags-off.smoke.spec.ts
 
       - name: "Evidence: a11y"
-        run: npm run evidence:a11y
+        run: pnpm run evidence:a11y
       - name: "Evidence: UI pack"
-        run: npm run evidence:ui-pack
+        run: pnpm run evidence:ui-pack
       - name: "Evidence: share-cap"
-        run: npm run evidence:share-cap
+        run: pnpm run evidence:share-cap
       - name: "Evidence: immutability"
-        run: npm run test -- src/lib/__tests__/evidence.immutability.test.ts
+        run: pnpm run test -- src/lib/__tests__/evidence.immutability.test.ts
 
       - name: Upload artefacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/poc-sweep.yml
+++ b/.github/workflows/poc-sweep.yml
@@ -33,12 +33,10 @@ jobs:
         run: |
           git diff --exit-code -- pnpm-lock.yaml
 
-      - name: Capture npm debug (on fail)
+      - name: Capture install debug (on fail)
         if: failure()
         run: |
-          echo "## npm ci failure (tail of log)" >> $GITHUB_STEP_SUMMARY
-          ls -la npm-debug.log || true
-          tail -n 200 npm-debug.log 2>/dev/null || true
+          echo "## Install failure context" >> $GITHUB_STEP_SUMMARY
 
       - name: Typecheck
         run: pnpm run typecheck

--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -40,23 +40,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: https://npm.pkg.github.com
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache node_modules
         id: cache-nm
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
-        run: npm ci
+        run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -69,23 +75,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Lint
-        run: npm run lint
+        run: pnpm run lint
 
       - name: Type check
-        run: npm run typecheck
+        run: pnpm run typecheck
 
   # ── Full test suite ──────────────────────────────────────────────────
   vitest:
@@ -96,20 +108,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Run full test suite
-        run: npx vitest run --reporter=verbose 2>&1 | tee vitest-output.txt
+        run: pnpm exec vitest run --reporter=verbose 2>&1 | tee vitest-output.txt
         env:
           NODE_OPTIONS: "--max-old-space-size=7168"
 
@@ -165,20 +183,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: "npm"
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
   # ── Gate (single required check for branch protection) ───────────────
   gate:

--- a/.github/workflows/ui-evidence-selftest.yml
+++ b/.github/workflows/ui-evidence-selftest.yml
@@ -20,16 +20,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: npm
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build (non-fatal)
-        run: npm run -s build || true
+        run: pnpm run -s build || true
 
       - name: Generate UI pack
         env:

--- a/.github/workflows/unified-evidence.yml
+++ b/.github/workflows/unified-evidence.yml
@@ -17,16 +17,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install unzip
         run: sudo apt-get update && sudo apt-get install -y unzip
 
       - name: Run unified composer
-        run: npm run evidence:compose
+        run: pnpm run evidence:compose
 
       - name: Upload unified artefacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Migrates all 9 install-touching GitHub Actions workflows from npm to pnpm to match the package layer migration in `eebb68b9` (no `package-lock.json`, only `pnpm-lock.yaml`, `packageManager: \"pnpm@10.18.0\"`).
- Every CI run was failing at install before this; the local pre-push gate uses pnpm directly and was masking the breakage.
- **Primary purpose:** prove that the recently-shipped contract tests are now actually enforced by `contract-validation.yml` in CI.

## Scope of change

- `pnpm/action-setup@v4` added BEFORE `actions/setup-node@v4` in every job (required order)
- `cache: 'pnpm'` + `cache-dependency-path: 'pnpm-lock.yaml'` on every setup-node
- All `hashFiles('package-lock.json')` retargeted to `pnpm-lock.yaml`
- `npm ci` → `pnpm install --frozen-lockfile`
- `npm run X` → `pnpm run X`; `npx X` → `pnpm exec X` (project devDependencies)
- `--if-present` preserved via `pnpm run --if-present`
- `poc-sweep.yml`: lockfile-drift check now diffs `pnpm-lock.yaml`; obsolete `npm-debug.log` lookup removed

Intentionally preserved:
- `registry-url: https://npm.pkg.github.com` (GitHub Packages domain)
- `Security Audit (npm)` job display name (P3 rename follow-up tracked separately)
- `NPM_CONFIG_ENGINE_STRICT` env (pnpm honours `engine-strict` independently)

Out of scope (flagged for follow-up):
- `.github/dependabot.yml` ecosystem still `npm` (won't track `pnpm-lock.yaml`)
- `main.yml` Node 18.x matrix entry (pre-existing engines mismatch with `>=20 <21`)
- `node_modules` cross-job cache restore behaviour under pnpm (iteration risk)

## Test plan

- [ ] `contract-validation.yml` install/cache steps succeed under pnpm
- [ ] Contract tests run and pass (proving the suite is enforced in CI)
- [ ] No diff outside `.github/workflows/`
- [ ] Local pre-push gate passes (already verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)