### PR TITLE
fix(ai-panel-v2): persistent-strip chevron float-out (round-14 regression)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -448,6 +448,37 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     }
   }, [state.activeTab])
   const openFloatingByUser = useFloatingPanelState((s) => s.open)
+
+  // Round-14: coordinates a user-initiated float-out from ANY trigger
+  // (the OlumiTabBody float-out icon, the persistent strip's chevron, the
+  // strip's redirect-mode button click). When the active dock tab is
+  // 'olumi', we must swap it to a non-Olumi fallback BEFORE opening the
+  // floating panel — otherwise FloatingOlumiPanel's render-time
+  // yieldToDockedOlumi guard suppresses the panel mount and the user
+  // sees nothing. The sessionStorage write is synchronous so the
+  // floating panel's persisted-state fallback read agrees with the
+  // React state on the very first render (useDockState's effect-based
+  // write would land too late). When activeTab is not 'olumi', the
+  // swap is skipped — just opens the panel.
+  const floatOutToWindow = () => {
+    if (state.activeTab === 'olumi') {
+      const fallback = lastNonOlumiTabRef.current
+      try {
+        const cur = JSON.parse(sessionStorage.getItem(OUTPUTS_DOCK_STORAGE_KEY) || '{}')
+        sessionStorage.setItem(
+          OUTPUTS_DOCK_STORAGE_KEY,
+          JSON.stringify({ ...cur, activeTab: fallback }),
+        )
+      } catch {
+        // sessionStorage blocked (private mode, quota). The React
+        // setState below still runs; useDockState's effect catches up.
+      }
+      setState((prev) => ({ ...prev, activeTab: fallback }))
+      useUIStore.getState().setActiveOutputTab(fallback as OutputTab)
+    }
+    openFloatingByUser('user')
+  }
+
   const transitionReceipt = useTransitionReceipt((s) => s.receipt)
   // Cog popover anchor — strip footer-stack only.
   const [cogAnchor, setCogAnchor] = useState<HTMLElement | null>(null)
@@ -2035,38 +2066,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 data-testid="olumi-tab-wrapper"
                 aria-hidden={effectiveActiveTab !== 'olumi'}
               >
-                <OlumiTabBody onFloatOut={() => {
-                  // The user wants to leave the docked surface for the
-                  // floating window. We must switch the active tab away
-                  // from 'olumi' first — otherwise FloatingOlumiPanel's
-                  // yieldToDockedOlumi render-time guard + OutputsDockBody's
-                  // close-floating guard effect would together suppress
-                  // the panel the moment it opened.
-                  //
-                  // Prefer the user's last non-Olumi tab so they return to
-                  // their previous Analysis/Compare/Model/Journey context
-                  // rather than always landing on Analysis.
-                  const fallback = lastNonOlumiTabRef.current
-                  // CRITICAL (round-8 fix): write sessionStorage SYNCHRONOUSLY
-                  // before opening the floating panel. useDockState writes via
-                  // a post-commit useEffect, so without this write the floating
-                  // panel's render-time yield gate (which reads sessionStorage
-                  // as a fallback) would still see the stale 'olumi' value and
-                  // suppress the panel mount. Pre-empting the write here keeps
-                  // both sources of truth (sessionStorage + useUIStore) in
-                  // sync at the exact moment the floating panel re-renders.
-                  try {
-                    const cur = JSON.parse(sessionStorage.getItem(OUTPUTS_DOCK_STORAGE_KEY) || '{}')
-                    sessionStorage.setItem(OUTPUTS_DOCK_STORAGE_KEY, JSON.stringify({ ...cur, activeTab: fallback }))
-                  } catch {
-                    // sessionStorage may be blocked (private mode, quota).
-                    // Fallback: the React setState below still runs; the
-                    // useDockState effect will catch up post-commit.
-                  }
-                  setState((prev) => ({ ...prev, activeTab: fallback }))
-                  useUIStore.getState().setActiveOutputTab(fallback as OutputTab)
-                  openFloatingByUser('user')
-                }} />
+                <OlumiTabBody onFloatOut={floatOutToWindow} />
               </div>
             )}
           </div>
@@ -2082,7 +2082,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             <StaleAnalysisBadge />
             <PersistentInputStrip
               isOlumiTabActive={effectiveActiveTab === 'olumi'}
-              onOpenFloating={() => openFloatingByUser('user')}
+              onOpenFloating={floatOutToWindow}
               onFocusFloating={focusFloating}
               onCogClick={handleCogClick}
             />

--- a/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
@@ -489,6 +489,71 @@ describe('Olumi tab click while floating is open', () => {
     useCanvasStore.setState({ nodes: [] } as any)
   })
 
