### PR TITLE
feat(coaching): mount Strengthen your model as the second Analysis-tab panel (static; dynamic/server coaching gated out)

### DIFF
--- a/src/canvas/components/coaching-panel/CoachingActionCard.tsx
+++ b/src/canvas/components/coaching-panel/CoachingActionCard.tsx
@@ -1,0 +1,97 @@
+/**
+ * CoachingActionCard — the single reusable coaching row.
+ *
+ * Collapsed: entity shape + the observation as the primary line (clamped to one
+ * line). There is NO invented title — with no `display_title` in the envelope,
+ * `grounding.observation` is the line (UX amendment 4; `display_title` is a
+ * future wire requirement). Expanded: reveals the coaching moment.
+ *
+ * Accessible disclosure (WAI-ARIA): the header is a native button carrying
+ * aria-expanded + aria-controls and is named by the observation; the expanded
+ * region is mounted only when open, labelled by the observation, and is a
+ * `region`. Controlled by the parent so the list can keep one row open at a time.
+ *
+ * Technical fields (signal_id, move, source) ride on data-* attributes for
+ * traceability/tests only — never rendered as prose (UX amendment 3).
+ */
+import { useId, type CSSProperties } from 'react'
+import { ChevronRight, ChevronDown } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { EntityTarget } from './EntityTarget'
+import { CoachingMoment } from './CoachingMoment'
+import { COACHING_COPY } from './constants'
+import type { CoachingSignal } from './types'
+
+interface CoachingActionCardProps {
+  signal: CoachingSignal
+  isOpen: boolean
+  onToggle: () => void
+}
+
+export function CoachingActionCard({ signal, isOpen, onToggle }: CoachingActionCardProps) {
+  const regionId = useId()
+  const labelId = useId()
+  const Chevron = isOpen ? ChevronDown : ChevronRight
+  const observation = signal.grounding?.observation ?? ''
+  const hasObservation = observation.trim().length > 0
+
+  // One-line clamp when collapsed; full text when open. Inline style avoids
+  // depending on the Tailwind line-clamp plugin (mirrors ExpandableCoachingText).
+  const clampStyle: CSSProperties | undefined = isOpen
+    ? undefined
+    : {
+        display: '-webkit-box',
+        WebkitLineClamp: 1,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+      }
+
+  return (
+    <div
+      className="overflow-hidden rounded-xl border border-panel-border bg-panel"
+      data-testid="coaching-card"
+      data-signal-id={signal.signal_id}
+      data-move={signal.move}
+      data-source={signal.source}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={regionId}
+        // Name comes from the observation text; fall back to a generic label
+        // only when there is no observation, so the control is always operable.
+        aria-label={hasObservation ? undefined : COACHING_COPY.itemFallback}
+        className="flex w-full items-start gap-2 px-3 py-2.5 text-left transition-colors hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-inset"
+      >
+        <span className="mt-0.5 flex-none">
+          <EntityTarget targetKind={signal.target_kind} />
+        </span>
+        <span
+          id={labelId}
+          className={`${typography.panelBody} min-w-0 flex-1 text-text-body`}
+          style={clampStyle}
+        >
+          {observation}
+        </span>
+        <Chevron className="mt-0.5 h-4 w-4 flex-none text-text-light" aria-hidden="true" />
+      </button>
+
+      {isOpen && (
+        <div
+          id={regionId}
+          role="region"
+          // Label the region by the observation when present; otherwise a
+          // generic name (an empty labelledby reference would fail a11y).
+          {...(hasObservation ? { 'aria-labelledby': labelId } : { 'aria-label': COACHING_COPY.itemFallback })}
+          className="border-t border-panel-border px-3 pb-3 pt-1"
+          data-testid="coaching-card-body"
+        >
+          <CoachingMoment signal={signal} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CoachingActionCard

--- a/src/canvas/components/coaching-panel/CoachingFutureFields.tsx
+++ b/src/canvas/components/coaching-panel/CoachingFutureFields.tsx
@@ -1,0 +1,77 @@
+/**
+ * CoachingFutureFields — render-only display of roadmap fields.
+ *
+ * Every field here is OPTIONAL and fixture-only this phase (UX amendment 7): it
+ * renders iff present, exactly as given. Nothing is computed — priority is never
+ * used to sort, lifecycle is never transitioned, staleness is never derived
+ * (F.6). Human strings render verbatim; the raw numeric `priority` is kept on a
+ * data attribute (traceability) rather than shown as prose (UX amendment 3).
+ */
+import { typography } from '@/styles/typography'
+import type { CoachingSignal } from './types'
+
+/** True when a signal carries any roadmap field worth expanding for. */
+export function hasFutureFields(s: CoachingSignal): boolean {
+  return (
+    s.priority != null ||
+    s.priority_reason != null ||
+    s.lifecycle_state != null ||
+    (s.suggested_actions?.length ?? 0) > 0 ||
+    (s.evidence?.length ?? 0) > 0 ||
+    s.staleness?.label != null
+  )
+}
+
+const pill =
+  'inline-flex items-center rounded-full border border-panel-border bg-transparent px-2 py-0.5 text-text-body'
+
+export function CoachingFutureFields({ signal }: { signal: CoachingSignal }) {
+  const { priority, priority_reason, lifecycle_state, suggested_actions, evidence, staleness } = signal
+
+  return (
+    <div
+      className="flex flex-col gap-2"
+      data-testid="coaching-future-fields"
+      data-priority={priority != null ? String(priority) : undefined}
+    >
+      {lifecycle_state && (
+        <span className={`${pill} ${typography.panelMeta}`} data-testid="coaching-lifecycle">
+          {lifecycle_state}
+        </span>
+      )}
+
+      {priority_reason && (
+        <p className={`${typography.panelMeta} text-text-light`}>{priority_reason}</p>
+      )}
+
+      {staleness?.label && (
+        <p className={`${typography.panelMeta} text-text-light`} data-testid="coaching-staleness">
+          {staleness.label}
+        </p>
+      )}
+
+      {suggested_actions && suggested_actions.length > 0 && (
+        <ul className="flex flex-col gap-1 list-none m-0 p-0" data-testid="coaching-suggested-actions">
+          {suggested_actions.map((action, i) => (
+            // Display-only: no handler, no execution this phase.
+            <li key={action.id ?? `${i}`} className={`${typography.panelBody} text-text-body`}>
+              {action.label}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {evidence && evidence.length > 0 && (
+        <ul className="flex flex-col gap-1 list-none m-0 p-0" data-testid="coaching-evidence">
+          {evidence.map((item, i) => (
+            <li key={item.ref ?? `${i}`} className={`${typography.panelMeta} text-text-light`}>
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default CoachingFutureFields

--- a/src/canvas/components/coaching-panel/CoachingList.tsx
+++ b/src/canvas/components/coaching-panel/CoachingList.tsx
@@ -1,0 +1,59 @@
+/**
+ * CoachingList — list mechanics, view-state ONLY (F.6).
+ *
+ * Owns two pieces of ephemeral view state, neither of which is computation:
+ *  - `openId`: which row is expanded — one row open at a time (toggle-to-null).
+ *  - `revealed`: show all / show fewer — a POSITIONAL slice of the received
+ *    array (`slice(0, N)`), never a filter or sort by meaning.
+ *
+ * Signals are rendered in the exact order received. The list never ranks,
+ * prioritises, or selects which signals matter — that is CEE's job.
+ */
+import { useState } from 'react'
+import { typo } from '@/styles/typography'
+import { CoachingActionCard } from './CoachingActionCard'
+import { COACHING_COPY, COACHING_DEFAULT_VISIBLE } from './constants'
+import type { CoachingSignal } from './types'
+
+export function CoachingList({ signals }: { signals: CoachingSignal[] }) {
+  const [openId, setOpenId] = useState<string | null>(null)
+  const [revealed, setRevealed] = useState(false)
+
+  const visible = revealed ? signals : signals.slice(0, COACHING_DEFAULT_VISIBLE)
+  const hiddenCount = signals.length - COACHING_DEFAULT_VISIBLE
+
+  return (
+    <div data-testid="coaching-list">
+      <ul className="m-0 flex list-none flex-col gap-2 p-0">
+        {visible.map((signal) => (
+          <li key={signal.signal_id}>
+            <CoachingActionCard
+              signal={signal}
+              isOpen={openId === signal.signal_id}
+              onToggle={() =>
+                setOpenId((prev) => (prev === signal.signal_id ? null : signal.signal_id))
+              }
+            />
+          </li>
+        ))}
+      </ul>
+
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          aria-expanded={revealed}
+          onClick={() => setRevealed((v) => !v)}
+          data-testid="coaching-reveal"
+          className={typo(
+            'panelMeta',
+            'mt-2 rounded text-text-light outline-none transition-colors hover:text-text-header focus-visible:text-text-header focus-visible:ring-2 focus-visible:ring-info/40',
+          )}
+        >
+          {revealed ? COACHING_COPY.showFewer : COACHING_COPY.showAll(signals.length)}
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default CoachingList

--- a/src/canvas/components/coaching-panel/CoachingMoment.tsx
+++ b/src/canvas/components/coaching-panel/CoachingMoment.tsx
@@ -1,0 +1,46 @@
+/**
+ * CoachingMoment — the expanded body of a coaching row.
+ *
+ * Shows the entity context (shape + human label), any roadmap fields when
+ * present, and an icon-only "Ask Olumi" affordance that is DISPLAY-ONLY this
+ * phase (no handler, no execution). The full observation lives in the row
+ * header (un-clamped when open) so it is not repeated here.
+ *
+ * The Ask-Olumi button is inlined (not imported from the in-flight
+ * pre-analysis-v3 directory) to keep this panel fully file-disjoint from that
+ * work; it uses the same DS tokens (info colour, 28px round, info focus ring).
+ */
+import { Sparkles } from 'lucide-react'
+import Tooltip from '@/components/Tooltip'
+import { EntityTarget } from './EntityTarget'
+import { CoachingFutureFields, hasFutureFields } from './CoachingFutureFields'
+import { COACHING_COPY } from './constants'
+import type { CoachingSignal } from './types'
+
+export function CoachingMoment({ signal }: { signal: CoachingSignal }) {
+  return (
+    <div className="flex flex-col gap-2 pt-1">
+      {signal.target_label && (
+        <EntityTarget targetKind={signal.target_kind} label={signal.target_label} showLabel />
+      )}
+
+      {hasFutureFields(signal) && <CoachingFutureFields signal={signal} />}
+
+      <div className="flex justify-end">
+        <Tooltip content={COACHING_COPY.askOlumi}>
+          {/* Display-only: no onClick this phase. aria-label names the icon-only action. */}
+          <button
+            type="button"
+            aria-label={COACHING_COPY.askOlumi}
+            className="inline-flex h-7 w-7 flex-none items-center justify-center rounded-full text-info outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40"
+            data-testid="coaching-ask-olumi"
+          >
+            <Sparkles size={16} aria-hidden="true" />
+          </button>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+export default CoachingMoment

--- a/src/canvas/components/coaching-panel/CoachingPanel.stories.tsx
+++ b/src/canvas/components/coaching-panel/CoachingPanel.stories.tsx
@@ -1,0 +1,92 @@
+/**
+ * Coaching panel — Storybook stories (CSF3).
+ *
+ * Render-only Phase 0 surface, exercised against local fixtures. The a11y addon
+ * runs automatically against each story. Rows expand on click (one open at a
+ * time); use "Show all" to reveal beyond the default set.
+ */
+import React from 'react'
+import { CoachingPanel } from './CoachingPanel'
+import {
+  typicalPanel,
+  emptySignals,
+  noSummary,
+  minimalSignal,
+  withAllFuture,
+  veryLongStrings,
+  bySource,
+  byMove,
+  unknownTargetKind,
+  forbiddenTermInLabel,
+} from './__fixtures__/coaching.fixtures'
+import type { Coaching } from './types'
+
+export default {
+  title: 'Canvas/Coaching Panel',
+  parameters: {
+    layout: 'padded',
+    backgrounds: { default: 'panel' },
+  },
+}
+
+/** Mimics the dock panel width and background. */
+function PanelWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        width: 380,
+        maxHeight: '90vh',
+        overflow: 'auto',
+        background: 'var(--bg-panel, #FEFEFE)',
+        borderRadius: 16,
+        padding: 16,
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** CSF story function with an optional display name (this repo's story style). */
+type Story = (() => React.ReactElement) & { storyName?: string }
+
+const story =
+  (coaching: Coaching | null, showStaleBanner = false): Story =>
+  () => (
+    <PanelWrapper>
+      <CoachingPanel coaching={coaching} showStaleBanner={showStaleBanner} />
+    </PanelWrapper>
+  )
+
+export const Default = story(typicalPanel)
+Default.storyName = 'Default (summary + reveal)'
+
+export const Empty = story(emptySignals)
+
+export const NoSummary = story(noSummary)
+NoSummary.storyName = 'No summary line'
+
+export const SingleSignal = story(minimalSignal)
+SingleSignal.storyName = 'Single minimal signal'
+
+export const AllFutureFields = story(withAllFuture)
+AllFutureFields.storyName = 'All future fields (expand the row)'
+
+export const StaleBanner = story(typicalPanel, true)
+StaleBanner.storyName = 'Stale banner (fixture-only)'
+
+export const LongStrings = story(veryLongStrings)
+LongStrings.storyName = 'Long strings (clamp + wrap)'
+
+export const Sources = story(bySource)
+Sources.storyName = 'One per source (+ unknown)'
+
+export const Moves = story(byMove)
+Moves.storyName = 'One per move (+ unknown)'
+
+export const UnknownEntity = story(unknownTargetKind)
+UnknownEntity.storyName = 'Unknown target kind (neutral marker)'
+
+export const ForbiddenTermData = story(forbiddenTermInLabel)
+ForbiddenTermData.storyName = 'Forbidden-term model data (verbatim)'

--- a/src/canvas/components/coaching-panel/CoachingPanel.tsx
+++ b/src/canvas/components/coaching-panel/CoachingPanel.tsx
@@ -1,0 +1,59 @@
+/**
+ * CoachingPanel — render-only coaching surface (Phase 0).
+ *
+ * Pure presentational: it renders the coaching envelope it is given and owns no
+ * data, no network, no storage, and (deliberately) no feature flag — a flag has
+ * no effect on an unmounted, Storybook/tests-only component, so it is deferred
+ * to the later mount PR (UX amendment 2). The future mount (Analysis tab) will
+ * flag-gate this component and swap the fixture feed for the live envelope.
+ *
+ * Renders, in order: an optional fixture-only stale banner, the orientation
+ * summary line (verbatim, omitted when absent — never synthesised), and either
+ * a neutral empty state or the signal list (in received order). All model
+ * strings render as TEXT — never HTML.
+ */
+import { typography } from '@/styles/typography'
+import { CoachingList } from './CoachingList'
+import { StaleBanner } from './StaleBanner'
+import { COACHING_COPY } from './constants'
+import type { Coaching } from './types'
+
+export interface CoachingPanelProps {
+  coaching?: Coaching | null
+  /**
+   * Fixture-only: render the panel-level stale banner. There is no live
+   * staleness data this phase; the UI never derives it (F.6).
+   */
+  showStaleBanner?: boolean
+  className?: string
+}
+
+export function CoachingPanel({ coaching, showStaleBanner = false, className = '' }: CoachingPanelProps) {
+  const signals = coaching?.signals ?? []
+
+  return (
+    <section
+      aria-label={COACHING_COPY.panelAria}
+      data-testid="coaching-panel"
+      className={`flex flex-col gap-3 ${className}`}
+    >
+      {showStaleBanner && <StaleBanner />}
+
+      {coaching?.summary && (
+        <p className={`${typography.panelBody} text-text-body`} data-testid="coaching-summary">
+          {coaching.summary}
+        </p>
+      )}
+
+      {signals.length === 0 ? (
+        <p className={`${typography.panelBody} text-text-light`} data-testid="coaching-empty">
+          {COACHING_COPY.emptyState}
+        </p>
+      ) : (
+        <CoachingList signals={signals} />
+      )}
+    </section>
+  )
+}
+
+export default CoachingPanel

--- a/src/canvas/components/coaching-panel/EntityTarget.tsx
+++ b/src/canvas/components/coaching-panel/EntityTarget.tsx
@@ -1,0 +1,50 @@
+/**
+ * EntityTarget — the entity-navigation cue for a coaching signal.
+ *
+ * Shape is the PRIMARY cue (NodeShapeIndicator, the codebase's shape-first
+ * identity channel); entity colour is SECONDARY outlined support on the label
+ * text only. Unknown/absent `target_kind` degrades to a neutral marker — never
+ * a raw technical string (UX amendment 3). No side borders, no light fills.
+ */
+import { typography } from '@/styles/typography'
+import type { NodeType } from '@/canvas/domain/nodes'
+import { NodeShapeIndicator } from '@/canvas/nodes/NodeShapeIndicator'
+import { KNOWN_ENTITY_KINDS, ENTITY_COLOUR } from './constants'
+
+interface EntityTargetProps {
+  targetKind?: string
+  /** Human label for the entity (user-facing). Only rendered when `showLabel`. */
+  label?: string
+  /** Show the label text beside the shape. Default false (shape-only, e.g. in row headers). */
+  showLabel?: boolean
+  className?: string
+}
+
+function isKnownKind(kind?: string): kind is NodeType {
+  return kind != null && (KNOWN_ENTITY_KINDS as readonly string[]).includes(kind)
+}
+
+export function EntityTarget({ targetKind, label, showLabel = false, className = '' }: EntityTargetProps) {
+  const known = isKnownKind(targetKind)
+  const labelColour = (targetKind && ENTITY_COLOUR[targetKind]) || 'text-text-body'
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+      {known ? (
+        <NodeShapeIndicator nodeKind={targetKind} size={12} />
+      ) : (
+        // Neutral marker for unknown/absent kind — a hollow dot (no entity
+        // fill, no technical string). Outlined, consistent with the DS ethos.
+        <span
+          className="inline-block h-2.5 w-2.5 rounded-full border border-text-light/50 bg-transparent"
+          aria-hidden="true"
+        />
+      )}
+      {showLabel && label && (
+        <span className={`${typography.panelMeta} ${labelColour}`}>{label}</span>
+      )}
+    </span>
+  )
+}
+
+export default EntityTarget

--- a/src/canvas/components/coaching-panel/StaleBanner.tsx
+++ b/src/canvas/components/coaching-panel/StaleBanner.tsx
@@ -1,0 +1,26 @@
+/**
+ * StaleBanner — panel-level "this coaching may be out of date" notice.
+ *
+ * FIXTURE-ONLY this phase. The UI never derives staleness (F.6); the banner is
+ * shown only when the panel is explicitly told to (a fixture/prop). When CEE
+ * provides a real staleness signal, this becomes a render of that field.
+ *
+ * DS: bg-panel + outlined warning border (never bg-warning-light); no side border.
+ */
+import { AlertTriangle } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { COACHING_COPY } from './constants'
+
+export function StaleBanner() {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md border border-warning/30 bg-panel px-3 py-2"
+      data-testid="coaching-stale-banner"
+    >
+      <AlertTriangle className="h-4 w-4 flex-none text-warning" aria-hidden="true" />
+      <span className={`${typography.panelBody} text-text-body`}>{COACHING_COPY.staleBanner}</span>
+    </div>
+  )
+}
+
+export default StaleBanner

--- a/src/canvas/components/coaching-panel/__fixtures__/coaching.fixtures.ts
+++ b/src/canvas/components/coaching-panel/__fixtures__/coaching.fixtures.ts
@@ -1,0 +1,449 @@
+/**
+ * Coaching panel fixtures — the render-only test/Storybook corpus.
+ *
+ * Typed `Coaching` objects exercising the full taxonomy: realistic/minimal,
+ * one-per-source, one-per-move, future-field-present, absent-optional,
+ * malformed/partial, safety (forbidden-term data + XSS-ish), and the F.6
+ * ordering trap. Enum values for move/source/target_kind are illustrative and
+ * UNCONFIRMED until Lane A lands; the UI must tolerate any of them.
+ *
+ * Observations are written free of the forbidden glossary terms EXCEPT the
+ * dedicated `forbiddenTermInLabel` fixture, which deliberately injects them
+ * into MODEL data to prove the UI renders model strings verbatim and never
+ * sanitises them.
+ */
+import type { Coaching } from '../types'
+
+// ── Realistic / minimal ────────────────────────────────────────────────────
+
+export const minimalSignal: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'sig-min-1',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: 'The retention estimate rests on a single quarter of data.' },
+    },
+  ],
+}
+
+export const typicalPanel: Coaching = {
+  version: '0.3',
+  summary: 'A few estimates are worth a second look before you analyse.',
+  signals: [
+    {
+      signal_id: 'sig-1',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: {
+        observation: 'The retention estimate rests on a single quarter of data.',
+        field_refs: ['ref:retention'],
+      },
+      target_kind: 'factor',
+      target_label: 'Customer retention',
+    },
+    {
+      signal_id: 'sig-2',
+      move: 'gather_evidence',
+      source: 'base_rate',
+      grounding: { observation: 'Similar launches usually take longer than first planned.' },
+      target_kind: 'option',
+      target_label: 'Launch in spring',
+    },
+    {
+      signal_id: 'sig-3',
+      move: 'reframe',
+      source: 'pattern',
+      grounding: { observation: 'The success measure mixes two outcomes that move apart over time.' },
+      target_kind: 'goal',
+      target_label: 'Grow active users',
+    },
+    {
+      signal_id: 'sig-4',
+      move: 'reconsider',
+      source: 'observation',
+      grounding: { observation: 'One supplier carries most of the delivery exposure.' },
+      target_kind: 'risk',
+      target_label: 'Supplier concentration',
+    },
+    {
+      signal_id: 'sig-5',
+      move: 'gather_evidence',
+      source: 'user_input',
+      grounding: { observation: 'The budget figure has not been revisited since the first draft.' },
+      target_kind: 'factor',
+      target_label: 'Marketing budget',
+    },
+  ],
+}
+
+// ── One per source (representative spread + unknown) ────────────────────────
+
+export const bySource: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'src-observation',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: 'This figure was entered by hand and has not changed since.' },
+    },
+    {
+      signal_id: 'src-base-rate',
+      move: 'gather_evidence',
+      source: 'base_rate',
+      grounding: { observation: 'Comparable efforts tend to land below this hopeful figure.' },
+    },
+    {
+      signal_id: 'src-pattern',
+      move: 'reframe',
+      source: 'pattern',
+      grounding: { observation: 'Two of your measures tend to pull in opposite directions.' },
+    },
+    {
+      signal_id: 'src-unknown',
+      move: 'reconsider',
+      source: 'some_new_source', // UNCONFIRMED enum — must render, never coerced.
+      grounding: { observation: 'A new kind of insight the UI has not seen before.' },
+    },
+  ],
+}
+
+// ── One per move (representative spread + unknown) ──────────────────────────
+
+export const byMove: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'move-check',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: 'Worth confirming this still holds.' },
+    },
+    {
+      signal_id: 'move-gather',
+      move: 'gather_evidence',
+      source: 'observation',
+      grounding: { observation: 'A little more data would firm this up.' },
+    },
+    {
+      signal_id: 'move-reframe',
+      move: 'reframe',
+      source: 'observation',
+      grounding: { observation: 'There may be a cleaner way to frame this.' },
+    },
+    {
+      signal_id: 'move-unknown',
+      move: 'frobnicate', // UNCONFIRMED enum — must render, never coerced.
+      source: 'observation',
+      grounding: { observation: 'An unfamiliar suggested move the UI tolerates.' },
+    },
+  ],
+}
+
+// ── Future-field-present ────────────────────────────────────────────────────
+
+export const withLifecycle: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'fut-lifecycle',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: 'This was flagged in an earlier pass.' },
+      target_kind: 'factor',
+      target_label: 'Churn rate',
+      lifecycle_state: 'Reopened',
+    },
+  ],
+}
+
+export const withPriority: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'fut-priority',
+      move: 'gather_evidence',
+      source: 'base_rate',
+      grounding: { observation: 'The headline figure looks optimistic against comparable cases.' },
+      priority: 1,
+      priority_reason: 'This estimate moves the result more than the others.',
+    },
+  ],
+}
+
+export const withSuggestedActions: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'fut-actions',
+      move: 'gather_evidence',
+      source: 'observation',
+      grounding: { observation: 'A quick check would settle the open question here.' },
+      suggested_actions: [
+        { id: 'a1', label: 'Pull last year of figures' },
+        { id: 'a2', label: 'Ask the finance team to confirm' },
+      ],
+    },
+  ],
+}
+
+export const withEvidence: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'fut-evidence',
+      move: 'check_assumption',
+      source: 'pattern',
+      grounding: { observation: 'Past results point the other way.' },
+      evidence: [
+        { label: 'Last three launches ran over time', ref: 'ev:1' },
+        { label: 'Industry survey, 2025', ref: 'ev:2' },
+      ],
+    },
+  ],
+}
+
+export const withStaleness: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'fut-staleness',
+      move: 'reconsider',
+      source: 'observation',
+      grounding: { observation: 'This was true earlier, but the figures have since moved.' },
+      staleness: { label: 'Based on figures from an earlier draft.' },
+    },
+  ],
+}
+
+export const withAllFuture: Coaching = {
+  version: '0.3',
+  summary: 'Every roadmap field at once, for visual tolerance.',
+  signals: [
+    {
+      signal_id: 'fut-all',
+      move: 'gather_evidence',
+      source: 'base_rate',
+      grounding: {
+        observation: 'The most influential estimate also has the least support behind it.',
+        field_refs: ['ref:influence', 'ref:support'],
+      },
+      target_kind: 'factor',
+      target_label: 'Conversion rate',
+      priority: 1,
+      priority_reason: 'It shifts the result more than anything else.',
+      lifecycle_state: 'New',
+      suggested_actions: [{ id: 'a1', label: 'Gather two more data points' }],
+      evidence: [{ label: 'Pilot cohort, small sample', ref: 'ev:pilot' }],
+      staleness: { label: 'From the first draft of figures.' },
+    },
+  ],
+}
+
+// ── Absent-optional ─────────────────────────────────────────────────────────
+
+export const noSummary: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'no-summary',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: 'No orientation summary on this envelope.' },
+      target_kind: 'factor',
+      target_label: 'Order value',
+    },
+  ],
+}
+
+export const noTargetKind: Coaching = {
+  version: '0.3',
+  summary: 'Signals without a target entity render with a neutral marker.',
+  signals: [
+    {
+      signal_id: 'no-target-kind',
+      move: 'reframe',
+      source: 'observation',
+      grounding: { observation: 'There is no entity attached to this one.' },
+    },
+  ],
+}
+
+export const noFutureFields: Coaching = {
+  version: '0.3',
+  summary: 'The live-shape baseline: required fields plus an entity label only.',
+  signals: [
+    {
+      signal_id: 'no-future-1',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: 'A plain signal with nothing optional set beyond its label.' },
+      target_kind: 'option',
+      target_label: 'Keep the current plan',
+    },
+    {
+      signal_id: 'no-future-2',
+      move: 'gather_evidence',
+      source: 'base_rate',
+      grounding: { observation: 'Another plain signal, no roadmap fields.' },
+      target_kind: 'goal',
+      target_label: 'Reduce wait times',
+    },
+  ],
+}
+
+// ── Malformed / partial (tolerance) ─────────────────────────────────────────
+
+export const missingGrounding: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'malformed-grounding',
+      move: 'check_assumption',
+      source: 'observation',
+      // Empty observation: the row must still render its header without throwing.
+      grounding: { observation: '' },
+      target_kind: 'factor',
+      target_label: 'A factor with no observation text',
+    },
+  ],
+}
+
+export const emptySignals: Coaching = {
+  version: '0.3',
+  summary: 'There is nothing to coach on yet.',
+  signals: [],
+}
+
+export const nullCoaching = null
+
+export const unknownTargetKind: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'unknown-kind',
+      move: 'reframe',
+      source: 'observation',
+      grounding: { observation: 'The target kind is something the UI does not recognise.' },
+      target_kind: 'mystery_kind', // UNCONFIRMED — degrades to neutral marker, no raw string shown.
+      target_label: 'Something unusual',
+    },
+  ],
+}
+
+const LONG = 'This observation is deliberately long so the collapsed row clamps it to a single line and the panel does not break its layout when the text runs well past a sensible width for a card.'
+
+export const veryLongStrings: Coaching = {
+  version: '0.3',
+  summary:
+    'A long orientation summary that should wrap gracefully across multiple lines without overflowing the panel or pushing other content out of view in any way.',
+  signals: [
+    {
+      signal_id: 'long-1',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: LONG },
+      target_kind: 'factor',
+      target_label: 'A target label that is itself quite long and descriptive for testing wrap behaviour',
+    },
+  ],
+}
+
+// ── Safety ──────────────────────────────────────────────────────────────────
+
+/**
+ * MODEL data containing forbidden glossary terms. The UI must render it
+ * VERBATIM (it never rewrites model strings — that is a CEE concern). The
+ * copyHygiene test scopes to UI-authored copy only and must NOT flag this.
+ */
+export const forbiddenTermInLabel: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'forbidden-1',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: {
+        observation: 'The edge between these two carries an unusually large coefficient weight.',
+      },
+      target_kind: 'factor',
+      target_label: 'the graph node',
+    },
+  ],
+}
+
+/** Strings that would be dangerous if interpreted as HTML. Must render as text. */
+export const xssish: Coaching = {
+  version: '0.3',
+  summary: '<script>alert(1)</script> stays as literal text.',
+  signals: [
+    {
+      signal_id: 'xss-1',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: '<img src=x onerror="alert(1)"> should appear as text.' },
+      target_kind: 'factor',
+      target_label: '<b>bold</b>',
+    },
+  ],
+}
+
+// ── F.6 ordering trap ────────────────────────────────────────────────────────
+
+/**
+ * priority values are 3, 1, 2 in ARRAY order. The UI must render rows in array
+ * order (priorityOutOfOrder-first, then -second, then -third) — proving it does
+ * not sort by priority. Render-not-compute test asserts the DOM order.
+ */
+export const priorityOutOfOrder: Coaching = {
+  version: '0.3',
+  signals: [
+    {
+      signal_id: 'order-first',
+      move: 'check_assumption',
+      source: 'observation',
+      grounding: { observation: 'First in the array, priority three.' },
+      priority: 3,
+    },
+    {
+      signal_id: 'order-second',
+      move: 'gather_evidence',
+      source: 'observation',
+      grounding: { observation: 'Second in the array, priority one.' },
+      priority: 1,
+    },
+    {
+      signal_id: 'order-third',
+      move: 'reframe',
+      source: 'observation',
+      grounding: { observation: 'Third in the array, priority two.' },
+      priority: 2,
+    },
+  ],
+}
+
+/** Named record so tests can iterate the whole corpus. `nullCoaching` excluded (it is not a Coaching). */
+export const coachingFixtures = {
+  minimalSignal,
+  typicalPanel,
+  bySource,
+  byMove,
+  withLifecycle,
+  withPriority,
+  withSuggestedActions,
+  withEvidence,
+  withStaleness,
+  withAllFuture,
+  noSummary,
+  noTargetKind,
+  noFutureFields,
+  missingGrounding,
+  emptySignals,
+  unknownTargetKind,
+  veryLongStrings,
+  forbiddenTermInLabel,
+  xssish,
+  priorityOutOfOrder,
+} satisfies Record<string, Coaching>

