### PR TITLE
feat(debug-bundle): V5 embedded-evidence resolver for scientific validation (post-PR #162)

### DIFF
--- a/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
@@ -2167,3 +2167,246 @@ describe('buildDebugBundleAsync — V5 proxy classification (PR #156 / PR #159 f
     expect(bundle.analysis_evidence_source).toBe('live_v5_cee_turn')
   })
 })
+
+// =====================================================================
+// Evidence resolver (post-PR #162 follow-up).
+//
+// Under V5 canonical mode (`VITE_V5_CANONICAL_ANALYSIS=true`,
+// `VITE_ENABLE_LEGACY_DIRECT_RUN=false`), the browser never fetches
+// PLoT/ISL directly, so `bundle.payloads.plot_response/isl_*` are
+// honestly null. The CEE V5 turn response embeds analysis evidence
+// in `blocks[type==='analysis_result'].enrichment`. The resolver
+// surfaces that embedded evidence to validators WITHOUT mutating
+// `bundle.payloads.*` (raw-capture truth preserved).
+//
+// Honesty: `scientific_validation.source` becomes
+// `'live_v5_cee_embedded'` ONLY when the embedded enrichment
+// actually carries indicative keys. Missing fields stay missing;
+// validators that need fields not in the enrichment stay
+// `'unavailable'` with their `required_upstream_support` intact.
+// =====================================================================
+
+describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
+  beforeEach(() => {
+    canvasState.currentScenarioId = null
+    canvasState.v5AnalysisFact = null
+    canvasState.results = null
+    traceState.payloads = []
+    inspectionState.enabled = true
+    inspectionState.resolvedAppEnv = 'staging'
+    inspectionState.reason = 'app_env_staging_enabled'
+  })
+
+  it('Dev/local: top-level plot_response present → evidence_resolution.plot_response_source = top_level; source = live_raw_payloads (regression)', async () => {
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        selected_plot_trace_is_usable_live_evidence: true,
+        payloads: {
+          cee_request: null,
+          cee_response: null,
+          plot_request: { scenario_id: 's-1' },
+          plot_response: {
+            factor_sensitivity: [{ factor_id: 'f1', impact: 0.3 }],
+            option_comparison: [{ id: 'opt_a', win_probability: 0.7 }],
+          },
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    expect(bundle.evidence_resolution).toBeDefined()
+    expect(bundle.evidence_resolution?.plot_response_source).toBe('top_level')
+    expect(bundle.evidence_resolution?.plot_response_source_path).toBe(
+      'payloads.plot_response',
+    )
+    // PR #156 round-4 regression preserved.
+    expect(bundle.scientific_validation?.source).toBe('live_raw_payloads')
+  })
+
+  it('Staging V5 canonical: top-level null + CEE embedded enrichment → evidence_resolution.plot_response_source = cee_embedded; source = live_v5_cee_embedded', async () => {
+    // Use a minimal real-shape enrichment (option_comparison +
+    // factor_sensitivity + robustness — 3 of 5 indicative keys).
+    // Same shape as `v5-analysis-result.staging-real-shape.json`.
+    const ceeResponse = {
+      blocks: [
+        { type: 'text', text: 'Ran analysis.' },
+        {
+          type: 'analysis_result',
+          summary: 'Ran analysis on your current scenario.',
+          enrichment: {
+            option_comparison: [{ id: 'opt_a', win_probability: 0.72 }],
+            factor_sensitivity: [
+              { factor_id: 'f1', sensitivity_score: 0.4, importance_rank: 1 },
+            ],
+            robustness: { fragile_edges: [], level: 'high' },
+          },
+        },
+      ],
+    }
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        cee_capture_provenance: 'analysis_producing_v5_turn',
+        selected_cee_trace_endpoint:
+          'https://cee-staging.onrender.com/proxy/v5/turn',
+        payloads: {
+          cee_request: { turn_id: 't-1', message: 'Run analysis' },
+          cee_response: ceeResponse,
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    // bundle.payloads.* stays as raw capture (NOT mutated).
+    expect(bundle.payloads.plot_response).toBeNull()
+    expect(bundle.payloads.cee_response).not.toBeNull()
+    // Resolver surfaced embedded enrichment.
+    expect(bundle.evidence_resolution?.plot_response_source).toBe(
+      'cee_embedded',
+    )
+    expect(bundle.evidence_resolution?.plot_response_source_path).toMatch(
+      /^payloads\.cee_response\.blocks\[1\]\.enrichment$/,
+    )
+    // scientific_validation.source flips to the new label.
+    expect(bundle.scientific_validation?.source).toBe('live_v5_cee_embedded')
+    // overall_status is NOT 'unavailable' (validators ran).
+    expect(bundle.scientific_validation?.overall_status).not.toBe(
+      'unavailable',
+    )
+  })
+
+  it('HONESTY: validators that need fields NOT in embedded enrichment stay unavailable with required_upstream_support', async () => {
+    // Enrichment has option_comparison + factor_sensitivity (basic
+    // shape) but NOT m1_coaching, flip_thresholds_status,
+    // auto_noise_applied, or factor_sensitivity[*].confidence_provenance.
+    // Those validators MUST stay unavailable — no fabrication.
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        payloads: {
+          cee_request: { turn_id: 't-2' },
+          cee_response: {
+            blocks: [
+              {
+                type: 'analysis_result',
+                enrichment: {
+                  option_comparison: [{ id: 'opt_a', win_probability: 0.6 }],
+                  factor_sensitivity: [
+                    {
+                      factor_id: 'f1',
+                      sensitivity_score: 0.4,
+                      importance_rank: 1,
+                    },
+                  ],
+                  // No confidence_provenance, no evpi_percentage_points,
+                  // no flip_thresholds_status, no auto_noise_applied,
+                  // no m1_coaching.
+                },
+              },
+            ],
+          },
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    expect(bundle.scientific_validation?.source).toBe('live_v5_cee_embedded')
+    // Validators that need fields NOT in enrichment stay unavailable.
+    const validators = bundle.scientific_validation?.validators
+    expect(validators?.confidence_validation?.status).toBe('unavailable')
+    expect(validators?.evpi_validation?.status).toBe('unavailable')
+    expect(validators?.flip_threshold_validation?.status).toBe('unavailable')
+    expect(validators?.evidence_gap_validation?.status).toBe('unavailable')
+    // Required upstream support is preserved (validators MUST
+    // document what they need from CEE/PLoT — honesty contract).
+    expect(
+      validators?.confidence_validation?.required_upstream_support,
+    ).toBeDefined()
+    expect(
+      (validators?.confidence_validation?.required_upstream_support as string[])
+        ?.length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('Missing evidence: both top-level and CEE-embedded missing → all sources unavailable; source falls through to hydrated_report or unavailable', async () => {
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        payloads: {
+          cee_request: null,
+          cee_response: null,
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    expect(bundle.evidence_resolution?.plot_response_source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.isl_request_source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.isl_response_source).toBe('unavailable')
+    // Source is one of the non-live labels — never live evidence.
+    expect(bundle.scientific_validation?.source).not.toBe('live_raw_payloads')
+    expect(bundle.scientific_validation?.source).not.toBe(
+      'live_v5_cee_embedded',
+    )
+  })
+
+  it('Mixed: top-level PLoT present + CEE-embedded ISL only → resolver picks each independently', async () => {
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        selected_plot_trace_is_usable_live_evidence: true,
+        payloads: {
+          cee_request: { turn_id: 't-mixed' },
+          cee_response: {
+            blocks: [
+              {
+                type: 'analysis_result',
+                enrichment: {
+                  factor_sensitivity: [{ factor_id: 'f-emb' }],
+                  downstream_calls: {
+                    isl: {
+                      response: {
+                        factor_sensitivity: [
+                          { factor_id: 'f-isl', evpi_percentage_points: 5 },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          plot_request: { scenario_id: 's-3' },
+          plot_response: {
+            factor_sensitivity: [{ factor_id: 'f-top', impact: 0.3 }],
+          },
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    // Top-level wins for PLoT.
+    expect(bundle.evidence_resolution?.plot_response_source).toBe('top_level')
+    // Embedded path used for ISL.
+    expect(bundle.evidence_resolution?.isl_response_source).toBe('cee_embedded')
+    expect(bundle.evidence_resolution?.isl_response_source_path).toMatch(
+      /enrichment\.downstream_calls\.isl\.response$/,
+    )
+    // Top-level PLoT body wins → source is live_raw_payloads.
+    expect(bundle.scientific_validation?.source).toBe('live_raw_payloads')
+  })
+
+  it('Stable shape: evidence_resolution is always present with all 9 fields', async () => {
+    const bundle = await buildDebugBundleAsync(makeDebugData())
+    expect(bundle.evidence_resolution).toBeDefined()
+    const er = bundle.evidence_resolution!
+    expect(er.plot_response_source).toBeDefined()
+    expect(er.plot_response_source_path !== undefined).toBe(true) // null is OK
+    expect(er.isl_request_source).toBeDefined()
+    expect(er.isl_request_source_path !== undefined).toBe(true)
+    expect(er.isl_response_source).toBeDefined()
+    expect(er.isl_response_source_path !== undefined).toBe(true)
+  })
+})

--- a/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
@@ -2197,7 +2197,7 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
     inspectionState.reason = 'app_env_staging_enabled'
   })
 
-  it('Dev/local: top-level plot_response present → evidence_resolution.plot_response_source = top_level; source = live_raw_payloads (regression)', async () => {
+  it('Dev/local: top-level plot_response present → evidence_resolution.plot_response_resolution.source = top_level; source = live_raw_payloads (regression)', async () => {
     const bundle = await buildDebugBundleAsync(
       makeDebugData({
         selected_plot_trace_is_usable_live_evidence: true,
@@ -2215,15 +2215,15 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
       }),
     )
     expect(bundle.evidence_resolution).toBeDefined()
-    expect(bundle.evidence_resolution?.plot_response_source).toBe('top_level')
-    expect(bundle.evidence_resolution?.plot_response_source_path).toBe(
+    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe('top_level')
+    expect(bundle.evidence_resolution?.plot_response_resolution.path).toBe(
       'payloads.plot_response',
     )
     // PR #156 round-4 regression preserved.
     expect(bundle.scientific_validation?.source).toBe('live_raw_payloads')
   })
 
-  it('Staging V5 canonical: top-level null + CEE embedded enrichment → evidence_resolution.plot_response_source = cee_embedded; source = live_v5_cee_embedded', async () => {
+  it('Staging V5 canonical: top-level null + CEE embedded enrichment → evidence_resolution.plot_response_resolution.source = cee_embedded; source = live_v5_cee_embedded', async () => {
     // Use a minimal real-shape enrichment (option_comparison +
     // factor_sensitivity + robustness — 3 of 5 indicative keys).
     // Same shape as `v5-analysis-result.staging-real-shape.json`.
@@ -2262,10 +2262,10 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
     expect(bundle.payloads.plot_response).toBeNull()
     expect(bundle.payloads.cee_response).not.toBeNull()
     // Resolver surfaced embedded enrichment.
-    expect(bundle.evidence_resolution?.plot_response_source).toBe(
+    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe(
       'cee_embedded',
     )
-    expect(bundle.evidence_resolution?.plot_response_source_path).toMatch(
+    expect(bundle.evidence_resolution?.plot_response_resolution.path).toMatch(
       /^payloads\.cee_response\.blocks\[1\]\.enrichment$/,
     )
     // scientific_validation.source flips to the new label.
@@ -2343,9 +2343,9 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
         },
       }),
     )
-    expect(bundle.evidence_resolution?.plot_response_source).toBe('unavailable')
-    expect(bundle.evidence_resolution?.isl_request_source).toBe('unavailable')
-    expect(bundle.evidence_resolution?.isl_response_source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.isl_request_resolution.source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.isl_response_resolution.source).toBe('unavailable')
     // Source is one of the non-live labels — never live evidence.
     expect(bundle.scientific_validation?.source).not.toBe('live_raw_payloads')
     expect(bundle.scientific_validation?.source).not.toBe(
@@ -2388,25 +2388,43 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
       }),
     )
     // Top-level wins for PLoT.
-    expect(bundle.evidence_resolution?.plot_response_source).toBe('top_level')
+    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe('top_level')
     // Embedded path used for ISL.
-    expect(bundle.evidence_resolution?.isl_response_source).toBe('cee_embedded')
-    expect(bundle.evidence_resolution?.isl_response_source_path).toMatch(
+    expect(bundle.evidence_resolution?.isl_response_resolution.source).toBe('cee_embedded')
+    expect(bundle.evidence_resolution?.isl_response_resolution.path).toMatch(
       /enrichment\.downstream_calls\.isl\.response$/,
     )
     // Top-level PLoT body wins → source is live_raw_payloads.
     expect(bundle.scientific_validation?.source).toBe('live_raw_payloads')
   })
 
-  it('Stable shape: evidence_resolution is always present with all 9 fields', async () => {
+  it('Stable shape: evidence_resolution emits all 5 spec fields per evidence kind', async () => {
     const bundle = await buildDebugBundleAsync(makeDebugData())
     expect(bundle.evidence_resolution).toBeDefined()
     const er = bundle.evidence_resolution!
-    expect(er.plot_response_source).toBeDefined()
-    expect(er.plot_response_source_path !== undefined).toBe(true) // null is OK
-    expect(er.isl_request_source).toBeDefined()
-    expect(er.isl_request_source_path !== undefined).toBe(true)
-    expect(er.isl_response_source).toBeDefined()
-    expect(er.isl_response_source_path !== undefined).toBe(true)
+    // Each kind exposes a resolution block carrying the spec fields:
+    //   source · path · available · required_upstream_support · notes
+    for (const res of [
+      er.plot_response_resolution,
+      er.isl_request_resolution,
+      er.isl_response_resolution,
+    ]) {
+      expect(['top_level', 'cee_embedded', 'unavailable']).toContain(res.source)
+      // path is `string | null` — non-null when source !== 'unavailable'.
+      expect(res.path === null || typeof res.path === 'string').toBe(true)
+      expect(typeof res.available).toBe('boolean')
+      expect(res.available).toBe(res.source !== 'unavailable')
+      // required_upstream_support is null when available, string when not.
+      expect(
+        res.required_upstream_support === null ||
+          typeof res.required_upstream_support === 'string',
+      ).toBe(true)
+      expect((res.required_upstream_support === null) === res.available).toBe(
+        true,
+      )
+      // notes is always a non-empty diagnostic string.
+      expect(typeof res.notes).toBe('string')
+      expect(res.notes.length).toBeGreaterThan(0)
+    }
   })
 })

--- a/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
@@ -2197,7 +2197,7 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
     inspectionState.reason = 'app_env_staging_enabled'
   })
 
-  it('Dev/local: top-level plot_response present → evidence_resolution.plot_response_resolution.source = top_level; source = live_raw_payloads (regression)', async () => {
+  it('Dev/local: top-level plot_response present → evidence_resolution.plot_response.source = top_level; source = live_raw_payloads (regression)', async () => {
     const bundle = await buildDebugBundleAsync(
       makeDebugData({
         selected_plot_trace_is_usable_live_evidence: true,
@@ -2215,15 +2215,15 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
       }),
     )
     expect(bundle.evidence_resolution).toBeDefined()
-    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe('top_level')
-    expect(bundle.evidence_resolution?.plot_response_resolution.path).toBe(
+    expect(bundle.evidence_resolution?.plot_response.source).toBe('top_level')
+    expect(bundle.evidence_resolution?.plot_response.path).toBe(
       'payloads.plot_response',
     )
     // PR #156 round-4 regression preserved.
     expect(bundle.scientific_validation?.source).toBe('live_raw_payloads')
   })
 
-  it('Staging V5 canonical: top-level null + CEE embedded enrichment → evidence_resolution.plot_response_resolution.source = cee_embedded; source = live_v5_cee_embedded', async () => {
+  it('Staging V5 canonical: top-level null + CEE embedded enrichment → evidence_resolution.plot_response.source = cee_embedded; source = live_v5_cee_embedded', async () => {
     // Use a minimal real-shape enrichment (option_comparison +
     // factor_sensitivity + robustness — 3 of 5 indicative keys).
     // Same shape as `v5-analysis-result.staging-real-shape.json`.
@@ -2262,10 +2262,10 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
     expect(bundle.payloads.plot_response).toBeNull()
     expect(bundle.payloads.cee_response).not.toBeNull()
     // Resolver surfaced embedded enrichment.
-    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe(
+    expect(bundle.evidence_resolution?.plot_response.source).toBe(
       'cee_embedded',
     )
-    expect(bundle.evidence_resolution?.plot_response_resolution.path).toMatch(
+    expect(bundle.evidence_resolution?.plot_response.path).toMatch(
       /^payloads\.cee_response\.blocks\[1\]\.enrichment$/,
     )
     // scientific_validation.source flips to the new label.
@@ -2281,8 +2281,13 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
     // shape) but NOT m1_coaching, flip_thresholds_status,
     // auto_noise_applied, or factor_sensitivity[*].confidence_provenance.
     // Those validators MUST stay unavailable — no fabrication.
+    // Provenance set to analysis_producing_v5_turn so the R-2 Blocker 2
+    // gate accepts the embedded path as live; this test isolates the
+    // VALIDATOR-level honesty (missing fields → unavailable), not the
+    // capture-provenance gate (covered separately below).
     const bundle = await buildDebugBundleAsync(
       makeDebugData({
+        cee_capture_provenance: 'analysis_producing_v5_turn',
         payloads: {
           cee_request: { turn_id: 't-2' },
           cee_response: {
@@ -2343,9 +2348,9 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
         },
       }),
     )
-    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe('unavailable')
-    expect(bundle.evidence_resolution?.isl_request_resolution.source).toBe('unavailable')
-    expect(bundle.evidence_resolution?.isl_response_resolution.source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.plot_response.source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.isl_request.source).toBe('unavailable')
+    expect(bundle.evidence_resolution?.isl_response.source).toBe('unavailable')
     // Source is one of the non-live labels — never live evidence.
     expect(bundle.scientific_validation?.source).not.toBe('live_raw_payloads')
     expect(bundle.scientific_validation?.source).not.toBe(
@@ -2388,10 +2393,10 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
       }),
     )
     // Top-level wins for PLoT.
-    expect(bundle.evidence_resolution?.plot_response_resolution.source).toBe('top_level')
+    expect(bundle.evidence_resolution?.plot_response.source).toBe('top_level')
     // Embedded path used for ISL.
-    expect(bundle.evidence_resolution?.isl_response_resolution.source).toBe('cee_embedded')
-    expect(bundle.evidence_resolution?.isl_response_resolution.path).toMatch(
+    expect(bundle.evidence_resolution?.isl_response.source).toBe('cee_embedded')
+    expect(bundle.evidence_resolution?.isl_response.path).toMatch(
       /enrichment\.downstream_calls\.isl\.response$/,
     )
     // Top-level PLoT body wins → source is live_raw_payloads.
@@ -2405,9 +2410,9 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
     // Each kind exposes a resolution block carrying the spec fields:
     //   source · path · available · required_upstream_support · notes
     for (const res of [
-      er.plot_response_resolution,
-      er.isl_request_resolution,
-      er.isl_response_resolution,
+      er.plot_response,
+      er.isl_request,
+      er.isl_response,
     ]) {
       expect(['top_level', 'cee_embedded', 'unavailable']).toContain(res.source)
       // path is `string | null` — non-null when source !== 'unavailable'.
@@ -2426,5 +2431,138 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
       expect(typeof res.notes).toBe('string')
       expect(res.notes.length).toBeGreaterThan(0)
     }
+  })
+
+  // ===================================================================
+  // R-2 Blocker 2 regressions — `'live_v5_cee_embedded'` MUST be
+  // gated on selected analysis-producing V5 CEE provenance. A
+  // legacy / stale / non-selected CEE response that happens to
+  // carry `analysis_result.enrichment` must NOT mislabel.
+  // ===================================================================
+
+  it("R-2 Blocker 2: cee_capture_provenance === 'fallback_legacy_cee' + enrichment → source NOT 'live_v5_cee_embedded'", async () => {
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        // Legacy CEE turn (e.g. /bff/cee/turn) — NOT a selected V5
+        // turn. Body happens to carry analysis_result.enrichment
+        // with indicative keys.
+        cee_capture_provenance: 'fallback_legacy_cee',
+        payloads: {
+          cee_request: { turn_id: 't-legacy' },
+          cee_response: {
+            blocks: [
+              {
+                type: 'analysis_result',
+                enrichment: {
+                  factor_sensitivity: [{ factor_id: 'f1' }],
+                  option_comparison: [{ id: 'opt' }],
+                  robustness: { fragile_edges: [] },
+                },
+              },
+            ],
+          },
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    // Resolver still lifts the body (it's there), but the
+    // classifier MUST refuse to emit `'live_v5_cee_embedded'`
+    // because the provenance gate failed.
+    expect(bundle.evidence_resolution?.plot_response.source).toBe(
+      'cee_embedded',
+    )
+    expect(bundle.scientific_validation?.source).not.toBe(
+      'live_v5_cee_embedded',
+    )
+    expect(bundle.scientific_validation?.source).not.toBe('live_raw_payloads')
+  })
+
+  it("R-2 Blocker 2: cee_capture_provenance === 'none' + enrichment → source NOT 'live_v5_cee_embedded'", async () => {
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        cee_capture_provenance: 'none',
+        payloads: {
+          cee_request: null,
+          // No selected CEE candidate — but somehow a CEE-shaped
+          // body is in payloads (defensive: also reject).
+          cee_response: {
+            blocks: [
+              {
+                type: 'analysis_result',
+                enrichment: { factor_sensitivity: [{ factor_id: 'f1' }] },
+              },
+            ],
+          },
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    expect(bundle.scientific_validation?.source).not.toBe(
+      'live_v5_cee_embedded',
+    )
+  })
+
+  it("R-2 Blocker 2: cee_capture_provenance === 'fallback_v5_turn' + enrichment → source IS 'live_v5_cee_embedded' (fallback-V5 IS selected V5)", async () => {
+    // fallback_v5_turn DOES count as a selected V5 turn — the
+    // selector's primary path missed but the fallback resolved
+    // to a genuine V5 endpoint. The classifier accepts this.
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        cee_capture_provenance: 'fallback_v5_turn',
+        payloads: {
+          cee_request: { turn_id: 't-fb-v5' },
+          cee_response: {
+            blocks: [
+              {
+                type: 'analysis_result',
+                enrichment: {
+                  factor_sensitivity: [{ factor_id: 'f1' }],
+                  option_comparison: [{ id: 'opt' }],
+                  robustness: { fragile_edges: [] },
+                },
+              },
+            ],
+          },
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    expect(bundle.scientific_validation?.source).toBe('live_v5_cee_embedded')
+  })
+
+  it('R-2 Blocker 2: undefined cee_capture_provenance + enrichment → source NOT live (defensive default)', async () => {
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        // cee_capture_provenance NOT set on data — classifier should
+        // default to rejecting cee_embedded as live.
+        payloads: {
+          cee_request: { turn_id: 't-undef' },
+          cee_response: {
+            blocks: [
+              {
+                type: 'analysis_result',
+                enrichment: { factor_sensitivity: [{ factor_id: 'f1' }] },
+              },
+            ],
+          },
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    expect(bundle.scientific_validation?.source).not.toBe(
+      'live_v5_cee_embedded',
+    )
   })
 })

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -1170,23 +1170,38 @@ interface DebugBundle {
 
   /**
    * Evidence-resolver output (post-PR #162 follow-up). Maps each
-   * scientific-validation evidence kind to its actual source:
+   * scientific-validation evidence kind to its resolution metadata:
    *
+   *   evidence_resolution: {
+   *     plot_response: Record | null,
+   *     plot_response_resolution: {
+   *       source: 'top_level' | 'cee_embedded' | 'unavailable',
+   *       path: string | null,
+   *       available: boolean,
+   *       required_upstream_support: string | null,
+   *       notes: string,
+   *     },
+   *     isl_request: ...,
+   *     isl_request_resolution: ...,
+   *     isl_response: ...,
+   *     isl_response_resolution: ...,
+   *   }
+   *
+   * Source meanings:
    *   - `'top_level'`    — taken from `bundle.payloads.{plot,isl}_*`
    *     (dev/local + direct-capture path).
    *   - `'cee_embedded'` — extracted from `bundle.payloads.cee_response`
    *     `.blocks[type==='analysis_result'].enrichment` (V5 canonical
-   *     path; this field is the reviewer-facing signal that validators
-   *     used embedded enrichment rather than top-level capture).
+   *     path; the reviewer-facing signal that validators used
+   *     embedded enrichment rather than top-level capture).
    *   - `'unavailable'`  — neither source carried usable evidence.
    *
-   * Each `*_source_path` field gives the concrete pathname inside
-   * the bundle so reviewers can locate the actual evidence body.
-   *
-   * Honesty boundary: this field does NOT mutate
-   * `bundle.payloads.*`. The top-level payloads always reflect raw
-   * browser capture; the resolver result is a separate, additive
-   * diagnostic that records what the validators ACTUALLY saw.
+   * Honesty boundary: this field does NOT mutate `bundle.payloads.*`.
+   * The top-level payloads always reflect raw browser capture; the
+   * resolver result is a separate, additive diagnostic that records
+   * what the validators ACTUALLY saw and why. When `available` is
+   * `false`, `required_upstream_support` documents what would
+   * unlock this evidence kind — never inferred or fabricated.
    */
   evidence_resolution?: ResolvedEvidence
 
@@ -4052,14 +4067,14 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       // the CEE source.
       selectedPlotTraceIsUsableLiveEvidence:
         data.selected_plot_trace_is_usable_live_evidence === true ||
-        resolvedEvidence.plot_response_source === 'cee_embedded',
+        resolvedEvidence.plot_response_resolution.source === 'cee_embedded',
       // Evidence-resolver: tell classifySource that the resolved
       // PLoT response came from CEE-embedded enrichment so it
       // can emit the distinct `'live_v5_cee_embedded'` source label.
       // Informational discriminator only — does NOT change the
       // live-evidence semantics (both 'live_raw_payloads' and
       // 'live_v5_cee_embedded' are live raw evidence).
-      plotResponseSource: resolvedEvidence.plot_response_source,
+      plotResponseSource: resolvedEvidence.plot_response_resolution.source,
     })
   } catch {
     // All four sections are additive — keep partial state on failure.

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -106,7 +106,7 @@ import {
 } from '../../../lib/scientificValidation'
 import {
   resolveScientificEvidence,
-  type ResolvedEvidence,
+  type EvidenceResolutionReport,
 } from '../../../lib/v5EmbeddedEvidence'
 import {
   ADDITIVE_EXTENSIONS_KEY,
@@ -1169,41 +1169,35 @@ interface DebugBundle {
   scientific_validation?: ScientificValidation
 
   /**
-   * Evidence-resolver output (post-PR #162 follow-up). Maps each
-   * scientific-validation evidence kind to its resolution metadata:
+   * Evidence-resolver output (post-PR #162 follow-up). Per-kind
+   * resolution METADATA — reviewers read:
    *
-   *   evidence_resolution: {
-   *     plot_response: Record | null,
-   *     plot_response_resolution: {
-   *       source: 'top_level' | 'cee_embedded' | 'unavailable',
-   *       path: string | null,
-   *       available: boolean,
-   *       required_upstream_support: string | null,
-   *       notes: string,
-   *     },
-   *     isl_request: ...,
-   *     isl_request_resolution: ...,
-   *     isl_response: ...,
-   *     isl_response_resolution: ...,
-   *   }
+   *   evidence_resolution.plot_request.source
+   *   evidence_resolution.plot_request.path
+   *   evidence_resolution.plot_request.available
+   *   evidence_resolution.plot_request.required_upstream_support
+   *   evidence_resolution.plot_request.notes
+   *
+   *   (same five fields for plot_response, isl_request, isl_response)
    *
    * Source meanings:
-   *   - `'top_level'`    — taken from `bundle.payloads.{plot,isl}_*`
-   *     (dev/local + direct-capture path).
-   *   - `'cee_embedded'` — extracted from `bundle.payloads.cee_response`
-   *     `.blocks[type==='analysis_result'].enrichment` (V5 canonical
-   *     path; the reviewer-facing signal that validators used
-   *     embedded enrichment rather than top-level capture).
-   *   - `'unavailable'`  — neither source carried usable evidence.
+   *   - `'top_level'`    — `bundle.payloads.<kind>` was non-null.
+   *   - `'cee_embedded'` — lifted from somewhere inside
+   *     `bundle.payloads.cee_response`. The exact pathname (e.g.
+   *     `payloads.cee_response.blocks[3].enrichment._meta.payloads.plot_response`
+   *     or `payloads.cee_response.blocks[3].enrichment`) is in `path`.
+   *   - `'unavailable'`  — neither source carried a usable body.
    *
-   * Honesty boundary: this field does NOT mutate `bundle.payloads.*`.
-   * The top-level payloads always reflect raw browser capture; the
-   * resolver result is a separate, additive diagnostic that records
-   * what the validators ACTUALLY saw and why. When `available` is
-   * `false`, `required_upstream_support` documents what would
-   * unlock this evidence kind — never inferred or fabricated.
+   * Honesty boundary: this field carries METADATA ONLY. Resolved
+   * bodies are NOT included here — they flow into the validators
+   * (via `inputs.{plotRequest,plotResponse,islRequest,islResponse}`),
+   * and the raw browser capture stays in `bundle.payloads.*`
+   * untouched. Reviewers can trace each resolved body via the
+   * `path` string. When `available === false`,
+   * `required_upstream_support` documents what would unlock this
+   * evidence kind — never inferred, never fabricated.
    */
-  evidence_resolution?: ResolvedEvidence
+  evidence_resolution?: EvidenceResolutionReport
 
   // Enhancement sections (Debug Panel V2.1)
 
@@ -4031,50 +4025,74 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     // for reviewer transparency.
     const resolvedEvidence = resolveScientificEvidence(
       {
+        plot_request: bundle.payloads.plot_request,
         plot_response: bundle.payloads.plot_response,
         isl_request: bundle.payloads.isl_request,
         isl_response: bundle.payloads.isl_response,
       },
       bundle.payloads.cee_response,
     )
-    bundle.evidence_resolution = resolvedEvidence
+    // `bundle.evidence_resolution` exposes METADATA ONLY (no bodies).
+    // Bodies live in `bundle.payloads.*` (raw browser capture) AND
+    // are routed into validators below. Reviewers can trace each
+    // resolved body via `evidence_resolution.<kind>.path`.
+    bundle.evidence_resolution = resolvedEvidence.resolution
+
+    // Reviewer Blocker 2: gate `'live_v5_cee_embedded'` on a
+    // SELECTED analysis-producing V5 CEE turn — not just on
+    // `bundle.payloads.cee_response` having an `analysis_result`
+    // block with enrichment. A legacy / stale / non-selected CEE
+    // response that happens to carry an analysis_result block
+    // (e.g. an older `/bff/cee/turn` capture, or a fallback that
+    // landed on a non-V5 endpoint) must NOT be labelled live.
+    //
+    // The CEE-side analysis-producing selector (PR #156) records
+    // its provenance in `data.cee_capture_provenance`. We accept:
+    //   - `'analysis_producing_v5_turn'` — selector picked an
+    //     analysis-producing V5 turn.
+    //   - `'fallback_v5_turn'`           — fallback resolved to a
+    //     genuine V5 endpoint (still V5, just discovered via the
+    //     latest-V5 fallback path).
+    // We reject:
+    //   - `'fallback_legacy_cee'`        — fallback landed on a
+    //     non-V5 endpoint (legacy `/bff/cee/turn` etc.).
+    //   - `'none'`                       — no CEE candidate at all.
+    //   - undefined                      — provenance not threaded.
+    const ceeProvenance = data.cee_capture_provenance
+    const ceeIsSelectedV5 =
+      ceeProvenance === 'analysis_producing_v5_turn' ||
+      ceeProvenance === 'fallback_v5_turn'
 
     bundle.scientific_validation = runScientificValidation({
-      plotRequest: bundle.payloads.plot_request,
+      plotRequest: resolvedEvidence.bodies.plot_request,
       // Resolver output: top-level capture when present, else
-      // embedded enrichment from CEE V5 analysis_result block,
-      // else null. Honesty contract preserved — no fabrication.
-      plotResponse: resolvedEvidence.plot_response,
+      // embedded `_meta.payloads` sidecar, else embedded
+      // `analysis_result.enrichment` body, else null.
+      plotResponse: resolvedEvidence.bodies.plot_response,
       ceeRequest: bundle.payloads.cee_request,
       ceeResponse: bundle.payloads.cee_response,
-      islRequest: resolvedEvidence.isl_request,
-      islResponse: resolvedEvidence.isl_response,
+      islRequest: resolvedEvidence.bodies.isl_request,
+      islResponse: resolvedEvidence.bodies.isl_response,
       resultsReport: storeState.results?.report ?? null,
       ceeAnalysisReady: storeState.ceeAnalysisReady ?? null,
       capturePipelineStatus: bundle.capture_pipeline_status ?? null,
-      // PR #156 round-4 (reviewer P0): thread the usability flag so
-      // `classifySource` can't overclaim `live_raw_payloads` from a
-      // failed/non-usable selected PLoT trace whose error body
-      // happens to carry an indicative key.
-      //
-      // Evidence-resolver extension: when the resolver supplied the
-      // body from CEE-embedded enrichment, there is NO PLoT trace
-      // to check (V5 canonical has no direct PLoT call). The
-      // usability is instead verified by the CEE-side
-      // analysis-producing selector that ALREADY confirmed the
-      // turn was usable analysis evidence — passing `true` here
-      // is honest because the upstream gate has already validated
-      // the CEE source.
+      // PR #156 round-4 (reviewer P0): usability gate for top-level
+      // PLoT path. For the `'cee_embedded'` path, the equivalent
+      // usability gate is `ceeIsSelectedV5` (below) — we pass `true`
+      // here so the classifier doesn't double-gate the embedded
+      // path on a PLoT-trace check that doesn't apply when no PLoT
+      // trace exists at all (V5 canonical).
       selectedPlotTraceIsUsableLiveEvidence:
         data.selected_plot_trace_is_usable_live_evidence === true ||
-        resolvedEvidence.plot_response_resolution.source === 'cee_embedded',
-      // Evidence-resolver: tell classifySource that the resolved
-      // PLoT response came from CEE-embedded enrichment so it
-      // can emit the distinct `'live_v5_cee_embedded'` source label.
-      // Informational discriminator only — does NOT change the
-      // live-evidence semantics (both 'live_raw_payloads' and
-      // 'live_v5_cee_embedded' are live raw evidence).
-      plotResponseSource: resolvedEvidence.plot_response_resolution.source,
+        resolvedEvidence.resolution.plot_response.source === 'cee_embedded',
+      // Evidence-resolver: tell `classifySource` whether the
+      // resolved `plotResponse` came from CEE-embedded enrichment
+      // AND whether the captured CEE response was the selected
+      // analysis-producing V5 turn (NOT a legacy / fallback /
+      // stale CEE response). Only when BOTH are true does
+      // `classifySource` emit `'live_v5_cee_embedded'`.
+      plotResponseSource: resolvedEvidence.resolution.plot_response.source,
+      ceeCaptureIsSelectedV5Turn: ceeIsSelectedV5,
     })
   } catch {
     // All four sections are additive — keep partial state on failure.

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -105,6 +105,10 @@ import {
   type ScientificValidation,
 } from '../../../lib/scientificValidation'
 import {
+  resolveScientificEvidence,
+  type ResolvedEvidence,
+} from '../../../lib/v5EmbeddedEvidence'
+import {
   ADDITIVE_EXTENSIONS_KEY,
   ORIGINAL_TOP_LEVEL_KEYS_KEY,
   PHASE3_SIDECAR_BLOCKS_KEY,
@@ -1163,6 +1167,28 @@ interface DebugBundle {
    * intentional honesty, NOT a bug.
    */
   scientific_validation?: ScientificValidation
+
+  /**
+   * Evidence-resolver output (post-PR #162 follow-up). Maps each
+   * scientific-validation evidence kind to its actual source:
+   *
+   *   - `'top_level'`    — taken from `bundle.payloads.{plot,isl}_*`
+   *     (dev/local + direct-capture path).
+   *   - `'cee_embedded'` — extracted from `bundle.payloads.cee_response`
+   *     `.blocks[type==='analysis_result'].enrichment` (V5 canonical
+   *     path; this field is the reviewer-facing signal that validators
+   *     used embedded enrichment rather than top-level capture).
+   *   - `'unavailable'`  — neither source carried usable evidence.
+   *
+   * Each `*_source_path` field gives the concrete pathname inside
+   * the bundle so reviewers can locate the actual evidence body.
+   *
+   * Honesty boundary: this field does NOT mutate
+   * `bundle.payloads.*`. The top-level payloads always reflect raw
+   * browser capture; the resolver result is a separate, additive
+   * diagnostic that records what the validators ACTUALLY saw.
+   */
+  evidence_resolution?: ResolvedEvidence
 
   // Enhancement sections (Debug Panel V2.1)
 
@@ -3978,13 +4004,36 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
     // --- Scientific validation (P1) ---
     // Always runs (even when capture_pipeline_status is missing) — the
     // orchestrator falls back to `source: unavailable` honestly.
+    //
+    // Evidence-resolver follow-up (post-PR #162): under V5 canonical
+    // mode the browser never fetches PLoT/ISL directly, so
+    // `bundle.payloads.plot_response/isl_*` are honestly null. The
+    // CEE V5 turn response embeds analysis evidence in
+    // `blocks[type==='analysis_result'].enrichment`. The resolver
+    // surfaces that embedded evidence to validators WITHOUT mutating
+    // `bundle.payloads.*` (which stays raw-capture truth). The
+    // resolved view is also exposed on `bundle.evidence_resolution`
+    // for reviewer transparency.
+    const resolvedEvidence = resolveScientificEvidence(
+      {
+        plot_response: bundle.payloads.plot_response,
+        isl_request: bundle.payloads.isl_request,
+        isl_response: bundle.payloads.isl_response,
+      },
+      bundle.payloads.cee_response,
+    )
+    bundle.evidence_resolution = resolvedEvidence
+
     bundle.scientific_validation = runScientificValidation({
       plotRequest: bundle.payloads.plot_request,
-      plotResponse: bundle.payloads.plot_response,
+      // Resolver output: top-level capture when present, else
+      // embedded enrichment from CEE V5 analysis_result block,
+      // else null. Honesty contract preserved — no fabrication.
+      plotResponse: resolvedEvidence.plot_response,
       ceeRequest: bundle.payloads.cee_request,
       ceeResponse: bundle.payloads.cee_response,
-      islRequest: bundle.payloads.isl_request,
-      islResponse: bundle.payloads.isl_response,
+      islRequest: resolvedEvidence.isl_request,
+      islResponse: resolvedEvidence.isl_response,
       resultsReport: storeState.results?.report ?? null,
       ceeAnalysisReady: storeState.ceeAnalysisReady ?? null,
       capturePipelineStatus: bundle.capture_pipeline_status ?? null,
@@ -3992,8 +4041,25 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       // `classifySource` can't overclaim `live_raw_payloads` from a
       // failed/non-usable selected PLoT trace whose error body
       // happens to carry an indicative key.
+      //
+      // Evidence-resolver extension: when the resolver supplied the
+      // body from CEE-embedded enrichment, there is NO PLoT trace
+      // to check (V5 canonical has no direct PLoT call). The
+      // usability is instead verified by the CEE-side
+      // analysis-producing selector that ALREADY confirmed the
+      // turn was usable analysis evidence — passing `true` here
+      // is honest because the upstream gate has already validated
+      // the CEE source.
       selectedPlotTraceIsUsableLiveEvidence:
-        data.selected_plot_trace_is_usable_live_evidence === true,
+        data.selected_plot_trace_is_usable_live_evidence === true ||
+        resolvedEvidence.plot_response_source === 'cee_embedded',
+      // Evidence-resolver: tell classifySource that the resolved
+      // PLoT response came from CEE-embedded enrichment so it
+      // can emit the distinct `'live_v5_cee_embedded'` source label.
+      // Informational discriminator only — does NOT change the
+      // live-evidence semantics (both 'live_raw_payloads' and
+      // 'live_v5_cee_embedded' are live raw evidence).
+      plotResponseSource: resolvedEvidence.plot_response_source,
     })
   } catch {
     // All four sections are additive — keep partial state on failure.

--- a/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
+++ b/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
@@ -1,108 +1,272 @@
 /**
  * Unit tests for `src/lib/v5EmbeddedEvidence.ts` —
- * `resolveScientificEvidence` precedence + path-boundary +
- * malformed-input safety.
+ * `resolveScientificEvidence` precedence + `_meta.payloads`
+ * probing + path-boundary + malformed-input safety.
  *
- * Post-PR #162 follow-up: under V5 canonical mode, the browser
- * never fetches PLoT/ISL directly. Embedded enrichment in
- * `bundle.payloads.cee_response.blocks[type==='analysis_result'].enrichment`
- * is the only live evidence available to scientific validators.
- * This resolver lifts it WITHOUT mutating `bundle.payloads.*`.
+ * Post-PR #162 + R-2 review follow-up. Resolver shape:
  *
- * Honesty contract: top-level capture wins (preserves dev/local
- * path); embedded fallback requires at least one indicative key;
- * missing fields stay missing.
+ *   resolveScientificEvidence(topLevel, ceeResponse) →
+ *     {
+ *       bodies: { plot_request, plot_response, isl_request, isl_response },
+ *       resolution: {
+ *         plot_request:  { source, path, available, required_upstream_support, notes },
+ *         plot_response: { source, path, available, required_upstream_support, notes },
+ *         isl_request:   { source, path, available, required_upstream_support, notes },
+ *         isl_response:  { source, path, available, required_upstream_support, notes },
+ *       },
+ *     }
+ *
+ * Bodies and metadata kept in separate buckets so the bundle's
+ * `evidence_resolution` field stays purely metadata; bodies flow
+ * into validators only.
  */
 
 import { describe, it, expect } from 'vitest'
 
 import {
   resolveScientificEvidence,
-  type ResolvedEvidence,
+  type EvidenceResolutionReport,
 } from '../v5EmbeddedEvidence'
 import realCeeShape from '../../v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json'
 
 const EMPTY_TOP_LEVEL = {
+  plot_request: null,
   plot_response: null,
   isl_request: null,
   isl_response: null,
 }
 
 describe('resolveScientificEvidence — top-level precedence', () => {
-  it('returns top-level plot_response when present, regardless of CEE content', () => {
-    const topLevel = {
-      plot_response: { factor_sensitivity: [{ factor_id: 'f1' }] },
-      isl_request: null,
-      isl_response: null,
-    }
-    const r = resolveScientificEvidence(topLevel, realCeeShape)
-    expect(r.plot_response).toEqual(topLevel.plot_response)
-    expect(r.plot_response_resolution.source).toBe('top_level')
-    expect(r.plot_response_resolution.path).toBe('payloads.plot_response')
+  it('top-level plot_response wins regardless of CEE content', () => {
+    const r = resolveScientificEvidence(
+      {
+        ...EMPTY_TOP_LEVEL,
+        plot_response: { factor_sensitivity: [{ factor_id: 'top' }] },
+      },
+      realCeeShape,
+    )
+    expect(r.bodies.plot_response).toEqual({
+      factor_sensitivity: [{ factor_id: 'top' }],
+    })
+    expect(r.resolution.plot_response.source).toBe('top_level')
+    expect(r.resolution.plot_response.path).toBe('payloads.plot_response')
+    expect(r.resolution.plot_response.available).toBe(true)
+    expect(r.resolution.plot_response.required_upstream_support).toBeNull()
   })
 
-  it('returns top-level isl_request when present', () => {
-    const topLevel = {
-      plot_response: null,
-      isl_request: { parameter_uncertainties: {} },
-      isl_response: null,
-    }
-    const r = resolveScientificEvidence(topLevel, null)
-    expect(r.isl_request).toEqual(topLevel.isl_request)
-    expect(r.isl_request_resolution.source).toBe('top_level')
-    expect(r.isl_request_resolution.path).toBe('payloads.isl_request')
+  it('top-level plot_request wins (no embedded fallback for request)', () => {
+    const r = resolveScientificEvidence(
+      {
+        ...EMPTY_TOP_LEVEL,
+        plot_request: { graph: { nodes: [] } },
+      },
+      null,
+    )
+    expect(r.bodies.plot_request).toEqual({ graph: { nodes: [] } })
+    expect(r.resolution.plot_request.source).toBe('top_level')
+    expect(r.resolution.plot_request.path).toBe('payloads.plot_request')
   })
 
-  it('returns top-level isl_response when present', () => {
-    const topLevel = {
-      plot_response: null,
-      isl_request: null,
-      isl_response: { factor_sensitivity: [{ factor_id: 'f1' }] },
-    }
-    const r = resolveScientificEvidence(topLevel, null)
-    expect(r.isl_response).toEqual(topLevel.isl_response)
-    expect(r.isl_response_resolution.source).toBe('top_level')
-    expect(r.isl_response_resolution.path).toBe('payloads.isl_response')
+  it('top-level isl_request wins', () => {
+    const r = resolveScientificEvidence(
+      {
+        ...EMPTY_TOP_LEVEL,
+        isl_request: { parameter_uncertainties: { f1: { std: 0.1 } } },
+      },
+      null,
+    )
+    expect(r.resolution.isl_request.source).toBe('top_level')
+    expect(r.resolution.isl_request.path).toBe('payloads.isl_request')
+  })
+
+  it('top-level isl_response wins', () => {
+    const r = resolveScientificEvidence(
+      {
+        ...EMPTY_TOP_LEVEL,
+        isl_response: { factor_sensitivity: [{ factor_id: 'f1' }] },
+      },
+      null,
+    )
+    expect(r.resolution.isl_response.source).toBe('top_level')
+    expect(r.resolution.isl_response.path).toBe('payloads.isl_response')
   })
 })
 
-describe('resolveScientificEvidence — CEE-embedded fallback', () => {
-  it('lifts enrichment as plot_response when top-level is null (real staging fixture)', () => {
+describe('resolveScientificEvidence — _meta.payloads sidecar (Blocker 1)', () => {
+  // The reviewer's R-2 Blocker 1: the resolver MUST probe
+  // `enrichment._meta.payloads.<kind>` for each evidence kind.
+  // These tests prove it.
+
+  const ceeWithMeta = {
+    blocks: [
+      {
+        type: 'analysis_result',
+        enrichment: {
+          // Bare enrichment also has indicative keys — to prove
+          // `_meta.payloads.plot_response` is preferred over the
+          // bare enrichment (closer to upstream shape).
+          factor_sensitivity: [
+            { factor_id: 'from_bare', sensitivity_score: 0.1 },
+          ],
+          _meta: {
+            payloads: {
+              plot_request: { graph: { nodes: [{ id: 'meta_node' }] } },
+              plot_response: {
+                factor_sensitivity: [
+                  {
+                    factor_id: 'from_meta',
+                    confidence_provenance: { computation_source: 'plot' },
+                  },
+                ],
+                flip_thresholds_status: 'computed',
+              },
+              isl_request: {
+                parameter_uncertainties: { f1: { std: 0.2 } },
+              },
+              isl_response: {
+                factor_sensitivity: [
+                  { factor_id: 'from_meta_isl', evpi_percentage_points: 5.2 },
+                ],
+              },
+            },
+          },
+        },
+      },
+    ],
+  }
+
+  it('lifts plot_request from _meta.payloads.plot_request', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithMeta)
+    expect(r.bodies.plot_request).toEqual({
+      graph: { nodes: [{ id: 'meta_node' }] },
+    })
+    expect(r.resolution.plot_request.source).toBe('cee_embedded')
+    expect(r.resolution.plot_request.path).toBe(
+      'payloads.cee_response.blocks[0].enrichment._meta.payloads.plot_request',
+    )
+  })
+
+  it('lifts plot_response from _meta.payloads.plot_response in PREFERENCE to bare enrichment', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithMeta)
+    // The bare enrichment ALSO has a `factor_sensitivity` (from
+    // `from_bare`); the resolver MUST pick the `_meta.payloads`
+    // version (from `from_meta`) because it's closer to upstream shape.
+    expect(
+      (r.bodies.plot_response as Record<string, unknown>)?.factor_sensitivity,
+    ).toEqual([
+      {
+        factor_id: 'from_meta',
+        confidence_provenance: { computation_source: 'plot' },
+      },
+    ])
+    expect(r.resolution.plot_response.source).toBe('cee_embedded')
+    expect(r.resolution.plot_response.path).toBe(
+      'payloads.cee_response.blocks[0].enrichment._meta.payloads.plot_response',
+    )
+  })
+
+  it('lifts isl_request from _meta.payloads.isl_request', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithMeta)
+    expect(r.bodies.isl_request).toEqual({
+      parameter_uncertainties: { f1: { std: 0.2 } },
+    })
+    expect(r.resolution.isl_request.source).toBe('cee_embedded')
+    expect(r.resolution.isl_request.path).toBe(
+      'payloads.cee_response.blocks[0].enrichment._meta.payloads.isl_request',
+    )
+  })
+
+  it('lifts isl_response from _meta.payloads.isl_response (preferred over downstream_calls)', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithMeta)
+    expect(r.resolution.isl_response.source).toBe('cee_embedded')
+    expect(r.resolution.isl_response.path).toBe(
+      'payloads.cee_response.blocks[0].enrichment._meta.payloads.isl_response',
+    )
+  })
+
+  it('rejects malformed _meta.payloads (non-object) — falls through to next branch', () => {
+    const ceeMalformedMeta = {
+      blocks: [
+        {
+          type: 'analysis_result',
+          enrichment: {
+            factor_sensitivity: [{ factor_id: 'enr_only' }],
+            _meta: { payloads: 'not-an-object' },
+          },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeMalformedMeta)
+    // _meta.payloads is non-object → falls through to bare enrichment.
+    expect(r.resolution.plot_response.source).toBe('cee_embedded')
+    expect(r.resolution.plot_response.path).toBe(
+      'payloads.cee_response.blocks[0].enrichment',
+    )
+  })
+
+  it('rejects _meta.payloads.plot_response when it lacks indicative keys', () => {
+    // The plot_response indicative-keys gate applies to the sidecar
+    // path too — an empty/placeholder body must NOT be promoted.
+    const ceeEmptyMetaPlotResponse = {
+      blocks: [
+        {
+          type: 'analysis_result',
+          enrichment: {
+            // Bare enrichment lacks indicative keys.
+            summary: 'no indicative keys here',
+            _meta: {
+              payloads: {
+                // _meta sidecar plot_response also lacks indicative keys.
+                plot_response: { unrelated_key: 'placeholder' },
+              },
+            },
+          },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeEmptyMetaPlotResponse)
+    expect(r.resolution.plot_response.source).toBe('unavailable')
+    expect(r.bodies.plot_response).toBeNull()
+  })
+
+  it('rejects _meta.payloads.<kind> when the body is an empty object', () => {
+    const ceeEmptyMetaIsl = {
+      blocks: [
+        {
+          type: 'analysis_result',
+          enrichment: {
+            _meta: { payloads: { isl_request: {} } },
+          },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeEmptyMetaIsl)
+    expect(r.resolution.isl_request.source).toBe('unavailable')
+  })
+})
+
+describe('resolveScientificEvidence — bare enrichment fallback (existing path)', () => {
+  it('lifts bare enrichment as plot_response when top-level + _meta absent (real staging fixture)', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, realCeeShape)
-    expect(r.plot_response).not.toBeNull()
-    expect(r.plot_response_resolution.source).toBe('cee_embedded')
-    expect(r.plot_response_resolution.path).toMatch(
+    expect(r.bodies.plot_response).not.toBeNull()
+    expect(r.resolution.plot_response.source).toBe('cee_embedded')
+    expect(r.resolution.plot_response.path).toMatch(
       /^payloads\.cee_response\.blocks\[\d+\]\.enrichment$/,
     )
-    // Sanity check that the resolver lifted the actual enrichment
-    // (not a synthesized empty object).
+    // Sanity: the lifted body carries the fixture's enrichment keys.
     expect(
-      (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
+      (r.bodies.plot_response as Record<string, unknown>)?.factor_sensitivity,
     ).toBeDefined()
     expect(
-      (r.plot_response as Record<string, unknown>)?.option_comparison,
+      (r.bodies.plot_response as Record<string, unknown>)?.option_comparison,
     ).toBeDefined()
     expect(
-      (r.plot_response as Record<string, unknown>)?.robustness,
+      (r.bodies.plot_response as Record<string, unknown>)?.robustness,
     ).toBeDefined()
   })
 
-  it('returns full ResolvedEvidence shape even when only plot_response is found', () => {
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, realCeeShape)
-    // ISL fields stay unavailable — the fixture has no downstream_calls.isl.
-    expect(r.isl_request).toBeNull()
-    expect(r.isl_request_resolution.source).toBe('unavailable')
-    expect(r.isl_request_resolution.path).toBeNull()
-    expect(r.isl_response).toBeNull()
-    expect(r.isl_response_resolution.source).toBe('unavailable')
-    expect(r.isl_response_resolution.path).toBeNull()
-  })
-
-  it('lifts isl_response from enrichment.downstream_calls.isl.response when present', () => {
-    // Synthetic CEE response with downstream_calls — exercises the
-    // resolver's ISL fallback path (which the real staging fixture
-    // does not cover).
-    const ceeWithDownstreamIsl = {
+  it('lifts isl_response from downstream_calls.isl.response when _meta sidecar absent', () => {
+    const ceeWithDownstream = {
       blocks: [
         {
           type: 'analysis_result',
@@ -112,7 +276,7 @@ describe('resolveScientificEvidence — CEE-embedded fallback', () => {
               isl: {
                 response: {
                   factor_sensitivity: [
-                    { factor_id: 'f1', evpi_percentage_points: 5.2 },
+                    { factor_id: 'isl', evpi_percentage_points: 5.2 },
                   ],
                 },
               },
@@ -121,16 +285,15 @@ describe('resolveScientificEvidence — CEE-embedded fallback', () => {
         },
       ],
     }
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithDownstreamIsl)
-    expect(r.isl_response).not.toBeNull()
-    expect(r.isl_response_resolution.source).toBe('cee_embedded')
-    expect(r.isl_response_resolution.path).toMatch(
-      /^payloads\.cee_response\.blocks\[0\]\.enrichment\.downstream_calls\.isl\.response$/,
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithDownstream)
+    expect(r.resolution.isl_response.source).toBe('cee_embedded')
+    expect(r.resolution.isl_response.path).toBe(
+      'payloads.cee_response.blocks[0].enrichment.downstream_calls.isl.response',
     )
   })
 
-  it('picks the FIRST analysis_result block when multiple exist (predictable, reviewer-checkable)', () => {
-    const ceeWithMultipleBlocks = {
+  it('picks the FIRST analysis_result block when multiple exist', () => {
+    const ceeMulti = {
       blocks: [
         { type: 'text', text: 'noise' },
         {
@@ -143,45 +306,41 @@ describe('resolveScientificEvidence — CEE-embedded fallback', () => {
         },
       ],
     }
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithMultipleBlocks)
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeMulti)
     expect(
-      (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
+      (r.bodies.plot_response as Record<string, unknown>)?.factor_sensitivity,
     ).toEqual([{ factor_id: 'first' }])
-    expect(r.plot_response_resolution.path).toBe(
+    expect(r.resolution.plot_response.path).toBe(
       'payloads.cee_response.blocks[1].enrichment',
     )
   })
 })
 
 describe('resolveScientificEvidence — indicative-keys gate (no synthesis)', () => {
-  it('does NOT promote enrichment that lacks indicative keys', () => {
-    const ceeWithEmptyEnrichment = {
+  it('does NOT promote bare enrichment that lacks indicative keys', () => {
+    const ceeNoKeys = {
       blocks: [
         {
           type: 'analysis_result',
-          // No option_comparison, factor_sensitivity, m1_coaching,
-          // flip_thresholds, or robustness — just noise.
-          enrichment: { summary: 'A summary', leading_option_id: 'opt_1' },
+          enrichment: { summary: 'noise', leading_option_id: 'opt_1' },
         },
       ],
     }
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithEmptyEnrichment)
-    expect(r.plot_response).toBeNull()
-    expect(r.plot_response_resolution.source).toBe('unavailable')
-    expect(r.plot_response_resolution.path).toBeNull()
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeNoKeys)
+    expect(r.resolution.plot_response.source).toBe('unavailable')
+    expect(r.bodies.plot_response).toBeNull()
   })
 
-  it('does NOT promote enrichment={} (empty object)', () => {
-    const ceeWithEmptyObj = {
+  it('does NOT promote enrichment={} (empty)', () => {
+    const ceeEmpty = {
       blocks: [{ type: 'analysis_result', enrichment: {} }],
     }
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithEmptyObj)
-    expect(r.plot_response).toBeNull()
-    expect(r.plot_response_resolution.source).toBe('unavailable')
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeEmpty)
+    expect(r.resolution.plot_response.source).toBe('unavailable')
   })
 
-  it('promotes enrichment when ONLY robustness is present (single indicative key suffices)', () => {
-    const ceeWithRobustnessOnly = {
+  it('promotes enrichment when ONLY robustness is present (single key suffices)', () => {
+    const ceeRobOnly = {
       blocks: [
         {
           type: 'analysis_result',
@@ -189,129 +348,122 @@ describe('resolveScientificEvidence — indicative-keys gate (no synthesis)', ()
         },
       ],
     }
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithRobustnessOnly)
-    expect(r.plot_response_resolution.source).toBe('cee_embedded')
-    expect(r.plot_response).not.toBeNull()
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeRobOnly)
+    expect(r.resolution.plot_response.source).toBe('cee_embedded')
   })
 })
 
-describe('resolveScientificEvidence — unavailable when both missing', () => {
-  it('returns all unavailable when both top-level and CEE are null', () => {
+describe('resolveScientificEvidence — unavailable + metadata shape', () => {
+  it('returns all unavailable + populated metadata when nothing is present', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, null)
     // Bodies are null.
-    expect(r.plot_response).toBeNull()
-    expect(r.isl_request).toBeNull()
-    expect(r.isl_response).toBeNull()
-    // Each resolution block reports unavailable + null path +
+    expect(r.bodies.plot_request).toBeNull()
+    expect(r.bodies.plot_response).toBeNull()
+    expect(r.bodies.isl_request).toBeNull()
+    expect(r.bodies.isl_response).toBeNull()
+    // Each metadata entry reports unavailable + null path +
     // available=false + non-null required_upstream_support + a
     // non-empty diagnostic note.
-    for (const res of [
-      r.plot_response_resolution,
-      r.isl_request_resolution,
-      r.isl_response_resolution,
-    ]) {
-      expect(res.source).toBe('unavailable')
-      expect(res.path).toBeNull()
-      expect(res.available).toBe(false)
-      expect(typeof res.required_upstream_support).toBe('string')
-      expect((res.required_upstream_support as string).length).toBeGreaterThan(0)
-      expect(typeof res.notes).toBe('string')
-      expect(res.notes.length).toBeGreaterThan(0)
+    const kinds = [
+      r.resolution.plot_request,
+      r.resolution.plot_response,
+      r.resolution.isl_request,
+      r.resolution.isl_response,
+    ]
+    for (const e of kinds) {
+      expect(e.source).toBe('unavailable')
+      expect(e.path).toBeNull()
+      expect(e.available).toBe(false)
+      expect(typeof e.required_upstream_support).toBe('string')
+      expect((e.required_upstream_support as string).length).toBeGreaterThan(0)
+      expect(typeof e.notes).toBe('string')
+      expect(e.notes.length).toBeGreaterThan(0)
     }
-    // Type-anchor: ResolvedEvidence import is exercised through the
-    // resolver's return value shape.
-    const _typed: ResolvedEvidence = r
-    expect(_typed).toBe(r)
+    // Type-anchor for EvidenceResolutionReport import.
+    const _typed: EvidenceResolutionReport = r.resolution
+    expect(_typed).toBe(r.resolution)
   })
 
-  it('returns unavailable when CEE response has no analysis_result block', () => {
-    const ceeNoAnalysisBlock = {
-      blocks: [
-        { type: 'text', text: 'just a text block' },
-        { type: 'graph_patch', patch: { nodes: [] } },
-      ],
+  it('available=false ↔ required_upstream_support is non-null (invariant)', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, null)
+    for (const e of [
+      r.resolution.plot_request,
+      r.resolution.plot_response,
+      r.resolution.isl_request,
+      r.resolution.isl_response,
+    ]) {
+      // Strict iff: available iff required_upstream_support is null.
+      expect(e.available === (e.required_upstream_support === null)).toBe(true)
     }
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeNoAnalysisBlock)
-    expect(r.plot_response_resolution.source).toBe('unavailable')
-    expect(r.isl_response_resolution.source).toBe('unavailable')
   })
 })
 
-describe('resolveScientificEvidence — mixed sources (top-level + embedded)', () => {
-  it('top-level PLoT + embedded ISL (via downstream_calls)', () => {
-    const topLevel = {
-      plot_response: { factor_sensitivity: [{ factor_id: 'top' }] },
-      isl_request: null,
-      isl_response: null,
-    }
-    const ceeWithIsl = {
-      blocks: [
-        {
-          type: 'analysis_result',
-          enrichment: {
-            factor_sensitivity: [{ factor_id: 'embedded' }],
-            downstream_calls: {
-              isl: {
-                response: { factor_sensitivity: [{ factor_id: 'isl' }] },
+describe('resolveScientificEvidence — mixed sources', () => {
+  it('top-level PLoT + embedded ISL via downstream_calls', () => {
+    const r = resolveScientificEvidence(
+      {
+        ...EMPTY_TOP_LEVEL,
+        plot_response: { factor_sensitivity: [{ factor_id: 'top' }] },
+      },
+      {
+        blocks: [
+          {
+            type: 'analysis_result',
+            enrichment: {
+              factor_sensitivity: [{ factor_id: 'emb' }],
+              downstream_calls: {
+                isl: { response: { factor_sensitivity: [{ factor_id: 'isl' }] } },
               },
             },
           },
-        },
-      ],
-    }
-    const r = resolveScientificEvidence(topLevel, ceeWithIsl)
-    // PLoT comes from top-level (top-level wins).
-    expect(r.plot_response_resolution.source).toBe('top_level')
-    expect(
-      (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
-    ).toEqual([{ factor_id: 'top' }])
-    // ISL response comes from embedded (top-level was null).
-    expect(r.isl_response_resolution.source).toBe('cee_embedded')
-    expect(
-      (r.isl_response as Record<string, unknown>)?.factor_sensitivity,
-    ).toEqual([{ factor_id: 'isl' }])
+        ],
+      },
+    )
+    // PLoT from top-level.
+    expect(r.resolution.plot_response.source).toBe('top_level')
+    // ISL from embedded.
+    expect(r.resolution.isl_response.source).toBe('cee_embedded')
   })
 })
 
-describe('resolveScientificEvidence — malformed-input safety (no throws)', () => {
-  it('handles non-object ceeResponse', () => {
+describe('resolveScientificEvidence — malformed-input safety', () => {
+  it('handles non-object ceeResponse without throwing', () => {
     expect(() => resolveScientificEvidence(EMPTY_TOP_LEVEL, 'bad')).not.toThrow()
     expect(() => resolveScientificEvidence(EMPTY_TOP_LEVEL, 42)).not.toThrow()
     expect(() => resolveScientificEvidence(EMPTY_TOP_LEVEL, [])).not.toThrow()
   })
 
   it('handles ceeResponse.blocks not being an array', () => {
-    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, { blocks: 'not-array' })
-    expect(r.plot_response_resolution.source).toBe('unavailable')
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, { blocks: 'no' })
+    expect(r.resolution.plot_response.source).toBe('unavailable')
   })
 
   it('handles block missing type field', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
       blocks: [{ enrichment: { factor_sensitivity: [] } }],
     })
-    expect(r.plot_response_resolution.source).toBe('unavailable')
+    expect(r.resolution.plot_response.source).toBe('unavailable')
   })
 
   it('handles block.enrichment not being an object', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
-      blocks: [{ type: 'analysis_result', enrichment: 'string-not-object' }],
+      blocks: [{ type: 'analysis_result', enrichment: 'string' }],
     })
-    expect(r.plot_response_resolution.source).toBe('unavailable')
+    expect(r.resolution.plot_response.source).toBe('unavailable')
   })
 
-  it('handles top-level plot_response being an array (not object)', () => {
+  it('handles top-level plot_response being an array (defensively rejected)', () => {
     const r = resolveScientificEvidence(
-      { plot_response: [], isl_request: null, isl_response: null },
+      { ...EMPTY_TOP_LEVEL, plot_response: [] },
       null,
     )
-    // Array is NOT a plain object — defensive guard rejects it.
-    expect(r.plot_response_resolution.source).toBe('unavailable')
+    expect(r.resolution.plot_response.source).toBe('unavailable')
   })
 
   it('handles null/undefined block.enrichment', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
       blocks: [{ type: 'analysis_result', enrichment: null }],
     })
-    expect(r.plot_response_resolution.source).toBe('unavailable')
+    expect(r.resolution.plot_response.source).toBe('unavailable')
   })
 })

--- a/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
+++ b/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
@@ -37,8 +37,8 @@ describe('resolveScientificEvidence — top-level precedence', () => {
     }
     const r = resolveScientificEvidence(topLevel, realCeeShape)
     expect(r.plot_response).toEqual(topLevel.plot_response)
-    expect(r.plot_response_source).toBe('top_level')
-    expect(r.plot_response_source_path).toBe('payloads.plot_response')
+    expect(r.plot_response_resolution.source).toBe('top_level')
+    expect(r.plot_response_resolution.path).toBe('payloads.plot_response')
   })
 
   it('returns top-level isl_request when present', () => {
@@ -49,8 +49,8 @@ describe('resolveScientificEvidence — top-level precedence', () => {
     }
     const r = resolveScientificEvidence(topLevel, null)
     expect(r.isl_request).toEqual(topLevel.isl_request)
-    expect(r.isl_request_source).toBe('top_level')
-    expect(r.isl_request_source_path).toBe('payloads.isl_request')
+    expect(r.isl_request_resolution.source).toBe('top_level')
+    expect(r.isl_request_resolution.path).toBe('payloads.isl_request')
   })
 
   it('returns top-level isl_response when present', () => {
@@ -61,8 +61,8 @@ describe('resolveScientificEvidence — top-level precedence', () => {
     }
     const r = resolveScientificEvidence(topLevel, null)
     expect(r.isl_response).toEqual(topLevel.isl_response)
-    expect(r.isl_response_source).toBe('top_level')
-    expect(r.isl_response_source_path).toBe('payloads.isl_response')
+    expect(r.isl_response_resolution.source).toBe('top_level')
+    expect(r.isl_response_resolution.path).toBe('payloads.isl_response')
   })
 })
 
@@ -70,8 +70,8 @@ describe('resolveScientificEvidence — CEE-embedded fallback', () => {
   it('lifts enrichment as plot_response when top-level is null (real staging fixture)', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, realCeeShape)
     expect(r.plot_response).not.toBeNull()
-    expect(r.plot_response_source).toBe('cee_embedded')
-    expect(r.plot_response_source_path).toMatch(
+    expect(r.plot_response_resolution.source).toBe('cee_embedded')
+    expect(r.plot_response_resolution.path).toMatch(
       /^payloads\.cee_response\.blocks\[\d+\]\.enrichment$/,
     )
     // Sanity check that the resolver lifted the actual enrichment
@@ -91,11 +91,11 @@ describe('resolveScientificEvidence — CEE-embedded fallback', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, realCeeShape)
     // ISL fields stay unavailable — the fixture has no downstream_calls.isl.
     expect(r.isl_request).toBeNull()
-    expect(r.isl_request_source).toBe('unavailable')
-    expect(r.isl_request_source_path).toBeNull()
+    expect(r.isl_request_resolution.source).toBe('unavailable')
+    expect(r.isl_request_resolution.path).toBeNull()
     expect(r.isl_response).toBeNull()
-    expect(r.isl_response_source).toBe('unavailable')
-    expect(r.isl_response_source_path).toBeNull()
+    expect(r.isl_response_resolution.source).toBe('unavailable')
+    expect(r.isl_response_resolution.path).toBeNull()
   })
 
   it('lifts isl_response from enrichment.downstream_calls.isl.response when present', () => {
@@ -123,8 +123,8 @@ describe('resolveScientificEvidence — CEE-embedded fallback', () => {
     }
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithDownstreamIsl)
     expect(r.isl_response).not.toBeNull()
-    expect(r.isl_response_source).toBe('cee_embedded')
-    expect(r.isl_response_source_path).toMatch(
+    expect(r.isl_response_resolution.source).toBe('cee_embedded')
+    expect(r.isl_response_resolution.path).toMatch(
       /^payloads\.cee_response\.blocks\[0\]\.enrichment\.downstream_calls\.isl\.response$/,
     )
   })
@@ -147,7 +147,7 @@ describe('resolveScientificEvidence — CEE-embedded fallback', () => {
     expect(
       (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
     ).toEqual([{ factor_id: 'first' }])
-    expect(r.plot_response_source_path).toBe(
+    expect(r.plot_response_resolution.path).toBe(
       'payloads.cee_response.blocks[1].enrichment',
     )
   })
@@ -167,8 +167,8 @@ describe('resolveScientificEvidence — indicative-keys gate (no synthesis)', ()
     }
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithEmptyEnrichment)
     expect(r.plot_response).toBeNull()
-    expect(r.plot_response_source).toBe('unavailable')
-    expect(r.plot_response_source_path).toBeNull()
+    expect(r.plot_response_resolution.source).toBe('unavailable')
+    expect(r.plot_response_resolution.path).toBeNull()
   })
 
   it('does NOT promote enrichment={} (empty object)', () => {
@@ -177,7 +177,7 @@ describe('resolveScientificEvidence — indicative-keys gate (no synthesis)', ()
     }
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithEmptyObj)
     expect(r.plot_response).toBeNull()
-    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.plot_response_resolution.source).toBe('unavailable')
   })
 
   it('promotes enrichment when ONLY robustness is present (single indicative key suffices)', () => {
@@ -190,7 +190,7 @@ describe('resolveScientificEvidence — indicative-keys gate (no synthesis)', ()
       ],
     }
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithRobustnessOnly)
-    expect(r.plot_response_source).toBe('cee_embedded')
+    expect(r.plot_response_resolution.source).toBe('cee_embedded')
     expect(r.plot_response).not.toBeNull()
   })
 })
@@ -198,18 +198,30 @@ describe('resolveScientificEvidence — indicative-keys gate (no synthesis)', ()
 describe('resolveScientificEvidence — unavailable when both missing', () => {
   it('returns all unavailable when both top-level and CEE are null', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, null)
-    const expected: ResolvedEvidence = {
-      plot_response: null,
-      plot_response_source: 'unavailable',
-      plot_response_source_path: null,
-      isl_request: null,
-      isl_request_source: 'unavailable',
-      isl_request_source_path: null,
-      isl_response: null,
-      isl_response_source: 'unavailable',
-      isl_response_source_path: null,
+    // Bodies are null.
+    expect(r.plot_response).toBeNull()
+    expect(r.isl_request).toBeNull()
+    expect(r.isl_response).toBeNull()
+    // Each resolution block reports unavailable + null path +
+    // available=false + non-null required_upstream_support + a
+    // non-empty diagnostic note.
+    for (const res of [
+      r.plot_response_resolution,
+      r.isl_request_resolution,
+      r.isl_response_resolution,
+    ]) {
+      expect(res.source).toBe('unavailable')
+      expect(res.path).toBeNull()
+      expect(res.available).toBe(false)
+      expect(typeof res.required_upstream_support).toBe('string')
+      expect((res.required_upstream_support as string).length).toBeGreaterThan(0)
+      expect(typeof res.notes).toBe('string')
+      expect(res.notes.length).toBeGreaterThan(0)
     }
-    expect(r).toEqual(expected)
+    // Type-anchor: ResolvedEvidence import is exercised through the
+    // resolver's return value shape.
+    const _typed: ResolvedEvidence = r
+    expect(_typed).toBe(r)
   })
 
   it('returns unavailable when CEE response has no analysis_result block', () => {
@@ -220,8 +232,8 @@ describe('resolveScientificEvidence — unavailable when both missing', () => {
       ],
     }
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeNoAnalysisBlock)
-    expect(r.plot_response_source).toBe('unavailable')
-    expect(r.isl_response_source).toBe('unavailable')
+    expect(r.plot_response_resolution.source).toBe('unavailable')
+    expect(r.isl_response_resolution.source).toBe('unavailable')
   })
 })
 
@@ -249,12 +261,12 @@ describe('resolveScientificEvidence — mixed sources (top-level + embedded)', (
     }
     const r = resolveScientificEvidence(topLevel, ceeWithIsl)
     // PLoT comes from top-level (top-level wins).
-    expect(r.plot_response_source).toBe('top_level')
+    expect(r.plot_response_resolution.source).toBe('top_level')
     expect(
       (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
     ).toEqual([{ factor_id: 'top' }])
     // ISL response comes from embedded (top-level was null).
-    expect(r.isl_response_source).toBe('cee_embedded')
+    expect(r.isl_response_resolution.source).toBe('cee_embedded')
     expect(
       (r.isl_response as Record<string, unknown>)?.factor_sensitivity,
     ).toEqual([{ factor_id: 'isl' }])
@@ -270,21 +282,21 @@ describe('resolveScientificEvidence — malformed-input safety (no throws)', () 
 
   it('handles ceeResponse.blocks not being an array', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, { blocks: 'not-array' })
-    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.plot_response_resolution.source).toBe('unavailable')
   })
 
   it('handles block missing type field', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
       blocks: [{ enrichment: { factor_sensitivity: [] } }],
     })
-    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.plot_response_resolution.source).toBe('unavailable')
   })
 
   it('handles block.enrichment not being an object', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
       blocks: [{ type: 'analysis_result', enrichment: 'string-not-object' }],
     })
-    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.plot_response_resolution.source).toBe('unavailable')
   })
 
   it('handles top-level plot_response being an array (not object)', () => {
@@ -293,13 +305,13 @@ describe('resolveScientificEvidence — malformed-input safety (no throws)', () 
       null,
     )
     // Array is NOT a plain object — defensive guard rejects it.
-    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.plot_response_resolution.source).toBe('unavailable')
   })
 
   it('handles null/undefined block.enrichment', () => {
     const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
       blocks: [{ type: 'analysis_result', enrichment: null }],
     })
-    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.plot_response_resolution.source).toBe('unavailable')
   })
 })

--- a/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
+++ b/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit tests for `src/lib/v5EmbeddedEvidence.ts` —
+ * `resolveScientificEvidence` precedence + path-boundary +
+ * malformed-input safety.
+ *
+ * Post-PR #162 follow-up: under V5 canonical mode, the browser
+ * never fetches PLoT/ISL directly. Embedded enrichment in
+ * `bundle.payloads.cee_response.blocks[type==='analysis_result'].enrichment`
+ * is the only live evidence available to scientific validators.
+ * This resolver lifts it WITHOUT mutating `bundle.payloads.*`.
+ *
+ * Honesty contract: top-level capture wins (preserves dev/local
+ * path); embedded fallback requires at least one indicative key;
+ * missing fields stay missing.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  resolveScientificEvidence,
+  type ResolvedEvidence,
+} from '../v5EmbeddedEvidence'
+import realCeeShape from '../../v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json'
+
+const EMPTY_TOP_LEVEL = {
+  plot_response: null,
+  isl_request: null,
+  isl_response: null,
+}
+
+describe('resolveScientificEvidence — top-level precedence', () => {
+  it('returns top-level plot_response when present, regardless of CEE content', () => {
+    const topLevel = {
+      plot_response: { factor_sensitivity: [{ factor_id: 'f1' }] },
+      isl_request: null,
+      isl_response: null,
+    }
+    const r = resolveScientificEvidence(topLevel, realCeeShape)
+    expect(r.plot_response).toEqual(topLevel.plot_response)
+    expect(r.plot_response_source).toBe('top_level')
+    expect(r.plot_response_source_path).toBe('payloads.plot_response')
+  })
+
+  it('returns top-level isl_request when present', () => {
+    const topLevel = {
+      plot_response: null,
+      isl_request: { parameter_uncertainties: {} },
+      isl_response: null,
+    }
+    const r = resolveScientificEvidence(topLevel, null)
+    expect(r.isl_request).toEqual(topLevel.isl_request)
+    expect(r.isl_request_source).toBe('top_level')
+    expect(r.isl_request_source_path).toBe('payloads.isl_request')
+  })
+
+  it('returns top-level isl_response when present', () => {
+    const topLevel = {
+      plot_response: null,
+      isl_request: null,
+      isl_response: { factor_sensitivity: [{ factor_id: 'f1' }] },
+    }
+    const r = resolveScientificEvidence(topLevel, null)
+    expect(r.isl_response).toEqual(topLevel.isl_response)
+    expect(r.isl_response_source).toBe('top_level')
+    expect(r.isl_response_source_path).toBe('payloads.isl_response')
+  })
+})
+
+describe('resolveScientificEvidence — CEE-embedded fallback', () => {
+  it('lifts enrichment as plot_response when top-level is null (real staging fixture)', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, realCeeShape)
+    expect(r.plot_response).not.toBeNull()
+    expect(r.plot_response_source).toBe('cee_embedded')
+    expect(r.plot_response_source_path).toMatch(
+      /^payloads\.cee_response\.blocks\[\d+\]\.enrichment$/,
+    )
+    // Sanity check that the resolver lifted the actual enrichment
+    // (not a synthesized empty object).
+    expect(
+      (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
+    ).toBeDefined()
+    expect(
+      (r.plot_response as Record<string, unknown>)?.option_comparison,
+    ).toBeDefined()
+    expect(
+      (r.plot_response as Record<string, unknown>)?.robustness,
+    ).toBeDefined()
+  })
+
+  it('returns full ResolvedEvidence shape even when only plot_response is found', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, realCeeShape)
+    // ISL fields stay unavailable — the fixture has no downstream_calls.isl.
+    expect(r.isl_request).toBeNull()
+    expect(r.isl_request_source).toBe('unavailable')
+    expect(r.isl_request_source_path).toBeNull()
+    expect(r.isl_response).toBeNull()
+    expect(r.isl_response_source).toBe('unavailable')
+    expect(r.isl_response_source_path).toBeNull()
+  })
+
+  it('lifts isl_response from enrichment.downstream_calls.isl.response when present', () => {
+    // Synthetic CEE response with downstream_calls — exercises the
+    // resolver's ISL fallback path (which the real staging fixture
+    // does not cover).
+    const ceeWithDownstreamIsl = {
+      blocks: [
+        {
+          type: 'analysis_result',
+          enrichment: {
+            factor_sensitivity: [{ factor_id: 'f1' }],
+            downstream_calls: {
+              isl: {
+                response: {
+                  factor_sensitivity: [
+                    { factor_id: 'f1', evpi_percentage_points: 5.2 },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithDownstreamIsl)
+    expect(r.isl_response).not.toBeNull()
+    expect(r.isl_response_source).toBe('cee_embedded')
+    expect(r.isl_response_source_path).toMatch(
+      /^payloads\.cee_response\.blocks\[0\]\.enrichment\.downstream_calls\.isl\.response$/,
+    )
+  })
+
+  it('picks the FIRST analysis_result block when multiple exist (predictable, reviewer-checkable)', () => {
+    const ceeWithMultipleBlocks = {
+      blocks: [
+        { type: 'text', text: 'noise' },
+        {
+          type: 'analysis_result',
+          enrichment: { factor_sensitivity: [{ factor_id: 'first' }] },
+        },
+        {
+          type: 'analysis_result',
+          enrichment: { factor_sensitivity: [{ factor_id: 'second' }] },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithMultipleBlocks)
+    expect(
+      (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
+    ).toEqual([{ factor_id: 'first' }])
+    expect(r.plot_response_source_path).toBe(
+      'payloads.cee_response.blocks[1].enrichment',
+    )
+  })
+})
+
+describe('resolveScientificEvidence — indicative-keys gate (no synthesis)', () => {
+  it('does NOT promote enrichment that lacks indicative keys', () => {
+    const ceeWithEmptyEnrichment = {
+      blocks: [
+        {
+          type: 'analysis_result',
+          // No option_comparison, factor_sensitivity, m1_coaching,
+          // flip_thresholds, or robustness — just noise.
+          enrichment: { summary: 'A summary', leading_option_id: 'opt_1' },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithEmptyEnrichment)
+    expect(r.plot_response).toBeNull()
+    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.plot_response_source_path).toBeNull()
+  })
+
+  it('does NOT promote enrichment={} (empty object)', () => {
+    const ceeWithEmptyObj = {
+      blocks: [{ type: 'analysis_result', enrichment: {} }],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithEmptyObj)
+    expect(r.plot_response).toBeNull()
+    expect(r.plot_response_source).toBe('unavailable')
+  })
+
+  it('promotes enrichment when ONLY robustness is present (single indicative key suffices)', () => {
+    const ceeWithRobustnessOnly = {
+      blocks: [
+        {
+          type: 'analysis_result',
+          enrichment: { robustness: { fragile_edges: [] } },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeWithRobustnessOnly)
+    expect(r.plot_response_source).toBe('cee_embedded')
+    expect(r.plot_response).not.toBeNull()
+  })
+})
+
+describe('resolveScientificEvidence — unavailable when both missing', () => {
+  it('returns all unavailable when both top-level and CEE are null', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, null)
+    const expected: ResolvedEvidence = {
+      plot_response: null,
+      plot_response_source: 'unavailable',
+      plot_response_source_path: null,
+      isl_request: null,
+      isl_request_source: 'unavailable',
+      isl_request_source_path: null,
+      isl_response: null,
+      isl_response_source: 'unavailable',
+      isl_response_source_path: null,
+    }
+    expect(r).toEqual(expected)
+  })
+
+  it('returns unavailable when CEE response has no analysis_result block', () => {
+    const ceeNoAnalysisBlock = {
+      blocks: [
+        { type: 'text', text: 'just a text block' },
+        { type: 'graph_patch', patch: { nodes: [] } },
+      ],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, ceeNoAnalysisBlock)
+    expect(r.plot_response_source).toBe('unavailable')
+    expect(r.isl_response_source).toBe('unavailable')
+  })
+})
+
+describe('resolveScientificEvidence — mixed sources (top-level + embedded)', () => {
+  it('top-level PLoT + embedded ISL (via downstream_calls)', () => {
+    const topLevel = {
+      plot_response: { factor_sensitivity: [{ factor_id: 'top' }] },
+      isl_request: null,
+      isl_response: null,
+    }
+    const ceeWithIsl = {
+      blocks: [
+        {
+          type: 'analysis_result',
+          enrichment: {
+            factor_sensitivity: [{ factor_id: 'embedded' }],
+            downstream_calls: {
+              isl: {
+                response: { factor_sensitivity: [{ factor_id: 'isl' }] },
+              },
+            },
+          },
+        },
+      ],
+    }
+    const r = resolveScientificEvidence(topLevel, ceeWithIsl)
+    // PLoT comes from top-level (top-level wins).
+    expect(r.plot_response_source).toBe('top_level')
+    expect(
+      (r.plot_response as Record<string, unknown>)?.factor_sensitivity,
+    ).toEqual([{ factor_id: 'top' }])
+    // ISL response comes from embedded (top-level was null).
+    expect(r.isl_response_source).toBe('cee_embedded')
+    expect(
+      (r.isl_response as Record<string, unknown>)?.factor_sensitivity,
+    ).toEqual([{ factor_id: 'isl' }])
+  })
+})
+
+describe('resolveScientificEvidence — malformed-input safety (no throws)', () => {
+  it('handles non-object ceeResponse', () => {
+    expect(() => resolveScientificEvidence(EMPTY_TOP_LEVEL, 'bad')).not.toThrow()
+    expect(() => resolveScientificEvidence(EMPTY_TOP_LEVEL, 42)).not.toThrow()
+    expect(() => resolveScientificEvidence(EMPTY_TOP_LEVEL, [])).not.toThrow()
+  })
+
+  it('handles ceeResponse.blocks not being an array', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, { blocks: 'not-array' })
+    expect(r.plot_response_source).toBe('unavailable')
+  })
+
+  it('handles block missing type field', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      blocks: [{ enrichment: { factor_sensitivity: [] } }],
+    })
+    expect(r.plot_response_source).toBe('unavailable')
+  })
+
+  it('handles block.enrichment not being an object', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      blocks: [{ type: 'analysis_result', enrichment: 'string-not-object' }],
+    })
+    expect(r.plot_response_source).toBe('unavailable')
+  })
+
+  it('handles top-level plot_response being an array (not object)', () => {
+    const r = resolveScientificEvidence(
+      { plot_response: [], isl_request: null, isl_response: null },
+      null,
+    )
+    // Array is NOT a plain object — defensive guard rejects it.
+    expect(r.plot_response_source).toBe('unavailable')
+  })
+
+  it('handles null/undefined block.enrichment', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      blocks: [{ type: 'analysis_result', enrichment: null }],
+    })
+    expect(r.plot_response_source).toBe('unavailable')
+  })
+})

--- a/src/lib/scientificValidation/index.ts
+++ b/src/lib/scientificValidation/index.ts
@@ -89,6 +89,17 @@ function classifySource(
         // trustworthy. The bundle's evidence-source rollup will
         // settle on `hydrated_report` or `debug_fallback`.
       } else {
+        // Evidence-resolver follow-up (post-PR #162): when the
+        // resolved `plotResponse` came from CEE V5 embedded
+        // enrichment, emit a distinct label so reviewers can
+        // discriminate "top-level captured raw" vs "lifted from
+        // CEE V5 turn enrichment". Both are live raw evidence;
+        // the label is an informational source discriminator.
+        // The indicative-keys gate above + the usability gate
+        // above STILL apply — no relaxation of honesty here.
+        if (inputs.plotResponseSource === 'cee_embedded') {
+          return 'live_v5_cee_embedded'
+        }
         return 'live_raw_payloads'
       }
     }

--- a/src/lib/scientificValidation/index.ts
+++ b/src/lib/scientificValidation/index.ts
@@ -97,10 +97,26 @@ function classifySource(
         // the label is an informational source discriminator.
         // The indicative-keys gate above + the usability gate
         // above STILL apply — no relaxation of honesty here.
+        //
+        // Reviewer R-2 Blocker 2: when source is `'cee_embedded'`,
+        // we ADDITIONALLY require `ceeCaptureIsSelectedV5Turn` to
+        // be `true`. That signal comes from the CEE-side
+        // analysis-producing selector's provenance — only an
+        // `'analysis_producing_v5_turn'` or `'fallback_v5_turn'`
+        // capture qualifies. A legacy / stale / non-selected CEE
+        // response with `analysis_result.enrichment` MUST NOT
+        // be labelled live, regardless of body shape.
         if (inputs.plotResponseSource === 'cee_embedded') {
-          return 'live_v5_cee_embedded'
+          if (inputs.ceeCaptureIsSelectedV5Turn === true) {
+            return 'live_v5_cee_embedded'
+          }
+          // Not a selected V5 turn — fall through to the non-live
+          // labels below. The body had indicative-key shape but
+          // the capture provenance is wrong; we refuse to label
+          // as live evidence.
+        } else {
+          return 'live_raw_payloads'
         }
-        return 'live_raw_payloads'
       }
     }
   }

--- a/src/lib/scientificValidation/types.ts
+++ b/src/lib/scientificValidation/types.ts
@@ -136,6 +136,28 @@ export interface ValidatorInputs {
    * `selectedPlotTraceIsUsableLiveEvidence` gate.
    */
   plotResponseSource?: 'top_level' | 'cee_embedded' | 'unavailable'
+  /**
+   * Reviewer R-2 Blocker 2 gate: when the resolver's
+   * `plotResponseSource` is `'cee_embedded'`, the classifier must
+   * ALSO verify that `bundle.payloads.cee_response` was the
+   * SELECTED analysis-producing V5 turn — NOT a legacy / stale /
+   * fallback-legacy capture that happens to carry an
+   * `analysis_result` block.
+   *
+   * The bundle assembler computes this from
+   * `data.cee_capture_provenance` (`'analysis_producing_v5_turn'`
+   * OR `'fallback_v5_turn'` → true; anything else → false).
+   *
+   * `true`  → `classifySource` may emit `'live_v5_cee_embedded'`.
+   * `false` → classifier falls through to non-live source labels
+   *           (`'hydrated_report'` / `'unavailable'`) regardless
+   *           of body shape, preserving live-evidence honesty.
+   *
+   * Optional — defaults to `false` for legacy / sync-path callers
+   * (those callers don't supply embedded evidence either, so the
+   * default doesn't change behaviour for them).
+   */
+  ceeCaptureIsSelectedV5Turn?: boolean
 }
 
 /**

--- a/src/lib/scientificValidation/types.ts
+++ b/src/lib/scientificValidation/types.ts
@@ -47,8 +47,32 @@ export type ScientificValidationOverallStatus =
 
 export interface ScientificValidation {
   overall_status: ScientificValidationOverallStatus
-  /** Whether any raw PLoT payload was found in the bundle. */
-  source: 'live_raw_payloads' | 'hydrated_report' | 'debug_fallback' | 'unavailable'
+  /**
+   * Source of the evidence the validators actually consumed.
+   *
+   *   - `'live_raw_payloads'`     — top-level `bundle.payloads.plot_response`
+   *     was non-null AND carried at least one indicative key. The
+   *     classical "dev/local PLoT captured directly" path.
+   *   - `'live_v5_cee_embedded'`  — evidence resolver lifted the
+   *     analysis enrichment out of the CEE V5 turn response
+   *     (`bundle.payloads.cee_response.blocks[type==='analysis_result'].enrichment`)
+   *     because the top-level PLoT payload was null. Same indicative-keys
+   *     gate applies — empty or placeholder enrichment does NOT promote
+   *     to this label. Informational discriminator vs `'live_raw_payloads'`;
+   *     both are live raw evidence.
+   *   - `'hydrated_report'`       — no live capture or embedded
+   *     enrichment; canvas-store results.report carried derived
+   *     evidence.
+   *   - `'debug_fallback'`        — capture pipeline reported
+   *     `results_rendered_from_store_without_capture`.
+   *   - `'unavailable'`           — none of the above; honest fallback.
+   */
+  source:
+    | 'live_raw_payloads'
+    | 'live_v5_cee_embedded'
+    | 'hydrated_report'
+    | 'debug_fallback'
+    | 'unavailable'
   /** Validators keyed by name for easy lookup. */
   validators: Record<ValidatorName, ValidatorResult>
 }
@@ -90,6 +114,28 @@ export interface ValidatorInputs {
    * value.
    */
   selectedPlotTraceIsUsableLiveEvidence?: boolean
+  /**
+   * Evidence-resolver follow-up (post-PR #162): tells `classifySource`
+   * WHERE the resolved `plotResponse` came from so it can emit the
+   * appropriate `source` label:
+   *
+   *   - `'top_level'`    → `'live_raw_payloads'` (existing behaviour)
+   *   - `'cee_embedded'` → `'live_v5_cee_embedded'` (new label —
+   *     informational discriminator; same indicative-keys gate
+   *     applies, so an empty/placeholder embedded body cannot
+   *     promote to this label)
+   *   - `'unavailable'`  → falls through to `'hydrated_report'` /
+   *     `'debug_fallback'` / `'unavailable'` as before
+   *
+   * Optional — when undefined (legacy / sync-path callers), the
+   * classifier behaves exactly as it did before this field
+   * existed: top-level body shape alone determines the live label.
+   *
+   * Honesty boundary: this field is a label discriminator. It does
+   * NOT relax the indicative-keys gate or the
+   * `selectedPlotTraceIsUsableLiveEvidence` gate.
+   */
+  plotResponseSource?: 'top_level' | 'cee_embedded' | 'unavailable'
 }
 
 /**

--- a/src/lib/v5EmbeddedEvidence.ts
+++ b/src/lib/v5EmbeddedEvidence.ts
@@ -51,48 +51,80 @@
 export type EvidenceSource = 'top_level' | 'cee_embedded' | 'unavailable'
 
 /**
- * Output shape of `resolveScientificEvidence`. Always returns the
- * FULL shape — callers can read `*_source` and `*_source_path`
- * without optional chaining. Each evidence kind is resolved
- * independently (top-level PLoT + embedded ISL is a valid mix).
+ * Per-evidence-kind resolution metadata. Same shape regardless of
+ * which kind it describes. Matches the workstream spec's metadata
+ * suggestion (`source`, `path`, `available`, `required_upstream_support`,
+ * `notes`) so reviewers can read each evidence kind's provenance in
+ * a uniform way.
+ */
+export interface EvidenceResolutionEntry {
+  /** Source the evidence came from. */
+  source: EvidenceSource
+  /**
+   * Concrete pathname pointing at WHERE the resolved evidence body
+   * lives in the bundle, for reviewer transparency. Examples:
+   *   - `'payloads.plot_response'`                                  (top-level)
+   *   - `'payloads.cee_response.blocks[3].enrichment'`              (embedded)
+   *   - `null`                                                      (unavailable)
+   */
+  path: string | null
+  /** Convenience: `source !== 'unavailable'`. */
+  available: boolean
+  /**
+   * When `available === false`, a concise description of what
+   * upstream support (CEE / PLoT / ISL emission, or a top-level
+   * capture path) would make this evidence kind available. `null`
+   * when the evidence IS available — no upstream gap to document.
+   */
+  required_upstream_support: string | null
+  /** Short diagnostic note explaining the resolution decision. */
+  notes: string
+}
+
+/**
+ * Output shape of `resolveScientificEvidence`. Each evidence kind
+ * has:
+ *   - the resolved body (or `null`)
+ *   - a `resolution` block carrying source / path / availability /
+ *     upstream-support / notes metadata.
+ *
+ * Always returns the FULL shape — callers can read metadata without
+ * optional chaining. Each evidence kind is resolved independently
+ * (top-level PLoT + embedded ISL is a valid mix).
  */
 export interface ResolvedEvidence {
   /**
-   * Resolved PLoT response object. `null` only when neither
+   * Resolved PLoT response body. `null` only when neither
    * the top-level capture nor the embedded enrichment is usable.
    */
   plot_response: Record<string, unknown> | null
-  plot_response_source: EvidenceSource
-  /**
-   * Concrete pathname pointing at WHERE the resolved evidence
-   * was sourced (for reviewer transparency). Example values:
-   *   - `'payloads.plot_response'` (top-level)
-   *   - `'payloads.cee_response.blocks[3].enrichment'` (embedded)
-   *   - `null` (source is `'unavailable'`)
-   */
-  plot_response_source_path: string | null
+  plot_response_resolution: EvidenceResolutionEntry
 
   /**
-   * ISL request — resolved identically. V5 canonical does NOT
-   * carry an ISL request body in the enrichment block today, so
-   * this field commonly resolves to `'unavailable'`. The resolver
-   * threads it for symmetry + future-proofing if/when CEE exposes
-   * an ISL request side.
+   * ISL request body. V5 canonical does NOT carry an ISL request
+   * in the enrichment block today, so this field commonly resolves
+   * to `'unavailable'`. Threaded for symmetry + future-proofing.
    */
   isl_request: Record<string, unknown> | null
-  isl_request_source: EvidenceSource
-  isl_request_source_path: string | null
+  isl_request_resolution: EvidenceResolutionEntry
 
   /**
-   * ISL response — resolved identically. When the enrichment has
-   * `downstream_calls.isl.response` (path used by the V2
-   * responseMapper), the resolver lifts that body. Otherwise
+   * ISL response body. When the enrichment exposes
+   * `downstream_calls.isl.response` (same path the V2
+   * responseMapper uses), the resolver lifts that body. Otherwise
    * `'unavailable'`.
    */
   isl_response: Record<string, unknown> | null
-  isl_response_source: EvidenceSource
-  isl_response_source_path: string | null
+  isl_response_resolution: EvidenceResolutionEntry
 }
+
+/** Required-upstream-support strings (shared, single source of truth). */
+const REQUIRED_UPSTREAM_PLOT_RESPONSE =
+  'Top-level capture from `payloads.plot_response` OR CEE V5 response carrying an `analysis_result` block whose `enrichment` includes at least one of: option_comparison, factor_sensitivity, m1_coaching, flip_thresholds, robustness.'
+const REQUIRED_UPSTREAM_ISL_REQUEST =
+  'Top-level capture from `payloads.isl_request`. The V5 CEE enrichment does NOT currently embed an ISL request body; CEE would need to expose one (e.g. via `enrichment.downstream_calls.isl.request`) for resolution from `cee_embedded`.'
+const REQUIRED_UPSTREAM_ISL_RESPONSE =
+  'Top-level capture from `payloads.isl_response` OR CEE V5 response carrying `enrichment.downstream_calls.isl.response`.'
 
 /**
  * Indicative keys that mark a CEE V5 enrichment block as actually
@@ -173,6 +205,23 @@ function enrichmentHasIndicativeKey(
  * Pure function. Defensive on malformed inputs (returns
  * `'unavailable'` rather than throwing).
  */
+/** Build the metadata block for a given evidence kind. */
+function buildResolution(
+  source: EvidenceSource,
+  path: string | null,
+  notes: string,
+  requiredUpstreamSupport: string,
+): EvidenceResolutionEntry {
+  const available = source !== 'unavailable'
+  return {
+    source,
+    path,
+    available,
+    required_upstream_support: available ? null : requiredUpstreamSupport,
+    notes,
+  }
+}
+
 export function resolveScientificEvidence(
   topLevel: {
     plot_response: unknown
@@ -183,13 +232,16 @@ export function resolveScientificEvidence(
 ): ResolvedEvidence {
   // -------------------- plot_response ---------------------------
   let plot_response: Record<string, unknown> | null = null
-  let plot_response_source: EvidenceSource = 'unavailable'
-  let plot_response_source_path: string | null = null
+  let plot_response_resolution: EvidenceResolutionEntry
 
   if (isPlainObject(topLevel.plot_response)) {
     plot_response = topLevel.plot_response
-    plot_response_source = 'top_level'
-    plot_response_source_path = 'payloads.plot_response'
+    plot_response_resolution = buildResolution(
+      'top_level',
+      'payloads.plot_response',
+      'Top-level capture from `payloads.plot_response` (dev/local or direct-PLoT path).',
+      REQUIRED_UPSTREAM_PLOT_RESPONSE,
+    )
   } else {
     // Embedded fallback — only when the analysis_result block
     // carries indicative keys.
@@ -198,46 +250,73 @@ export function resolveScientificEvidence(
       const enrichment = found.block.enrichment
       if (isPlainObject(enrichment) && enrichmentHasIndicativeKey(enrichment)) {
         plot_response = enrichment
-        plot_response_source = 'cee_embedded'
-        plot_response_source_path = `payloads.cee_response.blocks[${found.index}].enrichment`
+        plot_response_resolution = buildResolution(
+          'cee_embedded',
+          `payloads.cee_response.blocks[${found.index}].enrichment`,
+          'Lifted from CEE V5 turn `analysis_result` block enrichment. Top-level `payloads.plot_response` was null (V5 canonical mode); enrichment carries at least one indicative key.',
+          REQUIRED_UPSTREAM_PLOT_RESPONSE,
+        )
+      } else {
+        plot_response_resolution = buildResolution(
+          'unavailable',
+          null,
+          'Found an `analysis_result` block but its `enrichment` is missing or lacks any indicative key (option_comparison, factor_sensitivity, m1_coaching, flip_thresholds, robustness). Not promoted — empty/placeholder bodies are not treated as live evidence.',
+          REQUIRED_UPSTREAM_PLOT_RESPONSE,
+        )
       }
+    } else {
+      plot_response_resolution = buildResolution(
+        'unavailable',
+        null,
+        'Neither top-level `payloads.plot_response` nor a CEE V5 `analysis_result` block was found.',
+        REQUIRED_UPSTREAM_PLOT_RESPONSE,
+      )
     }
   }
 
   // -------------------- isl_request -----------------------------
   // V5 canonical enrichment does NOT carry an ISL request body in
-  // the staging-real fixture. We thread the field for symmetry +
-  // honesty. Top-level only.
+  // the staging-real fixture. Top-level only for now; the unavailable
+  // branch documents the CEE side that would be needed.
   let isl_request: Record<string, unknown> | null = null
-  let isl_request_source: EvidenceSource = 'unavailable'
-  let isl_request_source_path: string | null = null
+  let isl_request_resolution: EvidenceResolutionEntry
 
   if (isPlainObject(topLevel.isl_request)) {
     isl_request = topLevel.isl_request
-    isl_request_source = 'top_level'
-    isl_request_source_path = 'payloads.isl_request'
+    isl_request_resolution = buildResolution(
+      'top_level',
+      'payloads.isl_request',
+      'Top-level capture from `payloads.isl_request`.',
+      REQUIRED_UPSTREAM_ISL_REQUEST,
+    )
+  } else {
+    isl_request_resolution = buildResolution(
+      'unavailable',
+      null,
+      'No top-level `payloads.isl_request`. The V5 CEE turn enrichment does not currently embed an ISL request body; if/when CEE exposes one (e.g. via `enrichment.downstream_calls.isl.request`), this resolver will need a `cee_embedded` branch to pick it up.',
+      REQUIRED_UPSTREAM_ISL_REQUEST,
+    )
   }
-  // No `cee_embedded` branch for isl_request — the V5 enrichment
-  // does not embed an ISL request body. If CEE later exposes one
-  // (e.g. under `enrichment.downstream_calls.isl.request`), add
-  // that branch here.
 
   // -------------------- isl_response ----------------------------
   let isl_response: Record<string, unknown> | null = null
-  let isl_response_source: EvidenceSource = 'unavailable'
-  let isl_response_source_path: string | null = null
+  let isl_response_resolution: EvidenceResolutionEntry
 
   if (isPlainObject(topLevel.isl_response)) {
     isl_response = topLevel.isl_response
-    isl_response_source = 'top_level'
-    isl_response_source_path = 'payloads.isl_response'
+    isl_response_resolution = buildResolution(
+      'top_level',
+      'payloads.isl_response',
+      'Top-level capture from `payloads.isl_response`.',
+      REQUIRED_UPSTREAM_ISL_RESPONSE,
+    )
   } else {
     // Embedded fallback — probe
     // `analysis_result_block.enrichment.downstream_calls.isl.response`.
-    // Same path the V2 responseMapper uses, kept here for
-    // reviewer-transparency (the path string surfaces in
-    // `isl_response_source_path`).
+    // Same path the V2 responseMapper uses.
     const found = findAnalysisResultBlock(ceeResponse)
+    let embeddedResponse: Record<string, unknown> | null = null
+    let embeddedPath: string | null = null
     if (found !== null) {
       const enrichment = found.block.enrichment
       if (isPlainObject(enrichment)) {
@@ -247,25 +326,37 @@ export function resolveScientificEvidence(
           if (isPlainObject(isl)) {
             const response = isl.response
             if (isPlainObject(response)) {
-              isl_response = response
-              isl_response_source = 'cee_embedded'
-              isl_response_source_path = `payloads.cee_response.blocks[${found.index}].enrichment.downstream_calls.isl.response`
+              embeddedResponse = response
+              embeddedPath = `payloads.cee_response.blocks[${found.index}].enrichment.downstream_calls.isl.response`
             }
           }
         }
       }
     }
+    if (embeddedResponse !== null && embeddedPath !== null) {
+      isl_response = embeddedResponse
+      isl_response_resolution = buildResolution(
+        'cee_embedded',
+        embeddedPath,
+        'Lifted from CEE V5 turn enrichment `downstream_calls.isl.response`.',
+        REQUIRED_UPSTREAM_ISL_RESPONSE,
+      )
+    } else {
+      isl_response_resolution = buildResolution(
+        'unavailable',
+        null,
+        'Neither top-level `payloads.isl_response` nor an embedded `enrichment.downstream_calls.isl.response` was found.',
+        REQUIRED_UPSTREAM_ISL_RESPONSE,
+      )
+    }
   }
 
   return {
     plot_response,
-    plot_response_source,
-    plot_response_source_path,
+    plot_response_resolution,
     isl_request,
-    isl_request_source,
-    isl_request_source_path,
+    isl_request_resolution,
     isl_response,
-    isl_response_source,
-    isl_response_source_path,
+    isl_response_resolution,
   }
 }

--- a/src/lib/v5EmbeddedEvidence.ts
+++ b/src/lib/v5EmbeddedEvidence.ts
@@ -6,66 +6,102 @@
  * PLoT `/v2/run` or ISL directly — analysis runs server-side inside
  * CEE. So `bundle.payloads.plot_response` / `plot_request` /
  * `isl_request` / `isl_response` are honestly null. But the CEE V5
- * turn response embeds analysis evidence under
- * `response.blocks[type==='analysis_result'].enrichment` (confirmed
- * by `src/v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json`,
- * a real staging capture from 2026-04-30).
+ * turn response embeds analysis evidence in two known places:
  *
- * Scientific validators in `src/lib/scientificValidation/*` are
- * hard-wired to read from `inputs.plotResponse` / `inputs.islRequest`
- * / `inputs.islResponse`. They never look at `inputs.ceeResponse`.
- * So embedded enrichment was ignored.
+ *   1. `response.blocks[type==='analysis_result'].enrichment`
+ *      — the canonical PLoT-shaped enrichment. Confirmed by
+ *      `src/v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json`
+ *      (real staging capture, 2026-04-30).
  *
- * This module surfaces embedded enrichment to validators WITHOUT
- * mutating `bundle.payloads.*` (which stays raw-capture truth). The
- * bundle assembler calls `resolveScientificEvidence` to compute a
- * resolved view + per-evidence-type source metadata; validators see
- * the resolved view; the bundle exposes the source metadata under
- * `bundle.evidence_resolution` for reviewer transparency.
+ *   2. `response.blocks[type==='analysis_result'].enrichment._meta.payloads`
+ *      — an optional metadata sidecar carrying the raw upstream
+ *      `plot_request`, `plot_response`, `isl_request`,
+ *      `isl_response` bodies. Forward-compatible path declared in
+ *      the workstream spec; the resolver probes it defensively
+ *      whether or not the current build emits it. When present, it
+ *      surfaces evidence that the simple `enrichment` shape lacks
+ *      (e.g. `confidence_provenance`, `evpi_percentage_points`,
+ *      `flip_thresholds_status`, ISL `parameter_uncertainties`).
+ *
+ * Scientific validators are hard-wired to read from `inputs.plotResponse`
+ * / `inputs.islRequest` / `inputs.islResponse`. This resolver lifts
+ * embedded bodies into the validator inputs WITHOUT mutating
+ * `bundle.payloads.*` (raw-capture truth preserved). The resolved
+ * source metadata is exported under `bundle.evidence_resolution` for
+ * reviewer transparency.
+ *
+ * Resolution precedence per evidence kind:
+ *
+ *   1. Top-level capture (`bundle.payloads.{plot,isl}_*`).
+ *      Preserves dev/local and direct-capture paths.
+ *
+ *   2. CEE V5 embedded — first the `_meta.payloads` sidecar
+ *      (if present and carries a usable body), then the
+ *      `analysis_result.enrichment` body. `_meta.payloads` wins
+ *      among embedded sources because it carries upstream-shape
+ *      bodies (closer to the truth) while bare `enrichment` is
+ *      a PLoT-shaped projection.
+ *
+ *   3. `'unavailable'`.
  *
  * Honesty contract:
- *   - Top-level capture wins over embedded (preserves dev/local and
- *     any future direct-PLoT capture path).
- *   - Embedded enrichment is promoted ONLY when it carries at least
- *     one of the canonical indicative keys (`option_comparison`,
+ *   - Top-level beats embedded — always.
+ *   - Embedded `plot_response` is promoted only when it carries at
+ *     least one of the canonical indicative keys (`option_comparison`,
  *     `factor_sensitivity`, `m1_coaching`, `flip_thresholds`,
- *     `robustness`). An empty `enrichment: {}` does NOT count.
- *   - Missing fields stay missing. The resolver does NOT fabricate
- *     `plot_request`, does NOT reconstruct ISL from canvas / UI
- *     state, does NOT infer EVPI / flip thresholds / confidence
- *     from anything other than the captured embedded body.
- *   - The resolver is pure: no store reads, no React, no side
- *     effects.
+ *     `robustness`). Mirrors `RAW_PAYLOAD_INDICATIVE_KEYS` in
+ *     `src/lib/scientificValidation/index.ts` so classifier and
+ *     resolver agree on what counts as "real" evidence.
+ *   - Other evidence kinds (`plot_request`, `isl_request`,
+ *     `isl_response`) require only a non-empty plain-object body —
+ *     they're metadata sidecars, not analysis bodies, so the
+ *     indicative-keys gate does not apply.
+ *   - Missing fields stay missing. The resolver does NOT fabricate.
+ *   - The resolver is pure: no store reads, no React, no side effects.
  */
 
 /**
  * Where the resolved evidence came from.
  *
- *   - `'top_level'`    — `bundle.payloads.plot_response` etc.
- *     (or sibling fields) were non-null. Dev/local path.
- *   - `'cee_embedded'` — extracted from the analysis_result block
- *     inside `bundle.payloads.cee_response`. Staging V5 canonical path.
- *   - `'unavailable'`  — neither top-level capture NOR embedded
- *     enrichment had usable evidence.
+ *   - `'top_level'`     — `bundle.payloads.{plot,isl}_*` was non-null.
+ *   - `'cee_embedded'`  — lifted from somewhere inside
+ *                          `bundle.payloads.cee_response` (either
+ *                          `_meta.payloads` or the
+ *                          `analysis_result.enrichment` body).
+ *                          `evidence_resolution.<kind>.path` records
+ *                          the exact nested path used.
+ *   - `'unavailable'`   — neither source carried a usable body.
  */
 export type EvidenceSource = 'top_level' | 'cee_embedded' | 'unavailable'
 
 /**
- * Per-evidence-kind resolution metadata. Same shape regardless of
- * which kind it describes. Matches the workstream spec's metadata
- * suggestion (`source`, `path`, `available`, `required_upstream_support`,
- * `notes`) so reviewers can read each evidence kind's provenance in
- * a uniform way.
+ * Per-evidence-kind metadata exposed on `bundle.evidence_resolution`.
+ * One block per evidence kind. Reviewers read:
+ *
+ *   evidence_resolution.plot_response.source
+ *   evidence_resolution.plot_response.path
+ *   evidence_resolution.plot_response.available
+ *   evidence_resolution.plot_response.required_upstream_support
+ *   evidence_resolution.plot_response.notes
+ *
+ * The actual resolved body is NOT included in this metadata — it
+ * lives in `bundle.payloads.*` (raw browser capture, possibly null)
+ * AND/OR can be traced via the `path` string. Validators consume
+ * the body separately via `ValidatorInputs.{plotResponse,islRequest,islResponse}`,
+ * threaded by `exportBundle.ts` from the resolver's separate body
+ * return.
  */
 export interface EvidenceResolutionEntry {
   /** Source the evidence came from. */
   source: EvidenceSource
   /**
-   * Concrete pathname pointing at WHERE the resolved evidence body
-   * lives in the bundle, for reviewer transparency. Examples:
-   *   - `'payloads.plot_response'`                                  (top-level)
-   *   - `'payloads.cee_response.blocks[3].enrichment'`              (embedded)
-   *   - `null`                                                      (unavailable)
+   * Concrete pathname pointing at WHERE the resolved body lives,
+   * for reviewer transparency. Examples:
+   *   - `'payloads.plot_response'`                                   (top-level)
+   *   - `'payloads.cee_response.blocks[3].enrichment'`               (cee_embedded — bare enrichment)
+   *   - `'payloads.cee_response.blocks[3].enrichment._meta.payloads.plot_response'`
+   *                                                                  (cee_embedded — meta sidecar)
+   *   - `null`                                                       (unavailable)
    */
   path: string | null
   /** Convenience: `source !== 'unavailable'`. */
@@ -77,65 +113,45 @@ export interface EvidenceResolutionEntry {
    * when the evidence IS available — no upstream gap to document.
    */
   required_upstream_support: string | null
-  /** Short diagnostic note explaining the resolution decision. */
+  /** Short diagnostic note explaining the resolver's decision. */
   notes: string
 }
 
 /**
- * Output shape of `resolveScientificEvidence`. Each evidence kind
- * has:
- *   - the resolved body (or `null`)
- *   - a `resolution` block carrying source / path / availability /
- *     upstream-support / notes metadata.
- *
- * Always returns the FULL shape — callers can read metadata without
- * optional chaining. Each evidence kind is resolved independently
- * (top-level PLoT + embedded ISL is a valid mix).
+ * Exported on `bundle.evidence_resolution`. Pure metadata —
+ * resolved bodies live elsewhere (see `resolveScientificEvidence`'s
+ * return shape for caller-side threading).
  */
-export interface ResolvedEvidence {
-  /**
-   * Resolved PLoT response body. `null` only when neither
-   * the top-level capture nor the embedded enrichment is usable.
-   */
-  plot_response: Record<string, unknown> | null
-  plot_response_resolution: EvidenceResolutionEntry
-
-  /**
-   * ISL request body. V5 canonical does NOT carry an ISL request
-   * in the enrichment block today, so this field commonly resolves
-   * to `'unavailable'`. Threaded for symmetry + future-proofing.
-   */
-  isl_request: Record<string, unknown> | null
-  isl_request_resolution: EvidenceResolutionEntry
-
-  /**
-   * ISL response body. When the enrichment exposes
-   * `downstream_calls.isl.response` (same path the V2
-   * responseMapper uses), the resolver lifts that body. Otherwise
-   * `'unavailable'`.
-   */
-  isl_response: Record<string, unknown> | null
-  isl_response_resolution: EvidenceResolutionEntry
+export interface EvidenceResolutionReport {
+  plot_request: EvidenceResolutionEntry
+  plot_response: EvidenceResolutionEntry
+  isl_request: EvidenceResolutionEntry
+  isl_response: EvidenceResolutionEntry
 }
 
-/** Required-upstream-support strings (shared, single source of truth). */
-const REQUIRED_UPSTREAM_PLOT_RESPONSE =
-  'Top-level capture from `payloads.plot_response` OR CEE V5 response carrying an `analysis_result` block whose `enrichment` includes at least one of: option_comparison, factor_sensitivity, m1_coaching, flip_thresholds, robustness.'
-const REQUIRED_UPSTREAM_ISL_REQUEST =
-  'Top-level capture from `payloads.isl_request`. The V5 CEE enrichment does NOT currently embed an ISL request body; CEE would need to expose one (e.g. via `enrichment.downstream_calls.isl.request`) for resolution from `cee_embedded`.'
-const REQUIRED_UPSTREAM_ISL_RESPONSE =
-  'Top-level capture from `payloads.isl_response` OR CEE V5 response carrying `enrichment.downstream_calls.isl.response`.'
-
 /**
- * Indicative keys that mark a CEE V5 enrichment block as actually
- * carrying analysis evidence (not an empty placeholder). Mirrors
- * `RAW_PAYLOAD_INDICATIVE_KEYS` in
- * `src/lib/scientificValidation/index.ts` so the classifier and
- * the resolver agree on what counts as "real" evidence.
+ * Resolver return shape. Carries both the resolved bodies (for
+ * threading into `runScientificValidation`) AND the metadata
+ * report (for the bundle's `evidence_resolution` field).
  *
- * Kept in sync with the validator-side constant to avoid drift:
- * if either layer adds a new indicative key, the other must too.
+ * Keeping bodies and metadata in separate buckets lets the bundle
+ * shape stay clean: `evidence_resolution.<kind>.<field>` is purely
+ * metadata, never a body. Bodies are validator-facing only and
+ * never written to a top-level bundle field.
  */
+export interface ResolvedEvidence {
+  /** Resolved bodies — fed to validators by the caller. */
+  bodies: {
+    plot_request: Record<string, unknown> | null
+    plot_response: Record<string, unknown> | null
+    isl_request: Record<string, unknown> | null
+    isl_response: Record<string, unknown> | null
+  }
+  /** Metadata report — copied verbatim to `bundle.evidence_resolution`. */
+  resolution: EvidenceResolutionReport
+}
+
+/** Indicative keys that gate `plot_response` promotion. */
 const RAW_PAYLOAD_INDICATIVE_KEYS = [
   'option_comparison',
   'factor_sensitivity',
@@ -144,21 +160,30 @@ const RAW_PAYLOAD_INDICATIVE_KEYS = [
   'robustness',
 ] as const
 
+/** Required-upstream-support copy (shared, single source of truth). */
+const REQ_PLOT_REQUEST =
+  'Top-level capture from `payloads.plot_request` OR CEE V5 response carrying `analysis_result.enrichment._meta.payloads.plot_request`.'
+const REQ_PLOT_RESPONSE =
+  'Top-level capture from `payloads.plot_response` OR CEE V5 response carrying `analysis_result.enrichment._meta.payloads.plot_response` OR an `analysis_result.enrichment` body with at least one of: option_comparison, factor_sensitivity, m1_coaching, flip_thresholds, robustness.'
+const REQ_ISL_REQUEST =
+  'Top-level capture from `payloads.isl_request` OR CEE V5 response carrying `analysis_result.enrichment._meta.payloads.isl_request`.'
+const REQ_ISL_RESPONSE =
+  'Top-level capture from `payloads.isl_response` OR CEE V5 response carrying `analysis_result.enrichment._meta.payloads.isl_response` OR `analysis_result.enrichment.downstream_calls.isl.response`.'
+
 /** Defensive: is the value a plain non-array object? */
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
 }
 
+/** Plain object AND non-empty (at least one own key). */
+function isNonEmptyObject(v: unknown): v is Record<string, unknown> {
+  return isPlainObject(v) && Object.keys(v).length > 0
+}
+
 /**
- * Walks `ceeResponse.blocks` and returns the FIRST block where
- * `type === 'analysis_result'`, along with its array index for
- * source-path construction. Returns `null` if no such block exists,
- * the response is malformed, or `blocks` is missing/non-array.
- *
- * (The staging fixture pattern shows a single `analysis_result`
- * block per turn — first-block semantics suffice. If CEE later
- * emits multiple, the resolver picks the first; that's predictable
- * and reviewer-checkable.)
+ * Find the FIRST analysis_result block in `ceeResponse.blocks[]`.
+ * Returns null if response is malformed, blocks is missing, or no
+ * such block exists.
  */
 function findAnalysisResultBlock(
   ceeResponse: unknown,
@@ -169,194 +194,291 @@ function findAnalysisResultBlock(
   for (let i = 0; i < blocks.length; i++) {
     const b = blocks[i]
     if (!isPlainObject(b)) continue
-    if (b.type === 'analysis_result') {
-      return { block: b, index: i }
-    }
+    if (b.type === 'analysis_result') return { block: b, index: i }
   }
   return null
 }
 
-/**
- * Returns true when `enrichment` carries at least one of the
- * canonical indicative keys with a non-null value. An empty
- * `{}` or an enrichment containing ONLY non-canonical keys
- * does NOT qualify — that prevents the resolver from promoting
- * a placeholder body to "live evidence" status.
- */
-function enrichmentHasIndicativeKey(
-  enrichment: Record<string, unknown>,
-): boolean {
+/** True iff the object carries at least one indicative key. */
+function hasIndicativeKey(o: Record<string, unknown>): boolean {
   return RAW_PAYLOAD_INDICATIVE_KEYS.some(
-    (k) => enrichment[k] !== undefined && enrichment[k] !== null,
+    (k) => o[k] !== undefined && o[k] !== null,
   )
 }
 
-/**
- * Resolve scientific-validation evidence for a captured bundle.
- *
- * Precedence per evidence kind:
- *   1. Top-level capture (preserves dev/local and direct-capture).
- *   2. CEE V5 embedded enrichment.
- *   3. `'unavailable'`.
- *
- * Each kind resolves independently — top-level PLoT plus
- * CEE-embedded ISL is a valid combination.
- *
- * Pure function. Defensive on malformed inputs (returns
- * `'unavailable'` rather than throwing).
- */
-/** Build the metadata block for a given evidence kind. */
-function buildResolution(
+/** Build a metadata entry. */
+function entry(
   source: EvidenceSource,
   path: string | null,
   notes: string,
-  requiredUpstreamSupport: string,
+  reqUpstream: string,
 ): EvidenceResolutionEntry {
   const available = source !== 'unavailable'
   return {
     source,
     path,
     available,
-    required_upstream_support: available ? null : requiredUpstreamSupport,
+    required_upstream_support: available ? null : reqUpstream,
     notes,
   }
 }
 
+/**
+ * Probe the embedded `_meta.payloads` sidecar (if present) for a
+ * named kind. Returns `{ body, path }` when a usable body is found,
+ * else `null`. For `plot_response` we apply the indicative-keys
+ * gate; for other kinds we only require a non-empty plain object
+ * (those are upstream-shape sidecars, not analysis bodies).
+ */
+function probeMetaPayloadsKind(
+  enrichment: Record<string, unknown>,
+  blockIndex: number,
+  kind: 'plot_request' | 'plot_response' | 'isl_request' | 'isl_response',
+): { body: Record<string, unknown>; path: string } | null {
+  const meta = enrichment._meta
+  if (!isPlainObject(meta)) return null
+  const payloads = (meta as Record<string, unknown>).payloads
+  if (!isPlainObject(payloads)) return null
+  const body = (payloads as Record<string, unknown>)[kind]
+  if (!isNonEmptyObject(body)) return null
+  if (kind === 'plot_response' && !hasIndicativeKey(body)) return null
+  return {
+    body,
+    path: `payloads.cee_response.blocks[${blockIndex}].enrichment._meta.payloads.${kind}`,
+  }
+}
+
+/**
+ * Resolve scientific-validation evidence from a captured bundle.
+ *
+ * Precedence per kind:
+ *   1. `topLevel.<kind>` (preserves dev/local).
+ *   2. `cee_response.blocks[*].enrichment._meta.payloads.<kind>`
+ *      (forward-compatible sidecar — closer to upstream shape).
+ *   3. For `plot_response` only: bare
+ *      `cee_response.blocks[*].enrichment` (PLoT-shaped projection).
+ *   4. For `isl_response` only: `enrichment.downstream_calls.isl.response`.
+ *   5. `'unavailable'`.
+ *
+ * Pure function. Defensive on malformed input.
+ */
 export function resolveScientificEvidence(
   topLevel: {
+    plot_request: unknown
     plot_response: unknown
     isl_request: unknown
     isl_response: unknown
   },
   ceeResponse: unknown,
 ): ResolvedEvidence {
-  // -------------------- plot_response ---------------------------
-  let plot_response: Record<string, unknown> | null = null
-  let plot_response_resolution: EvidenceResolutionEntry
+  const found = findAnalysisResultBlock(ceeResponse)
+  const enrichment =
+    found !== null && isPlainObject(found.block.enrichment)
+      ? (found.block.enrichment as Record<string, unknown>)
+      : null
 
+  // ------------------------- plot_request -------------------------
+  let plot_request: Record<string, unknown> | null = null
+  let plot_request_entry: EvidenceResolutionEntry
+  if (isPlainObject(topLevel.plot_request)) {
+    plot_request = topLevel.plot_request
+    plot_request_entry = entry(
+      'top_level',
+      'payloads.plot_request',
+      'Top-level capture from `payloads.plot_request`.',
+      REQ_PLOT_REQUEST,
+    )
+  } else if (enrichment !== null && found !== null) {
+    const probe = probeMetaPayloadsKind(enrichment, found.index, 'plot_request')
+    if (probe !== null) {
+      plot_request = probe.body
+      plot_request_entry = entry(
+        'cee_embedded',
+        probe.path,
+        'Lifted from CEE V5 turn enrichment `_meta.payloads.plot_request` sidecar.',
+        REQ_PLOT_REQUEST,
+      )
+    } else {
+      plot_request_entry = entry(
+        'unavailable',
+        null,
+        'No top-level `payloads.plot_request` and no `_meta.payloads.plot_request` sidecar in the CEE V5 enrichment.',
+        REQ_PLOT_REQUEST,
+      )
+    }
+  } else {
+    plot_request_entry = entry(
+      'unavailable',
+      null,
+      'No top-level `payloads.plot_request` and no CEE V5 `analysis_result` block to probe.',
+      REQ_PLOT_REQUEST,
+    )
+  }
+
+  // ------------------------- plot_response ------------------------
+  let plot_response: Record<string, unknown> | null = null
+  let plot_response_entry: EvidenceResolutionEntry
   if (isPlainObject(topLevel.plot_response)) {
     plot_response = topLevel.plot_response
-    plot_response_resolution = buildResolution(
+    plot_response_entry = entry(
       'top_level',
       'payloads.plot_response',
       'Top-level capture from `payloads.plot_response` (dev/local or direct-PLoT path).',
-      REQUIRED_UPSTREAM_PLOT_RESPONSE,
+      REQ_PLOT_RESPONSE,
     )
-  } else {
-    // Embedded fallback — only when the analysis_result block
-    // carries indicative keys.
-    const found = findAnalysisResultBlock(ceeResponse)
-    if (found !== null) {
-      const enrichment = found.block.enrichment
-      if (isPlainObject(enrichment) && enrichmentHasIndicativeKey(enrichment)) {
-        plot_response = enrichment
-        plot_response_resolution = buildResolution(
-          'cee_embedded',
-          `payloads.cee_response.blocks[${found.index}].enrichment`,
-          'Lifted from CEE V5 turn `analysis_result` block enrichment. Top-level `payloads.plot_response` was null (V5 canonical mode); enrichment carries at least one indicative key.',
-          REQUIRED_UPSTREAM_PLOT_RESPONSE,
-        )
-      } else {
-        plot_response_resolution = buildResolution(
-          'unavailable',
-          null,
-          'Found an `analysis_result` block but its `enrichment` is missing or lacks any indicative key (option_comparison, factor_sensitivity, m1_coaching, flip_thresholds, robustness). Not promoted — empty/placeholder bodies are not treated as live evidence.',
-          REQUIRED_UPSTREAM_PLOT_RESPONSE,
-        )
-      }
+  } else if (enrichment !== null && found !== null) {
+    // 1. Try the `_meta.payloads` sidecar first (closer to upstream shape).
+    const meta = probeMetaPayloadsKind(enrichment, found.index, 'plot_response')
+    if (meta !== null) {
+      plot_response = meta.body
+      plot_response_entry = entry(
+        'cee_embedded',
+        meta.path,
+        'Lifted from CEE V5 turn enrichment `_meta.payloads.plot_response` sidecar.',
+        REQ_PLOT_RESPONSE,
+      )
+    } else if (hasIndicativeKey(enrichment)) {
+      // 2. Fall back to the bare enrichment body (PLoT-shaped projection).
+      plot_response = enrichment
+      plot_response_entry = entry(
+        'cee_embedded',
+        `payloads.cee_response.blocks[${found.index}].enrichment`,
+        'Lifted from CEE V5 turn `analysis_result` block enrichment. Top-level `payloads.plot_response` was null; enrichment carries at least one indicative key.',
+        REQ_PLOT_RESPONSE,
+      )
     } else {
-      plot_response_resolution = buildResolution(
+      plot_response_entry = entry(
         'unavailable',
         null,
-        'Neither top-level `payloads.plot_response` nor a CEE V5 `analysis_result` block was found.',
-        REQUIRED_UPSTREAM_PLOT_RESPONSE,
+        'Found an `analysis_result` block but its `enrichment` is missing or lacks any indicative key (option_comparison, factor_sensitivity, m1_coaching, flip_thresholds, robustness). Not promoted.',
+        REQ_PLOT_RESPONSE,
       )
     }
+  } else {
+    plot_response_entry = entry(
+      'unavailable',
+      null,
+      'No top-level `payloads.plot_response` and no CEE V5 `analysis_result` block.',
+      REQ_PLOT_RESPONSE,
+    )
   }
 
-  // -------------------- isl_request -----------------------------
-  // V5 canonical enrichment does NOT carry an ISL request body in
-  // the staging-real fixture. Top-level only for now; the unavailable
-  // branch documents the CEE side that would be needed.
+  // ------------------------- isl_request --------------------------
   let isl_request: Record<string, unknown> | null = null
-  let isl_request_resolution: EvidenceResolutionEntry
-
+  let isl_request_entry: EvidenceResolutionEntry
   if (isPlainObject(topLevel.isl_request)) {
     isl_request = topLevel.isl_request
-    isl_request_resolution = buildResolution(
+    isl_request_entry = entry(
       'top_level',
       'payloads.isl_request',
       'Top-level capture from `payloads.isl_request`.',
-      REQUIRED_UPSTREAM_ISL_REQUEST,
+      REQ_ISL_REQUEST,
     )
+  } else if (enrichment !== null && found !== null) {
+    const probe = probeMetaPayloadsKind(enrichment, found.index, 'isl_request')
+    if (probe !== null) {
+      isl_request = probe.body
+      isl_request_entry = entry(
+        'cee_embedded',
+        probe.path,
+        'Lifted from CEE V5 turn enrichment `_meta.payloads.isl_request` sidecar.',
+        REQ_ISL_REQUEST,
+      )
+    } else {
+      isl_request_entry = entry(
+        'unavailable',
+        null,
+        'No top-level `payloads.isl_request` and no `_meta.payloads.isl_request` sidecar in the CEE V5 enrichment.',
+        REQ_ISL_REQUEST,
+      )
+    }
   } else {
-    isl_request_resolution = buildResolution(
+    isl_request_entry = entry(
       'unavailable',
       null,
-      'No top-level `payloads.isl_request`. The V5 CEE turn enrichment does not currently embed an ISL request body; if/when CEE exposes one (e.g. via `enrichment.downstream_calls.isl.request`), this resolver will need a `cee_embedded` branch to pick it up.',
-      REQUIRED_UPSTREAM_ISL_REQUEST,
+      'No top-level `payloads.isl_request` and no CEE V5 `analysis_result` block to probe.',
+      REQ_ISL_REQUEST,
     )
   }
 
-  // -------------------- isl_response ----------------------------
+  // ------------------------- isl_response -------------------------
   let isl_response: Record<string, unknown> | null = null
-  let isl_response_resolution: EvidenceResolutionEntry
-
+  let isl_response_entry: EvidenceResolutionEntry
   if (isPlainObject(topLevel.isl_response)) {
     isl_response = topLevel.isl_response
-    isl_response_resolution = buildResolution(
+    isl_response_entry = entry(
       'top_level',
       'payloads.isl_response',
       'Top-level capture from `payloads.isl_response`.',
-      REQUIRED_UPSTREAM_ISL_RESPONSE,
+      REQ_ISL_RESPONSE,
     )
-  } else {
-    // Embedded fallback — probe
-    // `analysis_result_block.enrichment.downstream_calls.isl.response`.
-    // Same path the V2 responseMapper uses.
-    const found = findAnalysisResultBlock(ceeResponse)
-    let embeddedResponse: Record<string, unknown> | null = null
-    let embeddedPath: string | null = null
-    if (found !== null) {
-      const enrichment = found.block.enrichment
-      if (isPlainObject(enrichment)) {
-        const downstream = enrichment.downstream_calls
-        if (isPlainObject(downstream)) {
-          const isl = downstream.isl
-          if (isPlainObject(isl)) {
-            const response = isl.response
-            if (isPlainObject(response)) {
-              embeddedResponse = response
-              embeddedPath = `payloads.cee_response.blocks[${found.index}].enrichment.downstream_calls.isl.response`
-            }
-          }
-        }
-      }
-    }
-    if (embeddedResponse !== null && embeddedPath !== null) {
-      isl_response = embeddedResponse
-      isl_response_resolution = buildResolution(
+  } else if (enrichment !== null && found !== null) {
+    // 1. `_meta.payloads.isl_response` first.
+    const meta = probeMetaPayloadsKind(enrichment, found.index, 'isl_response')
+    if (meta !== null) {
+      isl_response = meta.body
+      isl_response_entry = entry(
         'cee_embedded',
-        embeddedPath,
-        'Lifted from CEE V5 turn enrichment `downstream_calls.isl.response`.',
-        REQUIRED_UPSTREAM_ISL_RESPONSE,
+        meta.path,
+        'Lifted from CEE V5 turn enrichment `_meta.payloads.isl_response` sidecar.',
+        REQ_ISL_RESPONSE,
       )
     } else {
-      isl_response_resolution = buildResolution(
-        'unavailable',
-        null,
-        'Neither top-level `payloads.isl_response` nor an embedded `enrichment.downstream_calls.isl.response` was found.',
-        REQUIRED_UPSTREAM_ISL_RESPONSE,
-      )
+      // 2. Fall back to `enrichment.downstream_calls.isl.response`.
+      const downstream = enrichment.downstream_calls
+      if (isPlainObject(downstream)) {
+        const isl = (downstream as Record<string, unknown>).isl
+        if (isPlainObject(isl)) {
+          const response = (isl as Record<string, unknown>).response
+          if (isNonEmptyObject(response)) {
+            isl_response = response
+            isl_response_entry = entry(
+              'cee_embedded',
+              `payloads.cee_response.blocks[${found.index}].enrichment.downstream_calls.isl.response`,
+              'Lifted from CEE V5 turn enrichment `downstream_calls.isl.response`.',
+              REQ_ISL_RESPONSE,
+            )
+          } else {
+            isl_response_entry = entry(
+              'unavailable',
+              null,
+              'Found `enrichment.downstream_calls.isl` but `response` is missing or empty.',
+              REQ_ISL_RESPONSE,
+            )
+          }
+        } else {
+          isl_response_entry = entry(
+            'unavailable',
+            null,
+            'No `_meta.payloads.isl_response` sidecar and no `downstream_calls.isl` in the CEE V5 enrichment.',
+            REQ_ISL_RESPONSE,
+          )
+        }
+      } else {
+        isl_response_entry = entry(
+          'unavailable',
+          null,
+          'No `_meta.payloads.isl_response` sidecar and no `downstream_calls` in the CEE V5 enrichment.',
+          REQ_ISL_RESPONSE,
+        )
+      }
     }
+  } else {
+    isl_response_entry = entry(
+      'unavailable',
+      null,
+      'No top-level `payloads.isl_response` and no CEE V5 `analysis_result` block to probe.',
+      REQ_ISL_RESPONSE,
+    )
   }
 
   return {
-    plot_response,
-    plot_response_resolution,
-    isl_request,
-    isl_request_resolution,
-    isl_response,
-    isl_response_resolution,
+    bodies: { plot_request, plot_response, isl_request, isl_response },
+    resolution: {
+      plot_request: plot_request_entry,
+      plot_response: plot_response_entry,
+      isl_request: isl_request_entry,
+      isl_response: isl_response_entry,
+    },
   }
 }

--- a/src/lib/v5EmbeddedEvidence.ts
+++ b/src/lib/v5EmbeddedEvidence.ts
@@ -1,0 +1,271 @@
+/**
+ * V5 embedded-evidence resolver (post-PR #162 follow-up).
+ *
+ * Under V5 canonical mode (`VITE_V5_CANONICAL_ANALYSIS=true`,
+ * `VITE_ENABLE_LEGACY_DIRECT_RUN=false`), the browser never fetches
+ * PLoT `/v2/run` or ISL directly — analysis runs server-side inside
+ * CEE. So `bundle.payloads.plot_response` / `plot_request` /
+ * `isl_request` / `isl_response` are honestly null. But the CEE V5
+ * turn response embeds analysis evidence under
+ * `response.blocks[type==='analysis_result'].enrichment` (confirmed
+ * by `src/v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json`,
+ * a real staging capture from 2026-04-30).
+ *
+ * Scientific validators in `src/lib/scientificValidation/*` are
+ * hard-wired to read from `inputs.plotResponse` / `inputs.islRequest`
+ * / `inputs.islResponse`. They never look at `inputs.ceeResponse`.
+ * So embedded enrichment was ignored.
+ *
+ * This module surfaces embedded enrichment to validators WITHOUT
+ * mutating `bundle.payloads.*` (which stays raw-capture truth). The
+ * bundle assembler calls `resolveScientificEvidence` to compute a
+ * resolved view + per-evidence-type source metadata; validators see
+ * the resolved view; the bundle exposes the source metadata under
+ * `bundle.evidence_resolution` for reviewer transparency.
+ *
+ * Honesty contract:
+ *   - Top-level capture wins over embedded (preserves dev/local and
+ *     any future direct-PLoT capture path).
+ *   - Embedded enrichment is promoted ONLY when it carries at least
+ *     one of the canonical indicative keys (`option_comparison`,
+ *     `factor_sensitivity`, `m1_coaching`, `flip_thresholds`,
+ *     `robustness`). An empty `enrichment: {}` does NOT count.
+ *   - Missing fields stay missing. The resolver does NOT fabricate
+ *     `plot_request`, does NOT reconstruct ISL from canvas / UI
+ *     state, does NOT infer EVPI / flip thresholds / confidence
+ *     from anything other than the captured embedded body.
+ *   - The resolver is pure: no store reads, no React, no side
+ *     effects.
+ */
+
+/**
+ * Where the resolved evidence came from.
+ *
+ *   - `'top_level'`    — `bundle.payloads.plot_response` etc.
+ *     (or sibling fields) were non-null. Dev/local path.
+ *   - `'cee_embedded'` — extracted from the analysis_result block
+ *     inside `bundle.payloads.cee_response`. Staging V5 canonical path.
+ *   - `'unavailable'`  — neither top-level capture NOR embedded
+ *     enrichment had usable evidence.
+ */
+export type EvidenceSource = 'top_level' | 'cee_embedded' | 'unavailable'
+
+/**
+ * Output shape of `resolveScientificEvidence`. Always returns the
+ * FULL shape — callers can read `*_source` and `*_source_path`
+ * without optional chaining. Each evidence kind is resolved
+ * independently (top-level PLoT + embedded ISL is a valid mix).
+ */
+export interface ResolvedEvidence {
+  /**
+   * Resolved PLoT response object. `null` only when neither
+   * the top-level capture nor the embedded enrichment is usable.
+   */
+  plot_response: Record<string, unknown> | null
+  plot_response_source: EvidenceSource
+  /**
+   * Concrete pathname pointing at WHERE the resolved evidence
+   * was sourced (for reviewer transparency). Example values:
+   *   - `'payloads.plot_response'` (top-level)
+   *   - `'payloads.cee_response.blocks[3].enrichment'` (embedded)
+   *   - `null` (source is `'unavailable'`)
+   */
+  plot_response_source_path: string | null
+
+  /**
+   * ISL request — resolved identically. V5 canonical does NOT
+   * carry an ISL request body in the enrichment block today, so
+   * this field commonly resolves to `'unavailable'`. The resolver
+   * threads it for symmetry + future-proofing if/when CEE exposes
+   * an ISL request side.
+   */
+  isl_request: Record<string, unknown> | null
+  isl_request_source: EvidenceSource
+  isl_request_source_path: string | null
+
+  /**
+   * ISL response — resolved identically. When the enrichment has
+   * `downstream_calls.isl.response` (path used by the V2
+   * responseMapper), the resolver lifts that body. Otherwise
+   * `'unavailable'`.
+   */
+  isl_response: Record<string, unknown> | null
+  isl_response_source: EvidenceSource
+  isl_response_source_path: string | null
+}
+
+/**
+ * Indicative keys that mark a CEE V5 enrichment block as actually
+ * carrying analysis evidence (not an empty placeholder). Mirrors
+ * `RAW_PAYLOAD_INDICATIVE_KEYS` in
+ * `src/lib/scientificValidation/index.ts` so the classifier and
+ * the resolver agree on what counts as "real" evidence.
+ *
+ * Kept in sync with the validator-side constant to avoid drift:
+ * if either layer adds a new indicative key, the other must too.
+ */
+const RAW_PAYLOAD_INDICATIVE_KEYS = [
+  'option_comparison',
+  'factor_sensitivity',
+  'm1_coaching',
+  'flip_thresholds',
+  'robustness',
+] as const
+
+/** Defensive: is the value a plain non-array object? */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/**
+ * Walks `ceeResponse.blocks` and returns the FIRST block where
+ * `type === 'analysis_result'`, along with its array index for
+ * source-path construction. Returns `null` if no such block exists,
+ * the response is malformed, or `blocks` is missing/non-array.
+ *
+ * (The staging fixture pattern shows a single `analysis_result`
+ * block per turn — first-block semantics suffice. If CEE later
+ * emits multiple, the resolver picks the first; that's predictable
+ * and reviewer-checkable.)
+ */
+function findAnalysisResultBlock(
+  ceeResponse: unknown,
+): { block: Record<string, unknown>; index: number } | null {
+  if (!isPlainObject(ceeResponse)) return null
+  const blocks = ceeResponse.blocks
+  if (!Array.isArray(blocks)) return null
+  for (let i = 0; i < blocks.length; i++) {
+    const b = blocks[i]
+    if (!isPlainObject(b)) continue
+    if (b.type === 'analysis_result') {
+      return { block: b, index: i }
+    }
+  }
+  return null
+}
+
+/**
+ * Returns true when `enrichment` carries at least one of the
+ * canonical indicative keys with a non-null value. An empty
+ * `{}` or an enrichment containing ONLY non-canonical keys
+ * does NOT qualify — that prevents the resolver from promoting
+ * a placeholder body to "live evidence" status.
+ */
+function enrichmentHasIndicativeKey(
+  enrichment: Record<string, unknown>,
+): boolean {
+  return RAW_PAYLOAD_INDICATIVE_KEYS.some(
+    (k) => enrichment[k] !== undefined && enrichment[k] !== null,
+  )
+}
+
+/**
+ * Resolve scientific-validation evidence for a captured bundle.
+ *
+ * Precedence per evidence kind:
+ *   1. Top-level capture (preserves dev/local and direct-capture).
+ *   2. CEE V5 embedded enrichment.
+ *   3. `'unavailable'`.
+ *
+ * Each kind resolves independently — top-level PLoT plus
+ * CEE-embedded ISL is a valid combination.
+ *
+ * Pure function. Defensive on malformed inputs (returns
+ * `'unavailable'` rather than throwing).
+ */
+export function resolveScientificEvidence(
+  topLevel: {
+    plot_response: unknown
+    isl_request: unknown
+    isl_response: unknown
+  },
+  ceeResponse: unknown,
+): ResolvedEvidence {
+  // -------------------- plot_response ---------------------------
+  let plot_response: Record<string, unknown> | null = null
+  let plot_response_source: EvidenceSource = 'unavailable'
+  let plot_response_source_path: string | null = null
+
+  if (isPlainObject(topLevel.plot_response)) {
+    plot_response = topLevel.plot_response
+    plot_response_source = 'top_level'
+    plot_response_source_path = 'payloads.plot_response'
+  } else {
+    // Embedded fallback — only when the analysis_result block
+    // carries indicative keys.
+    const found = findAnalysisResultBlock(ceeResponse)
+    if (found !== null) {
+      const enrichment = found.block.enrichment
+      if (isPlainObject(enrichment) && enrichmentHasIndicativeKey(enrichment)) {
+        plot_response = enrichment
+        plot_response_source = 'cee_embedded'
+        plot_response_source_path = `payloads.cee_response.blocks[${found.index}].enrichment`
+      }
+    }
+  }
+
+  // -------------------- isl_request -----------------------------
+  // V5 canonical enrichment does NOT carry an ISL request body in
+  // the staging-real fixture. We thread the field for symmetry +
+  // honesty. Top-level only.
+  let isl_request: Record<string, unknown> | null = null
+  let isl_request_source: EvidenceSource = 'unavailable'
+  let isl_request_source_path: string | null = null
+
+  if (isPlainObject(topLevel.isl_request)) {
+    isl_request = topLevel.isl_request
+    isl_request_source = 'top_level'
+    isl_request_source_path = 'payloads.isl_request'
+  }
+  // No `cee_embedded` branch for isl_request — the V5 enrichment
+  // does not embed an ISL request body. If CEE later exposes one
+  // (e.g. under `enrichment.downstream_calls.isl.request`), add
+  // that branch here.
+
+  // -------------------- isl_response ----------------------------
+  let isl_response: Record<string, unknown> | null = null
+  let isl_response_source: EvidenceSource = 'unavailable'
+  let isl_response_source_path: string | null = null
+
+  if (isPlainObject(topLevel.isl_response)) {
+    isl_response = topLevel.isl_response
+    isl_response_source = 'top_level'
+    isl_response_source_path = 'payloads.isl_response'
+  } else {
+    // Embedded fallback — probe
+    // `analysis_result_block.enrichment.downstream_calls.isl.response`.
+    // Same path the V2 responseMapper uses, kept here for
+    // reviewer-transparency (the path string surfaces in
+    // `isl_response_source_path`).
+    const found = findAnalysisResultBlock(ceeResponse)
+    if (found !== null) {
+      const enrichment = found.block.enrichment
+      if (isPlainObject(enrichment)) {
+        const downstream = enrichment.downstream_calls
+        if (isPlainObject(downstream)) {
+          const isl = downstream.isl
+          if (isPlainObject(isl)) {
+            const response = isl.response
+            if (isPlainObject(response)) {
+              isl_response = response
+              isl_response_source = 'cee_embedded'
+              isl_response_source_path = `payloads.cee_response.blocks[${found.index}].enrichment.downstream_calls.isl.response`
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    plot_response,
+    plot_response_source,
+    plot_response_source_path,
+    isl_request,
+    isl_request_source,
+    isl_request_source_path,
+    isl_response,
+    isl_response_source,
+    isl_response_source_path,
+  }
+}


### PR DESCRIPTION
## Summary

DGAI-only evidence resolver for scientific validation under V5 canonical mode. Surfaces analysis evidence embedded inside the CEE `/proxy/v5/turn` response so validators can run when top-level `payloads.plot_*` / `isl_*` are honestly null (the inherent shape on staging post-PR #162).

**Branch**: `claude-ui/debug-bundle-evidence-resolver` → `staging` · **Commits**: `f3957b74` (initial) + `d4906db1` (nested per-kind metadata refactor per spec). **No production deploy.**

---

## Phase 0 — evidence-path inventory

Confirmed against the canonical staging-real fixture `src/v5/__tests__/fixtures/v5-analysis-result.staging-real-shape.json` (captured 2026-04-30 from `cee-staging.onrender.com`).

| Path | Present? | Carries |
|---|---|---|
| `bundle.payloads.cee_response` (top-level) | ✅ (post-PR #162) | Full V5 turn response |
| `cee_response.blocks[type==='analysis_result']` | ✅ | The analysis-result block |
| `cee_response.blocks[*].enrichment` | ✅ | `option_comparison[]`, `factor_sensitivity[]`, `robustness{}` |
| `enrichment.option_comparison[*]` | ✅ | `id`, `option_label`, `win_probability`, `outcome{mean,std,p10,p50,p90,...}` |
| `enrichment.factor_sensitivity[*]` | ✅ (partial) | `factor_id`, `factor_label`, `sensitivity_score`, `elasticity`, `direction`, `importance_rank` |
| `enrichment.factor_sensitivity[*].confidence_provenance` | ❌ not in fixture | — |
| `enrichment.factor_sensitivity[*].evpi_percentage_points` | ❌ not in fixture | — |
| `enrichment.factor_sensitivity[*].value_of_information` | ❌ not in fixture | — |
| `enrichment.robustness{}` | ✅ | `fragile_edges[]`, `robust_edges[]`, `is_robust`, `level`, ... |
| `enrichment.flip_thresholds` / `.flip_thresholds_status` | ❌ not in fixture | — |
| `enrichment.auto_noise_applied` / `.auto_noise_provenance` | ❌ not in fixture | — |
| `enrichment.m1_coaching` / `.evidence_gaps` | ❌ not in fixture | — |
| `enrichment._meta.payloads` | ❌ not in fixture (also not referenced in code) | — |
| `enrichment.downstream_calls` | ❌ not in real fixture; ⚠ referenced in V2 responseMapper for direct-PLoT path | resolver probes defensively (lifts `isl.response` if present) |

**Conclusion**: the embedded enrichment carries 3 of 5 `RAW_PAYLOAD_INDICATIVE_KEYS` (`option_comparison`, `factor_sensitivity`, `robustness`). Validators that read only those can move from `unavailable` to `partial`. Validators that need the unfound keys must stay `unavailable` with `required_upstream_support` documenting what CEE would need to emit.

---

## Validator-by-validator resolution

Per the spec: "Do not assume only `responseShapeValidation` can improve." I checked all seven validators against the documented enrichment shape.

| Validator | Reads from | Top-level evidence on staging? | Embedded evidence in V5 enrichment? | Resolution after this PR |
|---|---|---|---|---|
| `responseShapeValidation` | `plotResponse` indicative keys + `capturePipelineStatus` | ❌ null | ✅ 3 of 5 indicative keys (`option_comparison`, `factor_sensitivity`, `robustness`) | **moves `unavailable` → `partial`** with `claim_strength: 'observed'` for the present keys |
| `confidenceValidation` | `plotResponse.factor_sensitivity[*].confidence_provenance` | ❌ null | ❌ `confidence_provenance` not present per factor | **stays `unavailable`**; `required_upstream_support: ['plot.response.factor_sensitivity']` (needs the provenance field on each factor) |
| `evpiValidation` | `plotResponse.factor_sensitivity[*].evpi_percentage_points` / `.value_of_information` | ❌ null | ❌ neither EVPI field present in enrichment | **stays `unavailable`**; `required_upstream_support: ['plot.response.factor_sensitivity[*].evpi_percentage_points']` |
| `flipThresholdValidation` | `plotResponse.flip_thresholds_status` / `.flip_thresholds` | ❌ null | ❌ not in enrichment | **stays `unavailable`**; `required_upstream_support: ['plot.response.flip_thresholds_status']` |
| `autoNoiseValidation` | `plotResponse.auto_noise_applied` / `.auto_noise_provenance.applied` | ❌ null | ❌ not in enrichment | **stays `partial`**/`unavailable` (validator's pre-PR behaviour when both fields absent); `required_upstream_support: ['plot.response.auto_noise_applied', 'plot.response.auto_noise_provenance']` |
| `evidenceGapValidation` | `plotResponse.m1_coaching.evidence_gaps` + `ceeAnalysisReady.options[*].interventions` (canvas store) | ❌ null | ❌ `m1_coaching` not in enrichment | **stays `unavailable`**; `required_upstream_support: ['plot.response.m1_coaching.evidence_gaps']` |
| `userStdPropagation` | `plotRequest.graph.nodes[*].data.observed_state.std` + `islRequest.parameter_uncertainties` | ❌ both null in V5 canonical | ❌ no ISL request body in enrichment | **stays `unavailable`**; `required_upstream_support: ['plot.debug.isl_request', 'plot.debug.isl_response']` — separate tracked follow-up |

Net effect: `responseShapeValidation` flips, others stay honest. `scientific_validation.source` flips from `'hydrated_report'` to the new `'live_v5_cee_embedded'` label (informational discriminator vs `'live_raw_payloads'`). `overall_status` flips from `'unavailable'` away from that strict gate (the actual value depends on derived count — see the integration spec for assertions).

---

## Files changed (6 files, 2 commits)

| File | Status | Purpose |
|---|---|---|
| `src/lib/v5EmbeddedEvidence.ts` | **NEW** | Pure resolver: precedence + path-boundary + nested per-kind metadata |
| `src/lib/__tests__/v5EmbeddedEvidence.spec.ts` | **NEW** | 19 unit cases: precedence, indicative-keys gate, malformed-input safety, downstream ISL, mixed sources |
| `src/lib/scientificValidation/types.ts` | modified | `ScientificValidation['source']` union adds `'live_v5_cee_embedded'`; `ValidatorInputs.plotResponseSource?` informational |
| `src/lib/scientificValidation/index.ts` | modified | `classifySource` emits new label when source is `'cee_embedded'`; same indicative-keys gate; same usability gate |
| `src/components/debug/utils/exportBundle.ts` | modified | Runs resolver before `runScientificValidation`; threads resolved view; emits `bundle.evidence_resolution` |
| `src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts` | extended | 6 integration cases: dev/local regression, staging V5 canonical happy path, HONESTY test, missing-evidence, mixed, stable-shape |

---

## Tests added

**Unit (`v5EmbeddedEvidence.spec.ts`, 19 cases)** — top-level precedence (3), CEE-embedded fallback with real fixture (5), indicative-keys gate (3), unavailable when both missing (2), mixed sources (1), malformed-input safety (5).

**Integration (`exportBundle.liveCeeCapture.spec.ts`, 6 cases)** — addresses all 7 required test categories:
1. **Top-level wins**: dev/local fixture with `plot_response` populated → `top_level` source.
2. **Embedded fallback**: V5 canonical fixture (CEE response with enrichment, null top-level) → `cee_embedded` source + `live_v5_cee_embedded` label.
3. **Unavailable remains honest**: both null → all 3 kinds `unavailable`; validators stay unavailable.
4. **Validators move only when fields exist**: `responseShapeValidation` moves; others stay unavailable.
5. **`required_upstream_support` populated when insufficient**: HONESTY test asserts validators' `required_upstream_support` is non-empty.
6. **No raw payload fabrication**: assertion `bundle.payloads.plot_response === null` when only embedded evidence present (resolver writes to `evidence_resolution`, not `payloads.*`).
7. **PR #162 trace classification intact**: all PR #162 tests (V5 proxy classification, `analysis_evidence_source = 'live_v5_cee_proxy_turn'`) still pass.

---

## Before / after example

**Before (staging bundle `e46ebfd9`):**
```json
{
  "payloads": { "cee_request": {...}, "cee_response": {...},
                "plot_request": null, "plot_response": null,
                "isl_request": null, "isl_response": null },
  "scientific_validation": {
    "source": "hydrated_report",
    "overall_status": "unavailable",
    "validators": { "response_shape_validation": { "status": "unavailable", ... } }
  }
}
```

**After (with this PR):**
```json
{
  "payloads": { "cee_request": {...}, "cee_response": {...},
                "plot_request": null, "plot_response": null,    // ← unchanged: raw-capture truth
                "isl_request": null, "isl_response": null },
  "evidence_resolution": {
    "plot_response": { "option_comparison": [...], "factor_sensitivity": [...], "robustness": {...} },
    "plot_response_resolution": {
      "source": "cee_embedded",
      "path": "payloads.cee_response.blocks[1].enrichment",
      "available": true,
      "required_upstream_support": null,
      "notes": "Lifted from CEE V5 turn `analysis_result` block enrichment..."
    },
    "isl_request": null,
    "isl_request_resolution": {
      "source": "unavailable",
      "path": null,
      "available": false,
      "required_upstream_support": "Top-level capture from `payloads.isl_request`...",
      "notes": "No top-level `payloads.isl_request`. The V5 CEE turn enrichment does not currently embed an ISL request body..."
    },
    "isl_response": null,
    "isl_response_resolution": { ...similar... }
  },
  "scientific_validation": {
    "source": "live_v5_cee_embedded",           // ← new informational label
    "overall_status": "partial",                 // ← was "unavailable"
    "validators": {
      "response_shape_validation": { "status": "partial", "claim_strength": "observed", ... },
      "confidence_validation": { "status": "unavailable", "required_upstream_support": ["plot.response.factor_sensitivity"] },
      "evpi_validation": { "status": "unavailable", "required_upstream_support": ["plot.response.factor_sensitivity[*].evpi_percentage_points"] }
      // ... others stay unavailable with required_upstream_support populated
    }
  }
}
```

---

## Top-level PLoT / ISL nulls remain honest in V5 canonical mode

**Explicit statement**: Under `VITE_V5_CANONICAL_ANALYSIS=true` + `VITE_ENABLE_LEGACY_DIRECT_RUN=false`, the browser never fetches PLoT `/v2/run` or ISL endpoints directly — those services are invoked server-side inside CEE. So `bundle.payloads.plot_request`, `plot_response`, `isl_request`, `isl_response` are **inherently null** in raw browser capture. This PR does NOT change that. The resolver writes its output to a separate `bundle.evidence_resolution` field; reviewers see the true raw capture and the resolved view side-by-side.

---

## CEE follow-ups required for genuinely-absent fields

To unlock more validators in V5 canonical mode, CEE would need to expand the `analysis_result.enrichment` shape to include:

- `factor_sensitivity[*].confidence_provenance` → unlocks `confidenceValidation`
- `factor_sensitivity[*].evpi_percentage_points` or `value_of_information` → unlocks `evpiValidation`
- `flip_thresholds[]` + `flip_thresholds_status` → unlocks `flipThresholdValidation`
- `auto_noise_applied` + `auto_noise_provenance` → unlocks `autoNoiseValidation`
- `m1_coaching.evidence_gaps[]` → unlocks `evidenceGapValidation`
- An ISL request side (e.g. `enrichment.downstream_calls.isl.request`) → unlocks `userStdPropagation`

These are CEE / PLoT product decisions, out of scope for this DGAI-only PR. The resolver is forward-compatible: when CEE adds any of these keys, the validators pick them up automatically without further DGAI changes (because `inputs.plotResponse` already routes through the resolver and the validators already read these field paths).

---

## Verification

```
npm run typecheck                              # clean
npx vitest run <13-file plan list> --bail=1    # 590 / 590 pass (+25 over 565 baseline)
```

Pre-push fast gate (typecheck + lint changed + smoke + stale-.js + dep audit + V5 vendored-schemas SHA manifest) all green on both commits.

---

## Scope / honesty / standing constraints (all preserved)

- ✅ DGAI debug/capture/export only
- ✅ No CEE / PLoT / ISL / prompts / schemas / packages / lockfiles / migrations / netlify.toml changes
- ✅ No fake top-level PLoT/ISL payloads
- ✅ No relabeling embedded evidence as browser-captured PLoT/ISL
- ✅ Raw payload honesty preserved (`bundle.payloads.*` untouched)
- ✅ No routing Run analysis through CEE
- ✅ `recordBffError` hygiene NOT in this PR (separately deferred)
- ✅ No broadening into recommendation/tone/copy fixes
- ✅ PR #156 round-4 P0 invariants preserved
- ✅ PR #162 V5 proxy classification preserved (all PR #162 tests still pass)
- ✅ PR #159 mount untouched

PR remains paused for review on `staging`. **Do not merge or deploy production.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)