### PR TITLE
fix(results): drop "recommendation" from 5 remaining user-facing strings

### DIFF
--- a/src/components/results/ConditionalWinnerCards.tsx
+++ b/src/components/results/ConditionalWinnerCards.tsx
@@ -62,11 +62,14 @@ export function ConditionalWinnerCards({
   )
   if (flipping.length === 0) return null
   const visible = flipping.slice(0, MAX_CONDITIONAL_CARDS)
-  // (Round-7 P1.1) Glossary-safe header copy when composed inside the v17
-  // hero. Legacy panel keeps the original wording.
+  // (Round-7 P1.1, P0 follow-up) Glossary-safe header copy. Both v17 hero
+  // and legacy panel now use glossary-safe wording — the P0 surface-copy
+  // cleanup retired the "the recommendation" legacy string. The branches
+  // remain distinct so the v17 hero can use the more pointed "which
+  // option leads" phrasing.
   const headerHelpText = useV17Copy
     ? 'Factors that change which option leads when they shift'
-    : 'Factors that change the recommendation when they shift'
+    : 'Factors that change the result when they shift'
 
   return (
     <div className="space-y-2 pt-2 border-t border-panel-border/50" data-testid="conditional-winner-cards">

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -239,7 +239,7 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
     if (!readinessDimensions) return undefined
     return [
       { label: 'Evidence', value: readinessDimensions.evidence, tooltip: 'How well-supported your factor estimates are.' },
-      { label: 'Robustness', value: readinessDimensions.robustness, tooltip: 'How sensitive the recommendation is to assumption shifts.' },
+      { label: 'Robustness', value: readinessDimensions.robustness, tooltip: 'How sensitive the result is to assumption shifts.' },
       { label: 'Framing', value: readinessDimensions.clarity, tooltip: 'How clearly the decision and options are framed.' },
     ]
   }, [readinessDimensions])

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -324,13 +324,14 @@ function T1DominantNudge({
     ?? topDriver?.factorKey
     ?? null
   const explanation = `drives ${dominantPct}% of the outcome.`
-  // (Round-5 P1.2) v17 mode rewrites the trailing sentence to glossary-safe
-  // copy. The legacy version contains "the recommendation could change",
-  // which trips the glossary scanner. Pre-v17 callers keep the original
-  // wording unchanged to avoid silent UX shifts in the legacy panel.
+  // (Round-5 P1.2, P0 follow-up) Both v17 and legacy modes use glossary-
+  // safe copy. The legacy branch previously contained "the recommendation
+  // could change"; the P0 surface-copy cleanup retired that. The two
+  // branches diverge only in noun choice — v17 hero says "the leading
+  // option", legacy panel says "the result".
   const trailingClause = useV17Copy
     ? 'If your assumptions about this factor are wrong, the leading option could change.'
-    : 'If your assumptions about this factor are wrong, the recommendation could change.'
+    : 'If your assumptions about this factor are wrong, the result could change.'
   // (Round-5 P1.1) v17 mode: the dominant factor's label is user data and
   // still appears VERBATIM in the visible identity span. But when the same
   // label gets interpolated into generated text (aria-label, title), gate

--- a/src/components/results/copy/freshnessReasons.ts
+++ b/src/components/results/copy/freshnessReasons.ts
@@ -39,7 +39,7 @@ export const FRESHNESS_REASON_COPY: Readonly<Record<string, string>> = {
 
   // From the Wave 3 local-fallback selector
   local_graph_edited:
-    'You have made changes since the last analysis. Re-run to refresh the recommendation.',
+    'You have made changes since the last analysis. Re-run to refresh the analysis.',
   local_results_match:
     'Your analysis matches the current model.',
   no_options_yet:

--- a/src/pages/sandbox-guide/components/panel/sections/AdvancedMetricsSection.tsx
+++ b/src/pages/sandbox-guide/components/panel/sections/AdvancedMetricsSection.tsx
@@ -54,7 +54,7 @@ export function AdvancedMetricsSection({
               {graphQuality.recommendation && (
                 <div className="font-sans mt-3 p-3 bg-analytical-50 rounded-lg border border-analytical-200">
                   <div className="font-sans text-xs font-medium text-analytical-800 mb-1">
-                    Recommendation
+                    Suggestion
                   </div>
                   <div className="font-sans text-xs text-charcoal-900">{graphQuality.recommendation}</div>
                 </div>


### PR DESCRIPTION
## Summary

Companion to the CEE P0 surface-copy cleanup ([olumi-assistants-service#p0-v5-det-post-analysis](../../../olumi-assistants-service/pull/new/p0-v5-det-post-analysis)). Replaces prescriptive "recommendation" / "recommended" wording in five live runtime surfaces with neutral "result" / "leading option" / "analysis" framing. Matches the V5 `FORBIDDEN_USER_FACING_PHRASES` set, which bans both terms in user-facing copy.

### Strings replaced

| File | Surface | Change |
|---|---|---|
| `src/components/results/copy/freshnessReasons.ts:42` | stale-analysis toast (`local_graph_edited`) | "Re-run to refresh the recommendation." → "Re-run to refresh the analysis." |
| `src/components/results/DecisionConfidencePanel.tsx:242` | Robustness tooltip | "How sensitive the recommendation is to assumption shifts." → "How sensitive the result is to assumption shifts." |
| `src/components/results/ConditionalWinnerCards.tsx:69` | legacy panel header | "Factors that change the recommendation when they shift" → "Factors that change the result when they shift" |
| `src/components/results/TriageActionCardsBody.tsx:333` | legacy panel trailing clause | "the recommendation could change" → "the result could change" |
| `src/pages/sandbox-guide/components/panel/sections/AdvancedMetricsSection.tsx:57` | sandbox-guide display label | "Recommendation" → "Suggestion" |

### Safety notes

- **No data-contract changes.** `graphQuality.recommendation` data field is preserved verbatim — only the visible label text changes (`AdvancedMetricsSection.tsx:57`).
- **No selector / data-testid changes.** `data-testid="quality-recommendation"` and `recommendation: graphQuality.recommendation` references in other components (`ModelQualityScore.tsx`, `TrustSignal.tsx`) are untouched.
- **No test churn.** No snapshot/fixture/integration test asserts against the changed strings. The only tests that touch these files (`copy.freshnessReasons.test.ts`, `analysisFreshnessState.test.ts`) assert on code-key lists and `recommendedAction` (internal field), not the rewritten prose.
- The two legacy-panel branches (`ConditionalWinnerCards.tsx:69`, `TriageActionCardsBody.tsx:333`) were previously retained intentionally with a "Legacy panel keeps the original wording" comment; that comment is updated to record the P0 retirement.

## Test plan

- [ ] CI typecheck + vitest green
- [ ] Manual: stale-analysis toast text reads "Re-run to refresh the analysis."
- [ ] Manual: Robustness tooltip text reads "How sensitive the result is to assumption shifts."
- [ ] Manual: legacy `ConditionalWinnerCards` panel header reads "Factors that change the result when they shift"
- [ ] Manual: legacy `TriageActionCardsBody` trailing clause reads "the result could change"
- [ ] Manual: sandbox-guide AdvancedMetrics panel label reads "Suggestion"; underlying `graphQuality.recommendation` data passthrough still renders
- [ ] **Pause for Paul/ChatGPT review before merge — do not merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)