### PR TITLE
layout: first-load panel subtraction + raise NODE_LAYOUT_MIN_W globally to 200

### DIFF
--- a/src/canvas/__tests__/applyDraftResult.v5FreshDraft.regression.spec.ts
+++ b/src/canvas/__tests__/applyDraftResult.v5FreshDraft.regression.spec.ts
@@ -4,9 +4,17 @@
  * The class of bug this guards against (2026-05-13 P0):
  *   1. V5 response carries an inline draft_graph with N nodes.
  *   2. `applyDraftResult` writes every node at position `{0,0}` and calls
- *      `setPendingLayout(true)`.
+ *      `setPendingLayout(true, { isFirstLoad: true })`. The second arg
+ *      signals layoutGraph to subtract ANALYSIS_PANEL_WIDTH from the
+ *      canvas on this first auto-arrange so the freshly laid-out graph
+ *      fits the visible area with the dock open. Keep this assertion in
+ *      sync with applyDraftResult's layout signal — both the source call
+ *      shape in `src/canvas/utils/applyDraftResult.ts` and the direct
+ *      assertion in `src/canvas/utils/__tests__/applyDraftResult.spec.ts`
+ *      must be updated together if the call shape changes again.
  *   3. The measure-then-layout pipeline (or its 500 ms fallback) calls
- *      `applyLayout()`.
+ *      `applyLayout()`, which reads `pendingLayoutIsFirstLoad` from the
+ *      store and threads it through to layoutGraph as `{ isFirstLoad }`.
  *   4. Expected: positions become non-zero; no "Layout failed" banner.
  *
  * Two parallel suites:

--- a/src/canvas/__tests__/layout.semantic.spec.ts
+++ b/src/canvas/__tests__/layout.semantic.spec.ts
@@ -246,11 +246,18 @@ describe('normaliseTierRows — direct fixture (I.2)', () => {
       } as Node
     })
 
+    // Use a wider canvas so the 5-factor tier fits in max-width branch even
+    // with NODE_LAYOUT_MIN_W=200 (raised from 140). At 200, 5 factors need
+    // unclamped ≥ 224 → availableWidth ≥ 1240 → canvasSize.width ≥ 1459.
+    // 1500 leaves margin. The test's purpose is to verify intra-tier Y
+    // normalisation when ELK introduces Y noise — that requires the tier
+    // to be a single row.
+    const WIDE_CANVAS_5_FACTOR: CanvasSize = { width: 1500, height: 750 }
     const result = await layoutGraph(
       nodesWithHeights,
       fixture.edges as Edge[],
       {},
-      STD_CANVAS,
+      WIDE_CANVAS_5_FACTOR,
     )
 
     const optionYs = result.nodes
@@ -528,9 +535,9 @@ describe('constants contract', () => {
     expect(LAYOUT_BOX_MIN_W).toBe(NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X)
   })
 
