### PR TITLE
fix(debug-bundle): resolver probes parse-error CEE wrapper (PR #171)

### DIFF
--- a/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
+++ b/src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts
@@ -2565,4 +2565,184 @@ describe('buildDebugBundleAsync — evidence resolver (post-PR #162)', () => {
       'live_v5_cee_embedded',
     )
   })
+
+  // ===================================================================
+  // PR #169 — parse-error wrapper integration regression.
+  //
+  // Manual staging validation of PR #168 (commit `5e9847db`,
+  // 2026-05-21) found that the deployed bundle's
+  // `payloads.cee_response` carried a parse-error wrapper instead of
+  // the unwrapped V5 turn body. The wrapper shape (from
+  // `src/v5/responseParser.ts`):
+  //
+  //     { kind: 'parse_error', reason: '...', raw: <original CEE body> }
+  //
+  // Pre-fix the resolver only probed `cee_response.blocks[*]`, so
+  // `evidence_resolution.plot_response.source` resolved to
+  // `'unavailable'` and `scientific_validation.source` was
+  // `'unavailable'` — even though the full analysis enrichment lived
+  // under `cee_response.raw.blocks[0].enrichment`.
+  //
+  // This integration test pins the staging fixture shape end-to-end:
+  // a CEE response wrapped in parse_error, with provenance =
+  // analysis_producing_v5_turn (so the live-evidence gate accepts),
+  // resolves to cee_embedded and flips scientific_validation to
+  // live_v5_cee_embedded.
+  // ===================================================================
+
+  it('PR #169: parse-error-wrapped CEE response with `analysis_producing_v5_turn` provenance → live_v5_cee_embedded', async () => {
+    // Same shape as observed on staging: cee_response.kind === 'parse_error',
+    // cee_response.raw.blocks[0].type === 'analysis_result', enrichment
+    // carries indicative scientific keys.
+    const wrappedEnrichment = {
+      option_comparison: [{ id: 'opt_a', win_probability: 0.7 }],
+      factor_sensitivity: [
+        { factor_id: 'f1', sensitivity_score: 0.5, importance_rank: 1 },
+      ],
+      robustness: { fragile_edges: [], level: 'moderate' },
+    }
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        cee_capture_provenance: 'analysis_producing_v5_turn',
+        selected_cee_trace_endpoint:
+          'https://cee-staging.onrender.com/proxy/v5/turn',
+        payloads: {
+          cee_request: { turn_id: 't-parse-err', message: 'Run analysis' },
+          cee_response: {
+            kind: 'parse_error',
+            reason: 'body did not match OlumiResponse schema',
+            raw: {
+              blocks: [
+                {
+                  type: 'analysis_result',
+                  summary: 'Ran analysis on your current scenario.',
+                  enrichment: wrappedEnrichment,
+                },
+              ],
+            },
+          },
+          // V5 canonical: top-level PLoT/ISL inherently null (server-side).
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+
+    // Raw-payload honesty: bundle.payloads.* untouched.
+    expect(bundle.payloads.plot_response).toBeNull()
+    expect(bundle.payloads.isl_request).toBeNull()
+    expect(bundle.payloads.isl_response).toBeNull()
+    // cee_response still carries the parse-error wrapper verbatim.
+    expect(
+      (bundle.payloads.cee_response as { kind?: string } | null)?.kind,
+    ).toBe('parse_error')
+
+    // Resolver lifted the wrapped enrichment.
+    expect(bundle.evidence_resolution?.plot_response.source).toBe(
+      'cee_embedded',
+    )
+    expect(bundle.evidence_resolution?.plot_response.path).toBe(
+      'payloads.cee_response.raw.blocks[0].enrichment',
+    )
+    expect(bundle.evidence_resolution?.plot_response.available).toBe(true)
+    expect(
+      bundle.evidence_resolution?.plot_response.required_upstream_support,
+    ).toBeNull()
+
+    // Scientific validation flipped from `'unavailable'` (pre-fix) to
+    // `'live_v5_cee_embedded'` (gated by the R-2 Blocker 2 provenance
+    // check, which is satisfied by analysis_producing_v5_turn). The
+    // overall_status itself depends on how many validators reach
+    // observed/derived — with only 3 indicative keys it may still be
+    // `insufficient_raw_evidence`, but the SOURCE label is the key
+    // assertion (live evidence ran, not unavailable evidence).
+    expect(bundle.scientific_validation?.source).toBe('live_v5_cee_embedded')
+    expect(bundle.scientific_validation?.overall_status).not.toBe('unavailable')
+    // response_shape_validation reads the indicative keys directly;
+    // with 3 of 5 present in the wrapped enrichment it must NOT be
+    // `unavailable` (proves the resolver fed the body through).
+    expect(
+      bundle.scientific_validation?.validators.response_shape_validation
+        ?.status,
+    ).not.toBe('unavailable')
+  })
+
+  it('PR #169: parse-error wrapper + `fallback_v5_turn` provenance → live_v5_cee_embedded (fallback-V5 still IS selected V5)', async () => {
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        cee_capture_provenance: 'fallback_v5_turn',
+        payloads: {
+          cee_request: { turn_id: 't-fallback-wrap' },
+          cee_response: {
+            kind: 'parse_error',
+            reason: 'whatever',
+            raw: {
+              blocks: [
+                {
+                  type: 'analysis_result',
+                  enrichment: {
+                    factor_sensitivity: [{ factor_id: 'f1' }],
+                    robustness: { level: 'high' },
+                  },
+                },
+              ],
+            },
+          },
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    expect(bundle.evidence_resolution?.plot_response.source).toBe(
+      'cee_embedded',
+    )
+    expect(bundle.scientific_validation?.source).toBe('live_v5_cee_embedded')
+  })
+
+  it('PR #169: parse-error wrapper + `fallback_legacy_cee` provenance → cee_embedded but source NOT live (honesty gate preserved)', async () => {
+    // R-2 Blocker 2 gate still applies to wrapped enrichment. A
+    // wrapped legacy CEE turn must NOT mislabel as live V5 evidence.
+    const bundle = await buildDebugBundleAsync(
+      makeDebugData({
+        cee_capture_provenance: 'fallback_legacy_cee',
+        payloads: {
+          cee_request: { turn_id: 't-legacy-wrap' },
+          cee_response: {
+            kind: 'parse_error',
+            reason: 'whatever',
+            raw: {
+              blocks: [
+                {
+                  type: 'analysis_result',
+                  enrichment: {
+                    factor_sensitivity: [{ factor_id: 'f1' }],
+                  },
+                },
+              ],
+            },
+          },
+          plot_request: null,
+          plot_response: null,
+          isl_request: null,
+          isl_response: null,
+        },
+      }),
+    )
+    // Resolver STILL surfaces the embedded path (informational).
+    expect(bundle.evidence_resolution?.plot_response.source).toBe(
+      'cee_embedded',
+    )
+    expect(bundle.evidence_resolution?.plot_response.path).toBe(
+      'payloads.cee_response.raw.blocks[0].enrichment',
+    )
+    // But scientific_validation honesty gate refuses live label.
+    expect(bundle.scientific_validation?.source).not.toBe(
+      'live_v5_cee_embedded',
+    )
+    expect(bundle.scientific_validation?.source).not.toBe('live_raw_payloads')
+  })
 })

