### PR TITLE
ci(staging): bound Full Test Suite + make Staging Gate truthful

### DIFF
--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -236,7 +236,8 @@ jobs:
           # teardown/worker OOM signature — the exact string ERR_WORKER_OUT_OF_MEMORY
           # documented in docs/ops/vitest-full-suite-oom-diagnosis.md and matched by
           # the local pre-push gate (scripts/pre-push-validate.sh), so CI and local
-          # share one definition. Kept deliberately narrow: erring narrow fails SAFE —
+          # share one OOM signature (the CI pass/fail evaluator is otherwise
+          # stricter). Kept deliberately narrow: erring narrow fails SAFE —
           # an unmatched OOM yields a false FAILURE (gate red, artifact kept for a
           # human) rather than a false PASS. A broader match (e.g. bare "JavaScript
           # heap out of memory") could tolerate a parent-process heap death that

--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -233,7 +233,15 @@ jobs:
             fail=1
           fi
           # A non-zero exit with zero failures is tolerated ONLY for the known
-          # teardown/worker OOM signature — not for any other non-zero exit.
+          # teardown/worker OOM signature — the exact string ERR_WORKER_OUT_OF_MEMORY
+          # documented in docs/ops/vitest-full-suite-oom-diagnosis.md and matched by
+          # the local pre-push gate (scripts/pre-push-validate.sh), so CI and local
+          # share one definition. Kept deliberately narrow: erring narrow fails SAFE —
+          # an unmatched OOM yields a false FAILURE (gate red, artifact kept for a
+          # human) rather than a false PASS. A broader match (e.g. bare "JavaScript
+          # heap out of memory") could tolerate a parent-process heap death that
+          # should fail. Broadening to the fuller teardown signature is a
+          # deliberately-deferred future hardening, not a gap in this gate.
           if [ "${VITEST_EXIT}" -ne 0 ] && [ "${fail}" -eq 0 ]; then
             if [ "${has_oom}" -gt 0 ]; then
               echo "::warning::vitest exited ${VITEST_EXIT} but every test passed; tolerating the known teardown ERR_WORKER_OUT_OF_MEMORY (see docs/ops/vitest-full-suite-oom-diagnosis.md)."

--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -126,24 +126,71 @@ jobs:
           path: node_modules
           key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
+      # Bounded so a teardown hang (mode A) fails fast at 35 min instead of
+      # running to GitHub's 6-hour default. Normal runtime is ~15 min (≈45s
+      # tests + ≈850s teardown — see docs/ops/vitest-full-suite-oom-diagnosis.md).
+      #
+      # We capture vitest's REAL exit code (PIPESTATUS[0], not tee's) and force
+      # the step to exit 0 so the "Evaluate" step below is the single pass/fail
+      # arbiter. On a timeout the runner kills this step mid-command, so the
+      # exit_code echo never runs and steps.vitest.outputs.exit_code is empty —
+      # that empty value is how Evaluate distinguishes a timeout/kill from a
+      # completed-but-non-zero run.
       - name: Run full test suite
-        run: pnpm exec vitest run --reporter=verbose 2>&1 | tee vitest-output.txt
+        id: vitest
+        timeout-minutes: 35
+        run: |
+          set +e
+          pnpm exec vitest run --reporter=verbose 2>&1 | tee vitest-output.txt
+          code=${PIPESTATUS[0]}
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          echo "vitest exited with code ${code}"
+          exit 0
         env:
           NODE_OPTIONS: "--max-old-space-size=7168"
 
-      # Defence-in-depth against bail-like under-reporting regressions.
-      # Failure mode: vitest hits --bail=N and marks all files queued-but-
-      # never-started as "skipped" in the summary. The total stays high
-      # (~754) but skipped balloons (~653 from the 2026-04-18 audit).
-      # Healthy suite skips ~4 files (real it.skip()). Assert both the
-      # minimum total AND an upper bound on skipped to catch either
-      # (a) config-level exclusions removing files OR (b) bail reintroduced.
-      # if: always() so this still fires when vitest itself exits non-zero.
-      - name: Assert healthy test-file coverage (no bail-like under-reporting)
+      # Preserve the test log on every outcome (pass, fail, timeout, cancel) so
+      # a hung/cancelled run is still diagnosable. Test log only — no secrets or
+      # environment dumps. Placed before Evaluate so it survives a non-zero gate.
+      - name: Upload vitest output
         if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vitest-output
