### PR TITLE
fix(ai-panel-v2): strip composer 3-line min + grow + scrollbar inset (round-16)

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -75,6 +75,18 @@ const FLOATING_MIN_LINES = 3
 const FLOATING_MAX_LINES = 8
 
 /**
+ * Strip variant (docked Olumi tab composer): round-16 UX. Same fix as the
+ * floating variant — 3-line rest so the cog + send stack (58px) fits
+ * inside the textarea border, and grows on type up to 8 lines before
+ * internal scroll engages. The icon-stack inset is also bumped from
+ * `right-1.5` to `right-4` for THIS variant so that when the textarea
+ * hits its 8-line ceiling and the browser draws an internal scrollbar,
+ * the buttons leave room for the scrollbar instead of overlapping it.
+ */
+const STRIP_MIN_LINES = 3
+const STRIP_MAX_LINES = 8
+
+/**
  * AIInputBar — single shared composer used by the persistent strip, the docked
  * Olumi tab (currently unused — strip handles), the floating Olumi panel, the
  * first-use centred composer, and the AI Panel v2 welcome hero. Owns no message
@@ -119,6 +131,7 @@ export const AIInputBar = memo(
     const nodeCount = useCanvasStore((s) => s.nodes.length)
     const isWelcome = variant === 'welcome'
     const isFloating = variant === 'floating'
+    const isStrip = variant === 'strip'
 
     useImperativeHandle(
       ref,
@@ -134,18 +147,24 @@ export const AIInputBar = memo(
     // - floating: 3-line rest, grows to 8 lines (panel footer composer).
     //   Round-13: needs ≥ 3 lines so cog + send icons fit inside without
     //   overflowing the textarea border; grows on type for follow-ups.
-    // - strip / docked-tab / first-use: 1-line rest, grows to 2 lines
-    //   (compact surfaces).
+    // - strip: 3-line rest, grows to 8 lines (docked Olumi tab composer).
+    //   Round-16: same fix as round-13 for the floating variant.
+    // - docked-tab / first-use: 1-line rest, grows to 2 lines (compact
+    //   surfaces — not currently exercised by AI Panel v2 callers).
     const minLines = isWelcome
       ? WELCOME_MIN_LINES
       : isFloating
         ? FLOATING_MIN_LINES
-        : 1
+        : isStrip
+          ? STRIP_MIN_LINES
+          : 1
     const maxLines = isWelcome
       ? WELCOME_MAX_LINES
       : isFloating
         ? FLOATING_MAX_LINES
-        : MAX_LINES
+        : isStrip
+          ? STRIP_MAX_LINES
+          : MAX_LINES
     const minHeightPx = LINE_HEIGHT_PX * minLines + 16
     const maxHeightPx = LINE_HEIGHT_PX * maxLines + 16
     useLayoutEffect(() => {
@@ -216,11 +235,23 @@ export const AIInputBar = memo(
     const cogBtnSize = isWelcome ? 'w-8 h-8' : 'w-7 h-7'
     const cogIconSize = isWelcome ? 'w-4 h-4' : 'w-4 h-4'
     // Stack inset: the cog/send cluster sits inside the right edge of the
-    // textarea. Welcome variant gives more breathing room.
-    const stackInset = isWelcome ? 'right-2 bottom-2' : 'right-1.5 bottom-1'
+    // textarea. Welcome variant gives more breathing room. Strip variant
+    // (round-16) bumps the right inset from 6px to 16px so that when the
+    // textarea hits its 8-line ceiling and a vertical scrollbar appears,
+    // the icon stack leaves room for the scrollbar instead of overlapping
+    // it. Other variants keep their original 6px inset (the floating
+    // variant's auto-grow ceiling rarely engages internal scroll in
+    // practice; if it ever does, we can extend this).
+    const stackInset = isWelcome
+      ? 'right-2 bottom-2'
+      : isStrip
+        ? 'right-4 bottom-2'
+        : 'right-1.5 bottom-1'
     const stackGap = isWelcome ? 'gap-1' : 'gap-0.5'
     // Right padding on textarea reserves room for the cog+send cluster.
-    const textareaRightPad = isWelcome ? 'pr-24' : 'pr-16'
+    // Strip variant reserves a touch more so typed text doesn't drift
+    // under the icons when the stack is pushed inward by 10px.
+    const textareaRightPad = isWelcome ? 'pr-24' : isStrip ? 'pr-20' : 'pr-16'
 
     return (
       <div className={containerClasses} data-testid={testId ?? `ai-input-bar-${variant}`}>

--- a/src/canvas/components/__tests__/PersistentInputStrip.spec.tsx
+++ b/src/canvas/components/__tests__/PersistentInputStrip.spec.tsx
@@ -80,6 +80,40 @@ describe('PersistentInputStrip', () => {
       expect(screen.getByTestId('persistent-strip-composer')).toBeInTheDocument()
       expect(screen.getByRole('textbox')).toBeInTheDocument()
     })
+
+    it('round-16: strip variant has 3-line min (70px) and 8-line max (160px) so cog+send fit and composer grows', () => {
+      render(<PersistentInputStrip isOlumiTabActive onOpenFloating={() => {}} onCogClick={() => {}} />, {
+        wrapper: Wrapper,
+      })
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      // LINE_HEIGHT_PX (18) * STRIP_MIN_LINES (3) + 16 = 70.
+      // The cog + send icon stack (28 + 2 + 28 = 58px) now fits inside
+      // the textarea border without overflowing.
+      expect(textarea.style.minHeight).toBe('70px')
+      // LINE_HEIGHT_PX (18) * STRIP_MAX_LINES (8) + 16 = 160.
+      // Composer grows as user types; internal scroll engages beyond this.
+      expect(textarea.style.maxHeight).toBe('160px')
+    })
+
+    it('round-16: strip variant uses larger right inset on icon stack so the scrollbar is not covered when textarea scrolls', () => {
+      // When the textarea hits its 160px ceiling and the browser draws
+      // an internal vertical scrollbar (≈12px wide), the absolutely-
+      // positioned cog + send icon stack would overlap the scrollbar at
+      // the default `right-1.5` (6px) inset. Round-16 bumps the strip
+      // variant's stackInset to `right-4` (16px) so the icons sit clear
+      // of the scrollbar.
+      render(<PersistentInputStrip isOlumiTabActive onOpenFloating={() => {}} onCogClick={() => {}} />, {
+        wrapper: Wrapper,
+      })
+      const cog = screen.getByTestId('ai-input-bar-strip-cog')
+      const send = screen.getByTestId('ai-input-bar-strip-send')
+      // The icon stack is the absolutely-positioned div wrapping both
+      // buttons. Both icons share the same parent stack container.
+      const stack = cog.parentElement as HTMLElement
+      expect(stack).toBe(send.parentElement)
+      // Tailwind class assertion — `right-4` corresponds to a 16px inset.
+      expect(stack.className).toMatch(/\bright-4\b/)
+    })
   })
 
   describe('status mode — floating open (invariant: no textarea)', () => {


### PR DESCRIPTION
## Summary

Same fix shape as round-13 (floating panel composer), scoped strictly to the strip variant. Three coupled tweaks in `AIInputBar.tsx` only:

- `STRIP_MIN_LINES = 3` so the strip's rest height is 70px (was 34px) — the cog + send icon stack (58px) fits inside the textarea border.
- `STRIP_MAX_LINES = 8` so the composer grows on type up to 160px (was 52px) before internal scroll engages.
- Icon-stack right inset bumped from `right-1.5` (6px) to `right-4` (16px) on the strip variant, plus textarea `pr` from `pr-16` to `pr-20`, so when the textarea scrolls, the buttons leave room for the vertical scrollbar instead of overlapping it.

## User-reported requirements

> "Please make the text box in the Olumi right-hand tab twice the height it currently is so both of the submit and cog icon buttons fit within it. Also, it needs to expand as the user adds text to it. Be careful that the icon buttons don't cover the scroll bar. Make sure these updates are surgical and don't affect anything else."

## Strictly surgical

- welcome / floating / docked-tab / first-use variants unchanged.
- No `PersistentInputStrip` changes.
- No `FloatingOlumiPanel` changes.
- No store changes, no prop signature changes, no test deletions.

## Live-preview verification

| Check | Expected | Browser |
|---|---|---|
| Textarea min height | 70px | 70px ✓ |
| Textarea max (auto-grow ceiling) | 160px | 160px ✓ |
| Icon stack fully inside textarea | true | both icons inside ✓ |
| Cog inset from textarea right edge | 16px (scrollbar-clear) | 16px ✓ |

## Test plan

- [x] `npm run typecheck` — clean
- [x] 8/8 PersistentInputStrip specs pass (4 original + 2 round-15 + 2 round-16)
- [x] 64/64 related specs across PersistentInputStrip + aiPanelV2 + FirstUseComposer
- [x] Pre-push fast gate green
- [ ] Staging verification: open the Olumi tab, see the 3-line textbox at the bottom; type a multi-paragraph message and confirm the composer grows up to 8 lines and the scrollbar (when it engages beyond 8 lines) is not covered by the icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)