### PR TITLE
fix(coaching): code-review fixes for the AI auto-send change

### DIFF
--- a/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusTypes.ts
@@ -41,16 +41,17 @@ export type FocusOwnership = 'static_hygiene' | 'server_sourced' | 'gated'
 export type FocusSource = 'static_hygiene' | 'coaching_summary' | 'coaching_signal' | (string & {})
 
 /**
- * Display-only action descriptor. NOTHING here executes inside the presentational
- * component — it is handed to an injected handler. `prefill` drops text into the
- * chat composer (never auto-sends); `ask_olumi` is the existing display-only
- * sparkle affordance.
+ * Action descriptor. NOTHING here executes inside the presentational component —
+ * it is handed to an injected handler (the container `useFocusNow` auto-sends the
+ * text to Olumi + reveals the chat). The `prefill`/`prefillText` names are
+ * historical (the action used to prefill the composer); the behaviour is now
+ * send. `ask_olumi` is the sparkle affordance, wired to the same handler.
  */
 export type FocusActionKind = 'prefill' | 'ask_olumi'
 
 export interface FocusAction {
   kind: FocusActionKind
-  /** For kind='prefill': composer text. UI-authored (static) or verbatim (server). */
+  /** For kind='prefill': the prompt text sent to Olumi. UI-authored or verbatim. */
   prefillText?: string
   /** Visible control label. UI-authored, banned-term-safe. */
   label: string
@@ -99,7 +100,11 @@ export interface FocusNowProps {
   summary: string | null
   rows: FocusRow[]
   banner: FocusBannerState
-  /** Prefill the chat composer (no auto-send). Injected; presentational tree owns no store. */
+  /**
+   * Row-action handler (historical name). The injected container (useFocusNow)
+   * AUTO-SENDS the text to Olumi + reveals the chat. Injected so the presentational
+   * tree owns no store.
+   */
   onPrefill?: (text: string) => void
   /**
    * Whether the row action controls (the CTA + Ask Olumi icon) can produce a

--- a/src/canvas/components/pre-analysis-v3/hooks/useConversationActions.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/useConversationActions.ts
@@ -19,29 +19,12 @@ import { useCallback } from 'react'
 import { useOptionalConversationContext } from '../../../conversation/ConversationContext'
 import { useGuidanceStore } from '../../../stores/guidanceStore'
 import { useShowToast } from '../../../ToastContext'
-import { useUIStore } from '../../../../stores/uiStore'
-import { focusFloating } from '../../../hooks/useFloatingFocus'
-import { isAiPanelV2Enabled } from '../../../../flags'
+import { revealOlumiSurface } from '../../../conversation/revealOlumi'
 import { FIELD_FEEDBACK_COPY } from '../constants'
 
 export interface ConversationActions {
   /** Send a prefilled prompt now. Returns false when no surface accepted it. */
   sendPrompt: (label: string, prompt: string) => boolean
-}
-
-/**
- * Bring the conversation into view. The panel lives in the dock, so the
- * docked Olumi tab is the canonical reveal — forceActivateOutputTab also
- * triggers the dock's floating/docked singleton reconciliation. A minimised
- * floating panel keeps its focus callback registered, so focusFloating()
- * alone is NOT a reliable reveal (live-diagnosed); it runs after as a
- * best-effort focus when a visible floating panel ends up hosting the chat.
- */
-function revealOlumiSurface(): void {
-  if (isAiPanelV2Enabled()) {
-    useUIStore.getState().forceActivateOutputTab('olumi')
-  }
-  focusFloating()
 }
 
 export function useConversationActions(): ConversationActions {

--- a/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
@@ -95,9 +95,16 @@ export function InspectorCoaching({
       case 'discuss':
         sendToChat(action.prompt)
         break
-      case 'run_exercise':
-        sendToChat(`/exercise ${action.exercise}`)
+      case 'run_exercise': {
+        // Slash commands must EXECUTE — send only, never fall back to prefill
+        // (a prefilled '/exercise …' would sit in the composer as literal text).
+        const send = useGuidanceStore.getState()._sendMessage
+        if (send) {
+          send(`/exercise ${action.exercise}`)
+          revealOlumiSurface()
+        }
         break
+      }
       default:
         // For other action types, fall back to "Ask about this"
         if (questionText) sendToChat(questionText)

--- a/src/components/results/AnalysisHeroV17.tsx
+++ b/src/components/results/AnalysisHeroV17.tsx
@@ -59,17 +59,17 @@ export interface AnalysisHeroV17Props {
   nodeValueLookup?: Record<string, { value: number | null; unit: string | null; cap: number | null; displayValue?: string | null }>
   /**
    * Accepted for interface compatibility with `DecisionConfidencePanel`
-   * (the legacy panel forwards this to the dominant-factor Research chip
-   * for auto-send). The v17 hero has zero auto-send paths after Fix 9
-   * of the round-4 polish pass, so this prop is INTENTIONALLY IGNORED
-   * here — see the underscore-prefix destructure below. (Round-5 P1.1.)
+   * (the legacy panel forwards this to the dominant-factor Research chip).
+   * The v17 hero drives its own chat sends through the guidance-store
+   * `_sendMessage` wire (see prefillChat below), so this prop is
+   * INTENTIONALLY IGNORED here — see the underscore-prefix destructure below.
    */
   onSendMessage?: (text: string) => void
   /**
    * Accepted for interface compatibility with `DecisionConfidencePanel`
-   * (the legacy panel renders this inside `MissingKnowledgePrompt`, whose
-   * AI affordance prefers `_sendMessage` over `_prefillChat`). v17 hero
-   * INTENTIONALLY IGNORES it to avoid re-introducing an auto-send path.
+   * (the legacy panel renders this inside `MissingKnowledgePrompt`). v17 hero
+   * INTENTIONALLY IGNORES it — its own actions already auto-send via the
+   * guidance-store `_sendMessage` wire, so this separate affordance is redundant.
    */
   aiAffordance?: ReactNode
 }


### PR DESCRIPTION
Follow-up to [PR #207](https://github.com/Talchain/DecisionGuideAI/pull/207) (prefill → auto-send). Three verified findings from an xhigh multi-agent code review, fixed.

## 1. `run_exercise` slash-command (real defect)
Inspector `run_exercise` guidance actions routed through `sendToChat`, which falls back to `_prefillChat` when `_sendMessage` is null — so a `/exercise <name>` command could be **dumped into the composer as literal draft text** instead of executing. The old code was send-only. Fixed: `run_exercise` sends directly (no prefill fallback); the fallback stays only for regular question text (graceful degradation).

## 2. Stale/false docs
- `AnalysisHeroV17` `onSendMessage`/`aiAffordance` prop comments still claimed *"the v17 hero has zero auto-send paths"* — now false.
- `focusTypes` `FocusActionKind` + `onPrefill` JSDoc still said *"never auto-sends"*.
Corrected to describe the auto-send behaviour (identifiers kept as historical).

## 3. DRY
`useConversationActions` had a byte-identical **private** `revealOlumiSurface`; it now imports the shared `src/canvas/conversation/revealOlumi` one (removing the duplicate + its now-unused imports), so the live-diagnosed reveal logic has one source of truth.

## Deliberately NOT changed (flagged to you)
- **reveal-yanks-tab** + **reflect/`run_devils_advocacy` auto-send** — your explicit "all of them" choice, already annotated in-code as a watch-point.
- **moderate-CTA label copy** ("Check top estimate" now also sends) + **`DiscussWithAiButton` reveal consistency** — product/copy decisions I won't make unilaterally.
- **broader `prefill`→`send` identifier renames** — real naming debt, deferred as a separate mechanical refactor (risky to bundle here).

CI typecheck ✓ · ESLint ✓ · DS Δ+0 ✓ · pre-push ✓ · 471 affected tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)