### PR TITLE
fix(coaching): repair _prefillChat so inspector + hero AI prefills reach the composer

### DIFF
--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -21,6 +21,8 @@ import { logger } from '../../lib/logger'
 import { ChevronsRight } from 'lucide-react'
 import { ChatThread } from './zones/ChatThread'
 import { ChatComposer, type ChatComposerHandle } from './zones/ChatComposer'
+import { useOptionalConversationContext } from './ConversationContext'
+import { prefillInto } from './prefillTarget'
 import type { BriefReadiness } from './hooks/useBriefSignals'
 import { useThreadPersistence } from './hooks/useThreadPersistence'
 import { beginInteractionChain, getUiSurfaceState, recordCrossSurfaceEvent, recordInteractionEvent, recordUserAction, type InteractionStateSnapshot } from '../../lib/debug-state'
@@ -114,6 +116,11 @@ export const ConversationPanel = memo(function ConversationPanel({
   const nodeCount = useCanvasStore((s) => s.nodes.length)
   const scenarioId = useCanvasStore((s) => s.currentScenarioId)
   const composerRef = useRef<ChatComposerHandle>(null)
+  // Under `hideComposer` (AI panel v2) the legacy composerRef is never mounted —
+  // the visible composer is AIInputBar, bound to ConversationContext `draft`. We
+  // fall back to writing that draft so prefill actually populates the textarea.
+  // setDraft is the stable useState setter, so it's safe in the register effect's deps.
+  const setDraft = useOptionalConversationContext()?.setDraft
   const pendingBriefRef = useRef<string | null>(null)
   const generateInFlightRef = useRef(false)
   const wasThinkingRef = useRef(false)
@@ -479,14 +486,13 @@ export const ConversationPanel = memo(function ConversationPanel({
   useEffect(() => {
     const sendChipByLabelMessage = (label: string, message: string) =>
       sendChip({ id: `evidence-apply-${Date.now()}`, label, message, intent: 'primary' })
-    // When `hideComposer` is true (AI panel v2) the legacy composerRef is
-    // never mounted, so the default prefill would silently no-op. Use the
-    // caller-supplied override (which targets the visible AIInputBar) so
-    // inspector "Ask about this" and analysis hero prefill actions
-    // actually populate the textarea. Otherwise fall back to the legacy
-    // composer ref.
+    // Prefill the visible composer (see prefillInto): the legacy ChatComposer
+    // ref when mounted, else the ConversationContext draft AIInputBar renders
+    // under `hideComposer`. Writing to the null ref was the silent no-op behind
+    // inspector "Ask about this" / analysis-hero prefills doing nothing. A
+    // caller-supplied override still wins when provided.
     const prefillChat = prefillChatOverride
-      ?? ((text: string) => composerRef.current?.replaceText(text))
+      ?? ((text: string) => prefillInto(composerRef.current, setDraft, text))
     useGuidanceStore.getState().registerConversationCallbacks(
       sendMessage,
       handleScrollToPatch,
@@ -498,7 +504,7 @@ export const ConversationPanel = memo(function ConversationPanel({
     return () => {
       useGuidanceStore.setState({ _sendMessage: null, _runAnalysis: null, _sendChip: null, _scrollToPatch: null, _prefillChat: null, _dispatchAction: null })
     }
-  }, [sendMessage, handleScrollToPatch, sendChip, handleRunAnalysis, dispatchAction, prefillChatOverride])
+  }, [sendMessage, handleScrollToPatch, sendChip, handleRunAnalysis, dispatchAction, prefillChatOverride, setDraft])
 
   const handleInsertText = useCallback((text: string) => {
     composerRef.current?.replaceText(text)

--- a/src/canvas/conversation/__tests__/prefillTarget.spec.ts
+++ b/src/canvas/conversation/__tests__/prefillTarget.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * prefillInto — routes a chat prefill to whichever composer is visible.
+ *
+ * Regression guard for the "AI panel opens but the prompt never appears" bug:
+ * under aiPanelV2 the legacy ChatComposer is unmounted (ref null), so a prefill
+ * MUST fall through to the ConversationContext draft (which AIInputBar renders)
+ * instead of silently no-opping against the null ref.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { prefillInto } from '../prefillTarget'
+
+describe('prefillInto', () => {
+  it('writes to the legacy composer ref when one is mounted (replace)', () => {
+    const replaceText = vi.fn()
+    const setDraft = vi.fn()
+    prefillInto({ replaceText }, setDraft, 'hello')
+    expect(replaceText).toHaveBeenCalledWith('hello')
+    // the live draft is NOT touched when the legacy composer owns the textarea
+    expect(setDraft).not.toHaveBeenCalled()
+  })
+
+  it('writes to the ConversationContext draft when the legacy composer is absent', () => {
+    // This is the fix: composer ref is null under hideComposer (aiPanelV2), so
+    // the prefill must reach the live draft, not vanish.
+    const setDraft = vi.fn()
+    prefillInto(null, setDraft, 'hello')
+    expect(setDraft).toHaveBeenCalledWith('hello')
+  })
+
+  it('does not throw when neither target exists (no live conversation)', () => {
+    expect(() => prefillInto(null, undefined, 'hello')).not.toThrow()
+  })
+})

--- a/src/canvas/conversation/prefillTarget.ts
+++ b/src/canvas/conversation/prefillTarget.ts
@@ -1,0 +1,21 @@
+import type { ChatComposerHandle } from './zones/ChatComposer'
+
+/**
+ * Route a prefill to the visible composer.
+ *
+ * The legacy ChatComposer, when mounted, owns the textarea — set it directly via
+ * its ref. Under aiPanelV2 (`hideComposer`) that composer is NOT mounted and the
+ * visible composer is AIInputBar, which is bound to ConversationContext `draft` —
+ * so write the draft instead. Writing to the (null) composer ref was the silent
+ * no-op behind the "AI panel opens but nothing appears" prefill bug (inspector
+ * "Ask about this", analysis-hero prefills). Either path is replace semantics,
+ * matching the legacy `replaceText` behaviour.
+ */
+export function prefillInto(
+  composer: Pick<ChatComposerHandle, 'replaceText'> | null,
+  setDraft: ((text: string) => void) | undefined,
+  text: string,
+): void {
+  if (composer) composer.replaceText(text)
+  else setDraft?.(text)
+}


### PR DESCRIPTION
Follow-up to the Focus-panel prefill fix ([PR #204](https://github.com/Talchain/DecisionGuideAI/pull/204)) — extends the **same** repair to the other AI prefill affordances you flagged as "opens the panel but nothing happens".

## Shared root cause

The guidance-store `_prefillChat` is registered by `ConversationPanel` as `(text) => composerRef.current?.replaceText(text)`. Under aiPanelV2 (`hideComposer`) the legacy `ChatComposer` is **never mounted**, so that ref is `null` and the call is a **silent no-op** — and no caller passes a working override. The visible composer in that mode is `AIInputBar`, bound to ConversationContext `draft`. So **inspector "Ask about this"** (`InspectorCoaching`) and the **analysis-hero prefills** (`AnalysisHeroV17`), which both call `_prefillChat`, did nothing.

## Fix — one place, repairs every `_prefillChat` consumer

`ConversationPanel` now routes the prefill through a new `prefillInto` helper: the legacy composer ref when mounted, else the live ConversationContext `setDraft` (which `AIInputBar` renders). This matches what `OlumiTabBody` already registers, so `_prefillChat` writes the live draft regardless of which registration wins the race.

**`InspectorCoaching` and `AnalysisHeroV17` are unchanged** — they just work now. Replace semantics preserved (matches the legacy `replaceText`); the Focus panel keeps its own append behaviour.

```ts
const prefillChat = prefillChatOverride
  ?? ((text) => prefillInto(composerRef.current, setDraft, text))
```

## Tests

- **`prefillTarget.spec`** pins the exact regression: composer absent → write the draft (not a silent no-op); composer present → replaceText; neither → no throw.
- The chain's other links are already proven: `setDraft → real AIInputBar textarea` (`composerWiring.realDom.spec`, real components) and `OlumiTabBody registers _prefillChat = setDraft` (`OlumiTabBody.callbackLifecycle`).
- 0 new type/lint errors (CI typecheck ✓; app-typecheck diff identical pristine-vs-edited); DS Δ+0; pre-push ✓; `aiPanelV2.interactions` + `OlumiTabBody.callbackLifecycle` regression suites green.
- Pre-existing failures (`useConversation` V5 graph-fetch network errors, `aiPanelTranche1` Item 19 known-broken, `dispatchAction.dom`) confirmed **unchanged** by reverting the edit and re-running — not caused by this change.

## Scope

This touches `ConversationPanel` (the shared registration) by design — it's the single root for all `_prefillChat` consumers. No changes to the buttons themselves, Hero/Options content, flags, backend, or schemas. `DiscussWithAiButton` already worked (it auto-sends).

## Verify on staging

`https://staging--olumi.netlify.app/#/canvas` → build a model + run analysis:
- **Inspector "Ask about this"** (select a node → inspector) → chat opens with the question in the composer.
- **Analysis-hero prefill CTAs** → chat opens with the prompt in the composer.
- (Focus panel Try this / Ask Olumi already fixed in #204.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)