### PR TITLE
feat(ai-panel-v2): UX correction pass (blocked by pre-existing PreAnalysisPanel hook-order bug)

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -13,7 +13,7 @@ import { useCanvasStore } from '../store'
 import { useConversationContext } from '../conversation/ConversationContext'
 import { useStageAwarePlaceholder } from '../hooks/useStageAwarePlaceholder'
 
-export type AIInputBarVariant = 'strip' | 'docked-tab' | 'floating' | 'first-use'
+export type AIInputBarVariant = 'strip' | 'docked-tab' | 'floating' | 'first-use' | 'welcome'
 
 export interface AIInputBarHandle {
   focus(): void
@@ -22,7 +22,7 @@ export interface AIInputBarHandle {
 }
 
 export interface AIInputBarProps {
-  /** Layout variant — affects padding and chrome (cog, chevron). */
+  /** Layout variant — affects padding, sizing, and chrome (cog, chevron, send shape). */
   variant: AIInputBarVariant
   /** Override the stage-aware placeholder. Optional. */
   placeholder?: string
@@ -33,7 +33,7 @@ export interface AIInputBarProps {
   onCogClick?: (anchorEl: HTMLElement) => void
   /** Click handler for the chevron icon (strip only). Opens floating panel. */
   onChevronClick?: () => void
-  /** Hides the chevron icon (used by floating + first-use + docked-tab variants). */
+  /** Hides the chevron icon (used by floating + first-use + welcome + docked-tab variants). */
   hideChevron?: boolean
   /** Optional id for the textarea (for label/test wiring). */
   textareaId?: string
@@ -51,17 +51,27 @@ export interface AIInputBarProps {
 
 const MAX_LINES = 2
 const LINE_HEIGHT_PX = 18
+/** Welcome hero variant: three visible lines at rest, room to expand to six. */
+const WELCOME_MIN_LINES = 3
+const WELCOME_MAX_LINES = 6
 
 /**
  * AIInputBar — single shared composer used by the persistent strip, the docked
- * Olumi tab (currently unused — strip handles), the floating Olumi panel, and
- * the first-use centred composer. Owns no message state; reads draft from
- * ConversationContext so the draft survives surface switches (e.g. typing in
- * the strip → opening floating → docking → strip still has the text).
+ * Olumi tab (currently unused — strip handles), the floating Olumi panel, the
+ * first-use centred composer, and the AI Panel v2 welcome hero. Owns no message
+ * state; reads draft from ConversationContext so the draft survives surface
+ * switches (e.g. typing in the strip → opening floating → docking → strip still
+ * has the text).
  *
- * The variant only affects chrome (padding, which icons are visible). The
- * input logic — auto-grow up to 2 lines, Enter-to-send, Shift+Enter newline —
- * is identical across variants.
+ * The variant affects chrome (padding, which icons are visible, send-button
+ * shape, textarea minimum height). The input logic — auto-grow, Enter-to-send,
+ * Shift+Enter newline — is identical across variants.
+ *
+ * Composer styling rules (DS v5):
+ * - No blue focus ring; subtle border colour change on focus.
+ * - Send button is a filled circle (bg-info) in every variant.
+ * - Cog icon stays inside the input border, vertically aligned with send.
+ * - During generation, the textarea, cog, send and chevron are all disabled.
  */
 export const AIInputBar = memo(
   forwardRef<AIInputBarHandle, AIInputBarProps>(function AIInputBar(
@@ -88,6 +98,7 @@ export const AIInputBar = memo(
     // orchestrator routes the brief through the model-generation path
     // and emits auto-apply graph patches.
     const nodeCount = useCanvasStore((s) => s.nodes.length)
+    const isWelcome = variant === 'welcome'
 
     useImperativeHandle(
       ref,
@@ -98,14 +109,19 @@ export const AIInputBar = memo(
       [draft],
     )
 
-    // Auto-grow up to MAX_LINES, then scroll inside.
+    // Auto-grow up to the variant's max line count, then scroll inside.
+    // Welcome hero gives generous room (3 lines floor, 6 ceiling) so the
+    // composer reads as the primary action surface, not a tiny strip.
+    const minLines = isWelcome ? WELCOME_MIN_LINES : 1
+    const maxLines = isWelcome ? WELCOME_MAX_LINES : MAX_LINES
+    const minHeightPx = LINE_HEIGHT_PX * minLines + 16
+    const maxHeightPx = LINE_HEIGHT_PX * maxLines + 16
     useLayoutEffect(() => {
       const el = textareaRef.current
       if (!el) return
       el.style.height = 'auto'
-      const max = LINE_HEIGHT_PX * MAX_LINES + 8
-      el.style.height = `${Math.min(el.scrollHeight, max)}px`
-    }, [draft])
+      el.style.height = `${Math.min(Math.max(el.scrollHeight, minHeightPx), maxHeightPx)}px`
+    }, [draft, minHeightPx, maxHeightPx])
 
     const handleSend = useCallback(() => {
       const text = draft.trim()
@@ -144,14 +160,16 @@ export const AIInputBar = memo(
           return 'flex items-end gap-1 px-3 pb-3 pt-2 border-t border-panel-border'
         case 'first-use':
           return 'flex items-end gap-1 px-3 pb-3 pt-2'
+        case 'welcome':
+          return 'flex items-end gap-2 px-2 pb-2 pt-2'
       }
     })()
 
     // Empty canvas + isThinking === a model-generation turn is in flight.
     // The brief: composer must not invite a new decision while generating.
-    // We disable typing + replace the placeholder. Chat-mode thinking
-    // (nodeCount > 0) keeps the existing behaviour (Enter blocked via
-    // handleSend; typing still allowed so the user can compose follow-up).
+    // Disable typing, cog, chevron, send, and replace the placeholder. Chat-mode
+    // thinking (nodeCount > 0) keeps the existing behaviour — Enter blocked
+    // via handleSend, typing allowed so follow-ups can be composed.
     const isGenerating = isThinking && nodeCount === 0
     const inputDisabled = disabled || isGenerating
     const effectivePlaceholder = isGenerating
@@ -159,9 +177,22 @@ export const AIInputBar = memo(
       : placeholder ?? stagePlaceholder
     const canSend = draft.trim().length > 0 && !inputDisabled && !isThinking
 
+    // Send button geometry. Welcome variant gets a larger filled disc so the
+    // hero composer feels generous; other variants stay compact.
+    const sendBtnSize = isWelcome ? 'w-8 h-8' : 'w-7 h-7'
+    const sendIconSize = isWelcome ? 'w-4 h-4' : 'w-3.5 h-3.5'
+    const cogBtnSize = isWelcome ? 'w-8 h-8' : 'w-7 h-7'
+    const cogIconSize = isWelcome ? 'w-4 h-4' : 'w-4 h-4'
+    // Stack inset: the cog/send cluster sits inside the right edge of the
+    // textarea. Welcome variant gives more breathing room.
+    const stackInset = isWelcome ? 'right-2 bottom-2' : 'right-1.5 bottom-1'
+    const stackGap = isWelcome ? 'gap-1' : 'gap-0.5'
+    // Right padding on textarea reserves room for the cog+send cluster.
+    const textareaRightPad = isWelcome ? 'pr-24' : 'pr-16'
+
     return (
       <div className={containerClasses} data-testid={testId ?? `ai-input-bar-${variant}`}>
-        <div className="relative flex-1 bg-panel border border-panel-border rounded-lg focus-within:ring-2 focus-within:ring-info">
+        <div className="relative flex-1 bg-panel border border-panel-border rounded-lg transition-colors focus-within:border-info">
           <textarea
             ref={textareaRef}
             id={textareaId}
@@ -169,29 +200,29 @@ export const AIInputBar = memo(
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={effectivePlaceholder}
-            rows={1}
+            rows={minLines}
             disabled={inputDisabled}
             aria-disabled={inputDisabled}
             aria-label={ariaLabel ?? 'Chat message'}
             data-testid={`${testId ?? `ai-input-bar-${variant}`}-textarea`}
             className={typo(
               'panelBody',
-              'w-full resize-none bg-transparent outline-none text-text-body placeholder:text-text-light py-2 pl-3 pr-16',
+              `w-full resize-none bg-transparent outline-none text-text-body placeholder:text-text-light py-2 pl-3 ${textareaRightPad}`,
             )}
-            style={{ minHeight: 36, maxHeight: LINE_HEIGHT_PX * MAX_LINES + 16 }}
+            style={{ minHeight: minHeightPx, maxHeight: maxHeightPx }}
           />
-          <div className="absolute right-1.5 bottom-1 flex flex-col items-center gap-0.5">
+          <div className={`absolute ${stackInset} flex flex-col items-center ${stackGap}`}>
             {onCogClick ? (
               <button
                 type="button"
                 onClick={(e) => onCogClick(e.currentTarget)}
                 disabled={inputDisabled}
                 aria-disabled={inputDisabled}
-                className="inline-flex items-center justify-center w-6 h-6 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-50"
+                className={`inline-flex items-center justify-center ${cogBtnSize} rounded-full text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-50`}
                 aria-label="Settings"
                 data-testid={`${testId ?? `ai-input-bar-${variant}`}-cog`}
               >
-                <Settings className="w-4 h-4" aria-hidden="true" />
+                <Settings className={cogIconSize} aria-hidden="true" />
               </button>
             ) : null}
             <button
@@ -199,11 +230,11 @@ export const AIInputBar = memo(
               onClick={handleSend}
               disabled={!canSend}
               aria-disabled={!canSend}
-              className="inline-flex items-center justify-center w-6 h-6 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-40 disabled:hover:bg-transparent"
+              className={`inline-flex items-center justify-center ${sendBtnSize} rounded-full bg-info text-text-on-color hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-30 disabled:hover:opacity-30`}
               aria-label="Send"
               data-testid={`${testId ?? `ai-input-bar-${variant}`}-send`}
             >
-              <ArrowUp className="w-4 h-4" aria-hidden="true" />
+              <ArrowUp className={sendIconSize} aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -9,51 +9,104 @@ import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { AIInputBar, type AIInputBarHandle } from './AIInputBar'
 import { registerFloatingFocus } from '../hooks/useFloatingFocus'
+import { measureDockInset, clampPositionToViewport } from './FloatingOlumiPanel'
+import { NodeShape } from '../conversation/primitives/NodeShape'
+import type { NodeType } from '../domain/nodes'
 
 interface FirstUseComposerProps {
   /** Cog popover handler. Receives the cog button element for anchoring. */
   onCogClick: (anchorEl: HTMLElement) => void
 }
 
-const PANEL_WIDTH = 480
+/** Hero panel sizing. Width caps so very wide viewports don't dilute the focal
+ *  point; height has a generous floor so the hero reads as the primary surface
+ *  even at small viewports, and a 70vh cap so it never dominates tall screens. */
+const PANEL_WIDTH = 640
 const PANEL_MARGIN = 16
-// Content-fit height: panel sizes to its guidance + input + padding,
-// with a min-height floor so the layout doesn't collapse on edge cases
-// (empty stage placeholder, missing fonts). Fixed-height was brittle —
-// any copy or padding tweak would either clip or leave dead space.
-const PANEL_MIN_HEIGHT = 108
+const PANEL_MIN_HEIGHT = 460
+
+/** Reposition margin when post-graph auto-anchoring the floating panel. */
+const REPOSITION_EDGE_MARGIN = 16
+
+/** Six DS v5 node shapes that drift ambient atmosphere behind the hero. */
+const AMBIENT_LAYOUT: ReadonlyArray<{
+  kind: NodeType
+  top: string
+  left: string
+  size: number
+  delay: string
+  duration: string
+}> = [
+  { kind: 'goal',     top: '10%',  left: '8%',  size: 40, delay: '0s',    duration: '18s' },
+  { kind: 'decision', top: '20%',  left: '82%', size: 44, delay: '-3s',   duration: '22s' },
+  { kind: 'option',   top: '70%',  left: '12%', size: 36, delay: '-7s',   duration: '20s' },
+  { kind: 'factor',   top: '78%',  left: '78%', size: 32, delay: '-11s',  duration: '24s' },
+  { kind: 'risk',     top: '45%',  left: '4%',  size: 30, delay: '-5s',   duration: '19s' },
+  { kind: 'outcome',  top: '50%',  left: '88%', size: 34, delay: '-13s',  duration: '21s' },
+]
+
+/** Light-fill colours mirror the legacy EmptyState palette so the hero shapes
+ *  read as the same vocabulary used inside the canvas itself. */
+const AMBIENT_FILLS: Record<string, string> = {
+  goal:     'var(--goal-light, #F4DB92)',
+  decision: 'var(--info-light, #BAD7E4)',
+  option:   'var(--option-light, #DDDCF5)',
+  factor:   'var(--factor-light, #EEE6D8)',
+  risk:     'var(--danger-light, #FFB393)',
+  outcome:  'var(--success-light, #B8E2D0)',
+}
 
 /**
- * FirstUseComposer — centred composer that auto-opens when the canvas is
- * empty AND no conversation has begun. Sits above the canvas via portal.
+ * FirstUseComposer — AI Panel v2 welcome hero.
  *
- * Auto-dock rule: when the graph first gains nodes AND the panel was opened
- * by the system (source === 'system-first-use') AND the user has NOT
- * dragged/resized it, the floating panel docks: switches the dock to the
- * Olumi tab and closes the floating window. If the user manually opened or
- * moved the panel, this is skipped.
+ * Renders a large centred surface when the canvas is empty (initial first
+ * launch OR after a canvas reset). Sits above the canvas via portal. Holds
+ * its position through the post-submit generation window so the experience
+ * reads as the same surface transitioning, not a different component
+ * popping in.
  *
- * Reduced motion: animation duration is 0ms when
- * window.matchMedia('(prefers-reduced-motion: reduce)').matches.
+ * Auto-reposition rule (replaces the old auto-close): once the first graph
+ * appears (0 → N+ nodes) the hero unmounts, the floating panel slides to a
+ * bottom-right anchor near the Analysis dock, and Analysis activates so the
+ * user can see AI and analysis side by side. Skipped when the user already
+ * dragged or resized the panel (`userRepositioned`).
+ *
+ * Reset rule: when the graph drops back to zero nodes (canvas reset), the
+ * hero re-engages so the experience returns to a familiar starting state.
+ *
+ * Reduced motion: ambient drift shapes freeze, the auto-reposition fires
+ * synchronously without the 300ms slide delay.
  */
 export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: FirstUseComposerProps) {
   const nodeCount = useCanvasStore((s) => s.nodes.length)
-  const { messages } = useConversationContext()
+  const { draft, messages } = useConversationContext()
   const realMessageCount = messages.filter((m) => !m.synthetic).length
 
   const isOpen = useFloatingPanelState((s) => s.isOpen)
   const source = useFloatingPanelState((s) => s.source)
   const userRepositioned = useFloatingPanelState((s) => s.userRepositioned)
   const openFloating = useFloatingPanelState((s) => s.open)
-  const closeFloating = useFloatingPanelState((s) => s.close)
 
   const prefersReducedMotion = usePrefersReducedMotion()
-  const prevNodeCountRef = useRef(nodeCount)
   const inputBarRef = useRef<AIInputBarHandle | null>(null)
 
-  // Open the first-use composer when the canvas is empty AND no real
-  // messages exist. Only once per session — we don't reopen if the user
-  // closed it explicitly.
+  // Two separate previous-node-count cursors: the reset effect watches
+  // N → 0 transitions, the reposition effect watches 0 → N+ transitions.
+  // Keeping the cursors local to their effects avoids cross-effect coupling.
+  const resetPrevNodeCountRef = useRef(nodeCount)
+  const repositionPrevNodeCountRef = useRef(nodeCount)
+
+  // Tracks whether the user actually submitted via THIS composer instance.
+  // Set in handleAfterSend (AIInputBar callback). Used by the reposition
+  // effect to distinguish a real first-use submission from a 0→N+ node
+  // bump caused by scenario hydration, import, or session resume.
+  const userSentFromFirstUseRef = useRef(false)
+  const handleAfterSend = useCallback(() => {
+    userSentFromFirstUseRef.current = true
+  }, [])
+
+  // Open the hero on first mount when the canvas is empty and no real
+  // conversation has begun. Fires once unless a canvas reset re-engages it.
   const hasAutoOpenedRef = useRef(false)
   useEffect(() => {
     if (hasAutoOpenedRef.current) return
@@ -63,69 +116,92 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: F
     }
   }, [nodeCount, realMessageCount, isOpen, openFloating])
 
-  // Auto-dock requires positive evidence that the user actually submitted
-  // via THIS composer — otherwise any 0→N+ node transition (scenario
-  // hydration, import, session-resume, restored snapshot, programmatic
-  // graph load) would mis-fire the auto-dock.
-  //
-  // The signal is explicit: AIInputBar fires `onAfterSend` only when a
-  // submit is dispatched from this composer instance. No inference from
-  // message counts — hydration cannot fake the callback, so historic
-  // real (non-synthetic) messages restored before graph nodes do NOT
-  // unlock auto-dock.
-  const userSentFromFirstUseRef = useRef(false)
-  const handleAfterSend = useCallback(() => {
-    userSentFromFirstUseRef.current = true
-  }, [])
-
-  // Auto-dock: when the graph FIRST gains nodes, dock the panel if
-  // (a) it's still open, (b) it was opened by the system, (c) the user
-  // has not pointer-dragged or resized it, AND (d) the user has actually
-  // submitted via this composer (so hydration/import paths can't trigger).
+  // Canvas reset → re-engage the hero, but ONLY when the empty state is
+  // stable. Transient N → 0 transitions happen during scenario switches,
+  // graph imports, and session hydration — the canvas store briefly
+  // reports zero nodes before the new graph populates. Re-opening the
+  // hero on those would flicker the welcome surface over the loading
+  // graph. Debounce: wait 500ms and re-check; if a new graph has loaded
+  // by then, the reset was transient and we skip the re-engage.
   useEffect(() => {
-    const prev = prevNodeCountRef.current
-    prevNodeCountRef.current = nodeCount
-    if (prev !== 0 || nodeCount === 0) return // only fires on the 0 → N+ transition
+    const prev = resetPrevNodeCountRef.current
+    resetPrevNodeCountRef.current = nodeCount
+    if (prev <= 0 || nodeCount > 0) return // only fires on N → 0 (reset)
+    const id = window.setTimeout(() => {
+      // Re-read live state — if a new graph loaded during the debounce
+      // window, the reset was transient and we bail out silently.
+      if (useCanvasStore.getState().nodes.length === 0) {
+        userSentFromFirstUseRef.current = false
+        openFloating('system-first-use') // resets userRepositioned + source
+      }
+    }, 500)
+    return () => window.clearTimeout(id)
+  }, [nodeCount, openFloating])
+
+  // Auto-reposition on 0 → N+ transition (the legitimate first graph being
+  // drafted from the user's brief). Replaces the previous auto-close: per
+  // the brief, AI must remain visible alongside Analysis. The floating
+  // panel slides to a bottom-right anchor; the right-hand dock activates
+  // its Analysis tab; the "Model drafted. Review readiness." receipt fires.
+  useEffect(() => {
+    const prev = repositionPrevNodeCountRef.current
+    repositionPrevNodeCountRef.current = nodeCount
+    if (prev !== 0 || nodeCount === 0) return // only on 0 → N+
     if (!isOpen) return
     if (!canAutoDock({ source, userRepositioned })) return
     if (!userSentFromFirstUseRef.current) return // hydration/import guard
 
-    const performDock = () => {
-      // Brief: after auto-dock, the right panel expands and Analysis (not
-      // Olumi) becomes the active tab so the user sees readiness guidance.
-      //
-      // forceActivateOutputTab (not setActiveOutputTab) guarantees the
-      // OutputsDock sync fires even when the global activeOutputTab value
-      // is unchanged — e.g. global was already 'results' but the dock had
-      // another tab persisted to localStorage from a prior session.
+    const performReposition = () => {
+      // Activate Analysis tab so the user sees readiness guidance next to
+      // the floating AI panel. forceActivateOutputTab bumps the version
+      // counter so the dock syncs even when global tab was already 'results'.
       useUIStore.getState().forceActivateOutputTab('results')
-      closeFloating()
+
       // 3-second "Model drafted. Review readiness." banner at the top of
       // the Analysis tab. Self-clears via the store's internal timer.
       useTransitionReceipt.getState().show('model-drafted', 3000)
+
+      // Compute the bottom-right anchor near the Analysis dock. Anchor is
+      // clamped via the existing viewport+dock-inset rules so it never
+      // lands under the dock or off-canvas.
+      const vw = typeof window !== 'undefined' ? window.innerWidth : 1200
+      const vh = typeof window !== 'undefined' ? window.innerHeight : 800
+      const dockInset = measureDockInset()
+      const { size, performAutoReposition } = useFloatingPanelState.getState()
+      const anchorRaw = {
+        x: vw - dockInset - size.width - REPOSITION_EDGE_MARGIN,
+        y: vh - size.height - REPOSITION_EDGE_MARGIN,
+      }
+      const anchor = clampPositionToViewport(anchorRaw, size, vw, vh, dockInset)
+
+      // Delegate the rAF + slide-flag-clear orchestration to the store
+      // action so the timers live outside any component lifecycle. This
+      // composer's effect cleanup cannot accidentally cancel them on a
+      // dependency change (e.g. another node-count tick during the 450ms
+      // clear window).
+      performAutoReposition(anchor, { reducedMotion: prefersReducedMotion })
     }
     if (prefersReducedMotion) {
-      performDock()
+      performReposition()
       return
     }
-    // 300ms delay so the user perceives the transition before the panel
-    // closes and Analysis activates. Skipped under prefers-reduced-motion
-    // (handled above). The receipt banner appears once performDock fires.
-    const id = window.setTimeout(performDock, 300)
+    // 300ms delay so the user perceives the hero settling before the
+    // floating panel slides into place. Skipped under prefers-reduced-motion.
+    // Only the outer trigger timeout is cancelled on dep changes — the
+    // store action's internal rAF + clear run independently.
+    const id = window.setTimeout(performReposition, 300)
     return () => window.clearTimeout(id)
-  }, [nodeCount, isOpen, source, userRepositioned, prefersReducedMotion, closeFloating])
+  }, [nodeCount, isOpen, source, userRepositioned, prefersReducedMotion])
 
-  // First-use is rendered when ALL of:
-  //  - the panel is open
-  //  - source is system-first-use (NOT a user-driven open)
-  //  - the canvas has no nodes and no real messages (still empty)
-  // Otherwise the regular FloatingOlumiPanel handles rendering.
-  const shouldRender = isOpen && source === 'system-first-use' && nodeCount === 0 && realMessageCount === 0
+  // Hero renders whenever the canvas is empty AND the floating panel is
+  // system-opened. Includes the initial welcome state, the post-submit /
+  // pre-graph generation window, and any post-reset state. Once nodeCount
+  // > 0 the hero unmounts and the floating panel takes over.
+  const shouldRender = isOpen && source === 'system-first-use' && nodeCount === 0
 
-  // Register the floating-focus channel from THIS surface when first-use is
-  // active. FloatingOlumiPanel yields rendering to us during first-use, so
-  // its registration would point at a null input ref. Owning the channel
-  // here means focusFloating() lands in the first-use composer's textarea.
+  // Register the floating-focus channel from THIS surface when the hero is
+  // active. FloatingOlumiPanel yields to us in the same window, so its
+  // registration would point at a null input ref.
   useEffect(() => {
     if (!shouldRender) return
     return registerFloatingFocus(() => inputBarRef.current?.focus())
@@ -134,44 +210,144 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: F
   if (!shouldRender) return null
   if (typeof document === 'undefined') return null
 
+  // Drift recedes once the user starts typing so the composer becomes the
+  // visual focal point. Reduced-motion users see static faded shapes.
+  const hasDraft = draft.trim().length > 0
+
   return createPortal(
     <div
       role="dialog"
       aria-label="Describe your decision"
       data-testid="first-use-composer"
-      className="fixed bg-panel border border-panel-border rounded-lg shadow-2 flex flex-col"
+      className="fixed bg-panel border border-panel-border rounded-lg shadow-2 flex flex-col overflow-hidden"
       style={{
         zIndex: 300,
         // Responsive width: cap at PANEL_WIDTH on wide viewports, shrink to
-        // viewport - 2*margin on narrow ones so the composer never overflows.
+        // viewport - 2*margin on narrow ones so the hero never overflows.
         width: `min(${PANEL_WIDTH}px, calc(100vw - ${PANEL_MARGIN * 2}px))`,
-        // Content-fit height with a min-height floor (defensive only —
-        // expect the actual height to be guidance + input + ~24px padding).
+        // Min-height floor so the hero always reads as a prominent surface.
+        // Cap at 70vh so it doesn't dominate tall screens; content-fit
+        // between floor and cap keeps the layout responsive.
         minHeight: PANEL_MIN_HEIGHT,
-        // Vertical: pin near the upper third of the canvas so the focused
-        // start card sits where the eye lands first, with a hard 16px
-        // floor at narrow viewports. Horizontal: centre when there's
-        // room, otherwise pinned to the left margin.
+        maxHeight: '70vh',
+        // Horizontal centre when there's room; left margin on narrow viewports.
         left: `max(${PANEL_MARGIN}px, calc(50% - ${PANEL_WIDTH / 2}px))`,
-        top: `max(${PANEL_MARGIN}px, calc(30% - ${PANEL_MIN_HEIGHT / 2}px))`,
+        // Vertical centre. max() floor prevents overflow at very short viewports.
+        top: `max(${PANEL_MARGIN}px, calc(50vh - ${PANEL_MIN_HEIGHT / 2}px))`,
       }}
     >
-      <div className="flex flex-col items-center px-5 pt-3 pb-1.5">
-        <p className={typo('panelBody', 'text-text-light text-center')}>
+      <AmbientDriftShapes settled={hasDraft} reducedMotion={prefersReducedMotion} />
+      <div className="relative z-10 flex flex-col items-center justify-center flex-1 px-8 py-10 gap-4">
+        <img
+          src="/olumi-logo.png"
+          alt=""
+          aria-hidden="true"
+          width={64}
+          height={64}
+          className="block select-none"
+          draggable={false}
+        />
+        <h2
+          className={typo('welcomeHeading', 'text-text-body text-center m-0')}
+          data-testid="first-use-heading"
+        >
+          What are you deciding?
+        </h2>
+        <p
+          className={typo('panelBody', 'text-text-light text-center max-w-md')}
+          data-testid="first-use-guidance"
+        >
           Describe the decision, options, goal and constraints.
         </p>
+        <div className="w-full max-w-md mt-2">
+          <AIInputBar
+            ref={inputBarRef}
+            variant="welcome"
+            onCogClick={onCogClick}
+            hideChevron
+            placeholder="Describe your decision…"
+            ariaLabel="Describe your decision"
+            testId="first-use-input-bar"
+            onAfterSend={handleAfterSend}
+          />
+        </div>
       </div>
-      <AIInputBar
-        ref={inputBarRef}
-        variant="first-use"
-        onCogClick={onCogClick}
-        hideChevron
-        placeholder="Describe your decision…"
-        ariaLabel="Describe your decision"
-        testId="first-use-input-bar"
-        onAfterSend={handleAfterSend}
-      />
     </div>,
     document.body,
   )
 })
+
+/**
+ * AmbientDriftShapes — six low-opacity DS node shapes drifting subtly behind
+ * the hero content. CSS-only animation (no JS loop), settled state when the
+ * user starts typing, fully suppressed under prefers-reduced-motion.
+ *
+ * The shapes act as ambient atmosphere — never interactive, never on top of
+ * content, always aria-hidden. Opacity stays low (8-15%) so they read as
+ * texture rather than as discrete shapes competing for attention.
+ */
+function AmbientDriftShapes({ settled, reducedMotion }: { settled: boolean; reducedMotion: boolean }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`absolute inset-0 pointer-events-none ${settled ? 'ambient-drift-settled' : ''}`}
+      data-testid="first-use-ambient-shapes"
+    >
+      {AMBIENT_LAYOUT.map(({ kind, top, left, size, delay, duration }) => (
+        <div
+          key={kind}
+          className={reducedMotion ? 'ambient-drift-static' : 'ambient-drift-shape'}
+          style={{
+            position: 'absolute',
+            top,
+            left,
+            width: size,
+            height: size,
+            animationDelay: delay,
+            animationDuration: duration,
+          }}
+          data-shape={kind}
+        >
+          <NodeShape kind={kind} size={size} fill={AMBIENT_FILLS[kind]} />
+        </div>
+      ))}
+      <style>{`
+        @keyframes ambientDrift {
+          0%   { transform: translate(0, 0);       opacity: 0.14; }
+          25%  { transform: translate(6px, -4px);  opacity: 0.18; }
+          50%  { transform: translate(-2px, 6px);  opacity: 0.12; }
+          75%  { transform: translate(-6px, -2px); opacity: 0.16; }
+          100% { transform: translate(0, 0);       opacity: 0.14; }
+        }
+        .ambient-drift-shape {
+          opacity: 0.14;
+          animation-name: ambientDrift;
+          animation-timing-function: ease-in-out;
+          animation-iteration-count: infinite;
+          will-change: transform, opacity;
+        }
+        /* Once the user starts typing, drop opacity further so the composer
+           takes visual priority. Animation continues at the reduced level. */
+        .ambient-drift-settled .ambient-drift-shape {
+          opacity: 0.06;
+        }
+        /* Static fallback for reduced-motion users: faded, no animation. */
+        .ambient-drift-static {
+          opacity: 0.12;
+        }
+        .ambient-drift-settled .ambient-drift-static {
+          opacity: 0.06;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .ambient-drift-shape {
+            animation: none !important;
+            opacity: 0.12 !important;
+          }
+          .ambient-drift-settled .ambient-drift-shape {
+            opacity: 0.06 !important;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -19,6 +19,9 @@ import {
 } from '../hooks/useFloatingPanelState'
 import { AIInputBar, type AIInputBarHandle } from './AIInputBar'
 import { registerFloatingFocus } from '../hooks/useFloatingFocus'
+import { useUIStore } from '../../stores/uiStore'
+import { isAiPanelV2Enabled } from '../../flags'
+import { readPersistedActiveDockTab } from './OutputsDock'
 
 interface FloatingOlumiPanelProps {
   /** Called when the user clicks the Dock button. The host should switch the
@@ -31,6 +34,18 @@ interface FloatingOlumiPanelProps {
 const MIN_WIDTH = 320
 const MIN_HEIGHT = 300
 const DEFAULT_MARGIN = 16
+/** Side tab and drag handle dimensions. The side tab hosts minimise/dock
+ *  controls at 32×32 hit areas to match the welcome-variant send/cog
+ *  buttons elsewhere in the panel. The 36px column gives 2px breathing
+ *  room around each button. Full 44×44 (WCAG strict touch target) would
+ *  dominate the panel on smaller viewports; 32×32 is the established
+ *  in-panel icon-button scale.
+ *  The drag handle is a thin (6px) horizontal strip across the top. */
+const SIDE_TAB_WIDTH = 36
+const DRAG_HANDLE_HEIGHT = 6
+
+/** Which of the four corners is being dragged for resize. */
+type ResizeCorner = 'tl' | 'tr' | 'bl' | 'br'
 
 const noop = () => {}
 
@@ -120,6 +135,61 @@ export function fitsAtMinSize(
   return availableW >= MIN_WIDTH && availableH >= MIN_HEIGHT
 }
 
+/**
+ * Per-corner resize geometry. Given the drag start state (pre-pointerdown
+ * panel rect), the pointer delta, the viewport and dock inset, returns the
+ * panel's new x/y/w/h with all clamps applied (MIN_WIDTH/MIN_HEIGHT floor,
+ * computeMaxSize cap, dock-aware right-edge cap, margin floor on every
+ * edge). Pure function — easy to unit test and reuses the same constants
+ * the BR resize path has used since rounds 1-2.
+ *
+ * The corner being dragged is the FREE corner; the opposite corner stays
+ * fixed. For TL/TR/BL the panel's x and/or y shift so that the opposite
+ * corner remains at its starting screen coordinate while w/h grow or shrink.
+ */
+export function computeCornerResize(
+  corner: ResizeCorner,
+  startLeft: number,
+  startTop: number,
+  startW: number,
+  startH: number,
+  dx: number,
+  dy: number,
+  viewportW: number,
+  viewportH: number,
+  rightInset: number = 0,
+): { x: number; y: number; w: number; h: number } {
+  const max = computeMaxSize(viewportW, viewportH)
+  const fixedRight = startLeft + startW
+  const fixedBottom = startTop + startH
+
+  // Width cap depends on which side is fixed. When the LEFT edge stays put
+  // (BR/TR drags), the right edge can grow to the dock-aware boundary.
+  // When the RIGHT edge stays put (BL/TL drags), the left edge can shrink
+  // to the viewport margin.
+  const wRoomFromLeftFixed = Math.max(0, viewportW - startLeft - DEFAULT_MARGIN - rightInset)
+  const wRoomFromRightFixed = Math.max(0, fixedRight - DEFAULT_MARGIN)
+  const maxW = (corner === 'br' || corner === 'tr') ? wRoomFromLeftFixed : wRoomFromRightFixed
+
+  const hRoomFromTopFixed = Math.max(0, viewportH - startTop - DEFAULT_MARGIN)
+  const hRoomFromBottomFixed = Math.max(0, fixedBottom - DEFAULT_MARGIN)
+  const maxH = (corner === 'br' || corner === 'bl') ? hRoomFromTopFixed : hRoomFromBottomFixed
+
+  // Target dimensions from the pointer delta. Sign flips when the dragged
+  // corner is on the opposite side from the fixed corner.
+  const wTarget = (corner === 'br' || corner === 'tr') ? startW + dx : startW - dx
+  const hTarget = (corner === 'br' || corner === 'bl') ? startH + dy : startH - dy
+
+  const w = Math.max(MIN_WIDTH, Math.min(max.width, maxW, wTarget))
+  const h = Math.max(MIN_HEIGHT, Math.min(max.height, maxH, hTarget))
+
+  // Place the panel so the FIXED corner stays put. Derive x/y from the
+  // fixed corner's coordinates and the new width/height.
+  const x = (corner === 'br' || corner === 'tr') ? startLeft : fixedRight - w
+  const y = (corner === 'br' || corner === 'bl') ? startTop : fixedBottom - h
+  return { x, y, w, h }
+}
+
 export function clampPillPositionToViewport(
   pos: FloatingPanelPosition,
   viewportW: number,
@@ -145,7 +215,7 @@ export function clampPillPositionToViewport(
  * `dock.left < vw/2`, and the inset must still be reserved so the
  * floating panel doesn't drift under it.
  */
-function measureDockInset(): number {
+export function measureDockInset(): number {
   if (typeof document === 'undefined' || typeof window === 'undefined') return 0
   const dock = document.querySelector('aside[aria-label="Outputs dock"]') as HTMLElement | null
   if (!dock) return 0
@@ -186,18 +256,58 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   const close = useFloatingPanelState((s) => s.close)
   const minimise = useFloatingPanelState((s) => s.minimise)
   const restore = useFloatingPanelState((s) => s.restore)
-  // First-use composer takes over rendering when the system opened the panel
-  // on an empty canvas with no real messages — yield to that surface so
-  // exactly one composer is mounted at a time.
+  // First-use composer takes over rendering whenever the canvas is empty AND
+  // the panel was opened by the system (initial first-use OR re-opened on a
+  // canvas reset). This includes the post-submit / pre-graph window so the
+  // hero doesn't blink out and the user doesn't see the panel jump to the
+  // top-left while generation is in flight.
   const nodeCount = useCanvasStore((s) => s.nodes.length)
-  const realMessageCount = conversation.messages.filter((m) => !m.synthetic).length
-  const yieldToFirstUse = source === 'system-first-use' && nodeCount === 0 && realMessageCount === 0
+  const yieldToFirstUse = source === 'system-first-use' && nodeCount === 0
+
+  // Render-time duplicate-surface guard. If AI Panel v2 is on AND the docked
+  // Olumi tab is the active right-panel surface, the floating panel must
+  // NOT paint — even for a single frame. OutputsDockBody's useEffect closes
+  // the floating panel in this state (steady-state convergence), but the
+  // effect runs after first paint.
+  //
+  // OutputsDock and useUIStore can disagree on the first paint: OutputsDock
+  // restores `state.activeTab` from sessionStorage synchronously while
+  // useUIStore.activeOutputTab is still the default 'results' until the
+  // E1 sync effect runs (post-paint). Reading the persisted dock state
+  // synchronously here aligns the yield gate with whatever OutputsDock is
+  // about to paint. Falls back to useUIStore when no persisted state.
+  const activeOutputTab = useUIStore((s) => s.activeOutputTab)
+  const persistedDockTab = readPersistedActiveDockTab()
+  const effectiveDockTab = persistedDockTab ?? activeOutputTab
+  const yieldToDockedOlumi = isAiPanelV2Enabled() && effectiveDockTab === 'olumi'
+
+  // Post-graph auto-reposition: when FirstUseComposer commits the bottom-right
+  // anchor, it flags `isAutoRepositioning` so the panel applies a scoped CSS
+  // slide on left/top. The clearing timeout lives in the OWNER
+  // (FirstUseComposer.performReposition) rather than here — if it lived in
+  // a mounted effect on this panel, a yield/unmount during the transition
+  // window would strand the flag at `true` and the next mount would
+  // erroneously animate its initial position write.
+  const isAutoRepositioning = useFloatingPanelState((s) => s.isAutoRepositioning)
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const inputBarRef = useRef<AIInputBarHandle | null>(null)
   const rafRef = useRef<number | null>(null)
   const dragStateRef = useRef<{ pointerId: number; offsetX: number; offsetY: number } | null>(null)
-  const resizeStateRef = useRef<{ pointerId: number; startX: number; startY: number; startW: number; startH: number } | null>(null)
+  // Resize state tracks which corner is being dragged plus the panel's
+  // starting position/size. Pre-rounds-3 BR-only resize stored just
+  // startX/startY/startW/startH; with all-corner resize we also need the
+  // start left/top so the fixed (opposite) corner can stay put.
+  const resizeStateRef = useRef<{
+    pointerId: number
+    corner: ResizeCorner
+    startX: number
+    startY: number
+    startLeft: number
+    startTop: number
+    startW: number
+    startH: number
+  } | null>(null)
 
   // Apply position/size to DOM whenever isOpen flips to true OR the store
   // commits a new value (drag/resize end). During drag/resize this is bypassed
@@ -254,6 +364,13 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     // entry points.
     const rawPos = position ?? defaultCentredPosition({ width: w, height: h }, vw - dockInset, vh)
     const pos = clampPositionToViewport(rawPos, { width: w, height: h }, vw, vh, dockInset)
+    // Apply the slide transition INLINE (not via React style prop) so the
+    // browser sees: old el.style.left value → transition declaration → new
+    // el.style.left value, animating between them. Setting it on the React
+    // style prop would race with the layout effect's direct el.style writes.
+    // Only active during the post-graph auto-reposition window — drag/resize
+    // never trip this branch because they don't flip `isAutoRepositioning`.
+    el.style.transition = isAutoRepositioning ? 'left 300ms ease, top 300ms ease' : 'none'
     el.style.width = `${w}px`
     el.style.height = `${h}px`
     el.style.left = `${pos.x}px`
@@ -265,7 +382,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     if (position === null) {
       setInitialPosition(pos)
     }
-  }, [isOpen, isMinimised, position, size, setInitialPosition, minimise])
+  }, [isOpen, isMinimised, position, size, isAutoRepositioning, setInitialPosition, minimise])
 
   // Register a focus channel so the persistent status strip and Olumi-tab
   // click (when floating is open) can imperatively focus the input.
@@ -277,7 +394,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   //   schedule the focus on the next frame so React can remount before we
   //   call .focus() on the ref.
   useEffect(() => {
-    if (!isOpen || yieldToFirstUse) return
+    if (!isOpen || yieldToFirstUse || yieldToDockedOlumi) return
     return registerFloatingFocus(() => {
       const state = useFloatingPanelState.getState()
       if (state.isMinimised) {
@@ -287,7 +404,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         inputBarRef.current?.focus()
       }
     })
-  }, [isOpen, yieldToFirstUse])
+  }, [isOpen, yieldToFirstUse, yieldToDockedOlumi])
 
   // Clamp on viewport resize AND on dock resize/open/close so the panel
   // never leaves the visible area and never lands under the dock. The
@@ -417,7 +534,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
 
       if (drag) {
         const w = parseFloat(el.style.width || '400')
-        const h = parseFloat(el.style.height || '500')
+        const h = parseFloat(el.style.height || '550')
         const x = clamp(e.clientX - drag.offsetX, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vw - w - DEFAULT_MARGIN - dockInset))
         const y = clamp(e.clientY - drag.offsetY, DEFAULT_MARGIN, Math.max(DEFAULT_MARGIN, vh - h - DEFAULT_MARGIN))
         el.style.left = `${x}px`
@@ -431,23 +548,33 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
           useFloatingPanelState.getState().minimise()
           return
         }
-        const dw = e.clientX - resize.startX
-        const dh = e.clientY - resize.startY
-        // Resize comes from the bottom-right handle, so x/y stay fixed
-        // and we grow width/height. Cap the maximum width by the
-        // remaining space from the panel's current x to the dock's left
-        // edge (or viewport right - margin when no dock). MIN_WIDTH is
-        // preserved — the auto-minimise branch above handles the case
-        // where the dock leaves less room than MIN_WIDTH.
-        const x = parseFloat(el.style.left || '0')
-        const y = parseFloat(el.style.top || '0')
-        const { widthBudget, heightBudget } = computeResizeBudget(x, y, vw, vh, dockInset)
-        const requestedW = Math.max(MIN_WIDTH, resize.startW + dw)
-        const requestedH = Math.max(MIN_HEIGHT, resize.startH + dh)
-        const w = Math.max(MIN_WIDTH, Math.min(max.width, widthBudget, requestedW))
-        const h = Math.max(MIN_HEIGHT, Math.min(max.height, heightBudget, requestedH))
-        el.style.width = `${w}px`
-        el.style.height = `${h}px`
+        const dx = e.clientX - resize.startX
+        const dy = e.clientY - resize.startY
+        // Per-corner resize: the opposite corner stays fixed at its
+        // starting screen coordinate; the dragged corner's pointer delta
+        // drives the new width/height. computeCornerResize composes all
+        // clamps (MIN floor, computeMaxSize cap, dock-aware right-edge
+        // cap, margin floor) the same way the BR-only path did.
+        // `max` is read inside computeCornerResize (it shadows our local
+        // `max` here, which is fine — both call computeMaxSize on the
+        // same inputs).
+        void max
+        const next = computeCornerResize(
+          resize.corner,
+          resize.startLeft,
+          resize.startTop,
+          resize.startW,
+          resize.startH,
+          dx,
+          dy,
+          vw,
+          vh,
+          dockInset,
+        )
+        el.style.width = `${next.w}px`
+        el.style.height = `${next.h}px`
+        el.style.left = `${next.x}px`
+        el.style.top = `${next.y}px`
       }
     })
   }, [])
@@ -477,10 +604,22 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         rafRef.current = null
       }
       if (el) {
+        // For TL/TR/BL corners the panel's x or y shifts during resize.
+        // Commit the position too so the store stays in sync with the DOM —
+        // otherwise the next layout-effect re-render would snap the panel
+        // back to its pre-resize position. Both setSize and setPosition
+        // flip userRepositioned, which is the correct semantics for a
+        // user-initiated resize (canAutoDock returns false after).
         setSize({
           width: parseFloat(el.style.width || '0'),
           height: parseFloat(el.style.height || '0'),
         })
+        if (resize.corner !== 'br') {
+          setPosition({
+            x: parseFloat(el.style.left || '0'),
+            y: parseFloat(el.style.top || '0'),
+          })
+        }
       }
     }
   }, [setPosition, setSize])
@@ -501,23 +640,30 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     }
   }, [isOpen, handlePointerMove, handlePointerUp])
 
-  // Resize handle pointer-down.
-  const handleResizePointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
-    const el = containerRef.current
-    if (!el) return
-    e.preventDefault()
-    const rect = el.getBoundingClientRect()
-    resizeStateRef.current = {
-      pointerId: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      startW: rect.width,
-      startH: rect.height,
-    }
-    try {
-      ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
-    } catch {
-      // pointer capture optional
+  // Resize handle pointer-down. Captures the panel's current rect AND the
+  // identity of the dragged corner so pointermove can compute the new
+  // geometry with the opposite corner held fixed.
+  const handleResizePointerDown = useCallback((corner: ResizeCorner) => {
+    return (e: ReactPointerEvent<HTMLDivElement>) => {
+      const el = containerRef.current
+      if (!el) return
+      e.preventDefault()
+      const rect = el.getBoundingClientRect()
+      resizeStateRef.current = {
+        pointerId: e.pointerId,
+        corner,
+        startX: e.clientX,
+        startY: e.clientY,
+        startLeft: rect.left,
+        startTop: rect.top,
+        startW: rect.width,
+        startH: rect.height,
+      }
+      try {
+        ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+      } catch {
+        // pointer capture optional
+      }
     }
   }, [])
 
@@ -525,7 +671,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     minimise()
   }, [minimise])
 
-  if (!isOpen || yieldToFirstUse) return null
+  if (!isOpen || yieldToFirstUse || yieldToDockedOlumi) return null
   if (typeof document === 'undefined') return null
 
   // Minimised: render a small restore pill at the panel's last position.
@@ -571,54 +717,80 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       style={{
         zIndex: 300,
         width: 400,
-        height: 500,
+        height: 550,
         left: 0,
         top: 0,
         overflow: 'hidden',
       }}
     >
+      {/* Thin top drag handle. Replaces the previous bulky h-8 header — saves
+         conversation height while keeping a clear, pointer-driven drag
+         affordance. Decorative for assistive tech: not focusable, not
+         operable from the keyboard. Keyboard users reach Minimise + Dock
+         via the side-tab buttons below. The strip carries
+         `data-testid="floating-olumi-panel-header"` so existing drag tests
+         continue to pass. */}
       <div
         onPointerDown={handleHeaderPointerDown}
-        className="flex items-center justify-between px-3 h-8 bg-panel border-b border-panel-border select-none"
-        style={{ cursor: 'grab' }}
+        className="absolute top-0 left-0 right-0 select-none transition-colors hover:bg-panel-hover"
+        style={{ height: DRAG_HANDLE_HEIGHT, cursor: 'grab', zIndex: 2 }}
         data-testid="floating-olumi-panel-header"
+        aria-hidden="true"
       >
-        <div className="flex items-center gap-1.5 flex-1 min-w-0">
-          <MessageSquare className="w-4 h-4 text-text-light flex-shrink-0" aria-hidden="true" />
-          <span className={typo('panelHeader', 'text-text-body truncate')}>Olumi</span>
-        </div>
-        <div className="flex items-center gap-0.5 flex-shrink-0">
-          <button
-            type="button"
-            onClick={handleMinimise}
-            className="inline-flex items-center justify-center w-7 h-7 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
-            aria-label="Minimise"
-            data-testid="floating-olumi-panel-minimise"
-            title="Minimise"
-          >
-            <Minus className="w-4 h-4" aria-hidden="true" />
-          </button>
-          <button
-            type="button"
-            onClick={onDock}
-            className="inline-flex items-center justify-center w-7 h-7 rounded-sm text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
-            aria-label="Dock to panel"
-            data-testid="floating-olumi-panel-dock"
-            title="Dock to panel"
-          >
-            <PanelRight className="w-4 h-4" aria-hidden="true" />
-          </button>
-        </div>
+        <span
+          aria-hidden="true"
+          className="block absolute left-1/2 -translate-x-1/2 top-1/2 -translate-y-1/2 w-10 h-px bg-panel-border"
+        />
       </div>
 
-      {/* `floating-density` activates the scoped compact CSS overrides
-         defined in Conversation.module.css (tighter message gap, bubble
-         padding, chip sizing). `compact={true}` makes MessageBubble swap
-         from typography.body (16px) to typography.panelBody (12px) and
-         apply markdownContentCompact line-height — keeping the floating
-         surface a compact assistant, not a second full dashboard. The
-         docked Olumi tab and DraftChat remain at default density. */}
-      <div className="floating-density flex flex-1 min-h-0 flex-col">
+      {/* Side tab (left edge): hosts the minimise + dock controls in a
+         36px column. Visible identity affordance via a small Olumi mark
+         up top — the panel title is otherwise implicit. Buttons are 32×32
+         hit areas matching the welcome-variant cog/send pattern used
+         elsewhere in the panel. */}
+      <div
+        className="absolute top-0 bottom-0 left-0 bg-panel border-r border-panel-border flex flex-col items-center pt-2 pb-2 gap-1 select-none"
+        style={{ width: SIDE_TAB_WIDTH, paddingTop: DRAG_HANDLE_HEIGHT + 4, zIndex: 1 }}
+        data-testid="floating-olumi-panel-side-tab"
+      >
+        <MessageSquare
+          className="w-4 h-4 text-text-light flex-shrink-0"
+          aria-hidden="true"
+          data-testid="floating-olumi-panel-side-mark"
+        />
+        <button
+          type="button"
+          onClick={handleMinimise}
+          className="inline-flex items-center justify-center w-8 h-8 rounded text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info mt-1"
+          aria-label="Minimise"
+          data-testid="floating-olumi-panel-minimise"
+          title="Minimise"
+        >
+          <Minus className="w-4 h-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          onClick={onDock}
+          className="inline-flex items-center justify-center w-8 h-8 rounded text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
+          aria-label="Dock to panel"
+          data-testid="floating-olumi-panel-dock"
+          title="Dock to panel"
+        >
+          <PanelRight className="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Main content column. Sits to the right of the side tab and below
+         the thin drag handle. `floating-density` activates the scoped
+         compact CSS overrides defined in Conversation.module.css (tighter
+         message gap, bubble padding, chip sizing). `compact={true}` makes
+         MessageBubble swap from typography.body (16px) to typography.panelBody
+         (12px) and apply markdownContentCompact line-height — keeping the
+         floating surface a compact assistant, not a second full dashboard. */}
+      <div
+        className="floating-density flex flex-1 min-h-0 flex-col"
+        style={{ marginLeft: SIDE_TAB_WIDTH, marginTop: DRAG_HANDLE_HEIGHT }}
+      >
         <ConversationPanel
           conversation={conversation}
           onCollapse={close}
@@ -628,13 +800,37 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
           hideComposer
           compact
         />
+        <AIInputBar ref={inputBarRef} variant="floating" onCogClick={onCogClick} hideChevron />
       </div>
 
-      <AIInputBar ref={inputBarRef} variant="floating" onCogClick={onCogClick} hideChevron />
-
+      {/* Four corner resize handles. Each is a 12×12 hit area at the panel
+         edge with the appropriate diagonal cursor. The BR handle keeps its
+         legacy testid; TL/TR/BL are new for the all-corner pass. */}
       <div
-        onPointerDown={handleResizePointerDown}
+        onPointerDown={handleResizePointerDown('tl')}
+        className="absolute left-0 top-0 w-3 h-3 cursor-nwse-resize"
+        style={{ zIndex: 3 }}
+        data-testid="floating-olumi-panel-resize-handle-tl"
+        aria-hidden="true"
+      />
+      <div
+        onPointerDown={handleResizePointerDown('tr')}
+        className="absolute right-0 top-0 w-3 h-3 cursor-nesw-resize"
+        style={{ zIndex: 3 }}
+        data-testid="floating-olumi-panel-resize-handle-tr"
+        aria-hidden="true"
+      />
+      <div
+        onPointerDown={handleResizePointerDown('bl')}
+        className="absolute left-0 bottom-0 w-3 h-3 cursor-nesw-resize"
+        style={{ zIndex: 3 }}
+        data-testid="floating-olumi-panel-resize-handle-bl"
+        aria-hidden="true"
+      />
+      <div
+        onPointerDown={handleResizePointerDown('br')}
         className="absolute right-0 bottom-0 w-3 h-3 cursor-nwse-resize"
+        style={{ zIndex: 3 }}
         data-testid="floating-olumi-panel-resize-handle"
         aria-hidden="true"
       >

--- a/src/canvas/components/OlumiTabBody.tsx
+++ b/src/canvas/components/OlumiTabBody.tsx
@@ -77,6 +77,7 @@ export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabB
           onCollapse={handleCollapse}
           onAttach={handleAttach}
           hideComposer
+          compact
         />
       </div>
     </div>

--- a/src/canvas/components/OlumiTabBody.tsx
+++ b/src/canvas/components/OlumiTabBody.tsx
@@ -5,23 +5,26 @@ import { useConversationContext } from '../conversation/ConversationContext'
 import { ConversationPanel } from '../conversation/ConversationPanel'
 
 interface OlumiTabBodyProps {
-  /** Opens the floating Olumi panel for the user. */
+  /** Opens the floating Olumi panel for the user (manual float-out from
+   *  the docked tab). Rendered as a small, subtle icon-only control —
+   *  never as a CTA that blocks access to the docked conversation. */
   onFloatOut?: () => void
 }
 
 /**
  * OlumiTabBody — docked Olumi tab content.
  *
- * Two render states:
- *  - Empty conversation → guidance text + float-out.
- *  - Otherwise → full ConversationPanel with `hideComposer` (the persistent
- *    strip below the tab body owns submission).
+ * Round-3 UX correction: clicking the Olumi tab always docks the
+ * conversation here (handleTabClick closes the floating panel first if
+ * needed). The docked view is never a redirect to floating; the empty
+ * state shows a calm welcome line, and a small float-out icon lives in
+ * the top-right corner for users who prefer the floating window.
  *
- * When the floating panel is open, the tab is NOT switched to this body —
- * OutputsDock.handleTabClick intercepts the Olumi-tab click and calls
- * focusFloating() instead, so the user's current Analysis/Compare/Model
- * tab stays active. The previous "floating-state placeholder" branch was
- * removed in the UX correction pass to avoid wasting the right panel.
+ * Two render states:
+ *  - Empty conversation → calm welcome line + subtle float-out icon.
+ *  - Has messages → full ConversationPanel with `hideComposer` (the
+ *    persistent strip below the tab body owns submission so the docked
+ *    composer is never duplicated).
  */
 export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabBodyProps) {
   const conversation = useConversationContext()
@@ -34,31 +37,32 @@ export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabB
     // Attach evidence is handled by CogPopover, not here.
   }, [])
 
+  // Float-out icon — small, top-right corner, subtle. Available in both
+  // empty and populated states so users can switch surface preference
+  // without losing draft text (singleton ConversationContext preserves it).
+  const floatOutIcon = onFloatOut ? (
+    <div className="flex justify-end px-2 pt-1 pb-0.5">
+      <button
+        type="button"
+        onClick={onFloatOut}
+        className="inline-flex items-center justify-center w-6 h-6 rounded text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
+        aria-label="Open Olumi in floating panel"
+        data-testid="olumi-tab-float-out"
+        title="Open in floating window"
+      >
+        <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  ) : null
+
   if (realMessageCount === 0) {
     return (
-      <div
-        className="flex flex-1 min-h-0 items-center justify-center px-6 py-6"
-        data-testid="olumi-tab-empty"
-      >
-        <div className="flex flex-col items-center gap-3 max-w-xs">
-          <p className={typo('panelBody', 'text-text-light text-center')}>
-            Describe your decision, the options you're weighing, and what a good outcome looks like.
+      <div className="flex flex-1 min-h-0 flex-col" data-testid="olumi-tab-empty">
+        {floatOutIcon}
+        <div className="flex flex-1 items-center justify-center px-6 py-6">
+          <p className={typo('panelBody', 'text-text-light text-center max-w-xs')}>
+            Start a conversation with Olumi using the input below.
           </p>
-          {onFloatOut ? (
-            <button
-              type="button"
-              onClick={onFloatOut}
-              className={typo(
-                'panelMeta',
-                'inline-flex items-center gap-1 text-text-light hover:text-text-body focus:outline-none focus-visible:ring-2 focus-visible:ring-info rounded px-1.5 py-0.5',
-              )}
-              aria-label="Open Olumi in floating panel"
-              data-testid="olumi-tab-float-out"
-            >
-              <ExternalLink className="w-3 h-3" aria-hidden="true" />
-              <span>Open floating</span>
-            </button>
-          ) : null}
         </div>
       </div>
     )
@@ -66,20 +70,7 @@ export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabB
 
   return (
     <div className="flex flex-1 min-h-0 flex-col" data-testid="olumi-tab-body">
-      {onFloatOut ? (
-        <div className="flex justify-end px-2 pt-1 pb-0.5">
-          <button
-            type="button"
-            onClick={onFloatOut}
-            className="inline-flex items-center justify-center w-6 h-6 rounded text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
-            aria-label="Open Olumi in floating panel"
-            data-testid="olumi-tab-float-out"
-            title="Open in floating window"
-          >
-            <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
-          </button>
-        </div>
-      ) : null}
+      {floatOutIcon}
       <div className="flex flex-1 min-h-0 flex-col">
         <ConversationPanel
           conversation={conversation}

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -125,7 +125,38 @@ interface OutputsDockState {
   activeTab: OutputsDockTab
 }
 
-const STORAGE_KEY = 'canvas.outputsDock.v1'
+export const OUTPUTS_DOCK_STORAGE_KEY = 'canvas.outputsDock.v1'
+const STORAGE_KEY = OUTPUTS_DOCK_STORAGE_KEY
+
+/**
+ * Render-time read of the persisted dock-tab from sessionStorage. Used by
+ * FloatingOlumiPanel to align its render-time duplicate-surface yield gate
+ * with the SAME effective tab that OutputsDock paints on first render —
+ * before the E1 sync effect copies the persisted state into useUIStore.
+ *
+ * Without this, OutputsDock can restore `state.activeTab='olumi'` from
+ * sessionStorage while `useUIStore.activeOutputTab` is still the default
+ * 'results', and both surfaces would paint for one frame before the post-
+ * paint effect reconciles them.
+ *
+ * Returns `null` when sessionStorage is unavailable or the persisted
+ * payload is missing/invalid (consumer falls back to useUIStore).
+ */
+export function readPersistedActiveDockTab(): OutputsDockTab | null {
+  if (typeof sessionStorage === 'undefined') return null
+  try {
+    const raw = sessionStorage.getItem(OUTPUTS_DOCK_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<OutputsDockState>
+    const tab = parsed?.activeTab
+    if (tab === 'results' || tab === 'compare' || tab === 'diagnostics' || tab === 'journey' || tab === 'olumi') {
+      return tab
+    }
+    return null
+  } catch {
+    return null
+  }
+}
 
 /**
  * Pure helper for the toggle-open click handler.
@@ -144,36 +175,14 @@ export function deriveNextDockIsOpen(isFirstUse: boolean, storedIsOpen: boolean)
   return !wasVisuallyOpen
 }
 
-/**
- * Pure helper: derive the visible (effective) tab the dock should show.
- *
- * The persisted `state.activeTab` is the source of truth for what the
- * user chose, but it cannot be displayed directly under one condition:
- * `aiPanelV2On && state.activeTab === 'olumi' && floatingPanelIsOpen`.
- * In that case the floating panel is the single readable conversation
- * surface, and the docked tab must show whatever non-Olumi tab the
- * user was last on (Compare / Model / Analysis), to avoid wasting the
- * right panel and to avoid the duplicate-readable-surface invariant
- * breaking.
- *
- * Render-time helper (no React state), so the very first paint already
- * shows the fallback. An accompanying effect commits the fallback back
- * to persisted state + the global useUIStore so external consumers
- * (history, telemetry) stay aligned.
- *
- * Tested in isolation via aiPanelV2.interactions.spec.tsx.
- */
-export function selectEffectiveActiveTab(
-  storedActiveTab: OutputsDockTab,
-  aiPanelV2On: boolean,
-  floatingPanelIsOpen: boolean,
-  lastNonOlumiTab: OutputsDockTab,
-): OutputsDockTab {
-  if (!aiPanelV2On) return storedActiveTab
-  if (storedActiveTab !== 'olumi') return storedActiveTab
-  if (!floatingPanelIsOpen) return storedActiveTab
-  return lastNonOlumiTab
-}
+// Round-2 had `selectEffectiveActiveTab` — a render-time redirect from
+// 'olumi' to a fallback when the floating panel was open. Round-3 made
+// the click handler close the floating panel on Olumi-tab click, and
+// round-5 added a guard effect for non-click paths, so the helper became
+// dead identity. Removed in round-5 to avoid future reviewers assuming it
+// still enforces the duplicate-surface invariant — the invariant is now
+// enforced by `handleTabClick` + the close-floating-on-olumi-active
+// effect (see OutputsDockBody below).
 
 /** Dynamic accessor: re-evaluates feature flags on every call. Exported so
  *  parity tests can verify tab gating without remounting OutputsDock. The
@@ -411,47 +420,33 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // realMessageCount kept for downstream consumers (Olumi tab empty-state
   // logic); intentionally does NOT participate in isFirstUse.
   void realMessageCount
-  // Floating panel state — needed for tab gating + footer-stack mode.
-  const floatingPanelIsOpen = useFloatingPanelState((s) => s.isOpen)
 
-  // UX correction (P0): when floating Olumi is open AND the dock would
-  // otherwise activate the Olumi tab, redirect away so the docked
-  // surface never duplicates the floating conversation. Two-part guard:
-  //
-  // 1) `effectiveActiveTab` is computed AT RENDER TIME (see below),
-  //    so the docked Olumi body never paints — not even a one-frame
-  //    flash on initial mount when persisted state already had
-  //    activeTab='olumi'.
-  // 2) An effect commits the redirect back into the persisted dock
-  //    state + global useUIStore so subsequent renders + external
-  //    consumers (history, programmatic navigation) are consistent.
-  //
-  // Fallback policy: prefer the LAST non-Olumi tab the user was on
-  // (Compare / Model / Diagnostics) rather than blindly forcing
-  // 'results'. The ref is updated whenever a non-Olumi tab activates.
-  const lastNonOlumiTabRef = useRef<OutputsDockTab>(state.activeTab !== 'olumi' ? state.activeTab : 'results')
+  // Round 3 UX correction: clicking the Olumi tab CLOSES the floating panel
+  // and shows the docked Olumi conversation (see handleTabClick). For the
+  // non-click paths (programmatic setActiveOutputTab, persisted state on
+  // page load) we add a guard effect below so the duplicate-readable-
+  // surface invariant ("never both at once") still holds.
+  const effectiveActiveTab = state.activeTab
+
+  // Track the last non-Olumi tab the user was on so the docked-Olumi
+  // float-out path can return them to that context (Analysis / Compare /
+  // Model / Journey) rather than always defaulting to Analysis.
+  const lastNonOlumiTabRef = useRef<OutputsDockTab>(
+    state.activeTab !== 'olumi' ? state.activeTab : 'results',
+  )
   useEffect(() => {
     if (state.activeTab !== 'olumi') lastNonOlumiTabRef.current = state.activeTab
   }, [state.activeTab])
-  const effectiveActiveTab = selectEffectiveActiveTab(
-    state.activeTab,
-    aiPanelV2On,
-    floatingPanelIsOpen,
-    lastNonOlumiTabRef.current,
-  )
-  const olumiRedirectActive = effectiveActiveTab !== state.activeTab
+  // Close the floating panel whenever the docked Olumi tab becomes active
+  // (covers programmatic + restored-state paths that bypass handleTabClick).
+  // The singleton ConversationContext preserves draft + message state, so
+  // closing here is purely a surface switch with no data loss.
   useEffect(() => {
-    if (!olumiRedirectActive) return
-    const fallback = lastNonOlumiTabRef.current
-    setState((prev) => (prev.activeTab === 'olumi' ? { ...prev, activeTab: fallback } : prev))
-    // Keep the global store in sync — without this, useUIStore reports
-    // 'olumi' as the active tab even though the dock visually shows the
-    // fallback. Downstream consumers (history, deep links, telemetry)
-    // would otherwise diverge from what the user sees.
-    if (useUIStore.getState().activeOutputTab === 'olumi') {
-      useUIStore.getState().setActiveOutputTab(fallback as OutputTab)
+    if (state.activeTab !== 'olumi') return
+    if (useFloatingPanelState.getState().isOpen) {
+      useFloatingPanelState.getState().close()
     }
-  }, [olumiRedirectActive, setState])
+  }, [state.activeTab])
   const openFloatingByUser = useFloatingPanelState((s) => s.open)
   const transitionReceipt = useTransitionReceipt((s) => s.receipt)
   // Cog popover anchor — strip footer-stack only.
@@ -1265,15 +1260,13 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   }
 
   const handleTabClick = (tab: OutputsDockTab) => {
-    // UX correction (P0.1): when the floating Olumi panel is open, clicking
-    // the Olumi tab focuses the floating panel instead of switching the
-    // right panel to a blank placeholder. The user's current Analysis /
-    // Compare / Model tab stays visible. Dock-back is exclusively via the
-    // floating header's PanelRight button. Replaces the brief PR #149
-    // "placeholder" branch that wasted the right panel.
+    // UX correction (round 3): clicking the Olumi tab ALWAYS docks the
+    // conversation into the right panel. If the floating panel is open,
+    // close it first so the conversation surface is unambiguous. The
+    // singleton ConversationContext preserves the draft text and message
+    // state across the floating-to-docked transition (no data loss).
     if (tab === 'olumi' && useFloatingPanelState.getState().isOpen) {
-      focusFloating()
-      return
+      useFloatingPanelState.getState().close()
     }
     setState(prev => ({ ...prev, isOpen: true, activeTab: tab }))
     // E1: Sync tab state to Zustand store for cross-component navigation
@@ -1415,20 +1408,16 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             </span>
             <nav className="flex flex-1 min-w-0 gap-1" aria-label="Outputs sections">
               {OUTPUT_TABS.map(tab => {
-                // When floating Olumi is open, the Olumi tab is the
-                // interactive control that focuses the floating panel.
-                // Make that intent visible to AT users on the BUTTON
-                // (not just the dot indicator) so screen readers reading
-                // the tab announce the state.
-                const olumiOpenLabel = tab.id === 'olumi' && floatingPanelIsOpen
+                // Round-3 UX correction: clicking Olumi always docks (closes
+                // floating), so the tab no longer needs the "Olumi is open"
+                // signage that round 2 added. Text-only label keeps Olumi
+                // visually consistent with Analysis / Compare / Model.
                 return (
                 <button
                   key={tab.id}
                   type="button"
                   onClick={() => handleTabClick(tab.id)}
                   data-testid={tab.id === 'diagnostics' ? 'outputs-dock-tab-diagnostics' : tab.id === 'olumi' ? 'outputs-dock-tab-olumi' : undefined}
-                  aria-label={olumiOpenLabel ? 'Olumi is open. Focus floating panel' : undefined}
-                  title={olumiOpenLabel ? 'Olumi is open. Focus floating panel' : undefined}
                   className={`flex-1 px-2 py-1 rounded ${typography.caption} font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1 ${
                     effectiveActiveTab === tab.id
                       ? 'text-info border-b-2 border-info'
@@ -1441,18 +1430,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   }
                 >
                   <span className={`inline-flex items-center gap-1${tab.id === 'results' && showResultsTabStaleWarning ? ' text-warning' : ''}`}>
-                    {tab.id === 'olumi' && <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />}
                     {tab.label}
-                    {tab.id === 'olumi' && floatingPanelIsOpen && (
-                      // Subtle visual indicator — small filled dot in the
-                      // tab label. aria-label lives on the BUTTON above so
-                      // screen readers announce the open state.
-                      <span
-                        className="inline-flex w-1.5 h-1.5 rounded-full bg-info"
-                        data-testid="olumi-tab-floating-badge"
-                        aria-hidden="true"
-                      />
-                    )}
                     {tab.id === 'results' && showResultsTabStaleWarning && (
                       <AlertTriangle
                         className="w-3 h-3 text-warning"
@@ -1527,8 +1505,8 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     : 'text-text-header/70 bg-panel border-panel-border hover:bg-panel hover:text-text-header'
                 }`}
                 style={effectiveActiveTab === tab.id ? { backgroundColor: 'rgba(82,163,200,0.15)' } : undefined}
-                aria-label={tab.id === 'olumi' && floatingPanelIsOpen ? 'Olumi is open. Focus floating panel' : tab.label}
-                title={tab.id === 'olumi' && floatingPanelIsOpen ? 'Olumi is open. Focus floating panel' : tab.label}
+                aria-label={tab.label}
+                title={tab.label}
               >
                 <Icon className="w-3.5 h-3.5" aria-hidden="true" />
               </button>
@@ -2057,7 +2035,22 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 data-testid="olumi-tab-wrapper"
                 aria-hidden={effectiveActiveTab !== 'olumi'}
               >
-                <OlumiTabBody onFloatOut={() => openFloatingByUser('user')} />
+                <OlumiTabBody onFloatOut={() => {
+                  // The user wants to leave the docked surface for the
+                  // floating window. We must switch the active tab away
+                  // from 'olumi' first — otherwise FloatingOlumiPanel's
+                  // yieldToDockedOlumi render-time guard + OutputsDockBody's
+                  // close-floating guard effect would together suppress
+                  // the panel the moment it opened.
+                  //
+                  // Prefer the user's last non-Olumi tab so they return to
+                  // their previous Analysis/Compare/Model/Journey context
+                  // rather than always landing on Analysis.
+                  const fallback = lastNonOlumiTabRef.current
+                  setState((prev) => ({ ...prev, activeTab: fallback }))
+                  useUIStore.getState().setActiveOutputTab(fallback as OutputTab)
+                  openFloatingByUser('user')
+                }} />
               </div>
             )}
           </div>

--- a/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
+++ b/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
@@ -1,17 +1,18 @@
 /**
- * FirstUseComposer — auto-dock receipt + reduced-motion verification.
+ * FirstUseComposer — auto-reposition receipt + reduced-motion verification.
  *
- * Closes verification gaps #1 and #3 from the integration sign-off:
+ * Round-3 UX correction: the post-graph behaviour is now REPOSITION (not
+ * close). The floating panel stays open, slides to a bottom-right anchor
+ * near the Analysis dock, and the Analysis tab activates so the user can
+ * see AI and analysis side by side.
  *
- *   1. The auto-dock effect itself MUST trigger the "Model drafted. Review
- *      readiness." receipt via useTransitionReceipt.show. The browser
- *      walkthrough re-triggered the receipt manually after expiry — this
- *      test proves the actual auto-dock transition fires it.
+ *   1. The auto-reposition effect MUST trigger the "Model drafted. Review
+ *      readiness." receipt via useTransitionReceipt.show.
  *
- *   3. When prefers-reduced-motion is set, auto-dock fires synchronously
- *      (no 300 ms setTimeout). This test asserts the receipt + dock-close
- *      both happen WITHIN the same render tick, without advancing fake
- *      timers.
+ *   3. When prefers-reduced-motion is set, auto-reposition fires
+ *      synchronously (no 300 ms setTimeout). This test asserts the
+ *      receipt + reposition both happen WITHIN the same render tick,
+ *      without advancing fake timers.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
@@ -36,13 +37,20 @@ const canvasMockState: {
   _internal: { graphHash?: string }
   selection: null
 } = { nodes: [], edges: [], results: { status: 'idle' }, _internal: {}, selection: null }
-vi.mock('../../store', () => ({
-  useCanvasStore: (selector: (s: any) => any) => selector(canvasMockState),
-  selectResultsStatus: (s: any) => s.results?.status,
-  selectReport: (s: any) => s.results?.report,
-  selectError: (s: any) => s.results?.error,
-  selectResultsSource: (s: any) => s.results?.source,
-}))
+vi.mock('../../store', () => {
+  // The mock acts both as a selector hook AND exposes getState() so the
+  // FirstUseComposer's reset-debounce effect (which reads live state via
+  // useCanvasStore.getState()) can observe the current node count.
+  const useCanvasStore: any = (selector: (s: any) => any) => selector(canvasMockState)
+  useCanvasStore.getState = () => canvasMockState
+  return {
+    useCanvasStore,
+    selectResultsStatus: (s: any) => s.results?.status,
+    selectReport: (s: any) => s.results?.report,
+    selectError: (s: any) => s.results?.error,
+    selectResultsSource: (s: any) => s.results?.source,
+  }
+})
 vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
   useStageAwarePlaceholder: () => 'Describe your decision…',
 }))
@@ -145,12 +153,12 @@ function driveUserSubmittedViaFirstUse(): { rerender: (ui: React.ReactElement) =
   return { rerender }
 }
 
-describe('FirstUseComposer — auto-dock fires the transition receipt (gap #1)', () => {
+describe('FirstUseComposer — auto-reposition fires the transition receipt (gap #1)', () => {
   it('shows the receipt after the 300 ms slide delay when reduced motion is off', () => {
     vi.useFakeTimers()
     const { rerender } = driveUserSubmittedViaFirstUse()
 
-    // 0 → 2 nodes: triggers the auto-dock effect.
+    // 0 → 2 nodes: triggers the auto-reposition effect.
     act(() => {
       canvasMockState.nodes = [{ id: 'n1' }, { id: 'n2' }]
     })
@@ -160,20 +168,52 @@ describe('FirstUseComposer — auto-dock fires the transition receipt (gap #1)',
     expect(useTransitionReceipt.getState().receipt).toBeNull()
     expect(useFloatingPanelState.getState().isOpen).toBe(true)
     expect(useUIStore.getState().activeOutputTabVersion).toBe(0)
+    // Position not yet repositioned either.
+    expect(useFloatingPanelState.getState().position).toBeNull()
 
-    // Advance past the slide delay.
+    // Advance past the slide delay (300ms for performReposition to run) +
+    // rAF deferral (jsdom's rAF is implemented as a ~16ms timer) so the
+    // position write committed inside requestAnimationFrame is observable.
     act(() => {
       vi.advanceTimersByTime(300)
     })
-
-    // performDock has now committed all three side effects together:
+    // performReposition has run: receipt is committed, isAutoRepositioning
+    // is true, but position is still pending the rAF.
     expect(useTransitionReceipt.getState().receipt).toBe('model-drafted')
-    expect(useFloatingPanelState.getState().isOpen).toBe(false)
+    expect(useFloatingPanelState.getState().isAutoRepositioning).toBe(true)
+    // Flush the rAF + the 450ms clear timeout that owner-clears the flag.
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // All four side effects now committed:
+    //   - receipt fired
+    //   - Analysis tab activated (forceActivateOutputTab → version++)
+    //   - floating panel stays OPEN, position set to a bottom-right anchor
+    //   - isAutoRepositioning has been owner-cleared after the slide window
+    expect(useTransitionReceipt.getState().receipt).toBe('model-drafted')
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
     expect(useUIStore.getState().activeOutputTab).toBe('results')
     expect(useUIStore.getState().activeOutputTabVersion).toBe(1)
+    expect(useFloatingPanelState.getState().isAutoRepositioning).toBe(false)
+    // Position is now set (was null before) and exactly equals the
+    // dock-aware bottom-right anchor. This proves the rAF-deferred write
+    // inside performAutoReposition actually ran — not just that some
+    // value landed.
+    // jsdom default viewport: 1024×768. Default panel size: 400×550.
+    // dockInset = 0 (no aria-label="Outputs dock" in this test render).
+    //   anchorRaw.x = 1024 - 0 - 400 - 16 = 608
+    //   anchorRaw.y = 768 - 550 - 16 = 202
+    // clampPositionToViewport leaves both unchanged (both within margins).
+    const pos = useFloatingPanelState.getState().position
+    expect(pos).toEqual({ x: 608, y: 202 })
+    // userRepositioned must NOT flip — automatic reposition uses direct
+    // setState, not the setPosition setter, so canAutoDock on subsequent
+    // transitions still respects the system-vs-user origin.
+    expect(useFloatingPanelState.getState().userRepositioned).toBe(false)
   })
 
-  it('does NOT trigger the receipt when userRepositioned blocks auto-dock', () => {
+  it('does NOT trigger the receipt when userRepositioned blocks auto-reposition', () => {
     vi.useFakeTimers()
     const { rerender } = driveUserSubmittedViaFirstUse()
 
@@ -201,7 +241,7 @@ describe('FirstUseComposer — auto-dock fires the transition receipt (gap #1)',
 })
 
 describe('FirstUseComposer — reduced motion (gap #3)', () => {
-  it('auto-docks synchronously without the 300 ms slide delay when prefers-reduced-motion is set', () => {
+  it('auto-repositions synchronously without the 300 ms slide delay when prefers-reduced-motion is set', () => {
     reducedMotionState.value = true
     // Critical: use REAL timers. The reduced-motion branch should not call
     // setTimeout at all — if it does, the test would still pass under fake
@@ -217,11 +257,14 @@ describe('FirstUseComposer — reduced motion (gap #3)', () => {
     })
     rerender(<FirstUseComposer onCogClick={() => {}} />)
 
-    // No setTimeout means all three side effects commit synchronously.
+    // No setTimeout means all side effects commit synchronously: receipt
+    // shows, Analysis tab activated, floating panel stays open and is
+    // repositioned to bottom-right.
     expect(useTransitionReceipt.getState().receipt).toBe('model-drafted')
-    expect(useFloatingPanelState.getState().isOpen).toBe(false)
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
     expect(useUIStore.getState().activeOutputTab).toBe('results')
     expect(useUIStore.getState().activeOutputTabVersion).toBe(1)
+    expect(useFloatingPanelState.getState().position).not.toBeNull()
   })
 })
 
@@ -242,8 +285,8 @@ describe('FirstUseComposer — responsive width (P1.2)', () => {
   })
 })
 
-describe('FirstUseComposer — focused start card (UX correction P0.4)', () => {
-  it('uses the concise guidance copy and content-fit height', () => {
+describe('FirstUseComposer — welcome hero (round-3 UX correction)', () => {
+  it('uses the concise guidance copy and hero min-height', () => {
     render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
     const dialog = screen.getByTestId('first-use-composer') as HTMLElement
 
@@ -256,21 +299,59 @@ describe('FirstUseComposer — focused start card (UX correction P0.4)', () => {
       screen.queryByText(/Describe your decision, the options you're weighing/i),
     ).toBeNull()
 
-    // Content-fit: the dialog has `min-height` (not a fixed `height`).
-    // jsdom can't evaluate the layout but the inline style proves the
-    // chosen sizing strategy.
+    // Hero min-height: 460px floor so the welcome surface reads as a
+    // prominent invitation rather than a small utility panel. The cap is
+    // 70vh (max-height) so it never dominates tall screens.
     const style = dialog.getAttribute('style') ?? ''
-    expect(style).toMatch(/min-height:\s*108px/i)
+    expect(style).toMatch(/min-height:\s*460px/i)
+    expect(style).toMatch(/max-height:\s*70vh/i)
     expect(style).not.toMatch(/(^|[^-])height:\s*\d+px/i)
+  })
+
+  it('renders the welcome heading "What are you deciding?"', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const heading = screen.getByTestId('first-use-heading')
+    expect(heading).toBeInTheDocument()
+    expect(heading.textContent).toBe('What are you deciding?')
+    expect(heading.tagName).toBe('H2')
+  })
+
+  it('renders the six ambient drift shapes behind the hero content', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const shapeContainer = screen.getByTestId('first-use-ambient-shapes')
+    expect(shapeContainer).toBeInTheDocument()
+    expect(shapeContainer.getAttribute('aria-hidden')).toBe('true')
+    // Six shapes — goal, decision, option, factor, risk, outcome.
+    const kinds = Array.from(shapeContainer.querySelectorAll('[data-shape]'))
+      .map((el) => el.getAttribute('data-shape'))
+    expect(kinds.sort()).toEqual(
+      ['decision', 'factor', 'goal', 'option', 'outcome', 'risk'],
+    )
+  })
+
+  it('renders the Olumi logo as decorative imagery above the heading', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const dialog = screen.getByTestId('first-use-composer')
+    const img = dialog.querySelector('img[src*="olumi-logo"]') as HTMLImageElement | null
+    expect(img).not.toBeNull()
+    // Logo is decorative — heading carries the semantic label.
+    expect(img?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('uses the welcome variant of AIInputBar (three visible lines at rest)', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const textarea = screen.getByTestId('first-use-input-bar-textarea') as HTMLTextAreaElement
+    // Welcome variant sets minHeight: 18 * 3 + 16 = 70px.
+    expect(textarea.style.minHeight).toBe('70px')
   })
 
   it('does NOT render prompt-suggestion chips (explicitly excluded)', () => {
     render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
     expect(screen.queryByTestId('suggested-chips')).toBeNull()
-    // Defensive: no buttons claiming to seed a prompt suggestion.
+    // Defensive: no buttons claiming to seed a prompt suggestion. The hero
+    // has only the AIInputBar's cog + send buttons.
     const dialog = screen.getByTestId('first-use-composer')
     const buttons = dialog.querySelectorAll('button')
-    // Only the AIInputBar's cog + send buttons may be present.
     const labels = Array.from(buttons).map((b) => b.getAttribute('aria-label') ?? '')
     expect(labels.every((l) => /^(Settings|Send)$/.test(l))).toBe(true)
   })
@@ -382,7 +463,7 @@ describe('FirstUseComposer — auto-dock does NOT misfire on hydration/import (r
     expect(useUIStore.getState().activeOutputTabVersion).toBe(0)
   })
 
-  it('AUTO-DOCKS when the user submits BEFORE nodes appear (the legitimate first-use path)', () => {
+  it('AUTO-REPOSITIONS when the user submits BEFORE nodes appear (the legitimate first-use path)', () => {
     vi.useFakeTimers()
     const { rerender } = driveUserSubmittedViaFirstUse()
     // onAfterSend has flipped userSentFromFirstUseRef. Now graph builds.
@@ -390,14 +471,87 @@ describe('FirstUseComposer — auto-dock does NOT misfire on hydration/import (r
       canvasMockState.nodes = [{ id: 'n1' }, { id: 'n2' }]
     })
     rerender(<FirstUseComposer onCogClick={() => {}} />)
+    // 300ms slide trigger + 16ms rAF + 450ms owner-clear → 800ms total to
+    // observe the full reposition completion.
     act(() => {
-      vi.advanceTimersByTime(300)
+      vi.advanceTimersByTime(800)
     })
 
-    // Auto-dock fires — proves the explicit-signal guard does not break the
-    // legitimate first-use path.
+    // Auto-reposition fires — proves the explicit-signal guard does not
+    // break the legitimate first-use path. Floating stays OPEN (round-3
+    // change from auto-close to auto-reposition).
     expect(useTransitionReceipt.getState().receipt).toBe('model-drafted')
-    expect(useFloatingPanelState.getState().isOpen).toBe(false)
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
+    expect(useFloatingPanelState.getState().position).not.toBeNull()
     expect(useUIStore.getState().activeOutputTabVersion).toBe(1)
+  })
+})
+
+describe('FirstUseComposer — canvas reset debounce (round-3 robustness)', () => {
+  // Round-3 raised concern: the reset effect was firing on any N→0
+  // transition, including transient hydration/import clears where the
+  // canvas store briefly reports zero nodes before the new graph
+  // populates. The debounce waits 500ms and re-reads live state — if a
+  // new graph has already loaded, the reset is treated as transient and
+  // skipped.
+  //
+  // Tests start with a NON-empty canvas so the one-shot initial auto-open
+  // guard (`hasAutoOpenedRef`) doesn't fire on mount and conflate the
+  // reset re-engage with the initial open. The floating panel's source is
+  // pre-flipped to 'user' so we can observe whether the reset effect
+  // flips it back to 'system-first-use'.
+
+  it('does NOT re-engage the hero when nodes re-populate within the debounce window (transient hydration)', () => {
+    vi.useFakeTimers()
+    // Initial state: canvas has nodes (skips initial auto-open). Floating
+    // panel was previously opened by the user (so source='user').
+    canvasMockState.nodes = [{ id: 'n1' }, { id: 'n2' }]
+    useFloatingPanelState.getState().open('user')
+    const { rerender } = render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(useFloatingPanelState.getState().source).toBe('user')
+
+    // Transient: nodes briefly clear (scenario switch / import).
+    act(() => {
+      canvasMockState.nodes = []
+    })
+    rerender(<FirstUseComposer onCogClick={() => {}} />)
+    // ...then repopulate before the 500ms debounce expires.
+    act(() => {
+      vi.advanceTimersByTime(200)
+      canvasMockState.nodes = [{ id: 'n3' }]
+    })
+    rerender(<FirstUseComposer onCogClick={() => {}} />)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // The debounce checks live state — nodeCount === 1 so re-engage is
+    // skipped. Source stays 'user' (not flipped back to 'system-first-use'
+    // by the reset effect).
+    expect(useFloatingPanelState.getState().source).toBe('user')
+  })
+
+  it('DOES re-engage the hero when nodes stay at 0 past the debounce window (intentional reset)', () => {
+    vi.useFakeTimers()
+    // Initial state: canvas has nodes, floating was opened by user.
+    canvasMockState.nodes = [{ id: 'n1' }]
+    useFloatingPanelState.getState().open('user')
+    const { rerender } = render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(useFloatingPanelState.getState().source).toBe('user')
+
+    // Intentional canvas reset: nodes clear and stay cleared.
+    act(() => {
+      canvasMockState.nodes = []
+    })
+    rerender(<FirstUseComposer onCogClick={() => {}} />)
+    // Past the debounce window with zero nodes still live.
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+
+    // The debounce confirmed empty state — re-engage fired and flipped
+    // source back to 'system-first-use' so the hero re-appears.
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
+    expect(useFloatingPanelState.getState().source).toBe('system-first-use')
   })
 })

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.density.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.density.spec.tsx
@@ -156,12 +156,16 @@ describe('floating-density scope', () => {
     }
   })
 
-  it('docked OlumiTabBody does NOT pass compact=true to ConversationPanel', () => {
-    // Density differential at the React-prop level: docked tab keeps
-    // normal density (compact=false), floating uses compact=true.
+  it('docked OlumiTabBody passes compact=true to ConversationPanel (round-7: matches floating typography)', () => {
+    // Round-7 typography unification (brief item 9): docked and floating
+    // Olumi conversation surfaces must share the same panelBody typography
+    // (12px) so the docked text doesn't read as larger than the floating
+    // text. Both now pass `compact=true`. The CSS-level density (via the
+    // `.floating-density` wrapper class) remains floating-only because
+    // the wrapper governs message-bubble spacing/padding, not font-size.
     render(<OlumiTabBody onFloatOut={() => {}} />, { wrapper: Wrapper })
     const cp = document.querySelector('[data-testid="mocked-conversation-panel"]') as HTMLElement
     expect(cp).toBeTruthy()
-    expect(cp.getAttribute('data-compact')).toBe('false')
+    expect(cp.getAttribute('data-compact')).toBe('true')
   })
 })

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.resize.spec.ts
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.resize.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * FloatingOlumiPanel — all-corner resize geometry.
+ *
+ * Pure-function tests for `computeCornerResize`. The round-3 UX pass added
+ * top-left / top-right / bottom-left handles alongside the existing
+ * bottom-right one. Each corner's geometry update must:
+ *  - hold the opposite corner fixed at its starting screen coordinate;
+ *  - respect MIN_WIDTH (320) and MIN_HEIGHT (300) floors;
+ *  - respect computeMaxSize (60% vw, 80% vh) and dock-aware margin caps;
+ *  - never produce a position that would leave the panel off-canvas.
+ *
+ * No DOM rendering needed — these are pure-function assertions composed of
+ * the same constants the runtime resize path uses.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+// FloatingOlumiPanel's transitive imports pull in supabase and the markdown
+// renderer — stub both ahead of the dynamic import below.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+import { computeCornerResize } from '../FloatingOlumiPanel'
+
+const VIEWPORT = { w: 1200, h: 800 }
+const MARGIN = 16
+const MIN_W = 320
+const MIN_H = 300
+
+// A typical mid-canvas starting rect, well away from edges and dock.
+const START = { left: 400, top: 200, w: 500, h: 400 }
+
+describe('computeCornerResize — bottom-right (BR)', () => {
+  it('grows width and height with positive deltas, holds top-left fixed', () => {
+    const next = computeCornerResize('br', START.left, START.top, START.w, START.h, 60, 50, VIEWPORT.w, VIEWPORT.h)
+    expect(next.x).toBe(START.left)
+    expect(next.y).toBe(START.top)
+    expect(next.w).toBe(START.w + 60)
+    expect(next.h).toBe(START.h + 50)
+  })
+
+  it('honours MIN_WIDTH / MIN_HEIGHT floors when delta would shrink past them', () => {
+    const next = computeCornerResize('br', START.left, START.top, START.w, START.h, -10000, -10000, VIEWPORT.w, VIEWPORT.h)
+    expect(next.w).toBe(MIN_W)
+    expect(next.h).toBe(MIN_H)
+    expect(next.x).toBe(START.left)
+    expect(next.y).toBe(START.top)
+  })
+
+  it('caps width at dock-aware available room when rightInset is provided', () => {
+    // Dock occupies 360px on the right. The panel's right edge must stay
+    // clear of the dock + margin. Max W from left=400: 1200 - 400 - 16 - 360 = 424.
+    const next = computeCornerResize('br', START.left, START.top, START.w, START.h, 10000, 0, VIEWPORT.w, VIEWPORT.h, 360)
+    expect(next.w).toBe(424)
+    expect(next.x).toBe(START.left)
+  })
+})
+
+describe('computeCornerResize — top-right (TR)', () => {
+  it('moves top edge downward and grows width with positive dy / positive dx', () => {
+    // dy = +50 should SHRINK height by 50 and move y by +50 (top edge drops).
+    const next = computeCornerResize('tr', START.left, START.top, START.w, START.h, 60, 50, VIEWPORT.w, VIEWPORT.h)
+    // Left unchanged
+    expect(next.x).toBe(START.left)
+    // Top drops by dy (height shrinks)
+    expect(next.y).toBe(START.top + 50)
+    // Width grows by dx
+    expect(next.w).toBe(START.w + 60)
+    // Height shrinks by dy
+    expect(next.h).toBe(START.h - 50)
+    // Bottom edge stays put: y + h === startTop + startH
+    expect(next.y + next.h).toBe(START.top + START.h)
+  })
+
+  it('honours MIN_HEIGHT — dy cannot shrink height below 300', () => {
+    const next = computeCornerResize('tr', START.left, START.top, START.w, START.h, 0, 10000, VIEWPORT.w, VIEWPORT.h)
+    expect(next.h).toBe(MIN_H)
+    // y moves up by exactly (startH - MIN_H) so the bottom edge stays fixed.
+    expect(next.y).toBe(START.top + START.h - MIN_H)
+  })
+})
+
+describe('computeCornerResize — bottom-left (BL)', () => {
+  it('moves left edge rightward and grows height with positive dx / positive dy', () => {
+    const next = computeCornerResize('bl', START.left, START.top, START.w, START.h, 60, 50, VIEWPORT.w, VIEWPORT.h)
+    // Top unchanged
+    expect(next.y).toBe(START.top)
+    // Left drops by dx (width shrinks)
+    expect(next.x).toBe(START.left + 60)
+    // Width shrinks by dx
+    expect(next.w).toBe(START.w - 60)
+    // Height grows by dy
+    expect(next.h).toBe(START.h + 50)
+    // Right edge stays put: x + w === startLeft + startW
+    expect(next.x + next.w).toBe(START.left + START.w)
+  })
+
+  it('honours MIN_WIDTH — dx cannot shrink width below 320', () => {
+    const next = computeCornerResize('bl', START.left, START.top, START.w, START.h, 10000, 0, VIEWPORT.w, VIEWPORT.h)
+    expect(next.w).toBe(MIN_W)
+    // x moves right by exactly (startW - MIN_W) so the right edge stays fixed.
+    expect(next.x).toBe(START.left + START.w - MIN_W)
+  })
+
+  it('honours computeMaxSize cap (60% vw) when dragging outward to the left', () => {
+    // Negative dx (drag left) wants to grow width to the viewport margin
+    // (884px). But computeMaxSize caps at 60% vw = 720px first. With the
+    // right edge fixed at startLeft + startW = 900, the new x lands at
+    // 900 - 720 = 180. Both edges remain inside the viewport (margin 16).
+    const next = computeCornerResize('bl', START.left, START.top, START.w, START.h, -10000, 0, VIEWPORT.w, VIEWPORT.h)
+    expect(next.w).toBe(Math.floor(VIEWPORT.w * 0.6))
+    expect(next.x).toBe(START.left + START.w - next.w)
+    // Right edge stays put.
+    expect(next.x + next.w).toBe(START.left + START.w)
+    // Left edge still clears the margin (no underflow).
+    expect(next.x).toBeGreaterThanOrEqual(MARGIN)
+  })
+})
+
+describe('computeCornerResize — top-left (TL)', () => {
+  it('moves both edges with negative-mirror deltas, holds bottom-right fixed', () => {
+    const next = computeCornerResize('tl', START.left, START.top, START.w, START.h, 60, 50, VIEWPORT.w, VIEWPORT.h)
+    // x drops (left edge moves right), width shrinks by dx.
+    expect(next.x).toBe(START.left + 60)
+    expect(next.w).toBe(START.w - 60)
+    // y drops (top edge moves down), height shrinks by dy.
+    expect(next.y).toBe(START.top + 50)
+    expect(next.h).toBe(START.h - 50)
+    // Bottom-right corner stays at (startLeft + startW, startTop + startH).
+    expect(next.x + next.w).toBe(START.left + START.w)
+    expect(next.y + next.h).toBe(START.top + START.h)
+  })
+
+  it('honours both MIN floors simultaneously', () => {
+    const next = computeCornerResize('tl', START.left, START.top, START.w, START.h, 10000, 10000, VIEWPORT.w, VIEWPORT.h)
+    expect(next.w).toBe(MIN_W)
+    expect(next.h).toBe(MIN_H)
+    expect(next.x).toBe(START.left + START.w - MIN_W)
+    expect(next.y).toBe(START.top + START.h - MIN_H)
+  })
+
+  it('respects computeMaxSize caps when dragging outward', () => {
+    // Large negative dx/dy: width and height want to grow. Caps:
+    //   - width:  min(computeMaxSize=720, marginCap=884) = 720
+    //   - height: min(computeMaxSize=640, marginCap=584) = 584
+    // x = (startLeft + startW) - w = 900 - 720 = 180.
+    // y = (startTop + startH) - h = 600 - 584 = 16 (= MARGIN floor).
+    const next = computeCornerResize('tl', START.left, START.top, START.w, START.h, -10000, -10000, VIEWPORT.w, VIEWPORT.h)
+    expect(next.w).toBe(Math.floor(VIEWPORT.w * 0.6))         // 720
+    expect(next.h).toBe(START.top + START.h - MARGIN)         // 584
+    expect(next.x).toBe(START.left + START.w - next.w)        // 180
+    expect(next.y).toBe(START.top + START.h - next.h)         // 16 (== MARGIN)
+    // Bottom-right still fixed.
+    expect(next.x + next.w).toBe(START.left + START.w)
+    expect(next.y + next.h).toBe(START.top + START.h)
+    // No edge underflows the margin.
+    expect(next.x).toBeGreaterThanOrEqual(MARGIN)
+    expect(next.y).toBeGreaterThanOrEqual(MARGIN)
+  })
+})
+
+describe('computeCornerResize — dock-aware caps', () => {
+  it('TR: width cap respects rightInset (dock space)', () => {
+    // Dock 360 wide → max width from left=400: 1200 - 400 - 16 - 360 = 424.
+    const next = computeCornerResize('tr', START.left, START.top, START.w, START.h, 10000, 0, VIEWPORT.w, VIEWPORT.h, 360)
+    expect(next.w).toBe(424)
+    expect(next.x).toBe(START.left)
+  })
+
+  it('BL: dock inset only matters for the right-anchored edge (left edge cap unchanged)', () => {
+    // Right edge fixed at 900; left can shrink to MARGIN (16). Dock doesn't
+    // affect the BL maxW formula because the panel's right edge is already
+    // fixed inside the dock-clear zone (at 900, dock starts at 1200-360=840;
+    // we'd need to verify the assertion separately on a wider start). For
+    // this case (panel right edge at 900, dock left at 840), the start
+    // position itself OVERLAPS the dock — not a normal user state. The
+    // helper does NOT relocate the panel; it only caps W on the left side.
+    const next = computeCornerResize('bl', START.left, START.top, START.w, START.h, -100, 0, VIEWPORT.w, VIEWPORT.h, 360)
+    // x = startLeft + dx = 300; w = startW - dx = 600 (since startW=500, dx=-100 → w=600)
+    // But w is capped at MIN floor, computeMaxSize cap, and right-fixed cap.
+    // Right-fixed cap = (startLeft + startW) - DEFAULT_MARGIN = 900 - 16 = 884.
+    // computeMaxSize.width = 1200 * 0.6 = 720.
+    // So w = min(720, 884, 600) = 600.
+    expect(next.w).toBe(600)
+    expect(next.x).toBe(START.left + (-100))
+    expect(next.x + next.w).toBe(START.left + START.w)
+  })
+})
+
+describe('computeCornerResize — sub-minimum invariant', () => {
+  it.each(['tl', 'tr', 'bl', 'br'] as const)('%s never returns a sub-MIN size', (corner) => {
+    // Push every direction past extreme. Always expect w >= MIN_W, h >= MIN_H.
+    const cases: Array<[number, number]> = [
+      [10000, 10000],
+      [-10000, -10000],
+      [10000, -10000],
+      [-10000, 10000],
+    ]
+    for (const [dx, dy] of cases) {
+      const next = computeCornerResize(corner, START.left, START.top, START.w, START.h, dx, dy, VIEWPORT.w, VIEWPORT.h)
+      expect(next.w).toBeGreaterThanOrEqual(MIN_W)
+      expect(next.h).toBeGreaterThanOrEqual(MIN_H)
+    }
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
@@ -85,6 +85,18 @@ vi.mock('../../conversation/useConversation', () => ({
 vi.mock('../../ui/inspector-v2/useStaleGuard', () => ({
   useStaleGuard: () => ({ analysisState: 'none', isStale: false }),
 }))
+// PreAnalysisPanel pulls in ToastProvider + readiness fetches that fail
+// outside the full app shell. Stub it to a placeholder so the dock can
+// expand for tests that require non-empty canvas state.
+vi.mock('../pre-analysis', () => ({
+  PreAnalysisPanel: () => null,
+}))
+// Readiness store fetches /bff/cee/graph-readiness which jsdom can't parse
+// as a relative URL. Stub the hook so the dock can render past readiness
+// gating in dock-expanded tests.
+vi.mock('../../hooks/useGraphReadiness', () => ({
+  useGraphReadiness: () => ({ readiness: { state: 'ready' } }),
+}))
 vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
   useStageAwarePlaceholder: () => 'Describe your decision…',
 }))
@@ -172,10 +184,9 @@ describe('Olumi tab click while floating is open', () => {
     } catch {}
   })
 
-  it('focuses the floating panel and does NOT switch the active tab', async () => {
+  it('closes the floating panel and activates the docked Olumi tab', async () => {
     const { fireEvent } = await import('@testing-library/react')
     const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
-    const { registerFloatingFocus, focusFloating } = await import('../../hooks/useFloatingFocus')
     const { useUIStore } = await import('../../../stores/uiStore')
     const { OutputsDock } = await import('../OutputsDock')
 
@@ -184,10 +195,7 @@ describe('Olumi tab click while floating is open', () => {
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
     useFloatingPanelState.getState().reset()
     useFloatingPanelState.getState().open('user')
-
-    // Register a focus channel so we can prove focusFloating fired.
-    const focusSpy = vi.fn()
-    const unregister = registerFloatingFocus(focusSpy)
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
 
     const { findByLabelText } = render(
       <Wrapper>
@@ -195,68 +203,29 @@ describe('Olumi tab click while floating is open', () => {
       </Wrapper>,
     )
 
-    // Find by aria-label — when floating is open the button's aria-label
-    // becomes "Olumi is open. Focus floating panel" (accessible state
-    // moved off the dot indicator onto the interactive control).
-    const olumiTab = (await findByLabelText('Olumi is open. Focus floating panel')) as HTMLElement
+    // Round-3 UX correction: tab labels are text-only, no "Olumi is open"
+    // accessible state. Find by the plain label.
+    const olumiTab = (await findByLabelText('Olumi')) as HTMLElement
     expect(olumiTab).toBeTruthy()
     fireEvent.click(olumiTab)
 
-    // Intercept fired: the focusFloating channel was invoked.
-    expect(focusSpy).toHaveBeenCalledTimes(1)
-    // And the global active tab was NOT switched to 'olumi'.
-    expect(useUIStore.getState().activeOutputTab).toBe('results')
-
-    // Sanity: calling focusFloating directly hits the spy too.
-    focusFloating()
-    expect(focusSpy).toHaveBeenCalledTimes(2)
-    unregister()
+    // The click closes the floating panel and activates the docked tab.
+    // The singleton ConversationContext preserves draft + messages across
+    // the surface switch (no data loss).
+    expect(useFloatingPanelState.getState().isOpen).toBe(false)
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
   })
 
-  it('initial paint: docked Olumi conversation body is NOT rendered when persisted activeTab=olumi + floating already open', async () => {
-    // Pre-paint regression. The previous implementation used a
-    // useEffect to redirect from 'olumi' to a fallback, which left a
-    // one-frame window where the docked conversation could paint. The
-    // fix derives `effectiveActiveTab` at render time so the very
-    // first paint already shows the fallback tab.
+  it('persisted activeTab=olumi + floating open → floating closes, docked surface activates (round-3 guard)', async () => {
+    // Round-3 UX correction: when the dock restores from persisted state
+    // with activeTab=olumi AND floating happens to be open, the duplicate-
+    // readable-surface invariant requires one of the two to give. The new
+    // policy: docked Olumi wins, floating closes (see the guard effect in
+    // OutputsDockBody). The singleton ConversationContext preserves draft
+    // + messages across the close, so nothing is lost.
     const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
     const { OutputsDock } = await import('../OutputsDock')
 
-    try {
-      sessionStorage.setItem(
-        'canvas.outputsDock.v1',
-        JSON.stringify({ isOpen: true, activeTab: 'olumi' }),
-      )
-    } catch {}
-    useFloatingPanelState.getState().reset()
-    useFloatingPanelState.getState().open('user')
-
-    const { container } = render(
-      <Wrapper>
-        <OutputsDock />
-      </Wrapper>,
-    )
-
-    // SYNCHRONOUS post-render assertions — no waitFor, no setTimeout.
-    // If a one-frame flash existed the wrapper's `hidden` class would
-    // not be set yet (the effect hasn't run).
-    const wrapper = container.querySelector('[data-testid="olumi-tab-wrapper"]')
-    if (wrapper) {
-      expect(wrapper.classList.contains('hidden')).toBe(true)
-      expect(wrapper.getAttribute('aria-hidden')).toBe('true')
-    }
-    // Defensive: no docked Olumi body / empty-state surface visible.
-    expect(container.querySelector('[data-testid="olumi-tab-body"]:not([aria-hidden="true"])')).toBeNull()
-  })
-
-  it('programmatic activeTab=olumi while floating open is auto-redirected to results (render-level intercept)', async () => {
-    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
-    const { useUIStore } = await import('../../../stores/uiStore')
-    const { OutputsDock } = await import('../OutputsDock')
-
-    // Pre-seed: dock state persisted with activeTab='olumi'. This is the
-    // path the click intercept does NOT cover — restoration from
-    // sessionStorage / external programmatic state.
     try {
       sessionStorage.setItem(
         'canvas.outputsDock.v1',
@@ -272,27 +241,41 @@ describe('Olumi tab click while floating is open', () => {
       </Wrapper>,
     )
 
-    // The render-level effect must redirect away from 'olumi' so the
-    // docked surface never renders the conversation while floating is open.
+    // Allow the guard effect to run.
     await new Promise((r) => setTimeout(r, 50))
-    // The dock's persisted activeTab should now be NOT 'olumi'. We can't
-    // peek into the local useState directly, but the global useUIStore
-    // sync (E1) reflects what the dock visibly shows; alternatively, the
-    // docked Olumi body wrapper would carry an unhidden state if 'olumi'
-    // were still active.
-    const olumiWrapper = document.querySelector('[data-testid="olumi-tab-wrapper"]') as HTMLElement | null
-    if (olumiWrapper) {
-      // Wrapper exists but must be hidden (active tab is no longer 'olumi').
-      expect(olumiWrapper.classList.contains('hidden')).toBe(true)
-    }
-    // Defensive: no docked-Olumi conversation surface should be visible.
-    const visibleConversation = document.querySelector(
-      '[data-testid="olumi-tab-body"]:not([aria-hidden="true"])',
-    )
-    expect(visibleConversation).toBeNull()
+    expect(useFloatingPanelState.getState().isOpen).toBe(false)
   })
 
-  it('Olumi tab button carries an accessible "Focus floating panel" label when floating is open', async () => {
+  it('programmatic activeTab=olumi while floating open → guard effect closes floating', async () => {
+    // Round-3 UX correction: the guard effect at OutputsDockBody fires
+    // whenever activeTab becomes 'olumi' and the floating panel is open,
+    // closing the latter so the duplicate-readable-surface invariant holds.
+    // (The empty-canvas case here renders the dock in rail mode, so we
+    // only assert the store state, not the docked body's visibility.)
+    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
+    const { OutputsDock } = await import('../OutputsDock')
+
+    try {
+      sessionStorage.setItem(
+        'canvas.outputsDock.v1',
+        JSON.stringify({ isOpen: true, activeTab: 'olumi' }),
+      )
+    } catch {}
+    useFloatingPanelState.getState().reset()
+    useFloatingPanelState.getState().open('user')
+
+    render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    await new Promise((r) => setTimeout(r, 50))
+    // Floating panel is now closed. The guard ran on first render.
+    expect(useFloatingPanelState.getState().isOpen).toBe(false)
+  })
+
+  it('Olumi tab button carries the plain "Olumi" label (text-only, round-3 UX)', async () => {
     const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
     const { OutputsDock } = await import('../OutputsDock')
     useFloatingPanelState.getState().reset()
@@ -302,24 +285,18 @@ describe('Olumi tab click while floating is open', () => {
         <OutputsDock />
       </Wrapper>,
     )
-    // The BUTTON itself (interactive element) carries the accessible
-    // state, not just a non-interactive dot indicator. AT users hear
-    // the state when they reach the button.
-    const olumiBtn = (await findByLabelText('Olumi is open. Focus floating panel')) as HTMLElement
+    // Round 3 removed the "Olumi is open" signage from the tab. The label
+    // is now consistently "Olumi" regardless of floating-panel state.
+    const olumiBtn = (await findByLabelText('Olumi')) as HTMLElement
     expect(olumiBtn.tagName).toBe('BUTTON')
-    expect(olumiBtn.getAttribute('title')).toBe('Olumi is open. Focus floating panel')
+    expect(olumiBtn.getAttribute('title')).toBe('Olumi')
   })
 
-  it('redirect preserves the LAST non-Olumi tab + syncs useUIStore', async () => {
-    // Reviewer P0.2: the fallback should preserve the user's last
-    // non-Olumi tab (Compare/Model/Diagnostics) rather than blindly
-    // jumping to Analysis. And useUIStore must reflect the final state
-    // so downstream consumers (history, telemetry) don't diverge.
-    //
-    // Test flow: user is on Diagnostics (Model tab — that's enabled in
-    // the test mock; Compare is gated off). Floating opens. Something
-    // programmatically calls setActiveOutputTab('olumi'). The redirect
-    // should bring them back to Diagnostics, not to Analysis.
+  it('programmatic activeTab=olumi keeps Olumi as the active dock tab (round-3 no-redirect)', async () => {
+    // Round 3 removed the round-2 redirect-away-from-Olumi-when-floating-open
+    // policy. With the click intercept now CLOSING the floating panel
+    // instead of focusing it, the state `activeTab === 'olumi'` is the
+    // canonical docked state and must NOT be redirected away from.
     const { fireEvent } = await import('@testing-library/react')
     const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
     const { useUIStore } = await import('../../../stores/uiStore')
@@ -334,15 +311,8 @@ describe('Olumi tab click while floating is open', () => {
       </Wrapper>,
     )
 
-    // Activate Model (which maps to the 'diagnostics' tab id under FF-on
-    // — the dock's labels say "Model" but internally it's 'diagnostics').
-    // Floating is closed here so the click intercept doesn't trigger.
-    const modelBtn = (await screen.findByLabelText('Model')) as HTMLElement
-    fireEvent.click(modelBtn)
-    await new Promise((r) => setTimeout(r, 50))
-    expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
-
-    // Now open floating, then programmatically request 'olumi'.
+    // Open floating, then programmatically request 'olumi' (e.g. from a
+    // restored session or a deep link).
     act(() => {
       useFloatingPanelState.getState().open('user')
     })
@@ -351,11 +321,162 @@ describe('Olumi tab click while floating is open', () => {
     })
     await new Promise((r) => setTimeout(r, 50))
 
-    // useUIStore must reflect the redirected tab, not 'olumi'.
+    // The dock honours the programmatic request — 'olumi' stays active.
+    // (The click intercept that closes floating only fires on user clicks;
+    // programmatic state restoration does not need to close floating, and
+    // the duplicate-readable-surface invariant is enforced by users only
+    // ever clicking the Olumi tab.)
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
+    void fireEvent
+  })
+
+  it('docked-tab float-out switches active tab AND opens floating (round-3 regression guard)', async () => {
+    // Round-3 follow-up: the `yieldToDockedOlumi` render-time guard and the
+    // close-floating-when-olumi guard effect together would suppress the
+    // floating panel if `onFloatOut` only called `open('user')`. The fix
+    // is for `onFloatOut` to ALSO switch the active tab away from 'olumi'
+    // so the docked surface yields and the floating panel becomes the
+    // sole readable conversation surface.
+    const { fireEvent } = await import('@testing-library/react')
+    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
+    const { useUIStore } = await import('../../../stores/uiStore')
+    const { useCanvasStore } = await import('../../store')
+    const { OutputsDock } = await import('../OutputsDock')
+
+    // Pre-state: user has a graph (so dock is expanded, not rail-mode) AND
+    // is on the Olumi tab, no floating open.
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+    } as any)
+    useUIStore.setState({ activeOutputTab: 'olumi', activeOutputTabVersion: 0 })
+    useFloatingPanelState.getState().reset()
+    try {
+      sessionStorage.setItem(
+        'canvas.outputsDock.v1',
+        JSON.stringify({ isOpen: true, activeTab: 'olumi' }),
+      )
+    } catch {}
+
+    const { findByTestId } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    // Click the float-out icon in the docked Olumi tab body.
+    const floatOutBtn = (await findByTestId('olumi-tab-float-out')) as HTMLElement
+    fireEvent.click(floatOutBtn)
+    await new Promise((r) => setTimeout(r, 50))
+
+    // After the click:
+    //   - Floating panel is OPEN (not suppressed by the yield/guard).
+    //   - Active tab is no longer 'olumi' (so the docked surface yields).
+    //   - Source is 'user' (so canAutoDock returns false).
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
     expect(useUIStore.getState().activeOutputTab).not.toBe('olumi')
-    // And the fallback must be 'diagnostics' (the user's last non-Olumi
-    // tab), NOT the default 'results'.
+    expect(useFloatingPanelState.getState().source).toBe('user')
+
+    // Cleanup: leave the canvas store empty for the next test.
+    useCanvasStore.setState({ nodes: [] } as any)
+  })
+
+  it('persisted activeTab=olumi + global=results + floating open → floating yields on first render (round-5 race guard)', async () => {
+    // Round-5 P0: OutputsDock restores `state.activeTab` from sessionStorage
+    // synchronously, while useUIStore.activeOutputTab is still the default
+    // 'results' until the post-paint E1 sync effect runs. Without the
+    // persisted-state read in FloatingOlumiPanel's yield gate, both
+    // surfaces would paint for one frame. The yield gate now reads the
+    // same sessionStorage source as OutputsDock and pre-empts the flash.
+    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
+    const { useUIStore } = await import('../../../stores/uiStore')
+    const { useCanvasStore } = await import('../../store')
+    const { FloatingOlumiPanel } = await import('../FloatingOlumiPanel')
+
+    // Pre-state: persisted dock state says 'olumi'; global store still
+    // 'results' (the disagreement is the bug condition).
+    try {
+      sessionStorage.setItem(
+        'canvas.outputsDock.v1',
+        JSON.stringify({ isOpen: true, activeTab: 'olumi' }),
+      )
+    } catch {}
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useFloatingPanelState.getState().reset()
+    useFloatingPanelState.getState().open('user')
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
+
+    // Render the floating panel in isolation (not via OutputsDock — the
+    // race-of-interest is FloatingOlumiPanel's render-time gate alone).
+    // Need a graph so the panel doesn't yield via yieldToFirstUse.
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+    } as any)
+
+    const { container } = render(
+      <Wrapper>
+        <FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />
+      </Wrapper>,
+    )
+
+    // The yield gate read the persisted 'olumi' tab and returned null
+    // immediately — no floating panel DOM, no duplicate-surface flash.
+    expect(container.querySelector('[data-testid="floating-olumi-panel"]')).toBeNull()
+
+    // Cleanup: clear the persisted state so subsequent tests don't inherit it.
+    try { sessionStorage.removeItem('canvas.outputsDock.v1') } catch {}
+    useCanvasStore.setState({ nodes: [] } as any)
+  })
+
+  it('docked Olumi float-out returns the user to the LAST non-Olumi tab (round-5 UX)', async () => {
+    // Round-5: float-out should preserve the user's previous Analysis/
+    // Compare/Model/Journey context rather than always defaulting to
+    // Analysis. lastNonOlumiTabRef tracks whichever non-Olumi tab the
+    // user was last on.
+    const { fireEvent } = await import('@testing-library/react')
+    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
+    const { useUIStore } = await import('../../../stores/uiStore')
+    const { useCanvasStore } = await import('../../store')
+    const { OutputsDock } = await import('../OutputsDock')
+
+    // Pre-state: user has a graph (dock expanded), was on Model
+    // (internally 'diagnostics'), then switched to Olumi.
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+    } as any)
+    useUIStore.setState({ activeOutputTab: 'diagnostics', activeOutputTabVersion: 0 })
+    useFloatingPanelState.getState().reset()
+    try {
+      sessionStorage.setItem(
+        'canvas.outputsDock.v1',
+        JSON.stringify({ isOpen: true, activeTab: 'diagnostics' }),
+      )
+    } catch {}
+
+    const { findByTestId } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    // Switch to Olumi — lastNonOlumiTabRef captures 'diagnostics'.
+    // (Expanded-dock tab buttons identify by testid; the rail-mode aria-label
+    //  used by other tests in this block isn't present once the dock expands.)
+    const olumiBtn = (await findByTestId('outputs-dock-tab-olumi')) as HTMLElement
+    fireEvent.click(olumiBtn)
+    await new Promise((r) => setTimeout(r, 50))
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
+
+    // Float out — should return to 'diagnostics', not the 'results' default.
+    const floatOutBtn = (await findByTestId('olumi-tab-float-out')) as HTMLElement
+    fireEvent.click(floatOutBtn)
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
     expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
+
+    // Cleanup.
+    try { sessionStorage.removeItem('canvas.outputsDock.v1') } catch {}
+    useCanvasStore.setState({ nodes: [] } as any)
   })
 
   it('falls through to normal tab activation when floating is CLOSED', async () => {

--- a/src/canvas/components/__tests__/aiPanelV2.interactions.spec.tsx
+++ b/src/canvas/components/__tests__/aiPanelV2.interactions.spec.tsx
@@ -315,53 +315,11 @@ describe('deriveNextDockIsOpen (toggleOpen first-use rail invariant)', () => {
   })
 })
 
-describe('selectEffectiveActiveTab — Olumi-tab redirect policy', () => {
-  // Imported via the same beforeAll dynamic-import dance as
-  // deriveNextDockIsOpen to keep test startup fast.
-  let selectEffectiveActiveTab: (
-    storedActiveTab: 'results' | 'compare' | 'diagnostics' | 'journey' | 'olumi',
-    aiPanelV2On: boolean,
-    floatingPanelIsOpen: boolean,
-    lastNonOlumiTab: 'results' | 'compare' | 'diagnostics' | 'journey' | 'olumi',
-  ) => 'results' | 'compare' | 'diagnostics' | 'journey' | 'olumi'
-  beforeAll(async () => {
-    const mod = await import('../OutputsDock')
-    selectEffectiveActiveTab = mod.selectEffectiveActiveTab
-  }, 30_000)
-
-  it('passes through the stored tab when FF-off (no redirect ever)', () => {
-    expect(selectEffectiveActiveTab('olumi', false, true, 'results')).toBe('olumi')
-    expect(selectEffectiveActiveTab('compare', false, true, 'results')).toBe('compare')
-  })
-
-  it('passes through the stored tab when FF-on but stored tab is not olumi', () => {
-    expect(selectEffectiveActiveTab('results', true, true, 'compare')).toBe('results')
-    expect(selectEffectiveActiveTab('compare', true, true, 'results')).toBe('compare')
-    expect(selectEffectiveActiveTab('diagnostics', true, true, 'results')).toBe('diagnostics')
-  })
-
-  it('passes through stored olumi when floating is closed (no need to redirect)', () => {
-    expect(selectEffectiveActiveTab('olumi', true, false, 'results')).toBe('olumi')
-    expect(selectEffectiveActiveTab('olumi', true, false, 'compare')).toBe('olumi')
-  })
-
-  it('redirects to lastNonOlumiTab when FF-on AND stored=olumi AND floating open', () => {
-    expect(selectEffectiveActiveTab('olumi', true, true, 'compare')).toBe('compare')
-    expect(selectEffectiveActiveTab('olumi', true, true, 'diagnostics')).toBe('diagnostics')
-    expect(selectEffectiveActiveTab('olumi', true, true, 'results')).toBe('results')
-  })
-
-  it('never returns olumi when the redirect condition is satisfied', () => {
-    // Even if lastNonOlumiTab is somehow 'olumi' (defensive callers
-    // shouldn't pass this, but a future bug shouldn't make the
-    // duplicate-surface invariant break silently).
-    const result = selectEffectiveActiveTab('olumi', true, true, 'olumi')
-    // The helper returns whatever was passed; callers are responsible
-    // for not seeding `lastNonOlumiTabRef.current = 'olumi'`. Document
-    // the contract via assertion.
-    expect(result).toBe('olumi')
-  })
-})
+// Round-2 had a `selectEffectiveActiveTab` redirect helper. Round-3 made it
+// dead identity, and round-5 removed it entirely (see OutputsDock.tsx — the
+// duplicate-surface invariant is now enforced by handleTabClick + the
+// close-floating-on-olumi-active guard effect). The corresponding test
+// block was removed in round-5 to avoid keeping stale-meaning coverage.
 
 // Attach evidence: intentionally not tested as a functional feature here —
 // it is shipped as "Coming soon" until the orchestrator turn API supports a

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -4,23 +4,27 @@
  * Renders user messages (right-aligned, info bg) and assistant messages
  * (left-aligned, panel bg) with optional inline blocks and action chips.
  *
- * Progressive disclosure: long assistant text (>300 chars, no blocks, not
- * synthetic) is clamped to ~6 lines with a "Show more" toggle.
+ * Progressive disclosure: long assistant text (>CLAMP_CHAR_THRESHOLD=3000
+ * chars, no blocks, not synthetic) is clamped at a natural paragraph or
+ * sentence boundary with a "Show more" toggle. The threshold is a SAFETY
+ * NET for outlier responses — ordinary assistant turns render in full
+ * (see the round-3 UX correction; the prior 600-char threshold was found
+ * to cut typical responses too aggressively).
  *
  * Streaming: when `message.isStreaming` is true, text renders incrementally
  * with a blinking cursor. Provisional tool-backed turns render at reduced
  * opacity until `turn_complete`.
  */
 
-import { memo, useState, useMemo } from 'react'
+import { memo, useState, useMemo, useRef } from 'react'
 import { typography } from '../../styles/typography'
 import { safeRichText } from '../utils/safeRichText'
 import { InlineBlocks } from './InlineBlocks'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronUp, ListPlus, AlignLeft } from 'lucide-react'
 import { BaseRateChipRow } from './BaseRateChipRow'
 import { FeedbackRow } from './FeedbackRow'
 import { StalenessPill, type StalenessFreshness } from './StalenessPill'
-import { isOrchestratorRenderingV2Enabled, isDeterministicCeeEnabled } from '../../flags'
+import { isOrchestratorRenderingV2Enabled, isDeterministicCeeEnabled, isAiPanelV2Enabled } from '../../flags'
 import { useCanvasStore } from '../store'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { FALLBACK_TEXT } from './validateResponse'
@@ -50,8 +54,15 @@ function sanitiseFactorIds(text: string, labelMap: Map<string, string>): string 
   })
 }
 
-/** Character threshold for applying progressive disclosure. */
-const CLAMP_CHAR_THRESHOLD = 600
+/**
+ * Character threshold for applying progressive disclosure. Round-3 UX pass
+ * raised this from 600 → 3000 because the prior threshold cut typical
+ * assistant responses too aggressively, hiding genuinely useful core
+ * content behind a Show more click. The toggle remains as a safety net
+ * for outlier responses (multi-thousand-character explanations); for
+ * everyday turns the message renders in full.
+ */
+const CLAMP_CHAR_THRESHOLD = 3000
 /** Minimum characters that must be hidden for truncation to be worthwhile. */
 const MIN_HIDDEN_CHARS = 150
 /**
@@ -286,6 +297,18 @@ export const MessageBubble = memo(function MessageBubble({
           disabled={isStreaming}
         />
       )}
+      {/* Explain more + Summarise are AI Panel v2 affordances only — MessageBubble
+          is shared with the FF-off legacy DraftChat surface, and we must not
+          change FF-off parity. The flag guard is the single source of truth. */}
+      {isAiPanelV2Enabled()
+        && !isUser
+        && !message.synthetic
+        && !isStreaming
+        && displayContent.trim().length > 0
+        && displayContent !== FALLBACK_TEXT
+        && onArtefactMessage && (
+        <FollowUpActions onSendFollowUp={onArtefactMessage} />
+      )}
       {!isUser && !message.synthetic && displayContent !== FALLBACK_TEXT && onFeedback && (
         <FeedbackRow turnId={message.clientTurnId} onFeedback={onFeedback} />
       )}
@@ -293,6 +316,57 @@ export const MessageBubble = memo(function MessageBubble({
     </>
   )
 })
+
+/**
+ * FollowUpActions — subtle Explain more + Summarise icon row on assistant
+ * messages. Routes through the existing conversation send path (the same
+ * onArtefactMessage callback used by InsightsStrip actions), so no new
+ * prompt/PMS/backend wiring is required. User-facing copy is visible in
+ * the resulting user-message bubble so nothing internal leaks.
+ *
+ * Subtle by design — same visual weight as the feedback thumbs row, never
+ * a large CTA. Per-row single-flight guard so a double-click can't fire
+ * the same follow-up twice.
+ */
+function FollowUpActions({ onSendFollowUp }: { onSendFollowUp: (text: string) => void }) {
+  const sentRef = useRef(false)
+  const dispatch = (text: string) => {
+    if (sentRef.current) return
+    sentRef.current = true
+    onSendFollowUp(text)
+    // Re-enable after a short window so the user can still ask
+    // a different follow-up on the same message later.
+    setTimeout(() => { sentRef.current = false }, 500)
+  }
+  return (
+    <div
+      className="flex items-center gap-1 mt-1"
+      data-testid="message-follow-up-actions"
+      aria-label="Follow up on this response"
+    >
+      <button
+        type="button"
+        onClick={() => dispatch('Please explain that in more detail.')}
+        className="inline-flex items-center justify-center w-6 h-6 rounded text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
+        aria-label="Explain in more detail"
+        title="Explain more"
+        data-testid="message-action-explain-more"
+      >
+        <ListPlus className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={() => dispatch('Please summarise that as concise bullets.')}
+        className="inline-flex items-center justify-center w-6 h-6 rounded text-text-light hover:text-text-body hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
+        aria-label="Summarise this response"
+        title="Summarise"
+        data-testid="message-action-summarise"
+      >
+        <AlignLeft className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}
 
 /** Map insight type → action chip config with optional deterministic action routing. */
 interface InsightAction {

--- a/src/canvas/conversation/__tests__/MessageBubble.actions.spec.tsx
+++ b/src/canvas/conversation/__tests__/MessageBubble.actions.spec.tsx
@@ -1,0 +1,198 @@
+/**
+ * MessageBubble — Explain more / Summarise follow-up actions.
+ *
+ * Round-3 UX correction added two subtle icon actions to the assistant
+ * message footer (alongside the existing copy/retry/feedback affordances).
+ * Each action dispatches a follow-up via the existing send path
+ * (`onArtefactMessage` → `sendMessage` with `debugSource: 'artefact_action'`).
+ *
+ * The brief requires:
+ *  - actions render on assistant messages only;
+ *  - never on user messages;
+ *  - never on streaming/thinking turns;
+ *  - never on synthetic messages;
+ *  - accessible aria-label + title;
+ *  - route through the existing conversation send path;
+ *  - single-flight guard so a double-click sends one follow-up.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// Stub the supabase + markdown chains the MessageBubble import graph touches.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+import { MessageBubble } from '../MessageBubble'
+import type { ConversationMessage } from '../types'
+
+// AI Panel v2 flag enabled for the whole suite; FF-off parity is asserted
+// in a dedicated spec (MessageBubble.followUp.ffOff.spec.tsx).
+beforeEach(() => {
+  try { window.localStorage.setItem('feature.aiPanelV2', 'true') } catch {}
+})
+
+function baseMessage(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'turn-1',
+    role: 'assistant',
+    content: 'Here is a clear answer to your question.',
+    clientTurnId: 'client-turn-1',
+    ...overrides,
+  } as ConversationMessage
+}
+
+describe('FollowUpActions — render gating', () => {
+  it('renders Explain more + Summarise on a normal assistant message', () => {
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+      />,
+    )
+    expect(screen.getByTestId('message-action-explain-more')).toBeInTheDocument()
+    expect(screen.getByTestId('message-action-summarise')).toBeInTheDocument()
+  })
+
+  it('does NOT render on user messages', () => {
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={baseMessage({ role: 'user', content: 'help me decide' })}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+      />,
+    )
+    expect(screen.queryByTestId('message-action-explain-more')).toBeNull()
+    expect(screen.queryByTestId('message-action-summarise')).toBeNull()
+  })
+
+  it('does NOT render on streaming messages', () => {
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={baseMessage({ isStreaming: true, content: 'partial …' })}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+      />,
+    )
+    expect(screen.queryByTestId('message-action-explain-more')).toBeNull()
+    expect(screen.queryByTestId('message-action-summarise')).toBeNull()
+  })
+
+  it('does NOT render on synthetic messages', () => {
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={baseMessage({ synthetic: true })}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+      />,
+    )
+    expect(screen.queryByTestId('message-action-explain-more')).toBeNull()
+  })
+
+  it('does NOT render when onArtefactMessage callback is absent', () => {
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+      />,
+    )
+    expect(screen.queryByTestId('message-action-explain-more')).toBeNull()
+  })
+})
+
+describe('FollowUpActions — accessibility', () => {
+  it('Explain more has an accessible label and tooltip', () => {
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+        onArtefactMessage={vi.fn()}
+      />,
+    )
+    const btn = screen.getByTestId('message-action-explain-more')
+    expect(btn.getAttribute('aria-label')).toBe('Explain in more detail')
+    expect(btn.getAttribute('title')).toBe('Explain more')
+  })
+
+  it('Summarise has an accessible label and tooltip', () => {
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+        onArtefactMessage={vi.fn()}
+      />,
+    )
+    const btn = screen.getByTestId('message-action-summarise')
+    expect(btn.getAttribute('aria-label')).toBe('Summarise this response')
+    expect(btn.getAttribute('title')).toBe('Summarise')
+  })
+
+  it('action row has an accessible group label', () => {
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+        onArtefactMessage={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('message-follow-up-actions')
+    expect(row.getAttribute('aria-label')).toBe('Follow up on this response')
+  })
+})
+
+describe('FollowUpActions — send path wiring', () => {
+  it('Explain more sends the British-English follow-up text via onArtefactMessage', () => {
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('message-action-explain-more'))
+    expect(onArtefactMessage).toHaveBeenCalledTimes(1)
+    expect(onArtefactMessage).toHaveBeenCalledWith('Please explain that in more detail.')
+  })
+
+  it('Summarise sends the British-English follow-up text via onArtefactMessage', () => {
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('message-action-summarise'))
+    expect(onArtefactMessage).toHaveBeenCalledTimes(1)
+    expect(onArtefactMessage).toHaveBeenCalledWith('Please summarise that as concise bullets.')
+  })
+
+  it('single-flight guard: double-click on Explain more only sends once', () => {
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={baseMessage()}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+      />,
+    )
+    const btn = screen.getByTestId('message-action-explain-more')
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    expect(onArtefactMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/canvas/conversation/__tests__/MessageBubble.followUp.ffOff.spec.tsx
+++ b/src/canvas/conversation/__tests__/MessageBubble.followUp.ffOff.spec.tsx
@@ -1,0 +1,89 @@
+/**
+ * MessageBubble — FF-off parity for the new Follow-up actions.
+ *
+ * MessageBubble is shared between AI Panel v2 surfaces (floating + docked
+ * Olumi) and the FF-off legacy DraftChat surface. The Explain more +
+ * Summarise affordances must NEVER render under FF-off — adding them
+ * silently would change legacy conversation parity.
+ *
+ * The flag guard (`isAiPanelV2Enabled()`) inside MessageBubble.tsx is the
+ * single source of truth. This spec proves the guard holds end-to-end:
+ * with `feature.aiPanelV2` off and the same callbacks that AI Panel v2
+ * surfaces use, no follow-up icons appear in the rendered bubble.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+import { MessageBubble } from '../MessageBubble'
+import type { ConversationMessage } from '../types'
+
+const ASSISTANT_MESSAGE: ConversationMessage = {
+  id: 'turn-ff-off',
+  role: 'assistant',
+  content: 'Legacy DraftChat path — no AI Panel v2 affordances expected.',
+  clientTurnId: 'client-turn-ff-off',
+} as ConversationMessage
+
+describe('FollowUpActions — FF-off parity (legacy DraftChat path)', () => {
+  beforeEach(() => {
+    try {
+      window.localStorage.setItem('feature.aiPanelV2', 'false')
+    } catch {}
+  })
+
+  it('does NOT render Explain more / Summarise when aiPanelV2 flag is off', () => {
+    // Same callback shape AI Panel v2 surfaces pass through — proves the
+    // gate is the FLAG, not the callback presence.
+    const onArtefactMessage = vi.fn()
+    render(
+      <MessageBubble
+        message={ASSISTANT_MESSAGE}
+        onChipClick={async () => undefined}
+        onArtefactMessage={onArtefactMessage}
+        onFeedback={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('message-action-explain-more')).toBeNull()
+    expect(screen.queryByTestId('message-action-summarise')).toBeNull()
+    expect(screen.queryByTestId('message-follow-up-actions')).toBeNull()
+  })
+
+  it('legacy DraftChat surfaces (compact=false) also remain unchanged', () => {
+    // compact prop is independent of the flag, but both code paths must
+    // suppress the affordances under FF-off.
+    render(
+      <MessageBubble
+        message={ASSISTANT_MESSAGE}
+        onChipClick={async () => undefined}
+        onArtefactMessage={vi.fn()}
+        onFeedback={vi.fn()}
+        compact={false}
+      />,
+    )
+    expect(screen.queryByTestId('message-action-explain-more')).toBeNull()
+  })
+
+  it('flipping the flag to true re-enables the affordances (sanity check)', () => {
+    try { window.localStorage.setItem('feature.aiPanelV2', 'true') } catch {}
+    render(
+      <MessageBubble
+        message={ASSISTANT_MESSAGE}
+        onChipClick={async () => undefined}
+        onArtefactMessage={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('message-action-explain-more')).toBeInTheDocument()
+    expect(screen.getByTestId('message-action-summarise')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/conversation/__tests__/progressiveDisclosure.spec.ts
+++ b/src/canvas/conversation/__tests__/progressiveDisclosure.spec.ts
@@ -1,106 +1,119 @@
 /**
  * Progressive disclosure threshold tests.
  *
+ * Round-3 UX correction raised the threshold from 600 → 3000 chars: the
+ * prior threshold cut typical assistant responses too aggressively. The
+ * boundary-detection algorithm is unchanged — only the safety-net
+ * threshold moved. These tests pin behaviour to the new value.
+ *
  * Verifies:
- * 1. Messages under 600 chars show full text (no truncation)
- * 2. Messages over 600 chars truncate at a natural boundary
+ * 1. Messages under 3000 chars show full text (no truncation)
+ * 2. Messages over 3000 chars truncate at a natural boundary
  * 3. Truncation only fires when ≥150 chars would be hidden (MIN_HIDDEN_CHARS)
  * 4. Paragraph-break guard: a break >100 chars before the threshold is skipped;
  *    falls through to sentence-end path instead.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// MessageBubble's transitive import chain reaches threadService which
+// throws at module load when Supabase env vars are missing in the test
+// environment. Mock the chain ahead of the dynamic import so this pure
+// unit-test file can actually run.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
 import { findNaturalTruncation } from '../MessageBubble'
 
+const THRESHOLD = 3000
+
 describe('findNaturalTruncation', () => {
-  it('returns null for text under 600 chars (shows full text)', () => {
-    const shortText = 'A'.repeat(400)
+  it('returns null for text under the threshold (shows full text)', () => {
+    const shortText = 'A'.repeat(2000)
     expect(findNaturalTruncation(shortText)).toBeNull()
   })
 
-  it('returns null for text exactly at 600 chars', () => {
-    const exactText = 'A'.repeat(600)
+  it('returns null for text exactly at the threshold', () => {
+    const exactText = 'A'.repeat(THRESHOLD)
     expect(findNaturalTruncation(exactText)).toBeNull()
   })
 
-  it('truncates text over 600 chars at paragraph boundary when break is within 100 chars of threshold', () => {
-    // Paragraph break at index 550, which is 50 chars before CLAMP_CHAR_THRESHOLD (600).
-    // 50 <= MAX_PARA_BREAK_DISTANCE (100) → guard passes.
-    // The hidden portion is 200+ chars of A's, well over MIN_HIDDEN_CHARS (150).
-    // Using all A's so no sentence endings exist in the hidden portion — ensuring
-    // the paragraph-break path is taken, not the sentence-end path.
-    const intro = 'A'.repeat(550)               // 550 chars, no sentence endings
-    const hidden = '\n\n' + 'A'.repeat(200)     // 202 chars, no sentence endings
+  it('truncates text over the threshold at a paragraph boundary when the break is within 100 chars', () => {
+    // Paragraph break at index THRESHOLD-50, well within MAX_PARA_BREAK_DISTANCE (100).
+    // Hidden portion (200+ chars) exceeds MIN_HIDDEN_CHARS (150).
+    const intro = 'A'.repeat(THRESHOLD - 50)     // no sentence endings
+    const hidden = '\n\n' + 'A'.repeat(200)      // 202 chars
     const fullText = intro + hidden
-    expect(fullText.length).toBeGreaterThan(600)
+    expect(fullText.length).toBeGreaterThan(THRESHOLD)
 
     const result = findNaturalTruncation(fullText)
     expect(result).not.toBeNull()
-    // Must cut at the paragraph break: result is the first 550 A's
     expect(result).toBe(intro)
   })
 
-  it('skips paragraph break when it is >100 chars before threshold (guard kicks in)', () => {
-    // Paragraph break at index 400 → 600 - 400 = 200 > MAX_PARA_BREAK_DISTANCE (100).
-    // Guard should skip this break. The function then falls through to sentence-end.
-    const intro = 'A'.repeat(400)               // 400 chars, no sentence endings
-    const hidden = '\n\n' + 'A'.repeat(300)     // 302 chars, no sentence endings
+  it('skips a paragraph break that sits >100 chars before the threshold (guard kicks in)', () => {
+    // Paragraph break at index THRESHOLD-200 → 200 > MAX_PARA_BREAK_DISTANCE (100).
+    // Falls through to sentence-end path; with no sentence endings, returns null.
+    const intro = 'A'.repeat(THRESHOLD - 200)    // no sentence endings
+    const hidden = '\n\n' + 'A'.repeat(300)      // 302 chars, no sentence endings
     const fullText = intro + hidden
-    expect(fullText.length).toBeGreaterThan(600)
+    expect(fullText.length).toBeGreaterThan(THRESHOLD)
 
-    // No sentence endings exist anywhere in this text, so the sentence-end path
-    // also finds nothing. The function must return null (no valid cut point).
     const result = findNaturalTruncation(fullText)
     expect(result).toBeNull()
   })
 
-  it('truncates at sentence boundary when no paragraph break available', () => {
-    // Single long paragraph with sentences — must exceed 600 chars total
-    const text = 'First sentence is about the decision model and factors. ' +
-      'Second sentence describes the key external risk factors. ' +
-      'Third sentence explains the uncertainty in market conditions. ' +
-      'Fourth sentence covers the regulatory landscape analysis. ' +
-      'Fifth sentence discusses the competitive positioning strategy. ' +
-      'Sixth sentence outlines the financial implications of each option. ' +
-      'Seventh sentence provides the sensitivity analysis overview here. ' +
-      'Eighth sentence summarises the robustness of the recommendation. ' +
-      'Ninth sentence highlights the key drivers of the decision outcome. ' +
-      'Tenth sentence concludes with the final recommendation details. ' +
-      'Eleventh sentence adds extra context about implementation timeline. ' +
-      'Twelfth sentence provides resource allocation recommendations now.'
-    expect(text.length).toBeGreaterThan(600)
+  it('truncates at a sentence boundary when no paragraph break is available', () => {
+    // Build a single paragraph that exceeds the threshold with many short
+    // sentences so the sentence-end path is the only viable cut point.
+    const sentence = 'This is a sentence of moderate length used to fill content. '
+    const repeats = Math.ceil((THRESHOLD + 200) / sentence.length)
+    const text = sentence.repeat(repeats)
+    expect(text.length).toBeGreaterThan(THRESHOLD)
 
     const result = findNaturalTruncation(text)
-    // Should truncate at a sentence boundary (ends with period)
     if (result) {
+      // The result must end at a sentence boundary (.!?).
       expect(result).toMatch(/[.!?]$/)
     }
   })
 
-  it('returns null when hidden content would be less than 150 chars', () => {
-    // Sentence boundary at ~590, only 60 chars hidden — below MIN_HIDDEN_CHARS (150).
-    // Use a long run of A's then a sentence ending, then short tail.
-    const mainText = 'A'.repeat(588) + '. '   // 590 chars, sentence end at pos 588
-    const tail = 'A'.repeat(60)               // 60 chars — below MIN_HIDDEN_CHARS
+  it('returns null when the hidden content would be less than MIN_HIDDEN_CHARS', () => {
+    // Sentence boundary near the threshold, but only ~60 chars hidden — below
+    // MIN_HIDDEN_CHARS (150). Truncation isn't worthwhile.
+    const mainText = 'A'.repeat(THRESHOLD - 12) + '. '
+    const tail = 'A'.repeat(60)
     const fullText = mainText + tail
-    expect(fullText.length).toBeGreaterThan(600)
+    expect(fullText.length).toBeGreaterThan(THRESHOLD)
 
     const result = findNaturalTruncation(fullText)
-    // Should return null because hidden content (60 chars) < MIN_HIDDEN_CHARS (150)
     expect(result).toBeNull()
   })
 
-  it('truncates when hidden content exceeds 150 chars', () => {
-    // Sentence boundary at ~400, then 250+ A's of content.
-    // 400 + 2 + 250 = 652 chars total. Hidden after sentence boundary = 250 chars ≥ 150.
-    // No paragraph breaks, so sentence-end path is used.
-    const intro = 'A'.repeat(398) + '. '       // 400 chars, sentence end at pos 398
-    const tail = 'A'.repeat(252)               // 252 chars — exceeds MIN_HIDDEN_CHARS (150)
+  it('truncates when the hidden content exceeds MIN_HIDDEN_CHARS', () => {
+    // Sentence boundary near the threshold; hidden tail >150 chars.
+    const intro = 'A'.repeat(THRESHOLD - 202) + '. '   // sentence end near threshold
+    const tail = 'A'.repeat(252)                       // 252 hidden chars
     const fullText = intro + tail
-    expect(fullText.length).toBeGreaterThan(600)
+    expect(fullText.length).toBeGreaterThan(THRESHOLD)
 
     const result = findNaturalTruncation(fullText)
     expect(result).not.toBeNull()
-    expect(result!.length).toBeLessThanOrEqual(600)
+    expect(result!.length).toBeLessThanOrEqual(THRESHOLD)
+  })
+
+  it('ordinary assistant responses (~1500 chars) render in full (no Show more)', () => {
+    // Sanity check on the round-3 raise — a typical assistant response
+    // length is well under the new 3000 safety-net threshold and must
+    // NOT be truncated.
+    const ordinaryText = 'A'.repeat(1500)
+    expect(findNaturalTruncation(ordinaryText)).toBeNull()
   })
 })

--- a/src/canvas/hooks/__tests__/useFloatingPanelState.spec.ts
+++ b/src/canvas/hooks/__tests__/useFloatingPanelState.spec.ts
@@ -11,7 +11,7 @@ describe('useFloatingPanelState', () => {
     expect(s.isOpen).toBe(false)
     expect(s.userRepositioned).toBe(false)
     expect(s.source).toBe('user')
-    expect(s.size).toEqual({ width: 400, height: 500 })
+    expect(s.size).toEqual({ width: 400, height: 550 })
     expect(s.position).toBeNull()
   })
 
@@ -53,6 +53,134 @@ describe('useFloatingPanelState', () => {
     useFloatingPanelState.getState().toggle()
     expect(useFloatingPanelState.getState().isOpen).toBe(false)
   })
+})
+
+describe('performAutoReposition — lifecycle invariants (round-6)', () => {
+  it('repeat calls cancel and replace prior rAF + clear timers', () => {
+    useFloatingPanelState.getState().reset()
+    const anchorA = { x: 100, y: 100 }
+    const anchorB = { x: 600, y: 200 }
+
+    const rafQueue: FrameRequestCallback[] = []
+    const originalRaf = window.requestAnimationFrame
+    const originalCancel = window.cancelAnimationFrame
+    let cancelCount = 0
+    window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      rafQueue.push(cb)
+      return rafQueue.length
+    }
+    window.cancelAnimationFrame = (id: number) => {
+      cancelCount++
+      void id
+    }
+
+    try {
+      useFloatingPanelState.getState().performAutoReposition(anchorA, { reducedMotion: false })
+      expect(cancelCount).toBe(0)
+      expect(rafQueue.length).toBe(1)
+
+      // Second call supersedes: prior rAF is cancelled before a new one
+      // is scheduled. The prior clear timeout is also cancelled (via
+      // clearTimeout, not cancelAnimationFrame — accounted for in the
+      // cancelCount metric on the rAF channel only).
+      useFloatingPanelState.getState().performAutoReposition(anchorB, { reducedMotion: false })
+      expect(cancelCount).toBe(1)
+      expect(rafQueue.length).toBe(2)
+
+      // Even if both rAFs fire (our stub doesn't model cancellation), the
+      // last-write-wins ordering lands the panel at anchorB.
+      rafQueue.forEach((cb) => cb(performance.now()))
+      expect(useFloatingPanelState.getState().position).toEqual(anchorB)
+    } finally {
+      window.requestAnimationFrame = originalRaf
+      window.cancelAnimationFrame = originalCancel
+    }
+  })
+
+  it('reset() cancels any in-flight transition timers', () => {
+    useFloatingPanelState.getState().reset()
+    let cancelCount = 0
+    const originalRaf = window.requestAnimationFrame
+    const originalCancel = window.cancelAnimationFrame
+    window.requestAnimationFrame = (_cb: FrameRequestCallback) => 42
+    window.cancelAnimationFrame = (id: number) => { cancelCount++; void id }
+
+    try {
+      useFloatingPanelState.getState().performAutoReposition({ x: 100, y: 100 }, { reducedMotion: false })
+      expect(useFloatingPanelState.getState().isAutoRepositioning).toBe(true)
+
+      // Reset before the rAF or clear timer fires.
+      useFloatingPanelState.getState().reset()
+      expect(cancelCount).toBe(1)
+      expect(useFloatingPanelState.getState().isAutoRepositioning).toBe(false)
+      expect(useFloatingPanelState.getState().position).toBeNull()
+    } finally {
+      window.requestAnimationFrame = originalRaf
+      window.cancelAnimationFrame = originalCancel
+    }
+  })
+
+  it('does NOT flip userRepositioned (auto-dock guard preserved)', () => {
+    useFloatingPanelState.getState().reset()
+    useFloatingPanelState.getState().open('system-first-use')
+    expect(useFloatingPanelState.getState().userRepositioned).toBe(false)
+    useFloatingPanelState.getState().performAutoReposition({ x: 600, y: 200 }, { reducedMotion: true })
+    expect(useFloatingPanelState.getState().userRepositioned).toBe(false)
+  })
+})
+
+describe('performAutoReposition (round-5: store-owned timers)', () => {
+  it('writes the anchor synchronously under reducedMotion + clears isAutoRepositioning', () => {
+    useFloatingPanelState.getState().reset()
+    const anchor = { x: 600, y: 200 }
+    useFloatingPanelState.getState().performAutoReposition(anchor, { reducedMotion: true })
+    const s = useFloatingPanelState.getState()
+    expect(s.position).toEqual(anchor)
+    expect(s.isAutoRepositioning).toBe(false)
+    // Direct setState must not flip userRepositioned — the auto-reposition
+    // is system-initiated, not user-initiated.
+    expect(s.userRepositioned).toBe(false)
+  })
+
+  it('arms isAutoRepositioning synchronously, defers the position write to rAF, owner-clears after the window', async () => {
+    useFloatingPanelState.getState().reset()
+    const anchor = { x: 600, y: 200 }
+
+    // Stub rAF + setTimeout with fake-ish controllers so we can step through
+    // the orchestration without relying on real frames.
+    const rafCallbacks: FrameRequestCallback[] = []
+    const originalRaf = window.requestAnimationFrame
+    window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    }
+
+    try {
+      useFloatingPanelState.getState().performAutoReposition(anchor, { reducedMotion: false })
+
+      // Phase 1 (synchronous): flag is set, position NOT yet written.
+      let s = useFloatingPanelState.getState()
+      expect(s.isAutoRepositioning).toBe(true)
+      expect(s.position).toBeNull()
+
+      // Phase 2: flush the rAF — position lands at the anchor.
+      rafCallbacks.forEach((cb) => cb(performance.now()))
+      s = useFloatingPanelState.getState()
+      expect(s.position).toEqual(anchor)
+      expect(s.isAutoRepositioning).toBe(true)
+
+      // Phase 3: wait past the 450ms clear window. The clear is owned by
+      // the store action (not by any component), so it fires even with no
+      // FloatingOlumiPanel mounted in this unit test environment.
+      await new Promise((r) => setTimeout(r, 500))
+      s = useFloatingPanelState.getState()
+      expect(s.isAutoRepositioning).toBe(false)
+      // Position remains at the anchor — the clear only touches the flag.
+      expect(s.position).toEqual(anchor)
+    } finally {
+      window.requestAnimationFrame = originalRaf
+    }
+  }, 10_000)
 })
 
 describe('canAutoDock', () => {

--- a/src/canvas/hooks/useFloatingPanelState.ts
+++ b/src/canvas/hooks/useFloatingPanelState.ts
@@ -27,6 +27,11 @@ export interface FloatingPanelState {
   position: FloatingPanelPosition | null
   /** Current panel size. */
   size: FloatingPanelSize
+  /** Transient flag set by the post-graph auto-reposition path so the floating
+   *  panel can apply a scoped CSS slide transition on left/top without
+   *  affecting drag responsiveness. Cleared by FloatingOlumiPanel after the
+   *  transition window completes. Never set under prefers-reduced-motion. */
+  isAutoRepositioning: boolean
   /** Open the floating panel. Pass source='system-first-use' for the first-use
    *  flow (auto-dockable) or 'user' for any user-driven open (never auto-docks). */
   open: (source: FloatingPanelSource) => void
@@ -46,20 +51,39 @@ export interface FloatingPanelState {
    *  Only writes if `position` is currently null. Does NOT flip
    *  userRepositioned — preserves the auto-dock invariant. */
   setInitialPosition: (pos: FloatingPanelPosition) => void
+  /** Orchestrate the post-graph auto-reposition: arm the slide transition
+   *  flag, defer the position write to the next animation frame so the
+   *  panel's mount paint has a real "from" coordinate, then owner-clear
+   *  the flag after the transition window. Owned by the store (not any
+   *  component) so re-render cleanup cannot cancel its scheduled writes.
+   *  Under prefers-reduced-motion: writes the position synchronously, no
+   *  transition, no deferred clear.
+   *  Direct setState bypasses setPosition's userRepositioned flip so an
+   *  automatic reposition doesn't look like a user drag. */
+  performAutoReposition: (anchor: FloatingPanelPosition, options?: { reducedMotion?: boolean }) => void
   /** Reset state (used on page load / scenario change). */
   reset: () => void
 }
 
-const DEFAULT_SIZE: FloatingPanelSize = { width: 400, height: 500 }
+const DEFAULT_SIZE: FloatingPanelSize = { width: 400, height: 550 }
 
-const INITIAL: Pick<FloatingPanelState, 'isOpen' | 'userRepositioned' | 'source' | 'isMinimised' | 'position' | 'size'> = {
+const INITIAL: Pick<FloatingPanelState, 'isOpen' | 'userRepositioned' | 'source' | 'isMinimised' | 'position' | 'size' | 'isAutoRepositioning'> = {
   isOpen: false,
   userRepositioned: false,
   source: 'user',
   isMinimised: false,
   position: null,
   size: DEFAULT_SIZE,
+  isAutoRepositioning: false,
 }
+
+// Module-scope handles for the active auto-reposition transition's timers.
+// Stored outside the Zustand state because they're transient orchestration
+// details (no need to subscribe), and the store factory closes over them so
+// repeated `performAutoReposition` calls can supersede a still-pending
+// transition cleanly. Never null after the first call until the next call.
+let _autoRepositionRafId: number | null = null
+let _autoRepositionClearId: number | null = null
 
 export const useFloatingPanelState = create<FloatingPanelState>((set, get) => ({
   ...INITIAL,
@@ -76,7 +100,61 @@ export const useFloatingPanelState = create<FloatingPanelState>((set, get) => ({
   setSize: (size) => set({ size, userRepositioned: true }),
   setInitialPosition: (position) =>
     set((s) => (s.position === null ? { position } : s)),
-  reset: () => set(INITIAL),
+  performAutoReposition: (anchor, options) => {
+    const reducedMotion = options?.reducedMotion ?? false
+
+    // Supersede any still-pending transition. Cancels orphan rAFs and the
+    // 450ms clear from a prior call so repeated triggers don't leak timers
+    // and don't write stale anchors on top of fresher ones. Safe even on
+    // first invocation (both ids are null).
+    if (typeof window !== 'undefined') {
+      if (_autoRepositionRafId !== null) window.cancelAnimationFrame(_autoRepositionRafId)
+      if (_autoRepositionClearId !== null) window.clearTimeout(_autoRepositionClearId)
+    }
+    _autoRepositionRafId = null
+    _autoRepositionClearId = null
+
+    if (reducedMotion) {
+      // Instant settle: no transition, no deferred clear.
+      set({ position: anchor, isAutoRepositioning: false })
+      return
+    }
+    // Arm the slide flag synchronously so the panel's NEXT layout effect
+    // run writes the CSS transition declaration. The position write is
+    // deferred to the next animation frame so the panel's mount paint at
+    // the centred default has a real visible "from" coordinate to animate
+    // from. The 450ms clear timeout is owned here — outside any component
+    // lifecycle — so a panel unmount or a parent re-render cannot cancel
+    // it. The window must outlast the 300ms transition with margin.
+    set({ isAutoRepositioning: true })
+    if (typeof window !== 'undefined') {
+      _autoRepositionRafId = window.requestAnimationFrame(() => {
+        _autoRepositionRafId = null
+        set({ position: anchor })
+      })
+      _autoRepositionClearId = window.setTimeout(() => {
+        _autoRepositionClearId = null
+        set({ isAutoRepositioning: false })
+      }, 450)
+    } else {
+      // SSR / test environments without a DOM: write synchronously and
+      // skip the timers. The flag clears immediately so subsequent renders
+      // never observe a stale `true`.
+      set({ position: anchor, isAutoRepositioning: false })
+    }
+  },
+  reset: () => {
+    // Cancel any in-flight auto-reposition timers and clear the flag — a
+    // reset (page load, scenario switch) must not leave orphan timers that
+    // later overwrite the freshly-reset state.
+    if (typeof window !== 'undefined') {
+      if (_autoRepositionRafId !== null) window.cancelAnimationFrame(_autoRepositionRafId)
+      if (_autoRepositionClearId !== null) window.clearTimeout(_autoRepositionClearId)
+    }
+    _autoRepositionRafId = null
+    _autoRepositionClearId = null
+    set(INITIAL)
+  },
 }))
 
 /**

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -53,6 +53,13 @@ export const typography = {
   panelBody: 'text-xs font-sans leading-relaxed',                 // 12px — body text, descriptions, bullets, card content
   panelMeta: 'text-[11px] font-sans leading-snug',                // 11px — badges, pills, axis labels, tertiary metadata
 
+  // AI Panel v2 first-use hero heading. Inter, 24px, semibold, calm rhythm.
+  // Used exclusively by the FirstUseComposer welcome surface so the hero
+  // reads as a prominent invitation without breaking the strict panel-text
+  // hierarchy used elsewhere. Neutral letter spacing — display tightening
+  // (tracking-tight) felt off on this hero scale.
+  welcomeHeading: 'text-[24px] font-semibold font-sans leading-snug', // 24px — AI Panel v2 hero only
+
   // Utility
   screenReaderOnly: 'sr-only',
 } as const


### PR DESCRIPTION
> **🚧 DRAFT — blocked by pre-existing PreAnalysisPanel hook-order bug.**
> Browser verification of the post-graph AI Panel v2 experience cannot complete until that issue is fixed on staging. See *Known limitation* and *Blocker tracking* below.

## Summary

Refines the AI Panel v2 floating-first UX from a small auxiliary surface into a polished, intuitive Olumi companion. UI/UX only — no CEE, PLoT, ISL, prompt, PMS, schema, package, or backend changes. Single `useConversation()` instance invariant and FF-off parity hold exactly. `VITE_FEATURE_AI_PANEL_V2` in-code default remains off.

## What changed

**First-use hero (FirstUseComposer)**
- Large centred surface (640px × ≥460px, capped 70vh): Olumi logo, "What are you deciding?" heading (new `welcomeHeading` token), guidance copy, ≥3-line composer.
- Six DS v5 node shapes drift ambiently behind content via CSS keyframes; `prefers-reduced-motion` → static faded shapes.
- Hero stays mounted through the post-submit generation window so controls lock in place rather than jumping to top-left.
- Canvas reset re-engages the hero with a 500ms debounce that skips transient hydration/import clears.

**Post-graph behaviour**
- AI panel stays open and slides to a bottom-right anchor near the Analysis dock.
- Orchestration owned by a new `performAutoReposition` store action with cancel-on-repeat and reset-cleanup so re-renders cannot strand `isAutoRepositioning=true`.
- Auto-dock-close replaced with auto-reposition; `userRepositioned` preserved (system reposition uses direct setState).

**Composer styling (AIInputBar)**
- Removed blue `focus-within` ring; subtle border-only focus on `info`.
- Circular `bg-info` send button (32×32 in welcome, 28×28 elsewhere). Cog stays inside the input border, aligned with send.
- Welcome variant: 3-line min, 6-line max textarea.
- Generation lock disables textarea + cog + send + chevron.

**Floating panel chrome**
- Replaced bulky top header with a 36px left-edge side tab hosting 32×32 minimise + dock buttons, and a 6px aria-hidden top drag handle.
- Keyboard-accessible side-tab controls; drag is pointer-only.

**All-corner resize (FloatingOlumiPanel)**
- Added TL/TR/BL handles alongside the existing BR.
- New pure helper `computeCornerResize` composes the same `MIN_WIDTH`/`MIN_HEIGHT`, `computeMaxSize`, dock-aware right-cap and margin floors the BR path has always used. No clamp helper or store refactor.

**Duplicate-surface safety**
- Render-time yield gate in FloatingOlumiPanel reads both `useUIStore` and the persisted dock state, so a first-paint disagreement (after page reload with `activeTab=olumi` persisted) never paints both surfaces.
- Olumi tab click closes floating then activates Olumi; a guard effect covers the non-click paths.
- Float-out from docked Olumi returns the user to their last non-Olumi tab (`lastNonOlumiTabRef`) so context is preserved.

**Conversation surface**
- Show more threshold raised 600 → 3000 chars so typical responses render in full; remains as a safety net for outliers.
- New `Explain more` (ListPlus) + `Summarise` (AlignLeft) icon actions on assistant messages — FF-gated via `isAiPanelV2Enabled()` so legacy DraftChat parity is preserved. British English follow-up copy routed through the existing `onArtefactMessage` send path.

**Olumi tab visual treatment**
- Text-only label, no MessageSquare icon in expanded tab row.
- Removed bulky "Open" badge and "Olumi is open. Focus floating panel" aria-label — now consistent with Analysis/Compare/Model.

**Misc**
- Default floating panel height 500 → 550px.
- Removed dead `selectEffectiveActiveTab` identity helper.
- Welcome heading uses neutral letter-spacing (no `tracking-tight`).

## Test plan

- [x] Typecheck clean (`tsc -p tsconfig.ci.json --noEmit`)
- [x] Lint zero errors/warnings on modified files
- [x] Pre-push fast gate passed locally (typecheck + lint changed files + 459 smoke tests + stale-.js + dep audit + vendored schemas)
- [x] **Focused AI Panel v2 suite: 161 / 161 passing across 15 spec files** — see `Test counts` below
- [x] FF-off parity verified in browser: no hero, no floating, no Olumi tab, no strip; legacy DraftChat path intact
- [x] Browser: empty first-load welcome hero (logo, heading, guidance, 6 ambient shapes, ≥3-line composer)
- [x] Browser: generating state after first submit — hero still centred, all controls disabled, placeholder swapped
- [ ] **Browser: post-graph AI floating bottom-right + Analysis visible** ← blocked
- [ ] **Browser: docked Olumi conversation after clicking Olumi tab** ← blocked
- [ ] **Browser: reset canvas returns to welcome hero** ← blocked
- [ ] **Browser: floating panel resized from at least two corners (pointer-driven)** ← blocked (DOM-level presence of all four handles confirmed; geometry unit-tested)
- [ ] **Browser: Explain more / Summarise on a real assistant response** ← blocked
- [ ] **Browser: docked vs floating typography comparison** ← blocked

## Test counts

| File | Tests |
|---|---|
| `aiPanelV2.typography.spec.ts` | 8 |
| `aiPanelV2.parity.spec.tsx` | 8 |
| `aiPanelV2.interactions.spec.tsx` | 13 |
| `aiPanelV2.polish.spec.tsx` | 8 |
| `FirstUseComposer.spec.tsx` | 17 |
| `FloatingOlumiPanel.clamp.spec.ts` | 22 |
| `FloatingOlumiPanel.density.spec.tsx` | 4 |
| `FloatingOlumiPanel.dockInset.spec.tsx` | 12 |
| `FloatingOlumiPanel.resize.spec.ts` *(new)* | 17 |
| `OutputsDock.conversationSingleton.spec.tsx` | 11 |
| `PersistentInputStrip.spec.tsx` | 4 |
| `MessageBubble.actions.spec.tsx` *(new)* | 11 |
| `MessageBubble.followUp.ffOff.spec.tsx` *(new)* | 3 |
| `progressiveDisclosure.spec.ts` | 8 |
| `useFloatingPanelState.spec.ts` | 15 |
| **Total** | **161** |

## Files changed (16, +2,002 / −583)

Source (8): `AIInputBar.tsx`, `FirstUseComposer.tsx`, `FloatingOlumiPanel.tsx`, `OlumiTabBody.tsx`, `OutputsDock.tsx`, `MessageBubble.tsx`, `useFloatingPanelState.ts`, `typography.ts`.

Tests modified (5): `FirstUseComposer.spec.tsx`, `OutputsDock.conversationSingleton.spec.tsx`, `aiPanelV2.interactions.spec.tsx`, `progressiveDisclosure.spec.ts`, `useFloatingPanelState.spec.ts`.

Tests new (3): `FloatingOlumiPanel.resize.spec.ts`, `MessageBubble.actions.spec.tsx`, `MessageBubble.followUp.ffOff.spec.tsx`.

**No excluded paths touched** — zero changes to `.env`, lockfiles, `supabase/`, `scripts/`, `.github/`, `vite.config*`, CEE/PLoT/ISL adapters, prompts, schemas, debug-bundle, payload-trace. No changes to `useConversation.ts`, orchestration, model contracts, or backend semantics.

## FF-off parity

Verified in browser with `VITE_FEATURE_AI_PANEL_V2='false'`:
- No first-use hero
- No floating Olumi panel
- No Olumi tab in OutputsDock
- No persistent input strip footer
- Legacy DraftChat overlay path renders normally
- Console clean (no hook-order errors, no warnings)

Supplementary: `aiPanelV2.parity.spec.tsx` (8 tests) + `MessageBubble.followUp.ffOff.spec.tsx` (3 tests, new in this PR) cover the gating at the spec level.

## Known limitation — blocker for this PR's verification

**Pre-existing PreAnalysisPanel hook-order error in `src/canvas/components/pre-analysis/PreAnalysisPanel.tsx:1319`.**

The component has a conditional `if (...) return null` followed by `useMemo`/`useCallback` calls at line 1325+. When the panel transitions between the early-return and past-early-return paths on subsequent renders, React throws `Rendered more hooks than during the previous render`. This is a textbook Rules-of-Hooks violation.

I confirmed this reproduces on plain `origin/staging` without any of this PR's changes (stashed work, ran the same first-use submit → canvas-store-add-node flow, error fires identically). **It is not caused by this PR.**

It blocks browser verification of:
- post-graph floating bottom-right
- docked Olumi conversation
- canvas reset → hero
- two-corner resize (pointer-driven)
- Explain more / Summarise on real assistant response
- docked vs floating typography comparison

The auto-reposition behaviour itself is fully covered by deterministic unit tests (15 in `useFloatingPanelState.spec.ts`, including the round-6 lifecycle invariants for cancel-on-repeat, reset cleanup, and `userRepositioned` preservation).

## Blocker tracking

This PR depends on a separate fix landing on staging:

- [ ] **PreAnalysisPanel hook-order fix** — investigation plan tracked separately. Smallest safe fix: move all `useMemo`/`useCallback` calls above the conditional `return null` at line 1319, or extract the post-return-null branch into a child component.

Once that fix lands on staging:
1. Rebase this branch onto updated staging.
2. Rerun typecheck and focused suite.
3. Complete the 6 blocked browser-verification states above.
4. Promote from draft to ready-for-review.

## Authorisation status

**Do not merge or deploy.** The current staging flag (`VITE_FEATURE_AI_PANEL_V2`) is unchanged. The in-code default remains `false`. Nothing else is enabled by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)