### PR TITLE
test(v5/ai-panel): pin prompt-chip dispatch + mapV5Blocks review_card invariant

### DIFF
--- a/src/canvas/conversation/__tests__/SuggestedChips.promptChip.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.promptChip.spec.tsx
@@ -1,0 +1,88 @@
+/**
+ * SuggestedChips — prompt-chip contract under V5.
+ *
+ * Pins the live behaviour at SuggestedChips.tsx:171
+ *   `if (!c.action_type) return true`
+ * and the subsequent click path: chips without `action_type` must render
+ * AND dispatch their full `message` via onChipClick.
+ *
+ * The readiness-gate spec already covers the *rendering* pass-through
+ * (`shows chips with no action_type regardless of readiness`). This file
+ * pins the *dispatch* half: under V5, clicking a prompt chip surfaces the
+ * full chip object (with the `message` intact) to the handler, so the
+ * upstream `dispatchAction` keyword-fallback path can route it as a
+ * normal conversation turn.
+ *
+ * If this test ever fails, prompt chips have regressed and the V5
+ * filter / click handler needs investigating — do NOT patch the test;
+ * fix the production code.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { SuggestedChips } from '../zones/SuggestedChips'
+import type { ActionChip } from '../types'
+
+describe('SuggestedChips — prompt chip (no action_type) dispatches under V5', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('renders the prompt chip and dispatches the full chip (message intact) on click', () => {
+    const onChipClick = vi.fn().mockResolvedValue(undefined)
+    const promptChip: ActionChip = {
+      id: 'chip-prompt',
+      label: 'Tell me more',
+      intent: 'primary',
+      message: 'Tell me more about this result',
+      // no action_type
+    }
+
+    render(<SuggestedChips chips={[promptChip]} onChipClick={onChipClick} />)
+
+    const button = screen.getByTestId('suggested-chip-chip-prompt')
+    expect(button).toBeInTheDocument()
+
+    fireEvent.click(button)
+
+    expect(onChipClick).toHaveBeenCalledTimes(1)
+    const received = onChipClick.mock.calls[0][0] as ActionChip
+    expect(received).toEqual(promptChip)
+    expect(received.message).toBe('Tell me more about this result')
+    expect(received.action_type).toBeUndefined()
+  })
+})
+
+describe('SuggestedChips — prompt chip (no action_type) also dispatches under V4', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', '')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('renders and dispatches the prompt chip with V5 off (V4 passthrough)', () => {
+    const onChipClick = vi.fn().mockResolvedValue(undefined)
+    const promptChip: ActionChip = {
+      id: 'chip-prompt-v4',
+      label: 'Why did it pick that?',
+      intent: 'primary',
+      message: 'Why did the analysis pick that option?',
+    }
+
+    render(<SuggestedChips chips={[promptChip]} onChipClick={onChipClick} />)
+
+    fireEvent.click(screen.getByTestId('suggested-chip-chip-prompt-v4'))
+
+    expect(onChipClick).toHaveBeenCalledTimes(1)
+    expect(onChipClick.mock.calls[0][0]).toEqual(promptChip)
+    expect((onChipClick.mock.calls[0][0] as ActionChip).message).toBe(
+      'Why did the analysis pick that option?',
+    )
+  })
+})

--- a/src/v5/blocks/__tests__/mapV5Blocks.reviewCardGuard.spec.ts
+++ b/src/v5/blocks/__tests__/mapV5Blocks.reviewCardGuard.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * mapV5Blocks — `review_card` live-path invariant guard.
+ *
+ * Live-path contract (verified Phase 0 / 2026-05-21):
+ *   - V5 OlumiResponseSchema is strict; `review_card` is NOT a valid V5
+ *     block kind. Phase 3 sidecar blocks (`review_card`, `coaching`,
+ *     `evidence`, `exercise`) are split out by the parser BEFORE
+ *     `mapV5Blocks` runs and routed to GuidanceStore via
+ *     `extractPhase3FromV5Response`.
+ *   - As a defence-in-depth check, this test forces a `review_card`-shaped
+ *     block past the type system and asserts the mapper does NOT emit a
+ *     `ConversationBlock` of type `'review_card'`. If a future refactor
+ *     ever routes `review_card` into `message.blocks[]`, the AI panel
+ *     would suddenly start rendering Phase 3 cards in chat (alongside the
+ *     existing GuidanceStore surface). This test catches that regression.
+ *
+ * The current mapper's `default` branch produces `v5_unsupported` for any
+ * unknown kind, so the assertion is "type !== 'review_card'", not a
+ * specific positive shape — we are guarding the invariant, not the
+ * fallback's exact form.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { mapV5Block, mapV5Blocks } from '../mapV5Blocks'
+
+describe('mapV5Blocks — review_card invariant', () => {
+  it('mapV5Block never produces a ConversationBlock of type "review_card"', () => {
+    // Force a Phase 3 review_card shape past the strict V5 block union.
+    // In live code the parser would split this into the additive sidecar
+    // before the mapper sees it; the cast simulates the "what if a refactor
+    // bypassed the split?" failure mode.
+    const phase3ReviewCardShape = {
+      type: 'review_card',
+      title: 'A leads under most paths',
+      body: 'Confidence is fair; review the top driver before committing.',
+      variant: 'info',
+    } as unknown as Parameters<typeof mapV5Block>[0]
+
+    const result = mapV5Block(phase3ReviewCardShape)
+
+    // The mapper may return null or a v5_unsupported fallback — either is
+    // acceptable. The invariant is that it does NOT emit a review_card
+    // ConversationBlock that would land in message.blocks[] and surface
+    // inside the chat panel.
+    expect(result?.type).not.toBe('review_card')
+  })
+
+  it('mapV5Blocks batch never produces a ConversationBlock of type "review_card"', () => {
+    const blocks = [
+      { type: 'analysis_result', summary: 'A leads.', leading_option_id: 'opt-a' },
+      {
+        type: 'review_card',
+        title: 'A leads',
+        body: 'Confidence is fair.',
+        variant: 'info',
+      },
+    ] as unknown as Parameters<typeof mapV5Blocks>[0]
+
+    const out = mapV5Blocks(blocks)
+
+    // The legitimate analysis_result still maps correctly.
+    expect(out.some(b => b.type === 'v5_analysis_result')).toBe(true)
+    // The review_card-shaped block must NEVER surface as a review_card
+    // ConversationBlock.
+    expect(out.some(b => b.type === 'review_card')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Two regression-guard tests, **no production code changes**. PR opened for review only — do not merge or deploy.

## Phase 0 verification — original assumption was wrong

The originally planned change (suppress duplicate post-analysis coaching prose when `review_card` + `v5_analysis_result` co-occur) was based on a duplication scenario that **does not occur in the live code path**:

- **V5 is OFF by default** (`VITE_ENABLE_V5_ORCHESTRATOR` undefined in `.env.example`). The default live path is V4 (`/orchestrate/v1/turn`).
- **In V5, `mapV5Blocks` does NOT map `review_card` to a `ConversationBlock`.** Only the 8 V5 OlumiResponse types are mapped (`text → commentary`, `analysis_result → v5_analysis_result`, etc.). See `src/v5/blocks/mapV5Blocks.ts:32-116`.
- **Phase 3 `review_card`** (when CEE emits it inside `blocks[]`) is split out by the parser into the additive sidecar and routed to **`GuidanceStore`** via `extractPhase3FromV5Response` at `src/canvas/conversation/useConversation.ts:2762-2809`. It never lands in `message.blocks[]`.
- **In V4 there is no `v5_analysis_result` block at all** — duplication impossible there too.
- The only place both blocks co-occur is the parser-tolerance synthetic fixture at `src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts:80-133`.

The planned production change to `InlineBlocks.tsx` / `V5AnalysisResultBlock.tsx` / a new `coachingPrimary` selector was therefore dropped. This PR captures the two contracts worth pinning down so they cannot silently regress.

## What this PR ships

### 1. `src/canvas/conversation/__tests__/SuggestedChips.promptChip.spec.tsx`

Pins the dispatch half of the prompt-chip contract: with V5 active, a chip with no `action_type` renders AND clicking it surfaces the full chip (with `message` intact) to `onChipClick`. The rendering pass-through is already covered by `SuggestedChips.readinessGate.spec.tsx:106-115`; this file covers click-dispatch under both V5-on and V5-off, so a future tweak to the V5 filter at `SuggestedChips.tsx:171` (`if (!c.action_type) return true`) cannot silently drop prompt chips.

### 2. `src/v5/blocks/__tests__/mapV5Blocks.reviewCardGuard.spec.ts`

Defence-in-depth: forces a `review_card`-shaped block past the strict V5 type system and asserts the mapper **never** emits a `ConversationBlock` of type `review_card`. The current mapper's `default` branch produces `v5_unsupported` for unknown kinds, so the assertion is "type !== 'review_card'" — guarding the invariant, not the fallback's exact form. If a future refactor accidentally routes Phase 3 `review_card` content into `message.blocks[]`, this test fails loudly.

## Files changed

- `src/canvas/conversation/__tests__/SuggestedChips.promptChip.spec.tsx` (+57 lines, new)
- `src/v5/blocks/__tests__/mapV5Blocks.reviewCardGuard.spec.ts` (+62 lines, new)

**No production code changes.** No changes to `InlineBlocks.tsx`, `V5AnalysisResultBlock.tsx`, `MessageBubble.tsx`, `ChatThread.tsx`, `SuggestedChips.tsx`, `useConversation.ts`, parser, schema, packages, lockfiles, or any orchestrator path.

## Tests skipped (already covered)

| Originally planned | Why skipped |
|---|---|
| `SuggestedChips.multipleChips.spec.tsx` (cap at 2) | Already covered by `SuggestedChips.spec.tsx:75-82` |
| `SuggestedChips.executableChip.spec.tsx` (`explain_results → 'explain'`) | Already covered by `dispatchAction.spec.ts:27` and `SuggestedChips.readinessGate.spec.tsx:138-155` |
| `SuggestedChips.duplicates.spec.tsx` | Per reviewer instruction — would lock in undesirable no-dedup behaviour |

## Hand-off for the next workstream

Re-scope the production UI work around the **real live path**:

1. Identify where post-analysis coaching currently appears in the AI panel under the live (V4) and V5 paths.
2. Confirm whether Phase 3 content (`review_card`, `coaching`) is currently only visible in `GuidanceStore`, not inside the AI panel chat.
3. Propose the smallest safe change to make the best existing coaching content visible inside the AI panel **without inventing meaning** — this may be a `mapV5Blocks` routing decision (route `review_card` to chat as well as GuidanceStore?) or a chat-side surfacing of existing GuidanceStore content, not a UI suppression task.

## Verification

- Local typecheck: pass (`npm run typecheck`)
- Targeted tests: 4/4 pass (`npx vitest run` on the two new files)
- Adjacent specs: 84/84 pass across `SuggestedChips.spec.tsx`, `SuggestedChips.readinessGate.spec.tsx`, `SuggestedChips.aiPanelV2Polish.spec.tsx`, `mapV5Blocks.test.ts`, `parser.phase3-blocks-tolerance.spec.ts`
- Pre-existing failure (NOT introduced here): `dispatchAction.spec.ts` fails to load due to a Supabase env import — same failure on the staging baseline without these changes
- Pre-push gate: all checks passed (459 smoke tests, lint, dep audit, stale-.js check, vendored-tarball SHA)

## Test plan

- [ ] CI full suite passes on this branch
- [ ] Manual sanity on staging: nothing user-visible changed — coaching blocks still render, chips still render, click handlers still work
- [ ] Reviewer confirms the live-path finding and signs off on the test-only scope
- [ ] **Do not merge** — review only

🤖 Generated with [Claude Code](https://claude.com/claude-code)