### PR TITLE
feat(results): Track S factor value provenance passthrough + debug-only verification

### DIFF
--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -280,6 +280,11 @@ export function pickFactorSensitivityForUi(v2Response: V2RunResponse): FactorSen
         // VOI Fix: Pass through value_of_information for driver confidence display
         value_of_information: f.value_of_information as number | undefined,
         confidence_components: f.confidence_components as V2FactorSensitivity['confidence_components'],
+        // Track S: pass through factor value provenance. Guarded extraction keeps
+        // the adapter boundary safe and preserves explicit `false` (never coerces absent).
+        value_source: typeof f.value_source === 'string' ? f.value_source : undefined,
+        value_extraction_type: typeof f.value_extraction_type === 'string' ? f.value_extraction_type : undefined,
+        value_defaulted: typeof f.value_defaulted === 'boolean' ? f.value_defaulted : undefined,
       }))
       return { factors, _source_path: 'downstream_calls.isl' }
     }
@@ -330,6 +335,11 @@ export function pickFactorSensitivityForUi(v2Response: V2RunResponse): FactorSen
         // VOI Fix: Pass through value_of_information for driver confidence display
         value_of_information: f.value_of_information as number | undefined,
         confidence_components: f.confidence_components as V2FactorSensitivity['confidence_components'],
+        // Track S: pass through factor value provenance. Guarded extraction keeps
+        // the adapter boundary safe and preserves explicit `false` (never coerces absent).
+        value_source: typeof f.value_source === 'string' ? f.value_source : undefined,
+        value_extraction_type: typeof f.value_extraction_type === 'string' ? f.value_extraction_type : undefined,
+        value_defaulted: typeof f.value_defaulted === 'boolean' ? f.value_defaulted : undefined,
       }))
       return { factors, _source_path: 'enrichment' }
     }

