### PR TITLE
feat(ai-panel-v2): flip flag default ON — Olumi panel is now the primary surface

### DIFF
--- a/src/canvas/components/__tests__/aiPanelV2.parity.spec.tsx
+++ b/src/canvas/components/__tests__/aiPanelV2.parity.spec.tsx
@@ -1,13 +1,21 @@
 /**
- * FF-off parity for aiPanelV2.
+ * Flag default + rollback parity for aiPanelV2.
  *
- * Combines the flag-default check with render-level assertions:
- *  - When flag is OFF, OUTPUT_TABS_FOR_PARITY contains no 'olumi' tab.
- *  - When flag is OFF, the new aiPanelV2 surfaces (PersistentInputStrip,
- *    FloatingOlumiPanel, FirstUseComposer) all early-return null OR fail
- *    safely without a ConversationProvider in scope — guaranteeing they
- *    cannot leak into the legacy DraftChat experience.
- *  - When flag is ON, OUTPUT_TABS contains 'olumi'.
+ * As of this PR the aiPanelV2 flag's in-code default is ON — the
+ * floating-first AI Panel v2 is the primary composer surface. The
+ * legacy DraftChat path stays reachable via explicit FF-off override
+ * (`localStorage.setItem('feature.aiPanelV2', 'false')` or
+ * `VITE_FEATURE_AI_PANEL_V2=false`) so emergency rollback works.
+ *
+ * Tests assert:
+ *  - Flag defaults to TRUE when no env/localStorage override is set.
+ *  - localStorage="false" forces the flag OFF (rollback escape hatch).
+ *  - localStorage="true" keeps it ON.
+ *  - When flag is OFF, OUTPUT_TABS contains no 'olumi' tab (legacy path).
+ *  - When flag is ON (default), OUTPUT_TABS contains 'olumi'.
+ *  - Surfaces that should be invisible without an active selection /
+ *    stale analysis (SelectionPill, StaleAnalysisBadge) still render
+ *    nothing in the default state.
  *
  * We do NOT mount full OutputsDock here — the surrounding canvas store
  * setup is too heavy and the supabase/threadService dependency chain
@@ -51,7 +59,7 @@ vi.mock('../../hooks/useV2Run', () => ({
   useV2Run: () => ({ runV2Analysis: () => Promise.resolve() }),
 }))
 
-describe('FF-off parity (aiPanelV2 default)', () => {
+describe('aiPanelV2 default (round-12: default-ON, rollback via localStorage="false")', () => {
   beforeEach(() => {
     try {
       window.localStorage.removeItem('feature.aiPanelV2')
@@ -59,18 +67,18 @@ describe('FF-off parity (aiPanelV2 default)', () => {
     useFloatingPanelState.getState().reset()
   })
 
-  it('flag defaults to false when no env/localStorage override is set', async () => {
+  it('flag defaults to TRUE when no env/localStorage override is set', async () => {
     const flags = await import('../../../flags')
-    expect(flags.isAiPanelV2Enabled()).toBe(false)
+    expect(flags.isAiPanelV2Enabled()).toBe(true)
   })
 
-  it('localStorage="true" flips the flag', async () => {
+  it('localStorage="true" keeps the flag on (idempotent with default)', async () => {
     window.localStorage.setItem('feature.aiPanelV2', 'true')
     const flags = await import('../../../flags')
     expect(flags.isAiPanelV2Enabled()).toBe(true)
   })
 
-  it('localStorage="false" keeps the flag off', async () => {
+  it('localStorage="false" forces the flag OFF (rollback escape hatch)', async () => {
     window.localStorage.setItem('feature.aiPanelV2', 'false')
     const flags = await import('../../../flags')
     expect(flags.isAiPanelV2Enabled()).toBe(false)
@@ -95,8 +103,11 @@ describe('FF-off parity (aiPanelV2 default)', () => {
       vi.resetModules()
     })
 
-    it('OUTPUT_TABS list does NOT include "olumi" when flag is off', async () => {
-      window.localStorage.removeItem('feature.aiPanelV2')
+    it('OUTPUT_TABS list does NOT include "olumi" when flag is explicitly disabled (rollback)', async () => {
+      // Round-12: default is ON, so the FF-off path is only entered with
+      // an explicit localStorage="false" override (or env=false). This
+      // test exercises that rollback escape hatch.
+      window.localStorage.setItem('feature.aiPanelV2', 'false')
       const { getOutputTabsForParity } = await import('../OutputsDock')
       const ids = getOutputTabsForParity().map((t) => t.id)
       expect(ids).not.toContain('olumi')
@@ -106,8 +117,9 @@ describe('FF-off parity (aiPanelV2 default)', () => {
       expect(ids).toEqual(expect.arrayContaining(['results', 'diagnostics']))
     })
 
-    it('OUTPUT_TABS list DOES include "olumi" when flag is on', async () => {
-      window.localStorage.setItem('feature.aiPanelV2', 'true')
+    it('OUTPUT_TABS list DOES include "olumi" by default (flag default-ON)', async () => {
+      // Round-12: no override needed — default is ON.
+      window.localStorage.removeItem('feature.aiPanelV2')
       const { getOutputTabsForParity } = await import('../OutputsDock')
       const ids = getOutputTabsForParity().map((t) => t.id)
       expect(ids).toContain('olumi')

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -355,7 +355,10 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
 
 describe('SuggestedChips — FF-off legacy parity (no polish)', () => {
   beforeEach(() => {
-    try { localStorage.removeItem('feature.aiPanelV2') } catch {}
+    // Round-12: aiPanelV2 flag now defaults to TRUE, so `removeItem` no
+    // longer engages the FF-off path. Explicit "false" override drives
+    // the legacy parity branch.
+    try { localStorage.setItem('feature.aiPanelV2', 'false') } catch {}
     vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', '')
     setAnalysisState('current')
   })

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -322,6 +322,14 @@ const FLAGS_CONFIG = {
   aiPanelV2: {
     envKey: 'VITE_FEATURE_AI_PANEL_V2',
     storageKey: 'feature.aiPanelV2',
+    // Default ON. The floating-first AI Panel v2 is now the primary
+    // composer surface. The legacy DraftChat path remains reachable via
+    // `localStorage.setItem('feature.aiPanelV2', 'false')` and/or
+    // `VITE_FEATURE_AI_PANEL_V2=false` for emergency rollback; the FF-off
+    // branches in OutputsDock / ReactFlowGraph / CanvasToolbar / etc. are
+    // intentionally preserved as a fallback rather than archived in this
+    // PR (separate clean-up PR will move the orphaned legacy files).
+    defaultValue: true,
   },
   // V5 canonical analysis path — when ON, all user-visible analysis triggers
   // (OutputsDock "Run", Compare-tab rerun, goal-threshold rerun) route through


### PR DESCRIPTION
## Summary

- Add `defaultValue: true` to the `aiPanelV2` flag config in `src/flags.ts` so the floating-first AI Panel v2 is the default composer surface for everyone (previously required a localhost localStorage opt-in or staging env var).
- Update the parity spec to assert default-ON and rename it to reflect the new contract (`aiPanelV2 default (round-12: default-ON, rollback via localStorage='false')`).
- Update one FF-off legacy-parity test in `SuggestedChips.aiPanelV2Polish.spec.tsx` to explicitly set `feature.aiPanelV2=false` instead of relying on the (former) default-OFF.

## Why

User feedback was that they kept seeing the legacy DraftChat surface on localhost because the flag's in-code default was OFF; the new Olumi panel only appeared with an explicit `localStorage.setItem('feature.aiPanelV2', 'true')` opt-in. After rounds 1–11 of UX correction work (PRs #152, #154, #158, #160, #161) the Olumi experience is the intended primary surface, so the default should match.

## Scope deliberately preserved (NOT changed in this PR)

- All ten flag-gated callsites still branch on `isAiPanelV2Enabled()` — no inlining of the FF-on path.
- `DraftChat.tsx` + `showDraftChat` store fields stay in place.
- Tests for both FF-on and FF-off branches continue to run.

A separate clean-up PR will move the orphaned legacy files into an archive folder once this default-flip is verified on staging.

## Rollback escape hatches (preserved)

- Browser: `localStorage.setItem('feature.aiPanelV2', 'false')` + reload.
- Build/deploy: `VITE_FEATURE_AI_PANEL_V2=false`.

The factory's resolution order (`src/lib/flagFactory.ts`) is unchanged: localStorage > env var > defaultValue. Only the defaultValue moved.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npx vitest run src/canvas/components/__tests__/aiPanelV2 src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish src/canvas/conversation/__tests__/MessageBubble.followUp.ffOff src/canvas/conversation/__tests__/MessageBubble.actions` — 66/66 pass.
- [x] Pre-push fast gate — 459 smoke tests + lint + dep audit + stale-.js + vendored schemas, all passed.
- [ ] Staging deploy — confirm localhost (post-merge) shows the new hero on an empty canvas without any localStorage poke.
- [ ] Rollback smoke — `localStorage.setItem('feature.aiPanelV2', 'false')` + reload still renders legacy DraftChat.
- [ ] CI full suite — pre-existing `useConversation.hook.spec.ts` failures (38/64, `getV5Endpoint` mock missing) reproduce on plain `origin/staging` and are not my regression; tracked under MEMORY.md > Pre-existing Test Failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)