### PR TITLE
refactor(coaching): second-pass review cleanup (DRY + stale docs)

### DIFF
--- a/src/canvas/components/coaching-panel/focus-now/FocusNowContainer.tsx
+++ b/src/canvas/components/coaching-panel/focus-now/FocusNowContainer.tsx
@@ -9,8 +9,8 @@
  * Behaviour stays static / fail-closed: `coaching_summary` is gated off
  * (CERTIFY_SUMMARY=false), there are no server/dynamic coaching rows, no readiness
  * rows, no `bias_findings`, and no UI-authored analytical claims. Mounting it adds
- * only the six generic static hygiene rows + the certified freshness banner +
- * prefill-only actions.
+ * only the six generic static hygiene rows + the certified freshness banner + row
+ * actions that AUTO-SEND their (UI-authored, banned-term-safe) prompt to Olumi.
  */
 import { FocusNowPanel } from './FocusNowPanel'
 import { useFocusNow } from './useFocusNow'

--- a/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
+++ b/src/canvas/components/coaching-panel/focus-now/focusConstants.ts
@@ -33,7 +33,7 @@ export const FOCUS_COPY = {
   emptyState: 'Nothing to focus on right now.',
   /** Bold lead-in before a row's nudge. */
   tryThisLabel: 'Try this',
-  /** Icon affordance label + tooltip — prefills the chat and opens it (same as the CTA). */
+  /** Icon affordance label + tooltip — sends the prompt to Olumi + opens the chat (same as the CTA). */
   askOlumi: 'Ask Olumi',
   /** Generic accessible name for a row whose primary line is empty (operability, not a title). */
   itemFallback: 'Focus item',

--- a/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
@@ -67,14 +67,16 @@ export function InspectorCoaching({
     [panelType, labelContext],
   )
 
-  // Send the text to Olumi immediately (auto-send) and reveal the chat. Falls back
-  // to prefilling the composer only if the send wire is unavailable.
-  const sendToChat = useCallback((text: string) => {
+  // Send the text to Olumi immediately (auto-send) and reveal the chat. Prose falls
+  // back to prefilling the composer when the send wire is unavailable; slash
+  // commands pass allowPrefillFallback:false because a prefilled '/exercise …'
+  // would sit in the composer as literal text instead of executing.
+  const sendToChat = useCallback((text: string, opts?: { allowPrefillFallback?: boolean }) => {
     const state = useGuidanceStore.getState()
     if (state._sendMessage) {
       state._sendMessage(text)
       revealOlumiSurface()
-    } else if (state._prefillChat) {
+    } else if (opts?.allowPrefillFallback !== false && state._prefillChat) {
       state._prefillChat(text)
       revealOlumiSurface()
     }
@@ -95,16 +97,10 @@ export function InspectorCoaching({
       case 'discuss':
         sendToChat(action.prompt)
         break
-      case 'run_exercise': {
-        // Slash commands must EXECUTE — send only, never fall back to prefill
-        // (a prefilled '/exercise …' would sit in the composer as literal text).
-        const send = useGuidanceStore.getState()._sendMessage
-        if (send) {
-          send(`/exercise ${action.exercise}`)
-          revealOlumiSurface()
-        }
+      case 'run_exercise':
+        // Slash command: send-only (no prefill fallback — see sendToChat).
+        sendToChat(`/exercise ${action.exercise}`, { allowPrefillFallback: false })
         break
-      }
       default:
         // For other action types, fall back to "Ask about this"
         if (questionText) sendToChat(questionText)

--- a/src/components/results/AnalysisHeroV17.tsx
+++ b/src/components/results/AnalysisHeroV17.tsx
@@ -92,13 +92,12 @@ export const AnalysisHeroV17 = memo(function AnalysisHeroV17({
   onConfirm,
   expertMode: _expertMode,
   nodeValueLookup,
-  // (Round-5 P1.1) These two props are accepted on the public interface
-  // for compatibility with DecisionConfidencePanel's prop shape but are
-  // INTENTIONALLY NOT forwarded into TriageActionCardsBody — they're
-  // both auto-send wires (Research chip + DiscussWithAiButton ai
-  // affordance). The v17 hero must have zero auto-send paths, so we
-  // accept-and-ignore. The body renders its contextual blocks without
-  // those two surfaces in v17 mode.
+  // These two props are accepted on the public interface for compatibility with
+  // DecisionConfidencePanel's prop shape but are INTENTIONALLY NOT forwarded into
+  // TriageActionCardsBody — they are redundant here. The v17 hero drives its own
+  // chat sends through the guidance-store `_sendMessage` wire (see prefillChat
+  // below), so the Research chip + DiscussWithAiButton affordance are not needed;
+  // accept-and-ignore. The body renders its contextual blocks without them.
   onSendMessage: _onSendMessage,
   aiAffordance: _aiAffordance,
 }: AnalysisHeroV17Props) {
@@ -281,11 +280,10 @@ export const AnalysisHeroV17 = memo(function AnalysisHeroV17({
             callout, conditional scenarios, dominant-factor nudge, T1
             checks footer) still render — those are signals the v17 top
             section does not duplicate. */}
-        {/* (Round-5 P1.1) onSendMessage + aiAffordance intentionally NOT
-            forwarded. Both are auto-send wires (Research chip +
-            DiscussWithAiButton). v17 must have zero auto-send paths,
-            so the body composes without them — Research chip + AI
-            affordance simply don't render in v17 mode. */}
+        {/* onSendMessage + aiAffordance intentionally NOT forwarded — the v17
+            hero drives its own chat sends via the guidance-store `_sendMessage`
+            wire, so the Research chip + DiscussWithAiButton affordance are
+            redundant and simply don't render in v17 mode. */}
         <TriageActionCardsBody
           data={data}
           onFocusNode={onFocusNode}


### PR DESCRIPTION
Follow-up review of the previous review-fix commit ([PR #208](https://github.com/Talchain/DecisionGuideAI/pull/208)). **No live bug found** — the finders converged on one DRY refactor and three more stale "prefill" comments the first pass missed.

## 1. DRY — `run_exercise`
The `run_exercise` block copy-pasted `sendToChat`'s send+reveal sequence (drift risk). `sendToChat` now takes an `{ allowPrefillFallback }` option; `run_exercise` passes `false` (slash commands must execute, never prefill), so the send/reveal wiring lives in **one** place again while keeping the send-only semantics.

## 2. Stale docs (sibling spots the first pass missed)
- `AnalysisHeroV17` **body** comments (both the destructure and the JSX) still asserted *"the v17 hero must have zero auto-send paths"* — contradicting the auto-sending `prefillChat` helper and the already-corrected prop JSDoc. Reworded to the real reason (redundant wires; the hero sends via `_sendMessage`).
- `FocusNowContainer` (the **one authorized live-mount** file) said mounting adds *"prefill-only actions"* → now *"actions that auto-send their prompt to Olumi"* (matters for anyone auditing that file's safety envelope).
- `focusConstants.askOlumi` JSDoc said the icon *"prefills the chat"* → now *"sends the prompt to Olumi + opens the chat"*.

CI typecheck ✓ · ESLint ✓ · DS Δ+0 ✓ · pre-push ✓ · 142 affected tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)