-  it('NODE_CARD_MAX_W is 320, NODE_LAYOUT_MIN_W is 140', () => {
+  it('NODE_CARD_MAX_W is 320, NODE_LAYOUT_MIN_W is 200', () => {
     expect(NODE_CARD_MAX_W).toBe(320)
-    expect(NODE_LAYOUT_MIN_W).toBe(140)
+    expect(NODE_LAYOUT_MIN_W).toBe(200)
   })
 
   it('COLLISION_GAP < expected node-node gap', () => {

--- a/src/canvas/__tests__/layout.spec.ts
+++ b/src/canvas/__tests__/layout.spec.ts
@@ -415,10 +415,10 @@ describe('ELK Layout', () => {
     expect(Math.abs(optionCentre - factorCentre)).toBeLessThanOrEqual(1)
   })
 
-  it('nodeW is clamped to NODE_LAYOUT_MIN_W (140) when tier is too wide for canvas', async () => {
+  it('nodeW is clamped to NODE_LAYOUT_MIN_W (200) when tier is too wide for canvas', async () => {
     // 14-node graph: 7 factors in tier 2. On a 936px narrow canvas,
-    // 7 * 140 + 6 * 30 = 1160px > 936 * 0.85 = 795px, so multi-row fires.
-    // layoutNodeWidth must equal 140.
+    // 7 * 200 + 6 * 30 = 1580px > 936 * 0.85 = 795px, so multi-row fires.
+    // layoutNodeWidth must equal 200.
     const nodes: Node[] = [
       makeNode('d', 'decision'),
       makeNode('o1', 'option'), makeNode('o2', 'option'), makeNode('o3', 'option'),
@@ -493,6 +493,151 @@ describe('ELK Layout', () => {
     expect(dY).toBeLessThan(o1Y)
     expect(o1Y).toBeLessThan(f1Y)
     expect(f1Y).toBeLessThan(gY)
+  })
+
+  // ---------------------------------------------------------------------------
+  // First-load panel subtraction (isFirstLoad option)
+  //
+  // layoutGraph accepts an optional `isFirstLoad: true` flag that subtracts
+  // ANALYSIS_PANEL_WIDTH (416) from canvasSize.width before computing
+  // availableWidth. The flag is opt-in: callers that omit it (or pass false)
+  // get the panel-agnostic behaviour used for all manual auto-arranges.
+  //
+  // Asserting BOTH `layoutNodeWidth` (which branch fired) AND `factorRowCount`
+  // (actual row splitting) to lock the distinction: the min-width branch
+  // lowers per-box elkBoxW AND sets a nodesPerRow ceiling; actual tier-row
+  // splitting only happens when tierSize > nodesPerRow. At 1440 + isFirstLoad
+  // for a 4-node tier this means a true 2+2 split, not a single overflowing
+  // row.
+  // ---------------------------------------------------------------------------
+
+  function factorRowCount(nodes: Node[]): number {
+    return new Set(
+      nodes.filter(n => n.type === 'factor').map(n => Math.round(n.position.y)),
+    ).size
+  }
+
+  /**
+   * Distribution of factor nodes per Y-row, sorted by Y ascending. Locks the
+   * balanced-split contract from applyTierRowSplitting — e.g. 4 nodes at
+   * nodesPerRow=3 should produce [2, 2] (balanced), not [3, 1] (greedy).
+   */
+  function factorRowDistribution(nodes: Node[]): number[] {
+    const buckets = new Map<number, number>()
+    for (const n of nodes) {
+      if (n.type !== 'factor') continue
+      const y = Math.round(n.position.y)
+      buckets.set(y, (buckets.get(y) ?? 0) + 1)
+    }
+    return Array.from(buckets.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([, count]) => count)
+  }
+
+  it('first-load: 4-factor tier @ 1440px with isFirstLoad=true → min-width branch + splits into 2 rows', async () => {
+    // effectiveCanvasWidth = max(224, 1440 - 416) = 1024
+    // availableWidth      = 1024 * 0.85 = 870
+    // unclamped per-box   = floor((870 - 3*30) / 4) = 195 < 224 (= MIN_W + PAD_X)
+    //   → min-width branch fires (elkBoxW = 224)
+    // nodesPerRow         = floor((870 + 60) / (224 + 60)) = 3
+    //   → tier size 4 > 3 → applyTierRowSplitting splits 2+2
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+    ]
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(
+      nodes,
+      edges,
+      { isFirstLoad: true },
+      { width: 1440, height: 900 },
+    )
+    expect(layoutNodeWidth).toBe(NODE_LAYOUT_MIN_W)
+    expect(factorRowCount(laid)).toBe(2)
+    // Balanced 2+2 split: 4 nodes at nodesPerRow=3
+    //   → rowCount = ceil(4/3) = 2, base = floor(4/2) = 2, remainder = 0
+    //   → rows = [2, 2]
+    expect(factorRowDistribution(laid)).toEqual([2, 2])
+  })
+
+  it('first-load: 4-factor tier @ 1440px with isFirstLoad=false → full canvas, max-width branch, single row', async () => {
+    // availableWidth    = 1440 * 0.85 = 1224
+    // unclamped per-box = floor((1224 - 90) / 4) = 283 ≥ 224
+    //   → max-width branch fires (elkBoxW = NODE_CARD_MAX_W + LAYOUT_PADDING_X)
+    // 4 nodes single row at NODE_CARD_MAX_W, no splitting.
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+    ]
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(
+      nodes,
+      edges,
+      { isFirstLoad: false },
+      { width: 1440, height: 900 },
+    )
+    expect(layoutNodeWidth).toBe(NODE_CARD_MAX_W)
+    expect(factorRowCount(laid)).toBe(1)
+  })
+
+  it('global-threshold-shift: 5-factor tier @ 1300px, no isFirstLoad → now min-width branch + splits (was max-width pre NODE_LAYOUT_MIN_W=200)', async () => {
+    // Locks the GLOBAL behaviour change introduced by raising NODE_LAYOUT_MIN_W
+    // from 140 to 200. The threshold check is `unclamped ≥ NODE_LAYOUT_MIN_W +
+    // LAYOUT_PADDING_X`, which jumped from 164 to 224.
+    //
+    // 5-factor tier @ 1300px canvas (no first-load):
+    //   availableWidth      = 1300 * 0.85 = 1105
+    //   unclamped per-box   = floor((1105 - 4*30) / 5) = floor(985/5) = 197
+    //   Pre-200: 197 ≥ 164 → max-width branch, single row at NODE_CARD_MAX_W
+    //   Post-200: 197 < 224 → min-width branch fires
+    //   nodesPerRow = floor((1105 + 60) / (224 + 60)) = floor(1165/284) = 4
+    //   tier size 5 > 4 → applyTierRowSplitting splits 3+2
+    //
+    // This test exists to make the global threshold shift explicit. A
+    // non-first-load 5-factor tier at typical viewport now produces 200px
+    // multi-row instead of 320px single-row. Intended outcome of the brief
+    // (compressed cards stay readable at 200 instead of 140) — but it
+    // affects every layout path, not just first-load. The brief's risk-tier
+    // A "two constants + first-load gate" framing under-stated this; this
+    // test makes future agents see it.
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'),
+      makeNode('f3', 'factor'), makeNode('f4', 'factor'), makeNode('f5', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
+      makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
+      makeEdge('e6', 'o1', 'f5'),
+    ]
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(
+      nodes,
+      edges,
+      {},
+      TEST_CANVAS,
+    )
+    expect(layoutNodeWidth).toBe(NODE_LAYOUT_MIN_W) // 200, was 320 pre-change
+    expect(factorRowCount(laid)).toBe(2)            // 2 distinct Y-rows
+    // Exact balanced distribution: 5 nodes / 2 rows = base 2 + remainder 1
+    //   → rowCount = ceil(5/4) = 2, base = floor(5/2) = 2, remainder = 5%2 = 1
+    //   → rows = [base+1, base] = [3, 2]
+    // Locks the balanced-split contract in applyTierRowSplitting — a future
+    // change to greedy (5,0) or unbalanced (4,1) would surface here.
+    expect(factorRowDistribution(laid)).toEqual([3, 2])
   })
 })
 

--- a/src/canvas/__tests__/useInitialLayoutGuard.spec.tsx
+++ b/src/canvas/__tests__/useInitialLayoutGuard.spec.tsx
@@ -60,10 +60,13 @@ describe('useInitialLayoutGuard', () => {
     seed({ nodes: stackedNodes(['a', 'b', 'c']), currentScenarioId: 'scA' })
     const { rerender } = renderHook(() => useInitialLayoutGuard())
     expect(setPendingLayoutSpy).toHaveBeenCalledTimes(1)
-    expect(setPendingLayoutSpy).toHaveBeenCalledWith(true)
+    // useInitialLayoutGuard now signals first-load so layoutGraph can subtract
+    // the analysis panel width before computing availableWidth.
+    expect(setPendingLayoutSpy).toHaveBeenCalledWith(true, { isFirstLoad: true })
     // Spy calls through to the real store action — verify the resulting
     // transition actually occurred.
     expect(useCanvasStore.getState().pendingLayout).toBe(true)
+    expect(useCanvasStore.getState().pendingLayoutIsFirstLoad).toBe(true)
     expect(useCanvasStore.getState().layoutRequestId).toBe(requestIdBefore + 1)
     // Re-render without state change — must not re-fire.
     rerender()

--- a/src/canvas/hooks/useInitialLayoutGuard.ts
+++ b/src/canvas/hooks/useInitialLayoutGuard.ts
@@ -38,8 +38,13 @@ import { getGraphIdentityKey, graphNeedsInitialLayout } from '../utils/graphNeed
  *   - Identity key includes a structural hash of node + edge ids, so a
  *     scenario whose graph structure changes is re-evaluated even if its
  *     scenario id is unchanged.
- *   - Never calls `applyLayout` directly — only `setPendingLayout(true)`.
- *     The existing measurement pipeline owns the actual layout run.
+ *   - Never calls `applyLayout` directly — only
+ *     `setPendingLayout(true, { isFirstLoad: true })`. The existing
+ *     measurement pipeline owns the actual layout run. The
+ *     `isFirstLoad: true` flag is one of the two first-load entry points
+ *     (the other being `applyDraftResult`) that signal layoutGraph to
+ *     subtract ANALYSIS_PANEL_WIDTH from the canvas on this first
+ *     auto-arrange. See LayoutOptions in `src/canvas/utils/layout.ts`.
  */
 export function useInitialLayoutGuard(): void {
   const pendingLayout = useCanvasStore((s) => s.pendingLayout)
@@ -105,7 +110,13 @@ export function useInitialLayoutGuard(): void {
     if (graphNeedsInitialLayout(nodes)) {
       inFlightKeyRef.current = key
       lastObservedLayoutVersionRef.current = layoutVersion
-      setPendingLayout(true)
+      // `isFirstLoad: true` — this guard fires when a persisted/stacked
+      // graph hydrates without going through the normal measurement
+      // pipeline. The analysis panel is open by default and the user
+      // hasn't interacted yet, so layoutGraph subtracts
+      // ANALYSIS_PANEL_WIDTH from the available canvas for this first
+      // auto-arrange.
+      setPendingLayout(true, { isFirstLoad: true })
     }
   }, [
     pendingLayout,

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -479,10 +479,17 @@ interface CanvasState {
   //                      waiting, and applyLayout silently no-ops if the
   //                      stored id has moved on (stale-request guard).
   pendingLayout: boolean
+  // First-load companion flag for pendingLayout. Set to true ONLY by call
+  // sites where the analysis panel is reliably open and the user hasn't yet
+  // had a chance to move it — applyDraftResult (fresh CEE draft) and
+  // useInitialLayoutGuard (stacked persisted graph). Read inside applyLayout
+  // and passed to layoutGraph as `{ isFirstLoad }`. Always cleared together
+  // with `pendingLayout: false` so a subsequent pending layout starts clean.
+  pendingLayoutIsFirstLoad: boolean
   layoutInProgress: boolean
   layoutVersion: number
   layoutRequestId: number
-  setPendingLayout: (value: boolean) => void
+  setPendingLayout: (value: boolean, opts?: { isFirstLoad?: boolean }) => void
   // Track 3: Hydrated thread entries from scenario row (consumed once by useConversation, then cleared)
   _hydratedThread: unknown[] | null
   // Track 3: Hydrated scenario events from scenario row (consumed by Journey tab)
@@ -1304,6 +1311,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   })(),
   // Layout lifecycle (D2 of layout-stabilisation brief)
   pendingLayout: false,
+  pendingLayoutIsFirstLoad: false,
   layoutInProgress: false,
   layoutVersion: 0,
   layoutRequestId: 0,
@@ -2108,6 +2116,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       const layoutOptions = useLayoutStore.getState()
 
       const canvasSize = layoutOptions.canvasSize ?? undefined
+      // Read isFirstLoad from store state — applyDraftResult /
+      // useInitialLayoutGuard set it via setPendingLayout(true, { isFirstLoad:
+      // true }). All other call sites leave it false. Snapshot it here at the
+      // moment of dispatch; it is cleared together with pendingLayout below.
+      const isFirstLoad = get().pendingLayoutIsFirstLoad
       const { nodes: layoutedNodes, layoutNodeWidth } = await layoutGraph(
         nodes,
         edges,
@@ -2116,6 +2129,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
           spacing: layoutOptions.nodeSpacing,
           layerSpacing: layoutOptions.layerSpacing,
           preserveLocked: layoutOptions.respectLocked,
+          isFirstLoad,
         },
         canvasSize
       )
@@ -2139,6 +2153,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         nodes: layoutedNodes,
         layoutVersion: get().layoutVersion + 1,
         pendingLayout: false,
+        pendingLayoutIsFirstLoad: false,
       })
     } catch (err) {
       console.error('[CANVAS] Layout failed:', err)
@@ -2148,7 +2163,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // newer request superseded us, leave pendingLayout=true so the
       // newer request runs.
       if (isCurrentGen()) {
-        set({ pendingLayout: false })
+        set({ pendingLayout: false, pendingLayoutIsFirstLoad: false })
       }
       // Rethrow so callers can provide user-facing error feedback
       throw err
@@ -3788,11 +3803,18 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   // true also bumps layoutRequestId so the measurement hook in
   // ReactFlowGraph can detect a second draft arriving before the first has
   // settled and supersede it (stale-request guard).
-  setPendingLayout: (value: boolean) => {
+  setPendingLayout: (value: boolean, opts?: { isFirstLoad?: boolean }) => {
     if (value) {
-      set({ pendingLayout: true, layoutRequestId: get().layoutRequestId + 1 })
+      // opts.isFirstLoad is opt-in. Only the first-load entry points
+      // (applyDraftResult, useInitialLayoutGuard) pass `{ isFirstLoad: true }`;
+      // every other caller omits opts and the flag stays false.
+      set({
+        pendingLayout: true,
+        pendingLayoutIsFirstLoad: opts?.isFirstLoad === true,
+        layoutRequestId: get().layoutRequestId + 1,
+      })
     } else {
-      set({ pendingLayout: false })
+      set({ pendingLayout: false, pendingLayoutIsFirstLoad: false })
     }
   },
 

--- a/src/canvas/utils/__tests__/applyDraftResult.spec.ts
+++ b/src/canvas/utils/__tests__/applyDraftResult.spec.ts
@@ -790,7 +790,7 @@ describe('applyDraftResult — measurement-aware layout deferral (D2)', () => {
     storeEdges = []
   })
 
-  it('flips setPendingLayout(true) instead of calling applyLayout directly', () => {
+  it('flips setPendingLayout(true, { isFirstLoad: true }) instead of calling applyLayout directly', () => {
     const draftData = {
       nodes: [{ id: 'g1', kind: 'goal', label: 'Revenue' }],
       edges: [],
@@ -798,7 +798,11 @@ describe('applyDraftResult — measurement-aware layout deferral (D2)', () => {
 
     applyDraftResult(draftData)
 
-    expect(mockSetPendingLayout).toHaveBeenCalledWith(true)
+    // applyDraftResult is one of the two first-load entry points (the other
+    // being useInitialLayoutGuard). It passes { isFirstLoad: true } so
+    // layoutGraph subtracts the analysis panel width on the first
+    // auto-arrange. All other layout triggers omit the option.
+    expect(mockSetPendingLayout).toHaveBeenCalledWith(true, { isFirstLoad: true })
     // The auto-trigger path defers layout; ELK runs in ReactFlowGraph's
     // measurement effect once nodes are measured. Failure surfacing for
     // auto-triggered layouts lives at the ReactFlowGraph layer (the

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -149,7 +149,12 @@ export function applyDraftResult(
   // layout-stabilisation brief). The measurement hook in ReactFlowGraph
   // runs applyLayout once every unlocked node has measured.width/height,
   // or after a 500 ms safety fallback.
-  store.setPendingLayout(true)
+  //
+  // `isFirstLoad: true` — this is a fresh graph from a CEE draft. The
+  // analysis panel (OutputsDock) is reliably open and the user has not
+  // had a chance to move it. layoutGraph subtracts ANALYSIS_PANEL_WIDTH
+  // from the available canvas so the first auto-arrange fits visibly.
+  store.setPendingLayout(true, { isFirstLoad: true })
 
   // Immediate autosave for crash resilience
   try {

--- a/src/canvas/utils/layout.ts
+++ b/src/canvas/utils/layout.ts
@@ -12,6 +12,7 @@ import {
   COLLISION_GAP,
   CANVAS_MARGIN,
   TIER_BY_KIND,
+  ANALYSIS_PANEL_WIDTH,
 } from './nodeLayoutConstants'
 
 export interface CanvasSize {
@@ -26,6 +27,18 @@ interface LayoutOptions {
   spacing?: number
   layerSpacing?: number
   preserveLocked?: boolean
+  /**
+   * When `true`, subtract `ANALYSIS_PANEL_WIDTH` from `canvasSize.width`
+   * before computing `availableWidth`. Reflects the first-load state where
+   * the analysis panel (OutputsDock) is reliably open and the user has not
+   * yet had a chance to move or close it. After first load this flag MUST be
+   * left unset (or `false`) so subsequent auto-arranges remain panel-agnostic.
+   *
+   * Set to `true` only at the two first-load entry points:
+   *   - `applyDraftResult` (fresh CEE draft → graph)
+   *   - `useInitialLayoutGuard` (stacked persisted graph → first auto-arrange)
+   */
+  isFirstLoad?: boolean
 }
 
 /**
@@ -53,7 +66,8 @@ export async function layoutGraph(
     direction = 'DOWN',
     spacing = 60,
     layerSpacing,
-    preserveLocked = true
+    preserveLocked = true,
+    isFirstLoad = false,
   } = options
 
   const effectiveNodeSpacing = Math.max(20, spacing)
@@ -85,7 +99,23 @@ export async function layoutGraph(
   }
   const maxTierCount = Math.max(...tierCounts.values())
 
-  const availableWidth = canvasSize.width * 0.85
+  // First-load only: subtract the analysis panel's fixed width before
+  // computing availableWidth so the freshly laid-out graph fits inside the
+  // visible canvas (the panel is open by default and the user hasn't yet had
+  // a chance to move it). After first load, this flag is `false` and the
+  // layout uses the full canvas — auto-arrange ignores any panel because the
+  // user may have moved or closed it.
+  //
+  // The Math.max floor keeps `effectiveCanvasWidth` non-negative on
+  // degenerately narrow viewports (e.g. canvasSize.width ≤ ANALYSIS_PANEL_WIDTH);
+  // it does NOT guarantee that `availableWidth` (= effective × 0.85) stays
+  // above a single ELK box width. Downstream branches (min-width fallback +
+  // nodesPerRow clamped to ≥ 1) handle the resulting narrow availableWidth
+  // gracefully by splitting one-node-per-row.
+  const effectiveCanvasWidth = isFirstLoad
+    ? Math.max(NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X, canvasSize.width - ANALYSIS_PANEL_WIDTH)
+    : canvasSize.width
+  const availableWidth = effectiveCanvasWidth * 0.85
   const isDownLayout = direction === 'DOWN'
 
   let elkBoxW: number

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -14,10 +14,55 @@
  * will have heavy text wrapping. Only reached when the widest tier cannot fit
  * in one row at any wider width and multi-row splitting is preferred.
  */
-export const NODE_LAYOUT_MIN_W = 140
+export const NODE_LAYOUT_MIN_W = 200
 
 /** Maximum rendered card width. Used by BaseNode and as the ELK pinned width. */
 export const NODE_CARD_MAX_W = 320
+
+/**
+ * First-load heuristic for the analysis panel (OutputsDock) width when
+ * expanded. Matches the CSS variable `--dock-right-expanded: 26rem` in
+ * `src/index.css` (26 × 16 = 416px at the default 16px base font).
+ *
+ * Used by `layoutGraph`'s first-load branch only (when called with
+ * `{ isFirstLoad: true }`): subsequent auto-arranges deliberately ignore all
+ * panels because the user may have moved or hidden them.
+ *
+ * --- KNOWN LIMITATIONS (deliberate trade-off, not bugs) ---
+ *
+ * This constant is a SINGLE FIXED VALUE — a heuristic, not a measurement.
+ * It does NOT reflect:
+ *
+ *   1. The dock's persisted closed state. When the user has previously
+ *      closed the dock, OutputsDock renders a 40px rail instead of the
+ *      416px expanded panel. The first-load subtraction over-corrects in
+ *      that case, compressing cards more than necessary.
+ *
+ *   2. User-resized dock width. OutputsDock has a left-edge
+ *      `cursor-col-resize` handle and persists the chosen width to
+ *      `localStorage.panel.results.width` (see OutputsDock.tsx). This
+ *      constant ignores any persisted resize — a user who has dragged
+ *      the dock wider or narrower still gets the 416px subtraction.
+ *
+ *   3. The dock's 12px right offset (`right: 12` in its asideStyle).
+ *      The actual horizontal space the dock occupies in the viewport is
+ *      `12 + 416 = 428px`, but we subtract only 416. Slight under-correction
+ *      for the open-dock case.
+ *
+ * Resolving any of these requires either DOM querying (rejected in PR #172
+ * because the floating-first v2 Olumi panel has a different selector and a
+ * draggable position) OR reading the persisted dock state from the canvas
+ * store (a larger architectural change — would need a separate brief).
+ *
+ * For now, this heuristic is acceptable because:
+ *   - On a fresh CEE draft (applyDraftResult), the dock is typically open
+ *     by default for first-time users.
+ *   - The over-correction (closed dock) is graceful: cards compress to
+ *     200px instead of 320px, but remain visible (no overflow).
+ *   - The under-correction (12px offset) means the rightmost card may
+ *     visually touch the dock's left edge by 12px — minor.
+ */
+export const ANALYSIS_PANEL_WIDTH = 416
 
 /** Horizontal padding added around the rendered card to form the ELK box. */
 export const LAYOUT_PADDING_X = 24


### PR DESCRIPTION
## Summary

Two coupled changes addressing two distinct auto-arrange issues:

1. **First-load panel overflow.** On a fresh CEE draft or stacked saved graph load, the OutputsDock is typically open (~416px right edge) but `layoutGraph` computed `availableWidth` from full `canvasSize.width`, so the rendered row extended behind the dock. Fix: opt-in `isFirstLoad?: boolean` flag on LayoutOptions that subtracts `ANALYSIS_PANEL_WIDTH` (416) before computing `availableWidth`. Wired ONLY at the two first-load entry points.
2. **Min-width fallback was too narrow at 140px.** Raised `NODE_LAYOUT_MIN_W` to 200 so compressed cards stay readable. **GLOBAL change** — the threshold gate is `unclamped >= NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X`, which jumped from 164 to 224 for every layout path.

## Key behaviour table

| Viewport | isFirstLoad | Effective canvas | Branch | Outcome |
|---|---|---|---|---|
| 1300 | true | 884 | min-width | 2 rows of 2 @ 200px |
| 1440 | true | 1024 | min-width | 2 rows of 2 @ 200px |
| 1920 | true | 1504 | max-width | single row, overflows 1504 by 52 |
| any | false/omit | full canvas | per existing rules | threshold now 224 (was 164); 5-factor tiers at 1300–1440 now fall to min-width @ 200 |

## Where `isFirstLoad: true` is wired

- `src/canvas/utils/applyDraftResult.ts:152` — fresh CEE draft → graph
- `src/canvas/hooks/useInitialLayoutGuard.ts` — stacked persisted graph → first auto-arrange

All other layout call sites (`applyPatch`, `applyClarifierGraph`, manual auto-arrange button, etc.) leave the flag unset and stay panel-agnostic.

## ANALYSIS_PANEL_WIDTH heuristic — known limitations (documented in the constant's JSDoc)

This is a single fixed value, not a measurement. Three deliberate trade-offs:

1. **Persisted-closed dock state ignored.** When the user has closed the dock (40px rail), the first-load subtraction over-corrects. Cards compress to 200px more than strictly needed, but remain visible (graceful).
2. **User-resized dock width ignored.** OutputsDock has a `cursor-col-resize` handle and persists `localStorage.panel.results.width` ([OutputsDock.tsx:1239, 1350, 1415](src/canvas/components/OutputsDock.tsx#L1239)). The constant ignores any persisted resize.
3. **Dock's 12px right offset ignored.** Rightmost card may touch the dock left edge by 12px — minor under-correction.

Resolving requires either DOM querying (rejected in PR #172 because the v2 `FloatingOlumiPanel` has a different selector + draggable position) OR reading persisted dock state from the canvas store (separate brief). The heuristic is acceptable because:
- On fresh CEE drafts, dock is typically open by default
- Over-correction (closed dock) is graceful — cards still visible
- Under-correction (12px offset) is minor

## Files changed (10)

| Path | Change |
|---|---|
| `src/canvas/utils/nodeLayoutConstants.ts` | `NODE_LAYOUT_MIN_W: 140 → 200`; add `ANALYSIS_PANEL_WIDTH = 416` with explicit limitations doc |
| `src/canvas/utils/layout.ts` | Add `isFirstLoad?: boolean` to LayoutOptions; compute `effectiveCanvasWidth` with floor |
| `src/canvas/store.ts` | Add `pendingLayoutIsFirstLoad` field; extend `setPendingLayout` signature; thread through `applyLayout` |
| `src/canvas/utils/applyDraftResult.ts` | Pass `{ isFirstLoad: true }` |
| `src/canvas/hooks/useInitialLayoutGuard.ts` | Pass `{ isFirstLoad: true }` |
| `src/canvas/__tests__/layout.spec.ts` | 140→200 update + 3 new tests (`factorRowCount` + `factorRowDistribution` helpers; balanced-split assertions) |
| `src/canvas/__tests__/layout.semantic.spec.ts` | Constants-contract `toBe(140) → toBe(200)`; widen one test's canvas to 1500px so 5-factor stays single-row |
| `src/canvas/__tests__/useInitialLayoutGuard.spec.tsx` | Updated assertion for new call shape + `pendingLayoutIsFirstLoad` field |
| `src/canvas/utils/__tests__/applyDraftResult.spec.ts` | Updated assertion for new call shape |
| `src/canvas/__tests__/applyDraftResult.v5FreshDraft.regression.spec.ts` | JSDoc refreshed with new call shape and sync-pointer |

## What I want the reviewer to know

- The brief framed this as risk tier A "two constants + first-load gate" but constant #2 (`NODE_LAYOUT_MIN_W`) is **global** — every layout path that hits min-width fallback now renders at 200 instead of 140, AND more layouts trigger the min-width fallback (because the threshold shifted from 164 to 224). The `global-threshold-shift` test locks this explicitly so future agents see the change in code.
- Three balanced-split distribution assertions added (`[2,2]`, `[3,2]`) that lock both branch choice AND row distribution — addresses prior review-round feedback distinguishing "min-width branch fires" from "rows actually split".

## Out of scope

- `NODE_CARD_MAX_W` (stays 320)
- `MIN_GAP`, `LAYOUT_PADDING_X/Y`, `CANVAS_MARGIN`, the 0.85 breathing factor
- ELK config, `applyGlobalTranslation`, `centreRowsOnSpine`
- DOM querying for panel state
- Store-backed dock width (would address heuristic limitations)
- Re-layout on dock open/close/resize

## Test plan

- [x] 11 layout/lifecycle/BaseNode/applyDraftResult specs — **163/163 tests pass** locally
- [x] `npm run typecheck` — 0 errors
- [x] `git diff --check` — clean
- [x] Pre-push fast gate — all 7 checks passed
- [ ] CI Contract Validation
- [ ] CI Staging Tests (known-failing on every recent staging push per the pnpm-migration tracker; local pre-push gate is authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)