### PR TITLE
V17 hero top-section — banner slim, pill removal, dependency line, KQ render rule

### DIFF
--- a/docs/investigations/analysis-hero-v17-top-section.md
+++ b/docs/investigations/analysis-hero-v17-top-section.md
@@ -426,3 +426,41 @@ npx vitest run src/components/results/analysisHeroV17/__tests__ \
 # 2. Load a scenario that produces an orphaned plot result and a normal result.
 # 3. Confirm acceptance criteria 1–7.
 ```
+
+---
+
+# Implementation appendix (2026-05-21)
+
+This appendix captures decisions made **during implementation** that diverge from estimates in the body of the report above. The body is preserved as written so the reasoning is traceable; this appendix is what future agents should rely on for current state.
+
+## A1. Banner height: 44 px floor, not 36 px
+
+Task 1 estimated the slim banner at ~36 px. The actual floor is **~46 px** (44 px button + ~2 px border). The 36 px estimate didn't account for WCAG 2.1 AA target size (44×44 px minimum), which is non-negotiable for the "Run analysis" button. Implementation drops container vertical padding entirely (`px-3` only) so the visible row floors at the button's `min-h-[44px]`. Visual reduction is still meaningful (was ~64 px → now ~46 px, –28 %) but smaller than the body of this report claims.
+
+**Do not chase 36 px** without breaking the touch target — that path is closed.
+
+## A2. Dependency-line dominance gate: rank-1 + ratio, not `normalisedInfluence >= 0.5`
+
+Task 3 implied a simple corroboration via `normalisedInfluence` could suffice. It can't. `computeNormalisedInfluences` at `useResultsSectionData.ts:420–446` always pegs the top driver at `1.0` when any real elasticity exists ("top factor = 100%, others proportional"). A `>= 0.5` gate on the top driver is therefore trivially satisfied — it cannot detect ties.
+
+Final implementation in `buildDependencyLine` (after review-feedback round 2):
+
+1. `data.recommendation.dominantFactorId` + `dominantFactorLabel` populated.
+2. Named factor IS the **rank-1 driver** in `data.drivers.drivers[]` (consistency check).
+3. Dominance gate: prefer `influenceScore >= 0.5` (absolute ISL structural causal influence) when available; otherwise require `top1/top2 normalisedInfluence ratio >= 2.0` (the same 2:1 threshold the legacy heuristic uses, applied here as a guard, not a selector).
+4. Glossary banned-term gate on the cleaned label.
+
+The "safe alternative path" wording in Task 3 referred to the absence of the legacy heuristic in the `recommendation` source path. That's still true — but it does NOT guarantee dominance is real, only that the source isn't the worst-case heuristic. The ratio/`influenceScore` gates above are what actually protect against M1 emissions without confidence checks and tie cases.
+
+## A3. Key question card: `reviewStatus === 'complete'` gate added
+
+Task 5 listed three conditions for rendering the Key question card. A fourth was added during implementation: **`data.confidence.reviewStatus === 'complete'`**. Upstream selector at `useResultsSectionData.ts:2524–2532` exposes `m2DecisionQualityPrompts` without that gate (comment on line 2512 explicitly defers gating to consumers). Without the gate, partial / in-progress / stale prompts could surface. The new gate mirrors the one `m2NarrativeSummary` uses (line 1461).
+
+## A4. Stop condition resolution (Task 3 stop condition)
+
+The Task 3 stop condition asked: "stop if the UI cannot distinguish safe `dominant_factor` sources from legacy heuristic output without modifying `useResultsSectionData.ts`." The implementation resolves this by reading from `data.recommendation.dominantFactor*` rather than `data.drivers.dominantFactor*`. The `recommendation` aggregate is populated only from PLoT B1 or M1 `key_drivers` (see `useResultsSectionData.ts:1465–1476`) — the legacy heuristic only contaminates `data.drivers.dominantFactor*`, which the hero deliberately does NOT read. No modification to `useResultsSectionData.ts` was needed.
+
+## A5. Vertical-height table revision
+
+The body of this report estimates ~140 px reduction above the input rows. With the 44 px banner floor (A1) and the dependency line at ~22 px (only when data is safe), the actual reduction is closer to ~120 px in the typical M1 case. The qualitative argument stands — two non-actionable pills, a redundant header label, and a generic question card all vanish — but the precise pixel target should be measured in-browser, not predicted from the table at line 309.
+

--- a/docs/investigations/analysis-hero-v17-top-section.md
+++ b/docs/investigations/analysis-hero-v17-top-section.md
@@ -1,0 +1,428 @@
+# V17 Hero — Top-Section Investigation
+
+**Date:** 2026-05-21
+**Phase:** 0 (investigation only — no implementation)
+**Flag:** `analysisHeroV17` remains off-by-default. No flag changes in this brief or its follow-on.
+**Files modified by this brief:** zero source files; this report only.
+
+## Scope recap
+
+- **In scope:** refresh banner sizing/copy; "No inputs verified" header placement; result context structure; meta pills retention; Key question card retention/conditional render.
+- **Out of scope:** everything below the Needs your input section; footer checks/CTA/Also-line; TriageActionCardsBody body content; V5 Phase 3 backend wiring.
+- **Branch:** `claude/relaxed-dhawan-f108ba` (worktree off staging).
+
+## Stop-condition results (all clear)
+
+| Stop condition | Result |
+|---|---|
+| Refresh banner upstream of ResultsBody / shared with non-Analysis surfaces | **Clear.** `AnalysisOrphanBanner` is rendered inside `ResultsBody` and is V17+ only — legacy panel has no knowledge of it. |
+| `factor_sensitivity.elasticity` not available per-option | **N/A — alternative path is safe.** Elasticity is decision-level (not per-option) in PLoT v2, but PLoT B1 emits `dominant_factor` directly on the response. Dominance is correctly framed as a decision property, not an option property — the proposed copy ("the result depends most on X") is grounded by this field. |
+| Key question chips wired to state Paul does not want to lose | **Clear.** Chips fire `onPrefillChat` only (populate chat composer text). No state is persisted, no handler beyond prefill. Hiding the card loses no behaviour. |
+| Meta pills have downstream test dependencies requiring broader refactor | **Bounded.** ~20 assertions across 3 V17-scoped test files. No tests outside the hero folder reference the pills. |
+| Any change requires backend/CEE/PLoT/schema/prompt edits | **Clear.** All five changes are pure front-end. V5 Phase 3 substitution is forwards-compatible by design. |
+
+---
+
+## Task 1 — Refresh banner audit
+
+### Current state
+
+- **Component:** `src/components/results/AnalysisOrphanBanner.tsx`
+- **Renders at:** `src/components/results/ResultsBody.tsx:219` (inside ResultsBody — not upstream)
+- **Trigger:** `useAnalysisStateSource().showOrphanBanner === true` — true when canonical-analysis flag is ON and no `run_analysis` fact exists for the current scenario (`orphaned_plot_result` classification).
+- **Scope confirmation:** V17+ Analysis surface only. The legacy `DecisionConfidencePanel` does not import or reference this banner. Safe to restyle.
+
+Current markup (two stacked text lines + button):
+
+```tsx
+<div className="flex items-start gap-3 rounded-lg border border-panel-border bg-panel p-3">
+  <div className="flex-1">
+    <p className={`${typography.body} text-text-body`}>Analysis needs refresh</p>
+    <p className={`${typography.bodySmall} text-text-light mt-1`}>
+      Re-run analysis to attach AI explanations to these results.
+    </p>
+  </div>
+  <button className="...min-h-[44px] bg-primary text-text-on-color" onClick={handleRunAnalysis}>
+    Run analysis
+  </button>
+</div>
+```
+
+- Body line uses `typography.body` + `bodySmall` stack → ~64 px tall including padding.
+- Action dispatcher: `useGuidanceStore._dispatchAction({ action_type: 'run_analysis', source: 'chip' })` — same path the suggested chips use.
+
+### Recommendation
+
+Collapse to a single-row strip using `panelMeta` typography:
+
+```
+Refresh analysis · Coaching may be out of date          [Run analysis]
+```
+
+- Title copy uses **"Refresh analysis"** rather than "Analysis needs refresh" — action-led phrasing.
+- One `<p>` element with the dot-separator pattern already used elsewhere in the hero (`HeroFooter` uses the same `·` glyph).
+- Body copy "Re-run analysis to attach AI explanations to these results." removed — its content is already implied by the title and CTA.
+- Button keeps `min-h-[44px]` for touch target; visually it now matches the row height.
+- Estimated height: ~64 px → ~36 px (–28 px / –44%).
+- `role="status"` and `data-testid="analysis-orphan-banner"` preserved.
+
+### Files affected
+
+- `src/components/results/AnalysisOrphanBanner.tsx` — restyle markup, drop second `<p>`, change typography token.
+- `src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx` — update copy assertion (remove "Re-run analysis to attach AI explanations…" expectation; add `Refresh analysis` + `Coaching may be out of date` + dot-separator check).
+
+---
+
+## Task 2 — Header strip "No inputs verified" placement
+
+### Current state
+
+- **Component:** `src/components/results/analysisHeroV17/ReadinessColourStrip.tsx:22–25`
+- **Source:** `buildAnalysisHeroViewModel.ts:437–453` (`checkedCount` field).
+- Renders as a meta-line **right of the "Strengthen this decision" title**:
+
+```tsx
+<div className="flex items-baseline justify-between gap-2">
+  <p className={typography.panelHeader}>Strengthen this decision</p>
+  {checkedCount && <p className={typography.panelMeta}>{checkedCount}</p>}
+</div>
+```
+
+Then the 4-segment fill bars render below, and a legend row repeats the dimension labels (Structure / Evidence / Coverage / Verified). The Verified segment's fill width = `confirmedFactorCount / totalFactorCount`, so the same count is encoded twice: once as the strip fill (geometric) and once as the text "No inputs verified" (literal). The legend label "Verified" appears a third time underneath the strip as a static word but does not duplicate the count.
+
+### Recommendation
+
+Remove the `checkedCount` text from the strip header entirely. Move the count to an accessible tooltip / `aria-label` on the Verified segment.
+
+Concrete change:
+
+1. In `ReadinessColourStrip.tsx`, drop the `{checkedCount && <p>…}` element.
+2. On the Verified fill bar, extend the existing `title` attribute — for the Verified dimension specifically, append the literal count: `"Verified: 0% (No inputs verified)"` / `"Verified: 100% (3 inputs verified)"`. Other dimensions keep their unmodified `Label: NN%` tooltip.
+3. The Verified segment gains a matching `aria-label` carrying the same composite text.
+4. `buildAnalysisHeroViewModel.ts` retains `checkedCount` for the tooltip string; it is no longer rendered as visible text.
+
+This honours Paul's preference ("Do not retain visible header text") while keeping the signal screen-reader and pointer-hover discoverable.
+
+### Files affected
+
+- `src/components/results/analysisHeroV17/ReadinessColourStrip.tsx` — remove visible label, augment Verified segment tooltip + aria-label.
+- `src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts` — keep `checkedCount` selector tests (the VM string is unchanged), but mark them as tooltip-text tests rather than visible-text tests. Update the `p1Fixes.spec.tsx` regex if it relied on rendered text.
+
+---
+
+## Task 3 — Result context: add "depends most on" line
+
+### Data availability map
+
+| Question | Finding |
+|---|---|
+| Which field produces the **result line** today? | `data.recommendation.recommendedOption.label` → "{label} currently leads." Fallback: "No option currently leads." (`buildResultLine` in `buildAnalysisHeroViewModel.ts:130`). |
+| Which field produces the **reason line** today? | `data.confidence.topFragileEdge` (or `m1CoachingTopFragileEdge`). Format: "If {fromLabel} shifts, {alt} could come out ahead." Null when no fragile edge (`buildReasonLine`, line 142). |
+| Is `factor_sensitivity.elasticity` available **per-option**? | **No.** `V2FactorSensitivity` has no `option_id` field. The `factor_sensitivity[]` array is a single global list across the analysis. |
+| Is elasticity available for the **leading option specifically**? | Not per-option. But this is fine — see next row. |
+| What confidence/threshold makes a single dominant factor safe? | PLoT B1 (already shipped) emits a top-level `dominant_factor: { factor_id, factor_label }` on `V2RunResponse`. UI currently consumes it at `useResultsSectionData.ts:1825–1850` with precedence: (1) PLoT `dominant_factor`, (2) M1 coaching `key_drivers.dominant_factor`, (3) legacy heuristic `detectDominantFactorLegacy` (UI-SEM-040, scheduled for removal). Heuristic uses `top1Influence > 0.5` AND `top1/top2 > 2:1`. |
+| Recommended fallback when sparse/ambiguous | Omit the dependency clause entirely. Render only the result line. Never fabricate a factor name. **Legacy heuristic output is explicitly NOT a safe source — implementation must distinguish it from PLoT B1 / M1 sources and omit the dependency line when only the heuristic is available.** |
+
+### Recommendation — structure
+
+```
+Hire a Tech Lead comes out ahead most often.
+The result depends most on Technical Leadership Capacity.
+```
+
+Implementation in `buildAnalysisHeroViewModel.ts`:
+
+1. **Update the result-line copy** from "{label} currently leads." → "{label} comes out ahead most often." This is the Olumi Communication Glossary's preferred phrasing (probabilistic, not categorical) and is already used in row reason copy ("could come out ahead").
+2. **Add a second computed field** `dependencyLine: string | null`. Source from `data.recommendation.dominantFactor` (existing field surfaced from `useResultsSectionData`), restricted to PLoT B1 or M1 origins. If `dominantFactorLabel` is present and passes `safeInterpolatedLabel`, render:
+   ```
+   The result depends most on {label}.
+   ```
+   Otherwise return `null`.
+3. **Move the flip-risk line** out of the Row-0 result context block. It is already mirrored in Row 1's reason copy (the fragile edge surfaces as the top input row when present). The result context becomes: result line + dependency line (when safe). The fragile narrative remains visible immediately below in the input rows.
+
+#### `HeroResultContext.tsx` after change
+
+```tsx
+<section className="rounded-md border p-2.5 flex flex-col gap-1.5">
+  <p className={typography.panelHeader}>{resultLine}</p>
+  {dependencyLine && <p className={typography.panelBody}>{dependencyLine}</p>}
+  {/* metaPills block removed — see Task 4 */}
+</section>
+```
+
+#### Wording rationale
+
+- "depends most on" is dependency framing, grounded by a measured field. "because" is causal framing and would over-claim against M1's current shape. When V5 Phase 3 ships `narrative_summary`, the dependency line can be replaced by the richer causal sentence without breaking the slot.
+- The leading-option `label` is already passed through `safeLabel` (existing helper using `containsBannedTerm`). Apply the same guard to the dominant factor label.
+
+### Files affected
+
+- `src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts` — change `buildResultLine` copy; add `selectDependencyLine` selector; export `dependencyLine: string | null` on `AnalysisHeroVM`.
+- `src/components/results/analysisHeroV17/HeroResultContext.tsx` — render `dependencyLine` between result line and the now-removed pills.
+- `src/components/results/analysisHeroV17/analysisHeroVM.types.ts` — add `dependencyLine` field to interface; reasonLine becomes redundant in result context but is kept on VM as a future slot for V5 Phase 3.
+
+---
+
+## Task 4 — Meta pills removal
+
+### Current state
+
+In `buildAnalysisHeroViewModel.ts:148–198`:
+
+- **Stability pill** always emitted when `stability` is finite. Four bands → "Fragile result" / "Moderate stability" / "Stable result" or "Mostly stable" / "Highly stable".
+- **Evidence pill** always emitted. Three tiers → "Evidence limited" / "Evidence moderate" / "Evidence adequate".
+- **Reflect pill** emitted only when `state === 'reflect'`.
+
+So in the typical case, the result context always renders **two pills** (stability + evidence). They contradict-feel because the user reads "Highly stable" and "Evidence limited" simultaneously — a classic "what does that mean?" pattern that the Footer checks already address with concrete checks ("Sensitive assumption", "Stability limited", etc.).
+
+The Footer checks row (`HeroFooter.tsx`) is the existing home for these signals. Each state has 4 checks plus state-specific hints — stability and evidence are both represented there.
+
+### Co-occurrence in real fixtures
+
+Stability and evidence pills **always co-occur** when their inputs are defined. There is no guard suppressing either. The "Highly stable" + "Evidence limited" pairing is not a fixture artefact — it is the default for any analysis with high stability and a poor evidence tier.
+
+### Downstream usage
+
+- Pills are read by `HeroResultContext.tsx` only.
+- ~13 assertions in `buildAnalysisHeroViewModel.spec.ts` lines 491–560, plus ~7 in `accessibility.spec.tsx`, plus 1 in `p1Fixes.spec.tsx`. No consumer outside the V17 hero folder reads the `metaPills` field.
+
+### Recommendation — clean removal
+
+Full removal, no zombie fields:
+
+- Delete `MetaPill` type from `analysisHeroVM.types.ts`.
+- Delete `metaPills` field from `AnalysisHeroVM`.
+- Delete `selectMetaPills` selector from `buildAnalysisHeroViewModel.ts`.
+- Delete pills block from `HeroResultContext.tsx`.
+- Delete `META_PILL_CLASS` export from `tokens.ts`.
+
+This is the largest single vertical-space win in the brief. Stability and evidence signals remain in `HeroFooter` checks below — no UX regression.
+
+### Files affected
+
+- `src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts`
+- `src/components/results/analysisHeroV17/analysisHeroVM.types.ts`
+- `src/components/results/analysisHeroV17/HeroResultContext.tsx`
+- `src/components/results/analysisHeroV17/tokens.ts`
+- Test surface — see §8.
+
+---
+
+## Task 5 — Key question card: conditional render
+
+### Source logic
+
+`selectKeyQuestion` (`buildAnalysisHeroViewModel.ts:202–261`) has three branches:
+
+1. **`state === 'strong'`** → returns `null` (card hidden).
+2. **`data.confidence.m2DecisionQualityPrompts[0].question` present and glossary-safe** → returns the DQP verbatim plus up to 3 extras from `dqps.slice(1, 4)`.
+3. **Fallback** → category-driven template keyed off `topRow.category`:
+   - `evidence` / `causal` / `risk` → "How confident are you this estimate is realistic?"
+   - `coverage` → "Are the alternatives genuinely different?"
+   - `reflect` → "Could early preference for one route be influencing the framing?"
+   - `ready` → null
+4. **No safe template** → returns `null`.
+
+Chips are always `['High', 'Some', 'Not sure', 'Add note']`. They fire `onPrefillChat(`${question} My answer: ${chip}`)` — chat-composer prefill only. No state is dispatched, no handler beyond prefill exists.
+
+### Frequency
+
+- `m2DecisionQualityPrompts` is populated by the V5 Phase 3 `decision_review` block, which is **not yet wired** on M1. Today, branch (2) virtually never fires; the card lands in branch (3) for almost every decision.
+- The templated questions are by design generic ("How confident are you this estimate is realistic?") — same copy across every decision sharing the same `topRow.category`. Hence "templated, repetitive across decisions".
+
+### Click-behaviour audit
+
+The chips' only side effect is `onPrefillChat`. `onPrefillChat` reads from `useGuidanceStore.getState()._prefillChat(text)` which populates the chat composer text. Paul's "broken on click" report likely means:
+
+- The composer is not visible (chat panel closed) — `chatPrefillAvailable === false`. In this case, `HeroKeyQuestion.tsx` already hides the chip strip (Fix 6, lines 38–55). The text "{question}" still renders but the chips disappear. From the user's perspective the card looks broken because the chips are advertised but cannot be clicked.
+- Or the chip click does fire but visibly nothing happens because the composer is off-screen.
+
+This is a UX failure mode rather than a wiring bug. The fix is to hide the **whole card** when chips cannot meaningfully complete their action, not just the chip strip.
+
+### Recommendation
+
+Tighten the conditional render. Card shows only when all three are true:
+
+1. `data.confidence.m2DecisionQualityPrompts[0]` is genuinely present.
+2. Question passes `containsBannedTerm` glossary check.
+3. `chatPrefillAvailable === true`.
+
+```ts
+// in selectKeyQuestion
+if (state === 'strong') return null
+
+// 1. Real DQP path — only this path gets the card on M1
+const dqp = data?.confidence?.m2DecisionQualityPrompts?.[0]?.question
+if (dqp && !containsBannedTerm(dqp)) {
+  return { text: dqp, extras: dqps.slice(1, 4), chips: [...] }
+}
+
+// 2. Template fallback — REMOVED (return null)
+return null
+```
+
+- Branch (3) (the category template) is removed entirely. The card renders only when V5 Phase 3 supplies a real `decision_quality_prompts[0]`.
+- When hidden on M1, the coaching intent already lives in Row 1's AI action prompt ("Help me check whether the [factor] estimate is realistic"). No regression — templated questions were already generic.
+- When V5 Phase 3 ships, branch (1) fires automatically with real, decision-specific copy. No further code change.
+- Additionally, in `HeroKeyQuestion.tsx`, if `chatPrefillAvailable === false`, return `null` — hide the entire card (not just the chip strip). This removes the "advertised but unclickable" failure mode.
+
+#### Note on chip persistence
+
+Chips do not write to any persistent state. They only call `_prefillChat`. Hiding them costs nothing.
+
+### Files affected
+
+- `src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts` — drop the category-template branch in `selectKeyQuestion`. Replace with `return null` after the DQP branch.
+- `src/components/results/analysisHeroV17/HeroKeyQuestion.tsx` — when `chatPrefillAvailable === false`, return `null` (hide entire card).
+- Test surface — see §8.
+
+---
+
+## Proposed final top-section structure
+
+```
+[Banner — only when orphaned]
+Refresh analysis · Coaching may be out of date              [Run analysis]
+
+[Hero card]
+Strengthen this decision                                       [Actions ▾]
+[four-colour strip — Structure · Evidence · Coverage · Verified, count moved to tooltip]
+
+Hire a Tech Lead comes out ahead most often.
+The result depends most on Technical Leadership Capacity.
+
+[Key question card — hidden on M1; renders when V5 Phase 3 supplies real DQP and chat is open]
+
+Needs your input
+Technical Leadership Capacity      High         ✦ 💬
+Check this first. It could change the result.
+
+[checks + CTA + Also-line]
+```
+
+---
+
+## Vertical-height estimate
+
+Approximate heights based on current DS v5 token sizes (1.5× line-height assumed, 12 px panelMeta, 14 px panelBody, 18 px panelHeader). Numbers are intentionally conservative.
+
+| Block | Current | After |
+|---|---:|---:|
+| Refresh banner (when present) | ~64 px | ~36 px |
+| ReadinessColourStrip header line | ~22 px (title + count) | ~22 px (title only, count in tooltip) |
+| Result line | ~22 px | ~22 px |
+| Reason line (when present) | ~22 px | 0 (moved/removed) |
+| Meta pills row | ~28 px (with gap) | 0 |
+| Dependency line | 0 | ~22 px (when data safe) |
+| Key question card (typical M1) | ~84 px (question + chips + padding) | 0 (hidden until V5 P3) |
+| **Total above "Needs your input"** | **~242 px (typical)** | **~102 px (typical)** |
+
+**Net reduction: ~140 px above the input rows**, ~58% reduction in the top-block height. The cognitive load drop is larger than the pixel count suggests: two non-actionable text pills, a redundant header label, and a generic question card all vanish, leaving two grounded sentences ("X comes out ahead most often. The result depends most on Y.") above the input rows.
+
+---
+
+## V5 Phase 3 substitution notes (forwards-compatibility)
+
+| Slot | M1 today (after this brief) | V5 Phase 3 substitution |
+|---|---|---|
+| Result line | "{label} comes out ahead most often." | Replace with `decision_review.narrative_summary.headline` when present; otherwise keep current copy. |
+| Dependency line | "The result depends most on {dominantFactorLabel}." | Replace with `decision_review.narrative_summary.dependency_clause` (richer phrasing, may include direction/magnitude). |
+| Reason line (currently surfaces in Row 1, not result context) | Fragile-edge templated copy | `decision_review.scenario_contexts[0].narrative` — drop the template entirely. |
+| Key question card | Hidden | Renders automatically when `m2DecisionQualityPrompts[0]` is populated. No code change. |
+| Meta pills | Removed | Replaced by structured evidence blocks in the existing Footer checks — no return of the pill UI. |
+| Refresh banner | Same trigger; slimmer markup | Unchanged. |
+
+Every slot is additive — no V5 Phase 3 field needs the M1 fallback removed before it can render. The V17 hero shape stays stable.
+
+---
+
+## Files affected — consolidated
+
+| File | Change |
+|---|---|
+| `src/components/results/AnalysisOrphanBanner.tsx` | Collapse to single-row strip; drop second `<p>`; switch to `panelMeta` typography; change title to "Refresh analysis". |
+| `src/components/results/analysisHeroV17/ReadinessColourStrip.tsx` | Remove visible `checkedCount` text; extend Verified segment tooltip + aria-label. |
+| `src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts` | Update `buildResultLine` copy; add `selectDependencyLine`; remove `selectMetaPills`; drop category-template branch in `selectKeyQuestion`. |
+| `src/components/results/analysisHeroV17/HeroResultContext.tsx` | Render `dependencyLine`; remove pills block. |
+| `src/components/results/analysisHeroV17/HeroKeyQuestion.tsx` | Hide entire card when `chatPrefillAvailable === false`. |
+| `src/components/results/analysisHeroV17/analysisHeroVM.types.ts` | Add `dependencyLine`; remove `metaPills` and `MetaPill`. |
+| `src/components/results/analysisHeroV17/tokens.ts` | Remove `META_PILL_CLASS` export. |
+
+**Reused existing utilities (no new code required):**
+
+- `safeInterpolatedLabel` / `containsBannedTerm` — `analysisHeroV17/glossaryCheck.ts`
+- `stripEncodingNotation` / `cleanFactorLabel` — `src/components/results/utils/cleanFactorLabel.ts`
+- Dominant-factor selection — already wired in `useResultsSectionData.ts:1825–1850`; expose the existing `dominantFactor` field on `recommendation` for hero VM consumption.
+- `_dispatchAction({ action_type: 'run_analysis', source: 'chip' })` — already used by `AnalysisOrphanBanner` and chip surfaces.
+- Dot-separator glyph (`·`) — already used in `HeroFooter`.
+
+---
+
+## Tests to update / add
+
+### Update (existing assertions to revise)
+
+| File | Tests | Change |
+|---|---|---|
+| `src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx` | `renders when canonical flag is on AND no V5 fact attached`; cross-scenario fact test | Replace "Re-run analysis to attach AI explanations to these results." expectation with "Refresh analysis" + dot-separator + "Coaching may be out of date" presence. Banner is one row. |
+| `src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts` lines 491–560 | All stability-band, evidence-tier, and "evidence thin" anti-drift tests | Delete tests asserting `metaPills` contents (entire `metaPills` selector removed). |
+| `src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts` lines 314–360 | "No inputs verified" / "1 input verified" / "N inputs verified" tests | Convert from "rendered text" expectation to "tooltip / aria-label text on Verified segment" expectation. |
+| `src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts` lines 363–448 | Key-question selection tests | Delete the category-template tests (`templates from top row for evidence category`, `risk-category top row → same factor/estimate template`). Keep the DQP-verbatim test and the banned-term-fallback test (latter now asserts the card is hidden when DQP fails the gate). Update `hides Key-question card when no DQP and no rows` to "hides Key-question card on M1 fallback (no DQP)". |
+| `src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts` lines 453–488 | Result line + reason line tests | Update result-line expectation to "{label} comes out ahead most often." Keep reason-line "fragile edge present → narrative" assertion but expect rendering in Row 1, not result context. |
+| `src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx` lines ~185–230 | Stability label binding tests | Delete (pills no longer exist). The Fragile signal still surfaces via the Footer check. |
+| `src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx` | Chat-closed key-question test | Update to expect the entire card hidden (not just chips) when `chatPrefillAvailable === false`. |
+| `src/components/results/analysisHeroV17/__tests__/p1Fixes.spec.tsx` | "No inputs verified" regex lock | Replace visible-text assertion with tooltip/aria-label assertion. |
+
+### Add (new assertions)
+
+| Coverage area | New test |
+|---|---|
+| Dependency line — happy path | Given `dominantFactor` from safe source (PLoT B1 or M1), hero renders "The result depends most on Technical Leadership Capacity." below the result line. |
+| Dependency line — safe fallback | When `dominantFactor` is undefined, the dependency line is omitted (no fabricated factor name). |
+| Dependency line — legacy heuristic excluded | When the only dominant-factor source is the legacy heuristic, the dependency line is omitted. |
+| Dependency line — banned-term gate | When `dominantFactor.factor_label` contains a banned glossary term, dependency line is omitted. |
+| Dependency line — encoding strip | When `factor_label = 'Tech Lead Capacity (0/1)'`, rendered text reads "Tech Lead Capacity" (encoding stripped via existing `stripEncodingNotation`). |
+| Meta pills absent | The result context section never contains any element with the pill class or stability/evidence labels. |
+| Key question card hidden on templated fallback | Given no `m2DecisionQualityPrompts`, the hero does not render any element with `data-testid="hero-v17-key-question-text"`. |
+| Key question card hidden when chat closed | Given a real DQP but `chatPrefillAvailable === false`, the entire card is hidden. |
+| Refresh banner scope | Banner only renders inside ResultsBody when `showOrphanBanner === true`. |
+| Verified-count tooltip | The Verified segment in `ReadinessColourStrip` carries both percentage and literal count in its `title` and `aria-label`. |
+
+---
+
+## Acceptance criteria (Paul-verifiable on staging)
+
+With `analysisHeroV17` flag ON and an orphaned-analysis fixture:
+
+1. The refresh banner renders as a single row: `Refresh analysis · Coaching may be out of date` followed by a `Run analysis` button. No body copy line below the title.
+2. The hero header reads "Strengthen this decision" with no "No inputs verified" text on the same row. Hovering the Verified segment of the strip shows the count in a tooltip.
+3. Above the input rows, exactly two sentences render: a result line ending "...comes out ahead most often." and a dependency line of the form "The result depends most on {factor}." The dependency line is absent when no safe dominant-factor source is supplied.
+4. No "Highly stable", "Evidence limited", "Stable result", "Mostly stable", "Fragile result", or other pill copy appears in the result context block. Footer checks below still surface stability and evidence signals.
+5. The Key question card does not render in M1 fallback mode (templated questions removed). The card renders automatically when a real `decision_quality_prompts[0]` is provided via V5 Phase 3 fixture AND chat is open.
+6. With chat panel closed (`chatPrefillAvailable === false`), the Key question card is fully hidden — neither chips nor question text appear.
+7. Vertical height of the block above "Needs your input" drops by ≥ 100 px on a typical analysis (measured on a desktop viewport at default zoom).
+8. All hero tests pass (`npx vitest run --changed --bail=1`). Glossary scanner test continues to pass against the dependency-line copy.
+9. Typecheck passes (`npm run typecheck`).
+10. Production flag default is unchanged (`analysisHeroV17` off-by-default).
+
+---
+
+## Verification (during implementation, not in this brief)
+
+When the implementation brief is authorised:
+
+```bash
+# Tier 1 smoke (after the change)
+npm run typecheck
+npx vitest run --changed --bail=1
+
+# Targeted vitest pass over hero tests
+npx vitest run src/components/results/analysisHeroV17/__tests__ \
+              src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx \
+              --reporter=verbose
+
+# Visual verification (staging or local dev with flag on)
+# 1. localStorage.setItem('feature.analysisHeroV17', 'true')
+# 2. Load a scenario that produces an orphaned plot result and a normal result.
+# 3. Confirm acceptance criteria 1–7.
+```

--- a/src/components/results/AnalysisHeroV17.tsx
+++ b/src/components/results/AnalysisHeroV17.tsx
@@ -247,8 +247,7 @@ export const AnalysisHeroV17 = memo(function AnalysisHeroV17({
 
         <HeroResultContext
           resultLine={heroVm.resultLine}
-          reasonLine={heroVm.reasonLine}
-          metaPills={heroVm.metaPills}
+          dependencyLine={heroVm.dependencyLine}
         />
 
         {heroVm.keyQuestion && (

--- a/src/components/results/AnalysisOrphanBanner.tsx
+++ b/src/components/results/AnalysisOrphanBanner.tsx
@@ -37,11 +37,16 @@ export function AnalysisOrphanBanner() {
 
   if (!showOrphanBanner) return null
 
+  // Banner height note: the WCAG 2.1 AA touch-target rule (44×44px) sets
+  // the floor — `min-h-[44px]` on the button drives the row height. The
+  // container drops vertical padding to let that 44px be the visible
+  // total, instead of stacking extra padding around it. Horizontal
+  // padding (`px-3`) remains so text and button don't crowd the edges.
   return (
     <div
       role="status"
       data-testid="analysis-orphan-banner"
-      className="flex items-center gap-3 rounded-lg border border-panel-border bg-panel px-3 py-2"
+      className="flex items-center gap-3 rounded-lg border border-panel-border bg-panel px-3"
     >
       <p className={`${typography.panelMeta} text-text-light flex-1 min-w-0`}>
         <span className="text-text-body">Refresh analysis</span>
@@ -54,7 +59,7 @@ export function AnalysisOrphanBanner() {
         disabled={!dispatchAction}
         data-testid="analysis-orphan-banner-run"
         className={[
-          'shrink-0 rounded-full px-4 py-2 min-h-[44px]',
+          'shrink-0 rounded-full px-4 py-1.5 min-h-[44px]',
           'bg-primary text-text-on-color',
           'hover:opacity-90 active:opacity-80',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-2',

--- a/src/components/results/AnalysisOrphanBanner.tsx
+++ b/src/components/results/AnalysisOrphanBanner.tsx
@@ -41,16 +41,13 @@ export function AnalysisOrphanBanner() {
     <div
       role="status"
       data-testid="analysis-orphan-banner"
-      className="flex items-start gap-3 rounded-lg border border-panel-border bg-panel p-3"
+      className="flex items-center gap-3 rounded-lg border border-panel-border bg-panel px-3 py-2"
     >
-      <div className="flex-1">
-        <p className={`${typography.body} text-text-body`}>
-          Analysis needs refresh
-        </p>
-        <p className={`${typography.bodySmall} text-text-light mt-1`}>
-          Re-run analysis to attach AI explanations to these results.
-        </p>
-      </div>
+      <p className={`${typography.panelMeta} text-text-light flex-1 min-w-0`}>
+        <span className="text-text-body">Refresh analysis</span>
+        {' · '}
+        Coaching may be out of date
+      </p>
       <button
         type="button"
         onClick={handleRunAnalysis}

--- a/src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx
+++ b/src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx
@@ -48,8 +48,14 @@ describe('AnalysisOrphanBanner', () => {
   it('renders when canonical flag is on AND no V5 fact attached', () => {
     render(<AnalysisOrphanBanner />)
     expect(screen.getByTestId('analysis-orphan-banner')).toBeInTheDocument()
-    expect(screen.getByText('Analysis needs refresh')).toBeInTheDocument()
+    // Single-row strip: action-led title + dot-separator + secondary copy.
+    expect(screen.getByText('Refresh analysis')).toBeInTheDocument()
+    expect(screen.getByText(/Coaching may be out of date/)).toBeInTheDocument()
+    const banner = screen.getByTestId('analysis-orphan-banner')
+    expect(banner.textContent ?? '').toMatch(/Refresh analysis\s*·\s*Coaching may be out of date/)
     expect(screen.getByTestId('analysis-orphan-banner-run')).toBeInTheDocument()
+    // Slimmed copy — the legacy second sentence is gone.
+    expect(banner.textContent ?? '').not.toMatch(/Re-run analysis to attach/)
   })
 
   it('does NOT render when canonical flag is off (direct_plot_legacy, not orphan)', () => {

--- a/src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx
+++ b/src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx
@@ -58,6 +58,21 @@ describe('AnalysisOrphanBanner', () => {
     expect(banner.textContent ?? '').not.toMatch(/Re-run analysis to attach/)
   })
 
+  it('container has no vertical padding — row height is driven by the 44px button (WCAG floor)', () => {
+    render(<AnalysisOrphanBanner />)
+    const banner = screen.getByTestId('analysis-orphan-banner')
+    // No py-* / pt-* / pb-* / p-* on the container — only px-* allowed.
+    // This is the structural assertion behind the slim-row visual goal:
+    // without container vertical padding, the visible row floors at the
+    // button's min-h-[44px] touch target rather than stacking padding
+    // around it.
+    expect(banner.className).not.toMatch(/(^|\s)(p-|py-|pt-|pb-)\d/)
+    expect(banner.className).toMatch(/(^|\s)px-3(\s|$)/)
+    // Button must still meet the 44px WCAG touch target.
+    const button = screen.getByTestId('analysis-orphan-banner-run')
+    expect(button.className).toMatch(/min-h-\[44px\]/)
+  })
+
   it('does NOT render when canonical flag is off (direct_plot_legacy, not orphan)', () => {
     mockIsV5CanonicalAnalysisEnabled.mockReturnValue(false)
     render(<AnalysisOrphanBanner />)

--- a/src/components/results/analysisHeroV17/HeroKeyQuestion.tsx
+++ b/src/components/results/analysisHeroV17/HeroKeyQuestion.tsx
@@ -3,8 +3,15 @@
  *
  * The question text is glossary-scanned upstream in
  * `buildAnalysisHeroViewModel.selectKeyQuestion`. If no safe grounded
- * question is available, this component does not render — the orchestrator
- * passes `null` and the caller hides the card entirely.
+ * question is available, the orchestrator passes `null` and the caller
+ * hides the card entirely.
+ *
+ * Render rule (2026-05-21): the card shows only when a real DQP is
+ * available AND chat is open (chatPrefillAvailable === true). When chat
+ * is closed, the chips can't meaningfully complete their action, so the
+ * whole card hides — not just the chip strip. This removes the
+ * "advertised but unclickable" failure mode the dangling question text
+ * previously created.
  */
 
 import { useState } from 'react'
@@ -14,12 +21,13 @@ import type { KeyQuestion } from './analysisHeroVM.types'
 interface Props {
   keyQuestion: KeyQuestion
   onPrefillChat: (text: string) => void
-  /** When false, the answer chips render as disabled. */
+  /** When false, the entire card is hidden. */
   chatPrefillAvailable: boolean
 }
 
 export function HeroKeyQuestion({ keyQuestion, onPrefillChat, chatPrefillAvailable }: Props) {
   const [expanded, setExpanded] = useState(false)
+  if (!chatPrefillAvailable) return null
   return (
     <section
       className="rounded-md border border-panel-border p-2.5 flex flex-col gap-1.5"
@@ -48,10 +56,10 @@ export function HeroKeyQuestion({ keyQuestion, onPrefillChat, chatPrefillAvailab
       >
         {keyQuestion.text}
       </p>
-      {/* (Fix 6) Chips are prefill-only. When chat is unavailable, hide
-          the entire chip strip rather than render dead buttons. The
-          key-question text still renders so the user can read it. */}
-      {chatPrefillAvailable && keyQuestion.chips.length > 0 && (
+      {/* Chips are prefill-only. The whole card is hidden upstream when
+          chat is unavailable (see the early return above), so chips are
+          always meaningfully clickable when this block renders. */}
+      {keyQuestion.chips.length > 0 && (
         <div className="flex items-center gap-1 flex-wrap" data-testid="hero-v17-key-question-chips">
           {keyQuestion.chips.map(chip => (
             <button

--- a/src/components/results/analysisHeroV17/HeroResultContext.tsx
+++ b/src/components/results/analysisHeroV17/HeroResultContext.tsx
@@ -1,22 +1,26 @@
 /**
- * HeroResultContext — result line + reason line + meta pills.
+ * HeroResultContext — result line + dependency line.
  *
- * Per docs/investigations/analysis-hero-v17.md §4.1. The "Result fragile"
- * pill is bound to stability < 0.5 upstream in buildAnalysisHeroViewModel
- * (anti-drift test in accessibility.spec.tsx).
+ * Per docs/investigations/analysis-hero-v17-top-section.md:
+ * - The result line uses "comes out ahead most often" framing (Olumi
+ *   communication glossary — probabilistic, not categorical).
+ * - The dependency line surfaces below the result line when a safe
+ *   dominant-factor source is available. Built upstream in
+ *   `buildAnalysisHeroViewModel.buildDependencyLine`; null hides the line.
+ * - The flip-risk reason line and the meta pills (stability + evidence
+ *   bands) were removed (2026-05-21). Flip-risk content already surfaces
+ *   in Row 1 of the input rows below; stability and evidence signals
+ *   remain in HeroFooter checks.
  */
 
 import { typography } from '@/styles/typography'
-import type { MetaPill } from './analysisHeroVM.types'
-import { META_PILL_CLASS } from './tokens'
 
 interface Props {
   resultLine: string
-  reasonLine: string | null
-  metaPills: MetaPill[]
+  dependencyLine: string | null
 }
 
-export function HeroResultContext({ resultLine, reasonLine, metaPills }: Props) {
+export function HeroResultContext({ resultLine, dependencyLine }: Props) {
   return (
     <section
       className="rounded-md border border-panel-border p-2.5 flex flex-col gap-1.5"
@@ -24,18 +28,13 @@ export function HeroResultContext({ resultLine, reasonLine, metaPills }: Props) 
       data-testid="hero-v17-result-context"
     >
       <p className={`${typography.panelHeader} text-text-header`}>{resultLine}</p>
-      {reasonLine && <p className={`${typography.panelBody} text-text-body`}>{reasonLine}</p>}
-      {metaPills.length > 0 && (
-        <div className="flex items-center gap-1.5 flex-wrap">
-          {metaPills.map(p => (
-            <span
-              key={p.label}
-              className={`inline-flex items-center px-2 py-0.5 rounded-full border ${typography.panelMeta} bg-transparent ${META_PILL_CLASS[p.tone]}`}
-            >
-              {p.label}
-            </span>
-          ))}
-        </div>
+      {dependencyLine && (
+        <p
+          className={`${typography.panelBody} text-text-body`}
+          data-testid="hero-v17-dependency-line"
+        >
+          {dependencyLine}
+        </p>
       )}
     </section>
   )

--- a/src/components/results/analysisHeroV17/ReadinessColourStrip.tsx
+++ b/src/components/results/analysisHeroV17/ReadinessColourStrip.tsx
@@ -4,6 +4,11 @@
  * Per docs/investigations/analysis-hero-v17.md §4.2. v1 segments are
  * Structure / Evidence / Coverage / Verified; "User input" is the future
  * label once per-factor provenance is plumbed.
+ *
+ * `checkedCount` (e.g. "No inputs verified" / "3 inputs verified") is
+ * surfaced on the Verified segment's tooltip + aria-label only — never
+ * rendered as visible text (see docs/investigations/analysis-hero-v17-top-section.md
+ * task 2).
  */
 
 import { typography } from '@/styles/typography'
@@ -20,24 +25,29 @@ export function ReadinessColourStrip({ checkedCount, dimensions }: Props) {
     <div className="flex flex-col gap-1.5" data-testid="hero-v17-strip">
       <div className="flex items-baseline justify-between gap-2">
         <p className={`${typography.panelHeader} text-text-header`}>Strengthen this decision</p>
-        {checkedCount && (
-          <p className={`${typography.panelMeta} text-text-light truncate`}>{checkedCount}</p>
-        )}
       </div>
       <div className="grid grid-cols-4 gap-1" role="group" aria-label="Decision readiness dimensions">
-        {dimensions.map(d => (
-          <div
-            key={d.label}
-            className="h-1.5 rounded-full bg-panel-hover overflow-hidden"
-            title={`${d.label}: ${Math.round(d.value * 100)}%`}
-            data-testid={`strip-${d.label.toLowerCase()}`}
-          >
+        {dimensions.map(d => {
+          const pct = Math.round(d.value * 100)
+          const isVerified = d.label === 'Verified'
+          const composite = isVerified && checkedCount
+            ? `${d.label}: ${pct}% (${checkedCount})`
+            : `${d.label}: ${pct}%`
+          return (
             <div
-              className={`h-full rounded-full ${STRIP_FILL_CLASS[d.token]}`}
-              style={{ width: `${Math.round(d.value * 100)}%` }}
-            />
-          </div>
-        ))}
+              key={d.label}
+              className="h-1.5 rounded-full bg-panel-hover overflow-hidden"
+              title={composite}
+              aria-label={isVerified ? composite : undefined}
+              data-testid={`strip-${d.label.toLowerCase()}`}
+            >
+              <div
+                className={`h-full rounded-full ${STRIP_FILL_CLASS[d.token]}`}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          )
+        })}
       </div>
       <div className="grid grid-cols-4 gap-1" aria-hidden="true">
         {dimensions.map(d => (

--- a/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
@@ -1,17 +1,15 @@
 /**
- * AnalysisHeroV17 — accessibility + "Fragile" label binding.
+ * AnalysisHeroV17 — accessibility + post-pill-removal anti-drift.
  *
  * Per docs/brief-analysis-hero-v17-implementation.md §3 step 8 + §13.2:
  *   - Every IconBtn has an accessible name and a tooltip
  *   - +3 toggles carry correct aria-expanded
  *   - Actions menu has role=menu / role=menuitem
- *   - "Result fragile" pill is bound to stability < 0.5 only
  *
- * Per docs/investigations/analysis-hero-v17.md §12.3:
- *   - The string "Result fragile" must only render when stability is
- *     numeric AND < 0.5. Above that, the appropriate band label renders
- *     (Result moderate / Stable result / Highly stable).
- *   - When stability is null/NaN, no stability-band pill renders at all.
+ * Per docs/investigations/analysis-hero-v17-top-section.md task 4:
+ *   - Stability/evidence meta pills were removed from the result-context
+ *     block. This file's "Meta-pill removal anti-drift" describe block
+ *     guards against any pill copy returning to that section.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -179,77 +177,64 @@ describe('AnalysisHeroV17 — accessibility', () => {
   })
 })
 
-// ── "Fragile" label binding (investigation §12.3) ──────────────────────────
+// ── Meta-pill removal anti-drift (2026-05-21) ─────────────────────────────
+//
+// The stability and evidence pills used to render inside the result-context
+// block. They were removed because they were non-actionable, frequently
+// felt contradictory ("Highly stable" + "Evidence limited"), and the same
+// signals already surface in the Footer checks below. See
+// docs/investigations/analysis-hero-v17-top-section.md task 4.
+//
+// This describe block now guards against the pill copy ever returning to
+// the result context.
 
-describe('AnalysisHeroV17 — "Fragile" label binding to stability', () => {
-  function findPill(label: string): HTMLElement | null {
-    // Pills render inside hero-v17-result-context. Search there for the
-    // exact text.
+describe('AnalysisHeroV17 — result-context pill copy never returns (post-removal anti-drift)', () => {
+  function resultContextText(): string {
     const ctx = screen.queryByTestId('hero-v17-result-context')
-    if (!ctx) return null
-    const candidates = ctx.querySelectorAll('span')
-    for (const c of Array.from(candidates)) {
-      if (c.textContent === label) return c as HTMLElement
-    }
-    return null
+    return ctx?.textContent ?? ''
   }
 
-  // Pill labels normalised in Fix 2:
-  //   "Result fragile"  → "Fragile result"
-  //   "Result moderate" → "Moderate stability"
-  //   "Stable result"   unchanged
-  //   "Highly stable"   unchanged
+  const PILL_LABELS = [
+    'Fragile result',
+    'Moderate stability',
+    'Stable result',
+    'Mostly stable',
+    'Highly stable',
+    'Evidence limited',
+    'Evidence moderate',
+    'Evidence adequate',
+    'Reflective check',
+    // Legacy labels that were removed in earlier passes — still guarded.
+    'Result fragile',
+    'Evidence thin',
+  ]
 
-  it('stability 0.4 → "Fragile result" pill renders with danger tone', () => {
+  it.each([0.0, 0.25, 0.4, 0.5, 0.6, 0.7, 0.75, 0.85, 0.9, 1])(
+    'stability %s → no pill copy in result context',
+    (stability) => {
+      const { unmount } = render(
+        <AnalysisHeroV17 data={makeData({ stability })} vm={makeVm()} fragileEdgeCount={0} />,
+      )
+      const text = resultContextText()
+      for (const label of PILL_LABELS) {
+        expect(text).not.toContain(label)
+      }
+      unmount()
+    },
+  )
+
+  it('result context only contains the result line (no pills, no flip-risk reason)', () => {
     render(<AnalysisHeroV17 data={makeData({ stability: 0.4 })} vm={makeVm()} fragileEdgeCount={0} />)
-    const pill = findPill('Fragile result')
-    expect(pill).toBeTruthy()
-    expect(pill!.className).toContain('text-danger')
-  })
-
-  it('stability 0.5 exactly → NOT fragile (boundary)', () => {
-    render(<AnalysisHeroV17 data={makeData({ stability: 0.5 })} vm={makeVm()} fragileEdgeCount={0} />)
-    expect(findPill('Fragile result')).toBeNull()
-    expect(findPill('Moderate stability')).toBeTruthy()
-  })
-
-  it('stability 0.7 → "Stable result"', () => {
-    render(<AnalysisHeroV17 data={makeData({ stability: 0.7 })} vm={makeVm()} fragileEdgeCount={0} />)
-    expect(findPill('Fragile result')).toBeNull()
-    expect(findPill('Stable result')).toBeTruthy()
-  })
-
-  it('stability 0.9 → "Highly stable"', () => {
-    render(<AnalysisHeroV17 data={makeData({ stability: 0.9 })} vm={makeVm()} fragileEdgeCount={0} />)
-    expect(findPill('Fragile result')).toBeNull()
-    expect(findPill('Highly stable')).toBeTruthy()
-  })
-
-  it('stability missing → no stability-band pill renders at all', () => {
-    render(<AnalysisHeroV17 data={makeData({ stability: undefined })} vm={makeVm()} fragileEdgeCount={0} />)
-    expect(findPill('Fragile result')).toBeNull()
-    expect(findPill('Moderate stability')).toBeNull()
-    expect(findPill('Stable result')).toBeNull()
-    expect(findPill('Highly stable')).toBeNull()
-  })
-
-  it('"Fragile result" copy NEVER renders when stability >= 0.5 (anti-drift)', () => {
-    for (const stability of [0.5, 0.6, 0.7, 0.85, 0.9, 1]) {
-      const { container, unmount } = render(
-        <AnalysisHeroV17 data={makeData({ stability })} vm={makeVm()} fragileEdgeCount={0} />,
-      )
-      expect(container.textContent ?? '').not.toContain('Fragile result')
-      unmount()
-    }
-  })
-
-  it('Fix-2 anti-drift: the legacy "Result fragile" copy never appears at any stability', () => {
-    for (const stability of [0.0, 0.25, 0.49, 0.5, 0.7, 0.9, 1]) {
-      const { container, unmount } = render(
-        <AnalysisHeroV17 data={makeData({ stability })} vm={makeVm()} fragileEdgeCount={0} />,
-      )
-      expect(container.textContent ?? '').not.toContain('Result fragile')
-      unmount()
+    const ctx = screen.getByTestId('hero-v17-result-context')
+    // The result-line text is present.
+    expect(ctx.textContent ?? '').toMatch(/comes out ahead/)
+    // No pill elements — the previous markup nested span pills inside the section.
+    const spans = ctx.querySelectorAll('span')
+    for (const s of Array.from(spans)) {
+      const t = s.textContent ?? ''
+      for (const label of PILL_LABELS) {
+        expect(t).not.toBe(label)
+      }
     }
   })
 })

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -107,14 +107,33 @@ function makeData(overrides: {
   } as ResultsSectionDataReturn
 }
 
-/** Build a DriverItem stub with the influence corroboration field populated. */
-function makeDriver(factorKey: string, factorLabel: string, normalisedInfluence: number): DriverItem {
+/**
+ * Build a DriverItem stub with the influence corroboration fields populated.
+ *
+ * In real data (`useResultsSectionData.computeNormalisedInfluences`) the
+ * top driver always has `normalisedInfluence === 1.0` when any real
+ * elasticity exists. Tests should respect that invariant — pass realistic
+ * ratios (top1=1.0, top2 < 1.0 reflecting the actual rank-1 vs rank-2
+ * elasticity gap) rather than arbitrary values that real normalisation
+ * could not produce.
+ *
+ * `influenceScore` (optional in DriverItem) is the absolute ISL structural
+ * causal influence on a 0–1 scale; the dependency-line gate prefers it
+ * when present.
+ */
+function makeDriver(
+  factorKey: string,
+  factorLabel: string,
+  normalisedInfluence: number,
+  options: { rank?: number; influenceScore?: number } = {},
+): DriverItem {
   return {
     factorKey,
     factorLabel,
     rawElasticity: normalisedInfluence,
     normalisedInfluence,
-    rank: 1,
+    influenceScore: options.influenceScore,
+    rank: options.rank ?? 1,
     semanticLabel: 'biggest',
     canFocus: true,
   } as DriverItem
@@ -538,22 +557,59 @@ describe('buildAnalysisHeroViewModel', () => {
     // `data.drivers.dominantFactor*`, which the hero deliberately does not
     // read.
     //
-    // Three additional gates (2026-05-21 review):
+    // Gates (rewritten 2026-05-21 after review-feedback round 2):
     //  1. dominantFactorId + dominantFactorLabel both populated
-    //  2. matching driver in data.drivers.drivers[] has normalisedInfluence >= 0.5
-    //     (corroborates against M1 emissions without confidence + tie cases)
-    //  3. cleaned label passes the glossary banned-term gate
+    //  2. named factor is the RANK-1 driver in data.drivers.drivers[]
+    //  3. Dominance check:
+    //       - influenceScore >= 0.5 (absolute) when present, OR
+    //       - top1/top2 normalisedInfluence ratio >= 2.0 (relative gap)
+    //  4. cleaned label passes the glossary banned-term gate
+    //
+    // **Important invariant**: in real data
+    // (`useResultsSectionData.computeNormalisedInfluences`) the top driver
+    // ALWAYS has `normalisedInfluence === 1.0` when any real elasticity
+    // exists. Tests below honour that invariant — top1=1.0, top2 in (0..1]
+    // expresses the actual rank-1-vs-rank-2 gap.
 
-    it('renders "The result depends most on {factor}." when dominantFactor matches a driver with influence >= 0.5', () => {
+    it('renders dependency line when influenceScore >= 0.5 (absolute-scale dominance)', () => {
       const data = makeData({
         winnerLabel: 'Tech Lead',
         stability: 0.7,
-        drivers: [makeDriver('n_lead', 'Technical Leadership Capacity', 0.62)],
+        drivers: [
+          makeDriver('n_lead', 'Technical Leadership Capacity', 1.0, { rank: 1, influenceScore: 0.7 }),
+          makeDriver('n_other', 'Other', 0.4, { rank: 2, influenceScore: 0.2 }),
+        ],
       })
       ;(data.recommendation as any).dominantFactorId = 'n_lead'
       ;(data.recommendation as any).dominantFactorLabel = 'Technical Leadership Capacity'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
       expect(vm.dependencyLine).toBe('The result depends most on Technical Leadership Capacity.')
+    })
+
+    it('renders dependency line when influenceScore is absent and top1/top2 normalisedInfluence ratio >= 2.0', () => {
+      // No influenceScore → falls back to ratio gate. top1=1.0, top2=0.4 → ratio 2.5.
+      const data = makeData({
+        stability: 0.7,
+        drivers: [
+          makeDriver('n_lead', 'Tech Lead', 1.0, { rank: 1 }),
+          makeDriver('n_other', 'Other', 0.4, { rank: 2 }),
+        ],
+      })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Tech Lead.')
+    })
+
+    it('renders when there is only ONE driver with non-zero influence (no top-2 to compare against)', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_lead', 'Tech Lead', 1.0, { rank: 1 })],
+      })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Tech Lead.')
     })
 
     it('omits the dependency line when no dominantFactor is supplied (no fabrication)', () => {
@@ -565,20 +621,20 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.dependencyLine).toBeNull()
     })
 
-    it('omits the dependency line when dominantFactorId is present but label is missing', () => {
+    it('omits when dominantFactorId is present but label is missing', () => {
       const data = makeData({
         stability: 0.7,
-        drivers: [makeDriver('n_lead', 'Tech Lead', 0.7)],
+        drivers: [makeDriver('n_lead', 'Tech Lead', 1.0, { rank: 1, influenceScore: 0.7 })],
       })
       ;(data.recommendation as any).dominantFactorId = 'n_lead'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
       expect(vm.dependencyLine).toBeNull()
     })
 
-    it('omits the dependency line when the factor label contains a banned glossary term', () => {
+    it('omits when the factor label contains a banned glossary term', () => {
       const data = makeData({
         stability: 0.7,
-        drivers: [makeDriver('n_w', 'the winning capacity', 0.7)],
+        drivers: [makeDriver('n_w', 'the winning capacity', 1.0, { rank: 1, influenceScore: 0.7 })],
       })
       ;(data.recommendation as any).dominantFactorId = 'n_w'
       ;(data.recommendation as any).dominantFactorLabel = 'the winning capacity'
@@ -589,7 +645,7 @@ describe('buildAnalysisHeroViewModel', () => {
     it('strips encoding notation from the factor label before rendering', () => {
       const data = makeData({
         stability: 0.7,
-        drivers: [makeDriver('n_lead', 'Tech Lead Capacity', 0.7)],
+        drivers: [makeDriver('n_lead', 'Tech Lead Capacity', 1.0, { rank: 1, influenceScore: 0.7 })],
       })
       ;(data.recommendation as any).dominantFactorId = 'n_lead'
       ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead Capacity (0/1)'
@@ -597,53 +653,192 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.dependencyLine).toBe('The result depends most on Tech Lead Capacity.')
     })
 
-    it('omits the dependency line when the matching driver has low influence (<0.5) — suppresses M1 emissions without confidence', () => {
-      const data = makeData({
-        stability: 0.7,
-        drivers: [makeDriver('n_lead', 'Tech Lead', 0.45)],
-      })
-      ;(data.recommendation as any).dominantFactorId = 'n_lead'
-      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
-      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
-      expect(vm.dependencyLine).toBeNull()
-    })
-
-    it('omits the dependency line when no driver matches the dominantFactorId (stale or inconsistent state)', () => {
-      const data = makeData({
-        stability: 0.7,
-        drivers: [makeDriver('n_other', 'Other Factor', 0.9)],
-      })
-      ;(data.recommendation as any).dominantFactorId = 'n_lead'
-      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
-      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
-      expect(vm.dependencyLine).toBeNull()
-    })
-
-    it('omits the dependency line in a tie (neither top driver crosses 0.5)', () => {
+    it('omits when the rank-1 driver has influenceScore < 0.5 (M1 emission without genuine dominance)', () => {
       const data = makeData({
         stability: 0.7,
         drivers: [
-          makeDriver('n_a', 'Factor A', 0.48),
-          makeDriver('n_b', 'Factor B', 0.46),
+          makeDriver('n_lead', 'Tech Lead', 1.0, { rank: 1, influenceScore: 0.3 }),
+          makeDriver('n_other', 'Other', 0.95, { rank: 2, influenceScore: 0.28 }),
         ],
       })
-      // Even if recommendation names one of them as dominant, the
-      // 0.5 corroboration floor isn't met → omit.
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
+    })
+
+    it('omits in a tie: top1=1.0 and top2=0.95 → ratio 1.05 (< 2.0), no influenceScore', () => {
+      // Realistic near-tie shape: normaliser always sets top1=1.0, so the
+      // tie signal lives in how close top2 is to top1.
+      const data = makeData({
+        stability: 0.7,
+        drivers: [
+          makeDriver('n_a', 'Factor A', 1.0, { rank: 1 }),
+          makeDriver('n_b', 'Factor B', 0.95, { rank: 2 }),
+        ],
+      })
       ;(data.recommendation as any).dominantFactorId = 'n_a'
       ;(data.recommendation as any).dominantFactorLabel = 'Factor A'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
       expect(vm.dependencyLine).toBeNull()
     })
 
-    it('renders at the exact 0.5 boundary (>= 0.5 is enough)', () => {
+    it('omits when dominantFactorId does not match the rank-1 driver (inconsistent state)', () => {
       const data = makeData({
         stability: 0.7,
-        drivers: [makeDriver('n_lead', 'Tech Lead', 0.5)],
+        drivers: [
+          makeDriver('n_other', 'Other Factor', 1.0, { rank: 1, influenceScore: 0.9 }),
+          makeDriver('n_lead', 'Tech Lead', 0.3, { rank: 2, influenceScore: 0.2 }),
+        ],
+      })
+      // Recommendation claims n_lead is dominant but the rank-1 driver is n_other.
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
+    })
+
+    it('renders at the influenceScore 0.5 boundary (>= 0.5 is enough)', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_lead', 'Tech Lead', 1.0, { rank: 1, influenceScore: 0.5 })],
       })
       ;(data.recommendation as any).dominantFactorId = 'n_lead'
       ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
       expect(vm.dependencyLine).toBe('The result depends most on Tech Lead.')
+    })
+
+    it('renders at the ratio 2.0 boundary (top1=1.0, top2=0.5) when influenceScore is absent', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [
+          makeDriver('n_lead', 'Tech Lead', 1.0, { rank: 1 }),
+          makeDriver('n_other', 'Other', 0.5, { rank: 2 }),
+        ],
+      })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Tech Lead.')
+    })
+
+    it('omits just below the ratio 2.0 boundary (top1=1.0, top2=0.51 → ratio ~1.96)', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [
+          makeDriver('n_lead', 'Tech Lead', 1.0, { rank: 1 }),
+          makeDriver('n_other', 'Other', 0.51, { rank: 2 }),
+        ],
+      })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
+    })
+
+    // ── Integration-style: drivers built via real normalisation ─────────
+    //
+    // The unit tests above set normalisedInfluence values by hand. The
+    // helpers below match the production formula
+    // (`useResultsSectionData.computeNormalisedInfluences`) exactly, so
+    // these scenarios prove the gate behaves correctly against the
+    // realistic data shape (top1 always 1.0) — not just against arbitrary
+    // numbers a test author might invent.
+
+    /**
+     * Mirror of `computeNormalisedInfluences` at
+     * `useResultsSectionData.ts:420–446`. If any of these constants drift,
+     * update both here and the test that asserts the invariants below.
+     */
+    function buildDriversFromRawElasticities(
+      raws: Array<{ id: string; label: string; elasticity: number; influenceScore?: number }>,
+    ): DriverItem[] {
+      const abs = raws.map(r => Math.abs(r.elasticity))
+      const actualMax = Math.max(...abs)
+      const sorted = [...raws].sort((a, b) => Math.abs(b.elasticity) - Math.abs(a.elasticity))
+      return sorted.map((r, i) => {
+        const ni = actualMax < 0.001 ? 0 : Math.min(1, Math.abs(r.elasticity) / actualMax)
+        return {
+          factorKey: r.id,
+          factorLabel: r.label,
+          rawElasticity: r.elasticity,
+          normalisedInfluence: ni,
+          influenceScore: r.influenceScore,
+          rank: i + 1,
+          semanticLabel: i === 0 ? 'biggest' : ni >= 0.5 ? 'strong' : ni >= 0.2 ? 'moderate' : 'minor',
+          canFocus: true,
+        } as DriverItem
+      })
+    }
+
+    it('integration: real normalisation invariants — top driver always 1.0 when elasticity is non-zero', () => {
+      const drivers = buildDriversFromRawElasticities([
+        { id: 'n_a', label: 'A', elasticity: 0.8 },
+        { id: 'n_b', label: 'B', elasticity: 0.3 },
+        { id: 'n_c', label: 'C', elasticity: 0.1 },
+      ])
+      // Sanity guard for the test itself: the production normaliser
+      // pegs the top driver at 1.0, no matter the absolute elasticity.
+      expect(drivers[0].normalisedInfluence).toBe(1)
+      expect(drivers[1].normalisedInfluence).toBeCloseTo(0.375, 3)
+      expect(drivers[2].normalisedInfluence).toBeCloseTo(0.125, 3)
+    })
+
+    it('integration: clear dominance from real elasticities (0.8 vs 0.3 → ratio 2.67) renders', () => {
+      const drivers = buildDriversFromRawElasticities([
+        { id: 'n_a', label: 'Factor A', elasticity: 0.8 },
+        { id: 'n_b', label: 'Factor B', elasticity: 0.3 },
+      ])
+      const data = makeData({ stability: 0.7, drivers })
+      ;(data.recommendation as any).dominantFactorId = 'n_a'
+      ;(data.recommendation as any).dominantFactorLabel = 'Factor A'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Factor A.')
+    })
+
+    it('integration: near-tie from real elasticities (0.80 vs 0.78 → ratio 1.025) omits', () => {
+      const drivers = buildDriversFromRawElasticities([
+        { id: 'n_a', label: 'Factor A', elasticity: 0.80 },
+        { id: 'n_b', label: 'Factor B', elasticity: 0.78 },
+      ])
+      // Real ratio is 1.025 even though top driver's normalisedInfluence
+      // is the maximum value 1.0. The gate must catch this.
+      expect(drivers[0].normalisedInfluence).toBe(1)
+      expect(drivers[1].normalisedInfluence).toBeCloseTo(0.975, 3)
+      const data = makeData({ stability: 0.7, drivers })
+      ;(data.recommendation as any).dominantFactorId = 'n_a'
+      ;(data.recommendation as any).dominantFactorLabel = 'Factor A'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
+    })
+
+    it('integration: dominant by influenceScore but not by ratio — influenceScore wins', () => {
+      // Real ratio is only 1.5 (below 2.0 gate), but influenceScore for
+      // top1 is 0.7 (≥ 0.5 absolute floor), so the line should render.
+      const drivers = buildDriversFromRawElasticities([
+        { id: 'n_a', label: 'Factor A', elasticity: 0.6, influenceScore: 0.7 },
+        { id: 'n_b', label: 'Factor B', elasticity: 0.4, influenceScore: 0.25 },
+      ])
+      const data = makeData({ stability: 0.7, drivers })
+      ;(data.recommendation as any).dominantFactorId = 'n_a'
+      ;(data.recommendation as any).dominantFactorLabel = 'Factor A'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Factor A.')
+    })
+
+    it('integration: tiny absolute elasticities (all below 0.001) → normaliser returns 0 → omit', () => {
+      const drivers = buildDriversFromRawElasticities([
+        { id: 'n_a', label: 'A', elasticity: 0.0005 },
+        { id: 'n_b', label: 'B', elasticity: 0.0002 },
+      ])
+      // The normaliser early-returns all zeros when actualMax < 0.001.
+      expect(drivers.every(d => d.normalisedInfluence === 0)).toBe(true)
+      const data = makeData({ stability: 0.7, drivers })
+      ;(data.recommendation as any).dominantFactorId = 'n_a'
+      ;(data.recommendation as any).dominantFactorLabel = 'A'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
     })
   })
 

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -12,6 +12,7 @@ import type { ResultsVM } from '../../types'
 import type {
   ConfidenceSectionData,
   DecisionResultData,
+  DriverItem,
   EvidenceGapItem,
   OptionResult,
   FragileEdgeItem,
@@ -30,6 +31,14 @@ function makeData(overrides: {
   dimensions?: { evidence: number; robustness: number; clarity: number }
   bias?: Array<{ type: string; description: string }>
   dqp?: string[]
+  /**
+   * Review status surfaced on `data.confidence.reviewStatus`. The Key
+   * question card requires `'complete'` to render — defaulted to that
+   * value here so existing DQP-present tests behave unchanged.
+   */
+  reviewStatus?: string
+  /** Drivers list for dependency-line corroboration. */
+  drivers?: DriverItem[]
 } = {}): ResultsSectionDataReturn {
   const winner = overrides.winnerLabel === null
     ? null
@@ -61,6 +70,10 @@ function makeData(overrides: {
     nextActions: [],
     topNextActions: [],
     topFragileEdge: overrides.fragile,
+    // Honour an explicit `undefined` in overrides (distinct from "key
+    // absent"). 'in' check lets callers test the "missing reviewStatus"
+    // case alongside other values like 'in_progress'.
+    reviewStatus: 'reviewStatus' in overrides ? overrides.reviewStatus : 'complete',
     m2BiasFindings: overrides.bias?.map(b => ({
       type: b.type,
       source: 'test',
@@ -75,15 +88,36 @@ function makeData(overrides: {
     })),
   } as ConfidenceSectionData
 
+  const drivers = overrides.drivers ?? []
+
   return {
     recommendation,
-    drivers: { drivers: [], topDrivers: [], driversStatus: 'computed', totalCount: 0, hasMagnitudeData: false },
+    drivers: {
+      drivers,
+      topDrivers: drivers.slice(0, 3),
+      driversStatus: 'computed',
+      totalCount: drivers.length,
+      hasMagnitudeData: drivers.length > 0,
+    },
     confidence,
     improvements: { improvements: [], count: 0, hasHighPriority: false },
     isLoading: false,
     isError: false,
     goalLabel: 'Goal',
   } as ResultsSectionDataReturn
+}
+
+/** Build a DriverItem stub with the influence corroboration field populated. */
+function makeDriver(factorKey: string, factorLabel: string, normalisedInfluence: number): DriverItem {
+  return {
+    factorKey,
+    factorLabel,
+    rawElasticity: normalisedInfluence,
+    normalisedInfluence,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: true,
+  } as DriverItem
 }
 
 function makeVm(overrides: Partial<ResultsVM> = {}): ResultsVM {
@@ -380,6 +414,25 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.keyQuestion?.text).toBe('What evidence would change your view?')
     })
 
+    it('hides the card when reviewStatus !== "complete" even if a clean DQP is present (in-progress / stale guard)', () => {
+      // Upstream selector exposes m2DecisionQualityPrompts even during a
+      // partial review. Without the reviewStatus gate the card would
+      // surface stale or in-progress prompts.
+      const cases: Array<string | undefined> = [undefined, 'in_progress', 'pending', 'failed']
+      for (const status of cases) {
+        const vm = buildAnalysisHeroViewModel({
+          ...STD_ARGS,
+          data: makeData({
+            stability: 0.7,
+            dqp: ['What evidence would change your view?'],
+            reviewStatus: status,
+          }),
+          vm: makeVm({ decisionState: 'sensitive' }),
+        })
+        expect(vm.keyQuestion, `reviewStatus=${status ?? 'undefined'}`).toBeNull()
+      }
+    })
+
     it('rejects DQP that contains a banned term and hides the card (no template fallback)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
@@ -484,9 +537,19 @@ describe('buildAnalysisHeroViewModel', () => {
     // and M1 key_drivers); the legacy heuristic only contaminates
     // `data.drivers.dominantFactor*`, which the hero deliberately does not
     // read.
+    //
+    // Three additional gates (2026-05-21 review):
+    //  1. dominantFactorId + dominantFactorLabel both populated
+    //  2. matching driver in data.drivers.drivers[] has normalisedInfluence >= 0.5
+    //     (corroborates against M1 emissions without confidence + tie cases)
+    //  3. cleaned label passes the glossary banned-term gate
 
-    it('renders "The result depends most on {factor}." when recommendation.dominantFactorLabel is populated', () => {
-      const data = makeData({ winnerLabel: 'Tech Lead', stability: 0.7 })
+    it('renders "The result depends most on {factor}." when dominantFactor matches a driver with influence >= 0.5', () => {
+      const data = makeData({
+        winnerLabel: 'Tech Lead',
+        stability: 0.7,
+        drivers: [makeDriver('n_lead', 'Technical Leadership Capacity', 0.62)],
+      })
       ;(data.recommendation as any).dominantFactorId = 'n_lead'
       ;(data.recommendation as any).dominantFactorLabel = 'Technical Leadership Capacity'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
@@ -503,14 +566,20 @@ describe('buildAnalysisHeroViewModel', () => {
     })
 
     it('omits the dependency line when dominantFactorId is present but label is missing', () => {
-      const data = makeData({ stability: 0.7 })
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_lead', 'Tech Lead', 0.7)],
+      })
       ;(data.recommendation as any).dominantFactorId = 'n_lead'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
       expect(vm.dependencyLine).toBeNull()
     })
 
     it('omits the dependency line when the factor label contains a banned glossary term', () => {
-      const data = makeData({ stability: 0.7 })
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_w', 'the winning capacity', 0.7)],
+      })
       ;(data.recommendation as any).dominantFactorId = 'n_w'
       ;(data.recommendation as any).dominantFactorLabel = 'the winning capacity'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
@@ -518,11 +587,63 @@ describe('buildAnalysisHeroViewModel', () => {
     })
 
     it('strips encoding notation from the factor label before rendering', () => {
-      const data = makeData({ stability: 0.7 })
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_lead', 'Tech Lead Capacity', 0.7)],
+      })
       ;(data.recommendation as any).dominantFactorId = 'n_lead'
       ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead Capacity (0/1)'
       const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
       expect(vm.dependencyLine).toBe('The result depends most on Tech Lead Capacity.')
+    })
+
+    it('omits the dependency line when the matching driver has low influence (<0.5) — suppresses M1 emissions without confidence', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_lead', 'Tech Lead', 0.45)],
+      })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
+    })
+
+    it('omits the dependency line when no driver matches the dominantFactorId (stale or inconsistent state)', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_other', 'Other Factor', 0.9)],
+      })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
+    })
+
+    it('omits the dependency line in a tie (neither top driver crosses 0.5)', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [
+          makeDriver('n_a', 'Factor A', 0.48),
+          makeDriver('n_b', 'Factor B', 0.46),
+        ],
+      })
+      // Even if recommendation names one of them as dominant, the
+      // 0.5 corroboration floor isn't met → omit.
+      ;(data.recommendation as any).dominantFactorId = 'n_a'
+      ;(data.recommendation as any).dominantFactorLabel = 'Factor A'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
+    })
+
+    it('renders at the exact 0.5 boundary (>= 0.5 is enough)', () => {
+      const data = makeData({
+        stability: 0.7,
+        drivers: [makeDriver('n_lead', 'Tech Lead', 0.5)],
+      })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Tech Lead.')
     })
   })
 

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -139,7 +139,7 @@ describe('buildAnalysisHeroViewModel', () => {
         vm: makeVm({ decisionState: 'indeterminate' }),
       })
       expect(vm.state).toBe('weak')
-      expect(vm.resultLine).toBe('No option currently leads clearly.')
+      expect(vm.resultLine).toBe('No option currently comes out ahead clearly.')
     })
 
     it('moderate: default mid-range state', () => {
@@ -151,14 +151,16 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.state).toBe('moderate')
     })
 
-    it('reflect: robust + bias findings → reflect state with reflective pill', () => {
+    it('reflect: robust + bias findings → reflect state with reflective footer check', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.7, bias: [{ type: 'Anchoring', description: 'd' }] }),
         vm: makeVm({ decisionState: 'robust' }),
       })
       expect(vm.state).toBe('reflect')
-      expect(vm.metaPills.some(p => p.tone === 'reflect')).toBe(true)
+      // The reflect signal now surfaces via the 4th footer check
+      // (pills removed 2026-05-21 — see analysis-hero-v17-top-section.md task 4).
+      expect(vm.footerChecks.some(c => c.tone === 'reflect')).toBe(true)
     })
 
     it('strong: high stability + no gaps + no fragile → strong, ready row, brief CTA', () => {
@@ -189,7 +191,7 @@ describe('buildAnalysisHeroViewModel', () => {
         vm: undefined as unknown as ResultsVM,
       })
       expect(vm.state).toBe('weak')
-      expect(vm.resultLine).toBe('No option currently leads clearly.')
+      expect(vm.resultLine).toBe('No option currently comes out ahead clearly.')
       expect(vm.reasonLine).toBeNull()
     })
 
@@ -360,6 +362,12 @@ describe('buildAnalysisHeroViewModel', () => {
   })
 
   describe('key question selection', () => {
+    // 2026-05-21: card renders ONLY when a real V5 Phase-3 DQP is present
+    // and passes the glossary gate. The category-driven template fallback
+    // was removed — generic templated questions on M1 burned space without
+    // adding signal. See docs/investigations/analysis-hero-v17-top-section.md
+    // task 5.
+
     it('uses decision_quality_prompts[0] verbatim when present and clean', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
@@ -372,7 +380,7 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.keyQuestion?.text).toBe('What evidence would change your view?')
     })
 
-    it('rejects DQP that contains a banned term and falls back to template', () => {
+    it('rejects DQP that contains a banned term and hides the card (no template fallback)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -382,23 +390,16 @@ describe('buildAnalysisHeroViewModel', () => {
         }),
         vm: makeVm({ decisionState: 'sensitive' }),
       })
-      // Falls through to category-keyed template for the top evidence row.
-      // The factor label is intentionally not interpolated — the row title
-      // above the question already names it.
-      expect(vm.keyQuestion?.text).toBe('How confident are you this estimate is realistic?')
+      expect(vm.keyQuestion).toBeNull()
     })
 
-    it('templates from top row for evidence category — generic phrasing, no label interpolation', () => {
+    it('hides Key-question card on M1 templated-fallback (no DQP, has top row)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.7, gaps: [gap('Marketing spend', 'nm', 0.6)] }),
         vm: makeVm(),
       })
-      // Polish-pass: the factor label is NOT interpolated into the question.
-      // The row title carries the label visually; the question stays generic
-      // so it reads cleanly for any factor type.
-      expect(vm.keyQuestion?.text).toBe('How confident are you this estimate is realistic?')
-      expect(vm.keyQuestion?.text).not.toContain('Marketing spend')
+      expect(vm.keyQuestion).toBeNull()
     })
 
     it('hides Key-question card when no DQP and no rows', () => {
@@ -410,28 +411,20 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.keyQuestion).toBeNull()
     })
 
-    it('risk-category top row → same factor/estimate template, no "underperform"', () => {
-      // Polish-pass refinement 3: a factor-targeted risk row (the fragile
-      // edge) must not say "underperform" — that verb fits options, not
-      // factors/estimates/risks/costs/capacities.
-      const fragile = {
-        fromId: 'n_f', fromLabel: 'Technical Leadership Capacity',
-        toId: 'n_x', toLabel: 'Outcome',
-        switchProbability: 0.42,
-        alternativeWinnerLabel: 'Option B',
-      } as FragileEdgeItem
+    it('strong state always hides the key-question card', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
-        data: makeData({ stability: 0.7, fragile }),
-        vm: makeVm({ decisionState: 'sensitive' }),
+        data: makeData({
+          stability: 0.9,
+          dqp: ['What evidence would change your view?'],
+        }),
+        vm: makeVm({ decisionState: 'robust', evidenceLevel: 'good' }),
       })
-      expect(vm.inputRows[0].category).toBe('risk')
-      expect(vm.keyQuestion?.text).toBe('How confident are you this estimate is realistic?')
-      expect(vm.keyQuestion?.text.toLowerCase()).not.toContain('underperform')
-      expect(vm.keyQuestion?.text).not.toContain('Technical Leadership Capacity')
+      expect(vm.state).toBe('strong')
+      expect(vm.keyQuestion).toBeNull()
     })
 
-    it('user-supplied factor label containing banned term → row title preserves user data, question stays generic', () => {
+    it('user-supplied factor label containing banned term → row title preserves user data; key question hidden on fallback', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -442,24 +435,23 @@ describe('buildAnalysisHeroViewModel', () => {
       })
       // Row title preserves the user's label (we never rewrite user data).
       expect(vm.inputRows[0].title).toBe('the winning team')
-      // Polish-pass: the question template no longer interpolates the
-      // factor label, so banned-term smuggling via labels is moot here.
-      expect(vm.keyQuestion?.text).toBe('How confident are you this estimate is realistic?')
-      expect(vm.keyQuestion?.text.toLowerCase()).not.toContain('winning')
+      // No DQP → card hidden. The banned-term-in-label never reaches the
+      // question text path because that path no longer exists.
+      expect(vm.keyQuestion).toBeNull()
     })
   })
 
-  describe('result + reason line', () => {
-    it('result line uses winner label', () => {
+  describe('result + reason + dependency lines', () => {
+    it('result line uses winner label with "comes out ahead most often" framing', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ winnerLabel: 'Tech Lead' }),
         vm: makeVm(),
       })
-      expect(vm.resultLine).toBe('Tech Lead currently leads.')
+      expect(vm.resultLine).toBe('Tech Lead comes out ahead most often.')
     })
 
-    it('reason line derived from topFragileEdge when present', () => {
+    it('reason line derived from topFragileEdge stays on the VM (rendered in Row 1, not result context)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -485,79 +477,67 @@ describe('buildAnalysisHeroViewModel', () => {
       })
       expect(vm.reasonLine).toBeNull()
     })
-  })
 
-  describe('meta pills (Fix 2 label normalisation)', () => {
-    it('binds "Fragile result" label to stability < 0.5 only', () => {
-      const fragile = buildAnalysisHeroViewModel({
-        ...STD_ARGS,
-        data: makeData({ stability: 0.4 }),
-        vm: makeVm(),
-      })
-      expect(fragile.metaPills.some(p => p.label === 'Fragile result')).toBe(true)
-      // Anti-drift: legacy label gone.
-      expect(fragile.metaPills.some(p => p.label === 'Result fragile')).toBe(false)
+    // ── Dependency line: "The result depends most on {factor}." ──────────
+    // Sourced ONLY from `data.recommendation.dominantFactorId/Label`. That
+    // path in useResultsSectionData.ts collapses two safe sources (PLoT B1
+    // and M1 key_drivers); the legacy heuristic only contaminates
+    // `data.drivers.dominantFactor*`, which the hero deliberately does not
+    // read.
 
-      const stable = buildAnalysisHeroViewModel({
+    it('renders "The result depends most on {factor}." when recommendation.dominantFactorLabel is populated', () => {
+      const data = makeData({ winnerLabel: 'Tech Lead', stability: 0.7 })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Technical Leadership Capacity'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Technical Leadership Capacity.')
+    })
+
+    it('omits the dependency line when no dominantFactor is supplied (no fabrication)', () => {
+      const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.7 }),
         vm: makeVm(),
       })
-      expect(stable.metaPills.some(p => p.label === 'Fragile result')).toBe(false)
+      expect(vm.dependencyLine).toBeNull()
     })
 
-    it('stability bands → labels: 0.4 Fragile result; 0.6 Moderate stability; 0.75 Stable result; 0.9 Highly stable', () => {
-      const cases: Array<[number, string]> = [
-        [0.4, 'Fragile result'],
-        [0.6, 'Moderate stability'],
-        [0.75, 'Stable result'],
-        [0.9, 'Highly stable'],
-      ]
-      for (const [stability, expectedLabel] of cases) {
-        const vm = buildAnalysisHeroViewModel({
-          ...STD_ARGS,
-          data: makeData({ stability }),
-          vm: makeVm(),
-        })
-        expect(vm.metaPills.some(p => p.label === expectedLabel), `stability ${stability}`).toBe(true)
-      }
+    it('omits the dependency line when dominantFactorId is present but label is missing', () => {
+      const data = makeData({ stability: 0.7 })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
     })
 
-    it('evidenceLevel → pill: needs_work=Evidence limited; fair=Evidence moderate; good=Evidence adequate', () => {
-      const cases: Array<['needs_work' | 'fair' | 'good', string]> = [
-        ['needs_work', 'Evidence limited'],
-        ['fair', 'Evidence moderate'],
-        ['good', 'Evidence adequate'],
-      ]
-      for (const [level, expectedLabel] of cases) {
-        const vm = buildAnalysisHeroViewModel({
-          ...STD_ARGS,
-          data: makeData({ stability: 0.7 }),
-          vm: makeVm({ evidenceLevel: level }),
-        })
-        expect(vm.metaPills.some(p => p.label === expectedLabel), `level ${level}`).toBe(true)
-      }
+    it('omits the dependency line when the factor label contains a banned glossary term', () => {
+      const data = makeData({ stability: 0.7 })
+      ;(data.recommendation as any).dominantFactorId = 'n_w'
+      ;(data.recommendation as any).dominantFactorLabel = 'the winning capacity'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBeNull()
     })
 
-    it('the legacy "Evidence thin" pill never appears (Fix 2 anti-drift)', () => {
-      for (const level of ['needs_work', 'fair', 'good'] as const) {
-        const vm = buildAnalysisHeroViewModel({
-          ...STD_ARGS,
-          data: makeData({ stability: 0.7 }),
-          vm: makeVm({ evidenceLevel: level }),
-        })
-        expect(vm.metaPills.some(p => p.label === 'Evidence thin')).toBe(false)
-      }
+    it('strips encoding notation from the factor label before rendering', () => {
+      const data = makeData({ stability: 0.7 })
+      ;(data.recommendation as any).dominantFactorId = 'n_lead'
+      ;(data.recommendation as any).dominantFactorLabel = 'Tech Lead Capacity (0/1)'
+      const vm = buildAnalysisHeroViewModel({ ...STD_ARGS, data, vm: makeVm() })
+      expect(vm.dependencyLine).toBe('The result depends most on Tech Lead Capacity.')
     })
+  })
 
-    it('no stability pill at all when stability is null', () => {
+  describe('meta pills removal (2026-05-21)', () => {
+    // Pills were removed from the result-context block. Stability and
+    // evidence signals continue to surface in the HeroFooter checks below.
+    // See docs/investigations/analysis-hero-v17-top-section.md task 4.
+
+    it('the VM does not expose a metaPills field', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
-        data: makeData({ stability: undefined }),
+        data: makeData({ stability: 0.7 }),
         vm: makeVm(),
       })
-      const stabilityLabels = ['Fragile result', 'Moderate stability', 'Stable result', 'Highly stable']
-      expect(vm.metaPills.filter(p => stabilityLabels.includes(p.label))).toHaveLength(0)
+      expect((vm as Record<string, unknown>).metaPills).toBeUndefined()
     })
   })
 
@@ -683,7 +663,7 @@ describe('buildAnalysisHeroViewModel', () => {
   // grounded rule below ties both labels to whether a fragile/sensitive
   // factor is actually present in the data.
 
-  describe('grounded stability + sensitivity wording', () => {
+  describe('grounded stability + sensitivity wording (footer-check only post-pill-removal)', () => {
     const fragileEdge = {
       fromId: 'n_f',
       fromLabel: 'Hiring rate',
@@ -693,58 +673,43 @@ describe('buildAnalysisHeroViewModel', () => {
       alternativeWinnerLabel: 'Option B',
     } as FragileEdgeItem
 
-    it('0.75 stability with NO fragile factor → "Stable result" pill + "Stability limited" check', () => {
+    it('0.75 stability with NO fragile factor → "Stability limited" check (not "Sensitive assumption")', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.75 }),
         vm: makeVm(),
       })
-      expect(vm.metaPills.map(p => p.label)).toContain('Stable result')
-      expect(vm.metaPills.map(p => p.label)).not.toContain('Mostly stable')
       const stabilityCheck = vm.footerChecks[1]
       expect(stabilityCheck.label).toBe('Stability limited')
-      // Anti-drift: the bare "Sensitive" must not appear, and we must
-      // not over-claim a specific assumption when none is grounded.
       expect(stabilityCheck.label).not.toBe('Sensitive')
       expect(stabilityCheck.label).not.toBe('Sensitive assumption')
     })
 
-    it('0.75 stability WITH fragile factor → "Mostly stable" pill + "Sensitive assumption" check', () => {
+    it('0.75 stability WITH fragile factor → "Sensitive assumption" check', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.75, fragile: fragileEdge }),
         vm: makeVm(),
       })
-      expect(vm.metaPills.map(p => p.label)).toContain('Mostly stable')
-      expect(vm.metaPills.map(p => p.label)).not.toContain('Stable result')
-      const stabilityCheck = vm.footerChecks[1]
-      expect(stabilityCheck.label).toBe('Sensitive assumption')
+      expect(vm.footerChecks[1].label).toBe('Sensitive assumption')
     })
 
-    it('low stability WITH fragile factor → fragile/moderate pill + "Sensitive assumption" check', () => {
+    it('low stability WITH fragile factor → "Sensitive assumption" check', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.6, fragile: fragileEdge }),
         vm: makeVm(),
       })
-      // Pill stays "Moderate stability" — the soften only applies to the
-      // 0.7–0.85 band; below that the pessimistic pill is already accurate.
-      expect(vm.metaPills.map(p => p.label)).toContain('Moderate stability')
       expect(vm.footerChecks[1].label).toBe('Sensitive assumption')
     })
 
-    it('low stability WITHOUT fragile factor → "Stability limited" check (not "Sensitive assumption")', () => {
+    it('low stability WITHOUT fragile factor → "Stability limited" check (no over-claim)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.4 }),
         vm: makeVm(),
       })
-      const stabilityCheck = vm.footerChecks[1]
-      expect(stabilityCheck.label).toBe('Stability limited')
-      // The fragile-result pill is still surfaced at the system level —
-      // this only governs the footer check, where over-claiming a single
-      // named assumption when none is grounded would be wrong.
-      expect(vm.metaPills.map(p => p.label)).toContain('Fragile result')
+      expect(vm.footerChecks[1].label).toBe('Stability limited')
     })
 
     it('≥0.85 stability → "Stable" check regardless of fragile-factor presence', () => {

--- a/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
@@ -158,8 +158,13 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
     })
   })
 
-  describe('key-question chips', () => {
-    it('chips strip is HIDDEN when chat is closed (key-question text still renders)', () => {
+  describe('key-question card (2026-05-21 tighter render rule)', () => {
+    // The whole card now hides when chat is closed — not just the chip
+    // strip. Previously the question text dangled while the chips were
+    // hidden, creating an "advertised but unclickable" failure mode.
+    // See docs/investigations/analysis-hero-v17-top-section.md task 5.
+
+    it('entire card is HIDDEN when chat is closed (text + chips both gone)', () => {
       render(
         <AnalysisHeroV17
           data={makeData({ gaps: [gap('Cost', 'n_c', 0.5)] })}
@@ -167,10 +172,22 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
           fragileEdgeCount={0}
         />,
       )
-      // Key-question text still renders so the user can still read it.
-      expect(screen.queryByTestId('hero-v17-key-question-text')).toBeTruthy()
-      // Chips strip hidden.
+      expect(screen.queryByTestId('hero-v17-key-question')).toBeNull()
+      expect(screen.queryByTestId('hero-v17-key-question-text')).toBeNull()
       expect(screen.queryByTestId('hero-v17-key-question-chips')).toBeNull()
+    })
+
+    it('M1 fallback (no DQP) + chat open → card still hidden (no template fallback)', () => {
+      useGuidanceStore.setState({ _prefillChat: () => {}, _sendMessage: () => {} })
+      render(
+        <AnalysisHeroV17
+          data={makeData({ gaps: [gap('Cost', 'n_c', 0.5)] })}
+          vm={makeVm()}
+          fragileEdgeCount={0}
+        />,
+      )
+      // No m2DecisionQualityPrompts in fixture → keyQuestion === null.
+      expect(screen.queryByTestId('hero-v17-key-question')).toBeNull()
     })
   })
 

--- a/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
@@ -135,7 +135,7 @@ describe('AnalysisHeroV17 — glossary compliance (VM output)', () => {
     if (vm.contribution.text) acc.push(vm.contribution.text)
     acc.push(vm.resultLine)
     if (vm.reasonLine) acc.push(vm.reasonLine)
-    vm.metaPills.forEach(p => acc.push(p.label))
+    if (vm.dependencyLine) acc.push(vm.dependencyLine)
     if (vm.keyQuestion) {
       acc.push(vm.keyQuestion.text)
       acc.push(...vm.keyQuestion.extras)
@@ -162,7 +162,7 @@ describe('AnalysisHeroV17 — glossary compliance (VM output)', () => {
     }
   })
 
-  it('user-supplied label contains banned term → key question swaps in generic fallback, never amplifies banned label', () => {
+  it('user-supplied label contains banned term → key question hides on M1 fallback, never amplifies banned label', () => {
     const vm = buildAnalysisHeroViewModel({
       data: makeData({ gapLabels: ['the winning team'] }),
       vm: makeVm(),
@@ -170,9 +170,10 @@ describe('AnalysisHeroV17 — glossary compliance (VM output)', () => {
     })
     // Row title preserves the user's label — we do not rewrite user data.
     expect(vm.inputRows[0].title).toBe('the winning team')
-    // But the templated KEY QUESTION must NOT contain the banned term.
-    expect(vm.keyQuestion).toBeTruthy()
-    expect(findBannedTerm(vm.keyQuestion!.text)).toBeNull()
+    // No DQP is present in this fixture, so the card is hidden — the
+    // templated fallback was removed (2026-05-21). The banned-term-in-label
+    // never reaches the key-question text because that path no longer exists.
+    expect(vm.keyQuestion).toBeNull()
   })
 
   it('fragile fromLabel contains banned term → reason line falls back, no leak', () => {
@@ -429,7 +430,7 @@ describe('AnalysisHeroV17 — comprehensive banned-term sweep through user label
     if (vm.contribution.text) acc.push(vm.contribution.text)
     acc.push(vm.resultLine)
     if (vm.reasonLine) acc.push(vm.reasonLine)
-    vm.metaPills.forEach(p => acc.push(p.label))
+    if (vm.dependencyLine) acc.push(vm.dependencyLine)
     if (vm.keyQuestion) {
       acc.push(vm.keyQuestion.text)
       acc.push(...vm.keyQuestion.extras)

--- a/src/components/results/analysisHeroV17/__tests__/p1Fixes.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/p1Fixes.spec.tsx
@@ -331,17 +331,33 @@ describe('AnalysisHeroV17 — P1.5: factor filter widens with data.kind', () => 
     })
   })
 
-  // Fix 1 dropped the separate `hero-v17-contribution` element; assertions
-  // moved to the strip's `checkedCount` text (rendered inside hero-v17-strip).
-  function strippedVerifiedText(): string {
-    const strip = screen.queryByTestId('hero-v17-strip')
-    // The checkedCount is the second visible text in the strip header
-    // (after "Strengthen this decision"). Match the inputs-verified
-    // pattern directly.
-    const text = strip?.textContent ?? ''
-    const m = text.match(/(\d+ input(s)? verified|No inputs verified)/)
+  // Verified count moved (2026-05-21) from visible header text to the
+  // Verified strip-segment's tooltip + aria-label. The visible header
+  // never carries the count any more; we read it off the segment's
+  // composite title attribute "Verified: NN% (No inputs verified)".
+  // See docs/investigations/analysis-hero-v17-top-section.md task 2.
+  function verifiedTooltipCount(): string {
+    const seg = screen.queryByTestId('strip-verified')
+    const title = seg?.getAttribute('title') ?? ''
+    const m = title.match(/(\d+ input(s)? verified|No inputs verified)/)
     return m ? m[0] : ''
   }
+
+  it('verified-segment tooltip always carries the count alongside the percentage', () => {
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'n_factor', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor' } } as never,
+        { id: 'n_goal', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal' } } as never,
+      ],
+      confirmedNodeIds: new Set(['n_factor']),
+    })
+    render(<AnalysisHeroV17 data={makeData()} vm={makeVm()} fragileEdgeCount={0} />)
+    const seg = screen.getByTestId('strip-verified')
+    const title = seg.getAttribute('title') ?? ''
+    expect(title).toMatch(/^Verified: \d+%/)
+    expect(title).toContain('1 input verified')
+    expect(seg.getAttribute('aria-label')).toBe(title)
+  })
 
   it('counts a node whose React Flow type is undefined but data.kind === "factor"', () => {
     useCanvasStore.setState({
@@ -352,7 +368,7 @@ describe('AnalysisHeroV17 — P1.5: factor filter widens with data.kind', () => 
       confirmedNodeIds: new Set(['n_factor_by_kind']),
     })
     render(<AnalysisHeroV17 data={makeData()} vm={makeVm()} fragileEdgeCount={0} />)
-    expect(strippedVerifiedText()).toBe('1 input verified')
+    expect(verifiedTooltipCount()).toBe('1 input verified')
   })
 
   it('counts nodes whose React Flow type IS "factor" (legacy path still works)', () => {
@@ -363,18 +379,20 @@ describe('AnalysisHeroV17 — P1.5: factor filter widens with data.kind', () => 
       confirmedNodeIds: new Set(['n_legacy']),
     })
     render(<AnalysisHeroV17 data={makeData()} vm={makeVm()} fragileEdgeCount={0} />)
-    expect(strippedVerifiedText()).toBe('1 input verified')
+    expect(verifiedTooltipCount()).toBe('1 input verified')
   })
 
-  it('zero factors → checkedCount hidden, no NaN, no "of 0" leak', () => {
+  it('zero factors → tooltip carries no count, no NaN, no "of 0" leak', () => {
     useCanvasStore.setState({
       nodes: [{ id: 'n_g', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal' } } as never],
       confirmedNodeIds: new Set<string>(),
     })
     render(<AnalysisHeroV17 data={makeData()} vm={makeVm()} fragileEdgeCount={0} />)
-    expect(strippedVerifiedText()).toBe('')
-    // Anti-drift: the legacy "0 of 4 verified" form is gone.
+    expect(verifiedTooltipCount()).toBe('')
+    // Strip header never carries the count text any more (moved to tooltip).
     const strip = screen.queryByTestId('hero-v17-strip')
+    expect(strip?.textContent ?? '').not.toMatch(/inputs? verified/)
+    // Anti-drift: the legacy "0 of 4 verified" form is gone.
     expect(strip?.textContent ?? '').not.toMatch(/\d+ of \d+ verified/)
   })
 })

--- a/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
+++ b/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
@@ -42,11 +42,6 @@ export interface DimensionSegment {
   tooltip: string
 }
 
-export interface MetaPill {
-  label: string
-  tone: 'neutral' | 'warn' | 'danger' | 'reflect'
-}
-
 export interface HeroRow {
   /** Stable key for React reconciliation. */
   key: string
@@ -126,8 +121,18 @@ export interface AnalysisHeroVM {
   dimensions: DimensionSegment[]
   /** Top hero result card. */
   resultLine: string
+  /**
+   * Flip-risk narrative — kept on the VM as a future slot for V5 Phase 3
+   * substitution but no longer rendered in the result-context block. The
+   * fragile-edge signal already surfaces in Row 1 of the input rows below.
+   */
   reasonLine: string | null
-  metaPills: MetaPill[]
+  /**
+   * "The result depends most on {factor}." Renders below the result line
+   * when a safe dominant-factor source (PLoT B1 / M1 key_drivers) is
+   * available and the label passes the glossary gate. `null` hides the line.
+   */
+  dependencyLine: string | null
   /** Key question card — null hides the card entirely. */
   keyQuestion: KeyQuestion | null
   /** Top 3 visible rows. */

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -41,13 +41,13 @@ import {
   type StructureSignals,
   type CoverageSignals,
 } from './canvasSignals'
+import { stripEncodingNotation } from '../utils/cleanFactorLabel'
 import type {
   AnalysisHeroVM,
   DimensionSegment,
   HeroRow,
   HeroState,
   KeyQuestion,
-  MetaPill,
   FooterCheck,
   FooterCta,
   AlsoLink,
@@ -129,9 +129,9 @@ function clamp01(v: number | undefined | null): number {
 
 function buildResultLine(data: ResultsSectionDataReturn): string {
   const winner = data?.recommendation?.recommendedOption
-  if (!winner) return 'No option currently leads clearly.'
+  if (!winner) return 'No option currently comes out ahead clearly.'
   const label = safeLabel(winner.label, 'The leading option')
-  return `${label} currently leads.`
+  return `${label} comes out ahead most often.`
 }
 
 function buildReasonLine(data: ResultsSectionDataReturn): string | null {
@@ -145,69 +145,48 @@ function buildReasonLine(data: ResultsSectionDataReturn): string | null {
   return null
 }
 
-function buildMetaPills(
-  data: ResultsSectionDataReturn,
-  vm: ResultsVM,
-  state: HeroState,
-  hasFragileFactor: boolean,
-): MetaPill[] {
-  const pills: MetaPill[] = []
-  const stability = data?.recommendation?.recommendationStability
-  // Result-state pill bound to stability bands (glossary §3). Copy
-  // normalised so all four bands have the same shape (Fix 2): noun-led
-  // or noun-trailing was inconsistent across "Result fragile" vs
-  // "Stable result" vs "Highly stable". The new shape keeps the glossary
-  // band label (Fragile / Moderate / Stable / Highly stable) front and
-  // centre with consistent context.
-  //
-  // 0.7–0.85 + fragile factor present: soften "Stable result" to
-  // "Mostly stable" so it reads consistently with the grounded
-  // "Sensitive assumption" footer check. When no fragile factor exists,
-  // keep "Stable result" — there is no contradiction with the footer.
-  if (typeof stability === 'number' && Number.isFinite(stability)) {
-    if (stability < 0.5) {
-      pills.push({ label: 'Fragile result', tone: 'danger' })
-    } else if (stability < 0.7) {
-      pills.push({ label: 'Moderate stability', tone: 'warn' })
-    } else if (stability < 0.85) {
-      pills.push({
-        label: hasFragileFactor ? 'Mostly stable' : 'Stable result',
-        tone: 'neutral',
-      })
-    } else {
-      pills.push({ label: 'Highly stable', tone: 'neutral' })
-    }
-  }
-  // Evidence pill driven by evidenceLevel from the VM. Defensive `?.`
-  // because `vm` may be missing in a degraded bundle. Labels reflowed
-  // (Fix 2): "Evidence thin" → "Evidence limited" (the awkward word goes);
-  // "Evidence limited" (fair) → "Evidence moderate" (mid-tier rename so
-  // there's no collision); good stays "Evidence adequate".
-  if (vm?.evidenceLevel === 'needs_work') {
-    pills.push({ label: 'Evidence limited', tone: 'danger' })
-  } else if (vm?.evidenceLevel === 'fair') {
-    pills.push({ label: 'Evidence moderate', tone: 'warn' })
-  } else {
-    pills.push({ label: 'Evidence adequate', tone: 'neutral' })
-  }
-  // Reflective pill — only when state === 'reflect'.
-  if (state === 'reflect') {
-    pills.push({ label: 'Reflective check', tone: 'reflect' })
-  }
-  return pills
+/**
+ * Dependency line: "The result depends most on {factor}."
+ *
+ * Only emits when the dominant factor comes from a safe source:
+ * `data.recommendation.dominantFactorId` / `dominantFactorLabel` are populated
+ * exclusively from PLoT B1 (`report.dominant_factor`) or M1
+ * (`m1Coaching.key_drivers.dominant_factor`) — see
+ * `useResultsSectionData.ts:1465–1476`. The legacy heuristic
+ * (`detectDominantFactorLegacy`) only contaminates `data.drivers.dominantFactor*`,
+ * which this function deliberately does NOT read.
+ *
+ * Returns `null` when no dominant factor is available or the label fails the
+ * glossary gate — the result-context block then renders the result line alone.
+ */
+function buildDependencyLine(data: ResultsSectionDataReturn): string | null {
+  const rec = data?.recommendation
+  const id = rec?.dominantFactorId
+  const rawLabel = rec?.dominantFactorLabel
+  if (!id || !rawLabel) return null
+  const cleaned = stripEncodingNotation(rawLabel)
+  if (!cleaned) return null
+  if (containsBannedTerm(cleaned)) return null
+  return `The result depends most on ${cleaned}.`
 }
 
 // ── Key question ────────────────────────────────────────────────────────────
 
 function selectKeyQuestion(
   data: ResultsSectionDataReturn,
-  topRow: HeroRow | undefined,
   state: HeroState,
 ): KeyQuestion | null {
   // Strong-state CTA already invites the brief — no key question needed.
   if (state === 'strong') return null
 
-  // 1. Decision-review prompt verbatim (if clean).
+  // Decision-review prompt verbatim (if clean). When V5 Phase 3 wires
+  // `decision_review`, real DQPs populate automatically.
+  //
+  // The category-driven template fallback was removed (2026-05-21): on M1
+  // it produced generic, repetitive questions across every decision and
+  // burned vertical space without adding signal. When no real DQP is
+  // present, the card is hidden — coaching intent moves into the input
+  // row's AI action prompt instead.
   const dqps = data?.confidence?.m2DecisionQualityPrompts ?? []
   const dqp = dqps[0]?.question
   if (dqp && !containsBannedTerm(dqp)) {
@@ -218,45 +197,7 @@ function selectKeyQuestion(
     }
   }
 
-  // 2. Template from the top row's category. All current row categories
-  // (evidence / causal / risk) target factors or estimates, so they share
-  // a single factor-targeted template. The factor label is intentionally
-  // not interpolated — the row title above the key-question card already
-  // names it, and the generic phrasing reads cleanly for any factor type
-  // (capacities, costs, risks, budgets, etc).
-  //
-  // TODO: when hero rows can target options directly (e.g. an
-  // option-comparison row), use the option-targeted template
-  // `"What would make this option underperform?"`. Not wired yet because
-  // no current row category resolves to an option target.
-  if (topRow && topRow.title) {
-    let candidate: string | null = null
-    switch (topRow.category) {
-      case 'evidence':
-      case 'causal':
-      case 'risk':
-        candidate = 'How confident are you this estimate is realistic?'
-        break
-      case 'coverage':
-        candidate = 'Are the alternatives genuinely different?'
-        break
-      case 'reflect':
-        candidate = 'Could early preference for one route be influencing the framing?'
-        break
-      case 'ready':
-        candidate = null
-        break
-    }
-    if (candidate && !containsBannedTerm(candidate)) {
-      return {
-        text: candidate,
-        extras: [],
-        chips: ['High', 'Some', 'Not sure', 'Add note'],
-      }
-    }
-  }
-
-  // 3. No safe grounded question — hide the card.
+  // No real DQP — hide the card.
   return null
 }
 
@@ -427,8 +368,8 @@ export function buildAnalysisHeroViewModel(args: AnalysisHeroBuilderArgs): Analy
   const dimensions = buildDimensions(data, confirmedFactorCount, totalFactorCount, structureSignals, coverageSignals)
   const resultLine = buildResultLine(data)
   const reasonLine = buildReasonLine(data)
-  const metaPills = buildMetaPills(data, vm, state, hasFragileFactor)
-  const keyQuestion = selectKeyQuestion(data, topRow, state)
+  const dependencyLine = buildDependencyLine(data)
+  const keyQuestion = selectKeyQuestion(data, state)
   const footerChecks = buildFooterChecks(data, vm, state, hasFragileFactor)
   const footerCta = buildFooterCta(state, topRow)
   const footerHint = buildFooterHint(state)
@@ -466,7 +407,7 @@ export function buildAnalysisHeroViewModel(args: AnalysisHeroBuilderArgs): Analy
     dimensions,
     resultLine,
     reasonLine,
-    metaPills,
+    dependencyLine,
     keyQuestion,
     inputRows,
     hiddenRows,

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -1,29 +1,40 @@
 /**
  * AnalysisHeroV17 view-model builder — orchestrator.
  *
- * Source of truth: docs/investigations/analysis-hero-v17.md §9–§11.
+ * Source of truth: docs/investigations/analysis-hero-v17.md §9–§11
+ * (initial) + docs/investigations/analysis-hero-v17-top-section.md
+ * (2026-05-21 top-section optimisation pass).
  *
  * This function is pure and deterministic. The component must consume the
  * VM and render — no further computation in JSX. State selection lives in
  * `stateSelection.ts`; row ranking + category lives in `rowRanking.ts`;
  * this module wires them together and resolves the key question, dimensions,
- * meta pills, footer checks, and CTA.
+ * dependency line, footer checks, and CTA.
  *
  * v1 fallbacks (per Paul's approved direction):
  *   - The fourth strip segment is labelled "Verified" (not "User input")
  *     and sourced from confirmedFactorCount / totalFactorCount.
- *   - The verified count surfaces ONCE — via `checkedCount` rendered to the
- *     right of the dimension strip ("No inputs verified" / "1 input verified"
- *     / "N inputs verified"). The earlier separate `contribution` line below
- *     the strip was removed in Fix 1 of the Round-4 polish pass because it
- *     duplicated the strip's count. `contribution.text` is always `null` and
- *     the field is retained only for backward compatibility (deprecated;
- *     scheduled for removal in the next major VM bump).
+ *   - The verified count surfaces ONLY via the Verified strip-segment's
+ *     tooltip + aria-label — no visible header text. The VM exposes
+ *     `checkedCount` ("No inputs verified" / "1 input verified" / "N inputs
+ *     verified") which the renderer threads into that composite tooltip.
+ *   - The `contribution` field is dead-deprecated: text is always `null`
+ *     and the field is retained only for backward compatibility (scheduled
+ *     for removal in the next major VM bump).
  *   - Per-factor provenance ("You checked X · Olumi inferred Y") remains
  *     unimplemented because the data is not available upstream.
- *   - `decision_quality_prompts` is consumed when present; otherwise a
- *     category-driven template is used; if no safe grounded question can
- *     be produced, the Key-question card is hidden.
+ *   - Result line uses probabilistic framing: "{label} comes out ahead
+ *     most often." A dependency line "The result depends most on {factor}."
+ *     renders below only when `recommendation.dominantFactor*` is populated
+ *     AND a matching driver has `normalisedInfluence >= 0.5` (corroboration
+ *     against the same threshold PLoT B1 uses internally — suppresses
+ *     low-confidence M1 emissions and tie cases).
+ *   - Stability/evidence meta pills were removed entirely; those signals
+ *     surface in `footerChecks` instead.
+ *   - Key-question card renders only when a real `m2DecisionQualityPrompts[0]`
+ *     is present, `reviewStatus === 'complete'`, and the prompt passes the
+ *     glossary gate. No category-driven template fallback — generic
+ *     templated questions on M1 burned space without adding signal.
  */
 
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
@@ -148,22 +159,50 @@ function buildReasonLine(data: ResultsSectionDataReturn): string | null {
 /**
  * Dependency line: "The result depends most on {factor}."
  *
- * Only emits when the dominant factor comes from a safe source:
- * `data.recommendation.dominantFactorId` / `dominantFactorLabel` are populated
- * exclusively from PLoT B1 (`report.dominant_factor`) or M1
- * (`m1Coaching.key_drivers.dominant_factor`) — see
- * `useResultsSectionData.ts:1465–1476`. The legacy heuristic
- * (`detectDominantFactorLegacy`) only contaminates `data.drivers.dominantFactor*`,
- * which this function deliberately does NOT read.
+ * Source gates (post review-feedback 2026-05-21):
  *
- * Returns `null` when no dominant factor is available or the label fails the
- * glossary gate — the result-context block then renders the result line alone.
+ *   1. `data.recommendation.dominantFactorId` / `dominantFactorLabel`
+ *      must both be populated. That `recommendation` path in
+ *      `useResultsSectionData.ts:1465–1476` collapses two safe sources —
+ *      PLoT B1 (`report.dominant_factor`) and M1
+ *      (`m1Coaching.key_drivers.dominant_factor`) — and never emits the
+ *      legacy heuristic (which only contaminates
+ *      `data.drivers.dominantFactor*`, which this function deliberately
+ *      does NOT read).
+ *
+ *   2. Corroboration check: the matching driver in `data.drivers.drivers[]`
+ *      must have `normalisedInfluence >= 0.5`. This is the same threshold
+ *      PLoT B1 uses internally to classify dominance. The check guards
+ *      against three failure modes:
+ *        - M1 emits `key_drivers.dominant_factor` without verifying actual
+ *          dominance (no confidence gate upstream)
+ *        - Tie cases (top-2 factors near-equal → neither >= 0.5 in
+ *          normalised influence)
+ *        - Stale or inconsistent state where `recommendation` claims a
+ *          dominant factor but the underlying drivers don't support it
+ *      The influence-score field is NOT tainted by the legacy heuristic;
+ *      the heuristic only affects `data.drivers.dominantFactorId` selection,
+ *      not the per-driver `normalisedInfluence` values.
+ *
+ *   3. Cleaned factor label passes the glossary banned-term gate.
+ *
+ * Returns `null` when any gate fails — the result-context block then
+ * renders the result line alone.
  */
 function buildDependencyLine(data: ResultsSectionDataReturn): string | null {
   const rec = data?.recommendation
   const id = rec?.dominantFactorId
   const rawLabel = rec?.dominantFactorLabel
   if (!id || !rawLabel) return null
+  // Corroboration: the named factor must actually be dominant in the
+  // underlying drivers array. Match by factorKey (the driver's canonical
+  // id resolved from node_id / factor_id / id / normalised(label) per
+  // DriverItem definition).
+  const driver = data?.drivers?.drivers?.find(d => d.factorKey === id)
+  const influence = driver?.normalisedInfluence
+  if (typeof influence !== 'number' || !Number.isFinite(influence) || influence < 0.5) {
+    return null
+  }
   const cleaned = stripEncodingNotation(rawLabel)
   if (!cleaned) return null
   if (containsBannedTerm(cleaned)) return null
@@ -182,11 +221,21 @@ function selectKeyQuestion(
   // Decision-review prompt verbatim (if clean). When V5 Phase 3 wires
   // `decision_review`, real DQPs populate automatically.
   //
+  // Three gates (post review-feedback 2026-05-21):
+  //   1. reviewStatus === 'complete' — mirrors the gate `m2NarrativeSummary`
+  //      uses (see useResultsSectionData.ts:1461). The upstream selector
+  //      exposes `m2DecisionQualityPrompts` even when the review is still
+  //      in progress / stale; without this gate the card could render
+  //      partial or out-of-date prompts.
+  //   2. Question text passes `containsBannedTerm` (glossary safety).
+  //   3. State is not 'strong' (handled above).
+  //
   // The category-driven template fallback was removed (2026-05-21): on M1
   // it produced generic, repetitive questions across every decision and
   // burned vertical space without adding signal. When no real DQP is
-  // present, the card is hidden — coaching intent moves into the input
-  // row's AI action prompt instead.
+  // present (or the gates fail), the card is hidden — coaching intent
+  // moves into the input row's AI action prompt instead.
+  if (data?.confidence?.reviewStatus !== 'complete') return null
   const dqps = data?.confidence?.m2DecisionQualityPrompts ?? []
   const dqp = dqps[0]?.question
   if (dqp && !containsBannedTerm(dqp)) {
@@ -197,7 +246,7 @@ function selectKeyQuestion(
     }
   }
 
-  // No real DQP — hide the card.
+  // No safe gated DQP — hide the card.
   return null
 }
 

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -159,34 +159,39 @@ function buildReasonLine(data: ResultsSectionDataReturn): string | null {
 /**
  * Dependency line: "The result depends most on {factor}."
  *
- * Source gates (post review-feedback 2026-05-21):
+ * Source + corroboration gates (rewritten 2026-05-21 after review):
  *
- *   1. `data.recommendation.dominantFactorId` / `dominantFactorLabel`
- *      must both be populated. That `recommendation` path in
- *      `useResultsSectionData.ts:1465–1476` collapses two safe sources —
+ *   1. `data.recommendation.dominantFactorId` + `dominantFactorLabel` must
+ *      both be populated. That `recommendation` path
+ *      (`useResultsSectionData.ts:1465–1476`) collapses two safe sources —
  *      PLoT B1 (`report.dominant_factor`) and M1
  *      (`m1Coaching.key_drivers.dominant_factor`) — and never emits the
  *      legacy heuristic (which only contaminates
- *      `data.drivers.dominantFactor*`, which this function deliberately
- *      does NOT read).
+ *      `data.drivers.dominantFactor*`, deliberately not read here).
  *
- *   2. Corroboration check: the matching driver in `data.drivers.drivers[]`
- *      must have `normalisedInfluence >= 0.5`. This is the same threshold
- *      PLoT B1 uses internally to classify dominance. The check guards
- *      against three failure modes:
- *        - M1 emits `key_drivers.dominant_factor` without verifying actual
- *          dominance (no confidence gate upstream)
- *        - Tie cases (top-2 factors near-equal → neither >= 0.5 in
- *          normalised influence)
- *        - Stale or inconsistent state where `recommendation` claims a
- *          dominant factor but the underlying drivers don't support it
- *      The influence-score field is NOT tainted by the legacy heuristic;
- *      the heuristic only affects `data.drivers.dominantFactorId` selection,
- *      not the per-driver `normalisedInfluence` values.
+ *   2. Rank-1 consistency: the named factor MUST be the top-ranked driver
+ *      in `data.drivers.drivers[]`. If `dominantFactorId` doesn't match
+ *      the rank-1 driver, the recommendation and the underlying driver
+ *      array disagree — render nothing rather than over-claim.
  *
- *   3. Cleaned factor label passes the glossary banned-term gate.
+ *   3. Dominance gate. `normalisedInfluence` is relative — the top driver
+ *      is ALWAYS 1.0 when any real elasticity exists
+ *      (`computeNormalisedInfluences` at `useResultsSectionData.ts:420–446`),
+ *      so it can't distinguish dominance from a near-tie on its own.
+ *      Two checks:
+ *        (a) prefer `influenceScore` when present — that's the ISL
+ *            structural causal influence on an absolute 0–1 scale;
+ *            require `>= 0.5` (genuine dominance, not just "more than
+ *            half of the max");
+ *        (b) otherwise fall back to the top1/top2 normalisedInfluence
+ *            ratio `>= 2.0` — the same 2:1 threshold the legacy
+ *            heuristic uses, applied here as a guard (NOT a selector,
+ *            so it doesn't taint anything).
+ *      Either guard satisfies dominance; both failing omits the line.
  *
- * Returns `null` when any gate fails — the result-context block then
+ *   4. Cleaned factor label passes the glossary banned-term gate.
+ *
+ * Returns `null` whenever any gate fails — the result-context block then
  * renders the result line alone.
  */
 function buildDependencyLine(data: ResultsSectionDataReturn): string | null {
@@ -194,15 +199,35 @@ function buildDependencyLine(data: ResultsSectionDataReturn): string | null {
   const id = rec?.dominantFactorId
   const rawLabel = rec?.dominantFactorLabel
   if (!id || !rawLabel) return null
-  // Corroboration: the named factor must actually be dominant in the
-  // underlying drivers array. Match by factorKey (the driver's canonical
-  // id resolved from node_id / factor_id / id / normalised(label) per
-  // DriverItem definition).
-  const driver = data?.drivers?.drivers?.find(d => d.factorKey === id)
-  const influence = driver?.normalisedInfluence
-  if (typeof influence !== 'number' || !Number.isFinite(influence) || influence < 0.5) {
-    return null
+
+  const drivers = data?.drivers?.drivers
+  if (!drivers || drivers.length === 0) return null
+
+  // Rank-1 consistency. Sort defensively rather than trusting source order.
+  const sorted = [...drivers].sort((a, b) => a.rank - b.rank)
+  const top1 = sorted[0]
+  if (!top1 || top1.factorKey !== id) return null
+
+  // Dominance gate.
+  let isDominant = false
+  if (typeof top1.influenceScore === 'number' && Number.isFinite(top1.influenceScore)) {
+    // Absolute scale (ISL structural causal influence): 0.5 floor.
+    isDominant = top1.influenceScore >= 0.5
+  } else {
+    // Relative-only data: require a clear gap between top-1 and top-2.
+    const ni1 = top1.normalisedInfluence
+    if (!Number.isFinite(ni1) || ni1 <= 0) return null
+    const top2 = sorted[1]
+    const ni2 = top2?.normalisedInfluence ?? 0
+    if (ni2 > 0) {
+      isDominant = (ni1 / ni2) >= 2.0
+    } else {
+      // Only one driver with non-zero influence — genuinely dominant.
+      isDominant = true
+    }
   }
+  if (!isDominant) return null
+
   const cleaned = stripEncodingNotation(rawLabel)
   if (!cleaned) return null
   if (containsBannedTerm(cleaned)) return null

--- a/src/components/results/analysisHeroV17/tokens.ts
+++ b/src/components/results/analysisHeroV17/tokens.ts
@@ -13,7 +13,7 @@ import {
 import type { ElementType } from 'react'
 import type { IconBtn } from '@/canvas/components/pre-analysis/primitives/IconBtn'
 import type {
-  DimensionSegment, HeroRow, MetaPill, FooterCheck, RowAction,
+  DimensionSegment, HeroRow, FooterCheck, RowAction,
 } from './analysisHeroVM.types'
 
 export const STRIP_FILL_CLASS: Record<DimensionSegment['token'], string> = {
@@ -42,13 +42,6 @@ export const CATEGORY_DOT_CLASS: Record<HeroRow['category'], string> = {
 }
 
 export const PRIORITY_FILL_CLASS: Record<HeroRow['category'], string> = CATEGORY_DOT_CLASS
-
-export const META_PILL_CLASS: Record<MetaPill['tone'], string> = {
-  neutral: 'border-panel-border text-text-light',
-  warn: 'border-warning/45 text-warning',
-  danger: 'border-danger/45 text-danger',
-  reflect: 'border-option/55 text-option',
-}
 
 export const FOOTER_CHECK_CLASS: Record<FooterCheck['tone'], string> = {
   ok: 'text-success',


### PR DESCRIPTION
## Summary
- **Banner**: `Refresh analysis · Coaching may be out of date` single-row strip, ~64 → ~46 px (44 px WCAG touch-target floor).
- **Verified count**: moved from visible header text to the Verified strip-segment's tooltip + aria-label.
- **Result context**: `{label} comes out ahead most often.` + new `The result depends most on {factor}.` dependency line when a safe dominant factor is corroborated.
- **Meta pills**: removed cleanly (signals remain in HeroFooter checks).
- **Key question card**: renders only when `m2DecisionQualityPrompts[0]` is present AND `reviewStatus === 'complete'` AND chat is open AND glossary-safe. Category-template fallback dropped.

Feature flag `analysisHeroV17` remains **off-by-default**; affected surface is V17 hero only.

## Dependency-line dominance gate

Three layered checks (`buildAnalysisHeroViewModel.ts` `buildDependencyLine`):
1. **Rank-1 consistency** — named factor MUST be the rank-1 driver in `data.drivers.drivers[]`. Recommendation/drivers disagreement → omit.
2. **Dominance** — prefer `influenceScore >= 0.5` (absolute ISL structural causal influence); else require `top1/top2 normalisedInfluence ratio >= 2.0` (same 2:1 the legacy heuristic uses, applied here as a guard not a selector).
3. **Glossary gate** — cleaned label passes `containsBannedTerm`.

Round-2 review flagged a real bug in the previous gate (`normalisedInfluence >= 0.5` is trivially satisfied because top driver normalises to 1.0). This PR replaces it with the correct rank-1 + ratio/influenceScore gate.

## Phase 0 investigation
The Phase-0 investigation report is committed at `docs/investigations/analysis-hero-v17-top-section.md` and includes an **implementation appendix** documenting where the body of the report diverges from what was actually built (44 px floor vs. 36 px estimate; rank-1 + ratio gate vs. simple NI threshold).

## Test plan
- [x] Typecheck: clean (`npm run typecheck`)
- [x] Targeted vitest: 260/262 passing (65 viewModel + 9 banner + 18 chatClosedRender + 17 accessibility + 78 glossaryCompliance + others). The 2 pre-existing `bodyLabelSafety.spec.tsx` failures are from PR #175's `TriageActionCardsBody` legacy copy rename — unchanged from `origin/staging` baseline, body content out of scope for this PR.
- [x] ESLint on all touched files: clean
- [x] Production build: passes (~35 s)
- [x] Pre-push gate (`scripts/validate-prepush.sh`): ALL CHECKS PASSED
- [x] Browser preview at `#/canvas?e2e=1` after clean storage on both baseline and impl-overlay: renders cleanly, no error boundary, no console errors
- [x] V5 Phase 3 forwards-compatibility: every slot is additive — `narrative_summary`, real `decision_quality_prompts`, etc. drop in without redesign

