### PR TITLE
layout: tighten constants 20 → 15 (intended values; rendered gap stays 20)

### DIFF
--- a/src/canvas/__tests__/layout.semantic.spec.ts
+++ b/src/canvas/__tests__/layout.semantic.spec.ts
@@ -533,16 +533,24 @@ describe('constants contract', () => {
     expect(NODE_LAYOUT_MIN_W).toBe(140)
   })
 
-  it('COLLISION_GAP < expected node-node gap', () => {
-    // Default node-node gap is `Math.max(20, spacing=15) = 20` after the
-    // chain 60 → 30 → 20 → 15 (see layout.ts:54). The layoutGraph default
-    // is now 15, but the pre-ELK `Math.max(20, …)` floor and COLLISION_GAP
-    // both stay at 20, so the rendered gap is still 20. COLLISION_GAP=20
-    // equals the rendered gap, so the post-layout collision guard is
-    // essentially inert — it only fires when ELK/multi-row splitting drives
-    // nodes closer than 20px. The looser `toBeLessThan(30)` bound is kept
-    // deliberately: tightening to `toBeLessThan(20)` would fail (20 < 20 is
-    // false) and reduce headroom for future spacing tweaks.
+  it('COLLISION_GAP does not exceed the rendered node-node gap', () => {
+    // Rendered gap = `Math.max(20, default spacing)` = 20. (Default spacing
+    // is 15 after the chain 60 → 30 → 20 → 15; the literal-20 floor in
+    // layout.ts pins the runtime value at 20 even though the persisted
+    // intent is 15.) COLLISION_GAP must not exceed the rendered gap — if it
+    // did, the post-layout collision guard would push apart correctly-
+    // laid-out same-row pairs. Currently COLLISION_GAP=20 = rendered gap,
+    // so the guard is essentially inert; it only fires when ELK / multi-row
+    // splitting drives nodes closer than 20 px.
+    //
+    // The tight bound (`<= 20`) reflects the current contract; the loose
+    // `< 30` is a documentation-grade ceiling preserved from earlier rounds.
+    // Both are asserted so a future change that breaks either surfaces here.
+    //
+    // Note: the historical `COLLISION_GAP < MIN_GAP` relation no longer
+    // holds as of v6 (MIN_GAP=15 < COLLISION_GAP=20). The two constants
+    // serve unrelated concerns; see `nodeLayoutConstants.ts`.
+    expect(COLLISION_GAP).toBeLessThanOrEqual(20)
     expect(COLLISION_GAP).toBeLessThan(30)
   })
 

--- a/src/canvas/__tests__/layout.semantic.spec.ts
+++ b/src/canvas/__tests__/layout.semantic.spec.ts
@@ -534,14 +534,15 @@ describe('constants contract', () => {
   })
 
   it('COLLISION_GAP < expected node-node gap', () => {
-    // Default node-node gap is `Math.max(20, spacing=20) = 20` (default
-    // spacing reduction chain 60 → 30 → 20; see layout.ts:54). At the
-    // current default, COLLISION_GAP=20 equals the intended gap, so the
-    // post-layout collision guard is essentially inert — it only fires when
-    // ELK/multi-row splitting drives nodes closer than 20px. The looser
-    // `toBeLessThan(30)` bound is kept deliberately: a tighter
-    // `toBeLessThan(20)` would fail (20 < 20 is false) and reduce headroom
-    // for future spacing tweaks.
+    // Default node-node gap is `Math.max(20, spacing=15) = 20` after the
+    // chain 60 → 30 → 20 → 15 (see layout.ts:54). The layoutGraph default
+    // is now 15, but the pre-ELK `Math.max(20, …)` floor and COLLISION_GAP
+    // both stay at 20, so the rendered gap is still 20. COLLISION_GAP=20
+    // equals the rendered gap, so the post-layout collision guard is
+    // essentially inert — it only fires when ELK/multi-row splitting drives
+    // nodes closer than 20px. The looser `toBeLessThan(30)` bound is kept
+    // deliberately: tightening to `toBeLessThan(20)` would fail (20 < 20 is
+    // false) and reduce headroom for future spacing tweaks.
     expect(COLLISION_GAP).toBeLessThan(30)
   })
 

--- a/src/canvas/__tests__/layout.semantic.spec.ts
+++ b/src/canvas/__tests__/layout.semantic.spec.ts
@@ -548,8 +548,8 @@ describe('constants contract', () => {
     // Both are asserted so a future change that breaks either surfaces here.
     //
     // Note: the historical `COLLISION_GAP < MIN_GAP` relation no longer
-    // holds as of v6 (MIN_GAP=15 < COLLISION_GAP=20). The two constants
-    // serve unrelated concerns; see `nodeLayoutConstants.ts`.
+    // holds after the MIN_GAP 30 → 15 change (MIN_GAP=15 < COLLISION_GAP=20).
+    // The two constants serve unrelated concerns; see `nodeLayoutConstants.ts`.
     expect(COLLISION_GAP).toBeLessThanOrEqual(20)
     expect(COLLISION_GAP).toBeLessThan(30)
   })

--- a/src/canvas/__tests__/layout.spec.ts
+++ b/src/canvas/__tests__/layout.spec.ts
@@ -262,23 +262,26 @@ describe('ELK Layout', () => {
 
   it('4-factor tier on 1300px canvas: max-single fires; row overflows canvas (regression-lock for NODE_CARD_MAX_W=320)', async () => {
     // After restoring NODE_CARD_MAX_W to 320 and tightening the default
-    // spacing to 20 (chain 60 → 30 → 20), a 4-node tier on a 1300px canvas
-    // falls into the max-single branch and the rendered row visibly overflows
-    // the canvas. Math:
+    // spacing to 15 (chain 60 → 30 → 20 → 15), a 4-node tier on a 1300px
+    // canvas falls into the max-single branch and the rendered row visibly
+    // overflows the canvas. The pre-ELK `Math.max(20, spacing)` floor in
+    // layout.ts clamps effective spacing to 20 even when the caller passes
+    // 15, so the rendered last-edge stays at 1436 (was 1466 at spacing=30,
+    // 1556 at spacing=60). Math:
     //
+    //   effectiveSpacing = Math.max(20, SPACING) = 20
     //   rightEdge = CANVAS_MARGIN
-    //             + (N-1) * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + spacing)
+    //             + (N-1) * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + effectiveSpacing)
     //             + NODE_CARD_MAX_W
     //             = 24 + 3 * (320 + 24 + 20) + 320
     //             = 24 + 3 * 364 + 320
     //             = 1436
     //
-    // 1436 > 1300 → 136px overflow past the canvas right edge (was 166px
-    // with spacing=30, was 256px with spacing=60). The test exercises the
-    // production-default spacing path by passing spacing: SPACING where
-    // SPACING matches the layoutGraph default. Any future tweak of
-    // NODE_CARD_MAX_W, LAYOUT_PADDING_X, default spacing, or CANVAS_MARGIN
-    // surfaces here.
+    // 1436 > 1300 → 136px overflow past the canvas right edge. The test
+    // exercises the production-default spacing path by passing SPACING that
+    // matches the layoutGraph default; EFFECTIVE_SPACING below makes the
+    // pre-ELK floor explicit in the assertion so a future change to either
+    // value surfaces here.
     const nodes: Node[] = [
       makeNode('d', 'decision'),
       makeNode('o1', 'option'),
@@ -290,7 +293,8 @@ describe('ELK Layout', () => {
       makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'),
       makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
     ]
-    const SPACING = 20
+    const SPACING = 15
+    const EFFECTIVE_SPACING = Math.max(20, SPACING)
     const { nodes: laid, layoutNodeWidth } = await layoutGraph(
       nodes,
       edges,
@@ -298,7 +302,8 @@ describe('ELK Layout', () => {
       TEST_CANVAS,
     )
 
-    // max-single fires: unclamped = floor((1300*0.85 - 90)/4) = 253 ≥ 164.
+    // max-single fires: unclamped = floor((1300*0.85 - 3*MIN_GAP)/4)
+    //                             = floor((1105 - 45)/4) = 265 ≥ 164.
     expect(layoutNodeWidth).toBe(NODE_CARD_MAX_W)
 
     const factors = laid
@@ -309,7 +314,7 @@ describe('ELK Layout', () => {
     // Symbolic placement formula — resilient to future constant tweaks.
     const lastVisibleRightEdge = factors[3].position.x + NODE_CARD_MAX_W
     expect(lastVisibleRightEdge).toBe(
-      CANVAS_MARGIN + 3 * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + SPACING) + NODE_CARD_MAX_W,
+      CANVAS_MARGIN + 3 * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + EFFECTIVE_SPACING) + NODE_CARD_MAX_W,
     )
 
     // Outcome: row overflows the canvas. If any contributing constant

--- a/src/canvas/__tests__/layout.spec.ts
+++ b/src/canvas/__tests__/layout.spec.ts
@@ -324,6 +324,62 @@ describe('ELK Layout', () => {
     expect(lastVisibleRightEdge).toBeGreaterThan(TEST_CANVAS.width)
   })
 
+  it('7-factor tier on 1500px canvas: MIN_GAP=15 flips max-single ON (regression-lock for MIN_GAP)', async () => {
+    // MIN_GAP behaviour-flip lock. The `unclamped >= NODE_LAYOUT_MIN_W +
+    // LAYOUT_PADDING_X` gate decides max-single vs multi-row branch; MIN_GAP
+    // is the only knob that moves this threshold without touching widths.
+    //
+    //   unclamped = floor((1500*0.85 - 6*MIN_GAP) / 7)
+    //
+    // At MIN_GAP=30 (prior): floor((1275 - 180)/7) = floor(1095/7) = 156.
+    //   156 < 164 (= MIN_W + PADDING_X) → multi-row branch, nodes compress
+    //   to NODE_LAYOUT_MIN_W=140, the row fits the canvas at ~1268px.
+    // At MIN_GAP=15 (current): floor((1275 - 90)/7) = floor(1185/7) = 169.
+    //   169 >= 164 → max-single fires, every node at NODE_CARD_MAX_W=320,
+    //   the row visibly overflows by ~1028px.
+    //
+    // If MIN_GAP rises back to ~25+ this assertion flips and forces a
+    // deliberate review of whether 7-factor tiers should overflow at MAX_W
+    // or compress to fit.
+    const nodes: Node[] = [
+      makeNode('d', 'decision'),
+      makeNode('o1', 'option'),
+      makeNode('f1', 'factor'), makeNode('f2', 'factor'), makeNode('f3', 'factor'),
+      makeNode('f4', 'factor'), makeNode('f5', 'factor'), makeNode('f6', 'factor'),
+      makeNode('f7', 'factor'),
+    ]
+    const edges: Edge[] = [
+      makeEdge('e1', 'd', 'o1'),
+      makeEdge('e2', 'o1', 'f1'), makeEdge('e3', 'o1', 'f2'), makeEdge('e4', 'o1', 'f3'),
+      makeEdge('e5', 'o1', 'f4'), makeEdge('e6', 'o1', 'f5'), makeEdge('e7', 'o1', 'f6'),
+      makeEdge('e8', 'o1', 'f7'),
+    ]
+    const FLIP_CANVAS: CanvasSize = { width: 1500, height: 900 }
+    const SPACING = 15
+    const EFFECTIVE_SPACING = Math.max(20, SPACING)
+    const { nodes: laid, layoutNodeWidth } = await layoutGraph(
+      nodes,
+      edges,
+      { spacing: SPACING },
+      FLIP_CANVAS,
+    )
+
+    // max-single fired: nodes at MAX_W (proves MIN_GAP threshold relaxed).
+    expect(layoutNodeWidth).toBe(NODE_CARD_MAX_W)
+
+    const factors = laid
+      .filter(n => n.type === 'factor')
+      .sort((a, b) => a.position.x - b.position.x)
+    expect(factors).toHaveLength(7)
+
+    // Single-row placement formula: rightEdge = 24 + 6 * (320+24+20) + 320 = 2528.
+    const lastVisibleRightEdge = factors[6].position.x + NODE_CARD_MAX_W
+    expect(lastVisibleRightEdge).toBe(
+      CANVAS_MARGIN + 6 * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + EFFECTIVE_SPACING) + NODE_CARD_MAX_W,
+    )
+    expect(lastVisibleRightEdge).toBeGreaterThan(FLIP_CANVAS.width)
+  })
+
   it('nodeW stays at NODE_CARD_MAX_W when widest tier overflows the viewport', async () => {
     // 5 factors on a 1700px canvas previously compressed every node to ~241px.
     // New policy: pin every node to NODE_CARD_MAX_W and overflow horizontally.

--- a/src/canvas/__tests__/layoutStore.spec.ts
+++ b/src/canvas/__tests__/layoutStore.spec.ts
@@ -2,32 +2,139 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 const KEY_V4 = 'canvas-layout-options-v4'
 const KEY_V5 = 'canvas-layout-options-v5'
+const KEY_V6 = 'canvas-layout-options-v6'
 
 async function loadStore() {
   const mod = await import('../layoutStore')
   return mod.useLayoutStore.getState()
 }
 
-describe('layoutStore — v4 → v5 migration', () => {
+describe('layoutStore — v6 / v5 / v4 migration cascade', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.resetModules()
   })
 
-  it('uses fresh v5 defaults when neither v4 nor v5 exists', async () => {
+  // ── Layer: defaults ──────────────────────────────────────────────────────
+
+  it('uses fresh v6 defaults when no key exists', async () => {
     const state = await loadStore()
     expect(state.direction).toBe('DOWN')
-    expect(state.nodeSpacing).toBe(20)
+    expect(state.nodeSpacing).toBe(15)
     expect(state.layerSpacing).toBe(48)
     expect(state.respectLocked).toBe(true)
   })
 
-  it('migrates v4 default-like nodeSpacing=30 to v5 default 20', async () => {
+  // ── Layer: v6 (current key) ──────────────────────────────────────────────
+
+  it('reads v6 entry as-is when present', async () => {
+    localStorage.setItem(KEY_V6, JSON.stringify({
+      direction: 'RIGHT', nodeSpacing: 25, layerSpacing: 72, respectLocked: false,
+    }))
+    const state = await loadStore()
+    expect(state.direction).toBe('RIGHT')
+    expect(state.nodeSpacing).toBe(25)
+    expect(state.layerSpacing).toBe(72)
+    expect(state.respectLocked).toBe(false)
+  })
+
+  it('fills missing v6 fields from defaults when entry is partial', async () => {
+    localStorage.setItem(KEY_V6, JSON.stringify({ direction: 'RIGHT', nodeSpacing: 22 }))
+    const state = await loadStore()
+    expect(state.direction).toBe('RIGHT')
+    expect(state.nodeSpacing).toBe(22)
+    expect(state.layerSpacing).toBe(48)
+    expect(state.respectLocked).toBe(true)
+  })
+
+  // ── Layer: v5 → v6 migration ─────────────────────────────────────────────
+
+  it('migrates v5 default-like nodeSpacing=20 to v6 default 15', async () => {
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'DOWN', nodeSpacing: 20, layerSpacing: 48, respectLocked: true,
+    }))
+    const state = await loadStore()
+    expect(state.nodeSpacing).toBe(15)
+  })
+
+  it('preserves v5 customised nodeSpacing (non-20) across migration', async () => {
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'DOWN', nodeSpacing: 35, layerSpacing: 48, respectLocked: true,
+    }))
+    const state = await loadStore()
+    expect(state.nodeSpacing).toBe(35)
+  })
+
+  it('preserves v5 direction, layerSpacing, and respectLocked while migrating nodeSpacing', async () => {
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'RIGHT', nodeSpacing: 20, layerSpacing: 60, respectLocked: false,
+    }))
+    const state = await loadStore()
+    expect(state.direction).toBe('RIGHT')
+    expect(state.nodeSpacing).toBe(15)
+    expect(state.layerSpacing).toBe(60)
+    expect(state.respectLocked).toBe(false)
+  })
+
+  it('fills missing v5 fields from defaults while migrating', async () => {
+    // Same `??` fallback contract on the v5 → v6 migration path.
+    // nodeSpacing=20 still migrates; absent fields use v6 defaults.
+    localStorage.setItem(KEY_V5, JSON.stringify({ direction: 'RIGHT', nodeSpacing: 20 }))
+    const state = await loadStore()
+    expect(state.direction).toBe('RIGHT')
+    expect(state.nodeSpacing).toBe(15)
+    expect(state.layerSpacing).toBe(48)
+    expect(state.respectLocked).toBe(true)
+  })
+
+  it('preserves all v5 customisation when nodeSpacing is non-default', async () => {
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'LEFT', nodeSpacing: 80, layerSpacing: 120, respectLocked: false,
+    }))
+    const state = await loadStore()
+    expect(state.direction).toBe('LEFT')
+    expect(state.nodeSpacing).toBe(80)
+    expect(state.layerSpacing).toBe(120)
+    expect(state.respectLocked).toBe(false)
+  })
+
+  it('v6 entry takes precedence over a v5 entry', async () => {
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'DOWN', nodeSpacing: 20, layerSpacing: 48, respectLocked: true,
+    }))
+    localStorage.setItem(KEY_V6, JSON.stringify({
+      direction: 'RIGHT', nodeSpacing: 12, layerSpacing: 72, respectLocked: false,
+    }))
+    const state = await loadStore()
+    expect(state.direction).toBe('RIGHT')
+    expect(state.nodeSpacing).toBe(12)
+    expect(state.layerSpacing).toBe(72)
+    expect(state.respectLocked).toBe(false)
+  })
+
+  it('falls back to v5 migration when v6 is malformed but v5 is valid', async () => {
+    localStorage.setItem(KEY_V6, '{not valid json')
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'RIGHT', nodeSpacing: 20, layerSpacing: 60, respectLocked: false,
+    }))
+    const state = await loadStore()
+    expect(state.direction).toBe('RIGHT')
+    expect(state.nodeSpacing).toBe(15)
+    expect(state.layerSpacing).toBe(60)
+    expect(state.respectLocked).toBe(false)
+  })
+
+  // ── Layer: v4 → v6 migration (skips intermediate v5 default) ─────────────
+
+  it('migrates v4 default-like nodeSpacing=30 to v6 default 15', async () => {
+    // A v4 user holding nodeSpacing=30 (the v4 default) skips v5 entirely
+    // and lands on the v6 default 15 — same conservative-snap policy as
+    // the original v4 → v5 migration.
     localStorage.setItem(KEY_V4, JSON.stringify({
       direction: 'DOWN', nodeSpacing: 30, layerSpacing: 48, respectLocked: true,
     }))
     const state = await loadStore()
-    expect(state.nodeSpacing).toBe(20)
+    expect(state.nodeSpacing).toBe(15)
   })
 
   it('preserves v4 customised nodeSpacing (non-30) across migration', async () => {
@@ -44,108 +151,76 @@ describe('layoutStore — v4 → v5 migration', () => {
     }))
     const state = await loadStore()
     expect(state.direction).toBe('RIGHT')
-    expect(state.nodeSpacing).toBe(20)
+    expect(state.nodeSpacing).toBe(15)
     expect(state.layerSpacing).toBe(60)
     expect(state.respectLocked).toBe(false)
   })
 
