### PR TITLE
feat(v5): surface Phase 3 review_card in AI panel after Run analysis

### DIFF
--- a/src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts
+++ b/src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts
@@ -115,22 +115,43 @@ describe('adaptPhase3ReviewCard — mapping defaults', () => {
     })
   })
 
-  it('prefers body over description over summary (matches adaptCEEBlock priority)', () => {
+  it('prefers description over body over summary (matches adaptCEEBlock priority)', () => {
+    // Wrapped-path order in adaptCEEBlock is `description ?? body`. The Phase 3
+    // adapter mirrors that, with `summary` consulted only when both are absent
+    // (the v1.3 Phase 3 emit shape uses `summary`, not `body`/`description`).
     const block = adaptPhase3ReviewCard({
       title: 'T',
       body: 'B',
       description: 'D',
       summary: 'S',
     })
-    expect(block?.body).toBe('B')
+    expect(block?.body).toBe('D')
     const block2 = adaptPhase3ReviewCard({
       title: 'T',
-      description: 'D',
+      body: 'B',
       summary: 'S',
     })
-    expect(block2?.body).toBe('D')
+    expect(block2?.body).toBe('B')
     const block3 = adaptPhase3ReviewCard({ title: 'T', summary: 'S' })
     expect(block3?.body).toBe('S')
+  })
+
+  it('parity with adaptCEEBlock: body resolves the same way when both description and body are present', () => {
+    // Lock in the same observable behaviour as the wrapped path, end-to-end:
+    // a CEE block carrying both `description` and `body` must resolve to
+    // `description` in both adapters.
+    const wrapped = adaptCEEBlock({
+      block_type: 'review_card',
+      block_id: 'rc-parity',
+      data: { title: 'T', description: 'D', body: 'B' },
+    })
+    const bridged = adaptPhase3ReviewCard({
+      title: 'T',
+      description: 'D',
+      body: 'B',
+    })
+    expect(wrapped).toMatchObject({ type: 'review_card', title: 'T', body: 'D' })
+    expect(bridged).toMatchObject({ type: 'review_card', title: 'T', body: 'D' })
   })
 
   it('defaults variant to info when no tone or variant emitted', () => {

--- a/src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts
+++ b/src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts
@@ -1,0 +1,427 @@
+/**
+ * Phase 3 review_card bridge — DGAI V5 surfacing audit follow-up.
+ *
+ * The bridge appends CEE-produced Phase 3 review_card content to the assistant
+ * turn's `blocks[]` after Run analysis, so the existing ReviewCardBlockRenderer
+ * surfaces it in the AI panel. No new renderer, no schema/parser change.
+ *
+ * Tests below cover the 11 requirements from the brief:
+ *
+ *   1. review_card appended on current run_analysis turn with Phase 3 rawBlocks.
+ *   2. review_card NOT appended on non-run-analysis / stale / unrelated turns.
+ *   3. v5_analysis_result remains before review_card.
+ *   4. evidence blocks not inserted.
+ *   5. coaching blocks not inserted.
+ *   6. prompt chips without action_type unchanged — see existing
+ *      ChatThread.chipGroup.spec.tsx / SuggestedChips.spec.tsx; the bridge
+ *      does not touch action chips. Spot-check via mappedBlocks/chips
+ *      separation here (composePhase3BridgedBlocks does not see chips).
+ *   7. executable chips unchanged — same.
+ *   8. mapV5Blocks does not emit review_card directly (regression guard).
+ *   9. duplicate review_card not inserted when one already exists in mappedBlocks.
+ *  10. cap respected: only top 1 review_card.
+ *  11. review_card mapping defaults match existing adaptCEEBlock wrapped-block
+ *      defaults (summary→body, variant defaults to info, tone→variant mapping).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  adaptPhase3ReviewCard,
+  selectTopPhase3ReviewCard,
+  composePhase3BridgedBlocks,
+  adaptCEEBlock,
+} from '../useConversation'
+import type { ConversationBlock } from '../types'
+import type { Phase3RawBlock } from '../../../v5/extractPhase3FromV5Response'
+import { mapV5Blocks } from '../../../v5/blocks/mapV5Blocks'
+
+// ─── Test fixtures ──────────────────────────────────────────────────────
+
+function makeReviewCardRaw(overrides: Record<string, unknown> = {}): Phase3RawBlock {
+  return {
+    type: 'review_card',
+    id: 'rc-1',
+    source: 'sidecar_blocks_array',
+    raw: {
+      type: 'review_card',
+      block_id: 'rc-narrative-1',
+      signal_id: 'review:narrative:opt-a',
+      created_at: '2026-05-18T10:00:00.000+01:00',
+      source_handler: 'decision_review',
+      graph_hash_at_generation: 'graph-h-1',
+      freshness: 'fresh',
+      card_kind: 'narrative',
+      title: 'Decision review',
+      summary: 'Robust under the modelled uncertainty.',
+      target_refs: [{ type: 'option', id: 'opt-a' }],
+      ...overrides,
+    },
+  }
+}
+
+function makeEvidenceRaw(): Phase3RawBlock {
+  return {
+    type: 'evidence',
+    id: 'ev-1',
+    source: 'sidecar_blocks_array',
+    raw: {
+      type: 'evidence',
+      block_id: 'ev-1',
+      signal_id: 'ev:1',
+      factor_ref: 'node-A',
+      target_refs: [{ type: 'node', id: 'node-A' }],
+    },
+  }
+}
+
+function makeCoachingRaw(): Phase3RawBlock {
+  return {
+    type: 'coaching',
+    id: 'coach-1',
+    source: 'sidecar_blocks_array',
+    raw: {
+      type: 'coaching',
+      block_id: 'coach-1',
+      signal_id: 'coaching:strengthen:node-A',
+      action_intent: 'gather_evidence',
+      priority_rank: 1,
+      coaching_kind: 'strengthen',
+      title: 'Strengthen evidence',
+      target_refs: [{ type: 'node', id: 'node-A', label: 'Factor A' }],
+    },
+  }
+}
+
+const V5_ANALYSIS_RESULT_BLOCK: ConversationBlock = {
+  type: 'v5_analysis_result',
+  summary: 'Option A leads',
+  leading_option_id: 'opt-a',
+  win_probabilities: { 'opt-a': 0.7, 'opt-b': 0.3 },
+}
+
+// ─── (11) Mapping defaults parity with adaptCEEBlock ────────────────────
+
+describe('adaptPhase3ReviewCard — mapping defaults', () => {
+  it('maps title and falls back summary→body when body/description absent', () => {
+    const block = adaptPhase3ReviewCard({
+      title: 'Decision review',
+      summary: 'Robust under the modelled uncertainty.',
+    })
+    expect(block).toEqual({
+      type: 'review_card',
+      title: 'Decision review',
+      body: 'Robust under the modelled uncertainty.',
+      variant: 'info',
+    })
+  })
+
+  it('prefers body over description over summary (matches adaptCEEBlock priority)', () => {
+    const block = adaptPhase3ReviewCard({
+      title: 'T',
+      body: 'B',
+      description: 'D',
+      summary: 'S',
+    })
+    expect(block?.body).toBe('B')
+    const block2 = adaptPhase3ReviewCard({
+      title: 'T',
+      description: 'D',
+      summary: 'S',
+    })
+    expect(block2?.body).toBe('D')
+    const block3 = adaptPhase3ReviewCard({ title: 'T', summary: 'S' })
+    expect(block3?.body).toBe('S')
+  })
+
+  it('defaults variant to info when no tone or variant emitted', () => {
+    const block = adaptPhase3ReviewCard({ title: 'T', summary: 'S' })
+    expect(block?.variant).toBe('info')
+    expect(block?.tone).toBeUndefined()
+  })
+
+  it('maps tone challenger→alert and facilitator→info, passes tone through', () => {
+    const a = adaptPhase3ReviewCard({ title: 'T', summary: 'S', tone: 'challenger' })
+    expect(a?.variant).toBe('alert')
+    expect(a?.tone).toBe('challenger')
+    const f = adaptPhase3ReviewCard({ title: 'T', summary: 'S', tone: 'facilitator' })
+    expect(f?.variant).toBe('info')
+    expect(f?.tone).toBe('facilitator')
+  })
+
+  it('honours explicit variant when tone absent', () => {
+    const alert = adaptPhase3ReviewCard({ title: 'T', summary: 'S', variant: 'alert' })
+    expect(alert?.variant).toBe('alert')
+    const info = adaptPhase3ReviewCard({ title: 'T', summary: 'S', variant: 'info' })
+    expect(info?.variant).toBe('info')
+  })
+
+  it('passes priority through only for the valid four-value union', () => {
+    const high = adaptPhase3ReviewCard({ title: 'T', summary: 'S', priority: 'high' })
+    expect(high?.priority).toBe('high')
+    // unknown priority strings and numeric priority_rank are NOT promoted to
+    // the categorical priority field — no invented mapping.
+    const bogus = adaptPhase3ReviewCard({ title: 'T', summary: 'S', priority: 'p1' })
+    expect(bogus?.priority).toBeUndefined()
+    const numeric = adaptPhase3ReviewCard({ title: 'T', summary: 'S', priority_rank: 1 })
+    expect(numeric?.priority).toBeUndefined()
+  })
+
+  it('refuses to render with empty title (no fabricated copy)', () => {
+    expect(adaptPhase3ReviewCard({ summary: 'body only' })).toBeNull()
+    expect(adaptPhase3ReviewCard({ title: '', summary: 'body only' })).toBeNull()
+    expect(adaptPhase3ReviewCard({ title: '   ', summary: 'body only' })).toBeNull()
+  })
+
+  it('refuses to render with empty body (no fabricated copy)', () => {
+    expect(adaptPhase3ReviewCard({ title: 'T only' })).toBeNull()
+    expect(adaptPhase3ReviewCard({ title: 'T', body: '', description: '', summary: '' })).toBeNull()
+  })
+
+  it('mapping parity: same defaults as adaptCEEBlock wrapped review_card branch', () => {
+    // Existing wrapped-block path (adaptCEEBlock) given equivalent CEE wrapped
+    // shape — must produce the same variant/tone/priority defaults the bridge
+    // does. Body source preference differs only in that wrapped CEE uses
+    // `data.description ?? data.body` (no `summary` fallback), so we test with
+    // a body that matches both code paths.
+    const wrapped = adaptCEEBlock({
+      block_type: 'review_card',
+      block_id: 'rc-1',
+      data: {
+        title: 'Decision review',
+        description: 'Robust under the modelled uncertainty.',
+        tone: 'facilitator',
+        priority: 'high',
+      },
+    })
+    const bridged = adaptPhase3ReviewCard({
+      title: 'Decision review',
+      description: 'Robust under the modelled uncertainty.',
+      tone: 'facilitator',
+      priority: 'high',
+    })
+    expect(bridged).toEqual({
+      type: 'review_card',
+      title: 'Decision review',
+      body: 'Robust under the modelled uncertainty.',
+      variant: 'info',
+      tone: 'facilitator',
+      priority: 'high',
+    })
+    // adaptCEEBlock includes the same fields with identical defaults.
+    expect(wrapped).toMatchObject({
+      type: 'review_card',
+      title: 'Decision review',
+      body: 'Robust under the modelled uncertainty.',
+      variant: 'info',
+      tone: 'facilitator',
+      priority: 'high',
+    })
+  })
+})
+
+// ─── (10) Selector: top 1 by priority_rank, tie-broken by harvest order ─
+
+describe('selectTopPhase3ReviewCard — cap and ranking', () => {
+  it('returns null when no review_card present', () => {
+    expect(selectTopPhase3ReviewCard([])).toBeNull()
+    expect(selectTopPhase3ReviewCard([makeEvidenceRaw(), makeCoachingRaw()])).toBeNull()
+  })
+
+  it('returns the single review_card when only one present', () => {
+    const rc = makeReviewCardRaw()
+    expect(selectTopPhase3ReviewCard([rc])).toBe(rc)
+  })
+
+  it('returns the lowest priority_rank when multiple present (ascending = higher priority)', () => {
+    const r3 = makeReviewCardRaw({ block_id: 'r3', priority_rank: 3, title: 'T3' })
+    const r1 = makeReviewCardRaw({ block_id: 'r1', priority_rank: 1, title: 'T1' })
+    const r2 = makeReviewCardRaw({ block_id: 'r2', priority_rank: 2, title: 'T2' })
+    const picked = selectTopPhase3ReviewCard([r3, r1, r2])
+    expect((picked?.raw as { block_id: string }).block_id).toBe('r1')
+  })
+
+  it('falls back to harvest order when priority_rank is missing on all candidates', () => {
+    const first = makeReviewCardRaw({ block_id: 'first', title: 'first' })
+    const second = makeReviewCardRaw({ block_id: 'second', title: 'second' })
+    delete (first.raw as Record<string, unknown>).priority_rank
+    delete (second.raw as Record<string, unknown>).priority_rank
+    expect((selectTopPhase3ReviewCard([first, second])!.raw as { block_id: string }).block_id).toBe('first')
+  })
+
+  it('treats ranked candidates as outranking unranked ones', () => {
+    const unranked = makeReviewCardRaw({ block_id: 'unranked', title: 'unranked' })
+    delete (unranked.raw as Record<string, unknown>).priority_rank
+    const ranked = makeReviewCardRaw({ block_id: 'ranked', priority_rank: 5, title: 'ranked' })
+    const picked = selectTopPhase3ReviewCard([unranked, ranked])
+    expect((picked?.raw as { block_id: string }).block_id).toBe('ranked')
+  })
+})
+
+// ─── Composition: gating, ordering, dedupe, exclusion ───────────────────
+
+describe('composePhase3BridgedBlocks — gating', () => {
+  it('(1) appends review_card when factPresent is true', () => {
+    const rc = makeReviewCardRaw()
+    const result = composePhase3BridgedBlocks(true, [rc], [V5_ANALYSIS_RESULT_BLOCK])
+    expect(result).toHaveLength(2)
+    expect(result[1].type).toBe('review_card')
+  })
+
+  it('(2a) does NOT append review_card when factPresent is false (conversational/follow-up turn)', () => {
+    const rc = makeReviewCardRaw()
+    const result = composePhase3BridgedBlocks(false, [rc], [V5_ANALYSIS_RESULT_BLOCK])
+    expect(result).toEqual([V5_ANALYSIS_RESULT_BLOCK])
+    expect(result.some((b) => b.type === 'review_card')).toBe(false)
+  })
+
+  it('(2b) does NOT append when no review_card rawBlocks are present', () => {
+    const result = composePhase3BridgedBlocks(
+      true,
+      [makeEvidenceRaw(), makeCoachingRaw()],
+      [V5_ANALYSIS_RESULT_BLOCK],
+    )
+    expect(result).toEqual([V5_ANALYSIS_RESULT_BLOCK])
+  })
+
+  it('(2c) does NOT append when the only review_card is unusable (missing title or body)', () => {
+    const empty: Phase3RawBlock = {
+      type: 'review_card',
+      id: 'rc-empty',
+      source: 'sidecar_blocks_array',
+      raw: { type: 'review_card', summary: 'body only, no title' },
+    }
+    const result = composePhase3BridgedBlocks(true, [empty], [V5_ANALYSIS_RESULT_BLOCK])
+    expect(result).toEqual([V5_ANALYSIS_RESULT_BLOCK])
+  })
+})
+
+describe('composePhase3BridgedBlocks — ordering', () => {
+  it('(3) preserves v5_analysis_result first, then review_card after V5-mapped blocks', () => {
+    const rc = makeReviewCardRaw({ title: 'Review', summary: 'Body' })
+    const explanationBlock: ConversationBlock = {
+      type: 'v5_explanation',
+      narrative: 'Because…',
+      referenced_option_ids: ['opt-a'],
+    }
+    const result = composePhase3BridgedBlocks(
+      true,
+      [rc],
+      [V5_ANALYSIS_RESULT_BLOCK, explanationBlock],
+    )
+    expect(result.map((b) => b.type)).toEqual([
+      'v5_analysis_result',
+      'v5_explanation',
+      'review_card',
+    ])
+  })
+})
+
+describe('composePhase3BridgedBlocks — exclusions', () => {
+  it('(4) does not insert evidence blocks even when factPresent and rawBlocks contain evidence', () => {
+    const result = composePhase3BridgedBlocks(true, [makeEvidenceRaw()], [V5_ANALYSIS_RESULT_BLOCK])
+    expect(result.some((b) => b.type === 'evidence')).toBe(false)
+  })
+
+  it('(5) does not insert coaching blocks (no InlineBlocks renderer)', () => {
+    const result = composePhase3BridgedBlocks(true, [makeCoachingRaw()], [V5_ANALYSIS_RESULT_BLOCK])
+    expect(result.some((b) => (b as { type: string }).type === 'coaching')).toBe(false)
+  })
+
+  it('(4,5) when mixed Phase 3 rawBlocks arrive, only the top review_card is surfaced', () => {
+    const rc = makeReviewCardRaw({ priority_rank: 1 })
+    const result = composePhase3BridgedBlocks(
+      true,
+      [makeEvidenceRaw(), makeCoachingRaw(), rc],
+      [V5_ANALYSIS_RESULT_BLOCK],
+    )
+    expect(result.map((b) => b.type)).toEqual(['v5_analysis_result', 'review_card'])
+  })
+})
+
+describe('composePhase3BridgedBlocks — dedupe and cap', () => {
+  it('(9) does not insert a duplicate when mappedBlocks already carries a review_card', () => {
+    const existing: ConversationBlock = {
+      type: 'review_card',
+      title: 'Existing',
+      body: 'Existing body',
+      variant: 'info',
+    }
+    const rc = makeReviewCardRaw()
+    const result = composePhase3BridgedBlocks(true, [rc], [V5_ANALYSIS_RESULT_BLOCK, existing])
+    expect(result.filter((b) => b.type === 'review_card')).toHaveLength(1)
+    // The pre-existing review_card is preserved; the Phase 3 candidate is dropped.
+    expect((result.find((b) => b.type === 'review_card') as { title: string }).title).toBe('Existing')
+  })
+
+  it('(10) cap respected: at most one Phase 3 review_card is inserted, even when many present', () => {
+    const r1 = makeReviewCardRaw({ block_id: 'r1', priority_rank: 1, title: 'T1' })
+    const r2 = makeReviewCardRaw({ block_id: 'r2', priority_rank: 2, title: 'T2' })
+    const r3 = makeReviewCardRaw({ block_id: 'r3', priority_rank: 3, title: 'T3' })
+    const result = composePhase3BridgedBlocks(true, [r1, r2, r3], [V5_ANALYSIS_RESULT_BLOCK])
+    const inserted = result.filter((b) => b.type === 'review_card')
+    expect(inserted).toHaveLength(1)
+    expect((inserted[0] as { title: string }).title).toBe('T1')
+  })
+})
+
+// ─── (8) Regression: mapV5Blocks does not emit review_card itself ────────
+
+describe('mapV5Blocks — regression guard', () => {
+  it('does not emit review_card from any V5-schema-strict block type', () => {
+    // OlumiResponseSchema rejects Phase 3 blocks at the parser boundary, so
+    // mapV5Blocks never sees them — only the schema-strict block types.
+    // Construct one of each strict block type and confirm none produce a
+    // review_card.
+    const v5Blocks = [
+      { type: 'text', content: 'hello' },
+      {
+        type: 'analysis_result',
+        summary: 'Option A leads',
+        leading_option_id: 'opt-a',
+        win_probabilities: { 'opt-a': 0.7, 'opt-b': 0.3 },
+      },
+      {
+        type: 'graph_patch',
+        status: 'proposed',
+        operation: 'add_node',
+        target_id: 'n1',
+        before: null,
+        after: { id: 'n1', label: 'Factor 1' },
+      },
+      {
+        type: 'explanation',
+        narrative: 'Because…',
+        referenced_option_ids: ['opt-a'],
+      },
+      {
+        type: 'comparison',
+        options: [{ label: 'A' }, { label: 'B' }],
+      },
+      {
+        type: 'flip_analysis',
+        narrative: 'If X then Y',
+        flip_scenarios: [],
+      },
+    ] as Parameters<typeof mapV5Blocks>[0]
+
+    const mapped = mapV5Blocks(v5Blocks)
+    expect(mapped.some((b) => b.type === 'review_card')).toBe(false)
+  })
+})
+
+// ─── (6,7) Chips unchanged note ─────────────────────────────────────────
+
+describe('chips unchanged by bridge', () => {
+  it('(6,7) bridge composition does not see suggested_actions / actionChips', () => {
+    // The bridge function only composes `blocks`. The V5 turn-rendering site
+    // still computes `actionChips` from `target.response.suggested_actions`
+    // separately and passes them to addMessage unchanged. This test fixes
+    // the contract by asserting composePhase3BridgedBlocks never touches
+    // chip data (it is not accepted as input).
+    type ComposeArgs = Parameters<typeof composePhase3BridgedBlocks>
+    const args: ComposeArgs = [true, [makeReviewCardRaw()], [V5_ANALYSIS_RESULT_BLOCK]]
+    expect(args).toHaveLength(3) // factPresent, rawBlocks, mappedBlocks — no chips
+    const result = composePhase3BridgedBlocks(...args)
+    expect(result).toHaveLength(2)
+  })
+})

--- a/src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts
+++ b/src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts
@@ -154,6 +154,34 @@ describe('adaptPhase3ReviewCard — mapping defaults', () => {
     expect(bridged).toMatchObject({ type: 'review_card', title: 'T', body: 'D' })
   })
 
+  it('nullish precedence: empty-string description does NOT fall through to body or summary', () => {
+    // adaptCEEBlock uses `dataObj.description ?? dataObj.body ?? ''`, which
+    // only falls through on null/undefined. An empty-string `description` is
+    // SELECTED (and produces an empty body string in the wrapped path).
+    // The bridge mirrors that selection and then refuses to render an empty
+    // card — strict parity on which field is selected, no silent fallthrough
+    // to body/summary content the wrapped path would have suppressed.
+    expect(
+      adaptPhase3ReviewCard({ title: 'T', description: '', body: 'B' }),
+    ).toBeNull()
+    expect(
+      adaptPhase3ReviewCard({ title: 'T', description: '', summary: 'S' }),
+    ).toBeNull()
+    expect(
+      adaptPhase3ReviewCard({ title: 'T', description: '', body: 'B', summary: 'S' }),
+    ).toBeNull()
+    // Sanity check: when description is undefined (not present), body IS
+    // selected — that's the wrapped-path's nullish fallthrough behaviour.
+    expect(
+      adaptPhase3ReviewCard({ title: 'T', body: 'B' }),
+    ).toMatchObject({ body: 'B' })
+    // Empty-string body with a later summary likewise refuses, because
+    // body is selected (empty) before summary can be considered.
+    expect(
+      adaptPhase3ReviewCard({ title: 'T', body: '', summary: 'S' }),
+    ).toBeNull()
+  })
+
   it('defaults variant to info when no tone or variant emitted', () => {
     const block = adaptPhase3ReviewCard({ title: 'T', summary: 'S' })
     expect(block?.variant).toBe('info')

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -830,14 +830,17 @@ export function adaptPhase3ReviewCard(
       : ''
   if (!title) return null
 
-  const body =
-    typeof raw.description === 'string' && raw.description.length > 0
-      ? raw.description
-      : typeof raw.body === 'string' && raw.body.length > 0
-        ? raw.body
-        : typeof raw.summary === 'string' && raw.summary.length > 0
-          ? raw.summary
-          : ''
+  // Nullish-coalescing selection — matches the wrapped-block path's
+  // `dataObj.description ?? dataObj.body ?? ''` precedence (only falls
+  // through on null/undefined, NOT on empty string). The bridge then
+  // refuses the card when the selected field is empty, so an empty-string
+  // `description` rejects the card rather than silently surfacing a `body`
+  // or `summary` that the wrapped path would have suppressed.
+  const descriptionField =
+    typeof raw.description === 'string' ? raw.description : undefined
+  const bodyField = typeof raw.body === 'string' ? raw.body : undefined
+  const summaryField = typeof raw.summary === 'string' ? raw.summary : undefined
+  const body = descriptionField ?? bodyField ?? summaryField ?? ''
   if (!body) return null
 
   const tone =

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -807,8 +807,12 @@ function extractRawBlockType(block: unknown): string | null {
  * Mapping mirrors the existing wrapped-block path (`adaptCEEBlock` review_card
  * branch above) so the bridge surfaces no different defaults than CEE wrapped
  * blocks would today:
- *   - title    ← raw.title                                    (required)
- *   - body     ← raw.body ?? raw.description ?? raw.summary   (required)
+ *   - title    ← raw.title                                          (required)
+ *   - body     ← raw.description ?? raw.body ?? raw.summary         (required)
+ *                (description/body order matches adaptCEEBlock at the
+ *                 useConversation review_card branch; `summary` is the
+ *                 v1.3 Phase 3 extension — only consulted when wrapped-path
+ *                 fields are both absent.)
  *   - variant  ← tone='challenger'→'alert', tone='facilitator'→'info';
  *                else raw.variant when 'alert'/'info'; else 'info'
  *   - tone     ← passthrough when 'challenger'/'facilitator'
@@ -827,10 +831,10 @@ export function adaptPhase3ReviewCard(
   if (!title) return null
 
   const body =
-    typeof raw.body === 'string' && raw.body.length > 0
-      ? raw.body
-      : typeof raw.description === 'string' && raw.description.length > 0
-        ? raw.description
+    typeof raw.description === 'string' && raw.description.length > 0
+      ? raw.description
+      : typeof raw.body === 'string' && raw.body.length > 0
+        ? raw.body
         : typeof raw.summary === 'string' && raw.summary.length > 0
           ? raw.summary
           : ''
@@ -911,7 +915,11 @@ export function selectTopPhase3ReviewCard(
  *   - At least one rawBlock of type 'review_card' must adapt to a usable
  *     ReviewCardBlock (non-empty title + body).
  *   - No review_card is already present in mappedBlocks (defensive dedupe;
- *     mapV5Blocks does not emit review_card today).
+ *     mapV5Blocks does not emit review_card today, so this branch is
+ *     unreachable in practice. If a future V5 schema change makes
+ *     mapV5Blocks emit a legitimately different review_card alongside a
+ *     Phase 3 candidate, refine this check to dedupe by block_id rather
+ *     than by type so both surfaces remain available.).
  *
  * Cap: 1 review_card (top by priority_rank, ties by harvest order).
  *

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -28,6 +28,7 @@ import { applyV5State } from '../../v5/applyV5State'
 import {
   extractPhase3FromV5Response,
   v5ResponseHasRunAnalysisFact,
+  type Phase3RawBlock,
 } from '../../v5/extractPhase3FromV5Response'
 import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled } from '../../flags'
@@ -63,6 +64,7 @@ import type {
   ProposalReviewItem,
   RelatedElementRef,
   BaseRateChipSet,
+  ReviewCardBlock,
 } from './types'
 import { MAX_CHIPS_PER_TURN, MAX_SUGGESTED_ACTIONS } from './types'
 import { applyAutoApplyPatch, synthesiseCeeAnalysisReady } from './utils/applyPatch'
@@ -795,6 +797,141 @@ function extractRawBlockType(block: unknown): string | null {
   if (typeof obj.block_type === 'string') return obj.block_type
   if (typeof obj.type === 'string') return obj.type
   return null
+}
+
+/**
+ * adaptPhase3ReviewCard — lossless mapper from a verbatim CEE Phase 3
+ * review_card raw payload (see `extractPhase3FromV5Response.rawBlocks[].raw`)
+ * to the UI's typed `ReviewCardBlock` shape.
+ *
+ * Mapping mirrors the existing wrapped-block path (`adaptCEEBlock` review_card
+ * branch above) so the bridge surfaces no different defaults than CEE wrapped
+ * blocks would today:
+ *   - title    ← raw.title                                    (required)
+ *   - body     ← raw.body ?? raw.description ?? raw.summary   (required)
+ *   - variant  ← tone='challenger'→'alert', tone='facilitator'→'info';
+ *                else raw.variant when 'alert'/'info'; else 'info'
+ *   - tone     ← passthrough when 'challenger'/'facilitator'
+ *   - priority ← passthrough when 'critical'/'high'/'medium'/'low'
+ *
+ * Returns null when title or body would be empty — the bridge refuses to
+ * render an empty card. No fallback copy, no semantic rewriting.
+ */
+export function adaptPhase3ReviewCard(
+  raw: Record<string, unknown>,
+): ReviewCardBlock | null {
+  const title =
+    typeof raw.title === 'string' && raw.title.trim().length > 0
+      ? raw.title
+      : ''
+  if (!title) return null
+
+  const body =
+    typeof raw.body === 'string' && raw.body.length > 0
+      ? raw.body
+      : typeof raw.description === 'string' && raw.description.length > 0
+        ? raw.description
+        : typeof raw.summary === 'string' && raw.summary.length > 0
+          ? raw.summary
+          : ''
+  if (!body) return null
+
+  const tone =
+    raw.tone === 'challenger' || raw.tone === 'facilitator'
+      ? (raw.tone as 'challenger' | 'facilitator')
+      : undefined
+  const variantDirect: 'info' | 'alert' | undefined =
+    raw.variant === 'alert' ? 'alert' : raw.variant === 'info' ? 'info' : undefined
+  const variantFromTone: 'info' | 'alert' | undefined =
+    tone === 'challenger' ? 'alert' : tone === 'facilitator' ? 'info' : undefined
+  const variant: 'info' | 'alert' = variantFromTone ?? variantDirect ?? 'info'
+
+  const priority =
+    raw.priority === 'critical' ||
+    raw.priority === 'high' ||
+    raw.priority === 'medium' ||
+    raw.priority === 'low'
+      ? (raw.priority as 'critical' | 'high' | 'medium' | 'low')
+      : undefined
+
+  return {
+    type: 'review_card',
+    title,
+    body,
+    variant,
+    ...(tone ? { tone } : {}),
+    ...(priority ? { priority } : {}),
+  }
+}
+
+/**
+ * selectTopPhase3ReviewCard — pick the highest-priority review_card from
+ * extractPhase3FromV5Response's verbatim rawBlocks list.
+ *
+ * Ranking: CEE v1.3 §0 emits an optional `priority_rank: number` on Phase 3
+ * blocks where lower values mean higher priority. When at least one candidate
+ * carries it, sort ascending by priority_rank; ties and missing values
+ * preserve harvest order. No new ranking is invented.
+ */
+export function selectTopPhase3ReviewCard(
+  rawBlocks: readonly Phase3RawBlock[],
+): Phase3RawBlock | null {
+  const candidates = rawBlocks.filter((b) => b.type === 'review_card')
+  if (candidates.length === 0) return null
+
+  const indexed = candidates.map((b, i) => ({
+    block: b,
+    rank:
+      typeof b.raw.priority_rank === 'number' && Number.isFinite(b.raw.priority_rank)
+        ? (b.raw.priority_rank as number)
+        : Number.POSITIVE_INFINITY,
+    order: i,
+  }))
+  indexed.sort((a, b) => a.rank - b.rank || a.order - b.order)
+  return indexed[0]?.block ?? null
+}
+
+/**
+ * composePhase3BridgedBlocks — pure composition of the Phase 3 review_card
+ * bridge applied at the V5 assistant-turn rendering site.
+ *
+ * Inputs:
+ *   - factPresent: whether the current response carries a successful
+ *     run_analysis fact (computed by v5ResponseHasRunAnalysisFact).
+ *   - phase3RawBlocks: verbatim Phase 3 blocks harvested by
+ *     extractPhase3FromV5Response.
+ *   - mappedBlocks: V5 schema-strict blocks already produced by mapV5Blocks.
+ *
+ * Returns the final ordered blocks array for the assistant turn:
+ *   [...mappedBlocks, ...top-1 review_card when eligible]
+ *
+ * Eligibility:
+ *   - factPresent must be true (gates out conversational follow-ups and stale
+ *     responses).
+ *   - At least one rawBlock of type 'review_card' must adapt to a usable
+ *     ReviewCardBlock (non-empty title + body).
+ *   - No review_card is already present in mappedBlocks (defensive dedupe;
+ *     mapV5Blocks does not emit review_card today).
+ *
+ * Cap: 1 review_card (top by priority_rank, ties by harvest order).
+ *
+ * Evidence and coaching rawBlocks are intentionally NOT surfaced:
+ *   - evidence: v1.3 shape mismatch with EvidenceBlockRenderer (tracked as a
+ *     follow-up issue).
+ *   - coaching: no InlineBlocks renderer; remains in GuidanceStore.
+ */
+export function composePhase3BridgedBlocks(
+  factPresent: boolean,
+  phase3RawBlocks: readonly Phase3RawBlock[],
+  mappedBlocks: readonly ConversationBlock[],
+): ConversationBlock[] {
+  if (!factPresent) return [...mappedBlocks]
+  const topReview = selectTopPhase3ReviewCard(phase3RawBlocks)
+  if (!topReview) return [...mappedBlocks]
+  const adapted = adaptPhase3ReviewCard(topReview.raw)
+  if (!adapted) return [...mappedBlocks]
+  if (mappedBlocks.some((b) => b.type === 'review_card')) return [...mappedBlocks]
+  return [...mappedBlocks, adapted]
 }
 
 export function adaptCEEBlock(raw: unknown): ConversationBlock {
@@ -2879,6 +3016,18 @@ export function useConversation(): UseConversationReturn {
 
             const mappedBlocks =
               target.kind === 'blocks' ? mapV5Blocks(target.response.blocks) : []
+
+            // Phase 3 review_card bridge — surface CEE-produced post-analysis
+            // review_card prose in the AI panel after Run analysis. Reuses the
+            // existing ReviewCardBlockRenderer; no schema / parser / CEE change.
+            // Gating, cap, dedupe, and evidence/coaching exclusion documented
+            // on composePhase3BridgedBlocks above.
+            const finalBlocks = composePhase3BridgedBlocks(
+              factPresent,
+              phase3.rawBlocks,
+              mappedBlocks,
+            )
+
             // V5 suggested_actions → ActionChip. CEE caps count server-side;
             // UI additionally caps rendering per DS v5 §21.4 in SuggestedChips.
             // action_type when present drives deterministic routing on next click.
@@ -2893,7 +3042,7 @@ export function useConversation(): UseConversationReturn {
               id: crypto.randomUUID(),
               role: 'assistant',
               content: target.response.assistant_text,
-              ...(mappedBlocks.length > 0 ? { blocks: mappedBlocks } : {}),
+              ...(finalBlocks.length > 0 ? { blocks: finalBlocks } : {}),
               ...(actionChips.length > 0 ? { actionChips } : {}),
               timestamp: new Date(),
             })


### PR DESCRIPTION
## Summary

- Surfaces CEE-produced Phase 3 `review_card` prose in the AI panel right after the `v5_analysis_result` card, using the **existing** `ReviewCardBlockRenderer` — no new components, no schema/parser/CEE changes.
- One-file production change: a pure composition function in `useConversation.ts` (`composePhase3BridgedBlocks`) plus two small mapper helpers (`adaptPhase3ReviewCard`, `selectTopPhase3ReviewCard`), wired at the V5 turn-rendering site.
- Evidence intentionally deferred (v1.3 shape mismatch with `EvidenceBlockRenderer`) — a follow-up issue is described below.

Status: **draft, for review only. Do not merge or deploy.**

Base branch: **`staging`** (retargeted from `main` 2026-05-21 after a review pointed out the default-base mismatch — diff against staging is the intended 2-file delta).

### Amendment log

| Commit | Subject |
|---|---|
| `d5be590d` | Initial bridge — `composePhase3BridgedBlocks` + helpers + 26 tests |
| `5326ada2` | Risk 3 fix: align body precedence order with `adaptCEEBlock` (now `description ?? body ?? summary`); add parity test → 27 tests |
| `9907cebd` | Reviewer blocker fix: nullish-coalescing semantics so empty-string `description` does NOT fall through to body/summary; refuse the card when selected body is empty → 28 tests |

---

## Phase 0 addendum findings

1. **Live path confirmed:** `OlumiResponse` (with sidecar) → `extractPhase3FromV5Response(target.response)` (already called at `useConversation.ts:2762`) → `phase3.rawBlocks` → **new bridge** → `mappedBlocks` at `useConversation.ts:2880` → `addMessage({ blocks })` → `ChatThread → ChatMessage → InlineBlocks → ReviewCardBlockRenderer` (`InlineBlocks.tsx:204`).
2. **ReviewCardBlockRenderer shape compatibility:** required `title` ← raw `title`; required `body` ← raw `description ?? body ?? summary` (nullish-coalescing, matches the wrapped `adaptCEEBlock` precedence; `summary` is the v1.3 Phase 3 extension consulted only when the wrapped-path fields are both absent); required `variant` ← derived from `tone` (`'challenger'→'alert'`, `'facilitator'→'info'`) else raw `variant` else `'info'`. Optional `tone`, `priority` passed through when present. Empty selected `body` refuses to render — no fallback copy.
3. **Smallest mapping needed:** identical to the existing `adaptCEEBlock` `review_card` branch (`useConversation.ts:920-939`). No semantic rewriting. Empty title or body refuses to render (no fabricated copy).
4. **Gating:** reuses `factPresent` already computed locally at `useConversation.ts:2763` via `v5ResponseHasRunAnalysisFact(target.response, phase3)`. True iff `hasRunAnalysisFact === true`, OR `analysisFreshness === 'fresh'` AND response contains an `analysis_result` block. This excludes conversational follow-up turns and stale responses — does **not** fire on freshness alone.
5. **Evidence deferred:** v1.3 evidence emit shape (`block_id`, `signal_id`, `factor_ref`, `target_refs`) does **not** match `EvidenceBlockRenderer` (`findings: EvidenceFinding[]`, `query: string`). Surfacing would require fabricating `findings`/`query`, which violates the brief's *no invented meaning* rule. Excluded from this PR.

---

## Exact field path wired

`OlumiResponse[__additive__][phase3_blocks_from_blocks_array][]` (verbatim CEE Phase 3 block) → `extractPhase3FromV5Response` → `phase3.rawBlocks[]` (each with `.type`, `.raw`, `.id`, `.source`) → `composePhase3BridgedBlocks(factPresent, phase3.rawBlocks, mappedBlocks)` → `finalBlocks` → `addMessage({ blocks: finalBlocks })` → message.blocks → `ChatMessage` → `InlineBlocks` → `ReviewCardBlockRenderer`.

---

## Why no schema/parser/CEE change was needed

- The parser (`src/v5/responseParser.ts`) already extracts Phase 3 blocks from `blocks[]` per the v1.3 tolerance contract and stashes them verbatim in the sidecar under `PHASE3_SIDECAR_BLOCKS_KEY`.
- `extractPhase3FromV5Response` already harvests them losslessly into `rawBlocks`.
- The existing `ReviewCardBlockRenderer` in `InlineBlocks.tsx` consumes a typed shape that's a small lossless rename away from the CEE Phase 3 emit shape.
- The bridge is therefore purely a UI-layer wire from already-extracted data to an existing renderer. CEE PRs #190 and #191 ship the content; this PR ships its visibility.

---

## Block types surfaced and deliberately excluded

| Phase 3 type | Action in this PR | Reason |
|---|---|---|
| `review_card` | **Surfaced** (top 1 only) | Shape maps to existing renderer with the same defaults as the wrapped-block path |
| `evidence` | **Excluded** | v1.3 shape mismatches `EvidenceBlockRenderer` — see follow-up below |
| `coaching` | **Excluded** | No `InlineBlocks` renderer; remains in `GuidanceStore` (already user-visible via `GuidanceStrip`) |
| `exercise` | **Untouched** | Existing flag-gated path unchanged |

---

## Gating logic

- `factPresent === true` (computed by `v5ResponseHasRunAnalysisFact`) is the single gate.
- Falsy `factPresent` → bridge returns `mappedBlocks` unchanged. Conversational follow-up turns and stale responses do not surface review_card prose.
- A Phase 3 review_card must adapt to a usable `ReviewCardBlock` (non-empty title + body). Empty / malformed candidates are skipped silently — no fallback copy.

## Cap and dedupe behaviour

- **Cap:** top 1 review_card. Ranking by CEE-emitted `priority_rank` ascending (per v1.3 §0). Ties and missing values fall back to harvest order. No new ranking invented.
- **Dedupe:** if `mappedBlocks` already contains a `review_card`, the Phase 3 candidate is dropped. (`mapV5Blocks` does not emit `review_card` today; this is defensive against future schema changes.)

---

## Tests added

`src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts` — 28 focused tests covering all 11 brief requirements (26 at initial open; +1 in `5326ada2` for body-precedence parity; +1 in `9907cebd` for nullish-coalescing empty-`description` rejection):

1. ✅ review_card appended on current run_analysis turn with Phase 3 rawBlocks
2. ✅ NOT appended on non-run-analysis / stale / unrelated turns (factPresent=false; no rawBlocks; unusable candidate)
3. ✅ `v5_analysis_result` remains before review_card (order preserved)
4. ✅ evidence blocks not inserted
5. ✅ coaching blocks not inserted
6. ✅ prompt chips unchanged — bridge does not see `suggested_actions`/`actionChips` (contract test)
7. ✅ executable chips unchanged — same
8. ✅ `mapV5Blocks` does not emit `review_card` (regression guard against all six V5 strict block types)
9. ✅ duplicate review_card not inserted when one already present in mappedBlocks
10. ✅ cap respected: at most one Phase 3 review_card inserted, even with many present
11. ✅ mapping defaults parity with `adaptCEEBlock` wrapped review_card branch (`description ?? body ?? summary` precedence, `variant: 'info'` default, `tone→variant`, `priority` passthrough, empty-string `description` does NOT fall through)

---

## Verification

- ✅ `npm run typecheck` clean on latest head (`9907cebd`).
- ✅ All 28 bridge tests pass on latest head.
- ✅ `--changed` smoke set: 1 pre-existing failure (`useConversation.hook.spec.ts > V5 graph re-fetch on analyse response`) — **verified pre-existing** by stashing the diff and running on the origin/staging baseline; same failure occurs unmodified. Zero net new failures.
- ✅ Pre-push gate passed on every push (initial + both amendments): typecheck + lint changed-files + 459-test smoke suite + stale-.js + dep audit + vendored-schema SHA manifest.

## Manual staging smoke plan (post-merge)

Use a fresh scenario:

1. Draft graph
2. Click **Run analysis**
3. ✅ AI panel shows assistant text + `v5_analysis_result` card
4. ✅ AI panel now also shows CEE-produced `review_card` prose
5. ✅ Evidence block does **not** appear (deferred)
6. ✅ Coaching block does **not** appear
7. ✅ Suggested chips still appear and dispatch correctly
8. ✅ GuidanceStrip does not feel duplicated or noisy alongside the new inline card
9. Capture a screenshot or short clip showing the improved Golden Journey row

**Golden Journey row improved:** *Run analysis → AI panel proactively explains the result.*

---

## Files changed

Diff vs `origin/staging` (latest head `9907cebd`):

- `src/canvas/conversation/useConversation.ts` (+161 / -1) — two helpers (`adaptPhase3ReviewCard`, `selectTopPhase3ReviewCard`), one pure composition function (`composePhase3BridgedBlocks`), and the call-site swap from inline `mappedBlocks` to `finalBlocks`.
- `src/canvas/conversation/__tests__/phase3ReviewCardBridge.spec.ts` (+476) — new focused test file.

Total: **637 insertions, 1 deletion, 2 files changed.**

No other files touched. No CEE, PLoT, ISL, prompt, PMS, schema, parser, package, lockfile, migration, Netlify, Results-panel, GuidanceStrip, or AI-panel-layout change.

---

## Follow-up issue to file

**Title:** Add v1.3 evidence block renderer for AI panel

**Description:** Phase 3 `evidence` rawBlocks use a v1.3 shape (`block_id`, `signal_id`, `factor_ref`, `target_refs`) that does not match the existing `EvidenceBlockRenderer` (which expects `findings: EvidenceFinding[]` and `query: string`). Add a dedicated renderer aligned with the v1.3 emit shape (or confirm a v1.3 evidence field contract with CEE first). Do not block the review_card bridge on this.

## Other deferred follow-ups

- Dedicated `coaching` renderer for `InlineBlocks` (currently lands only in `GuidanceStore`)
- Dedicated `decision_review` card reader (consume `analysis_result.enrichment.decision_review` directly in the Results panel)
- `GuidanceStrip` expansion (show full block prose vs. compressed top signal)
- Results panel `decision_review` reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)
