### PR TITLE
feat(debug-panel): mount <DebugPanel /> in AppPoC, gate on staging env (PR #156 follow-up)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,6 +49,21 @@
   # adding to `[build.environment]` ONLY after sign-off.
   VITE_FEATURE_AI_PANEL_V2 = "true"
 
+  # Debug panel + payload-trace-store env gate (PR #156 follow-up).
+  # `VITE_APP_ENV=staging` makes:
+  #   1. `<DebugPanel />` (mounted in AppPoC) eligible when the user
+  #      adds `?diag` / `?diag=1` to the URL OR sets
+  #      `window.__OLUMI_DEBUG = true` in the console. `<DebugPanel />`
+  #      refuses to render unless `VITE_APP_ENV ∈ {staging, development}`
+  #      — see `src/components/DebugPanel.tsx :: shouldShowDebugPanel`.
+  #   2. The payload-trace-store env gate (PR #152, PR #156) report
+  #      `payload_inspection_status.enabled === true` with reason
+  #      `app_env_staging_enabled` — see
+  #      `src/lib/payload-trace-store.ts :: determinePayloadInspectionStatus`.
+  # Production (main) does NOT inherit this; the trace-store gate stays
+  # closed by default and the debug panel refuses to render.
+  VITE_APP_ENV = "staging"
+
 # =============================================================================
 # Security Headers (P0 - Enterprise Compliance)
 # =============================================================================

--- a/src/poc/AppPoC.tsx
+++ b/src/poc/AppPoC.tsx
@@ -22,6 +22,23 @@ const PlotWorkspace = lazy(() => import('../routes/PlotWorkspace'))
 const PlcLab = lazy(() => import('../routes/PlcLab'))
 const DecisionTemplates = lazy(() => import('../routes/templates/DecisionTemplates').then(m => ({ default: m.DecisionTemplates })))
 
+// PR #156 follow-up — staging-only debug-export UI.
+// `<DebugPanel />` is the visibility / sizing shell that delegates the
+// actual debug content to `<DebugPanelV2 />`. It is the entry point for
+// the manual debug-bundle export validation surfaced by PR #156.
+//
+// Safety: `<DebugPanel />` has its own multi-gate visibility check in
+// `shouldShowDebugPanel()` (`src/components/DebugPanel.tsx:35`):
+//   1. `VITE_APP_ENV` MUST be `staging` or `development`. In production
+//      builds (`VITE_APP_ENV=production` or any non-allowed value) the
+//      component refuses to render.
+//   2. AND the user must opt in via `?diag` / `?diag=1` (supports both
+//      regular and HashRouter URLs — e.g. `/#/canvas?diag=1`) OR set
+//      `window.__OLUMI_DEBUG = true` in the browser console.
+// Lazy-loaded so the debug code path stays out of the entry chunk
+// production users download.
+const DebugPanel = lazy(() => import('../components/DebugPanel'))
+
 // C.1a: Scenario persistence routes
 const ScenarioListPage = lazy(() => import('../pages/ScenarioListPage'))
 const SharedBriefPage = lazy(() => import('../pages/SharedBriefPage'))
@@ -878,6 +895,15 @@ export default function AppPoC() {
       <QueryClientProvider client={queryClient}>
         <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <AuthProvider>
+            {/* PR #156 follow-up — debug-export UI mount.
+                Lazy-loaded so the production entry chunk stays untouched.
+                Self-gated by `shouldShowDebugPanel()` (staging-only +
+                `?diag` URL param OR `window.__OLUMI_DEBUG = true`).
+                Renders `null` outside the activation window so it has
+                zero visible cost for normal users. */}
+            <Suspense fallback={null}>
+              <DebugPanel />
+            </Suspense>
             <Suspense fallback={<RouteLoadingFallback />}>
               <CanvasErrorBoundary>
                 <Routes>


### PR DESCRIPTION
## Summary

Tiny DGAI-only follow-up to PR #156. **Two files, +41 lines.** Mounts the debug-export UI in `AppPoC` so the manual staging acceptance test from PR #156's brief can actually run on the deployed staging build.

## Root cause this fixes

PR #156's bundle-export pipeline ships and is unit-tested (~487 passing), but the deployed staging build never instantiates the bundle-export UI:

- `src/main.tsx` mounts ONLY `AppPoC.tsx` (the `/#/canvas` shell).
- `<DebugDrawer>` / `<DebugPanel>` / `<DebugPanelV2>` are only mounted from `App.tsx`, which is **not** part of the deployed entry chunk.

Net effect: there is no UI affordance to trigger Export bundle on the live build, so the 8-step manual acceptance can't be executed without programmatic JS injection (which the user explicitly excluded as an acceptance route).

## Changes (DGAI-only, scope-disciplined)

1. **`src/poc/AppPoC.tsx`** — Lazy-import `<DebugPanel />`; mount once inside `<AuthProvider>`, outside `<Routes>`, wrapped in `<Suspense fallback={null}>`. Available on every PoC route without touching first-paint.

2. **`netlify.toml`** — Added `VITE_APP_ENV = "staging"` under `[context.staging.environment]`. This:
   - Makes `<DebugPanel />`'s self-gate (`shouldShowDebugPanel()`) recognise the staging env so the user can opt in via `?diag` / `?diag=1` URL param OR `window.__OLUMI_DEBUG = true`.
   - Aligns the payload-trace-store env gate (`determinePayloadInspectionStatus`) to report `payload_inspection_status.enabled === true` with reason `app_env_staging_enabled` — the path PR #152 / PR #156 tests already cover.

## What was NOT changed

- No PR #156 capture logic touched.
- No CEE / PLoT / ISL / prompts / schemas / packages / lockfile changes.
- No production env vars changed; the `[build.environment]` block is untouched. Production does NOT inherit the staging context, so both the debug UI and the trace-store gate stay **closed by default** in production.
- No new feature flags introduced.
- No keyboard shortcut wired (`Cmd+Shift+D` stays `import.meta.env.DEV`-only in `DebugDrawer.tsx`).

## Safety (defence in depth)

`<DebugPanel />` is **not visible to normal users** even on staging:

1. **Env gate**: `VITE_APP_ENV` must be `staging` or `development`. Production stays off.
2. **Opt-in gate**: even on staging the user must add `?diag` / `?diag=1` to the URL OR set `window.__OLUMI_DEBUG = true` in the console.
3. **First-paint cost**: lazy-loaded behind `<Suspense fallback={null}>`. When neither gate is true, the component returns `null` after first effect.

## Verification

```bash
npm run typecheck                                    # clean
npx vitest run \
  src/components/debug/__tests__/DebugPanelV2.spec.tsx \
  src/lib/__tests__/payload-trace-store.envGate.spec.ts \
  --bail=1                                            # 33 / 33 pass
npx vitest run --changed --bail=1                    # no diff-affected tests
```

Pre-push fast gate (typecheck + lint changed + smoke suite + stale-.js + dep audit + V5 vendored-schemas SHA manifest) all green.

## Test plan

- [ ] After merge, Netlify staging deploy lands cleanly.
- [ ] Hard reload `https://staging--olumi.netlify.app/#/canvas?diag=1`.
- [ ] Open / create a fresh scenario; submit a decision description.
- [ ] Click "Analyse now"; wait for V1 PLoT engine run to complete.
- [ ] Open Debug panel; trigger Export bundle; confirm JSON contains:
  - `payloads.plot_request` populated
  - `payloads.plot_response` populated
  - `payloads.cee_request === null`
  - `payloads.cee_response === null`
  - `analysis_evidence_source === 'live_plot_v1_engine_turn'`
  - `capture_pipeline_status !== 'hydrated_only'`
  - `scientific_validation.source !== 'hydrated_report'`
- [ ] Send a chat message in same session; export again; verify CEE + PLoT coexist.
- [ ] Hard reload (no Run-analysis); export; verify `capture_pipeline_status === 'hydrated_only'`.
- [ ] Confirm in production that `?diag=1` does NOT activate the debug panel (env gate keeps it closed).

PR remains paused for review on `staging`. **Do not merge or deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)