### PR TITLE
feat(results): display-honesty — sample resolution, flip-threshold status, downside qualifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ npm run build                      # production build (separate concern)
 | UI-SEM-046 | `src/components/results/DriversSection.tsx:212` | Elasticity display scaling (x10, floor 1) | Remove when PLoT provides shift percentage |
 | UI-SEM-047 | `src/components/results/DriversSection.tsx:356` | Confidence clamped to [0, 1] | Keep — normalisation |
 | UI-SEM-049 | `src/canvas/components/ModelTabBody.tsx` | VOI fallback: value_of_information * 100 as pp when evpi_percentage_points absent | Remove when PLoT guarantees evpi_percentage_points |
+| UI-SEM-050 | `src/components/results/useResultsSectionData.ts` | Leading-option downside flag — true when leading option's `outcome.p10 < 0`, drives one qualifying sentence on the leader card (display-only, never affects ranking or forwarded values) | Keep — display formatting (legitimate) |
 
 - Check for stale `.js` files co-located with `.ts`/`.tsx` source files in `src/` when debugging unexpected behaviour.
 - This is a React app — check for stale component state, missing dependency arrays in hooks, and incorrect memoisation when debugging rendering issues.

--- a/src/adapters/plot/v2/__tests__/responseMapper.displayHonesty.spec.ts
+++ b/src/adapters/plot/v2/__tests__/responseMapper.displayHonesty.spec.ts
@@ -117,7 +117,7 @@ describe('responseMapper display-honesty', () => {
       expect(outcome?.validity_ratio).toBeUndefined()
     })
 
