### PR TITLE
layout: lower runtime floors so spacing=15 actually renders at 15

### DIFF
--- a/src/canvas/__tests__/layout.semantic.spec.ts
+++ b/src/canvas/__tests__/layout.semantic.spec.ts
@@ -534,23 +534,24 @@ describe('constants contract', () => {
   })
 
   it('COLLISION_GAP does not exceed the rendered node-node gap', () => {
-    // Rendered gap = `Math.max(20, default spacing)` = 20. (Default spacing
-    // is 15 after the chain 60 → 30 → 20 → 15; the literal-20 floor in
-    // layout.ts pins the runtime value at 20 even though the persisted
-    // intent is 15.) COLLISION_GAP must not exceed the rendered gap — if it
-    // did, the post-layout collision guard would push apart correctly-
-    // laid-out same-row pairs. Currently COLLISION_GAP=20 = rendered gap,
-    // so the guard is essentially inert; it only fires when ELK / multi-row
-    // splitting drives nodes closer than 20 px.
+    // Rendered gap = `Math.max(15, default spacing=15)` = 15 after the
+    // chain 60 → 30 → 20 → 15 and the matching floor change (the pre-ELK
+    // `Math.max` lower bound was lowered to 15 together with this constant).
+    // COLLISION_GAP must not exceed the rendered gap — if it did, the
+    // post-layout collision guard would push apart correctly-laid-out
+    // same-row pairs. COLLISION_GAP=15 = rendered gap, so the guard is
+    // essentially inert; it only fires when ELK / multi-row splitting
+    // drives nodes closer than 15 px.
     //
-    // The tight bound (`<= 20`) reflects the current contract; the loose
+    // The tight bound (`<= 15`) reflects the current contract; the loose
     // `< 30` is a documentation-grade ceiling preserved from earlier rounds.
     // Both are asserted so a future change that breaks either surfaces here.
     //
-    // Note: the historical `COLLISION_GAP < MIN_GAP` relation no longer
-    // holds after the MIN_GAP 30 → 15 change (MIN_GAP=15 < COLLISION_GAP=20).
-    // The two constants serve unrelated concerns; see `nodeLayoutConstants.ts`.
-    expect(COLLISION_GAP).toBeLessThanOrEqual(20)
+    // Note: MIN_GAP=15 = COLLISION_GAP=15 now (both lowered in the same
+    // change). The historical `COLLISION_GAP < MIN_GAP` relation does not
+    // hold; the two constants serve unrelated concerns despite the
+    // numeric coincidence (see `nodeLayoutConstants.ts`).
+    expect(COLLISION_GAP).toBeLessThanOrEqual(15)
     expect(COLLISION_GAP).toBeLessThan(30)
   })
 

