### PR TITLE
fix(ai-panel-v2): UX polish — 10 items (PR #148 follow-up)

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -147,7 +147,17 @@ export const AIInputBar = memo(
       }
     })()
 
-    const canSend = draft.trim().length > 0 && !disabled && !isThinking
+    // Empty canvas + isThinking === a model-generation turn is in flight.
+    // The brief: composer must not invite a new decision while generating.
+    // We disable typing + replace the placeholder. Chat-mode thinking
+    // (nodeCount > 0) keeps the existing behaviour (Enter blocked via
+    // handleSend; typing still allowed so the user can compose follow-up).
+    const isGenerating = isThinking && nodeCount === 0
+    const inputDisabled = disabled || isGenerating
+    const effectivePlaceholder = isGenerating
+      ? 'Generating your decision model…'
+      : placeholder ?? stagePlaceholder
+    const canSend = draft.trim().length > 0 && !inputDisabled && !isThinking
 
     return (
       <div className={containerClasses} data-testid={testId ?? `ai-input-bar-${variant}`}>
@@ -158,9 +168,9 @@ export const AIInputBar = memo(
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={placeholder ?? stagePlaceholder}
+            placeholder={effectivePlaceholder}
             rows={1}
-            disabled={disabled}
+            disabled={inputDisabled}
             aria-label={ariaLabel ?? 'Chat message'}
             data-testid={`${testId ?? `ai-input-bar-${variant}`}-textarea`}
             className={typo(

--- a/src/canvas/components/CogPopover.tsx
+++ b/src/canvas/components/CogPopover.tsx
@@ -33,7 +33,7 @@ interface MenuItem {
   onSelect?: () => void
 }
 
-const POPOVER_W = 220
+const POPOVER_W = 240
 const POPOVER_MARGIN = 4
 
 /**
@@ -128,7 +128,10 @@ export const CogPopover = memo(function CogPopover({
   const items: MenuItem[] = []
   items.push({
     id: 'attach',
-    label: 'Attach evidence',
+    // Shortened to "Attach" so the row never wraps inside the popover —
+    // "Attach evidence" + the "Coming soon" badge competed for width and
+    // broke onto two lines on narrow viewports.
+    label: 'Attach',
     icon: Paperclip,
     testId: 'cog-popover-attach',
     // When a host wires `onAttachEvidence` AND the backend supports
@@ -175,7 +178,7 @@ export const CogPopover = memo(function CogPopover({
     <div
       ref={popoverRef}
       role="menu"
-      aria-label="Olumi settings"
+      aria-label="Assistant options"
       data-testid="cog-popover"
       className="fixed bg-panel border border-panel-border rounded-lg shadow-2 py-1"
       // z-index 950 layers ABOVE the OutputsDock (zIndex: 900 in OutputsDock.tsx)
@@ -185,6 +188,15 @@ export const CogPopover = memo(function CogPopover({
       // open from elements inside the panel, so they layer naturally above it.
       style={{ zIndex: 950, left: position.left, top: position.top, width: POPOVER_W }}
     >
+      <div
+        className={typo(
+          'panelMeta',
+          'px-3 pt-2 pb-1 text-text-light uppercase tracking-wide',
+        )}
+        data-testid="cog-popover-heading"
+      >
+        Assistant options
+      </div>
       {items.map((item) => {
         const Icon = item.icon
         const isDisabled = item.status === 'coming-soon'

--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -16,6 +16,7 @@ interface FirstUseComposerProps {
 }
 
 const PANEL_WIDTH = 480
+const PANEL_MARGIN = 16
 // Height tightened in the UX polish pass: guidance text + input bar with
 // minimal gap — no large dead space below the textarea.
 const PANEL_HEIGHT = 152
@@ -139,10 +140,16 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: F
       className="fixed bg-panel border border-panel-border rounded-lg shadow-2 flex flex-col"
       style={{
         zIndex: 300,
-        width: PANEL_WIDTH,
+        // Responsive width: cap at PANEL_WIDTH on wide viewports, shrink to
+        // viewport - 2*margin on narrow ones so the composer never overflows.
+        width: `min(${PANEL_WIDTH}px, calc(100vw - ${PANEL_MARGIN * 2}px))`,
         height: PANEL_HEIGHT,
-        left: `calc(50% - ${PANEL_WIDTH / 2}px)`,
-        top: `calc(50% - ${PANEL_HEIGHT / 2}px)`,
+        // Position: centred when there's room, otherwise pinned to the
+        // left margin. The max(margin, …) clamp prevents negative left at
+        // narrow widths; the min(…) cap stops it pushing past the centre
+        // when the responsive width kicks in.
+        left: `max(${PANEL_MARGIN}px, calc(50% - ${PANEL_WIDTH / 2}px))`,
+        top: `max(${PANEL_MARGIN}px, calc(50% - ${PANEL_HEIGHT / 2}px))`,
       }}
     >
       <div className="flex flex-col items-center px-6 pt-4 pb-2">

--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -16,7 +16,9 @@ interface FirstUseComposerProps {
 }
 
 const PANEL_WIDTH = 480
-const PANEL_HEIGHT = 200
+// Height tightened in the UX polish pass: guidance text + input bar with
+// minimal gap — no large dead space below the textarea.
+const PANEL_HEIGHT = 152
 
 /**
  * FirstUseComposer — centred composer that auto-opens when the canvas is
@@ -143,12 +145,11 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: F
         top: `calc(50% - ${PANEL_HEIGHT / 2}px)`,
       }}
     >
-      <div className="flex flex-col items-center justify-center px-6 pt-5 pb-3 gap-2">
+      <div className="flex flex-col items-center px-6 pt-4 pb-2">
         <p className={typo('panelBody', 'text-text-light text-center')}>
           Describe your decision, the options you're weighing, and what a good outcome looks like.
         </p>
       </div>
-      <div className="flex-1" />
       <AIInputBar
         ref={inputBarRef}
         variant="first-use"

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -238,8 +238,15 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       return
     }
     const max = computeMaxSize(vw, vh)
-    const w = clamp(size.width, MIN_WIDTH, max.width)
-    const h = clamp(size.height, MIN_HEIGHT, max.height)
+    // Cap width/height at the available canvas (viewport − margins − dock
+    // inset) so a stored size that exceeds the current canvas shrinks to
+    // fit instead of overlapping the dock. `fitsAtMinSize` above
+    // guarantees the cap is ≥ MIN_WIDTH × MIN_HEIGHT (so the clamp floor
+    // is always reachable).
+    const availableW = vw - 2 * DEFAULT_MARGIN - dockInset
+    const availableH = vh - 2 * DEFAULT_MARGIN
+    const w = clamp(size.width, MIN_WIDTH, Math.min(max.width, availableW))
+    const h = clamp(size.height, MIN_HEIGHT, Math.min(max.height, availableH))
     // Restored / stored positions can land outside the visible canvas when
     // the window has shrunk OR when the OutputsDock is open. Clamp so the
     // header is always visible, grabbable, and not under the dock. Mirrors
@@ -324,8 +331,14 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         return
       }
       const max = computeMaxSize(vw, vh)
-      const w = clamp(parseFloat(el.style.width || '0') || size.width, MIN_WIDTH, max.width)
-      const h = clamp(parseFloat(el.style.height || '0') || size.height, MIN_HEIGHT, max.height)
+      // Mirror the layout effect's cap: when the available canvas
+      // shrinks (viewport resize or dock expand), width/height must
+      // shrink to fit. `fitsAtMinSize` above guarantees the cap is
+      // ≥ MIN_WIDTH × MIN_HEIGHT.
+      const availableW = vw - 2 * DEFAULT_MARGIN - dockInset
+      const availableH = vh - 2 * DEFAULT_MARGIN
+      const w = clamp(parseFloat(el.style.width || '0') || size.width, MIN_WIDTH, Math.min(max.width, availableW))
+      const h = clamp(parseFloat(el.style.height || '0') || size.height, MIN_HEIGHT, Math.min(max.height, availableH))
       const x = clamp(parseFloat(el.style.left || '0'), DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vw - w - DEFAULT_MARGIN - dockInset))
       const y = clamp(parseFloat(el.style.top || '0'), DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vh - h - DEFAULT_MARGIN))
       el.style.width = `${w}px`

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -55,6 +55,39 @@ function defaultCentredPosition(size: FloatingPanelSize, viewportW: number, view
 }
 
 /**
+ * Clamp a candidate position into the visible viewport so the panel never
+ * sits partially (or fully) off-screen. Used for restored stored positions
+ * (a smaller viewport since last session can leave the stored x/y outside
+ * the visible region), the minimise pill's anchor, and any defensive
+ * recompute. Mirrors the drag-time clamp at handlePointerMove so the same
+ * rules apply whether the user dragged or the panel was placed by us.
+ */
+export function clampPositionToViewport(
+  pos: FloatingPanelPosition,
+  size: FloatingPanelSize,
+  viewportW: number,
+  viewportH: number,
+): FloatingPanelPosition {
+  return {
+    x: clamp(pos.x, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportW - size.width - DEFAULT_MARGIN)),
+    y: clamp(pos.y, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportH - size.height - DEFAULT_MARGIN)),
+  }
+}
+
+const PILL_W = 84
+const PILL_H = 28
+export function clampPillPositionToViewport(
+  pos: FloatingPanelPosition,
+  viewportW: number,
+  viewportH: number,
+): FloatingPanelPosition {
+  return {
+    x: clamp(pos.x, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportW - PILL_W - DEFAULT_MARGIN)),
+    y: clamp(pos.y, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportH - PILL_H - DEFAULT_MARGIN)),
+  }
+}
+
+/**
  * FloatingOlumiPanel — portaled draggable/resizable Olumi conversation window.
  *
  * Performance: pointer-move handlers update the panel's CSS via direct style
@@ -115,14 +148,20 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     const max = computeMaxSize(vw, vh)
     const w = clamp(size.width, MIN_WIDTH, max.width)
     const h = clamp(size.height, MIN_HEIGHT, max.height)
-    const pos = position ?? defaultCentredPosition({ width: w, height: h }, vw, vh)
+    // Restored / stored positions can land outside the viewport when the
+    // window has shrunk since the panel was last placed. Clamp so the
+    // header is always visible and grabbable. Mirrors handlePointerMove's
+    // drag-time clamp so the same bounds apply across entry points.
+    const rawPos = position ?? defaultCentredPosition({ width: w, height: h }, vw, vh)
+    const pos = clampPositionToViewport(rawPos, { width: w, height: h }, vw, vh)
     el.style.width = `${w}px`
     el.style.height = `${h}px`
     el.style.left = `${pos.x}px`
     el.style.top = `${pos.y}px`
-    // Commit the computed centred default into the store the first time the
-    // panel opens. Without this, the minimise pill would fall back to its
-    // 50%/50% CSS placeholder because store.position is still null.
+    // Commit the centred default the FIRST time the panel opens so the
+    // minimise pill anchor isn't null. Stored-position clamping is reapplied
+    // on every render via this same effect, so we don't need to write back —
+    // the DOM is always correct.
     if (position === null) {
       setInitialPosition(pos)
     }
@@ -306,7 +345,12 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   // never fall back to 50%/50% in normal flow. Defensive fallback kept for
   // edge cases (SSR rehydrate, etc.).
   if (isMinimised) {
-    const pos = position
+    // Clamp the pill anchor too — a stored position from when the panel
+    // was full-sized may sit too close to the right/bottom edge for the
+    // small pill to remain fully visible after the viewport changes.
+    const vw = typeof window !== 'undefined' ? window.innerWidth : 1200
+    const vh = typeof window !== 'undefined' ? window.innerHeight : 800
+    const pillPos = position ? clampPillPositionToViewport(position, vw, vh) : null
     return createPortal(
       <button
         type="button"
@@ -314,8 +358,8 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         className="fixed inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-panel border border-panel-border shadow-2 hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
         style={{
           zIndex: 300,
-          left: pos ? pos.x : '50%',
-          top: pos ? pos.y : '50%',
+          left: pillPos ? pillPos.x : '50%',
+          top: pillPos ? pillPos.y : '50%',
         }}
         data-testid="floating-olumi-panel-pill"
         aria-label="Restore Olumi"

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -219,6 +219,21 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     // panel. User can close the dock to restore. This preserves the
     // brief's "MIN_WIDTH whenever possible, otherwise minimise" rule.
     if (!fitsAtMinSize(vw, vh, dockInset)) {
+      // First-open path: store.position is still null, so the pill's
+      // `position ? pos.x : '50%'` fallback in the JSX below would
+      // render the pill at the centre of the viewport — which can sit
+      // under the dock on narrow viewports. Commit a safe top-left
+      // anchor (clamped against the dock for defence-in-depth) before
+      // minimising so the pill is always visible and grabbable.
+      if (position === null) {
+        const safePillPos = clampPillPositionToViewport(
+          { x: DEFAULT_MARGIN, y: DEFAULT_MARGIN },
+          vw,
+          vh,
+          dockInset,
+        )
+        setInitialPosition(safePillPos)
+      }
       minimise()
       return
     }

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -80,6 +80,31 @@ export function clampPositionToViewport(
 
 const PILL_W = 84
 const PILL_H = 28
+/**
+ * Compute the maximum size a panel may grow to during a bottom-right
+ * resize drag, given the current top-left position and dock inset. The
+ * panel's x/y do not move during resize, so the right edge of the panel
+ * cannot extend past `vw - dockInset - DEFAULT_MARGIN`.
+ *
+ * No `MIN_WIDTH`/`MIN_HEIGHT` floor here — when the dock leaves less
+ * space than the min, the panel MUST shrink below the min to stay clear
+ * (the user can close the dock to grow back). Negative budgets are
+ * floored at 0; the caller composes this with MIN_WIDTH via
+ * `min(widthBudget, max(MIN_WIDTH, requested))`.
+ */
+export function computeResizeBudget(
+  x: number,
+  y: number,
+  viewportW: number,
+  viewportH: number,
+  rightInset: number = 0,
+): { widthBudget: number; heightBudget: number } {
+  return {
+    widthBudget: Math.max(0, viewportW - x - DEFAULT_MARGIN - rightInset),
+    heightBudget: Math.max(0, viewportH - y - DEFAULT_MARGIN),
+  }
+}
+
 export function clampPillPositionToViewport(
   pos: FloatingPanelPosition,
   viewportW: number,
@@ -96,13 +121,14 @@ export function clampPillPositionToViewport(
 /**
  * Compute the reserved area at the right edge for the OutputsDock —
  * `vw - dock.left` captures the dock's width AND any right-edge gap
- * (e.g. `right: 12px`). Previous implementation only counted the dock
- * when its right edge was within 2px of the viewport edge, which
- * silently returned 0 because the dock styles itself with `right: 12px`.
+ * (e.g. `right: 12px`). The OutputsDock is the only element in the app
+ * with this aria-label, so the selector is unambiguous.
  *
- * Returns 0 when the dock element is absent (FF-off path), is not
- * positioned on the right side, or sits entirely above the viewport's
- * right axis (defensive).
+ * Returns 0 when the dock element is absent (FF-off path) or has zero
+ * size (defensive — e.g. hidden via CSS). No half-viewport guard:
+ * narrow viewports legitimately place a right-anchored dock with
+ * `dock.left < vw/2`, and the inset must still be reserved so the
+ * floating panel doesn't drift under it.
  */
 function measureDockInset(): number {
   if (typeof document === 'undefined' || typeof window === 'undefined') return 0
@@ -110,9 +136,6 @@ function measureDockInset(): number {
   if (!dock) return 0
   const rect = dock.getBoundingClientRect()
   if (rect.width === 0 || rect.height === 0) return 0
-  // Sanity: dock must be on the right half of the viewport. Anything else
-  // (e.g. mocked left-side layout in a test) is treated as no inset.
-  if (rect.left < window.innerWidth / 2) return 0
   const inset = window.innerWidth - rect.left
   return inset > 0 ? inset : 0
 }
@@ -325,8 +348,22 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       } else if (resize) {
         const dw = e.clientX - resize.startX
         const dh = e.clientY - resize.startY
-        const w = clamp(resize.startW + dw, MIN_WIDTH, max.width)
-        const h = clamp(resize.startH + dh, MIN_HEIGHT, max.height)
+        // Resize comes from the bottom-right handle, so x/y stay fixed
+        // and we grow width/height. Cap the maximum width by the
+        // remaining space from the panel's current x to the dock's left
+        // edge (or viewport right - margin when no dock). Without this
+        // the right edge can slide under the dock as the user resizes.
+        const x = parseFloat(el.style.left || '0')
+        const y = parseFloat(el.style.top || '0')
+        const { widthBudget, heightBudget } = computeResizeBudget(x, y, vw, vh, dockInset)
+        // Compose: requested width floors at MIN_WIDTH, then caps at the
+        // dock-aware budget. When the budget is below MIN_WIDTH (narrow
+        // viewport + open dock), the budget wins — the panel shrinks
+        // below MIN_WIDTH to stay clear of the dock.
+        const requestedW = Math.max(MIN_WIDTH, resize.startW + dw)
+        const requestedH = Math.max(MIN_HEIGHT, resize.startH + dh)
+        const w = Math.min(max.width, widthBudget, requestedW)
+        const h = Math.min(max.height, heightBudget, requestedH)
         el.style.width = `${w}px`
         el.style.height = `${h}px`
       }

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -292,11 +292,30 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   useEffect(() => {
     if (!isOpen) return
     const handle = () => {
-      const el = containerRef.current
-      if (!el) return
+      const fp = useFloatingPanelState.getState()
+      if (!fp.isOpen) return
       const vw = window.innerWidth
       const vh = window.innerHeight
       const dockInset = measureDockInset()
+
+      // Minimised path: the full panel isn't rendered (containerRef is
+      // null) but the restore pill is. Window / dock changes still need
+      // to keep the pill visible and clear of the dock — without this
+      // the pill can drift off-screen on viewport shrink or under the
+      // dock on expand. Direct store write bypasses setPosition's
+      // `userRepositioned` flip so an automatic clamp doesn't look like
+      // a user drag (would otherwise defeat auto-dock invariants).
+      if (fp.isMinimised) {
+        if (!fp.position) return
+        const next = clampPillPositionToViewport(fp.position, vw, vh, dockInset)
+        if (next.x !== fp.position.x || next.y !== fp.position.y) {
+          useFloatingPanelState.setState({ position: next })
+        }
+        return
+      }
+
+      const el = containerRef.current
+      if (!el) return
       // Same MIN_WIDTH-or-minimise rule as the layout effect: if the
       // viewport-or-dock resize leaves no room for a MIN_WIDTH panel,
       // auto-minimise to the pill.

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -86,11 +86,10 @@ const PILL_H = 28
  * panel's x/y do not move during resize, so the right edge of the panel
  * cannot extend past `vw - dockInset - DEFAULT_MARGIN`.
  *
- * No `MIN_WIDTH`/`MIN_HEIGHT` floor here — when the dock leaves less
- * space than the min, the panel MUST shrink below the min to stay clear
- * (the user can close the dock to grow back). Negative budgets are
- * floored at 0; the caller composes this with MIN_WIDTH via
- * `min(widthBudget, max(MIN_WIDTH, requested))`.
+ * Returns raw geometry only (floored at 0). Callers compose this with
+ * `MIN_WIDTH` / `MIN_HEIGHT`. See `fitsAtMinSize` — when the available
+ * space is smaller than MIN, the safe UX is to auto-minimise to the
+ * restore pill rather than render a too-narrow panel.
  */
 export function computeResizeBudget(
   x: number,
@@ -103,6 +102,22 @@ export function computeResizeBudget(
     widthBudget: Math.max(0, viewportW - x - DEFAULT_MARGIN - rightInset),
     heightBudget: Math.max(0, viewportH - y - DEFAULT_MARGIN),
   }
+}
+
+/**
+ * Returns true when the available canvas (viewport minus dock inset and
+ * margins on both sides) can fit a panel at MIN_WIDTH × MIN_HEIGHT.
+ * When false, the panel should auto-minimise to the pill — rendering at
+ * a sub-MIN_WIDTH size would be unusable.
+ */
+export function fitsAtMinSize(
+  viewportW: number,
+  viewportH: number,
+  rightInset: number = 0,
+): boolean {
+  const availableW = viewportW - 2 * DEFAULT_MARGIN - rightInset
+  const availableH = viewportH - 2 * DEFAULT_MARGIN
+  return availableW >= MIN_WIDTH && availableH >= MIN_HEIGHT
 }
 
 export function clampPillPositionToViewport(
@@ -199,6 +214,14 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     const vw = typeof window !== 'undefined' ? window.innerWidth : 1200
     const vh = typeof window !== 'undefined' ? window.innerHeight : 800
     const dockInset = measureDockInset()
+    // If the dock + margins leave less room than MIN_WIDTH × MIN_HEIGHT,
+    // auto-minimise to the pill instead of rendering an unusably narrow
+    // panel. User can close the dock to restore. This preserves the
+    // brief's "MIN_WIDTH whenever possible, otherwise minimise" rule.
+    if (!fitsAtMinSize(vw, vh, dockInset)) {
+      minimise()
+      return
+    }
     const max = computeMaxSize(vw, vh)
     const w = clamp(size.width, MIN_WIDTH, max.width)
     const h = clamp(size.height, MIN_HEIGHT, max.height)
@@ -220,7 +243,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     if (position === null) {
       setInitialPosition(pos)
     }
-  }, [isOpen, isMinimised, position, size, setInitialPosition])
+  }, [isOpen, isMinimised, position, size, setInitialPosition, minimise])
 
   // Register a focus channel so the persistent status strip and Olumi-tab
   // click (when floating is open) can imperatively focus the input.
@@ -259,6 +282,13 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       const vw = window.innerWidth
       const vh = window.innerHeight
       const dockInset = measureDockInset()
+      // Same MIN_WIDTH-or-minimise rule as the layout effect: if the
+      // viewport-or-dock resize leaves no room for a MIN_WIDTH panel,
+      // auto-minimise to the pill.
+      if (!fitsAtMinSize(vw, vh, dockInset)) {
+        useFloatingPanelState.getState().minimise()
+        return
+      }
       const max = computeMaxSize(vw, vh)
       const w = clamp(parseFloat(el.style.width || '0') || size.width, MIN_WIDTH, max.width)
       const h = clamp(parseFloat(el.style.height || '0') || size.height, MIN_HEIGHT, max.height)
@@ -346,24 +376,29 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         el.style.left = `${x}px`
         el.style.top = `${y}px`
       } else if (resize) {
+        // If the dock leaves no room for a MIN_WIDTH × MIN_HEIGHT panel,
+        // auto-minimise instead of rendering a too-narrow surface. Cancel
+        // the in-flight resize so pointerup doesn't commit a bad size.
+        if (!fitsAtMinSize(vw, vh, dockInset)) {
+          resizeStateRef.current = null
+          useFloatingPanelState.getState().minimise()
+          return
+        }
         const dw = e.clientX - resize.startX
         const dh = e.clientY - resize.startY
         // Resize comes from the bottom-right handle, so x/y stay fixed
         // and we grow width/height. Cap the maximum width by the
         // remaining space from the panel's current x to the dock's left
-        // edge (or viewport right - margin when no dock). Without this
-        // the right edge can slide under the dock as the user resizes.
+        // edge (or viewport right - margin when no dock). MIN_WIDTH is
+        // preserved — the auto-minimise branch above handles the case
+        // where the dock leaves less room than MIN_WIDTH.
         const x = parseFloat(el.style.left || '0')
         const y = parseFloat(el.style.top || '0')
         const { widthBudget, heightBudget } = computeResizeBudget(x, y, vw, vh, dockInset)
-        // Compose: requested width floors at MIN_WIDTH, then caps at the
-        // dock-aware budget. When the budget is below MIN_WIDTH (narrow
-        // viewport + open dock), the budget wins — the panel shrinks
-        // below MIN_WIDTH to stay clear of the dock.
         const requestedW = Math.max(MIN_WIDTH, resize.startW + dw)
         const requestedH = Math.max(MIN_HEIGHT, resize.startH + dh)
-        const w = Math.min(max.width, widthBudget, requestedW)
-        const h = Math.min(max.height, heightBudget, requestedH)
+        const w = Math.max(MIN_WIDTH, Math.min(max.width, widthBudget, requestedW))
+        const h = Math.max(MIN_HEIGHT, Math.min(max.height, heightBudget, requestedH))
         el.style.width = `${w}px`
         el.style.height = `${h}px`
       }

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -55,19 +55,14 @@ function defaultCentredPosition(size: FloatingPanelSize, viewportW: number, view
 }
 
 /**
- * Clamp a candidate position into the visible viewport so the panel never
- * sits partially (or fully) off-screen. Used for restored stored positions
- * (a smaller viewport since last session can leave the stored x/y outside
- * the visible region), the minimise pill's anchor, and any defensive
- * recompute. Mirrors the drag-time clamp at handlePointerMove so the same
- * rules apply whether the user dragged or the panel was placed by us.
- */
-/**
- * Clamp a position into the visible canvas area. `rightInset` reserves
- * pixels at the right edge for the OutputsDock so the floating panel does
- * not land under it — the dock sits at z-index 900 and would obscure the
- * floating panel (z-300) without this. Callers pass the dock's measured
- * width (0 when the dock is collapsed or absent).
+ * Clamp a candidate position into the visible canvas area so the panel
+ * never sits partially (or fully) off-screen AND never lands under the
+ * OutputsDock (z-900, would obscure the floating panel at z-300).
+ *
+ * `rightInset` reserves space from the viewport's right edge inward —
+ * callers pass the dock's measured offset (see `measureDockInset`). It
+ * captures both the dock's width and any right-edge gap so the floating
+ * panel cannot land in the strip between the dock and the viewport edge.
  */
 export function clampPositionToViewport(
   pos: FloatingPanelPosition,
@@ -98,16 +93,28 @@ export function clampPillPositionToViewport(
   }
 }
 
-/** Measure the OutputsDock's rendered width (returns 0 when not present). */
+/**
+ * Compute the reserved area at the right edge for the OutputsDock —
+ * `vw - dock.left` captures the dock's width AND any right-edge gap
+ * (e.g. `right: 12px`). Previous implementation only counted the dock
+ * when its right edge was within 2px of the viewport edge, which
+ * silently returned 0 because the dock styles itself with `right: 12px`.
+ *
+ * Returns 0 when the dock element is absent (FF-off path), is not
+ * positioned on the right side, or sits entirely above the viewport's
+ * right axis (defensive).
+ */
 function measureDockInset(): number {
-  if (typeof document === 'undefined') return 0
+  if (typeof document === 'undefined' || typeof window === 'undefined') return 0
   const dock = document.querySelector('aside[aria-label="Outputs dock"]') as HTMLElement | null
   if (!dock) return 0
   const rect = dock.getBoundingClientRect()
-  // Only count the dock as an inset if it's actually pinned to the right
-  // edge. (Defensive — in test envs the layout may not run.)
-  if (rect.right < (typeof window !== 'undefined' ? window.innerWidth : 0) - 2) return 0
-  return rect.width
+  if (rect.width === 0 || rect.height === 0) return 0
+  // Sanity: dock must be on the right half of the viewport. Anything else
+  // (e.g. mocked left-side layout in a test) is treated as no inset.
+  if (rect.left < window.innerWidth / 2) return 0
+  const inset = window.innerWidth - rect.left
+  return inset > 0 ? inset : 0
 }
 
 /**
@@ -214,7 +221,13 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     })
   }, [isOpen, yieldToFirstUse])
 
-  // Clamp on viewport resize so the panel never leaves the visible area.
+  // Clamp on viewport resize AND on dock resize/open/close so the panel
+  // never leaves the visible area and never lands under the dock. The
+  // ResizeObserver watches the dock element: it fires when the dock
+  // mounts, unmounts (via the cleanup re-evaluation pass), expands, or
+  // collapses to its rail width. Without this, a panel placed when the
+  // dock was closed would be stranded under the dock when the user opens
+  // it, since the layout effect's deps don't include dock state.
   useEffect(() => {
     if (!isOpen) return
     const handle = () => {
@@ -234,7 +247,36 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       el.style.top = `${y}px`
     }
     window.addEventListener('resize', handle)
-    return () => window.removeEventListener('resize', handle)
+    // Track the dock element across mounts/unmounts so we re-clamp when
+    // it appears, expands (rail → full), or collapses (full → rail).
+    let dockObs: ResizeObserver | null = null
+    let dockEl: Element | null = null
+    const watchDock = () => {
+      const next = typeof document !== 'undefined'
+        ? document.querySelector('aside[aria-label="Outputs dock"]')
+        : null
+      if (next === dockEl) return
+      if (dockObs && dockEl) dockObs.unobserve(dockEl)
+      dockEl = next
+      if (next && dockObs) dockObs.observe(next)
+    }
+    if (typeof ResizeObserver !== 'undefined') {
+      dockObs = new ResizeObserver(handle)
+      watchDock()
+    }
+    // Re-evaluate the watched element shortly after mount in case the
+    // dock renders asynchronously (CSR boot, conditional rendering).
+    const mountCheckId = typeof window !== 'undefined' ? window.setTimeout(watchDock, 100) : 0
+    // The dock dispatches this event on tab clicks; piggy-back to also
+    // recheck whether the watched element has changed.
+    const onDockOpened = () => { watchDock(); handle() }
+    window.addEventListener('outputs-dock-opened', onDockOpened)
+    return () => {
+      window.removeEventListener('resize', handle)
+      window.removeEventListener('outputs-dock-opened', onDockOpened)
+      if (mountCheckId) window.clearTimeout(mountCheckId)
+      if (dockObs) dockObs.disconnect()
+    }
   }, [isOpen, size])
 
   // Pointer-driven drag from the header bar.

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -62,14 +62,23 @@ function defaultCentredPosition(size: FloatingPanelSize, viewportW: number, view
  * recompute. Mirrors the drag-time clamp at handlePointerMove so the same
  * rules apply whether the user dragged or the panel was placed by us.
  */
+/**
+ * Clamp a position into the visible canvas area. `rightInset` reserves
+ * pixels at the right edge for the OutputsDock so the floating panel does
+ * not land under it — the dock sits at z-index 900 and would obscure the
+ * floating panel (z-300) without this. Callers pass the dock's measured
+ * width (0 when the dock is collapsed or absent).
+ */
 export function clampPositionToViewport(
   pos: FloatingPanelPosition,
   size: FloatingPanelSize,
   viewportW: number,
   viewportH: number,
+  rightInset: number = 0,
 ): FloatingPanelPosition {
+  const maxX = Math.max(DEFAULT_MARGIN, viewportW - size.width - DEFAULT_MARGIN - rightInset)
   return {
-    x: clamp(pos.x, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportW - size.width - DEFAULT_MARGIN)),
+    x: clamp(pos.x, DEFAULT_MARGIN, maxX),
     y: clamp(pos.y, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportH - size.height - DEFAULT_MARGIN)),
   }
 }
