### PR TITLE
REVERT PR #183: lower runtime floors — caused layout failures

### DIFF
--- a/src/canvas/__tests__/layout.semantic.spec.ts
+++ b/src/canvas/__tests__/layout.semantic.spec.ts
@@ -534,24 +534,23 @@ describe('constants contract', () => {
   })
 
   it('COLLISION_GAP does not exceed the rendered node-node gap', () => {
-    // Rendered gap = `Math.max(15, default spacing=15)` = 15 after the
-    // chain 60 → 30 → 20 → 15 and the matching floor change (the pre-ELK
-    // `Math.max` lower bound was lowered to 15 together with this constant).
-    // COLLISION_GAP must not exceed the rendered gap — if it did, the
-    // post-layout collision guard would push apart correctly-laid-out
-    // same-row pairs. COLLISION_GAP=15 = rendered gap, so the guard is
-    // essentially inert; it only fires when ELK / multi-row splitting
-    // drives nodes closer than 15 px.
+    // Rendered gap = `Math.max(20, default spacing)` = 20. (Default spacing
+    // is 15 after the chain 60 → 30 → 20 → 15; the literal-20 floor in
+    // layout.ts pins the runtime value at 20 even though the persisted
+    // intent is 15.) COLLISION_GAP must not exceed the rendered gap — if it
+    // did, the post-layout collision guard would push apart correctly-
+    // laid-out same-row pairs. Currently COLLISION_GAP=20 = rendered gap,
+    // so the guard is essentially inert; it only fires when ELK / multi-row
+    // splitting drives nodes closer than 20 px.
     //
-    // The tight bound (`<= 15`) reflects the current contract; the loose
+    // The tight bound (`<= 20`) reflects the current contract; the loose
     // `< 30` is a documentation-grade ceiling preserved from earlier rounds.
     // Both are asserted so a future change that breaks either surfaces here.
     //
-    // Note: MIN_GAP=15 = COLLISION_GAP=15 now (both lowered in the same
-    // change). The historical `COLLISION_GAP < MIN_GAP` relation does not
-    // hold; the two constants serve unrelated concerns despite the
-    // numeric coincidence (see `nodeLayoutConstants.ts`).
-    expect(COLLISION_GAP).toBeLessThanOrEqual(15)
+    // Note: the historical `COLLISION_GAP < MIN_GAP` relation no longer
+    // holds after the MIN_GAP 30 → 15 change (MIN_GAP=15 < COLLISION_GAP=20).
+    // The two constants serve unrelated concerns; see `nodeLayoutConstants.ts`.
+    expect(COLLISION_GAP).toBeLessThanOrEqual(20)
     expect(COLLISION_GAP).toBeLessThan(30)
   })
 

