### PR TITLE
fix(coaching): Focus panel row actions open + prefill chat (PR #199 follow-up)

### DIFF
--- a/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
@@ -4,22 +4,22 @@
  * Collapsed: a neutral topical icon (static rows) or the entity shape cue (server
  * rows that reference a real entity) + the primary line, clamped to one line.
  * Expanded: "what Olumi noticed" (server rows only — a static row never claims
- * detection), "why it matters", a "Try this" nudge, then one safe action plus the
- * display-only "Ask Olumi" affordance.
+ * detection), "why it matters", a "Try this" nudge, then one safe action.
  *
  * Accessibility scaffold replicated from CoachingActionCard (a11y-proven): the
  * header is a native button carrying aria-expanded + aria-controls, named by the
  * primary line; the expanded region is mounted only when open and labelled by the
  * primary line. Controlled by the parent so the list keeps one row open at a time.
  *
- * The action is DISPLAY/PREFILL-ONLY: the card never touches a store or sends —
- * it calls the injected `onTryAction`. "Ask Olumi" has no handler this phase.
+ * The action is PREFILL-ONLY: the card never touches a store or sends — it calls
+ * the injected `onTryAction`, which prefills the chat composer and opens the chat
+ * tab (never auto-sends). There is no separate "Ask Olumi" control: a dead button
+ * with no working handler is worse than no button.
  */
 import { useId, type CSSProperties } from 'react'
 import {
   ChevronRight,
   ChevronDown,
-  Sparkles,
   Target,
   Clock,
   Flag,
@@ -29,7 +29,6 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { typography } from '@/styles/typography'
-import Tooltip from '@/components/Tooltip'
 import { EntityTarget } from '../EntityTarget'
 import { FOCUS_COPY } from './focusConstants'
 import type { FocusRow } from './focusTypes'
@@ -146,18 +145,6 @@ export function FocusRowCard({ row, isOpen, onToggle, onTryAction }: FocusRowCar
                 {row.action.label}
               </button>
             )}
-
-            {/* Display-only: no onClick this phase. */}
-            <Tooltip content={FOCUS_COPY.askOlumi}>
-              <button
-                type="button"
-                aria-label={FOCUS_COPY.askOlumi}
-                data-testid="focus-ask-olumi"
-                className="ml-auto inline-flex h-7 w-7 flex-none items-center justify-center rounded-full border border-panel-border text-info outline-none transition-colors hover:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info"
-              >
-                <Sparkles className="h-4 w-4" aria-hidden="true" />
-              </button>
-            </Tooltip>
           </div>
         </div>
       )}

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/a11y.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/a11y.spec.tsx
@@ -45,11 +45,9 @@ describe('FocusNowPanel accessibility', () => {
     await expectNoViolations(container)
   })
 
