### PR TITLE
V17 hero row title — wrap to 2 lines instead of single-line truncating

### DIFF
--- a/src/components/results/analysisHeroV17/HeroInputRows.tsx
+++ b/src/components/results/analysisHeroV17/HeroInputRows.tsx
@@ -83,7 +83,7 @@ function HeroInputRow({ row, dispatchRowAction, chatPrefillAvailable }: HeroInpu
               data-testid="hero-v17-row-dot"
             />
             <p
-              className={`${typography.panelHeader} text-text-header truncate min-w-0 flex-1`}
+              className={`${typography.panelHeader} text-text-header line-clamp-2 break-words min-w-0 flex-1`}
               title={row.title}
               data-testid="hero-v17-row-title"
             >

--- a/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
@@ -242,6 +242,44 @@ describe('AnalysisHeroV17 — accessibility', () => {
   // render a priority text pill" assertion higher up — keeping just one
   // anti-drift test to avoid duplicate coverage)
 
+  it('row title wraps to two lines instead of single-line truncating (verb prefix preservation)', () => {
+    // Anti-drift on the 2026-05-22 truncation fix. Long verb-led titles
+    // like "Verify Technical Leadership Capacity" exceeded the available
+    // column width in OutputsDock and clipped the factor label after the
+    // verb. The fix replaces `truncate` (single-line ellipsis) with
+    // `line-clamp-2` (allow wrap to 2 lines, ellipsis only beyond that)
+    // + `break-words`. The verb prefix stays on the first line, the
+    // factor label wraps; the `title` attribute remains for the rare
+    // case where 2 lines still aren't enough.
+    render(
+      <AnalysisHeroV17
+        data={makeData({
+          stability: 0.7,
+          gaps: [gap('Technical Leadership Capacity', 'n_lead', 0.6)],
+        })}
+        vm={makeVm()}
+        fragileEdgeCount={0}
+      />,
+    )
+    const rowRoot = screen.getByTestId('hero-v17-input-rows')
+    const title = rowRoot.querySelector('[data-testid="hero-v17-row-title"]') as HTMLElement
+    expect(title).toBeTruthy()
+    // Sanity: the title text carries the verb prefix + the user label.
+    expect(title.textContent).toBe('Verify Technical Leadership Capacity')
+    // Anti-drift on the regression: `truncate` is single-line clip and
+    // must not be on the title element.
+    expect(title.className).not.toMatch(/(^|\s)truncate(\s|$)/)
+    // Positive assertion: the new wrap behaviour is in place.
+    expect(title.className).toMatch(/(^|\s)line-clamp-2(\s|$)/)
+    // Layout context unchanged: title still claims the available column
+    // width inside the dot+title flex row (so action icons stay
+    // right-aligned in the parent flex).
+    expect(title.className).toMatch(/(^|\s)flex-1(\s|$)/)
+    expect(title.className).toMatch(/(^|\s)min-w-0(\s|$)/)
+    // Tooltip stays for the rare overflow-beyond-two-lines case.
+    expect(title.getAttribute('title')).toBe('Verify Technical Leadership Capacity')
+  })
+
   it('footer does not render the 4-check row (Result clear / Stability / Evidence / Framing)', () => {
     render(
       <AnalysisHeroV17


### PR DESCRIPTION
## Summary

CSS-only fix for the visible row-title truncation reported on the post-PR-#179 staging deploy. Long verb-led titles like `"Verify Technical Leadership Capacity"` were clipping to `"Verify Technical Leadership Capa..."` because the title `<p>` carried Tailwind's `truncate` utility (single-line ellipsis).

## Change

Single-line CSS class swap on `HeroInputRows.tsx:86`:

```diff
- className={`${typography.panelHeader} text-text-header truncate min-w-0 flex-1`}
+ className={`${typography.panelHeader} text-text-header line-clamp-2 break-words min-w-0 flex-1`}
```

Properties preserved per brief:
- ✓ `Verify ` verb prefix stays on line 1; factor label wraps to line 2 if needed
- ✓ Action icons stay right-aligned (outer flex unchanged)
- ✓ `min-w-0 flex-1` retained — title still claims available column width
- ✓ `title` attribute tooltip preserved for the rare overflow-beyond-two-lines case
- ✓ DS v5 tokens only — `line-clamp-2` already in use elsewhere in the file (line 94, row reason)
- ✓ No inline styles, no hex values, no copy changes

## Anti-drift test added

`accessibility.spec.tsx` — asserts:
- title element does NOT have `truncate`
- title element DOES have `line-clamp-2`
- `flex-1 min-w-0` still applied (layout context preserved)
- full verb-prefixed user label appears in `textContent`
- `title` tooltip attribute preserved

## Dependency-line — NOT in scope of this PR

The dependency-line rule is **unchanged**:
- safe sources only: PLoT-B1 `report.dominant_factor` OR M1 `key_drivers.dominant_factor`
- no `detectDominantFactorLegacy`, no heuristic fallback
- omit when safe source / gate criteria not met (correct behaviour, not a bug)

The previous diagnostic against the `olumi-debug-50b336a6-20260510` staging bundle established the gate logic is correct (gate evaluates `influenceScore=1` → PASS → line would render for that scenario). Paul will run a console snippet against the specific screenshot scenario to definitively classify the missing-line case before any dependency-line work is authorised.

## Test plan
- [x] `npm run typecheck`: clean
- [x] `npx vitest run src/components/results/analysisHeroV17/__tests__ src/components/results/__tests__/AnalysisOrphanBanner.spec.tsx`: 272 passing (was 271 + 1 new wrap-anti-drift test). The 2 pre-existing `bodyLabelSafety.spec.tsx` failures (PR #175 legacy copy rename in `TriageActionCardsBody`) remain unchanged from baseline — body-copy cleanup track, tracked separately, not regressed.
- [x] ESLint clean on touched files (`HeroInputRows.tsx`, `accessibility.spec.tsx`)
- [x] `scripts/validate-prepush.sh`: ALL CHECKS PASSED

## Files touched (only these two)
- `src/components/results/analysisHeroV17/HeroInputRows.tsx`
- `src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx`

No dependency-line code changed. No data-layer or selector changes. No copy changes. No other files modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)