--- a/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
+++ b/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
@@ -467,3 +467,245 @@ describe('resolveScientificEvidence — malformed-input safety', () => {
     expect(r.resolution.plot_response.source).toBe('unavailable')
   })
 })
+
+/**
+ * PR #169 — parse-error wrapper coverage.
+ *
+ * `src/v5/responseParser.ts` wraps the original CEE body when the
+ * OlumiResponse schema fails:
+ *
+ *     { kind: 'parse_error', reason: '...', raw: <original CEE body> }
+ *
+ * Manual staging validation of PR #168 (commit `5e9847db`,
+ * 2026-05-21) showed this in the wild — the bundle had
+ * `payloads.cee_response.kind === 'parse_error'` with full
+ * enrichment under `payloads.cee_response.raw.blocks[0].enrichment`.
+ * Pre-fix the resolver only probed `cee_response.blocks[*]` and
+ * therefore marked `plot_response.source === 'unavailable'`. These
+ * tests pin the fallback probe.
+ */
+describe('resolveScientificEvidence — parse-error wrapper (PR #169)', () => {
+  const wrappedEnrichment = {
+    factor_sensitivity: [
+      { factor_id: 'wrapped-f1', sensitivity_score: 0.42 },
+    ],
+    option_comparison: [
+      { id: 'wrapped-o1', win_probability: 0.61 },
+    ],
+    robustness: { is_robust: true, level: 'high' },
+  }
+
+  const parseErrorBody = {
+    kind: 'parse_error',
+    reason: 'body did not match OlumiResponse schema',
+    raw: {
+      blocks: [
+        {
+          type: 'analysis_result',
+          summary: 'wrapped',
+          enrichment: wrappedEnrichment,
+        },
+      ],
+    },
+  }
+
+  it('lifts bare enrichment from `cee_response.raw.blocks[*].enrichment`', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, parseErrorBody)
+    expect(r.resolution.plot_response.source).toBe('cee_embedded')
+    expect(r.resolution.plot_response.path).toBe(
+      'payloads.cee_response.raw.blocks[0].enrichment',
+    )
+    expect(r.resolution.plot_response.available).toBe(true)
+    expect(r.resolution.plot_response.required_upstream_support).toBeNull()
+    expect(r.bodies.plot_response).toEqual(wrappedEnrichment)
+  })
+
+  it('lifts `_meta.payloads.plot_response` sidecar from inside the wrapper', () => {
+    const sidecarPlot = {
+      factor_sensitivity: [{ factor_id: 'sidecar-f1' }],
+      confidence_provenance: { foo: 'bar' },
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'whatever',
+      raw: {
+        blocks: [
+          {
+            type: 'analysis_result',
+            enrichment: {
+              ...wrappedEnrichment,
+              _meta: { payloads: { plot_response: sidecarPlot } },
+            },
+          },
+        ],
+      },
+    })
+    expect(r.resolution.plot_response.source).toBe('cee_embedded')
+    expect(r.resolution.plot_response.path).toBe(
+      'payloads.cee_response.raw.blocks[0].enrichment._meta.payloads.plot_response',
+    )
+    expect(r.bodies.plot_response).toEqual(sidecarPlot)
+  })
+
+  it('lifts `downstream_calls.isl.response` from inside the wrapper', () => {
+    const downstreamIslResp = {
+      factor_sensitivity: [{ factor_id: 'isl-f1', elasticity: 0.3 }],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'whatever',
+      raw: {
+        blocks: [
+          {
+            type: 'analysis_result',
+            enrichment: {
+              ...wrappedEnrichment,
+              downstream_calls: { isl: { response: downstreamIslResp } },
+            },
+          },
+        ],
+      },
+    })
+    expect(r.resolution.isl_response.source).toBe('cee_embedded')
+    expect(r.resolution.isl_response.path).toBe(
+      'payloads.cee_response.raw.blocks[0].enrichment.downstream_calls.isl.response',
+    )
+    expect(r.bodies.isl_response).toEqual(downstreamIslResp)
+  })
+
+  it('lifts ISL request from `_meta.payloads.isl_request` inside the wrapper', () => {
+    const sidecarIslReq = {
+      parameter_uncertainties: [{ name: 'p1', std: 0.1 }],
+    }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'x',
+      raw: {
+        blocks: [
+          {
+            type: 'analysis_result',
+            enrichment: {
+              ...wrappedEnrichment,
+              _meta: { payloads: { isl_request: sidecarIslReq } },
+            },
+          },
+        ],
+      },
+    })
+    expect(r.resolution.isl_request.source).toBe('cee_embedded')
+    expect(r.resolution.isl_request.path).toBe(
+      'payloads.cee_response.raw.blocks[0].enrichment._meta.payloads.isl_request',
+    )
+    expect(r.bodies.isl_request).toEqual(sidecarIslReq)
+  })
+
+  it('top-level path WINS over wrapper — unwrapped blocks beat raw.blocks', () => {
+    // Defensive: if both an unwrapped `.blocks` AND a `.raw.blocks` are
+    // present, prefer the unwrapped form (it implies the body parsed
+    // successfully, not the wrapper variant). Pre-fix this was the
+    // only path the resolver knew about, so this test pins the
+    // ordering rather than reversing it.
+    const unwrappedEnrichment = { factor_sensitivity: [{ factor_id: 'unwrapped-f1' }] }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      blocks: [
+        { type: 'analysis_result', enrichment: unwrappedEnrichment },
+      ],
+      // Defensive `raw.blocks` shouldn't be reached when top-level is good.
+      raw: {
+        blocks: [
+          { type: 'analysis_result', enrichment: wrappedEnrichment },
+        ],
+      },
+    })
+    expect(r.resolution.plot_response.path).toBe(
+      'payloads.cee_response.blocks[0].enrichment',
+    )
+    expect(r.bodies.plot_response).toEqual(unwrappedEnrichment)
+  })
+
+  it('top-level `payloads.plot_response` still beats the wrapper', () => {
+    const topPlot = { factor_sensitivity: [{ factor_id: 'top' }] }
+    const r = resolveScientificEvidence(
+      { ...EMPTY_TOP_LEVEL, plot_response: topPlot },
+      parseErrorBody,
+    )
+    expect(r.resolution.plot_response.source).toBe('top_level')
+    expect(r.resolution.plot_response.path).toBe('payloads.plot_response')
+    expect(r.bodies.plot_response).toEqual(topPlot)
+  })
+
+  it('parse-error wrapper without `raw` field → unavailable (no throw)', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'no raw',
+    })
+    expect(r.resolution.plot_response.source).toBe('unavailable')
+    expect(r.resolution.plot_response.required_upstream_support).not.toBeNull()
+  })
+
+  it('parse-error wrapper with `raw` but no analysis_result block → unavailable', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'x',
+      raw: {
+        blocks: [
+          { type: 'commentary', text: 'no analysis here' },
+        ],
+      },
+    })
+    expect(r.resolution.plot_response.source).toBe('unavailable')
+  })
+
+  it('parse-error wrapper with `raw.blocks` not an array → unavailable, no throw', () => {
+    expect(() =>
+      resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+        kind: 'parse_error',
+        reason: 'x',
+        raw: { blocks: 'not-an-array' },
+      }),
+    ).not.toThrow()
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'x',
+      raw: { blocks: 'not-an-array' },
+    })
+    expect(r.resolution.plot_response.source).toBe('unavailable')
+  })
+
+  it('wrapper enrichment WITHOUT indicative keys is NOT promoted (honesty gate preserved)', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'x',
+      raw: {
+        blocks: [
+          {
+            type: 'analysis_result',
+            // No factor_sensitivity / option_comparison / etc.
+            enrichment: { summary: 'no science here' },
+          },
+        ],
+      },
+    })
+    expect(r.resolution.plot_response.source).toBe('unavailable')
+  })
+
+  it('picks FIRST analysis_result inside wrapper when multiple exist', () => {
+    const first = { factor_sensitivity: [{ factor_id: 'first' }] }
+    const second = { factor_sensitivity: [{ factor_id: 'second' }] }
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      kind: 'parse_error',
+      reason: 'x',
+      raw: {
+        blocks: [
+          { type: 'commentary', text: 'noise' },
+          { type: 'analysis_result', enrichment: first },
+          { type: 'analysis_result', enrichment: second },
+        ],
+      },
+    })
+    expect(r.resolution.plot_response.path).toBe(
+      'payloads.cee_response.raw.blocks[1].enrichment',
+    )
+    expect(r.bodies.plot_response).toEqual(first)
+  })
+})