-  it('names the panel region and the icon-only affordances', () => {
+  it('names the panel region and the icon-only re-run affordance', () => {
     renderPanel({ banner: { kind: 'stale', canRerun: true }, onRerun: () => {} })
     expect(screen.getByRole('region', { name: 'Strengthen your model' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Re-run analysis' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /define what success/i }))
-    expect(screen.getByRole('button', { name: 'Ask Olumi' })).toBeInTheDocument()
   })
 })

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
@@ -33,7 +33,6 @@ const UI_COPY: string[] = [
   FOCUS_COPY.header,
   FOCUS_COPY.emptyState,
   FOCUS_COPY.tryThisLabel,
-  FOCUS_COPY.askOlumi,
   FOCUS_COPY.itemFallback,
   FOCUS_COPY.showFewer,
   FOCUS_COPY.staleText,

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
@@ -59,11 +59,11 @@ describe('FocusNowPanel interaction', () => {
     )
   })
 
-  it('Ask Olumi is display-only (clicking it triggers no prefill)', () => {
-    const onPrefill = vi.fn()
-    renderPanel({ onPrefill })
-    fireEvent.click(screen.getByRole('button', { name: /capture an insight/i }))
-    fireEvent.click(screen.getByTestId('focus-ask-olumi'))
-    expect(onPrefill).not.toHaveBeenCalled()
+  it('renders exactly one action control per expanded row (no dead Ask-Olumi button)', () => {
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    // The prefill CTA is the only interactive control inside the expanded body.
+    expect(screen.getByTestId('focus-action')).toBeInTheDocument()
+    expect(screen.queryByTestId('focus-ask-olumi')).toBeNull()
   })
 })

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
@@ -1,25 +1,33 @@
 /**
  * useFocusNow container — enforces the two boundaries the presentational layer
  * cannot: (1) the uncertified coaching_summary is gated OFF; (2) the row action
- * prefills the composer ONLY and never sends. Also maps the live freshness source
- * to the banner.
+ * prefills the composer AND opens the chat tab so the prefill is visible, but
+ * NEVER sends and never triggers an analysis run. Also maps the live freshness
+ * source to the banner.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-const { prefillChat, sendMessage, runV2Analysis } = vi.hoisted(() => ({
-  prefillChat: vi.fn(),
-  sendMessage: vi.fn(),
-  runV2Analysis: vi.fn(),
-}))
+const { prefillChat, sendMessage, runV2Analysis, forceActivateOutputTab, focusFloating, setCanvasState } =
+  vi.hoisted(() => ({
+    prefillChat: vi.fn(),
+    sendMessage: vi.fn(),
+    runV2Analysis: vi.fn(),
+    forceActivateOutputTab: vi.fn(),
+    focusFloating: vi.fn(),
+    setCanvasState: vi.fn(),
+  }))
 
 vi.mock('@/canvas/store', () => ({
-  useCanvasStore: (sel: (s: unknown) => unknown) =>
-    sel({
-      ceeAnalysisReady: { coaching_summary: 'live CEE prose that is not claim-certified' },
-      analysisFreshness: { freshness: 'stale' },
-      analysisFreshnessDirty: false,
-    }),
+  useCanvasStore: Object.assign(
+    (sel: (s: unknown) => unknown) =>
+      sel({
+        ceeAnalysisReady: { coaching_summary: 'live CEE prose that is not claim-certified' },
+        analysisFreshness: { freshness: 'stale' },
+        analysisFreshnessDirty: false,
+      }),
+    { setState: setCanvasState },
+  ),
 }))
 vi.mock('@/canvas/hooks/useV2Run', () => ({
   useV2Run: () => ({ runV2Analysis, isRunning: false, cancelRun: vi.fn(), error: null }),
@@ -29,6 +37,13 @@ vi.mock('@/canvas/stores/guidanceStore', () => ({
     getState: () => ({ _prefillChat: prefillChat, _sendMessage: sendMessage }),
   }),
 }))
+vi.mock('@/stores/uiStore', () => ({
+  useUIStore: Object.assign(() => undefined, {
+    getState: () => ({ forceActivateOutputTab }),
+  }),
+}))
+vi.mock('@/canvas/hooks/useFloatingFocus', () => ({ focusFloating }))
+vi.mock('@/flags', () => ({ isAiPanelV2Enabled: () => true }))
 
 import { useFocusNow } from '../useFocusNow'
 
@@ -37,6 +52,9 @@ describe('useFocusNow container', () => {
     prefillChat.mockClear()
     sendMessage.mockClear()
     runV2Analysis.mockClear()
+    forceActivateOutputTab.mockClear()
+    focusFloating.mockClear()
+    setCanvasState.mockClear()
   })
 
   it('gates the uncertified coaching_summary OFF (summary is null despite live data)', () => {
@@ -51,11 +69,19 @@ describe('useFocusNow container', () => {
     expect(result.current.banner).toEqual({ kind: 'stale', canRerun: true })
   })
 
-  it('onPrefill prefills the composer only — never sends', () => {
+  it('onPrefill persists the composer text, reveals the chat, and never sends', () => {
     const { result } = renderHook(() => useFocusNow())
     result.current.onPrefill?.('Help me add a risk.')
+    // 1. persists the composer text (a freshly-mounting composer initialises from it)
+    expect(setCanvasState).toHaveBeenCalledWith({ draftComposerText: 'Help me add a risk.' })
+    // 2. updates the live composer when one is already mounted
     expect(prefillChat).toHaveBeenCalledWith('Help me add a risk.')
+    // 3. reveals the Olumi chat surface (docked tab + best-effort floating focus)
+    expect(forceActivateOutputTab).toHaveBeenCalledWith('olumi')
+    expect(focusFloating).toHaveBeenCalled()
+    // never auto-sends, never triggers a re-run
     expect(sendMessage).not.toHaveBeenCalled()
+    expect(runV2Analysis).not.toHaveBeenCalled()
   })
 
   it('onRerun triggers a re-run', () => {

--- a/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
@@ -33,8 +33,6 @@ export const FOCUS_COPY = {
   emptyState: 'Nothing to focus on right now.',
   /** Bold lead-in before a row's nudge. */
   tryThisLabel: 'Try this',
-  /** Icon-only, display-only affordance label. */
-  askOlumi: 'Ask Olumi',
   /** Generic accessible name for a row whose primary line is empty (operability, not a title). */
   itemFallback: 'Focus item',
   /** Reveal-toggle copy. */

--- a/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
+++ b/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
@@ -12,13 +12,23 @@
  *     defaults OFF (CERTIFY_SUMMARY=false). A live mount must keep it hidden or
  *     flip this on ONLY once the summary is passed through Gate Zero / certified
  *     CEE output. Do not call the panel live-safe while it shows uncertified prose.
- *  2. PREFILL-ONLY — the row action drains to the composer via `_prefillChat`.
- *     There is deliberately NO `_sendMessage` fallback: Focus Now never auto-sends.
+ *  2. PREFILL-ONLY + VISIBLE — the row action prefills the composer (via
+ *     `draftComposerText` for the unmounted case + `_prefillChat` for an already-
+ *     mounted one) AND reveals the Olumi/chat surface so the prefill is actually
+ *     visible. On the Analysis tab the chat composer is not mounted (ConversationPanel
+ *     lives in the Olumi tab) and its `_prefillChat` callback is null; the persisted
+ *     `draftComposerText` is what a freshly-mounting composer initialises from, and
+ *     `forceActivateOutputTab('olumi')` mounts/reveals it (the live-diagnosed reveal
+ *     used by useConversationActions). There is deliberately NO `_sendMessage`:
+ *     never auto-sends.
  */
 import { useCallback, useMemo } from 'react'
 import { useCanvasStore } from '@/canvas/store'
 import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
 import { useV2Run } from '@/canvas/hooks/useV2Run'
+import { useUIStore } from '@/stores/uiStore'
+import { focusFloating } from '@/canvas/hooks/useFloatingFocus'
+import { isAiPanelV2Enabled } from '@/flags'
 import { classifyFreshnessForDisplay } from '@/canvas/store/analysisFreshness'
 import { buildFocusRows } from './buildFocusRows'
 import { freshnessToBanner } from './freshnessBanner'
@@ -53,9 +63,24 @@ export function useFocusNow(): FocusNowProps {
   )
 
   const onPrefill = useCallback((text: string) => {
-    // Prefill ONLY — never auto-send.
-    const prefill = useGuidanceStore.getState()._prefillChat
-    if (prefill) prefill(text)
+    // Prefill the chat and reveal it — NEVER auto-send.
+    // 1. Persist the composer text. A freshly-mounting composer initialises from
+    //    draftComposerText, which is what covers the Analysis-tab case: there the
+    //    chat composer is unmounted and its `_prefillChat` callback is therefore
+    //    null (ConversationPanel's unmount cleanup nulls the guidance registry —
+    //    the live-diagnosed root cause of "the spark does nothing").
+    useCanvasStore.setState({ draftComposerText: text })
+    // 2. If a composer IS already mounted (e.g. an open floating chat), update its
+    //    live value too — the mount-time initialiser in (1) won't re-run for it.
+    useGuidanceStore.getState()._prefillChat?.(text)
+    // 3. Reveal the Olumi chat surface so the prefill is visible. Mirrors the
+    //    live-diagnosed reveal in useConversationActions: forceActivate the docked
+    //    Olumi tab (bumps the version so the dock reconciles + opens even when the
+    //    tab value is unchanged), then best-effort focus a hosting floating panel.
+    if (isAiPanelV2Enabled()) {
+      useUIStore.getState().forceActivateOutputTab('olumi')
+    }
+    focusFloating()
   }, [])
 
   const onRerun = useCallback(() => {

--- a/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
@@ -8,7 +8,7 @@
  * store state → no summary, no freshness banner).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ResultsBody } from '../ResultsBody'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type {
@@ -31,11 +31,13 @@ vi.mock('@/flags', async () => {
     isAnalysisHeroV17Enabled: vi.fn(() => false),
     isAnalysisHeroCompareEnabled: vi.fn(() => false),
     isFocusNowPanelEnabled: vi.fn(() => true),
+    isAiPanelV2Enabled: vi.fn(() => true),
   }
 })
 
 import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled } from '@/flags'
 import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
 
 function makeData(): ResultsSectionDataReturn {
   const winner = { id: 'opt_a', label: 'Option A', expectedValue: 0.8, p10: 0.6, p90: 0.95, winProbability: 0.7, goalProbability: 0.7 } as unknown as OptionResult
@@ -83,7 +85,8 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     vi.mocked(isAnalysisHeroV17Enabled).mockReturnValue(false)
     vi.mocked(isAnalysisHeroCompareEnabled).mockReturnValue(false)
     vi.mocked(isFocusNowPanelEnabled).mockReturnValue(true)
-    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false, draftComposerText: null })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
   })
 
   it('mounts the Focus panel (flag default-ON)', () => {
@@ -125,5 +128,24 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     expect(screen.getByText('Define what success looks like')).toBeInTheDocument()
     // …and no verbatim server summary line (coaching_summary gated off)
     expect(screen.queryByTestId('focus-summary')).toBeNull()
+  })
+
+  it('clicking a row action prefills the composer and reveals the Olumi chat tab', () => {
+    // Regression for the staging blocker: on the Analysis tab the chat composer
+    // is unmounted (its prefill callback is null), so a working action must
+    // persist the prefill to draftComposerText AND switch the dock to the Olumi
+    // tab so a freshly-mounting composer shows it. End-to-end through the real
+    // FocusNowContainer → useFocusNow → onPrefill (no hook mock).
+    expect(useUIStore.getState().activeOutputTab).toBe('results')
+    renderBody()
+    // expand the "Add a risk" static row, then click its prefill CTA
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    fireEvent.click(screen.getByTestId('focus-action'))
+    // the prefill text is persisted for a freshly-mounting composer…
+    expect(useCanvasStore.getState().draftComposerText).toBe(
+      'Help me think through a risk worth adding to this decision.',
+    )
+    // …and the chat surface is revealed (Olumi tab activated)
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
   })
 })


