### PR TITLE
fix(coaching): Focus action — no draft clobber + no dead buttons when chat unreachable

### DIFF
--- a/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.stories.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.stories.tsx
@@ -89,3 +89,6 @@ LongStrings.storyName = 'Long strings (clamp + wrap)'
 
 export const ForbiddenTermData = story({ summary: forbiddenSummary })
 ForbiddenTermData.storyName = 'Forbidden-term server prose (verbatim)'
+
+export const ActionsDisabled = story({ actionsEnabled: false })
+ActionsDisabled.storyName = 'Actions hidden (aiPanelV2 off — rows informational, no dead buttons)'

--- a/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowPanel.tsx
@@ -29,6 +29,7 @@ export function FocusNowPanel({
   rows,
   banner,
   onPrefill,
+  actionsEnabled = true,
   onRerun,
   rerunDisabled = false,
   showFreshnessBanner = true,
@@ -43,9 +44,15 @@ export function FocusNowPanel({
   const visible = revealed ? safeRows : safeRows.slice(0, FOCUS_DEFAULT_VISIBLE)
   const hiddenCount = safeRows.length - FOCUS_DEFAULT_VISIBLE
 
-  const handleTry = (row: FocusRow) => {
-    if (row.action?.kind === 'prefill' && row.action.prefillText) onPrefill?.(row.action.prefillText)
-  }
+  // Only expose an action handler when the action can actually reveal the chat
+  // (see actionsEnabled). When it cannot, the card renders no action controls,
+  // so the rows stay informational instead of presenting dead buttons.
+  const handleTry =
+    actionsEnabled
+      ? (row: FocusRow) => {
+          if (row.action?.kind === 'prefill' && row.action.prefillText) onPrefill?.(row.action.prefillText)
+        }
+      : undefined
 
   return (
     <section

--- a/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusRowCard.tsx
@@ -17,6 +17,8 @@
  * the chat composer and opens the chat tab. Never auto-sends, never mutates the
  * graph, never runs analysis. The "Ask Olumi" icon is a native button with an
  * accessible label + tooltip, so it is keyboard-operable and not a dead control.
+ * The whole action bar is omitted when no `onTryAction` is injected (e.g. the
+ * container cannot reveal the chat because aiPanelV2 is off) — never a dead button.
  */
 import { useId, type CSSProperties } from 'react'
 import {
@@ -138,7 +140,7 @@ export function FocusRowCard({ row, isOpen, onToggle, onTryAction }: FocusRowCar
             </p>
           )}
 
-          {row.action?.kind === 'prefill' && row.action.prefillText && (
+          {onTryAction && row.action?.kind === 'prefill' && row.action.prefillText && (
             <div className="mt-1 flex items-center gap-2">
               <button
                 type="button"

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/composerDraft.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/composerDraft.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * mergeComposerDraft — never clobber an unsent draft; append with separation.
+ */
+import { describe, it, expect } from 'vitest'
+import { mergeComposerDraft } from '../composerDraft'
+
+const PROMPT = 'Help me think through a risk worth adding to this decision.'
+
+describe('mergeComposerDraft', () => {
+  it('returns just the prompt when there is no draft', () => {
+    expect(mergeComposerDraft(null, PROMPT)).toBe(PROMPT)
+    expect(mergeComposerDraft(undefined, PROMPT)).toBe(PROMPT)
+    expect(mergeComposerDraft('', PROMPT)).toBe(PROMPT)
+  })
+
+  it('treats a whitespace-only draft as empty', () => {
+    expect(mergeComposerDraft('   \n  ', PROMPT)).toBe(PROMPT)
+  })
+
+  it('appends to a non-empty draft with a blank-line separator (never overwrites)', () => {
+    expect(mergeComposerDraft('I am leaning towards option A', PROMPT)).toBe(
+      `I am leaning towards option A\n\n${PROMPT}`,
+    )
+  })
+
+  it('trims trailing whitespace on the draft before appending', () => {
+    expect(mergeComposerDraft('my draft\n\n', PROMPT)).toBe(`my draft\n\n${PROMPT}`)
+  })
+
+  it('is idempotent: a repeat click does not stack the same prompt twice', () => {
+    const once = mergeComposerDraft('my draft', PROMPT)
+    expect(mergeComposerDraft(once, PROMPT)).toBe(once)
+  })
+
+  it('appends a different prompt even when one prompt is already present', () => {
+    const first = mergeComposerDraft('my draft', PROMPT)
+    const second = 'Help me define what success looks like for this decision.'
+    expect(mergeComposerDraft(first, second)).toBe(`${first}\n\n${second}`)
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/interaction.spec.tsx
@@ -78,4 +78,15 @@ describe('FocusNowPanel interaction', () => {
     expect(icon.tagName).toBe('BUTTON')
     expect(icon).not.toHaveAttribute('disabled')
   })
+
+  it('renders NO action controls when actionsEnabled is false (rows stay informational)', () => {
+    renderPanel({ actionsEnabled: false })
+    // the row still expands and shows its guidance…
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    expect(screen.getByTestId('focus-card-body')).toBeInTheDocument()
+    // …but neither action control is present (no dead buttons when the chat
+    // surface cannot be revealed)
+    expect(screen.queryByTestId('focus-action')).toBeNull()
+    expect(screen.queryByTestId('focus-ask-olumi')).toBeNull()
+  })
 })

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
@@ -8,14 +8,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-const { prefillChat, sendMessage, runV2Analysis, forceActivateOutputTab, focusFloating, setCanvasState } =
+const { store, prefillChat, sendMessage, runV2Analysis, forceActivateOutputTab, focusFloating, setCanvasState, aiPanelV2 } =
   vi.hoisted(() => ({
+    // Mutable holder so a test can seed an existing composer draft.
+    store: { draftComposerText: null as string | null },
     prefillChat: vi.fn(),
     sendMessage: vi.fn(),
     runV2Analysis: vi.fn(),
     forceActivateOutputTab: vi.fn(),
     focusFloating: vi.fn(),
     setCanvasState: vi.fn(),
+    aiPanelV2: vi.fn(() => true),
   }))
 
 vi.mock('@/canvas/store', () => ({
@@ -26,7 +29,10 @@ vi.mock('@/canvas/store', () => ({
         analysisFreshness: { freshness: 'stale' },
         analysisFreshnessDirty: false,
       }),
-    { setState: setCanvasState },
+    {
+      setState: setCanvasState,
+      getState: () => ({ draftComposerText: store.draftComposerText }),
+    },
   ),
 }))
 vi.mock('@/canvas/hooks/useV2Run', () => ({
@@ -43,12 +49,14 @@ vi.mock('@/stores/uiStore', () => ({
   }),
 }))
 vi.mock('@/canvas/hooks/useFloatingFocus', () => ({ focusFloating }))
-vi.mock('@/flags', () => ({ isAiPanelV2Enabled: () => true }))
+vi.mock('@/flags', () => ({ isAiPanelV2Enabled: aiPanelV2 }))
 
 import { useFocusNow } from '../useFocusNow'
 
 describe('useFocusNow container', () => {
   beforeEach(() => {
+    store.draftComposerText = null
+    aiPanelV2.mockReturnValue(true)
     prefillChat.mockClear()
     sendMessage.mockClear()
     runV2Analysis.mockClear()
@@ -74,7 +82,7 @@ describe('useFocusNow container', () => {
     result.current.onPrefill?.('Help me add a risk.')
     // 1. persists the composer text (a freshly-mounting composer initialises from it)
     expect(setCanvasState).toHaveBeenCalledWith({ draftComposerText: 'Help me add a risk.' })
-    // 2. updates the live composer when one is already mounted
+    // 2. updates the live composer when one is already mounted (same merged text)
     expect(prefillChat).toHaveBeenCalledWith('Help me add a risk.')
     // 3. reveals the Olumi chat surface (docked tab + best-effort floating focus)
     expect(forceActivateOutputTab).toHaveBeenCalledWith('olumi')
@@ -82,6 +90,27 @@ describe('useFocusNow container', () => {
     // never auto-sends, never triggers a re-run
     expect(sendMessage).not.toHaveBeenCalled()
     expect(runV2Analysis).not.toHaveBeenCalled()
+  })
+
+  it('onPrefill APPENDS to an unsent draft — never clobbers it', () => {
+    store.draftComposerText = 'I am leaning towards option A'
+    const { result } = renderHook(() => useFocusNow())
+    result.current.onPrefill?.('Help me add a risk.')
+    const merged = 'I am leaning towards option A\n\nHelp me add a risk.'
+    expect(setCanvasState).toHaveBeenCalledWith({ draftComposerText: merged })
+    // the already-mounted composer receives the SAME merged text (no clobber there either)
+    expect(prefillChat).toHaveBeenCalledWith(merged)
+  })
+
+  it('exposes actionsEnabled=true when aiPanelV2 is on', () => {
+    const { result } = renderHook(() => useFocusNow())
+    expect(result.current.actionsEnabled).toBe(true)
+  })
+
+  it('exposes actionsEnabled=false when aiPanelV2 is off (controls must hide, not be dead)', () => {
+    aiPanelV2.mockReturnValue(false)
+    const { result } = renderHook(() => useFocusNow())
+    expect(result.current.actionsEnabled).toBe(false)
   })
 
   it('onRerun triggers a re-run', () => {

--- a/src/canvas/components/coaching-panel/focus-now/composerDraft.ts
+++ b/src/canvas/components/coaching-panel/focus-now/composerDraft.ts
@@ -1,0 +1,29 @@
+/**
+ * composerDraft — merge a Focus row's prefill prompt into the chat composer draft
+ * WITHOUT clobbering unsent user text.
+ *
+ * The chat composer mirrors its value to canvas-store `draftComposerText` (see
+ * useComposerState: debounced write-through + unmount flush), so a message the
+ * user typed on the Olumi tab is persisted there even after they switch to the
+ * Analysis tab. A Focus action that overwrote `draftComposerText` would silently
+ * destroy that unsent draft. So we APPEND with a blank-line separator instead —
+ * the user keeps their text and gets the suggested prompt, and can trim either.
+ *
+ * This is prefill-only: it never sends, and it is the same text whether the
+ * composer is mounted (live value) or not (persisted draft a fresh mount reads).
+ */
+
+/**
+ * @param existing current composer draft (null/undefined/empty when none)
+ * @param prompt   the row's UI-authored prefill text
+ * @returns the merged composer text: just `prompt` when there is no draft,
+ *          otherwise `draft` + blank line + `prompt`. Idempotent: if the draft
+ *          already ends with `prompt` (a repeat click), it is returned unchanged
+ *          so prompts don't stack.
+ */
+export function mergeComposerDraft(existing: string | null | undefined, prompt: string): string {
+  const base = (existing ?? '').replace(/\s+$/, '')
+  if (base.length === 0) return prompt
+  if (base.endsWith(prompt)) return base
+  return `${base}\n\n${prompt}`
+}

--- a/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
@@ -101,6 +101,14 @@ export interface FocusNowProps {
   banner: FocusBannerState
   /** Prefill the chat composer (no auto-send). Injected; presentational tree owns no store. */
   onPrefill?: (text: string) => void
+  /**
+   * Whether the row action controls (the CTA + Ask Olumi icon) can produce a
+   * visible effect. The action reveals the Olumi chat tab, which only exists when
+   * aiPanelV2 is enabled (OutputsDock redirects 'olumi'→'results' otherwise). When
+   * false the panel renders NO action controls so rows stay informational rather
+   * than becoming dead buttons. Default true (standalone / Storybook).
+   */
+  actionsEnabled?: boolean
   /** Trigger a re-run of analysis. Injected. */
   onRerun?: () => void
   /** Disable the re-run affordance while a run is in flight. */

--- a/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
+++ b/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
@@ -12,15 +12,18 @@
  *     defaults OFF (CERTIFY_SUMMARY=false). A live mount must keep it hidden or
  *     flip this on ONLY once the summary is passed through Gate Zero / certified
  *     CEE output. Do not call the panel live-safe while it shows uncertified prose.
- *  2. PREFILL-ONLY + VISIBLE — the row action prefills the composer (via
- *     `draftComposerText` for the unmounted case + `_prefillChat` for an already-
- *     mounted one) AND reveals the Olumi/chat surface so the prefill is actually
- *     visible. On the Analysis tab the chat composer is not mounted (ConversationPanel
- *     lives in the Olumi tab) and its `_prefillChat` callback is null; the persisted
- *     `draftComposerText` is what a freshly-mounting composer initialises from, and
- *     `forceActivateOutputTab('olumi')` mounts/reveals it (the live-diagnosed reveal
- *     used by useConversationActions). There is deliberately NO `_sendMessage`:
- *     never auto-sends.
+ *  2. PREFILL-ONLY + VISIBLE — the row action MERGES the prompt into the composer
+ *     (via `draftComposerText` for the unmounted case + `_prefillChat` for an
+ *     already-mounted one) AND reveals the Olumi/chat surface. It APPENDS to, never
+ *     clobbers, an unsent draft (the composer mirrors its value to draftComposerText,
+ *     so a message typed on the Olumi tab is persisted there). On the Analysis tab
+ *     the chat composer is not mounted (ConversationPanel lives in the Olumi tab) and
+ *     its `_prefillChat` callback is null; the persisted `draftComposerText` is what
+ *     a freshly-mounting composer initialises from, and `forceActivateOutputTab('olumi')`
+ *     mounts/reveals it (the live-diagnosed reveal used by useConversationActions).
+ *     There is deliberately NO `_sendMessage`: never auto-sends. The reveal needs
+ *     aiPanelV2 (the dock redirects 'olumi'→'results' otherwise), so `actionsEnabled`
+ *     gates the controls off when it is disabled — no dead buttons.
  */
 import { useCallback, useMemo } from 'react'
 import { useCanvasStore } from '@/canvas/store'
@@ -32,6 +35,7 @@ import { isAiPanelV2Enabled } from '@/flags'
 import { classifyFreshnessForDisplay } from '@/canvas/store/analysisFreshness'
 import { buildFocusRows } from './buildFocusRows'
 import { freshnessToBanner } from './freshnessBanner'
+import { mergeComposerDraft } from './composerDraft'
 import type { FocusNowProps } from './focusTypes'
 
 /**
@@ -62,17 +66,24 @@ export function useFocusNow(): FocusNowProps {
     [freshness, dirty],
   )
 
+  // The row action reveals the Olumi chat tab, which only exists when aiPanelV2 is
+  // on — OutputsDock redirects a requested 'olumi' tab to 'results' otherwise, so
+  // the action would set a draft nobody can see. When off we tell the panel to
+  // render NO action controls (rows stay informational, never dead buttons).
+  const actionsEnabled = isAiPanelV2Enabled()
+
   const onPrefill = useCallback((text: string) => {
     // Prefill the chat and reveal it — NEVER auto-send.
-    // 1. Persist the composer text. A freshly-mounting composer initialises from
-    //    draftComposerText, which is what covers the Analysis-tab case: there the
-    //    chat composer is unmounted and its `_prefillChat` callback is therefore
-    //    null (ConversationPanel's unmount cleanup nulls the guidance registry —
-    //    the live-diagnosed root cause of "the spark does nothing").
-    useCanvasStore.setState({ draftComposerText: text })
-    // 2. If a composer IS already mounted (e.g. an open floating chat), update its
-    //    live value too — the mount-time initialiser in (1) won't re-run for it.
-    useGuidanceStore.getState()._prefillChat?.(text)
+    // 1. Merge into (never clobber) any unsent draft. The chat composer mirrors
+    //    its value to draftComposerText (useComposerState), so a message typed on
+    //    the Olumi tab is persisted here; overwriting it would silently destroy
+    //    the user's unsent text. A freshly-mounting composer initialises from this.
+    const merged = mergeComposerDraft(useCanvasStore.getState().draftComposerText, text)
+    useCanvasStore.setState({ draftComposerText: merged })
+    // 2. If a composer IS already mounted (e.g. an open floating chat), set its
+    //    live value to the SAME merged text — the mount-time initialiser in (1)
+    //    won't re-run for it. (`_prefillChat` is null on the Analysis tab.)
+    useGuidanceStore.getState()._prefillChat?.(merged)
     // 3. Reveal the Olumi chat surface so the prefill is visible. Mirrors the
     //    live-diagnosed reveal in useConversationActions: forceActivate the docked
     //    Olumi tab (bumps the version so the dock reconciles + opens even when the
@@ -94,5 +105,6 @@ export function useFocusNow(): FocusNowProps {
     onPrefill,
     onRerun,
     rerunDisabled: isRunning,
+    actionsEnabled,
   }
 }

--- a/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
@@ -35,7 +35,12 @@ vi.mock('@/flags', async () => {
   }
 })
 
-import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled } from '@/flags'
+import {
+  isAnalysisHeroV17Enabled,
+  isAnalysisHeroCompareEnabled,
+  isFocusNowPanelEnabled,
+  isAiPanelV2Enabled,
+} from '@/flags'
 import { useCanvasStore } from '@/canvas/store'
 import { useUIStore } from '@/stores/uiStore'
 
@@ -85,6 +90,7 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     vi.mocked(isAnalysisHeroV17Enabled).mockReturnValue(false)
     vi.mocked(isAnalysisHeroCompareEnabled).mockReturnValue(false)
     vi.mocked(isFocusNowPanelEnabled).mockReturnValue(true)
+    vi.mocked(isAiPanelV2Enabled).mockReturnValue(true)
     useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false, draftComposerText: null })
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
   })
@@ -155,5 +161,33 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     // …with NO graph mutation (node/edge collections untouched by reference).
     expect(useCanvasStore.getState().nodes).toBe(nodesBefore)
     expect(useCanvasStore.getState().edges).toBe(edgesBefore)
+  })
+
+  it('APPENDS to an existing unsent draft — never clobbers it', () => {
+    // The composer mirrors its value to draftComposerText; a Focus action must not
+    // destroy a message the user was still writing on the Olumi tab.
+    useCanvasStore.setState({ draftComposerText: 'I am leaning towards option A' })
+    renderBody()
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    fireEvent.click(screen.getByTestId('focus-action'))
+    expect(useCanvasStore.getState().draftComposerText).toBe(
+      `I am leaning towards option A\n\n${PROMPT}`,
+    )
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
+  })
+
+  it('aiPanelV2 OFF: the panel shows but renders NO action controls (no dead buttons)', () => {
+    // The reveal needs the Olumi tab, which the dock redirects to 'results' when
+    // aiPanelV2 is off. So the controls would be dead — they must not render.
+    vi.mocked(isAiPanelV2Enabled).mockReturnValue(false)
+    renderBody()
+    expect(screen.getByTestId('focus-now-panel')).toBeInTheDocument()
+    // the row still expands and shows its guidance…
+    fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
+    expect(screen.getByTestId('focus-card-body')).toBeInTheDocument()
+    // …but neither action control is present, and the tab is not switched
+    expect(screen.queryByTestId('focus-action')).toBeNull()
+    expect(screen.queryByTestId('focus-ask-olumi')).toBeNull()
+    expect(useUIStore.getState().activeOutputTab).toBe('results')
   })
 })


### PR DESCRIPTION
Final verification pass on the Focus panel action behaviour (PR #202 follow-up). It surfaced **two real defects I had introduced**, both fixed narrowly — action behaviour + tests only.

## 1. Draft clobber → now appends, never overwrites

The chat composer mirrors its value to canvas-store `draftComposerText` (`useComposerState`: debounced write-through + unmount flush). So a message the user is still typing on the Olumi tab is **persisted there** even after switching to the Analysis tab. The Focus action wrote `draftComposerText` unconditionally — **silently destroying that unsent draft**.

Fix: new pure `mergeComposerDraft()` **appends** the prompt with a blank-line separator (empty draft → just the prompt; idempotent on repeat clicks). The already-mounted composer receives the same merged text. Still strictly prefill-only.

| Existing draft | Click "Try this" / Ask Olumi → composer becomes |
|---|---|
| _(empty)_ | the prompt |
| `I am leaning towards option A` | `I am leaning towards option A` + blank line + the prompt |

This matches the spirit of the canonical `useConversationActions` path, whose primary delivery (`sendChip`) never touches the user's draft.

## 2. `aiPanelV2` off → controls were dead → now hidden

The reveal needs the docked **Olumi** tab, but `OutputsDock` redirects a requested `'olumi'` tab to `'results'` when `aiPanelV2` is off (emergency-rollback mode). So the controls would set a draft nobody can see — a dead button.

Fix: `useFocusNow` derives `actionsEnabled = isAiPanelV2Enabled()`. When off, the panel renders **no action controls** (CTA + sparkle) — rows stay informational (title / why it matters / try this still show). No visible control that silently does nothing.

## Tests (prove the real effect through mounted ResultsBody, not just handler calls)

- CTA **and** Ask Olumi each write the **expected merged prompt** and switch to the Olumi tab — `ResultsBody.focusPlacement` (`it.each`, real container + stores).
- Existing draft is **appended, not overwritten** — `ResultsBody.focusPlacement` + `useFocusNow` + a pure `mergeComposerDraft` unit suite.
- No auto-send · no graph mutation (node/edge refs unchanged) · no analysis run — `useFocusNow` + `ResultsBody.focusPlacement`.
- Icon has accessible name + is keyboard-operable — `a11y` + `interaction`.
- `aiPanelV2` off → both controls hidden, no tab switch — `ResultsBody.focusPlacement` + `interaction`.
- Stale state still shows a single freshness notice; panel stays 2nd after Hero, before Options — existing placement tests.

focus-now + parent coaching-panel **196** green · CI typecheck ✓ · ESLint ✓ · DS guard Δ+0 ✓ · pre-push fast gate ✓. New Storybook story for the actions-hidden state.

## Scope

focus-now module + its placement test only. No Hero/Options/OutputsDock/placement/flag/backend/schema/prompt/migration/V6 changes. `coaching_summary` stays gated off; no dynamic rows.

## Staging walkthrough for Paul

`https://staging--olumi.netlify.app/#/canvas` → build a model → run analysis → **Analysis tab** → 2nd panel:
1. **Try this** opens chat with the prompt prefilled, not sent.
2. **Ask Olumi** sparkle does the same; Tab to it + Enter works; hover shows "Ask Olumi".
3. **Draft test:** type an unsent message in chat → return to Analysis tab → click a Focus action → your message is **kept**, the prompt is **appended** below it.
4. Stale state shows **one** freshness notice only; panel stays 2nd after Hero, before Options.

## Two product decisions still yours (not made here)

- Whether the sparkle earns its place or feels noisy next to the CTA.
- Whether to rename **"Strengthen your model"** → **"Improve your model"** to avoid colliding with Hero's "Strengthen this decision". Both are one-line changes I can make on your word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)