+          path: vitest-output.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+      # Single pass/fail arbiter for the Full Test Suite job. Combines:
+      #  - timeout/kill detection (empty exit_code from the step above),
+      #  - genuine test-failure detection (failed counts in the summary),
+      #  - defence-in-depth against bail-like under-reporting (file-count
+      #    thresholds — vitest hitting --bail=N marks queued-but-never-started
+      #    files as "skipped"; healthy suite skips ~4, the 2026-04-18 audit saw
+      #    ~653), and
+      #  - tolerance for the KNOWN teardown ERR_WORKER_OUT_OF_MEMORY signature
+      #    (mode B) — and ONLY that signature — when zero tests failed.
+      # if: always() so it still fires when vitest exits non-zero or is killed.
+      - name: Evaluate test results
+        if: always()
+        env:
+          VITEST_EXIT: ${{ steps.vitest.outputs.exit_code }}
         run: |
+          # Disable errexit: grep "no match" assignments (e.g. the no-failures
+          # fallback summary) exit non-zero and, under the runner's default
+          # `bash -eo pipefail`, a failing `var=$(grep ... | tail)` would abort
+          # the step before we reach our explicit checks. Every failure path
+          # below ends in an explicit `exit`, so this cannot mask a real failure.
+          set +e
           if [ ! -f vitest-output.txt ]; then
-            echo "::error::vitest-output.txt missing — cannot verify test-file coverage"
+            echo "::error::vitest-output.txt missing — the test step failed to start."
+            exit 1
+          fi
+          # Empty exit_code => the step was killed before it could report its
+          # exit (35-min timeout or runner cancellation). Mode A.
+          if [ -z "${VITEST_EXIT}" ]; then
+            echo "::error::Full Test Suite did not complete — it timed out (35 min) or was cancelled before reporting. This is a CI hang, not a test failure; inspect the 'vitest-output' artifact to see how far it got."
+            tail -30 vitest-output.txt || true
             exit 1
           fi
           # Summary line shape: " Test Files  14 failed | 734 passed | 4 skipped (755)"
@@ -153,24 +200,47 @@ jobs:
             summary=$(grep -oE '^\s*Test Files +[0-9]+ passed \| [0-9]+ skipped \([0-9]+\)' vitest-output.txt | tail -1)
           fi
           if [ -z "$summary" ]; then
-            echo "::error::could not parse 'Test Files' summary from vitest output"
+            echo "::error::could not parse 'Test Files' summary from vitest output (crash before summary?). Exit code was ${VITEST_EXIT}."
             tail -30 vitest-output.txt
             exit 1
           fi
           echo "Parsed summary: ${summary}"
           total=$(echo "$summary" | grep -oE '\([0-9]+\)' | tr -d '()')
           skipped=$(echo "$summary" | grep -oE '[0-9]+ skipped' | grep -oE '[0-9]+')