--- a/src/canvas/components/coaching-panel/__tests__/a11y.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/a11y.spec.tsx
@@ -1,0 +1,50 @@
+/**
+ * Accessibility — no axe violations across key visual states; role/name checks.
+ *
+ * color-contrast is disabled (consistent with the repo's a11y suites): the
+ * entity colours and primary/info hit the known DS contrast landmine, which is
+ * a flagged token-level issue, not a panel defect.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe, configureAxe } from 'vitest-axe'
+import { CoachingPanel } from '../CoachingPanel'
+import { typicalPanel, withAllFuture, emptySignals } from '../__fixtures__/coaching.fixtures'
+
+configureAxe({ rules: { 'color-contrast': { enabled: false } } })
+
+async function expectNoViolations(container: HTMLElement) {
+  const results = await axe(container)
+  expect(results.violations).toEqual([])
+}
+
+describe('CoachingPanel accessibility', () => {
+  it('has no violations when collapsed', async () => {
+    const { container } = render(<CoachingPanel coaching={typicalPanel} />)
+    await expectNoViolations(container)
+  })
+
+  it('has no violations with a row expanded', async () => {
+    const { container } = render(<CoachingPanel coaching={typicalPanel} />)
+    fireEvent.click(screen.getByRole('button', { name: /retention estimate rests/i }))
+    await expectNoViolations(container)
+  })
+
+  it('has no violations with all future fields shown', async () => {
+    const { container } = render(<CoachingPanel coaching={withAllFuture} showStaleBanner />)
+    fireEvent.click(screen.getByRole('button', { name: /most influential estimate/i }))
+    await expectNoViolations(container)
+  })
+
+  it('has no violations in the empty state', async () => {
+    const { container } = render(<CoachingPanel coaching={emptySignals} />)
+    await expectNoViolations(container)
+  })
+
+  it('names the panel region and the icon-only Ask Olumi affordance', () => {
+    render(<CoachingPanel coaching={typicalPanel} />)
+    expect(screen.getByRole('region', { name: 'Coaching' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /retention estimate rests/i }))
+    expect(screen.getByRole('button', { name: 'Ask Olumi' })).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/coaching-panel/__tests__/content.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/content.spec.tsx
@@ -1,0 +1,67 @@
+/**
+ * Content — the panel renders the data it is given (and only that).
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CoachingPanel } from '../CoachingPanel'
+import {
+  typicalPanel,
+  noSummary,
+  noFutureFields,
+  withAllFuture,
+  withPriority,
+} from '../__fixtures__/coaching.fixtures'
+
+describe('CoachingPanel content', () => {
+  it('renders the orientation summary line when present', () => {
+    render(<CoachingPanel coaching={typicalPanel} />)
+    expect(screen.getByTestId('coaching-summary')).toHaveTextContent(typicalPanel.summary!)
+  })
+
+  it('omits the summary line when absent (no synthesised line)', () => {
+    render(<CoachingPanel coaching={noSummary} />)
+    expect(screen.queryByTestId('coaching-summary')).toBeNull()
+  })
+
+  it('renders each visible signal observation as the primary line', () => {
+    render(<CoachingPanel coaching={noFutureFields} />)
+    expect(
+      screen.getByText('A plain signal with nothing optional set beyond its label.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Another plain signal, no roadmap fields.')).toBeInTheDocument()
+  })
+
+  it('shows the target entity label only when a row is expanded', () => {
+    render(<CoachingPanel coaching={noFutureFields} />)
+    // Collapsed: label not shown (clean rows; shape is the row-level cue).
+    expect(screen.queryByText('Keep the current plan')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /a plain signal with nothing optional/i }))
+    expect(screen.getByText('Keep the current plan')).toBeInTheDocument()
+  })
+
+  it('renders future fields verbatim when present (after expand)', () => {
+    render(<CoachingPanel coaching={withAllFuture} />)
+    fireEvent.click(screen.getByRole('button', { name: /most influential estimate/i }))
+    expect(screen.getByText('New')).toBeInTheDocument()
+    expect(screen.getByText('It shifts the result more than anything else.')).toBeInTheDocument()
+    expect(screen.getByText('Gather two more data points')).toBeInTheDocument()
+    expect(screen.getByText('Pilot cohort, small sample')).toBeInTheDocument()
+    expect(screen.getByText('From the first draft of figures.')).toBeInTheDocument()
+  })
+
+  it('does not render a bare numeric priority as prose (kept on a data attribute)', () => {
+    render(<CoachingPanel coaching={withPriority} />)
+    fireEvent.click(screen.getByRole('button', { name: /headline figure looks optimistic/i }))
+    // The human reason is shown; the raw number is not surfaced as copy.
+    expect(
+      screen.getByText('This estimate moves the result more than the others.'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('coaching-future-fields')).toHaveAttribute('data-priority', '1')
+  })
+
+  it('omits the future-fields block entirely when no roadmap fields are present', () => {
+    render(<CoachingPanel coaching={noFutureFields} />)
+    fireEvent.click(screen.getByRole('button', { name: /a plain signal with nothing optional/i }))
+    expect(screen.queryByTestId('coaching-future-fields')).toBeNull()
+  })
+})

--- a/src/canvas/components/coaching-panel/__tests__/copyHygiene.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/copyHygiene.spec.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copy hygiene — UI-authored copy only.
+ *
+ * Scans the panel's own copy (COACHING_COPY) for the forbidden glossary terms,
+ * all-caps, and em dashes. It deliberately does NOT scan model-supplied strings:
+ * those are data the UI renders verbatim (proven by the render check below and
+ * the safety suite). This is the boundary — glossary correction of model output
+ * is a CEE/mapper concern, never the renderer's (F.6 / UX amendment 3).
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CoachingPanel } from '../CoachingPanel'
+import { COACHING_COPY } from '../constants'
+import { forbiddenTermInLabel } from '../__fixtures__/coaching.fixtures'
+
+const FORBIDDEN = ['node', 'edge', 'graph', 'coefficient', 'weight', 'evpi', 'winner', 'recommended']
+
+// All user-facing UI-authored strings, including the dynamic reveal labels.
+const UI_COPY: string[] = [
+  COACHING_COPY.panelAria,
+  COACHING_COPY.emptyState,
+  COACHING_COPY.showFewer,
+  COACHING_COPY.askOlumi,
+  COACHING_COPY.itemFallback,
+  COACHING_COPY.staleBanner,
+  COACHING_COPY.showMore(2),
+  COACHING_COPY.showAll(5),
+]
+
+describe('CoachingPanel copy hygiene (UI copy only)', () => {
+  it.each(FORBIDDEN)('contains no forbidden term: %s', (term) => {
+    const re = new RegExp(`\\b${term}\\b`, 'i')
+    for (const copy of UI_COPY) {
+      expect(copy, `"${copy}" should not contain "${term}"`).not.toMatch(re)
+    }
+  })
+
+  it('uses no all-caps words and no em dashes (sentence case, British English)', () => {
+    for (const copy of UI_COPY) {
+      expect(copy).not.toMatch(/\b[A-Z]{2,}\b/) // no SHOUTED words
+      expect(copy).not.toContain('—') // no em dash
+    }
+  })
+
+  it('renders model data containing forbidden terms verbatim (hygiene scopes to UI copy only)', () => {
+    render(<CoachingPanel coaching={forbiddenTermInLabel} />)
+    fireEvent.click(screen.getByRole('button', { name: /large coefficient weight/i }))
+    expect(screen.getByText('the graph node')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/coaching-panel/__tests__/fixtures.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/fixtures.spec.tsx
@@ -1,0 +1,26 @@
+/**
+ * Fixture coverage — every fixture in the corpus renders and is axe-clean.
+ * A cheap guard that the whole taxonomy stays valid as the panel evolves.
+ */
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { axe, configureAxe } from 'vitest-axe'
+import { CoachingPanel } from '../CoachingPanel'
+import { coachingFixtures } from '../__fixtures__/coaching.fixtures'
+
+configureAxe({ rules: { 'color-contrast': { enabled: false } } })
+
+const entries = Object.entries(coachingFixtures)
+
+describe('CoachingPanel fixture corpus', () => {
+  it.each(entries)('renders %s without throwing', (_name, fixture) => {
+    const { getByTestId } = render(<CoachingPanel coaching={fixture} />)
+    expect(getByTestId('coaching-panel')).toBeInTheDocument()
+  })
+
+  it.each(entries)('has no axe violations for %s', async (_name, fixture) => {
+    const { container } = render(<CoachingPanel coaching={fixture} />)
+    const results = await axe(container)
+    expect(results.violations).toEqual([])
+  })
+})