--- a/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
+++ b/src/lib/__tests__/v5EmbeddedEvidence.spec.ts
@@ -708,4 +708,39 @@ describe('resolveScientificEvidence — parse-error wrapper (PR #169)', () => {
     )
     expect(r.bodies.plot_response).toEqual(first)
   })
+
+  // PR #169 reviewer round-1 follow-up #1 — pin the intentionally
+  // structural test in `findAnalysisResultBlock`. The fallback does
+  // NOT require `kind === 'parse_error'`; it walks `ceeResponse.raw.blocks[*]`
+  // whenever the unwrapped `.blocks` is absent. This is forward-compat
+  // with potential CEE wrapper-shape evolution. The live-evidence
+  // honesty contract is still owned by the downstream provenance gate
+  // (R-2 Blocker 2) in `scientificValidation/index.ts`, so accepting a
+  // non-parse_error wrapper here cannot mislabel as live by itself.
+  it('resolves raw wrapper structurally even when kind !== parse_error (forward-compat)', () => {
+    const r = resolveScientificEvidence(EMPTY_TOP_LEVEL, {
+      // Anything other than 'parse_error' — including completely
+      // unknown wrapper shapes — must still resolve via raw.blocks.
+      kind: 'something_else_unknown',
+      raw: {
+        blocks: [
+          {
+            type: 'analysis_result',
+            enrichment: {
+              factor_sensitivity: [{ factor_id: 'fwd-f1' }],
+              robustness: { level: 'low' },
+            },
+          },
+        ],
+      },
+    })
+    expect(r.resolution.plot_response.source).toBe('cee_embedded')
+    expect(r.resolution.plot_response.path).toBe(
+      'payloads.cee_response.raw.blocks[0].enrichment',
+    )
+    expect(r.bodies.plot_response).toEqual({
+      factor_sensitivity: [{ factor_id: 'fwd-f1' }],
+      robustness: { level: 'low' },
+    })
+  })
 })

