### PR TITLE
fix(analysis): stop raw-stability robustness overclaims

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -975,14 +975,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
 
   const decisionReadiness = report?.decision_readiness || readinessFromConfidence
   const recommendationStability = (report as any)?.robustness?.recommendation_stability ?? (report as any)?.robustness?.ranking_stability
-  // Brief 5.8B D8: footer status + meta re-skinned to the wireframe via the
-  // pure helper (./utils/postAnalysisFooter.ts). The helper owns the
-  // wireframe stability bands + evidence-gap derivation so the logic can be
-  // unit-tested in isolation. The legacy `getStabilityClassification`
-  // heroLabel ("Stability sensitive") was the orphan-text source D6
-  // flagged — superseded by the deterministic strings here.
-  const postFooterStatus = derivePostFooterStatus(recommendationStability)
-  const POST_FOOTER_ICONS = { check: CheckCircle, warning: AlertTriangle, danger: XCircle } as const
+  // Footer status is driven by the display-safe robustness verdict ONLY
+  // (single-source rule — the same `robustnessVerdict` field that drives the
+  // certified "Robustness unknown" glyph), NEVER by raw recommendation_stability.
+  // With no display-safe verdict in the contract today the verdict is undefined,
+  // so the footer renders the neutral "Robustness unknown" state instead of a
+  // green "Stable result" derived from raw stability (which contradicted the
+  // glyph on the same tab). Raw stability is retained only as neutral metadata
+  // in derivePostFooterMeta below. See ./utils/postAnalysisFooter.ts +
+  // ROBUSTNESS-VERDICT-CONTRACT.
+  const postFooterStatus = derivePostFooterStatus(resultsSectionData.recommendation.robustnessVerdict)
+  const POST_FOOTER_ICONS = { check: CheckCircle, warning: AlertTriangle, unknown: HelpCircle } as const
   const postRunFooter = {
     icon: POST_FOOTER_ICONS[postFooterStatus.icon],
     iconClass: postFooterStatus.iconClass,

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -302,7 +302,13 @@ describe('OutputsDock analyse convergence', () => {
 
     const footer = screen.getByTestId('results-analysis-footer')
     expect(footer).toBeInTheDocument()
-    expect(footer).toHaveTextContent('Stable result')
+    // Robustness trust fix (ROBUSTNESS-VERDICT-CONTRACT): raw
+    // recommendation_stability (0.87) with NO display-safe robustnessVerdict no
+    // longer renders a positive "Stable result" verdict — the footer stays
+    // neutral ("Robustness unknown"), matching the certified glyph. The raw %
+    // is retained only as neutral metadata.
+    expect(footer).not.toHaveTextContent('Stable result')
+    expect(footer).toHaveTextContent('Robustness unknown')
     expect(footer).toHaveTextContent('87%')
     expect(screen.queryByText('Compare available in the tab bar')).not.toBeInTheDocument()
   })

--- a/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
+++ b/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
@@ -1,12 +1,15 @@
 /**
- * Brief 5.8B D8 — post-analysis footer status + meta derivation.
+ * Post-analysis footer status + meta derivation.
  *
- * Pure helper underpinning the AnalysisFooter call inside OutputsDock.
- * Covers all four stability bands + the evidence-gap meta cases.
+ * Pure helper underpinning the AnalysisFooter call inside OutputsDock. Status is
+ * driven ONLY by the display-safe robustnessVerdict (single-source rule), and
+ * is runtime-safe (unexpected values fall neutral); meta covers the neutral
+ * "{N}% stability" + evidence-gap cases.
  */
 
 import { describe, it, expect } from 'vitest'
 import { derivePostFooterStatus, derivePostFooterMeta } from '../postAnalysisFooter'
+import type { RobustnessLevel } from '@/components/results/types'
 
 describe('derivePostFooterStatus — display-safe verdict only (robustness trust fix)', () => {
   // Single-source rule (ROBUSTNESS-VERDICT-CONTRACT): the footer verdict comes
@@ -50,6 +53,36 @@ describe('derivePostFooterStatus — display-safe verdict only (robustness trust
     expect(status.icon).not.toBe('check')
     expect(status.iconClass).not.toContain('success')
     expect(status.label).toBe('Robustness unknown')
+  })
+})
+
+describe('derivePostFooterStatus — runtime-safe: unexpected values fall NEUTRAL (not a verdict)', () => {
+  // Type safety is necessary but NOT sufficient. If a raw stability number
+  // (e.g. 0.87), a stringified number, or any malformed value accidentally
+  // reaches the helper at runtime, it must fall neutral — NEVER fabricate a
+  // "Sensitive to assumptions"/"Stable result" claim from an uncertified source.
+  const NEUTRAL = { icon: 'unknown', iconClass: 'text-text-light', label: 'Robustness unknown' } as const
+  const UNEXPECTED: Array<[string, unknown]> = [
+    ['raw number 0.87', 0.87],
+    ['raw number 0.5', 0.5],
+    ['raw number 1', 1],
+    ['stringified number "0.87"', '0.87'],
+    ['unknown string "unexpected"', 'unexpected'],
+    ['empty string', ''],
+    ['NaN', Number.NaN],
+    ['boolean true', true],
+    ['object', {}],
+    ['array', []],
+  ]
+  it.each(UNEXPECTED)('%s → neutral "Robustness unknown", no verdict / no positive styling', (_label, value) => {
+    const status = derivePostFooterStatus(value as unknown as RobustnessLevel)
+    expect(status).toEqual(NEUTRAL)
+    expect(status.label).not.toBe('Stable result')
+    expect(status.label).not.toBe('Sensitive to assumptions')
+    expect(status.icon).not.toBe('check')
+    expect(status.icon).not.toBe('warning')
+    expect(status.iconClass).not.toContain('success')
+    expect(status.iconClass).not.toContain('warning')
   })
 })
 

--- a/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
+++ b/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
@@ -8,47 +8,48 @@
 import { describe, it, expect } from 'vitest'
 import { derivePostFooterStatus, derivePostFooterMeta } from '../postAnalysisFooter'
 