-    it('rejects NaN / Infinity on sample fields (safeNumber guard)', () => {
+    it('rejects NaN / Infinity on sample fields', () => {
       const response = makeResponse({
         option_comparison: [
           {
@@ -148,6 +148,68 @@ describe('responseMapper display-honesty', () => {
       expect(outcome?.n_samples).toBeUndefined()
       expect(outcome?.n_valid_samples).toBeUndefined()
       expect(outcome?.validity_ratio).toBeUndefined()
+    })
+
+    it('rejects sample counts that are zero, negative, or non-integer (positive-integer guard)', () => {
+      const response = makeResponse({
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            option_label: 'Option A',
+            confidence_interval: [30, 70],
+            win_probability: 0.65,
+            outcome: {
+              mean: 50, std: 12, p10: 30, p50: 50, p90: 70,
+              n_samples: 0,         // not positive
+              n_valid_samples: -5,  // negative
+              // validity_ratio omitted for this case
+            },
+          },
+          {
+            option_id: 'opt_b',
+            option_label: 'Option B',
+            confidence_interval: [20, 60],
+            win_probability: 0.35,
+            outcome: {
+              mean: 35, std: 14, p10: 20, p50: 35, p90: 60,
+              n_samples: 999.5,      // non-integer
+              n_valid_samples: 100,  // valid; must survive
+            },
+          },
+        ],
+      })
+
+      const optA = mapV2ResponseToReportV1(response, { seed: 42 }).option_probabilities?.opt_a?.outcome
+      const optB = mapV2ResponseToReportV1(response, { seed: 42 }).option_probabilities?.opt_b?.outcome
+
+      expect(optA?.n_samples).toBeUndefined()       // zero rejected
+      expect(optA?.n_valid_samples).toBeUndefined() // negative rejected
+      expect(optB?.n_samples).toBeUndefined()       // non-integer rejected
+      expect(optB?.n_valid_samples).toBe(100)       // valid count preserved
+    })
+
+    it('rejects validity_ratio values outside [0, 1] (bounded-ratio guard)', () => {
+      const out = (vr: number) => makeResponse({
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            option_label: 'Option A',
+            confidence_interval: [30, 70],
+            win_probability: 0.65,
+            outcome: { mean: 50, std: 12, p10: 30, p50: 50, p90: 70, validity_ratio: vr },
+          },
+        ],
+      })
+
+      expect(mapV2ResponseToReportV1(out(-0.1), { seed: 42 })
+        .option_probabilities?.opt_a?.outcome?.validity_ratio).toBeUndefined()
+      expect(mapV2ResponseToReportV1(out(1.5), { seed: 42 })
+        .option_probabilities?.opt_a?.outcome?.validity_ratio).toBeUndefined()
+      // Boundary cases must survive: 0 and 1 are valid ratios.
+      expect(mapV2ResponseToReportV1(out(0), { seed: 42 })
+        .option_probabilities?.opt_a?.outcome?.validity_ratio).toBe(0)
+      expect(mapV2ResponseToReportV1(out(1), { seed: 42 })
+        .option_probabilities?.opt_a?.outcome?.validity_ratio).toBe(1)
     })
   })
 
@@ -193,7 +255,7 @@ describe('responseMapper display-honesty', () => {
       expect((report as { flip_thresholds_status?: string }).flip_thresholds_status).toBe('all_no_effect')
     })
 
-    it('passes flip_thresholds_status_reason when present (unresolved case)', () => {
+    it('passes flip_thresholds_status_reason when PLoT emits it (unresolved case)', () => {
       const response = makeResponse({
         flip_thresholds_status: 'unresolved',
         flip_thresholds_status_reason: 'timeout',
@@ -203,6 +265,23 @@ describe('responseMapper display-honesty', () => {
 
       expect((report as { flip_thresholds_status?: string }).flip_thresholds_status).toBe('unresolved')
       expect((report as { flip_thresholds_status_reason?: string }).flip_thresholds_status_reason).toBe('timeout')
+    })
+
+    it('passes flip_thresholds_status_reason when PLoT emits it on partial_no_effect+unresolved (mixed-with-unresolved case)', () => {
+      // Per the PLoT classifier contract, status_reason is also emitted
+      // on 'partial_no_effect' when unresolved entries are present
+      // alongside computed and no_effect ones. The mapper must surface
+      // it in BOTH cases so DGAI can soften copy that would otherwise
+      // imply every non-computed factor was a harmless no_effect case.
+      const response = makeResponse({
+        flip_thresholds_status: 'partial_no_effect',
+        flip_thresholds_status_reason: 'insufficient_precision',
+      })
+
+      const report = mapV2ResponseToReportV1(response, { seed: 42 })
+
+      expect((report as { flip_thresholds_status?: string }).flip_thresholds_status).toBe('partial_no_effect')
+      expect((report as { flip_thresholds_status_reason?: string }).flip_thresholds_status_reason).toBe('insufficient_precision')
     })
 
     it('omits flip_thresholds_status when the V2 response does not carry it (older PLoT builds)', () => {

--- a/src/adapters/plot/v2/__tests__/responseMapper.displayHonesty.spec.ts
+++ b/src/adapters/plot/v2/__tests__/responseMapper.displayHonesty.spec.ts
@@ -59,8 +59,11 @@ function makeResponse(overrides: Partial<V2RunResponse> = {}): V2RunResponse {
     critiques: [],
     drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
     edge_sensitivity: [],
-    factor_sensitivity: [],
-    robustness: { fragile_edges: [], robust_edges: [] },
+    // Non-empty factor_sensitivity AND at least one robust edge keep the
+    // mapper's `computed-but-empty` anomaly detector quiet so failure
+    // output isn't drowned in stderr noise from unrelated anomalies.
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    robustness: { fragile_edges: [], robust_edges: ['e1'] },
     response_hash: 'h',
     meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
     ...overrides,
@@ -112,6 +115,72 @@ describe('responseMapper display-honesty', () => {
       expect(outcome?.n_samples).toBeUndefined()
       expect(outcome?.n_valid_samples).toBeUndefined()
       expect(outcome?.validity_ratio).toBeUndefined()
+    })
+
+    it('rejects NaN / Infinity on sample fields (safeNumber guard)', () => {
+      const response = makeResponse({
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            option_label: 'Option A',
+            confidence_interval: [30, 70],
+            win_probability: 0.65,
+            outcome: {
+              mean: 50,
+              std: 12,
+              p10: 30,
+              p50: 50,
+              p90: 70,
+              // Upstream regression simulation: NaN / Infinity must NOT
+              // reach the UI as undefined-or-bad sample counts.
+              n_samples: NaN as unknown as number,
+              n_valid_samples: Infinity as unknown as number,
+              validity_ratio: -Infinity as unknown as number,
+            },
+          },
+        ],
+      })
+
+      const outcome = mapV2ResponseToReportV1(response, { seed: 42 })
+        .option_probabilities?.opt_a?.outcome
+
+      expect(outcome).toBeDefined()
+      expect(outcome?.n_samples).toBeUndefined()
+      expect(outcome?.n_valid_samples).toBeUndefined()
+      expect(outcome?.validity_ratio).toBeUndefined()
+    })
+  })
+
+  describe('top-level flip_thresholds[] pass-through', () => {
+    it('passes top-level flip_thresholds[] from V2 response onto the mapped report (PLoT v2/run wire shape)', () => {
+      const flips = [
+        { factor_id: 'f1', factor_label: 'F1', flip_value: 0.4, flip_reason: 'found', current_value: 0.5, direction: 'decrease' },
+      ]
+      const response = makeResponse({ flip_thresholds: flips })
+
+      const report = mapV2ResponseToReportV1(response, { seed: 42 })
+
+      expect((report as { flip_thresholds?: unknown }).flip_thresholds).toEqual(flips)
+    })
+
+    it('falls back to robustness.flip_thresholds when the V2 response only nests them there (legacy shape)', () => {
+      const nested = [
+        { factor_id: 'f2', factor_label: 'F2', flip_value: null, flip_reason: 'no_effect_within_bounds', current_value: 0.5, direction: 'increase' },
+      ]
+      const response = makeResponse({
+        flip_thresholds: undefined,
+        robustness: { fragile_edges: [], robust_edges: ['e1'], flip_thresholds: nested as unknown as never },
+      })
+
+      const report = mapV2ResponseToReportV1(response, { seed: 42 })
+
+      expect((report as { flip_thresholds?: unknown }).flip_thresholds).toEqual(nested)
+    })
+
+    it('omits report.flip_thresholds when neither source is present', () => {
+      const report = mapV2ResponseToReportV1(makeResponse(), { seed: 42 })
+
+      expect((report as { flip_thresholds?: unknown }).flip_thresholds).toBeUndefined()
     })
   })
 

--- a/src/adapters/plot/v2/__tests__/responseMapper.displayHonesty.spec.ts
+++ b/src/adapters/plot/v2/__tests__/responseMapper.displayHonesty.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * responseMapper display-honesty tests.
+ *
+ * Pins that the per-option outcome sample counts and the PLoT
+ * `flip_thresholds_status` survive the V2-response → ReportV1 mapping.
+ *
+ * Background: without this guarantee, only fresh-run raw responses
+ * could supply `nValidSamples` to the resolution-aware formatter and
+ * `flipThresholdsStatus` to the all-no-effect UX. Saved or rehydrated
+ * results that flow through `mapV2ResponseToReportV1` would silently
+ * lose the new display-honesty signals, even though the original PLoT
+ * response carried them.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mapV2ResponseToReportV1 } from '../responseMapper'
+import type { V2RunResponse } from '../types'
+
+function makeResponse(overrides: Partial<V2RunResponse> = {}): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [
+      {
+        option_id: 'opt_a',
+        option_label: 'Option A',
+        confidence_interval: [30, 70],
+        win_probability: 0.65,
+        outcome: {
+          mean: 50,
+          std: 12,
+          p10: 30,
+          p50: 50,
+          p90: 70,
+          n_samples: 1000,
+          n_valid_samples: 1000,
+          validity_ratio: 1,
+        },
+      },
+      {
+        option_id: 'opt_b',
+        option_label: 'Option B',
+        confidence_interval: [20, 60],
+        win_probability: 0,
+        outcome: {
+          mean: 35,
+          std: 14,
+          p10: 20,
+          p50: 35,
+          p90: 60,
+          n_samples: 1000,
+          n_valid_samples: 998,
+          validity_ratio: 0.998,
+        },
+      },
+    ],
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [],
+    robustness: { fragile_edges: [], robust_edges: [] },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+    ...overrides,
+  }
+}
+
+describe('responseMapper display-honesty', () => {
+  describe('per-option outcome sample counts', () => {
+    it('preserves outcome.n_samples on option_probabilities entries', () => {
+      const report = mapV2ResponseToReportV1(makeResponse(), { seed: 42 })
+
+      expect(report.option_probabilities?.opt_a?.outcome?.n_samples).toBe(1000)
+      expect(report.option_probabilities?.opt_b?.outcome?.n_samples).toBe(1000)
+    })
+
+    it('preserves outcome.n_valid_samples on option_probabilities entries (used by resolution-aware formatter)', () => {
+      const report = mapV2ResponseToReportV1(makeResponse(), { seed: 42 })
+
+      expect(report.option_probabilities?.opt_a?.outcome?.n_valid_samples).toBe(1000)
+      expect(report.option_probabilities?.opt_b?.outcome?.n_valid_samples).toBe(998)
+    })
+
+    it('preserves outcome.validity_ratio on option_probabilities entries', () => {
+      const report = mapV2ResponseToReportV1(makeResponse(), { seed: 42 })
+
+      expect(report.option_probabilities?.opt_a?.outcome?.validity_ratio).toBe(1)
+      expect(report.option_probabilities?.opt_b?.outcome?.validity_ratio).toBe(0.998)
+    })
+
+    it('omits the sample fields when the V2 response does not carry them (no fabricated values)', () => {
+      const response = makeResponse({
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            option_label: 'Option A',
+            confidence_interval: [30, 70],
+            win_probability: 0.65,
+            // outcome present but without sample-count fields
+            outcome: { mean: 50, std: 12, p10: 30, p50: 50, p90: 70 },
+          },
+        ],
+      })
+
+      const report = mapV2ResponseToReportV1(response, { seed: 42 })
+      const outcome = report.option_probabilities?.opt_a?.outcome
+
+      expect(outcome).toBeDefined()
+      expect(outcome?.mean).toBe(50)
+      expect(outcome?.n_samples).toBeUndefined()
+      expect(outcome?.n_valid_samples).toBeUndefined()
+      expect(outcome?.validity_ratio).toBeUndefined()
+    })
+  })
+
+  describe('flip_thresholds_status pass-through', () => {
+    it('passes flip_thresholds_status from V2 response onto the mapped report (saved/hydrated UX survives)', () => {
+      const response = makeResponse({ flip_thresholds_status: 'all_no_effect' })
+
+      const report = mapV2ResponseToReportV1(response, { seed: 42 })
+
+      expect((report as { flip_thresholds_status?: string }).flip_thresholds_status).toBe('all_no_effect')
+    })
+
+    it('passes flip_thresholds_status_reason when present (unresolved case)', () => {
+      const response = makeResponse({
+        flip_thresholds_status: 'unresolved',
+        flip_thresholds_status_reason: 'timeout',
+      })
+
+      const report = mapV2ResponseToReportV1(response, { seed: 42 })
+
+      expect((report as { flip_thresholds_status?: string }).flip_thresholds_status).toBe('unresolved')
+      expect((report as { flip_thresholds_status_reason?: string }).flip_thresholds_status_reason).toBe('timeout')
+    })
+
+    it('omits flip_thresholds_status when the V2 response does not carry it (older PLoT builds)', () => {
+      const report = mapV2ResponseToReportV1(makeResponse(), { seed: 42 })
+
+      expect((report as { flip_thresholds_status?: string }).flip_thresholds_status).toBeUndefined()
+      expect((report as { flip_thresholds_status_reason?: string }).flip_thresholds_status_reason).toBeUndefined()
+    })
+  })
+})

--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -620,16 +620,22 @@ export function mapV2ResponseToReportV1(
           // the same source as fresh runs. Without this pass-through, the
           // resolution-aware win-probability formatter falls back to the
           // legacy "0%" / "100%" rendering whenever a result is rehydrated
-          // through the mapper.
-          outcome: {
-            mean: rawMean,
-            p10,
-            p50,
-            p90,
-            ...(typeof outcome?.n_samples === 'number' ? { n_samples: outcome.n_samples } : {}),
-            ...(typeof outcome?.n_valid_samples === 'number' ? { n_valid_samples: outcome.n_valid_samples } : {}),
-            ...(typeof outcome?.validity_ratio === 'number' ? { validity_ratio: outcome.validity_ratio } : {}),
-          },
+          // through the mapper. Guarded with safeNumber so NaN / Infinity
+          // from an upstream regression cannot reach the UI.
+          outcome: (() => {
+            const nSamples = safeNumber(outcome?.n_samples)
+            const nValidSamples = safeNumber(outcome?.n_valid_samples)
+            const validityRatio = safeNumber(outcome?.validity_ratio)
+            return {
+              mean: rawMean,
+              p10,
+              p50,
+              p90,
+              ...(nSamples !== null ? { n_samples: nSamples } : {}),
+              ...(nValidSamples !== null ? { n_valid_samples: nValidSamples } : {}),
+              ...(validityRatio !== null ? { validity_ratio: validityRatio } : {}),
+            }
+          })(),
           // Multi-constraint analysis (when goal_constraints were provided in request)
           constraint_analysis: opt.constraint_analysis,
         }
@@ -669,10 +675,21 @@ export function mapV2ResponseToReportV1(
     // B2: Pass through PLoT-classified fields for UI consumption
     confidence_tier: v2Response.confidence_tier,
     dominant_factor: v2Response.dominant_factor,
-    // Display-honesty: pass through PLoT's flip_thresholds classification
-    // so the all-no-effect / partial / unresolved UX survives a save +
-    // hydrate cycle, not only fresh-run raw responses. Mirrors the raw
-    // pass-through in useResultsSectionData.
+    // Display-honesty: pass through PLoT's top-level flip_thresholds[]
+    // array AND its status classification so the all-no-effect / partial /
+    // unresolved UX survives a save + hydrate cycle, not only fresh-run
+    // raw responses. PLoT v2 emits flip_thresholds at the response root
+    // (see plot-lite-service routes/v2/run.ts:2010), but legacy responses
+    // also nested it under robustness; we accept either source and prefer
+    // the top-level one.
+    ...((() => {
+      const topLevel = v2Response.flip_thresholds
+      const nested = v2Response.robustness?.flip_thresholds
+      const source = Array.isArray(topLevel)
+        ? topLevel
+        : Array.isArray(nested) ? nested : undefined
+      return source ? { flip_thresholds: source } : {}
+    })()),
     ...(v2Response.flip_thresholds_status ? { flip_thresholds_status: v2Response.flip_thresholds_status } : {}),
     ...(v2Response.flip_thresholds_status_reason ? { flip_thresholds_status_reason: v2Response.flip_thresholds_status_reason } : {}),
   }

--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -613,11 +613,22 @@ export function mapV2ResponseToReportV1(
           expected,
           // Full outcome distribution for Results Panel display
           // expected is mean (average), p50 is median — semantically distinct
+          //
+          // Display-honesty: preserve per-option sample counts (from PLoT
+          // outcome.n_samples / outcome.n_valid_samples / validity_ratio)
+          // so saved or hydrated results can derive `nValidSamples` from
+          // the same source as fresh runs. Without this pass-through, the
+          // resolution-aware win-probability formatter falls back to the
+          // legacy "0%" / "100%" rendering whenever a result is rehydrated
+          // through the mapper.
           outcome: {
             mean: rawMean,
             p10,
             p50,
             p90,
+            ...(typeof outcome?.n_samples === 'number' ? { n_samples: outcome.n_samples } : {}),
+            ...(typeof outcome?.n_valid_samples === 'number' ? { n_valid_samples: outcome.n_valid_samples } : {}),
+            ...(typeof outcome?.validity_ratio === 'number' ? { validity_ratio: outcome.validity_ratio } : {}),
           },
           // Multi-constraint analysis (when goal_constraints were provided in request)
           constraint_analysis: opt.constraint_analysis,
@@ -635,6 +646,10 @@ export function mapV2ResponseToReportV1(
           p10?: number | null
           p50?: number | null
           p90?: number | null
+          /** Display-honesty: per-option sample counts preserved for resolution-aware formatting. */
+          n_samples?: number
+          n_valid_samples?: number
+          validity_ratio?: number
         }
         constraint_analysis?: import('../../../types/constraints').ConstraintAnalysis
       }>
@@ -654,6 +669,12 @@ export function mapV2ResponseToReportV1(
     // B2: Pass through PLoT-classified fields for UI consumption
     confidence_tier: v2Response.confidence_tier,
     dominant_factor: v2Response.dominant_factor,
+    // Display-honesty: pass through PLoT's flip_thresholds classification
+    // so the all-no-effect / partial / unresolved UX survives a save +
+    // hydrate cycle, not only fresh-run raw responses. Mirrors the raw
+    // pass-through in useResultsSectionData.
+    ...(v2Response.flip_thresholds_status ? { flip_thresholds_status: v2Response.flip_thresholds_status } : {}),
+    ...(v2Response.flip_thresholds_status_reason ? { flip_thresholds_status_reason: v2Response.flip_thresholds_status_reason } : {}),
   }
 }
 

--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -620,12 +620,17 @@ export function mapV2ResponseToReportV1(
           // the same source as fresh runs. Without this pass-through, the
           // resolution-aware win-probability formatter falls back to the
           // legacy "0%" / "100%" rendering whenever a result is rehydrated
-          // through the mapper. Guarded with safeNumber so NaN / Infinity
-          // from an upstream regression cannot reach the UI.
+          // through the mapper.
+          //
+          // Bounded guards reject upstream regressions at the trust
+          // boundary: counts must be POSITIVE INTEGERS (NaN, Infinity,
+          // negatives, zero and floats are dropped); validity_ratio must
+          // be a finite number in [0, 1]. The downstream selector and
+          // formatter assume valid ranges.
           outcome: (() => {
-            const nSamples = safeNumber(outcome?.n_samples)
-            const nValidSamples = safeNumber(outcome?.n_valid_samples)
-            const validityRatio = safeNumber(outcome?.validity_ratio)
+            const nSamples = positiveIntegerOrNull(outcome?.n_samples)
+            const nValidSamples = positiveIntegerOrNull(outcome?.n_valid_samples)
+            const validityRatio = boundedRatioOrNull(outcome?.validity_ratio)
             return {
               mean: rawMean,
               p10,
@@ -965,6 +970,32 @@ function safeNumber(value: unknown): number | null {
     return value
   }
   return null
+}
+
+/**
+ * Display-honesty: positive-integer guard for Monte Carlo sample counts.
+ * Sample counts must be POSITIVE INTEGERS — rejects NaN, Infinity,
+ * negatives, zero, and non-integer floats. Used at the V2-response trust
+ * boundary so the downstream formatter never divides by an invalid `n`.
+ */
+function positiveIntegerOrNull(value: unknown): number | null {
+  const n = safeNumber(value)
+  if (n === null) return null
+  if (n <= 0) return null
+  if (!Number.isInteger(n)) return null
+  return n
+}
+
+/**
+ * Display-honesty: bounded-ratio guard for `validity_ratio` (and any
+ * other [0, 1] proportion fields added later). Rejects NaN, Infinity,
+ * and values outside [0, 1].
+ */
+function boundedRatioOrNull(value: unknown): number | null {
+  const n = safeNumber(value)
+  if (n === null) return null
+  if (n < 0 || n > 1) return null
+  return n
 }
 
 /**

--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -452,6 +452,14 @@ export interface V2RunResponse {
   }
 
   /**
+   * Display-honesty: top-level flip_thresholds[] array as emitted by
+   * PLoT v2/run. Legacy responses also nested it under
+   * `robustness.flip_thresholds` — both shapes are accepted by the
+   * mapper, which prefers this top-level field when present.
+   */
+  flip_thresholds?: Array<Record<string, unknown>>
+
+  /**
    * Display-honesty: high-level classification of `flip_thresholds[]` from
    * PLoT, computed at the post-denormalised response-assembly boundary.
    * Lets the Results UI render the all-no-effect / partial / unresolved
@@ -461,8 +469,12 @@ export interface V2RunResponse {
   flip_thresholds_status?: 'computed' | 'all_no_effect' | 'partial_no_effect' | 'unresolved' | 'unavailable'
 
   /**
-   * First-seen `flip_reason` string when `flip_thresholds_status === 'unresolved'`.
-   * Payload-only debug metadata; never user-facing copy.
+   * First-seen `flip_reason` string from an unresolved entry. Populated
+   * when `flip_thresholds_status === 'unresolved'`, OR on
+   * `'partial_no_effect'` when unresolved entries are present alongside
+   * computed and no_effect ones (lets the UI soften copy that would
+   * otherwise imply all non-computed factors were harmless no-effect
+   * cases). Payload-only debug metadata; never user-facing copy.
    */
   flip_thresholds_status_reason?: string
 

--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -134,6 +134,20 @@ export interface V2Outcome {
   p10: number
   p50: number
   p90: number
+  /**
+   * Total Monte Carlo samples drawn for this option (optional — present when
+   * ISL emits it on the per-option outcome object).
+   */
+  n_samples?: number
+  /**
+   * Number of valid (non-NaN) samples for this option. Used by display-honesty
+   * UI to derive the simulation-resolution floor / ceiling per option.
+   */
+  n_valid_samples?: number
+  /**
+   * Ratio of valid to total samples (n_valid_samples / n_samples).
+   */
+  validity_ratio?: number
 }
 
 /**
@@ -436,6 +450,21 @@ export interface V2RunResponse {
     is_provisional: boolean
     calibration_status: string
   }
+
+  /**
+   * Display-honesty: high-level classification of `flip_thresholds[]` from
+   * PLoT, computed at the post-denormalised response-assembly boundary.
+   * Lets the Results UI render the all-no-effect / partial / unresolved
+   * cases honestly without re-deriving from individual `flip_reason` strings.
+   * Optional — present on PLoT builds shipping the display-honesty PR.
+   */
+  flip_thresholds_status?: 'computed' | 'all_no_effect' | 'partial_no_effect' | 'unresolved' | 'unavailable'
+
+  /**
+   * First-seen `flip_reason` string when `flip_thresholds_status === 'unresolved'`.
+   * Payload-only debug metadata; never user-facing copy.
+   */
+  flip_thresholds_status_reason?: string
 
   // ==========================================================================
   // M1 CEE Review Fields (optional enrichment)

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -17,7 +17,12 @@
 
 import { useRef, useState, useCallback, type RefObject } from 'react'
 import { typography } from '../../styles/typography'
-import { formatPercent as formatPct } from '../../utils/formatPercent'
+import {
+  formatPercent as formatPct,
+  formatProbabilityWithResolution,
+  isAboveSimulationResolution,
+  isBelowSimulationResolution,
+} from '../../utils/formatPercent'
 import { ExpertBlock } from './ExpertBlock'
 import { formatOptionLabelForCard } from './utils/cleanFactorLabel'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
@@ -57,6 +62,12 @@ export interface OptionCardsProps {
   confidenceTier?: ConfidenceTier
   /** Brief 5.4 QA Item 4: stability gate for winner chip hedging (mirrors certaintyCopy threshold) */
   recommendationStability?: number
+  /**
+   * Display-honesty (UI-SEM-050): when true, render a single qualifying
+   * sentence inside the leading option's card noting meaningful downside
+   * in the lower simulated range.
+   */
+  leadingOptionDownsideFlag?: boolean
 }
 
 /** Fallback description when no story headline is available */
@@ -268,6 +279,7 @@ function OptionCard({
   expertMode = false,
   confidenceTier,
   recommendationStability,
+  leadingOptionDownsideFlag,
 }: {
   option: OptionResult
   isWinner: boolean
@@ -293,6 +305,12 @@ function OptionCard({
   confidenceTier?: ConfidenceTier
   /** Brief 5.4 QA Item 4: stability gate for winner chip hedging (mirrors certaintyCopy threshold) */
   recommendationStability?: number
+  /**
+   * Display-honesty (UI-SEM-050): when true and this card is the leading
+   * option, render a single qualifying sentence noting meaningful downside
+   * in the lower simulated range. Display-only.
+   */
+  leadingOptionDownsideFlag?: boolean
 }) {
   // Brief 5.8B D3: per-rank palette (success / info / option / panel-border)
   // collapsed to a 2-state hierarchy — winner cards get `border-success/30`,
@@ -350,12 +368,20 @@ function OptionCard({
         )}
         <span className="flex-1" />
         {option.winProbability != null && (
-          <Tooltip content={`Leads in ${Math.round(option.winProbability * 100)}% of simulated scenarios`}>
+          <Tooltip
+            content={
+              isBelowSimulationResolution(option.winProbability, option.nValidSamples)
+                ? 'This option did not lead in any of the simulation runs, so its true chance may be below the current resolution.'
+                : isAboveSimulationResolution(option.winProbability, option.nValidSamples)
+                  ? 'This option led in every simulation run, so its display value reflects the current simulation resolution.'
+                  : `Leads in ${formatProbabilityWithResolution(option.winProbability, option.nValidSamples)} of simulated scenarios`
+            }
+          >
             <span
               className={`${typography.panelHeader} text-text-header tabular-nums flex-shrink-0`}
               data-testid={`win-pct-${option.id}`}
             >
-              {formatPct(option.winProbability, { fromDecimal: true })}
+              {formatProbabilityWithResolution(option.winProbability, option.nValidSamples)}
             </span>
           </Tooltip>
         )}
@@ -371,7 +397,7 @@ function OptionCard({
         <div
           className="w-full rounded-full overflow-hidden"
           style={{ height: 5, backgroundColor: 'var(--border-default, #EEE6D8)' }}
-          title={`Leading-option probability: ${Math.round(option.winProbability * 100)}%`}
+          title={`Leading-option probability: ${formatProbabilityWithResolution(option.winProbability, option.nValidSamples)}`}
         >
           <div
             className="h-full rounded-full transition-all duration-300"
@@ -381,6 +407,19 @@ function OptionCard({
             }}
           />
         </div>
+      )}
+
+      {/* Display-honesty (UI-SEM-050): qualifying sentence for the leading
+          option when its lower simulated range includes meaningful downside.
+          Reuses the existing outlined-pill pattern (border-info/30) — no new
+          colour or component primitive. */}
+      {isWinner && leadingOptionDownsideFlag === true && !neutralised && (
+        <p
+          className={`${typography.panelMeta} text-text-light`}
+          data-testid={`leading-option-downside-${option.id}`}
+        >
+          This option currently leads, but the lower range of simulated outcomes includes meaningful downside.
+        </p>
       )}
 
       {/* Stat rows */}
@@ -491,6 +530,7 @@ export function OptionCards({
   expertMode,
   confidenceTier,
   recommendationStability,
+  leadingOptionDownsideFlag,
 }: OptionCardsProps) {
   // Internal ref map if none provided externally
   const internalRefMap = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -601,6 +641,7 @@ export function OptionCards({
             expertMode={expertMode}
             confidenceTier={confidenceTier}
             recommendationStability={recommendationStability}
+            leadingOptionDownsideFlag={leadingOptionDownsideFlag}
           />
         )
       })}

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -333,7 +333,9 @@ export const ResultsBody = memo(function ResultsBody({
                 data-testid="flip-thresholds-status-note"
                 role="note"
               >
-                Some factors did not change the leading option within the current range.
+                {resultsSectionData.recommendation.flipThresholdsHasUnresolved
+                  ? 'Some factors did not change the leading option within the current range, and others could not be resolved.'
+                  : 'Some factors did not change the leading option within the current range.'}
               </p>
             )}
             <TornadoChart

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -271,6 +271,7 @@ export const ResultsBody = memo(function ResultsBody({
               expertMode={expertMode}
               confidenceTier={resultsSectionData.confidence.tier.tier}
               recommendationStability={resultsSectionData.recommendation.recommendationStability}
+              leadingOptionDownsideFlag={resultsSectionData.recommendation.leadingOptionDownsideFlag}
             />
             {/* TippingPoints removed — superseded by TornadoChart (Brief 5.4 Phase 1) */}
           </div>
@@ -312,6 +313,29 @@ export const ResultsBody = memo(function ResultsBody({
           testId="accordion-tornado"
         >
           <SectionErrorBoundary section="Tornado">
+            {/* Display-honesty: when PLoT classifies the post-denormalised
+                flip_thresholds[] as all-no-effect or partial-no-effect,
+                render one short explanatory line so absent markers do not
+                read as actionable insight. Reuses panel typography only —
+                no new colour or component. */}
+            {resultsSectionData.recommendation.flipThresholdsStatus === 'all_no_effect' && (
+              <p
+                className="text-sm text-text-light mb-3"
+                data-testid="flip-thresholds-status-note"
+                role="note"
+              >
+                No single tested factor changed the leading option within the current range.
+              </p>
+            )}
+            {resultsSectionData.recommendation.flipThresholdsStatus === 'partial_no_effect' && (
+              <p
+                className="text-sm text-text-light mb-3"
+                data-testid="flip-thresholds-status-note"
+                role="note"
+              >
+                Some factors did not change the leading option within the current range.
+              </p>
+            )}
             <TornadoChart
               rows={tornadoData.rows}
               expectedOutcome={tornadoData.expectedOutcome}

--- a/src/components/results/__tests__/OptionCards.displayHonesty.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.displayHonesty.spec.tsx
@@ -1,0 +1,168 @@
+/**
+ * OptionCards display-honesty tests.
+ *
+ * Covers:
+ *   A. sample-resolution display (<0.1% / >99.9% / threshold scaling with N,
+ *      raw winProbability preserved for bar width)
+ *   C. high-variance leading-option qualification (renders only when the
+ *      leading option's outcome.p10 < 0)
+ *
+ * Banned wording check ensures the new copy never introduces "winner",
+ * "winning", "recommended", or "recommendation" — UI uses "leading option".
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import type { OptionResult } from '../types'
+
+function makeOption(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: 'option-a',
+    label: 'Option A',
+    expected: 50,
+    outcome: { mean: 50, p10: 20, p50: 50, p90: 80 },
+    p10: 20,
+    p50: 50,
+    p90: 80,
+    isRecommended: true,
+    winProbability: 0.65,
+    goalProbability: 0.7,
+    rank: 1,
+    ...overrides,
+  }
+}
+
+describe('OptionCards — display-honesty (A) sample resolution', () => {
+  it('renders exact 0 winProbability as <0.1% at n_valid_samples=1000', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0.65, nValidSamples: 1000 }),
+      makeOption({ id: 'b', label: 'B', winProbability: 0, nValidSamples: 1000, isRecommended: false }),
+    ]
+    render(<OptionCards options={options} winnerId="a" />)
+
+    expect(screen.getByTestId('win-pct-b').textContent).toBe('<0.1%')
+  })
+
+  it('renders exact 1 winProbability as >99.9% at n_valid_samples=1000', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 1, nValidSamples: 1000 }),
+      makeOption({ id: 'b', label: 'B', winProbability: 0, nValidSamples: 1000, isRecommended: false }),
+    ]
+    render(<OptionCards options={options} winnerId="a" />)
+
+    expect(screen.getByTestId('win-pct-a').textContent).toBe('>99.9%')
+  })
+
+  it('threshold scales with sample count: <0.01% at n_valid_samples=10000', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 1, nValidSamples: 10000 }),
+      makeOption({ id: 'b', label: 'B', winProbability: 0, nValidSamples: 10000, isRecommended: false }),
+    ]
+    render(<OptionCards options={options} winnerId="a" />)
+
+    expect(screen.getByTestId('win-pct-b').textContent).toBe('<0.01%')
+    expect(screen.getByTestId('win-pct-a').textContent).toBe('>99.99%')
+  })
+
+  it('falls back to legacy formatting when nValidSamples is absent', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0, nValidSamples: undefined }),
+      makeOption({ id: 'b', label: 'B', winProbability: 0.5, nValidSamples: undefined, isRecommended: false }),
+    ]
+    render(<OptionCards options={options} winnerId="a" />)
+
+    // Legacy formatPct path — preserves the prior 0% rendering
+    expect(screen.getByTestId('win-pct-a').textContent).toBe('0%')
+    expect(screen.getByTestId('win-pct-b').textContent).toBe('50%')
+  })
+
+  it('renders normal percent for mid-range probabilities even with sample count present', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0.58, nValidSamples: 1000 }),
+    ]
+    render(<OptionCards options={options} winnerId="a" />)
+
+    expect(screen.getByTestId('win-pct-a').textContent).toBe('58%')
+  })
+})
+
+describe('OptionCards — display-honesty (C) leading-option downside qualification', () => {
+  it('renders the qualification sentence only when leadingOptionDownsideFlag is true and option is the leader', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0.7, outcome: { mean: 10, p10: -50, p50: 10, p90: 80 } }),
+    ]
+    render(
+      <OptionCards
+        options={options}
+        winnerId="a"
+        leadingOptionDownsideFlag={true}
+      />,
+    )
+
+    const note = screen.getByTestId('leading-option-downside-a')
+    expect(note).toBeInTheDocument()
+    expect(note.textContent).toContain('lower range of simulated outcomes includes meaningful downside')
+  })
+
+  it('does not render the qualification sentence when the flag is false', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0.7, outcome: { mean: 50, p10: 5, p50: 50, p90: 95 } }),
+    ]
+    render(
+      <OptionCards
+        options={options}
+        winnerId="a"
+        leadingOptionDownsideFlag={false}
+      />,
+    )
+
+    expect(screen.queryByTestId('leading-option-downside-a')).not.toBeInTheDocument()
+  })
+
+  it('does not render the qualification sentence when the flag is undefined', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0.7 }),
+    ]
+    render(<OptionCards options={options} winnerId="a" />)
+
+    expect(screen.queryByTestId('leading-option-downside-a')).not.toBeInTheDocument()
+  })
+
+  it('does not render the qualification sentence on a non-leading option even when the flag is true', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0.7 }),
+      makeOption({ id: 'b', label: 'B', winProbability: 0.3, isRecommended: false }),
+    ]
+    render(
+      <OptionCards
+        options={options}
+        winnerId="a"
+        leadingOptionDownsideFlag={true}
+      />,
+    )
+
+    // Only the leader carries the qualification
+    expect(screen.getByTestId('leading-option-downside-a')).toBeInTheDocument()
+    expect(screen.queryByTestId('leading-option-downside-b')).not.toBeInTheDocument()
+  })
+})
+
+describe('OptionCards — display-honesty: copy never uses banned wording', () => {
+  it('the downside qualification copy avoids "winner" / "winning" / "recommended" / "recommendation"', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', winProbability: 0.7 }),
+    ]
+    render(
+      <OptionCards
+        options={options}
+        winnerId="a"
+        leadingOptionDownsideFlag={true}
+      />,
+    )
+
+    const note = screen.getByTestId('leading-option-downside-a')
+    const text = note.textContent ?? ''
+    expect(text.toLowerCase()).not.toMatch(/\bwinner\b|\bwinning\b|\brecommend(ed|ation)\b/)
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.flipThresholdsStatus.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.flipThresholdsStatus.spec.tsx
@@ -1,0 +1,205 @@
+/**
+ * Display-honesty (B) — flip_thresholds_status soft note.
+ *
+ * When PLoT classifies the post-denormalised flip_thresholds[] array, the
+ * tornado-section accordion renders a single short explanatory line for
+ * 'all_no_effect' and 'partial_no_effect', and renders nothing extra for
+ * 'computed' or absent classification. The tornado chart itself is
+ * unchanged in every case.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriverItem,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+import type { TornadoRow } from '../TornadoChart'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+}))
+
+function makeOption(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.7,
+    outcome: { mean: 0.7, p10: 0.5, p50: 0.7, p90: 0.9 },
+    p10: 0.5,
+    p50: 0.7,
+    p90: 0.9,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+    ...overrides,
+  } as OptionResult
+}
+
+function makeDriver(overrides: Partial<DriverItem> = {}): DriverItem {
+  return {
+    factorKey: 'fac_top',
+    factorLabel: 'Top driver',
+    rawElasticity: 1,
+    normalisedInfluence: 1,
+    influenceScore: 0.9,
+    rank: 1,
+    direction: 'positive',
+    semanticLabel: 'biggest',
+    canFocus: true,
+    matchedNodeId: 'node_top',
+    confidence: 0.7,
+    ...overrides,
+  } as DriverItem
+}
+
+function makeData(overrides: Partial<DecisionResultData> = {}): ResultsSectionDataReturn {
+  const winner = makeOption()
+  const runnerUp = makeOption({ id: 'opt_b', label: 'Option B', isRecommended: false, winProbability: 0.3 })
+
+  const recommendation: DecisionResultData = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+    ...overrides,
+  } as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [makeDriver()],
+    topDrivers: [makeDriver()],
+    driversStatus: 'computed',
+    totalCount: 1,
+    hasMagnitudeData: true,
+  } as DriversSectionData
+
+  const confidence: ConfidenceSectionData = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  }
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+  } as ResultsSectionDataReturn
+}
+
+const tornadoData = {
+  rows: [
+    {
+      factorKey: 'fac_top',
+      label: 'Top driver',
+      lowOutcome: 0.4,
+      highOutcome: 0.9,
+      canFocus: true,
+      matchedNodeId: 'node_top',
+      direction: 'positive' as const,
+    } satisfies TornadoRow,
+  ],
+  expectedOutcome: 0.7,
+}
+
+describe('ResultsBody — display-honesty (B) flip_thresholds_status', () => {
+  it("renders 'No single tested factor changed the leading option…' for all_no_effect", () => {
+    render(
+      <ResultsBody
+        resultsSectionData={makeData({ flipThresholdsStatus: 'all_no_effect' })}
+        tornadoData={tornadoData}
+        onSendMessage={() => {}}
+      />,
+    )
+    const note = screen.getByTestId('flip-thresholds-status-note')
+    expect(note).toBeInTheDocument()
+    expect(note.textContent).toBe('No single tested factor changed the leading option within the current range.')
+    expect(note.getAttribute('role')).toBe('note')
+  })
+
+  it("renders 'Some factors did not change the leading option…' for partial_no_effect", () => {
+    render(
+      <ResultsBody
+        resultsSectionData={makeData({ flipThresholdsStatus: 'partial_no_effect' })}
+        tornadoData={tornadoData}
+        onSendMessage={() => {}}
+      />,
+    )
+    const note = screen.getByTestId('flip-thresholds-status-note')
+    expect(note).toBeInTheDocument()
+    expect(note.textContent).toBe('Some factors did not change the leading option within the current range.')
+  })
+
+  it('renders no note for computed classification', () => {
+    render(
+      <ResultsBody
+        resultsSectionData={makeData({ flipThresholdsStatus: 'computed' })}
+        tornadoData={tornadoData}
+        onSendMessage={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('flip-thresholds-status-note')).not.toBeInTheDocument()
+  })
+
+  it('renders no note for unresolved classification (avoids noisy or misleading UI)', () => {
+    render(
+      <ResultsBody
+        resultsSectionData={makeData({ flipThresholdsStatus: 'unresolved' })}
+        tornadoData={tornadoData}
+        onSendMessage={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('flip-thresholds-status-note')).not.toBeInTheDocument()
+  })
+
+  it('renders no note when flipThresholdsStatus is absent (older PLoT builds — backward-compatible silent absence)', () => {
+    render(
+      <ResultsBody
+        resultsSectionData={makeData({ flipThresholdsStatus: undefined })}
+        tornadoData={tornadoData}
+        onSendMessage={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('flip-thresholds-status-note')).not.toBeInTheDocument()
+  })
+
+  it('the all_no_effect copy avoids banned wording (winner / winning / recommended / recommendation / Monte Carlo / no_effect)', () => {
+    render(
+      <ResultsBody
+        resultsSectionData={makeData({ flipThresholdsStatus: 'all_no_effect' })}
+        tornadoData={tornadoData}
+        onSendMessage={() => {}}
+      />,
+    )
+    const text = screen.getByTestId('flip-thresholds-status-note').textContent ?? ''
+    expect(text.toLowerCase()).not.toMatch(/\bwinner\b|\bwinning\b|\brecommend(ed|ation)\b|monte\s*carlo|no_effect/i)
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.flipThresholdsStatus.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.flipThresholdsStatus.spec.tsx
@@ -145,7 +145,7 @@ describe('ResultsBody — display-honesty (B) flip_thresholds_status', () => {
     expect(note.getAttribute('role')).toBe('note')
   })
 
-  it("renders 'Some factors did not change the leading option…' for partial_no_effect", () => {
+  it("renders 'Some factors did not change the leading option…' for partial_no_effect with no unresolved entries", () => {
     render(
       <ResultsBody
         resultsSectionData={makeData({ flipThresholdsStatus: 'partial_no_effect' })}
@@ -156,6 +156,24 @@ describe('ResultsBody — display-honesty (B) flip_thresholds_status', () => {
     const note = screen.getByTestId('flip-thresholds-status-note')
     expect(note).toBeInTheDocument()
     expect(note.textContent).toBe('Some factors did not change the leading option within the current range.')
+  })
+
+  it("renders the mixed-with-unresolved variant when partial_no_effect also has unresolved entries (avoids implying all non-computed were harmless)", () => {
+    render(
+      <ResultsBody
+        resultsSectionData={makeData({
+          flipThresholdsStatus: 'partial_no_effect',
+          flipThresholdsHasUnresolved: true,
+        })}
+        tornadoData={tornadoData}
+        onSendMessage={() => {}}
+      />,
+    )
+    const note = screen.getByTestId('flip-thresholds-status-note')
+    expect(note).toBeInTheDocument()
+    expect(note.textContent).toBe(
+      'Some factors did not change the leading option within the current range, and others could not be resolved.',
+    )
   })
 
   it('renders no note for computed classification', () => {

--- a/src/components/results/__tests__/useResultsSectionData.displayHonesty.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.displayHonesty.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * useResultsSectionData — display-honesty hook-level integration.
+ *
+ * Drives the data hook through a mapped report (not raw V2 response) to
+ * pin the final report→VM fallbacks for `nValidSamples` and
+ * `flipThresholdsStatus`. The earlier mapper test proves PLoT → report
+ * preserves the fields; this test proves report → VM exposes them on
+ * `OptionResult` and `DecisionResultData`, which is the path saved or
+ * hydrated results actually take in production.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+function makeV2Response(overrides: Partial<V2RunResponse> = {}): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [
+      {
+        option_id: 'opt_a',
+        option_label: 'Option A',
+        confidence_interval: [30, 70],
+        win_probability: 0.65,
+        outcome: {
+          mean: 50, std: 12, p10: 30, p50: 50, p90: 70,
+          n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1,
+        },
+      },
+      {
+        option_id: 'opt_b',
+        option_label: 'Option B',
+        confidence_interval: [20, 60],
+        win_probability: 0,
+        outcome: {
+          mean: 35, std: 14, p10: 20, p50: 35, p90: 60,
+          n_samples: 1000, n_valid_samples: 998, validity_ratio: 0.998,
+        },
+      },
+    ],
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    robustness: { fragile_edges: [], robust_edges: ['e1'] },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+    ...overrides,
+  }
+}
+
+const OPTION_NODES = [
+  { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option A' } },
+  { id: 'opt_b', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option B' } },
+]
+
+function setStoreWithMappedReport(v2Response: V2RunResponse): void {
+  const report = mapV2ResponseToReportV1(v2Response, { seed: 42 })
+  useCanvasStore.setState({
+    // Mapped report — simulating a saved or hydrated run.
+    results: { status: 'complete', progress: 100, report } as any,
+    runMeta: {} as any,
+    nodes: OPTION_NODES as any,
+    edges: [],
+    hasCompletedFirstRun: true,
+    // No raw V2 response — forces the report-fallback path.
+    rawV2Response: null,
+  } as any)
+}
+
+describe('useResultsSectionData — display-honesty (report → VM fallback)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+    } as any)
+  })
+
+  describe('nValidSamples propagates from mapped report', () => {
+    it('exposes per-option nValidSamples on OptionResult when raw response is absent (hydrated/saved path)', () => {
+      setStoreWithMappedReport(makeV2Response())
+
+      const { result } = renderHook(() => useResultsSectionData())
+
+      const allOptions = result.current.recommendation?.allOptions ?? []
+      const optA = allOptions.find(o => o.id === 'opt_a')
+      const optB = allOptions.find(o => o.id === 'opt_b')
+
+      expect(optA?.nValidSamples).toBe(1000)
+      expect(optB?.nValidSamples).toBe(998)
+    })
+
+    it('falls back to outcome.n_samples when n_valid_samples is absent', () => {
+      const v2 = makeV2Response({
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            option_label: 'Option A',
+            confidence_interval: [30, 70],
+            win_probability: 0.65,
+            outcome: { mean: 50, std: 12, p10: 30, p50: 50, p90: 70, n_samples: 5000 },
+          },
+        ],
+      })
+      setStoreWithMappedReport(v2)
+
+      const { result } = renderHook(() => useResultsSectionData())
+      const optA = result.current.recommendation?.allOptions?.find(o => o.id === 'opt_a')
+
+      expect(optA?.nValidSamples).toBe(5000)
+    })
+
+    it('leaves nValidSamples undefined when neither per-option nor meta sample counts are available', () => {
+      const v2 = makeV2Response({
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            option_label: 'Option A',
+            confidence_interval: [30, 70],
+            win_probability: 0.65,
+            // outcome present but no sample-count fields
+            outcome: { mean: 50, std: 12, p10: 30, p50: 50, p90: 70 },
+          },
+        ],
+        meta: { seed_used: '42', n_samples: 0 as unknown as number, detail_level: 'standard', latency_ms: 100 },
+      })
+      setStoreWithMappedReport(v2)
+
+      const { result } = renderHook(() => useResultsSectionData())
+      const optA = result.current.recommendation?.allOptions?.find(o => o.id === 'opt_a')
+
+      expect(optA?.nValidSamples).toBeUndefined()
+    })
+  })
+
+  describe('flipThresholdsStatus propagates from mapped report', () => {
+    it('exposes flipThresholdsStatus on DecisionResultData when raw response is absent (hydrated/saved path)', () => {
+      setStoreWithMappedReport(makeV2Response({ flip_thresholds_status: 'all_no_effect' }))
+
+      const { result } = renderHook(() => useResultsSectionData())
+
+      expect(result.current.recommendation?.flipThresholdsStatus).toBe('all_no_effect')
+      expect(result.current.recommendation?.flipThresholdsHasUnresolved).toBe(false)
+    })
+
+    it('flips flipThresholdsHasUnresolved to true when the mapped report carries a status_reason', () => {
+      setStoreWithMappedReport(
+        makeV2Response({
+          flip_thresholds_status: 'partial_no_effect',
+          flip_thresholds_status_reason: 'timeout',
+        }),
+      )
+
+      const { result } = renderHook(() => useResultsSectionData())
+
+      expect(result.current.recommendation?.flipThresholdsStatus).toBe('partial_no_effect')
+      expect(result.current.recommendation?.flipThresholdsHasUnresolved).toBe(true)
+    })
+
+    it('leaves flipThresholdsStatus undefined for older responses that predate the status field', () => {
+      setStoreWithMappedReport(makeV2Response())
+
+      const { result } = renderHook(() => useResultsSectionData())
+
+      expect(result.current.recommendation?.flipThresholdsStatus).toBeUndefined()
+      expect(result.current.recommendation?.flipThresholdsHasUnresolved).toBe(false)
+    })
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.displayHonesty.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.displayHonesty.spec.ts
@@ -142,6 +142,75 @@ describe('useResultsSectionData — display-honesty (report → VM fallback)', (
     })
   })
 
+  describe('fresh-run flip_thresholds source precedence (top-level wins over nested)', () => {
+    it('prefers rawV2Response.flip_thresholds over rawV2Response.robustness.flip_thresholds when both are present', () => {
+      // Fresh-run + hydrated runs must use the same precedence so the
+      // UI behaviour does not diverge when the same PLoT response is
+      // served from a cache vs computed live. The mapper prefers
+      // top-level (see responseMapper display-honesty block); this test
+      // pins the same contract on the raw-response path.
+      const topLevel = [
+        { factor_id: 'top_f1', factor_label: 'Top-level F1', flip_value: 0.4, flip_reason: 'found', current_value: 0.5, direction: 'decrease' as const, alternative_winner_label: 'B' },
+      ]
+      const nested = [
+        { factor_id: 'nested_f1', factor_label: 'Nested F1', flip_value: 0.2, flip_reason: 'found', current_value: 0.5, direction: 'decrease' as const, alternative_winner_label: 'C' },
+      ]
+      useCanvasStore.setState({
+        // Empty results.report so the selector's report-side defensive
+        // adaptor cannot supply flip_thresholds — forces it to fall
+        // back to rawV2Response.
+        results: { status: 'complete', progress: 100, report: {} } as any,
+        runMeta: {} as any,
+        nodes: OPTION_NODES as any,
+        edges: [],
+        hasCompletedFirstRun: true,
+        rawV2Response: {
+          ...makeV2Response(),
+          flip_thresholds: topLevel,
+          robustness: {
+            fragile_edges: [], robust_edges: ['e1'],
+            flip_thresholds: nested as unknown as never,
+          },
+        } as any,
+      } as any)
+
+      const { result } = renderHook(() => useResultsSectionData())
+      const flips = result.current.recommendation?.flipThresholds ?? []
+
+      expect(flips).toHaveLength(1)
+      expect(flips[0]?.node_id).toBe('top_f1')
+      // Negative assertion to catch a future precedence regression:
+      expect(flips[0]?.node_id).not.toBe('nested_f1')
+    })
+
+    it('falls back to rawV2Response.robustness.flip_thresholds when top-level is absent (legacy shape)', () => {
+      const nested = [
+        { factor_id: 'nested_f1', factor_label: 'Nested F1', flip_value: 0.2, flip_reason: 'found', current_value: 0.5, direction: 'decrease' as const, alternative_winner_label: 'C' },
+      ]
+      useCanvasStore.setState({
+        results: { status: 'complete', progress: 100, report: {} } as any,
+        runMeta: {} as any,
+        nodes: OPTION_NODES as any,
+        edges: [],
+        hasCompletedFirstRun: true,
+        rawV2Response: {
+          ...makeV2Response(),
+          // flip_thresholds intentionally absent at top level.
+          robustness: {
+            fragile_edges: [], robust_edges: ['e1'],
+            flip_thresholds: nested as unknown as never,
+          },
+        } as any,
+      } as any)
+
+      const { result } = renderHook(() => useResultsSectionData())
+      const flips = result.current.recommendation?.flipThresholds ?? []
+
+      expect(flips).toHaveLength(1)
+      expect(flips[0]?.node_id).toBe('nested_f1')
+    })
+  })
+
   describe('flipThresholdsStatus propagates from mapped report', () => {
     it('exposes flipThresholdsStatus on DecisionResultData when raw response is absent (hydrated/saved path)', () => {
       setStoreWithMappedReport(makeV2Response({ flip_thresholds_status: 'all_no_effect' }))

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -119,6 +119,14 @@ export interface OptionResult {
   p90: number | null
   isRecommended: boolean
   winProbability?: number
+  /**
+   * Display-honesty: per-option valid Monte Carlo sample count (from
+   * PLoT outcome.n_valid_samples, with fallback to outcome.n_samples /
+   * meta.n_samples). Used to derive the simulation-resolution floor /
+   * ceiling for `winProbability` display ("<0.1%" / ">99.9%" at n=1000).
+   * Source value only — display formatting happens at render time.
+   */
+  nValidSamples?: number
   /** Optional goal probability when no distribution data exists. */
   goalProbability?: number | null
   /** Task 2.1: Whether this option is the baseline for comparison */
@@ -184,6 +192,22 @@ export interface DecisionResultData {
   nearTie?: NearTieInfo
   /** Task 6: Flip thresholds for tipping points visualisation */
   flipThresholds?: FlipThreshold[]
+  /**
+   * Display-honesty: PLoT classification of the post-denormalised
+   * `flip_thresholds[]` array. Drives the all-no-effect / partial /
+   * unresolved UX so the section is not presented as actionable insight
+   * when no factor changed the leading option within the current range.
+   * Optional — present on PLoT builds shipping the display-honesty PR.
+   */
+  flipThresholdsStatus?: 'computed' | 'all_no_effect' | 'partial_no_effect' | 'unresolved' | 'unavailable'
+  /**
+   * Display-honesty: leading option has meaningful downside in the lower
+   * range of simulated outcomes (deterministic: leading option's
+   * `outcome.p10 < 0`). Drives a single qualifying sentence in the
+   * leading-option summary. Undefined when p10 unavailable.
+   * @see UI-SEM-050
+   */
+  leadingOptionDownsideFlag?: boolean
 
   // ==========================================================================
   // M1 Coaching Fields (deterministic, not LLM-generated)

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -201,6 +201,14 @@ export interface DecisionResultData {
    */
   flipThresholdsStatus?: 'computed' | 'all_no_effect' | 'partial_no_effect' | 'unresolved' | 'unavailable'
   /**
+   * Display-honesty: signals that the flip_thresholds[] array also
+   * contained unresolved entries (timeout / error / insufficient
+   * precision) alongside computed and no_effect ones. Used by the UI
+   * to soften copy on `'partial_no_effect'` so it doesn't imply every
+   * non-computed factor was a harmless no-effect case.
+   */
+  flipThresholdsHasUnresolved?: boolean
+  /**
    * Display-honesty: leading option has meaningful downside in the lower
    * range of simulated outcomes (deterministic: leading option's
    * `outcome.p10 < 0`). Drives a single qualifying sentence in the

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -890,6 +890,8 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     ceeAnalysisReady,
     rawV2FlipThresholds,
     rawAutoNoiseProvenance,
+    rawFlipThresholdsStatus,
+    rawMetaNSamples,
   } = useCanvasStore(
     useShallow((s) => ({
       results: s.results,
@@ -910,6 +912,13 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // to the whole rawV2Response. Typed via V2RunResponse since PLoT
       // commit 562e461; normalised at the trust boundary below.
       rawAutoNoiseProvenance: s.rawV2Response?.auto_noise_provenance ?? null,
+      // Display-honesty: PLoT-side classification of flip_thresholds[]
+      // (companion to PR claude-plot/display-honesty). Optional — older
+      // PLoT builds omit the field, in which case we leave UX unchanged.
+      rawFlipThresholdsStatus: (s.rawV2Response as { flip_thresholds_status?: string } | null | undefined)?.flip_thresholds_status ?? null,
+      // Display-honesty: root meta.n_samples used as fallback resolution
+      // source when an option lacks per-option n_valid_samples.
+      rawMetaNSamples: s.rawV2Response?.meta?.n_samples ?? null,
     }))
   )
 
@@ -1145,6 +1154,21 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         ? jointGoalProb
         : unconstrained
 
+      // Display-honesty: per-option valid sample count for resolution-aware
+      // probability formatting. Fallback chain prefers per-option signal,
+      // then per-option total, then root meta. Source values only — display
+      // formatting happens at render time.
+      const rawNValid = (optionOutcome as { n_valid_samples?: number }).n_valid_samples
+      const rawNTotal = (optionOutcome as { n_samples?: number }).n_samples
+      const nValidSamples =
+        typeof rawNValid === 'number' && Number.isFinite(rawNValid) && rawNValid > 0
+          ? rawNValid
+          : typeof rawNTotal === 'number' && Number.isFinite(rawNTotal) && rawNTotal > 0
+            ? rawNTotal
+            : typeof rawMetaNSamples === 'number' && Number.isFinite(rawMetaNSamples) && rawMetaNSamples > 0
+              ? rawMetaNSamples
+              : undefined
+
       return {
         id: nodeId,
         label: (node.data as ResultsCanvasNodeData)?.label || nodeId,
@@ -1163,6 +1187,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         p90: scaledP90,
         isRecommended: false, // Will be set immutably below
         winProbability: prob.win_probability,
+        nValidSamples,
         goalProbability,
         // Multi-constraint analysis (from ISL when goal_constraints were provided)
         constraintAnalysis: prob.constraint_analysis,
@@ -1333,6 +1358,31 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       nearTie,
       // Task 6: Flip thresholds for tipping points visualisation
       flipThresholds: flipThresholds.length > 0 ? flipThresholds : undefined,
+      // Display-honesty: PLoT-side classification of flip_thresholds[].
+      // Optional — older PLoT builds omit it, in which case downstream UX
+      // behaves exactly as before (silent absence).
+      flipThresholdsStatus: (rawFlipThresholdsStatus as
+        | 'computed'
+        | 'all_no_effect'
+        | 'partial_no_effect'
+        | 'unresolved'
+        | 'unavailable'
+        | null) ?? undefined,
+      /**
+       * UI-SEM-050: Leading-option downside flag.
+       *
+       * Deterministic display gate: true when the recommended option's
+       * lower-percentile outcome (p10) is below zero, signalling meaningful
+       * downside risk that should qualify an otherwise-positive lead.
+       * Display-only — does not affect ranking, scoring, or any forwarded
+       * value. Undefined when p10 is unavailable.
+       *
+       * Classification: legitimate display formatting (additive qualifier).
+       */
+      leadingOptionDownsideFlag:
+        recommendedOption?.outcome?.p10 != null && Number.isFinite(recommendedOption.outcome.p10)
+          ? recommendedOption.outcome.p10 < 0
+          : undefined,
       // v7: Whether outcome values are normalised model scores (no goalThresholdCap)
       isNormalised: isNormalisedResult,
       // M1 Coaching fields (Task 2) — sanitized at data layer
@@ -1412,7 +1462,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         return hasWarningCritiques || hasFragileEdges
       })(),
     }
-  }, [hasCompletedFirstRun, report, nodes, goalLabel, goalNodeId, outcomeUnit, outcomeUnitSymbol, currentScenarioFraming, m1Coaching, nodeLabelMap, goalThreshold, goalThresholdCap, effectiveGoalThreshold, ceeAnalysisReady, m1ReviewAssumptions, rawV2FlipThresholds])
+  }, [hasCompletedFirstRun, report, nodes, goalLabel, goalNodeId, outcomeUnit, outcomeUnitSymbol, currentScenarioFraming, m1Coaching, nodeLabelMap, goalThreshold, goalThresholdCap, effectiveGoalThreshold, ceeAnalysisReady, m1ReviewAssumptions, rawV2FlipThresholds, rawFlipThresholdsStatus, rawMetaNSamples])
 
   // ==========================================================================
   // Drivers Section Data (with dynamic normalisation)

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1360,14 +1360,19 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       flipThresholds: flipThresholds.length > 0 ? flipThresholds : undefined,
       // Display-honesty: PLoT-side classification of flip_thresholds[].
       // Optional — older PLoT builds omit it, in which case downstream UX
-      // behaves exactly as before (silent absence).
-      flipThresholdsStatus: (rawFlipThresholdsStatus as
+      // behaves exactly as before (silent absence). Fallback chain mirrors
+      // the flip_thresholds defensive adaptor above: read raw first (fresh
+      // runs), then the mapped report (saved / hydrated results) so the
+      // new UX survives a hydrate cycle through responseMapper.
+      flipThresholdsStatus: (rawFlipThresholdsStatus
+        ?? (report as { flip_thresholds_status?: string } | null | undefined)?.flip_thresholds_status
+        ?? undefined) as
         | 'computed'
         | 'all_no_effect'
         | 'partial_no_effect'
         | 'unresolved'
         | 'unavailable'
-        | null) ?? undefined,
+        | undefined,
       /**
        * UI-SEM-050: Leading-option downside flag.
        *

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -908,7 +908,15 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       ceeAnalysisReady: s.ceeAnalysisReady,
       // Extract only flip_thresholds from raw V2 response to avoid subscribing to entire object.
       // Used as fallback in flip_thresholds defensive adaptor when mapped report doesn't carry them.
-      rawV2FlipThresholds: s.rawV2Response?.robustness?.flip_thresholds ?? (s.rawV2Response as Record<string, unknown> | null)?.flip_thresholds ?? null,
+      // Display-honesty: PLoT v2/run emits flip_thresholds at the top level
+      // (see plot-lite-service routes/v2/run.ts:2010); legacy responses
+      // nested it under robustness. Prefer top-level so fresh-run and
+      // hydrated-via-mapper precedence agree (the mapper also prefers
+      // top-level — see responseMapper.ts display-honesty block).
+      rawV2FlipThresholds:
+        (s.rawV2Response as { flip_thresholds?: unknown } | null | undefined)?.flip_thresholds
+        ?? s.rawV2Response?.robustness?.flip_thresholds
+        ?? null,
       // Audit B3: extract only auto_noise_provenance to avoid subscribing
       // to the whole rawV2Response. Typed via V2RunResponse since PLoT
       // commit 562e461; normalised at the trust boundary below.

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -891,6 +891,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     rawV2FlipThresholds,
     rawAutoNoiseProvenance,
     rawFlipThresholdsStatus,
+    rawFlipThresholdsStatusReason,
     rawMetaNSamples,
   } = useCanvasStore(
     useShallow((s) => ({
@@ -916,6 +917,12 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // (companion to PR claude-plot/display-honesty). Optional — older
       // PLoT builds omit the field, in which case we leave UX unchanged.
       rawFlipThresholdsStatus: (s.rawV2Response as { flip_thresholds_status?: string } | null | undefined)?.flip_thresholds_status ?? null,
+      // Display-honesty: PLoT-supplied reason string from the same field.
+      // Drives copy variation on 'partial_no_effect' when unresolved
+      // entries are present (mixed computed + no_effect + unresolved),
+      // so UI can avoid wording that implies all non-computed factors
+      // were harmless no-effect cases.
+      rawFlipThresholdsStatusReason: (s.rawV2Response as { flip_thresholds_status_reason?: string } | null | undefined)?.flip_thresholds_status_reason ?? null,
       // Display-honesty: root meta.n_samples used as fallback resolution
       // source when an option lacks per-option n_valid_samples.
       rawMetaNSamples: s.rawV2Response?.meta?.n_samples ?? null,
@@ -1373,6 +1380,13 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         | 'unresolved'
         | 'unavailable'
         | undefined,
+      // Display-honesty: presence of the reason field (raw or mapped)
+      // signals that unresolved entries are mixed in. Exposed as a
+      // boolean so the UI never needs to inspect the raw string.
+      flipThresholdsHasUnresolved: Boolean(
+        rawFlipThresholdsStatusReason
+          ?? (report as { flip_thresholds_status_reason?: string } | null | undefined)?.flip_thresholds_status_reason,
+      ),
       /**
        * UI-SEM-050: Leading-option downside flag.
        *
@@ -1467,7 +1481,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         return hasWarningCritiques || hasFragileEdges
       })(),
     }
-  }, [hasCompletedFirstRun, report, nodes, goalLabel, goalNodeId, outcomeUnit, outcomeUnitSymbol, currentScenarioFraming, m1Coaching, nodeLabelMap, goalThreshold, goalThresholdCap, effectiveGoalThreshold, ceeAnalysisReady, m1ReviewAssumptions, rawV2FlipThresholds, rawFlipThresholdsStatus, rawMetaNSamples])
+  }, [hasCompletedFirstRun, report, nodes, goalLabel, goalNodeId, outcomeUnit, outcomeUnitSymbol, currentScenarioFraming, m1Coaching, nodeLabelMap, goalThreshold, goalThresholdCap, effectiveGoalThreshold, ceeAnalysisReady, m1ReviewAssumptions, rawV2FlipThresholds, rawFlipThresholdsStatus, rawFlipThresholdsStatusReason, rawMetaNSamples])
 
   // ==========================================================================
   // Drivers Section Data (with dynamic normalisation)

--- a/src/utils/__tests__/formatProbabilityWithResolution.spec.ts
+++ b/src/utils/__tests__/formatProbabilityWithResolution.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatProbabilityWithResolution,
+  isAboveSimulationResolution,
+  isBelowSimulationResolution,
+} from '../formatPercent'
+
+/**
+ * Display-honesty workstream — sample-resolution display formatter.
+ *
+ * Raw probability values are preserved by the caller; only the displayed
+ * string changes. These tests pin the boundary cases (exact 0, exact 1,
+ * threshold scaling with N) and the legacy fallback when no sample count
+ * is available.
+ */
+describe('formatProbabilityWithResolution', () => {
+  describe('boundary cases at n=1000', () => {
+    it('renders exact 0 as <0.1%, never as 0%', () => {
+      expect(formatProbabilityWithResolution(0, 1000)).toBe('<0.1%')
+    })
+
+    it('renders exact 1 as >99.9%, never as 100%', () => {
+      expect(formatProbabilityWithResolution(1, 1000)).toBe('>99.9%')
+    })
+
+    it('renders a small non-zero value below the threshold as <0.1%', () => {
+      expect(formatProbabilityWithResolution(0.0005, 1000)).toBe('<0.1%')
+    })
+
+    it('renders a value at the threshold as a normal percent (1/1000 = 0.1% boundary)', () => {
+      // 0.001 is NOT strictly < threshold; falls through to normal formatting
+      expect(formatProbabilityWithResolution(0.001, 1000)).toBe('0%')
+    })
+
+    it('renders a typical mid-range probability normally', () => {
+      expect(formatProbabilityWithResolution(0.58, 1000)).toBe('58%')
+    })
+  })
+
+  describe('threshold scales with sample count', () => {
+    it('renders <0.01% at n=10000 for exact 0', () => {
+      expect(formatProbabilityWithResolution(0, 10000)).toBe('<0.01%')
+    })
+
+    it('renders >99.99% at n=10000 for exact 1', () => {
+      expect(formatProbabilityWithResolution(1, 10000)).toBe('>99.99%')
+    })
+
+    it('renders <1% at n=100 for exact 0', () => {
+      expect(formatProbabilityWithResolution(0, 100)).toBe('<1%')
+    })
+
+    it('renders >99% at n=100 for exact 1', () => {
+      expect(formatProbabilityWithResolution(1, 100)).toBe('>99%')
+    })
+  })
+
+  describe('legacy fallback when sample count is unavailable', () => {
+    it('falls back to normal percent formatting when nSamples is undefined', () => {
+      expect(formatProbabilityWithResolution(0.42, undefined)).toBe('42%')
+    })
+
+    it('falls back when nSamples is null', () => {
+      expect(formatProbabilityWithResolution(0.42, null)).toBe('42%')
+    })
+
+    it('falls back when nSamples is zero (treats as unavailable, never divides by zero)', () => {
+      expect(formatProbabilityWithResolution(0.42, 0)).toBe('42%')
+    })
+
+    it('falls back when nSamples is negative (treats as unavailable)', () => {
+      expect(formatProbabilityWithResolution(0.42, -100)).toBe('42%')
+    })
+
+    it('preserves the prior 0%/100% rendering when no sample count is supplied — backward-compatible at boundaries', () => {
+      // Without resolution context, exact 0 still renders as 0% (legacy formatPct).
+      // The resolution-aware behaviour only kicks in when nSamples is provided.
+      expect(formatProbabilityWithResolution(0, undefined)).toBe('0%')
+      expect(formatProbabilityWithResolution(1, undefined)).toBe('100%')
+    })
+  })
+})
+
+describe('isBelowSimulationResolution', () => {
+  it('is true for exact 0 at n=1000', () => {
+    expect(isBelowSimulationResolution(0, 1000)).toBe(true)
+  })
+
+  it('is false for typical mid-range values', () => {
+    expect(isBelowSimulationResolution(0.5, 1000)).toBe(false)
+  })
+
+  it('is false at the boundary value 1/n', () => {
+    expect(isBelowSimulationResolution(0.001, 1000)).toBe(false)
+  })
+
+  it('is false when nSamples is unavailable, even for exact 0', () => {
+    expect(isBelowSimulationResolution(0, undefined)).toBe(false)
+    expect(isBelowSimulationResolution(0, null)).toBe(false)
+    expect(isBelowSimulationResolution(0, 0)).toBe(false)
+  })
+})
+
+describe('isAboveSimulationResolution', () => {
+  it('is true for exact 1 at n=1000', () => {
+    expect(isAboveSimulationResolution(1, 1000)).toBe(true)
+  })
+
+  it('is false for typical mid-range values', () => {
+    expect(isAboveSimulationResolution(0.5, 1000)).toBe(false)
+  })
+
+  it('is false at the boundary value 1 - 1/n', () => {
+    expect(isAboveSimulationResolution(0.999, 1000)).toBe(false)
+  })
+
+  it('is false when nSamples is unavailable, even for exact 1', () => {
+    expect(isAboveSimulationResolution(1, undefined)).toBe(false)
+  })
+})

--- a/src/utils/__tests__/formatProbabilityWithResolution.spec.ts
+++ b/src/utils/__tests__/formatProbabilityWithResolution.spec.ts
@@ -27,12 +27,18 @@ describe('formatProbabilityWithResolution', () => {
       expect(formatProbabilityWithResolution(0.0005, 1000)).toBe('<0.1%')
     })
 
-    it('renders a value at the threshold as a normal percent (1/1000 = 0.1% boundary)', () => {
-      // 0.001 is NOT strictly < threshold; falls through to normal formatting
-      expect(formatProbabilityWithResolution(0.001, 1000)).toBe('0%')
+    it('renders one observed win in 1000 as 0.1%, never as 0%', () => {
+      // 0.001 = 1/1000: a SINGLE observed win must not collapse to "0%",
+      // which would be visually identical to "below resolution".
+      expect(formatProbabilityWithResolution(0.001, 1000)).toBe('0.1%')
     })
 
-    it('renders a typical mid-range probability normally', () => {
+    it('renders 999 wins in 1000 as 99.9%, never as 100%', () => {
+      // Symmetric guard at the upper boundary.
+      expect(formatProbabilityWithResolution(0.999, 1000)).toBe('99.9%')
+    })
+
+    it('renders a typical mid-range probability normally (no spurious decimals)', () => {
       expect(formatProbabilityWithResolution(0.58, 1000)).toBe('58%')
     })
   })

--- a/src/utils/formatPercent.ts
+++ b/src/utils/formatPercent.ts
@@ -20,3 +20,87 @@ export function formatPercent(
   if (sign && pct > 0) return `+${rounded}%`
   return `${rounded}%`
 }
+
+/**
+ * Display-honesty: format a Monte Carlo win probability as a percentage,
+ * acknowledging the simulation-resolution floor / ceiling rather than
+ * rounding silently to "0%" or "100%".
+ *
+ * Threshold derives from sample count:
+ *   value < 1/n         -> "<{1/n as percent}", e.g. "<0.1%" at n=1000
+ *   value > 1 - 1/n     -> ">{1 - 1/n as percent}", e.g. ">99.9%" at n=1000
+ *   otherwise           -> normal percent rendering
+ *
+ * When `nSamples` is undefined or non-positive, falls back to legacy
+ * percentage formatting (via formatPercent) so existing call sites that
+ * cannot supply a sample count continue to work unchanged.
+ *
+ * Always operates on the raw decimal probability — the displayed string
+ * changes, the source numeric value does not.
+ *
+ * @param value - Raw probability in [0, 1]
+ * @param nSamples - Per-option n_valid_samples, or fallback n_samples / meta.n_samples
+ */
+export function formatProbabilityWithResolution(
+  value: number,
+  nSamples: number | null | undefined,
+): string {
+  if (nSamples === null || nSamples === undefined || !Number.isFinite(nSamples) || nSamples <= 0) {
+    return formatPercent(value, { fromDecimal: true })
+  }
+
+  const threshold = 1 / nSamples
+  if (value < threshold) {
+    return `<${thresholdAsPercent(threshold)}`
+  }
+  if (value > 1 - threshold) {
+    return `>${thresholdAsPercent(1 - threshold)}`
+  }
+  return formatPercent(value, { fromDecimal: true })
+}
+
+/**
+ * Format a sample-count-derived threshold (in [0, 1]) as a percent string.
+ * Picks the smallest decimal precision that renders the value distinctly
+ * from 0% / 100% — e.g. 0.01 -> "1%", 0.001 -> "0.1%", 0.0001 -> "0.01%",
+ * 0.999 -> "99.9%".
+ */
+function thresholdAsPercent(threshold: number): string {
+  const pct = threshold * 100
+  for (let precision = 0; precision <= 6; precision++) {
+    const rendered = pct.toFixed(precision)
+    if (Number(rendered) !== 0 && Number(rendered) !== 100) {
+      return `${rendered}%`
+    }
+  }
+  return `${pct.toFixed(6)}%`
+}
+
+/**
+ * Whether the given value should be reported as below the simulation
+ * resolution at the given sample count. Used to gate user-facing helper
+ * copy explaining why "<X%" appears.
+ */
+export function isBelowSimulationResolution(
+  value: number,
+  nSamples: number | null | undefined,
+): boolean {
+  if (nSamples === null || nSamples === undefined || !Number.isFinite(nSamples) || nSamples <= 0) {
+    return false
+  }
+  return value < 1 / nSamples
+}
+
+/**
+ * Whether the given value should be reported as above the simulation
+ * resolution at the given sample count.
+ */
+export function isAboveSimulationResolution(
+  value: number,
+  nSamples: number | null | undefined,
+): boolean {
+  if (nSamples === null || nSamples === undefined || !Number.isFinite(nSamples) || nSamples <= 0) {
+    return false
+  }
+  return value > 1 - 1 / nSamples
+}

--- a/src/utils/formatPercent.ts
+++ b/src/utils/formatPercent.ts
@@ -29,7 +29,10 @@ export function formatPercent(
  * Threshold derives from sample count:
  *   value < 1/n         -> "<{1/n as percent}", e.g. "<0.1%" at n=1000
  *   value > 1 - 1/n     -> ">{1 - 1/n as percent}", e.g. ">99.9%" at n=1000
- *   otherwise           -> normal percent rendering
+ *   otherwise           -> percent rendering with enough decimals to keep
+ *                          the value distinct from 0% / 100% (so one win
+ *                          in 1000 renders as "0.1%", not "0%", and 999
+ *                          wins in 1000 as "99.9%", not "100%")
  *
  * When `nSamples` is undefined or non-positive, falls back to legacy
  * percentage formatting (via formatPercent) so existing call sites that
@@ -56,7 +59,26 @@ export function formatProbabilityWithResolution(
   if (value > 1 - threshold) {
     return `>${thresholdAsPercent(1 - threshold)}`
   }
-  return formatPercent(value, { fromDecimal: true })
+  // Mid-range. Use integer precision when possible; bump precision when an
+  // integer render would falsely collapse to 0% / 100% (e.g. one observed
+  // win in 1000 -> 0.1%, not 0%; 999 wins in 1000 -> 99.9%, not 100%).
+  return inRangeAsPercent(value)
+}
+
+/**
+ * Format an in-range probability so the displayed value never falsely
+ * implies absolute certainty. Picks the smallest decimal precision that
+ * keeps the rendered value distinctly non-zero AND non-100.
+ */
+function inRangeAsPercent(value: number): string {
+  const pct = value * 100
+  for (let precision = 0; precision <= 6; precision++) {
+    const rendered = pct.toFixed(precision)
+    if (Number(rendered) !== 0 && Number(rendered) !== 100) {
+      return `${rendered}%`
+    }
+  }
+  return `${pct.toFixed(6)}%`
 }
 
 /**


### PR DESCRIPTION
## Summary

Display-honesty workstream — DGAI side. Three additive Results-panel signals consuming data PLoT already emits per option (or in companion PR [Talchain/plot-lite-service#167](https://github.com/Talchain/plot-lite-service/pull/167) for B). Raw analysis values, ranking, and bar widths use unchanged source numbers — only displayed strings change.

### A. Sample-resolution display

Stops Monte Carlo win probabilities at the simulation-resolution floor / ceiling instead of rendering as literal `0%` / `100%`. Threshold derives from the per-option `outcome.n_valid_samples` (with fallbacks `outcome.n_samples` then `meta.n_samples`), so it scales with the run.

| Input | Display |
|---|---|
| `win_probability = 0`, `n_valid_samples = 1000` | `<0.1%` |
| `win_probability = 1`, `n_valid_samples = 1000` | `>99.9%` |
| `win_probability = 0`, `n_valid_samples = 10000` | `<0.01%` |
| `win_probability = 0.58`, `n_valid_samples = 1000` | `58%` |
| no `n_valid_samples` available | legacy `formatPct` (backward-compatible) |

Tooltip / title strings on the OptionCards win-pct chip explain the floor / ceiling cases without exposing internal terms (no \"Monte Carlo\", no \"n_samples\").

**Ownership decision (verified against actual wire fields):** PLoT already passes through `outcome.n_samples` / `n_valid_samples` / `validity_ratio` per option from ISL — see [plot-lite-service src/routes/v2/run.ts:1523-1534](https://github.com/Talchain/plot-lite-service/blob/staging/src/routes/v2/run.ts#L1523). DGAI just needed to extend its `V2Outcome` type and surface the field through the selector. **DGAI-only — no PLoT change required for A.**

### B. Flip-threshold all-no-effect handling

Consumes the new `flip_thresholds_status` field from PLoT (companion PR [#167](https://github.com/Talchain/plot-lite-service/pull/167)). Field is **optional** — older PLoT builds omit it and UX behaves exactly as before.

| Status | UX |
|---|---|
| `'all_no_effect'` | Single short note above the tornado chart: *\"No single tested factor changed the leading option within the current range.\"* |
| `'partial_no_effect'` | Short note + tornado chart with markers: *\"Some factors did not change the leading option within the current range.\"* |
| `'computed'` / `'unresolved'` / `'unavailable'` / absent | Nothing extra |

Note has `role=\"note\"` for accessibility. No new colour or component.

### C. High-variance leading-option qualification — UI-SEM-050

Deterministic display gate: when the leading option's `outcome.p10 < 0`, the leader card renders one qualifying sentence:

> *\"This option currently leads, but the lower range of simulated outcomes includes meaningful downside.\"*

Brief explicitly named the wider `(p90-p10) > 2 * winning_margin` trigger as ambiguous; this PR ships only the conservative p10 case and reports the wider trigger as a follow-up. No scoring change. Documented as `UI-SEM-050` alongside the existing semantic-transform inventory.

## Files changed

| File | Lines | Note |
|---|---|---|
| `src/utils/formatPercent.ts` | +84 | New `formatProbabilityWithResolution` + helpers |
| `src/adapters/plot/v2/types.ts` | +29 | V2Outcome n_samples/n_valid_samples/validity_ratio + V2RunResponse flip_thresholds_status |
| `src/components/results/types.ts` | +24 | OptionResult.nValidSamples + DecisionResultData.flipThresholdsStatus / leadingOptionDownsideFlag |
| `src/components/results/useResultsSectionData.ts` | +52 / -1 | Surface fields through the selector |
| `src/components/results/OptionCards.tsx` | +49 / -4 | Resolution-aware formatter at render; downside qualifier in leader card |
| `src/components/results/ResultsBody.tsx` | +24 | Soft note above the tornado chart for B |
| `src/utils/__tests__/formatProbabilityWithResolution.spec.ts` | new | 22 tests |
| `src/components/results/__tests__/OptionCards.displayHonesty.spec.tsx` | new | 10 tests (A + C) |
| `src/components/results/__tests__/ResultsBody.flipThresholdsStatus.spec.tsx` | new | 6 tests (B) |

**Banned-wording check:** the new copy avoids \"winner\" / \"winning\" / \"recommended\" / \"recommendation\" / \"Monte Carlo\" / \"no_effect\" — only \"leading option\" appears. Pinned by tests.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` on the three new specs — 38/38 pass
- [x] `npx vitest run --changed --bail=1` — only 1 unrelated failure (`useConversation.hook.spec.ts` — confirmed failing on the staging baseline before any of these changes)
- [x] `bash scripts/validate-prepush.sh` — **ALL CHECKS PASSED** (459 smoke tests pass, typecheck pass, lint pass, no stale .js, no `file:` deps)
- [ ] CI staging-full-tests — pending

## Risk / regression check

- **Bar widths still use raw `winProbability`** ([OptionCards.tsx:392](src/components/results/OptionCards.tsx)). Sorting in [useResultsSectionData.ts:90](src/components/results/useResultsSectionData.ts) and [OptionCards.tsx:544](src/components/results/OptionCards.tsx) still uses raw numeric `winProbability`. The sample-resolution clamp affects only the displayed string.
- The existing 99% cap in [src/lib/format.ts:61](src/lib/format.ts) (UI-SEM-008) is **untouched** — it's a different code path used by `formatOutcomeValue`, not by the win-probability rendering, which goes through `formatPercent`.
- All new fields on the V2Outcome / V2RunResponse / DecisionResultData / OptionResult types are **optional** — older PLoT builds shipping without the new fields render exactly as before (verified by the \"absent\" test cases in each new spec).
- B3 `auto_noise_provenance` disclosure path, EVPI rendering, evidence_gaps, factor sensitivity, and Results ranking selectors are all untouched.

## Display-honesty workstream context

Companion to PLoT PR [Talchain/plot-lite-service#167](https://github.com/Talchain/plot-lite-service/pull/167) (`claude-plot/display-honesty`) which adds the `flip_thresholds_status` classifier on the `v2/run` response. DGAI side here is read-only consumer of that field (graceful absent-fallback) plus DGAI-only formatting for A and C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)