### PR TITLE
fix(v5): tolerate CEE action_type alias 'explain_results' in parser

### DIFF
--- a/src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts
+++ b/src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * PR #175 bridge — end-to-end wiring against the live CEE staging fixture
+ * (debug bundle b82c89dd).
+ *
+ * Complements `phase3ReviewCardBridge.spec.ts` (unit tests on the composition
+ * function) and `src/v5/__tests__/responseParser.actionTypeAlias.spec.ts`
+ * (parser-side assertions). This spec proves the parse→extract→bridge chain
+ * works end-to-end on the trimmed live fixture.
+ *
+ * Lives in `src/canvas/conversation/__tests__/` rather than in `src/v5/__tests__/`
+ * deliberately. Importing `useConversation.ts` (where the bridge composition
+ * function lives) from within `src/v5/**` would drag the entire conversation
+ * graph into the tsconfig.ci.json typecheck scope (which is intentionally
+ * limited to v5/**), surfacing pre-existing type errors in unrelated files.
+ *
+ * Brief assertions covered here:
+ *   10a. On the real fixture (review_cards with null body), the bridge
+ *        refuses to render — returns mappedBlocks unchanged. No fabricated
+ *        copy. The empty body is a separate CEE-side issue not in scope.
+ *   10b. When CEE emits a usable review_card body (synthetic — the same
+ *        shape CEE will emit upstream once the null-body issue is fixed),
+ *        the bridge appends review_card after v5_analysis_result.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { parseV5Response } from '../../../v5/responseParser'
+import { extractPhase3FromV5Response } from '../../../v5/extractPhase3FromV5Response'
+import { composePhase3BridgedBlocks } from '../useConversation'
+import type { ConversationBlock } from '../types'
+
+const FIXTURE_PATH = resolve(
+  __dirname,
+  '../../../v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json',
+)
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as Record<string, unknown>
+}
+
+function makeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('PR #175 bridge — live fixture (cee-response-b82c89dd)', () => {
+  it('(10a) on the real fixture (review_cards with null body) the bridge refuses to render — returns mappedBlocks unchanged, no fabricated copy', async () => {
+    // The live CEE staging response b82c89dd emitted review_cards with
+    // null summary/body/description. The bridge's "refuse empty body" rule
+    // means no review_card appends — exactly the correct behaviour per the
+    // PR #175 brief's "no fabricated copy" requirement. This test locks
+    // that down so future regressions don't silently start rendering
+    // empty cards.
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const phase3 = extractPhase3FromV5Response(result.response)
+
+    const mappedBlocks: ConversationBlock[] = [
+      {
+        type: 'v5_analysis_result',
+        summary: 'Ran analysis on your current scenario.',
+        leading_option_id: 'opt_tech_lead',
+        win_probabilities: { 'Hire One Tech Lead': 0.94325 },
+      },
+    ]
+    const finalBlocks = composePhase3BridgedBlocks(true, phase3.rawBlocks, mappedBlocks)
+    expect(finalBlocks.map((b) => b.type)).toEqual(['v5_analysis_result'])
+    expect(finalBlocks.some((b) => b.type === 'review_card')).toBe(false)
+  })
+
+  it('(10b) when CEE emits a usable review_card body, the bridge appends after v5_analysis_result', async () => {
+    // Substitute a non-null summary on one rawBlock — the same shape CEE
+    // will emit upstream once the null-body issue is resolved. All other
+    // fields preserved verbatim from the live CEE response.
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const phase3 = extractPhase3FromV5Response(result.response)
+
+    const realReviewCard = phase3.rawBlocks.find((b) => b.type === 'review_card')
+    expect(realReviewCard).toBeDefined()
+    const usableRawBlocks = phase3.rawBlocks.map((b) =>
+      b === realReviewCard
+        ? {
+            ...b,
+            raw: { ...b.raw, summary: 'Hiring a Tech Lead remains robust under the modelled uncertainty.' },
+          }
+        : b,
+    )
+
+    const mappedBlocks: ConversationBlock[] = [
+      {
+        type: 'v5_analysis_result',
+        summary: 'Ran analysis on your current scenario.',
+        leading_option_id: 'opt_tech_lead',
+        win_probabilities: { 'Hire One Tech Lead': 0.94325 },
+      },
+    ]
+    const finalBlocks = composePhase3BridgedBlocks(true, usableRawBlocks, mappedBlocks)
+    expect(finalBlocks.map((b) => b.type)).toEqual([
+      'v5_analysis_result',
+      'review_card',
+    ])
+    const card = finalBlocks[1] as { type: 'review_card'; title: string; body: string }
+    expect(card.title).toBe('A load-bearing assumption')
+    expect(card.body).toBe('Hiring a Tech Lead remains robust under the modelled uncertainty.')
+  })
+})

--- a/src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts
+++ b/src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts
@@ -12,14 +12,6 @@
  * function lives) from within `src/v5/**` would drag the entire conversation
  * graph into the tsconfig.ci.json typecheck scope (which is intentionally
  * limited to v5/**), surfacing pre-existing type errors in unrelated files.
- *
- * Brief assertions covered here:
- *   10a. On the real fixture (review_cards with null body), the bridge
- *        refuses to render — returns mappedBlocks unchanged. No fabricated
- *        copy. The empty body is a separate CEE-side issue not in scope.
- *   10b. When CEE emits a usable review_card body (synthetic — the same
- *        shape CEE will emit upstream once the null-body issue is fixed),
- *        the bridge appends review_card after v5_analysis_result.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -27,7 +19,10 @@ import { resolve } from 'node:path'
 
 import { parseV5Response } from '../../../v5/responseParser'
 import { extractPhase3FromV5Response } from '../../../v5/extractPhase3FromV5Response'
-import { composePhase3BridgedBlocks } from '../useConversation'
+import {
+  composePhase3BridgedBlocks,
+  adaptPhase3ReviewCard,
+} from '../useConversation'
 import type { ConversationBlock } from '../types'
 
 const FIXTURE_PATH = resolve(
@@ -46,65 +41,79 @@ function makeResponse(body: unknown, status = 200): Response {
   })
 }
 
+const V5_ANALYSIS_RESULT_BLOCK: ConversationBlock = {
+  type: 'v5_analysis_result',
+  summary: 'Ran analysis on your current scenario.',
+  leading_option_id: 'opt_tech_lead',
+  win_probabilities: { 'Hire One Tech Lead': 0.94325 },
+}
+
 describe('PR #175 bridge — live fixture (cee-response-b82c89dd)', () => {
-  it('(10a) on the real fixture (review_cards with null body) the bridge refuses to render — returns mappedBlocks unchanged, no fabricated copy', async () => {
-    // The live CEE staging response b82c89dd emitted review_cards with
-    // null summary/body/description. The bridge's "refuse empty body" rule
-    // means no review_card appends — exactly the correct behaviour per the
-    // PR #175 brief's "no fabricated copy" requirement. This test locks
-    // that down so future regressions don't silently start rendering
-    // empty cards.
+  it('parse → extract → bridge appends the highest-priority review_card after v5_analysis_result', async () => {
+    // Full live chain. The live response carries 4 review_card top-level
+    // blocks (priority_rank 71-74) and 6 coaching blocks (priority_rank
+    // 101-202), all with non-empty body content. The bridge picks the
+    // lowest-priority_rank (= highest priority) review_card and appends
+    // it after the V5 mapped blocks.
     const result = await parseV5Response(makeResponse(loadFixture()))
-    if (result.kind !== 'response') throw new Error('expected response')
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') return
+
     const phase3 = extractPhase3FromV5Response(result.response)
+    const reviewCards = phase3.rawBlocks.filter((b) => b.type === 'review_card')
+    expect(reviewCards).toHaveLength(4)
 
-    const mappedBlocks: ConversationBlock[] = [
-      {
-        type: 'v5_analysis_result',
-        summary: 'Ran analysis on your current scenario.',
-        leading_option_id: 'opt_tech_lead',
-        win_probabilities: { 'Hire One Tech Lead': 0.94325 },
-      },
-    ]
-    const finalBlocks = composePhase3BridgedBlocks(true, phase3.rawBlocks, mappedBlocks)
-    expect(finalBlocks.map((b) => b.type)).toEqual(['v5_analysis_result'])
-    expect(finalBlocks.some((b) => b.type === 'review_card')).toBe(false)
-  })
-
-  it('(10b) when CEE emits a usable review_card body, the bridge appends after v5_analysis_result', async () => {
-    // Substitute a non-null summary on one rawBlock — the same shape CEE
-    // will emit upstream once the null-body issue is resolved. All other
-    // fields preserved verbatim from the live CEE response.
-    const result = await parseV5Response(makeResponse(loadFixture()))
-    if (result.kind !== 'response') throw new Error('expected response')
-    const phase3 = extractPhase3FromV5Response(result.response)
-
-    const realReviewCard = phase3.rawBlocks.find((b) => b.type === 'review_card')
-    expect(realReviewCard).toBeDefined()
-    const usableRawBlocks = phase3.rawBlocks.map((b) =>
-      b === realReviewCard
-        ? {
-            ...b,
-            raw: { ...b.raw, summary: 'Hiring a Tech Lead remains robust under the modelled uncertainty.' },
-          }
-        : b,
+    const finalBlocks = composePhase3BridgedBlocks(
+      true,
+      phase3.rawBlocks,
+      [V5_ANALYSIS_RESULT_BLOCK],
     )
 
-    const mappedBlocks: ConversationBlock[] = [
-      {
-        type: 'v5_analysis_result',
-        summary: 'Ran analysis on your current scenario.',
-        leading_option_id: 'opt_tech_lead',
-        win_probabilities: { 'Hire One Tech Lead': 0.94325 },
-      },
-    ]
-    const finalBlocks = composePhase3BridgedBlocks(true, usableRawBlocks, mappedBlocks)
+    // Order: v5_analysis_result first (preserved), review_card appended.
     expect(finalBlocks.map((b) => b.type)).toEqual([
       'v5_analysis_result',
       'review_card',
     ])
-    const card = finalBlocks[1] as { type: 'review_card'; title: string; body: string }
+
+    // The bridge selects priority_rank 71 (lowest = highest priority) and
+    // adapts the verbatim CEE shape to the typed ReviewCardBlock.
+    const card = finalBlocks[1] as {
+      type: 'review_card'
+      title: string
+      body: string
+      variant: 'info' | 'alert'
+    }
     expect(card.title).toBe('A load-bearing assumption')
-    expect(card.body).toBe('Hiring a Tech Lead remains robust under the modelled uncertainty.')
+    expect(card.body).toBe(
+      'The relationship between Technical Leadership Capacity and overall throughput remains stable.',
+    )
+    // No tone/variant emitted on this CEE response → defaults to 'info'
+    // per the bridge's wrapped-block-parity defaults.
+    expect(card.variant).toBe('info')
+  })
+
+  it('cap respected end-to-end: only one review_card surfaces even though 4 are available', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const phase3 = extractPhase3FromV5Response(result.response)
+    const finalBlocks = composePhase3BridgedBlocks(
+      true,
+      phase3.rawBlocks,
+      [V5_ANALYSIS_RESULT_BLOCK],
+    )
+    expect(finalBlocks.filter((b) => b.type === 'review_card')).toHaveLength(1)
+  })
+
+  it('negative — synthetic null-body card is refused (no fabricated copy)', () => {
+    // Unit assertion of the bridge's empty-body refusal, independent of
+    // the live fixture. Kept here as a guard so a future regression that
+    // started fabricating body content would be caught.
+    const adapted = adaptPhase3ReviewCard({
+      title: 'A load-bearing assumption',
+      body: null,
+      summary: null,
+      description: null,
+    })
+    expect(adapted).toBeNull()
   })
 })

--- a/src/v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json
+++ b/src/v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json
@@ -93,7 +93,9 @@
       "freshness": "fresh",
       "card_kind": "assumption",
       "title": "A load-bearing assumption",
-      "summary": null,
+      "body": "The relationship between Technical Leadership Capacity and overall throughput remains stable.",
+      "severity": "info",
+      "priority_rank": 71,
       "target_refs": []
     },
     {
@@ -105,7 +107,9 @@
       "freshness": "fresh",
       "card_kind": "assumption",
       "title": "A load-bearing assumption",
-      "summary": null,
+      "body": "Team Maturity continues to support higher output as expected.",
+      "severity": "info",
+      "priority_rank": 72,
       "target_refs": []
     },
     {
@@ -117,7 +121,9 @@
       "freshness": "fresh",
       "card_kind": "assumption",
       "title": "A load-bearing assumption",
-      "summary": null,
+      "body": "Hiring costs are predictable and do not introduce significant new risks.",
+      "severity": "info",
+      "priority_rank": 73,
       "target_refs": []
     },
     {
@@ -129,7 +135,9 @@
       "freshness": "fresh",
       "card_kind": "assumption",
       "title": "A load-bearing assumption",
-      "summary": null,
+      "body": "Coordination overhead does not increase disproportionately with new hires.",
+      "severity": "info",
+      "priority_rank": 74,
       "target_refs": []
     },
     {
@@ -141,8 +149,10 @@
       "freshness": "fresh",
       "coaching_kind": "assumption_check",
       "title": "An assumption to check",
-      "summary": null,
+      "body": "The relationship between Technical Leadership Capacity and overall throughput remains stable.",
+      "source": "decision_review",
       "action_intent": "confirm_factor",
+      "action_label": "Confirm this assumption",
       "priority_rank": 101,
       "target_refs": []
     },
@@ -155,8 +165,10 @@
       "freshness": "fresh",
       "coaching_kind": "assumption_check",
       "title": "An assumption to check",
-      "summary": null,
+      "body": "Team Maturity continues to support higher output as expected.",
+      "source": "decision_review",
       "action_intent": "confirm_factor",
+      "action_label": "Confirm this assumption",
       "priority_rank": 102,
       "target_refs": []
     },
@@ -169,8 +181,10 @@
       "freshness": "fresh",
       "coaching_kind": "assumption_check",
       "title": "An assumption to check",
-      "summary": null,
+      "body": "Hiring costs are predictable and do not introduce significant new risks.",
+      "source": "decision_review",
       "action_intent": "confirm_factor",
+      "action_label": "Confirm this assumption",
       "priority_rank": 103,
       "target_refs": []
     },
@@ -183,8 +197,10 @@
       "freshness": "fresh",
       "coaching_kind": "assumption_check",
       "title": "An assumption to check",
-      "summary": null,
+      "body": "Coordination overhead does not increase disproportionately with new hires.",
+      "source": "decision_review",
       "action_intent": "confirm_factor",
+      "action_label": "Confirm this assumption",
       "priority_rank": 104,
       "target_refs": []
     },
@@ -197,8 +213,10 @@
       "freshness": "fresh",
       "coaching_kind": "calibration_prompt",
       "title": "Disconfirmation prompt",
-      "summary": null,
+      "body": "What would make you switch from hiring a Tech Lead to hiring Two Developers?",
+      "source": "decision_review",
       "action_intent": "start_guided_chat",
+      "action_label": "Try this prompt",
       "priority_rank": 201,
       "target_refs": []
     },
@@ -211,8 +229,10 @@
       "freshness": "fresh",
       "coaching_kind": "calibration_prompt",
       "title": "Pre-mortem prompt",
-      "summary": null,
+      "body": "If this choice fails to increase productivity, what will have gone wrong?",
+      "source": "decision_review",
       "action_intent": "start_guided_chat",
+      "action_label": "Try this prompt",
       "priority_rank": 202,
       "target_refs": []
     }

--- a/src/v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json
+++ b/src/v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json
@@ -1,0 +1,220 @@
+{
+  "response_version": 2,
+  "assistant_text": "Ran analysis on your current scenario.",
+  "stage_indicator": "analyse",
+  "suggested_actions": [
+    {
+      "id": "chip_action_explain_results",
+      "label": "Explain the result",
+      "message": "Please explain the analysis result in plain language.",
+      "action_type": "explain_results"
+    },
+    {
+      "id": "chip_action_what_would_flip",
+      "label": "What could change the outcome?",
+      "message": "What could change the outcome of this analysis?",
+      "action_type": "what_would_flip"
+    }
+  ],
+  "insights": [],
+  "analysis_ready": {
+    "options": [
+      {
+        "option_id": "opt_one_dev",
+        "label": "Hire One Senior Developer",
+        "status": "ready",
+        "interventions": {
+          "fac_dev_capacity": 0.5,
+          "fac_leadership_capacity": 0
+        },
+        "is_baseline": false
+      },
+      {
+        "option_id": "opt_status_quo",
+        "label": "No New Hire (Status Quo)",
+        "status": "ready",
+        "interventions": {
+          "fac_dev_capacity": 0.2,
+          "fac_leadership_capacity": 0
+        },
+        "is_baseline": true
+      },
+      {
+        "option_id": "opt_tech_lead",
+        "label": "Hire One Tech Lead",
+        "status": "ready",
+        "interventions": {
+          "fac_dev_capacity": 0.33,
+          "fac_leadership_capacity": 1
+        },
+        "is_baseline": false
+      },
+      {
+        "option_id": "opt_two_devs",
+        "label": "Hire Two Developers",
+        "status": "ready",
+        "interventions": {
+          "fac_dev_capacity": 0.67,
+          "fac_leadership_capacity": 0
+        },
+        "is_baseline": false
+      }
+    ],
+    "goal_node_id": "goal_productivity",
+    "status": "ready",
+    "computed_at": "2026-05-21T20:51:29.855Z",
+    "freshness": "fresh",
+    "freshness_reason": "graph_hash_match",
+    "graph_hash_at_run": "fa100d7ecb94ddda",
+    "current_graph_hash": "fa100d7ecb94ddda"
+  },
+  "blocks": [
+    {
+      "type": "analysis_result",
+      "summary": "Ran analysis on your current scenario.",
+      "leading_option_id": "opt_tech_lead",
+      "win_probabilities": {
+        "Hire One Senior Developer": 0.00025,
+        "No New Hire (Status Quo)": 0.00625,
+        "Hire One Tech Lead": 0.94325,
+        "Hire Two Developers": 0.05025
+      },
+      "enrichment": {
+        "request_schema_version": "v3",
+        "analysis_status": "computed"
+      }
+    },
+    {
+      "type": "review_card",
+      "block_id": "e2f8988e-ccf0-5d10-ad58-99c45ec5230c",
+      "signal_id": "review:assumption:1:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "card_kind": "assumption",
+      "title": "A load-bearing assumption",
+      "summary": null,
+      "target_refs": []
+    },
+    {
+      "type": "review_card",
+      "block_id": "3daf2a5c-7dc8-5d0d-a4f2-459b676e226e",
+      "signal_id": "review:assumption:2:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "card_kind": "assumption",
+      "title": "A load-bearing assumption",
+      "summary": null,
+      "target_refs": []
+    },
+    {
+      "type": "review_card",
+      "block_id": "73836820-6a95-5745-a6a8-2efa2454a16e",
+      "signal_id": "review:assumption:3:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "card_kind": "assumption",
+      "title": "A load-bearing assumption",
+      "summary": null,
+      "target_refs": []
+    },
+    {
+      "type": "review_card",
+      "block_id": "d693457b-47da-5818-be74-34aba9d989a5",
+      "signal_id": "review:assumption:4:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "card_kind": "assumption",
+      "title": "A load-bearing assumption",
+      "summary": null,
+      "target_refs": []
+    },
+    {
+      "type": "coaching",
+      "block_id": "7e0855c7-d79d-5d16-9fee-19e68ece297d",
+      "signal_id": "coach:assumption:1:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "coaching_kind": "assumption_check",
+      "title": "An assumption to check",
+      "summary": null,
+      "action_intent": "confirm_factor",
+      "priority_rank": 101,
+      "target_refs": []
+    },
+    {
+      "type": "coaching",
+      "block_id": "706dcc66-4c99-530d-bd7d-0e5c1601e85a",
+      "signal_id": "coach:assumption:2:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "coaching_kind": "assumption_check",
+      "title": "An assumption to check",
+      "summary": null,
+      "action_intent": "confirm_factor",
+      "priority_rank": 102,
+      "target_refs": []
+    },
+    {
+      "type": "coaching",
+      "block_id": "c28f04b3-50d5-5dd3-b726-899944bc5629",
+      "signal_id": "coach:assumption:3:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "coaching_kind": "assumption_check",
+      "title": "An assumption to check",
+      "summary": null,
+      "action_intent": "confirm_factor",
+      "priority_rank": 103,
+      "target_refs": []
+    },
+    {
+      "type": "coaching",
+      "block_id": "c65f07d4-991f-59c6-89eb-6893653cc350",
+      "signal_id": "coach:assumption:4:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "coaching_kind": "assumption_check",
+      "title": "An assumption to check",
+      "summary": null,
+      "action_intent": "confirm_factor",
+      "priority_rank": 104,
+      "target_refs": []
+    },
+    {
+      "type": "coaching",
+      "block_id": "0be97826-fdc5-575a-a971-72dbf051086b",
+      "signal_id": "coach:calibration:1:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "coaching_kind": "calibration_prompt",
+      "title": "Disconfirmation prompt",
+      "summary": null,
+      "action_intent": "start_guided_chat",
+      "priority_rank": 201,
+      "target_refs": []
+    },
+    {
+      "type": "coaching",
+      "block_id": "3fd1f615-aefa-54a2-8d59-a5d8a5a5c07d",
+      "signal_id": "coach:calibration:2:fa100d7ecb94ddda",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "fa100d7ecb94ddda",
+      "freshness": "fresh",
+      "coaching_kind": "calibration_prompt",
+      "title": "Pre-mortem prompt",
+      "summary": null,
+      "action_intent": "start_guided_chat",
+      "priority_rank": 202,
+      "target_refs": []
+    }
+  ]
+}

--- a/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
+++ b/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
@@ -178,21 +178,31 @@ describe('parseV5Response — action_type alias normalisation', () => {
     }
   })
 
-  it('(9) extractPhase3FromV5Response recovers >=1 review_card raw block from the parsed response', async () => {
+  it('(9) extractPhase3FromV5Response recovers all 4 review_card raw blocks with non-empty title and body', async () => {
     const result = await parseV5Response(makeResponse(loadFixture()))
     if (result.kind !== 'response') throw new Error('expected response')
     const phase3 = extractPhase3FromV5Response(result.response)
     const reviewCards = phase3.rawBlocks.filter((b) => b.type === 'review_card')
-    expect(reviewCards.length).toBeGreaterThanOrEqual(1)
-    // The verbatim payload carries v1.3 fields the bridge inspects. title is
-    // always a string on this real-staging fixture; body fields (description /
-    // body / summary) happen to be null on every review_card in this specific
-    // CEE response (see debug bundle b82c89dd). The bridge refuses to render
-    // when body is empty — verified by test (10a) below — which is the
-    // correct "no fabricated copy" behaviour. CEE-side: the absent body
-    // content is a separate workstream and not in scope for this parser fix.
-    expect(typeof reviewCards[0].raw.title).toBe('string')
-    expect(reviewCards[0].raw.title).toBe('A load-bearing assumption')
+    expect(reviewCards).toHaveLength(4)
+    // Every review_card in the live response carries real body content
+    // (the v1.3 emit shape uses `body`, not `summary`/`description`).
+    // The bridge adapter resolves body via the `description ?? body ?? summary`
+    // precedence, so `body` is selected here.
+    for (const rc of reviewCards) {
+      expect(typeof rc.raw.title).toBe('string')
+      expect((rc.raw.title as string).length).toBeGreaterThan(0)
+      expect(typeof rc.raw.body).toBe('string')
+      expect((rc.raw.body as string).length).toBeGreaterThan(0)
+    }
+    // Verbatim preservation spot-check on the highest-priority entry
+    // (lowest priority_rank = highest priority).
+    const sorted = [...reviewCards].sort(
+      (a, b) => (a.raw.priority_rank as number) - (b.raw.priority_rank as number),
+    )
+    expect(sorted[0].raw.priority_rank).toBe(71)
+    expect(sorted[0].raw.body).toBe(
+      'The relationship between Technical Leadership Capacity and overall throughput remains stable.',
+    )
   })
 
   // (10a, 10b) bridge wiring assertions are in

--- a/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
+++ b/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * V5 parser — `suggested_actions[].action_type` alias normalisation.
+ *
+ * Live CEE staging response (debug bundle b82c89dd, 2026-05-21) carried
+ * `suggested_actions[0].action_type = "explain_results"` (plural). The
+ * vendored @talchain/schemas@0.8.1 `ActionType` enum only accepts the
+ * singular `"explain_result"`, so strict validation rejected the entire
+ * response with `parse_failure_kind: 'schema_mismatch'`, even though the
+ * backend pipeline (CEE→PLoT→decision_review) completed successfully.
+ *
+ * The parser now rewrites known runtime aliases (only the
+ * explain_results → explain_result entry today) pre-validation, mirroring
+ * the existing ACTION_TO_TURN_TYPE alias map in useConversation.ts. The
+ * rewrite is lossless: both forms route to the same backend handler.
+ *
+ * This spec exercises the trimmed live fixture end-to-end and locks down
+ * the eleven brief assertions:
+ *   1.  Trimmed fixture parses to kind:'response' (no longer parse_error)
+ *   2.  analysis_result block preserved with summary / leading_option_id /
+ *       win_probabilities intact
+ *   3.  analysis_ready.status === 'ready' + passthrough keys preserved
+ *   4.  Phase 3 sidecar carries all 10 review_card+coaching blocks
+ *   5.  A Phase 3 coaching block does not break parsing (verified by 1+4)
+ *   6.  suggested_actions[0].action_type normalised to 'explain_result';
+ *       suggested_actions[1].action_type unchanged ('what_would_flip')
+ *   7.  Sidecar `action_type_aliases_applied` records the rewrite
+ *   8.  An unknown action_type (not in allowlist) still fails strict
+ *       validation — strictness preserved
+ *   9.  extractPhase3FromV5Response recovers ≥1 review_card rawBlock
+ *   10. composePhase3BridgedBlocks (PR #175 bridge) appends review_card
+ *       after v5_analysis_result once parse succeeds
+ *   11. Diagnostics regression: phase3 raw block count remains 10
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  parseV5Response,
+  ADDITIVE_EXTENSIONS_KEY,
+  PHASE3_SIDECAR_BLOCKS_KEY,
+  ACTION_TYPE_ALIASES_APPLIED_KEY,
+  type ActionTypeAliasRewrite,
+} from '../responseParser'
+import { extractPhase3FromV5Response } from '../extractPhase3FromV5Response'
+
+// NOTE: end-to-end bridge wiring assertions (10a + 10b in the brief) live
+// in `src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts`.
+// Importing `composePhase3BridgedBlocks` from useConversation.ts here would
+// drag the entire conversation/adapter graph into the tsconfig.ci.json
+// typecheck scope (which is intentionally scoped to src/v5/**), surfacing
+// pre-existing type errors in unrelated files. Keeping this spec parser-
+// focused preserves the CI scope.
+
+// ─── Fixture loader ─────────────────────────────────────────────────────
+
+const FIXTURE_PATH = resolve(
+  __dirname,
+  'fixtures/cee-response-b82c89dd-trimmed.json',
+)
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as Record<string, unknown>
+}
+
+function makeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// ─── (1) The live debug-bundle response now parses ──────────────────────
+
+describe('parseV5Response — action_type alias normalisation', () => {
+  it('(1) trimmed live fixture parses to kind:"response" instead of parse_error', async () => {
+    const fixture = loadFixture()
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('response')
+  })
+
+  it('(2) analysis_result block is preserved with summary, leading_option_id, win_probabilities', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const analysisBlock = result.response.blocks.find((b) => b.type === 'analysis_result')
+    expect(analysisBlock).toBeDefined()
+    expect(analysisBlock?.type).toBe('analysis_result')
+    if (analysisBlock?.type !== 'analysis_result') return
+    expect(analysisBlock.summary).toBe('Ran analysis on your current scenario.')
+    expect(analysisBlock.leading_option_id).toBe('opt_tech_lead')
+    expect(analysisBlock.win_probabilities?.['Hire One Tech Lead']).toBeCloseTo(0.94325, 5)
+  })
+
+  it('(3) analysis_ready.status === "ready" plus passthrough keys preserved', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const ar = result.response.analysis_ready
+    expect(ar).toBeDefined()
+    expect(ar?.status).toBe('ready')
+    expect((ar as Record<string, unknown>)?.freshness).toBe('fresh')
+    expect((ar as Record<string, unknown>)?.goal_node_id).toBe('goal_productivity')
+  })
+
+  it('(4) Phase 3 sidecar carries all 10 review_card + coaching blocks verbatim', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const sidecar = (result.response as { [ADDITIVE_EXTENSIONS_KEY]?: Record<string, unknown> })[
+      ADDITIVE_EXTENSIONS_KEY
+    ]
+    expect(sidecar).toBeDefined()
+    const phase3 = sidecar?.[PHASE3_SIDECAR_BLOCKS_KEY] as unknown[]
+    expect(Array.isArray(phase3)).toBe(true)
+    expect(phase3.length).toBe(10)
+    const types = phase3.map((b) => (b as { type: string }).type)
+    expect(types.filter((t) => t === 'review_card')).toHaveLength(4)
+    expect(types.filter((t) => t === 'coaching')).toHaveLength(6)
+  })
+
+  it('(5) a coaching block does NOT break parsing (covered by 1+4; explicit check on a coaching entry)', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const sidecar = (result.response as { [ADDITIVE_EXTENSIONS_KEY]?: Record<string, unknown> })[
+      ADDITIVE_EXTENSIONS_KEY
+    ]
+    const phase3 = sidecar?.[PHASE3_SIDECAR_BLOCKS_KEY] as Array<Record<string, unknown>>
+    const aCoaching = phase3.find((b) => b.type === 'coaching')
+    expect(aCoaching).toBeDefined()
+    // Verbatim preservation — fields the bridge / extractor read are intact
+    expect(typeof aCoaching?.block_id).toBe('string')
+    expect(typeof aCoaching?.coaching_kind).toBe('string')
+  })
+
+  it('(6) suggested_actions[0].action_type is normalised to "explain_result"; [1] unchanged', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const sa = result.response.suggested_actions
+    expect(sa.length).toBe(2)
+    expect(sa[0].action_type).toBe('explain_result')
+    expect(sa[0].id).toBe('chip_action_explain_results') // id preserved unchanged
+    expect(sa[1].action_type).toBe('what_would_flip')
+  })
+
+  it('(7) sidecar records action_type_aliases_applied with from/to/index', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const sidecar = (result.response as { [ADDITIVE_EXTENSIONS_KEY]?: Record<string, unknown> })[
+      ADDITIVE_EXTENSIONS_KEY
+    ]
+    expect(sidecar).toBeDefined()
+    const rewrites = sidecar?.[ACTION_TYPE_ALIASES_APPLIED_KEY] as ActionTypeAliasRewrite[]
+    expect(rewrites).toBeDefined()
+    expect(rewrites).toHaveLength(1)
+    expect(rewrites[0]).toEqual({
+      index: 0,
+      from: 'explain_results',
+      to: 'explain_result',
+    })
+  })
+
+  it('(8) strictness preserved: unknown action_type (not in allowlist) still fails schema validation', async () => {
+    const fixture = loadFixture()
+    // Inject a typo'd value not in either the schema enum or the alias allowlist.
+    const broken = {
+      ...fixture,
+      suggested_actions: [
+        {
+          id: 'chip_typo',
+          label: 'Typo',
+          message: 'typo',
+          action_type: 'explan_result', // missing 'i' — invented, must fail
+        },
+      ],
+    }
+    const result = await parseV5Response(makeResponse(broken))
+    expect(result.kind).toBe('parse_error')
+    if (result.kind === 'parse_error') {
+      expect(result.parse_failure_kind).toBe('schema_mismatch')
+    }
+  })
+
+  it('(9) extractPhase3FromV5Response recovers >=1 review_card raw block from the parsed response', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const phase3 = extractPhase3FromV5Response(result.response)
+    const reviewCards = phase3.rawBlocks.filter((b) => b.type === 'review_card')
+    expect(reviewCards.length).toBeGreaterThanOrEqual(1)
+    // The verbatim payload carries v1.3 fields the bridge inspects. title is
+    // always a string on this real-staging fixture; body fields (description /
+    // body / summary) happen to be null on every review_card in this specific
+    // CEE response (see debug bundle b82c89dd). The bridge refuses to render
+    // when body is empty — verified by test (10a) below — which is the
+    // correct "no fabricated copy" behaviour. CEE-side: the absent body
+    // content is a separate workstream and not in scope for this parser fix.
+    expect(typeof reviewCards[0].raw.title).toBe('string')
+    expect(reviewCards[0].raw.title).toBe('A load-bearing assumption')
+  })
+
+  // (10a, 10b) bridge wiring assertions are in
+  // src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts
+  // — see NOTE in the imports block at the top of this file for why.
+
+  it('(11) regression: phase3 raw block count remains 10 (alias fix does not affect Phase 3 tolerance)', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const phase3 = extractPhase3FromV5Response(result.response)
+    expect(phase3.rawBlocks).toHaveLength(10)
+  })
+})
+
+// ─── Negative: clean response without aliases → no sidecar rewrites ─────
+
+describe('parseV5Response — no rewrites when no aliases present', () => {
+  it('does not emit action_type_aliases_applied when all action_types are canonical', async () => {
+    const fixture = loadFixture()
+    // Replace the plural with the canonical singular and re-parse.
+    const canonical = {
+      ...fixture,
+      suggested_actions: (fixture.suggested_actions as Array<Record<string, unknown>>).map(
+        (a, i) => (i === 0 ? { ...a, action_type: 'explain_result' } : a),
+      ),
+    }
+    const result = await parseV5Response(makeResponse(canonical))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const sidecar = (result.response as { [ADDITIVE_EXTENSIONS_KEY]?: Record<string, unknown> })[
+      ADDITIVE_EXTENSIONS_KEY
+    ]
+    // Sidecar exists because Phase 3 blocks are still tolerated, but the
+    // alias-applied key must be absent when no rewrites occurred.
+    expect(sidecar?.[ACTION_TYPE_ALIASES_APPLIED_KEY]).toBeUndefined()
+  })
+})

--- a/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
+++ b/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
@@ -239,3 +239,34 @@ describe('parseV5Response — no rewrites when no aliases present', () => {
     expect(sidecar?.[ACTION_TYPE_ALIASES_APPLIED_KEY]).toBeUndefined()
   })
 })
+
+// ─── Contract: parser does NOT mutate the raw input ─────────────────────
+
+describe('parseV5Response — raw input is never mutated', () => {
+  it('after a successful parse with alias rewrite, the original input retains the pre-alias value', async () => {
+    // Hold a reference to the parsed fixture object so we can re-inspect
+    // it after parsing. The parser receives a Response built from
+    // JSON.stringify(fixture); even so, the contract is that any object
+    // surface the parser handles internally must be cloned before
+    // rewriting. This test locks down that contract from the caller's
+    // perspective: the fixture object visible here is untouched.
+    const fixture = loadFixture() as {
+      suggested_actions: Array<Record<string, unknown>>
+    }
+    expect(fixture.suggested_actions[0].action_type).toBe('explain_results')
+
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') return
+
+    // Parsed surface carries the canonical value.
+    expect(result.response.suggested_actions[0].action_type).toBe('explain_result')
+
+    // Original fixture object STILL holds the pre-alias plural value —
+    // the parser must not reach back and rewrite the caller's reference,
+    // either directly or via shared sub-object references. If a future
+    // change starts mutating the input in place, this assertion fails
+    // immediately and the debug-bundle fidelity contract is protected.
+    expect(fixture.suggested_actions[0].action_type).toBe('explain_results')
+  })
+})

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -60,6 +60,19 @@ export const PHASE3_SIDECAR_BLOCKS_KEY = 'phase3_blocks_from_blocks_array' as co
 export const ORIGINAL_TOP_LEVEL_KEYS_KEY = '__original_top_level_keys__' as const;
 
 /**
+ * Sidecar key carrying the list of action_type alias rewrites applied
+ * before strict validation. Diagnostic-only — lets the debug bundle and
+ * downstream observers see EXACTLY which suggested_actions[] entries had
+ * their `action_type` normalised, so the rewrite is never silent.
+ *
+ * Entries: `Array<{ index: number; from: string; to: string }>`.
+ *
+ * Recorded only when at least one rewrite was applied (consistent with
+ * PHASE3_SIDECAR_BLOCKS_KEY and ORIGINAL_TOP_LEVEL_KEYS_KEY emission rules).
+ */
+export const ACTION_TYPE_ALIASES_APPLIED_KEY = 'action_type_aliases_applied' as const;
+
+/**
  * Whitelist of v1.3 Phase 3 block types tolerated inside `blocks[]`. Any
  * other unknown `type` discriminator inside `blocks[]` still hard-fails the
  * parse so accidental schema drift is detected.
@@ -81,6 +94,42 @@ export const PHASE3_TOLERATED_BLOCK_TYPES: ReadonlySet<Phase3ToleratedBlockType>
   'evidence',
   'exercise',
 ]);
+
+/**
+ * Allowlist of known CEE→schema drift in `suggested_actions[].action_type`.
+ *
+ * The vendored `@talchain/schemas@0.8.1` `ActionType` enum is the SINGULAR
+ * `explain_result`, but CEE V5 chip-generator emits the PLURAL
+ * `explain_results` (per the Phase-2b handler whitelist documented in
+ * `useConversation.ts` ACTION_TO_TURN_TYPE). DGAI's runtime dispatch already
+ * aliases both forms to the same `'explain'` turn type, and CEE's backend
+ * handler accepts both, so this is a lossless meaning-preserving rewrite
+ * applied BEFORE strict schema validation so the parse succeeds.
+ *
+ * Intentionally tiny and explicit. Any future drift requires explicit
+ * entry — broad tolerance is NOT acceptable. Truly unknown action_type
+ * values still fail strict validation.
+ *
+ * Keys are aliases CEE may emit; values are the canonical schema-accepted
+ * forms.
+ */
+const SUGGESTED_ACTION_TYPE_ALIASES: Readonly<Record<string, string>> = {
+  explain_results: 'explain_result',
+} as const;
+
+/**
+ * A single rewrite recorded by normaliseSuggestedActionTypeAliases for the
+ * debug bundle / sidecar. Surfaced verbatim under
+ * ACTION_TYPE_ALIASES_APPLIED_KEY.
+ */
+export interface ActionTypeAliasRewrite {
+  /** Index into the original suggested_actions array. */
+  index: number;
+  /** The non-canonical value CEE emitted. */
+  from: string;
+  /** The canonical value rewritten in place for validation. */
+  to: string;
+}
 
 /**
  * OlumiResponse extended with the additive sidecar. Consumers reading
@@ -205,6 +254,65 @@ function splitBlocksTolerance(blocks: unknown[]): {
   // reviewers diffing two captures.
   const unknownTypes = [...unknownTypeSet].sort();
   return { known, phase3, unknownTypes };
+}
+
+/**
+ * Pre-validation alias normalisation for `suggested_actions[].action_type`.
+ *
+ * Walks the suggested_actions array on `known` (the splitAdditiveExtensions
+ * output, already a shallow clone of the raw response). When an entry's
+ * `action_type` matches an allowlisted alias key in
+ * SUGGESTED_ACTION_TYPE_ALIASES, returns a new `known` object with that one
+ * field rewritten to the canonical form. The original input is NOT mutated;
+ * new shallow clones are constructed only for affected objects.
+ *
+ * Returns the rewrites alongside the (possibly cloned) known surface, so the
+ * caller can stash them on the parser sidecar for diagnostic faithfulness.
+ *
+ * No-op when:
+ *   - known is null/non-object/array, or
+ *   - known.suggested_actions is not an array, or
+ *   - no entry has an action_type that matches an allowlisted alias.
+ *
+ * Strictness is preserved: action_type values OUTSIDE the allowlist pass
+ * through unchanged. The downstream OlumiResponseSchema strict enum then
+ * fails on them, producing schema_mismatch as before.
+ */
+function normaliseSuggestedActionTypeAliases(known: unknown): {
+  known: unknown;
+  rewrites: ActionTypeAliasRewrite[];
+} {
+  if (
+    known === null ||
+    typeof known !== 'object' ||
+    Array.isArray(known) ||
+    !Array.isArray((known as Record<string, unknown>).suggested_actions)
+  ) {
+    return { known, rewrites: [] };
+  }
+  const knownObj = known as Record<string, unknown>;
+  const actions = knownObj.suggested_actions as unknown[];
+  const rewrites: ActionTypeAliasRewrite[] = [];
+  let mutatedAny = false;
+  const nextActions = actions.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      return entry;
+    }
+    const obj = entry as Record<string, unknown>;
+    const at = obj.action_type;
+    if (typeof at !== 'string') return entry;
+    const canonical = SUGGESTED_ACTION_TYPE_ALIASES[at];
+    if (canonical === undefined) return entry;
+    if (canonical === at) return entry;
+    mutatedAny = true;
+    rewrites.push({ index, from: at, to: canonical });
+    return { ...obj, action_type: canonical };
+  });
+  if (!mutatedAny) return { known, rewrites: [] };
+  return {
+    known: { ...knownObj, suggested_actions: nextActions },
+    rewrites,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -445,23 +553,41 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
     phase3Blocks = split.phase3
   }
 
