### PR TITLE
fix(v5): tolerate v1.3 Phase 3 block types inside blocks[]; honest v5_cee_capture; sidecar survives redactor

### DIFF
--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -200,9 +200,12 @@ export interface ResultsState {
  * current scenario?". Generic `ceeAnalysisReady` readiness MUST NOT be used
  * as a substitute.
  *
- * Phase 3 blocks (coaching / review_card / evidence) are preserved verbatim
- * in `rawBlocks` so consumers can read freshness, action_intent,
- * priority_rank, target_refs, and graph_hash_at_generation directly.
+ * Phase 3 blocks (coaching / review_card / evidence / exercise) are
+ * preserved verbatim in `rawBlocks` so consumers can read freshness,
+ * action_intent, priority_rank, target_refs, and graph_hash_at_generation
+ * directly. The `source` discriminator tracks where the parser harvested
+ * each block (sidecar / analysis_ready / enrichment / blocks[] via the
+ * Phase 3 tolerance shim).
  */
 export interface V5AnalysisFactState {
   /** The scenarioId this fact attaches to. Cleared when scenario changes. */
@@ -217,10 +220,10 @@ export interface V5AnalysisFactState {
   freshnessReason: string | null
   /** Raw Phase 3 blocks preserved verbatim — no field flattening. */
   rawBlocks: Array<{
-    type: 'coaching' | 'review_card' | 'evidence'
+    type: 'coaching' | 'review_card' | 'evidence' | 'exercise'
     raw: Record<string, unknown>
     id: string
-    source: 'sidecar' | 'analysis_ready' | 'enrichment'
+    source: 'sidecar' | 'analysis_ready' | 'enrichment' | 'sidecar_blocks_array'
   }>
   /** When this slice was written (ms since epoch). Diagnostics only. */
   writtenAt: number

--- a/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
+++ b/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
@@ -1,0 +1,462 @@
+// @vitest-environment jsdom
+/**
+ * v5_cee_capture diagnostic — Phase 3 blocks-array tolerance.
+ *
+ * This is the debug-bundle counterpart to
+ *   src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
+ * The bundle assertions live here (not in v5/__tests__) because
+ * tsconfig.ci.json `include` is a small set of files plus the src/v5/
+ * tree — pulling buildDebugBundleAsync / DebugData into the v5 graph
+ * would surface latent type errors in untouched debug modules and break
+ * CI. Debug __tests__ already live outside the ci typecheck graph (the
+ * existing exportBundle specs use the same imports).
+ *
+ * Acceptance points covered:
+ *   - Parse-error envelope flows into v5_cee_capture with parse_ok:false
+ *     and the offending unknown block types enumerated.
+ *   - End-to-end callV5Turn → recordResponsePayload → redactor → bundle
+ *     preserves the Phase 3 sidecar through the trace store's
+ *     Object.keys-based redactor.
+ *   - Success-path emits honest diagnostics:
+ *       - raw_response_present:false (the trace stores a parsed clone,
+ *         not the literal wire JSON).
+ *       - response_top_level_keys reflects the ORIGINAL CEE root keys
+ *         (via the parser's sidecar metadata), not the parsed-clone keys.
+ *       - has_additive_extensions:true only when CEE emitted top-level
+ *         additive fields. Phase-3-only responses (with the metadata
+ *         sidecar carrying ONLY phase3 blocks + original-key list) MUST
+ *         report has_additive_extensions:false.
+ *       - phase3_blocks_tolerated_count and phase3_block_types name the
+ *         Phase 3 blocks the parser tolerated out of `blocks[]`.
+ */
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const { mockIsV5CanonicalAnalysisEnabled } = vi.hoisted(() => ({
+  mockIsV5CanonicalAnalysisEnabled: vi.fn(() => true),
+}))
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isV5CanonicalAnalysisEnabled: mockIsV5CanonicalAnalysisEnabled,
+  }
+})
+
+import { parseV5Response } from '../../../v5/responseParser'
+import { useCanvasStore } from '../../../canvas/store'
+import type { V5AnalysisFactState } from '../../../canvas/store'
+import { callV5Turn } from '../../../v5/v5Adapter'
+import { usePayloadTraceStore } from '../../../lib/payload-trace-store'
+import { buildDebugBundleAsync } from '../utils/exportBundle'
+import type { DebugData } from '../hooks/useDebugData'
+
+// ── Test fixtures ─────────────────────────────────────────────────────
+
+/** Same shape as the v5 spec's ceeFixture — kept here so the two specs
+ *  can evolve independently. Includes top-level additive freshness keys
+ *  AND Phase 3 blocks inside blocks[]. */
+function ceeFixture(): Record<string, unknown> {
+  const graphHash = 'graph-h-1'
+  const createdAt = '2026-05-18T10:00:00.000+01:00'
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [
+      {
+        type: 'analysis_result',
+        summary: 'Option A leads.',
+        leading_option_id: 'opt-a',
+        win_probabilities: { 'opt-a': 0.72, 'opt-b': 0.23, 'opt-c': 0.05 },
+      },
+      {
+        type: 'review_card',
+        block_id: 'rc-narrative-1',
+        signal_id: 'review:narrative:opt-a',
+        created_at: createdAt,
+        source_handler: 'decision_review',
+        graph_hash_at_generation: graphHash,
+        freshness: 'fresh',
+        card_kind: 'narrative',
+        title: 'Decision review',
+      },
+      {
+        type: 'coaching',
+        block_id: 'coach-strengthen-1',
+        signal_id: 'coaching:strengthen:node-A',
+        created_at: createdAt,
+        source_handler: 'run_analysis',
+        graph_hash_at_generation: graphHash,
+        freshness: 'fresh',
+        coaching_kind: 'strengthen',
+        title: 'Strengthen evidence for Factor A',
+        action_intent: 'gather_evidence',
+        priority_rank: 1,
+      },
+    ],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+    analysis_freshness: 'fresh',
+    has_run_analysis_fact: true,
+    freshness_reason: 'just_minted',
+  }
+}
+
+/** Phase 3 blocks present in blocks[] but NO top-level additive fields. */
+function phase3OnlyFixture(): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [
+      { type: 'analysis_result', summary: 'leads', leading_option_id: 'opt-a' },
+      {
+        type: 'review_card',
+        block_id: 'rc-1',
+        signal_id: 'rc:1',
+        card_kind: 'narrative',
+      },
+      {
+        type: 'coaching',
+        block_id: 'co-1',
+        signal_id: 'co:1',
+        coaching_kind: 'strengthen',
+        title: 'Strengthen',
+      },
+    ],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+  }
+}
+
+function makeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function makeDebugData(overrides: Partial<DebugData> = {}): DebugData {
+  return {
+    overall: { status: 'success', total_duration_ms: 100, request_id: 'req-test-1' },
+    services: { cee: null, plot: null, isl: null },
+    error: null,
+    builds: { ui: 'test', cee: null, plot: null, isl: null },
+    diagnostics: {
+      plot_has_downstream_calls: false,
+      downstream_calls_path_found: null,
+      downstream_calls_paths_checked: [],
+      isl_data_source: 'none',
+      cee_trace_present: false,
+      cee_degraded: false,
+      llm_raw_available: false,
+      llm_raw_path_found: null,
+      e_values_present: false,
+      isl_edge_e_values_present: false,
+      plot_edge_e_values_exposed: false,
+      ui_edge_e_values_available: false,
+      evpi_present: false,
+      confidence_differentiated: false,
+      confidence_unique_values: [],
+      factor_confidence_differentiated: false,
+      factor_confidence_unique_values: [],
+      confidence_source_bootstrap: false,
+      intercept_populated: false,
+      epsilon_std_present: false,
+      response_hash_present: false,
+      mca_computed: false,
+    },
+    ceeTrace: null,
+    corrections: [],
+    correctionsSummary: null,
+    pipeline: {
+      status: 'success',
+      total_duration_ms: 100,
+      stages: [],
+      connectivity: { decision_count: 0, option_count: 0, goal_count: 0, factor_count: 0, edge_count: 0 },
+    },
+    payloads: {
+      cee_request: null,
+      cee_response: null,
+      plot_request: null,
+      plot_response: null,
+      isl_request: null,
+      isl_response: null,
+    },
+    gates: [],
+    validation: { summary: { errors: 0, warnings: 0, info: 0 }, issues: [] },
+    winningOption: null,
+    robustness: { status: 'unavailable', stability: null, context_label: 'N/A', description: '' },
+    hasData: true,
+    orchestrator: null,
+    v12_4_checks: null,
+    request_id_chain: null,
+    feature_flags_at_request: null,
+    timing: null,
+    schema_versions: null,
+    cee_observability: null,
+    m1_coaching: null,
+    m2_review: null,
+    cee_downstream: null,
+    cee_operations: null,
+    diagnostic_trace: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
+  useCanvasStore.setState({
+    results: { status: 'idle' },
+    currentScenarioId: 'scenario-A',
+    v5AnalysisFact: null,
+  } as any)
+})
+
+describe('v5_cee_capture — parse-failure path', () => {
+  it('(10) parse-error envelope flows into v5_cee_capture with parse_ok=false + enumerated types', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({ type: 'totally_unknown_future_type' })
+    const parsed = await parseV5Response(makeResponse(fixture))
+    expect(parsed.kind).toBe('parse_error')
+
+    const data = makeDebugData({
+      payloads: {
+        cee_request: { kind: 'message', message: 'run' },
+        cee_response: parsed as unknown as Record<string, unknown>,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    expect(bundle.v5_canonical_analysis).toBeDefined()
+    const diag = bundle.v5_canonical_analysis!
+    expect(diag.v5_cee_capture).not.toBeNull()
+    const capture = diag.v5_cee_capture!
+
+    expect(capture.parse_ok).toBe(false)
+    expect(capture.response_present).toBe(true)
+    expect(capture.raw_response_present).toBe(true)
+    expect(capture.parse_failure_kind).toBe('unknown_block_types')
+    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
+    expect(capture.parse_error ?? '').toContain('totally_unknown_future_type')
+    expect(capture.response_top_level_keys).toEqual(
+      expect.arrayContaining(['response_version', 'assistant_text', 'blocks']),
+    )
+    expect(diag.debug_capture_status).toBe('parse_failed')
+  })
+})
+
+describe('v5_cee_capture — end-to-end through redactor', () => {
+  it('callV5Turn → trace-store redactor → bundle preserves Phase 3 fields', async () => {
+    // P1 regression — the parser stashes Phase 3 blocks on a
+    // NON-ENUMERABLE sidecar so they don't leak into JSON.stringify. The
+    // trace store's redactor uses Object.keys (skips non-enumerable), so
+    // a literal "store the parsed response" would lose the sidecar before
+    // the bundle reads it. v5Adapter promotes the sidecar to an
+    // enumerable property on a shallow clone for the trace body — this
+    // test proves the clone survives the redactor and the bundle still
+    // populates phase3_blocks_tolerated_count + phase3_block_types.
+
+    usePayloadTraceStore.setState({ payloads: [], selectedId: null } as any)
+
+    const fixture = ceeFixture()
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const result = await callV5Turn(
+      { kind: 'message', message: 'run analysis' } as never,
+      { fetchImpl },
+    )
+    expect(result.kind).toBe('response')
+
+    const traced = usePayloadTraceStore.getState().payloads
+    expect(traced).toHaveLength(1)
+    const tracedBody = traced[0].response?.body as Record<string, unknown>
+
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        report: { schema: 'report.v1' } as any,
+        hash: 'hash-e2e',
+      },
+      currentScenarioId: 'scenario-A',
+      v5AnalysisFact: {
+        scenarioId: 'scenario-A',
+        analysisHash: 'hash-e2e',
+        hasRunAnalysisFact: true,
+        freshness: 'fresh',
+        freshnessReason: null,
+        rawBlocks: [],
+        writtenAt: Date.now(),
+      } satisfies V5AnalysisFactState,
+    } as any)
+
+    const data = makeDebugData({
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 200,
+          success: true,
+          duration_ms: 312,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
+      payloads: {
+        cee_request: traced[0].request?.body as Record<string, unknown> | null,
+        cee_response: tracedBody,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
+    expect(capture.parse_ok).toBe(true)
+    expect(capture.phase3_blocks_tolerated_count).toBe(2)
+    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
+    expect(capture.raw_response_present).toBe(false)
+    expect(capture.response_top_level_keys).not.toContain('__additive__')
+    expect(capture.response_top_level_keys).toEqual(
+      expect.arrayContaining([
+        'analysis_freshness',
+        'has_run_analysis_fact',
+        'freshness_reason',
+      ]),
+    )
+    // Fixture emits top-level additive fields, so has_additive_extensions
+    // must be true here. The next test pins the OPPOSITE case (Phase 3
+    // blocks present, no top-level additives → false).
+    expect(capture.has_additive_extensions).toBe(true)
+  })
+})
+
+describe('v5_cee_capture — success path honest semantics', () => {
+  it('parse-success envelope populates v5_cee_capture with phase3 counts + honest raw flags', async () => {
+    const parsed = await parseV5Response(makeResponse(ceeFixture()))
+    expect(parsed.kind).toBe('response')
+    if (parsed.kind !== 'response') throw new Error('unreachable')
+
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        report: { schema: 'report.v1' } as any,
+        hash: 'hash-success',
+      },
+      currentScenarioId: 'scenario-A',
+      v5AnalysisFact: {
+        scenarioId: 'scenario-A',
+        analysisHash: 'hash-success',
+        hasRunAnalysisFact: true,
+        freshness: 'fresh',
+        freshnessReason: null,
+        rawBlocks: [],
+        writtenAt: Date.now(),
+      } satisfies V5AnalysisFactState,
+    } as any)
+
+    const data = makeDebugData({
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 200,
+          success: true,
+          duration_ms: 312,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
+      payloads: {
+        cee_request: { kind: 'message', message: 'run' },
+        cee_response: parsed.response as unknown as Record<string, unknown>,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    const diag = bundle.v5_canonical_analysis!
+    expect(diag.v5_cee_capture).not.toBeNull()
+    const capture = diag.v5_cee_capture!
+
+    expect(capture.parse_ok).toBe(true)
+    expect(capture.parse_error).toBeNull()
+    expect(capture.parse_failure_kind).toBeNull()
+    // Success path stores a parsed clone, not the verbatim wire JSON.
+    expect(capture.raw_response_present).toBe(false)
+    // response_top_level_keys reflects the ORIGINAL CEE root shape from
+    // the parser's sidecar metadata — including the top-level Phase 3
+    // freshness extras, NOT the parsed-clone's `__additive__` key.
+    expect(capture.response_top_level_keys).toEqual(
+      [
+        'analysis_freshness',
+        'assistant_text',
+        'blocks',
+        'freshness_reason',
+        'has_run_analysis_fact',
+        'insights',
+        'response_version',
+        'stage_indicator',
+        'suggested_actions',
+      ].sort(),
+    )
+    expect(capture.response_top_level_keys).not.toContain('__additive__')
+    expect(capture.phase3_blocks_tolerated_count).toBe(2)
+    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
+    expect(diag.debug_capture_status).toBe('complete')
+  })
+
+  it('Phase-3-only response: has_additive_extensions:false, phase3 counts > 0', async () => {
+    // Pin the documented separation between top-level additive
+    // extensions and the metadata sidecar. The parser writes the sidecar
+    // whenever Phase 3 blocks land in blocks[] (and stashes the
+    // original-top-level-keys list alongside). Those slots are
+    // diagnostic-only — they MUST NOT flip has_additive_extensions, which
+    // is reserved for genuine top-level additive fields.
+    const parsed = await parseV5Response(makeResponse(phase3OnlyFixture()))
+    expect(parsed.kind).toBe('response')
+    if (parsed.kind !== 'response') throw new Error('unreachable')
+
+    const data = makeDebugData({
+      services: {
+        cee: { name: 'CEE', status: 200, success: true, duration_ms: 200, endpoint: '/bff/orchestrate/v2/turn' },
+        plot: null,
+        isl: null,
+      },
+      payloads: {
+        cee_request: { kind: 'message', message: 'run' },
+        cee_response: parsed.response as unknown as Record<string, unknown>,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
+
+    expect(capture.parse_ok).toBe(true)
+    expect(capture.phase3_blocks_tolerated_count).toBeGreaterThan(0)
+    expect(capture.phase3_block_types.sort()).toEqual(['coaching', 'review_card'])
+    // The whole point of this test: top-level additives are absent so
+    // has_additive_extensions stays honest at false.
+    expect(capture.has_additive_extensions).toBe(false)
+  })
+})

--- a/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
+++ b/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
@@ -251,6 +251,54 @@ describe('v5_cee_capture — parse-failure path', () => {
     )
     expect(diag.debug_capture_status).toBe('parse_failed')
   })
+
+  it('mixed blocks (Phase 3 + unknown) → parse fails AND phase3 count populated from raw fallback', async () => {
+    // Pin the design: when CEE emits both tolerated Phase 3 blocks AND a
+    // truly-unknown block type inside `blocks[]`, the parser hard-fails
+    // (the unknown type dominates) — but the debug bundle must still
+    // surface the Phase 3 blocks the parser would have tolerated, sourced
+    // from the captured raw envelope. That lets reviewers see "CEE did
+    // emit review_card + coaching, the unknown_future_type is the
+    // offender" rather than collapsing both signals into a single
+    // failure with no Phase 3 visibility.
+    const fixture = ceeFixture() // includes analysis_result + review_card + coaching
+    ;(fixture.blocks as unknown[]).push({
+      type: 'totally_unknown_future_type',
+      payload: { whatever: 1 },
+    })
+    const parsed = await parseV5Response(makeResponse(fixture))
+    expect(parsed.kind).toBe('parse_error')
+
+    const data = makeDebugData({
+      payloads: {
+        cee_request: { kind: 'message', message: 'run' },
+        cee_response: parsed as unknown as Record<string, unknown>,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
+
+    // Parse failure still dominates the capture status.
+    expect(capture.parse_ok).toBe(false)
+    expect(capture.parse_failure_kind).toBe('unknown_block_types')
+    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
+
+    // But the Phase 3 blocks the parser WOULD have tolerated must still
+    // be visible to the reviewer — sourced from the parse_error
+    // envelope's `raw.blocks[]` via the bundle's raw fallback path.
+    expect(capture.phase3_blocks_tolerated_count).toBe(2)
+    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
+
+    // raw_response_present remains true here — the parse_error envelope
+    // preserved the verbatim pre-validation JSON, which is the basis for
+    // the raw fallback enumeration.
+    expect(capture.raw_response_present).toBe(true)
+  })
 })
 
 describe('v5_cee_capture — end-to-end through redactor', () => {

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -2725,13 +2725,22 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     // (now sourced from sidecar metadata) plus the phase3 sidecar.
     const rawResponsePresent = ceeIsParseErrorEnvelope && ceeRawResponseObject !== null
 
-    const hasAdditiveExtensions =
-      ceeResponseObject !== null &&
-      !ceeIsParseErrorEnvelope &&
-      Object.prototype.hasOwnProperty.call(
-        ceeResponseObject,
-        ADDITIVE_EXTENSIONS_KEY,
-      )
+    // `has_additive_extensions` is documented as TOP-LEVEL additive
+    // extensions only — the kind of unknown keys CEE emits at the
+    // response root ahead of a schema bump. The sidecar may also carry
+    // diagnostic metadata (Phase 3 blocks lifted out of `blocks[]`,
+    // original top-level key list); those are NOT top-level additive
+    // fields and must not flip this flag. Compute from the sidecar's
+    // remaining keys after excluding the metadata slots.
+    const hasAdditiveExtensions = (() => {
+      if (successSidecar === null) return false
+      for (const k of Object.keys(successSidecar)) {
+        if (k === PHASE3_SIDECAR_BLOCKS_KEY) continue
+        if (k === ORIGINAL_TOP_LEVEL_KEYS_KEY) continue
+        return true
+      }
+      return false
+    })()
 
     const v5Capture: V5CeeCapture | null =
       requestPresent || responsePresent || ceeService

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -46,6 +46,7 @@ import {
   ORIGINAL_TOP_LEVEL_KEYS_KEY,
   PHASE3_SIDECAR_BLOCKS_KEY,
   PHASE3_TOLERATED_BLOCK_TYPES,
+  V5_PARSE_ERROR_KIND,
   type ParseFailureKind,
 } from '../../../v5/responseParser'
 
@@ -2582,7 +2583,7 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     //       the original 200 JSON sits at `raw`.
     // We classify here so the bundle reflects both cases honestly.
     const ceeIsParseErrorEnvelope =
-      ceeResponseObject !== null && ceeResponseObject.kind === 'parse_error'
+      ceeResponseObject !== null && ceeResponseObject.kind === V5_PARSE_ERROR_KIND
     const ceeRawResponseObject: Record<string, unknown> | null =
       ceeIsParseErrorEnvelope &&
       ceeResponseObject !== null &&

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -41,7 +41,13 @@ import {
   type V5CeeCapture,
 } from '../../../lib/v5CanonicalAnalysisDiagnostics'
 import { isV5CanonicalAnalysisEnabled } from '../../../flags'
-import { ADDITIVE_EXTENSIONS_KEY } from '../../../v5/responseParser'
+import {
+  ADDITIVE_EXTENSIONS_KEY,
+  ORIGINAL_TOP_LEVEL_KEYS_KEY,
+  PHASE3_SIDECAR_BLOCKS_KEY,
+  PHASE3_TOLERATED_BLOCK_TYPES,
+  type ParseFailureKind,
+} from '../../../v5/responseParser'
 
 // =============================================================================
 // Feature Flag
@@ -2562,12 +2568,35 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     const storeState = useCanvasStore.getState()
     const fact = storeState.v5AnalysisFact
 
+    const ceeRequest = bundle.payloads.cee_request
     const ceeResponse = bundle.payloads.cee_response
     const ceeResponseObject =
       ceeResponse && typeof ceeResponse === 'object' && !Array.isArray(ceeResponse)
         ? (ceeResponse as Record<string, unknown>)
         : null
-    const responseBlocks = ceeResponseObject?.blocks
+
+    // The captured body may be either:
+    //   (a) a successful OlumiResponse (object), or
+    //   (b) a `parse_error` envelope from responseParser: `{ kind:
+    //       'parse_error', reason, raw?, parse_failure_kind?, ... }`. In (b)
+    //       the original 200 JSON sits at `raw`.
+    // We classify here so the bundle reflects both cases honestly.
+    const ceeIsParseErrorEnvelope =
+      ceeResponseObject !== null && ceeResponseObject.kind === 'parse_error'
+    const ceeRawResponseObject: Record<string, unknown> | null =
+      ceeIsParseErrorEnvelope &&
+      ceeResponseObject !== null &&
+      typeof ceeResponseObject.raw === 'object' &&
+      ceeResponseObject.raw !== null &&
+      !Array.isArray(ceeResponseObject.raw)
+        ? (ceeResponseObject.raw as Record<string, unknown>)
+        : ceeIsParseErrorEnvelope
+          ? null
+          : ceeResponseObject
+
+    // analysis_result detection runs against the RAW response when present
+    // so a parse_error doesn't hide the upstream Phase 3-tolerated payload.
+    const responseBlocks = ceeRawResponseObject?.blocks
     const ceeResponseHasAnalysisResult = Array.isArray(responseBlocks)
       ? responseBlocks.some(
           (b) =>
@@ -2578,36 +2607,155 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
         )
       : false
 
-    const ceeService = data.services.cee ?? null
-    // services.cee carries { status, duration_ms, success } only — endpoint
-    // is not on the type. We surface request_id + status + duration; the
-    // exact URL is recoverable from getV5Endpoint() but reading it here
-    // would re-resolve env at export time, which is misleading when the
-    // capture pre-dates the export.
-    const v5Capture: V5CeeCapture | null = ceeService
-      ? {
-          request_id: data.overall.request_id,
-          scenario_id: storeState.currentScenarioId,
-          turn_id: fact?.analysisHash ?? null,
-          endpoint: null,
-          status: ceeService.status,
-          duration_ms: ceeService.duration_ms,
-          request_present: bundle.payloads.cee_request !== null,
-          response_present: ceeResponseObject !== null,
-          parse_ok: ceeResponseObject !== null,
-          parse_error: null,
-          response_top_level_keys: ceeResponseObject
-            ? Object.keys(ceeResponseObject).sort()
-            : null,
-          has_additive_extensions:
-            ceeResponseObject !== null &&
-            Object.prototype.hasOwnProperty.call(
-              ceeResponseObject,
-              ADDITIVE_EXTENSIONS_KEY,
+    // Enumerate Phase 3 blocks landing inside `blocks[]` (whitelisted set
+    // only). Read from the parsed response's sidecar first; if the parser
+    // failed before stashing the sidecar, fall back to scanning the raw
+    // blocks array.
+    const phase3FromSidecar = (() => {
+      if (ceeResponseObject === null || ceeIsParseErrorEnvelope) return null
+      const sidecar = (ceeResponseObject as Record<string | symbol, unknown>)[
+        ADDITIVE_EXTENSIONS_KEY as unknown as string
+      ]
+      if (!sidecar || typeof sidecar !== 'object' || Array.isArray(sidecar)) return null
+      const fromBlocksArray = (sidecar as Record<string, unknown>)[
+        PHASE3_SIDECAR_BLOCKS_KEY
+      ]
+      return Array.isArray(fromBlocksArray) ? fromBlocksArray : null
+    })()
+    const phase3FromRaw = phase3FromSidecar === null && Array.isArray(responseBlocks)
+      ? responseBlocks.filter(
+          (b) =>
+            b !== null &&
+            typeof b === 'object' &&
+            !Array.isArray(b) &&
+            typeof (b as Record<string, unknown>).type === 'string' &&
+            (PHASE3_TOLERATED_BLOCK_TYPES as ReadonlySet<string>).has(
+              (b as Record<string, unknown>).type as string,
             ),
-          source: 'proxy_v5_turn',
-        }
+        )
       : null
+    const phase3Source = phase3FromSidecar ?? phase3FromRaw ?? []
+    const phase3BlockTypes = Array.from(
+      new Set(
+        phase3Source
+          .map((b) =>
+            b !== null && typeof b === 'object' && !Array.isArray(b)
+              ? ((b as Record<string, unknown>).type as string)
+              : null,
+          )
+          .filter((t): t is string => typeof t === 'string'),
+      ),
+    ).sort()
+
+    // ceeService is no longer the gate — payload-trace evidence
+    // (cee_request / cee_response) is sufficient to emit a capture object,
+    // and parse failures must populate the diagnostic even when the
+    // services slice is empty.
+    const ceeService = data.services.cee ?? null
+    const requestPresent = ceeRequest !== null && ceeRequest !== undefined
+    const responsePresent = ceeResponse !== null && ceeResponse !== undefined
+    const parseOk = responsePresent && !ceeIsParseErrorEnvelope
+
+    const parseError = ceeIsParseErrorEnvelope
+      ? (() => {
+          const reason =
+            typeof ceeResponseObject?.reason === 'string'
+              ? (ceeResponseObject.reason as string)
+              : 'parse_error'
+          return reason.length > 500 ? `${reason.slice(0, 500)}…` : reason
+        })()
+      : null
+    const parseFailureKind: ParseFailureKind | null = ceeIsParseErrorEnvelope
+      ? (typeof ceeResponseObject?.parse_failure_kind === 'string'
+          ? (ceeResponseObject.parse_failure_kind as ParseFailureKind)
+          : 'schema_mismatch')
+      : null
+    const unknownBlockTypes = ceeIsParseErrorEnvelope &&
+      Array.isArray(ceeResponseObject?.unknown_block_types)
+      ? (ceeResponseObject!.unknown_block_types as unknown[]).filter(
+          (t): t is string => typeof t === 'string',
+        )
+      : null
+
+    // response_top_level_keys — must reflect the ORIGINAL CEE root shape,
+    // not the parsed clone (which has `__additive__` promoted as an
+    // enumerable key and is missing the demoted top-level Phase 3 extras
+    // like analysis_freshness / has_run_analysis_fact / freshness_reason).
+    //
+    // Source precedence:
+    //   1. Parse-error envelope → keys of `envelope.raw` (verbatim original).
+    //   2. Success path with sidecar carrying ORIGINAL_TOP_LEVEL_KEYS_KEY
+    //      metadata (parser writes this whenever any sidecar is emitted).
+    //   3. Fallback: keys of the captured body (parsed clone). Honest only
+    //      when no sidecar is present — i.e. CEE emitted no top-level
+    //      additives AND no Phase 3 blocks AND the parsed shape equals
+    //      the wire shape.
+    const successSidecar: Record<string, unknown> | null =
+      ceeResponseObject !== null && !ceeIsParseErrorEnvelope
+        ? (() => {
+            const sc = (ceeResponseObject as Record<string | symbol, unknown>)[
+              ADDITIVE_EXTENSIONS_KEY as unknown as string
+            ]
+            return sc && typeof sc === 'object' && !Array.isArray(sc)
+              ? (sc as Record<string, unknown>)
+              : null
+          })()
+        : null
+    const originalKeysFromSidecar = successSidecar
+      ? (successSidecar[ORIGINAL_TOP_LEVEL_KEYS_KEY] as unknown)
+      : null
+    const responseTopLevelKeys: string[] | null = ceeIsParseErrorEnvelope
+      ? ceeRawResponseObject !== null
+        ? Object.keys(ceeRawResponseObject).sort()
+        : null
+      : Array.isArray(originalKeysFromSidecar)
+        ? (originalKeysFromSidecar as unknown[]).filter(
+            (k): k is string => typeof k === 'string',
+          )
+        : ceeResponseObject !== null
+          ? Object.keys(ceeResponseObject).sort()
+          : null
+
+    // raw_response_present — true iff the bundle carries the VERBATIM
+    // pre-validation JSON body. The parser preserves it on the parse_error
+    // path via `envelope.raw`. On success the trace stores a parsed clone
+    // (validated, blocks pruned, sidecar promoted to an enumerable key) —
+    // not the literal wire JSON — so this is honestly false. Reviewers
+    // wanting to reconstruct the original use `response_top_level_keys`
+    // (now sourced from sidecar metadata) plus the phase3 sidecar.
+    const rawResponsePresent = ceeIsParseErrorEnvelope && ceeRawResponseObject !== null
+
+    const hasAdditiveExtensions =
+      ceeResponseObject !== null &&
+      !ceeIsParseErrorEnvelope &&
+      Object.prototype.hasOwnProperty.call(
+        ceeResponseObject,
+        ADDITIVE_EXTENSIONS_KEY,
+      )
+
+    const v5Capture: V5CeeCapture | null =
+      requestPresent || responsePresent || ceeService
+        ? {
+            request_id: data.overall.request_id,
+            scenario_id: storeState.currentScenarioId,
+            turn_id: fact?.analysisHash ?? null,
+            endpoint: null,
+            status: ceeService?.status ?? null,
+            duration_ms: ceeService?.duration_ms ?? null,
+            request_present: requestPresent,
+            response_present: responsePresent,
+            parse_ok: parseOk,
+            parse_error: parseError,
+            response_top_level_keys: responseTopLevelKeys,
+            raw_response_present: rawResponsePresent,
+            parse_failure_kind: parseFailureKind,
+            unknown_block_types: unknownBlockTypes,
+            has_additive_extensions: hasAdditiveExtensions,
+            phase3_blocks_tolerated_count: phase3Source.length,
+            phase3_block_types: phase3BlockTypes,
+            source: 'proxy_v5_turn',
+          }
+        : null
 
     const plotRequestCaptured = bundle.payloads.plot_request !== null
 

--- a/src/lib/__tests__/v5CanonicalAnalysisDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalAnalysisDiagnostics.spec.ts
@@ -24,7 +24,12 @@ function capture(overrides: Partial<V5CeeCapture> = {}): V5CeeCapture {
     parse_ok: true,
     parse_error: null,
     response_top_level_keys: ['blocks', 'assistant_text'],
+    raw_response_present: false,
+    parse_failure_kind: null,
+    unknown_block_types: null,
     has_additive_extensions: false,
+    phase3_blocks_tolerated_count: 0,
+    phase3_block_types: [],
     source: 'proxy_v5_turn',
     ...overrides,
   }

--- a/src/lib/v5CanonicalAnalysisDiagnostics.ts
+++ b/src/lib/v5CanonicalAnalysisDiagnostics.ts
@@ -15,6 +15,7 @@
  */
 
 import type { AnalysisStateSource } from '../canvas/hooks/useAnalysisStateSource'
+import type { ParseFailureKind } from '../v5/responseParser'
 
 export type AnalysisFactStatus = 'present' | 'missing' | 'unknown_not_checked'
 
@@ -37,8 +38,39 @@ export interface V5CeeCapture {
   parse_ok: boolean
   parse_error: string | null
   response_top_level_keys: string[] | null
-  /** Whether additive extensions were detected on the response root. */
+  /**
+   * Whether the bundle carries the VERBATIM pre-validation JSON body.
+   *   - Parse-error path: true when the parser envelope preserved `raw`
+   *     (the JSON.parse output before strict validation).
+   *   - Success path: false. The trace stores a parsed clone (validated,
+   *     `blocks[]` pruned of tolerated Phase 3 entries, `__additive__`
+   *     sidecar promoted to an enumerable key) — not the literal wire
+   *     JSON. Reviewers reconstructing the wire shape combine
+   *     `response_top_level_keys` (sourced from sidecar metadata) with
+   *     the phase3 sidecar.
+   */
+  raw_response_present: boolean
+  /** Why parsing failed; null on success. */
+  parse_failure_kind: ParseFailureKind | null
+  /**
+   * Offending block `type` values when parse_failure_kind is
+   * `unknown_block_types`. Null otherwise.
+   */
+  unknown_block_types: string[] | null
+  /**
+   * Whether top-level additive extensions (NOT phase 3 blocks-array
+   * entries) were detected. Phase 3 blocks have dedicated fields below.
+   */
   has_additive_extensions: boolean
+  /**
+   * Count of v1.3 Phase 3 blocks tolerated out of `blocks[]` by the parser
+   * (review_card / coaching / evidence / exercise). Distinct from
+   * `has_additive_extensions` because Phase 3 blocks live inside `blocks[]`
+   * per the contract, not as top-level additive fields.
+   */
+  phase3_blocks_tolerated_count: number
+  /** Distinct, sorted Phase 3 block types observed (subset of the whitelist). */
+  phase3_block_types: string[]
   source: 'proxy_v5_turn'
 }
 

--- a/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
+++ b/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 /**
- * V5 Phase 3 blocks-array tolerance — end-to-end regression.
+ * V5 Phase 3 blocks-array tolerance — parser/extractor/state regressions.
  *
  * Acceptance brief (canonical V5 analysis, 2026-05-18):
  *   The vendored @talchain/schemas@0.8.1 does not include the frozen v1.3
@@ -17,26 +17,13 @@
  * truly-unknown entries still hard-fail and are named in the debug
  * bundle.
  *
- * These tests cover the ten acceptance points from the brief:
- *   1. Realistic CEE response (analysis_result + review_card + coaching)
- *      parses successfully.
- *   2. Phase 3 blocks are preserved in the sidecar with `raw` intact.
- *   3. `response.blocks` after strict validation contains only legacy
- *      schema-known entries.
- *   4. extractPhase3FromV5Response reads the sidecar Phase 3 blocks and
- *      writes them into v5AnalysisFact.rawBlocks.
- *   5. Results report is applied from the analysis_result block (store
- *      slice set).
- *   6. useAnalysisStateSource returns 'cee_v5_run_analysis' for the
- *      attached fact.
- *   7. The typed-error path does not render — routeV5Response returns a
- *      content target, not `typed_error`.
- *   8. Unknown block type inside blocks[] still fails parse and is
- *      enumerated in v5_cee_capture.parse_error / unknown_block_types.
- *   9. Malformed-known nested block (missing required field) still fails
- *      parse — nested product schemas remain strict.
- *  10. The debug bundle's v5_cee_capture is populated on parse failure
- *      rather than being null.
+ * NOTE: debug-bundle integration assertions live in
+ *   src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
+ * Pulling buildDebugBundleAsync / DebugData into the v5 typecheck graph
+ * (tsconfig.ci.json includes only specific files plus the src/v5/ tree)
+ * would surface latent type errors in untouched debug modules and break
+ * CI. Keep the v5 spec focused on parser/extractor and runtime store
+ * behaviour.
  */
 import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
@@ -73,8 +60,6 @@ import {
 } from '../../canvas/hooks/useAnalysisStateSource'
 import { useCanvasStore } from '../../canvas/store'
 import type { V5AnalysisFactState } from '../../canvas/store'
-import { buildDebugBundleAsync } from '../../components/debug/utils/exportBundle'
-import type { DebugData } from '../../components/debug/hooks/useDebugData'
 import { callV5Turn } from '../v5Adapter'
 import { usePayloadTraceStore } from '../../lib/payload-trace-store'
 
@@ -154,74 +139,6 @@ function makeResponse(body: unknown, status = 200, headers: Record<string, strin
   })
 }
 
-function makeDebugData(overrides: Partial<DebugData> = {}): DebugData {
-  return {
-    overall: { status: 'success', total_duration_ms: 100, request_id: 'req-test-1' },
-    services: { cee: null, plot: null, isl: null },
-    error: null,
-    builds: { ui: 'test', cee: null, plot: null, isl: null },
-    diagnostics: {
-      plot_has_downstream_calls: false,
-      downstream_calls_path_found: null,
-      downstream_calls_paths_checked: [],
-      isl_data_source: 'none',
-      cee_trace_present: false,
-      cee_degraded: false,
-      llm_raw_available: false,
-      llm_raw_path_found: null,
-      e_values_present: false,
-      isl_edge_e_values_present: false,
-      plot_edge_e_values_exposed: false,
-      ui_edge_e_values_available: false,
-      evpi_present: false,
-      confidence_differentiated: false,
-      confidence_unique_values: [],
-      factor_confidence_differentiated: false,
-      factor_confidence_unique_values: [],
-      confidence_source_bootstrap: false,
-      intercept_populated: false,
-      epsilon_std_present: false,
-      response_hash_present: false,
-      mca_computed: false,
-    },
-    ceeTrace: null,
-    corrections: [],
-    correctionsSummary: null,
-    pipeline: {
-      status: 'success',
-      total_duration_ms: 100,
-      stages: [],
-      connectivity: { decision_count: 0, option_count: 0, goal_count: 0, factor_count: 0, edge_count: 0 },
-    },
-    payloads: {
-      cee_request: null,
-      cee_response: null,
-      plot_request: null,
-      plot_response: null,
-      isl_request: null,
-      isl_response: null,
-    },
-    gates: [],
-    validation: { summary: { errors: 0, warnings: 0, info: 0 }, issues: [] },
-    winningOption: null,
-    robustness: { status: 'unavailable', stability: null, context_label: 'N/A', description: '' },
-    hasData: true,
-    orchestrator: null,
-    v12_4_checks: null,
-    request_id_chain: null,
-    feature_flags_at_request: null,
-    timing: null,
-    schema_versions: null,
-    cee_observability: null,
-    m1_coaching: null,
-    m2_review: null,
-    cee_downstream: null,
-    cee_operations: null,
-    diagnostic_trace: null,
-    ...overrides,
-  }
-}
-
 beforeEach(() => {
   vi.clearAllMocks()
   mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
@@ -297,6 +214,121 @@ describe('parser tolerance — happy path (analysis_result + review_card + coach
     // assistant_text is '' and there is one analysis_result block, so
     // routing classifies as `blocks`.
     expect(target.kind).toBe('blocks')
+  })
+})
+
+// ── All four canonical Phase 3 types — accepting exactly these is the
+// central contract; the happy-path fixture only exercises two, so this
+// test pins coverage for evidence and exercise as well.
+
+describe('parser tolerance — all four canonical Phase 3 types', () => {
+  function fourTypesFixture(): Record<string, unknown> {
+    return {
+      response_version: 2,
+      assistant_text: '',
+      blocks: [
+        { type: 'analysis_result', summary: 'leads', leading_option_id: 'opt-a' },
+        {
+          type: 'review_card',
+          block_id: 'rc-1',
+          signal_id: 'rc:1',
+          card_kind: 'narrative',
+        },
+        {
+          type: 'coaching',
+          block_id: 'co-1',
+          signal_id: 'co:1',
+          coaching_kind: 'strengthen',
+          title: 'Strengthen evidence',
+        },
+        {
+          type: 'evidence',
+          block_id: 'ev-1',
+          signal_id: 'ev:1',
+          factor_ref: 'node-A',
+          target_refs: [{ type: 'node', id: 'node-A' }],
+        },
+        {
+          type: 'exercise',
+          block_id: 'ex-1',
+          signal_id: 'ex:1',
+          exercise_kind: 'pre_mortem',
+          title: 'Pre-mortem',
+        },
+      ],
+      suggested_actions: [],
+      insights: [],
+      stage_indicator: 'analyse',
+    }
+  }
+
+  it('parses successfully and routes every type to the right bucket', async () => {
+    const result = await parseV5Response(makeResponse(fourTypesFixture()))
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+
+    // Legacy-known set in response.blocks; Phase 3 set in sidecar.
+    expect(result.response.blocks.map((b) => b.type)).toEqual(['analysis_result'])
+
+    const sidecar = (result.response as Record<string | symbol, unknown>)[
+      ADDITIVE_EXTENSIONS_KEY
+    ] as Record<string, unknown>
+    const phase3 = sidecar[PHASE3_SIDECAR_BLOCKS_KEY] as Array<Record<string, unknown>>
+    expect(phase3).toHaveLength(4)
+    const sidecarTypes = phase3.map((b) => b.type).sort()
+    expect(sidecarTypes).toEqual(['coaching', 'evidence', 'exercise', 'review_card'])
+
+    // Each block's discriminating field survives verbatim.
+    expect(phase3.find((b) => b.type === 'review_card')!.card_kind).toBe('narrative')
+    expect(phase3.find((b) => b.type === 'coaching')!.coaching_kind).toBe('strengthen')
+    expect(phase3.find((b) => b.type === 'evidence')!.factor_ref).toBe('node-A')
+    expect(phase3.find((b) => b.type === 'exercise')!.exercise_kind).toBe('pre_mortem')
+  })
+
+  it('extractor surfaces all four types with raw intact', async () => {
+    const result = await parseV5Response(makeResponse(fourTypesFixture()))
+    if (result.kind !== 'response') throw new Error('parse failed')
+    const extraction = extractPhase3FromV5Response(result.response)
+
+    expect(extraction.rawBlocks).toHaveLength(4)
+    const extractedTypes = extraction.rawBlocks.map((b) => b.type).sort()
+    expect(extractedTypes).toEqual(['coaching', 'evidence', 'exercise', 'review_card'])
+    // All four come from the blocks-array sidecar source.
+    for (const block of extraction.rawBlocks) {
+      expect(block.source).toBe('sidecar_blocks_array')
+    }
+    // Raw payload verbatim — pick a discriminating field from each type.
+    expect(extraction.rawBlocks.find((b) => b.type === 'review_card')!.raw.block_id).toBe('rc-1')
+    expect(extraction.rawBlocks.find((b) => b.type === 'coaching')!.raw.block_id).toBe('co-1')
+    expect(extraction.rawBlocks.find((b) => b.type === 'evidence')!.raw.block_id).toBe('ev-1')
+    expect(extraction.rawBlocks.find((b) => b.type === 'exercise')!.raw.block_id).toBe('ex-1')
+  })
+
+  it('callV5Turn carries all four types through to the trace clone sidecar', async () => {
+    usePayloadTraceStore.setState({ payloads: [], selectedId: null } as any)
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify(fourTypesFixture()), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const result = await callV5Turn(
+      { kind: 'message', message: 'run analysis' } as never,
+      { fetchImpl },
+    )
+    expect(result.kind).toBe('response')
+
+    const traced = usePayloadTraceStore.getState().payloads
+    expect(traced).toHaveLength(1)
+    const tracedBody = traced[0].response?.body as Record<string, unknown>
+    const tracedSidecar = tracedBody[ADDITIVE_EXTENSIONS_KEY] as Record<string, unknown>
+    const tracedPhase3 = tracedSidecar[PHASE3_SIDECAR_BLOCKS_KEY] as Array<Record<string, unknown>>
+    expect(tracedPhase3.map((b) => b.type).sort()).toEqual([
+      'coaching',
+      'evidence',
+      'exercise',
+      'review_card',
+    ])
   })
 })
 
@@ -386,7 +418,40 @@ describe('extractor + store-level state source', () => {
   })
 })
 
-// ── 8–10. Negative paths + debug bundle ───────────────────────────────
+// ── Runtime sidecar non-enumerable contract ────────────────────────────
+
+describe('callV5Turn runtime/traced sidecar split', () => {
+  it('runtime response keeps sidecar non-enumerable; traced clone is enumerable', async () => {
+    usePayloadTraceStore.setState({ payloads: [], selectedId: null } as any)
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify(ceeFixture()), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const result = await callV5Turn(
+      { kind: 'message', message: 'run analysis' } as never,
+      { fetchImpl },
+    )
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+
+    // Runtime contract: JSON.stringify and ordinary Object.keys consumers
+    // do NOT see `__additive__` on the OlumiResponse surface.
+    const runtimeResponse = result.response as Record<string, unknown>
+    expect(Object.keys(runtimeResponse)).not.toContain(ADDITIVE_EXTENSIONS_KEY)
+    expect(
+      (runtimeResponse as Record<string | symbol, unknown>)[ADDITIVE_EXTENSIONS_KEY],
+    ).toBeDefined()
+
+    // Trace clone: sidecar is ENUMERABLE so the trace store's
+    // Object.keys-based redactor preserves it for the debug bundle.
+    const traced = usePayloadTraceStore.getState().payloads
+    expect(traced).toHaveLength(1)
+    const tracedBody = traced[0].response?.body as Record<string, unknown>
+    expect(Object.keys(tracedBody)).toContain(ADDITIVE_EXTENSIONS_KEY)
+  })
+})
 
 // ── Drift guard — keep LEGACY_SCHEMA_KNOWN_BLOCK_TYPES in sync ─────────
 
@@ -402,17 +467,10 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
    * LEGACY_SCHEMA_KNOWN_BLOCK_TYPES in src/v5/responseParser.ts.
    */
   it('mirrors every block type declared by the vendored schema', () => {
-    // Reach into zod internals — `discriminatedUnion` carries the
-    // discriminator values in `_def.optionsMap` as a Map keyed by the
-    // literal value. This is stable across zod 3.x; if zod upgrades and
-    // breaks this access, the test fails loudly and surfaces the issue.
     const def = (BlockSchema as unknown as { _def: { optionsMap?: Map<string, unknown> } })._def
     expect(def.optionsMap).toBeDefined()
     const declaredTypes = new Set<string>(def.optionsMap!.keys())
 
-    // Mirror imported from the parser via a runtime check rather than
-    // re-exporting the private set — we test the actual behaviour by
-    // sending one block of each declared type through parseV5Response.
     // Phase 3 whitelist must NOT overlap with the legacy schema set; if
     // a Phase 3 type lands in the schema, the parser still treats it as
     // a tolerated phase3 entry — surface that conflict here.
@@ -466,16 +524,11 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
     for (const decl of declaredTypes) {
       const minimal = minimalEachType[decl]
       if (!minimal) {
-        // A new declared type that we don't have a sample for — this is
-        // exactly the drift case the guard catches. Surface it by name.
         missing.push(decl)
         continue
       }
       const parsed = BlockSchema.safeParse(minimal)
       if (!parsed.success) {
-        // If our hand-built sample is wrong for a renamed schema, fail
-        // with both the offending type and the zod error so the next
-        // editor knows exactly what changed.
         throw new Error(
           `drift: block type "${decl}" no longer accepts the canonical minimal sample. ` +
             `Update LEGACY_SCHEMA_KNOWN_BLOCK_TYPES and minimalEachType. zod error: ${parsed.error.message}`,
@@ -497,10 +550,7 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
    * separate hand-mirrored set (`LEGACY_SCHEMA_KNOWN_BLOCK_TYPES`); a
    * type that the vendored schema accepts but the mirror omits would be
    * misrouted into the `unknown` bucket and hard-fail at runtime even
-   * though the BlockSchema check above passes. This test fires
-   * `parseV5Response` against an OlumiResponse wrapping the minimal
-   * block sample for every declared type, asserting `kind === 'response'`
-   * on each. Catches mirror omissions.
+   * though the BlockSchema check above passes.
    */
   it('round-trips every declared block type through parseV5Response', async () => {
     const def = (BlockSchema as unknown as { _def: { optionsMap?: Map<string, unknown> } })._def
@@ -543,7 +593,7 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
     const misrouted: string[] = []
     for (const decl of declaredTypes) {
       const sample = minimalEachType[decl]
-      if (!sample) continue // covered by the previous test's `missing` array
+      if (!sample) continue
 
       const payload = { ...baseShell, blocks: [sample] }
       const result = await parseV5Response(
@@ -572,6 +622,8 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
   })
 })
 
+// ── Negative paths — unknown and malformed blocks ─────────────────────
+
 describe('parser strictness — unknown and malformed blocks', () => {
   it('(8) unknown block type inside blocks[] still fails parse with enumerated types', async () => {
     const fixture = ceeFixture()
@@ -590,6 +642,35 @@ describe('parser strictness — unknown and malformed blocks', () => {
     expect((result.raw as Record<string, unknown>).blocks).toBeTruthy()
   })
 
+  it('multiple unknown blocks of the same type dedupe to a single entry in unknown_block_types', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push(
+      { type: 'totally_unknown_future_type', a: 1 },
+      { type: 'totally_unknown_future_type', a: 2 },
+      { type: 'another_unknown_type', b: 3 },
+    )
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('parse_error')
+    if (result.kind !== 'parse_error') throw new Error('unreachable')
+    // Dedupe + sort so reviewers see a clean, stable list — not a bloated
+    // one with each unknown block duplicated.
+    expect(result.unknown_block_types).toEqual([
+      'another_unknown_type',
+      'totally_unknown_future_type',
+    ])
+  })
+
+  it('an array entry inside blocks[] is classified as `array`, not `object`', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push(['not', 'a', 'block'])
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('parse_error')
+    if (result.kind !== 'parse_error') throw new Error('unreachable')
+    expect(result.parse_failure_kind).toBe('unknown_block_types')
+    expect(result.unknown_block_types).toContain('array')
+    expect(result.unknown_block_types).not.toContain('object')
+  })
+
   it('(9) malformed-known block still fails parse — nested product schemas remain strict', async () => {
     const fixture = ceeFixture()
     ;(fixture.blocks as unknown[]).push({ type: 'text' /* required `content` missing */ })
@@ -597,261 +678,5 @@ describe('parser strictness — unknown and malformed blocks', () => {
     expect(result.kind).toBe('parse_error')
     if (result.kind !== 'parse_error') throw new Error('unreachable')
     expect(result.parse_failure_kind).toBe('schema_mismatch')
-  })
-})
-
-describe('debug bundle — v5_cee_capture populated on parse failure', () => {
-  it('(10) parse-error envelope flows into v5_cee_capture with parse_ok=false + enumerated types', async () => {
-    // Construct the parse_error envelope exactly as recordResponsePayload
-    // would have stored it under bundle.payloads.cee_response when
-    // parseV5Response hard-fails on an unknown block type.
-    const fixture = ceeFixture()
-    ;(fixture.blocks as unknown[]).push({ type: 'totally_unknown_future_type' })
-    const parsed = await parseV5Response(makeResponse(fixture))
-    expect(parsed.kind).toBe('parse_error')
-
-    // Seed the store so the canonical-analysis classifier has the bits it
-    // needs to read alongside the capture.
-    useCanvasStore.setState({
-      results: { status: 'idle' },
-      currentScenarioId: 'scenario-A',
-      v5AnalysisFact: null,
-    } as any)
-
-    const data = makeDebugData({
-      payloads: {
-        cee_request: { kind: 'message', message: 'run' },
-        // Mirror what v5Adapter's recordResponsePayload writes when parse fails.
-        cee_response: parsed as unknown as Record<string, unknown>,
-        plot_request: null,
-        plot_response: null,
-        isl_request: null,
-        isl_response: null,
-      },
-    })
-
-    const bundle = await buildDebugBundleAsync(data)
-    expect(bundle.v5_canonical_analysis).toBeDefined()
-    const diag = bundle.v5_canonical_analysis!
-    expect(diag.v5_cee_capture).not.toBeNull()
-    const capture = diag.v5_cee_capture!
-
-    expect(capture.parse_ok).toBe(false)
-    expect(capture.response_present).toBe(true)
-    expect(capture.raw_response_present).toBe(true)
-    expect(capture.parse_failure_kind).toBe('unknown_block_types')
-    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
-    expect(capture.parse_error ?? '').toContain('totally_unknown_future_type')
-    // Top-level keys read from the raw envelope, not the parse_error wrapper.
-    expect(capture.response_top_level_keys).toEqual(
-      expect.arrayContaining(['response_version', 'assistant_text', 'blocks']),
-    )
-    // Classifier maps parse_ok:false to debug_capture_status:'parse_failed'.
-    expect(diag.debug_capture_status).toBe('parse_failed')
-  })
-
-  it('end-to-end: callV5Turn → trace-store redactor → bundle preserves Phase 3 fields', async () => {
-    // P1 regression — the parser stashes Phase 3 blocks on a
-    // NON-ENUMERABLE sidecar so they don't leak into JSON.stringify. The
-    // trace store's redactor uses Object.keys (skips non-enumerable), so
-    // a literal "store the parsed response" would lose the sidecar before
-    // the bundle reads it. v5Adapter promotes the sidecar to an
-    // enumerable property on a shallow clone for the trace body — this
-    // test proves the clone survives the redactor and the bundle still
-    // populates phase3_blocks_tolerated_count + phase3_block_types.
-
-    // Clear any prior trace entries from the shared zustand store.
-    usePayloadTraceStore.setState({ payloads: [], selectedId: null } as any)
-
-    const fixture = ceeFixture()
-    const fetchImpl: typeof fetch = async () =>
-      new Response(JSON.stringify(fixture), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-
-    const result = await callV5Turn(
-      { kind: 'message', message: 'run analysis' } as never,
-      { fetchImpl },
-    )
-    expect(result.kind).toBe('response')
-    if (result.kind !== 'response') throw new Error('unreachable')
-
-    // Pin the intended split between runtime contract safety and
-    // diagnostic exportability:
-    //   - The runtime `result.response` keeps the sidecar NON-ENUMERABLE
-    //     so JSON.stringify, Object.keys, and ordinary consumers don't
-    //     see `__additive__` leaking onto the OlumiResponse surface.
-    //   - The trace clone (what v5Adapter records into the trace store)
-    //     promotes the sidecar to an ENUMERABLE property so the redactor
-    //     (Object.keys-based) preserves it for the debug bundle.
-    const runtimeResponse = result.response as Record<string, unknown>
-    expect(Object.keys(runtimeResponse)).not.toContain(ADDITIVE_EXTENSIONS_KEY)
-    // Bracket access still reaches the non-enumerable sidecar.
-    expect(
-      (runtimeResponse as Record<string | symbol, unknown>)[ADDITIVE_EXTENSIONS_KEY],
-    ).toBeDefined()
-
-    // Reach into the trace store to pull what the bundle assembler will
-    // read from in production (post-redaction).
-    const traced = usePayloadTraceStore.getState().payloads
-    expect(traced).toHaveLength(1)
-    const tracedBody = traced[0].response?.body as Record<string, unknown> | undefined
-    expect(tracedBody).toBeDefined()
-
-    // Sidecar must be present and ENUMERABLE on the traced body
-    // (post-redaction) — the diagnostic split with the runtime object.
-    const tracedKeys = Object.keys(tracedBody!)
-    expect(tracedKeys).toContain(ADDITIVE_EXTENSIONS_KEY)
-    const tracedSidecar = tracedBody![ADDITIVE_EXTENSIONS_KEY] as Record<string, unknown>
-    expect(tracedSidecar).toBeDefined()
-    expect(Array.isArray(tracedSidecar[PHASE3_SIDECAR_BLOCKS_KEY])).toBe(true)
-    const tracedPhase3 = tracedSidecar[PHASE3_SIDECAR_BLOCKS_KEY] as Array<Record<string, unknown>>
-    expect(tracedPhase3).toHaveLength(2)
-    expect(tracedPhase3.map((b) => b.type).sort()).toEqual(['coaching', 'review_card'])
-
-    // Now drive buildDebugBundleAsync with this real traced body — proves
-    // the diagnostic fields populate end-to-end through redaction.
-    useCanvasStore.setState({
-      results: {
-        status: 'complete',
-        report: { schema: 'report.v1' } as any,
-        hash: 'hash-e2e',
-      },
-      currentScenarioId: 'scenario-A',
-      v5AnalysisFact: {
-        scenarioId: 'scenario-A',
-        analysisHash: 'hash-e2e',
-        hasRunAnalysisFact: true,
-        freshness: 'fresh',
-        freshnessReason: null,
-        rawBlocks: [],
-        writtenAt: Date.now(),
-      } satisfies V5AnalysisFactState,
-    } as any)
-
-    const data = makeDebugData({
-      services: {
-        cee: {
-          name: 'CEE',
-          status: 200,
-          success: true,
-          duration_ms: 312,
-          endpoint: '/bff/orchestrate/v2/turn',
-        },
-        plot: null,
-        isl: null,
-      },
-      payloads: {
-        cee_request: traced[0].request?.body as Record<string, unknown> | null,
-        cee_response: tracedBody as Record<string, unknown>,
-        plot_request: null,
-        plot_response: null,
-        isl_request: null,
-        isl_response: null,
-      },
-    })
-
-    const bundle = await buildDebugBundleAsync(data)
-    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
-    expect(capture.parse_ok).toBe(true)
-    expect(capture.has_additive_extensions).toBe(true)
-    expect(capture.phase3_blocks_tolerated_count).toBe(2)
-    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
-    // Honest semantics on success: the trace stores a parsed clone, NOT
-    // the literal wire JSON. response_top_level_keys must still reflect
-    // the original CEE root shape (via the parser's sidecar metadata).
-    expect(capture.raw_response_present).toBe(false)
-    expect(capture.response_top_level_keys).not.toContain('__additive__')
-    expect(capture.response_top_level_keys).toEqual(
-      expect.arrayContaining([
-        'analysis_freshness',
-        'has_run_analysis_fact',
-        'freshness_reason',
-      ]),
-    )
-  })
-
-  it('parse-success envelope populates v5_cee_capture with phase3 counts', async () => {
-    const parsed = await parseV5Response(makeResponse(ceeFixture()))
-    expect(parsed.kind).toBe('response')
-    if (parsed.kind !== 'response') throw new Error('unreachable')
-
-    // Seed the store with the matching fact + report so the diagnostic
-    // shows the successful canonical state.
-    useCanvasStore.setState({
-      results: {
-        status: 'complete',
-        report: { schema: 'report.v1' } as any,
-        hash: 'hash-success',
-      },
-      currentScenarioId: 'scenario-A',
-      v5AnalysisFact: {
-        scenarioId: 'scenario-A',
-        analysisHash: 'hash-success',
-        hasRunAnalysisFact: true,
-        freshness: 'fresh',
-        freshnessReason: null,
-        rawBlocks: [],
-        writtenAt: Date.now(),
-      } satisfies V5AnalysisFactState,
-    } as any)
-
-    const data = makeDebugData({
-      services: {
-        cee: {
-          name: 'CEE',
-          status: 200,
-          success: true,
-          duration_ms: 312,
-          endpoint: '/bff/orchestrate/v2/turn',
-        },
-        plot: null,
-        isl: null,
-      },
-      payloads: {
-        cee_request: { kind: 'message', message: 'run' },
-        cee_response: parsed.response as unknown as Record<string, unknown>,
-        plot_request: null,
-        plot_response: null,
-        isl_request: null,
-        isl_response: null,
-      },
-    })
-
-    const bundle = await buildDebugBundleAsync(data)
-    const diag = bundle.v5_canonical_analysis!
-    expect(diag.v5_cee_capture).not.toBeNull()
-    const capture = diag.v5_cee_capture!
-
-    expect(capture.parse_ok).toBe(true)
-    expect(capture.parse_error).toBeNull()
-    expect(capture.parse_failure_kind).toBeNull()
-    // Success path stores a parsed clone, not the verbatim wire JSON, so
-    // raw_response_present must be honest about that.
-    expect(capture.raw_response_present).toBe(false)
-    // But response_top_level_keys must STILL reflect the ORIGINAL CEE
-    // root shape, sourced from the parser's sidecar metadata. The fixture
-    // emits analysis_freshness / has_run_analysis_fact / freshness_reason
-    // at the root; the parsed clone demotes them into __additive__, but
-    // the original-keys stash preserves the wire view for diagnostics.
-    expect(capture.response_top_level_keys).toEqual(
-      [
-        'analysis_freshness',
-        'assistant_text',
-        'blocks',
-        'freshness_reason',
-        'has_run_analysis_fact',
-        'insights',
-        'response_version',
-        'stage_indicator',
-        'suggested_actions',
-      ].sort(),
-    )
-    // __additive__ must NOT leak into response_top_level_keys.
-    expect(capture.response_top_level_keys).not.toContain('__additive__')
-    expect(capture.phase3_blocks_tolerated_count).toBe(2)
-    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
-    expect(diag.debug_capture_status).toBe('complete')
   })
 })

--- a/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
+++ b/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
@@ -1,0 +1,857 @@
+// @vitest-environment jsdom
+/**
+ * V5 Phase 3 blocks-array tolerance — end-to-end regression.
+ *
+ * Acceptance brief (canonical V5 analysis, 2026-05-18):
+ *   The vendored @talchain/schemas@0.8.1 does not include the frozen v1.3
+ *   Phase 3 block types `review_card | coaching | evidence | exercise` in
+ *   its `blocks[]` discriminated union. CEE emits them inside `blocks[]`
+ *   per the contract, which caused strict validation to reject the entire
+ *   response, short-circuit applyV5State, and leave the debug bundle's
+ *   `v5_cee_capture` null.
+ *
+ * The fix splits `blocks[]` into legacy-known / Phase 3 whitelist /
+ * truly-unknown buckets before strict validation. Legacy-known entries
+ * go through strict zod; Phase 3 entries are preserved verbatim and
+ * stashed in the sidecar under `phase3_blocks_from_blocks_array`;
+ * truly-unknown entries still hard-fail and are named in the debug
+ * bundle.
+ *
+ * These tests cover the ten acceptance points from the brief:
+ *   1. Realistic CEE response (analysis_result + review_card + coaching)
+ *      parses successfully.
+ *   2. Phase 3 blocks are preserved in the sidecar with `raw` intact.
+ *   3. `response.blocks` after strict validation contains only legacy
+ *      schema-known entries.
+ *   4. extractPhase3FromV5Response reads the sidecar Phase 3 blocks and
+ *      writes them into v5AnalysisFact.rawBlocks.
+ *   5. Results report is applied from the analysis_result block (store
+ *      slice set).
+ *   6. useAnalysisStateSource returns 'cee_v5_run_analysis' for the
+ *      attached fact.
+ *   7. The typed-error path does not render — routeV5Response returns a
+ *      content target, not `typed_error`.
+ *   8. Unknown block type inside blocks[] still fails parse and is
+ *      enumerated in v5_cee_capture.parse_error / unknown_block_types.
+ *   9. Malformed-known nested block (missing required field) still fails
+ *      parse — nested product schemas remain strict.
+ *  10. The debug bundle's v5_cee_capture is populated on parse failure
+ *      rather than being null.
+ */
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const { mockIsV5CanonicalAnalysisEnabled } = vi.hoisted(() => ({
+  mockIsV5CanonicalAnalysisEnabled: vi.fn(() => true),
+}))
+
+vi.mock('../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../flags')>()
+  return {
+    ...actual,
+    isV5CanonicalAnalysisEnabled: mockIsV5CanonicalAnalysisEnabled,
+  }
+})
+
+import { BlockSchema } from '@talchain/schemas/boundary'
+
+import {
+  parseV5Response,
+  ADDITIVE_EXTENSIONS_KEY,
+  PHASE3_SIDECAR_BLOCKS_KEY,
+  PHASE3_TOLERATED_BLOCK_TYPES,
+  type OlumiResponseWithExtensions,
+} from '../responseParser'
+import {
+  extractPhase3FromV5Response,
+  v5ResponseHasRunAnalysisFact,
+} from '../extractPhase3FromV5Response'
+import { routeV5Response } from '../responseRouter'
+import {
+  classifyAnalysisStateSource,
+  readAnalysisStateSourceFromStore,
+} from '../../canvas/hooks/useAnalysisStateSource'
+import { useCanvasStore } from '../../canvas/store'
+import type { V5AnalysisFactState } from '../../canvas/store'
+import { buildDebugBundleAsync } from '../../components/debug/utils/exportBundle'
+import type { DebugData } from '../../components/debug/hooks/useDebugData'
+import { callV5Turn } from '../v5Adapter'
+import { usePayloadTraceStore } from '../../lib/payload-trace-store'
+
+// ── Test fixtures ─────────────────────────────────────────────────────
+
+/**
+ * Fixture mirroring a real canonical CEE V5 turn carrying analysis_result
+ * + review_card + coaching inside `blocks[]`, plus top-level Phase 3
+ * freshness signals. Field shapes follow the frozen v1.3 contract
+ * (`v5-analysis-tab-data-contract-v1_3.md` §0 common metadata + §1 block
+ * types).
+ *
+ * Synthetic, not the actual redacted capture for request
+ * e07ac755-d392-40fa-90ca-82c4872703ba. Replace with a real redacted
+ * golden fixture when one is committed — assertions below address the
+ * contract, not specific user content, so the replacement is mechanical.
+ */
+function ceeFixture(): Record<string, unknown> {
+  const graphHash = 'graph-h-1'
+  const createdAt = '2026-05-18T10:00:00.000+01:00'
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [
+      {
+        type: 'analysis_result',
+        summary: 'Option A leads.',
+        leading_option_id: 'opt-a',
+        win_probabilities: { 'opt-a': 0.72, 'opt-b': 0.23, 'opt-c': 0.05 },
+      },
+      {
+        // v1.3 §1.1 ReviewCardBlock
+        type: 'review_card',
+        block_id: 'rc-narrative-1',
+        signal_id: 'review:narrative:opt-a',
+        created_at: createdAt,
+        source_handler: 'decision_review',
+        graph_hash_at_generation: graphHash,
+        freshness: 'fresh',
+        card_kind: 'narrative',
+        title: 'Decision review',
+        summary: 'Robust under the modelled uncertainty.',
+        target_refs: [{ type: 'option', id: 'opt-a' }],
+      },
+      {
+        // v1.3 §1.2 CoachingBlock
+        type: 'coaching',
+        block_id: 'coach-strengthen-1',
+        signal_id: 'coaching:strengthen:node-A',
+        created_at: createdAt,
+        source_handler: 'run_analysis',
+        graph_hash_at_generation: graphHash,
+        freshness: 'fresh',
+        coaching_kind: 'strengthen',
+        title: 'Strengthen evidence for Factor A',
+        detail: 'Confirm the source before relying on this factor.',
+        action_intent: 'gather_evidence',
+        priority_rank: 1,
+        target_refs: [{ type: 'node', id: 'node-A', label: 'Factor A' }],
+      },
+    ],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+    // Top-level Phase 3 metadata — captured via the additive-extensions
+    // sidecar (not the blocks-array sidecar).
+    analysis_freshness: 'fresh',
+    has_run_analysis_fact: true,
+    freshness_reason: 'just_minted',
+  }
+}
+
+function makeResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+}
+
+function makeDebugData(overrides: Partial<DebugData> = {}): DebugData {
+  return {
+    overall: { status: 'success', total_duration_ms: 100, request_id: 'req-test-1' },
+    services: { cee: null, plot: null, isl: null },
+    error: null,
+    builds: { ui: 'test', cee: null, plot: null, isl: null },
+    diagnostics: {
+      plot_has_downstream_calls: false,
+      downstream_calls_path_found: null,
+      downstream_calls_paths_checked: [],
+      isl_data_source: 'none',
+      cee_trace_present: false,
+      cee_degraded: false,
+      llm_raw_available: false,
+      llm_raw_path_found: null,
+      e_values_present: false,
+      isl_edge_e_values_present: false,
+      plot_edge_e_values_exposed: false,
+      ui_edge_e_values_available: false,
+      evpi_present: false,
+      confidence_differentiated: false,
+      confidence_unique_values: [],
+      factor_confidence_differentiated: false,
+      factor_confidence_unique_values: [],
+      confidence_source_bootstrap: false,
+      intercept_populated: false,
+      epsilon_std_present: false,
+      response_hash_present: false,
+      mca_computed: false,
+    },
+    ceeTrace: null,
+    corrections: [],
+    correctionsSummary: null,
+    pipeline: {
+      status: 'success',
+      total_duration_ms: 100,
+      stages: [],
+      connectivity: { decision_count: 0, option_count: 0, goal_count: 0, factor_count: 0, edge_count: 0 },
+    },
+    payloads: {
+      cee_request: null,
+      cee_response: null,
+      plot_request: null,
+      plot_response: null,
+      isl_request: null,
+      isl_response: null,
+    },
+    gates: [],
+    validation: { summary: { errors: 0, warnings: 0, info: 0 }, issues: [] },
+    winningOption: null,
+    robustness: { status: 'unavailable', stability: null, context_label: 'N/A', description: '' },
+    hasData: true,
+    orchestrator: null,
+    v12_4_checks: null,
+    request_id_chain: null,
+    feature_flags_at_request: null,
+    timing: null,
+    schema_versions: null,
+    cee_observability: null,
+    m1_coaching: null,
+    m2_review: null,
+    cee_downstream: null,
+    cee_operations: null,
+    diagnostic_trace: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
+  // Reset canvas store to a clean baseline for store-level assertions.
+  useCanvasStore.setState({
+    results: { status: 'idle' },
+    currentScenarioId: 'scenario-A',
+    v5AnalysisFact: null,
+  } as any)
+})
+
+// ── 1–3, 7. Parser success path ───────────────────────────────────────
+
+describe('parser tolerance — happy path (analysis_result + review_card + coaching)', () => {
+  it('parses successfully and splits blocks[] into legacy-known and sidecar Phase 3', async () => {
+    const result = await parseV5Response(makeResponse(ceeFixture()))
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+
+    const response = result.response as OlumiResponseWithExtensions
+
+    // (3) `response.blocks` after strict validation contains ONLY legacy
+    // schema-known entries. review_card and coaching are NOT in blocks[].
+    expect(response.blocks).toHaveLength(1)
+    expect(response.blocks[0].type).toBe('analysis_result')
+
+    // (2) Phase 3 blocks land in the sidecar verbatim.
+    const sidecar = (response as Record<string | symbol, unknown>)[ADDITIVE_EXTENSIONS_KEY]
+    expect(sidecar).toBeDefined()
+    const phase3FromArray = (sidecar as Record<string, unknown>)[PHASE3_SIDECAR_BLOCKS_KEY]
+    expect(Array.isArray(phase3FromArray)).toBe(true)
+    expect(phase3FromArray as unknown[]).toHaveLength(2)
+    const types = (phase3FromArray as Array<Record<string, unknown>>)
+      .map((b) => b.type)
+      .sort()
+    expect(types).toEqual(['coaching', 'review_card'])
+
+    // Verbatim preservation — every v1.3 §0/§1 field round-trips
+    // unchanged. If the parser starts flattening or stripping fields
+    // this assertion fails on the offender.
+    const reviewCard = (phase3FromArray as Array<Record<string, unknown>>).find(
+      (b) => b.type === 'review_card',
+    )!
+    expect(reviewCard.block_id).toBe('rc-narrative-1')
+    expect(reviewCard.signal_id).toBe('review:narrative:opt-a')
+    expect(reviewCard.source_handler).toBe('decision_review')
+    expect(reviewCard.card_kind).toBe('narrative')
+    expect(reviewCard.graph_hash_at_generation).toBe('graph-h-1')
+    expect(reviewCard.freshness).toBe('fresh')
+    expect(reviewCard.created_at).toBe('2026-05-18T10:00:00.000+01:00')
+    const coaching = (phase3FromArray as Array<Record<string, unknown>>).find(
+      (b) => b.type === 'coaching',
+    )!
+    expect(coaching.action_intent).toBe('gather_evidence')
+    expect(coaching.priority_rank).toBe(1)
+    expect(coaching.coaching_kind).toBe('strengthen')
+    expect(coaching.signal_id).toBe('coaching:strengthen:node-A')
+    expect((coaching.target_refs as unknown[])[0]).toEqual({
+      type: 'node',
+      id: 'node-A',
+      label: 'Factor A',
+    })
+
+    // Top-level additive freshness fields are also captured.
+    expect((sidecar as Record<string, unknown>).analysis_freshness).toBe('fresh')
+    expect((sidecar as Record<string, unknown>).has_run_analysis_fact).toBe(true)
+  })
+
+  it('(7) routeV5Response returns a content target — typed-error path is NOT taken', async () => {
+    const result = await parseV5Response(makeResponse(ceeFixture()))
+    const target = routeV5Response(result)
+    expect(target.kind).not.toBe('typed_error')
+    // assistant_text is '' and there is one analysis_result block, so
+    // routing classifies as `blocks`.
+    expect(target.kind).toBe('blocks')
+  })
+})
+
+// ── 4–6. Extractor + store-level state-source classification ──────────
+
+describe('extractor + store-level state source', () => {
+  it('(4) extractPhase3FromV5Response surfaces the sidecar Phase 3 blocks with raw intact', async () => {
+    const result = await parseV5Response(makeResponse(ceeFixture()))
+    if (result.kind !== 'response') throw new Error('parse failed')
+    const extraction = extractPhase3FromV5Response(result.response)
+
+    expect(extraction.rawBlocks).toHaveLength(2)
+    const sources = extraction.rawBlocks.map((b) => b.source)
+    expect(sources.every((s) => s === 'sidecar_blocks_array')).toBe(true)
+    const types = extraction.rawBlocks.map((b) => b.type).sort()
+    expect(types).toEqual(['coaching', 'review_card'])
+    // raw blocks are verbatim — verify a discriminating field on each.
+    const coaching = extraction.rawBlocks.find((b) => b.type === 'coaching')!
+    expect(coaching.raw.action_intent).toBe('gather_evidence')
+    const reviewCard = extraction.rawBlocks.find((b) => b.type === 'review_card')!
+    expect(reviewCard.raw.card_kind).toBe('narrative')
+
+    // Top-level CEE freshness signal landed in the sidecar too.
+    expect(extraction.analysisFreshness).toBe('fresh')
+    expect(extraction.hasRunAnalysisFact).toBe(true)
+    expect(v5ResponseHasRunAnalysisFact(result.response, extraction)).toBe(true)
+  })
+
+  it('(5–6) populates v5AnalysisFact + results.report and reports cee_v5_run_analysis', async () => {
+    const result = await parseV5Response(makeResponse(ceeFixture()))
+    if (result.kind !== 'response') throw new Error('parse failed')
+    const extraction = extractPhase3FromV5Response(result.response)
+
+    // Mirror the production write path in useConversation.ts:2766 — store
+    // the fact and the report so the state-source classifier sees both.
+    const analysisHash = 'hash-from-analysis-result'
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        report: { schema: 'report.v1' } as any,
+        hash: analysisHash,
+      },
+      currentScenarioId: 'scenario-A',
+      v5AnalysisFact: {
+        scenarioId: 'scenario-A',
+        analysisHash,
+        hasRunAnalysisFact: extraction.hasRunAnalysisFact,
+        freshness: extraction.analysisFreshness,
+        freshnessReason: extraction.freshnessReason,
+        rawBlocks: extraction.rawBlocks.map((b) => ({
+          type: b.type,
+          raw: b.raw,
+          id: b.id,
+          source: b.source,
+        })),
+        writtenAt: Date.now(),
+      } satisfies V5AnalysisFactState,
+    } as any)
+
+    // rawBlocks survives the round-trip and carries Phase 3 fields.
+    const stored = useCanvasStore.getState().v5AnalysisFact
+    expect(stored).not.toBeNull()
+    expect(stored!.rawBlocks).toHaveLength(2)
+    const storedTypes = stored!.rawBlocks.map((b) => b.type).sort()
+    expect(storedTypes).toEqual(['coaching', 'review_card'])
+
+    // (6) classifier returns cee_v5_run_analysis when the fact attaches to
+    // the current scenario AND analysisHash matches results.hash.
+    const sourceResult = readAnalysisStateSourceFromStore()
+    expect(sourceResult.source).toBe('cee_v5_run_analysis')
+    expect(sourceResult.hasResultsReport).toBe(true)
+    expect(sourceResult.factPresentForScenario).toBe(true)
+    expect(sourceResult.showOrphanBanner).toBe(false)
+  })
+
+  it('classifier returns "none" before the fact + report land (baseline)', () => {
+    // Sanity: confirm the suite isn't accidentally producing the success
+    // state in beforeEach. With no fact + idle results, source is 'none'.
+    const sourceResult = classifyAnalysisStateSource({
+      canonicalFlagOn: true,
+      reportPresent: false,
+      reportHash: null,
+      currentScenarioId: 'scenario-A',
+      fact: null,
+    })
+    expect(sourceResult.source).toBe('none')
+  })
+})
+
+// ── 8–10. Negative paths + debug bundle ───────────────────────────────
+
+// ── Drift guard — keep LEGACY_SCHEMA_KNOWN_BLOCK_TYPES in sync ─────────
+
+describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
+  /**
+   * The parser hardcodes the legacy block-type whitelist from
+   * @talchain/schemas (currently v0.8.1). If the schema package is
+   * upgraded — new block types added, existing renamed/removed — the
+   * parser's classifier silently misroutes them: new types end up in the
+   * `unknown` bucket and hard-fail parse. This drift guard introspects
+   * the strict `BlockSchema` discriminated union and asserts the parser
+   * mirror stays in sync. When this fires, update
+   * LEGACY_SCHEMA_KNOWN_BLOCK_TYPES in src/v5/responseParser.ts.
+   */
+  it('mirrors every block type declared by the vendored schema', () => {
+    // Reach into zod internals — `discriminatedUnion` carries the
+    // discriminator values in `_def.optionsMap` as a Map keyed by the
+    // literal value. This is stable across zod 3.x; if zod upgrades and
+    // breaks this access, the test fails loudly and surfaces the issue.
+    const def = (BlockSchema as unknown as { _def: { optionsMap?: Map<string, unknown> } })._def
+    expect(def.optionsMap).toBeDefined()
+    const declaredTypes = new Set<string>(def.optionsMap!.keys())
+
+    // Mirror imported from the parser via a runtime check rather than
+    // re-exporting the private set — we test the actual behaviour by
+    // sending one block of each declared type through parseV5Response.
+    // Phase 3 whitelist must NOT overlap with the legacy schema set; if
+    // a Phase 3 type lands in the schema, the parser still treats it as
+    // a tolerated phase3 entry — surface that conflict here.
+    for (const phase3Type of PHASE3_TOLERATED_BLOCK_TYPES) {
+      expect(declaredTypes.has(phase3Type)).toBe(false)
+    }
+
+    // For each declared legacy type, confirm a payload carrying that
+    // block (and nothing exotic) parses successfully. If the schema
+    // renames or drops a type, our parser's `known` bucket breaks and
+    // this assertion fires with a clear failure point.
+    const minimalEachType: Record<string, Record<string, unknown>> = {
+      text: { type: 'text', content: 'hi' },
+      error: {
+        type: 'error',
+        error_code: 'INTERNAL_ERROR',
+        severity: 'error',
+      },
+      analysis_result: {
+        type: 'analysis_result',
+        summary: 'ok',
+        leading_option_id: 'opt-1',
+      },
+      graph_patch: {
+        type: 'graph_patch',
+        status: 'applied',
+        operation: 'set_factor_value',
+        target_id: 'f1',
+        before: null,
+        after: { value: 1 },
+      },
+      explanation: { type: 'explanation', narrative: 'why', referenced_option_ids: ['opt-1'] },
+      comparison: {
+        type: 'comparison',
+        options: [{ option_id: 'opt-1', label: 'Option 1' }],
+      },
+      flip_analysis: {
+        type: 'flip_analysis',
+        narrative: 'flip',
+        flip_scenarios: [],
+      },
+      draft_graph: {
+        type: 'draft_graph',
+        nodes: [],
+        edges: [],
+        node_count: 0,
+        edge_count: 0,
+      },
+    }
+    const missing: string[] = []
+    for (const decl of declaredTypes) {
+      const minimal = minimalEachType[decl]
+      if (!minimal) {
+        // A new declared type that we don't have a sample for — this is
+        // exactly the drift case the guard catches. Surface it by name.
+        missing.push(decl)
+        continue
+      }
+      const parsed = BlockSchema.safeParse(minimal)
+      if (!parsed.success) {
+        // If our hand-built sample is wrong for a renamed schema, fail
+        // with both the offending type and the zod error so the next
+        // editor knows exactly what changed.
+        throw new Error(
+          `drift: block type "${decl}" no longer accepts the canonical minimal sample. ` +
+            `Update LEGACY_SCHEMA_KNOWN_BLOCK_TYPES and minimalEachType. zod error: ${parsed.error.message}`,
+        )
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `drift: vendored @talchain/schemas declares block type(s) not in the parser mirror: ` +
+          `${missing.join(', ')}. Add them to LEGACY_SCHEMA_KNOWN_BLOCK_TYPES in src/v5/responseParser.ts.`,
+      )
+    }
+  })
+
+  /**
+   * Stronger drift guard: every declared block type must round-trip
+   * through DGAI's `parseV5Response`, not just through zod's
+   * `BlockSchema.safeParse`. The parser's `splitBlocksTolerance` keeps a
+   * separate hand-mirrored set (`LEGACY_SCHEMA_KNOWN_BLOCK_TYPES`); a
+   * type that the vendored schema accepts but the mirror omits would be
+   * misrouted into the `unknown` bucket and hard-fail at runtime even
+   * though the BlockSchema check above passes. This test fires
+   * `parseV5Response` against an OlumiResponse wrapping the minimal
+   * block sample for every declared type, asserting `kind === 'response'`
+   * on each. Catches mirror omissions.
+   */
+  it('round-trips every declared block type through parseV5Response', async () => {
+    const def = (BlockSchema as unknown as { _def: { optionsMap?: Map<string, unknown> } })._def
+    const declaredTypes = [...(def.optionsMap!.keys())]
+    const minimalEachType: Record<string, Record<string, unknown>> = {
+      text: { type: 'text', content: 'hi' },
+      error: { type: 'error', error_code: 'INTERNAL_ERROR', severity: 'error' },
+      analysis_result: {
+        type: 'analysis_result',
+        summary: 'ok',
+        leading_option_id: 'opt-1',
+      },
+      graph_patch: {
+        type: 'graph_patch',
+        status: 'applied',
+        operation: 'set_factor_value',
+        target_id: 'f1',
+        before: null,
+        after: { value: 1 },
+      },
+      explanation: { type: 'explanation', narrative: 'why', referenced_option_ids: ['opt-1'] },
+      comparison: { type: 'comparison', options: [{ option_id: 'opt-1', label: 'Option 1' }] },
+      flip_analysis: { type: 'flip_analysis', narrative: 'flip', flip_scenarios: [] },
+      draft_graph: {
+        type: 'draft_graph',
+        nodes: [],
+        edges: [],
+        node_count: 0,
+        edge_count: 0,
+      },
+    }
+    const baseShell = {
+      response_version: 2,
+      assistant_text: '',
+      suggested_actions: [],
+      insights: [],
+      stage_indicator: 'analyse',
+    } as const
+
+    const misrouted: string[] = []
+    for (const decl of declaredTypes) {
+      const sample = minimalEachType[decl]
+      if (!sample) continue // covered by the previous test's `missing` array
+
+      const payload = { ...baseShell, blocks: [sample] }
+      const result = await parseV5Response(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      if (result.kind !== 'response') {
+        misrouted.push(
+          `${decl} (kind=${result.kind}` +
+            (result.kind === 'parse_error'
+              ? `, failure_kind=${result.parse_failure_kind ?? 'n/a'}, reason="${result.reason}"`
+              : '') +
+            ')',
+        )
+      }
+    }
+    if (misrouted.length > 0) {
+      throw new Error(
+        `drift: parseV5Response did not round-trip declared block type(s) — ` +
+          `the parser's LEGACY_SCHEMA_KNOWN_BLOCK_TYPES is likely missing them. ` +
+          `Offenders: ${misrouted.join('; ')}.`,
+      )
+    }
+  })
+})
+
+describe('parser strictness — unknown and malformed blocks', () => {
+  it('(8) unknown block type inside blocks[] still fails parse with enumerated types', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({
+      type: 'totally_unknown_future_type',
+      payload: { whatever: 1 },
+    })
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('parse_error')
+    if (result.kind !== 'parse_error') throw new Error('unreachable')
+    expect(result.parse_failure_kind).toBe('unknown_block_types')
+    expect(result.unknown_block_types).toEqual(['totally_unknown_future_type'])
+    expect(result.reason).toContain('totally_unknown_future_type')
+    // Original raw response preserved for diagnostics.
+    expect(result.raw).toBeTruthy()
+    expect((result.raw as Record<string, unknown>).blocks).toBeTruthy()
+  })
+
+  it('(9) malformed-known block still fails parse — nested product schemas remain strict', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({ type: 'text' /* required `content` missing */ })
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('parse_error')
+    if (result.kind !== 'parse_error') throw new Error('unreachable')
+    expect(result.parse_failure_kind).toBe('schema_mismatch')
+  })
+})
+
+describe('debug bundle — v5_cee_capture populated on parse failure', () => {
+  it('(10) parse-error envelope flows into v5_cee_capture with parse_ok=false + enumerated types', async () => {
+    // Construct the parse_error envelope exactly as recordResponsePayload
+    // would have stored it under bundle.payloads.cee_response when
+    // parseV5Response hard-fails on an unknown block type.
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({ type: 'totally_unknown_future_type' })
+    const parsed = await parseV5Response(makeResponse(fixture))
+    expect(parsed.kind).toBe('parse_error')
+
+    // Seed the store so the canonical-analysis classifier has the bits it
+    // needs to read alongside the capture.
+    useCanvasStore.setState({
+      results: { status: 'idle' },
+      currentScenarioId: 'scenario-A',
+      v5AnalysisFact: null,
+    } as any)
+
+    const data = makeDebugData({
+      payloads: {
+        cee_request: { kind: 'message', message: 'run' },
+        // Mirror what v5Adapter's recordResponsePayload writes when parse fails.
+        cee_response: parsed as unknown as Record<string, unknown>,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    expect(bundle.v5_canonical_analysis).toBeDefined()
+    const diag = bundle.v5_canonical_analysis!
+    expect(diag.v5_cee_capture).not.toBeNull()
+    const capture = diag.v5_cee_capture!
+
+    expect(capture.parse_ok).toBe(false)
+    expect(capture.response_present).toBe(true)
+    expect(capture.raw_response_present).toBe(true)
+    expect(capture.parse_failure_kind).toBe('unknown_block_types')
+    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
+    expect(capture.parse_error ?? '').toContain('totally_unknown_future_type')
+    // Top-level keys read from the raw envelope, not the parse_error wrapper.
+    expect(capture.response_top_level_keys).toEqual(
+      expect.arrayContaining(['response_version', 'assistant_text', 'blocks']),
+    )
+    // Classifier maps parse_ok:false to debug_capture_status:'parse_failed'.
+    expect(diag.debug_capture_status).toBe('parse_failed')
+  })
+
+  it('end-to-end: callV5Turn → trace-store redactor → bundle preserves Phase 3 fields', async () => {
+    // P1 regression — the parser stashes Phase 3 blocks on a
+    // NON-ENUMERABLE sidecar so they don't leak into JSON.stringify. The
+    // trace store's redactor uses Object.keys (skips non-enumerable), so
+    // a literal "store the parsed response" would lose the sidecar before
+    // the bundle reads it. v5Adapter promotes the sidecar to an
+    // enumerable property on a shallow clone for the trace body — this
+    // test proves the clone survives the redactor and the bundle still
+    // populates phase3_blocks_tolerated_count + phase3_block_types.
+
+    // Clear any prior trace entries from the shared zustand store.
+    usePayloadTraceStore.setState({ payloads: [], selectedId: null } as any)
+
+    const fixture = ceeFixture()
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const result = await callV5Turn(
+      { kind: 'message', message: 'run analysis' } as never,
+      { fetchImpl },
+    )
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+
+    // Pin the intended split between runtime contract safety and
+    // diagnostic exportability:
+    //   - The runtime `result.response` keeps the sidecar NON-ENUMERABLE
+    //     so JSON.stringify, Object.keys, and ordinary consumers don't
+    //     see `__additive__` leaking onto the OlumiResponse surface.
+    //   - The trace clone (what v5Adapter records into the trace store)
+    //     promotes the sidecar to an ENUMERABLE property so the redactor
+    //     (Object.keys-based) preserves it for the debug bundle.
+    const runtimeResponse = result.response as Record<string, unknown>
+    expect(Object.keys(runtimeResponse)).not.toContain(ADDITIVE_EXTENSIONS_KEY)
+    // Bracket access still reaches the non-enumerable sidecar.
+    expect(
+      (runtimeResponse as Record<string | symbol, unknown>)[ADDITIVE_EXTENSIONS_KEY],
+    ).toBeDefined()
+
+    // Reach into the trace store to pull what the bundle assembler will
+    // read from in production (post-redaction).
+    const traced = usePayloadTraceStore.getState().payloads
+    expect(traced).toHaveLength(1)
+    const tracedBody = traced[0].response?.body as Record<string, unknown> | undefined
+    expect(tracedBody).toBeDefined()
+
+    // Sidecar must be present and ENUMERABLE on the traced body
+    // (post-redaction) — the diagnostic split with the runtime object.
+    const tracedKeys = Object.keys(tracedBody!)
+    expect(tracedKeys).toContain(ADDITIVE_EXTENSIONS_KEY)
+    const tracedSidecar = tracedBody![ADDITIVE_EXTENSIONS_KEY] as Record<string, unknown>
+    expect(tracedSidecar).toBeDefined()
+    expect(Array.isArray(tracedSidecar[PHASE3_SIDECAR_BLOCKS_KEY])).toBe(true)
+    const tracedPhase3 = tracedSidecar[PHASE3_SIDECAR_BLOCKS_KEY] as Array<Record<string, unknown>>
+    expect(tracedPhase3).toHaveLength(2)
+    expect(tracedPhase3.map((b) => b.type).sort()).toEqual(['coaching', 'review_card'])
+
+    // Now drive buildDebugBundleAsync with this real traced body — proves
+    // the diagnostic fields populate end-to-end through redaction.
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        report: { schema: 'report.v1' } as any,
+        hash: 'hash-e2e',
+      },
+      currentScenarioId: 'scenario-A',
+      v5AnalysisFact: {
+        scenarioId: 'scenario-A',
+        analysisHash: 'hash-e2e',
+        hasRunAnalysisFact: true,
+        freshness: 'fresh',
+        freshnessReason: null,
+        rawBlocks: [],
+        writtenAt: Date.now(),
+      } satisfies V5AnalysisFactState,
+    } as any)
+
+    const data = makeDebugData({
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 200,
+          success: true,
+          duration_ms: 312,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
+      payloads: {
+        cee_request: traced[0].request?.body as Record<string, unknown> | null,
+        cee_response: tracedBody as Record<string, unknown>,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
+    expect(capture.parse_ok).toBe(true)
+    expect(capture.has_additive_extensions).toBe(true)
+    expect(capture.phase3_blocks_tolerated_count).toBe(2)
+    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
+    // Honest semantics on success: the trace stores a parsed clone, NOT
+    // the literal wire JSON. response_top_level_keys must still reflect
+    // the original CEE root shape (via the parser's sidecar metadata).
+    expect(capture.raw_response_present).toBe(false)
+    expect(capture.response_top_level_keys).not.toContain('__additive__')
+    expect(capture.response_top_level_keys).toEqual(
+      expect.arrayContaining([
+        'analysis_freshness',
+        'has_run_analysis_fact',
+        'freshness_reason',
+      ]),
+    )
+  })
+
+  it('parse-success envelope populates v5_cee_capture with phase3 counts', async () => {
+    const parsed = await parseV5Response(makeResponse(ceeFixture()))
+    expect(parsed.kind).toBe('response')
+    if (parsed.kind !== 'response') throw new Error('unreachable')
+
+    // Seed the store with the matching fact + report so the diagnostic
+    // shows the successful canonical state.
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        report: { schema: 'report.v1' } as any,
+        hash: 'hash-success',
+      },
+      currentScenarioId: 'scenario-A',
+      v5AnalysisFact: {
+        scenarioId: 'scenario-A',
+        analysisHash: 'hash-success',
+        hasRunAnalysisFact: true,
+        freshness: 'fresh',
+        freshnessReason: null,
+        rawBlocks: [],
+        writtenAt: Date.now(),
+      } satisfies V5AnalysisFactState,
+    } as any)
+
+    const data = makeDebugData({
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 200,
+          success: true,
+          duration_ms: 312,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
+      payloads: {
+        cee_request: { kind: 'message', message: 'run' },
+        cee_response: parsed.response as unknown as Record<string, unknown>,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    const diag = bundle.v5_canonical_analysis!
+    expect(diag.v5_cee_capture).not.toBeNull()
+    const capture = diag.v5_cee_capture!
+
+    expect(capture.parse_ok).toBe(true)
+    expect(capture.parse_error).toBeNull()
+    expect(capture.parse_failure_kind).toBeNull()
+    // Success path stores a parsed clone, not the verbatim wire JSON, so
+    // raw_response_present must be honest about that.
+    expect(capture.raw_response_present).toBe(false)
+    // But response_top_level_keys must STILL reflect the ORIGINAL CEE
+    // root shape, sourced from the parser's sidecar metadata. The fixture
+    // emits analysis_freshness / has_run_analysis_fact / freshness_reason
+    // at the root; the parsed clone demotes them into __additive__, but
+    // the original-keys stash preserves the wire view for diagnostics.
+    expect(capture.response_top_level_keys).toEqual(
+      [
+        'analysis_freshness',
+        'assistant_text',
+        'blocks',
+        'freshness_reason',
+        'has_run_analysis_fact',
+        'insights',
+        'response_version',
+        'stage_indicator',
+        'suggested_actions',
+      ].sort(),
+    )
+    // __additive__ must NOT leak into response_top_level_keys.
+    expect(capture.response_top_level_keys).not.toContain('__additive__')
+    expect(capture.phase3_blocks_tolerated_count).toBe(2)
+    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
+    expect(diag.debug_capture_status).toBe('complete')
+  })
+})

--- a/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
+++ b/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
@@ -443,6 +443,13 @@ describe('callV5Turn runtime/traced sidecar split', () => {
     expect(
       (runtimeResponse as Record<string | symbol, unknown>)[ADDITIVE_EXTENSIONS_KEY],
     ).toBeDefined()
+    // JSON.stringify is the canonical wire-serialisation path consumers
+    // hit (egress validation logs, prompt-cache fingerprints, network
+    // re-emit). The non-enumerable sidecar MUST NOT leak through it.
+    const stringified = JSON.stringify(result.response)
+    expect(stringified).not.toContain(ADDITIVE_EXTENSIONS_KEY)
+    expect(stringified).not.toContain('phase3_blocks_from_blocks_array')
+    expect(stringified).not.toContain('__original_top_level_keys__')
 
     // Trace clone: sidecar is ENUMERABLE so the trace store's
     // Object.keys-based redactor preserves it for the debug bundle.

--- a/src/v5/__tests__/responseParser.additiveTolerance.spec.ts
+++ b/src/v5/__tests__/responseParser.additiveTolerance.spec.ts
@@ -60,6 +60,11 @@ describe('parseV5Response additive top-level tolerance', () => {
     }
     const result = await parseV5Response(makeResponse(payload))
     expect(result.kind).toBe('parse_error')
+    if (result.kind !== 'parse_error') throw new Error('unreachable')
+    // Phase 3 fix: every parse_error now carries an explicit failure kind so
+    // the debug bundle can distinguish a malformed-known block from an
+    // unknown-type or non-JSON failure.
+    expect(result.parse_failure_kind).toBe('schema_mismatch')
   })
 
   it('still fails parse when a known top-level field is the wrong type', async () => {
@@ -69,6 +74,8 @@ describe('parseV5Response additive top-level tolerance', () => {
     }
     const result = await parseV5Response(makeResponse(payload))
     expect(result.kind).toBe('parse_error')
+    if (result.kind !== 'parse_error') throw new Error('unreachable')
+    expect(result.parse_failure_kind).toBe('schema_mismatch')
   })
 
   it('sidecar is frozen and non-enumerable', async () => {

--- a/src/v5/extractPhase3FromV5Response.ts
+++ b/src/v5/extractPhase3FromV5Response.ts
@@ -1,13 +1,21 @@
 /**
- * extractPhase3FromV5Response — read Phase 3 coaching/review/evidence content
- * out of a V5 OlumiResponse without losing fidelity.
+ * extractPhase3FromV5Response — read Phase 3 coaching / review / evidence /
+ * exercise content out of a V5 OlumiResponse without losing fidelity.
  *
- * CEE V5 Phase 3A may carry coaching content in one of three places:
- *   1. The additive sidecar attached by responseParser (ADDITIVE_EXTENSIONS_KEY).
- *   2. `analysis_ready` (declared as passthrough in the V5 schema).
- *   3. The `analysis_result` block's `enrichment` record (passthrough).
+ * CEE V5 Phase 3A may carry coaching content in one of four places:
+ *   1. The additive sidecar attached by responseParser, at the sidecar
+ *      root (conventional `phase3_blocks`, per-type arrays, or single
+ *      `review_card`). Source: 'sidecar'.
+ *   2. The same sidecar's `phase3_blocks_from_blocks_array` slot — Phase 3
+ *      blocks the parser lifted out of `blocks[]` per the v1.3 contract,
+ *      stashed there to keep `OlumiResponse.blocks` strict-schema-clean.
+ *      Source: 'sidecar_blocks_array'.
+ *   3. `analysis_ready` (declared as passthrough in the V5 schema).
+ *      Source: 'analysis_ready'.
+ *   4. The `analysis_result` block's `enrichment` record (passthrough).
+ *      Source: 'enrichment'.
  *
- * This extractor harvests Phase 3 surfaces from all three and returns:
+ * This extractor harvests Phase 3 surfaces from all four and returns:
  *   - `rawBlocks`: the original block payloads, preserved verbatim so
  *     downstream consumers can keep `freshness`, `action_intent`,
  *     `priority_rank`, `target_refs`, `graph_hash_at_generation`, etc.

--- a/src/v5/extractPhase3FromV5Response.ts
+++ b/src/v5/extractPhase3FromV5Response.ts
@@ -29,11 +29,15 @@
  */
 import type { OlumiResponse } from '@talchain/schemas/boundary'
 
-import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from './responseParser'
+import {
+  ADDITIVE_EXTENSIONS_KEY,
+  PHASE3_SIDECAR_BLOCKS_KEY,
+  type OlumiResponseWithExtensions,
+} from './responseParser'
 
 // ─── Types ─────────────────────────────────────────────────────────────
 
-export type Phase3BlockType = 'coaching' | 'review_card' | 'evidence'
+export type Phase3BlockType = 'coaching' | 'review_card' | 'evidence' | 'exercise'
 
 export type AnalysisFreshness = 'fresh' | 'stale' | 'unknown' | 'none'
 
@@ -47,7 +51,7 @@ export interface Phase3RawBlock {
   /** Stable id when CEE provided one; falls back to a derived id otherwise. */
   id: string
   /** Source location, useful for diagnostics. */
-  source: 'sidecar' | 'analysis_ready' | 'enrichment'
+  source: 'sidecar' | 'analysis_ready' | 'enrichment' | 'sidecar_blocks_array'
 }
 
 /** Subset shape derived from a Phase 3 block for the legacy GuidanceItem
@@ -96,7 +100,12 @@ function safeBoolean(v: unknown): boolean | undefined {
   return typeof v === 'boolean' ? v : undefined
 }
 
-const PHASE3_TYPES: ReadonlySet<Phase3BlockType> = new Set(['coaching', 'review_card', 'evidence'])
+const PHASE3_TYPES: ReadonlySet<Phase3BlockType> = new Set([
+  'coaching',
+  'review_card',
+  'evidence',
+  'exercise',
+])
 
 function isPhase3BlockType(v: unknown): v is Phase3BlockType {
   return typeof v === 'string' && PHASE3_TYPES.has(v as Phase3BlockType)
@@ -306,6 +315,28 @@ export function extractPhase3FromV5Response(
   const sidecar = (response as OlumiResponseWithExtensions)[ADDITIVE_EXTENSIONS_KEY]
   if (sidecar && isPlainObject(sidecar)) {
     collectFromContainer(sidecar, 'sidecar', rawBlocks, seenIds, 'sidecar')
+
+    // 1b. Phase 3 blocks pulled out of `blocks[]` by responseParser are
+    // stashed under PHASE3_SIDECAR_BLOCKS_KEY as a flat array. Each entry is
+    // a verbatim block payload with a string `type` already validated
+    // against the Phase 3 whitelist. Preserve the original ordering so
+    // downstream consumers can rebuild the block sequence.
+    const fromBlocksArray = sidecar[PHASE3_SIDECAR_BLOCKS_KEY]
+    if (Array.isArray(fromBlocksArray)) {
+      for (let i = 0; i < fromBlocksArray.length; i++) {
+        const entry = fromBlocksArray[i]
+        if (!isPlainObject(entry)) continue
+        const type = entry.type
+        if (!isPhase3BlockType(type)) continue
+        const id =
+          safeString(entry.block_id) ??
+          safeString(entry.id) ??
+          `sidecar_blocks_array:${type}[${i}]`
+        if (seenIds.has(id)) continue
+        seenIds.add(id)
+        rawBlocks.push({ type, raw: entry, id, source: 'sidecar_blocks_array' })
+      }
+    }
   }
 
   // 2. analysis_ready passthrough.

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -63,16 +63,24 @@ export const ORIGINAL_TOP_LEVEL_KEYS_KEY = '__original_top_level_keys__' as cons
  * Whitelist of v1.3 Phase 3 block types tolerated inside `blocks[]`. Any
  * other unknown `type` discriminator inside `blocks[]` still hard-fails the
  * parse so accidental schema drift is detected.
+ *
+ * Exported as `ReadonlySet` to prevent accidental mutation of the
+ * tolerated-type allowlist at consumer boundaries (.add/.delete are not
+ * available on the public type). The underlying Set is constructed from a
+ * literal tuple so the union member type can still be derived.
  */
-export const PHASE3_TOLERATED_BLOCK_TYPES = new Set([
+export type Phase3ToleratedBlockType =
+  | 'review_card'
+  | 'coaching'
+  | 'evidence'
+  | 'exercise';
+
+export const PHASE3_TOLERATED_BLOCK_TYPES: ReadonlySet<Phase3ToleratedBlockType> = new Set<Phase3ToleratedBlockType>([
   'review_card',
   'coaching',
   'evidence',
   'exercise',
-] as const);
-
-export type Phase3ToleratedBlockType =
-  typeof PHASE3_TOLERATED_BLOCK_TYPES extends Set<infer T> ? T : never;
+]);
 
 /**
  * OlumiResponse extended with the additive sidecar. Consumers reading

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -16,13 +16,21 @@
  *
  * Additive top-level tolerance (v5-canonical-analysis brief, correction 7):
  * - OlumiResponseSchema is .strict() so unknown top-level keys would fail
- *   parse. CEE may emit additive top-level fields (e.g. guidance_items,
- *   phase 3 coaching/review_card/evidence blocks, analysis_freshness)
- *   ahead of a schema-package bump. To tolerate these without losing them,
- *   unknown top-level keys are split off into an `additiveExtensions` map
- *   BEFORE strict validation, then attached to the parsed result via a
- *   non-enumerable sidecar (`__additive__`). Nested schemas remain strict —
- *   only the response root is widened.
+ *   parse. Unknown top-level keys are split off into an `additiveExtensions`
+ *   map BEFORE strict validation, then attached to the parsed result via a
+ *   non-enumerable sidecar (`__additive__`).
+ *
+ * v1.3 Phase 3 blocks-array tolerance (Phase 3 fix, 2026-05-18):
+ * - CEE emits the v1.3 Phase 3 block types `review_card | coaching |
+ *   evidence | exercise` INSIDE `blocks[]` per the frozen contract. The
+ *   vendored @talchain/schemas (0.8.1) does not yet include them in the
+ *   `blocks[]` discriminated union, so a literal pass-through fails strict
+ *   validation. We tolerate ONLY this canonical whitelist by splitting
+ *   `blocks[]` into known-to-schema, phase3-tolerated, and truly-unknown
+ *   before validation. Known blocks go to strict validation; phase3 blocks
+ *   are attached to the sidecar under `phase3_blocks_from_blocks_array`;
+ *   truly-unknown types still produce a `parse_error` whose `reason`
+ *   enumerates the offending types. Nested product schemas remain strict.
  */
 import {
   OlumiResponseSchema,
@@ -33,6 +41,38 @@ import {
 
 /** Sidecar key used to carry additive extensions on a parsed OlumiResponse. */
 export const ADDITIVE_EXTENSIONS_KEY = '__additive__' as const;
+
+/**
+ * Sidecar key inside the additive-extensions map under which v1.3 Phase 3
+ * blocks pulled out of `blocks[]` are stashed. Consumers (e.g.
+ * extractPhase3FromV5Response) read this slot directly.
+ */
+export const PHASE3_SIDECAR_BLOCKS_KEY = 'phase3_blocks_from_blocks_array' as const;
+
+/**
+ * Sidecar key carrying the pre-validation top-level key list of the raw
+ * CEE body. Recorded only when a sidecar is being emitted (i.e. on success
+ * paths where additive top-level keys or Phase 3 blocks were tolerated).
+ * Diagnostic-only — lets the debug bundle report the ORIGINAL CEE root
+ * shape instead of the parsed-clone shape (which has `__additive__`
+ * promoted as an enumerable key in the trace store).
+ */
+export const ORIGINAL_TOP_LEVEL_KEYS_KEY = '__original_top_level_keys__' as const;
+
+/**
+ * Whitelist of v1.3 Phase 3 block types tolerated inside `blocks[]`. Any
+ * other unknown `type` discriminator inside `blocks[]` still hard-fails the
+ * parse so accidental schema drift is detected.
+ */
+export const PHASE3_TOLERATED_BLOCK_TYPES = new Set([
+  'review_card',
+  'coaching',
+  'evidence',
+  'exercise',
+] as const);
+
+export type Phase3ToleratedBlockType =
+  typeof PHASE3_TOLERATED_BLOCK_TYPES extends Set<infer T> ? T : never;
 
 /**
  * OlumiResponse extended with the additive sidecar. Consumers reading
@@ -79,6 +119,77 @@ function splitAdditiveExtensions(raw: unknown): {
     }
   }
   return { known, extensions };
+}
+
+/**
+ * Block types declared by the strict @talchain/schemas (0.8.1) discriminated
+ * union for `blocks[]`. Source: dist/boundary/blocks.js inside the vendored
+ * tarball. Kept as a DGAI-side mirror so the parser can classify entries
+ * BEFORE strict validation and give a precise diagnostic on truly unknown
+ * types. If the schema package adds a block type, add it here too; a missed
+ * type produces a clear parse_error (the offender is named in
+ * `unknown_block_types`), which the tests will catch.
+ */
+const LEGACY_SCHEMA_KNOWN_BLOCK_TYPES: ReadonlySet<string> = new Set([
+  'text',
+  'error',
+  'analysis_result',
+  'graph_patch',
+  'explanation',
+  'comparison',
+  'flip_analysis',
+  'draft_graph',
+]);
+
+/**
+ * Classify the entries of `blocks[]` against the v1.3 contract:
+ *   - `known`: entries with a `type` in the legacy schema. Forwarded to
+ *     strict validation as-is.
+ *   - `phase3`: entries with a `type` in PHASE3_TOLERATED_BLOCK_TYPES.
+ *     Preserved verbatim and stashed in the sidecar.
+ *   - `unknown`: shape-broken entries (non-object, missing `type`, or any
+ *     `type` neither in the legacy schema nor in the Phase 3 whitelist).
+ *     The parser hard-fails when this bucket is non-empty and surfaces
+ *     offending types via `unknown_block_types` so the debug bundle can
+ *     name them.
+ *
+ * Original input is NOT mutated. The returned arrays are new arrays of the
+ * same entries (referential to the original block objects).
+ */
+function splitBlocksTolerance(blocks: unknown[]): {
+  known: unknown[];
+  phase3: unknown[];
+  unknown: unknown[];
+  unknownTypes: string[];
+} {
+  const known: unknown[] = [];
+  const phase3: unknown[] = [];
+  const unknown: unknown[] = [];
+  const unknownTypes: string[] = [];
+  for (const entry of blocks) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      unknown.push(entry);
+      unknownTypes.push(typeof entry);
+      continue;
+    }
+    const type = (entry as { type?: unknown }).type;
+    if (typeof type !== 'string') {
+      unknown.push(entry);
+      unknownTypes.push('<missing-type>');
+      continue;
+    }
+    if (PHASE3_TOLERATED_BLOCK_TYPES.has(type as Phase3ToleratedBlockType)) {
+      phase3.push(entry);
+      continue;
+    }
+    if (LEGACY_SCHEMA_KNOWN_BLOCK_TYPES.has(type)) {
+      known.push(entry);
+      continue;
+    }
+    unknown.push(entry);
+    unknownTypes.push(type);
+  }
+  return { known, phase3, unknown, unknownTypes };
 }
 
 // ---------------------------------------------------------------------------
@@ -177,6 +288,17 @@ function truncateBody(text: string, maxLen = 500): string {
 // Result types
 // ---------------------------------------------------------------------------
 
+/**
+ * Why a parse_error fired. Surfaced verbatim in the debug bundle so a
+ * reader can distinguish a transport-level non-JSON body from a schema
+ * mismatch from an unknown block type from a malformed-known nested shape.
+ */
+export type ParseFailureKind =
+  | 'non_json'
+  | 'non_ok_non_boundary'
+  | 'schema_mismatch'
+  | 'unknown_block_types'
+
 export type V5ParseResult =
   | { kind: 'response'; response: OlumiResponse }
   | { kind: 'boundary_error'; error: BoundaryError }
@@ -187,6 +309,10 @@ export type V5ParseResult =
       raw?: unknown
       source?: ErrorSource
       diagnosticHeaders?: DiagnosticHeaders
+      /** Why parsing failed; populated for all parse_error branches. */
+      parse_failure_kind?: ParseFailureKind
+      /** Populated when parse_failure_kind === 'unknown_block_types'. */
+      unknown_block_types?: string[]
     };
 
 // ---------------------------------------------------------------------------
@@ -208,6 +334,7 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
       http_status: res.status,
       source: 'unknown',
       diagnosticHeaders: captureDiagnosticHeaders(res),
+      parse_failure_kind: 'non_json',
     };
   }
 
@@ -224,6 +351,7 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
       raw: truncateBody(text),
       source,
       diagnosticHeaders: captureDiagnosticHeaders(res),
+      parse_failure_kind: 'non_json',
     };
   }
 
@@ -242,35 +370,93 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
       raw,
       source,
       diagnosticHeaders: captureDiagnosticHeaders(res),
+      parse_failure_kind: 'non_ok_non_boundary',
     };
   }
 
   // 2xx path: must parse as OlumiResponse.
-  // Tolerance step: split additive top-level keys off the known surface so
-  // strict validation only sees the declared shape. Nested schemas remain
-  // strict (unknown keys inside blocks / suggested_actions / etc. still fail).
+  // Tolerance step 1: split additive top-level keys off the known surface
+  // so strict validation only sees the declared shape.
   const { known, extensions } = splitAdditiveExtensions(raw);
-  const parsed = OlumiResponseSchema.safeParse(known);
-  if (parsed.success) {
-    if (Object.keys(extensions).length === 0) {
-      return { kind: 'response', response: parsed.data };
+
+  // Tolerance step 2 (Phase 3 blocks-array fix): if `blocks` is an array,
+  // classify each entry. Schema-known entries continue to strict validation;
+  // Phase 3 whitelist entries get stashed in the sidecar; truly unknown
+  // entries trigger a hard parse_error that names the offending types.
+  let phase3Blocks: readonly unknown[] = []
+  let knownForValidation: unknown = known
+  if (
+    known !== null &&
+    typeof known === 'object' &&
+    !Array.isArray(known) &&
+    Array.isArray((known as Record<string, unknown>).blocks)
+  ) {
+    const split = splitBlocksTolerance(
+      (known as Record<string, unknown>).blocks as unknown[],
+    )
+    if (split.unknown.length > 0) {
+      // Hard-fail when truly unknown block types appear. The raw response
+      // is preserved verbatim so reviewers can inspect the offending
+      // payload via the debug bundle.
+      return {
+        kind: 'parse_error',
+        reason: `unknown block type(s) in blocks[]: ${split.unknownTypes.join(', ')}`,
+        http_status: res.status,
+        raw,
+        diagnosticHeaders: captureDiagnosticHeaders(res),
+        parse_failure_kind: 'unknown_block_types',
+        unknown_block_types: split.unknownTypes,
+      }
     }
-    // Attach extensions via a non-enumerable, readonly property. Consumers
-    // who care opt in via the ADDITIVE_EXTENSIONS_KEY symbol; everyone else
-    // sees the unchanged OlumiResponse shape.
-    const withExt: OlumiResponseWithExtensions = parsed.data;
+    // Replace blocks for validation with the legacy-known slice, leaving
+    // the raw input untouched. We build a shallow clone of the known
+    // surface (which is itself already a shallow clone of raw produced by
+    // splitAdditiveExtensions).
+    knownForValidation = {
+      ...(known as Record<string, unknown>),
+      blocks: split.known,
+    }
+    phase3Blocks = split.phase3
+  }
+
+  const parsed = OlumiResponseSchema.safeParse(knownForValidation)
+  if (parsed.success) {
+    const hasTopLevelExt = Object.keys(extensions).length > 0
+    const hasPhase3 = phase3Blocks.length > 0
+    if (!hasTopLevelExt && !hasPhase3) {
+      return { kind: 'response', response: parsed.data }
+    }
+    // Compose the sidecar payload. Top-level additive keys keep their
+    // existing surface. Phase 3 blocks pulled out of blocks[] land under a
+    // distinct key so consumers can read them without conflating with
+    // top-level additive keys. The pre-validation top-level keys are
+    // stashed too, so the debug bundle can faithfully report the ORIGINAL
+    // CEE root shape (the parsed clone surfaces `__additive__` and drops
+    // the demoted top-level extras, so its keys list is misleading).
+    const sidecar: Record<string, unknown> = { ...extensions }
+    if (hasPhase3) {
+      sidecar[PHASE3_SIDECAR_BLOCKS_KEY] = Object.freeze(phase3Blocks.slice())
+    }
+    if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
+      sidecar[ORIGINAL_TOP_LEVEL_KEYS_KEY] = Object.freeze(
+        Object.keys(raw as Record<string, unknown>).sort(),
+      )
+    }
+    const withExt: OlumiResponseWithExtensions = parsed.data
     Object.defineProperty(withExt, ADDITIVE_EXTENSIONS_KEY, {
-      value: Object.freeze(extensions),
+      value: Object.freeze(sidecar),
       enumerable: false,
       writable: false,
       configurable: false,
-    });
-    return { kind: 'response', response: withExt };
+    })
+    return { kind: 'response', response: withExt }
   }
   return {
     kind: 'parse_error',
     reason: 'body did not match OlumiResponse schema',
     http_status: res.status,
     raw,
+    diagnosticHeaders: captureDiagnosticHeaders(res),
+    parse_failure_kind: 'schema_mismatch',
   };
 }

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -155,11 +155,11 @@ const LEGACY_SCHEMA_KNOWN_BLOCK_TYPES: ReadonlySet<string> = new Set([
  *     strict validation as-is.
  *   - `phase3`: entries with a `type` in PHASE3_TOLERATED_BLOCK_TYPES.
  *     Preserved verbatim and stashed in the sidecar.
- *   - `unknown`: shape-broken entries (non-object, missing `type`, or any
- *     `type` neither in the legacy schema nor in the Phase 3 whitelist).
- *     The parser hard-fails when this bucket is non-empty and surfaces
- *     offending types via `unknown_block_types` so the debug bundle can
- *     name them.
+ *   - `unknownTypes`: a deduped + sorted list of offending `type` labels
+ *     (or shape descriptors like `'array'` / `'<missing-type>'`) for any
+ *     entry that is neither legacy-known nor in the Phase 3 whitelist.
+ *     The parser hard-fails when this list is non-empty and surfaces it
+ *     verbatim via `unknown_block_types` for the debug bundle.
  *
  * Original input is NOT mutated. The returned arrays are new arrays of the
  * same entries (referential to the original block objects).
@@ -167,32 +167,26 @@ const LEGACY_SCHEMA_KNOWN_BLOCK_TYPES: ReadonlySet<string> = new Set([
 function splitBlocksTolerance(blocks: unknown[]): {
   known: unknown[];
   phase3: unknown[];
-  unknown: unknown[];
   unknownTypes: string[];
 } {
   const known: unknown[] = [];
   const phase3: unknown[] = [];
-  const unknown: unknown[] = [];
   const unknownTypeSet = new Set<string>();
   for (const entry of blocks) {
     if (entry === null || entry === undefined) {
-      unknown.push(entry);
       unknownTypeSet.add(entry === null ? 'null' : 'undefined');
       continue;
     }
     if (Array.isArray(entry)) {
-      unknown.push(entry);
       unknownTypeSet.add('array');
       continue;
     }
     if (typeof entry !== 'object') {
-      unknown.push(entry);
       unknownTypeSet.add(typeof entry);
       continue;
     }
     const type = (entry as { type?: unknown }).type;
     if (typeof type !== 'string') {
-      unknown.push(entry);
       unknownTypeSet.add('<missing-type>');
       continue;
     }
@@ -204,14 +198,13 @@ function splitBlocksTolerance(blocks: unknown[]): {
       known.push(entry);
       continue;
     }
-    unknown.push(entry);
     unknownTypeSet.add(type);
   }
   // Dedupe + sort so multiple unknown blocks of the same type don't bloat
   // the parse_error reason / debug bundle, and the ordering is stable for
   // reviewers diffing two captures.
   const unknownTypes = [...unknownTypeSet].sort();
-  return { known, phase3, unknown, unknownTypes };
+  return { known, phase3, unknownTypes };
 }
 
 // ---------------------------------------------------------------------------
@@ -321,6 +314,17 @@ export type ParseFailureKind =
   | 'schema_mismatch'
   | 'unknown_block_types'
 
+/**
+ * Literal value of `V5ParseResult['kind']` for the parse-error branch.
+ * Exported so the debug bundle (and any other consumer that introspects
+ * a captured response body) discriminates the envelope by this constant
+ * rather than a hand-rolled string literal — keeps the wire-shape contract
+ * centralised. If the kind label ever changes here, every comparison
+ * follows automatically.
+ */
+export const V5_PARSE_ERROR_KIND = 'parse_error' as const
+export type V5ParseErrorKind = typeof V5_PARSE_ERROR_KIND
+
 export type V5ParseResult =
   | { kind: 'response'; response: OlumiResponse }
   | { kind: 'boundary_error'; error: BoundaryError }
@@ -416,7 +420,7 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
     const split = splitBlocksTolerance(
       (known as Record<string, unknown>).blocks as unknown[],
     )
-    if (split.unknown.length > 0) {
+    if (split.unknownTypes.length > 0) {
       // Hard-fail when truly unknown block types appear. The raw response
       // is preserved verbatim so reviewers can inspect the offending
       // payload via the debug bundle.

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -165,17 +165,27 @@ function splitBlocksTolerance(blocks: unknown[]): {
   const known: unknown[] = [];
   const phase3: unknown[] = [];
   const unknown: unknown[] = [];
-  const unknownTypes: string[] = [];
+  const unknownTypeSet = new Set<string>();
   for (const entry of blocks) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    if (entry === null || entry === undefined) {
       unknown.push(entry);
-      unknownTypes.push(typeof entry);
+      unknownTypeSet.add(entry === null ? 'null' : 'undefined');
+      continue;
+    }
+    if (Array.isArray(entry)) {
+      unknown.push(entry);
+      unknownTypeSet.add('array');
+      continue;
+    }
+    if (typeof entry !== 'object') {
+      unknown.push(entry);
+      unknownTypeSet.add(typeof entry);
       continue;
     }
     const type = (entry as { type?: unknown }).type;
     if (typeof type !== 'string') {
       unknown.push(entry);
-      unknownTypes.push('<missing-type>');
+      unknownTypeSet.add('<missing-type>');
       continue;
     }
     if (PHASE3_TOLERATED_BLOCK_TYPES.has(type as Phase3ToleratedBlockType)) {
@@ -187,8 +197,12 @@ function splitBlocksTolerance(blocks: unknown[]): {
       continue;
     }
     unknown.push(entry);
-    unknownTypes.push(type);
+    unknownTypeSet.add(type);
   }
+  // Dedupe + sort so multiple unknown blocks of the same type don't bloat
+  // the parse_error reason / debug bundle, and the ordering is stable for
+  // reviewers diffing two captures.
+  const unknownTypes = [...unknownTypeSet].sort();
   return { known, phase3, unknown, unknownTypes };
 }
 

--- a/src/v5/v5Adapter.ts
+++ b/src/v5/v5Adapter.ts
@@ -18,7 +18,12 @@
 import type { OrchestratorTurnPayload } from '@talchain/schemas/boundary';
 
 import { recordRequestPayload, recordResponsePayload } from '../lib/payload-trace-store';
-import { parseV5Response, type V5ParseResult } from './responseParser';
+import {
+  ADDITIVE_EXTENSIONS_KEY,
+  parseV5Response,
+  type OlumiResponseWithExtensions,
+  type V5ParseResult,
+} from './responseParser';
 
 export type V5CallResult = V5ParseResult;
 
@@ -138,11 +143,34 @@ export async function callV5Turn(
   }
 
   const parsed = await parseV5Response(res);
+
+  // Build a trace-safe diagnostic body.
+  //
+  // The parser attaches its additive-extensions sidecar (top-level keys
+  // outside the strict schema + v1.3 Phase 3 blocks tolerated out of
+  // `blocks[]`) as a NON-ENUMERABLE property so it stays invisible to
+  // JSON.stringify and normal enumeration. The diagnostic trace store
+  // redacts via Object.keys (src/utils/payloadRedaction.ts:247), which
+  // SKIPS non-enumerable properties — dropping the sidecar before the
+  // debug bundle can read it. Promote the sidecar to an ENUMERABLE
+  // property on a shallow clone so it survives redaction. The runtime
+  // `parsed.response` object stays untouched (its sidecar remains
+  // non-enumerable for non-diagnostic consumers).
+  let traceBody: unknown
+  if (parsed.kind === 'response') {
+    const additive = (parsed.response as OlumiResponseWithExtensions)[ADDITIVE_EXTENSIONS_KEY]
+    traceBody = additive
+      ? { ...parsed.response, [ADDITIVE_EXTENSIONS_KEY]: additive }
+      : parsed.response
+  } else {
+    traceBody = parsed
+  }
+
   recordResponsePayload({
     id: requestId,
     status: res.status,
     headers: Object.fromEntries(res.headers.entries()),
-    body: parsed.kind === 'response' ? parsed.response : parsed,
+    body: traceBody,
     duration: Date.now() - requestedAt,
   });
   return parsed;


### PR DESCRIPTION
## Summary

- **Parser tolerance for v1.3 Phase 3 block types.** CEE emits `review_card | coaching | evidence | exercise` inside `blocks[]` per the frozen v1.3 contract, but the vendored `@talchain/schemas@0.8.1` strict discriminated union does not yet include them. Before this PR, every canonical-V5 turn hard-failed with `parse_error`, `applyV5State` was skipped, `v5AnalysisFact` was never written, and the debug bundle reported `debug_capture_status: cee_capture_missing` despite a successful 200 OK. The parser now whitelist-tolerates exactly the four canonical Phase 3 types via a pre-validation split of `blocks[]`; legacy-known types still flow through strict zod, Phase 3 entries are stashed verbatim on a sidecar, and truly-unknown types hard-fail with `parse_failure_kind: 'unknown_block_types'` plus the offenders enumerated in `unknown_block_types[]`.
- **Sidecar survives the trace redactor.** The parser's `__additive__` sidecar is intentionally non-enumerable for runtime contract safety (JSON.stringify, ordinary `Object.keys` consumers). The trace store's redactor uses `Object.keys`, so a literal "store the parsed response" lost the sidecar before the bundle could read it. `v5Adapter` now records a shallow clone with the sidecar promoted to an enumerable property — the runtime `parsed.response` object stays untouched.
- **Honest `v5_cee_capture`.** `raw_response_present` is now true only when the parser preserved the verbatim pre-validation JSON (parse-error path). `response_top_level_keys` sources from a new sidecar metadata stash on success, so it reflects the ORIGINAL CEE root keys (including `analysis_freshness`, `has_run_analysis_fact`, `freshness_reason`) rather than the parsed-clone keys (which would include `__additive__` and miss the demoted top-level extras). The capture object is emitted whenever request OR response payload evidence exists — no longer gated solely on `data.services.cee`.

## Acceptance points (all covered by tests)

1. Real-shape CEE response (`analysis_result + review_card + coaching`) parses successfully.
2. Phase 3 blocks preserved in the sidecar with all v1.3 §0/§1 metadata fields intact.
3. `response.blocks` after strict validation contains only legacy schema-known entries.
4. `extractPhase3FromV5Response` reads sidecar Phase 3 blocks and writes them into `v5AnalysisFact.rawBlocks`.
5. `results.report` is applied from `analysis_result`.
6. `useAnalysisStateSource` returns `cee_v5_run_analysis`.
7. Typed-error / "Something went wrong" path does NOT render for the fixture.
8. Unknown block type inside `blocks[]` still fails parse and is enumerated in `v5_cee_capture.parse_error` + `unknown_block_types`.
9. Malformed known legacy block still fails strict parse (`parse_failure_kind: 'schema_mismatch'`).
10. Debug bundle is populated on parse failure rather than `v5_cee_capture: null`.

Two additional drift/safety tests added:
- **Schema drift guard via parser**: every block type declared by `BlockSchema`'s discriminated union must round-trip through `parseV5Response`, catching omissions in `LEGACY_SCHEMA_KNOWN_BLOCK_TYPES`.
- **Runtime vs traced sidecar split**: after `callV5Turn`, `result.response` keeps the sidecar non-enumerable while the traced clone exposes it enumerably for the redactor.

## Scope

Touches DGAI only:

- `src/v5/responseParser.ts` — Phase 3 whitelist, blocks[] split, sidecar metadata (phase3 blocks + original top-level keys), richer parse_error metadata
- `src/v5/v5Adapter.ts` — enumerable diagnostic clone for the trace store
- `src/v5/extractPhase3FromV5Response.ts` — `'exercise'` type + `'sidecar_blocks_array'` source
- `src/canvas/store.ts` — `V5AnalysisFactState.rawBlocks` type widened
- `src/lib/v5CanonicalAnalysisDiagnostics.ts` — `V5CeeCapture` shape extended (raw_response_present, parse_failure_kind, unknown_block_types, phase3_blocks_tolerated_count, phase3_block_types)
- `src/components/debug/utils/exportBundle.ts` — capture wiring honest on success and parse failure
- `src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts` — new 12-test regression suite (end-to-end through redactor + drift guards)
- `src/v5/__tests__/responseParser.additiveTolerance.spec.ts` — asserts new `parse_failure_kind`

**No changes to** CEE, PLoT, prompts, `@talchain/schemas`, model settings, or Phase 3 UX rendering.

## Local gates

- Targeted vitest (16 suites covering parser, extractor, adapter, router, state-source, orphan-banner, exportBundle v1.5/v2.0/structure, payload-trace-store): **272/272 passing**.
- Pre-existing failure in `useConversation.hook.spec.ts > V5 graph re-fetch on analyse response` confirmed unchanged from baseline via stash-test (also pre-dates this branch).

## Pre-push gate — bypassed with authorisation

Local pre-push gate was bypassed with `--no-verify` after the user explicitly authorised it. **Bypass reason: 15 pre-existing typecheck errors in untouched files.** The exact set is unchanged from the baseline at branch HEAD `476f9f5e feat(v5-canonical-analysis)...`:

```
src/components/debug/hooks/useDebugData.ts:1207 — Property 'stage_snapshots' does not exist on type '{}'
src/components/debug/hooks/useDebugData.ts:1320 — Property 'llm_raw' does not exist on type '{}'
src/components/debug/hooks/useDebugData.ts:1623 — Property 'llm_raw' does not exist on type '{}'
src/components/debug/hooks/useDebugData.ts:2266 — GateStatus vs 'pending' comparison
src/components/debug/hooks/useDebugData.ts:2596 — 'ceePayload' declared but never read
src/components/debug/hooks/useDebugData.ts:3587 — Property 'pipeline' does not exist on type '{}'
src/components/debug/hooks/useDebugData.ts:3735 — TracedPayload | undefined vs TracedPayload | null
src/components/debug/utils/exportBundle.ts:359  — number | null vs number | undefined
src/components/debug/utils/exportBundle.ts:1414 — EnrichedGraphEdge.strength_std unknown vs number
src/components/debug/utils/exportBundle.ts:1622 — RunMetaState.ceeAnalysisReady missing
src/components/debug/utils/exportBundle.ts:1904 — ResultsState → Record<string, unknown> conversion
src/components/debug/utils/exportBundle.ts:1905 — CanvasState → Record<string, unknown> conversion
src/components/debug/utils/exportBundle.ts:2232 — EnrichedFullGraph vs structural target
src/components/debug/utils/exportBundle.ts:2295 — llm_calls {} | null vs unknown[] | null
src/components/debug/utils/exportBundle.ts:2367 — analysis_ready unknown vs AnalysisReadyShape
```

All 15 are in files (or parts of files) not touched by this PR. Reviewers can verify by checking out `476f9f5e` and running `npm run typecheck` — same set with line numbers shifted by ±1 from this PR's line deltas.

Targeted tests for this PR all pass locally. **CI remains the authoritative gate.** This PR MUST NOT be merged if CI shows any new regression.

Follow-up: the baseline typecheck debt in `useDebugData.ts` / `exportBundle.ts` should be addressed in a separate PR. It is NOT in scope here.

## Out of scope

- **Bumping `@talchain/schemas`** from the vendored `0.8.1` tarball to `0.13.0` (which carries native Phase 3 schemas). Per the task brief, the schema package is held fixed in this PR; the parser-level tolerance is the right level for it. A sequenced upgrade can later replace the whitelist with native validation.
- **Phase 3 UX rendering** (review-card / coaching panels). This PR only ensures Phase 3 blocks are parsed, captured, and preserved on the fact slice. Phase 3B will wire the rendering.
- **Real CEE golden fixture.** The regression test fixture is contract-faithful but synthetic (doc-noted in the spec). Staging acceptance must use a real CEE response containing Phase 3 blocks (see test plan below).

## Test plan

- [ ] CI's `staging-full-tests.yml` passes (full ~6,284-test suite). **Authoritative gate.**
- [ ] CI typecheck delta: only the 15 pre-existing errors above. No new errors introduced.
- [ ] After merge, run staging acceptance with `VITE_V5_CANONICAL_ANALYSIS=true`:
  - [ ] Trigger analysis via the canonical path.
  - [ ] `/proxy/v5/turn` is called; `/v2/run` is NOT called from the browser.
  - [ ] CEE returns `analysis_result` plus Phase 3 blocks (`review_card`, `coaching`, optionally `evidence` / `exercise`).
  - [ ] DGAI does not show "Something went wrong".
  - [ ] Results panel renders.
  - [ ] Canvas store: `v5AnalysisFact` is populated for the current scenario.
  - [ ] Debug bundle (via Export):
    - [ ] `v5_canonical_analysis.debug_capture_status: 'complete'`
    - [ ] `v5_canonical_analysis.analysis_state_source: 'cee_v5_run_analysis'`
    - [ ] `v5_canonical_analysis.analysis_fact_status: 'present'`
    - [ ] `v5_cee_capture.parse_ok: true`
    - [ ] `v5_cee_capture.raw_response_present: false` (success path is honest)
    - [ ] `v5_cee_capture.phase3_blocks_tolerated_count > 0`
    - [ ] `v5_cee_capture.phase3_block_types` includes the expected Phase 3 block types
    - [ ] `v5_cee_capture.response_top_level_keys` includes `analysis_freshness` (or whatever Phase 3 metadata CEE emits at root) and does NOT include `__additive__`
- [ ] Once staging acceptance passes, replace the synthetic regression fixture with the redacted real capture (assertions are field-shape based — substitution is mechanical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)