### PR TITLE
fix(coaching): restore + wire the Ask Olumi icon in the Focus panel (PR #201 follow-up)

### DIFF
--- a/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
@@ -4,22 +4,25 @@
  * Collapsed: a neutral topical icon (static rows) or the entity shape cue (server
  * rows that reference a real entity) + the primary line, clamped to one line.
  * Expanded: "what Olumi noticed" (server rows only — a static row never claims
- * detection), "why it matters", a "Try this" nudge, then one safe action.
+ * detection), "why it matters", a "Try this" nudge, then the action bar: a primary
+ * CTA plus an "Ask Olumi" icon affordance.
  *
  * Accessibility scaffold replicated from CoachingActionCard (a11y-proven): the
  * header is a native button carrying aria-expanded + aria-controls, named by the
  * primary line; the expanded region is mounted only when open and labelled by the
  * primary line. Controlled by the parent so the list keeps one row open at a time.
  *
- * The action is PREFILL-ONLY: the card never touches a store or sends — it calls
- * the injected `onTryAction`, which prefills the chat composer and opens the chat
- * tab (never auto-sends). There is no separate "Ask Olumi" control: a dead button
- * with no working handler is worse than no button.
+ * Both action controls are PREFILL-ONLY and do the SAME thing: the card never
+ * touches a store or sends — each calls the injected `onTryAction`, which prefills
+ * the chat composer and opens the chat tab. Never auto-sends, never mutates the
+ * graph, never runs analysis. The "Ask Olumi" icon is a native button with an
+ * accessible label + tooltip, so it is keyboard-operable and not a dead control.
  */
 import { useId, type CSSProperties } from 'react'
 import {
   ChevronRight,
   ChevronDown,
+  Sparkles,
   Target,
   Clock,
   Flag,
@@ -29,6 +32,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { typography } from '@/styles/typography'
+import Tooltip from '@/components/Tooltip'
 import { EntityTarget } from '../EntityTarget'
 import { FOCUS_COPY } from './focusConstants'
 import type { FocusRow } from './focusTypes'
@@ -134,8 +138,8 @@ export function FocusRowCard({ row, isOpen, onToggle, onTryAction }: FocusRowCar
             </p>
           )}
 