-  it('preserves all v4 customisation when nodeSpacing is non-default', async () => {
-    localStorage.setItem(KEY_V4, JSON.stringify({
-      direction: 'LEFT', nodeSpacing: 80, layerSpacing: 120, respectLocked: false,
-    }))
-    const state = await loadStore()
-    expect(state.direction).toBe('LEFT')
-    expect(state.nodeSpacing).toBe(80)
-    expect(state.layerSpacing).toBe(120)
-    expect(state.respectLocked).toBe(false)
-  })
-
-  it('v5 entry takes precedence over a v4 entry', async () => {
-    localStorage.setItem(KEY_V4, JSON.stringify({
-      direction: 'DOWN', nodeSpacing: 30, layerSpacing: 48, respectLocked: true,
-    }))
-    localStorage.setItem(KEY_V5, JSON.stringify({
-      direction: 'RIGHT', nodeSpacing: 15, layerSpacing: 72, respectLocked: false,
-    }))
-    const state = await loadStore()
-    expect(state.direction).toBe('RIGHT')
-    expect(state.nodeSpacing).toBe(15)
-    expect(state.layerSpacing).toBe(72)
-    expect(state.respectLocked).toBe(false)
-  })
-
-  it('migrates only nodeSpacing and preserves other default-like fields', async () => {
-    // Sanity: the 30 → 20 rule is targeted to nodeSpacing alone. Other v4
-    // fields that happen to equal a v4 default (e.g. layerSpacing=48) are
-    // left literal — they are not "snapped" to the v5 default by the
-    // migration. Only nodeSpacing has a value-driven remap.
-    localStorage.setItem(KEY_V4, JSON.stringify({
-      direction: 'DOWN', nodeSpacing: 30, layerSpacing: 48, respectLocked: true,
-    }))
-    const state = await loadStore()
-    expect(state.nodeSpacing).toBe(20)
-    expect(state.layerSpacing).toBe(48)
-  })
-
-  it('fills missing v5 fields from defaults when entry is partial', async () => {
-    // Locks in the `??` fallback: if a v5 entry has only some fields
-    // (manual edit, partial write, future-version subset), absent fields
-    // come from the current defaults rather than crashing or leaking
-    // `undefined` to ELK.
-    localStorage.setItem(KEY_V5, JSON.stringify({ direction: 'RIGHT', nodeSpacing: 25 }))
-    const state = await loadStore()
-    expect(state.direction).toBe('RIGHT')
-    expect(state.nodeSpacing).toBe(25)
-    expect(state.layerSpacing).toBe(48)
-    expect(state.respectLocked).toBe(true)
-  })
-
   it('fills missing v4 fields from defaults while migrating', async () => {
-    // Same `??` fallback contract on the v4 → v5 migration path.
-    // nodeSpacing=30 still migrates; absent fields use v5 defaults.
     localStorage.setItem(KEY_V4, JSON.stringify({ direction: 'RIGHT', nodeSpacing: 30 }))
     const state = await loadStore()
     expect(state.direction).toBe('RIGHT')
-    expect(state.nodeSpacing).toBe(20)
+    expect(state.nodeSpacing).toBe(15)
     expect(state.layerSpacing).toBe(48)
     expect(state.respectLocked).toBe(true)
   })
 
