### PR TITLE
feat(v5): hydrate Results panel from V5 analysis_result blocks (Area 1 / P0)

### DIFF
--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -2698,10 +2698,24 @@ export function useConversation(): UseConversationReturn {
             // between request and response, this response is stale and
             // must not regress V5 state. See applyV5State's top-of-
             // function invariant.
-            const stateApply = applyV5State(target.response, useCanvasStore.getState(), {
-              turnClientId,
-              currentClientTurnId: activeV5TurnIdRef.current,
-            })
+            // The full canvas store already satisfies the legacy V5ApplicatorStore
+            // surface (stage, graph_patch, runMeta, ceeAnalysisReady). Step 5
+            // (results hydration, 2026-05-12) reads `currentResultsHash` for
+            // dedupe — the store carries that value at `results.hash`, not at
+            // the top level, so we splice it in here rather than widening the
+            // store shape upstream.
+            const v5StoreSnapshot = useCanvasStore.getState()
+            const stateApply = applyV5State(
+              target.response,
+              {
+                ...v5StoreSnapshot,
+                currentResultsHash: v5StoreSnapshot.results?.hash ?? null,
+              },
+              {
+                turnClientId,
+                currentClientTurnId: activeV5TurnIdRef.current,
+              },
+            )
             if (import.meta.env.DEV) {
               if (stateApply.applied.length > 0) {
                 console.warn('[sendTurn V5] state applied:', stateApply.applied)

--- a/src/components/results/__tests__/v5-analysis-to-results-panel.wire-to-selector.spec.ts
+++ b/src/components/results/__tests__/v5-analysis-to-results-panel.wire-to-selector.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * V5 analysis_result → Results panel selector wire-to-selector proof.
+ *
+ * Asserts the END-TO-END contract that the user-visible Results panel can
+ * actually consume V5-hydrated analysis data. The five-link chain:
+ *
+ *   1. Real staging V5 envelope (label-keyed win_probabilities + canonical
+ *      enrichment.option_comparison)
+ *        ↓
+ *   2. applyV5State step 5 ─ mapV5AnalysisToReport builds ReportV1
+ *        ↓
+ *   3. resultsComplete payload (report keyed by canonical option_id)
+ *        ↓
+ *   4. useCanvasStore.results.report
+ *        ↓
+ *   5. useResultsSectionData selector → allOptions[].winProbability
+ *
+ * Specifically asserts the field path the user told us must be tested:
+ *
+ *   report.option_probabilities[option_id].win_probability
+ *
+ * surfaces on the Results panel as `result.current.allOptions[id].winProbability`
+ * with the exact value from the staging envelope — no rounding, no defaults,
+ * no silent zeros, no synthesised opt_0/opt_1 keys.
+ *
+ * The chain catches the regression class the user warned about ("hydrating
+ * the wrong field can still leave the UI empty"). A label-keyed mapper
+ * output would silently produce zero matches when the selector reads
+ * `optionProbs[node.id]` (useResultsSectionData.ts:1042) — this test will
+ * fail loudly in that scenario.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+import { applyV5State, type V5ApplicatorStore } from '../../../v5/applyV5State'
+import { useCanvasStore } from '../../../canvas/store'
+import { useResultsSectionData } from '../useResultsSectionData'
+
+// Real staging V5 envelope (redacted, label-keyed win_probabilities). Same
+// fixture mapV5AnalysisToReport.test.ts uses for its real-payload assertions
+// — sharing the fixture ensures the selector and the mapper are tested
+// against identical wire shape. The fixture lives under src/v5/__tests__/
+// because the V5 mapper is the producing side; this test imports it via
+// relative path so the two cannot drift apart.
+import realStagingFixture from '../../../v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json'
+
+interface StagingFixtureBlock {
+  type: 'analysis_result'
+  summary: string
+  leading_option_id: string
+  win_probabilities: Record<string, number>
+  enrichment: {
+    option_comparison: Array<{
+      id?: string
+      option_id?: string
+      option_label?: string
+      win_probability?: number
+      outcome?: { mean?: number; p10?: number; p50?: number; p90?: number }
+    }>
+    [k: string]: unknown
+  }
+}
+
+describe('V5 analysis_result → Results panel selector wire-to-selector proof', () => {
+  beforeEach(() => {
+    // Reset the canvas store to a clean state. The seed below mirrors what
+    // the real V5 draft_graph path would produce: option nodes named with
+    // canonical option_ids that match enrichment.option_comparison[].id.
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 } as unknown as ReturnType<
+        typeof useCanvasStore.getState
+      >['results'],
+      runMeta: {} as ReturnType<typeof useCanvasStore.getState>['runMeta'],
+      nodes: [
+        // Option nodes: data.kind === 'option' is the gate at
+        // useResultsSectionData.ts:1043 (`optionNodes = nodes.filter(...)`)
+        {
+          id: 'opt_hire_local',
+          type: 'option',
+          position: { x: 0, y: 0 },
+          data: { kind: 'option', label: 'Hire Two Senior Engineers Locally' },
+        },
+        {
+          id: 'opt_offshore',
+          type: 'option',
+          position: { x: 0, y: 0 },
+          data: { kind: 'option', label: 'Engage Offshore Partner' },
+        },
+        {
+          id: 'opt_status_quo',
+          type: 'option',
+          position: { x: 0, y: 0 },
+          data: { kind: 'option', label: 'Maintain Current Team (Status Quo)' },
+        },
+        {
+          id: 'opt_tiered_pricing',
+          type: 'option',
+          position: { x: 0, y: 0 },
+          data: { kind: 'option', label: 'Introduce Tiered Pricing for Gradual Hiring' },
+        },
+      ] as unknown as ReturnType<typeof useCanvasStore.getState>['nodes'],
+      edges: [],
+      hasCompletedFirstRun: false,
+      currentScenarioFraming: null,
+      ceeAnalysisReady: undefined,
+    })
+  })
+
+  it('after applyV5State step 5, every option row exposes the exact win_probability from the staging fixture', () => {
+    // Build the OlumiResponse-shaped envelope by ferrying the fixture block.
+    const block = (realStagingFixture.blocks[0] as unknown) as StagingFixtureBlock
+    const envelope = {
+      response_version: 2,
+      assistant_text: realStagingFixture.assistant_text,
+      blocks: [block],
+      suggested_actions: [],
+      insights: [],
+      stage_indicator: 'analyse',
+    } as unknown as OlumiResponse
+
+    // Capture what applyV5State step 5 passes to resultsComplete. A partial
+    // store double — we do NOT invoke the real `useCanvasStore.resultsComplete`
+    // here because its side-effect chain (snapshot creation, scenarios.update,
+    // telemetry) is out of scope for this contract test. We just need the
+    // payload step 5 produces, then plumb it into the store via setState.
+    const captured: Array<{ report: unknown; hash: string }> = []
+    const applicatorStore: V5ApplicatorStore = {
+      setCurrentStage: vi.fn(),
+      updateNode: vi.fn(),
+      updateEdgeData: vi.fn(),
+      setRunMeta: vi.fn(),
+      setCeeAnalysisReady: vi.fn(),
+      nodes: [],
+      edges: [],
+      resultsComplete: (params) => {
+        captured.push({ report: params.report, hash: params.hash })
+      },
+      currentResultsHash: null,
+    }
+
+    const apply = applyV5State(envelope, applicatorStore)
+    expect(apply.applied).toContain('analysis_result:results_hydrated')
+    expect(captured).toHaveLength(1)
+
+    // Plumb the captured payload into the canvas store the same way the real
+    // resultsComplete action would (the parts useResultsSectionData reads).
+    const { report, hash } = captured[0]
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report,
+        hash,
+      } as unknown as ReturnType<typeof useCanvasStore.getState>['results'],
+      hasCompletedFirstRun: true,
+    } as Partial<ReturnType<typeof useCanvasStore.getState>>)
+
+    // Render the Results panel selector and verify exact win_probability
+    // surfaces per option_id.
+    const { result } = renderHook(() => useResultsSectionData())
+    const allOptions = result.current.recommendation.allOptions
+    expect(allOptions).toHaveLength(4)
+
+    const byId = new Map(allOptions.map((o) => [o.id, o]))
+    // EXACT values from real staging envelope — these are the field-path
+    // assertions the brief requires:
+    //   report.option_probabilities[option_id].win_probability
+    //     → OptionResult.winProbability
+    expect(byId.get('opt_hire_local')?.winProbability).toBe(0.7193333333333334)
+    expect(byId.get('opt_offshore')?.winProbability).toBe(0.054)
+    expect(byId.get('opt_status_quo')?.winProbability).toBe(0.22533333333333333)
+    expect(byId.get('opt_tiered_pricing')?.winProbability).toBe(0.0013333333333333333)
+  })
+
+  it('recommended option is opt_hire_local (highest win_probability, matches leading_option_id)', () => {
+    const block = (realStagingFixture.blocks[0] as unknown) as StagingFixtureBlock
+    const envelope = {
+      response_version: 2,
+      assistant_text: 'Analysis complete.',
+      blocks: [block],
+      suggested_actions: [],
+      insights: [],
+      stage_indicator: 'analyse',
+    } as unknown as OlumiResponse
+
+    const captured: Array<{ report: unknown; hash: string }> = []
+    const applicatorStore: V5ApplicatorStore = {
+      setCurrentStage: vi.fn(),
+      updateNode: vi.fn(),
+      updateEdgeData: vi.fn(),
+      setRunMeta: vi.fn(),
+      setCeeAnalysisReady: vi.fn(),
+      nodes: [],
+      edges: [],
+      resultsComplete: (params) => {
+        captured.push({ report: params.report, hash: params.hash })
+      },
+      currentResultsHash: null,
+    }
+    applyV5State(envelope, applicatorStore)
+
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: captured[0].report,
+        hash: captured[0].hash,
+      } as unknown as ReturnType<typeof useCanvasStore.getState>['results'],
+      hasCompletedFirstRun: true,
+    } as Partial<ReturnType<typeof useCanvasStore.getState>>)
+
+    const { result } = renderHook(() => useResultsSectionData())
+    const recommended = result.current.recommendation.recommendedOption
+    expect(recommended?.id).toBe('opt_hire_local')
+    expect(recommended?.winProbability).toBe(0.7193333333333334)
+  })
+
+  it('option labels in win_probabilities (e.g. "Hire Two Senior Engineers Locally") do NOT leak as synthetic option rows', () => {
+    // Regression guard: an earlier mapper draft keyed option_probabilities
+    // by win_probabilities keys verbatim — which in real staging are LABELS,
+    // not IDs. That would have produced "ghost" option entries (e.g. an
+    // entry keyed by "Hire Two Senior Engineers Locally") that the
+    // selector's `optionProbs[node.id]` lookup would silently miss while
+    // simultaneously polluting the store.
+    const block = (realStagingFixture.blocks[0] as unknown) as StagingFixtureBlock
+    const envelope = {
+      response_version: 2,
+      assistant_text: 'Analysis complete.',
+      blocks: [block],
+      suggested_actions: [],
+      insights: [],
+      stage_indicator: 'analyse',
+    } as unknown as OlumiResponse
+
+    const captured: Array<{ report: unknown; hash: string }> = []
+    const applicatorStore: V5ApplicatorStore = {
+      setCurrentStage: vi.fn(),
+      updateNode: vi.fn(),
+      updateEdgeData: vi.fn(),
+      setRunMeta: vi.fn(),
+      setCeeAnalysisReady: vi.fn(),
+      nodes: [],
+      edges: [],
+      resultsComplete: (params) => {
+        captured.push({ report: params.report, hash: params.hash })
+      },
+      currentResultsHash: null,
+    }
+    applyV5State(envelope, applicatorStore)
+
+    const report = captured[0].report as {
+      option_probabilities?: Record<string, unknown>
+    }
+    const keys = Object.keys(report.option_probabilities ?? {})
+    // All keys must be canonical option_ids — no human-language labels.
+    for (const key of keys) {
+      expect(key).toMatch(/^opt_/)
+      expect(key).not.toContain(' ')
+    }
+  })
+})

