### PR TITLE
fix(v5): drop "recommendation" from two user-facing Results strings

### DIFF
--- a/src/components/results/StressTestSection.tsx
+++ b/src/components/results/StressTestSection.tsx
@@ -105,7 +105,7 @@ function SensitiveAssumptionCard({
     >
       <span className={`${typography.panelMeta} text-warning`}>Sensitive</span>
       <p className={`${typography.panelBody} text-text-body`}>
-        {cleanLabel}. A shift could change the recommendation.
+        {cleanLabel}. A shift could change the result.
       </p>
       <button
         type="button"

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -151,7 +151,7 @@ function mapEvidenceGapsToActions(
     // through the shared resolver so pre- and post-analysis agree.
     const { text: detail } = resolveTriageBodyText({
       coaching: gap.suggestion,
-      generic: `This factor has ${gap.confidence}% confidence. Improving it could change the recommendation.`,
+      generic: `This factor has ${gap.confidence}% confidence. Improving it could change the result.`,
     })
     return {
       key: `gap-${gap.factorId}-${i}`,


### PR DESCRIPTION
## Summary

V5 P0 stabilisation companion to backend PR Talchain/olumi-assistants-service#173. Two user-facing strings in the Results tab still emit "recommendation"; replaced with "result" per the brief.

- [src/components/results/StressTestSection.tsx#L108](src/components/results/StressTestSection.tsx#L108) — "A shift could change the recommendation." → "A shift could change the result."
- [src/components/results/TriageActionCardsBody.tsx#L154](src/components/results/TriageActionCardsBody.tsx#L154) — "Improving it could change the recommendation." → "Improving it could change the result."

## Scope — deliberately narrow

This PR is **intentionally a two-string patch**, scoped per the original brief. Other surfaces still using "recommendation" exist in the codebase but are **out of scope** for this PR and should land in a follow-up sweep:

- [src/components/results/ChallengeSection.tsx#L131](src/components/results/ChallengeSection.tsx#L131), [#L258](src/components/results/ChallengeSection.tsx#L258), [#L264](src/components/results/ChallengeSection.tsx#L264) — Challenge Section prose
- [src/components/results/ConditionalWinnerCards.tsx#L69](src/components/results/ConditionalWinnerCards.tsx#L69) — "Factors that change the recommendation when they shift"
- [src/canvas/components/model-tab/RelationshipsSection.tsx#L659](src/canvas/components/model-tab/RelationshipsSection.tsx#L659) — Fragile-relationships prose (model tab, not Results)
- [src/canvas/components/ConditionalGuidance/types.ts#L65](src/canvas/components/ConditionalGuidance/types.ts#L65) — TypeScript type doc-comment (non-rendered)
- [src/components/results/analysisHeroV17/rowRanking.ts#L135](src/components/results/analysisHeroV17/rowRanking.ts#L135) — Source comment (non-rendered)

If you'd prefer this PR be expanded into a full Results-surface sweep instead, say so and I'll roll the additional component edits into the same branch.

## Companion / pairing

Backend (CEE) PR: Talchain/olumi-assistants-service#173 adds defence-in-depth regex for `recommendation` / `recommended` / `the winner` / `winning (option|probability|side|choice|outcome)`. Both PRs ship independently (no order-of-deploy constraint). The DGAI strings are user-authored copy, not LLM-emitted; they don't depend on the CEE egress guard.

## Test plan

- [x] `pnpm vitest run StressTestSection.spec.tsx StressTestSection.factorSensitivityIntegration.spec.tsx` — 19/19 pass
- [x] `pnpm vitest run glossaryCompliance.spec.tsx p1Fixes.spec.tsx bodyLabelSafety.spec.tsx` (exercise `resolveTriageBodyText`) — 103/103 pass
- [x] `pnpm exec tsc --noEmit` — zero new errors
- [x] Pre-push hooks all green

## Bundle budget

No risk — pure string replacement, no net delta.

## Review

Pausing for Paul/ChatGPT-led review. **Do not merge without explicit authorisation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)