-  it('returns defaults when v5 is malformed and no v4 entry exists', async () => {
-    localStorage.setItem(KEY_V5, '{not valid json')
-    const state = await loadStore()
-    expect(state.direction).toBe('DOWN')
-    expect(state.nodeSpacing).toBe(20)
-    expect(state.layerSpacing).toBe(48)
-    expect(state.respectLocked).toBe(true)
-  })
-
-  it('falls back to v4 migration when v5 is malformed but v4 is valid', async () => {
-    localStorage.setItem(KEY_V5, '{not valid json')
+  it('falls back to v4 migration when both v6 and v5 are malformed but v4 is valid', async () => {
+    localStorage.setItem(KEY_V6, '{not valid')
+    localStorage.setItem(KEY_V5, '{also not valid')
     localStorage.setItem(KEY_V4, JSON.stringify({
       direction: 'RIGHT', nodeSpacing: 30, layerSpacing: 60, respectLocked: false,
     }))
     const state = await loadStore()
     expect(state.direction).toBe('RIGHT')
-    expect(state.nodeSpacing).toBe(20)
+    expect(state.nodeSpacing).toBe(15)
     expect(state.layerSpacing).toBe(60)
     expect(state.respectLocked).toBe(false)
   })
 
-  it('returns defaults when v4 JSON is malformed and no v5 entry exists', async () => {
-    localStorage.setItem(KEY_V4, '{not valid json')
+  // ── Layer: cascade ordering ──────────────────────────────────────────────
+
+  it('cascade ordering: v6 beats v5 beats v4 when all three exist', async () => {
+    localStorage.setItem(KEY_V4, JSON.stringify({
+      direction: 'LEFT', nodeSpacing: 30, layerSpacing: 48, respectLocked: true,
+    }))
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'UP', nodeSpacing: 20, layerSpacing: 60, respectLocked: true,
+    }))
+    localStorage.setItem(KEY_V6, JSON.stringify({
+      direction: 'RIGHT', nodeSpacing: 12, layerSpacing: 72, respectLocked: false,
+    }))
     const state = await loadStore()
-    expect(state.direction).toBe('DOWN')
-    expect(state.nodeSpacing).toBe(20)
+    // v6 wins all four fields; v5 and v4 are ignored.
+    expect(state.direction).toBe('RIGHT')
+    expect(state.nodeSpacing).toBe(12)
+    expect(state.layerSpacing).toBe(72)
+    expect(state.respectLocked).toBe(false)
   })
 
-  it('returns defaults when both v5 and v4 are malformed', async () => {
-    localStorage.setItem(KEY_V5, '{not valid')
-    localStorage.setItem(KEY_V4, '{also not valid')
+  // ── Layer: robustness + sanity ──────────────────────────────────────────
+
+  it('returns defaults when all three keys (v6, v5, v4) are malformed', async () => {
+    localStorage.setItem(KEY_V6, '{not valid')
+    localStorage.setItem(KEY_V5, '{also not valid')
+    localStorage.setItem(KEY_V4, '{still not valid')
     const state = await loadStore()
     expect(state.direction).toBe('DOWN')
-    expect(state.nodeSpacing).toBe(20)
+    expect(state.nodeSpacing).toBe(15)
     expect(state.layerSpacing).toBe(48)
     expect(state.respectLocked).toBe(true)
+  })
+
+  it('migrates only nodeSpacing and preserves other default-like fields', async () => {
+    // Sanity: the value-driven snap rules (20 → 15 for v5, 30 → 15 for v4)
+    // apply to nodeSpacing alone. Other fields equal to a prior-version
+    // default (e.g. layerSpacing=48) stay literal — they are not "snapped"
+    // to v6 defaults by the migration.
+    localStorage.setItem(KEY_V5, JSON.stringify({
+      direction: 'DOWN', nodeSpacing: 20, layerSpacing: 48, respectLocked: true,
+    }))
+    const state = await loadStore()
+    expect(state.nodeSpacing).toBe(15)
+    expect(state.layerSpacing).toBe(48)
   })
 })

--- a/src/canvas/layoutStore.ts
+++ b/src/canvas/layoutStore.ts
@@ -24,17 +24,25 @@ interface LayoutOptions {
   setLayoutNodeWidth: (width: number) => void
 }
 
+// v6: nodeSpacing reduced 20 → 15 (intended). The rendered gap stays at 20 px
+// because layout.ts retains its `Math.max(20, spacing)` pre-ELK floor and the
+// post-ELK `applyCollisionGuard` keeps COLLISION_GAP=20. This bump records the
+// intended value and migrates returning users' persisted state; the floors
+// would need to be lowered separately to make the rendered gap match.
+// Migration policy: v5 default-like nodeSpacing=20 maps to v6 default 15; v4
+// default-like nodeSpacing=30 also maps to 15 (a direct v4 → v6 user skips
+// the intermediate v5 default). All other persisted fields carry over.
 // v5: nodeSpacing reduced 30 → 20 — modest further horizontal compression.
 // 4-node row drops 1466 → 1436 (−30 px); 5-node row 1840 → 1800 (−40 px);
 // 6-node row 2214 → 2164 (−50 px) at NODE_CARD_MAX_W=320. effectiveNodeSpacing
-// now equals COLLISION_GAP=20, so the post-layout collision guard is inert at
+// equals COLLISION_GAP=20, so the post-layout collision guard is inert at
 // the default spacing — it only fires when ELK/multi-row splitting drives
 // nodes closer than 20 px.
-// v5 also introduces v4→v5 migration in loadPersistedOptions: default-like
+// v5 introduced v4→v5 migration in loadPersistedOptions: default-like
 // nodeSpacing=30 maps to the new default 20; other v4 settings (custom
 // nodeSpacing, direction, layerSpacing, respectLocked) carry over unchanged.
 // Earlier bumps (v3→v4, etc.) read only the current key and so reset all
-// customisation; this is the first revision with an explicit migration.
+// customisation; v5 was the first revision with an explicit migration.
 // v4: nodeSpacing reduced 60 → 30 — horizontal gap tightened so 4-node tiers
 // fit a tighter footprint at typical laptop viewports. Layer (vertical)
 // spacing left at 48 from v3; the horizontal change addresses the observed
@@ -43,7 +51,8 @@ interface LayoutOptions {
 // v3: layerSpacing reduced 90 → 48 (cumulative −47 % across two passes:
 // 90 → 68 (−25 %), then 68 → 48 (−30 %)) so tiers sit closer vertically.
 // Earlier bump: v1 → v2 changed 80/120 → 60/90.
-const KEY = 'canvas-layout-options-v5'
+const KEY = 'canvas-layout-options-v6'
+const KEY_V5 = 'canvas-layout-options-v5'
 const KEY_V4 = 'canvas-layout-options-v4'
 
 type PersistedOptions = Partial<Pick<LayoutOptions, 'direction' | 'nodeSpacing' | 'layerSpacing' | 'respectLocked'>>
@@ -59,23 +68,37 @@ function tryParse(key: string): PersistedOptions | null {
 }
 
 function loadPersistedOptions(): Pick<LayoutOptions, 'direction' | 'nodeSpacing' | 'layerSpacing' | 'respectLocked'> {
-  const defaults = { direction: 'DOWN' as Direction, nodeSpacing: 20, layerSpacing: 48, respectLocked: true }
+  const defaults = { direction: 'DOWN' as Direction, nodeSpacing: 15, layerSpacing: 48, respectLocked: true }
 
-  // v5 (current) — written by persist() after any user change since this revision.
-  const v5 = tryParse(KEY)
+  // v6 (current) — written by persist() after any user change since this revision.
+  const v6 = tryParse(KEY)
+  if (v6) {
+    return {
+      direction: v6.direction ?? defaults.direction,
+      nodeSpacing: v6.nodeSpacing ?? defaults.nodeSpacing,
+      layerSpacing: v6.layerSpacing ?? defaults.layerSpacing,
+      respectLocked: v6.respectLocked ?? defaults.respectLocked,
+    }
+  }
+  // v5 → v6 migration: map default-like nodeSpacing=20 (v5 default) to the
+  // new v6 default 15; custom nodeSpacing (≠ 20), direction, layerSpacing,
+  // and respectLocked carry over unchanged. Parsed independently of v6 so a
+  // corrupt v6 entry still falls back to a valid v5 entry.
+  const v5 = tryParse(KEY_V5)
   if (v5) {
     return {
       direction: v5.direction ?? defaults.direction,
-      nodeSpacing: v5.nodeSpacing ?? defaults.nodeSpacing,
+      nodeSpacing: v5.nodeSpacing === 20
+        ? defaults.nodeSpacing
+        : (v5.nodeSpacing ?? defaults.nodeSpacing),
       layerSpacing: v5.layerSpacing ?? defaults.layerSpacing,
       respectLocked: v5.respectLocked ?? defaults.respectLocked,
     }
   }
-  // v4 → v5 migration: map default-like nodeSpacing=30 to the new default
-  // 20; custom nodeSpacing (≠ 30), direction, layerSpacing, and
-  // respectLocked carry over unchanged. Parsed independently of v5 so a
-  // corrupt v5 entry still falls back to a valid v4 entry. The v4 entry is
-  // left in place until the next persist() call writes v5.
+  // v4 → v6 migration: a v4 user with default-like nodeSpacing=30 skips v5
+  // entirely and lands on the v6 default 15 (same conservative-snap policy
+  // as v4 → v5). Custom v4 nodeSpacing (≠ 30) and other v4 settings carry
+  // over unchanged. Parsed independently of v6 and v5.
   const v4 = tryParse(KEY_V4)
   if (v4) {
     return {

--- a/src/canvas/utils/layout.ts
+++ b/src/canvas/utils/layout.ts
@@ -51,12 +51,14 @@ export async function layoutGraph(
 ): Promise<{ nodes: Node[]; edges: Edge[]; layoutNodeWidth: number }> {
   const {
     direction = 'DOWN',
-    // Default horizontal node-node spacing. Reduction chain 60 → 30 → 20.
-    // At spacing=20 the max-width 4-node row drops from 1556 (spacing=60) to
-    // 1466 (spacing=30) to 1436 (spacing=20) at NODE_CARD_MAX_W=320. The
-    // Math.max(20, …) floor below still clamps any caller passing a smaller
-    // value; effectiveNodeSpacing now equals COLLISION_GAP=20.
-    spacing = 20,
+    // Default horizontal node-node spacing. Reduction chain 60 → 30 → 20 → 15.
+    // The Math.max(20, …) floor on line 64 is deliberately retained, so the
+    // rendered gap is still 20 px — `spacing=15` documents the intended value
+    // but is clamped at runtime. To genuinely render at 15, a future change
+    // would need to lower both that floor AND `COLLISION_GAP` (currently 20).
+    // 4-node max-width row at NODE_CARD_MAX_W=320: 1556 → 1466 → 1436 → 1436
+    // (no change in rendered width at gap=15 because of the floor).
+    spacing = 15,
     layerSpacing,
     preserveLocked = true
   } = options

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -51,9 +51,13 @@ export const DEFAULT_NODE_HEIGHT = 100
 export const MIN_GAP = 15
 
 /**
- * Post-layout safety gap. Smaller than `MIN_GAP` because it only fires when
- * ELK / multi-row splitting leaves two same-row nodes closer than this
- * threshold (rare; rounding-induced).
+ * Post-layout safety gap. Fires when ELK / multi-row splitting leaves two
+ * same-row nodes closer than this threshold (rare; rounding-induced). Note
+ * that as of v6 (MIN_GAP 30 → 15) this no longer satisfies
+ * `COLLISION_GAP < MIN_GAP` — MIN_GAP is now a width-calc safety reserve
+ * only, while COLLISION_GAP matches the rendered node-node gap
+ * (`Math.max(20, spacing)` in layout.ts). The two constants serve unrelated
+ * concerns despite the historical numeric ordering.
  */
 export const COLLISION_GAP = 20
 

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -39,8 +39,16 @@ export const DEFAULT_NODE_HEIGHT = 100
 
 // ─── Spacing ─────────────────────────────────────────────────────────────────
 
-/** Minimum horizontal gap between nodes in the same tier. */
-export const MIN_GAP = 30
+/**
+ * Width-calc safety reserve used in `floor((availableWidth - (N-1)*MIN_GAP) / N)`
+ * to decide whether a tier renders at NODE_CARD_MAX_W or compresses to
+ * NODE_LAYOUT_MIN_W with multi-row splitting. NOT a visual floor on the
+ * rendered gap — the actual rendered gap is `effectiveNodeSpacing` in
+ * `layout.ts`, clamped by `Math.max(20, spacing)` and the post-layout
+ * `applyCollisionGuard` (COLLISION_GAP). Lowering this value relaxes the
+ * width-calc threshold (more tiers render at MAX_W).
+ */
+export const MIN_GAP = 15
 
 /**
  * Post-layout safety gap. Smaller than `MIN_GAP` because it only fires when

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -52,12 +52,13 @@ export const MIN_GAP = 15
 
 /**
  * Post-layout safety gap. Fires when ELK / multi-row splitting leaves two
- * same-row nodes closer than this threshold (rare; rounding-induced). Note
- * that as of v6 (MIN_GAP 30 → 15) this no longer satisfies
- * `COLLISION_GAP < MIN_GAP` — MIN_GAP is now a width-calc safety reserve
- * only, while COLLISION_GAP matches the rendered node-node gap
- * (`Math.max(20, spacing)` in layout.ts). The two constants serve unrelated
- * concerns despite the historical numeric ordering.
+ * same-row nodes closer than this threshold (rare; rounding-induced).
+ *
+ * Note: now larger than `MIN_GAP` (15) after the MIN_GAP 30 → 15 change.
+ * The historical `COLLISION_GAP < MIN_GAP` relation no longer holds and
+ * is not required — the two constants serve unrelated concerns. MIN_GAP
+ * is a width-calc safety reserve only; COLLISION_GAP matches the
+ * rendered node-node gap (`Math.max(20, spacing)` in layout.ts).
  */
 export const COLLISION_GAP = 20
 


### PR DESCRIPTION
## Summary

- `MIN_GAP` 30 → 15, default `spacing` 20 → 15, `nodeSpacing` 20 → 15, KEY v5 → v6 with cascade migration (v5 → v6 mirroring the existing v4 → v5 pattern; v4 → v6 skips the intermediate v5 default).
- **Important:** rendered node-node gap stays at 20 px. The pre-ELK `Math.max(20, spacing)` floor on [`layout.ts:64`](src/canvas/utils/layout.ts:64) and the post-ELK `applyCollisionGuard` with `COLLISION_GAP=20` are unchanged per the brief's "do not change" list, so they pin the rendered gap at 20. The constants record the intended value; the floor-lowering option was raised in planning and explicitly excluded.
- Side effect from `MIN_GAP` 30 → 15: the width-calc threshold `floor((availableWidth − (N−1)·MIN_GAP) / N)` relaxes — borderline tiers now render at `NODE_CARD_MAX_W` more often (modest increase in horizontal overflow on those tiers).
- localStorage cascade is now v6 / v5 / v4. Each layer is parsed independently (preserves the corrupt-fallback robustness from `75d2a15b`). v5 users holding `nodeSpacing=20` (v5 default) migrate to 15; v4 users with `nodeSpacing=30` (v4 default) migrate directly to 15 without passing through 20.

## Edge-case row widths (1440 px canvas)

| Tier | Brief said    | Actual after deploy | Why                              |
|------|---------------|---------------------|----------------------------------|
| 4    | 1421 (gap=15) | 1436 (gap=20)       | `Math.max(20, 15) = 20`          |
| 5    | 1780 (gap=15) | 1800 (gap=20)       | same                             |
| 6    | 2139 (gap=15) | 2164 (gap=20)       | same                             |

Visual perceptibility: none.

## Test plan

- [x] Typecheck clean
- [x] 9-spec layout sweep + `layoutStore.spec.ts`: 121 tests pass (8 runnable layout specs + 18 store-cascade tests; `ReactFlowGraph.layout.dom.spec.tsx` is excluded locally per `vitest.config.ts`, runs in CI)
- [x] `npx vitest run --changed`: only failure is a pre-existing `useConversation.hook.spec.ts` V5 graph re-fetch test (confirmed unchanged on `origin/staging` HEAD; unrelated to layout)
- [x] Manual `bash scripts/validate-prepush.sh`: all 7 gates green (branch, typecheck, lint, smoke 459 tests, stale-.js, dep audit, vendored schemas SHA, close-out doc)
- [ ] CI full-suite, E2E, coverage, bundle policy, security scans — wait for green before merging

## Files changed

- `src/canvas/utils/nodeLayoutConstants.ts` — `MIN_GAP` 30 → 15; comment clarifies role
- `src/canvas/utils/layout.ts` — default `spacing` 20 → 15; comment chain extended; documents that the `Math.max(20, …)` floor pins rendered gap at 20
- `src/canvas/layoutStore.ts` — defaults `nodeSpacing` 20 → 15; KEY v5 → v6; `KEY_V5` promoted to legacy; `loadPersistedOptions` extended to v6 / v5 / v4 cascade
- `src/canvas/__tests__/layout.spec.ts` — `SPACING` 20 → 15; new `EFFECTIVE_SPACING` local makes the pre-ELK floor explicit in the symbolic assertion; comment math updated (unclamped 253 → 265 at `MIN_GAP=15`)
- `src/canvas/__tests__/layout.semantic.spec.ts` — comment update; `toBeLessThan(30)` assertion untouched
- `src/canvas/__tests__/layoutStore.spec.ts` — restructured to v6 / v5 / v4 cascade; 18 tests (was 13). New v5 → v6 layer mirrors v4 → v5; cascade-ordering and three-key robustness tests added

## Rollback

Single `git revert d97813a2` reverts everything atomically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)