--- a/src/canvas/__tests__/layout.spec.ts
+++ b/src/canvas/__tests__/layout.spec.ts
@@ -262,21 +262,22 @@ describe('ELK Layout', () => {
 
   it('4-factor tier on 1300px canvas: max-single fires; row overflows canvas (regression-lock for NODE_CARD_MAX_W=320)', async () => {
     // After restoring NODE_CARD_MAX_W to 320 and tightening the default
-    // spacing to 15 (chain 60 → 30 → 20 → 15) — with the pre-ELK floor
-    // and COLLISION_GAP lowered to 15 in the same change — a 4-node tier
-    // on a 1300px canvas falls into the max-single branch and the rendered
-    // row visibly overflows the canvas. Math:
+    // spacing to 15 (chain 60 → 30 → 20 → 15), a 4-node tier on a 1300px
+    // canvas falls into the max-single branch and the rendered row visibly
+    // overflows the canvas. The pre-ELK `Math.max(20, spacing)` floor in
+    // layout.ts clamps effective spacing to 20 even when the caller passes
+    // 15, so the rendered last-edge stays at 1436 (was 1466 at spacing=30,
+    // 1556 at spacing=60). Math:
     //
-    //   effectiveSpacing = Math.max(15, SPACING) = 15
+    //   effectiveSpacing = Math.max(20, SPACING) = 20
     //   rightEdge = CANVAS_MARGIN
     //             + (N-1) * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + effectiveSpacing)
     //             + NODE_CARD_MAX_W
-    //             = 24 + 3 * (320 + 24 + 15) + 320
-    //             = 24 + 3 * 359 + 320
-    //             = 1421
+    //             = 24 + 3 * (320 + 24 + 20) + 320
+    //             = 24 + 3 * 364 + 320
+    //             = 1436
     //
-    // 1421 > 1300 → 121px overflow past the canvas right edge (was 136px at
-    // floor=20, 166px at spacing=30, 256px at spacing=60). The test
+    // 1436 > 1300 → 136px overflow past the canvas right edge. The test
     // exercises the production-default spacing path by passing SPACING that
     // matches the layoutGraph default; EFFECTIVE_SPACING below makes the
     // pre-ELK floor explicit in the assertion so a future change to either
@@ -293,7 +294,7 @@ describe('ELK Layout', () => {
       makeEdge('e4', 'o1', 'f3'), makeEdge('e5', 'o1', 'f4'),
     ]
     const SPACING = 15
-    const EFFECTIVE_SPACING = Math.max(15, SPACING)
+    const EFFECTIVE_SPACING = Math.max(20, SPACING)
     const { nodes: laid, layoutNodeWidth } = await layoutGraph(
       nodes,
       edges,
@@ -355,7 +356,7 @@ describe('ELK Layout', () => {
     ]
     const FLIP_CANVAS: CanvasSize = { width: 1500, height: 900 }
     const SPACING = 15
-    const EFFECTIVE_SPACING = Math.max(15, SPACING)
+    const EFFECTIVE_SPACING = Math.max(20, SPACING)
     const { nodes: laid, layoutNodeWidth } = await layoutGraph(
       nodes,
       edges,
@@ -371,7 +372,7 @@ describe('ELK Layout', () => {
       .sort((a, b) => a.position.x - b.position.x)
     expect(factors).toHaveLength(7)
 
-    // Single-row placement formula: rightEdge = 24 + 6 * (320+24+15) + 320 = 2498.
+    // Single-row placement formula: rightEdge = 24 + 6 * (320+24+20) + 320 = 2528.
     const lastVisibleRightEdge = factors[6].position.x + NODE_CARD_MAX_W
     expect(lastVisibleRightEdge).toBe(
       CANVAS_MARGIN + 6 * (NODE_CARD_MAX_W + LAYOUT_PADDING_X + EFFECTIVE_SPACING) + NODE_CARD_MAX_W,
@@ -595,8 +596,8 @@ describe('applyCollisionGuard', () => {
 
   it('pushes the right neighbour right when the gap is below threshold', () => {
     // nodeA at x=0 width=100 ends at x=100.
-    // nodeB at x=105 leaves a 5px gap, below COLLISION_GAP=15.
-    // Expected: nodeB pushed to x=115 (leftRight + COLLISION_GAP).
+    // nodeB at x=105 leaves a 5px gap, below COLLISION_GAP=20.
+    // Expected: nodeB pushed to x=120 (leftRight + COLLISION_GAP).
     const positionMap = new Map<string, { x: number; y: number }>([
       ['a', { x: 0, y: 200 }],
       ['b', { x: 105, y: 200 }],
@@ -609,19 +610,18 @@ describe('applyCollisionGuard', () => {
     applyCollisionGuard(positionMap, sizeMap, 100)
 
     expect(positionMap.get('a')).toEqual({ x: 0, y: 200 })
-    expect(positionMap.get('b')).toEqual({ x: 115, y: 200 })
+    expect(positionMap.get('b')).toEqual({ x: 120, y: 200 })
   })
 
   it('cascades the second sweep when pushing a node into its right neighbour', () => {
     // Three nodes, each 100px wide, on the same row:
     //   a at x=0   (right edge 100)
-    //   b at x=105 (5px gap → pushed to x=115, right edge 215)
-    //   c at x=220 (5px gap from b@115 → pushed to x=230 in the forward
-    //               sweep, which uses b's already-updated position)
+    //   b at x=105 (5px gap → pushed to x=120, right edge 220)
+    //   c at x=235 (15px gap from b@120 → pushed to x=240 in 2nd sweep)
     const positionMap = new Map<string, { x: number; y: number }>([
       ['a', { x: 0,   y: 100 }],
       ['b', { x: 105, y: 100 }],
-      ['c', { x: 220, y: 100 }],
+      ['c', { x: 235, y: 100 }],
     ])
     const sizeMap = new Map<string, { width: number; height: number }>([
       ['a', { width: 100, height: 100 }],
@@ -632,8 +632,8 @@ describe('applyCollisionGuard', () => {
     applyCollisionGuard(positionMap, sizeMap, 100)
 
     expect(positionMap.get('a')!.x).toBe(0)
-    expect(positionMap.get('b')!.x).toBe(115)
-    expect(positionMap.get('c')!.x).toBe(230)
+    expect(positionMap.get('b')!.x).toBe(120)
+    expect(positionMap.get('c')!.x).toBe(240)
   })
 
   it('does not touch nodes on different Y rows', () => {

--- a/src/canvas/layoutStore.ts
+++ b/src/canvas/layoutStore.ts
@@ -24,11 +24,11 @@ interface LayoutOptions {
   setLayoutNodeWidth: (width: number) => void
 }
 
-// v6: nodeSpacing reduced 20 → 15. Initially deployed (PR #182) with both
-// runtime floors held at 20, so the persisted intent and rendered gap did
-// not match. A follow-up lowered the pre-ELK floor on layout.ts:64
-// (`Math.max(20, …)` → `Math.max(15, …)`) and `COLLISION_GAP` 20 → 15
-// together so the rendered gap now matches the persisted intent.
+// v6: nodeSpacing reduced 20 → 15 (intended). The rendered gap stays at 20 px
+// because layout.ts retains its `Math.max(20, spacing)` pre-ELK floor and the
+// post-ELK `applyCollisionGuard` keeps COLLISION_GAP=20. This bump records the
+// intended value and migrates returning users' persisted state; the floors
+// would need to be lowered separately to make the rendered gap match.
 // Migration policy: v5 default-like nodeSpacing=20 maps to v6 default 15; v4
 // default-like nodeSpacing=30 also maps to 15 (a direct v4 → v6 user skips
 // the intermediate v5 default). All other persisted fields carry over.

--- a/src/canvas/utils/layout.ts
+++ b/src/canvas/utils/layout.ts
@@ -52,16 +52,18 @@ export async function layoutGraph(
   const {
     direction = 'DOWN',
     // Default horizontal node-node spacing. Reduction chain 60 → 30 → 20 → 15.
-    // Both runtime floors (the `Math.max(15, …)` clamp on line 64 and
-    // COLLISION_GAP in nodeLayoutConstants.ts) were lowered to 15 together
-    // with this default so the value is no longer clamped at runtime.
-    // 4-node max-width row at NODE_CARD_MAX_W=320: 1556 → 1466 → 1436 → 1421.
+    // The Math.max(20, …) floor on line 64 is deliberately retained, so the
+    // rendered gap is still 20 px — `spacing=15` documents the intended value
+    // but is clamped at runtime. To genuinely render at 15, a future change
+    // would need to lower both that floor AND `COLLISION_GAP` (currently 20).
+    // 4-node max-width row at NODE_CARD_MAX_W=320: 1556 → 1466 → 1436 → 1436
+    // (no change in rendered width at gap=15 because of the floor).
     spacing = 15,
     layerSpacing,
     preserveLocked = true
   } = options
 
-  const effectiveNodeSpacing = Math.max(15, spacing)
+  const effectiveNodeSpacing = Math.max(20, spacing)
   const effectiveLayerSpacing = Math.max(30, layerSpacing ?? spacing * 1.5)
 
   const unlocked = preserveLocked

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -44,7 +44,7 @@ export const DEFAULT_NODE_HEIGHT = 100
  * to decide whether a tier renders at NODE_CARD_MAX_W or compresses to
  * NODE_LAYOUT_MIN_W with multi-row splitting. NOT a visual floor on the
  * rendered gap — the actual rendered gap is `effectiveNodeSpacing` in
- * `layout.ts`, clamped by `Math.max(15, spacing)` and the post-layout
+ * `layout.ts`, clamped by `Math.max(20, spacing)` and the post-layout
  * `applyCollisionGuard` (COLLISION_GAP). Lowering this value relaxes the
  * width-calc threshold (more tiers render at MAX_W).
  */
@@ -54,14 +54,13 @@ export const MIN_GAP = 15
  * Post-layout safety gap. Fires when ELK / multi-row splitting leaves two
  * same-row nodes closer than this threshold (rare; rounding-induced).
  *
- * Matches the rendered node-node gap (`Math.max(15, spacing)` in
- * layout.ts) and is tracked together with it — if the pre-ELK floor
- * changes, this must change with it so the collision guard does not
- * push apart correctly-laid-out same-row pairs. Equal to MIN_GAP after
- * both were lowered to 15 in the same change; the two constants still
- * serve unrelated concerns despite the numeric coincidence.
+ * Note: now larger than `MIN_GAP` (15) after the MIN_GAP 30 → 15 change.
+ * The historical `COLLISION_GAP < MIN_GAP` relation no longer holds and
+ * is not required — the two constants serve unrelated concerns. MIN_GAP
+ * is a width-calc safety reserve only; COLLISION_GAP matches the
+ * rendered node-node gap (`Math.max(20, spacing)` in layout.ts).
  */
-export const COLLISION_GAP = 15
+export const COLLISION_GAP = 20
 
 /**
  * Minimum px from graph edge to canvas origin after global translation.


### PR DESCRIPTION
## P0 Revert

PR #183 (\`69b78888\`) lowered the pre-ELK \`Math.max\` floor and \`COLLISION_GAP\` from 20 → 15. Post-deploy, the user reports the canvas now renders with all nodes piled together and the toast banner "Layout failed. Try again." appears — i.e. \`layoutGraph\` is throwing at runtime for some graph shapes.

This PR reverts \`69b78888\` cleanly. The previous state (PR #182, persistent-default=15 but runtime floors held at 20) becomes effective again. Rendered gap returns to 20 px; visible reduction is again deferred.

Root cause not yet identified; CI typecheck/lint/build all passed pre-merge, smoke + 9-spec sweep + layoutStore tests all green locally and in PR CI, so the failure is a runtime regression not caught by the existing test surface. Investigation will follow as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)