### PR DESCRIPTION
## What was broken

PR #199 staging review found the Focus / "Strengthen your model" panel's row actions were **dead on the Analysis tab**: clicking a **Try this** CTA did nothing visible, and the icon-only **Ask Olumi** sparkle had no handler at all.

## Root cause (live-diagnosed)

On the Analysis tab the chat composer is unmounted — `ConversationPanel` lives in the Olumi tab, and its unmount cleanup **nulls the guidance-store callbacks** (`_prefillChat`). So the row action's prefill went to a null callback and nothing revealed the chat. This is the same "the spark does nothing" failure mode already documented and solved in [`useConversationActions`](src/canvas/components/pre-analysis-v3/hooks/useConversationActions.ts).

## Fix (`useFocusNow.onPrefill`) — strictly prefill-only, never sends

1. **Persist** the prefill to canvas-store `draftComposerText` — a freshly-mounting composer initialises from it, which covers the unmounted Analysis-tab case.
2. Still call `_prefillChat` for an **already-mounted** floating composer.
3. **Reveal** the chat via `forceActivateOutputTab('olumi')` (gated on `aiPanelV2`) + `focusFloating()` — the same live-proven reveal `useConversationActions` uses.

No `_sendMessage`, no auto-run: it only prefills + opens the chat.

