### PR TITLE
fix(ai-panel-v2): strip falls back to composer when floating is minimised (round-15)

### DIFF
--- a/src/canvas/components/PersistentInputStrip.tsx
+++ b/src/canvas/components/PersistentInputStrip.tsx
@@ -48,19 +48,28 @@ export const PersistentInputStrip = memo(function PersistentInputStrip({
   onCogClick,
 }: PersistentInputStripProps) {
   const floatingIsOpen = useFloatingPanelState((s) => s.isOpen)
+  // Round-15: when the floating panel is collapsed to a pill, isOpen
+  // stays true but isMinimised flips to true. The pill has no textarea,
+  // so the strip must take over composing — falling through to the
+  // normal composer/redirect modes below. Without this guard the strip
+  // stays in "Olumi is open · Focus" status mode even though there's
+  // nowhere else to type.
+  const floatingIsMinimised = useFloatingPanelState((s) => s.isMinimised)
   const placeholder = useStageAwarePlaceholder()
 
   const handleFocus = useCallback(() => {
     onFocusFloating?.()
   }, [onFocusFloating])
 
-  // Status mode — floating panel is open. No textarea is rendered so the
-  // "no duplicate composer" invariant holds. Fixed copy ("Olumi is open ·
-  // Focus") replaces the previous truncated last-message preview: that
-  // preview was noisy, broke at 50 chars mid-sentence, and read as
-  // disabled chrome rather than a clickable affordance. Clicking anywhere
-  // focuses the floating panel via the registered focus channel.
-  if (floatingIsOpen) {
+  // Status mode — floating panel is open AND NOT minimised (i.e. the
+  // full panel is visible with its own composer). No textarea is rendered
+  // here so the "no duplicate composer" invariant holds. Fixed copy
+  // ("Olumi is open · Focus") replaces the previous truncated
+  // last-message preview: that preview was noisy, broke at 50 chars
+  // mid-sentence, and read as disabled chrome rather than a clickable
+  // affordance. Clicking focuses the floating panel via the registered
+  // focus channel.
+  if (floatingIsOpen && !floatingIsMinimised) {
     return (
       <button
         type="button"

--- a/src/canvas/components/__tests__/PersistentInputStrip.spec.tsx
+++ b/src/canvas/components/__tests__/PersistentInputStrip.spec.tsx
@@ -111,6 +111,50 @@ describe('PersistentInputStrip', () => {
       fireEvent.click(screen.getByTestId('persistent-strip-status'))
       expect(onFocusFloating).toHaveBeenCalledTimes(1)
     })
+
+    it('falls back to composer mode when floating is minimised (round-15 regression)', () => {
+      // Round-15 P0: when the user collapses the floating panel to a
+      // pill, `isOpen` stays true but `isMinimised` flips to true. The
+      // pill has no textarea, so the strip must take over composing.
+      // Previously the gate was `if (floatingIsOpen)` alone, which kept
+      // the strip in "Olumi is open · Focus" status mode and left the
+      // user with no place to type.
+      act(() => {
+        useFloatingPanelState.getState().open('user')
+        useFloatingPanelState.getState().minimise()
+      })
+      render(<PersistentInputStrip isOlumiTabActive onOpenFloating={() => {}} onCogClick={() => {}} />, {
+        wrapper: Wrapper,
+      })
+      // Status mode must NOT render — the strip must give the user a
+      // textarea since the minimised pill has none.
+      expect(screen.queryByTestId('persistent-strip-status')).toBeNull()
+      // Composer mode renders with the real textarea.
+      expect(screen.getByTestId('persistent-strip-composer')).toBeInTheDocument()
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    it('returns to status mode when the panel is restored from the minimised pill', () => {
+      // Symmetry check: minimising the panel re-shows the strip
+      // composer; restoring from the pill must put the strip BACK into
+      // status mode so the floating composer is the sole place to type
+      // (the "no duplicate composer" invariant).
+      act(() => {
+        useFloatingPanelState.getState().open('user')
+        useFloatingPanelState.getState().minimise()
+      })
+      const { rerender } = render(
+        <PersistentInputStrip isOlumiTabActive onOpenFloating={() => {}} onCogClick={() => {}} />,
+        { wrapper: Wrapper },
+      )
+      expect(screen.getByTestId('persistent-strip-composer')).toBeInTheDocument()
+      act(() => {
+        useFloatingPanelState.getState().restore()
+      })
+      rerender(<PersistentInputStrip isOlumiTabActive onOpenFloating={() => {}} onCogClick={() => {}} />)
+      expect(screen.getByTestId('persistent-strip-status')).toBeInTheDocument()
+      expect(screen.queryByRole('textbox')).toBeNull()
+    })
   })
 
   describe('draft preservation across floating open/close', () => {


### PR DESCRIPTION
## Summary

Strictly surgical 2-line fix in `PersistentInputStrip.tsx`. The status-mode gate now also checks `!isMinimised`, so when the user collapses the floating panel to a pill, the strip flips to its composer mode and the user has a textbox to type in again.

## User-reported bug

> "When I click to collapse the floating AI panel, it works, but the AI text box that's meant to be at the bottom of the right-hand panel isn't displayed. It still just says 'Olumi is open. Focus'. Be very careful to only make a surgical fix that doesn't affect anything else."

## Root cause

`useFloatingPanelState.isOpen` stays `true` when the panel collapses to a pill — only `isMinimised` flips. The strip's gate was `if (floatingIsOpen)` alone, so the status mode ("Olumi is open · Focus →") kept rendering even after minimise. The pill has no textarea, so the user lost their composer entirely.

## Fix

```diff
+ const floatingIsMinimised = useFloatingPanelState((s) => s.isMinimised)
- if (floatingIsOpen) {
+ if (floatingIsOpen && !floatingIsMinimised) {
```

When `isMinimised === true`, the gate falls through to the existing composer / redirect modes (no new branches). Restoring the pill puts the strip back into status mode — the "no duplicate composer" invariant is preserved.

## Scope (strictly surgical)

- One new selector subscription + one boolean AND in the existing condition.
- No store changes, no FloatingOlumiPanel changes, no floatOut-helper changes.
- Composer / redirect modes unchanged.
- No prop signature changes, no test deletions.

## Regression spec

Two new tests in `PersistentInputStrip.spec.tsx`:
- **"falls back to composer mode when floating is minimised (round-15 regression)"** — opens floating, minimises, asserts the strip renders composer mode with a real `<textarea>` (NOT status).
- **"returns to status mode when the panel is restored from the minimised pill"** — symmetry guard: minimise → composer, restore → status. Pre-fix code fails the first test (status mode still renders).

## Test plan

- [x] `npm run typecheck` — clean
- [x] 6/6 PersistentInputStrip specs pass (4 original + 2 new)
- [x] No collateral damage: aiPanelV2.interactions + aiPanelV2.polish suites pass
- [x] Pre-push fast gate green (459 smoke tests + lint + dep audit + vendored schemas)
- [ ] Staging verification: open floating, minimise it, confirm the strip at the bottom of the right panel shows a textbox you can type into; restore the floating panel and confirm the strip swaps back to "Olumi is open · Focus".

🤖 Generated with [Claude Code](https://claude.com/claude-code)