### PR TITLE
fix(coaching): Focus prefill writes the LIVE chat draft (panel opened but text never appeared)

### DIFF
--- a/src/canvas/components/coaching-panel/focus-now/__tests__/composerWiring.realDom.spec.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/composerWiring.realDom.spec.tsx
@@ -1,0 +1,74 @@
+/**
+ * Real-DOM proof of the composer binding the staging bug lived in.
+ *
+ * The visible aiPanelV2 composer is AIInputBar, whose textarea is bound directly to
+ * ConversationContext `draft`. A Focus action (useFocusNow.onPrefill) writes that
+ * draft via `setDraft(mergeComposerDraft(draft, text))`. The placement spec stubs
+ * the context; THIS spec uses the REAL ConversationProvider + REAL AIInputBar to
+ * prove the click actually reaches the textarea — the kind of real-DOM wiring a
+ * mocked-hook test cannot prove. Only the heavyweight conversation runtime is
+ * stubbed (the established aiPanelV2 test pattern); the provider still supplies the
+ * real draft/setDraft.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  ConversationProvider,
+  useOptionalConversationContext,
+} from '@/canvas/conversation/ConversationContext'
+import { AIInputBar } from '@/canvas/components/AIInputBar'
+import { mergeComposerDraft } from '../composerDraft'
+
+vi.mock('@/canvas/conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    sendMessage: vi.fn(),
+    isThinking: false,
+    cancelTurn: vi.fn(),
+  }),
+}))
+
+const PROMPT = 'Help me think through a risk worth adding to this decision.'
+
+/**
+ * Mirrors the CORE of useFocusNow.onPrefill: merge the prompt into the LIVE
+ * conversation draft. (The reveal/forceActivate is covered elsewhere; this isolates
+ * the composer-binding contract.)
+ */
+function PrefillProbe({ text }: { text: string }) {
+  const convo = useOptionalConversationContext()
+  return (
+    <button type="button" onClick={() => convo?.setDraft(mergeComposerDraft(convo.draft, text))}>
+      prefill
+    </button>
+  )
+}
+
+function renderHarness() {
+  return render(
+    <ConversationProvider>
+      <AIInputBar variant="strip" testId="probe-bar" />
+      <PrefillProbe text={PROMPT} />
+    </ConversationProvider>,
+  )
+}
+
+describe('Focus prefill → real AIInputBar composer', () => {
+  it('writing the conversation draft shows the prompt in the real AIInputBar textarea', () => {
+    renderHarness()
+    const textarea = screen.getByTestId('probe-bar-textarea') as HTMLTextAreaElement
+    expect(textarea.value).toBe('')
+    fireEvent.click(screen.getByText('prefill'))
+    expect(textarea.value).toBe(PROMPT)
+  })
+
+  it('appends to an unsent draft the user already typed, never clobbering it', () => {
+    renderHarness()
+    const textarea = screen.getByTestId('probe-bar-textarea') as HTMLTextAreaElement
+    // user types an unsent message directly into the composer
+    fireEvent.change(textarea, { target: { value: 'I am leaning towards option A' } })
+    expect(textarea.value).toBe('I am leaning towards option A')
+    fireEvent.click(screen.getByText('prefill'))
+    expect(textarea.value).toBe(`I am leaning towards option A\n\n${PROMPT}`)
+  })
+})

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/useFocusNow.spec.ts
@@ -1,68 +1,67 @@
 /**
  * useFocusNow container — enforces the two boundaries the presentational layer
  * cannot: (1) the uncertified coaching_summary is gated OFF; (2) the row action
- * prefills the composer AND opens the chat tab so the prefill is visible, but
- * NEVER sends and never triggers an analysis run. Also maps the live freshness
- * source to the banner.
+ * MERGES the prompt into the LIVE chat composer (ConversationContext draft, which
+ * the visible AIInputBar renders) and reveals the chat, but NEVER sends and never
+ * runs analysis. Also maps the live freshness source to the banner, and gates the
+ * action controls off when there is no live chat / aiPanelV2 is disabled.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-const { store, prefillChat, sendMessage, runV2Analysis, forceActivateOutputTab, focusFloating, setCanvasState, aiPanelV2 } =
-  vi.hoisted(() => ({
-    // Mutable holder so a test can seed an existing composer draft.
-    store: { draftComposerText: null as string | null },
-    prefillChat: vi.fn(),
+const h = vi.hoisted(() => {
+  const draftBox = { draft: '' }
+  return {
+    draftBox,
+    setDraft: vi.fn((text: string) => {
+      draftBox.draft = text
+    }),
     sendMessage: vi.fn(),
     runV2Analysis: vi.fn(),
     forceActivateOutputTab: vi.fn(),
     focusFloating: vi.fn(),
-    setCanvasState: vi.fn(),
     aiPanelV2: vi.fn(() => true),
-  }))
+    hasConversation: { value: true },
+  }
+})
 
 vi.mock('@/canvas/store', () => ({
-  useCanvasStore: Object.assign(
-    (sel: (s: unknown) => unknown) =>
-      sel({
-        ceeAnalysisReady: { coaching_summary: 'live CEE prose that is not claim-certified' },
-        analysisFreshness: { freshness: 'stale' },
-        analysisFreshnessDirty: false,
-      }),
-    {
-      setState: setCanvasState,
-      getState: () => ({ draftComposerText: store.draftComposerText }),
-    },
-  ),
+  useCanvasStore: (sel: (s: unknown) => unknown) =>
+    sel({
+      ceeAnalysisReady: { coaching_summary: 'live CEE prose that is not claim-certified' },
+      analysisFreshness: { freshness: 'stale' },
+      analysisFreshnessDirty: false,
+    }),
 }))
 vi.mock('@/canvas/hooks/useV2Run', () => ({
-  useV2Run: () => ({ runV2Analysis, isRunning: false, cancelRun: vi.fn(), error: null }),
+  useV2Run: () => ({ runV2Analysis: h.runV2Analysis, isRunning: false, cancelRun: vi.fn(), error: null }),
 }))
-vi.mock('@/canvas/stores/guidanceStore', () => ({
-  useGuidanceStore: Object.assign(() => undefined, {
-    getState: () => ({ _prefillChat: prefillChat, _sendMessage: sendMessage }),
-  }),
+vi.mock('@/canvas/conversation/ConversationContext', () => ({
+  useOptionalConversationContext: () =>
+    h.hasConversation.value
+      ? { draft: h.draftBox.draft, setDraft: h.setDraft, sendMessage: h.sendMessage }
+      : null,
 }))
 vi.mock('@/stores/uiStore', () => ({
   useUIStore: Object.assign(() => undefined, {
-    getState: () => ({ forceActivateOutputTab }),
+    getState: () => ({ forceActivateOutputTab: h.forceActivateOutputTab }),
   }),
 }))
-vi.mock('@/canvas/hooks/useFloatingFocus', () => ({ focusFloating }))
-vi.mock('@/flags', () => ({ isAiPanelV2Enabled: aiPanelV2 }))
+vi.mock('@/canvas/hooks/useFloatingFocus', () => ({ focusFloating: h.focusFloating }))
+vi.mock('@/flags', () => ({ isAiPanelV2Enabled: h.aiPanelV2 }))
 
 import { useFocusNow } from '../useFocusNow'
 
 describe('useFocusNow container', () => {
   beforeEach(() => {
-    store.draftComposerText = null
-    aiPanelV2.mockReturnValue(true)
-    prefillChat.mockClear()
-    sendMessage.mockClear()
-    runV2Analysis.mockClear()
-    forceActivateOutputTab.mockClear()
-    focusFloating.mockClear()
-    setCanvasState.mockClear()
+    h.draftBox.draft = ''
+    h.hasConversation.value = true
+    h.aiPanelV2.mockReturnValue(true)
+    h.setDraft.mockClear()
+    h.sendMessage.mockClear()
+    h.runV2Analysis.mockClear()
+    h.forceActivateOutputTab.mockClear()
+    h.focusFloating.mockClear()
   })
 
   it('gates the uncertified coaching_summary OFF (summary is null despite live data)', () => {
@@ -77,38 +76,39 @@ describe('useFocusNow container', () => {
     expect(result.current.banner).toEqual({ kind: 'stale', canRerun: true })
   })
 
-  it('onPrefill persists the composer text, reveals the chat, and never sends', () => {
+  it('onPrefill writes the prompt to the live chat draft, reveals the chat, and never sends', () => {
     const { result } = renderHook(() => useFocusNow())
     result.current.onPrefill?.('Help me add a risk.')
-    // 1. persists the composer text (a freshly-mounting composer initialises from it)
-    expect(setCanvasState).toHaveBeenCalledWith({ draftComposerText: 'Help me add a risk.' })
-    // 2. updates the live composer when one is already mounted (same merged text)
-    expect(prefillChat).toHaveBeenCalledWith('Help me add a risk.')
-    // 3. reveals the Olumi chat surface (docked tab + best-effort floating focus)
-    expect(forceActivateOutputTab).toHaveBeenCalledWith('olumi')
-    expect(focusFloating).toHaveBeenCalled()
-    // never auto-sends, never triggers a re-run
-    expect(sendMessage).not.toHaveBeenCalled()
-    expect(runV2Analysis).not.toHaveBeenCalled()
+    // writes the prompt into the ConversationContext draft (what AIInputBar renders)
+    expect(h.setDraft).toHaveBeenCalledWith('Help me add a risk.')
+    // reveals the Olumi chat surface (docked tab + best-effort floating focus)
+    expect(h.forceActivateOutputTab).toHaveBeenCalledWith('olumi')
+    expect(h.focusFloating).toHaveBeenCalled()
+    // never auto-sends, never triggers a re-run, never touches the legacy draft store
+    expect(h.sendMessage).not.toHaveBeenCalled()
+    expect(h.runV2Analysis).not.toHaveBeenCalled()
   })
 
   it('onPrefill APPENDS to an unsent draft — never clobbers it', () => {
-    store.draftComposerText = 'I am leaning towards option A'
+    h.draftBox.draft = 'I am leaning towards option A'
     const { result } = renderHook(() => useFocusNow())
     result.current.onPrefill?.('Help me add a risk.')
-    const merged = 'I am leaning towards option A\n\nHelp me add a risk.'
-    expect(setCanvasState).toHaveBeenCalledWith({ draftComposerText: merged })
-    // the already-mounted composer receives the SAME merged text (no clobber there either)
-    expect(prefillChat).toHaveBeenCalledWith(merged)
+    expect(h.setDraft).toHaveBeenCalledWith('I am leaning towards option A\n\nHelp me add a risk.')
   })
 
-  it('exposes actionsEnabled=true when aiPanelV2 is on', () => {
+  it('exposes actionsEnabled=true when aiPanelV2 is on and a live chat exists', () => {
     const { result } = renderHook(() => useFocusNow())
     expect(result.current.actionsEnabled).toBe(true)
   })
 
   it('exposes actionsEnabled=false when aiPanelV2 is off (controls must hide, not be dead)', () => {
-    aiPanelV2.mockReturnValue(false)
+    h.aiPanelV2.mockReturnValue(false)
+    const { result } = renderHook(() => useFocusNow())
+    expect(result.current.actionsEnabled).toBe(false)
+  })
+
+  it('exposes actionsEnabled=false when there is no live conversation (cannot reach the composer)', () => {
+    h.hasConversation.value = false
     const { result } = renderHook(() => useFocusNow())
     expect(result.current.actionsEnabled).toBe(false)
   })
@@ -116,6 +116,6 @@ describe('useFocusNow container', () => {
   it('onRerun triggers a re-run', () => {
     const { result } = renderHook(() => useFocusNow())
     result.current.onRerun?.()
-    expect(runV2Analysis).toHaveBeenCalledTimes(1)
+    expect(h.runV2Analysis).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
+++ b/src/canvas/components/coaching-panel/focus-now/useFocusNow.ts
@@ -12,24 +12,26 @@
  *     defaults OFF (CERTIFY_SUMMARY=false). A live mount must keep it hidden or
  *     flip this on ONLY once the summary is passed through Gate Zero / certified
  *     CEE output. Do not call the panel live-safe while it shows uncertified prose.
- *  2. PREFILL-ONLY + VISIBLE — the row action MERGES the prompt into the composer
- *     (via `draftComposerText` for the unmounted case + `_prefillChat` for an
- *     already-mounted one) AND reveals the Olumi/chat surface. It APPENDS to, never
- *     clobbers, an unsent draft (the composer mirrors its value to draftComposerText,
- *     so a message typed on the Olumi tab is persisted there). On the Analysis tab
- *     the chat composer is not mounted (ConversationPanel lives in the Olumi tab) and
- *     its `_prefillChat` callback is null; the persisted `draftComposerText` is what
- *     a freshly-mounting composer initialises from, and `forceActivateOutputTab('olumi')`
- *     mounts/reveals it (the live-diagnosed reveal used by useConversationActions).
- *     There is deliberately NO `_sendMessage`: never auto-sends. The reveal needs
- *     aiPanelV2 (the dock redirects 'olumi'→'results' otherwise), so `actionsEnabled`
- *     gates the controls off when it is disabled — no dead buttons.
+ *  2. PREFILL-ONLY + VISIBLE — the row action MERGES the prompt into the live chat
+ *     composer AND reveals the Olumi/chat surface. The visible aiPanelV2 composer is
+ *     `AIInputBar`, whose textarea is bound directly to ConversationContext `draft`
+ *     (`value={draft}` / `setDraft`). So we write the draft through that context —
+ *     NOT canvas-store `draftComposerText` (the LEGACY composer's draft, which the
+ *     aiPanelV2 composer never reads) and NOT the guidance-store `_prefillChat`
+ *     (unreliable: ConversationPanel overwrites it with a no-op `composerRef`
+ *     under `hideComposer`). A functional `setDraft(prev => merge(prev, text))`
+ *     APPENDS to, never clobbers, an unsent draft and needs no reactive read.
+ *     There is deliberately NO `sendMessage`: never auto-sends. The reveal needs
+ *     aiPanelV2 (the dock redirects 'olumi'→'results' otherwise) and a live
+ *     conversation, so `actionsEnabled` gates the controls off otherwise — no dead
+ *     buttons. This is the same live ConversationContext path useConversationActions
+ *     uses to dodge the guidance-store registration race.
  */
 import { useCallback, useMemo } from 'react'
 import { useCanvasStore } from '@/canvas/store'
