### PR TITLE
F1 PR B: pre-analysis model receipt card (V5 path, DGAI-only, flag-gated)

### DIFF
--- a/src/canvas/adapters/__tests__/modelCardAdapter.spec.ts
+++ b/src/canvas/adapters/__tests__/modelCardAdapter.spec.ts
@@ -13,6 +13,8 @@ import {
   deriveConfidenceLabel,
   selectModelCardData,
   selectModelReceiptData,
+  maybeBuildModelReceiptBlock,
+  type ReceiptStoreSlice,
 } from '../modelCardAdapter'
 
 // ---------------------------------------------------------------------------
@@ -256,6 +258,9 @@ describe('selectModelReceiptData', () => {
     expect(data!.optionCount).toBe(1)
     expect(data!.goalLabel).toBe('Profit')
     expect(data!.readiness).toBe('ready')
+    // coachingSummary is the CEE summary, verbatim (distinct from topInsight,
+    // which here is the first critique).
+    expect(data!.coachingSummary).toBe('The model looks good. Consider adding evidence.')
     expect(data!.topInsight).toBe('Missing time horizon')
     expect(data!.topEvidenceGap).toContain('Revenue')
     expect(data!.adjustments).toHaveLength(1)
@@ -271,7 +276,98 @@ describe('selectModelReceiptData', () => {
       },
       repairsApplied: null,
     })
+    // topInsight truncates to the first sentence; coachingSummary keeps the full
+    // CEE text. They MUST differ for a multi-sentence summary.
     expect(data!.topInsight).toBe('First sentence.')
+    expect(data!.coachingSummary).toBe('First sentence. Second sentence.')
+    expect(data!.coachingSummary).not.toBe(data!.topInsight)
     expect(data!.readiness).toBe('incomplete')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// § maybeBuildModelReceiptBlock (post-draft receipt gate — branch matrix)
+// ---------------------------------------------------------------------------
+
+describe('maybeBuildModelReceiptBlock', () => {
+  // A complete, valid post-draft store slice (graph + analysis_ready + coaching).
+  const readyStore: ReceiptStoreSlice = {
+    nodes: [
+      { id: '1', data: { kind: 'factor', label: 'Revenue', observedState: { value: 1 } } },
+      { id: '2', data: { kind: 'goal', label: 'Profit' } },
+      { id: '3', data: { kind: 'option', label: 'Option A' } },
+    ] as any[],
+    edges: [{ id: 'e1' }] as any[],
+    ceeAnalysisReady: {
+      status: 'ready',
+      coaching_summary: 'One assumption worth checking: assess team expertise first.',
+    },
+    repairsApplied: null,
+  }
+
+  it('returns null when the flag is disabled', () => {
+    expect(
+      maybeBuildModelReceiptBlock({ enabled: false, isDraftTurn: true, store: readyStore }),
+    ).toBeNull()
+  })
+
+  it('returns null when this is not a draft turn', () => {
+    expect(
+      maybeBuildModelReceiptBlock({ enabled: true, isDraftTurn: false, store: readyStore }),
+    ).toBeNull()
+  })
+
+  it('returns null when the graph is not in the store (no nodes)', () => {
+    expect(
+      maybeBuildModelReceiptBlock({
+        enabled: true,
+        isDraftTurn: true,
+        store: { ...readyStore, nodes: [] },
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when analysis_ready has not been normalised into the store', () => {
+    expect(
+      maybeBuildModelReceiptBlock({
+        enabled: true,
+        isDraftTurn: true,
+        store: { ...readyStore, ceeAnalysisReady: null },
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when coaching_summary did not survive (empty / whitespace)', () => {
+    expect(
+      maybeBuildModelReceiptBlock({
+        enabled: true,
+        isDraftTurn: true,
+        store: { ...readyStore, ceeAnalysisReady: { status: 'ready', coaching_summary: '   ' } },
+      }),
+    ).toBeNull()
+    expect(
+      maybeBuildModelReceiptBlock({
+        enabled: true,
+        isDraftTurn: true,
+        store: { ...readyStore, ceeAnalysisReady: { status: 'ready', coaching_summary: null } },
+      }),
+    ).toBeNull()
+  })
+
+  it('builds the block when the flag is on, it is a draft turn, and coaching is present', () => {
+    const block = maybeBuildModelReceiptBlock({
+      enabled: true,
+      isDraftTurn: true,
+      store: readyStore,
+    })
+    expect(block).not.toBeNull()
+    expect(block!.type).toBe('model_receipt')
+    expect(block!.coachingSummary).toBe('One assumption worth checking: assess team expertise first.')
+  })
+
+  it('returns selectModelReceiptData output plus the block type discriminant', () => {
+    const data = selectModelReceiptData(readyStore)
+    const block = maybeBuildModelReceiptBlock({ enabled: true, isDraftTurn: true, store: readyStore })
+    expect(block).toEqual({ type: 'model_receipt', ...data })
   })
 })

--- a/src/canvas/adapters/modelCardAdapter.ts
+++ b/src/canvas/adapters/modelCardAdapter.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Node, Edge } from '@xyflow/react'
+import type { ModelReceiptBlockType } from '../conversation/types'
 
 // ---------------------------------------------------------------------------
 // § 1 — Types
@@ -45,6 +46,12 @@ export interface ModelReceiptData {
   edgeCount: number
   optionCount: number
   goalLabel: string | null
+  /**
+   * CEE-owned coaching (analysis_ready.coaching_summary), verbatim. This is the
+   * card's main content (F1 PR B). DGAI never rewrites or augments it — it is
+   * displayed as-is and is intentionally exempt from the DGAI copy/glossary gate.
+   */
+  coachingSummary: string | null
   topInsight: string | null
   topEvidenceGap: string | null
   readiness: 'ready' | 'blocked' | 'incomplete' | 'unknown'
@@ -222,7 +229,7 @@ export function selectModelCardData(store: StoreSlice): ModelCardData {
 // § 7 — selectModelReceiptData (store → view-model for conversation block)
 // ---------------------------------------------------------------------------
 
-interface ReceiptStoreSlice {
+export interface ReceiptStoreSlice {
   nodes: Node[]
   edges: Edge[]
   ceeAnalysisReady: {
@@ -230,7 +237,9 @@ interface ReceiptStoreSlice {
     coaching_summary?: string | null
     model_critiques?: Array<{ message: string }> | null
   } | null
-  repairsApplied: RawRepair[] | null
+  // `| undefined` so the full canvas store (where repairs_applied is optional)
+  // is structurally assignable; formatRepairs already tolerates null/undefined.
+  repairsApplied: RawRepair[] | null | undefined
 }
 
 export function selectModelReceiptData(store: ReceiptStoreSlice): ModelReceiptData | null {
@@ -276,9 +285,48 @@ export function selectModelReceiptData(store: ReceiptStoreSlice): ModelReceiptDa
     edgeCount: store.edges.length,
     optionCount: counts.option,
     goalLabel: goalLabel ?? null,
+    // CEE coaching, verbatim and untruncated (distinct from `topInsight`, which
+    // takes only the first sentence). This is the card's main content.
+    coachingSummary: coaching ?? null,
     topInsight,
     topEvidenceGap,
     readiness,
     adjustments: formatRepairs(store.repairsApplied, store.nodes),
   }
+}
+
+// ---------------------------------------------------------------------------
+// § 8 — maybeBuildModelReceiptBlock (post-draft receipt gate)
+// ---------------------------------------------------------------------------
+
+/**
+ * F1 PR B — construct the client-synthesised model_receipt block for the
+ * post-draft assistant message, or return null.
+ *
+ * Pure and path-agnostic: it only reads the canvas store, so the same gate
+ * serves the V5 live path (the one wired today) and a future V4 wiring. It
+ * centralises the race/order rules so they are unit-testable in isolation.
+ *
+ * No receipt is better than a partial one (brief). A receipt is produced only
+ * when ALL hold:
+ *   - the flag is enabled;
+ *   - this turn applied a fresh draft graph (`isDraftTurn`) — so the card fires
+ *     once, on the generative turn, never on later conversational updates;
+ *   - the graph is in the store (selectModelReceiptData returns non-null);
+ *   - analysis_ready has been normalised into the store (`ceeAnalysisReady`);
+ *   - CEE coaching survived into the store (`coachingSummary` is non-empty) —
+ *     the coaching IS the card's value, so without it there is no card.
+ */
+export function maybeBuildModelReceiptBlock(args: {
+  enabled: boolean
+  isDraftTurn: boolean
+  store: ReceiptStoreSlice
+}): ModelReceiptBlockType | null {
+  const { enabled, isDraftTurn, store } = args
+  if (!enabled || !isDraftTurn) return null
+  const data = selectModelReceiptData(store)
+  if (!data) return null
+  if (!store.ceeAnalysisReady) return null
+  if (!data.coachingSummary || data.coachingSummary.trim().length === 0) return null
+  return { type: 'model_receipt', ...data }
 }

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -230,6 +230,11 @@ function BlockRenderer({
 
     case 'model_receipt':
       if (!isPreAnalysisEnrichedEnabled()) return null
+      // No coaching summary = no card (brief invariant). The construction gate
+      // (maybeBuildModelReceiptBlock) already enforces this on the live path;
+      // guard the render path too so a coaching-less block (e.g. a hydrated or
+      // legacy one) can never show a headline/nudge shell.
+      if (!block.coachingSummary?.trim()) return null
       return <ModelReceiptBlock data={block} />
 
     case 'evidence':

--- a/src/canvas/conversation/ModelReceiptBlock.tsx
+++ b/src/canvas/conversation/ModelReceiptBlock.tsx
@@ -47,6 +47,11 @@ export const ModelReceiptBlock = memo(function ModelReceiptBlock({ data }: Model
   const [detailsExpanded, setDetailsExpanded] = useState(false)
   const [adjustmentsExpanded, setAdjustmentsExpanded] = useState(false)
 
+  // No coaching summary = no card (brief invariant). The coaching IS the card's
+  // value; without it there is nothing to show. Enforced here so the component
+  // is correct for any caller, and again at the InlineBlocks dispatch.
+  if (!data.coachingSummary || data.coachingSummary.trim().length === 0) return null
+
   const countsLine = [
     data.factorCount > 0 ? `${data.factorCount} factor${data.factorCount !== 1 ? 's' : ''}` : null,
     `${data.edgeCount} relationship${data.edgeCount !== 1 ? 's' : ''}`,
@@ -89,7 +94,7 @@ export const ModelReceiptBlock = memo(function ModelReceiptBlock({ data }: Model
           onClick={() => setDetailsExpanded(!detailsExpanded)}
           className={`${typography.panelMeta} text-text-light inline-flex items-center gap-1 hover:text-text-body transition-colors`}
           aria-expanded={detailsExpanded}
-          aria-controls="receipt-details"
+          aria-controls={detailsExpanded ? 'receipt-details' : undefined}
         >
           Model details
           {detailsExpanded
@@ -116,7 +121,7 @@ export const ModelReceiptBlock = memo(function ModelReceiptBlock({ data }: Model
             onClick={() => setAdjustmentsExpanded(!adjustmentsExpanded)}
             className={`${typography.panelMeta} text-text-light inline-flex items-center gap-1 hover:text-text-body transition-colors`}
             aria-expanded={adjustmentsExpanded}
-            aria-controls="receipt-adjustments"
+            aria-controls={adjustmentsExpanded ? 'receipt-adjustments' : undefined}
           >
             <Wrench className="w-3 h-3" aria-hidden="true" />
             Olumi made {data.adjustments.length} adjustment{data.adjustments.length !== 1 ? 's' : ''} to keep the model valid

--- a/src/canvas/conversation/ModelReceiptBlock.tsx
+++ b/src/canvas/conversation/ModelReceiptBlock.tsx
@@ -1,32 +1,37 @@
 /**
- * ModelReceiptBlock — structured summary block rendered in conversation after
- * graph generation.
+ * ModelReceiptBlock — pre-analysis "check this before analysis" card rendered in
+ * the conversation after graph generation (F1 PR B).
+ *
+ * Action-first hierarchy: a neutral headline, then the CEE-provided coaching
+ * (analysis_ready.coaching_summary) verbatim as the main content, then a static
+ * neutral next-step nudge. Model statistics (counts / readiness / goal) are
+ * demoted into a collapsed "Model details" disclosure — never in the primary
+ * visual path. Honest pre-analysis: no materiality / confidence / likelihood /
+ * winner / verdict language, no colour-as-status (analysis has not run yet).
  *
  * Consumes only the stable view-model from selectModelReceiptData.
  * No direct reads from guidance_items, envelope fields, or patch timing.
- *
- * Phase 2B: Pre-analysis enrichment.
  */
 
 import { memo, useState } from 'react'
-import { ChevronDown, ChevronRight, CheckCircle2, Wrench } from 'lucide-react'
+import { ChevronDown, ChevronRight, ClipboardCheck, Wrench } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import type { ModelReceiptData } from '../adapters/modelCardAdapter'
 
 // ---------------------------------------------------------------------------
-// § 1 — Readiness pill
+// § 1 — Readiness label (neutral; demoted to the "Model details" disclosure)
 // ---------------------------------------------------------------------------
 
-function readinessPill(readiness: ModelReceiptData['readiness']) {
+function readinessLabel(readiness: ModelReceiptData['readiness']): string {
   switch (readiness) {
     case 'ready':
-      return { text: 'Ready', className: 'text-success border border-success/30 bg-transparent' }
+      return 'Ready to run'
     case 'blocked':
-      return { text: 'Needs attention', className: 'text-danger border border-danger/30 bg-transparent' }
+      return 'Needs attention'
     case 'incomplete':
-      return { text: 'Needs review', className: 'text-warning border border-warning/30 bg-transparent' }
+      return 'Needs review'
     default:
-      return { text: 'Unknown', className: 'text-text-light border border-text-light/30 bg-transparent' }
+      return 'Draft'
   }
 }
 
@@ -39,57 +44,71 @@ interface ModelReceiptBlockProps {
 }
 
 export const ModelReceiptBlock = memo(function ModelReceiptBlock({ data }: ModelReceiptBlockProps) {
+  const [detailsExpanded, setDetailsExpanded] = useState(false)
   const [adjustmentsExpanded, setAdjustmentsExpanded] = useState(false)
 
-  const pill = readinessPill(data.readiness)
-
-  const modelLine = [
+  const countsLine = [
     data.factorCount > 0 ? `${data.factorCount} factor${data.factorCount !== 1 ? 's' : ''}` : null,
     `${data.edgeCount} relationship${data.edgeCount !== 1 ? 's' : ''}`,
     data.optionCount > 0 ? `${data.optionCount} option${data.optionCount !== 1 ? 's' : ''}` : null,
   ].filter(Boolean).join(', ')
 
-  const targetLine = data.goalLabel ? ` targeting ${data.goalLabel}` : ''
-  const nextStepLine = data.topEvidenceGap
-    ? `Next step: add evidence for ${data.topEvidenceGap}`
-    : data.readiness === 'ready'
-      ? 'Next step: run analysis when you are ready.'
-      : null
+  const detailLine = [
+    readinessLabel(data.readiness),
+    countsLine,
+    data.goalLabel ? `toward ${data.goalLabel}` : null,
+  ].filter(Boolean).join(' · ')
 
   return (
     <div
-      className="bg-surface-secondary rounded-lg shadow-s1 p-3 space-y-1.5"
+      className="bg-panel rounded-lg shadow-s1 p-3 space-y-1.5"
       data-testid="model-receipt-block"
     >
-      {/* Header */}
+      {/* 1 — Action headline (neutral icon; no success/verdict colour) */}
       <div className="flex items-center gap-1.5">
-        <CheckCircle2 className="w-3.5 h-3.5 text-success shrink-0" aria-hidden="true" />
-        <span className={typography.panelHeader}>Model generated</span>
-        <span className={`${typography.panelMeta} px-1.5 py-0.5 rounded-full ${pill.className}`}>
-          {pill.text}
-        </span>
+        <ClipboardCheck className="w-3.5 h-3.5 text-text-light shrink-0" aria-hidden="true" />
+        <span className={typography.panelHeader}>Check this before analysis</span>
       </div>
 
-      {/* Model size */}
-      <p className={`${typography.bodySmall} text-text-body`}>
-        {modelLine}{targetLine}
+      {/* 2 — Main content: CEE coaching, verbatim. Not glossary-gated (CEE owns it). */}
+      {data.coachingSummary && (
+        <p className={`${typography.bodySmall} text-text-body`}>
+          {data.coachingSummary}
+        </p>
+      )}
+
+      {/* 3 — Static neutral next-step nudge (DGAI chrome; passes the copy gate) */}
+      <p className={`${typography.panelMeta} text-text-light`}>
+        Review or strengthen this before running analysis.
       </p>
 
-      {/* Top insight */}
-      {data.topInsight && (
-        <p className={`${typography.bodySmall} text-text-body`}>
-          {data.topInsight}
-        </p>
-      )}
+      {/* 4 — Demoted "Model details": readiness + counts + goal, collapsed */}
+      <div>
+        <button
+          type="button"
+          onClick={() => setDetailsExpanded(!detailsExpanded)}
+          className={`${typography.panelMeta} text-text-light inline-flex items-center gap-1 hover:text-text-body transition-colors`}
+          aria-expanded={detailsExpanded}
+          aria-controls="receipt-details"
+        >
+          Model details
+          {detailsExpanded
+            ? <ChevronDown className="w-3 h-3" aria-hidden="true" />
+            : <ChevronRight className="w-3 h-3" aria-hidden="true" />
+          }
+        </button>
 
-      {/* Top evidence gap */}
-      {nextStepLine && (
-        <p className={`${typography.panelMeta} text-text-light`}>
-          {nextStepLine}
-        </p>
-      )}
+        {detailsExpanded && (
+          <p
+            id="receipt-details"
+            className={`${typography.panelMeta} text-text-light mt-1 pl-4`}
+          >
+            {detailLine}
+          </p>
+        )}
+      </div>
 
-      {/* Adjustments */}
+      {/* 5 — Collapsible adjustments (unchanged behaviour) */}
       {data.adjustments.length > 0 && (
         <div>
           <button

--- a/src/canvas/conversation/__tests__/InlineBlocks.dsv5.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.dsv5.spec.tsx
@@ -9,7 +9,7 @@
  * - review_card alert variant renders with the alert class (Task 4 regression guard)
  */
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { InlineBlocks } from '../InlineBlocks'
 import { adaptCEEBlock, deriveProposalItemFromOperation } from '../useConversation'
@@ -21,15 +21,20 @@ import type {
   BriefBlock,
   ReviewCardBlock,
   CommentaryBlock,
+  ModelReceiptBlockType,
 } from '../types'
-import { isOrchestratorRenderingV2Enabled } from '../../../flags'
+import { isOrchestratorRenderingV2Enabled, isPreAnalysisEnrichedEnabled } from '../../../flags'
 
-// Mock the flag so we can assert ungated behaviour explicitly.
+// Mock the flag so we can assert ungated behaviour explicitly. isPreAnalysis-
+// EnrichedEnabled is added as a bare vi.fn() (no factory return value — vitest
+// config has mockReset:true, which wipes factory-level mockReturnValue); the
+// model_receipt describe below sets it per-test in a scoped beforeEach.
 vi.mock('../../../flags', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../flags')>()
   return {
     ...actual,
     isOrchestratorRenderingV2Enabled: vi.fn().mockReturnValue(true),
+    isPreAnalysisEnrichedEnabled: vi.fn(),
   }
 })
 
@@ -352,5 +357,47 @@ describe('deriveProposalItemFromOperation — edge label resolution (DS v5 §21.
     )
     expect(item!.description).toBe('Update factor')
     expect(item!.elementLabel).toBeUndefined()
+  })
+})
+
+// -----------------------------------------------------------------------------
+// model_receipt — "no coaching summary = no card" render gate (F1 PR B)
+// preAnalysisEnriched is forced on in the flags mock above, so these tests
+// exercise the coaching guard, not the flag guard.
+// -----------------------------------------------------------------------------
+
+describe('InlineBlocks — model_receipt coaching render gate', () => {
+  // Force the pre-analysis flag on for these tests (mockReset wipes the factory
+  // value, so set it here, after the per-test reset).
+  beforeEach(() => {
+    vi.mocked(isPreAnalysisEnrichedEnabled).mockReturnValue(true)
+  })
+
+  const base: Omit<ModelReceiptBlockType, 'coachingSummary'> = {
+    type: 'model_receipt',
+    factorCount: 2,
+    edgeCount: 1,
+    optionCount: 1,
+    goalLabel: 'Profit',
+    topInsight: null,
+    topEvidenceGap: null,
+    readiness: 'ready',
+    adjustments: [],
+  }
+
+  it('renders the card when coaching summary is present', () => {
+    const block: ModelReceiptBlockType = { ...base, coachingSummary: 'Assess team expertise first.' }
+    render(<InlineBlocks blocks={[block]} />)
+    expect(screen.getByTestId('model-receipt-block')).toBeInTheDocument()
+  })
+
+  it('renders no card when coaching summary is missing or blank', () => {
+    const missing: ModelReceiptBlockType = { ...base, coachingSummary: null }
+    const { rerender } = render(<InlineBlocks blocks={[missing]} />)
+    expect(screen.queryByTestId('model-receipt-block')).not.toBeInTheDocument()
+
+    const blank: ModelReceiptBlockType = { ...base, coachingSummary: '   ' }
+    rerender(<InlineBlocks blocks={[blank]} />)
+    expect(screen.queryByTestId('model-receipt-block')).not.toBeInTheDocument()
   })
 })

--- a/src/canvas/conversation/__tests__/ModelReceiptBlock.spec.tsx
+++ b/src/canvas/conversation/__tests__/ModelReceiptBlock.spec.tsx
@@ -1,22 +1,25 @@
 /**
  * ModelReceiptBlock — component tests.
- * Phase 2B: Pre-analysis enrichment.
+ *
+ * F1 PR B: the card now leads with action ("Check this before analysis") and the
+ * CEE coaching as main content; model statistics are demoted into a collapsed
+ * "Model details" disclosure. These tests assert that action-oriented hierarchy
+ * (they previously asserted the old stats-led "Model generated" layout — updated
+ * deliberately because that layout was the weak UX this PR replaces).
  */
 
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { ModelReceiptBlock } from '../ModelReceiptBlock'
 import type { ModelReceiptData } from '../../adapters/modelCardAdapter'
-
-vi.mock('../../../lib/posthog', () => ({
-  trackEvent: vi.fn(),
-}))
+import { findBannedTerm } from '../../../components/results/analysisHeroV17/glossaryCheck'
 
 const fullData: ModelReceiptData = {
   factorCount: 5,
   edgeCount: 8,
   optionCount: 2,
   goalLabel: 'Revenue growth',
+  coachingSummary: 'One assumption worth checking: assess team expertise first.',
   topInsight: 'Missing time horizon may affect accuracy.',
   topEvidenceGap: 'Marketing spend: no observed data',
   readiness: 'ready',
@@ -27,88 +30,88 @@ const fullData: ModelReceiptData = {
 }
 
 describe('ModelReceiptBlock', () => {
-  it('renders with full data', () => {
+  it('leads with the action headline and the CEE coaching as main content', () => {
     render(<ModelReceiptBlock data={fullData} />)
 
-    expect(screen.getByText('Model generated')).toBeInTheDocument()
-    expect(screen.getByText('Ready')).toBeInTheDocument()
+    expect(screen.getByText('Check this before analysis')).toBeInTheDocument()
+    // CEE coaching rendered verbatim as the primary content.
+    expect(screen.getByText(fullData.coachingSummary!)).toBeInTheDocument()
+    // Static neutral next-step nudge.
+    expect(screen.getByText('Review or strengthen this before running analysis.')).toBeInTheDocument()
+    // The old stats-led header is gone.
+    expect(screen.queryByText('Model generated')).not.toBeInTheDocument()
+  })
+
+  it('keeps model counts out of the primary view until "Model details" is expanded', () => {
+    render(<ModelReceiptBlock data={fullData} />)
+
+    // Counts are NOT in the primary visual path.
+    expect(screen.queryByText(/5 factors/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/8 relationships/)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Model details'))
+
     expect(screen.getByText(/5 factors/)).toBeInTheDocument()
     expect(screen.getByText(/8 relationships/)).toBeInTheDocument()
+    expect(screen.getByText(/2 options/)).toBeInTheDocument()
     expect(screen.getByText(/Revenue growth/)).toBeInTheDocument()
-    expect(screen.getByText(/Missing time horizon/)).toBeInTheDocument()
-    expect(screen.getByText(/Next step: add evidence for Marketing spend/)).toBeInTheDocument()
+    // Neutral readiness label (no colour-as-verdict pill).
+    expect(screen.getByText(/Ready to run/)).toBeInTheDocument()
   })
 
-  it('renders with partial data without crashing', () => {
-    render(
-      <ModelReceiptBlock
-        data={{
-          factorCount: 2,
-          edgeCount: 3,
-          optionCount: 0,
-          goalLabel: null,
-          topInsight: null,
-          topEvidenceGap: null,
-          readiness: 'unknown',
-          adjustments: [],
-        }}
-      />,
-    )
+  it('renders the headline and nudge even when there is no coaching (defensive)', () => {
+    render(<ModelReceiptBlock data={{ ...fullData, coachingSummary: null }} />)
 
-    expect(screen.getByText('Model generated')).toBeInTheDocument()
-    expect(screen.getByText('Unknown')).toBeInTheDocument()
-    expect(screen.getByText(/2 factors/)).toBeInTheDocument()
-    // No insight or gap text
-    expect(screen.queryByText(/Missing/)).not.toBeInTheDocument()
+    expect(screen.getByText('Check this before analysis')).toBeInTheDocument()
+    expect(screen.getByText('Review or strengthen this before running analysis.')).toBeInTheDocument()
+    expect(screen.queryByText(fullData.coachingSummary!)).not.toBeInTheDocument()
   })
 
-  it('shows a ready next-step when there is no evidence gap', () => {
-    render(
-      <ModelReceiptBlock
-        data={{
-          ...fullData,
-          topEvidenceGap: null,
-          topInsight: null,
-          adjustments: [],
-        }}
-      />,
-    )
-
-    expect(screen.getByText('Next step: run analysis when you are ready.')).toBeInTheDocument()
-  })
-
-  it('renders adjustments collapsed by default', () => {
+  it('renders adjustments collapsed by default and expands on click', () => {
     render(<ModelReceiptBlock data={fullData} />)
 
-    const adjustBtn = screen.getByText(/2 adjustments/)
-    expect(adjustBtn).toBeInTheDocument()
-
-    // Details not visible initially
+    expect(screen.getByText(/Olumi made 2 adjustments to keep the model valid/)).toBeInTheDocument()
     expect(screen.queryByText('Floored')).not.toBeInTheDocument()
-  })
 
-  it('expands adjustments on click', () => {
-    render(<ModelReceiptBlock data={fullData} />)
-
-    fireEvent.click(screen.getByText(/2 adjustments/))
+    fireEvent.click(screen.getByText(/Olumi made 2 adjustments/))
 
     expect(screen.getByText('Floored')).toBeInTheDocument()
     expect(screen.getByText('Defaulted')).toBeInTheDocument()
   })
 
-  it('shows readiness pills with text labels', () => {
+  it('shows neutral readiness labels inside "Model details"', () => {
     const { rerender } = render(
       <ModelReceiptBlock data={{ ...fullData, readiness: 'blocked' }} />,
     )
-    expect(screen.getByText('Needs attention')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Model details'))
+    expect(screen.getByText(/Needs attention/)).toBeInTheDocument()
 
-    rerender(
-      <ModelReceiptBlock data={{ ...fullData, readiness: 'incomplete' }} />,
-    )
-    expect(screen.getByText('Needs review')).toBeInTheDocument()
+    // rerender keeps the disclosure expanded; only the label changes.
+    rerender(<ModelReceiptBlock data={{ ...fullData, readiness: 'incomplete' }} />)
+    expect(screen.getByText(/Needs review/)).toBeInTheDocument()
   })
 
-  it('has accessible test-id', () => {
+  it('contains no banned glossary terms in DGAI static copy', () => {
+    const { container } = render(<ModelReceiptBlock data={fullData} />)
+    // Scan the DGAI-authored copy (headline, nudge, Model details). The CEE
+    // coaching is owned by CEE and intentionally exempt — strip it first.
+    fireEvent.click(screen.getByText('Model details'))
+    const dgaiCopy = (container.textContent ?? '').replace(fullData.coachingSummary ?? '', '')
+    expect(findBannedTerm(dgaiCopy)).toBeNull()
+  })
+
+  it('does not render IDs, hashes, _meta, or coaching_state', () => {
+    const { container } = render(<ModelReceiptBlock data={fullData} />)
+    // Expand every disclosure so all rendered text is scanned.
+    fireEvent.click(screen.getByText('Model details'))
+    fireEvent.click(screen.getByText(/Olumi made 2 adjustments/))
+    const text = container.textContent ?? ''
+    expect(text).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}/i) // uuid
+    expect(text).not.toMatch(/\b[a-f0-9]{12,}\b/i)                    // long hex hash
+    expect(text).not.toMatch(/node_|_id\b|_meta|coaching_state|coaching_lifecycle/i)
+  })
+
+  it('has an accessible test-id', () => {
     render(<ModelReceiptBlock data={fullData} />)
     expect(screen.getByTestId('model-receipt-block')).toBeInTheDocument()
   })

--- a/src/canvas/conversation/__tests__/ModelReceiptBlock.spec.tsx
+++ b/src/canvas/conversation/__tests__/ModelReceiptBlock.spec.tsx
@@ -59,12 +59,18 @@ describe('ModelReceiptBlock', () => {
     expect(screen.getByText(/Ready to run/)).toBeInTheDocument()
   })
 
-  it('renders the headline and nudge even when there is no coaching (defensive)', () => {
-    render(<ModelReceiptBlock data={{ ...fullData, coachingSummary: null }} />)
+  it('renders nothing when there is no coaching summary (null or blank)', () => {
+    // Brief invariant: no coaching = no card. The coaching is the card's value,
+    // so the component must not show a headline/nudge shell without it.
+    const { container, rerender } = render(
+      <ModelReceiptBlock data={{ ...fullData, coachingSummary: null }} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText('Check this before analysis')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('model-receipt-block')).not.toBeInTheDocument()
 
-    expect(screen.getByText('Check this before analysis')).toBeInTheDocument()
-    expect(screen.getByText('Review or strengthen this before running analysis.')).toBeInTheDocument()
-    expect(screen.queryByText(fullData.coachingSummary!)).not.toBeInTheDocument()
+    rerender(<ModelReceiptBlock data={{ ...fullData, coachingSummary: '   ' }} />)
+    expect(container).toBeEmptyDOMElement()
   })
 
   it('renders adjustments collapsed by default and expands on click', () => {

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -377,13 +377,16 @@ export interface EvidenceBlock {
   query: string
 }
 
-// Phase 2B: Model receipt block — structured summary after graph generation
+// Phase 2B: Model receipt block — structured summary after graph generation.
+// F1 PR B: action-first pre-analysis card. `coachingSummary` is the CEE-owned
+// (analysis_ready.coaching_summary) main content; DGAI adds only static chrome.
 export interface ModelReceiptBlockType {
   type: 'model_receipt'
   factorCount: number
   edgeCount: number
   optionCount: number
   goalLabel: string | null
+  coachingSummary: string | null
   topInsight: string | null
   topEvidenceGap: string | null
   readiness: 'ready' | 'blocked' | 'incomplete' | 'unknown'

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -31,7 +31,8 @@ import {
   type Phase3RawBlock,
 } from '../../v5/extractPhase3FromV5Response'
 import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
-import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled } from '../../flags'
+import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled } from '../../flags'
+import { maybeBuildModelReceiptBlock } from '../adapters/modelCardAdapter'
 import { assembleAnalysisInputsSummary } from '../analysis/assembleAnalysisInputsSummary'
 import { useResultsStore } from '../stores/resultsStore'
 import { hydrateMessagesFromThread, formatSessionBoundary } from './utils/hydrateThread'
@@ -2970,9 +2971,15 @@ export function useConversation(): UseConversationReturn {
             )
             const inlineNodeCount = (inlineGraph?.nodes as unknown[] | undefined)?.length ?? 0
 
+            // F1 PR B: track whether THIS turn applied a fresh inline draft graph.
+            // Used below to construct the post-draft model_receipt card exactly
+            // once — later conversational turns leave the canvas non-empty, so
+            // this branch does not re-run and no second receipt is emitted.
+            let draftAppliedThisTurn = false
             if (inlineGraph && inlineNodeCount > 0 && canvasIsEmpty) {
               if (useCanvasStore.getState().currentScenarioId === scenarioIdAtDispatch) {
                 applyDraftResult(inlineGraph as any)
+                draftAppliedThisTurn = true
                 if (import.meta.env.DEV) {
                   console.log('[sendTurn V5] graph applied from inline response:', inlineNodeCount, 'nodes')
                 }
@@ -3039,6 +3046,18 @@ export function useConversation(): UseConversationReturn {
               mappedBlocks,
             )
 
+            // F1 PR B: append the client-synthesised pre-analysis model receipt
+            // on the turn that applied a fresh draft graph, after applyDraftResult
+            // committed nodes/edges + ceeAnalysisReady (incl coaching_summary) to
+            // the store synchronously above. Gated on the flag + a non-empty
+            // coaching summary; the block is local-only (no CEE/wire/parser change).
+            const receipt = maybeBuildModelReceiptBlock({
+              enabled: isPreAnalysisEnrichedEnabled(),
+              isDraftTurn: draftAppliedThisTurn,
+              store: useCanvasStore.getState(),
+            })
+            const renderBlocks = receipt ? [...finalBlocks, receipt] : finalBlocks
+
             // V5 suggested_actions → ActionChip. CEE caps count server-side;
             // UI additionally caps rendering per DS v5 §21.4 in SuggestedChips.
             // action_type when present drives deterministic routing on next click.
@@ -3053,7 +3072,7 @@ export function useConversation(): UseConversationReturn {
               id: crypto.randomUUID(),
               role: 'assistant',
               content: target.response.assistant_text,
-              ...(finalBlocks.length > 0 ? { blocks: finalBlocks } : {}),
+              ...(renderBlocks.length > 0 ? { blocks: renderBlocks } : {}),
               ...(actionChips.length > 0 ? { actionChips } : {}),
               timestamp: new Date(),
             })


### PR DESCRIPTION
## What

After a draft model is generated on the **V5 orchestrator path** (the live staging path), this appends a **client-synthesised `model_receipt`** conversation block that leads with action and the CEE coaching summary. It reuses the existing `ModelReceiptBlock` + `selectModelReceiptData` (previously dead-wired — zero call sites). Behind `VITE_FEATURE_PRE_ANALYSIS_ENRICHED` (default off; already on for staging).

> **Do not merge yet.** Pending the staging end-to-end liveness proof (below).

## Scope (DGAI-only)

No CEE / schema-package / parser / prompt / AI-Panel / lifecycle / `coaching_state` changes. No new `blocks[]` wire type. 6 files changed.

## Phase 0 — why the V5 path (not V4 `handleEnvelope`)

Verified directly from the **deployed staging bundle** (commit `529e7621`, `VITE_APP_ENV:"staging"`): `VITE_ENABLE_V5_ORCHESTRATOR:"true"`. So a draft routes to `/bff/orchestrate/v2/turn` → `callV5Turn` / `routeV5Response`; the V4 `handleEnvelope` path is never reached on staging. A V4 construction site would have shipped **dark**. `VITE_FEATURE_PRE_ANALYSIS_ENRICHED:"true"` is also already baked on staging, so the render gate is open.

## The 9 proofs

1. **Construction site** — `useConversation.ts` V5 `sendTurn` branch, right after `finalBlocks` is built and before `addMessage`: `finalBlocks.push(maybeBuildModelReceiptBlock(...))`, fired only when a fresh inline draft graph was applied this turn (`draftAppliedThisTurn`).
2. **Race/order** — injected **after** `applyDraftResult` synchronously commits nodes/edges + `ceeAnalysisReady` (incl. `coaching_summary`) to the store. The pure gate requires flag + draft-turn + graph-in-store + `ceeAnalysisReady` + non-empty `coachingSummary`. Draft-turn-only ⇒ the inline-apply branch only runs while the canvas is empty, so later turns emit no second receipt.
3. **`coaching_summary` preservation** — `normaliseAnalysisReady` (spreads `...obj`) → `validateAnalysisReadyContract` (returns the object unchanged) → `applyDraftResult` `setCeeAnalysisReady` → `selectModelReceiptData` reads `ceeAnalysisReady.coaching_summary`.
4. **Hierarchy** — leads with "Check this before analysis" → CEE `coaching_summary` (verbatim) → static neutral nudge. Statistics no longer lead.
5. **Counts demoted** — readiness + counts + goal live in a collapsed **"Model details"** disclosure; never in the primary visual path.
6. **Tests updated + why** — the old `ModelReceiptBlock.spec` asserted the stats-led "Model generated" layout this PR replaces; rewritten to the action-first hierarchy + a glossary scan (CEE coaching stripped, since CEE owns it) + a no-ID scan. Added the `maybeBuildModelReceiptBlock` branch matrix (flag off / not-draft / no nodes / no analysis_ready / no coaching / happy path / shape-equality). **42/42 pass.**
7. **Flag-off parity** — `maybeBuildModelReceiptBlock` returns null when disabled (no block emitted), **and** `InlineBlocks` returns null for `model_receipt` when the flag is off (belt-and-braces). `flags.ts` untouched.
8. **No internal data renders** — the view-model carries no IDs/hashes/`_meta`/`coaching_state`; locked by a no-ID/`coaching_state` scan test.
9. **No CEE/schema/parser/prompt/AI-Panel/lifecycle work; no new wire block type.** The block is appended in-memory only.

## Verification

- CI typecheck (`tsc -p tsconfig.ci.json --noEmit`): **0 errors**.
- `ModelReceiptBlock.spec` + `modelCardAdapter.spec`: **42/42 pass**.
- ESLint (changed files): **0 errors**.
- Pre-push gate: **all checks passed** (smoke suite 459 pass).
- Pre-existing `useConversation.hook.spec.ts` failures are **unrelated** — identical (`38 failed`) with and without this change (stale `v5Adapter` mock missing `getV5Endpoint`, tracked separately).

## Staging liveness gate (acceptance — do before merge)

Flag is already on. Generate a draft via the AI Panel v2 composer and confirm the real DGAI↔CEE chain:

1. Network: **POST `/bff/orchestrate/v2/turn`**.
2. Response includes/preserves `analysis_ready.coaching_summary`.
3. The receipt card renders under the post-draft assistant message — "Check this before analysis" → CEE coaching as main content → nudge → counts collapsed; no IDs/hashes/`_meta`/`coaching_state`.
4. `localStorage.setItem('feature.preAnalysisEnriched','0')` then regenerate → **no card** (old experience restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
