### PR TITLE
fix(ai-panel-v2): UX correction pass — focus over placeholder, product-rule chip, floating density, focused first-use, gen-state lock

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -171,6 +171,7 @@ export const AIInputBar = memo(
             placeholder={effectivePlaceholder}
             rows={1}
             disabled={inputDisabled}
+            aria-disabled={inputDisabled}
             aria-label={ariaLabel ?? 'Chat message'}
             data-testid={`${testId ?? `ai-input-bar-${variant}`}-textarea`}
             className={typo(
@@ -184,7 +185,8 @@ export const AIInputBar = memo(
               <button
                 type="button"
                 onClick={(e) => onCogClick(e.currentTarget)}
-                disabled={disabled}
+                disabled={inputDisabled}
+                aria-disabled={inputDisabled}
                 className="inline-flex items-center justify-center w-6 h-6 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-50"
                 aria-label="Settings"
                 data-testid={`${testId ?? `ai-input-bar-${variant}`}-cog`}
@@ -196,6 +198,7 @@ export const AIInputBar = memo(
               type="button"
               onClick={handleSend}
               disabled={!canSend}
+              aria-disabled={!canSend}
               className="inline-flex items-center justify-center w-6 h-6 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-40 disabled:hover:bg-transparent"
               aria-label="Send"
               data-testid={`${testId ?? `ai-input-bar-${variant}`}-send`}
@@ -208,8 +211,9 @@ export const AIInputBar = memo(
           <button
             type="button"
             onClick={onChevronClick}
-            disabled={disabled}
-            className="inline-flex items-center justify-center w-7 h-7 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
+            disabled={inputDisabled}
+            aria-disabled={inputDisabled}
+            className="inline-flex items-center justify-center w-7 h-7 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-50"
             aria-label="Open Olumi in floating panel"
             data-testid={`${testId ?? `ai-input-bar-${variant}`}-chevron`}
             title="Open in floating window"

--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -17,9 +17,11 @@ interface FirstUseComposerProps {
 
 const PANEL_WIDTH = 480
 const PANEL_MARGIN = 16
-// Height tightened in the UX polish pass: guidance text + input bar with
-// minimal gap — no large dead space below the textarea.
-const PANEL_HEIGHT = 152
+// Content-fit height: panel sizes to its guidance + input + padding,
+// with a min-height floor so the layout doesn't collapse on edge cases
+// (empty stage placeholder, missing fonts). Fixed-height was brittle —
+// any copy or padding tweak would either clip or leave dead space.
+const PANEL_MIN_HEIGHT = 108
 
 /**
  * FirstUseComposer — centred composer that auto-opens when the canvas is
@@ -143,18 +145,20 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: F
         // Responsive width: cap at PANEL_WIDTH on wide viewports, shrink to
         // viewport - 2*margin on narrow ones so the composer never overflows.
         width: `min(${PANEL_WIDTH}px, calc(100vw - ${PANEL_MARGIN * 2}px))`,
-        height: PANEL_HEIGHT,
-        // Position: centred when there's room, otherwise pinned to the
-        // left margin. The max(margin, …) clamp prevents negative left at
-        // narrow widths; the min(…) cap stops it pushing past the centre
-        // when the responsive width kicks in.
+        // Content-fit height with a min-height floor (defensive only —
+        // expect the actual height to be guidance + input + ~24px padding).
+        minHeight: PANEL_MIN_HEIGHT,
+        // Vertical: pin near the upper third of the canvas so the focused
+        // start card sits where the eye lands first, with a hard 16px
+        // floor at narrow viewports. Horizontal: centre when there's
+        // room, otherwise pinned to the left margin.
         left: `max(${PANEL_MARGIN}px, calc(50% - ${PANEL_WIDTH / 2}px))`,
-        top: `max(${PANEL_MARGIN}px, calc(50% - ${PANEL_HEIGHT / 2}px))`,
+        top: `max(${PANEL_MARGIN}px, calc(30% - ${PANEL_MIN_HEIGHT / 2}px))`,
       }}
     >
-      <div className="flex flex-col items-center px-6 pt-4 pb-2">
+      <div className="flex flex-col items-center px-5 pt-3 pb-1.5">
         <p className={typo('panelBody', 'text-text-light text-center')}>
-          Describe your decision, the options you're weighing, and what a good outcome looks like.
+          Describe the decision, options, goal and constraints.
         </p>
       </div>
       <AIInputBar

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -611,7 +611,12 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         </div>
       </div>
 
-      <div className="flex flex-1 min-h-0 flex-col">
+      {/* `floating-density` activates the scoped compact CSS overrides
+         defined in Conversation.module.css (tighter message gap, bubble
+         padding, chip sizing). The class is a CSS hook only; React /
+         ConversationPanel props are unchanged so the docked Olumi tab
+         keeps its normal density. */}
+      <div className="floating-density flex flex-1 min-h-0 flex-col">
         <ConversationPanel
           conversation={conversation}
           onCollapse={close}

--- a/src/canvas/components/OlumiTabBody.tsx
+++ b/src/canvas/components/OlumiTabBody.tsx
@@ -1,10 +1,8 @@
 import { memo, useCallback } from 'react'
-import { ExternalLink, MessageSquare } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
 import { typo } from '../../styles/typography'
 import { useConversationContext } from '../conversation/ConversationContext'
 import { ConversationPanel } from '../conversation/ConversationPanel'
-import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
-import { focusFloating } from '../hooks/useFloatingFocus'
 
 interface OlumiTabBodyProps {
   /** Opens the floating Olumi panel for the user. */
@@ -14,19 +12,20 @@ interface OlumiTabBodyProps {
 /**
  * OlumiTabBody — docked Olumi tab content.
  *
- * Three render states:
- *  - Floating panel is open → placeholder + actions ("Focus floating",
- *    "Dock here"). Preserves the one-readable-surface invariant: we never
- *    render the conversation twice.
- *  - Empty conversation (and floating closed) → guidance text + float-out.
+ * Two render states:
+ *  - Empty conversation → guidance text + float-out.
  *  - Otherwise → full ConversationPanel with `hideComposer` (the persistent
  *    strip below the tab body owns submission).
+ *
+ * When the floating panel is open, the tab is NOT switched to this body —
+ * OutputsDock.handleTabClick intercepts the Olumi-tab click and calls
+ * focusFloating() instead, so the user's current Analysis/Compare/Model
+ * tab stays active. The previous "floating-state placeholder" branch was
+ * removed in the UX correction pass to avoid wasting the right panel.
  */
 export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabBodyProps) {
   const conversation = useConversationContext()
   const realMessageCount = conversation.messages.filter((m) => !m.synthetic).length
-  const floatingIsOpen = useFloatingPanelState((s) => s.isOpen)
-  const closeFloating = useFloatingPanelState((s) => s.close)
 
   const handleCollapse = useCallback(() => {
     // The dock's own collapse button handles this; ChatTopBar is hidden anyway.
@@ -34,54 +33,6 @@ export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabB
   const handleAttach = useCallback(() => {
     // Attach evidence is handled by CogPopover, not here.
   }, [])
-
-  const handleFocusFloating = useCallback(() => {
-    focusFloating()
-  }, [])
-  const handleDockHere = useCallback(() => {
-    closeFloating()
-  }, [closeFloating])
-
-  if (floatingIsOpen) {
-    return (
-      <div
-        className="flex flex-1 min-h-0 items-center justify-center px-6 py-6"
-        data-testid="olumi-tab-floating-placeholder"
-      >
-        <div className="flex flex-col items-center gap-3 max-w-xs">
-          <MessageSquare className="w-8 h-8 text-text-light" aria-hidden="true" />
-          <p className={typo('panelBody', 'text-text-body text-center')}>
-            Olumi is open in the floating panel.
-          </p>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={handleFocusFloating}
-              className={typo(
-                'panelMeta',
-                'inline-flex items-center gap-1 text-info hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-info rounded px-1.5 py-0.5',
-              )}
-              data-testid="olumi-tab-focus-floating"
-            >
-              Focus floating
-            </button>
-            <span className={typo('panelMeta', 'text-text-light')} aria-hidden="true">·</span>
-            <button
-              type="button"
-              onClick={handleDockHere}
-              className={typo(
-                'panelMeta',
-                'inline-flex items-center gap-1 text-info hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-info rounded px-1.5 py-0.5',
-              )}
-              data-testid="olumi-tab-dock-here"
-            >
-              Dock here
-            </button>
-          </div>
-        </div>
-      </div>
-    )
-  }
 
   if (realMessageCount === 0) {
     return (

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1191,11 +1191,16 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   }
 
   const handleTabClick = (tab: OutputsDockTab) => {
-    // Polish (Item 1): the docked Olumi tab is reachable even when floating
-    // is open — OlumiTabBody renders the floating-state placeholder (with
-    // Focus floating / Dock here actions) instead of duplicating the
-    // conversation. The placeholder owns the focus affordance; the tab click
-    // just activates the tab.
+    // UX correction (P0.1): when the floating Olumi panel is open, clicking
+    // the Olumi tab focuses the floating panel instead of switching the
+    // right panel to a blank placeholder. The user's current Analysis /
+    // Compare / Model tab stays visible. Dock-back is exclusively via the
+    // floating header's PanelRight button. Replaces the brief PR #149
+    // "placeholder" branch that wasted the right panel.
+    if (tab === 'olumi' && useFloatingPanelState.getState().isOpen) {
+      focusFloating()
+      return
+    }
     setState(prev => ({ ...prev, isOpen: true, activeTab: tab }))
     // E1: Sync tab state to Zustand store for cross-component navigation
     useUIStore.getState().setActiveOutputTab(tab as OutputTab)
@@ -1356,16 +1361,15 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     {tab.id === 'olumi' && <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />}
                     {tab.label}
                     {tab.id === 'olumi' && floatingPanelIsOpen && (
+                      // P1.6 subtler indicator — small filled dot in the
+                      // tab label instead of the previous outlined "Open"
+                      // pill, which competed with the active-tab underline.
                       <span
-                        className={typo(
-                          'panelMeta',
-                          'inline-flex items-center text-info border border-info/30 rounded-full px-1.5 leading-none',
-                        )}
+                        className="inline-flex w-1.5 h-1.5 rounded-full bg-info"
                         data-testid="olumi-tab-floating-badge"
-                        aria-label="Olumi is open in the floating panel"
-                      >
-                        Open
-                      </span>
+                        aria-label="Olumi is open. Focus floating panel"
+                        title="Olumi is open. Focus floating panel"
+                      />
                     )}
                     {tab.id === 'results' && showResultsTabStaleWarning && (
                       <AlertTriangle

--- a/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
+++ b/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
@@ -242,6 +242,45 @@ describe('FirstUseComposer — responsive width (P1.2)', () => {
   })
 })
 
+describe('FirstUseComposer — focused start card (UX correction P0.4)', () => {
+  it('uses the concise guidance copy and content-fit height', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const dialog = screen.getByTestId('first-use-composer') as HTMLElement
+
+    // Concise copy — reviewer-approved string verbatim.
+    expect(
+      screen.getByText(/Describe the decision, options, goal and constraints\./i),
+    ).toBeInTheDocument()
+    // Previous verbose copy must NOT leak through.
+    expect(
+      screen.queryByText(/Describe your decision, the options you're weighing/i),
+    ).toBeNull()
+
+    // Content-fit: the dialog has `min-height` (not a fixed `height`).
+    // jsdom can't evaluate the layout but the inline style proves the
+    // chosen sizing strategy.
+    const style = dialog.getAttribute('style') ?? ''
+    expect(style).toMatch(/min-height:\s*108px/i)
+    expect(style).not.toMatch(/(^|[^-])height:\s*\d+px/i)
+  })
+
+  it('does NOT render prompt-suggestion chips (explicitly excluded)', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(screen.queryByTestId('suggested-chips')).toBeNull()
+    // Defensive: no buttons claiming to seed a prompt suggestion.
+    const dialog = screen.getByTestId('first-use-composer')
+    const buttons = dialog.querySelectorAll('button')
+    // Only the AIInputBar's cog + send buttons may be present.
+    const labels = Array.from(buttons).map((b) => b.getAttribute('aria-label') ?? '')
+    expect(labels.every((l) => /^(Settings|Send)$/.test(l))).toBe(true)
+  })
+
+  it('keeps the cog button inside the input field (welcome-cog invariant)', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(screen.getByTestId('first-use-input-bar-cog')).toBeInTheDocument()
+  })
+})
+
 describe('FirstUseComposer — auto-dock does NOT misfire on hydration/import (review #2)', () => {
   // The reviewer flagged: auto-dock should only fire for a graph produced by
   // the user submitting via the first-use composer — NOT for any 0→N+ node

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.density.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.density.spec.tsx
@@ -1,0 +1,137 @@
+/**
+ * Floating-density scope guard (UX correction P0.3).
+ *
+ * The CSS module `Conversation.module.css` adds scoped compact rules
+ * under `:global(.floating-density)`. This spec proves:
+ *
+ *   1. The floating panel mounts ConversationPanel inside a
+ *      `floating-density` wrapper, so the compact CSS rules apply.
+ *   2. The docked OlumiTabBody does NOT wrap ConversationPanel in
+ *      `floating-density`, so the docked surface keeps normal density.
+ *
+ * Combined with the existing aiPanelV2.parity.spec.tsx (FF-off renders no
+ * floating panel at all), this confirms there is no density leak into
+ * either the docked Olumi tab or DraftChat.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+const canvasMockState = {
+  nodes: [{ id: 'n1' }] as Array<{ id: string }>,
+  edges: [] as Array<unknown>,
+  results: { status: 'idle' as const },
+  _internal: {} as Record<string, unknown>,
+  selection: null,
+  ceeAnalysisReady: null as any,
+  graphHealth: null as any,
+  runMeta: {} as any,
+}
+vi.mock('../../store', () => {
+  const useCanvasStore: any = (selector: (s: any) => any) => selector(canvasMockState)
+  useCanvasStore.getState = () => canvasMockState
+  useCanvasStore.setState = (patch: any) => Object.assign(canvasMockState, patch)
+  useCanvasStore.subscribe = () => () => {}
+  return {
+    useCanvasStore,
+    selectResultsStatus: (s: any) => s.results?.status,
+    selectReport: (s: any) => s.results?.report,
+    selectError: (s: any) => s.results?.error,
+    selectResultsSource: (s: any) => s.results?.source,
+  }
+})
+
+vi.mock('../../conversation/ConversationPanel', () => ({
+  ConversationPanel: () => <div data-testid="mocked-conversation-panel" />,
+}))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Ask',
+}))
+vi.mock('../../ui/inspector-v2/useStaleGuard', () => ({
+  useStaleGuard: () => ({ analysisState: 'none', isStale: false }),
+}))
+
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      return {
+        messages: [
+          // Non-empty so OlumiTabBody renders the conversation branch
+          // (not the empty-state branch).
+          { id: 'a-0', role: 'assistant', content: 'hi', synthetic: false },
+        ],
+        isThinking: false,
+        longRunningHint: null,
+        lastFailedInput: null,
+        sendMessage,
+        sendSystemEvent: vi.fn(),
+        sendChip: vi.fn(),
+        retryLast: vi.fn(),
+        patchBlockStates: new Map(),
+        setPatchBlockState: vi.fn(),
+        patchRejections: new Map(),
+        setPatchRejection: vi.fn(),
+      }
+    },
+    isNonConversationalContent: () => false,
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { FloatingOlumiPanel } from '../FloatingOlumiPanel'
+import { OlumiTabBody } from '../OlumiTabBody'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+beforeEach(() => {
+  useFloatingPanelState.getState().reset()
+})
+
+describe('floating-density scope', () => {
+  it('floating panel wraps ConversationPanel in a .floating-density container', () => {
+    useFloatingPanelState.getState().open('user')
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    const cp = document.querySelector('[data-testid="mocked-conversation-panel"]') as HTMLElement
+    expect(cp).toBeTruthy()
+    // Walk up — at least one ancestor must carry the `floating-density` class.
+    let ancestor: HTMLElement | null = cp.parentElement
+    let found = false
+    while (ancestor) {
+      if (ancestor.classList.contains('floating-density')) {
+        found = true
+        break
+      }
+      ancestor = ancestor.parentElement
+    }
+    expect(found).toBe(true)
+  })
+
+  it('docked OlumiTabBody does NOT wrap ConversationPanel in .floating-density', () => {
+    render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
+    const cp = document.querySelector('[data-testid="mocked-conversation-panel"]') as HTMLElement
+    expect(cp).toBeTruthy()
+    // No ancestor must carry `floating-density` — otherwise the compact
+    // CSS rules would leak into the docked tab.
+    let ancestor: HTMLElement | null = cp.parentElement
+    while (ancestor) {
+      expect(ancestor.classList.contains('floating-density')).toBe(false)
+      ancestor = ancestor.parentElement
+    }
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
@@ -148,3 +148,97 @@ describe('useConversation singleton invariant', () => {
     expect(useConversationCallCount.n).toBe(1)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Olumi tab click intercept (UX correction P0.1)
+// ---------------------------------------------------------------------------
+
+describe('Olumi tab click while floating is open', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    useConversationCallCount.n = 0
+    flagState.aiPanelV2 = true
+    try { sessionStorage.clear() } catch {}
+    try { localStorage.clear() } catch {}
+    // Pin the dock to expanded so the tab-row renders (the collapsed
+    // icon rail uses different testids / labels and would skip the
+    // intercept under test).
+    try {
+      // useDockState uses sessionStorage (not localStorage).
+      sessionStorage.setItem(
+        'canvas.outputsDock.v1',
+        JSON.stringify({ isOpen: true, activeTab: 'results' }),
+      )
+    } catch {}
+  })
+
+  it('focuses the floating panel and does NOT switch the active tab', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
+    const { registerFloatingFocus, focusFloating } = await import('../../hooks/useFloatingFocus')
+    const { useUIStore } = await import('../../../stores/uiStore')
+    const { OutputsDock } = await import('../OutputsDock')
+
+    // Pre-state: Analysis tab is active in the global store, and the
+    // floating panel is open.
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useFloatingPanelState.getState().reset()
+    useFloatingPanelState.getState().open('user')
+
+    // Register a focus channel so we can prove focusFloating fired.
+    const focusSpy = vi.fn()
+    const unregister = registerFloatingFocus(focusSpy)
+
+    const { findByLabelText } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    // Find the Olumi tab by its visible text (the testid is conditional
+    // on the tab being in OUTPUT_TABS at render time; visible-text lookup
+    // is the resilient path).
+    // Find by aria-label — works for both the expanded tab row AND the
+    // collapsed icon rail; both rails wire `handleTabClick` so the
+    // intercept fires from either path.
+    const olumiTab = (await findByLabelText('Olumi')) as HTMLElement
+    expect(olumiTab).toBeTruthy()
+    fireEvent.click(olumiTab)
+
+    // Intercept fired: the focusFloating channel was invoked.
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    // And the global active tab was NOT switched to 'olumi'.
+    expect(useUIStore.getState().activeOutputTab).toBe('results')
+
+    // Sanity: calling focusFloating directly hits the spy too.
+    focusFloating()
+    expect(focusSpy).toHaveBeenCalledTimes(2)
+    unregister()
+  })
+
+  it('falls through to normal tab activation when floating is CLOSED', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
+    const { useUIStore } = await import('../../../stores/uiStore')
+    const { OutputsDock } = await import('../OutputsDock')
+
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useFloatingPanelState.getState().reset()
+    expect(useFloatingPanelState.getState().isOpen).toBe(false)
+
+    const { findByLabelText } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    // Find by aria-label — works for both the expanded tab row AND the
+    // collapsed icon rail; both rails wire `handleTabClick` so the
+    // intercept fires from either path.
+    const olumiTab = (await findByLabelText('Olumi')) as HTMLElement
+    expect(olumiTab).toBeTruthy()
+    fireEvent.click(olumiTab)
+    // With floating closed, the click activates the Olumi tab normally.
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
+  })
+})

--- a/src/canvas/components/__tests__/aiPanelV2.polish.spec.tsx
+++ b/src/canvas/components/__tests__/aiPanelV2.polish.spec.tsx
@@ -97,28 +97,26 @@ beforeEach(() => {
   conversationMockState.isThinking = false
 })
 
-describe('Item 1 — Olumi tab placeholder when floating is open', () => {
-  it('renders the floating-state placeholder (not the conversation) when isOpen', () => {
+describe('Item 1 — Olumi tab when floating is open', () => {
+  // UX correction: the previous "full-page placeholder when floating open"
+  // branch was removed. OlumiTabBody no longer renders a placeholder; the
+  // OutputsDock.handleTabClick intercept calls focusFloating() instead,
+  // keeping the current Analysis/Compare/Model tab active. So when the
+  // floating panel IS open AND someone still mounts OlumiTabBody directly
+  // (e.g. a test or a manual programmatic activeTab='olumi' state), the
+  // tab body falls through to its empty / conversation render — the right
+  // panel is never wasted on a "Olumi is open" placeholder.
+
+  it('does NOT render a floating-state placeholder when the floating panel is open', () => {
     useFloatingPanelState.getState().open('user')
     render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
-    expect(screen.getByTestId('olumi-tab-floating-placeholder')).toBeInTheDocument()
-    expect(screen.getByText(/Olumi is open in the floating panel\./i)).toBeInTheDocument()
-    expect(screen.getByTestId('olumi-tab-focus-floating')).toBeInTheDocument()
-    expect(screen.getByTestId('olumi-tab-dock-here')).toBeInTheDocument()
-    // The empty-state body must NOT also render — one readable surface only.
-    expect(screen.queryByTestId('olumi-tab-empty')).toBeNull()
-    expect(screen.queryByTestId('olumi-tab-body')).toBeNull()
+    expect(screen.queryByTestId('olumi-tab-floating-placeholder')).toBeNull()
+    expect(screen.queryByTestId('olumi-tab-focus-floating')).toBeNull()
+    expect(screen.queryByTestId('olumi-tab-dock-here')).toBeNull()
+    expect(screen.queryByText(/Olumi is open in the floating panel/i)).toBeNull()
   })
 
-  it('Dock here closes the floating panel', () => {
-    useFloatingPanelState.getState().open('user')
-    expect(useFloatingPanelState.getState().isOpen).toBe(true)
-    render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
-    fireEvent.click(screen.getByTestId('olumi-tab-dock-here'))
-    expect(useFloatingPanelState.getState().isOpen).toBe(false)
-  })
-
-  it('falls back to the existing empty-state body when floating is closed and no messages', () => {
+  it('still falls back to the existing empty-state body when floating is closed and no messages', () => {
     render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
     expect(screen.getByTestId('olumi-tab-empty')).toBeInTheDocument()
     expect(screen.queryByTestId('olumi-tab-floating-placeholder')).toBeNull()
@@ -132,10 +130,35 @@ describe('Item 4 — AIInputBar generating state (isThinking + empty canvas)', (
 
   it('shows "Generating your decision model…" placeholder and disables typing during a generate turn', () => {
     conversationMockState.isThinking = true
-    render(<AIInputBar variant="first-use" hideChevron testId="gen" />, { wrapper: Wrapper })
+    render(<AIInputBar variant="first-use" hideChevron testId="gen" onCogClick={() => {}} />, { wrapper: Wrapper })
     const textarea = screen.getByTestId('gen-textarea') as HTMLTextAreaElement
     expect(textarea.placeholder).toBe('Generating your decision model…')
     expect(textarea).toBeDisabled()
+    expect(textarea).toHaveAttribute('aria-disabled', 'true')
+    // Cog + send must also lock during generation so the user can't open
+    // a settings popover or fire a duplicate send mid-turn.
+    const cog = screen.getByTestId('gen-cog')
+    expect(cog).toBeDisabled()
+    expect(cog).toHaveAttribute('aria-disabled', 'true')
+    const send = screen.getByTestId('gen-send')
+    expect(send).toBeDisabled()
+    expect(send).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('locks the chevron on the strip variant during a generate turn', () => {
+    conversationMockState.isThinking = true
+    render(
+      <AIInputBar
+        variant="strip"
+        testId="strip-gen"
+        onCogClick={() => {}}
+        onChevronClick={() => {}}
+      />,
+      { wrapper: Wrapper },
+    )
+    const chevron = screen.getByTestId('strip-gen-chevron')
+    expect(chevron).toBeDisabled()
+    expect(chevron).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('does NOT disable typing when isThinking but nodes already exist (chat-mode thinking)', () => {

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -1838,3 +1838,44 @@
 :global(.response-chip-group) > [data-testid^="chat-message-"] {
   margin-bottom: 0;
 }
+
+/* ---------------------------------------------------------------------------
+ * § floating-density — compact overrides for the floating Olumi panel
+ *
+ * Scope guarantee: every selector below is descended from
+ * `:global(.floating-density)`, so the docked Olumi tab and DraftChat
+ * (which never mount inside a `.floating-density` ancestor) keep their
+ * normal density. The floating panel adds the class in
+ * FloatingOlumiPanel.tsx around its ConversationPanel render.
+ * ---------------------------------------------------------------------------*/
+
+:global(.floating-density) .messageList {
+  gap: 12px;
+  padding: 12px 12px 6px;
+}
+
+:global(.floating-density) .messageBubble {
+  padding: 12px;
+}
+
+:global(.floating-density) .messageBubbleAssistant {
+  padding: 12px;
+}
+
+/* Inner block stack — tighter gap between coaching/evidence/patch blocks
+ * within a single assistant turn. */
+:global(.floating-density) .inlineBlock,
+:global(.floating-density) .blockStack {
+  gap: 6px;
+}
+
+/* Suggested-chip row: tighter top margin + compact button padding while
+ * preserving sufficient hit target via min-height. */
+:global(.floating-density) [data-testid="suggested-chips"] {
+  margin-top: 12px;
+}
+
+:global(.floating-density) [data-testid="suggested-chips"] button {
+  padding: 6px 12px;
+  min-height: 32px;
+}

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -1,15 +1,21 @@
 /**
  * aiPanelV2 UX polish — Run analysis chip suppression/relabel.
  *
- * Contract (only when aiPanelV2 is ON):
- *   - analysisState === 'current'  → run_analysis chip is SUPPRESSED entirely.
- *     Analysis/readiness is the canonical place for re-running.
- *   - analysisState === 'stale'    → run_analysis chip is RELABELLED to 'Rerun'.
- *     The action stays available but the label tells the user nothing fresh.
- *   - analysisState === 'none'     → unchanged (the user has never run).
+ * Product rule (only when aiPanelV2 is ON):
+ *   - no analysis exists       → keep chip as-is ("Run analysis")
+ *   - current analysis exists  → SUPPRESS chip entirely
+ *                                (Analysis/readiness panel owns rerun)
+ *   - stale analysis exists    → RELABEL to "Rerun"
  *
- * When aiPanelV2 is OFF, the chip is rendered unchanged (legacy parity).
+ * Decision keys off `results.status === 'complete'` + `isStale` from the
+ * stale guard. This is the loosened path — the old `analysisState ===
+ * 'current'` predicate raced on staging when the hash compare lagged.
  *
+ * Detection covers both V2 chips (`action_type === 'run_analysis'`) and
+ * legacy / prompt-style chips matched by the tolerant regex
+ * `/^(?:run|rerun)\s+(?:the\s+)?analysis\.?$/i`.
+ *
+ * When aiPanelV2 is OFF, chips render unchanged (legacy parity).
  * Independent of the V5 readiness gate — this filter runs after the V5
  * filter, on whatever survives.
  */
@@ -170,6 +176,118 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
       />,
     )
     expect(screen.getByTestId('suggested-chip-conv-1')).toBeInTheDocument()
+  })
+
+  // Pin against the actual CEE fixture shape (tests/fixtures/cee-responses/
+  // v5-turn.explain-stale.json) — what live staging emits after analysis.
+  it('suppresses the real CEE-fixture-shape chip when current', () => {
+    setAnalysisState('current')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'cee-fixture',
+            label: 'Rerun analysis',
+            message: 'Rerun the analysis.',
+            action_type: 'run_analysis',
+          }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    expect(screen.queryByTestId('suggested-chip-cee-fixture')).toBeNull()
+  })
+
+  it('relabels the real CEE-fixture-shape chip to "Rerun" when stale', () => {
+    setAnalysisState('stale')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'cee-stale',
+            label: 'Rerun analysis',
+            message: 'Rerun the analysis.',
+            action_type: 'run_analysis',
+          }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-cee-stale')
+    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
+  })
+
+  // Regex fallback — V4-legacy chips drop action_type but carry the
+  // canonical copy in the message field.
+  it('suppresses a chip with "Run the analysis" message and no action_type when current', () => {
+    setAnalysisState('current')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'msg-only',
+            action_type: undefined,
+            label: 'Run',
+            message: 'Run the analysis',
+          }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    expect(screen.queryByTestId('suggested-chip-msg-only')).toBeNull()
+  })
+
+  it('suppresses a chip with trailing-period "Rerun the analysis." message when current', () => {
+    setAnalysisState('current')
+    render(
+      <SuggestedChips
+        chips={[
+          makeChip({
+            id: 'msg-period',
+            action_type: undefined,
+            label: 'Rerun',
+            message: 'Rerun the analysis.',
+          }),
+        ]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    expect(screen.queryByTestId('suggested-chip-msg-period')).toBeNull()
+  })
+
+  // Reviewer amendment: regression should pin the exact product-rule
+  // matrix, regardless of internal predicate names.
+  it('product rule: none → keep, current → suppress, stale → Rerun', () => {
+    const fixture = () =>
+      makeChip({
+        id: 'matrix',
+        label: 'Rerun analysis',
+        message: 'Rerun the analysis.',
+        action_type: 'run_analysis',
+      })
+
+    // none
+    setAnalysisState('none')
+    const { unmount: u1 } = render(
+      <SuggestedChips chips={[fixture()]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
+    )
+    expect(screen.getByTestId('suggested-chip-matrix')).toHaveTextContent(/Rerun analysis/i)
+    u1()
+
+    // current
+    setAnalysisState('current')
+    const { unmount: u2 } = render(
+      <SuggestedChips chips={[fixture()]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
+    )
+    expect(screen.queryByTestId('suggested-chip-matrix')).toBeNull()
+    u2()
+
+    // stale
+    setAnalysisState('stale')
+    render(
+      <SuggestedChips chips={[fixture()]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
+    )
+    expect(screen.getByTestId('suggested-chip-matrix')).toHaveTextContent(/^\s*Rerun\s*$/i)
   })
 })
 

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -19,6 +19,7 @@ import { isV5Eligible } from '../../../v5/eligibility'
 import { logV5StateEvent } from '../../../v5/debugLog'
 import { isAiPanelV2Enabled } from '../../../flags'
 import { useAnalysisStatus } from '../../hooks/useAnalysisReady'
+import { useCanvasStore } from '../../store'
 import { useStaleGuard } from '../../ui/inspector-v2/useStaleGuard'
 import type { ActionChip } from '../types'
 
@@ -56,26 +57,47 @@ const READINESS_GATED_ACTIONS = new Set<string>(['run_analysis'])
  * would risk false-positives on conversational chips that happen to mention
  * "analysis" (e.g. "Explain the analysis").
  */
-// Canonical run-analysis affordance strings. Module-scoped so it isn't
-// re-allocated per chip render. The two-tier (action_type OR canonical
-// label/message/prompt) check matches both V2 chips and legacy
-// prompt-style chips. CEE serialises dispatch text as `prompt`; the UI
-// normalises it to `message` in validateResponse.ts:88, but the raw
-// `prompt` field is preserved on the chip — both shapes can therefore
-// arrive at this filter, so we match either.
-const RUN_ANALYSIS_CANONICAL = new Set(['run analysis', 'rerun analysis', 'rerun'])
+// Run-analysis affordance detection. action_type is the primary key; the
+// fallback regex catches V4-legacy or prompt-only chips where the
+// `action_type` field is absent. Tolerant of "Run analysis", "Rerun
+// analysis", "Run the analysis", "Rerun the analysis", with or without
+// a trailing period. Conservative enough to NOT match conversational
+// chips like "Explain the analysis" or "What was the analysis?".
+const RUN_ANALYSIS_RE = /^(?:run|rerun)\s+(?:the\s+)?analysis\.?$/i
 
 function normForMatch(s: string | undefined): string {
-  return (s ?? '').trim().toLowerCase()
+  return (s ?? '').trim()
 }
 
 function isRunAnalysisAffordance(chip: ActionChip): boolean {
   if (chip.action_type === 'run_analysis') return true
   return (
-    RUN_ANALYSIS_CANONICAL.has(normForMatch(chip.label)) ||
-    RUN_ANALYSIS_CANONICAL.has(normForMatch(chip.message)) ||
-    RUN_ANALYSIS_CANONICAL.has(normForMatch(chip.prompt))
+    RUN_ANALYSIS_RE.test(normForMatch(chip.label)) ||
+    RUN_ANALYSIS_RE.test(normForMatch(chip.message)) ||
+    RUN_ANALYSIS_RE.test(normForMatch(chip.prompt))
   )
+}
+
+/**
+ * Product rule for the run-analysis affordance under aiPanelV2:
+ *   - no analysis exists       → keep chip as-is ("Run analysis")
+ *   - current analysis exists  → suppress chip entirely
+ *   - stale analysis exists    → relabel chip to "Rerun"
+ *
+ * The decision keys off `results.status === 'complete'` (analysis has
+ * produced results at least once) plus `isStale` from the stale guard.
+ * This avoids the fragile `analysisState === 'current'` path which can
+ * race on staging when the hash compare lags by one tick.
+ */
+type RunAnalysisPolish = 'suppress' | 'relabel-rerun' | 'keep'
+
+function decideRunAnalysisPolish(
+  resultsComplete: boolean,
+  isStale: boolean,
+): RunAnalysisPolish {
+  if (!resultsComplete) return 'keep'   // no analysis yet
+  if (isStale) return 'relabel-rerun'   // graph drifted since last analysis
+  return 'suppress'                     // current analysis owns the action
 }
 
 interface SuggestedChipsProps {
@@ -110,11 +132,12 @@ export function SuggestedChips({
   const analysisStatus = useAnalysisStatus()
   // aiPanelV2 polish: once an analysis has been RUN (results exist), the
   // canonical place for re-running it is the Analysis/readiness panel.
-  // Suppress the "Run analysis" chip from the conversation when current,
-  // relabel to "Rerun" when stale. analysisState === 'none' keeps the
-  // original chip unchanged. Gated by the FF so legacy chip behaviour is
-  // identical when aiPanelV2 is off.
-  const { analysisState } = useStaleGuard()
+  // Decision is via `decideRunAnalysisPolish` (product rule, see helper
+  // above): no analysis → keep; current → suppress; stale → "Rerun".
+  // Keys off results.status === 'complete' rather than the fragile
+  // analysisState === 'current' path (which can race on staging).
+  const { isStale } = useStaleGuard()
+  const resultsComplete = useCanvasStore((s) => s.results?.status === 'complete')
   const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {
     if (!chipError) return
@@ -173,17 +196,18 @@ export function SuggestedChips({
     }
   }
 
-  // aiPanelV2: suppress / relabel any "Run analysis" affordance based on
-  // the current analysis state. Detection is intentionally broad — CEE
-  // may emit chips with action_type === 'run_analysis' OR legacy
-  // prompt-style chips with no action_type but a canonical label/message.
-  // Both shapes are user-facing duplicates of the Analysis-panel rerun
-  // affordance once analysis exists, so the polish applies to both.
+  // aiPanelV2: apply the product rule to run-analysis affordances.
+  // See `decideRunAnalysisPolish` for the contract. Detection covers both
+  // V2 chips (action_type === 'run_analysis') and legacy prompt-style
+  // chips matched by the canonical regex.
+  const polish = aiPanelV2On
+    ? decideRunAnalysisPolish(resultsComplete, isStale)
+    : 'keep'
   const polished = aiPanelV2On
     ? supported
-        .filter((c) => !(isRunAnalysisAffordance(c) && analysisState === 'current'))
+        .filter((c) => !(isRunAnalysisAffordance(c) && polish === 'suppress'))
         .map((c) =>
-          isRunAnalysisAffordance(c) && analysisState === 'stale'
+          isRunAnalysisAffordance(c) && polish === 'relabel-rerun'
             ? { ...c, label: 'Rerun' }
             : c,
         )


### PR DESCRIPTION
## Summary

Focused UX correction on top of merged PR #149. Live staging manual testing showed Olumi appearing in too many competing places. This pass tightens the FF-on UX without reopening the architecture or touching FF-off.

**Default-off in code retained.** Staging env (\`VITE_FEATURE_AI_PANEL_V2=true\` via \`[context.staging.environment]\`) already enables the flag for manual testing.

## P0 changes

| # | Item | Source |
|---|---|---|
| P0.1 | Olumi tab click while floating open → focus floating, keep current Analysis/Compare/Model tab active. \`OlumiTabBody\` placeholder branch removed. | \`OutputsDock.tsx\`, \`OlumiTabBody.tsx\` |
| P0.2 | Run-analysis chip product rule: none → keep, current → suppress, stale → "Rerun". Keys off \`results.status === 'complete' && !isStale\` (replaces fragile \`analysisState === 'current'\`). Regex fallback catches V4-legacy chips like \`"Rerun the analysis."\`. | \`SuggestedChips.tsx\` |
| P0.3 | Floating panel density: scoped \`.floating-density\` CSS wrapper tightens gap/padding/chip sizing inside the floating panel only. Docked Olumi + DraftChat unchanged. | \`FloatingOlumiPanel.tsx\`, \`Conversation.module.css\` |
| P0.4 | First-use composer as focused start card: content-fit \`min-height: 108px\`, concise copy, no prompt chips, cog inside input. | \`FirstUseComposer.tsx\` |
| P0.5 | Generation-state lock: textarea, cog, send AND chevron all carry \`disabled\` + \`aria-disabled\` during a generate turn. \`handleSend\` continues to short-circuit on \`isThinking\` for race safety. | \`AIInputBar.tsx\` |

## P1 polish

- **P1.6** Olumi tab "Open" indicator: outlined pill → subtle 6×6 filled info dot. \`aria-label\` + \`title\` "Olumi is open. Focus floating panel".

## FF-off parity

Zero source touch points outside FF-gated code paths. \`aiPanelV2.parity.spec.tsx\` re-runs green. CSS scope wrapper \`.floating-density\` exists only inside FloatingOlumiPanel, which doesn't mount under FF-off.

## Tests

| Spec | Coverage |
|---|---|
| \`aiPanelV2.polish.spec.tsx\` | Updated Item 1 (no placeholder) + Item 4 (cog/send/chevron disabled + aria-disabled) |
| \`OutputsDock.conversationSingleton.spec.tsx\` | New Olumi-tab-click intercept tests (focused floating + tab unchanged; intercept skipped when floating closed) |
| \`SuggestedChips.aiPanelV2Polish.spec.tsx\` | Real CEE fixture shape (suppress / relabel); regex fallback for V4-legacy chips; product-rule matrix |
| \`FirstUseComposer.spec.tsx\` | New focused-start-card describe (concise copy, content-fit, no prompt chips, cog inside input) |
| \`FloatingOlumiPanel.density.spec.tsx\` (new) | \`.floating-density\` wrapper present in floating panel; absent in docked OlumiTabBody (scope-leak regression guard) |

**Verification:** typecheck clean; 151 tests pass across 13 polish-affected specs; pre-push fast gate green.

## Browser screenshots (local, pre-merge)

Captured against the local Vite preview at 1440×900:

1. **Floating panel open + Analysis tab visible** — no placeholder; the right panel keeps showing Analysis ✓
2. **Click Olumi tab while floating open** — active tab stays \`Analysis\`, \`floatingOpen=true\`, no placeholder rendered (DOM-confirmed) ✓
3. **First-use composer** — width 480px (responsive), \`min-height: 108px\` content-fit, concise copy, cog inside input, no prompt chips ✓
4. **aria-disabled wiring** — textarea/cog/send/chevron all carry both \`disabled\` and \`aria-disabled\` attrs ✓
5. **Floating-density wrapper** — \`.floating-density\` ancestor confirmed for floating panel's ConversationPanel; absent for docked OlumiTabBody ✓

Post-deploy staging smoke planned after merge:
- Floating open + Analysis visible
- Click Olumi while floating → focuses
- Post-analysis: no "Run analysis" chip (real backend)
- Stale: "Rerun" relabel (after a graph edit)
- Generating state controls disabled
- Persistent strip "Olumi is open · Focus →"

## Deploy posture

- Default-off in code (\`aiPanelV2\` has no \`defaultValue\` → \`false\`).
- Staging enabled via existing \`[context.staging.environment]\` in netlify.toml.
- Production / main untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)