### PR TITLE
feat(analysis): freshness dirty overlay + robustness single-source (UI-only, draft)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -49,6 +49,7 @@ import { useOnboarding } from './onboarding/useOnboarding'
 import { useCanvasKeyboardShortcuts } from './hooks/useCanvasKeyboardShortcuts'
 import type { Blueprint } from '../templates/blueprints/types'
 import { blueprintToGraph } from '../templates/mapper/blueprintToGraph'
+import { commitTemplateGraphReplace } from './blueprints/commitTemplateGraph'
 import { InfluenceExplainer, useInfluenceExplainer } from '../components/assistants/InfluenceExplainer'
 // DraftChat is mounted directly below (FF off path); the aiPanelV2
 // floating-first host is mounted as a sibling when the flag is on.
@@ -1202,20 +1203,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
       }
     })
 
-    // Batch update store - REPLACE existing graph, not merge
-    // This matches the user expectation from "Start from Template" confirmation
-    const store = useCanvasStore.getState()
-    store.pushHistory()
-    useCanvasStore.setState(() => ({
-      nodes: newNodes,
-      edges: newEdges
-    }))
-    // Template insert/replace is a full graph mutation via bare setState (bypasses
-    // the edit chokepoints), so mark the freshness overlay dirty — a retained CEE
-    // 'fresh' verdict must not survive starting-from / replacing-with a template.
-    // Covers both insertBlueprint (start-from) and handleConfirmReplace (which
-    // calls insertBlueprint after pruning the existing template).
-    useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+    // Batch update store — REPLACE existing graph, not merge (matches the "Start
+    // from Template" confirmation). commitTemplateGraphReplace pushes one history
+    // frame, replaces the graph, AND marks the freshness overlay dirty — a retained
+    // CEE 'fresh' verdict must not survive starting-from / replacing-with a template.
+    // Covers handleConfirmReplace too (it calls insertBlueprint after pruning).
+    commitTemplateGraphReplace(newNodes, newEdges)
 
     showToast(`Started from "${blueprint.name}" template.`, 'success')
 

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -1210,6 +1210,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
       nodes: newNodes,
       edges: newEdges
     }))
+    // Template insert/replace is a full graph mutation via bare setState (bypasses
+    // the edit chokepoints), so mark the freshness overlay dirty — a retained CEE
+    // 'fresh' verdict must not survive starting-from / replacing-with a template.
+    // Covers both insertBlueprint (start-from) and handleConfirmReplace (which
+    // calls insertBlueprint after pruning the existing template).
+    useCanvasStore.getState().markAnalysisFreshnessDirty?.()
 
     showToast(`Started from "${blueprint.name}" template.`, 'success')
 

--- a/src/canvas/blueprints/__tests__/commitTemplateGraph.spec.ts
+++ b/src/canvas/blueprints/__tests__/commitTemplateGraph.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * commitTemplateGraphReplace — template insert/replace must dirty the freshness
+ * overlay (regression for the false-fresh hole where a retained CEE 'fresh' verdict
+ * survived "Start from Template" / replace).
+ *
+ * insertBlueprint ("Start from Template") and handleConfirmReplace (which prunes the
+ * existing template then calls insertBlueprint) both route their graph replace
+ * through this helper, so exercising it directly covers both paths' dirtying without
+ * rendering the whole ReactFlowGraph canvas tree (which pulls OutputsDock/Supabase/
+ * ELK and is impractical to mock reliably; ReactFlow dom tests are excluded in
+ * vitest.config.ts for jsdom issues).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { commitTemplateGraphReplace } from '../commitTemplateGraph'
+import { useCanvasStore } from '../../store'
+import { resolveDisplayedFreshness } from '../../store/analysisFreshness'
+import type { EdgeData } from '../../domain/edges'
+
+const node = (id: string): Node =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id } }) as Node
+
+const dirty = () => useCanvasStore.getState().analysisFreshnessDirty
+const displayed = () => {
+  const s = useCanvasStore.getState()
+  return resolveDisplayedFreshness(s.analysisFreshness, s.analysisFreshnessDirty)
+}
+const applyFresh = () =>
+  useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    nodes: [],
+    edges: [] as Edge<EdgeData>[],
+    history: { past: [], future: [] },
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+  })
+})
+
+describe('commitTemplateGraphReplace — template insert/replace dirties freshness', () => {
+  it('insert ("Start from Template"): replaces the graph and downgrades a retained fresh verdict', () => {
+    applyFresh()
+    expect(displayed()).toBe('fresh') // precondition: a clean fresh analysis
+
+    commitTemplateGraphReplace([node('t1')], [])
+
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toEqual(['t1'])
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown') // CEE 'fresh' + local dirty → cannot-confirm
+  })
+
+  it('replace: a fresh verdict does not survive replacing an existing template', () => {
+    // Seed an existing template + a fresh verdict.
+    useCanvasStore.setState({ nodes: [node('old')] })
+    applyFresh()
+    // handleConfirmReplace prunes the existing template via bare setState (which
+    // does NOT dirty on its own)...
+    useCanvasStore.setState({ nodes: [] })
+    expect(dirty()).toBe(false)
+    // ...then calls insertBlueprint → commitTemplateGraphReplace, which dirties.
+    commitTemplateGraphReplace([node('t2')], [])
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toEqual(['t2'])
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('does not fabricate stale: a CEE stale verdict stays stale (overlay only downgrades fresh)', () => {
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
+    commitTemplateGraphReplace([node('t1')], [])
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('stale')
+  })
+
+  it('pushes a single history frame so the template insert is undoable', () => {
+    useCanvasStore.setState({ nodes: [node('old')], history: { past: [], future: [] } })
+    commitTemplateGraphReplace([node('t1')], [])
+    expect(useCanvasStore.getState().history.past.length).toBe(1)
+  })
+})

--- a/src/canvas/blueprints/commitTemplateGraph.ts
+++ b/src/canvas/blueprints/commitTemplateGraph.ts
@@ -16,16 +16,16 @@
  */
 
 import type { Edge, Node } from '@xyflow/react'
-import { useCanvasStore } from '../store'
 import type { EdgeData } from '../domain/edges'
+import { commitGraphMutation } from '../mutations/commitGraphMutation'
 
 export function commitTemplateGraphReplace(
   nodes: Node[],
   edges: Edge<EdgeData>[],
 ): void {
-  const store = useCanvasStore.getState()
-  store.pushHistory()
-  useCanvasStore.setState({ nodes, edges })
-  // Optional-chained so partial store doubles in tests don't break.
-  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+  // Template insert/replace is a full graph replace. Delegate to the shared
+  // graph-mutation commit so it converges on the same dirty-overlay path as every
+  // other raw-setState graph route (TemplatesPanel merge, …) rather than
+  // re-implementing pushHistory + setState + markDirty here.
+  commitGraphMutation(() => ({ nodes, edges }), { pushHistory: true })
 }

--- a/src/canvas/blueprints/commitTemplateGraph.ts
+++ b/src/canvas/blueprints/commitTemplateGraph.ts
@@ -1,0 +1,31 @@
+/**
+ * commitTemplateGraphReplace — the single canvas-store commit for a template
+ * ("blueprint") graph replace.
+ *
+ * Pushes one history frame, replaces the graph's nodes/edges, then marks the
+ * analysis-freshness overlay dirty. A template insert/replace is an
+ * analysis-affecting graph mutation done via bare setState (it bypasses the store
+ * edit chokepoints), so a retained CEE 'fresh' verdict must be downgraded to
+ * cannot-confirm — otherwise "Start from Template" / replace would leave the
+ * Results panel falsely claiming the prior analysis reflects the new graph.
+ *
+ * Extracted from ReactFlowGraph.insertBlueprint so the freshness-dirty behaviour is
+ * unit-testable without rendering the whole canvas tree. Used by insertBlueprint
+ * ("Start from Template") and — transitively, since it calls insertBlueprint after
+ * pruning the existing template — handleConfirmReplace.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+import { useCanvasStore } from '../store'
+import type { EdgeData } from '../domain/edges'
+
+export function commitTemplateGraphReplace(
+  nodes: Node[],
+  edges: Edge<EdgeData>[],
+): void {
+  const store = useCanvasStore.getState()
+  store.pushHistory()
+  useCanvasStore.setState({ nodes, edges })
+  // Optional-chained so partial store doubles in tests don't break.
+  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+}

--- a/src/canvas/compare-tab/CompareTabBody.tsx
+++ b/src/canvas/compare-tab/CompareTabBody.tsx
@@ -6,6 +6,7 @@
  */
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { useCanvasStore } from '../store'
+import { classifyFreshnessForDisplay } from '../store/analysisFreshness'
 import { useAnalysisSnapshotStore, selectSnapshots } from '../stores/analysisSnapshotStore'
 import { useUIStore } from '../../stores/uiStore'
 import { deriveCompareState } from './deriveCompareState'
@@ -28,7 +29,13 @@ const EXPERT_STORAGE_KEY = 'feature.compareExpert'
 export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
   // Snapshot data
   const snapshots = useAnalysisSnapshotStore(selectSnapshots)
-  const graphIsStale = useCanvasStore(s => s.graphEditedSinceLastRun)
+  // "Results outdated" must reflect the CEE freshness verdict + local dirty
+  // overlay (the shared display semantic being 'changed' — CEE 'stale' OR a
+  // retained-fresh-now-dirtied), NOT the local `graphEditedSinceLastRun` flag,
+  // which would independently fabricate a stale state.
+  const analysisFreshness = useCanvasStore(s => s.analysisFreshness)
+  const analysisFreshnessDirty = useCanvasStore(s => s.analysisFreshnessDirty)
+  const graphIsStale = classifyFreshnessForDisplay(analysisFreshness, analysisFreshnessDirty) === 'changed'
 
   // UI state
   const [preset, setPreset] = useState<RunPreset>('prev')

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.freshness.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.freshness.spec.tsx
@@ -1,0 +1,94 @@
+/**
+ * CompareTabBody — freshness → compareState wiring at the component boundary.
+ *
+ * deriveCompareState (pure) and classifyFreshnessForDisplay (pure) are unit-tested
+ * separately; this locks the wiring CompareTabBody adds: graphIsStale is sourced
+ * from classifyFreshnessForDisplay(analysisFreshness, analysisFreshnessDirty) ===
+ * 'changed', NOT graphEditedSinceLastRun. The heavy child tree is stubbed; Hero
+ * echoes the `state` prop so we can assert the derived CompareState.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { AnalysisSnapshot } from '../types'
+
+// Two snapshots, same winner, 30pp margin → non-stale path resolves to 'improving'.
+const SNAPSHOTS = [
+  { runNumber: 1, winnerId: 'opt-a', winnerProbability: 65, runnerUpProbability: 35 },
+  { runNumber: 2, winnerId: 'opt-a', winnerProbability: 65, runnerUpProbability: 35 },
+] as unknown as AnalysisSnapshot[]
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockCanvasState: any = { analysisFreshness: null, analysisFreshnessDirty: false, selection: { nodeIds: new Set() } }
+
+vi.mock('../../store', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useCanvasStore: (selector: (s: any) => unknown) => selector(mockCanvasState),
+}))
+vi.mock('../../stores/analysisSnapshotStore', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useAnalysisSnapshotStore: (selector: (s: any) => unknown) => selector({ snapshots: SNAPSHOTS }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  selectSnapshots: (s: any) => s.snapshots,
+}))
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector({ activeOutputTab: 'compare' }),
+    { getState: () => ({ setActiveOutputTab: vi.fn() }) },
+  ),
+}))
+vi.mock('../deriveTransitions', () => ({
+  deriveTransitions: () => [],
+  buildCumulativeTransition: () => null,
+}))
+// Stub the heavy child tree; Hero echoes the derived compareState.
+vi.mock('../Hero', () => ({ Hero: ({ state }: { state: string }) => <div data-testid="compare-state">{state}</div> }))
+vi.mock('../TabHeader', () => ({ TabHeader: () => null }))
+vi.mock('../RunSelector', () => ({ RunSelector: () => null }))
+vi.mock('../TrajectorySection', () => ({ TrajectorySection: () => null }))
+vi.mock('../TransitionsSection', () => ({ TransitionsSection: () => null }))
+vi.mock('../CompareFooter', () => ({ CompareFooter: () => null }))
+vi.mock('../EmptyState', () => ({ EmptyState: () => null }))
+
+import { CompareTabBody } from '../CompareTabBody'
+
+const stateText = () => screen.getByTestId('compare-state').textContent
+
+beforeEach(() => {
+  mockCanvasState = { analysisFreshness: null, analysisFreshnessDirty: false, selection: { nodeIds: new Set() } }
+})
+
+describe('CompareTabBody — freshness drives the stale compare state (CEE-sourced)', () => {
+  it('CEE stale verdict → compareState "stale"', () => {
+    mockCanvasState.analysisFreshness = { freshness: 'stale' }
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(stateText()).toBe('stale')
+  })
+
+  it('fresh verdict dirtied by a local edit (changed) → compareState "stale"', () => {
+    mockCanvasState.analysisFreshness = { freshness: 'fresh' }
+    mockCanvasState.analysisFreshnessDirty = true
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(stateText()).toBe('stale')
+  })
+
+  it('CEE-sourced unknown (cannot-confirm) → NOT "stale" (no fabrication)', () => {
+    mockCanvasState.analysisFreshness = { freshness: 'unknown' }
+    mockCanvasState.analysisFreshnessDirty = true
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(stateText()).not.toBe('stale')
+  })
+
+  it('confirmed-fresh verdict (clean) → NOT "stale"', () => {
+    mockCanvasState.analysisFreshness = { freshness: 'fresh' }
+    mockCanvasState.analysisFreshnessDirty = false
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(stateText()).not.toBe('stale')
+  })
+
+  it('no freshness verdict (null) → NOT "stale"', () => {
+    mockCanvasState.analysisFreshness = null
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(stateText()).not.toBe('stale')
+  })
+})

--- a/src/canvas/components/DraftChat.tsx
+++ b/src/canvas/components/DraftChat.tsx
@@ -631,6 +631,10 @@ export function DraftChat() {
       nodes: [...state.nodes, ...nodes],
       edges: [...state.edges, ...edges],
     })
+    // Draft append mutates the graph via bare setState (bypasses the edit
+    // chokepoints) → mark the freshness overlay dirty. Routed through
+    // setAnalysisFreshness below, which clears it only on a genuine fresh verdict.
+    useCanvasStore.getState().markAnalysisFreshnessDirty?.()
     // Always apply layout for AI drafts since all nodes start at (0,0)
     // This ensures proper positioning whether starting fresh or replacing an existing graph
     if (import.meta.env.DEV) {
@@ -776,6 +780,10 @@ export function DraftChat() {
     // because it also captures ceeAnalysisReadyNodeIds and persists to sessionStorage.
     if (resolvedAnalysisReady) {
       useCanvasStore.getState().setCeeAnalysisReady(resolvedAnalysisReady)
+      // Route through the freshness source of truth (mirrors applyDraftResult /
+      // accepted patches): a draft carries readiness, usually no `freshness`, so
+      // the reducer degrades to 'unknown' instead of leaving a stale 'fresh'.
+      useCanvasStore.getState().setAnalysisFreshness?.(resolvedAnalysisReady)
     }
 
     // Commit CEE coaching payload (typed, type-guarded by adapter). Null when absent.

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -30,7 +30,7 @@ import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource } from '../store'
-import { resolveDisplayedFreshness } from '../store/analysisFreshness'
+import { resolveDisplayedFreshness, classifyFreshnessForDisplay } from '../store/analysisFreshness'
 import { deriveResultsTabFreshness } from './resultsTabFreshness'
 import { typography, typo } from '../../styles/typography'
 import {
@@ -589,6 +589,11 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const freshnessDirty = useCanvasStore(s => s.analysisFreshnessDirty)
   const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
   const analysisStale = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
+  // Within the not-fresh window, distinguish a model that definitely CHANGED since
+  // the run (CEE 'stale' or a local edit that downgraded a retained 'fresh') from a
+  // CANNOT-CONFIRM state where CEE could not determine freshness — so the stale
+  // banner never claims "you've updated the model" for a CEE-sourced 'unknown'.
+  const analysisChangedSinceRun = classifyFreshnessForDisplay(ceeFreshness, freshnessDirty) === 'changed'
 
   // Build persistence object only when Supabase persistence is active
   const v2Persistence = useMemo<V2RunPersistence | undefined>(() => {
@@ -1989,24 +1994,30 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     </span>
                   </div>
                 )}
-                {/* Brief 4 Task 13: top-level stale card.
-                    Full border-warning/30 + bg-warning/5; the results body
-                    below dims to 0.6 so the user sees stale data but can't
-                    miss that it's stale. Scroll and selection remain usable
-                    (no pointer-events:none) — only mutation affordances are
-                    disabled inside ResultsBody via aria-disabled. */}
+                {/* Brief 4 Task 13: top-level "results may be outdated" card.
+                    Shows when the analysis is not confirmed-fresh; the results body
+                    below dims to 0.6 so the user can't miss it. Scroll and selection
+                    remain usable (no pointer-events:none) — only mutation affordances
+                    are disabled inside ResultsBody via aria-disabled.
+                    Header copy distinguishes a model that definitely CHANGED since the
+                    run (CEE 'stale' or a local edit) from a CANNOT-CONFIRM state (CEE
+                    could not determine freshness) — the latter must not claim the user
+                    edited the model. */}
                 {analysisStale && !isError && report && (
                   <div
                     className="px-3 py-2.5 rounded-lg border border-warning/30"
                     style={{ backgroundColor: 'rgb(255 166 86 / 0.05)' }}
                     role="status"
                     data-testid="graph-stale-banner"
+                    data-banner-variant={analysisChangedSinceRun ? 'changed' : 'cannot-confirm'}
                   >
                     <div className="flex items-start gap-2">
                       <AlertTriangle size={14} className="text-warning flex-shrink-0 mt-1" aria-hidden="true" />
                       <div className="flex-1 min-w-0">
                         <p className={`${typography.panelHeader} text-text-header`}>
-                          You've updated the model since this analysis ran
+                          {analysisChangedSinceRun
+                            ? "You've updated the model since this analysis ran"
+                            : "Can't confirm this analysis is current"}
                         </p>
                         <p className={`${typography.panelBody} text-text-light`}>
                           Results may not reflect your current graph.

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -30,6 +30,7 @@ import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource } from '../store'
+import { resolveDisplayedFreshness } from '../store/analysisFreshness'
 import { typography, typo } from '../../styles/typography'
 import {
   trackCompareOpened,
@@ -576,9 +577,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     isPersistenceActive: _isPersistenceActive,
   } = useScenario()
 
-  // C.1b: Show stale banner whenever graph is edited after a completed run,
-  // regardless of whether Supabase persistence is active (canvas store is unconditional)
-  const analysisStale = useCanvasStore(s => s.graphEditedSinceLastRun)
+  // Results-surface staleness is driven by the CEE freshness slice (the single
+  // source of truth) via the same fresh→unknown dirty rule as AnalysisFreshnessNotice
+  // — NOT by the local `graphEditedSinceLastRun` flag, which fabricated 'stale' and
+  // could contradict the CEE-only notice (e.g. a validated patch + CEE 'fresh' showed
+  // "reflects the current model" alongside "may not reflect your current graph").
+  // The results may be outdated when the displayed verdict is 'stale' (CEE) or
+  // 'unknown' (cannot-confirm: a local edit downgraded a fresh verdict, or CEE
+  // could not determine freshness). 'fresh'/'none'/null → not stale.
+  const ceeFreshness = useCanvasStore(s => s.analysisFreshness)
+  const freshnessDirty = useCanvasStore(s => s.analysisFreshnessDirty)
+  const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
+  const analysisStale = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
 
   // Build persistence object only when Supabase persistence is active
   const v2Persistence = useMemo<V2RunPersistence | undefined>(() => {

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -588,7 +588,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const ceeFreshness = useCanvasStore(s => s.analysisFreshness)
   const freshnessDirty = useCanvasStore(s => s.analysisFreshnessDirty)
   const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
-  const analysisStale = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
+  const analysisNotConfirmedFresh = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
   // Within the not-fresh window, distinguish a model that definitely CHANGED since
   // the run (CEE 'stale' or a local edit that downgraded a retained 'fresh') from a
   // CANNOT-CONFIRM state where CEE could not determine freshness — so the stale
@@ -2003,7 +2003,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     run (CEE 'stale' or a local edit) from a CANNOT-CONFIRM state (CEE
                     could not determine freshness) — the latter must not claim the user
                     edited the model. */}
-                {analysisStale && !isError && report && (
+                {analysisNotConfirmedFresh && !isError && report && (
                   <div
                     className="px-3 py-2.5 rounded-lg border border-warning/30"
                     style={{ backgroundColor: 'rgb(255 166 86 / 0.05)' }}
@@ -2058,8 +2058,8 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     ====================================================================== */}
                 {!isPreRun && hasInlineSummary && resultsSectionData && (
                   <div
-                    style={{ opacity: analysisStale && !isError ? 0.6 : 1 }}
-                    aria-disabled={analysisStale && !isError ? true : undefined}
+                    style={{ opacity: analysisNotConfirmedFresh && !isError ? 0.6 : 1 }}
+                    aria-disabled={analysisNotConfirmedFresh && !isError ? true : undefined}
                     data-testid="results-body-stale-wrapper"
                   >
                   <ResultsBody
@@ -2098,7 +2098,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     onSetFactorValue={handleTriageSetValue}
                     expertMode={expertMode}
                     nodeValueLookup={nodeValueLookup}
-                    isStale={analysisStale && !isError}
+                    isStale={analysisNotConfirmedFresh && !isError}
                   />
                   </div>
                 )}

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -24,13 +24,14 @@
  */
 
 import { useEffect, useState, useRef, useMemo, useCallback, lazy, Suspense } from 'react'
-import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, XCircle, MessageCircle, MessageSquare, CheckCircle } from 'lucide-react'
+import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, HelpCircle, XCircle, MessageCircle, MessageSquare, CheckCircle } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource } from '../store'
 import { resolveDisplayedFreshness } from '../store/analysisFreshness'
+import { deriveResultsTabFreshness } from './resultsTabFreshness'
 import { typography, typo } from '../../styles/typography'
 import {
   trackCompareOpened,
@@ -50,7 +51,6 @@ import { dockHostsOlumi } from './olumiSurface'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { focusFloating } from '../hooks/useFloatingFocus'
 import { isV5Eligible } from '../../v5/eligibility'
-import { useStaleGuard } from '../ui/inspector-v2/useStaleGuard'
 import { countFactorsToVerify } from './model-tab/utils'
 import { getGoalDirection } from '../utils/getObjectiveText'
 import { deriveVerdict } from '../utils/interpretOutcome'
@@ -1413,10 +1413,19 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     window.addEventListener('mouseup', handleUp)
   }
 
-  // AI panel v2: stale-aware warning indicator on the Results tab label.
+  // AI panel v2: freshness indicator on the Results tab label. Driven by the CEE
+  // freshness verdict + local dirty overlay (displayedFreshness), NOT the legacy
+  // useStaleGuard graph-hash path (_internal.graphHash is never written, so its
+  // isStale can never fire and would contradict the CEE-derived Results state).
   // Strictly FF-gated — no behaviour change when FF_AI_PANEL_V2 is off.
-  const { isStale } = useStaleGuard()
-  const showResultsTabStaleWarning = isAiPanelV2Enabled() && isStale
+  //
+  // It MUST distinguish a genuine CEE 'stale' verdict (warning glyph + stale label)
+  // from the cannot-confirm overlay state ('unknown' — produced when local edits
+  // downgrade a retained 'fresh'), which gets a NEUTRAL glyph + neutral label,
+  // mirroring AnalysisFreshnessNotice. Rendering the stale glyph/label for
+  // cannot-confirm would fabricate 'stale', which the overlay never does.
+  const { reallyStale: resultsTabReallyStale, showIcon: showResultsTabFreshnessIcon } =
+    deriveResultsTabFreshness(isAiPanelV2Enabled(), displayedFreshness)
 
   // Task C: Panel coordination — hide OutputsDock when an overlay panel is active
   const activeRightPanel = useUIStore(s => s.activeRightPanel)
@@ -1510,14 +1519,22 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                       : undefined
                   }
                 >
-                  <span className={`inline-flex items-center gap-1${tab.id === 'results' && showResultsTabStaleWarning ? ' text-warning' : ''}`}>
+                  <span className={`inline-flex items-center gap-1${tab.id === 'results' && resultsTabReallyStale ? ' text-warning' : ''}`}>
                     {tab.label}
-                    {tab.id === 'results' && showResultsTabStaleWarning && (
-                      <AlertTriangle
-                        className="w-3 h-3 text-warning"
-                        aria-label="Analysis is stale"
-                        data-testid="results-tab-stale-icon"
-                      />
+                    {tab.id === 'results' && showResultsTabFreshnessIcon && (
+                      resultsTabReallyStale ? (
+                        <AlertTriangle
+                          className="w-3 h-3 text-warning"
+                          aria-label="Analysis is stale"
+                          data-testid="results-tab-stale-icon"
+                        />
+                      ) : (
+                        <HelpCircle
+                          className="w-3 h-3 text-text-light"
+                          aria-label="Cannot confirm whether this analysis is current."
+                          data-testid="results-tab-cannot-confirm-icon"
+                        />
+                      )
                     )}
                     {tab.id === 'diagnostics' && factorsToVerify > 0 && (
                       <span

--- a/src/canvas/components/StaleAnalysisBadge.tsx
+++ b/src/canvas/components/StaleAnalysisBadge.tsx
@@ -1,22 +1,32 @@
 import { memo, useCallback } from 'react'
 import { typo } from '../../styles/typography'
-import { useStaleGuard } from '../ui/inspector-v2/useStaleGuard'
+import { useCanvasStore } from '../store'
+import { resolveDisplayedFreshness } from '../store/analysisFreshness'
 import { useV2Run } from '../hooks/useV2Run'
 
 /**
- * StaleAnalysisBadge — "Analysis stale · Rerun" above the persistent input
- * strip when the graph hash has diverged from the last analysis hash.
- * Clicking "Rerun" triggers a fresh analysis run.
+ * StaleAnalysisBadge — "Analysis stale · Rerun" above the persistent input strip,
+ * shown only when the CEE analysis verdict is genuinely 'stale'. Clicking "Rerun"
+ * triggers a fresh analysis run.
+ *
+ * Source of truth is the CEE freshness verdict + local dirty overlay
+ * (resolveDisplayedFreshness), NOT the legacy useStaleGuard graph-hash path
+ * (_internal.graphHash is never written, so it could never fire). The badge appears
+ * ONLY on a real CEE 'stale' verdict — the overlay can only downgrade a retained
+ * fresh → 'unknown' (cannot-confirm), never to 'stale', so this copy is never
+ * fabricated. The cannot-confirm state is surfaced on the Results surface instead.
  */
 export const StaleAnalysisBadge = memo(function StaleAnalysisBadge() {
-  const { isStale } = useStaleGuard()
+  const ceeFreshness = useCanvasStore(s => s.analysisFreshness)
+  const freshnessDirty = useCanvasStore(s => s.analysisFreshnessDirty)
+  const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
   const { runV2Analysis } = useV2Run()
 
   const handleRerun = useCallback(() => {
     void runV2Analysis()
   }, [runV2Analysis])
 
-  if (!isStale) return null
+  if (displayedFreshness !== 'stale') return null
 
   return (
     <div

--- a/src/canvas/components/__tests__/SelectionPill.StaleAnalysisBadge.spec.tsx
+++ b/src/canvas/components/__tests__/SelectionPill.StaleAnalysisBadge.spec.tsx
@@ -17,17 +17,10 @@ import { fireEvent, render, screen } from '@testing-library/react'
 
 // Mutable hook mocks the tests reconfigure.
 const selectionState: { value: { id: string; label: string; kind: 'node' | 'edge' } | null } = { value: null }
-const staleState: { analysisState: 'none' | 'current' | 'stale'; isStale: boolean } = {
-  analysisState: 'none',
-  isStale: false,
-}
 const runV2Spy = vi.fn()
 
 vi.mock('../../hooks/useSelectionContext', () => ({
   useSelectionContext: () => selectionState.value,
-}))
-vi.mock('../../ui/inspector-v2/useStaleGuard', () => ({
-  useStaleGuard: () => staleState,
 }))
 vi.mock('../../hooks/useV2Run', () => ({
   useV2Run: () => ({ runV2Analysis: runV2Spy }),
@@ -35,6 +28,7 @@ vi.mock('../../hooks/useV2Run', () => ({
 
 import { SelectionPill } from '../SelectionPill'
 import { StaleAnalysisBadge } from '../StaleAnalysisBadge'
+import { useCanvasStore } from '../../store'
 
 describe('SelectionPill — gap #2', () => {
   it('renders nothing when no element is selected', () => {
@@ -59,21 +53,29 @@ describe('SelectionPill — gap #2', () => {
   })
 })
 
-describe('StaleAnalysisBadge — gap #2', () => {
+describe('StaleAnalysisBadge — gap #2 (CEE-derived, single source)', () => {
+  // The badge now derives from the CEE freshness verdict + local dirty overlay
+  // (resolveDisplayedFreshness), NOT the legacy useStaleGuard graph-hash path.
   beforeEach(() => {
     runV2Spy.mockClear()
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
   })
 
-  it('renders nothing when analysis is not stale', () => {
-    staleState.analysisState = 'none'
-    staleState.isStale = false
+  it('renders nothing when there is no CEE verdict yet', () => {
     const { container } = render(<StaleAnalysisBadge />)
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders "Analysis stale · Rerun" when isStale is true', () => {
-    staleState.analysisState = 'stale'
-    staleState.isStale = true
+  it('renders nothing on a fresh-but-locally-edited verdict (cannot-confirm) — never fabricates stale', () => {
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+    useCanvasStore.getState().markAnalysisFreshnessDirty()
+    // displayed = 'unknown' (cannot-confirm), NOT 'stale' → badge stays hidden.
+    const { container } = render(<StaleAnalysisBadge />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders "Analysis stale · Rerun" only on a genuine CEE stale verdict', () => {
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
     render(<StaleAnalysisBadge />)
     const badge = screen.getByTestId('ai-panel-stale-badge')
     expect(badge).toBeInTheDocument()
@@ -84,13 +86,13 @@ describe('StaleAnalysisBadge — gap #2', () => {
   })
 
   it('clicking Rerun invokes the EXISTING useV2Run() runV2Analysis, not a second path', () => {
-    staleState.isStale = true
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
     render(<StaleAnalysisBadge />)
     fireEvent.click(screen.getByTestId('ai-panel-stale-badge-rerun'))
     expect(runV2Spy).toHaveBeenCalledTimes(1)
-    // The mocked useV2Run hook is the SAME hook called by OutputsDock at
-    // line 404 and ConversationPanel at line 129. The badge holds no
-    // alternative analysis route of its own — it is a thin wrapper over
-    // the canonical run trigger, so green here proves no second route.
+    // The mocked useV2Run hook is the SAME hook called by OutputsDock and
+    // ConversationPanel. The badge holds no alternative analysis route of its
+    // own — it is a thin wrapper over the canonical run trigger, so green here
+    // proves no second route.
   })
 })

--- a/src/canvas/components/__tests__/resultsTabFreshness.spec.ts
+++ b/src/canvas/components/__tests__/resultsTabFreshness.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Results-tab freshness indicator — never fabricates 'stale'.
+ *
+ * Regression for the adversarial finding: the Results-tab icon previously lit the
+ * warning AlertTriangle + aria-label "Analysis is stale" for displayedFreshness
+ * === 'unknown' (the cannot-confirm overlay state), fabricating 'stale' at the
+ * a11y layer. The decision now distinguishes a genuine CEE 'stale' (warning) from
+ * cannot-confirm ('unknown' → neutral), mirroring AnalysisFreshnessNotice.
+ */
+import { describe, it, expect } from 'vitest'
+import { deriveResultsTabFreshness } from '../resultsTabFreshness'
+
+describe('deriveResultsTabFreshness', () => {
+  it('genuine CEE stale → warning icon (reallyStale)', () => {
+    expect(deriveResultsTabFreshness(true, 'stale')).toEqual({
+      reallyStale: true,
+      cannotConfirm: false,
+      showIcon: true,
+    })
+  })
+
+  it('cannot-confirm (unknown) → NEUTRAL icon, never the stale treatment', () => {
+    const r = deriveResultsTabFreshness(true, 'unknown')
+    expect(r).toEqual({ reallyStale: false, cannotConfirm: true, showIcon: true })
+    // The whole point: 'unknown' must NOT map to the stale flag.
+    expect(r.reallyStale).toBe(false)
+  })
+
+  it('fresh → no icon', () => {
+    expect(deriveResultsTabFreshness(true, 'fresh')).toEqual({
+      reallyStale: false,
+      cannotConfirm: false,
+      showIcon: false,
+    })
+  })
+
+  it('none → no icon', () => {
+    expect(deriveResultsTabFreshness(true, 'none')).toEqual({
+      reallyStale: false,
+      cannotConfirm: false,
+      showIcon: false,
+    })
+  })
+
+  it('null verdict (no analysis yet) → no icon', () => {
+    expect(deriveResultsTabFreshness(true, null)).toEqual({
+      reallyStale: false,
+      cannotConfirm: false,
+      showIcon: false,
+    })
+  })
+
+  it('aiPanelV2 disabled → no icon regardless of verdict (FF-gated)', () => {
+    for (const v of ['stale', 'unknown', 'fresh', 'none', null] as const) {
+      expect(deriveResultsTabFreshness(false, v)).toEqual({
+        reallyStale: false,
+        cannotConfirm: false,
+        showIcon: false,
+      })
+    }
+  })
+})

--- a/src/canvas/components/model-tab/ReanalyseBar.tsx
+++ b/src/canvas/components/model-tab/ReanalyseBar.tsx
@@ -1,22 +1,27 @@
 /**
  * ReanalyseBar — sticky bottom bar prompting re-analysis after graph edits.
  *
- * Visible only when graphEditedSinceLastRun === true in canvas store.
- * Triggers onReanalyse() which calls OutputsDock's handleRunAnalysis.
+ * Visible only when the analysis is DEFINITELY out of date — the shared CEE
+ * freshness display semantic (`classifyFreshnessForDisplay`) is 'changed'
+ * (CEE 'stale' OR a retained-fresh-now-dirtied by a local edit), NOT the local
+ * `graphEditedSinceLastRun` flag (which would claim "Model changed" without a
+ * CEE verdict). Triggers onReanalyse() which calls OutputsDock's handleRunAnalysis.
  */
 
 import { RefreshCw } from 'lucide-react'
 import { typography } from '../../../styles/typography'
 import { useCanvasStore } from '../../store'
+import { classifyFreshnessForDisplay } from '../../store/analysisFreshness'
 
 interface ReanalyseBarProps {
   onReanalyse?: () => void
 }
 
 export function ReanalyseBar({ onReanalyse }: ReanalyseBarProps) {
-  const graphEditedSinceLastRun = useCanvasStore(s => s.graphEditedSinceLastRun)
+  const analysisFreshness = useCanvasStore(s => s.analysisFreshness)
+  const analysisFreshnessDirty = useCanvasStore(s => s.analysisFreshnessDirty)
 
-  if (!graphEditedSinceLastRun) return null
+  if (classifyFreshnessForDisplay(analysisFreshness, analysisFreshnessDirty) !== 'changed') return null
 
   return (
     <div

--- a/src/canvas/components/model-tab/__tests__/ReanalyseBar.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/ReanalyseBar.spec.tsx
@@ -1,35 +1,66 @@
 /**
- * ReanalyseBar — unit tests
+ * ReanalyseBar — unit tests.
+ *
+ * The bar now derives visibility from the CEE freshness slice + local dirty
+ * overlay (shared `classifyFreshnessForDisplay` === 'changed'), NOT the local
+ * `graphEditedSinceLastRun` flag. The real classifier runs against the mocked
+ * store slices.
  */
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ReanalyseBar } from '../ReanalyseBar'
 
-let mockGraphEditedSinceLastRun = false
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockFreshness: any = null
+let mockDirty = false
 
 vi.mock('../../../store', () => ({
   useCanvasStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ graphEditedSinceLastRun: mockGraphEditedSinceLastRun })
+    selector({ analysisFreshness: mockFreshness, analysisFreshnessDirty: mockDirty })
   ),
 }))
 
 describe('ReanalyseBar', () => {
-  it('renders nothing when graphEditedSinceLastRun is false', () => {
-    mockGraphEditedSinceLastRun = false
+  it('renders nothing when the analysis is confirmed current (fresh, clean)', () => {
+    mockFreshness = { freshness: 'fresh' }
+    mockDirty = false
     const { container } = render(<ReanalyseBar />)
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders bar when graphEditedSinceLastRun is true', () => {
-    mockGraphEditedSinceLastRun = true
+  it('renders nothing when there is no freshness verdict', () => {
+    mockFreshness = null
+    mockDirty = false
+    const { container } = render(<ReanalyseBar />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing for a CEE cannot-confirm (unknown) verdict — never fabricates "changed"', () => {
+    mockFreshness = { freshness: 'unknown' }
+    mockDirty = false
+    const { container } = render(<ReanalyseBar />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the bar on a genuine CEE stale verdict', () => {
+    mockFreshness = { freshness: 'stale' }
+    mockDirty = false
     render(<ReanalyseBar />)
     expect(screen.getByTestId('reanalyse-bar')).toBeInTheDocument()
     expect(screen.getByText(/Model changed/)).toBeInTheDocument()
   })
 
+  it('renders the bar when a retained fresh verdict is dirtied by a local edit (changed)', () => {
+    mockFreshness = { freshness: 'fresh' }
+    mockDirty = true
+    render(<ReanalyseBar />)
+    expect(screen.getByTestId('reanalyse-bar')).toBeInTheDocument()
+  })
+
   it('calls onReanalyse when button is clicked', () => {
-    mockGraphEditedSinceLastRun = true
+    mockFreshness = { freshness: 'stale' }
+    mockDirty = false
     const onReanalyse = vi.fn()
     render(<ReanalyseBar onReanalyse={onReanalyse} />)
 
@@ -38,7 +69,8 @@ describe('ReanalyseBar', () => {
   })
 
   it('re-analyse button is disabled when onReanalyse is not provided', () => {
-    mockGraphEditedSinceLastRun = true
+    mockFreshness = { freshness: 'stale' }
+    mockDirty = false
     render(<ReanalyseBar />)
     const btn = screen.getByTestId('reanalyse-button')
     expect(btn).toBeDisabled()

--- a/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.statusBanner.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.statusBanner.spec.tsx
@@ -80,6 +80,11 @@ interface MockCanvasState {
   ceeAnalysisReady: { status?: string } | null
   results: { status: string; report: unknown } | null
   graphEditedSinceLastRun: boolean
+  // Freshness now drives the display state (via classifyFreshnessForDisplay);
+  // graphEditedSinceLastRun is retained on the mock but no longer read by the hook.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  analysisFreshness: any
+  analysisFreshnessDirty: boolean
 }
 
 let mockCanvasState: MockCanvasState
@@ -190,6 +195,8 @@ describe('PreAnalysisPanel.StatusBanner — DOM rendering across four helper sta
       ceeAnalysisReady: null,
       results: { status: 'idle', report: null },
       graphEditedSinceLastRun: false,
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
     }
   })
 
@@ -218,7 +225,7 @@ describe('PreAnalysisPanel.StatusBanner — DOM rendering across four helper sta
   it('results_stale: orphan StatusBanner is suppressed (Brief 5.8B D0 #1)', () => {
     mockCanvasState.ceeAnalysisReady = { status: 'ready' }
     mockCanvasState.results = { status: 'complete', report: { option_comparison: [] } }
-    mockCanvasState.graphEditedSinceLastRun = true
+    mockCanvasState.analysisFreshness = { freshness: 'stale' }
     render(<PreAnalysisPanel onAnalyse={vi.fn()} />)
     expect(screen.queryByTestId('pre-analysis-status-banner')).not.toBeInTheDocument()
   })
@@ -249,7 +256,7 @@ describe('PreAnalysisPanel.StatusBanner — DOM rendering across four helper sta
   it('results_stale: footer CTA shows "Rerun analysis"', () => {
     mockCanvasState.ceeAnalysisReady = { status: 'ready' }
     mockCanvasState.results = { status: 'complete', report: { option_comparison: [] } }
-    mockCanvasState.graphEditedSinceLastRun = true
+    mockCanvasState.analysisFreshness = { freshness: 'stale' }
     render(<PreAnalysisPanel onAnalyse={vi.fn()} />)
     // Helper drives the label — stale state surfaces "Rerun analysis"
     expect(
@@ -260,7 +267,7 @@ describe('PreAnalysisPanel.StatusBanner — DOM rendering across four helper sta
   it('results_stale: footer CTA renders the secondary outlined variant', () => {
     mockCanvasState.ceeAnalysisReady = { status: 'ready' }
     mockCanvasState.results = { status: 'complete', report: { option_comparison: [] } }
-    mockCanvasState.graphEditedSinceLastRun = true
+    mockCanvasState.analysisFreshness = { freshness: 'stale' }
     render(<PreAnalysisPanel onAnalyse={vi.fn()} />)
     const button = screen.getByRole('button', { name: /rerun analysis/i })
     // Variant is exposed via data-action-variant for both DOM tests and
@@ -275,7 +282,7 @@ describe('PreAnalysisPanel.StatusBanner — DOM rendering across four helper sta
   it('results_stale: footer aria-label matches the visible "Rerun analysis"', () => {
     mockCanvasState.ceeAnalysisReady = { status: 'ready' }
     mockCanvasState.results = { status: 'complete', report: { option_comparison: [] } }
-    mockCanvasState.graphEditedSinceLastRun = true
+    mockCanvasState.analysisFreshness = { freshness: 'stale' }
     render(<PreAnalysisPanel onAnalyse={vi.fn()} />)
     const button = screen.getByRole('button', { name: /rerun analysis/i })
     expect(button).toHaveAttribute('aria-label', 'Rerun analysis')

--- a/src/canvas/components/resultsTabFreshness.ts
+++ b/src/canvas/components/resultsTabFreshness.ts
@@ -1,0 +1,35 @@
+/**
+ * Results-tab freshness indicator decision.
+ *
+ * Maps the displayed freshness verdict (CEE verdict + local dirty overlay, via
+ * resolveDisplayedFreshness) to the Results-tab label's icon treatment. Extracted
+ * as a pure function so the "never fabricate stale" rule is explicit and unit-
+ * testable without rendering OutputsDock (which pulls Supabase/ELK/heavy deps).
+ *
+ * The cannot-confirm overlay state ('unknown', produced when local edits downgrade
+ * a retained 'fresh') must NEVER be mapped to the stale glyph/label — that would
+ * fabricate 'stale', which the overlay never produces. It gets a NEUTRAL glyph +
+ * neutral label instead, mirroring AnalysisFreshnessNotice's icon/copy map.
+ * fresh/none → no icon. Gated off entirely when the aiPanelV2 surface is disabled.
+ */
+
+import type { AnalysisFreshnessValue } from '../store/analysisFreshness'
+
+export interface ResultsTabFreshnessIndicator {
+  /** Genuine CEE 'stale' verdict → warning glyph + "Analysis is stale". */
+  reallyStale: boolean
+  /** Cannot-confirm overlay state ('unknown') → NEUTRAL glyph + neutral label. */
+  cannotConfirm: boolean
+  /** Whether to render any freshness icon on the Results tab. */
+  showIcon: boolean
+}
+
+export function deriveResultsTabFreshness(
+  aiPanelV2On: boolean,
+  displayedFreshness: AnalysisFreshnessValue | null,
+): ResultsTabFreshnessIndicator {
+  const f = aiPanelV2On ? displayedFreshness : null
+  const reallyStale = f === 'stale'
+  const cannotConfirm = f === 'unknown'
+  return { reallyStale, cannotConfirm, showIcon: reallyStale || cannotConfirm }
+}

--- a/src/canvas/conversation/ActionStrip.tsx
+++ b/src/canvas/conversation/ActionStrip.tsx
@@ -72,13 +72,12 @@ export function ActionStrip({ messages, patchBlockStates, onNavigate }: ActionSt
   const nodeCount = useCanvasStore((s) => s.nodes.length)
   const resultsStatus = useCanvasStore((s) => s.results.status)
   const hasCompletedFirstRun = useCanvasStore((s) => s.hasCompletedFirstRun)
-  const graphEditedSinceLastRun = useCanvasStore((s) => s.graphEditedSinceLastRun)
-  // P0 V5 golden-path repair (Wave 3 wiring): wire freshness signal
-  // from the most recent CEE turn. When present, takes precedence over
-  // the local edit signal so this surface stays in sync with whatever
-  // the wire said — eliminating the multi-surface drift the brief
-  // flagged.
-  const wireFreshness = useCanvasStore((s) => s.ceeAnalysisReady?.freshness ?? null)
+  // Freshness comes from the CEE slice + local dirty overlay (the shared display
+  // semantic), NOT the dead/local `graphEditedSinceLastRun` flag — so the
+  // "Results outdated" badge stays in sync with the rest of the analysis trust
+  // surface and never independently fabricates stale.
+  const analysisFreshness = useCanvasStore((s) => s.analysisFreshness)
+  const analysisFreshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const guidanceItems = useGuidanceStore((s) => s.guidanceItems)
   const activeGuidanceItemId = useGuidanceStore((s) => s.activeGuidanceItemId)
 
@@ -87,12 +86,12 @@ export function ActionStrip({ messages, patchBlockStates, onNavigate }: ActionSt
     nodeCount,
     resultsStatus,
     hasCompletedFirstRun,
-    graphEditedSinceLastRun,
-    wireFreshness,
+    analysisFreshness,
+    analysisFreshnessDirty,
     guidance: { guidanceItems, activeGuidanceItemId, _sendMessage: null, _scrollToPatch: null },
     messages,
     patchBlockStates,
-  }), [nodeCount, resultsStatus, hasCompletedFirstRun, graphEditedSinceLastRun, wireFreshness, guidanceItems, activeGuidanceItemId, messages, patchBlockStates])
+  }), [nodeCount, resultsStatus, hasCompletedFirstRun, analysisFreshness, analysisFreshnessDirty, guidanceItems, activeGuidanceItemId, messages, patchBlockStates])
 
   const { status, topGuidanceItem, guidanceCount, ctaKind } = useMemo(
     () => selectConversationStatus(input),

--- a/src/canvas/conversation/__tests__/ActionStrip.test.tsx
+++ b/src/canvas/conversation/__tests__/ActionStrip.test.tsx
@@ -45,7 +45,8 @@ beforeEach(() => {
     nodes: [{ id: 'n1', position: { x: 0, y: 0 }, data: {} }] as any,
     results: { status: 'idle', progress: 0 },
     hasCompletedFirstRun: false,
-    graphEditedSinceLastRun: false,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
   })
 })
 
@@ -130,12 +131,13 @@ describe('ActionStrip', () => {
     expect(screen.getByTestId('action-strip-badge')).toHaveTextContent('Analysing\u2026')
   })
 
-  it('state badge shows "Results outdated" when stale', () => {
+  it('state badge shows "Results outdated" when the CEE freshness verdict is stale (changed)', () => {
     useGuidanceStore.getState().setGuidanceItems([makeItem()])
     useCanvasStore.setState({
       results: { status: 'complete', progress: 100 },
       hasCompletedFirstRun: true,
-      graphEditedSinceLastRun: true,
+      analysisFreshness: { freshness: 'stale' } as any,
+      analysisFreshnessDirty: false,
     })
 
     render(

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -46,8 +46,9 @@ function makeChip(overrides: Partial<ActionChip> = {}): ActionChip {
  *   stale         → complete + CEE 'stale'
  *   cannot-confirm→ complete + CEE 'fresh' downgraded by a local edit (dirty)
  *   cee-unknown   → complete + CEE-sourced unknown (cannot confirm, no edit claim)
+ *   no-verdict    → complete but NO freshness verdict at all (legacy / non-CEE run)
  */
-function setAnalysisState(state: 'none' | 'current' | 'stale' | 'cannot-confirm' | 'cee-unknown') {
+function setAnalysisState(state: 'none' | 'current' | 'stale' | 'cannot-confirm' | 'cee-unknown' | 'no-verdict') {
   if (state === 'none') {
     useCanvasStore.setState({
       results: { status: 'idle' } as any,
@@ -61,6 +62,10 @@ function setAnalysisState(state: 'none' | 'current' | 'stale' | 'cannot-confirm'
     analysisFreshness: null,
     analysisFreshnessDirty: false,
   })
+  if (state === 'no-verdict') {
+    // results complete but no analysis_ready freshness ever set → slice stays null.
+    return
+  }
   if (state === 'stale') {
     useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
     return
@@ -141,6 +146,22 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
       />,
     )
     const chip = screen.getByTestId('suggested-chip-cu1')
+    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
+    expect(chip).not.toHaveTextContent(/Run analysis/i)
+  })
+
+  it('relabels to "Rerun" when results are complete but there is NO freshness verdict (not confirmed-current → not suppressed)', () => {
+    // A completed analysis with no freshness verdict is NOT confirmed-current, so
+    // it must keep the rerun affordance rather than be suppressed as if current.
+    // Mirrors useStageAwarePlaceholder, which treats this state as not-"latest".
+    setAnalysisState('no-verdict')
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'nv1', action_type: 'run_analysis', label: 'Run analysis' })]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-nv1')
     expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
     expect(chip).not.toHaveTextContent(/Run analysis/i)
   })

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -150,10 +150,13 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
     expect(chip).not.toHaveTextContent(/Run analysis/i)
   })
 
-  it('relabels to "Rerun" when results are complete but there is NO freshness verdict (not confirmed-current → not suppressed)', () => {
+  it('keeps (does NOT suppress) the run-analysis chip when complete but NO freshness verdict — V5 off, no readiness gate', () => {
     // A completed analysis with no freshness verdict is NOT confirmed-current, so
-    // it must keep the rerun affordance rather than be suppressed as if current.
-    // Mirrors useStageAwarePlaceholder, which treats this state as not-"latest".
+    // it must NOT be suppressed as if current (mirrors useStageAwarePlaceholder,
+    // which treats this state as not-"latest"). It is NOT relabelled to "Rerun"
+    // either — that label carries a readiness-gate bypass reserved for a real
+    // verdict; with no verdict the chip stays a plain 'keep' that the gate governs.
+    // V5 is off in this suite, so no gate applies → the chip renders as-is.
     setAnalysisState('no-verdict')
     render(
       <SuggestedChips
@@ -162,8 +165,8 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
       />,
     )
     const chip = screen.getByTestId('suggested-chip-nv1')
-    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
-    expect(chip).not.toHaveTextContent(/Run analysis/i)
+    expect(chip).toBeInTheDocument() // not suppressed
+    expect(chip).toHaveTextContent(/Run analysis/i) // kept, not relabelled to "Rerun"
   })
 
   it('leaves the Run analysis chip unchanged when no analysis has been run yet', () => {

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -7,8 +7,8 @@
  *                                          (Analysis/readiness panel owns rerun)
  *   - stale / cannot-confirm analysis    → RELABEL to "Rerun"
  *
- * Decision keys off `results.status === 'complete'` + the CEE freshness verdict +
- * local dirty overlay (resolveDisplayedFreshness being 'stale' or 'unknown').
+ * Decision keys off `results.status === 'complete'` + the shared freshness display
+ * semantic (`changed` or `cannot_confirm`).
  * This replaces the legacy `isStale` from useStaleGuard, whose production input
  * `_internal.graphHash` is never written — so the rerun affordance never appeared
  * after a graph edit even though the Results surface showed cannot-confirm.
@@ -45,11 +45,11 @@ function makeChip(overrides: Partial<ActionChip> = {}): ActionChip {
  *   current       → complete + CEE 'fresh', clean
  *   stale         → complete + CEE 'stale'
  *   cannot-confirm→ complete + CEE 'fresh' downgraded by a local edit (dirty)
+ *   cee-unknown   → complete + CEE-sourced unknown (cannot confirm, no edit claim)
  */
-function setAnalysisState(state: 'none' | 'current' | 'stale' | 'cannot-confirm') {
+function setAnalysisState(state: 'none' | 'current' | 'stale' | 'cannot-confirm' | 'cee-unknown') {
   if (state === 'none') {
     useCanvasStore.setState({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       results: { status: 'idle' } as any,
       analysisFreshness: null,
       analysisFreshnessDirty: false,
@@ -57,13 +57,16 @@ function setAnalysisState(state: 'none' | 'current' | 'stale' | 'cannot-confirm'
     return
   }
   useCanvasStore.setState({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     results: { status: 'complete', graphHash: 'abc123' } as any,
     analysisFreshness: null,
     analysisFreshnessDirty: false,
   })
   if (state === 'stale') {
     useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
+    return
+  }
+  if (state === 'cee-unknown') {
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'unknown', freshness_reason: 'no_hash' })
     return
   }
   // current + cannot-confirm both start from a CEE 'fresh' verdict.
@@ -125,6 +128,19 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
       />,
     )
     const chip = screen.getByTestId('suggested-chip-cc1')
+    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
+    expect(chip).not.toHaveTextContent(/Run analysis/i)
+  })
+
+  it('relabels to "Rerun" when CEE reports cannot-confirm freshness', () => {
+    setAnalysisState('cee-unknown')
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'cu1', action_type: 'run_analysis', label: 'Run analysis' })]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-cu1')
     expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
     expect(chip).not.toHaveTextContent(/Run analysis/i)
   })
@@ -289,9 +305,9 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
   })
 
   // V5 readiness gate previously filtered run_analysis when status !==
-  // 'ready'. Stale analysis (graph drifted since last run) maps to
-  // status !== 'ready', so the chip was dropped upstream and the polish
-  // never saw it. The aiPanelV2 bypass keeps it alive to be relabelled.
+  // 'ready'. Stale/cannot-confirm analysis can map to status !== 'ready', so
+  // the chip was dropped upstream and the polish never saw it. The aiPanelV2
+  // bypass keeps it alive to be relabelled.
   it('V5-on stale: run_analysis survives readiness gate and is relabelled to "Rerun"', () => {
     // Enable V5 so the readiness filter is active.
     vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
@@ -300,7 +316,6 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
     // ceeAnalysisReady is null / not 'ready' — this is the V5 path that
     // would normally filter out the run_analysis chip BEFORE the polish.
     useCanvasStore.setState({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ceeAnalysisReady: null as any,
     })
     render(
@@ -327,7 +342,6 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
     vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
     setAnalysisState('current')
     useCanvasStore.setState({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ceeAnalysisReady: {
         goal_node_id: 'g',
         status: 'ready',
@@ -352,7 +366,7 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
 
   // Reviewer amendment: regression should pin the exact product-rule
   // matrix, regardless of internal predicate names.
-  it('product rule: none → keep, current → suppress, stale → Rerun', () => {
+  it('product rule: none → keep, current → suppress, stale/cannot-confirm → Rerun', () => {
     const fixture = () =>
       makeChip({
         id: 'matrix',
@@ -377,12 +391,15 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
     expect(screen.queryByTestId('suggested-chip-matrix')).toBeNull()
     u2()
 
-    // stale
-    setAnalysisState('stale')
-    render(
-      <SuggestedChips chips={[fixture()]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
-    )
-    expect(screen.getByTestId('suggested-chip-matrix')).toHaveTextContent(/^\s*Rerun\s*$/i)
+    // stale / cannot-confirm
+    for (const state of ['stale', 'cannot-confirm', 'cee-unknown'] as const) {
+      setAnalysisState(state)
+      const { unmount } = render(
+        <SuggestedChips chips={[fixture()]} onChipClick={vi.fn().mockResolvedValue(undefined)} />,
+      )
+      expect(screen.getByTestId('suggested-chip-matrix')).toHaveTextContent(/^\s*Rerun\s*$/i)
+      unmount()
+    }
   })
 })
 

--- a/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.aiPanelV2Polish.spec.tsx
@@ -2,14 +2,16 @@
  * aiPanelV2 UX polish — Run analysis chip suppression/relabel.
  *
  * Product rule (only when aiPanelV2 is ON):
- *   - no analysis exists       → keep chip as-is ("Run analysis")
- *   - current analysis exists  → SUPPRESS chip entirely
- *                                (Analysis/readiness panel owns rerun)
- *   - stale analysis exists    → RELABEL to "Rerun"
+ *   - no analysis exists                 → keep chip as-is ("Run analysis")
+ *   - confirmed-current analysis exists  → SUPPRESS chip entirely
+ *                                          (Analysis/readiness panel owns rerun)
+ *   - stale / cannot-confirm analysis    → RELABEL to "Rerun"
  *
- * Decision keys off `results.status === 'complete'` + `isStale` from the
- * stale guard. This is the loosened path — the old `analysisState ===
- * 'current'` predicate raced on staging when the hash compare lagged.
+ * Decision keys off `results.status === 'complete'` + the CEE freshness verdict +
+ * local dirty overlay (resolveDisplayedFreshness being 'stale' or 'unknown').
+ * This replaces the legacy `isStale` from useStaleGuard, whose production input
+ * `_internal.graphHash` is never written — so the rerun affordance never appeared
+ * after a graph edit even though the Results surface showed cannot-confirm.
  *
  * Detection covers both V2 chips (`action_type === 'run_analysis'`) and
  * legacy / prompt-style chips matched by the tolerant regex
@@ -36,23 +38,39 @@ function makeChip(overrides: Partial<ActionChip> = {}): ActionChip {
   }
 }
 
-/** Drive useStaleGuard's three return shapes via the canvas store. */
-function setAnalysisState(state: 'none' | 'current' | 'stale') {
+/**
+ * Drive the run-analysis polish input via the CEE freshness verdict + dirty
+ * overlay (the production source), NOT the dead useStaleGuard graph-hash path.
+ *   none          → no analysis (idle, no verdict)
+ *   current       → complete + CEE 'fresh', clean
+ *   stale         → complete + CEE 'stale'
+ *   cannot-confirm→ complete + CEE 'fresh' downgraded by a local edit (dirty)
+ */
+function setAnalysisState(state: 'none' | 'current' | 'stale' | 'cannot-confirm') {
   if (state === 'none') {
     useCanvasStore.setState({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       results: { status: 'idle' } as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      _internal: { graphHash: undefined } as any,
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
     })
     return
   }
   useCanvasStore.setState({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     results: { status: 'complete', graphHash: 'abc123' } as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    _internal: { graphHash: state === 'current' ? 'abc123' : 'xyz999' } as any,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
   })
+  if (state === 'stale') {
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
+    return
+  }
+  // current + cannot-confirm both start from a CEE 'fresh' verdict.
+  useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+  if (state === 'cannot-confirm') {
+    useCanvasStore.getState().markAnalysisFreshnessDirty()
+  }
 }
 
 describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
@@ -92,6 +110,21 @@ describe('SuggestedChips — aiPanelV2 Run analysis polish', () => {
       />,
     )
     const chip = screen.getByTestId('suggested-chip-r1')
+    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
+    expect(chip).not.toHaveTextContent(/Run analysis/i)
+  })
+
+  it('relabels to "Rerun" when a fresh analysis is cannot-confirm after a local edit', () => {
+    // The key production regression: before, isStale (dead useStaleGuard) never
+    // fired, so a post-edit cannot-confirm state kept the rerun chip suppressed.
+    setAnalysisState('cannot-confirm')
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'cc1', action_type: 'run_analysis', label: 'Run analysis' })]}
+        onChipClick={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-cc1')
     expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
     expect(chip).not.toHaveTextContent(/Run analysis/i)
   })

--- a/src/canvas/conversation/__tests__/SuggestedChips.readinessGate.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.readinessGate.spec.tsx
@@ -216,6 +216,66 @@ describe('SuggestedChips readiness gate', () => {
   })
 })
 
+// The aiPanelV2 'relabel-rerun' polish bypasses the readiness gate so a stale /
+// cannot-confirm analysis can still offer "Rerun". A completed analysis with NO
+// freshness verdict must NOT get that bypass (there is no rerunnable analysis —
+// a click would fall back to a conversation turn), while a real cannot-confirm
+// verdict (rerun-after-edit) still must.
+describe('SuggestedChips readiness gate — complete results, no freshness verdict (no bypass)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+    try { localStorage.setItem('feature.aiPanelV2', 'true') } catch { /* jsdom */ }
+    // Completed run, readiness MISSING (ceeAnalysisReady null → analysisStatus !== 'ready').
+    useCanvasStore.setState({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      results: { status: 'complete', graphHash: 'h' } as any,
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ceeAnalysisReady: null as any,
+    })
+  })
+  afterEach(() => {
+    try { localStorage.removeItem('feature.aiPanelV2') } catch { /* jsdom */ }
+    vi.unstubAllEnvs()
+    useCanvasStore.setState({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      results: { status: 'idle' } as any,
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ceeAnalysisReady: null as any,
+    })
+  })
+
+  it('HIDES run_analysis when complete + no freshness verdict + readiness missing (does not bypass the gate)', () => {
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'nv', action_type: 'run_analysis' })]}
+        onChipClick={vi.fn()}
+      />,
+    )
+    // No verdict → polish 'keep' → subject to the gate → filtered (status !== ready).
+    expect(screen.queryByTestId('suggested-chip-nv')).toBeNull()
+  })
+
+  it('STILL bypasses for a real cannot-confirm verdict (rerun-after-edit) even when readiness is missing', () => {
+    // A retained 'fresh' verdict downgraded by a local edit = cannot-confirm. The
+    // graph was analysis-ready; a rerun re-derives inputs, so the bypass is correct.
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+    useCanvasStore.getState().markAnalysisFreshnessDirty()
+    render(
+      <SuggestedChips
+        chips={[makeChip({ id: 'cc', action_type: 'run_analysis', label: 'Run analysis' })]}
+        onChipClick={vi.fn()}
+      />,
+    )
+    const chip = screen.getByTestId('suggested-chip-cc')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveTextContent(/^\s*Rerun\s*$/i)
+  })
+})
+
 describe('SuggestedChips double-click safety', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')

--- a/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
+++ b/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
@@ -160,17 +160,46 @@ describe('applyAutoApplyPatch — freshness dirty overlay (#3 auto-apply path)',
     expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled()
   })
 
-  it('marks dirty on a modify-only batch (modifiedIds > 0, no adds) — pins the OR-guard disjunct', () => {
+  it('marks dirty on a modify-only batch that changes an ANALYTICAL field (no adds) — pins the OR-guard disjunct', () => {
     storeState.nodes = [
-      { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Price', kind: 'factor' } },
+      { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Price', kind: 'factor', observedState: { value: 100 } } },
     ]
     const patch = makePatchBlock([
-      op('update_node', 'fac-1', { label: 'Unit price' }),
+      // observed_state is analysis-affecting (the V2 adapter forwards it to PLoT).
+      op('update_node', 'fac-1', { observed_state: { value: 200 } }),
     ])
     const result = applyAutoApplyPatch(patch)
     expect(result.addedNodeCount).toBe(0)
     expect(result.modifiedIds.length).toBeGreaterThan(0)
     expect(mocks.markAnalysisFreshnessDirty).toHaveBeenCalled()
+  })
+
+  // P1: cosmetic-only edits are NOT analysis-affecting — a label/body rename must
+  // not fabricate a persistent 'unknown'. The shared analyticalChange taxonomy
+  // excludes label, so the patch path matches the store edit chokepoints exactly.
+  it('does NOT dirty a label-only (cosmetic) update_node despite modifiedIds > 0', () => {
+    storeState.nodes = [
+      { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Price', kind: 'factor' } },
+    ]
+    const patch = makePatchBlock([op('update_node', 'fac-1', { label: 'Unit price' })])
+    const result = applyAutoApplyPatch(patch)
+    expect(result.modifiedIds.length).toBeGreaterThan(0) // id was pushed...
+    expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled() // ...but only cosmetic
+  })
+
+  // P1: a re-normalised structured field that is a NEW object reference with
+  // IDENTICAL content (e.g. CEE re-emitting the same observed_state, keys reordered)
+  // is a shallow-reference difference, not a value change — semantic comparison must
+  // treat it as a no-op so it does not over-dirty.
+  it('does NOT dirty a same-content observed_state re-send (shallow-reference, not a value change)', () => {
+    storeState.nodes = [
+      { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Price', kind: 'factor', observedState: { value: 100, unit: 'USD' } } },
+    ]
+    // New object literal, identical content, keys in a different order.
+    const patch = makePatchBlock([op('update_node', 'fac-1', { observed_state: { unit: 'USD', value: 100 } })])
+    const result = applyAutoApplyPatch(patch)
+    expect(result.modifiedIds.length).toBeGreaterThan(0)
+    expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled()
   })
 
   // P1: dirty must reflect an ACTUAL graph delta, not the inflated modifiedIds

--- a/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
+++ b/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
@@ -34,6 +34,7 @@ const mocks = {
   setPendingLayout: vi.fn(),
   setOutcomeNode: vi.fn(),
   pushHistory: vi.fn(),
+  markAnalysisFreshnessDirty: vi.fn(),
 }
 
 vi.mock('../../store', () => ({
@@ -44,6 +45,7 @@ vi.mock('../../store', () => ({
       setPendingLayout: mocks.setPendingLayout,
       setOutcomeNode: mocks.setOutcomeNode,
       pushHistory: mocks.pushHistory,
+      markAnalysisFreshnessDirty: mocks.markAnalysisFreshnessDirty,
     }),
     setState: (update: any) => {
       if (update.nodes !== undefined) storeState.nodes = update.nodes
@@ -134,6 +136,19 @@ describe('sortPatchOperations', () => {
 // ---------------------------------------------------------------------------
 // applyAutoApplyPatch — node insertion
 // ---------------------------------------------------------------------------
+
+describe('applyAutoApplyPatch — freshness dirty overlay (#3 auto-apply path)', () => {
+  it('marks the freshness overlay dirty after an op-replay graph mutation', () => {
+    const patch = makePatchBlock([
+      op('add_node', 'factor-1', { kind: 'factor', label: 'Market size' }),
+    ])
+    applyAutoApplyPatch(patch)
+    // Auto-apply / op-replay bypasses the edit chokepoints (bare setState), so the
+    // overlay must be marked dirty here; applyAnalysisReadyPatch (run after accept)
+    // clears it iff the patch supplies a fresh new verdict.
+    expect(mocks.markAnalysisFreshnessDirty).toHaveBeenCalled()
+  })
+})
 
 describe('applyAutoApplyPatch — node insertion', () => {
   it('inserts nodes with correct IDs and types from kind field', () => {

--- a/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
+++ b/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
@@ -148,6 +148,17 @@ describe('applyAutoApplyPatch — freshness dirty overlay (#3 auto-apply path)',
     // clears it iff the patch supplies a fresh new verdict.
     expect(mocks.markAnalysisFreshnessDirty).toHaveBeenCalled()
   })
+
+  it('does NOT dirty when the op batch is a no-op (all ops skipped → nothing mutated)', () => {
+    // A fully-rejected / no-op batch must not create a spurious persistent 'unknown'.
+    const patch = makePatchBlock([
+      { op: 'add_node', target_id: '', data: { kind: 'factor', label: 'No ID' } }, // skipped (empty id)
+    ])
+    const result = applyAutoApplyPatch(patch)
+    expect(result.addedNodeCount).toBe(0)
+    expect(result.modifiedIds).toHaveLength(0)
+    expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled()
+  })
 })
 
 describe('applyAutoApplyPatch — node insertion', () => {

--- a/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
+++ b/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
@@ -159,6 +159,19 @@ describe('applyAutoApplyPatch — freshness dirty overlay (#3 auto-apply path)',
     expect(result.modifiedIds).toHaveLength(0)
     expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled()
   })
+
+  it('marks dirty on a modify-only batch (modifiedIds > 0, no adds) — pins the OR-guard disjunct', () => {
+    storeState.nodes = [
+      { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Price', kind: 'factor' } },
+    ]
+    const patch = makePatchBlock([
+      op('update_node', 'fac-1', { label: 'Unit price' }),
+    ])
+    const result = applyAutoApplyPatch(patch)
+    expect(result.addedNodeCount).toBe(0)
+    expect(result.modifiedIds.length).toBeGreaterThan(0)
+    expect(mocks.markAnalysisFreshnessDirty).toHaveBeenCalled()
+  })
 })
 
 describe('applyAutoApplyPatch — node insertion', () => {

--- a/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
+++ b/src/canvas/conversation/__tests__/autoApplyPatch.spec.ts
@@ -172,6 +172,34 @@ describe('applyAutoApplyPatch — freshness dirty overlay (#3 auto-apply path)',
     expect(result.modifiedIds.length).toBeGreaterThan(0)
     expect(mocks.markAnalysisFreshnessDirty).toHaveBeenCalled()
   })
+
+  // P1: dirty must reflect an ACTUAL graph delta, not the inflated modifiedIds
+  // (every update/remove op pushes an id before confirming a real change).
+  it('does NOT dirty a same-value update_node (no real delta despite modifiedIds > 0)', () => {
+    storeState.nodes = [
+      { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Price', kind: 'factor' } },
+    ]
+    const patch = makePatchBlock([op('update_node', 'fac-1', { label: 'Price' })]) // same value
+    const result = applyAutoApplyPatch(patch)
+    expect(result.modifiedIds.length).toBeGreaterThan(0) // id was pushed...
+    expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled() // ...but nothing changed
+  })
+
+  it('does NOT dirty an update_node for an absent target', () => {
+    storeState.nodes = []
+    const patch = makePatchBlock([op('update_node', 'ghost', { label: 'X' })])
+    const result = applyAutoApplyPatch(patch)
+    expect(result.modifiedIds.length).toBeGreaterThan(0)
+    expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled()
+  })
+
+  it('does NOT dirty a remove_node for an absent target', () => {
+    storeState.nodes = []
+    const patch = makePatchBlock([{ op: 'remove_node', target_id: 'ghost', data: {} }])
+    const result = applyAutoApplyPatch(patch)
+    expect(result.modifiedIds.length).toBeGreaterThan(0)
+    expect(mocks.markAnalysisFreshnessDirty).not.toHaveBeenCalled()
+  })
 })
 
 describe('applyAutoApplyPatch — node insertion', () => {

--- a/src/canvas/conversation/__tests__/selectors.test.ts
+++ b/src/canvas/conversation/__tests__/selectors.test.ts
@@ -33,7 +33,8 @@ function makeInput(overrides: Partial<ConversationStatusInput> = {}): Conversati
     nodeCount: 0,
     resultsStatus: 'idle',
     hasCompletedFirstRun: false,
-    graphEditedSinceLastRun: false,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
     guidance: {
       guidanceItems: [],
       activeGuidanceItemId: null,
@@ -133,23 +134,23 @@ describe('selectConversationStatus', () => {
     expect(result.status).toBe('analysis_running')
   })
 
-  it('returns analysis_ready when complete and not stale', () => {
+  it('returns analysis_ready when complete and freshness is current', () => {
     const result = selectConversationStatus(makeInput({
       nodeCount: 3,
       resultsStatus: 'complete',
       hasCompletedFirstRun: true,
-      graphEditedSinceLastRun: false,
+      analysisFreshness: { freshness: 'fresh' },
     }))
     expect(result.status).toBe('analysis_ready')
     expect(result.ctaKind).toBe('view_results')
   })
 
-  it('returns analysis_stale when graph edited since last run', () => {
+  it('returns analysis_stale when the CEE freshness verdict is stale (changed)', () => {
     const result = selectConversationStatus(makeInput({
       nodeCount: 3,
       resultsStatus: 'complete',
       hasCompletedFirstRun: true,
-      graphEditedSinceLastRun: true,
+      analysisFreshness: { freshness: 'stale' },
     }))
     expect(result.status).toBe('analysis_stale')
     expect(result.ctaKind).toBe('view_results')
@@ -217,7 +218,7 @@ describe('selectConversationStatus', () => {
       nodeCount: 3,
       resultsStatus: 'complete',
       hasCompletedFirstRun: true,
-      graphEditedSinceLastRun: false,
+      analysisFreshness: { freshness: 'fresh' },
     })).ctaKind).toBe('view_results')
 
     // brief_ready → view_brief
@@ -233,63 +234,72 @@ describe('selectConversationStatus', () => {
     })).ctaKind).toBeNull()
   })
 
-  // P0 V5 golden-path repair (Wave 3 wiring): wire freshness wins over
-  // local edit signal. Pin the precedence so future changes don't drift
-  // back to local-only derivation.
-  describe('wire freshness precedence (Wave 3)', () => {
-    it('wireFreshness="stale" → analysis_stale even when local says no edits', () => {
+  // Single source of truth: staleness is the CEE freshness verdict + local dirty
+  // overlay via classifyFreshnessForDisplay (=== 'changed'). Pin the mapping so it
+  // never drifts back to independently deriving stale from graphEditedSinceLastRun.
+  describe('freshness classifier (single source)', () => {
+    it('CEE stale verdict → analysis_stale', () => {
       const result = selectConversationStatus(
         makeInput({
           nodeCount: 5,
           resultsStatus: 'complete',
           hasCompletedFirstRun: true,
-          graphEditedSinceLastRun: false,
-          wireFreshness: 'stale',
+          analysisFreshness: { freshness: 'stale' },
         }),
       )
       expect(result.status).toBe('analysis_stale')
     })
 
-    it('wireFreshness="fresh" → analysis_ready even when local says edited', () => {
-      // Pre-Wave-3, the local signal alone would have flagged this as
-      // stale. The wire is authoritative — the round-trip already
-      // absorbed the edit.
+    it('CEE fresh + clean → analysis_ready', () => {
       const result = selectConversationStatus(
         makeInput({
           nodeCount: 5,
           resultsStatus: 'complete',
           hasCompletedFirstRun: true,
-          graphEditedSinceLastRun: true,
-          wireFreshness: 'fresh',
+          analysisFreshness: { freshness: 'fresh' },
+          analysisFreshnessDirty: false,
         }),
       )
       expect(result.status).toBe('analysis_ready')
     })
 
-    it('wireFreshness="unknown" or absent → falls back to local edit signal', () => {
-      // Unknown is CEE saying "I couldn't decide". Local signal then
-      // takes over, preserving pre-Wave-3 behaviour for legacy turns.
-      const stale = selectConversationStatus(
+    it('CEE fresh downgraded by a local edit (dirty) → analysis_stale (changed)', () => {
+      // The dirty overlay correctly flags a model edited since the fresh verdict.
+      const result = selectConversationStatus(
         makeInput({
           nodeCount: 5,
           resultsStatus: 'complete',
           hasCompletedFirstRun: true,
-          graphEditedSinceLastRun: true,
-          wireFreshness: 'unknown',
+          analysisFreshness: { freshness: 'fresh' },
+          analysisFreshnessDirty: true,
         }),
       )
-      expect(stale.status).toBe('analysis_stale')
+      expect(result.status).toBe('analysis_stale')
+    })
 
-      const ready = selectConversationStatus(
+    it('CEE-sourced unknown (cannot-confirm) → analysis_ready, NOT analysis_stale (no fabrication)', () => {
+      const result = selectConversationStatus(
         makeInput({
           nodeCount: 5,
           resultsStatus: 'complete',
           hasCompletedFirstRun: true,
-          graphEditedSinceLastRun: false,
-          wireFreshness: null,
+          analysisFreshness: { freshness: 'unknown' },
+          analysisFreshnessDirty: true,
         }),
       )
-      expect(ready.status).toBe('analysis_ready')
+      expect(result.status).toBe('analysis_ready')
+    })
+
+    it('no freshness verdict + complete → analysis_ready', () => {
+      const result = selectConversationStatus(
+        makeInput({
+          nodeCount: 5,
+          resultsStatus: 'complete',
+          hasCompletedFirstRun: true,
+          analysisFreshness: null,
+        }),
+      )
+      expect(result.status).toBe('analysis_ready')
     })
   })
 })

--- a/src/canvas/conversation/selectors.ts
+++ b/src/canvas/conversation/selectors.ts
@@ -10,6 +10,7 @@ import { selectTopItem } from '../stores/guidanceStore'
 import type { GuidanceState } from '../stores/guidanceStore'
 import type { ConversationMessage, GraphPatchBlock } from './types'
 import type { PatchBlockState } from './useConversation'
+import { classifyFreshnessForDisplay, type AnalysisFreshnessState } from '../store/analysisFreshness'
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -50,18 +51,16 @@ export interface ConversationStatusInput {
   resultsStatus: 'idle' | 'preparing' | 'connecting' | 'streaming' | 'complete' | 'error' | 'cancelled'
   /** Whether analysis has completed at least once this session */
   hasCompletedFirstRun: boolean
-  /** Whether the graph has been structurally edited since the last completed analysis */
-  graphEditedSinceLastRun: boolean
   /**
-   * P0 V5 golden-path repair (Wave 3 wiring): authoritative wire-side
-   * freshness verdict from the most recent CEE turn response. When
-   * present and informative ('fresh' | 'stale'), takes precedence over
-   * `graphEditedSinceLastRun` — the wire is computed against the
-   * canonical graph hash at the time analysis ran, so it's the
-   * authoritative answer when both signals disagree. `null` /
-   * undefined / 'unknown' / 'none' fall back to the local signal.
+   * CEE freshness slice + local dirty overlay — the single source the visible
+   * "Results outdated" status derives from, via `classifyFreshnessForDisplay`
+   * (=== 'changed'). Replaces the old `graphEditedSinceLastRun` / `wireFreshness`
+   * pair: the slice IS the retained CEE wire verdict, and the classifier folds
+   * in the dirty overlay, so this surface never independently derives stale from
+   * the local edit flag, and a CEE-unknown verdict never fabricates 'outdated'.
    */
-  wireFreshness?: 'fresh' | 'stale' | 'unknown' | 'none' | null
+  analysisFreshness: AnalysisFreshnessState | null
+  analysisFreshnessDirty: boolean
   /** Guidance store state snapshot */
   guidance: GuidanceState
   /** Conversation messages */
@@ -132,23 +131,19 @@ export function selectConversationStatus(input: ConversationStatusInput): Conver
     nodeCount,
     resultsStatus,
     hasCompletedFirstRun,
-    graphEditedSinceLastRun,
-    wireFreshness,
+    analysisFreshness,
+    analysisFreshnessDirty,
     guidance,
     messages,
     patchBlockStates,
   } = input
 
-  // P0 V5 golden-path repair (Wave 3 wiring): authoritative staleness
-  // signal. Wire freshness wins when present and informative; local
-  // edit signal is fallback. Eliminates the disagreement between
-  // surfaces that pre-Wave-3 derived staleness independently.
-  const isStale =
-    wireFreshness === 'fresh'
-      ? false
-      : wireFreshness === 'stale'
-        ? true
-        : graphEditedSinceLastRun
+  // Single source of truth: the CEE freshness verdict + local dirty overlay via
+  // the shared display semantic. 'changed' (CEE 'stale' OR a retained-fresh-now-
+  // dirtied) is the only state that renders "Results outdated"; 'cannot_confirm'
+  // (CEE-unknown) and 'current'/'none' do not — so this surface never fabricates
+  // stale, and never independently derives it from `graphEditedSinceLastRun`.
+  const isStale = classifyFreshnessForDisplay(analysisFreshness, analysisFreshnessDirty) === 'changed'
 
   const topGuidanceItem = selectTopItem(guidance)
   const guidanceCount = guidance.guidanceItems.length

--- a/src/canvas/conversation/selectors.ts
+++ b/src/canvas/conversation/selectors.ts
@@ -166,8 +166,8 @@ export function selectConversationStatus(input: ConversationStatusInput): Conver
     return { status: 'brief_ready', topGuidanceItem, guidanceCount, ctaKind: 'view_brief' }
   }
 
-  // Analysis completed — check staleness via the unified isStale signal
-  // above (wire freshness wins, local edit signal is fallback).
+  // Analysis completed — check staleness via the CEE-derived isStale signal
+  // above (classifyFreshnessForDisplay === 'changed'; no local-flag fallback).
   if (hasCompletedFirstRun && resultsStatus === 'complete') {
     if (isStale) {
       return { status: 'analysis_stale', topGuidanceItem, guidanceCount, ctaKind: 'view_results' }

--- a/src/canvas/conversation/utils/__tests__/mirrorAnalysisReady.spec.ts
+++ b/src/canvas/conversation/utils/__tests__/mirrorAnalysisReady.spec.ts
@@ -2,8 +2,11 @@
  * Tests for mirrorAnalysisReady — shared analysis_ready → store mirroring.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { buildAnalysisReadyPatch } from '../mirrorAnalysisReady'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { buildAnalysisReadyPatch, applyAnalysisReadyPatch } from '../mirrorAnalysisReady'
+import { applyValidatedGraph } from '../applyPatch'
+import { useCanvasStore } from '../../../store'
+import { resolveDisplayedFreshness } from '../../../store/analysisFreshness'
 import type { GraphPatchBlock } from '../../types'
 
 const makeBlock = (overrides: Partial<GraphPatchBlock> = {}): GraphPatchBlock => ({
@@ -41,5 +44,63 @@ describe('buildAnalysisReadyPatch', () => {
     const patch1 = buildAnalysisReadyPatch(block)
     const patch2 = buildAnalysisReadyPatch(block)
     expect(patch1!.ceeAnalysisReady).toBe(patch2!.ceeAnalysisReady)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #3: accepted graph patches route freshness through the source-of-truth reducer
+// and dirty semantic changes. Both manual (ConversationPanel) and auto
+// (useConversation) acceptance funnel through these same primitives —
+// applyValidatedGraph / applyAutoApplyPatch for the mutation and
+// applyAnalysisReadyPatch for the analysis_ready ingress — so exercising them
+// directly covers both paths.
+// ---------------------------------------------------------------------------
+
+describe('applyAnalysisReadyPatch — freshness source of truth', () => {
+  const factorNode = { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'F' } }
+  const displayed = () => {
+    const s = useCanvasStore.getState()
+    return resolveDisplayedFreshness(s.analysisFreshness, s.analysisFreshnessDirty)
+  }
+
+  beforeEach(() => {
+    useCanvasStore.setState({
+      nodes: [],
+      edges: [],
+      history: { past: [], future: [] },
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      ceeAnalysisReady: null,
+    })
+    // Establish a prior 'fresh' verdict (real payload shape).
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+  })
+
+  it('routes a patch analysis_ready.freshness through the freshness reducer (no longer dropped)', () => {
+    applyAnalysisReadyPatch(
+      { ceeAnalysisReady: { options: [], goal_node_id: 'g1', freshness: 'stale', freshness_reason: 'graph_changed' } as any },
+      {},
+    )
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('stale')
+  })
+
+  it('a graph patch with NO accompanying analysis_ready dirties the verdict → unknown (not false-fresh)', () => {
+    // buildAnalysisReadyPatch returns null when the block carries no analysis_ready,
+    // so applyAnalysisReadyPatch never runs — but the graph mutation still dirties.
+    expect(buildAnalysisReadyPatch(makeBlock())).toBeNull()
+    applyValidatedGraph({ nodes: [factorNode], edges: [] })
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('a graph patch WITH a fresh re-analysis clears the overlay → fresh', () => {
+    applyValidatedGraph({ nodes: [factorNode], edges: [] }) // mutation dirties
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    applyAnalysisReadyPatch(
+      { ceeAnalysisReady: { options: [], goal_node_id: 'g1', freshness: 'fresh', freshness_reason: 'reanalysed' } as any },
+      {},
+    )
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+    expect(displayed()).toBe('fresh')
   })
 })

--- a/src/canvas/conversation/utils/__tests__/mirrorAnalysisReady.spec.ts
+++ b/src/canvas/conversation/utils/__tests__/mirrorAnalysisReady.spec.ts
@@ -103,4 +103,36 @@ describe('applyAnalysisReadyPatch — freshness source of truth', () => {
     expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
     expect(displayed()).toBe('fresh')
   })
+
+  it('a FRESH verdict with POPULATED option interventions survives the backfill (no false-dirty)', () => {
+    // Regression: the intervention backfill (batchUpdateNodes) runs AFTER the
+    // fresh verdict is ingested. It writes CEE's own data back onto option nodes
+    // and must NOT re-dirty / wipe the just-set fresh verdict.
+    useCanvasStore.setState({
+      nodes: [{ id: 'opt1', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option 1', kind: 'option' } } as never],
+      edges: [],
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      ceeAnalysisReady: null,
+    })
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: {
+          options: [{ id: 'opt1', label: 'Option 1', interventions: { fac1: { value: 1 } } }],
+          goal_node_id: 'g1',
+          freshness: 'fresh',
+          freshness_reason: 'reanalysed',
+        } as never,
+      },
+      {},
+    )
+    // The backfill ran (interventions written) but the fresh verdict is intact.
+    expect(
+      (useCanvasStore.getState().nodes[0].data as { interventions?: unknown }).interventions,
+    ).toBeDefined()
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('fresh')
+    expect(useCanvasStore.getState().ceeAnalysisReady).not.toBeNull()
+    expect(displayed()).toBe('fresh')
+  })
 })

--- a/src/canvas/conversation/utils/__tests__/mirrorAnalysisReady.spec.ts
+++ b/src/canvas/conversation/utils/__tests__/mirrorAnalysisReady.spec.ts
@@ -104,6 +104,22 @@ describe('applyAnalysisReadyPatch — freshness source of truth', () => {
     expect(displayed()).toBe('fresh')
   })
 
+  it('graph-patch + CEE-fresh → the Results-surface stale chrome is NOT stale (no contradiction with the notice)', () => {
+    // Regression for the dual-staleness contradiction: OutputsDock derives its
+    // stale banner/dimming from the CEE slice (analysisStale = displayed is
+    // 'stale'|'unknown'), NOT graphEditedSinceLastRun. After a validated patch +
+    // CEE 'fresh', the notice shows 'fresh' AND the dock derivation must agree.
+    applyValidatedGraph({ nodes: [factorNode], edges: [] })
+    applyAnalysisReadyPatch(
+      { ceeAnalysisReady: { options: [], goal_node_id: 'g1', freshness: 'fresh', freshness_reason: 'reanalysed' } as any },
+      {},
+    )
+    const display = displayed()
+    expect(display).toBe('fresh')
+    // OutputsDock: const analysisStale = displayed === 'stale' || displayed === 'unknown'
+    expect(display === 'stale' || display === 'unknown').toBe(false)
+  })
+
   it('a FRESH verdict with POPULATED option interventions survives the backfill (no false-dirty)', () => {
     // Regression: the intervention backfill (batchUpdateNodes) runs AFTER the
     // fresh verdict is ingested. It writes CEE's own data back onto option nodes

--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -363,6 +363,12 @@ export function applyAutoApplyPatch(patchBlock: GraphPatchBlock): ApplyPatchResu
     // Non-critical
   }
 
+  // Op-replay graph mutation bypasses the edit chokepoints (bare setState), so
+  // mark the freshness overlay dirty (see applyValidatedGraph). The accept flow's
+  // applyAnalysisReadyPatch clears it iff the patch supplies a fresh new verdict.
+  // Optional-chained so partial store doubles in tests don't break.
+  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+
   return result
 }
 
@@ -382,6 +388,11 @@ export function applyValidatedGraph(validated: { nodes: unknown[]; edges: unknow
     edges: validated.edges as any,
   })
   validateNodesBatch(validated.nodes as any)
+  // This full-graph replace bypasses the edit chokepoints (bare setState), so the
+  // freshness overlay must be marked dirty here. applyAnalysisReadyPatch (called
+  // after accept) clears it iff the patch supplies a fresh new verdict.
+  // Optional-chained so partial store doubles in tests don't break.
+  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -10,6 +10,7 @@ import { useCanvasStore } from '../../store'
 import { DEFAULT_EDGE_DATA } from '../../domain/edges'
 import { saveAutosave } from '../../store/scenarios'
 import { validateNodesBatch } from '../../domain/nodes'
+import { hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from '../../domain/analyticalChange'
 import type { PatchOperation, GraphPatchBlock } from '../types'
 import type { EffectDirection, CEEAnalysisReady, CEEInterventionV3 } from '../../../adapters/cee/types'
 
@@ -367,31 +368,37 @@ export function applyAutoApplyPatch(patchBlock: GraphPatchBlock): ApplyPatchResu
   // mark the freshness overlay dirty (see applyValidatedGraph). The accept flow's
   // applyAnalysisReadyPatch clears it iff the patch supplies a fresh new verdict.
   //
-  // Dirty ONLY on an ACTUAL graph delta — `modifiedIds` is inflated (every update/
-  // remove op pushes an id before confirming the target exists or a value changed),
-  // so a same-value update, an absent update target, or a remove of an absent id
-  // must NOT create a spurious persistent 'unknown'. Compute the real delta from
-  // adds, present-target removals, and value-changing updates. Optional-chained so
-  // partial store doubles in tests don't break.
+  // Dirty ONLY on an ACTUAL, ANALYSIS-AFFECTING graph delta. `modifiedIds` is
+  // inflated (every update/remove op pushes an id before confirming the target
+  // exists or a value changed), so it cannot drive dirtying. Two over-dirty traps
+  // to avoid:
+  //   1. absent targets / same-value re-sends → no real change.
+  //   2. cosmetic (label/body) edits, or a re-normalised structured field that is
+  //      a new object reference with IDENTICAL content (e.g. CEE re-emitting the
+  //      same observed_state) → not analysis-affecting.
+  // Both are handled by the SHARED analysis-affecting taxonomy (domain/
+  // analyticalChange) with SEMANTIC (by-value) comparison — the same predicate the
+  // store edit chokepoints use, so the patch path can never diverge from them.
+  // Adds and present-target removals are inherently structural (topology change).
+  // Optional-chained markDirty so partial store doubles in tests don't break.
   const hadRealAdd = newNodes.length > 0 || newEdges.length > 0
   const hadRealRemove =
     existingNodes.some((n) => removeNodeIds.has(n.id)) ||
     existingEdges.some((e) => removeEdgeIds.has(e.id))
   const hadRealNodeUpdate = existingNodes.some((n) => {
     const u = nodeUpdates.get(n.id)
-    return !!u && Object.keys(u).some((k) => (n.data as Record<string, unknown> | undefined)?.[k] !== u[k])
+    return !!u && hasAnalyticalNodeChange(n, { data: u })
   })
   const hadRealEdgeUpdate = existingEdges.some((e) => {
     const u = edgeUpdates.get(e.id)
     if (!u) return false
     const { _rewireSource, _rewireTarget, ...dataUpdate } = u as Record<string, unknown>
-    const endpointChanged =
-      (typeof _rewireSource === 'string' && _rewireSource !== e.source) ||
-      (typeof _rewireTarget === 'string' && _rewireTarget !== e.target)
-    const dataChanged = Object.keys(dataUpdate).some(
-      (k) => (e.data as Record<string, unknown> | undefined)?.[k] !== dataUpdate[k],
-    )
-    return endpointChanged || dataChanged
+    const endpointUpdates = {
+      ...(typeof _rewireSource === 'string' ? { source: _rewireSource } : {}),
+      ...(typeof _rewireTarget === 'string' ? { target: _rewireTarget } : {}),
+      data: dataUpdate,
+    }
+    return hasAnalyticalEdgeChange(e, endpointUpdates)
   })
   const mutated = hadRealAdd || hadRealRemove || hadRealNodeUpdate || hadRealEdgeUpdate
   if (mutated) {

--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -366,8 +366,14 @@ export function applyAutoApplyPatch(patchBlock: GraphPatchBlock): ApplyPatchResu
   // Op-replay graph mutation bypasses the edit chokepoints (bare setState), so
   // mark the freshness overlay dirty (see applyValidatedGraph). The accept flow's
   // applyAnalysisReadyPatch clears it iff the patch supplies a fresh new verdict.
-  // Optional-chained so partial store doubles in tests don't break.
-  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+  // Only dirty when something ACTUALLY changed — a no-op or fully-rejected
+  // operation batch must not create a spurious persistent 'unknown'. Optional-
+  // chained so partial store doubles in tests don't break.
+  const mutated =
+    result.addedNodeCount > 0 || result.addedEdgeCount > 0 || result.modifiedIds.length > 0
+  if (mutated) {
+    useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+  }
 
   return result
 }

--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -366,11 +366,34 @@ export function applyAutoApplyPatch(patchBlock: GraphPatchBlock): ApplyPatchResu
   // Op-replay graph mutation bypasses the edit chokepoints (bare setState), so
   // mark the freshness overlay dirty (see applyValidatedGraph). The accept flow's
   // applyAnalysisReadyPatch clears it iff the patch supplies a fresh new verdict.
-  // Only dirty when something ACTUALLY changed — a no-op or fully-rejected
-  // operation batch must not create a spurious persistent 'unknown'. Optional-
-  // chained so partial store doubles in tests don't break.
-  const mutated =
-    result.addedNodeCount > 0 || result.addedEdgeCount > 0 || result.modifiedIds.length > 0
+  //
+  // Dirty ONLY on an ACTUAL graph delta — `modifiedIds` is inflated (every update/
+  // remove op pushes an id before confirming the target exists or a value changed),
+  // so a same-value update, an absent update target, or a remove of an absent id
+  // must NOT create a spurious persistent 'unknown'. Compute the real delta from
+  // adds, present-target removals, and value-changing updates. Optional-chained so
+  // partial store doubles in tests don't break.
+  const hadRealAdd = newNodes.length > 0 || newEdges.length > 0
+  const hadRealRemove =
+    existingNodes.some((n) => removeNodeIds.has(n.id)) ||
+    existingEdges.some((e) => removeEdgeIds.has(e.id))
+  const hadRealNodeUpdate = existingNodes.some((n) => {
+    const u = nodeUpdates.get(n.id)
+    return !!u && Object.keys(u).some((k) => (n.data as Record<string, unknown> | undefined)?.[k] !== u[k])
+  })
+  const hadRealEdgeUpdate = existingEdges.some((e) => {
+    const u = edgeUpdates.get(e.id)
+    if (!u) return false
+    const { _rewireSource, _rewireTarget, ...dataUpdate } = u as Record<string, unknown>
+    const endpointChanged =
+      (typeof _rewireSource === 'string' && _rewireSource !== e.source) ||
+      (typeof _rewireTarget === 'string' && _rewireTarget !== e.target)
+    const dataChanged = Object.keys(dataUpdate).some(
+      (k) => (e.data as Record<string, unknown> | undefined)?.[k] !== dataUpdate[k],
+    )
+    return endpointChanged || dataChanged
+  })
+  const mutated = hadRealAdd || hadRealRemove || hadRealNodeUpdate || hadRealEdgeUpdate
   if (mutated) {
     useCanvasStore.getState().markAnalysisFreshnessDirty?.()
   }

--- a/src/canvas/conversation/utils/mirrorAnalysisReady.ts
+++ b/src/canvas/conversation/utils/mirrorAnalysisReady.ts
@@ -47,6 +47,15 @@ export function applyAnalysisReadyPatch(
 ): void {
   useCanvasStore.getState().setCeeAnalysisReady(patch.ceeAnalysisReady)
 
+  // Freshness source of truth: a patch's analysis_ready.freshness must flow
+  // through the freshness reducer, not be silently dropped. When it carries a
+  // verdict, the reducer applies it (and clears the dirty overlay that the graph
+  // mutation set); when it lacks one, the reducer leaves the retained verdict +
+  // dirty overlay in place so the patch shows "cannot confirm" rather than a
+  // stale "fresh". Mirrors the V5 ingress at applyV5State. Optional-chained so
+  // partial store doubles in tests don't break.
+  useCanvasStore.getState().setAnalysisFreshness?.(patch.ceeAnalysisReady)
+
   const backfillResult = backfillInterventionsOntoOptionNodes(patch.ceeAnalysisReady)
   if (backfillResult.interventionBackfilledCount > 0) {
     logger.warn('analysis_ready.intervention_backfill', {

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -20,7 +20,7 @@ import { logV5StateEvent } from '../../../v5/debugLog'
 import { isAiPanelV2Enabled } from '../../../flags'
 import { useAnalysisStatus } from '../../hooks/useAnalysisReady'
 import { useCanvasStore } from '../../store'
-import { useStaleGuard } from '../../ui/inspector-v2/useStaleGuard'
+import { resolveDisplayedFreshness } from '../../store/analysisFreshness'
 import type { ActionChip } from '../types'
 
 // Actions that V5 CEE handles end-to-end. Chips whose action_type is set and
@@ -77,20 +77,23 @@ function isRunAnalysisAffordance(chip: ActionChip): boolean {
  *   - current analysis exists  → suppress chip entirely
  *   - stale analysis exists    → relabel chip to "Rerun"
  *
- * The decision keys off `results.status === 'complete'` (analysis has
- * produced results at least once) plus `isStale` from the stale guard.
- * This avoids the fragile `analysisState === 'current'` path which can
- * race on staging when the hash compare lags by one tick.
+ * The decision keys off `results.status === 'complete'` (analysis has produced
+ * results at least once) plus `rerunRecommended` — the CEE freshness verdict +
+ * local dirty overlay (resolveDisplayedFreshness) being 'stale' or 'unknown'
+ * (cannot-confirm). This replaces the legacy `isStale` from useStaleGuard, whose
+ * production input `_internal.graphHash` is never written, so it never fired —
+ * leaving the rerun affordance suppressed even after a graph edit, while the
+ * Results surface correctly showed cannot-confirm.
  */
 type RunAnalysisPolish = 'suppress' | 'relabel-rerun' | 'keep'
 
 function decideRunAnalysisPolish(
   resultsComplete: boolean,
-  isStale: boolean,
+  rerunRecommended: boolean,
 ): RunAnalysisPolish {
-  if (!resultsComplete) return 'keep'   // no analysis yet
-  if (isStale) return 'relabel-rerun'   // graph drifted since last analysis
-  return 'suppress'                     // current analysis owns the action
+  if (!resultsComplete) return 'keep'        // no analysis yet
+  if (rerunRecommended) return 'relabel-rerun' // stale / cannot-confirm since last run
+  return 'suppress'                          // confirmed-current analysis owns the action
 }
 
 interface SuggestedChipsProps {
@@ -125,11 +128,14 @@ export function SuggestedChips({
   const analysisStatus = useAnalysisStatus()
   // aiPanelV2 polish: once an analysis has been RUN (results exist), the
   // canonical place for re-running it is the Analysis/readiness panel.
-  // Decision is via `decideRunAnalysisPolish` (product rule, see helper
-  // above): no analysis → keep; current → suppress; stale → "Rerun".
-  // Keys off results.status === 'complete' rather than the fragile
-  // analysisState === 'current' path (which can race on staging).
-  const { isStale } = useStaleGuard()
+  // Decision is via `decideRunAnalysisPolish` (product rule, see helper above):
+  // no analysis → keep; confirmed-current → suppress; stale/cannot-confirm →
+  // "Rerun". `rerunRecommended` is the CEE freshness verdict + local dirty overlay
+  // (resolveDisplayedFreshness), NOT the dead useStaleGuard graph-hash path.
+  const ceeFreshness = useCanvasStore((s) => s.analysisFreshness)
+  const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
+  const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
+  const rerunRecommended = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
   const resultsComplete = useCanvasStore((s) => s.results?.status === 'complete')
   const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {
@@ -152,7 +158,7 @@ export function SuggestedChips({
   // change to either branch from re-introducing "filtered before
   // relabel" behaviour.
   const runAnalysisPolish: RunAnalysisPolish = aiPanelV2On
-    ? decideRunAnalysisPolish(resultsComplete, isStale)
+    ? decideRunAnalysisPolish(resultsComplete, rerunRecommended)
     : 'keep'
 
   // Filter rule (V5 active):

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -20,7 +20,7 @@ import { logV5StateEvent } from '../../../v5/debugLog'
 import { isAiPanelV2Enabled } from '../../../flags'
 import { useAnalysisStatus } from '../../hooks/useAnalysisReady'
 import { useCanvasStore } from '../../store'
-import { resolveDisplayedFreshness } from '../../store/analysisFreshness'
+import { classifyFreshnessForDisplay } from '../../store/analysisFreshness'
 import type { ActionChip } from '../types'
 
 // Actions that V5 CEE handles end-to-end. Chips whose action_type is set and
@@ -75,12 +75,12 @@ function isRunAnalysisAffordance(chip: ActionChip): boolean {
  * Product rule for the run-analysis affordance under aiPanelV2:
  *   - no analysis exists       → keep chip as-is ("Run analysis")
  *   - current analysis exists  → suppress chip entirely
- *   - stale analysis exists    → relabel chip to "Rerun"
+ *   - stale / cannot-confirm analysis exists → relabel chip to "Rerun"
  *
  * The decision keys off `results.status === 'complete'` (analysis has produced
- * results at least once) plus `rerunRecommended` — the CEE freshness verdict +
- * local dirty overlay (resolveDisplayedFreshness) being 'stale' or 'unknown'
- * (cannot-confirm). This replaces the legacy `isStale` from useStaleGuard, whose
+ * results at least once) plus `rerunRecommended` — the shared freshness display
+ * semantic (classifyFreshnessForDisplay) being 'changed' or 'cannot_confirm'.
+ * This replaces the legacy `isStale` from useStaleGuard, whose
  * production input `_internal.graphHash` is never written, so it never fired —
  * leaving the rerun affordance suppressed even after a graph edit, while the
  * Results surface correctly showed cannot-confirm.
@@ -130,12 +130,12 @@ export function SuggestedChips({
   // canonical place for re-running it is the Analysis/readiness panel.
   // Decision is via `decideRunAnalysisPolish` (product rule, see helper above):
   // no analysis → keep; confirmed-current → suppress; stale/cannot-confirm →
-  // "Rerun". `rerunRecommended` is the CEE freshness verdict + local dirty overlay
-  // (resolveDisplayedFreshness), NOT the dead useStaleGuard graph-hash path.
+  // "Rerun". `rerunRecommended` uses the shared freshness display semantic, NOT
+  // the dead useStaleGuard graph-hash path.
   const ceeFreshness = useCanvasStore((s) => s.analysisFreshness)
   const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
-  const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
-  const rerunRecommended = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
+  const freshnessSemantic = classifyFreshnessForDisplay(ceeFreshness, freshnessDirty)
+  const rerunRecommended = freshnessSemantic === 'changed' || freshnessSemantic === 'cannot_confirm'
   const resultsComplete = useCanvasStore((s) => s.results?.status === 'complete')
   const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {
@@ -164,9 +164,9 @@ export function SuggestedChips({
   // Filter rule (V5 active):
   //   action_type === 'run_analysis' → gated by analysisStatus === 'ready',
   //                                    EXCEPT when aiPanelV2 will relabel to
-  //                                    "Rerun" (stale), in which case the chip
-  //                                    must survive the gate so the polish can
-  //                                    apply.
+  //                                    "Rerun" (stale/cannot-confirm), in which
+  //                                    case the chip must survive the gate so the
+  //                                    polish can apply.
   //   action_type absent              → pass through (conversational)
   //   action_type in V5_ENABLED_ACTIONS but NOT readiness-gated → pass through
   //   action_type present but unknown → hide (treat as potentially executable

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -20,7 +20,7 @@ import { logV5StateEvent } from '../../../v5/debugLog'
 import { isAiPanelV2Enabled } from '../../../flags'
 import { useAnalysisStatus } from '../../hooks/useAnalysisReady'
 import { useCanvasStore } from '../../store'
-import { classifyFreshnessForDisplay } from '../../store/analysisFreshness'
+import { classifyFreshnessForDisplay, type FreshnessDisplaySemantic } from '../../store/analysisFreshness'
 import type { ActionChip } from '../types'
 
 // Actions that V5 CEE handles end-to-end. Chips whose action_type is set and
@@ -73,32 +73,42 @@ function isRunAnalysisAffordance(chip: ActionChip): boolean {
 
 /**
  * Product rule for the run-analysis affordance under aiPanelV2:
- *   - no analysis exists                       → keep chip as-is ("Run analysis")
- *   - confirmed-current analysis exists        → suppress chip entirely
- *   - complete but NOT confirmed-current       → relabel chip to "Rerun"
- *     (stale, cannot-confirm, OR no freshness verdict)
+ *   - no analysis exists            → keep chip as-is ("Run analysis")
+ *   - confirmed-current analysis    → suppress chip entirely
+ *   - stale / cannot-confirm        → relabel chip to "Rerun" (may bypass the V5
+ *                                     readiness gate — a prior analysis exists and
+ *                                     a rerun re-derives inputs from the graph)
+ *   - complete, NO freshness verdict→ keep ("Run analysis"), SUBJECT to the gate
  *
- * Suppression is the ONLY branch that requires a positive signal — a CONFIRMED
- * CURRENT verdict (classifyFreshnessForDisplay === 'current'). A completed
- * analysis with no freshness verdict ('none') is NOT confirmed current, so it
- * keeps the rerun affordance available rather than being suppressed as if current
- * — matching how useStageAwarePlaceholder treats the same state (not "latest").
+ * Two positive-signal branches:
+ *   - SUPPRESS requires a CONFIRMED-CURRENT verdict (semantic === 'current').
+ *   - the readiness-gate-bypassing 'relabel-rerun' requires a REAL freshness
+ *     verdict ('changed' / 'cannot_confirm'), which implies a prior analysis that
+ *     a rerun can re-derive from the current graph.
+ * A completed analysis with NO freshness verdict ('none') gets neither: it is not
+ * confirmed current (so not suppressed — matching useStageAwarePlaceholder, which
+ * treats it as not-"latest"), but it has nothing rerunnable to justify bypassing
+ * the readiness gate. Relabelling it to "Rerun" would let a run_analysis chip
+ * survive the gate even when ceeAnalysisReady is missing, and a click then falls
+ * back to a conversation turn ("promises action, delivers chat"). So it stays a
+ * plain 'keep' chip, shown only when the readiness gate is satisfied.
  *
  * This replaces the legacy `isStale` from useStaleGuard, whose production input
- * `_internal.graphHash` is never written, so it never fired — leaving the rerun
- * affordance suppressed even after a graph edit, while the Results surface
- * correctly showed cannot-confirm.
+ * `_internal.graphHash` is never written, so it never fired.
  */
 type RunAnalysisPolish = 'suppress' | 'relabel-rerun' | 'keep'
 
 function decideRunAnalysisPolish(
   resultsComplete: boolean,
-  confirmedCurrent: boolean,
+  freshnessSemantic: FreshnessDisplaySemantic,
 ): RunAnalysisPolish {
-  if (!resultsComplete) return 'keep'      // no analysis yet
-  if (confirmedCurrent) return 'suppress'  // confirmed-current analysis owns the action
-  return 'relabel-rerun'                    // complete but not confirmed-current
-                                            // (stale / cannot-confirm / no verdict) → offer rerun
+  if (!resultsComplete) return 'keep'                     // no analysis yet
+  if (freshnessSemantic === 'current') return 'suppress'  // confirmed-current owns the action
+  if (freshnessSemantic === 'changed' || freshnessSemantic === 'cannot_confirm') {
+    return 'relabel-rerun'  // real verdict: prior analysis exists → offer rerun (gate-bypassing)
+  }
+  return 'keep'  // 'none': complete but no verdict → not current, but no rerunnable
+                 // analysis to justify a gate bypass; the readiness gate decides visibility
 }
 
 interface SuggestedChipsProps {
@@ -134,13 +144,13 @@ export function SuggestedChips({
   // aiPanelV2 polish: once an analysis has been RUN (results exist), the
   // canonical place for re-running it is the Analysis/readiness panel.
   // Decision is via `decideRunAnalysisPolish` (product rule, see helper above):
-  // no analysis → keep; confirmed-current → suppress; everything else complete
-  // (stale / cannot-confirm / no verdict) → "Rerun". `confirmedCurrent` uses the
-  // shared freshness display semantic, NOT the dead useStaleGuard graph-hash path.
+  // no analysis → keep; confirmed-current → suppress; stale/cannot-confirm →
+  // "Rerun" (gate-bypassing); complete-but-no-verdict → keep (gate decides).
+  // `freshnessSemantic` is the shared freshness display semantic, NOT the dead
+  // useStaleGuard graph-hash path.
   const ceeFreshness = useCanvasStore((s) => s.analysisFreshness)
   const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const freshnessSemantic = classifyFreshnessForDisplay(ceeFreshness, freshnessDirty)
-  const confirmedCurrent = freshnessSemantic === 'current'
   const resultsComplete = useCanvasStore((s) => s.results?.status === 'complete')
   const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {
@@ -163,7 +173,7 @@ export function SuggestedChips({
   // change to either branch from re-introducing "filtered before
   // relabel" behaviour.
   const runAnalysisPolish: RunAnalysisPolish = aiPanelV2On
-    ? decideRunAnalysisPolish(resultsComplete, confirmedCurrent)
+    ? decideRunAnalysisPolish(resultsComplete, freshnessSemantic)
     : 'keep'
 
   // Filter rule (V5 active):

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -73,27 +73,32 @@ function isRunAnalysisAffordance(chip: ActionChip): boolean {
 
 /**
  * Product rule for the run-analysis affordance under aiPanelV2:
- *   - no analysis exists       → keep chip as-is ("Run analysis")
- *   - current analysis exists  → suppress chip entirely
- *   - stale / cannot-confirm analysis exists → relabel chip to "Rerun"
+ *   - no analysis exists                       → keep chip as-is ("Run analysis")
+ *   - confirmed-current analysis exists        → suppress chip entirely
+ *   - complete but NOT confirmed-current       → relabel chip to "Rerun"
+ *     (stale, cannot-confirm, OR no freshness verdict)
  *
- * The decision keys off `results.status === 'complete'` (analysis has produced
- * results at least once) plus `rerunRecommended` — the shared freshness display
- * semantic (classifyFreshnessForDisplay) being 'changed' or 'cannot_confirm'.
- * This replaces the legacy `isStale` from useStaleGuard, whose
- * production input `_internal.graphHash` is never written, so it never fired —
- * leaving the rerun affordance suppressed even after a graph edit, while the
- * Results surface correctly showed cannot-confirm.
+ * Suppression is the ONLY branch that requires a positive signal — a CONFIRMED
+ * CURRENT verdict (classifyFreshnessForDisplay === 'current'). A completed
+ * analysis with no freshness verdict ('none') is NOT confirmed current, so it
+ * keeps the rerun affordance available rather than being suppressed as if current
+ * — matching how useStageAwarePlaceholder treats the same state (not "latest").
+ *
+ * This replaces the legacy `isStale` from useStaleGuard, whose production input
+ * `_internal.graphHash` is never written, so it never fired — leaving the rerun
+ * affordance suppressed even after a graph edit, while the Results surface
+ * correctly showed cannot-confirm.
  */
 type RunAnalysisPolish = 'suppress' | 'relabel-rerun' | 'keep'
 
 function decideRunAnalysisPolish(
   resultsComplete: boolean,
-  rerunRecommended: boolean,
+  confirmedCurrent: boolean,
 ): RunAnalysisPolish {
-  if (!resultsComplete) return 'keep'        // no analysis yet
-  if (rerunRecommended) return 'relabel-rerun' // stale / cannot-confirm since last run
-  return 'suppress'                          // confirmed-current analysis owns the action
+  if (!resultsComplete) return 'keep'      // no analysis yet
+  if (confirmedCurrent) return 'suppress'  // confirmed-current analysis owns the action
+  return 'relabel-rerun'                    // complete but not confirmed-current
+                                            // (stale / cannot-confirm / no verdict) → offer rerun
 }
 
 interface SuggestedChipsProps {
@@ -129,13 +134,13 @@ export function SuggestedChips({
   // aiPanelV2 polish: once an analysis has been RUN (results exist), the
   // canonical place for re-running it is the Analysis/readiness panel.
   // Decision is via `decideRunAnalysisPolish` (product rule, see helper above):
-  // no analysis → keep; confirmed-current → suppress; stale/cannot-confirm →
-  // "Rerun". `rerunRecommended` uses the shared freshness display semantic, NOT
-  // the dead useStaleGuard graph-hash path.
+  // no analysis → keep; confirmed-current → suppress; everything else complete
+  // (stale / cannot-confirm / no verdict) → "Rerun". `confirmedCurrent` uses the
+  // shared freshness display semantic, NOT the dead useStaleGuard graph-hash path.
   const ceeFreshness = useCanvasStore((s) => s.analysisFreshness)
   const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const freshnessSemantic = classifyFreshnessForDisplay(ceeFreshness, freshnessDirty)
-  const rerunRecommended = freshnessSemantic === 'changed' || freshnessSemantic === 'cannot_confirm'
+  const confirmedCurrent = freshnessSemantic === 'current'
   const resultsComplete = useCanvasStore((s) => s.results?.status === 'complete')
   const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {
@@ -158,7 +163,7 @@ export function SuggestedChips({
   // change to either branch from re-introducing "filtered before
   // relabel" behaviour.
   const runAnalysisPolish: RunAnalysisPolish = aiPanelV2On
-    ? decideRunAnalysisPolish(resultsComplete, rerunRecommended)
+    ? decideRunAnalysisPolish(resultsComplete, confirmedCurrent)
     : 'keep'
 
   // Filter rule (V5 active):

--- a/src/canvas/domain/analyticalChange.ts
+++ b/src/canvas/domain/analyticalChange.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared "is this graph edit analysis-affecting?" taxonomy.
+ *
+ * Single source of truth for which node/edge fields change the analysis (and
+ * therefore should invalidate readiness / dirty the freshness overlay), used by
+ * both the store edit actions (updateNode/updateEdge) and the raw patch-apply path
+ * (applyAutoApplyPatch). Cosmetic fields — label, body, description, position,
+ * colour — are deliberately excluded.
+ *
+ * Comparison is SEMANTIC: structured fields (observedState, prior, interventions)
+ * are compared by value, so a re-normalised object with identical content (e.g.
+ * CEE re-sending the same observed_state) is NOT treated as a change. This prevents
+ * shallow-reference churn from fabricating a stale verdict.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+
+export const ANALYTICAL_NODE_DATA_FIELDS = [
+  'observedState', 'interventions', 'is_baseline',
+  'prior', 'kind', 'success_threshold', 'goalThreshold',
+  // goal_threshold_raw is the user-edited goal target (GoalSection inline edit +
+  // inspector); the V2 adapter derives the PLoT goal_threshold from it, so a change
+  // IS analysis-affecting.
+  'goal_threshold_raw', 'goal_threshold',
+] as const
+
+export const ANALYTICAL_EDGE_FIELDS = [
+  'weight', 'direction', 'strengthStd',
+  'confidence', 'beliefExists', 'beliefStrength', 'belief',
+  'exists_probability',
+] as const
+
+/** Key-order-insensitive deep equality for small JSON-safe analytical values. */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false
+  const aArr = Array.isArray(a)
+  if (aArr !== Array.isArray(b)) return false
+  if (aArr) {
+    const ax = a as unknown[]
+    const bx = b as unknown[]
+    return ax.length === bx.length && ax.every((v, i) => deepEqual(v, bx[i]))
+  }
+  const ao = a as Record<string, unknown>
+  const bo = b as Record<string, unknown>
+  const ak = Object.keys(ao)
+  const bk = Object.keys(bo)
+  return ak.length === bk.length && ak.every((k) => k in bo && deepEqual(ao[k], bo[k]))
+}
+
+/** True when a node update touches an analytically meaningful field by VALUE. */
+export function hasAnalyticalNodeChange(oldNode: Node, updates: Partial<Node>): boolean {
+  // Node-level: kind change (ReactFlow `type` field).
+  if (updates.type !== undefined && updates.type !== oldNode.type) return true
+
+  const oldData = (oldNode.data ?? {}) as Record<string, unknown>
+  const newData = updates.data as Record<string, unknown> | undefined
+  if (!newData) return false
+
+  for (const field of ANALYTICAL_NODE_DATA_FIELDS) {
+    if (field in newData && !deepEqual(newData[field], oldData[field])) return true
+  }
+  return false
+}
+
+/** True when an edge update touches an analytically meaningful field by VALUE. */
+export function hasAnalyticalEdgeChange(oldEdge: Edge, updates: Partial<Edge>): boolean {
+  // Top-level endpoint changes (defence-in-depth; primary path is updateEdgeEndpoints).
+  if (updates.source !== undefined && updates.source !== oldEdge.source) return true
+  if (updates.target !== undefined && updates.target !== oldEdge.target) return true
+
+  const oldData = (oldEdge.data ?? {}) as Record<string, unknown>
+  const newData = updates.data as Record<string, unknown> | undefined
+  if (!newData) return false
+
+  for (const field of ANALYTICAL_EDGE_FIELDS) {
+    if (field in newData && !deepEqual(newData[field], oldData[field])) return true
+  }
+  return false
+}

--- a/src/canvas/hooks/__tests__/useAnalysisDisplayState.spec.ts
+++ b/src/canvas/hooks/__tests__/useAnalysisDisplayState.spec.ts
@@ -4,6 +4,10 @@
  * deriveAnalysisDisplayState.spec.ts; these tests cover the store-to-helper
  * wiring (which selectors fire, which fields the helper sees) using a
  * minimal Zustand vanilla store as a stand-in for useCanvasStore.
+ *
+ * Staleness is sourced from the CEE freshness slice + local dirty overlay via
+ * the shared classifyFreshnessForDisplay (=== 'changed'), NOT the legacy
+ * graphEditedSinceLastRun flag. The real classifier runs against the mock store.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
@@ -13,7 +17,9 @@ import { create, type StoreApi, type UseBoundStore } from 'zustand'
 interface MockCanvasState {
   ceeAnalysisReady: { status?: string } | null
   results: { status: string; report: unknown } | null
-  graphEditedSinceLastRun: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  analysisFreshness: any
+  analysisFreshnessDirty: boolean
 }
 
 let store: UseBoundStore<StoreApi<MockCanvasState>>
@@ -32,7 +38,8 @@ function makeStore(initial: Partial<MockCanvasState> = {}) {
   return create<MockCanvasState>(() => ({
     ceeAnalysisReady: null,
     results: { status: 'idle', report: null },
-    graphEditedSinceLastRun: false,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
     ...initial,
   }))
 }
@@ -50,11 +57,12 @@ describe('useAnalysisDisplayState', () => {
     expect(result.current.cta).toEqual({ kind: 'primary', label: 'Run analysis' })
   })
 
-  it('returns complete view when results.report is populated and graph is unedited', () => {
+  it('returns complete view when results.report is populated and freshness is current', () => {
     store = makeStore({
       ceeAnalysisReady: { status: 'ready' },
       results: { status: 'complete', report: { option_comparison: [] } },
-      graphEditedSinceLastRun: false,
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: false,
     })
     const { result } = renderHook(() => useAnalysisDisplayState())
     expect(result.current.state).toBe('complete')
@@ -62,15 +70,38 @@ describe('useAnalysisDisplayState', () => {
     expect(result.current.cta).toBeNull()
   })
 
-  it('returns results_stale view when graph was edited after the last run', () => {
+  it('returns results_stale view when the CEE freshness verdict is stale (changed)', () => {
     store = makeStore({
       ceeAnalysisReady: { status: 'ready' },
       results: { status: 'complete', report: { option_comparison: [] } },
-      graphEditedSinceLastRun: true,
+      analysisFreshness: { freshness: 'stale' },
     })
     const { result } = renderHook(() => useAnalysisDisplayState())
     expect(result.current.state).toBe('results_stale')
     expect(result.current.cta).toEqual({ kind: 'secondary', label: 'Rerun analysis' })
+  })
+
+  it('returns results_stale when a retained fresh verdict is dirtied by a local edit (changed)', () => {
+    store = makeStore({
+      ceeAnalysisReady: { status: 'ready' },
+      results: { status: 'complete', report: { option_comparison: [] } },
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: true,
+    })
+    const { result } = renderHook(() => useAnalysisDisplayState())
+    expect(result.current.state).toBe('results_stale')
+  })
+
+  it('CEE-sourced unknown (cannot-confirm) → complete, NOT results_stale (no fabricated "outdated")', () => {
+    store = makeStore({
+      ceeAnalysisReady: { status: 'ready' },
+      results: { status: 'complete', report: { option_comparison: [] } },
+      analysisFreshness: { freshness: 'unknown' },
+      analysisFreshnessDirty: true,
+    })
+    const { result } = renderHook(() => useAnalysisDisplayState())
+    expect(result.current.state).toBe('complete')
+    expect(result.current.headline).toBe('Analysis complete')
   })
 
   it('returns not_ready view when CEE status is missing/non-ready', () => {
@@ -86,7 +117,6 @@ describe('useAnalysisDisplayState', () => {
     store = makeStore({
       ceeAnalysisReady: { status: 'needs_user_mapping' },
       results: { status: 'complete', report: { option_comparison: [] } },
-      graphEditedSinceLastRun: false,
     })
     const { result } = renderHook(() => useAnalysisDisplayState())
     expect(result.current.state).toBe('not_ready')
@@ -99,7 +129,6 @@ describe('useAnalysisDisplayState', () => {
     store = makeStore({
       ceeAnalysisReady: { status: 'ready' },
       results: { status: 'complete', report: null },
-      graphEditedSinceLastRun: false,
     })
     const { result } = renderHook(() => useAnalysisDisplayState())
     expect(result.current.state).toBe('ready_to_analyse')
@@ -107,9 +136,8 @@ describe('useAnalysisDisplayState', () => {
   })
 
   it('tolerates partial-mock store shapes (legacy fixtures omit fields)', () => {
-    // Some legacy test fixtures mock the store without `results` or
-    // `graphEditedSinceLastRun`. The hook must not crash; it falls back
-    // to safe defaults.
+    // Some legacy test fixtures mock the store without `results` or the
+    // freshness slices. The hook must not crash; it falls back to safe defaults.
     store = create<Partial<MockCanvasState>>(() => ({
       ceeAnalysisReady: { status: 'ready' },
     })) as unknown as UseBoundStore<StoreApi<MockCanvasState>>

--- a/src/canvas/hooks/__tests__/useStageAwarePlaceholder.spec.ts
+++ b/src/canvas/hooks/__tests__/useStageAwarePlaceholder.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * useStageAwarePlaceholder — composer placeholder derives from the CEE freshness
+ * verdict + local dirty overlay, NOT the dead useStaleGuard graph-hash path.
+ *
+ * Regression for the review finding: after a graph edit the composer kept claiming
+ * "Ask about the latest analysis…" (because useStaleGuard.analysisState stayed
+ * 'current' — _internal.graphHash is never written), contradicting the Results
+ * surface's cannot-confirm state. It must never claim "latest" unless the verdict
+ * is confirmed-fresh.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const selectionRef: { value: { id: string; label: string; kind: 'node' | 'edge' } | null } = { value: null }
+vi.mock('../useSelectionContext', () => ({
+  useSelectionContext: () => selectionRef.value,
+}))
+
+import { useStageAwarePlaceholder } from '../useStageAwarePlaceholder'
+import { useCanvasStore } from '../../store'
+
+const node = (id: string) => ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id } })
+const placeholder = () => renderHook(() => useStageAwarePlaceholder()).result.current
+
+beforeEach(() => {
+  selectionRef.value = null
+  useCanvasStore.setState({
+    nodes: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    results: { status: 'idle' } as any,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+  })
+})
+
+const complete = () => useCanvasStore.setState({ results: { status: 'complete' } as never })
+const setFresh = () => useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+
+describe('useStageAwarePlaceholder', () => {
+  it('no model → "Describe your decision…"', () => {
+    expect(placeholder()).toBe('Describe your decision…')
+  })
+
+  it('model exists, no analysis → "Ask about this model…"', () => {
+    useCanvasStore.setState({ nodes: [node('a')] as never })
+    expect(placeholder()).toBe('Ask about this model…')
+  })
+
+  it('selection wins over everything → "Ask about {label}…"', () => {
+    useCanvasStore.setState({ nodes: [node('a')] as never })
+    complete(); setFresh()
+    selectionRef.value = { id: 'g', label: 'Switch jobs?', kind: 'node' }
+    expect(placeholder()).toBe('Ask about Switch jobs?…')
+  })
+
+  it('confirmed-fresh analysis → "Ask about the latest analysis…"', () => {
+    complete(); setFresh()
+    expect(placeholder()).toBe('Ask about the latest analysis…')
+  })
+
+  it('CEE stale verdict → "Model changed. Ask or rerun…"', () => {
+    complete()
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
+    expect(placeholder()).toBe('Model changed. Ask or rerun…')
+  })
+
+  it('REGRESSION: fresh analysis edited locally (cannot-confirm) → "Model changed…", NEVER "latest"', () => {
+    complete(); setFresh()
+    useCanvasStore.getState().markAnalysisFreshnessDirty()
+    const p = placeholder()
+    expect(p).toBe('Model changed. Ask or rerun…')
+    expect(p).not.toMatch(/latest/i)
+  })
+
+  it('CEE-sourced unknown (cannot-confirm) → neutral "Ask about this analysis…", never "latest"', () => {
+    complete()
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'unknown', freshness_reason: 'no_hash' })
+    const p = placeholder()
+    expect(p).toBe('Ask about this analysis…')
+    expect(p).not.toMatch(/latest/i)
+  })
+})

--- a/src/canvas/hooks/useAnalysisDisplayState.ts
+++ b/src/canvas/hooks/useAnalysisDisplayState.ts
@@ -11,6 +11,7 @@
  */
 
 import { useCanvasStore } from '../store'
+import { classifyFreshnessForDisplay } from '../store/analysisFreshness'
 import {
   deriveAnalysisDisplayState,
   type AnalysisDisplayStateView,
@@ -18,15 +19,21 @@ import {
 
 export function useAnalysisDisplayState(): AnalysisDisplayStateView {
   // Defensive optional chaining: legacy test fixtures mock a partial store
-  // shape that omits `results` and/or `graphEditedSinceLastRun`. The runtime
-  // store always provides them (initial state at store.ts:1113, 1128).
+  // shape that omits `results`. The runtime store always provides it.
   const ceeAnalysisReadyStatus = useCanvasStore((s) => s.ceeAnalysisReady?.status)
   const hasReport = useCanvasStore((s) => s.results?.report != null)
-  const graphEditedSinceLastRun = useCanvasStore((s) => s.graphEditedSinceLastRun ?? false)
+  // "Results may be outdated" must reflect the CEE freshness verdict + local
+  // dirty overlay (the shared display semantic being 'changed'), NOT the local
+  // `graphEditedSinceLastRun` flag — so a CEE-sourced 'unknown' (cannot-confirm)
+  // never fabricates a stale claim here.
+  const analysisFreshness = useCanvasStore((s) => s.analysisFreshness)
+  const analysisFreshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
+  const analysisChanged =
+    classifyFreshnessForDisplay(analysisFreshness, analysisFreshnessDirty) === 'changed'
 
   return deriveAnalysisDisplayState({
     ceeAnalysisReadyStatus,
     hasReport,
-    graphEditedSinceLastRun,
+    analysisChanged,
   })
 }

--- a/src/canvas/hooks/useStageAwarePlaceholder.ts
+++ b/src/canvas/hooks/useStageAwarePlaceholder.ts
@@ -1,32 +1,48 @@
 import { useCanvasStore, selectResultsStatus } from '../store'
-import { useStaleGuard } from '../ui/inspector-v2/useStaleGuard'
+import { classifyFreshnessForDisplay } from '../store/analysisFreshness'
 import { useSelectionContext } from './useSelectionContext'
 
 /**
  * Returns the placeholder text the persistent input strip / floating composer
  * should display, derived from the current canvas + analysis + selection state.
  *
+ * Freshness comes from the CEE verdict + local dirty overlay
+ * (classifyFreshnessForDisplay), NOT the legacy useStaleGuard graph-hash path
+ * (_internal.graphHash is never written, so its 'stale' never fired and its
+ * 'current' falsely persisted after an edit — the composer would still claim
+ * "latest analysis" once the Results surface had moved to cannot-confirm).
+ *
  * Priority (highest first):
- *   1. Node/edge selected      → "Ask about [label]..."
- *   2. Post-analysis stale     → "Model changed. Ask or rerun..."
- *   3. Post-analysis current   → "Ask about the latest analysis..."
- *   4. Model exists            → "Ask about this model..."
- *   5. No model                → "Describe your decision..."
+ *   1. Node/edge selected            → "Ask about [label]..."
+ *   2. Model changed since the run    → "Model changed. Ask or rerun..."
+ *      (CEE 'stale' OR a local edit that downgraded a retained 'fresh')
+ *   3. Confirmed current analysis     → "Ask about the latest analysis..."
+ *   4. Analysis exists, can't confirm → "Ask about this analysis..."
+ *      (cannot-confirm / no freshness verdict — never claims "latest")
+ *   5. Model exists                   → "Ask about this model..."
+ *   6. No model                       → "Describe your decision..."
  */
 export function useStageAwarePlaceholder(): string {
   const nodeCount = useCanvasStore((s) => s.nodes.length)
   const resultsStatus = useCanvasStore(selectResultsStatus)
-  const { analysisState } = useStaleGuard()
+  const ceeFreshness = useCanvasStore((s) => s.analysisFreshness)
+  const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const selection = useSelectionContext()
+  const freshness = classifyFreshnessForDisplay(ceeFreshness, freshnessDirty)
 
   if (selection) {
     return `Ask about ${selection.label}…`
   }
-  if (analysisState === 'stale') {
+  if (freshness === 'changed') {
     return 'Model changed. Ask or rerun…'
   }
-  if (resultsStatus === 'complete' && analysisState === 'current') {
+  if (freshness === 'current') {
     return 'Ask about the latest analysis…'
+  }
+  // Analysis ran but freshness is cannot-confirm or absent → acknowledge the
+  // analysis without claiming it is current.
+  if (resultsStatus === 'complete') {
+    return 'Ask about this analysis…'
   }
   if (nodeCount > 0) {
     return 'Ask about this model…'

--- a/src/canvas/mutations/__tests__/commitGraphMutation.spec.ts
+++ b/src/canvas/mutations/__tests__/commitGraphMutation.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * commitGraphMutation — the shared canvas-store commit that every raw-setState graph
+ * route converges on (template insert/replace via commitTemplateGraphReplace, and
+ * both TemplatesPanel merges). It must dirty the analysis-freshness overlay so a
+ * structural graph change cannot leave a retained CEE 'fresh' verdict falsely intact.
+ *
+ * Exercising the helper directly covers those call sites' dirtying without rendering
+ * the heavy panels/canvas (TemplatesPanel pulls async template fetches + scenarios;
+ * ReactFlowGraph pulls OutputsDock/Supabase/ELK). The routing — that the merge
+ * handlers actually call this — is guarded separately by a source check.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { commitGraphMutation } from '../commitGraphMutation'
+import { useCanvasStore } from '../../store'
+import { resolveDisplayedFreshness } from '../../store/analysisFreshness'
+import type { EdgeData } from '../../domain/edges'
+
+const node = (id: string): Node =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id } }) as Node
+const edge = (id: string, source: string, target: string): Edge =>
+  ({ id, source, target }) as Edge
+
+const dirty = () => useCanvasStore.getState().analysisFreshnessDirty
+const displayed = () => {
+  const s = useCanvasStore.getState()
+  return resolveDisplayedFreshness(s.analysisFreshness, s.analysisFreshnessDirty)
+}
+const applyFresh = () =>
+  useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    nodes: [],
+    edges: [] as Edge<EdgeData>[],
+    history: { past: [], future: [] },
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+  })
+})
+
+describe('commitGraphMutation — merge form (TemplatesPanel "Merge into Current" / card merge)', () => {
+  it('appends to the CURRENT graph and downgrades a retained fresh verdict to cannot-confirm', () => {
+    useCanvasStore.setState({ nodes: [node('a')], edges: [edge('e-a', 'a', 'a')] as Edge<EdgeData>[] })
+    applyFresh()
+    expect(displayed()).toBe('fresh') // precondition: clean fresh analysis
+
+    // The exact appender shape both TemplatesPanel merges use.
+    commitGraphMutation((cur) => ({
+      nodes: [...cur.nodes, node('b'), node('c')],
+      edges: [...cur.edges, edge('e-b', 'b', 'c')],
+    }))
+
+    // Functional updater read the CURRENT store state (['a'] + new), not a stale snapshot.
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toEqual(['a', 'b', 'c'])
+    expect(useCanvasStore.getState().edges.map((e) => e.id)).toEqual(['e-a', 'e-b'])
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown') // CEE 'fresh' + local dirty → cannot-confirm
+  })
+
+  it('does not fabricate stale: a CEE stale verdict stays stale (overlay only downgrades fresh)', () => {
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
+    commitGraphMutation((cur) => ({ nodes: [...cur.nodes, node('b')], edges: cur.edges }))
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('stale')
+  })
+})
+
+describe('commitGraphMutation — replace form (template insert/replace)', () => {
+  it('replaces the graph and downgrades a retained fresh verdict', () => {
+    useCanvasStore.setState({ nodes: [node('old')] })
+    applyFresh()
+    commitGraphMutation(() => ({ nodes: [node('t1')], edges: [] }), { pushHistory: true })
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toEqual(['t1'])
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+})
+
+describe('commitGraphMutation — history', () => {
+  it('pushes a single history frame by default (undoable)', () => {
+    useCanvasStore.setState({ nodes: [node('old')], history: { past: [], future: [] } })
+    commitGraphMutation((cur) => ({ nodes: [...cur.nodes, node('b')], edges: cur.edges }))
+    expect(useCanvasStore.getState().history.past.length).toBe(1)
+  })
+
+  it('skips the history frame when pushHistory: false', () => {
+    useCanvasStore.setState({ nodes: [node('old')], history: { past: [], future: [] } })
+    commitGraphMutation((cur) => ({ nodes: [...cur.nodes, node('b')], edges: cur.edges }), { pushHistory: false })
+    expect(useCanvasStore.getState().history.past.length).toBe(0)
+    // Still dirties — the commit happened, only the undo frame was skipped.
+    expect(dirty()).toBe(true)
+  })
+})

--- a/src/canvas/mutations/__tests__/commitValidatedMutation.spec.ts
+++ b/src/canvas/mutations/__tests__/commitValidatedMutation.spec.ts
@@ -8,11 +8,13 @@ vi.mock('../../../adapters/plot', () => ({
 }))
 
 // Mock the canvas store
+const markAnalysisFreshnessDirty = vi.fn()
 vi.mock('../../store', () => {
   const state = {
     nodes: [{ id: 'n1', type: 'factor', data: { label: 'Test' } }],
     edges: [],
     pushHistory: vi.fn(),
+    markAnalysisFreshnessDirty: () => markAnalysisFreshnessDirty(),
   }
   return {
     useCanvasStore: {
@@ -52,6 +54,11 @@ describe('commitValidatedMutation', () => {
     await commitValidatedMutation(ops, localApply, showToast)
 
     expect(showToast).not.toHaveBeenCalled()
+  })
+
+  it('marks the freshness overlay dirty on a successful mutation (covers bare-setState localApply e.g. insert-factor-between)', async () => {
+    await commitValidatedMutation(ops, localApply, showToast)
+    expect(markAnalysisFreshnessDirty).toHaveBeenCalled()
   })
 
   it('falls back to localApply when adapter import throws', async () => {

--- a/src/canvas/mutations/__tests__/commitValidatedMutation.spec.ts
+++ b/src/canvas/mutations/__tests__/commitValidatedMutation.spec.ts
@@ -2,9 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { commitValidatedMutation } from '../commitValidatedMutation'
 import type { PatchOperation } from '../../conversation/types'
 
-// Mock the plot adapter module
+// Mock the plot adapter module. `validatePatch` is settable per-test (via the
+// hoisted holder) so we can exercise the dormant Phase-1 validated-graph branch
+// in addition to the Phase-2 localApply fallback.
+const plotState = vi.hoisted(() => ({ validatePatch: undefined as ((arg: unknown) => unknown) | undefined }))
 vi.mock('../../../adapters/plot', () => ({
-  plot: {},
+  plot: {
+    get validatePatch() {
+      return plotState.validatePatch
+    },
+  },
 }))
 
 // Mock the canvas store
@@ -33,6 +40,7 @@ describe('commitValidatedMutation', () => {
     vi.clearAllMocks()
     showToast = vi.fn()
     localApply = vi.fn()
+    plotState.validatePatch = undefined // default: no PLoT validate-patch → Phase 2
   })
 
   it('falls back to localApply when adapter has no validatePatch', async () => {
@@ -59,6 +67,22 @@ describe('commitValidatedMutation', () => {
   it('marks the freshness overlay dirty on a successful mutation (covers bare-setState localApply e.g. insert-factor-between)', async () => {
     await commitValidatedMutation(ops, localApply, showToast)
     expect(markAnalysisFreshnessDirty).toHaveBeenCalled()
+  })
+
+  it('Phase-1 validated graph: marks dirty on success', async () => {
+    plotState.validatePatch = vi.fn(async () => ({ valid: true, graph: { nodes: [], edges: [] } }))
+    const result = await commitValidatedMutation(ops, localApply, showToast)
+    expect(result.success).toBe(true)
+    expect(markAnalysisFreshnessDirty).toHaveBeenCalledTimes(1)
+    expect(localApply).not.toHaveBeenCalled() // full graph returned → no local fallback
+  })
+
+  it('Phase-1 rejected: does NOT dirty and surfaces the toast', async () => {
+    plotState.validatePatch = vi.fn(async () => ({ valid: false, message: 'nope' }))
+    const result = await commitValidatedMutation(ops, localApply, showToast)
+    expect(result.success).toBe(false)
+    expect(markAnalysisFreshnessDirty).not.toHaveBeenCalled()
+    expect(showToast).toHaveBeenCalledWith('nope', 'error')
   })
 
   it('falls back to localApply when adapter import throws', async () => {

--- a/src/canvas/mutations/commitGraphMutation.ts
+++ b/src/canvas/mutations/commitGraphMutation.ts
@@ -1,0 +1,55 @@
+/**
+ * commitGraphMutation — the ONE canvas-store commit for an analysis-affecting graph
+ * mutation performed OUTSIDE the store edit chokepoints (template insert/replace,
+ * TemplatesPanel merge, and any future raw-setState graph route).
+ *
+ * It:
+ *   1. optionally pushes a single history frame (undoable),
+ *   2. applies the structural mutation via a FUNCTIONAL setState updater — so a
+ *      caller that `await`ed before committing still reads fresh store state (no
+ *      stale-closure clobber of concurrent edits), and
+ *   3. marks the analysis-freshness overlay dirty.
+ *
+ * Step 3 is the whole point. A bare `setState({ nodes, edges })` replaces/merges the
+ * graph without touching readiness or the freshness verdict, so a retained CEE
+ * 'fresh' verdict would survive the structural change and the Results panel would
+ * falsely claim the prior analysis still reflects the graph. The overlay can only
+ * DOWNGRADE a retained fresh → cannot-confirm; it never fabricates 'stale' — stale
+ * stays a CEE-only verdict (resolveDisplayedFreshness enforces this).
+ *
+ * Active raw-setState graph routes converge here so freshness invalidation has one
+ * definition rather than being re-derived (and forgotten) per call site.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+import { useCanvasStore } from '../store'
+import type { EdgeData } from '../domain/edges'
+
+export interface GraphSnapshot {
+  nodes: Node[]
+  // Loose `Edge[]` so call sites that build template edges as `any[]`/`Edge[]`
+  // need no cast; the helper narrows once on write-back to the store's `Edge<EdgeData>[]`.
+  edges: Edge[]
+}
+
+export interface CommitGraphMutationOptions {
+  /** Push a single undoable history frame before committing (default true). */
+  pushHistory?: boolean
+}
+
+export function commitGraphMutation(
+  mutate: (current: GraphSnapshot) => GraphSnapshot,
+  options: CommitGraphMutationOptions = {},
+): void {
+  const { pushHistory = true } = options
+  if (pushHistory) useCanvasStore.getState().pushHistory()
+  useCanvasStore.setState((current) => {
+    const next = mutate({
+      nodes: current.nodes as Node[],
+      edges: current.edges as Edge[],
+    })
+    return { nodes: next.nodes, edges: next.edges as Edge<EdgeData>[] }
+  })
+  // Optional-chained so partial store doubles in tests don't break.
+  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+}

--- a/src/canvas/mutations/commitValidatedMutation.ts
+++ b/src/canvas/mutations/commitValidatedMutation.ts
@@ -54,6 +54,11 @@ export async function commitValidatedMutation(
           // PLoT validated but didn't return full graph — apply locally
           localApply()
         }
+        // Every context-menu mutation is a user model edit → dirty the freshness
+        // overlay. Covers localApply paths that bare-setState (e.g. insert-factor-
+        // between) and the validated-graph branch; idempotent for callers whose
+        // localApply already dirties via a store action.
+        markFreshnessDirty()
         return { success: true }
       } else {
         // PLoT rejected the mutation
@@ -68,5 +73,11 @@ export async function commitValidatedMutation(
 
   // Phase 2: Local application (current behaviour for all mutations)
   localApply()
+  markFreshnessDirty()
   return { success: true }
+}
+
+/** Mark the freshness overlay dirty (optional-chained for partial test store doubles). */
+function markFreshnessDirty(): void {
+  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
 }

--- a/src/canvas/panels/TemplatesPanel.tsx
+++ b/src/canvas/panels/TemplatesPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import type { Node, Edge } from '@xyflow/react'
 import { Search, Layout } from 'lucide-react'
 import { plot, adapterName } from '../../adapters/plot'
 import { typography } from '../../styles/typography'
@@ -17,6 +18,7 @@ import { PanelShell } from './_shared/PanelShell'
 import { coerceNodes, toUiKind, type BackendNode } from '../adapters/backendKinds'
 import { PanelSection } from './_shared/PanelSection'
 import { useCanvasStore } from '../store'
+import { commitGraphMutation } from '../mutations/commitGraphMutation'
 import { createScenario, saveScenarios, loadScenarios, setCurrentScenarioId } from '../store/scenarios'
 import { TemplateSkeleton } from '../components/TemplateSkeleton'
 import { trackRunAttempt } from '../utils/sandboxTelemetry'
@@ -324,9 +326,10 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
         }
       })
 
-      // Directly append to store
-      state.pushHistory()
-      useCanvasStore.setState(currentState => ({
+      // Directly append to store via the shared graph-mutation commit so this
+      // analysis-affecting structural change dirties the freshness overlay
+      // (a bare setState would leave a retained CEE 'fresh' verdict falsely intact).
+      commitGraphMutation(currentState => ({
         nodes: [...currentState.nodes, ...newNodes],
         edges: [...currentState.edges, ...newEdges]
       }))
@@ -505,9 +508,10 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
         }
       })
 
-      // Directly append to store bypassing existing template check
-      state.pushHistory()
-      useCanvasStore.setState(currentState => ({
+      // Directly append to store (bypassing existing-template check) via the
+      // shared graph-mutation commit so this analysis-affecting structural change
+      // dirties the freshness overlay rather than leaving a retained 'fresh' verdict.
+      commitGraphMutation(currentState => ({
         nodes: [...currentState.nodes, ...newNodes],
         edges: [...currentState.edges, ...newEdges]
       }))

--- a/src/canvas/panels/__tests__/TemplatesPanel.mergeDirty.spec.tsx
+++ b/src/canvas/panels/__tests__/TemplatesPanel.mergeDirty.spec.tsx
@@ -1,0 +1,81 @@
+/**
+ * TemplatesPanel merge — BEHAVIOURAL freshness-dirty proof.
+ *
+ * Complements the source-scan routing guard (TemplatesPanel.mergeFreshness.spec.ts)
+ * and the shared-helper behaviour test (mutations/commitGraphMutation.spec.ts) by
+ * driving the real "Merge into Current" handler end-to-end and asserting it marks
+ * the analysis-freshness overlay dirty via the shared graph-commit path — i.e. a
+ * merge after a fresh analysis cannot leave a retained 'fresh' verdict intact.
+ *
+ * The store is mocked (rendering with the real store pulls scenarios/Supabase) but,
+ * unlike the handoff spec, getState exposes pushHistory + markAnalysisFreshnessDirty
+ * + createNodeId/createEdgeId so commitGraphMutation runs for real against the spy.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TemplatesPanel } from '../TemplatesPanel'
+import * as plotAdapter from '../../../adapters/plot'
+
+const markAnalysisFreshnessDirty = vi.fn()
+const pushHistory = vi.fn()
+let createSeq = 0
+
+vi.mock('../../../adapters/plot', () => ({
+  plot: { templates: vi.fn(), template: vi.fn() },
+  adapterName: 'httpv1',
+}))
+
+vi.mock('../../hooks/useTemplatesRun', () => ({
+  useTemplatesRun: () => ({
+    loading: false, progress: 0, canCancel: false, result: null, error: null,
+    run: vi.fn().mockResolvedValue(undefined), cancel: vi.fn(), clearError: vi.fn(),
+  }),
+}))
+
+vi.mock('../../store', () => ({
+  useCanvasStore: {
+    getState: vi.fn(() => ({
+      isDirty: false,
+      nodes: [],
+      edges: [],
+      setShowResultsPanel: vi.fn(),
+      pushHistory,
+      markAnalysisFreshnessDirty,
+      createNodeId: vi.fn(() => `n-${++createSeq}`),
+      createEdgeId: vi.fn(() => `e-${++createSeq}`),
+    })),
+    setState: vi.fn(),
+  },
+}))
+
+describe('TemplatesPanel — "Merge into Current" dirties the freshness overlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createSeq = 0
+    vi.mocked(plotAdapter.plot.templates).mockResolvedValue({
+      schema: 'templates.v1',
+      items: [{ id: 'template-1', name: 'Test Template', description: 'desc', version: '1.0' }],
+    } as never)
+    vi.mocked(plotAdapter.plot.template).mockResolvedValue({
+      schema: 'template.v1', id: 'template-1', name: 'Test Template', description: 'desc',
+      version: '1.0', default_seed: 1337,
+      graph: { nodes: [{ id: 'n1', label: 'Node 1', kind: 'goal' }], edges: [] },
+    } as never)
+  })
+
+  it('marks dirty through the shared commit when merging a template into the current canvas', async () => {
+    render(<TemplatesPanel isOpen onClose={vi.fn()} onInsertBlueprint={vi.fn()} />)
+
+    // Select a template so the footer (with "Merge into Current") renders.
+    await waitFor(() => expect(screen.getByText('Test Template')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /insert .*template/i }))
+
+    const mergeBtn = await screen.findByRole('button', { name: /merge into current/i })
+    expect(markAnalysisFreshnessDirty).not.toHaveBeenCalled() // not until the merge fires
+    fireEvent.click(mergeBtn)
+
+    // commitGraphMutation: pushHistory + setState + markAnalysisFreshnessDirty.
+    await waitFor(() => expect(markAnalysisFreshnessDirty).toHaveBeenCalled())
+    expect(pushHistory).toHaveBeenCalled()
+  })
+})

--- a/src/canvas/panels/__tests__/TemplatesPanel.mergeDirty.spec.tsx
+++ b/src/canvas/panels/__tests__/TemplatesPanel.mergeDirty.spec.tsx
@@ -16,8 +16,13 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { TemplatesPanel } from '../TemplatesPanel'
 import * as plotAdapter from '../../../adapters/plot'
 
-const markAnalysisFreshnessDirty = vi.fn()
-const pushHistory = vi.fn()
+// vi.hoisted so the vi.mock factory (hoisted above these) can reference the spies
+// eagerly — setState is read as a property at factory-eval time, not lazily.
+const { markAnalysisFreshnessDirty, pushHistory, setState } = vi.hoisted(() => ({
+  markAnalysisFreshnessDirty: vi.fn(),
+  pushHistory: vi.fn(),
+  setState: vi.fn(),
+}))
 let createSeq = 0
 
 vi.mock('../../../adapters/plot', () => ({
@@ -44,7 +49,7 @@ vi.mock('../../store', () => ({
       createNodeId: vi.fn(() => `n-${++createSeq}`),
       createEdgeId: vi.fn(() => `e-${++createSeq}`),
     })),
-    setState: vi.fn(),
+    setState,
   },
 }))
 
@@ -77,5 +82,15 @@ describe('TemplatesPanel — "Merge into Current" dirties the freshness overlay'
     // commitGraphMutation: pushHistory + setState + markAnalysisFreshnessDirty.
     await waitFor(() => expect(markAnalysisFreshnessDirty).toHaveBeenCalled())
     expect(pushHistory).toHaveBeenCalled()
+
+    // Prove the merge COMMITS the expected graph mutation, not just that it
+    // dirties: setState receives a functional updater that, run against a current
+    // graph, APPENDS the template's nodes/edges (preserving the existing ones).
+    const updater = setState.mock.calls.at(-1)?.[0]
+    expect(typeof updater).toBe('function')
+    const existing = { id: 'existing-node', type: 'goal', position: { x: 0, y: 0 }, data: {} }
+    const next = updater({ nodes: [existing], edges: [] })
+    expect(next.nodes.map((n: { id: string }) => n.id)).toEqual(['existing-node', 'n-1'])
+    expect(next.edges).toEqual([]) // template had no edges; existing edges preserved
   })
 })

--- a/src/canvas/panels/__tests__/TemplatesPanel.mergeFreshness.spec.ts
+++ b/src/canvas/panels/__tests__/TemplatesPanel.mergeFreshness.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * TemplatesPanel merge-freshness routing guard.
+ *
+ * Both merge actions ("Merge into Current" footer button → handleMergeIntoCurrent,
+ * and the template card's onMerge → handleMerge) are analysis-affecting structural
+ * graph changes. They previously appended via a bare `useCanvasStore.setState(...)`,
+ * which bypassed the freshness overlay and left a retained CEE 'fresh' verdict
+ * falsely intact after a merge. They must now route through the shared dirtying
+ * commit (commitGraphMutation) — proven behaviourally in
+ * mutations/__tests__/commitGraphMutation.spec.ts.
+ *
+ * This guard pins the routing at the source level so a future edit cannot quietly
+ * reintroduce a raw-setState graph mutation in this panel. (A full render test is
+ * impractical here: each merge awaits an async plot.template fetch and the real
+ * store pulls scenarios/Supabase; the shared-helper behaviour test plus this
+ * routing guard together cover both merges.)
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const stripComments = (src: string) =>
+  src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+
+const source = stripComments(
+  readFileSync(join(process.cwd(), 'src/canvas/panels/TemplatesPanel.tsx'), 'utf8'),
+)
+
+describe('TemplatesPanel — merge actions dirty the freshness overlay', () => {
+  it('imports the shared graph-mutation commit', () => {
+    expect(source).toMatch(/import\s*\{[^}]*\bcommitGraphMutation\b[^}]*\}\s*from\s*['"][^'"]*mutations\/commitGraphMutation['"]/)
+  })
+
+  it('routes BOTH merge handlers through commitGraphMutation (≥2 call sites)', () => {
+    const calls = source.match(/commitGraphMutation\s*\(/g) ?? []
+    expect(calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('contains NO raw useCanvasStore.setState graph mutation (the bypass that left fresh verdicts intact)', () => {
+    expect(source).not.toMatch(/useCanvasStore\.setState\s*\(/)
+  })
+})

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -2054,6 +2054,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       showDraftChat: false,
       currentBriefText: null,
       draftComposerText: null,
+      // Full graph replaced on import — clear the freshness verdict (it described
+      // the previous graph; never carry it onto an imported model).
+      analysisFreshness: null,
       // Graph Lens: auto-reset on canvas import (full graph replaced)
       lens: createDefaultLensState(),
     })
@@ -2921,6 +2924,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // causing buildRequest to ship stale analysis on the first turn.
       analysisStateReady: false,
       rawV2Response: null,
+      // Freshness verdict is per-scenario and session-derived — clear on switch
+      // so a verdict from the previous scenario cannot leak into this one.
+      analysisFreshness: null,
       isDirty: false,
       history: { past: [], future: [] },
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
@@ -4153,6 +4159,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       updates.history = { past: [], future: [] }
       updates.selection = { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null }
       updates.touchedNodeIds = new Set()
+      // A loaded graph is a new context — clear the freshness verdict so it can't
+      // leak from the previous graph/scenario.
+      updates.analysisFreshness = null
     }
 
     // Apply updates without clobbering panels/results/other slices

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -979,9 +979,11 @@ function logConstraintClearIfPresent(
  * Set the local freshness dirty overlay. Idempotent — only writes (and so only
  * triggers a re-render) on the false→true transition. Called from the proven
  * analysis-affecting edit recognition (invalidateAnalysisReady, the delete
- * chokepoints, and undo/redo) — never an independent edit detector. The display
- * rule (resolveDisplayedFreshness) uses it only to downgrade a retained 'fresh'
- * verdict to cannot-confirm; it never fabricates 'stale'.
+ * chokepoints, setOutcomeNode/setGoalThreshold) and via the public store action
+ * for external mutators — never an independent edit detector. (undo/redo/undoDraft
+ * set the flag INLINE in their atomic graph-swap set(), not through this helper.)
+ * The display rule (resolveDisplayedFreshness) uses it only to downgrade a
+ * retained 'fresh' verdict to cannot-confirm; it never fabricates 'stale'.
  */
 function markAnalysisFreshnessDirty(
   get: () => CanvasState,
@@ -3439,13 +3441,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     })
   },
 
-  // Public dirty-overlay API. Internal edits use the module helper of the same
-  // name (folded into invalidateAnalysisReady / the delete chokepoints); these
-  // actions exist for EXTERNAL mutators that bypass those chokepoints — accepted
-  // CEE graph patches (bare-setState graph writes) and the V5 applicator.
-  markAnalysisFreshnessDirty: () => {
-    if (!get().analysisFreshnessDirty) set(() => ({ analysisFreshnessDirty: true }))
-  },
+  // Public dirty-overlay API for EXTERNAL mutators that bypass the internal edit
+  // chokepoints — accepted CEE graph patches (bare-setState graph writes), the
+  // context-menu commit path, and the draft producers. Delegates to the module
+  // helper so the idempotent set lives in one place (no drift between the two).
+  markAnalysisFreshnessDirty: () => markAnalysisFreshnessDirty(get, set),
   clearAnalysisFreshnessDirty: () => {
     if (get().analysisFreshnessDirty) set(() => ({ analysisFreshnessDirty: false }))
   },

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -576,7 +576,7 @@ interface CanvasState {
   // Outcome node
   setOutcomeNode: (nodeId: string | null) => void
   // Goal threshold for probability_of_goal
-  setGoalThreshold: (threshold: number | null) => void
+  setGoalThreshold: (threshold: number | null, opts?: { fromCeeSync?: boolean }) => void
   /** Unified threshold + node data update. Prefer over calling setGoalThreshold + updateNode separately. */
   setGoalThresholdAndUpdateNode: (goalNodeId: string, value: number | null) => void
   // Results actions
@@ -1474,6 +1474,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     for (const u of updates) updatesById.set(u.id, u.data)
 
     let changedCount = 0
+    // Mirror updateNode: track whether any node's change touched an analytical
+    // field so this producer path (e.g. applyDraftResult intervention backfill)
+    // invalidates readiness and dirties the freshness overlay, instead of
+    // silently mutating analytical state under a retained 'fresh' verdict.
+    let anyAnalyticalChange = false
     const nextNodes = currentNodes.map(n => {
       const patch = updatesById.get(n.id)
       if (!patch) return n // preserve identity for untouched nodes
@@ -1485,6 +1490,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       }
       if (!changed) return n
       changedCount += 1
+      if (hasAnalyticalNodeChange(n, { data: patch as Node['data'] })) anyAnalyticalChange = true
       return { ...n, data: merged }
     })
 
@@ -1492,6 +1498,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
     pushToHistory(get, set, label ?? `Batch updated ${changedCount} node${changedCount !== 1 ? 's' : ''}`)
     set(() => ({ nodes: nextNodes }))
+    if (anyAnalyticalChange) {
+      invalidateAnalysisReady(get, set, `batch_update_nodes analytical (${changedCount})`)
+    }
     return { updatedCount: changedCount }
   },
 
@@ -2515,11 +2524,23 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   },
 
   setOutcomeNode: (nodeId) => {
+    // Changing which node is the goal/outcome is analysis-affecting → dirty the
+    // freshness overlay on a real change. (Producer paths that also call this —
+    // applyDraftResult / applyAutoApplyPatch — dirty via their own mutation marks;
+    // load/scenario paths set outcomeNodeId directly and reset the overlay.)
+    const changed = get().outcomeNodeId !== nodeId
     set({ outcomeNodeId: nodeId })
+    if (changed) markAnalysisFreshnessDirty(get, set)
   },
 
-  setGoalThreshold: (threshold) => {
+  setGoalThreshold: (threshold, opts) => {
+    // The goal threshold is sent to PLoT, so a user change is analysis-affecting
+    // → dirty the freshness overlay on a real change. The CEE-sync caller inside
+    // setCeeAnalysisReady passes { fromCeeSync: true } so an ingestion write does
+    // NOT self-dirty.
+    const changed = get().goalThreshold !== threshold
     set({ goalThreshold: threshold })
+    if (changed && !opts?.fromCeeSync) markAnalysisFreshnessDirty(get, set)
   },
 
   setGoalThresholdAndUpdateNode: (goalNodeId, value) => {
@@ -3377,7 +3398,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // Sync goal threshold from CEE to store (fixes "?" badge on goals with thresholds)
       const ceeThreshold = (analysisReady as any).goal_threshold ?? (analysisReady as any).goal_threshold_raw
       if (ceeThreshold != null && get().goalThreshold == null) {
-        get().setGoalThreshold(typeof ceeThreshold === 'number' ? ceeThreshold : Number(ceeThreshold))
+        // Producer write (syncing the threshold FROM the analysis) — must not
+        // self-dirty the freshness overlay.
+        get().setGoalThreshold(typeof ceeThreshold === 'number' ? ceeThreshold : Number(ceeThreshold), { fromCeeSync: true })
       }
       // Persist to sessionStorage for tab-refresh survival (with node IDs for validation)
       try {

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -5,6 +5,7 @@ import { saveSnapshot as persistSnapshot, importCanvas as persistImport, exportC
 import { setsEqual, mapsEqual } from './store/utils'
 import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS, type EdgeData } from './domain/edges'
 import { NODE_REGISTRY, type NodeType, type NodeData } from './domain/nodes'
+import { hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from './domain/analyticalChange'
 import { applyLayout, applyLayoutWithPolicy } from './layout'
 import { mergePolicy } from './layout/policy'
 import { policyToPreset, policyToSpacing } from './layout/adapters'
@@ -1075,68 +1076,11 @@ function maybeInvalidateOnEdgeDelete(
   return false
 }
 
-/**
- * Detect whether an edge update touches analytically meaningful fields.
- * Used to decide if ceeAnalysisReady should be invalidated.
- */
-function hasAnalyticalEdgeChange(
-  oldEdge: Edge<EdgeData>,
-  updates: Partial<Edge<EdgeData>>,
-): boolean {
-  // Top-level endpoint changes (defence-in-depth; primary path is updateEdgeEndpoints)
-  if (updates.source !== undefined && updates.source !== oldEdge.source) return true
-  if (updates.target !== undefined && updates.target !== oldEdge.target) return true
-
-  const oldData = oldEdge.data ?? {}
-  const newData = updates.data
-  if (!newData) return false
-
-  const ANALYTICAL_EDGE_FIELDS = [
-    'weight', 'direction', 'strengthStd',
-    'confidence', 'beliefExists', 'beliefStrength', 'belief',
-    'exists_probability',
-  ] as const
-
-  for (const field of ANALYTICAL_EDGE_FIELDS) {
-    if (field in newData && (newData as Record<string, unknown>)[field] !== (oldData as Record<string, unknown>)[field]) {
-      return true
-    }
-  }
-  return false
-}
-
-/**
- * Detect whether a node update touches analytically meaningful fields.
- * Checks both node-level fields (type/kind) and data-level fields.
- */
-function hasAnalyticalNodeChange(
-  oldNode: Node,
-  updates: Partial<Node>,
-): boolean {
-  // Node-level: kind change (ReactFlow type field)
-  if (updates.type !== undefined && updates.type !== oldNode.type) return true
-
-  const oldData = (oldNode.data ?? {}) as Record<string, unknown>
-  const newData = updates.data as Record<string, unknown> | undefined
-  if (!newData) return false
-
-  const ANALYTICAL_NODE_DATA_FIELDS = [
-    'observedState', 'interventions', 'is_baseline',
-    'prior', 'kind', 'success_threshold', 'goalThreshold',
-    // goal_threshold_raw is the user-edited goal target (GoalSection inline edit
-    // + inspector); the V2 adapter derives the PLoT goal_threshold from it, so a
-    // change IS analysis-affecting. Without these, an inline goal-target edit
-    // neither invalidated readiness nor dirtied the freshness verdict.
-    'goal_threshold_raw', 'goal_threshold',
-  ] as const
-
-  for (const field of ANALYTICAL_NODE_DATA_FIELDS) {
-    if (field in newData && newData[field] !== oldData[field]) {
-      return true
-    }
-  }
-  return false
-}
+// hasAnalyticalEdgeChange / hasAnalyticalNodeChange — the "is this graph edit
+// analysis-affecting?" taxonomy now lives in domain/analyticalChange.ts so the
+// store edit chokepoints (updateNode/updateEdge) and the raw patch-apply path
+// (applyAutoApplyPatch) share ONE definition with SEMANTIC (by-value) comparison.
+// Imported at the top of this module.
 
 function getMaxNumericId(ids: string[]): number {
   return ids.reduce((max, id) => {

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -385,6 +385,12 @@ interface CanvasState {
   // Analysis freshness verdict from CEE analysis_ready.freshness — retained
   // across turns; sourced independently of ceeAnalysisReady / v5AnalysisFact.
   analysisFreshness: AnalysisFreshnessState | null
+  // Local dirty overlay: set true by an analysis-affecting local edit (reusing
+  // the existing invalidateAnalysisReady / delete / undo-redo recognition), so the
+  // UI can downgrade a retained CEE 'fresh' verdict to cannot-confirm WITHOUT
+  // fabricating 'stale'. Cleared when a new analysis_ready arrives or on
+  // scenario switch/load/import/reset. NOT a graph hash; see analysisFreshness.ts.
+  analysisFreshnessDirty: boolean
   // CEE coaching payload from last /assist/v1/draft-graph response (build a555cf7b+).
   // Session-local — never persisted; cleared on new draft start and scenario reset.
   draftCoaching: CEEDraftCoaching | null
@@ -965,11 +971,34 @@ function logConstraintClearIfPresent(
   }
 }
 
+/**
+ * Set the local freshness dirty overlay. Idempotent — only writes (and so only
+ * triggers a re-render) on the false→true transition. Called from the proven
+ * analysis-affecting edit recognition (invalidateAnalysisReady, the delete
+ * chokepoints, and undo/redo) — never an independent edit detector. The display
+ * rule (resolveDisplayedFreshness) uses it only to downgrade a retained 'fresh'
+ * verdict to cannot-confirm; it never fabricates 'stale'.
+ */
+function markAnalysisFreshnessDirty(
+  get: () => CanvasState,
+  set: (fn: (s: CanvasState) => Partial<CanvasState>) => void,
+) {
+  if (!get().analysisFreshnessDirty) {
+    set(() => ({ analysisFreshnessDirty: true }))
+  }
+}
+
 function invalidateAnalysisReady(
   get: () => CanvasState,
   set: (fn: (s: CanvasState) => Partial<CanvasState>) => void,
   reason?: string
 ) {
+  // Local dirty overlay: every analysis-affecting edit that reaches this
+  // invalidation marks the retained CEE freshness verdict as no-longer-
+  // confirmable. Set unconditionally (independent of whether ceeAnalysisReady is
+  // currently present) — the display rule only acts on a retained 'fresh'
+  // verdict, and a new analysis_ready clears the overlay.
+  markAnalysisFreshnessDirty(get, set)
   const { ceeAnalysisReady } = get()
   if (ceeAnalysisReady) {
     if (import.meta.env.DEV) {
@@ -992,6 +1021,11 @@ function maybeInvalidateOnNodeDelete(
   set: (fn: (s: CanvasState) => Partial<CanvasState>) => void,
   deletedNodeIds: string[]
 ): boolean {
+  // Dirty overlay fires on ANY structural node removal (taxonomy: "structural
+  // node remove"), not just the critical subset that clears ceeAnalysisReady.
+  // This only sets the dirty flag — it deliberately does NOT widen the existing
+  // critical-gating of ceeAnalysisReady invalidation.
+  if (deletedNodeIds.length > 0) markAnalysisFreshnessDirty(get, set)
   const { ceeAnalysisReady } = get()
   if (shouldInvalidateOnNodeDelete(deletedNodeIds, ceeAnalysisReady)) {
     invalidateAnalysisReady(get, set, `Deleted critical node(s): ${deletedNodeIds.join(', ')}`)
@@ -1024,6 +1058,9 @@ function maybeInvalidateOnEdgeDelete(
   set: (fn: (s: CanvasState) => Partial<CanvasState>) => void,
   edge: { source: string; target: string }
 ): boolean {
+  // Dirty overlay fires on ANY structural edge removal (taxonomy: "structural
+  // edge remove"), not just edges touching the critical subset.
+  markAnalysisFreshnessDirty(get, set)
   const { ceeAnalysisReady } = get()
   if (shouldInvalidateOnEdgeDelete(edge, ceeAnalysisReady)) {
     invalidateAnalysisReady(get, set, `Deleted edge connecting critical nodes: ${edge.source} → ${edge.target}`)
@@ -1236,6 +1273,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   ceeAnalysisReady: null,
   // Freshness verdict — null until CEE emits analysis_ready (UI shows nothing).
   analysisFreshness: null,
+  // Local dirty overlay — false at cold start (no edits to invalidate a verdict).
+  analysisFreshnessDirty: false,
   ceeAnalysisReadyNodeIds: null,
   // V5 canonical analysis fact (v5-canonical-analysis brief)
   v5AnalysisFact: null,
@@ -1755,9 +1794,12 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     const past = history.past.slice(0, -1)
     // Preserve label from the entry being undone so redo can show it
     const future = [{ nodes, edges, label: prev.label }, ...history.future]
-    // Clear full readiness bundle + reset lens on undo (graph shape changed)
+    // Clear full readiness bundle + reset lens on undo (graph shape changed).
+    // The freshness verdict is RETAINED across undo (intentionally not in
+    // READINESS_CLEAR_FIELDS), so the reverted graph no longer matches it →
+    // set the dirty overlay so a retained 'fresh' verdict shows cannot-confirm.
     logConstraintClearIfPresent(get, 'undo')
-    set({ nodes: prev.nodes, edges: prev.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, lens: createDefaultLensState() })
+    set({ nodes: prev.nodes, edges: prev.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, analysisFreshnessDirty: true, lens: createDefaultLensState() })
     // Reset hash after undo
     const { nodes: newNodes, edges: newEdges } = get()
     set(() => ({ _internal: { lastHistoryHash: historyHash(newNodes, newEdges) } }))
@@ -1769,9 +1811,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     const next = history.future[0]
     const past = [...history.past, { nodes, edges, label: next.label }]
     const future = history.future.slice(1)
-    // Clear full readiness bundle + reset lens on redo (graph shape changed)
+    // Clear full readiness bundle + reset lens on redo (graph shape changed).
+    // Verdict is retained → reapplied graph no longer matches it → dirty overlay.
     logConstraintClearIfPresent(get, 'redo')
-    set({ nodes: next.nodes, edges: next.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, lens: createDefaultLensState() })
+    set({ nodes: next.nodes, edges: next.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, analysisFreshnessDirty: true, lens: createDefaultLensState() })
     // Reset hash after redo
     const { nodes: newNodes, edges: newEdges } = get()
     set(() => ({ _internal: { lastHistoryHash: historyHash(newNodes, newEdges) } }))
@@ -1800,6 +1843,15 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
       outcomeNodeId: shouldClearOutcome ? null : s.outcomeNodeId,
     }))
+
+    // Local dirty overlay: any structural removal here (node and/or edge,
+    // critical or not) makes a retained 'fresh' verdict no-longer-confirmable.
+    // The ceeAnalysisReady invalidation below keeps its existing critical-gating;
+    // this only sets the dirty flag and also covers the edge-only branch that is
+    // otherwise gated on ceeAnalysisReady being present.
+    if (selection.nodeIds.size > 0 || deletedEdges.length > 0) {
+      markAnalysisFreshnessDirty(get, set)
+    }
 
     // Check node deletions for invalidation
     if (selection.nodeIds.size > 0) {
@@ -1956,6 +2008,12 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null }
     }))
 
+    // Local dirty overlay: mirror deleteSelected — any structural removal marks
+    // the retained verdict no-longer-confirmable, independent of critical-gating.
+    if (selection.nodeIds.size > 0 || deletedEdges.length > 0) {
+      markAnalysisFreshnessDirty(get, set)
+    }
+
     // Mirror deleteSelected invalidation: check nodes first, then edges
     if (selection.nodeIds.size > 0) {
       maybeInvalidateOnNodeDelete(get, set, [...selection.nodeIds])
@@ -2055,8 +2113,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       currentBriefText: null,
       draftComposerText: null,
       // Full graph replaced on import — clear the freshness verdict (it described
-      // the previous graph; never carry it onto an imported model).
+      // the previous graph; never carry it onto an imported model) and its dirty
+      // overlay (no pending edit applies to a brand-new graph).
       analysisFreshness: null,
+      analysisFreshnessDirty: false,
       // Graph Lens: auto-reset on canvas import (full graph replaced)
       lens: createDefaultLensState(),
     })
@@ -2275,6 +2335,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // Clear CEE analysis_ready payload, pipeline trace, quality, and constraints
       ceeAnalysisReady: null,
       analysisFreshness: null,
+      analysisFreshnessDirty: false,
       ceeAnalysisReadyNodeIds: null,
       // V5 canonical analysis fact — clear on scenario reset (the fact does
       // not survive a graph reset; rerun analysis to mint a fresh one).
@@ -2925,8 +2986,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       analysisStateReady: false,
       rawV2Response: null,
       // Freshness verdict is per-scenario and session-derived — clear on switch
-      // so a verdict from the previous scenario cannot leak into this one.
+      // so a verdict (and any pending dirty overlay) from the previous scenario
+      // cannot leak into this one.
       analysisFreshness: null,
+      analysisFreshnessDirty: false,
       isDirty: false,
       history: { past: [], future: [] },
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
@@ -3261,6 +3324,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       draftChatPreDraftSnapshot: null,
       // Clear full readiness bundle + pipeline trace on draft undo
       ...READINESS_CLEAR_FIELDS,
+      // Verdict is retained → reverted graph no longer matches it → dirty overlay.
+      analysisFreshnessDirty: true,
       ceePipelineTrace: null,
       // Graph Lens: auto-reset on draft undo (graph shape changed)
       lens: createDefaultLensState(),
@@ -3320,7 +3385,15 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   setAnalysisFreshness: (rawAnalysisReady: unknown) => {
     set((state) => {
       const next = deriveAnalysisFreshnessUpdate(state.analysisFreshness, rawAnalysisReady)
-      return next === state.analysisFreshness ? {} : { analysisFreshness: next }
+      // A newly-applied analysis_ready verdict supersedes any pending local edits:
+      // clear the dirty overlay. `next !== prev` is true only when the reducer
+      // accepted a present payload (newer/unorderable) — absent or strictly-older
+      // payloads retain BOTH the verdict and the dirty overlay.
+      const verdictChanged = next !== state.analysisFreshness
+      if (!verdictChanged) return {}
+      const updates: Partial<CanvasState> = { analysisFreshness: next }
+      if (state.analysisFreshnessDirty) updates.analysisFreshnessDirty = false
+      return updates
     })
   },
 
@@ -4159,9 +4232,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       updates.history = { past: [], future: [] }
       updates.selection = { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null }
       updates.touchedNodeIds = new Set()
-      // A loaded graph is a new context — clear the freshness verdict so it can't
-      // leak from the previous graph/scenario.
+      // A loaded graph is a new context — clear the freshness verdict and its
+      // dirty overlay so neither leaks from the previous graph/scenario.
       updates.analysisFreshness = null
+      updates.analysisFreshnessDirty = false
     }
 
     // Apply updates without clobbering panels/results/other slices

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -1474,11 +1474,6 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     for (const u of updates) updatesById.set(u.id, u.data)
 
     let changedCount = 0
-    // Mirror updateNode: track whether any node's change touched an analytical
-    // field so this producer path (e.g. applyDraftResult intervention backfill)
-    // invalidates readiness and dirties the freshness overlay, instead of
-    // silently mutating analytical state under a retained 'fresh' verdict.
-    let anyAnalyticalChange = false
     const nextNodes = currentNodes.map(n => {
       const patch = updatesById.get(n.id)
       if (!patch) return n // preserve identity for untouched nodes
@@ -1490,7 +1485,6 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       }
       if (!changed) return n
       changedCount += 1
-      if (hasAnalyticalNodeChange(n, { data: patch as Node['data'] })) anyAnalyticalChange = true
       return { ...n, data: merged }
     })
 
@@ -1498,9 +1492,14 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
     pushToHistory(get, set, label ?? `Batch updated ${changedCount} node${changedCount !== 1 ? 's' : ''}`)
     set(() => ({ nodes: nextNodes }))
-    if (anyAnalyticalChange) {
-      invalidateAnalysisReady(get, set, `batch_update_nodes analytical (${changedCount})`)
-    }
+    // NOTE (freshness overlay): batchUpdateNodes is, today, exclusively the CEE
+    // intervention-backfill producer (applyDraftResult / mirrorAnalysisReady). It
+    // writes CEE's OWN analysis_ready data back onto option nodes for consistency
+    // — NOT a user model edit — so it must NOT dirty/invalidate the freshness
+    // verdict it was just ingested with (doing so wiped a fresh verdict). The
+    // producer's real model change (the graph replace) is dirtied by
+    // applyDraftResult/DraftChat. A future user-edit caller must route through
+    // updateNode (gated by hasAnalyticalNodeChange) rather than dirtying here.
     return { updatedCount: changedCount }
   },
 

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -650,6 +650,10 @@ interface CanvasState {
   setV5AnalysisFact: (fact: V5AnalysisFactState | null) => void
   /** Update the freshness slice from a raw response.analysis_ready (retain / order-by-computed_at / never absence→fresh). */
   setAnalysisFreshness: (rawAnalysisReady: unknown) => void
+  /** Public dirty-overlay setter for external graph mutators (e.g. accepted CEE graph patches) that bypass the internal edit chokepoints. */
+  markAnalysisFreshnessDirty: () => void
+  /** Clear the dirty overlay when a genuinely new analysis run completes (reliable run identity, e.g. a new analysis_result response_hash). */
+  clearAnalysisFreshnessDirty: () => void
   setDraftCoaching: (coaching: CEEDraftCoaching | null) => void
   setGoalConstraints: (constraints: CEEGoalConstraint[] | null) => void
   setCeePipelineTrace: (trace: CeePipelineTrace | null) => void
@@ -1624,12 +1628,23 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // Guard no-op changes
     if (!changes || changes.length === 0) return
 
-    // Note: Edge changes do NOT invalidate ceeAnalysisReady
-    // Only deletion of critical nodes (goal, option, intervention targets) invalidates
-    // Causal path validation is handled separately by usePreRunValidation
-
     const isSelectOnly = changes.every(c => c.type === 'select')
     const hasSelectChange = changes.some(c => c.type === 'select')
+
+    // Edge removals via React Flow's built-in delete (default deleteKeyCode =
+    // Backspace/Delete) reach the store ONLY through this handler — they never go
+    // through deleteEdgeById / deleteSelected. Route the removed edges through the
+    // edge-delete chokepoint so they mark the freshness overlay dirty (and
+    // invalidate readiness for critical edges), matching every other edge-delete
+    // path. Resolve the removed edges from the PRE-change edge list.
+    const removedEdgeChanges = changes.filter((c) => c.type === 'remove')
+    if (removedEdgeChanges.length > 0) {
+      const edgesBefore = get().edges
+      for (const change of removedEdgeChanges) {
+        const removed = edgesBefore.find((e) => e.id === (change as { id: string }).id)
+        if (removed) maybeInvalidateOnEdgeDelete(get, set, removed)
+      }
+    }
 
     set((s) => {
       const updatedEdges = applyEdgeChanges(changes, s.edges) as Edge<EdgeData>[]
@@ -3400,6 +3415,17 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       if (state.analysisFreshnessDirty) updates.analysisFreshnessDirty = false
       return updates
     })
+  },
+
+  // Public dirty-overlay API. Internal edits use the module helper of the same
+  // name (folded into invalidateAnalysisReady / the delete chokepoints); these
+  // actions exist for EXTERNAL mutators that bypass those chokepoints — accepted
+  // CEE graph patches (bare-setState graph writes) and the V5 applicator.
+  markAnalysisFreshnessDirty: () => {
+    if (!get().analysisFreshnessDirty) set(() => ({ analysisFreshnessDirty: true }))
+  },
+  clearAnalysisFreshnessDirty: () => {
+    if (get().analysisFreshnessDirty) set(() => ({ analysisFreshnessDirty: false }))
   },
 
   setGoalConstraints: (constraints: CEEGoalConstraint[] | null) => {

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -1117,6 +1117,11 @@ function hasAnalyticalNodeChange(
   const ANALYTICAL_NODE_DATA_FIELDS = [
     'observedState', 'interventions', 'is_baseline',
     'prior', 'kind', 'success_threshold', 'goalThreshold',
+    // goal_threshold_raw is the user-edited goal target (GoalSection inline edit
+    // + inspector); the V2 adapter derives the PLoT goal_threshold from it, so a
+    // change IS analysis-affecting. Without these, an inline goal-target edit
+    // neither invalidated readiness nor dirtied the freshness verdict.
+    'goal_threshold_raw', 'goal_threshold',
   ] as const
 
   for (const field of ANALYTICAL_NODE_DATA_FIELDS) {

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -14,6 +14,7 @@ import type { V2RunResponse } from '../adapters/plot/v2/types'
 import type { PLoTEnrichment } from '../adapters/plot/enrichment'
 import { trackResultsViewed, trackIssuesOpened } from './utils/sandboxTelemetry'
 import { addRun, generateGraphHash, loadRuns, type StoredRun } from './store/runHistory'
+import { deriveAnalysisFreshnessUpdate, type AnalysisFreshnessState } from './store/analysisFreshness'
 import * as scenarios from './store/scenarios'
 import type { ScenarioFraming } from './store/scenarios'
 import type { GraphHealth, ValidationIssue, NeedleMover } from './validation/types'
@@ -381,6 +382,9 @@ interface CanvasState {
   // CEE V3: analysis_ready payload from last draft
   // Used by useV2Run to build requests with resolved interventions
   ceeAnalysisReady: CEEAnalysisReady | null
+  // Analysis freshness verdict from CEE analysis_ready.freshness — retained
+  // across turns; sourced independently of ceeAnalysisReady / v5AnalysisFact.
+  analysisFreshness: AnalysisFreshnessState | null
   // CEE coaching payload from last /assist/v1/draft-graph response (build a555cf7b+).
   // Session-local — never persisted; cleared on new draft start and scenario reset.
   draftCoaching: CEEDraftCoaching | null
@@ -638,6 +642,8 @@ interface CanvasState {
    * no-analysis / orphan / reset states.
    */
   setV5AnalysisFact: (fact: V5AnalysisFactState | null) => void
+  /** Update the freshness slice from a raw response.analysis_ready (retain / order-by-computed_at / never absence→fresh). */
+  setAnalysisFreshness: (rawAnalysisReady: unknown) => void
   setDraftCoaching: (coaching: CEEDraftCoaching | null) => void
   setGoalConstraints: (constraints: CEEGoalConstraint[] | null) => void
   setCeePipelineTrace: (trace: CeePipelineTrace | null) => void
@@ -1228,6 +1234,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   },
   // CEE V3: analysis_ready payload
   ceeAnalysisReady: null,
+  // Freshness verdict — null until CEE emits analysis_ready (UI shows nothing).
+  analysisFreshness: null,
   ceeAnalysisReadyNodeIds: null,
   // V5 canonical analysis fact (v5-canonical-analysis brief)
   v5AnalysisFact: null,
@@ -2263,6 +2271,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       nextEdgeId: 1,
       // Clear CEE analysis_ready payload, pipeline trace, quality, and constraints
       ceeAnalysisReady: null,
+      analysisFreshness: null,
       ceeAnalysisReadyNodeIds: null,
       // V5 canonical analysis fact — clear on scenario reset (the fact does
       // not survive a graph reset; rerun analysis to mint a fresh one).
@@ -3300,6 +3309,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
   setV5AnalysisFact: (fact: V5AnalysisFactState | null) => {
     set({ v5AnalysisFact: fact })
+  },
+
+  setAnalysisFreshness: (rawAnalysisReady: unknown) => {
+    set((state) => {
+      const next = deriveAnalysisFreshnessUpdate(state.analysisFreshness, rawAnalysisReady)
+      return next === state.analysisFreshness ? {} : { analysisFreshness: next }
+    })
   },
 
   setGoalConstraints: (constraints: CEEGoalConstraint[] | null) => {

--- a/src/canvas/store/__tests__/analysisFreshness.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshness.spec.ts
@@ -71,6 +71,27 @@ describe('deriveAnalysisFreshnessUpdate', () => {
     expect(next?.freshness).toBe('stale')
   })
 
+  it('echo guard: a re-delivered identical payload is a no-op (same reference)', () => {
+    // computed_at is not part of the CEE contract today, so an echoed analysis_ready
+    // (no computed_at) must NOT look like a new verdict — otherwise it would clear
+    // the local dirty overlay. Identical content → same reference returned.
+    const p = prev({ freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: undefined })
+    const echoed = deriveAnalysisFreshnessUpdate(p, {
+      freshness: 'fresh',
+      freshness_reason: 'graph_hash_match',
+    })
+    expect(echoed).toBe(p) // no change → dirty overlay would be retained
+
+    // A genuinely different verdict (or different run hash) IS applied.
+    const changed = deriveAnalysisFreshnessUpdate(p, {
+      freshness: 'fresh',
+      freshness_reason: 'graph_hash_match',
+      current_graph_hash: 'new-hash',
+    })
+    expect(changed).not.toBe(p)
+    expect(changed?.currentGraphHash).toBe('new-hash')
+  })
+
   it('captures supporting fields (reason/hashes) when present', () => {
     const next = deriveAnalysisFreshnessUpdate(null, {
       freshness: 'fresh',

--- a/src/canvas/store/__tests__/analysisFreshness.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshness.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * deriveAnalysisFreshnessUpdate — the freshness slice contract:
+ * retain on absence · never absence→fresh · order by computed_at · 4 states.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  deriveAnalysisFreshnessUpdate,
+  type AnalysisFreshnessState,
+} from '../analysisFreshness'
+
+const prev = (over: Partial<AnalysisFreshnessState> = {}): AnalysisFreshnessState => ({
+  freshness: 'fresh',
+  computedAt: '2026-06-23T10:00:00.000Z',
+  ...over,
+})
+
+describe('deriveAnalysisFreshnessUpdate', () => {
+  it('captures the four CEE states verbatim', () => {
+    for (const f of ['fresh', 'stale', 'unknown', 'none'] as const) {
+      const next = deriveAnalysisFreshnessUpdate(null, { freshness: f })
+      expect(next?.freshness).toBe(f)
+    }
+  })
+
+  it('retains the previous verdict when a turn carries no analysis_ready', () => {
+    const p = prev({ freshness: 'stale' })
+    expect(deriveAnalysisFreshnessUpdate(p, undefined)).toBe(p)
+    expect(deriveAnalysisFreshnessUpdate(p, null)).toBe(p)
+    expect(deriveAnalysisFreshnessUpdate(p, 'not-an-object')).toBe(p)
+  })
+
+  it('never derives fresh from absence (null prev stays null)', () => {
+    expect(deriveAnalysisFreshnessUpdate(null, null)).toBeNull()
+    expect(deriveAnalysisFreshnessUpdate(null, undefined)).toBeNull()
+  })
+
+  it('degrades a present-but-missing/invalid freshness to unknown, never fresh', () => {
+    expect(deriveAnalysisFreshnessUpdate(null, {})?.freshness).toBe('unknown')
+    expect(deriveAnalysisFreshnessUpdate(null, { freshness: 'bogus' })?.freshness).toBe('unknown')
+    expect(deriveAnalysisFreshnessUpdate(null, { freshness: 42 })?.freshness).toBe('unknown')
+  })
+
+  it('orders by computed_at: ignores a strictly-older payload', () => {
+    const p = prev({ freshness: 'fresh', computedAt: '2026-06-23T12:00:00.000Z' })
+    const older = deriveAnalysisFreshnessUpdate(p, {
+      freshness: 'stale',
+      computed_at: '2026-06-23T09:00:00.000Z',
+    })
+    expect(older).toBe(p) // older ignored
+    const equal = deriveAnalysisFreshnessUpdate(p, {
+      freshness: 'stale',
+      computed_at: '2026-06-23T12:00:00.000Z',
+    })
+    expect(equal).toBe(p) // equal ignored (no change)
+  })
+
+  it('applies a newer payload', () => {
+    const p = prev({ freshness: 'fresh', computedAt: '2026-06-23T09:00:00.000Z' })
+    const next = deriveAnalysisFreshnessUpdate(p, {
+      freshness: 'stale',
+      computed_at: '2026-06-23T12:00:00.000Z',
+    })
+    expect(next?.freshness).toBe('stale')
+    expect(next?.computedAt).toBe('2026-06-23T12:00:00.000Z')
+  })
+
+  it('applies a payload without computed_at (cannot order → latest verdict wins)', () => {
+    const p = prev({ freshness: 'fresh', computedAt: '2026-06-23T12:00:00.000Z' })
+    const next = deriveAnalysisFreshnessUpdate(p, { freshness: 'stale' })
+    expect(next?.freshness).toBe('stale')
+  })
+
+  it('captures supporting fields (reason/hashes) when present', () => {
+    const next = deriveAnalysisFreshnessUpdate(null, {
+      freshness: 'fresh',
+      freshness_reason: 'graph_hash_match',
+      graph_hash_at_run: 'abc',
+      current_graph_hash: 'abc',
+      computed_at: '2026-06-23T10:00:00.000Z',
+    })
+    expect(next).toEqual({
+      freshness: 'fresh',
+      freshnessReason: 'graph_hash_match',
+      graphHashAtRun: 'abc',
+      currentGraphHash: 'abc',
+      computedAt: '2026-06-23T10:00:00.000Z',
+    })
+  })
+})

--- a/src/canvas/store/__tests__/analysisFreshness.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshness.spec.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   deriveAnalysisFreshnessUpdate,
+  resolveDisplayedFreshness,
   type AnalysisFreshnessState,
 } from '../analysisFreshness'
 
@@ -85,5 +86,47 @@ describe('deriveAnalysisFreshnessUpdate', () => {
       currentGraphHash: 'abc',
       computedAt: '2026-06-23T10:00:00.000Z',
     })
+  })
+})
+
+describe('resolveDisplayedFreshness (local dirty overlay display rule)', () => {
+  const fresh = prev({ freshness: 'fresh' })
+
+  it('returns null when there is no verdict (renders nothing)', () => {
+    expect(resolveDisplayedFreshness(null, false)).toBeNull()
+    expect(resolveDisplayedFreshness(null, true)).toBeNull()
+  })
+
+  it('passes a clean fresh verdict through unchanged', () => {
+    expect(resolveDisplayedFreshness(fresh, false)).toBe('fresh')
+  })
+
+  it('downgrades fresh → unknown when the local dirty overlay is set', () => {
+    expect(resolveDisplayedFreshness(fresh, true)).toBe('unknown')
+  })
+
+  it('never downgrades a CEE stale verdict (stays stale even when dirty)', () => {
+    const stale = prev({ freshness: 'stale' })
+    expect(resolveDisplayedFreshness(stale, true)).toBe('stale')
+    expect(resolveDisplayedFreshness(stale, false)).toBe('stale')
+  })
+
+  it('leaves unknown / none verdicts untouched regardless of dirty', () => {
+    for (const f of ['unknown', 'none'] as const) {
+      const s = prev({ freshness: f })
+      expect(resolveDisplayedFreshness(s, true)).toBe(f)
+      expect(resolveDisplayedFreshness(s, false)).toBe(f)
+    }
+  })
+
+  it('never fabricates stale and never upgrades (only fresh→unknown is possible)', () => {
+    // Exhaustive: the only state→display change the overlay can produce is
+    // fresh→unknown. Everything else is identity.
+    for (const f of ['fresh', 'stale', 'unknown', 'none'] as const) {
+      const out = resolveDisplayedFreshness(prev({ freshness: f }), true)
+      if (f === 'fresh') expect(out).toBe('unknown')
+      else expect(out).toBe(f)
+      expect(out).not.toBe('stale-fabricated') // sanity: no invented values
+    }
   })
 })

--- a/src/canvas/store/__tests__/analysisFreshness.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshness.spec.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest'
 import {
   deriveAnalysisFreshnessUpdate,
   resolveDisplayedFreshness,
+  classifyFreshnessForDisplay,
   type AnalysisFreshnessState,
 } from '../analysisFreshness'
 
@@ -149,5 +150,32 @@ describe('resolveDisplayedFreshness (local dirty overlay display rule)', () => {
       else expect(out).toBe(f)
       expect(out).not.toBe('stale-fabricated') // sanity: no invented values
     }
+  })
+})
+
+describe('classifyFreshnessForDisplay (copy semantic across AI-panel surfaces)', () => {
+  it('no verdict → none', () => {
+    expect(classifyFreshnessForDisplay(null, false)).toBe('none')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'none' }), false)).toBe('none')
+  })
+
+  it('clean fresh → current', () => {
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'fresh' }), false)).toBe('current')
+  })
+
+  it('CEE stale → changed', () => {
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'stale' }), true)).toBe('changed')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'stale' }), false)).toBe('changed')
+  })
+
+  it('dirty-overlay downgrade of a retained fresh → changed (user definitely edited)', () => {
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'fresh' }), true)).toBe('changed')
+  })
+
+  it('CEE-sourced unknown → cannot_confirm, NEVER changed (no false "you edited" claim)', () => {
+    // A present analysis_ready with missing/invalid freshness degrades to 'unknown'
+    // (deriveAnalysisFreshnessUpdate). That is cannot-confirm, not a user edit.
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'unknown' }), false)).toBe('cannot_confirm')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'unknown' }), true)).toBe('cannot_confirm')
   })
 })

--- a/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Local freshness dirty-overlay — store-integration contract.
+ *
+ * Drives the REAL canvas store through REAL edit actions (no mocked detector) to
+ * prove the overlay reuses the existing analysis-affecting edit recognition:
+ *   - analysis-affecting edits set the overlay (value, structural, undo/redo);
+ *   - cosmetic edits do NOT set it;
+ *   - a new analysis_ready clears it; absence retains it;
+ *   - CEE 'stale' is never downgraded;
+ *   - scenario load / reset clear both the verdict and the overlay.
+ * The display verdict is read through resolveDisplayedFreshness, the same pure
+ * rule the UI uses.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Node, Edge } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import type { EdgeData } from '../../domain/edges'
+import { resolveDisplayedFreshness } from '../analysisFreshness'
+import { createScenario } from '../scenarios'
+
+const T1 = '2026-06-23T10:00:00.000Z'
+const T2 = '2026-06-23T12:00:00.000Z'
+const T3 = '2026-06-23T14:00:00.000Z'
+
+const node = (id: string): Node =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id } }) as Node
+const edge = (id: string, source: string, target: string): Edge<EdgeData> =>
+  ({ id, source, target, data: {} as EdgeData }) as Edge<EdgeData>
+
+function seed(nodes: Node[] = [node('n1'), node('n2')], edges: Edge<EdgeData>[] = []) {
+  useCanvasStore.setState({
+    nodes,
+    edges,
+    history: { past: [], future: [] },
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    ceeAnalysisReady: null,
+  })
+}
+
+/** Apply a CEE 'fresh' verdict (and clear any pending overlay, as a real run does). */
+function applyFresh(computedAt = T1) {
+  useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', computed_at: computedAt })
+}
+
+const dirty = () => useCanvasStore.getState().analysisFreshnessDirty
+const verdict = () => useCanvasStore.getState().analysisFreshness?.freshness
+const displayed = () => {
+  const s = useCanvasStore.getState()
+  return resolveDisplayedFreshness(s.analysisFreshness, s.analysisFreshnessDirty)
+}
+
+beforeEach(() => {
+  seed()
+})
+
+describe('dirty overlay — analysis-affecting edits downgrade a retained fresh verdict', () => {
+  it('#1 factor value / observedState edit → displayed unknown', () => {
+    applyFresh()
+    expect(displayed()).toBe('fresh') // precondition: clean fresh
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7, baseline: 0.5 } } as Node['data'] })
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+    expect(verdict()).toBe('fresh') // CEE verdict itself is untouched (source of truth)
+  })
+
+  it('#1b edge weight / belief / confidence edit → displayed unknown', () => {
+    seed([node('n1'), node('n2')], [edge('e1', 'n1', 'n2')])
+    applyFresh()
+    useCanvasStore.getState().updateEdge('e1', { data: { weight: 1.5 } as EdgeData })
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('#2 structural node add → displayed unknown', () => {
+    applyFresh()
+    useCanvasStore.getState().addNode({ x: 1, y: 1 }, 'factor')
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('#2b structural node remove → displayed unknown', () => {
+    applyFresh()
+    useCanvasStore.getState().deleteNodeById('n1')
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('#2c structural edge add → displayed unknown', () => {
+    applyFresh()
+    useCanvasStore.getState().addEdge({ source: 'n1', target: 'n2', data: {} as EdgeData } as Omit<Edge<EdgeData>, 'id'>)
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('#2d structural edge remove → displayed unknown', () => {
+    seed([node('n1'), node('n2')], [edge('e1', 'n1', 'n2')])
+    applyFresh()
+    useCanvasStore.getState().deleteEdgeById('e1')
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('#3 undo of an analysis-affecting edit → displayed unknown', () => {
+    applyFresh()
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
+    applyFresh(T2) // a fresh re-run clears the overlay so we isolate undo's effect
+    expect(dirty()).toBe(false)
+    useCanvasStore.getState().undo()
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('#3b redo of an analysis-affecting edit → displayed unknown', () => {
+    applyFresh(T1)
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
+    applyFresh(T2) // newer run clears the overlay
+    useCanvasStore.getState().undo()
+    applyFresh(T3) // newer-still run clears again, to isolate redo's effect
+    expect(dirty()).toBe(false)
+    useCanvasStore.getState().redo()
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+})
+
+describe('dirty overlay — cosmetic edits never dirty', () => {
+  it('#4 label-only edit does not dirty', () => {
+    applyFresh()
+    useCanvasStore.getState().updateNode('n1', { data: { label: 'Renamed' } as Node['data'] })
+    expect(dirty()).toBe(false)
+    expect(displayed()).toBe('fresh')
+  })
+
+  it('#4b position-only edit does not dirty', () => {
+    applyFresh()
+    useCanvasStore.getState().updateNode('n1', { position: { x: 99, y: 99 } })
+    expect(dirty()).toBe(false)
+    expect(displayed()).toBe('fresh')
+  })
+})
+
+describe('dirty overlay — verdict lifecycle', () => {
+  it('#5 missing analysis_ready on a non-edit turn retains the last CEE verdict', () => {
+    applyFresh()
+    useCanvasStore.getState().setAnalysisFreshness(undefined) // analyse turn without analysis_ready
+    expect(verdict()).toBe('fresh')
+    expect(dirty()).toBe(false)
+    expect(displayed()).toBe('fresh')
+  })
+
+  it('#6 a new analysis_ready clears the dirty overlay', () => {
+    applyFresh()
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
+    expect(dirty()).toBe(true)
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', computed_at: T2 })
+    expect(dirty()).toBe(false)
+    expect(displayed()).toBe('fresh')
+  })
+
+  it('#7 a CEE stale verdict is never downgraded, even after a local edit', () => {
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', computed_at: T1 })
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
+    expect(dirty()).toBe(true) // overlay set...
+    expect(verdict()).toBe('stale')
+    expect(displayed()).toBe('stale') // ...but stale is never downgraded
+  })
+})
+
+describe('dirty overlay — scenario / reset boundaries', () => {
+  it('#8 loadScenario resets BOTH the CEE verdict and the dirty overlay', () => {
+    const s = createScenario({ name: 'Scenario A', nodes: [node('s1')], edges: [] })
+    applyFresh()
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
+    expect(dirty()).toBe(true)
+    expect(verdict()).toBe('fresh')
+
+    useCanvasStore.getState().loadScenario(s.id)
+    expect(useCanvasStore.getState().analysisFreshness).toBeNull()
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+    expect(displayed()).toBeNull() // no verdict → no notice
+  })
+
+  it('#8b resetCanvas clears both the verdict and the dirty overlay', () => {
+    applyFresh()
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
+    expect(dirty()).toBe(true)
+    useCanvasStore.getState().resetCanvas()
+    expect(useCanvasStore.getState().analysisFreshness).toBeNull()
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+  })
+})
+
+describe('#9 no forbidden freshness paths', () => {
+  // The overlay must never depend on v5AnalysisFact.freshness, useStaleGuard,
+  // _context_summary, or any client graph hash. Comments legitimately *mention*
+  // those names ("deliberately independent of …"), so scan comment-stripped code.
+  const stripComments = (src: string) =>
+    src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+
+  const read = (rel: string) => stripComments(readFileSync(join(process.cwd(), rel), 'utf8'))
+
+  it('the dedicated freshness modules use no forbidden API', () => {
+    const freshnessFiles = [
+      'src/canvas/store/analysisFreshness.ts',
+      'src/components/results/AnalysisFreshnessNotice.tsx',
+    ]
+    for (const f of freshnessFiles) {
+      const code = read(f)
+      expect(code, f).not.toMatch(/v5AnalysisFact/)
+      expect(code, f).not.toMatch(/useStaleGuard/)
+      expect(code, f).not.toMatch(/_context_summary/)
+      expect(code, f).not.toMatch(/generateGraphHash|computeClientHash/)
+    }
+  })
+
+  it('the store never reads v5AnalysisFact.freshness, useStaleGuard, or _context_summary', () => {
+    // The store legitimately holds an unrelated `v5AnalysisFact` slice; what is
+    // forbidden is sourcing freshness from `v5AnalysisFact.freshness`.
+    const code = read('src/canvas/store.ts')
+    expect(code).not.toMatch(/v5AnalysisFact\s*\??\.\s*freshness/)
+    expect(code).not.toMatch(/useStaleGuard/)
+    expect(code).not.toMatch(/_context_summary/)
+  })
+})

--- a/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
@@ -20,10 +20,6 @@ import type { EdgeData } from '../../domain/edges'
 import { resolveDisplayedFreshness } from '../analysisFreshness'
 import { createScenario } from '../scenarios'
 
-const T1 = '2026-06-23T10:00:00.000Z'
-const T2 = '2026-06-23T12:00:00.000Z'
-const T3 = '2026-06-23T14:00:00.000Z'
-
 const node = (id: string): Node =>
   ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id } }) as Node
 const edge = (id: string, source: string, target: string): Edge<EdgeData> =>
@@ -41,9 +37,18 @@ function seed(nodes: Node[] = [node('n1'), node('n2')], edges: Edge<EdgeData>[] 
   })
 }
 
-/** Apply a CEE 'fresh' verdict (and clear any pending overlay, as a real run does). */
-function applyFresh(computedAt = T1) {
-  useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', computed_at: computedAt })
+/**
+ * Apply a CEE 'fresh' verdict using the ACTUAL supported payload shape
+ * (freshness + freshness_reason only — the CEE contract carries no computed_at
+ * or graph-hash on analysis_ready).
+ */
+function applyFresh() {
+  useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
+}
+
+/** Reset the dirty overlay for test isolation (a real store action, not a synthetic field). */
+function clearDirty() {
+  useCanvasStore.getState().clearAnalysisFreshnessDirty()
 }
 
 const dirty = () => useCanvasStore.getState().analysisFreshnessDirty
@@ -115,10 +120,22 @@ describe('dirty overlay — analysis-affecting edits downgrade a retained fresh 
     expect(displayed()).toBe('unknown')
   })
 
+  it('#2f Backspace/Delete edge removal via onEdgesChange → displayed unknown, never stale', () => {
+    // React Flow's built-in delete (default deleteKeyCode = Backspace) routes edge
+    // removals through onEdgesChange ONLY — not deleteEdgeById/deleteSelected.
+    seed([node('n1'), node('n2')], [edge('e1', 'n1', 'n2')])
+    applyFresh()
+    useCanvasStore.getState().onEdgesChange([{ type: 'remove', id: 'e1' }])
+    expect(useCanvasStore.getState().edges).toHaveLength(0) // edge actually removed
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+    expect(displayed()).not.toBe('stale') // overlay never fabricates 'stale'
+  })
+
   it('#3 undo of an analysis-affecting edit → displayed unknown', () => {
     applyFresh()
     useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
-    applyFresh(T2) // a fresh re-run clears the overlay so we isolate undo's effect
+    clearDirty() // reset for isolation (a real store action, not a synthetic verdict)
     expect(dirty()).toBe(false)
     useCanvasStore.getState().undo()
     expect(dirty()).toBe(true)
@@ -126,11 +143,10 @@ describe('dirty overlay — analysis-affecting edits downgrade a retained fresh 
   })
 
   it('#3b redo of an analysis-affecting edit → displayed unknown', () => {
-    applyFresh(T1)
+    applyFresh()
     useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
-    applyFresh(T2) // newer run clears the overlay
     useCanvasStore.getState().undo()
-    applyFresh(T3) // newer-still run clears again, to isolate redo's effect
+    clearDirty() // reset for isolation
     expect(dirty()).toBe(false)
     useCanvasStore.getState().redo()
     expect(dirty()).toBe(true)
@@ -163,17 +179,23 @@ describe('dirty overlay — verdict lifecycle', () => {
     expect(displayed()).toBe('fresh')
   })
 
-  it('#6 a new analysis_ready clears the dirty overlay', () => {
+  it('#6 a new analysis_ready with a CHANGED verdict clears the overlay (real payload shape)', () => {
+    // Honest path: when the rerun's verdict CONTENT differs (here fresh→stale,
+    // freshness-only shape), the reducer applies it and clears the overlay. No
+    // synthetic computed_at. (The same-verdict rerun case is the run-identity
+    // clear in applyV5State — see applyV5State.results-hydration.test.ts.)
     applyFresh()
     useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
     expect(dirty()).toBe(true)
-    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', computed_at: T2 })
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
     expect(dirty()).toBe(false)
-    expect(displayed()).toBe('fresh')
+    expect(verdict()).toBe('stale')
+    expect(displayed()).toBe('stale')
   })
 
-  it('#6b a re-delivered (echoed) analysis_ready does NOT clear the dirty overlay', () => {
-    // computed_at is absent from the CEE contract; an echoed identical payload on a
+  it('#6b a re-delivered (echoed) identical analysis_ready does NOT clear the overlay', () => {
+    // Actual supported payload shape (freshness + freshness_reason only). With no
+    // computed_at / run id on analysis_ready, an echoed identical payload on a
     // conversational turn must not flip the notice back to fresh after a real edit.
     const payload = { freshness: 'fresh' as const, freshness_reason: 'graph_hash_match' }
     useCanvasStore.getState().setAnalysisFreshness(payload)
@@ -185,7 +207,7 @@ describe('dirty overlay — verdict lifecycle', () => {
   })
 
   it('#7 a CEE stale verdict is never downgraded, even after a local edit', () => {
-    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', computed_at: T1 })
+    useCanvasStore.getState().setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
     useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
     expect(dirty()).toBe(true) // overlay set...
     expect(verdict()).toBe('stale')

--- a/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
@@ -242,6 +242,14 @@ describe('dirty overlay — additional analysis-affecting mutations (review roun
     expect(displayed()).toBe('unknown')
   })
 
+  it('setOutcomeNode no-op (same node) does not dirty', () => {
+    useCanvasStore.setState({ outcomeNodeId: 'n1' })
+    applyFresh()
+    useCanvasStore.getState().setOutcomeNode('n1') // unchanged → no dirty
+    expect(dirty()).toBe(false)
+    expect(displayed()).toBe('fresh')
+  })
+
   it('batchUpdateNodes does NOT dirty — it is the CEE intervention-backfill producer, not a user edit', () => {
     // batchUpdateNodes writes CEE's own analysis_ready data (interventions) back
     // onto option nodes for consistency, right after a fresh verdict is ingested.

--- a/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
@@ -215,6 +215,50 @@ describe('dirty overlay — verdict lifecycle', () => {
   })
 })
 
+describe('dirty overlay — additional analysis-affecting mutations (review round)', () => {
+  it('user setGoalThreshold dirties; CEE-sync write does not', () => {
+    applyFresh()
+    useCanvasStore.getState().setGoalThreshold(50) // user change
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+
+    // CEE-sync producer write must NOT self-dirty.
+    useCanvasStore.setState({ analysisFreshnessDirty: false, goalThreshold: null })
+    useCanvasStore.getState().setGoalThreshold(80, { fromCeeSync: true })
+    expect(dirty()).toBe(false)
+  })
+
+  it('setGoalThreshold no-op (same value) does not dirty', () => {
+    useCanvasStore.setState({ goalThreshold: 50 })
+    applyFresh()
+    useCanvasStore.getState().setGoalThreshold(50) // unchanged
+    expect(dirty()).toBe(false)
+  })
+
+  it('setOutcomeNode change dirties (goal/outcome reselection)', () => {
+    applyFresh()
+    useCanvasStore.getState().setOutcomeNode('n2')
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
+  it('batchUpdateNodes dirties on an analytical change, not a cosmetic one', () => {
+    applyFresh()
+    useCanvasStore.getState().batchUpdateNodes(
+      [{ id: 'n1', data: { observedState: { value: 0.7 } } as Node['data'] }],
+      'analytical',
+    )
+    expect(dirty()).toBe(true)
+
+    useCanvasStore.setState({ analysisFreshnessDirty: false })
+    useCanvasStore.getState().batchUpdateNodes(
+      [{ id: 'n1', data: { label: 'Renamed' } as Node['data'] }],
+      'cosmetic',
+    )
+    expect(dirty()).toBe(false)
+  })
+})
+
 describe('dirty overlay — scenario / reset boundaries', () => {
   it('#8 loadScenario resets BOTH the CEE verdict and the dirty overlay', () => {
     const s = createScenario({ name: 'Scenario A', nodes: [node('s1')], edges: [] })

--- a/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
@@ -242,20 +242,19 @@ describe('dirty overlay — additional analysis-affecting mutations (review roun
     expect(displayed()).toBe('unknown')
   })
 
-  it('batchUpdateNodes dirties on an analytical change, not a cosmetic one', () => {
+  it('batchUpdateNodes does NOT dirty — it is the CEE intervention-backfill producer, not a user edit', () => {
+    // batchUpdateNodes writes CEE's own analysis_ready data (interventions) back
+    // onto option nodes for consistency, right after a fresh verdict is ingested.
+    // It must NOT dirty/invalidate that verdict (an earlier round wrongly did,
+    // wiping a fresh draft). The producer's real model change (the graph replace)
+    // is dirtied by applyDraftResult/DraftChat, not here.
     applyFresh()
     useCanvasStore.getState().batchUpdateNodes(
       [{ id: 'n1', data: { observedState: { value: 0.7 } } as Node['data'] }],
-      'analytical',
-    )
-    expect(dirty()).toBe(true)
-
-    useCanvasStore.setState({ analysisFreshnessDirty: false })
-    useCanvasStore.getState().batchUpdateNodes(
-      [{ id: 'n1', data: { label: 'Renamed' } as Node['data'] }],
-      'cosmetic',
+      'backfill-interventions',
     )
     expect(dirty()).toBe(false)
+    expect(displayed()).toBe('fresh')
   })
 })
 

--- a/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
@@ -104,6 +104,17 @@ describe('dirty overlay — analysis-affecting edits downgrade a retained fresh 
     expect(displayed()).toBe('unknown')
   })
 
+  it('#2e inline goal-target edit (goal_threshold_raw) → displayed unknown', () => {
+    // The live Model-tab GoalSection writes goal_threshold_raw via updateNode; the
+    // V2 adapter derives the PLoT goal_threshold from it, so this is analytical.
+    applyFresh()
+    useCanvasStore.getState().updateNode('n1', {
+      data: { goal_threshold_raw: 80, threshold_source: 'user', threshold_confirmed: false } as Node['data'],
+    })
+    expect(dirty()).toBe(true)
+    expect(displayed()).toBe('unknown')
+  })
+
   it('#3 undo of an analysis-affecting edit → displayed unknown', () => {
     applyFresh()
     useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
@@ -159,6 +170,18 @@ describe('dirty overlay — verdict lifecycle', () => {
     useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', computed_at: T2 })
     expect(dirty()).toBe(false)
     expect(displayed()).toBe('fresh')
+  })
+
+  it('#6b a re-delivered (echoed) analysis_ready does NOT clear the dirty overlay', () => {
+    // computed_at is absent from the CEE contract; an echoed identical payload on a
+    // conversational turn must not flip the notice back to fresh after a real edit.
+    const payload = { freshness: 'fresh' as const, freshness_reason: 'graph_hash_match' }
+    useCanvasStore.getState().setAnalysisFreshness(payload)
+    useCanvasStore.getState().updateNode('n1', { data: { observedState: { value: 0.7 } } as Node['data'] })
+    expect(dirty()).toBe(true)
+    useCanvasStore.getState().setAnalysisFreshness(payload) // echo of the same run
+    expect(dirty()).toBe(true) // overlay retained
+    expect(displayed()).toBe('unknown')
   })
 
   it('#7 a CEE stale verdict is never downgraded, even after a local edit', () => {

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -39,6 +39,17 @@ function nonEmptyString(v: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined
 }
 
+/** Field-wise equality — used to treat a re-delivered identical payload as a no-op. */
+function sameVerdict(a: AnalysisFreshnessState, b: AnalysisFreshnessState): boolean {
+  return (
+    a.freshness === b.freshness &&
+    a.freshnessReason === b.freshnessReason &&
+    a.graphHashAtRun === b.graphHashAtRun &&
+    a.currentGraphHash === b.currentGraphHash &&
+    a.computedAt === b.computedAt
+  )
+}
+
 /**
  * Pure reducer for the analysis-freshness slice. See module doc for the rules.
  * `rawAnalysisReady` is the verbatim `response.analysis_ready` (or null/undefined
@@ -67,18 +78,30 @@ export function deriveAnalysisFreshnessUpdate(
 
   // Order by computed_at: ignore a strictly-older (or equal) payload when both
   // timestamps are present. When the new payload has no computed_at we cannot
-  // order it, so we apply it as the latest turn's verdict.
+  // order it, so we fall through to the content check below.
   if (prev?.computedAt && computedAt && computedAt <= prev.computedAt) {
     return prev
   }
 
-  return {
+  const next: AnalysisFreshnessState = {
     freshness,
     freshnessReason: nonEmptyString(o.freshness_reason),
     graphHashAtRun: nonEmptyString(o.graph_hash_at_run),
     currentGraphHash: nonEmptyString(o.current_graph_hash),
     computedAt,
   }
+
+  // Echo guard: a re-delivered payload identical to the stored verdict is a no-op
+  // (returns the same reference). This matters because `computed_at` is not part
+  // of the CEE analysis_ready contract today — without this, every re-delivered
+  // analysis_ready (e.g. echoed on a conversational turn) would look like a new
+  // verdict and wrongly clear the local dirty overlay. With it, a reference
+  // change reliably means "a genuinely new/changed verdict".
+  if (prev && sameVerdict(prev, next)) {
+    return prev
+  }
+
+  return next
 }
 
 /**

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -80,3 +80,26 @@ export function deriveAnalysisFreshnessUpdate(
     computedAt,
   }
 }
+
+/**
+ * Local dirty-overlay display rule.
+ *
+ * CEE's verdict (`state.freshness`) is the source of truth. The local dirty
+ * overlay is set by analysis-affecting local edits (see the store wiring) and
+ * cleared when a new `analysis_ready` arrives or the scenario resets.
+ *
+ * The ONLY thing the overlay may do is downgrade a retained `fresh` verdict to
+ * `unknown` (cannot-confirm) — it never fabricates `stale`, never upgrades, and
+ * never touches a CEE `stale`/`unknown`/`none` verdict. Returns the value to
+ * display, or null when there is no verdict to show.
+ */
+export function resolveDisplayedFreshness(
+  state: AnalysisFreshnessState | null,
+  dirty: boolean,
+): AnalysisFreshnessValue | null {
+  if (!state) return null
+  // Suppress a stale-since-edit 'fresh' verdict to cannot-confirm. CEE 'stale'
+  // stays 'stale'; everything else passes through unchanged.
+  if (state.freshness === 'fresh' && dirty) return 'unknown'
+  return state.freshness
+}

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -1,0 +1,82 @@
+/**
+ * Analysis freshness slice — sourced ONLY from `response.analysis_ready`.
+ *
+ * Deliberately independent of `v5AnalysisFact` and `useStaleGuard` (both
+ * excluded by the brief) and of `ceeAnalysisReady` (which is cleared on
+ * analyse-turns-without-analysis_ready and on graph edits — that conflicts with
+ * the "retain last verdict" requirement). This slice holds CEE's last freshness
+ * verdict verbatim and follows three rules:
+ *   - retain: a turn WITHOUT analysis_ready keeps the previous verdict;
+ *   - never absence→fresh: a present payload with missing/invalid freshness
+ *     degrades to 'unknown', never 'fresh';
+ *   - order by computed_at: a strictly-older payload is ignored.
+ *
+ * The UI renders this verdict as cautious, non-scientific messaging. Supporting
+ * fields (reason / hashes / computed_at) are held for ordering and debug only —
+ * they are technical and must not be shown as user copy.
+ */
+
+export type AnalysisFreshnessValue = 'fresh' | 'stale' | 'unknown' | 'none'
+
+export interface AnalysisFreshnessState {
+  freshness: AnalysisFreshnessValue
+  /** Technical reason code from CEE (e.g. 'graph_hash_match') — debug only, never user copy. */
+  freshnessReason?: string
+  graphHashAtRun?: string
+  currentGraphHash?: string
+  /** ISO timestamp used to order updates. */
+  computedAt?: string
+}
+
+const VALID: ReadonlySet<AnalysisFreshnessValue> = new Set([
+  'fresh',
+  'stale',
+  'unknown',
+  'none',
+])
+
+function nonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+/**
+ * Pure reducer for the analysis-freshness slice. See module doc for the rules.
+ * `rawAnalysisReady` is the verbatim `response.analysis_ready` (or null/undefined
+ * when the turn carried none).
+ */
+export function deriveAnalysisFreshnessUpdate(
+  prev: AnalysisFreshnessState | null,
+  rawAnalysisReady: unknown,
+): AnalysisFreshnessState | null {
+  // Retain: absence of analysis_ready never changes (and never clears) the verdict.
+  if (rawAnalysisReady === null || typeof rawAnalysisReady !== 'object') {
+    return prev
+  }
+
+  const o = rawAnalysisReady as Record<string, unknown>
+
+  // Never absence→fresh: a present payload with a missing/invalid freshness
+  // value degrades to 'unknown', not 'fresh'.
+  const fRaw = o.freshness
+  const freshness: AnalysisFreshnessValue =
+    typeof fRaw === 'string' && VALID.has(fRaw as AnalysisFreshnessValue)
+      ? (fRaw as AnalysisFreshnessValue)
+      : 'unknown'
+
+  const computedAt = nonEmptyString(o.computed_at)
+
+  // Order by computed_at: ignore a strictly-older (or equal) payload when both
+  // timestamps are present. When the new payload has no computed_at we cannot
+  // order it, so we apply it as the latest turn's verdict.
+  if (prev?.computedAt && computedAt && computedAt <= prev.computedAt) {
+    return prev
+  }
+
+  return {
+    freshness,
+    freshnessReason: nonEmptyString(o.freshness_reason),
+    graphHashAtRun: nonEmptyString(o.graph_hash_at_run),
+    currentGraphHash: nonEmptyString(o.current_graph_hash),
+    computedAt,
+  }
+}

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -126,3 +126,34 @@ export function resolveDisplayedFreshness(
   if (state.freshness === 'fresh' && dirty) return 'unknown'
   return state.freshness
 }
+
+/** Copy-oriented classification of the displayed freshness. */
+export type FreshnessDisplaySemantic = 'current' | 'changed' | 'cannot_confirm' | 'none'
+
+/**
+ * Classify the displayed freshness for COPY decisions across the visible
+ * AI-panel surfaces (composer placeholder, Results stale banner, chip relabel).
+ * Single source so those surfaces can't drift from each other or from the CEE
+ * verdict — and so none of them re-derive currentness from the dead useStaleGuard.
+ *
+ * Distinguishes a model that definitely CHANGED since the run — a CEE 'stale'
+ * verdict, OR a local edit that downgraded a retained 'fresh' (the dirty overlay)
+ * — from a CANNOT-CONFIRM state where CEE itself could not determine freshness
+ * (a present analysis_ready with missing/invalid freshness → 'unknown'). The two
+ * warrant different copy: "you've changed the model" vs the neutral "can't confirm
+ * this is current". 'changed' must never be claimed for a CEE-sourced 'unknown'.
+ */
+export function classifyFreshnessForDisplay(
+  state: AnalysisFreshnessState | null,
+  dirty: boolean,
+): FreshnessDisplaySemantic {
+  const displayed = resolveDisplayedFreshness(state, dirty)
+  if (displayed === null || displayed === 'none') return 'none'
+  if (displayed === 'fresh') return 'current'
+  if (displayed === 'stale') return 'changed'
+  // displayed === 'unknown': only the dirty-overlay downgrade of a retained
+  // 'fresh' verdict means the user definitely changed the model since the run.
+  // A CEE-sourced 'unknown' (state.freshness === 'unknown') is cannot-confirm.
+  if (state?.freshness === 'fresh' && dirty) return 'changed'
+  return 'cannot_confirm'
+}

--- a/src/canvas/utils/__tests__/applyDraftResult.spec.ts
+++ b/src/canvas/utils/__tests__/applyDraftResult.spec.ts
@@ -22,6 +22,8 @@ const mockSetCeeQuality = vi.fn()
 const mockSetGoalConstraints = vi.fn()
 const mockSetDraftCoaching = vi.fn()
 const mockSetPreAnalysisSensitivity = vi.fn()
+const mockMarkAnalysisFreshnessDirty = vi.fn()
+const mockSetAnalysisFreshness = vi.fn()
 
 let storeNodes: any[] = []
 let storeEdges: any[] = []
@@ -39,6 +41,8 @@ vi.mock('../../store', () => ({
         setPendingLayout: mockSetPendingLayout,
         setOutcomeNode: mockSetOutcomeNode,
         setCeeAnalysisReady: mockSetCeeAnalysisReady,
+        markAnalysisFreshnessDirty: mockMarkAnalysisFreshnessDirty,
+        setAnalysisFreshness: mockSetAnalysisFreshness,
         setCeePipelineTrace: mockSetCeePipelineTrace,
         setCeeQuality: mockSetCeeQuality,
         setGoalConstraints: mockSetGoalConstraints,
@@ -192,6 +196,35 @@ describe('applyDraftResult', () => {
 
     applyDraftResult(draftData)
     expect(mockSetCeeAnalysisReady).toHaveBeenCalledWith(draftData.analysis_ready)
+  })
+
+  it('marks the freshness overlay dirty on the draft graph replace (no false-fresh)', () => {
+    const draftData = {
+      nodes: [{ id: 'g1', kind: 'goal', label: 'Revenue' }],
+      edges: [],
+    } as any
+    applyDraftResult(draftData)
+    // Draft replaces the graph via bare setState (bypasses the edit chokepoints),
+    // so the overlay must be marked dirty — a draft after a fresh analysis must not
+    // keep showing 'fresh'.
+    expect(mockMarkAnalysisFreshnessDirty).toHaveBeenCalled()
+  })
+
+  it('routes the draft analysis_ready through the freshness reducer', () => {
+    const draftData = {
+      nodes: [{ id: 'g1', kind: 'goal', label: 'Revenue' }],
+      edges: [],
+      analysis_ready: {
+        options: [{ id: 'o1', status: 'ready', interventions: {} }],
+        goal_node_id: 'g1',
+        status: 'ready',
+        // no `freshness` — a draft is readiness, not a run; reducer degrades to unknown
+      },
+    } as any
+    applyDraftResult(draftData)
+    // The patch's analysis_ready is routed to the freshness reducer (not just
+    // setCeeAnalysisReady), carrying the same payload so a stale 'fresh' can't survive.
+    expect(mockSetAnalysisFreshness).toHaveBeenCalledWith(draftData.analysis_ready)
   })
 
   it('returns zero counts for empty graph', () => {

--- a/src/canvas/utils/__tests__/deriveAnalysisDisplayState.spec.ts
+++ b/src/canvas/utils/__tests__/deriveAnalysisDisplayState.spec.ts
@@ -10,7 +10,7 @@ function makeInput(
   return {
     ceeAnalysisReadyStatus: undefined,
     hasReport: false,
-    graphEditedSinceLastRun: false,
+    analysisChanged: false,
     ...overrides,
   }
 }
@@ -30,12 +30,12 @@ describe('deriveAnalysisDisplayState', () => {
   })
 
   describe('complete', () => {
-    it('CEE ready + hasReport && !graphEditedSinceLastRun → complete', () => {
+    it('CEE ready + hasReport && !analysisChanged → complete', () => {
       const view = deriveAnalysisDisplayState(
         makeInput({
           ceeAnalysisReadyStatus: 'ready',
           hasReport: true,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       expect(view.state).toBe('complete')
@@ -47,12 +47,12 @@ describe('deriveAnalysisDisplayState', () => {
   })
 
   describe('results_stale', () => {
-    it('CEE ready + hasReport && graphEditedSinceLastRun → results_stale', () => {
+    it('CEE ready + hasReport && analysisChanged → results_stale', () => {
       const view = deriveAnalysisDisplayState(
         makeInput({
           ceeAnalysisReadyStatus: 'ready',
           hasReport: true,
-          graphEditedSinceLastRun: true,
+          analysisChanged: true,
         }),
       )
       expect(view.state).toBe('results_stale')
@@ -91,7 +91,7 @@ describe('deriveAnalysisDisplayState', () => {
             makeInput({
               ceeAnalysisReadyStatus: status,
               hasReport: true,
-              graphEditedSinceLastRun: stale,
+              analysisChanged: stale,
             }),
           )
           expect(view.state).toBe('not_ready')
@@ -121,7 +121,7 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: undefined,
           hasReport: true,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       expect(view.state).toBe('complete')
@@ -133,7 +133,7 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: 'missing',
           hasReport: true,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       expect(view.state).toBe('complete')
@@ -144,7 +144,7 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: undefined,
           hasReport: true,
-          graphEditedSinceLastRun: true,
+          analysisChanged: true,
         }),
       )
       expect(view.state).toBe('results_stale')
@@ -157,7 +157,7 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: 'some_future_value',
           hasReport: true,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       expect(view.state).toBe('complete')
@@ -175,7 +175,7 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: 'ready',
           hasReport: false,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       expect(view.state).toBe('ready_to_analyse')
@@ -188,7 +188,7 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: undefined,
           hasReport: false,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       expect(view.state).toBe('not_ready')
@@ -205,7 +205,7 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: 'ready',
           hasReport: true,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       expect(before.state).toBe('ready_to_analyse')
@@ -217,14 +217,14 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: 'ready',
           hasReport: true,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       const after = deriveAnalysisDisplayState(
         makeInput({
           ceeAnalysisReadyStatus: 'ready',
           hasReport: true,
-          graphEditedSinceLastRun: true,
+          analysisChanged: true,
         }),
       )
       expect(before.state).toBe('complete')
@@ -236,14 +236,14 @@ describe('deriveAnalysisDisplayState', () => {
         makeInput({
           ceeAnalysisReadyStatus: 'ready',
           hasReport: true,
-          graphEditedSinceLastRun: false,
+          analysisChanged: false,
         }),
       )
       const after = deriveAnalysisDisplayState(
         makeInput({
           ceeAnalysisReadyStatus: 'needs_user_mapping',
           hasReport: true,
-          graphEditedSinceLastRun: true,
+          analysisChanged: true,
         }),
       )
       expect(before.state).toBe('complete')

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -145,6 +145,12 @@ export function applyDraftResult(
   // shape drift is logged via devWarn in DEV builds only.
   validateNodesBatch(nodes)
 
+  // Draft application replaces the graph via bare setState (bypasses the edit
+  // chokepoints), so mark the freshness overlay dirty. If the draft carries an
+  // analysis_ready verdict it is routed through setAnalysisFreshness below, which
+  // clears the overlay only when a genuine fresh verdict accompanies it.
+  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+
   // Defer layout until React Flow has measured the inserted nodes (D2 of
   // layout-stabilisation brief). The measurement hook in ReactFlowGraph
   // runs applyLayout once every unlocked node has measured.width/height,
@@ -178,6 +184,11 @@ export function applyDraftResult(
       ? { ...draftData.analysis_ready, coaching_summary: coachingSummary }
       : draftData.analysis_ready
     useCanvasStore.getState().setCeeAnalysisReady(analysisReadyWithCoaching)
+    // Route the draft's analysis_ready through the freshness source of truth
+    // (mirrors the accepted-patch path). A draft is readiness, not a run — it
+    // typically carries no `freshness`, so the reducer degrades to 'unknown'
+    // rather than leaving a prior 'fresh' verdict showing false-fresh.
+    useCanvasStore.getState().setAnalysisFreshness?.(analysisReadyWithCoaching)
 
     // Backfill interventions onto option nodes. CEE publishes intervention data
     // via analysis_ready.options[], not via graph_patch add_node operations, so

--- a/src/canvas/utils/deriveAnalysisDisplayState.ts
+++ b/src/canvas/utils/deriveAnalysisDisplayState.ts
@@ -25,8 +25,15 @@ export interface DeriveAnalysisDisplayStateInput {
   ceeAnalysisReadyStatus: string | undefined
   /** True when results.report is non-null (populated run response). */
   hasReport: boolean
-  /** Canvas-store flag: true when the graph was edited after the last run. */
-  graphEditedSinceLastRun: boolean
+  /**
+   * True when the analysis is DEFINITELY out of date — the shared CEE freshness
+   * display semantic (`classifyFreshnessForDisplay`) is 'changed' (CEE 'stale'
+   * OR a retained-fresh-now-dirtied by a local edit). Sourced via the hook from
+   * the CEE freshness slice + dirty overlay, NOT the local `graphEditedSinceLastRun`
+   * flag — so 'cannot_confirm' (CEE-unknown) never fabricates a 'Results may be
+   * outdated' claim here (it falls through to the neutral 'complete' completion fact).
+   */
+  analysisChanged: boolean
 }
 
 export interface AnalysisDisplayCTA {
@@ -71,11 +78,13 @@ function isExplicitNotReady(status: string | undefined): boolean {
  * Precedence (first match wins):
  *   1. Explicit non-ready CEE status (needs_encoding / needs_user_mapping /
  *      needs_user_input) → 'not_ready' even when a prior report exists.
- *   2. hasReport && !graphEditedSinceLastRun → 'complete'
+ *   2. hasReport && !analysisChanged → 'complete'
  *      Works even when readiness is briefly absent (undefined / 'missing'),
  *      because a populated, current report stands on its own — readiness
- *      gating only matters before a successful run lands.
- *   3. hasReport && graphEditedSinceLastRun → 'results_stale'
+ *      gating only matters before a successful run lands. (Includes the
+ *      CEE-unknown 'cannot_confirm' case: 'Analysis complete' is a completion
+ *      fact, not a freshness claim, so it is the correct neutral fallback.)
+ *   3. hasReport && analysisChanged → 'results_stale'
  *   4. ceeAnalysisReadyStatus === 'ready' (no report) → 'ready_to_analyse'
  *   5. else (no report, no readiness signal) → 'not_ready'
  *
@@ -88,7 +97,7 @@ function isExplicitNotReady(status: string | undefined): boolean {
 export function deriveAnalysisDisplayState(
   input: DeriveAnalysisDisplayStateInput,
 ): AnalysisDisplayStateView {
-  const { ceeAnalysisReadyStatus, hasReport, graphEditedSinceLastRun } = input
+  const { ceeAnalysisReadyStatus, hasReport, analysisChanged } = input
 
   if (isExplicitNotReady(ceeAnalysisReadyStatus)) {
     return {
@@ -100,7 +109,7 @@ export function deriveAnalysisDisplayState(
     }
   }
 
-  if (hasReport && !graphEditedSinceLastRun) {
+  if (hasReport && !analysisChanged) {
     return {
       state: 'complete',
       headline: 'Analysis complete',
@@ -110,7 +119,7 @@ export function deriveAnalysisDisplayState(
     }
   }
 
-  if (hasReport && graphEditedSinceLastRun) {
+  if (hasReport && analysisChanged) {
     return {
       state: 'results_stale',
       headline: 'Results may be outdated',

--- a/src/canvas/utils/deriveAnalysisDisplayState.ts
+++ b/src/canvas/utils/deriveAnalysisDisplayState.ts
@@ -80,10 +80,10 @@ function isExplicitNotReady(status: string | undefined): boolean {
  *      needs_user_input) → 'not_ready' even when a prior report exists.
  *   2. hasReport && !analysisChanged → 'complete'
  *      Works even when readiness is briefly absent (undefined / 'missing'),
- *      because a populated, current report stands on its own — readiness
- *      gating only matters before a successful run lands. (Includes the
- *      CEE-unknown 'cannot_confirm' case: 'Analysis complete' is a completion
- *      fact, not a freshness claim, so it is the correct neutral fallback.)
+ *      because a populated report stands on its own — readiness gating only
+ *      matters before a successful run lands. 'Analysis complete' is a completion
+ *      fact, not a currentness claim, so this is also the correct neutral
+ *      fallback for the CEE-unknown 'cannot_confirm' case (which is NOT 'changed').
  *   3. hasReport && analysisChanged → 'results_stale'
  *   4. ceeAnalysisReadyStatus === 'ready' (no report) → 'ready_to_analyse'
  *   5. else (no report, no readiness signal) → 'not_ready'

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -2419,6 +2419,9 @@ export async function captureDisplayState(): Promise<DisplayState> {
     const { deriveAnalysisDisplayState } = await import(
       '../../../canvas/utils/deriveAnalysisDisplayState'
     )
+    const { classifyFreshnessForDisplay } = await import(
+      '../../../canvas/store/analysisFreshness'
+    )
     const state = useCanvasStore.getState()
 
     const nodes = state.nodes ?? []
@@ -2620,13 +2623,17 @@ export async function captureDisplayState(): Promise<DisplayState> {
     const ceeStatus = (state as { ceeAnalysisReady?: { status?: string } | null })
       .ceeAnalysisReady?.status
     const hasReport = Boolean((results as { report?: unknown } | null | undefined)?.report)
-    const graphEditedSinceLastRun = Boolean(
-      (state as { graphEditedSinceLastRun?: boolean }).graphEditedSinceLastRun,
-    )
+    // CEE-sourced staleness (shared display semantic === 'changed'), mirroring
+    // the runtime hook — NOT the local graphEditedSinceLastRun flag.
+    const analysisChanged =
+      classifyFreshnessForDisplay(
+        (state as { analysisFreshness?: Parameters<typeof classifyFreshnessForDisplay>[0] }).analysisFreshness ?? null,
+        Boolean((state as { analysisFreshnessDirty?: boolean }).analysisFreshnessDirty),
+      ) === 'changed'
     const displayView = deriveAnalysisDisplayState({
       ceeAnalysisReadyStatus: ceeStatus,
       hasReport,
-      graphEditedSinceLastRun,
+      analysisChanged,
     })
 
     return {

--- a/src/components/results/AnalysisFreshnessNotice.stories.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * AnalysisFreshnessNotice — the four freshness states + the unset (hidden) case.
+ * Prop-driven (the `state` override stands in for the store slice).
+ */
+import React from 'react'
+import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
+import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
+
+export default {
+  title: 'Results/AnalysisFreshnessNotice',
+  parameters: { layout: 'padded', backgrounds: { default: 'panel' } },
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ width: 380, fontFamily: 'Inter, system-ui, sans-serif' }}>{children}</div>
+  )
+}
+
+const story = (state: AnalysisFreshnessState | null) => () => (
+  <Wrapper>
+    <AnalysisFreshnessNotice state={state} />
+  </Wrapper>
+)
+
+type Story = (() => React.ReactElement) & { storyName?: string }
+
+export const Fresh: Story = story({ freshness: 'fresh' })
+Fresh.storyName = '1 · fresh'
+
+export const Stale: Story = story({ freshness: 'stale' })
+Stale.storyName = '2 · stale'
+
+export const Unknown: Story = story({ freshness: 'unknown' })
+Unknown.storyName = '3 · unknown'
+
+export const None: Story = story({ freshness: 'none' })
+None.storyName = '4 · none'
+
+export const Unset: Story = () => (
+  <Wrapper>
+    {/* Slice unset → renders nothing (placeholder text below is just the story note). */}
+    <p style={{ fontSize: 11, color: 'var(--text-light)' }}>
+      Slice unset — the notice renders nothing (no verdict to show).
+    </p>
+    <AnalysisFreshnessNotice state={null} />
+  </Wrapper>
+)
+Unset.storyName = '5 · unset (missing analysis_ready → hidden)'

--- a/src/components/results/AnalysisFreshnessNotice.stories.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.stories.tsx
@@ -17,9 +17,9 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   )
 }
 
-const story = (state: AnalysisFreshnessState | null) => () => (
+const story = (state: AnalysisFreshnessState | null, dirty = false) => () => (
   <Wrapper>
-    <AnalysisFreshnessNotice state={state} />
+    <AnalysisFreshnessNotice state={state} dirty={dirty} />
   </Wrapper>
 )
 
@@ -36,6 +36,15 @@ Unknown.storyName = '3 · unknown'
 
 export const None: Story = story({ freshness: 'none' })
 None.storyName = '4 · none'
+
+// CEE verdict is 'fresh' but a local analysis-affecting edit set the dirty
+// overlay → the notice shows the cannot-confirm (unknown) message instead.
+export const FreshButDirty: Story = story({ freshness: 'fresh' }, true)
+FreshButDirty.storyName = '6 · fresh + local edit (downgraded to cannot-confirm)'
+
+// CEE 'stale' is never downgraded by the overlay, even after an edit.
+export const StaleStaysStale: Story = story({ freshness: 'stale' }, true)
+StaleStaysStale.storyName = '7 · stale + local edit (stays stale)'
 
 export const Unset: Story = () => (
   <Wrapper>

--- a/src/components/results/AnalysisFreshnessNotice.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.tsx
@@ -1,0 +1,72 @@
+/**
+ * AnalysisFreshnessNotice — cautious freshness/staleness messaging for the
+ * Analysis results path.
+ *
+ * Renders CEE's `analysis_ready.freshness` verdict (held in the `analysisFreshness`
+ * store slice) as one of four non-scientific lines. It reads the slice directly
+ * (a `state` prop overrides it for tests/stories). When the slice is unset it
+ * renders nothing — it never asserts a freshness state we don't have.
+ *
+ * Source rules live in the slice reducer (retain / order-by-computed_at /
+ * never-absence→fresh). This component is display-only: it does NOT use
+ * v5AnalysisFact, useStaleGuard, or any local graph-hash computation, and it
+ * never shows the technical reason/hash fields as copy (they ride on data-*).
+ */
+import { AlertTriangle, CheckCircle2, HelpCircle } from 'lucide-react'
+import { useCanvasStore } from '@/canvas/store'
+import { typography } from '@/styles/typography'
+import type {
+  AnalysisFreshnessState,
+  AnalysisFreshnessValue,
+} from '@/canvas/store/analysisFreshness'
+
+/** Cautious, non-scientific copy. One short line per state. */
+export const FRESHNESS_COPY: Record<AnalysisFreshnessValue, string> = {
+  fresh: 'Analysis reflects the current model.',
+  stale: 'Model changed since this analysis. Re-run to update.',
+  unknown: 'Cannot confirm whether this analysis is current.',
+  none: 'No analysis yet.',
+}
+
+const ICON: Record<AnalysisFreshnessValue, typeof AlertTriangle> = {
+  fresh: CheckCircle2,
+  stale: AlertTriangle,
+  unknown: HelpCircle,
+  none: HelpCircle,
+}
+
+export interface AnalysisFreshnessNoticeProps {
+  /** Override the store slice (tests / Storybook). `undefined` → read the store. */
+  state?: AnalysisFreshnessState | null
+  className?: string
+}
+
+export function AnalysisFreshnessNotice({ state: stateProp, className = '' }: AnalysisFreshnessNoticeProps) {
+  const storeState = useCanvasStore((s) => s.analysisFreshness)
+  const state = stateProp !== undefined ? stateProp : storeState
+
+  // No verdict yet → no notice (never claim a freshness state we don't hold).
+  if (!state) return null
+
+  const { freshness } = state
+  const isStale = freshness === 'stale'
+  const Icon = ICON[freshness]
+
+  return (
+    <div
+      data-testid="analysis-freshness-notice"
+      data-freshness={freshness}
+      data-freshness-reason={state.freshnessReason}
+      className={`flex items-center gap-2 rounded-md border px-3 py-2 bg-panel ${isStale ? 'border-warning/30' : 'border-panel-border'} ${className}`.trim()}
+    >
+      <Icon
+        size={14}
+        className={`flex-none ${isStale ? 'text-warning' : 'text-text-light'}`}
+        aria-hidden="true"
+      />
+      <span className={`${typography.panelBody} text-text-body`}>{FRESHNESS_COPY[freshness]}</span>
+    </div>
+  )
+}
+
+export default AnalysisFreshnessNotice

--- a/src/components/results/AnalysisFreshnessNotice.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.tsx
@@ -15,9 +15,10 @@
 import { AlertTriangle, CheckCircle2, HelpCircle } from 'lucide-react'
 import { useCanvasStore } from '@/canvas/store'
 import { typography } from '@/styles/typography'
-import type {
-  AnalysisFreshnessState,
-  AnalysisFreshnessValue,
+import {
+  resolveDisplayedFreshness,
+  type AnalysisFreshnessState,
+  type AnalysisFreshnessValue,
 } from '@/canvas/store/analysisFreshness'
 
 /** Cautious, non-scientific copy. One short line per state. */
@@ -38,24 +39,35 @@ const ICON: Record<AnalysisFreshnessValue, typeof AlertTriangle> = {
 export interface AnalysisFreshnessNoticeProps {
   /** Override the store slice (tests / Storybook). `undefined` → read the store. */
   state?: AnalysisFreshnessState | null
+  /** Override the local dirty overlay (tests / Storybook). `undefined` → read the store. */
+  dirty?: boolean
   className?: string
 }
 
-export function AnalysisFreshnessNotice({ state: stateProp, className = '' }: AnalysisFreshnessNoticeProps) {
+export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, className = '' }: AnalysisFreshnessNoticeProps) {
   const storeState = useCanvasStore((s) => s.analysisFreshness)
+  const storeDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const state = stateProp !== undefined ? stateProp : storeState
+  const dirty = dirtyProp !== undefined ? dirtyProp : storeDirty
 
   // No verdict yet → no notice (never claim a freshness state we don't hold).
   if (!state) return null
 
-  const { freshness } = state
+  // CEE verdict is the source of truth; the local dirty overlay may only
+  // downgrade a retained 'fresh' to cannot-confirm (never fabricate 'stale').
+  const freshness = resolveDisplayedFreshness(state, dirty) as AnalysisFreshnessValue
   const isStale = freshness === 'stale'
   const Icon = ICON[freshness]
+  // Mark when the displayed verdict differs from CEE's because of a local edit —
+  // technical signal for tests/debug only, not user copy.
+  const downgraded = state.freshness === 'fresh' && freshness === 'unknown'
 
   return (
     <div
       data-testid="analysis-freshness-notice"
       data-freshness={freshness}
+      data-cee-freshness={state.freshness}
+      data-freshness-dirty={downgraded ? 'true' : undefined}
       data-freshness-reason={state.freshnessReason}
       className={`flex items-center gap-2 rounded-md border px-3 py-2 bg-panel ${isStale ? 'border-warning/30' : 'border-panel-border'} ${className}`.trim()}
     >

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -16,7 +16,8 @@ import Tooltip from '@/components/Tooltip'
 import { TriageHealthHeader } from '@/components/shared/TriageHealthHeader'
 import type { DecisionHealthRingDimensions } from '@/components/shared/DecisionHealthRing'
 import { HeroQualifier } from './HeroQualifier'
-import { useAnalysisFreshnessState } from '@/lib/useAnalysisFreshnessState'
+import { useCanvasStore } from '@/canvas/store'
+import { resolveDisplayedFreshness } from '@/canvas/store/analysisFreshness'
 import { buildCertaintyCopy } from './utils/certaintyCopy'
 import { typography } from '@/styles/typography'
 import type { ResultsSectionDataReturn } from './useResultsSectionData'
@@ -92,11 +93,17 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
   onSendMessage,
   aiAffordance,
 }: DecisionConfidencePanelProps) {
-  // P0 V5 golden-path repair (Wave 3 wiring, third-round follow-up):
-  // single-source freshness verdict consumed by HeroQualifier alongside
-  // completeness reasons and dimension scores. Stale wire freshness
-  // wins above the other two qualifier sources.
-  const freshnessState = useAnalysisFreshnessState()
+  // Freshness for the hero qualifier comes from the CEE-only freshness slice
+  // (the single source of truth), routed through the same display rule as the
+  // AnalysisFreshnessNotice. This deliberately replaces the legacy
+  // useAnalysisFreshnessState path, which fabricated 'stale' from a local edit
+  // signal — the UI must never fabricate 'stale', and a fabricated stale qualifier
+  // contradicted the CEE-only notice. The hero now surfaces ONLY a genuine CEE
+  // 'stale' verdict (resolveDisplayedFreshness can only ever downgrade fresh→unknown,
+  // never invent stale).
+  const ceeFreshness = useCanvasStore((s) => s.analysisFreshness)
+  const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
+  const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
 
   // Audit B3 (P0): visible auto-noise disclosure marker. Renders only when
   // PLoT explicitly emitted `applied=true` with a provisional calibration
@@ -290,24 +297,17 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
           ringCaption={hasWinProbability ? 'win probability' : undefined}
           secondaryIndicator={stabilityIndicator}
           qualifier={
-            // P0 V5 golden-path repair:
-            //   Wave 3 (third-round follow-up): pass `freshness` and
-            //     `freshnessReason` from `useAnalysisFreshnessState`
-            //     so a stale CEE verdict surfaces ahead of completeness
-            //     and dimension qualifiers. Stale results are the
-            //     highest-impact warning the panel can give.
-            //   Wave 4: pass `completenessReasons` alongside dimensions.
-            //     Partial source data is more critical than a low
-            //     evidence dimension.
-            //   Existing: dimensions remain the lowest-priority qualifier.
+            // Qualifier precedence: a genuine CEE 'stale' verdict is the
+            // highest-impact warning, then completeness reasons, then dimensions.
+            // Freshness is the CEE-only verdict (never a fabricated local stale).
             readinessDimensions ||
             (data.completeness?.reasons?.length ?? 0) > 0 ||
-            freshnessState.freshness === 'stale' ? (
+            displayedFreshness === 'stale' ? (
               <HeroQualifier
                 dimensions={readinessDimensions}
                 completenessReasons={data.completeness?.reasons}
-                freshness={freshnessState.freshness}
-                freshnessReason={freshnessState.reason}
+                freshness={displayedFreshness ?? undefined}
+                freshnessReason={ceeFreshness?.freshnessReason}
               />
             ) : undefined
           }

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -27,6 +27,7 @@ import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWit
 import { DecisionConfidencePanel } from './DecisionConfidencePanel'
 import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
+import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
 import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled } from '@/flags'
 
 export interface StrengthCorrectionDisplay {
@@ -217,6 +218,10 @@ export const ResultsBody = memo(function ResultsBody({
           fact for the scenario. Renders only when canonical flag is ON and
           there is no V5 fact attached. */}
       <AnalysisOrphanBanner />
+
+      {/* Freshness/staleness — CEE analysis_ready.freshness verdict. Renders
+          nothing until a verdict exists; never asserts a state we don't hold. */}
+      <AnalysisFreshnessNotice />
 
       {/* ── DECISION CONFIDENCE TRIAGE ────────────────────────────── */}
       {/* Comparison mode: v17 ABOVE legacy panel. Opt-in only. */}

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -402,11 +402,12 @@ function T1ChecksFooter({
   useV17Copy?: boolean
 }) {
   const hasWinner = !!data.recommendation.recommendedOption
-  // Robustness single source: CEE's categorical robustness level ONLY
-  // (robustnessLevelExplicit — never the UI-SEM-005 stability fallback, and never
-  // a UI-local recommendationStability >= 0.85 threshold). 'high' = robust; any
-  // other CEE level = sensitive; CEE omitted = robustness unknown.
-  const robustnessLevel = data.recommendation.robustnessLevelExplicit
+  // Robustness glyph: driven ONLY by the display-safe robustness verdict
+  // (`robustnessVerdict`) — never PLoT `report.robustness.level`, never the
+  // UI-SEM-005 stability fallback, never a recommendationStability threshold.
+  // No display-safe verdict exists in the contract today, so this is undefined
+  // and the glyph renders "Robustness unknown". See ROBUSTNESS-VERDICT-CONTRACT.
+  const robustnessLevel = data.recommendation.robustnessVerdict
   const robustOk = robustnessLevel === 'high'
   const robustKnown = robustnessLevel != null
   const gaps = data.confidence.topEvidenceGaps ?? data.confidence.evidenceGaps ?? []

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useMemo, memo, useState, type ReactNode } from 'react'
-import { AlertTriangle, Check, ChevronDown, ChevronRight, X } from 'lucide-react'
+import { AlertTriangle, Check, ChevronDown, ChevronRight, HelpCircle, X } from 'lucide-react'
 import { ConditionalWinnerCards } from './ConditionalWinnerCards'
 import { resolveTriageBodyText } from '@/components/shared/resolveTriageBodyText'
 import { dedupTriageItems } from './utils/dedupTriageItems'
@@ -432,6 +432,7 @@ function T1ChecksFooter({
         />
         <ChecksGlyph
           ok={robustOk}
+          unknown={!robustKnown}
           okLabel="Robust"
           notOkLabel={robustKnown ? 'Sensitive' : 'Robustness unknown'}
           dataTestid="checks-robust"
@@ -457,19 +458,30 @@ function ChecksGlyph({
   ok,
   okLabel,
   notOkLabel,
+  unknown = false,
   dataTestid,
 }: {
   ok: boolean
   okLabel: string
   notOkLabel: string
+  /**
+   * Neutral third state: the check could not be determined (e.g. no
+   * display-safe robustness verdict). Renders a muted help glyph, NOT the red
+   * "X" — an unknown is not a failure.
+   */
+  unknown?: boolean
   dataTestid: string
 }) {
-  const Icon = ok ? Check : X
-  const colour = ok ? 'text-success' : 'text-danger'
+  const Icon = unknown ? HelpCircle : ok ? Check : X
+  // Neutral muted colour for unknown (NOT the red danger used for not-ok) — an
+  // undetermined check is not a failure. Class-based so snapshot guards that strip
+  // classes are unaffected.
+  const colour = unknown ? 'text-text-light' : ok ? 'text-success' : 'text-danger'
+  const label = unknown ? notOkLabel : ok ? okLabel : notOkLabel
   return (
     <span className="inline-flex items-center gap-1" data-testid={dataTestid}>
       <Icon size={12} className={`${colour} flex-shrink-0`} aria-hidden="true" />
-      <span>{ok ? okLabel : notOkLabel}</span>
+      <span>{label}</span>
     </span>
   )
 }

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -407,9 +407,9 @@ function T1ChecksFooter({
   // UI-SEM-005 stability fallback, never a recommendationStability threshold.
   // No display-safe verdict exists in the contract today, so this is undefined
   // and the glyph renders "Robustness unknown". See ROBUSTNESS-VERDICT-CONTRACT.
-  const robustnessLevel = data.recommendation.robustnessVerdict
-  const robustOk = robustnessLevel === 'high'
-  const robustKnown = robustnessLevel != null
+  const robustnessVerdict = data.recommendation.robustnessVerdict
+  const robustOk = robustnessVerdict === 'high'
+  const robustKnown = robustnessVerdict != null
   const gaps = data.confidence.topEvidenceGaps ?? data.confidence.evidenceGaps ?? []
   const evidenceWeak = gaps.some(g => typeof g.confidence === 'number' && g.confidence < 50)
   const evidenceKnown = gaps.length > 0

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -402,10 +402,11 @@ function T1ChecksFooter({
   useV17Copy?: boolean
 }) {
   const hasWinner = !!data.recommendation.recommendedOption
-  // Robustness single source: CEE's categorical robustness level (not a UI-local
-  // recommendationStability >= 0.85 threshold). 'high' = robust; any other known
-  // level = sensitive; absent = robustness unknown. One verdict, no competing read.
-  const robustnessLevel = data.recommendation.robustnessLevel
+  // Robustness single source: CEE's categorical robustness level ONLY
+  // (robustnessLevelExplicit — never the UI-SEM-005 stability fallback, and never
+  // a UI-local recommendationStability >= 0.85 threshold). 'high' = robust; any
+  // other CEE level = sensitive; CEE omitted = robustness unknown.
+  const robustnessLevel = data.recommendation.robustnessLevelExplicit
   const robustOk = robustnessLevel === 'high'
   const robustKnown = robustnessLevel != null
   const gaps = data.confidence.topEvidenceGaps ?? data.confidence.evidenceGaps ?? []

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -402,9 +402,12 @@ function T1ChecksFooter({
   useV17Copy?: boolean
 }) {
   const hasWinner = !!data.recommendation.recommendedOption
-  const stability = data.recommendation.recommendationStability
-  const robustOk = typeof stability === 'number' && Number.isFinite(stability) && stability >= 0.85
-  const robustKnown = typeof stability === 'number' && Number.isFinite(stability)
+  // Robustness single source: CEE's categorical robustness level (not a UI-local
+  // recommendationStability >= 0.85 threshold). 'high' = robust; any other known
+  // level = sensitive; absent = robustness unknown. One verdict, no competing read.
+  const robustnessLevel = data.recommendation.robustnessLevel
+  const robustOk = robustnessLevel === 'high'
+  const robustKnown = robustnessLevel != null
   const gaps = data.confidence.topEvidenceGaps ?? data.confidence.evidenceGaps ?? []
   const evidenceWeak = gaps.some(g => typeof g.confidence === 'number' && g.confidence < 50)
   const evidenceKnown = gaps.length > 0

--- a/src/components/results/__tests__/AnalysisFreshnessNotice.spec.tsx
+++ b/src/components/results/__tests__/AnalysisFreshnessNotice.spec.tsx
@@ -1,0 +1,70 @@
+/**
+ * AnalysisFreshnessNotice — four-state rendering, hidden-when-unset, store-read.
+ *
+ * Copy is asserted via the exported FRESHNESS_COPY constant (the single source
+ * of truth) rather than duplicated string literals.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { configureAxe } from 'vitest-axe'
+
+// Controllable store stub so the no-prop (store-read) path is deterministic.
+const h = vi.hoisted(() => ({ slice: null as unknown }))
+vi.mock('@/canvas/store', () => ({
+  useCanvasStore: (sel: (s: { analysisFreshness: unknown }) => unknown) =>
+    sel({ analysisFreshness: h.slice }),
+}))
+
+import { AnalysisFreshnessNotice, FRESHNESS_COPY } from '../AnalysisFreshnessNotice'
+
+const axeConfigured = configureAxe({ rules: { 'color-contrast': { enabled: false } } })
+const TESTID = 'analysis-freshness-notice'
+
+beforeEach(() => {
+  h.slice = null
+})
+
+describe('AnalysisFreshnessNotice — four states (prop-driven)', () => {
+  it.each(['fresh', 'stale', 'unknown', 'none'] as const)('renders the %s message', (freshness) => {
+    render(<AnalysisFreshnessNotice state={{ freshness }} />)
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(FRESHNESS_COPY[freshness])
+    expect(el).toHaveAttribute('data-freshness', freshness)
+  })
+})
+
+describe('AnalysisFreshnessNotice — never asserts a state it does not hold', () => {
+  it('renders nothing when the slice is unset (prop null)', () => {
+    render(<AnalysisFreshnessNotice state={null} />)
+    expect(screen.queryByTestId(TESTID)).toBeNull()
+  })
+
+  it('renders nothing when the store slice is unset (no prop)', () => {
+    h.slice = null
+    render(<AnalysisFreshnessNotice />)
+    expect(screen.queryByTestId(TESTID)).toBeNull()
+  })
+})
+
+describe('AnalysisFreshnessNotice — store-read fallback', () => {
+  it('reads the verdict from the store when no prop is given', () => {
+    h.slice = { freshness: 'stale', freshnessReason: 'graph_hash_match' }
+    render(<AnalysisFreshnessNotice />)
+    expect(screen.getByTestId(TESTID)).toHaveTextContent(FRESHNESS_COPY.stale)
+  })
+
+  it('does not surface the technical reason as user copy', () => {
+    h.slice = { freshness: 'stale', freshnessReason: 'graph_hash_match' }
+    render(<AnalysisFreshnessNotice />)
+    const el = screen.getByTestId(TESTID)
+    expect(el.textContent ?? '').not.toContain('graph_hash_match') // reason is data-* only
+    expect(el).toHaveAttribute('data-freshness-reason', 'graph_hash_match')
+  })
+})
+
+describe('AnalysisFreshnessNotice — accessibility', () => {
+  it.each(['fresh', 'stale', 'unknown', 'none'] as const)('has no axe violations: %s', async (freshness) => {
+    const { container } = render(<AnalysisFreshnessNotice state={{ freshness }} />)
+    expect((await axeConfigured(container)).violations).toEqual([])
+  })
+})

--- a/src/components/results/__tests__/AnalysisFreshnessNotice.spec.tsx
+++ b/src/components/results/__tests__/AnalysisFreshnessNotice.spec.tsx
@@ -9,10 +9,10 @@ import { render, screen } from '@testing-library/react'
 import { configureAxe } from 'vitest-axe'
 
 // Controllable store stub so the no-prop (store-read) path is deterministic.
-const h = vi.hoisted(() => ({ slice: null as unknown }))
+const h = vi.hoisted(() => ({ slice: null as unknown, dirty: false as boolean }))
 vi.mock('@/canvas/store', () => ({
-  useCanvasStore: (sel: (s: { analysisFreshness: unknown }) => unknown) =>
-    sel({ analysisFreshness: h.slice }),
+  useCanvasStore: (sel: (s: { analysisFreshness: unknown; analysisFreshnessDirty: boolean }) => unknown) =>
+    sel({ analysisFreshness: h.slice, analysisFreshnessDirty: h.dirty }),
 }))
 
 import { AnalysisFreshnessNotice, FRESHNESS_COPY } from '../AnalysisFreshnessNotice'
@@ -22,6 +22,7 @@ const TESTID = 'analysis-freshness-notice'
 
 beforeEach(() => {
   h.slice = null
+  h.dirty = false
 })
 
 describe('AnalysisFreshnessNotice — four states (prop-driven)', () => {
@@ -62,9 +63,50 @@ describe('AnalysisFreshnessNotice — store-read fallback', () => {
   })
 })
 
+describe('AnalysisFreshnessNotice — local dirty overlay (display rule)', () => {
+  it('downgrades a fresh verdict to the unknown message when dirty (prop)', () => {
+    render(<AnalysisFreshnessNotice state={{ freshness: 'fresh' }} dirty />)
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(FRESHNESS_COPY.unknown)
+    expect(el).toHaveAttribute('data-freshness', 'unknown')
+    // CEE's true verdict is preserved for traceability; the downgrade is flagged.
+    expect(el).toHaveAttribute('data-cee-freshness', 'fresh')
+    expect(el).toHaveAttribute('data-freshness-dirty', 'true')
+  })
+
+  it('does not downgrade a CEE stale verdict when dirty (stays stale)', () => {
+    render(<AnalysisFreshnessNotice state={{ freshness: 'stale' }} dirty />)
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(FRESHNESS_COPY.stale)
+    expect(el).toHaveAttribute('data-freshness', 'stale')
+    expect(el).not.toHaveAttribute('data-freshness-dirty')
+  })
+
+  it('shows the clean fresh message when fresh and not dirty', () => {
+    render(<AnalysisFreshnessNotice state={{ freshness: 'fresh' }} dirty={false} />)
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(FRESHNESS_COPY.fresh)
+    expect(el).toHaveAttribute('data-freshness', 'fresh')
+  })
+
+  it('reads the dirty overlay from the store (no prop) and downgrades fresh', () => {
+    h.slice = { freshness: 'fresh' }
+    h.dirty = true
+    render(<AnalysisFreshnessNotice />)
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(FRESHNESS_COPY.unknown)
+    expect(el).toHaveAttribute('data-freshness', 'unknown')
+  })
+})
+
 describe('AnalysisFreshnessNotice — accessibility', () => {
   it.each(['fresh', 'stale', 'unknown', 'none'] as const)('has no axe violations: %s', async (freshness) => {
     const { container } = render(<AnalysisFreshnessNotice state={{ freshness }} />)
+    expect((await axeConfigured(container)).violations).toEqual([])
+  })
+
+  it('has no axe violations in the dirty-downgraded state', async () => {
+    const { container } = render(<AnalysisFreshnessNotice state={{ freshness: 'fresh' }} dirty />)
     expect((await axeConfigured(container)).violations).toEqual([])
   })
 })

--- a/src/components/results/__tests__/DecisionConfidencePanel.extraction.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.extraction.spec.tsx
@@ -97,6 +97,11 @@ function makeData(opts: FixtureOpts = { withFragile: true, withDominant: true, w
     analysisStatus: 'computed',
     recommendationStability: 0.92,
     robustnessLevel: 'high',
+    // Display-safe verdict drives the Robust/Sensitive glyph (production never
+    // populates this from PLoT — set here so this rendered-HTML regression guard
+    // keeps exercising the populated "Robust" glyph; see the provenance test in
+    // useResultsSectionData.spec.ts).
+    robustnessVerdict: 'high',
     coachingReadiness: 'ready',
     coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
   } as DecisionResultData

--- a/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
@@ -72,6 +72,7 @@ interface MakeOpts {
   dominantFactorId?: string
   fragile?: FragileEdgeItem | undefined
   recommendationStability?: number | undefined
+  robustnessLevel?: DecisionResultData['robustnessLevel']
   gaps?: EvidenceGapItem[]
 }
 
@@ -98,7 +99,7 @@ function makeData(opts: MakeOpts = {}): ResultsSectionDataReturn {
     analysisStatus: 'computed',
     recommendationStability:
       'recommendationStability' in opts ? opts.recommendationStability : 0.92,
-    robustnessLevel: 'high',
+    robustnessLevel: 'robustnessLevel' in opts ? opts.robustnessLevel : 'high',
     coachingReadiness: 'ready',
   } as DecisionResultData
 
@@ -234,11 +235,20 @@ describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + chec
     expect(screen.getByTestId('checks-addressed')).toHaveTextContent('1/1 addressed')
   })
 
-  it('flips Robust to "Sensitive" when stability < 0.85', () => {
+  it('flips Robust to "Sensitive" when CEE robustness level is not high', () => {
+    // Robustness single source: the glyph follows CEE's categorical level, not a
+    // UI-local recommendationStability >= 0.85 threshold.
     render(
-      <DecisionConfidencePanel data={makeData({ recommendationStability: 0.6 })} />,
+      <DecisionConfidencePanel data={makeData({ robustnessLevel: 'moderate' })} />,
     )
     expect(screen.getByTestId('checks-robust')).toHaveTextContent('Sensitive')
+  })
+
+  it('shows "Robustness unknown" when CEE provides no robustness level', () => {
+    render(
+      <DecisionConfidencePanel data={makeData({ robustnessLevel: undefined })} />,
+    )
+    expect(screen.getByTestId('checks-robust')).toHaveTextContent('Robustness unknown')
   })
 
   it('flips Evidence to "Evidence gaps" when any review-card confidence < 50%', () => {

--- a/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
@@ -73,7 +73,7 @@ interface MakeOpts {
   fragile?: FragileEdgeItem | undefined
   recommendationStability?: number | undefined
   robustnessLevel?: DecisionResultData['robustnessLevel']
-  robustnessLevelExplicit?: DecisionResultData['robustnessLevelExplicit']
+  robustnessVerdict?: DecisionResultData['robustnessVerdict']
   gaps?: EvidenceGapItem[]
 }
 
@@ -100,13 +100,14 @@ function makeData(opts: MakeOpts = {}): ResultsSectionDataReturn {
     analysisStatus: 'computed',
     recommendationStability:
       'recommendationStability' in opts ? opts.recommendationStability : 0.92,
-    // robustnessLevel is the fallback-inclusive field (may be derived from
-    // recommendationStability via UI-SEM-005). robustnessLevelExplicit is the
-    // CEE-only field the checks glyph reads — they are set independently here so
-    // a test can prove the glyph ignores the fallback field.
+    // robustnessLevel is the structured PLoT/fallback field (NOT display-safe).
+    // robustnessVerdict is the display-safe verdict the glyph reads — they are
+    // set independently here so a test can prove the glyph ignores the structured
+    // field. Production never populates robustnessVerdict today (always undefined);
+    // tests set it to simulate a future display-safe robustness contract.
     robustnessLevel: 'robustnessLevel' in opts ? opts.robustnessLevel : 'high',
-    robustnessLevelExplicit:
-      'robustnessLevelExplicit' in opts ? opts.robustnessLevelExplicit : 'high',
+    robustnessVerdict:
+      'robustnessVerdict' in opts ? opts.robustnessVerdict : 'high',
     coachingReadiness: 'ready',
   } as DecisionResultData
 
@@ -242,36 +243,36 @@ describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + chec
     expect(screen.getByTestId('checks-addressed')).toHaveTextContent('1/1 addressed')
   })
 
-  it('flips Robust to "Sensitive" when CEE robustness level is not high', () => {
-    // Robustness single source: the glyph follows CEE's categorical level, not a
-    // UI-local recommendationStability >= 0.85 threshold.
+  it('flips Robust to "Sensitive" when the display-safe verdict is not high', () => {
+    // The glyph follows the display-safe robustnessVerdict, not a UI-local
+    // recommendationStability threshold or the structured PLoT level.
     render(
       <DecisionConfidencePanel
-        data={makeData({ robustnessLevelExplicit: 'moderate' })}
+        data={makeData({ robustnessVerdict: 'moderate' })}
       />,
     )
     expect(screen.getByTestId('checks-robust')).toHaveTextContent('Sensitive')
   })
 
-  it('shows "Robustness unknown" when CEE provides no robustness level', () => {
+  it('shows "Robustness unknown" when there is no display-safe verdict', () => {
     render(
       <DecisionConfidencePanel
-        data={makeData({ robustnessLevelExplicit: undefined })}
+        data={makeData({ robustnessVerdict: undefined })}
       />,
     )
     expect(screen.getByTestId('checks-robust')).toHaveTextContent('Robustness unknown')
   })
 
-  it('ignores the UI-local fallback robustness level for the glyph (renders unknown)', () => {
-    // Proof of single source: even when the fallback-inclusive robustnessLevel is
-    // 'high' (e.g. derived from recommendationStability via UI-SEM-005), the glyph
-    // must read only the CEE-provided robustnessLevelExplicit. With that absent,
-    // the glyph stays "Robustness unknown" — it never promotes the fallback.
+  it('ignores the structured PLoT/fallback robustnessLevel for the glyph (renders unknown)', () => {
+    // Proof of provenance: even when the structured robustnessLevel is 'high'
+    // (PLoT report.robustness.level, or derived from recommendationStability via
+    // UI-SEM-005), the glyph must read ONLY robustnessVerdict. With that absent —
+    // as production always sets it today — the glyph stays "Robustness unknown".
     render(
       <DecisionConfidencePanel
         data={makeData({
           robustnessLevel: 'high',
-          robustnessLevelExplicit: undefined,
+          robustnessVerdict: undefined,
           recommendationStability: 0.99,
         })}
       />,

--- a/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
@@ -153,7 +153,37 @@ function makeData(opts: MakeOpts = {}): ResultsSectionDataReturn {
 }
 
 beforeEach(() => {
-  useCanvasStore.setState({ draftCoaching: null })
+  useCanvasStore.setState({ draftCoaching: null, analysisFreshness: null, analysisFreshnessDirty: false })
+})
+
+describe('DecisionConfidencePanel — hero freshness qualifier is CEE-only (never fabricated stale)', () => {
+  it('shows a freshness qualifier for a genuine CEE stale verdict', () => {
+    useCanvasStore.setState({
+      analysisFreshness: { freshness: 'stale', freshnessReason: 'graph_hash_match' },
+      analysisFreshnessDirty: false,
+    })
+    const { container } = render(<DecisionConfidencePanel data={makeData()} />)
+    expect(container.querySelector('[data-qualifier-source="freshness"]')).not.toBeNull()
+  })
+
+  it('does NOT fabricate a stale qualifier from a local edit (CEE fresh + dirty → no freshness qualifier)', () => {
+    // The legacy useAnalysisFreshnessState path turned graphEditedSinceLastRun into
+    // a fabricated 'stale'. The hero now reads the CEE-only slice via
+    // resolveDisplayedFreshness, which can only downgrade fresh→unknown — and
+    // HeroQualifier renders the freshness qualifier only for a genuine 'stale'.
+    useCanvasStore.setState({
+      analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match' },
+      analysisFreshnessDirty: true,
+    })
+    const { container } = render(<DecisionConfidencePanel data={makeData()} />)
+    expect(container.querySelector('[data-qualifier-source="freshness"]')).toBeNull()
+  })
+
+  it('shows no freshness qualifier when there is no CEE verdict', () => {
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+    const { container } = render(<DecisionConfidencePanel data={makeData()} />)
+    expect(container.querySelector('[data-qualifier-source="freshness"]')).toBeNull()
+  })
 })
 
 describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + checks', () => {
@@ -254,13 +284,29 @@ describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + chec
     expect(screen.getByTestId('checks-robust')).toHaveTextContent('Sensitive')
   })
 
-  it('shows "Robustness unknown" when there is no display-safe verdict', () => {
+  const glyphIconClass = (testid: string) =>
+    screen.getByTestId(testid).querySelector('svg')?.getAttribute('class') ?? ''
+
+  it('shows "Robustness unknown" as a NEUTRAL state (not a red failure)', () => {
     render(
       <DecisionConfidencePanel
         data={makeData({ robustnessVerdict: undefined })}
       />,
     )
     expect(screen.getByTestId('checks-robust')).toHaveTextContent('Robustness unknown')
+    // Unknown renders the muted neutral glyph, NOT the red danger "X" that would
+    // falsely imply "not robust".
+    expect(glyphIconClass('checks-robust')).toContain('text-text-light')
+    expect(glyphIconClass('checks-robust')).not.toContain('text-danger')
+  })
+
+  it('renders Robust (success) and Sensitive (danger) distinctly from unknown', () => {
+    const { rerender } = render(
+      <DecisionConfidencePanel data={makeData({ robustnessVerdict: 'high' })} />,
+    )
+    expect(glyphIconClass('checks-robust')).toContain('text-success')
+    rerender(<DecisionConfidencePanel data={makeData({ robustnessVerdict: 'moderate' })} />)
+    expect(glyphIconClass('checks-robust')).toContain('text-danger')
   })
 
   it('ignores the structured PLoT/fallback robustnessLevel for the glyph (renders unknown)', () => {

--- a/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
@@ -73,6 +73,7 @@ interface MakeOpts {
   fragile?: FragileEdgeItem | undefined
   recommendationStability?: number | undefined
   robustnessLevel?: DecisionResultData['robustnessLevel']
+  robustnessLevelExplicit?: DecisionResultData['robustnessLevelExplicit']
   gaps?: EvidenceGapItem[]
 }
 
@@ -99,7 +100,13 @@ function makeData(opts: MakeOpts = {}): ResultsSectionDataReturn {
     analysisStatus: 'computed',
     recommendationStability:
       'recommendationStability' in opts ? opts.recommendationStability : 0.92,
+    // robustnessLevel is the fallback-inclusive field (may be derived from
+    // recommendationStability via UI-SEM-005). robustnessLevelExplicit is the
+    // CEE-only field the checks glyph reads — they are set independently here so
+    // a test can prove the glyph ignores the fallback field.
     robustnessLevel: 'robustnessLevel' in opts ? opts.robustnessLevel : 'high',
+    robustnessLevelExplicit:
+      'robustnessLevelExplicit' in opts ? opts.robustnessLevelExplicit : 'high',
     coachingReadiness: 'ready',
   } as DecisionResultData
 
@@ -239,14 +246,35 @@ describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + chec
     // Robustness single source: the glyph follows CEE's categorical level, not a
     // UI-local recommendationStability >= 0.85 threshold.
     render(
-      <DecisionConfidencePanel data={makeData({ robustnessLevel: 'moderate' })} />,
+      <DecisionConfidencePanel
+        data={makeData({ robustnessLevelExplicit: 'moderate' })}
+      />,
     )
     expect(screen.getByTestId('checks-robust')).toHaveTextContent('Sensitive')
   })
 
   it('shows "Robustness unknown" when CEE provides no robustness level', () => {
     render(
-      <DecisionConfidencePanel data={makeData({ robustnessLevel: undefined })} />,
+      <DecisionConfidencePanel
+        data={makeData({ robustnessLevelExplicit: undefined })}
+      />,
+    )
+    expect(screen.getByTestId('checks-robust')).toHaveTextContent('Robustness unknown')
+  })
+
+  it('ignores the UI-local fallback robustness level for the glyph (renders unknown)', () => {
+    // Proof of single source: even when the fallback-inclusive robustnessLevel is
+    // 'high' (e.g. derived from recommendationStability via UI-SEM-005), the glyph
+    // must read only the CEE-provided robustnessLevelExplicit. With that absent,
+    // the glyph stays "Robustness unknown" — it never promotes the fallback.
+    render(
+      <DecisionConfidencePanel
+        data={makeData({
+          robustnessLevel: 'high',
+          robustnessLevelExplicit: undefined,
+          recommendationStability: 0.99,
+        })}
+      />,
     )
     expect(screen.getByTestId('checks-robust')).toHaveTextContent('Robustness unknown')
   })

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -1300,6 +1300,71 @@ describe('useResultsSectionData — Track S value provenance into data.drivers',
 })
 
 // =============================================================================
+// Robustness glyph provenance — PLoT level must NOT drive the display-safe verdict
+// =============================================================================
+
+describe('robustness verdict provenance (glyph is not PLoT-driven)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 } as any,
+      runMeta: {},
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      currentScenarioFraming: null,
+      ceeAnalysisReady: undefined,
+    })
+  })
+
+  it('a PLoT robustness.level=high alone does NOT render Robust (robustnessVerdict stays undefined)', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: {
+          run: { critique: [] },
+          robustness: { level: 'high', recommendation_stability: 0.99, fragile_edges: [] },
+          option_comparison: [],
+        },
+      } as any,
+      hasCompletedFirstRun: true,
+      runMeta: {},
+      nodes: [],
+      edges: [],
+    })
+
+    const { result } = renderHook(() => useResultsSectionData())
+
+    // The structured PLoT level is preserved for qualified/detailed display...
+    expect(result.current.recommendation.robustnessLevel).toBe('high')
+    // ...but the display-safe verdict that drives the Robust/Sensitive glyph is
+    // NOT populated from it — so the glyph renders "Robustness unknown".
+    expect(result.current.recommendation.robustnessVerdict).toBeUndefined()
+  })
+
+  it('even a UI-SEM-005 fallback (no level, high stability) does NOT populate the verdict', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: {
+          run: { critique: [] },
+          robustness: { recommendation_stability: 0.99, fragile_edges: [] }, // no level → fallback derives one
+          option_comparison: [],
+        },
+      } as any,
+      hasCompletedFirstRun: true,
+      runMeta: {},
+      nodes: [],
+      edges: [],
+    })
+
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.recommendation.robustnessVerdict).toBeUndefined()
+  })
+})
+
+// =============================================================================
 // Baseline Resolution Tests (Task 2.1)
 // =============================================================================
 

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -178,8 +178,15 @@ export interface DecisionResultData {
   winProbability?: number
   /** How the winner was determined - for honest labelling */
   determinedBy?: WinnerDeterminedBy
-  /** Robustness level from PLoT */
+  /** Robustness level from PLoT (may be UI-SEM-005 stability fallback when CEE omits it) */
   robustnessLevel?: RobustnessLevel
+  /**
+   * CEE-provided structured robustness level ONLY — undefined when CEE omitted
+   * it (no UI-local stability fallback applied). Use this, not `robustnessLevel`,
+   * for any single-source robustness verdict that must read "unknown" when CEE
+   * provides nothing.
+   */
+  robustnessLevelExplicit?: RobustnessLevel
   /** Robustness label from PLoT (fallback when level missing) */
   robustnessLabel?: RobustnessLabel
   /** Goal text from scenario framing */

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -178,15 +178,24 @@ export interface DecisionResultData {
   winProbability?: number
   /** How the winner was determined - for honest labelling */
   determinedBy?: WinnerDeterminedBy
-  /** Robustness level from PLoT (may be UI-SEM-005 stability fallback when CEE omits it) */
+  /**
+   * Structured robustness level from the analysis report (PLoT
+   * report.robustness.level), or the UI-SEM-005 stability fallback when the
+   * report omits it. This is STRUCTURED DATA — safe to surface in detailed,
+   * qualified contexts, but it must NOT drive the binary Robust/Sensitive glyph
+   * (PLoT-level semantics are not a display-safe verdict). Use `robustnessVerdict`
+   * for the glyph.
+   */
   robustnessLevel?: RobustnessLevel
   /**
-   * CEE-provided structured robustness level ONLY — undefined when CEE omitted
-   * it (no UI-local stability fallback applied). Use this, not `robustnessLevel`,
-   * for any single-source robustness verdict that must read "unknown" when CEE
-   * provides nothing.
+   * Display-safe robustness verdict that drives the binary Robust/Sensitive
+   * glyph. Sourced ONLY from an explicit display-safe robustness verdict — never
+   * from PLoT `report.robustness.level` and never from the UI-SEM-005 stability
+   * fallback. No such display-safe field exists in the CEE/UI contract today, so
+   * this is currently always `undefined` → the glyph renders "Robustness unknown".
+   * See the "display-safe robustness verdict contract" follow-up (ROBUSTNESS-VERDICT-CONTRACT).
    */
-  robustnessLevelExplicit?: RobustnessLevel
+  robustnessVerdict?: RobustnessLevel
   /** Robustness label from PLoT (fallback when level missing) */
   robustnessLabel?: RobustnessLabel
   /** Goal text from scenario framing */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1372,6 +1372,9 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       determinedBy,
       // Task 1.5: Robustness level and label
       robustnessLevel,
+      // CEE-only structured robustness (no UI-SEM-005 stability fallback): present
+      // only when CEE actually provided a level. Drives single-source verdicts.
+      robustnessLevelExplicit: hasExplicitLevel ? robustnessLevel : undefined,
       robustnessLabel,
       // Task 1.7: Goal text from framing
       goalText,

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1370,11 +1370,17 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       winProbability,
       // Task 1.4: How winner was determined
       determinedBy,
-      // Task 1.5: Robustness level and label
+      // Task 1.5: Robustness level and label. `robustnessLevel` is STRUCTURED
+      // DATA (PLoT report.robustness.level, or the UI-SEM-005 fallback) — kept for
+      // qualified/detailed display, NOT for the binary glyph.
       robustnessLevel,
-      // CEE-only structured robustness (no UI-SEM-005 stability fallback): present
-      // only when CEE actually provided a level. Drives single-source verdicts.
-      robustnessLevelExplicit: hasExplicitLevel ? robustnessLevel : undefined,
+      // Display-safe robustness verdict for the Robust/Sensitive glyph. PLoT
+      // `report.robustness.level` is deliberately NOT a display-safe verdict
+      // (PLoT-level semantics are not contractually safe to binarise), so it must
+      // not drive the glyph. No display-safe robustness field exists in the
+      // CEE/UI contract today → always undefined → glyph renders "Robustness
+      // unknown". See ROBUSTNESS-VERDICT-CONTRACT follow-up.
+      robustnessVerdict: undefined,
       robustnessLabel,
       // Task 1.7: Goal text from framing
       goalText,

--- a/src/v5/__tests__/applyV5State.results-hydration.test.ts
+++ b/src/v5/__tests__/applyV5State.results-hydration.test.ts
@@ -272,10 +272,7 @@ describe('applyV5State — step 5: dirty overlay clear (run identity + explicit 
     const { store } = makeStore({ clearAnalysisFreshnessDirty, currentResultsHash: null })
 
     applyV5State(
-      baseResponse({
-        blocks: [validAnalysisBlock],
-        analysis_ready: { freshness: 'fresh' },
-      } as Partial<OlumiResponse>),
+      baseResponse({ blocks: [validAnalysisBlock], analysis_ready: { freshness: 'fresh' } as never }),
       store,
     )
 
@@ -297,7 +294,7 @@ describe('applyV5State — step 5: dirty overlay clear (run identity + explicit 
     const probeResultsComplete = vi.fn()
     const probe = makeStore({ resultsComplete: probeResultsComplete })
     applyV5State(
-      baseResponse({ blocks: [validAnalysisBlock], analysis_ready: { freshness: 'fresh' } } as Partial<OlumiResponse>),
+      baseResponse({ blocks: [validAnalysisBlock], analysis_ready: { freshness: 'fresh' } as never }),
       probe.store,
     )
     const hydratedHash = (probeResultsComplete.mock.calls[0]?.[0] as { hash: string }).hash
@@ -306,7 +303,7 @@ describe('applyV5State — step 5: dirty overlay clear (run identity + explicit 
     const clearAnalysisFreshnessDirty = vi.fn()
     const { store } = makeStore({ clearAnalysisFreshnessDirty, currentResultsHash: hydratedHash })
     applyV5State(
-      baseResponse({ blocks: [validAnalysisBlock], analysis_ready: { freshness: 'fresh' } } as Partial<OlumiResponse>),
+      baseResponse({ blocks: [validAnalysisBlock], analysis_ready: { freshness: 'fresh' } as never }),
       store,
     )
 

--- a/src/v5/__tests__/applyV5State.results-hydration.test.ts
+++ b/src/v5/__tests__/applyV5State.results-hydration.test.ts
@@ -259,31 +259,56 @@ describe('applyV5State — step 5: results hydration', () => {
 // The CEE analysis_ready contract carries no computed_at / run id, so the
 // reducer's echo-guard cannot distinguish a same-verdict rerun from an echo.
 // The reliable run identity is the analysis_result response_hash dedupe: a NEW
-// hash means a completed run → clear the overlay; a duplicate hash or a turn with
-// no analysis_result block (conversational echo) must NOT clear it.
+// hash means a completed run. BUT the overlay is cleared ONLY when that same
+// response ALSO carries an explicit analysis_ready.freshness verdict — otherwise
+// clearing would re-show a retained 'fresh' verdict despite the new result
+// asserting no CEE freshness (false-fresh). Duplicate hash / no analysis_result
+// block (conversational echo) never clear.
 // ---------------------------------------------------------------------------
 
-describe('applyV5State — step 5: dirty overlay clear (run identity)', () => {
-  it('clears the overlay when a new analysis_result hydrates (new response_hash)', () => {
+describe('applyV5State — step 5: dirty overlay clear (run identity + explicit freshness)', () => {
+  it('clears the overlay when a new analysis_result hydrates WITH an explicit freshness verdict', () => {
     const clearAnalysisFreshnessDirty = vi.fn()
     const { store } = makeStore({ clearAnalysisFreshnessDirty, currentResultsHash: null })
 
-    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+    applyV5State(
+      baseResponse({
+        blocks: [validAnalysisBlock],
+        analysis_ready: { freshness: 'fresh' },
+      } as Partial<OlumiResponse>),
+      store,
+    )
 
     expect(clearAnalysisFreshnessDirty).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT clear the overlay when the new analysis_result carries NO freshness verdict (would be false-fresh)', () => {
+    const clearAnalysisFreshnessDirty = vi.fn()
+    const { store } = makeStore({ clearAnalysisFreshnessDirty, currentResultsHash: null })
+
+    // New result hydrates (new hash) but the response has no analysis_ready.freshness.
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+
+    expect(clearAnalysisFreshnessDirty).not.toHaveBeenCalled()
   })
 
   it('does NOT clear the overlay for a duplicate analysis_result (same response_hash = echo)', () => {
     // Discover the hydrated hash via a probe run, then re-run with currentResultsHash set to it.
     const probeResultsComplete = vi.fn()
     const probe = makeStore({ resultsComplete: probeResultsComplete })
-    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), probe.store)
+    applyV5State(
+      baseResponse({ blocks: [validAnalysisBlock], analysis_ready: { freshness: 'fresh' } } as Partial<OlumiResponse>),
+      probe.store,
+    )
     const hydratedHash = (probeResultsComplete.mock.calls[0]?.[0] as { hash: string }).hash
     expect(hydratedHash).toBeTruthy()
 
     const clearAnalysisFreshnessDirty = vi.fn()
     const { store } = makeStore({ clearAnalysisFreshnessDirty, currentResultsHash: hydratedHash })
-    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+    applyV5State(
+      baseResponse({ blocks: [validAnalysisBlock], analysis_ready: { freshness: 'fresh' } } as Partial<OlumiResponse>),
+      store,
+    )
 
     expect(clearAnalysisFreshnessDirty).not.toHaveBeenCalled()
   })

--- a/src/v5/__tests__/applyV5State.results-hydration.test.ts
+++ b/src/v5/__tests__/applyV5State.results-hydration.test.ts
@@ -253,3 +253,47 @@ describe('applyV5State — step 5: results hydration', () => {
     expect(callArgs.report.confidence.why).toContain('8 robust edges')
   })
 })
+
+// ---------------------------------------------------------------------------
+// #4: clearing the local freshness dirty overlay on a genuine new run.
+// The CEE analysis_ready contract carries no computed_at / run id, so the
+// reducer's echo-guard cannot distinguish a same-verdict rerun from an echo.
+// The reliable run identity is the analysis_result response_hash dedupe: a NEW
+// hash means a completed run → clear the overlay; a duplicate hash or a turn with
+// no analysis_result block (conversational echo) must NOT clear it.
+// ---------------------------------------------------------------------------
+
+describe('applyV5State — step 5: dirty overlay clear (run identity)', () => {
+  it('clears the overlay when a new analysis_result hydrates (new response_hash)', () => {
+    const clearAnalysisFreshnessDirty = vi.fn()
+    const { store } = makeStore({ clearAnalysisFreshnessDirty, currentResultsHash: null })
+
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+
+    expect(clearAnalysisFreshnessDirty).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT clear the overlay for a duplicate analysis_result (same response_hash = echo)', () => {
+    // Discover the hydrated hash via a probe run, then re-run with currentResultsHash set to it.
+    const probeResultsComplete = vi.fn()
+    const probe = makeStore({ resultsComplete: probeResultsComplete })
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), probe.store)
+    const hydratedHash = (probeResultsComplete.mock.calls[0]?.[0] as { hash: string }).hash
+    expect(hydratedHash).toBeTruthy()
+
+    const clearAnalysisFreshnessDirty = vi.fn()
+    const { store } = makeStore({ clearAnalysisFreshnessDirty, currentResultsHash: hydratedHash })
+    applyV5State(baseResponse({ blocks: [validAnalysisBlock] }), store)
+
+    expect(clearAnalysisFreshnessDirty).not.toHaveBeenCalled()
+  })
+
+  it('does NOT clear the overlay on a turn with no analysis_result block (conversational echo)', () => {
+    const clearAnalysisFreshnessDirty = vi.fn()
+    const { store } = makeStore({ clearAnalysisFreshnessDirty })
+
+    applyV5State(baseResponse({ blocks: [] }), store)
+
+    expect(clearAnalysisFreshnessDirty).not.toHaveBeenCalled()
+  })
+})

--- a/src/v5/__tests__/applyV5State.results-hydration.test.ts
+++ b/src/v5/__tests__/applyV5State.results-hydration.test.ts
@@ -32,9 +32,11 @@ function makeStore(
   store: V5ApplicatorStore
   resultsComplete: ReturnType<typeof vi.fn>
   setRunMeta: ReturnType<typeof vi.fn>
+  setAnalysisFreshness: ReturnType<typeof vi.fn>
 } {
   const resultsComplete = vi.fn()
   const setRunMeta = vi.fn()
+  const setAnalysisFreshness = vi.fn()
   return {
     store: {
       setCurrentStage: vi.fn(),
@@ -42,6 +44,7 @@ function makeStore(
       updateEdgeData: vi.fn(),
       setRunMeta,
       setCeeAnalysisReady: vi.fn(),
+      setAnalysisFreshness,
       resultsComplete,
       nodes: [],
       edges: [],
@@ -50,6 +53,7 @@ function makeStore(
     },
     resultsComplete,
     setRunMeta,
+    setAnalysisFreshness,
   }
 }
 
@@ -317,5 +321,33 @@ describe('applyV5State — step 5: dirty overlay clear (run identity + explicit 
     applyV5State(baseResponse({ blocks: [] }), store)
 
     expect(clearAnalysisFreshnessDirty).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Step 4: analysis_ready → freshness reducer ingress. setAnalysisFreshness is
+// called UNCONDITIONALLY every turn (retain-on-absence lives in the reducer), so
+// the slice always sees the raw payload (or undefined). Asserted directly so the
+// optional-chained call can't silently no-op (the round-3 too-loose-mock trap).
+// ---------------------------------------------------------------------------
+
+describe('applyV5State — step 4: setAnalysisFreshness ingress', () => {
+  it('routes an explicit analysis_ready.freshness verdict to the reducer', () => {
+    const { store, setAnalysisFreshness } = makeStore()
+    applyV5State(baseResponse({ analysis_ready: { freshness: 'fresh' } as never }), store)
+    expect(setAnalysisFreshness).toHaveBeenCalledTimes(1)
+    expect(setAnalysisFreshness).toHaveBeenCalledWith({ freshness: 'fresh' })
+  })
+
+  it('still routes a present payload that lacks freshness (reducer degrades to unknown)', () => {
+    const { store, setAnalysisFreshness } = makeStore()
+    applyV5State(baseResponse({ analysis_ready: { goal_node_id: 'g1' } as never }), store)
+    expect(setAnalysisFreshness).toHaveBeenCalledWith({ goal_node_id: 'g1' })
+  })
+
+  it('routes undefined when the turn carries no analysis_ready (reducer retains)', () => {
+    const { store, setAnalysisFreshness } = makeStore()
+    applyV5State(baseResponse({ blocks: [] }), store)
+    expect(setAnalysisFreshness).toHaveBeenCalledWith(undefined)
   })
 })

--- a/src/v5/__tests__/freshness-state-matrix.test.tsx
+++ b/src/v5/__tests__/freshness-state-matrix.test.tsx
@@ -41,8 +41,22 @@ import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../canvas/co
 // ─── Mock the canvas store + freshness hook for V5GraphPatchBlock ────────
 
 vi.mock('../../canvas/store', () => ({
-  useCanvasStore: (selector: (s: { nodes: unknown; edges: unknown }) => unknown) =>
-    selector({ nodes: [], edges: [] }),
+  useCanvasStore: (
+    selector: (s: {
+      nodes: unknown
+      edges: unknown
+      analysisFreshness: { freshness: string } | null
+      analysisFreshnessDirty: boolean
+    }) => unknown,
+  ) =>
+    // The V5GraphPatchBlock hint now derives from the CEE freshness slice via
+    // classifyFreshnessForDisplay; mirror the controllable verdict into the slice.
+    selector({
+      nodes: [],
+      edges: [],
+      analysisFreshness: { freshness: mockFreshnessState().freshness },
+      analysisFreshnessDirty: false,
+    }),
 }))
 
 const mockFreshnessState = vi.fn(() => ({

--- a/src/v5/__tests__/freshness-state-matrix.test.tsx
+++ b/src/v5/__tests__/freshness-state-matrix.test.tsx
@@ -38,7 +38,7 @@ import {
 import type { CEEAnalysisReady } from '../../adapters/cee/types'
 import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../canvas/conversation/types'
 
-// ─── Mock the canvas store + freshness hook for V5GraphPatchBlock ────────
+// ─── Mock the canvas store (CEE freshness slice) for V5GraphPatchBlock ────
 
 vi.mock('../../canvas/store', () => ({
   useCanvasStore: (
@@ -59,21 +59,13 @@ vi.mock('../../canvas/store', () => ({
     }),
 }))
 
-const mockFreshnessState = vi.fn(() => ({
-  freshness: 'unknown' as 'unknown' | 'fresh' | 'stale' | 'none',
-  reason: null as string | null,
-  recommendedAction: 'continue_editing' as
-    | 'view_results'
-    | 'rerun_analysis'
-    | 'run_analysis'
-    | 'add_options'
-    | 'continue_editing'
-    | null,
-  inputsMissing: [] as ReadonlyArray<keyof AnalysisFreshnessInputs>,
-}))
-
-vi.mock('../../lib/useAnalysisFreshnessState', () => ({
-  useAnalysisFreshnessState: () => mockFreshnessState(),
+// Drives the CEE freshness slice the V5GraphPatchBlock describe reads
+// (analysisFreshness.freshness, via the useCanvasStore mock above). The
+// HeroQualifier describe passes `freshness` as a prop, and the legacy-derivation
+// describe calls deriveAnalysisFreshnessState directly — so no component here
+// consumes the useAnalysisFreshnessState hook, and it is intentionally NOT mocked.
+const mockFreshnessState = vi.fn<[], { freshness: 'unknown' | 'fresh' | 'stale' | 'none' }>(() => ({
+  freshness: 'unknown',
 }))
 
 const { V5GraphPatchBlock } = await import('../blocks/V5GraphPatchBlock')
@@ -199,19 +191,7 @@ describe('V5GraphPatchBlock — receipt hint surfaces ONLY the stale state disti
     [FreshnessVerdict, 'visible' | 'absent']
   >) {
     it(`freshness=${verdict} → receipt freshness hint ${outcome}`, () => {
-      mockFreshnessState.mockReturnValue({
-        freshness: verdict,
-        reason: verdict === 'stale' ? 'graph_hash_diverged' : null,
-        recommendedAction:
-          verdict === 'stale'
-            ? 'rerun_analysis'
-            : verdict === 'fresh'
-              ? 'view_results'
-              : verdict === 'none'
-                ? 'run_analysis'
-                : 'continue_editing',
-        inputsMissing: [],
-      })
+      mockFreshnessState.mockReturnValue({ freshness: verdict })
       render(<V5GraphPatchBlock block={APPLIED_PATCH} />)
       const hint = screen.queryByTestId('v5-change-freshness-hint')
       if (outcome === 'visible') {
@@ -272,19 +252,7 @@ describe('freshness verdicts produce distinct user-facing outcomes (no collapse)
 
     for (const v of verdicts) {
       cleanup()
-      mockFreshnessState.mockReturnValue({
-        freshness: v,
-        reason: v === 'stale' ? 'graph_hash_diverged' : null,
-        recommendedAction:
-          v === 'stale'
-            ? 'rerun_analysis'
-            : v === 'fresh'
-              ? 'view_results'
-              : v === 'none'
-                ? 'run_analysis'
-                : 'continue_editing',
-        inputsMissing: [],
-      })
+      mockFreshnessState.mockReturnValue({ freshness: v })
       render(<V5GraphPatchBlock block={APPLIED_PATCH} />)
       const hint = screen.queryByTestId('v5-change-freshness-hint')
       const hintText = hint ? hint.textContent ?? '' : 'NO_HINT'

--- a/src/v5/__tests__/journey-3-and-6-wire-to-dom.test.tsx
+++ b/src/v5/__tests__/journey-3-and-6-wire-to-dom.test.tsx
@@ -8,8 +8,8 @@
  *     → applyV5State (writes ceeAnalysisReady incl. freshness)
  *     → mapV5Blocks (graph_patch → v5_graph_patch)
  *     → V5GraphPatchBlock renders friendly receipt
- *     → useAnalysisFreshnessState (mocked from store snapshot)
- *     → freshness hint surfaces when stale
+ *     → classifyFreshnessForDisplay over the CEE freshness slice (mocked)
+ *     → freshness hint surfaces when the verdict is 'changed' (stale)
  *     → no internal terms appear in the DOM
  *
  * This catches regressions in any layer in one journey-shaped test
@@ -26,7 +26,7 @@ import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
 import { mapV5Blocks } from '../blocks/mapV5Blocks'
 import { RAW_ID_PATTERN } from '../../canvas/conversation/friendlyOperation'
 import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../canvas/conversation/types'
-import type { AnalysisFreshnessState } from '../../lib/analysisFreshnessState'
+import type { AnalysisFreshnessValue } from '../../canvas/store/analysisFreshness'
 
 // ─── Canvas-store mock ────────────────────────────────────────────────────
 //
@@ -49,11 +49,10 @@ const EDGES = [
 // classifyFreshnessForDisplay (=== 'changed'); we assert on whether the hint
 // appears, not on the derivation itself — that is unit-tested separately.
 
-const mockFreshnessState = vi.fn<[], AnalysisFreshnessState>(() => ({
+// Drives the CEE freshness slice the component reads (analysisFreshness.freshness);
+// the component runs the real classifyFreshnessForDisplay over it.
+const mockFreshnessState = vi.fn<[], { freshness: AnalysisFreshnessValue }>(() => ({
   freshness: 'unknown',
-  reason: null,
-  recommendedAction: 'continue_editing',
-  inputsMissing: [],
 }))
 
 vi.mock('../../canvas/store', () => ({
@@ -147,12 +146,7 @@ function expectNoLeakInDOM(): void {
 
 beforeEach(() => {
   cleanup()
-  mockFreshnessState.mockReturnValue({
-    freshness: 'unknown',
-    reason: null,
-    recommendedAction: 'continue_editing',
-    inputsMissing: [],
-  })
+  mockFreshnessState.mockReturnValue({ freshness: 'unknown' })
 })
 
 // ─── Wire envelopes ───────────────────────────────────────────────────────
@@ -275,12 +269,7 @@ describe('Workstream 1 — Journey 3 wire-to-DOM (add_constraint)', () => {
   })
 
   it('V5GraphPatchBlock renders the friendly receipt + stale freshness hint', () => {
-    mockFreshnessState.mockReturnValue({
-      freshness: 'stale',
-      reason: 'graph_hash_diverged',
-      recommendedAction: 'rerun_analysis',
-      inputsMissing: [],
-    })
+    mockFreshnessState.mockReturnValue({ freshness: 'stale' })
     const envelope = journey3Envelope({ freshness: 'stale' })
     const block = mapV5Blocks(envelope.blocks)[0] as V5GraphPatchBlockType
 
@@ -297,12 +286,7 @@ describe('Workstream 1 — Journey 3 wire-to-DOM (add_constraint)', () => {
   })
 
   it('V5GraphPatchBlock suppresses freshness hint on a fresh-after-mutation turn', () => {
-    mockFreshnessState.mockReturnValue({
-      freshness: 'fresh',
-      reason: 'graph_hash_match',
-      recommendedAction: 'view_results',
-      inputsMissing: [],
-    })
+    mockFreshnessState.mockReturnValue({ freshness: 'fresh' })
     const envelope = journey3Envelope({ freshness: 'fresh' })
     const block = mapV5Blocks(envelope.blocks)[0] as V5GraphPatchBlockType
 
@@ -325,12 +309,7 @@ describe('Workstream 1 — Journey 6 wire-to-DOM (set_factor_value)', () => {
   })
 
   it('V5GraphPatchBlock renders a clean numeric-update receipt + stale hint', () => {
-    mockFreshnessState.mockReturnValue({
-      freshness: 'stale',
-      reason: 'graph_hash_diverged',
-      recommendedAction: 'rerun_analysis',
-      inputsMissing: [],
-    })
+    mockFreshnessState.mockReturnValue({ freshness: 'stale' })
     const envelope = journey6Envelope({ freshness: 'stale' })
     const block = mapV5Blocks(envelope.blocks)[0] as V5GraphPatchBlockType
 

--- a/src/v5/__tests__/journey-3-and-6-wire-to-dom.test.tsx
+++ b/src/v5/__tests__/journey-3-and-6-wire-to-dom.test.tsx
@@ -42,17 +42,12 @@ const EDGES = [
   { id: 'edge_morale_to_outcome', source: 'fac_team_morale', target: 'goal_outcome' },
 ]
 
-vi.mock('../../canvas/store', () => ({
-  useCanvasStore: (selector: (s: { nodes: unknown; edges: unknown }) => unknown) =>
-    selector({ nodes: NODES, edges: EDGES }),
-}))
-
-// ─── Freshness hook mock ──────────────────────────────────────────────────
+// ─── Freshness mock ───────────────────────────────────────────────────────
 //
-// Each test sets the verdict the freshness derivation would produce given
-// the canvas-store ceeAnalysisReady (written by applyV5State a moment
-// earlier). We assert on whether the hint appears, not on the
-// derivation itself — the derivation is unit-tested separately.
+// Each test sets the verdict the CEE freshness slice holds. The
+// V5GraphPatchBlock hint now derives from that slice via
+// classifyFreshnessForDisplay (=== 'changed'); we assert on whether the hint
+// appears, not on the derivation itself — that is unit-tested separately.
 
 const mockFreshnessState = vi.fn<[], AnalysisFreshnessState>(() => ({
   freshness: 'unknown',
@@ -61,8 +56,21 @@ const mockFreshnessState = vi.fn<[], AnalysisFreshnessState>(() => ({
   inputsMissing: [],
 }))
 
-vi.mock('../../lib/useAnalysisFreshnessState', () => ({
-  useAnalysisFreshnessState: () => mockFreshnessState(),
+vi.mock('../../canvas/store', () => ({
+  useCanvasStore: (
+    selector: (s: {
+      nodes: unknown
+      edges: unknown
+      analysisFreshness: { freshness: string } | null
+      analysisFreshnessDirty: boolean
+    }) => unknown,
+  ) =>
+    selector({
+      nodes: NODES,
+      edges: EDGES,
+      analysisFreshness: { freshness: mockFreshnessState().freshness },
+      analysisFreshnessDirty: false,
+    }),
 }))
 
 const { V5GraphPatchBlock } = await import('../blocks/V5GraphPatchBlock')

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -57,6 +57,8 @@ export interface V5ApplicatorStore {
   setRunMeta: (meta: { ceeReviewV1: CeeDecisionReviewPayloadV1 | null }) => void
   /** Write (or clear) the CEE analysis_ready payload that gates the run. */
   setCeeAnalysisReady: (analysisReady: CEEAnalysisReady | null) => void
+  /** Optional: update the freshness slice from a raw response.analysis_ready (retain / order / never absence→fresh). */
+  setAnalysisFreshness?: (rawAnalysisReady: unknown) => void
   /**
    * Results hydration (V5-exclusive path). When the response carries an
    * analysis_result block, the applicator builds a ReportV1 via
@@ -515,6 +517,9 @@ export function applyV5State(
   // Stale-turn guard lives at the top of applyV5State (before step 1) so
   // it covers stage, graph_patch, and runMeta writes as well as this step.
   const rawAnalysisReady = (response as { analysis_ready?: unknown }).analysis_ready
+  // Freshness slice: retain on absence, order by computed_at, never absence→fresh.
+  // Independent of ceeAnalysisReady (which clears on analyse-turns-without-analysis_ready).
+  store.setAnalysisFreshness?.(rawAnalysisReady)
   if (rawAnalysisReady !== undefined) {
     const normalised = normaliseV5AnalysisReady(rawAnalysisReady)
     if (normalised) {

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -59,6 +59,8 @@ export interface V5ApplicatorStore {
   setCeeAnalysisReady: (analysisReady: CEEAnalysisReady | null) => void
   /** Optional: update the freshness slice from a raw response.analysis_ready (retain / order / never absence→fresh). */
   setAnalysisFreshness?: (rawAnalysisReady: unknown) => void
+  /** Optional: clear the local dirty overlay when a genuinely new analysis run completes (new analysis_result response_hash). */
+  clearAnalysisFreshnessDirty?: () => void
   /**
    * Results hydration (V5-exclusive path). When the response carries an
    * analysis_result block, the applicator builds a ReportV1 via
@@ -627,6 +629,14 @@ export function applyV5State(
           rawV2Response: null,
         })
         applied.push('analysis_result:results_hydrated')
+        // Reliable run identity: a NEW analysis_result response_hash (hash !==
+        // prevHash) means a genuinely new analysis completed — not a re-delivered
+        // analysis_ready echo. Clear the local dirty overlay here so a real rerun
+        // resolves the verdict even when the analysis_ready payload is byte-
+        // identical (the CEE contract carries no computed_at / run id on
+        // analysis_ready, so the reducer's echo-guard alone cannot distinguish a
+        // rerun from an echo). An echoed result (same hash) skips this branch.
+        store.clearAnalysisFreshnessDirty?.()
         logV5StateStep({
           step_number: 5,
           step_name: 'results_hydration',

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -631,12 +631,28 @@ export function applyV5State(
         applied.push('analysis_result:results_hydrated')
         // Reliable run identity: a NEW analysis_result response_hash (hash !==
         // prevHash) means a genuinely new analysis completed — not a re-delivered
-        // analysis_ready echo. Clear the local dirty overlay here so a real rerun
+        // analysis_ready echo. Clear the local dirty overlay so a real rerun
         // resolves the verdict even when the analysis_ready payload is byte-
         // identical (the CEE contract carries no computed_at / run id on
         // analysis_ready, so the reducer's echo-guard alone cannot distinguish a
-        // rerun from an echo). An echoed result (same hash) skips this branch.
-        store.clearAnalysisFreshnessDirty?.()
+        // rerun from an echo).
+        //
+        // BUT only clear when THIS response also carries an explicit
+        // analysis_ready.freshness verdict. A new analysis_result with NO CEE
+        // freshness would otherwise un-dirty a RETAINED prior 'fresh' verdict and
+        // re-show false-fresh — so without a freshness verdict we keep the overlay
+        // dirty (the retained 'fresh' stays displayed as cannot-confirm).
+        const ar =
+          rawAnalysisReady && typeof rawAnalysisReady === 'object'
+            ? (rawAnalysisReady as { freshness?: unknown })
+            : null
+        const hasExplicitFreshness =
+          !!ar &&
+          typeof ar.freshness === 'string' &&
+          (['fresh', 'stale', 'unknown', 'none'] as const).includes(ar.freshness as 'fresh')
+        if (hasExplicitFreshness) {
+          store.clearAnalysisFreshnessDirty?.()
+        }
         logV5StateStep({
           step_number: 5,
           step_name: 'results_hydration',

--- a/src/v5/blocks/V5GraphPatchBlock.tsx
+++ b/src/v5/blocks/V5GraphPatchBlock.tsx
@@ -22,7 +22,7 @@
 import { useMemo, type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import { useCanvasStore } from '../../canvas/store'
-import { useAnalysisFreshnessState } from '../../lib/useAnalysisFreshnessState'
+import { classifyFreshnessForDisplay } from '../../canvas/store/analysisFreshness'
 import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../canvas/conversation/types'
 import { buildV5PatchReceipt, buildV5PatchDeps } from './v5GraphPatchDescription'
 
@@ -43,15 +43,22 @@ export function V5GraphPatchBlock({ block }: V5GraphPatchBlockProps): ReactEleme
   )
 
   // Workstream 1, Phase 3c — distinct freshness vs structural readiness.
-  // When the mutation just landed AND a prior analysis is now out of date,
-  // surface a small hint inline with the receipt so the user understands
-  // the impact without navigating to the results panel. We deliberately
-  // only surface the 'stale' verdict here; 'fresh' / 'none' / 'unknown'
-  // would be redundant noise alongside the run/rerun chip the CEE already
-  // emits.
-  const freshness = useAnalysisFreshnessState()
+  // When the mutation just landed AND the analysis is now definitely out of
+  // date, surface a small hint inline with the receipt so the user understands
+  // the impact without navigating to the results panel.
+  //
+  // Sourced from the CEE freshness slice + local dirty overlay via the shared
+  // `classifyFreshnessForDisplay` (NOT the legacy `useAnalysisFreshnessState`,
+  // whose reducer could fabricate 'stale' from `graphEditedSinceLastRun` when
+  // wire freshness was absent/unknown). We deliberately only surface the
+  // 'changed' semantic here (CEE 'stale' OR a retained-fresh-now-dirtied);
+  // 'cannot_confirm' / 'current' / 'none' would be redundant noise alongside
+  // the run/rerun chip the CEE already emits.
+  const analysisFreshness = useCanvasStore((s) => s.analysisFreshness)
+  const analysisFreshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const showStaleHint =
-    receipt.status === 'applied' && freshness.freshness === 'stale'
+    receipt.status === 'applied' &&
+    classifyFreshnessForDisplay(analysisFreshness, analysisFreshnessDirty) === 'changed'
 
   const isApplied = receipt.status === 'applied'
 

--- a/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
+++ b/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
@@ -32,13 +32,13 @@ const EDGES = [
 // reads the `analysisFreshness` slice (+ dirty overlay) from the store and runs
 // the real `classifyFreshnessForDisplay`; the hint shows only on 'changed'
 // (CEE 'stale' OR a retained-fresh-now-dirtied). Default 'unknown' → no hint.
-import type { AnalysisFreshnessState } from '../../../lib/analysisFreshnessState'
+import type { AnalysisFreshnessValue } from '../../../canvas/store/analysisFreshness'
 
-const mockFreshnessState = vi.fn<[], AnalysisFreshnessState>(() => ({
+// Drives the CEE freshness slice the component actually reads
+// (analysisFreshness.freshness). The component runs the real
+// classifyFreshnessForDisplay over this.
+const mockFreshnessState = vi.fn<[], { freshness: AnalysisFreshnessValue }>(() => ({
   freshness: 'unknown',
-  reason: null,
-  recommendedAction: 'continue_editing',
-  inputsMissing: [],
 }))
 // Controls the dirty overlay (default clean; set true to exercise the
 // fresh→changed downgrade path).
@@ -79,12 +79,7 @@ function expectNoLeakInDOM(): void {
 beforeEach(() => {
   cleanup()
   mockAnalysisFreshnessDirty = false
-  mockFreshnessState.mockReturnValue({
-    freshness: 'unknown',
-    reason: null,
-    recommendedAction: 'continue_editing',
-    inputsMissing: [],
-  })
+  mockFreshnessState.mockReturnValue({ freshness: 'unknown' })
 })
 
 describe('V5GraphPatchBlock — clean receipt rendering', () => {
@@ -182,12 +177,7 @@ describe('V5GraphPatchBlock — clean receipt rendering', () => {
   })
 
   it('shows freshness hint when applied and prior analysis is now stale', () => {
-    mockFreshnessState.mockReturnValue({
-      freshness: 'stale',
-      reason: 'graph_hash_diverged',
-      recommendedAction: 'rerun_analysis',
-      inputsMissing: [],
-    })
+    mockFreshnessState.mockReturnValue({ freshness: 'stale' })
     const block: V5GraphPatchBlockType = {
       type: 'v5_graph_patch',
       status: 'applied',
@@ -205,12 +195,7 @@ describe('V5GraphPatchBlock — clean receipt rendering', () => {
 
   it('does NOT show freshness hint when freshness is fresh / none / unknown', () => {
     for (const freshness of ['fresh', 'none', 'unknown'] as const) {
-      mockFreshnessState.mockReturnValue({
-        freshness,
-        reason: null,
-        recommendedAction: freshness === 'fresh' ? 'view_results' : 'continue_editing',
-        inputsMissing: [],
-      })
+      mockFreshnessState.mockReturnValue({ freshness })
       const block: V5GraphPatchBlockType = {
         type: 'v5_graph_patch',
         status: 'applied',
@@ -226,12 +211,7 @@ describe('V5GraphPatchBlock — clean receipt rendering', () => {
   })
 
   it('does NOT show freshness hint on noop status (no impact change to surface)', () => {
-    mockFreshnessState.mockReturnValue({
-      freshness: 'stale',
-      reason: 'graph_hash_diverged',
-      recommendedAction: 'rerun_analysis',
-      inputsMissing: [],
-    })
+    mockFreshnessState.mockReturnValue({ freshness: 'stale' })
     const block: V5GraphPatchBlockType = {
       type: 'v5_graph_patch',
       status: 'noop',
@@ -419,17 +399,7 @@ describe('V5GraphPatchBlock — G2 freshness no-leak across all four verdicts', 
   it.each(FRESHNESS_VERDICTS)(
     'outerHTML stays clean when freshness verdict is "%s"',
     (verdict) => {
-      mockFreshnessState.mockReturnValue({
-        freshness: verdict,
-        reason: null,
-        recommendedAction:
-          verdict === 'stale'
-            ? 'rerun_analysis'
-            : verdict === 'fresh'
-              ? 'view_results'
-              : 'continue_editing',
-        inputsMissing: [],
-      })
+      mockFreshnessState.mockReturnValue({ freshness: verdict })
       const block: V5GraphPatchBlockType = {
         type: 'v5_graph_patch',
         status: 'applied',
@@ -447,12 +417,7 @@ describe('V5GraphPatchBlock — G2 freshness no-leak across all four verdicts', 
     // 'none' means no analysis has run yet — the receipt must not say
     // "out of date" / "rerun" / "analysis", which would imply prior
     // results the user could view.
-    mockFreshnessState.mockReturnValue({
-      freshness: 'none',
-      reason: 'no_options_yet',
-      recommendedAction: 'continue_editing',
-      inputsMissing: [],
-    })
+    mockFreshnessState.mockReturnValue({ freshness: 'none' })
     const block: V5GraphPatchBlockType = {
       type: 'v5_graph_patch',
       status: 'applied',
@@ -475,12 +440,7 @@ describe('V5GraphPatchBlock — G2 freshness no-leak across all four verdicts', 
   it('on freshness=unknown, the receipt avoids false certainty', () => {
     // 'unknown' means the verdict cannot be derived — the receipt must
     // not assert either "up to date" OR "out of date".
-    mockFreshnessState.mockReturnValue({
-      freshness: 'unknown',
-      reason: null,
-      recommendedAction: 'continue_editing',
-      inputsMissing: [],
-    })
+    mockFreshnessState.mockReturnValue({ freshness: 'unknown' })
     const block: V5GraphPatchBlockType = {
       type: 'v5_graph_patch',
       status: 'applied',

--- a/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
+++ b/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
@@ -28,13 +28,10 @@ const EDGES = [
   { id: 'edge_morale_to_outcome', source: 'fac_morale', target: 'goal_outcome' },
 ]
 
-vi.mock('../../../canvas/store', () => ({
-  useCanvasStore: (selector: (s: { nodes: unknown; edges: unknown }) => unknown) =>
-    selector({ nodes: NODES, edges: EDGES }),
-}))
-
-// Mock the freshness hook so each test can control the verdict
-// independently. Default is the neutral 'unknown' verdict (no hint).
+// Each test controls the CEE freshness verdict independently. The component
+// reads the `analysisFreshness` slice (+ dirty overlay) from the store and runs
+// the real `classifyFreshnessForDisplay`; the hint shows only on 'changed'
+// (CEE 'stale' OR a retained-fresh-now-dirtied). Default 'unknown' → no hint.
 import type { AnalysisFreshnessState } from '../../../lib/analysisFreshnessState'
 
 const mockFreshnessState = vi.fn<[], AnalysisFreshnessState>(() => ({
@@ -43,9 +40,25 @@ const mockFreshnessState = vi.fn<[], AnalysisFreshnessState>(() => ({
   recommendedAction: 'continue_editing',
   inputsMissing: [],
 }))
+// Controls the dirty overlay (default clean; set true to exercise the
+// fresh→changed downgrade path).
+let mockAnalysisFreshnessDirty = false
 
-vi.mock('../../../lib/useAnalysisFreshnessState', () => ({
-  useAnalysisFreshnessState: () => mockFreshnessState(),
+vi.mock('../../../canvas/store', () => ({
+  useCanvasStore: (
+    selector: (s: {
+      nodes: unknown
+      edges: unknown
+      analysisFreshness: { freshness: string } | null
+      analysisFreshnessDirty: boolean
+    }) => unknown,
+  ) =>
+    selector({
+      nodes: NODES,
+      edges: EDGES,
+      analysisFreshness: { freshness: mockFreshnessState().freshness },
+      analysisFreshnessDirty: mockAnalysisFreshnessDirty,
+    }),
 }))
 
 // Import AFTER the mock so the component uses the mocked store.
@@ -65,6 +78,7 @@ function expectNoLeakInDOM(): void {
 
 beforeEach(() => {
   cleanup()
+  mockAnalysisFreshnessDirty = false
   mockFreshnessState.mockReturnValue({
     freshness: 'unknown',
     reason: null,


### PR DESCRIPTION
> **Status: DRAFT — review only. Nothing is merged or deployed.** `mergedAt: null`, draft, base `staging`. Latest push (7 commits, `e46bc685`→`8e5542b5`) made with explicit approval.

## Scope

Bundled **Analysis trust-surface** work on the Results/AnalysisHero path and the visible AI-panel affordances: freshness messaging, the robustness glyph, a shared graph-mutation/dirty seam, and the migration of **every** visible "current/stale" affordance onto the single CEE freshness source. UI-only: **no backend/schema/prompt/CEE/PLoT/ISL changes.**

## Freshness — source of truth & local overlay

- **CEE `analysis_ready.freshness` is the source of truth.** The `analysisFreshness` slice holds the last CEE verdict (retain-on-absence; never absence→fresh; order by `computed_at`; content echo-guard). Display rule `resolveDisplayedFreshness(state, dirty)`: `fresh + dirty → 'unknown'`; else the CEE verdict; null when none.
- **The UI never fabricates `stale`** — the overlay can only downgrade a retained `fresh` to `unknown`. No client graph hash; no `v5AnalysisFact.freshness`, `useStaleGuard`, or `_context_summary`.
- **`classifyFreshnessForDisplay(state, dirty)`** is the shared copy/semantic helper: `current` | `changed` (CEE `stale` **or** a dirty-overlay downgrade of a retained `fresh`) | `cannot_confirm` (CEE-sourced `unknown`) | `none`. Single source so every visible surface agrees and none re-derives currentness from a local flag.
- Scenario switch / load / import / reset clear both the verdict and the overlay.

## Single-source migration — every visible currentness consumer is CEE-sourced

**Results surface (no dead `useStaleGuard`):**
- `StaleAnalysisBadge` + OutputsDock stale affordances derive from the CEE slice + display rule. The badge renders only on a genuine CEE `stale` verdict (never fabricated).
- The Results tab icon distinguishes a genuine `stale` (warning `AlertTriangle` + "Analysis is stale") from cannot-confirm `unknown` (neutral `HelpCircle` + "Cannot confirm whether this analysis is current."), mirroring `AnalysisFreshnessNotice`. The OutputsDock banner uses neutral cannot-confirm copy for a CEE-sourced `unknown`. `deriveResultsTabFreshness` extracted + unit-tested.
- Legacy `DecisionConfidencePanel` + Results-body dimming read the CEE slice via `resolveDisplayedFreshness`.

**AI-panel affordances:** `SuggestedChips` + `useStageAwarePlaceholder` off the dead `useStaleGuard`. Placeholder no longer claims "latest analysis" after a cannot-confirm edit. Run-analysis chip: `current` → suppress; `changed`/`cannot_confirm` → relabel "Rerun" (gate-bypassing); no-verdict `none` → keep (readiness gate decides) — so a no-verdict chip never bypasses the gate into a "promises action, delivers chat" fallback.

**Bounded sweep — the remaining five visible currentness consumers migrated off the local `graphEditedSinceLastRun` flag to the CEE-sourced classifier:**
- `V5GraphPatchBlock` (the "Latest analysis is now out of date" hint);
- `ActionStrip` / `selectConversationStatus` (the "Results outdated" badge);
- Compare tab (`CompareTabBody` → `deriveCompareState` "Results outdated"/"Rerun");
- `useAnalysisDisplayState` / `deriveAnalysisDisplayState` (consumed by `InputsDock` + `StickyFooter`; debug `exportBundle` mirrors it);
- `ReanalyseBar` (the "Model changed…" bar).

On these surfaces **only `classifyFreshnessForDisplay(...) === 'changed'`** (CEE `stale`, or a retained-fresh-now-dirtied — the same edit set the local flag tracked) renders stale/outdated copy. **`cannot_confirm`, `current`, and `none` no longer render stale/outdated copy** there — they fall through to each surface's neutral non-stale state (hidden / ready / "Analysis complete" completion-fact / normal comparison). `useAnalysisFreshnessState` now has **no production consumers**.

## Edit-invalidation coverage & shared graph-mutation seam

- **Shared `commitGraphMutation(updater, opts)`** (`src/canvas/mutations/commitGraphMutation.ts`): one history frame + functional-updater `setState` (post-`await` atomic) + `markAnalysisFreshnessDirty`. Active raw-`setState` graph routes converge here.
  - **TemplatesPanel "Merge into Current" + the card merge** route through it (were bare `setState` appends that left a retained `fresh` falsely intact). **`commitTemplateGraphReplace`** (template insert/replace) delegates to it. Regression-covered.
- **Shared analysis-affecting taxonomy** (`src/canvas/domain/analyticalChange.ts`) is the single by-value predicate used by `updateNode`/`updateEdge` **and** `applyAutoApplyPatch`, so they can't diverge. `applyAutoApplyPatch` dirties only on a TRUE analysis-affecting delta (semantic comparison; label/body-only or re-normalised same-content `observed_state` no longer fabricates a persistent `unknown`).
- Also set by the existing chokepoints (`invalidateAnalysisReady`, deletes, undo/redo/undoDraft, `setGoalThreshold` scalar/sync-exempt, `setOutcomeNode`, `applyDraftResult`/`DraftChat`, `commitValidatedMutation`). Cosmetic edits never dirty.

### Clearing
- `setAnalysisFreshness` clears when it accepts a new verdict.
- V5 run-identity clear (`applyV5State` step 5) is gated on the response carrying an explicit `analysis_ready.freshness`.
- `batchUpdateNodes` invalidation reverted (it is exclusively the CEE intervention-backfill producer).

## Robustness glyph — display-safe verdict only

- The binary Robust/Sensitive glyph reads **only `robustnessVerdict`** (display-safe), undefined until a UI-safe upstream verdict exists → renders **"Robustness unknown" NEUTRALLY**. PLoT `robustness.level` stays structured data (`robustnessLevel`) but does not drive the glyph. Provenance test: PLoT `level: 'high'` alone does not render "Robust".

## Tests

- `CompareTabBody.freshness.spec.tsx` locks the component-boundary states (CEE `stale` + fresh-dirtied → `'stale'`; `cannot_confirm`/`current`/`null` → not `'stale'`).
- V5 freshness tests (`V5GraphPatchBlock.test`, `freshness-state-matrix`, `journey-3-and-6-wire-to-dom`) now drive the actual `analysisFreshness` slice shape rather than the retired legacy `useAnalysisFreshnessState` scaffolding; the dead legacy-hook mock was removed (the matrix's separate `deriveAnalysisFreshnessState` legacy-derivation describe is retained intentionally).
- Plus: `deriveResultsTabFreshness`, `commitGraphMutation` (merge/replace/no-fabricate/history), `TemplatesPanel.mergeDirty` (executes the captured updater + asserts merge shape) + `mergeFreshness`, `classifyFreshnessForDisplay` matrix, `useStageAwarePlaceholder`, `SuggestedChips` (incl. no-verdict/missing-readiness gate regression), `selectors`, `ActionStrip`, `useAnalysisDisplayState`, `ReanalyseBar`, `PreAnalysisPanel.statusBanner`.

## Verification (latest)

- **Fast pre-push gate PASSED** on every push: `tsconfig.ci.json` typecheck, lint (changed files), smoke suite, stale-`.js` check, dependency audit, DS-v5 ratchet report-only (Δ0).
- Latest sweep: **131 passing tests across the affected suites, CI typecheck clean, lint 0 errors, no new type errors** (baseline-vs-current diff confirms zero net-new type-error signatures in touched files). Stale comments around wire-freshness/local-fallback semantics were corrected (`selectors.ts`, `deriveAnalysisDisplayState.ts`).
- Pre-existing-unrelated (identical on baseline, CI-only): `MixedBlocks`/`ChatThread.chipGroup`/`phase3ReviewCardBridge`/`OutputsDock.analysis-run` "Missing Supabase env" worktree load errors; `extraction.spec`+`polishD4.spec` `recommendation→result` body-copy drift; the known-broken `aiPanelTranche1` clamp assertion; pre-existing `MockInstance`/fixture-shape type errors in some specs. CEE Contract Validation runs on the PR (other GH workflows are blocked by the repo's known pnpm-install infra issue, not this PR).

## Remaining deferred (tracked — genuinely not in this PR)

- **Inspector-v2 `StaleGuardBanner` migration:** the entity panels still feed it from the dead `useStaleGuard().isStale`. Dead-but-benign (the banner never renders → no false claim; panels have a separate working `useEditConfirmation` signal). Follow-up to migrate it to the CEE source.
- **Legacy `useAnalysisFreshnessState` / `deriveAnalysisFreshnessState` dead-code removal:** the hook now has no production consumers; the lib (+ `freshnessReasons`, dormant `applyClarifierGraph`) can be retired in a cleanup pass.
- **Evidence-glyph consistency:** evidence "unknown" still renders red (deferred to bundle with the extraction-snapshot regen).
- **Echoed-verdict edge case:** a new `analysis_result` hash echoing a prior fresh `analysis_ready` (rare CEE inconsistency; needs run-id linkage / CEE `computed_at`).
- **Robustness verdict upstream contract** (`ROBUSTNESS-VERDICT-CONTRACT`) — define a display-safe robustness verdict upstream so the glyph can light up.
- **Broader readiness-invalidation cleanup** (dormant `commitValidatedMutation` PLoT branch, dead inspector-v2 mutators, `AnalysisHeroV17` footer stability check).
- **`handleConfirmReplace` double-undo-frame** (pre-existing, unrelated to freshness): a template replace records two undo frames so the first undo lands on a pruned intermediate.

Do not merge or deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