--- a/src/v5/__tests__/applyV5State.debug.test.ts
+++ b/src/v5/__tests__/applyV5State.debug.test.ts
@@ -61,12 +61,13 @@ describe('applyV5State [v5-state] debug logging', () => {
     vi.stubEnv('VITE_V5_STATE_DEBUG', 'true')
     applyV5State(makeMinimalAnalyseResponse(), makeStore())
     const calls = (infoSpy.mock.calls as unknown[][]).filter((c) => c[0] === '[v5-state]')
-    // 4 numbered steps, each logs exactly once per applyV5State invocation
-    expect(calls.length).toBe(4)
+    // 5 numbered steps, each logs exactly once per applyV5State invocation
+    // (step 5 is results hydration, added 2026-05-12)
+    expect(calls.length).toBe(5)
     const stepNumbers = calls
       .map((c) => (c[1] as { step_number: number }).step_number)
       .sort()
-    expect(stepNumbers).toEqual([1, 2, 3, 4])
+    expect(stepNumbers).toEqual([1, 2, 3, 4, 5])
   })
 
   it('never includes user text — only keys/counts/enum values', () => {

--- a/src/v5/__tests__/applyV5State.results-hydration.test.ts
+++ b/src/v5/__tests__/applyV5State.results-hydration.test.ts
@@ -1,0 +1,255 @@
+/**
+ * applyV5State — step 5 (results hydration) integration tests.
+ *
+ * Asserts the contract between applyV5State and store.resultsComplete when
+ * an analysis_result block arrives: build a ReportV1 via
+ * mapV5AnalysisToReport, hash-dedupe against currentResultsHash, write
+ * through resultsComplete with the V5 provenance string. Mirrors the V4
+ * envelope path's dedupe/source-tag conventions
+ * (useConversation.ts:1861-1895).
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+
+function baseResponse(overrides: Partial<OlumiResponse> = {}): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+    ...overrides,
+  }
+}
+
+function makeStore(
+  extras: Partial<V5ApplicatorStore> = {},
+): {
+  store: V5ApplicatorStore
+  resultsComplete: ReturnType<typeof vi.fn>
+  setRunMeta: ReturnType<typeof vi.fn>
+} {
+  const resultsComplete = vi.fn()
+  const setRunMeta = vi.fn()
+  return {
+    store: {
+      setCurrentStage: vi.fn(),
+      updateNode: vi.fn(),
+      updateEdgeData: vi.fn(),
+      setRunMeta,
+      setCeeAnalysisReady: vi.fn(),
+      resultsComplete,
+      nodes: [],
+      edges: [],
+      currentResultsHash: null,
+      ...extras,
+    },
+    resultsComplete,
+    setRunMeta,
+  }
+}
+
+const validAnalysisBlock = {
+  type: 'analysis_result' as const,
+  summary: 'A leads',
+  leading_option_id: 'opt_a',
+  win_probabilities: { opt_a: 0.64, opt_b: 0.36 },
+  enrichment: {
+    factor_sensitivity: [
+      { factor_id: 'fac_market', factor_label: 'Market', sensitivity: 0.4, direction: 'positive' as const },
+    ],
+  },
+}
+
+describe('applyV5State — step 5: results hydration', () => {
+  it('calls resultsComplete exactly once for a well-formed analysis_result block', () => {
+    const { store, resultsComplete } = makeStore()
+    const result = applyV5State(
+      baseResponse({ blocks: [validAnalysisBlock], stage_indicator: 'analyse' }),
+      store,
+    )
+
+    expect(resultsComplete).toHaveBeenCalledTimes(1)
+    expect(result.applied).toContain('analysis_result:results_hydrated')
+  })
+
+  it('passes resultsSource: "conversation" and null V2-shaped fields (enrichment, rawV2Response)', () => {
+    const { store, resultsComplete } = makeStore()
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+
+    const callArgs = resultsComplete.mock.calls[0]?.[0] as {
+      resultsSource: string
+      enrichment: unknown
+      rawV2Response: unknown
+    }
+    expect(callArgs.resultsSource).toBe('conversation')
+    expect(callArgs.enrichment).toBeNull()
+    expect(callArgs.rawV2Response).toBeNull()
+  })
+
+  it('hydrated report carries option_probabilities keyed exactly by win_probabilities keys', () => {
+    const { store, resultsComplete } = makeStore()
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+
+    const callArgs = resultsComplete.mock.calls[0]?.[0] as {
+      report: { option_probabilities?: Record<string, { win_probability?: number }> }
+    }
+    expect(callArgs.report.option_probabilities).toBeDefined()
+    const keys = Object.keys(callArgs.report.option_probabilities!).sort()
+    expect(keys).toEqual(['opt_a', 'opt_b'])
+    expect(callArgs.report.option_probabilities!.opt_a.win_probability).toBe(0.64)
+    expect(callArgs.report.option_probabilities!.opt_b.win_probability).toBe(0.36)
+  })
+
+  it('hydrated report carries factor_sensitivity from enrichment', () => {
+    const { store, resultsComplete } = makeStore()
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+
+    const callArgs = resultsComplete.mock.calls[0]?.[0] as {
+      report: { factor_sensitivity?: Array<{ factor_id: string; sensitivity: number }> }
+    }
+    expect(callArgs.report.factor_sensitivity).toBeDefined()
+    expect(callArgs.report.factor_sensitivity![0].factor_id).toBe('fac_market')
+    expect(callArgs.report.factor_sensitivity![0].sensitivity).toBe(0.4)
+  })
+
+  it('passes a stable response_hash to resultsComplete (used for dedupe)', () => {
+    const { store, resultsComplete } = makeStore()
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+
+    const callArgs = resultsComplete.mock.calls[0]?.[0] as { hash: string; report: { model_card: { response_hash: string } } }
+    expect(callArgs.hash).toMatch(/^v5:[0-9a-f]{16}$/)
+    expect(callArgs.hash).toBe(callArgs.report.model_card.response_hash)
+  })
+
+  it('skips the write when currentResultsHash matches the new block hash (dedupe)', () => {
+    // First call: compute hash and capture it
+    const { store: probeStore, resultsComplete: probeResultsComplete } = makeStore()
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), probeStore)
+    const observedHash = probeResultsComplete.mock.calls[0]?.[0]?.hash as string
+
+    // Second call: provide that same hash as currentResultsHash → no write
+    const { store, resultsComplete } = makeStore({ currentResultsHash: observedHash })
+    const result = applyV5State(
+      baseResponse({ blocks: [validAnalysisBlock] }),
+      store,
+    )
+
+    expect(resultsComplete).not.toHaveBeenCalled()
+    expect(result.applied).not.toContain('analysis_result:results_hydrated')
+  })
+
+  it('emits when currentResultsHash differs from the new block hash', () => {
+    const { store, resultsComplete } = makeStore({ currentResultsHash: 'v5:0000000000000000' })
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+    expect(resultsComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call resultsComplete when the response has no analysis_result block', () => {
+    const { store, resultsComplete } = makeStore()
+    const result = applyV5State(
+      baseResponse({
+        blocks: [{ type: 'text', content: 'hi' }],
+        stage_indicator: 'frame',
+      }),
+      store,
+    )
+
+    expect(resultsComplete).not.toHaveBeenCalled()
+    expect(result.applied).not.toContain('analysis_result:results_hydrated')
+  })
+
+  it('defers (records reason, does not throw) when store omits resultsComplete', () => {
+    // Minimal store without resultsComplete — applicator should not crash.
+    const minimalStore: V5ApplicatorStore = {
+      setCurrentStage: vi.fn(),
+      updateNode: vi.fn(),
+      updateEdgeData: vi.fn(),
+      setRunMeta: vi.fn(),
+      setCeeAnalysisReady: vi.fn(),
+      nodes: [],
+      edges: [],
+      // resultsComplete intentionally omitted
+    }
+
+    const result = applyV5State(
+      baseResponse({ blocks: [validAnalysisBlock] }),
+      minimalStore,
+    )
+
+    expect(result.applied).not.toContain('analysis_result:results_hydrated')
+    const deferredReasons = result.deferred.map((d) => d.reason)
+    expect(deferredReasons).toContain('results_hydration_store_lacks_resultsComplete')
+  })
+
+  it('preserves existing step 2 decision_review write (setRunMeta still called when enrichment has decision_review)', () => {
+    const { store, resultsComplete, setRunMeta } = makeStore()
+    applyV5State(
+      baseResponse({
+        blocks: [
+          {
+            ...validAnalysisBlock,
+            enrichment: {
+              ...validAnalysisBlock.enrichment,
+              decision_review: {
+                intent: 'selection',
+                analysis_state: 'ran',
+                readiness: { level: 'ready', headline: 'Go', factors: [] },
+                blocks: [],
+              },
+            },
+          },
+        ],
+      }),
+      store,
+    )
+
+    // Step 2 wrote ceeReviewV1
+    expect(setRunMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ceeReviewV1: expect.objectContaining({ intent: 'selection' }),
+      }),
+    )
+    // Step 5 wrote results
+    expect(resultsComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('stale-turn guard prevents results hydration (no resultsComplete call)', () => {
+    const { store, resultsComplete } = makeStore()
+    const result = applyV5State(
+      baseResponse({ blocks: [validAnalysisBlock] }),
+      store,
+      { turnClientId: 'old', currentClientTurnId: 'new' },
+    )
+
+    expect(resultsComplete).not.toHaveBeenCalled()
+    expect(result.applied).toEqual([])
+    expect(result.deferred[0]?.reason).toBe('stale_turn_all_writes_skipped')
+  })
+
+  it('confidence level derived from robustness.fragile_edges vs robust_edges ratio', () => {
+    const { store, resultsComplete } = makeStore()
+    const blockWithRobustness = {
+      ...validAnalysisBlock,
+      enrichment: {
+        ...validAnalysisBlock.enrichment,
+        robustness: {
+          fragile_edges: ['e1'],
+          robust_edges: ['e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8', 'e9'],
+        },
+      },
+    }
+    applyV5State(baseResponse({ blocks: [blockWithRobustness] }), store)
+
+    const callArgs = resultsComplete.mock.calls[0]?.[0] as {
+      report: { confidence: { level: string; why: string } }
+    }
+    expect(callArgs.report.confidence.level).toBe('high')
+    expect(callArgs.report.confidence.why).toContain('1 fragile edge')
+    expect(callArgs.report.confidence.why).toContain('8 robust edges')
+  })
+})

--- a/src/v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json
+++ b/src/v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json
@@ -1,0 +1,246 @@
+{
+  "__source__": "Redacted from olumi-assistants-service-cee-ws1/tests/fixtures/cross-service/v5-turn.run-analysis.staging.json",
+  "__captured_at__": "2026-04-30T15:18:13.322Z",
+  "__captured_against__": "cee-staging.onrender.com / build 3bb151b",
+  "__notes__": "block.win_probabilities is keyed by option LABELS in real staging (not option_ids). enrichment.option_comparison provides the canonical option_id <-> option_label mapping. This fixture proves the mapper resolves label-keyed win_probabilities to id-keyed option_probabilities via option_comparison lookup.",
+  "response_version": 2,
+  "assistant_text": "Ran analysis on your current scenario.",
+  "blocks": [
+    {
+      "type": "analysis_result",
+      "summary": "Ran analysis on your current scenario.",
+      "leading_option_id": "opt_hire_local",
+      "win_probabilities": {
+        "Hire Two Senior Engineers Locally": 0.7193333333333334,
+        "Engage Offshore Partner": 0.054,
+        "Maintain Current Team (Status Quo)": 0.22533333333333333,
+        "Introduce Tiered Pricing for Gradual Hiring": 0.0013333333333333333
+      },
+      "enrichment": {
+        "option_comparison": [
+          {
+            "id": "opt_hire_local",
+            "option_id": "opt_hire_local",
+            "option_label": "Hire Two Senior Engineers Locally",
+            "win_probability": 0.7193333333333334,
+            "outcome": {
+              "mean": 0.23738816930471338,
+              "std": 0.2038227722573291,
+              "p10": -0.032343256259984,
+              "p50": 0.25567048396546965,
+              "p90": 0.4781610864397162,
+              "n_samples": 1000,
+              "n_valid_samples": 1000,
+              "validity_ratio": 1
+            }
+          },
+          {
+            "id": "opt_offshore",
+            "option_id": "opt_offshore",
+            "option_label": "Engage Offshore Partner",
+            "win_probability": 0.054,
+            "outcome": {
+              "mean": -0.018731465612763915,
+              "std": 0.23564911160953672,
+              "p10": -0.33661857408479445,
+              "p50": -0.008841477119347269,
+              "p90": 0.2731568353844233,
+              "n_samples": 1000,
+              "n_valid_samples": 1000,
+              "validity_ratio": 1
+            }
+          },
+          {
+            "id": "opt_status_quo",
+            "option_id": "opt_status_quo",
+            "option_label": "Maintain Current Team (Status Quo)",
+            "win_probability": 0.22533333333333333,
+            "outcome": {
+              "mean": 0.1532310946292253,
+              "std": 0.08239545291341459,
+              "p10": 0.0414029025062178,
+              "p50": 0.1600100924568532,
+              "p90": 0.25588875563055646,
+              "n_samples": 1000,
+              "n_valid_samples": 1000,
+              "validity_ratio": 1
+            }
+          },
+          {
+            "id": "opt_tiered_pricing",
+            "option_id": "opt_tiered_pricing",
+            "option_label": "Introduce Tiered Pricing for Gradual Hiring",
+            "win_probability": 0.0013333333333333333,
+            "outcome": {
+              "mean": 0.14956494518602742,
+              "std": 0.12261773920425771,
+              "p10": -0.014252341936082205,
+              "p50": 0.15983345417333378,
+              "p90": 0.2991353629850236,
+              "n_samples": 1000,
+              "n_valid_samples": 1000,
+              "validity_ratio": 1
+            }
+          }
+        ],
+        "factor_sensitivity": [
+          {
+            "factor_id": "fac_eng_capacity",
+            "factor_label": "Engineering Capacity",
+            "sensitivity_score": 0.43249999999999994,
+            "elasticity": 1,
+            "direction": "positive",
+            "importance_rank": 1
+          },
+          {
+            "factor_id": "fac_offshore",
+            "factor_label": "Offshore Engagement",
+            "sensitivity_score": -0.33599999999999997,
+            "elasticity": 0.7768786127167631,
+            "direction": "negative",
+            "importance_rank": 2
+          },
+          {
+            "factor_id": "fac_talent_market",
+            "factor_label": "Local Talent Market Tightness",
+            "sensitivity_score": -0.23249999999999998,
+            "elasticity": 0.5375722543352601,
+            "direction": "negative",
+            "importance_rank": 3
+          }
+        ],
+        "robustness": {
+          "fragile_edges": [
+            {
+              "edge_id": "fac_eng_capacity->out_delivery_throughput",
+              "from_id": "fac_eng_capacity",
+              "to_id": "out_delivery_throughput",
+              "switch_probability": 0.452,
+              "marginal_switch_probability": 0.09,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Engineering Capacity",
+              "to_label": "Q3 Roadmap Delivery Throughput",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "out_delivery_throughput->goal_q3_delivery",
+              "from_id": "out_delivery_throughput",
+              "to_id": "goal_q3_delivery",
+              "switch_probability": 0.388,
+              "marginal_switch_probability": 0.09,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Q3 Roadmap Delivery Throughput",
+              "to_label": "Deliver Q3 Roadmap Commitments",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "fac_hiring_cost->risk_cost_overrun",
+              "from_id": "fac_hiring_cost",
+              "to_id": "risk_cost_overrun",
+              "switch_probability": 0.084,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Hiring and Staffing Cost",
+              "to_label": "Budget Overrun Risk",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "risk_cost_overrun->goal_q3_delivery",
+              "from_id": "risk_cost_overrun",
+              "to_id": "goal_q3_delivery",
+              "switch_probability": 0.432,
+              "marginal_switch_probability": 0.16,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Budget Overrun Risk",
+              "to_label": "Deliver Q3 Roadmap Commitments",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "out_team_quality->goal_q3_delivery",
+              "from_id": "out_team_quality",
+              "to_id": "goal_q3_delivery",
+              "switch_probability": 0.24,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Team Capability and Code Quality",
+              "to_label": "Deliver Q3 Roadmap Commitments",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "risk_onboarding_delay->goal_q3_delivery",
+              "from_id": "risk_onboarding_delay",
+              "to_id": "goal_q3_delivery",
+              "switch_probability": 0.288,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Onboarding and Ramp-Up Delay",
+              "to_label": "Deliver Q3 Roadmap Commitments",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "fac_eng_capacity->risk_onboarding_delay",
+              "from_id": "fac_eng_capacity",
+              "to_id": "risk_onboarding_delay",
+              "switch_probability": 0.16,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Engineering Capacity",
+              "to_label": "Onboarding and Ramp-Up Delay",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "fac_eng_capacity->out_team_quality",
+              "from_id": "fac_eng_capacity",
+              "to_id": "out_team_quality",
+              "switch_probability": 0.316,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Engineering Capacity",
+              "to_label": "Team Capability and Code Quality",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            },
+            {
+              "edge_id": "risk_coordination->goal_q3_delivery",
+              "from_id": "risk_coordination",
+              "to_id": "goal_q3_delivery",
+              "switch_probability": 0.196,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_status_quo",
+              "from_label": "Offshore Coordination Failure",
+              "to_label": "Deliver Q3 Roadmap Commitments",
+              "severity": "warning",
+              "alternative_winner_label": "Maintain Current Team (Status Quo)"
+            }
+          ],
+          "robust_edges": [
+            {
+              "edge_id": "fac_offshore->out_delivery_throughput",
+              "from_id": "fac_offshore",
+              "to_id": "out_delivery_throughput",
+              "switch_probability": 1,
+              "from_label": "Offshore Engagement",
+              "to_label": "Q3 Roadmap Delivery Throughput",
+              "alternative_winner_id": null,
+              "alternative_winner_label": null
+            }
+          ],
+          "is_robust": true,
+          "level": "moderate",
+          "recommendation_stability": 0.7193333333333334,
+          "recommended_option_id": "opt_hire_local"
+        }
+      }
+    }
+  ],
+  "suggested_actions": [],
+  "insights": [],
+  "stage_indicator": "analyse"
+}

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -652,14 +652,22 @@ describe('mapV5AnalysisToReport — duplicate-label edge case', () => {
     expect(report.option_probabilities!.opt_a2.win_probability).toBe(0.3)
   })
 
-  it('path A degraded: when option_comparison entries lack win_probability AND two share the same label, both fall back to the same block.win_probabilities[label] value (acknowledged limitation)', () => {
-    // This is the genuine edge case: option_comparison present but entries
-    // omit win_probability, so we fall through to block.win_probabilities[
-    // option_label] — and two options sharing a label collide. This is a
-    // backend-side data-quality issue (option_comparison entries SHOULD
-    // carry their own win_probability when win_probabilities is
-    // label-keyed); the mapper preserves honest behaviour rather than
-    // synthesising a delta.
+  it('path A degraded: when option_comparison entries lack win_probability AND two share the same label, BOTH omit win_probability (no false precision)', () => {
+    // The genuine edge case: option_comparison present but entries omit
+    // win_probability, AND two options share an option_label.
+    //
+    // The label-keyed block.win_probabilities Record cannot disambiguate
+    // two options that share a label. Earlier drafts of this mapper let
+    // BOTH options fall through to block.win_probabilities[label] and
+    // each receive the same value — false precision from ambiguous data.
+    //
+    // The mapper now detects label duplication among option_comparison
+    // entries and skips the label-keyed fallback for any duplicated
+    // label. The two options surface with NO win_probability, which is
+    // the honest representation: "we cannot tell which option this
+    // 0.6 belongs to". Backend should populate
+    // option_comparison.win_probability per option when this
+    // configuration is possible.
     const block: AnalysisResultBlock = {
       type: 'analysis_result',
       summary: '',
@@ -676,12 +684,44 @@ describe('mapV5AnalysisToReport — duplicate-label edge case', () => {
     const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
       option_probabilities?: Record<string, { win_probability?: number }>
     }
-    // Both options collapse to the same value — the mapper does not invent
-    // a tie-break. Acknowledged limitation; backend should populate
-    // option_comparison.win_probability per option when this configuration
-    // is possible.
-    expect(report.option_probabilities!.opt_a1.win_probability).toBe(0.6)
-    expect(report.option_probabilities!.opt_a2.win_probability).toBe(0.6)
+    // Both option entries exist but win_probability is omitted on each.
+    expect(report.option_probabilities!.opt_a1).toBeDefined()
+    expect(report.option_probabilities!.opt_a2).toBeDefined()
+    expect(report.option_probabilities!.opt_a1.win_probability).toBeUndefined()
+    expect(report.option_probabilities!.opt_a2.win_probability).toBeUndefined()
+  })
+
+  it('path A mixed: when one duplicate-label entry has its own win_probability and the other does not, only the explicit one renders', () => {
+    // Regression guard for the duplicate-label fix. A per-entry
+    // win_probability is canonical and trumps the duplicate-label
+    // ambiguity check; the entry that lacks one must still omit.
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a1',
+      win_probabilities: { 'Hire Locally': 0.6 },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a1', option_id: 'opt_a1', option_label: 'Hire Locally', win_probability: 0.55 },
+          { id: 'opt_a2', option_id: 'opt_a2', option_label: 'Hire Locally' /* no win_probability */ },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+      option_comparison?: Array<{ option_id: string; win_probability?: number }>
+    }
+    // Explicit entry: uses its own canonical value.
+    expect(report.option_probabilities!.opt_a1.win_probability).toBe(0.55)
+    // Ambiguous-label entry: omitted, not silently set to 0.6.
+    expect(report.option_probabilities!.opt_a2.win_probability).toBeUndefined()
+
+    // Same guarantee applies to the inspector OutcomePanel passthrough.
+    const ocByOptId = new Map(
+      report.option_comparison!.map((o) => [o.option_id, o]),
+    )
+    expect(ocByOptId.get('opt_a1')?.win_probability).toBe(0.55)
+    expect(ocByOptId.get('opt_a2')?.win_probability).toBeUndefined()
   })
 
   it('path B: option_comparison absent AND label-keyed win_probabilities — labels survive as Record keys with no disambiguation (Results panel honestly misses by node.id)', () => {

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -1,0 +1,609 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+// Real staging V5 envelope captured 2026-04-30 against cee-staging.onrender.com
+// (redacted excerpt of olumi-assistants-service-cee-ws1/tests/fixtures/
+// cross-service/v5-turn.run-analysis.staging.json). The defining shape
+// characteristic: block.win_probabilities is keyed by option LABELS, not
+// option IDs — the mapper must resolve label-keys to canonical option_ids
+// via enrichment.option_comparison so the Results panel selector
+// (useResultsSectionData.ts:1042 reads `optionProbs[canvas_node_id]`) hits.
+import realStagingFixture from './fixtures/v5-analysis-result.staging-real-shape.json'
+
+const baseBlock = (overrides: Partial<AnalysisResultBlock> = {}): AnalysisResultBlock => ({
+  type: 'analysis_result',
+  summary: 'Option A leads',
+  leading_option_id: 'opt_a',
+  ...overrides,
+})
+
+describe('mapV5AnalysisToReport — option IDs and probabilities', () => {
+  it('option_probabilities keys match win_probabilities keys exactly (no synthesised opt_0/opt_1)', () => {
+    const block = baseBlock({
+      win_probabilities: { opt_a: 0.64, opt_b: 0.36 },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number; confidence: number }>
+    }
+
+    expect(report.option_probabilities).toBeDefined()
+    const keys = Object.keys(report.option_probabilities!).sort()
+    expect(keys).toEqual(['opt_a', 'opt_b'])
+    expect(report.option_probabilities!.opt_a?.win_probability).toBe(0.64)
+    expect(report.option_probabilities!.opt_b?.win_probability).toBe(0.36)
+  })
+
+  it('missing probability surfaces as undefined, never as silent 0', () => {
+    // Enrichment.option_comparison lists a third option that win_probabilities
+    // omits — its win_probability must be undefined, not 0.
+    const block = baseBlock({
+      win_probabilities: { opt_a: 0.5, opt_b: 0.5 },
+      enrichment: {
+        option_comparison: [
+          { option_id: 'opt_c' /* no win_probability */ },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    expect(report.option_probabilities!.opt_c).toBeDefined()
+    expect(report.option_probabilities!.opt_c.win_probability).toBeUndefined()
+  })
+
+  it('omits option_probabilities when block has neither win_probabilities nor enrichment.option_comparison', () => {
+    const block = baseBlock({ leading_option_id: null })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, unknown>
+    }
+    expect(report.option_probabilities).toBeUndefined()
+  })
+
+  it('leading_option_id: null is supported without crashing or injecting synthetic primary', () => {
+    const block = baseBlock({ leading_option_id: null, win_probabilities: { opt_a: 0.5 } })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      leading_option_id?: string
+    }
+    expect(report.leading_option_id).toBeUndefined()
+    expect(report.option_probabilities).toBeDefined()
+  })
+})
+
+describe('mapV5AnalysisToReport — factor sensitivity (dual shape, alias set)', () => {
+  it('top-level enrichment.factor_sensitivity is collected with {factor_id, factor_label, sensitivity, direction}', () => {
+    const block = baseBlock({
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_market', factor_label: 'Market size', sensitivity: 0.42, direction: 'positive' },
+          { factor_id: 'fac_comp', factor_label: 'Competition', sensitivity: 0.21, direction: 'negative' },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: Array<{ factor_id: string; factor_label: string; sensitivity: number; direction: string }>
+    }
+    expect(report.factor_sensitivity).toEqual([
+      { factor_id: 'fac_market', factor_label: 'Market size', sensitivity: 0.42, direction: 'positive' },
+      { factor_id: 'fac_comp', factor_label: 'Competition', sensitivity: 0.21, direction: 'negative' },
+    ])
+  })
+
+  it('per-result enrichment.results[].factor_sensitivity is also collected', () => {
+    const block = baseBlock({
+      enrichment: {
+        results: [
+          {
+            option_id: 'opt_a',
+            factor_sensitivity: [
+              { factor_id: 'fac_x', factor_label: 'X', sensitivity: 0.31, direction: 'positive' },
+            ],
+          },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: Array<{ factor_id: string }>
+    }
+    expect(report.factor_sensitivity).toBeDefined()
+    expect(report.factor_sensitivity!.map((f) => f.factor_id)).toContain('fac_x')
+  })
+
+  it('mixed top-level + per-result: same factor_id deduped, higher magnitude wins', () => {
+    const block = baseBlock({
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_shared', label: 'Shared', sensitivity: 0.20 },
+        ],
+        results: [
+          {
+            option_id: 'opt_a',
+            factor_sensitivity: [
+              { factor_id: 'fac_shared', label: 'Shared', sensitivity: 0.55 },
+            ],
+          },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: Array<{ factor_id: string; sensitivity: number }>
+    }
+    expect(report.factor_sensitivity).toHaveLength(1)
+    expect(report.factor_sensitivity![0].sensitivity).toBe(0.55)
+  })
+
+  it('alias set: {label, elasticity} and {factor_label, sensitivity_score} both normalise', () => {
+    const block = baseBlock({
+      enrichment: {
+        factor_sensitivity: [
+          { label: 'Legacy', elasticity: 0.4, direction: 'positive' },
+          { factor_label: 'ISL', sensitivity_score: 0.6, node_id: 'fac_isl' },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: Array<{ factor_id: string; factor_label: string; sensitivity: number; direction: string }>
+    }
+    expect(report.factor_sensitivity).toBeDefined()
+    const byLabel = new Map(report.factor_sensitivity!.map((f) => [f.factor_label, f]))
+    expect(byLabel.get('Legacy')?.sensitivity).toBe(0.4)
+    expect(byLabel.get('Legacy')?.direction).toBe('positive')
+    expect(byLabel.get('ISL')?.sensitivity).toBe(0.6)
+    expect(byLabel.get('ISL')?.factor_id).toBe('fac_isl')
+  })
+
+  it('direction defaults to sign of magnitude when missing', () => {
+    const block = baseBlock({
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_pos', label: 'Positive', sensitivity: 0.3 },
+          { factor_id: 'fac_neg', label: 'Negative', sensitivity: -0.2 },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: Array<{ factor_id: string; sensitivity: number; direction: string }>
+    }
+    const byId = new Map(report.factor_sensitivity!.map((f) => [f.factor_id, f]))
+    expect(byId.get('fac_pos')?.direction).toBe('positive')
+    expect(byId.get('fac_pos')?.sensitivity).toBe(0.3) // absolute value
+    expect(byId.get('fac_neg')?.direction).toBe('negative')
+    expect(byId.get('fac_neg')?.sensitivity).toBe(0.2) // absolute value
+  })
+
+  it('entries missing both id and magnitude are dropped, never defaulted', () => {
+    const block = baseBlock({
+      enrichment: {
+        factor_sensitivity: [
+          {}, // no id, no magnitude
+          { factor_id: 'fac_a' /* no magnitude */ },
+          { sensitivity: 0.5 /* no id */ },
+          { factor_id: 'fac_b', sensitivity: 0.4 }, // valid
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: Array<{ factor_id: string }>
+    }
+    expect(report.factor_sensitivity).toHaveLength(1)
+    expect(report.factor_sensitivity![0].factor_id).toBe('fac_b')
+  })
+
+  it('omits factor_sensitivity entirely when enrichment has none (no empty-array placeholder)', () => {
+    const block = baseBlock({ enrichment: { factor_sensitivity: [] } })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: unknown
+    }
+    expect(report.factor_sensitivity).toBeUndefined()
+  })
+})
+
+describe('mapV5AnalysisToReport — drivers + confidence derivation', () => {
+  it('drivers derived from top 5 factors by absolute sensitivity', () => {
+    const block = baseBlock({
+      enrichment: {
+        factor_sensitivity: Array.from({ length: 8 }, (_, i) => ({
+          factor_id: `fac_${i}`,
+          factor_label: `Factor ${i}`,
+          sensitivity: 0.1 + i * 0.1, // 0.1, 0.2, ..., 0.8
+          direction: 'positive',
+        })),
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block)
+    expect(report.drivers).toHaveLength(5)
+    // Sorted descending by sensitivity, so top driver is fac_7
+    expect(report.drivers[0].label).toBe('Factor 7')
+    expect(report.drivers[0].polarity).toBe('up')
+    expect(report.drivers[0].strength).toBe('high') // 0.8 >= 0.7
+    expect(report.drivers[0].nodeId).toBe('fac_7')
+  })
+
+  it('confidence level "high" when robust:fragile edge ratio >= 0.7', () => {
+    const block = baseBlock({
+      enrichment: {
+        robustness: {
+          fragile_edges: ['e1'],
+          robust_edges: ['e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8', 'e9', 'e10'],
+        },
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block)
+    expect(report.confidence.level).toBe('high')
+    expect(report.confidence.why).toContain('1 fragile edge')
+    expect(report.confidence.why).toContain('9 robust edges')
+  })
+
+  it('confidence level "low" when robust:fragile ratio < 0.3', () => {
+    const block = baseBlock({
+      enrichment: {
+        robustness: {
+          fragile_edges: ['e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8'],
+          robust_edges: ['e9'],
+        },
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block)
+    expect(report.confidence.level).toBe('low')
+  })
+
+  it('confidence level "medium" with informative reason when only factors are present (no robustness)', () => {
+    const block = baseBlock({
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_a', label: 'A', sensitivity: 0.4 },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block)
+    expect(report.confidence.level).toBe('medium')
+    expect(report.confidence.why).toContain('1 sensitivity factor')
+  })
+
+  it('confidence fallback "Based on available data" when nothing present', () => {
+    const block = baseBlock({})
+
+    const report = mapV5AnalysisToReport(block)
+    expect(report.confidence.level).toBe('medium')
+    expect(report.confidence.why).toBe('Based on available data')
+  })
+})
+
+describe('mapV5AnalysisToReport — robustness + flip_thresholds + edge_e_values passthrough', () => {
+  it('robustness passes through fragile_edges, robust_edges, flip_thresholds, edge_e_values, ranking_stability', () => {
+    const block = baseBlock({
+      enrichment: {
+        robustness: {
+          fragile_edges: [{ edge_id: 'e1' }],
+          robust_edges: ['e2'],
+          ranking_stability: 0.85,
+          recommendation_stability: 0.9,
+          is_robust: true,
+          level: 'high',
+          recommended_option_id: 'opt_a',
+          flip_thresholds: [{ factor_id: 'fac_a', flip_at: 0.5 }],
+          edge_e_values: [{ edge_id: 'e1', e_value: 0.3 }],
+        },
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      robustness?: Record<string, unknown>
+    }
+    expect(report.robustness).toBeDefined()
+    expect(report.robustness!.fragile_edges).toEqual([{ edge_id: 'e1' }])
+    expect(report.robustness!.robust_edges).toEqual(['e2'])
+    expect(report.robustness!.ranking_stability).toBe(0.85)
+    expect(report.robustness!.recommendation_stability).toBe(0.9)
+    expect(report.robustness!.is_robust).toBe(true)
+    expect(report.robustness!.level).toBe('high')
+    expect(report.robustness!.recommended_option_id).toBe('opt_a')
+    expect(report.robustness!.flip_thresholds).toEqual([{ factor_id: 'fac_a', flip_at: 0.5 }])
+    expect(report.robustness!.edge_e_values).toEqual([{ edge_id: 'e1', e_value: 0.3 }])
+  })
+
+  it('top-level enrichment.flip_thresholds and enrichment.edge_e_values surface on the report', () => {
+    const block = baseBlock({
+      enrichment: {
+        flip_thresholds: [{ factor_id: 'fac_top', flip_at: 0.42 }],
+        edge_e_values: [{ edge_id: 'e_top', e_value: 0.71 }],
+        conditional_probabilities: { 'opt_a': 0.7 },
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      flip_thresholds?: unknown[]
+      edge_e_values?: unknown[]
+      conditional_probabilities?: unknown
+    }
+    expect(report.flip_thresholds).toEqual([{ factor_id: 'fac_top', flip_at: 0.42 }])
+    expect(report.edge_e_values).toEqual([{ edge_id: 'e_top', e_value: 0.71 }])
+    expect(report.conditional_probabilities).toEqual({ 'opt_a': 0.7 })
+  })
+
+  it('robustness absent when enrichment.robustness is missing or non-object', () => {
+    const block = baseBlock({ enrichment: {} })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      robustness?: unknown
+    }
+    expect(report.robustness).toBeUndefined()
+  })
+})
+
+describe('mapV5AnalysisToReport — enrichment.option_comparison hydrates outcome/CI fields', () => {
+  it('outcome.mean/p10/p50/p90 flow from enrichment.option_comparison entries when present', () => {
+    const block = baseBlock({
+      win_probabilities: { opt_a: 0.6 },
+      enrichment: {
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            outcome: { mean: 12.5, p10: 8.0, p50: 12.0, p90: 17.0 },
+            confidence_interval: [9.0, 16.0],
+            probability_of_goal: 0.55,
+            expected_outcome: 12.5,
+          },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, {
+        win_probability?: number
+        goal_probability?: number
+        expected?: number
+        outcome?: { mean?: number | null; p10?: number | null; p50?: number | null; p90?: number | null }
+      }>
+    }
+    const opt = report.option_probabilities!.opt_a
+    expect(opt.win_probability).toBe(0.6)
+    expect(opt.goal_probability).toBe(0.55)
+    expect(opt.expected).toBe(12.5)
+    expect(opt.outcome).toEqual({ mean: 12.5, p10: 8.0, p50: 12.0, p90: 17.0 })
+  })
+
+  it('confidence_interval midpoint fills `expected` when outcome.mean is absent', () => {
+    const block = baseBlock({
+      win_probabilities: { opt_a: 0.5 },
+      enrichment: {
+        option_comparison: [
+          { option_id: 'opt_a', confidence_interval: [10, 20] },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { expected?: number; outcome?: { p10?: number | null; p90?: number | null } }>
+    }
+    const opt = report.option_probabilities!.opt_a
+    expect(opt.expected).toBe(15)
+    expect(opt.outcome?.p10).toBe(10)
+    expect(opt.outcome?.p90).toBe(20)
+  })
+
+  it('outcome quantiles are null (not 0) when enrichment has no option_comparison', () => {
+    const block = baseBlock({
+      win_probabilities: { opt_a: 0.5 },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { outcome?: { mean?: number | null; p10?: number | null; p50?: number | null; p90?: number | null } }>
+    }
+    const opt = report.option_probabilities!.opt_a
+    expect(opt.outcome).toEqual({ mean: null, p10: null, p50: null, p90: null })
+  })
+})
+
+describe('mapV5AnalysisToReport — real staging payload (label-keyed win_probabilities)', () => {
+  // The fixture is a redacted excerpt of the actual staging envelope captured
+  // 2026-04-30 / build 3bb151b. It encodes the specific shape that broke the
+  // first-pass mapper: win_probabilities keyed by option labels rather than
+  // option IDs. Without enrichment.option_comparison lookup, the Results
+  // panel would silently miss every entry.
+  const block = realStagingFixture.blocks[0] as AnalysisResultBlock
+
+  it('option_probabilities is keyed by canonical option_id (not by win_probabilities label-keys)', () => {
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    const keys = Object.keys(report.option_probabilities ?? {}).sort()
+    // Real option_ids from enrichment.option_comparison, NOT the human labels
+    // (e.g. "Hire Two Senior Engineers Locally") that win_probabilities uses
+    // as keys.
+    expect(keys).toEqual(['opt_hire_local', 'opt_offshore', 'opt_status_quo', 'opt_tiered_pricing'])
+    // No label-keyed entries leaked through.
+    expect(report.option_probabilities!['Hire Two Senior Engineers Locally']).toBeUndefined()
+  })
+
+  it('win_probability resolves correctly from label-keyed win_probabilities via option_comparison.option_label', () => {
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    // Exact values from the captured staging response — NOT rounded, NOT
+    // approximated. This is the field the Results panel reads at
+    // useResultsSectionData.ts:1146 (`prob.win_probability`).
+    expect(report.option_probabilities!.opt_hire_local.win_probability).toBe(0.7193333333333334)
+    expect(report.option_probabilities!.opt_offshore.win_probability).toBe(0.054)
+    expect(report.option_probabilities!.opt_status_quo.win_probability).toBe(0.22533333333333333)
+    expect(report.option_probabilities!.opt_tiered_pricing.win_probability).toBe(0.0013333333333333333)
+  })
+
+  it('outcome quantiles flow through from enrichment.option_comparison[*].outcome (real staging shape)', () => {
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, {
+        outcome?: { mean?: number | null; p10?: number | null; p50?: number | null; p90?: number | null }
+      }>
+    }
+    const winner = report.option_probabilities!.opt_hire_local
+    // Real staging outcome values — preserved exactly.
+    expect(winner.outcome).toEqual({
+      mean: 0.23738816930471338,
+      p10: -0.032343256259984,
+      p50: 0.25567048396546965,
+      p90: 0.4781610864397162,
+    })
+  })
+
+  it('factor_sensitivity passes through with real {factor_id, factor_label, sensitivity_score, direction, importance_rank}', () => {
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      factor_sensitivity?: Array<{ factor_id: string; factor_label: string; sensitivity: number; direction: string }>
+    }
+    expect(report.factor_sensitivity).toBeDefined()
+    // Sorted by absolute sensitivity descending — top driver is Engineering Capacity.
+    expect(report.factor_sensitivity![0].factor_id).toBe('fac_eng_capacity')
+    expect(report.factor_sensitivity![0].factor_label).toBe('Engineering Capacity')
+    expect(report.factor_sensitivity![0].sensitivity).toBe(0.43249999999999994)
+    expect(report.factor_sensitivity![0].direction).toBe('positive')
+  })
+
+  it('confidence level derives from real robustness fragile/robust edge ratio', () => {
+    const report = mapV5AnalysisToReport(block)
+    // Real staging: 9 fragile vs 1 robust → ratio 0.1 → level 'low'.
+    expect(report.confidence.level).toBe('low')
+    expect(report.confidence.why).toContain('fragile edge')
+    expect(report.confidence.why).toContain('robust edge')
+  })
+
+  it('leading_option_id is preserved verbatim (proper ID form, never relabelled)', () => {
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      leading_option_id?: string
+    }
+    expect(report.leading_option_id).toBe('opt_hire_local')
+  })
+
+  it('robustness.recommended_option_id passes through', () => {
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      robustness?: { recommended_option_id?: string; recommendation_stability?: number }
+    }
+    expect(report.robustness?.recommended_option_id).toBe('opt_hire_local')
+    expect(report.robustness?.recommendation_stability).toBe(0.7193333333333334)
+  })
+})
+
+describe('mapV5AnalysisToReport — label-keyed resolution unit cases', () => {
+  it('win_probabilities keyed by labels: option_comparison.option_label resolves to canonical option_id', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: 'A leads',
+      leading_option_id: 'opt_a',
+      // Real-staging behaviour: keyed by label, not by ID.
+      win_probabilities: {
+        'Option A — full name': 0.6,
+        'Option B — full name': 0.4,
+      },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a', option_id: 'opt_a', option_label: 'Option A — full name' },
+          { id: 'opt_b', option_id: 'opt_b', option_label: 'Option B — full name' },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    expect(Object.keys(report.option_probabilities!).sort()).toEqual(['opt_a', 'opt_b'])
+    expect(report.option_probabilities!.opt_a.win_probability).toBe(0.6)
+    expect(report.option_probabilities!.opt_b.win_probability).toBe(0.4)
+    // No label-keyed leakage:
+    expect(report.option_probabilities!['Option A — full name']).toBeUndefined()
+  })
+
+  it('option_comparison.win_probability takes precedence over block.win_probabilities mismatches', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a',
+      // Conflict: block says 0.5, enrichment says 0.7 — enrichment is canonical.
+      win_probabilities: { 'opt_a': 0.5 },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a', option_id: 'opt_a', option_label: 'A', win_probability: 0.7 },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    expect(report.option_probabilities!.opt_a.win_probability).toBe(0.7)
+  })
+
+  it('no option_comparison: emits verbatim keys (best-effort, honest miss when keys are labels)', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: null,
+      win_probabilities: { opt_a: 0.5, opt_b: 0.5 },
+      // No option_comparison in enrichment.
+      enrichment: {},
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    expect(Object.keys(report.option_probabilities!).sort()).toEqual(['opt_a', 'opt_b'])
+  })
+})
+
+describe('mapV5AnalysisToReport — deterministic hash + minimal envelope', () => {
+  it('returns a valid minimal ReportV1 when block carries only summary + leading_option_id', () => {
+    const block = baseBlock({ leading_option_id: 'opt_a' })
+
+    const report = mapV5AnalysisToReport(block)
+    expect(report.schema).toBe('report.v1')
+    expect(report.meta.seed).toBe(0)
+    expect(report.meta.response_id).toMatch(/^v5:[0-9a-f]{16}$/)
+    expect(report.model_card.response_hash).toBe(report.meta.response_id)
+    expect(report.confidence.level).toBe('medium')
+    expect(report.drivers).toEqual([])
+  })
+
+  it('identical block content produces identical hash (dedupe contract)', () => {
+    const blockA = baseBlock({ win_probabilities: { opt_a: 0.6, opt_b: 0.4 } })
+    const blockB = baseBlock({ win_probabilities: { opt_b: 0.4, opt_a: 0.6 } }) // different key order
+
+    const reportA = mapV5AnalysisToReport(blockA)
+    const reportB = mapV5AnalysisToReport(blockB)
+    expect(reportA.model_card.response_hash).toBe(reportB.model_card.response_hash)
+  })
+
+  it('different block content produces different hash', () => {
+    const blockA = baseBlock({ summary: 'A leads' })
+    const blockB = baseBlock({ summary: 'B leads' })
+
+    const reportA = mapV5AnalysisToReport(blockA)
+    const reportB = mapV5AnalysisToReport(blockB)
+    expect(reportA.model_card.response_hash).not.toBe(reportB.model_card.response_hash)
+  })
+
+  it('caller-provided responseHash overrides derived hash', () => {
+    const block = baseBlock({})
+
+    const report = mapV5AnalysisToReport(block, { responseHash: 'caller-hash-123' })
+    expect(report.model_card.response_hash).toBe('caller-hash-123')
+    expect(report.meta.response_id).toBe('caller-hash-123')
+  })
+
+  it('seed flows through to report.meta.seed', () => {
+    const block = baseBlock({})
+
+    const report = mapV5AnalysisToReport(block, { seed: 42 })
+    expect(report.meta.seed).toBe(42)
+  })
+})

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -498,6 +498,213 @@ describe('mapV5AnalysisToReport — real staging payload (label-keyed win_probab
   })
 })
 
+describe('mapV5AnalysisToReport — option_comparison passthrough for the inspector OutcomePanel', () => {
+  // OutcomePanel.OptionComparisonSection at
+  // src/canvas/ui/inspector-v2/panels/OutcomePanel.tsx:70 reads
+  // `report.option_comparison[]` directly. The V4 mapper never populated
+  // this; the V5 enrichment carries it byte-for-byte from PLoT so the V5
+  // path passes it through. Tests below pin the inspector-consumed shape
+  // (option_id + option_label + win_probability + outcome.{mean,p10,p50,p90})
+  // so a downstream reshape would fail loudly.
+
+  it('passes through option_comparison entries keyed by option_id with the OutcomePanel-consumed fields', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+      enrichment: {
+        option_comparison: [
+          {
+            id: 'opt_a',
+            option_id: 'opt_a',
+            option_label: 'Option A',
+            win_probability: 0.6,
+            outcome: { mean: 12.5, p10: 8, p50: 12, p90: 17 },
+          },
+          {
+            id: 'opt_b',
+            option_id: 'opt_b',
+            option_label: 'Option B',
+            win_probability: 0.4,
+            outcome: { mean: 8, p10: 4, p50: 7.5, p90: 12 },
+          },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_comparison?: Array<{
+        option_id: string
+        option_label?: string
+        win_probability?: number
+        outcome?: { mean?: number | null; p10?: number | null; p50?: number | null; p90?: number | null }
+      }>
+    }
+    expect(report.option_comparison).toBeDefined()
+    expect(report.option_comparison).toHaveLength(2)
+
+    const optA = report.option_comparison!.find((o) => o.option_id === 'opt_a')!
+    expect(optA.option_label).toBe('Option A')
+    expect(optA.win_probability).toBe(0.6)
+    expect(optA.outcome).toEqual({ mean: 12.5, p10: 8, p50: 12, p90: 17 })
+
+    const optB = report.option_comparison!.find((o) => o.option_id === 'opt_b')!
+    expect(optB.win_probability).toBe(0.4)
+  })
+
+  it('option_comparison_status passes through from enrichment when present', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 1 },
+      enrichment: {
+        option_comparison: [{ id: 'opt_a', option_id: 'opt_a', option_label: 'A', win_probability: 1 }],
+        option_comparison_status: 'computed',
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_comparison_status?: string
+    }
+    expect(report.option_comparison_status).toBe('computed')
+  })
+
+  it('option_comparison omitted from report when enrichment lacks it (honest miss, no synthetic rows)', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: null,
+      win_probabilities: { opt_a: 0.5 },
+      enrichment: {}, // no option_comparison
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_comparison?: unknown
+    }
+    expect(report.option_comparison).toBeUndefined()
+  })
+
+  it('option_comparison entries with no outcome data omit the outcome field rather than emit null-filled placeholder', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.7 },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a', option_id: 'opt_a', option_label: 'A', win_probability: 0.7 },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_comparison?: Array<{ option_id: string; outcome?: unknown }>
+    }
+    expect(report.option_comparison![0].outcome).toBeUndefined()
+  })
+
+  it('real staging fixture produces option_comparison with all 4 options and exact win_probabilities', () => {
+    const block = realStagingFixture.blocks[0] as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_comparison?: Array<{ option_id: string; win_probability?: number }>
+    }
+    expect(report.option_comparison).toBeDefined()
+    expect(report.option_comparison).toHaveLength(4)
+    const byId = new Map(report.option_comparison!.map((o) => [o.option_id, o]))
+    expect(byId.get('opt_hire_local')?.win_probability).toBe(0.7193333333333334)
+    expect(byId.get('opt_offshore')?.win_probability).toBe(0.054)
+    expect(byId.get('opt_status_quo')?.win_probability).toBe(0.22533333333333333)
+    expect(byId.get('opt_tiered_pricing')?.win_probability).toBe(0.0013333333333333333)
+  })
+})
+
+describe('mapV5AnalysisToReport — duplicate-label edge case', () => {
+  // The reviewer flagged: when block.win_probabilities is keyed by labels
+  // (real staging behaviour) AND two options happen to share a label,
+  // the label-keyed Record cannot distinguish them. The mapper must
+  // handle this correctly in path A (option_comparison present) — each
+  // option_comparison entry has its own win_probability, so duplicate
+  // labels are not ambiguous — and document the limitation in path B
+  // (option_comparison absent).
+
+  it('path A: duplicate option_labels disambiguate correctly because option_comparison carries per-option win_probability', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a1',
+      // Block-level win_probabilities is label-keyed (real-staging shape)
+      // and two options share the SAME label — collision is unavoidable
+      // at this level.
+      win_probabilities: { 'Hire Locally': 0.6 },
+      enrichment: {
+        option_comparison: [
+          // Each option_comparison entry carries its own canonical win_probability
+          { id: 'opt_a1', option_id: 'opt_a1', option_label: 'Hire Locally', win_probability: 0.6 },
+          { id: 'opt_a2', option_id: 'opt_a2', option_label: 'Hire Locally', win_probability: 0.3 },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    // option_comparison.win_probability takes precedence over the
+    // label-keyed block.win_probabilities, so the two duplicate-label
+    // options retain distinct probabilities.
+    expect(report.option_probabilities!.opt_a1.win_probability).toBe(0.6)
+    expect(report.option_probabilities!.opt_a2.win_probability).toBe(0.3)
+  })
+
+  it('path A degraded: when option_comparison entries lack win_probability AND two share the same label, both fall back to the same block.win_probabilities[label] value (acknowledged limitation)', () => {
+    // This is the genuine edge case: option_comparison present but entries
+    // omit win_probability, so we fall through to block.win_probabilities[
+    // option_label] — and two options sharing a label collide. This is a
+    // backend-side data-quality issue (option_comparison entries SHOULD
+    // carry their own win_probability when win_probabilities is
+    // label-keyed); the mapper preserves honest behaviour rather than
+    // synthesising a delta.
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a1',
+      win_probabilities: { 'Hire Locally': 0.6 },
+      enrichment: {
+        option_comparison: [
+          // No win_probability on either entry
+          { id: 'opt_a1', option_id: 'opt_a1', option_label: 'Hire Locally' },
+          { id: 'opt_a2', option_id: 'opt_a2', option_label: 'Hire Locally' },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    // Both options collapse to the same value — the mapper does not invent
+    // a tie-break. Acknowledged limitation; backend should populate
+    // option_comparison.win_probability per option when this configuration
+    // is possible.
+    expect(report.option_probabilities!.opt_a1.win_probability).toBe(0.6)
+    expect(report.option_probabilities!.opt_a2.win_probability).toBe(0.6)
+  })
+
+  it('path B: option_comparison absent AND label-keyed win_probabilities — labels survive as Record keys with no disambiguation (Results panel honestly misses by node.id)', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: null,
+      // Label-keyed win_probabilities, no enrichment to resolve.
+      win_probabilities: { 'Hire Locally': 0.6 },
+      enrichment: {},
+    }
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<string, { win_probability?: number }>
+    }
+    // Path B emits verbatim. No id-keyed entry exists — the selector
+    // lookup `optionProbs[node.id]` honestly misses rather than
+    // mismatching against the wrong canvas node.
+    expect(Object.keys(report.option_probabilities!).sort()).toEqual(['Hire Locally'])
+    expect(report.option_probabilities!['Hire Locally'].win_probability).toBe(0.6)
+    expect(report.option_probabilities!.opt_anything).toBeUndefined()
+  })
+})
+
 describe('mapV5AnalysisToReport — label-keyed resolution unit cases', () => {
   it('win_probabilities keyed by labels: option_comparison.option_label resolves to canonical option_id', () => {
     const block: AnalysisResultBlock = {
@@ -590,6 +797,56 @@ describe('mapV5AnalysisToReport — deterministic hash + minimal envelope', () =
     const reportA = mapV5AnalysisToReport(blockA)
     const reportB = mapV5AnalysisToReport(blockB)
     expect(reportA.model_card.response_hash).not.toBe(reportB.model_card.response_hash)
+  })
+
+  it('enrichment delta produces a different hash even when summary/leading/win_probabilities are identical (dedupe regression guard)', () => {
+    // Regression guard for the dedupe hole the brief codex review flagged:
+    // the same summary + leading + win_probabilities with changed
+    // factor_sensitivity / robustness must NOT be deduped away — the
+    // Results panel needs to re-hydrate when enrichment changes.
+    const blockA = baseBlock({
+      win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_x', label: 'X', sensitivity: 0.3 },
+        ],
+      },
+    })
+    const blockB = baseBlock({
+      win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_x', label: 'X', sensitivity: 0.9 }, // changed magnitude
+        ],
+      },
+    })
+
+    const reportA = mapV5AnalysisToReport(blockA)
+    const reportB = mapV5AnalysisToReport(blockB)
+    expect(reportA.model_card.response_hash).not.toBe(reportB.model_card.response_hash)
+  })
+
+  it('enrichment with re-ordered keys produces the SAME hash (stable canonical serialisation)', () => {
+    // Counterpart to the previous test: incidental object-key reordering
+    // must not invalidate dedupe (otherwise the same response received
+    // twice would double-hydrate).
+    const blockA = baseBlock({
+      enrichment: {
+        factor_sensitivity: [{ factor_id: 'fac_x', label: 'X', sensitivity: 0.3 }],
+        robustness: { fragile_edges: ['e1'], robust_edges: ['e2'] },
+      },
+    })
+    const blockB = baseBlock({
+      enrichment: {
+        // Same content, different top-level key order
+        robustness: { robust_edges: ['e2'], fragile_edges: ['e1'] },
+        factor_sensitivity: [{ label: 'X', sensitivity: 0.3, factor_id: 'fac_x' }],
+      },
+    })
+
+    const reportA = mapV5AnalysisToReport(blockA)
+    const reportB = mapV5AnalysisToReport(blockB)
+    expect(reportA.model_card.response_hash).toBe(reportB.model_card.response_hash)
   })
 
   it('caller-provided responseHash overrides derived hash', () => {

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -808,6 +808,114 @@ describe('mapV5AnalysisToReport — label-keyed resolution unit cases', () => {
   })
 })
 
+describe('mapV5AnalysisToReport — headline results (conservative/likely/optimistic) derive from leading option, never fabricated 0', () => {
+  // Regression guard: report.results.{conservative,likely,optimistic} is
+  // consumed by DetailedAnalysisSection, DecisionSummary, OutcomesSignal,
+  // TemplatesPanel as the headline p10/p50/p90. Earlier draft hardcoded
+  // these to 0, which would render as "0" in every consumer instead of
+  // "no data". The mapper now derives from the LEADING option's outcome
+  // (or first option if no leader), with null when no usable data exists.
+
+  it('headline results derive from leading option_comparison outcome quantiles', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.7, opt_b: 0.3 },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a', option_id: 'opt_a', option_label: 'A', outcome: { mean: 12.5, p10: 8, p50: 12, p90: 17 } },
+          { id: 'opt_b', option_id: 'opt_b', option_label: 'B', outcome: { mean: 7, p10: 3, p50: 6.5, p90: 11 } },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block)
+    // Pulled from opt_a (leading) outcome — NOT from opt_b, NOT zeros.
+    expect(report.results.conservative).toBe(8)
+    expect(report.results.likely).toBe(12)
+    expect(report.results.optimistic).toBe(17)
+  })
+
+  it('headline results fall back to first option_comparison entry when leading_option_id does not match any entry', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_phantom', // not in option_comparison
+      win_probabilities: { opt_a: 0.6 },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a', option_id: 'opt_a', option_label: 'A', outcome: { p10: 1, p50: 2, p90: 3 } },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block)
+    expect(report.results.conservative).toBe(1)
+    expect(report.results.likely).toBe(2)
+    expect(report.results.optimistic).toBe(3)
+  })
+
+  it('headline results derive from confidence_interval when outcome is absent', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 1 },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a', option_id: 'opt_a', option_label: 'A', confidence_interval: [10, 20] },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block)
+    expect(report.results.conservative).toBe(10)
+    expect(report.results.likely).toBe(15) // CI midpoint
+    expect(report.results.optimistic).toBe(20)
+  })
+
+  it('headline results are null (not 0) when no option_comparison entry has outcome or CI data', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 1 },
+      enrichment: {
+        option_comparison: [
+          { id: 'opt_a', option_id: 'opt_a', option_label: 'A' /* no outcome, no CI */ },
+        ],
+      },
+    }
+    const report = mapV5AnalysisToReport(block)
+    // Type-lie tolerated for V4 parity; runtime value is null, NOT 0.
+    expect(report.results.conservative).toBeNull()
+    expect(report.results.likely).toBeNull()
+    expect(report.results.optimistic).toBeNull()
+  })
+
+  it('headline results are null (not 0) when enrichment has no option_comparison at all', () => {
+    const block: AnalysisResultBlock = {
+      type: 'analysis_result',
+      summary: '',
+      leading_option_id: null,
+      win_probabilities: { opt_a: 0.5 },
+      enrichment: {},
+    }
+    const report = mapV5AnalysisToReport(block)
+    expect(report.results.conservative).toBeNull()
+    expect(report.results.likely).toBeNull()
+    expect(report.results.optimistic).toBeNull()
+  })
+
+  it('real staging fixture: headline results pull from opt_hire_local (the leader) outcome', () => {
+    const block = realStagingFixture.blocks[0] as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block)
+    // Exact values from the staging fixture's opt_hire_local.outcome:
+    //   p10: -0.032343256259984, p50: 0.25567048396546965, p90: 0.4781610864397162
+    expect(report.results.conservative).toBe(-0.032343256259984)
+    expect(report.results.likely).toBe(0.25567048396546965)
+    expect(report.results.optimistic).toBe(0.4781610864397162)
+  })
+})
+
 describe('mapV5AnalysisToReport — deterministic hash + minimal envelope', () => {
   it('returns a valid minimal ReportV1 when block carries only summary + leading_option_id', () => {
     const block = baseBlock({ leading_option_id: 'opt_a' })

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -32,11 +32,13 @@
 import type { OlumiResponse, StageType } from '@talchain/schemas/boundary'
 import type { Edge, Node } from '@xyflow/react'
 
+import type { ReportV1 } from '../adapters/plot/types'
 import type { CEEAnalysisReady } from '../adapters/cee/types'
 import type { CeeDecisionReviewPayloadV1 } from '../types/cee'
 import type { ScenarioStage } from '../types/scenario'
 import { logV5StateStep } from './debugLog'
 import { extractDecisionReview } from './decisionReviewAdapter'
+import { mapV5AnalysisToReport } from './mapV5AnalysisToReport'
 import { v5StageToScenarioStage } from './stageMapper'
 
 /**
@@ -55,6 +57,33 @@ export interface V5ApplicatorStore {
   setRunMeta: (meta: { ceeReviewV1: CeeDecisionReviewPayloadV1 | null }) => void
   /** Write (or clear) the CEE analysis_ready payload that gates the run. */
   setCeeAnalysisReady: (analysisReady: CEEAnalysisReady | null) => void
+  /**
+   * Results hydration (V5-exclusive path). When the response carries an
+   * analysis_result block, the applicator builds a ReportV1 via
+   * mapV5AnalysisToReport and calls this setter so the main Results panel
+   * renders V5 analyses without selector changes (mirrors the V4 envelope
+   * path at useConversation.ts:1865+). Optional so the applicator stays
+   * testable against minimal store doubles.
+   *
+   * The real canvas store's resultsComplete accepts a wider params shape
+   * (drivers, cee*, rawV2Response); the V5 path only uses the narrow
+   * subset declared here. TypeScript's structural subtyping accepts the
+   * wider real implementation in this slot.
+   */
+  resultsComplete?: (params: {
+    report: ReportV1
+    hash: string
+    resultsSource?: 'direct' | 'conversation'
+    enrichment?: unknown
+    rawV2Response?: unknown
+  }) => void
+  /**
+   * Current results hash for dedupe. When the new analysis hash matches
+   * this value, the applicator skips the resultsComplete write — same
+   * pattern as the V4 path (useConversation.ts:1861). null when no
+   * analysis has been hydrated yet.
+   */
+  currentResultsHash?: string | null
 }
 
 /**
@@ -554,6 +583,90 @@ export function applyV5State(
       output_keys: [],
       applied: false,
       skip_reason: 'missing_on_conversational_turn',
+    })
+  }
+
+  // 5. Results hydration. When the response carries an analysis_result
+  // block, build a ReportV1 via mapV5AnalysisToReport and hydrate the
+  // canvas store's results slice via resultsComplete. Mirrors the V4
+  // envelope path at useConversation.ts:1865+ so the main Results panel
+  // renders V5 analyses without selector changes.
+  //
+  // Dedupe by hash: skip the write when the new block's hash matches the
+  // store's currentResultsHash. The stale-turn invariant at the top of
+  // applyV5State already covers this write (any stale response returns
+  // before reaching step 5).
+  //
+  // Gated on store.resultsComplete being provided. The applicator is
+  // tested against minimal store doubles that may omit it; callers in
+  // useConversation.ts wire the real store action. When omitted, the
+  // step is a no-op and `deferred` records why.
+  const analysisBlock = response.blocks.find(
+    (b): b is Extract<V5Block, { type: 'analysis_result' }> =>
+      b.type === 'analysis_result',
+  )
+  if (analysisBlock) {
+    if (typeof store.resultsComplete === 'function') {
+      const report = mapV5AnalysisToReport(analysisBlock)
+      const hash = report.model_card.response_hash
+      const prevHash = store.currentResultsHash ?? null
+      if (hash !== prevHash) {
+        store.resultsComplete({
+          report,
+          hash,
+          resultsSource: 'conversation',
+          // V5 carries no V2 envelope; pass null so the canvas store's
+          // V2-shaped enrichment / rawV2Response slots are explicitly
+          // cleared rather than left to a stale prior write.
+          enrichment: null,
+          rawV2Response: null,
+        })
+        applied.push('analysis_result:results_hydrated')
+        logV5StateStep({
+          step_number: 5,
+          step_name: 'results_hydration',
+          input_keys: [
+            'analysis_result',
+            'win_probabilities',
+            'enrichment',
+            'leading_option_id',
+          ],
+          output_keys: ['results.report', 'results.hash'],
+          applied: true,
+        })
+      } else {
+        logV5StateStep({
+          step_number: 5,
+          step_name: 'results_hydration',
+          input_keys: ['analysis_result'],
+          output_keys: [],
+          applied: false,
+          skip_reason: 'duplicate_hash',
+        })
+      }
+    } else {
+      deferred.push({
+        reason: 'results_hydration_store_lacks_resultsComplete',
+        block: analysisBlock,
+        detail: 'Applicator was passed a store without resultsComplete; analysis_result block content not hydrated into results.report.',
+      })
+      logV5StateStep({
+        step_number: 5,
+        step_name: 'results_hydration',
+        input_keys: ['analysis_result'],
+        output_keys: [],
+        applied: false,
+        skip_reason: 'store_lacks_resultsComplete',
+      })
+    }
+  } else {
+    logV5StateStep({
+      step_number: 5,
+      step_name: 'results_hydration',
+      input_keys: [],
+      output_keys: [],
+      applied: false,
+      skip_reason: 'no_analysis_result_block',
     })
   }
 

--- a/src/v5/debugLog.ts
+++ b/src/v5/debugLog.ts
@@ -12,7 +12,7 @@
  */
 
 export interface V5StateLogCtx {
-  step_number: 1 | 2 | 3 | 4
+  step_number: 1 | 2 | 3 | 4 | 5
   step_name: string
   /** Field names read from the V5 response at this step (never values). */
   input_keys: readonly string[]

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -303,10 +303,25 @@ export function mapV5AnalysisToReport(
   //   1. enrichment.option_comparison[*].win_probability (canonical)
   //   2. block.win_probabilities[option_id]  (block-keyed-by-id)
   //   3. block.win_probabilities[option_label] (block-keyed-by-label,
-  //      real staging behaviour as of 2026-04-30 build 3bb151b)
+  //      real staging behaviour as of 2026-04-30 build 3bb151b) — ONLY
+  //      when the label is unique among option_comparison entries.
+  //      Duplicate labels with no per-entry win_probability collapse to
+  //      undefined rather than to a shared value: a label-keyed Record
+  //      cannot disambiguate two options that share a label, and
+  //      rendering both at the same number is false precision, not
+  //      "honest miss". See duplicate-label tests for the contract.
   // Path B (no option_comparison): emit entries keyed by win_probabilities
   // keys verbatim. Honest miss in the Results panel when those keys are
   // labels.
+  const labelOccurrences = new Map<string, number>()
+  for (const r of resolvedOptions) {
+    if (r.optionLabel !== undefined) {
+      labelOccurrences.set(r.optionLabel, (labelOccurrences.get(r.optionLabel) ?? 0) + 1)
+    }
+  }
+  const labelIsUnique = (label: string | undefined): label is string =>
+    label !== undefined && (labelOccurrences.get(label) ?? 0) === 1
+
   const iterator: Array<{ optionId: string; enriched: RawOptionEnrichmentEntry | undefined; label: string | undefined }> =
     resolvedOptions.length > 0
       ? resolvedOptions.map((r) => ({
@@ -320,7 +335,7 @@ export function mapV5AnalysisToReport(
     const winProb =
       safeFiniteNumber(enriched?.win_probability) ??
       safeFiniteNumber(winProbs[optionId]) ??
-      (label !== undefined ? safeFiniteNumber(winProbs[label]) : undefined)
+      (labelIsUnique(label) ? safeFiniteNumber(winProbs[label]) : undefined)
 
     const ci = Array.isArray(enriched?.confidence_interval)
       ? enriched.confidence_interval
@@ -520,10 +535,15 @@ export function mapV5AnalysisToReport(
       ({ optionId, optionLabel, enriched }) => {
         const entry: InspectorOptionComparison = { option_id: optionId }
         if (optionLabel) entry.option_label = optionLabel
+        // Mirror the duplicate-label guard from the option_probabilities
+        // resolution: labels shared by multiple option_comparison entries
+        // must NOT use the label-keyed winProbs fallback, because the
+        // OutcomePanel would render multiple rows at the same numeric
+        // probability — false precision from ambiguous source data.
         const winProb =
           safeFiniteNumber(enriched.win_probability) ??
           safeFiniteNumber(winProbs[optionId]) ??
-          (optionLabel !== undefined ? safeFiniteNumber(winProbs[optionLabel]) : undefined)
+          (labelIsUnique(optionLabel) ? safeFiniteNumber(winProbs[optionLabel]) : undefined)
         if (winProb !== undefined) entry.win_probability = winProb
         const expected = safeFiniteNumber(enriched.expected_outcome)
         if (expected !== undefined) entry.expected_outcome = expected
@@ -560,15 +580,33 @@ export function mapV5AnalysisToReport(
 }
 
 /**
- * Stable canonical JSON serialiser — sorts object keys at every nesting
- * level so the resulting string is byte-identical for two values that
- * differ only by key-insertion order. Used by deriveBlockHash so the
- * Results-panel dedupe responds to genuine content changes (e.g. updated
- * factor_sensitivity) rather than to incidental key reordering.
+ * Stable serialiser used by deriveBlockHash. Sorts object keys at every
+ * nesting level so the resulting string is byte-identical for two values
+ * that differ only by key-insertion order — meaning incidental object-key
+ * reordering does not invalidate dedupe, but genuine content changes
+ * (updated factor_sensitivity, etc.) do.
+ *
+ * NOT strictly JSON-canonical (a real wire payload coming through
+ * JSON.parse cannot contain `undefined` or symbols, but defensive
+ * production callers might pass them in). Both `undefined` and `null`
+ * serialise to `"null"` here, and unsupported types (functions, symbols)
+ * also map to `"null"`. The hash purpose is content equality, and
+ * collapsing JSON-unrepresentable values to a single sentinel is honest
+ * for that purpose. Object properties whose value is `undefined` are
+ * preserved in the key order rather than omitted (JSON would drop them)
+ * so the serialisation stays sensitive to "this key exists but is
+ * unset" vs "this key is absent" — both rare for the wire payload but
+ * relevant if a caller hands us a synthesised block.
  */
 function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value)
+  if (value === undefined) return 'null'
+  if (value === null) return 'null'
+  if (typeof value === 'function' || typeof value === 'symbol') return 'null'
+  if (typeof value !== 'object') {
+    const serialised = JSON.stringify(value)
+    // JSON.stringify can return undefined for e.g. NaN/Infinity wrapped
+    // in unsupported contexts; collapse to "null" for hash purposes.
+    return serialised ?? 'null'
   }
   if (Array.isArray(value)) {
     return '[' + value.map(stableStringify).join(',') + ']'

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -1,0 +1,519 @@
+/**
+ * mapV5AnalysisToReport — pure mapper from a V5 `analysis_result` block to
+ * the canvas store's `ReportV1` shape.
+ *
+ * Mirrors the V4 [`mapV2ResponseToReportV1`](../adapters/plot/v2/responseMapper.ts)
+ * output fields (option_probabilities, drivers, factor_sensitivity,
+ * robustness, confidence, warnings) so the existing main Results panel —
+ * which already consumes that shape from V4 turns — can render V5 analysis
+ * data without any selector changes.
+ *
+ * The V5 envelope is slimmer than a V2RunResponse: only `win_probabilities`
+ * (Record<option_id, number>) is guaranteed at the block level. Outcome
+ * quantiles, confidence intervals, and per-option goal probabilities live
+ * inside `enrichment.option_comparison[]` IF PLoT included them in the
+ * enrichment passthrough (the boundary contract is "enrichment is
+ * byte-for-byte PLoT" — see olumi-schemas/src/orchestrator/handler-results.ts).
+ *
+ * No silent defaults: missing numerics surface as `null`/`undefined`. Option
+ * IDs are taken verbatim from `win_probabilities` keys (no synthesised
+ * `opt_0`/`opt_1` placeholders). Sensitivity entries are read against the
+ * full alias set documented in the backend's deriveTopDriversFromTopLevel
+ * (olumi-assistants-service/src/orchestrator-v5/context/analysis-fallback.ts).
+ *
+ * Pure function — no store reads, no side effects, no DEV-time logging
+ * that depends on `import.meta.env`.
+ */
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import type { ReportV1, ConfidenceLevel } from '../adapters/plot/types'
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function safeString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+function safeFiniteNumber(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === 'object' && !Array.isArray(v)
+}
+
+// ─── Factor sensitivity normalisation ──────────────────────────────────
+
+interface NormalisedFactor {
+  factor_id: string
+  factor_label: string
+  sensitivity: number // absolute magnitude
+  direction: 'positive' | 'negative'
+}
+
+/**
+ * Normalise one raw factor_sensitivity entry. Accepts the full alias set
+ * the backend tolerates (factor_id|node_id|id, label|factor_label,
+ * sensitivity|elasticity|sensitivity_score|importance_score, direction
+ * explicit or implied by sign). Returns null when the entry has no usable
+ * ID or no usable magnitude — entries are dropped, never defaulted.
+ */
+function normaliseFactorEntry(entry: unknown): NormalisedFactor | null {
+  if (!isPlainObject(entry)) return null
+
+  // Priority order matches V4's pickFactorSensitivityForUi:
+  // sensitivity_score (unnormalized canonical) wins over elasticity
+  // (which staging emits as a normalized 0–1 value, e.g. 1.0 for the top
+  // factor, masking the actual magnitude). See
+  // src/adapters/plot/v2/responseMapper.ts createDriversPayloadFromV2:753–757.
+  const rawMagnitude =
+    safeFiniteNumber(entry.sensitivity_score) ??
+    safeFiniteNumber(entry.sensitivity) ??
+    safeFiniteNumber(entry.elasticity) ??
+    safeFiniteNumber(entry.importance_score)
+  if (rawMagnitude === undefined) return null
+
+  const factorId =
+    safeString(entry.factor_id) ??
+    safeString(entry.node_id) ??
+    safeString(entry.id) ??
+    safeString(entry.factor_label) ??
+    safeString(entry.label)
+  if (!factorId) return null
+
+  const factorLabel =
+    safeString(entry.factor_label) ?? safeString(entry.label) ?? factorId
+
+  const explicitDirection =
+    entry.direction === 'positive' || entry.direction === 'negative'
+      ? entry.direction
+      : undefined
+  const direction: 'positive' | 'negative' =
+    explicitDirection ?? (rawMagnitude >= 0 ? 'positive' : 'negative')
+
+  return {
+    factor_id: factorId,
+    factor_label: factorLabel,
+    sensitivity: Math.abs(rawMagnitude),
+    direction,
+  }
+}
+
+/**
+ * Collect factor_sensitivity entries from top-level `enrichment.factor_sensitivity`
+ * AND from per-result `enrichment.results[].factor_sensitivity[]`. Both
+ * shapes are observed in the wild (staging emits top-level, the per-result
+ * shape is documented in CEE's context/analysis-fallback.ts). Mirrors that
+ * backend's getAllFactors/deriveTopDriversFromTopLevel precedence: an entry
+ * present in BOTH shapes is deduped by `factor_id` with the higher absolute
+ * sensitivity winning.
+ */
+function collectFactors(enrichment: Record<string, unknown>): NormalisedFactor[] {
+  const byId = new Map<string, NormalisedFactor>()
+
+  const candidates: unknown[] = []
+  if (Array.isArray(enrichment.factor_sensitivity)) {
+    candidates.push(...enrichment.factor_sensitivity)
+  }
+  if (Array.isArray(enrichment.results)) {
+    for (const r of enrichment.results) {
+      if (isPlainObject(r) && Array.isArray(r.factor_sensitivity)) {
+        candidates.push(...r.factor_sensitivity)
+      }
+    }
+  }
+
+  for (const raw of candidates) {
+    const norm = normaliseFactorEntry(raw)
+    if (!norm) continue
+    const existing = byId.get(norm.factor_id)
+    if (!existing || norm.sensitivity > existing.sensitivity) {
+      byId.set(norm.factor_id, norm)
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => {
+    const diff = b.sensitivity - a.sensitivity
+    if (diff !== 0) return diff
+    return a.factor_id.localeCompare(b.factor_id)
+  })
+}
+
+// ─── Confidence derivation ─────────────────────────────────────────────
+
+function deriveConfidence(
+  enrichment: Record<string, unknown> | undefined,
+  factorsCount: number,
+): { level: ConfidenceLevel; why: string } {
+  const robustness = isPlainObject(enrichment?.robustness)
+    ? enrichment!.robustness
+    : undefined
+  const fragileCount = Array.isArray(robustness?.fragile_edges)
+    ? robustness!.fragile_edges.length
+    : 0
+  const robustCount = Array.isArray(robustness?.robust_edges)
+    ? robustness!.robust_edges.length
+    : 0
+  const total = fragileCount + robustCount
+
+  if (total === 0) {
+    return {
+      level: 'medium',
+      why:
+        factorsCount > 0
+          ? `Based on ${factorsCount} sensitivity factor${factorsCount === 1 ? '' : 's'}`
+          : 'Based on available data',
+    }
+  }
+
+  const robustRatio = robustCount / total
+  const level: ConfidenceLevel =
+    robustRatio >= 0.7 ? 'high' : robustRatio >= 0.3 ? 'medium' : 'low'
+  return {
+    level,
+    why: `${fragileCount} fragile edge${fragileCount === 1 ? '' : 's'}, ${robustCount} robust edge${robustCount === 1 ? '' : 's'}`,
+  }
+}
+
+// ─── Option-level enrichment lookup ────────────────────────────────────
+
+interface RawOptionEnrichmentEntry {
+  id?: unknown
+  option_id?: unknown
+  label?: unknown
+  option_label?: unknown
+  win_probability?: unknown
+  probability_of_goal?: unknown
+  probability_of_joint_goal?: unknown
+  confidence_interval?: unknown
+  expected_outcome?: unknown
+  outcome?: { mean?: unknown; p10?: unknown; p50?: unknown; p90?: unknown }
+}
+
+interface ResolvedOptionEntry {
+  optionId: string
+  optionLabel: string | undefined
+  enriched: RawOptionEnrichmentEntry
+}
+
+/**
+ * Index enrichment.option_comparison[] (when present) — each entry carries
+ * BOTH a canonical option_id (e.g. `opt_hire_local`) AND a human option_label
+ * (e.g. `"Hire Two Senior Engineers Locally"`). This dual indexing is the
+ * key to resolving `block.win_probabilities` keys, which in real staging
+ * payloads are keyed by LABELS, not IDs (verified against
+ * tests/fixtures/cross-service/v5-turn.run-analysis.staging.json on
+ * 2026-04-30). The Results panel selector reads
+ * `option_probabilities[canvas_node_id]` where the canvas node id is
+ * `opt_hire_local`, so option_probabilities MUST be keyed by option_id —
+ * NOT by the label-keyed win_probabilities Record verbatim.
+ */
+function resolveOptionEntries(
+  enrichment: Record<string, unknown> | undefined,
+): ResolvedOptionEntry[] {
+  const raw = enrichment?.option_comparison
+  if (!Array.isArray(raw)) return []
+  const out: ResolvedOptionEntry[] = []
+  for (const entry of raw) {
+    if (!isPlainObject(entry)) continue
+    const e = entry as RawOptionEnrichmentEntry
+    const optionId = safeString(e.id) ?? safeString(e.option_id)
+    if (!optionId) continue
+    const optionLabel = safeString(e.option_label) ?? safeString(e.label)
+    out.push({ optionId, optionLabel, enriched: e })
+  }
+  return out
+}
+
+// ─── Public mapper ─────────────────────────────────────────────────────
+
+export interface MapV5AnalysisOptions {
+  /** Seed used for the run. Defaults to 0 when caller has none. */
+  seed?: number
+  /**
+   * Optional override for response_hash. When omitted the hash is derived
+   * deterministically from the block (summary + leading_option_id +
+   * win_probabilities) so identical analyses dedupe in the store.
+   */
+  responseHash?: string
+}
+
+/**
+ * Map a V5 analysis_result block to a ReportV1 shape. The store's
+ * `report` slice is widened by index signature in consumers (see
+ * useAnalysisResults.ts InspectorReport interface and
+ * useResultsSectionData.ts ResultsReport type), so this mapper returns the
+ * `ReportV1` core fields PLUS the auxiliary V4-mapper fields (option_probabilities,
+ * factor_sensitivity, robustness, drivers_status, robustness_status,
+ * warnings) the main Results panel reads.
+ */
+export function mapV5AnalysisToReport(
+  block: AnalysisResultBlock,
+  options: MapV5AnalysisOptions = {},
+): ReportV1 {
+  const seed = options.seed ?? 0
+  const enrichment = isPlainObject(block.enrichment) ? block.enrichment : undefined
+
+  // Factor sensitivity — collected and ranked once; reused for drivers + factor_sensitivity passthrough.
+  const factors = enrichment ? collectFactors(enrichment) : []
+  const drivers = factors.slice(0, 5).map((f) => ({
+    label: f.factor_label,
+    polarity:
+      f.direction === 'positive' ? ('up' as const) : ('down' as const),
+    strength:
+      f.sensitivity >= 0.7
+        ? ('high' as const)
+        : f.sensitivity >= 0.3
+          ? ('medium' as const)
+          : ('low' as const),
+    contribution: f.sensitivity,
+    nodeId: f.factor_id,
+  }))
+
+  const confidence = deriveConfidence(enrichment, factors.length)
+
+  // Option probabilities — keyed by canonical option_id when
+  // `enrichment.option_comparison` is present (the source of truth). When
+  // absent, fall back to keying by `block.win_probabilities` keys verbatim
+  // — those may be labels in real staging payloads, in which case the
+  // downstream Results-panel lookup at useResultsSectionData.ts:1042
+  // (`optionProbs[node.id]`) will honestly miss rather than silently
+  // mismatch.
+  const resolvedOptions = resolveOptionEntries(enrichment)
+  const winProbs = block.win_probabilities ?? {}
+
+  type ResultsOptionProbability = {
+    goal_probability?: number
+    probability_of_joint_goal?: number
+    confidence: number
+    win_probability?: number
+    expected?: number
+    outcome?: {
+      mean?: number | null
+      p10?: number | null
+      p50?: number | null
+      p90?: number | null
+    }
+  }
+  const option_probabilities: Record<string, ResultsOptionProbability> = {}
+
+  // Resolution path A: option_comparison is the canonical source.
+  // For each entry, look up win_probability in three places:
+  //   1. enrichment.option_comparison[*].win_probability (canonical)
+  //   2. block.win_probabilities[option_id]  (block-keyed-by-id)
+  //   3. block.win_probabilities[option_label] (block-keyed-by-label,
+  //      real staging behaviour as of 2026-04-30 build 3bb151b)
+  // Path B (no option_comparison): emit entries keyed by win_probabilities
+  // keys verbatim. Honest miss in the Results panel when those keys are
+  // labels.
+  const iterator: Array<{ optionId: string; enriched: RawOptionEnrichmentEntry | undefined; label: string | undefined }> =
+    resolvedOptions.length > 0
+      ? resolvedOptions.map((r) => ({
+          optionId: r.optionId,
+          enriched: r.enriched,
+          label: r.optionLabel,
+        }))
+      : Object.keys(winProbs).map((k) => ({ optionId: k, enriched: undefined, label: undefined }))
+
+  for (const { optionId, enriched, label } of iterator) {
+    const winProb =
+      safeFiniteNumber(enriched?.win_probability) ??
+      safeFiniteNumber(winProbs[optionId]) ??
+      (label !== undefined ? safeFiniteNumber(winProbs[label]) : undefined)
+
+    const ci = Array.isArray(enriched?.confidence_interval)
+      ? enriched.confidence_interval
+      : null
+    const ciLow =
+      ci && safeFiniteNumber(ci[0]) !== undefined ? (ci[0] as number) : null
+    const ciHigh =
+      ci && safeFiniteNumber(ci[1]) !== undefined ? (ci[1] as number) : null
+    const ciMid =
+      ciLow != null && ciHigh != null ? (ciLow + ciHigh) / 2 : null
+
+    const outcome = isPlainObject(enriched?.outcome) ? enriched.outcome : undefined
+    const rawMean = safeFiniteNumber(outcome?.mean)
+    const rawExpected = safeFiniteNumber(enriched?.expected_outcome)
+    const expected = rawMean ?? rawExpected ?? ciMid ?? undefined
+
+    const p10 = safeFiniteNumber(outcome?.p10) ?? ciLow
+    const p50 = safeFiniteNumber(outcome?.p50) ?? null
+    const p90 = safeFiniteNumber(outcome?.p90) ?? ciHigh
+
+    option_probabilities[optionId] = {
+      // No silent defaults — undefined when missing.
+      ...(safeFiniteNumber(enriched?.probability_of_goal) !== undefined
+        ? { goal_probability: safeFiniteNumber(enriched?.probability_of_goal) }
+        : {}),
+      ...(safeFiniteNumber(enriched?.probability_of_joint_goal) !== undefined
+        ? {
+            probability_of_joint_goal: safeFiniteNumber(
+              enriched?.probability_of_joint_goal,
+            ),
+          }
+        : {}),
+      confidence: 0.5,
+      ...(winProb !== undefined ? { win_probability: winProb } : {}),
+      ...(expected !== undefined ? { expected } : {}),
+      outcome: {
+        mean: rawMean ?? null,
+        p10: p10 ?? null,
+        p50,
+        p90: p90 ?? null,
+      },
+    }
+  }
+
+  // Robustness passthrough — enrichment.robustness when present.
+  const robustnessRaw = isPlainObject(enrichment?.robustness)
+    ? enrichment!.robustness
+    : undefined
+  const robustness = robustnessRaw
+    ? {
+        fragile_edges: Array.isArray(robustnessRaw.fragile_edges)
+          ? robustnessRaw.fragile_edges
+          : [],
+        robust_edges: Array.isArray(robustnessRaw.robust_edges)
+          ? robustnessRaw.robust_edges
+          : [],
+        ...(safeFiniteNumber(robustnessRaw.ranking_stability) !== undefined
+          ? { ranking_stability: safeFiniteNumber(robustnessRaw.ranking_stability) }
+          : {}),
+        ...(safeFiniteNumber(robustnessRaw.recommendation_stability) !== undefined
+          ? {
+              recommendation_stability: safeFiniteNumber(
+                robustnessRaw.recommendation_stability,
+              ),
+            }
+          : {}),
+        ...(typeof robustnessRaw.is_robust === 'boolean'
+          ? { is_robust: robustnessRaw.is_robust }
+          : {}),
+        ...(safeString(robustnessRaw.level) !== undefined
+          ? { level: safeString(robustnessRaw.level) }
+          : {}),
+        ...(safeString(robustnessRaw.recommended_option_id) !== undefined
+          ? {
+              recommended_option_id: safeString(
+                robustnessRaw.recommended_option_id,
+              ),
+            }
+          : {}),
+        ...(Array.isArray(robustnessRaw.flip_thresholds)
+          ? { flip_thresholds: robustnessRaw.flip_thresholds }
+          : {}),
+        ...(Array.isArray(robustnessRaw.edge_e_values)
+          ? { edge_e_values: robustnessRaw.edge_e_values }
+          : {}),
+        ...(Array.isArray(robustnessRaw.conditional_winners)
+          ? { conditional_winners: robustnessRaw.conditional_winners }
+          : {}),
+      }
+    : undefined
+
+  // Top-level enrichment fields that live alongside robustness in V4 output.
+  const topLevelFlipThresholds = Array.isArray(enrichment?.flip_thresholds)
+    ? (enrichment!.flip_thresholds as unknown[])
+    : undefined
+  const topLevelEdgeEValues = Array.isArray(enrichment?.edge_e_values)
+    ? (enrichment!.edge_e_values as unknown[])
+    : undefined
+  const conditionalProbabilities = enrichment?.conditional_probabilities
+
+  // Deterministic response_hash when caller has none. Stable across identical
+  // blocks so the store's hash-dedupe in resultsComplete works.
+  const responseHash =
+    options.responseHash ??
+    deriveBlockHash({
+      summary: block.summary,
+      leading_option_id: block.leading_option_id,
+      win_probabilities: winProbs,
+    })
+
+  const report: ReportV1 = {
+    schema: 'report.v1',
+    meta: {
+      seed,
+      response_id: responseHash,
+      elapsed_ms: 0,
+    },
+    model_card: {
+      response_hash: responseHash,
+      response_hash_algo: 'sha256',
+      normalized: true,
+    },
+    results: {
+      conservative: 0,
+      likely: 0,
+      optimistic: 0,
+    },
+    confidence,
+    drivers,
+  }
+
+  // Auxiliary fields the main Results panel + inspector helpers read via
+  // the widened ResultsReport / InspectorReport index signatures. These are
+  // NOT on ReportV1 but are written onto the same record by the V4 mapper.
+  const widened = report as ReportV1 & Record<string, unknown>
+  if (factors.length > 0) {
+    widened.factor_sensitivity = factors.map((f) => ({
+      factor_id: f.factor_id,
+      factor_label: f.factor_label,
+      sensitivity: f.sensitivity,
+      direction: f.direction,
+    }))
+  }
+  if (robustness) widened.robustness = robustness
+  if (topLevelFlipThresholds) widened.flip_thresholds = topLevelFlipThresholds
+  if (topLevelEdgeEValues) widened.edge_e_values = topLevelEdgeEValues
+  if (conditionalProbabilities !== undefined) {
+    widened.conditional_probabilities = conditionalProbabilities
+  }
+  if (block.leading_option_id != null) {
+    widened.leading_option_id = block.leading_option_id
+  }
+  if (Object.keys(option_probabilities).length > 0) {
+    // ReportV1 declares `option_probabilities` as Record<string, OptionProbability>
+    // where OptionProbability.goal_probability is required. The V4 mapper widens
+    // the slot at runtime (responseMapper.ts:627-640) with an inline cast so
+    // missing goal_probability surfaces as undefined rather than a fabricated 0.
+    // Mirror that contract here — the consumer (ResultsReport in
+    // src/components/results/types.ts:777) explicitly widens this field.
+    widened.option_probabilities = option_probabilities as unknown as ReportV1['option_probabilities']
+  }
+  if (block.summary.length > 0) {
+    widened.summary = block.summary
+  }
+
+  return report
+}
+
+/**
+ * Deterministic 16-hex-char hash derived from block content. Stable across
+ * identical inputs so the store's hash-dedupe path doesn't double-write.
+ * Lightweight non-crypto digest — collisions are extremely unlikely across
+ * the population of analysis blocks a single session produces, and the
+ * dedupe is best-effort (a collision wastes one set() call, not user data).
+ */
+function deriveBlockHash(parts: {
+  summary: string
+  leading_option_id: string | null
+  win_probabilities: Record<string, number>
+}): string {
+  // Canonicalise win_probabilities key order so identical content hashes
+  // regardless of object key insertion order.
+  const sortedProbs = Object.keys(parts.win_probabilities)
+    .sort()
+    .map((k) => `${k}:${parts.win_probabilities[k]}`)
+    .join(',')
+  const seed = `${parts.summary}|${parts.leading_option_id ?? ''}|${sortedProbs}`
+
+  // FNV-1a 64-bit (BigInt) — deterministic, no crypto dependency.
+  let h = 0xcbf29ce484222325n
+  for (let i = 0; i < seed.length; i++) {
+    h ^= BigInt(seed.charCodeAt(i))
+    h = (h * 0x100000001b3n) & 0xffffffffffffffffn
+  }
+  return `v5:${h.toString(16).padStart(16, '0')}`
+}

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -423,12 +423,20 @@ export function mapV5AnalysisToReport(
 
   // Deterministic response_hash when caller has none. Stable across identical
   // blocks so the store's hash-dedupe in resultsComplete works.
+  //
+  // Includes the full enrichment payload (stable-serialised) so two blocks
+  // with the same summary + leading_option_id + win_probabilities but
+  // changed factor_sensitivity / robustness / option_comparison produce
+  // DIFFERENT hashes and re-hydrate the Results panel. Earlier drafts hashed
+  // only the top-level keys, which let enrichment-only deltas (legitimate
+  // re-analysis with same probabilities) silently dedupe.
   const responseHash =
     options.responseHash ??
     deriveBlockHash({
       summary: block.summary,
       leading_option_id: block.leading_option_id,
       win_probabilities: winProbs,
+      enrichment: block.enrichment,
     })
 
   const report: ReportV1 = {
@@ -482,6 +490,68 @@ export function mapV5AnalysisToReport(
     // src/components/results/types.ts:777) explicitly widens this field.
     widened.option_probabilities = option_probabilities as unknown as ReportV1['option_probabilities']
   }
+
+  // Inspector-facing `option_comparison` passthrough. The right-hand
+  // OutcomePanel.OptionComparisonSection at
+  // src/canvas/ui/inspector-v2/panels/OutcomePanel.tsx:70 reads
+  // `r?.option_comparison as OptionComparisonEntry[]` and renders
+  // ranked rows with win-probability bars. The V4 mapper never
+  // populated this field (it is a pre-existing gap on V4); the V5
+  // enrichment carries `option_comparison` byte-for-byte from PLoT,
+  // so the V5 path can fix the inspector without changing OutcomePanel.
+  // Shape narrowed to the OutcomePanel-consumed subset
+  // (option_id, option_label, win_probability, outcome) — extra
+  // enrichment fields are deliberately dropped so they don't leak
+  // into the inspector's DOM.
+  if (resolvedOptions.length > 0) {
+    type InspectorOptionComparison = {
+      option_id: string
+      option_label?: string
+      win_probability?: number
+      expected_outcome?: number
+      outcome?: {
+        mean?: number | null
+        p10?: number | null
+        p50?: number | null
+        p90?: number | null
+      }
+    }
+    const optionComparison: InspectorOptionComparison[] = resolvedOptions.map(
+      ({ optionId, optionLabel, enriched }) => {
+        const entry: InspectorOptionComparison = { option_id: optionId }
+        if (optionLabel) entry.option_label = optionLabel
+        const winProb =
+          safeFiniteNumber(enriched.win_probability) ??
+          safeFiniteNumber(winProbs[optionId]) ??
+          (optionLabel !== undefined ? safeFiniteNumber(winProbs[optionLabel]) : undefined)
+        if (winProb !== undefined) entry.win_probability = winProb
+        const expected = safeFiniteNumber(enriched.expected_outcome)
+        if (expected !== undefined) entry.expected_outcome = expected
+        const outcome = isPlainObject(enriched.outcome) ? enriched.outcome : undefined
+        if (outcome) {
+          const mean = safeFiniteNumber(outcome.mean)
+          const p10 = safeFiniteNumber(outcome.p10)
+          const p50 = safeFiniteNumber(outcome.p50)
+          const p90 = safeFiniteNumber(outcome.p90)
+          if (mean !== undefined || p10 !== undefined || p50 !== undefined || p90 !== undefined) {
+            entry.outcome = {
+              mean: mean ?? null,
+              p10: p10 ?? null,
+              p50: p50 ?? null,
+              p90: p90 ?? null,
+            }
+          }
+        }
+        return entry
+      },
+    )
+    widened.option_comparison = optionComparison
+    // OutcomePanel also checks option_comparison_status. Mirror the
+    // top-level enrichment field when present so error/pending states
+    // pass through verbatim.
+    const ocStatus = safeString(enrichment?.option_comparison_status)
+    if (ocStatus !== undefined) widened.option_comparison_status = ocStatus
+  }
   if (block.summary.length > 0) {
     widened.summary = block.summary
   }
@@ -490,8 +560,35 @@ export function mapV5AnalysisToReport(
 }
 
 /**
- * Deterministic 16-hex-char hash derived from block content. Stable across
- * identical inputs so the store's hash-dedupe path doesn't double-write.
+ * Stable canonical JSON serialiser — sorts object keys at every nesting
+ * level so the resulting string is byte-identical for two values that
+ * differ only by key-insertion order. Used by deriveBlockHash so the
+ * Results-panel dedupe responds to genuine content changes (e.g. updated
+ * factor_sensitivity) rather than to incidental key reordering.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']'
+  }
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj).sort()
+  return (
+    '{' +
+    keys.map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k])).join(',') +
+    '}'
+  )
+}
+
+/**
+ * Deterministic 16-hex-char hash derived from block content INCLUDING the
+ * full enrichment payload. Stable across identical inputs so the store's
+ * hash-dedupe path doesn't double-write, and DISTINCT for any block whose
+ * enrichment differs (so re-runs that produce updated drivers / robustness
+ * / option_comparison hydrate the Results panel fresh).
+ *
  * Lightweight non-crypto digest — collisions are extremely unlikely across
  * the population of analysis blocks a single session produces, and the
  * dedupe is best-effort (a collision wastes one set() call, not user data).
@@ -500,6 +597,7 @@ function deriveBlockHash(parts: {
   summary: string
   leading_option_id: string | null
   win_probabilities: Record<string, number>
+  enrichment: Record<string, unknown> | undefined
 }): string {
   // Canonicalise win_probabilities key order so identical content hashes
   // regardless of object key insertion order.
@@ -507,7 +605,8 @@ function deriveBlockHash(parts: {
     .sort()
     .map((k) => `${k}:${parts.win_probabilities[k]}`)
     .join(',')
-  const seed = `${parts.summary}|${parts.leading_option_id ?? ''}|${sortedProbs}`
+  const enrichmentSerialised = stableStringify(parts.enrichment ?? null)
+  const seed = `${parts.summary}|${parts.leading_option_id ?? ''}|${sortedProbs}|${enrichmentSerialised}`
 
   // FNV-1a 64-bit (BigInt) — deterministic, no crypto dependency.
   let h = 0xcbf29ce484222325n

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -16,9 +16,13 @@
  * byte-for-byte PLoT" — see olumi-schemas/src/orchestrator/handler-results.ts).
  *
  * No silent defaults: missing numerics surface as `null`/`undefined`. Option
- * IDs are taken verbatim from `win_probabilities` keys (no synthesised
- * `opt_0`/`opt_1` placeholders). Sensitivity entries are read against the
- * full alias set documented in the backend's deriveTopDriversFromTopLevel
+ * IDs come from the canonical `enrichment.option_comparison[].option_id`
+ * when present (the source of truth even though `block.win_probabilities`
+ * may be keyed by labels in real staging); they fall back to the raw
+ * `win_probabilities` keys only when no `option_comparison` exists, and
+ * the duplicate-label guard prevents false precision in that fallback.
+ * Sensitivity entries are read against the full alias set documented in the
+ * backend's deriveTopDriversFromTopLevel
  * (olumi-assistants-service/src/orchestrator-v5/context/analysis-fallback.ts).
  *
  * Pure function — no store reads, no side effects, no DEV-time logging
@@ -234,7 +238,10 @@ export interface MapV5AnalysisOptions {
   /**
    * Optional override for response_hash. When omitted the hash is derived
    * deterministically from the block (summary + leading_option_id +
-   * win_probabilities) so identical analyses dedupe in the store.
+   * win_probabilities + canonical-serialised enrichment) so identical
+   * analyses dedupe in the store, but enrichment-only deltas (updated
+   * factor_sensitivity / robustness / option_comparison with unchanged
+   * probabilities) still produce a distinct hash and re-hydrate.
    */
   responseHash?: string
 }
@@ -454,6 +461,47 @@ export function mapV5AnalysisToReport(
       enrichment: block.enrichment,
     })
 
+  // Headline `results` triple (conservative/likely/optimistic) is consumed
+  // by DetailedAnalysisSection, DecisionSummary, OutcomesSignal, and
+  // TemplatesPanel as the p10 / p50 / p90 of the headline option's outcome
+  // distribution. V4 derives these from the FIRST option's confidence_interval
+  // and emits `null` when the CI is absent (passing through the type's
+  // declared `number` via implicit narrowing — see
+  // src/adapters/plot/v2/responseMapper.ts:486-490). The V5 mapper mirrors
+  // that contract: prefer the LEADING option's outcome (semantically more
+  // meaningful than "first by array order"), fall back to the first
+  // option_comparison entry, and surface `null` when neither has usable
+  // quantiles. Fabricated zeros — earlier behaviour — would mislead every
+  // consumer to render "0" instead of "no data".
+  const headlineOption = (() => {
+    if (resolvedOptions.length === 0) return undefined
+    if (block.leading_option_id) {
+      const byLeader = resolvedOptions.find((r) => r.optionId === block.leading_option_id)
+      if (byLeader) return byLeader
+    }
+    return resolvedOptions[0]
+  })()
+  const headlineOutcome = isPlainObject(headlineOption?.enriched.outcome)
+    ? headlineOption!.enriched.outcome
+    : undefined
+  const headlineCI = Array.isArray(headlineOption?.enriched.confidence_interval)
+    ? headlineOption!.enriched.confidence_interval
+    : null
+  const headlineCiLow =
+    headlineCI && safeFiniteNumber(headlineCI[0]) !== undefined
+      ? (headlineCI[0] as number)
+      : null
+  const headlineCiHigh =
+    headlineCI && safeFiniteNumber(headlineCI[1]) !== undefined
+      ? (headlineCI[1] as number)
+      : null
+  const headlineConservative = safeFiniteNumber(headlineOutcome?.p10) ?? headlineCiLow
+  const headlineLikely =
+    safeFiniteNumber(headlineOutcome?.p50) ??
+    safeFiniteNumber(headlineOutcome?.mean) ??
+    (headlineCiLow != null && headlineCiHigh != null ? (headlineCiLow + headlineCiHigh) / 2 : null)
+  const headlineOptimistic = safeFiniteNumber(headlineOutcome?.p90) ?? headlineCiHigh
+
   const report: ReportV1 = {
     schema: 'report.v1',
     meta: {
@@ -466,10 +514,13 @@ export function mapV5AnalysisToReport(
       response_hash_algo: 'sha256',
       normalized: true,
     },
+    // Type lies (number, not number | null) — V4 does the same. Downstream
+    // consumers narrow-check before display; passing fabricated 0 here
+    // would render as "0" in DetailedAnalysisSection / DecisionSummary etc.
     results: {
-      conservative: 0,
-      likely: 0,
-      optimistic: 0,
+      conservative: headlineConservative as unknown as number,
+      likely: headlineLikely as unknown as number,
+      optimistic: headlineOptimistic as unknown as number,
     },
     confidence,
     drivers,


### PR DESCRIPTION
## Scope

PR #137 hydrates V5 `analysis_result` blocks into the V4-compatible results report shape so the **main Results panel** renders ranked options and probability data from V5 analysis turns.

**Scope inclusions (the entire PR):**
- `report.option_probabilities[option_id].win_probability` — consumed by `useResultsSectionData → recommendation.allOptions[].winProbability` (the main Results panel selector).
- `report.option_comparison[]` and `report.option_comparison_status` — consumed by `OutcomePanel.OptionComparisonSection` (inspector right-hand panel). **Scope-expansion during review:** V5 enrichment carries `option_comparison` byte-for-byte from PLoT, so the V5 path can fix the inspector without changing OutcomePanel.
- `report.drivers`, `factor_sensitivity`, `robustness`, `flip_thresholds`, `edge_e_values`, `conditional_probabilities` — the V4-mirror auxiliary fields the Results-panel data hook reads.

**Out-of-scope — explicit carve-outs:**
- ❌ **Not** a claim of full V5 experience readiness. Manual testing should remain targeted, not broad.
- ❌ **Step 3 label resolution** ("the relevant factor" placeholders for `remove_node` / multi-op edits) → **Area 3** (backend, separate PR).
- ❌ **`edit_graph` no-op telemetry** (honest `mutation_applied` + `operations_count` fields) → **Area 2** (backend).
- ❌ **`edit_graph` no-op latency** (negative-intent pre-LLM fast path) → **Area 2** (backend).
- ❌ **Chip/coaching coherence** (evidence ranker + chip accumulation 1→4-5) → **Areas 4a + 4b** (backend).
- ❌ **Debug observability** (CEE trace nulls, bundle capture gaps) → separate workstream.
- ❌ **V4 `option_comparison` gap** — V4's `mapV2ResponseToReportV1` still doesn't populate `report.option_comparison`. Pre-existing debt, not addressed here. V5 turns get the fix; V4 turns do not.

## Commit chain (latest first)

| SHA | Subject | Round |
|---|---|---|
| `95db9bd0` | duplicate-label safety + stableStringify contract | Round-2 review |
| `111bddec` | enrichment-aware hash + option_comparison passthrough | Round-1 review |
| `d387346a` | hydrate Results panel from V5 analysis_result blocks (Area 1 / P0) | Initial |

## Files changed (9 total, against `origin/staging`)

| Type | File | Purpose |
|---|---|---|
| 📝 modified | `src/canvas/conversation/useConversation.ts` | Splice `results.hash` → `currentResultsHash` into `applyV5State` call (one block, V5 send-path) |
| ✨ new | `src/v5/mapV5AnalysisToReport.ts` | Pure mapper, V4-mirror shape, label-keyed `win_probabilities` resolution via `enrichment.option_comparison`, duplicate-label safety |
| ✨ new | `src/v5/__tests__/mapV5AnalysisToReport.test.ts` | 42 unit tests — base + real-staging payload + duplicate-label cases + hash dedupe |
| 📝 modified | `src/v5/applyV5State.ts` | Add step 5 (results hydration), optional `resultsComplete` + `currentResultsHash` on `V5ApplicatorStore` |
| ✨ new | `src/v5/__tests__/applyV5State.results-hydration.test.ts` | 12 integration tests for step 5 |
| 📝 modified | `src/v5/__tests__/applyV5State.debug.test.ts` | Lift step-count expectation 4→5 |
| 📝 modified | `src/v5/debugLog.ts` | Add `5` to `step_number` union |
| ✨ new | `src/v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json` | Redacted excerpt of the real staging V5 envelope (captured 2026-04-30 against `cee-staging.onrender.com` build `3bb151b`) |
| ✨ new | `src/components/results/__tests__/v5-analysis-to-results-panel.wire-to-selector.spec.ts` | 3 wire-to-selector tests proving the field-path `report.option_probabilities[option_id].win_probability` surfaces on the Results panel selector with exact staging values |

**Forbidden file types in diff:** none (verified — no `package.json`, no lockfile, no `.npmrc`, no `/migrations/`, no `/schemas/`, no `/prompts/`, no `.sql`, no backend files).

## Verification (against HEAD `95db9bd0`)

| Check | Result |
|---|---|
| V5 test suite (`pnpm vitest run src/v5/ + wire-to-selector.spec.ts`) | **397 / 397 pass** (27 files) |
| Typecheck (`pnpm typecheck` = `tsc -p tsconfig.ci.json --noEmit`) | **clean** |
| Diff scope vs `origin/staging` | **9 files** — all in V5 / Results-test / V5-send-path |
| `package.json` / lockfile / `.npmrc` churn | **none** |
| Untracked artefacts | **none** |
| macOS Finder ` 2.ts` / ` 3.ts` duplicates in diff | **none** |
| Pre-existing baseline noise (`conversation-flow.spec.ts` 12 / 12 fail) | **identical on HEAD vs `origin/staging`** — confirmed by stash-pop. Tracked in brief §10 item 2. |

## Real-payload grounding

The mapper is tested against a real staging V5 envelope captured 2026-04-30 against `cee-staging.onrender.com` build `3bb151b`. The captured shape revealed the **label-keyed `win_probabilities`** behaviour the original draft would have silently failed on, leading to:
- Mapper resolves label-keyed keys to canonical option_ids via `enrichment.option_comparison.option_label` lookup.
- `sensitivity_score` prioritised over `elasticity` (staging normalises elasticity to 1 for the top factor, masking actual magnitude).
- Duplicate-label safety: when two options share a label AND lack per-entry `option_comparison.win_probability`, both surface with `win_probability` **omitted** (honest miss) rather than each receiving the same shared value (false precision).
- Hash includes the full enrichment via stable canonical serialisation so enrichment-only deltas re-hydrate (factor_sensitivity / robustness changes are not silently deduped away).

## Visible-render / selector-level proof

`src/components/results/__tests__/v5-analysis-to-results-panel.wire-to-selector.spec.ts` exercises the end-to-end chain:

```
V5 envelope
  → mapV5AnalysisToReport
  → applyV5State step 5
  → store.resultsComplete payload
  → useCanvasStore.results.report
  → useResultsSectionData
  → recommendation.allOptions[].winProbability
```

…and asserts exact match against the staging envelope:

```ts
expect(byId.get('opt_hire_local')?.winProbability).toBe(0.7193333333333334)
expect(byId.get('opt_offshore')?.winProbability).toBe(0.054)
expect(byId.get('opt_status_quo')?.winProbability).toBe(0.22533333333333333)
expect(byId.get('opt_tiered_pricing')?.winProbability).toBe(0.0013333333333333333)
```

## Test plan

- [x] Mapper unit tests — 42 pass (real-staging fixture, dual-shape factor_sensitivity, duplicate-label safety, hash stability, option_comparison passthrough).
- [x] Applicator integration tests — 12 pass (step 5 contract).
- [x] Wire-to-selector tests — 3 pass (end-to-end field-path assertion).
- [x] Pre-existing `applyV5State` tests — 53 pass, unchanged.
- [x] V5 suite total — 397 tests pass across 27 files.
- [x] `pnpm typecheck` — clean.
- [x] No `package.json` / lockfile / `.npmrc` churn.
- [x] No backend / schema / prompt / migration files touched.
- [x] No unrelated UI files touched.
- [ ] Codex final-round review (in progress — this PR is paused at HEAD `95db9bd0` pending review).
- [ ] Manual smoke on staging after merge: confirm Results panel + OutcomePanel render ranked options with numeric win probabilities for a real V5 `run_analysis` turn.

## Follow-up debt (tracked in brief §10)

1. **OutcomePanel.OptionComparisonSection for V4 turns** — V5 fixed in this PR via passthrough; V4 mapper still doesn't populate `report.option_comparison`. Out of scope.
2. **12 `conversation-flow` URL-parse test failures** — pre-existing baseline noise on `origin/staging @ b5802b78`; `useGraphReadiness.ts:76` `fetch(relative-url)` in vitest env. Not caused by this PR.
3. **macOS Finder ` 2.ts` / ` 3.ts` duplicates** — iCloud sync artefacts cleaned locally during PR work. Recommend `.gitignore` rule.
4. **`win_probabilities` key-shape ambiguity** — schema-level tightening in `olumi-schemas/src/boundary/blocks.ts` could let the mapper drop its path-B label fallback.
5. **Sensitivity alias priority** — documented (`sensitivity_score > sensitivity > elasticity > importance_score`); revisit if PLoT changes which field carries the canonical magnitude.
6. **Duplicate-label safety** — FIXED in `95db9bd0`. Backend should populate `option_comparison.win_probability` per-option when duplicate-label configurations are possible.
7. **Hash over-invalidation if backend adds volatile fields** — deferred per round-2 reviewer. Mitigation if it appears: hash a UI-consumed projection of enrichment rather than the raw object.

## Do not merge

This PR is paused at HEAD `95db9bd0` pending **final focused Codex review**. Do not merge until Paul confirms.

Brief: `~/.claude/plans/area-1-v5-analysis-hydration-brief.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)