The dead **Ask Olumi** sparkle is **removed entirely** (no working handler this phase — a dead button is worse than none), dropping the `Sparkles`/`Tooltip` imports and the now-unused `FOCUS_COPY.askOlumi`.

## Expected behaviour per control

- **"Try this" CTA** (every expanded row) → switches the dock to the Olumi/chat tab with the row's prompt prefilled in the composer, ready to edit and send. Never auto-sends.
- **Sparkle / Ask Olumi icon** → removed (it had no handler).
- **Re-run analysis** (stale banner button) → unchanged (`useV2Run`).

## Scope

`coaching-panel/focus-now/` module + its placement test only. No Hero/Options/OutputsDock/flag/backend/schema changes. `coaching_summary` stays gated off. No dynamic/server rows.

## Tests

- `useFocusNow.spec` — asserts persist + `_prefillChat` + `forceActivateOutputTab('olumi')` + `focusFloating`, and **never** `_sendMessage`/`runV2Analysis`.
- `interaction.spec` — single prefill CTA per row; the old sparkle testid is gone.
- `a11y.spec` — sparkle assertion dropped; no axe violations.
- `ResultsBody.focusPlacement.spec` — new end-to-end test: real click → `draftComposerText` set + Olumi tab activated.
- Full focus-now suite (112) + existing parent coaching-panel suite (79) green; typecheck + ESLint + DS guard clean; pre-push fast gate passed.

## How to verify on staging

`https://staging--olumi.netlify.app/#/canvas` → build a model → run analysis → **Analysis tab** → 2nd panel ("Strengthen your model") → expand any row → click its **Try this** button → the chat tab opens with the prompt prefilled (not sent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)