### PR TITLE
feat(debug-bundle): V5 diagnostic data + scientific evidence integrity

### DIFF
--- a/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
@@ -193,6 +193,22 @@ describe('additive diagnostics — buildDebugBundleAsync', () => {
     expect(bundle.debug_redaction_manifest?.preserved_analytical_paths).toBeInstanceOf(Array)
   })
 
+  it('capture_pipeline_status is ALWAYS emitted on async export, even when legacy classifier produced nothing useful', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.capture_pipeline_status).toBeDefined()
+    expect(typeof bundle.capture_pipeline_status).toBe('string')
+  })
+
+  it('v5_canonical_turn_diagnostics is ALWAYS emitted on async export, with the verbatim VITE_V5_CANONICAL_ANALYSIS env-key', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.v5_canonical_turn_diagnostics).toBeDefined()
+    expect(bundle.v5_canonical_turn_diagnostics?.canonical_flag_env_key).toBe(
+      'VITE_V5_CANONICAL_ANALYSIS',
+    )
+    expect(bundle.v5_canonical_turn_diagnostics?.coherence).toBeDefined()
+    expect(bundle.v5_canonical_turn_diagnostics?.scenario_id_reconciliation).toBeDefined()
+  })
+
   it('scenario_id reconciliation lifts session.scenario_id from store', async () => {
     canvasState.currentScenarioId = 'sid-from-store'
     const bundle = await buildDebugBundleAsync(makeDebugData())

--- a/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
@@ -13,7 +13,7 @@
  * unchanged.
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import type { DebugData, RequestIdChain } from '../hooks/useDebugData'
 
 vi.mock('../../../lib/version-cache', () => ({
@@ -336,5 +336,80 @@ describe('additive diagnostics — buildDebugBundleAsync', () => {
     for (const literal of requiredLiterals) {
       expect(json).toContain(literal)
     }
+  })
+})
+
+// ----------------------------------------------------------------------------
+// Forced-absence regression: mocks the legacy classifier to throw so
+// bundle.v5_canonical_analysis is genuinely absent. Asserts the
+// synthesised fallback derives fact-presence, emits contradiction issues,
+// and stamps diagnostic_source_strength.latest_v5_turn = 'fallback'.
+// ----------------------------------------------------------------------------
+
+describe('forced legacy-classifier absence — synthesised fallback covers the gap', () => {
+  beforeEach(() => {
+    canvasState.currentScenarioId = 'sid-forced'
+    canvasState.v5AnalysisFact = {
+      scenarioId: 'sid-forced',
+      analysisHash: 'v5:abc',
+      hasRunAnalysisFact: true,
+      freshness: 'fresh',
+    }
+    canvasState.results = {
+      report: { summary: 'forced' },
+      hash: 'v5:abc',
+      rawV2Response: null,
+    }
+    analysisStateSourceResult.source = 'cee_v5_run_analysis'
+    analysisStateSourceResult.hasResultsReport = true
+    analysisStateSourceResult.factPresentForScenario = true
+  })
+
+  afterEach(() => {
+    analysisStateSourceResult.source = 'none'
+    analysisStateSourceResult.hasResultsReport = false
+    analysisStateSourceResult.factPresentForScenario = false
+    vi.doUnmock('../../../lib/v5CanonicalAnalysisDiagnostics')
+    vi.resetModules()
+  })
+
+  it('throws-on-classify → bundle.v5_canonical_analysis is undefined, but capture_pipeline_status + v5_canonical_turn_diagnostics still emit with fact-presence preserved', async () => {
+    // Force the legacy classifier to throw so the inner try/catch around
+    // `classifyV5CanonicalAnalysisDiagnostic` leaves
+    // `bundle.v5_canonical_analysis` undefined. Re-import the bundle
+    // assembler with the mock active so the new module graph picks it up.
+    vi.doMock('../../../lib/v5CanonicalAnalysisDiagnostics', () => ({
+      classifyV5CanonicalAnalysisDiagnostic: () => {
+        throw new Error('forced classifier failure for test')
+      },
+    }))
+    vi.resetModules()
+    const { buildDebugBundleAsync: build } = await import('../utils/exportBundle')
+
+    const bundle = await build(makeDebugData())
+
+    // Legacy block was forced absent.
+    expect(bundle.v5_canonical_analysis).toBeUndefined()
+
+    // The new fields must STILL emit, with fact-presence preserved by
+    // the synthesised fallback derivation from sourceResult.
+    expect(bundle.v5_canonical_turn_diagnostics).toBeDefined()
+    expect(bundle.v5_canonical_turn_diagnostics!.analysis_fact.present).toBe(true)
+    expect(bundle.v5_canonical_turn_diagnostics!.analysis_fact.source).toBe(
+      'source_classifier',
+    )
+
+    // Headline contradictions must still fire (additive issues).
+    expect(bundle.v5_canonical_turn_diagnostics!.coherence.issues).toContain(
+      'analysis_fact_present_but_cee_capture_missing',
+    )
+    expect(bundle.v5_canonical_turn_diagnostics!.coherence.issues).toContain(
+      'results_rendered_from_store_without_capture',
+    )
+
+    // diagnostic_source_strength must reflect the fallback path.
+    expect(
+      bundle.v5_canonical_turn_diagnostics!.diagnostic_source_strength.latest_v5_turn,
+    ).toBe('fallback')
   })
 })

--- a/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression coverage — legacy bundle fields and PR #147 invariants
+ * must survive the additive diagnostic plumbing in this PR.
+ *
+ * The new sections (scenario_id_reconciliation, capture_pipeline_status,
+ * v5_canonical_turn_diagnostics, scientific_validation,
+ * debug_redaction_manifest) are emitted ALONGSIDE existing fields, not
+ * in place of them.
+ *
+ * PR #147 parser-level invariants (whitelist, sidecar enumeration,
+ * raw_response_present) are covered in v5-cee-capture.phase3-tolerance.spec.ts.
+ * This spec asserts the BUNDLE-LEVEL surfaces those tests rely on are
+ * unchanged.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { DebugData, RequestIdChain } from '../hooks/useDebugData'
+
+vi.mock('../../../lib/version-cache', () => ({
+  getClientBuild: () => 'test-build',
+  getVersionInfo: () => ({ short: 'test-version', branch: 'main' }),
+}))
+
+vi.mock('../../../utils/debugLogBuffer', () => ({
+  getBufferedLogs: () => [],
+}))
+
+vi.mock('../../../lib/debug-state', () => ({
+  getUserActions: () => [],
+}))
+
+const canvasState: {
+  currentScenarioId: string | null
+  v5AnalysisFact: unknown
+  results: unknown
+  goalConstraints: unknown[]
+  ceeAnalysisReady: unknown
+} = {
+  currentScenarioId: null,
+  v5AnalysisFact: null,
+  results: null,
+  goalConstraints: [],
+  ceeAnalysisReady: null,
+}
+
+vi.mock('../../../canvas/store', () => ({
+  useCanvasStore: { getState: () => canvasState },
+}))
+
+vi.mock('../../../canvas/hooks/useAnalysisStateSource', () => ({
+  readAnalysisStateSourceFromStore: () => ({
+    source: 'none',
+    showOrphanBanner: false,
+    hasResultsReport: false,
+    factPresentForScenario: false,
+  }),
+}))
+
+vi.mock('../../../lib/payload-trace-store', () => ({
+  usePayloadTraceStore: { getState: () => ({ payloads: [] }) },
+}))
+
+import { buildDebugBundle, buildDebugBundleAsync } from '../utils/exportBundle'
+
+function makeDebugData(overrides: Partial<DebugData> = {}): DebugData {
+  return {
+    overall: { status: 'success', total_duration_ms: 1200, request_id: 'req-main' },
+    services: { cee: null, plot: null, isl: null },
+    error: null,
+    builds: { ui: 'test-build', cee: null, plot: null, isl: null },
+    diagnostics: {
+      plot_has_downstream_calls: false,
+      downstream_calls_path_found: null,
+      downstream_calls_paths_checked: [],
+      isl_data_source: 'none',
+      cee_trace_present: false,
+      cee_degraded: false,
+      llm_raw_available: false,
+      llm_raw_path_found: null,
+      e_values_present: false,
+      evpi_present: false,
+      confidence_differentiated: false,
+      confidence_unique_values: [],
+      confidence_source_bootstrap: false,
+      intercept_populated: false,
+      epsilon_std_present: false,
+      response_hash_present: false,
+      mca_computed: false,
+    },
+    ceeTrace: null,
+    corrections: [],
+    correctionsSummary: null,
+    pipeline: {
+      status: 'success',
+      total_duration_ms: 1200,
+      stages: [],
+      llm_metadata: null,
+      llm_raw: null,
+      node_extraction: null,
+      connectivity: { decision_count: 0, option_count: 0, goal_count: 0, factor_count: 0, edge_count: 0 },
+    },
+    payloads: {
+      cee_request: null,
+      cee_response: null,
+      plot_request: null,
+      plot_response: null,
+      isl_request: null,
+      isl_response: null,
+    },
+    gates: [],
+    validation: { summary: { errors: 0, warnings: 0, info: 0 }, issues: [] },
+    winningOption: null,
+    robustness: { status: 'unavailable', stability: null, context_label: 'N/A', description: '' },
+    hasData: true,
+    orchestrator: null,
+    v12_4_checks: null,
+    request_id_chain: {
+      ui_generated: 'ui-req',
+      from_plot: { ui: 'ui-req', plot: null, isl: null, isl_echoed: null, all_match: false, chain_complete: false },
+      plot_chain_present: false,
+      draft_trace: { cee_trace: null },
+    } as RequestIdChain,
+    feature_flags_at_request: {} as never,
+    timing: null,
+    schema_versions: null,
+    cee_observability: null,
+    m1_coaching: null,
+    m2_review: null,
+    cee_downstream: null,
+    cee_operations: null,
+    diagnostic_trace: null,
+    ...overrides,
+  }
+}
+
+describe('legacy bundle field invariants — buildDebugBundle (sync)', () => {
+  beforeEach(() => {
+    canvasState.currentScenarioId = null
+    canvasState.v5AnalysisFact = null
+    canvasState.results = null
+    canvasState.ceeAnalysisReady = null
+  })
+
+  it('emits the legacy pipeline.v5_pipeline_status field', () => {
+    const bundle = buildDebugBundle(makeDebugData())
+    expect(bundle.pipeline).toBeDefined()
+    expect(bundle.pipeline.v5_pipeline_status).toBeDefined()
+    expect(bundle.pipeline.v5_pipeline_status_source).toBeDefined()
+  })
+
+  it('emits the legacy effective_cee_response_source field', () => {
+    const bundle = buildDebugBundle(makeDebugData())
+    expect(bundle.effective_cee_response_source).toBeDefined()
+  })
+
+  it('session shape contains scenario_id_source (new) plus all legacy keys', () => {
+    const bundle = buildDebugBundle(makeDebugData())
+    expect(bundle.session.scenario_id).toBeNull()
+    expect(bundle.session.scenario_id_source).toBe('none')
+    expect(bundle.session.timestamp).toBeDefined()
+    expect(bundle.session.feature_flags).not.toBeUndefined()
+    expect(bundle.session.build_info).toBeDefined()
+  })
+})
+
+describe('additive diagnostics — buildDebugBundleAsync', () => {
+  beforeEach(() => {
+    canvasState.currentScenarioId = 'sid-test'
+    canvasState.v5AnalysisFact = null
+    canvasState.results = null
+    canvasState.ceeAnalysisReady = null
+  })
+
+  it('legacy v5_canonical_analysis block is preserved (composition, not replacement)', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    // Either present (canonical flag on) or absent (flag off + bailed).
+    // When present, must carry the legacy enum fields.
+    if (bundle.v5_canonical_analysis) {
+      expect(bundle.v5_canonical_analysis.canonical_flag_on).toBeDefined()
+      expect(bundle.v5_canonical_analysis.analysis_state_source).toBeDefined()
+      expect(bundle.v5_canonical_analysis.debug_capture_status).toBeDefined()
+    }
+  })
+
+  it('new diagnostic fields are emitted alongside legacy fields (not in place of)', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    // Legacy still there
+    expect(bundle.pipeline.v5_pipeline_status).toBeDefined()
+    // New additive fields are emitted (or undefined honestly if assembly bailed)
+    expect('scenario_id_reconciliation' in bundle).toBe(true)
+    // Manifest is always emitted, even on partial assembly
+    expect(bundle.debug_redaction_manifest).toBeDefined()
+    expect(bundle.debug_redaction_manifest?.preserved_analytical_paths).toBeInstanceOf(Array)
+  })
+
+  it('scenario_id reconciliation lifts session.scenario_id from store', async () => {
+    canvasState.currentScenarioId = 'sid-from-store'
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.session.scenario_id).toBe('sid-from-store')
+    expect(bundle.session.scenario_id_source).toBe('store')
+  })
+
+  it('scientific_validation always emits — even with no PLoT payload, reports source = unavailable', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.scientific_validation).toBeDefined()
+    expect(bundle.scientific_validation?.source).toBe('unavailable')
+    expect(bundle.scientific_validation?.overall_status).toBe('unavailable')
+  })
+
+  it('debug_redaction_manifest enumerates preserved analytical paths', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    const manifest = bundle.debug_redaction_manifest
+    expect(manifest).toBeDefined()
+    expect(manifest!.preserved_analytical_paths.length).toBeGreaterThan(0)
+    expect(manifest!.preserved_analytical_paths).toContain(
+      'payloads.plot_request.graph.nodes[*].data.observed_state.*',
+    )
+  })
+
+  it('omitted sections are recorded in the manifest when assembly bailed', async () => {
+    // With our mocks, sourceResult.source === 'none' so v5_canonical_analysis
+    // is still emitted (the legacy classifier handles 'no_analysis_signal' case);
+    // capture_pipeline_status depends on the legacy block. Both should be present.
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    const omitted = bundle.debug_redaction_manifest?.omitted ?? []
+    // Every omitted entry has a reason
+    for (const entry of omitted) {
+      expect(typeof entry.path).toBe('string')
+      expect(typeof entry.reason).toBe('string')
+    }
+  })
+})

--- a/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts
@@ -47,13 +47,23 @@ vi.mock('../../../canvas/store', () => ({
   useCanvasStore: { getState: () => canvasState },
 }))
 
+// Mutable analysis-state-source result so individual tests can simulate
+// the post-run state (fact present, results present, source =
+// cee_v5_run_analysis) without rewiring the mock factory.
+const analysisStateSourceResult: {
+  source: string
+  showOrphanBanner: boolean
+  hasResultsReport: boolean
+  factPresentForScenario: boolean
+} = {
+  source: 'none',
+  showOrphanBanner: false,
+  hasResultsReport: false,
+  factPresentForScenario: false,
+}
+
 vi.mock('../../../canvas/hooks/useAnalysisStateSource', () => ({
-  readAnalysisStateSourceFromStore: () => ({
-    source: 'none',
-    showOrphanBanner: false,
-    hasResultsReport: false,
-    factPresentForScenario: false,
-  }),
+  readAnalysisStateSourceFromStore: () => ({ ...analysisStateSourceResult }),
 }))
 
 vi.mock('../../../lib/payload-trace-store', () => ({
@@ -209,6 +219,52 @@ describe('additive diagnostics — buildDebugBundleAsync', () => {
     expect(bundle.v5_canonical_turn_diagnostics?.scenario_id_reconciliation).toBeDefined()
   })
 
+  // ------------------------------------------------------------------
+  // Legacy-classifier-failure regression: when the synthesised fallback
+  // engages, fact presence must be DERIVED from the analysis-state
+  // source classifier (not defaulted to 'unknown_not_checked'). Without
+  // this, the headline contradiction issue can never fire.
+  // ------------------------------------------------------------------
+
+  it('synthesised fallback derives analysis_fact.present from sourceResult.factPresentForScenario, NOT unknown_not_checked', async () => {
+    // Simulate the post-run state: source classifier reports fact + results
+    // present even though the legacy `v5_canonical_analysis` block itself
+    // may emit weak signals. The fallback must lift fact-presence into
+    // the synthesised diagnostic so the contradiction issue surfaces.
+    canvasState.currentScenarioId = 'sid-x'
+    canvasState.v5AnalysisFact = {
+      scenarioId: 'sid-x',
+      analysisHash: 'v5:abc',
+      hasRunAnalysisFact: true,
+      freshness: 'fresh',
+    }
+    canvasState.results = { report: { summary: 'x' }, hash: 'v5:abc', rawV2Response: null }
+    analysisStateSourceResult.source = 'cee_v5_run_analysis'
+    analysisStateSourceResult.hasResultsReport = true
+    analysisStateSourceResult.factPresentForScenario = true
+
+    try {
+      const bundle = await buildDebugBundleAsync(makeDebugData())
+      const td = bundle.v5_canonical_turn_diagnostics
+      expect(td).toBeDefined()
+      // The fallback path must NOT lose fact-presence to 'unknown_not_checked'.
+      expect(td!.analysis_fact.present).toBe(true)
+      // The headline contradiction issues must fire (additive, independent
+      // of which final status the classifier picked).
+      expect(td!.coherence.issues).toContain(
+        'analysis_fact_present_but_cee_capture_missing',
+      )
+      expect(td!.coherence.issues).toContain(
+        'results_rendered_from_store_without_capture',
+      )
+    } finally {
+      // Reset the shared mock state so subsequent tests start clean.
+      analysisStateSourceResult.source = 'none'
+      analysisStateSourceResult.hasResultsReport = false
+      analysisStateSourceResult.factPresentForScenario = false
+    }
+  })
+
   it('scenario_id reconciliation lifts session.scenario_id from store', async () => {
     canvasState.currentScenarioId = 'sid-from-store'
     const bundle = await buildDebugBundleAsync(makeDebugData())
@@ -243,6 +299,42 @@ describe('additive diagnostics — buildDebugBundleAsync', () => {
     for (const entry of omitted) {
       expect(typeof entry.path).toBe('string')
       expect(typeof entry.reason).toBe('string')
+    }
+  })
+
+  it('top-level JSON snapshot — every brief-required field name is present in the serialised bundle (grep target)', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    const json = JSON.stringify(bundle)
+    // Reviewers grep these literal strings to locate the diagnostic
+    // surfaces. Asserting on the serialised JSON guards against future
+    // changes that rename or hide them.
+    const requiredLiterals = [
+      '"scenario_id_reconciliation"',
+      '"capture_pipeline_status"',
+      '"v5_canonical_turn_diagnostics"',
+      '"scientific_validation"',
+      '"debug_redaction_manifest"',
+      // Within v5_canonical_turn_diagnostics
+      '"canonical_flag_env_key"',
+      '"feature_flag_diagnostic"',
+      '"VITE_V5_CANONICAL_ANALYSIS"',
+      '"effective_cee_response_source"',
+      '"latest_v5_turn"',
+      '"coherence"',
+      // Within scientific_validation
+      '"overall_status"',
+      '"user_std_propagation"',
+      '"confidence_validation"',
+      '"evidence_gap_validation"',
+      '"evpi_validation"',
+      '"flip_threshold_validation"',
+      '"auto_noise_validation"',
+      '"response_shape_validation"',
+      // Within debug_redaction_manifest
+      '"preserved_analytical_paths"',
+    ]
+    for (const literal of requiredLiterals) {
+      expect(json).toContain(literal)
     }
   })
 })

--- a/src/components/debug/__tests__/exportBundle.scenarioId.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.scenarioId.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration tests for the scenario-ID reconciliation wire-in.
+ *
+ * Verifies that buildDebugBundleAsync replaces the previously-hardcoded
+ * `session.scenario_id = null` with a value resolved from the store /
+ * V5 fact / payload trace / URL / full_graph, and emits the top-level
+ * `scenario_id_reconciliation` block recording all candidates + conflicts.
+ *
+ * The sync export path (buildDebugBundle) continues to emit `null` +
+ * `scenario_id_source: 'none'` since it cannot reach the canvas store.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { DebugData, RequestIdChain } from '../hooks/useDebugData'
+
+vi.mock('../../../lib/version-cache', () => ({
+  getClientBuild: () => 'test-build',
+  getVersionInfo: () => ({ short: 'test-version', branch: 'main' }),
+}))
+
+vi.mock('../../../utils/debugLogBuffer', () => ({
+  getBufferedLogs: () => [],
+}))
+
+vi.mock('../../../lib/debug-state', () => ({
+  getUserActions: () => [],
+}))
+
+// Canvas store mock — controllable per test via the mutable state object below.
+const canvasState: {
+  currentScenarioId: string | null
+  v5AnalysisFact: {
+    scenarioId: string | null
+    analysisHash: string | null
+    hasRunAnalysisFact: boolean | null
+    freshness: 'fresh' | 'stale' | 'unknown' | 'none' | null
+  } | null
+  results: { report: unknown; hash: string | null; rawV2Response: unknown } | null
+  goalConstraints: unknown[]
+  ceeAnalysisReady: unknown
+} = {
+  currentScenarioId: null,
+  v5AnalysisFact: null,
+  results: null,
+  goalConstraints: [],
+  ceeAnalysisReady: null,
+}
+
+vi.mock('../../../canvas/store', () => ({
+  useCanvasStore: {
+    getState: () => canvasState,
+  },
+}))
+
+// useAnalysisStateSource consumer used by buildDebugBundleAsync — return a
+// minimal classification so the v5_canonical_analysis path doesn't blow up.
+vi.mock('../../../canvas/hooks/useAnalysisStateSource', () => ({
+  readAnalysisStateSourceFromStore: () => ({
+    source: 'none',
+    showOrphanBanner: false,
+    hasResultsReport: false,
+    factPresentForScenario: false,
+  }),
+}))
+
+// Payload trace store mock — list controllable per test.
+const traceState: {
+  payloads: Array<{ service: string; endpoint?: string; request?: { body?: unknown } }>
+} = { payloads: [] }
+
+vi.mock('../../../lib/payload-trace-store', () => ({
+  usePayloadTraceStore: {
+    getState: () => traceState,
+  },
+}))
+
+import { buildDebugBundleAsync, buildDebugBundle } from '../utils/exportBundle'
+
+function makeDebugData(overrides: Partial<DebugData> = {}): DebugData {
+  return {
+    overall: { status: 'success', total_duration_ms: 1200, request_id: 'req-main' },
+    services: { cee: null, plot: null, isl: null },
+    error: null,
+    builds: { ui: 'test-build', cee: null, plot: null, isl: null },
+    diagnostics: {
+      plot_has_downstream_calls: false,
+      downstream_calls_path_found: null,
+      downstream_calls_paths_checked: [],
+      isl_data_source: 'none',
+      cee_trace_present: false,
+      cee_degraded: false,
+      llm_raw_available: false,
+      llm_raw_path_found: null,
+      e_values_present: false,
+      evpi_present: false,
+      confidence_differentiated: false,
+      confidence_unique_values: [],
+      confidence_source_bootstrap: false,
+      intercept_populated: false,
+      epsilon_std_present: false,
+      response_hash_present: false,
+      mca_computed: false,
+    },
+    ceeTrace: null,
+    corrections: [],
+    correctionsSummary: null,
+    pipeline: {
+      status: 'success',
+      total_duration_ms: 1200,
+      stages: [],
+      llm_metadata: null,
+      llm_raw: null,
+      node_extraction: null,
+      connectivity: { decision_count: 0, option_count: 0, goal_count: 0, factor_count: 0, edge_count: 0 },
+    },
+    payloads: {
+      cee_request: null,
+      cee_response: null,
+      plot_request: null,
+      plot_response: null,
+      isl_request: null,
+      isl_response: null,
+    },
+    gates: [],
+    validation: { summary: { errors: 0, warnings: 0, info: 0 }, issues: [] },
+    winningOption: null,
+    robustness: { status: 'unavailable', stability: null, context_label: 'N/A', description: '' },
+    hasData: true,
+    orchestrator: null,
+    v12_4_checks: null,
+    request_id_chain: {
+      ui_generated: 'ui-req',
+      from_plot: { ui: 'ui-req', plot: null, isl: null, isl_echoed: null, all_match: false, chain_complete: false },
+      plot_chain_present: false,
+      draft_trace: { cee_trace: null },
+    } as RequestIdChain,
+    feature_flags_at_request: {} as never,
+    timing: null,
+    schema_versions: null,
+    cee_observability: null,
+    m1_coaching: null,
+    m2_review: null,
+    cee_downstream: null,
+    cee_operations: null,
+    diagnostic_trace: null,
+    ...overrides,
+  }
+}
+
+describe('buildDebugBundle (sync) — session.scenario_id', () => {
+  beforeEach(() => {
+    canvasState.currentScenarioId = null
+    canvasState.v5AnalysisFact = null
+    traceState.payloads = []
+  })
+
+  it('emits scenario_id null and source "none" — sync path cannot resolve stores', () => {
+    const bundle = buildDebugBundle(makeDebugData())
+    expect(bundle.session.scenario_id).toBeNull()
+    expect(bundle.session.scenario_id_source).toBe('none')
+    expect(bundle.scenario_id_reconciliation).toBeUndefined()
+  })
+})
+
+describe('buildDebugBundleAsync — scenario_id reconciliation wire-in', () => {
+  beforeEach(() => {
+    canvasState.currentScenarioId = null
+    canvasState.v5AnalysisFact = null
+    traceState.payloads = []
+  })
+
+  it('resolves session.scenario_id from canvas store when present', async () => {
+    canvasState.currentScenarioId = 'sid-from-store'
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.session.scenario_id).toBe('sid-from-store')
+    expect(bundle.session.scenario_id_source).toBe('store')
+    expect(bundle.scenario_id_reconciliation?.selected_scenario_id).toBe('sid-from-store')
+    expect(bundle.scenario_id_reconciliation?.selected_source).toBe('store')
+  })
+
+  it('falls back to v5AnalysisFact.scenarioId when store is null', async () => {
+    canvasState.v5AnalysisFact = {
+      scenarioId: 'sid-from-fact',
+      analysisHash: null,
+      hasRunAnalysisFact: null,
+      freshness: null,
+    }
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.session.scenario_id).toBe('sid-from-fact')
+    expect(bundle.session.scenario_id_source).toBe('v5_fact')
+  })
+
+  it('falls back to the latest V5 payload body when store + fact are null', async () => {
+    traceState.payloads = [
+      {
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        request: { body: { scenario_id: 'sid-from-payload', kind: 'analysis' } },
+      },
+    ]
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.session.scenario_id).toBe('sid-from-payload')
+    expect(bundle.session.scenario_id_source).toBe('payload')
+  })
+
+  it('records conflicts when store + fact disagree (store still wins)', async () => {
+    canvasState.currentScenarioId = 'sid-A'
+    canvasState.v5AnalysisFact = {
+      scenarioId: 'sid-B',
+      analysisHash: null,
+      hasRunAnalysisFact: null,
+      freshness: null,
+    }
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.session.scenario_id).toBe('sid-A')
+    expect(bundle.session.scenario_id_source).toBe('store')
+    expect(bundle.scenario_id_reconciliation?.conflicts).toContain(
+      'store=sid-A vs v5_fact=sid-B',
+    )
+  })
+
+  it('emits null + "none" + no conflicts when every candidate is null', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.session.scenario_id).toBeNull()
+    expect(bundle.session.scenario_id_source).toBe('none')
+    expect(bundle.scenario_id_reconciliation?.conflicts).toEqual([])
+  })
+})

--- a/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
@@ -1,0 +1,291 @@
+/**
+ * Fixture-style integration test — proves the uploaded-bundle failure
+ * the brief describes is explainable from a single export in under 60
+ * seconds of reading. Simulates the exact set of contradictions the
+ * uploaded bundle showed:
+ *
+ *   - analysis_state_source = 'cee_v5_run_analysis'
+ *   - effective_cee_response_source = 'none'
+ *   - v5_cee_capture = null
+ *   - analysis_fact_status = 'present'
+ *   - pipeline.v5_pipeline_status = 'proxy_or_network_failure'
+ *     (legacy classifier mislabelling missing capture)
+ *   - session.scenario_id null in the uploaded bundle
+ *
+ * Assertions: the exported bundle's machine-readable fields must answer
+ * every diagnostic question the brief lists, without a human having to
+ * cross-reference multiple sections.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { DebugData, RequestIdChain } from '../hooks/useDebugData'
+
+vi.mock('../../../lib/version-cache', () => ({
+  getClientBuild: () => 'fixture-build',
+  getVersionInfo: () => ({ short: 'fixture-version', branch: 'main' }),
+}))
+
+vi.mock('../../../utils/debugLogBuffer', () => ({
+  getBufferedLogs: () => [],
+}))
+
+vi.mock('../../../lib/debug-state', () => ({
+  getUserActions: () => [],
+}))
+
+// Canvas store: scenario in progress, v5AnalysisFact present, results
+// rendered from store-only (no rawV2Response).
+const canvasState: {
+  currentScenarioId: string | null
+  v5AnalysisFact: {
+    scenarioId: string | null
+    analysisHash: string | null
+    hasRunAnalysisFact: boolean | null
+    freshness: 'fresh' | 'stale' | 'unknown' | 'none' | null
+  } | null
+  results: { report: unknown; hash: string | null; rawV2Response: unknown } | null
+  goalConstraints: unknown[]
+  ceeAnalysisReady: unknown
+} = {
+  currentScenarioId: 'sid-uploaded-bundle',
+  v5AnalysisFact: {
+    scenarioId: 'sid-uploaded-bundle',
+    analysisHash: 'v5:abc123',
+    hasRunAnalysisFact: true,
+    freshness: 'fresh',
+  },
+  results: {
+    report: { summary: 'Plan A is recommended' },
+    hash: 'v5:abc123',
+    // Hydrated case: no rawV2Response — Results came from saved/cached
+    // state, not a fresh PLoT v2/run.
+    rawV2Response: null,
+  },
+  goalConstraints: [],
+  ceeAnalysisReady: null,
+}
+
+vi.mock('../../../canvas/store', () => ({
+  useCanvasStore: { getState: () => canvasState },
+}))
+
+// Analysis-state classifier: claims cee_v5_run_analysis source (the
+// orphan path the legacy classifier produces when fact + results match).
+vi.mock('../../../canvas/hooks/useAnalysisStateSource', () => ({
+  readAnalysisStateSourceFromStore: () => ({
+    source: 'cee_v5_run_analysis',
+    showOrphanBanner: false,
+    hasResultsReport: true,
+    factPresentForScenario: true,
+  }),
+}))
+
+// Payload trace store: empty — no V5 CEE call captured in this turn.
+vi.mock('../../../lib/payload-trace-store', () => ({
+  usePayloadTraceStore: { getState: () => ({ payloads: [] }) },
+}))
+
+import { buildDebugBundleAsync } from '../utils/exportBundle'
+
+function makeFixtureDebugData(): DebugData {
+  return {
+    overall: {
+      status: 'success',
+      total_duration_ms: 1200,
+      request_id: 'req-uploaded',
+    },
+    // Legacy classifier mislabelled this as proxy_or_network_failure
+    // even though no failed HTTP record exists. The pipeline status
+    // is fed in via debug data so we can confirm the new fields
+    // contradict it honestly.
+    services: { cee: null, plot: null, isl: null },
+    error: null,
+    builds: { ui: 'fixture-build', cee: null, plot: null, isl: null },
+    diagnostics: {
+      plot_has_downstream_calls: false,
+      downstream_calls_path_found: null,
+      downstream_calls_paths_checked: [],
+      isl_data_source: 'none',
+      cee_trace_present: false,
+      cee_degraded: false,
+      llm_raw_available: false,
+      llm_raw_path_found: null,
+      e_values_present: false,
+      evpi_present: false,
+      confidence_differentiated: false,
+      confidence_unique_values: [],
+      confidence_source_bootstrap: false,
+      intercept_populated: false,
+      epsilon_std_present: false,
+      response_hash_present: false,
+      mca_computed: false,
+    },
+    ceeTrace: null,
+    corrections: [],
+    correctionsSummary: null,
+    pipeline: {
+      status: 'success',
+      total_duration_ms: 1200,
+      stages: [],
+      llm_metadata: null,
+      llm_raw: null,
+      node_extraction: null,
+      connectivity: {
+        decision_count: 0,
+        option_count: 0,
+        goal_count: 0,
+        factor_count: 0,
+        edge_count: 0,
+      },
+    },
+    payloads: {
+      // No CEE capture at all — analysis fact present but no proof of
+      // the turn that minted it.
+      cee_request: null,
+      cee_response: null,
+      plot_request: null,
+      plot_response: null,
+      isl_request: null,
+      isl_response: null,
+    },
+    gates: [],
+    validation: { summary: { errors: 0, warnings: 0, info: 0 }, issues: [] },
+    winningOption: null,
+    robustness: {
+      status: 'unavailable',
+      stability: null,
+      context_label: 'N/A',
+      description: '',
+    },
+    hasData: true,
+    orchestrator: null,
+    v12_4_checks: null,
+    request_id_chain: {
+      ui_generated: 'ui-req',
+      from_plot: {
+        ui: 'ui-req',
+        plot: null,
+        isl: null,
+        isl_echoed: null,
+        all_match: false,
+        chain_complete: false,
+      },
+      plot_chain_present: false,
+      draft_trace: { cee_trace: null },
+    } as RequestIdChain,
+    feature_flags_at_request: {} as never,
+    timing: null,
+    schema_versions: null,
+    cee_observability: null,
+    m1_coaching: null,
+    m2_review: null,
+    cee_downstream: null,
+    cee_operations: null,
+    diagnostic_trace: null,
+  }
+}
+
+describe('uploaded-bundle fixture — every contradiction the brief lists is machine-readable', () => {
+  beforeEach(() => {
+    canvasState.currentScenarioId = 'sid-uploaded-bundle'
+    canvasState.v5AnalysisFact = {
+      scenarioId: 'sid-uploaded-bundle',
+      analysisHash: 'v5:abc123',
+      hasRunAnalysisFact: true,
+      freshness: 'fresh',
+    }
+    canvasState.results = {
+      report: { summary: 'Plan A is recommended' },
+      hash: 'v5:abc123',
+      rawV2Response: null,
+    }
+  })
+
+  it('Q1: was canonical V5 analysis enabled? → canonical_flag_on is a boolean (not unknown)', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    const td = bundle.v5_canonical_turn_diagnostics
+    expect(td).toBeDefined()
+    expect(typeof td!.canonical_flag_on).toBe('boolean')
+    expect(td!.canonical_flag_env_key).toBe('VITE_V5_CANONICAL_ANALYSIS')
+  })
+
+  it('Q2 + Q3: did CEE return a parseable response? → parse.parse_ok null when no capture', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    const td = bundle.v5_canonical_turn_diagnostics!
+    expect(td.latest_v5_turn.request_present).toBe(false)
+    expect(td.latest_v5_turn.response_present).toBe(false)
+    expect(td.parse.parse_ok).toBeNull()
+  })
+
+  it('Q4: did Results render from live CEE/PLoT, hydrated state, or fallback? → capture_pipeline_status answers in one field', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    // No rawV2Response + no V5 capture + results.report present
+    // → hydrated_only is the honest label.
+    expect(bundle.capture_pipeline_status).toBe('hydrated_only')
+  })
+
+  it('Q5: is there a contradiction between fact, capture, and analysis state? → coherence.issues lists exact codes', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    const issues = bundle.v5_canonical_turn_diagnostics!.coherence.issues
+    expect(issues).toContain('analysis_state_cee_v5_but_effective_cee_response_none')
+    expect(issues).toContain('analysis_fact_present_but_cee_capture_missing')
+    expect(bundle.v5_canonical_turn_diagnostics!.coherence.state).toBe('contradictory')
+  })
+
+  it('Q6: which scientific validators have evidence? → hydrated_report labelled honestly, overall_status = insufficient_raw_evidence', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    expect(bundle.scientific_validation).toBeDefined()
+    // Capture is hydrated_only with results.report present → source
+    // hydrated_report. This is the honest classification (NOT
+    // unavailable) because there IS a report to inspect, but every
+    // validator must report inferred/unavailable rather than pretend
+    // live raw payloads exist.
+    expect(bundle.scientific_validation!.source).toBe('hydrated_report')
+    // With zero validators reaching derived/observed evidence → exactly
+    // the insufficient_raw_evidence state the brief calls out.
+    expect(bundle.scientific_validation!.overall_status).toBe('insufficient_raw_evidence')
+    // Every validator must declare claim_strength honestly.
+    for (const v of Object.values(bundle.scientific_validation!.validators)) {
+      expect(['observed', 'derived', 'inferred', 'unavailable']).toContain(v.claim_strength)
+      // Honesty rule: inferred never pairs with pass.
+      if (v.claim_strength === 'inferred') {
+        expect(v.status).not.toBe('pass')
+      }
+    }
+  })
+
+  it('Q7: which upstream support is required? → user_std_propagation lists plot.debug.isl_request', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    const stdValidator =
+      bundle.scientific_validation!.validators.user_std_propagation
+    expect(stdValidator.required_upstream_support).toContain('plot.debug.isl_request')
+  })
+
+  it('Q8: scenario_id is populated honestly with source — never hardcoded null', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    expect(bundle.session.scenario_id).toBe('sid-uploaded-bundle')
+    expect(bundle.session.scenario_id_source).toBe('store')
+    expect(bundle.scenario_id_reconciliation?.candidates.store).toBe('sid-uploaded-bundle')
+    expect(bundle.scenario_id_reconciliation?.candidates.v5_fact).toBe('sid-uploaded-bundle')
+    // Same value across both → no conflict
+    expect(bundle.scenario_id_reconciliation?.conflicts).toEqual([])
+  })
+
+  it('legacy fields preserved alongside the new honest ones', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    // Legacy enum still emitted — consumers depending on it do not break.
+    expect(bundle.v5_canonical_analysis).toBeDefined()
+    expect(bundle.pipeline.v5_pipeline_status).toBeDefined()
+  })
+
+  it('redaction manifest documents the analytical preservation policy verbatim', async () => {
+    const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+    const manifest = bundle.debug_redaction_manifest!
+    expect(manifest.preserved_analytical_paths).toContain(
+      'payloads.plot_request.graph.nodes[*].data.observed_state.*',
+    )
+    expect(manifest.preserved_analytical_paths).toContain(
+      'payloads.plot_response.factor_sensitivity[*]',
+    )
+  })
+})

--- a/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
@@ -365,6 +365,148 @@ describe('uploaded-bundle fixture — every contradiction the brief lists is mac
     }
   })
 
+  it('round-5 P0.1 + P1.3: trace response BODY drives parse diagnostics when bundle.payloads.cee_response is null', async () => {
+    // Trace entry carries a successful response body; bundle.payloads
+    // are empty. The snapshot's parse fields must derive from the
+    // trace body — not appear empty.
+    traceState.payloads = [
+      {
+        id: 'trace-body-1',
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        status: 200,
+        completed: true,
+        request: { body: { kind: 'analysis' } },
+        response: {
+          body: {
+            blocks: [{ type: 'analysis_result', enrichment: {} }],
+            output_text: 'ok',
+          },
+        },
+      },
+    ]
+    try {
+      const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+      const td = bundle.v5_canonical_turn_diagnostics!
+      expect(td.latest_v5_turn.source).toBe('payload_trace')
+      expect(td.latest_v5_turn.response_present).toBe(true)
+      expect(td.latest_v5_turn.response_body_present).toBe(true)
+      // parse_ok is derived from the trace body (not bundle.payloads,
+      // which is null in this fixture).
+      expect(td.parse.parse_ok).toBe(true)
+      expect(td.diagnostic_source_strength.parse).toBe('live_response')
+      // response_top_level_keys must reflect the trace body's keys.
+      expect(td.parse.response_top_level_keys).toEqual(
+        expect.arrayContaining(['blocks', 'output_text']),
+      )
+    } finally {
+      traceState.payloads = []
+    }
+  })
+
+  it('round-5 P1.3: trace parse-error envelope drives parse_failure_kind + raw_response_present', async () => {
+    traceState.payloads = [
+      {
+        id: 'trace-parse-err',
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        status: 200,
+        completed: true,
+        response: {
+          body: {
+            kind: 'parse_error',
+            reason: 'schema validation failed',
+            parse_failure_kind: 'schema_mismatch',
+            raw: { unknown_top_level_key: 'something' },
+          },
+        },
+      },
+    ]
+    try {
+      const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+      const td = bundle.v5_canonical_turn_diagnostics!
+      expect(td.latest_v5_turn.response_body_present).toBe(true)
+      expect(td.parse.parse_ok).toBe(false)
+      expect(td.parse.parse_failure_kind).toBe('schema_mismatch')
+      expect(td.parse.raw_response_present).toBe(true)
+      // Issue must fire whenever parse_ok=false AND raw_response_present.
+      expect(td.coherence.issues).toContain('parse_failed_with_raw_preserved')
+    } finally {
+      traceState.payloads = []
+    }
+  })
+
+  it('round-5 P0.2/P0.3: trace status-only failure (no body) → parse_ok null, response_body_present false, source_strength.parse unavailable', async () => {
+    traceState.payloads = [
+      {
+        id: 'trace-500-no-body',
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        status: 500,
+        completed: true,
+        // No request.body, no response.body — pure metadata stub
+        // with HTTP-level completion.
+      },
+    ]
+    try {
+      const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+      const td = bundle.v5_canonical_turn_diagnostics!
+      // Capture is assembled (trace tier active).
+      expect(td.latest_v5_turn.source).toBe('payload_trace')
+      // HTTP completion observed but body absent — these must
+      // disagree.
+      expect(td.latest_v5_turn.response_present).toBe(true)
+      expect(td.latest_v5_turn.response_body_present).toBe(false)
+      // Parse provenance must be honestly unavailable, NOT
+      // 'live_response' with parse_ok: true.
+      expect(td.parse.parse_ok).toBeNull()
+      expect(td.diagnostic_source_strength.parse).toBe('unavailable')
+    } finally {
+      traceState.payloads = []
+    }
+  })
+
+  it('round-5 Imp3: trace entry AND bundle.payloads BOTH present → trace tier wins, request_id sourced from trace', async () => {
+    // Both sources exist with different request_ids. The canonical
+    // resolver must pick `payload_trace` (highest tier) and the
+    // request_id must come from the trace, not the bundle/session.
+    traceState.payloads = [
+      {
+        id: 'trace-wins',
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        status: 200,
+        completed: true,
+        request: { body: {} },
+        response: { body: { blocks: [] } },
+      },
+    ]
+    try {
+      const data: DebugData = {
+        ...makeFixtureDebugData(),
+        overall: {
+          status: 'success',
+          total_duration_ms: 100,
+          request_id: 'session-loses',
+        },
+        payloads: {
+          ...makeFixtureDebugData().payloads,
+          cee_request: { kind: 'from-bundle' },
+          cee_response: { blocks: [] },
+        },
+      }
+      const bundle = await buildDebugBundleAsync(data)
+      const td = bundle.v5_canonical_turn_diagnostics!
+      expect(td.latest_v5_turn.source).toBe('payload_trace')
+      expect(td.latest_v5_turn.request_id).toBe('trace-wins')
+      expect(td.latest_v5_turn.request_id_source).toBe('payload_trace')
+      // The diagnostic_source_strength reports live_trace, not bundle.
+      expect(td.diagnostic_source_strength.latest_v5_turn).toBe('live_trace')
+    } finally {
+      traceState.payloads = []
+    }
+  })
+
   it('regression: service-metadata-only 5xx → parse.parse_ok is null (NOT false) and diagnostic_source_strength.parse is unavailable', async () => {
     // services.cee reports a V5-endpoint 5xx but neither the trace nor
     // the bundle.payloads carry a response body. Per P0.2 the parse

--- a/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
@@ -80,9 +80,20 @@ vi.mock('../../../canvas/hooks/useAnalysisStateSource', () => ({
   }),
 }))
 
-// Payload trace store: empty — no V5 CEE call captured in this turn.
+// Payload trace store — controllable per test. Default empty for the
+// uploaded-failure scenarios; populated in the trace-present test below.
+const traceState: {
+  payloads: Array<{
+    id?: string
+    service?: string
+    endpoint?: string
+    status?: number
+    duration?: number
+  }>
+} = { payloads: [] }
+
 vi.mock('../../../lib/payload-trace-store', () => ({
-  usePayloadTraceStore: { getState: () => ({ payloads: [] }) },
+  usePayloadTraceStore: { getState: () => traceState },
 }))
 
 import { buildDebugBundleAsync } from '../utils/exportBundle'
@@ -276,6 +287,42 @@ describe('uploaded-bundle fixture — every contradiction the brief lists is mac
     // Legacy enum still emitted — consumers depending on it do not break.
     expect(bundle.v5_canonical_analysis).toBeDefined()
     expect(bundle.pipeline.v5_pipeline_status).toBeDefined()
+  })
+
+  it('when a V5 payload-trace entry exists, latest_v5_turn populates endpoint + request_id from the trace, source = payload_trace, diagnostic_source_strength.latest_v5_turn = live_trace', async () => {
+    traceState.payloads = [
+      {
+        id: 'req-trace-abc',
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        status: 200,
+        duration: 142,
+      },
+    ]
+    try {
+      // Inject CEE payloads so v5_cee_capture is assembled; the test
+      // confirms endpoint + request_id come from the trace entry
+      // (not the session-level request_id).
+      const data: DebugData = {
+        ...makeFixtureDebugData(),
+        payloads: {
+          ...makeFixtureDebugData().payloads,
+          cee_request: { kind: 'request' },
+          cee_response: { blocks: [] },
+        },
+      }
+      const bundle = await buildDebugBundleAsync(data)
+      const turn = bundle.v5_canonical_turn_diagnostics!.latest_v5_turn
+      expect(turn.endpoint).toBe('/bff/orchestrate/v2/turn')
+      expect(turn.request_id).toBe('req-trace-abc')
+      expect(turn.duration_ms).toBe(142)
+      expect(turn.source).toBe('payload_trace')
+      expect(
+        bundle.v5_canonical_turn_diagnostics!.diagnostic_source_strength.latest_v5_turn,
+      ).toBe('live_trace')
+    } finally {
+      traceState.payloads = []
+    }
   })
 
   it('reproduces the misleading legacy proxy_or_network_failure label: legacy classifies as proxy/network because services.cee returned 5xx, but no V5 CEE payload-trace failure exists — new classifier disagrees and emits legacy_pipeline_status_misleading_proxy_or_network_failure', async () => {

--- a/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
@@ -278,6 +278,41 @@ describe('uploaded-bundle fixture — every contradiction the brief lists is mac
     expect(bundle.pipeline.v5_pipeline_status).toBeDefined()
   })
 
+  it('reproduces the misleading legacy proxy_or_network_failure label: legacy classifies as proxy/network because services.cee returned 5xx, but no V5 CEE payload-trace failure exists — new classifier disagrees and emits legacy_pipeline_status_misleading_proxy_or_network_failure', async () => {
+    // Inject a 5xx services.cee record so derivePipelineStatus emits
+    // proxy_or_network_failure (the misleading legacy label the brief
+    // calls out). Crucially, the payload-trace store still has NO V5
+    // turn record (mocked empty above), so our new classifier sees
+    // failedHttpRecord: { present: false } and lands on hydrated_only.
+    // The disagreement must surface as an explicit coherence issue.
+    const dataWith5xx: DebugData = {
+      ...makeFixtureDebugData(),
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 502,
+          success: false,
+          duration_ms: 80,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
+    }
+    const bundle = await buildDebugBundleAsync(dataWith5xx)
+
+    // Legacy reports the misleading classification.
+    expect(bundle.pipeline.v5_pipeline_status).toBe('proxy_or_network_failure')
+
+    // New classifier sees no V5 payload-trace failure → does NOT echo
+    // proxy_or_network_failure. The disagreement is captured as an
+    // explicit coherence issue.
+    expect(bundle.capture_pipeline_status).not.toBe('proxy_or_network_failure')
+    expect(bundle.v5_canonical_turn_diagnostics!.coherence.issues).toContain(
+      'legacy_pipeline_status_misleading_proxy_or_network_failure',
+    )
+  })
+
   it('redaction manifest documents the analytical preservation policy verbatim', async () => {
     const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
     const manifest = bundle.debug_redaction_manifest!

--- a/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
@@ -565,8 +565,27 @@ describe('uploaded-bundle fixture — every contradiction the brief lists is mac
     // proxy_or_network_failure. The disagreement is captured as an
     // explicit coherence issue.
     expect(bundle.capture_pipeline_status).not.toBe('proxy_or_network_failure')
-    expect(bundle.v5_canonical_turn_diagnostics!.coherence.issues).toContain(
+
+    // FINAL ACCEPTANCE check C — one bundle must contain ALL the
+    // example issue codes from the brief so a reviewer can read a
+    // single export and understand every dimension of the original
+    // failure: analysis-state contradiction, missing capture despite a
+    // fact, results rendered from store, and the legacy mislabel.
+    const issues = bundle.v5_canonical_turn_diagnostics!.coherence.issues
+    expect(issues).toContain(
+      'analysis_state_cee_v5_but_effective_cee_response_none',
+    )
+    expect(issues).toContain(
+      'analysis_fact_present_but_cee_capture_missing',
+    )
+    expect(issues).toContain(
+      'results_rendered_from_store_without_capture',
+    )
+    expect(issues).toContain(
       'legacy_pipeline_status_misleading_proxy_or_network_failure',
+    )
+    expect(bundle.v5_canonical_turn_diagnostics!.coherence.state).toBe(
+      'contradictory',
     )
   })
 

--- a/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.uploadedFailureFixture.spec.ts
@@ -317,12 +317,80 @@ describe('uploaded-bundle fixture — every contradiction the brief lists is mac
       expect(turn.request_id).toBe('req-trace-abc')
       expect(turn.duration_ms).toBe(142)
       expect(turn.source).toBe('payload_trace')
+      // P1.3: request_id_source is explicit so reviewers don't mistake
+      // the session-level fallback for the actual trace id.
+      expect(turn.request_id_source).toBe('payload_trace')
       expect(
         bundle.v5_canonical_turn_diagnostics!.diagnostic_source_strength.latest_v5_turn,
       ).toBe('live_trace')
     } finally {
       traceState.payloads = []
     }
+  })
+
+  it('regression: V5 trace entry alone (request+response) is sufficient to populate v5_cee_capture and latest_v5_turn when bundle.payloads.cee_* are null', async () => {
+    // The trace store carries a full V5 turn record but bundle.payloads
+    // are empty (e.g. capture path didn't propagate them). Per P0.1 the
+    // capture should still be assembled from the trace.
+    traceState.payloads = [
+      {
+        id: 'trace-only-req',
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        status: 200,
+        duration: 99,
+        completed: true,
+        request: { body: { kind: 'analysis', scenario_id: 'sid-uploaded-bundle' } },
+        response: { body: { blocks: [] } },
+      },
+    ]
+    try {
+      // bundle.payloads.cee_request/response stay null (the default
+      // makeFixtureDebugData shape) so this is genuinely a trace-only path.
+      const bundle = await buildDebugBundleAsync(makeFixtureDebugData())
+      const turn = bundle.v5_canonical_turn_diagnostics!.latest_v5_turn
+      // Capture WAS assembled despite empty bundle.payloads.
+      expect(bundle.v5_canonical_analysis?.v5_cee_capture).not.toBeNull()
+      // request/response presence reflect the trace entry, not bundle.payloads.
+      expect(turn.request_present).toBe(true)
+      expect(turn.response_present).toBe(true)
+      // Provenance fields all come from the trace.
+      expect(turn.request_id).toBe('trace-only-req')
+      expect(turn.endpoint).toBe('/bff/orchestrate/v2/turn')
+      expect(turn.duration_ms).toBe(99)
+      expect(turn.source).toBe('payload_trace')
+      expect(turn.request_id_source).toBe('payload_trace')
+    } finally {
+      traceState.payloads = []
+    }
+  })
+
+  it('regression: service-metadata-only 5xx → parse.parse_ok is null (NOT false) and diagnostic_source_strength.parse is unavailable', async () => {
+    // services.cee reports a V5-endpoint 5xx but neither the trace nor
+    // the bundle.payloads carry a response body. Per P0.2 the parse
+    // surface must report unavailable, not "parsed and failed".
+    const data: DebugData = {
+      ...makeFixtureDebugData(),
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 502,
+          success: false,
+          duration_ms: 75,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
+    }
+    const bundle = await buildDebugBundleAsync(data)
+    const td = bundle.v5_canonical_turn_diagnostics!
+    // Parse evidence is genuinely absent — surface it honestly.
+    expect(td.parse.parse_ok).toBeNull()
+    expect(td.diagnostic_source_strength.parse).toBe('unavailable')
+    // latest_v5_turn.source reflects the service-metadata tier.
+    expect(td.latest_v5_turn.source).toBe('service_metadata')
+    expect(td.diagnostic_source_strength.latest_v5_turn).toBe('service_metadata')
   })
 
   it('reproduces the misleading legacy proxy_or_network_failure label: legacy classifies as proxy/network because services.cee returned 5xx, but no V5 CEE payload-trace failure exists — new classifier disagrees and emits legacy_pipeline_status_misleading_proxy_or_network_failure', async () => {

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -52,6 +52,7 @@ import {
   classifyV5CapturePipelineStatus,
   detectFailedHttpRecord,
   findLatestV5TurnEntry,
+  hasResponseBody,
   type CapturePipelineStatus,
 } from '../../../lib/v5CapturePipelineStatus'
 import {
@@ -2691,12 +2692,35 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     const storeState = useCanvasStore.getState()
     const fact = storeState.v5AnalysisFact
 
+    // Hoist trace lookup BEFORE parse-field derivation so the parse
+    // diagnostics can fall back to trace.response.body when
+    // bundle.payloads.cee_response is null (round-5 P0.1).
+    const v5TraceStorePre = await import('../../../lib/payload-trace-store')
+    const v5TraceStatePre = v5TraceStorePre.usePayloadTraceStore.getState()
+    const latestV5TracePre = findLatestV5TurnEntry(v5TraceStatePre.payloads)
+    const traceResponseBody =
+      latestV5TracePre?.response?.body !== undefined
+        ? latestV5TracePre.response.body
+        : null
+
     const ceeRequest = bundle.payloads.cee_request
     const ceeResponse = bundle.payloads.cee_response
+    // EFFECTIVE response body for parse-field derivation. Prefer the
+    // bundle-payloads object (already-redacted and normalised); fall
+    // back to the trace-store body when the bundle path didn't
+    // propagate the response. Either source feeds `ceeResponseObject`
+    // and every downstream parse signal (parse_ok, parse_error,
+    // response_top_level_keys, Phase 3 counts, unknown_block_types).
+    const effectiveResponseBody = ceeResponse ?? traceResponseBody
     const ceeResponseObject =
-      ceeResponse && typeof ceeResponse === 'object' && !Array.isArray(ceeResponse)
-        ? (ceeResponse as Record<string, unknown>)
+      effectiveResponseBody &&
+      typeof effectiveResponseBody === 'object' &&
+      !Array.isArray(effectiveResponseBody)
+        ? (effectiveResponseBody as Record<string, unknown>)
         : null
+    // Distinct from `responsePresent` (HTTP completion): true only when
+    // an actual parseable body object was captured.
+    const responseBodyPresent = ceeResponseObject !== null
 
     // The captured body may be either:
     //   (a) a successful OlumiResponse (object), or
@@ -2866,14 +2890,10 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       return false
     })()
 
-    // Look up the actual V5 turn entry in the payload-trace store so
-    // capture-level fields (request_id, endpoint, duration_ms,
-    // request_present, response_present) reflect the real call rather
-    // than coarse session-level values.
-    const v5TraceStore = await import('../../../lib/payload-trace-store')
-    const v5TraceState = v5TraceStore.usePayloadTraceStore.getState()
-    const latestV5Trace = findLatestV5TurnEntry(v5TraceState.payloads)
-    const latestV5TraceTyped = latestV5Trace as
+    // Re-use the trace lookup from above (hoisted before parse
+    // derivation). `latestV5TraceTyped` carries the typed view used by
+    // the capture assembly.
+    const latestV5TraceTyped = latestV5TracePre as
       | {
           id?: string
           endpoint?: string
@@ -2885,6 +2905,18 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
         }
       | null
 
+    // V5-endpoint failure signal for the narrowed service_metadata
+    // tier (round-5 P1.4): only failure evidence activates the tier;
+    // successful service records with no payloads fall through to
+    // `store` or `none` so missingness is visible.
+    const serviceMetadataV5FailurePresent =
+      ceeService !== null &&
+      typeof ceeService.endpoint === 'string' &&
+      ceeService.endpoint.includes('/orchestrate/v2/turn') &&
+      (ceeService.success === false ||
+        (typeof ceeService.status === 'number' &&
+          (ceeService.status >= 500 || ceeService.status === 0)))
+
     // Single canonical source for capture assembly. Once a tier is
     // selected, ALL related fields derive from that same source to
     // avoid mixed-provenance bundles. The helper is shared with the
@@ -2894,10 +2926,7 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       traceEntryPresent: latestV5TraceTyped !== null,
       bundlePayloadsCeeRequestPresent: requestPresent,
       bundlePayloadsCeeResponsePresent: responsePresent,
-      serviceMetadataV5EndpointPresent:
-        ceeService !== null &&
-        typeof ceeService.endpoint === 'string' &&
-        ceeService.endpoint.includes('/orchestrate/v2/turn'),
+      serviceMetadataV5FailurePresent,
       // First try block doesn't read `factPresentForScenario` here.
       // 'store' tier is meaningless for V5CeeCapture assembly (the
       // capture object requires evidence); only the snapshot uses
@@ -2924,12 +2953,17 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
           ? responsePresent
           : false
 
-    // parse_ok semantics: only meaningful when a response body was
-    // actually parsed. Without a response there's nothing to parse —
-    // emit `false` here in the legacy V5CeeCapture (existing contract)
-    // but the new snapshot will overlay `null` when response_present
-    // is false to be honest about evidence absence.
-    const parseOkLegacy = tierResponsePresent && !ceeIsParseErrorEnvelope
+    // parse_ok semantics: only meaningful when a parseable response
+    // BODY was captured. Round-5 P0.3 lesson: a 500 status with no
+    // body previously inherited `parseOkLegacy = true` because
+    // `tierResponsePresent` was true (status set) and
+    // `ceeIsParseErrorEnvelope` was false (no body to misclassify).
+    // Gate the legacy boolean on `responseBodyPresent` so status-only
+    // / failure-without-body trace entries report `false` honestly.
+    // The new snapshot still overlays `null` in this case (it never
+    // claims "parsed and failed" without evidence) but the legacy
+    // field must also be honest for backward-compat consumers.
+    const parseOkLegacy = responseBodyPresent && !ceeIsParseErrorEnvelope
 
     const v5Capture: V5CeeCapture | null =
       captureTier === 'none'
@@ -3056,6 +3090,16 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     const latestV5Trace = findLatestV5TurnEntry(traceState.payloads)
     const v5TraceEntryPresent = latestV5Trace !== null
 
+    // Mirror the body-presence detection from the first try block —
+    // either bundle.payloads.cee_response is an object OR the trace
+    // entry carries a response body. Drives parse provenance in the
+    // snapshot.
+    const snapshotResponseBodyPresent =
+      (bundle.payloads.cee_response !== null &&
+        typeof bundle.payloads.cee_response === 'object' &&
+        !Array.isArray(bundle.payloads.cee_response)) ||
+      (latestV5Trace !== null && hasResponseBody(latestV5Trace))
+
     // Re-compute the canonical capture tier in this try block too —
     // the first try block (legacy assembly) might have bailed, but
     // this block must still pick a tier consistent with the rest of
@@ -3066,7 +3110,9 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       traceEntryPresent: v5TraceEntryPresent,
       bundlePayloadsCeeRequestPresent: bundle.payloads.cee_request !== null,
       bundlePayloadsCeeResponsePresent: bundle.payloads.cee_response !== null,
-      serviceMetadataV5EndpointPresent: ceeServiceIsV5,
+      // Round-5 P1.4: service_metadata tier only fires on V5 failure
+      // evidence — successful service records fall through.
+      serviceMetadataV5FailurePresent: serviceMetadataV5Failure,
       factPresentForScenario: sourceResult.factPresentForScenario,
     })
 
@@ -3140,6 +3186,7 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       optionCount,
       factorSensitivityCount,
       captureTier: snapshotCaptureTier,
+      responseBodyPresent: snapshotResponseBodyPresent,
       renderedOptionCount,
       renderedFactorCount,
       capturePipeline,

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -2524,10 +2524,27 @@ export function buildDebugBundle(data: DebugData, options: ExportOptions = {}): 
         environment: getEnvironment(),
       },
       feature_flags: (featureFlagsAtRequest as Record<string, unknown> | null) ?? null,
-      // Sync path cannot resolve store/payload sources; async export
-      // overwrites these two fields via reconcileScenarioId.
-      scenario_id: null,
-      scenario_id_source: 'none' as ScenarioIdSource,
+      // Sync path cannot reach the canvas store / payload trace store,
+      // but URL and full_graph candidates are available synchronously.
+      // Async export overwrites these via the full reconcileScenarioId
+      // run. This partial reconciliation prevents the legacy hardcoded
+      // null when a user is on /scenarios/<id> and exports synchronously.
+      ...(() => {
+        const partial = reconcileScenarioId({
+          storeScenarioId: null,
+          v5FactScenarioId: null,
+          payloadScenarioId: null,
+          urlScenarioId:
+            typeof window !== 'undefined' && window.location
+              ? extractScenarioIdFromUrl(window.location.href)
+              : null,
+          fullGraphScenarioId: extractScenarioIdFromFullGraph(fullGraph),
+        })
+        return {
+          scenario_id: partial.selected_scenario_id,
+          scenario_id_source: partial.selected_source,
+        }
+      })(),
       current_route: null,
       session_id: null,
       session_started_at: null,
@@ -2911,80 +2928,86 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     bundle.session.scenario_id_source = reconciliation.selected_source
     bundle.scenario_id_reconciliation = reconciliation
 
-    // --- Capture pipeline status (P0.2) ---
-    // Only emit when the legacy v5_canonical_analysis block was assembled —
-    // it carries the canonical v5_cee_capture summary we need. Without it,
-    // we cannot honestly classify capture state.
-    const legacy = bundle.v5_canonical_analysis
-    if (legacy) {
-      const failedHttp = detectFailedHttpRecord(traceState.payloads)
-      const rawV2Present = storeState.results?.rawV2Response != null
-      const capturePipeline = classifyV5CapturePipelineStatus({
-        v5Capture: legacy.v5_cee_capture
-          ? {
-              request_present: legacy.v5_cee_capture.request_present,
-              response_present: legacy.v5_cee_capture.response_present,
-              parse_ok: legacy.v5_cee_capture.parse_ok,
-              raw_response_present: legacy.v5_cee_capture.raw_response_present,
-            }
-          : null,
-        hasResultsReport: sourceResult.hasResultsReport,
-        rawV2ResponsePresent: rawV2Present,
-        failedHttpRecord: failedHttp,
-        analysisStateSource: legacy.analysis_state_source,
-        effectiveCeeResponseSource: bundle.effective_cee_response_source ?? null,
-        analysisFactPresent: legacy.analysis_fact_status === 'present',
-        scenarioIdConflictCount: reconciliation.conflicts.length,
-        legacyPipelineStatus: bundle.pipeline.v5_pipeline_status ?? null,
-      })
-      bundle.capture_pipeline_status = capturePipeline.capture_pipeline_status
+    // --- Capture pipeline status (P0.2) + Turn diagnostics (P0.3) ---
+    // ALWAYS emit, even when the legacy v5_canonical_analysis block was not
+    // assembled (e.g. classifier bailed). When legacy is absent we fall back
+    // to a synthesised "no-legacy-data" diagnostic with honest enum values
+    // so consumers can rely on these fields being present on every export.
+    const legacy: V5CanonicalAnalysisDiagnostic =
+      bundle.v5_canonical_analysis ?? {
+        v5_cee_capture: null,
+        analysis_state_source: sourceResult.source,
+        analysis_fact_status: 'unknown_not_checked',
+        debug_capture_status: 'cee_capture_missing',
+        canonical_flag_on: isV5CanonicalAnalysisEnabled(),
+      }
 
-      // --- V5 canonical turn diagnostics (P0.3) ---
-      // graph_hash_at_generation: read-through. The v5AnalysisFact slice
-      // may not carry this field on every code path; emit null when
-      // absent rather than fabricating from elsewhere.
-      const graphHash =
-        fact && typeof (fact as Record<string, unknown>).graphHashAtGeneration === 'string'
-          ? ((fact as Record<string, unknown>).graphHashAtGeneration as string)
-          : null
+    const failedHttp = detectFailedHttpRecord(traceState.payloads)
+    const rawV2Present = storeState.results?.rawV2Response != null
+    const capturePipeline = classifyV5CapturePipelineStatus({
+      v5Capture: legacy.v5_cee_capture
+        ? {
+            request_present: legacy.v5_cee_capture.request_present,
+            response_present: legacy.v5_cee_capture.response_present,
+            parse_ok: legacy.v5_cee_capture.parse_ok,
+            raw_response_present: legacy.v5_cee_capture.raw_response_present,
+          }
+        : null,
+      hasResultsReport: sourceResult.hasResultsReport,
+      rawV2ResponsePresent: rawV2Present,
+      failedHttpRecord: failedHttp,
+      analysisStateSource: legacy.analysis_state_source,
+      effectiveCeeResponseSource: bundle.effective_cee_response_source ?? null,
+      analysisFactPresent: legacy.analysis_fact_status === 'present',
+      scenarioIdConflictCount: reconciliation.conflicts.length,
+      legacyPipelineStatus: bundle.pipeline.v5_pipeline_status ?? null,
+    })
+    bundle.capture_pipeline_status = capturePipeline.capture_pipeline_status
 
-      // Flag diagnostic — guard against environments without
-      // localStorage (e.g. SSR / jsdom edge cases).
-      const flagDiagnostic = (() => {
-        try {
-          return diagnoseV5CanonicalAnalysis()
-        } catch {
-          return null
-        }
-      })()
+    // graph_hash_at_generation: read-through. The v5AnalysisFact slice
+    // may not carry this field on every code path; emit null when
+    // absent rather than fabricating from elsewhere.
+    const graphHash =
+      fact && typeof (fact as Record<string, unknown>).graphHashAtGeneration === 'string'
+        ? ((fact as Record<string, unknown>).graphHashAtGeneration as string)
+        : null
 
-      const optionCount = extractOptionCountFromPlotResponse(bundle.payloads.plot_response)
-      const factorSensitivityCount = extractFactorSensitivityCountFromPlotResponse(
-        bundle.payloads.plot_response,
-      )
+    // Flag diagnostic — guard against environments without
+    // localStorage (e.g. SSR / jsdom edge cases).
+    const flagDiagnostic = (() => {
+      try {
+        return diagnoseV5CanonicalAnalysis()
+      } catch {
+        return null
+      }
+    })()
 
-      const base = assembleV5CanonicalTurnDiagnostics({
-        legacyDiagnostic: legacy,
-        flagDiagnostic,
-        analysisStateSource: legacy.analysis_state_source,
-        hasResultsReport: sourceResult.hasResultsReport,
-        graphHashAtGeneration: graphHash,
-        optionCount,
-        factorSensitivityCount,
-        capturePipeline,
-        scenarioIdReconciliation: reconciliation,
-      })
+    const optionCount = extractOptionCountFromPlotResponse(bundle.payloads.plot_response)
+    const factorSensitivityCount = extractFactorSensitivityCountFromPlotResponse(
+      bundle.payloads.plot_response,
+    )
 
-      bundle.v5_canonical_turn_diagnostics = attachAnalysisFactDetails(
-        base,
-        fact
-          ? {
-              hasRunAnalysisFact: fact.hasRunAnalysisFact,
-              freshness: fact.freshness,
-            }
-          : null,
-      )
-    }
+    const base = assembleV5CanonicalTurnDiagnostics({
+      legacyDiagnostic: legacy,
+      flagDiagnostic,
+      analysisStateSource: legacy.analysis_state_source,
+      hasResultsReport: sourceResult.hasResultsReport,
+      graphHashAtGeneration: graphHash,
+      optionCount,
+      factorSensitivityCount,
+      capturePipeline,
+      scenarioIdReconciliation: reconciliation,
+    })
+
+    bundle.v5_canonical_turn_diagnostics = attachAnalysisFactDetails(
+      base,
+      fact
+        ? {
+            hasRunAnalysisFact: fact.hasRunAnalysisFact,
+            freshness: fact.freshness,
+          }
+        : null,
+    )
 
     // --- Scientific validation (P1) ---
     // Always runs (even when capture_pipeline_status is missing) — the

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -2524,11 +2524,15 @@ export function buildDebugBundle(data: DebugData, options: ExportOptions = {}): 
         environment: getEnvironment(),
       },
       feature_flags: (featureFlagsAtRequest as Record<string, unknown> | null) ?? null,
-      // Sync path cannot reach the canvas store / payload trace store,
-      // but URL and full_graph candidates are available synchronously.
-      // Async export overwrites these via the full reconcileScenarioId
-      // run. This partial reconciliation prevents the legacy hardcoded
-      // null when a user is on /scenarios/<id> and exports synchronously.
+      // Sync path cannot reach the canvas store / payload trace store.
+      // URL is available synchronously; full_graph is reachable but the
+      // current `transformGraphDataEnriched` does NOT propagate
+      // scenarioId into `_meta` (documented in
+      // `extractScenarioIdFromFullGraph`), so that candidate is
+      // effectively always null today. Async export overwrites these
+      // via the full reconcileScenarioId run. This partial
+      // reconciliation prevents the legacy hardcoded null when a user
+      // is on /scenarios/<id> and exports synchronously.
       ...(() => {
         const partial = reconcileScenarioId({
           storeScenarioId: null,
@@ -2931,13 +2935,22 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     // --- Capture pipeline status (P0.2) + Turn diagnostics (P0.3) ---
     // ALWAYS emit, even when the legacy v5_canonical_analysis block was not
     // assembled (e.g. classifier bailed). When legacy is absent we fall back
-    // to a synthesised "no-legacy-data" diagnostic with honest enum values
-    // so consumers can rely on these fields being present on every export.
+    // to a SYNTHESISED diagnostic that DERIVES real signals from the canvas
+    // store rather than defaulting everything to "unknown". This keeps the
+    // `analysis_fact_present_but_cee_capture_missing` contradiction fire-able
+    // even when the legacy classifier itself failed mid-export.
+    const legacyFromClassifier = bundle.v5_canonical_analysis !== undefined
     const legacy: V5CanonicalAnalysisDiagnostic =
       bundle.v5_canonical_analysis ?? {
         v5_cee_capture: null,
         analysis_state_source: sourceResult.source,
-        analysis_fact_status: 'unknown_not_checked',
+        // Derive from real store signals, not 'unknown_not_checked'.
+        // The canvas store already tells us whether a fact attaches to
+        // the current scenario; that fact-presence drives the headline
+        // contradiction issue and must not be lost.
+        analysis_fact_status: sourceResult.factPresentForScenario
+          ? 'present'
+          : 'missing',
         debug_capture_status: 'cee_capture_missing',
         canonical_flag_on: isV5CanonicalAnalysisEnabled(),
       }
@@ -2989,9 +3002,11 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
 
     const base = assembleV5CanonicalTurnDiagnostics({
       legacyDiagnostic: legacy,
+      legacyDiagnosticFromClassifier: legacyFromClassifier,
       flagDiagnostic,
       analysisStateSource: legacy.analysis_state_source,
       hasResultsReport: sourceResult.hasResultsReport,
+      effectiveCeeResponseSource: bundle.effective_cee_response_source ?? null,
       graphHashAtGeneration: graphHash,
       optionCount,
       factorSensitivityCount,

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -40,7 +40,42 @@ import {
   type V5CanonicalAnalysisDiagnostic,
   type V5CeeCapture,
 } from '../../../lib/v5CanonicalAnalysisDiagnostics'
-import { isV5CanonicalAnalysisEnabled } from '../../../flags'
+import {
+  extractScenarioIdFromFullGraph,
+  extractScenarioIdFromLatestV5Payload,
+  extractScenarioIdFromUrl,
+  reconcileScenarioId,
+  type ScenarioIdReconciliation,
+  type ScenarioIdSource,
+} from '../../../lib/scenarioIdReconciliation'
+import {
+  classifyV5CapturePipelineStatus,
+  detectFailedHttpRecord,
+  type CapturePipelineStatus,
+} from '../../../lib/v5CapturePipelineStatus'
+import {
+  assembleV5CanonicalTurnDiagnostics,
+  attachAnalysisFactDetails,
+  extractFactorSensitivityCountFromPlotResponse,
+  extractOptionCountFromPlotResponse,
+  type V5CanonicalTurnDiagnostics,
+} from '../../../lib/v5CanonicalTurnDiagnostics'
+import {
+  diagnoseV5CanonicalAnalysis,
+  isV5CanonicalAnalysisEnabled,
+} from '../../../flags'
+import {
+  buildDebugBundleEventFields,
+  emitDebugBundleEvent,
+} from '../../../lib/debugBundleLogger'
+import {
+  buildDebugRedactionManifest,
+  type DebugRedactionManifest,
+} from '../../../lib/debugRedactionManifest'
+import {
+  runScientificValidation,
+  type ScientificValidation,
+} from '../../../lib/scientificValidation'
 import {
   ADDITIVE_EXTENSIONS_KEY,
   ORIGINAL_TOP_LEVEL_KEYS_KEY,
@@ -1049,6 +1084,57 @@ interface DebugBundle {
    */
   v5_canonical_analysis?: V5CanonicalAnalysisDiagnostic
 
+  /**
+   * Scenario-ID reconciliation snapshot. Populated by
+   * buildDebugBundleAsync. Mirrors `session.scenario_id` /
+   * `session.scenario_id_source` but additionally records the full
+   * candidate map and any disagreement between sources. Absent on the
+   * sync export path.
+   */
+  scenario_id_reconciliation?: ScenarioIdReconciliation
+
+  /**
+   * Honest capture-pipeline status. Sits ALONGSIDE the legacy
+   * `pipeline.v5_pipeline_status` (untouched) and replaces the
+   * overused `proxy_or_network_failure` label with a coherent reading
+   * that distinguishes missing capture / hydrated-only results /
+   * actual network failure. Populated by buildDebugBundleAsync.
+   */
+  capture_pipeline_status?: CapturePipelineStatus
+
+  /**
+   * Richer V5 canonical turn diagnostics. Composes (does not replace)
+   * the legacy `v5_canonical_analysis` block. Surfaces analysis-fact
+   * detail, parse outcome, results metrics, scenario-ID reconciliation,
+   * and coherence issues — all in one place so reviewers can answer
+   * the brief's eleven goal questions from a single section.
+   * Populated by buildDebugBundleAsync.
+   */
+  v5_canonical_turn_diagnostics?: V5CanonicalTurnDiagnostics
+
+  /**
+   * Redaction manifest — surfaces every path under `payloads.*` that
+   * was redacted (sensitive_key / max_depth / array_capped / size_limit
+   * / circular_reference) and lists the declarative
+   * `preserved_analytical_paths` policy. Always emitted by
+   * buildDebugBundleAsync.
+   */
+  debug_redaction_manifest?: DebugRedactionManifest
+
+  /**
+   * Scientific validation section — seven validators covering PR
+   * #166–#170 surfaces (evidence-gap intervention exclusion, confidence
+   * provenance, user-std propagation, EVPI honesty, flip_thresholds_status,
+   * auto_noise agreement, response shape).
+   *
+   * Every validator emits `status` + `claim_strength`
+   * (observed/derived/inferred/unavailable). `inferred` never pairs
+   * with `pass`. Overall_status is `insufficient_raw_evidence` when
+   * fewer than three validators reach derived/observed evidence —
+   * intentional honesty, NOT a bug.
+   */
+  scientific_validation?: ScientificValidation
+
   // Enhancement sections (Debug Panel V2.1)
 
   /** Orchestrator status from CEE pipeline */
@@ -1089,7 +1175,16 @@ interface DebugBundle {
       environment: string
     }
     feature_flags: Record<string, unknown> | null
-    scenario_id: null
+    /**
+     * Reconciled scenario ID. Populated by buildDebugBundleAsync via
+     * `reconcileScenarioId` (preference: store > v5_fact > payload > url
+     * > full_graph). Sync export path keeps this null — only the async
+     * export resolves the canvas store and payload trace.
+     */
+    scenario_id: string | null
+    /** Which source the reconciled scenario_id came from. 'none' when no
+     *  candidate had a value (also the sync-path default). */
+    scenario_id_source: ScenarioIdSource
     current_route: null
     session_id: null
     session_started_at: null
@@ -2429,7 +2524,10 @@ export function buildDebugBundle(data: DebugData, options: ExportOptions = {}): 
         environment: getEnvironment(),
       },
       feature_flags: (featureFlagsAtRequest as Record<string, unknown> | null) ?? null,
+      // Sync path cannot resolve store/payload sources; async export
+      // overwrites these two fields via reconcileScenarioId.
       scenario_id: null,
+      scenario_id_source: 'none' as ScenarioIdSource,
       current_route: null,
       session_id: null,
       session_started_at: null,
@@ -2783,22 +2881,275 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     // errors. The absence of v5_canonical_analysis itself is a signal.
   }
 
+  // Scenario-ID reconciliation + capture pipeline status + canonical
+  // turn diagnostics. All three live in one try block because they
+  // share inputs (canvas store + payload-trace). Each section is
+  // additive — failure to assemble one does not block the rest.
+  try {
+    const { useCanvasStore } = await import('../../../canvas/store')
+    const { usePayloadTraceStore } = await import('../../../lib/payload-trace-store')
+    const { readAnalysisStateSourceFromStore } = await import(
+      '../../../canvas/hooks/useAnalysisStateSource'
+    )
+    const storeState = useCanvasStore.getState()
+    const traceState = usePayloadTraceStore.getState()
+    const fact = storeState.v5AnalysisFact
+    const sourceResult = readAnalysisStateSourceFromStore()
+
+    // --- Scenario ID reconciliation (P0.1) ---
+    const reconciliation = reconcileScenarioId({
+      storeScenarioId: storeState.currentScenarioId ?? null,
+      v5FactScenarioId: fact?.scenarioId ?? null,
+      payloadScenarioId: extractScenarioIdFromLatestV5Payload(traceState.payloads),
+      urlScenarioId:
+        typeof window !== 'undefined' && window.location
+          ? extractScenarioIdFromUrl(window.location.href)
+          : null,
+      fullGraphScenarioId: extractScenarioIdFromFullGraph(bundle.full_graph),
+    })
+    bundle.session.scenario_id = reconciliation.selected_scenario_id
+    bundle.session.scenario_id_source = reconciliation.selected_source
+    bundle.scenario_id_reconciliation = reconciliation
+
+    // --- Capture pipeline status (P0.2) ---
+    // Only emit when the legacy v5_canonical_analysis block was assembled —
+    // it carries the canonical v5_cee_capture summary we need. Without it,
+    // we cannot honestly classify capture state.
+    const legacy = bundle.v5_canonical_analysis
+    if (legacy) {
+      const failedHttp = detectFailedHttpRecord(traceState.payloads)
+      const rawV2Present = storeState.results?.rawV2Response != null
+      const capturePipeline = classifyV5CapturePipelineStatus({
+        v5Capture: legacy.v5_cee_capture
+          ? {
+              request_present: legacy.v5_cee_capture.request_present,
+              response_present: legacy.v5_cee_capture.response_present,
+              parse_ok: legacy.v5_cee_capture.parse_ok,
+              raw_response_present: legacy.v5_cee_capture.raw_response_present,
+            }
+          : null,
+        hasResultsReport: sourceResult.hasResultsReport,
+        rawV2ResponsePresent: rawV2Present,
+        failedHttpRecord: failedHttp,
+        analysisStateSource: legacy.analysis_state_source,
+        effectiveCeeResponseSource: bundle.effective_cee_response_source ?? null,
+        analysisFactPresent: legacy.analysis_fact_status === 'present',
+        scenarioIdConflictCount: reconciliation.conflicts.length,
+        legacyPipelineStatus: bundle.pipeline.v5_pipeline_status ?? null,
+      })
+      bundle.capture_pipeline_status = capturePipeline.capture_pipeline_status
+
+      // --- V5 canonical turn diagnostics (P0.3) ---
+      // graph_hash_at_generation: read-through. The v5AnalysisFact slice
+      // may not carry this field on every code path; emit null when
+      // absent rather than fabricating from elsewhere.
+      const graphHash =
+        fact && typeof (fact as Record<string, unknown>).graphHashAtGeneration === 'string'
+          ? ((fact as Record<string, unknown>).graphHashAtGeneration as string)
+          : null
+
+      // Flag diagnostic — guard against environments without
+      // localStorage (e.g. SSR / jsdom edge cases).
+      const flagDiagnostic = (() => {
+        try {
+          return diagnoseV5CanonicalAnalysis()
+        } catch {
+          return null
+        }
+      })()
+
+      const optionCount = extractOptionCountFromPlotResponse(bundle.payloads.plot_response)
+      const factorSensitivityCount = extractFactorSensitivityCountFromPlotResponse(
+        bundle.payloads.plot_response,
+      )
+
+      const base = assembleV5CanonicalTurnDiagnostics({
+        legacyDiagnostic: legacy,
+        flagDiagnostic,
+        analysisStateSource: legacy.analysis_state_source,
+        hasResultsReport: sourceResult.hasResultsReport,
+        graphHashAtGeneration: graphHash,
+        optionCount,
+        factorSensitivityCount,
+        capturePipeline,
+        scenarioIdReconciliation: reconciliation,
+      })
+
+      bundle.v5_canonical_turn_diagnostics = attachAnalysisFactDetails(
+        base,
+        fact
+          ? {
+              hasRunAnalysisFact: fact.hasRunAnalysisFact,
+              freshness: fact.freshness,
+            }
+          : null,
+      )
+    }
+
+    // --- Scientific validation (P1) ---
+    // Always runs (even when capture_pipeline_status is missing) — the
+    // orchestrator falls back to `source: unavailable` honestly.
+    bundle.scientific_validation = runScientificValidation({
+      plotRequest: bundle.payloads.plot_request,
+      plotResponse: bundle.payloads.plot_response,
+      ceeRequest: bundle.payloads.cee_request,
+      ceeResponse: bundle.payloads.cee_response,
+      islRequest: bundle.payloads.isl_request,
+      islResponse: bundle.payloads.isl_response,
+      resultsReport: storeState.results?.report ?? null,
+      ceeAnalysisReady: storeState.ceeAnalysisReady ?? null,
+      capturePipelineStatus: bundle.capture_pipeline_status ?? null,
+    })
+  } catch {
+    // All four sections are additive — keep partial state on failure.
+    // Absence of the top-level fields IS the signal.
+  }
+
+  // --- Redaction manifest (P0.5) ---
+  // Always emit, even when prior sections bailed — the manifest is the
+  // safety surface for "what did we suppress and why" and must remain
+  // available regardless of upstream assembly outcomes.
+  try {
+    bundle.debug_redaction_manifest = buildDebugRedactionManifest(bundle, [
+      {
+        path: 'v5_canonical_analysis',
+        present: bundle.v5_canonical_analysis !== undefined,
+        reason_if_omitted: 'legacy_classifier_bailed_or_disabled',
+      },
+      {
+        path: 'capture_pipeline_status',
+        present: bundle.capture_pipeline_status !== undefined,
+        reason_if_omitted: 'capture_pipeline_classifier_bailed_or_legacy_missing',
+      },
+      {
+        path: 'v5_canonical_turn_diagnostics',
+        present: bundle.v5_canonical_turn_diagnostics !== undefined,
+        reason_if_omitted: 'turn_diagnostics_assembler_bailed_or_legacy_missing',
+      },
+      {
+        path: 'scenario_id_reconciliation',
+        present: bundle.scenario_id_reconciliation !== undefined,
+        reason_if_omitted: 'reconciliation_bailed',
+      },
+      {
+        path: 'scientific_validation',
+        present: bundle.scientific_validation !== undefined,
+        reason_if_omitted: 'validators_bailed',
+      },
+    ])
+  } catch {
+    // Manifest is purely descriptive — never block export on its
+    // absence. Reviewers should treat a missing manifest as a signal
+    // that the manifest assembler itself errored.
+  }
+
   return bundle
+}
+
+/**
+ * Generate an opaque export identifier for render-log correlation.
+ * Distinct from request_id so support can grep for "this export" in the
+ * absence of a per-turn request id (e.g. on hydrated bundles).
+ */
+function makeExportId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `exp-${crypto.randomUUID()}`
+    }
+  } catch {
+    // fall through
+  }
+  return `exp-${Date.now().toString(16)}-${Math.floor(Math.random() * 1e9).toString(16)}`
 }
 
 /**
  * Export all debug data as a single JSON bundle file (async).
  * Captures display_state, panel_state, and orchestrator context from stores.
  *
+ * Emits four structured render-log events for diagnostic observability
+ * (see debugBundleLogger.ts):
+ *   1. dgai.debug_bundle.export_started — at entry
+ *   2. dgai.debug_bundle.capture_status — after capture-pipeline assembly
+ *   3. dgai.debug_bundle.scientific_validation_summary — after validators
+ *   4. dgai.debug_bundle.export_completed — just before download
+ *
  * Filename format: olumi-debug-{short_request_id}-{date}.json
  */
 export async function exportDebugBundleAsync(data: DebugData, options: ExportOptions = {}): Promise<void> {
-  const bundle = await buildDebugBundleAsync(data, options)
-  const json = JSON.stringify(bundle, null, 2)
+  const exportId = makeExportId()
+  emitDebugBundleEvent(
+    'dgai.debug_bundle.export_started',
+    buildDebugBundleEventFields({ export_id: exportId }),
+  )
 
+  const bundle = await buildDebugBundleAsync(data, options)
+
+  // Structural fields drawn from the assembled bundle — no raw payloads.
+  const turn = bundle.v5_canonical_turn_diagnostics
+  emitDebugBundleEvent(
+    'dgai.debug_bundle.capture_status',
+    buildDebugBundleEventFields({
+      export_id: exportId,
+      scenario_id_source: bundle.session.scenario_id_source ?? null,
+      capture_pipeline_status: bundle.capture_pipeline_status ?? null,
+      coherence_state: turn?.coherence.state ?? null,
+      coherence_issue_count: turn ? turn.coherence.issues.length : null,
+      canonical_flag_on: turn?.canonical_flag_on ?? null,
+      has_v5_capture: turn ? turn.latest_v5_turn.request_present : null,
+      parse_ok: turn?.parse.parse_ok ?? null,
+      has_results: turn?.results.present ?? null,
+    }),
+  )
+
+  // Scientific validation summary — counts derived from the validator map.
+  const sv = bundle.scientific_validation ?? null
+  const validatorEntries = sv ? Object.values(sv.validators) : []
+  const availableCount = validatorEntries.filter(
+    (v) => v.claim_strength === 'observed' || v.claim_strength === 'derived',
+  ).length
+  const unavailableCount = validatorEntries.filter(
+    (v) => v.claim_strength === 'unavailable',
+  ).length
+  emitDebugBundleEvent(
+    'dgai.debug_bundle.scientific_validation_summary',
+    buildDebugBundleEventFields({
+      export_id: exportId,
+      scientific_validation_available_count: sv ? availableCount : null,
+      scientific_validation_unavailable_count: sv ? unavailableCount : null,
+    }),
+  )
+
+  const json = JSON.stringify(bundle, null, 2)
   const shortId = data.overall.request_id?.slice(0, 8) ?? 'unknown'
   const date = formatShortTimestamp().slice(0, 8) // YYYYMMDD
   const filename = `olumi-debug-${shortId}-${date}.json`
+
+  // Count omitted sections — these are top-level keys that ended up
+  // `undefined` or unassembled on this export (e.g. v5_canonical_turn_diagnostics
+  // bailed). Treat null as present; undefined as omitted.
+  const omittedCount = (() => {
+    const optionalKeys: Array<keyof typeof bundle> = [
+      'v5_canonical_analysis',
+      'capture_pipeline_status',
+      'v5_canonical_turn_diagnostics',
+      'scenario_id_reconciliation',
+      'scientific_validation',
+      'debug_redaction_manifest',
+    ]
+    return optionalKeys.reduce(
+      (n, k) => (bundle[k] === undefined ? n + 1 : n),
+      0,
+    )
+  })()
+
+  emitDebugBundleEvent(
+    'dgai.debug_bundle.export_completed',
+    buildDebugBundleEventFields({
+      export_id: exportId,
+      bundle_size_bytes: json.length,
+      omitted_sections_count: omittedCount,
+    }),
+  )
 
   downloadFile(json, filename)
 }

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -51,6 +51,7 @@ import {
 import {
   classifyV5CapturePipelineStatus,
   detectFailedHttpRecord,
+  findLatestV5TurnEntry,
   type CapturePipelineStatus,
 } from '../../../lib/v5CapturePipelineStatus'
 import {
@@ -2862,15 +2863,28 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       return false
     })()
 
+    // Look up the actual V5 turn entry in the payload-trace store so
+    // capture-level fields (request_id, endpoint, duration_ms) reflect
+    // the real call rather than coarse session-level values.
+    const v5TraceStore = await import('../../../lib/payload-trace-store')
+    const v5TraceState = v5TraceStore.usePayloadTraceStore.getState()
+    const latestV5Trace = findLatestV5TurnEntry(v5TraceState.payloads)
+
     const v5Capture: V5CeeCapture | null =
       requestPresent || responsePresent || ceeService
         ? {
-            request_id: data.overall.request_id,
+            // Prefer the actual trace entry id when available; fall back
+            // to the session-level request_id (the legacy behaviour).
+            request_id: latestV5Trace?.id ?? data.overall.request_id,
             scenario_id: storeState.currentScenarioId,
             turn_id: fact?.analysisHash ?? null,
-            endpoint: null,
-            status: ceeService?.status ?? null,
-            duration_ms: ceeService?.duration_ms ?? null,
+            // Real endpoint from the trace entry > service-metadata
+            // endpoint > null. Required for log correlation.
+            endpoint:
+              latestV5Trace?.endpoint ?? ceeService?.endpoint ?? null,
+            status: latestV5Trace?.status ?? ceeService?.status ?? null,
+            duration_ms:
+              latestV5Trace?.duration ?? ceeService?.duration_ms ?? null,
             request_present: requestPresent,
             response_present: responsePresent,
             parse_ok: parseOk,
@@ -2882,6 +2896,11 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
             has_additive_extensions: hasAdditiveExtensions,
             phase3_blocks_tolerated_count: phase3Source.length,
             phase3_block_types: phase3BlockTypes,
+            // Legacy `source: 'proxy_v5_turn'` literal kept for
+            // backward-compat with existing consumers. The richer
+            // provenance enum lives on the new
+            // `v5_canonical_turn_diagnostics.latest_v5_turn.source`
+            // field per the brief.
             source: 'proxy_v5_turn',
           }
         : null
@@ -2957,6 +2976,25 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
 
     const failedHttp = detectFailedHttpRecord(traceState.payloads)
     const rawV2Present = storeState.results?.rawV2Response != null
+
+    // Service-metadata-only failure: V5 endpoint reports failure in
+    // data.services.cee but the payload-trace has no entry for it.
+    // Reviewers need to distinguish this from `hydrated_only`.
+    const ceeService = data.services.cee ?? null
+    const ceeServiceEndpoint =
+      typeof ceeService?.endpoint === 'string' ? ceeService.endpoint : ''
+    const ceeServiceIsV5 = ceeServiceEndpoint.includes('/orchestrate/v2/turn')
+    const ceeServiceFailed =
+      ceeService !== null &&
+      (ceeService.success === false ||
+        (typeof ceeService.status === 'number' &&
+          (ceeService.status >= 500 || ceeService.status === 0)))
+    const serviceMetadataV5Failure =
+      ceeServiceIsV5 && ceeServiceFailed && !failedHttp.present
+
+    const latestV5Trace = findLatestV5TurnEntry(traceState.payloads)
+    const v5TraceEntryPresent = latestV5Trace !== null
+
     const capturePipeline = classifyV5CapturePipelineStatus({
       v5Capture: legacy.v5_cee_capture
         ? {
@@ -2969,6 +3007,7 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       hasResultsReport: sourceResult.hasResultsReport,
       rawV2ResponsePresent: rawV2Present,
       failedHttpRecord: failedHttp,
+      serviceMetadataV5Failure,
       analysisStateSource: legacy.analysis_state_source,
       effectiveCeeResponseSource: bundle.effective_cee_response_source ?? null,
       analysisFactPresent: legacy.analysis_fact_status === 'present',
@@ -3000,6 +3039,21 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       bundle.payloads.plot_response,
     )
 
+    // Rendered counts from bundle.display_state when present. Counts
+    // are honest (length of the rendered arrays) and `null` when the
+    // display state itself is absent — never fabricated.
+    const displayState = bundle.display_state as
+      | { rendered_options?: unknown; rendered_factors?: unknown }
+      | null
+    const renderedOptionCount =
+      displayState && Array.isArray(displayState.rendered_options)
+        ? displayState.rendered_options.length
+        : null
+    const renderedFactorCount =
+      displayState && Array.isArray(displayState.rendered_factors)
+        ? displayState.rendered_factors.length
+        : null
+
     const base = assembleV5CanonicalTurnDiagnostics({
       legacyDiagnostic: legacy,
       legacyDiagnosticFromClassifier: legacyFromClassifier,
@@ -3010,6 +3064,10 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       graphHashAtGeneration: graphHash,
       optionCount,
       factorSensitivityCount,
+      v5TraceEntryPresent,
+      ceeServiceV5EndpointPresent: ceeServiceIsV5,
+      renderedOptionCount,
+      renderedFactorCount,
       capturePipeline,
       scenarioIdReconciliation: reconciliation,
     })

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -57,8 +57,10 @@ import {
 import {
   assembleV5CanonicalTurnDiagnostics,
   attachAnalysisFactDetails,
+  determineCaptureTier,
   extractFactorSensitivityCountFromPlotResponse,
   extractOptionCountFromPlotResponse,
+  type LatestV5TurnSource,
   type V5CanonicalTurnDiagnostics,
 } from '../../../lib/v5CanonicalTurnDiagnostics'
 import {
@@ -2775,7 +2777,8 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     const ceeService = data.services.cee ?? null
     const requestPresent = ceeRequest !== null && ceeRequest !== undefined
     const responsePresent = ceeResponse !== null && ceeResponse !== undefined
-    const parseOk = responsePresent && !ceeIsParseErrorEnvelope
+    // (parseOk is now derived from the canonical-source tier below
+    // — see `parseOkLegacy` near the V5CeeCapture assembly.)
 
     const parseError = ceeIsParseErrorEnvelope
       ? (() => {
@@ -2864,30 +2867,89 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     })()
 
     // Look up the actual V5 turn entry in the payload-trace store so
-    // capture-level fields (request_id, endpoint, duration_ms) reflect
-    // the real call rather than coarse session-level values.
+    // capture-level fields (request_id, endpoint, duration_ms,
+    // request_present, response_present) reflect the real call rather
+    // than coarse session-level values.
     const v5TraceStore = await import('../../../lib/payload-trace-store')
     const v5TraceState = v5TraceStore.usePayloadTraceStore.getState()
     const latestV5Trace = findLatestV5TurnEntry(v5TraceState.payloads)
+    const latestV5TraceTyped = latestV5Trace as
+      | {
+          id?: string
+          endpoint?: string
+          status?: number
+          duration?: number
+          completed?: boolean
+          request?: { body?: unknown } | undefined
+          response?: { body?: unknown } | undefined
+        }
+      | null
+
+    // Single canonical source for capture assembly. Once a tier is
+    // selected, ALL related fields derive from that same source to
+    // avoid mixed-provenance bundles. The helper is shared with the
+    // second try block (turn diagnostics) so the two views never
+    // disagree about where the capture data came from.
+    const captureTier: LatestV5TurnSource = determineCaptureTier({
+      traceEntryPresent: latestV5TraceTyped !== null,
+      bundlePayloadsCeeRequestPresent: requestPresent,
+      bundlePayloadsCeeResponsePresent: responsePresent,
+      serviceMetadataV5EndpointPresent:
+        ceeService !== null &&
+        typeof ceeService.endpoint === 'string' &&
+        ceeService.endpoint.includes('/orchestrate/v2/turn'),
+      // First try block doesn't read `factPresentForScenario` here.
+      // 'store' tier is meaningless for V5CeeCapture assembly (the
+      // capture object requires evidence); only the snapshot uses
+      // 'store' when capture is absent but a fact exists.
+      factPresentForScenario: false,
+    })
+
+    // Derive request_present / response_present from the SAME tier as
+    // the rest of the capture metadata. Trace-tier reads from the
+    // trace entry; bundle-payloads tier reads from bundle.payloads;
+    // service-metadata + none tiers have no body evidence.
+    const tierRequestPresent =
+      captureTier === 'payload_trace'
+        ? latestV5TraceTyped?.request !== undefined
+        : captureTier === 'bundle_payloads'
+          ? requestPresent
+          : false
+    const tierResponsePresent =
+      captureTier === 'payload_trace'
+        ? latestV5TraceTyped?.response !== undefined ||
+          latestV5TraceTyped?.completed === true ||
+          typeof latestV5TraceTyped?.status === 'number'
+        : captureTier === 'bundle_payloads'
+          ? responsePresent
+          : false
+
+    // parse_ok semantics: only meaningful when a response body was
+    // actually parsed. Without a response there's nothing to parse —
+    // emit `false` here in the legacy V5CeeCapture (existing contract)
+    // but the new snapshot will overlay `null` when response_present
+    // is false to be honest about evidence absence.
+    const parseOkLegacy = tierResponsePresent && !ceeIsParseErrorEnvelope
 
     const v5Capture: V5CeeCapture | null =
-      requestPresent || responsePresent || ceeService
-        ? {
+      captureTier === 'none'
+        ? null
+        : {
             // Prefer the actual trace entry id when available; fall back
             // to the session-level request_id (the legacy behaviour).
-            request_id: latestV5Trace?.id ?? data.overall.request_id,
+            request_id: latestV5TraceTyped?.id ?? data.overall.request_id,
             scenario_id: storeState.currentScenarioId,
             turn_id: fact?.analysisHash ?? null,
             // Real endpoint from the trace entry > service-metadata
             // endpoint > null. Required for log correlation.
             endpoint:
-              latestV5Trace?.endpoint ?? ceeService?.endpoint ?? null,
-            status: latestV5Trace?.status ?? ceeService?.status ?? null,
+              latestV5TraceTyped?.endpoint ?? ceeService?.endpoint ?? null,
+            status: latestV5TraceTyped?.status ?? ceeService?.status ?? null,
             duration_ms:
-              latestV5Trace?.duration ?? ceeService?.duration_ms ?? null,
-            request_present: requestPresent,
-            response_present: responsePresent,
-            parse_ok: parseOk,
+              latestV5TraceTyped?.duration ?? ceeService?.duration_ms ?? null,
+            request_present: tierRequestPresent,
+            response_present: tierResponsePresent,
+            parse_ok: parseOkLegacy,
             parse_error: parseError,
             response_top_level_keys: responseTopLevelKeys,
             raw_response_present: rawResponsePresent,
@@ -2903,7 +2965,6 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
             // field per the brief.
             source: 'proxy_v5_turn',
           }
-        : null
 
     const plotRequestCaptured = bundle.payloads.plot_request !== null
 
@@ -2995,6 +3056,20 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     const latestV5Trace = findLatestV5TurnEntry(traceState.payloads)
     const v5TraceEntryPresent = latestV5Trace !== null
 
+    // Re-compute the canonical capture tier in this try block too —
+    // the first try block (legacy assembly) might have bailed, but
+    // this block must still pick a tier consistent with the rest of
+    // the bundle. Inputs are deterministic from traceState + bundle
+    // payloads + data.services + canvas store; the helper guarantees
+    // we never disagree.
+    const snapshotCaptureTier = determineCaptureTier({
+      traceEntryPresent: v5TraceEntryPresent,
+      bundlePayloadsCeeRequestPresent: bundle.payloads.cee_request !== null,
+      bundlePayloadsCeeResponsePresent: bundle.payloads.cee_response !== null,
+      serviceMetadataV5EndpointPresent: ceeServiceIsV5,
+      factPresentForScenario: sourceResult.factPresentForScenario,
+    })
+
     const capturePipeline = classifyV5CapturePipelineStatus({
       v5Capture: legacy.v5_cee_capture
         ? {
@@ -3064,8 +3139,7 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       graphHashAtGeneration: graphHash,
       optionCount,
       factorSensitivityCount,
-      v5TraceEntryPresent,
-      ceeServiceV5EndpointPresent: ceeServiceIsV5,
+      captureTier: snapshotCaptureTier,
       renderedOptionCount,
       renderedFactorCount,
       capturePipeline,

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -462,6 +462,8 @@ export const isAnalysisHeroV17Enabled = flags.analysisHeroV17
 export const isAnalysisHeroCompareEnabled = flags.analysisHeroCompare
 export const isAiPanelV2Enabled = flags.aiPanelV2
 export const isV5CanonicalAnalysisEnabled = flags.v5CanonicalAnalysis
+export const diagnoseV5CanonicalAnalysis = () =>
+  diagnoseFlagState(FLAGS_CONFIG.v5CanonicalAnalysis)
 
 
 // ============================================================================

--- a/src/lib/__tests__/debugBundleLogger.spec.ts
+++ b/src/lib/__tests__/debugBundleLogger.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for debugBundleLogger — the structured render-log events emitted
+ * around debug-bundle export. Verifies the privacy guard:
+ *   - Allowlisted fields only.
+ *   - Known sensitive patterns (JWT, Bearer, key=value, email) scrubbed
+ *     to '[REDACTED]'.
+ *   - Missing fields emit as null, never as undefined or stripped.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('../logger', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import {
+  ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS,
+  buildDebugBundleEventFields,
+  emitDebugBundleEvent,
+} from '../debugBundleLogger'
+import { logger } from '../logger'
+
+describe('emitDebugBundleEvent — shape and allowlist', () => {
+  beforeEach(() => {
+    ;(logger.info as ReturnType<typeof vi.fn>).mockClear()
+  })
+
+  it('emits the event name in the payload', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.export_started',
+      buildDebugBundleEventFields({ export_id: 'exp-1' }),
+    )
+    expect(payload.event).toBe('dgai.debug_bundle.export_started')
+  })
+
+  it('emits every allowed field — missing keys default to null', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.export_completed',
+      buildDebugBundleEventFields({ export_id: 'exp-2' }),
+    )
+    for (const key of ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS) {
+      expect(payload).toHaveProperty(key)
+    }
+    expect(payload.coherence_issue_count).toBeNull()
+    expect(payload.scientific_validation_unavailable_count).toBeNull()
+  })
+
+  it('payload contains exactly the allowed keys + event', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.capture_status',
+      buildDebugBundleEventFields({}),
+    )
+    const expectedKeys = new Set<string>([...ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS, 'event'])
+    for (const key of Object.keys(payload)) {
+      expect(expectedKeys.has(key)).toBe(true)
+    }
+  })
+
+  it('logger.info is invoked with the emitted payload', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.scientific_validation_summary',
+      buildDebugBundleEventFields({
+        scientific_validation_available_count: 2,
+        scientific_validation_unavailable_count: 5,
+      }),
+    )
+    expect(logger.info).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledWith(payload)
+  })
+})
+
+describe('emitDebugBundleEvent — privacy guard', () => {
+  beforeEach(() => {
+    ;(logger.info as ReturnType<typeof vi.fn>).mockClear()
+  })
+
+  it('redacts JWT-shaped tokens leaking into string fields', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.export_started',
+      buildDebugBundleEventFields({
+        export_id: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+      }),
+    )
+    expect(payload.export_id).toBe('[REDACTED]')
+  })
+
+  it('redacts Bearer tokens', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.export_started',
+      buildDebugBundleEventFields({
+        export_id: 'Bearer sk-1234567890abcdef',
+      }),
+    )
+    expect(payload.export_id).toBe('[REDACTED]')
+  })
+
+  it('redacts api_key=value and similar patterns', () => {
+    for (const value of [
+      'api_key=abc',
+      'api-key: 123',
+      'token=xyz',
+      'authorization: Bearer x',
+      'password=hunter2',
+    ]) {
+      const payload = emitDebugBundleEvent(
+        'dgai.debug_bundle.export_started',
+        buildDebugBundleEventFields({ export_id: value }),
+      )
+      expect(payload.export_id).toBe('[REDACTED]')
+    }
+  })
+
+  it('redacts email-shaped values', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.export_started',
+      buildDebugBundleEventFields({ export_id: 'paul@example.com' }),
+    )
+    expect(payload.export_id).toBe('[REDACTED]')
+  })
+
+  it('leaves clean values untouched', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.export_started',
+      buildDebugBundleEventFields({
+        export_id: 'exp-abc',
+        scenario_id_source: 'store',
+        capture_pipeline_status: 'complete',
+        coherence_state: 'complete',
+        coherence_issue_count: 0,
+        canonical_flag_on: true,
+      }),
+    )
+    expect(payload.export_id).toBe('exp-abc')
+    expect(payload.scenario_id_source).toBe('store')
+    expect(payload.capture_pipeline_status).toBe('complete')
+    expect(payload.canonical_flag_on).toBe(true)
+    expect(payload.coherence_issue_count).toBe(0)
+  })
+
+  it('numeric and boolean values bypass the scrub', () => {
+    const payload = emitDebugBundleEvent(
+      'dgai.debug_bundle.capture_status',
+      buildDebugBundleEventFields({
+        coherence_issue_count: 3,
+        canonical_flag_on: false,
+        bundle_size_bytes: 12345,
+      }),
+    )
+    expect(payload.coherence_issue_count).toBe(3)
+    expect(payload.canonical_flag_on).toBe(false)
+    expect(payload.bundle_size_bytes).toBe(12345)
+  })
+})
+
+describe('buildDebugBundleEventFields', () => {
+  it('emits every allowlisted field with null defaults', () => {
+    const fields = buildDebugBundleEventFields({})
+    for (const key of ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS) {
+      expect(fields[key]).toBeNull()
+    }
+  })
+
+  it('preserves provided values, defaults others to null', () => {
+    const fields = buildDebugBundleEventFields({
+      export_id: 'x',
+      capture_pipeline_status: 'complete',
+    })
+    expect(fields.export_id).toBe('x')
+    expect(fields.capture_pipeline_status).toBe('complete')
+    expect(fields.scenario_id_source).toBeNull()
+  })
+})

--- a/src/lib/__tests__/debugRedactionManifest.spec.ts
+++ b/src/lib/__tests__/debugRedactionManifest.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for debugRedactionManifest — the section that surfaces every
+ * redacted/omitted path in the bundle and documents the analytical
+ * preservation policy.
+ *
+ * Verifies:
+ *   - analytical numeric fields under approved paths are preserved (not
+ *     surfaced as `redacted` entries — they remain in the bundle).
+ *   - sensitive keys (auth/token) are surfaced as redacted entries.
+ *   - array truncation, max-depth markers, circular references are
+ *     each surfaced with stable reason codes.
+ *   - the preserved_analytical_paths list is emitted verbatim.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildDebugRedactionManifest,
+  collectOmittedSections,
+  collectRedactedPaths,
+  PRESERVED_ANALYTICAL_PATHS,
+} from '../debugRedactionManifest'
+
+describe('collectRedactedPaths', () => {
+  it('emits empty array when nothing is redacted', () => {
+    const out = collectRedactedPaths({
+      foo: 'bar',
+      nested: { value: 0.5, count: 3 },
+    })
+    expect(out).toEqual([])
+  })
+
+  it('emits sensitive_key for [REDACTED] string values', () => {
+    const out = collectRedactedPaths({
+      headers: { authorization: '[REDACTED]', accept: 'application/json' },
+    })
+    expect(out).toContainEqual({
+      path: 'headers.authorization',
+      reason: 'sensitive_key',
+    })
+    // Non-redacted string at sibling path is not emitted
+    expect(out).not.toContainEqual({
+      path: 'headers.accept',
+      reason: expect.anything(),
+    })
+  })
+
+  it('emits string_truncated when the truncation suffix is present', () => {
+    const out = collectRedactedPaths({
+      body: {
+        text: 'lorem ipsum ... [truncated_by: bundle_redaction, 12345 chars total]',
+      },
+    })
+    expect(out).toContainEqual({
+      path: 'body.text',
+      reason: 'string_truncated',
+    })
+  })
+
+  it('emits max_depth_or_unserialisable for { __redacted: true } objects', () => {
+    const out = collectRedactedPaths({
+      deep: { __redacted: true, type: 'object', keys: ['a', 'b'] },
+    })
+    expect(out).toContainEqual({
+      path: 'deep',
+      reason: 'max_depth_or_unserialisable',
+    })
+  })
+
+  it('emits array_capped for { __truncated: true } objects and walks surviving items', () => {
+    const out = collectRedactedPaths({
+      list: {
+        __truncated: true,
+        items: [{ inner: '[REDACTED]' }],
+        totalCount: 100,
+      },
+    })
+    expect(out).toContainEqual({ path: 'list', reason: 'array_capped' })
+    expect(out).toContainEqual({
+      path: 'list[0].inner',
+      reason: 'sensitive_key',
+    })
+  })
+
+  it('emits size_limit for { __sizeLimitExceeded: true } objects', () => {
+    const out = collectRedactedPaths({
+      raw_error: { __sizeLimitExceeded: true, originalSize: 99999 },
+    })
+    expect(out).toContainEqual({ path: 'raw_error', reason: 'size_limit' })
+  })
+
+  it('emits circular_reference for { __circular: true } objects', () => {
+    const out = collectRedactedPaths({
+      cycle: { __circular: true, type: 'object' },
+    })
+    expect(out).toContainEqual({
+      path: 'cycle',
+      reason: 'circular_reference',
+    })
+  })
+
+  it('survives genuine self-reference cycles without overflowing', () => {
+    const root: Record<string, unknown> = { name: 'root' }
+    root.self = root
+    expect(() => collectRedactedPaths(root)).not.toThrow()
+  })
+
+  it('walks nested arrays with [idx] notation', () => {
+    const out = collectRedactedPaths({
+      items: [{ password: '[REDACTED]' }, { name: 'ok' }],
+    })
+    expect(out).toContainEqual({
+      path: 'items[0].password',
+      reason: 'sensitive_key',
+    })
+  })
+})
+
+describe('analytical preservation policy', () => {
+  it('observed_state numeric children are NOT surfaced as redacted (they remain in the bundle)', () => {
+    // The existing redactor allowlists observed_state via neverRedactKeys.
+    // Build a bundle slice where observed_state contains analytical
+    // numeric fields and assert no redaction markers are picked up.
+    const out = collectRedactedPaths({
+      data: {
+        observed_state: {
+          value: 0.42,
+          std: 0.05,
+          baseline: 0.4,
+          unit: 'pp',
+          cap: 1,
+        },
+      },
+    })
+    expect(out).toEqual([])
+  })
+
+  it('edge.data.strength numeric is NOT surfaced as redacted', () => {
+    const out = collectRedactedPaths({
+      payloads: {
+        plot_request: {
+          graph: {
+            edges: [
+              {
+                id: 'e1',
+                data: {
+                  strength: 0.7,
+                  exists_probability: 0.9,
+                  function_params: { intercept: 0.1, slope: 0.4 },
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+    expect(out).toEqual([])
+  })
+
+  it('generic numeric scalar under a non-analytical path is also not redacted (numeric values pass redaction)', () => {
+    // Numerics are passed through by redactPayload regardless of path.
+    // The point of the brief is that they should not be relied upon
+    // BY KEY NAME alone — but path-aware preservation is descriptive
+    // policy. The manifest just surfaces what the redactor produced.
+    const out = collectRedactedPaths({ telemetry: { value: 42, mean: 1.5 } })
+    expect(out).toEqual([])
+  })
+})
+
+describe('collectOmittedSections', () => {
+  it('emits an entry per probe that reports present=false', () => {
+    const out = collectOmittedSections([
+      { path: 'v5_canonical_turn_diagnostics', present: false, reason_if_omitted: 'assembler_bailed' },
+      { path: 'capture_pipeline_status', present: true, reason_if_omitted: 'n/a' },
+      { path: 'scientific_validation', present: false, reason_if_omitted: 'p1_not_built_yet' },
+    ])
+    expect(out).toEqual([
+      { path: 'v5_canonical_turn_diagnostics', reason: 'assembler_bailed' },
+      { path: 'scientific_validation', reason: 'p1_not_built_yet' },
+    ])
+  })
+})
+
+describe('buildDebugRedactionManifest — top-level assembler', () => {
+  it('emits the policy preservation list verbatim', () => {
+    const manifest = buildDebugRedactionManifest({ payloads: {} }, [])
+    expect(manifest.preserved_analytical_paths).toEqual([
+      ...PRESERVED_ANALYTICAL_PATHS,
+    ])
+  })
+
+  it('scopes redacted scan to bundle.payloads.* (not the whole bundle)', () => {
+    const manifest = buildDebugRedactionManifest(
+      {
+        payloads: {
+          cee_request: {
+            headers: { authorization: '[REDACTED]' },
+          },
+        },
+        // Sibling object containing a marker — must NOT appear in the
+        // manifest because the scan is scoped to payloads.
+        meta: {
+          something: { __redacted: true },
+        },
+      },
+      [],
+    )
+    expect(manifest.redacted).toContainEqual({
+      path: 'payloads.cee_request.headers.authorization',
+      reason: 'sensitive_key',
+    })
+    expect(manifest.redacted).not.toContainEqual({
+      path: expect.stringContaining('meta'),
+      reason: expect.anything(),
+    })
+  })
+
+  it('returns empty redacted list when nothing is marked', () => {
+    const manifest = buildDebugRedactionManifest({ payloads: {} }, [])
+    expect(manifest.redacted).toEqual([])
+    expect(manifest.omitted).toEqual([])
+  })
+
+  it('handles non-object bundle root gracefully', () => {
+    expect(buildDebugRedactionManifest(null, [])).toMatchObject({
+      redacted: [],
+      omitted: [],
+    })
+    expect(buildDebugRedactionManifest('string-root', [])).toMatchObject({
+      redacted: [],
+    })
+  })
+})

--- a/src/lib/__tests__/scenarioIdReconciliation.spec.ts
+++ b/src/lib/__tests__/scenarioIdReconciliation.spec.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for scenarioIdReconciliation — the resolver that replaces the
+ * hardcoded `session.scenario_id = null` in exportBundle.ts.
+ *
+ * Covers the brief's required cases:
+ *   - store wins when present
+ *   - fact fallback when store null
+ *   - payload fallback when store + fact null
+ *   - URL fallback when store + fact + payload null
+ *   - full_graph fallback when all live sources null
+ *   - conflict recorded when sources disagree (selected source still respected)
+ *   - selected_scenario_id null only when every source is null
+ *
+ * Plus extractor helpers (payload trace, URL, full_graph).
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractScenarioIdFromFullGraph,
+  extractScenarioIdFromLatestV5Payload,
+  extractScenarioIdFromUrl,
+  reconcileScenarioId,
+} from '../scenarioIdReconciliation'
+
+describe('reconcileScenarioId — preference order', () => {
+  it('store wins when all sources present', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: 'sid-store',
+      v5FactScenarioId: 'sid-fact',
+      payloadScenarioId: 'sid-payload',
+      urlScenarioId: 'sid-url',
+      fullGraphScenarioId: 'sid-graph',
+    })
+    expect(out.selected_scenario_id).toBe('sid-store')
+    expect(out.selected_source).toBe('store')
+  })
+
+  it('v5_fact wins when store is null', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: null,
+      v5FactScenarioId: 'sid-fact',
+      payloadScenarioId: 'sid-payload',
+      urlScenarioId: 'sid-url',
+      fullGraphScenarioId: 'sid-graph',
+    })
+    expect(out.selected_scenario_id).toBe('sid-fact')
+    expect(out.selected_source).toBe('v5_fact')
+  })
+
+  it('payload wins when store + fact null', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: null,
+      v5FactScenarioId: null,
+      payloadScenarioId: 'sid-payload',
+      urlScenarioId: 'sid-url',
+      fullGraphScenarioId: 'sid-graph',
+    })
+    expect(out.selected_scenario_id).toBe('sid-payload')
+    expect(out.selected_source).toBe('payload')
+  })
+
+  it('url wins when store + fact + payload null', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: null,
+      v5FactScenarioId: null,
+      payloadScenarioId: null,
+      urlScenarioId: 'sid-url',
+      fullGraphScenarioId: 'sid-graph',
+    })
+    expect(out.selected_scenario_id).toBe('sid-url')
+    expect(out.selected_source).toBe('url')
+  })
+
+  it('full_graph is the last non-null fallback', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: null,
+      v5FactScenarioId: null,
+      payloadScenarioId: null,
+      urlScenarioId: null,
+      fullGraphScenarioId: 'sid-graph',
+    })
+    expect(out.selected_scenario_id).toBe('sid-graph')
+    expect(out.selected_source).toBe('full_graph')
+  })
+
+  it('selected_scenario_id is null and source is "none" only when every candidate is null', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: null,
+      v5FactScenarioId: null,
+      payloadScenarioId: null,
+      urlScenarioId: null,
+      fullGraphScenarioId: null,
+    })
+    expect(out.selected_scenario_id).toBeNull()
+    expect(out.selected_source).toBe('none')
+    expect(out.conflicts).toEqual([])
+  })
+})
+
+describe('reconcileScenarioId — candidates and conflicts', () => {
+  it('always emits the full candidates map', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: 'A',
+      v5FactScenarioId: null,
+      payloadScenarioId: 'B',
+      urlScenarioId: null,
+      fullGraphScenarioId: 'C',
+    })
+    expect(out.candidates).toEqual({
+      store: 'A',
+      v5_fact: null,
+      payload: 'B',
+      url: null,
+      full_graph: 'C',
+    })
+  })
+
+  it('records a conflict when two non-null candidates disagree', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: 'sid-A',
+      v5FactScenarioId: 'sid-B',
+      payloadScenarioId: null,
+      urlScenarioId: null,
+      fullGraphScenarioId: null,
+    })
+    expect(out.selected_scenario_id).toBe('sid-A')
+    expect(out.selected_source).toBe('store')
+    expect(out.conflicts).toContain('store=sid-A vs v5_fact=sid-B')
+  })
+
+  it('does not emit a conflict when two sources carry the same value', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: 'sid-X',
+      v5FactScenarioId: 'sid-X',
+      payloadScenarioId: 'sid-X',
+      urlScenarioId: null,
+      fullGraphScenarioId: null,
+    })
+    expect(out.conflicts).toEqual([])
+  })
+
+  it('records multiple pairwise conflicts when three sources disagree', () => {
+    const out = reconcileScenarioId({
+      storeScenarioId: 'A',
+      v5FactScenarioId: 'B',
+      payloadScenarioId: 'C',
+      urlScenarioId: null,
+      fullGraphScenarioId: null,
+    })
+    expect(out.conflicts).toEqual([
+      'store=A vs v5_fact=B',
+      'store=A vs payload=C',
+      'v5_fact=B vs payload=C',
+    ])
+  })
+})
+
+describe('extractScenarioIdFromLatestV5Payload', () => {
+  it('returns scenario_id from the first matching V5 payload', () => {
+    const payloads = [
+      {
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        request: { body: { scenario_id: 'sid-latest', kind: 'analysis' } },
+      },
+      {
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        request: { body: { scenario_id: 'sid-older' } },
+      },
+    ]
+    expect(extractScenarioIdFromLatestV5Payload(payloads)).toBe('sid-latest')
+  })
+
+  it('skips non-CEE payloads', () => {
+    const payloads = [
+      {
+        service: 'PLoT',
+        endpoint: '/orchestrate/v2/turn',
+        request: { body: { scenario_id: 'sid-plot' } },
+      },
+      {
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v2/turn',
+        request: { body: { scenario_id: 'sid-cee' } },
+      },
+    ]
+    expect(extractScenarioIdFromLatestV5Payload(payloads)).toBe('sid-cee')
+  })
+
+  it('skips CEE payloads that target a non-V5 endpoint', () => {
+    const payloads = [
+      {
+        service: 'CEE',
+        endpoint: '/bff/orchestrate/v1/turn',
+        request: { body: { scenario_id: 'sid-v1' } },
+      },
+    ]
+    expect(extractScenarioIdFromLatestV5Payload(payloads)).toBeNull()
+  })
+
+  it('returns null when no V5 payload has a scenario_id', () => {
+    expect(extractScenarioIdFromLatestV5Payload([])).toBeNull()
+    expect(
+      extractScenarioIdFromLatestV5Payload([
+        {
+          service: 'CEE',
+          endpoint: '/bff/orchestrate/v2/turn',
+          request: { body: { kind: 'analysis' } },
+        },
+      ]),
+    ).toBeNull()
+  })
+
+  it('handles malformed bodies without throwing', () => {
+    const payloads = [
+      { service: 'CEE', endpoint: '/bff/orchestrate/v2/turn', request: { body: null } },
+      { service: 'CEE', endpoint: '/bff/orchestrate/v2/turn', request: { body: 'string-body' } },
+      { service: 'CEE', endpoint: '/bff/orchestrate/v2/turn', request: { body: [1, 2, 3] } },
+    ]
+    expect(extractScenarioIdFromLatestV5Payload(payloads)).toBeNull()
+  })
+})
+
+describe('extractScenarioIdFromUrl', () => {
+  it('reads ?scenarioId= query param', () => {
+    expect(
+      extractScenarioIdFromUrl('https://app.example.com/decision?scenarioId=abc-123'),
+    ).toBe('abc-123')
+  })
+
+  it('reads ?scenario_id= query param (snake_case fallback)', () => {
+    expect(
+      extractScenarioIdFromUrl('https://app.example.com/decision?scenario_id=abc-123'),
+    ).toBe('abc-123')
+  })
+
+  it('reads /scenarios/<id> path segment', () => {
+    expect(
+      extractScenarioIdFromUrl('https://app.example.com/scenarios/sid-path/results'),
+    ).toBe('sid-path')
+  })
+
+  it('returns null for unrelated URLs', () => {
+    expect(extractScenarioIdFromUrl('https://app.example.com/dashboard')).toBeNull()
+  })
+
+  it('returns null on parse failure', () => {
+    expect(extractScenarioIdFromUrl(null)).toBeNull()
+    expect(extractScenarioIdFromUrl('not a url')).toBeNull()
+  })
+})
+
+describe('extractScenarioIdFromFullGraph', () => {
+  it('reads scenarioId from _meta', () => {
+    expect(
+      extractScenarioIdFromFullGraph({ _meta: { scenarioId: 'sid-meta' } }),
+    ).toBe('sid-meta')
+  })
+
+  it('reads scenario_id from _meta (snake_case)', () => {
+    expect(
+      extractScenarioIdFromFullGraph({ _meta: { scenario_id: 'sid-meta' } }),
+    ).toBe('sid-meta')
+  })
+
+  it('falls back to top-level scenarioId', () => {
+    expect(extractScenarioIdFromFullGraph({ scenarioId: 'sid-top' })).toBe('sid-top')
+  })
+
+  it('returns null when nothing matches', () => {
+    expect(extractScenarioIdFromFullGraph(null)).toBeNull()
+    expect(extractScenarioIdFromFullGraph({})).toBeNull()
+    expect(extractScenarioIdFromFullGraph({ _meta: {} })).toBeNull()
+    expect(extractScenarioIdFromFullGraph('string')).toBeNull()
+    expect(extractScenarioIdFromFullGraph([1, 2, 3])).toBeNull()
+  })
+})

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -71,9 +71,11 @@ function makeReconciliation(): ScenarioIdReconciliation {
 function defaults(): AssembleV5CanonicalTurnDiagnosticsInputs {
   return {
     legacyDiagnostic: makeLegacy(),
+    legacyDiagnosticFromClassifier: true,
     flagDiagnostic: { resolved: true, source: 'env' },
     analysisStateSource: 'cee_v5_run_analysis',
     hasResultsReport: true,
+    effectiveCeeResponseSource: 'direct',
     graphHashAtGeneration: null,
     optionCount: 0,
     factorSensitivityCount: 0,
@@ -105,13 +107,90 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
     expect(out.canonical_flag_source).toBe('unknown')
   })
 
-  it('latest_v5_turn mirrors the legacy capture fields', () => {
-    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+  it('latest_v5_turn mirrors the legacy capture fields (including brief-required request_id, scenario_id, turn_id, endpoint, duration_ms, source)', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          request_id: 'req-1',
+          scenario_id: 'sid-1',
+          turn_id: 'turn-1',
+          endpoint: '/bff/orchestrate/v2/turn',
+          status: 200,
+          duration_ms: 123,
+          source: 'proxy_v5_turn',
+        }),
+      }),
+    })
     expect(out.latest_v5_turn).toEqual({
       request_present: true,
       response_present: true,
+      request_id: 'req-1',
+      scenario_id: 'sid-1',
+      turn_id: 'turn-1',
+      endpoint: '/bff/orchestrate/v2/turn',
       status: 200,
+      duration_ms: 123,
+      source: 'proxy_v5_turn',
     })
+  })
+
+  it('effective_cee_response_source is exposed at top level (mirror of bundle field)', () => {
+    expect(assembleV5CanonicalTurnDiagnostics(defaults()).effective_cee_response_source).toBe('direct')
+    expect(
+      assembleV5CanonicalTurnDiagnostics({
+        ...defaults(),
+        effectiveCeeResponseSource: 'none',
+      }).effective_cee_response_source,
+    ).toBe('none')
+  })
+
+  it('parse.unknown_block_types surfaces from the legacy capture', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          parse_ok: false,
+          parse_failure_kind: 'unknown_block_types',
+          unknown_block_types: ['mystery_block', 'experimental'],
+        }),
+      }),
+    })
+    expect(out.parse.unknown_block_types).toEqual(['mystery_block', 'experimental'])
+  })
+
+  it('analysis_fact.source distinguishes legacy classifier from synthesised fallback', () => {
+    const fromClassifier = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnosticFromClassifier: true,
+      legacyDiagnostic: makeLegacy({ analysis_fact_status: 'present' }),
+    })
+    expect(fromClassifier.analysis_fact.source).toBe('v5_canonical_analysis')
+
+    const fromFallback = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnosticFromClassifier: false,
+      legacyDiagnostic: makeLegacy({ analysis_fact_status: 'present' }),
+    })
+    expect(fromFallback.analysis_fact.source).toBe('source_classifier')
+
+    const noFact = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({ analysis_fact_status: 'missing' }),
+    })
+    expect(noFact.analysis_fact.source).toBe('none')
+  })
+
+  it('feature_flag_diagnostic emits the compact { VITE_V5_CANONICAL_ANALYSIS: { value, source } } shape', () => {
+    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+    expect(out.feature_flag_diagnostic).toEqual({
+      VITE_V5_CANONICAL_ANALYSIS: { value: true, source: 'env' },
+    })
+  })
+
+  it('results.rendered_counts_documented_in points to bundle.display_state (no fabrication)', () => {
+    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+    expect(out.results.rendered_counts_documented_in).toBe('bundle.display_state')
   })
 
   it('emits null fields when legacy capture is null', () => {

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest'
 import {
   assembleV5CanonicalTurnDiagnostics,
   attachAnalysisFactDetails,
+  determineCaptureTier,
   extractFactorSensitivityCountFromPlotResponse,
   extractOptionCountFromPlotResponse,
   type AssembleV5CanonicalTurnDiagnosticsInputs,
@@ -79,8 +80,7 @@ function defaults(): AssembleV5CanonicalTurnDiagnosticsInputs {
     graphHashAtGeneration: null,
     optionCount: 0,
     factorSensitivityCount: 0,
-    v5TraceEntryPresent: false,
-    ceeServiceV5EndpointPresent: false,
+    captureTier: 'bundle_payloads',
     renderedOptionCount: null,
     renderedFactorCount: null,
     capturePipeline: {
@@ -130,57 +130,99 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
       request_present: true,
       response_present: true,
       request_id: 'req-1',
+      // Default captureTier is bundle_payloads → session-level
+      // request_id provenance.
+      request_id_source: 'session',
       scenario_id: 'sid-1',
       turn_id: 'turn-1',
       endpoint: '/bff/orchestrate/v2/turn',
       status: 200,
       duration_ms: 123,
       // Brief's provenance enum: bundle.payloads.cee_* carried the data
-      // (v5TraceEntryPresent: false in defaults).
+      // (default captureTier is 'bundle_payloads').
       source: 'bundle_payloads',
     })
   })
 
-  it('latest_v5_turn.source = "payload_trace" when v5TraceEntryPresent is true', () => {
+  it('latest_v5_turn.source = "payload_trace" when captureTier is payload_trace', () => {
     const out = assembleV5CanonicalTurnDiagnostics({
       ...defaults(),
-      v5TraceEntryPresent: true,
+      captureTier: 'payload_trace',
     })
     expect(out.latest_v5_turn.source).toBe('payload_trace')
+    // request_id_source must also flip to payload_trace.
+    expect(out.latest_v5_turn.request_id_source).toBe('payload_trace')
   })
 
-  it('latest_v5_turn.source = "service_metadata" when only services.cee endpoint matches V5', () => {
+  it('latest_v5_turn.source = "service_metadata" when captureTier is service_metadata', () => {
     const out = assembleV5CanonicalTurnDiagnostics({
       ...defaults(),
       legacyDiagnostic: makeLegacy({
         v5_cee_capture: makeCapture({ request_present: false, response_present: false }),
       }),
-      v5TraceEntryPresent: false,
-      ceeServiceV5EndpointPresent: true,
+      captureTier: 'service_metadata',
     })
     expect(out.latest_v5_turn.source).toBe('service_metadata')
+    expect(out.latest_v5_turn.request_id_source).toBe('session')
   })
 
-  it('latest_v5_turn.source = "store" when no capture but fact is present', () => {
+  it('latest_v5_turn.source = "store" when captureTier is store (no capture, fact present)', () => {
     const out = assembleV5CanonicalTurnDiagnostics({
       ...defaults(),
       legacyDiagnostic: makeLegacy({
         v5_cee_capture: null,
         analysis_fact_status: 'present',
       }),
+      captureTier: 'store',
     })
     expect(out.latest_v5_turn.source).toBe('store')
+    expect(out.latest_v5_turn.request_id_source).toBe('none')
   })
 
-  it('latest_v5_turn.source = "none" when no capture and no fact', () => {
+  it('latest_v5_turn.source = "none" when captureTier is none', () => {
     const out = assembleV5CanonicalTurnDiagnostics({
       ...defaults(),
       legacyDiagnostic: makeLegacy({
         v5_cee_capture: null,
         analysis_fact_status: 'missing',
       }),
+      captureTier: 'none',
     })
     expect(out.latest_v5_turn.source).toBe('none')
+    expect(out.latest_v5_turn.request_id_source).toBe('none')
+  })
+
+  it('parse_ok is null when response_present is false (does NOT conflate "no response" with "parsed and failed")', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          request_present: true,
+          response_present: false,
+          parse_ok: false, // legacy capture would report false, but
+          // the snapshot must overlay null per P0.2
+        }),
+      }),
+    })
+    expect(out.parse.parse_ok).toBeNull()
+    expect(out.diagnostic_source_strength.parse).toBe('unavailable')
+  })
+
+  it('diagnostic_source_strength.parse is "unavailable" for service-metadata-only failures', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      captureTier: 'service_metadata',
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          request_present: false,
+          response_present: false,
+          parse_ok: false,
+        }),
+      }),
+    })
+    expect(out.parse.parse_ok).toBeNull()
+    expect(out.diagnostic_source_strength.parse).toBe('unavailable')
+    expect(out.diagnostic_source_strength.latest_v5_turn).toBe('service_metadata')
   })
 
   it('results.rendered_option_count / rendered_factor_count surface from display_state when provided', () => {
@@ -202,7 +244,7 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
   it('diagnostic_source_strength tracks each block independently', () => {
     const live = assembleV5CanonicalTurnDiagnostics({
       ...defaults(),
-      v5TraceEntryPresent: true,
+      captureTier: 'payload_trace',
       optionCount: 2,
       factorSensitivityCount: 5,
     })
@@ -218,6 +260,7 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
         v5_cee_capture: null,
         analysis_fact_status: 'present',
       }),
+      captureTier: 'store',
       hasResultsReport: true,
       optionCount: 0,
       factorSensitivityCount: 0,
@@ -478,5 +521,76 @@ describe('coherence contradiction surfacing (composition)', () => {
     expect(out.coherence.issues).toContain(
       'analysis_fact_present_but_cee_capture_missing',
     )
+  })
+})
+
+describe('determineCaptureTier — single canonical resolver', () => {
+  it('returns payload_trace when a trace entry exists (highest tier)', () => {
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: true,
+        bundlePayloadsCeeRequestPresent: true,
+        bundlePayloadsCeeResponsePresent: true,
+        serviceMetadataV5EndpointPresent: true,
+        factPresentForScenario: true,
+      }),
+    ).toBe('payload_trace')
+  })
+
+  it('returns bundle_payloads when no trace entry but cee_request OR cee_response is set', () => {
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: false,
+        bundlePayloadsCeeRequestPresent: true,
+        bundlePayloadsCeeResponsePresent: false,
+        serviceMetadataV5EndpointPresent: false,
+        factPresentForScenario: false,
+      }),
+    ).toBe('bundle_payloads')
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: false,
+        bundlePayloadsCeeRequestPresent: false,
+        bundlePayloadsCeeResponsePresent: true,
+        serviceMetadataV5EndpointPresent: false,
+        factPresentForScenario: false,
+      }),
+    ).toBe('bundle_payloads')
+  })
+
+  it('returns service_metadata when only data.services.cee V5 endpoint is present', () => {
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: false,
+        bundlePayloadsCeeRequestPresent: false,
+        bundlePayloadsCeeResponsePresent: false,
+        serviceMetadataV5EndpointPresent: true,
+        factPresentForScenario: false,
+      }),
+    ).toBe('service_metadata')
+  })
+
+  it('returns store when no capture evidence but a fact is present', () => {
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: false,
+        bundlePayloadsCeeRequestPresent: false,
+        bundlePayloadsCeeResponsePresent: false,
+        serviceMetadataV5EndpointPresent: false,
+        factPresentForScenario: true,
+      }),
+    ).toBe('store')
+  })
+
+  it('returns none when there is no evidence at all', () => {
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: false,
+        bundlePayloadsCeeRequestPresent: false,
+        bundlePayloadsCeeResponsePresent: false,
+        serviceMetadataV5EndpointPresent: false,
+        factPresentForScenario: false,
+      }),
+    ).toBe('none')
   })
 })

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -86,6 +86,11 @@ function defaults(): AssembleV5CanonicalTurnDiagnosticsInputs {
 }
 
 describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classifier', () => {
+  it('emits canonical_flag_env_key as the verbatim VITE_V5_CANONICAL_ANALYSIS string', () => {
+    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+    expect(out.canonical_flag_env_key).toBe('VITE_V5_CANONICAL_ANALYSIS')
+  })
+
   it('emits canonical_flag_on, canonical_flag_source from inputs', () => {
     const out = assembleV5CanonicalTurnDiagnostics(defaults())
     expect(out.canonical_flag_on).toBe(true)

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for v5CanonicalTurnDiagnostics — the richer assembler that
+ * composes (not replaces) the legacy classifier. Covers the brief's
+ * required cases plus extractor helpers.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  assembleV5CanonicalTurnDiagnostics,
+  attachAnalysisFactDetails,
+  extractFactorSensitivityCountFromPlotResponse,
+  extractOptionCountFromPlotResponse,
+  type AssembleV5CanonicalTurnDiagnosticsInputs,
+} from '../v5CanonicalTurnDiagnostics'
+import type { V5CanonicalAnalysisDiagnostic, V5CeeCapture } from '../v5CanonicalAnalysisDiagnostics'
+import type { ScenarioIdReconciliation } from '../scenarioIdReconciliation'
+
+function makeCapture(overrides: Partial<V5CeeCapture> = {}): V5CeeCapture {
+  return {
+    request_id: 'req-x',
+    scenario_id: 'sid-1',
+    turn_id: null,
+    endpoint: null,
+    status: 200,
+    duration_ms: 50,
+    request_present: true,
+    response_present: true,
+    parse_ok: true,
+    parse_error: null,
+    response_top_level_keys: ['blocks'],
+    raw_response_present: false,
+    parse_failure_kind: null,
+    unknown_block_types: null,
+    has_additive_extensions: false,
+    phase3_blocks_tolerated_count: 0,
+    phase3_block_types: [],
+    source: 'proxy_v5_turn',
+    ...overrides,
+  }
+}
+
+function makeLegacy(
+  overrides: Partial<V5CanonicalAnalysisDiagnostic> = {},
+): V5CanonicalAnalysisDiagnostic {
+  return {
+    v5_cee_capture: makeCapture(),
+    analysis_state_source: 'cee_v5_run_analysis',
+    analysis_fact_status: 'present',
+    debug_capture_status: 'complete',
+    canonical_flag_on: true,
+    ...overrides,
+  }
+}
+
+function makeReconciliation(): ScenarioIdReconciliation {
+  return {
+    selected_scenario_id: 'sid-1',
+    selected_source: 'store',
+    candidates: {
+      store: 'sid-1',
+      v5_fact: null,
+      payload: null,
+      url: null,
+      full_graph: null,
+    },
+    conflicts: [],
+  }
+}
+
+function defaults(): AssembleV5CanonicalTurnDiagnosticsInputs {
+  return {
+    legacyDiagnostic: makeLegacy(),
+    flagDiagnostic: { resolved: true, source: 'env' },
+    analysisStateSource: 'cee_v5_run_analysis',
+    hasResultsReport: true,
+    graphHashAtGeneration: null,
+    optionCount: 0,
+    factorSensitivityCount: 0,
+    capturePipeline: {
+      capture_pipeline_status: 'complete',
+      coherence: { state: 'complete', issues: [] },
+    },
+    scenarioIdReconciliation: makeReconciliation(),
+  }
+}
+
+describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classifier', () => {
+  it('emits canonical_flag_on, canonical_flag_source from inputs', () => {
+    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+    expect(out.canonical_flag_on).toBe(true)
+    expect(out.canonical_flag_source).toBe('env')
+  })
+
+  it('falls back to canonical_flag_source = "unknown" when flagDiagnostic is null', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      flagDiagnostic: null,
+    })
+    expect(out.canonical_flag_source).toBe('unknown')
+  })
+
+  it('latest_v5_turn mirrors the legacy capture fields', () => {
+    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+    expect(out.latest_v5_turn).toEqual({
+      request_present: true,
+      response_present: true,
+      status: 200,
+    })
+  })
+
+  it('emits null fields when legacy capture is null', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({ v5_cee_capture: null }),
+    })
+    expect(out.latest_v5_turn.request_present).toBe(false)
+    expect(out.parse.parse_ok).toBeNull()
+    expect(out.analysis_fact.phase3_raw_block_count).toBe(0)
+  })
+
+  it('parse details surface from the legacy capture', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          parse_ok: false,
+          parse_error: 'boom',
+          parse_failure_kind: 'schema_mismatch',
+          raw_response_present: true,
+          response_top_level_keys: ['kind', 'reason', 'raw'],
+        }),
+      }),
+    })
+    expect(out.parse.parse_ok).toBe(false)
+    expect(out.parse.parse_error).toBe('boom')
+    expect(out.parse.parse_failure_kind).toBe('schema_mismatch')
+    expect(out.parse.raw_response_present).toBe(true)
+    expect(out.parse.response_top_level_keys).toEqual(['kind', 'reason', 'raw'])
+  })
+
+  it('analysis_fact.present mirrors legacy analysis_fact_status', () => {
+    const present = assembleV5CanonicalTurnDiagnostics(defaults()).analysis_fact.present
+    expect(present).toBe(true)
+
+    const missing = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({ analysis_fact_status: 'missing' }),
+    }).analysis_fact.present
+    expect(missing).toBe(false)
+  })
+
+  it('graph_hash_at_generation is null when input is null (read-through)', () => {
+    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+    expect(out.analysis_fact.graph_hash_at_generation).toBeNull()
+  })
+
+  it('graph_hash_at_generation emits the slice value when present', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      graphHashAtGeneration: 'gh-abc123',
+    })
+    expect(out.analysis_fact.graph_hash_at_generation).toBe('gh-abc123')
+  })
+
+  it('phase3 block counts/types pass through from the capture', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          phase3_blocks_tolerated_count: 3,
+          phase3_block_types: ['coaching', 'evidence', 'review_card'],
+        }),
+      }),
+    })
+    expect(out.analysis_fact.phase3_raw_block_count).toBe(3)
+    expect(out.analysis_fact.phase3_raw_block_types).toEqual([
+      'coaching',
+      'evidence',
+      'review_card',
+    ])
+  })
+
+  it('results.source uses the existing 5-value AnalysisStateSource enum', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      analysisStateSource: 'orphaned_plot_result',
+    })
+    expect(out.results.source).toBe('orphaned_plot_result')
+  })
+
+  it('coherence + capture_pipeline_status come from the capture-pipeline classifier verbatim', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      capturePipeline: {
+        capture_pipeline_status: 'results_rendered_from_store_without_capture',
+        coherence: {
+          state: 'contradictory',
+          issues: ['results_rendered_from_store_without_capture'],
+        },
+      },
+    })
+    expect(out.capture_pipeline_status).toBe('results_rendered_from_store_without_capture')
+    expect(out.coherence.state).toBe('contradictory')
+    expect(out.coherence.issues).toContain('results_rendered_from_store_without_capture')
+  })
+
+  it('scenario_id_reconciliation is exposed verbatim', () => {
+    const recon: ScenarioIdReconciliation = {
+      selected_scenario_id: 'sid-x',
+      selected_source: 'payload',
+      candidates: {
+        store: null,
+        v5_fact: null,
+        payload: 'sid-x',
+        url: null,
+        full_graph: null,
+      },
+      conflicts: [],
+    }
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      scenarioIdReconciliation: recon,
+    })
+    expect(out.scenario_id_reconciliation).toEqual(recon)
+  })
+})
+
+describe('attachAnalysisFactDetails', () => {
+  it('overlays has_run_analysis_fact and freshness when a fact is provided', () => {
+    const base = assembleV5CanonicalTurnDiagnostics(defaults())
+    const withFact = attachAnalysisFactDetails(base, {
+      hasRunAnalysisFact: true,
+      freshness: 'fresh',
+    })
+    expect(withFact.analysis_fact.has_run_analysis_fact).toBe(true)
+    expect(withFact.analysis_fact.freshness).toBe('fresh')
+    // Other fields preserved
+    expect(withFact.analysis_fact.scenario_id).toBe(base.analysis_fact.scenario_id)
+  })
+
+  it('is a no-op when fact is null', () => {
+    const base = assembleV5CanonicalTurnDiagnostics(defaults())
+    const out = attachAnalysisFactDetails(base, null)
+    expect(out).toBe(base)
+  })
+})
+
+describe('option / factor_sensitivity extractors', () => {
+  it('extractOptionCountFromPlotResponse returns array length', () => {
+    expect(
+      extractOptionCountFromPlotResponse({ option_comparison: [{ id: 'a' }, { id: 'b' }] }),
+    ).toBe(2)
+  })
+
+  it('extractOptionCountFromPlotResponse returns 0 when missing', () => {
+    expect(extractOptionCountFromPlotResponse(null)).toBe(0)
+    expect(extractOptionCountFromPlotResponse({})).toBe(0)
+    expect(extractOptionCountFromPlotResponse({ option_comparison: 'not-array' })).toBe(0)
+  })
+
+  it('extractFactorSensitivityCountFromPlotResponse returns array length', () => {
+    expect(
+      extractFactorSensitivityCountFromPlotResponse({
+        factor_sensitivity: [{}, {}, {}],
+      }),
+    ).toBe(3)
+  })
+
+  it('extractFactorSensitivityCountFromPlotResponse returns 0 when missing', () => {
+    expect(extractFactorSensitivityCountFromPlotResponse(null)).toBe(0)
+    expect(extractFactorSensitivityCountFromPlotResponse({})).toBe(0)
+  })
+})
+
+describe('coherence contradiction surfacing (composition)', () => {
+  it('cee_v5_run_analysis + effective none + analysis_fact_present → contradictory state with issues', () => {
+    // This is the headline contradiction from the brief. The assembler
+    // accepts the capture-pipeline classifier's output verbatim; the
+    // contradiction is detected there. Verify the wiring surfaces it.
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      analysisStateSource: 'cee_v5_run_analysis',
+      capturePipeline: {
+        capture_pipeline_status: 'results_rendered_from_store_without_capture',
+        coherence: {
+          state: 'contradictory',
+          issues: [
+            'analysis_state_cee_v5_but_effective_cee_response_none',
+            'results_rendered_from_store_without_capture',
+            'analysis_fact_present_but_cee_capture_missing',
+          ],
+        },
+      },
+    })
+    expect(out.coherence.state).toBe('contradictory')
+    expect(out.coherence.issues).toContain(
+      'analysis_state_cee_v5_but_effective_cee_response_none',
+    )
+    expect(out.coherence.issues).toContain(
+      'analysis_fact_present_but_cee_capture_missing',
+    )
+  })
+})

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -81,6 +81,9 @@ function defaults(): AssembleV5CanonicalTurnDiagnosticsInputs {
     optionCount: 0,
     factorSensitivityCount: 0,
     captureTier: 'bundle_payloads',
+    // Default: body was captured (matches default makeCapture()
+    // which has request_present=true, response_present=true).
+    responseBodyPresent: true,
     renderedOptionCount: null,
     renderedFactorCount: null,
     capturePipeline: {
@@ -129,6 +132,9 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
     expect(out.latest_v5_turn).toEqual({
       request_present: true,
       response_present: true,
+      // Default responseBodyPresent=true in defaults() → distinct from
+      // response_present (HTTP completion) — body was actually captured.
+      response_body_present: true,
       request_id: 'req-1',
       // Default captureTier is bundle_payloads → session-level
       // request_id provenance.
@@ -192,20 +198,59 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
     expect(out.latest_v5_turn.request_id_source).toBe('none')
   })
 
-  it('parse_ok is null when response_present is false (does NOT conflate "no response" with "parsed and failed")', () => {
+  it('parse_ok is null when response_body_present is false (round-5 P0.2 — does NOT conflate HTTP completion with parseable body)', () => {
     const out = assembleV5CanonicalTurnDiagnostics({
       ...defaults(),
       legacyDiagnostic: makeLegacy({
         v5_cee_capture: makeCapture({
           request_present: true,
-          response_present: false,
-          parse_ok: false, // legacy capture would report false, but
-          // the snapshot must overlay null per P0.2
+          response_present: true, // HTTP completed
+          parse_ok: false,
         }),
       }),
+      // Critically: HTTP completed but NO body. Most common case is
+      // a 500/empty response that nonetheless sets `completed=true`.
+      responseBodyPresent: false,
     })
     expect(out.parse.parse_ok).toBeNull()
     expect(out.diagnostic_source_strength.parse).toBe('unavailable')
+    expect(out.latest_v5_turn.response_present).toBe(true)
+    expect(out.latest_v5_turn.response_body_present).toBe(false)
+  })
+
+  it('parse_ok = true when body present AND not a parse-error envelope', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          request_present: true,
+          response_present: true,
+          parse_ok: true,
+        }),
+      }),
+      responseBodyPresent: true,
+    })
+    expect(out.parse.parse_ok).toBe(true)
+    expect(out.diagnostic_source_strength.parse).toBe('live_response')
+    expect(out.latest_v5_turn.response_body_present).toBe(true)
+  })
+
+  it('parse_ok = false (NOT true) when body is a parse-error envelope', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({
+          request_present: true,
+          response_present: true,
+          parse_ok: false,
+          parse_failure_kind: 'schema_mismatch',
+          raw_response_present: true,
+        }),
+      }),
+      responseBodyPresent: true,
+    })
+    expect(out.parse.parse_ok).toBe(false)
+    expect(out.diagnostic_source_strength.parse).toBe('live_response')
   })
 
   it('diagnostic_source_strength.parse is "unavailable" for service-metadata-only failures', () => {
@@ -219,10 +264,22 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
           parse_ok: false,
         }),
       }),
+      responseBodyPresent: false,
     })
     expect(out.parse.parse_ok).toBeNull()
     expect(out.diagnostic_source_strength.parse).toBe('unavailable')
     expect(out.diagnostic_source_strength.latest_v5_turn).toBe('service_metadata')
+  })
+
+  it('request_id_source = "none" when the actual request_id is null (round-5 P1.1)', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({ request_id: null }),
+      }),
+    })
+    expect(out.latest_v5_turn.request_id).toBeNull()
+    expect(out.latest_v5_turn.request_id_source).toBe('none')
   })
 
   it('results.rendered_option_count / rendered_factor_count surface from display_state when provided', () => {
@@ -531,7 +588,7 @@ describe('determineCaptureTier — single canonical resolver', () => {
         traceEntryPresent: true,
         bundlePayloadsCeeRequestPresent: true,
         bundlePayloadsCeeResponsePresent: true,
-        serviceMetadataV5EndpointPresent: true,
+        serviceMetadataV5FailurePresent: true,
         factPresentForScenario: true,
       }),
     ).toBe('payload_trace')
@@ -543,7 +600,7 @@ describe('determineCaptureTier — single canonical resolver', () => {
         traceEntryPresent: false,
         bundlePayloadsCeeRequestPresent: true,
         bundlePayloadsCeeResponsePresent: false,
-        serviceMetadataV5EndpointPresent: false,
+        serviceMetadataV5FailurePresent: false,
         factPresentForScenario: false,
       }),
     ).toBe('bundle_payloads')
@@ -552,22 +609,47 @@ describe('determineCaptureTier — single canonical resolver', () => {
         traceEntryPresent: false,
         bundlePayloadsCeeRequestPresent: false,
         bundlePayloadsCeeResponsePresent: true,
-        serviceMetadataV5EndpointPresent: false,
+        serviceMetadataV5FailurePresent: false,
         factPresentForScenario: false,
       }),
     ).toBe('bundle_payloads')
   })
 
-  it('returns service_metadata when only data.services.cee V5 endpoint is present', () => {
+  it('returns service_metadata only when V5 endpoint reports FAILURE evidence', () => {
     expect(
       determineCaptureTier({
         traceEntryPresent: false,
         bundlePayloadsCeeRequestPresent: false,
         bundlePayloadsCeeResponsePresent: false,
-        serviceMetadataV5EndpointPresent: true,
+        serviceMetadataV5FailurePresent: true,
         factPresentForScenario: false,
       }),
     ).toBe('service_metadata')
+  })
+
+  it('round-5 P1.4: successful V5 service-metadata record does NOT activate service_metadata tier — falls through to store/none so missing payloads are visible', () => {
+    // Successful service record + fact present → tier should be 'store',
+    // NOT 'service_metadata'. The fall-through is the diagnostic
+    // signal that payloads are missing despite a successful call.
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: false,
+        bundlePayloadsCeeRequestPresent: false,
+        bundlePayloadsCeeResponsePresent: false,
+        serviceMetadataV5FailurePresent: false,
+        factPresentForScenario: true,
+      }),
+    ).toBe('store')
+    // Successful service record + no fact → 'none'.
+    expect(
+      determineCaptureTier({
+        traceEntryPresent: false,
+        bundlePayloadsCeeRequestPresent: false,
+        bundlePayloadsCeeResponsePresent: false,
+        serviceMetadataV5FailurePresent: false,
+        factPresentForScenario: false,
+      }),
+    ).toBe('none')
   })
 
   it('returns store when no capture evidence but a fact is present', () => {
@@ -576,7 +658,7 @@ describe('determineCaptureTier — single canonical resolver', () => {
         traceEntryPresent: false,
         bundlePayloadsCeeRequestPresent: false,
         bundlePayloadsCeeResponsePresent: false,
-        serviceMetadataV5EndpointPresent: false,
+        serviceMetadataV5FailurePresent: false,
         factPresentForScenario: true,
       }),
     ).toBe('store')
@@ -588,7 +670,7 @@ describe('determineCaptureTier — single canonical resolver', () => {
         traceEntryPresent: false,
         bundlePayloadsCeeRequestPresent: false,
         bundlePayloadsCeeResponsePresent: false,
-        serviceMetadataV5EndpointPresent: false,
+        serviceMetadataV5FailurePresent: false,
         factPresentForScenario: false,
       }),
     ).toBe('none')

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -79,6 +79,10 @@ function defaults(): AssembleV5CanonicalTurnDiagnosticsInputs {
     graphHashAtGeneration: null,
     optionCount: 0,
     factorSensitivityCount: 0,
+    v5TraceEntryPresent: false,
+    ceeServiceV5EndpointPresent: false,
+    renderedOptionCount: null,
+    renderedFactorCount: null,
     capturePipeline: {
       capture_pipeline_status: 'complete',
       coherence: { state: 'complete', issues: [] },
@@ -131,7 +135,97 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
       endpoint: '/bff/orchestrate/v2/turn',
       status: 200,
       duration_ms: 123,
-      source: 'proxy_v5_turn',
+      // Brief's provenance enum: bundle.payloads.cee_* carried the data
+      // (v5TraceEntryPresent: false in defaults).
+      source: 'bundle_payloads',
+    })
+  })
+
+  it('latest_v5_turn.source = "payload_trace" when v5TraceEntryPresent is true', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      v5TraceEntryPresent: true,
+    })
+    expect(out.latest_v5_turn.source).toBe('payload_trace')
+  })
+
+  it('latest_v5_turn.source = "service_metadata" when only services.cee endpoint matches V5', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: makeCapture({ request_present: false, response_present: false }),
+      }),
+      v5TraceEntryPresent: false,
+      ceeServiceV5EndpointPresent: true,
+    })
+    expect(out.latest_v5_turn.source).toBe('service_metadata')
+  })
+
+  it('latest_v5_turn.source = "store" when no capture but fact is present', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: null,
+        analysis_fact_status: 'present',
+      }),
+    })
+    expect(out.latest_v5_turn.source).toBe('store')
+  })
+
+  it('latest_v5_turn.source = "none" when no capture and no fact', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: null,
+        analysis_fact_status: 'missing',
+      }),
+    })
+    expect(out.latest_v5_turn.source).toBe('none')
+  })
+
+  it('results.rendered_option_count / rendered_factor_count surface from display_state when provided', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      renderedOptionCount: 3,
+      renderedFactorCount: 7,
+    })
+    expect(out.results.rendered_option_count).toBe(3)
+    expect(out.results.rendered_factor_count).toBe(7)
+  })
+
+  it('results rendered counts are null (not fabricated) when display_state is absent', () => {
+    const out = assembleV5CanonicalTurnDiagnostics(defaults())
+    expect(out.results.rendered_option_count).toBeNull()
+    expect(out.results.rendered_factor_count).toBeNull()
+  })
+
+  it('diagnostic_source_strength tracks each block independently', () => {
+    const live = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      v5TraceEntryPresent: true,
+      optionCount: 2,
+      factorSensitivityCount: 5,
+    })
+    expect(live.diagnostic_source_strength).toEqual({
+      latest_v5_turn: 'live_trace',
+      parse: 'live_response',
+      results: 'plot_response',
+    })
+
+    const fallback = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: null,
+        analysis_fact_status: 'present',
+      }),
+      hasResultsReport: true,
+      optionCount: 0,
+      factorSensitivityCount: 0,
+    })
+    expect(fallback.diagnostic_source_strength).toEqual({
+      latest_v5_turn: 'fallback',
+      parse: 'unavailable',
+      results: 'store_report',
     })
   })
 

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -185,6 +185,40 @@ describe('assembleV5CanonicalTurnDiagnostics — composition with legacy classif
     expect(out.latest_v5_turn.request_id_source).toBe('none')
   })
 
+  it('stabilisation regression: latest_v5_turn.source is DOWNGRADED to "none" when captureTier=payload_trace but capture is null (rare synthesised-fallback path) — prevents claiming live_trace without capture', () => {
+    // Models the edge case where bundle.v5_canonical_analysis was
+    // assigned the synthesised fallback (legacyDiagnostic with
+    // v5_cee_capture=null) but the snapshot's tier resolver still
+    // sees trace evidence. Claiming source='payload_trace' here
+    // would be a provenance contradiction (every capture field is
+    // null), so the assembler must downgrade.
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({ v5_cee_capture: null }),
+      captureTier: 'payload_trace',
+      responseBodyPresent: true,
+    })
+    expect(out.latest_v5_turn.source).toBe('none')
+    // Source-strength must also reflect the downgrade (was previously
+    // 'live_trace' from the unfiltered captureTier mapping).
+    expect(out.diagnostic_source_strength.latest_v5_turn).toBe('unavailable')
+    // request_id_source must also stay coherent (capture null → 'none').
+    expect(out.latest_v5_turn.request_id_source).toBe('none')
+  })
+
+  it('stabilisation regression: latest_v5_turn.source stays "store" when captureTier=store and capture is null (the honest no-capture-but-fact path)', () => {
+    const out = assembleV5CanonicalTurnDiagnostics({
+      ...defaults(),
+      legacyDiagnostic: makeLegacy({
+        v5_cee_capture: null,
+        analysis_fact_status: 'present',
+      }),
+      captureTier: 'store',
+    })
+    expect(out.latest_v5_turn.source).toBe('store')
+    expect(out.diagnostic_source_strength.latest_v5_turn).toBe('fallback')
+  })
+
   it('latest_v5_turn.source = "none" when captureTier is none', () => {
     const out = assembleV5CanonicalTurnDiagnostics({
       ...defaults(),

--- a/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
+++ b/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
@@ -21,6 +21,7 @@ import {
   classifyV5CapturePipelineStatus,
   detectFailedHttpRecord,
   findLatestV5TurnEntry,
+  hasResponseBody,
   type V5CapturePipelineStatusInputs,
 } from '../v5CapturePipelineStatus'
 
@@ -465,25 +466,30 @@ describe('findLatestV5TurnEntry — preference order', () => {
     ).toBeNull()
   })
 
-  it('prefers an entry with a completed response over a request-only entry', () => {
-    const completed = v5({
-      id: 'c1',
+  it('prefers an entry WITH response body over a status-only entry (round-5 P1.2)', () => {
+    const withBody = v5({
+      id: 'b1',
       response: { body: { ok: true } },
       status: 200,
       completed: true,
     })
+    const statusOnly = v5({ id: 'h1', status: 500, completed: true })
+    // status-only first in the list — picker must still pick the
+    // body-bearing entry. Prevents a metadata stub from masking a
+    // parseable response.
+    expect(findLatestV5TurnEntry([statusOnly, withBody])).toBe(withBody)
+  })
+
+  it('prefers a status-only entry over a request-only entry when no body exists', () => {
+    const statusOnly = v5({ id: 'h1', status: 500, completed: true })
     const requestOnly = v5({ id: 'r1', request: { body: { kind: 'analysis' } } })
-    // request-only first, completed-response second — picker must still
-    // pick the completed-response entry.
-    const out = findLatestV5TurnEntry([requestOnly, completed])
-    expect(out).toBe(completed)
+    expect(findLatestV5TurnEntry([requestOnly, statusOnly])).toBe(statusOnly)
   })
 
   it('prefers a request-only entry over a metadata-only stub', () => {
     const requestOnly = v5({ id: 'r1', request: { body: {} } })
     const metadataOnly = v5({ id: 'm1' })
-    const out = findLatestV5TurnEntry([metadataOnly, requestOnly])
-    expect(out).toBe(requestOnly)
+    expect(findLatestV5TurnEntry([metadataOnly, requestOnly])).toBe(requestOnly)
   })
 
   it('falls back to metadata-only stub when nothing else exists', () => {
@@ -491,8 +497,21 @@ describe('findLatestV5TurnEntry — preference order', () => {
     expect(findLatestV5TurnEntry([stub])).toBe(stub)
   })
 
-  it('accepts status-only as completed-response evidence (HTTP completed even without response body)', () => {
+  it('accepts status-only as response evidence when no body-bearing entry exists', () => {
     const statusOnly = v5({ id: 'h1', status: 500, completed: true })
     expect(findLatestV5TurnEntry([statusOnly])).toBe(statusOnly)
+  })
+})
+
+describe('hasResponseBody — body-presence helper', () => {
+  it('returns true only when response.body is non-null', () => {
+    expect(hasResponseBody({ response: { body: { ok: true } } })).toBe(true)
+    expect(hasResponseBody({ response: { body: [] } })).toBe(true)
+  })
+
+  it('returns false for status-only / metadata-only entries', () => {
+    expect(hasResponseBody({ response: { body: null } })).toBe(false)
+    expect(hasResponseBody({ response: {} })).toBe(false)
+    expect(hasResponseBody({})).toBe(false)
   })
 })

--- a/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
+++ b/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from 'vitest'
 import {
   classifyV5CapturePipelineStatus,
   detectFailedHttpRecord,
+  findLatestV5TurnEntry,
   type V5CapturePipelineStatusInputs,
 } from '../v5CapturePipelineStatus'
 
@@ -444,5 +445,54 @@ describe('detectFailedHttpRecord — scoped to V5 CEE turns', () => {
         v5({ completed: false, source: 'preflight_or_network' }),
       ]),
     ).toEqual({ present: true, source: 'preflight_or_network' })
+  })
+})
+
+describe('findLatestV5TurnEntry — preference order', () => {
+  const v5 = (overrides: Record<string, unknown> = {}) => ({
+    service: 'CEE',
+    endpoint: '/bff/orchestrate/v2/turn',
+    ...overrides,
+  })
+
+  it('returns null when no V5 entries exist', () => {
+    expect(findLatestV5TurnEntry([])).toBeNull()
+    expect(
+      findLatestV5TurnEntry([
+        { service: 'PLoT', endpoint: '/plot/v2/run' },
+        { service: 'CEE', endpoint: '/bff/orchestrate/v1/turn' },
+      ]),
+    ).toBeNull()
+  })
+
+  it('prefers an entry with a completed response over a request-only entry', () => {
+    const completed = v5({
+      id: 'c1',
+      response: { body: { ok: true } },
+      status: 200,
+      completed: true,
+    })
+    const requestOnly = v5({ id: 'r1', request: { body: { kind: 'analysis' } } })
+    // request-only first, completed-response second — picker must still
+    // pick the completed-response entry.
+    const out = findLatestV5TurnEntry([requestOnly, completed])
+    expect(out).toBe(completed)
+  })
+
+  it('prefers a request-only entry over a metadata-only stub', () => {
+    const requestOnly = v5({ id: 'r1', request: { body: {} } })
+    const metadataOnly = v5({ id: 'm1' })
+    const out = findLatestV5TurnEntry([metadataOnly, requestOnly])
+    expect(out).toBe(requestOnly)
+  })
+
+  it('falls back to metadata-only stub when nothing else exists', () => {
+    const stub = v5({ id: 'meta' })
+    expect(findLatestV5TurnEntry([stub])).toBe(stub)
+  })
+
+  it('accepts status-only as completed-response evidence (HTTP completed even without response body)', () => {
+    const statusOnly = v5({ id: 'h1', status: 500, completed: true })
+    expect(findLatestV5TurnEntry([statusOnly])).toBe(statusOnly)
   })
 })

--- a/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
+++ b/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
@@ -29,6 +29,7 @@ function defaults(): V5CapturePipelineStatusInputs {
     hasResultsReport: false,
     rawV2ResponsePresent: false,
     failedHttpRecord: { present: false, source: null },
+    serviceMetadataV5Failure: false,
     analysisStateSource: 'none',
     effectiveCeeResponseSource: 'none',
     analysisFactPresent: false,
@@ -68,6 +69,28 @@ describe('classifyV5CapturePipelineStatus — capture_pipeline_status enum', () 
       failedHttpRecord: { present: true, source: 'cee' },
     })
     expect(out.capture_pipeline_status).toBe('request_failed')
+  })
+
+  it('V5-endpoint service-metadata failure WITHOUT trace evidence → request_failed_from_service_metadata (not hydrated_only)', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      serviceMetadataV5Failure: true,
+      // Even with results present + no rawV2 — service-metadata
+      // failure must take precedence so reviewers don't read
+      // hydrated_only and miss the actual failure signal.
+      hasResultsReport: true,
+      rawV2ResponsePresent: false,
+    })
+    expect(out.capture_pipeline_status).toBe('request_failed_from_service_metadata')
+  })
+
+  it('trace-recorded failure takes precedence over service-metadata flag', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      failedHttpRecord: { present: true, source: 'preflight_or_network' },
+      serviceMetadataV5Failure: true,
+    })
+    expect(out.capture_pipeline_status).toBe('proxy_or_network_failure')
   })
 
   it('results present, no capture, no failed record, rawV2Response present → results_rendered_from_store_without_capture', () => {
@@ -274,6 +297,36 @@ describe('classifyV5CapturePipelineStatus — coherence issues', () => {
     })
     expect(out.capture_pipeline_status).toBe('proxy_or_network_failure')
     expect(out.coherence.issues).not.toContain(
+      'legacy_pipeline_status_misleading_proxy_or_network_failure',
+    )
+  })
+
+  it('legacy says proxy_or_network_failure but new says request_failed → mislabel issue STILL fires (different evidence strength)', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      v5Capture: {
+        request_present: true,
+        response_present: false,
+        parse_ok: false,
+        raw_response_present: false,
+      },
+      failedHttpRecord: { present: true, source: 'cee' },
+      legacyPipelineStatus: 'proxy_or_network_failure',
+    })
+    expect(out.capture_pipeline_status).toBe('request_failed')
+    expect(out.coherence.issues).toContain(
+      'legacy_pipeline_status_misleading_proxy_or_network_failure',
+    )
+  })
+
+  it('legacy says proxy_or_network_failure but new says request_failed_from_service_metadata → mislabel issue fires', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      serviceMetadataV5Failure: true,
+      legacyPipelineStatus: 'proxy_or_network_failure',
+    })
+    expect(out.capture_pipeline_status).toBe('request_failed_from_service_metadata')
+    expect(out.coherence.issues).toContain(
       'legacy_pipeline_status_misleading_proxy_or_network_failure',
     )
   })

--- a/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
+++ b/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
@@ -147,6 +147,77 @@ describe('classifyV5CapturePipelineStatus — capture_pipeline_status enum', () 
   })
 })
 
+describe('classifyV5CapturePipelineStatus — negative tests for unrelated failed payloads', () => {
+  it('an unrelated failed PLoT record does NOT trigger proxy_or_network_failure', () => {
+    // detectFailedHttpRecord already scopes to V5 turns. This integration
+    // check confirms the upstream classifier respects the scoping.
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: false,
+      // Caller passes failedHttpRecord = {present: false} when the
+      // scoped detection found nothing (even if unrelated services
+      // failed elsewhere). Status must be hydrated_only, not
+      // proxy_or_network_failure.
+      failedHttpRecord: { present: false, source: null },
+    })
+    expect(out.capture_pipeline_status).not.toBe('proxy_or_network_failure')
+    expect(out.capture_pipeline_status).toBe('hydrated_only')
+  })
+
+  it('issue legacy_pipeline_status_misleading_proxy_or_network_failure fires even when results are hydrated_only', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: false,
+      legacyPipelineStatus: 'proxy_or_network_failure',
+    })
+    expect(out.capture_pipeline_status).toBe('hydrated_only')
+    expect(out.coherence.issues).toContain(
+      'legacy_pipeline_status_misleading_proxy_or_network_failure',
+    )
+  })
+})
+
+describe('classifyV5CapturePipelineStatus — additive coherence issues', () => {
+  it('results_rendered_from_store_without_capture fires regardless of whether final status is hydrated_only or results_rendered_from_store_without_capture', () => {
+    const hydrated = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: false,
+    })
+    expect(hydrated.capture_pipeline_status).toBe('hydrated_only')
+    expect(hydrated.coherence.issues).toContain(
+      'results_rendered_from_store_without_capture',
+    )
+
+    const rawPresent = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: true,
+    })
+    expect(rawPresent.capture_pipeline_status).toBe(
+      'results_rendered_from_store_without_capture',
+    )
+    expect(rawPresent.coherence.issues).toContain(
+      'results_rendered_from_store_without_capture',
+    )
+  })
+
+  it('parse_failed_with_raw_preserved fires whenever parse_ok=false and raw_response_present=true, regardless of status enum', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      v5Capture: {
+        request_present: true,
+        response_present: true,
+        parse_ok: false,
+        raw_response_present: true,
+      },
+    })
+    expect(out.coherence.issues).toContain('parse_failed_with_raw_preserved')
+  })
+})
+
 describe('classifyV5CapturePipelineStatus — coherence issues', () => {
   it('analysis_state_source=cee_v5_run_analysis + effective_cee_response_source=none emits the explicit issue', () => {
     const out = classifyV5CapturePipelineStatus({
@@ -221,41 +292,47 @@ describe('classifyV5CapturePipelineStatus — coherence issues', () => {
   })
 })
 
-describe('detectFailedHttpRecord', () => {
+describe('detectFailedHttpRecord — scoped to V5 CEE turns', () => {
+  const v5 = (overrides: Record<string, unknown> = {}) => ({
+    service: 'CEE',
+    endpoint: '/bff/orchestrate/v2/turn',
+    ...overrides,
+  })
+
   it('returns absent when no payload qualifies', () => {
     expect(detectFailedHttpRecord([])).toEqual({ present: false, source: null })
     expect(
       detectFailedHttpRecord([
-        { completed: true, status: 200 },
-        { completed: true, status: 201 },
+        v5({ completed: true, status: 200 }),
+        v5({ completed: true, status: 201 }),
       ]),
     ).toEqual({ present: false, source: null })
   })
 
-  it('returns present + source when a record has completed=false', () => {
+  it('returns present + source when a V5 record has completed=false', () => {
     expect(
-      detectFailedHttpRecord([{ completed: false, source: 'preflight_or_network' }]),
+      detectFailedHttpRecord([v5({ completed: false, source: 'preflight_or_network' })]),
     ).toEqual({ present: true, source: 'preflight_or_network' })
   })
 
-  it('returns present when status >= 500', () => {
-    const out = detectFailedHttpRecord([{ completed: true, status: 502, source: 'proxy' }])
+  it('returns present when V5 status >= 500', () => {
+    const out = detectFailedHttpRecord([v5({ completed: true, status: 502, source: 'proxy' })])
     expect(out.present).toBe(true)
     expect(out.source).toBe('proxy')
   })
 
-  it('returns present when error/errorName fields are set', () => {
+  it('returns present when V5 error/errorName fields are set', () => {
     expect(
-      detectFailedHttpRecord([{ completed: true, error: 'fetch failed' }]).present,
+      detectFailedHttpRecord([v5({ completed: true, error: 'fetch failed' })]).present,
     ).toBe(true)
     expect(
-      detectFailedHttpRecord([{ completed: true, errorName: 'TypeError' }]).present,
+      detectFailedHttpRecord([v5({ completed: true, errorName: 'TypeError' })]).present,
     ).toBe(true)
   })
 
-  it('returns present when source is a network/proxy classification', () => {
+  it('returns present when V5 source is a network/proxy classification', () => {
     for (const source of ['proxy', 'netlify', 'preflight_or_network', 'browser_timeout']) {
-      const out = detectFailedHttpRecord([{ completed: true, status: 200, source }])
+      const out = detectFailedHttpRecord([v5({ completed: true, status: 200, source })])
       expect(out.present).toBe(true)
       expect(out.source).toBe(source)
     }
@@ -263,7 +340,56 @@ describe('detectFailedHttpRecord', () => {
 
   it('source "cee" alone is not enough — must pair with a failure signal', () => {
     expect(
-      detectFailedHttpRecord([{ completed: true, status: 200, source: 'cee' }]).present,
+      detectFailedHttpRecord([v5({ completed: true, status: 200, source: 'cee' })]).present,
     ).toBe(false)
+  })
+
+  // --- Scoping (the reviewer-flagged correctness fix) ---
+
+  it('IGNORES a failed PLoT record — only V5 CEE turns influence capture status', () => {
+    expect(
+      detectFailedHttpRecord([
+        {
+          service: 'PLoT',
+          endpoint: '/plot/v2/run',
+          completed: false,
+          source: 'proxy',
+          status: 502,
+        },
+      ]),
+    ).toEqual({ present: false, source: null })
+  })
+
+  it('IGNORES a failed CEE record on a non-V5 endpoint (legacy /turn, draft-graph, etc)', () => {
+    expect(
+      detectFailedHttpRecord([
+        {
+          service: 'CEE',
+          endpoint: '/bff/orchestrate/v1/turn',
+          completed: false,
+          source: 'preflight_or_network',
+        },
+        {
+          service: 'CEE',
+          endpoint: '/cee/draft-graph',
+          completed: false,
+          source: 'proxy',
+        },
+      ]),
+    ).toEqual({ present: false, source: null })
+  })
+
+  it('returns the V5 failure even when an unrelated record appears first', () => {
+    expect(
+      detectFailedHttpRecord([
+        {
+          service: 'PLoT',
+          endpoint: '/plot/v2/run',
+          completed: false,
+          source: 'proxy',
+        },
+        v5({ completed: false, source: 'preflight_or_network' }),
+      ]),
+    ).toEqual({ present: true, source: 'preflight_or_network' })
   })
 })

--- a/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
+++ b/src/lib/__tests__/v5CapturePipelineStatus.spec.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for v5CapturePipelineStatus — the additive classifier that
+ * replaces the legacy `proxy_or_network_failure` overuse with a coherent
+ * 7-state reading of the capture surface.
+ *
+ * Covers the brief's required cases:
+ *   - no failed HTTP record → never `proxy_or_network_failure`
+ *   - actual failed proxy/network record → `proxy_or_network_failure`
+ *   - results present, no capture, no failed record → `results_rendered_from_store_without_capture`
+ *   - results present, rawV2Response = null → `hydrated_only`
+ *   - parse-error envelope → `parse_failed`
+ *   - no results, no capture → `capture_missing`
+ *   - legacy pipeline disagreement → `legacy_pipeline_status_misleading_proxy_or_network_failure`
+ *
+ * Plus the explicit contradiction-as-coherence-issue cases from P0.2.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyV5CapturePipelineStatus,
+  detectFailedHttpRecord,
+  type V5CapturePipelineStatusInputs,
+} from '../v5CapturePipelineStatus'
+
+function defaults(): V5CapturePipelineStatusInputs {
+  return {
+    v5Capture: null,
+    hasResultsReport: false,
+    rawV2ResponsePresent: false,
+    failedHttpRecord: { present: false, source: null },
+    analysisStateSource: 'none',
+    effectiveCeeResponseSource: 'none',
+    analysisFactPresent: false,
+    scenarioIdConflictCount: 0,
+    legacyPipelineStatus: null,
+  }
+}
+
+describe('classifyV5CapturePipelineStatus — capture_pipeline_status enum', () => {
+  it('no V5 capture + no results + no failed record → capture_missing', () => {
+    const out = classifyV5CapturePipelineStatus(defaults())
+    expect(out.capture_pipeline_status).toBe('capture_missing')
+    expect(out.coherence.state).toBe('missing')
+  })
+
+  it('no failed HTTP record never emits proxy_or_network_failure', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: true,
+    })
+    expect(out.capture_pipeline_status).not.toBe('proxy_or_network_failure')
+    expect(out.capture_pipeline_status).toBe('results_rendered_from_store_without_capture')
+  })
+
+  it('failed HTTP record classified as proxy/network → proxy_or_network_failure', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      failedHttpRecord: { present: true, source: 'preflight_or_network' },
+    })
+    expect(out.capture_pipeline_status).toBe('proxy_or_network_failure')
+  })
+
+  it('failed HTTP record with non-network source → request_failed', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      failedHttpRecord: { present: true, source: 'cee' },
+    })
+    expect(out.capture_pipeline_status).toBe('request_failed')
+  })
+
+  it('results present, no capture, no failed record, rawV2Response present → results_rendered_from_store_without_capture', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: true,
+    })
+    expect(out.capture_pipeline_status).toBe('results_rendered_from_store_without_capture')
+    expect(out.coherence.issues).toContain('results_rendered_from_store_without_capture')
+  })
+
+  it('results present, no capture, no failed record, no rawV2Response → hydrated_only', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: false,
+    })
+    expect(out.capture_pipeline_status).toBe('hydrated_only')
+  })
+
+  it('request present + no response + no failed proxy record → request_failed', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      v5Capture: {
+        request_present: true,
+        response_present: false,
+        parse_ok: false,
+        raw_response_present: false,
+      },
+    })
+    expect(out.capture_pipeline_status).toBe('request_failed')
+  })
+
+  it('parse-error envelope present (parse_ok=false) → parse_failed', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      v5Capture: {
+        request_present: true,
+        response_present: true,
+        parse_ok: false,
+        raw_response_present: true,
+      },
+    })
+    expect(out.capture_pipeline_status).toBe('parse_failed')
+    expect(out.coherence.issues).toContain('parse_failed_with_raw_preserved')
+  })
+
+  it('successful capture + results → complete', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      v5Capture: {
+        request_present: true,
+        response_present: true,
+        parse_ok: true,
+        raw_response_present: false,
+      },
+      hasResultsReport: true,
+    })
+    expect(out.capture_pipeline_status).toBe('complete')
+    expect(out.coherence.state).toBe('complete')
+    expect(out.coherence.issues).toEqual([])
+  })
+
+  it('successful non-analysis capture (no results yet) also reads as complete', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      v5Capture: {
+        request_present: true,
+        response_present: true,
+        parse_ok: true,
+        raw_response_present: false,
+      },
+      hasResultsReport: false,
+    })
+    expect(out.capture_pipeline_status).toBe('complete')
+  })
+})
+
+describe('classifyV5CapturePipelineStatus — coherence issues', () => {
+  it('analysis_state_source=cee_v5_run_analysis + effective_cee_response_source=none emits the explicit issue', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      analysisStateSource: 'cee_v5_run_analysis',
+      effectiveCeeResponseSource: 'none',
+      hasResultsReport: true,
+      rawV2ResponsePresent: false,
+    })
+    expect(out.coherence.issues).toContain(
+      'analysis_state_cee_v5_but_effective_cee_response_none',
+    )
+    expect(out.coherence.state).toBe('contradictory')
+  })
+
+  it('analysis_fact_present + v5_capture null emits analysis_fact_present_but_cee_capture_missing', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      analysisFactPresent: true,
+      hasResultsReport: true,
+      rawV2ResponsePresent: false,
+    })
+    expect(out.coherence.issues).toContain(
+      'analysis_fact_present_but_cee_capture_missing',
+    )
+  })
+
+  it('scenario_id conflict count > 0 emits scenario_id_conflict', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      scenarioIdConflictCount: 2,
+    })
+    expect(out.coherence.issues).toContain('scenario_id_conflict')
+  })
+
+  it('legacy pipeline says proxy_or_network_failure but capture says results_rendered_from_store_without_capture → emits legacy_pipeline_status_misleading_proxy_or_network_failure', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      hasResultsReport: true,
+      rawV2ResponsePresent: true,
+      legacyPipelineStatus: 'proxy_or_network_failure',
+    })
+    expect(out.capture_pipeline_status).toBe('results_rendered_from_store_without_capture')
+    expect(out.coherence.issues).toContain(
+      'legacy_pipeline_status_misleading_proxy_or_network_failure',
+    )
+  })
+
+  it('legacy pipeline agrees with capture (both proxy_or_network_failure) → no disagreement issue', () => {
+    const out = classifyV5CapturePipelineStatus({
+      ...defaults(),
+      failedHttpRecord: { present: true, source: 'preflight_or_network' },
+      legacyPipelineStatus: 'proxy_or_network_failure',
+    })
+    expect(out.capture_pipeline_status).toBe('proxy_or_network_failure')
+    expect(out.coherence.issues).not.toContain(
+      'legacy_pipeline_status_misleading_proxy_or_network_failure',
+    )
+  })
+
+  it('coherence.state is "missing" only when status is capture_missing', () => {
+    expect(
+      classifyV5CapturePipelineStatus(defaults()).coherence.state,
+    ).toBe('missing')
+    expect(
+      classifyV5CapturePipelineStatus({
+        ...defaults(),
+        hasResultsReport: true,
+        rawV2ResponsePresent: false,
+      }).coherence.state,
+    ).not.toBe('missing')
+  })
+})
+
+describe('detectFailedHttpRecord', () => {
+  it('returns absent when no payload qualifies', () => {
+    expect(detectFailedHttpRecord([])).toEqual({ present: false, source: null })
+    expect(
+      detectFailedHttpRecord([
+        { completed: true, status: 200 },
+        { completed: true, status: 201 },
+      ]),
+    ).toEqual({ present: false, source: null })
+  })
+
+  it('returns present + source when a record has completed=false', () => {
+    expect(
+      detectFailedHttpRecord([{ completed: false, source: 'preflight_or_network' }]),
+    ).toEqual({ present: true, source: 'preflight_or_network' })
+  })
+
+  it('returns present when status >= 500', () => {
+    const out = detectFailedHttpRecord([{ completed: true, status: 502, source: 'proxy' }])
+    expect(out.present).toBe(true)
+    expect(out.source).toBe('proxy')
+  })
+
+  it('returns present when error/errorName fields are set', () => {
+    expect(
+      detectFailedHttpRecord([{ completed: true, error: 'fetch failed' }]).present,
+    ).toBe(true)
+    expect(
+      detectFailedHttpRecord([{ completed: true, errorName: 'TypeError' }]).present,
+    ).toBe(true)
+  })
+
+  it('returns present when source is a network/proxy classification', () => {
+    for (const source of ['proxy', 'netlify', 'preflight_or_network', 'browser_timeout']) {
+      const out = detectFailedHttpRecord([{ completed: true, status: 200, source }])
+      expect(out.present).toBe(true)
+      expect(out.source).toBe(source)
+    }
+  })
+
+  it('source "cee" alone is not enough — must pair with a failure signal', () => {
+    expect(
+      detectFailedHttpRecord([{ completed: true, status: 200, source: 'cee' }]).present,
+    ).toBe(false)
+  })
+})

--- a/src/lib/debugBundleLogger.ts
+++ b/src/lib/debugBundleLogger.ts
@@ -1,0 +1,122 @@
+/**
+ * Structured render-log events for debug-bundle export.
+ *
+ * Emits four events around debug export lifecycle:
+ *   - dgai.debug_bundle.export_started
+ *   - dgai.debug_bundle.capture_status
+ *   - dgai.debug_bundle.scientific_validation_summary
+ *   - dgai.debug_bundle.export_completed
+ *
+ * Privacy-safe by construction:
+ *   - Allowlisted field keys only (compile-time enforced).
+ *   - Missing values emit as `null`, never substituted.
+ *   - Never accepts free-form payloads, prose, IDs beyond export_id.
+ *
+ * Backed by the existing `logger.info` channel so global log-level
+ * configuration applies.
+ */
+
+import { logger } from './logger'
+
+export type DebugBundleEventName =
+  | 'dgai.debug_bundle.export_started'
+  | 'dgai.debug_bundle.capture_status'
+  | 'dgai.debug_bundle.scientific_validation_summary'
+  | 'dgai.debug_bundle.export_completed'
+
+/**
+ * Permitted structural field set. Any field not on this list is rejected
+ * by `emitDebugBundleEvent` at runtime (and is a compile error at the
+ * TypeScript level via the `DebugBundleEventFields` type below).
+ */
+export const ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS = [
+  'export_id',
+  'scenario_id_source',
+  'capture_pipeline_status',
+  'coherence_state',
+  'coherence_issue_count',
+  'canonical_flag_on',
+  'has_v5_capture',
+  'parse_ok',
+  'has_results',
+  'scientific_validation_available_count',
+  'scientific_validation_unavailable_count',
+  'bundle_size_bytes',
+  'omitted_sections_count',
+] as const
+
+export type DebugBundleEventField =
+  (typeof ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS)[number]
+
+/**
+ * Compile-time enforced event-field shape. Every emitted event must
+ * provide exactly these keys (values may be null). Tests assert that no
+ * other key ever ends up in the emitted payload.
+ */
+export type DebugBundleEventFields = Record<
+  DebugBundleEventField,
+  string | number | boolean | null
+>
+
+/**
+ * Sensitive substrings that must never appear in any emitted field
+ * value. Caller bugs (e.g. accidentally passing a raw header or user
+ * prose) get filtered with `'[REDACTED]'` rather than emitted verbatim.
+ *
+ * Tests verify the guard catches each pattern.
+ */
+const SENSITIVE_SUBSTRINGS: readonly RegExp[] = [
+  /\beyJ[\w-]+\.[\w-]+\.[\w-]+/i, // JWT
+  /\bbearer\s+\S+/i, // Bearer token
+  /\b(api[_-]?key|token|secret|password|authorization)\s*[:=]/i,
+  /[\w.+-]+@[\w-]+\.[\w.-]+/, // email
+]
+
+function scrubField(value: string | number | boolean | null): string | number | boolean | null {
+  if (typeof value !== 'string') return value
+  if (value.length === 0) return value
+  for (const pattern of SENSITIVE_SUBSTRINGS) {
+    if (pattern.test(value)) return '[REDACTED]'
+  }
+  return value
+}
+
+/**
+ * Emit a structured debug-bundle event. Returns the fully-resolved
+ * payload (post-allowlist + scrub) so callers / tests can inspect it.
+ */
+export function emitDebugBundleEvent(
+  event: DebugBundleEventName,
+  fields: DebugBundleEventFields,
+): Readonly<DebugBundleEventFields & { event: DebugBundleEventName }> {
+  // Strip any fields not on the allowlist (caller bug guard) and scrub
+  // remaining string values for sensitive substrings.
+  const safe: Partial<DebugBundleEventFields> = {}
+  for (const key of ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS) {
+    const raw = fields[key]
+    safe[key] = raw === undefined ? null : scrubField(raw)
+  }
+
+  const payload = {
+    event,
+    ...(safe as DebugBundleEventFields),
+  } as const
+
+  logger.info(payload)
+  return payload
+}
+
+/**
+ * Pure factory for building the standard fields object from a partial.
+ * Missing keys default to null. Useful in callers that build the
+ * payload incrementally during export.
+ */
+export function buildDebugBundleEventFields(
+  partial: Partial<DebugBundleEventFields>,
+): DebugBundleEventFields {
+  const out = {} as DebugBundleEventFields
+  for (const key of ALLOWED_DEBUG_BUNDLE_EVENT_FIELDS) {
+    out[key] = partial[key] ?? null
+  }
+  return out
+}

--- a/src/lib/debugRedactionManifest.ts
+++ b/src/lib/debugRedactionManifest.ts
@@ -1,0 +1,190 @@
+/**
+ * Debug redaction manifest — surfaces which paths in the bundle were
+ * redacted or omitted, and which paths the analytical-preservation
+ * policy declares as kept-verbatim.
+ *
+ * The brief requires path-aware semantics rather than a generic
+ * key-name allowlist. The existing `redactPayload` already uses
+ * key-scoped allowlists (`neverRedactKeys: ['observed_state',
+ * 'constraint_analysis', 'goal_constraints']`) and does NOT globally
+ * allowlist generic scalars like `value` / `mean` / `std`. This module
+ * makes that policy *visible* and *auditable* in every export.
+ *
+ * Pure module. Reads the assembled bundle post-redaction and produces a
+ * summary section — does not modify or re-walk the payloads.
+ */
+
+/**
+ * Declarative policy: paths under which analytical numeric fields are
+ * preserved by the existing redactor. Used in the manifest to document
+ * what the policy claims; tests check that the listed paths exist in
+ * the bundle when their parents are present.
+ */
+export const PRESERVED_ANALYTICAL_PATHS: readonly string[] = [
+  'payloads.plot_request.graph.nodes[*].data.observed_state.*',
+  'payloads.plot_request.graph.edges[*].data.strength',
+  'payloads.plot_request.graph.edges[*].data.exists_probability',
+  'payloads.plot_request.graph.edges[*].data.function_params.*',
+  'payloads.plot_request.parameter_uncertainties[*]',
+  'payloads.plot_response.option_comparison[*]',
+  'payloads.plot_response.factor_sensitivity[*]',
+  'payloads.plot_response.m1_coaching.evidence_gaps[*]',
+  'payloads.plot_response.flip_thresholds[*]',
+  'payloads.plot_response.flip_thresholds_status',
+  'payloads.plot_response.factor_sensitivity[*].confidence_provenance',
+  'payloads.plot_response.auto_noise_provenance',
+  'payloads.plot_response.auto_noise_applied',
+  'payloads.plot_response.value_of_information',
+  'payloads.plot_response.evpi',
+  'payloads.plot_response.evpi_percentage_points',
+]
+
+export interface RedactedEntry {
+  path: string
+  reason: string
+}
+
+export interface OmittedEntry {
+  path: string
+  reason: string
+}
+
+export interface DebugRedactionManifest {
+  redacted: RedactedEntry[]
+  omitted: OmittedEntry[]
+  preserved_analytical_paths: string[]
+}
+
+/**
+ * Walk a bundle subtree and collect every redaction marker placed by
+ * `redactPayload`. Path uses dot/bracket notation:
+ *   payloads.cee_request.headers.authorization
+ *   payloads.plot_response.option_comparison[0].interventions
+ *
+ * Markers detected:
+ *   - String value '[REDACTED]'        → reason: 'sensitive_key'
+ *   - Object { __redacted: true }      → reason: 'max_depth' | 'unserialisable'
+ *   - Object { __truncated: true }     → reason: 'array_capped'
+ *   - Object { __sizeLimitExceeded:true} → reason: 'size_limit'
+ *   - Object { __circular: true }      → reason: 'circular_reference'
+ *   - String containing '[truncated_by: …]' suffix → reason: 'string_truncated'
+ */
+export function collectRedactedPaths(
+  root: unknown,
+  rootPath = '',
+  out: RedactedEntry[] = [],
+  visited: WeakSet<object> = new WeakSet(),
+): RedactedEntry[] {
+  if (root === null || root === undefined) return out
+
+  // Strings — only check for truncation suffix or '[REDACTED]'.
+  if (typeof root === 'string') {
+    if (root === '[REDACTED]') {
+      out.push({ path: rootPath, reason: 'sensitive_key' })
+    } else if (root.includes('[truncated_by:')) {
+      out.push({ path: rootPath, reason: 'string_truncated' })
+    }
+    return out
+  }
+
+  if (typeof root !== 'object') return out
+  if (visited.has(root as object)) return out
+  visited.add(root as object)
+
+  if (Array.isArray(root)) {
+    root.forEach((item, idx) => {
+      collectRedactedPaths(item, `${rootPath}[${idx}]`, out, visited)
+    })
+    return out
+  }
+
+  // Object markers.
+  const obj = root as Record<string, unknown>
+  if (obj.__redacted === true) {
+    out.push({ path: rootPath, reason: 'max_depth_or_unserialisable' })
+    return out
+  }
+  if (obj.__truncated === true) {
+    out.push({ path: rootPath, reason: 'array_capped' })
+    // Walk the surviving items so we still catch redactions inside them.
+    const items = obj.items
+    if (Array.isArray(items)) {
+      items.forEach((item, idx) => {
+        collectRedactedPaths(item, `${rootPath}[${idx}]`, out, visited)
+      })
+    }
+    return out
+  }
+  if (obj.__sizeLimitExceeded === true) {
+    out.push({ path: rootPath, reason: 'size_limit' })
+    return out
+  }
+  if (obj.__circular === true) {
+    out.push({ path: rootPath, reason: 'circular_reference' })
+    return out
+  }
+
+  // Generic object walk.
+  for (const key of Object.keys(obj)) {
+    const childPath = rootPath ? `${rootPath}.${key}` : key
+    collectRedactedPaths(obj[key], childPath, out, visited)
+  }
+  return out
+}
+
+/**
+ * Detect optional bundle sections that ended up unassembled. Each
+ * `omitted` entry carries a stable reason code so consumers can tell
+ * "v5_canonical_turn_diagnostics not present because assembler bailed"
+ * from "v5_canonical_turn_diagnostics not present because canonical
+ * flag was off and there was no V5 capture".
+ */
+export interface OmittedSectionProbe {
+  path: string
+  present: boolean
+  reason_if_omitted: string
+}
+
+export function collectOmittedSections(
+  probes: ReadonlyArray<OmittedSectionProbe>,
+): OmittedEntry[] {
+  const out: OmittedEntry[] = []
+  for (const p of probes) {
+    if (!p.present) {
+      out.push({ path: p.path, reason: p.reason_if_omitted })
+    }
+  }
+  return out
+}
+
+/**
+ * Build the full manifest. Inputs are the already-redacted bundle root
+ * plus a list of optional-section probes. The function does no further
+ * mutation of the bundle.
+ */
+export function buildDebugRedactionManifest(
+  bundleRoot: unknown,
+  omittedProbes: ReadonlyArray<OmittedSectionProbe>,
+): DebugRedactionManifest {
+  // Only scan within payloads.* by default — the rest of the bundle is
+  // already diagnostic and unlikely to contain analytical-numeric
+  // material. Scanning the whole bundle would surface noise from
+  // synthesised diagnostic objects that are designed to look like
+  // markers (e.g. counts named __redacted_count). Scoping to payloads
+  // keeps the manifest focused.
+  const bundle =
+    bundleRoot && typeof bundleRoot === 'object' && !Array.isArray(bundleRoot)
+      ? (bundleRoot as Record<string, unknown>)
+      : null
+
+  const redacted: RedactedEntry[] = []
+  if (bundle?.payloads) {
+    collectRedactedPaths(bundle.payloads, 'payloads', redacted)
+  }
+
+  return {
+    redacted,
+    omitted: collectOmittedSections(omittedProbes),
+    preserved_analytical_paths: [...PRESERVED_ANALYTICAL_PATHS],
+  }
+}

--- a/src/lib/scenarioIdReconciliation.ts
+++ b/src/lib/scenarioIdReconciliation.ts
@@ -152,9 +152,15 @@ export function extractScenarioIdFromUrl(href: string | null): string | null {
 }
 
 /**
- * Read scenario-ID from `full_graph` metadata. Today's
- * `transformGraphDataEnriched` output uses `_meta` for non-graph fields;
- * scenarioId may live there or at the root depending on export path.
+ * Read scenario-ID from `full_graph` metadata.
+ *
+ * NOTE — as of this PR, `transformGraphDataEnriched` in exportBundle.ts
+ * writes only `node_type_field` and `enriched: true` into `_meta`. It
+ * does NOT propagate scenarioId. The helper is kept defensive (covering
+ * future expansion of `_meta`) but reviewers should treat
+ * `candidates.full_graph` as effectively dead today. The reconciler
+ * still emits it for completeness but the candidate will almost always
+ * be null until `transformGraphDataEnriched` is updated upstream.
  */
 export function extractScenarioIdFromFullGraph(
   fullGraph: unknown,

--- a/src/lib/scenarioIdReconciliation.ts
+++ b/src/lib/scenarioIdReconciliation.ts
@@ -1,0 +1,178 @@
+/**
+ * Scenario-ID reconciliation for the debug bundle.
+ *
+ * Replaces the hardcoded `session.scenario_id = null` in exportBundle.ts.
+ * Pulls candidate IDs from five sources (canvas store, V5 analysis fact,
+ * latest V5 payload, URL/route, full_graph metadata), applies a stable
+ * preference order, and records any disagreement between sources.
+ *
+ * Pure module. No React, no zustand subscriptions — callers extract the
+ * candidates and pass them in. Helpers below are also pure and exported
+ * for direct testing.
+ */
+
+export type ScenarioIdSource =
+  | 'store'
+  | 'v5_fact'
+  | 'payload'
+  | 'url'
+  | 'full_graph'
+  | 'none'
+
+export interface ScenarioIdReconciliationInputs {
+  storeScenarioId: string | null
+  v5FactScenarioId: string | null
+  payloadScenarioId: string | null
+  urlScenarioId: string | null
+  fullGraphScenarioId: string | null
+}
+
+export interface ScenarioIdReconciliation {
+  selected_scenario_id: string | null
+  selected_source: ScenarioIdSource
+  candidates: {
+    store: string | null
+    v5_fact: string | null
+    payload: string | null
+    url: string | null
+    full_graph: string | null
+  }
+  /** Pairs of non-null candidates that disagree. Stable string format
+   *  `<source_a>=<id_a> vs <source_b>=<id_b>`. */
+  conflicts: string[]
+}
+
+const PREFERENCE_ORDER: ReadonlyArray<Exclude<ScenarioIdSource, 'none'>> = [
+  'store',
+  'v5_fact',
+  'payload',
+  'url',
+  'full_graph',
+]
+
+/**
+ * Apply the preference order and emit reconciled output. The selected ID
+ * is the first non-null candidate; conflicts list every pair of non-null
+ * candidates that disagree, regardless of which one was selected.
+ */
+export function reconcileScenarioId(
+  inputs: ScenarioIdReconciliationInputs,
+): ScenarioIdReconciliation {
+  const candidates = {
+    store: inputs.storeScenarioId,
+    v5_fact: inputs.v5FactScenarioId,
+    payload: inputs.payloadScenarioId,
+    url: inputs.urlScenarioId,
+    full_graph: inputs.fullGraphScenarioId,
+  }
+
+  let selected_scenario_id: string | null = null
+  let selected_source: ScenarioIdSource = 'none'
+  for (const source of PREFERENCE_ORDER) {
+    const value = candidates[source]
+    if (value !== null) {
+      selected_scenario_id = value
+      selected_source = source
+      break
+    }
+  }
+
+  const conflicts: string[] = []
+  const present: Array<[Exclude<ScenarioIdSource, 'none'>, string]> = []
+  for (const source of PREFERENCE_ORDER) {
+    const value = candidates[source]
+    if (value !== null) present.push([source, value])
+  }
+  for (let i = 0; i < present.length; i++) {
+    for (let j = i + 1; j < present.length; j++) {
+      if (present[i][1] !== present[j][1]) {
+        conflicts.push(
+          `${present[i][0]}=${present[i][1]} vs ${present[j][0]}=${present[j][1]}`,
+        )
+      }
+    }
+  }
+
+  return {
+    selected_scenario_id,
+    selected_source,
+    candidates,
+    conflicts,
+  }
+}
+
+/**
+ * Walk the payload trace (most-recent-first per payload-trace-store) and
+ * return the `scenario_id` field of the first V5 CEE turn request body
+ * found. The V5 endpoint is `/orchestrate/v2/turn`; the body shape is
+ * built by `src/v5/buildPayload.ts` and always carries `scenario_id` at
+ * the root.
+ */
+export function extractScenarioIdFromLatestV5Payload(
+  payloads: ReadonlyArray<{
+    service?: string
+    endpoint?: string
+    request?: { body?: unknown }
+  }>,
+): string | null {
+  for (const p of payloads) {
+    const endpoint = typeof p.endpoint === 'string' ? p.endpoint : ''
+    const isV5Turn =
+      p.service === 'CEE' && endpoint.includes('/orchestrate/v2/turn')
+    if (!isV5Turn) continue
+    const body = p.request?.body
+    if (body && typeof body === 'object' && !Array.isArray(body)) {
+      const sid = (body as Record<string, unknown>).scenario_id
+      if (typeof sid === 'string' && sid.length > 0) return sid
+    }
+  }
+  return null
+}
+
+/**
+ * Best-effort URL/route scenario-ID extraction. Looks for:
+ *   - `?scenarioId=...` / `?scenario_id=...` query params
+ *   - `/scenarios/<id>` or `/scenario/<id>` path segments
+ * Returns null on parse failure or absence.
+ */
+export function extractScenarioIdFromUrl(href: string | null): string | null {
+  if (!href) return null
+  try {
+    const url = new URL(href)
+    const fromQuery =
+      url.searchParams.get('scenarioId') ??
+      url.searchParams.get('scenario_id')
+    if (fromQuery && fromQuery.length > 0) return fromQuery
+    const match = url.pathname.match(/\/scenarios?\/([^/?#]+)/i)
+    if (match && match[1] && match[1].length > 0) return match[1]
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read scenario-ID from `full_graph` metadata. Today's
+ * `transformGraphDataEnriched` output uses `_meta` for non-graph fields;
+ * scenarioId may live there or at the root depending on export path.
+ */
+export function extractScenarioIdFromFullGraph(
+  fullGraph: unknown,
+): string | null {
+  if (!fullGraph || typeof fullGraph !== 'object' || Array.isArray(fullGraph)) {
+    return null
+  }
+  const fg = fullGraph as Record<string, unknown>
+
+  const fromMeta = (() => {
+    const meta = fg._meta
+    if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return null
+    const m = meta as Record<string, unknown>
+    const v = m.scenarioId ?? m.scenario_id
+    return typeof v === 'string' && v.length > 0 ? v : null
+  })()
+  if (fromMeta) return fromMeta
+
+  const topLevel = fg.scenarioId ?? fg.scenario_id
+  return typeof topLevel === 'string' && topLevel.length > 0 ? topLevel : null
+}

--- a/src/lib/scientificValidation/__tests__/index.spec.ts
+++ b/src/lib/scientificValidation/__tests__/index.spec.ts
@@ -529,6 +529,47 @@ describe('runScientificValidation — overall_status', () => {
     expect(out.overall_status).toBe('complete')
   })
 
+  it('stabilisation regression: partial when ≥3 derived AND at least one validator returns status=partial (NOT complete) — brief says complete requires no partial/fail results', () => {
+    // Construct a state where multiple validators reach derived/observed
+    // evidence and none `fail` outright, but `response_shape_validation`
+    // returns `partial` because the capture_pipeline_status flags the
+    // source as `hydrated_only` (claim_strength=inferred, status=partial).
+    const out = runScientificValidation(
+      inputs({
+        capturePipelineStatus: 'hydrated_only',
+        plotResponse: {
+          option_comparison: [],
+          factor_sensitivity: [
+            {
+              factor_id: 'f1',
+              confidence: 0.42,
+              evpi_percentage_points: 3,
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_isl_bootstrap',
+                formula_version: 'plot_unified_v3',
+              },
+            },
+          ],
+          m1_coaching: { evidence_gaps: [{ factor_id: 'f1' }] },
+          flip_thresholds: [],
+          flip_thresholds_status: 'all_no_effect',
+          robustness: {},
+          auto_noise_applied: true,
+          auto_noise_provenance: { applied: true },
+        },
+        resultsReport: { summary: 'hydrated' },
+        ceeAnalysisReady: { options: [{ interventions: {} }] },
+      }),
+    )
+    // response_shape_validation will return status=partial (hydrated path)
+    // — overall_status must NOT report 'complete' just because no
+    // validator outright failed.
+    expect(
+      out.validators.response_shape_validation.status,
+    ).toBe('partial')
+    expect(out.overall_status).toBe('partial')
+  })
+
   it('partial when ≥3 derived BUT at least one validator fails', () => {
     const out = runScientificValidation(
       inputs({

--- a/src/lib/scientificValidation/__tests__/index.spec.ts
+++ b/src/lib/scientificValidation/__tests__/index.spec.ts
@@ -499,9 +499,23 @@ describe('runScientificValidation — overall_status', () => {
     expect(out.overall_status).toBe('insufficient_raw_evidence')
   })
 
-  it('complete when ≥3 validators derived/observed AND none fail', () => {
+  it('complete when ALL 7 validators reach pass — including user_std_propagation via captured ISL request', () => {
+    // For `complete` the bundle MUST have ISL request evidence so
+    // user_std_propagation can confirm std propagation. Without it,
+    // the validator reports `unavailable` which now correctly
+    // disqualifies `complete` (per final-acceptance B1).
     const out = runScientificValidation(
       inputs({
+        plotRequest: {
+          graph: {
+            nodes: [
+              { id: 'f1', data: { observed_state: { std: 0.05 } } },
+            ],
+          },
+        },
+        islRequest: {
+          parameter_uncertainties: { f1: { mean: 0.4, std: 0.05 } },
+        },
         plotResponse: {
           option_comparison: [],
           factor_sensitivity: [
@@ -527,6 +541,49 @@ describe('runScientificValidation — overall_status', () => {
     )
     expect(out.source).toBe('live_raw_payloads')
     expect(out.overall_status).toBe('complete')
+    // Sanity: every validator must be at pass status. Otherwise the
+    // strict rule would have downgraded to partial.
+    for (const [name, v] of Object.entries(out.validators)) {
+      expect([name, v.status]).toEqual([name, 'pass'])
+    }
+  })
+
+  it('final-acceptance regression: partial (NOT complete) when ≥3 derived BUT some validators are unavailable — disqualifies complete per the strict honesty rule', () => {
+    // Same fixture as the `complete` test BUT without ISL request.
+    // user_std_propagation now reports unavailable. Per the
+    // final-acceptance B1 rule, ANY unavailable validator disqualifies
+    // 'complete'. The bundle must surface this as `partial` so
+    // reviewers see the missing ISL evidence rather than reading
+    // 'complete' and assuming everything was proven.
+    const out = runScientificValidation(
+      inputs({
+        plotResponse: {
+          option_comparison: [],
+          factor_sensitivity: [
+            {
+              factor_id: 'f1',
+              confidence: 0.42,
+              evpi_percentage_points: 3,
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_isl_bootstrap',
+                formula_version: 'plot_unified_v3',
+              },
+            },
+          ],
+          m1_coaching: { evidence_gaps: [{ factor_id: 'f1' }] },
+          flip_thresholds: [],
+          flip_thresholds_status: 'all_no_effect',
+          robustness: {},
+          auto_noise_applied: true,
+          auto_noise_provenance: { applied: true },
+        },
+        ceeAnalysisReady: { options: [{ interventions: {} }] },
+      }),
+    )
+    // user_std_propagation is unavailable (no ISL request) — must
+    // disqualify complete.
+    expect(out.validators.user_std_propagation.status).toBe('unavailable')
+    expect(out.overall_status).toBe('partial')
   })
 
   it('stabilisation regression: partial when ≥3 derived AND at least one validator returns status=partial (NOT complete) — brief says complete requires no partial/fail results', () => {

--- a/src/lib/scientificValidation/__tests__/index.spec.ts
+++ b/src/lib/scientificValidation/__tests__/index.spec.ts
@@ -1,0 +1,560 @@
+/**
+ * Tests for the scientific-validation orchestrator and seven validators.
+ *
+ * Single combined file (one describe block per validator) to keep
+ * fixture setup local. Covers every brief-required honesty rule:
+ *
+ *   - user_std_propagation emits `unavailable` when ISL request is
+ *     missing and never passes from reconstructed values.
+ *   - confidence_validation detects plot_unified_v3 and old-lattice
+ *     values.
+ *   - evidence_gap_validation flags intervention-target leakage.
+ *   - evpi_validation separates surfaced values from raw diagnostic
+ *     mirrors.
+ *   - flip_threshold_validation uses flip_thresholds_status when
+ *     present; reports unavailable when absent (no inferred pass).
+ *   - auto_noise_validation checks top-level/provenance agreement.
+ *   - hydrated/saved report path is labelled honestly and does not
+ *     pretend raw payloads exist.
+ *   - overall_status = insufficient_raw_evidence when < 3 derived.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  runScientificValidation,
+  type ValidatorInputs,
+} from '../index'
+import { runAutoNoiseValidation } from '../autoNoiseValidation'
+import { runConfidenceValidation } from '../confidenceValidation'
+import { runEvidenceGapValidation } from '../evidenceGapValidation'
+import { runEvpiValidation } from '../evpiValidation'
+import { runFlipThresholdValidation } from '../flipThresholdValidation'
+import { runResponseShapeValidation } from '../responseShapeValidation'
+import { runUserStdPropagation } from '../userStdPropagation'
+import { assertHonestyRules } from '../types'
+
+function inputs(overrides: Partial<ValidatorInputs> = {}): ValidatorInputs {
+  return {
+    plotRequest: null,
+    plotResponse: null,
+    ceeRequest: null,
+    ceeResponse: null,
+    islRequest: null,
+    islResponse: null,
+    resultsReport: null,
+    ceeAnalysisReady: null,
+    capturePipelineStatus: 'complete',
+    ...overrides,
+  }
+}
+
+// ============================================================================
+// user_std_propagation
+// ============================================================================
+
+describe('user_std_propagation', () => {
+  it('emits unavailable when ISL request is missing (the common case)', () => {
+    const result = runUserStdPropagation(
+      inputs({
+        plotRequest: {
+          graph: {
+            nodes: [
+              { id: 'f1', data: { observed_state: { std: 0.05 } } },
+            ],
+          },
+        },
+      }),
+    )
+    expect(result.status).toBe('unavailable')
+    expect(result.claim_strength).toBe('unavailable')
+    expect(result.required_upstream_support).toContain('plot.debug.isl_request')
+  })
+
+  it('never pairs status="pass" with claim_strength="inferred" — assertHonestyRules guard', () => {
+    // Hypothetical caller bug: returning inferred + pass. The guard must downgrade.
+    const downgraded = assertHonestyRules({
+      status: 'pass',
+      claim_strength: 'inferred',
+      source_paths: [],
+      limitations: [],
+      required_upstream_support: [],
+      details: {},
+    })
+    expect(downgraded.status).toBe('partial')
+    expect(downgraded.limitations[0]).toMatch(/inferred/)
+  })
+
+  it('includes expected_from_plot_request as inferred reference (not used as proof)', () => {
+    const result = runUserStdPropagation(
+      inputs({
+        plotRequest: {
+          graph: {
+            nodes: [
+              { id: 'f1', data: { observed_state: { std: 0.05 } } },
+              { id: 'f2', data: { observed_state: { std: 0.12 } } },
+            ],
+          },
+        },
+      }),
+    )
+    expect(result.details.expected_from_plot_request).toEqual([
+      { factor_id: 'f1', std: 0.05, source: expect.any(String) },
+      { factor_id: 'f2', std: 0.12, source: expect.any(String) },
+    ])
+    expect(result.status).toBe('unavailable') // not 'pass'
+  })
+
+  it('passes when ISL request is captured AND std matches PLoT request user input', () => {
+    const result = runUserStdPropagation(
+      inputs({
+        plotRequest: {
+          graph: {
+            nodes: [{ id: 'f1', data: { observed_state: { std: 0.05 } } }],
+          },
+        },
+        islRequest: {
+          parameter_uncertainties: { f1: { mean: 0.4, std: 0.05 } },
+        },
+      }),
+    )
+    expect(result.status).toBe('pass')
+    expect(result.claim_strength).toBe('derived')
+  })
+
+  it('flags widened ISL std as fail', () => {
+    const result = runUserStdPropagation(
+      inputs({
+        plotRequest: {
+          graph: {
+            nodes: [{ id: 'f1', data: { observed_state: { std: 0.05 } } }],
+          },
+        },
+        islRequest: {
+          parameter_uncertainties: { f1: { mean: 0.4, std: 0.10 } },
+        },
+      }),
+    )
+    expect(result.status).toBe('fail')
+    expect(result.claim_strength).toBe('derived')
+  })
+})
+
+// ============================================================================
+// confidence_validation
+// ============================================================================
+
+describe('confidence_validation', () => {
+  it('returns unavailable when factor_sensitivity is missing', () => {
+    expect(runConfidenceValidation(inputs()).status).toBe('unavailable')
+    expect(
+      runConfidenceValidation(inputs({ plotResponse: { factor_sensitivity: [] } })).status,
+    ).toBe('unavailable')
+  })
+
+  it('returns unavailable when no factor carries confidence_provenance', () => {
+    const result = runConfidenceValidation(
+      inputs({
+        plotResponse: {
+          factor_sensitivity: [
+            { factor_id: 'f1', confidence: 0.5 },
+          ],
+        },
+      }),
+    )
+    expect(result.status).toBe('unavailable')
+    expect(result.required_upstream_support).toContain(
+      'plot.response.factor_sensitivity[*].confidence_provenance',
+    )
+  })
+
+  it('detects plot_unified_v3 formula version and passes', () => {
+    const result = runConfidenceValidation(
+      inputs({
+        plotResponse: {
+          factor_sensitivity: [
+            {
+              factor_id: 'f1',
+              confidence: 0.42,
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_isl_bootstrap',
+                formula_version: 'plot_unified_v3',
+              },
+            },
+            {
+              factor_id: 'f2',
+              confidence: 0.81,
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_isl_bootstrap',
+                formula_version: 'plot_unified_v3',
+              },
+            },
+          ],
+        },
+      }),
+    )
+    expect(result.status).toBe('pass')
+    expect(result.claim_strength).toBe('derived')
+    expect(result.details.v3_plus_count).toBe(2)
+  })
+
+  it('flags old-lattice values (0.25/0.375/0.5/0.625/0.75) — partial when present with v3+', () => {
+    const result = runConfidenceValidation(
+      inputs({
+        plotResponse: {
+          factor_sensitivity: [
+            {
+              factor_id: 'f1',
+              confidence: 0.375,
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_graph',
+                formula_version: 'plot_unified_v3',
+              },
+            },
+          ],
+        },
+      }),
+    )
+    expect(result.status).toBe('partial')
+    expect(result.details.old_lattice_match_count).toBe(1)
+  })
+
+  it('fails when only old-lattice values present with v1/v2 provenance', () => {
+    const result = runConfidenceValidation(
+      inputs({
+        plotResponse: {
+          factor_sensitivity: [
+            {
+              factor_id: 'f1',
+              confidence: 0.5,
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_graph',
+                formula_version: 'plot_unified_v2',
+              },
+            },
+          ],
+        },
+      }),
+    )
+    expect(result.status).toBe('fail')
+  })
+})
+
+// ============================================================================
+// evidence_gap_validation
+// ============================================================================
+
+describe('evidence_gap_validation', () => {
+  it('returns unavailable when m1_coaching.evidence_gaps absent', () => {
+    expect(runEvidenceGapValidation(inputs()).status).toBe('unavailable')
+  })
+
+  it('passes when evidence gaps exist and none match intervention levers', () => {
+    const result = runEvidenceGapValidation(
+      inputs({
+        plotResponse: {
+          m1_coaching: {
+            evidence_gaps: [{ factor_id: 'f1', factor_label: 'Cost' }],
+          },
+        },
+        ceeAnalysisReady: {
+          options: [{ interventions: { lever_a: { value: 1 } } }],
+        },
+      }),
+    )
+    expect(result.status).toBe('pass')
+    expect(result.details.intervention_leakage_count).toBe(0)
+  })
+
+  it('flags intervention-target leakage (PR #166 regression detector)', () => {
+    const result = runEvidenceGapValidation(
+      inputs({
+        plotResponse: {
+          m1_coaching: {
+            evidence_gaps: [{ factor_id: 'lever_a', factor_label: 'A' }],
+          },
+        },
+        ceeAnalysisReady: {
+          options: [{ interventions: { lever_a: { value: 1 } } }],
+        },
+      }),
+    )
+    expect(result.status).toBe('partial')
+    expect(result.details.intervention_leakage_count).toBe(1)
+  })
+
+  it('handles array-shape interventions (alternate canvas store shape)', () => {
+    const result = runEvidenceGapValidation(
+      inputs({
+        plotResponse: {
+          m1_coaching: {
+            evidence_gaps: [{ factor_id: 'lever_z' }],
+          },
+        },
+        ceeAnalysisReady: {
+          options: [{ interventions: [{ factor_id: 'lever_z', value: 0.5 }] }],
+        },
+      }),
+    )
+    expect(result.details.intervention_lever_count).toBe(1)
+    expect(result.details.intervention_leakage_count).toBe(1)
+  })
+})
+
+// ============================================================================
+// evpi_validation
+// ============================================================================
+
+describe('evpi_validation', () => {
+  it('separates surfaced (evpi_percentage_points) from raw (value_of_information)', () => {
+    const result = runEvpiValidation(
+      inputs({
+        plotResponse: {
+          factor_sensitivity: [
+            { factor_id: 'f1', evpi_percentage_points: 5, value_of_information: 0.05 },
+            { factor_id: 'f2', evpi_percentage_points: 2, value_of_information: -0.01 },
+          ],
+        },
+      }),
+    )
+    expect(result.details.surfaced).toMatchObject({ count: 2, min: 2, max: 5, negative_count: 0 })
+    expect(result.details.raw_diagnostic).toMatchObject({ negative_count: 1 })
+    expect(result.status).toBe('pass') // surfaced has no negatives
+  })
+
+  it('fails when SURFACED EVPI has negative values', () => {
+    const result = runEvpiValidation(
+      inputs({
+        plotResponse: {
+          factor_sensitivity: [
+            { factor_id: 'f1', evpi_percentage_points: -2 },
+          ],
+        },
+      }),
+    )
+    expect(result.status).toBe('fail')
+  })
+
+  it('returns unavailable when neither field is present', () => {
+    expect(
+      runEvpiValidation(inputs({ plotResponse: { factor_sensitivity: [{ factor_id: 'f1' }] } })).status,
+    ).toBe('unavailable')
+  })
+})
+
+// ============================================================================
+// flip_threshold_validation
+// ============================================================================
+
+describe('flip_threshold_validation', () => {
+  it('passes when flip_thresholds_status is present (PR #167 upstream)', () => {
+    const result = runFlipThresholdValidation(
+      inputs({
+        plotResponse: {
+          flip_thresholds_status: 'all_no_effect',
+          flip_thresholds: [{ factor_id: 'f1', flip_reason: 'no_effect' }],
+        },
+      }),
+    )
+    expect(result.status).toBe('pass')
+    expect(result.claim_strength).toBe('derived')
+    expect(result.details.flip_thresholds_status).toBe('all_no_effect')
+  })
+
+  it('returns unavailable when flip_thresholds_status is absent — never infers a pass', () => {
+    const result = runFlipThresholdValidation(
+      inputs({
+        plotResponse: {
+          flip_thresholds: [{ factor_id: 'f1', flip_value: 0.5 }],
+        },
+      }),
+    )
+    expect(result.status).toBe('unavailable')
+    expect(result.claim_strength).toBe('unavailable')
+    expect(result.required_upstream_support).toContain('plot.response.flip_thresholds_status')
+    // Inferred buckets are reported as advisory only
+    expect(result.details.inferred_buckets).toMatchObject({ found: 1 })
+  })
+})
+
+// ============================================================================
+// auto_noise_validation
+// ============================================================================
+
+describe('auto_noise_validation', () => {
+  it('passes when top-level and provenance.applied agree', () => {
+    const result = runAutoNoiseValidation(
+      inputs({
+        plotResponse: {
+          auto_noise_applied: true,
+          auto_noise_provenance: { applied: true, formula_version: 'v2' },
+        },
+      }),
+    )
+    expect(result.status).toBe('pass')
+    expect(result.details.agreement).toBe(true)
+  })
+
+  it('fails when top-level and provenance.applied disagree', () => {
+    const result = runAutoNoiseValidation(
+      inputs({
+        plotResponse: {
+          auto_noise_applied: true,
+          auto_noise_provenance: { applied: false },
+        },
+      }),
+    )
+    expect(result.status).toBe('fail')
+    expect(result.details.agreement).toBe(false)
+  })
+
+  it('returns unavailable when neither field is present', () => {
+    expect(
+      runAutoNoiseValidation(inputs({ plotResponse: {} })).status,
+    ).toBe('unavailable')
+  })
+})
+
+// ============================================================================
+// response_shape_validation
+// ============================================================================
+
+describe('response_shape_validation', () => {
+  it('marks source live when capture_pipeline_status is complete', () => {
+    const result = runResponseShapeValidation(
+      inputs({
+        plotResponse: {
+          option_comparison: [],
+          factor_sensitivity: [],
+          m1_coaching: {},
+          flip_thresholds: [],
+          robustness: {},
+        },
+      }),
+    )
+    expect(result.details.source).toBe('live')
+    expect(result.claim_strength).toBe('observed')
+    expect(result.status).toBe('pass')
+  })
+
+  it('marks source hydrated when capture_pipeline_status is hydrated_only (does NOT pretend live)', () => {
+    const result = runResponseShapeValidation(
+      inputs({
+        plotResponse: { option_comparison: [] },
+        capturePipelineStatus: 'hydrated_only',
+      }),
+    )
+    expect(result.details.source).toBe('hydrated')
+    expect(result.claim_strength).toBe('inferred')
+    expect(result.status).toBe('partial') // never 'pass' with inferred
+  })
+
+  it('marks source fallback when capture_pipeline_status is results_rendered_from_store_without_capture', () => {
+    const result = runResponseShapeValidation(
+      inputs({
+        plotResponse: null,
+        capturePipelineStatus: 'results_rendered_from_store_without_capture',
+      }),
+    )
+    expect(result.details.source).toBe('fallback')
+    expect(result.claim_strength).toBe('inferred')
+  })
+
+  it('marks source unavailable when capture_pipeline_status is capture_missing', () => {
+    const result = runResponseShapeValidation(
+      inputs({
+        plotResponse: null,
+        capturePipelineStatus: 'capture_missing',
+      }),
+    )
+    expect(result.details.source).toBe('unavailable')
+    expect(result.status).toBe('unavailable')
+  })
+})
+
+// ============================================================================
+// orchestrator — overall_status
+// ============================================================================
+
+describe('runScientificValidation — overall_status', () => {
+  it('emits unavailable when no PLoT response key is present', () => {
+    const out = runScientificValidation(inputs({ plotResponse: null, capturePipelineStatus: 'capture_missing' }))
+    expect(out.source).toBe('unavailable')
+    expect(out.overall_status).toBe('unavailable')
+  })
+
+  it('insufficient_raw_evidence when fewer than 3 validators have observed/derived evidence', () => {
+    const out = runScientificValidation(
+      inputs({
+        plotResponse: {
+          factor_sensitivity: [
+            { factor_id: 'f1', evpi_percentage_points: 3 },
+          ],
+        },
+      }),
+    )
+    // evpi_validation = derived; response_shape_validation = observed.
+    // Others = unavailable. Two derived/observed → insufficient_raw_evidence.
+    expect(out.source).toBe('live_raw_payloads')
+    expect(out.overall_status).toBe('insufficient_raw_evidence')
+  })
+
+  it('complete when ≥3 validators derived/observed AND none fail', () => {
+    const out = runScientificValidation(
+      inputs({
+        plotResponse: {
+          option_comparison: [],
+          factor_sensitivity: [
+            {
+              factor_id: 'f1',
+              confidence: 0.42,
+              evpi_percentage_points: 3,
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_isl_bootstrap',
+                formula_version: 'plot_unified_v3',
+              },
+            },
+          ],
+          m1_coaching: { evidence_gaps: [{ factor_id: 'f1' }] },
+          flip_thresholds: [],
+          flip_thresholds_status: 'all_no_effect',
+          robustness: {},
+          auto_noise_applied: true,
+          auto_noise_provenance: { applied: true },
+        },
+        ceeAnalysisReady: { options: [{ interventions: {} }] },
+      }),
+    )
+    expect(out.source).toBe('live_raw_payloads')
+    expect(out.overall_status).toBe('complete')
+  })
+
+  it('partial when ≥3 derived BUT at least one validator fails', () => {
+    const out = runScientificValidation(
+      inputs({
+        plotResponse: {
+          option_comparison: [],
+          factor_sensitivity: [
+            {
+              factor_id: 'f1',
+              confidence: 0.5,
+              evpi_percentage_points: -2, // surfaced negative → evpi_validation fails
+              confidence_provenance: {
+                computation_source: 'plot_unified_from_graph',
+                formula_version: 'plot_unified_v3',
+              },
+            },
+          ],
+          m1_coaching: { evidence_gaps: [{ factor_id: 'f1' }] },
+          flip_thresholds: [],
+          flip_thresholds_status: 'all_no_effect',
+          robustness: {},
+          auto_noise_applied: true,
+          auto_noise_provenance: { applied: true },
+        },
+        ceeAnalysisReady: { options: [] },
+      }),
+    )
+    expect(out.overall_status).toBe('partial')
+  })
+})

--- a/src/lib/scientificValidation/autoNoiseValidation.ts
+++ b/src/lib/scientificValidation/autoNoiseValidation.ts
@@ -1,0 +1,78 @@
+/**
+ * auto_noise_validation — checks top-level `auto_noise_applied` and
+ * `auto_noise_provenance.applied` for agreement. A disagreement means
+ * the reported applied state differs from the provenance record —
+ * likely a bug or stale field.
+ */
+
+import { assertHonestyRules, type ValidatorInputs, type ValidatorResult } from './types'
+
+export function runAutoNoiseValidation(inputs: ValidatorInputs): ValidatorResult {
+  if (
+    !inputs.plotResponse ||
+    typeof inputs.plotResponse !== 'object' ||
+    Array.isArray(inputs.plotResponse)
+  ) {
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: [],
+      limitations: ['PLoT response missing.'],
+      required_upstream_support: ['plot.response.auto_noise_applied', 'plot.response.auto_noise_provenance'],
+      details: {},
+    })
+  }
+
+  const pr = inputs.plotResponse as Record<string, unknown>
+  const applied_top = pr.auto_noise_applied
+  const prov = pr.auto_noise_provenance
+
+  if (applied_top === undefined && prov === undefined) {
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: [],
+      limitations: ['Neither auto_noise_applied nor auto_noise_provenance is present.'],
+      required_upstream_support: ['plot.response.auto_noise_applied', 'plot.response.auto_noise_provenance'],
+      details: {},
+    })
+  }
+
+  const applied_top_bool =
+    typeof applied_top === 'boolean' ? applied_top : null
+  const applied_prov =
+    prov && typeof prov === 'object' && !Array.isArray(prov)
+      ? (typeof (prov as Record<string, unknown>).applied === 'boolean'
+          ? ((prov as Record<string, unknown>).applied as boolean)
+          : null)
+      : null
+
+  const agreement =
+    applied_top_bool !== null && applied_prov !== null
+      ? applied_top_bool === applied_prov
+      : null
+
+  const status: ValidatorResult['status'] =
+    agreement === null ? 'partial' : agreement ? 'pass' : 'fail'
+
+  const limitations: string[] = []
+  if (applied_top_bool === null) limitations.push('auto_noise_applied not a boolean.')
+  if (applied_prov === null) limitations.push('auto_noise_provenance.applied not a boolean.')
+
+  return assertHonestyRules({
+    status,
+    claim_strength: 'derived',
+    source_paths: [
+      'payloads.plot_response.auto_noise_applied',
+      'payloads.plot_response.auto_noise_provenance',
+    ],
+    limitations,
+    required_upstream_support: [],
+    details: {
+      auto_noise_applied_top_level: applied_top_bool,
+      auto_noise_applied_provenance: applied_prov,
+      agreement,
+      provenance: prov ?? null,
+    },
+  })
+}

--- a/src/lib/scientificValidation/confidenceValidation.ts
+++ b/src/lib/scientificValidation/confidenceValidation.ts
@@ -1,0 +1,146 @@
+/**
+ * confidence_validation — verifies factor confidence is sourced from
+ * the `plot_unified_v3+` pipeline (PR #170). Detects:
+ *   - presence of `confidence_provenance.computation_source` and
+ *     `formula_version`;
+ *   - whether values match the old discrete lattice
+ *     `{0.25, 0.375, 0.5, 0.625, 0.75}`;
+ *   - distinct confidence count (continuous bootstrap should show many).
+ */
+
+import { assertHonestyRules, type ValidatorInputs, type ValidatorResult } from './types'
+
+const OLD_LATTICE = new Set([0.25, 0.375, 0.5, 0.625, 0.75])
+const PROVENANCE_REGEX = /^plot_unified_v(\d+)$/
+
+interface FactorRow {
+  factor_id: string | null
+  confidence: number | null
+  confidence_source: string | null
+  computation_source: string | null
+  formula_version: string | null
+  formula_version_number: number | null
+  confidence_components: Record<string, unknown> | null
+  old_lattice_match: boolean
+}
+
+function readFactorRow(entry: unknown): FactorRow | null {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
+  const e = entry as Record<string, unknown>
+  const factor_id =
+    typeof e.factor_id === 'string'
+      ? e.factor_id
+      : typeof e.id === 'string'
+      ? e.id
+      : null
+  const confidence = typeof e.confidence === 'number' ? e.confidence : null
+  const confidence_source =
+    typeof e.confidence_source === 'string' ? e.confidence_source : null
+
+  const prov = e.confidence_provenance
+  const provObj =
+    prov && typeof prov === 'object' && !Array.isArray(prov)
+      ? (prov as Record<string, unknown>)
+      : null
+  const computation_source =
+    provObj && typeof provObj.computation_source === 'string'
+      ? (provObj.computation_source as string)
+      : null
+  const formula_version =
+    provObj && typeof provObj.formula_version === 'string'
+      ? (provObj.formula_version as string)
+      : null
+  const formula_match = formula_version ? PROVENANCE_REGEX.exec(formula_version) : null
+  const formula_version_number = formula_match ? Number(formula_match[1]) : null
+
+  const components_raw = provObj?.confidence_components
+  const confidence_components =
+    components_raw && typeof components_raw === 'object' && !Array.isArray(components_raw)
+      ? (components_raw as Record<string, unknown>)
+      : null
+
+  return {
+    factor_id,
+    confidence,
+    confidence_source,
+    computation_source,
+    formula_version,
+    formula_version_number,
+    confidence_components,
+    old_lattice_match: confidence !== null && OLD_LATTICE.has(confidence),
+  }
+}
+
+export function runConfidenceValidation(inputs: ValidatorInputs): ValidatorResult {
+  const response = inputs.plotResponse
+  if (!response || typeof response !== 'object' || Array.isArray(response)) {
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: [],
+      limitations: ['PLoT response not captured in bundle.payloads.plot_response.'],
+      required_upstream_support: ['plot.response.factor_sensitivity'],
+      details: {},
+    })
+  }
+  const fs = (response as Record<string, unknown>).factor_sensitivity
+  if (!Array.isArray(fs) || fs.length === 0) {
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: ['payloads.plot_response.factor_sensitivity'],
+      limitations: ['factor_sensitivity missing or empty in PLoT response.'],
+      required_upstream_support: ['plot.response.factor_sensitivity'],
+      details: {},
+    })
+  }
+
+  const rows = fs.map(readFactorRow).filter((r): r is FactorRow => r !== null)
+  const provenance_present_count = rows.filter((r) => r.computation_source !== null).length
+  const v3_plus_count = rows.filter(
+    (r) => r.formula_version_number !== null && r.formula_version_number >= 3,
+  ).length
+  const old_lattice_match_count = rows.filter((r) => r.old_lattice_match).length
+  const distinct_confidence_count = new Set(
+    rows.map((r) => (r.confidence === null ? null : r.confidence)),
+  ).size
+
+  let status: ValidatorResult['status']
+  if (provenance_present_count === 0) {
+    status = 'unavailable'
+  } else if (v3_plus_count > 0 && old_lattice_match_count === 0) {
+    status = 'pass'
+  } else if (v3_plus_count > 0) {
+    status = 'partial'
+  } else {
+    status = 'fail'
+  }
+
+  const claim_strength: ValidatorResult['claim_strength'] =
+    status === 'unavailable' ? 'unavailable' : 'derived'
+
+  return assertHonestyRules({
+    status,
+    claim_strength,
+    source_paths: [
+      'payloads.plot_response.factor_sensitivity',
+      'payloads.plot_response.factor_sensitivity[*].confidence_provenance',
+    ],
+    limitations:
+      provenance_present_count === 0
+        ? ['No factor carries confidence_provenance — PR #170 work has not propagated yet.']
+        : [],
+    required_upstream_support:
+      provenance_present_count === 0
+        ? ['plot.response.factor_sensitivity[*].confidence_provenance']
+        : [],
+    details: {
+      factor_count: rows.length,
+      provenance_present_count,
+      v3_plus_count,
+      old_lattice_match_count,
+      distinct_confidence_count,
+      factors: rows,
+    },
+  })
+}

--- a/src/lib/scientificValidation/evidenceGapValidation.ts
+++ b/src/lib/scientificValidation/evidenceGapValidation.ts
@@ -1,0 +1,111 @@
+/**
+ * evidence_gap_validation — verifies PR #166: evidence gaps are sourced
+ * from enriched PLoT factor_sensitivity and EXCLUDE intervention levers.
+ *
+ * Reads:
+ *   - `bundle.payloads.plot_response.m1_coaching.evidence_gaps[]`
+ *   - canvas store `ceeAnalysisReady.options[*].interventions` keys
+ *
+ * Flags any evidence gap whose factor_id matches an intervention lever.
+ */
+
+import { assertHonestyRules, type ValidatorInputs, type ValidatorResult } from './types'
+
+function readEvidenceGaps(plotResponse: unknown): unknown[] {
+  if (!plotResponse || typeof plotResponse !== 'object' || Array.isArray(plotResponse)) return []
+  const coaching = (plotResponse as Record<string, unknown>).m1_coaching
+  if (!coaching || typeof coaching !== 'object' || Array.isArray(coaching)) return []
+  const gaps = (coaching as Record<string, unknown>).evidence_gaps
+  return Array.isArray(gaps) ? gaps : []
+}
+
+function readInterventionLevers(ceeAnalysisReady: unknown): Set<string> {
+  const out = new Set<string>()
+  if (!ceeAnalysisReady || typeof ceeAnalysisReady !== 'object' || Array.isArray(ceeAnalysisReady)) {
+    return out
+  }
+  const options = (ceeAnalysisReady as Record<string, unknown>).options
+  if (!Array.isArray(options)) return out
+  for (const opt of options) {
+    if (!opt || typeof opt !== 'object' || Array.isArray(opt)) continue
+    const interventions = (opt as Record<string, unknown>).interventions
+    if (interventions && typeof interventions === 'object' && !Array.isArray(interventions)) {
+      for (const k of Object.keys(interventions as Record<string, unknown>)) out.add(k)
+    }
+    // Handle alternate shape: array of {factor_id, value}
+    if (Array.isArray(interventions)) {
+      for (const item of interventions) {
+        if (item && typeof item === 'object' && !Array.isArray(item)) {
+          const id = (item as Record<string, unknown>).factor_id ?? (item as Record<string, unknown>).target_node_id
+          if (typeof id === 'string') out.add(id)
+        }
+      }
+    }
+  }
+  return out
+}
+
+interface FlaggedGap {
+  factor_id: string
+  factor_label: string | null
+  is_intervention_lever: boolean
+}
+
+export function runEvidenceGapValidation(inputs: ValidatorInputs): ValidatorResult {
+  const gaps = readEvidenceGaps(inputs.plotResponse)
+  if (gaps.length === 0) {
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: ['payloads.plot_response.m1_coaching.evidence_gaps'],
+      limitations: ['m1_coaching.evidence_gaps absent or empty in PLoT response.'],
+      required_upstream_support: ['plot.response.m1_coaching.evidence_gaps'],
+      details: {},
+    })
+  }
+
+  const levers = readInterventionLevers(inputs.ceeAnalysisReady)
+  const flagged: FlaggedGap[] = []
+  for (const g of gaps) {
+    if (!g || typeof g !== 'object' || Array.isArray(g)) continue
+    const obj = g as Record<string, unknown>
+    const factor_id =
+      typeof obj.factor_id === 'string'
+        ? obj.factor_id
+        : typeof obj.target_node_id === 'string'
+        ? obj.target_node_id
+        : null
+    if (!factor_id) continue
+    const factor_label =
+      typeof obj.factor_label === 'string' ? obj.factor_label : null
+    flagged.push({
+      factor_id,
+      factor_label,
+      is_intervention_lever: levers.has(factor_id),
+    })
+  }
+
+  const leakage_count = flagged.filter((f) => f.is_intervention_lever).length
+  const status: ValidatorResult['status'] =
+    leakage_count === 0 ? 'pass' : 'partial'
+
+  return assertHonestyRules({
+    status,
+    claim_strength: 'derived',
+    source_paths: [
+      'payloads.plot_response.m1_coaching.evidence_gaps',
+      'canvas.ceeAnalysisReady.options[*].interventions',
+    ],
+    limitations:
+      levers.size === 0
+        ? ['No intervention levers known — cannot prove exclusion from evidence gaps.']
+        : [],
+    required_upstream_support: [],
+    details: {
+      evidence_gap_count: gaps.length,
+      intervention_lever_count: levers.size,
+      intervention_leakage_count: leakage_count,
+      flagged_gaps: flagged,
+    },
+  })
+}

--- a/src/lib/scientificValidation/evpiValidation.ts
+++ b/src/lib/scientificValidation/evpiValidation.ts
@@ -1,0 +1,100 @@
+/**
+ * evpi_validation — separates user-facing EVPI percentage-point values
+ * from raw diagnostic mirrors and surfaces min/max/negative counts.
+ *
+ * Sources:
+ *   - `bundle.payloads.plot_response.factor_sensitivity[*].evpi_percentage_points`
+ *     (surfaced, user-facing)
+ *   - `bundle.payloads.plot_response.factor_sensitivity[*].value_of_information`
+ *     (raw diagnostic mirror; may legitimately be negative)
+ */
+
+import { assertHonestyRules, type ValidatorInputs, type ValidatorResult } from './types'
+
+interface Stats {
+  count: number
+  min: number | null
+  max: number | null
+  negative_count: number
+}
+
+function summariseNumbers(values: ReadonlyArray<number>): Stats {
+  if (values.length === 0) {
+    return { count: 0, min: null, max: null, negative_count: 0 }
+  }
+  let min = values[0]
+  let max = values[0]
+  let neg = 0
+  for (const v of values) {
+    if (v < min) min = v
+    if (v > max) max = v
+    if (v < 0) neg++
+  }
+  return { count: values.length, min, max, negative_count: neg }
+}
+
+function extractFromFactorSensitivity(plotResponse: unknown): {
+  surfaced: number[]
+  raw: number[]
+} {
+  if (!plotResponse || typeof plotResponse !== 'object' || Array.isArray(plotResponse)) {
+    return { surfaced: [], raw: [] }
+  }
+  const fs = (plotResponse as Record<string, unknown>).factor_sensitivity
+  if (!Array.isArray(fs)) return { surfaced: [], raw: [] }
+  const surfaced: number[] = []
+  const raw: number[] = []
+  for (const entry of fs) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+    const e = entry as Record<string, unknown>
+    if (typeof e.evpi_percentage_points === 'number') surfaced.push(e.evpi_percentage_points)
+    if (typeof e.value_of_information === 'number') raw.push(e.value_of_information)
+  }
+  return { surfaced, raw }
+}
+
+export function runEvpiValidation(inputs: ValidatorInputs): ValidatorResult {
+  const { surfaced, raw } = extractFromFactorSensitivity(inputs.plotResponse)
+  if (surfaced.length === 0 && raw.length === 0) {
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: [
+        'payloads.plot_response.factor_sensitivity[*].evpi_percentage_points',
+        'payloads.plot_response.factor_sensitivity[*].value_of_information',
+      ],
+      limitations: ['No EVPI / value_of_information values found in PLoT response.'],
+      required_upstream_support: [
+        'plot.response.factor_sensitivity[*].evpi_percentage_points',
+      ],
+      details: {},
+    })
+  }
+
+  const surfacedStats = summariseNumbers(surfaced)
+  const rawStats = summariseNumbers(raw)
+
+  // Surfaced (user-facing) negatives are the main concern: they would
+  // mean the UI shows negative EVPI to a user. Negatives in raw
+  // diagnostic mirrors are expected and not a fail signal.
+  const status: ValidatorResult['status'] =
+    surfacedStats.negative_count > 0 ? 'fail' : 'pass'
+
+  return assertHonestyRules({
+    status,
+    claim_strength: 'derived',
+    source_paths: [
+      'payloads.plot_response.factor_sensitivity[*].evpi_percentage_points',
+      'payloads.plot_response.factor_sensitivity[*].value_of_information',
+    ],
+    limitations:
+      surfacedStats.count === 0
+        ? ['Only raw diagnostic EVPI is present (no surfaced values).']
+        : [],
+    required_upstream_support: [],
+    details: {
+      surfaced: surfacedStats,
+      raw_diagnostic: rawStats,
+    },
+  })
+}

--- a/src/lib/scientificValidation/flipThresholdValidation.ts
+++ b/src/lib/scientificValidation/flipThresholdValidation.ts
@@ -1,0 +1,93 @@
+/**
+ * flip_threshold_validation — validates PR #167 surface:
+ *   - if `bundle.payloads.plot_response.flip_thresholds_status` is
+ *     present, classify directly (`derived`);
+ *   - if absent, emit `unavailable` with explicit upstream support
+ *     requirement. Do NOT infer `_status` from `flip_value` presence as
+ *     proof — that's `inferred` evidence and cannot pair with pass.
+ */
+
+import { assertHonestyRules, type ValidatorInputs, type ValidatorResult } from './types'
+
+interface FlipBuckets {
+  found: number
+  no_effect: number
+  unresolved: number
+  unavailable: number
+}
+
+function bucketFlipThresholds(entries: unknown): FlipBuckets {
+  const out: FlipBuckets = { found: 0, no_effect: 0, unresolved: 0, unavailable: 0 }
+  if (!Array.isArray(entries)) return out
+  for (const e of entries) {
+    if (!e || typeof e !== 'object' || Array.isArray(e)) continue
+    const flip_value = (e as Record<string, unknown>).flip_value
+    const flip_reason = (e as Record<string, unknown>).flip_reason
+    if (typeof flip_value === 'number' && Number.isFinite(flip_value)) {
+      out.found++
+    } else if (flip_reason === 'no_effect' || flip_reason === 'no_bracket') {
+      out.no_effect++
+    } else if (flip_reason === 'unresolved' || flip_reason === 'not_resolved') {
+      out.unresolved++
+    } else {
+      out.unavailable++
+    }
+  }
+  return out
+}
+
+export function runFlipThresholdValidation(inputs: ValidatorInputs): ValidatorResult {
+  if (
+    !inputs.plotResponse ||
+    typeof inputs.plotResponse !== 'object' ||
+    Array.isArray(inputs.plotResponse)
+  ) {
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: [],
+      limitations: ['PLoT response missing.'],
+      required_upstream_support: ['plot.response.flip_thresholds_status'],
+      details: {},
+    })
+  }
+
+  const pr = inputs.plotResponse as Record<string, unknown>
+  const status_field = pr.flip_thresholds_status
+  const thresholds = pr.flip_thresholds
+
+  if (status_field !== undefined && status_field !== null) {
+    // PR #167 upstream emit available — derived directly.
+    const buckets = bucketFlipThresholds(thresholds)
+    return assertHonestyRules({
+      status: 'pass',
+      claim_strength: 'derived',
+      source_paths: [
+        'payloads.plot_response.flip_thresholds_status',
+        'payloads.plot_response.flip_thresholds',
+      ],
+      limitations: [],
+      required_upstream_support: [],
+      details: {
+        flip_thresholds_status: status_field,
+        buckets,
+      },
+    })
+  }
+
+  // Status field absent — emit unavailable. Do NOT promote inferred buckets
+  // to a pass.
+  return assertHonestyRules({
+    status: 'unavailable',
+    claim_strength: 'unavailable',
+    source_paths: thresholds ? ['payloads.plot_response.flip_thresholds'] : [],
+    limitations: [
+      'flip_thresholds_status is not yet emitted by PLoT (PR #167 work in flight). ' +
+        'Bucket counts from flip_value presence are provided as inferred evidence only.',
+    ],
+    required_upstream_support: ['plot.response.flip_thresholds_status'],
+    details: {
+      inferred_buckets: bucketFlipThresholds(thresholds),
+    },
+  })
+}

--- a/src/lib/scientificValidation/index.ts
+++ b/src/lib/scientificValidation/index.ts
@@ -85,17 +85,20 @@ function classifyOverall(
     (v) => v.claim_strength === 'observed' || v.claim_strength === 'derived',
   ).length
   const failCount = Object.values(validators).filter((v) => v.status === 'fail').length
-  // Stabilisation fix: per the brief, `complete` requires "no
-  // `partial`/`fail` results". The previous code only checked
-  // `fail`, letting a `partial` validator (e.g. a hydrated
-  // response_shape_validation that downgrades pass→partial via
-  // assertHonestyRules) still surface as `overall_status: complete`.
-  // Both states now disqualify `complete`.
   const partialCount = Object.values(validators).filter(
     (v) => v.status === 'partial',
   ).length
+  // Final acceptance honesty rule: `complete` is impossible if ANY
+  // validator is partial, fail, OR unavailable. The bundle must not
+  // claim a complete picture when some evidence couldn't be reached
+  // (e.g. user_std_propagation reports `unavailable` until DGAI
+  // captures the ISL request). Each unreachable validator is a real
+  // gap; surface it via `partial` so reviewers see the cost.
+  const unavailableCount = Object.values(validators).filter(
+    (v) => v.status === 'unavailable',
+  ).length
   if (derivedCount < 3) return 'insufficient_raw_evidence'
-  if (failCount > 0 || partialCount > 0) return 'partial'
+  if (failCount > 0 || partialCount > 0 || unavailableCount > 0) return 'partial'
   return 'complete'
 }
 

--- a/src/lib/scientificValidation/index.ts
+++ b/src/lib/scientificValidation/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Scientific validation orchestrator.
+ *
+ * Runs the seven validators and emits the bundle's
+ * `scientific_validation` section. Pure function over a slim
+ * `ValidatorInputs` shape; tests can drive it without React/Zustand.
+ *
+ * Overall status rules (from the brief):
+ *   - complete                     — ≥3 validators with claim_strength
+ *                                    ∈ {observed, derived} AND no
+ *                                    `partial`/`fail` results
+ *   - partial                      — some derived but < 3 total
+ *   - insufficient_raw_evidence    — < 3 validators with observed/derived
+ *                                    evidence
+ *   - unavailable                  — no live raw payloads at all
+ *
+ * Order matters less than honesty: the goal is "do not overclaim".
+ */
+
+import { runAutoNoiseValidation } from './autoNoiseValidation'
+import { runConfidenceValidation } from './confidenceValidation'
+import { runEvidenceGapValidation } from './evidenceGapValidation'
+import { runEvpiValidation } from './evpiValidation'
+import { runFlipThresholdValidation } from './flipThresholdValidation'
+import { runResponseShapeValidation } from './responseShapeValidation'
+import { runUserStdPropagation } from './userStdPropagation'
+import type {
+  ScientificValidation,
+  ScientificValidationOverallStatus,
+  ValidatorInputs,
+  ValidatorName,
+  ValidatorResult,
+} from './types'
+
+export type {
+  ClaimStrength,
+  ScientificValidation,
+  ScientificValidationOverallStatus,
+  ValidationStatus,
+  ValidatorInputs,
+  ValidatorName,
+  ValidatorResult,
+} from './types'
+
+const RAW_PAYLOAD_INDICATIVE_KEYS = [
+  'option_comparison',
+  'factor_sensitivity',
+  'm1_coaching',
+  'flip_thresholds',
+  'robustness',
+] as const
+
+function classifySource(
+  inputs: ValidatorInputs,
+): ScientificValidation['source'] {
+  // live_raw_payloads — any of the indicative keys exists on the captured
+  // PLoT response.
+  if (
+    inputs.plotResponse &&
+    typeof inputs.plotResponse === 'object' &&
+    !Array.isArray(inputs.plotResponse)
+  ) {
+    const obj = inputs.plotResponse as Record<string, unknown>
+    if (RAW_PAYLOAD_INDICATIVE_KEYS.some((k) => obj[k] !== undefined && obj[k] !== null)) {
+      return 'live_raw_payloads'
+    }
+  }
+  // hydrated_report — capture-pipeline says hydrated_only AND we still
+  // have results derived from the canvas store.
+  if (inputs.capturePipelineStatus === 'hydrated_only' && inputs.resultsReport) {
+    return 'hydrated_report'
+  }
+  if (inputs.capturePipelineStatus === 'results_rendered_from_store_without_capture') {
+    return 'debug_fallback'
+  }
+  return 'unavailable'
+}
+
+function classifyOverall(
+  validators: Record<ValidatorName, ValidatorResult>,
+  source: ScientificValidation['source'],
+): ScientificValidationOverallStatus {
+  if (source === 'unavailable') return 'unavailable'
+  const derivedCount = Object.values(validators).filter(
+    (v) => v.claim_strength === 'observed' || v.claim_strength === 'derived',
+  ).length
+  const failCount = Object.values(validators).filter((v) => v.status === 'fail').length
+  if (derivedCount < 3) return 'insufficient_raw_evidence'
+  if (failCount > 0) return 'partial'
+  return 'complete'
+}
+
+export function runScientificValidation(
+  inputs: ValidatorInputs,
+): ScientificValidation {
+  const validators: Record<ValidatorName, ValidatorResult> = {
+    user_std_propagation: runUserStdPropagation(inputs),
+    confidence_validation: runConfidenceValidation(inputs),
+    evidence_gap_validation: runEvidenceGapValidation(inputs),
+    evpi_validation: runEvpiValidation(inputs),
+    flip_threshold_validation: runFlipThresholdValidation(inputs),
+    auto_noise_validation: runAutoNoiseValidation(inputs),
+    response_shape_validation: runResponseShapeValidation(inputs),
+  }
+
+  const source = classifySource(inputs)
+  const overall_status = classifyOverall(validators, source)
+
+  return {
+    overall_status,
+    source,
+    validators,
+  }
+}

--- a/src/lib/scientificValidation/index.ts
+++ b/src/lib/scientificValidation/index.ts
@@ -85,8 +85,17 @@ function classifyOverall(
     (v) => v.claim_strength === 'observed' || v.claim_strength === 'derived',
   ).length
   const failCount = Object.values(validators).filter((v) => v.status === 'fail').length
+  // Stabilisation fix: per the brief, `complete` requires "no
+  // `partial`/`fail` results". The previous code only checked
+  // `fail`, letting a `partial` validator (e.g. a hydrated
+  // response_shape_validation that downgrades pass→partial via
+  // assertHonestyRules) still surface as `overall_status: complete`.
+  // Both states now disqualify `complete`.
+  const partialCount = Object.values(validators).filter(
+    (v) => v.status === 'partial',
+  ).length
   if (derivedCount < 3) return 'insufficient_raw_evidence'
-  if (failCount > 0) return 'partial'
+  if (failCount > 0 || partialCount > 0) return 'partial'
   return 'complete'
 }
 

--- a/src/lib/scientificValidation/responseShapeValidation.ts
+++ b/src/lib/scientificValidation/responseShapeValidation.ts
@@ -1,0 +1,100 @@
+/**
+ * response_shape_validation — always emits. Lists which required fields
+ * are present/missing on the PLoT response and classifies the source as
+ * live / hydrated / fallback / unavailable.
+ *
+ * The source classification is derived from `capture_pipeline_status`:
+ *   - complete                                              → live
+ *   - results_rendered_from_store_without_capture           → fallback
+ *   - hydrated_only                                         → hydrated
+ *   - parse_failed / request_failed / proxy_or_network_failure → fallback
+ *   - capture_missing                                       → unavailable
+ */
+
+import { assertHonestyRules, type ValidatorInputs, type ValidatorResult } from './types'
+
+const REQUIRED_PLOT_RESPONSE_KEYS = [
+  'option_comparison',
+  'factor_sensitivity',
+  'm1_coaching',
+  'flip_thresholds',
+  'robustness',
+] as const
+
+function classifySource(status: string | null): 'live' | 'hydrated' | 'fallback' | 'unavailable' {
+  switch (status) {
+    case 'complete':
+      return 'live'
+    case 'hydrated_only':
+      return 'hydrated'
+    case 'parse_failed':
+    case 'request_failed':
+    case 'proxy_or_network_failure':
+    case 'results_rendered_from_store_without_capture':
+      return 'fallback'
+    case 'capture_missing':
+    default:
+      return 'unavailable'
+  }
+}
+
+export function runResponseShapeValidation(inputs: ValidatorInputs): ValidatorResult {
+  const source = classifySource(inputs.capturePipelineStatus)
+
+  const presence: Record<string, boolean> = {}
+  let present_count = 0
+  if (
+    inputs.plotResponse &&
+    typeof inputs.plotResponse === 'object' &&
+    !Array.isArray(inputs.plotResponse)
+  ) {
+    const obj = inputs.plotResponse as Record<string, unknown>
+    for (const k of REQUIRED_PLOT_RESPONSE_KEYS) {
+      const isPresent = obj[k] !== undefined && obj[k] !== null
+      presence[k] = isPresent
+      if (isPresent) present_count++
+    }
+  } else {
+    for (const k of REQUIRED_PLOT_RESPONSE_KEYS) presence[k] = false
+  }
+
+  let status: ValidatorResult['status']
+  let claim_strength: ValidatorResult['claim_strength']
+  if (source === 'unavailable') {
+    status = 'unavailable'
+    claim_strength = 'unavailable'
+  } else if (source === 'hydrated' || source === 'fallback') {
+    status = 'partial'
+    claim_strength = 'inferred'
+  } else {
+    status =
+      present_count === REQUIRED_PLOT_RESPONSE_KEYS.length ? 'pass' : 'partial'
+    claim_strength = 'observed'
+  }
+
+  const limitations: string[] = []
+  if (source === 'hydrated') {
+    limitations.push(
+      'PLoT response was hydrated from saved state; live raw payloads are not available for this export.',
+    )
+  }
+  if (source === 'fallback') {
+    limitations.push(
+      'PLoT response was reconstructed without a fresh capture; treat fields as advisory.',
+    )
+  }
+
+  return assertHonestyRules({
+    status,
+    claim_strength,
+    source_paths: ['payloads.plot_response'],
+    limitations,
+    required_upstream_support: [],
+    details: {
+      source,
+      required_keys: [...REQUIRED_PLOT_RESPONSE_KEYS],
+      presence,
+      present_count,
+    },
+  })
+}

--- a/src/lib/scientificValidation/types.ts
+++ b/src/lib/scientificValidation/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared types for scientific validation. Every validator returns the
+ * same shape so reviewers can scan the section uniformly.
+ *
+ * Honesty rules (enforced by the orchestrator + per-validator tests):
+ *   - `observed`     — raw captured payload present in bundle.payloads.*
+ *   - `derived`      — computed directly from captured raw payloads
+ *   - `inferred`     — reconstructed from canvas/store/report state;
+ *                      NEVER pairs with status='pass'
+ *   - `unavailable`  — required evidence missing; required_upstream_support
+ *                      populated
+ *
+ * `details` is a per-validator opaque object documented inline below.
+ */
+
+export type ValidationStatus = 'pass' | 'fail' | 'unavailable' | 'partial'
+
+export type ClaimStrength = 'observed' | 'derived' | 'inferred' | 'unavailable'
+
+export interface ValidatorResult {
+  status: ValidationStatus
+  claim_strength: ClaimStrength
+  /** Bundle-relative dot/bracket paths the validator read from. */
+  source_paths: string[]
+  /** Free-form notes that explain limitations or context. */
+  limitations: string[]
+  /** Required upstream fields the validator could not find. */
+  required_upstream_support: string[]
+  /** Per-validator opaque details object. Documented per validator. */
+  details: Record<string, unknown>
+}
+
+export type ValidatorName =
+  | 'user_std_propagation'
+  | 'confidence_validation'
+  | 'evidence_gap_validation'
+  | 'evpi_validation'
+  | 'flip_threshold_validation'
+  | 'auto_noise_validation'
+  | 'response_shape_validation'
+
+export type ScientificValidationOverallStatus =
+  | 'complete'
+  | 'partial'
+  | 'insufficient_raw_evidence'
+  | 'unavailable'
+
+export interface ScientificValidation {
+  overall_status: ScientificValidationOverallStatus
+  /** Whether any raw PLoT payload was found in the bundle. */
+  source: 'live_raw_payloads' | 'hydrated_report' | 'debug_fallback' | 'unavailable'
+  /** Validators keyed by name for easy lookup. */
+  validators: Record<ValidatorName, ValidatorResult>
+}
+
+/**
+ * Inputs the orchestrator passes to every validator. Each validator
+ * picks what it needs — types stay loose because the underlying payloads
+ * are `unknown` and we validate shapes at read time.
+ */
+export interface ValidatorInputs {
+  plotRequest: unknown
+  plotResponse: unknown
+  ceeRequest: unknown
+  ceeResponse: unknown
+  islRequest: unknown
+  islResponse: unknown
+  /** Canvas store results.report (from the canvas store at export time). */
+  resultsReport: unknown
+  /** Canvas store ceeAnalysisReady.options[*].interventions key set. */
+  ceeAnalysisReady: unknown
+  /** capture_pipeline_status — drives response_shape_validation source. */
+  capturePipelineStatus: string | null
+}
+
+/**
+ * Tiny helper: assert that `inferred` never pairs with `pass`. Validators
+ * call this before returning; tests cover the rule.
+ */
+export function assertHonestyRules(result: ValidatorResult): ValidatorResult {
+  if (result.claim_strength === 'inferred' && result.status === 'pass') {
+    return {
+      ...result,
+      status: 'partial',
+      limitations: [
+        ...result.limitations,
+        'status downgraded from pass to partial: inferred evidence cannot prove a pass',
+      ],
+    }
+  }
+  return result
+}

--- a/src/lib/scientificValidation/userStdPropagation.ts
+++ b/src/lib/scientificValidation/userStdPropagation.ts
@@ -1,0 +1,131 @@
+/**
+ * user_std_propagation — verifies that user-supplied
+ * `observed_state.std` flows canvas → PLoT request → ISL request →
+ * `parameter_uncertainties.std`. (Scientific PR #168 / #169.)
+ *
+ * DGAI's bundle does NOT carry an independent ISL request payload —
+ * ISL is invoked inside PLoT and DGAI only sees the V2 PLoT request /
+ * response. This validator therefore:
+ *   - reads `bundle.payloads.isl_request.parameter_uncertainties` first;
+ *   - if absent (the common case), emits `unavailable` with
+ *     `required_upstream_support: ['plot.debug.isl_request']`;
+ *   - optionally includes an `expected_from_plot_request` inferred map
+ *     reconstructed from `bundle.payloads.plot_request.graph.nodes[].data.observed_state.std`
+ *     so reviewers can compare manually — but `claim_strength` stays
+ *     `unavailable` (NEVER `inferred`+`pass`).
+ */
+
+import { assertHonestyRules, type ValidatorInputs, type ValidatorResult } from './types'
+
+interface ExpectedEntry {
+  factor_id: string
+  std: number | null
+  source: 'plot_request.graph.nodes[*].data.observed_state.std'
+}
+
+function inferExpectedFromPlotRequest(plotRequest: unknown): ExpectedEntry[] {
+  if (!plotRequest || typeof plotRequest !== 'object' || Array.isArray(plotRequest)) return []
+  const graph = (plotRequest as Record<string, unknown>).graph
+  if (!graph || typeof graph !== 'object' || Array.isArray(graph)) return []
+  const nodes = (graph as Record<string, unknown>).nodes
+  if (!Array.isArray(nodes)) return []
+  const out: ExpectedEntry[] = []
+  for (const n of nodes) {
+    if (!n || typeof n !== 'object' || Array.isArray(n)) continue
+    const node = n as Record<string, unknown>
+    const id = typeof node.id === 'string' ? node.id : null
+    if (!id) continue
+    const data = (node.data ?? {}) as Record<string, unknown>
+    const obs = (data.observed_state ?? data.observedState) as Record<string, unknown> | undefined
+    if (!obs || typeof obs !== 'object') continue
+    const std = typeof obs.std === 'number' ? obs.std : null
+    if (std === null) continue
+    out.push({
+      factor_id: id,
+      std,
+      source: 'plot_request.graph.nodes[*].data.observed_state.std',
+    })
+  }
+  return out
+}
+
+interface ObservedEntry {
+  factor_id: string
+  std: number | null
+  status: 'pass' | 'widened' | 'missing' | 'defaulted'
+}
+
+function compareWithIslRequest(
+  islRequest: unknown,
+  expected: ExpectedEntry[],
+): { entries: ObservedEntry[]; sourcePath: string } | null {
+  if (!islRequest || typeof islRequest !== 'object' || Array.isArray(islRequest)) return null
+  const pu = (islRequest as Record<string, unknown>).parameter_uncertainties
+  if (!pu || typeof pu !== 'object' || Array.isArray(pu)) return null
+  const entries: ObservedEntry[] = []
+  const expectedByFactor = new Map(expected.map((e) => [e.factor_id, e.std]))
+  for (const factor_id of Object.keys(pu as Record<string, unknown>)) {
+    const v = (pu as Record<string, unknown>)[factor_id]
+    const islStd =
+      v && typeof v === 'object' && !Array.isArray(v) && typeof (v as Record<string, unknown>).std === 'number'
+        ? ((v as Record<string, unknown>).std as number)
+        : null
+    const expectedStd = expectedByFactor.get(factor_id) ?? null
+    let status: ObservedEntry['status']
+    if (islStd === null) {
+      status = 'missing'
+    } else if (expectedStd === null) {
+      status = 'defaulted'
+    } else if (Math.abs(islStd - expectedStd) < 1e-9) {
+      status = 'pass'
+    } else if (islStd > expectedStd) {
+      status = 'widened'
+    } else {
+      // ISL std smaller than user input — narrower; treat as defaulted
+      // since the user didn't ask for it.
+      status = 'defaulted'
+    }
+    entries.push({ factor_id, std: islStd, status })
+  }
+  return { entries, sourcePath: 'payloads.isl_request.parameter_uncertainties' }
+}
+
+export function runUserStdPropagation(inputs: ValidatorInputs): ValidatorResult {
+  const expected = inferExpectedFromPlotRequest(inputs.plotRequest)
+  const observed = compareWithIslRequest(inputs.islRequest, expected)
+
+  if (observed === null) {
+    // ISL request not captured — the common case in DGAI today.
+    return assertHonestyRules({
+      status: 'unavailable',
+      claim_strength: 'unavailable',
+      source_paths: expected.length ? ['payloads.plot_request.graph.nodes[*].data.observed_state.std'] : [],
+      limitations: [
+        'ISL request payload is not captured by DGAI (ISL runs inside PLoT). ' +
+          'DGAI cannot prove what PLoT forwarded to ISL from canvas/expected values alone — ' +
+          'an inferred reconstruction is provided for reviewer comparison but never used as proof.',
+      ],
+      required_upstream_support: ['plot.debug.isl_request', 'plot.debug.isl_response'],
+      details: { expected_from_plot_request: expected },
+    })
+  }
+
+  const allPass = observed.entries.length > 0 && observed.entries.every((e) => e.status === 'pass')
+  const anyWidened = observed.entries.some((e) => e.status === 'widened')
+  const status: ValidatorResult['status'] = allPass ? 'pass' : anyWidened ? 'fail' : 'partial'
+
+  return assertHonestyRules({
+    status,
+    claim_strength: 'derived',
+    source_paths: [
+      'payloads.isl_request.parameter_uncertainties',
+      'payloads.plot_request.graph.nodes[*].data.observed_state.std',
+    ],
+    limitations: [],
+    required_upstream_support: [],
+    details: {
+      observed: observed.entries,
+      expected_from_plot_request: expected,
+    },
+  })
+}

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -1,0 +1,209 @@
+/**
+ * V5 canonical turn diagnostics — richer assembler for the debug bundle.
+ *
+ * Composes (not replaces) the existing
+ * `classifyV5CanonicalAnalysisDiagnostic`. Adds:
+ *   - canonical flag source (env / localStorage / default / unknown)
+ *   - latest V5 turn capture summary
+ *   - parse outcome details
+ *   - analysis-fact details (incl. read-through graph_hash_at_generation)
+ *   - results metrics (option count, factor sensitivity count)
+ *   - scenario-ID reconciliation (re-exported into the snapshot)
+ *   - capture-pipeline status + coherence issues
+ *
+ * The new field is `bundle.v5_canonical_turn_diagnostics`. The legacy
+ * block `bundle.v5_canonical_analysis` stays untouched and continues to
+ * be emitted alongside.
+ *
+ * Pure module. No React, no zustand subscriptions.
+ */
+
+import type { AnalysisStateSource } from '../canvas/hooks/useAnalysisStateSource'
+import type { ParseFailureKind } from '../v5/responseParser'
+import type { ScenarioIdReconciliation } from './scenarioIdReconciliation'
+import type {
+  V5CanonicalAnalysisDiagnostic,
+  V5CeeCapture,
+} from './v5CanonicalAnalysisDiagnostics'
+import type {
+  CapturePipelineStatus,
+  CoherenceIssue,
+  CoherenceState,
+} from './v5CapturePipelineStatus'
+
+export type CanonicalFlagSource = 'env' | 'localStorage' | 'default' | 'unknown'
+
+export interface V5CanonicalTurnDiagnostics {
+  canonical_flag_on: boolean
+  canonical_flag_source: CanonicalFlagSource
+  latest_v5_turn: {
+    request_present: boolean
+    response_present: boolean
+    status: number | null
+  }
+  parse: {
+    parse_ok: boolean | null
+    parse_error: string | null
+    parse_failure_kind: ParseFailureKind | null
+    raw_response_present: boolean
+    response_top_level_keys: string[] | null
+  }
+  analysis_fact: {
+    present: boolean
+    has_run_analysis_fact: boolean | null
+    freshness: 'fresh' | 'stale' | 'unknown' | 'none' | null
+    scenario_id: string | null
+    /** Read-through from canvas v5AnalysisFact slice. Null when the slice
+     *  does not carry the field on this code path. */
+    graph_hash_at_generation: string | null
+    phase3_raw_block_count: number
+    phase3_raw_block_types: string[]
+  }
+  results: {
+    present: boolean
+    source: AnalysisStateSource
+    option_count: number
+    factor_sensitivity_count: number
+  }
+  capture_pipeline_status: CapturePipelineStatus
+  coherence: {
+    state: CoherenceState
+    issues: CoherenceIssue[]
+  }
+  scenario_id_reconciliation: ScenarioIdReconciliation
+}
+
+export interface AssembleV5CanonicalTurnDiagnosticsInputs {
+  /** Output of the legacy classifier (already on the bundle). */
+  legacyDiagnostic: V5CanonicalAnalysisDiagnostic
+  /** Result of diagnoseFlagState for the canonical flag. Pass null when
+   *  the source cannot be resolved (e.g. tests without localStorage). */
+  flagDiagnostic: {
+    resolved: boolean
+    source: 'env' | 'localStorage' | 'default'
+  } | null
+  /** From the existing AnalysisStateSource classifier. */
+  analysisStateSource: AnalysisStateSource
+  hasResultsReport: boolean
+  /** Read-through. Slice may not carry this on every code path; emit null. */
+  graphHashAtGeneration: string | null
+  /** Results metrics from bundle payloads / canvas store. */
+  optionCount: number
+  factorSensitivityCount: number
+  /** Output of classifyV5CapturePipelineStatus. */
+  capturePipeline: {
+    capture_pipeline_status: CapturePipelineStatus
+    coherence: { state: CoherenceState; issues: CoherenceIssue[] }
+  }
+  /** Output of reconcileScenarioId. */
+  scenarioIdReconciliation: ScenarioIdReconciliation
+}
+
+export function assembleV5CanonicalTurnDiagnostics(
+  inputs: AssembleV5CanonicalTurnDiagnosticsInputs,
+): V5CanonicalTurnDiagnostics {
+  const capture: V5CeeCapture | null = inputs.legacyDiagnostic.v5_cee_capture
+
+  const canonical_flag_source: CanonicalFlagSource = inputs.flagDiagnostic
+    ? inputs.flagDiagnostic.source
+    : 'unknown'
+
+  const latest_v5_turn = {
+    request_present: capture?.request_present ?? false,
+    response_present: capture?.response_present ?? false,
+    status: capture?.status ?? null,
+  }
+
+  const parse = {
+    parse_ok: capture ? capture.parse_ok : null,
+    parse_error: capture?.parse_error ?? null,
+    parse_failure_kind: capture?.parse_failure_kind ?? null,
+    raw_response_present: capture?.raw_response_present ?? false,
+    response_top_level_keys: capture?.response_top_level_keys ?? null,
+  }
+
+  // analysis_fact.* — scenario_id comes from the V5 capture (which already
+  // reads from canvas store currentScenarioId in exportBundle assembly);
+  // present + has_run_analysis_fact + freshness come from the legacy
+  // diagnostic; graph_hash_at_generation is a read-through.
+  const analysis_fact = {
+    present: inputs.legacyDiagnostic.analysis_fact_status === 'present',
+    has_run_analysis_fact: null as boolean | null,
+    freshness: null as 'fresh' | 'stale' | 'unknown' | 'none' | null,
+    scenario_id: capture?.scenario_id ?? null,
+    graph_hash_at_generation: inputs.graphHashAtGeneration,
+    phase3_raw_block_count: capture?.phase3_blocks_tolerated_count ?? 0,
+    phase3_raw_block_types: capture?.phase3_block_types ?? [],
+  }
+
+  const results = {
+    present: inputs.hasResultsReport,
+    source: inputs.analysisStateSource,
+    option_count: inputs.optionCount,
+    factor_sensitivity_count: inputs.factorSensitivityCount,
+  }
+
+  return {
+    canonical_flag_on: inputs.legacyDiagnostic.canonical_flag_on,
+    canonical_flag_source,
+    latest_v5_turn,
+    parse,
+    analysis_fact,
+    results,
+    capture_pipeline_status: inputs.capturePipeline.capture_pipeline_status,
+    coherence: inputs.capturePipeline.coherence,
+    scenario_id_reconciliation: inputs.scenarioIdReconciliation,
+  }
+}
+
+/**
+ * Pure helper for the assembler to fill `analysis_fact.has_run_analysis_fact`
+ * and `analysis_fact.freshness` when the canvas store's v5AnalysisFact
+ * slice is available to the caller. Kept separate so the main assembler
+ * stays free of store coupling.
+ */
+export function attachAnalysisFactDetails(
+  diagnostics: V5CanonicalTurnDiagnostics,
+  fact: {
+    hasRunAnalysisFact: boolean | null
+    freshness: 'fresh' | 'stale' | 'unknown' | 'none' | null
+  } | null,
+): V5CanonicalTurnDiagnostics {
+  if (!fact) return diagnostics
+  return {
+    ...diagnostics,
+    analysis_fact: {
+      ...diagnostics.analysis_fact,
+      has_run_analysis_fact: fact.hasRunAnalysisFact,
+      freshness: fact.freshness,
+    },
+  }
+}
+
+/**
+ * Extract option count from a PLoT V2 response (already in the bundle
+ * payloads). Returns 0 when the response is absent or doesn't carry
+ * `option_comparison`. Treats anything except an array as 0.
+ */
+export function extractOptionCountFromPlotResponse(
+  plotResponse: unknown,
+): number {
+  if (!plotResponse || typeof plotResponse !== 'object' || Array.isArray(plotResponse)) {
+    return 0
+  }
+  const oc = (plotResponse as Record<string, unknown>).option_comparison
+  return Array.isArray(oc) ? oc.length : 0
+}
+
+/**
+ * Extract factor_sensitivity entry count from a PLoT V2 response.
+ */
+export function extractFactorSensitivityCountFromPlotResponse(
+  plotResponse: unknown,
+): number {
+  if (!plotResponse || typeof plotResponse !== 'object' || Array.isArray(plotResponse)) {
+    return 0
+  }
+  const fs = (plotResponse as Record<string, unknown>).factor_sensitivity
+  return Array.isArray(fs) ? fs.length : 0
+}

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -33,7 +33,16 @@ import type {
 
 export type CanonicalFlagSource = 'env' | 'localStorage' | 'default' | 'unknown'
 
+/**
+ * Literal env var name the canonical-analysis flag is bound to. Kept as
+ * a constant so the bundle carries the grep-able `VITE_V5_CANONICAL_ANALYSIS`
+ * string verbatim (brief D — feature flag visibility).
+ */
+export const CANONICAL_FLAG_ENV_KEY = 'VITE_V5_CANONICAL_ANALYSIS' as const
+
 export interface V5CanonicalTurnDiagnostics {
+  /** Verbatim env-key string for grep-ability across exported bundles. */
+  canonical_flag_env_key: typeof CANONICAL_FLAG_ENV_KEY
   canonical_flag_on: boolean
   canonical_flag_source: CanonicalFlagSource
   latest_v5_turn: {
@@ -144,6 +153,7 @@ export function assembleV5CanonicalTurnDiagnostics(
   }
 
   return {
+    canonical_flag_env_key: CANONICAL_FLAG_ENV_KEY,
     canonical_flag_on: inputs.legacyDiagnostic.canonical_flag_on,
     canonical_flag_source,
     latest_v5_turn,

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -37,6 +37,16 @@ export type CanonicalFlagSource = 'env' | 'localStorage' | 'default' | 'unknown'
  * Provenance enum for the latest V5 turn snapshot — describes WHERE the
  * capture data came from rather than the legacy `'proxy_v5_turn'`
  * literal on V5CeeCapture.source.
+ *
+ * **Intentional brief extension**: the brief lists four values
+ * (`payload_trace | bundle_payloads | store | none`). DGAI's bundle
+ * also carries `data.services.cee` records which are evidence-strength
+ * distinct from both `bundle.payloads` and trace-store data. We add
+ * `service_metadata` as a fifth value so reviewers see honest
+ * provenance attribution; tests and JSDoc document this addition. If
+ * the brief enum is to be kept stable for cross-team consumers,
+ * service-metadata exclusivity is also recorded in
+ * `diagnostic_source_strength.latest_v5_turn`.
  */
 export type LatestV5TurnSource =
   | 'payload_trace'
@@ -44,6 +54,37 @@ export type LatestV5TurnSource =
   | 'service_metadata'
   | 'store'
   | 'none'
+
+/**
+ * Single canonical capture-tier resolver. Used by both the legacy
+ * `V5CeeCapture` assembly site and the new snapshot assembler so the
+ * two views never disagree about where the capture data came from.
+ *
+ * Tier order (highest evidence first):
+ *   1. payload_trace — V5 turn entry exists in the trace store
+ *   2. bundle_payloads — bundle.payloads.cee_request/response set
+ *   3. service_metadata — only data.services.cee for V5 endpoint
+ *   4. store — no capture but a v5AnalysisFact exists for the scenario
+ *   5. none — no evidence at all
+ */
+export function determineCaptureTier(inputs: {
+  traceEntryPresent: boolean
+  bundlePayloadsCeeRequestPresent: boolean
+  bundlePayloadsCeeResponsePresent: boolean
+  serviceMetadataV5EndpointPresent: boolean
+  factPresentForScenario: boolean
+}): LatestV5TurnSource {
+  if (inputs.traceEntryPresent) return 'payload_trace'
+  if (
+    inputs.bundlePayloadsCeeRequestPresent ||
+    inputs.bundlePayloadsCeeResponsePresent
+  ) {
+    return 'bundle_payloads'
+  }
+  if (inputs.serviceMetadataV5EndpointPresent) return 'service_metadata'
+  if (inputs.factPresentForScenario) return 'store'
+  return 'none'
+}
 
 /**
  * Diagnostic-source strength per major bundle block. Reviewers use this
@@ -98,6 +139,13 @@ export interface V5CanonicalTurnDiagnostics {
     response_present: boolean
     /** HTTP request_id from the captured CEE call. */
     request_id: string | null
+    /**
+     * Where `request_id` came from:
+     *   - `payload_trace` — the actual id of the V5 trace entry
+     *   - `session`       — fallback to `data.overall.request_id`
+     *   - `none`          — no capture and no session id
+     */
+    request_id_source: 'payload_trace' | 'session' | 'none'
     /** Scenario the call was issued against. */
     scenario_id: string | null
     /** Per-turn client identifier (typically the analysis hash). */
@@ -114,7 +162,9 @@ export interface V5CanonicalTurnDiagnostics {
      * brief's richer provenance enum:
      *   - payload_trace   — assembled from a payload-trace-store entry
      *   - bundle_payloads — assembled from `bundle.payloads.cee_*`
-     *   - service_metadata — only `data.services.cee` was present
+     *   - service_metadata — only `data.services.cee` was present (DGAI
+     *                        intentional extension to the brief enum;
+     *                        see LatestV5TurnSource JSDoc)
      *   - store           — derived from canvas store fact, no capture
      *   - none            — no capture at all
      */
@@ -155,13 +205,18 @@ export interface V5CanonicalTurnDiagnostics {
     option_count: number
     factor_sensitivity_count: number
     /**
-     * Brief lists `rendered_option_count` / `rendered_factor_count` /
-     * `influence_unmatched_count`. These require display-state
-     * inspection that this snapshot does not perform; the bundle's
-     * existing `display_state` block carries those signals when
-     * captured. Documented here for traceability; values are not
-     * synthesised to avoid overclaiming.
+     * Count of options actually rendered by the UI, sourced from
+     * `bundle.display_state.rendered_options.length`. Null when
+     * display_state is absent (no fabrication).
      */
+    rendered_option_count: number | null
+    /**
+     * Count of factors actually rendered by the UI, sourced from
+     * `bundle.display_state.rendered_factors.length`. Null when
+     * display_state is absent.
+     */
+    rendered_factor_count: number | null
+    /** Stable pointer to where rendered counts live in the wider bundle. */
     rendered_counts_documented_in: 'bundle.display_state'
   }
   capture_pipeline_status: CapturePipelineStatus
@@ -203,17 +258,13 @@ export interface AssembleV5CanonicalTurnDiagnosticsInputs {
   optionCount: number
   factorSensitivityCount: number
   /**
-   * True when a V5 turn entry was found in the payload-trace store at
-   * assembly time. Drives `latest_v5_turn.source` and
-   * `diagnostic_source_strength.latest_v5_turn`.
+   * Canonical capture tier resolved once at the call site (via
+   * `determineCaptureTier`). Drives `latest_v5_turn.source` directly
+   * and feeds `diagnostic_source_strength.latest_v5_turn`. Replaces
+   * the previous ad-hoc boolean inputs to ensure the assembler can't
+   * disagree with the upstream V5CeeCapture assembly about provenance.
    */
-  v5TraceEntryPresent: boolean
-  /**
-   * True when `data.services.cee.endpoint` matched the V5 turn
-   * endpoint (`/orchestrate/v2/turn`). Used as the next-best evidence
-   * tier when no trace entry is recorded.
-   */
-  ceeServiceV5EndpointPresent: boolean
+  captureTier: LatestV5TurnSource
   /**
    * Rendered counts pulled from `bundle.display_state` when present;
    * `null` when display_state is absent.
@@ -238,27 +289,26 @@ export function assembleV5CanonicalTurnDiagnostics(
     ? inputs.flagDiagnostic.source
     : 'unknown'
 
-  // Map the legacy `V5CeeCapture.source` literal + trace/service
-  // evidence to the brief's richer provenance enum.
-  const latestV5TurnSource: LatestV5TurnSource = (() => {
-    if (capture === null) {
-      // No capture object at all — derived from store fact or nothing.
-      return inputs.legacyDiagnostic.analysis_fact_status === 'present'
-        ? 'store'
-        : 'none'
-    }
-    if (inputs.v5TraceEntryPresent) return 'payload_trace'
-    if (capture.request_present || capture.response_present) {
-      return 'bundle_payloads'
-    }
-    if (inputs.ceeServiceV5EndpointPresent) return 'service_metadata'
-    return 'none'
-  })()
+  // Capture tier comes from the upstream resolver — single canonical
+  // source of truth shared with the V5CeeCapture assembly.
+  const latestV5TurnSource: LatestV5TurnSource = inputs.captureTier
+
+  // request_id source attribution. Trace-tier entries carry the real
+  // payload-trace id; lower tiers fall back to the session-level
+  // request_id. Explicit field so reviewers don't mistake the
+  // fallback for the actual trace id.
+  const requestIdSource: 'payload_trace' | 'session' | 'none' =
+    capture === null
+      ? 'none'
+      : latestV5TurnSource === 'payload_trace'
+        ? 'payload_trace'
+        : 'session'
 
   const latest_v5_turn = {
     request_present: capture?.request_present ?? false,
     response_present: capture?.response_present ?? false,
     request_id: capture?.request_id ?? null,
+    request_id_source: requestIdSource,
     scenario_id: capture?.scenario_id ?? null,
     turn_id: capture?.turn_id ?? null,
     endpoint: capture?.endpoint ?? null,
@@ -267,8 +317,19 @@ export function assembleV5CanonicalTurnDiagnostics(
     source: latestV5TurnSource,
   }
 
+  // parse_ok is only meaningful when a response was actually received.
+  // Without a response body there's nothing to parse — emit `null` so
+  // reviewers don't mistake "no response" for "parsed and failed".
+  // (The legacy V5CeeCapture.parse_ok stays boolean for backward-compat;
+  // this snapshot overlays null based on response_present.)
+  const parseOkResolved: boolean | null =
+    capture === null
+      ? null
+      : capture.response_present
+        ? capture.parse_ok
+        : null
   const parse = {
-    parse_ok: capture ? capture.parse_ok : null,
+    parse_ok: parseOkResolved,
     parse_error: capture?.parse_error ?? null,
     parse_failure_kind: capture?.parse_failure_kind ?? null,
     raw_response_present: capture?.raw_response_present ?? false,
@@ -321,12 +382,16 @@ export function assembleV5CanonicalTurnDiagnostics(
             : latestV5TurnSource === 'store'
               ? 'fallback'
               : 'unavailable',
+    // Parse strength is honest about evidence: 'live_response' only
+    // when a response body was actually received and parsed (success
+    // OR parse-error envelope with raw preserved). When the response
+    // is absent (capture null OR service-metadata-only), parse
+    // strength is 'unavailable' — never `live_response` based on a
+    // synthesised `parse_ok = false`.
     parse:
-      capture?.parse_ok === true || capture?.parse_ok === false
-        ? 'live_response'
-        : capture === null
-          ? 'unavailable'
-          : 'fallback',
+      capture === null || !capture.response_present
+        ? 'unavailable'
+        : 'live_response',
     results:
       inputs.optionCount > 0 || inputs.factorSensitivityCount > 0
         ? 'plot_response'

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -40,15 +40,48 @@ export type CanonicalFlagSource = 'env' | 'localStorage' | 'default' | 'unknown'
  */
 export const CANONICAL_FLAG_ENV_KEY = 'VITE_V5_CANONICAL_ANALYSIS' as const
 
+/**
+ * Compact feature-flag diagnostic — grep-ability surface for support
+ * tooling. Currently scoped to the canonical-analysis flag; structure
+ * leaves room for future flags without breaking consumers.
+ */
+export interface FeatureFlagDiagnostic {
+  VITE_V5_CANONICAL_ANALYSIS: {
+    value: boolean
+    source: CanonicalFlagSource
+  }
+}
+
 export interface V5CanonicalTurnDiagnostics {
   /** Verbatim env-key string for grep-ability across exported bundles. */
   canonical_flag_env_key: typeof CANONICAL_FLAG_ENV_KEY
   canonical_flag_on: boolean
   canonical_flag_source: CanonicalFlagSource
+  /** Compact keyed feature-flag object for support tooling. */
+  feature_flag_diagnostic: FeatureFlagDiagnostic
+  /**
+   * Top-level mirror of the bundle's `effective_cee_response_source`
+   * (direct/downstream/none) so a single section answers "which CEE
+   * extraction path produced the captured response".
+   */
+  effective_cee_response_source: 'direct' | 'downstream' | 'none' | null
   latest_v5_turn: {
     request_present: boolean
     response_present: boolean
+    /** HTTP request_id from the captured CEE call. */
+    request_id: string | null
+    /** Scenario the call was issued against. */
+    scenario_id: string | null
+    /** Per-turn client identifier (typically the analysis hash). */
+    turn_id: string | null
+    /** CEE endpoint hit. Null when the trace didn't record it. */
+    endpoint: string | null
+    /** HTTP status code. */
     status: number | null
+    /** Wall-clock duration of the call in ms. */
+    duration_ms: number | null
+    /** Source discriminator for capture provenance. */
+    source: 'proxy_v5_turn' | null
   }
   parse: {
     parse_ok: boolean | null
@@ -56,6 +89,9 @@ export interface V5CanonicalTurnDiagnostics {
     parse_failure_kind: ParseFailureKind | null
     raw_response_present: boolean
     response_top_level_keys: string[] | null
+    /** Offending block `type` values when parse_failure_kind is
+     *  `unknown_block_types`; null otherwise. */
+    unknown_block_types: string[] | null
   }
   analysis_fact: {
     present: boolean
@@ -67,12 +103,29 @@ export interface V5CanonicalTurnDiagnostics {
     graph_hash_at_generation: string | null
     phase3_raw_block_count: number
     phase3_raw_block_types: string[]
+    /**
+     * Where the fact-presence signal came from:
+     *   - 'v5_canonical_analysis' — legacy classifier output
+     *   - 'source_classifier'     — synthesised fallback derived from
+     *                               `sourceResult.factPresentForScenario`
+     *   - 'none'                  — no fact present
+     */
+    source: 'v5_canonical_analysis' | 'source_classifier' | 'none'
   }
   results: {
     present: boolean
     source: AnalysisStateSource
     option_count: number
     factor_sensitivity_count: number
+    /**
+     * Brief lists `rendered_option_count` / `rendered_factor_count` /
+     * `influence_unmatched_count`. These require display-state
+     * inspection that this snapshot does not perform; the bundle's
+     * existing `display_state` block carries those signals when
+     * captured. Documented here for traceability; values are not
+     * synthesised to avoid overclaiming.
+     */
+    rendered_counts_documented_in: 'bundle.display_state'
   }
   capture_pipeline_status: CapturePipelineStatus
   coherence: {
@@ -85,6 +138,9 @@ export interface V5CanonicalTurnDiagnostics {
 export interface AssembleV5CanonicalTurnDiagnosticsInputs {
   /** Output of the legacy classifier (already on the bundle). */
   legacyDiagnostic: V5CanonicalAnalysisDiagnostic
+  /** Whether `legacyDiagnostic` came from a real classifier run vs.
+   *  the synthesised fallback. Drives `analysis_fact.source`. */
+  legacyDiagnosticFromClassifier: boolean
   /** Result of diagnoseFlagState for the canonical flag. Pass null when
    *  the source cannot be resolved (e.g. tests without localStorage). */
   flagDiagnostic: {
@@ -94,6 +150,8 @@ export interface AssembleV5CanonicalTurnDiagnosticsInputs {
   /** From the existing AnalysisStateSource classifier. */
   analysisStateSource: AnalysisStateSource
   hasResultsReport: boolean
+  /** Mirror of bundle.effective_cee_response_source. */
+  effectiveCeeResponseSource: 'direct' | 'downstream' | 'none' | null
   /** Read-through. Slice may not carry this on every code path; emit null. */
   graphHashAtGeneration: string | null
   /** Results metrics from bundle payloads / canvas store. */
@@ -120,7 +178,13 @@ export function assembleV5CanonicalTurnDiagnostics(
   const latest_v5_turn = {
     request_present: capture?.request_present ?? false,
     response_present: capture?.response_present ?? false,
+    request_id: capture?.request_id ?? null,
+    scenario_id: capture?.scenario_id ?? null,
+    turn_id: capture?.turn_id ?? null,
+    endpoint: capture?.endpoint ?? null,
     status: capture?.status ?? null,
+    duration_ms: capture?.duration_ms ?? null,
+    source: capture?.source ?? null,
   }
 
   const parse = {
@@ -129,20 +193,29 @@ export function assembleV5CanonicalTurnDiagnostics(
     parse_failure_kind: capture?.parse_failure_kind ?? null,
     raw_response_present: capture?.raw_response_present ?? false,
     response_top_level_keys: capture?.response_top_level_keys ?? null,
+    unknown_block_types: capture?.unknown_block_types ?? null,
   }
 
   // analysis_fact.* — scenario_id comes from the V5 capture (which already
   // reads from canvas store currentScenarioId in exportBundle assembly);
   // present + has_run_analysis_fact + freshness come from the legacy
   // diagnostic; graph_hash_at_generation is a read-through.
+  const factPresent = inputs.legacyDiagnostic.analysis_fact_status === 'present'
+  const factSource: 'v5_canonical_analysis' | 'source_classifier' | 'none' =
+    !factPresent
+      ? 'none'
+      : inputs.legacyDiagnosticFromClassifier
+        ? 'v5_canonical_analysis'
+        : 'source_classifier'
   const analysis_fact = {
-    present: inputs.legacyDiagnostic.analysis_fact_status === 'present',
+    present: factPresent,
     has_run_analysis_fact: null as boolean | null,
     freshness: null as 'fresh' | 'stale' | 'unknown' | 'none' | null,
     scenario_id: capture?.scenario_id ?? null,
     graph_hash_at_generation: inputs.graphHashAtGeneration,
     phase3_raw_block_count: capture?.phase3_blocks_tolerated_count ?? 0,
     phase3_raw_block_types: capture?.phase3_block_types ?? [],
+    source: factSource,
   }
 
   const results = {
@@ -150,12 +223,22 @@ export function assembleV5CanonicalTurnDiagnostics(
     source: inputs.analysisStateSource,
     option_count: inputs.optionCount,
     factor_sensitivity_count: inputs.factorSensitivityCount,
+    rendered_counts_documented_in: 'bundle.display_state' as const,
   }
+
+  const feature_flag_diagnostic = {
+    [CANONICAL_FLAG_ENV_KEY]: {
+      value: inputs.legacyDiagnostic.canonical_flag_on,
+      source: canonical_flag_source,
+    },
+  } as FeatureFlagDiagnostic
 
   return {
     canonical_flag_env_key: CANONICAL_FLAG_ENV_KEY,
     canonical_flag_on: inputs.legacyDiagnostic.canonical_flag_on,
     canonical_flag_source,
+    feature_flag_diagnostic,
+    effective_cee_response_source: inputs.effectiveCeeResponseSource,
     latest_v5_turn,
     parse,
     analysis_fact,

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -325,7 +325,23 @@ export function assembleV5CanonicalTurnDiagnostics(
 
   // Capture tier comes from the upstream resolver — single canonical
   // source of truth shared with the V5CeeCapture assembly.
-  const latestV5TurnSource: LatestV5TurnSource = inputs.captureTier
+  //
+  // Stabilisation coherence guard: when `capture === null` (legacy
+  // synthesised fallback path, e.g. classifier threw), the assembler
+  // cannot honestly report fields from V5CeeCapture. Claiming
+  // `source: 'payload_trace'` while every capture field is null would
+  // be a provenance contradiction. Downgrade to `'store'` (if a fact
+  // is present) or `'none'` so latest_v5_turn.source and the rest of
+  // the section stay coherent. The `diagnostic_source_strength`
+  // mapping below already maps these downgraded values to 'fallback'
+  // / 'unavailable' respectively — reviewers still see that capture
+  // was absent on this export.
+  const latestV5TurnSource: LatestV5TurnSource =
+    capture === null
+      ? inputs.captureTier === 'store'
+        ? 'store'
+        : 'none'
+      : inputs.captureTier
 
   // request_id source attribution. Trace-tier entries carry the real
   // payload-trace id; lower tiers fall back to the session-level

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -63,7 +63,13 @@ export type LatestV5TurnSource =
  * Tier order (highest evidence first):
  *   1. payload_trace — V5 turn entry exists in the trace store
  *   2. bundle_payloads — bundle.payloads.cee_request/response set
- *   3. service_metadata — only data.services.cee for V5 endpoint
+ *   3. service_metadata — V5 endpoint reports FAILURE in
+ *                         `data.services.cee` with no payload/trace
+ *                         evidence. Narrowed to failure evidence
+ *                         only (round-5 P1.4): a successful service
+ *                         record without payloads is suspicious and
+ *                         should drop to `store` or `none` so the
+ *                         missingness is visible.
  *   4. store — no capture but a v5AnalysisFact exists for the scenario
  *   5. none — no evidence at all
  */
@@ -71,7 +77,14 @@ export function determineCaptureTier(inputs: {
   traceEntryPresent: boolean
   bundlePayloadsCeeRequestPresent: boolean
   bundlePayloadsCeeResponsePresent: boolean
-  serviceMetadataV5EndpointPresent: boolean
+  /**
+   * True when `data.services.cee.endpoint` matches the V5 turn
+   * endpoint AND the record indicates a failure (success === false,
+   * status >= 500, status === 0, or `error` set). Successful
+   * service-metadata records do NOT activate this tier — they fall
+   * through so reviewers see the missing-payload anomaly.
+   */
+  serviceMetadataV5FailurePresent: boolean
   factPresentForScenario: boolean
 }): LatestV5TurnSource {
   if (inputs.traceEntryPresent) return 'payload_trace'
@@ -81,7 +94,7 @@ export function determineCaptureTier(inputs: {
   ) {
     return 'bundle_payloads'
   }
-  if (inputs.serviceMetadataV5EndpointPresent) return 'service_metadata'
+  if (inputs.serviceMetadataV5FailurePresent) return 'service_metadata'
   if (inputs.factPresentForScenario) return 'store'
   return 'none'
 }
@@ -136,7 +149,21 @@ export interface V5CanonicalTurnDiagnostics {
   effective_cee_response_source: 'direct' | 'downstream' | 'none' | null
   latest_v5_turn: {
     request_present: boolean
+    /**
+     * True when HTTP-level completion is observed (status set,
+     * `completed === true`, or a `response` object is present). This
+     * does NOT imply a parseable body is available — see
+     * `response_body_present` for that distinction.
+     */
     response_present: boolean
+    /**
+     * True only when a parseable response body was actually captured.
+     * Distinguishes HTTP completion from body availability — a 500
+     * with no body sets `response_present: true` but
+     * `response_body_present: false`, preventing reviewers from
+     * mistaking metadata for parse evidence.
+     */
+    response_body_present: boolean
     /** HTTP request_id from the captured CEE call. */
     request_id: string | null
     /**
@@ -266,6 +293,13 @@ export interface AssembleV5CanonicalTurnDiagnosticsInputs {
    */
   captureTier: LatestV5TurnSource
   /**
+   * True when a parseable response body was captured (round-5 P0.2):
+   * trace.response.body OR bundle.payloads.cee_response is an object.
+   * Critical: a status-only trace entry sets response_present=true
+   * but body_present=false, so parse_ok must be null.
+   */
+  responseBodyPresent: boolean
+  /**
    * Rendered counts pulled from `bundle.display_state` when present;
    * `null` when display_state is absent.
    */
@@ -295,10 +329,12 @@ export function assembleV5CanonicalTurnDiagnostics(
 
   // request_id source attribution. Trace-tier entries carry the real
   // payload-trace id; lower tiers fall back to the session-level
-  // request_id. Explicit field so reviewers don't mistake the
-  // fallback for the actual trace id.
+  // request_id. Round-5 P1.1: when no actual id value exists (capture
+  // absent OR capture.request_id null), source MUST be `'none'` —
+  // emitting `'session'` with a null id would mislead reviewers into
+  // thinking the session-level fallback was attempted but came up empty.
   const requestIdSource: 'payload_trace' | 'session' | 'none' =
-    capture === null
+    capture === null || capture.request_id === null
       ? 'none'
       : latestV5TurnSource === 'payload_trace'
         ? 'payload_trace'
@@ -307,6 +343,7 @@ export function assembleV5CanonicalTurnDiagnostics(
   const latest_v5_turn = {
     request_present: capture?.request_present ?? false,
     response_present: capture?.response_present ?? false,
+    response_body_present: capture !== null && inputs.responseBodyPresent,
     request_id: capture?.request_id ?? null,
     request_id_source: requestIdSource,
     scenario_id: capture?.scenario_id ?? null,
@@ -317,17 +354,14 @@ export function assembleV5CanonicalTurnDiagnostics(
     source: latestV5TurnSource,
   }
 
-  // parse_ok is only meaningful when a response was actually received.
-  // Without a response body there's nothing to parse — emit `null` so
-  // reviewers don't mistake "no response" for "parsed and failed".
-  // (The legacy V5CeeCapture.parse_ok stays boolean for backward-compat;
-  // this snapshot overlays null based on response_present.)
+  // parse_ok is only meaningful when a response BODY was actually
+  // captured and parsed. Round-5 P0.2/P0.3 lesson: status-only or
+  // failure-without-body trace entries previously inherited
+  // `parse_ok: true` from the synthesised legacy value. Gate on the
+  // explicit `responseBodyPresent` signal now — without a body, there
+  // is nothing to parse.
   const parseOkResolved: boolean | null =
-    capture === null
-      ? null
-      : capture.response_present
-        ? capture.parse_ok
-        : null
+    capture === null || !inputs.responseBodyPresent ? null : capture.parse_ok
   const parse = {
     parse_ok: parseOkResolved,
     parse_error: capture?.parse_error ?? null,
@@ -382,14 +416,12 @@ export function assembleV5CanonicalTurnDiagnostics(
             : latestV5TurnSource === 'store'
               ? 'fallback'
               : 'unavailable',
-    // Parse strength is honest about evidence: 'live_response' only
-    // when a response body was actually received and parsed (success
-    // OR parse-error envelope with raw preserved). When the response
-    // is absent (capture null OR service-metadata-only), parse
-    // strength is 'unavailable' — never `live_response` based on a
-    // synthesised `parse_ok = false`.
+    // Parse strength is honest about evidence: 'live_response' ONLY
+    // when a parseable response body was actually captured. Round-5
+    // P0.2: status-only or failure-without-body responses must NOT
+    // surface as 'live_response' just because response_present=true.
     parse:
-      capture === null || !capture.response_present
+      capture === null || !inputs.responseBodyPresent
         ? 'unavailable'
         : 'live_response',
     results:

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -34,6 +34,34 @@ import type {
 export type CanonicalFlagSource = 'env' | 'localStorage' | 'default' | 'unknown'
 
 /**
+ * Provenance enum for the latest V5 turn snapshot — describes WHERE the
+ * capture data came from rather than the legacy `'proxy_v5_turn'`
+ * literal on V5CeeCapture.source.
+ */
+export type LatestV5TurnSource =
+  | 'payload_trace'
+  | 'bundle_payloads'
+  | 'service_metadata'
+  | 'store'
+  | 'none'
+
+/**
+ * Diagnostic-source strength per major bundle block. Reviewers use this
+ * to know which fields were sourced from live trace data vs. synthesised
+ * fallback vs. store-only assembly.
+ */
+export interface DiagnosticSourceStrength {
+  latest_v5_turn:
+    | 'live_trace'
+    | 'service_metadata'
+    | 'bundle_payloads'
+    | 'fallback'
+    | 'unavailable'
+  parse: 'live_response' | 'fallback' | 'unavailable'
+  results: 'plot_response' | 'store_report' | 'unavailable'
+}
+
+/**
  * Literal env var name the canonical-analysis flag is bound to. Kept as
  * a constant so the bundle carries the grep-able `VITE_V5_CANONICAL_ANALYSIS`
  * string verbatim (brief D — feature flag visibility).
@@ -80,8 +108,17 @@ export interface V5CanonicalTurnDiagnostics {
     status: number | null
     /** Wall-clock duration of the call in ms. */
     duration_ms: number | null
-    /** Source discriminator for capture provenance. */
-    source: 'proxy_v5_turn' | null
+    /**
+     * Where the capture data came from. Distinct from the legacy
+     * `V5CeeCapture.source: 'proxy_v5_turn'` literal; this is the
+     * brief's richer provenance enum:
+     *   - payload_trace   — assembled from a payload-trace-store entry
+     *   - bundle_payloads — assembled from `bundle.payloads.cee_*`
+     *   - service_metadata — only `data.services.cee` was present
+     *   - store           — derived from canvas store fact, no capture
+     *   - none            — no capture at all
+     */
+    source: LatestV5TurnSource
   }
   parse: {
     parse_ok: boolean | null
@@ -133,6 +170,14 @@ export interface V5CanonicalTurnDiagnostics {
     issues: CoherenceIssue[]
   }
   scenario_id_reconciliation: ScenarioIdReconciliation
+  /**
+   * Per-major-block source strength — tells reviewers which fields came
+   * from live trace, service metadata, plot response, store state, or
+   * fallback. Aggregates explicit `analysis_fact.source` /
+   * `scenario_id_reconciliation.selected_source` for the rest of the
+   * snapshot.
+   */
+  diagnostic_source_strength: DiagnosticSourceStrength
 }
 
 export interface AssembleV5CanonicalTurnDiagnosticsInputs {
@@ -157,6 +202,24 @@ export interface AssembleV5CanonicalTurnDiagnosticsInputs {
   /** Results metrics from bundle payloads / canvas store. */
   optionCount: number
   factorSensitivityCount: number
+  /**
+   * True when a V5 turn entry was found in the payload-trace store at
+   * assembly time. Drives `latest_v5_turn.source` and
+   * `diagnostic_source_strength.latest_v5_turn`.
+   */
+  v5TraceEntryPresent: boolean
+  /**
+   * True when `data.services.cee.endpoint` matched the V5 turn
+   * endpoint (`/orchestrate/v2/turn`). Used as the next-best evidence
+   * tier when no trace entry is recorded.
+   */
+  ceeServiceV5EndpointPresent: boolean
+  /**
+   * Rendered counts pulled from `bundle.display_state` when present;
+   * `null` when display_state is absent.
+   */
+  renderedOptionCount: number | null
+  renderedFactorCount: number | null
   /** Output of classifyV5CapturePipelineStatus. */
   capturePipeline: {
     capture_pipeline_status: CapturePipelineStatus
@@ -175,6 +238,23 @@ export function assembleV5CanonicalTurnDiagnostics(
     ? inputs.flagDiagnostic.source
     : 'unknown'
 
+  // Map the legacy `V5CeeCapture.source` literal + trace/service
+  // evidence to the brief's richer provenance enum.
+  const latestV5TurnSource: LatestV5TurnSource = (() => {
+    if (capture === null) {
+      // No capture object at all — derived from store fact or nothing.
+      return inputs.legacyDiagnostic.analysis_fact_status === 'present'
+        ? 'store'
+        : 'none'
+    }
+    if (inputs.v5TraceEntryPresent) return 'payload_trace'
+    if (capture.request_present || capture.response_present) {
+      return 'bundle_payloads'
+    }
+    if (inputs.ceeServiceV5EndpointPresent) return 'service_metadata'
+    return 'none'
+  })()
+
   const latest_v5_turn = {
     request_present: capture?.request_present ?? false,
     response_present: capture?.response_present ?? false,
@@ -184,7 +264,7 @@ export function assembleV5CanonicalTurnDiagnostics(
     endpoint: capture?.endpoint ?? null,
     status: capture?.status ?? null,
     duration_ms: capture?.duration_ms ?? null,
-    source: capture?.source ?? null,
+    source: latestV5TurnSource,
   }
 
   const parse = {
@@ -223,7 +303,36 @@ export function assembleV5CanonicalTurnDiagnostics(
     source: inputs.analysisStateSource,
     option_count: inputs.optionCount,
     factor_sensitivity_count: inputs.factorSensitivityCount,
+    /** Count from bundle.display_state.rendered_options when present. */
+    rendered_option_count: inputs.renderedOptionCount,
+    /** Count from bundle.display_state.rendered_factors when present. */
+    rendered_factor_count: inputs.renderedFactorCount,
     rendered_counts_documented_in: 'bundle.display_state' as const,
+  }
+
+  const diagnostic_source_strength: DiagnosticSourceStrength = {
+    latest_v5_turn:
+      latestV5TurnSource === 'payload_trace'
+        ? 'live_trace'
+        : latestV5TurnSource === 'bundle_payloads'
+          ? 'bundle_payloads'
+          : latestV5TurnSource === 'service_metadata'
+            ? 'service_metadata'
+            : latestV5TurnSource === 'store'
+              ? 'fallback'
+              : 'unavailable',
+    parse:
+      capture?.parse_ok === true || capture?.parse_ok === false
+        ? 'live_response'
+        : capture === null
+          ? 'unavailable'
+          : 'fallback',
+    results:
+      inputs.optionCount > 0 || inputs.factorSensitivityCount > 0
+        ? 'plot_response'
+        : inputs.hasResultsReport
+          ? 'store_report'
+          : 'unavailable',
   }
 
   const feature_flag_diagnostic = {
@@ -246,6 +355,7 @@ export function assembleV5CanonicalTurnDiagnostics(
     capture_pipeline_status: inputs.capturePipeline.capture_pipeline_status,
     coherence: inputs.capturePipeline.coherence,
     scenario_id_reconciliation: inputs.scenarioIdReconciliation,
+    diagnostic_source_strength,
   }
 }
 

--- a/src/lib/v5CapturePipelineStatus.ts
+++ b/src/lib/v5CapturePipelineStatus.ts
@@ -1,0 +1,226 @@
+/**
+ * Honest capture-pipeline status for the debug bundle.
+ *
+ * Sits ALONGSIDE the existing `derivePipelineStatus` (which feeds the
+ * legacy `pipeline.v5_pipeline_status` field). The legacy classifier
+ * over-emits `proxy_or_network_failure` when there's no captured failed
+ * HTTP record — this module replaces that with a coherent reading that
+ * distinguishes "missing capture" from "actual proxy/network failure".
+ *
+ * Pure module. Callers extract candidates from the bundle + payload-trace
+ * snapshot and pass them in. The legacy field is NOT modified.
+ */
+
+import type { AnalysisStateSource } from '../canvas/hooks/useAnalysisStateSource'
+
+export type CapturePipelineStatus =
+  | 'complete'
+  | 'parse_failed'
+  | 'request_failed'
+  | 'proxy_or_network_failure'
+  | 'results_rendered_from_store_without_capture'
+  | 'hydrated_only'
+  | 'capture_missing'
+
+export type CoherenceIssue =
+  | 'analysis_state_cee_v5_but_effective_cee_response_none'
+  | 'analysis_fact_present_but_cee_capture_missing'
+  | 'results_rendered_from_store_without_capture'
+  | 'scenario_id_conflict'
+  | 'parse_failed_with_raw_preserved'
+  | 'legacy_pipeline_status_misleading_proxy_or_network_failure'
+
+export type CoherenceState = 'complete' | 'partial' | 'contradictory' | 'missing'
+
+export interface FailedHttpRecord {
+  present: boolean
+  /** When present, the trace-store source classification of the failure. */
+  source: string | null
+}
+
+export interface V5CapturePipelineStatusInputs {
+  /**
+   * Slim view of the v5_cee_capture block already assembled by
+   * exportBundle. Null when no V5 CEE call was captured at all.
+   */
+  v5Capture: {
+    request_present: boolean
+    response_present: boolean
+    parse_ok: boolean
+    raw_response_present: boolean
+  } | null
+  /** True when canvas store has a populated results.report. */
+  hasResultsReport: boolean
+  /** True when the canvas store carries `rawV2Response` (fresh-run signal). */
+  rawV2ResponsePresent: boolean
+  /** Failed-HTTP-record signal from the payload-trace store. */
+  failedHttpRecord: FailedHttpRecord
+  /** From the existing AnalysisStateSource classifier. */
+  analysisStateSource: AnalysisStateSource
+  /** Existing bundle field. */
+  effectiveCeeResponseSource: 'direct' | 'downstream' | 'none' | null
+  /** Whether the canvas store has a populated v5AnalysisFact for the scenario. */
+  analysisFactPresent: boolean
+  /** Number of disagreeing scenario-ID sources from reconciliation. */
+  scenarioIdConflictCount: number
+  /** Legacy `pipeline.v5_pipeline_status` value, for disagreement detection. */
+  legacyPipelineStatus: string | null
+}
+
+export interface V5CapturePipelineStatusResult {
+  capture_pipeline_status: CapturePipelineStatus
+  coherence: {
+    state: CoherenceState
+    issues: CoherenceIssue[]
+  }
+}
+
+const PROXY_NETWORK_SOURCES: ReadonlySet<string> = new Set([
+  'proxy',
+  'netlify',
+  'preflight_or_network',
+  'browser_timeout',
+])
+
+/**
+ * Classify capture pipeline status + coherence issues. Pure function.
+ *
+ * State precedence (first match wins):
+ *   1. No V5 request captured:
+ *        a. Failed HTTP record (proxy/network) → proxy_or_network_failure
+ *        b. Failed HTTP record (other)         → request_failed
+ *        c. Results present + rawV2Response    → results_rendered_from_store_without_capture
+ *        d. Results present, no rawV2Response  → hydrated_only
+ *        e. Nothing                            → capture_missing
+ *   2. Request present, no response:
+ *        a. Failed HTTP record (proxy/network) → proxy_or_network_failure
+ *        b. Otherwise                          → request_failed
+ *   3. parse_ok === false                       → parse_failed
+ *   4. parse_ok === true                        → complete
+ *
+ * `complete` covers both analysis-bearing turns (with results) and
+ * non-analysis turns (capture honest, no results expected). The
+ * distinction is reported elsewhere — this module only classifies the
+ * capture surface, not the turn type.
+ */
+export function classifyV5CapturePipelineStatus(
+  inputs: V5CapturePipelineStatusInputs,
+): V5CapturePipelineStatusResult {
+  let status: CapturePipelineStatus
+
+  if (inputs.v5Capture === null || !inputs.v5Capture.request_present) {
+    if (inputs.failedHttpRecord.present) {
+      const src = inputs.failedHttpRecord.source
+      status =
+        src !== null && PROXY_NETWORK_SOURCES.has(src)
+          ? 'proxy_or_network_failure'
+          : 'request_failed'
+    } else if (inputs.hasResultsReport) {
+      status = inputs.rawV2ResponsePresent
+        ? 'results_rendered_from_store_without_capture'
+        : 'hydrated_only'
+    } else {
+      status = 'capture_missing'
+    }
+  } else if (!inputs.v5Capture.response_present) {
+    const src = inputs.failedHttpRecord.source
+    status =
+      inputs.failedHttpRecord.present &&
+      src !== null &&
+      PROXY_NETWORK_SOURCES.has(src)
+        ? 'proxy_or_network_failure'
+        : 'request_failed'
+  } else if (!inputs.v5Capture.parse_ok) {
+    status = 'parse_failed'
+  } else {
+    status = 'complete'
+  }
+
+  const issues: CoherenceIssue[] = []
+
+  if (
+    inputs.analysisStateSource === 'cee_v5_run_analysis' &&
+    inputs.effectiveCeeResponseSource === 'none'
+  ) {
+    issues.push('analysis_state_cee_v5_but_effective_cee_response_none')
+  }
+
+  if (
+    inputs.analysisFactPresent &&
+    (inputs.v5Capture === null || !inputs.v5Capture.request_present)
+  ) {
+    issues.push('analysis_fact_present_but_cee_capture_missing')
+  }
+
+  if (status === 'results_rendered_from_store_without_capture') {
+    issues.push('results_rendered_from_store_without_capture')
+  }
+
+  if (inputs.scenarioIdConflictCount > 0) {
+    issues.push('scenario_id_conflict')
+  }
+
+  if (status === 'parse_failed' && inputs.v5Capture?.raw_response_present) {
+    issues.push('parse_failed_with_raw_preserved')
+  }
+
+  if (
+    inputs.legacyPipelineStatus === 'proxy_or_network_failure' &&
+    status !== 'proxy_or_network_failure' &&
+    status !== 'request_failed'
+  ) {
+    issues.push('legacy_pipeline_status_misleading_proxy_or_network_failure')
+  }
+
+  let state: CoherenceState
+  if (status === 'capture_missing') {
+    state = 'missing'
+  } else if (issues.length > 0) {
+    state = 'contradictory'
+  } else if (status === 'complete') {
+    state = 'complete'
+  } else {
+    state = 'partial'
+  }
+
+  return {
+    capture_pipeline_status: status,
+    coherence: { state, issues },
+  }
+}
+
+/**
+ * Scan a payload-trace snapshot for the first failed HTTP record. A
+ * record qualifies when:
+ *   - `completed === false`, OR
+ *   - `status >= 500`, OR
+ *   - `error` / `errorName` strings are set, OR
+ *   - `source` is one of the explicit network/proxy classifications.
+ *
+ * Returns the source classification of the first failure found, or
+ * { present: false, source: null } when no failure is recorded.
+ */
+export function detectFailedHttpRecord(
+  payloads: ReadonlyArray<{
+    completed?: boolean
+    status?: number
+    error?: string
+    errorName?: string
+    source?: string
+  }>,
+): FailedHttpRecord {
+  for (const p of payloads) {
+    const sourceFlag =
+      typeof p.source === 'string' && PROXY_NETWORK_SOURCES.has(p.source)
+    const isFailed =
+      p.completed === false ||
+      (typeof p.status === 'number' && p.status >= 500) ||
+      typeof p.error === 'string' ||
+      typeof p.errorName === 'string' ||
+      sourceFlag
+    if (isFailed) {
+      return { present: true, source: (p.source as string) ?? null }
+    }
+  }
+  return { present: false, source: null }
+}

--- a/src/lib/v5CapturePipelineStatus.ts
+++ b/src/lib/v5CapturePipelineStatus.ts
@@ -236,22 +236,47 @@ export function classifyV5CapturePipelineStatus(
 }
 
 /**
- * Locate the most-recent V5 CEE turn entry in the payload-trace
- * snapshot. The store keeps entries most-recent-first, so we simply
- * return the first matching record. Used by the bundle assembler to
- * populate `latest_v5_turn.{request_id, endpoint, duration_ms}` from
- * the actual capture rather than from coarse session-level data.
+ * Locate the most-relevant V5 CEE turn entry in the payload-trace
+ * snapshot. Used by the bundle assembler to populate
+ * `latest_v5_turn.{request_id, endpoint, duration_ms,
+ * request_present, response_present}` from the actual capture
+ * rather than from coarse session-level data.
+ *
+ * Preference order (the trace store keeps entries most-recent-first):
+ *   1. completed response (status set OR completed === true)
+ *   2. request-only (request body present but no response yet)
+ *   3. any matching V5 entry (metadata-only stub fallback)
+ *
+ * Returns null when no V5 turn entry is recorded.
  */
 export function findLatestV5TurnEntry<
-  T extends { service?: string; endpoint?: string },
+  T extends {
+    service?: string
+    endpoint?: string
+    completed?: boolean
+    status?: number
+    request?: { body?: unknown }
+    response?: { body?: unknown }
+  },
 >(payloads: ReadonlyArray<T>): T | null {
-  for (const p of payloads) {
+  const v5 = payloads.filter((p) => {
     const endpoint = typeof p.endpoint === 'string' ? p.endpoint : ''
-    if (p.service === 'CEE' && endpoint.includes('/orchestrate/v2/turn')) {
-      return p
-    }
-  }
-  return null
+    return p.service === 'CEE' && endpoint.includes('/orchestrate/v2/turn')
+  })
+  if (v5.length === 0) return null
+
+  // Tier 1: completed response (most authoritative).
+  const completed = v5.find(
+    (p) => p.response !== undefined || p.completed === true || typeof p.status === 'number',
+  )
+  if (completed) return completed
+
+  // Tier 2: request-only (request fired, response pending).
+  const requestOnly = v5.find((p) => p.request !== undefined)
+  if (requestOnly) return requestOnly
+
+  // Tier 3: metadata-only stub fallback.
+  return v5[0]
 }
 
 /**

--- a/src/lib/v5CapturePipelineStatus.ts
+++ b/src/lib/v5CapturePipelineStatus.ts
@@ -152,7 +152,19 @@ export function classifyV5CapturePipelineStatus(
     issues.push('analysis_fact_present_but_cee_capture_missing')
   }
 
-  if (status === 'results_rendered_from_store_without_capture') {
+  // ADDITIVE — fires whenever results exist without a live V5 capture
+  // AND no failed HTTP record explains the absence. The chosen `status`
+  // may be `hydrated_only` or `results_rendered_from_store_without_capture`
+  // depending on rawV2Response evidence, but the contradiction itself is
+  // present in both cases. Decoupling means reviewers see ALL applicable
+  // issues regardless of which status enum was selected.
+  const resultsWithoutLiveCapture =
+    inputs.hasResultsReport &&
+    (inputs.v5Capture === null ||
+      !inputs.v5Capture.request_present ||
+      !inputs.v5Capture.response_present) &&
+    !inputs.failedHttpRecord.present
+  if (resultsWithoutLiveCapture) {
     issues.push('results_rendered_from_store_without_capture')
   }
 
@@ -160,7 +172,15 @@ export function classifyV5CapturePipelineStatus(
     issues.push('scenario_id_conflict')
   }
 
-  if (status === 'parse_failed' && inputs.v5Capture?.raw_response_present) {
+  // Independent of chosen status: fires whenever a parse-error envelope
+  // preserved the raw response. parse_ok=false + raw_response_present=true
+  // is the canonical PR #147 invariant signature; emit it as a visible
+  // issue so reviewers don't have to cross-reference status enums.
+  if (
+    inputs.v5Capture !== null &&
+    !inputs.v5Capture.parse_ok &&
+    inputs.v5Capture.raw_response_present
+  ) {
     issues.push('parse_failed_with_raw_preserved')
   }
 
@@ -190,18 +210,25 @@ export function classifyV5CapturePipelineStatus(
 }
 
 /**
- * Scan a payload-trace snapshot for the first failed HTTP record. A
- * record qualifies when:
- *   - `completed === false`, OR
- *   - `status >= 500`, OR
- *   - `error` / `errorName` strings are set, OR
- *   - `source` is one of the explicit network/proxy classifications.
+ * Scan a payload-trace snapshot for the first failed HTTP record that
+ * belongs to the V5 CEE turn (the `/orchestrate/v2/turn` endpoint).
+ * Unrelated failed records (PLoT, legacy CEE endpoints, ISL probes,
+ * etc.) MUST NOT influence the V5 capture classification.
  *
- * Returns the source classification of the first failure found, or
- * { present: false, source: null } when no failure is recorded.
+ * A record qualifies when ALL of:
+ *   - service is CEE
+ *   - endpoint contains `/orchestrate/v2/turn`
+ *   - one of: `completed === false`, `status >= 500`, `error` /
+ *     `errorName` set, or `source ∈ {proxy,netlify,preflight_or_network,
+ *     browser_timeout}`.
+ *
+ * Returns the source classification of the first qualifying failure, or
+ * { present: false, source: null } when no V5-turn failure is recorded.
  */
 export function detectFailedHttpRecord(
   payloads: ReadonlyArray<{
+    service?: string
+    endpoint?: string
     completed?: boolean
     status?: number
     error?: string
@@ -210,6 +237,12 @@ export function detectFailedHttpRecord(
   }>,
 ): FailedHttpRecord {
   for (const p of payloads) {
+    // Scope filter: only V5 CEE turn records influence V5 capture status.
+    const endpoint = typeof p.endpoint === 'string' ? p.endpoint : ''
+    const isV5CeeTurn =
+      p.service === 'CEE' && endpoint.includes('/orchestrate/v2/turn')
+    if (!isV5CeeTurn) continue
+
     const sourceFlag =
       typeof p.source === 'string' && PROXY_NETWORK_SOURCES.has(p.source)
     const isFailed =

--- a/src/lib/v5CapturePipelineStatus.ts
+++ b/src/lib/v5CapturePipelineStatus.ts
@@ -235,17 +235,46 @@ export function classifyV5CapturePipelineStatus(
   }
 }
 
+/** Whether a trace-store entry carries a parseable response body. */
+function traceEntryHasResponseBody(p: {
+  response?: { body?: unknown }
+}): boolean {
+  return (
+    p.response !== undefined &&
+    p.response !== null &&
+    p.response.body !== undefined &&
+    p.response.body !== null
+  )
+}
+
+/** Whether a trace-store entry carries a request body. */
+function traceEntryHasRequestBody(p: {
+  request?: { body?: unknown }
+}): boolean {
+  return (
+    p.request !== undefined &&
+    p.request !== null &&
+    p.request.body !== undefined &&
+    p.request.body !== null
+  )
+}
+
 /**
  * Locate the most-relevant V5 CEE turn entry in the payload-trace
  * snapshot. Used by the bundle assembler to populate
  * `latest_v5_turn.{request_id, endpoint, duration_ms,
- * request_present, response_present}` from the actual capture
- * rather than from coarse session-level data.
+ * request_present, response_present, response_body_present}` from the
+ * actual capture rather than from coarse session-level data.
  *
  * Preference order (the trace store keeps entries most-recent-first):
- *   1. completed response (status set OR completed === true)
- *   2. request-only (request body present but no response yet)
- *   3. any matching V5 entry (metadata-only stub fallback)
+ *   1. response BODY present (a parseable response was captured)
+ *   2. response metadata only (completed === true OR status set, no body)
+ *   3. request-only (request body present but no response yet)
+ *   4. any matching V5 entry (metadata-only stub fallback)
+ *
+ * The body-first preference prevents a status-only metadata stub from
+ * masking a richer body-bearing entry — directly addresses the
+ * round-5 P1.2 concern.
  *
  * Returns null when no V5 turn entry is recorded.
  */
@@ -265,18 +294,31 @@ export function findLatestV5TurnEntry<
   })
   if (v5.length === 0) return null
 
-  // Tier 1: completed response (most authoritative).
-  const completed = v5.find(
-    (p) => p.response !== undefined || p.completed === true || typeof p.status === 'number',
-  )
-  if (completed) return completed
+  // Tier 1: a parseable response body is present (most authoritative).
+  const withBody = v5.find(traceEntryHasResponseBody)
+  if (withBody) return withBody
 
-  // Tier 2: request-only (request fired, response pending).
-  const requestOnly = v5.find((p) => p.request !== undefined)
+  // Tier 2: HTTP completed but no body (status set or completed flag).
+  const completedNoBody = v5.find(
+    (p) => p.completed === true || typeof p.status === 'number',
+  )
+  if (completedNoBody) return completedNoBody
+
+  // Tier 3: request fired, response pending.
+  const requestOnly = v5.find(traceEntryHasRequestBody)
   if (requestOnly) return requestOnly
 
-  // Tier 3: metadata-only stub fallback.
+  // Tier 4: metadata-only stub fallback.
   return v5[0]
+}
+
+/**
+ * Body-presence helper exposed for callers that need to disambiguate
+ * "HTTP completed" from "parseable body available". This is the
+ * structural signal behind `latest_v5_turn.response_body_present`.
+ */
+export function hasResponseBody(p: { response?: { body?: unknown } }): boolean {
+  return traceEntryHasResponseBody(p)
 }
 
 /**

--- a/src/lib/v5CapturePipelineStatus.ts
+++ b/src/lib/v5CapturePipelineStatus.ts
@@ -17,6 +17,13 @@ export type CapturePipelineStatus =
   | 'complete'
   | 'parse_failed'
   | 'request_failed'
+  /**
+   * V5-endpoint failure detected via `data.services.cee` 5xx/error
+   * when the payload-trace has NO corresponding record. Distinguishes
+   * "service-metadata says it failed" from "trace recorded a failed
+   * proxy call" so reviewers know the evidence is metadata-level.
+   */
+  | 'request_failed_from_service_metadata'
   | 'proxy_or_network_failure'
   | 'results_rendered_from_store_without_capture'
   | 'hydrated_only'
@@ -55,6 +62,14 @@ export interface V5CapturePipelineStatusInputs {
   rawV2ResponsePresent: boolean
   /** Failed-HTTP-record signal from the payload-trace store. */
   failedHttpRecord: FailedHttpRecord
+  /**
+   * Service-metadata-only V5 endpoint failure signal: true when
+   * `data.services.cee.endpoint` matches the V5 turn endpoint AND its
+   * status indicates failure (>= 500 or success === false), but the
+   * payload-trace has no corresponding entry. Distinct from
+   * `failedHttpRecord` which requires trace-store evidence.
+   */
+  serviceMetadataV5Failure: boolean
   /** From the existing AnalysisStateSource classifier. */
   analysisStateSource: AnalysisStateSource
   /** Existing bundle field. */
@@ -115,6 +130,12 @@ export function classifyV5CapturePipelineStatus(
         src !== null && PROXY_NETWORK_SOURCES.has(src)
           ? 'proxy_or_network_failure'
           : 'request_failed'
+    } else if (inputs.serviceMetadataV5Failure) {
+      // Service-metadata 5xx without a trace entry — the failure
+      // happened but the trace store doesn't carry corroborating
+      // evidence. Distinct from `request_failed` (trace-confirmed)
+      // and `proxy_or_network_failure` (network/proxy source).
+      status = 'request_failed_from_service_metadata'
     } else if (inputs.hasResultsReport) {
       status = inputs.rawV2ResponsePresent
         ? 'results_rendered_from_store_without_capture'
@@ -184,10 +205,15 @@ export function classifyV5CapturePipelineStatus(
     issues.push('parse_failed_with_raw_preserved')
   }
 
+  // Legacy says `proxy_or_network_failure` (a specific network/proxy
+  // cause), but the new scoped classifier disagrees about the cause.
+  // Fire the mislabel issue whenever the new status is anything OTHER
+  // than `proxy_or_network_failure` — including `request_failed`, which
+  // is still a different evidence-strength claim (the failure happened
+  // but it's not proxy/network-confirmed).
   if (
     inputs.legacyPipelineStatus === 'proxy_or_network_failure' &&
-    status !== 'proxy_or_network_failure' &&
-    status !== 'request_failed'
+    status !== 'proxy_or_network_failure'
   ) {
     issues.push('legacy_pipeline_status_misleading_proxy_or_network_failure')
   }
@@ -207,6 +233,25 @@ export function classifyV5CapturePipelineStatus(
     capture_pipeline_status: status,
     coherence: { state, issues },
   }
+}
+
+/**
+ * Locate the most-recent V5 CEE turn entry in the payload-trace
+ * snapshot. The store keeps entries most-recent-first, so we simply
+ * return the first matching record. Used by the bundle assembler to
+ * populate `latest_v5_turn.{request_id, endpoint, duration_ms}` from
+ * the actual capture rather than from coarse session-level data.
+ */
+export function findLatestV5TurnEntry<
+  T extends { service?: string; endpoint?: string },
+>(payloads: ReadonlyArray<T>): T | null {
+  for (const p of payloads) {
+    const endpoint = typeof p.endpoint === 'string' ? p.endpoint : ''
+    if (p.service === 'CEE' && endpoint.includes('/orchestrate/v2/turn')) {
+      return p
+    }
+  }
+  return null
 }
 
 /**


### PR DESCRIPTION
## Summary

Diagnostic plumbing only — no product behaviour, prompts, schemas, packages, lockfiles, CEE, PLoT, or ISL code were changed. Makes the exported debug bundle the canonical evidence artefact for V5 staging validation.

The current bundle contradicts itself: \`analysis_state_source = cee_v5_run_analysis\` alongside \`effective_cee_response_source = none\`, \`v5_cee_capture = null\` while an analysis fact appears present, \`pipeline.v5_pipeline_status = proxy_or_network_failure\` with no failed request, \`session.scenario_id = null\` while a graph exists. This PR makes those contradictions explicit, classifies capture state honestly, and lays down a scientific-validation section that never overclaims from inferred data.

## Contradictions fixed (P0)

| Symptom in uploaded bundles | New surface |
|---|---|
| `session.scenario_id` hardcoded null | Reconciled from store > v5_fact > payload > url > full_graph; conflicts recorded in `scenario_id_reconciliation.conflicts` |
| `proxy_or_network_failure` with no failed request | New `capture_pipeline_status` enum (7 states); `proxy_or_network_failure` only when an actual proxy/network record exists; emits `legacy_pipeline_status_misleading_proxy_or_network_failure` coherence issue when the legacy field disagrees |
| `analysis_state_source = cee_v5_run_analysis` + `effective_cee_response_source = none` | Explicit coherence issue `analysis_state_cee_v5_but_effective_cee_response_none` |
| `analysis_fact_status = present` + `v5_cee_capture = null` | Explicit coherence issue `analysis_fact_present_but_cee_capture_missing` |
| Results rendered from store, no live capture | Status `results_rendered_from_store_without_capture` or `hydrated_only` — never confused with network failure |

The legacy `pipeline.v5_pipeline_status` field and the legacy `v5_canonical_analysis` block stay **untouched**; the new fields are emitted alongside.

## New bundle fields

- \`session.scenario_id\` (was hardcoded \`null\`) + \`session.scenario_id_source\`
- \`scenario_id_reconciliation\` — full candidate map + conflicts
- \`capture_pipeline_status\` — additive honest classifier
- \`v5_canonical_turn_diagnostics\` — composed snapshot (canonical_flag_source, latest_v5_turn, parse, analysis_fact, results metrics, coherence)
- \`scientific_validation\` — seven validators (see matrix below)
- \`debug_redaction_manifest\` — preserved_analytical_paths policy + redacted/omitted manifest

## Render-log events added

Privacy-safe structural fields only (compile-time allowlist + runtime JWT/Bearer/key=/email scrub):

- \`dgai.debug_bundle.export_started\`
- \`dgai.debug_bundle.capture_status\`
- \`dgai.debug_bundle.scientific_validation_summary\`
- \`dgai.debug_bundle.export_completed\`

## Scientific validation availability matrix

| Validator | Source | claim_strength | Notes |
|---|---|---|---|
| user_std_propagation | ISL request (not captured by DGAI today) | `unavailable` until upstream lands | `required_upstream_support: ['plot.debug.isl_request']`. Optional inferred `expected_from_plot_request` for reviewer comparison only |
| confidence_validation | `factor_sensitivity[*].confidence_provenance` | `derived` when present | Detects `plot_unified_v3` + old-lattice `{0.25, 0.375, 0.5, 0.625, 0.75}` |
| evidence_gap_validation | `m1_coaching.evidence_gaps` + canvas `ceeAnalysisReady.options[*].interventions` | `derived` | Flags intervention-target leakage (PR #166 regression detector) |
| evpi_validation | `evpi_percentage_points` + `value_of_information` | `derived` | Surfaced vs raw diagnostic mirrors separated; surfaced negatives → fail |
| flip_threshold_validation | `flip_thresholds_status` (PR #167) | `derived` when present; otherwise `unavailable` | Never infers a pass from `flip_value` presence |
| auto_noise_validation | `auto_noise_applied` + `auto_noise_provenance` | `derived` | Checks top-level/provenance agreement |
| response_shape_validation | `bundle.payloads.plot_response` keys | `observed` / `inferred` | Honest live vs hydrated vs fallback labelling |

Honesty rule: \`inferred\` never pairs with \`status: pass\`. Enforced by \`assertHonestyRules\` and covered in tests. \`overall_status = insufficient_raw_evidence\` when fewer than three validators reach observed/derived evidence — that's correct behaviour for hydrated/Supabase-resumed bundles, **not** a bug.

## Required upstream support (per service)

- **PLoT** — expose ISL request payload at \`plot.debug.isl_request\` so user-std propagation can verify what was forwarded to ISL.
- **PLoT** — emit \`flip_thresholds_status\` enum so flip-threshold validation can move from \`unavailable\` to \`derived\` (PR #167 in flight).
- **PLoT/ISL** — confirm \`auto_noise_provenance.applied\` parity with top-level \`auto_noise_applied\` (validator flags disagreement when seen).

## Redaction policy

- Path-aware preservation list (declarative, audited in every export via \`debug_redaction_manifest.preserved_analytical_paths\`) — no generic key allowlist like \`{value, mean, std, unit, cap}\`.
- Existing \`redactPayload\` continues to allowlist by KEY for the analytical containers (\`observed_state\`, \`constraint_analysis\`, \`goal_constraints\`); the manifest documents this policy explicitly.
- Sensitive keys (\`password\`, \`token\`, \`secret\`, \`apiKey\`, \`api_key\`, \`authorization\`) remain masked.
- Manifest reports redacted paths (with reason codes: \`sensitive_key\`, \`max_depth_or_unserialisable\`, \`array_capped\`, \`size_limit\`, \`circular_reference\`, \`string_truncated\`) and omitted top-level sections (with reason codes per assembler).

## Files changed

**New (pure modules):**
- \`src/lib/scenarioIdReconciliation.ts\`
- \`src/lib/v5CapturePipelineStatus.ts\`
- \`src/lib/v5CanonicalTurnDiagnostics.ts\`
- \`src/lib/debugBundleLogger.ts\`
- \`src/lib/debugRedactionManifest.ts\`
- \`src/lib/scientificValidation/\` (types, orchestrator, 7 validators)

**New tests:** 8 spec files

**Modified (surgical):**
- \`src/components/debug/utils/exportBundle.ts\` — additive wiring (+354/-3)
- \`src/flags.ts\` — 2-line addition exposing \`diagnoseV5CanonicalAnalysis()\`

**Not modified:** \`src/v5/responseParser.ts\`, \`applyV5State.ts\`, \`v5Adapter.ts\`, \`payload-trace-store.ts\`, \`v5CanonicalAnalysisDiagnostics.ts\`, \`derivePipelineStatus.ts\`, \`canvas/store.ts\`, CEE/PLoT/ISL code, prompts, schemas, package.json, lockfiles.

## P2 exclusion (deliberate)

No debug UI card in this PR. No \`DebugPanelV2.tsx\` edits. No testing-suite UI work. The new sections are JSON-only.

## Tests run

Local pre-push gate: **ALL CHECKS PASSED** after a clean \`pnpm install --frozen-lockfile\` repaired pre-existing pnpm-cache corruption. Smoke (7 files, 459 tests, 3.76s) + typecheck + lint + dep audit + V5 schemas SHA all green.

New tests in this PR: **139 tests across 8 files, all passing locally** (3.39s):
- \`src/lib/__tests__/scenarioIdReconciliation.spec.ts\`
- \`src/lib/__tests__/v5CapturePipelineStatus.spec.ts\`
- \`src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts\`
- \`src/lib/__tests__/debugBundleLogger.spec.ts\`
- \`src/lib/__tests__/debugRedactionManifest.spec.ts\`
- \`src/lib/scientificValidation/__tests__/index.spec.ts\`
- \`src/components/debug/__tests__/exportBundle.scenarioId.spec.ts\`
- \`src/components/debug/__tests__/exportBundle.legacyInvariants.spec.ts\`

CI will run the full \~6,284-test suite via \`.github/workflows/staging-full-tests.yml\`.

## Manual acceptance plan

After review and staging deploy:
1. Start a draft graph with the brief's scenario (\"hire marketing manager vs AI tool\").
2. Click Run Analysis.
3. Export the debug bundle immediately after Results render.
4. The bundle should show canonical flag status, CEE capture status, parse status, scenario ID source, \`capture_pipeline_status\`, \`coherence.issues\`, live vs hydrated source, every scientific validator with status + claim_strength + required_upstream_support, and the redaction manifest.
5. Render-log events visible in browser console.

## Known limitations

- ISL request/response are bundled inside V2 PLoT — DGAI cannot observe an independent ISL surface. \`user_std_propagation\` will report \`unavailable\` until \`plot.debug.isl_request\` lands.
- \`flip_thresholds_status\` is PR #167 work-in-flight. Validator reports \`unavailable\` until upstream emits it.
- \`graph_hash_at_generation\` is read-through with \`null\` fallback — the \`v5AnalysisFact\` slice may not carry it on every code path; intentionally not expanding scope to wire that.
- \`overall_status = insufficient_raw_evidence\` is the expected state for hydrated/Supabase-resumed bundles — that's honesty, not a bug.

## Explicit confirmations

- ✓ No CEE / PLoT / ISL / prompt / PMS / schema-package changes
- ✓ No Results UI redesign or Phase 3 rendering work
- ✓ No debug UI card (P2 deliberately excluded)
- ✓ No rollback of PR #147 (parser invariants preserved; legacy \`v5_canonical_analysis\` block emitted unchanged)
- ✓ No lockfile / package churn
- ✓ Legacy \`pipeline.v5_pipeline_status\` field untouched

## Test plan

- [ ] CI green on \`staging-full-tests.yml\`
- [ ] Manual acceptance scenario on staging — export bundle and confirm new sections answer the brief's eleven goal questions
- [ ] Render-log events visible in browser console with structural fields only (no prose, no payloads, no tokens)
- [ ] PR not merged until upstream review signs off

🤖 Generated with [Claude Code](https://claude.com/claude-code)