### PR TITLE
layout: panel-aware visible canvas + max-row-fits threshold

### DIFF
--- a/src/canvas/__tests__/layout.spec.ts
+++ b/src/canvas/__tests__/layout.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { layoutGraph, groupByYRow, applyCollisionGuard } from '../utils/layout'
 import type { CanvasSize } from '../utils/layout'
 import {
@@ -484,6 +484,209 @@ describe('ELK Layout', () => {
     expect(dY).toBeLessThan(o1Y)
     expect(o1Y).toBeLessThan(f1Y)
     expect(f1Y).toBeLessThan(gY)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Panel-aware width regression tests
+  //
+  // layoutGraph queries both [data-testid="outputs-dock"] and .react-flow at
+  // the start of every call, then computes visibleCanvasWidth as
+  // (dockEl.left − rfEl.left) — the dock's left edge in canvas-local
+  // coordinates. Naturally captures the dock's width AND its `right:12` CSS
+  // offset because the rect's `.left` already reflects them. Without both
+  // elements mocked (the default in jsdom), querySelector returns null for at
+  // least one → fallback to canvasSize.width → behaviour identical to the
+  // pre-change pipeline.
+  //
+  // Max-width branch fires only when BOTH:
+  //   (a) unclampedElkBoxW ≥ NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X  (existing)
+  //   (b) maxSingleVisibleRowEnd ≤ visibleCanvasWidth              (new)
+  //
+  // Where, for the widest tier of size N:
+  //   maxSingleVisibleRowEnd
+  //     = CANVAS_MARGIN
+  //       + (N − 1) * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + spacing)
+  //       + NODE_CARD_MAX_W
+  // (derived from actual placement geometry — not coupled to the incidental
+  // equality CANVAS_MARGIN === LAYOUT_PADDING_X).
+  //
+  // With current constants (NODE_CARD_MAX_W=256, LAYOUT_PADDING_X=24,
+  // spacing=60, CANVAS_MARGIN=24):
+  //   4-node maxSingleVisibleRowEnd = 24 + 3*340 + 256 = 1300
+  //   5-node maxSingleVisibleRowEnd = 24 + 4*340 + 256 = 1640
+  //
+  // IMPORTANT — "min-width branch fires" ≠ "tier splits into multiple rows".
+  // The min-width branch lowers per-box elkBoxW from 280 to 164 and sets a
+  // nodesPerRow ceiling. Actual row splitting only happens downstream in
+  // `applyTierRowSplitting`, gated by `tierSize > nodesPerRow`. For 4-node
+  // tiers, nodesPerRow ≥ 4 keeps them single-row even when the min-width
+  // branch fires. These tests assert both the branch choice (via
+  // `layoutNodeWidth`) AND the actual visible row count (via
+  // `factorRowCount(laid)`) to keep the distinction explicit.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Count distinct Y-rows occupied by the factor tier. Round to integer to
+   * absorb sub-pixel rounding; row separation is at least
+   * DEFAULT_NODE_HEIGHT + subRowSpacing ≫ 1px, so rounding is safe.
+   */
+  function factorRowCount(nodes: Node[]): number {
+    return new Set(
+      nodes.filter(n => n.type === 'factor').map(n => Math.round(n.position.y)),
+    ).size
+  }
+
+  /**
+   * Mock both the .react-flow container and the [data-testid="outputs-dock"]
+   * element so layoutGraph's panel-aware branch fires deterministically.
+   * Mirrors the real OutputsDock CSS: `position: fixed; right: <offset>;
+   * width: <dockWidth>`. The dock's left position in canvas-local coords is
+   * therefore `canvasWidth - dockRightOffset - dockWidth`.
+   */
+  function mockDockAndCanvas(opts: {
+    canvasWidth: number
+    dockWidth: number
+    dockRightOffset?: number
+    rfLeft?: number
+  }): void {
+    const { canvasWidth, dockWidth, dockRightOffset = 12, rfLeft = 0 } = opts
+    const dockLeft = rfLeft + canvasWidth - dockRightOffset - dockWidth
+    const rfRect = { left: rfLeft, width: canvasWidth, right: rfLeft + canvasWidth } as DOMRect
+    const dockRect = { left: dockLeft, width: dockWidth, right: dockLeft + dockWidth } as DOMRect
+    const rfEl = { getBoundingClientRect: () => rfRect } as unknown as Element
+    const dockEl = { getBoundingClientRect: () => dockRect } as unknown as Element
+    const original = document.querySelector.bind(document)
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '[data-testid="outputs-dock"]') return dockEl
+      if (selector === '.react-flow') return rfEl
+      return original(selector)
+    })
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('panel-aware: 4-factor tier @ 1300px with 480px dock → min-width branch + splits into 2 rows', async () => {
+    // dockLeft = 1300 − 12 − 480 = 808 → visibleCanvasWidth = 808.
+    // maxSingleVisibleRowEnd = 1300 > 808 → condition (b) fails → min-width
+    // branch. nodesPerRow = floor((max(164, 808*0.85) + 60) / (164 + 60))
+    //   = floor((686 + 60) / 224) = 3. Tier size 4 > 3 → applyTierRowSplitting
+    // genuinely splits the tier into 2 rows of 2.
+    // Locks the brief's Task 6 outcome: a dock-occupied 1300px canvas no
+    // longer renders a 1300px row.
+    mockDockAndCanvas({ canvasWidth: 1300, dockWidth: 480 })
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+    ]
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(nodes, edges, {}, TEST_CANVAS)
+    expect(layoutNodeWidth).toBe(NODE_LAYOUT_MIN_W)
+    expect(factorRowCount(laid)).toBe(2)
+  })
+
+  it('panel-aware: 4-factor tier @ 1440px with 416px dock → min-width branch fires; tier stays single row (typical laptop)', async () => {
+    // dockLeft = 1440 − 12 − 416 = 1012 → visibleCanvasWidth = 1012.
+    // maxSingleVisibleRowEnd = 1300 > 1012 → min-width branch. nodesPerRow
+    // = floor((max(164, 1012*0.85) + 60) / (164 + 60)) = floor((860 + 60) /
+    // 224) = 4. Tier size 4 ≤ 4 → NO actual row split (applyTierRowSplitting
+    // skips). Outcome: 4 nodes on one row at NODE_LAYOUT_MIN_W (140) — all
+    // visible (row span = 4 * 164 + 3 * 60 = 836 fits in 1012), but each
+    // card is narrower than the dock-closed max (256).
+    //
+    // This case demonstrates the smarter threshold: the brief's panel-aware
+    // availableWidth change alone would NOT trigger min-width fallback here
+    // (per-box min check still passes: avail = 860; per-box = floor((860-90)
+    // /4) = 192 ≥ 164). Only the new max-row-fits check forces fallback.
+    mockDockAndCanvas({ canvasWidth: 1440, dockWidth: 416 })
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+    ]
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(
+      nodes,
+      edges,
+      {},
+      { width: 1440, height: 900 },
+    )
+    expect(layoutNodeWidth).toBe(NODE_LAYOUT_MIN_W)
+    expect(factorRowCount(laid)).toBe(1)
+  })
+
+  it('panel-aware: 4-factor tier @ 1920px with 416px dock → max-width branch fires; tier stays single row', async () => {
+    // dockLeft = 1920 − 12 − 416 = 1492 → visibleCanvasWidth = 1492.
+    // maxSingleVisibleRowEnd = 1300 ≤ 1492 → max-width branch fires (no
+    // min-width fallback). Locks the high-end behaviour so we do not
+    // accidentally over-trigger the min-width fallback at wide viewports
+    // where the row genuinely fits the visible canvas.
+    mockDockAndCanvas({ canvasWidth: 1920, dockWidth: 416 })
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+    ]
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(
+      nodes,
+      edges,
+      {},
+      { width: 1920, height: 1080 },
+    )
+    expect(layoutNodeWidth).toBe(NODE_CARD_MAX_W)
+    expect(factorRowCount(laid)).toBe(1)
+  })
+
+  it('panel-aware: 4-factor tier @ 1300px with 40px collapsed-rail dock → min-width branch fires; tier stays single row', async () => {
+    // The OutputsDock is always mounted: when closed it collapses to a 40px
+    // rail (CSS var --dock-right-collapsed). With NODE_CARD_MAX_W=256 the
+    // 4-node row is sized to exactly fit a 1300px canvas — so even a thin
+    // 40px rail at the right makes the rendered row overflow into the rail.
+    //
+    // dockLeft = 1300 − 12 − 40 = 1248 → visibleCanvasWidth = 1248.
+    // maxSingleVisibleRowEnd = 1300 > 1248 → min-width branch fires.
+    // nodesPerRow = floor((max(164, 1248*0.85) + 60) / (164 + 60))
+    //   = floor((1060 + 60) / 224) = 5. Tier size 4 ≤ 5 → NO row split.
+    // Outcome: 4 nodes on one row at NODE_LAYOUT_MIN_W; row span = 4 * 164 +
+    // 3 * 60 = 836 fits within visibleCanvasWidth (1248).
+    //
+    // Locks this behaviour explicitly. The trade-off (lose ~116px of card
+    // width to avoid 52px of overlap with the thin rail) is the cost of the
+    // exact-fit NODE_CARD_MAX_W from PR #157; if a future change wants to
+    // tolerate small rail overlap, this test will surface the inversion.
+    mockDockAndCanvas({ canvasWidth: 1300, dockWidth: 40 })
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+    ]
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(nodes, edges, {}, TEST_CANVAS)
+    expect(layoutNodeWidth).toBe(NODE_LAYOUT_MIN_W)
+    expect(factorRowCount(laid)).toBe(1)
   })
 })
 