-describe('derivePostFooterStatus (Brief 5.8B D8)', () => {
-  it('≥0.85 → success "Stable result"', () => {
-    expect(derivePostFooterStatus(0.85)).toEqual({
+describe('derivePostFooterStatus — display-safe verdict only (robustness trust fix)', () => {
+  // Single-source rule (ROBUSTNESS-VERDICT-CONTRACT): the footer verdict comes
+  // ONLY from the display-safe `robustnessVerdict`, never from raw
+  // recommendation_stability. So the helper now takes the verdict, not a number.
+
+  it('verdict "high" → success "Stable result" (the ONLY path to a positive verdict)', () => {
+    expect(derivePostFooterStatus('high')).toEqual({
       icon: 'check',
       iconClass: 'text-success',
       label: 'Stable result',
     })
-    expect(derivePostFooterStatus(0.92)).toEqual({
-      icon: 'check',
-      iconClass: 'text-success',
-      label: 'Stable result',
-    })
   })
 
-  it('0.60..0.84 → warning "Sensitive to assumptions"', () => {
-    expect(derivePostFooterStatus(0.60)).toMatchObject({
-      icon: 'warning',
-      label: 'Sensitive to assumptions',
-    })
-    expect(derivePostFooterStatus(0.84)).toMatchObject({
-      icon: 'warning',
-      label: 'Sensitive to assumptions',
-    })
+  it('verdict "moderate" | "low" | "very_low" → warning "Sensitive to assumptions"', () => {
+    for (const v of ['moderate', 'low', 'very_low'] as const) {
+      expect(derivePostFooterStatus(v)).toEqual({
+        icon: 'warning',
+        iconClass: 'text-warning',
+        label: 'Sensitive to assumptions',
+      })
+    }
   })
 
-  it('<0.60 → danger "Provisional result"', () => {
-    expect(derivePostFooterStatus(0.59)).toMatchObject({
-      icon: 'danger',
-      label: 'Provisional result',
-    })
-    expect(derivePostFooterStatus(0)).toMatchObject({
-      icon: 'danger',
-      label: 'Provisional result',
-    })
+  it('undefined / null verdict → neutral "Robustness unknown" (matches the certified glyph)', () => {
+    for (const v of [undefined, null] as const) {
+      expect(derivePostFooterStatus(v)).toEqual({
+        icon: 'unknown',
+        iconClass: 'text-text-light',
+        label: 'Robustness unknown',
+      })
+    }
   })
 
-  it('missing / NaN / non-finite → danger "Fragile result" fallback', () => {
-    expect(derivePostFooterStatus(undefined)).toMatchObject({ label: 'Fragile result' })
-    expect(derivePostFooterStatus(null)).toMatchObject({ label: 'Fragile result' })
-    expect(derivePostFooterStatus(Number.NaN)).toMatchObject({ label: 'Fragile result' })
-    expect(derivePostFooterStatus(Number.POSITIVE_INFINITY)).toMatchObject({ label: 'Fragile result' })
+  it('trust fix: an ABSENT display-safe verdict never renders "Stable result" nor a green/check positive icon', () => {
+    // This is the live-contract case today (robustnessVerdict is always
+    // undefined). Previously raw stability ≥ 0.85 rendered a green "Stable
+    // result" that contradicted the neutral robustness glyph.
+    const status = derivePostFooterStatus(undefined)
+    expect(status.label).not.toBe('Stable result')
+    expect(status.icon).not.toBe('check')
+    expect(status.iconClass).not.toContain('success')
+    expect(status.label).toBe('Robustness unknown')
   })
 })
 

--- a/src/canvas/components/utils/__tests__/robustnessSingleSource.render.spec.tsx
+++ b/src/canvas/components/utils/__tests__/robustnessSingleSource.render.spec.tsx
@@ -1,0 +1,129 @@
+/**
+ * Robustness single-source rule — rendered-state + footer↔glyph consistency.
+ *
+ * Guards the live trust fix (ROBUSTNESS-VERDICT-CONTRACT): the post-analysis
+ * AnalysisFooter must derive its verdict ONLY from the display-safe
+ * `robustnessVerdict`, never from raw `recommendation_stability` /
+ * `ranking_stability`. With no display-safe verdict in the contract today the
+ * footer renders the neutral "Robustness unknown" state, in lock-step with the
+ * certified glyph (TriageActionCardsBody `checks-robust`) — so the Analysis tab
+ * can never show a green "Stable result" beside a neutral "Robustness unknown".
+ *
+ * These render the ACTUAL presentational AnalysisFooter (the live footer
+ * component, env-free) the way OutputsDock wires it (metaPlacement="stacked",
+ * POST_FOOTER_ICONS mapping), so the assertions reflect rendered DOM, not just
+ * the pure mapping.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { CheckCircle, AlertTriangle, HelpCircle, type LucideIcon } from 'lucide-react'
+import { AnalysisFooter } from '../../../shared/AnalysisFooter'
+import { derivePostFooterStatus } from '../postAnalysisFooter'
+import type { RobustnessLevel } from '@/components/results/types'
+
+afterEach(() => cleanup())
+
+// Mirror OutputsDock.tsx's icon map (the caller maps the icon name → component).
+const POST_FOOTER_ICONS: Record<string, LucideIcon> = {
+  check: CheckCircle,
+  warning: AlertTriangle,
+  unknown: HelpCircle,
+}
+
+/** Render the live footer exactly as OutputsDock does for a given verdict. */
+function renderFooter(verdict: RobustnessLevel | null | undefined) {
+  const status = derivePostFooterStatus(verdict)
+  return render(
+    <AnalysisFooter
+      statusIcon={POST_FOOTER_ICONS[status.icon]}
+      statusIconClassName={status.iconClass}
+      statusText={status.label}
+      metaText="87% stability"
+      metaPlacement="stacked"
+      actionLabel="Rerun"
+      onAction={() => {}}
+      testId="results-analysis-footer"
+    />,
+  )
+}
+
+describe('AnalysisFooter — raw stability cannot render a positive robustness verdict', () => {
+  it('no display-safe verdict (live contract today) → neutral "Robustness unknown", no positive styling', () => {
+    const { container } = renderFooter(undefined)
+    const footer = screen.getByTestId('results-analysis-footer')
+    expect(footer).toHaveTextContent('Robustness unknown')
+    expect(footer).not.toHaveTextContent('Stable result')
+    // No green/check success styling anywhere in the neutral footer.
+    expect(container.querySelector('.text-success')).toBeNull()
+    expect(container.querySelector('.lucide-check-circle')).toBeNull()
+    expect(container.querySelector('.lucide-help-circle')).not.toBeNull()
+  })
+
+  it('raw high recommendation_stability / ranking_stability are NOT inputs — only the verdict is', () => {
+    // OutputsDock now passes `recommendation.robustnessVerdict` (undefined in
+    // production) — NOT report.robustness.recommendation_stability and NOT the
+    // ranking_stability fallback. So however high those raw fields are, the
+    // footer that renders is the undefined-verdict (neutral) one above. The
+    // helper's signature makes this structural: it accepts only RobustnessLevel.
+    const status = derivePostFooterStatus(undefined)
+    expect(status).toEqual({ icon: 'unknown', iconClass: 'text-text-light', label: 'Robustness unknown' })
+    // Sanity: a raw number is not a RobustnessLevel; passing one is a type error
+    // at call sites, and at runtime any non-'high' value falls to Sensitive,
+    // never the positive "Stable result" path reserved for the verdict 'high'.
+    expect(status.label).not.toBe('Stable result')
+  })
+
+  it('the ONLY path to a positive green "Stable result" is robustnessVerdict === "high"', () => {
+    const { container } = renderFooter('high')
+    const footer = screen.getByTestId('results-analysis-footer')
+    expect(footer).toHaveTextContent('Stable result')
+    // Positive verdict → success styling is allowed (stacked mode applies
+    // statusIconClassName to both icon and label).
+    expect(container.querySelector('.text-success')).not.toBeNull()
+    expect(container.querySelector('.lucide-check-circle')).not.toBeNull()
+  })
+
+  it('known non-"high" verdict → warning "Sensitive to assumptions" (no success styling)', () => {
+    for (const v of ['moderate', 'low', 'very_low'] as const) {
+      const { container } = renderFooter(v)
+      const footer = screen.getByTestId('results-analysis-footer')
+      expect(footer).toHaveTextContent('Sensitive to assumptions')
+      expect(footer).not.toHaveTextContent('Stable result')
+      expect(container.querySelector('.text-success')).toBeNull()
+      cleanup()
+    }
+  })
+})
+
+describe('footer ↔ certified glyph consistency (single source)', () => {
+  // The certified robustness glyph (TriageActionCardsBody.tsx:411-412) is:
+  //   robustOk   = robustnessVerdict === 'high'    → positive ("Robust")
+  //   robustKnown = robustnessVerdict != null      → else "Sensitive"
+  //   neither    = undefined/null                  → "Robustness unknown"
+  // The footer MUST agree: positive iff the glyph is positive; otherwise the
+  // footer must NOT render a positive "Stable result". This proves the two
+  // sibling surfaces can never contradict (e.g. green "Stable result" beside a
+  // neutral "Robustness unknown" glyph on the same Analysis tab).
+  const ALL: Array<RobustnessLevel | null | undefined> = [
+    undefined, null, 'high', 'moderate', 'low', 'very_low',
+  ]
+
+  it('footer renders a positive verdict iff the glyph would (verdict === "high")', () => {
+    for (const v of ALL) {
+      const status = derivePostFooterStatus(v)
+      const glyphPositive = v === 'high'
+      const footerPositive = status.label === 'Stable result' && status.icon === 'check'
+      expect(footerPositive).toBe(glyphPositive)
+      if (!glyphPositive) {
+        // Glyph neutral/sensitive → footer must not be a positive "Stable result".
+        expect(status.label).not.toBe('Stable result')
+        expect(status.iconClass).not.toContain('success')
+      }
+    }
+  })
+
+  it('when the glyph is neutral (verdict undefined), the footer is also neutral', () => {
+    expect(derivePostFooterStatus(undefined).label).toBe('Robustness unknown')
+  })
+})

--- a/src/canvas/components/utils/__tests__/robustnessSingleSource.render.spec.tsx
+++ b/src/canvas/components/utils/__tests__/robustnessSingleSource.render.spec.tsx
@@ -94,6 +94,21 @@ describe('AnalysisFooter — raw stability cannot render a positive robustness v
       cleanup()
     }
   })
+
+  it('runtime-safe: a raw stability NUMBER that slips through at runtime → neutral footer, no verdict styling', () => {
+    // Defense-in-depth (rendered): even if 0.87 reached the wired helper at
+    // runtime, the footer must render neutral "Robustness unknown" — never a
+    // green "Stable result" nor an amber "Sensitive to assumptions" from an
+    // uncertified raw value.
+    const { container } = renderFooter(0.87 as unknown as RobustnessLevel)
+    const footer = screen.getByTestId('results-analysis-footer')
+    expect(footer).toHaveTextContent('Robustness unknown')
+    expect(footer).not.toHaveTextContent('Stable result')
+    expect(footer).not.toHaveTextContent('Sensitive to assumptions')
+    expect(container.querySelector('.text-success')).toBeNull()
+    expect(container.querySelector('.lucide-check-circle')).toBeNull()
+    expect(container.querySelector('.lucide-help-circle')).not.toBeNull()
+  })
 })
 
 describe('footer ↔ certified glyph consistency (single source)', () => {

--- a/src/canvas/components/utils/postAnalysisFooter.ts
+++ b/src/canvas/components/utils/postAnalysisFooter.ts
@@ -1,28 +1,37 @@
 /**
- * Post-analysis footer status + meta derivation (Brief 5.8B D8).
+ * Post-analysis footer status + meta derivation.
  *
- * Pure function — extracted from OutputsDock so the wireframe-aligned
- * stability bands and evidence-gap meta logic can be tested in isolation
- * without dragging in the full OutputsDock dependency tree.
+ * Pure function — extracted from OutputsDock so the verdict mapping and
+ * evidence-gap meta logic can be tested in isolation without dragging in the
+ * full OutputsDock dependency tree.
  *
- * Bands (per the wireframe + brief D8 step 1):
- *   - stability ≥ 0.85 → success "Stable result"
- *   - stability ≥ 0.60 → warning "Sensitive to assumptions"
- *   - stability < 0.60 → danger "Provisional result"
- *   - stability missing/non-finite → danger "Fragile result" fallback
+ * Status (single-source robustness rule — see ROBUSTNESS-VERDICT-CONTRACT):
+ * a positive/negative robustness verdict may ONLY come from the display-safe
+ * `robustnessVerdict` (the same field that drives the certified
+ * "Robustness unknown" glyph) — NEVER from raw `recommendation_stability` /
+ * `ranking_stability`. No display-safe verdict exists in the contract today,
+ * so `robustnessVerdict` is undefined and the footer stays NEUTRAL
+ * ("Robustness unknown") — matching the glyph rather than contradicting it
+ * with a green "Stable result" derived from raw stability.
+ *   - robustnessVerdict 'high'                      → success "Stable result"
+ *   - robustnessVerdict 'moderate' | 'low' | 'very_low' → warning "Sensitive to assumptions"
+ *   - robustnessVerdict missing / undefined         → neutral "Robustness unknown"
  *
- * Meta (per brief D8 step 1):
+ * Meta (unchanged): raw stability is retained ONLY as neutral metadata
+ * ("{N}% stability"), never as a verdict.
  *   - "{N}% stability" — appended when stability is finite
  *   - "Evidence gaps remain" — appended when any review-card confidence < 50%
  *   - "Evidence strong"      — appended when there are gaps AND none weak
  *   - omitted entirely when there are no review cards at all
  *
- * The Lucide icon is supplied by name (`'check' | 'warning' | 'danger'`)
+ * The Lucide icon is supplied by name (`'check' | 'warning' | 'unknown'`)
  * rather than as the icon component so this helper has no React import.
  * The caller maps the name back to a `LucideIcon`.
  */
 
-export type PostFooterIcon = 'check' | 'warning' | 'danger'
+import type { RobustnessLevel } from '@/components/results/types'
+
+export type PostFooterIcon = 'check' | 'warning' | 'unknown'
 
 export interface PostFooterStatus {
   icon: PostFooterIcon
@@ -40,17 +49,25 @@ export interface PostFooterMetaInput {
   reviewCards: ReadonlyArray<{ confidence?: number | null }>
 }
 
-export function derivePostFooterStatus(stability: number | null | undefined): PostFooterStatus {
-  if (typeof stability !== 'number' || !Number.isFinite(stability)) {
-    return { icon: 'danger', iconClass: 'text-danger', label: 'Fragile result' }
+/**
+ * Derive the footer status from the display-safe robustness verdict ONLY.
+ * Raw stability must never reach this function — it is surfaced separately as
+ * neutral metadata via `derivePostFooterMeta`. With no display-safe verdict in
+ * the contract today the verdict is undefined and the footer renders the
+ * neutral "Robustness unknown" state, in lock-step with the certified glyph.
+ */
+export function derivePostFooterStatus(
+  robustnessVerdict: RobustnessLevel | null | undefined,
+): PostFooterStatus {
+  if (robustnessVerdict == null) {
+    return { icon: 'unknown', iconClass: 'text-text-light', label: 'Robustness unknown' }
   }
-  if (stability >= 0.85) {
+  if (robustnessVerdict === 'high') {
     return { icon: 'check', iconClass: 'text-success', label: 'Stable result' }
   }
-  if (stability >= 0.60) {
-    return { icon: 'warning', iconClass: 'text-warning', label: 'Sensitive to assumptions' }
-  }
-  return { icon: 'danger', iconClass: 'text-danger', label: 'Provisional result' }
+  // Known but not high (moderate / low / very_low) → sensitive, mirroring the
+  // certified glyph's "Sensitive" label.
+  return { icon: 'warning', iconClass: 'text-warning', label: 'Sensitive to assumptions' }
 }
 
 export function derivePostFooterMeta({ stability, reviewCards }: PostFooterMetaInput): string | null {

--- a/src/canvas/components/utils/postAnalysisFooter.ts
+++ b/src/canvas/components/utils/postAnalysisFooter.ts
@@ -55,19 +55,34 @@ export interface PostFooterMetaInput {
  * neutral metadata via `derivePostFooterMeta`. With no display-safe verdict in
  * the contract today the verdict is undefined and the footer renders the
  * neutral "Robustness unknown" state, in lock-step with the certified glyph.
+ *
+ * RUNTIME-SAFE (allowlist, not catch-all): ONLY the known display-safe verdict
+ * enum values produce a verdict. Type safety alone is not enough — if a raw
+ * stability number (e.g. 0.87), a stringified number, or any other malformed
+ * value accidentally reaches this helper at runtime, it must fall NEUTRAL,
+ * never fabricate a "Sensitive to assumptions"/"Stable result" claim from an
+ * uncertified source. So the only branches that emit a verdict are the exact
+ * enum matches; everything else (undefined, null, unknown string, number,
+ * malformed) returns "Robustness unknown".
  */
 export function derivePostFooterStatus(
   robustnessVerdict: RobustnessLevel | null | undefined,
 ): PostFooterStatus {
-  if (robustnessVerdict == null) {
-    return { icon: 'unknown', iconClass: 'text-text-light', label: 'Robustness unknown' }
-  }
   if (robustnessVerdict === 'high') {
     return { icon: 'check', iconClass: 'text-success', label: 'Stable result' }
   }
-  // Known but not high (moderate / low / very_low) → sensitive, mirroring the
-  // certified glyph's "Sensitive" label.
-  return { icon: 'warning', iconClass: 'text-warning', label: 'Sensitive to assumptions' }
+  // Known display-safe non-high verdicts → sensitive, mirroring the certified
+  // glyph's "Sensitive" label. Explicit allowlist (NOT a non-high catch-all)
+  // so unexpected runtime values cannot reach this positive-ish branch.
+  if (
+    robustnessVerdict === 'moderate' ||
+    robustnessVerdict === 'low' ||
+    robustnessVerdict === 'very_low'
+  ) {
+    return { icon: 'warning', iconClass: 'text-warning', label: 'Sensitive to assumptions' }
+  }
+  // undefined / null / unknown string / number / malformed → neutral.
+  return { icon: 'unknown', iconClass: 'text-text-light', label: 'Robustness unknown' }
 }
 
 export function derivePostFooterMeta({ stability, reviewCards }: PostFooterMetaInput): string | null {

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -16,6 +16,7 @@ import type {
   EvidenceGapItem,
   OptionResult,
   FragileEdgeItem,
+  RobustnessLevel,
 } from '../../types'
 
 function makeOption(id: string, label: string, winProb: number): OptionResult {
@@ -53,6 +54,13 @@ function makeData(overrides: {
    */
   dominantFactorId?: string
   dominantFactorLabel?: string
+  /**
+   * Display-safe robustness verdict. Required for the 'strong' posture and the
+   * result-line sensitivity caveat — raw `stability` alone no longer drives
+   * either (ROBUSTNESS-VERDICT-CONTRACT). Undefined by default to mirror the
+   * live contract (no display-safe verdict today).
+   */
+  robustnessVerdict?: RobustnessLevel
 } = {}): ResultsSectionDataReturn {
   const winner = overrides.winnerLabel === null
     ? null
@@ -72,6 +80,7 @@ function makeData(overrides: {
     coachingReadinessDimensions: overrides.dimensions ?? { evidence: 0.6, robustness: 0.7, clarity: 0.65 },
     dominantFactorId: overrides.dominantFactorId,
     dominantFactorLabel: overrides.dominantFactorLabel,
+    robustnessVerdict: overrides.robustnessVerdict,
   } as DecisionResultData
 
   const tierValue = overrides.tier ?? 'fair'
@@ -248,16 +257,33 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.footerChecks.some(c => c.tone === 'reflect')).toBe(true)
     })
 
-    it('strong: high stability + no gaps + no fragile → strong, ready row, brief CTA', () => {
+    it('strong: high stability + no gaps + no fragile + display-safe verdict → strong, ready row, brief CTA', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
-        data: makeData({ stability: 0.9 }),
+        // Trust fix: the confident 'strong' posture now also requires the
+        // display-safe robustnessVerdict === 'high' (ROBUSTNESS-VERDICT-CONTRACT).
+        data: makeData({ stability: 0.9, robustnessVerdict: 'high' }),
         vm: makeVm({ decisionState: 'robust', evidenceLevel: 'good' }),
       })
       expect(vm.state).toBe('strong')
       expect(vm.inputRows[0]?.category).toBe('ready')
       expect(vm.footerCta.kind).toBe('create-decision-brief')
       expect(vm.keyQuestion).toBeNull()
+    })
+
+    it('trust fix: high stability WITHOUT a display-safe verdict does NOT reach strong — no "ready to brief" overclaim', () => {
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        // Same high-stability inputs, but robustnessVerdict is undefined (the
+        // live contract today). Raw stability alone must not unlock the
+        // confident posture.
+        data: makeData({ stability: 0.9 }),
+        vm: makeVm({ decisionState: 'robust', evidenceLevel: 'good' }),
+      })
+      expect(vm.state).not.toBe('strong')
+      expect(vm.footerCta.kind).not.toBe('create-decision-brief')
+      expect(vm.footerCta.label).not.toBe('Create decision brief')
+      expect(vm.footerHint).not.toBe('Ready to brief')
     })
 
     it('defensive: undefined data does not crash — renders empty-state VM', () => {
@@ -520,6 +546,7 @@ describe('buildAnalysisHeroViewModel', () => {
         ...STD_ARGS,
         data: makeData({
           stability: 0.9,
+          robustnessVerdict: 'high',
           dqp: ['What evidence would change your view?'],
         }),
         vm: makeVm({ decisionState: 'robust', evidenceLevel: 'good' }),
@@ -557,12 +584,13 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.resultLine).toBe('Tech Lead comes out ahead most often.')
     })
 
-    it('result line appends sensitivity nuance when softening gate fires AND a fragile edge exists (V17 power pass 2026-05-27)', () => {
-      // Codex review case: 74% stability + fair tier + topFragileEdge.
-      // shouldSoftenPhrasing returns true (tier ∈ {fair, needs_work} AND
-      // stability < 0.85); fragile-edge presence completes the gate. The
-      // hero headline must NOT read as unconditional when downstream
-      // signals say the result is sensitive.
+    it('trust fix: result line does NOT append a sensitivity caveat from raw stability alone (no display-safe verdict), even with a fragile edge', () => {
+      // Previously: 74% stability + fair tier + fragile edge appended
+      // "…but the result is sensitive to assumptions" via shouldSoftenPhrasing
+      // (raw stability < 0.85). That derived a robustness/sensitivity claim
+      // from an uncertified number and could contradict the neutral
+      // "Robustness unknown" glyph. With robustnessVerdict undefined (the live
+      // contract today) the caveat must NOT fire — the headline stays neutral.
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -580,12 +608,13 @@ describe('buildAnalysisHeroViewModel', () => {
         }),
         vm: makeVm(),
       })
-      expect(vm.resultLine).toBe('Tech Lead comes out ahead most often, but the result is sensitive to assumptions.')
+      expect(vm.resultLine).toBe('Tech Lead comes out ahead most often.')
     })
 
     it('result line nuance is suppressed when stability is high (≥ 0.85), even with a fragile edge', () => {
-      // Robust analysis: stability above the softening threshold → no
-      // nuance regardless of fragile-edge presence.
+      // Verdict-gated (trust fix): with robustnessVerdict undefined the caveat
+      // never fires — raw stability (here 0.9) no longer affects it, with or
+      // without a fragile edge.
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -607,7 +636,9 @@ describe('buildAnalysisHeroViewModel', () => {
     })
 
     it('result line nuance is suppressed when tier is strong, even with low stability + fragile edge', () => {
-      // Strong tier short-circuits the softening gate.
+      // Verdict-gated (trust fix): undefined robustnessVerdict → no caveat,
+      // regardless of confidence tier or low raw stability + a fragile edge.
+      // Tier/stability no longer gate the caveat.
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -629,8 +660,9 @@ describe('buildAnalysisHeroViewModel', () => {
     })
 
     it('result line nuance is suppressed when no fragile edge is present, even under a sensitive tier+stability combo', () => {
-      // shouldSoftenPhrasing alone is not enough — without a concrete
-      // fragile signal there is no actionable nuance to surface.
+      // Verdict-gated (trust fix): undefined robustnessVerdict → no caveat; the
+      // tier/stability inputs here are irrelevant to it now. (The caveat also
+      // still requires a concrete fragile edge — see the "low verdict" test.)
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
@@ -643,19 +675,18 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.resultLine).toBe('Tech Lead comes out ahead most often.')
     })
 
-    it('result line nuance fires when stability is missing AND tier is fair AND a fragile edge exists — footer parity (Codex round-3 P2 #2)', () => {
-      // shouldSoftenPhrasing treats null/undefined stability as weak (see
-      // certaintyCopy:120). This means a bundle that lacks a numeric
-      // stability value still produces "Stability sensitive" downstream
-      // when paired with a soft tier. Documenting that the hero matches
-      // the footer's behaviour here so any future tightening is a
-      // deliberate, jointly-applied change.
+    it('result line appends the sensitivity caveat ONLY from a non-"high" display-safe verdict + a fragile edge', () => {
+      // Authorised path: a known non-'high' robustnessVerdict means the result
+      // is sensitive; with a concrete fragile edge to point at, the caveat
+      // fires. This is the single-source replacement for the old raw-stability
+      // gate (ROBUSTNESS-VERDICT-CONTRACT).
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeData({
           winnerLabel: 'Tech Lead',
           tier: 'fair',
-          stability: undefined,
+          stability: 0.74,
+          robustnessVerdict: 'low',
           fragile: {
             fromId: 'n_h',
             fromLabel: 'Hiring rate',
@@ -668,6 +699,28 @@ describe('buildAnalysisHeroViewModel', () => {
         vm: makeVm(),
       })
       expect(vm.resultLine).toBe('Tech Lead comes out ahead most often, but the result is sensitive to assumptions.')
+    })
+
+    it('result line stays neutral when the display-safe verdict is "high", even with a fragile edge', () => {
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        data: makeData({
+          winnerLabel: 'Tech Lead',
+          tier: 'fair',
+          stability: 0.74,
+          robustnessVerdict: 'high',
+          fragile: {
+            fromId: 'n_h',
+            fromLabel: 'Hiring rate',
+            toId: 'n_o',
+            toLabel: 'Outcome',
+            switchProbability: 0.42,
+            alternativeWinnerLabel: 'Two Developers',
+          } as FragileEdgeItem,
+        }),
+        vm: makeVm(),
+      })
+      expect(vm.resultLine).toBe('Tech Lead comes out ahead most often.')
     })
   })
 
@@ -692,6 +745,9 @@ describe('buildAnalysisHeroViewModel', () => {
         winnerLabel: 'Tech Lead',
         stability: 0.74,
         tier: 'fair',
+        // Display-safe verdict drives the sensitivity nuance now (not raw
+        // stability) — a genuinely sensitive but corroborated-dominant result.
+        robustnessVerdict: 'low',
         drivers,
         dominantFactorId: 'n_tl',
         dominantFactorLabel: 'Technical Leadership',
@@ -730,7 +786,7 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(row1.reason).toBe('If the estimate changes for Hiring rate, the leading option could change.')
     })
 
-    it('hero result line carries the sensitivity nuance (74% stability + fragile + fair tier)', () => {
+    it('hero result line carries the sensitivity nuance (display-safe "low" verdict + fragile edge)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
         data: makeCanonicalFixture(),
@@ -1187,7 +1243,7 @@ describe('buildAnalysisHeroViewModel', () => {
     it('strong → create-decision-brief (prefill)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
-        data: makeData({ stability: 0.9 }),
+        data: makeData({ stability: 0.9, robustnessVerdict: 'high' }),
         vm: makeVm({ decisionState: 'robust', evidenceLevel: 'good' }),
       })
       expect(vm.footerCta.kind).toBe('create-decision-brief')
@@ -1233,7 +1289,7 @@ describe('buildAnalysisHeroViewModel', () => {
     it('strong: caveats + next closest + revisit trigger (3 safe items, renders normally)', () => {
       const vm = buildAnalysisHeroViewModel({
         ...STD_ARGS,
-        data: makeData({ stability: 0.9 }),
+        data: makeData({ stability: 0.9, robustnessVerdict: 'high' }),
         vm: makeVm({ decisionState: 'robust', evidenceLevel: 'good' }),
       })
       const labels = vm.alsoLinks.map(l => l.label)

--- a/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/chatClosedRender.spec.tsx
@@ -28,12 +28,14 @@ import type {
   DecisionResultData,
   EvidenceGapItem,
   OptionResult,
+  RobustnessLevel,
 } from '../../types'
 
 function makeData(overrides: {
   stability?: number
   gaps?: EvidenceGapItem[]
   bias?: Array<{ type: string; description: string }>
+  robustnessVerdict?: RobustnessLevel
 } = {}): ResultsSectionDataReturn {
   const winner: OptionResult = { id: 'opt_a', label: 'Option A', winProbability: 0.7 } as OptionResult
   const recommendation: DecisionResultData = {
@@ -44,6 +46,9 @@ function makeData(overrides: {
     analysisStatus: 'computed',
     recommendationStability: overrides.stability ?? 0.7,
     coachingReadinessDimensions: { evidence: 0.6, robustness: 0.7, clarity: 0.65 },
+    // Trust fix: the 'strong' posture requires the display-safe verdict, so
+    // strong-state tests pass robustnessVerdict: 'high' (ROBUSTNESS-VERDICT-CONTRACT).
+    robustnessVerdict: overrides.robustnessVerdict,
   } as DecisionResultData
   const confidence: ConfidenceSectionData = {
     tier: { tier: 'fair', icon: 'AlertTriangle', label: 'Fair', description: 'd' },
@@ -206,7 +211,7 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
       // anyway because the links are prefill-dependent.
       render(
         <AnalysisHeroV17
-          data={makeData({ stability: 0.9 })}
+          data={makeData({ stability: 0.9, robustnessVerdict: 'high' })}
           vm={makeVm({ decisionState: 'robust', evidenceLevel: 'good' })}
           fragileEdgeCount={0}
         />,
@@ -233,7 +238,7 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
       useGuidanceStore.setState({ _prefillChat: () => {}, _sendMessage: () => {} })
       render(
         <AnalysisHeroV17
-          data={makeData({ stability: 0.9 })}
+          data={makeData({ stability: 0.9, robustnessVerdict: 'high' })}
           vm={makeVm({ decisionState: 'robust', evidenceLevel: 'good' })}
           fragileEdgeCount={0}
         />,
@@ -321,7 +326,7 @@ describe('AnalysisHeroV17 — chat-closed render mode', () => {
     it('strong state CTA: hidden when chat is closed', () => {
       render(
         <AnalysisHeroV17
-          data={makeData({ stability: 0.9 })}
+          data={makeData({ stability: 0.9, robustnessVerdict: 'high' })}
           vm={makeVm({ decisionState: 'robust', evidenceLevel: 'good' })}
           fragileEdgeCount={0}
         />,

--- a/src/components/results/analysisHeroV17/__tests__/stateSelection.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/stateSelection.spec.ts
@@ -49,24 +49,47 @@ describe('selectHeroState', () => {
   })
 
   describe('STRONG', () => {
-    it('high stability + no gaps + no fragile edges → strong', () => {
-      expect(selectHeroState(base({ stability: 0.9, evidenceGapCount: 0, fragileEdgeCount: 0 }))).toBe('strong')
+    // Trust fix (ROBUSTNESS-VERDICT-CONTRACT): the confident 'strong' posture
+    // now also requires the display-safe robustnessVerdict === 'high'. The
+    // strong-expecting cases below pass it explicitly; the no-verdict / non-high
+    // cases are covered in "STRONG requires the display-safe verdict" below.
+    it('high stability + no gaps + no fragile edges + verdict high → strong', () => {
+      expect(selectHeroState(base({ stability: 0.9, evidenceGapCount: 0, fragileEdgeCount: 0, robustnessVerdict: 'high' }))).toBe('strong')
     })
 
-    it('exactly 0.85 stability + 1 gap + no fragile → strong (boundary)', () => {
-      expect(selectHeroState(base({ stability: 0.85, evidenceGapCount: 1, fragileEdgeCount: 0 }))).toBe('strong')
+    it('exactly 0.85 stability + 1 gap + no fragile + verdict high → strong (boundary)', () => {
+      expect(selectHeroState(base({ stability: 0.85, evidenceGapCount: 1, fragileEdgeCount: 0, robustnessVerdict: 'high' }))).toBe('strong')
     })
 
     it('just below 0.85 stability → NOT strong', () => {
-      expect(selectHeroState(base({ stability: 0.849, evidenceGapCount: 0 }))).not.toBe('strong')
+      expect(selectHeroState(base({ stability: 0.849, evidenceGapCount: 0, robustnessVerdict: 'high' }))).not.toBe('strong')
     })
 
     it('any fragile edge breaks strong', () => {
-      expect(selectHeroState(base({ stability: 0.9, evidenceGapCount: 0, fragileEdgeCount: 1 }))).not.toBe('strong')
+      expect(selectHeroState(base({ stability: 0.9, evidenceGapCount: 0, fragileEdgeCount: 1, robustnessVerdict: 'high' }))).not.toBe('strong')
     })
 
     it('2+ gaps breaks strong', () => {
-      expect(selectHeroState(base({ stability: 0.9, evidenceGapCount: 2 }))).not.toBe('strong')
+      expect(selectHeroState(base({ stability: 0.9, evidenceGapCount: 2, robustnessVerdict: 'high' }))).not.toBe('strong')
+    })
+  })
+
+  describe('STRONG requires the display-safe verdict (trust fix)', () => {
+    it('high stability + no gaps + no fragile but NO verdict → NOT strong (neutral moderate)', () => {
+      // Raw stability alone must not unlock the confident "ready to brief"
+      // posture. With robustnessVerdict undefined (the live contract today) the
+      // hero falls back to the neutral 'moderate' state.
+      const state = selectHeroState(base({ stability: 0.95, evidenceGapCount: 0, fragileEdgeCount: 0, robustnessVerdict: undefined, decisionState: 'sensitive' }))
+      expect(state).not.toBe('strong')
+      expect(state).toBe('moderate')
+    })
+
+    it('high stability + good signals but verdict is "low"/"moderate"/"very_low" → NOT strong', () => {
+      for (const verdict of ['low', 'moderate', 'very_low'] as const) {
+        expect(
+          selectHeroState(base({ stability: 0.95, evidenceGapCount: 0, fragileEdgeCount: 0, robustnessVerdict: verdict, decisionState: 'sensitive' })),
+        ).not.toBe('strong')
+      }
     })
   })
 
@@ -87,8 +110,8 @@ describe('selectHeroState', () => {
       expect(selectHeroState(base({ decisionState: 'indeterminate', biasFindings: 1, stability: 0.7 }))).toBe('moderate')
     })
 
-    it('robust but reflect signals would also satisfy strong → strong wins', () => {
-      expect(selectHeroState(base({ decisionState: 'robust', biasFindings: 1, stability: 0.9, evidenceGapCount: 0, fragileEdgeCount: 0 }))).toBe('strong')
+    it('robust but reflect signals would also satisfy strong → strong wins (with display-safe verdict)', () => {
+      expect(selectHeroState(base({ decisionState: 'robust', biasFindings: 1, stability: 0.9, evidenceGapCount: 0, fragileEdgeCount: 0, robustnessVerdict: 'high' }))).toBe('strong')
     })
   })
 

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -67,7 +67,6 @@ import {
   type CoverageSignals,
 } from './canvasSignals'
 import { stripEncodingNotation } from '../utils/cleanFactorLabel'
-import { shouldSoftenPhrasing } from '../utils/certaintyCopy'
 import type {
   AnalysisHeroVM,
   DimensionSegment,
@@ -157,21 +156,22 @@ function buildResultLine(data: ResultsSectionDataReturn): string {
   const winner = data?.recommendation?.recommendedOption
   if (!winner) return 'No option currently comes out ahead clearly.'
   const label = safeLabel(winner.label, 'The leading option')
-  // V17 power pass (2026-05-27): when the same softening gate the
-  // AnalysisFooter uses (`shouldSoftenPhrasing`: tier ∈ {needs_work, fair}
-  // AND stability < 0.85) fires AND a fragile edge is present, append a
-  // clarifying clause so the hero headline no longer reads as
-  // unconditional. Without this, a 74% stability + fragile-edge case
-  // shows "X comes out ahead most often." at the top of the panel while
-  // the footer says "Stability sensitive" — the two surfaces contradict.
-  // Gate reuses certaintyCopy.shouldSoftenPhrasing so the hero and the
-  // footer share the exact same threshold.
-  const tier = data?.confidence?.tier?.tier
-  const stability = data?.recommendation?.recommendationStability
+  // Sensitivity caveat is gated on the display-safe robustness verdict ONLY —
+  // never raw recommendation_stability (single-source rule, see
+  // ROBUSTNESS-VERDICT-CONTRACT). A known non-'high' verdict means the result
+  // is sensitive; with a concrete fragile edge also present we append the
+  // clarifying clause so the headline isn't read as unconditional. No
+  // display-safe verdict exists in the contract today → the verdict is
+  // undefined → the caveat never fires and the headline stays neutral
+  // ("…comes out ahead most often."), in lock-step with the certified
+  // "Robustness unknown" glyph rather than deriving a sensitivity claim from
+  // an uncertified stability number.
+  const verdict = data?.recommendation?.robustnessVerdict
+  const verdictSensitive = verdict != null && verdict !== 'high'
   const hasFragile = !!(
     data?.confidence?.topFragileEdge ?? data?.confidence?.m1CoachingTopFragileEdge
   )
-  if (shouldSoftenPhrasing(tier, stability ?? undefined) && hasFragile) {
+  if (verdictSensitive && hasFragile) {
     return `${label} comes out ahead most often, but the result is sensitive to assumptions.`
   }
   return `${label} comes out ahead most often.`
@@ -486,6 +486,9 @@ export function buildAnalysisHeroViewModel(args: AnalysisHeroBuilderArgs): Analy
     optionCount: allOptions.length,
     biasFindings: biasFindings.length,
     framingFlag: false, // Not plumbed in v1.
+    // Display-safe verdict gates the confident 'strong' posture — raw stability
+    // alone must not unlock "Ready to brief" (ROBUSTNESS-VERDICT-CONTRACT).
+    robustnessVerdict: recommendation?.robustnessVerdict ?? null,
   })
 
   const allRows = rankHeroRows(data, state)

--- a/src/components/results/analysisHeroV17/stateSelection.ts
+++ b/src/components/results/analysisHeroV17/stateSelection.ts
@@ -11,7 +11,7 @@
  * documented at the call site below.
  */
 
-import type { DecisionState } from '../types'
+import type { DecisionState, RobustnessLevel } from '../types'
 import type { HeroState } from './analysisHeroVM.types'
 
 export interface StateSelectionInputs {
@@ -32,6 +32,14 @@ export interface StateSelectionInputs {
   biasFindings: number
   /** Optional framing-check flag — defaults to false in v1 (data not plumbed yet). */
   framingFlag: boolean
+  /**
+   * Display-safe robustness verdict (`data.recommendation.robustnessVerdict`).
+   * REQUIRED for the confident 'strong' posture — raw `stability` alone must
+   * never unlock "Ready to brief"/"Create decision brief" (single-source rule,
+   * see ROBUSTNESS-VERDICT-CONTRACT). Undefined today → 'strong' is unreachable
+   * and the hero falls back to the neutral 'moderate'/'reflect' posture.
+   */
+  robustnessVerdict?: RobustnessLevel | null
 }
 
 export function selectHeroState(input: StateSelectionInputs): HeroState {
@@ -44,6 +52,7 @@ export function selectHeroState(input: StateSelectionInputs): HeroState {
     optionCount,
     biasFindings,
     framingFlag,
+    robustnessVerdict,
   } = input
 
   // 1. WEAK — no clear winner, low-stability with many gaps, many gaps,
@@ -53,8 +62,19 @@ export function selectHeroState(input: StateSelectionInputs): HeroState {
   if (evidenceGapCount >= 4) return 'weak'
   if (optionCount < 2) return 'weak'
 
-  // 2. STRONG — high stability, ≤1 evidence gap, no fragile connections.
-  if (stability !== null && stability >= 0.85 && evidenceGapCount <= 1 && fragileEdgeCount === 0) {
+  // 2. STRONG — confident "ready to brief" posture. Gated on the display-safe
+  //    robustness verdict (`robustnessVerdict === 'high'`) IN ADDITION to the
+  //    quality signals: high stability + ≤1 evidence gap + no fragile edges.
+  //    Raw stability alone must NOT unlock the confident posture (single-source
+  //    rule — ROBUSTNESS-VERDICT-CONTRACT). No display-safe verdict exists in
+  //    the contract today, so this branch is currently unreachable and the hero
+  //    falls back to the neutral 'moderate'/'reflect' posture instead of
+  //    over-claiming "Ready to brief" from an uncertified stability number.
+  if (
+    robustnessVerdict === 'high' &&
+    stability !== null && stability >= 0.85 &&
+    evidenceGapCount <= 1 && fragileEdgeCount === 0
+  ) {
     return 'strong'
   }
 


### PR DESCRIPTION
## Live staging trust fix — stop raw-stability robustness overclaims

A read-only investigation found a **live trust contradiction** on staging (`AnalysisHeroV17` is the live hero; build `a1f4826e`): the certified robustness **glyph** correctly renders neutral **"Robustness unknown"** (it reads the display-safe `robustnessVerdict`, which is undefined today), but several **sibling surfaces still derived a positive robustness/confidence verdict from raw `recommendation_stability`** — so the same Analysis tab could show **"Robustness unknown"** *and* a green **"Stable result"** at once.

This PR enforces a **single-source rule**: positive/negative robustness, stability, and "ready/strong" claims may come **only** from the display-safe `robustnessVerdict` — never from raw stability. With no display-safe verdict in the contract today, these surfaces now render the **neutral** fallback, in lock-step with the glyph.

This is **not** caused by #195 or #196 — it is pre-existing (the verdict decoupling never reached these surfaces) but now live and higher priority than UI polish.

> ### ⚠️ V17-off gate (read before disabling the flag)
> **Do NOT disable `VITE_FEATURE_ANALYSIS_HERO_V17` until the legacy `DecisionConfidencePanel` / `certaintyCopy` path is re-sourced off `robustnessVerdict` (or explicitly neutralised).** This PR fixes the footer (hero-independent) + the V17 hero surfaces. The legacy hero's `buildCertaintyCopy` still derives a "sensitive" headline from raw stability `< 0.70`; it is **not live while V17 is force-baked on**, but turning V17 **off** makes it the dominant Analysis-tab headline and reintroduces the same raw-stability trust contradiction beside the neutral glyph. See "Deferred" below.

### Surfaces fixed (UI-only, display-only)

- **F1 (mandatory, hero-independent) — post-analysis `AnalysisFooter`.** `OutputsDock.tsx` + `utils/postAnalysisFooter.ts`. `derivePostFooterStatus` now takes `robustnessVerdict` instead of raw stability: `'high'` → "Stable result" (success/check); known non-high (`'moderate'`/`'low'`/`'very_low'`) → "Sensitive to assumptions" (warning); **everything else → neutral "Robustness unknown"** (muted help icon). It uses an **explicit allowlist, not a non-high catch-all**, so it is **runtime-safe**: a stray raw stability number (e.g. `0.87`), a stringified number, or any malformed value that slips through at runtime falls neutral — it can never fabricate a "Sensitive to assumptions"/"Stable result" verdict. Raw `{N}% stability` is retained only as **neutral metadata** via `derivePostFooterMeta` (unchanged). **Before:** raw stability ≥ 0.85 rendered a green "Stable result" that contradicted the glyph. **After:** neutral, matching the glyph.
- **F2 (V17 hero, live while the flag is on) — `stateSelection.ts` strong posture.** The confident `'strong'` state ("Ready to brief" / "Create decision brief") now requires `robustnessVerdict === 'high'` **in addition** to the quality signals. **Before:** raw stability ≥ 0.85 alone unlocked the confident posture. **After:** unreachable without a display-safe verdict → neutral `'moderate'`/`'reflect'`.
- **F3 (V17 hero) — `buildAnalysisHeroViewModel.ts` result line.** The "…but the result is sensitive to assumptions" caveat is now gated on `robustnessVerdict` (known non-high) instead of `shouldSoftenPhrasing(raw stability)`. **Before:** raw stability < 0.85 + fragile edge appended the caveat. **After:** fires only from the display-safe verdict; neutral headline otherwise. (`shouldSoftenPhrasing` is unchanged and still used by `winnerChipCopy.ts` / `getStabilityDisplayLabel.ts`.)

### Inspected — NOT changed here (deferred, with reasons)

- **⚠️ Legacy hero `DecisionConfidencePanel` / `certaintyCopy.ts` — deferred, CONDITIONALLY live.** `buildCertaintyCopy` (`certaintyCopy.ts:154`) derives a "…the result is sensitive to your estimates" headline from raw stability `< 0.70` (plus the `shouldSoftenPhrasing` caveat). It is consumed **only** by the legacy `DecisionConfidencePanel`; the V17 hero does not use `certaintyCopy` at all. Since `VITE_FEATURE_ANALYSIS_HERO_V17="1"` is **build-baked on staging** (verified from the deployed bundle — `version.json` `a1f4826e` + `flags-*.js`), DCP is **not rendered today**, so this is **not a live contradiction now**. **But if V17 is disabled, DCP/certaintyCopy becomes the dominant Analysis-tab headline and the raw-stability "sensitive" claim would again contradict the neutral glyph.** Tracked under `ROBUSTNESS-VERDICT-CONTRACT`: it must be re-sourced off `robustnessVerdict` **before/with any decision to turn V17 off**. (Fixing it now would mean reworking the legacy certainty-copy subsystem + its tests — out of scope for this minimal, V17-targeted fix. The F1 footer fix is hero-independent, so the footer stays correct regardless of the flag.)
- **Deferred (broader, separate decision) — canvas nodes:** `GoalNode.tsx` (stability data-bar coloured from `robustness.level` + raw fallback) and `DecisionNode.tsx` (derives a `'robust'/'sensitive'` tier from raw stability in its popover). Same trust class as F1 but on the **canvas** — they need canvas-viz design decisions + their own tests, so they are reported for a follow-up rather than patched here.
- **Dead / suppressed (no live contradiction):** `buildFooterChecks` (raw-stability `'Stable'` label — VM field **not consumed** by HeroFooter; flagged in review to delete/re-source if ever re-surfaced), `ResultsFooter` + `getStabilityDisplayLabel` (deleted from ResultsBody, Brief 5.8B D8), `TriageActionCardsBody` StabilityNarrative (suppressed under V17 via `suppressTriageQueue`), legacy `DecisionConfidencePanel` "Stability: N%".
- **Safe / neutral:** `winnerChipCopy` (`shouldSoftenPhrasing` picks a chat-prompt *question* label — "What makes this the current leader?" vs "this lead?" — not a robustness verdict; tracked so the raw-stability dependency is recorded); Model-tab `StatusBar` "{N}% stability" (neutral metric).

### Boundaries honoured

- UI/display-only. **No** backend / schema / prompt / CEE / PLoT / ISL / contract / dependency / Netlify-flag changes.
- Does **not** redefine the meaning of "robust/stable/confident/sensitive" — only re-sources the verdict to the display-safe field. The positively-informative version remains deferred until the display-safe robustness verdict contract lands (`ROBUSTNESS-VERDICT-CONTRACT`).
- Does **not** change certified freshness logic. **#196 remains held and untouched.** Not folded into #196.

### Tests

- `postAnalysisFooter.spec.ts` — verdict-driven: `'high'` → "Stable result"; non-high → "Sensitive to assumptions"; **undefined → neutral "Robustness unknown"** (asserts no "Stable result" / no green-check from an absent verdict).
- `stateSelection.spec.ts` — `'strong'` requires `robustnessVerdict === 'high'`; high stability **without** a verdict → not strong (neutral `'moderate'`).
- `buildAnalysisHeroViewModel.spec.ts` — high stability without verdict does not reach `'strong'` / "Create decision brief"; result-line caveat fires only from a non-high verdict + fragile edge, neutral otherwise.
- `chatClosedRender.spec.tsx` — strong-state fixtures pass `robustnessVerdict: 'high'`.
- `OutputsDock.analysis-run.spec.tsx` — footer-copy assertion updated: raw stability `0.87` with no verdict → neutral "Robustness unknown" + retains "87%" metadata.
- **`robustnessSingleSource.render.spec.tsx` (new)** — rendered-state proof on the **actual** presentational `AnalysisFooter` (env-free, wired as OutputsDock does): undefined verdict → "Robustness unknown" + **no `text-success` + help icon (not check)**; `'high'` → "Stable result" + success/check (the only positive path); non-high → "Sensitive to assumptions"; **runtime-safe: a raw `0.87` that slips through → neutral footer** (no "Stable result", no "Sensitive", no success styling). Plus an explicit **`ranking_stability`/`recommendation_stability` are not inputs** assertion and a **footer↔glyph consistency** test (footer renders a positive verdict iff `robustnessVerdict === 'high'`, mirroring the certified glyph — so a green "Stable result" can never sit beside a neutral "Robustness unknown" glyph).
- **`postAnalysisFooter.spec.ts` — runtime-safety regression** (`it.each`): `0.87`, `"0.87"`, `"unexpected"`, empty string, `NaN`, boolean, object, array → all neutral "Robustness unknown" (no verdict, no positive/warning styling).

Targeted run: **538 passing** across the touched + adjacent trust surfaces. The only red is the **2 pre-existing, documented `bodyLabelSafety` failures** (PR #175 `recommendation`→`result` copy drift, unrelated). Production files are type-clean (`tsc -p tsconfig.app.json`); the 3 `buildAnalysisHeroViewModel.spec` type errors are pre-existing on `staging` (missing `FragileEdgeItem` export + two `as` casts). `OutputsDock.analysis-run.spec.tsx` is env-gated locally (needs full CI env; fails identically on baseline) — its updated assertion is the correct forward-fix. The local pre-push gate (typecheck, lint, smoke, dep audit, DS drift) passed.

### Running UI verification

**Browser/preview drive-through: NOT completed** — and not meaningfully achievable for this surface: (1) the post-analysis `AnalysisFooter` only renders **after a completed analysis**, which is unreachable in a guest/preview session because staging bakes V5-canonical + guest auth → the known CEE **NULL-graph 500**; (2) the canvas's continuous animation loop never reaches `document_idle`, blocking DOM-driven automation; (3) the preview tooling targets the session root, not this fix worktree. **Rendered-state inspection IS completed** instead: `robustnessSingleSource.render.spec.tsx` renders the real `AnalysisFooter` (the live footer component) and asserts the neutral DOM for the undefined-verdict (live-contract) case, and existing tests cover the certified glyph rendering neutral. **Manual steps** (for a reviewer with a working completed analysis): open the Analysis tab post-run with `report.robustness.recommendation_stability ≥ 0.85` and no display-safe `robustnessVerdict` → the footer must read "Robustness unknown" (muted, not green "Stable result"), the "{N}% stability" remains as neutral meta, and the checks-footer robustness glyph must also read "Robustness unknown" — the two must agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