--- a/src/canvas/__tests__/layout.spec.ts
+++ b/src/canvas/__tests__/layout.spec.ts
@@ -262,22 +262,21 @@ describe('ELK Layout', () => {
 
   it('4-factor tier on 1300px canvas: max-single fires; row overflows canvas (regression-lock for NODE_CARD_MAX_W=320)', async () => {
     // After restoring NODE_CARD_MAX_W to 320 and tightening the default
-    // spacing to 15 (chain 60 → 30 → 20 → 15), a 4-node tier on a 1300px
-    // canvas falls into the max-single branch and the rendered row visibly
-    // overflows the canvas. The pre-ELK `Math.max(20, spacing)` floor in
-    // layout.ts clamps effective spacing to 20 even when the caller passes
-    // 15, so the rendered last-edge stays at 1436 (was 1466 at spacing=30,
-    // 1556 at spacing=60). Math:
+    // spacing to 15 (chain 60 → 30 → 20 → 15) — with the pre-ELK floor
+    // and COLLISION_GAP lowered to 15 in the same change — a 4-node tier
+    // on a 1300px canvas falls into the max-single branch and the rendered
+    // row visibly overflows the canvas. Math:
     //
-    //   effectiveSpacing = Math.max(20, SPACING) = 20
+    //   effectiveSpacing = Math.max(15, SPACING) = 15
     //   rightEdge = CANVAS_MARGIN
     //             + (N-1) * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + effectiveSpacing)
     //             + NODE_CARD_MAX_W
-    //             = 24 + 3 * (320 + 24 + 20) + 320
-    //             = 24 + 3 * 364 + 320
-    //             = 1436
+    //             = 24 + 3 * (320 + 24 + 15) + 320
+    //             = 24 + 3 * 359 + 320
+    //             = 1421
     //
-    // 1436 > 1300 → 136px overflow past the canvas right edge. The test
+    // 1421 > 1300 → 121px overflow past the canvas right edge (was 136px at
+    // floor=20, 166px at spacing=30, 256px at spacing=60). The test
     // exercises the production-default spacing path by passing SPACING that
     // matches the layoutGraph default; EFFECTIVE_SPACING below makes the
     // pre-ELK floor explicit in the assertion so a future change to either
@@ -294,7 +293,7 @@ describe('ELK Layout', () => {
       makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
     ]
     const SPACING = 15
-    const EFFECTIVE_SPACING = Math.max(20, SPACING)
+    const EFFECTIVE_SPACING = Math.max(15, SPACING)
     const { nodes: laid, layoutNodeWidth } = await layoutGraph(
       nodes,
       edges,
@@ -356,7 +355,7 @@ describe('ELK Layout', () => {
     ]
     const FLIP_CANVAS: CanvasSize = { width: 1500, height: 900 }
     const SPACING = 15
-    const EFFECTIVE_SPACING = Math.max(20, SPACING)
+    const EFFECTIVE_SPACING = Math.max(15, SPACING)
     const { nodes: laid, layoutNodeWidth } = await layoutGraph(
       nodes,
       edges,
@@ -372,7 +371,7 @@ describe('ELK Layout', () => {
       .sort((a, b) => a.position.x - b.position.x)
     expect(factors).toHaveLength(7)
 
-    // Single-row placement formula: rightEdge = 24 + 6 * (320+24+20) + 320 = 2528.
+    // Single-row placement formula: rightEdge = 24 + 6 * (320+24+15) + 320 = 2498.
     const lastVisibleRightEdge = factors[6].position.x + NODE_CARD_MAX_W
     expect(lastVisibleRightEdge).toBe(
       CANVAS_MARGIN + 6 * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + EFFECTIVE_SPACING) + NODE_CARD_MAX_W,
@@ -596,8 +595,8 @@ describe('applyCollisionGuard', () => {
 
   it('pushes the right neighbour right when the gap is below threshold', () => {
     // nodeA at x=0 width=100 ends at x=100.
-    // nodeB at x=105 leaves a 5px gap, below COLLISION_GAP=20.
-    // Expected: nodeB pushed to x=120 (leftRight + COLLISION_GAP).
+    // nodeB at x=105 leaves a 5px gap, below COLLISION_GAP=15.
+    // Expected: nodeB pushed to x=115 (leftRight + COLLISION_GAP).
     const positionMap = new Map<string, { x: number; y: number }>([
       ['a', { x: 0, y: 200 }],
       ['b', { x: 105, y: 200 }],
@@ -610,18 +609,19 @@ describe('applyCollisionGuard', () => {
     applyCollisionGuard(positionMap, sizeMap, 100)
 
     expect(positionMap.get('a')).toEqual({ x: 0, y: 200 })
-    expect(positionMap.get('b')).toEqual({ x: 120, y: 200 })
+    expect(positionMap.get('b')).toEqual({ x: 115, y: 200 })
   })
 
   it('cascades the second sweep when pushing a node into its right neighbour', () => {
     // Three nodes, each 100px wide, on the same row:
     //   a at x=0   (right edge 100)
-    //   b at x=105 (5px gap → pushed to x=120, right edge 220)
-    //   c at x=235 (15px gap from b@120 → pushed to x=240 in 2nd sweep)
+    //   b at x=105 (5px gap → pushed to x=115, right edge 215)
+    //   c at x=220 (5px gap from b@115 → pushed to x=230 in the forward
+    //               sweep, which uses b's already-updated position)
     const positionMap = new Map<string, { x: number; y: number }>([
       ['a', { x: 0,   y: 100 }],
       ['b', { x: 105, y: 100 }],
-      ['c', { x: 235, y: 100 }],
+      ['c', { x: 220, y: 100 }],
     ])
     const sizeMap = new Map<string, { width: number; height: number }>([
       ['a', { width: 100, height: 100 }],
@@ -632,8 +632,8 @@ describe('applyCollisionGuard', () => {
     applyCollisionGuard(positionMap, sizeMap, 100)
 
     expect(positionMap.get('a')!.x).toBe(0)
-    expect(positionMap.get('b')!.x).toBe(120)
-    expect(positionMap.get('c')!.x).toBe(240)
+    expect(positionMap.get('b')!.x).toBe(115)
+    expect(positionMap.get('c')!.x).toBe(230)
   })
 
   it('does not touch nodes on different Y rows', () => {

--- a/src/canvas/layoutStore.ts
+++ b/src/canvas/layoutStore.ts
@@ -24,11 +24,11 @@ interface LayoutOptions {
   setLayoutNodeWidth: (width: number) => void
 }
 
-// v6: nodeSpacing reduced 20 → 15 (intended). The rendered gap stays at 20 px
-// because layout.ts retains its `Math.max(20, spacing)` pre-ELK floor and the
-// post-ELK `applyCollisionGuard` keeps COLLISION_GAP=20. This bump records the
-// intended value and migrates returning users' persisted state; the floors
-// would need to be lowered separately to make the rendered gap match.
+// v6: nodeSpacing reduced 20 → 15. Initially deployed (PR #182) with both
+// runtime floors held at 20, so the persisted intent and rendered gap did
+// not match. A follow-up lowered the pre-ELK floor on layout.ts:64
+// (`Math.max(20, …)` → `Math.max(15, …)`) and `COLLISION_GAP` 20 → 15
+// together so the rendered gap now matches the persisted intent.
 // Migration policy: v5 default-like nodeSpacing=20 maps to v6 default 15; v4
 // default-like nodeSpacing=30 also maps to 15 (a direct v4 → v6 user skips
 // the intermediate v5 default). All other persisted fields carry over.

--- a/src/canvas/utils/layout.ts
+++ b/src/canvas/utils/layout.ts
@@ -52,18 +52,16 @@ export async function layoutGraph(
   const {
     direction = 'DOWN',
     // Default horizontal node-node spacing. Reduction chain 60 → 30 → 20 → 15.
-    // The Math.max(20, …) floor on line 64 is deliberately retained, so the
-    // rendered gap is still 20 px — `spacing=15` documents the intended value
-    // but is clamped at runtime. To genuinely render at 15, a future change
-    // would need to lower both that floor AND `COLLISION_GAP` (currently 20).
-    // 4-node max-width row at NODE_CARD_MAX_W=320: 1556 → 1466 → 1436 → 1436
-    // (no change in rendered width at gap=15 because of the floor).
+    // Both runtime floors (the `Math.max(15, …)` clamp on line 64 and
+    // COLLISION_GAP in nodeLayoutConstants.ts) were lowered to 15 together
+    // with this default so the value is no longer clamped at runtime.
+    // 4-node max-width row at NODE_CARD_MAX_W=320: 1556 → 1466 → 1436 → 1421.
     spacing = 15,
     layerSpacing,
     preserveLocked = true
   } = options
 
-  const effectiveNodeSpacing = Math.max(20, spacing)
+  const effectiveNodeSpacing = Math.max(15, spacing)
   const effectiveLayerSpacing = Math.max(30, layerSpacing ?? spacing * 1.5)
 
   const unlocked = preserveLocked

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -44,7 +44,7 @@ export const DEFAULT_NODE_HEIGHT = 100
  * to decide whether a tier renders at NODE_CARD_MAX_W or compresses to
  * NODE_LAYOUT_MIN_W with multi-row splitting. NOT a visual floor on the
  * rendered gap — the actual rendered gap is `effectiveNodeSpacing` in
- * `layout.ts`, clamped by `Math.max(20, spacing)` and the post-layout
+ * `layout.ts`, clamped by `Math.max(15, spacing)` and the post-layout
  * `applyCollisionGuard` (COLLISION_GAP). Lowering this value relaxes the
  * width-calc threshold (more tiers render at MAX_W).
  */
@@ -54,13 +54,14 @@ export const MIN_GAP = 15
  * Post-layout safety gap. Fires when ELK / multi-row splitting leaves two
  * same-row nodes closer than this threshold (rare; rounding-induced).
  *
- * Note: now larger than `MIN_GAP` (15) after the MIN_GAP 30 → 15 change.
- * The historical `COLLISION_GAP < MIN_GAP` relation no longer holds and
- * is not required — the two constants serve unrelated concerns. MIN_GAP
- * is a width-calc safety reserve only; COLLISION_GAP matches the
- * rendered node-node gap (`Math.max(20, spacing)` in layout.ts).
+ * Matches the rendered node-node gap (`Math.max(15, spacing)` in
+ * layout.ts) and is tracked together with it — if the pre-ELK floor
+ * changes, this must change with it so the collision guard does not
+ * push apart correctly-laid-out same-row pairs. Equal to MIN_GAP after
+ * both were lowered to 15 in the same change; the two constants still
+ * serve unrelated concerns despite the numeric coincidence.
  */
-export const COLLISION_GAP = 20
+export const COLLISION_GAP = 15
 
 /**
  * Minimum px from graph edge to canvas origin after global translation.


### PR DESCRIPTION
## Summary

Follow-up to [PR #182](https://github.com/Talchain/DecisionGuideAI/pull/182). That PR set the persisted `nodeSpacing` default to 15 but kept the two literal-20 runtime floors (`Math.max(20, spacing)` on [layout.ts:64](src/canvas/utils/layout.ts:64) and `COLLISION_GAP=20` on [nodeLayoutConstants.ts:50](src/canvas/utils/nodeLayoutConstants.ts:50)) per the brief's exclusion list, so the rendered gap stayed at 20 despite the persisted value being 15. This PR lowers both floors to 15 in lockstep so persisted intent and rendered output finally agree.

- `layout.ts:64`: `Math.max(20, spacing)` → `Math.max(15, spacing)`
- `nodeLayoutConstants.ts:50`: `COLLISION_GAP = 20` → `COLLISION_GAP = 15`
- Comments updated across `layout.ts`, `nodeLayoutConstants.ts`, `layoutStore.ts` to drop the "rendered stays at 20" caveats
- Tests updated: `EFFECTIVE_SPACING` formula in the 4-factor and 7-factor regression tests; 3 `applyCollisionGuard` tests updated to the new threshold (input positions in the cascade test adjusted so the cascade still triggers); `COLLISION_GAP` tight bound in `layout.semantic.spec.ts` tightened `<=20` → `<=15`

Both floors must move together: the pre-ELK clamp controls the value ELK sees, and the post-ELK guard pushes adjacent same-row pairs back to `COLLISION_GAP`. Lowering one alone is either inert (pre-ELK only) or risks overlap (guard only).

## Effect — rendered row widths at NODE_CARD_MAX_W=320

| Tier | Before this PR | After this PR | Δ   |
|------|----------------|---------------|-----|
| 4    | 1436           | 1421          | −15 |
| 5    | 1800           | 1780          | −20 |
| 6    | 2164           | 2139          | −25 |
| 7    | 2528           | 2498          | −30 |

Matches the row-widths table in the original brief. Visually subtle but genuinely tighter on dense factor rows.

## Test plan

- [x] Typecheck clean
- [x] 9-spec layout sweep + `layoutStore.spec.ts`: 122 tests pass (same count; existing tests adjusted to the new floor — the regression locks use `EFFECTIVE_SPACING = Math.max(15, SPACING)` so they verify the new rendered widths)
- [x] 3 `applyCollisionGuard` unit tests updated; cascade test re-uses adjusted input positions so the cascade behaviour is still exercised
- [x] `--changed` sweep: only pre-existing failure is the V5 graph re-fetch test in `useConversation.hook.spec.ts` (confirmed unrelated on `origin/staging` HEAD across three prior rounds)
- [x] Manual `bash scripts/validate-prepush.sh`: all 7 gates green

## Rollback

Single `git revert` of the squashed commit. Self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)