--- a/src/canvas/components/coaching-panel/__tests__/interaction.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/interaction.spec.tsx
@@ -1,0 +1,77 @@
+/**
+ * Interaction — expand/collapse exclusivity, show all/fewer, button semantics.
+ * View-state only; no data is computed.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CoachingPanel } from '../CoachingPanel'
+import { typicalPanel, noFutureFields } from '../__fixtures__/coaching.fixtures'
+
+const rowA = /retention estimate rests/i
+const rowB = /usually take longer/i
+
+describe('CoachingPanel interaction', () => {
+  it('expands a row to reveal its coaching moment', () => {
+    render(<CoachingPanel coaching={typicalPanel} />)
+    const a = screen.getByRole('button', { name: rowA })
+    expect(a).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(a)
+    expect(a).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getAllByTestId('coaching-card-body')).toHaveLength(1)
+  })
+
+  it('keeps only one row open at a time', () => {
+    render(<CoachingPanel coaching={typicalPanel} />)
+    const a = screen.getByRole('button', { name: rowA })
+    const b = screen.getByRole('button', { name: rowB })
+    fireEvent.click(a)
+    expect(a).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(b)
+    expect(b).toHaveAttribute('aria-expanded', 'true')
+    expect(a).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getAllByTestId('coaching-card-body')).toHaveLength(1)
+  })
+
+  it('toggles the same row closed on a second activation', () => {
+    render(<CoachingPanel coaching={typicalPanel} />)
+    const a = screen.getByRole('button', { name: rowA })
+    fireEvent.click(a)
+    fireEvent.click(a)
+    expect(a).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('coaching-card-body')).toBeNull()
+  })
+
+  it('reveals all rows and collapses back to the default set', () => {
+    render(<CoachingPanel coaching={typicalPanel} />) // 5 signals, default visible 3
+    expect(screen.getAllByTestId('coaching-card')).toHaveLength(3)
+    expect(screen.queryByText('One supplier carries most of the delivery exposure.')).toBeNull()
+
+    const reveal = screen.getByTestId('coaching-reveal')
+    expect(reveal).toHaveTextContent('Show all 5')
+    fireEvent.click(reveal)
+    expect(screen.getAllByTestId('coaching-card')).toHaveLength(5)
+    expect(
+      screen.getByText('One supplier carries most of the delivery exposure.'),
+    ).toBeInTheDocument()
+    expect(reveal).toHaveTextContent('Show fewer')
+
+    fireEvent.click(reveal)
+    expect(screen.getAllByTestId('coaching-card')).toHaveLength(3)
+  })
+
+  it('does not show a reveal control when all signals fit the default set', () => {
+    render(<CoachingPanel coaching={noFutureFields} />) // 2 signals
+    expect(screen.queryByTestId('coaching-reveal')).toBeNull()
+  })
+
+  it('exposes native button semantics for full keyboard operation', () => {
+    render(<CoachingPanel coaching={typicalPanel} />)
+    // Row headers + the reveal control are all native, enabled buttons —
+    // keyboard-operable (Tab focus, Enter/Space activate) by construction.
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.length).toBeGreaterThanOrEqual(4) // 3 rows + reveal
+    buttons.forEach((b) => expect(b).not.toBeDisabled())
+    // The reveal control carries disclosure state.
+    expect(screen.getByTestId('coaching-reveal')).toHaveAttribute('aria-expanded', 'false')
+  })
+})

--- a/src/canvas/components/coaching-panel/__tests__/renderNotCompute.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/renderNotCompute.spec.tsx
@@ -1,0 +1,36 @@
+/**
+ * Render, do not compute (invariant F.6).
+ *
+ * The panel must render signals in the order received and must not rank by
+ * priority, select which signals matter, or transition lifecycle. These tests
+ * are the guardrail against accidentally introducing CEE-owned logic.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CoachingPanel } from '../CoachingPanel'
+import { priorityOutOfOrder, typicalPanel, withLifecycle } from '../__fixtures__/coaching.fixtures'
+
+describe('CoachingPanel F.6 — render, do not compute', () => {
+  it('renders rows in received array order, never sorted by priority', () => {
+    render(<CoachingPanel coaching={priorityOutOfOrder} />)
+    const ids = screen
+      .getAllByTestId('coaching-card')
+      .map((el) => el.getAttribute('data-signal-id'))
+    // Array order is 3,1,2 by priority — DOM must follow the array, not priority.
+    expect(ids).toEqual(['order-first', 'order-second', 'order-third'])
+  })
+
+  it('renders every received signal (no selection/filtering) once revealed', () => {
+    render(<CoachingPanel coaching={typicalPanel} />)
+    fireEvent.click(screen.getByTestId('coaching-reveal'))
+    expect(screen.getAllByTestId('coaching-card')).toHaveLength(typicalPanel.signals.length)
+  })
+
+  it('renders lifecycle state verbatim with no value-driven hiding or de-emphasis', () => {
+    render(<CoachingPanel coaching={withLifecycle} />)
+    const card = screen.getByTestId('coaching-card')
+    expect(card).toBeInTheDocument() // not hidden because it is "Reopened"
+    fireEvent.click(card.querySelector('button')!)
+    expect(screen.getByTestId('coaching-lifecycle')).toHaveTextContent('Reopened')
+  })
+})

--- a/src/canvas/components/coaching-panel/__tests__/safety.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/safety.spec.tsx
@@ -1,0 +1,31 @@
+/**
+ * Safety — model-supplied strings are rendered as TEXT, never HTML.
+ *
+ * Proves there is no `dangerouslySetInnerHTML` path: HTML-looking strings appear
+ * verbatim and no corresponding elements are parsed into the DOM. Also proves
+ * the UI renders model data containing forbidden glossary terms verbatim (it
+ * never sanitises or rewrites model strings — that is a CEE concern).
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CoachingPanel } from '../CoachingPanel'
+import { xssish, forbiddenTermInLabel } from '../__fixtures__/coaching.fixtures'
+
+describe('CoachingPanel render-as-text safety', () => {
+  it('renders HTML-looking strings as literal text, parsing no elements', () => {
+    const { container } = render(<CoachingPanel coaching={xssish} />)
+    expect(screen.getByText(/should appear as text/)).toBeInTheDocument()
+    expect(screen.getByText(/stays as literal text/)).toBeInTheDocument()
+    // No injected elements from the model strings.
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('renders model data containing forbidden terms verbatim (no sanitisation)', () => {
+    render(<CoachingPanel coaching={forbiddenTermInLabel} />)
+    const header = screen.getByRole('button', { name: /large coefficient weight/i })
+    expect(header).toBeInTheDocument()
+    fireEvent.click(header)
+    expect(screen.getByText('the graph node')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/coaching-panel/__tests__/tolerance.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/tolerance.spec.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tolerance — malformed / partial / absent data degrades safely, never throws.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CoachingPanel } from '../CoachingPanel'
+import {
+  missingGrounding,
+  emptySignals,
+  unknownTargetKind,
+  veryLongStrings,
+} from '../__fixtures__/coaching.fixtures'
+
+describe('CoachingPanel tolerance', () => {
+  it('renders a row with empty grounding without throwing', () => {
+    render(<CoachingPanel coaching={missingGrounding} />)
+    const card = screen.getByTestId('coaching-card')
+    expect(card).toBeInTheDocument()
+    // Header is still operable; expanding does not throw.
+    fireEvent.click(card.querySelector('button')!)
+    expect(screen.getByTestId('coaching-card-body')).toBeInTheDocument()
+  })
+
+  it('shows the neutral empty state for an empty signal list', () => {
+    render(<CoachingPanel coaching={emptySignals} />)
+    expect(screen.getByTestId('coaching-empty')).toHaveTextContent('No coaching to show yet.')
+    expect(screen.queryByTestId('coaching-list')).toBeNull()
+  })
+
+  it('shows the empty state for null coaching', () => {
+    render(<CoachingPanel coaching={null} />)
+    expect(screen.getByTestId('coaching-empty')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when no coaching prop is provided', () => {
+    render(<CoachingPanel />)
+    expect(screen.getByTestId('coaching-empty')).toBeInTheDocument()
+  })
+
+  it('degrades an unknown target kind to a neutral marker, never a raw string', () => {
+    render(<CoachingPanel coaching={unknownTargetKind} />)
+    expect(screen.getByTestId('coaching-card')).toBeInTheDocument()
+    expect(screen.queryByText('mystery_kind')).toBeNull()
+  })
+
+  it('renders very long strings without a reveal control (single signal)', () => {
+    render(<CoachingPanel coaching={veryLongStrings} />)
+    expect(screen.getByTestId('coaching-summary')).toBeInTheDocument()
+    expect(screen.getByTestId('coaching-card')).toBeInTheDocument()
+    expect(screen.queryByTestId('coaching-reveal')).toBeNull()
+  })
+})

--- a/src/canvas/components/coaching-panel/constants.ts
+++ b/src/canvas/components/coaching-panel/constants.ts
@@ -1,0 +1,63 @@
+/**
+ * Coaching panel — UI-authored copy + display lookups.
+ *
+ * Everything here is sentence case, British English, no all-caps, no em dashes,
+ * and free of the forbidden glossary terms (node, edge, graph, coefficient,
+ * weight, EVPI, winner, recommended). The copyHygiene test enforces this over
+ * THIS object only — model-supplied strings are rendered verbatim and are never
+ * scanned or rewritten by the UI (F.6 / UX amendment 3).
+ */
+import type { NodeType } from '@/canvas/domain/nodes'
+
+/** Rows shown before the "show all / fewer" reveal. Display chunking, not selection. */
+export const COACHING_DEFAULT_VISIBLE = 3
+
+export const COACHING_COPY = {
+  /** Region accessible name. */
+  panelAria: 'Coaching',
+  /** Shown when there are no signals (absence of data, not a computed judgement). */
+  emptyState: 'No coaching to show yet.',
+  /** Reveal-toggle copy. `showMore` is reserved for a future paged variant. */
+  showMore: (n: number) => `Show ${n} more`,
+  showAll: (n: number) => `Show all ${n}`,
+  showFewer: 'Show fewer',
+  /** Icon-only, display-only affordance label. */
+  askOlumi: 'Ask Olumi',
+  /**
+   * Generic accessible name for a row whose observation is empty — an
+   * operability affordance, not an invented title (it asserts no meaning).
+   */
+  itemFallback: 'Coaching item',
+  /** Panel-level stale banner. Fixture-only until CEE provides a staleness signal. */
+  staleBanner: 'This coaching may be out of date.',
+} as const
+
+/**
+ * Known entity kinds (mirrors the canvas `NodeType` set). Used only to decide
+ * whether to render the entity shape; unknown values fall through to neutral.
+ */
+export const KNOWN_ENTITY_KINDS: readonly NodeType[] = [
+  'goal',
+  'decision',
+  'option',
+  'factor',
+  'risk',
+  'outcome',
+  'action',
+  'constraint',
+]
+
+/**
+ * target_kind → secondary entity colour token for the label text. Static display
+ * lookup ONLY — colour is keyed to entity kind, never inferred from observation
+ * text or sentiment (F.6). Shape is the primary cue; this is secondary support.
+ * Kinds not listed render in neutral body text.
+ */
+export const ENTITY_COLOUR: Record<string, string> = {
+  goal: 'text-goal',
+  option: 'text-option',
+  factor: 'text-factor',
+  risk: 'text-danger',
+  outcome: 'text-success',
+  decision: 'text-info',
+}

