### PR TITLE
chore(deploy): enable aiPanelV2 on staging via Netlify context env

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,6 +35,21 @@
   VITE_ENABLE_ORCHESTRATOR_V2 = "true"
 
 # =============================================================================
+# Staging-only env overrides
+# Netlify's deploy-context syntax scopes env vars to a specific branch's
+# builds. `[context.staging.environment]` applies only to builds for the
+# `staging` branch (which Netlify deploys to `staging--olumi.netlify.app`).
+# The production context (main) inherits ONLY from `[build.environment]`
+# above, so flags listed here stay off in production until explicitly
+# promoted.
+# =============================================================================
+[context.staging.environment]
+  # aiPanelV2 — floating-first Olumi UX (PR #148 + PR #149).
+  # Enabled on staging for manual testing. Promote to production by
+  # adding to `[build.environment]` ONLY after sign-off.
+  VITE_FEATURE_AI_PANEL_V2 = "true"
+
+# =============================================================================
 # Security Headers (P0 - Enterprise Compliance)
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Single-file follow-up to merged [PR #149](https://github.com/Talchain/DecisionGuideAI/pull/149). Adds a Netlify `[context.staging.environment]` block to `netlify.toml` so the staging branch deploy (\`staging--olumi.netlify.app\`) receives \`VITE_FEATURE_AI_PANEL_V2=true\`. Production (\`main\` → \`olumi.netlify.app\`) is intentionally NOT touched and stays off.

## Why this approach

- Project's staging mechanism is Netlify branch deploys (\`docs/DEPLOY.md\` confirms staging URL).
- Netlify context syntax (\`[context.<branch>.environment]\`) is the canonical config-based scoping for branch-specific env vars.
- Production context (main) inherits only from \`[build.environment]\`, so this change does NOT affect production builds.
- In-code default in \`src/flags.ts\` remains \`false\` — only the staging build receives the env override.

## Test plan

- [x] Diff is netlify.toml-only (15 lines added, no source changes).
- [x] Pre-push gate green.
- [ ] After merge: monitor Netlify staging build; confirm deploy URL serves FF-on first-use composer.
- [ ] If the toml-context approach doesn't take effect (e.g. Netlify site is configured for \`main\` as production context only), fall back to enabling via Netlify dashboard.

## Promotion path

To enable in production after sign-off, move \`VITE_FEATURE_AI_PANEL_V2 = "true"\` from the \`[context.staging.environment]\` block into \`[build.environment]\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)