--- a/src/lib/v5EmbeddedEvidence.ts
+++ b/src/lib/v5EmbeddedEvidence.ts
@@ -23,6 +23,21 @@
  *      (e.g. `confidence_provenance`, `evpi_percentage_points`,
  *      `flip_thresholds_status`, ISL `parameter_uncertainties`).
  *
+ *   3. `response.raw.blocks[type==='analysis_result'].enrichment`
+ *      — the SAME shape as #1, but reached via the parse-error
+ *      wrapper emitted by `src/v5/responseParser.ts` when the CEE
+ *      body fails the OlumiResponse schema. The wrapper shape is
+ *      `{ kind: 'parse_error', reason: '...', raw: <original> }`.
+ *      Manual staging validation of PR #168 (commit `5e9847db`,
+ *      2026-05-21) observed this in the wild — full enrichment
+ *      lived under `payloads.cee_response.raw.blocks[0].enrichment`
+ *      while top-level `cee_response.blocks` was absent. PR #169
+ *      added the fallback probe so embedded evidence resolves even
+ *      when the captured body wraps the original CEE response.
+ *      `_meta.payloads` and `downstream_calls.isl.response` are
+ *      probed under the wrapper too (same enrichment shape, just
+ *      reached via the `.raw.` prefix).
+ *
  * Scientific validators are hard-wired to read from `inputs.plotResponse`
  * / `inputs.islRequest` / `inputs.islResponse`. This resolver lifts
  * embedded bodies into the validator inputs WITHOUT mutating