--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -234,6 +234,12 @@ export interface V2FactorSensitivity {
   attribution_stability?: string
   /** Rank flip rate from PLoT bootstrap */
   rank_flip_rate?: number
+  /** Track S: provenance of the factor value (where it came from). Optional/additive; absent on pre-Track-S payloads. */
+  value_source?: string
+  /** Track S: how the value was obtained (explicit / inferred / …). Optional/additive. */
+  value_extraction_type?: string
+  /** Track S: true when the value was assumed/defaulted rather than provided. Optional/additive. */
+  value_defaulted?: boolean
 }
 
 /**

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -723,6 +723,14 @@ export function DriversSection({
         driversStatus,
         hasMagnitudeData,
         islError,
+        // Track S: factor value provenance — verification-only. Gated behind
+        // window.__OLUMI_DEBUG; never rendered to the DOM or shown to users.
+        provenance: drivers.map(d => ({
+          factorKey: d.factorKey,
+          valueSource: d.valueSource,
+          valueExtractionType: d.valueExtractionType,
+          valueDefaulted: d.valueDefaulted,
+        })),
       })
     }
   }, [drivers, driversStatus, hasMagnitudeData, islError])

--- a/src/components/results/__tests__/DriversSection.valueProvenance.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.valueProvenance.spec.tsx
@@ -1,0 +1,173 @@
+/**
+ * Track S — factor value provenance: normalize survival, no-DOM-leak, and
+ * debug-only exposure.
+ *
+ * Covers (DGAI/UI passthrough brief):
+ * - normalizeFactorSensitivity maps snake_case value_* → camelCase value* and
+ *   preserves only-when-present (explicit false kept; absent stays absent;
+ *   non-conforming types ignored).
+ * - The values are NEVER rendered to the DOM in normal mode (no user-facing
+ *   copy or badges) — uses sentinel strings to rule out coincidental matches.
+ * - The values ARE surfaced in the existing window.__OLUMI_DEBUG diagnostic
+ *   (verification-only) and are strictly gated behind that flag.
+ *
+ * End-to-end survival into `data.drivers` (normalize → DriverItem build) is
+ * proven separately in useResultsSectionData.spec.ts; mapper survival in
+ * test/__tests__/invariants/ui/value-provenance-preservation.test.ts.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DriversSection } from '../DriversSection'
+import { normalizeFactorSensitivity } from '../useResultsSectionData'
+import type { DriversSectionData, DriverItem } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+}))
+
+function makeDriver(overrides: Partial<DriverItem> & { factorKey: string }): DriverItem {
+  return {
+    factorLabel: overrides.factorKey,
+    rawElasticity: 0.5,
+    normalisedInfluence: 0.5,
+    influenceScore: 0.5,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: false,
+    direction: 'positive',
+    confidence: 0.5,
+    ...overrides,
+  }
+}
+
+function makeDriversData(drivers: DriverItem[]): DriversSectionData {
+  return {
+    drivers,
+    topDrivers: drivers.slice(0, 3),
+    driversStatus: 'computed',
+    totalCount: drivers.length,
+    hasMagnitudeData: true,
+  }
+}
+
+describe('Track S value provenance — normalizeFactorSensitivity', () => {
+  const emptyLabels = new Map<string, string>()
+
+  it('maps snake_case value_* to camelCase and preserves value_defaulted=true', () => {
+    const n = normalizeFactorSensitivity(
+      {
+        factor_id: 'fac_a',
+        elasticity: 0.5,
+        value_source: 'brief_extraction',
+        value_extraction_type: 'inferred',
+        value_defaulted: true,
+      },
+      emptyLabels,
+    )
+
+    expect(n.valueSource).toBe('brief_extraction')
+    expect(n.valueExtractionType).toBe('inferred')
+    expect(n.valueDefaulted).toBe(true)
+  })
+
+  it('preserves an explicit value_defaulted=false (no coercion)', () => {
+    const n = normalizeFactorSensitivity(
+      { factor_id: 'fac_a', elasticity: 0.5, value_defaulted: false },
+      emptyLabels,
+    )
+    expect(n.valueDefaulted).toBe(false)
+  })
+
+  it('leaves absent provenance fields absent (never coerced)', () => {
+    const n = normalizeFactorSensitivity({ factor_id: 'fac_a', elasticity: 0.5 }, emptyLabels)
+    expect(n.valueSource).toBeUndefined()
+    expect(n.valueExtractionType).toBeUndefined()
+    expect(n.valueDefaulted).toBeUndefined()
+  })
+
+  it('ignores non-conforming types via guarded extraction', () => {
+    const n = normalizeFactorSensitivity(
+      { factor_id: 'fac_a', elasticity: 0.5, value_source: 99, value_defaulted: 'true' },
+      emptyLabels,
+    )
+    expect(n.valueSource).toBeUndefined()
+    expect(n.valueDefaulted).toBeUndefined()
+  })
+})
+
+describe('Track S value provenance — no user-facing DOM leak', () => {
+  it('does not render raw provenance values as visible text or markup in normal mode', () => {
+    const data = makeDriversData([
+      makeDriver({
+        factorKey: 'fac_a',
+        factorLabel: 'Factor A',
+        valueSource: 'SENTINEL_SOURCE',
+        valueExtractionType: 'SENTINEL_EXTRACTION',
+        valueDefaulted: true,
+      }),
+    ])
+
+    const { container } = render(<DriversSection data={data} goalLabel="test" />)
+
+    // Sanity: the section rendered.
+    expect(screen.getByTestId('drivers-confidence-header')).toBeInTheDocument()
+    // No visible text leak.
+    expect(screen.queryByText(/SENTINEL_SOURCE/)).toBeNull()
+    expect(screen.queryByText(/SENTINEL_EXTRACTION/)).toBeNull()
+    // And no leak into markup either — title/aria-label/data-* attributes are not
+    // text nodes, so this guards against a future regression that queryByText misses.
+    expect(container.innerHTML).not.toContain('SENTINEL_SOURCE')
+    expect(container.innerHTML).not.toContain('SENTINEL_EXTRACTION')
+  })
+})
+
+describe('Track S value provenance — debug-only exposure (window.__OLUMI_DEBUG)', () => {
+  afterEach(() => {
+    delete (window as Window & { __OLUMI_DEBUG?: boolean }).__OLUMI_DEBUG
+    vi.restoreAllMocks()
+  })
+
+  const data = makeDriversData([
+    makeDriver({
+      factorKey: 'fac_a',
+      factorLabel: 'Factor A',
+      valueSource: 'SENTINEL_SOURCE',
+      valueExtractionType: 'SENTINEL_EXTRACTION',
+      valueDefaulted: true,
+    }),
+  ])
+
+  it('surfaces provenance in the diagnostic when the debug flag is on', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    ;(window as Window & { __OLUMI_DEBUG?: boolean }).__OLUMI_DEBUG = true
+
+    render(<DriversSection data={data} goalLabel="test" />)
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[DriversSection] Data diagnostic:',
+      expect.objectContaining({
+        provenance: expect.arrayContaining([
+          expect.objectContaining({
+            factorKey: 'fac_a',
+            valueSource: 'SENTINEL_SOURCE',
+            valueExtractionType: 'SENTINEL_EXTRACTION',
+            valueDefaulted: true,
+          }),
+        ]),
+      }),
+    )
+  })
+
+  it('emits nothing when the debug flag is off (strictly gated)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // __OLUMI_DEBUG left unset
+
+    render(<DriversSection data={data} goalLabel="test" />)
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      '[DriversSection] Data diagnostic:',
+      expect.anything(),
+    )
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -1228,6 +1228,78 @@ describe('useResultsSectionData runtime safety', () => {
 })
 
 // =============================================================================
+// Track S — factor value provenance survives into data.drivers
+// =============================================================================
+
+describe('useResultsSectionData — Track S value provenance into data.drivers', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 } as any,
+      runMeta: {},
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      currentScenarioFraming: null,
+      ceeAnalysisReady: undefined,
+    })
+  })
+
+  const setReportWithFactor = (factor: Record<string, unknown>) => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: {
+          run: { critique: [] },
+          robustness: { fragile_edges: [] },
+          option_comparison: [],
+          factor_sensitivity: [factor],
+        },
+      } as any,
+      hasCompletedFirstRun: true,
+      nodes: [],
+      edges: [],
+    })
+  }
+
+  it('carries value_source / value_extraction_type / value_defaulted=true onto the driver', () => {
+    setReportWithFactor({
+      factor_id: 'fac_a',
+      label: 'Factor A',
+      sensitivity_score: 0.5,
+      value_source: 'brief_extraction',
+      value_extraction_type: 'inferred',
+      value_defaulted: true,
+    })
+
+    const { result } = renderHook(() => useResultsSectionData())
+    const driver = result.current.drivers.drivers[0]
+
+    expect(driver).toBeDefined()
+    expect(driver?.valueSource).toBe('brief_extraction')
+    expect(driver?.valueExtractionType).toBe('inferred')
+    expect(driver?.valueDefaulted).toBe(true)
+  })
+
+  it('preserves explicit value_defaulted=false and leaves absent fields absent', () => {
+    setReportWithFactor({
+      factor_id: 'fac_a',
+      label: 'Factor A',
+      sensitivity_score: 0.5,
+      value_defaulted: false,
+      // value_source / value_extraction_type intentionally omitted
+    })
+
+    const { result } = renderHook(() => useResultsSectionData())
+    const driver = result.current.drivers.drivers[0]
+
+    expect(driver?.valueDefaulted).toBe(false)
+    expect(driver?.valueSource).toBeUndefined()
+    expect(driver?.valueExtractionType).toBeUndefined()
+  })
+})
+
+// =============================================================================
 // Baseline Resolution Tests (Task 2.1)
 // =============================================================================
 

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -444,6 +444,12 @@ export interface DriverItem {
   evpi?: number
   /** ISL EVPI: expected improvement in percentage points */
   evpiPercentagePoints?: number
