### PR TITLE
layout: narrow NODE_CARD_MAX_W 320 -> 256 for exact 1300px-canvas fit

### DIFF
--- a/src/canvas/__tests__/layout.semantic.spec.ts
+++ b/src/canvas/__tests__/layout.semantic.spec.ts
@@ -528,8 +528,8 @@ describe('constants contract', () => {
     expect(LAYOUT_BOX_MIN_W).toBe(NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X)
   })
 
-  it('NODE_CARD_MAX_W is 320, NODE_LAYOUT_MIN_W is 140', () => {
-    expect(NODE_CARD_MAX_W).toBe(320)
+  it('NODE_CARD_MAX_W is 256, NODE_LAYOUT_MIN_W is 140', () => {
+    expect(NODE_CARD_MAX_W).toBe(256)
     expect(NODE_LAYOUT_MIN_W).toBe(140)
   })
 

--- a/src/canvas/__tests__/layout.spec.ts
+++ b/src/canvas/__tests__/layout.spec.ts
@@ -7,6 +7,7 @@ import {
   LAYOUT_PADDING_X,
   LAYOUT_PADDING_Y,
   DEFAULT_NODE_HEIGHT,
+  CANVAS_MARGIN,
 } from '../utils/nodeLayoutConstants'
 import type { Node, Edge } from '@xyflow/react'
 
@@ -91,8 +92,8 @@ describe('ELK Layout', () => {
 
   it('returns layoutNodeWidth', async () => {
     const { layoutNodeWidth } = await layoutGraph(mockNodes, mockEdges, {}, TEST_CANVAS)
-    expect(layoutNodeWidth).toBeGreaterThanOrEqual(140)
-    expect(layoutNodeWidth).toBeLessThanOrEqual(320)
+    expect(layoutNodeWidth).toBeGreaterThanOrEqual(NODE_LAYOUT_MIN_W)
+    expect(layoutNodeWidth).toBeLessThanOrEqual(NODE_CARD_MAX_W)
   })
 
   it('preserves locked node positions', async () => {
@@ -234,7 +235,7 @@ describe('ELK Layout', () => {
   // Viewport-constrained sizing
   // ---------------------------------------------------------------------------
 
-  it('nodeW stays within [140, 320] for small graphs on a wide canvas', async () => {
+  it('nodeW stays within [NODE_LAYOUT_MIN_W, NODE_CARD_MAX_W] for small graphs on a wide canvas', async () => {
     // 8-node graph: widest tier = 3 options. Should produce generous nodeW near MAX.
     const nodes: Node[] = [
       makeNode('d', 'decision'),
@@ -250,8 +251,8 @@ describe('ELK Layout', () => {
       makeEdge('e8', 'out', 'g'),
     ]
     const { nodes: laid, layoutNodeWidth } = await layoutGraph(nodes, edges, {}, TEST_CANVAS)
-    expect(layoutNodeWidth).toBeGreaterThanOrEqual(140)
-    expect(layoutNodeWidth).toBeLessThanOrEqual(320)
+    expect(layoutNodeWidth).toBeGreaterThanOrEqual(NODE_LAYOUT_MIN_W)
+    expect(layoutNodeWidth).toBeLessThanOrEqual(NODE_CARD_MAX_W)
     // All positions must be finite
     laid.forEach(n => {
       expect(Number.isFinite(n.position.x)).toBe(true)
@@ -259,7 +260,62 @@ describe('ELK Layout', () => {
     })
   })
 
-  it('nodeW stays at NODE_CARD_MAX_W (320) when widest tier overflows the viewport', async () => {
+  it('4-factor tier on 1300px canvas: locks exact-fit boundary (regression-lock for NODE_CARD_MAX_W=256)', async () => {
+    // The 320 → 256 change was sized to make a 4-node tier exactly fit a
+    // 1300px canvas after CANVAS_MARGIN translation. Math:
+    //
+    //   rightEdge = CANVAS_MARGIN
+    //             + (N-1) * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + spacing)
+    //             + NODE_CARD_MAX_W
+    //             = 24 + 3 * (256 + 24 + 60) + 256
+    //             = 24 + 3 * 340 + 256
+    //             = 1300
+    //
+    // i.e. 4*256 + 4*24 + 3*60 = 1300 exactly. This test locks the placement
+    // formula and the exact-fit outcome so that any future tweak of any
+    // contributing constant (NODE_CARD_MAX_W, LAYOUT_PADDING_X, default
+    // spacing, CANVAS_MARGIN) surfaces immediately rather than as a silent
+    // layout drift.
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+    ]
+    const SPACING = 60
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(
+      nodes,
+      edges,
+      { spacing: SPACING },
+      TEST_CANVAS,
+    )
+
+    // max-single fires: unclamped = floor((1300*0.85 - 90)/4) = 253 ≥ 164.
+    expect(layoutNodeWidth).toBe(NODE_CARD_MAX_W)
+
+    const factors = laid
+      .filter(n => n.type === 'factor')
+      .sort((a, b) => a.position.x - b.position.x)
+    expect(factors).toHaveLength(4)
+
+    // Symbolic placement formula — resilient to future constant tweaks.
+    const lastVisibleRightEdge = factors[3].position.x + NODE_CARD_MAX_W
+    expect(lastVisibleRightEdge).toBe(
+      CANVAS_MARGIN + 3 * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + SPACING) + NODE_CARD_MAX_W,
+    )
+
+    // Outcome: exact fit. If NODE_CARD_MAX_W is later changed in either
+    // direction (or any other contributing constant), this assertion flips
+    // and forces a deliberate review of the new layout intent.
+    expect(lastVisibleRightEdge).toBe(TEST_CANVAS.width)
+  })
+
+  it('nodeW stays at NODE_CARD_MAX_W when widest tier overflows the viewport', async () => {
     // 5 factors on a 1700px canvas previously compressed every node to ~241px.
     // New policy: pin every node to NODE_CARD_MAX_W and overflow horizontally.
     const nodes: Node[] = [
@@ -337,7 +393,7 @@ describe('ELK Layout', () => {
     ]
     const { nodes: laid } = await layoutGraph(nodes, edges, {}, WIDE_CANVAS)
 
-    // ELK box width is uniform at NODE_CARD_MAX_W + LAYOUT_PADDING_X = 344 in this case
+    // ELK box width is uniform at NODE_CARD_MAX_W + LAYOUT_PADDING_X (= 280 with NODE_CARD_MAX_W=256) in this case
     const elkBoxW = NODE_CARD_MAX_W + LAYOUT_PADDING_X
     const tierMean = (ids: string[]): number => {
       const xs = ids.map(id => laid.find(n => n.id === id)!.position.x)

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -438,7 +438,8 @@ export const OptionNode = memo((props: NodeProps) => {
         const baseline = baselineOptionInterventions?.[c.factorId] ?? c.observedValue
         // Graph v1.1 Task 6: compaction for pre-analysis pills. Bumped from 15
         // to 22 so multi-word factor labels (e.g. "Senior technical leadership")
-        // read more meaningfully before truncation; still fits NODE_CARD_MAX_W=320.
+        // read more meaningfully before truncation. Sized against the NODE_CARD_MAX_W
+        // card; revisit if the card width changes materially.
         const shortLabel = compactFactorLabel(c.label, 22)
 
         if (baseline === undefined) {

--- a/src/canvas/nodes/__tests__/BaseNode.maxWidth.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.maxWidth.spec.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
 import { Target } from 'lucide-react'
 import { BaseNode } from '../BaseNode'
+import { NODE_CARD_MAX_W } from '../../utils/nodeLayoutConstants'
 
 vi.mock('@xyflow/react', async () => {
   const actual = await vi.importActual('@xyflow/react')
@@ -77,15 +78,17 @@ describe('BaseNode — maxWidth (H1)', () => {
     expect(nodeEl.style.maxWidth).toBe('200px')
   })
 
-  it('uses NODE_CARD_MAX_W (320px) fallback when no maxWidth prop and no layoutNodeWidth', () => {
+  it('uses NODE_CARD_MAX_W fallback when no maxWidth prop and no layoutNodeWidth', () => {
     // BaseNode's pre-layout fallback is sourced from the ELK NODE_CARD_MAX_W
     // constant (imported from ../utils/nodeLayoutConstants) so the rendered
-    // width matches ELK's assumed box size once a layout has run.
+    // width matches ELK's assumed box size once a layout has run. We assert
+    // against the imported constant rather than a hardcoded literal so that
+    // future tweaks to NODE_CARD_MAX_W only need to change one place.
     const { container } = render(
       <BaseNode {...baseProps} nodeType="factor" icon={Target} />
     )
     const nodeEl = container.firstChild as HTMLElement
-    expect(nodeEl.style.maxWidth).toBe('320px')
+    expect(nodeEl.style.maxWidth).toBe(`${NODE_CARD_MAX_W}px`)
   })
 
   it('label element has break-words class to prevent overflow', () => {

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -17,7 +17,7 @@
 export const NODE_LAYOUT_MIN_W = 140
 
 /** Maximum rendered card width. Used by BaseNode and as the ELK pinned width. */
-export const NODE_CARD_MAX_W = 320
+export const NODE_CARD_MAX_W = 256
 
 /** Horizontal padding added around the rendered card to form the ELK box. */
 export const LAYOUT_PADDING_X = 24


### PR DESCRIPTION
## Summary

Reduces `NODE_CARD_MAX_W` from 320 → 256 so a 4-factor tier exactly fits a 1300px canvas (no overflow). Single source change in `src/canvas/utils/nodeLayoutConstants.ts`; tests refactored to reference the constant rather than hardcoded literals.

Math: `4 * 256 + 4 * 24 + 3 * 60 = 1300` (NODE_CARD_MAX_W * N + LAYOUT_PADDING_X * N + spacing * (N-1)). After CANVAS_MARGIN translation, the visible right edge of the last factor lands at `x = 1300` exactly.

## Behaviour at 1300px canvas (0.85 breathing factor unchanged)

| Tier size | Layout branch | Visible span |
|---|---|---|
| 2-3 | max-single | comfortable fit |
| **4** | max-single | **exactly 1300px (no overflow)** |
| 5 | max-single | 1616px (316px overflow — single row preserved) |
| 6 | min-split (threshold fails: `floor(955/6)=159 < 164`) | 2 rows of 3 at 140px |

## Changes (5 files, +74 / -14)

- `src/canvas/utils/nodeLayoutConstants.ts` — `NODE_CARD_MAX_W: 320 → 256`
- `src/canvas/__tests__/layout.spec.ts` — replaced literal `320`/`344` with `NODE_CARD_MAX_W`; added regression test that asserts the exact-fit boundary (`lastVisibleRightEdge === TEST_CANVAS.width`)
- `src/canvas/__tests__/layout.semantic.spec.ts` — constants-contract assertion updated to `256`
- `src/canvas/nodes/__tests__/BaseNode.maxWidth.spec.tsx` — refactored to import `NODE_CARD_MAX_W` and assert against the constant (locks BaseNode behaviour, not a coincident literal)
- `src/canvas/nodes/OptionNode.tsx` — comment-only refresh of a stale `NODE_CARD_MAX_W=320` reference at the 22-char compaction site

`BaseNode.tsx` source not touched; it already imports `NODE_CARD_MAX_W` and picks up the new value automatically. `LAYOUT_BOX_MAX_W` is declared as `NODE_CARD_MAX_W + LAYOUT_PADDING_X` and recomputes to 280.

## Out of scope

`NODE_LAYOUT_MIN_W`, `LAYOUT_PADDING_X/Y`, `MIN_GAP`, the 0.85 breathing factor, ELK config, BaseNode.tsx source.

## Test plan

- [x] 9 layout/lifecycle/BaseNode specs — 117/117 tests pass locally
- [x] 16 canvas/nodes specs (broader sweep) — 370/370 tests pass locally
- [x] `npm run typecheck` — 0 errors
- [x] Lint on changed files — 0 errors (2 pre-existing `react-hooks/exhaustive-deps` warnings at `OptionNode.tsx:811/863` from commit `8bea5d23c`, unrelated)
- [x] Pre-push fast gate — all 7 checks passed (459 smoke tests)
- [ ] CI full ~6,284-test suite (post-merge, via `staging-full-tests.yml`)
- [ ] Visual review on staging deploy — long labels, expanded card descriptions, OptionNode 22-char compacted pills

## Visual risks (flagged for awareness)

The 64px (20%) reduction in card width may cause:
- Tighter text wrapping on long factor / option labels
- Expanded BaseNode cards (which also use `NODE_CARD_MAX_W` at line 276) become tighter — affects description readability
- OptionNode 22-char `compactFactorLabel` limit was sized for 320px and may visually clip at 256px

These are quality observations, not correctness issues. Acceptable to revisit in a follow-up if visual review surfaces problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)