-          <div className="mt-1 flex items-center gap-2">
-            {row.action?.kind === 'prefill' && row.action.prefillText && (
+          {row.action?.kind === 'prefill' && row.action.prefillText && (
+            <div className="mt-1 flex items-center gap-2">
               <button
                 type="button"
                 onClick={() => onTryAction?.(row)}
@@ -144,8 +148,22 @@ export function FocusRowCard({ row, isOpen, onToggle, onTryAction }: FocusRowCar
               >
                 {row.action.label}
               </button>
-            )}
-          </div>
+
+              {/* Icon affordance — same prefill + open-chat action as the CTA
+                  (never sends, never mutates the graph, never runs analysis). */}
+              <Tooltip content={FOCUS_COPY.askOlumi}>
+                <button
+                  type="button"
+                  onClick={() => onTryAction?.(row)}
+                  aria-label={FOCUS_COPY.askOlumi}
+                  data-testid="focus-ask-olumi"
+                  className="ml-auto inline-flex h-7 w-7 flex-none items-center justify-center rounded-full border border-panel-border text-info outline-none transition-colors hover:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info"
+                >
+                  <Sparkles className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </Tooltip>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/a11y.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/a11y.spec.tsx
@@ -45,9 +45,11 @@ describe('FocusNowPanel accessibility', () => {
     await expectNoViolations(container)
   })
 
-  it('names the panel region and the icon-only re-run affordance', () => {
+  it('names the panel region and the icon-only affordances', () => {
     renderPanel({ banner: { kind: 'stale', canRerun: true }, onRerun: () => {} })
     expect(screen.getByRole('region', { name: 'Strengthen your model' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Re-run analysis' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /define what success/i }))
+    expect(screen.getByRole('button', { name: 'Ask Olumi' })).toBeInTheDocument()
   })
 })

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/copyHygiene.spec.tsx
@@ -33,6 +33,7 @@ const UI_COPY: string[] = [
   FOCUS_COPY.header,
   FOCUS_COPY.emptyState,
   FOCUS_COPY.tryThisLabel,
+  FOCUS_COPY.askOlumi,
   FOCUS_COPY.itemFallback,
   FOCUS_COPY.showFewer,
   FOCUS_COPY.staleText,

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
@@ -59,11 +59,23 @@ describe('FocusNowPanel interaction', () => {
     )
   })
 
-  it('renders exactly one action control per expanded row (no dead Ask-Olumi button)', () => {
+  it('the Ask Olumi icon prefills the same prompt and never auto-sends', () => {
+    const onPrefill = vi.fn()
+    renderPanel({ onPrefill })
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    fireEvent.click(screen.getByTestId('focus-ask-olumi'))
+    expect(onPrefill).toHaveBeenCalledTimes(1)
+    expect(onPrefill).toHaveBeenCalledWith(
+      'Help me think through a risk worth adding to this decision.',
+    )
+  })
+
+  it('the Ask Olumi icon has an accessible name and is keyboard-operable', () => {
     renderPanel()
     fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
-    // The prefill CTA is the only interactive control inside the expanded body.
-    expect(screen.getByTestId('focus-action')).toBeInTheDocument()
-    expect(screen.queryByTestId('focus-ask-olumi')).toBeNull()
+    // Native button named by aria-label → operable by Enter/Space, focusable.
+    const icon = screen.getByRole('button', { name: 'Ask Olumi' })
+    expect(icon.tagName).toBe('BUTTON')
+    expect(icon).not.toHaveAttribute('disabled')
   })
 })

--- a/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
@@ -33,6 +33,8 @@ export const FOCUS_COPY = {
   emptyState: 'Nothing to focus on right now.',
   /** Bold lead-in before a row's nudge. */
   tryThisLabel: 'Try this',
+  /** Icon affordance label + tooltip — prefills the chat and opens it (same as the CTA). */
+  askOlumi: 'Ask Olumi',
   /** Generic accessible name for a row whose primary line is empty (operability, not a title). */
   itemFallback: 'Focus item',
   /** Reveal-toggle copy. */

--- a/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
@@ -130,22 +130,30 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     expect(screen.queryByTestId('focus-summary')).toBeNull()
   })
 
-  it('clicking a row action prefills the composer and reveals the Olumi chat tab', () => {
-    // Regression for the staging blocker: on the Analysis tab the chat composer
-    // is unmounted (its prefill callback is null), so a working action must
-    // persist the prefill to draftComposerText AND switch the dock to the Olumi
-    // tab so a freshly-mounting composer shows it. End-to-end through the real
-    // FocusNowContainer → useFocusNow → onPrefill (no hook mock).
+  // Regression for the staging blocker: on the Analysis tab the chat composer is
+  // unmounted (its prefill callback is null), so a working action must persist the
+  // prefill to draftComposerText AND switch the dock to the Olumi tab so a freshly-
+  // mounting composer shows it. End-to-end through the real FocusNowContainer →
+  // useFocusNow → onPrefill (no hook mock). Both row controls must behave the same.
+  const PROMPT = 'Help me think through a risk worth adding to this decision.'
+
+  it.each([
+    ['the row CTA', 'focus-action'],
+    ['the Ask Olumi icon', 'focus-ask-olumi'],
+  ])('clicking %s prefills the composer and reveals the Olumi chat tab', (_label, testid) => {
     expect(useUIStore.getState().activeOutputTab).toBe('results')
     renderBody()
-    // expand the "Add a risk" static row, then click its prefill CTA
+    const nodesBefore = useCanvasStore.getState().nodes
+    const edgesBefore = useCanvasStore.getState().edges
+    // expand the "Add a risk" static row, then click the control under test
     fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
-    fireEvent.click(screen.getByTestId('focus-action'))
+    fireEvent.click(screen.getByTestId(testid))
     // the prefill text is persisted for a freshly-mounting composer…
-    expect(useCanvasStore.getState().draftComposerText).toBe(
-      'Help me think through a risk worth adding to this decision.',
-    )
-    // …and the chat surface is revealed (Olumi tab activated)
+    expect(useCanvasStore.getState().draftComposerText).toBe(PROMPT)
+    // …and the chat surface is revealed (Olumi tab activated)…
     expect(useUIStore.getState().activeOutputTab).toBe('olumi')
+    // …with NO graph mutation (node/edge collections untouched by reference).
+    expect(useCanvasStore.getState().nodes).toBe(nodesBefore)
+    expect(useCanvasStore.getState().edges).toBe(edgesBefore)
   })
 })


### PR DESCRIPTION
## Why

In [PR #201](https://github.com/Talchain/DecisionGuideAI/pull/201) I removed the **Ask Olumi / sparkle** icon as part of the dead-button fix. That removal was **not an authorised product decision**. Now that the prefill + open-chat mechanism exists, the correct fix is to **restore the icon and wire it**, not delete it.

## What changed

The sparkle is back in the row action bar, wired to the **same `onTryAction` handler** as the primary CTA. Clicking **either** control:
- prefills the row's prompt into the chat composer, and
- opens/reveals the Olumi chat tab.

Both are strictly **prefill-only**: never auto-send, never mutate the graph, never run analysis. The icon is a native `<button>` with `aria-label` + Tooltip **"Ask Olumi"**, so it is keyboard-operable and not a dead control. Restores `FOCUS_COPY.askOlumi` and its copy-hygiene scan entry.

**Process correction recorded in the commit:** do not remove visible UI affordances as a "fix" unless explicitly authorised, or unless removal is the only safe way to prevent a broken/unsafe action.

## Expected behaviour per control

- **"Try this" CTA** → opens the Olumi/chat tab with the row's prompt prefilled.
- **Ask Olumi sparkle** → does the **same** (prefill + open chat).
- Neither auto-sends, mutates the graph, or runs analysis.
- Re-run analysis (stale banner) → unchanged.

## Tests (all 7 requested)

1. CTA click → opens Olumi/chat + prefills — `ResultsBody.focusPlacement` (it.each) + `interaction` + `useFocusNow`.
2. Ask Olumi icon click → opens Olumi/chat + prefills — `ResultsBody.focusPlacement` (it.each) + `interaction`.
3. No auto-send — `useFocusNow` (`_sendMessage` never called) + exact-prefill assertions.
4. No graph mutation — `ResultsBody.focusPlacement` (node/edge collections referentially unchanged).
5. No analysis run — `useFocusNow` (`runV2Analysis` never called).
6. Icon has accessible name + tooltip + keyboard-operable — `a11y` + `interaction`.
7. ResultsBody mounted context works — `ResultsBody.focusPlacement` end-to-end (real container/stores).

focus-now suite **114** green · parent coaching-panel **79** green · CI typecheck ✓ · ESLint ✓ · DS guard Δ+0 ✓ · pre-push fast gate ✓.

## Scope

focus-now module + its placement test only. No Hero/Options/OutputsDock/placement/flag/backend/schema/prompt/migration/V6 changes. `coaching_summary` stays gated off; no dynamic rows.

## How to verify on staging

`https://staging--olumi.netlify.app/#/canvas` → build a model → run analysis → **Analysis tab** → 2nd panel ("Strengthen your model") → expand any row. You'll see two controls: the **Try this** button and the **Ask Olumi** sparkle. Click either → the chat tab opens with the prompt prefilled (not sent). Hover/focus the sparkle → "Ask Olumi" tooltip; Tab to it and press Enter → same action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)