### PR TITLE
feat(results): B3 auto-noise disclosure + provenance — rebased onto staging

### DIFF
--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -408,6 +408,36 @@ export interface V2RunResponse {
   dominant_factor?: { factor_id: string; factor_label: string }
 
   // ==========================================================================
+  // Audit B3 (P0) — auto-noise disclosure
+  // ==========================================================================
+
+  /**
+   * Whether ISL applied its operational auto-noise heuristic on this run.
+   * Echoed verbatim from ISL's `_metadata.auto_noise_applied`. `null` when
+   * ISL omitted the flag entirely (PLoT logs `auto_noise_flag_missing_from_isl`
+   * when this happens on a computed/partial response). Absent on
+   * `analysis_status: 'blocked' | 'failed'`.
+   */
+  auto_noise_applied?: boolean | null
+  /**
+   * Analysis-level auto-noise provenance metadata (audit B3). Always
+   * carries full formula provenance, including when `applied: false`.
+   * Absent on `analysis_status: 'blocked' | 'failed'`. Forward-compat:
+   * enum slots are typed `string` so future calibration values from PLoT
+   * do not crash old UI builds (mirrors A1 `confidence_provenance`).
+   */
+  auto_noise_provenance?: {
+    applied: boolean
+    effect: string
+    formula_version: string
+    multiplier: number
+    noise_distribution: string
+    filter_scope: string
+    is_provisional: boolean
+    calibration_status: string
+  }
+
+  // ==========================================================================
   // M1 CEE Review Fields (optional enrichment)
   // ==========================================================================
 

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -284,8 +284,8 @@ export const ModelTabBody = memo(function ModelTabBody({
       return Array.isArray(raw) ? raw : null
     })(),
     recommendationStability: robustness?.recommendationStability ?? null,
-    autoNoiseApplied: (rawV2Response as any)?.auto_noise_applied ?? (rawV2Response as any)?._meta?.auto_noise_applied ?? null,
-    autoNoiseProvenance: normalizeAutoNoiseProvenance((rawV2Response as any)?.auto_noise_provenance),
+    autoNoiseApplied: rawV2Response?.auto_noise_applied ?? null,
+    autoNoiseProvenance: normalizeAutoNoiseProvenance(rawV2Response?.auto_noise_provenance),
     stabilityPenaltyFactor: (rawV2Response as any)?.stability_penalty_factor ?? null,
   }), [rawV2Response, repairsApplied, results, robustness])
 

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -32,6 +32,7 @@ import type { UserAction, ValidationMetadata } from '../domain/validation'
 import type { EdgeData } from '../domain/edges'
 import { RisksSection } from './model-tab/RisksSection'
 import { ModelHealthSection } from './model-tab/ModelHealthSection'
+import { normalizeAutoNoiseProvenance } from '../../components/results/types'
 import { ModelTabHeader } from './model-tab/ModelTabHeader'
 import { ReanalyseBar } from './model-tab/ReanalyseBar'
 import { ModelFooter } from './model-tab/ModelFooter'
@@ -284,6 +285,7 @@ export const ModelTabBody = memo(function ModelTabBody({
     })(),
     recommendationStability: robustness?.recommendationStability ?? null,
     autoNoiseApplied: (rawV2Response as any)?.auto_noise_applied ?? (rawV2Response as any)?._meta?.auto_noise_applied ?? null,
+    autoNoiseProvenance: normalizeAutoNoiseProvenance((rawV2Response as any)?.auto_noise_provenance),
     stabilityPenaltyFactor: (rawV2Response as any)?.stability_penalty_factor ?? null,
   }), [rawV2Response, repairsApplied, results, robustness])
 

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -284,7 +284,15 @@ export const ModelTabBody = memo(function ModelTabBody({
       return Array.isArray(raw) ? raw : null
     })(),
     recommendationStability: robustness?.recommendationStability ?? null,
-    autoNoiseApplied: rawV2Response?.auto_noise_applied ?? null,
+    // Legacy fallback: older PLoT builds emitted the flag under `_meta`
+    // before it was promoted to a top-level field. Cached/hydrated bundles
+    // captured pre-promotion still rely on this read path; without it the
+    // Model card audit row vanishes for those bundles. Same `as any` shape
+    // as stabilityPenaltyFactor below (legacy fields aren't on V2RunResponse).
+    autoNoiseApplied:
+      rawV2Response?.auto_noise_applied
+      ?? (rawV2Response as any)?._meta?.auto_noise_applied
+      ?? null,
     autoNoiseProvenance: normalizeAutoNoiseProvenance(rawV2Response?.auto_noise_provenance),
     stabilityPenaltyFactor: (rawV2Response as any)?.stability_penalty_factor ?? null,
   }), [rawV2Response, repairsApplied, results, robustness])