@@ -181,20 +196,78 @@ function isNonEmptyObject(v: unknown): v is Record<string, unknown> {
 }
 
 /**
- * Find the FIRST analysis_result block in `ceeResponse.blocks[]`.
- * Returns null if response is malformed, blocks is missing, or no
- * such block exists.
+ * Walk `blocks[]` looking for the first `analysis_result` entry.
+ * Helper for `findAnalysisResultBlock` — accepts an `unknown` so the
+ * caller can pass either `ceeResponse.blocks` or
+ * `ceeResponse.raw.blocks` without re-asserting Array-ness.
  */
-function findAnalysisResultBlock(
-  ceeResponse: unknown,
+function findInBlocks(
+  blocks: unknown,
 ): { block: Record<string, unknown>; index: number } | null {
-  if (!isPlainObject(ceeResponse)) return null
-  const blocks = ceeResponse.blocks
   if (!Array.isArray(blocks)) return null
   for (let i = 0; i < blocks.length; i++) {
     const b = blocks[i]
     if (!isPlainObject(b)) continue
     if (b.type === 'analysis_result') return { block: b, index: i }
+  }
+  return null
+}
+
+/**
+ * Find the FIRST analysis_result block reachable from `ceeResponse`.
+ *
+ * PR #169: extended to handle the parse-error wrapper shape emitted
+ * by `src/v5/responseParser.ts` when the CEE turn body fails the
+ * OlumiResponse schema. In that case the captured body has shape:
+ *
+ *     { kind: 'parse_error', reason: '...', raw: <original CEE body> }
+ *
+ * so `ceeResponse.blocks` is absent but `ceeResponse.raw.blocks[*]`
+ * carries the same `analysis_result` enrichment we would otherwise
+ * inspect. The wrapper is observed on staging exports (build
+ * `5e9847db`+) — manual validation showed `payloads.cee_response.kind
+ * = parse_error` with full enrichment under `.raw.blocks[0].enrichment`.
+ *
+ * Probe order:
+ *   1. `ceeResponse.blocks[*]`              → unwrapped (clean body).
+ *   2. `ceeResponse.raw.blocks[*]`          → parse-error wrapper.
+ *
+ * The returned `pathPrefix` is the canonical bundle-relative path to
+ * the matched block (with or without the `.raw.` segment). Callers
+ * compose evidence paths as `${pathPrefix}.enrichment[...]`.
+ *
+ * Returns null if neither location carries an `analysis_result` block,
+ * or if `ceeResponse` is not a plain object.
+ */
+function findAnalysisResultBlock(
+  ceeResponse: unknown,
+): {
+  block: Record<string, unknown>
+  index: number
+  pathPrefix: string
+} | null {
+  if (!isPlainObject(ceeResponse)) return null
+  // 1. Try the top-level (unwrapped) shape first.
+  const top = findInBlocks(ceeResponse.blocks)
+  if (top !== null) {
+    return {
+      ...top,
+      pathPrefix: `payloads.cee_response.blocks[${top.index}]`,
+    }
+  }
+  // 2. Fall back to the parse-error wrapper. We don't require
+  //    `kind === 'parse_error'` explicitly — the structural test
+  //    (`.raw.blocks[*]` carries an analysis_result) is sufficient
+  //    and forward-compatible if the wrapper shape evolves.
+  const raw = ceeResponse.raw
+  if (isPlainObject(raw)) {
+    const wrapped = findInBlocks(raw.blocks)
+    if (wrapped !== null) {
+      return {
+        ...wrapped,
+        pathPrefix: `payloads.cee_response.raw.blocks[${wrapped.index}]`,
+      }
+    }
   }
   return null
 }
@@ -232,7 +305,7 @@ function entry(
  */
 function probeMetaPayloadsKind(
   enrichment: Record<string, unknown>,
-  blockIndex: number,
+  pathPrefix: string,
   kind: 'plot_request' | 'plot_response' | 'isl_request' | 'isl_response',
 ): { body: Record<string, unknown>; path: string } | null {
   const meta = enrichment._meta
@@ -244,7 +317,7 @@ function probeMetaPayloadsKind(
   if (kind === 'plot_response' && !hasIndicativeKey(body)) return null
   return {
     body,
-    path: `payloads.cee_response.blocks[${blockIndex}].enrichment._meta.payloads.${kind}`,
+    path: `${pathPrefix}.enrichment._meta.payloads.${kind}`,
   }
 }
 
@@ -289,7 +362,7 @@ export function resolveScientificEvidence(
       REQ_PLOT_REQUEST,
     )
   } else if (enrichment !== null && found !== null) {
-    const probe = probeMetaPayloadsKind(enrichment, found.index, 'plot_request')
+    const probe = probeMetaPayloadsKind(enrichment, found.pathPrefix, 'plot_request')
     if (probe !== null) {
       plot_request = probe.body
       plot_request_entry = entry(
@@ -328,7 +401,7 @@ export function resolveScientificEvidence(
     )
   } else if (enrichment !== null && found !== null) {
     // 1. Try the `_meta.payloads` sidecar first (closer to upstream shape).
-    const meta = probeMetaPayloadsKind(enrichment, found.index, 'plot_response')
+    const meta = probeMetaPayloadsKind(enrichment, found.pathPrefix, 'plot_response')
     if (meta !== null) {
       plot_response = meta.body
       plot_response_entry = entry(
@@ -342,7 +415,7 @@ export function resolveScientificEvidence(
       plot_response = enrichment
       plot_response_entry = entry(
         'cee_embedded',
-        `payloads.cee_response.blocks[${found.index}].enrichment`,
+        `${found.pathPrefix}.enrichment`,
         'Lifted from CEE V5 turn `analysis_result` block enrichment. Top-level `payloads.plot_response` was null; enrichment carries at least one indicative key.',
         REQ_PLOT_RESPONSE,
       )
@@ -375,7 +448,7 @@ export function resolveScientificEvidence(
       REQ_ISL_REQUEST,
     )
   } else if (enrichment !== null && found !== null) {
-    const probe = probeMetaPayloadsKind(enrichment, found.index, 'isl_request')
+    const probe = probeMetaPayloadsKind(enrichment, found.pathPrefix, 'isl_request')
     if (probe !== null) {
       isl_request = probe.body
       isl_request_entry = entry(
@@ -414,7 +487,7 @@ export function resolveScientificEvidence(
     )
   } else if (enrichment !== null && found !== null) {
     // 1. `_meta.payloads.isl_response` first.
-    const meta = probeMetaPayloadsKind(enrichment, found.index, 'isl_response')
+    const meta = probeMetaPayloadsKind(enrichment, found.pathPrefix, 'isl_response')
     if (meta !== null) {
       isl_response = meta.body
       isl_response_entry = entry(
@@ -434,7 +507,7 @@ export function resolveScientificEvidence(
             isl_response = response
             isl_response_entry = entry(
               'cee_embedded',
-              `payloads.cee_response.blocks[${found.index}].enrichment.downstream_calls.isl.response`,
+              `${found.pathPrefix}.enrichment.downstream_calls.isl.response`,
               'Lifted from CEE V5 turn enrichment `downstream_calls.isl.response`.',
               REQ_ISL_RESPONSE,
             )


### PR DESCRIPTION
## Root cause

Manual staging validation of PR #168 (commit `5e9847db`, 2026-05-21) confirmed the V5 CEE capture works end-to-end (`analysis_evidence_source = live_v5_cee_proxy_turn`, `cee_capture_provenance = analysis_producing_v5_turn`) and that the captured body carried full enrichment (`option_comparison`, `factor_sensitivity`, `m1_coaching`, `flip_thresholds`, `robustness`, `_meta.payloads.isl_*`, `downstream_calls`).

But the bundle reported:
- `payloads.cee_response.kind = parse_error`
- `payloads.cee_response.reason = "body did not match OlumiResponse schema"`
- `evidence_resolution.plot_response.source = unavailable`
- `scientific_validation.source = unavailable`

Because `src/v5/responseParser.ts` wraps the CEE body when `OlumiResponseSchema.safeParse` fails:

```
{ kind: 'parse_error', reason: '...', raw: <original CEE body> }
```

PR #168's resolver only probed `cee_response.blocks[*].enrichment`, so the wrapped body — sitting under `cee_response.raw.blocks[*].enrichment` — was invisible.

## Surgical changes (DGAI only)

1. **`src/lib/v5EmbeddedEvidence.ts`** — `findAnalysisResultBlock` now falls back to `ceeResponse.raw.blocks[*]` when `ceeResponse.blocks[*]` is absent or carries no `analysis_result`. Returned `pathPrefix` reflects which location matched (`payloads.cee_response.blocks[i]` vs `payloads.cee_response.raw.blocks[i]`), so all downstream path strings (sidecar `_meta.payloads`, `downstream_calls.isl.response`, bare enrichment) carry the correct prefix into the bundle.
2. **`probeMetaPayloadsKind`** signature swap: takes the resolved `pathPrefix` (string) instead of a raw `blockIndex` (number). Same semantics, supports both wrapped and unwrapped shapes uniformly.
3. Top-level JSDoc updated to document the parse-error wrapper as case 3 of the embedded-evidence locations.

## Honesty invariants preserved

- `bundle.payloads.*` remains raw browser-captured truth ONLY. Never mutated, never synthesised.
- Indicative-keys gate (`option_comparison` / `factor_sensitivity` / `m1_coaching` / `flip_thresholds` / `robustness`) still applies to wrapped enrichment. Empty bodies are NOT promoted.
- R-2 Blocker 2 provenance gate from PR #168 still applies — only `analysis_producing_v5_turn` or `fallback_v5_turn` provenance accepts `cee_embedded` as `live_v5_cee_embedded`. A wrapped legacy CEE turn does not mislabel.
- `payloads.plot_request / plot_response / isl_request / isl_response` stay `null` under V5 canonical (browser never fetches them directly).
- Top-level body (when present) still beats the wrapper — successful parse is closer to truth.

## Tests

- **`src/lib/__tests__/v5EmbeddedEvidence.spec.ts`** — 11 new unit cases (total file now 37 tests):
  - bare wrapped enrichment → `cee_embedded` + path `payloads.cee_response.raw.blocks[0].enrichment`
  - `_meta.payloads.plot_response` sidecar inside wrapper → correct nested path
  - `_meta.payloads.isl_request` sidecar inside wrapper
  - `downstream_calls.isl.response` inside wrapper
  - top-level (unwrapped) `.blocks` still beats `.raw.blocks` when both exist
  - top-level `payloads.plot_response` still beats the wrapper
  - parse-error wrapper without `raw` → unavailable
  - parse-error wrapper with `raw` but no `analysis_result` block → unavailable
  - parse-error wrapper with `raw.blocks` not an array → unavailable (no throw)
  - wrapped enrichment without indicative keys → unavailable (honesty gate preserved)
  - multiple analysis_result blocks inside wrapper → picks first

- **`src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts`** — 3 new integration cases matching the exact staging shape:
  - parse-error wrapped + `analysis_producing_v5_turn` provenance → `evidence_resolution.plot_response.source = cee_embedded`, `path = payloads.cee_response.raw.blocks[0].enrichment`, `scientific_validation.source = live_v5_cee_embedded`, `response_shape_validation.status != unavailable`.
  - parse-error wrapped + `fallback_v5_turn` provenance → same live label (fallback-V5 still IS selected V5).
  - parse-error wrapped + `fallback_legacy_cee` provenance → `evidence_resolution.plot_response.source = cee_embedded` (informational), but `scientific_validation.source` does NOT promote to live (R-2 Blocker 2 gate still applies).

## Verification

```bash
npm run typecheck   # passes

npx vitest run \
  src/lib/__tests__/v5EmbeddedEvidence.spec.ts \
  src/components/debug/__tests__/exportBundle.liveCeeCapture.spec.ts \
  src/lib/scientificValidation/__tests__/index.spec.ts \
  src/lib/__tests__/contract-validators.spec.ts \
  src/lib/__tests__/v5TraceMatching.spec.ts \
  src/lib/__tests__/analysisProducingCeeTurn.spec.ts \
  src/lib/__tests__/analysisProducingPlotTurn.spec.ts \
  src/lib/__tests__/payload-trace-store.envGate.spec.ts \
  src/components/debug/__tests__/useDebugData.spec.ts \
  src/adapters/plot/v1/__tests__/http.payloadTraceStore.spec.ts \
  src/adapters/plot/v1/__tests__/sseClient.payloadTraceStore.spec.ts \
  src/lib/__tests__/v5CapturePipelineStatus.spec.ts \
  src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
# 615 passed

# Pre-push fast gate ran cleanly during the push.
```

## Files NOT modified (explicit no-change list)

- CEE / PLoT / ISL / prompts / schemas / `@talchain/schemas` vendored tarball
- Package files / lockfiles / `netlify.toml`
- `src/v5/responseParser.ts` (parse_error producer — left untouched)
- All scientific validators (consume whatever the resolver feeds; no per-validator code changes)
- `useDebugData.ts` / `exportBundle.ts` (resolver call site unchanged — the wrapper-handling is internal to `v5EmbeddedEvidence.ts`)

## Parse-error origin — separate observation (NOT fixed here)

Per the brief's requirement #9: investigated only, not addressed.

`src/v5/responseParser.ts:480-487` returns `parse_error` with `parse_failure_kind: 'schema_mismatch'` whenever `OlumiResponseSchema.safeParse(knownForValidation)` fails on a 2xx response. The `reason: "body did not match OlumiResponse schema"` Paul observed maps to this branch exactly.

This is almost certainly contract drift between the vendored `@talchain/schemas` package and the live CEE staging response shape — possibly an additive field CEE started emitting that hasn't been split into the additive-extensions sidecar, or a nested shape change. Resolving it requires either:

- a CEE-side schema-conforming change, OR
- a DGAI vendored-schema bump (`@talchain/schemas` tarball update + SHA manifest update), OR
- additive-tolerance extension in `responseParser.ts` (`splitAdditiveExtensions` / `splitBlocksTolerance`).

All three require CEE/DGAI contract work outside the scope of this PR. Flagging here for a separate follow-up — once the parse_error is also fixed at source, the resolver's wrapper fallback becomes a safety net rather than the primary path, but it will still be useful for diagnostic transparency.

## Manual staging acceptance (after merge)

1. Hard reload `https://staging--olumi.netlify.app/#/canvas?diag=1`.
2. Create / open scenario; click Run analysis; let it complete.
3. Click "Test" pill → Export bundle.
4. Confirm in the JSON:
   - **Tier 1** (regression): `payloads.cee_request/response` populated; `analysis_evidence_source === 'live_v5_cee_proxy_turn'`; `cee_capture_provenance === 'analysis_producing_v5_turn'`.
   - **Tier 2** (this PR): `evidence_resolution.plot_response.source === 'cee_embedded'`; `evidence_resolution.plot_response.path` starts with `payloads.cee_response.raw.blocks[` (when the parse-error still fires) OR `payloads.cee_response.blocks[` (after CEE/schema fix); `scientific_validation.source === 'live_v5_cee_embedded'`; `response_shape_validation.status !== 'unavailable'`.
   - **Tier 3**: `payloads.plot_request / plot_response / isl_request / isl_response` remain `null` (raw capture truth).

## Pause for review

Do not merge. Do not deploy production. Awaiting reviewer feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)