--- a/src/canvas/utils/layout.ts
+++ b/src/canvas/utils/layout.ts
@@ -85,7 +85,33 @@ export async function layoutGraph(
   }
   const maxTierCount = Math.max(...tierCounts.values())
 
-  const availableWidth = canvasSize.width * 0.85
+  // Panel-aware visible canvas. OutputsDock is a position:fixed overlay so
+  // canvasSize.width (the .react-flow container) does not shrink when the dock
+  // is mounted. Query the dock and the canvas container and use their bounding
+  // rects to compute the visible canvas right boundary in canvas-local coords
+  // (dockLeft − rfLeft). This naturally captures both the dock's width and its
+  // `right` margin (the rect's `.left` already reflects them), avoiding the
+  // off-by-12 error of `canvasSize.width − dockWidth`.
+  //
+  // SSR-guarded; in jsdom tests without both elements mocked, querySelector
+  // returns null for at least one → fallback to canvasSize.width → behaviour
+  // identical to the pre-change pipeline.
+  const MIN_BOX_W = NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X
+  let visibleCanvasWidth = canvasSize.width
+  if (typeof document !== 'undefined') {
+    const dockEl = document.querySelector('[data-testid="outputs-dock"]')
+    const rfEl = document.querySelector('.react-flow')
+    if (dockEl && rfEl) {
+      const dockLeft = dockEl.getBoundingClientRect().left
+      const rfLeft = rfEl.getBoundingClientRect().left
+      const computed = dockLeft - rfLeft
+      if (computed > 0) visibleCanvasWidth = computed
+    }
+  }
+  visibleCanvasWidth = Math.max(MIN_BOX_W, visibleCanvasWidth)
+
+  const availableWidth = Math.max(MIN_BOX_W, visibleCanvasWidth * 0.85)
+
   const isDownLayout = direction === 'DOWN'
 
   let elkBoxW: number