@@ -80,11 +89,25 @@ export function clampPillPositionToViewport(
   pos: FloatingPanelPosition,
   viewportW: number,
   viewportH: number,
+  rightInset: number = 0,
 ): FloatingPanelPosition {
+  const maxX = Math.max(DEFAULT_MARGIN, viewportW - PILL_W - DEFAULT_MARGIN - rightInset)
   return {
-    x: clamp(pos.x, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportW - PILL_W - DEFAULT_MARGIN)),
+    x: clamp(pos.x, DEFAULT_MARGIN, maxX),
     y: clamp(pos.y, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, viewportH - PILL_H - DEFAULT_MARGIN)),
   }
+}
+
+/** Measure the OutputsDock's rendered width (returns 0 when not present). */
+function measureDockInset(): number {
+  if (typeof document === 'undefined') return 0
+  const dock = document.querySelector('aside[aria-label="Outputs dock"]') as HTMLElement | null
+  if (!dock) return 0
+  const rect = dock.getBoundingClientRect()
+  // Only count the dock as an inset if it's actually pinned to the right
+  // edge. (Defensive — in test envs the layout may not run.)
+  if (rect.right < (typeof window !== 'undefined' ? window.innerWidth : 0) - 2) return 0
+  return rect.width
 }
 
 /**
@@ -145,15 +168,17 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     if (!el || !isOpen || isMinimised) return
     const vw = typeof window !== 'undefined' ? window.innerWidth : 1200
     const vh = typeof window !== 'undefined' ? window.innerHeight : 800
+    const dockInset = measureDockInset()
     const max = computeMaxSize(vw, vh)
     const w = clamp(size.width, MIN_WIDTH, max.width)
     const h = clamp(size.height, MIN_HEIGHT, max.height)
-    // Restored / stored positions can land outside the viewport when the
-    // window has shrunk since the panel was last placed. Clamp so the
-    // header is always visible and grabbable. Mirrors handlePointerMove's
-    // drag-time clamp so the same bounds apply across entry points.
-    const rawPos = position ?? defaultCentredPosition({ width: w, height: h }, vw, vh)
-    const pos = clampPositionToViewport(rawPos, { width: w, height: h }, vw, vh)
+    // Restored / stored positions can land outside the visible canvas when
+    // the window has shrunk OR when the OutputsDock is open. Clamp so the
+    // header is always visible, grabbable, and not under the dock. Mirrors
+    // handlePointerMove's drag-time clamp so the same bounds apply across
+    // entry points.
+    const rawPos = position ?? defaultCentredPosition({ width: w, height: h }, vw - dockInset, vh)
+    const pos = clampPositionToViewport(rawPos, { width: w, height: h }, vw, vh, dockInset)
     el.style.width = `${w}px`
     el.style.height = `${h}px`
     el.style.left = `${pos.x}px`
@@ -197,10 +222,11 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       if (!el) return
       const vw = window.innerWidth
       const vh = window.innerHeight
+      const dockInset = measureDockInset()
       const max = computeMaxSize(vw, vh)
       const w = clamp(parseFloat(el.style.width || '0') || size.width, MIN_WIDTH, max.width)
       const h = clamp(parseFloat(el.style.height || '0') || size.height, MIN_HEIGHT, max.height)
-      const x = clamp(parseFloat(el.style.left || '0'), DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vw - w - DEFAULT_MARGIN))
+      const x = clamp(parseFloat(el.style.left || '0'), DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vw - w - DEFAULT_MARGIN - dockInset))
       const y = clamp(parseFloat(el.style.top || '0'), DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vh - h - DEFAULT_MARGIN))
       el.style.width = `${w}px`
       el.style.height = `${h}px`
@@ -244,12 +270,13 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       rafRef.current = null
       const vw = window.innerWidth
       const vh = window.innerHeight
+      const dockInset = measureDockInset()
       const max = computeMaxSize(vw, vh)
 
       if (drag) {
         const w = parseFloat(el.style.width || '400')
         const h = parseFloat(el.style.height || '500')
-        const x = clamp(e.clientX - drag.offsetX, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vw - w - DEFAULT_MARGIN))
+        const x = clamp(e.clientX - drag.offsetX, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vw - w - DEFAULT_MARGIN - dockInset))
         const y = clamp(e.clientY - drag.offsetY, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vh - h - DEFAULT_MARGIN))
         el.style.left = `${x}px`
         el.style.top = `${y}px`
@@ -350,7 +377,8 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     // small pill to remain fully visible after the viewport changes.
     const vw = typeof window !== 'undefined' ? window.innerWidth : 1200
     const vh = typeof window !== 'undefined' ? window.innerHeight : 800
-    const pillPos = position ? clampPillPositionToViewport(position, vw, vh) : null
+    const dockInset = measureDockInset()
+    const pillPos = position ? clampPillPositionToViewport(position, vw, vh, dockInset) : null
     return createPortal(
       <button
         type="button"

--- a/src/canvas/components/OlumiTabBody.tsx
+++ b/src/canvas/components/OlumiTabBody.tsx
@@ -1,8 +1,10 @@
 import { memo, useCallback } from 'react'
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, MessageSquare } from 'lucide-react'
 import { typo } from '../../styles/typography'
 import { useConversationContext } from '../conversation/ConversationContext'
 import { ConversationPanel } from '../conversation/ConversationPanel'
+import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
+import { focusFloating } from '../hooks/useFloatingFocus'
 
 interface OlumiTabBodyProps {
   /** Opens the floating Olumi panel for the user. */