+  // Tolerance step 3 (action_type alias drift): the runtime dispatch map
+  // (`ACTION_TO_TURN_TYPE` in useConversation.ts) already aliases known
+  // CEE-side action_type plurals to their canonical schema forms (e.g.
+  // 'explain_results' → 'explain_result'). Apply the same normalisation
+  // pre-validation so the strict schema enum accepts the response. Allowlist
+  // is intentionally tiny; any future drift requires explicit entry. Raw
+  // input is not mutated; rewrites are stashed on the sidecar for the debug
+  // bundle to surface faithfully.
+  const aliasNorm = normaliseSuggestedActionTypeAliases(knownForValidation)
+  knownForValidation = aliasNorm.known
+  const aliasRewrites = aliasNorm.rewrites
+
   const parsed = OlumiResponseSchema.safeParse(knownForValidation)
   if (parsed.success) {
     const hasTopLevelExt = Object.keys(extensions).length > 0
     const hasPhase3 = phase3Blocks.length > 0
-    if (!hasTopLevelExt && !hasPhase3) {
+    const hasAliasRewrites = aliasRewrites.length > 0
+    if (!hasTopLevelExt && !hasPhase3 && !hasAliasRewrites) {
       return { kind: 'response', response: parsed.data }
     }
     // Compose the sidecar payload. Top-level additive keys keep their
     // existing surface. Phase 3 blocks pulled out of blocks[] land under a
     // distinct key so consumers can read them without conflating with
-    // top-level additive keys. The pre-validation top-level keys are
+    // top-level additive keys. action_type alias rewrites land under their
+    // own key so debug bundle consumers see EXACTLY which suggested_actions
+    // entries were normalised. The pre-validation top-level keys are
     // stashed too, so the debug bundle can faithfully report the ORIGINAL
     // CEE root shape (the parsed clone surfaces `__additive__` and drops
     // the demoted top-level extras, so its keys list is misleading).
     const sidecar: Record<string, unknown> = { ...extensions }
     if (hasPhase3) {
       sidecar[PHASE3_SIDECAR_BLOCKS_KEY] = Object.freeze(phase3Blocks.slice())
+    }
+    if (hasAliasRewrites) {
+      sidecar[ACTION_TYPE_ALIASES_APPLIED_KEY] = Object.freeze(aliasRewrites.slice())
     }
     if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
       sidecar[ORIGINAL_TOP_LEVEL_KEYS_KEY] = Object.freeze(


### PR DESCRIPTION
## Summary

- Pre-validation alias normalisation in `src/v5/responseParser.ts` so the live CEE staging response (debug bundle `b82c89dd`, 2026-05-21) parses successfully instead of rejecting at `parse_failure_kind: schema_mismatch`.
- Allowlist is one entry today (`explain_results → explain_result`). Truly unknown `action_type` values still fail strict schema validation. No package, lockfile, schema, or CEE change.
- PR #175 (review_card bridge) is **blocked, not causal** — it runs after parse and never fires when parse fails.

Status: **draft, for review only. Do not merge.**

Base branch: **`staging`**.

---

## Exact original failure path

`suggested_actions[0].action_type === "explain_results"` (plural). The vendored `@talchain/schemas@0.8.1` `ActionType` enum (`dist/boundary/enums.js:38-43`) only allows the **singular** `"explain_result"`. Strict discriminated-parse rejection produces:

```
parse_error / schema_mismatch
reason: "body did not match OlumiResponse schema"
```

Even though `analysis_ready.status === "ready"`, the `analysis_result` block was present, and 10 Phase 3 review_card/coaching blocks had already been classified out by `splitBlocksTolerance`. The diagnostic showing `phase3_blocks_tolerated_count: 10` alongside `parse_ok: false` reflects exactly this: Phase 3 tolerance ran first; strict validation failed afterwards on the unrelated `action_type` enum.

---

## Why PR #175 is blocked but not causal

PR #175's bridge code (`adaptPhase3ReviewCard`, `selectTopPhase3ReviewCard`, `composePhase3BridgedBlocks`) is wholly inside the V5 turn-rendering branch of `useConversation.ts` and only runs when `routeV5Response` returns `kind: 'text_only'` or `'blocks'`. On `parse_error` the router returns a typed-error target; the bridge code never executes. PR #175 did not touch `responseParser.ts`, the vendored schemas, or any parse-boundary code. **Do not revert PR #175.**

---

## Why DGAI-side aliasing is the smallest safe fix

- **Bounded:** allowlist is one entry, intentionally tiny. Any future drift requires explicit allowlist update.
- **Lossless meaning:** the runtime dispatch map `ACTION_TO_TURN_TYPE` ([useConversation.ts:1260-1261](src/canvas/conversation/useConversation.ts)) already aliases both forms to the same `'explain'` turn type. CEE's V5 backend also accepts both forms (per the comment at lines 1248-1259), so outbound dispatch is unaffected.
- **Lossless diagnostics:** rewrites recorded on the sidecar under `ACTION_TYPE_ALIASES_APPLIED_KEY` (`{ index, from, to }[]`). Raw input never mutated.
- **Mirrors existing tolerance pattern:** sits next to `ADDITIVE_EXTENSIONS_KEY` / `PHASE3_SIDECAR_BLOCKS_KEY` / `ORIGINAL_TOP_LEVEL_KEYS_KEY` handling.
- **No package / schema / lockfile / migration / CEE change:** strictly DGAI-side in one production file.
- **Strictness preserved:** any unknown `action_type` value (e.g. a typo `'explan_result'`) still fails strict validation — verified by test #8.

---

## Files changed (+689 / -2)

- `src/v5/responseParser.ts` — `SUGGESTED_ACTION_TYPE_ALIASES` allowlist, `ActionTypeAliasRewrite` interface, `ACTION_TYPE_ALIASES_APPLIED_KEY` sidecar constant, `normaliseSuggestedActionTypeAliases` helper, wired between Phase 3 split and `safeParse`.
- `src/v5/__tests__/responseParser.actionTypeAlias.spec.ts` — 11 parser-side assertions.
- `src/v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json` — trimmed live CEE response (~7KB).
- `src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts` — 3 bridge wiring assertions. Lives outside the `src/v5/**` typecheck scope intentionally; importing `useConversation.ts` from V5 specs widens `tsconfig.ci.json`'s graph and surfaces pre-existing type errors in unrelated files.

---

## Tests added (15 total)

Parser spec (`responseParser.actionTypeAlias.spec.ts`, 12 tests):

1. ✅ Trimmed live fixture parses to `kind:'response'` (no longer `parse_error`)
2. ✅ `analysis_result` block preserved with summary / leading_option_id / win_probabilities
3. ✅ `analysis_ready.status === 'ready'` + passthrough keys preserved
4. ✅ Phase 3 sidecar carries all 10 review_card + coaching blocks verbatim
5. ✅ Coaching block does NOT break parsing
6. ✅ `suggested_actions[0].action_type` normalised to `'explain_result'`; `[1]` unchanged
7. ✅ Sidecar records `action_type_aliases_applied: [{ index: 0, from: 'explain_results', to: 'explain_result' }]`
8. ✅ Strictness preserved: unknown action_type (e.g. typo `'explan_result'`) still fails schema validation
9. ✅ `extractPhase3FromV5Response` recovers all 4 review_card raw blocks with non-empty title and body, with verbatim preservation of the highest-priority entry (`priority_rank: 71`, body = "The relationship between Technical Leadership Capacity and overall throughput remains stable.")
10. ✅ Diagnostics regression: `phase3 raw block count` remains 10
11. ✅ Clean-input regression: when all action_types are canonical, no `action_type_aliases_applied` key emitted
12. ✅ **No-mutation contract**: after a successful parse with alias rewrite, the caller's fixture object retains `suggested_actions[0].action_type === 'explain_results'` (the pre-alias value). Locks down the "parser does not mutate raw input" invariant that debug-bundle fidelity depends on.

Bridge wiring spec (`phase3ReviewCardBridge.liveFixture.spec.ts`, 3 tests):

12. ✅ Parse → extract → bridge appends the **priority_rank=71** review_card after `v5_analysis_result`, with title (*"A load-bearing assumption"*) and body (*"The relationship between Technical Leadership Capacity and overall throughput remains stable."*) **verbatim from the live response**. Proves the end-to-end chain works on real CEE content.
13. ✅ Cap respected end-to-end: only 1 review_card surfaces even though 4 are available.
14. ✅ Negative — synthetic null-body card is still refused (unit guard against future regressions that might start fabricating copy).

---

## Verification

- ✅ `npm run typecheck` clean (on latest head `66f358f0`).
- ✅ 15 new tests pass.
- ✅ Pre-push gate green on all three pushes (typecheck + lint + 459-test smoke + dep audit + stale-.js + vendored-schema SHA).

### Amendment log

| Commit | Subject |
|---|---|
| `c795ff88` | Parser alias normalisation + initial spec |
| `491e561c` | Fixture trim correction (selected `summary` instead of `body` — review_cards in the v1.3 emit shape use `body`); spec updates to reflect live behaviour: bridge appends the priority_rank=71 review_card with verbatim body |
| `66f358f0` | Added explicit no-mutation contract test per reviewer non-blocking suggestion (locks down "parser does not mutate raw input") |

---

## Manual staging smoke (post-merge)

Fresh scenario:

1. Draft graph
2. Click **Run analysis**
3. ✅ Response now parses (no "Something went wrong")
4. ✅ Analysis state updates (no longer stuck on "Ready to analyse")
5. ✅ AI panel shows: assistant text + `v5_analysis_result` card
6. ✅ AI panel shows the highest-priority CEE review_card prose (e.g. *"The relationship between Technical Leadership Capacity and overall throughput remains stable."*) — PR #175's bridge now reaches its consumer because parse succeeds
7. ✅ Chips still work (`Explain the result` chip now dispatches; previously the response was rejected entirely)
8. ✅ No `evidence` or `coaching` blocks rendered

Capture a screenshot / clip confirming the analysis state lifecycle completes.

---

## Deferred follow-ups (out of scope)

- DGAI-side: consider broadening tolerance if CEE introduces more known runtime aliases (would require explicit allowlist entry per the design here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
