### PR TITLE
fix(v5): tolerate unknown blocks[] types (defensive parser hardening)

### DIFF
--- a/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
+++ b/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
@@ -12,8 +12,10 @@
  * existing exportBundle specs use the same imports).
  *
  * Acceptance points covered:
- *   - Parse-error envelope flows into v5_cee_capture with parse_ok:false
- *     and the offending unknown block types enumerated.
+ *   - Unknown blocks[] types are TOLERATED (defensive hardening, 2026-06):
+ *     v5_cee_capture stays parse_ok:true and surfaces unknown_block_types +
+ *     unknown_blocks_tolerated_count from the sidecar. A genuine parse
+ *     failure (malformed known block) still reports parse_ok:false.
  *   - End-to-end callV5Turn → recordResponsePayload → redactor → bundle
  *     preserves the Phase 3 sidecar through the trace store's
  *     Object.keys-based redactor.
@@ -216,57 +218,93 @@ beforeEach(() => {
   } as any)
 })
 
-describe('v5_cee_capture — parse-failure path', () => {
-  it('(10) parse-error envelope flows into v5_cee_capture with parse_ok=false + enumerated types', async () => {
-    const fixture = ceeFixture()
-    ;(fixture.blocks as unknown[]).push({ type: 'totally_unknown_future_type' })
-    const parsed = await parseV5Response(makeResponse(fixture))
-    expect(parsed.kind).toBe('parse_error')
-
-    const data = makeDebugData({
+describe('v5_cee_capture — unknown-block tolerance path', () => {
+  // Build a success-path DebugData from a parsed OlumiResponse body. Mirrors
+  // the proven `success path honest semantics` pattern below: passing
+  // `parsed.response` (object reference) keeps the NON-ENUMERABLE
+  // `__additive__` sidecar accessible to the capture builder.
+  function successData(responseBody: Record<string, unknown>) {
+    return makeDebugData({
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 200,
+          success: true,
+          duration_ms: 200,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
       payloads: {
         cee_request: { kind: 'message', message: 'run' },
-        cee_response: parsed as unknown as Record<string, unknown>,
+        cee_response: responseBody,
         plot_request: null,
         plot_response: null,
         isl_request: null,
         isl_response: null,
       },
     })
+  }
 
-    const bundle = await buildDebugBundleAsync(data)
-    expect(bundle.v5_canonical_analysis).toBeDefined()
-    const diag = bundle.v5_canonical_analysis!
-    expect(diag.v5_cee_capture).not.toBeNull()
-    const capture = diag.v5_cee_capture!
-
-    expect(capture.parse_ok).toBe(false)
-    expect(capture.response_present).toBe(true)
-    expect(capture.raw_response_present).toBe(true)
-    expect(capture.parse_failure_kind).toBe('unknown_block_types')
-    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
-    expect(capture.parse_error ?? '').toContain('totally_unknown_future_type')
-    expect(capture.response_top_level_keys).toEqual(
-      expect.arrayContaining(['response_version', 'assistant_text', 'blocks']),
-    )
-    expect(diag.debug_capture_status).toBe('parse_failed')
-  })
-
-  it('mixed blocks (Phase 3 + unknown) → parse fails AND phase3 count populated from raw fallback', async () => {
-    // Pin the design: when CEE emits both tolerated Phase 3 blocks AND a
-    // truly-unknown block type inside `blocks[]`, the parser hard-fails
-    // (the unknown type dominates) — but the debug bundle must still
-    // surface the Phase 3 blocks the parser would have tolerated, sourced
-    // from the captured raw envelope. That lets reviewers see "CEE did
-    // emit review_card + coaching, the unknown_future_type is the
-    // offender" rather than collapsing both signals into a single
-    // failure with no Phase 3 visibility.
-    const fixture = ceeFixture() // includes analysis_result + review_card + coaching
+  it('(5,6) an unknown block is tolerated: v5_cee_capture is parse_ok=true and surfaces unknown_block_types + unknown_blocks_tolerated_count from the sidecar', async () => {
+    const fixture = ceeFixture()
     ;(fixture.blocks as unknown[]).push({
       type: 'totally_unknown_future_type',
       payload: { whatever: 1 },
     })
     const parsed = await parseV5Response(makeResponse(fixture))
+    expect(parsed.kind).toBe('response')
+    if (parsed.kind !== 'response') throw new Error('unreachable')
+
+    const bundle = await buildDebugBundleAsync(
+      successData(parsed.response as unknown as Record<string, unknown>),
+    )
+    const diag = bundle.v5_canonical_analysis!
+    expect(diag.v5_cee_capture).not.toBeNull()
+    const capture = diag.v5_cee_capture!
+
+    // Tolerated — NOT a parse failure.
+    expect(capture.parse_ok).toBe(true)
+    expect(capture.parse_failure_kind).toBeNull()
+    expect(diag.debug_capture_status).toBe('complete')
+
+    // (6) Structured, observable diagnostic on the capture object.
+    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
+    expect(capture.unknown_blocks_tolerated_count).toBe(1)
+
+    // (7) No raw block payload leaks into the structured capture.
+    expect(JSON.stringify(capture)).not.toContain('whatever')
+  })
+
+  it('mixed blocks (Phase 3 + unknown) → tolerated: phase3 counts AND unknown counts both surface', async () => {
+    const fixture = ceeFixture() // analysis_result + review_card + coaching
+    ;(fixture.blocks as unknown[]).push({
+      type: 'totally_unknown_future_type',
+      payload: { whatever: 1 },
+    })
+    const parsed = await parseV5Response(makeResponse(fixture))
+    expect(parsed.kind).toBe('response')
+    if (parsed.kind !== 'response') throw new Error('unreachable')
+
+    const bundle = await buildDebugBundleAsync(
+      successData(parsed.response as unknown as Record<string, unknown>),
+    )
+    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
+
+    expect(capture.parse_ok).toBe(true)
+    // Phase 3 tolerated blocks still enumerated...
+    expect(capture.phase3_blocks_tolerated_count).toBe(2)
+    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
+    // ...alongside the unknown-block diagnostic.
+    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
+    expect(capture.unknown_blocks_tolerated_count).toBe(1)
+  })
+
+  it('(12) a genuine parse failure (malformed KNOWN block) still flows into v5_cee_capture with parse_ok=false', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({ type: 'text' /* required content missing */ })
+    const parsed = await parseV5Response(makeResponse(fixture))
     expect(parsed.kind).toBe('parse_error')
 
     const data = makeDebugData({
@@ -281,23 +319,12 @@ describe('v5_cee_capture — parse-failure path', () => {
     })
 
     const bundle = await buildDebugBundleAsync(data)
-    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
-
-    // Parse failure still dominates the capture status.
+    const diag = bundle.v5_canonical_analysis!
+    const capture = diag.v5_cee_capture!
     expect(capture.parse_ok).toBe(false)
-    expect(capture.parse_failure_kind).toBe('unknown_block_types')
-    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
-
-    // But the Phase 3 blocks the parser WOULD have tolerated must still
-    // be visible to the reviewer — sourced from the parse_error
-    // envelope's `raw.blocks[]` via the bundle's raw fallback path.
-    expect(capture.phase3_blocks_tolerated_count).toBe(2)
-    expect(capture.phase3_block_types).toEqual(['coaching', 'review_card'])
-
-    // raw_response_present remains true here — the parse_error envelope
-    // preserved the verbatim pre-validation JSON, which is the basis for
-    // the raw fallback enumeration.
+    expect(capture.parse_failure_kind).toBe('schema_mismatch')
     expect(capture.raw_response_present).toBe(true)
+    expect(diag.debug_capture_status).toBe('parse_failed')
   })
 })
 

--- a/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
+++ b/src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
@@ -417,6 +417,70 @@ describe('v5_cee_capture — end-to-end through redactor', () => {
     // blocks present, no top-level additives → false).
     expect(capture.has_additive_extensions).toBe(true)
   })
+
+  it('callV5Turn → trace-store redactor → bundle preserves the unknown_blocks diagnostic', async () => {
+    // Companion to the Phase 3 test above: the unknown_blocks diagnostic
+    // rides the SAME non-enumerable __additive__ sidecar, so it must
+    // likewise survive the trace store's Object.keys-based redactor (via
+    // v5Adapter's enumerable-clone promotion) end-to-end into the bundle —
+    // not just the synthetic object-ref path used by the tolerance tests.
+    usePayloadTraceStore.setState({ payloads: [], selectedId: null } as any)
+
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({
+      type: 'totally_unknown_future_type',
+      payload: { whatever: 1 },
+    })
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const result = await callV5Turn(
+      { kind: 'message', message: 'run analysis' } as never,
+      { fetchImpl },
+    )
+    expect(result.kind).toBe('response')
+
+    const traced = usePayloadTraceStore.getState().payloads
+    expect(traced).toHaveLength(1)
+    const tracedBody = traced[0].response?.body as Record<string, unknown>
+
+    const data = makeDebugData({
+      services: {
+        cee: {
+          name: 'CEE',
+          status: 200,
+          success: true,
+          duration_ms: 312,
+          endpoint: '/bff/orchestrate/v2/turn',
+        },
+        plot: null,
+        isl: null,
+      },
+      payloads: {
+        cee_request: traced[0].request?.body as Record<string, unknown> | null,
+        cee_response: tracedBody,
+        plot_request: null,
+        plot_response: null,
+        isl_request: null,
+        isl_response: null,
+      },
+    })
+
+    const bundle = await buildDebugBundleAsync(data)
+    const capture = bundle.v5_canonical_analysis!.v5_cee_capture!
+
+    // Survived the REAL redactor (not just the synthetic object-ref path).
+    expect(capture.parse_ok).toBe(true)
+    expect(capture.unknown_block_types).toEqual(['totally_unknown_future_type'])
+    expect(capture.unknown_blocks_tolerated_count).toBe(1)
+    // Phase 3 tolerated blocks still present alongside.
+    expect(capture.phase3_blocks_tolerated_count).toBe(2)
+    // No raw payload leaked through the redactor into the capture.
+    expect(JSON.stringify(capture)).not.toContain('whatever')
+  })
 })
 
 describe('v5_cee_capture — success path honest semantics', () => {

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -127,6 +127,7 @@ import {
   ORIGINAL_TOP_LEVEL_KEYS_KEY,
   PHASE3_SIDECAR_BLOCKS_KEY,
   PHASE3_TOLERATED_BLOCK_TYPES,
+  UNKNOWN_BLOCKS_KEY,
   V5_PARSE_ERROR_KIND,
   type ParseFailureKind,
 } from '../../../v5/responseParser'
@@ -3423,6 +3424,33 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       ),
     ).sort()
 
+    // Unknown `blocks[]` entries tolerated (dropped) by the parser on the
+    // success path (defensive hardening, 2026-06). Read from the parsed
+    // response's sidecar `unknown_blocks` slot; carries ONLY type labels +
+    // a count — never raw payload (the parser guarantees this). Mirrors the
+    // phase3 sidecar read above.
+    const unknownBlocksSidecar = (() => {
+      if (ceeResponseObject === null || ceeIsParseErrorEnvelope) return null
+      const sidecar = (ceeResponseObject as Record<string | symbol, unknown>)[
+        ADDITIVE_EXTENSIONS_KEY as unknown as string
+      ]
+      if (!sidecar || typeof sidecar !== 'object' || Array.isArray(sidecar)) return null
+      const slot = (sidecar as Record<string, unknown>)[UNKNOWN_BLOCKS_KEY]
+      return slot && typeof slot === 'object' && !Array.isArray(slot)
+        ? (slot as Record<string, unknown>)
+        : null
+    })()
+    const unknownBlockTypesTolerated: string[] | null =
+      unknownBlocksSidecar && Array.isArray(unknownBlocksSidecar.types)
+        ? (unknownBlocksSidecar.types as unknown[]).filter(
+            (t): t is string => typeof t === 'string',
+          )
+        : null
+    const unknownBlocksToleratedCount: number =
+      unknownBlocksSidecar && typeof unknownBlocksSidecar.count === 'number'
+        ? unknownBlocksSidecar.count
+        : 0
+
     // ceeService is no longer the gate — payload-trace evidence
     // (cee_request / cee_response) is sufficient to emit a capture object,
     // and parse failures must populate the diagnostic even when the
@@ -3514,6 +3542,7 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
       for (const k of Object.keys(successSidecar)) {
         if (k === PHASE3_SIDECAR_BLOCKS_KEY) continue
         if (k === ORIGINAL_TOP_LEVEL_KEYS_KEY) continue
+        if (k === UNKNOWN_BLOCKS_KEY) continue
         return true
       }
       return false
@@ -3633,7 +3662,8 @@ export async function buildDebugBundleAsync(data: DebugData, options: ExportOpti
             response_top_level_keys: responseTopLevelKeys,
             raw_response_present: rawResponsePresent,
             parse_failure_kind: parseFailureKind,
-            unknown_block_types: unknownBlockTypes,
+            unknown_block_types: unknownBlockTypes ?? unknownBlockTypesTolerated,
+            unknown_blocks_tolerated_count: unknownBlocksToleratedCount,
             has_additive_extensions: hasAdditiveExtensions,
             phase3_blocks_tolerated_count: phase3Source.length,
             phase3_block_types: phase3BlockTypes,

--- a/src/lib/__tests__/v5CanonicalAnalysisDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalAnalysisDiagnostics.spec.ts
@@ -30,6 +30,7 @@ function capture(overrides: Partial<V5CeeCapture> = {}): V5CeeCapture {
     has_additive_extensions: false,
     phase3_blocks_tolerated_count: 0,
     phase3_block_types: [],
+    unknown_blocks_tolerated_count: 0,
     source: 'proxy_v5_turn',
     ...overrides,
   }

--- a/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
+++ b/src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts
@@ -36,6 +36,7 @@ function makeCapture(overrides: Partial<V5CeeCapture> = {}): V5CeeCapture {
     has_additive_extensions: false,
     phase3_blocks_tolerated_count: 0,
     phase3_block_types: [],
+    unknown_blocks_tolerated_count: 0,
     source: 'proxy_v5_turn',
     ...overrides,
   }

--- a/src/lib/v5CanonicalAnalysisDiagnostics.ts
+++ b/src/lib/v5CanonicalAnalysisDiagnostics.ts
@@ -53,10 +53,18 @@ export interface V5CeeCapture {
   /** Why parsing failed; null on success. */
   parse_failure_kind: ParseFailureKind | null
   /**
-   * Offending block `type` values when parse_failure_kind is
-   * `unknown_block_types`. Null otherwise.
+   * Unknown `blocks[]` type labels (unique, sorted).
+   *   - Success path (defensive tolerance, 2026-06): the types dropped from
+   *     `blocks[]` and recorded in the `unknown_blocks` sidecar.
+   *   - Legacy parse-error path: null (unknown blocks no longer hard-fail).
+   * Null when no unknown blocks were present.
    */
   unknown_block_types: string[] | null
+  /**
+   * Count of unknown `blocks[]` entries tolerated (dropped) by the parser on
+   * the success path. 0 when none. Mirrors `phase3_blocks_tolerated_count`.
+   */
+  unknown_blocks_tolerated_count: number
   /**
    * Whether top-level additive extensions (NOT phase 3 blocks-array
    * entries) were detected. Phase 3 blocks have dedicated fields below.

--- a/src/lib/v5CanonicalTurnDiagnostics.ts
+++ b/src/lib/v5CanonicalTurnDiagnostics.ts
@@ -221,8 +221,9 @@ export interface V5CanonicalTurnDiagnostics {
     parse_failure_kind: ParseFailureKind | null
     raw_response_present: boolean
     response_top_level_keys: string[] | null
-    /** Offending block `type` values when parse_failure_kind is
-     *  `unknown_block_types`; null otherwise. */
+    /** Unknown `blocks[]` type labels — the tolerated/dropped types from the
+     *  `unknown_blocks` sidecar on success, or null. The legacy parse-error
+     *  path no longer populates this (unknown blocks are now tolerated). */
     unknown_block_types: string[] | null
   }
   analysis_fact: {

--- a/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
+++ b/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
@@ -49,6 +49,7 @@ import {
   PHASE3_SIDECAR_BLOCKS_KEY,
   PHASE3_TOLERATED_BLOCK_TYPES,
   UNKNOWN_BLOCKS_KEY,
+  MAX_UNKNOWN_BLOCK_TYPE_LABEL_LENGTH,
   type OlumiResponseWithExtensions,
 } from '../responseParser'
 import {
@@ -469,8 +470,10 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
    * The parser hardcodes the legacy block-type whitelist from
    * @talchain/schemas (currently v0.8.1). If the schema package is
    * upgraded — new block types added, existing renamed/removed — the
-   * parser's classifier silently misroutes them: new types end up in the
-   * `unknown` bucket and hard-fail parse. This drift guard introspects
+   * parser's classifier silently misroutes them: new types fall into the
+   * `unknown` bucket and (since the 2026-06 tolerance change) are dropped
+   * into the `unknown_blocks` sidecar rather than rendered. This drift
+   * guard introspects
    * the strict `BlockSchema` discriminated union and asserts the parser
    * mirror stays in sync. When this fires, update
    * LEGACY_SCHEMA_KNOWN_BLOCK_TYPES in src/v5/responseParser.ts.
@@ -772,6 +775,26 @@ describe('parser tolerance — unknown blocks (defensive hardening)', () => {
     expect(unknown.types).toContain('fact')
     // The block value is NOT leaked into the diagnostic.
     expect(JSON.stringify(unknown)).not.toContain('42%')
+  })
+
+  it('bounds a pathologically long unknown type label (defensive privacy cap)', async () => {
+    const longType = 'x'.repeat(500)
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({ type: longType, payload: { whatever: 1 } })
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+    const unknown = readUnknown(result)
+    expect(unknown.count).toBe(1)
+    // The 500-char discriminator is NOT preserved verbatim — it is bounded so
+    // a buggy/user-content-like type can't dump unbounded content into the
+    // diagnostic (which flows to the debug bundle).
+    expect(unknown.types[0]).not.toBe(longType)
+    expect(unknown.types[0]).toContain('[truncated]')
+    expect(unknown.types[0].length).toBeLessThanOrEqual(
+      MAX_UNKNOWN_BLOCK_TYPE_LABEL_LENGTH + '...[truncated]'.length,
+    )
+    expect(JSON.stringify(unknown)).not.toContain(longType)
   })
 
   it('(12) a malformed KNOWN block still hard-fails — nested product schemas remain strict', async () => {

--- a/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
+++ b/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
@@ -14,8 +14,9 @@
  * truly-unknown buckets before strict validation. Legacy-known entries
  * go through strict zod; Phase 3 entries are preserved verbatim and
  * stashed in the sidecar under `phase3_blocks_from_blocks_array`;
- * truly-unknown entries still hard-fail and are named in the debug
- * bundle.
+ * truly-unknown entries are tolerated (defensive hardening, 2026-06):
+ * dropped from the validated blocks[] and recorded in the `unknown_blocks`
+ * sidecar diagnostic instead of failing the whole turn.
  *
  * NOTE: debug-bundle integration assertions live in
  *   src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts
@@ -47,6 +48,7 @@ import {
   ADDITIVE_EXTENSIONS_KEY,
   PHASE3_SIDECAR_BLOCKS_KEY,
   PHASE3_TOLERATED_BLOCK_TYPES,
+  UNKNOWN_BLOCKS_KEY,
   type OlumiResponseWithExtensions,
 } from '../responseParser'
 import {
@@ -629,27 +631,61 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
   })
 })
 
-// ── Negative paths — unknown and malformed blocks ─────────────────────
+// ── Defensive tolerance — unknown blocks (2026-06) + malformed-known ───
+//
+// Unknown `blocks[]` types are NO LONGER fatal: they are dropped from the
+// validated blocks[], the rest of the response still parses, and a
+// privacy-safe { types, count, by_type } diagnostic lands in the
+// `unknown_blocks` sidecar. A malformed KNOWN block still hard-fails.
 
-describe('parser strictness — unknown and malformed blocks', () => {
-  it('(8) unknown block type inside blocks[] still fails parse with enumerated types', async () => {
+describe('parser tolerance — unknown blocks (defensive hardening)', () => {
+  type UnknownSidecar = { types: string[]; count: number; by_type: Record<string, number> }
+  const readUnknown = (result: Awaited<ReturnType<typeof parseV5Response>>): UnknownSidecar => {
+    if (result.kind !== 'response') throw new Error('expected a parsed response')
+    const sidecar = (result.response as Record<string | symbol, unknown>)[ADDITIVE_EXTENSIONS_KEY] as
+      | Record<string, unknown>
+      | undefined
+    return sidecar?.[UNKNOWN_BLOCKS_KEY] as UnknownSidecar
+  }
+
+  it('(3,4) an unknown block type is tolerated: response parses, known blocks survive, unknown is dropped + recorded in the sidecar', async () => {
     const fixture = ceeFixture()
     ;(fixture.blocks as unknown[]).push({
       type: 'totally_unknown_future_type',
       payload: { whatever: 1 },
     })
     const result = await parseV5Response(makeResponse(fixture))
-    expect(result.kind).toBe('parse_error')
-    if (result.kind !== 'parse_error') throw new Error('unreachable')
-    expect(result.parse_failure_kind).toBe('unknown_block_types')
-    expect(result.unknown_block_types).toEqual(['totally_unknown_future_type'])
-    expect(result.reason).toContain('totally_unknown_future_type')
-    // Original raw response preserved for diagnostics.
-    expect(result.raw).toBeTruthy()
-    expect((result.raw as Record<string, unknown>).blocks).toBeTruthy()
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+
+    // Known block survives; unknown is NOT in the validated blocks[].
+    expect(result.response.blocks).toHaveLength(1)
+    expect(result.response.blocks[0].type).toBe('analysis_result')
+    expect(result.response.blocks.map((b) => b.type)).not.toContain(
+      'totally_unknown_future_type',
+    )
+
+    // (5,6) Observable diagnostic — type + count, deduped.
+    const unknown = readUnknown(result)
+    expect(unknown).toBeDefined()
+    expect(unknown.types).toEqual(['totally_unknown_future_type'])
+    expect(unknown.count).toBe(1)
+    expect(unknown.by_type).toEqual({ totally_unknown_future_type: 1 })
+
+    // (7) NO raw payload / user content leaks into the diagnostic.
+    expect(JSON.stringify(unknown)).not.toContain('whatever')
   })
 
-  it('multiple unknown blocks of the same type dedupe to a single entry in unknown_block_types', async () => {
+  it('(8,9) routeV5Response renders the known content — NOT a typed error — when an unknown block is present', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({ type: 'totally_unknown_future_type', a: 1 })
+    const result = await parseV5Response(makeResponse(fixture))
+    const target = routeV5Response(result)
+    expect(target.kind).not.toBe('typed_error')
+    expect(target.kind).toBe('blocks')
+  })
+
+  it('(10) multiple unknown blocks: types deduped + sorted; count reflects EVERY dropped entry', async () => {
     const fixture = ceeFixture()
     ;(fixture.blocks as unknown[]).push(
       { type: 'totally_unknown_future_type', a: 1 },
@@ -657,28 +693,67 @@ describe('parser strictness — unknown and malformed blocks', () => {
       { type: 'another_unknown_type', b: 3 },
     )
     const result = await parseV5Response(makeResponse(fixture))
-    expect(result.kind).toBe('parse_error')
-    if (result.kind !== 'parse_error') throw new Error('unreachable')
-    // Dedupe + sort so reviewers see a clean, stable list — not a bloated
-    // one with each unknown block duplicated.
-    expect(result.unknown_block_types).toEqual([
-      'another_unknown_type',
-      'totally_unknown_future_type',
-    ])
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+    const unknown = readUnknown(result)
+    expect(unknown.types).toEqual(['another_unknown_type', 'totally_unknown_future_type'])
+    expect(unknown.count).toBe(3)
+    expect(unknown.by_type).toEqual({
+      totally_unknown_future_type: 2,
+      another_unknown_type: 1,
+    })
+    // Known block still survives alongside the dropped unknowns.
+    expect(result.response.blocks).toHaveLength(1)
   })
 
-  it('an array entry inside blocks[] is classified as `array`, not `object`', async () => {
+  it('(11) array / missing-type entries are tolerated (classified `array` / `<missing-type>`), not fatal', async () => {
     const fixture = ceeFixture()
-    ;(fixture.blocks as unknown[]).push(['not', 'a', 'block'])
+    ;(fixture.blocks as unknown[]).push(['not', 'a', 'block'], { no: 'type' })
     const result = await parseV5Response(makeResponse(fixture))
-    expect(result.kind).toBe('parse_error')
-    if (result.kind !== 'parse_error') throw new Error('unreachable')
-    expect(result.parse_failure_kind).toBe('unknown_block_types')
-    expect(result.unknown_block_types).toContain('array')
-    expect(result.unknown_block_types).not.toContain('object')
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+    const unknown = readUnknown(result)
+    expect(unknown.types).toContain('array')
+    expect(unknown.types).toContain('<missing-type>')
+    expect(unknown.types).not.toContain('object')
+    expect(unknown.count).toBe(2)
   })
 
-  it('(9) malformed-known block still fails parse — nested product schemas remain strict', async () => {
+  it('a response whose ONLY block is unknown still parses (empty validated blocks[]) and routes to text', async () => {
+    const result = await parseV5Response(
+      makeResponse({
+        response_version: 2,
+        assistant_text: 'Here is some prose.',
+        blocks: [{ type: 'totally_unknown_future_type', a: 1 }],
+        suggested_actions: [],
+        insights: [],
+        stage_indicator: 'analyse',
+      }),
+    )
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+    expect(result.response.blocks).toHaveLength(0)
+    expect(readUnknown(result).count).toBe(1)
+    expect(routeV5Response(result).kind).toBe('text_only')
+  })
+
+  it('(13) FactBlock is NOT a supported V5 blocks[] type — a `fact` block is tolerated-and-dropped, never promoted to a known block', async () => {
+    const fixture = ceeFixture()
+    ;(fixture.blocks as unknown[]).push({ type: 'fact', label: 'ROI', value: '42%' })
+    const result = await parseV5Response(makeResponse(fixture))
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+    // fact is dropped from validated blocks[] (not rendered as a known block).
+    // (Cast to string: the strict OlumiResponse block union legitimately has
+    // no 'fact' member — proving at runtime that the parser dropped it.)
+    expect(result.response.blocks.map((b) => b.type as string)).not.toContain('fact')
+    const unknown = readUnknown(result)
+    expect(unknown.types).toContain('fact')
+    // The block value is NOT leaked into the diagnostic.
+    expect(JSON.stringify(unknown)).not.toContain('42%')
+  })
+
+  it('(12) a malformed KNOWN block still hard-fails — nested product schemas remain strict', async () => {
     const fixture = ceeFixture()
     ;(fixture.blocks as unknown[]).push({ type: 'text' /* required `content` missing */ })
     const result = await parseV5Response(makeResponse(fixture))

--- a/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
+++ b/src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts
@@ -554,14 +554,16 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
 
   /**
    * Stronger drift guard: every declared block type must round-trip
-   * through DGAI's `parseV5Response`, not just through zod's
-   * `BlockSchema.safeParse`. The parser's `splitBlocksTolerance` keeps a
-   * separate hand-mirrored set (`LEGACY_SCHEMA_KNOWN_BLOCK_TYPES`); a
-   * type that the vendored schema accepts but the mirror omits would be
-   * misrouted into the `unknown` bucket and hard-fail at runtime even
-   * though the BlockSchema check above passes.
+   * through DGAI's `parseV5Response` INTO THE VALIDATED `blocks[]`, not
+   * just parse successfully. The parser's `splitBlocksTolerance` keeps a
+   * separate hand-mirrored set (`LEGACY_SCHEMA_KNOWN_BLOCK_TYPES`); a type
+   * the vendored schema accepts but the mirror omits would — since the
+   * defensive-hardening change (2026-06) — be silently DROPPED into the
+   * `unknown_blocks` sidecar instead of hard-failing. So `kind ===
+   * 'response'` alone is no longer sufficient proof of recognition; we
+   * assert the block actually survives into `response.blocks`.
    */
-  it('round-trips every declared block type through parseV5Response', async () => {
+  it('round-trips every declared block type into validated blocks[] (not dropped as unknown)', async () => {
     const def = (BlockSchema as unknown as { _def: { optionsMap?: Map<string, unknown> } })._def
     const declaredTypes = [...(def.optionsMap!.keys())]
     const minimalEachType: Record<string, Record<string, unknown>> = {
@@ -618,6 +620,25 @@ describe('LEGACY_SCHEMA_KNOWN_BLOCK_TYPES drift guard', () => {
               ? `, failure_kind=${result.parse_failure_kind ?? 'n/a'}, reason="${result.reason}"`
               : '') +
             ')',
+        )
+        continue
+      }
+      // Tolerance-era strengthening: parsing successfully is no longer
+      // sufficient. A declared type missing from
+      // LEGACY_SCHEMA_KNOWN_BLOCK_TYPES would now be silently DROPPED into
+      // the unknown_blocks sidecar rather than hard-failing — so assert the
+      // block actually survived into the validated blocks[].
+      const survived = result.response.blocks.some(
+        (b) => (b as { type?: unknown }).type === decl,
+      )
+      if (!survived) {
+        const sidecar = (result.response as Record<string | symbol, unknown>)[
+          ADDITIVE_EXTENSIONS_KEY
+        ] as Record<string, unknown> | undefined
+        const dropped =
+          (sidecar?.[UNKNOWN_BLOCKS_KEY] as { types?: string[] } | undefined)?.types ?? []
+        misrouted.push(
+          `${decl} (parsed but DROPPED → unknown_blocks: ${JSON.stringify(dropped)})`,
         )
       }
     }

--- a/src/v5/__tests__/responseParser.fixtures.test.ts
+++ b/src/v5/__tests__/responseParser.fixtures.test.ts
@@ -8,7 +8,11 @@
  * parser has drifted or the schema version is wrong.
  */
 import { describe, it, expect } from 'vitest'
-import { parseV5Response } from '../responseParser'
+import {
+  parseV5Response,
+  ADDITIVE_EXTENSIONS_KEY,
+  UNKNOWN_BLOCKS_KEY,
+} from '../responseParser'
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -262,9 +266,11 @@ describe('parseV5Response fixtures — parse_error paths', () => {
     }
   })
 
-  it('v0.6.0-shape response (unknown block type) → parse_error (defensive)', async () => {
-    // v0.6.0 didn't have this block type, but adding a guard against a
-    // hypothetical older CEE emitting a shape the strict schema rejects.
+  it('response carrying an unknown block type → tolerated (dropped + recorded in sidecar), NOT a parse_error', async () => {
+    // Defensive hardening (2026-06): an unknown block type is no longer
+    // fatal. The unknown block is dropped from the validated blocks[], the
+    // rest of the response parses, and the drop is recorded in the
+    // `unknown_blocks` sidecar so it stays observable.
     const body = {
       response_version: 2,
       assistant_text: 'hi',
@@ -274,6 +280,17 @@ describe('parseV5Response fixtures — parse_error paths', () => {
       stage_indicator: 'frame',
     }
     const r = await parseV5Response(jsonResponse(200, body))
-    expect(r.kind).toBe('parse_error')
+    expect(r.kind).toBe('response')
+    if (r.kind !== 'response') throw new Error('unreachable')
+    // Unknown block dropped; known fields preserved.
+    expect(r.response.blocks).toHaveLength(0)
+    expect(r.response.assistant_text).toBe('hi')
+    // Recorded in the sidecar diagnostic (type + count, no payload).
+    const sidecar = (r.response as Record<string | symbol, unknown>)[
+      ADDITIVE_EXTENSIONS_KEY
+    ] as Record<string, unknown>
+    const unknown = sidecar[UNKNOWN_BLOCKS_KEY] as { types: string[]; count: number }
+    expect(unknown.types).toEqual(['unknown_new_block'])
+    expect(unknown.count).toBe(1)
   })
 })

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -99,9 +99,13 @@ export const ACTION_TYPE_ALIASES_APPLIED_KEY = 'action_type_aliases_applied' as 
 export const UNKNOWN_BLOCKS_KEY = 'unknown_blocks' as const;
 
 /**
- * Whitelist of v1.3 Phase 3 block types tolerated inside `blocks[]`. Any
- * other unknown `type` discriminator inside `blocks[]` still hard-fails the
- * parse so accidental schema drift is detected.
+ * Whitelist of v1.3 Phase 3 block types tolerated inside `blocks[]` and
+ * stashed verbatim in the sidecar (vs. legacy-known types, which continue to
+ * strict validation). Since the defensive-hardening change (2026-06) any
+ * OTHER `type` discriminator inside `blocks[]` is no longer fatal — it is
+ * dropped from the validated `blocks[]` and recorded in the `unknown_blocks`
+ * sidecar diagnostic. This whitelist therefore distinguishes "preserve
+ * verbatim for downstream Phase 3 consumers" from "drop + diagnose".
  *
  * Exported as `ReadonlySet` to prevent accidental mutation of the
  * tolerated-type allowlist at consumer boundaries (.add/.delete are not

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -229,6 +229,24 @@ const LEGACY_SCHEMA_KNOWN_BLOCK_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Defensive bound on the `type` label stored in the `unknown_blocks`
+ * diagnostic. `type` is a producer-controlled discriminator and legitimate
+ * values are short (e.g. `analysis_result`); but if a future CEE/model bug
+ * emitted a pathologically long or user-content-like discriminator, the
+ * diagnostic must not preserve it unbounded. Cap to a generous discriminator
+ * length so the diagnostic stays small and content-free. Drop counts are
+ * unaffected. Real type names are well under the cap, so this is a no-op for
+ * legitimate input.
+ */
+export const MAX_UNKNOWN_BLOCK_TYPE_LABEL_LENGTH = 64;
+
+function boundUnknownBlockTypeLabel(label: string): string {
+  return label.length <= MAX_UNKNOWN_BLOCK_TYPE_LABEL_LENGTH
+    ? label
+    : `${label.slice(0, MAX_UNKNOWN_BLOCK_TYPE_LABEL_LENGTH)}...[truncated]`;
+}
+
+/**
  * Classify the entries of `blocks[]` against the v1.3 contract:
  *   - `known`: entries with a `type` in the legacy schema. Forwarded to
  *     strict validation as-is.
@@ -258,7 +276,8 @@ function splitBlocksTolerance(blocks: unknown[]): {
   const unknownTypeSet = new Set<string>();
   const unknownByType: Record<string, number> = {};
   let unknownCount = 0;
-  const addUnknown = (label: string): void => {
+  const addUnknown = (rawLabel: string): void => {
+    const label = boundUnknownBlockTypeLabel(rawLabel);
     unknownTypeSet.add(label);
     unknownByType[label] = (unknownByType[label] ?? 0) + 1;
     unknownCount += 1;

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -29,8 +29,17 @@
  *   `blocks[]` into known-to-schema, phase3-tolerated, and truly-unknown
  *   before validation. Known blocks go to strict validation; phase3 blocks
  *   are attached to the sidecar under `phase3_blocks_from_blocks_array`;
- *   truly-unknown types still produce a `parse_error` whose `reason`
- *   enumerates the offending types. Nested product schemas remain strict.
+ *   truly-unknown block types are NO LONGER fatal (defensive hardening,
+ *   2026-06): they are dropped from the validated `blocks[]`, the rest of
+ *   the response still parses/renders, and a privacy-safe
+ *   `{ types, count, by_type }` diagnostic is stashed in the sidecar under
+ *   `unknown_blocks`. Nested product schemas remain strict — a malformed
+ *   KNOWN block still hard-fails as `schema_mismatch`.
+ *
+ *   Contract rule: unknown-block tolerance is a SAFETY NET, not a rendering
+ *   contract. Dropped != rendered. A new user-facing block type requires an
+ *   explicit allowlist + mapper + renderer + visibility tests before CEE
+ *   relies on it being shown to the user.
  */
 import {
   OlumiResponseSchema,
@@ -71,6 +80,23 @@ export const ORIGINAL_TOP_LEVEL_KEYS_KEY = '__original_top_level_keys__' as cons
  * PHASE3_SIDECAR_BLOCKS_KEY and ORIGINAL_TOP_LEVEL_KEYS_KEY emission rules).
  */
 export const ACTION_TYPE_ALIASES_APPLIED_KEY = 'action_type_aliases_applied' as const;
+
+/**
+ * Sidecar key carrying the privacy-safe diagnostic for unknown `blocks[]`
+ * entries that were dropped by the defensive-hardening tolerance (2026-06).
+ *
+ * Value shape: `{ types: string[]; count: number; by_type: Record<string, number> }`.
+ *   - `types`: unique, sorted block-type labels (incl. shape descriptors
+ *     `'array'` / `'null'` / `'<missing-type>'`).
+ *   - `count`: total number of unknown entries dropped.
+ *   - `by_type`: per-type drop counts.
+ *
+ * Diagnostic-only and deliberately content-free: it NEVER carries the raw
+ * block payload, labels, IDs, values, or any user content. Recorded only
+ * when at least one unknown block was dropped (consistent with the other
+ * sidecar emission rules).
+ */
+export const UNKNOWN_BLOCKS_KEY = 'unknown_blocks' as const;
 
 /**
  * Whitelist of v1.3 Phase 3 block types tolerated inside `blocks[]`. Any
@@ -183,9 +209,9 @@ function splitAdditiveExtensions(raw: unknown): {
  * union for `blocks[]`. Source: dist/boundary/blocks.js inside the vendored
  * tarball. Kept as a DGAI-side mirror so the parser can classify entries
  * BEFORE strict validation and give a precise diagnostic on truly unknown
- * types. If the schema package adds a block type, add it here too; a missed
- * type produces a clear parse_error (the offender is named in
- * `unknown_block_types`), which the tests will catch.
+ * types. If the schema package adds a block type, add it here too so it is
+ * strict-validated; an unlisted type is now tolerated (dropped + recorded in
+ * the `unknown_blocks` sidecar diagnostic) rather than fatal.
  */
 const LEGACY_SCHEMA_KNOWN_BLOCK_TYPES: ReadonlySet<string> = new Set([
   'text',
@@ -207,8 +233,11 @@ const LEGACY_SCHEMA_KNOWN_BLOCK_TYPES: ReadonlySet<string> = new Set([
  *   - `unknownTypes`: a deduped + sorted list of offending `type` labels
  *     (or shape descriptors like `'array'` / `'<missing-type>'`) for any
  *     entry that is neither legacy-known nor in the Phase 3 whitelist.
- *     The parser hard-fails when this list is non-empty and surfaces it
- *     verbatim via `unknown_block_types` for the debug bundle.
+ *     The parser now TOLERATES these (defensive hardening): they are
+ *     dropped from the validated `blocks[]` and surfaced verbatim via the
+ *     `unknown_blocks` sidecar diagnostic for the debug bundle.
+ *   - `unknownCount`: total number of dropped unknown entries.
+ *   - `unknownByType`: per-type drop counts.
  *
  * Original input is NOT mutated. The returned arrays are new arrays of the
  * same entries (referential to the original block objects).
@@ -217,26 +246,35 @@ function splitBlocksTolerance(blocks: unknown[]): {
   known: unknown[];
   phase3: unknown[];
   unknownTypes: string[];
+  unknownCount: number;
+  unknownByType: Record<string, number>;
 } {
   const known: unknown[] = [];
   const phase3: unknown[] = [];
   const unknownTypeSet = new Set<string>();
+  const unknownByType: Record<string, number> = {};
+  let unknownCount = 0;
+  const addUnknown = (label: string): void => {
+    unknownTypeSet.add(label);
+    unknownByType[label] = (unknownByType[label] ?? 0) + 1;
+    unknownCount += 1;
+  };
   for (const entry of blocks) {
     if (entry === null || entry === undefined) {
-      unknownTypeSet.add(entry === null ? 'null' : 'undefined');
+      addUnknown(entry === null ? 'null' : 'undefined');
       continue;
     }
     if (Array.isArray(entry)) {
-      unknownTypeSet.add('array');
+      addUnknown('array');
       continue;
     }
     if (typeof entry !== 'object') {
-      unknownTypeSet.add(typeof entry);
+      addUnknown(typeof entry);
       continue;
     }
     const type = (entry as { type?: unknown }).type;
     if (typeof type !== 'string') {
-      unknownTypeSet.add('<missing-type>');
+      addUnknown('<missing-type>');
       continue;
     }
     if (PHASE3_TOLERATED_BLOCK_TYPES.has(type as Phase3ToleratedBlockType)) {
@@ -247,13 +285,13 @@ function splitBlocksTolerance(blocks: unknown[]): {
       known.push(entry);
       continue;
     }
-    unknownTypeSet.add(type);
+    addUnknown(type);
   }
-  // Dedupe + sort so multiple unknown blocks of the same type don't bloat
-  // the parse_error reason / debug bundle, and the ordering is stable for
-  // reviewers diffing two captures.
+  // Dedupe + sort so multiple unknown blocks of the same type produce a
+  // stable, compact diagnostic; `unknownByType` retains per-type counts and
+  // `unknownCount` the total number of dropped entries.
   const unknownTypes = [...unknownTypeSet].sort();
-  return { known, phase3, unknownTypes };
+  return { known, phase3, unknownTypes, unknownCount, unknownByType };
 }
 
 /**
@@ -420,6 +458,12 @@ export type ParseFailureKind =
   | 'non_json'
   | 'non_ok_non_boundary'
   | 'schema_mismatch'
+  /**
+   * @deprecated No longer produced. Unknown `blocks[]` types are now tolerated
+   * (dropped + recorded in the `unknown_blocks` sidecar) instead of failing
+   * the parse. Retained for back-compat with diagnostics consumers that still
+   * reference the literal.
+   */
   | 'unknown_block_types'
 
 /**
@@ -445,7 +489,11 @@ export type V5ParseResult =
       diagnosticHeaders?: DiagnosticHeaders
       /** Why parsing failed; populated for all parse_error branches. */
       parse_failure_kind?: ParseFailureKind
-      /** Populated when parse_failure_kind === 'unknown_block_types'. */
+      /**
+       * @deprecated Unknown blocks are now tolerated (see the `unknown_blocks`
+       * sidecar on the success path); this no longer populates from `blocks[]`
+       * tolerance. Kept on the type for back-compat with existing consumers.
+       */
       unknown_block_types?: string[]
     };
 
@@ -518,6 +566,9 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
   // Phase 3 whitelist entries get stashed in the sidecar; truly unknown
   // entries trigger a hard parse_error that names the offending types.
   let phase3Blocks: readonly unknown[] = []
+  let unknownBlockTypes: readonly string[] = []
+  let unknownBlockCount = 0
+  let unknownBlocksByType: Record<string, number> = {}
   let knownForValidation: unknown = known
   if (
     known !== null &&
@@ -528,29 +579,27 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
     const split = splitBlocksTolerance(
       (known as Record<string, unknown>).blocks as unknown[],
     )
-    if (split.unknownTypes.length > 0) {
-      // Hard-fail when truly unknown block types appear. The raw response
-      // is preserved verbatim so reviewers can inspect the offending
-      // payload via the debug bundle.
-      return {
-        kind: 'parse_error',
-        reason: `unknown block type(s) in blocks[]: ${split.unknownTypes.join(', ')}`,
-        http_status: res.status,
-        raw,
-        diagnosticHeaders: captureDiagnosticHeaders(res),
-        parse_failure_kind: 'unknown_block_types',
-        unknown_block_types: split.unknownTypes,
-      }
-    }
-    // Replace blocks for validation with the legacy-known slice, leaving
-    // the raw input untouched. We build a shallow clone of the known
-    // surface (which is itself already a shallow clone of raw produced by
-    // splitAdditiveExtensions).
+    // Defensive hardening (2026-06): truly-unknown block types are NO LONGER
+    // fatal. Only `split.known` continues to strict validation; unknown
+    // entries are dropped from the validated `blocks[]`, the rest of the
+    // response parses normally, and a privacy-safe { types, count, by_type }
+    // diagnostic is stashed in the sidecar under `unknown_blocks` below. This
+    // converts a future-additive CEE block from a whole-turn INTERNAL_ERROR
+    // into an observable, non-fatal compatibility event. Tolerance is a
+    // safety net, not a rendering contract — dropped blocks are never
+    // rendered. Malformed KNOWN blocks still hard-fail via strict zod
+    // (nested product schemas remain strict). Raw input is not mutated; the
+    // known surface is already a shallow clone from splitAdditiveExtensions.
     knownForValidation = {
       ...(known as Record<string, unknown>),
       blocks: split.known,
     }
     phase3Blocks = split.phase3
+    if (split.unknownTypes.length > 0) {
+      unknownBlockTypes = split.unknownTypes
+      unknownBlockCount = split.unknownCount
+      unknownBlocksByType = split.unknownByType
+    }
   }
 
   // Tolerance step 3 (action_type alias drift): the runtime dispatch map
@@ -570,7 +619,8 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
     const hasTopLevelExt = Object.keys(extensions).length > 0
     const hasPhase3 = phase3Blocks.length > 0
     const hasAliasRewrites = aliasRewrites.length > 0
-    if (!hasTopLevelExt && !hasPhase3 && !hasAliasRewrites) {
+    const hasUnknownBlocks = unknownBlockCount > 0
+    if (!hasTopLevelExt && !hasPhase3 && !hasAliasRewrites && !hasUnknownBlocks) {
       return { kind: 'response', response: parsed.data }
     }
     // Compose the sidecar payload. Top-level additive keys keep their
@@ -588,6 +638,17 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
     }
     if (hasAliasRewrites) {
       sidecar[ACTION_TYPE_ALIASES_APPLIED_KEY] = Object.freeze(aliasRewrites.slice())
+    }
+    if (hasUnknownBlocks) {
+      // Privacy-safe diagnostic ONLY — type labels + counts, NEVER raw block
+      // payload or user content. Rides the __additive__ sidecar into the
+      // debug bundle via v5Adapter; surfaced structurally on V5CeeCapture by
+      // exportBundle (unknown_block_types + unknown_blocks_tolerated_count).
+      sidecar[UNKNOWN_BLOCKS_KEY] = Object.freeze({
+        types: Object.freeze(unknownBlockTypes.slice()),
+        count: unknownBlockCount,
+        by_type: Object.freeze({ ...unknownBlocksByType }),
+      })
     }
     if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
       sidecar[ORIGINAL_TOP_LEVEL_KEYS_KEY] = Object.freeze(


### PR DESCRIPTION
## What & why

Defensive V5 parser hardening (from the completed schema-drift/liveness audit). Today a **single unknown `blocks[]` type** in a `/orchestrate/v2/turn` response fails strict validation → `parse_error` → `INTERNAL_ERROR` banner, **blanking the entire turn**. Under the live staging V5 path that means one future-additive CEE block breaks the whole response.

This makes unknown blocks a **tolerated, observable, non-fatal** compatibility event — the smallest change that removes the risk, with **no new rendering**.

## Behaviour before → after

| | Before | After |
|---|---|---|
| Whole turn (unknown block present) | ⛔ `parse_error` → `INTERNAL_ERROR` banner | ✅ parses; known blocks render |
| Unknown entries | cause of failure | dropped from validated `blocks[]`, recorded in sidecar |
| Known blocks | (never reached) | parse/map/render **unchanged** |
| Malformed **known** block | ⛔ `schema_mismatch` | ⛔ `schema_mismatch` (**unchanged** — strict preserved) |
| Array / null / missing-type entry | ⛔ hard-fail | dropped + counted (`array`/`null`/`<missing-type>`) |

## Diagnostic (load-bearing, privacy-safe)

New frozen sidecar slot `unknown_blocks` = `{ types: string[], count: number, by_type: Record<string,number> }` — **type labels + counts only; never raw payload, labels, IDs, values, or user content**. Observable two ways:
1. Rides the `__additive__` sidecar into the debug-bundle trace body via `v5Adapter` (already wired).
2. Surfaced structurally on `V5CeeCapture`: `unknown_block_types` now populates on the success path + new `unknown_blocks_tolerated_count` (mirrors `phase3_blocks_tolerated_count`).

Tests assert the diagnostic is **observable** (not merely "didn't crash") and that no raw payload leaks.

## Files changed (9)

Production:
- `src/v5/responseParser.ts` — `splitBlocksTolerance` returns `unknownCount`/`unknownByType`; hard-fail return replaced with sidecar emission; `UNKNOWN_BLOCKS_KEY` added; `ParseFailureKind 'unknown_block_types'` kept but deprecated.
- `src/lib/v5CanonicalAnalysisDiagnostics.ts` — `V5CeeCapture.unknown_blocks_tolerated_count` added; `unknown_block_types` doc updated.
- `src/components/debug/utils/exportBundle.ts` — populate both fields from the success-path sidecar; exclude `UNKNOWN_BLOCKS_KEY` from the `has_additive_extensions` scan.
- `src/lib/v5CanonicalTurnDiagnostics.ts` — doc note (reads the same capture; auto-picks up the field).

Tests:
- `src/v5/__tests__/parser.phase3-blocks-tolerance.spec.ts`, `src/v5/__tests__/responseParser.fixtures.test.ts`, `src/components/debug/__tests__/v5-cee-capture.phase3-tolerance.spec.ts`, `src/lib/__tests__/v5CanonicalAnalysisDiagnostics.spec.ts`, `src/lib/__tests__/v5CanonicalTurnDiagnostics.spec.ts`.

## Verification

- Typecheck: `tsc -p tsconfig.app.json --noEmit` — no new errors in changed files (the narrow `tsconfig.ci.json` gate also passed in the pre-push hook).
- Tests: **38 files / 578 passing** — focused parser/diagnostics/contract suites + the **real-staging-fixture wire→DOM regression** (`mapV5AnalysisToReport`, `v5-analysis-to-results-panel.wire-to-selector`, `OptionCards.v5-visible-render`) unchanged.
- Lint: 0 errors on changed files. Pre-push gate: all checks passed.

## FactBlock contradiction — resolved

`fact` is a **V4-path / thread-hydration `ConversationBlock`** (`useConversation.ts` `adaptCEEBlock`, `hydrateThread.ts`, rendered by `InlineBlocks`), **not** a V5 wire `blocks[]` type — absent from the `@talchain/schemas@0.8.1` union, the V5 allowlist, and every V5 fixture. The v1.3 contract conflates the V4 channel with V5. After this change a `fact` block in a V5 envelope is tolerated-and-dropped (pinned by a test) until it gets explicit V5 allowlist + mapper + renderer support.

## Out of scope (not touched)

F1 · ModelReceiptBlock wiring · new renderers · AI-Panel/lifecycle surfacing · CEE output · schema package · prompts/PMS · any known-block behaviour.

## Contract rule — apply in the v1.3 Analysis-tab contract (lives outside this repo)

The DGAI-side rule is embedded in the `responseParser.ts` header doc-comment. Proposed patch text for the contract owner:

```md
### Unknown-block tolerance (DGAI safety net)
- Unknown `blocks[]` types are a compatibility safety net, NOT a rendering contract:
  DGAI drops them, keeps known blocks, and records a privacy-safe {type,count}
  diagnostic. Dropped ≠ rendered.
- A new USER-FACING block type requires, before CEE emits it: contract update →
  DGAI parser allowlist entry → mapper case → renderer/AI-Panel surface → tests
  proving visibility. CEE must not ship a user-facing blocks[] type ahead of DGAI.
- Additive TOP-LEVEL fields are tolerated but invisible until separately rendered.
- Phase-3 block names (review_card|coaching|evidence|exercise) must match the agreed
  shape + rendering path; today only review_card reaches chat (others → guidance).
- FactBlock is delivered via the V4/legacy block channel, NOT V5 blocks[]; it is not a
  supported V5 wire block until given explicit V5 allowlist+mapper+renderer support.
```

> Not merged, not deployed. Base `staging` for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
