### PR TITLE
V17 hero — verb-led rows + lighter result context + CTA mirror + footer cleanup

### DIFF
--- a/src/components/results/AnalysisHeroV17.tsx
+++ b/src/components/results/AnalysisHeroV17.tsx
@@ -267,8 +267,6 @@ export const AnalysisHeroV17 = memo(function AnalysisHeroV17({
 
         <HeroFooter
           alsoLinks={heroVm.alsoLinks}
-          footerChecks={heroVm.footerChecks}
-          footerHint={heroVm.footerHint}
           footerCta={heroVm.footerCta}
           onAlsoClick={handleAlsoClick}
           onCtaClick={handleCtaClick}

--- a/src/components/results/analysisHeroV17/HeroFooter.tsx
+++ b/src/components/results/analysisHeroV17/HeroFooter.tsx
@@ -1,5 +1,5 @@
 /**
- * HeroFooter — also-line + footer check glyphs + state-dependent CTA.
+ * HeroFooter — also-line + state-dependent CTA.
  *
  * No auto-send paths after Fix 9 — every state's CTA is prefill-only.
  * The caller (`AnalysisHeroV17.handleCtaClick`) dispatches through
@@ -13,20 +13,28 @@
  * surfaces hide:
  *   - Also-line is hidden entirely (every link is prefill)
  *   - Footer CTA is hidden for weak / reflect / strong states
- *   - Moderate CTA stays visible with a softer label "Focus key
- *     estimate" because its focus side-effect is still useful without
- *     chat — onFocusNode runs even when prefill no-ops.
+ *   - Moderate CTA stays visible because its focus side-effect is still
+ *     useful without chat — onFocusNode runs even when prefill no-ops.
+ *
+ * 2026-05-21 correction pass:
+ *   - Footer-checks block (Result clear / Sensitive assumption /
+ *     Evidence gaps / Framing OK) REMOVED — duplicated the readiness
+ *     strip above and added cognitive load.
+ *   - Hint line ("Check the highest-priority input") REMOVED — duplicated
+ *     Row 1.
+ *   - Chat-closed CTA label flip now mirrors the CTA's `targetLabel`
+ *     ("Focus {target}" / "Focus top estimate") so closed/open copy is
+ *     consistent and there's no per-mode rename.
+ *   - The `footerChecks` and `footerHint` props are no longer consumed by
+ *     this component; the VM fields are retained with `@deprecated` JSDoc
+ *     (data-layer surgery is out of scope for this pass).
  */
 
-import { Check, X } from 'lucide-react'
 import { typography } from '@/styles/typography'
-import type { AlsoLink, FooterCheck, FooterCta } from './analysisHeroVM.types'
-import { FOOTER_CHECK_CLASS } from './tokens'
+import type { AlsoLink, FooterCta } from './analysisHeroVM.types'
 
 interface Props {
   alsoLinks: AlsoLink[]
-  footerChecks: FooterCheck[]
-  footerHint: string
   footerCta: FooterCta
   onAlsoClick: (link: AlsoLink) => void
   onCtaClick: () => void
@@ -34,19 +42,24 @@ interface Props {
   chatPrefillAvailable: boolean
 }
 
-export function HeroFooter({ alsoLinks, footerChecks, footerHint, footerCta, onAlsoClick, onCtaClick, chatPrefillAvailable }: Props) {
-  // Also-line visibility: minimum-items rule (Fix 7) AND chat
-  // availability (Fix 6). Need both ≥ 2 safe items AND chat open.
+export function HeroFooter({ alsoLinks, footerCta, onAlsoClick, onCtaClick, chatPrefillAvailable }: Props) {
+  // Also-line visibility: minimum-items rule AND chat availability.
   const showAlsoLine = chatPrefillAvailable && alsoLinks.length >= 2
 
-  // CTA visibility (Fix 6):
+  // CTA visibility:
   //   - moderate (check-key-estimate): always visible; focus side-effect
-  //     remains useful without chat. Label flips to "Focus key estimate"
+  //     remains useful without chat. Label flips to a "Focus" variant
   //     when chat is closed.
   //   - all other states: prefill-only — hide when chat is closed.
   const showCta = chatPrefillAvailable || footerCta.kind === 'check-key-estimate'
+
+  // Chat-closed label flip — mirrors the cleaned target derived in
+  // buildFooterCta. `targetLabel` is `null` for non-mirroring states or
+  // when Row 1's underlying label was unsafe / non-Verify; in that case
+  // we fall back to "Focus top estimate" (parallel to "Check top
+  // estimate" in chat-open mode).
   const ctaLabel = !chatPrefillAvailable && footerCta.kind === 'check-key-estimate'
-    ? 'Focus key estimate'
+    ? (footerCta.targetLabel ? `Focus ${footerCta.targetLabel}` : 'Focus top estimate')
     : footerCta.label
 
   return (
@@ -68,23 +81,8 @@ export function HeroFooter({ alsoLinks, footerChecks, footerHint, footerCta, onA
           ))}
         </div>
       )}
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex flex-col gap-0.5 min-w-0">
-          <div className={`flex items-center gap-2 flex-wrap ${typography.panelMeta}`}>
-            {footerChecks.map(c => (
-              <span key={c.label} className={`inline-flex items-center gap-1 ${FOOTER_CHECK_CLASS[c.tone]}`}>
-                {c.tone === 'ok'
-                  ? <Check size={11} aria-hidden="true" />
-                  : c.tone === 'reflect'
-                    ? <span className="text-[10px]" aria-hidden="true">◌</span>
-                    : <X size={11} aria-hidden="true" />}
-                {c.label}
-              </span>
-            ))}
-          </div>
-          <p className={`${typography.panelMeta} text-text-light`}>{footerHint}</p>
-        </div>
-        {showCta && (
+      {showCta && (
+        <div className="flex items-center justify-end">
           <button
             type="button"
             onClick={onCtaClick}
@@ -93,8 +91,8 @@ export function HeroFooter({ alsoLinks, footerChecks, footerHint, footerCta, onA
           >
             {ctaLabel}
           </button>
-        )}
-      </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/src/components/results/analysisHeroV17/HeroFooter.tsx
+++ b/src/components/results/analysisHeroV17/HeroFooter.tsx
@@ -62,6 +62,12 @@ export function HeroFooter({ alsoLinks, footerCta, onAlsoClick, onCtaClick, chat
     ? (footerCta.targetLabel ? `Focus ${footerCta.targetLabel}` : 'Focus top estimate')
     : footerCta.label
 
+  // Skip the whole section when neither child would render. Without
+  // this guard, weak / reflect / strong states with chat closed (CTA
+  // hidden, also-line hidden) would still emit the `pt-2 border-t`
+  // wrapper — a stray horizontal divider line with no content.
+  if (!showAlsoLine && !showCta) return null
+
   return (
     <section className="flex flex-col gap-2 pt-2 border-t border-panel-border" data-testid="hero-v17-footer">
       {showAlsoLine && (

--- a/src/components/results/analysisHeroV17/HeroInputRows.tsx
+++ b/src/components/results/analysisHeroV17/HeroInputRows.tsx
@@ -9,7 +9,7 @@
 import { useState } from 'react'
 import { typography } from '@/styles/typography'
 import type { HeroRow, RowAction } from './analysisHeroVM.types'
-import { ROW_TINT_CLASS, CATEGORY_DOT_CLASS, PRIORITY_FILL_CLASS } from './tokens'
+import { ROW_TINT_CLASS, CATEGORY_DOT_CLASS } from './tokens'
 import { HeroActionRow } from './HeroActionRow'
 
 interface HeroInputRowsProps {
@@ -69,19 +69,16 @@ function HeroInputRow({ row, dispatchRowAction, chatPrefillAvailable }: HeroInpu
       className={`px-2.5 py-2 border-b border-panel-border last:border-b-0 ${ROW_TINT_CLASS[row.category]}`}
       data-testid={`hero-v17-row-${row.category}`}
     >
-      {/* (Fix 5) gap-2 → gap-3 to give the right-aligned action cluster
-          breathing room from the priority pill. */}
+      {/* Priority pill (text + mini bar) removed in the 2026-05-21
+          correction pass: row order communicates priority and the verb-led
+          title + reason carry the actionable signal. `row.priority` and
+          `row.priorityWidth` stay on the VM type (still consumed by
+          buildResultsVM tests) but are not rendered. */}
       <div className="flex items-start gap-3 justify-between">
         <div className="flex flex-col gap-1 min-w-0 flex-1">
           <div className="flex items-center gap-1.5 min-w-0">
             <span className={`w-2 h-2 rounded-full flex-shrink-0 ${CATEGORY_DOT_CLASS[row.category]}`} aria-hidden="true" />
             <p className={`${typography.panelHeader} text-text-header truncate min-w-0 flex-1`} title={row.title}>{row.title}</p>
-            <span className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light flex-shrink-0`} title="Evidence priority">
-              <span className="w-6 h-[3px] rounded-full bg-panel-hover overflow-hidden">
-                <span className={`block h-full rounded-full ${PRIORITY_FILL_CLASS[row.category]}`} style={{ width: `${row.priorityWidth}%` }} />
-              </span>
-              {row.priority}
-            </span>
           </div>
           <p className={`${typography.panelBody} text-text-body line-clamp-2`}>{row.reason}</p>
         </div>

--- a/src/components/results/analysisHeroV17/HeroInputRows.tsx
+++ b/src/components/results/analysisHeroV17/HeroInputRows.tsx
@@ -77,10 +77,25 @@ function HeroInputRow({ row, dispatchRowAction, chatPrefillAvailable }: HeroInpu
       <div className="flex items-start gap-3 justify-between">
         <div className="flex flex-col gap-1 min-w-0 flex-1">
           <div className="flex items-center gap-1.5 min-w-0">
-            <span className={`w-2 h-2 rounded-full flex-shrink-0 ${CATEGORY_DOT_CLASS[row.category]}`} aria-hidden="true" />
-            <p className={`${typography.panelHeader} text-text-header truncate min-w-0 flex-1`} title={row.title}>{row.title}</p>
+            <span
+              className={`w-2 h-2 rounded-full flex-shrink-0 ${CATEGORY_DOT_CLASS[row.category]}`}
+              aria-hidden="true"
+              data-testid="hero-v17-row-dot"
+            />
+            <p
+              className={`${typography.panelHeader} text-text-header truncate min-w-0 flex-1`}
+              title={row.title}
+              data-testid="hero-v17-row-title"
+            >
+              {row.title}
+            </p>
           </div>
-          <p className={`${typography.panelBody} text-text-body line-clamp-2`}>{row.reason}</p>
+          <p
+            className={`${typography.panelBody} text-text-body line-clamp-2`}
+            data-testid="hero-v17-row-reason"
+          >
+            {row.reason}
+          </p>
         </div>
         <HeroActionRow
           actions={row.actions}

--- a/src/components/results/analysisHeroV17/HeroResultContext.tsx
+++ b/src/components/results/analysisHeroV17/HeroResultContext.tsx
@@ -1,16 +1,20 @@
 /**
  * HeroResultContext — result line + dependency line.
  *
- * Per docs/investigations/analysis-hero-v17-top-section.md:
+ * Per docs/investigations/analysis-hero-v17-top-section.md and the
+ * 2026-05-21 correction pass:
  * - The result line uses "comes out ahead most often" framing (Olumi
  *   communication glossary — probabilistic, not categorical).
  * - The dependency line surfaces below the result line when a safe
  *   dominant-factor source is available. Built upstream in
  *   `buildAnalysisHeroViewModel.buildDependencyLine`; null hides the line.
  * - The flip-risk reason line and the meta pills (stability + evidence
- *   bands) were removed (2026-05-21). Flip-risk content already surfaces
- *   in Row 1 of the input rows below; stability and evidence signals
- *   remain in HeroFooter checks.
+ *   bands) were removed earlier. Flip-risk content already surfaces in
+ *   Row 1 of the input rows below.
+ * - Visual chrome (rounded-md border + padding) was removed in the 2026-05-21
+ *   correction pass. The result + dependency lines now read as plain prose
+ *   inside the outer hero card, separated from neighbours by the parent's
+ *   `space-y-3`. The outer hero card already provides the border.
  */
 
 import { typography } from '@/styles/typography'
@@ -23,7 +27,7 @@ interface Props {
 export function HeroResultContext({ resultLine, dependencyLine }: Props) {
   return (
     <section
-      className="rounded-md border border-panel-border p-2.5 flex flex-col gap-1.5"
+      className="flex flex-col gap-1"
       aria-label="Result context"
       data-testid="hero-v17-result-context"
     >

--- a/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
@@ -138,7 +138,22 @@ describe('AnalysisHeroV17 — accessibility', () => {
     expect(screen.getByTestId('hero-v17-hidden-rows')).toBeInTheDocument()
   })
 
-  it('input rows expose category via both colour dot AND text label (colour is never the only signal)', () => {
+  it('input rows expose category via colour dot AND verb-led title (colour is never the only signal)', () => {
+    // Updated contract (2026-05-21 corrections pass): priority text
+    // labels were removed alongside the mini-bar. Category is now
+    // conveyed by:
+    //   1. The category dot (visible, accessible via the row's testid),
+    //      keyed by `CATEGORY_DOT_CLASS[row.category]`.
+    //   2. The verb-led title ("Verify ...", "Challenge ...", "Add ...")
+    //      which encodes the category intent in plain language.
+    //   3. The row reason copy.
+    //
+    // Note on the prior test: it asserted `/High|Medium|Low|Ready/`
+    // appeared in row text and was passing accidentally because
+    // `buildReason` produces `"High evidence priority. ..."` strings —
+    // i.e. the band literal was inside the reason copy, NOT in a
+    // priority pill. That signal is no longer load-bearing for
+    // category communication.
     render(
       <AnalysisHeroV17
         data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.6)] })}
@@ -146,12 +161,49 @@ describe('AnalysisHeroV17 — accessibility', () => {
         fragileEdgeCount={0}
       />,
     )
-    // Every visible row carries a priority text label inside its priority span.
     const rowRoot = screen.getByTestId('hero-v17-input-rows')
-    const priorityText = rowRoot.textContent ?? ''
-    // At least one of the band labels must appear.
-    const hasBandLabel = /High|Medium|Low|Ready/.test(priorityText)
-    expect(hasBandLabel).toBe(true)
+    // Each visible row has a category dot (aria-hidden span carrying
+    // the colour class) — non-colour signal is the verb-led title.
+    const rows = rowRoot.querySelectorAll('article')
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of Array.from(rows)) {
+      // Dot present (colour channel for sighted users).
+      const dot = row.querySelector('span[aria-hidden="true"]')
+      expect(dot).toBeTruthy()
+      // Verb-led title present (text channel — encodes category for
+      // colour-blind / screen-reader users without depending on hue).
+      const titleEl = row.querySelector('p')
+      const titleText = titleEl?.textContent ?? ''
+      const startsWithVerb = /^(Verify|Challenge|Add)\s+/.test(titleText)
+        || titleText === 'Add an alternative option'
+        || titleText === 'Create decision brief'
+      expect(startsWithVerb, `Row title "${titleText}" should be verb-led`).toBe(true)
+    }
+  })
+
+  it('input rows do NOT render a priority text pill (anti-drift on the removed channel)', () => {
+    // Sibling guard for the contract above: the prior priority pill
+    // (`<span title="Evidence priority">{High|Medium|Low|Ready}</span>`)
+    // is absent. This protects against accidental resurrection of the
+    // removed channel — the reason text containing words like "High
+    // evidence priority" is allowed (that's reason copy), but no span
+    // should hold ONLY a bare band label.
+    render(
+      <AnalysisHeroV17
+        data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.6)] })}
+        vm={makeVm()}
+        fragileEdgeCount={0}
+      />,
+    )
+    const rowRoot = screen.getByTestId('hero-v17-input-rows')
+    // No tooltip-equipped priority span.
+    expect(rowRoot.querySelector('span[title="Evidence priority"]')).toBeNull()
+    // No span whose entire text content equals a bare band label.
+    const spans = rowRoot.querySelectorAll('span')
+    for (const s of Array.from(spans)) {
+      const t = (s.textContent ?? '').trim()
+      expect(['High', 'Medium', 'Low', 'Ready']).not.toContain(t)
+    }
   })
 
   it('legend list (4 dimension labels) renders visible text alongside coloured dots', () => {
@@ -182,26 +234,9 @@ describe('AnalysisHeroV17 — accessibility', () => {
     expect(ctx.className).not.toMatch(/(^|\s)(p-|px-|py-|pt-|pb-)\d/)
   })
 
-  it('row markup does not render priority text pill or mini-bar', () => {
-    render(
-      <AnalysisHeroV17
-        data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.5)] })}
-        vm={makeVm()}
-        fragileEdgeCount={0}
-      />,
-    )
-    const rowRoot = screen.getByTestId('hero-v17-input-rows')
-    // No tooltip-equipped priority pill span (previous container carried
-    // `title="Evidence priority"`).
-    const priorityPill = rowRoot.querySelector('span[title="Evidence priority"]')
-    expect(priorityPill).toBeNull()
-    // Spans inside rows must NOT carry only the band-name text content.
-    const spans = rowRoot.querySelectorAll('span')
-    for (const s of Array.from(spans)) {
-      const t = (s.textContent ?? '').trim()
-      expect(['High', 'Medium', 'Low', 'Ready']).not.toContain(t)
-    }
-  })
+  // (priority-pill anti-drift consolidated into the "input rows do NOT
+  // render a priority text pill" assertion higher up — keeping just one
+  // anti-drift test to avoid duplicate coverage)
 
   it('footer does not render the 4-check row (Result clear / Stability / Evidence / Framing)', () => {
     render(

--- a/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
@@ -164,6 +164,95 @@ describe('AnalysisHeroV17 — accessibility', () => {
     expect(text).toContain('Verified')
   })
 
+  // ── 2026-05-21 corrections pass: row/footer cleanup anti-drift ──────────
+
+  it('result context has no nested-card chrome (no border / rounded / padding)', () => {
+    render(
+      <AnalysisHeroV17
+        data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.5)] })}
+        vm={makeVm()}
+        fragileEdgeCount={0}
+      />,
+    )
+    const ctx = screen.getByTestId('hero-v17-result-context')
+    // The section's own border/rounded/padding classes were removed —
+    // it leans on the outer hero card's `p-3 space-y-3`.
+    expect(ctx.className).not.toMatch(/(^|\s)border(\s|$)/)
+    expect(ctx.className).not.toMatch(/(^|\s)rounded-/)
+    expect(ctx.className).not.toMatch(/(^|\s)(p-|px-|py-|pt-|pb-)\d/)
+  })
+
+  it('row markup does not render priority text pill or mini-bar', () => {
+    render(
+      <AnalysisHeroV17
+        data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.5)] })}
+        vm={makeVm()}
+        fragileEdgeCount={0}
+      />,
+    )
+    const rowRoot = screen.getByTestId('hero-v17-input-rows')
+    // No tooltip-equipped priority pill span (previous container carried
+    // `title="Evidence priority"`).
+    const priorityPill = rowRoot.querySelector('span[title="Evidence priority"]')
+    expect(priorityPill).toBeNull()
+    // Spans inside rows must NOT carry only the band-name text content.
+    const spans = rowRoot.querySelectorAll('span')
+    for (const s of Array.from(spans)) {
+      const t = (s.textContent ?? '').trim()
+      expect(['High', 'Medium', 'Low', 'Ready']).not.toContain(t)
+    }
+  })
+
+  it('footer does not render the 4-check row (Result clear / Stability / Evidence / Framing)', () => {
+    render(
+      <AnalysisHeroV17
+        data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.5)] })}
+        vm={makeVm()}
+        fragileEdgeCount={0}
+      />,
+    )
+    const footer = screen.getByTestId('hero-v17-footer')
+    const text = footer.textContent ?? ''
+    expect(text).not.toContain('Result clear')
+    expect(text).not.toContain('Stability limited')
+    expect(text).not.toContain('Sensitive assumption')
+    expect(text).not.toContain('Evidence gaps')
+    expect(text).not.toContain('Evidence covered')
+    expect(text).not.toContain('Framing OK')
+  })
+
+  it('footer does not render the hint line', () => {
+    render(
+      <AnalysisHeroV17
+        data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.5)] })}
+        vm={makeVm()}
+        fragileEdgeCount={0}
+      />,
+    )
+    const footer = screen.getByTestId('hero-v17-footer')
+    const text = footer.textContent ?? ''
+    expect(text).not.toContain('Check the highest-priority input')
+    expect(text).not.toContain('Improve inputs first')
+    expect(text).not.toContain('Challenge before deciding')
+    expect(text).not.toContain('Ready to brief')
+  })
+
+  it('row action icons distinguish AI (Work through with AI) from Discuss (Discuss with AI) via aria-label', () => {
+    render(
+      <AnalysisHeroV17
+        data={makeData({ stability: 0.7, gaps: [gap('Cost', 'n_c', 0.5)] })}
+        vm={makeVm()}
+        fragileEdgeCount={0}
+      />,
+    )
+    const rowRoot = screen.getByTestId('hero-v17-input-rows')
+    const aiBtn = rowRoot.querySelector('[aria-label="Work through with AI"]')
+    const discussBtn = rowRoot.querySelector('[aria-label="Discuss with AI"]')
+    expect(aiBtn).toBeTruthy()
+    expect(discussBtn).toBeTruthy()
+    expect(aiBtn).not.toBe(discussBtn)
+  })
+
   it('Actions menu items are keyboard-accessible — focus visible on click', () => {
     render(<AnalysisHeroV17 data={makeData()} vm={makeVm()} fragileEdgeCount={0} />)
     const toggle = screen.getByTestId('hero-v17-actions-toggle')

--- a/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
@@ -164,15 +164,19 @@ describe('AnalysisHeroV17 — accessibility', () => {
     const rowRoot = screen.getByTestId('hero-v17-input-rows')
     // Each visible row has a category dot (aria-hidden span carrying
     // the colour class) — non-colour signal is the verb-led title.
+    // Targets the stable hero-v17-row-dot and hero-v17-row-title test
+    // IDs rather than first-`<p>` / first-`span[aria-hidden]` selectors,
+    // which would have matched arbitrary DOM nodes if the row markup
+    // evolved.
     const rows = rowRoot.querySelectorAll('article')
     expect(rows.length).toBeGreaterThan(0)
     for (const row of Array.from(rows)) {
       // Dot present (colour channel for sighted users).
-      const dot = row.querySelector('span[aria-hidden="true"]')
+      const dot = row.querySelector('[data-testid="hero-v17-row-dot"]')
       expect(dot).toBeTruthy()
       // Verb-led title present (text channel — encodes category for
       // colour-blind / screen-reader users without depending on hue).
-      const titleEl = row.querySelector('p')
+      const titleEl = row.querySelector('[data-testid="hero-v17-row-title"]')
       const titleText = titleEl?.textContent ?? ''
       const startsWithVerb = /^(Verify|Challenge|Add)\s+/.test(titleText)
         || titleText === 'Add an alternative option'

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -496,7 +496,7 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.keyQuestion).toBeNull()
     })
 
-    it('user-supplied factor label containing banned term → row title preserves user data; key question hidden on fallback', () => {
+    it('user-supplied factor label containing banned term → row title preserves user data after Verify prefix; key question hidden on fallback', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -505,8 +505,10 @@ describe('buildAnalysisHeroViewModel', () => {
         }),
         vm: makeVm({ decisionState: 'sensitive' }),
       })
-      // Row title preserves the user's label (we never rewrite user data).
-      expect(vm.inputRows[0].title).toBe('the winning team')
+      // Row title preserves the user's label after the Verify prefix —
+      // we never rewrite user data, we only prepend a verb (2026-05-21
+      // corrections pass).
+      expect(vm.inputRows[0].title).toBe('Verify the winning team')
       // No DQP → card hidden. The banned-term-in-label never reaches the
       // question text path because that path no longer exists.
       expect(vm.keyQuestion).toBeNull()
@@ -868,7 +870,7 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.footerCta.label).toBe('Review weak inputs')
     })
 
-    it('moderate → check-key-estimate with topRow focusTargetId', () => {
+    it('moderate → check-key-estimate, CTA label mirrors Row 1 verb-led target', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.7, gaps: [gap('Cost', 'n_cost', 0.5)] }),
@@ -876,10 +878,17 @@ describe('buildAnalysisHeroViewModel', () => {
       })
       expect(vm.footerCta.kind).toBe('check-key-estimate')
       expect(vm.footerCta.focusTargetId).toBe('n_cost')
+      // CTA mirror: Row 1 title is 'Verify Cost' → CTA label is 'Check Cost'
+      expect(vm.footerCta.label).toBe('Check Cost')
+      // targetLabel exposes the cleaned (no-Verify-prefix) underlying label.
+      expect(vm.footerCta.targetLabel).toBe('Cost')
+      // chatPrompt uses the same cleaned label — anti-drift on the Verify
+      // interpolation flaw (must NOT contain 'Verify' anywhere).
       expect(vm.footerCta.chatPrompt).toContain('Cost')
+      expect(vm.footerCta.chatPrompt).not.toContain('Verify ')
     })
 
-    it('moderate with no topRow → focusTargetId undefined, generic prompt', () => {
+    it('moderate with no topRow → focusTargetId undefined, fallback label and generic prompt', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({ stability: 0.7 }),
@@ -887,6 +896,51 @@ describe('buildAnalysisHeroViewModel', () => {
       })
       expect(vm.footerCta.kind).toBe('check-key-estimate')
       expect(vm.footerCta.focusTargetId).toBeUndefined()
+      expect(vm.footerCta.label).toBe('Check top estimate')
+      expect(vm.footerCta.targetLabel).toBeNull()
+    })
+
+    // CTA mirror policy + safety guards (2026-05-21 corrections).
+    // NOTE on coverage / reflect Row-1 cases: state selection forces
+    // 'weak' when optionCount < 2 (the coverage-row trigger), and
+    // 'reflect' when bias findings appear in a robust decision. So a
+    // moderate-state CTA with a non-Verify Row 1 is structurally hard
+    // to construct. The simpler reachable case — moderate state with
+    // no topRow at all — is covered by the existing "moderate with no
+    // topRow" test above, which already asserts the 'Check top
+    // estimate' fallback + null targetLabel.
+
+    it('CTA chatPrompt never contains the "Verify " prefix (anti-drift on interpolation flaw)', () => {
+      // Bug guarded against: prior gate composed chatPrompt as
+      //   "Check whether the estimate for ${row1Title} ..."
+      // which would interpolate "Verify Tech Lead in Place" verbatim.
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        data: makeData({ stability: 0.7, gaps: [gap('Tech Lead in Place', 'n_t', 0.6)] }),
+        vm: makeVm(),
+      })
+      expect(vm.footerCta.chatPrompt).not.toContain('Verify ')
+      expect(vm.footerCta.chatPrompt).toContain('Tech Lead in Place')
+      expect(vm.footerCta.label).toBe('Check Tech Lead in Place')
+    })
+
+    it('moderate with banned-term user label → CTA falls back to "Check top estimate", banned term not amplified', () => {
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        data: makeData({
+          stability: 0.7,
+          gaps: [gap('the winning team', 'n_w', 0.6)],
+        }),
+        vm: makeVm({ decisionState: 'sensitive' }),
+      })
+      // Row 1 title still preserves the user label after verb prefix:
+      // 'Verify the winning team'. But the underlying stripped label
+      // ('the winning team') contains a banned term → CTA falls back.
+      expect(vm.inputRows[0].title).toBe('Verify the winning team')
+      expect(vm.footerCta.label).toBe('Check top estimate')
+      expect(vm.footerCta.targetLabel).toBeNull()
+      expect(vm.footerCta.label.toLowerCase()).not.toContain('winning')
+      expect(vm.footerCta.chatPrompt.toLowerCase()).not.toContain('winning')
     })
 
     it('reflect → challenge-result kind, "Test the result" label (Fix 9)', () => {

--- a/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
@@ -250,7 +250,7 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
       expect(screen.queryByTestId('hero-v17-footer-cta')).toBeNull()
     })
 
-    it('moderate state CTA: VISIBLE with label "Focus key estimate" when chat is closed', () => {
+    it('moderate state CTA: VISIBLE with "Focus {target}" mirror when chat is closed', () => {
       render(
         <AnalysisHeroV17
           data={makeData({ gaps: [gap('Cost', 'n_c', 0.5)] })}
@@ -259,7 +259,24 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
         />,
       )
       const cta = screen.getByTestId('hero-v17-footer-cta')
-      expect(cta.textContent).toBe('Focus key estimate')
+      // CTA mirror policy (2026-05-21): chat-closed flips to
+      // "Focus {targetLabel}" using the cleaned Row 1 target.
+      expect(cta.textContent).toBe('Focus Cost')
+    })
+
+    it('moderate state CTA: chat-closed + no Row 1 → "Focus top estimate" fallback', () => {
+      // Moderate state with no rows: no fragile edge, no evidence gaps,
+      // 2 options, no bias findings → moderate, empty inputRows.
+      // topRow is undefined → CTA falls back to "Focus top estimate".
+      render(
+        <AnalysisHeroV17
+          data={makeData({ stability: 0.7 })}
+          vm={makeVm()}
+          fragileEdgeCount={0}
+        />,
+      )
+      const cta = screen.getByTestId('hero-v17-footer-cta')
+      expect(cta.textContent).toBe('Focus top estimate')
     })
 
     it('reflect state CTA: hidden when chat is closed (prefill-only post-Fix-9)', () => {
@@ -284,7 +301,7 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
       expect(screen.queryByTestId('hero-v17-footer-cta')).toBeNull()
     })
 
-    it('moderate CTA flips back to "Test the result"-ish full label when chat opens', () => {
+    it('moderate CTA flips to "Check {target}" mirror when chat opens', () => {
       useGuidanceStore.setState({ _prefillChat: () => {}, _sendMessage: () => {} })
       render(
         <AnalysisHeroV17
@@ -294,7 +311,8 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
         />,
       )
       const cta = screen.getByTestId('hero-v17-footer-cta')
-      expect(cta.textContent).toBe('Check key estimate')
+      // CTA mirror policy (2026-05-21): chat-open uses "Check {targetLabel}".
+      expect(cta.textContent).toBe('Check Cost')
     })
   })
 })

--- a/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
@@ -250,6 +250,25 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
       expect(screen.queryByTestId('hero-v17-footer-cta')).toBeNull()
     })
 
+    it('weak state + chat closed: hero-v17-footer section skipped entirely (no stray border-t)', () => {
+      // Anti-drift on the self-review fix (2026-05-21): when both the
+      // also-line and the CTA are hidden, the whole <section> is
+      // skipped so the `pt-2 border-t` wrapper doesn't render an empty
+      // horizontal divider line.
+      const data: ResultsSectionDataReturn = {
+        ...makeData({ gaps: [gap('A', 'a', 0.4), gap('B', 'b', 0.3), gap('C', 'c', 0.2), gap('D', 'd', 0.1)] }),
+        recommendation: { ...makeData().recommendation, recommendedOption: null, allOptions: [] },
+      } as ResultsSectionDataReturn
+      render(
+        <AnalysisHeroV17
+          data={data}
+          vm={makeVm({ decisionState: 'indeterminate' })}
+          fragileEdgeCount={0}
+        />,
+      )
+      expect(screen.queryByTestId('hero-v17-footer')).toBeNull()
+    })
+
     it('moderate state CTA: VISIBLE with "Focus {target}" mirror when chat is closed', () => {
       render(
         <AnalysisHeroV17

--- a/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
@@ -145,8 +145,11 @@ describe('AnalysisHeroV17 — glossary compliance (VM output)', () => {
       acc.push(r.title, r.reason, r.priority, r.chatPrompt)
     }
     vm.alsoLinks.forEach(a => { acc.push(a.label); acc.push(a.chatPrompt) })
-    vm.footerChecks.forEach(c => acc.push(c.label))
-    acc.push(vm.footerHint, vm.footerCta.label, vm.footerCta.chatPrompt)
+    // `footerChecks` + `footerHint` are deprecated (no longer rendered
+    // by HeroFooter post 2026-05-21 corrections pass). They remain on
+    // the VM with @deprecated JSDoc, but are not user-visible copy and
+    // should not be scanned by the user-visible-copy glossary sweep.
+    acc.push(vm.footerCta.label, vm.footerCta.chatPrompt)
     return acc
   }
 
@@ -443,8 +446,10 @@ describe('AnalysisHeroV17 — comprehensive banned-term sweep through user label
       acc.push(r.reason, r.priority, r.chatPrompt)
     }
     vm.alsoLinks.forEach(a => { acc.push(a.label); acc.push(a.chatPrompt) })
-    vm.footerChecks.forEach(c => acc.push(c.label))
-    acc.push(vm.footerHint, vm.footerCta.label, vm.footerCta.chatPrompt)
+    // `footerChecks` + `footerHint` are deprecated (no longer rendered
+    // post 2026-05-21 corrections pass) — see the parallel helper above
+    // for the same skip.
+    acc.push(vm.footerCta.label, vm.footerCta.chatPrompt)
     return acc
   }
 

--- a/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
@@ -168,8 +168,10 @@ describe('AnalysisHeroV17 — glossary compliance (VM output)', () => {
       vm: makeVm(),
       ...HERO_DEFAULTS,
     })
-    // Row title preserves the user's label — we do not rewrite user data.
-    expect(vm.inputRows[0].title).toBe('the winning team')
+    // Row title preserves the user's label after the Verify prefix
+    // (2026-05-21 corrections pass) — we do not rewrite user data, we
+    // only prepend a verb.
+    expect(vm.inputRows[0].title).toBe('Verify the winning team')
     // No DQP is present in this fixture, so the card is hidden — the
     // templated fallback was removed (2026-05-21). The banned-term-in-label
     // never reaches the key-question text because that path no longer exists.
@@ -460,9 +462,14 @@ describe('AnalysisHeroV17 — comprehensive banned-term sweep through user label
         ...HERO_DEFAULTS,
       })
 
-      // Row title preserves the user's label verbatim — we never rewrite
-      // user data. That's intentional.
-      expect(vm.inputRows[0].title).toBe(factorLabel)
+      // Row title preserves the user's label verbatim AFTER the verb
+      // prefix (2026-05-21 corrections pass): risk/evidence/causal rows
+      // are prepended with "Verify ". We never rewrite the user's label,
+      // we only prepend a verb. The user-data preservation guarantee is
+      // unchanged — the factor label still flows through unchanged as the
+      // suffix of the title.
+      expect(vm.inputRows[0].title).toBe(`Verify ${factorLabel}`)
+      expect(vm.inputRows[0].title.endsWith(factorLabel)).toBe(true)
 
       // But every piece of GENERATED copy must be clean of the banned term.
       const offenders: Array<{ field: string; text: string }> = []

--- a/src/components/results/analysisHeroV17/__tests__/p1Fixes.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/p1Fixes.spec.tsx
@@ -117,8 +117,9 @@ describe('AnalysisHeroV17 — P1.1: prefillChat never auto-sends', () => {
     const cta = screen.getByTestId('hero-v17-footer-cta') as HTMLButtonElement
     // The moderate-state CTA stays visible even when chat is closed
     // (Fix 6) because its focus side-effect is still useful. The label
-    // flips to "Focus key estimate" to be honest about what works.
-    expect(cta.textContent).toBe('Focus key estimate')
+    // flips to "Focus {target}" mirror (2026-05-21 corrections) — Row 1
+    // is 'Verify Cost', so the cleaned target is 'Cost'.
+    expect(cta.textContent).toBe('Focus Cost')
     fireEvent.click(cta)
     expect(focusSpy).toHaveBeenCalledWith('n_c')  // focus runs
     expect(sendSpy).not.toHaveBeenCalled()        // never auto-sends
@@ -286,9 +287,13 @@ describe('rowRanking — P1.4: row chatPrompts use safe fallback for banned labe
     })
     const rows = rankHeroRows(data, 'moderate')
     const row = rows[0]
-    // Title preserves the user's exact label — we do not rewrite user data.
-    expect(row.title).toBe('the winning team')
-    // But the generated chatPrompt must NOT contain the banned term.
+    // Verb-led title (2026-05-21 corrections): evidence → 'Verify {raw
+    // label}'. The user's exact label is preserved verbatim after the
+    // verb prefix — we don't rewrite user data, we just prepend a verb.
+    expect(row.title).toBe('Verify the winning team')
+    // But the generated chatPrompt must NOT contain the banned term —
+    // chatPrompt continues to interpolate the raw label via safeRowLabel,
+    // which substitutes 'this factor' when the underlying label is unsafe.
     expect(row.chatPrompt.toLowerCase()).not.toContain('winning')
     expect(row.chatPrompt).toContain('this factor')
   })

--- a/src/components/results/analysisHeroV17/__tests__/rowRanking.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/rowRanking.spec.ts
@@ -238,4 +238,33 @@ describe('rankHeroRows — polish pass: fragile/risk row shape', () => {
     expect(coverageRow).toBeTruthy()
     expect(coverageRow!.actions).toContain('add')
   })
+
+  // ── verbLeadTitle defensive behaviour (2026-05-21 self-review) ─────────
+  it('verb prefix never composes with an empty user label — falls back to generic phrase', () => {
+    // Degenerate upstream data (empty fragile-edge fromLabel). The
+    // verbLeadTitle helper trims and falls back rather than producing
+    // "Verify " (trailing space, no factor name).
+    const rows = rankHeroRows(
+      makeData({
+        fragile: { fromId: 'n_f', fromLabel: '', alternativeWinnerLabel: 'B' },
+      }),
+      'moderate',
+    )
+    const riskRow = rows.find(r => r.category === 'risk')
+    expect(riskRow).toBeTruthy()
+    expect(riskRow!.title).toBe('Verify this factor')
+    expect(riskRow!.title).not.toMatch(/Verify\s*$/) // never trailing-space empty
+  })
+
+  it('verb prefix handles whitespace-only user labels by falling back', () => {
+    const rows = rankHeroRows(
+      makeData({
+        fragile: { fromId: 'n_f', fromLabel: '   ', alternativeWinnerLabel: 'B' },
+      }),
+      'moderate',
+    )
+    const riskRow = rows.find(r => r.category === 'risk')
+    expect(riskRow).toBeTruthy()
+    expect(riskRow!.title).toBe('Verify this factor')
+  })
 })

--- a/src/components/results/analysisHeroV17/__tests__/rowRanking.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/rowRanking.spec.ts
@@ -101,10 +101,11 @@ describe('rankHeroRows', () => {
       'moderate',
     )
     expect(rows[0].category).toBe('risk')
-    expect(rows[0].title).toBe('Hiring rate')
+    // Verb-led title (2026-05-21 corrections): risk → 'Verify {raw label}'.
+    expect(rows[0].title).toBe('Verify Hiring rate')
   })
 
-  it('evidence gaps sorted by VOI descending', () => {
+  it('evidence gaps sorted by VOI descending — titles carry the Verify prefix', () => {
     const rows = rankHeroRows(
       makeData({
         gaps: [
@@ -115,7 +116,11 @@ describe('rankHeroRows', () => {
       }),
       'moderate',
     )
-    expect(rows.map(r => r.title)).toEqual(['High priority', 'Mid priority', 'Low priority'])
+    expect(rows.map(r => r.title)).toEqual([
+      'Verify High priority',
+      'Verify Mid priority',
+      'Verify Low priority',
+    ])
   })
 
   it('VOI band: ≥0.5 → High, ≥0.2 → Medium, else Low', () => {
@@ -157,9 +162,11 @@ describe('rankHeroRows', () => {
       }),
       'moderate',
     )
-    const fragileRow = rows.find(r => r.title === 'Hiring rate')
-    const evidenceRow = rows.find(r => r.title === 'Evidence factor')
-    const reflectRow = rows.find(r => r.title === 'Sunk cost')
+    // Verb-led titles per 2026-05-21 corrections pass: risk/evidence get
+    // "Verify " prefix; reflect gets "Challenge " prefix.
+    const fragileRow = rows.find(r => r.title === 'Verify Hiring rate')
+    const evidenceRow = rows.find(r => r.title === 'Verify Evidence factor')
+    const reflectRow = rows.find(r => r.title === 'Challenge Sunk cost')
     expect(fragileRow?.category).toBe('risk')
     expect(evidenceRow?.category).toBe('evidence')
     expect(reflectRow?.category).toBe('reflect')

--- a/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
+++ b/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
@@ -97,6 +97,16 @@ export interface FooterCta {
   chatPrompt: string
   /** Factor to focus (moderate state only). */
   focusTargetId: string | undefined
+  /**
+   * Cleaned target label used for the chat-closed "Focus {target}"
+   * variant (moderate state only). `null` when the CTA does not mirror
+   * Row 1 — either the state is not moderate, or Row 1's underlying
+   * user label was unsafe (banned-term) / non-Verify-prefixed. The
+   * `label` and `chatPrompt` fields are already composed from this
+   * value upstream; `HeroFooter` reads `targetLabel` directly to avoid
+   * re-parsing `label`. Added 2026-05-21 corrections pass.
+   */
+  targetLabel: string | null
 }
 
 /**
@@ -141,9 +151,20 @@ export interface AnalysisHeroVM {
   hiddenRows: HeroRow[]
   /** "Also:" footer links (up to 3). */
   alsoLinks: AlsoLink[]
-  /** Footer check glyphs. */
+  /**
+   * @deprecated 2026-05-21 corrections pass: no longer rendered by
+   * HeroFooter (the 4-check row duplicated the readiness strip above
+   * and added cognitive load). Retained on the VM for forward-compat
+   * with a potential debug surface; scheduled for removal in the next
+   * major VM bump if no consumer emerges.
+   */
   footerChecks: FooterCheck[]
-  /** Footer hint line above the CTA. */
+  /**
+   * @deprecated 2026-05-21 corrections pass: no longer rendered by
+   * HeroFooter (the hint duplicated Row 1's title). Retained on the
+   * VM for forward-compat; scheduled for removal in the next major
+   * VM bump.
+   */
   footerHint: string
   /** State-dependent CTA. */
   footerCta: FooterCta

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -332,8 +332,15 @@ function buildFooterChecks(
 }
 
 function buildFooterCta(state: HeroState, topRow: HeroRow | undefined): FooterCta {
-  // Source of truth: investigation §11.4 + brief §3 step 6. Sequencing is
-  // enforced at the call site (component dispatches via prop handlers).
+  // Source of truth: investigation §11.4 + 2026-05-21 corrections pass.
+  // Sequencing is enforced at the call site (component dispatches via
+  // prop handlers).
+  //
+  // CTA mirroring policy (corrections pass §7a):
+  //   - weak / reflect / strong → state-specific CTA (intent isn't
+  //     "check one estimate"; mirroring would produce mismatched copy).
+  //   - moderate → mirror Row 1's verb-led title via a cleaned
+  //     `targetLabel`. See §7 in the plan for the derivation.
   switch (state) {
     case 'weak':
       return {
@@ -341,16 +348,38 @@ function buildFooterCta(state: HeroState, topRow: HeroRow | undefined): FooterCt
         kind: 'review-weak-inputs',
         chatPrompt: 'Walk me through the highest-priority inputs one at a time. Ask what I know before suggesting changes.',
         focusTargetId: undefined,
+        targetLabel: null,
       }
-    case 'moderate':
+    case 'moderate': {
+      // Step 1: strip the "Verify " prefix Row 1 carries, so the result
+      // composes with "Check " / "Focus " without producing
+      // "Check Verify Tech Lead in Place".
+      const row1Title = topRow?.title ?? ''
+      const stripped = row1Title.startsWith('Verify ')
+        ? row1Title.slice('Verify '.length)
+        : ''
+      // Step 2: glossary-safe handling on the stripped label. If the
+      // underlying user label trips the banned-term scanner, fall back
+      // to the safe generic — never amplify the banned term into CTA
+      // copy or the chat prompt.
+      const safeTargetLabel = stripped && !containsBannedTerm(stripped)
+        ? stripped
+        : null
+      // Step 3: compose label + chatPrompt from the single safe target.
+      const label = safeTargetLabel
+        ? `Check ${safeTargetLabel}`
+        : 'Check top estimate'
+      const chatPrompt = safeTargetLabel
+        ? `Check whether the estimate for ${safeTargetLabel} matches my experience.`
+        : 'Check whether the highest-priority estimate matches my experience.'
       return {
-        label: 'Check key estimate',
+        label,
         kind: 'check-key-estimate',
-        chatPrompt: topRow?.title
-          ? `Check whether the estimate for ${safeLabel(topRow.title, 'this factor')} matches my experience.`
-          : 'Check whether the highest-priority estimate matches my experience.',
+        chatPrompt,
         focusTargetId: topRow?.targetNodeId,
+        targetLabel: safeTargetLabel,
       }
+    }
     case 'reflect':
       return {
         // Internal kind retained for compatibility; user-facing copy is
@@ -362,6 +391,7 @@ function buildFooterCta(state: HeroState, topRow: HeroRow | undefined): FooterCt
         kind: 'challenge-result',
         chatPrompt: 'Challenge the current leading option. Make the strongest case for the next closest option.',
         focusTargetId: undefined,
+        targetLabel: null,
       }
     case 'strong':
       return {
@@ -369,6 +399,7 @@ function buildFooterCta(state: HeroState, topRow: HeroRow | undefined): FooterCt
         kind: 'create-decision-brief',
         chatPrompt: 'Help me capture the result, rationale, key assumptions and caveats as a decision brief.',
         focusTargetId: undefined,
+        targetLabel: null,
       }
   }
 }

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -3,13 +3,13 @@
  *
  * Source of truth: docs/investigations/analysis-hero-v17.md §9–§11
  * (initial) + docs/investigations/analysis-hero-v17-top-section.md
- * (2026-05-21 top-section optimisation pass).
+ * (2026-05-21 top-section optimisation passes).
  *
  * This function is pure and deterministic. The component must consume the
  * VM and render — no further computation in JSX. State selection lives in
- * `stateSelection.ts`; row ranking + category lives in `rowRanking.ts`;
- * this module wires them together and resolves the key question, dimensions,
- * dependency line, footer checks, and CTA.
+ * `stateSelection.ts`; row ranking + category + verb-led title composition
+ * lives in `rowRanking.ts`; this module wires them together and resolves
+ * the key question, dimensions, dependency line, and CTA.
  *
  * v1 fallbacks (per Paul's approved direction):
  *   - The fourth strip segment is labelled "Verified" (not "User input")
@@ -26,11 +26,25 @@
  *   - Result line uses probabilistic framing: "{label} comes out ahead
  *     most often." A dependency line "The result depends most on {factor}."
  *     renders below only when `recommendation.dominantFactor*` is populated
- *     AND a matching driver has `normalisedInfluence >= 0.5` (corroboration
- *     against the same threshold PLoT B1 uses internally — suppresses
- *     low-confidence M1 emissions and tie cases).
- *   - Stability/evidence meta pills were removed entirely; those signals
- *     surface in `footerChecks` instead.
+ *     AND the named factor IS the rank-1 driver AND a dominance check
+ *     passes: prefer `influenceScore >= 0.5` (absolute ISL structural
+ *     causal influence) when present, else require `top1/top2
+ *     normalisedInfluence ratio >= 2.0` (the same 2:1 threshold the
+ *     legacy heuristic uses internally, applied here as a guard not a
+ *     selector). Suppresses low-confidence M1 emissions and tie cases.
+ *     See `buildDependencyLine` below for the full gate.
+ *   - Stability/evidence meta pills were removed entirely. The
+ *     `footerChecks` and `footerHint` VM fields are also no longer
+ *     rendered by HeroFooter (corrections pass) — they remain on the VM
+ *     with `@deprecated` JSDoc, scheduled for removal in the next major
+ *     VM bump. Stability + evidence signals continue to surface via the
+ *     readiness colour-strip at the top of the hero.
+ *   - Row titles are verb-led ("Verify {factor}", "Challenge {bias type}",
+ *     "Add an alternative option"); see `verbLeadTitle` in rowRanking.ts.
+ *     User labels are preserved verbatim after the verb prefix.
+ *   - Footer CTA (moderate state only) mirrors Row 1 via a cleaned
+ *     `targetLabel` derived from Row 1's verb-led title; weak / reflect /
+ *     strong keep state-specific CTAs. See `buildFooterCta` below.
  *   - Key-question card renders only when a real `m2DecisionQualityPrompts[0]`
  *     is present, `reviewStatus === 'complete'`, and the prompt passes the
  *     glossary gate. No category-driven template fallback — generic

--- a/src/components/results/analysisHeroV17/rowRanking.ts
+++ b/src/components/results/analysisHeroV17/rowRanking.ts
@@ -114,15 +114,29 @@ function actionsForCategory(category: RowCategory, hasTarget: boolean): RowActio
   }
 }
 
-/** Glossary-aligned reason copy template. Ground → Propose. */
+/**
+ * Glossary-aligned reason copy template. Ground → Propose.
+ *
+ * 2026-05-21 correction pass: the `${band} evidence priority. ` lede was
+ * removed alongside the priority pill + mini-bar. Row order communicates
+ * priority; the reason explains why the row matters, not what its band
+ * is. Without this change, evidence rows still emitted
+ *   "High evidence priority. Check whether this estimate matches your
+ *    experience."
+ * which preserved the priority-band vocabulary the pill removal was
+ * meant to retire.
+ *
+ * `band` is still passed through (used by downstream
+ * `priority`/`priorityWidth` fields on the row VM, retained for forward-
+ * compat with tests that exercise the data layer), but it no longer
+ * influences the rendered reason copy.
+ */
 function buildReason(
-  category: RowCategory,
-  band: PriorityBand,
+  _category: RowCategory,
+  _band: PriorityBand,
   ground: string,
 ): string {
-  // Ground → Propose minimum. Band labelled per glossary §8.
-  const priorityLede = band === 'Ready' ? '' : `${band} evidence priority. `
-  return `${priorityLede}${ground}`.trim()
+  return ground.trim()
 }
 
 /**

--- a/src/components/results/analysisHeroV17/rowRanking.ts
+++ b/src/components/results/analysisHeroV17/rowRanking.ts
@@ -131,9 +131,15 @@ function buildReason(
  * phrase BEFORE interpolation. The row's own `title` field still preserves
  * the user's exact label — we do not rewrite user data, only the
  * generated prompt that names it.
+ *
+ * Defensive guard (2026-05-21 self-review): trim the label and fall back
+ * to the generic phrase when the cleaned label is empty. `safeRowLabel`
+ * only filters banned terms, so whitespace-only inputs would otherwise
+ * pass through and produce `"Help me with    ."`.
  */
 function chatPromptFor(title: string, fallback = 'this factor'): string {
-  const safe = safeRowLabel(title, fallback)
+  const trimmed = (title ?? '').trim()
+  const safe = trimmed ? safeRowLabel(trimmed, fallback) : fallback
   return `Help me with ${safe}. Ask one focused question first, then suggest the smallest useful update.`
 }
 

--- a/src/components/results/analysisHeroV17/rowRanking.ts
+++ b/src/components/results/analysisHeroV17/rowRanking.ts
@@ -59,20 +59,27 @@ function bandFromVoi(voi: number | null | undefined): { band: PriorityBand; widt
  * when an explicit evidence-source row exists.
  */
 function verbLeadTitle(category: RowCategory, label: string): string {
+  // Defensive: never compose a prefix-with-empty-label like "Verify "
+  // (trailing space, no factor name). Generic fallbacks below produce
+  // sensible copy if upstream data is degenerate. In normal data,
+  // factor labels are always non-empty by the time we reach a row
+  // builder, so these fallbacks are belt-and-braces.
+  const trimmed = (label ?? '').trim()
   switch (category) {
     case 'evidence':
     case 'risk':
     case 'causal':
-      return `Verify ${label}`
+      return trimmed ? `Verify ${trimmed}` : 'Verify this factor'
     case 'reflect':
-      return `Challenge ${label}`
+      return trimmed ? `Challenge ${trimmed}` : 'Challenge this assumption'
     case 'coverage':
       // The coverage row's underlying source isn't a noun phrase that
       // composes with "Add " (the literal was 'Option coverage'), so
       // substitute a verb-led title. No user data is interpolated here.
       return 'Add an alternative option'
     case 'ready':
-      // Existing 'Create decision brief' is already imperative — keep.
+      // Existing 'Create decision brief' is already imperative — keep
+      // the row builder's literal verbatim.
       return label
   }
 }

--- a/src/components/results/analysisHeroV17/rowRanking.ts
+++ b/src/components/results/analysisHeroV17/rowRanking.ts
@@ -40,6 +40,44 @@ function bandFromVoi(voi: number | null | undefined): { band: PriorityBand; widt
 }
 
 /**
+ * Verb-led title composition.
+ *
+ * Row TITLES preserve the user's verbatim label (`gap.factorLabel`,
+ * `fragile.fromLabel`, `f.type`) — we never rewrite user data. The verb
+ * is prepended; the underlying user-supplied string flows through
+ * unchanged. The TITLE field is the only place this preservation applies;
+ * generated copy (reason, chatPrompt) still uses `safeRowLabel`.
+ *
+ * Verb mapping (locked 2026-05-21):
+ *   evidence / risk / causal  →  Verify  (estimate to check)
+ *   reflect                    →  Challenge  (framing / result challenge)
+ *   coverage                   →  Add  (missing structural element — special-cased)
+ *   ready                      →  (existing imperative literal — no prefix)
+ *
+ * Validate ("evidence/source to validate") is documented but unused; no
+ * current row category resolves to a citable-source shape. Add the branch
+ * when an explicit evidence-source row exists.
+ */
+function verbLeadTitle(category: RowCategory, label: string): string {
+  switch (category) {
+    case 'evidence':
+    case 'risk':
+    case 'causal':
+      return `Verify ${label}`
+    case 'reflect':
+      return `Challenge ${label}`
+    case 'coverage':
+      // The coverage row's underlying source isn't a noun phrase that
+      // composes with "Add " (the literal was 'Option coverage'), so
+      // substitute a verb-led title. No user data is interpolated here.
+      return 'Add an alternative option'
+    case 'ready':
+      // Existing 'Create decision brief' is already imperative — keep.
+      return label
+  }
+}
+
+/**
  * Action set per row category. Right-aligned cluster on every row.
  *
  * (Fix 4) Standardised ordering: positions 1-2 are always `ai` + `discuss`,
@@ -97,13 +135,12 @@ function chatPromptFor(title: string, fallback = 'this factor'): string {
 function fragileEdgeRow(data: ResultsSectionDataReturn): HeroRow | null {
   const fragile = data?.confidence?.topFragileEdge ?? data?.confidence?.m1CoachingTopFragileEdge
   if (!fragile) return null
-  const title = fragile.fromLabel
+  // Verbed display title vs. raw label for chat prompt — `chatPromptFor`
+  // uses the user's underlying label, NOT the "Verify "-prefixed title.
+  const rawLabel = fragile.fromLabel
+  const title = verbLeadTitle('risk', rawLabel)
   const { band, width } = bandFromVoi(0.6) // fragile edges are inherently high-priority
-  // Short, complete sentence — the priority bar already shows "High",
-  // so the `High evidence priority. ` lede `buildReason` would prepend
-  // pushes the visible copy to two lines and truncates mid-sentence on
-  // the current panel width. Render the bare ground string so it fits
-  // on one line as-rendered.
+  // Short, complete sentence — kept from earlier rounds.
   const reason = 'Check this first. It could change the result.'
   return {
     key: `risk-${fragile.fromId}`,
@@ -114,7 +151,7 @@ function fragileEdgeRow(data: ResultsSectionDataReturn): HeroRow | null {
     category: 'risk',
     actions: actionsForCategory('risk', !!fragile.fromId),
     targetNodeId: fragile.fromId,
-    chatPrompt: chatPromptFor(title),
+    chatPrompt: chatPromptFor(rawLabel),
   }
 }
 
@@ -142,7 +179,9 @@ function evidenceGapRows(data: ResultsSectionDataReturn): HeroRow[] {
       : fallbackGround
     return {
       key: `evidence-${gap.factorId}`,
-      title: gap.factorLabel,
+      // Verbed display title; chatPrompt continues to interpolate the
+      // raw user label (not the "Verify "-prefixed title).
+      title: verbLeadTitle('evidence', gap.factorLabel),
       reason: buildReason('evidence', band, ground),
       priority: band,
       priorityWidth: width,
@@ -158,7 +197,10 @@ function coverageRow(data: ResultsSectionDataReturn): HeroRow | null {
   const optionCount = data?.recommendation?.allOptions?.length ?? 0
   if (optionCount >= 2) return null
   // Single-option model: coverage row prompting to add an alternative.
-  const title = 'Option coverage'
+  // `verbLeadTitle('coverage', ...)` ignores its label argument and
+  // returns the special-cased 'Add an alternative option' literal — see
+  // the verb-mapping comment above.
+  const title = verbLeadTitle('coverage', '')
   return {
     key: 'coverage-options',
     title,
@@ -187,7 +229,8 @@ function reflectRows(data: ResultsSectionDataReturn): HeroRow[] {
       : (f.description ?? 'Worth considering whether this pattern is influencing the framing.')
     return {
       key: `reflect-${i}`,
-      title: rawTitle,
+      // Verbed display title; chatPrompt continues to use the raw label.
+      title: verbLeadTitle('reflect', rawTitle),
       reason: buildReason('reflect', 'Medium', safeReason),
       priority: 'Medium' as const,
       priorityWidth: 60,

--- a/src/components/results/analysisHeroV17/tokens.ts
+++ b/src/components/results/analysisHeroV17/tokens.ts
@@ -41,10 +41,6 @@ export const CATEGORY_DOT_CLASS: Record<HeroRow['category'], string> = {
   ready: 'bg-success',
 }
 
-// `PRIORITY_FILL_CLASS` and `FOOTER_CHECK_CLASS` were removed in the
-// 2026-05-21 correction pass alongside the priority-pill mini-bar and
-// the footer-checks block. No remaining renderer consumes them.
-
 interface ActionIconDef {
   Icon: ElementType
   tooltip: string

--- a/src/components/results/analysisHeroV17/tokens.ts
+++ b/src/components/results/analysisHeroV17/tokens.ts
@@ -13,7 +13,7 @@ import {
 import type { ElementType } from 'react'
 import type { IconBtn } from '@/canvas/components/pre-analysis/primitives/IconBtn'
 import type {
-  DimensionSegment, HeroRow, FooterCheck, RowAction,
+  DimensionSegment, HeroRow, RowAction,
 } from './analysisHeroVM.types'
 
 export const STRIP_FILL_CLASS: Record<DimensionSegment['token'], string> = {
@@ -41,14 +41,9 @@ export const CATEGORY_DOT_CLASS: Record<HeroRow['category'], string> = {
   ready: 'bg-success',
 }
 
-export const PRIORITY_FILL_CLASS: Record<HeroRow['category'], string> = CATEGORY_DOT_CLASS
-
-export const FOOTER_CHECK_CLASS: Record<FooterCheck['tone'], string> = {
-  ok: 'text-success',
-  warn: 'text-warning',
-  danger: 'text-danger',
-  reflect: 'text-option',
-}
+// `PRIORITY_FILL_CLASS` and `FOOTER_CHECK_CLASS` were removed in the
+// 2026-05-21 correction pass alongside the priority-pill mini-bar and
+// the footer-checks block. No remaining renderer consumes them.
 
 interface ActionIconDef {
   Icon: ElementType


### PR DESCRIPTION
## Summary
- **Result context**: dropped nested-card chrome (no `border` / `rounded-md` / padding) — result line + dependency line render as plain prose inside the outer hero card.
- **Verb-led row titles**: `Verify {factor}`, `Challenge {bias}`, `Add an alternative option`. User labels preserved verbatim after the verb prefix.
- **Priority pill + mini-bar removed** from row markup. Row order conveys priority; category dot + verb-led title carry the channel.
- **Reason copy** dropped the `${band} evidence priority.` lede — band literal no longer appears in row reasons (matches the brief intent: reason explains why, not what band).
- **Footer**: 4-check row + hint line removed. `footerChecks` + `footerHint` VM fields retained `@deprecated`.
- **CTA mirrors Row 1** (moderate state only): clean `targetLabel` pipeline derives a single safe value from Row 1's verb-led title and uses it for both `label` (`Check {target}`) and `chatPrompt`. Anti-drift test asserts `chatPrompt` never contains `'Verify '`. Chat-closed flips to `Focus {target}` / `Focus top estimate`.

Feature flag `analysisHeroV17` stays **off-by-default**.

## Self-review + reviewer-feedback rounds incorporated

This PR includes the original implementation + three rounds of reviewer feedback:

| Commit | Round | What changed |
|---|---|---|
| `778422a3` | Initial | The seven hero-only corrections from the staging-screenshot brief |
| `f0bc7d6f` | Self-review | Empty bordered footer in weak/reflect/strong + chat closed → early-return `null`. Defensive empty-label fallback in `verbLeadTitle` |
| `b61d339f` | Review round 4 | `chatPromptFor` whitespace handling, dead exports in `tokens.ts`, stale header comments in `buildAnalysisHeroViewModel.ts`, stale priority-label test replaced with the new contract |
| `fb6889a9` | Review round 5 | Stable test IDs on row title/dot/reason, `footerChecks`/`footerHint` dropped from glossary user-visible-copy helpers, `buildReason` drops the `${band} evidence priority.` lede, memorial comment in `tokens.ts` removed |

## CTA mirror — final pipeline

In `buildFooterCta` moderate branch:

```ts
const row1Title = topRow?.title ?? ''
const stripped = row1Title.startsWith('Verify ')
  ? row1Title.slice('Verify '.length)
  : ''
const safeTargetLabel = stripped && !containsBannedTerm(stripped) ? stripped : null
const label = safeTargetLabel ? `Check ${safeTargetLabel}` : 'Check top estimate'
const chatPrompt = safeTargetLabel
  ? `Check whether the estimate for ${safeTargetLabel} matches my experience.`
  : 'Check whether the highest-priority estimate matches my experience.'
return { label, kind: 'check-key-estimate', chatPrompt, focusTargetId: topRow?.targetNodeId, targetLabel: safeTargetLabel }
```

Properties:
- Verify-prefixed Row 1 → mirrored copy
- Non-Verify Row 1 (coverage / reflect) → `Check top estimate` fallback
- Banned-term user label → fallback (banned term never amplified into label OR chatPrompt)
- No Row 1 → fallback

State-by-state CTA policy explicit in code comments: only moderate mirrors; weak / reflect / strong keep state-specific CTAs (their intent isn't "check one estimate").

## Test plan
- [x] Typecheck: clean
- [x] **271 hero+banner tests passing** (across 10 files). The 2 pre-existing `bodyLabelSafety.spec.tsx` failures are PR #175's `TriageActionCardsBody` legacy copy rename — body content out of scope, unchanged from `origin/staging` baseline.
- [x] ESLint clean on all touched files
- [x] Production build: passes (~30s)
- [x] Pre-push gate (`scripts/validate-prepush.sh`): ALL CHECKS PASSED
- [x] V5 Phase 3 forwards-compat preserved: `narrative_summary`, real `decision_quality_prompts`, etc. drop in without redesign

## Browser preview — baseline parity, not independently clean

Per reviewer round 5: production `build + preview` reproduces a generic `Render Error` on `#/canvas?e2e=1` from **both this branch AND clean `origin/staging`**. The error is **baseline parity, not a regression introduced by this PR**. Structurally my changed files only import into `ResultsBody.tsx`, which does not mount on `/canvas` without an analysis result — they cannot affect the canvas mount path.

This close-out does **not** include an independently clean post-analysis-route artefact; the route is broken on baseline.

## Files touched
- `src/components/results/AnalysisHeroV17.tsx` (composition root prop wiring)
- `src/components/results/analysisHeroV17/HeroResultContext.tsx`
- `src/components/results/analysisHeroV17/HeroInputRows.tsx` (+ test IDs)
- `src/components/results/analysisHeroV17/HeroFooter.tsx`
- `src/components/results/analysisHeroV17/rowRanking.ts` (verbLeadTitle, buildReason, chatPromptFor defensive)
- `src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts` (CTA pipeline, header docs)
- `src/components/results/analysisHeroV17/analysisHeroVM.types.ts` (`targetLabel` + `@deprecated` JSDoc)
- `src/components/results/analysisHeroV17/tokens.ts` (dead exports removed)
- 6 hero test files updated, 1 banner test file updated

## Out of scope (deliberately untouched)
`useResultsSectionData.ts`, `useGuidanceStore`, `ResultsBody.tsx`, `src/canvas/conversation/*`, `TriageActionCardsBody.tsx`, lower Analysis content. Removal of the `@deprecated` `footerChecks` / `footerHint` VM fields scheduled for the next major VM bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)