## Files touched
- `src/components/results/AnalysisOrphanBanner.tsx` — single-row strip + `Refresh analysis` copy
- `src/components/results/AnalysisHeroV17.tsx` — prop wiring to updated HeroResultContext
- `src/components/results/analysisHeroV17/ReadinessColourStrip.tsx` — Verified-segment tooltip + aria-label
- `src/components/results/analysisHeroV17/HeroResultContext.tsx` — dependency line + pills removal
- `src/components/results/analysisHeroV17/HeroKeyQuestion.tsx` — full-card hide when chat closed
- `src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts` — dependency-line builder, reviewStatus gate, category-template removal, MetaPill removal
- `src/components/results/analysisHeroV17/analysisHeroVM.types.ts` — `dependencyLine` field, `metaPills` + `MetaPill` removed
- `src/components/results/analysisHeroV17/tokens.ts` — `META_PILL_CLASS` removed
- Test surface: 5 spec files updated, 14 new tests added (incl. 5 integration-style with real normalisation formula)
- `docs/investigations/analysis-hero-v17-top-section.md` — Phase-0 report + implementation appendix

## Out of scope (deliberately untouched)
`useResultsSectionData.ts`, `useGuidanceStore`, `ResultsBody.tsx`, `src/canvas/conversation/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)