### PR TITLE
feat(canvas): move Olumi to first (leftmost) outputs-dock tab

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -192,11 +192,14 @@ export function deriveNextDockIsOpen(isFirstUse: boolean, storedIsOpen: boolean)
  *  required for the gating to reflect the new flag state. */
 export function getOutputTabsForParity(): { id: OutputsDockTab; label: string }[] {
   return [
+    // Olumi leads the strip as the first (leftmost) tab by product decision —
+    // keep it first. The default-SELECTED tab is independent: it stays
+    // 'results' (Analysis) via the state initialiser, not array position.
+    ...(isAiPanelV2Enabled() ? [{ id: 'olumi' as const, label: 'Olumi' }] : []),
     { id: 'results', label: 'Analysis' },
     ...(isCompareTabEnabled() ? [{ id: 'compare' as const, label: 'Compare' }] : []),
     { id: 'diagnostics', label: 'Model' },
     ...(isJourneyTabEnabled() ? [{ id: 'journey' as const, label: 'Journey' }] : []),
-    ...(isAiPanelV2Enabled() ? [{ id: 'olumi' as const, label: 'Olumi' }] : []),
   ]
 }
 

--- a/src/canvas/components/__tests__/aiPanelV2.parity.spec.tsx
+++ b/src/canvas/components/__tests__/aiPanelV2.parity.spec.tsx
@@ -123,8 +123,8 @@ describe('aiPanelV2 default (round-12: default-ON, rollback via localStorage="fa
       const { getOutputTabsForParity } = await import('../OutputsDock')
       const ids = getOutputTabsForParity().map((t) => t.id)
       expect(ids).toContain('olumi')
-      // Olumi appears at the end (last position).
-      expect(ids[ids.length - 1]).toBe('olumi')
+      // Olumi appears at the start (first position).
+      expect(ids[0]).toBe('olumi')
     })
   })
 })


### PR DESCRIPTION
## Summary
Moves the **Olumi** tab to the first (leftmost) position in the right-hand OutputsDock tab strip, before Analysis / Compare / Model.

## Change
- Reorder `getOutputTabsForParity()` — the single source of truth for both the expanded tab strip and the collapsed icon rail — so the Olumi entry leads.
- **Formatting unchanged:** every tab renders through one generic button template, so Olumi keeps byte-for-byte identical styling — only its position changes (verified live: `olumiClassEqualsCompareClass: true`).
- The default-**selected** tab stays `results` (Analysis): it's hardcoded in the state initialiser, not derived from array position. `resolveTab()` checks membership, not order.
- Update `aiPanelV2.parity.spec.tsx` to assert Olumi is first (`ids[0]`) instead of last.

## Verification
- Live browser DOM order: `["Olumi", "Analysis", "Compare", "Model"]`.
- 81 OutputsDock-related tests pass (parity, interactions, polish, conversationSingleton, FirstUseComposer, ResultsLink, CompactOptionSpread); typecheck + lint clean.
- Pre-push fast gate: all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)