+          files_failed=$(echo "$summary" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' | tail -1)
+          files_failed=${files_failed:-0}
+          # Individual-test failures: " Tests  3 failed | 6215 passed | 1 skipped (6219)"
+          tests_failed=$(grep -oE '^\s*Tests +[0-9]+ failed' vitest-output.txt | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' | tail -1)
+          tests_failed=${tests_failed:-0}
+          has_oom=$(grep -c 'ERR_WORKER_OUT_OF_MEMORY' vitest-output.txt || true)
+          has_oom=${has_oom:-0}
           min_total=700
           max_skipped=50
-          echo "total=${total} skipped=${skipped} (thresholds: total>=${min_total}, skipped<=${max_skipped})"
+          echo "exit=${VITEST_EXIT} files_failed=${files_failed} tests_failed=${tests_failed} total=${total} skipped=${skipped} oom=${has_oom} (thresholds: total>=${min_total}, skipped<=${max_skipped})"
           fail=0
-          if [ "$total" -lt "$min_total" ]; then
+          # Genuine test failures are NEVER tolerated.
+          if [ "${files_failed}" -gt 0 ] || [ "${tests_failed}" -gt 0 ]; then
+            echo "::error::Test failures detected: ${files_failed} file(s), ${tests_failed} test(s). This is a real failure, not an infra issue."
+            fail=1
+          fi
+          # Defence-in-depth against bail-like under-reporting / over-exclusion.
+          if [ "${total}" -lt "${min_total}" ]; then
             echo "::error::Discovered ${total} test files, below minimum ${min_total}. Likely cause: config exclusions expanded or files removed from src/tests."
             fail=1
           fi
-          if [ "$skipped" -gt "$max_skipped" ]; then
+          if [ "${skipped}" -gt "${max_skipped}" ]; then
             echo "::error::${skipped} test files reported as skipped (max ${max_skipped}). Likely cause: --bail=N reintroduced (see docs/ui/ci-test-coverage-audit.md §1) or large it.skip() block added."
             fail=1
+          fi
+          # A non-zero exit with zero failures is tolerated ONLY for the known
+          # teardown/worker OOM signature — not for any other non-zero exit.
+          if [ "${VITEST_EXIT}" -ne 0 ] && [ "${fail}" -eq 0 ]; then
+            if [ "${has_oom}" -gt 0 ]; then
+              echo "::warning::vitest exited ${VITEST_EXIT} but every test passed; tolerating the known teardown ERR_WORKER_OUT_OF_MEMORY (see docs/ops/vitest-full-suite-oom-diagnosis.md)."
+            else
+              echo "::error::vitest exited ${VITEST_EXIT} with zero reported failures and no ERR_WORKER_OUT_OF_MEMORY signature — unexplained non-zero exit, not tolerated."
+              fail=1
+            fi
           fi
           exit $fail
 
@@ -213,13 +283,23 @@ jobs:
     steps:
       - name: Check all jobs passed
         run: |
+          echo "Job results:"
+          echo "  tsc:    ${{ needs.tsc.result }}"
+          echo "  vitest: ${{ needs.vitest.result }}"
+          echo "  build:  ${{ needs.build.result }}"
           if [ "${{ needs.tsc.result }}" != "success" ] || \
              [ "${{ needs.vitest.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ]; then
-            echo "One or more jobs failed:"
-            echo "  tsc:    ${{ needs.tsc.result }}"
-            echo "  vitest: ${{ needs.vitest.result }}"
-            echo "  build:  ${{ needs.build.result }}"
+            echo "::error::Staging Gate failed — one or more jobs did not succeed (see results above)."
+            # The Full Test Suite job is the authority on test outcome: its
+            # "Evaluate test results" step prints a precise reason and the
+            # 'vitest-output' artifact preserves the log on every outcome.
+            # A timeout/hang ('failure'/'cancelled' with an "did not complete"
+            # error), an OOM-tolerated pass ('success' + a ::warning::), and a
+            # genuine test failure all look different there — check it first.
+            if [ "${{ needs.vitest.result }}" != "success" ]; then
+              echo "::error::vitest is '${{ needs.vitest.result }}'. Open the Full Test Suite job logs + download the 'vitest-output' artifact to tell a CI hang/timeout apart from a real test failure."
+            fi
             exit 1
           fi
           echo "All jobs passed."


### PR DESCRIPTION
## Why

After PR #187 merged, the **Full Test Suite** job hung in `pnpm exec vitest run --reporter=verbose` for ~90 min (no job timeout → GitHub's 6h default) and had to be cancelled. Because **Staging Gate** requires `vitest` to be `success`, the cancelled job flipped the gate to an **ambiguous failure**. This is a CI-infra hang, **not** a PR #187 parser regression.

Two distinct OOM-related failure modes exist (per [`docs/ops/vitest-full-suite-oom-diagnosis.md`](../blob/staging/docs/ops/vitest-full-suite-oom-diagnosis.md)):
- **(A) hang** — vitest never exits, job runs to 6h and is cancelled (this incident).
- **(B) OOM-on-exit** — vitest prints a passing summary, then exits non-zero during teardown ("occasionally even at 7 GB").

This PR makes the suite **bounded** and the gate **truthful**, fixing both modes. **CI-only.**

## Changes (`.github/workflows/staging-full-tests.yml` only)

1. **35-min step-level timeout** on the vitest run (normal runtime ~15 min). A teardown hang now fails fast instead of running for hours.
2. **Capture vitest's real exit code** via `PIPESTATUS[0]`; the run step exits 0 so a single **Evaluate test results** step is the pass/fail arbiter. On a timeout the runner kills the step before the `exit_code` echo runs → `steps.vitest.outputs.exit_code` is **empty**, which is how Evaluate detects a hang/cancel (mode A).
3. **Always upload `vitest-output.txt`** as an artifact (`if: always()`, 14-day retention) so a hung/cancelled run stays diagnosable. Test log only — no secrets/env dumps.
4. **Comprehensive evaluate step** (replaces the coverage-only assertion, preserving its `total>=700` / `skipped<=50` thresholds):
   - missing output → **fail**
   - empty exit code (timeout/cancel) → **fail** (clear "did not complete" reason)
   - no parsable summary → **fail**
   - any `Test Files`/`Tests` failures → **fail** (never tolerated)
   - file-coverage thresholds breached → **fail**
   - non-zero exit + zero failures + `ERR_WORKER_OUT_OF_MEMORY` → **pass with `::warning::`** (mode B, this signature **only**)
   - non-zero exit + zero failures + no OOM signature → **fail** (unexplained, not tolerated)
5. **Clearer Staging Gate message** — pass/fail semantics unchanged; it now prints each job result and points to the Full Test Suite logs + artifact so timeout vs OOM-tolerated-pass vs genuine failure are easy to tell apart.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Hang in teardown | runs to 6h, cancelled, gate ambiguous-fails | step times out at **35 min** → fail with clear reason, artifact preserved |
| OOM-on-exit, all tests passed | step fails on non-zero exit → **false gate failure** | **pass (warning)**, gate passes |
| Genuine test failure | fails | **fails** (unchanged) |
| Crash before summary / unparsable | fails | **fails** (clearer message) |
| Non-zero exit, zero failures, no OOM | fails | **fails** (not tolerated) |
| Diagnostics after any outcome | `vitest-output.txt` lost | **uploaded artifact** (`if: always()`) |

## Verification

- `yaml.safe_load` parses clean; all 7 `run:` blocks pass `bash -n` under `-eo pipefail`.
- **Local scratch simulation** of the evaluate logic (with `set +e`, matching the step) across 8 fixtures — clean pass, pass+OOM-on-exit, genuine failure, no-summary, empty-exit/timeout, malformed, unexplained-non-zero, bail-like under-reporting — all produced the expected PASS/FAIL.
- Added `set +e` to the evaluate step: under the runner's default `bash -eo pipefail`, a failing `var=$(grep ... | tail)` (the no-failures fallback) would otherwise abort the step before our explicit checks. Every failure path ends in an explicit `exit`, so it cannot mask a real failure.
- `git diff --stat` shows **only** `.github/workflows/staging-full-tests.yml`.

## Branch protection (context)

`staging` is **unprotected**; `main`'s required checks (`TypeScript`, `Tests + Coverage`, `CEE Contract Validation`) come from `ci.yml`, which is **not** touched. **Staging Gate is not a required check anywhere** (advisory), so this change cannot weaken branch protection.

## Scope

CI-only. **No** product / parser / F1 / ModelReceipt / AI Panel / lifecycle / CEE / schema / prompt / UI / package / lockfile changes. Full Test Suite is **not** disabled and **not** `continue-on-error`.

> The workflow only runs on push to `staging`, so the new behaviour is exercised end-to-end only once this lands. This PR carries the local-simulation evidence; live confirmation comes on the next staging push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)