### PR TITLE
feat(v5): UI chip whitelist + plural dispatch mapping for Phase 2b (companion to olumi-assistants-service#170)

### DIFF
--- a/src/canvas/conversation/__tests__/SuggestedChips.readinessGate.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.readinessGate.spec.tsx
@@ -127,6 +127,82 @@ describe('SuggestedChips readiness gate', () => {
     expect(screen.queryByTestId('suggested-chip-chip_unknown')).toBeNull()
   })
 
+  // Phase 2b of the V5 completion plan (2026-05-13): backend PR
+  // olumi-assistants-service#170 emits post-analysis "Explain the result"
+  // and decide-fragile "What would make this flip?" as executable
+  // action_type chips so the new dispatchDeterministicChipClick path can
+  // bypass Sonnet ORIENT (~12s win per click). The V5 UI filter must
+  // recognise these as known executable chips, otherwise they'd be
+  // treated as "unknown" by the test above and HIDDEN — defeating the
+  // user-visible latency win.
+  it('shows explain_results chip when V5 is active (Phase 2b — added to V5_ENABLED_ACTIONS)', () => {
+    setReady('ready')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'chip_action_explain_results',
+            label: 'Explain the result',
+            action_type: 'explain_results',
+          }),
+        ]}
+        onChipClick={vi.fn()}
+      />,
+    )
+    expect(
+      screen.getByTestId('suggested-chip-chip_action_explain_results'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows what_would_flip chip when V5 is active (Phase 2b)', () => {
+    setReady('ready')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'chip_action_what_would_flip',
+            label: 'What could change the outcome?',
+            action_type: 'what_would_flip',
+          }),
+        ]}
+        onChipClick={vi.fn()}
+      />,
+    )
+    expect(
+      screen.getByTestId('suggested-chip-chip_action_what_would_flip'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows explain_results AND what_would_flip even without analysis readiness (NOT readiness-gated like run_analysis)', () => {
+    // These are post-analysis-context chips that wrap deterministic
+    // explanation handlers — they don't require a fresh analysis to be
+    // useful. Only `run_analysis` itself is readiness-gated.
+    setReady(null) // no readiness
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'chip_action_explain_results',
+            label: 'Explain the result',
+            action_type: 'explain_results',
+          }),
+          makeChip({
+            id: 'chip_action_what_would_flip',
+            label: 'What could change the outcome?',
+            action_type: 'what_would_flip',
+          }),
+        ]}
+        onChipClick={vi.fn()}
+      />,
+    )
+    expect(
+      screen.getByTestId('suggested-chip-chip_action_explain_results'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('suggested-chip-chip_action_what_would_flip'),
+    ).toBeInTheDocument()
+  })
+
   it('does not hide run_analysis when V5 is off (V4 passthrough)', () => {
     vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', '')
     setReady(null) // no readiness, but V5 is off so the gate does not apply

--- a/src/canvas/conversation/__tests__/dispatchAction.spec.ts
+++ b/src/canvas/conversation/__tests__/dispatchAction.spec.ts
@@ -19,6 +19,12 @@ describe('ACTION_TO_TURN_TYPE mapping', () => {
   const expectedMappings: Record<string, string> = {
     run_analysis: 'run_analysis',
     explain_result: 'explain',
+    // Phase 2b of the V5 completion plan (2026-05-13): backend handler ID
+    // is the PLURAL `explain_results`. Singular kept as legacy alias
+    // because chip-generator's prompt chips used it as a discriminator.
+    // Both must map identically to 'explain' so the deterministic
+    // chip-click bypass fires regardless of which alias the chip carries.
+    explain_results: 'explain',
     compare_options: 'explain',
     what_would_flip: 'explain',
     challenge_assumption: 'conversation',

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -1096,7 +1096,17 @@ export interface PatchRejectionInfo {
 /** Deterministic action_type → turn type mapping. Falls back to 'conversation' for unknown actions. Exported for tests. */
 export const ACTION_TO_TURN_TYPE: Record<string, Exclude<TurnType, 'system_event'>> = {
   run_analysis: 'run_analysis',
+  // V5 backend handler ID is the PLURAL `explain_results` (see backend
+  // `src/orchestrator-v5/handlers/chip-click-dispatch.ts:137-141` whitelist +
+  // `src/orchestrator-v5/compose/chip-generator.ts` chip emission, post-
+  // Phase-2b). Singular `explain_result` retained as a legacy alias because
+  // the chip-generator's `promptChip(...)` used it as a discriminator string
+  // for years and existing chip surfaces still emit it; either form must
+  // reach the same 'explain' turn type so dispatch is consistent and the
+  // deterministic chip-click bypass fires regardless of which alias the
+  // chip carries.
   explain_result: 'explain',
+  explain_results: 'explain',
   compare_options: 'explain',
   what_would_flip: 'explain',
   challenge_assumption: 'conversation',

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -23,7 +23,20 @@ import type { ActionChip } from '../types'
 // Actions that V5 CEE handles end-to-end. Chips whose action_type is set and
 // not in this list are filtered out when V5 is active. On V4 this set is
 // unused — all chips pass through unchanged.
-const V5_ENABLED_ACTIONS = new Set<string>(['run_analysis', 'edit_graph', 'draft_graph'])
+//
+// Phase 2b of the V5 completion plan (2026-05-13): added `explain_results`
+// and `what_would_flip`. Backend PR olumi-assistants-service#170 emits these
+// as executable `action_type` chips and the new
+// `dispatchDeterministicChipClick` path bypasses Sonnet ORIENT (~12s saved
+// per click). Without these entries here, the V5 UI's filter below would
+// HIDE the new executable chips, defeating the latency fix entirely.
+const V5_ENABLED_ACTIONS = new Set<string>([
+  'run_analysis',
+  'edit_graph',
+  'draft_graph',
+  'explain_results',
+  'what_would_flip',
+])
 
 // Chips whose action_type is in this set require analysis readiness
 // (ceeAnalysisReady.status === 'ready') before they can render. Without it,


### PR DESCRIPTION
## Summary

Closes the user-facing latency win for backend PR olumi-assistants-service#170 by ensuring the V5 UI surfaces the new executable chips backend #170 emits.

Reviewer of #170 correctly identified the gap: `V5_ENABLED_ACTIONS` in `SuggestedChips.tsx` was `['run_analysis', 'edit_graph', 'draft_graph']` — so when backend #170 started emitting `action_type: 'explain_results'` / `'what_would_flip'` chips, the V5 UI filter HID them as "unknown action_type". Backend bypass implemented, but the common user path never fires. This PR closes that gap.

## Paired deployment with olumi-assistants-service#170 — order is mandatory

**Merge + deploy backend olumi-assistants-service#170 FIRST. Only then merge + deploy this PR.** Do NOT deploy this PR before #170.

Why: if this UI PR ships to staging ahead of #170, the V5 UI would expose chips whose backend dispatcher does not yet exist on staging. The chip-click would fall through to the legacy `chip.action_type === 'run_analysis'` gate, miss the new whitelist, and degrade to the slow Sonnet path with no fallback — strictly worse than the pre-PR baseline for any user landing on staging mid-deploy.

The previous version of this PR body suggested either order was fine; that was incorrect and is corrected by the V5 tracker (DGAI #139) per the 2026-05-13 directional correction.

## Changes

1. **`src/canvas/conversation/zones/SuggestedChips.tsx:23-37`** — extend `V5_ENABLED_ACTIONS` to include `explain_results` and `what_would_flip`. Neither is readiness-gated — the wrapped deterministic handlers don't require a fresh analysis to produce useful output.
2. **`src/canvas/conversation/useConversation.ts:1097-1112`** — extend `ACTION_TO_TURN_TYPE` with the PLURAL `explain_results: 'explain'` (matches backend handler ID per `chip-click-dispatch.ts:137-141` whitelist). Singular `explain_result` retained as legacy alias.

## Tests

- **`SuggestedChips.readinessGate.spec.tsx`** — 3 new cases:
  - `explain_results` chip shown when V5 active.
  - `what_would_flip` chip shown when V5 active.
  - BOTH shown without analysis readiness (not readiness-gated like `run_analysis`).
- **`dispatchAction.spec.ts`** — extended `expectedMappings` with `explain_results: 'explain'`. (This file fails to load due to a pre-existing baseline supabase-import issue unrelated to this PR; the assertion lands in the right place so it works once the baseline is fixed. Runtime contract is covered by SuggestedChips component tests.)

## Verification (baseline-diff principle)

| Check | Result |
|---|---|
| Targeted (SuggestedChips suites) | ✅ 24/24 (21 prior + 3 new) |
| Full V5 suite | ✅ 403/403 unchanged |
| exportBundle suite | ✅ 132/132 unchanged |
| Wire-to-selector test | ✅ 3/3 unchanged |
| Aggregate (V5 + SuggestedChips + wire-to-selector) | ✅ 446/446 |
| `pnpm typecheck` | ✅ clean |
| Baseline-diff vs `origin/staging @ 21c6d1e2` | ✅ zero NEW deterministic failures |
| package.json / pnpm-lock.yaml churn | ✅ none |

**Baseline-diff testing discipline.** The full test suite is NOT described as green in this PR. The known baseline-failure state pre-dates this PR and is tracked under Phase 4 methodology cleanup in the V5 tracker (DGAI #139). The merge criterion here is "no NEW deterministic failures vs baseline" — met.

## End-to-end flow (post-merge of #170 then this PR)

```
1. Backend run_analysis succeeds.
2. Backend chip-generator emits two executable chips:
   { id: 'chip_action_explain_results',  action_type: 'explain_results',  ... }
   { id: 'chip_action_what_would_flip',  action_type: 'what_would_flip',  ... }
3. UI SuggestedChips filter sees BOTH action_types in V5_ENABLED_ACTIONS → renders.
4. User clicks "Explain the result":
   - UI dispatchAction maps explain_results → 'explain' turn type.
   - Backend route-v2 sees chip.action_type === 'explain_results' → routes to
     dispatchDeterministicChipClick (bypassing Sonnet ORIENT, ~12s saved).
   - Handler receives hydrated context from prior run_analysis fact via
     buildAnalysisFromPriorFacts.
   - Deterministic-fallback prose composer produces explanation.
5. Result: <2s end-to-end vs ~13s previously.
```

## Scope

- Phase 2b UI complement to backend #170 only.
- Does NOT address Phase 2a (#169), Phase 2c (raw-value suppression, read-only diagnosis in progress), Phase 2d (no-op handling), Phase 1 debug exporter (#138), or Phase 3+ coaching.
- V4 path unaffected.

## Brief / Tracker

Phase 2b section in `V5_CURRENT_STATE.md` (DGAI #139). The tracker records the paired-deployment ordering and the Option (i) ship-as-is trade-off resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)