### PR TITLE
test(v5/ws1): add receipt no-leak and proposal-chip forward-compat coverage

### DIFF
--- a/src/canvas/conversation/__tests__/ActionChipRow.proposalForwardCompat.spec.tsx
+++ b/src/canvas/conversation/__tests__/ActionChipRow.proposalForwardCompat.spec.tsx
@@ -1,0 +1,182 @@
+/**
+ * ActionChipRow — proposal-chip forward-compatibility tests.
+ *
+ * Workstream 1 forward-compat gate: any future suggested action whose
+ * id matches `^prop_[0-9a-f]{12}$` (the proposal-chip naming scheme)
+ * MUST render through the standard ActionChipRow pipeline without
+ * special-case UI, without crashing on long labels, and without
+ * serialising any structured chip metadata (`parameters`,
+ * `action_type`, `proposal_ref`) into the DOM.
+ *
+ * The UI deliberately does NOT re-enforce server-side label length or
+ * sanitisation — that contract belongs to CEE's proposal safety filter.
+ * The UI's job is to render gracefully and avoid metadata leakage.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { ActionChipRow } from '../ActionChipRow'
+import type { ActionChip } from '../types'
+import { expectNoChipMetadataLeaks } from '../../../test/helpers/expectNoChipMetadataLeaks'
+
+const PROPOSAL_ID_PATTERN = /^prop_[0-9a-f]{12}$/
+
+function proposalChip(overrides: Partial<ActionChip> = {}): ActionChip {
+  return {
+    id: 'prop_abcdef012345',
+    label: 'Apply suggested change',
+    intent: 'primary',
+    message: 'apply the proposed change please',
+    ...overrides,
+  }
+}
+
+describe('ActionChipRow — proposal chip forward compatibility', () => {
+  it('renders a chip whose id matches `prop_<12hex>` identically to a normal suggested action', () => {
+    const chip = proposalChip()
+    // Sanity: the id matches the proposal pattern.
+    expect(chip.id).toMatch(PROPOSAL_ID_PATTERN)
+
+    const onChipClick = vi.fn().mockResolvedValue(undefined)
+    render(<ActionChipRow chips={[chip]} onChipClick={onChipClick} />)
+
+    // Standard testid pattern (`chip-{id}`) — the proposal chip uses
+    // the same path as any other suggested action.
+    const button = screen.getByTestId(`chip-${chip.id}`)
+    expect(button).toBeInTheDocument()
+    expect(button.tagName).toBe('BUTTON')
+    expect(button.textContent).toBe(chip.label)
+    expect(button).not.toBeDisabled()
+
+    // Click dispatches `onChipClick` once with the chip — same contract
+    // as every other suggested action.
+    fireEvent.click(button)
+    expect(onChipClick).toHaveBeenCalledTimes(1)
+    expect(onChipClick).toHaveBeenCalledWith(chip)
+
+    expectNoChipMetadataLeaks(button)
+  })
+
+  it('renders a natural 80-character proposal label gracefully (UI does not re-enforce server-side length limits)', () => {
+    // 80-char natural sentence-case label — the kind of decision-oriented
+    // copy that would pass the CEE proposal safety filter. No padding
+    // tricks: this is the realistic shape we want to prove renders.
+    const longLabel = 'Apply the proposed restructure to your marketing budget allocation by next week.'
+    expect(longLabel.length).toBe(80)
+
+    const chip = proposalChip({ label: longLabel })
+    render(
+      <ActionChipRow chips={[chip]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
+    )
+    const button = screen.getByTestId(`chip-${chip.id}`)
+
+    // The full label must remain available in textContent — this proves
+    // the UI passes the label through without truncation or sanitisation.
+    //
+    // Visual wrap / truncate behaviour is purely a CSS concern and is
+    // NOT observable in jsdom (no layout engine). If pixel-perfect wrap
+    // is part of the acceptance contract for proposal chips, follow up
+    // with a Storybook story or a Playwright pixel check — neither
+    // belongs in this unit-test file.
+    expect(button.textContent).toBe(longLabel)
+    expectNoChipMetadataLeaks(button)
+  })
+
+  it('does not serialise chip parameters / action_type / proposal_ref into the DOM', () => {
+    // Future-state chip carrying the structured metadata that internal
+    // routing layers care about. The UI must consume `message` only and
+    // leave the rest off the rendered surface.
+    const chip = proposalChip({
+      action_type: 'apply_proposed_change',
+      parameters: {
+        proposal_ref: 'pending_action_xyz',
+        chip_metadata: { foo: 'bar', nested: { secret: 'value' } },
+        handler_id: 'handler-001',
+      },
+    })
+    render(
+      <ActionChipRow chips={[chip]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
+    )
+    const button = screen.getByTestId(`chip-${chip.id}`)
+
+    // Visible text is just the label.
+    expect(button.textContent).toBe(chip.label)
+
+    // No structured metadata leaks. Also assert specific values
+    // inline as a belt-and-braces check on top of the helper, so a
+    // failure log identifies the exact value that escaped.
+    const html = button.outerHTML
+    expect(html).not.toContain('pending_action_xyz')
+    expect(html).not.toContain('handler-001')
+    expect(html).not.toContain('foo')
+    expect(html).not.toContain('bar')
+    expect(html).not.toContain('secret')
+
+    expectNoChipMetadataLeaks(button)
+  })
+
+  it('does not break and does not expose internal metadata when chip carries `public_label` / `public_message`', () => {
+    // Forward-compat for the proposal payload contract: future suggested
+    // actions may carry `public_label` / `public_message` on their
+    // `parameters` object (or anywhere else inside the chip metadata).
+    // The current UI must remain stable in their presence — it is free
+    // to ignore them per the brief, but it must NOT crash, must not
+    // surface them as visible text, and must not serialise them into
+    // the rendered DOM.
+    const PUBLIC_LABEL_VALUE = 'Friendly preview label that should not leak'
+    const PUBLIC_MESSAGE_VALUE = 'Friendly preview message that should not leak'
+    const chip = proposalChip({
+      action_type: 'apply_proposed_change',
+      parameters: {
+        public_label: PUBLIC_LABEL_VALUE,
+        public_message: PUBLIC_MESSAGE_VALUE,
+        proposal_ref: 'pending_action_xyz',
+      },
+    })
+    render(
+      <ActionChipRow chips={[chip]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
+    )
+    const button = screen.getByTestId(`chip-${chip.id}`)
+
+    // Visible text remains the chip's `label` — public_label/message
+    // are NOT promoted onto the rendered surface in the current UI.
+    expect(button.textContent).toBe(chip.label)
+
+    // Neither the field names nor the values appear in the DOM.
+    const html = button.outerHTML
+    expect(html).not.toContain('public_label')
+    expect(html).not.toContain('public_message')
+    expect(html).not.toContain(PUBLIC_LABEL_VALUE)
+    expect(html).not.toContain(PUBLIC_MESSAGE_VALUE)
+
+    expectNoChipMetadataLeaks(button)
+  })
+
+  it('keeps the proposal chip clickable when rendered alongside non-proposal chips', () => {
+    // Mixed-row guard: the proposal chip must not interfere with sibling
+    // chips, and must remain clickable in its own right.
+    const proposal = proposalChip({ id: 'prop_0123456789ab', label: 'Apply suggestion' })
+    const sibling: ActionChip = {
+      id: 'sibling-1',
+      label: 'Try a different angle',
+      intent: 'secondary',
+      message: 'try a different angle please',
+    }
+    const onChipClick = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ActionChipRow chips={[sibling, proposal]} onChipClick={onChipClick} />,
+    )
+
+    const proposalButton = screen.getByTestId(`chip-${proposal.id}`)
+    const siblingButton = screen.getByTestId(`chip-${sibling.id}`)
+    expect(proposalButton).toBeInTheDocument()
+    expect(siblingButton).toBeInTheDocument()
+
+    fireEvent.click(proposalButton)
+    expect(onChipClick).toHaveBeenCalledWith(proposal)
+
+    expectNoChipMetadataLeaks(proposalButton)
+    expectNoChipMetadataLeaks(siblingButton)
+  })
+})

--- a/src/canvas/conversation/__tests__/GraphPatchBlock.noLeak.spec.tsx
+++ b/src/canvas/conversation/__tests__/GraphPatchBlock.noLeak.spec.tsx
@@ -1,0 +1,255 @@
+/**
+ * GraphPatchBlock no-leak tests — Workstream 1 G4.
+ *
+ * The V4 graph_patch path renders through `describeOperation` (with a
+ * 4-tier label fallback chain) and `safeRichText` for any CEE-provided
+ * summary. This suite proves that V4 `update_node` / `update_edge`
+ * receipts never fall through to raw JSON, raw schema keys, or
+ * unfamiliar internal terms — including when the operation payload is
+ * malformed or unfamiliar.
+ *
+ * Mocks the canvas store with a small controlled node set so the label
+ * fallback paths are deterministic. Mirrors the mock pattern in
+ * `GraphPatchBlock.spec.tsx`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import type { GraphPatchBlock } from '../types'
+import { expectNoReceiptUserFacingTextLeaks } from '../../../test/helpers/expectNoReceiptLeaks'
+
+const storeMocks = vi.hoisted(() => ({
+  selectNodeWithoutHistory: vi.fn(),
+  selectNodes: vi.fn(),
+  setShowInspectorPanel: vi.fn(),
+  setHighlightedNodes: vi.fn(),
+  setHighlightedEdges: vi.fn(),
+  canvasNodes: [] as Array<{ id: string; data?: { label?: string } }>,
+  canvasEdges: [] as Array<{ id: string; source: string; target: string }>,
+}))
+
+vi.mock('../../store', () => {
+  const mockState = {
+    get nodes() { return storeMocks.canvasNodes },
+    get edges() { return storeMocks.canvasEdges },
+    selectNodeWithoutHistory: storeMocks.selectNodeWithoutHistory,
+    selectNodes: storeMocks.selectNodes,
+    setShowInspectorPanel: storeMocks.setShowInspectorPanel,
+    setHighlightedNodes: storeMocks.setHighlightedNodes,
+    setHighlightedEdges: storeMocks.setHighlightedEdges,
+  }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+import { InlineBlocks } from '../InlineBlocks'
+
+function patchBlock(overrides: Partial<GraphPatchBlock>): GraphPatchBlock {
+  return {
+    type: 'graph_patch',
+    patch_id: 'patch-noleak-1',
+    // Empty summary by default — receipt then falls back to the
+    // contextual "Review the suggested change." line, which is clean.
+    // Tests that intend to assert OPERATION-derived rendering must keep
+    // summary empty so the assertion is not satisfied by the summary text.
+    summary: '',
+    operations: [],
+    target_graph_hash: 'hash-x',
+    ...overrides,
+  }
+}
+
+function expectNoLeakInPatchCard(): void {
+  // The V4 card carries a deterministic testid based on patch_id. Use a
+  // prefix-resilient selector so future patch_id formats don't break this.
+  // We assert against the USER-FACING text surface only (textContent +
+  // aria-labels) — V4 retains the `block-graph-patch-{patch_id}` testid
+  // and `graphPatchBlock` CSS module classes by design, and those
+  // implementation-detail attributes are not part of the user-facing
+  // contract. A regression that puts schema terms into rendered text
+  // (or aria-labels read by assistive tech) WILL still trip this.
+  const card = document.querySelector('[data-testid^="block-graph-patch-"]') as HTMLElement | null
+  expect(card, 'V4 graph_patch card not found in DOM').not.toBeNull()
+  expectNoReceiptUserFacingTextLeaks(card!)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storeMocks.canvasNodes = [
+    { id: 'fac_morale', data: { label: 'team morale' } },
+    { id: 'goal_outcome', data: { label: 'overall outcome' } },
+  ]
+  storeMocks.canvasEdges = [
+    { id: 'edge_morale_to_outcome', source: 'fac_morale', target: 'goal_outcome' },
+  ]
+})
+
+describe('V4 GraphPatchBlock — G4 update_node no-leak', () => {
+  it('renders friendly receipt for happy-path update_node (resolved label + known field)', () => {
+    const block = patchBlock({
+      operations: [
+        { op: 'update_node', target_id: 'fac_morale', data: { label: 'team morale revised' } },
+      ],
+    })
+    render(<InlineBlocks blocks={[block]} />)
+    // Friendly description should mention the resolved node label.
+    // describeOperation emits markdown bold around the label; safeRichText
+    // renders it as <strong>. Assert via textContent so the markdown
+    // syntax is irrelevant.
+    const list = screen.getByTestId('patch-proposal-list')
+    expect(list.textContent).toContain('team morale')
+    expect(list.textContent?.toLowerCase()).toContain('label')
+    expectNoLeakInPatchCard()
+  })
+
+  it('renders friendly receipt when update_node carries empty data (no priority field)', () => {
+    const block = patchBlock({
+      operations: [
+        { op: 'update_node', target_id: 'fac_morale', data: {} },
+      ],
+    })
+    render(<InlineBlocks blocks={[block]} />)
+    const list = screen.getByTestId('patch-proposal-list')
+    // Falls to "Update **{label}**" with no trailing field.
+    expect(list.textContent).toContain('team morale')
+    expectNoLeakInPatchCard()
+  })
+
+  it('renders generic receipt when update_node target_id is unmapped AND data is empty', () => {
+    // No node label resolves; describeOperation falls back to genericForOp
+    // which derives element type from the id prefix word ("factor" /
+    // "option" / "goal" / "decision" / "outcome" / "constraint"). The raw
+    // id MUST NOT appear in the rendered DOM.
+    const block = patchBlock({
+      operations: [
+        { op: 'update_node', target_id: 'unmapped_id_with_no_known_prefix', data: {} },
+      ],
+    })
+    render(<InlineBlocks blocks={[block]} />)
+    const list = screen.getByTestId('patch-proposal-list')
+    expect(list.textContent?.toLowerCase()).toContain('update factor')
+    // The raw id substring must not leak.
+    expect(list.outerHTML).not.toContain('unmapped_id_with_no_known_prefix')
+    expectNoLeakInPatchCard()
+  })
+
+  it('renders generic receipt and does not leak unfamiliar field keys when update_node data is malformed', () => {
+    // Defensive: a future schema drift puts a foreign object in
+    // op.data. The receipt must not serialise the foreign object's
+    // keys/values into the DOM.
+    //
+    // The `as unknown as Record<…>` cast below is a deliberate
+    // wire-shape simulation, NOT an endorsed schema example. The V4
+    // PatchOperation type's `data` field is typed narrowly; this cast
+    // forces a malformed shape past the compile-time check so the
+    // runtime receipt path can be exercised against schema drift.
+    const block = patchBlock({
+      operations: [
+        {
+          op: 'update_node',
+          target_id: 'fac_morale',
+          data: {
+            // Foreign keys that should never appear in user-facing copy.
+            weirdInternalKey: { nested: 'should-not-leak' },
+            anotherSecret: 'pending_xyz',
+          } as unknown as Record<string, unknown>,
+        },
+      ],
+    })
+    render(<InlineBlocks blocks={[block]} />)
+    const list = screen.getByTestId('patch-proposal-list')
+    // Friendly label still renders.
+    expect(list.textContent).toContain('team morale')
+    // Receipt collapses to the bare label — no field suffix rendered
+    // because the unfamiliar keys fail the `isAllowlistedFieldKey` gate
+    // in friendlyOperation.ts.
+    expect(list.textContent?.toLowerCase()).not.toContain(':')
+    // Raw camelCase keys must not leak.
+    expect(list.outerHTML).not.toContain('weirdInternalKey')
+    expect(list.outerHTML).not.toContain('anotherSecret')
+    // Humanised forms of the unknown keys must ALSO not leak — without
+    // the allowlist gate, friendlyFieldName would render
+    // "Another secret" / "Weird internal key" — a friendly-looking leak
+    // of an internal field name. Same regression class as raw IDs.
+    const lowered = list.outerHTML.toLowerCase()
+    expect(lowered).not.toContain('another secret')
+    expect(lowered).not.toContain('weird internal key')
+    // Foreign value content must not leak either.
+    expect(list.outerHTML).not.toContain('should-not-leak')
+    expect(list.outerHTML).not.toContain('pending_xyz')
+    expect(lowered).not.toContain('pending xyz')
+    expectNoLeakInPatchCard()
+  })
+})
+
+describe('V4 GraphPatchBlock — G4 update_edge no-leak', () => {
+  it('renders friendly receipt for happy-path update_edge (resolved endpoints)', () => {
+    const block = patchBlock({
+      operations: [
+        {
+          op: 'update_edge',
+          target_id: 'edge_morale_to_outcome',
+          data: { weight: 0.5 },
+        },
+      ],
+    })
+    render(<InlineBlocks blocks={[block]} />)
+    const list = screen.getByTestId('patch-proposal-list')
+    expect(list.textContent).toContain('team morale')
+    expect(list.textContent).toContain('overall outcome')
+    expectNoLeakInPatchCard()
+  })
+
+  it('renders generic "Update connection" when update_edge endpoints cannot be resolved AND data is empty', () => {
+    const block = patchBlock({
+      operations: [
+        { op: 'update_edge', target_id: 'edge_unknown_unmapped', data: {} },
+      ],
+    })
+    render(<InlineBlocks blocks={[block]} />)
+    const list = screen.getByTestId('patch-proposal-list')
+    expect(list.textContent?.toLowerCase()).toContain('update connection')
+    // Raw id must not leak.
+    expect(list.outerHTML).not.toContain('edge_unknown_unmapped')
+    expectNoLeakInPatchCard()
+  })
+
+  it('does not leak unfamiliar field keys when update_edge data is malformed', () => {
+    // The `as unknown as Record<…>` cast forces a malformed wire-shape
+    // simulation past the compile-time PatchOperation `data` typing —
+    // it is NOT an endorsed schema example. Same defensive intent as
+    // the corresponding update_node malformed test above.
+    const block = patchBlock({
+      operations: [
+        {
+          op: 'update_edge',
+          target_id: 'edge_morale_to_outcome',
+          data: {
+            weirdEdgeMeta: { internal: true, ref: 'pending_internal_ref' },
+          } as unknown as Record<string, unknown>,
+        },
+      ],
+    })
+    render(<InlineBlocks blocks={[block]} />)
+    const list = screen.getByTestId('patch-proposal-list')
+    // Endpoints render safely.
+    expect(list.textContent).toContain('team morale')
+    expect(list.textContent).toContain('overall outcome')
+    // Receipt collapses to the bare connection label — no field suffix.
+    expect(list.textContent?.toLowerCase()).not.toContain(':')
+    // Raw camelCase keys must not leak.
+    expect(list.outerHTML).not.toContain('weirdEdgeMeta')
+    expect(list.outerHTML).not.toContain('pending_internal_ref')
+    // Humanised forms must ALSO not leak — same regression class as
+    // raw keys, just dressed up in sentence case.
+    const lowered = list.outerHTML.toLowerCase()
+    expect(lowered).not.toContain('weird edge meta')
+    expect(lowered).not.toContain('pending internal ref')
+    expectNoLeakInPatchCard()
+  })
+})

--- a/src/canvas/conversation/__tests__/friendlyOperation.spec.ts
+++ b/src/canvas/conversation/__tests__/friendlyOperation.spec.ts
@@ -443,3 +443,125 @@ describe('describeOperation — add_edge with same-patch node labels (Fix 1)', (
     expect(describeOperation(op, deps)).toBe('Add connection')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────
+// Receipt field-suffix allowlist gate (RECEIPT_FIELD_ALLOWLIST)
+//
+// `describeOperation` only renders a `: <FieldLabel>` suffix when the
+// changed key is on the receipt allowlist. The allowlist is the union
+// of `UPDATE_FIELD_PRIORITY` (priority order) and `Object.keys(FIELD_LABELS)`
+// (curated friendly labels). Foreign / drifted / malformed keys must
+// suppress the suffix and fall back to the bare label. Without the
+// gate, `friendlyFieldName` would convert arbitrary camelCase like
+// `weirdInternalKey` into "Weird internal key" — a friendly-looking
+// leak of an internal field name.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('describeOperation — receipt field-suffix allowlist gate', () => {
+  it('update_node with a known UPDATE_FIELD_PRIORITY key renders the friendly suffix', () => {
+    // Using `kind` rather than `label` because `label` is also tier-2 of
+    // resolveNodeLabel and would shadow the store-resolved entity label
+    // — that interaction belongs to the label-resolution suite, not here.
+    const op: PatchOperation = {
+      op: 'update_node',
+      target_id: 'fac_morale',
+      data: { kind: 'risk' },
+    }
+    const deps = makeDeps({ nodeLabels: new Map([['fac_morale', 'team morale']]) })
+    const result = describeOperation(op, deps)
+    expect(result).toBe('Update **team morale**: Kind')
+  })
+
+  it('update_node with a curated FIELD_LABELS-only key (not in priority list) renders the friendly suffix', () => {
+    // `baseline` is in FIELD_LABELS ("Baseline") but NOT in
+    // UPDATE_FIELD_PRIORITY. The gate must allow it through —
+    // priority order and display safety are different concepts.
+    // Same property holds for `exists_probability`, `strength_std`,
+    // `range_min`, `range_max`.
+    const op: PatchOperation = {
+      op: 'update_node',
+      target_id: 'fac_morale',
+      data: { baseline: 0.5 },
+    }
+    const deps = makeDeps({ nodeLabels: new Map([['fac_morale', 'team morale']]) })
+    const result = describeOperation(op, deps)
+    expect(result).toBe('Update **team morale**: Baseline')
+  })
+
+  it('update_node with an unknown key suppresses the suffix and renders the bare label', () => {
+    const op: PatchOperation = {
+      op: 'update_node',
+      target_id: 'fac_morale',
+      // Cast: deliberate wire-shape simulation (foreign key) — NOT an
+      // endorsed schema example. This is the leakage class the gate
+      // exists to block.
+      data: { weirdInternalKey: 'should-not-leak' } as unknown as Record<string, unknown>,
+    }
+    const deps = makeDeps({ nodeLabels: new Map([['fac_morale', 'team morale']]) })
+    const result = describeOperation(op, deps)
+    expect(result).toBe('Update **team morale**')
+    // Humanised form of the unknown key must not appear.
+    expect(result.toLowerCase()).not.toContain('weird internal key')
+    // Raw key must not appear either.
+    expect(result).not.toContain('weirdInternalKey')
+  })
+
+  it('update_edge with a curated FIELD_LABELS-only key (exists_probability) renders the friendly suffix', () => {
+    // Real-world edges carry `exists_probability` as a wire field —
+    // this is the regression case from the third-round review.
+    const op: PatchOperation = {
+      op: 'update_edge',
+      target_id: 'edge_1',
+      data: { exists_probability: 0.8 },
+    }
+    const deps = makeDeps({
+      edgeEndpoints: new Map([['edge_1', { from: 'fac_a', to: 'fac_b' }]]),
+      nodeLabels: new Map([['fac_a', 'A'], ['fac_b', 'B']]),
+    })
+    const result = describeOperation(op, deps)
+    expect(result).toBe('Update connection **A** → **B**: Existence probability')
+  })
+
+  it('update_edge with another curated FIELD_LABELS-only key (strength_std) renders the friendly suffix', () => {
+    const op: PatchOperation = {
+      op: 'update_edge',
+      target_id: 'edge_1',
+      data: { strength_std: 0.1 },
+    }
+    const deps = makeDeps({
+      edgeEndpoints: new Map([['edge_1', { from: 'fac_a', to: 'fac_b' }]]),
+      nodeLabels: new Map([['fac_a', 'A'], ['fac_b', 'B']]),
+    })
+    const result = describeOperation(op, deps)
+    expect(result).toBe('Update connection **A** → **B**: Strength uncertainty')
+  })
+
+  it('update_edge with an unknown key suppresses the suffix and renders the bare connection', () => {
+    const op: PatchOperation = {
+      op: 'update_edge',
+      target_id: 'edge_1',
+      data: { weirdEdgeMeta: { internal: true } } as unknown as Record<string, unknown>,
+    }
+    const deps = makeDeps({
+      edgeEndpoints: new Map([['edge_1', { from: 'fac_a', to: 'fac_b' }]]),
+      nodeLabels: new Map([['fac_a', 'A'], ['fac_b', 'B']]),
+    })
+    const result = describeOperation(op, deps)
+    expect(result).toBe('Update connection **A** → **B**')
+    expect(result.toLowerCase()).not.toContain('weird edge meta')
+    expect(result).not.toContain('weirdEdgeMeta')
+  })
+
+  it('update_node with a camelCase variant of a curated key (existsProbability) renders the friendly suffix', () => {
+    // CEE may emit a camelCase variant of an otherwise-curated key.
+    // The gate's snake-case parity check should accept it.
+    const op: PatchOperation = {
+      op: 'update_node',
+      target_id: 'fac_morale',
+      data: { existsProbability: 0.9 } as unknown as Record<string, unknown>,
+    }
+    const deps = makeDeps({ nodeLabels: new Map([['fac_morale', 'team morale']]) })
+    const result = describeOperation(op, deps)
+    expect(result).toBe('Update **team morale**: Existence probability')
+  })
+})

--- a/src/canvas/conversation/friendlyOperation.ts
+++ b/src/canvas/conversation/friendlyOperation.ts
@@ -146,6 +146,12 @@ export function friendlyFieldName(key: string): string {
 /**
  * Returns the first changed key from `data` according to UPDATE_FIELD_PRIORITY,
  * then any remaining keys (excluding `id`), sorted for determinism.
+ *
+ * Note: callers should NOT use the returned key to render a friendly suffix
+ * unless `isAllowlistedFieldKey` confirms it is on the known-fields
+ * allowlist — otherwise an unfamiliar payload key like `weirdInternalKey`
+ * would humanise to "Weird internal key" and leak through `friendlyFieldName`
+ * into the receipt. See `describeOperation`.
  */
 export function firstChangedKey(
   data: Record<string, unknown> | undefined,
@@ -158,6 +164,46 @@ export function firstChangedKey(
     .filter((k) => k !== 'id')
     .sort()
   return rest[0]
+}
+
+/**
+ * Allowlist gate for receipt field suffixes.
+ *
+ * Two separate concepts are deliberately combined into one display
+ * allowlist:
+ *
+ *   - `UPDATE_FIELD_PRIORITY` — ordered list used by `firstChangedKey`
+ *     to *pick* which key to surface when an update payload carries
+ *     several. Priority order, not a safety contract.
+ *   - `FIELD_LABELS` (from modelCardAdapter) — curated table of
+ *     friendly labels for receipt-renderable fields. Some entries here
+ *     (e.g. `exists_probability`, `strength_std`, `baseline`,
+ *     `range_min`, `range_max`) are valid update fields whose curated
+ *     friendly label should appear in receipts, even though they are
+ *     not part of the priority order.
+ *
+ * The receipt allowlist is the UNION of both — any key that has been
+ * intentionally added to either deserves its curated suffix. Anything
+ * else (foreign / drifted / malformed payloads) must NOT produce a
+ * humanised suffix, because `friendlyFieldName` would convert arbitrary
+ * camelCase like `anotherSecret` into "Another secret" — a
+ * friendly-looking leak of an internal field name.
+ *
+ * Exported (with the legacy name `UPDATE_FIELD_PRIORITY_SET` removed)
+ * so future contributors do not conflate priority order with display
+ * safety.
+ */
+export const RECEIPT_FIELD_ALLOWLIST: ReadonlySet<string> = new Set([
+  ...UPDATE_FIELD_PRIORITY,
+  ...Object.keys(FIELD_LABELS),
+])
+
+export function isAllowlistedFieldKey(key: string): boolean {
+  if (RECEIPT_FIELD_ALLOWLIST.has(key)) return true
+  // camelCase ↔ snake_case parity: CEE may emit a camelCase variant
+  // (e.g. `existsProbability`) of an otherwise-curated key.
+  const snake = key.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase()
+  return RECEIPT_FIELD_ALLOWLIST.has(snake)
 }
 
 // ---------------------------------------------------------------------------
@@ -256,7 +302,11 @@ export function describeOperation(op: PatchOperation, deps: DescribeOpDeps): str
       const label = resolveNodeLabel(op.target_id, deps, op.data)
       const field = firstChangedKey(op.data)
       if (!label) return generic
-      if (!field) return `Update **${label}**`
+      // Only render a field suffix when the key is on the known-fields
+      // allowlist — otherwise `friendlyFieldName` would humanise a
+      // foreign / drifted key (e.g. `anotherSecret` → "Another secret")
+      // into a friendly-looking leak of an internal field name.
+      if (!field || !isAllowlistedFieldKey(field)) return `Update **${label}**`
       return `Update **${label}**: ${friendlyFieldName(field)}`
     }
 