-import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
 import { useV2Run } from '@/canvas/hooks/useV2Run'
 import { useUIStore } from '@/stores/uiStore'
+import { useOptionalConversationContext } from '@/canvas/conversation/ConversationContext'
 import { focusFloating } from '@/canvas/hooks/useFloatingFocus'
 import { isAiPanelV2Enabled } from '@/flags'
 import { classifyFreshnessForDisplay } from '@/canvas/store/analysisFreshness'
@@ -56,6 +58,9 @@ export function useFocusNow(): FocusNowProps {
   const freshness = useCanvasStore((s) => s.analysisFreshness)
   const dirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const { runV2Analysis, isRunning } = useV2Run()
+  // The live chat. Optional: null if somehow rendered outside the provider (then we
+  // cannot reach the composer, so we disable the action controls — never dead).
+  const conversation = useOptionalConversationContext()
 
   // Uncertified prose is gated OFF; the data path stays visible for the mount PR.
   const coachingSummary = CERTIFY_SUMMARY ? rawSummary : null
@@ -66,33 +71,31 @@ export function useFocusNow(): FocusNowProps {
     [freshness, dirty],
   )
 
-  // The row action reveals the Olumi chat tab, which only exists when aiPanelV2 is
-  // on — OutputsDock redirects a requested 'olumi' tab to 'results' otherwise, so
-  // the action would set a draft nobody can see. When off we tell the panel to
-  // render NO action controls (rows stay informational, never dead buttons).
-  const actionsEnabled = isAiPanelV2Enabled()
+  // The row action needs (a) a live conversation to write the draft into and (b)
+  // aiPanelV2 — the reveal targets the Olumi tab, which OutputsDock redirects to
+  // 'results' when aiPanelV2 is off. Without both, the controls could not produce a
+  // visible effect, so the panel renders NO action controls (rows stay
+  // informational, never dead buttons).
+  const setDraft = conversation?.setDraft
+  const draft = conversation?.draft ?? ''
+  const actionsEnabled = isAiPanelV2Enabled() && !!setDraft
 
   const onPrefill = useCallback((text: string) => {
-    // Prefill the chat and reveal it — NEVER auto-send.
-    // 1. Merge into (never clobber) any unsent draft. The chat composer mirrors
-    //    its value to draftComposerText (useComposerState), so a message typed on
-    //    the Olumi tab is persisted here; overwriting it would silently destroy
-    //    the user's unsent text. A freshly-mounting composer initialises from this.
-    const merged = mergeComposerDraft(useCanvasStore.getState().draftComposerText, text)
-    useCanvasStore.setState({ draftComposerText: merged })
-    // 2. If a composer IS already mounted (e.g. an open floating chat), set its
-    //    live value to the SAME merged text — the mount-time initialiser in (1)
-    //    won't re-run for it. (`_prefillChat` is null on the Analysis tab.)
-    useGuidanceStore.getState()._prefillChat?.(merged)
-    // 3. Reveal the Olumi chat surface so the prefill is visible. Mirrors the
-    //    live-diagnosed reveal in useConversationActions: forceActivate the docked
-    //    Olumi tab (bumps the version so the dock reconciles + opens even when the
-    //    tab value is unchanged), then best-effort focus a hosting floating panel.
+    if (!setDraft) return
+    // Prefill the LIVE chat composer and reveal it — NEVER auto-send.
+    // The visible aiPanelV2 composer (AIInputBar) is bound to ConversationContext
+    // `draft`, so writing through setDraft updates whichever surface is showing
+    // (strip / floating / docked). APPEND to, never clobber, an unsent draft — the
+    // closed-over `draft` is the latest committed value (this hook subscribes to it).
+    setDraft(mergeComposerDraft(draft, text))
+    // Reveal the Olumi chat surface so the prefill is visible: forceActivate the
+    // docked Olumi tab (bumps the version so the dock reconciles + opens even when
+    // the tab value is unchanged), then best-effort focus a hosting floating panel.
     if (isAiPanelV2Enabled()) {
       useUIStore.getState().forceActivateOutputTab('olumi')
     }
     focusFloating()
-  }, [])
+  }, [setDraft, draft])
 
   const onRerun = useCallback(() => {
     void runV2Analysis()

--- a/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusPlacement.spec.tsx
@@ -35,6 +35,22 @@ vi.mock('@/flags', async () => {
   }
 })
 
+// ResultsBody is not wrapped in a ConversationProvider here, so stub the live chat
+// with a stateful fake: setDraft updates a holder we can assert against. This is
+// the surface the visible AIInputBar reads — the real effect of a Focus action.
+const convo = vi.hoisted(() => {
+  const box = { draft: '' }
+  return {
+    box,
+    setDraft: vi.fn((text: string) => {
+      box.draft = text
+    }),
+  }
+})
+vi.mock('@/canvas/conversation/ConversationContext', () => ({
+  useOptionalConversationContext: () => ({ draft: convo.box.draft, setDraft: convo.setDraft }),
+}))
+
 import {
   isAnalysisHeroV17Enabled,
   isAnalysisHeroCompareEnabled,
@@ -91,7 +107,9 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     vi.mocked(isAnalysisHeroCompareEnabled).mockReturnValue(false)
     vi.mocked(isFocusNowPanelEnabled).mockReturnValue(true)
     vi.mocked(isAiPanelV2Enabled).mockReturnValue(true)
-    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false, draftComposerText: null })
+    convo.box.draft = ''
+    convo.setDraft.mockClear()
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
   })
 