@@ -94,8 +120,30 @@ export async function layoutGraph(
 
   if (isDownLayout && maxTierCount > 1) {
     const unclampedElkBoxW = Math.floor((availableWidth - (maxTierCount - 1) * MIN_GAP) / maxTierCount)
+    // Visible right edge of the rightmost node after centreRowsOnSpine +
+    // applyGlobalTranslation. The widest tier's leftmost lands at
+    // CANVAS_MARGIN, the rightmost is (N−1) strides further, and the
+    // rightmost node's visible right edge is NODE_CARD_MAX_W beyond its left.
+    //
+    // Derived directly from placement geometry — does NOT rely on the
+    // incidental equality CANVAS_MARGIN === LAYOUT_PADDING_X (= 24 today).
+    // A future tweak to either constant keeps this formula correct because
+    // it mirrors what the layout actually produces.
+    const maxSingleVisibleRowEnd =
+      CANVAS_MARGIN
+      + (maxTierCount - 1) * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + effectiveNodeSpacing)
+      + NODE_CARD_MAX_W
 
-    if (unclampedElkBoxW >= NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X) {
+    // Max-single fires only if BOTH:
+    //   1. Per-box min-width threshold passes (existing — keeps ELK from
+    //      receiving degenerate sub-min per-box widths).
+    //   2. The rendered row's visible right edge fits within the visible
+    //      canvas (new — stops the row spanning behind the OutputsDock at
+    //      typical laptop viewports). Compared against `visibleCanvasWidth`
+    //      (raw, no 0.85 factor) because we're asking whether the row
+    //      actually fits visibly, not whether ELK can place the boxes with
+    //      margin.
+    if (unclampedElkBoxW >= MIN_BOX_W && maxSingleVisibleRowEnd <= visibleCanvasWidth) {
       elkBoxW = NODE_CARD_MAX_W + LAYOUT_PADDING_X
       gap = effectiveNodeSpacing
     } else {


### PR DESCRIPTION
> **Draft — visual review on staging deploy required before merge.** Not part of the AI Panel v2 work (PR #158 is already merged into staging; this branches off the post-#158 staging HEAD `5335be78`).

## Summary

Makes the deterministic ELK layout aware of the right-hand `OutputsDock` overlay so 4-node tiers stop rendering behind the dock at typical laptop viewports.

Two changes in `src/canvas/utils/layout.ts`:

1. **Panel-aware visible canvas.** Query `[data-testid="outputs-dock"]` and `.react-flow` and compute `visibleCanvasWidth = dockEl.left - rfEl.left`. The rect's `.left` already reflects the dock's `right: 12` CSS offset, so the math captures it without hardcoding. SSR-guarded; jsdom without both elements mocked falls back to `canvasSize.width` (identical to pre-change pipeline).

2. **Smarter max-width threshold.** The pre-existing branch only checked that *min-width per box* would fit — which let a 1300px row span behind the dock even when only ~1000px was visible. The new condition also checks that the *rendered max-width row's visible right edge* fits the visible canvas. The fit metric is derived from placement geometry (`CANVAS_MARGIN + (N-1)*stride + NODE_CARD_MAX_W`) rather than the box-footprint formula, so it does not silently desync if `CANVAS_MARGIN` or `LAYOUT_PADDING_X` ever change.

## Important distinction — min-width branch ≠ row splitting

This is the most easily-conflated point in the change:

- **"Min-width branch fires"** means the threshold condition above failed, so `elkBoxW` drops from 280 → 164 and `nodesPerRow` is computed. This always happens when the row wouldn't fit visibly.
- **"Tier splits into multiple rows"** is a separate downstream decision, gated in `applyTierRowSplitting` by `tierSize > nodesPerRow`. For 4-node tiers, `nodesPerRow ≥ 4` keeps them on **one** row even when the min-width branch fired — all 4 cards visible, just at the narrower 140px width.

Only when the visible canvas is tight enough that `nodesPerRow < tierSize` do rows actually split.

## Corrected boundary table

`NODE_CARD_MAX_W = 256` (from PR #157), so `maxSingleVisibleRowEnd = 24 + 3*340 + 256 = 1300` for 4-node tiers. Dock right offset = 12px.

| canvas | Dock width | visible | Branch fires | Actual rows |
|---|---|---|---|---|
| 1300 | 480 | 808 | min-width | **2** (true split, `nodesPerRow=3 < 4`) |
| 1300 | 40 (collapsed rail) | 1248 | min-width | **1** (`nodesPerRow=5 ≥ 4`) |
| 1440 | 416 | 1012 | min-width | **1** (`nodesPerRow=4 ≥ 4`) — typical laptop |
| 1716 | 416 | 1288 | min-width | **1** (`nodesPerRow=5 ≥ 4`) |
| 1728 | 416 | 1300 | max-width | **1** (exact-fit boundary) |
| 1920 | 416 | 1492 | max-width | **1** |
| any | none mounted (jsdom / SSR) | full canvas | unchanged | unchanged |

At typical laptops the practical outcome is *"4 cards visible at min width (140) on one row"* — not multi-row. That's the intended trade-off given `NODE_CARD_MAX_W=256` is sized for exact-fit at canvas=1300.

## Known follow-up — NOT part of this PR

**`canvasSize` freshness across deferred layout paths.** The new DOM dock math is only as good as the `canvasSize` argument paired with it. Several auto-layout paths call `setPendingLayout(true)` without first refreshing `canvasSize`, so they may pass a stale value (or the 1300 fallback). Centralising the canvas-size capture before each `setPendingLayout` call is a separate architectural change. A reviewer flagged this twice; documenting here so it isn't forgotten.

**Re-layout on dock open/close/resize.** Layout only fires on template insertion or manual apply; opening the dock mid-session does not re-trigger `layoutGraph`. Existing laid-out graphs can therefore still overlap the dock until the next layout pass. Separate brief.

## Test matrix

`src/canvas/__tests__/layout.spec.ts`:

| Test | Asserts |
|---|---|
| 1300+480 dock → min-width branch + splits to 2 rows | `layoutNodeWidth === NODE_LAYOUT_MIN_W` + `factorRowCount === 2` |
| 1440+416 dock (typical laptop) → min-width, single row | `layoutNodeWidth === NODE_LAYOUT_MIN_W` + `factorRowCount === 1` |
| 1920+416 dock → max-width branch, single row | `layoutNodeWidth === NODE_CARD_MAX_W` + `factorRowCount === 1` |
| 1300+40 collapsed rail → min-width, single row | `layoutNodeWidth === NODE_LAYOUT_MIN_W` + `factorRowCount === 1` |

Each test mocks both `[data-testid="outputs-dock"]` and `.react-flow` via the new `mockDockAndCanvas` helper, with configurable dock right offset (default 12 mirroring the OutputsDock CSS). `factorRowCount` is a small new helper that counts distinct Y-rows in the factor tier.

The PR #157 exact-fit regression test (4-factor tier on 1300px canvas: locks exact-fit boundary) **still passes unchanged**: jsdom returns null for the selectors → fallback to `canvasSize.width` → behaviour identical to pre-change.

## Verification

- [x] 9 layout/lifecycle/BaseNode specs — **121/121 tests pass** locally
- [x] `npm run typecheck` — exit 0, 0 errors
- [x] Pre-push fast gate — all checks passed (incl. 459-test smoke suite)
- [ ] Visual review on staging deploy — at typical 1440px viewport with dock open, confirm 4-node tiers no longer extend behind the dock
- [ ] CI full ~6,284-test suite (post-merge, via `staging-full-tests.yml`)

## Out of scope

- `NODE_CARD_MAX_W`, `NODE_LAYOUT_MIN_W`, `LAYOUT_PADDING_X/Y`, `MIN_GAP`, the 0.85 breathing factor, ELK config
- `centreRowsOnSpine` / `applyGlobalTranslation` — centring still happens on graph spine
- BaseNode.tsx source — already uses NODE_CARD_MAX_W via import
- Any caller-side measurement code (`DraftChat.tsx`, `LayoutOptionsPanel.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)