### PR TITLE
fix(pre-analysis): defer empty-state return until after all hooks (Rules of Hooks)

### DIFF
--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -1312,12 +1312,22 @@ export function PreAnalysisPanel({
 
   // Don't show panel if canvas is empty AND not loading
   // When loading, show the "Generating..." placeholder via ModelHealthCard
-  if (!data.isLoading &&
-      data.nodesByKind.goal.length === 0 &&
-      data.nodesByKind.option.length === 0 &&
-      data.nodesByKind.factor.length === 0) {
-    return null
-  }
+  //
+  // The early-return for this empty state has moved to *after* the
+  // remaining hooks below so the panel's hook order stays stable across
+  // renders (Rules of Hooks). Previously, returning null here while later
+  // renders fell through to ~17 additional hooks caused React to throw
+  // "Rendered more hooks than during the previous render" on the
+  // empty → non-empty canvas transition. We instead set a boolean here
+  // and consult it just before the JSX return. The hooks below are pure
+  // useMemo / useCallback / one debug useEffect — running them on the
+  // empty path is cheap (most inputs are empty arrays) and has no side
+  // effect on the empty-state user experience.
+  const isEmptyState =
+    !data.isLoading &&
+    data.nodesByKind.goal.length === 0 &&
+    data.nodesByKind.option.length === 0 &&
+    data.nodesByKind.factor.length === 0
 
   // === READINESS SCORE (for adaptive footer CTA) ===
   // D11: Decision shape — smooth 0–1 score from graph state (replaces completeness heuristic).
@@ -2032,6 +2042,12 @@ export function PreAnalysisPanel({
     : { kind: 'derived', mustFixCount, reviewNextCount }
 
   const isFailed = bannerState.kind === 'failed'
+
+  // Deferred empty-state gate (see `isEmptyState` above). All hooks have now
+  // executed in the same order they will on a populated render, so this
+  // late return cannot trigger the "Rendered more hooks than during the
+  // previous render" error.
+  if (isEmptyState) return null
 
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden" data-testid="pre-analysis-panel">

--- a/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.spec.tsx
@@ -252,6 +252,97 @@ describe('PreAnalysisPanel', () => {
       expect(container.firstChild).toBeNull()
     })
 
+    it('survives the empty → populated transition without a hook-order error (regression)', () => {
+      // Regression guard: before the round-6 fix, `PreAnalysisPanel` early-
+      // returned on the empty-canvas branch BEFORE running ~17 subsequent
+      // hooks. When the canvas later transitioned to having goal/option/
+      // factor nodes, React saw more hooks than the previous render and
+      // threw "Rendered more hooks than during the previous render".
+      //
+      // The fix defers the empty-state `return null` to AFTER all hooks
+      // have executed, so the panel's hook order is stable across renders.
+      //
+      // We assert no console.error fires during the transition — the
+      // hook-order check writes via console.error / a thrown error before
+      // the render commits.
+      const emptyData = createMockData({
+        nodesByKind: {
+          goal: [],
+          decision: [],
+          option: [],
+          factor: [],
+          risk: [],
+          outcome: [],
+        },
+      })
+      const populatedData = createMockData() // defaults: 1 goal + 2 options
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        mockUsePreAnalysisData.mockReturnValue(emptyData)
+        const { container, rerender } = render(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+        // Sanity: empty path returned null on first render.
+        expect(container.firstChild).toBeNull()
+
+        // Now flip the data source to populated (simulates a graph_patch
+        // arriving after the user submitted a brief). With the old early-
+        // return placement, this rerender would throw the hook-count error.
+        mockUsePreAnalysisData.mockReturnValue(populatedData)
+        rerender(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+
+        // Panel now renders (populated path).
+        expect(screen.getByTestId('pre-analysis-panel')).toBeInTheDocument()
+
+        // Hook-order errors surface via console.error before the throw.
+        const hookOrderErrors = consoleErrorSpy.mock.calls.filter((args) => {
+          const msg = String(args[0] ?? '')
+          return /Rendered more hooks|Rules of Hooks|change in the order of Hooks/i.test(msg)
+        })
+        expect(hookOrderErrors).toEqual([])
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
+
+    it('survives the populated → empty transition without a hook-order error (symmetric regression)', () => {
+      // The hook-count violation was bidirectional: an in-graph render
+      // followed by a render where all goal/option/factor nodes were
+      // removed would also trip (more hooks before, fewer after).
+      const populatedData = createMockData()
+      const emptyData = createMockData({
+        nodesByKind: {
+          goal: [],
+          decision: [],
+          option: [],
+          factor: [],
+          risk: [],
+          outcome: [],
+        },
+      })
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        mockUsePreAnalysisData.mockReturnValue(populatedData)
+        const { container, rerender } = render(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+        expect(screen.getByTestId('pre-analysis-panel')).toBeInTheDocument()
+
+        mockUsePreAnalysisData.mockReturnValue(emptyData)
+        rerender(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+        // Empty path returns null on the second render.
+        expect(container.firstChild).toBeNull()
+
+        const hookOrderErrors = consoleErrorSpy.mock.calls.filter((args) => {
+          const msg = String(args[0] ?? '')
+          return /Rendered more hooks|Rules of Hooks|change in the order of Hooks/i.test(msg)
+        })
+        expect(hookOrderErrors).toEqual([])
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
+
     it('renders panel when nodes exist', () => {
       mockUsePreAnalysisData.mockReturnValue(createMockData())
 


### PR DESCRIPTION
## Summary

`PreAnalysisPanel` has a conditional `if (...) return null` at line 1319 followed by ~17 additional `useMemo` / `useCallback` / `useEffect` calls. When the canvas transitions between the empty state (early return) and the populated state (past the return), React sees a different number of hooks executed across renders and throws:

```
Rendered more hooks than during the previous render
```

This is a textbook Rules of Hooks violation. It is **pre-existing on staging** — reproduces on plain `origin/staging` without any other changes — and blocks every flow where the panel mounts on an empty canvas and then receives `goal`/`option`/`factor` nodes. Most notably, it blocks the full browser verification of the AI Panel v2 post-graph UX (see draft PR #158).

## Fix — Option C (smallest safe path)

Replace the early `return null` at line 1319 with a `const isEmptyState` boolean. Move the actual `return null` to immediately before the JSX `return (...)` at line 2036.

```diff
- if (!data.isLoading &&
-     data.nodesByKind.goal.length === 0 &&
-     data.nodesByKind.option.length === 0 &&
-     data.nodesByKind.factor.length === 0) {
-   return null
- }
+ const isEmptyState =
+   !data.isLoading &&
+   data.nodesByKind.goal.length === 0 &&
+   data.nodesByKind.option.length === 0 &&
+   data.nodesByKind.factor.length === 0
  ...
+ if (isEmptyState) return null
  return (
    <div className="flex flex-col flex-1 min-h-0 overflow-hidden" data-testid="pre-analysis-panel">
```

All hooks below the old gate now execute unconditionally. They are all pure `useMemo`/`useCallback` (plus one `useEffect` that is gated by `VITE_DEBUG_PREANALYSIS` and only logs), with proper dependency arrays, so empty-state inputs produce empty-state outputs cheaply and have no side effect on the empty UX.

## Alternatives considered

| Option | Outcome |
|---|---|
| **A** — Lift all 17 hooks above the conditional return | Rejected. The hooks depend on intermediate variables defined between line 1319 and line 1944, so lifting them cascades into a much larger refactor. |
| **B** — Extract a child component containing the post-gate hooks | Viable but requires wiring ~30 props to the child; meaningfully larger diff and prop-stability risk. Worth doing as a separate cleanup pass once this urgent unblock lands. |
| **C** — Defer the `return null` to after the hooks ✅ | Chosen. Smallest possible diff (1 line moved + 5 explanatory lines), no new components, no prop wiring, no behaviour change. |

## Scope

- Only `src/canvas/components/pre-analysis/PreAnalysisPanel.tsx` and its spec file changed.
- **Zero AI Panel v2 files touched** — `AIInputBar`, `FirstUseComposer`, `FloatingOlumiPanel`, `OlumiTabBody`, `OutputsDock`, `useFloatingPanelState`, `MessageBubble`, `typography.ts` all untouched.
- No backend, prompts, schemas, CEE, PLoT, ISL, package files, generated files, or feature-flag changes.

## Test plan

- [x] **2 new regression tests** in `PreAnalysisPanel.spec.tsx`:
  - empty → populated transition (rerender, assert no Rules-of-Hooks `console.error`)
  - populated → empty transition (the bug is bidirectional)
- [x] Confirmed both tests catch the bug **without** the fix: they fail with the exact error messages this PR resolves (`Rendered more hooks than expected` / `Rendered fewer hooks than expected`). Stashed the source change, ran the tests, observed the expected failures, restored, confirmed pass.
- [x] Full `PreAnalysisPanel.spec.tsx`: **67 passing** + 1 pre-existing skip
- [x] Full pre-analysis suite (49 spec files): **737 passing** + 13 pre-existing skips, 0 failures
- [x] Canvas store + buildResultsVM smoke: **107 passing**
- [x] Typecheck clean
- [x] Lint clean on changed files
- [x] Pre-push fast gate passed (typecheck + lint changed files + 459 smoke tests + stale-.js + dep audit + vendored schemas)

## Files changed

| File | Lines |
|---|---|
| `src/canvas/components/pre-analysis/PreAnalysisPanel.tsx` | +22 / −6 |
| `src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.spec.tsx` | +91 / 0 |

## Unblocks

- Draft PR #158 (AI Panel v2 UX correction pass) can rebase onto staging once this lands, then complete the 6 currently-blocked browser-verification states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)