+  it('persistent strip chevron from Olumi tab opens floating panel (round-14 regression)', async () => {
+    // Round-14 P0: when the user is on the docked Olumi tab and the
+    // floating panel is closed, the persistent strip renders the
+    // AIInputBar variant='strip' with a chevron-up button. Clicking the
+    // chevron must open the floating panel — and to do so, the active
+    // tab must be swapped away from 'olumi' BEFORE the open() call.
+    // Without the swap, FloatingOlumiPanel's render-time
+    // yieldToDockedOlumi guard suppresses the panel mount and the user
+    // sees nothing happen.
+    //
+    // Bug history: round-3 fixed the OlumiTabBody float-out icon path.
+    // Round-8 added the synchronous sessionStorage write. Round-14
+    // extracts both into a single `floatOutToWindow` helper and applies
+    // it to BOTH the float-out icon AND the persistent strip's
+    // onOpenFloating handler — previously the strip's chevron called
+    // openFloatingByUser('user') without the tab swap, regressing the
+    // round-3 fix for users who routed through the strip instead of the
+    // OlumiTabBody icon.
+    const { fireEvent } = await import('@testing-library/react')
+    const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')
+    const { useUIStore } = await import('../../../stores/uiStore')
+    const { useCanvasStore } = await import('../../store')
+    const { OutputsDock } = await import('../OutputsDock')
+
+    // Pre-state: graph exists (dock expanded), activeTab='olumi',
+    // floating closed.
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+    } as any)
+    useUIStore.setState({ activeOutputTab: 'olumi', activeOutputTabVersion: 0 })
+    useFloatingPanelState.getState().reset()
+    try {
+      sessionStorage.setItem(
+        'canvas.outputsDock.v1',
+        JSON.stringify({ isOpen: true, activeTab: 'olumi' }),
+      )
+    } catch {}
+
+    const { findByTestId } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    // Persistent strip renders the AIInputBar variant='strip' with a
+    // chevron when isOlumiTabActive=true && floating closed. The chevron
+    // testid is wired by AIInputBar as `${testId ?? 'ai-input-bar-${variant}'}-chevron`.
+    const chevron = (await findByTestId('ai-input-bar-strip-chevron')) as HTMLElement
+    fireEvent.click(chevron)
+    await new Promise((r) => setTimeout(r, 50))
+
+    // After the click, the floating panel must be OPEN and the active
+    // tab must have swapped away from 'olumi' so the yield gate clears.
+    expect(useFloatingPanelState.getState().isOpen).toBe(true)
+    expect(useUIStore.getState().activeOutputTab).not.toBe('olumi')
+    // Synchronous sessionStorage write keeps the render-time fallback
+    // read in agreement.
+    const persisted = JSON.parse(sessionStorage.getItem('canvas.outputsDock.v1') || '{}').activeTab
+    expect(persisted).not.toBe('olumi')
+
+    // Cleanup.
+    try { sessionStorage.removeItem('canvas.outputsDock.v1') } catch {}
+    useCanvasStore.setState({ nodes: [] } as any)
+  })
+
   it('falls through to normal tab activation when floating is CLOSED', async () => {
     const { fireEvent } = await import('@testing-library/react')
     const { useFloatingPanelState } = await import('../../hooks/useFloatingPanelState')


### PR DESCRIPTION
## Summary

Single-file behaviour fix (plus a regression spec). The persistent-strip chevron's float-out handler now goes through the same tab-swap + sync-sessionStorage helper the OlumiTabBody float-out icon already uses. Extracted both into `floatOutToWindow` in `OutputsDockBody` so the round-3+round-8 fix can't regress on one trigger again.

## User-reported bug

> "The floating AI pop-out button on the right-hand panel is not working. The floating AI panel isn't being displayed when I click it."

Reproducer: docked Olumi tab active, floating panel closed, user clicks the chevron-up in the persistent input strip → nothing visible happens.

## Root cause

`PersistentInputStrip.onOpenFloating` was wired to `() => openFloatingByUser('user')` — opens the floating-panel store state, but does NOT switch the active dock tab away from 'olumi'. `FloatingOlumiPanel`'s render-time `yieldToDockedOlumi` guard then suppresses the mount because `effectiveDockTab` is still 'olumi'.

The same problem on a different trigger (the OlumiTabBody float-out icon) was fixed in round-3 (tab swap) and round-8 (sync sessionStorage write), but that fix lived inline in the icon's handler. The strip never got it.

## Fix

Extract a single `floatOutToWindow` helper in OutputsDockBody:

```tsx
const floatOutToWindow = () => {
  if (state.activeTab === 'olumi') {
    const fallback = lastNonOlumiTabRef.current
    try { /* sync sessionStorage write */ } catch {}
    setState((prev) => ({ ...prev, activeTab: fallback }))
    useUIStore.getState().setActiveOutputTab(fallback as OutputTab)
  }
  openFloatingByUser('user')
}
```

Wire it to BOTH triggers:
- `OlumiTabBody.onFloatOut` (was inline closure, now → helper)
- `PersistentInputStrip.onOpenFloating` (was direct call, now → helper)

The conditional `if (state.activeTab === 'olumi')` makes the helper safe to call from non-Olumi contexts too (the strip's redirect-mode click on Analysis/Compare/Model tabs).

## Regression spec

New test in `OutputsDock.conversationSingleton.spec.tsx`: "persistent strip chevron from Olumi tab opens floating panel (round-14 regression)". Sets up graph-with-nodes + activeTab=olumi + floating closed + persisted sessionStorage agrees, clicks the chevron via testid `ai-input-bar-strip-chevron`, asserts floating IS open AND active tab is no longer 'olumi' AND persisted sessionStorage agrees. The pre-fix code path fails this test; the new code passes.

## Test plan

- [x] `npm run typecheck` — clean
- [x] 12/12 OutputsDock.conversationSingleton specs pass (round-3, round-5, round-8, **round-14** all green)
- [x] Pre-push fast gate — 459 smoke tests + lint + dep audit + vendored schemas — all passed
- [ ] Staging verification: open floating panel, dock it to the Olumi tab, click the chevron-up in the strip composer — floating panel must mount.

## Why deferred staging verification

The bug only reproduces when `nodeCount > 0` (graph exists) AND the user is on the Olumi tab. Driving the local preview into that state needs a real CEE roundtrip, which is too slow for a tight verify loop in this turn. The spec covers the exact failure mode; staging verification will confirm visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)