@@ -12,23 +14,74 @@ interface OlumiTabBodyProps {
 /**
  * OlumiTabBody — docked Olumi tab content.
  *
- * Renders the conversation thread at full panel height. Composer is owned by
- * the persistent input strip below the tab body — this surface intentionally
- * does NOT render its own composer (preserves the "no duplicate composer"
- * invariant). Reuses ConversationPanel with `hideComposer` so all patch /
- * feedback / run wiring stays in a single source of truth.
+ * Three render states:
+ *  - Floating panel is open → placeholder + actions ("Focus floating",
+ *    "Dock here"). Preserves the one-readable-surface invariant: we never
+ *    render the conversation twice.
+ *  - Empty conversation (and floating closed) → guidance text + float-out.
+ *  - Otherwise → full ConversationPanel with `hideComposer` (the persistent
+ *    strip below the tab body owns submission).
  */
 export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabBodyProps) {
   const conversation = useConversationContext()
   const realMessageCount = conversation.messages.filter((m) => !m.synthetic).length
+  const floatingIsOpen = useFloatingPanelState((s) => s.isOpen)
+  const closeFloating = useFloatingPanelState((s) => s.close)
 
-  // No-op handlers — the docked surface delegates these to its host.
   const handleCollapse = useCallback(() => {
     // The dock's own collapse button handles this; ChatTopBar is hidden anyway.
   }, [])
   const handleAttach = useCallback(() => {
     // Attach evidence is handled by CogPopover, not here.
   }, [])
+
+  const handleFocusFloating = useCallback(() => {
+    focusFloating()
+  }, [])
+  const handleDockHere = useCallback(() => {
+    closeFloating()
+  }, [closeFloating])
+
+  if (floatingIsOpen) {
+    return (
+      <div
+        className="flex flex-1 min-h-0 items-center justify-center px-6 py-6"
+        data-testid="olumi-tab-floating-placeholder"
+      >
+        <div className="flex flex-col items-center gap-3 max-w-xs">
+          <MessageSquare className="w-8 h-8 text-text-light" aria-hidden="true" />
+          <p className={typo('panelBody', 'text-text-body text-center')}>
+            Olumi is open in the floating panel.
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleFocusFloating}
+              className={typo(
+                'panelMeta',
+                'inline-flex items-center gap-1 text-info hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-info rounded px-1.5 py-0.5',
+              )}
+              data-testid="olumi-tab-focus-floating"
+            >
+              Focus floating
+            </button>
+            <span className={typo('panelMeta', 'text-text-light')} aria-hidden="true">·</span>
+            <button
+              type="button"
+              onClick={handleDockHere}
+              className={typo(
+                'panelMeta',
+                'inline-flex items-center gap-1 text-info hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-info rounded px-1.5 py-0.5',
+              )}
+              data-testid="olumi-tab-dock-here"
+            >
+              Dock here
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   if (realMessageCount === 0) {
     return (

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -30,7 +30,7 @@ import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource } from '../store'
-import { typography } from '../../styles/typography'
+import { typography, typo } from '../../styles/typography'
 import {
   trackCompareOpened,
   trackAutoFixClicked,
@@ -47,7 +47,6 @@ import { useConversationContext, useOptionalConversationContext } from '../conve
 import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { focusFloating } from '../hooks/useFloatingFocus'
-import { typo } from '../../styles/typography'
 import { isV5Eligible } from '../../v5/eligibility'
 import { useStaleGuard } from '../ui/inspector-v2/useStaleGuard'
 import { countFactorsToVerify } from './model-tab/utils'
@@ -1358,7 +1357,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     {tab.label}
                     {tab.id === 'olumi' && floatingPanelIsOpen && (
                       <span
-                        className="inline-flex items-center text-info border border-info/30 rounded-full px-1.5 leading-none text-[10px] font-medium"
+                        className={typo(
+                          'panelMeta',
+                          'inline-flex items-center text-info border border-info/30 rounded-full px-1.5 leading-none',
+                        )}
                         data-testid="olumi-tab-floating-badge"
                         aria-label="Olumi is open in the floating panel"
                       >

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1192,13 +1192,11 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   }
 
   const handleTabClick = (tab: OutputsDockTab) => {
-    // Brief: when the floating Olumi panel is open, clicking the Olumi tab
-    // focuses the floating panel rather than activating the docked surface —
-    // avoids rendering the same conversation in two surfaces simultaneously.
-    if (tab === 'olumi' && useFloatingPanelState.getState().isOpen) {
-      focusFloating()
-      return
-    }
+    // Polish (Item 1): the docked Olumi tab is reachable even when floating
+    // is open — OlumiTabBody renders the floating-state placeholder (with
+    // Focus floating / Dock here actions) instead of duplicating the
+    // conversation. The placeholder owns the focus affordance; the tab click
+    // just activates the tab.
     setState(prev => ({ ...prev, isOpen: true, activeTab: tab }))
     // E1: Sync tab state to Zustand store for cross-component navigation
     useUIStore.getState().setActiveOutputTab(tab as OutputTab)
@@ -1348,7 +1346,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     state.activeTab === tab.id
                       ? 'text-info border-b-2 border-info'
                       : 'text-text-header/70 hover:bg-panel hover:text-text-header border-b-2 border-transparent'
-                  } ${tab.id === 'olumi' && floatingPanelIsOpen ? 'opacity-60' : ''}`}
+                  }`}
                   style={
                     state.activeTab === tab.id
                       ? { backgroundColor: 'rgba(82,163,200,0.15)' }
@@ -1358,6 +1356,15 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   <span className={`inline-flex items-center gap-1${tab.id === 'results' && showResultsTabStaleWarning ? ' text-warning' : ''}`}>
                     {tab.id === 'olumi' && <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />}
                     {tab.label}
+                    {tab.id === 'olumi' && floatingPanelIsOpen && (
+                      <span
+                        className="inline-flex items-center text-info border border-info/30 rounded-full px-1.5 leading-none text-[10px] font-medium"
+                        data-testid="olumi-tab-floating-badge"
+                        aria-label="Olumi is open in the floating panel"
+                      >
+                        Open
+                      </span>
+                    )}
                     {tab.id === 'results' && showResultsTabStaleWarning && (
                       <AlertTriangle
                         className="w-3 h-3 text-warning"

--- a/src/canvas/components/PersistentInputStrip.tsx
+++ b/src/canvas/components/PersistentInputStrip.tsx
@@ -70,7 +70,7 @@ export const PersistentInputStrip = memo(function PersistentInputStrip({
         aria-label="Focus floating Olumi panel"
       >
         <span className={typo('panelMeta', 'text-text-body text-left')}>Olumi is open</span>
-        <span className={typo('panelMeta', 'text-info font-medium flex-shrink-0')}>Focus →</span>
+        <span className={typo('panelMeta', 'text-info flex-shrink-0')}>Focus →</span>
       </button>
     )
   }

--- a/src/canvas/components/PersistentInputStrip.tsx
+++ b/src/canvas/components/PersistentInputStrip.tsx
@@ -1,9 +1,7 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback } from 'react'
 import { ChevronUp } from 'lucide-react'
 import { typo } from '../../styles/typography'
-import { useConversationContext } from '../conversation/ConversationContext'
 import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
-import { useStaleGuard } from '../ui/inspector-v2/useStaleGuard'
 import { useStageAwarePlaceholder } from '../hooks/useStageAwarePlaceholder'
 import { AIInputBar } from './AIInputBar'
 
@@ -22,36 +20,6 @@ interface PersistentInputStripProps {
   onFocusFloating?: () => void
   /** Click handler for the cog icon (Attach / Voice / Depth menu). */
   onCogClick: (anchorEl: HTMLElement) => void
-}
-
-/**
- * Status-strip text: the literal first 50 characters of the last assistant
- * message. Overridden to "Thinking…" while a turn is in flight and to
- * "Analysis stale · Rerun" when the graph diverged from the last analysis.
- *
- * NEVER an LLM-generated summary — this is a passthrough.
- */
-function useStatusText(): string {
-  const { messages, isThinking } = useConversationContext()
-  const { isStale } = useStaleGuard()
-
-  return useMemo(() => {
-    if (isThinking) return 'Thinking…'
-    if (isStale) return 'Analysis stale · Rerun'
-    let lastAssistant: typeof messages[number] | undefined
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const m = messages[i]
-      if (m.role === 'assistant' && !m.synthetic) {
-        lastAssistant = m
-        break
-      }
-    }
-    if (!lastAssistant) return 'Ready'
-    const raw = (lastAssistant.content ?? '').trim()
-    if (!raw) return 'Ready'
-    if (raw.length <= 50) return raw
-    return raw.slice(0, 50).trimEnd() + '…'
-  }, [messages, isThinking, isStale])
 }
 
 /**
@@ -75,7 +43,6 @@ export const PersistentInputStrip = memo(function PersistentInputStrip({
   onCogClick,
 }: PersistentInputStripProps) {
   const floatingIsOpen = useFloatingPanelState((s) => s.isOpen)
-  const statusText = useStatusText()
   const placeholder = useStageAwarePlaceholder()
 
   const handleFocus = useCallback(() => {
@@ -83,8 +50,11 @@ export const PersistentInputStrip = memo(function PersistentInputStrip({
   }, [onFocusFloating])
 
   // Status mode — floating panel is open. No textarea is rendered so the
-  // "no duplicate composer" invariant holds. Clicking anywhere on the strip
-  // focuses the floating panel's textarea via the registered focus channel.
+  // "no duplicate composer" invariant holds. Fixed copy ("Olumi is open ·
+  // Focus") replaces the previous truncated last-message preview: that
+  // preview was noisy, broke at 50 chars mid-sentence, and read as
+  // disabled chrome rather than a clickable affordance. Clicking anywhere
+  // focuses the floating panel via the registered focus channel.
   if (floatingIsOpen) {
     return (
       <button
@@ -94,8 +64,8 @@ export const PersistentInputStrip = memo(function PersistentInputStrip({
         data-testid="persistent-strip-status"
         aria-label="Focus floating Olumi panel"
       >
-        <span className={typo('panelMeta', 'text-text-light truncate text-left')}>{statusText}</span>
-        <span className={typo('panelMeta', 'text-text-light flex-shrink-0')}>Focus →</span>
+        <span className={typo('panelMeta', 'text-text-body text-left')}>Olumi is open</span>
+        <span className={typo('panelMeta', 'text-info font-medium flex-shrink-0')}>Focus →</span>
       </button>
     )
   }

--- a/src/canvas/components/PersistentInputStrip.tsx
+++ b/src/canvas/components/PersistentInputStrip.tsx
@@ -27,11 +27,16 @@ interface PersistentInputStripProps {
  * Outside the tab content area; always visible (sibling of the dock body).
  *
  * Modes:
- *  - composer (floating closed, Olumi tab active):   AIInputBar (sends to docked conversation)
- *  - composer (floating closed, other tab active):   AIInputBar — but clicks open floating
- *                                                    rather than sending (chevron is the
- *                                                    explicit float-out affordance).
- *  - status (floating open):                         status line + focus button
+ *  - composer (floating closed, Olumi tab active):   AIInputBar (sends to docked conversation).
+ *  - redirect (floating closed, other tab active):   a button-shaped placeholder
+ *                                                    (NOT AIInputBar) — clicking anywhere
+ *                                                    opens the floating panel. Any visual
+ *                                                    submit/cog affordances would mislead
+ *                                                    on this surface, so the placeholder
+ *                                                    only shows the stage-aware prompt copy
+ *                                                    and a chevron hint.
+ *  - status (floating open):                         fixed "Olumi is open · Focus →" line —
+ *                                                    clicking focuses the floating textarea.
  *
  * Invariant: when floating is open, the strip MUST NOT render a textarea —
  * preserves the "no duplicate composer" rule.

--- a/src/canvas/components/__tests__/CogPopover.spec.tsx
+++ b/src/canvas/components/__tests__/CogPopover.spec.tsx
@@ -47,6 +47,14 @@ describe('CogPopover', () => {
     expect(badges.length).toBe(3)
   })
 
+  it('renders an "Assistant options" heading and uses "Attach" (not "Attach evidence") as the menu label', () => {
+    setup()
+    expect(screen.getByTestId('cog-popover-heading')).toHaveTextContent(/Assistant options/i)
+    const attachBtn = screen.getByTestId('cog-popover-attach')
+    expect(attachBtn).toHaveTextContent(/^\s*Attach\s*Coming soon\s*$/i)
+    expect(attachBtn).not.toHaveTextContent(/evidence/i)
+  })
+
   it('Attach evidence becomes functional ONLY when onAttachEvidence is supplied', () => {
     const onAttachEvidence = vi.fn()
     const { onClose } = setup({ onAttachEvidence })

--- a/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
+++ b/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
@@ -225,6 +225,23 @@ describe('FirstUseComposer — reduced motion (gap #3)', () => {
   })
 })
 
+describe('FirstUseComposer — responsive width (P1.2)', () => {
+  it('uses a CSS clamp so the composer never overflows narrow viewports', () => {
+    // Render and inspect the inline style. We assert the responsive shape
+    // (min(...) for width, max(...) for left/top) rather than computed
+    // pixels because jsdom does not evaluate CSS clamp() at runtime.
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const dialog = screen.getByTestId('first-use-composer') as HTMLElement
+    const style = dialog.getAttribute('style') ?? ''
+    expect(style).toMatch(/width:\s*min\(/i)
+    expect(style).toMatch(/calc\(100vw\s*-\s*32px\)/i)
+    expect(style).toMatch(/left:\s*max\(/i)
+    expect(style).toMatch(/top:\s*max\(/i)
+    // Defensive: no raw px-only width that would have overflowed.
+    expect(style).not.toMatch(/width:\s*480px/i)
+  })
+})
+
 describe('FirstUseComposer — auto-dock does NOT misfire on hydration/import (review #2)', () => {
   // The reviewer flagged: auto-dock should only fire for a graph produced by
   // the user submitting via the first-use composer — NOT for any 0→N+ node

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
@@ -24,6 +24,7 @@ vi.mock('../../utils/markdown', () => ({
 import {
   clampPositionToViewport,
   clampPillPositionToViewport,
+  computeResizeBudget,
 } from '../FloatingOlumiPanel'
 
 const VIEWPORT = { w: 1200, h: 800 }
@@ -110,5 +111,55 @@ describe('clampPillPositionToViewport', () => {
     const out = clampPillPositionToViewport({ x: 1100, y: 100 }, VIEWPORT.w, VIEWPORT.h, 360)
     expect(out.x).toBe(VIEWPORT.w - 84 - MARGIN - 360)
     expect(out.x).toBe(740)
+  })
+})
+
+describe('computeResizeBudget — bottom-right resize bounds', () => {
+  // P1 regression: the previous resize handler grew width without
+  // accounting for the dock inset, allowing the right edge to slide
+  // under the dock as the user resized. computeResizeBudget caps the
+  // available width from the panel's current x to either the viewport
+  // right margin (no dock) or the dock's left edge (open dock).
+
+  it('width budget includes dock inset', () => {
+    // x=600, dock 360 wide + 12 gap → dockInset 372 on a 1200 viewport.
+    // Budget = 1200 - 600 - 16 - 372 = 212.
+    const out = computeResizeBudget(600, 100, VIEWPORT.w, VIEWPORT.h, 372)
+    expect(out.widthBudget).toBe(212)
+  })
+
+  it('width budget falls back to viewport-minus-margin when no dock', () => {
+    const out = computeResizeBudget(600, 100, VIEWPORT.w, VIEWPORT.h, 0)
+    expect(out.widthBudget).toBe(VIEWPORT.w - 600 - MARGIN)
+  })
+
+  it('does NOT floor width budget at MIN_WIDTH — the dock constraint wins', () => {
+    // x near the dock: 900, dock 360 → remaining canvas is tiny.
+    // 1200 - 900 - 16 - 360 = -76. Floored at 0 (not MIN_WIDTH) so the
+    // caller's composed clamp lets the panel shrink below MIN_WIDTH
+    // rather than overlap the dock.
+    const out = computeResizeBudget(900, 100, VIEWPORT.w, VIEWPORT.h, 360)
+    expect(out.widthBudget).toBe(0)
+  })
+
+  it('height budget mirrors width budget for the bottom edge', () => {
+    const out = computeResizeBudget(0, 500, VIEWPORT.w, VIEWPORT.h, 0)
+    expect(out.heightBudget).toBe(VIEWPORT.h - 500 - MARGIN)
+  })
+
+  it('caps a resize attempt that would exceed the dock-aware budget', () => {
+    // Simulate: panel at x=600, current size 400x500. User drags resize
+    // handle far right (dw=1000). Without budget the width would grow
+    // to 1400; with the dock-aware cap it must stop at widthBudget.
+    const { widthBudget } = computeResizeBudget(600, 100, VIEWPORT.w, VIEWPORT.h, 372)
+    const startW = 400
+    const dw = 1000
+    const wPreCapped = Math.max(startW, startW + dw)
+    expect(wPreCapped).toBe(1400) // sanity: pre-cap value would overflow
+    const wCapped = Math.min(wPreCapped, widthBudget)
+    expect(wCapped).toBe(widthBudget)
+    // And the right edge stays clear of the dock left.
+    const dockLeft = VIEWPORT.w - 372 // dock.left = vw - inset
+    expect(600 + wCapped).toBeLessThanOrEqual(dockLeft)
   })
 })

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
@@ -36,6 +36,31 @@ describe('clampPositionToViewport', () => {
     expect(out).toEqual({ x: 200, y: 100 })
   })
 
+  it('rightInset (open OutputsDock) shrinks the usable area on the right edge', () => {
+    // OutputsDock open at 360px on the right. The floating panel's right
+    // edge must stay clear of the dock. Without rightInset the panel
+    // (400px wide) could land at x=784 (viewport_w − panel_w − margin),
+    // which sits UNDER the dock. With rightInset=360, max x must drop to
+    // 1200 − 400 − 16 − 360 = 424.
+    const out = clampPositionToViewport({ x: 1000, y: 100 }, SIZE, VIEWPORT.w, VIEWPORT.h, 360)
+    expect(out.x).toBe(VIEWPORT.w - SIZE.width - MARGIN - 360)
+    expect(out.x).toBe(424)
+  })
+
+  it('rightInset of 0 (dock closed/collapsed) preserves the original right edge', () => {
+    const without = clampPositionToViewport({ x: 1000, y: 100 }, SIZE, VIEWPORT.w, VIEWPORT.h)
+    const withZero = clampPositionToViewport({ x: 1000, y: 100 }, SIZE, VIEWPORT.w, VIEWPORT.h, 0)
+    expect(withZero).toEqual(without)
+  })
+
+  it('rightInset larger than usable width still keeps the panel at the margin (no negative x)', () => {
+    // Dock 1100px on a 1200px viewport: only 100px of usable area remains
+    // — less than the 400px panel. Top-left must still be at the margin,
+    // not a negative coordinate.
+    const out = clampPositionToViewport({ x: 800, y: 100 }, SIZE, VIEWPORT.w, VIEWPORT.h, 1100)
+    expect(out.x).toBe(MARGIN)
+  })
+
   it('clamps an x that would push the right edge off-screen', () => {
     // Right edge would be at 1000 + 400 = 1400, viewport is 1200 → x must
     // become 1200 - 400 - 16 = 784.
@@ -77,5 +102,13 @@ describe('clampPillPositionToViewport', () => {
     // Pill height 28 + margin 16: max y is 800 - 28 - 16 = 756.
     const out = clampPillPositionToViewport({ x: 200, y: 790 }, VIEWPORT.w, VIEWPORT.h)
     expect(out.y).toBe(VIEWPORT.h - 28 - MARGIN)
+  })
+
+  it('rightInset shrinks the right edge so the pill never lands under the dock', () => {
+    // Pill width 84 + margin 16 + dock 360 = 460. Max x on a 1200 viewport
+    // becomes 1200 − 460 = 740.
+    const out = clampPillPositionToViewport({ x: 1100, y: 100 }, VIEWPORT.w, VIEWPORT.h, 360)
+    expect(out.x).toBe(VIEWPORT.w - 84 - MARGIN - 360)
+    expect(out.x).toBe(740)
   })
 })

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * FloatingOlumiPanel — viewport-clamp helpers.
+ *
+ * Pure-function tests for clampPositionToViewport / clampPillPositionToViewport.
+ * Covers the polish requirement: default, restored, and minimised positions
+ * are all clamped to the visible viewport so the panel never lands partially
+ * off-canvas (e.g. after the user resizes their window between sessions).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+// FloatingOlumiPanel's transitive imports pull in supabase and the markdown
+// renderer — stub both ahead of the dynamic import below.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+import {
+  clampPositionToViewport,
+  clampPillPositionToViewport,
+} from '../FloatingOlumiPanel'
+
+const VIEWPORT = { w: 1200, h: 800 }
+const SIZE = { width: 400, height: 500 }
+const MARGIN = 16
+
+describe('clampPositionToViewport', () => {
+  it('passes through a fully visible position unchanged', () => {
+    const out = clampPositionToViewport({ x: 200, y: 100 }, SIZE, VIEWPORT.w, VIEWPORT.h)
+    expect(out).toEqual({ x: 200, y: 100 })
+  })
+
+  it('clamps an x that would push the right edge off-screen', () => {
+    // Right edge would be at 1000 + 400 = 1400, viewport is 1200 → x must
+    // become 1200 - 400 - 16 = 784.
+    const out = clampPositionToViewport({ x: 1000, y: 100 }, SIZE, VIEWPORT.w, VIEWPORT.h)
+    expect(out.x).toBe(VIEWPORT.w - SIZE.width - MARGIN)
+    expect(out.y).toBe(100)
+  })
+
+  it('clamps a y that would push the bottom edge off-screen', () => {
+    const out = clampPositionToViewport({ x: 200, y: 700 }, SIZE, VIEWPORT.w, VIEWPORT.h)
+    expect(out.x).toBe(200)
+    expect(out.y).toBe(VIEWPORT.h - SIZE.height - MARGIN)
+  })
+
+  it('clamps negative coordinates to the margin', () => {
+    const out = clampPositionToViewport({ x: -50, y: -200 }, SIZE, VIEWPORT.w, VIEWPORT.h)
+    expect(out).toEqual({ x: MARGIN, y: MARGIN })
+  })
+
+  it('degenerate viewport (smaller than panel) still produces a sane top-left at the margin', () => {
+    const out = clampPositionToViewport({ x: 500, y: 500 }, SIZE, 200, 200)
+    expect(out).toEqual({ x: MARGIN, y: MARGIN })
+  })
+})
+
+describe('clampPillPositionToViewport', () => {
+  it('passes through a fully visible pill position unchanged', () => {
+    const out = clampPillPositionToViewport({ x: 200, y: 100 }, VIEWPORT.w, VIEWPORT.h)
+    expect(out).toEqual({ x: 200, y: 100 })
+  })
+
+  it('clamps a pill x that would push past the right edge', () => {
+    // Pill width 84 + margin 16: max x is 1200 - 84 - 16 = 1100.
+    const out = clampPillPositionToViewport({ x: 1180, y: 100 }, VIEWPORT.w, VIEWPORT.h)
+    expect(out.x).toBe(VIEWPORT.w - 84 - MARGIN)
+  })
+
+  it('clamps a pill y that would push past the bottom edge', () => {
+    // Pill height 28 + margin 16: max y is 800 - 28 - 16 = 756.
+    const out = clampPillPositionToViewport({ x: 200, y: 790 }, VIEWPORT.w, VIEWPORT.h)
+    expect(out.y).toBe(VIEWPORT.h - 28 - MARGIN)
+  })
+})

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
@@ -25,6 +25,7 @@ import {
   clampPositionToViewport,
   clampPillPositionToViewport,
   computeResizeBudget,
+  fitsAtMinSize,
 } from '../FloatingOlumiPanel'
 
 const VIEWPORT = { w: 1200, h: 800 }
@@ -147,19 +148,53 @@ describe('computeResizeBudget — bottom-right resize bounds', () => {
     expect(out.heightBudget).toBe(VIEWPORT.h - 500 - MARGIN)
   })
 
-  it('caps a resize attempt that would exceed the dock-aware budget', () => {
-    // Simulate: panel at x=600, current size 400x500. User drags resize
-    // handle far right (dw=1000). Without budget the width would grow
-    // to 1400; with the dock-aware cap it must stop at widthBudget.
+  it('caps a resize attempt that would exceed the dock-aware budget (MIN_WIDTH preserved)', () => {
+    // Panel at x=600, current size 400x500. User drags resize handle far
+    // right (dw=1000). Without budget the width would grow to 1400;
+    // with the dock-aware cap AND the MIN_WIDTH floor, it caps at
+    // `max(MIN_WIDTH=320, min(max.width, widthBudget, requested))`.
+    // Here widthBudget = 1200 - 600 - 16 - 372 = 212, but MIN_WIDTH=320
+    // wins → wCapped = 320. (At narrower budgets the layout effect would
+    // have auto-minimised; here the test viewport leaves room for that
+    // path NOT to fire.)
     const { widthBudget } = computeResizeBudget(600, 100, VIEWPORT.w, VIEWPORT.h, 372)
     const startW = 400
     const dw = 1000
-    const wPreCapped = Math.max(startW, startW + dw)
-    expect(wPreCapped).toBe(1400) // sanity: pre-cap value would overflow
-    const wCapped = Math.min(wPreCapped, widthBudget)
-    expect(wCapped).toBe(widthBudget)
-    // And the right edge stays clear of the dock left.
-    const dockLeft = VIEWPORT.w - 372 // dock.left = vw - inset
-    expect(600 + wCapped).toBeLessThanOrEqual(dockLeft)
+    const max = { width: Math.floor(VIEWPORT.w * 0.6), height: 720 }
+    const requestedW = Math.max(320, startW + dw)
+    const wCapped = Math.max(320, Math.min(max.width, widthBudget, requestedW))
+    expect(wCapped).toBe(320)
+  })
+})
+
+describe('fitsAtMinSize — auto-minimise gate', () => {
+  // P1 follow-up: when the dock + margins leave less room than
+  // MIN_WIDTH × MIN_HEIGHT (320 × 300), the panel must auto-minimise
+  // to the pill rather than render at a sub-MIN size.
+
+  it('returns true on a wide viewport with no dock', () => {
+    expect(fitsAtMinSize(VIEWPORT.w, VIEWPORT.h, 0)).toBe(true)
+  })
+
+  it('returns true with an open dock when room remains for a MIN_WIDTH panel', () => {
+    // 1200 - 32 (margins) - 400 (dock) = 768 — plenty of room for MIN_WIDTH (320).
+    expect(fitsAtMinSize(VIEWPORT.w, VIEWPORT.h, 400)).toBe(true)
+  })
+
+  it('returns false when dock + margins leave less than MIN_WIDTH', () => {
+    // 1200 - 32 (margins) - 900 (dock) = 268 — below MIN_WIDTH (320).
+    expect(fitsAtMinSize(VIEWPORT.w, VIEWPORT.h, 900)).toBe(false)
+  })
+
+  it('returns false on a viewport too short for MIN_HEIGHT', () => {
+    expect(fitsAtMinSize(VIEWPORT.w, 200, 0)).toBe(false)
+  })
+
+  it('boundary: exactly MIN_WIDTH room → fits (≥ comparison)', () => {
+    // 800 - 32 = 768 - dockInset. Set inset so available width === 320.
+    const inset = 800 - 2 * MARGIN - 320
+    expect(fitsAtMinSize(800, 600, inset)).toBe(true)
+    // One pixel less and it must NOT fit.
+    expect(fitsAtMinSize(800, 600, inset + 1)).toBe(false)
   })
 })

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.clamp.spec.ts
@@ -115,12 +115,15 @@ describe('clampPillPositionToViewport', () => {
   })
 })
 
-describe('computeResizeBudget — bottom-right resize bounds', () => {
-  // P1 regression: the previous resize handler grew width without
-  // accounting for the dock inset, allowing the right edge to slide
-  // under the dock as the user resized. computeResizeBudget caps the
-  // available width from the panel's current x to either the viewport
-  // right margin (no dock) or the dock's left edge (open dock).
+describe('computeResizeBudget — raw geometry helper', () => {
+  // Contract: computeResizeBudget is a pure geometry helper that returns
+  // the raw space available from (x, y) to the dock-aware bottom-right
+  // corner. It does NOT enforce MIN_WIDTH / MIN_HEIGHT — those are the
+  // caller's responsibility. The composition rule the resize handler
+  // uses is `max(MIN_WIDTH, min(max.width, widthBudget, requested))`.
+  // When the geometry is so tight that no MIN-sized panel fits, the
+  // resize handler (and the layout effect) consult `fitsAtMinSize` and
+  // auto-minimise to the pill instead — see the dockInset spec.
 
   it('width budget includes dock inset', () => {
     // x=600, dock 360 wide + 12 gap → dockInset 372 on a 1200 viewport.
@@ -134,11 +137,11 @@ describe('computeResizeBudget — bottom-right resize bounds', () => {
     expect(out.widthBudget).toBe(VIEWPORT.w - 600 - MARGIN)
   })
 
-  it('does NOT floor width budget at MIN_WIDTH — the dock constraint wins', () => {
-    // x near the dock: 900, dock 360 → remaining canvas is tiny.
-    // 1200 - 900 - 16 - 360 = -76. Floored at 0 (not MIN_WIDTH) so the
-    // caller's composed clamp lets the panel shrink below MIN_WIDTH
-    // rather than overlap the dock.
+  it('returns raw geometry, floored at 0 (no MIN_WIDTH floor here)', () => {
+    // x near the dock: 900, dock 360 → 1200 - 900 - 16 - 360 = -76.
+    // Helper floors at 0 (negative budgets would break consumer math).
+    // The caller's MIN_WIDTH floor + `fitsAtMinSize` gate handle the
+    // "no room at all" case by auto-minimising.
     const out = computeResizeBudget(900, 100, VIEWPORT.w, VIEWPORT.h, 360)
     expect(out.widthBudget).toBe(0)
   })
@@ -148,15 +151,16 @@ describe('computeResizeBudget — bottom-right resize bounds', () => {
     expect(out.heightBudget).toBe(VIEWPORT.h - 500 - MARGIN)
   })
 
-  it('caps a resize attempt that would exceed the dock-aware budget (MIN_WIDTH preserved)', () => {
-    // Panel at x=600, current size 400x500. User drags resize handle far
-    // right (dw=1000). Without budget the width would grow to 1400;
-    // with the dock-aware cap AND the MIN_WIDTH floor, it caps at
-    // `max(MIN_WIDTH=320, min(max.width, widthBudget, requested))`.
-    // Here widthBudget = 1200 - 600 - 16 - 372 = 212, but MIN_WIDTH=320
-    // wins → wCapped = 320. (At narrower budgets the layout effect would
-    // have auto-minimised; here the test viewport leaves room for that
-    // path NOT to fire.)
+  it('composes correctly: preserve MIN_WIDTH and clamp to budget', () => {
+    // Panel at x=600, current size 400x500. User drags resize handle
+    // far right (dw=1000) → requested = 1400. The resize handler
+    // composes `max(MIN_WIDTH, min(max.width, widthBudget, requested))`.
+    //
+    // Here `widthBudget = 1200 - 600 - 16 - 372 = 212`, below MIN_WIDTH.
+    // Result: composed width = max(320, min(720, 212, 1400)) = 320.
+    // MIN_WIDTH is preserved; the panel does not shrink below it. The
+    // layout effect's `fitsAtMinSize` gate decides whether the panel
+    // is rendered at all at this viewport — see the dockInset spec.
     const { widthBudget } = computeResizeBudget(600, 100, VIEWPORT.w, VIEWPORT.h, 372)
     const startW = 400
     const dw = 1000

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -1,0 +1,240 @@
+/**
+ * DOM-level dock-inset regression: the floating panel's layout effect must
+ * read the real OutputsDock width (including any right-edge offset like
+ * `right: 12px`) and clamp accordingly. Verifies both the initial layout
+ * and re-clamping when the dock's width changes after the panel is open.
+ *
+ * jsdom does not run CSS layout, so we mount a stub <aside> and override
+ * its getBoundingClientRect to simulate the real dock's placement.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+const canvasMockState = {
+  nodes: [{ id: 'n1' }],
+  edges: [] as Array<unknown>,
+  results: { status: 'idle' as const },
+  _internal: {} as Record<string, unknown>,
+  selection: null as null | { id: string; label: string; kind: string },
+  ceeAnalysisReady: null as any,
+  graphHealth: null as any,
+  runMeta: {} as any,
+}
+vi.mock('../../store', () => {
+  const useCanvasStore: any = (selector: (s: any) => any) => selector(canvasMockState)
+  useCanvasStore.getState = () => canvasMockState
+  useCanvasStore.setState = (patch: any) => Object.assign(canvasMockState, patch)
+  useCanvasStore.subscribe = () => () => {}
+  return {
+    useCanvasStore,
+    selectResultsStatus: (s: any) => s.results?.status,
+    selectReport: (s: any) => s.results?.report,
+    selectError: (s: any) => s.results?.error,
+    selectResultsSource: (s: any) => s.results?.source,
+  }
+})
+
+// Stub ConversationPanel — its deep render is irrelevant for layout
+// invariants and adds tens of transitive deps. We only need the outer
+// FloatingOlumiPanel container to mount with its layout effect.
+vi.mock('../../conversation/ConversationPanel', () => ({
+  ConversationPanel: () => null,
+}))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Ask',
+}))
+vi.mock('../../ui/inspector-v2/useStaleGuard', () => ({
+  useStaleGuard: () => ({ analysisState: 'none', isStale: false }),
+}))
+
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      return {
+        // Empty messages: avoids pulling in ConversationPanel's bubble
+        // rendering path (which transitively requires more exports).
+        messages: [],
+        isThinking: false,
+        longRunningHint: null,
+        lastFailedInput: null,
+        sendMessage,
+        sendSystemEvent: vi.fn(),
+        sendChip: vi.fn(),
+        retryLast: vi.fn(),
+        patchBlockStates: new Map(),
+        setPatchBlockState: vi.fn(),
+        patchRejections: new Map(),
+        setPatchRejection: vi.fn(),
+      }
+    },
+    isNonConversationalContent: () => false,
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { FloatingOlumiPanel } from '../FloatingOlumiPanel'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+const VIEWPORT_W = 1440
+const VIEWPORT_H = 900
+
+/** Mount a stub OutputsDock <aside> with a mocked bounding rect. */
+function mountStubDock(opts: { width: number; right: number }): {
+  el: HTMLElement
+  setWidth: (w: number) => void
+  unmount: () => void
+} {
+  const el = document.createElement('aside')
+  el.setAttribute('aria-label', 'Outputs dock')
+  document.body.appendChild(el)
+  const state = { ...opts }
+  el.getBoundingClientRect = function () {
+    const left = VIEWPORT_W - state.width - state.right
+    return {
+      left,
+      top: 60,
+      right: VIEWPORT_W - state.right,
+      bottom: VIEWPORT_H - 12,
+      width: state.width,
+      height: VIEWPORT_H - 72,
+      x: left,
+      y: 60,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+  return {
+    el,
+    setWidth: (w: number) => { state.width = w },
+    unmount: () => el.remove(),
+  }
+}
+
+beforeEach(() => {
+  // Pin viewport so the test is deterministic.
+  Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  Object.defineProperty(window, 'innerHeight', { value: VIEWPORT_H, configurable: true })
+  useFloatingPanelState.getState().reset()
+})
+
+afterEach(() => {
+  document.body.querySelectorAll('aside[aria-label="Outputs dock"]').forEach((el) => el.remove())
+})
+
+describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
+  it('respects the dock width AND its right-edge gap when laying out for the first time', () => {
+    // Dock: 388px wide, 12px right offset → reserved area = 400.
+    // Default panel is 400px wide. Without dock-aware clamp the centred
+    // x would be (1440-400)/2 = 520; with inset=400 the max x becomes
+    // 1440 - 400 - 16 - 400 = 624 (no constraint here) but the centred
+    // default uses `vw - dockInset` so the panel centres in the visible
+    // canvas instead — left = (1440-400-400)/2 = 320.
+    const dock = mountStubDock({ width: 388, right: 12 })
+    useFloatingPanelState.getState().open('user')
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement
+    expect(panel).toBeTruthy()
+    const left = parseFloat(panel.style.left)
+    const width = parseFloat(panel.style.width)
+    // The right edge of the panel must clear the dock's left edge.
+    const panelRight = left + width
+    const dockLeft = VIEWPORT_W - 388 - 12
+    expect(panelRight).toBeLessThanOrEqual(dockLeft)
+    dock.unmount()
+  })
+
+  it('clamps a stored position that would land under the dock back into the visible canvas', () => {
+    // Pre-place the panel at x=1200 (would overlap the dock).
+    const dock = mountStubDock({ width: 388, right: 12 })
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: false,
+      position: { x: 1200, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement
+    const left = parseFloat(panel.style.left)
+    const width = parseFloat(panel.style.width)
+    const panelRight = left + width
+    const dockLeft = VIEWPORT_W - 388 - 12
+    expect(panelRight).toBeLessThanOrEqual(dockLeft)
+    dock.unmount()
+  })
+
+  it('re-clamps when the dock width changes AFTER the panel is open (ResizeObserver path)', () => {
+    // Start with the dock collapsed (rail = 40px + 12 right).
+    const dock = mountStubDock({ width: 40, right: 12 })
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: false,
+      // Park the panel at x=1000 — visible while dock is collapsed
+      // (rail at left=1388), would overlap when dock expands.
+      position: { x: 1000, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement
+    // Initial layout with rail-width dock: panel right (1400) <= rail
+    // left (1388)? Actually 1400 > 1388 — clamp moves panel left to
+    // dockLeft - width − margin. Let's just assert the invariant.
+    let left = parseFloat(panel.style.left)
+    let width = parseFloat(panel.style.width)
+    expect(left + width).toBeLessThanOrEqual(VIEWPORT_W - 40 - 12)
+
+    // Now the dock expands (e.g. user clicked a tab → full 388px width).
+    // Dispatch the dock-opened event the dock already emits; the
+    // observer hook also re-runs on this. Even without ResizeObserver
+    // support in jsdom, the event-driven recompute kicks in.
+    act(() => {
+      dock.setWidth(388)
+      window.dispatchEvent(new Event('outputs-dock-opened'))
+    })
+
+    left = parseFloat(panel.style.left)
+    width = parseFloat(panel.style.width)
+    const dockLeftAfter = VIEWPORT_W - 388 - 12
+    expect(left + width).toBeLessThanOrEqual(dockLeftAfter)
+    dock.unmount()
+  })
+
+  it('treats an absent dock (FF-off, dock unmounted) as zero inset', () => {
+    // No stub mounted. measureDockInset returns 0 → panel can extend to
+    // the viewport's right margin minus default margin.
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: false,
+      position: { x: 1000, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement
+    const left = parseFloat(panel.style.left)
+    const width = parseFloat(panel.style.width)
+    // Max right edge = viewport - margin (16). Just assert no off-screen.
+    expect(left + width).toBeLessThanOrEqual(VIEWPORT_W - 16)
+  })
+})

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -219,6 +219,48 @@ describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
     dock.unmount()
   })
 
+  it('reserves dock inset on a narrow viewport even when dock.left < vw/2', () => {
+    // Narrow viewport: 800px. Dock 500px wide + 12 right gap → left=288.
+    // 288 < 400 (half of 800) — the previous half-viewport guard would
+    // have dropped the inset to 0 and centred the panel at x=200.
+    // With the guard removed, the inset is properly reserved and the
+    // panel is clamped to the left margin (the dock leaves too little
+    // room for a 400px panel to fit — that's a viewport-too-small
+    // condition the user resolves by closing the dock — but the
+    // reservation MUST happen so the panel doesn't drift right under
+    // the dock).
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    const dock = mountStubDock({ width: 500, right: 12 })
+    dock.el.getBoundingClientRect = function () {
+      const left = 800 - 500 - 12 // 288
+      return { left, top: 60, right: 800 - 12, bottom: 900 - 12, width: 500, height: 800, x: left, y: 60, toJSON: () => ({}) } as DOMRect
+    }
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: false,
+      position: { x: 600, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement
+    const left = parseFloat(panel.style.left)
+    // Without inset (regression) the panel would centre at x = (800-400)/2 = 200.
+    // With the inset properly reserved the panel is pinned to the
+    // left margin (16). The distinguishing assertion is `left === 16`.
+    expect(left).toBe(16)
+    dock.unmount()
+    Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  })
+
+  // Note: the resize math is regression-tested as a pure function via
+  // `computeResizeBudget` in FloatingOlumiPanel.clamp.spec — that's the
+  // load-bearing assertion. The DOM-level drag plumbing isn't readily
+  // testable in jsdom (no PointerEvent class, no layout-driven rect),
+  // and exercising it here would only verify React's event delegation
+  // (already covered by RTL's own tests).
+
   it('treats an absent dock (FF-off, dock unmounted) as zero inset', () => {
     // No stub mounted. measureDockInset returns 0 → panel can extend to
     // the viewport's right margin minus default margin.

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -107,14 +107,16 @@ function mountStubDock(opts: { width: number; right: number }): {
   document.body.appendChild(el)
   const state = { ...opts }
   el.getBoundingClientRect = function () {
-    const left = VIEWPORT_W - state.width - state.right
+    const viewportW = window.innerWidth || VIEWPORT_W
+    const viewportH = window.innerHeight || VIEWPORT_H
+    const left = viewportW - state.width - state.right
     return {
       left,
       top: 60,
-      right: VIEWPORT_W - state.right,
-      bottom: VIEWPORT_H - 12,
+      right: viewportW - state.right,
+      bottom: viewportH - 12,
       width: state.width,
-      height: VIEWPORT_H - 72,
+      height: viewportH - 72,
       x: left,
       y: 60,
       toJSON: () => ({}),
@@ -404,29 +406,30 @@ describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
     Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
   })
 
-  it('restore after narrow-viewport resize shrinks width so the panel clears the dock', () => {
+  it('1440 → 800 while minimised, then restore: shrinks width so the panel clears the dock', () => {
     // Reviewer-flagged smoke defect: at 800px with dock open, restoring
     // the panel rendered at width 400 starting at x=16 → right edge 416,
     // overlapping the dock at left=372. Fix: layout effect now caps
     // width at the available canvas (vw - 2*margin - dockInset), with
     // MIN_WIDTH as the floor. `fitsAtMinSize` guarantees the cap is
     // ≥ MIN_WIDTH (otherwise auto-minimise fires).
-    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
     const dock = mountStubDock({ width: 416, right: 12 })
-    dock.el.getBoundingClientRect = function () {
-      const left = 800 - 416 - 12 // 372
-      return { left, top: 60, right: 788, bottom: 888, width: 416, height: 828, x: left, y: 60, toJSON: () => ({}) } as DOMRect
-    }
-    // User had a 400px-wide panel from before the resize and now restores.
+    // User had a 400px-wide panel from before the resize, minimised it,
+    // then the viewport shrank from 1440 → 800 while the pill was shown.
     useFloatingPanelState.setState({
       isOpen: true,
       source: 'user',
       userRepositioned: true,
-      isMinimised: false,
-      position: { x: 16, y: 100 },
+      isMinimised: true,
+      position: { x: 900, y: 100 },
       size: { width: 400, height: 500 },
     } as any)
     render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    act(() => { window.dispatchEvent(new Event('resize')) })
+    act(() => { useFloatingPanelState.getState().restore() })
+
     // Available canvas: 800 - 32 - 412 = 356 (>= MIN_WIDTH 320). The
     // restored width must shrink to 356, not stay at 400.
     const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -371,6 +371,36 @@ describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
     // max pill x at 800 viewport = 800 - 84 - 16 = 700.
     expect(after).toBeTruthy()
     expect(after!.x).toBeLessThanOrEqual(700)
+    // The automatic clamp is a geometry correction — it must NOT flip
+    // userRepositioned. That flag is reserved for genuine user drags
+    // (it gates auto-dock). If a future refactor swaps the direct
+    // setState for `setPosition`, this assertion catches it.
+    expect(useFloatingPanelState.getState().userRepositioned).toBe(true)
+    Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  })
+
+  it('automatic minimised-pill clamp does NOT flip userRepositioned from false → true', () => {
+    // System-opened panel (e.g. first-use), no user drag yet. The
+    // automatic clamp on viewport resize must preserve userRepositioned
+    // === false — otherwise the next 0→N node transition would skip
+    // auto-dock (`canAutoDock` requires !userRepositioned).
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'system-first-use',
+      userRepositioned: false,
+      isMinimised: true,
+      position: { x: 1300, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    act(() => { window.dispatchEvent(new Event('resize')) })
+
+    const after = useFloatingPanelState.getState()
+    // Position changed (clamped), but userRepositioned MUST stay false.
+    expect(after.position!.x).toBeLessThanOrEqual(700)
+    expect(after.userRepositioned).toBe(false)
     Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
   })
 

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -248,6 +248,45 @@ describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
     Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
   })
 
+  it('first-open auto-minimise commits a safe pill anchor (no 50%/50% fallback under the dock)', () => {
+    // Same narrow-viewport scenario as above, but with position=null
+    // (first-open state). The bug: the pill's `position ? pos.x : '50%'`
+    // fallback would render the pill at the centre, which lands under
+    // the dock on narrow viewports. Fix: commit a top-left safe anchor
+    // BEFORE calling minimise.
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    const dock = mountStubDock({ width: 600, right: 12 })
+    dock.el.getBoundingClientRect = function () {
+      const left = 800 - 600 - 12 // 188
+      return { left, top: 60, right: 788, bottom: 888, width: 600, height: 828, x: left, y: 60, toJSON: () => ({}) } as DOMRect
+    }
+    // First-open: position is null in store.
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: false,
+      isMinimised: false,
+      position: null,
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(useFloatingPanelState.getState().isMinimised).toBe(true)
+    const committed = useFloatingPanelState.getState().position
+    // A safe anchor MUST have been committed — not null.
+    expect(committed).not.toBeNull()
+    // And it must be a real pixel position (not the 50% fallback). The
+    // top-left margin (16, 16) is the canonical safe anchor.
+    expect(committed!.x).toBe(16)
+    expect(committed!.y).toBe(16)
+    // Verify the pill's rendered style uses a numeric left/top, not 50%.
+    const pill = document.querySelector('[data-testid="floating-olumi-panel-pill"]') as HTMLElement
+    expect(pill).toBeTruthy()
+    expect(pill.style.left).toBe('16px')
+    expect(pill.style.top).toBe('16px')
+    dock.unmount()
+    Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  })
+
   it('does NOT auto-minimise on a wide viewport (room remains for MIN_WIDTH)', () => {
     // 1440x900 with dock 400 + 12 → available = 1440 - 32 - 412 = 996
     // — comfortably above MIN_WIDTH. Panel must render normally.

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -404,6 +404,45 @@ describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
     Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
   })
 
+  it('restore after narrow-viewport resize shrinks width so the panel clears the dock', () => {
+    // Reviewer-flagged smoke defect: at 800px with dock open, restoring
+    // the panel rendered at width 400 starting at x=16 → right edge 416,
+    // overlapping the dock at left=372. Fix: layout effect now caps
+    // width at the available canvas (vw - 2*margin - dockInset), with
+    // MIN_WIDTH as the floor. `fitsAtMinSize` guarantees the cap is
+    // ≥ MIN_WIDTH (otherwise auto-minimise fires).
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    const dock = mountStubDock({ width: 416, right: 12 })
+    dock.el.getBoundingClientRect = function () {
+      const left = 800 - 416 - 12 // 372
+      return { left, top: 60, right: 788, bottom: 888, width: 416, height: 828, x: left, y: 60, toJSON: () => ({}) } as DOMRect
+    }
+    // User had a 400px-wide panel from before the resize and now restores.
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: false,
+      position: { x: 16, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    // Available canvas: 800 - 32 - 412 = 356 (>= MIN_WIDTH 320). The
+    // restored width must shrink to 356, not stay at 400.
+    const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement
+    expect(panel).toBeTruthy()
+    const left = parseFloat(panel.style.left)
+    const width = parseFloat(panel.style.width)
+    expect(width).toBeLessThanOrEqual(356)
+    expect(width).toBeGreaterThanOrEqual(320) // MIN_WIDTH preserved
+    // Right edge must not overlap the dock.
+    expect(left + width).toBeLessThanOrEqual(372)
+    // userRepositioned preserved (geometry correction is not a user drag).
+    expect(useFloatingPanelState.getState().userRepositioned).toBe(true)
+    dock.unmount()
+    Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  })
+
   it('reclamps the minimised pill when the dock expands (no drift under dock)', () => {
     // Start with rail-width dock + pill at x=1300 on a 1440px viewport.
     const dock = mountStubDock({ width: 40, right: 12 })

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -219,37 +219,85 @@ describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
     dock.unmount()
   })
 
-  it('reserves dock inset on a narrow viewport even when dock.left < vw/2', () => {
-    // Narrow viewport: 800px. Dock 500px wide + 12 right gap → left=288.
-    // 288 < 400 (half of 800) — the previous half-viewport guard would
-    // have dropped the inset to 0 and centred the panel at x=200.
-    // With the guard removed, the inset is properly reserved and the
-    // panel is clamped to the left margin (the dock leaves too little
-    // room for a 400px panel to fit — that's a viewport-too-small
-    // condition the user resolves by closing the dock — but the
-    // reservation MUST happen so the panel doesn't drift right under
-    // the dock).
+  it('auto-minimises to the pill when the dock leaves less than MIN_WIDTH × MIN_HEIGHT', () => {
+    // 800x900 viewport with a 600px-wide dock + 12px gap → available
+    // width = 800 - 32 - 612 = 156, well below MIN_WIDTH (320). The
+    // layout effect must call minimise() instead of rendering a
+    // too-narrow panel.
     Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
-    const dock = mountStubDock({ width: 500, right: 12 })
+    const dock = mountStubDock({ width: 600, right: 12 })
     dock.el.getBoundingClientRect = function () {
-      const left = 800 - 500 - 12 // 288
-      return { left, top: 60, right: 800 - 12, bottom: 900 - 12, width: 500, height: 800, x: left, y: 60, toJSON: () => ({}) } as DOMRect
+      const left = 800 - 600 - 12 // 188
+      return { left, top: 60, right: 788, bottom: 888, width: 600, height: 828, x: left, y: 60, toJSON: () => ({}) } as DOMRect
+    }
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: false,
+      isMinimised: false,
+      position: { x: 100, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    // After the layout effect runs, the store is minimised and the
+    // restore pill is rendered in place of the full panel.
+    expect(useFloatingPanelState.getState().isMinimised).toBe(true)
+    expect(document.querySelector('[data-testid="floating-olumi-panel-pill"]')).toBeTruthy()
+    expect(document.querySelector('[data-testid="floating-olumi-panel"]')).toBeNull()
+    dock.unmount()
+    Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  })
+
+  it('does NOT auto-minimise on a wide viewport (room remains for MIN_WIDTH)', () => {
+    // 1440x900 with dock 400 + 12 → available = 1440 - 32 - 412 = 996
+    // — comfortably above MIN_WIDTH. Panel must render normally.
+    const dock = mountStubDock({ width: 400, right: 12 })
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: false,
+      isMinimised: false,
+      position: { x: 100, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(useFloatingPanelState.getState().isMinimised).toBe(false)
+    expect(document.querySelector('[data-testid="floating-olumi-panel"]')).toBeTruthy()
+    dock.unmount()
+  })
+
+  it('reserves dock inset on a narrow viewport even when dock.left < vw/2', () => {
+    // Narrow viewport: 900px. Dock 420px wide + 12 right gap → left=468,
+    // which is > 450 (half of 900) on the nose. To exercise the
+    // dock.left < vw/2 case we drop to 880x900: dock left=448 < 440.
+    //
+    // Crucially we also leave room above MIN_WIDTH (320): 880 - 32 - 432
+    // = 416, well above MIN_WIDTH so the layout effect does NOT
+    // auto-minimise — the panel renders and the left-clamp assertion
+    // distinguishes the inset-applied path from the regression.
+    Object.defineProperty(window, 'innerWidth', { value: 880, configurable: true })
+    const dock = mountStubDock({ width: 420, right: 12 })
+    dock.el.getBoundingClientRect = function () {
+      const left = 880 - 420 - 12 // 448
+      return { left, top: 60, right: 880 - 12, bottom: 900 - 12, width: 420, height: 800, x: left, y: 60, toJSON: () => ({}) } as DOMRect
     }
     useFloatingPanelState.setState({
       isOpen: true,
       source: 'user',
       userRepositioned: true,
       isMinimised: false,
+      // Park at x=600 — under the dock if inset is dropped to 0,
+      // clamped to the left margin (16) when inset is honoured.
       position: { x: 600, y: 100 },
       size: { width: 400, height: 500 },
     } as any)
     render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(useFloatingPanelState.getState().isMinimised).toBe(false)
     const panel = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement
     const left = parseFloat(panel.style.left)
-    // Without inset (regression) the panel would centre at x = (800-400)/2 = 200.
-    // With the inset properly reserved the panel is pinned to the
-    // left margin (16). The distinguishing assertion is `left === 16`.
-    expect(left).toBe(16)
+    const width = parseFloat(panel.style.width)
+    // Inset honoured → panel right edge must be ≤ dock left (448).
+    expect(left + width).toBeLessThanOrEqual(448)
     dock.unmount()
     Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
   })

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.dockInset.spec.tsx
@@ -348,6 +348,62 @@ describe('FloatingOlumiPanel — dock-inset clamp (real DOM)', () => {
   // and exercising it here would only verify React's event delegation
   // (already covered by RTL's own tests).
 
+  it('reclamps the minimised pill on viewport resize (no drift off-screen)', () => {
+    // Start with the pill committed at x=1300 on a 1440px viewport
+    // (where 1300 + 84-px pill + 16-px margin = 1400, still visible).
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: true,
+      position: { x: 1300, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(useFloatingPanelState.getState().position).toEqual({ x: 1300, y: 100 })
+
+    // Shrink the viewport: 800px. The pill at x=1300 would now sit off-
+    // screen. The resize handler must reclamp it back into view.
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    act(() => { window.dispatchEvent(new Event('resize')) })
+
+    const after = useFloatingPanelState.getState().position
+    // max pill x at 800 viewport = 800 - 84 - 16 = 700.
+    expect(after).toBeTruthy()
+    expect(after!.x).toBeLessThanOrEqual(700)
+    Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  })
+
+  it('reclamps the minimised pill when the dock expands (no drift under dock)', () => {
+    // Start with rail-width dock + pill at x=1300 on a 1440px viewport.
+    const dock = mountStubDock({ width: 40, right: 12 })
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: true,
+      position: { x: 1300, y: 100 },
+      size: { width: 400, height: 500 },
+    } as any)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    // At rail width the dock left = 1388; pill at x=1300 (right edge 1384) fits.
+    expect(useFloatingPanelState.getState().position!.x).toBe(1300)
+
+    // Dock expands to 388 + 12 → dock.left = 1040. Pill at x=1300 now
+    // overlaps the dock. The dock-opened event fires (the dock dispatches
+    // it on tab activation; we trigger directly here).
+    act(() => {
+      dock.setWidth(388)
+      window.dispatchEvent(new Event('outputs-dock-opened'))
+    })
+
+    const after = useFloatingPanelState.getState().position
+    // Pill width 84 + margin 16; dock at left=1040 → max pill x = 1040 - 84 - 16 = 940.
+    expect(after).toBeTruthy()
+    expect(after!.x).toBeLessThanOrEqual(940)
+    dock.unmount()
+  })
+
   it('treats an absent dock (FF-off, dock unmounted) as zero inset', () => {
     // No stub mounted. measureDockInset returns 0 → panel can extend to
     // the viewport's right margin minus default margin.

--- a/src/canvas/components/__tests__/aiPanelV2.polish.spec.tsx
+++ b/src/canvas/components/__tests__/aiPanelV2.polish.spec.tsx
@@ -1,0 +1,219 @@
+/**
+ * aiPanelV2 UX polish — regression coverage for the PR #148 polish pass.
+ *
+ * Covers:
+ *  - Item 1: docked Olumi tab shows a placeholder ("Olumi is open in the
+ *    floating panel") with Focus + Dock actions when floating is open.
+ *  - Item 4: AIInputBar shows "Generating your decision model…" and
+ *    disables typing when isThinking + canvas is empty (model-generation
+ *    turn in flight).
+ *  - Item 5: PersistentInputStrip status mode uses fixed copy ("Olumi is
+ *    open · Focus →") — not a truncated last-message preview.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+// Heavy imports — same stub pattern as the interactions spec.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }),
+  },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+// Canvas store mock — tests flip `canvasMockState.nodes` between empty
+// (generating) and populated.
+const canvasMockState: { nodes: Array<{ id: string }> } = { nodes: [{ id: 'n1' }] }
+vi.mock('../../store', () => ({
+  useCanvasStore: (selector: (s: any) => any) => selector(canvasMockState),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Ask about this model…',
+}))
+vi.mock('../../ui/inspector-v2/useStaleGuard', () => ({
+  useStaleGuard: () => ({ analysisState: 'none', isStale: false }),
+}))
+vi.mock('../../hooks/useSelectionContext', () => ({
+  useSelectionContext: () => null,
+}))
+
+// useConversation mock — `messages` and `isThinking` are mutable so tests
+// can drive different states. Stable mock fns to avoid identity churn.
+const conversationMockState: {
+  messages: Array<{ id: string; role: string; content?: string; synthetic?: boolean }>
+  isThinking: boolean
+} = { messages: [], isThinking: false }
+
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      const [sendSystemEvent] = useState(() => vi.fn())
+      const [sendChip] = useState(() => vi.fn())
+      const [retryLast] = useState(() => vi.fn())
+      const [setPatchBlockState] = useState(() => vi.fn())
+      const [setPatchRejection] = useState(() => vi.fn())
+      return {
+        messages: conversationMockState.messages,
+        isThinking: conversationMockState.isThinking,
+        longRunningHint: null,
+        lastFailedInput: null,
+        sendMessage,
+        sendSystemEvent,
+        sendChip,
+        retryLast,
+        patchBlockStates: new Map(),
+        setPatchBlockState,
+        patchRejections: new Map(),
+        setPatchRejection,
+      }
+    },
+  }
+})
+
+import { ConversationProvider, useConversationContext } from '../../conversation/ConversationContext'
+import { AIInputBar } from '../AIInputBar'
+import { OlumiTabBody } from '../OlumiTabBody'
+import { PersistentInputStrip } from '../PersistentInputStrip'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+beforeEach(() => {
+  useFloatingPanelState.getState().reset()
+  canvasMockState.nodes = [{ id: 'n1' }]
+  conversationMockState.messages = []
+  conversationMockState.isThinking = false
+})
+
+describe('Item 1 — Olumi tab placeholder when floating is open', () => {
+  it('renders the floating-state placeholder (not the conversation) when isOpen', () => {
+    useFloatingPanelState.getState().open('user')
+    render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
+    expect(screen.getByTestId('olumi-tab-floating-placeholder')).toBeInTheDocument()
+    expect(screen.getByText(/Olumi is open in the floating panel\./i)).toBeInTheDocument()
+    expect(screen.getByTestId('olumi-tab-focus-floating')).toBeInTheDocument()
+    expect(screen.getByTestId('olumi-tab-dock-here')).toBeInTheDocument()
+    // The empty-state body must NOT also render — one readable surface only.
+    expect(screen.queryByTestId('olumi-tab-empty')).toBeNull()
+    expect(screen.queryByTestId('olumi-tab-body')).toBeNull()
+  })
+
+  it('Dock here closes the floating panel', () => {
+    useFloatingPanelState.getState().open('user')
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
+    render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
+    fireEvent.click(screen.getByTestId('olumi-tab-dock-here'))
+    expect(useFloatingPanelState.getState().isOpen).toBe(false)
+  })
+
+  it('falls back to the existing empty-state body when floating is closed and no messages', () => {
+    render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
+    expect(screen.getByTestId('olumi-tab-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('olumi-tab-floating-placeholder')).toBeNull()
+  })
+})
+
+describe('Item 4 — AIInputBar generating state (isThinking + empty canvas)', () => {
+  beforeEach(() => {
+    canvasMockState.nodes = []
+  })
+
+  it('shows "Generating your decision model…" placeholder and disables typing during a generate turn', () => {
+    conversationMockState.isThinking = true
+    render(<AIInputBar variant="first-use" hideChevron testId="gen" />, { wrapper: Wrapper })
+    const textarea = screen.getByTestId('gen-textarea') as HTMLTextAreaElement
+    expect(textarea.placeholder).toBe('Generating your decision model…')
+    expect(textarea).toBeDisabled()
+  })
+
+  it('does NOT disable typing when isThinking but nodes already exist (chat-mode thinking)', () => {
+    canvasMockState.nodes = [{ id: 'n1' }]
+    conversationMockState.isThinking = true
+    render(<AIInputBar variant="docked-tab" hideChevron testId="chat" />, { wrapper: Wrapper })
+    const textarea = screen.getByTestId('chat-textarea') as HTMLTextAreaElement
+    // Chat-mode thinking still blocks Enter via handleSend, but the textarea
+    // stays editable so the user can compose follow-up while waiting.
+    expect(textarea).not.toBeDisabled()
+    expect(textarea.placeholder).not.toMatch(/Generating/i)
+  })
+
+  it('prevents duplicate sends while a generate turn is in flight', () => {
+    conversationMockState.isThinking = true
+    canvasMockState.nodes = []
+    let capturedSendMessage: any = null
+    function Capture() {
+      capturedSendMessage = useConversationContext().sendMessage
+      return null
+    }
+    render(
+      <Wrapper>
+        <Capture />
+        <AIInputBar variant="first-use" hideChevron testId="gen" />
+      </Wrapper>,
+    )
+    const textarea = screen.getByTestId('gen-textarea') as HTMLTextAreaElement
+    // The textarea is disabled so fireEvent.change would normally be a no-op,
+    // but jsdom permits programmatic value mutation. Still — pressing Enter
+    // must not dispatch a send because handleSend's isThinking guard rejects.
+    act(() => {
+      fireEvent.change(textarea, { target: { value: 'try to interrupt' } })
+    })
+    act(() => {
+      fireEvent.keyDown(textarea, { key: 'Enter' })
+    })
+    expect((capturedSendMessage as any).mock?.calls ?? []).toHaveLength(0)
+  })
+})
+
+describe('Item 5 — PersistentInputStrip status copy is fixed (no truncated preview)', () => {
+  it('shows "Olumi is open" + "Focus →" instead of the last assistant message preview', () => {
+    useFloatingPanelState.getState().open('user')
+    conversationMockState.messages = [
+      { id: 'a-0', role: 'assistant', content: 'A very long assistant message that would previously appear truncated to fifty characters in the strip status.' },
+    ]
+    render(
+      <PersistentInputStrip
+        isOlumiTabActive={true}
+        onOpenFloating={() => {}}
+        onFocusFloating={() => {}}
+        onCogClick={() => {}}
+      />,
+      { wrapper: Wrapper },
+    )
+    const status = screen.getByTestId('persistent-strip-status')
+    expect(status).toHaveTextContent(/Olumi is open/)
+    expect(status).toHaveTextContent(/Focus/)
+    // The previous preview substring must not leak through.
+    expect(status).not.toHaveTextContent(/A very long assistant message/)
+    expect(status).not.toHaveTextContent(/Thinking/)
+  })
+
+  it('keeps the fixed copy even while a turn is in flight (no "Thinking…" override)', () => {
+    useFloatingPanelState.getState().open('user')
+    conversationMockState.isThinking = true
+    render(
+      <PersistentInputStrip
+        isOlumiTabActive={true}
+        onOpenFloating={() => {}}
+        onFocusFloating={() => {}}
+        onCogClick={() => {}}
+      />,
+      { wrapper: Wrapper },
+    )
+    const status = screen.getByTestId('persistent-strip-status')
+    expect(status).toHaveTextContent(/Olumi is open/)
+    expect(status).not.toHaveTextContent(/Thinking/)
+  })
+})

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -1,0 +1,140 @@
+/**
+ * aiPanelV2 UX polish — Run analysis chip suppression/relabel.
+ *
+ * Contract (only when aiPanelV2 is ON):
+ *   - analysisState === 'current'  → run_analysis chip is SUPPRESSED entirely.
+ *     Analysis/readiness is the canonical place for re-running.
+ *   - analysisState === 'stale'    → run_analysis chip is RELABELLED to 'Rerun'.
+ *     The action stays available but the label tells the user nothing fresh.
+ *   - analysisState === 'none'     → unchanged (the user has never run).
+ *
+ * When aiPanelV2 is OFF, the chip is rendered unchanged (legacy parity).
+ *
+ * Independent of the V5 readiness gate — this filter runs after the V5
+ * filter, on whatever survives.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SuggestedChips } from '../zones/SuggestedChips'
+import { useCanvasStore } from '../../store'
+import type { ActionChip } from '../types'
+
+function makeChip(overrides: Partial<ActionChip> = {}): ActionChip {
+  return {
+    id: overrides.id ?? 'chip_1',
+    label: 'Run analysis',
+    intent: 'primary',
+    message: 'Please run the analysis now',
+    ...overrides,
+  }
+}
+
+/** Drive useStaleGuard's three return shapes via the canvas store. */
+function setAnalysisState(state: 'none' | 'current' | 'stale') {
+  if (state === 'none') {
+    useCanvasStore.setState({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      results: { status: 'idle' } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _internal: { graphHash: undefined } as any,
+    })
+    return
+  }
+  useCanvasStore.setState({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    results: { status: 'complete', graphHash: 'abc123' } as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _internal: { graphHash: state === 'current' ? 'abc123' : 'xyz999' } as any,
+  })
+}
+
+describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
+  beforeEach(() => {
+    // Polish filter is FF-gated. makeFlag eagerly snapshots import.meta.env
+    // at module load — vi.stubEnv arrives too late. localStorage is the only
+    // runtime-mutable override path. Any non-'0'/'false' value enables.
+    try { localStorage.setItem('feature.aiPanelV2', 'true') } catch {}
+    // V5 off so the upstream readiness gate doesn't pre-filter the
+    // run_analysis chip — we're testing the downstream polish step.
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', '')
+    setAnalysisState('none')
+  })
+  afterEach(() => {
+    try { localStorage.removeItem('feature.aiPanelV2') } catch {}
+    vi.unstubAllEnvs()
+    setAnalysisState('none')
+  })
+
+  it('suppresses the Run analysis chip entirely when current analysis exists', () => {
+    setAnalysisState('current')
+    render(
+      <SuggestedChips
+        chips={[makeChip({ action_type: 'run_analysis' })]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    expect(screen.queryByTestId('suggested-chip-chip_1')).toBeNull()
+  })
+
+  it('relabels the Run analysis chip to "Rerun" when analysis is stale', () => {
+    setAnalysisState('stale')
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'r1', action_type: 'run_analysis', label: 'Run analysis' })]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-r1')
+    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
+    expect(chip).not.toHaveTextContent(/Run analysis/i)
+  })
+
+  it('leaves the Run analysis chip unchanged when no analysis has been run yet', () => {
+    setAnalysisState('none')
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'n1', action_type: 'run_analysis', label: 'Run analysis' })]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-n1')
+    expect(chip).toHaveTextContent(/Run analysis/i)
+  })
+
+  it('does NOT touch non-run_analysis chips (current path is run_analysis-specific)', () => {
+    setAnalysisState('current')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({ id: 'x', action_type: undefined, label: 'Explain', message: 'Explain it' }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    expect(screen.getByTestId('suggested-chip-x')).toBeInTheDocument()
+  })
+})
+
+describe('SuggestedChips — FF-off legacy parity (no polish)', () => {
+  beforeEach(() => {
+    try { localStorage.removeItem('feature.aiPanelV2') } catch {}
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', '')
+    setAnalysisState('current')
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    setAnalysisState('none')
+  })
+
+  it('still renders the Run analysis chip when current analysis exists (FF off — legacy)', () => {
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'l1', action_type: 'run_analysis', label: 'Run analysis' })]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-l1')
+    expect(chip).toHaveTextContent(/Run analysis/i)
+  })
+})

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -114,6 +114,63 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
     )
     expect(screen.getByTestId('suggested-chip-x')).toBeInTheDocument()
   })
+
+  // Defensive: legacy/prompt-style chips arrive without action_type. The
+  // polish must catch them by canonical label/message too.
+  it('suppresses a label-only "Run analysis" chip (no action_type) when current', () => {
+    setAnalysisState('current')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'legacy-1',
+            action_type: undefined,
+            label: 'Run analysis',
+            message: 'Run analysis',
+          }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    expect(screen.queryByTestId('suggested-chip-legacy-1')).toBeNull()
+  })
+
+  it('relabels a label-only "Run analysis" chip to "Rerun" when stale', () => {
+    setAnalysisState('stale')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'legacy-2',
+            action_type: undefined,
+            label: 'Run analysis',
+            message: 'Run analysis',
+          }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-legacy-2')
+    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
+  })
+
+  it('does NOT false-positive on conversational chips that mention analysis', () => {
+    setAnalysisState('current')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'conv-1',
+            action_type: undefined,
+            label: 'Explain the analysis',
+            message: 'Explain the analysis in plain terms',
+          }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    expect(screen.getByTestId('suggested-chip-conv-1')).toBeInTheDocument()
+  })
 })
 
 describe('SuggestedChips — FF-off legacy parity (no polish)', () => {

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -17,7 +17,9 @@ import { useState, useEffect } from 'react'
 import { typography } from '../../../styles/typography'
 import { isV5Eligible } from '../../../v5/eligibility'
 import { logV5StateEvent } from '../../../v5/debugLog'
+import { isAiPanelV2Enabled } from '../../../flags'
 import { useAnalysisStatus } from '../../hooks/useAnalysisReady'
+import { useStaleGuard } from '../../ui/inspector-v2/useStaleGuard'
 import type { ActionChip } from '../types'
 
 // Actions that V5 CEE handles end-to-end. Chips whose action_type is set and
@@ -75,6 +77,14 @@ export function SuggestedChips({
   // fly; hoisting the two subscribers keeps React's dispatcher aligned.
   const [chipError, setChipError] = useState<string | null>(null)
   const analysisStatus = useAnalysisStatus()
+  // aiPanelV2 polish: once an analysis has been RUN (results exist), the
+  // canonical place for re-running it is the Analysis/readiness panel.
+  // Suppress the "Run analysis" chip from the conversation when current,
+  // relabel to "Rerun" when stale. analysisState === 'none' keeps the
+  // original chip unchanged. Gated by the FF so legacy chip behaviour is
+  // identical when aiPanelV2 is off.
+  const { analysisState } = useStaleGuard()
+  const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {
     if (!chipError) return
     const timer = setTimeout(() => setChipError(null), 5_000)
@@ -132,8 +142,20 @@ export function SuggestedChips({
     }
   }
 
+  // aiPanelV2: suppress / relabel the Run analysis chip based on the
+  // current analysis state. See header note above analysisState read.
+  const polished = aiPanelV2On
+    ? supported
+        .filter((c) => !(c.action_type === 'run_analysis' && analysisState === 'current'))
+        .map((c) =>
+          c.action_type === 'run_analysis' && analysisState === 'stale'
+            ? { ...c, label: 'Rerun' }
+            : c,
+        )
+    : supported
+
   // DS v5 §21.4: max 2 suggested action chips
-  const visible = supported.filter(c => !!(c.message || c.prompt)).slice(0, 2)
+  const visible = polished.filter(c => !!(c.message || c.prompt)).slice(0, 2)
   if (visible.length === 0) return null
 
   const disabled = isThinking || isHistorical

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -56,20 +56,25 @@ const READINESS_GATED_ACTIONS = new Set<string>(['run_analysis'])
  * would risk false-positives on conversational chips that happen to mention
  * "analysis" (e.g. "Explain the analysis").
  */
+// Canonical run-analysis affordance strings. Module-scoped so it isn't
+// re-allocated per chip render. The two-tier (action_type OR canonical
+// label/message/prompt) check matches both V2 chips and legacy
+// prompt-style chips. CEE serialises dispatch text as `prompt`; the UI
+// normalises it to `message` in validateResponse.ts:88, but the raw
+// `prompt` field is preserved on the chip — both shapes can therefore
+// arrive at this filter, so we match either.
+const RUN_ANALYSIS_CANONICAL = new Set(['run analysis', 'rerun analysis', 'rerun'])
+
+function normForMatch(s: string | undefined): string {
+  return (s ?? '').trim().toLowerCase()
+}
+
 function isRunAnalysisAffordance(chip: ActionChip): boolean {
   if (chip.action_type === 'run_analysis') return true
-  const norm = (s: string | undefined) => (s ?? '').trim().toLowerCase()
-  const label = norm(chip.label)
-  const msg = norm(chip.message)
-  // `prompt` mirrors `message` for V2 chip payloads (see validateResponse
-  // mapping in conversation/types.ts:484). Both are user-facing dispatch
-  // strings — match either so a prompt-only V2 chip is caught as well.
-  const prompt = norm(chip.prompt)
-  const CANONICAL = new Set(['run analysis', 'rerun analysis', 'rerun'])
   return (
-    CANONICAL.has(label) ||
-    CANONICAL.has(msg) ||
-    CANONICAL.has(prompt)
+    RUN_ANALYSIS_CANONICAL.has(normForMatch(chip.label)) ||
+    RUN_ANALYSIS_CANONICAL.has(normForMatch(chip.message)) ||
+    RUN_ANALYSIS_CANONICAL.has(normForMatch(chip.prompt))
   )
 }
 

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -61,12 +61,15 @@ function isRunAnalysisAffordance(chip: ActionChip): boolean {
   const norm = (s: string | undefined) => (s ?? '').trim().toLowerCase()
   const label = norm(chip.label)
   const msg = norm(chip.message)
+  // `prompt` mirrors `message` for V2 chip payloads (see validateResponse
+  // mapping in conversation/types.ts:484). Both are user-facing dispatch
+  // strings — match either so a prompt-only V2 chip is caught as well.
+  const prompt = norm(chip.prompt)
+  const CANONICAL = new Set(['run analysis', 'rerun analysis', 'rerun'])
   return (
-    label === 'run analysis' ||
-    label === 'rerun analysis' ||
-    label === 'rerun' ||
-    msg === 'run analysis' ||
-    msg === 'rerun analysis'
+    CANONICAL.has(label) ||
+    CANONICAL.has(msg) ||
+    CANONICAL.has(prompt)
   )
 }
 

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -47,6 +47,29 @@ const V5_ENABLED_ACTIONS = new Set<string>([
 // a chip that promises action and delivers chat.
 const READINESS_GATED_ACTIONS = new Set<string>(['run_analysis'])
 
+/**
+ * Detects a "Run analysis" affordance regardless of whether the chip
+ * carries `action_type: 'run_analysis'` or just a canonical label/message.
+ * Used by the aiPanelV2 polish to suppress / relabel once analysis exists.
+ *
+ * Conservative match list — anything beyond these literal canonical strings
+ * would risk false-positives on conversational chips that happen to mention
+ * "analysis" (e.g. "Explain the analysis").
+ */
+function isRunAnalysisAffordance(chip: ActionChip): boolean {
+  if (chip.action_type === 'run_analysis') return true
+  const norm = (s: string | undefined) => (s ?? '').trim().toLowerCase()
+  const label = norm(chip.label)
+  const msg = norm(chip.message)
+  return (
+    label === 'run analysis' ||
+    label === 'rerun analysis' ||
+    label === 'rerun' ||
+    msg === 'run analysis' ||
+    msg === 'rerun analysis'
+  )
+}
+
 interface SuggestedChipsProps {
   chips: ActionChip[]
   onChipClick: (chip: ActionChip) => Promise<void>
@@ -142,13 +165,17 @@ export function SuggestedChips({
     }
   }
 
-  // aiPanelV2: suppress / relabel the Run analysis chip based on the
-  // current analysis state. See header note above analysisState read.
+  // aiPanelV2: suppress / relabel any "Run analysis" affordance based on
+  // the current analysis state. Detection is intentionally broad — CEE
+  // may emit chips with action_type === 'run_analysis' OR legacy
+  // prompt-style chips with no action_type but a canonical label/message.
+  // Both shapes are user-facing duplicates of the Analysis-panel rerun
+  // affordance once analysis exists, so the polish applies to both.
   const polished = aiPanelV2On
     ? supported
-        .filter((c) => !(c.action_type === 'run_analysis' && analysisState === 'current'))
+        .filter((c) => !(isRunAnalysisAffordance(c) && analysisState === 'current'))
         .map((c) =>
-          c.action_type === 'run_analysis' && analysisState === 'stale'
+          isRunAnalysisAffordance(c) && analysisState === 'stale'
             ? { ...c, label: 'Rerun' }
             : c,
         )


### PR DESCRIPTION
## Summary

**Sequential follow-up to merged [PR #148](https://github.com/Talchain/DecisionGuideAI/pull/148).** That PR landed the Batch 2 floating-first architecture into `staging` on 2026-05-19 (mergeCommit `49188616`). **This PR is layered on top of that** — it contains UX polish only and does not republish the architecture diff. Review #149 in isolation.

> **Relationship:** #148 = architecture (merged). #149 = polish on top (open, draft). Not a supersedes — sequential.

FF-on visual + behaviour only; FF-off path unchanged. Draft — do not merge, do not enable the flag in production.

## Items

| # | Brief item | What changed |
|---|------------|--------------|
| 1 | Duplicate Olumi surfaces | Docked Olumi tab renders a placeholder ("Olumi is open in the floating panel") with **Focus floating** + **Dock here** actions when floating is open. `handleTabClick` no longer intercepts the Olumi tab click so the placeholder is reachable. |
| 2 | Run analysis chip after analysis has run | Chip is suppressed when `analysisState === 'current'`; relabelled to "Rerun" when `analysisState === 'stale'`. Analysis/readiness panel is the canonical re-run surface. FF-gated. Match is broad: `action_type === 'run_analysis'` OR canonical label/message/prompt. |
| 3 | Floating panel bounds | New `clampPositionToViewport` + `clampPillPositionToViewport` helpers applied at first open, on every render of the restored panel, during drag/resize, on viewport resize, and via a `ResizeObserver` watching the dock element so reclamping happens when the dock opens / collapses / expands. Inset is computed as `vw - dock.left` so the dock's right-edge gap is honoured.<br><br>**Edge case — MIN_WIDTH preservation + auto-minimise:** when the available canvas (viewport − margins − dock inset) is smaller than `MIN_WIDTH × MIN_HEIGHT`, the panel auto-minimises to the restore pill rather than rendering at sub-MIN size. Gated by a `fitsAtMinSize()` predicate consulted from the layout effect, the viewport+dock resize observer, and the resize-drag handler. First-open auto-minimise commits a safe top-left pill anchor before minimising so the pill does not fall back to the JSX 50%/50% placeholder (which could sit under the dock on narrow viewports).<br><br>**Edge case — minimised-pill lifecycle:** while minimised, viewport resize, dock expand, dock collapse, and restore cycles all reclamp the pill's stored position. The handler branches on `isMinimised` (read via `useFloatingPanelState.getState()` so it isn't gated by the unmounted `containerRef`) and writes the new position via direct `setState` so the automatic geometry correction does NOT flip `userRepositioned` — that flag is reserved for genuine user drags and gates auto-dock invariants. |
| 4 | Generating-state input | Empty canvas + `isThinking` → composer textarea disabled with placeholder "Generating your decision model…". Prevents duplicate/conflicting sends. Chat-mode thinking unchanged. |
| 5 | Persistent strip status | Replaces the truncated last-message preview with fixed copy: "Olumi is open · Focus →". Raw `font-medium` removed in favour of `typo('panelMeta', …)`. |
| 6 | First-use composer spacing | Panel height 200 → 152; width responsive via `min(480px, calc(100vw - 32px))`; positioned at `max(16px, calc(50% - 240px))` so it never overflows narrow viewports. |
| 7 | Olumi tab floating-state indicator | `opacity-60` swapped for an explicit info-coloured "Open" badge using the `typo()` helper. |
| 8 | Cog popover polish | Added "Assistant options" heading; shortened "Attach evidence" → "Attach" so the Coming-soon badge never wraps; popover width 220 → 240. |
| 9 | Floating header affordances | Verified existing `cursor: 'grab'` on header + `title` tooltips on minimise/dock. |
| 10 | Welcome composer cog | Verified the cog icon already renders inside the input field for the `first-use` variant. |

## Tests

- `aiPanelV2.polish.spec.tsx` — Items 1, 4, 5.
- `SuggestedChips.aiPanelV2Polish.spec.tsx` — Item 2 + FF-off legacy parity + label/prompt-only chip matching.
- `FloatingOlumiPanel.clamp.spec.ts` — clamp helpers + `computeResizeBudget` pure-function coverage + `fitsAtMinSize` boundary cases.
- `FloatingOlumiPanel.dockInset.spec.tsx` — DOM-level dock-inset clamping including dynamic dock-width changes, narrow viewports, MIN_WIDTH auto-minimise on first open, the safe pill anchor for first-open auto-minimise, **minimised-pill reclamping on viewport resize**, **minimised-pill reclamping on dock expand/collapse**, and **`userRepositioned` preservation across automatic clamps (both true and false → preserved unchanged)**.
- `CogPopover.spec.tsx` — Item 8.
- Singleton + first-use guards from PR #148 still pass.

## Test plan

- [x] Typecheck clean (`npm run typecheck`).
- [x] 136+ tests pass across the polish-affected specs.
- [x] Pre-push fast gate green (lint, smoke, stale-.js, deps audit, manifest).
- [x] FF-off browser parity: DraftChat + 3-tab dock; no Olumi tab, strip, or floating panel.
- [x] FF-on browser screenshots (post Vite restart): Olumi tab placeholder, "Open" badge, fixed strip copy, cog popover with heading + Attach label, first-use composer with tightened spacing and responsive width (405px at 437px viewport = `vw - 32px`), floating panel parked at x=1300 with dock open clamped back to x=596 (dock.left=1012), minimised pill at stored x=1300 reclamps to x=272 after viewport resize to 800px.
- [ ] Reviewer manual pass on a real staging build with running CEE (auto-dock + generating-state behaviour with a live orchestrator).

## Limitations / explicit non-goals
- [x] Reviewer manual pass on a real staging build with running CEE — pending staging deploy (this PR).

## Known limitations carried into staging

These are acceptable for staging manual testing; none block default-off merge.

- **Real backend draft-graph path** — only exercised against a mocked orchestrator locally. Live CEE/PLoT validation on staging.
- **Evidence upload** — `Attach` remains "Coming soon" in the cog popover until the orchestrator turn API gains a file parameter.
- **Reduced-motion verification** — covered by unit test (mocked `matchMedia`); not visually re-walked across browsers.
- **Cross-browser drag/resize** — pointer-event flow tested in Chrome/jsdom; Safari/Firefox manual coverage pending.
- **OutputsDock decomposition** — deferred. The file is large but stable; further split is a separate, post-staging refactor.

## Deploy posture

- Default-off in code (`aiPanelV2` has no `defaultValue` → falls back to `false`).
- Staging enables via env (`VITE_FEATURE_AI_PANEL_V2=true`) or `localStorage.setItem('feature.aiPanelV2','true')`.
- Production and `main` remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)