### PR TITLE
fix(canvas): persist scenario_id so a conversation keeps one UUID across refresh

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -17,6 +17,7 @@ import { useKeyboardShortcuts } from './useKeyboardShortcuts'
 import { loadState, saveState } from './persist'
 import * as scenarios from './store/scenarios'
 import type { Scenario } from './store/scenarios'
+import { isUUID } from '../services/turn-request-builder'
 import { validateCeeAnalysisReady } from './utils/ceeAnalysisReadyValidation'
 import type { CEEAnalysisReady } from '../adapters/cee/types'
 import { CanvasContextMenu } from './contextMenu/CanvasContextMenu'
@@ -1430,9 +1431,18 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
           nodes: autosave.nodes,
           edges: autosave.edges,
         })
-        // Clear stale scenario ID - user is now in draft mode
-        scenarios.clearCurrentScenarioId()
-        useCanvasStore.setState({ currentScenarioId: null })
+        // Scenario/thread continuity: preserve a UUID-format current-scenario ID across
+        // the refresh so the in-flight CEE conversation keeps the same scenario_id. The
+        // periodic autosave stamps this same ID into the autosave slot, so the recovered
+        // graph and the preserved conversation belong together. Only a missing or legacy
+        // (non-UUID) ID is cleared to drop into draft mode.
+        const persistedScenarioId = scenarios.getCurrentScenarioId()
+        if (persistedScenarioId && isUUID(persistedScenarioId)) {
+          useCanvasStore.setState({ currentScenarioId: persistedScenarioId })
+        } else {
+          scenarios.clearCurrentScenarioId()
+          useCanvasStore.setState({ currentScenarioId: null })
+        }
         // FIX: Do NOT clear autosave after consuming it.
         // Keep autosave data until user explicitly saves (scenario save) or next autosave cycle.
         // This ensures if browser crashes again before manual save, data can still be recovered.

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useConversation } from '../useConversation'
 import { useCanvasStore } from '../../store'
+import { getCurrentScenarioId } from '../../store/scenarios'
 import { useResultsStore } from '../../stores/resultsStore'
 import { _clearTraces, getInteractionChains, recordUiSurfaceState } from '../../../lib/debug-state'
 
@@ -1678,6 +1679,75 @@ describe('null-initial scenario_id lifecycle', () => {
 
     const request = mockStreamTurn.mock.calls[0][0]
     expect(UUID_RE.test(request.client_turn_id)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scenario_id persistence + continuity (scenario/thread continuity fix)
+// Proves the lazily-allocated conversation UUID is PERSISTED through the
+// localStorage current-scenario writer and reused across a simulated refresh,
+// and that every turn type in one session shares the same UUID.
+// ---------------------------------------------------------------------------
+
+describe('scenario_id persistence + continuity', () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  const LS_KEY = 'olumi-canvas-current-scenario-id'
+
+  beforeEach(() => {
+    mockCallV5Turn.mockResolvedValue(makeV5SuccessResult())
+    // Start each test with a clean current-scenario storage slot + null store id.
+    localStorage.removeItem(LS_KEY)
+    useCanvasStore.setState({ currentScenarioId: null as any })
+  })
+
+  it('persists the lazily allocated UUID through the current-scenario storage writer', async () => {
+    expect(localStorage.getItem(LS_KEY)).toBeNull()
+    mockCallTurn.mockResolvedValueOnce({ assistant_text: 'ok', client_turn_id: 'resp-persist' })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => { await result.current.sendMessage('hello') })
+
+    const sentId = mockStreamTurn.mock.calls[0][0].scenario_id
+    expect(UUID_RE.test(sentId)).toBe(true)
+    // The storage writer was called — not just in-memory setState.
+    expect(getCurrentScenarioId()).toBe(sentId)
+    expect(localStorage.getItem(LS_KEY)).toBe(sentId)
+  })
+
+  it('reuses the persisted UUID after a simulated refresh — no fresh allocation', async () => {
+    mockCallTurn.mockResolvedValue({ assistant_text: 'ok', client_turn_id: 'resp-refresh' })
+
+    const hook1 = renderHook(() => useConversation())
+    await act(async () => { await hook1.result.current.sendMessage('first') })
+    const firstId = mockStreamTurn.mock.calls[0][0].scenario_id
+    expect(UUID_RE.test(firstId)).toBe(true)
+
+    // Simulate a page refresh: in-memory store is recreated and rehydrates the
+    // current-scenario id from localStorage (mirrors store init at store.ts:1199).
+    useCanvasStore.setState({ currentScenarioId: getCurrentScenarioId() as any })
+    const hook2 = renderHook(() => useConversation())
+    await act(async () => { await hook2.result.current.sendMessage('after refresh') })
+    const secondId = mockStreamTurn.mock.calls[1][0].scenario_id
+
+    expect(secondId).toBe(firstId)
+    expect(getCurrentScenarioId()).toBe(firstId)
+  })
+
+  it('in-session: message → run_analysis → graph edit → explain all share one UUID', async () => {
+    mockCallTurn.mockResolvedValue({ assistant_text: 'ok', client_turn_id: 'resp-session' })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => { await result.current.sendMessage('normal message') })
+    await act(async () => { await result.current.sendMessage('run it', { turnType: 'run_analysis' }) })
+    await act(async () => {
+      await result.current.sendSystemEvent({ type: 'direct_graph_edit', payload: { changed_node_ids: [] } })
+    })
+    await act(async () => { await result.current.sendMessage('why?', { turnType: 'explain' }) })
+
+    const ids = mockStreamTurn.mock.calls.map((c: any) => c[0].scenario_id)
+    expect(ids).toHaveLength(4)
+    expect(new Set(ids).size).toBe(1)
+    expect(UUID_RE.test(ids[0])).toBe(true)
   })
 })
 

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -8,6 +8,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { useCanvasStore } from '../store'
+import { setCurrentScenarioId } from '../store/scenarios'
 import { useDraftStore } from '../stores/draftStore'
 import { generateGraphHash } from '../utils/graphHash'
 import { callOrchestratorTurn, streamOrchestratorTurn, OrchestratorError } from './turnService'