@@ -277,7 +327,10 @@ export function describeOperation(op: PatchOperation, deps: DescribeOpDeps): str
       const field = firstChangedKey(op.data)
       if (!from && !to) return generic
       const base = `Update connection **${from || '?'}** → **${to || '?'}**`
-      return field ? `${base}: ${friendlyFieldName(field)}` : base
+      // Same allowlist gate as update_node — never humanise an unfamiliar
+      // edge field key. Falls back to the bare connection label.
+      if (!field || !isAllowlistedFieldKey(field)) return base
+      return `${base}: ${friendlyFieldName(field)}`
     }
 
     case 'remove_edge': {

--- a/src/test/helpers/expectNoChipMetadataLeaks.ts
+++ b/src/test/helpers/expectNoChipMetadataLeaks.ts
@@ -1,0 +1,80 @@
+/**
+ * expectNoChipMetadataLeaks — purpose-built no-leak helper for ActionChip
+ * elements.
+ *
+ * Differs from `expectNoReceiptLeaks` because chip rendering has intentional
+ * attributes that would (correctly) be rejected by the strict receipt helper:
+ *   - `data-testid="chip-{id}"` may carry id prefixes such as `prop_` (used
+ *     by forward-compat proposal chips). The receipt helper's
+ *     RAW_ID_PATTERN deliberately matches these; for chips the id-bearing
+ *     testid is the contract.
+ *   - `data-chip-role="facilitator|challenger|scientist"` is a styling hook.
+ *
+ * What this helper enforces is what the chip surface MUST NOT carry: the
+ * structured `parameters` payload, the wire `action_type` string, proposal
+ * refs, handler ids, schema/internal terms, and raw JSON tells.
+ *
+ * Use on a chip `<button>` (or its container) — not on receipts.
+ */
+
+import { expect } from 'vitest'
+
+/**
+ * Forbidden chip-DOM tells. Excludes the chip-id-bearing attributes
+ * intentionally rendered by ActionChipRow (data-testid, data-chip-role).
+ */
+export const CHIP_FORBIDDEN_TERMS: readonly string[] = [
+  // Structured chip metadata that must never serialise into DOM.
+  'parameters',
+  'chip_metadata',
+  'proposal_ref',
+  'pending_actions',
+  'handler_id',
+  'graph_hash',
+  // Forward-compat: future proposal payloads may carry public_label /
+  // public_message on chip metadata. The current UI ignores them; they
+  // must not appear in DOM as either field names or values.
+  'public_label',
+  'public_message',
+  // Wire-allowed action type literals — the chip dispatches `message`,
+  // not the action_type string, so the literal must not leak.
+  'action_type',
+  'apply_proposed_change',
+  'run_analysis',
+  'what_would_flip',
+  'explain_result',
+  'explain_results',
+  'explain_from_structure',
+  'compare_options',
+  'set_factor_value',
+  'add_constraint',
+  'adjust_edge_strength',
+  'update_node',
+  'update_edge',
+  'add_node',
+  'add_edge',
+  // Validation / error machinery.
+  'STRUCTURAL_VALIDATION_FAILED',
+  'INTERNAL_ERROR',
+  'zod',
+  'invalid_type',
+  // Raw JSON tells.
+  '{"',
+  '":',
+]
+
+/**
+ * Assert a chip element's `outerHTML` carries no metadata, parameters,
+ * action type, proposal ref, schema/internal term, or raw JSON.
+ *
+ * Cites the specific leaked term on failure.
+ */
+export function expectNoChipMetadataLeaks(element: HTMLElement): void {
+  const lowered = element.outerHTML.toLowerCase()
+  for (const term of CHIP_FORBIDDEN_TERMS) {
+    expect(
+      lowered,
+      `chip outerHTML leaked forbidden term: "${term}"`,
+    ).not.toContain(term.toLowerCase())
+  }
+}

--- a/src/test/helpers/expectNoReceiptLeaks.ts
+++ b/src/test/helpers/expectNoReceiptLeaks.ts
@@ -1,0 +1,217 @@
+/**
+ * expectNoReceiptLeaks — strict assertion helper for V5 / V4 graph-patch
+ * receipt rendering.
+ *
+ * Asserts the rendered receipt's `outerHTML` does not contain:
+ *   - raw element IDs (matched via the production RAW_ID_PATTERN)
+ *   - mathematical operator glyphs (`<=` / `>=` / `≤` / `≥` / `lte` / `gte`)
+ *     — receipts must use decision-language phrases per the V5 UI contract
+ *   - any internal schema field, handler keyword, or wire-allowed action
+ *     type literal that should never reach the rendered surface
+ *   - raw JSON tells (`{"`, `":`)
+ *
+ * Use this on receipt cards (V5GraphPatchBlock, V4 GraphPatchBlockRenderer).
+ * Do NOT use this on suggested-action chips — those have intentional
+ * attributes (e.g. `data-testid="chip-prop_<hex>"`) that this helper
+ * would (correctly) reject. Use `expectNoChipMetadataLeaks` for chips.
+ */
+
+import { expect } from 'vitest'
+import { RAW_ID_PATTERN } from '../../canvas/conversation/friendlyOperation'
+
+/**
+ * Forbidden internal terms in the rendered receipt DOM. Exported so failing
+ * assertions can cite the exact leaked term in test output.
+ *
+ * These are unique snake_case / SCREAMING_SNAKE / namespaced strings that
+ * would never appear in legitimate user-facing copy by accident — checked
+ * as plain substrings (case-insensitive).
+ *
+ * Short English-prone substrings (`mean`, `std`, `noop`, `operator`,
+ * `provenance`, `before`, `after`) are checked separately as
+ * word-boundary regexes in `RECEIPT_FORBIDDEN_WORD_REGEXES` to avoid
+ * false positives on legitimate copy like the V4 dismiss button label
+ * "Not what I meant".
+ */
+export const RECEIPT_FORBIDDEN_TERMS: readonly string[] = [
+  // Schema field names + raw JSON shape tells.
+  'target_id',
+  'node_id',
+  'edge_id',
+  'constraint_id',
+  'handler_id',
+  'graph_hash',
+  'proposal_ref',
+  'chip_metadata',
+  'pending_actions',
+  'raw_value',
+  'fact_type',
+  '{"',
+  '":',
+  // V5 + V4 operation names — wire-only.
+  'set_factor_value',
+  'add_constraint',
+  'adjust_edge_strength',
+  'update_node',
+  'update_edge',
+  'add_node',
+  'add_edge',
+  'remove_node',
+  'remove_edge',
+  // Wire-allowed action type literals — never user-facing copy.
+  'apply_proposed_change',
+  'run_analysis',
+  'what_would_flip',
+  'explain_result',
+  'explain_results',
+  'explain_from_structure',
+  'compare_options',
+  // Validation / error machinery — never user-facing copy.
+  'STRUCTURAL_VALIDATION_FAILED',
+  'INTERNAL_ERROR',
+  'zod',
+  'invalid_type',
+  'precondition',
+  // Block-type discriminator — must never reach user-facing copy.
+  // V4 retains this in internal DOM machinery (`block-graph-patch-{patch_id}`
+  // testid + CSS module classes like `graphPatchBlock`); V4 receipt tests
+  // therefore use `expectNoReceiptUserFacingTextLeaks` (textContent +
+  // aria-labels only), which scopes the assertion to what the user sees
+  // and explicitly accepts the internal-DOM exception. V5 uses Tailwind
+  // (no CSS modules) and a renamed testid (`v5-change-receipt`), so the
+  // full-outerHTML form catches any regression on that surface.
+  'graph-patch',
+  'graph_patch',
+  'graphpatch',
+]
+
+/**
+ * Raw edge-id pattern — supplements the production `RAW_ID_PATTERN`
+ * (which deliberately omits `edge_` since edge IDs are not the typical
+ * leak vector — V5 receipts resolve edges via from/to endpoint labels).
+ * Defensive coverage so any leaked `edge_xxx` substring trips the helper.
+ */
+export const RECEIPT_FORBIDDEN_RAW_EDGE_ID_PATTERN = /\bedge_[a-z0-9_]+/i
+
+/**
+ * Word-boundary forbidden terms — short strings whose substrings appear
+ * in legitimate UI copy (e.g. "meant" in V4's "Not what I meant" button)
+ * but whose standalone-word forms would still indicate a real leak from
+ * the schema layer (e.g. an unwrapped `strength.mean` value).
+ *
+ * Each entry must match only the standalone word, never an embedded
+ * substring. Entries are checked with the `i` (case-insensitive) flag.
+ */
+export const RECEIPT_FORBIDDEN_WORD_REGEXES: readonly RegExp[] = [
+  /\bmean\b/i,
+  /\bstd\b/i,
+  /\bnoop\b/i,
+  /\bbefore\b/i,
+  /\bafter\b/i,
+  /\boperator\b/i,
+  /\bprovenance\b/i,
+]
+
+/**
+ * Operator-glyph guard — symbol forms forbidden in the default receipt
+ * surface. Decision-language phrases ("at most" / "at least") are the
+ * contract.
+ */
+export const RECEIPT_FORBIDDEN_OPERATOR_GLYPHS = /(?:<=|>=|≤|≥|\blte\b|\bgte\b)/i
+
+/**
+ * Assert a receipt element's `outerHTML` carries no raw IDs, no operator
+ * glyphs, and no forbidden internal/wire term. On failure, the assertion
+ * message cites the specific leaked term so the test output points at the
+ * regression rather than dumping the whole DOM.
+ */
+export function expectNoReceiptLeaks(element: HTMLElement): void {
+  const rendered = element.outerHTML
+  const lowered = rendered.toLowerCase()
+
+  expect(
+    rendered,
+    'receipt outerHTML matched RAW_ID_PATTERN (raw element id leaked)',
+  ).not.toMatch(RAW_ID_PATTERN)
+
+  expect(
+    rendered,
+    'receipt outerHTML matched RECEIPT_FORBIDDEN_RAW_EDGE_ID_PATTERN (raw edge id leaked)',
+  ).not.toMatch(RECEIPT_FORBIDDEN_RAW_EDGE_ID_PATTERN)
+
+  expect(
+    rendered,
+    'receipt outerHTML matched RECEIPT_FORBIDDEN_OPERATOR_GLYPHS (use decision-language phrases)',
+  ).not.toMatch(RECEIPT_FORBIDDEN_OPERATOR_GLYPHS)
+
+  for (const term of RECEIPT_FORBIDDEN_TERMS) {
+    expect(
+      lowered,
+      `receipt outerHTML leaked forbidden term: "${term}"`,
+    ).not.toContain(term.toLowerCase())
+  }
+
+  for (const pattern of RECEIPT_FORBIDDEN_WORD_REGEXES) {
+    expect(
+      rendered,
+      `receipt outerHTML leaked forbidden standalone word matching ${pattern}`,
+    ).not.toMatch(pattern)
+  }
+}
+
+/**
+ * Variant of `expectNoReceiptLeaks` that scopes the assertion to the
+ * user-facing surface only — visible `textContent` and `aria-label`
+ * attributes — rather than full `outerHTML`.
+ *
+ * Use this where the rendered card carries internal DOM machinery in
+ * its testid / CSS class names that intentionally repeats schema-like
+ * tokens (e.g. V4's `data-testid="block-graph-patch-{patch_id}"` and
+ * its `graphPatchBlock` CSS module classes). Scoping to textContent +
+ * aria-labels expresses the contract precisely: those tokens may
+ * persist in implementation-detail attributes, but they MUST NOT bleed
+ * into anything the user reads or hears via assistive tech.
+ *
+ * Tradeoff: this form does NOT catch attribute-level leaks (e.g. a
+ * future `data-operation="add_constraint"` regression). For that, use
+ * the strict `expectNoReceiptLeaks` against full outerHTML on a
+ * surface that already has clean attributes (V5 receipts).
+ */
+export function expectNoReceiptUserFacingTextLeaks(element: HTMLElement): void {
+  const textContent = element.textContent ?? ''
+  const elementOwnAriaLabel = element.getAttribute('aria-label') ?? ''
+  const childAriaLabels = Array.from(element.querySelectorAll('[aria-label]'))
+    .map((el) => el.getAttribute('aria-label') ?? '')
+    .join('\n')
+  const surface = [textContent, elementOwnAriaLabel, childAriaLabels].join('\n')
+  const lowered = surface.toLowerCase()
+
+  expect(
+    surface,
+    'user-facing receipt surface matched RAW_ID_PATTERN (raw element id leaked)',
+  ).not.toMatch(RAW_ID_PATTERN)
+
+  expect(
+    surface,
+    'user-facing receipt surface matched RECEIPT_FORBIDDEN_RAW_EDGE_ID_PATTERN (raw edge id leaked)',
+  ).not.toMatch(RECEIPT_FORBIDDEN_RAW_EDGE_ID_PATTERN)
+
+  expect(
+    surface,
+    'user-facing receipt surface matched RECEIPT_FORBIDDEN_OPERATOR_GLYPHS (use decision-language phrases)',
+  ).not.toMatch(RECEIPT_FORBIDDEN_OPERATOR_GLYPHS)
+
+  for (const term of RECEIPT_FORBIDDEN_TERMS) {
+    expect(
+      lowered,
+      `user-facing receipt surface leaked forbidden term: "${term}"`,
+    ).not.toContain(term.toLowerCase())
+  }
+
+  for (const pattern of RECEIPT_FORBIDDEN_WORD_REGEXES) {
+    expect(
+      surface,
+      `user-facing receipt surface leaked forbidden standalone word matching ${pattern}`,
+    ).not.toMatch(pattern)
+  }
+}

--- a/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
+++ b/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
@@ -11,7 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 
 import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../../canvas/conversation/types'
-import { RAW_ID_PATTERN } from '../../../canvas/conversation/friendlyOperation'
+import { expectNoReceiptLeaks } from '../../../test/helpers/expectNoReceiptLeaks'
 
 // Mock the canvas store so the block uses our controlled nodes/edges.
 // Includes both the underscore-prefixed ids used by simpler fixtures
@@ -51,60 +51,16 @@ vi.mock('../../../lib/useAnalysisFreshnessState', () => ({
 // Import AFTER the mock so the component uses the mocked store.
 import { V5GraphPatchBlock } from '../V5GraphPatchBlock'
 
-// Forbidden internal terms in default UI surfaces. Extended after
-// code-review NR1 to cover schema field names that real CEE blocks
-// carry (constraint_id, node_id, provenance, raw_value) plus the
-// edge-strength object's internals (mean, std). Mathematical
-// operator glyphs (≤ / ≥ / <=) are also forbidden — receipts use
-// decision-language phrases ("at most" / "at least") per the
-// CEE format-confirmation table.
-const FORBIDDEN_TERMS = [
-  'target_id',
-  'operator',
-  'noop',
-  'fact_type',
-  'graph_hash',
-  'set_factor_value',
-  'add_constraint',
-  'adjust_edge_strength',
-  'before',
-  'after',
-  // NR1 additions — schema field names emitted on CEE block payloads
-  // that real receipts must never surface.
-  'constraint_id',
-  'node_id',
-  'provenance',
-  'raw_value',
-  'mean',
-  'std',
-  // Second-round B2 additions — schema/handler-mechanics terms.
-  // The previous data-testid="v5-graph-patch" leaked "graph-patch"
-  // into outerHTML. Renamed to v5-change-receipt + the gate now
-  // catches any future regression that re-introduces the schema
-  // term in the rendered DOM.
-  'graph-patch',
-  'graph_patch',
-  'graphpatch',
-]
-
-// Operator-glyph guard. Decision-language only — no `<=` / `>=` /
-// `≤` / `≥` / `lte` / `gte` strings should reach the default DOM.
-// A separate const because `'<='` / `'>='` literals are short and a
-// single regex over outerHTML is the cheapest assertion.
-const FORBIDDEN_OPERATOR_GLYPHS = /(?:<=|>=|≤|≥|\blte\b|\bgte\b)/i
-
+// Inline FORBIDDEN_TERMS / FORBIDDEN_OPERATOR_GLYPHS / expectNoLeakInDOM
+// were consolidated into the shared `expectNoReceiptLeaks` helper so V4
+// and V5 receipt tests share one source of truth. Cited terms appear in
+// failure messages — see `src/test/helpers/expectNoReceiptLeaks.ts`.
+// The shared list now includes the block-type discriminator
+// (`graph-patch` / `graph_patch` / `graphpatch`) — V5's renamed testid
+// (`v5-change-receipt`) and Tailwind-only styling means full outerHTML
+// stays clean against that term, so no V5-local exception is needed.
 function expectNoLeakInDOM(): void {
-  const card = screen.getByTestId('v5-change-receipt')
-  // Assert against outerHTML — covers attribute-level leaks (e.g. a
-  // future `data-operation="add_constraint"` regression) as well as
-  // text content. Pure textContent only catches innerText leaks and
-  // missed the data-operation regression caught in code review.
-  const rendered = card.outerHTML
-  expect(rendered).not.toMatch(RAW_ID_PATTERN)
-  expect(rendered).not.toMatch(FORBIDDEN_OPERATOR_GLYPHS)
-  for (const term of FORBIDDEN_TERMS) {
-    expect(rendered.toLowerCase()).not.toContain(term)
-  }
+  expectNoReceiptLeaks(screen.getByTestId('v5-change-receipt'))
 }
 
 beforeEach(() => {
@@ -428,5 +384,178 @@ describe('V5GraphPatchBlock — code-review regression bar (P1.1 / P1.2 / P1.3)'
     const change = screen.queryByTestId('v5-change-summary')
     expect(change).not.toBeNull()
     expect((change!.textContent ?? '').trim().length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// G2 — V5 receipt no-leak across all four freshness verdicts.
+// ---------------------------------------------------------------------------
+//
+// The component renders a stale-only inline hint
+// (`Latest analysis is now out of date.`) when status='applied' AND
+// freshness='stale'. The other three verdicts must render without any
+// freshness wording — these tests prove the per-state outerHTML stays
+// clean and that `none` does not imply analysis exists, while `unknown`
+// avoids false certainty.
+// ---------------------------------------------------------------------------
+
+describe('V5GraphPatchBlock — G2 freshness no-leak across all four verdicts', () => {
+  const FRESHNESS_VERDICTS = ['fresh', 'stale', 'none', 'unknown'] as const
+
+  it.each(FRESHNESS_VERDICTS)(
+    'outerHTML stays clean when freshness verdict is "%s"',
+    (verdict) => {
+      mockFreshnessState.mockReturnValue({
+        freshness: verdict,
+        reason: null,
+        recommendedAction:
+          verdict === 'stale'
+            ? 'rerun_analysis'
+            : verdict === 'fresh'
+              ? 'view_results'
+              : 'continue_editing',
+        inputsMissing: [],
+      })
+      const block: V5GraphPatchBlockType = {
+        type: 'v5_graph_patch',
+        status: 'applied',
+        operation: 'set_factor_value',
+        target_id: 'fac_team_morale',
+        before: { value: 0.5, raw_value: 50, unit: '%' },
+        after: { value: 0.7, raw_value: 70, unit: '%' },
+      }
+      render(<V5GraphPatchBlock block={block} />)
+      expectNoLeakInDOM()
+    },
+  )
+
+  it('on freshness=none, the receipt does not imply an analysis exists', () => {
+    // 'none' means no analysis has run yet — the receipt must not say
+    // "out of date" / "rerun" / "analysis", which would imply prior
+    // results the user could view.
+    mockFreshnessState.mockReturnValue({
+      freshness: 'none',
+      reason: 'no_options_yet',
+      recommendedAction: 'continue_editing',
+      inputsMissing: [],
+    })
+    const block: V5GraphPatchBlockType = {
+      type: 'v5_graph_patch',
+      status: 'applied',
+      operation: 'set_factor_value',
+      target_id: 'fac_team_morale',
+      before: { value: 0.5 },
+      after: { value: 0.7 },
+    }
+    render(<V5GraphPatchBlock block={block} />)
+    const card = screen.getByTestId('v5-change-receipt')
+    const text = (card.textContent ?? '').toLowerCase()
+    expect(text).not.toContain('out of date')
+    expect(text).not.toContain('analysis')
+    expect(text).not.toMatch(/\brerun\b|\bre-run\b/)
+    // Hint testid should not render at all.
+    expect(screen.queryByTestId('v5-change-freshness-hint')).toBeNull()
+    expectNoLeakInDOM()
+  })
+
+  it('on freshness=unknown, the receipt avoids false certainty', () => {
+    // 'unknown' means the verdict cannot be derived — the receipt must
+    // not assert either "up to date" OR "out of date".
+    mockFreshnessState.mockReturnValue({
+      freshness: 'unknown',
+      reason: null,
+      recommendedAction: 'continue_editing',
+      inputsMissing: [],
+    })
+    const block: V5GraphPatchBlockType = {
+      type: 'v5_graph_patch',
+      status: 'applied',
+      operation: 'set_factor_value',
+      target_id: 'fac_team_morale',
+      before: { value: 0.5 },
+      after: { value: 0.7 },
+    }
+    render(<V5GraphPatchBlock block={block} />)
+    const card = screen.getByTestId('v5-change-receipt')
+    const text = (card.textContent ?? '').toLowerCase()
+    expect(text).not.toContain('out of date')
+    expect(text).not.toContain('up to date')
+    expect(screen.queryByTestId('v5-change-freshness-hint')).toBeNull()
+    expectNoLeakInDOM()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// G3 — adjust_edge_strength missing/malformed before/after stays graceful.
+// ---------------------------------------------------------------------------
+
+describe('V5GraphPatchBlock — G3 adjust_edge_strength graceful fallback', () => {
+  it('renders generic action label when before AND after are both null', () => {
+    // Worst-case: no payload to extract from. The receipt must still
+    // render the action label cleanly with no change summary and no
+    // raw shape leakage.
+    const block: V5GraphPatchBlockType = {
+      type: 'v5_graph_patch',
+      status: 'applied',
+      operation: 'adjust_edge_strength',
+      target_id: 'edge_morale_to_outcome',
+      before: null,
+      after: null,
+    }
+    render(<V5GraphPatchBlock block={block} />)
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    // Endpoints resolve via the canvas store fallback (edge id is in EDGES).
+    expect(screen.getByTestId('v5-change-entity').textContent).toBe(
+      'team morale → overall outcome',
+    )
+    // No raw shape — change summary is suppressed when scalars cannot be derived.
+    expect(screen.queryByTestId('v5-change-summary')).toBeNull()
+    expectNoLeakInDOM()
+  })
+
+  it('renders generic receipt when target_id does not resolve to a known edge AND before/after are both null', () => {
+    // Worst-case fallback: payload empty AND id is unmapped. The
+    // receipt must remain generic; nothing about the edge shape, no
+    // change summary, no entity row, no raw id in DOM. The `edge_`
+    // prefix is intentionally not in the production RAW_ID_PATTERN
+    // (V5 receipts resolve edges via from/to labels) — so we assert
+    // explicitly that the unmapped target_id never reaches DOM, on top
+    // of the helper's RECEIPT_FORBIDDEN_RAW_EDGE_ID_PATTERN check.
+    const block: V5GraphPatchBlockType = {
+      type: 'v5_graph_patch',
+      status: 'applied',
+      operation: 'adjust_edge_strength',
+      target_id: 'edge_unknown_unmapped',
+      before: null,
+      after: null,
+    }
+    render(<V5GraphPatchBlock block={block} />)
+    const card = screen.getByTestId('v5-change-receipt')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    expect(screen.queryByTestId('v5-change-entity')).toBeNull()
+    expect(screen.queryByTestId('v5-change-summary')).toBeNull()
+    expect(card.outerHTML).not.toContain('edge_unknown_unmapped')
+    expectNoLeakInDOM()
+  })
+
+  it('renders gracefully when after is a scalar/string (malformed shape)', () => {
+    // Defensive: a malformed `after` value (string instead of object)
+    // must not throw and must not fall through to raw rendering. The
+    // strengthScalar() null path keeps the change summary suppressed.
+    const block: V5GraphPatchBlockType = {
+      type: 'v5_graph_patch',
+      status: 'applied',
+      operation: 'adjust_edge_strength',
+      target_id: 'edge_morale_to_outcome',
+      before: null,
+      // Cast through unknown — V5 wire schema disallows this in
+      // production, but the UI must be defensive against any
+      // schema-package drift that loosens the type at runtime.
+      after: 'oops' as unknown as null,
+    }
+    render(<V5GraphPatchBlock block={block} />)
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    expect(screen.queryByTestId('v5-change-summary')).toBeNull()
+    expectNoLeakInDOM()
   })
 })


### PR DESCRIPTION
## Summary

Closes UI WS1 acceptance gates **G2 / G3 / G4** plus the proposal-chip forward-compatibility check, and lands one production fix surfaced during review.

- **G2** — V5 receipt rendering has no internal leakage across freshness states `fresh | stale | none | unknown`.
- **G3** — `adjust_edge_strength` receipts handle missing/malformed `before`/`after` gracefully without exposing raw shape or edge ids.
- **G4** — V4 `update_node` / `update_edge` receipts never fall through to raw JSON, raw camelCase keys, **or humanised unknown-key forms**.
- **Forward-compat** — `prop_<12hex>` chips render as standard suggested actions; `parameters`, `action_type`, `proposal_ref`, `chip_metadata`, `handler_id`, `public_label`, `public_message` do not leak.

### Production fix

`src/canvas/conversation/friendlyOperation.ts` introduces `RECEIPT_FIELD_ALLOWLIST = UPDATE_FIELD_PRIORITY ∪ Object.keys(FIELD_LABELS)` and gates the field-suffix in `describeOperation`'s `update_node` / `update_edge` cases via a new `isAllowlistedFieldKey` helper. Without the gate, foreign payload keys reached `friendlyFieldName` and produced sentence-cased leaks like `"Another secret"` / `"Weird edge meta"` — same regression class as raw IDs, just dressed up. The allowlist deliberately separates *priority order* (which key to surface first) from *display safety* (which keys are receipt-safe), so curated FIELD_LABELS-only keys (`exists_probability`, `strength_std`, `baseline`, `range_min`, `range_max`) keep rendering their friendly suffixes.

### Section A freshness rendering

Product decision: the V5 receipt's stale-only inline hint is the accepted design. `fresh` / `none` / `unknown` render no freshness row by design — the CEE run/rerun chip is the action surface for analysis guidance. Rationale already documented in `V5GraphPatchBlock.tsx:49-51`. No additional code change in this PR.

### Files changed (7)

- `src/canvas/conversation/friendlyOperation.ts` — production allowlist gate
- `src/canvas/conversation/__tests__/friendlyOperation.spec.ts` — +7 allowlist-gate unit tests
- `src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx` — G2 freshness no-leak loop + G3 graceful-fallback tests
- `src/test/helpers/expectNoReceiptLeaks.ts` — strict + user-facing-text receipt no-leak helpers
- `src/test/helpers/expectNoChipMetadataLeaks.ts` — chip-specific no-leak helper
- `src/canvas/conversation/__tests__/GraphPatchBlock.noLeak.spec.tsx` — G4 V4 no-leak suite (raw + humanised)
- `src/canvas/conversation/__tests__/ActionChipRow.proposalForwardCompat.spec.tsx` — proposal-chip forward-compat suite

No CEE / PLoT / ISL / prompt / schema / env / lockfile / package / migration / generated / Docs/v5 files touched.

### Push note

Pushed with one-shot authorised `--no-verify` after the local pre-push fast gate flagged 46 inherited TypeScript errors (all in files this branch does not touch — same 46 exist on `origin/staging` itself). Zero new TypeScript errors introduced by this branch. All other pre-push checks were green: branch guard, lint on changed files (7), 8-file smoke suite (459/459), no stale `.js`, no non-allowlisted `file:` deps, V5 vendored schemas SHA. Per `MEMORY.md` (2026-04-30) GitHub Actions is also broken at install due to the incomplete pnpm migration; this PR does not aim to repair that infra debt.

## Test plan

- [x] Targeted vitest run (3 primary files): 35/35 pass
- [x] Broader receipt + chip + describeOperation neighbourhood (16 files): 281/281 pass
- [x] Smoke suite (8 files, 459 tests): pass
- [x] Lint on changed files (7): pass
- [x] No new TS errors (vs origin/staging): confirmed (46 = 46)
- [ ] Reviewer to merge once happy with the Section A acceptance and the inherited-debt push note

🤖 Generated with [Claude Code](https://claude.com/claude-code)