+  /** Track S: provenance of the factor value. Optional; absent on pre-Track-S payloads. */
+  valueSource?: string
+  /** Track S: how the value was obtained (explicit / inferred / …). Optional. */
+  valueExtractionType?: string
+  /** Track S: true when the value was assumed/defaulted. Distinct from isDefaultedConfidence (a confidence signal). */
+  valueDefaulted?: boolean
 }
 
 export interface DriversSectionData {
@@ -759,6 +765,12 @@ export interface RawFactorSensitivity {
   rank_flip_rate?: number
   evpi?: number
   evpi_percentage_points?: number
+  /** Track S: provenance of the factor value. Optional/additive; mirrors V2FactorSensitivity. */
+  value_source?: string
+  /** Track S: how the value was obtained (explicit / inferred / …). Optional/additive. */
+  value_extraction_type?: string
+  /** Track S: true when the value was assumed/defaulted. Optional/additive. */
+  value_defaulted?: boolean
 }
 
 export interface UiFactorSensitivity {
@@ -790,6 +802,12 @@ export interface UiFactorSensitivity {
   rankFlipRate?: number
   evpi?: number
   evpiPercentagePoints?: number
+  /** Track S: provenance of the factor value. Optional; absent on pre-Track-S payloads. */
+  valueSource?: string
+  /** Track S: how the value was obtained (explicit / inferred / …). Optional. */
+  valueExtractionType?: string
+  /** Track S: true when the value was assumed/defaulted. Distinct from isDefaultedConfidence (a confidence signal). */
+  valueDefaulted?: boolean
 }
 
 // =============================================================================

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -384,6 +384,12 @@ export function normalizeFactorSensitivity(raw: unknown, nodeLabelMap: Map<strin
       }
     : undefined
 
+  // Track S: factor value provenance — preserve only when present. Strict typeof
+  // guards keep an explicit `false` and never coerce an absent value → false.
+  const valueSource = typeof typed.value_source === 'string' ? typed.value_source : undefined
+  const valueExtractionType = typeof typed.value_extraction_type === 'string' ? typed.value_extraction_type : undefined
+  const valueDefaulted = typeof typed.value_defaulted === 'boolean' ? typed.value_defaulted : undefined
+
   return {
     factorId: rawId ?? label,
     label,
@@ -398,6 +404,9 @@ export function normalizeFactorSensitivity(raw: unknown, nodeLabelMap: Map<strin
     confidenceSource,
     samplingStability,
     confidenceProvenance,
+    valueSource,
+    valueExtractionType,
+    valueDefaulted,
     attributionStability: (typed.attribution_stability === 'high' || typed.attribution_stability === 'moderate' || typed.attribution_stability === 'low' || typed.attribution_stability === 'negligible') ? typed.attribution_stability : undefined,
     rankFlipRate: typeof typed.rank_flip_rate === 'number' ? typed.rank_flip_rate : undefined,
     evpi: typeof typed.evpi === 'number' ? typed.evpi : undefined,
@@ -1780,6 +1789,11 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           }),
           // Audit A1-PRIMARY: plumb provenance through for the column-header marker.
           confidenceProvenance: f.raw.confidenceProvenance,
+          // Track S: factor value provenance — carried into the driver model for
+          // verification only (exposed via the __OLUMI_DEBUG diagnostic, not the DOM).
+          valueSource: f.raw.valueSource,
+          valueExtractionType: f.raw.valueExtractionType,
+          valueDefaulted: f.raw.valueDefaulted,
         }
       })
       .sort((a, b) => a.rank - b.rank) // Sort by rank