--- a/src/canvas/components/coaching-panel/focus-now/FocusBanner.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusBanner.tsx
@@ -1,0 +1,68 @@
+/**
+ * FocusBanner — the single panel-level freshness banner.
+ *
+ * Renders the freshness verdict it is GIVEN (the UI never derives staleness, F.6).
+ * Three states, DS-correct (outlined `bg-panel`, never a soft `bg-warning-light`
+ * fill):
+ *   - 'stale'         → outlined warning + a short "Re-run" affordance.
+ *   - 'cannot_confirm'→ NEUTRAL note, no warning colour, no re-run-as-stale.
+ *   - 'none'          → renders nothing.
+ *
+ * Prop-driven and store-free: the re-run is an injected callback; the button is
+ * disabled while a run is in flight.
+ */
+import { AlertTriangle, Info } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { FOCUS_COPY } from './focusConstants'
+import type { FocusBannerState } from './focusTypes'
+
+interface FocusBannerProps {
+  state: FocusBannerState
+  onRerun?: () => void
+  rerunDisabled?: boolean
+}
+
+export function FocusBanner({ state, onRerun, rerunDisabled = false }: FocusBannerProps) {
+  if (state.kind === 'none') return null
+
+  if (state.kind === 'cannot_confirm') {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-md border border-panel-border bg-panel px-3 py-2"
+        data-testid="focus-banner"
+        data-banner="cannot_confirm"
+      >
+        <Info className="h-4 w-4 flex-none text-text-light" aria-hidden="true" />
+        <span className={`${typography.panelBody} min-w-0 text-text-light`}>
+          {FOCUS_COPY.cannotConfirmText}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md border border-warning/30 bg-panel px-3 py-2"
+      data-testid="focus-banner"
+      data-banner="stale"
+    >
+      <AlertTriangle className="h-4 w-4 flex-none text-warning" aria-hidden="true" />
+      <span className={`${typography.panelBody} min-w-0 flex-1 text-text-body`}>
+        {FOCUS_COPY.staleText}
+      </span>
+      {onRerun && (
+        <button
+          type="button"
+          onClick={onRerun}
+          disabled={rerunDisabled}
+          data-testid="focus-rerun"
+          className="ml-auto flex-none whitespace-nowrap rounded-full bg-primary px-3 py-1 text-text-on-color outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-info disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <span className={typography.panelMeta}>{FOCUS_COPY.rerunLabel}</span>
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default FocusBanner

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowContainer.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowContainer.tsx
@@ -17,7 +17,10 @@ import { useFocusNow } from './useFocusNow'
 
 export function FocusNowContainer({ className }: { className?: string }) {
   const props = useFocusNow()
-  return <FocusNowPanel {...props} className={className} />
+  // The Analysis tab already renders AnalysisFreshnessNotice as the freshness
+  // surface, so the panel suppresses its OWN stale banner here to avoid a
+  // duplicate stale notice (different wording) on the same trust surface.
+  return <FocusNowPanel {...props} showFreshnessBanner={false} className={className} />
 }
 
 export default FocusNowContainer

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowContainer.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowContainer.tsx
@@ -1,0 +1,23 @@
+/**
+ * FocusNowContainer — the ONE authorized live mount of the Focus Now panel.
+ *
+ * Wires the store-aware `useFocusNow` hook to the presentational `FocusNowPanel`.
+ * It is mounted as the SECOND Analysis-tab panel (immediately after the hero) by
+ * `src/components/results/ResultsBody.tsx` — the single importer the inertness
+ * guard allow-lists. Any other external import is still a guard violation.
+ *
+ * Behaviour stays static / fail-closed: `coaching_summary` is gated off
+ * (CERTIFY_SUMMARY=false), there are no server/dynamic coaching rows, no readiness
+ * rows, no `bias_findings`, and no UI-authored analytical claims. Mounting it adds
+ * only the six generic static hygiene rows + the certified freshness banner +
+ * prefill-only actions.
+ */
+import { FocusNowPanel } from './FocusNowPanel'
+import { useFocusNow } from './useFocusNow'
+
+export function FocusNowContainer({ className }: { className?: string }) {
+  const props = useFocusNow()
+  return <FocusNowPanel {...props} className={className} />
+}
+
+export default FocusNowContainer

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowEmpty.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowEmpty.tsx
@@ -1,0 +1,20 @@
+/**
+ * FocusNowEmpty — honest, non-theatrical empty state.
+ *
+ * Because the static hygiene rows are always available, the live panel is
+ * effectively never empty today; this shows only when a caller suppresses the
+ * static rows and no server rows exist, or defensively when malformed input
+ * collapses everything. Sparse-but-true: a calm line, no judgement, no theatrics.
+ */
+import { typography } from '@/styles/typography'
+import { FOCUS_COPY } from './focusConstants'
+
+export function FocusNowEmpty() {
+  return (
+    <p className={`${typography.panelBody} text-text-light`} data-testid="focus-empty">
+      {FOCUS_COPY.emptyState}
+    </p>
+  )
+}
+
+export default FocusNowEmpty

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.stories.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.stories.tsx
@@ -1,0 +1,91 @@
+/**
+ * Focus Now — Storybook stories (CSF3).
+ *
+ * Render-only surface, exercised with explicit props (no store). The a11y addon
+ * runs against each story. Rows expand on click (one open at a time). The summary
+ * stories carry SERVER prose (uncertified) only to exercise verbatim render +
+ * tolerance — the live container gates real `coaching_summary` display off.
+ */
+import React from 'react'
+import { FocusNowPanel } from './FocusNowPanel'
+import { buildFocusRows } from './buildFocusRows'
+import {
+  serverRow,
+  forbiddenSummary,
+  longSummary,
+} from './__fixtures__/focus.fixtures'
+import type { FocusNowProps } from './focusTypes'
+
+export default {
+  title: 'Canvas/Focus Now',
+  parameters: {
+    layout: 'padded',
+    backgrounds: { default: 'canvas' },
+  },
+}
+
+/** Mimics the dock panel width + warm canvas behind the card. */
+function PanelWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        width: 380,
+        maxHeight: '90vh',
+        overflow: 'auto',
+        background: 'var(--bg-canvas, #F4F0EA)',
+        padding: 16,
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const staticRows = buildFocusRows({}).rows
+const noop = () => {}
+const base: FocusNowProps = {
+  summary: null,
+  rows: staticRows,
+  banner: { kind: 'none' },
+  onPrefill: noop,
+  onRerun: noop,
+  rerunDisabled: false,
+}
+
+type Story = (() => React.ReactElement) & { storyName?: string }
+
+const story =
+  (overrides: Partial<FocusNowProps>): Story =>
+  () => (
+    <PanelWrapper>
+      <FocusNowPanel {...base} {...overrides} />
+    </PanelWrapper>
+  )
+
+export const StaticOnly = story({})
+StaticOnly.storyName = 'Static hygiene rows'
+
+export const StaticPlusSummary = story({ summary: 'Here is where things stand on this decision so far.' })
+StaticPlusSummary.storyName = 'Static rows + summary line'
+
+export const StaleBanner = story({ banner: { kind: 'stale', canRerun: true } })
+StaleBanner.storyName = 'Stale banner (+ re-run)'
+
+export const CannotConfirm = story({ banner: { kind: 'cannot_confirm' } })
+CannotConfirm.storyName = 'Cannot-confirm banner (neutral)'
+
+export const ServerRow = story({ rows: [serverRow, ...staticRows] })
+ServerRow.storyName = 'Server row above static (expand it)'
+
+export const ShowMore = story({ rows: [serverRow, ...staticRows] })
+ShowMore.storyName = 'Show more / fewer (7 rows)'
+
+export const Empty = story({ rows: [] })
+Empty.storyName = 'Honest empty state'
+
+export const LongStrings = story({ summary: longSummary, rows: [serverRow, ...staticRows] })
+LongStrings.storyName = 'Long strings (clamp + wrap)'
+
+export const ForbiddenTermData = story({ summary: forbiddenSummary })
+ForbiddenTermData.storyName = 'Forbidden-term server prose (verbatim)'

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
@@ -1,0 +1,113 @@
+/**
+ * FocusNowPanel — the "Focus now" coaching surface (render-only).
+ *
+ * Pure presentational and store-free: it renders the rows + freshness banner it is
+ * GIVEN and owns no data, no network, no storage, and no feature flag. A thin
+ * container (`useFocusNow`) supplies live props at mount time; here, props come
+ * from fixtures/stories/tests.
+ *
+ * Layout: one calm outer card (prototype-aligned) containing the header, the
+ * single panel-level freshness banner, an optional verbatim summary line, and the
+ * rows. One row opens at a time; "show all / fewer" is a positional slice (never a
+ * filter or sort by meaning, F.6). An honest empty state shows when there are no
+ * rows. All strings render as TEXT — never HTML.
+ *
+ * Claim-safety: `summary` is uncertified CEE prose; the live container gates its
+ * display (see useFocusNow). Gated rows are dropped defensively before render.
+ */
+import { useState } from 'react'
+import { typography, typo } from '@/styles/typography'
+import { FocusBanner } from './FocusBanner'
+import { FocusRowCard } from './FocusRowCard'
+import { FocusNowEmpty } from './FocusNowEmpty'
+import { dropGatedRows } from './buildFocusRows'
+import { FOCUS_COPY, FOCUS_DEFAULT_VISIBLE } from './focusConstants'
+import type { FocusNowProps, FocusRow } from './focusTypes'
+
+export function FocusNowPanel({
+  summary,
+  rows,
+  banner,
+  onPrefill,
+  onRerun,
+  rerunDisabled = false,
+  className = '',
+}: FocusNowProps) {
+  const [openId, setOpenId] = useState<string | null>(null)
+  const [revealed, setRevealed] = useState(false)
+
+  // Defensive: never render a gated row, even if a caller passes one in.
+  const safeRows = dropGatedRows(rows ?? [])
+  const visible = revealed ? safeRows : safeRows.slice(0, FOCUS_DEFAULT_VISIBLE)
+  const hiddenCount = safeRows.length - FOCUS_DEFAULT_VISIBLE
+
+  const handleTry = (row: FocusRow) => {
+    if (row.action?.kind === 'prefill' && row.action.prefillText) onPrefill?.(row.action.prefillText)
+  }
+
+  return (
+    <section
+      aria-label={FOCUS_COPY.panelAria}
+      data-testid="focus-now-panel"
+      className={`overflow-hidden rounded-2xl border border-panel-border bg-panel shadow-sm ${className}`}
+    >
+      <div className="px-3.5 pb-2 pt-3">
+        <h2 className={`${typography.panelHeader} text-text-header`}>{FOCUS_COPY.header}</h2>
+      </div>
+
+      {banner.kind !== 'none' && (
+        <div className="px-3.5 pb-2">
+          <FocusBanner state={banner} onRerun={onRerun} rerunDisabled={rerunDisabled} />
+        </div>
+      )}
+
+      {summary && (
+        <div className="px-3.5 pb-2">
+          <p className={`${typography.panelBody} text-text-body`} data-testid="focus-summary">
+            {summary}
+          </p>
+        </div>
+      )}
+
+      {safeRows.length === 0 ? (
+        <div className="px-3.5 pb-3">
+          <FocusNowEmpty />
+        </div>
+      ) : (
+        <>
+          <ul className="m-0 list-none p-0">
+            {visible.map((row) => (
+              <li key={row.id} className="border-t border-panel-border first:border-t-0">
+                <FocusRowCard
+                  row={row}
+                  isOpen={openId === row.id}
+                  onToggle={() => setOpenId((prev) => (prev === row.id ? null : row.id))}
+                  onTryAction={handleTry}
+                />
+              </li>
+            ))}
+          </ul>
+
+          {hiddenCount > 0 && (
+            <div className="px-3.5 pb-3 pt-2">
+              <button
+                type="button"
+                aria-expanded={revealed}
+                onClick={() => setRevealed((v) => !v)}
+                data-testid="focus-reveal"
+                className={typo(
+                  'panelMeta',
+                  'rounded text-text-light outline-none transition-colors hover:text-text-header focus-visible:text-text-header focus-visible:ring-2 focus-visible:ring-info/40',
+                )}
+              >
+                {revealed ? FOCUS_COPY.showFewer : FOCUS_COPY.showAll(safeRows.length)}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+export default FocusNowPanel

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
@@ -15,7 +15,7 @@
  * Claim-safety: `summary` is uncertified CEE prose; the live container gates its
  * display (see useFocusNow). Gated rows are dropped defensively before render.
  */
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { typography, typo } from '@/styles/typography'
 import { FocusBanner } from './FocusBanner'
 import { FocusRowCard } from './FocusRowCard'
@@ -35,6 +35,7 @@ export function FocusNowPanel({
 }: FocusNowProps) {
   const [openId, setOpenId] = useState<string | null>(null)
   const [revealed, setRevealed] = useState(false)
+  const listId = useId()
 
   // Defensive: never render a gated row, even if a caller passes one in.
   const safeRows = dropGatedRows(rows ?? [])
@@ -75,7 +76,7 @@ export function FocusNowPanel({
         </div>
       ) : (
         <>
-          <ul className="m-0 list-none p-0">
+          <ul id={listId} className="m-0 list-none p-0">
             {visible.map((row) => (
               <li key={row.id} className="border-t border-panel-border first:border-t-0">
                 <FocusRowCard
@@ -93,6 +94,7 @@ export function FocusNowPanel({
               <button
                 type="button"
                 aria-expanded={revealed}
+                aria-controls={listId}
                 onClick={() => setRevealed((v) => !v)}
                 data-testid="focus-reveal"
                 className={typo(

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
@@ -31,6 +31,7 @@ export function FocusNowPanel({
   onPrefill,
   onRerun,
   rerunDisabled = false,
+  showFreshnessBanner = true,
   className = '',
 }: FocusNowProps) {
   const [openId, setOpenId] = useState<string | null>(null)
@@ -56,7 +57,7 @@ export function FocusNowPanel({
         <h2 className={`${typography.panelHeader} text-text-header`}>{FOCUS_COPY.header}</h2>
       </div>
 
-      {banner.kind !== 'none' && (
+      {showFreshnessBanner && banner.kind !== 'none' && (
         <div className="px-3.5 pb-2">
           <FocusBanner state={banner} onRerun={onRerun} rerunDisabled={rerunDisabled} />
         </div>

--- a/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
@@ -1,0 +1,168 @@
+/**
+ * FocusRowCard — one Focus Now coaching row.
+ *
+ * Collapsed: a neutral topical icon (static rows) or the entity shape cue (server
+ * rows that reference a real entity) + the primary line, clamped to one line.
+ * Expanded: "what Olumi noticed" (server rows only — a static row never claims
+ * detection), "why it matters", a "Try this" nudge, then one safe action plus the
+ * display-only "Ask Olumi" affordance.
+ *
+ * Accessibility scaffold replicated from CoachingActionCard (a11y-proven): the
+ * header is a native button carrying aria-expanded + aria-controls, named by the
+ * primary line; the expanded region is mounted only when open and labelled by the
+ * primary line. Controlled by the parent so the list keeps one row open at a time.
+ *
+ * The action is DISPLAY/PREFILL-ONLY: the card never touches a store or sends —
+ * it calls the injected `onTryAction`. "Ask Olumi" has no handler this phase.
+ */
+import { useId, type CSSProperties } from 'react'
+import {
+  ChevronRight,
+  ChevronDown,
+  Sparkles,
+  Target,
+  Clock,
+  Flag,
+  ShieldAlert,
+  Scale,
+  Lightbulb,
+  type LucideIcon,
+} from 'lucide-react'
+import { typography } from '@/styles/typography'
+import Tooltip from '@/components/Tooltip'
+import { EntityTarget } from '../EntityTarget'
+import { FOCUS_COPY } from './focusConstants'
+import type { FocusRow } from './focusTypes'
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  target: Target,
+  clock: Clock,
+  flag: Flag,
+  'shield-alert': ShieldAlert,
+  scale: Scale,
+  lightbulb: Lightbulb,
+}
+
+interface FocusRowCardProps {
+  row: FocusRow
+  isOpen: boolean
+  onToggle: () => void
+  onTryAction?: (row: FocusRow) => void
+}
+
+function RowMarker({ row }: { row: FocusRow }) {
+  // Server rows that name an entity use the shape-first cue; static rows use a
+  // neutral topical icon; anything else degrades to EntityTarget's neutral dot.
+  if (row.targetKind) {
+    return <EntityTarget targetKind={row.targetKind} />
+  }
+  const Icon = row.iconKey ? ICON_MAP[row.iconKey] : undefined
+  if (Icon) {
+    return <Icon className="h-[18px] w-[18px] text-text-light" aria-hidden="true" />
+  }
+  return <EntityTarget />
+}
+
+export function FocusRowCard({ row, isOpen, onToggle, onTryAction }: FocusRowCardProps) {
+  const regionId = useId()
+  const labelId = useId()
+  const Chevron = isOpen ? ChevronDown : ChevronRight
+  const primary = row.primary ?? ''
+  const hasPrimary = primary.trim().length > 0
+
+  const clampStyle: CSSProperties | undefined = isOpen
+    ? undefined
+    : {
+        display: '-webkit-box',
+        WebkitLineClamp: 1,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+      }
+
+  return (
+    <div
+      data-testid="focus-card"
+      data-row-id={row.id}
+      data-ownership={row.ownership}
+      data-source={row.source}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={regionId}
+        aria-label={hasPrimary ? undefined : FOCUS_COPY.itemFallback}
+        className="flex w-full items-start gap-2.5 px-3.5 py-2.5 text-left transition-colors hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-inset"
+      >
+        <span className="mt-0.5 flex-none">
+          <RowMarker row={row} />
+        </span>
+        <span
+          id={labelId}
+          className={`${typography.panelBody} min-w-0 flex-1 text-text-header`}
+          style={clampStyle}
+        >
+          {primary}
+        </span>
+        <Chevron className="mt-0.5 h-4 w-4 flex-none text-text-light" aria-hidden="true" />
+      </button>
+
+      {isOpen && (
+        <div
+          id={regionId}
+          role="region"
+          {...(hasPrimary ? { 'aria-labelledby': labelId } : { 'aria-label': FOCUS_COPY.itemFallback })}
+          className="flex flex-col gap-2 pb-3 pl-[42px] pr-3.5 pt-1"
+          data-testid="focus-card-body"
+        >
+          {/* Server rows only — a static row never claims a detection. */}
+          {row.noticed && (
+            <p className={`${typography.panelBody} text-text-body`} data-testid="focus-noticed">
+              {row.noticed}
+            </p>
+          )}
+
+          {row.whyItMatters && (
+            <p className={`${typography.panelBody} text-text-light`} data-testid="focus-why">
+              {row.whyItMatters}
+            </p>
+          )}
+
+          {row.tryThis && (
+            <p className={`${typography.panelBody} text-text-body`} data-testid="focus-try">
+              <span className="text-primary">{FOCUS_COPY.tryThisLabel}</span>{' '}
+              {row.tryThis}
+            </p>
+          )}
+
+          <div className="mt-1 flex items-center gap-2">
+            {row.action?.kind === 'prefill' && row.action.prefillText && (
+              <button
+                type="button"
+                onClick={() => onTryAction?.(row)}
+                data-testid="focus-action"
+                className={`${typography.panelMeta} inline-flex flex-none items-center rounded-full bg-primary px-3 py-1.5 text-text-on-color outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-info`}
+              >
+                {row.action.label}
+              </button>
+            )}
+
+            {/* Display-only: no onClick this phase. */}
+            <Tooltip content={FOCUS_COPY.askOlumi}>
+              <button
+                type="button"
+                aria-label={FOCUS_COPY.askOlumi}
+                data-testid="focus-ask-olumi"
+                className="ml-auto inline-flex h-7 w-7 flex-none items-center justify-center rounded-full border border-panel-border text-info outline-none transition-colors hover:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info"
+              >
+                <Sparkles className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </Tooltip>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default FocusRowCard

--- a/src/canvas/components/coaching-panel/focus-now/__fixtures__/focus.fixtures.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__fixtures__/focus.fixtures.ts
@@ -58,7 +58,6 @@ export const serverRow: FocusRow = {
   whyItMatters: 'A genuinely different route tends to make the choice clearer.',
   tryThis: 'Sketch a different kind of option',
   targetKind: 'option',
-  targetLabel: 'Hybrid plan',
   action: { kind: 'prefill', label: 'Try this', prefillText: 'Sketch a different kind of option' },
 }
 

--- a/src/canvas/components/coaching-panel/focus-now/__fixtures__/focus.fixtures.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__fixtures__/focus.fixtures.ts
@@ -1,0 +1,85 @@
+/**
+ * Focus Now — test + Storybook fixtures.
+ *
+ * Includes deliberately "unsafe" SERVER fixtures (banned terms, HTML-looking
+ * strings) to prove the UI renders server-supplied data verbatim as TEXT and
+ * never scans or rewrites it (F.6 / claim-safety boundary). These are NOT
+ * UI-authored copy and are NOT scanned by the copy-hygiene suite.
+ */
+import type { CoachingSignal } from '../../types'
+import type { FocusBannerState, FocusRow } from '../focusTypes'
+
+/** A fully-populated structured coaching signal (future Lane-A shape). */
+export const signalFull: CoachingSignal = {
+  signal_id: 'sig-options',
+  move: 'add',
+  source: 'analysis',
+  grounding: { observation: 'Your options rely on the same lever.' },
+  target_kind: 'option',
+  target_label: 'Hybrid plan',
+  priority_reason: 'A genuinely different route tends to make the choice clearer.',
+  suggested_actions: [{ label: 'Sketch a different kind of option' }],
+}
+
+/** A minimal valid signal — observation only. */
+export const signalMinimal: CoachingSignal = {
+  signal_id: 'sig-minimal',
+  move: 'review',
+  source: 'structural',
+  grounding: { observation: 'One outcome carries most of the weight here.' },
+}
+
+/** Unusable signal — empty observation, must be dropped by the mapper. */
+export const signalNoObservation: CoachingSignal = {
+  signal_id: 'sig-empty',
+  move: 'noop',
+  source: 'structural',
+  grounding: { observation: '   ' },
+}
+
+/** Two signals to assert received-order preservation (no ranking). */
+export const signalsOrdered: CoachingSignal[] = [
+  { signal_id: 'sig-a', move: 'review', source: 'analysis', grounding: { observation: 'First, as received.' }, priority: 1 },
+  { signal_id: 'sig-b', move: 'review', source: 'analysis', grounding: { observation: 'Second, as received.' }, priority: 99 },
+]
+
+/** A pre-built server row, for render tests. */
+export const serverRow: FocusRow = {
+  id: 'signal:sig-options',
+  ownership: 'server_sourced',
+  source: 'coaching_signal',
+  primary: 'Your options rely on the same lever.',
+  whyItMatters: 'A genuinely different route tends to make the choice clearer.',
+  tryThis: 'Sketch a different kind of option',
+  targetKind: 'option',
+  targetLabel: 'Hybrid plan',
+  action: { kind: 'prefill', label: 'Try this', prefillText: 'Sketch a different kind of option' },
+}
+
+/**
+ * A GATED row (science-heavy). The mapper never emits one; this exists so tests
+ * can pass it in and assert it is dropped and never rendered.
+ */
+export const gatedRow: FocusRow = {
+  id: 'gated:influence',
+  ownership: 'gated',
+  source: 'coaching_signal',
+  primary: 'This factor has the most influence on the result',
+  noticed: 'Sensitivity analysis shows this drives the outcome.',
+}
+
+/** SERVER prose with banned terms — must render verbatim (not scanned/rewritten). */
+export const forbiddenSummary =
+  'The recommended winner is option A, based on the graph nodes and edges and its EVPI.'
+
+/** SERVER prose that looks like HTML — must render as literal text, parse no elements. */
+export const xssSummary =
+  '<img src=x onerror="alert(1)"> this should appear as text <script>noop()</script>'
+
+/** Long server prose to exercise wrapping/clamp. */
+export const longSummary =
+  'Across the latest pass several of your estimates lean optimistic, and a couple of the figures bundle a few different things together, so it is worth a careful second look before you commit to a direction here.'
+
+export const bannerStale: FocusBannerState = { kind: 'stale', canRerun: true }
+export const bannerCannotConfirm: FocusBannerState = { kind: 'cannot_confirm' }
+export const bannerNone: FocusBannerState = { kind: 'none' }

--- a/src/canvas/components/coaching-panel/focus-now/__fixtures__/focus.fixtures.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__fixtures__/focus.fixtures.ts
@@ -19,6 +19,12 @@ export const signalFull: CoachingSignal = {
   target_label: 'Hybrid plan',
   priority_reason: 'A genuinely different route tends to make the choice clearer.',
   suggested_actions: [{ label: 'Sketch a different kind of option' }],
+  // Roadmap / science-ish fields the mapper must NEVER leak onto a FocusRow.
+  // Present here so the "no science leak" assertion can actually fail on a regression.
+  priority: 7,
+  lifecycle_state: 'active',
+  evidence: [{ label: 'supporting note' }],
+  staleness: { label: 'last seen 2 turns ago' },
 }
 
 /** A minimal valid signal — observation only. */

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/a11y.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/a11y.spec.tsx
@@ -1,0 +1,55 @@
+/**
+ * Accessibility — no axe violations across key states; region naming + operable
+ * controls. color-contrast is disabled (repo convention: a flagged DS
+ * token-level landmine, not a panel defect).
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe, configureAxe } from 'vitest-axe'
+import { FocusNowPanel } from '../FocusNowPanel'
+import { buildFocusRows } from '../buildFocusRows'
+import type { FocusNowProps } from '../focusTypes'
+
+configureAxe({ rules: { 'color-contrast': { enabled: false } } })
+
+const staticRows = buildFocusRows({}).rows
+function renderPanel(overrides: Partial<FocusNowProps> = {}) {
+  const props: FocusNowProps = { summary: null, rows: staticRows, banner: { kind: 'none' }, ...overrides }
+  return render(<FocusNowPanel {...props} />)
+}
+
+async function expectNoViolations(container: HTMLElement) {
+  const results = await axe(container)
+  expect(results.violations).toEqual([])
+}
+
+describe('FocusNowPanel accessibility', () => {
+  it('has no violations when collapsed', async () => {
+    const { container } = renderPanel()
+    await expectNoViolations(container)
+  })
+
+  it('has no violations with a row expanded', async () => {
+    const { container } = renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /define what success/i }))
+    await expectNoViolations(container)
+  })
+
+  it('has no violations with the stale banner shown', async () => {
+    const { container } = renderPanel({ banner: { kind: 'stale', canRerun: true }, onRerun: () => {} })
+    await expectNoViolations(container)
+  })
+
+  it('has no violations in the empty state', async () => {
+    const { container } = renderPanel({ rows: [] })
+    await expectNoViolations(container)
+  })
+
+  it('names the panel region and the icon-only affordances', () => {
+    renderPanel({ banner: { kind: 'stale', canRerun: true }, onRerun: () => {} })
+    expect(screen.getByRole('region', { name: 'Strengthen your model' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Re-run analysis' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /define what success/i }))
+    expect(screen.getByRole('button', { name: 'Ask Olumi' })).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/banner.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/banner.spec.tsx
@@ -1,0 +1,37 @@
+/**
+ * FocusBanner — the three freshness states render correctly and the re-run
+ * affordance appears ONLY when appropriate (stale, not in-flight).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FocusBanner } from '../FocusBanner'
+
+describe('FocusBanner', () => {
+  it('stale: shows re-run; click fires onRerun', () => {
+    const onRerun = vi.fn()
+    render(<FocusBanner state={{ kind: 'stale', canRerun: true }} onRerun={onRerun} />)
+    fireEvent.click(screen.getByTestId('focus-rerun'))
+    expect(onRerun).toHaveBeenCalledTimes(1)
+  })
+
+  it('stale: re-run is disabled while a run is in flight', () => {
+    render(<FocusBanner state={{ kind: 'stale', canRerun: true }} onRerun={() => {}} rerunDisabled />)
+    expect(screen.getByTestId('focus-rerun')).toBeDisabled()
+  })
+
+  it('stale: re-run button has an accessible name', () => {
+    render(<FocusBanner state={{ kind: 'stale', canRerun: true }} onRerun={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Re-run analysis' })).toBeInTheDocument()
+  })
+
+  it('cannot_confirm: neutral note, no re-run even when onRerun is provided', () => {
+    render(<FocusBanner state={{ kind: 'cannot_confirm' }} onRerun={() => {}} />)
+    expect(screen.getByTestId('focus-banner')).toHaveAttribute('data-banner', 'cannot_confirm')
+    expect(screen.queryByTestId('focus-rerun')).toBeNull()
+  })
+
+  it('none: renders nothing', () => {
+    const { container } = render(<FocusBanner state={{ kind: 'none' }} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/buildFocusRows.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/buildFocusRows.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * buildFocusRows — pure mapper. Ownership composition, F.6 (no rank/sort), and
+ * fail-closed behaviour.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildFocusRows, mapSignalToFocusRow, dropGatedRows } from '../buildFocusRows'
+import { STATIC_HYGIENE_ROWS } from '../focusConstants'
+import {
+  signalFull,
+  signalMinimal,
+  signalNoObservation,
+  signalsOrdered,
+  gatedRow,
+  serverRow,
+} from '../__fixtures__/focus.fixtures'
+
+describe('buildFocusRows — summary', () => {
+  it('trims a non-empty coaching_summary', () => {
+    expect(buildFocusRows({ coachingSummary: '  hello  ' }).summary).toBe('hello')
+  })
+  it('returns null for empty / whitespace / null / non-string summary', () => {
+    expect(buildFocusRows({ coachingSummary: '' }).summary).toBeNull()
+    expect(buildFocusRows({ coachingSummary: '   ' }).summary).toBeNull()
+    expect(buildFocusRows({ coachingSummary: null }).summary).toBeNull()
+    expect(buildFocusRows({ coachingSummary: 123 as unknown as string }).summary).toBeNull()
+  })
+  it('never synthesises a summary when none is given', () => {
+    expect(buildFocusRows({}).summary).toBeNull()
+  })
+})
+
+describe('buildFocusRows — static rows', () => {
+  it('includes the six static hygiene rows by default, in fixed order', () => {
+    const { rows } = buildFocusRows({})
+    expect(rows).toHaveLength(STATIC_HYGIENE_ROWS.length)
+    expect(rows.map((r) => r.id)).toEqual(STATIC_HYGIENE_ROWS.map((r) => r.id))
+    expect(rows.every((r) => r.ownership === 'static_hygiene')).toBe(true)
+  })
+  it('omits static rows when suppressStatic is set', () => {
+    expect(buildFocusRows({ suppressStatic: true }).rows).toHaveLength(0)
+  })
+  it('static rows never carry a "noticed" line (no false detection)', () => {
+    for (const r of buildFocusRows({}).rows) expect(r.noticed).toBeUndefined()
+  })
+})
+
+describe('buildFocusRows — server rows', () => {
+  it('maps signals to server rows BEFORE static rows', () => {
+    const { rows } = buildFocusRows({ signals: [signalFull] })
+    expect(rows[0].ownership).toBe('server_sourced')
+    expect(rows[0].primary).toBe('Your options rely on the same lever.')
+    expect(rows.slice(1).every((r) => r.ownership === 'static_hygiene')).toBe(true)
+  })
+  it('preserves received order (never ranks by priority) — F.6', () => {
+    const { rows } = buildFocusRows({ signals: signalsOrdered, suppressStatic: true })
+    expect(rows.map((r) => r.primary)).toEqual(['First, as received.', 'Second, as received.'])
+  })
+  it('drops a signal with an empty observation', () => {
+    const { rows } = buildFocusRows({ signals: [signalNoObservation], suppressStatic: true })
+    expect(rows).toHaveLength(0)
+  })
+  it('maps only allow-listed human fields (no numeric priority / science leak)', () => {
+    const r = mapSignalToFocusRow(signalFull)!
+    expect(r.whyItMatters).toBe('A genuinely different route tends to make the choice clearer.')
+    expect(r.tryThis).toBe('Sketch a different kind of option')
+    expect(r.action).toEqual({ kind: 'prefill', label: 'Try this', prefillText: 'Sketch a different kind of option' })
+    expect(r.targetKind).toBe('option')
+    expect(Object.keys(r)).not.toContain('priority')
+    expect(Object.keys(r)).not.toContain('lifecycle_state')
+  })
+  it('omits the action when a signal has no suggested action', () => {
+    const r = mapSignalToFocusRow(signalMinimal)!
+    expect(r.action).toBeUndefined()
+    expect(r.primary).toBe('One outcome carries most of the weight here.')
+  })
+  it('returns null for a null / undefined signal', () => {
+    expect(mapSignalToFocusRow(null)).toBeNull()
+    expect(mapSignalToFocusRow(undefined)).toBeNull()
+  })
+  it('dedups duplicate signal ids (first wins)', () => {
+    const dup = [
+      { signal_id: 'x', move: 'm', source: 's', grounding: { observation: 'first' } },
+      { signal_id: 'x', move: 'm', source: 's', grounding: { observation: 'second' } },
+    ]
+    const { rows } = buildFocusRows({ signals: dup, suppressStatic: true })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].primary).toBe('first')
+  })
+})
+
+describe('buildFocusRows — gated + fail-closed', () => {
+  it('dropGatedRows removes any gated row', () => {
+    expect(dropGatedRows([gatedRow, serverRow]).map((r) => r.id)).toEqual([serverRow.id])
+  })
+  it('never emits a gated row', () => {
+    const { rows } = buildFocusRows({ signals: [signalFull, signalMinimal] })
+    expect(rows.some((r) => r.ownership === 'gated')).toBe(false)
+  })
+  it('degrades to static-only on malformed input without throwing', () => {
+    const call = () =>
+      buildFocusRows({ coachingSummary: {} as unknown as string, signals: 'nope' as unknown as [] })
+    expect(call).not.toThrow()
+    const vm = call()
+    expect(vm.summary).toBeNull()
+    expect(vm.rows.every((r) => r.ownership === 'static_hygiene')).toBe(true)
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/buildFocusRows.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/buildFocusRows.spec.ts
@@ -65,8 +65,10 @@ describe('buildFocusRows — server rows', () => {
     expect(r.tryThis).toBe('Sketch a different kind of option')
     expect(r.action).toEqual({ kind: 'prefill', label: 'Try this', prefillText: 'Sketch a different kind of option' })
     expect(r.targetKind).toBe('option')
-    expect(Object.keys(r)).not.toContain('priority')
-    expect(Object.keys(r)).not.toContain('lifecycle_state')
+    // signalFull carries these science-ish fields; the mapper must drop them all.
+    for (const leaked of ['priority', 'lifecycle_state', 'evidence', 'staleness']) {
+      expect(Object.keys(r)).not.toContain(leaked)
+    }
   })
   it('omits the action when a signal has no suggested action', () => {
     const r = mapSignalToFocusRow(signalMinimal)!

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/content.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/content.spec.tsx
@@ -15,6 +15,23 @@ function renderPanel(overrides: Partial<FocusNowProps> = {}) {
 }
 
 describe('FocusNowPanel content', () => {
+  it('shows its own freshness banner by default, but suppresses it when showFreshnessBanner=false', () => {
+    // standalone (default): the panel owns the stale banner
+    const { rerender } = renderPanel({ banner: { kind: 'stale', canRerun: true }, onRerun: () => {} })
+    expect(screen.getByTestId('focus-banner')).toBeInTheDocument()
+    // mounted context (showFreshnessBanner=false): suppressed, so no DUPLICATE stale notice
+    rerender(
+      <FocusNowPanel
+        summary={null}
+        rows={staticRows}
+        banner={{ kind: 'stale', canRerun: true }}
+        onRerun={() => {}}
+        showFreshnessBanner={false}
+      />,
+    )
+    expect(screen.queryByTestId('focus-banner')).toBeNull()
+  })
+
   it('renders the header and the static hygiene rows', () => {
     renderPanel()
     expect(screen.getByRole('heading', { name: 'Strengthen your model' })).toBeInTheDocument()

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/content.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/content.spec.tsx
@@ -1,0 +1,61 @@
+/**
+ * FocusNowPanel content — static rows render safely (and never claim a detection),
+ * server rows render their fields, and the summary renders verbatim or is omitted.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { FocusNowPanel } from '../FocusNowPanel'
+import { buildFocusRows } from '../buildFocusRows'
+import type { FocusNowProps, FocusRow } from '../focusTypes'
+
+const staticRows = buildFocusRows({}).rows
+function renderPanel(overrides: Partial<FocusNowProps> = {}) {
+  const props: FocusNowProps = { summary: null, rows: staticRows, banner: { kind: 'none' }, ...overrides }
+  return render(<FocusNowPanel {...props} />)
+}
+
+describe('FocusNowPanel content', () => {
+  it('renders the header and the static hygiene rows', () => {
+    renderPanel()
+    expect(screen.getByRole('heading', { name: 'Strengthen your model' })).toBeInTheDocument()
+    expect(screen.getByText('Define what success looks like')).toBeInTheDocument()
+    expect(screen.getByText('Set a time horizon')).toBeInTheDocument()
+    expect(screen.getByText('Add a risk worth watching')).toBeInTheDocument()
+    expect(screen.getByText('Capture an insight while it is fresh')).toBeInTheDocument()
+  })
+
+  it('a static row shows why + try this, but never a "noticed" line', () => {
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /define what success looks like/i }))
+    const body = screen.getByTestId('focus-card-body')
+    expect(within(body).getByTestId('focus-why')).toBeInTheDocument()
+    expect(within(body).getByTestId('focus-try')).toBeInTheDocument()
+    expect(within(body).queryByTestId('focus-noticed')).toBeNull()
+  })
+
+  it('a server row renders its "what Olumi noticed" line verbatim', () => {
+    const row: FocusRow = {
+      id: 'sv',
+      ownership: 'server_sourced',
+      source: 'coaching_signal',
+      primary: 'Server title',
+      noticed: 'Olumi noticed this thing.',
+      whyItMatters: 'Because reasons.',
+    }
+    renderPanel({ rows: [row] })
+    fireEvent.click(screen.getByRole('button', { name: /server title/i }))
+    expect(screen.getByTestId('focus-noticed')).toHaveTextContent('Olumi noticed this thing.')
+  })
+
+  it('renders the summary line verbatim when present, omits it when null', () => {
+    const { rerender } = renderPanel({ summary: 'Here is your orientation.' })
+    expect(screen.getByTestId('focus-summary')).toHaveTextContent('Here is your orientation.')
+    rerender(<FocusNowPanel summary={null} rows={staticRows} banner={{ kind: 'none' }} />)
+    expect(screen.queryByTestId('focus-summary')).toBeNull()
+  })
+
+  it('shows the honest empty state when there are no rows', () => {
+    renderPanel({ rows: [] })
+    expect(screen.getByTestId('focus-empty')).toHaveTextContent('Nothing to focus on right now.')
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
@@ -1,0 +1,76 @@
+/**
+ * Copy hygiene — UI-AUTHORED copy only.
+ *
+ * Scans FOCUS_COPY + every static row's user-facing strings against the union of
+ * the canonical glossary list, the existing coaching-panel forbidden list, and
+ * this task's banned vocabulary. It deliberately does NOT scan server-supplied
+ * strings — those are rendered verbatim and are a CEE/Gate-Zero concern, never
+ * the renderer's (F.6). Server prose is therefore explicitly NOT claim-certified
+ * by this suite.
+ */
+import { describe, it, expect } from 'vitest'
+import { findBannedTerm } from '@/test/glossaryBannedTerms'
+import { FOCUS_COPY, STATIC_HYGIENE_ROWS } from '../focusConstants'
+
+const EXISTING_FORBIDDEN = ['node', 'edge', 'graph', 'coefficient', 'weight', 'evpi', 'winner', 'recommended']
+const TASK_FORBIDDEN = [
+  'driver',
+  'influence',
+  'sensitivity',
+  'fragile',
+  'evpi',
+  'voi',
+  'value of information',
+  'what would change',
+  'flip',
+  'high confidence',
+  'stable result',
+  'this matters most',
+]
+
+const UI_COPY: string[] = [
+  FOCUS_COPY.panelAria,
+  FOCUS_COPY.header,
+  FOCUS_COPY.emptyState,
+  FOCUS_COPY.tryThisLabel,
+  FOCUS_COPY.askOlumi,
+  FOCUS_COPY.itemFallback,
+  FOCUS_COPY.showFewer,
+  FOCUS_COPY.staleText,
+  FOCUS_COPY.rerunLabel,
+  FOCUS_COPY.cannotConfirmText,
+  FOCUS_COPY.showAll(3),
+  ...STATIC_HYGIENE_ROWS.flatMap((r) => [
+    r.primary,
+    r.whyItMatters ?? '',
+    r.tryThis ?? '',
+    r.action?.label ?? '',
+    r.action?.prefillText ?? '',
+  ]),
+].filter((s) => s.length > 0)
+
+describe('Focus Now copy hygiene (UI-authored copy only)', () => {
+  it('contains no canonical glossary banned term', () => {
+    for (const copy of UI_COPY) {
+      const hit = findBannedTerm(copy)
+      expect(hit, `"${copy}" contains banned term "${hit}"`).toBeNull()
+    }
+  })
+
+  it.each([...new Set([...EXISTING_FORBIDDEN, ...TASK_FORBIDDEN])])(
+    'contains no forbidden term: %s',
+    (term) => {
+      const re = new RegExp(`\\b${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+      for (const copy of UI_COPY) {
+        expect(copy, `"${copy}" should not contain "${term}"`).not.toMatch(re)
+      }
+    },
+  )
+
+  it('uses no all-caps words and no em dashes (sentence case, British English)', () => {
+    for (const copy of UI_COPY) {
+      expect(copy).not.toMatch(/\b[A-Z]{2,}\b/)
+      expect(copy).not.toContain('—')
+    }
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
@@ -57,10 +57,19 @@ describe('Focus Now copy hygiene (UI-authored copy only)', () => {
     }
   })
 
+  it('positive control — the banned-term scanner actually fires on bad copy', () => {
+    // Guards against a silently-broken matcher: a clean UI_COPY pass must mean the
+    // copy is clean, not that findBannedTerm always returns null.
+    expect(findBannedTerm('the recommended winner uses the graph')).not.toBeNull()
+  })
+
   it.each([...new Set([...EXISTING_FORBIDDEN, ...TASK_FORBIDDEN])])(
     'contains no forbidden term: %s',
     (term) => {
       const re = new RegExp(`\\b${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+      // positive control: the regex must fire on the term it is built from, so a
+      // clean pass means "copy is clean", not "the matcher is broken".
+      expect(`a ${term} b`, `regex for "${term}" must fire`).toMatch(re)
       for (const copy of UI_COPY) {
         expect(copy, `"${copy}" should not contain "${term}"`).not.toMatch(re)
       }

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/freshnessBanner.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/freshnessBanner.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * freshnessBanner — pure adapter, locked to the real `classifyFreshnessForDisplay`
+ * so the banner can never drift from the certified freshness source. The
+ * cannot-confirm state must NEVER surface as stale.
+ */
+import { describe, it, expect } from 'vitest'
+import { freshnessToBanner } from '../freshnessBanner'
+import {
+  classifyFreshnessForDisplay,
+  type AnalysisFreshnessState,
+} from '@/canvas/store/analysisFreshness'
+
+describe('freshnessToBanner (pure)', () => {
+  it('maps changed -> stale + canRerun', () => {
+    expect(freshnessToBanner('changed')).toEqual({ kind: 'stale', canRerun: true })
+  })
+  it('maps cannot_confirm -> cannot_confirm (no re-run)', () => {
+    expect(freshnessToBanner('cannot_confirm')).toEqual({ kind: 'cannot_confirm' })
+  })
+  it('maps current / none / null / undefined -> none', () => {
+    expect(freshnessToBanner('current')).toEqual({ kind: 'none' })
+    expect(freshnessToBanner('none')).toEqual({ kind: 'none' })
+    expect(freshnessToBanner(null)).toEqual({ kind: 'none' })
+    expect(freshnessToBanner(undefined)).toEqual({ kind: 'none' })
+  })
+})
+
+describe('freshnessToBanner through the real classifier', () => {
+  const banner = (state: AnalysisFreshnessState | null, dirty: boolean) =>
+    freshnessToBanner(classifyFreshnessForDisplay(state, dirty))
+
+  it('CEE stale -> stale banner', () => {
+    expect(banner({ freshness: 'stale' }, false)).toEqual({ kind: 'stale', canRerun: true })
+  })
+  it('fresh + local edit (dirty) -> stale banner', () => {
+    expect(banner({ freshness: 'fresh' }, true)).toEqual({ kind: 'stale', canRerun: true })
+  })
+  it('CEE-sourced unknown -> cannot_confirm (never stale)', () => {
+    expect(banner({ freshness: 'unknown' }, false)).toEqual({ kind: 'cannot_confirm' })
+  })
+  it('fresh + not dirty -> none', () => {
+    expect(banner({ freshness: 'fresh' }, false)).toEqual({ kind: 'none' })
+  })
+  it('no verdict -> none', () => {
+    expect(banner(null, false)).toEqual({ kind: 'none' })
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
@@ -29,8 +29,12 @@ const SRC = resolve(process.cwd(), 'src')
 const MODULE_DIR = join(SRC, 'canvas', 'components', 'coaching-panel', 'focus-now')
 
 // Capture the specifier of any import / re-export / dynamic import() / require().
-// Covers: `from 'x'`, side-effect `import 'x'`, `import('x')`, `require('x')`.
-const SPEC_RE = /(?:\bfrom\s+|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)['"]([^'"\n]+)['"]/g
+// Covers `from 'x'`, side-effect `import 'x'`, `import('x')`, `require('x')`, and
+// their "glued" zero-whitespace forms (`import{X}from'x'`, `import'x'`) — the
+// `\s*` (not `\s+`) is load-bearing for that. Spurious in-string captures from
+// the relaxed `from`/`import` are harmless: resolveSpec/PATH_RE never turn them
+// into offenders (proven by the negative controls below).
+const SPEC_RE = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s*|\brequire\s*\(\s*)['"]([^'"\n]+)['"]/g
 
 // Boundary-aware path backstop: matches `.../coaching-panel/focus-now` and
 // `.../coaching-panel/focus-now/<file>`, but NOT a sibling like `focus-now-helpers`.
@@ -101,6 +105,9 @@ describe('Focus Now inertness', () => {
     ['require()', PARENT, "const m = require('./focus-now')"],
     ['side-effect import', PARENT, "import './focus-now'"],
     ['multiline dynamic import', PARENT, "const m = import(\n      './focus-now'\n    )"],
+    ['glued no-whitespace named import', PARENT, "import{FocusNowPanel}from'./focus-now'"],
+    ['glued no-whitespace re-export', PARENT, "export{FocusNowPanel}from'./focus-now'"],
+    ['glued no-whitespace side-effect', PARENT, "import'./focus-now'"],
   ])('FLAGS dynamic/relative import: %s', (_label, importer, code) => {
     expect(findFocusNowImports(code, importer).length).toBeGreaterThan(0)
   })

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
@@ -1,19 +1,59 @@
 /**
  * Inertness guard (CI tripwire).
  *
- * Focus Now is render-only, unmounted, and behind no feature flag. This test
- * fails if ANY file outside `coaching-panel/focus-now/` imports the module —
- * proving it is not wired into the app. When the deliberate mount PR lands, that
- * PR must update/remove this guard, which keeps the "inert until mounted"
- * invariant honest rather than implicit.
+ * Focus Now is render-only, unmounted, and behind no feature flag. This test fails
+ * if ANY file outside the module imports it — via static import, type-only import,
+ * re-export, dynamic import(), React.lazy, or require() — whether by alias
+ * ('@/.../focus-now') or RELATIVE path ('./focus-now', '../focus-now',
+ * './focus-now/FocusNowPanel').
+ *
+ * It RESOLVES each import specifier to an absolute path and checks whether it lands
+ * inside the module; it does NOT substring-match whole files. That closes the blind
+ * spot found in PR #199 review, where a substring check ('coaching-panel/focus-now')
+ * missed relative imports from the parent `coaching-panel` barrel (e.g.
+ * `import { FocusNowPanel } from './focus-now'`). The in-test positive/negative
+ * controls below are committed coverage, not just PR-body evidence.
+ *
+ * When the deliberate mount PR lands, it must update/remove this guard.
  */
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve, sep } from 'node:path'
 
 const SRC = resolve(process.cwd(), 'src')
 const MODULE_DIR = join(SRC, 'canvas', 'components', 'coaching-panel', 'focus-now')
-const NEEDLE = 'coaching-panel/focus-now'
+
+// Capture the specifier of any import / re-export / dynamic import() / require().
+// Covers: `from 'x'`, side-effect `import 'x'`, `import('x')`, `require('x')`.
+const SPEC_RE = /(?:\bfrom\s+|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)['"]([^'"\n]+)['"]/g
+
+// Boundary-aware path backstop: matches `.../coaching-panel/focus-now` and
+// `.../coaching-panel/focus-now/<file>`, but NOT a sibling like `focus-now-helpers`.
+const PATH_RE = /coaching-panel\/focus-now(\/|$)/
+
+/** The '@/' alias maps to <src>/. Relative specifiers resolve against the importer's dir. */
+function resolveSpec(spec: string, importerFile: string, srcRoot: string): string | null {
+  if (spec.startsWith('@/')) return resolve(srcRoot, spec.slice(2))
+  if (spec === '.' || spec === '..' || spec.startsWith('./') || spec.startsWith('../')) {
+    return resolve(dirname(importerFile), spec)
+  }
+  return null // bare package specifier — never a focus-now import
+}
+
+function isUnderModule(p: string): boolean {
+  return p === MODULE_DIR || p.startsWith(MODULE_DIR + sep)
+}
+
+/** Offending specifiers in `content` that resolve into (or path-match) the module. */
+export function findFocusNowImports(content: string, importerFile: string, srcRoot = SRC): string[] {
+  const offenders: string[] = []
+  for (const m of content.matchAll(SPEC_RE)) {
+    const spec = m[1]
+    const resolved = resolveSpec(spec, importerFile, srcRoot)
+    if ((resolved && isUnderModule(resolved)) || PATH_RE.test(spec)) offenders.push(spec)
+  }
+  return offenders
+}
 
 function walk(dir: string, acc: string[] = []): string[] {
   for (const name of readdirSync(dir)) {
@@ -26,15 +66,45 @@ function walk(dir: string, acc: string[] = []): string[] {
 }
 
 describe('Focus Now inertness', () => {
-  it('is not imported by any file outside its own module', () => {
-    const offenders = walk(SRC)
-      .filter((f) => !f.startsWith(MODULE_DIR))
-      .filter((f) => readFileSync(f, 'utf8').includes(NEEDLE))
-      .map((f) => f.slice(SRC.length - 3)) // show as src/...
-
+  it('is not imported by any file outside its own module (alias OR relative, static OR dynamic)', () => {
+    const offenders: string[] = []
+    for (const file of walk(SRC)) {
+      if (file === MODULE_DIR || file.startsWith(MODULE_DIR + sep)) continue
+      const hits = findFocusNowImports(readFileSync(file, 'utf8'), file)
+      if (hits.length) offenders.push(`${file.slice(SRC.length - 3)} -> ${hits.join(', ')}`)
+    }
     expect(
       offenders,
-      `Focus Now is render-only/unmounted; nothing outside its module may import it yet. Offenders: ${offenders.join(', ')}`,
+      `Focus Now is render-only/unmounted; nothing outside its module may import it yet:\n${offenders.join('\n')}`,
     ).toEqual([])
+  })
+
+  // Committed positive controls — the import forms a substring check missed.
+  const PARENT = join(SRC, 'canvas', 'components', 'coaching-panel', 'index.ts')
+  const SIBLING = join(SRC, 'canvas', 'components', 'coaching-panel', '__tests__', 'x.ts')
+
+  it.each([
+    ['relative static from parent barrel', PARENT, "import { FocusNowPanel } from './focus-now'"],
+    ['relative type-only from parent', PARENT, "import type { FocusRow } from './focus-now'"],
+    ['relative re-export from parent barrel', PARENT, "export { FocusNowPanel } from './focus-now'"],
+    ['relative re-export star', PARENT, "export * from './focus-now'"],
+    ['relative lazy/dynamic from parent', PARENT, "const X = lazy(() => import('./focus-now'))"],
+    ['relative deep file from parent', PARENT, "import { FocusRowCard } from './focus-now/FocusRowCard'"],
+    ['relative from sibling dir (../)', SIBLING, "import x from '../focus-now'"],
+    ['aliased static', PARENT, "import { FocusNowPanel } from '@/canvas/components/coaching-panel/focus-now'"],
+    ['aliased lazy/dynamic', PARENT, "const X = lazy(() => import('@/canvas/components/coaching-panel/focus-now'))"],
+    ['require()', PARENT, "const m = require('./focus-now')"],
+  ])('FLAGS dynamic/relative import: %s', (_label, importer, code) => {
+    expect(findFocusNowImports(code, importer).length).toBeGreaterThan(0)
+  })
+
+  it.each([
+    ['bare package import', PARENT, "import React from 'react'"],
+    ['unrelated sibling module', PARENT, "import { CoachingPanel } from './CoachingPanel'"],
+    ['similarly-named relative sibling', PARENT, "import x from './focus-now-helpers'"],
+    ['similarly-named aliased sibling', PARENT, "import x from '@/canvas/components/coaching-panel/focus-now-helpers'"],
+    ['unrelated relative path elsewhere', join(SRC, 'foo', 'bar.ts'), "import './focus-now'"],
+  ])('does NOT flag: %s', (_label, importer, code) => {
+    expect(findFocusNowImports(code, importer)).toEqual([])
   })
 })

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Inertness guard (CI tripwire).
+ *
+ * Focus Now is render-only, unmounted, and behind no feature flag. This test
+ * fails if ANY file outside `coaching-panel/focus-now/` imports the module —
+ * proving it is not wired into the app. When the deliberate mount PR lands, that
+ * PR must update/remove this guard, which keeps the "inert until mounted"
+ * invariant honest rather than implicit.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const SRC = resolve(process.cwd(), 'src')
+const MODULE_DIR = join(SRC, 'canvas', 'components', 'coaching-panel', 'focus-now')
+const NEEDLE = 'coaching-panel/focus-now'
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist') continue
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) walk(full, acc)
+    else if (/\.(ts|tsx)$/.test(name)) acc.push(full)
+  }
+  return acc
+}
+
+describe('Focus Now inertness', () => {
+  it('is not imported by any file outside its own module', () => {
+    const offenders = walk(SRC)
+      .filter((f) => !f.startsWith(MODULE_DIR))
+      .filter((f) => readFileSync(f, 'utf8').includes(NEEDLE))
+      .map((f) => f.slice(SRC.length - 3)) // show as src/...
+
+    expect(
+      offenders,
+      `Focus Now is render-only/unmounted; nothing outside its module may import it yet. Offenders: ${offenders.join(', ')}`,
+    ).toEqual([])
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
@@ -14,6 +14,11 @@
  * `import { FocusNowPanel } from './focus-now'`). The in-test positive/negative
  * controls below are committed coverage, not just PR-body evidence.
  *
+ * Known limitation (regex-based by design): it does not catch computed/indirect
+ * dynamic imports such as `const p = './focus-now'; import(p)`. That is not a
+ * current risk for an inert tripwire; an AST/parser-based guard would be more
+ * exhaustive if this ever needs to harden further (PR #199 review note).
+ *
  * When the deliberate mount PR lands, it must update/remove this guard.
  */
 import { describe, it, expect } from 'vitest'
@@ -32,8 +37,8 @@ const SPEC_RE = /(?:\bfrom\s+|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)['"
 const PATH_RE = /coaching-panel\/focus-now(\/|$)/
 
 /** The '@/' alias maps to <src>/. Relative specifiers resolve against the importer's dir. */
-function resolveSpec(spec: string, importerFile: string, srcRoot: string): string | null {
-  if (spec.startsWith('@/')) return resolve(srcRoot, spec.slice(2))
+function resolveSpec(spec: string, importerFile: string): string | null {
+  if (spec.startsWith('@/')) return resolve(SRC, spec.slice(2))
   if (spec === '.' || spec === '..' || spec.startsWith('./') || spec.startsWith('../')) {
     return resolve(dirname(importerFile), spec)
   }
@@ -45,11 +50,11 @@ function isUnderModule(p: string): boolean {
 }
 
 /** Offending specifiers in `content` that resolve into (or path-match) the module. */
-export function findFocusNowImports(content: string, importerFile: string, srcRoot = SRC): string[] {
+export function findFocusNowImports(content: string, importerFile: string): string[] {
   const offenders: string[] = []
   for (const m of content.matchAll(SPEC_RE)) {
     const spec = m[1]
-    const resolved = resolveSpec(spec, importerFile, srcRoot)
+    const resolved = resolveSpec(spec, importerFile)
     if ((resolved && isUnderModule(resolved)) || PATH_RE.test(spec)) offenders.push(spec)
   }
   return offenders
@@ -94,6 +99,8 @@ describe('Focus Now inertness', () => {
     ['aliased static', PARENT, "import { FocusNowPanel } from '@/canvas/components/coaching-panel/focus-now'"],
     ['aliased lazy/dynamic', PARENT, "const X = lazy(() => import('@/canvas/components/coaching-panel/focus-now'))"],
     ['require()', PARENT, "const m = require('./focus-now')"],
+    ['side-effect import', PARENT, "import './focus-now'"],
+    ['multiline dynamic import', PARENT, "const m = import(\n      './focus-now'\n    )"],
   ])('FLAGS dynamic/relative import: %s', (_label, importer, code) => {
     expect(findFocusNowImports(code, importer).length).toBeGreaterThan(0)
   })

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
@@ -1,25 +1,22 @@
 /**
- * Inertness guard (CI tripwire).
+ * Mount guard (CI tripwire) — ALLOW-LIST.
  *
- * Focus Now is render-only, unmounted, and behind no feature flag. This test fails
- * if ANY file outside the module imports it — via static import, type-only import,
- * re-export, dynamic import(), React.lazy, or require() — whether by alias
- * ('@/.../focus-now') or RELATIVE path ('./focus-now', '../focus-now',
+ * Focus Now is now mounted in exactly ONE authorised place: ResultsBody renders
+ * `FocusNowContainer` as the second Analysis-tab panel. This test fails if ANY
+ * OTHER file outside the module imports it — via static / type-only / re-export /
+ * dynamic import() / React.lazy / require / side-effect / glued forms, by alias
+ * ('@/.../focus-now') or relative path ('./focus-now', '../focus-now',
  * './focus-now/FocusNowPanel').
  *
- * It RESOLVES each import specifier to an absolute path and checks whether it lands
- * inside the module; it does NOT substring-match whole files. That closes the blind
- * spot found in PR #199 review, where a substring check ('coaching-panel/focus-now')
- * missed relative imports from the parent `coaching-panel` barrel (e.g.
- * `import { FocusNowPanel } from './focus-now'`). The in-test positive/negative
- * controls below are committed coverage, not just PR-body evidence.
+ * It RESOLVES each import specifier to an absolute path (not a substring match), so
+ * the parent-barrel relative-import blind spot found in PR #199 review stays
+ * closed. The authorised importer is exempt; a test below proves that mount is
+ * actually wired (so the allow-list can't silently mask a removed mount), and the
+ * positive/negative controls prove unauthorised imports are still caught.
  *
  * Known limitation (regex-based by design): it does not catch computed/indirect
- * dynamic imports such as `const p = './focus-now'; import(p)`. That is not a
- * current risk for an inert tripwire; an AST/parser-based guard would be more
- * exhaustive if this ever needs to harden further (PR #199 review note).
- *
- * When the deliberate mount PR lands, it must update/remove this guard.
+ * dynamic imports such as `const p = './focus-now'; import(p)`. Out of scope for a
+ * tripwire; an AST/parser-based guard would be more exhaustive (PR #199 review note).
  */
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
@@ -27,6 +24,10 @@ import { dirname, join, resolve, sep } from 'node:path'
 
 const SRC = resolve(process.cwd(), 'src')
 const MODULE_DIR = join(SRC, 'canvas', 'components', 'coaching-panel', 'focus-now')
+
+// The ONE authorised live mount: ResultsBody renders FocusNowContainer as the
+// second Analysis-tab panel. Any OTHER external importer is a guard violation.
+const AUTHORIZED_IMPORTERS = new Set([join(SRC, 'components', 'results', 'ResultsBody.tsx')])
 
 // Capture the specifier of any import / re-export / dynamic import() / require().
 // Covers `from 'x'`, side-effect `import 'x'`, `import('x')`, `require('x')`, and
@@ -75,17 +76,40 @@ function walk(dir: string, acc: string[] = []): string[] {
 }
 
 describe('Focus Now inertness', () => {
-  it('is not imported by any file outside its own module (alias OR relative, static OR dynamic)', () => {
+  it('is imported ONLY by the authorised Analysis-tab mount (alias OR relative, static OR dynamic)', () => {
     const offenders: string[] = []
     for (const file of walk(SRC)) {
       if (file === MODULE_DIR || file.startsWith(MODULE_DIR + sep)) continue
+      if (AUTHORIZED_IMPORTERS.has(file)) continue
       const hits = findFocusNowImports(readFileSync(file, 'utf8'), file)
       if (hits.length) offenders.push(`${file.slice(SRC.length - 3)} -> ${hits.join(', ')}`)
     }
     expect(
       offenders,
-      `Focus Now is render-only/unmounted; nothing outside its module may import it yet:\n${offenders.join('\n')}`,
+      `Only ResultsBody may import Focus Now; remove these other imports:\n${offenders.join('\n')}`,
     ).toEqual([])
+  })
+
+  it('the authorised mount (ResultsBody) actually imports the module', () => {
+    // Guards against the allow-list masking a REMOVED mount: if the panel is
+    // unmounted, this fails — the allow-list entry would otherwise be dead.
+    for (const f of AUTHORIZED_IMPORTERS) {
+      expect(
+        findFocusNowImports(readFileSync(f, 'utf8'), f).length,
+        `${f.slice(SRC.length - 3)} should import focus-now (mount must stay wired)`,
+      ).toBeGreaterThan(0)
+    }
+  })
+
+  it('an UNAUTHORISED importer is still flagged (allow-list is not a blanket exemption)', () => {
+    const unauthorised = join(SRC, 'components', 'results', 'SomeOtherPanel.tsx')
+    expect(AUTHORIZED_IMPORTERS.has(unauthorised)).toBe(false)
+    expect(
+      findFocusNowImports(
+        "import { FocusNowPanel } from '@/canvas/components/coaching-panel/focus-now'",
+        unauthorised,
+      ).length,
+    ).toBeGreaterThan(0)
   })
 
   // Committed positive controls — the import forms a substring check missed.

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
@@ -1,0 +1,69 @@
+/**
+ * FocusNowPanel interaction — one row open at a time, show all/fewer, and the
+ * prefill-only action contract (the panel never auto-sends).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FocusNowPanel } from '../FocusNowPanel'
+import { buildFocusRows } from '../buildFocusRows'
+import { serverRow } from '../__fixtures__/focus.fixtures'
+import type { FocusNowProps } from '../focusTypes'
+
+const staticRows = buildFocusRows({}).rows
+function renderPanel(overrides: Partial<FocusNowProps> = {}) {
+  const props: FocusNowProps = { summary: null, rows: staticRows, banner: { kind: 'none' }, ...overrides }
+  return render(<FocusNowPanel {...props} />)
+}
+
+describe('FocusNowPanel interaction', () => {
+  it('opens one row at a time', () => {
+    renderPanel()
+    const r1 = screen.getByRole('button', { name: /define what success/i })
+    const r2 = screen.getByRole('button', { name: /set a time horizon/i })
+    fireEvent.click(r1)
+    expect(r1).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(r2)
+    expect(r1).toHaveAttribute('aria-expanded', 'false')
+    expect(r2).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('toggles a row closed on a second click', () => {
+    renderPanel()
+    const r1 = screen.getByRole('button', { name: /define what success/i })
+    fireEvent.click(r1)
+    fireEvent.click(r1)
+    expect(r1).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('reveals hidden rows past the default-visible cap, then collapses again', () => {
+    renderPanel({ rows: [serverRow, ...staticRows] }) // 7 rows, cap is 6
+    const reveal = screen.getByTestId('focus-reveal')
+    expect(reveal).toHaveTextContent('Show all 7')
+    fireEvent.click(reveal)
+    expect(reveal).toHaveTextContent('Show fewer')
+  })
+
+  it('shows no reveal when rows fit within the default-visible cap', () => {
+    renderPanel() // exactly 6 static rows
+    expect(screen.queryByTestId('focus-reveal')).toBeNull()
+  })
+
+  it('the "Try this" action prefills the composer and never auto-sends', () => {
+    const onPrefill = vi.fn()
+    renderPanel({ onPrefill })
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    fireEvent.click(screen.getByTestId('focus-action'))
+    expect(onPrefill).toHaveBeenCalledTimes(1)
+    expect(onPrefill).toHaveBeenCalledWith(
+      'Help me think through a risk worth adding to this decision.',
+    )
+  })
+
+  it('Ask Olumi is display-only (clicking it triggers no prefill)', () => {
+    const onPrefill = vi.fn()
+    renderPanel({ onPrefill })
+    fireEvent.click(screen.getByRole('button', { name: /capture an insight/i }))
+    fireEvent.click(screen.getByTestId('focus-ask-olumi'))
+    expect(onPrefill).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/narrow.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/narrow.spec.tsx
@@ -1,0 +1,47 @@
+/**
+ * Narrow layout + keyboard — controls are native, focusable buttons (inherently
+ * keyboard-operable) and the panel renders within a narrow (~360px) container.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FocusNowPanel } from '../FocusNowPanel'
+import { buildFocusRows } from '../buildFocusRows'
+import { serverRow } from '../__fixtures__/focus.fixtures'
+
+const staticRows = buildFocusRows({}).rows
+
+function renderNarrow(ui: React.ReactElement) {
+  return render(<div style={{ width: 360 }}>{ui}</div>)
+}
+
+describe('FocusNowPanel keyboard + narrow', () => {
+  it('row toggles are native, focusable buttons', () => {
+    renderNarrow(<FocusNowPanel summary={null} rows={staticRows} banner={{ kind: 'none' }} />)
+    const row = screen.getByRole('button', { name: /define what success/i })
+    expect(row.tagName).toBe('BUTTON')
+    expect(row).not.toHaveAttribute('tabindex', '-1')
+    row.focus()
+    expect(document.activeElement).toBe(row)
+  })
+
+  it('the action and re-run controls are native buttons', () => {
+    renderNarrow(
+      <FocusNowPanel
+        summary={null}
+        rows={staticRows}
+        banner={{ kind: 'stale', canRerun: true }}
+        onRerun={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('focus-rerun').tagName).toBe('BUTTON')
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    expect(screen.getByTestId('focus-action').tagName).toBe('BUTTON')
+  })
+
+  it('renders the reveal control inside a narrow container without error', () => {
+    renderNarrow(
+      <FocusNowPanel summary={null} rows={[serverRow, ...staticRows]} banner={{ kind: 'none' }} />,
+    )
+    expect(screen.getByTestId('focus-reveal')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/safety.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/safety.spec.tsx
@@ -1,0 +1,42 @@
+/**
+ * Safety — SERVER strings are rendered verbatim as TEXT (gating is row-TYPE
+ * selection by the mapper, never rewriting server copy). No dangerouslySetInnerHTML
+ * path: HTML-looking strings appear literally and parse no elements.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FocusNowPanel } from '../FocusNowPanel'
+import { buildFocusRows } from '../buildFocusRows'
+import { forbiddenSummary, xssSummary, serverRow } from '../__fixtures__/focus.fixtures'
+import type { FocusNowProps, FocusRow } from '../focusTypes'
+
+const staticRows = buildFocusRows({}).rows
+function renderPanel(overrides: Partial<FocusNowProps> = {}) {
+  const props: FocusNowProps = { summary: null, rows: staticRows, banner: { kind: 'none' }, ...overrides }
+  return render(<FocusNowPanel {...props} />)
+}
+
+describe('FocusNowPanel render-as-text safety', () => {
+  it('renders a banned-term server summary verbatim (UI never rewrites server prose)', () => {
+    renderPanel({ summary: forbiddenSummary })
+    expect(screen.getByTestId('focus-summary')).toHaveTextContent(forbiddenSummary)
+  })
+
+  it('renders HTML-looking server prose as literal text, parsing no elements', () => {
+    const { container } = renderPanel({ summary: xssSummary })
+    expect(screen.getByTestId('focus-summary')).toHaveTextContent('this should appear as text')
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('renders server-row strings containing banned terms verbatim', () => {
+    const row: FocusRow = {
+      ...serverRow,
+      primary: 'recommended winner uses the graph',
+      noticed: 'driver sensitivity was flagged',
+    }
+    renderPanel({ rows: [row] })
+    fireEvent.click(screen.getByRole('button', { name: /recommended winner uses the graph/i }))
+    expect(screen.getByTestId('focus-noticed')).toHaveTextContent('driver sensitivity was flagged')
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/tolerance.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/tolerance.spec.tsx
@@ -1,0 +1,43 @@
+/**
+ * Tolerance — malformed / missing / extreme data degrades gracefully and never
+ * crashes; a gated row passed via props is dropped at the render boundary.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FocusNowPanel } from '../FocusNowPanel'
+import { gatedRow } from '../__fixtures__/focus.fixtures'
+import type { FocusRow } from '../focusTypes'
+
+function panel(rows: FocusRow[], summary: string | null = null) {
+  return render(<FocusNowPanel summary={summary} rows={rows} banner={{ kind: 'none' }} />)
+}
+
+describe('FocusNowPanel tolerance', () => {
+  it('renders the empty state when rows is empty', () => {
+    panel([])
+    expect(screen.getByTestId('focus-empty')).toBeInTheDocument()
+  })
+
+  it('does not crash on a row with an empty primary (uses a generic name)', () => {
+    panel([{ id: 'x', ownership: 'static_hygiene', source: 'static_hygiene', primary: '' }])
+    expect(screen.getByRole('button', { name: 'Focus item' })).toBeInTheDocument()
+  })
+
+  it('handles a very long primary without crashing', () => {
+    panel([{ id: 'long', ownership: 'static_hygiene', source: 'static_hygiene', primary: 'x'.repeat(400) }])
+    expect(screen.getByTestId('focus-card')).toBeInTheDocument()
+  })
+
+  it('degrades an unknown target kind to a neutral marker', () => {
+    panel([
+      { id: 'u', ownership: 'server_sourced', source: 'coaching_signal', primary: 'Unknown kind row', targetKind: 'mystery' },
+    ])
+    expect(screen.getByText('Unknown kind row')).toBeInTheDocument()
+  })
+
+  it('drops a gated row passed via props (never renders it)', () => {
+    panel([gatedRow])
+    expect(screen.queryByText(/most influence on the result/i)).toBeNull()
+    expect(screen.getByTestId('focus-empty')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * useFocusNow container — enforces the two boundaries the presentational layer
+ * cannot: (1) the uncertified coaching_summary is gated OFF; (2) the row action
+ * prefills the composer ONLY and never sends. Also maps the live freshness source
+ * to the banner.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { prefillChat, sendMessage, runV2Analysis } = vi.hoisted(() => ({
+  prefillChat: vi.fn(),
+  sendMessage: vi.fn(),
+  runV2Analysis: vi.fn(),
+}))
+
+vi.mock('@/canvas/store', () => ({
+  useCanvasStore: (sel: (s: unknown) => unknown) =>
+    sel({
+      ceeAnalysisReady: { coaching_summary: 'live CEE prose that is not claim-certified' },
+      analysisFreshness: { freshness: 'stale' },
+      analysisFreshnessDirty: false,
+    }),
+}))
+vi.mock('@/canvas/hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis, isRunning: false, cancelRun: vi.fn(), error: null }),
+}))
+vi.mock('@/canvas/stores/guidanceStore', () => ({
+  useGuidanceStore: Object.assign(() => undefined, {
+    getState: () => ({ _prefillChat: prefillChat, _sendMessage: sendMessage }),
+  }),
+}))
+
+import { useFocusNow } from '../useFocusNow'
+
+describe('useFocusNow container', () => {
+  beforeEach(() => {
+    prefillChat.mockClear()
+    sendMessage.mockClear()
+    runV2Analysis.mockClear()
+  })
+
+  it('gates the uncertified coaching_summary OFF (summary is null despite live data)', () => {
+    const { result } = renderHook(() => useFocusNow())
+    expect(result.current.summary).toBeNull()
+  })
+
+  it('still surfaces the static rows and maps freshness to the banner', () => {
+    const { result } = renderHook(() => useFocusNow())
+    expect(result.current.rows.length).toBeGreaterThan(0)
+    expect(result.current.rows.every((r) => r.ownership === 'static_hygiene')).toBe(true)
+    expect(result.current.banner).toEqual({ kind: 'stale', canRerun: true })
+  })
+
+  it('onPrefill prefills the composer only — never sends', () => {
+    const { result } = renderHook(() => useFocusNow())
+    result.current.onPrefill?.('Help me add a risk.')
+    expect(prefillChat).toHaveBeenCalledWith('Help me add a risk.')
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('onRerun triggers a re-run', () => {
+    const { result } = renderHook(() => useFocusNow())
+    result.current.onRerun?.()
+    expect(runV2Analysis).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/buildFocusRows.ts
+++ b/src/canvas/components/coaching-panel/focus-now/buildFocusRows.ts
@@ -71,7 +71,6 @@ export function mapSignalToFocusRow(signal: CoachingSignal | undefined | null): 
     whyItMatters: nonEmpty(signal.priority_reason),
     tryThis,
     targetKind: nonEmpty(signal.target_kind),
-    targetLabel: nonEmpty(signal.target_label),
     ...(tryThis ? { action: { kind: 'prefill' as const, label: FOCUS_COPY.tryThisLabel, prefillText: tryThis } } : {}),
   }
 }

--- a/src/canvas/components/coaching-panel/focus-now/buildFocusRows.ts
+++ b/src/canvas/components/coaching-panel/focus-now/buildFocusRows.ts
@@ -1,0 +1,104 @@
+/**
+ * Focus Now — pure view-model mapper.
+ *
+ * Composes the rows the panel renders, honestly and render-only (F.6):
+ *   - server_sourced rows first, in RECEIVED order (never ranked/sorted/selected),
+ *     mapped from a structured coaching signal reading ONLY allow-listed human
+ *     fields — never a science field, so a gated row can't be constructed here;
+ *   - the fixed static_hygiene rows next (unless suppressed);
+ *   - gated rows dropped (belt-and-braces), empty-primary rows dropped,
+ *     duplicate ids dropped.
+ *
+ * `coaching_summary` is NOT mapped to a row — it has no per-entity grounding to
+ * justify one — it maps to the panel summary line, verbatim, and is never
+ * synthesised. (It is also NOT claim-certified; the live container gates its
+ * display — see useFocusNow.)
+ *
+ * Pure and fail-closed: malformed input degrades to "static rows only, no
+ * summary" and never throws.
+ */
+import type { CoachingSignal } from '../types'
+import type { FocusRow } from './focusTypes'
+import { STATIC_HYGIENE_ROWS } from './focusConstants'
+
+export interface BuildFocusRowsInput {
+  /** Live: store.ceeAnalysisReady?.coaching_summary. NOT claim-certified. */
+  coachingSummary?: string | null
+  /** Future Lane-A structured coaching signals. Default none. */
+  signals?: readonly CoachingSignal[]
+  /** Escape hatch for a context that suppresses the generic nudges. Default false. */
+  suppressStatic?: boolean
+}
+
+export interface FocusViewModel {
+  /** Verbatim orientation line, or null. Never synthesised. */
+  summary: string | null
+  rows: FocusRow[]
+}
+
+function nonEmpty(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined
+}
+
+/** Remove any row that claims gated ownership. The mapper never emits one; this defends the render path. */
+export function dropGatedRows(rows: readonly FocusRow[]): FocusRow[] {
+  return rows.filter((r) => r && r.ownership !== 'gated')
+}
+
+/**
+ * Map a structured coaching signal to a server_sourced row. Reads ONLY human
+ * allow-listed fields (observation, priority_reason, first suggested action,
+ * target). Numeric priority, lifecycle, evidence, staleness and any science
+ * field are deliberately ignored. Returns null when there is no usable line.
+ *
+ * One-way DISPLAY adaptation only: the canonical coaching wire shape is owned
+ * upstream by CEE, not here. `FocusRow` is internal UI state — a server signal
+ * maps INTO it for rendering, never the reverse.
+ */
+export function mapSignalToFocusRow(signal: CoachingSignal | undefined | null): FocusRow | null {
+  if (!signal || typeof signal !== 'object') return null
+  const observation = nonEmpty(signal.grounding?.observation)
+  if (!observation) return null
+
+  const tryThis = nonEmpty(signal.suggested_actions?.[0]?.label)
+  const id = nonEmpty(signal.signal_id) ?? observation
+
+  return {
+    id: `signal:${id}`,
+    ownership: 'server_sourced',
+    source: 'coaching_signal',
+    primary: observation,
+    whyItMatters: nonEmpty(signal.priority_reason),
+    tryThis,
+    targetKind: nonEmpty(signal.target_kind),
+    targetLabel: nonEmpty(signal.target_label),
+    ...(tryThis ? { action: { kind: 'prefill' as const, label: 'Try this', prefillText: tryThis } } : {}),
+  }
+}
+
+export function buildFocusRows(input: BuildFocusRowsInput = {}): FocusViewModel {
+  const summary = nonEmpty(input.coachingSummary) ?? null
+
+  const signals = Array.isArray(input.signals) ? input.signals : []
+  const serverRows = signals
+    .map(mapSignalToFocusRow)
+    .filter((r): r is FocusRow => r != null)
+
+  const staticRows = input.suppressStatic ? [] : STATIC_HYGIENE_ROWS
+
+  // Fixed structural order — positional composition, NOT meaning-based ranking.
+  const combined = dropGatedRows([...serverRows, ...staticRows]).filter(
+    (r) => nonEmpty(r.primary) != null,
+  )
+
+  // Drop duplicate ids (first occurrence wins). Namespaced ids make this near-impossible.
+  const seen = new Set<string>()
+  const rows: FocusRow[] = []
+  for (const r of combined) {
+    if (seen.has(r.id)) continue
+    seen.add(r.id)
+    rows.push(r)
+  }
+
+  return { summary, rows }
+}

--- a/src/canvas/components/coaching-panel/focus-now/buildFocusRows.ts
+++ b/src/canvas/components/coaching-panel/focus-now/buildFocusRows.ts
@@ -19,7 +19,7 @@
  */
 import type { CoachingSignal } from '../types'
 import type { FocusRow } from './focusTypes'
-import { STATIC_HYGIENE_ROWS } from './focusConstants'
+import { FOCUS_COPY, STATIC_HYGIENE_ROWS } from './focusConstants'
 
 export interface BuildFocusRowsInput {
   /** Live: store.ceeAnalysisReady?.coaching_summary. NOT claim-certified. */
@@ -72,7 +72,7 @@ export function mapSignalToFocusRow(signal: CoachingSignal | undefined | null): 
     tryThis,
     targetKind: nonEmpty(signal.target_kind),
     targetLabel: nonEmpty(signal.target_label),
-    ...(tryThis ? { action: { kind: 'prefill' as const, label: 'Try this', prefillText: tryThis } } : {}),
+    ...(tryThis ? { action: { kind: 'prefill' as const, label: FOCUS_COPY.tryThisLabel, prefillText: tryThis } } : {}),
   }
 }
 

--- a/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
@@ -1,0 +1,126 @@
+/**
+ * Focus Now — UI-authored copy + the static decision-hygiene rows.
+ *
+ * Everything here is UI-AUTHORED and therefore copy-hygiene-tested: sentence
+ * case, British English, no all-caps, no em dashes, free of the forbidden
+ * glossary terms. Server-supplied strings (e.g. `coaching_summary`) are NOT in
+ * this file — they are rendered verbatim and never scanned or rewritten (F.6).
+ *
+ * The six static rows are GENERIC modelling nudges. They are unconditional (their
+ * presence never depends on the user's model) and they never claim Olumi detected
+ * a specific problem — so none of them carries a `noticed` line. Anything that
+ * would interpret the user's model (missing evidence, weak options, best next
+ * question, …) is server-owned and is NOT here.
+ */
+import type { FocusRow } from './focusTypes'
+
+/** Rows shown before the "show all / fewer" reveal. Display chunking, not selection. */
+export const FOCUS_DEFAULT_VISIBLE = 6
+
+/**
+ * Single, easily-changed visible title. The static-only release uses a
+ * NON-situational title: six fixed generic rows cannot honestly claim situational
+ * priority. "Focus now" is reserved for a later version with server-sourced,
+ * prioritised coaching rows. Change this one constant to retitle.
+ */
+export const FOCUS_TITLE = 'Strengthen your model'
+
+export const FOCUS_COPY = {
+  /** Region accessible name + visible header (both = FOCUS_TITLE). */
+  panelAria: FOCUS_TITLE,
+  header: FOCUS_TITLE,
+  /** Shown when there are no rows (absence of data, never a computed judgement). */
+  emptyState: 'Nothing to focus on right now.',
+  /** Bold lead-in before a row's nudge. */
+  tryThisLabel: 'Try this',
+  /** Icon-only, display-only affordance label. */
+  askOlumi: 'Ask Olumi',
+  /** Generic accessible name for a row whose primary line is empty (operability, not a title). */
+  itemFallback: 'Focus item',
+  /** Reveal-toggle copy. */
+  showAll: (n: number) => `Show all ${n}`,
+  showFewer: 'Show fewer',
+  /**
+   * Panel-level freshness banner copy.
+   *
+   * The freshness VERDICT is single-sourced (classifyFreshnessForDisplay — the
+   * certified PRs 195/197 source). The COPY below is a LOCAL LITERAL, not the
+   * shared FRESHNESS_COPY constant (src/components/results/AnalysisFreshnessNotice
+   * .tsx), because that canonical string ('Model changed since this analysis.
+   * Re-run to update.') bundles its own CTA — which would double-render against
+   * this panel's separate Re-run button — and uses different wording.
+   * INERT-ONLY DEBT + LIVE-MOUNT BLOCKER: before any live mount, reconcile this to
+   * the single freshness-copy source (consume FRESHNESS_COPY, or have that source
+   * own this wording) so freshness surfaces cannot drift.
+   */
+  staleText: 'These results may be out of date because the model has changed since the last analysis.',
+  rerunLabel: 'Re-run analysis',
+  cannotConfirmText: 'We cannot confirm these results are up to date.',
+} as const
+
+/**
+ * The six sanctioned static hygiene rows. Order is fixed and structural — it
+ * never depends on the user's model (that would make it server-owned).
+ */
+export const STATIC_HYGIENE_ROWS: readonly FocusRow[] = [
+  {
+    id: 'static:define-success',
+    ownership: 'static_hygiene',
+    source: 'static_hygiene',
+    primary: 'Define what success looks like',
+    whyItMatters: 'A clear goal gives everything else something to aim at.',
+    tryThis: 'Write a one-line goal you would be happy to be judged on.',
+    iconKey: 'target',
+    action: { kind: 'prefill', label: 'Define success', prefillText: 'Help me define what success looks like for this decision.' },
+  },
+  {
+    id: 'static:set-time-horizon',
+    ownership: 'static_hygiene',
+    source: 'static_hygiene',
+    primary: 'Set a time horizon',
+    whyItMatters: 'Knowing when the outcome lands shapes what counts as a good choice.',
+    tryThis: 'Note the date or window by which this needs to pay off.',
+    iconKey: 'clock',
+    action: { kind: 'prefill', label: 'Set a horizon', prefillText: 'Help me set a sensible time horizon for this decision.' },
+  },
+  {
+    id: 'static:add-outcome',
+    ownership: 'static_hygiene',
+    source: 'static_hygiene',
+    primary: 'Add an outcome you care about',
+    whyItMatters: 'Naming the result you want keeps the options honest.',
+    tryThis: 'Add one outcome that would tell you this went well.',
+    iconKey: 'flag',
+    action: { kind: 'prefill', label: 'Add an outcome', prefillText: 'Help me add an outcome I care about for this decision.' },
+  },
+  {
+    id: 'static:add-risk',
+    ownership: 'static_hygiene',
+    source: 'static_hygiene',
+    primary: 'Add a risk worth watching',
+    whyItMatters: 'Spelling out what could go wrong is easier before you commit.',
+    tryThis: 'Add one thing that could set this back.',
+    iconKey: 'shield-alert',
+    action: { kind: 'prefill', label: 'Add a risk', prefillText: 'Help me think through a risk worth adding to this decision.' },
+  },
+  {
+    id: 'static:add-constraint',
+    ownership: 'static_hygiene',
+    source: 'static_hygiene',
+    primary: 'Add a constraint you are working within',
+    whyItMatters: 'Limits on budget, time or people change which options are real.',
+    tryThis: 'Add one limit the decision has to live within.',
+    iconKey: 'scale',
+    action: { kind: 'prefill', label: 'Add a constraint', prefillText: 'Help me capture a constraint that shapes this decision.' },
+  },
+  {
+    id: 'static:capture-insight',
+    ownership: 'static_hygiene',
+    source: 'static_hygiene',
+    primary: 'Capture an insight while it is fresh',
+    whyItMatters: 'A note now saves re-deriving the same thought later.',
+    tryThis: 'Jot down one thing you have learned so far.',
+    iconKey: 'lightbulb',
+    action: { kind: 'prefill', label: 'Capture insight', prefillText: 'Help me capture an insight I have had about this decision.' },
+  },
+]

--- a/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
@@ -1,0 +1,110 @@
+/**
+ * Focus Now — typed row-ownership model.
+ *
+ * The Focus Now panel is grounded in an explicit OWNERSHIP model so the UI is
+ * honest about what it may author versus what must come from the server.
+ *
+ * `FocusRow` is INTERNAL UI DISPLAY STATE ONLY. It is NOT a CEE/server contract,
+ * boundary type, or wire schema, and must not be treated as one — it does not
+ * mirror any wire contract. The canonical wire shapes are owned upstream; this
+ * model only describes what the panel renders, and it deliberately does NOT import
+ * from `@talchain/schemas` (the structured coaching wire — "Lane A" — is not open
+ * yet). A server-provided coaching signal is mapped INTO this display shape (see
+ * buildFocusRows), never the reverse.
+ *
+ * Invariant F.6 — render, do not compute. These types describe data the UI is
+ * GIVEN (static UI-owned hygiene rows) or PASSED THROUGH (server copy, verbatim).
+ * The renderer never ranks, prioritises, selects, interprets the model, or
+ * derives staleness; those belong to CEE.
+ */
+
+/**
+ * Who owns a row.
+ *
+ * - `static_hygiene` — UI-authored generic decision-hygiene prompt. Allowed ONLY
+ *   when unconditional and generic; it must NOT claim Olumi detected anything in
+ *   the user's model (so a static row never carries `noticed`).
+ * - `server_sourced` — presence/wording depends on the user's model/analysis/
+ *   evidence; rendered ONLY when the source field exists, copy passed through
+ *   verbatim. Today the only live server source is `coaching_summary` (mapped to
+ *   the panel summary line, not a row).
+ * - `gated` — science-heavy content (influence/sensitivity/drivers/EVPI/fragility/
+ *   flip/confidence/"what would change"). The mapper NEVER emits one; the type
+ *   member exists so a test can pass one in and assert it is dropped.
+ */
+export type FocusOwnership = 'static_hygiene' | 'server_sourced' | 'gated'
+
+/**
+ * Provenance tag for traceability/tests/dev only. Never rendered as prose.
+ * Open string so future server sources are tolerated.
+ */
+export type FocusSource = 'static_hygiene' | 'coaching_summary' | 'coaching_signal' | (string & {})
+
+/**
+ * Display-only action descriptor. NOTHING here executes inside the presentational
+ * component — it is handed to an injected handler. `prefill` drops text into the
+ * chat composer (never auto-sends); `ask_olumi` is the existing display-only
+ * sparkle affordance.
+ */
+export type FocusActionKind = 'prefill' | 'ask_olumi'
+
+export interface FocusAction {
+  kind: FocusActionKind
+  /** For kind='prefill': composer text. UI-authored (static) or verbatim (server). */
+  prefillText?: string
+  /** Visible control label. UI-authored, banned-term-safe. */
+  label: string
+}
+
+export interface FocusRow {
+  /** Stable, namespaced id ('static:add-risk' / 'signal:<id>'). Used as React key + dedup. */
+  id: string
+  ownership: FocusOwnership
+  source: FocusSource
+  /** Collapsed primary line (the title). Always present and non-empty for a renderable row. */
+  primary: string
+  /**
+   * "What Olumi noticed" — ONLY set for server_sourced rows (verbatim server
+   * copy). NEVER set for static_hygiene (that line would falsely claim detection).
+   */
+  noticed?: string
+  /** "Why it matters" — generic content-free string (static) or verbatim (server). */
+  whyItMatters?: string
+  /** "Try this" nudge shown in the expanded body. */
+  tryThis?: string
+  /** Optional neutral topical icon key (static rows). Maps to a Lucide icon in the card. */
+  iconKey?: string
+  /** Optional entity cue (server rows that reference a real entity). Unknown kind → neutral dot. */
+  targetKind?: string
+  targetLabel?: string
+  /** The single safe action wired to the row. Display/prefill-only. */
+  action?: FocusAction
+}
+
+/** Panel-level freshness banner state (output of the freshness adapter). */
+export type FocusBannerState =
+  | { kind: 'none' }
+  /** CEE 'stale' or a local edit downgraded a retained 'fresh' → offer a re-run. */
+  | { kind: 'stale'; canRerun: true }
+  /** Overlay 'unknown' — neutral "cannot confirm", NEVER shown as stale, no rerun. */
+  | { kind: 'cannot_confirm' }
+
+/** Props for the presentational FocusNowPanel — prop-driven, store-free. */
+export interface FocusNowProps {
+  /**
+   * Verbatim orientation line from `coaching_summary`, or null.
+   * NOT claim-certified (CEE prose). In the unmounted component this is exercised
+   * only for tolerance/layout/XSS-safety; the live container defaults it to null
+   * until it is hidden or Gate-Zero-certified upstream.
+   */
+  summary: string | null
+  rows: FocusRow[]
+  banner: FocusBannerState
+  /** Prefill the chat composer (no auto-send). Injected; presentational tree owns no store. */
+  onPrefill?: (text: string) => void
+  /** Trigger a re-run of analysis. Injected. */
+  onRerun?: () => void
+  /** Disable the re-run affordance while a run is in flight. */
+  rerunDisabled?: boolean
+  className?: string
+}

--- a/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
@@ -105,5 +105,12 @@ export interface FocusNowProps {
   onRerun?: () => void
   /** Disable the re-run affordance while a run is in flight. */
   rerunDisabled?: boolean
+  /**
+   * Whether to render the panel's own freshness/stale banner. Default true
+   * (standalone use). Set false when mounted inside a surface that already owns
+   * freshness (e.g. ResultsBody renders AnalysisFreshnessNotice) so the trust
+   * surface shows a SINGLE stale notice, not a duplicate.
+   */
+  showFreshnessBanner?: boolean
   className?: string
 }

--- a/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
@@ -76,7 +76,6 @@ export interface FocusRow {
   iconKey?: string
   /** Optional entity cue (server rows that reference a real entity). Unknown kind → neutral dot. */
   targetKind?: string
-  targetLabel?: string
   /** The single safe action wired to the row. Display/prefill-only. */
   action?: FocusAction
 }

--- a/src/canvas/components/coaching-panel/focus-now/freshnessBanner.ts
+++ b/src/canvas/components/coaching-panel/focus-now/freshnessBanner.ts
@@ -1,0 +1,29 @@
+/**
+ * Focus Now — freshness → banner adapter (pure).
+ *
+ * Maps the canonical display freshness semantic (`classifyFreshnessForDisplay`,
+ * the single source used by the live Results stale banner + StaleAnalysisBadge)
+ * to the panel's one banner state. The UI never derives staleness itself (F.6);
+ * it renders this verdict.
+ *
+ * Hard rule (mirrors analysisFreshness.ts): the cannot-confirm state must NEVER
+ * be shown as stale — it gets a neutral note and offers no re-run-as-stale. Only
+ * a genuine 'changed' verdict offers the re-run affordance.
+ */
+import type { FreshnessDisplaySemantic } from '@/canvas/store/analysisFreshness'
+import type { FocusBannerState } from './focusTypes'
+
+export function freshnessToBanner(
+  semantic: FreshnessDisplaySemantic | null | undefined,
+): FocusBannerState {
+  switch (semantic) {
+    case 'changed':
+      return { kind: 'stale', canRerun: true }
+    case 'cannot_confirm':
+      return { kind: 'cannot_confirm' }
+    case 'current':
+    case 'none':
+    default:
+      return { kind: 'none' }
+  }
+}

--- a/src/canvas/components/coaching-panel/focus-now/index.ts
+++ b/src/canvas/components/coaching-panel/focus-now/index.ts
@@ -1,11 +1,12 @@
 /**
  * Focus Now — public entry.
  *
- * Render-only coaching surface. The future mount PR can `lazy(() => import(...))`
- * `FocusNowPanel` and wire it with `useFocusNow` from the Analysis tab. The
- * presentational component and pure helpers carry no heavy deps; `useFocusNow`
- * (the container) is the only store-aware export.
+ * Static / fail-closed coaching surface. `FocusNowContainer` is the authorised
+ * live mount (wired by ResultsBody as the second Analysis-tab panel, the only
+ * importer the inertness guard allow-lists). The presentational `FocusNowPanel` +
+ * pure helpers carry no heavy deps; `useFocusNow` is the only store-aware export.
  */
+export { FocusNowContainer } from './FocusNowContainer'
 export { FocusNowPanel, default } from './FocusNowPanel'
 export { FocusBanner } from './FocusBanner'
 export { FocusRowCard } from './FocusRowCard'

--- a/src/canvas/components/coaching-panel/focus-now/index.ts
+++ b/src/canvas/components/coaching-panel/focus-now/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Focus Now — public entry.
+ *
+ * Render-only coaching surface. The future mount PR can `lazy(() => import(...))`
+ * `FocusNowPanel` and wire it with `useFocusNow` from the Analysis tab. The
+ * presentational component and pure helpers carry no heavy deps; `useFocusNow`
+ * (the container) is the only store-aware export.
+ */
+export { FocusNowPanel, default } from './FocusNowPanel'
+export { FocusBanner } from './FocusBanner'
+export { FocusRowCard } from './FocusRowCard'
+export { FocusNowEmpty } from './FocusNowEmpty'
+export { buildFocusRows, mapSignalToFocusRow, dropGatedRows } from './buildFocusRows'
+export { freshnessToBanner } from './freshnessBanner'
+export { useFocusNow } from './useFocusNow'
+export { STATIC_HYGIENE_ROWS, FOCUS_COPY, FOCUS_DEFAULT_VISIBLE } from './focusConstants'
+export type {
+  FocusRow,
+  FocusOwnership,
+  FocusSource,
+  FocusAction,
+  FocusActionKind,
+  FocusBannerState,
+  FocusNowProps,
+} from './focusTypes'
+export type { BuildFocusRowsInput, FocusViewModel } from './buildFocusRows'

--- a/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
+++ b/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
@@ -1,0 +1,73 @@
+/**
+ * useFocusNow — the ONLY store-aware file in the Focus Now module.
+ *
+ * Reads live state and returns the prop bag for the presentational FocusNowPanel,
+ * so the rendered tree owns no store, no network and no private store APIs. The
+ * component is currently unmounted; this hook is the ready-to-wire container for
+ * the future mount PR.
+ *
+ * Two boundaries are enforced here, not in the presentational layer:
+ *  1. CLAIM-SAFETY — `coaching_summary` is uncertified CEE prose. The banned-terms
+ *     tests certify UI-authored copy ONLY, never server prose. Display therefore
+ *     defaults OFF (CERTIFY_SUMMARY=false). A live mount must keep it hidden or
+ *     flip this on ONLY once the summary is passed through Gate Zero / certified
+ *     CEE output. Do not call the panel live-safe while it shows uncertified prose.
+ *  2. PREFILL-ONLY — the row action drains to the composer via `_prefillChat`.
+ *     There is deliberately NO `_sendMessage` fallback: Focus Now never auto-sends.
+ */
+import { useCallback, useMemo } from 'react'
+import { useCanvasStore } from '@/canvas/store'
+import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import { useV2Run } from '@/canvas/hooks/useV2Run'
+import { classifyFreshnessForDisplay } from '@/canvas/store/analysisFreshness'
+import { buildFocusRows } from './buildFocusRows'
+import { freshnessToBanner } from './freshnessBanner'
+import type { FocusNowProps } from './focusTypes'
+
+/**
+ * See boundary (1) above. HARD MOUNT-PR GATE — keep false until ALL are resolved
+ * (none are resolved today; do not flip on assumption):
+ *   - the exact live field / carrier of `coaching_summary` is unresolved unless
+ *     verified (read here from `ceeAnalysisReady`, a generic-model carrier — see
+ *     the store.ts caveat that it is NOT scenario-scoped);
+ *   - draft-time vs post-analysis enrichment phase is unresolved unless verified;
+ *   - a possible stale / phase-mismatch risk is unresolved unless verified;
+ *   - a live mount MUST hide it until Gate Zero / certified CEE output exists.
+ * Until then display is fail-closed (null), so the inert component is unaffected.
+ */
+const CERTIFY_SUMMARY = false
+
+export function useFocusNow(): FocusNowProps {
+  const rawSummary = useCanvasStore((s) => s.ceeAnalysisReady?.coaching_summary ?? null)
+  const freshness = useCanvasStore((s) => s.analysisFreshness)
+  const dirty = useCanvasStore((s) => s.analysisFreshnessDirty)
+  const { runV2Analysis, isRunning } = useV2Run()
+
+  // Uncertified prose is gated OFF; the data path stays visible for the mount PR.
+  const coachingSummary = CERTIFY_SUMMARY ? rawSummary : null
+
+  const vm = useMemo(() => buildFocusRows({ coachingSummary }), [coachingSummary])
+  const banner = useMemo(
+    () => freshnessToBanner(classifyFreshnessForDisplay(freshness, dirty)),
+    [freshness, dirty],
+  )
+
+  const onPrefill = useCallback((text: string) => {
+    // Prefill ONLY — never auto-send.
+    const prefill = useGuidanceStore.getState()._prefillChat
+    if (prefill) prefill(text)
+  }, [])
+
+  const onRerun = useCallback(() => {
+    void runV2Analysis()
+  }, [runV2Analysis])
+
+  return {
+    summary: vm.summary,
+    rows: vm.rows,
+    banner,
+    onPrefill,
+    onRerun,
+    rerunDisabled: isRunning,
+  }
+}

--- a/src/canvas/components/coaching-panel/index.ts
+++ b/src/canvas/components/coaching-panel/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Coaching panel — public entry.
+ *
+ * Render-only Phase 0 surface. The later mount PR can `lazy(() => import(...))`
+ * this module from the Analysis tab once Lane A's coaching wire is live.
+ */
+export { CoachingPanel, default } from './CoachingPanel'
+export type { CoachingPanelProps } from './CoachingPanel'
+export type {
+  Coaching,
+  CoachingSignal,
+  CoachingGrounding,
+  CoachingMove,
+  CoachingSource,
+  CoachingTargetKind,
+  CoachingSuggestedAction,
+  CoachingEvidenceItem,
+  CoachingStaleness,
+} from './types'

--- a/src/canvas/components/coaching-panel/types.ts
+++ b/src/canvas/components/coaching-panel/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Coaching panel — LOCAL typed mock of the coaching envelope.
+ *
+ * Phase 0 render layer. This is the ONLY place the shape is declared. We do NOT
+ * import from `@talchain/schemas`: Lane A (the structured coaching wire) is not
+ * open yet, so this mirrors the agreed envelope shape from the brief and stays
+ * deliberately tolerant. When Lane A's contract lands (envelope spec v0.3 /
+ * signal contract v0.3 — not yet in the repo), reconcile this file and the
+ * fixtures against it.
+ *
+ * Invariant F.6 — render, do not compute. These types describe data the UI is
+ * GIVEN. The renderer never ranks, prioritises, selects, transitions lifecycle,
+ * or derives staleness; those belong to CEE.
+ */
+
+/**
+ * UNCONFIRMED enum. `move` is a technical signal field. It is used for
+ * traceability/tests/debug only (see UX amendment 3) — never rendered as
+ * user-facing copy. Kept as an open string so unknown values are tolerated.
+ */
+export type CoachingMove = string
+
+/**
+ * UNCONFIRMED enum. `source` is a technical provenance field. Traceability-only;
+ * never rendered as user-facing copy. Open string so unknowns are tolerated.
+ */
+export type CoachingSource = string
+
+/**
+ * Entity kind the coaching is about. Known kinds drive the entity shape/colour
+ * cue; unknown/absent kinds degrade to a neutral marker (never a raw string).
+ * `(string & {})` keeps literal autocomplete while tolerating any value.
+ */
+export type CoachingTargetKind = 'goal' | 'option' | 'factor' | (string & {})
+
+export interface CoachingGrounding {
+  /** Human-readable observation. The collapsed primary line (no invented title). */
+  observation: string
+  /** Technical refs — traceability/debug only, never user-facing copy. */
+  field_refs?: string[]
+}
+
+export interface CoachingSuggestedAction {
+  id?: string
+  /** Human label. Display-only this phase (no execution). */
+  label: string
+}
+
+export interface CoachingEvidenceItem {
+  /** Human label. */
+  label: string
+  /** Technical ref — traceability/debug only. */
+  ref?: string
+}
+
+export interface CoachingStaleness {
+  /** Human label rendered verbatim when present (fixture-only this phase). */
+  label?: string
+  [key: string]: unknown
+}
+
+export interface CoachingSignal {
+  signal_id: string
+  move: CoachingMove
+  source: CoachingSource
+  grounding: CoachingGrounding
+  target_kind?: CoachingTargetKind
+  /** Technical refs — traceability/debug only. */
+  target_refs?: string[]
+  /** Human label for the target entity (user-facing). */
+  target_label?: string
+
+  // ── Roadmap fields: OPTIONAL, fixture-only future-state render. Never assumed
+  //    live and never drive production behaviour (UX amendment 7). ──
+  /** Render-only; NEVER used to sort/rank (F.6). Numeric priority is not shown as prose. */
+  priority?: number | string
+  /** Human prose, rendered verbatim when present. */
+  priority_reason?: string
+  /** Lifecycle label rendered verbatim as a badge; no transition logic (F.6). */
+  lifecycle_state?: string
+  suggested_actions?: CoachingSuggestedAction[]
+  evidence?: CoachingEvidenceItem[]
+  staleness?: CoachingStaleness
+}
+
+export interface Coaching {
+  /** Envelope version metadata; not rendered. */
+  version: string
+  /** Orientation summary line (user-facing). Omitted from the UI when absent. */
+  summary?: string
+  signals: CoachingSignal[]
+}

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -29,7 +29,7 @@ import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
 import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
 import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
-import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled } from '@/flags'
+import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled } from '@/flags'
 
 export interface StrengthCorrectionDisplay {
   edgeId: string
@@ -237,10 +237,14 @@ export const ResultsBody = memo(function ResultsBody({
 
       {/* ── SECOND PANEL: Strengthen your model (Focus) ───────────────
           Static / fail-closed coaching panel mounted directly after the hero.
-          coaching_summary stays gated off; no server/dynamic/readiness/bias rows. */}
-      <SectionErrorBoundary section="Strengthen your model">
-        <FocusNowContainer />
-      </SectionErrorBoundary>
+          coaching_summary stays gated off; no server/dynamic/readiness/bias rows.
+          Default-ON flag (kill switch); suppresses its own stale banner (the tab's
+          AnalysisFreshnessNotice owns freshness). */}
+      {isFocusNowPanelEnabled() && (
+        <SectionErrorBoundary section="Strengthen your model">
+          <FocusNowContainer />
+        </SectionErrorBoundary>
+      )}
 
       {/* Old RecommendationSection/HeroSection suppressed — triage panel replaces it */}
 

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -28,6 +28,7 @@ import { DecisionConfidencePanel } from './DecisionConfidencePanel'
 import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
 import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
+import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
 import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled } from '@/flags'
 
 export interface StrengthCorrectionDisplay {
@@ -232,6 +233,13 @@ export const ResultsBody = memo(function ResultsBody({
       )}
       <SectionErrorBoundary section="Decision confidence">
         {showV17 && !showCompare ? heroV17Element : decisionConfidenceElement}
+      </SectionErrorBoundary>
+
+      {/* ── SECOND PANEL: Strengthen your model (Focus) ───────────────
+          Static / fail-closed coaching panel mounted directly after the hero.
+          coaching_summary stays gated off; no server/dynamic/readiness/bias rows. */}
+      <SectionErrorBoundary section="Strengthen your model">
+        <FocusNowContainer />
       </SectionErrorBoundary>
 
       {/* Old RecommendationSection/HeroSection suppressed — triage panel replaces it */}

--- a/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
@@ -30,10 +30,12 @@ vi.mock('@/flags', async () => {
     ...actual,
     isAnalysisHeroV17Enabled: vi.fn(() => false),
     isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
   }
 })
 
-import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled } from '@/flags'
+import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled } from '@/flags'
+import { useCanvasStore } from '@/canvas/store'
 
 function makeData(): ResultsSectionDataReturn {
   const winner = { id: 'opt_a', label: 'Option A', expectedValue: 0.8, p10: 0.6, p90: 0.95, winProbability: 0.7, goalProbability: 0.7 } as unknown as OptionResult
@@ -80,11 +82,32 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
   beforeEach(() => {
     vi.mocked(isAnalysisHeroV17Enabled).mockReturnValue(false)
     vi.mocked(isAnalysisHeroCompareEnabled).mockReturnValue(false)
+    vi.mocked(isFocusNowPanelEnabled).mockReturnValue(true)
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
   })
 
-  it('mounts the Focus panel', () => {
+  it('mounts the Focus panel (flag default-ON)', () => {
     renderBody()
     expect(screen.getByTestId('focus-now-panel')).toBeInTheDocument()
+  })
+
+  it('flag OFF: Focus panel absent, hero + options unchanged and still ordered', () => {
+    vi.mocked(isFocusNowPanelEnabled).mockReturnValue(false)
+    renderBody()
+    expect(screen.queryByTestId('focus-now-panel')).toBeNull()
+    const hero = screen.getByTestId('decision-confidence-panel')
+    const options = screen.getByTestId('section-header-options')
+    expect(hero).toBeInTheDocument()
+    expect(before(hero, options), 'hero still precedes options when Focus is off').toBe(true)
+  })
+
+  it('STALE verdict: the mounted panel shows NO second stale banner (no duplicate)', () => {
+    // Drive the freshness source stale; AnalysisFreshnessNotice owns the notice,
+    // and the mounted Focus panel must NOT add its own (showFreshnessBanner=false).
+    useCanvasStore.setState({ analysisFreshness: { freshness: 'stale' }, analysisFreshnessDirty: false })
+    renderBody()
+    expect(screen.getByTestId('focus-now-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('focus-banner')).toBeNull()
   })
 
   it('renders the Focus panel AFTER the hero and BEFORE the options section', () => {

--- a/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
@@ -1,0 +1,106 @@
+/**
+ * ResultsBody — Focus / "Strengthen your model" panel placement.
+ *
+ * Proves the static Focus panel is mounted as the SECOND Analysis-tab panel:
+ * immediately after the hero (DecisionConfidencePanel / AnalysisHeroV17) and
+ * before the Options Comparison section. Render-only, fail-closed: the panel
+ * shows the generic static hygiene rows with no server/dynamic content (default
+ * store state → no summary, no freshness banner).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+  }
+})
+
+import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled } from '@/flags'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = { id: 'opt_a', label: 'Option A', expectedValue: 0.8, p10: 0.6, p90: 0.95, winProbability: 0.7, goalProbability: 0.7 } as unknown as OptionResult
+  const runnerUp = { id: 'opt_b', label: 'Option B', expectedValue: 0.4, p10: 0.2, p90: 0.6, winProbability: 0.3, goalProbability: 0.3 } as unknown as OptionResult
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+  const drivers: DriversSectionData = { drivers: [], topDrivers: [], driversStatus: 'computed', totalCount: 0, hasMagnitudeData: false }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [], topUncertainties: [], improvements: [], topImprovements: [],
+    evidenceGaps: [], topEvidenceGaps: [], nextActions: [], topNextActions: [],
+  } as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = { improvements: [], count: 0, hasHighPriority: false }
+  return {
+    recommendation, drivers, confidence, improvements,
+    isLoading: false, isError: false, goalLabel: 'Maximise success',
+  } as ResultsSectionDataReturn
+}
+
+function renderBody() {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+const before = (a: HTMLElement, b: HTMLElement) =>
+  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', () => {
+  beforeEach(() => {
+    vi.mocked(isAnalysisHeroV17Enabled).mockReturnValue(false)
+    vi.mocked(isAnalysisHeroCompareEnabled).mockReturnValue(false)
+  })
+
+  it('mounts the Focus panel', () => {
+    renderBody()
+    expect(screen.getByTestId('focus-now-panel')).toBeInTheDocument()
+  })
+
+  it('renders the Focus panel AFTER the hero and BEFORE the options section', () => {
+    renderBody()
+    const hero = screen.getByTestId('decision-confidence-panel')
+    const focus = screen.getByTestId('focus-now-panel')
+    const options = screen.getByTestId('section-header-options')
+    expect(before(hero, focus), 'hero must precede the Focus panel').toBe(true)
+    expect(before(focus, options), 'Focus panel must precede the options section').toBe(true)
+  })
+
+  it('is fail-closed: shows static hygiene rows, no server summary', () => {
+    renderBody()
+    // generic static prompt present…
+    expect(screen.getByText('Define what success looks like')).toBeInTheDocument()
+    // …and no verbatim server summary line (coaching_summary gated off)
+    expect(screen.queryByTestId('focus-summary')).toBeNull()
+  })
+})

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -306,6 +306,17 @@ const FLAGS_CONFIG = {
     envKey: 'VITE_FEATURE_ANALYSIS_HERO_V17',
     storageKey: 'feature.analysisHeroV17',
   },
+  // Focus / "Strengthen your model" panel — controls ONLY the visibility of the
+  // mounted STATIC panel (the 2nd Analysis-tab panel). DEFAULT-ON for review/
+  // staging dogfooding; acts as a kill switch (rollback without a revert PR) via
+  //   localStorage.setItem('feature.focusNowPanel', '0')   // or VITE_FEATURE_FOCUS_NOW_PANEL=0
+  // It does NOT enable coaching_summary, dynamic/server rows, or any uncertified
+  // content — those stay gated regardless of this flag.
+  focusNowPanel: {
+    envKey: 'VITE_FEATURE_FOCUS_NOW_PANEL',
+    storageKey: 'feature.focusNowPanel',
+    defaultValue: true,
+  },
   // Analysis hero v17 — opt-in comparison mode. When ON, BOTH the new hero
   // AND the existing DecisionConfidencePanel render (new hero above), for
   // internal visual review only. Never default-on. Bootable via the URL
@@ -415,6 +426,7 @@ const flags = {
   deterministicCee: makeFlag(FLAGS_CONFIG.deterministicCee),
   analysisHeroV17: makeFlag(FLAGS_CONFIG.analysisHeroV17),
   analysisHeroCompare: makeFlag(FLAGS_CONFIG.analysisHeroCompare),
+  focusNowPanel: makeFlag(FLAGS_CONFIG.focusNowPanel),
   aiPanelV2: makeFlag(FLAGS_CONFIG.aiPanelV2),
   v5CanonicalAnalysis: makeFlag(FLAGS_CONFIG.v5CanonicalAnalysis),
 }
@@ -478,6 +490,7 @@ export const isOrchestratorRenderingV2Enabled = flags.orchestratorRenderingV2
 export const isDeterministicCeeEnabled = flags.deterministicCee
 export const isAnalysisHeroV17Enabled = flags.analysisHeroV17
 export const isAnalysisHeroCompareEnabled = flags.analysisHeroCompare
+export const isFocusNowPanelEnabled = flags.focusNowPanel
 export const isAiPanelV2Enabled = flags.aiPanelV2
 export const isV5CanonicalAnalysisEnabled = flags.v5CanonicalAnalysis
 export const diagnoseV5CanonicalAnalysis = () =>


### PR DESCRIPTION
> ## ⚠️ SCOPE UPDATE — now a MOUNTED static panel (no longer inert-only)
> The Focus / **"Strengthen your model"** panel is now **mounted as the second Analysis-tab panel** (immediately after the hero / Decision-confidence panel, before Options Comparison) via `ResultsBody.tsx`. It is **static and fail-closed**: `coaching_summary` stays gated off, and dynamic/server coaching rows remain gated out. The inertness guard is now an **allow-list** (only ResultsBody may import it). Still **draft** — pending Paul's visual review at `http://localhost:5173/#/canvas?diag=1` (run an analysis → Analysis tab → the panel is the 2nd panel). See the "MOUNTED" comment below for the full diff/verification and the one live UX note (duplicate stale banner under a stale verdict, tracked in #200).
>
> _(The original "inert foundation" evidence pack below is retained for history.)_

---

**Draft. Do not mark ready, merge, deploy, mount, add a feature flag, or broaden scope.**

## Summary
First foundation of the **"Strengthen your model"** coaching panel (internal module `src/canvas/components/coaching-panel/focus-now/`). It is **render-only, unmounted, behind no feature flag**, and built additively on the prior unpushed render module.

- Explicit **row-ownership** model — `static_hygiene | server_sourced | gated`.
- Six UI-owned **static hygiene rows** (generic nudges; never claim a detection).
- **Freshness banner** wired to the certified single source `classifyFreshnessForDisplay` (PRs 195/197); re-run via `useV2Run`.
- **Prefill-only** row action via `_prefillChat` (container-only; never auto-sends).
- `coaching_summary` display **gated OFF** (uncertified CEE prose).
- Gated science rows (influence/sensitivity/drivers/EVPI/fragility/flip) are **never constructed**.
- **Inertness CI guard** + Storybook + 82 module tests.

The visible title is **"Strengthen your model"** (single `FOCUS_TITLE` constant); "Focus now" is reserved for a later version with server-sourced prioritised rows.

## Scope (hard)
No live mount, no flag, no backend/CEE/PLoT/ISL, no schemas/prompts/generated files/migrations, no V6. **0 files outside `coaching-panel/`.**

---

## Evidence pack — commit `0388268f`

> Verification used `bash` + `git grep` + `rg --glob` (no fragile zsh pathspec interpolation). Note: this `git grep` lacks PCRE (`git grep -P` unsupported), so `\b`-dependent patterns were run with `rg`/`\b`-free patterns and the known positives re-proven.

### Positive-control scans (regex fires on a bad needle, then actual focus-now result)
```
# [BANNED TERM] needle: EVPI
1:resolve this unknown first to maximise EVPI
  -> fires on needle (PASS)
actual focus-now UI strings (title/stale/button): 0
  (0 = clean)

# [LEGACY TOKEN] needle: bg-sand-50
1:sand-50
1:ink-900
  -> fires on needle (PASS)
actual focus-now: 0
  (0 = clean)

# [RAW TYPOGRAPHY] needle: font-semibold
1:font-semibold
  -> fires on needle (PASS)
actual focus-now source: 0
  (0 = clean)

# [RAW HEX] needle: #1F2937   (focus-now allows only var() fallback)
1:#1F2937
  -> fires on needle (PASS)
actual focus-now hex (var() fallback is the only one):
src/canvas/components/coaching-panel/focus-now/FocusNowPanel.stories.tsx:35:        background: 'var(--bg-canvas, #F4F0EA)',
actual focus-now hex OUTSIDE var(): 0
  (0 = clean)

# [bg-*-light] needle: bg-warning-light
1:bg-warning-light
  -> fires on needle (PASS)
actual focus-now class usages: 0
  (0 = clean; 1 doc-comment mention only)

# [CONTRACT ASSERTION] needle: 'FocusRow is a CEE wire contract'
actual positive assertions in focus-now:   (0 = none; all 'contract' mentions are negations)
```

### Contract-language — `FocusRow` is internal display state, not a contract
```
positive control: printf 'FocusRow is a CEE contract' | grep -iE 'is a (cee|server|wire|boundary) (contract|type|schema)'  -> FIRES (PASS)
actual positive assertions that FocusRow IS a contract:  0
every 'contract' mention in focus-now (all negations / unrelated):
  focusTypes.ts:7   * `FocusRow` is INTERNAL UI DISPLAY STATE ONLY. It is NOT a CEE/server contract,
  focusTypes.ts:9   * mirror any wire contract. The canonical wire shapes are owned upstream ...
  __tests__/interaction.spec.tsx:3   * prefill-only action contract (the panel never auto-sends)   [test description]
```

### Dynamic-import inertness proof (guard catches `React.lazy`, not only static imports)
The guard substring-matches file **content** (`includes('coaching-panel/focus-now')`), so static, dynamic `import()`, and `React.lazy` all trip it. Proven by planting a probe outside the module:
```
probe: export const Probe = lazy(() => import('@/canvas/components/coaching-panel/focus-now'))

WITH probe present:
  FAIL  .../focus-now/__tests__/inertness.spec.ts > is not imported by any file outside its own module
  AssertionError: ... Offenders: src/__inertness_probe__.tsx
        Tests  1 failed (1)

after removing probe:
  ✓ .../focus-now/__tests__/inertness.spec.ts  (1 test)
        Tests  1 passed (1)
  (probe deleted; tree clean)

rg --glob cross-check (importers outside the module):  exit 1 = none
```
### 20 imported files byte-identical to bb9006b2 (blob OID compare)
```
identical blob OIDs: 20 / 20
```

### All 44 files new-to-mainline (absent on origin/staging) — require review
```
files added vs origin/staging: 44
module present on origin/staging? (empty = entire module is new)
```

### Scope + results (commit 0388268f)
```
files outside coaching-panel/: 0
diff-stat:  44 files changed, 3221 insertions(+)
tests:     Test Files 20 passed | Tests 161 passed (82 focus-now incl. inertness + 79 existing)
typecheck: focus-now type errors: 0   (tsc -p tsconfig.app.json)
eslint:    exit 0
DS guard:  No net-new ratcheted violations vs baseline
```

### coaching_summary hidden (fail-closed) + provenance unresolved
```
src/canvas/components/coaching-panel/focus-now/useFocusNow.ts:12: *     defaults OFF (CERTIFY_SUMMARY=false). A live mount must keep it hidden or
src/canvas/components/coaching-panel/focus-now/useFocusNow.ts:38:const CERTIFY_SUMMARY = false
src/canvas/components/coaching-panel/focus-now/useFocusNow.ts:47:  const coachingSummary = CERTIFY_SUMMARY ? rawSummary : null
```

### Stale-copy finding — `FRESHNESS_COPY` exists but is **not** a clean drop-in
A canonical shared constant exists: `FRESHNESS_COPY` (`src/components/results/AnalysisFreshnessNotice.tsx`, the #195 single source), `stale: 'Model changed since this analysis. Re-run to update.'`. It was **not** imported because it (a) bundles its own "Re-run to update." CTA → would double-render against this panel's separate Re-run button, (b) uses different wording, (c) lives in a results `.tsx` → couples the inert canvas component. The local `staleText` literal is marked in code as **inert-only debt + live-mount blocker**.

---

## Reviewer (Codex) — review **all 44 files**
All 44 are new-to-mainline (20 re-imported render-module files byte-identical to `bb9006b2` + 24 new). Please review every file, and **specifically scrutinise the inertness-guard logic** in `focus-now/__tests__/inertness.spec.ts` (not only that it passes): the `src/` walk, the `MODULE_DIR` self-exclusion, the substring needle, and whether it could false-pass (e.g. path-alias variants) or false-fail.

## Live-mount blockers (tracked separately — NOT in this PR)
1. `coaching_summary` provenance + Gate Zero certification.
2. Stale-copy reconciliation with `FRESHNESS_COPY`.
3. Placement decision for the mounted panel.
4. Canonical coaching/block/signal contract designation.
5. Dynamic/server rows certification before display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

