### PR TITLE
polish(analysis): live hero UI coverage and rerun affordances

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2027,7 +2027,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                         type="button"
                         onClick={handleRunAnalysis}
                         disabled={isRunning || !canRunAnalysis}
-                        className={`${typography.panelBody} bg-primary text-text-on-color rounded-md px-3 py-1 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0`}
+                        className={`${typography.panelBody} bg-primary text-text-on-color rounded-md px-3 py-1 hover:bg-primary-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-inset disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0`}
                       >
                         Rerun analysis
                       </button>

--- a/src/canvas/components/StaleAnalysisBadge.tsx
+++ b/src/canvas/components/StaleAnalysisBadge.tsx
@@ -36,10 +36,11 @@ export const StaleAnalysisBadge = memo(function StaleAnalysisBadge() {
       aria-live="polite"
     >
       <span className={typo('panelMeta', 'text-warning')}>Analysis stale</span>
-      <span className={typo('panelMeta', 'text-text-light')}>·</span>
+      <span className={typo('panelMeta', 'text-text-light')} aria-hidden="true">·</span>
       <button
         type="button"
         onClick={handleRerun}
+        aria-label="Rerun analysis"
         className={typo('panelMeta', 'text-info hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-info rounded px-0.5')}
         data-testid="ai-panel-stale-badge-rerun"
       >

--- a/src/canvas/components/__tests__/SelectionPill.StaleAnalysisBadge.spec.tsx
+++ b/src/canvas/components/__tests__/SelectionPill.StaleAnalysisBadge.spec.tsx
@@ -83,6 +83,9 @@ describe('StaleAnalysisBadge — gap #2 (CEE-derived, single source)', () => {
     expect(badge).toHaveTextContent('Rerun')
     expect(badge).toHaveAttribute('role', 'status')
     expect(badge).toHaveAttribute('aria-live', 'polite')
+    // a11y: the compact visible "Rerun" carries the full action name for AT,
+    // aligned with the other rerun affordances.
+    expect(screen.getByRole('button', { name: 'Rerun analysis' })).toBeInTheDocument()
   })
 
   it('clicking Rerun invokes the EXISTING useV2Run() runV2Analysis, not a second path', () => {

--- a/src/canvas/components/model-tab/ReanalyseBar.tsx
+++ b/src/canvas/components/model-tab/ReanalyseBar.tsx
@@ -37,11 +37,11 @@ export function ReanalyseBar({ onReanalyse }: ReanalyseBarProps) {
         type="button"
         onClick={onReanalyse}
         disabled={!onReanalyse}
-        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-text-on-color ${typography.panelMeta} font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed shrink-0`}
+        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-text-on-color ${typography.panelMeta} font-medium hover:bg-primary-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-inset disabled:opacity-50 disabled:cursor-not-allowed shrink-0`}
         data-testid="reanalyse-button"
       >
         <RefreshCw className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-        Re-analyse
+        Rerun analysis
       </button>
     </div>
   )

--- a/src/canvas/components/model-tab/__tests__/ReanalyseBar.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/ReanalyseBar.spec.tsx
@@ -58,6 +58,13 @@ describe('ReanalyseBar', () => {
     expect(screen.getByTestId('reanalyse-bar')).toBeInTheDocument()
   })
 
+  it('labels the rerun action "Rerun analysis" (aligned across rerun affordances)', () => {
+    mockFreshness = { freshness: 'stale' }
+    mockDirty = false
+    render(<ReanalyseBar onReanalyse={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Rerun analysis' })).toBeInTheDocument()
+  })
+
   it('calls onReanalyse when button is clicked', () => {
     mockFreshness = { freshness: 'stale' }
     mockDirty = false

--- a/src/components/results/AnalysisFreshnessNotice.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.tsx
@@ -72,8 +72,7 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
       className={`flex items-center gap-2 rounded-md border px-3 py-2 bg-panel ${isStale ? 'border-warning/30' : 'border-panel-border'} ${className}`.trim()}
     >
       <Icon
-        size={14}
-        className={`flex-none ${isStale ? 'text-warning' : 'text-text-light'}`}
+        className={`w-3.5 h-3.5 flex-none ${isStale ? 'text-warning' : 'text-text-light'}`}
         aria-hidden="true"
       />
       <span className={`${typography.panelBody} text-text-body`}>{FRESHNESS_COPY[freshness]}</span>

--- a/src/components/results/DecisionConfidencePanel.stories.tsx
+++ b/src/components/results/DecisionConfidencePanel.stories.tsx
@@ -1,0 +1,133 @@
+/**
+ * DecisionConfidencePanel — Storybook stories (the LIVE legacy Analysis hero).
+ *
+ * Default flags render this panel (aiPanelV2 ON, analysisHeroV17 OFF). Until now
+ * it had zero stories; this file covers the visible hero states for demo / manual
+ * golden-journey QA:
+ *   - freshness: fresh · changed/stale · cannot-confirm (via the CEE slice + the
+ *     AnalysisFreshnessNotice that sits above the hero in ResultsBody)
+ *   - robustness unknown (the certified default: no display-safe verdict → neutral
+ *     "Robustness unknown" glyph in the checks footer)
+ *   - data variants: close-call · rich · minimal-degraded
+ *   - a narrow panel, to show the checks-footer counter no longer orphans
+ *
+ * Freshness is driven by the real canvas store (the hero's HeroQualifier reads it);
+ * AnalysisFreshnessNotice is given the same verdict via its prop override so the
+ * notice + hero stay in sync. NO trust logic is touched — these are display props.
+ */
+
+import React, { useLayoutEffect } from 'react'
+import { DecisionConfidencePanel } from './DecisionConfidencePanel'
+import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
+import { useCanvasStore } from '@/canvas/store'
+import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
+import { normalisedFixture } from '../../__fixtures__/resultsPanelV7.normalised.hook'
+import { sensitiveFixture } from '../../__fixtures__/resultsPanelV7.sensitive.hook'
+import { richFixture } from '../../__fixtures__/resultsPanelV7.rich.hook'
+import { minimalFixture } from '../../__fixtures__/resultsPanelV7.minimal.hook'
+import type { ResultsSectionDataReturn } from './useResultsSectionData'
+
+export default {
+  title: 'Results Panel v7/Decision Confidence (live hero)',
+  parameters: {
+    layout: 'padded',
+    backgrounds: { default: 'panel' },
+  },
+}
+
+const noopFocus = (_nodeId: string) => {}
+
+// Stable per-state verdicts (stable refs keep the store-effect deps clean).
+const FRESH: AnalysisFreshnessState = { freshness: 'fresh', freshnessReason: 'graph_hash_match' }
+const STALE: AnalysisFreshnessState = { freshness: 'stale', freshnessReason: 'graph_changed' }
+
+/** Sets the CEE freshness slice the hero reads, and resets it on unmount. */
+function FreshnessSetter({
+  state,
+  dirty = false,
+  children,
+}: {
+  state: AnalysisFreshnessState | null
+  dirty?: boolean
+  children: React.ReactNode
+}) {
+  useLayoutEffect(() => {
+    useCanvasStore.setState({ analysisFreshness: state, analysisFreshnessDirty: dirty })
+    return () => useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+  }, [state, dirty])
+  return <>{children}</>
+}
+
+function PanelWrapper({ width = 380, children }: { width?: number; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        width,
+        maxHeight: '90vh',
+        overflow: 'auto',
+        background: 'var(--bg-panel, #FFFDF7)',
+        borderRadius: 16,
+        padding: 16,
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** Mirrors the live ResultsBody slice: freshness notice above the hero. */
+function HeroStory({
+  data,
+  freshness = null,
+  dirty = false,
+  width = 380,
+}: {
+  data: ResultsSectionDataReturn
+  freshness?: AnalysisFreshnessState | null
+  dirty?: boolean
+  width?: number
+}) {
+  return (
+    <FreshnessSetter state={freshness} dirty={dirty}>
+      <PanelWrapper width={width}>
+        <div className="space-y-3">
+          <AnalysisFreshnessNotice state={freshness} dirty={dirty} />
+          <DecisionConfidencePanel data={data} onFocusNode={noopFocus} />
+        </div>
+      </PanelWrapper>
+    </FreshnessSetter>
+  )
+}
+
+// ── Freshness states ──────────────────────────────────────────────────────
+
+export const Fresh = () => <HeroStory data={normalisedFixture} freshness={FRESH} />
+Fresh.storyName = 'Fresh (analysis reflects current model)'
+
+export const ChangedStale = () => <HeroStory data={normalisedFixture} freshness={STALE} />
+ChangedStale.storyName = 'Changed / stale (re-run to update)'
+
+export const CannotConfirm = () => <HeroStory data={normalisedFixture} freshness={FRESH} dirty />
+CannotConfirm.storyName = 'Cannot-confirm (fresh verdict, edited since)'
+
+// ── Robustness unknown (certified default) ────────────────────────────────
+
+export const RobustnessUnknown = () => <HeroStory data={normalisedFixture} freshness={FRESH} />
+RobustnessUnknown.storyName = 'Robustness unknown (neutral checks glyph)'
+
+// ── Data variants ─────────────────────────────────────────────────────────
+
+export const CloseCall = () => <HeroStory data={sensitiveFixture} freshness={FRESH} />
+CloseCall.storyName = 'Close call (near-tie)'
+
+export const Rich = () => <HeroStory data={richFixture} freshness={FRESH} />
+Rich.storyName = 'Rich (3 options, 5 factors)'
+
+export const MinimalDegraded = () => <HeroStory data={minimalFixture} freshness={FRESH} />
+MinimalDegraded.storyName = 'Minimal / degraded (no drivers)'
+
+// ── Narrow panel (checks-footer counter no longer orphans) ────────────────
+
+export const NarrowPanel = () => <HeroStory data={normalisedFixture} freshness={STALE} width={300} />
+NarrowPanel.storyName = 'Narrow panel (300px — checks footer wraps cleanly)'

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -423,6 +423,9 @@ function T1ChecksFooter({
 
   return (
     <div className="border-t border-panel-border pt-3" data-testid="t1-checks-footer">
+      {/* Glyphs + addressed-counter wrap on a single flex row. The counter flows
+          inline (no `ml-auto` push) so that on narrow panels it wraps left-aligned
+          beneath the glyphs instead of orphaning onto its own far-right line. */}
       <div className={`flex items-center flex-wrap gap-x-3 gap-y-1 ${typography.panelMeta} text-text-light`}>
         <ChecksGlyph
           ok={hasWinner}
@@ -444,7 +447,7 @@ function T1ChecksFooter({
           dataTestid="checks-evidence"
         />
         {total > 0 && (
-          <span className="ml-auto" data-testid="checks-addressed">
+          <span data-testid="checks-addressed">
             {addressed}/{total} addressed
           </span>
         )}

--- a/src/components/results/__tests__/DecisionConfidencePanel.stories.smoke.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.stories.smoke.spec.tsx
@@ -1,0 +1,66 @@
+/**
+ * DecisionConfidencePanel.stories — smoke + freshness-state coverage.
+ *
+ * Renders every story from the live-hero story file so the stories can't rot,
+ * and locks the component-integration freshness states the story drives through
+ * the real canvas store (DecisionConfidencePanel → HeroQualifier reads it,
+ * AnalysisFreshnessNotice renders above): fresh / changed-stale / cannot-confirm.
+ * Trust logic is untouched — these assert display output only.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import * as stories from '../DecisionConfidencePanel.stories'
+
+afterEach(() => cleanup())
+
+type StoryFn = () => JSX.Element
+const storyEntries = Object.entries(stories).filter(
+  ([name, val]) => name !== 'default' && typeof val === 'function',
+) as Array<[string, StoryFn]>
+
+describe('DecisionConfidencePanel stories', () => {
+  it('exposes the expected live-hero stories', () => {
+    const names = storyEntries.map(([n]) => n)
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'Fresh',
+        'ChangedStale',
+        'CannotConfirm',
+        'RobustnessUnknown',
+        'CloseCall',
+        'Rich',
+        'MinimalDegraded',
+        'NarrowPanel',
+      ]),
+    )
+  })
+
+  it.each(storyEntries)('story %s renders the hero without crashing', (_name, Story) => {
+    render(<Story />)
+    expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
+  })
+
+  it('Fresh: shows the current-model freshness notice', () => {
+    render(<stories.Fresh />)
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveTextContent(
+      /reflects the current model/i,
+    )
+  })
+
+  it('ChangedStale: shows the model-changed freshness notice', () => {
+    render(<stories.ChangedStale />)
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveTextContent(/model changed/i)
+  })
+
+  it('CannotConfirm: shows the cannot-confirm freshness notice (never fabricates stale)', () => {
+    render(<stories.CannotConfirm />)
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).toHaveTextContent(/cannot confirm/i)
+    expect(notice).not.toHaveTextContent(/model changed/i)
+  })
+
+  it('RobustnessUnknown: the robustness check renders the neutral "Robustness unknown" glyph', () => {
+    render(<stories.RobustnessUnknown />)
+    expect(screen.getByTestId('checks-robust')).toHaveTextContent('Robustness unknown')
+  })
+})


### PR DESCRIPTION
> **Status: DRAFT — review only. Do not merge, deploy, or mark ready.**

## Stacked on PR #195

This PR is **stacked on top of PR #195** (`claude/analysis-freshness-robustness-v1`). PR #195 — the Codex-certified freshness/currentness/robustness **trust surface** — **remains frozen at `8e5542b5`** and is untouched by this work. Base of this PR is `claude/analysis-freshness-robustness-v1` (NOT `staging`), so the diff shows only this branch's UI polish.

## What this is

UI-only **polish + coverage** on the **live legacy `DecisionConfidencePanel`** Analysis surface (the default hero: `aiPanelV2` ON, `analysisHeroV17` OFF). Near-term demo / manual golden-journey QA readiness.

- **No `AnalysisHeroV17` enablement or polish** — the flag stays OFF; `AnalysisHeroV17/*` is untouched (separate future PR).
- **No trust-logic changes** — `resolveDisplayedFreshness`, `classifyFreshnessForDisplay`, the `analysisFreshness` slice, dirty-overlay, the run/rerun readiness-gate, robustness claim semantics, and the `FRESHNESS_COPY` state→copy mapping are all unchanged. The robustness glyph still renders the certified neutral "Robustness unknown" by default.
- **No backend/schema/prompt/CEE/PLoT/ISL changes.**

## Changes

**Files changed: 9 (+219 / −7)** — all display components, stories, and tests.

**Storybook coverage (the live hero had zero stories):**
- New `DecisionConfidencePanel.stories.tsx` — fresh · changed/stale · cannot-confirm · robustness-unknown · close-call / rich / minimal-degraded data variants · narrow (300px) panel. Reuses existing `resultsPanelV7` fixtures; a small `FreshnessSetter` drives the CEE slice the hero reads (display props only).
- New `DecisionConfidencePanel.stories.smoke.spec.tsx` — renders every story (rot-guard) and locks the component-integration freshness states + the neutral robustness glyph.

**Rough-spot polish (genuine, visible):**
- **Rerun affordances:** `ReanalyseBar` + the OutputsDock `graph-stale-banner` button use `hover:bg-primary-hover` (colour shift, DS primary pattern) + a `focus-visible` ring; the rerun action label is aligned to **"Rerun analysis"**.
- **Accessible labels:** `StaleAnalysisBadge` keeps the compact visible "Rerun" but gains `aria-label="Rerun analysis"` and `aria-hidden` on the decorative "·" separator.
- **Narrow-footer wrap fix:** `T1ChecksFooter` drops `ml-auto` so the addressed-counter wraps left-aligned beneath the glyphs instead of orphaning to its own far-right line (class-only — invisible to the extraction zero-diff gate).
- **Icon sizing:** `AnalysisFreshnessNotice` uses Tailwind `w-3.5 h-3.5` per the DS rule (visually identical to the prior Lucide `size` prop).

**Targeted tests** for the touched markup: `ReanalyseBar` "Rerun analysis" label; `StaleAnalysisBadge` rerun control accessible name.

## Verification

- **Tests:** 138 passing across the touched/new suites (incl. the new label/aria tests + 13 story-smoke tests).
- **Typecheck:** CI gate (`tsconfig.ci.json`) clean; zero net-new type errors (baseline-diffed).
- **Lint:** 0 errors.
- **Remaining 3 failures are pre-existing on the frozen baseline** `8e5542b5` and documented (the `recommendation→result` copy drift in `polishD4`, and the stale `extraction` structure baseline). Confirmed they fail identically with this branch's changes stashed — not introduced here.

## Follow-up note (do NOT solve in this PR)

**DS icon-sizing rule vs. the extraction zero-diff gate — tension.** Applying Tailwind sizing to Lucide icons (`className="w-3 h-3"` instead of `size={...}`) can change the SVG's `width`/`height` **attributes** (Lucide defaults to 24 when `size` is omitted) even when the rendered size is visually unchanged (CSS wins). In extraction-gated components (e.g. `TriageActionCardsBody`), this trips the structure/attribute gate — so the `ChecksGlyph` icon was deliberately left on `size={12}` here. Resolution options for later: either the extraction gate should strip `width`/`height`, or the DS rule should explicitly allow Lucide `size={...}` props in gated components. Tracked as a follow-up; intentionally not solved in this PR.

Do not merge or deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