@@ -1597,8 +1598,9 @@ export function useConversation(): UseConversationReturn {
       const store = useCanvasStore.getState()
       const { nodeIds, edgeIds } = store.selection
       // Lazy UUID allocation: generate a fresh UUID when store has no scenario_id or a
-      // legacy non-UUID format (e.g. "scenario-1709827200000-abc"). Persist to store so
-      // subsequent turns in the same session reuse the same ID.
+      // legacy non-UUID format (e.g. "scenario-1709827200000-abc"). Persist to store AND
+      // through the localStorage current-scenario writer so the same conversation reuses
+      // the same ID across a page refresh / store re-init (scenario/thread continuity).
       let scenarioId = store.currentScenarioId
       if (!scenarioId || !isUUID(scenarioId)) {
         const newId = crypto.randomUUID()
@@ -1607,6 +1609,7 @@ export function useConversation(): UseConversationReturn {
         }
         scenarioId = newId
         useCanvasStore.setState({ currentScenarioId: scenarioId })
+        setCurrentScenarioId(scenarioId)
       }
       const conversationHistory = buildHistory(messagesRef.current, 5)
       const selectedElements: SelectedElementsPayload | undefined =
@@ -2695,9 +2698,10 @@ export function useConversation(): UseConversationReturn {
           })
         }
 
-        // Lazy UUID allocation — mirrors V4 buildRequest (line 1403-1413).
+        // Lazy UUID allocation — mirrors V4 buildRequest above.
         // If the store has no scenario_id or a legacy non-UUID format, generate
-        // one client-side and persist it so subsequent turns reuse the same ID.
+        // one client-side and persist it (store + localStorage writer) so subsequent
+        // turns — including after a page refresh / re-init — reuse the same ID.
         let currentScenarioId = useCanvasStore.getState().currentScenarioId
         if (!currentScenarioId || !isUUID(currentScenarioId)) {
           const newId = crypto.randomUUID()
@@ -2706,6 +2710,7 @@ export function useConversation(): UseConversationReturn {
           }
           currentScenarioId = newId
           useCanvasStore.setState({ currentScenarioId: newId })
+          setCurrentScenarioId(newId)
         }
 
         const resolvedTurnType: TurnType = isSystemEvent

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -2982,10 +2982,18 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // P0-2: Set saving state
     set({ isSaving: true })
 
