### PR TITLE
fix(ai-panel-v2): floating composer 3-line min + grow + flush tab seam

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -52,16 +52,27 @@ export interface AIInputBarProps {
 const MAX_LINES = 2
 const LINE_HEIGHT_PX = 18
 /**
- * Welcome hero variant: round-12 UX correction. The rest-state textarea
- * is THREE lines tall (≈70px = 18*3 + 16) so the absolutely-positioned
- * cog + send icon stack (32px + 4px gap + 32px = 68px) fits comfortably
- * INSIDE the textarea border without overflowing into the surrounding
- * canvas. Three lines reads as an invitation (you can type a sentence
- * or two) rather than a form (14-line monolith from round-8). It still
- * grows organically as the user types, capped at 12 lines.
+ * Welcome hero variant: the rest-state textarea is THREE lines tall
+ * (≈70px = 18*3 + 16) so the absolutely-positioned cog + send icon
+ * stack (32px + 4px gap + 32px = 68px) fits comfortably INSIDE the
+ * textarea border. Grows on type up to 12 lines.
  */
 const WELCOME_MIN_LINES = 3
 const WELCOME_MAX_LINES = 12
+
+/**
+ * Floating Olumi panel variant: round-13 UX. The floating panel's footer
+ * composer (variant='floating') previously inherited the default 1-line
+ * min and 2-line max, so the cog + send icon stack (28px + 2px gap + 28px
+ * = 58px) overflowed the textarea and the composer felt cramped during
+ * follow-up questions. Bump the rest state to 3 lines (≈70px) so the
+ * icon stack fits with breathing room, and allow growth up to 8 lines
+ * (≈160px) before internal scroll engages — generous enough for a
+ * multi-sentence follow-up without crowding the conversation history
+ * above.
+ */
+const FLOATING_MIN_LINES = 3
+const FLOATING_MAX_LINES = 8
 
 /**
  * AIInputBar — single shared composer used by the persistent strip, the docked
@@ -107,6 +118,7 @@ export const AIInputBar = memo(
     // and emits auto-apply graph patches.
     const nodeCount = useCanvasStore((s) => s.nodes.length)
     const isWelcome = variant === 'welcome'
+    const isFloating = variant === 'floating'
 
     useImperativeHandle(
       ref,
@@ -118,10 +130,22 @@ export const AIInputBar = memo(
     )
 
     // Auto-grow up to the variant's max line count, then scroll inside.
-    // Welcome hero starts at 1 line and grows organically as the user
-    // types (Claude-style), capped at 12 lines before internal scroll.
-    const minLines = isWelcome ? WELCOME_MIN_LINES : 1
-    const maxLines = isWelcome ? WELCOME_MAX_LINES : MAX_LINES
+    // - welcome: 3-line rest, grows to 12 lines (hero composer).
+    // - floating: 3-line rest, grows to 8 lines (panel footer composer).
+    //   Round-13: needs ≥ 3 lines so cog + send icons fit inside without
+    //   overflowing the textarea border; grows on type for follow-ups.
+    // - strip / docked-tab / first-use: 1-line rest, grows to 2 lines
+    //   (compact surfaces).
+    const minLines = isWelcome
+      ? WELCOME_MIN_LINES
+      : isFloating
+        ? FLOATING_MIN_LINES
+        : 1
+    const maxLines = isWelcome
+      ? WELCOME_MAX_LINES
+      : isFloating
+        ? FLOATING_MAX_LINES
+        : MAX_LINES
     const minHeightPx = LINE_HEIGHT_PX * minLines + 16
     const maxHeightPx = LINE_HEIGHT_PX * maxLines + 16
     useLayoutEffect(() => {

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -728,7 +728,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
       role="dialog"
       aria-label="Olumi conversation"
       data-testid="floating-olumi-panel"
-      className="fixed bg-panel border border-panel-border rounded-lg shadow-2 flex flex-col"
+      className="fixed bg-panel border border-panel-border rounded-r-lg shadow-2 flex flex-col"
       style={{
         zIndex: 300,
         width: 400,


### PR DESCRIPTION
## Summary

- **Floating-panel composer**: bump `FLOATING_MIN_LINES` from 1 → 3 (34px → 70px rest height) so the cog + send icon stack (28+2+28=58px) fits inside the textarea border. Bump `FLOATING_MAX_LINES` from 2 → 8 so the composer grows generously as the user types follow-up questions.
- **Side tab seam**: change the floating panel's root from `rounded-lg` (all four corners) to `rounded-r-lg` (right corners only). The panel's left corners are now square, so the side tab's flat right edge butts directly against the panel's flat left edge with no visible quarter-circle gap.

## Why

Round-12 user feedback after testing the merged hero on staging:

> "Double the height of the text input so both of the right-hand icon buttons fit comfortably within it. Also, the text box should expand to accommodate the text the user enters."

> "[The side tab] feels disconnected. There is a little bit of a gap between the rounded corner of the AI panel and the tab."

The user picked **square the panel's left corners** from a three-way option set (vs. overlap-by-1px or accept-the-gap-with-separate-pills).

## Scope

- Strip / docked-tab / first-use composer variants are unchanged (still 1-line rest, 2-line max — compact surfaces).
- Welcome (hero) variant unchanged (3-line rest, 12-line max — already shipped in PR #161).
- Side tab CSS (rounded-l-lg, border, position) unchanged.
- No flag changes; no test deletions.

## Test plan

- [x] `npm run typecheck` — clean
- [x] 25/25 related specs pass (FirstUseComposer + FloatingOlumiPanel.density)
- [x] Pre-push fast gate green (459 smoke tests + lint + dep audit + vendored schemas)
- [ ] Staging verification: after merge, draft any decision; open the floating panel — confirm cog + send fit inside the textbox with breathing room, the textbox grows as you type a follow-up, and the side tab joins the panel's left edge with no visible gap.

## Geometry note

Floating-variant `minHeight = LINE_HEIGHT_PX (18) × WELCOME_MIN_LINES_alike (3) + 16 = 70px`. Same formula as the welcome hero, whose 70px result is already pinned by `FirstUseComposer.spec.tsx`. The browser preview can't easily reach the floating-panel state without a working CEE draft; deferred to staging verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)