@@ -136,17 +154,17 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     expect(screen.queryByTestId('focus-summary')).toBeNull()
   })
 
-  // Regression for the staging blocker: on the Analysis tab the chat composer is
-  // unmounted (its prefill callback is null), so a working action must persist the
-  // prefill to draftComposerText AND switch the dock to the Olumi tab so a freshly-
-  // mounting composer shows it. End-to-end through the real FocusNowContainer →
-  // useFocusNow → onPrefill (no hook mock). Both row controls must behave the same.
+  // Regression for the staging blocker: the visible aiPanelV2 composer (AIInputBar)
+  // is bound to ConversationContext `draft`, so a working action must write THAT
+  // draft (not the legacy canvas-store draftComposerText) AND reveal the Olumi tab.
+  // End-to-end through the real FocusNowContainer → useFocusNow → onPrefill (no hook
+  // mock); only the live chat is stubbed. Both row controls must behave the same.
   const PROMPT = 'Help me think through a risk worth adding to this decision.'
 
   it.each([
     ['the row CTA', 'focus-action'],
     ['the Ask Olumi icon', 'focus-ask-olumi'],
-  ])('clicking %s prefills the composer and reveals the Olumi chat tab', (_label, testid) => {
+  ])('clicking %s writes the prompt to the live chat draft and reveals the Olumi tab', (_label, testid) => {
     expect(useUIStore.getState().activeOutputTab).toBe('results')
     renderBody()
     const nodesBefore = useCanvasStore.getState().nodes
@@ -154,8 +172,8 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
     // expand the "Add a risk" static row, then click the control under test
     fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
     fireEvent.click(screen.getByTestId(testid))
-    // the prefill text is persisted for a freshly-mounting composer…
-    expect(useCanvasStore.getState().draftComposerText).toBe(PROMPT)
+    // the prompt lands in the live conversation draft (what AIInputBar renders)…
+    expect(convo.box.draft).toBe(PROMPT)
     // …and the chat surface is revealed (Olumi tab activated)…
     expect(useUIStore.getState().activeOutputTab).toBe('olumi')
     // …with NO graph mutation (node/edge collections untouched by reference).
@@ -164,15 +182,13 @@ describe('ResultsBody — Focus panel placement (second Analysis-tab panel)', ()
   })
 
   it('APPENDS to an existing unsent draft — never clobbers it', () => {
-    // The composer mirrors its value to draftComposerText; a Focus action must not
-    // destroy a message the user was still writing on the Olumi tab.
-    useCanvasStore.setState({ draftComposerText: 'I am leaning towards option A' })
+    // A message the user is still writing lives in the conversation draft; a Focus
+    // action must append below it, not overwrite it.
+    convo.box.draft = 'I am leaning towards option A'
     renderBody()
     fireEvent.click(screen.getByRole('button', { name: /add a risk worth watching/i }))
     fireEvent.click(screen.getByTestId('focus-action'))
-    expect(useCanvasStore.getState().draftComposerText).toBe(
-      `I am leaning towards option A\n\n${PROMPT}`,
-    )
+    expect(convo.box.draft).toBe(`I am leaning towards option A\n\n${PROMPT}`)
     expect(useUIStore.getState().activeOutputTab).toBe('olumi')
   })
 


### PR DESCRIPTION
## Symptom (staging)

Clicking a Focus AI button / the **Ask Olumi** sparkle opened the AI panel but **the prompt never appeared in the composer**.

## Root cause (traced through the real composer wiring)

The visible aiPanelV2 composer is **`AIInputBar`**, whose textarea is bound **directly to ConversationContext `draft`** ([AIInputBar.tsx:126,289](src/canvas/components/AIInputBar.tsx#L289)): `value={draft}` / `onChange={e => setDraft(...)}`.

My action wrote canvas-store **`draftComposerText`** — the **legacy** composer's draft, which `AIInputBar` never reads. And that legacy draft is only consumed by a *freshly mounting* composer; the docked tab / strip are **always mounted** (just CSS-`hidden`, [OutputsDock.tsx:2165](src/canvas/components/OutputsDock.tsx#L2165)), so nothing ever re-read it. The guidance-store `_prefillChat` is also unreliable — `ConversationPanel` overwrites it with a no-op `composerRef.replaceText` under `hideComposer`, and no caller passes a working override. So the prompt landed nowhere visible.

## Fix

`useFocusNow.onPrefill` now writes the **live conversation draft** through the ConversationContext directly:

```ts
setDraft(mergeComposerDraft(draft, text))
```

This is the same live-context surface `useConversationActions` uses to dodge the guidance-store registration race. It updates whichever `AIInputBar` variant is showing (strip / floating / docked) and still **appends to, never clobbers** an unsent draft. Still strictly prefill-only: no `sendMessage`, no graph mutation, no analysis run. `actionsEnabled` now also requires a live conversation (else controls hide — no dead buttons). Dropped the `draftComposerText` write and the `_prefillChat` call entirely.

## Tests

- **NEW `composerWiring.realDom.spec`** — mounts the **real `ConversationProvider` + real `AIInputBar`** and proves a click puts the prompt in the **actual textarea** (and appends to a typed draft). This is the real-DOM proof a mocked-hook test can't give — and the gap the bug lived in.
- `useFocusNow` + `ResultsBody.focusPlacement` updated to assert the **live conversation draft** (not the legacy store); both row controls covered end-to-end; append-not-clobber; no send / no graph mutation / no run; `aiPanelV2` off + no-conversation → controls hidden.
- focus-now + parent coaching-panel **208** green · CI typecheck ✓ · ESLint ✓ · DS guard Δ+0 ✓ · pre-push ✓.

## Scope

focus-now module + its placement test only. No Hero/Options/OutputsDock/flag/backend/schema changes. `coaching_summary` stays gated off.

> Note: other AI prefill buttons in the app (inspector "Ask about this", hero prefill) rely on the **same** flaky `_prefillChat` registration and may show the symptom too — out of scope for this PR, flagged for follow-up.

## Verify on staging

`https://staging--olumi.netlify.app/#/canvas` → run analysis → **Analysis tab** → 2nd panel → expand a row → click **Try this** or **Ask Olumi** → the chat opens **with the prompt in the composer**, ready to edit/send (not sent). Type an unsent message first, then click → it's **kept**, the prompt appended below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)