+    // Does a saved record already exist for the current ID? `currentScenarioId` can be
+    // a lazily-allocated conversation UUID (set by the first CEE turn) that has NO record
+    // yet. In that case we must ADOPT that UUID as the new record's ID rather than mint a
+    // replacement — otherwise updateScenario() would silently no-op and the model would be
+    // lost. This keeps model identity == CEE conversation identity across a save.
+    const hasExistingRecord =
+      currentScenarioId != null && scenarios.getScenario(currentScenarioId) != null
+
     try {
-      if (currentScenarioId) {
-        // Update existing scenario
-        scenarios.updateScenario(currentScenarioId, {
+      if (hasExistingRecord) {
+        // Update existing scenario (ID preserved)
+        scenarios.updateScenario(currentScenarioId!, {
           name,
           graph: { nodes, edges },
           framing: currentScenarioFraming || undefined,
@@ -3011,15 +3019,18 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
           isSaving: false,
           lastSavedAt: Date.now()
         })
-        return currentScenarioId
+        return currentScenarioId!
       } else {
-        // Create new scenario - auto-generate name if not provided
+        // No record yet. Create one, ADOPTING the existing conversation UUID when present
+        // (so the saved model reuses the same ID); otherwise createScenario mints a fresh
+        // UUID. Auto-generate a name if not provided.
         const scenarioName = name
           || currentScenarioFraming?.title
           || `Decision - ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
 
         const scenario = scenarios.createScenario({
           name: scenarioName,
+          id: currentScenarioId ?? undefined,
           nodes,
           edges,
           framing: currentScenarioFraming || undefined,

--- a/src/canvas/store/__tests__/scenarioIdContinuity.spec.ts
+++ b/src/canvas/store/__tests__/scenarioIdContinuity.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Scenario/thread continuity fix — store + scenarios coverage.
+ *
+ * Covers the localStorage-side guarantees of the fix:
+ *  - new scenario IDs are UUID-format (generateId → crypto.randomUUID);
+ *  - saving the current *unsaved* model ADOPTS the existing conversation UUID
+ *    rather than minting a replacement or silently no-opping (highest-risk path);
+ *  - existing legacy-format saved models still load and remain usable, with the
+ *    deliberate "save creates a new UUID-backed record" PoC compatibility behaviour;
+ *  - the autosave-recovery preserve gate (UUID kept, legacy/null cleared) — the
+ *    classification the ReactFlowGraph init effect applies.
+ *
+ * The full ReactFlowGraph render is not exercised here (ReactFlow DOM mounts are
+ * fragile/excluded locally); the recovery gate's classification is unit-tested
+ * against the real modules and the end-to-end refresh behaviour is proven by the
+ * runtime browser re-trace on staging.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import {
+  createScenario,
+  saveScenarios,
+  loadScenarios,
+  getScenario,
+  getCurrentScenarioId,
+  setCurrentScenarioId,
+  clearCurrentScenarioId,
+  type Scenario,
+} from '../scenarios'
+import { isUUID } from '../../../services/turn-request-builder'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const LS_KEYS = ['olumi-canvas-scenarios', 'olumi-canvas-autosave', 'olumi-canvas-current-scenario-id']
+
+function aNode(id = 'n1') {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor' } } as any
+}
+
+function legacyRecord(id: string): Scenario {
+  const now = Date.now()
+  return {
+    id,
+    name: 'Legacy model',
+    createdAt: now,
+    updatedAt: now,
+    graph: { nodes: [aNode('legacy-node')], edges: [] },
+  } as Scenario
+}
+
+beforeEach(() => {
+  for (const k of LS_KEYS) localStorage.removeItem(k)
+  useCanvasStore.getState().reset()
+})
+
+// ---------------------------------------------------------------------------
+// New-ID format
+// ---------------------------------------------------------------------------
+
+describe('new scenario ID format', () => {
+  it('createScenario mints a UUID-format id (no legacy "scenario-" prefix)', () => {
+    const s = createScenario({ name: 'Fresh', nodes: [aNode()], edges: [] })
+    expect(UUID_RE.test(s.id)).toBe(true)
+    expect(s.id.startsWith('scenario-')).toBe(false)
+  })
+
+  it('createScenario adopts an explicit id when provided', () => {
+    const id = '11111111-2222-4333-8444-555555555555'
+    const s = createScenario({ id, name: 'Adopted', nodes: [aNode()], edges: [] })
+    expect(s.id).toBe(id)
+    expect(getScenario(id)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Highest-risk: save current unsaved model preserves the UUID
+// ---------------------------------------------------------------------------
+
+describe('saveCurrentScenario — preserve/adopt UUID', () => {
+  it('adopts the existing conversation UUID; same id before and after, no replacement, no no-op', () => {
+    const X = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+    useCanvasStore.setState({ currentScenarioId: X as any, nodes: [aNode('keep')], edges: [] })
+    // Precondition: a lazily-allocated conversation UUID with NO saved record yet.
+    expect(getScenario(X)).toBeUndefined()
+
+    const returned = useCanvasStore.getState().saveCurrentScenario('My model')
+
+    expect(returned).toBe(X)                                   // returned id unchanged
+    expect(useCanvasStore.getState().currentScenarioId).toBe(X) // store id unchanged
+    const record = getScenario(X)
+    expect(record).toBeDefined()                               // not a silent no-op
+    expect(record!.graph.nodes.some(n => n.id === 'keep')).toBe(true)
+    expect(loadScenarios()).toHaveLength(1)                    // no replacement minted
+    expect(loadScenarios()[0].id).toBe(X)
+  })
+
+  it('updates in place when a record already exists (id preserved, no duplicate)', () => {
+    const X = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+    createScenario({ id: X, name: 'Existing', nodes: [aNode('old')], edges: [] })
+    useCanvasStore.setState({ currentScenarioId: X as any, nodes: [aNode('new')], edges: [] })
+
+    const returned = useCanvasStore.getState().saveCurrentScenario()
+
+    expect(returned).toBe(X)
+    expect(loadScenarios()).toHaveLength(1)
+    expect(getScenario(X)!.graph.nodes.some(n => n.id === 'new')).toBe(true)
+  })
+
+  it('mints a fresh UUID when there is no current id at all (brand-new model)', () => {
+    useCanvasStore.setState({ currentScenarioId: null as any, nodes: [aNode()], edges: [] })
+    const returned = useCanvasStore.getState().saveCurrentScenario()
+    expect(returned).not.toBeNull()
+    expect(UUID_RE.test(returned as string)).toBe(true)
+    expect(useCanvasStore.getState().currentScenarioId).toBe(returned)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Existing legacy saved models
+// ---------------------------------------------------------------------------
+
+describe('legacy saved models', () => {
+  it('a legacy-format saved model still loads and is usable', () => {
+    const legacyId = 'scenario-1709827200000-abc'
+    saveScenarios([legacyRecord(legacyId)])
+
+    const ok = useCanvasStore.getState().loadScenario(legacyId)
+
+    expect(ok).toBe(true)
+    expect(useCanvasStore.getState().currentScenarioId).toBe(legacyId)
+    expect(useCanvasStore.getState().nodes.some(n => n.id === 'legacy-node')).toBe(true)
+    // Its id fails the UUID guard, so the next CEE turn will mint a fresh UUID
+    // (proven by the useConversation "replaces legacy non-UUID scenario_id" test).
+    expect(isUUID(legacyId)).toBe(false)
+  })
+
+  it('ACCEPTED PoC behaviour: after the guard mints a UUID, saving creates a NEW UUID record; the legacy record is not mutated', () => {
+    const legacyId = 'scenario-1709827200000-abc'
+    saveScenarios([legacyRecord(legacyId)])
+    useCanvasStore.getState().loadScenario(legacyId)
+
+    // Simulate the next CEE turn's lazy-allocation guard swapping in a UUID.
+    const mintedUuid = 'c8146c5c-3a92-4ae4-8a89-9a633efa3d93'
+    useCanvasStore.setState({ currentScenarioId: mintedUuid as any })
+    setCurrentScenarioId(mintedUuid)
+
+    useCanvasStore.getState().saveCurrentScenario()
+
+    const records = loadScenarios()
+    expect(records).toHaveLength(2)                            // new UUID record + untouched legacy
+    expect(getScenario(mintedUuid)).toBeDefined()
+    expect(getScenario(legacyId)).toBeDefined()               // legacy record NOT migrated/rewritten
+    expect(getScenario(legacyId)!.id).toBe(legacyId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Autosave-recovery preserve gate (classification the init effect applies)
+// ---------------------------------------------------------------------------
+
+describe('autosave-recovery preserve gate', () => {
+  it('preserves a UUID-format persisted current id; clears a legacy or absent one', () => {
+    // UUID → preserved
+    const uuid = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+    setCurrentScenarioId(uuid)
+    const persisted = getCurrentScenarioId()
+    expect(persisted && isUUID(persisted)).toBe(true) // recovery keeps it
+
+    // legacy → not preserved (would be cleared to null / draft mode)
+    setCurrentScenarioId('scenario-1709827200000-abc')
+    const legacy = getCurrentScenarioId()
+    expect(!!(legacy && isUUID(legacy))).toBe(false)
+
+    // absent → not preserved
+    clearCurrentScenarioId()
+    const absent = getCurrentScenarioId()
+    expect(!!(absent && isUUID(absent))).toBe(false)
+  })
+})

--- a/src/canvas/store/scenarios.ts
+++ b/src/canvas/store/scenarios.ts
@@ -65,10 +65,16 @@ function isLocalStorageAvailable(): boolean {
 }
 
 /**
- * Generate a unique ID for scenarios
+ * Generate a unique ID for scenarios.
+ *
+ * Uses crypto.randomUUID() so new scenario/model IDs are UUID-format and pass the
+ * orchestrator's isUUID() wire guard — keeping model identity and CEE conversation
+ * identity on the same stable ID. Legacy "scenario-{ts}-{rand}" IDs already saved in
+ * localStorage are NOT migrated; they still load and function, and receive a fresh
+ * UUID on their next CEE turn via the lazy-allocation guard in useConversation.
  */
 function generateId(): string {
-  return `scenario-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+  return crypto.randomUUID()
 }
 
 /**
@@ -283,6 +289,13 @@ export function createScenario(params: {
   name: string
   nodes: Node[]
   edges: Edge[]
+  /**
+   * Optional explicit record ID. When omitted, a fresh UUID is generated.
+   * Used by saveCurrentScenario to ADOPT an already-allocated conversation UUID
+   * (the lazily-assigned scenario_id) when first persisting an unsaved model, so
+   * the saved record reuses the same ID rather than minting a replacement.
+   */
+  id?: string
   source_template_id?: string
   source_template_version?: string
   framing?: ScenarioFraming
@@ -295,7 +308,7 @@ export function createScenario(params: {
   const now = Date.now()
   const { nodes, edges } = deepCloneGraph(params.nodes, params.edges)
   const scenario: Scenario = {
-    id: generateId(),
+    id: params.id ?? generateId(),
     name: params.name,
     createdAt: now,
     updatedAt: now,


### PR DESCRIPTION
## What & why

The canvas used one in-memory `currentScenarioId` field as **both** the model-record key and the CEE conversation key (`scenario_id`). The lazily-allocated conversation UUID was only set in-memory, so a page refresh / store re-init re-read `null` from localStorage and minted a **new** UUID — fragmenting CEE conversation memory. A read-only runtime trace confirmed a fresh `scenario_id` on refresh and on reset; localStorage `olumi-canvas-current-scenario-id` stayed `null` throughout a session.

This is the smallest safe UI/DGAI fix. No CEE/PLoT/prompt changes. No separate `thread_id` (one canvas model = one conversation).

## Changes
1. **Persist the lazy UUID** — both lazy-alloc sites (V4 `buildRequest`, V5 `sendTurn`) now call `setCurrentScenarioId(newId)`, not just `setState`.
2. **Autosave recovery preserves a UUID-format id** (`ReactFlowGraph.tsx`) instead of clearing to `null`; only missing/legacy ids drop to draft mode. (Block is `import.meta.env.PROD`-gated.)
3. **`generateId()` → `crypto.randomUUID()`** so new scenario/model ids pass the `isUUID` wire guard. No live code depends on the old `scenario-` prefix. Existing legacy saved ids are **not** migrated.
4. **`saveCurrentScenario` adopts the existing UUID** when first saving an unsaved model (`createScenario` gains an optional `id`) — no replacement minted, no silent no-op.

## Tests
- New `scenarioIdContinuity.spec.ts` (8) + 3 `useConversation` continuity tests — **11/11 pass**.
- CI typecheck green; changed-file lint 0 errors.
- 6 pre-existing `useConversation.hook.spec.ts` failures (stale V5 `getV5Endpoint` mock) are baseline-only — proven unchanged by stashing.

## Runtime validation (real browser, local build)
- Dev build: refresh preserves `scenario_id` (Fix #1).
- Prod build + seeded autosave: recovery preserves the UUID and the next send reuses it (Fix #2).

## Decision-table semantics
Preserve: normal message, chip, run analysis, explain, inline edit→follow-up, refresh, navigation, autosave recovery, save-current-unsaved-model. New UUID: template, reset, draft-new-over-graph, import.

## Save-path note
The save-current-unsaved-model branch is currently **dormant** in the live PoC (no exposed Save button; persistence is autosave-driven). Covered by unit test. **If a Save UI is restored, re-verify the save-adoption path in a real browser before external/pilot use.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)