--- a/src/test/__tests__/invariants/ui/value-provenance-preservation.test.ts
+++ b/src/test/__tests__/invariants/ui/value-provenance-preservation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Track S — factor value provenance preservation invariants
+ *
+ * Verifies that the optional, additive value-provenance fields emitted by ISL
+ * on factor_sensitivity[*] survive `pickFactorSensitivityForUi()` on BOTH
+ * real-data branches (downstream_calls.isl and enrichment):
+ *   - value_source           (string)
+ *   - value_extraction_type  (string)
+ *   - value_defaulted        (boolean)
+ *
+ * Sibling of importance-score-preservation.test.ts — same explicit-pick
+ * preservation pattern. Guards against the fields being dropped by the
+ * adapter boundary (the historical drop point before Track S).
+ *
+ * Preserve-only-when-present contract:
+ *   - explicit `false` is preserved (never coerced away);
+ *   - an absent field stays absent (never coerced to false / "");
+ *   - non-conforming types are ignored (guarded extraction → undefined).
+ *
+ * A real-data field (sensitivity_score) is included in every fixture so the
+ * ISL / enrichment branch is actually taken (not the top-level fallback).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { pickFactorSensitivityForUi } from '../../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../../adapters/plot/v2/types'
+
+const islResponse = (factor: Record<string, unknown>) =>
+  ({
+    downstream_calls: { isl: { response: { factor_sensitivity: [factor] } } },
+  } as unknown as V2RunResponse)
+
+const enrichmentResponse = (factor: Record<string, unknown>) =>
+  ({
+    enrichment: { sensitivity_analysis: { factors: [factor] } },
+  } as unknown as V2RunResponse)
+
+describe('Track S value provenance preservation (pickFactorSensitivityForUi)', () => {
+  // pickFactorSensitivityForUi logs DEV branch diagnostics via console.warn.
+  // Suppress them here to keep this unit spec's output clean — branch selection
+  // is asserted explicitly via `_source_path`, so the logs are redundant.
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('downstream_calls.isl branch', () => {
+    it('preserves value_source, value_extraction_type and value_defaulted=true', () => {
+      const result = pickFactorSensitivityForUi(
+        islResponse({
+          factor_id: 'fac_a',
+          label: 'Factor A',
+          sensitivity_score: 0.5,
+          value_source: 'brief_extraction',
+          value_extraction_type: 'inferred',
+          value_defaulted: true,
+        }),
+      )
+
+      expect(result._source_path).toBe('downstream_calls.isl')
+      expect(result.factors[0].value_source).toBe('brief_extraction')
+      expect(result.factors[0].value_extraction_type).toBe('inferred')
+      expect(result.factors[0].value_defaulted).toBe(true)
+    })
+
+    it('preserves an explicit value_defaulted=false (no coercion)', () => {
+      const result = pickFactorSensitivityForUi(
+        islResponse({
+          factor_id: 'fac_a',
+          sensitivity_score: 0.5,
+          value_source: 'explicit',
+          value_defaulted: false,
+        }),
+      )
+
+      expect(result.factors[0].value_defaulted).toBe(false)
+    })
+
+    it('leaves an absent value_defaulted absent (never coerced to false)', () => {
+      const result = pickFactorSensitivityForUi(
+        islResponse({
+          factor_id: 'fac_a',
+          sensitivity_score: 0.5,
+          value_source: 'explicit',
+          value_extraction_type: 'explicit',
+          // value_defaulted intentionally omitted
+        }),
+      )
+
+      expect(result.factors[0].value_defaulted).toBeUndefined()
+      expect(result.factors[0].value_source).toBe('explicit')
+      expect(result.factors[0].value_extraction_type).toBe('explicit')
+    })
+
+    it('ignores non-conforming types via guarded extraction', () => {
+      const result = pickFactorSensitivityForUi(
+        islResponse({
+          factor_id: 'fac_a',
+          sensitivity_score: 0.5,
+          value_source: 42, // not a string
+          value_defaulted: 'true', // not a boolean
+        }),
+      )
+
+      expect(result.factors[0].value_source).toBeUndefined()
+      expect(result.factors[0].value_defaulted).toBeUndefined()
+    })
+  })
+
+  describe('enrichment branch', () => {
+    it('preserves value_source, value_extraction_type and value_defaulted=true', () => {
+      const result = pickFactorSensitivityForUi(
+        enrichmentResponse({
+          factor_id: 'fac_b',
+          label: 'Factor B',
+          sensitivity_score: 0.5,
+          value_source: 'cee_inference',
+          value_extraction_type: 'inferred',
+          value_defaulted: true,
+        }),
+      )
+
+      expect(result._source_path).toBe('enrichment')
+      expect(result.factors[0].value_source).toBe('cee_inference')
+      expect(result.factors[0].value_extraction_type).toBe('inferred')
+      expect(result.factors[0].value_defaulted).toBe(true)
+    })
+
+    it('preserves an explicit value_defaulted=false and leaves absent absent', () => {
+      const explicitFalse = pickFactorSensitivityForUi(
+        enrichmentResponse({ factor_id: 'fac_b', sensitivity_score: 0.5, value_defaulted: false }),
+      )
+      expect(explicitFalse.factors[0].value_defaulted).toBe(false)
+
+      const omitted = pickFactorSensitivityForUi(
+        enrichmentResponse({ factor_id: 'fac_b', sensitivity_score: 0.5 }),
+      )
+      expect(omitted.factors[0].value_defaulted).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

ISL emits optional factor-level **value-provenance** fields on `factor_sensitivity[*]` — `value_source`, `value_extraction_type`, `value_defaulted` — and PLoT PR #178 passes them through when present. They were silently dropped at two UI explicit-pick points. This PR is the **smallest safe passthrough**: the fields now survive end-to-end into the UI driver model (`data.drivers`), with **debug-only** verification and **no user-facing UI**.

This is **not** a `DecisionConfidencePanel` retirement. The panel is a decision-level hero on its own `AnalysisHeroV17` migration track and does not consume `factor_sensitivity`. Factor provenance is a separate factor-level concern in the Drivers layer; the two tracks stay decoupled.

## Data path (survival confirmed at each stage)

| Stage | Result |
|---|---|
| `V2FactorSensitivity` / `RawFactorSensitivity` (wire types) | fields declared (snake_case) |
| `pickFactorSensitivityForUi` (`downstream_calls.isl` + `enrichment`) | guarded passthrough on both real-data branches; fallback untouched |
| `mapV2ResponseToReportV1` | unchanged — passes `.factors` through |
| `normalizeFactorSensitivity` | preserve-only-when-present → camelCase `valueSource`/`valueExtractionType`/`valueDefaulted` |
| `DriverItem` / `data.drivers` | carried onto the driver model |
| Debug surface | exposed only via the existing `window.__OLUMI_DEBUG` console diagnostic in `DriversSection` |

`value_defaulted` (a value signal) is kept distinct from `isDefaultedConfidence` (a confidence signal). Preserve semantics: explicit `false` kept; absent stays absent; non-conforming types ignored.

## Tests

- **Mapper survival** (`value-provenance-preservation.test.ts`): both real-data branches + true/false/absent/non-conforming matrix.
- **Normalize + no-leak + debug gating** (`DriversSection.valueProvenance.spec.tsx`): snake→camel matrix; negative-DOM (sentinel strings, asserts no text **or** markup leak); `__OLUMI_DEBUG` on→logged / off→silent.
- **End-to-end into `data.drivers`** (`useResultsSectionData.spec.ts`): hook test asserts the fields reach `data.drivers.drivers[*]`.

Local: new + regression set pass (incl. `responseMapper-thin-adapter` and panel-contract invariants). CI typecheck (`tsconfig.ci.json`) clean; lint 0 errors.

## Files (8, +444, all additive)

- `src/adapters/plot/v2/types.ts`
- `src/adapters/plot/v2/responseMapper.ts`
- `src/components/results/types.ts`
- `src/components/results/useResultsSectionData.ts`
- `src/components/results/DriversSection.tsx`
- `src/components/results/__tests__/useResultsSectionData.spec.ts`
- `src/components/results/__tests__/DriversSection.valueProvenance.spec.tsx` _(new)_
- `src/test/__tests__/invariants/ui/value-provenance-preservation.test.ts` _(new)_

## Explicitly NOT in this PR

No user-facing copy, badges, or normal-DOM provenance UI · `DecisionConfidencePanel` · `AnalysisHeroV17` · canvas `SourceProvenancePill`/`observedState.source` · PLoT · ISL · CEE · prompt/PMS · CI/workflows · `package.json` · performance tests · `path_decomposition`.

## Future gate

Visible user-facing provenance UI remains blocked until **both**: (1) populated-field proof from PLoT staging, and (2) Paul/ChatGPT review of user-facing copy.

## Notes

- **Do not merge** — opened for review.
- CI (GitHub Actions) may fail at the install step due to a known repo-level pnpm-migration issue, unrelated to this change. The local pre-push fast gate passed (typecheck, lint-changed, 8-file smoke, stale-.js, dep audit, DS-v5 ratchet Δ0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