--- a/src/canvas/components/__tests__/ModelTabBody.autoNoiseFallback.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.autoNoiseFallback.spec.tsx
@@ -1,0 +1,159 @@
+/**
+ * Regression: the `_meta.auto_noise_applied` legacy fallback in
+ * ModelTabBody's auditTrail selector. Older PLoT builds emitted the
+ * flag only under `_meta`; cached or Supabase-hydrated bundles
+ * captured pre-promotion still rely on this read path. The B3
+ * disclosure work (PR for `claude-plot-ui/b3-auto-noise-disclosure`)
+ * tightened the selector to `V2RunResponse` types and accidentally
+ * dropped the fallback in an earlier draft. This spec locks the
+ * fallback in so future additive work cannot hide existing audit
+ * metadata.
+ *
+ * Strategy: mock ModelHealthSection with a spy and capture the
+ * `auditTrail` prop ModelTabBody passes. That isolates the selector
+ * logic from the Accordion's expansion behaviour and from any
+ * rendering changes in the audit section itself.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+import { ModelTabBody } from '../ModelTabBody'
+
+// ── Mock state matching ModelTabBody.spec.tsx pattern, plus rawV2Response ────
+
+const mockUpdateNode = vi.fn()
+const mockUpdateEdge = vi.fn()
+const mockSetHighlightedNodes = vi.fn()
+const mockSetHighlightedEdges = vi.fn()
+
+let mockRawV2Response: unknown = null
+
+function getMockState() {
+  return {
+    updateNode: mockUpdateNode,
+    updateEdge: mockUpdateEdge,
+    ceePipelineTrace: null,
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+    setHighlightedNodes: mockSetHighlightedNodes,
+    setHighlightedEdges: mockSetHighlightedEdges,
+    currentScenarioId: null,
+    currentStage: null,
+    graphEditedSinceLastRun: false,
+    rawV2Response: mockRawV2Response,
+  }
+}
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    vi.fn((selector: (s: any) => any) => selector(getMockState())),
+    { getState: getMockState },
+  ),
+}))
+
+vi.mock('../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// Spy on ModelHealthSection — capture the `auditTrail` prop ModelTabBody
+// hands down. The selector under test is the inline `useMemo(auditTrail …)`
+// in ModelTabBody; this mock isolates it from rendering concerns.
+const modelHealthSpy = vi.fn()
+vi.mock('../model-tab/ModelHealthSection', () => ({
+  ModelHealthSection: (props: { auditTrail: unknown }) => {
+    modelHealthSpy(props.auditTrail)
+    return null
+  },
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeGoalNode(): Node {
+  return { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Pick the right vendor' } }
+}
+
+function makeFactorNode(): Node {
+  return {
+    id: 'f1',
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Budget',
+      category: 'observable',
+      observedState: { value: 0.5 },
+    },
+  }
+}
+
+const DEFAULT_PROPS = {
+  showDebug: false,
+  hasDiagnostics: false,
+  diagnostics: null,
+  hasTrim: false,
+  effectiveCorrelationId: null,
+  correlationMismatch: false,
+  correlationIdHeader: null,
+  robustness: null,
+}
+
+function renderTabAndCaptureAuditTrail() {
+  modelHealthSpy.mockClear()
+  render(
+    <ModelTabBody
+      {...DEFAULT_PROPS}
+      nodes={[makeGoalNode(), makeFactorNode()] as Node[]}
+      edges={[] as Edge[]}
+    />,
+  )
+  // ModelHealthSection is rendered unconditionally on line 664 of
+  // ModelTabBody — exactly one call expected.
+  expect(modelHealthSpy).toHaveBeenCalled()
+  return modelHealthSpy.mock.calls[0][0] as { autoNoiseApplied: boolean | null }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRawV2Response = null
+})
+
+describe('ModelTabBody auditTrail selector — _meta.auto_noise_applied legacy fallback', () => {
+  it('falls back to _meta.auto_noise_applied when the top-level field is absent', () => {
+    // Legacy shape: cached/hydrated bundles captured before the flag was
+    // promoted to a top-level field. Only `_meta.auto_noise_applied`
+    // carries the signal.
+    mockRawV2Response = { _meta: { auto_noise_applied: true } }
+    const auditTrail = renderTabAndCaptureAuditTrail()
+    expect(auditTrail.autoNoiseApplied).toBe(true)
+  })
+
+  it('top-level field wins over _meta when both are present', () => {
+    // Top-level `false` + `_meta` `true` → selector resolves to `false`.
+    mockRawV2Response = {
+      auto_noise_applied: false,
+      _meta: { auto_noise_applied: true },
+    }
+    const auditTrail = renderTabAndCaptureAuditTrail()
+    expect(auditTrail.autoNoiseApplied).toBe(false)
+  })
+
+  it('top-level true is preserved even when _meta is undefined', () => {
+    mockRawV2Response = { auto_noise_applied: true }
+    const auditTrail = renderTabAndCaptureAuditTrail()
+    expect(auditTrail.autoNoiseApplied).toBe(true)
+  })
+
+  it('returns null when neither top-level nor _meta carries the flag', () => {
+    mockRawV2Response = {} // no signal at all
+    const auditTrail = renderTabAndCaptureAuditTrail()
+    expect(auditTrail.autoNoiseApplied).toBeNull()
+  })
+
+  it('returns null when rawV2Response itself is null', () => {
+    mockRawV2Response = null
+    const auditTrail = renderTabAndCaptureAuditTrail()
+    expect(auditTrail.autoNoiseApplied).toBeNull()
+  })
+})

--- a/src/canvas/components/model-tab/ModelHealthSection.tsx
+++ b/src/canvas/components/model-tab/ModelHealthSection.tsx
@@ -235,19 +235,33 @@ function ModelHealthSectionInner({
                   </span>
                 </>
               )}
-              {auditTrail.autoNoiseApplied != null && (
-                <>
-                  <span className={`${typography.panelMeta} text-text-light`}>Outcome uncertainty adjustment</span>
-                  <span
-                    className={`${typography.panelMeta} text-text-body text-right`}
-                    data-testid="model-health-auto-noise-row"
-                  >
-                    {auditTrail.autoNoiseApplied
-                      ? 'Operational adjustment applied (calibration pending).'
-                      : 'No additional uncertainty adjustment applied.'}
-                  </span>
-                </>
-              )}
+              {(() => {
+                // Audit B3: prefer the explicit boolean echo, but fall
+                // back to the structured provenance's `applied` field
+                // when the boolean is null and provenance is valid. This
+                // keeps the accordion useful under payload drift where
+                // PLoT might emit the structured block alone (a
+                // future-state we don't expect today, but defending
+                // against costs nothing).
+                const applied =
+                  auditTrail.autoNoiseApplied
+                  ?? auditTrail.autoNoiseProvenance?.applied
+                  ?? null
+                if (applied == null) return null
+                return (
+                  <>
+                    <span className={`${typography.panelMeta} text-text-light`}>Outcome uncertainty adjustment</span>
+                    <span
+                      className={`${typography.panelMeta} text-text-body text-right`}
+                      data-testid="model-health-auto-noise-row"
+                    >
+                      {applied
+                        ? 'Operational adjustment applied (calibration pending).'
+                        : 'No additional uncertainty adjustment applied.'}
+                    </span>
+                  </>
+                )
+              })()}
               {auditTrail.stabilityPenaltyFactor != null && (
                 <>
                   <span className={`${typography.panelMeta} text-text-light`}>Stability penalty</span>

--- a/src/canvas/components/model-tab/ModelHealthSection.tsx
+++ b/src/canvas/components/model-tab/ModelHealthSection.tsx
@@ -15,6 +15,7 @@ import { SectionErrorBoundary } from '../GraphTextView'
 import { Accordion } from '../../../components/results/Accordion'
 import type { CeeQualityDimensions } from '../../store'
 import { DetailToggleContext } from './DetailToggleContext'
+import type { AutoNoiseProvenance } from '../../../components/results/types'
 
 /** Audit trail data from PLoT response */
 export interface AuditTrailData {
@@ -25,6 +26,14 @@ export interface AuditTrailData {
   inferenceWarnings: Array<{ code?: string; severity?: string; message?: string }> | null
   recommendationStability: number | null
   autoNoiseApplied: boolean | null
+  /**
+   * Audit B3 (P0): structured disclosure metadata for the auto-noise
+   * adjustment. Null when the response is from an older PLoT build that
+   * does not emit the field, or when normalisation rejected a malformed
+   * payload — the accordion falls back to the legacy `autoNoiseApplied`
+   * boolean and the visible marker simply does not render.
+   */
+  autoNoiseProvenance: AutoNoiseProvenance | null
   stabilityPenaltyFactor: number | null
 }
 
@@ -228,9 +237,14 @@ function ModelHealthSectionInner({
               )}
               {auditTrail.autoNoiseApplied != null && (
                 <>
-                  <span className={`${typography.panelMeta} text-text-light`}>Auto-noise</span>
-                  <span className={`${typography.panelMeta} text-text-body text-right`}>
-                    {auditTrail.autoNoiseApplied ? 'Applied' : 'Not applied'}
+                  <span className={`${typography.panelMeta} text-text-light`}>Outcome uncertainty adjustment</span>
+                  <span
+                    className={`${typography.panelMeta} text-text-body text-right`}
+                    data-testid="model-health-auto-noise-row"
+                  >
+                    {auditTrail.autoNoiseApplied
+                      ? 'Operational adjustment applied (calibration pending).'
+                      : 'No additional uncertainty adjustment applied.'}
                   </span>
                 </>
               )}

--- a/src/canvas/components/model-tab/ModelHealthSection.tsx
+++ b/src/canvas/components/model-tab/ModelHealthSection.tsx
@@ -117,6 +117,12 @@ function ModelHealthSectionInner({
       auditTrail.nSamples != null ||
       auditTrail.recommendationStability != null ||
       auditTrail.autoNoiseApplied != null ||
+      // Audit B3 (P0): provenance counts as an audit signal in its own
+      // right. Without this, a payload-drift case where the boolean is
+      // null but valid provenance exists would treat the whole section
+      // as pre-analysis, producing mixed pre-analysis copy alongside the
+      // provenance-fallback row that the audit-trail render block emits.
+      auditTrail.autoNoiseProvenance != null ||
       auditTrail.stabilityPenaltyFactor != null ||
       (auditTrail.repairsApplied != null && auditTrail.repairsApplied.length > 0) ||
       (auditTrail.inferenceWarnings != null && auditTrail.inferenceWarnings.length > 0)

--- a/src/canvas/components/model-tab/__tests__/ModelHealthSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/ModelHealthSection.spec.tsx
@@ -242,6 +242,41 @@ describe('ModelHealthSection', () => {
       expect(screen.queryByTestId('model-health-auto-noise-row')).not.toBeInTheDocument()
     })
 
+    it('treats autoNoiseProvenance alone as an audit signal (no mixed pre-analysis content)', () => {
+      // Audit-feedback P1-3: payload drift where provenance arrives
+      // without the boolean must not trip the pre-analysis branch — that
+      // would render the "Run analysis to see..." copy alongside the
+      // provenance-fallback row that the audit-trail block emits.
+      render(
+        <DetailToggleContext.Provider value={{ showDetail: true }}>
+          <ModelHealthSection
+            auditTrail={makeAudit({
+              autoNoiseApplied: null,
+              autoNoiseProvenance: {
+                applied: true,
+                effect: 'widens_outcome_and_risk_uncertainty',
+                formulaVersion: 'plot_auto_v1',
+                multiplier: 1.0,
+                noiseDistribution: 'normal_zero_mean_outcome_std',
+                filterScope: 'outcome_and_risk_nodes',
+                isProvisional: true,
+                calibrationStatus: 'provisional_pending_pilot_calibration',
+              },
+              seedUsed: null,
+              responseHash: null,
+              nSamples: null,
+              recommendationStability: null,
+              stabilityPenaltyFactor: null,
+            })}
+          />
+        </DetailToggleContext.Provider>
+      )
+      // Pre-analysis block must NOT render — provenance is enough signal.
+      expect(screen.queryByTestId('model-card-pre-analysis')).not.toBeInTheDocument()
+      // The provenance-derived audit row IS rendered.
+      expect(screen.getByTestId('model-health-auto-noise-row')).toBeInTheDocument()
+    })
+
     it('falls back to autoNoiseProvenance.applied when autoNoiseApplied is null but provenance is valid', () => {
       // Defensive guard against payload drift: a future PLoT build that
       // emits structured provenance without the boolean echo should still

--- a/src/canvas/components/model-tab/__tests__/ModelHealthSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/ModelHealthSection.spec.tsx
@@ -242,6 +242,34 @@ describe('ModelHealthSection', () => {
       expect(screen.queryByTestId('model-health-auto-noise-row')).not.toBeInTheDocument()
     })
 
+    it('falls back to autoNoiseProvenance.applied when autoNoiseApplied is null but provenance is valid', () => {
+      // Defensive guard against payload drift: a future PLoT build that
+      // emits structured provenance without the boolean echo should still
+      // populate the accordion row. Today's PLoT always emits both, so
+      // this is an audit-feedback Imp-3 follow-up.
+      render(
+        <DetailToggleContext.Provider value={{ showDetail: true }}>
+          <ModelHealthSection
+            auditTrail={makeAudit({
+              autoNoiseApplied: null,
+              autoNoiseProvenance: {
+                applied: true,
+                effect: 'widens_outcome_and_risk_uncertainty',
+                formulaVersion: 'plot_auto_v1',
+                multiplier: 1.0,
+                noiseDistribution: 'normal_zero_mean_outcome_std',
+                filterScope: 'outcome_and_risk_nodes',
+                isProvisional: true,
+                calibrationStatus: 'provisional_pending_pilot_calibration',
+              },
+            })}
+          />
+        </DetailToggleContext.Provider>
+      )
+      const row = screen.getByTestId('model-health-auto-noise-row')
+      expect(row).toHaveTextContent('Operational adjustment applied (calibration pending).')
+    })
+
     it('uses no user-facing technical jargon — payload-only fields stay out of the DOM', () => {
       render(
         <DetailToggleContext.Provider value={{ showDetail: true }}>

--- a/src/canvas/components/model-tab/__tests__/ModelHealthSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/ModelHealthSection.spec.tsx
@@ -46,6 +46,7 @@ describe('ModelHealthSection', () => {
       inferenceWarnings: null,
       recommendationStability: null,
       autoNoiseApplied: null,
+      autoNoiseProvenance: null,
       stabilityPenaltyFactor: null,
     }
     render(<ModelHealthSection auditTrail={emptyAudit} factorCount={3} edgeCount={5} />)
@@ -66,6 +67,7 @@ describe('ModelHealthSection', () => {
       inferenceWarnings: null,
       recommendationStability: null,
       autoNoiseApplied: null,
+      autoNoiseProvenance: null,
       stabilityPenaltyFactor: null,
     }
     render(<ModelHealthSection auditTrail={auditTrail} />)
@@ -81,6 +83,7 @@ describe('ModelHealthSection', () => {
       inferenceWarnings: null,
       recommendationStability: 0.71,
       autoNoiseApplied: null,
+      autoNoiseProvenance: null,
       stabilityPenaltyFactor: null,
     }
     render(<ModelHealthSection auditTrail={auditTrail} ceeQuality={{ overall: 7.2, structure: 8, causality: 6.5, coverage: 7, safety: 7.5 }} />)
@@ -101,6 +104,7 @@ describe('ModelHealthSection', () => {
       ],
       recommendationStability: null,
       autoNoiseApplied: null,
+      autoNoiseProvenance: null,
       stabilityPenaltyFactor: null,
     }
     render(<ModelHealthSection auditTrail={auditTrail} />)
@@ -119,6 +123,7 @@ describe('ModelHealthSection', () => {
       ],
       recommendationStability: null,
       autoNoiseApplied: null,
+      autoNoiseProvenance: null,
       stabilityPenaltyFactor: 0.90,
     }
     render(<ModelHealthSection auditTrail={auditTrail} />)
@@ -134,6 +139,7 @@ describe('ModelHealthSection', () => {
       inferenceWarnings: null,
       recommendationStability: null,
       autoNoiseApplied: null,
+      autoNoiseProvenance: null,
       stabilityPenaltyFactor: null,
     }
     render(<ModelHealthSection auditTrail={auditTrail} />)
@@ -152,6 +158,7 @@ describe('ModelHealthSection', () => {
       inferenceWarnings: null,
       recommendationStability: 0.71,
       autoNoiseApplied: true,
+      autoNoiseProvenance: null,
       stabilityPenaltyFactor: null,
     }
     render(
@@ -186,5 +193,85 @@ describe('ModelHealthSection', () => {
       </DetailToggleContext.Provider>
     )
     expect(screen.queryByTestId('quality-row-structure')).not.toBeInTheDocument()
+  })
+
+  // ─── Audit B3: auto-noise disclosure copy ────────────────────────────────
+  describe('auto-noise disclosure (audit B3)', () => {
+    function makeAudit(overrides: Partial<AuditTrailData>): AuditTrailData {
+      return {
+        seedUsed: '42',
+        responseHash: 'abc',
+        nSamples: 1000,
+        repairsApplied: null,
+        inferenceWarnings: null,
+        recommendationStability: null,
+        autoNoiseApplied: null,
+        autoNoiseProvenance: null,
+        stabilityPenaltyFactor: null,
+        ...overrides,
+      }
+    }
+
+    it('renders non-technical copy when auto-noise was applied', () => {
+      render(
+        <DetailToggleContext.Provider value={{ showDetail: true }}>
+          <ModelHealthSection auditTrail={makeAudit({ autoNoiseApplied: true })} />
+        </DetailToggleContext.Provider>
+      )
+      const row = screen.getByTestId('model-health-auto-noise-row')
+      expect(row).toHaveTextContent('Operational adjustment applied (calibration pending).')
+      expect(screen.getByText('Outcome uncertainty adjustment')).toBeInTheDocument()
+    })
+
+    it('renders non-technical copy when auto-noise was not applied', () => {
+      render(
+        <DetailToggleContext.Provider value={{ showDetail: true }}>
+          <ModelHealthSection auditTrail={makeAudit({ autoNoiseApplied: false })} />
+        </DetailToggleContext.Provider>
+      )
+      const row = screen.getByTestId('model-health-auto-noise-row')
+      expect(row).toHaveTextContent('No additional uncertainty adjustment applied.')
+    })
+
+    it('omits the row entirely when autoNoiseApplied is null (legacy/no signal)', () => {
+      render(
+        <DetailToggleContext.Provider value={{ showDetail: true }}>
+          <ModelHealthSection auditTrail={makeAudit({ autoNoiseApplied: null })} />
+        </DetailToggleContext.Provider>
+      )
+      expect(screen.queryByTestId('model-health-auto-noise-row')).not.toBeInTheDocument()
+    })
+
+    it('uses no user-facing technical jargon — payload-only fields stay out of the DOM', () => {
+      render(
+        <DetailToggleContext.Provider value={{ showDetail: true }}>
+          <ModelHealthSection
+            auditTrail={makeAudit({
+              autoNoiseApplied: true,
+              autoNoiseProvenance: {
+                applied: true,
+                effect: 'widens_outcome_and_risk_uncertainty',
+                formulaVersion: 'plot_auto_v1',
+                multiplier: 1.0,
+                noiseDistribution: 'normal_zero_mean_outcome_std',
+                filterScope: 'outcome_and_risk_nodes',
+                isProvisional: true,
+                calibrationStatus: 'provisional_pending_pilot_calibration',
+              },
+            })}
+          />
+        </DetailToggleContext.Provider>
+      )
+      const audit = screen.getByTestId('model-health-audit')
+      const text = audit.textContent ?? ''
+      // Payload-only enum literals must never leak into rendered text.
+      expect(text).not.toMatch(/plot_auto_v1/)
+      expect(text).not.toMatch(/normal_zero_mean_outcome_std/)
+      expect(text).not.toMatch(/outcome_and_risk_nodes/)
+      expect(text).not.toMatch(/widens_outcome_and_risk_uncertainty/)
+      expect(text).not.toMatch(/provisional_pending_pilot_calibration/)
+      expect(text).not.toMatch(/auto-noise/i)
+      expect(text).not.toMatch(/variance/i)
+    })
   })
 })

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -118,8 +118,13 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
         type="button"
         // Mirrors A1's DriversSection.tsx:823 touch-target enlargement
         // pattern: `before:` pseudo-element extends the hit area to ≥44px
-        // without affecting flow layout.
-        className="bg-transparent border-0 p-0 cursor-help inline-flex items-center justify-center text-text-light focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-info rounded relative before:absolute before:content-[''] before:left-0 before:right-0 before:-inset-3"
+        // without affecting flow layout. The icon glyph is 14px (w-3.5);
+        // `-inset-4` adds 16px of pseudo-element bleed on every axis,
+        // giving a 14 + 32 = 46px effective hit area (DS v5 / WCAG 2.5.5
+        // requires ≥44px). A1's pattern uses `-inset-y-4` because the
+        // anchor text supplies horizontal width; for an icon-only button
+        // we extend symmetrically.
+        className="bg-transparent border-0 p-0 cursor-help inline-flex items-center justify-center text-text-light focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-info rounded relative before:absolute before:content-[''] before:-inset-4"
         aria-label={autoNoiseAriaLabel}
         data-testid="auto-noise-provisional-marker"
       >

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -10,7 +10,9 @@
  * Uses shared TriageHealthHeader + TriageActionCardsBody.
  */
 
-import { useMemo, memo, type ReactNode } from 'react'
+import { useMemo, memo, useState, type ReactNode } from 'react'
+import { AlertTriangle, Check, ChevronDown, ChevronRight, Info, X } from 'lucide-react'
+import Tooltip from '@/components/Tooltip'
 import { TriageHealthHeader } from '@/components/shared/TriageHealthHeader'
 import type { DecisionHealthRingDimensions } from '@/components/shared/DecisionHealthRing'
 import { HeroQualifier } from './HeroQualifier'
@@ -95,6 +97,36 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
   // completeness reasons and dimension scores. Stale wire freshness
   // wins above the other two qualifier sources.
   const freshnessState = useAnalysisFreshnessState()
+
+  // Audit B3 (P0): visible auto-noise disclosure marker. Renders only when
+  // PLoT explicitly emitted `applied=true` with a provisional calibration
+  // status — old/cached responses without the field yield no marker
+  // (graceful degradation). Mirrors A1's DriversSection.tsx Info+Tooltip
+  // pattern. User-facing copy avoids "auto-noise" / "variance" jargon per
+  // brief — `multiplier`, `formula_version`, etc. are payload-only fields
+  // and never appear in user-visible strings.
+  const showAutoNoiseMarker =
+    data.autoNoiseProvenance?.applied === true &&
+    data.autoNoiseProvenance?.isProvisional === true
+  const autoNoiseTooltipContent =
+    'Outcome ranges include an operational uncertainty adjustment pending pilot calibration.'
+  const autoNoiseAriaLabel =
+    'Outcome uncertainty adjustment — operational estimate pending pilot calibration'
+  const autoNoiseAdornment = showAutoNoiseMarker ? (
+    <Tooltip content={autoNoiseTooltipContent}>
+      <button
+        type="button"
+        // Mirrors A1's DriversSection.tsx:823 touch-target enlargement
+        // pattern: `before:` pseudo-element extends the hit area to ≥44px
+        // without affecting flow layout.
+        className="bg-transparent border-0 p-0 cursor-help inline-flex items-center justify-center text-text-light focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-info rounded relative before:absolute before:content-[''] before:left-0 before:right-0 before:-inset-3"
+        aria-label={autoNoiseAriaLabel}
+        data-testid="auto-noise-provisional-marker"
+      >
+        <Info className="w-3.5 h-3.5 text-text-light flex-shrink-0" aria-hidden="true" />
+      </button>
+    </Tooltip>
+  ) : undefined
 
   // Post-analysis ring shows winner's win probability directly. The readiness
   // composite (Structure/Evidence/Coverage/Verified) is pre-analysis-only.
@@ -276,6 +308,7 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
           }
           testId="confidence-health-header"
           noCardWrapper
+          titleAdornment={autoNoiseAdornment}
         />
 
         {/* Action-card body — extracted to TriageActionCardsBody for reuse by AnalysisHeroV17. */}

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -10,8 +10,8 @@
  * Uses shared TriageHealthHeader + TriageActionCardsBody.
  */
 
-import { useMemo, memo, useState, type ReactNode } from 'react'
-import { AlertTriangle, Check, ChevronDown, ChevronRight, Info, X } from 'lucide-react'
+import { useMemo, memo, type ReactNode } from 'react'
+import { Info } from 'lucide-react'
 import Tooltip from '@/components/Tooltip'
 import { TriageHealthHeader } from '@/components/shared/TriageHealthHeader'
 import type { DecisionHealthRingDimensions } from '@/components/shared/DecisionHealthRing'

--- a/src/components/results/__tests__/DecisionConfidencePanel.autoNoise.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.autoNoise.spec.tsx
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { DecisionConfidencePanel } from '../DecisionConfidencePanel'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type {
@@ -176,6 +176,45 @@ describe('DecisionConfidencePanel — auto-noise provenance disclosure (audit B3
       'aria-label',
       'Outcome uncertainty adjustment — operational estimate pending pilot calibration',
     )
+  })
+
+  it('hovering the marker reveals the verbatim tooltip copy', async () => {
+    // Tooltip primitive wraps the marker in a <div> that owns Floating UI's
+    // useHover. Hover events must target that wrapper (mirrors the A1
+    // DriversSection.provenance.spec.tsx pattern).
+    render(<DecisionConfidencePanel data={makeData(provisionalProvenance())} onSendMessage={() => {}} />)
+    const marker = screen.getByTestId('auto-noise-provisional-marker')
+    const tooltipRef = marker.parentElement!
+    fireEvent.pointerEnter(tooltipRef)
+    fireEvent.mouseEnter(tooltipRef)
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip.textContent).toBe(
+      'Outcome ranges include an operational uncertainty adjustment pending pilot calibration.',
+    )
+  })
+
+  it('focusing the marker reveals the same tooltip (keyboard accessibility)', async () => {
+    render(<DecisionConfidencePanel data={makeData(provisionalProvenance())} onSendMessage={() => {}} />)
+    const marker = screen.getByTestId('auto-noise-provisional-marker') as HTMLButtonElement
+    marker.focus()
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip.textContent).toBe(
+      'Outcome ranges include an operational uncertainty adjustment pending pilot calibration.',
+    )
+  })
+
+  it('marker hit area extends to ≥44px via the `before:-inset-4` pseudo-element pattern', () => {
+    // Touch target spec: WCAG 2.5.5 / DS v5 require ≥44px on every axis.
+    // Icon glyph is w-3.5 h-3.5 (14px); -inset-4 (16px on each side) gives
+    // 14 + 32 = 46px effective hit area. Asserting the class presence
+    // pins the configuration so a future drift back to -inset-3 (38px)
+    // fails this test.
+    render(<DecisionConfidencePanel data={makeData(provisionalProvenance())} onSendMessage={() => {}} />)
+    const marker = screen.getByTestId('auto-noise-provisional-marker')
+    expect(marker.className).toContain('before:-inset-4')
+    expect(marker.className).not.toMatch(/before:-inset-(0|1|2|3)\b/)
   })
 
   it('payload-only enum literals never appear in the rendered DOM', () => {

--- a/src/components/results/__tests__/DecisionConfidencePanel.autoNoise.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.autoNoise.spec.tsx
@@ -1,0 +1,194 @@
+/**
+ * DecisionConfidencePanel auto-noise disclosure tests (audit B3, P0).
+ *
+ * The visible marker (Info icon + Tooltip) is anchored next to the
+ * "Decision confidence" title via TriageHealthHeader's `titleAdornment`
+ * slot. It renders only when PLoT explicitly emitted
+ * `applied=true && is_provisional=true` for this run; cached / older
+ * payloads (no provenance) yield no marker — graceful degradation.
+ *
+ * Mirrors the A1 DriversSection.provenance.spec.tsx test pattern.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DecisionConfidencePanel } from '../DecisionConfidencePanel'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  AutoNoiseProvenance,
+  ConfidenceSectionData,
+  DriversSectionData,
+  DriverItem,
+  ImprovementsSectionData,
+  DecisionResultData,
+  OptionResult,
+} from '../types'
+import { useCanvasStore } from '@/canvas/store'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+}))
+
+function makeDriver(overrides: Partial<DriverItem> = {}): DriverItem {
+  return {
+    factorKey: 'fac_top',
+    factorLabel: 'Top driver',
+    rawElasticity: 1,
+    normalisedInfluence: 1,
+    influenceScore: 0.9,
+    rank: 1,
+    direction: 'positive',
+    semanticLabel: 'biggest',
+    canFocus: true,
+    matchedNodeId: 'node_top',
+    ...overrides,
+  }
+}
+
+function provisionalProvenance(
+  overrides: Partial<AutoNoiseProvenance> = {},
+): AutoNoiseProvenance {
+  return {
+    applied: true,
+    effect: 'widens_outcome_and_risk_uncertainty',
+    formulaVersion: 'plot_auto_v1',
+    multiplier: 1.0,
+    noiseDistribution: 'normal_zero_mean_outcome_std',
+    filterScope: 'outcome_and_risk_nodes',
+    isProvisional: true,
+    calibrationStatus: 'provisional_pending_pilot_calibration',
+    ...overrides,
+  }
+}
+
+function makeData(
+  autoNoiseProvenance: AutoNoiseProvenance | null,
+): ResultsSectionDataReturn {
+  const winner: OptionResult = {
+    id: 'opt_a',
+    label: 'Option A',
+    expectedValue: 0.8,
+    p10: 0.6,
+    p90: 0.95,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+  } as OptionResult
+
+  const recommendation: DecisionResultData = {
+    recommendedOption: winner,
+    allOptions: [winner],
+    goalLabel: 'Maximise success',
+    isSingleOption: true,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [makeDriver()],
+    topDrivers: [makeDriver()],
+    driversStatus: 'computed',
+    totalCount: 1,
+    hasMagnitudeData: true,
+  }
+
+  const confidence: ConfidenceSectionData = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  }
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    autoNoiseProvenance,
+  } as ResultsSectionDataReturn
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({ draftCoaching: null })
+})
+
+describe('DecisionConfidencePanel — auto-noise provenance disclosure (audit B3)', () => {
+  it('renders the visible marker when applied=true and isProvisional=true', () => {
+    render(<DecisionConfidencePanel data={makeData(provisionalProvenance())} onSendMessage={() => {}} />)
+    const marker = screen.getByTestId('auto-noise-provisional-marker')
+    expect(marker).toBeInTheDocument()
+    // Marker is anchored inside the trust panel header.
+    const card = screen.getByTestId('t1-decision-confidence-card')
+    expect(card.contains(marker)).toBe(true)
+  })
+
+  it('hides the marker when applied=false (no firing)', () => {
+    render(
+      <DecisionConfidencePanel
+        data={makeData(provisionalProvenance({ applied: false }))}
+        onSendMessage={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('auto-noise-provisional-marker')).toBeNull()
+  })
+
+  it('hides the marker when isProvisional=false (post-calibration future state)', () => {
+    render(
+      <DecisionConfidencePanel
+        data={makeData(provisionalProvenance({ isProvisional: false }))}
+        onSendMessage={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('auto-noise-provisional-marker')).toBeNull()
+  })
+
+  it('graceful degradation: missing provenance (old PLoT payload) renders without crashing and without the marker', () => {
+    expect(() =>
+      render(<DecisionConfidencePanel data={makeData(null)} onSendMessage={() => {}} />),
+    ).not.toThrow()
+    expect(screen.queryByTestId('auto-noise-provisional-marker')).toBeNull()
+    // Trust panel header itself still renders.
+    expect(screen.getByTestId('confidence-health-header')).toBeInTheDocument()
+  })
+
+  it('marker exposes the disclosure aria-label', () => {
+    render(<DecisionConfidencePanel data={makeData(provisionalProvenance())} onSendMessage={() => {}} />)
+    const marker = screen.getByTestId('auto-noise-provisional-marker')
+    expect(marker).toHaveAttribute(
+      'aria-label',
+      'Outcome uncertainty adjustment — operational estimate pending pilot calibration',
+    )
+  })
+
+  it('payload-only enum literals never appear in the rendered DOM', () => {
+    render(<DecisionConfidencePanel data={makeData(provisionalProvenance())} onSendMessage={() => {}} />)
+    const card = screen.getByTestId('t1-decision-confidence-card')
+    const text = card.textContent ?? ''
+    expect(text).not.toMatch(/plot_auto_v1/)
+    expect(text).not.toMatch(/normal_zero_mean_outcome_std/)
+    expect(text).not.toMatch(/outcome_and_risk_nodes/)
+    expect(text).not.toMatch(/widens_outcome_and_risk_uncertainty/)
+    expect(text).not.toMatch(/provisional_pending_pilot_calibration/)
+    // No "auto-noise" / "variance" jargon in user-facing copy.
+    expect(text).not.toMatch(/auto-noise/i)
+    expect(text).not.toMatch(/variance/i)
+  })
+})

--- a/src/components/results/__tests__/DecisionConfidencePanel.autoNoise.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.autoNoise.spec.tsx
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { DecisionConfidencePanel } from '../DecisionConfidencePanel'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type {

--- a/src/components/results/__tests__/autoNoiseProvenance.normalizer.spec.ts
+++ b/src/components/results/__tests__/autoNoiseProvenance.normalizer.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for `normalizeAutoNoiseProvenance` (audit B3, P0).
+ *
+ * The normaliser is the trust boundary between PLoT's snake_case payload
+ * and the UI's camelCase shape. Malformed input returns null — never
+ * partial fills, never throws — so a bad payload simply hides the marker
+ * (graceful degradation) without crashing the trust panel.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { normalizeAutoNoiseProvenance } from '../types'
+
+const validRaw = {
+  applied: true,
+  effect: 'widens_outcome_and_risk_uncertainty',
+  formula_version: 'plot_auto_v1',
+  multiplier: 1.0,
+  noise_distribution: 'normal_zero_mean_outcome_std',
+  filter_scope: 'outcome_and_risk_nodes',
+  is_provisional: true,
+  calibration_status: 'provisional_pending_pilot_calibration',
+}
+
+describe('normalizeAutoNoiseProvenance', () => {
+  it('camelCases a well-formed payload with applied=true', () => {
+    expect(normalizeAutoNoiseProvenance(validRaw)).toEqual({
+      applied: true,
+      effect: 'widens_outcome_and_risk_uncertainty',
+      formulaVersion: 'plot_auto_v1',
+      multiplier: 1.0,
+      noiseDistribution: 'normal_zero_mean_outcome_std',
+      filterScope: 'outcome_and_risk_nodes',
+      isProvisional: true,
+      calibrationStatus: 'provisional_pending_pilot_calibration',
+    })
+  })
+
+  it('camelCases a well-formed payload with applied=false (full metadata preserved)', () => {
+    const result = normalizeAutoNoiseProvenance({ ...validRaw, applied: false })
+    expect(result).not.toBeNull()
+    expect(result!.applied).toBe(false)
+    // Full formula provenance is preserved on applied=false — see brief.
+    expect(result!.multiplier).toBe(1.0)
+    expect(result!.formulaVersion).toBe('plot_auto_v1')
+    expect(result!.calibrationStatus).toBe('provisional_pending_pilot_calibration')
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty object', {}],
+    ['array', [validRaw]],
+    ['number', 42],
+    ['string', 'oops'],
+  ])('returns null for non-object input: %s', (_label, input) => {
+    expect(normalizeAutoNoiseProvenance(input)).toBeNull()
+  })
+
+  it('returns null for malformed boolean fields', () => {
+    expect(normalizeAutoNoiseProvenance({ ...validRaw, applied: 'true' })).toBeNull()
+    expect(normalizeAutoNoiseProvenance({ ...validRaw, is_provisional: 1 })).toBeNull()
+  })
+
+  it('returns null for malformed numeric multiplier', () => {
+    expect(normalizeAutoNoiseProvenance({ ...validRaw, multiplier: '1.0' })).toBeNull()
+    expect(normalizeAutoNoiseProvenance({ ...validRaw, multiplier: NaN })).toBeNull()
+    expect(normalizeAutoNoiseProvenance({ ...validRaw, multiplier: Infinity })).toBeNull()
+  })
+
+  it('returns null when any required string field is missing or empty', () => {
+    for (const key of [
+      'effect',
+      'formula_version',
+      'noise_distribution',
+      'filter_scope',
+      'calibration_status',
+    ] as const) {
+      const { [key]: _omit, ...rest } = validRaw
+      expect(normalizeAutoNoiseProvenance(rest)).toBeNull()
+      expect(normalizeAutoNoiseProvenance({ ...validRaw, [key]: '' })).toBeNull()
+      expect(normalizeAutoNoiseProvenance({ ...validRaw, [key]: 42 })).toBeNull()
+    }
+  })
+
+  it('forward-compat: unknown enum values pass through (string-typed UI side)', () => {
+    // Mirrors the A1 pattern (commit e46f305f) of relaxing UI enum types
+    // to `string` so a future calibrated PLoT build does not crash old UI.
+    const future = { ...validRaw, formula_version: 'plot_auto_v2', calibration_status: 'calibrated_pilot_v1' }
+    const result = normalizeAutoNoiseProvenance(future)
+    expect(result).not.toBeNull()
+    expect(result!.formulaVersion).toBe('plot_auto_v2')
+    expect(result!.calibrationStatus).toBe('calibrated_pilot_v1')
+  })
+})

--- a/src/components/results/__tests__/autoNoiseProvenance.normalizer.spec.ts
+++ b/src/components/results/__tests__/autoNoiseProvenance.normalizer.spec.ts
@@ -75,6 +75,7 @@ describe('normalizeAutoNoiseProvenance', () => {
       'filter_scope',
       'calibration_status',
     ] as const) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [key]: _omit, ...rest } = validRaw
       expect(normalizeAutoNoiseProvenance(rest)).toBeNull()
       expect(normalizeAutoNoiseProvenance({ ...validRaw, [key]: '' })).toBeNull()

--- a/src/components/results/__tests__/useResultsSectionData.autoNoise.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.autoNoise.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * useResultsSectionData — auto-noise provenance integration (audit B3, P0).
+ *
+ * Drives the data hook through the canvas store the same way production
+ * does: a real PLoT V3 response lands on `rawV2Response`, the hook reads
+ * it and surfaces `autoNoiseProvenance` to consumers. This proves the
+ * store→hook→component data path the unit-level DCP test cannot.
+ *
+ * Audit-feedback P1-5.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+
+const PLOT_V3_BASE = {
+  status: 'complete',
+  progress: 100,
+  report: {
+    run: { critique: [] },
+    robustness: { fragile_edges: [] },
+    option_comparison: [],
+  },
+} as const
+
+function setStore(rawV2Response: Record<string, unknown> | null) {
+  useCanvasStore.setState({
+    results: { ...PLOT_V3_BASE } as any,
+    runMeta: {} as any,
+    nodes: [],
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: rawV2Response as any,
+  } as any)
+}
+
+const validProvenance = {
+  applied: true,
+  effect: 'widens_outcome_and_risk_uncertainty',
+  formula_version: 'plot_auto_v1',
+  multiplier: 1.0,
+  noise_distribution: 'normal_zero_mean_outcome_std',
+  filter_scope: 'outcome_and_risk_nodes',
+  is_provisional: true,
+  calibration_status: 'provisional_pending_pilot_calibration',
+}
+
+describe('useResultsSectionData — autoNoiseProvenance integration (audit B3)', () => {
+  beforeEach(() => {
+    setStore(null)
+  })
+
+  it('surfaces normalised camelCase provenance from rawV2Response.auto_noise_provenance', () => {
+    setStore({
+      analysis_status: 'computed',
+      auto_noise_applied: true,
+      auto_noise_provenance: validProvenance,
+    })
+
+    const { result } = renderHook(() => useResultsSectionData())
+
+    expect(result.current.autoNoiseProvenance).toEqual({
+      applied: true,
+      effect: 'widens_outcome_and_risk_uncertainty',
+      formulaVersion: 'plot_auto_v1',
+      multiplier: 1.0,
+      noiseDistribution: 'normal_zero_mean_outcome_std',
+      filterScope: 'outcome_and_risk_nodes',
+      isProvisional: true,
+      calibrationStatus: 'provisional_pending_pilot_calibration',
+    })
+  })
+
+  it('returns null when rawV2Response itself is null (no run yet)', () => {
+    setStore(null)
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.autoNoiseProvenance).toBeNull()
+  })
+
+  it('returns null when the response predates B3 (no auto_noise_provenance field)', () => {
+    setStore({
+      analysis_status: 'computed',
+      // Old PLoT build, B3 disclosure not wired through.
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.autoNoiseProvenance).toBeNull()
+  })
+
+  it('returns null when the response carries a malformed provenance payload', () => {
+    setStore({
+      analysis_status: 'computed',
+      auto_noise_provenance: {
+        applied: true,
+        // Missing every other required field.
+      },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.autoNoiseProvenance).toBeNull()
+  })
+
+  it('preserves applied:false provenance with full metadata (calibration disclosure on no-fire)', () => {
+    setStore({
+      analysis_status: 'computed',
+      auto_noise_applied: false,
+      auto_noise_provenance: { ...validProvenance, applied: false },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.autoNoiseProvenance?.applied).toBe(false)
+    // Full formula metadata intact even on applied:false.
+    expect(result.current.autoNoiseProvenance?.formulaVersion).toBe('plot_auto_v1')
+    expect(result.current.autoNoiseProvenance?.calibrationStatus).toBe('provisional_pending_pilot_calibration')
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.autoNoise.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.autoNoise.spec.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useResultsSectionData } from '../useResultsSectionData'
 import { useCanvasStore } from '../../../canvas/store'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
 
 const PLOT_V3_BASE = {
   status: 'complete',
@@ -24,18 +25,26 @@ const PLOT_V3_BASE = {
   },
 } as const
 
-function setStore(rawV2Response: Record<string, unknown> | null) {
+/**
+ * Typed setStore — `rawV2Response` is `Partial<V2RunResponse>` rather
+ * than `Record<string, unknown>` so the tests exercise the typed contract
+ * instead of an untyped record. The cast on the full setState call
+ * remains because the canvas store has many required fields the hook
+ * does not consume; that pattern matches the rest of the suite (see
+ * `useResultsSectionData.spec.ts`).
+ */
+function setStore(rawV2Response: Partial<V2RunResponse> | null): void {
   useCanvasStore.setState({
     results: { ...PLOT_V3_BASE } as any,
     runMeta: {} as any,
     nodes: [],
     edges: [],
     hasCompletedFirstRun: true,
-    rawV2Response: rawV2Response as any,
+    rawV2Response: rawV2Response as V2RunResponse | null,
   } as any)
 }
 
-const validProvenance = {
+const validProvenance: NonNullable<V2RunResponse['auto_noise_provenance']> = {
   applied: true,
   effect: 'widens_outcome_and_risk_uncertainty',
   formula_version: 'plot_auto_v1',
@@ -88,12 +97,16 @@ describe('useResultsSectionData — autoNoiseProvenance integration (audit B3)',
   })
 
   it('returns null when the response carries a malformed provenance payload', () => {
+    // The cast is deliberate: the typed contract forbids partial
+    // provenance, but the runtime contract must defend against
+    // server-side drift / cached payloads. Asserting the normaliser
+    // rejects the malformed shape requires constructing one.
     setStore({
       analysis_status: 'computed',
       auto_noise_provenance: {
         applied: true,
         // Missing every other required field.
-      },
+      } as NonNullable<V2RunResponse['auto_noise_provenance']>,
     })
     const { result } = renderHook(() => useResultsSectionData())
     expect(result.current.autoNoiseProvenance).toBeNull()

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -287,6 +287,75 @@ export interface ConfidenceProvenance {
   inputQuality: ConfidenceInputQuality
 }
 
+// ─── Auto-noise provenance (audit B3) ───────────────────────────────────────
+//
+// Analysis-level disclosure for the operational variance adjustment ISL
+// applies in `_apply_auto_scaled_noise`. PLoT emits the snake_case payload
+// `auto_noise_provenance`; this UI type is the camelCase normalised form.
+//
+// Forward-compat: enum slots are typed `string` (mirrors A1's relaxed
+// confidence-provenance types — see commit e46f305f) so future calibration
+// values from PLoT do not crash old UI builds.
+//
+// UI surfaces ONLY the boolean gate (`applied && isProvisional`). All other
+// fields are payload-only debug metadata and must NEVER be rendered as
+// user-facing text.
+
+export type AutoNoiseEffect = string
+export type AutoNoiseFormulaVersion = string
+export type AutoNoiseDistribution = string
+export type AutoNoiseFilterScope = string
+export type AutoNoiseCalibrationStatus = string
+
+export interface AutoNoiseProvenance {
+  applied: boolean
+  effect: AutoNoiseEffect
+  formulaVersion: AutoNoiseFormulaVersion
+  multiplier: number
+  noiseDistribution: AutoNoiseDistribution
+  filterScope: AutoNoiseFilterScope
+  /** Drives whether the visible disclosure marker renders. */
+  isProvisional: boolean
+  calibrationStatus: AutoNoiseCalibrationStatus
+}
+
+/**
+ * Normalise a raw PLoT `auto_noise_provenance` payload (snake_case) into
+ * the UI's `AutoNoiseProvenance` (camelCase). Returns `null` on missing,
+ * non-object, or malformed input — never throws, never partially fills.
+ *
+ * Graceful degradation: an old PLoT build without the field, or a cached
+ * staging response, will return `null` here and the marker will simply
+ * not render. No silent typecast.
+ */
+export function normalizeAutoNoiseProvenance(raw: unknown): AutoNoiseProvenance | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+
+  if (typeof r.applied !== 'boolean') return null
+  if (typeof r.is_provisional !== 'boolean') return null
+  if (typeof r.multiplier !== 'number' || !Number.isFinite(r.multiplier)) return null
+
+  const stringFields: Array<['effect' | 'formula_version' | 'noise_distribution' | 'filter_scope' | 'calibration_status', string]> = []
+  for (const key of ['effect', 'formula_version', 'noise_distribution', 'filter_scope', 'calibration_status'] as const) {
+    const v = r[key]
+    if (typeof v !== 'string' || v.length === 0) return null
+    stringFields.push([key, v])
+  }
+  const m = Object.fromEntries(stringFields) as Record<typeof stringFields[number][0], string>
+
+  return {
+    applied: r.applied,
+    effect: m.effect,
+    formulaVersion: m.formula_version,
+    multiplier: r.multiplier,
+    noiseDistribution: m.noise_distribution,
+    filterScope: m.filter_scope,
+    isProvisional: r.is_provisional,
+    calibrationStatus: m.calibration_status,
+  }
+}
+
 export interface DriverItem {
   /** Canonical identifier: node_id ?? factor_id ?? id ?? normalised(label) */
   factorKey: string

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -907,8 +907,9 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // Used as fallback in flip_thresholds defensive adaptor when mapped report doesn't carry them.
       rawV2FlipThresholds: s.rawV2Response?.robustness?.flip_thresholds ?? (s.rawV2Response as Record<string, unknown> | null)?.flip_thresholds ?? null,
       // Audit B3: extract only auto_noise_provenance to avoid subscribing
-      // to the whole rawV2Response. Normalised at the trust boundary.
-      rawAutoNoiseProvenance: (s.rawV2Response as Record<string, unknown> | null)?.auto_noise_provenance ?? null,
+      // to the whole rawV2Response. Typed via V2RunResponse since PLoT
+      // commit 562e461; normalised at the trust boundary below.
+      rawAutoNoiseProvenance: s.rawV2Response?.auto_noise_provenance ?? null,
     }))
   )
 

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -48,6 +48,7 @@ import type {
   ConfidenceCalibrationStatus,
   ConfidenceInputQuality,
 } from './types'
+import { normalizeAutoNoiseProvenance } from './types'
 import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
 import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
 import { stripEncodingNotation, sanitizeCoachingText } from './utils/cleanFactorLabel'
@@ -864,6 +865,14 @@ export interface ResultsSectionDataReturn {
    * as truth.
    */
   completeness: import('./useResultCompleteness').ResultCompleteness
+  /**
+   * Audit B3 (P0): analysis-level auto-noise provenance from PLoT.
+   * `null` when the response predates this disclosure (old PLoT build,
+   * cached staging response) or when normalisation rejected a malformed
+   * payload. UI gates the visible marker on
+   * `autoNoiseProvenance?.applied && autoNoiseProvenance?.isProvisional`.
+   */
+  autoNoiseProvenance: import('./types').AutoNoiseProvenance | null
 }
 
 export function useResultsSectionData(): ResultsSectionDataReturn {
@@ -880,6 +889,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     goalThreshold,
     ceeAnalysisReady,
     rawV2FlipThresholds,
+    rawAutoNoiseProvenance,
   } = useCanvasStore(
     useShallow((s) => ({
       results: s.results,
@@ -896,7 +906,15 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // Extract only flip_thresholds from raw V2 response to avoid subscribing to entire object.
       // Used as fallback in flip_thresholds defensive adaptor when mapped report doesn't carry them.
       rawV2FlipThresholds: s.rawV2Response?.robustness?.flip_thresholds ?? (s.rawV2Response as Record<string, unknown> | null)?.flip_thresholds ?? null,
+      // Audit B3: extract only auto_noise_provenance to avoid subscribing
+      // to the whole rawV2Response. Normalised at the trust boundary.
+      rawAutoNoiseProvenance: (s.rawV2Response as Record<string, unknown> | null)?.auto_noise_provenance ?? null,
     }))
+  )
+
+  const autoNoiseProvenance = useMemo(
+    () => normalizeAutoNoiseProvenance(rawAutoNoiseProvenance),
+    [rawAutoNoiseProvenance],
   )
 
   // Cast report once at trust boundary — responseMapper returns ReportV1 with V2 pass-through fields
@@ -2589,6 +2607,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     goalLabel,
     goalNodeId,
     completeness,
+    autoNoiseProvenance,
   }
 }
 

--- a/src/components/shared/TriageHealthHeader.tsx
+++ b/src/components/shared/TriageHealthHeader.tsx
@@ -77,6 +77,13 @@ export interface TriageHealthHeaderProps {
    * the parent wrapper owns layout.
    */
   noCardWrapper?: boolean
+  /**
+   * Audit B3 (P0): optional inline adornment rendered immediately after the
+   * title text — used to anchor the auto-noise disclosure marker (Info icon
+   * + Tooltip) on the post-analysis trust panel. Pre-analysis callers leave
+   * it `undefined` and the title renders unchanged.
+   */
+  titleAdornment?: ReactNode
 }
 
 function DimensionBar({ dim }: { dim: TriageDimension }) {
@@ -115,6 +122,7 @@ export const TriageHealthHeader = memo(function TriageHealthHeader({
   qualifier,
   secondaryIndicator,
   noCardWrapper = false,
+  titleAdornment,
 }: TriageHealthHeaderProps) {
   const [coachingDismissed, setCoachingDismissed] = useState(false)
 
@@ -139,6 +147,14 @@ export const TriageHealthHeader = memo(function TriageHealthHeader({
     >
       {hideTitle ? (
         <p className="sr-only">{title}</p>
+      ) : titleAdornment != null ? (
+        // When an adornment is present, lift the title out of <p> so the
+        // adornment (which may contain block-level children, e.g. a Tooltip's
+        // wrapping <div>) does not violate <p>-cannot-contain-<div> nesting.
+        <div className={`${typography.panelHeader} text-text-header flex items-center gap-1`}>
+          <span>{title}</span>
+          {titleAdornment}
+        </div>
       ) : (
         <p className={`${typography.panelHeader} text-text-header`}>{title}</p>
       )}


### PR DESCRIPTION
B3 auto-noise disclosure layer, rebased from the long-lived
`claude-plot-ui/b3-auto-noise-disclosure` branch onto current
`origin/staging` (post-PR-#141, post-#138/#140/#142). Adopts the original
3-commit B3 work plus 2 post-rebase review fixes.

## Behaviour

Small additive disclosure/provenance layer for the **outcome uncertainty
adjustment** signal PLoT emits in `auto_noise_provenance`. When the
adjustment is applied AND the calibration status is provisional, the
Results panel (`DecisionConfidencePanel`) shows a non-technical info
marker; the Model card (`ModelHealthSection`) shows an audit row with
plain copy. No user-facing jargon: `multiplier`, `formula_version`, etc.
are payload-only.

## Scope (12 files, +989 / −9)

Type addition · canvas Model tab additions · Results disclosure UI +
selector slice · shared header. **No** changes to V5 hydration, option
probability mapping, ranking, Results selectors, shared Results
architecture, or debug-export work. Overlap audit (B3 readiness brief):
- `src/v5/**` — none
- `src/components/debug/**` — none (PR #141 territory untouched)
- `src/canvas/store.ts` — none
- `src/canvas/conversation/useConversation.ts` — none

## Reads / additions are strictly additive

- `useResultsSectionData.ts` +20 lines / 0 deletions: new optional
  `autoNoiseProvenance` field on the return type, subscribes to a NEW
  slice (`s.rawV2Response?.auto_noise_provenance`), normalises via
  `useMemo`. Zero alteration to existing selector slices.
- `types.ts` +69 lines: `AutoNoiseProvenance` type +
  `normalizeAutoNoiseProvenance` normaliser.
- `ModelTabBody.tsx`: preserves the legacy `_meta.auto_noise_applied`
  fallback (regression fix) + adds `autoNoiseProvenance` to the
  `auditTrail` selector. Pre-existing `(rawV2Response as any)?...` legacy
  shape preserved for fields not on `V2RunResponse`.
- `DecisionConfidencePanel.tsx`: adds the disclosure marker (Info icon +
  Tooltip) above the existing health header. Gated on
  `applied && isProvisional` so old/cached bundles produce no marker
  (graceful degradation).
- `ModelHealthSection.tsx`: adds the audit row to the Model card
  accordion. Treats `autoNoiseProvenance` alone as an audit signal so
  payload drift doesn't trip the pre-analysis branch.
- `TriageHealthHeader.tsx`: accepts an optional `marker` slot.

## Post-rebase fixes (reviewer feedback, addressed before push)

- Conflict in `DecisionConfidencePanel.tsx` was a 7-line additive import
  block — resolved by taking only the imports B3 actually uses (`Info`,
  `Tooltip`); 6 unused symbols (`useState, AlertTriangle, Check,
  ChevronDown, ChevronRight, X`) dropped. No design choice.
- Restored the `(rawV2Response as any)?._meta?.auto_noise_applied` legacy
  fallback in `ModelTabBody.tsx` that B3's typed selector rewrite had
  inadvertently dropped — cached/Supabase-hydrated bundles captured
  before the flag was promoted to a top-level field still rely on the
  `_meta` echo to surface the audit row.
- New regression test `ModelTabBody.autoNoiseFallback.spec.tsx` (5 cases)
  pins the selector contract: top-level wins, `_meta` fallback fires
  when top-level is absent, top-level=true preserved, null when no
  signal, null when `rawV2Response` itself null. Sanity-verified: spec
  fails without the fallback fix; passes with it.
- Two B3-introduced lint warnings cleaned (`waitFor` unused import,
  `_omit` destructure-rest idiom annotated).

## Tests

- `npm run typecheck` — clean
- Focused vitest (10 suites: ModelTabBody.spec, ModelTabBody.autoNoiseFallback,
  ModelHealthSection, DecisionConfidencePanel.autoNoise,
  DecisionConfidencePanel.heroD2a, useResultsSectionData.autoNoise,
  autoNoiseProvenance.normalizer, buildResultsVM, HeroQualifier,
  HeroFooterAlignment) — **182/182 passed**
- `bash scripts/validate-prepush.sh` — ALL CHECKS PASSED · smoke 459/459 ·
  stale-.js clean · dep audit clean · V5 tarball SHA matches
- Pre-push hook re-passed on this branch's push to origin

## Verification (PLoT/ISL live)

PLoT staging `efa5eee` (PR #165 EVPI clamp) · ISL staging `b382488`
(B3 auto-noise propagation). B3 staging smoke 21/21 PASS; surfaced
`evpi_percentage_points` all `>= 0`. See
`B3-post-evpi-clamp-validation-2026-05-14.md` in
`~/Documents/Olumi/audits/2026-05-truth-table/fixtures/staging-runs/`.

## Branch hygiene

This PR is from a scratch branch (`claude-local/b3-ui-rebase-readiness-20260514`)
created via isolated worktree to avoid mutating the long-lived
`claude-plot-ui/b3-auto-noise-disclosure` branch during readiness assessment.
The original B3 branch remains untouched at `d66b2329` (its pre-rebase
HEAD) for reference. After this squash-merge to staging, the scratch
branch can be deleted on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)