### PR TITLE
fix(analysis): driver section states influence only

### DIFF
--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -615,8 +615,12 @@ function DriverRow({
                   onSendMessage(
                     `Tell me more about how "${driver.factorLabel}" affects the outcome.`,
                   )
-                } else if (onFocus && driver.matchedNodeId) {
-                  onFocus(driver.matchedNodeId)
+                } else if (onFocus && driver.canFocus) {
+                  // Match the factor-name focus path: fall back to factorKey when
+                  // there is no matchedNodeId, so reusable/story/test surfaces
+                  // (no onSendMessage) keep the focus action instead of silently
+                  // no-opping.
+                  onFocus(driver.matchedNodeId ?? driver.factorKey)
                 }
               }}
               className={`${typography.panelMeta} text-info hover:underline cursor-pointer ml-auto`}
@@ -697,8 +701,14 @@ function DriverRow({
           of truth preserved. */}
 
 
-      {/* Quick-select for contested drivers — only when inbound edge has validation.status === 'contested' */}
-      {driver.hasContestedEdge && (
+      {/* Contested-driver quick-select — HIDDEN under the single-source rule: it
+          exposes confidence semantics (Weakly/Moderately/Strongly + a "Custom
+          confidence value" input, seeded from driver.confidence) in the
+          influence-only driver section, and it is orphaned today — its presets do
+          NOT propagate to the edge store (see the component). Gated on
+          DISPLAY_SAFE_DRIVER_CONFIDENCE so it returns (with propagation) when a
+          display-safe confidence source exists. */}
+      {DISPLAY_SAFE_DRIVER_CONFIDENCE && driver.hasContestedEdge && (
         <ContestedDriverQuickSelect driver={driver} />
       )}
 

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -15,7 +15,7 @@
 
 import { useState, useCallback, useEffect, useRef, type ChangeEvent } from 'react'
 import { AlertTriangle as TriangleAlert, Check, HelpCircle, Info, Minus } from 'lucide-react'
-import type { DriversSectionData, DriverItem } from './types'
+import type { DriversSectionData, DriverItem, DriverSemanticLabel } from './types'
 import { focusNodeById } from '../../canvas/utils/focusHelpers'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
 import { EMPTY_STATES } from './emptyStates'
@@ -60,9 +60,35 @@ const BAR_COLORS = {
   neutral: 'var(--text-light)', // Unknown direction
 }
 
-// Grid columns constant - shared between header and rows to avoid alignment drift
-// Two data columns: Sensitivity + Confidence (same width), plus icon column for glyphs
-const GRID_COLS = 'grid-cols-[minmax(120px,1fr)_85px_85px_28px]'
+// Single-source rule (see ROBUSTNESS-VERDICT-CONTRACT): there is no display-safe
+// source for driver confidence/evidence/stability today, so those signals stay
+// HIDDEN — the driver section communicates INFLUENCE only, and we NEVER show raw
+// or defaulted confidence (no raw %, no dashes). Flip this true ONLY when a
+// certified display-safe driver-confidence source exists; the gated Confidence
+// column + glyph + tooltip signals below then light up, and the grid widens to
+// match via gridCols().
+const DISPLAY_SAFE_DRIVER_CONFIDENCE = false
+
+// Fragility ("could change the result") belongs in the fragile-factors section,
+// NOT the driver section. Acceptance: driver section = "this matters most";
+// fragile section = "what to check because it could change the result". So the
+// driver-row fragility cross-refs — the "If wrong, X overtakes" microline and the
+// "Ranking may shift N%" rows/tooltip — stay hidden here. This is a placement
+// rule (not a display-safe-source gate): keep it false; fragility surfaces in the
+// fragile-factors section.
+const SHOW_FRAGILITY_IN_DRIVER_SECTION = false
+
+// Grid columns - shared between rows to avoid alignment drift. Influence-only by
+// default (factor name + Sensitivity/influence). The Confidence + glyph columns
+// return only when DISPLAY_SAFE_DRIVER_CONFIDENCE is true. (A function, not a
+// module-const ternary, so the grid stays coupled to the gate without tripping
+// no-constant-condition.)
+function gridCols(showConfidence: boolean): string {
+  return showConfidence
+    ? 'grid-cols-[minmax(120px,1fr)_85px_85px_28px]'
+    : 'grid-cols-[minmax(120px,1fr)_85px]'
+}
+const GRID_COLS = gridCols(DISPLAY_SAFE_DRIVER_CONFIDENCE)
 
 // Zero reason display messages - explains why sensitivity is zero
 const ZERO_REASON_MESSAGES: Record<string, string> = {
@@ -289,11 +315,19 @@ function DriverRow({
   const hasZeroReason = driver.zeroReason && ZERO_REASON_MESSAGES[driver.zeroReason]
   // Task 7c: ranking shift + technique added to tooltip — must be computed before this line
   // (rankingShiftWarn and techniqueSuggestion are computed after this block, so use inline checks)
-  const hasTooltipContent = decisionChangeRisk || showQualityHint || hasEnrichment || hasZeroReason
-    || (driver.attributionStability === 'low' || driver.attributionStability === 'negligible'
-        || (typeof driver.confidence === 'number' && driver.confidence < 0.9))
-    || ((driver.influenceScore ?? driver.normalisedInfluence ?? 0) > 0.6
-        && typeof driver.confidence === 'number' && driver.confidence < 0.5)
+  // The (i) info icon must appear only when the tooltip has VISIBLE content.
+  // Confidence/evidence/fragility lines (decisionChangeRisk, rankingShiftWarn,
+  // qualityHint) are gated off today, so they contribute to the icon only when
+  // their gate is on. Enrichment + zero-reason (an influence explanation) are
+  // always-visible. The technique chip moved out of the tooltip to a body chip.
+  const hasTooltipContent = hasEnrichment || hasZeroReason
+    || (DISPLAY_SAFE_DRIVER_CONFIDENCE && showQualityHint)
+    || (SHOW_FRAGILITY_IN_DRIVER_SECTION && (
+          !!decisionChangeRisk
+          || driver.attributionStability === 'low'
+          || driver.attributionStability === 'negligible'
+          || (typeof driver.confidence === 'number' && driver.confidence < 0.9)
+        ))
 
   const handleFocusClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
@@ -351,10 +385,14 @@ function DriverRow({
       {tooltipElasticityCopy && (
         <p>{tooltipElasticityCopy}</p>
       )}
-      {/* Decision change risk */}
-      {decisionChangeRisk && <p>{decisionChangeRisk}</p>}
-      {/* Quality hint */}
-      {showQualityHint && (
+      {/* Decision change risk — HIDDEN: a decision-flip / fragility claim
+          ("X becomes the better choice" / "can change which option is best").
+          Fragility belongs in the fragile-factors section, not the influence-only
+          driver section (SHOW_FRAGILITY_IN_DRIVER_SECTION). */}
+      {SHOW_FRAGILITY_IN_DRIVER_SECTION && decisionChangeRisk && <p>{decisionChangeRisk}</p>}
+      {/* Quality hint — HIDDEN: an evidence claim derived from raw fields
+          (single-source rule). Returns when DISPLAY_SAFE_DRIVER_CONFIDENCE is true. */}
+      {DISPLAY_SAFE_DRIVER_CONFIDENCE && showQualityHint && (
         <p className="flex items-center gap-1">
           <TriangleAlert className="w-3.5 h-3.5 text-warning flex-shrink-0" aria-hidden="true" />
           Could benefit from more evidence
@@ -367,8 +405,11 @@ function DriverRow({
           {ZERO_REASON_MESSAGES[driver.zeroReason!]}
         </p>
       )}
-      {/* Task 7c: Ranking shift warning — in tooltip only */}
-      {rankingShiftWarn && (
+      {/* Ranking shift warning (tooltip variant) — HIDDEN: a ranking-shift /
+          fragility claim. Fragility ("could change the result") belongs in the
+          fragile-factors section, not the driver section
+          (SHOW_FRAGILITY_IN_DRIVER_SECTION). */}
+      {SHOW_FRAGILITY_IN_DRIVER_SECTION && rankingShiftWarn && (
         <p className="flex items-center gap-1 text-warning">
           <span className="inline-block w-1.5 h-1.5 rounded-full bg-warning flex-shrink-0" aria-hidden="true" />
           {rankingShiftWarn}
@@ -462,13 +503,11 @@ function DriverRow({
           <div className={`${typography.panelBody} font-mono text-text-light w-9 text-right`}>-</div>
         )}
 
-        {/* Confidence bar — Brief 5.5 §2.2 Pattern C (amended Brief 5.7 D4:
-            4-dot scale → thin bar with numeric readout). Distinct from the
-            sensitivity bar via colour (info vs success/warning) and thickness
-            (h-1 vs h-1.5), preserving the three-bar visual separation intent
-            while restoring readability. The glyph column conveys High/Moderate/
-            Low verbally alongside. */}
-        {confidenceValue !== null ? (
+        {/* Confidence — HIDDEN under the single-source rule: no display-safe
+            driver-confidence source exists today, so we never render raw/defaulted
+            confidence (no bar, no %, no dash). Gated on DISPLAY_SAFE_DRIVER_CONFIDENCE
+            so it returns intact when a certified source lands. */}
+        {DISPLAY_SAFE_DRIVER_CONFIDENCE && confidenceValue !== null && (
           <button
             type="button"
             className="cursor-pointer bg-transparent p-0 border-0 w-full text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-info rounded"
@@ -499,12 +538,12 @@ function DriverRow({
               </span>
             </div>
           </button>
-        ) : (
-          <div className={`${typography.panelBody} font-mono text-text-light w-9 text-right`}>-</div>
         )}
 
-        {/* Icons column: confidence icon + default-estimate indicator */}
-        <div className="flex items-center gap-1 justify-start">
+        {/* Icons column (confidence glyph + default-estimate) — HIDDEN under the
+            single-source rule, gated like the Confidence bar above. */}
+        {DISPLAY_SAFE_DRIVER_CONFIDENCE && (
+          <div className="flex items-center gap-1 justify-start">
           {confidenceValue !== null && (() => {
             const IconComponent = confidenceValue >= 0.7 ? Check : confidenceValue >= 0.4 ? Minus : HelpCircle
             const cls = confidenceValue >= 0.7 ? 'text-success' : confidenceValue >= 0.4 ? 'text-info' : 'text-factor'
@@ -537,40 +576,44 @@ function DriverRow({
               <circle cx="6" cy="6" r="4.5" />
             </svg>
           )}
-        </div>
+          </div>
+        )}
       </div>
 
-      {/* Composite label + action link */}
+      {/* Composite label + action link.
+          INFLUENCE-ONLY pill (single-source rule — see ROBUSTNESS-VERDICT-CONTRACT).
+          Driver pills state influence ONLY; they must NEVER claim
+          stable / robust / confident / ready / evidence from raw fields. The
+          label maps from the upstream influence-derived `semanticLabel`
+          (UI-SEM-039: rank-1 'biggest', else elasticity threshold), NOT from raw
+          influence×confidence. Confidence/evidence belong in the
+          display-safe-gated Confidence column; fragility ("could change the
+          result") belongs in the fragile-factors section, not here. */}
       {(() => {
-        const influence = driver.influenceScore ?? driver.normalisedInfluence ?? 0
-        const conf = typeof driver.confidence === 'number' ? driver.confidence : 0.5
-        const isHighImpactLowEvidence = influence >= 0.7 && conf < 0.4
-        const isImportantStable = influence >= 0.7 && conf >= 0.4
+        const INFLUENCE_PILL: Record<DriverSemanticLabel, string> = {
+          biggest: 'Top driver',
+          strong: 'High-impact driver',
+          moderate: 'Moderate influence',
+          minor: 'Lower influence',
+        }
+        const pillText = INFLUENCE_PILL[driver.semanticLabel] ?? 'Lower influence'
+        // Subtle emphasis for the strongest influence — colour conveys
+        // prominence, NOT confidence/quality (outlined, text-text-body per DS).
+        const emphasised = driver.semanticLabel === 'biggest' || driver.semanticLabel === 'strong'
         return (
           <div className="flex items-center gap-1.5 px-3 pb-1">
-            {isHighImpactLowEvidence && (
-              <span className={`${typography.panelMeta} px-1.5 py-0.5 rounded-full border border-danger/30 text-danger bg-transparent`}>
-                High impact, low evidence
-              </span>
-            )}
-            {isImportantStable && (
-              <span className={`${typography.panelMeta} px-1.5 py-0.5 rounded-full border border-success/30 text-success bg-transparent`}>
-                Important and stable
-              </span>
-            )}
-            {!isHighImpactLowEvidence && !isImportantStable && (
-              <span className={`${typography.panelMeta} px-1.5 py-0.5 rounded-full border border-panel-border text-text-light bg-transparent`}>
-                Moderate
-              </span>
-            )}
+            <span
+              className={`${typography.panelMeta} px-1.5 py-0.5 rounded-full bg-transparent text-text-body border ${emphasised ? 'border-info/30' : 'border-panel-border'}`}
+              data-testid={`driver-influence-pill-${driver.factorKey}`}
+            >
+              {pillText}
+            </span>
             <button
               type="button"
               onClick={() => {
                 if (onSendMessage) {
                   onSendMessage(
-                    isHighImpactLowEvidence
-                      ? `How can I improve the evidence for "${driver.factorLabel}"? It has high impact but low confidence.`
-                      : `Tell me more about how "${driver.factorLabel}" affects the outcome.`,
+                    `Tell me more about how "${driver.factorLabel}" affects the outcome.`,
                   )
                 } else if (onFocus && driver.matchedNodeId) {
                   onFocus(driver.matchedNodeId)
@@ -578,7 +621,7 @@ function DriverRow({
               }}
               className={`${typography.panelMeta} text-info hover:underline cursor-pointer ml-auto`}
             >
-              {isHighImpactLowEvidence ? 'Improve' : 'Edit'}
+              Discuss
             </button>
           </div>
         )
@@ -598,8 +641,11 @@ function DriverRow({
         </ExpertBlock>
       )}
 
-      {/* V12.2: Microline overtake warning inside card */}
-      {microlineLabel && (
+      {/* Microline overtake warning — HIDDEN: "If wrong, X overtakes" is a
+          fragility/flip claim. Fragility ("could change the result") belongs in
+          the fragile-factors section, not the driver section
+          (SHOW_FRAGILITY_IN_DRIVER_SECTION). */}
+      {SHOW_FRAGILITY_IN_DRIVER_SECTION && microlineLabel && (
         <p
           className={`${typography.panelMeta} text-danger px-3 pb-1.5 -mt-0.5`}
           data-testid="driver-microline"
@@ -608,11 +654,11 @@ function DriverRow({
         </p>
       )}
 
-      {/* Brief 5.1 Task 7.5: visible, clickable technique suggestion. When
-          the driver has high influence AND low confidence, the suggestion
-          renders as a chip button that, on click, sends a scoped prompt
-          into the chat so the user can continue the thread in context. */}
-      {isTopDriver && techniqueSuggestion && onSendMessage && (
+      {/* Technique suggestion chip — HIDDEN: it is gated on LOW confidence
+          (techniqueSuggestion = influence > 0.6 && conf < 0.5), so it is a
+          confidence-derived signal. Hidden under the single-source rule until a
+          display-safe driver-confidence source exists. */}
+      {DISPLAY_SAFE_DRIVER_CONFIDENCE && isTopDriver && techniqueSuggestion && onSendMessage && (
         <div className="px-3 pb-1.5 -mt-0.5">
           <button
             type="button"
@@ -630,11 +676,10 @@ function DriverRow({
         </div>
       )}
 
-      {/* Brief 5.8B D5 step 4: surface "Ranking may shift {N}%" as a visible
-          row beneath the interpretation tag (was tooltip-only). Gated on
-          `rank_flip_rate >= 0.15` so we only call attention to genuinely
-          shift-prone factors. */}
-      {typeof driver.rankFlipRate === 'number' && driver.rankFlipRate >= 0.15 && (
+      {/* "Ranking may shift N%" — HIDDEN: a ranking-shift / fragility claim.
+          Fragility ("could change the result") belongs in the fragile-factors
+          section, not the driver section (SHOW_FRAGILITY_IN_DRIVER_SECTION). */}
+      {SHOW_FRAGILITY_IN_DRIVER_SECTION && typeof driver.rankFlipRate === 'number' && driver.rankFlipRate >= 0.15 && (
         <p
           className={`${typography.panelMeta} text-warning px-3 pb-1.5 -mt-0.5`}
           data-testid={`driver-ranking-shift-${driver.factorKey}`}
@@ -818,32 +863,38 @@ export function DriversSection({
               Influence
             </div>
           </Tooltip>
-          <Tooltip content={confidenceTooltipContent}>
-            <button
-              type="button"
-              // DS v5 a11y: minimum 44×44 touch target for the header info
-              // control. Achieved via a `before:` pseudo-element overlay that
-              // extends the hit area vertically (~16px above + 16px below the
-              // ~16px text = 48px effective, ≥ 44px requirement) WITHOUT
-              // shifting the grid layout — the pseudo-element is absolutely
-              // positioned and contributes no flow height. The button keeps
-              // its `p-0` content box so column alignment is unaffected.
-              className={`${typography.panelBody} text-text-light text-right cursor-help w-full bg-transparent border-0 p-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-info rounded inline-flex items-center justify-end gap-1 relative before:absolute before:content-[''] before:left-0 before:right-0 before:-inset-y-4`}
-              aria-label={confidenceAriaLabel}
-              data-testid="drivers-confidence-header"
-            >
-              <span>Confidence</span>
-              {anyConfidenceProvisional && (
-                <Info
-                  className="w-3.5 h-3.5 text-text-light flex-shrink-0"
-                  aria-hidden="true"
-                  data-testid="drivers-confidence-provisional-marker"
-                />
-              )}
-            </button>
-          </Tooltip>
-          {/* Empty cell for icon column */}
-          <div aria-hidden="true" />
+          {/* Confidence header — HIDDEN under the single-source rule (no
+              display-safe driver-confidence source today). Dropping it keeps the
+              header's grid-child count matched to gridCols() so the 2-column
+              influence-only layout stays aligned. Returns with the column. */}
+          {DISPLAY_SAFE_DRIVER_CONFIDENCE && (
+            <Tooltip content={confidenceTooltipContent}>
+              <button
+                type="button"
+                // DS v5 a11y: minimum 44×44 touch target for the header info
+                // control. Achieved via a `before:` pseudo-element overlay that
+                // extends the hit area vertically (~16px above + 16px below the
+                // ~16px text = 48px effective, ≥ 44px requirement) WITHOUT
+                // shifting the grid layout — the pseudo-element is absolutely
+                // positioned and contributes no flow height. The button keeps
+                // its `p-0` content box so column alignment is unaffected.
+                className={`${typography.panelBody} text-text-light text-right cursor-help w-full bg-transparent border-0 p-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-info rounded inline-flex items-center justify-end gap-1 relative before:absolute before:content-[''] before:left-0 before:right-0 before:-inset-y-4`}
+                aria-label={confidenceAriaLabel}
+                data-testid="drivers-confidence-header"
+              >
+                <span>Confidence</span>
+                {anyConfidenceProvisional && (
+                  <Info
+                    className="w-3.5 h-3.5 text-text-light flex-shrink-0"
+                    aria-hidden="true"
+                    data-testid="drivers-confidence-provisional-marker"
+                  />
+                )}
+              </button>
+            </Tooltip>
+          )}
+          {/* Empty cell for the icon column — only when the confidence/glyph column shows. */}
+          {DISPLAY_SAFE_DRIVER_CONFIDENCE && <div aria-hidden="true" />}
         </div>
 
         {/* v7.10 T9: Equal-influence note when all visible drivers are within ±0.01 */}

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -1,15 +1,21 @@
 /**
- * DriversSection Component - Redesigned
+ * DriversSection Component
  *
- * "What's Influencing This" panel with column-based layout.
+ * "What's Influencing This" panel — INFLUENCE ONLY (single-source rule; see
+ * ROBUSTNESS-VERDICT-CONTRACT). The driver section communicates how much each
+ * factor influences the current result; it does NOT render confidence / evidence
+ * / stability / fragility claims derived from raw fields (those are gated on
+ * DISPLAY_SAFE_DRIVER_CONFIDENCE / SHOW_FRAGILITY_IN_DRIVER_SECTION, both off
+ * today). Per-factor discussion is the bottom-right DiscussWithAiButton sparkle.
  *
  * Features:
  * - Panel title at top, separate from grid
- * - Column headers: "Sensitivity" and "Confidence" (right-aligned above bars)
+ * - One data column: "Influence" (sensitivity bar). The Confidence column +
+ *   glyph are hidden until a display-safe driver-confidence source exists.
  * - Direction arrows with matching bar colors (↘ orange, ↗ green)
- * - Two bars per row (Sensitivity + Confidence)
+ * - Influence-only pill per row (Top / High-impact / Moderate / Lower influence)
  * - Factor names can wrap, bars stay aligned
- * - Expanded view with contextual insights
+ * - Expanded view with contextual (influence / enrichment) insights
  * - ISL unavailable error state with retry
  */
 
@@ -346,6 +352,12 @@ function DriverRow({
     setIsTooltipOpen(prev => !prev)
   }, [])
 
+  // Close the tooltip if its content disappears (e.g. a data refresh removes the
+  // (i) trigger), so no orphaned tooltip stays open without a trigger to close it.
+  useEffect(() => {
+    if (!hasTooltipContent && isTooltipOpen) setIsTooltipOpen(false)
+  }, [hasTooltipContent, isTooltipOpen])
+
   // v7.5 T7: Softened tooltip copy
   const tooltipElasticityCopy = driver.rawElasticity > 0.001
     ? (() => {
@@ -495,7 +507,7 @@ function DriverRow({
           <DataBar
             value={sensitivityValue}
             colourVar={BAR_COLORS[barColor]}
-            label={`${cleanedLabel} sensitivity: ${Math.round(sensitivityValue * 100)}%`}
+            label={`${cleanedLabel} influence: ${Math.round(sensitivityValue * 100)}%`}
             size="standard"
             showPercent
           />
@@ -608,25 +620,10 @@ function DriverRow({
             >
               {pillText}
             </span>
-            <button
-              type="button"
-              onClick={() => {
-                if (onSendMessage) {
-                  onSendMessage(
-                    `Tell me more about how "${driver.factorLabel}" affects the outcome.`,
-                  )
-                } else if (onFocus && driver.canFocus) {
-                  // Match the factor-name focus path: fall back to factorKey when
-                  // there is no matchedNodeId, so reusable/story/test surfaces
-                  // (no onSendMessage) keep the focus action instead of silently
-                  // no-opping.
-                  onFocus(driver.matchedNodeId ?? driver.factorKey)
-                }
-              }}
-              className={`${typography.panelMeta} text-info hover:underline cursor-pointer ml-auto`}
-            >
-              Discuss
-            </button>
+            {/* No inline action here: the pill is an influence LABEL only. Per-factor
+                discussion is the bottom-right DiscussWithAiButton sparkle (kept as the
+                single, app-consistent "discuss this factor" affordance); node focus is
+                the factor-name button above. (Removed the duplicate inline "Discuss".) */}
           </div>
         )
       })()}

--- a/src/components/results/__tests__/DriversSection.columnAlignment.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.columnAlignment.spec.tsx
@@ -52,9 +52,11 @@ describe('DriversSection: Brief 5 Task 2 — column alignment + title a11y', () 
     const list = screen.getByTestId('drivers-list')
     expect(list).toBeInTheDocument()
 
-    // Headers and rows must both live under the same wrapper.
+    // Headers and rows live under the same wrapper. The Confidence column
+    // header is hidden (influence-only driver section), so only the Influence
+    // header remains alongside the row.
     expect(list).toHaveTextContent('Influence')
-    expect(list).toHaveTextContent('Confidence')
+    expect(list).not.toHaveTextContent('Confidence')
     expect(list).toHaveTextContent('Dedicated Design Expertise')
   })
 

--- a/src/components/results/__tests__/DriversSection.confidence-bar.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.confidence-bar.spec.tsx
@@ -1,9 +1,12 @@
 /**
- * DriversSection Confidence Bar DOM Tests
+ * DriversSection — Confidence column HIDDEN (single-source rule).
  *
- * Verifies the confidence bar renders correctly at edge values (0.0, 0.5, 1.0)
- * now that PLoT's unified formula can produce any value in [0,1].
- * Previously confidence was hardcoded to 0.8 for all factors.
+ * The driver section communicates INFLUENCE only. There is no display-safe
+ * driver-confidence source today (ROBUSTNESS-VERDICT-CONTRACT), so the
+ * Confidence column — bar, % readout, dash placeholder, and High/Moderate/Low
+ * glyph — must NOT render for ANY confidence value (no raw/defaulted confidence,
+ * no dashes). This previously asserted the confidence bar rendered at 0/0.5/1.0;
+ * it now guards that the column stays hidden and the influence-only pill renders.
  */
 
 import { describe, it, expect, vi } from 'vitest'
@@ -39,82 +42,58 @@ function makeDriversData(drivers: DriverItem[]): DriversSectionData {
   }
 }
 
-describe('DriversSection confidence bar rendering', () => {
-  it('renders 0% for confidence: 0.0 without layout breakage', () => {
+describe('DriversSection — Confidence column hidden (single-source rule)', () => {
+  it.each([0.0, 0.5, 0.6, 1.0])(
+    'does not render a confidence bar/readout for confidence %s',
+    (confidence) => {
+      const data = makeDriversData([
+        makeDriver({ factorKey: 'fac', factorLabel: 'Driver A', confidence }),
+      ])
+      render(<DriversSection data={data} goalLabel="test" />)
+      // The confidence progressbar (aria-label "... confidence: N%") must not exist.
+      expect(
+        screen.queryByRole('progressbar', { name: /confidence:/i }),
+      ).not.toBeInTheDocument()
+      // No confidence glyph either.
+      expect(screen.queryByTestId('confidence-glyph-fac')).not.toBeInTheDocument()
+    },
+  )
+
+  it('renders NO dash placeholder when confidence is missing (no dashes, single-source rule)', () => {
     const data = makeDriversData([
-      makeDriver({ factorKey: 'fac_zero', factorLabel: 'Zero confidence', confidence: 0.0 }),
+      makeDriver({ factorKey: 'fac_none', factorLabel: 'No estimate' }), // confidence undefined
     ])
     render(<DriversSection data={data} goalLabel="test" />)
-
-    const bar = screen.getByRole('progressbar', { name: /zero confidence confidence/i })
-    expect(bar).toBeInTheDocument()
-    expect(bar).toHaveAttribute('aria-valuenow', '0')
+    expect(screen.queryByRole('progressbar', { name: /confidence:/i })).not.toBeInTheDocument()
+    // Sensitivity is present (influenceScore 0.5), so no dash placeholder should appear at all.
+    expect(screen.queryByText('-')).not.toBeInTheDocument()
   })
 
-  it('renders 50% for confidence: 0.5 (new common default)', () => {
+  it('renders NO "High/Moderate/Low confidence" glyph or default-estimate icon', () => {
     const data = makeDriversData([
-      makeDriver({ factorKey: 'fac_half', factorLabel: 'Half confidence', confidence: 0.5 }),
+      makeDriver({ factorKey: 'fac_full', factorLabel: 'Full', confidence: 1.0, isDefaultedConfidence: true }),
     ])
     render(<DriversSection data={data} goalLabel="test" />)
-
-    const bar = screen.getByRole('progressbar', { name: /half confidence confidence/i })
-    expect(bar).toBeInTheDocument()
-    expect(bar).toHaveAttribute('aria-valuenow', '50')
+    expect(screen.queryByTestId('confidence-glyph-fac_full')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('default-estimate-icon')).not.toBeInTheDocument()
+    expect(screen.queryByTitle(/confidence/i)).not.toBeInTheDocument()
   })
 
-  it('renders 100% for confidence: 1.0 (full width)', () => {
+  it('renders the INFLUENCE-only pill instead of any stability/evidence claim', () => {
     const data = makeDriversData([
-      makeDriver({ factorKey: 'fac_full', factorLabel: 'Full confidence', confidence: 1.0 }),
+      makeDriver({ factorKey: 'fac', factorLabel: 'Driver A', confidence: 0.9, semanticLabel: 'biggest' }),
     ])
     render(<DriversSection data={data} goalLabel="test" />)
-
-    const bar = screen.getByRole('progressbar', { name: /full confidence confidence/i })
-    expect(bar).toBeInTheDocument()
-    expect(bar).toHaveAttribute('aria-valuenow', '100')
+    expect(screen.getByTestId('driver-influence-pill-fac')).toHaveTextContent('Top driver')
+    expect(screen.queryByText('Important and stable')).not.toBeInTheDocument()
+    expect(screen.queryByText('High impact, low evidence')).not.toBeInTheDocument()
   })
 
-  it('renders dash when confidence is undefined', () => {
-    const data = makeDriversData([
-      makeDriver({ factorKey: 'fac_none', factorLabel: 'No confidence' }),
-    ])
-    render(<DriversSection data={data} goalLabel="test" />)
-
-    // No confidence progressbar should exist
-    expect(screen.queryByRole('progressbar', { name: /no confidence confidence/i })).not.toBeInTheDocument()
-    // Dash placeholder should be rendered
-    const dashes = screen.getAllByText('-')
-    expect(dashes.length).toBeGreaterThanOrEqual(1)
-  })
-
-  // Brief 5.7 D4: Pattern C amended — 4-dot scale → thin bar + numeric readout.
-  // Track is h-1 (vs h-1.5 sensitivity) and bg-info (vs success/warning),
-  // preserving Pattern-A separation while restoring readability.
-  it('renders thin bar (bg-info, h-1) plus percentage readout for confidence: 0.6', () => {
-    const data = makeDriversData([
-      makeDriver({ factorKey: 'fac_60', factorLabel: '60 confidence', confidence: 0.6 }),
-    ])
-    render(<DriversSection data={data} goalLabel="test" />)
-
-    const bar = screen.getByRole('progressbar', { name: /60 confidence confidence/i })
-    expect(bar).toHaveClass('h-1', 'bg-panel-hover', 'rounded-full')
-
-    // Inner fill carries bg-info and width 60%
-    const fill = bar.firstElementChild as HTMLElement | null
-    expect(fill).not.toBeNull()
-    expect(fill).toHaveClass('bg-info', 'rounded-full')
-    expect(fill).toHaveStyle({ width: '60%' })
-
-    // Numeric readout present in the same column
-    expect(screen.getByText('60%')).toBeInTheDocument()
-  })
-
-  it('does not render any 4-dot indicator (no bg-text-body w-2 h-2 spans inside the confidence column)', () => {
+  it('does not render any 4-dot indicator (no bg-text-body w-2 h-2 spans)', () => {
     const data = makeDriversData([
       makeDriver({ factorKey: 'fac_full', factorLabel: 'Full', confidence: 1.0 }),
     ])
     const { container } = render(<DriversSection data={data} goalLabel="test" />)
-
-    // Pre-amendment dots used `w-2 h-2 rounded-full bg-text-body`. None of those should render.
     const dotCandidates = container.querySelectorAll('span.w-2.h-2.rounded-full.bg-text-body')
     expect(dotCandidates.length).toBe(0)
   })

--- a/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
@@ -161,21 +161,6 @@ describe('DriversSection — influence-only guard', () => {
     expect(screen.queryByLabelText('Custom confidence value')).toBeNull()
   })
 
-  it('Discuss action focuses by factorKey when canFocus + no matchedNodeId + no chat (P2 fallback)', () => {
-    const onFocus = vi.fn()
-    render(
-      <DriversSection
-        // canFocus but NO matchedNodeId and NO onSendMessage — the reusable/test
-        // surface where the focus action would previously silently no-op.
-        data={makeData([makeDriver({ factorKey: 'fac', canFocus: true })])}
-        goalLabel="test"
-        onFocusNode={onFocus}
-      />,
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Discuss' }))
-    expect(onFocus).toHaveBeenCalledWith('fac')
-  })
-
   it('does NOT render the decision-flip line even with the tooltip OPEN (decisionChangeRisk gated)', () => {
     // Force the (i) info icon to appear via a zero-reason line (an influence
     // explanation that is always visible), so we can open the top-driver tooltip

--- a/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
@@ -1,0 +1,184 @@
+/**
+ * DriversSection — INFLUENCE-ONLY guard (acceptance #6).
+ *
+ * Driver pills must state INFLUENCE only and must NEVER render a
+ * stability / robustness / confidence / readiness / evidence claim derived from
+ * raw fields. This guard locks the influence-label vocabulary and asserts none
+ * of the removed claim labels (or the raw-confidence column) can reappear — it
+ * is intentionally broader than the literal string "Important and stable".
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DriversSection } from '../DriversSection'
+import type { DriversSectionData, DriverItem, DriverSemanticLabel } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+}))
+
+function makeDriver(overrides: Partial<DriverItem> & { factorKey: string }): DriverItem {
+  return {
+    factorLabel: overrides.factorKey,
+    rawElasticity: 0.5,
+    normalisedInfluence: 0.8,
+    influenceScore: 0.8,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: false,
+    direction: 'positive',
+    ...overrides,
+  }
+}
+
+function makeData(drivers: DriverItem[]): DriversSectionData {
+  return {
+    drivers,
+    topDrivers: drivers.slice(0, 3),
+    driversStatus: 'computed',
+    totalCount: drivers.length,
+    hasMagnitudeData: true,
+  }
+}
+
+// Influence-only vocabulary (the ONLY labels a driver pill may show).
+const INFLUENCE_LABELS: Record<DriverSemanticLabel, string> = {
+  biggest: 'Top driver',
+  strong: 'High-impact driver',
+  moderate: 'Moderate influence',
+  minor: 'Lower influence',
+}
+
+// Removed stability / confidence / evidence claim labels — must never reappear.
+const BANNED_CLAIM_LABELS = [
+  'Important and stable',
+  'High impact, low evidence',
+  'High confidence',
+  'Moderate confidence',
+  'Low confidence',
+  'Could benefit from more evidence',
+  'Ranking may shift',
+]
+
+describe('DriversSection — influence-only guard', () => {
+  it.each(Object.entries(INFLUENCE_LABELS) as Array<[DriverSemanticLabel, string]>)(
+    'semanticLabel "%s" → influence-only pill "%s" (even at high raw confidence)',
+    (semanticLabel, expected) => {
+      render(
+        <DriversSection
+          data={makeData([makeDriver({ factorKey: 'fac', semanticLabel, confidence: 0.95 })])}
+          goalLabel="test"
+        />,
+      )
+      expect(screen.getByTestId('driver-influence-pill-fac')).toHaveTextContent(expected)
+    },
+  )
+
+  it('renders NONE of the removed stability/confidence/evidence claim labels (high raw confidence)', () => {
+    render(
+      <DriversSection
+        data={makeData([
+          makeDriver({ factorKey: 'fac', semanticLabel: 'biggest', confidence: 0.95, isDefaultedConfidence: true }),
+        ])}
+        goalLabel="test"
+      />,
+    )
+    for (const label of BANNED_CLAIM_LABELS) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument()
+    }
+    // No raw-confidence column: no bar, no glyph, no default-estimate icon.
+    expect(screen.queryByRole('progressbar', { name: /confidence:/i })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('confidence-glyph-fac')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('default-estimate-icon')).not.toBeInTheDocument()
+    // The pill is one of the four allowed influence labels.
+    const pill = screen.getByTestId('driver-influence-pill-fac')
+    expect(Object.values(INFLUENCE_LABELS)).toContain(pill.textContent?.trim())
+  })
+
+  it('an unknown/missing semanticLabel falls back to a neutral influence label (never a claim)', () => {
+    render(
+      <DriversSection
+        // Force a malformed semanticLabel at runtime; must not crash or claim.
+        data={makeData([makeDriver({ factorKey: 'fac', semanticLabel: 'bogus' as unknown as DriverSemanticLabel, confidence: 0.95 })])}
+        goalLabel="test"
+      />,
+    )
+    const pill = screen.getByTestId('driver-influence-pill-fac')
+    expect(Object.values(INFLUENCE_LABELS)).toContain(pill.textContent?.trim())
+    expect(screen.queryByText('Important and stable')).not.toBeInTheDocument()
+  })
+
+  it('a driver triggering EVERY non-influence signal renders none of them (influence only)', () => {
+    // One top driver that would, pre-fix, trigger: the confidence column + glyph
+    // + default-estimate + provisional header marker (low/defaulted/provisional
+    // confidence), the technique chip (influence>0.6 && conf<0.5), the
+    // "Ranking may shift" row (rankFlipRate>=0.15), and the "If wrong, X
+    // overtakes" microline (fragile edge). All must be hidden; only the
+    // influence pill + Sensitivity remain.
+    render(
+      <DriversSection
+        data={makeData([
+          makeDriver({
+            factorKey: 'fac',
+            semanticLabel: 'biggest',
+            influenceScore: 0.9,
+            confidence: 0.3,
+            isDefaultedConfidence: true,
+            rankFlipRate: 0.4,
+            fragileEdgeInfo: { switchProbability: 0.4, alternativeWinnerLabel: 'Option B' },
+            confidenceProvenance: {
+              computationSource: 'plot_unified_from_isl_bootstrap',
+              formulaVersion: 'plot_unified_v2',
+              isProvisional: true,
+              calibrationStatus: 'provisional_pending_pilot_calibration',
+              inputQuality: 'standard',
+            },
+          } as DriverItem),
+        ])}
+        goalLabel="test"
+        onSendMessage={() => {}}
+      />,
+    )
+    // Influence pill present (the one allowed signal).
+    expect(screen.getByTestId('driver-influence-pill-fac')).toHaveTextContent('Top driver')
+    // None of the non-influence signals.
+    expect(screen.queryByTestId('drivers-confidence-header')).toBeNull()
+    expect(screen.queryByTestId('drivers-confidence-provisional-marker')).toBeNull()
+    expect(screen.queryByTestId('confidence-glyph-fac')).toBeNull()
+    expect(screen.queryByTestId('default-estimate-icon')).toBeNull()
+    expect(screen.queryByTestId('driver-technique-chip-fac')).toBeNull()
+    expect(screen.queryByTestId('driver-ranking-shift-fac')).toBeNull()
+    expect(screen.queryByTestId('driver-microline')).toBeNull()
+    expect(screen.queryByText(/Ranking may shift/i)).toBeNull()
+    expect(screen.queryByText(/overtakes/i)).toBeNull()
+    expect(screen.queryByText(/reference class forecasting/i)).toBeNull()
+  })
+
+  it('does NOT render the decision-flip line even with the tooltip OPEN (decisionChangeRisk gated)', () => {
+    // Force the (i) info icon to appear via a zero-reason line (an influence
+    // explanation that is always visible), so we can open the top-driver tooltip
+    // and prove the fragility/decision-flip line is gated off inside it.
+    render(
+      <DriversSection
+        data={makeData([
+          makeDriver({
+            factorKey: 'fac',
+            semanticLabel: 'biggest',
+            influenceScore: 0.9,
+            flipRiskCategory: 'isolated',
+            fragileEdgeInfo: { switchProbability: 0.35, alternativeWinnerLabel: 'Option B' },
+            zeroReason: 'disconnected',
+          } as DriverItem),
+        ])}
+        goalLabel="test"
+      />,
+    )
+    // Open the tooltip via the info button.
+    fireEvent.click(screen.getByRole('button', { name: /more information/i }))
+    // The tooltip is open (the influence zero-reason line shows)...
+    expect(screen.getByText(/No causal path to goal/i)).toBeInTheDocument()
+    // ...but the decision-flip / fragility line is hidden.
+    expect(screen.queryByText(/becomes the better choice/i)).toBeNull()
+    expect(screen.queryByText(/can change which option is best/i)).toBeNull()
+  })
+})

--- a/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
@@ -124,6 +124,7 @@ describe('DriversSection — influence-only guard', () => {
             influenceScore: 0.9,
             confidence: 0.3,
             isDefaultedConfidence: true,
+            hasContestedEdge: true,
             rankFlipRate: 0.4,
             fragileEdgeInfo: { switchProbability: 0.4, alternativeWinnerLabel: 'Option B' },
             confidenceProvenance: {
@@ -152,6 +153,27 @@ describe('DriversSection — influence-only guard', () => {
     expect(screen.queryByText(/Ranking may shift/i)).toBeNull()
     expect(screen.queryByText(/overtakes/i)).toBeNull()
     expect(screen.queryByText(/reference class forecasting/i)).toBeNull()
+    // Contested-driver confidence control (Weakly/Moderately/Strongly presets +
+    // the "Custom confidence value" input) is hidden too.
+    expect(screen.queryByText('Weakly')).toBeNull()
+    expect(screen.queryByText('Moderately')).toBeNull()
+    expect(screen.queryByText('Strongly')).toBeNull()
+    expect(screen.queryByLabelText('Custom confidence value')).toBeNull()
+  })
+
+  it('Discuss action focuses by factorKey when canFocus + no matchedNodeId + no chat (P2 fallback)', () => {
+    const onFocus = vi.fn()
+    render(
+      <DriversSection
+        // canFocus but NO matchedNodeId and NO onSendMessage — the reusable/test
+        // surface where the focus action would previously silently no-op.
+        data={makeData([makeDriver({ factorKey: 'fac', canFocus: true })])}
+        goalLabel="test"
+        onFocusNode={onFocus}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Discuss' }))
+    expect(onFocus).toHaveBeenCalledWith('fac')
   })
 
   it('does NOT render the decision-flip line even with the tooltip OPEN (decisionChangeRisk gated)', () => {

--- a/src/components/results/__tests__/DriversSection.microline.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.microline.spec.tsx
@@ -41,8 +41,8 @@ function makeData(drivers: DriverItem[]): DriversSectionData {
   }
 }
 
-describe('DriversSection: V11 driver #1 microline', () => {
-  it('shows microline when driver #1 has fragile edge with switchProbability > 0 and alternativeWinnerLabel', () => {
+describe('DriversSection: driver #1 microline hidden (fragility → fragile-factors section)', () => {
+  it('does NOT show the microline even when driver #1 has a qualifying fragile edge', () => {
     const driver = makeDriver({
       fragileEdgeInfo: {
         switchProbability: 0.35,
@@ -51,10 +51,11 @@ describe('DriversSection: V11 driver #1 microline', () => {
     })
     render(<DriversSection data={makeData([driver])} goalLabel="Revenue" />)
 
-    const microline = screen.getByTestId('driver-microline')
-    expect(microline).toBeInTheDocument()
-    expect(microline.textContent).toBe('If wrong, Option B overtakes')
-    expect(microline.className).toContain('text-danger')
+    // "If wrong, X overtakes" is a fragility/flip claim; per the single-source
+    // rule it belongs in the fragile-factors section, not the influence-only
+    // driver section (SHOW_FRAGILITY_IN_DRIVER_SECTION).
+    expect(screen.queryByTestId('driver-microline')).not.toBeInTheDocument()
+    expect(screen.queryByText(/overtakes/i)).not.toBeInTheDocument()
   })
 
   it('hides microline when driver #1 has no fragileEdgeInfo', () => {
@@ -87,7 +88,7 @@ describe('DriversSection: V11 driver #1 microline', () => {
     expect(screen.queryByTestId('driver-microline')).not.toBeInTheDocument()
   })
 
-  it('only shows microline on first driver, not second', () => {
+  it('shows NO microline on any driver, even with qualifying fragile edges', () => {
     const driver1 = makeDriver({
       factorKey: 'factor-1',
       fragileEdgeInfo: {
@@ -109,8 +110,6 @@ describe('DriversSection: V11 driver #1 microline', () => {
     })
     render(<DriversSection data={makeData([driver1, driver2])} goalLabel="Revenue" />)
 
-    const microlines = screen.getAllByTestId('driver-microline')
-    expect(microlines).toHaveLength(1)
-    expect(microlines[0].textContent).toBe('If wrong, Option B overtakes')
+    expect(screen.queryAllByTestId('driver-microline')).toHaveLength(0)
   })
 })

--- a/src/components/results/__tests__/DriversSection.provenance.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.provenance.spec.tsx
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { DriversSection } from '../DriversSection'
 import {
   isValidConfidenceProvenance,
@@ -74,21 +74,23 @@ function makeDriversData(drivers: DriverItem[]): DriversSectionData {
 }
 
 describe('DriversSection confidence provenance disclosure (audit A1-PRIMARY)', () => {
-  it('renders the column-header Info marker when at least one row carries is_provisional', () => {
+  it('does NOT render the confidence provisional marker (Confidence column hidden, influence-only)', () => {
     const data = makeDriversData([
       makeDriver({
         factorKey: 'fac_a',
         factorLabel: 'Factor A',
         confidenceProvenance: provisionalProvenance(),
       }),
-      makeDriver({ factorKey: 'fac_b', factorLabel: 'Factor B', rank: 2 }), // no provenance — still triggers marker via fac_a
+      makeDriver({ factorKey: 'fac_b', factorLabel: 'Factor B', rank: 2 }),
     ])
 
     render(<DriversSection data={data} goalLabel="test" />)
 
-    const marker = screen.getByTestId('drivers-confidence-provisional-marker')
-    expect(marker).toBeInTheDocument()
-    expect(marker).toHaveAttribute('aria-hidden', 'true')
+    // The whole Confidence column (header + marker + tooltip) is hidden under
+    // the single-source rule; the provisional disclosure returns with the column
+    // when a display-safe driver-confidence source exists.
+    expect(screen.queryByTestId('drivers-confidence-provisional-marker')).toBeNull()
+    expect(screen.queryByTestId('drivers-confidence-header')).toBeNull()
   })
 
   it('does not render the marker when no driver carries provisional provenance', () => {
@@ -115,128 +117,16 @@ describe('DriversSection confidence provenance disclosure (audit A1-PRIMARY)', (
     expect(() => render(<DriversSection data={data} goalLabel="test" />)).not.toThrow()
     expect(screen.queryByTestId('drivers-confidence-provisional-marker')).toBeNull()
 
-    // Header itself still renders.
-    expect(screen.getByTestId('drivers-confidence-header')).toBeInTheDocument()
+    // The Confidence header is hidden (influence-only driver section).
+    expect(screen.queryByTestId('drivers-confidence-header')).toBeNull()
   })
 
-  it('column-header aria-label discloses calibration state when provisional', () => {
-    const data = makeDriversData([
-      makeDriver({
-        factorKey: 'fac_a',
-        factorLabel: 'Factor A',
-        confidenceProvenance: provisionalProvenance(),
-      }),
-    ])
-
-    render(<DriversSection data={data} goalLabel="test" />)
-
-    const header = screen.getByTestId('drivers-confidence-header')
-    expect(header).toHaveAttribute(
-      'aria-label',
-      'Confidence column info — operational estimate pending pilot calibration',
-    )
-  })
-
-  it('hovering the column header opens the tooltip with the calibration disclosure copy', async () => {
-    // Brief explicitly required tooltip-content coverage (not just aria-label).
-    // Drives the Tooltip via real hover, asserts the rendered text in the
-    // Floating UI portal.
-    const data = makeDriversData([
-      makeDriver({
-        factorKey: 'fac_a',
-        factorLabel: 'Factor A',
-        confidenceProvenance: provisionalProvenance(),
-      }),
-    ])
-
-    render(<DriversSection data={data} goalLabel="test" />)
-
-    const header = screen.getByTestId('drivers-confidence-header')
-    // Tooltip wraps children in a `<div ref={refs.setReference}>` — Floating
-    // UI's useHover attaches to that wrapper, so hover must target it.
-    const tooltipRef = header.parentElement!
-    fireEvent.pointerEnter(tooltipRef)
-    fireEvent.mouseEnter(tooltipRef)
-
-    const tooltip = await screen.findByRole('tooltip')
-    expect(tooltip.textContent).toBe(
-      'Confidence is an operational estimate pending pilot calibration.',
-    )
-
-    fireEvent.pointerLeave(tooltipRef)
-    fireEvent.mouseLeave(tooltipRef)
-    await waitFor(() => {
-      expect(screen.queryByRole('tooltip')).toBeNull()
-    })
-  })
-
-  it('focusing the column header (keyboard path) opens the same tooltip', async () => {
-    // Keyboard accessibility: tooltip MUST surface on focus, not just hover.
-    const data = makeDriversData([
-      makeDriver({
-        factorKey: 'fac_a',
-        factorLabel: 'Factor A',
-        confidenceProvenance: provisionalProvenance(),
-      }),
-    ])
-
-    render(<DriversSection data={data} goalLabel="test" />)
-
-    const header = screen.getByTestId('drivers-confidence-header')
-    header.focus()
-
-    const tooltip = await screen.findByRole('tooltip')
-    expect(tooltip.textContent).toBe(
-      'Confidence is an operational estimate pending pilot calibration.',
-    )
-  })
-
-  it('non-provisional payloads use the legacy column-header tooltip copy (forward-compat)', async () => {
-    const data = makeDriversData([
-      makeDriver({
-        factorKey: 'fac_a',
-        factorLabel: 'Factor A',
-        confidenceProvenance: provisionalProvenance({ isProvisional: false }),
-      }),
-    ])
-
-    render(<DriversSection data={data} goalLabel="test" />)
-
-    const header = screen.getByTestId('drivers-confidence-header')
-    // Tooltip wraps children in a `<div ref={refs.setReference}>` — Floating
-    // UI's useHover attaches to that wrapper, so hover must target it.
-    const tooltipRef = header.parentElement!
-    fireEvent.pointerEnter(tooltipRef)
-    fireEvent.mouseEnter(tooltipRef)
-
-    const tooltip = await screen.findByRole('tooltip')
-    // Legacy copy describes the panel mechanics; the disclosure text is
-    // reserved for the provisional case.
-    expect(tooltip.textContent).toMatch(/how stable this factor's ranking/)
-    expect(tooltip.textContent).not.toMatch(/pending pilot calibration/)
-  })
-
-  it('a11y: column-header touch target meets DS v5 ≥44px requirement via before:-inset-y-4 overlay', () => {
-    // JSDOM does not compute pseudo-element box dimensions, so we verify the
-    // class contract that drives runtime hit-area expansion. The pseudo-element
-    // adds ~16px above and below the ~16px text content (≈48px total ≥ 44px),
-    // and is absolutely positioned so it does NOT shift the surrounding grid.
-    const data = makeDriversData([
-      makeDriver({ factorKey: 'fac_a', factorLabel: 'Factor A' }),
-    ])
-
-    render(<DriversSection data={data} goalLabel="test" />)
-
-    const header = screen.getByTestId('drivers-confidence-header')
-    // Required positioning classes.
-    expect(header).toHaveClass('relative')
-    // Tailwind class assertion via className regex (toHaveClass requires
-    // an exact class name; the `before:` variant is one token).
-    expect(header.className).toMatch(/before:absolute/)
-    expect(header.className).toMatch(/before:-inset-y-4/)
-    expect(header.className).toMatch(/before:left-0/)
-    expect(header.className).toMatch(/before:right-0/)
-  })
+  // The confidence column-header INTERACTION tests (aria-label disclosure,
+  // hover/focus tooltip copy, legacy copy, ≥44px touch target) were removed:
+  // the Confidence header is hidden under the influence-only rule, so there is
+  // no header element to interact with. They return with the column when
+  // DISPLAY_SAFE_DRIVER_CONFIDENCE is true. The data-layer provenance tests
+  // below are unaffected (the data still carries provenance; the UI hides it).
 
   it('cross-version safety: legacy confidenceSource ("isl") with no confidence_provenance renders without crashing', () => {
     // Simulates a NEW UI receiving an OLD PLoT payload (deploy-order safety).
@@ -457,7 +347,7 @@ describe('DriversSection confidence provenance disclosure (audit A1-PRIMARY)', (
     })
   })
 
-  it('forward-compat: marker still renders when PLoT bumps formulaVersion / calibrationStatus / inputQuality', () => {
+  it('forward-compat: even with future provenance, the marker stays hidden (Confidence column hidden)', () => {
     // Locks down behaviour for when PLoT bumps to plot_unified_v3 (Jinghui
     // calibration) or extends calibration / input-quality vocabularies. The
     // is_provisional disclosure must continue to drive the marker even when
@@ -480,6 +370,6 @@ describe('DriversSection confidence provenance disclosure (audit A1-PRIMARY)', (
 
     render(<DriversSection data={data} goalLabel="test" />)
 
-    expect(screen.getByTestId('drivers-confidence-provisional-marker')).toBeInTheDocument()
+    expect(screen.queryByTestId('drivers-confidence-provisional-marker')).toBeNull()
   })
 })

--- a/src/components/results/__tests__/DriversSection.rankFlipD5.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.rankFlipD5.spec.tsx
@@ -43,16 +43,19 @@ function makeData(drivers: DriverItem[]): DriversSectionData {
   }
 }
 
-describe('DriversSection — Brief 5.8B D5 visible "Ranking may shift" row', () => {
-  it('renders the row when rankFlipRate >= 0.15', () => {
+describe('DriversSection — "Ranking may shift" row hidden (fragility → fragile-factors section)', () => {
+  it('does NOT render the row even when rankFlipRate >= 0.15', () => {
     render(
       <DriversSection
         data={makeData([makeDriver({ rankFlipRate: 0.32 })])}
       />,
     )
-    const row = screen.getByTestId('driver-ranking-shift-factor-1')
-    expect(row).toBeInTheDocument()
-    expect(row).toHaveTextContent('Ranking may shift 32%')
+    // "Ranking may shift" is a fragility/ranking-shift claim; per the
+    // single-source rule it belongs in the fragile-factors section, not the
+    // influence-only driver section (SHOW_FRAGILITY_IN_DRIVER_SECTION). So the
+    // row stays hidden even when rankFlipRate >= 0.15.
+    expect(screen.queryByTestId('driver-ranking-shift-factor-1')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Ranking may shift/i)).not.toBeInTheDocument()
   })
 
   it('omits the row when rankFlipRate < 0.15', () => {

--- a/src/components/results/__tests__/DriversSection.techniqueChip.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.techniqueChip.spec.tsx
@@ -1,21 +1,16 @@
 /**
- * DriversSection — Brief 5.1 Task 7.5 technique suggestion chip.
+ * DriversSection — technique-suggestion chip HIDDEN (single-source rule).
  *
- * The "Try: reference class forecasting" suggestion used to render only
- * inside the driver tooltip — a decorative dead-end. Task 7.5 promotes it
- * to a visible button on the card body that, when clicked, sends a scoped
- * prompt into the chat so the user can act on the suggestion.
- *
- * Chip visibility rule (mirrors the existing techniqueSuggestion selector
- * inside DriverRow): influence > 0.6 AND confidence < 0.5.
- *
- * Brief 5.4 Phase 3 (Path A): chip is further restricted to the top-ranked
- * driver only (index === 0). Lower-ranked drivers meeting the threshold do
- * NOT get a chip — prevents the same text appearing 3+ times per panel.
+ * The "Try: reference class forecasting" chip is gated on LOW confidence
+ * (influence > 0.6 AND confidence < 0.5), so it is a confidence-derived signal.
+ * Under the influence-only rule the driver section shows influence only and
+ * hides confidence-derived signals until a display-safe driver-confidence source
+ * exists (DISPLAY_SAFE_DRIVER_CONFIDENCE). This previously asserted the chip
+ * rendered + dispatched; it now guards that it does not appear.
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { DriversSection } from '../DriversSection'
 import type { DriversSectionData, DriverItem } from '../types'
 
@@ -51,94 +46,23 @@ function makeData(drivers: DriverItem[]): DriversSectionData {
   }
 }
 
-describe('DriversSection — Brief 5.1 Task 7.5 technique chip', () => {
-  it('renders the clickable technique chip when influence > 0.6 and confidence < 0.5', () => {
-    const onSendMessage = vi.fn()
+describe('DriversSection — technique chip hidden (confidence-derived, single-source rule)', () => {
+  it('does NOT render the chip even when it would qualify (influence > 0.6 AND confidence < 0.5)', () => {
     render(
       <DriversSection
         data={makeData([makeDriver({ influenceScore: 0.8, confidence: 0.4 })])}
-        onSendMessage={onSendMessage}
-      />,
-    )
-
-    const chip = screen.getByTestId('driver-technique-chip-f1')
-    expect(chip).toBeInTheDocument()
-    expect(chip).toHaveTextContent('Try: reference class forecasting')
-    expect(chip.tagName).toBe('BUTTON')
-  })
-
-  it('clicking the chip dispatches an onSendMessage call with factor context', () => {
-    const onSendMessage = vi.fn()
-    render(
-      <DriversSection
-        data={makeData([makeDriver({ influenceScore: 0.8, confidence: 0.4, factorLabel: 'Customer Churn' })])}
-        onSendMessage={onSendMessage}
-      />,
-    )
-
-    fireEvent.click(screen.getByTestId('driver-technique-chip-f1'))
-
-    expect(onSendMessage).toHaveBeenCalledTimes(1)
-    const prompt = onSendMessage.mock.calls[0][0] as string
-    expect(prompt).toContain('Try: reference class forecasting')
-    expect(prompt).toContain('Customer Churn')
-  })
-
-  it('omits the chip when confidence is high enough (no suggestion)', () => {
-    render(
-      <DriversSection
-        data={makeData([makeDriver({ influenceScore: 0.8, confidence: 0.8 })])}
         onSendMessage={() => {}}
       />,
     )
     expect(screen.queryByTestId('driver-technique-chip-f1')).not.toBeInTheDocument()
+    expect(screen.queryByText(/reference class forecasting/i)).not.toBeInTheDocument()
   })
 
-  it('omits the chip when influence is too low to warrant the suggestion', () => {
-    render(
-      <DriversSection
-        data={makeData([makeDriver({ influenceScore: 0.3, confidence: 0.3 })])}
-        onSendMessage={() => {}}
-      />,
-    )
+  it('renders no technique chip on any driver, regardless of confidence', () => {
+    const d1 = makeDriver({ factorKey: 'f1', rank: 1, influenceScore: 0.8, confidence: 0.4 })
+    const d2 = makeDriver({ factorKey: 'f2', rank: 2, influenceScore: 0.9, confidence: 0.3 })
+    render(<DriversSection data={makeData([d1, d2])} onSendMessage={() => {}} />)
     expect(screen.queryByTestId('driver-technique-chip-f1')).not.toBeInTheDocument()
-  })
-
-  it('omits the chip when no onSendMessage handler is wired (defensive)', () => {
-    render(
-      <DriversSection
-        data={makeData([makeDriver({ influenceScore: 0.8, confidence: 0.4 })])}
-      />,
-    )
-    expect(screen.queryByTestId('driver-technique-chip-f1')).not.toBeInTheDocument()
-  })
-
-  it('chip exposes an accessible label that names the technique and factor', () => {
-    render(
-      <DriversSection
-        data={makeData([makeDriver({ influenceScore: 0.8, confidence: 0.4, factorLabel: 'Churn Rate' })])}
-        onSendMessage={() => {}}
-      />,
-    )
-
-    const chip = screen.getByTestId('driver-technique-chip-f1')
-    const label = chip.getAttribute('aria-label') ?? ''
-    expect(label).toContain('reference class forecasting')
-    expect(label).toContain('Churn Rate')
-  })
-
-  it('Brief 5.4 P3: chip only on top-ranked driver; lower-ranked qualifying drivers get no chip', () => {
-    // Both drivers qualify by influence + confidence, but chip must only appear on index 0
-    const driver1 = makeDriver({ factorKey: 'f1', rank: 1, influenceScore: 0.8, confidence: 0.4 })
-    const driver2 = makeDriver({ factorKey: 'f2', rank: 2, influenceScore: 0.9, confidence: 0.3 })
-    render(
-      <DriversSection
-        data={makeData([driver1, driver2])}
-        onSendMessage={() => {}}
-      />,
-    )
-
-    expect(screen.getByTestId('driver-technique-chip-f1')).toBeInTheDocument()
     expect(screen.queryByTestId('driver-technique-chip-f2')).not.toBeInTheDocument()
   })
 })

--- a/src/components/results/__tests__/DriversSection.valueProvenance.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.valueProvenance.spec.tsx
@@ -110,8 +110,9 @@ describe('Track S value provenance — no user-facing DOM leak', () => {
 
     const { container } = render(<DriversSection data={data} goalLabel="test" />)
 
-    // Sanity: the section rendered.
-    expect(screen.getByTestId('drivers-confidence-header')).toBeInTheDocument()
+    // Sanity: the section rendered. (The drivers-list wrapper is always present;
+    // the Confidence header is hidden under the influence-only rule.)
+    expect(screen.getByTestId('drivers-list')).toBeInTheDocument()
     // No visible text leak.
     expect(screen.queryByText(/SENTINEL_SOURCE/)).toBeNull()
     expect(screen.queryByText(/SENTINEL_EXTRACTION/)).toBeNull()


### PR DESCRIPTION
## Driver section: influence-only (pills + Confidence column + fragility/coaching cross-refs)

Enforces a single, coherent rule on the live Analysis-tab drivers surface (`src/components/results/DriversSection.tsx`):

> **Driver section = influence only. Confidence / evidence / stability claims stay hidden unless display-safe. Fragility stays in the fragile-factors section.**

Previously the driver pills derived a green **"Important and stable"** (stability claim) and a red **"High impact, low evidence"** (evidence claim) from raw `influenceScore × confidence`; each row showed a raw **Confidence** bar + % + High/Moderate/Low glyph + a "Confidence" column header with a stability tooltip; and rows surfaced fragility/coaching cross-refs ("If wrong, X overtakes", "Ranking may shift N%", a low-confidence technique chip). These overclaim trust from uncertified raw fields and duplicate signals that belong in the Confidence column or the fragile-factors section. Sibling of the #197 robustness-footer fix (same single-source principle).

### What changed (UI / display-only)

- **Driver pills → influence only.** Mapped from the upstream influence-derived `DriverItem.semanticLabel` (UI-SEM-039) — **never** raw confidence: `biggest`→**"Top driver"**, `strong`→**"High-impact driver"**, `moderate`→**"Moderate influence"**, `minor`→**"Lower influence"** (unknown/missing → neutral "Lower influence"). Removed "Important and stable" + "High impact, low evidence"; outlined `text-text-body` styling (DS-compliant; colour conveys prominence, not quality). The row's action button no longer branches on confidence.
- **Two documented gates (both `false` today; the code returns intact when flipped):**
  - **`DISPLAY_SAFE_DRIVER_CONFIDENCE`** (no display-safe driver-confidence source exists — same posture as the robustness `robustnessVerdict` seam) hides every confidence/evidence signal: the per-row Confidence bar + % + **dash placeholder** (no dashes), the High/Moderate/Low glyph + default-estimate icon, the **column-header "Confidence" cell + its trailing icon cell** (so the header grid-child count matches the narrowed grid — fixes a header/row alignment break), the "Could benefit from more evidence" hint, the low-confidence **technique chip**, and the **contested-driver quick-select** (Weakly/Moderately/Strongly + a "Custom confidence value" input, seeded from `driver.confidence`) — a confidence control that was also **orphaned** (its presets don't propagate to the edge store). `gridCols()` narrows the grid to **factor + Sensitivity (influence)**.
  - **`SHOW_FRAGILITY_IN_DRIVER_SECTION`** (placement rule — fragility belongs in the fragile-factors section, acceptance #4/#5) hides the **"If wrong, X overtakes"** microline and **both** "Ranking may shift N%" variants (visible row + tooltip).
- **Kept:** the **Sensitivity (influence)** bar, factor labels, focus/keyboard affordances (the pill "Discuss" action's focus fallback now uses `matchedNodeId ?? factorKey` when `canFocus`, matching the factor-name path, so reusable/test surfaces without chat keep the focus action), and the data-layer confidence-provenance normalisation (the data still carries provenance; the UI hides it).

### Acceptance mapping
1. "Important and stable" gone ✓ 2. No pill says/implies stable/robust/confident/ready from raw stability ✓ 3. Pills communicate influence only ✓ 4. Fragility language stays in the fragile-factors section (microline + ranking-shift hidden here) ✓ 5. Driver axis ("this matters most") kept distinct from the fragile axis ✓ 6. Guard test catches *any* future driver-surface stability/robustness/confidence/readiness/fragility claim from raw fields — a single test triggers every non-influence signal (low/defaulted/provisional confidence + rankFlipRate≥0.15 + fragile edge) and asserts none render ✓

### Inspected — deferred (reported, not changed here)
- **Canvas surfaces (separate, broader — like the deferred GoalNode/DecisionNode robustness viz):** `DriversSignal.tsx` renders a `Confidence: {label} ±X%` calibration label from a conformal-prediction interval; `DriverChips`/`KeyDriversPanel`/`RecommendationCard/DriversSection` have no live importers (dead). Not in this Analysis-tab-scoped PR.

### Tests
- `DriversSection.confidence-bar.spec` + `DriversSection.influenceOnlyGuard.spec` (new): the Confidence bar/%/dash/glyph/default-estimate and the influence-only pill mapping; the guard locks the 4 influence labels (incl. high-confidence + malformed-semanticLabel) and bans the removed claim labels, with a test that triggers **every** non-influence signal and asserts none render.
- `provenance.spec`: collapsed the now-moot header-interaction tests to a "header hidden" guard; **kept the data-layer pure-function tests** (`normalizeFactorSensitivity` / `isDefaultedConfidenceFromRaw` / `isValidConfidenceProvenance`) intact.
- `microline` / `rankFlipD5` / `techniqueChip`: flipped to assert hidden even when their trigger conditions are met. `columnAlignment` / `valueProvenance`: anchors updated (Confidence header hidden; sanity anchors on `drivers-list`).
- All 10 `DriversSection.*` specs pass (60 tests). `DriversSection.tsx` type-clean (`tsc -p tsconfig.app.json`); eslint clean. `ResultsBody` + #197 footer/glyph + `driversAdapter` unaffected (57 tests).
- **#195 changed-state smoke:** no freshness/footer files touched (freshness/robustness specs green); a live browser smoke remains blocked by the known guest/null-graph 500 + canvas `document_idle` (see #197) — manual verification recommended.

### Post-review polish (rounds 2–3)
- **De-duplicated the discuss control:** removed the inline pill action button (it duplicated the established bottom-right `DiscussWithAiButton` sparkle once its original "Improve/Edit" intent was dropped). The pill is now a pure influence **label**; the sparkle is the single per-factor discuss affordance; node focus is the factor-name button.
- **Tooltip orphan guard:** the `FactorTooltip` now closes via effect when `hasTooltipContent` goes false, so a data refresh that removes the (i) trigger can't leave a tooltip stuck open.
- **A11y/doc parity:** the influence bar's accessible label now reads "influence" (matching the visible "Influence" header, was "sensitivity"); the file-header docblock updated to influence-only (no Confidence column / two bars).

### Boundaries
UI/display-only. No backend / schema / prompt / CEE / PLoT / ISL / contract / dependency / flag / env / deploy changes. Does not redefine robust/stable/confident/sensitive semantics. **#196 and #197 untouched.** Draft only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
