### PR TITLE
feat(results): analysis hero panel — flag-gated, read-only, two-lens launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,10 @@ npm run build                      # production build (separate concern)
 | UI-SEM-051 | `src/canvas/components/pre-analysis-v3/constants.ts` | Pre-analysis v3 bar state colour thresholds (warning <0.40, success >=0.75) | Keep — display formatting (legitimate) |
 | UI-SEM-052 | `src/canvas/components/pre-analysis-v3/constants.ts` | Pre-analysis v3 bar fill denominators (options/risks saturate at 3; frame thirds; estimates degree-fallback base weight 1) | Keep — display formatting (legitimate) |
 | UI-SEM-053 | `src/canvas/components/pre-analysis-v3/constants.ts` | Pre-analysis v3 gauge segment quantisation (continuous fill → lit-of-N discrete segments: round(fill·N), clamp [1,N] for positive fill, 0 when empty) | Keep — display formatting (legitimate) |
+| UI-SEM-054 | `src/components/results/analysis-hero/buildHeroModel.ts` | Analysis-hero outcome-axis layout domain (min/max over existing p10/p90/centres + goal threshold only when unit-compatible; 5% pad, unit pad on degenerate span) — positions bars only, never displayed as data | Keep — display formatting (legitimate) |
+| UI-SEM-055 | `src/components/results/analysis-hero/HeroOptionRow.tsx` | Analysis-hero track position clamp to [0,100]% of the track (layout only; readouts always show unclamped source values) | Keep — display formatting (legitimate) |
+| UI-SEM-056 | `src/components/results/analysis-hero/buildHeroModel.ts` | Analysis-hero constraint-presence copy switch (goal-and-limits vs goal-alone wording; "and limits" only when every goal-bearing option carries constraint analysis) | Keep — display formatting (legitimate) |
+| UI-SEM-057 | `src/components/results/analysis-hero/buildHeroModel.ts` | Analysis-hero sub-1% goal readout floor ("< 1%" when goalProbability < 0.01 — OptionCards parity) | Keep — display formatting (legitimate) |
 
 - Check for stale `.js` files co-located with `.ts`/`.tsx` source files in `src/` when debugging unexpected behaviour.
 - This is a React app — check for stale component state, missing dependency arrays in hooks, and incorrect memoisation when debugging rendering issues.

--- a/netlify.toml
+++ b/netlify.toml
@@ -64,6 +64,12 @@
   # closed by default and the debug panel refuses to render.
   VITE_APP_ENV = "staging"
 
+  # Analysis hero panel — answer-first lens hero above the existing
+  # Analysis-tab hero (read-only, feature-flagged). Enabled on staging for
+  # QA; promote to production by adding to `[build.environment]` ONLY after
+  # sign-off. See src/flags.ts `analysisHeroPanel`.
+  VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"
+
 # =============================================================================
 # Security Headers (P0 - Enterprise Compliance)
 # =============================================================================

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -29,7 +29,8 @@ import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
 import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
 import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
-import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled } from '@/flags'
+import { AnalysisHeroContainer } from './analysis-hero'
+import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled, isAnalysisHeroPanelEnabled } from '@/flags'
 
 export interface StrengthCorrectionDisplay {
   edgeId: string
@@ -223,6 +224,17 @@ export const ResultsBody = memo(function ResultsBody({
       {/* Freshness/staleness — CEE analysis_ready.freshness verdict. Renders
           nothing until a verdict exists; never asserts a state we don't hold. */}
       <AnalysisFreshnessNotice />
+
+      {/* ── ANALYSIS HERO (answer-first lens hero) ─────────────────
+          Feature-flagged (staging-on, production-off). Read-only
+          presentation over the SAME resultsSectionData object the panels
+          below consume — mounted ABOVE the existing hero block; flag off
+          renders nothing and the tab is unchanged. */}
+      {isAnalysisHeroPanelEnabled() && (
+        <SectionErrorBoundary section="Analysis hero">
+          <AnalysisHeroContainer data={resultsSectionData} isStale={isStale} />
+        </SectionErrorBoundary>
+      )}
 
       {/* ── DECISION CONFIDENCE TRIAGE ────────────────────────────── */}
       {/* Comparison mode: v17 ABOVE legacy panel. Opt-in only. */}

--- a/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
@@ -14,7 +14,7 @@
  * only external importer — so the fixture data is built locally.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ResultsBody } from '../ResultsBody'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type {
@@ -194,6 +194,40 @@ describe('ResultsBody — Analysis hero placement + flag regression', () => {
     const hero = screen.getByTestId('analysis-hero-panel')
     expect(hero.contains(notices[0])).toBe(false)
     expect(hero.textContent).not.toMatch(/stale|not analysed|re-run before/i)
+  })
+
+  it('flag ON: hero focus-next is neutral copy that scrolls the REAL mounted coaching panel', () => {
+    // Focus-next reconciliation (review item 1): the coaching panel orders
+    // its rows positionally (buildFocusRows), not by vm.topAction, so the
+    // hero deliberately names NO action — neutral copy targeting the panel
+    // container. This test runs against the real mounted tree, not a
+    // synthetic target.
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    renderBody()
+    const panel = screen.getByTestId('focus-now-panel')
+    const scrollSpy = vi.fn()
+    panel.scrollIntoView = scrollSpy
+
+    const focusNext = screen.getByTestId('hero-focus-next')
+    expect(focusNext.tagName).toBe('BUTTON')
+    // Neutral copy — names the panel, never a specific coaching row.
+    expect(focusNext).toHaveTextContent('Focus next: review the top actions below.')
+    const heroText = screen.getByTestId('analysis-hero-panel').textContent ?? ''
+    expect(heroText).not.toContain('Define what success looks like')
+    expect(heroText).not.toContain('Add a risk')
+
+    fireEvent.click(focusNext)
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('flag ON, coaching panel OFF: focus-next degrades to plain text (no dead link, no throw)', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    vi.mocked(isFocusNowPanelEnabled).mockReturnValue(false)
+    renderBody()
+    expect(screen.queryByTestId('focus-now-panel')).toBeNull()
+    const focusNext = screen.getByTestId('hero-focus-next')
+    expect(focusNext.tagName).toBe('P')
+    expect(focusNext).toHaveTextContent('Focus next: review the top actions below.')
   })
 
   it('flag ON with V17 hero enabled: new hero still precedes the V17 hero slot', () => {

--- a/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
@@ -1,0 +1,199 @@
+/**
+ * ResultsBody — Analysis hero panel placement + flag regression.
+ *
+ * Flag OFF: the Analysis tab renders EXACTLY as today — no hero element, the
+ * existing hero (DecisionConfidencePanel), Focus panel and Options section
+ * unchanged and in order.
+ *
+ * Flag ON: the new hero mounts AFTER the freshness notice slot and ABOVE the
+ * existing hero block (stack decision), with every existing panel still
+ * present and ordered. Stale prop routes the hero's Focus-next to Re-run.
+ *
+ * NOTE: this spec deliberately does not import anything from the
+ * analysis-hero module — its inertness guard allow-lists ResultsBody as the
+ * only external importer — so the fixture data is built locally.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }
+})
+
+import {
+  isAnalysisHeroV17Enabled,
+  isAnalysisHeroCompareEnabled,
+  isFocusNowPanelEnabled,
+  isAiPanelV2Enabled,
+  isAnalysisHeroPanelEnabled,
+} from '@/flags'
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.4,
+    outcome: { mean: 0.4, p10: 0.2, p50: 0.38, p90: 0.6 },
+    p10: 0.2,
+    p50: 0.38,
+    p90: 0.6,
+    isRecommended: false,
+    winProbability: 0.3,
+    goalProbability: 0.3,
+  } as unknown as OptionResult
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody(props: { isStale?: boolean } = {}) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      isStale={props.isStale}
+    />,
+  )
+}
+
+const before = (a: HTMLElement, b: HTMLElement) =>
+  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+describe('ResultsBody — Analysis hero placement + flag regression', () => {
+  beforeEach(() => {
+    vi.mocked(isAnalysisHeroV17Enabled).mockReturnValue(false)
+    vi.mocked(isAnalysisHeroCompareEnabled).mockReturnValue(false)
+    vi.mocked(isFocusNowPanelEnabled).mockReturnValue(true)
+    vi.mocked(isAiPanelV2Enabled).mockReturnValue(true)
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(false)
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+  })
+
+  it('flag OFF: no hero element; existing panels unchanged and ordered', () => {
+    renderBody()
+    expect(screen.queryByTestId('analysis-hero-panel')).toBeNull()
+    const existingHero = screen.getByTestId('decision-confidence-panel')
+    const focus = screen.getByTestId('focus-now-panel')
+    const options = screen.getByTestId('section-header-options')
+    expect(before(existingHero, focus)).toBe(true)
+    expect(before(focus, options)).toBe(true)
+  })
+
+  it('flag ON: hero mounts ABOVE the existing hero block; existing panels untouched', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    renderBody()
+    const hero = screen.getByTestId('analysis-hero-panel')
+    const existingHero = screen.getByTestId('decision-confidence-panel')
+    const focus = screen.getByTestId('focus-now-panel')
+    const options = screen.getByTestId('section-header-options')
+    expect(before(hero, existingHero), 'new hero must precede the existing hero').toBe(true)
+    expect(before(existingHero, focus), 'existing hero still precedes the Focus panel').toBe(true)
+    expect(before(focus, options), 'Focus panel still precedes options').toBe(true)
+  })
+
+  it('flag ON: hero consumes the same data (headline names the recommended option)', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    renderBody()
+    expect(screen.getByTestId('hero-headline')).toHaveTextContent('Option A best fits your goal.')
+  })
+
+  it('flag ON + stale: hero soft-disables and offers Re-run (no extra stale banner)', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    renderBody({ isStale: true })
+    expect(screen.getByTestId('hero-rerun')).toBeInTheDocument()
+    // The hero adds NO stale banner of its own — AnalysisFreshnessNotice owns
+    // stale wording, and with no freshness verdict there is exactly none.
+    expect(screen.queryByTestId('analysis-freshness-notice')).toBeNull()
+  })
+
+  it('flag ON with V17 hero enabled: new hero still precedes the V17 hero slot', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    vi.mocked(isAnalysisHeroV17Enabled).mockReturnValue(true)
+    renderBody()
+    const hero = screen.getByTestId('analysis-hero-panel')
+    const v17 = screen.getByTestId('analysis-hero-v17')
+    expect(before(hero, v17), 'new hero must precede AnalysisHeroV17').toBe(true)
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
@@ -181,11 +181,19 @@ describe('ResultsBody — Analysis hero placement + flag regression', () => {
 
   it('flag ON + stale: hero soft-disables and offers Re-run (no extra stale banner)', () => {
     vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    // Realistic stale state: the freshness slice IS stale, so the tab's
+    // AnalysisFreshnessNotice actually renders — the hero must not add a
+    // second stale surface of its own.
+    useCanvasStore.setState({ analysisFreshness: { freshness: 'stale' }, analysisFreshnessDirty: false })
     renderBody({ isStale: true })
     expect(screen.getByTestId('hero-rerun')).toBeInTheDocument()
-    // The hero adds NO stale banner of its own — AnalysisFreshnessNotice owns
-    // stale wording, and with no freshness verdict there is exactly none.
-    expect(screen.queryByTestId('analysis-freshness-notice')).toBeNull()
+    // Exactly ONE stale surface on the tab: the existing notice…
+    const notices = screen.getAllByTestId('analysis-freshness-notice')
+    expect(notices).toHaveLength(1)
+    // …and it is NOT inside the hero (the hero authors no stale banner).
+    const hero = screen.getByTestId('analysis-hero-panel')
+    expect(hero.contains(notices[0])).toBe(false)
+    expect(hero.textContent).not.toMatch(/stale|not analysed|re-run before/i)
   })
 
   it('flag ON with V17 hero enabled: new hero still precedes the V17 hero slot', () => {

--- a/src/components/results/analysis-hero/AnalysisHeroContainer.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroContainer.tsx
@@ -1,0 +1,36 @@
+/**
+ * AnalysisHeroContainer — the ONE authorised mount of the analysis hero.
+ *
+ * Mounted exclusively by ResultsBody (enforced by __tests__/inertness.spec.ts)
+ * inside a SectionErrorBoundary, behind the `analysisHeroPanel` flag. Bridges
+ * the store-aware hook to the store-free presentational panel and fails
+ * closed: an empty model renders nothing, leaving the existing tab unchanged.
+ *
+ * Props are the SAME objects ResultsBody already holds for the existing
+ * panels — the hero introduces no second data path.
+ */
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { AnalysisHeroPanel } from './AnalysisHeroPanel'
+import { useAnalysisHero } from './useAnalysisHero'
+
+export interface AnalysisHeroContainerProps {
+  data: ResultsSectionDataReturn
+  /** ResultsBody's existing staleness signal (OutputsDock freshness verdict). */
+  isStale?: boolean
+}
+
+export function AnalysisHeroContainer({ data, isStale = false }: AnalysisHeroContainerProps) {
+  const { model, onRerun, rerunDisabled, focusPanelMounted } = useAnalysisHero(data)
+  if (model.kind === 'empty') return null
+  return (
+    <AnalysisHeroPanel
+      model={model}
+      isStale={isStale}
+      onRerun={onRerun}
+      rerunDisabled={rerunDisabled}
+      focusPanelMounted={focusPanelMounted}
+    />
+  )
+}
+
+export default AnalysisHeroContainer

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -201,7 +201,12 @@ export function AnalysisHeroPanel({
             data-testid="hero-rerun"
             className={`${typography.panelMeta} inline-flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-text-on-color transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-50`}
           >
-            <RefreshCw aria-hidden="true" className="h-3.5 w-3.5" />
+            <RefreshCw
+              aria-hidden="true"
+              className={`h-3.5 w-3.5 ${
+                rerunDisabled ? 'animate-spin motion-reduce:animate-none' : ''
+              }`}
+            />
             {HERO_COPY.footer.rerun}
           </button>
         ) : focusPanelMounted ? (

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -91,18 +91,13 @@ export function AnalysisHeroPanel({
   const interactive = !isStale
   const showTabs = model.lenses.length > 1
 
-  const axis =
-    lens === 'goal'
-      ? model.hasConstraints
-        ? HERO_COPY.axis.goalWithLimits
-        : HERO_COPY.axis.goalOnly
-      : HERO_COPY.axis.outcome
-
+  // Constraint presence picks the goal-lens copy variant once for both
+  // the axis and the caption (the two share key structure in HERO_COPY).
+  const goalKey = model.hasConstraints ? ('goalWithLimits' as const) : ('goalOnly' as const)
+  const axis = lens === 'goal' ? HERO_COPY.axis[goalKey] : HERO_COPY.axis.outcome
   const caption =
     lens === 'goal'
-      ? model.hasConstraints
-        ? HERO_COPY.caption.goalWithLimits
-        : HERO_COPY.caption.goalOnly
+      ? HERO_COPY.caption[goalKey]
       : model.targetReadout
         ? `${HERO_COPY.caption.outcome} ${HERO_COPY.caption.outcomeTarget(model.targetReadout)}`
         : HERO_COPY.caption.outcome

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -21,7 +21,7 @@
  * ROBUSTNESS-VERDICT-CONTRACT), so the trust line is omitted rather than
  * derived. Raw 0-1 stability/confidence floats are never displayed.
  */
-import { useId, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { ArrowDown, Info, RefreshCw } from 'lucide-react'
 import { typography } from '@/styles/typography'
 import { HERO_COPY } from './heroCopy'
@@ -42,9 +42,12 @@ export interface AnalysisHeroPanelProps {
   focusPanelMounted: boolean
 }
 
+/** The coaching panel container the focus-next affordance scrolls to. */
+const FOCUS_PANEL_SELECTOR = '[data-testid="focus-now-panel"]'
+
 /** Scroll to the coaching panel below; no-op when the target is absent. */
 function scrollToFocusPanel() {
-  const el = document.querySelector('[data-testid="focus-now-panel"]')
+  const el = document.querySelector(FOCUS_PANEL_SELECTOR)
   if (!el) return
   const reduced =
     typeof window.matchMedia === 'function' &&
@@ -71,6 +74,19 @@ export function AnalysisHeroPanel({
   const panelId = useId()
   const [lensState, setLensState] = useState<HeroLens | null>(null)
   const [openRowId, setOpenRowId] = useState<string | null>(null)
+
+  // `focusPanelMounted` only says the coaching panel's flag is on. The
+  // focus-next affordance must never be an enabled no-op for keyboard and
+  // screen-reader users, so the actual scroll target's presence is confirmed
+  // post-commit (its error boundary may have replaced it) and the line
+  // degrades to plain text when the target is absent. Re-checked on every
+  // commit; React's setState equality bail-out keeps this loop-free.
+  const [focusTargetPresent, setFocusTargetPresent] = useState(false)
+  useEffect(() => {
+    setFocusTargetPresent(
+      focusPanelMounted && document.querySelector(FOCUS_PANEL_SELECTOR) != null,
+    )
+  })
 
   if (model.kind === 'status') {
     return (
@@ -204,7 +220,7 @@ export function AnalysisHeroPanel({
             />
             {HERO_COPY.footer.rerun}
           </button>
-        ) : focusPanelMounted ? (
+        ) : focusTargetPresent ? (
           <button
             type="button"
             onClick={scrollToFocusPanel}

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -1,0 +1,228 @@
+/**
+ * AnalysisHeroPanel — presentational, prop-driven, STORE-FREE.
+ *
+ * Renders the answer-first hero: headline + tension subline, lens tabs,
+ * axis, option rows (disclosure detail), caption, and the compressed footer
+ * strip (Main reason / Focus next). Also renders the curated non-chart
+ * states (partial / failed / blocked). Every number shown comes from the
+ * model built by buildHeroModel — this component adds layout and copy
+ * composition only.
+ *
+ * Lens switching and row disclosure are LOCAL render state: no fetch, no
+ * analysis rerun, no selector recomputation, and the row DOM persists across
+ * lens switches (values morph via transform/opacity in HeroOptionRow).
+ *
+ * Stale treatment (no hero-owned banner — AnalysisFreshnessNotice owns the
+ * wording): the chart area is dimmed and inert, lens and row interactions
+ * are locked, and Focus next becomes the Re-run analysis action.
+ *
+ * Trust discipline: no trust/stability wording is rendered anywhere in this
+ * panel — no producer-supplied display-safe label exists today (see
+ * ROBUSTNESS-VERDICT-CONTRACT), so the trust line is omitted rather than
+ * derived. Raw 0-1 stability/confidence floats are never displayed.
+ */
+import { useId, useState } from 'react'
+import { ArrowDown, Info, RefreshCw } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { HERO_COPY } from './heroCopy'
+import { HeroLensTabs, tabId } from './HeroLensTabs'
+import { HeroOptionRow, HERO_ROW_GRID } from './HeroOptionRow'
+import type { HeroChartModel, HeroLens, HeroStatusModel } from './heroTypes'
+
+export interface AnalysisHeroPanelProps {
+  model: HeroChartModel | HeroStatusModel
+  isStale: boolean
+  onRerun: () => void
+  rerunDisabled: boolean
+  /**
+   * Whether the coaching panel below is actually mounted (its flag is on).
+   * Gates the Focus-next scroll affordance so the hero never renders a dead
+   * link — with the panel absent the line degrades to plain text.
+   */
+  focusPanelMounted: boolean
+}
+
+/** Scroll to the coaching panel below; no-op when the target is absent. */
+function scrollToFocusPanel() {
+  const el = document.querySelector('[data-testid="focus-now-panel"]')
+  if (!el) return
+  const reduced =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  el.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' })
+}
+
+function StatusState({ model }: { model: HeroStatusModel }) {
+  return (
+    <div data-testid={`hero-status-${model.variant}`} className="space-y-1">
+      <h3 className={`${typography.panelHeader} text-text-header`}>{model.headline}</h3>
+      <p className={`${typography.panelBody} text-text-light`}>{model.body}</p>
+    </div>
+  )
+}
+
+export function AnalysisHeroPanel({
+  model,
+  isStale,
+  onRerun,
+  rerunDisabled,
+  focusPanelMounted,
+}: AnalysisHeroPanelProps) {
+  const panelId = useId()
+  const [lensState, setLensState] = useState<HeroLens | null>(null)
+  const [openRowId, setOpenRowId] = useState<string | null>(null)
+
+  if (model.kind === 'status') {
+    return (
+      <section
+        aria-label={HERO_COPY.panelAria}
+        data-testid="analysis-hero-panel"
+        className="rounded-lg border border-panel-border bg-panel p-3"
+      >
+        <StatusState model={model} />
+      </section>
+    )
+  }
+
+  // Local lens state guarded against model changes: fall back to the model's
+  // default whenever the remembered lens is no longer available.
+  const lens: HeroLens =
+    lensState && model.lenses.includes(lensState) ? lensState : model.defaultLens
+  const interactive = !isStale
+  const showTabs = model.lenses.length > 1
+
+  const axis =
+    lens === 'goal'
+      ? model.hasConstraints
+        ? HERO_COPY.axis.goalWithLimits
+        : HERO_COPY.axis.goalOnly
+      : HERO_COPY.axis.outcome
+
+  const caption =
+    lens === 'goal'
+      ? model.hasConstraints
+        ? HERO_COPY.caption.goalWithLimits
+        : HERO_COPY.caption.goalOnly
+      : model.targetReadout
+        ? `${HERO_COPY.caption.outcome} ${HERO_COPY.caption.outcomeTarget(model.targetReadout)}`
+        : HERO_COPY.caption.outcome
+
+  const leaderId = model.leaders[lens]
+
+  return (
+    <section
+      aria-label={HERO_COPY.panelAria}
+      data-testid="analysis-hero-panel"
+      className="space-y-2 rounded-lg border border-panel-border bg-panel p-3"
+    >
+      <div className="space-y-1">
+        <h3 className={`${typography.panelHeader} text-text-header`} data-testid="hero-headline">
+          {model.headline}
+        </h3>
+        {model.subline && (
+          <p className={`${typography.panelBody} text-text-light`} data-testid="hero-subline">
+            {model.subline}
+          </p>
+        )}
+      </div>
+
+      {/* Chart area — dimmed and inert while stale (soft-disable; the tab's
+          AnalysisFreshnessNotice carries the stale wording). */}
+      <div
+        data-testid="hero-chart-area"
+        className={`space-y-2 ${isStale ? 'pointer-events-none opacity-45' : ''}`}
+      >
+        {showTabs && (
+          <HeroLensTabs
+            lenses={model.lenses}
+            active={lens}
+            onSelect={setLensState}
+            interactive={interactive}
+            panelId={panelId}
+          />
+        )}
+
+        <div
+          id={panelId}
+          {...(showTabs ? { role: 'tabpanel', 'aria-labelledby': tabId(lens) } : {})}
+          className="space-y-1"
+        >
+          {/* Axis labels (decorative; values live in the row readouts).
+              Shares the row grid template so the track columns align. */}
+          <div aria-hidden="true" className={`${HERO_ROW_GRID} items-end py-0`}>
+            <span />
+            <span className={`${typography.panelMeta} relative flex justify-between text-text-light`}>
+              <span>{axis.left}</span>
+              <span className="absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-text-body">
+                {axis.mid}
+              </span>
+              <span>{axis.right}</span>
+            </span>
+            <span />
+            <span />
+          </div>
+
+          <div className="space-y-0.5" data-testid="hero-chart-rows">
+            {model.rows.map((row) => (
+              <HeroOptionRow
+                key={row.id}
+                row={row}
+                lens={lens}
+                isLeader={row.id === leaderId}
+                isOpen={openRowId === row.id}
+                onToggle={() => setOpenRowId((cur) => (cur === row.id ? null : row.id))}
+                interactive={interactive}
+                outcomeDomain={model.outcomeDomain}
+                targetValue={model.targetValue}
+              />
+            ))}
+          </div>
+        </div>
+
+        <p className={`${typography.panelBody} flex items-start gap-1.5 text-text-body`}>
+          <Info aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 flex-none text-info" />
+          <span data-testid="hero-caption">{caption}</span>
+        </p>
+      </div>
+
+      {/* Footer strip: Main reason · Focus next. The trust line is omitted —
+          no producer-supplied trust label exists (gap reported in the PR). */}
+      <div className="space-y-1.5 border-t border-panel-border pt-2">
+        {model.mainReason && (
+          <p className={`${typography.panelBody} text-text-body`} data-testid="hero-main-reason">
+            {model.mainReason}
+          </p>
+        )}
+        {isStale ? (
+          <button
+            type="button"
+            onClick={onRerun}
+            disabled={rerunDisabled}
+            data-testid="hero-rerun"
+            className={`${typography.panelMeta} inline-flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-text-on-color transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-50`}
+          >
+            <RefreshCw aria-hidden="true" className="h-3.5 w-3.5" />
+            {HERO_COPY.footer.rerun}
+          </button>
+        ) : focusPanelMounted ? (
+          <button
+            type="button"
+            onClick={scrollToFocusPanel}
+            aria-label={HERO_COPY.footer.focusNextAria}
+            data-testid="hero-focus-next"
+            className={`${typography.panelBody} inline-flex items-center gap-1.5 text-text-body hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+          >
+            <ArrowDown aria-hidden="true" className="h-3.5 w-3.5 text-info" />
+            {HERO_COPY.footer.focusNext}
+          </button>
+        ) : (
+          <p className={`${typography.panelBody} text-text-body`} data-testid="hero-focus-next">
+            {HERO_COPY.footer.focusNext}
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default AnalysisHeroPanel

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -139,7 +139,7 @@ export function AnalysisHeroPanel({
 
         <div
           id={panelId}
-          {...(showTabs ? { role: 'tabpanel', 'aria-labelledby': tabId(lens) } : {})}
+          {...(showTabs ? { role: 'tabpanel', 'aria-labelledby': tabId(panelId, lens) } : {})}
           className="space-y-1"
         >
           {/* Axis labels (decorative; values live in the row readouts).

--- a/src/components/results/analysis-hero/HeroLensTabs.tsx
+++ b/src/components/results/analysis-hero/HeroLensTabs.tsx
@@ -1,0 +1,101 @@
+/**
+ * HeroLensTabs — the lens switcher (Goal fit / Likely outcome).
+ *
+ * WAI-ARIA tabs pattern: role="tablist" with roving tabindex — Left/Right
+ * arrows (plus Home/End) move focus AND selection; only the active tab is
+ * in the tab order. Unavailable lenses are never passed in (no disabled
+ * dead tabs), and the parent hides this strip entirely when only one lens
+ * exists. Lens switching is pure local render state in the parent — no
+ * fetch, no rerun, no chart remount.
+ */
+import { useRef } from 'react'
+import { typography } from '@/styles/typography'
+import { HERO_COPY } from './heroCopy'
+import type { HeroLens } from './heroTypes'
+
+export interface HeroLensTabsProps {
+  lenses: HeroLens[]
+  active: HeroLens
+  onSelect: (lens: HeroLens) => void
+  /** False while stale — lens switching is locked. */
+  interactive: boolean
+  /** id of the tabpanel the tabs control. */
+  panelId: string
+}
+
+export function tabId(lens: HeroLens): string {
+  return `analysis-hero-tab-${lens}`
+}
+
+export function HeroLensTabs({ lenses, active, onSelect, interactive, panelId }: HeroLensTabsProps) {
+  const refs = useRef<Partial<Record<HeroLens, HTMLButtonElement | null>>>({})
+
+  const moveTo = (index: number) => {
+    const next = lenses[(index + lenses.length) % lenses.length]
+    onSelect(next)
+    refs.current[next]?.focus()
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (!interactive) return
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        e.preventDefault()
+        moveTo(index + 1)
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault()
+        moveTo(index - 1)
+        break
+      case 'Home':
+        e.preventDefault()
+        moveTo(0)
+        break
+      case 'End':
+        e.preventDefault()
+        moveTo(lenses.length - 1)
+        break
+    }
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label={HERO_COPY.tablistAria}
+      className="flex gap-0.5 rounded-full border border-panel-border p-0.5"
+    >
+      {lenses.map((lens, index) => {
+        const selected = lens === active
+        return (
+          <button
+            key={lens}
+            ref={(el) => {
+              refs.current[lens] = el
+            }}
+            type="button"
+            role="tab"
+            id={tabId(lens)}
+            aria-selected={selected}
+            aria-controls={panelId}
+            tabIndex={selected ? 0 : -1}
+            disabled={!interactive}
+            onClick={() => interactive && onSelect(lens)}
+            onKeyDown={(e) => onKeyDown(e, index)}
+            data-testid={`hero-lens-tab-${lens}`}
+            className={`${typography.panelMeta} flex-1 whitespace-nowrap rounded-full px-2 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info ${
+              selected
+                ? 'bg-primary text-text-on-color'
+                : 'bg-transparent text-text-light hover:bg-panel-hover hover:text-text-body'
+            } disabled:cursor-default`}
+          >
+            {HERO_COPY.lensLabel[lens]}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default HeroLensTabs

--- a/src/components/results/analysis-hero/HeroLensTabs.tsx
+++ b/src/components/results/analysis-hero/HeroLensTabs.tsx
@@ -23,8 +23,13 @@ export interface HeroLensTabsProps {
   panelId: string
 }
 
-export function tabId(lens: HeroLens): string {
-  return `analysis-hero-tab-${lens}`
+/**
+ * Tab element ids are scoped to the owning panel's useId (like every other
+ * id in the module) so a second concurrent mount can never produce
+ * duplicate DOM ids / ambiguous aria references.
+ */
+export function tabId(panelId: string, lens: HeroLens): string {
+  return `${panelId}-tab-${lens}`
 }
 
 export function HeroLensTabs({ lenses, active, onSelect, interactive, panelId }: HeroLensTabsProps) {
@@ -77,7 +82,7 @@ export function HeroLensTabs({ lenses, active, onSelect, interactive, panelId }:
             }}
             type="button"
             role="tab"
-            id={tabId(lens)}
+            id={tabId(panelId, lens)}
             aria-selected={selected}
             aria-controls={panelId}
             tabIndex={selected ? 0 : -1}

--- a/src/components/results/analysis-hero/HeroLensTabs.tsx
+++ b/src/components/results/analysis-hero/HeroLensTabs.tsx
@@ -38,14 +38,15 @@ export function HeroLensTabs({ lenses, active, onSelect, interactive, panelId }:
 
   const onKeyDown = (e: React.KeyboardEvent, index: number) => {
     if (!interactive) return
+    // Horizontal tablist: Left/Right + Home/End only (WAI-ARIA APG).
+    // Up/Down are deliberately NOT handled so page scrolling still works
+    // while the tablist has focus.
     switch (e.key) {
       case 'ArrowRight':
-      case 'ArrowDown':
         e.preventDefault()
         moveTo(index + 1)
         break
       case 'ArrowLeft':
-      case 'ArrowUp':
         e.preventDefault()
         moveTo(index - 1)
         break

--- a/src/components/results/analysis-hero/HeroOptionRow.tsx
+++ b/src/components/results/analysis-hero/HeroOptionRow.tsx
@@ -1,0 +1,240 @@
+/**
+ * HeroOptionRow — one option row: numbered token, label, chart track,
+ * readout, and a disclosure detail region.
+ *
+ * Accessibility scaffold follows the proven FocusRowCard / CoachingActionCard
+ * contract: the row header is a native <button> carrying aria-expanded +
+ * aria-controls, the detail region is mounted only when open and labelled by
+ * the row, and one-open-at-a-time is controlled by the parent. The lens
+ * leader is perceivable without colour: filled (vs outlined) number token,
+ * aria-current on the row button, and a visually-hidden "Leads on this view"
+ * cue.
+ *
+ * Track positions are LAYOUT ONLY — percentages of the track width computed
+ * from existing values; they are never displayed as data. Bars and dots
+ * animate via transform/opacity exclusively (no left/width animation), and
+ * the row DOM persists across lens switches so values morph without a
+ * remount. Reduced motion is respected via motion-reduce:transition-none.
+ *
+ * Option labels are producer/user content rendered as escaped React text
+ * nodes — no raw HTML injection of any kind.
+ */
+import { useId } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { HERO_COPY } from './heroCopy'
+import type { HeroLens, HeroRowVM } from './heroTypes'
+
+export interface HeroOptionRowProps {
+  row: HeroRowVM
+  lens: HeroLens
+  isLeader: boolean
+  isOpen: boolean
+  onToggle: () => void
+  /** False while stale — rows render but do not respond. */
+  interactive: boolean
+  /** Layout-only outcome domain; null hides outcome bars. */
+  outcomeDomain: { min: number; max: number } | null
+  /** Unit-compatible target value, or null (marker hidden). */
+  targetValue: number | null
+}
+
+/**
+ * Shared row grid: number+label · track · readout · chevron slot. The axis
+ * header in AnalysisHeroPanel uses the same template so columns align.
+ */
+export const HERO_ROW_GRID =
+  'grid w-full grid-cols-[minmax(0,7.5rem)_1fr_auto_0.875rem] items-center gap-2 rounded-lg px-2 py-1.5 text-left'
+
+/** Clamp a layout fraction to the track (layout maths only). */
+function trackPct(fraction: number): number {
+  return Math.max(0, Math.min(100, fraction * 100))
+}
+
+export function HeroOptionRow({
+  row,
+  lens,
+  isLeader,
+  isOpen,
+  onToggle,
+  interactive,
+  outcomeDomain,
+  targetValue,
+}: HeroOptionRowProps) {
+  const regionId = useId()
+  const labelId = useId()
+
+  // Per-lens layout positions (percent of track width). null → hidden.
+  let barStart: number | null = null
+  let barEnd: number | null = null
+  let dotPos: number | null = null
+  let targetPos: number | null = null
+  if (lens === 'goal') {
+    if (row.goal.value != null) {
+      barStart = 0
+      barEnd = trackPct(row.goal.value)
+      dotPos = barEnd
+    }
+  } else if (outcomeDomain) {
+    const span = outcomeDomain.max - outcomeDomain.min
+    const pos = (v: number) => trackPct((v - outcomeDomain.min) / span)
+    if (row.outcome.p10 != null && row.outcome.p90 != null) {
+      barStart = pos(row.outcome.p10)
+      barEnd = pos(row.outcome.p90)
+    }
+    if (row.outcome.centre != null) dotPos = pos(row.outcome.centre)
+    if (targetValue != null) targetPos = pos(targetValue)
+  }
+
+  const readout = lens === 'goal' ? row.goal.readout : row.outcome.readout
+  const readoutSuffix =
+    lens === 'goal' && row.goal.value != null ? ` ${HERO_COPY.readout.goalSuffix}` : ''
+
+  const expandable = row.hasDetail && interactive
+  const Chevron = isOpen ? ChevronDown : ChevronRight
+
+  const rowGrid = (
+    <>
+      <span className="flex min-w-0 items-center gap-2">
+        <span
+          aria-hidden="true"
+          className={`flex h-[18px] w-[18px] flex-none items-center justify-center rounded ${typography.panelMeta} ${
+            isLeader
+              ? 'bg-primary text-text-on-color'
+              : 'border border-option/40 bg-transparent text-text-body'
+          }`}
+        >
+          {row.index}
+        </span>
+        <span
+          id={labelId}
+          className={`${typography.panelBody} min-w-0 flex-1 truncate text-left text-text-header`}
+        >
+          {row.label}
+          {isLeader && <span className="sr-only"> ({HERO_COPY.srLeader})</span>}
+        </span>
+      </span>
+
+      {/* Chart track — layout-only positions, transform/opacity animation. */}
+      <span aria-hidden="true" className="relative block h-5 min-w-0">
+        <span className="absolute inset-x-0 top-1/2 h-px bg-panel-border" />
+        {/* Target marker (outcome lens, unit-compatible threshold only). */}
+        <span
+          data-testid="hero-target-marker"
+          data-visible={targetPos != null ? 'true' : 'false'}
+          className="absolute inset-0 transition-transform motion-reduce:transition-none"
+          style={{
+            transform: `translateX(${targetPos ?? 0}%)`,
+            opacity: targetPos != null ? 1 : 0,
+          }}
+        >
+          <span className="absolute bottom-0.5 left-0 top-0.5 w-0 border-l-2 border-dashed border-warning" />
+        </span>
+        {/* Range / probability bar: full-width element scaled from the left. */}
+        <span
+          className={`absolute left-0 h-1.5 w-full rounded-full transition-transform motion-reduce:transition-none ${
+            isLeader ? 'bg-primary/40' : 'bg-option/30'
+          }`}
+          style={{
+            top: 'calc(50% - 3px)',
+            transformOrigin: 'left',
+            transform: `translateX(${barStart ?? 0}%) scaleX(${
+              barStart != null && barEnd != null ? Math.max(barEnd - barStart, 0) / 100 : 0
+            })`,
+            opacity: barStart != null && barEnd != null ? 1 : 0,
+          }}
+        />
+        {/* Centre dot: full-width positioner translated by track percent. */}
+        <span
+          className="absolute inset-0 transition-transform motion-reduce:transition-none"
+          style={{
+            transform: `translateX(${dotPos ?? 0}%)`,
+            opacity: dotPos != null ? 1 : 0,
+          }}
+        >
+          <span
+            className={`absolute left-0 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-panel ${
+              isLeader ? 'bg-primary' : 'bg-option'
+            }`}
+          />
+        </span>
+      </span>
+
+      <span
+        className={`${typography.panelMeta} whitespace-nowrap text-right text-text-light`}
+      >
+        <span className={isLeader ? 'text-text-header' : 'text-text-body'}>{readout}</span>
+        {readoutSuffix}
+      </span>
+      {/* Chevron slot is reserved on every row (invisible when static) so the
+          track and readout columns stay aligned across the list. */}
+      <Chevron
+        aria-hidden="true"
+        className={`h-3.5 w-3.5 flex-none text-text-light ${expandable ? '' : 'invisible'}`}
+      />
+    </>
+  )
+
+  return (
+    <div data-testid={`hero-option-row-${row.index}`} data-option-id={row.id}>
+      {expandable ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={isOpen}
+          aria-controls={regionId}
+          aria-current={isLeader ? 'true' : undefined}
+          className={`${HERO_ROW_GRID} transition-colors hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-inset ${
+            isOpen ? 'bg-panel-hover' : ''
+          }`}
+        >
+          {rowGrid}
+        </button>
+      ) : (
+        <div aria-current={isLeader ? 'true' : undefined} className={HERO_ROW_GRID}>
+          {rowGrid}
+        </div>
+      )}
+
+      {expandable && isOpen && (
+        <div
+          id={regionId}
+          role="region"
+          aria-labelledby={labelId}
+          data-testid="hero-option-detail"
+          className="space-y-1 pb-2 pl-9 pr-2 pt-0.5"
+        >
+          {row.detail.why && (
+            <p className={`${typography.panelBody} text-text-body`} data-testid="hero-detail-why">
+              <span className="text-text-header">
+                {HERO_COPY.detail.whyLabel}
+              </span>{' '}
+              {row.detail.why}
+            </p>
+          )}
+          {row.detail.couldChangeIf && (
+            <p
+              className={`${typography.panelBody} text-text-body`}
+              data-testid="hero-detail-could-change"
+            >
+              <span className="text-text-header">
+                {HERO_COPY.detail.couldChangeIfLabel}
+              </span>{' '}
+              {row.detail.couldChangeIf}
+            </p>
+          )}
+          {row.detail.winChance && (
+            <p
+              className={`${typography.panelBody} text-text-light`}
+              data-testid="hero-detail-win"
+            >
+              {row.detail.winChance}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default HeroOptionRow

--- a/src/components/results/analysis-hero/HeroOptionRow.tsx
+++ b/src/components/results/analysis-hero/HeroOptionRow.tsx
@@ -46,7 +46,13 @@ export interface HeroOptionRowProps {
 export const HERO_ROW_GRID =
   'grid w-full grid-cols-[minmax(0,7.5rem)_1fr_auto_0.875rem] items-center gap-2 rounded-lg px-2 py-1.5 text-left'
 
-/** Clamp a layout fraction to the track (layout maths only). */
+/**
+ * UI-SEM-055: track position clamp to [0, 100]% of the track width.
+ * Layout maths only — positions bars/dots/markers on the fixed track; the
+ * clamped percentage is never displayed as data, never described
+ * semantically, and never fed back into selection logic (readouts always
+ * show the unclamped source values).
+ */
 function trackPct(fraction: number): number {
   return Math.max(0, Math.min(100, fraction * 100))
 }

--- a/src/components/results/analysis-hero/HeroOptionRow.tsx
+++ b/src/components/results/analysis-hero/HeroOptionRow.tsx
@@ -90,7 +90,10 @@ export function HeroOptionRow({
   const readoutSuffix =
     lens === 'goal' && row.goal.value != null ? ` ${HERO_COPY.readout.goalSuffix}` : ''
 
-  const expandable = row.hasDetail && interactive
+  const hasDetail = Boolean(
+    row.detail.why || row.detail.couldChangeIf || row.detail.winChance,
+  )
+  const expandable = hasDetail && interactive
   const Chevron = isOpen ? ChevronDown : ChevronRight
 
   const rowGrid = (

--- a/src/components/results/analysis-hero/__fixtures__/hero.fixtures.ts
+++ b/src/components/results/analysis-hero/__fixtures__/hero.fixtures.ts
@@ -1,0 +1,150 @@
+/**
+ * Analysis hero — test fixtures.
+ *
+ * Builds ResultsSectionDataReturn-shaped objects with distinct, easily
+ * assertable values. The default scenario deliberately diverges the two
+ * leaders: Option B is the Results Panel's recommended option (goal-fit
+ * headline leader) while Option A has the highest expected outcome — the
+ * tension subline case.
+ */
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriverItem,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../../types'
+import type { ResultCompleteness } from '../../useResultCompleteness'
+
+export function makeOption(overrides: Partial<OptionResult> & { id: string; label: string }): OptionResult {
+  return {
+    expected: null,
+    outcome: { mean: null, p10: null, p50: null, p90: null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    ...overrides,
+  } as OptionResult
+}
+
+/** Option A — highest expected outcome, weaker goal fit. */
+export const OPTION_A = makeOption({
+  id: 'opt_a',
+  label: 'Two developers',
+  expected: 68,
+  outcome: { mean: 68, p10: 54, p50: 67, p90: 82 },
+  winProbability: 0.3,
+  goalProbability: 0.34,
+})
+
+/** Option B — the recommended option (goal-fit leader). */
+export const OPTION_B = makeOption({
+  id: 'opt_b',
+  label: 'Upskill the team',
+  expected: 62,
+  outcome: { mean: 62, p10: 46, p50: 61, p90: 78 },
+  winProbability: 0.29,
+  isRecommended: true,
+  goalProbability: 0.49,
+})
+
+export const FULL_COMPLETENESS: ResultCompleteness = {
+  status: 'full',
+  missing: [],
+  reasons: [],
+} as ResultCompleteness
+
+export function makeDriver(label: string): DriverItem {
+  return {
+    factorKey: `fac_${label.toLowerCase().replace(/\s+/g, '_')}`,
+    factorLabel: label,
+    rawElasticity: 0.8,
+    normalisedInfluence: 1,
+    rank: 1,
+    semanticLabel: 'strongest',
+    canFocus: false,
+  } as unknown as DriverItem
+}
+
+export interface MakeHeroDataOptions {
+  recommendation?: Partial<DecisionResultData>
+  options?: OptionResult[]
+  topDriverLabel?: string | null
+  completeness?: ResultCompleteness
+  isLoading?: boolean
+  isError?: boolean
+}
+
+export function makeHeroData(opts: MakeHeroDataOptions = {}): ResultsSectionDataReturn {
+  const options = opts.options ?? [OPTION_A, OPTION_B]
+  const recommendedOption = options.find((o) => o.isRecommended) ?? null
+
+  const recommendation: DecisionResultData = {
+    recommendedOption,
+    allOptions: options,
+    goalLabel: 'Team productivity',
+    isSingleOption: options.length <= 1,
+    analysisStatus: 'computed',
+    outcomeUnit: 'count',
+    goalThreshold: 62,
+    isNormalised: false,
+    storyHeadlines: {
+      opt_b: 'Best placed once the goal and limits are both counted.',
+    },
+    flipThresholds: [
+      {
+        label: 'Team capacity',
+        node_id: 'fac_capacity',
+        current_value: 40,
+        flip_value: 30,
+        unit: '%',
+        alternative_winner_label: 'Two developers',
+      },
+    ],
+    ...opts.recommendation,
+  }
+
+  const driverLabel = opts.topDriverLabel === undefined ? 'Developer capacity' : opts.topDriverLabel
+  const topDrivers = driverLabel ? [makeDriver(driverLabel)] : []
+  const drivers: DriversSectionData = {
+    drivers: topDrivers,
+    topDrivers,
+    driversStatus: 'computed',
+    totalCount: topDrivers.length,
+    hasMagnitudeData: topDrivers.length > 0,
+  }
+
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: opts.isLoading ?? false,
+    isError: opts.isError ?? false,
+    goalLabel: 'Team productivity',
+    completeness: opts.completeness ?? FULL_COMPLETENESS,
+    autoNoiseProvenance: null,
+  } as ResultsSectionDataReturn
+}

--- a/src/components/results/analysis-hero/__tests__/a11y.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/a11y.spec.tsx
@@ -1,0 +1,116 @@
+/**
+ * Accessibility — axe scans plus the specific contract points: tab roving
+ * semantics, row disclosure aria, leader perceivable without colour, and
+ * reduced-motion handling on every animated element.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
+import { buildHeroModel } from '../buildHeroModel'
+import type { HeroChartModel, HeroStatusModel } from '../heroTypes'
+import { FULL_COMPLETENESS, makeHeroData } from '../__fixtures__/hero.fixtures'
+
+function chartModel(): HeroChartModel {
+  return buildHeroModel(makeHeroData()) as HeroChartModel
+}
+
+function renderPanel(model: HeroChartModel | HeroStatusModel, isStale = false) {
+  return render(
+    <AnalysisHeroPanel
+      model={model}
+      isStale={isStale}
+      onRerun={() => {}}
+      rerunDisabled={false}
+      focusPanelMounted={false}
+    />,
+  )
+}
+
+async function expectNoViolations(container: HTMLElement) {
+  const results = await axe(container)
+  expect(results.violations).toEqual([])
+}
+
+describe('AnalysisHero — accessibility', () => {
+  it('chart state has no axe violations', async () => {
+    const { container } = renderPanel(chartModel())
+    await expectNoViolations(container)
+  })
+
+  it('chart state with an open detail has no axe violations', async () => {
+    const { container } = renderPanel(chartModel())
+    fireEvent.click(screen.getByRole('button', { name: /Upskill the team/ }))
+    await expectNoViolations(container)
+  })
+
+  it('status state has no axe violations', async () => {
+    const model = buildHeroModel(
+      makeHeroData({ completeness: { ...FULL_COMPLETENESS, status: 'partial' } }),
+    ) as HeroStatusModel
+    const { container } = renderPanel(model)
+    await expectNoViolations(container)
+  })
+
+  it('implements the tabs pattern: tablist, aria-selected, tabpanel labelling', () => {
+    renderPanel(chartModel())
+    const tablist = screen.getByRole('tablist')
+    expect(tablist).toHaveAccessibleName('Results lens')
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'false')
+    const panel = screen.getByRole('tabpanel')
+    expect(panel).toHaveAttribute('aria-labelledby', tabs[0].id)
+  })
+
+  it('row buttons expose aria-expanded and label their detail region', () => {
+    renderPanel(chartModel())
+    const row = screen.getByRole('button', { name: /Upskill the team/ })
+    expect(row).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(row)
+    expect(row).toHaveAttribute('aria-expanded', 'true')
+    const region = screen.getByTestId('hero-option-detail')
+    expect(region).toHaveAttribute('role', 'region')
+    expect(region.id).toBe(row.getAttribute('aria-controls'))
+    expect(region).toHaveAccessibleName(/Upskill the team/)
+  })
+
+  it('marks the lens leader without relying on colour (aria-current + sr cue)', () => {
+    renderPanel(chartModel())
+    // Goal lens leader = the recommended option (row 2).
+    const leaderRow = screen.getByRole('button', { name: /Upskill the team/ })
+    expect(leaderRow).toHaveAttribute('aria-current', 'true')
+    expect(leaderRow).toHaveTextContent('Leads on this view')
+    const otherRow = screen.getByRole('button', { name: /Two developers/ })
+    expect(otherRow).not.toHaveAttribute('aria-current')
+  })
+
+  it('the leader highlight moves with the active lens', () => {
+    renderPanel(chartModel())
+    fireEvent.click(screen.getByTestId('hero-lens-tab-outcome'))
+    // Outcome leader = highest centre (Two developers).
+    expect(screen.getByRole('button', { name: /Two developers/ })).toHaveAttribute(
+      'aria-current',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: /Upskill the team/ })).not.toHaveAttribute(
+      'aria-current',
+    )
+  })
+
+  it('every transform-animated element opts out under prefers-reduced-motion', () => {
+    const { container } = renderPanel(chartModel())
+    const animated = container.querySelectorAll('[class*="transition-transform"]')
+    expect(animated.length).toBeGreaterThan(0)
+    for (const el of animated) {
+      expect(el.className).toContain('motion-reduce:transition-none')
+    }
+  })
+
+  it('stale chart area is hidden from interaction but the re-run control is operable', async () => {
+    const { container } = renderPanel(chartModel(), true)
+    expect(screen.getByTestId('hero-rerun')).toBeEnabled()
+    await expectNoViolations(container)
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -214,6 +214,16 @@ describe('buildHeroModel — states', () => {
     expect(buildHeroModel(makeHeroData({ isLoading: true })).kind).toBe('empty')
   })
 
+  it('fails closed (empty, no throw) on partially-shaped objects', () => {
+    // Review fix: the type promises these fields, but hydrated older state
+    // may not — the hero must render nothing rather than crash the tab.
+    expect(buildHeroModel(undefined as never).kind).toBe('empty')
+    expect(buildHeroModel({} as never).kind).toBe('empty')
+    expect(buildHeroModel({ recommendation: {} } as never).kind).toBe('empty')
+    const noDrivers = { ...makeHeroData(), drivers: undefined } as never
+    expect(buildHeroModel(noDrivers)).toMatchObject({ kind: 'chart', mainReason: null })
+  })
+
   it('returns empty before any analysis (no options, full completeness)', () => {
     expect(buildHeroModel(makeHeroData({ options: [] })).kind).toBe('empty')
   })
@@ -253,6 +263,14 @@ describe('buildHeroModel — detail lines and footer (sourced or omitted)', () =
     // Recommended option (B): first resolvable threshold.
     expect(m.rows[1].detail.couldChangeIf).toBe('Team capacity crosses 30%.')
     // Option A is the named alternative winner → same threshold line.
+    expect(m.rows[0].detail.couldChangeIf).toBe('Team capacity crosses 30%.')
+  })
+
+  it('matches the alternative winner across encoding notation differences', () => {
+    // Review fix: labels are normalised for the MATCH only — an option label
+    // carrying encoding notation still receives its sourced line.
+    const a = makeOption({ ...OPTION_A, label: 'Two developers (0=no, 1=yes)' })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, OPTION_B] })))
     expect(m.rows[0].detail.couldChangeIf).toBe('Team capacity crosses 30%.')
   })
 

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -118,11 +118,54 @@ describe('buildHeroModel — leaders and headline', () => {
   })
 
   it('constraint presence switches to goal-and-limits wording', () => {
+    // Constraints are request-level, so every option carries its analysis.
+    const a = makeOption({ ...OPTION_A, constraintAnalysis: CONSTRAINT })
     const b = makeOption({ ...OPTION_B, constraintAnalysis: CONSTRAINT })
-    const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_A, b] })))
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
     expect(m.hasConstraints).toBe(true)
     expect(m.headline).toBe('Upskill the team best meets the goal and your limits.')
     expect(m.subline).toContain('best meets the goal and your limits')
+  })
+
+  it('mixed constraint coverage falls back to goal-alone wording (never overstates)', () => {
+    // Anomalous shape: only one goal-bearing option carries constraint
+    // analysis. The collapsed goalProbability is joint for that option but
+    // goal-alone for the other, so the shared copy must not claim "and
+    // limits" for every bar.
+    const b = makeOption({ ...OPTION_B, constraintAnalysis: CONSTRAINT })
+    const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_A, b] })))
+    expect(m.hasConstraints).toBe(false)
+    expect(m.headline).toBe('Upskill the team best fits your goal.')
+  })
+
+  it('does not headline or highlight a recommended option that lacks its own goal value', () => {
+    // Recommended option B has no goalProbability while A has one: the hero
+    // must not claim B "best fits your goal" beside a "—" readout for B.
+    const b = makeOption({ ...OPTION_B, goalProbability: undefined })
+    const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_A, b] })))
+    expect(m.lenses).toContain('goal')
+    expect(m.leaders.goal).toBeNull()
+    expect(m.headline).toBe('Upskill the team currently looks strongest.')
+    expect(m.subline).toBeNull()
+  })
+
+  it('omits the subline when the outcome lens is hidden (centres without ranges)', () => {
+    // Options carry an expected centre but no p10-p90 range: the outcome
+    // lens is unavailable, so the hero must not assert an expected-outcome
+    // comparison it cannot show.
+    const strip = (o: ReturnType<typeof makeOption>) =>
+      makeOption({
+        ...o,
+        outcome: { mean: o.outcome.mean, p10: null, p50: null, p90: null },
+        p10: null,
+        p50: null,
+        p90: null,
+      })
+    const m = chart(buildHeroModel(makeHeroData({ options: [strip(OPTION_A), strip(OPTION_B)] })))
+    expect(m.lenses).toEqual(['goal'])
+    expect(m.subline).toBeNull()
+    // The goal-fit headline itself is still honest and allowed.
+    expect(m.headline).toBe('Upskill the team best fits your goal.')
   })
 
   it('equal leaders produce the aligned subline', () => {
@@ -271,6 +314,36 @@ describe('buildHeroModel — detail lines and footer (sourced or omitted)', () =
     const a = makeOption({ ...OPTION_A, label: 'Two developers (0=no, 1=yes)' })
     const m = chart(buildHeroModel(makeHeroData({ options: [a, OPTION_B] })))
     expect(m.rows[0].detail.couldChangeIf).toBe('Team capacity crosses 30%.')
+  })
+
+  it('renders a unitless 0-1 flip value as a number, never a qualitative word', () => {
+    // Regression: formatValueWithUnit would render 0.3 with no unit as a
+    // qualitative band word; a "crosses <value>" sentence must stay numeric.
+    const m = chart(
+      buildHeroModel(
+        makeHeroData({
+          recommendation: {
+            flipThresholds: [
+              {
+                label: 'Team capacity',
+                node_id: 'fac_capacity',
+                current_value: 0.5,
+                flip_value: 0.3,
+                alternative_winner_label: 'Two developers',
+              },
+            ],
+          },
+        }),
+      ),
+    )
+    expect(m.rows[1].detail.couldChangeIf).toBe('Team capacity crosses 0.3.')
+  })
+
+  it('floors sub-1% goal readouts at "< 1%" (OptionCards parity, UI-SEM-057)', () => {
+    const a = makeOption({ ...OPTION_A, goalProbability: 0.004 })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, OPTION_B] })))
+    expect(m.rows[0].goal.value).toBe(0.004)
+    expect(m.rows[0].goal.readout).toBe('< 1%')
   })
 
   it('omits Could-change-if when no flip thresholds resolve', () => {

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -151,7 +151,6 @@ describe('buildHeroModel — leaders and headline', () => {
     const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_B] })))
     expect(m.headline).toBe('Upskill the team is your only option.')
     expect(m.subline).toBeNull()
-    expect(m.isSingleOption).toBe(true)
   })
 })
 

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -79,6 +79,23 @@ describe('buildHeroModel — boundary values', () => {
     expect(m.targetValue).toBeNull()
   })
 
+  it('omits the target AND excludes it from the domain when the outcome unit is unknown', () => {
+    // isNormalised false alone is not enough: without the shared
+    // outcomeUnit convention there is no evidence the threshold and the
+    // displayed outcomes are the same metric — uncertainty fails closed.
+    const m = chart(
+      buildHeroModel(
+        makeHeroData({
+          recommendation: { outcomeUnit: undefined, isNormalised: false, goalThreshold: 1000 },
+        }),
+      ),
+    )
+    expect(m.targetValue).toBeNull()
+    expect(m.targetReadout).toBeNull()
+    // 1000 excluded from the layout domain: max stays near p90 (82) + pad.
+    expect(m.outcomeDomain!.max).toBeLessThan(100)
+  })
+
   it('includes a compatible out-of-range threshold in the layout domain', () => {
     const m = chart(
       buildHeroModel(makeHeroData({ recommendation: { goalThreshold: 95, isNormalised: false } })),

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -1,0 +1,291 @@
+/**
+ * buildHeroModel — boundary-value and gating tests.
+ *
+ * The point of this suite (per the brief): every value in the model must
+ * EQUAL the adapted response value it came from — no UI-created quantities,
+ * bands, deltas or thresholds — and every lens/state gate must fail closed.
+ */
+import { describe, expect, it } from 'vitest'
+import { buildHeroModel } from '../buildHeroModel'
+import type { HeroChartModel } from '../heroTypes'
+import {
+  FULL_COMPLETENESS,
+  makeHeroData,
+  makeOption,
+  OPTION_A,
+  OPTION_B,
+} from '../__fixtures__/hero.fixtures'
+import type { ResultCompleteness } from '../../useResultCompleteness'
+
+function chart(model: ReturnType<typeof buildHeroModel>): HeroChartModel {
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+const CONSTRAINT = {
+  constraints: [
+    {
+      node_id: 'fac_cost',
+      operator: '<=',
+      threshold: 100,
+      label: 'Cost',
+      prob_satisfied: 0.7,
+      failure_margin_median: 0,
+      near_miss_fraction: 0.1,
+      binding: true,
+    },
+  ],
+  joint_probability: 0.49,
+}
+
+describe('buildHeroModel — boundary values', () => {
+  it('goal-fit values equal the adapted goalProbability exactly', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.rows[0].goal.value).toBe(OPTION_A.goalProbability)
+    expect(m.rows[1].goal.value).toBe(OPTION_B.goalProbability)
+    expect(m.rows[0].goal.readout).toBe('34%')
+    expect(m.rows[1].goal.readout).toBe('49%')
+  })
+
+  it('outcome values equal the adapted outcome fields exactly', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.rows[0].outcome.p10).toBe(OPTION_A.outcome.p10)
+    expect(m.rows[0].outcome.p90).toBe(OPTION_A.outcome.p90)
+    expect(m.rows[0].outcome.centre).toBe(OPTION_A.expected)
+    expect(m.rows[1].outcome.centre).toBe(OPTION_B.expected)
+  })
+
+  it('target equals goalThreshold when unit-compatible (isNormalised === false)', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.targetValue).toBe(62)
+    // Threshold participates in the layout domain (62 < max already, min unaffected here)
+    expect(m.outcomeDomain).not.toBeNull()
+  })
+
+  it('omits the target AND excludes it from the domain when isNormalised is true', () => {
+    const m = chart(
+      buildHeroModel(makeHeroData({ recommendation: { isNormalised: true, goalThreshold: 1000 } })),
+    )
+    expect(m.targetValue).toBeNull()
+    expect(m.targetReadout).toBeNull()
+    // 1000 excluded: domain max stays near the option p90 (82 + 5% pad), far below 1000.
+    expect(m.outcomeDomain!.max).toBeLessThan(100)
+  })
+
+  it('omits the target when isNormalised is undefined (uncertainty fails closed)', () => {
+    const m = chart(
+      buildHeroModel(makeHeroData({ recommendation: { isNormalised: undefined } })),
+    )
+    expect(m.targetValue).toBeNull()
+  })
+
+  it('includes a compatible out-of-range threshold in the layout domain', () => {
+    const m = chart(
+      buildHeroModel(makeHeroData({ recommendation: { goalThreshold: 95, isNormalised: false } })),
+    )
+    expect(m.targetValue).toBe(95)
+    expect(m.outcomeDomain!.max).toBeGreaterThanOrEqual(95)
+  })
+})
+
+describe('buildHeroModel — leaders and headline', () => {
+  it('headline leader is the Results Panel recommended option, not a goal argmax', () => {
+    // Option A gets the HIGHER goalProbability, but B stays recommended:
+    // the headline must follow B (reconciles with the panels below).
+    const a = makeOption({ ...OPTION_A, goalProbability: 0.9 })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, OPTION_B] })))
+    expect(m.headline).toContain('Upskill the team')
+    expect(m.leaders.goal).toBe('opt_b')
+  })
+
+  it('outcome leader is the highest existing centre, independent of the recommendation', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.leaders.outcome).toBe('opt_a')
+  })
+
+  it('tied outcome centres break to the earliest option in allOptions[] order', () => {
+    const a = makeOption({ ...OPTION_A, expected: 62, outcome: { ...OPTION_A.outcome, mean: 62 } })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, OPTION_B] })))
+    expect(m.leaders.outcome).toBe('opt_a')
+  })
+
+  it('diverged leaders produce the tension subline (goal-alone wording without constraints)', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.subline).toBe(
+      'Two developers has the highest expected outcome, but Upskill the team best fits your goal.',
+    )
+    expect(m.headline).toBe('Upskill the team best fits your goal.')
+  })
+
+  it('constraint presence switches to goal-and-limits wording', () => {
+    const b = makeOption({ ...OPTION_B, constraintAnalysis: CONSTRAINT })
+    const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_A, b] })))
+    expect(m.hasConstraints).toBe(true)
+    expect(m.headline).toBe('Upskill the team best meets the goal and your limits.')
+    expect(m.subline).toContain('best meets the goal and your limits')
+  })
+
+  it('equal leaders produce the aligned subline', () => {
+    // Make the recommended option also the outcome leader.
+    const b = makeOption({ ...OPTION_B, expected: 90, outcome: { ...OPTION_B.outcome, mean: 90 } })
+    const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_A, b] })))
+    expect(m.subline).toBe('Upskill the team also has the strongest expected outcome.')
+  })
+
+  it('recommended id missing from analysed rows claims no leader (recovered-session guard)', () => {
+    const m = chart(
+      buildHeroModel(
+        makeHeroData({
+          recommendation: {
+            recommendedOption: makeOption({ id: 'canvas_ghost', label: 'Ghost' }),
+          },
+        }),
+      ),
+    )
+    expect(m.leaders.goal).toBeNull()
+    // Headline falls back to the outcome leader with "looks strongest" copy.
+    expect(m.headline).toBe('Two developers currently looks strongest.')
+  })
+
+  it('single option uses the only-option headline and no subline', () => {
+    const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_B] })))
+    expect(m.headline).toBe('Upskill the team is your only option.')
+    expect(m.subline).toBeNull()
+    expect(m.isSingleOption).toBe(true)
+  })
+})
+
+describe('buildHeroModel — lens gating and numbering', () => {
+  it('launch surface is exactly goal + outcome; no other lens can exist', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.lenses).toEqual(['goal', 'outcome'])
+    expect(m.defaultLens).toBe('goal')
+  })
+
+  it('hides Goal fit when no option has goalProbability, defaulting to outcome', () => {
+    const a = makeOption({ ...OPTION_A, goalProbability: undefined })
+    const b = makeOption({ ...OPTION_B, goalProbability: undefined })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
+    expect(m.lenses).toEqual(['outcome'])
+    expect(m.defaultLens).toBe('outcome')
+    // Without a goal basis the headline may not claim goal fit.
+    expect(m.headline).toBe('Upskill the team currently looks strongest.')
+    expect(m.subline).toBeNull()
+  })
+
+  it('hides Likely outcome when no option has a p10-p90 range', () => {
+    const strip = (o: ReturnType<typeof makeOption>) =>
+      makeOption({
+        ...o,
+        expected: null,
+        outcome: { mean: null, p10: null, p50: null, p90: null },
+        p10: null,
+        p50: null,
+        p90: null,
+      })
+    const m = chart(buildHeroModel(makeHeroData({ options: [strip(OPTION_A), strip(OPTION_B)] })))
+    expect(m.lenses).toEqual(['goal'])
+    expect(m.outcomeDomain).toBeNull()
+  })
+
+  it('returns empty when options exist but nothing is displayable', () => {
+    const bare = [
+      makeOption({ id: 'x', label: 'X' }),
+      makeOption({ id: 'y', label: 'Y' }),
+    ]
+    expect(buildHeroModel(makeHeroData({ options: bare })).kind).toBe('empty')
+  })
+
+  it('numbers rows by allOptions[] presentation order, identically for every lens', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    // Presentation numbering: index follows array order, not any per-lens ranking.
+    expect(m.rows.map((r) => [r.index, r.id])).toEqual([
+      [1, 'opt_a'],
+      [2, 'opt_b'],
+    ])
+    // Rows are shared across lenses (single array) — numbering cannot change
+    // when the lens changes because the model carries no per-lens row order.
+    expect(Object.keys(m.leaders)).toEqual(['goal', 'outcome'])
+  })
+})
+
+describe('buildHeroModel — states', () => {
+  it('returns empty while loading', () => {
+    expect(buildHeroModel(makeHeroData({ isLoading: true })).kind).toBe('empty')
+  })
+
+  it('returns empty before any analysis (no options, full completeness)', () => {
+    expect(buildHeroModel(makeHeroData({ options: [] })).kind).toBe('empty')
+  })
+
+  it('renders the failed status state on hook error (not null)', () => {
+    const failed: ResultCompleteness = { ...FULL_COMPLETENESS, status: 'failed' }
+    const m = buildHeroModel(makeHeroData({ isError: true, completeness: failed }))
+    expect(m).toMatchObject({ kind: 'status', variant: 'failed' })
+  })
+
+  it('renders the partial status state from completeness', () => {
+    const partial: ResultCompleteness = { ...FULL_COMPLETENESS, status: 'partial' }
+    const m = buildHeroModel(makeHeroData({ completeness: partial }))
+    expect(m).toMatchObject({ kind: 'status', variant: 'partial' })
+  })
+
+  it('renders the partial status state from analysisStatus', () => {
+    const m = buildHeroModel(makeHeroData({ recommendation: { analysisStatus: 'partial' } }))
+    expect(m).toMatchObject({ kind: 'status', variant: 'partial' })
+  })
+
+  it('renders the blocked status state from analysisStatus', () => {
+    const m = buildHeroModel(makeHeroData({ recommendation: { analysisStatus: 'blocked' } }))
+    expect(m).toMatchObject({ kind: 'status', variant: 'blocked' })
+  })
+})
+
+describe('buildHeroModel — detail lines and footer (sourced or omitted)', () => {
+  it('maps Why from storyHeadlines verbatim and omits it when absent', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.rows[1].detail.why).toBe('Best placed once the goal and limits are both counted.')
+    expect(m.rows[0].detail.why).toBeUndefined()
+  })
+
+  it('maps Could-change-if from producer flip thresholds only', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    // Recommended option (B): first resolvable threshold.
+    expect(m.rows[1].detail.couldChangeIf).toBe('Team capacity crosses 30%.')
+    // Option A is the named alternative winner → same threshold line.
+    expect(m.rows[0].detail.couldChangeIf).toBe('Team capacity crosses 30%.')
+  })
+
+  it('omits Could-change-if when no flip thresholds resolve', () => {
+    const m = chart(
+      buildHeroModel(makeHeroData({ recommendation: { flipThresholds: undefined } })),
+    )
+    expect(m.rows[0].detail.couldChangeIf).toBeUndefined()
+    expect(m.rows[1].detail.couldChangeIf).toBeUndefined()
+  })
+
+  it('formats win probability with the display-honesty formatter', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.rows[0].detail.winChance).toBe('30% chance it is the strongest option overall.')
+  })
+
+  it('omits the win line when winProbability is absent', () => {
+    const a = makeOption({ ...OPTION_A, winProbability: undefined })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, OPTION_B] })))
+    expect(m.rows[0].detail.winChance).toBeUndefined()
+  })
+
+  it('main reason names the Drivers section top driver; omitted when none', () => {
+    const withDriver = chart(buildHeroModel(makeHeroData()))
+    expect(withDriver.mainReason).toBe(
+      'Main reason: Developer capacity has the strongest effect on this result.',
+    )
+    const without = chart(buildHeroModel(makeHeroData({ topDriverLabel: null })))
+    expect(without.mainReason).toBeNull()
+  })
+
+  it('omits main reason instead of interpolating a glossary-tripping label', () => {
+    const m = chart(buildHeroModel(makeHeroData({ topDriverLabel: 'edge weight graph' })))
+    expect(m.mainReason).toBeNull()
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/content.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/content.spec.tsx
@@ -1,0 +1,154 @@
+/**
+ * Content and boundary rendering — the panel shows adapted response values
+ * verbatim, omits everything unsourced, and never renders trust wording,
+ * raw floats, a goal-alone marker, or the retired lenses.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
+import { buildHeroModel } from '../buildHeroModel'
+import type { HeroChartModel, HeroStatusModel } from '../heroTypes'
+import { FULL_COMPLETENESS, makeHeroData, makeOption, OPTION_A, OPTION_B } from '../__fixtures__/hero.fixtures'
+
+function chartModel(data = makeHeroData()): HeroChartModel {
+  const model = buildHeroModel(data)
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+function renderPanel(model: HeroChartModel | HeroStatusModel, props: Partial<Parameters<typeof AnalysisHeroPanel>[0]> = {}) {
+  return render(
+    <AnalysisHeroPanel
+      model={model}
+      isStale={false}
+      onRerun={() => {}}
+      rerunDisabled={false}
+      focusPanelMounted={false}
+      {...props}
+    />,
+  )
+}
+
+describe('AnalysisHeroPanel — content', () => {
+  it('renders the headline, tension subline, and goal readouts from response values', () => {
+    renderPanel(chartModel())
+    expect(screen.getByTestId('hero-headline')).toHaveTextContent(
+      'Upskill the team best fits your goal.',
+    )
+    expect(screen.getByTestId('hero-subline')).toHaveTextContent(
+      'Two developers has the highest expected outcome, but Upskill the team best fits your goal.',
+    )
+    // Goal-fit is the default lens: rendered joint probabilities equal the
+    // response values (0.34 → 34%, 0.49 → 49%).
+    expect(within(screen.getByTestId('hero-option-row-1')).getByText('34%')).toBeInTheDocument()
+    expect(within(screen.getByTestId('hero-option-row-2')).getByText('49%')).toBeInTheDocument()
+  })
+
+  it('switching to Likely outcome shows outcome centres in the readouts', () => {
+    renderPanel(chartModel())
+    fireEvent.click(screen.getByTestId('hero-lens-tab-outcome'))
+    expect(within(screen.getByTestId('hero-option-row-1')).getByText('68')).toBeInTheDocument()
+    expect(within(screen.getByTestId('hero-option-row-2')).getByText('62')).toBeInTheDocument()
+  })
+
+  it('shows win probability ONLY inside an opened option detail', () => {
+    renderPanel(chartModel())
+    expect(screen.queryByText(/chance it is the strongest option overall/)).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /Two developers/ }))
+    expect(screen.getByTestId('hero-detail-win')).toHaveTextContent(
+      '30% chance it is the strongest option overall.',
+    )
+  })
+
+  it('caption names the target with its response value when unit-compatible', () => {
+    renderPanel(chartModel())
+    fireEvent.click(screen.getByTestId('hero-lens-tab-outcome'))
+    expect(screen.getByTestId('hero-caption')).toHaveTextContent('your target of 62')
+    // Marker positioners exist per row and are visible on this lens.
+    for (const marker of screen.getAllByTestId('hero-target-marker')) {
+      expect(marker).toHaveAttribute('data-visible', 'true')
+    }
+  })
+
+  it('omits the target entirely when units are not compatible (isNormalised)', () => {
+    renderPanel(chartModel(makeHeroData({ recommendation: { isNormalised: true } })))
+    fireEvent.click(screen.getByTestId('hero-lens-tab-outcome'))
+    expect(screen.getByTestId('hero-caption')).not.toHaveTextContent('target')
+    for (const marker of screen.getAllByTestId('hero-target-marker')) {
+      expect(marker).toHaveAttribute('data-visible', 'false')
+    }
+  })
+
+  it('never renders a goal-alone marker (collapsed selector — one bar only)', () => {
+    const { container } = renderPanel(chartModel())
+    expect(screen.queryByTestId('hero-goal-alone')).toBeNull()
+    expect(container.textContent).not.toMatch(/goal alone/i)
+  })
+
+  it('never renders trust or stability wording, and no raw 0-1 floats', () => {
+    const { container } = renderPanel(chartModel())
+    const text = container.textContent ?? ''
+    expect(text).not.toMatch(/\btrust\b/i)
+    expect(text).not.toMatch(/\b(firm|fragile|provisional|robust|stability|confidence)\b/i)
+    expect(text).not.toMatch(/\b0\.\d+\b/)
+  })
+
+  it('renders only the two launch lenses — Stability and What changed do not exist', () => {
+    renderPanel(chartModel())
+    expect(screen.getAllByRole('tab')).toHaveLength(2)
+    expect(screen.queryByText(/stability/i)).toBeNull()
+    expect(screen.queryByText(/what changed/i)).toBeNull()
+  })
+
+  it('hides the tab strip when only one lens is available', () => {
+    const noGoal = [
+      makeOption({ ...OPTION_A, goalProbability: undefined }),
+      makeOption({ ...OPTION_B, goalProbability: undefined }),
+    ]
+    renderPanel(chartModel(makeHeroData({ options: noGoal })))
+    expect(screen.queryByRole('tablist')).toBeNull()
+    // The single available lens still renders its rows.
+    expect(screen.getByTestId('hero-option-row-1')).toBeInTheDocument()
+  })
+
+  it('omits unsourced detail lines instead of fabricating copy', () => {
+    const data = makeHeroData({
+      recommendation: { storyHeadlines: undefined, flipThresholds: undefined },
+    })
+    renderPanel(chartModel(data))
+    // Row 1 still has a win line, so it stays expandable — open it.
+    fireEvent.click(screen.getByRole('button', { name: /Two developers/ }))
+    expect(screen.queryByTestId('hero-detail-why')).toBeNull()
+    expect(screen.queryByTestId('hero-detail-could-change')).toBeNull()
+    expect(screen.getByTestId('hero-detail-win')).toBeInTheDocument()
+  })
+
+  it('renders the footer main reason from the top driver and neutral focus-next text', () => {
+    renderPanel(chartModel())
+    expect(screen.getByTestId('hero-main-reason')).toHaveTextContent(
+      'Main reason: Developer capacity has the strongest effect on this result.',
+    )
+    const focusNext = screen.getByTestId('hero-focus-next')
+    expect(focusNext).toHaveTextContent('Focus next: review the top actions below.')
+    // Coaching panel not mounted → plain text, not a dead link.
+    expect(focusNext.tagName).toBe('P')
+  })
+
+  it.each(['partial', 'failed', 'blocked'] as const)(
+    'renders the curated %s non-chart state (no rows, no fabricated numbers)',
+    (variant) => {
+      const data =
+        variant === 'blocked'
+          ? makeHeroData({ recommendation: { analysisStatus: 'blocked' } })
+          : variant === 'failed'
+            ? makeHeroData({ isError: true, completeness: { ...FULL_COMPLETENESS, status: 'failed' } })
+            : makeHeroData({ completeness: { ...FULL_COMPLETENESS, status: 'partial' } })
+      const model = buildHeroModel(data)
+      expect(model.kind).toBe('status')
+      renderPanel(model as HeroStatusModel)
+      expect(screen.getByTestId(`hero-status-${variant}`)).toBeInTheDocument()
+      expect(screen.queryByTestId('hero-option-row-1')).toBeNull()
+      expect(screen.queryByRole('tablist')).toBeNull()
+    },
+  )
+})

--- a/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
@@ -33,7 +33,11 @@ const UI_COPY: string[] = [
   HERO_COPY.caption.goalOnly,
   HERO_COPY.caption.outcome,
   HERO_COPY.caption.outcomeTarget('120'),
+  // HERO_COPY.readout.missing is deliberately NOT scanned: it is the
+  // app-wide missing-value placeholder glyph ('—', matching format.ts
+  // nullPlaceholder), not prose — the no-em-dash rule targets sentences.
   HERO_COPY.readout.goalSuffix,
+  HERO_COPY.readout.subOnePercent,
   HERO_COPY.detail.whyLabel,
   HERO_COPY.detail.couldChangeIfLabel,
   HERO_COPY.detail.couldChangeIf('Team capacity', '30%'),

--- a/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copy hygiene — UI-AUTHORED copy only (HERO_COPY). Scanned against the
+ * canonical glossary banned-term list plus the trust vocabulary this panel
+ * must never author (trust words render only from producer labels, and no
+ * producer label exists at launch). Producer-supplied strings (story
+ * headlines, option labels rendered verbatim in row titles) are deliberately
+ * NOT scanned — they are rendered as data, never authored here.
+ */
+import { describe, expect, it } from 'vitest'
+import { findBannedTerm } from '@/test/glossaryBannedTerms'
+import { HERO_COPY } from '../heroCopy'
+
+// Neutral placeholders so template output — not the arguments — is scanned.
+const L = 'Option Alpha'
+
+const UI_COPY: string[] = [
+  HERO_COPY.panelAria,
+  HERO_COPY.tablistAria,
+  HERO_COPY.lensLabel.goal,
+  HERO_COPY.lensLabel.outcome,
+  HERO_COPY.headline.goalWithLimits(L),
+  HERO_COPY.headline.goalOnly(L),
+  HERO_COPY.headline.outcomeOnly(L),
+  HERO_COPY.headline.singleOption(L),
+  HERO_COPY.headline.noLeader,
+  HERO_COPY.subline.diverged(L, 'Option Beta', true),
+  HERO_COPY.subline.diverged(L, 'Option Beta', false),
+  HERO_COPY.subline.aligned(L),
+  HERO_COPY.labelFallback,
+  HERO_COPY.factorFallback,
+  ...Object.values(HERO_COPY.axis).flatMap((a) => [a.left, a.mid, a.right]),
+  HERO_COPY.caption.goalWithLimits,
+  HERO_COPY.caption.goalOnly,
+  HERO_COPY.caption.outcome,
+  HERO_COPY.caption.outcomeTarget('120'),
+  HERO_COPY.readout.goalSuffix,
+  HERO_COPY.detail.whyLabel,
+  HERO_COPY.detail.couldChangeIfLabel,
+  HERO_COPY.detail.couldChangeIf('Team capacity', '30%'),
+  HERO_COPY.detail.winChance('58%'),
+  HERO_COPY.footer.mainReason('Team capacity'),
+  HERO_COPY.footer.focusNext,
+  HERO_COPY.footer.focusNextAria,
+  HERO_COPY.footer.rerun,
+  HERO_COPY.status.partial.headline,
+  HERO_COPY.status.partial.body,
+  HERO_COPY.status.failed.headline,
+  HERO_COPY.status.failed.body,
+  HERO_COPY.status.blocked.headline,
+  HERO_COPY.status.blocked.body,
+  HERO_COPY.srLeader,
+].filter((s) => s.length > 0)
+
+/**
+ * Trust/banding vocabulary this panel must never author (correction 8 of the
+ * review). The canonical glossary covers some of these; the rest are pinned
+ * here explicitly.
+ */
+const TRUST_FORBIDDEN = [
+  'trust',
+  'provisional',
+  'firm',
+  'moderate',
+  'fragile',
+  'confidence',
+  'stability',
+  'robust',
+]
+
+describe('Analysis hero copy hygiene (UI-authored copy only)', () => {
+  it('contains no canonical glossary banned term', () => {
+    for (const copy of UI_COPY) {
+      const hit = findBannedTerm(copy)
+      expect(hit, `"${copy}" contains banned term "${hit}"`).toBeNull()
+    }
+  })
+
+  it('positive control: the scanner fires on bad copy', () => {
+    expect(findBannedTerm('the recommended winner uses the graph')).not.toBeNull()
+  })
+
+  it.each(TRUST_FORBIDDEN)('authors no trust/banding word: %s', (term) => {
+    const re = new RegExp(`\\b${term}\\b`, 'i')
+    expect(`a ${term} b`, `regex for "${term}" must fire`).toMatch(re)
+    for (const copy of UI_COPY) {
+      expect(copy, `"${copy}" should not contain "${term}"`).not.toMatch(re)
+    }
+  })
+
+  it('uses no all-caps words and no em dashes (sentence case, British English)', () => {
+    for (const copy of UI_COPY) {
+      expect(copy).not.toMatch(/\b[A-Z]{2,}\b/)
+      expect(copy).not.toContain('—')
+    }
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
@@ -42,7 +42,8 @@ describe('Analysis hero source hygiene', () => {
   it.each([
     ['unsafe HTML', /dangerouslySetInnerHTML|\binnerHTML\b/],
     ['network access', /\bfetch\s*\(|\baxios\b|XMLHttpRequest|EventSource|WebSocket/],
-    ['UI banding threshold ternary', /[><]=?\s*0\.\d+\s*\?/],
+    // Catches `0.5`, no-leading-zero `.5`, and scientific `1e-1` literals.
+    ['UI banding threshold ternary', /[><]=?\s*(?:0?\.\d+|\d+(?:\.\d+)?e-\d+)\s*\?/i],
     [
       'trust/stability field reads',
       /robustnessLevel|robustnessLabel|robustnessVerdict|recommendationStability/,
@@ -55,9 +56,12 @@ describe('Analysis hero source hygiene', () => {
   })
 
   it('positive controls: each pattern fires on the code it bans', () => {
+    const banding = /[><]=?\s*(?:0?\.\d+|\d+(?:\.\d+)?e-\d+)\s*\?/i
     expect(/dangerouslySetInnerHTML|\binnerHTML\b/.test('el.innerHTML = x')).toBe(true)
     expect(/\bfetch\s*\(/.test('await fetch(url)')).toBe(true)
-    expect(/[><]=?\s*0\.\d+\s*\?/.test("conf >= 0.65 ? 'Firm' : 'Fragile'")).toBe(true)
+    expect(banding.test("conf >= 0.65 ? 'Firm' : 'Fragile'")).toBe(true)
+    expect(banding.test("p > .5 ? 'likely' : 'unlikely'")).toBe(true)
+    expect(banding.test("score >= 1e-1 ? 'a' : 'b'")).toBe(true)
     expect(/robustnessVerdict/.test('data.robustnessVerdict')).toBe(true)
     expect(/coaching-panel\/focus-now/.test("import x from '@/canvas/components/coaching-panel/focus-now'")).toBe(true)
   })

--- a/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Source hygiene guard — scans the module's production source (tests and
+ * fixtures excluded) for the failure modes the brief bans outright:
+ *
+ *   - unsafe HTML (dangerouslySetInnerHTML / innerHTML);
+ *   - any network path (fetch/axios/XHR/EventSource/WebSocket) — the hero is
+ *     a read-only layer over props, it must never introduce a second fetch;
+ *   - UI-created banding thresholds (a `>= 0.x ?` style ternary — the
+ *     prototype's band()/trustWord() shape);
+ *   - reads of the trust/stability fields the hero must not consume
+ *     (the robustness trio and recommendationStability — no producer
+ *     display-safe label exists, so any read would be a fabrication path);
+ *   - imports from the focus-now module (its inertness guard forbids
+ *     external importers — patterns were copied, not imported).
+ */
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const MODULE_DIR = resolve(process.cwd(), 'src', 'components', 'results', 'analysis-hero')
+
+function productionSources(dir: string, acc: { file: string; content: string }[] = []) {
+  for (const name of readdirSync(dir)) {
+    if (name === '__tests__' || name === '__fixtures__') continue
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) {
+      productionSources(full, acc)
+    } else if (/\.(ts|tsx)$/.test(name)) {
+      acc.push({ file: name, content: readFileSync(full, 'utf8') })
+    }
+  }
+  return acc
+}
+
+const sources = productionSources(MODULE_DIR)
+
+describe('Analysis hero source hygiene', () => {
+  it('scans a non-empty production source set (guard is alive)', () => {
+    expect(sources.map((s) => s.file)).toContain('buildHeroModel.ts')
+  })
+
+  it.each([
+    ['unsafe HTML', /dangerouslySetInnerHTML|\binnerHTML\b/],
+    ['network access', /\bfetch\s*\(|\baxios\b|XMLHttpRequest|EventSource|WebSocket/],
+    ['UI banding threshold ternary', /[><]=?\s*0\.\d+\s*\?/],
+    [
+      'trust/stability field reads',
+      /robustnessLevel|robustnessLabel|robustnessVerdict|recommendationStability/,
+    ],
+    ['focus-now imports', /coaching-panel\/focus-now/],
+  ])('contains no %s', (_label, re) => {
+    for (const { file, content } of sources) {
+      expect(re.test(content), `${file} must not match ${re}`).toBe(false)
+    }
+  })
+
+  it('positive controls: each pattern fires on the code it bans', () => {
+    expect(/dangerouslySetInnerHTML|\binnerHTML\b/.test('el.innerHTML = x')).toBe(true)
+    expect(/\bfetch\s*\(/.test('await fetch(url)')).toBe(true)
+    expect(/[><]=?\s*0\.\d+\s*\?/.test("conf >= 0.65 ? 'Firm' : 'Fragile'")).toBe(true)
+    expect(/robustnessVerdict/.test('data.robustnessVerdict')).toBe(true)
+    expect(/coaching-panel\/focus-now/.test("import x from '@/canvas/components/coaching-panel/focus-now'")).toBe(true)
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/inertness.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/inertness.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Mount guard (CI tripwire) — ALLOW-LIST.
+ *
+ * The analysis hero is mounted in exactly ONE authorised place: ResultsBody
+ * renders `AnalysisHeroContainer` behind the `analysisHeroPanel` flag. This
+ * test fails if ANY OTHER file outside the module imports it — via static /
+ * type-only / re-export / dynamic import() / React.lazy / require /
+ * side-effect / glued forms, by alias ('@/.../analysis-hero') or relative
+ * path. Mechanism copied from the proven focus-now inertness guard (import
+ * specifiers are RESOLVED to absolute paths, not substring-matched).
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve, sep } from 'node:path'
+
+const SRC = resolve(process.cwd(), 'src')
+const MODULE_DIR = join(SRC, 'components', 'results', 'analysis-hero')
+
+// The ONE authorised live mount.
+const AUTHORIZED_IMPORTERS = new Set([join(SRC, 'components', 'results', 'ResultsBody.tsx')])
+
+// Capture the specifier of any import / re-export / dynamic import() /
+// require() — including glued zero-whitespace forms (`import{X}from'x'`).
+const SPEC_RE = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s*|\brequire\s*\(\s*)['"]([^'"\n]+)['"]/g
+
+// Boundary-aware path backstop: matches `.../results/analysis-hero` and
+// `.../results/analysis-hero/<file>`, but NOT a sibling like
+// `analysis-hero-helpers`.
+const PATH_RE = /components\/results\/analysis-hero(\/|$)/
+
+function resolveSpec(spec: string, importerFile: string): string | null {
+  if (spec.startsWith('@/')) return resolve(SRC, spec.slice(2))
+  if (spec === '.' || spec === '..' || spec.startsWith('./') || spec.startsWith('../')) {
+    return resolve(dirname(importerFile), spec)
+  }
+  return null // bare package specifier — never an analysis-hero import
+}
+
+function isUnderModule(p: string): boolean {
+  return p === MODULE_DIR || p.startsWith(MODULE_DIR + sep)
+}
+
+export function findAnalysisHeroImports(content: string, importerFile: string): string[] {
+  const offenders: string[] = []
+  for (const m of content.matchAll(SPEC_RE)) {
+    const spec = m[1]
+    const resolved = resolveSpec(spec, importerFile)
+    if ((resolved && isUnderModule(resolved)) || PATH_RE.test(spec)) offenders.push(spec)
+  }
+  return offenders
+}
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist') continue
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) walk(full, acc)
+    else if (/\.(ts|tsx)$/.test(name)) acc.push(full)
+  }
+  return acc
+}
+
+describe('Analysis hero inertness', () => {
+  it('is imported ONLY by the authorised Analysis-tab mount', () => {
+    const offenders: string[] = []
+    for (const file of walk(SRC)) {
+      if (file === MODULE_DIR || file.startsWith(MODULE_DIR + sep)) continue
+      if (AUTHORIZED_IMPORTERS.has(file)) continue
+      const hits = findAnalysisHeroImports(readFileSync(file, 'utf8'), file)
+      if (hits.length) offenders.push(`${file.slice(SRC.length - 3)} -> ${hits.join(', ')}`)
+    }
+    expect(
+      offenders,
+      `Only ResultsBody may import the analysis hero; remove these other imports:\n${offenders.join('\n')}`,
+    ).toEqual([])
+  })
+
+  it('the authorised mount (ResultsBody) actually imports the module', () => {
+    for (const f of AUTHORIZED_IMPORTERS) {
+      expect(
+        findAnalysisHeroImports(readFileSync(f, 'utf8'), f).length,
+        `${f.slice(SRC.length - 3)} should import analysis-hero (mount must stay wired)`,
+      ).toBeGreaterThan(0)
+    }
+  })
+
+  const PARENT = join(SRC, 'components', 'results', 'index.ts')
+  const SIBLING = join(SRC, 'components', 'results', '__tests__', 'x.ts')
+
+  it.each([
+    ['relative static from parent dir', PARENT, "import { AnalysisHeroContainer } from './analysis-hero'"],
+    ['relative type-only', PARENT, "import type { HeroModel } from './analysis-hero/heroTypes'"],
+    ['relative re-export', PARENT, "export { AnalysisHeroContainer } from './analysis-hero'"],
+    ['relative re-export star', PARENT, "export * from './analysis-hero'"],
+    ['relative lazy/dynamic', PARENT, "const X = lazy(() => import('./analysis-hero'))"],
+    ['relative deep file', PARENT, "import { HeroOptionRow } from './analysis-hero/HeroOptionRow'"],
+    ['relative from sibling dir (../)', SIBLING, "import x from '../analysis-hero'"],
+    ['aliased static', PARENT, "import { AnalysisHeroContainer } from '@/components/results/analysis-hero'"],
+    ['aliased lazy/dynamic', PARENT, "const X = lazy(() => import('@/components/results/analysis-hero'))"],
+    ['require()', PARENT, "const m = require('./analysis-hero')"],
+    ['side-effect import', PARENT, "import './analysis-hero'"],
+    ['glued no-whitespace named import', PARENT, "import{AnalysisHeroContainer}from'./analysis-hero'"],
+  ])('FLAGS dynamic/relative import: %s', (_label, importer, code) => {
+    expect(findAnalysisHeroImports(code, importer).length).toBeGreaterThan(0)
+  })
+
+  it.each([
+    ['bare package import', PARENT, "import React from 'react'"],
+    ['unrelated sibling module', PARENT, "import { OptionCards } from './OptionCards'"],
+    ['similarly-named relative sibling', PARENT, "import x from './analysis-hero-helpers'"],
+    ['similarly-named aliased sibling', PARENT, "import x from '@/components/results/analysis-hero-helpers'"],
+    ['unrelated relative path elsewhere', join(SRC, 'foo', 'bar.ts'), "import './not-analysis-hero'"],
+  ])('does NOT flag: %s', (_label, importer, code) => {
+    expect(findAnalysisHeroImports(code, importer)).toEqual([])
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/inertness.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/inertness.spec.ts
@@ -20,8 +20,9 @@ const MODULE_DIR = join(SRC, 'components', 'results', 'analysis-hero')
 const AUTHORIZED_IMPORTERS = new Set([join(SRC, 'components', 'results', 'ResultsBody.tsx')])
 
 // Capture the specifier of any import / re-export / dynamic import() /
-// require() — including glued zero-whitespace forms (`import{X}from'x'`).
-const SPEC_RE = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s*|\brequire\s*\(\s*)['"]([^'"\n]+)['"]/g
+// require() — including glued zero-whitespace forms (`import{X}from'x'`)
+// and template-literal specifiers (`import(\`./x\`)` with no interpolation).
+const SPEC_RE = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s*|\brequire\s*\(\s*)['"`]([^'"`\n$]+)['"`]/g
 
 // Boundary-aware path backstop: matches `.../results/analysis-hero` and
 // `.../results/analysis-hero/<file>`, but NOT a sibling like
@@ -100,6 +101,7 @@ describe('Analysis hero inertness', () => {
     ['require()', PARENT, "const m = require('./analysis-hero')"],
     ['side-effect import', PARENT, "import './analysis-hero'"],
     ['glued no-whitespace named import', PARENT, "import{AnalysisHeroContainer}from'./analysis-hero'"],
+    ['template-literal dynamic import', PARENT, 'const X = lazy(() => import(`./analysis-hero`))'],
   ])('FLAGS dynamic/relative import: %s', (_label, importer, code) => {
     expect(findAnalysisHeroImports(code, importer).length).toBeGreaterThan(0)
   })

--- a/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
@@ -127,6 +127,14 @@ describe('AnalysisHero — interaction', () => {
     }
   })
 
+  it('focus-next click is a safe no-op when the scroll target is missing (no throw)', () => {
+    // Coaching panel flag on but its element absent (e.g. its error
+    // boundary tripped): the click must not throw.
+    render(<AnalysisHeroContainer data={makeHeroData()} />)
+    expect(document.querySelector('[data-testid="focus-now-panel"]')).toBeNull()
+    expect(() => fireEvent.click(screen.getByTestId('hero-focus-next'))).not.toThrow()
+  })
+
   it('focus-next degrades to plain text when the coaching panel is off (no dead link)', () => {
     vi.mocked(isFocusNowPanelEnabled).mockReturnValue(false)
     render(<AnalysisHeroContainer data={makeHeroData()} />)

--- a/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
@@ -1,0 +1,134 @@
+/**
+ * Interaction — disclosure rows (one open at a time, keyboard), lens tabs
+ * (roving arrows, local-state-only switching, no remount), stale
+ * soft-disable with the re-run route, and safe focus-next degradation.
+ *
+ * Rendered through the real AnalysisHeroContainer with useV2Run and the
+ * coaching-panel flag mocked, so the wiring under test is the shipped one.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AnalysisHeroContainer } from '../AnalysisHeroContainer'
+import { makeHeroData } from '../__fixtures__/hero.fixtures'
+
+const runSpy = vi.fn()
+let running = false
+
+vi.mock('@/canvas/hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis: runSpy, isRunning: running }),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return { ...actual, isFocusNowPanelEnabled: vi.fn(() => true) }
+})
+
+import { isFocusNowPanelEnabled } from '@/flags'
+
+describe('AnalysisHero — interaction', () => {
+  beforeEach(() => {
+    runSpy.mockClear()
+    running = false
+    vi.mocked(isFocusNowPanelEnabled).mockReturnValue(true)
+  })
+
+  it('opens and closes option detail, keeping one row open at a time', () => {
+    render(<AnalysisHeroContainer data={makeHeroData()} />)
+    const rowA = screen.getByRole('button', { name: /Two developers/ })
+    const rowB = screen.getByRole('button', { name: /Upskill the team/ })
+
+    fireEvent.click(rowA)
+    expect(rowA).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getAllByTestId('hero-option-detail')).toHaveLength(1)
+
+    fireEvent.click(rowB)
+    expect(rowB).toHaveAttribute('aria-expanded', 'true')
+    expect(rowA).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getAllByTestId('hero-option-detail')).toHaveLength(1)
+
+    fireEvent.click(rowB)
+    expect(rowB).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('hero-option-detail')).toBeNull()
+  })
+
+  it('moves lens selection with arrow keys (roving tabindex)', () => {
+    render(<AnalysisHeroContainer data={makeHeroData()} />)
+    const goalTab = screen.getByTestId('hero-lens-tab-goal')
+    const outcomeTab = screen.getByTestId('hero-lens-tab-outcome')
+    expect(goalTab).toHaveAttribute('aria-selected', 'true')
+    expect(outcomeTab).toHaveAttribute('tabindex', '-1')
+
+    fireEvent.keyDown(goalTab, { key: 'ArrowRight' })
+    expect(outcomeTab).toHaveAttribute('aria-selected', 'true')
+    expect(outcomeTab).toHaveAttribute('tabindex', '0')
+    expect(goalTab).toHaveAttribute('tabindex', '-1')
+
+    fireEvent.keyDown(outcomeTab, { key: 'ArrowLeft' })
+    expect(goalTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('lens switching is local state only: same row DOM nodes, no analysis call', () => {
+    render(<AnalysisHeroContainer data={makeHeroData()} />)
+    const row1 = screen.getByTestId('hero-option-row-1')
+    const row2 = screen.getByTestId('hero-option-row-2')
+
+    fireEvent.click(screen.getByTestId('hero-lens-tab-outcome'))
+    // Rows persist (values morph) — no remount of the chart.
+    expect(screen.getByTestId('hero-option-row-1')).toBe(row1)
+    expect(screen.getByTestId('hero-option-row-2')).toBe(row2)
+    // Numbering is stable across lens switches (presentation order).
+    expect(row1).toHaveTextContent(/^1/)
+    expect(row2).toHaveTextContent(/^2/)
+    expect(runSpy).not.toHaveBeenCalled()
+  })
+
+  it('stale: locks lens and row interactions and routes focus-next to re-run', () => {
+    render(<AnalysisHeroContainer data={makeHeroData()} isStale />)
+    // Lens tabs disabled; rows render as non-interactive (no disclosure buttons).
+    expect(screen.getByTestId('hero-lens-tab-goal')).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /Two developers/ })).toBeNull()
+    expect(screen.queryByTestId('hero-focus-next')).toBeNull()
+
+    const rerun = screen.getByTestId('hero-rerun')
+    fireEvent.click(rerun)
+    expect(runSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('stale: re-run is disabled while an analysis is already running', () => {
+    running = true
+    render(<AnalysisHeroContainer data={makeHeroData()} isStale />)
+    expect(screen.getByTestId('hero-rerun')).toBeDisabled()
+  })
+
+  it('focus-next scrolls to the mounted coaching panel', () => {
+    const target = document.createElement('div')
+    target.setAttribute('data-testid', 'focus-now-panel')
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    document.body.appendChild(target)
+    try {
+      render(<AnalysisHeroContainer data={makeHeroData()} />)
+      const focusNext = screen.getByTestId('hero-focus-next')
+      expect(focusNext.tagName).toBe('BUTTON')
+      fireEvent.click(focusNext)
+      expect(scrollSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      target.remove()
+    }
+  })
+
+  it('focus-next degrades to plain text when the coaching panel is off (no dead link)', () => {
+    vi.mocked(isFocusNowPanelEnabled).mockReturnValue(false)
+    render(<AnalysisHeroContainer data={makeHeroData()} />)
+    const focusNext = screen.getByTestId('hero-focus-next')
+    expect(focusNext.tagName).toBe('P')
+    expect(focusNext).toHaveTextContent('Focus next: review the top actions below.')
+  })
+
+  it('renders nothing at all for the empty model (fail-closed mount)', () => {
+    const { container } = render(
+      <AnalysisHeroContainer data={makeHeroData({ options: [] })} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
@@ -127,12 +127,17 @@ describe('AnalysisHero — interaction', () => {
     }
   })
 
-  it('focus-next click is a safe no-op when the scroll target is missing (no throw)', () => {
+  it('focus-next is NOT an enabled clickable when the scroll target is absent (flag on)', () => {
     // Coaching panel flag on but its element absent (e.g. its error
-    // boundary tripped): the click must not throw.
+    // boundary tripped): a keyboard/screen-reader user must not be offered
+    // a dead affordance — the line degrades to plain text.
     render(<AnalysisHeroContainer data={makeHeroData()} />)
     expect(document.querySelector('[data-testid="focus-now-panel"]')).toBeNull()
-    expect(() => fireEvent.click(screen.getByTestId('hero-focus-next'))).not.toThrow()
+    const focusNext = screen.getByTestId('hero-focus-next')
+    expect(focusNext.tagName).toBe('P')
+    expect(focusNext).toHaveTextContent('Focus next: review the top actions below.')
+    // No button/link role anywhere in the footer line.
+    expect(screen.queryByRole('button', { name: /actions panel below/i })).toBeNull()
   })
 
   it('focus-next degrades to plain text when the coaching panel is off (no dead link)', () => {

--- a/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
@@ -65,6 +65,16 @@ describe('AnalysisHero — interaction', () => {
 
     fireEvent.keyDown(outcomeTab, { key: 'ArrowLeft' })
     expect(goalTab).toHaveAttribute('aria-selected', 'true')
+
+    // Home/End jump to the first/last lens (WAI-ARIA APG).
+    fireEvent.keyDown(goalTab, { key: 'End' })
+    expect(outcomeTab).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(outcomeTab, { key: 'Home' })
+    expect(goalTab).toHaveAttribute('aria-selected', 'true')
+
+    // Up/Down are NOT hijacked on a horizontal tablist (page scroll keeps working).
+    fireEvent.keyDown(goalTab, { key: 'ArrowDown' })
+    expect(goalTab).toHaveAttribute('aria-selected', 'true')
   })
 
   it('lens switching is local state only: same row DOM nodes, no analysis call', () => {

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -289,11 +289,24 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
           )
   }
 
-  // Target/domain guard: strictly `isNormalised === false` — outcome values
-  // have been denormalised into user units, the same space as goalThreshold.
-  // `undefined` (older data, pre-run defaults) counts as uncertainty → omit.
+  // Target/domain guard — the threshold joins the chart ONLY when it
+  // provably shares the displayed outcome metric/unit:
+  //  1. `isNormalised === false`: outcome values were denormalised into the
+  //     goal node's user units (useResultsSectionData scales by
+  //     goal_threshold_cap), and `goalThreshold` is goal_threshold_raw from
+  //     the SAME goal node — same metric by construction. `true` means
+  //     outcomes are relative scores (threshold incompatible); `undefined`
+  //     (older data, pre-run defaults) counts as uncertainty → omit.
+  //  2. `outcomeUnit != null`: the Results Panel's shared unit convention
+  //     (outcomeUnit/outcomeUnitSymbol — the same fields SuccessTargetRow
+  //     and RangeVisualization format BOTH the threshold and outcome values
+  //     with) actually exists. An unknown unit removes the evidence that
+  //     threshold and outcomes share a metric → uncertainty → omit.
+  // An incompatible/uncertain threshold is excluded from BOTH the marker
+  // and the axis-domain calculation below, so it can never distort the chart.
   const targetCompatible =
     isNormalised === false &&
+    outcomeUnit != null &&
     typeof goalThreshold === 'number' &&
     Number.isFinite(goalThreshold)
   const targetValue = targetCompatible ? goalThreshold : null

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -1,0 +1,297 @@
+/**
+ * buildHeroModel — PURE mapper from the adapted Results Panel object
+ * (`ResultsSectionDataReturn`) to the hero's display model.
+ *
+ * Read-only discipline (the crux of this module):
+ *   - SELECTION of existing values is allowed (which option to highlight,
+ *     which existing figure to show). CREATION of values is not: no new
+ *     probabilities, deltas, confidence bands, qualitative bands, defaults
+ *     or clamps. Formatting reuses the existing Results Panel formatters
+ *     (formatThreshold, formatPercent, formatProbabilityWithResolution) so
+ *     hero numbers reconcile with the panels below.
+ *   - The outcome-axis domain is LAYOUT ONLY: it positions bars/dots and is
+ *     never displayed as data, never described semantically, and never fed
+ *     back into selection logic.
+ *
+ * Leader rules (review-locked):
+ *   - Headline leader = `recommendation.recommendedOption` (the Results
+ *     Panel's own leader) — never an independent argmax of goalProbability,
+ *     so the hero cannot disagree with the panels below. The goal-fit lens
+ *     highlight follows the same leader.
+ *   - Outcome leader = highest existing outcome centre (expected ?? mean ??
+ *     p50), a genuinely distinct question. Ties break deterministically to
+ *     the earliest option in `allOptions[]` presentation order.
+ *
+ * Goal-fit honesty: the adapted selector collapses joint/unconstrained into
+ * one `goalProbability` (= probability_of_joint_goal when constraints exist,
+ * else goal_probability — see useResultsSectionData). The hero therefore
+ * shows ONE bar labelled by constraint presence and renders NO separate
+ * goal-alone marker (selector gap, reported in the PR).
+ *
+ * Target/domain guard (top silent-bug risk): `goalThreshold` is in user
+ * units while outcome values are user-unit only when `isNormalised ===
+ * false`. The target marker renders — and the threshold joins the layout
+ * domain — ONLY under that exact condition; any uncertainty (undefined)
+ * omits both so an incompatible threshold can never distort the chart.
+ */
+
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { FlipThreshold, OptionResult } from '../types'
+import { formatThreshold } from '../RangeVisualization'
+import { stripEncodingNotation } from '../utils/cleanFactorLabel'
+import { safeInterpolatedLabel, containsBannedTerm } from '../analysisHeroV17/glossaryCheck'
+import { formatPercent, formatProbabilityWithResolution } from '@/utils/formatPercent'
+import { HERO_COPY } from './heroCopy'
+import type { HeroChartModel, HeroLens, HeroModel, HeroRowVM, HeroStatusModel } from './heroTypes'
+
+// ─── Small helpers (selection + display formatting only) ────────────────────
+
+function statusModel(variant: HeroStatusModel['variant']): HeroStatusModel {
+  const copy = HERO_COPY.status[variant]
+  return { kind: 'status', variant, headline: copy.headline, body: copy.body }
+}
+
+/** Existing-value fallback chains, mirroring the Results Panel conventions. */
+function outcomeCentre(o: OptionResult): number | null {
+  return o.expected ?? o.outcome?.mean ?? o.outcome?.p50 ?? o.p50 ?? null
+}
+function outcomeP10(o: OptionResult): number | null {
+  return o.outcome?.p10 ?? o.p10 ?? null
+}
+function outcomeP90(o: OptionResult): number | null {
+  return o.outcome?.p90 ?? o.p90 ?? null
+}
+
+/**
+ * Format a flip-threshold factor value with its OWN unit string (factor
+ * space, not outcome space — display formatting only, value unchanged).
+ */
+function formatFlipValue(value: number, unit?: string): string {
+  const rendered = value.toLocaleString(undefined, { maximumFractionDigits: 1 })
+  if (!unit) return rendered
+  if (unit === '%') return `${rendered}%`
+  if (/^[^0-9a-z]$/i.test(unit)) return `${unit}${rendered}`
+  return `${rendered} ${unit}`
+}
+
+/**
+ * "Could change if" line for one option — producer flip-threshold data only.
+ * The recommended option reads the first resolvable threshold (the value at
+ * which the recommendation changes); any other option only gets a line when
+ * a threshold explicitly names it as the alternative winner. No thresholds,
+ * no line.
+ */
+function couldChangeIfLine(
+  option: OptionResult,
+  isRecommended: boolean,
+  flipThresholds: readonly FlipThreshold[],
+): string | undefined {
+  const usable = flipThresholds.filter((ft) => ft.flip_value != null)
+  const ft = isRecommended
+    ? usable[0]
+    : usable.find((f) => f.alternative_winner_label === option.label)
+  if (!ft || ft.flip_value == null) return undefined
+  const factor = safeInterpolatedLabel(stripEncodingNotation(ft.label), HERO_COPY.factorFallback)
+  return HERO_COPY.detail.couldChangeIf(factor, formatFlipValue(ft.flip_value, ft.unit))
+}
+
+// ─── Main mapper ─────────────────────────────────────────────────────────────
+
+export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
+  const { recommendation, drivers, isLoading, isError } = data
+  // Optional-chained despite the type: fail closed rather than throw if a
+  // caller supplies a partially-shaped object (e.g. hydrated older state).
+  const completenessStatus = data.completeness?.status
+
+  // Non-chart states first. `completeness` consults SOURCE fields (P0 V5
+  // golden-path repair) and reads 'full' before any run, so these branches
+  // cannot fire on a fresh canvas. Curated copy only — statusReason may carry
+  // internal identifiers, so it is deliberately not interpolated.
+  if (isLoading) return { kind: 'empty' }
+  if (recommendation.analysisStatus === 'blocked') return statusModel('blocked')
+  if (isError || recommendation.analysisStatus === 'failed' || completenessStatus === 'failed') {
+    return statusModel('failed')
+  }
+  if (recommendation.analysisStatus === 'partial' || completenessStatus === 'partial') {
+    return statusModel('partial')
+  }
+
+  const options = recommendation.allOptions
+  // No analysis yet (the hook's pre-run default) — the tab stays unchanged.
+  if (options.length === 0) return { kind: 'empty' }
+
+  const { outcomeUnit, outcomeUnitSymbol, isNormalised, goalThreshold } = recommendation
+
+  // Constraint presence drives copy only (goal-and-limits vs goal-alone).
+  const hasConstraints = options.some(
+    (o) => (o.constraintAnalysis?.constraints?.length ?? 0) > 0,
+  )
+
+  const recommendedId = recommendation.recommendedOption?.id ?? null
+  const flipThresholds = recommendation.flipThresholds ?? []
+
+  // Rows in allOptions[] presentation order — the same order for every lens,
+  // so numbering is stable across lens switches (asserted in tests).
+  const rows: HeroRowVM[] = options.map((o, i) => {
+    const goalValue = o.goalProbability ?? null
+    const centre = outcomeCentre(o)
+    const why = recommendation.storyHeadlines?.[o.id]
+    const couldChangeIf = couldChangeIfLine(o, o.id === recommendedId, flipThresholds)
+    const winChance =
+      typeof o.winProbability === 'number'
+        ? HERO_COPY.detail.winChance(
+            formatProbabilityWithResolution(o.winProbability, o.nValidSamples),
+          )
+        : undefined
+    const detail = { why, couldChangeIf, winChance }
+    return {
+      id: o.id,
+      index: i + 1,
+      label: stripEncodingNotation(o.label),
+      goal: {
+        value: goalValue,
+        readout:
+          goalValue != null
+            ? formatPercent(goalValue, { fromDecimal: true })
+            : HERO_COPY.readout.missing,
+      },
+      outcome: {
+        p10: outcomeP10(o),
+        p90: outcomeP90(o),
+        centre,
+        readout:
+          centre != null
+            ? formatThreshold(centre, outcomeUnit, outcomeUnitSymbol, isNormalised)
+            : HERO_COPY.readout.missing,
+      },
+      detail,
+      hasDetail: Boolean(why || couldChangeIf || winChance),
+    }
+  })
+
+  // Lens availability — hidden entirely when the sourcing fields are absent.
+  const goalAvailable = rows.some((r) => r.goal.value != null)
+  const outcomeAvailable = rows.some(
+    (r) => r.outcome.p10 != null && r.outcome.p90 != null,
+  )
+  const lenses: HeroLens[] = []
+  if (goalAvailable) lenses.push('goal')
+  if (outcomeAvailable) lenses.push('outcome')
+  // Options exist but nothing displayable — the hero has nothing honest to say.
+  if (lenses.length === 0) return { kind: 'empty' }
+
+  // Outcome leader: highest existing centre; strict `>` keeps the earliest
+  // option on ties (deterministic allOptions[] order tie-break).
+  let outcomeLeaderId: string | null = null
+  let outcomeLeaderCentre = -Infinity
+  for (const r of rows) {
+    if (r.outcome.centre != null && r.outcome.centre > outcomeLeaderCentre) {
+      outcomeLeaderCentre = r.outcome.centre
+      outcomeLeaderId = r.id
+    }
+  }
+
+  // Headline leader: the Results Panel's recommended option. `find` also
+  // guards the recovered-session identity mismatch — if the recommended id
+  // is not among the analysed rows, no leader is claimed.
+  const headlineRow = rows.find((r) => r.id === recommendedId) ?? null
+  const outcomeLeaderRow = rows.find((r) => r.id === outcomeLeaderId) ?? null
+
+  const safeLabel = (row: HeroRowVM) =>
+    safeInterpolatedLabel(row.label, HERO_COPY.labelFallback)
+
+  let headline: string
+  if (rows.length === 1) {
+    headline = HERO_COPY.headline.singleOption(safeLabel(rows[0]))
+  } else if (headlineRow && goalAvailable) {
+    headline = hasConstraints
+      ? HERO_COPY.headline.goalWithLimits(safeLabel(headlineRow))
+      : HERO_COPY.headline.goalOnly(safeLabel(headlineRow))
+  } else if (headlineRow) {
+    headline = HERO_COPY.headline.outcomeOnly(safeLabel(headlineRow))
+  } else if (outcomeLeaderRow) {
+    headline = HERO_COPY.headline.outcomeOnly(safeLabel(outcomeLeaderRow))
+  } else {
+    headline = HERO_COPY.headline.noLeader
+  }
+
+  // Tension subline: goal-fit leader vs strongest expected outcome. Display
+  // selection only — needs both a goal-based headline leader and an outcome
+  // leader to be an honest comparison.
+  let subline: string | null = null
+  if (rows.length > 1 && goalAvailable && headlineRow && outcomeLeaderRow) {
+    subline =
+      headlineRow.id === outcomeLeaderRow.id
+        ? HERO_COPY.subline.aligned(safeLabel(headlineRow))
+        : HERO_COPY.subline.diverged(
+            safeLabel(outcomeLeaderRow),
+            safeLabel(headlineRow),
+            hasConstraints,
+          )
+  }
+
+  // Target/domain guard: strictly `isNormalised === false` — outcome values
+  // have been denormalised into user units, the same space as goalThreshold.
+  // `undefined` (older data, pre-run defaults) counts as uncertainty → omit.
+  const targetCompatible =
+    isNormalised === false &&
+    typeof goalThreshold === 'number' &&
+    Number.isFinite(goalThreshold)
+  const targetValue = targetCompatible ? goalThreshold : null
+
+  // Layout-only display domain for the outcome axis.
+  let outcomeDomain: { min: number; max: number } | null = null
+  if (outcomeAvailable) {
+    const values: number[] = []
+    for (const r of rows) {
+      if (r.outcome.p10 != null) values.push(r.outcome.p10)
+      if (r.outcome.p90 != null) values.push(r.outcome.p90)
+      if (r.outcome.centre != null) values.push(r.outcome.centre)
+    }
+    if (targetValue != null) values.push(targetValue)
+    let min = Math.min(...values)
+    let max = Math.max(...values)
+    const span = max - min
+    // 5% padding, matching RangeVisualization; degenerate spans get a unit
+    // pad so positioning maths stays finite. Layout only.
+    const pad = span > 0 ? span * 0.05 : Math.abs(min) * 0.05 || 1
+    min -= pad
+    max += pad
+    outcomeDomain = { min, max }
+  }
+
+  // Footer "Main reason": the Drivers section's own top driver label —
+  // selection of the existing #1, no re-ranking. Omitted (not replaced with
+  // a fallback) when the label would trip the glossary in generated copy.
+  const topDriverLabel = drivers.topDrivers[0]?.factorLabel
+  const cleanDriverLabel = topDriverLabel ? stripEncodingNotation(topDriverLabel) : null
+  const mainReason =
+    cleanDriverLabel && !containsBannedTerm(cleanDriverLabel)
+      ? HERO_COPY.footer.mainReason(cleanDriverLabel)
+      : null
+
+  const model: HeroChartModel = {
+    kind: 'chart',
+    headline,
+    subline,
+    lenses,
+    defaultLens: goalAvailable ? 'goal' : 'outcome',
+    hasConstraints,
+    rows,
+    leaders: {
+      // Goal-fit highlight follows the headline (Results Panel) leader —
+      // never an independent argmax. Null when no leader is claimable.
+      goal: headlineRow?.id ?? null,
+      outcome: outcomeLeaderId,
+    },
+    outcomeDomain,
+    targetValue,
+    targetReadout:
+      targetValue != null
+        ? formatThreshold(targetValue, outcomeUnit, outcomeUnitSymbol, false)
+        : null,
+    mainReason,
+    isSingleOption: rows.length === 1,
+  }
+  return model
+}

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -87,9 +87,17 @@ function couldChangeIfLine(
   flipThresholds: readonly FlipThreshold[],
 ): string | undefined {
   const usable = flipThresholds.filter((ft) => ft.flip_value != null)
+  // Normalise both sides for the MATCH only (display still uses the raw
+  // producer strings) — encoding notation on either label must not silently
+  // drop a sourced line.
+  const optionLabel = stripEncodingNotation(option.label)
   const ft = isRecommended
     ? usable[0]
-    : usable.find((f) => f.alternative_winner_label === option.label)
+    : usable.find(
+        (f) =>
+          f.alternative_winner_label != null &&
+          stripEncodingNotation(f.alternative_winner_label) === optionLabel,
+      )
   if (!ft || ft.flip_value == null) return undefined
   const factor = safeInterpolatedLabel(stripEncodingNotation(ft.label), HERO_COPY.factorFallback)
   return HERO_COPY.detail.couldChangeIf(factor, formatFlipValue(ft.flip_value, ft.unit))
@@ -98,9 +106,11 @@ function couldChangeIfLine(
 // ─── Main mapper ─────────────────────────────────────────────────────────────
 
 export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
+  // Fail closed on a partially-shaped object (e.g. hydrated older state):
+  // the type guarantees these fields, but the hero must render nothing —
+  // never throw — when a caller supplies less than the type promises.
+  if (!data?.recommendation?.allOptions) return { kind: 'empty' }
   const { recommendation, drivers, isLoading, isError } = data
-  // Optional-chained despite the type: fail closed rather than throw if a
-  // caller supplies a partially-shaped object (e.g. hydrated older state).
   const completenessStatus = data.completeness?.status
 
   // Non-chart states first. `completeness` consults SOURCE fields (P0 V5
@@ -263,7 +273,7 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
   // Footer "Main reason": the Drivers section's own top driver label —
   // selection of the existing #1, no re-ranking. Omitted (not replaced with
   // a fallback) when the label would trip the glossary in generated copy.
-  const topDriverLabel = drivers.topDrivers[0]?.factorLabel
+  const topDriverLabel = drivers?.topDrivers?.[0]?.factorLabel
   const cleanDriverLabel = topDriverLabel ? stripEncodingNotation(topDriverLabel) : null
   const mainReason =
     cleanDriverLabel && !containsBannedTerm(cleanDriverLabel)

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -47,7 +47,7 @@ import {
 } from '../utils/getExpectedValue'
 import { safeInterpolatedLabel, containsBannedTerm } from '../analysisHeroV17/glossaryCheck'
 import { formatPercent, formatProbabilityWithResolution } from '@/utils/formatPercent'
-import { formatValueWithUnit } from '@/canvas/utils/formatValueWithUnit'
+import { classifyUnit } from '@/utils/unitClassifier'
 import { HERO_COPY } from './heroCopy'
 import type { HeroChartModel, HeroLens, HeroModel, HeroRowVM, HeroStatusModel } from './heroTypes'
 
@@ -101,10 +101,39 @@ function couldChangeIfLine(
       )
   if (!ft || ft.flip_value == null) return undefined
   const factor = safeInterpolatedLabel(stripEncodingNotation(ft.label), HERO_COPY.factorFallback)
-  // formatValueWithUnit is the app-wide raw-value+unit convention (symbol
-  // prefix, ISO space-prefix, % suffix, generic suffix) — factor space, not
-  // outcome space; display formatting only, value unchanged.
-  return HERO_COPY.detail.couldChangeIf(factor, formatValueWithUnit(ft.flip_value, ft.unit))
+  return HERO_COPY.detail.couldChangeIf(factor, formatFlipValue(ft.flip_value, ft.unit))
+}
+
+/**
+ * UI-SEM-057: sub-1% goal readout floor. Mirrors OptionCards' existing
+ * display-honesty affordance (`goalProbability < 0.01` → "< 1% likely to
+ * reach target", OptionCards.tsx) so a 0.4% probability never rounds to a
+ * bare "0%" here while the panel below says "< 1%". Display-only; the
+ * value itself is unchanged and the bar still draws from the raw value.
+ */
+function goalReadout(value: number | null): string {
+  if (value == null) return HERO_COPY.readout.missing
+  if (value < 0.01) return HERO_COPY.readout.subOnePercent
+  return formatPercent(value, { fromDecimal: true })
+}
+
+/**
+ * Format a flip-threshold factor value with its OWN unit string (factor
+ * space, not outcome space). Unit placement follows the app-wide
+ * classifyUnit convention (symbol prefix, ISO space-prefix, % suffix,
+ * generic space-suffix) — but unlike formatValueWithUnit, the value ALWAYS
+ * renders as a number: a "crosses <value>" sentence must never substitute
+ * a qualitative word for the producer's numeric threshold. Display
+ * formatting only; the value itself is unchanged.
+ */
+function formatFlipValue(value: number, unit?: string): string {
+  const rendered = value.toLocaleString('en-GB', { maximumFractionDigits: 1 })
+  const { kind, canonical } = classifyUnit(unit ?? null)
+  if (kind === 'symbol') return `${canonical}${rendered}`
+  if (kind === 'iso') return `${canonical} ${rendered}`
+  if (kind === 'percent') return `${rendered}%`
+  if (kind === 'none' || kind === 'placeholder') return rendered
+  return `${rendered} ${canonical}`
 }
 
 // ─── Main mapper ─────────────────────────────────────────────────────────────
@@ -136,10 +165,19 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
 
   const { outcomeUnit, outcomeUnitSymbol, isNormalised, goalThreshold } = recommendation
 
-  // Constraint presence drives copy only (goal-and-limits vs goal-alone).
-  const hasConstraints = options.some(
-    (o) => (o.constraintAnalysis?.constraints?.length ?? 0) > 0,
-  )
+  // UI-SEM-056: constraint-presence copy switch (goal-and-limits vs
+  // goal-alone wording; same class as UI-SEM-050). Copy only — never a
+  // value transform. Because the selector collapses goalProbability PER
+  // OPTION (joint only for options that carry their own constraint
+  // analysis), the shared axis/caption claims "and limits" only when EVERY
+  // goal-bearing option is constrained; a mixed set (anomalous — constraints
+  // are request-level) falls back to the goal-alone wording, which may
+  // understate a constrained bar but never overstates an unconstrained one.
+  const optionHasConstraints = (o: OptionResult) =>
+    (o.constraintAnalysis?.constraints?.length ?? 0) > 0
+  const goalBearing = options.filter((o) => o.goalProbability != null)
+  const hasConstraints =
+    goalBearing.length > 0 && goalBearing.every(optionHasConstraints)
 
   const recommendedId = recommendation.recommendedOption?.id ?? null
   // Pre-filter once: resolvable thresholds only (shared across every row).
@@ -166,10 +204,7 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
       label: stripEncodingNotation(o.label),
       goal: {
         value: goalValue,
-        readout:
-          goalValue != null
-            ? formatPercent(goalValue, { fromDecimal: true })
-            : HERO_COPY.readout.missing,
+        readout: goalReadout(goalValue),
       },
       outcome: {
         p10: outcomeP10(o),
@@ -212,19 +247,25 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
   const headlineRow = rows.find((r) => r.id === recommendedId) ?? null
   const outcomeLeaderRow = rows.find((r) => r.id === outcomeLeaderId) ?? null
 
+  // A goal-fit claim ("best fits your goal") is only honest when the claimed
+  // option ITSELF carries a goal probability — a recommended option whose
+  // goal readout would be "—" must not be headlined or highlighted as the
+  // goal-fit leader while other rows show real figures.
+  const goalLeaderRow = headlineRow && headlineRow.goal.value != null ? headlineRow : null
+
   const safeLabel = (row: HeroRowVM) =>
     safeInterpolatedLabel(row.label, HERO_COPY.labelFallback)
 
   let headline: string
   if (rows.length === 1) {
     headline = HERO_COPY.headline.singleOption(safeLabel(rows[0]))
-  } else if (headlineRow && goalAvailable) {
+  } else if (goalLeaderRow) {
     headline = hasConstraints
-      ? HERO_COPY.headline.goalWithLimits(safeLabel(headlineRow))
-      : HERO_COPY.headline.goalOnly(safeLabel(headlineRow))
+      ? HERO_COPY.headline.goalWithLimits(safeLabel(goalLeaderRow))
+      : HERO_COPY.headline.goalOnly(safeLabel(goalLeaderRow))
   } else {
-    // No goal basis: name whichever leader exists with the weaker
-    // "looks strongest" claim, or claim no leader at all.
+    // No goal basis for the leader: name whichever leader exists with the
+    // weaker "looks strongest" claim, or claim no leader at all.
     const leader = headlineRow ?? outcomeLeaderRow
     headline = leader
       ? HERO_COPY.headline.outcomeOnly(safeLabel(leader))
@@ -232,16 +273,18 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
   }
 
   // Tension subline: goal-fit leader vs strongest expected outcome. Display
-  // selection only — needs both a goal-based headline leader and an outcome
-  // leader to be an honest comparison.
+  // selection only — and only when BOTH sides of the comparison are visible
+  // in the hero: a goal-backed leader AND an outcome lens the user can open
+  // (centres without ranges leave the outcome lens hidden, so the hero must
+  // not assert an expected-outcome comparison it cannot show).
   let subline: string | null = null
-  if (rows.length > 1 && goalAvailable && headlineRow && outcomeLeaderRow) {
+  if (rows.length > 1 && outcomeAvailable && goalLeaderRow && outcomeLeaderRow) {
     subline =
-      headlineRow.id === outcomeLeaderRow.id
-        ? HERO_COPY.subline.aligned(safeLabel(headlineRow))
+      goalLeaderRow.id === outcomeLeaderRow.id
+        ? HERO_COPY.subline.aligned(safeLabel(goalLeaderRow))
         : HERO_COPY.subline.diverged(
             safeLabel(outcomeLeaderRow),
-            safeLabel(headlineRow),
+            safeLabel(goalLeaderRow),
             hasConstraints,
           )
   }
@@ -255,7 +298,11 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
     Number.isFinite(goalThreshold)
   const targetValue = targetCompatible ? goalThreshold : null
 
-  // Layout-only display domain for the outcome axis.
+  // UI-SEM-054: outcome-axis layout domain derivation. Min/max over the
+  // existing p10/p90/centre values (plus the goal threshold ONLY when
+  // unit-compatible, i.e. isNormalised === false), padded 5% each side
+  // (matching RangeVisualization) with a unit pad on a degenerate span.
+  // Layout only — the domain positions bars and is never displayed as data.
   let outcomeDomain: { min: number; max: number } | null = null
   if (outcomeAvailable) {
     const values: number[] = []
@@ -296,8 +343,9 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
     rows,
     leaders: {
       // Goal-fit highlight follows the headline (Results Panel) leader —
-      // never an independent argmax. Null when no leader is claimable.
-      goal: headlineRow?.id ?? null,
+      // never an independent argmax — and only when that option carries its
+      // own goal probability. Null when no leader is claimable.
+      goal: goalLeaderRow?.id ?? null,
       outcome: outcomeLeaderId,
     },
     outcomeDomain,

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -39,8 +39,15 @@ import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { FlipThreshold, OptionResult } from '../types'
 import { formatThreshold } from '../RangeVisualization'
 import { stripEncodingNotation } from '../utils/cleanFactorLabel'
+import {
+  getExpectedValue,
+  getMedian,
+  getOptimistic,
+  getPessimistic,
+} from '../utils/getExpectedValue'
 import { safeInterpolatedLabel, containsBannedTerm } from '../analysisHeroV17/glossaryCheck'
 import { formatPercent, formatProbabilityWithResolution } from '@/utils/formatPercent'
+import { formatValueWithUnit } from '@/canvas/utils/formatValueWithUnit'
 import { HERO_COPY } from './heroCopy'
 import type { HeroChartModel, HeroLens, HeroModel, HeroRowVM, HeroStatusModel } from './heroTypes'
 
@@ -51,27 +58,22 @@ function statusModel(variant: HeroStatusModel['variant']): HeroStatusModel {
   return { kind: 'status', variant, headline: copy.headline, body: copy.body }
 }
 
-/** Existing-value fallback chains, mirroring the Results Panel conventions. */
+/**
+ * Existing-value fallback chains, composed from the canonical percentile
+ * helpers plus the deprecated top-level fields for backward compatibility
+ * (the same fallback ResultsBody itself uses). The centre deliberately
+ * blends mean → median (unlike getExpectedValue alone, which refuses the
+ * median): the hero shows ONE centre per option and prefers whichever
+ * existing value the Results Panel would surface first.
+ */
 function outcomeCentre(o: OptionResult): number | null {
-  return o.expected ?? o.outcome?.mean ?? o.outcome?.p50 ?? o.p50 ?? null
+  return getExpectedValue(o) ?? getMedian(o) ?? o.p50 ?? null
 }
 function outcomeP10(o: OptionResult): number | null {
-  return o.outcome?.p10 ?? o.p10 ?? null
+  return getPessimistic(o) ?? o.p10 ?? null
 }
 function outcomeP90(o: OptionResult): number | null {
-  return o.outcome?.p90 ?? o.p90 ?? null
-}
-
-/**
- * Format a flip-threshold factor value with its OWN unit string (factor
- * space, not outcome space — display formatting only, value unchanged).
- */
-function formatFlipValue(value: number, unit?: string): string {
-  const rendered = value.toLocaleString(undefined, { maximumFractionDigits: 1 })
-  if (!unit) return rendered
-  if (unit === '%') return `${rendered}%`
-  if (/^[^0-9a-z]$/i.test(unit)) return `${unit}${rendered}`
-  return `${rendered} ${unit}`
+  return getOptimistic(o) ?? o.p90 ?? null
 }
 
 /**
@@ -79,14 +81,13 @@ function formatFlipValue(value: number, unit?: string): string {
  * The recommended option reads the first resolvable threshold (the value at
  * which the recommendation changes); any other option only gets a line when
  * a threshold explicitly names it as the alternative winner. No thresholds,
- * no line.
+ * no line. `usable` is pre-filtered once by the caller (flip_value != null).
  */
 function couldChangeIfLine(
   option: OptionResult,
   isRecommended: boolean,
-  flipThresholds: readonly FlipThreshold[],
+  usable: readonly FlipThreshold[],
 ): string | undefined {
-  const usable = flipThresholds.filter((ft) => ft.flip_value != null)
   // Normalise both sides for the MATCH only (display still uses the raw
   // producer strings) — encoding notation on either label must not silently
   // drop a sourced line.
@@ -100,7 +101,10 @@ function couldChangeIfLine(
       )
   if (!ft || ft.flip_value == null) return undefined
   const factor = safeInterpolatedLabel(stripEncodingNotation(ft.label), HERO_COPY.factorFallback)
-  return HERO_COPY.detail.couldChangeIf(factor, formatFlipValue(ft.flip_value, ft.unit))
+  // formatValueWithUnit is the app-wide raw-value+unit convention (symbol
+  // prefix, ISO space-prefix, % suffix, generic suffix) — factor space, not
+  // outcome space; display formatting only, value unchanged.
+  return HERO_COPY.detail.couldChangeIf(factor, formatValueWithUnit(ft.flip_value, ft.unit))
 }
 
 // ─── Main mapper ─────────────────────────────────────────────────────────────
@@ -138,7 +142,10 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
   )
 
   const recommendedId = recommendation.recommendedOption?.id ?? null
-  const flipThresholds = recommendation.flipThresholds ?? []
+  // Pre-filter once: resolvable thresholds only (shared across every row).
+  const usableFlips = (recommendation.flipThresholds ?? []).filter(
+    (ft) => ft.flip_value != null,
+  )
 
   // Rows in allOptions[] presentation order — the same order for every lens,
   // so numbering is stable across lens switches (asserted in tests).
@@ -146,14 +153,13 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
     const goalValue = o.goalProbability ?? null
     const centre = outcomeCentre(o)
     const why = recommendation.storyHeadlines?.[o.id]
-    const couldChangeIf = couldChangeIfLine(o, o.id === recommendedId, flipThresholds)
+    const couldChangeIf = couldChangeIfLine(o, o.id === recommendedId, usableFlips)
     const winChance =
       typeof o.winProbability === 'number'
         ? HERO_COPY.detail.winChance(
             formatProbabilityWithResolution(o.winProbability, o.nValidSamples),
           )
         : undefined
-    const detail = { why, couldChangeIf, winChance }
     return {
       id: o.id,
       index: i + 1,
@@ -174,8 +180,7 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
             ? formatThreshold(centre, outcomeUnit, outcomeUnitSymbol, isNormalised)
             : HERO_COPY.readout.missing,
       },
-      detail,
-      hasDetail: Boolean(why || couldChangeIf || winChance),
+      detail: { why, couldChangeIf, winChance },
     }
   })
 
@@ -217,12 +222,13 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
     headline = hasConstraints
       ? HERO_COPY.headline.goalWithLimits(safeLabel(headlineRow))
       : HERO_COPY.headline.goalOnly(safeLabel(headlineRow))
-  } else if (headlineRow) {
-    headline = HERO_COPY.headline.outcomeOnly(safeLabel(headlineRow))
-  } else if (outcomeLeaderRow) {
-    headline = HERO_COPY.headline.outcomeOnly(safeLabel(outcomeLeaderRow))
   } else {
-    headline = HERO_COPY.headline.noLeader
+    // No goal basis: name whichever leader exists with the weaker
+    // "looks strongest" claim, or claim no leader at all.
+    const leader = headlineRow ?? outcomeLeaderRow
+    headline = leader
+      ? HERO_COPY.headline.outcomeOnly(safeLabel(leader))
+      : HERO_COPY.headline.noLeader
   }
 
   // Tension subline: goal-fit leader vs strongest expected outcome. Display
@@ -301,7 +307,6 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
         ? formatThreshold(targetValue, outcomeUnit, outcomeUnitSymbol, false)
         : null,
     mainReason,
-    isSingleOption: rows.length === 1,
   }
   return model
 }

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -1,0 +1,93 @@
+/**
+ * Analysis hero panel — ALL UI-authored copy.
+ *
+ * British English, sentence case, no all-caps, no em dashes. Scanned by
+ * __tests__/copyHygiene.spec.tsx against the canonical glossary banned-term
+ * list, so every string here must stay glossary-safe. Producer-supplied text
+ * (story headlines, option labels in row titles) is rendered verbatim
+ * elsewhere and is deliberately NOT routed through this file.
+ *
+ * Option/factor labels interpolated into these templates are gated with
+ * safeInterpolatedLabel first (generated copy only — user data is never
+ * rewritten where it appears verbatim).
+ */
+
+export const HERO_COPY = {
+  panelAria: 'Analysis summary',
+  tablistAria: 'Results lens',
+
+  lensLabel: {
+    goal: 'Goal fit',
+    outcome: 'Likely outcome',
+  } as const,
+
+  headline: {
+    goalWithLimits: (label: string) => `${label} best meets the goal and your limits.`,
+    goalOnly: (label: string) => `${label} best fits your goal.`,
+    outcomeOnly: (label: string) => `${label} currently looks strongest.`,
+    singleOption: (label: string) => `${label} is your only option.`,
+    noLeader: 'Here is how your options compare.',
+  },
+
+  subline: {
+    diverged: (outcomeLabel: string, goalLabel: string, withLimits: boolean) =>
+      `${outcomeLabel} has the highest expected outcome, but ${goalLabel} ${
+        withLimits ? 'best meets the goal and your limits' : 'best fits your goal'
+      }.`,
+    aligned: (label: string) => `${label} also has the strongest expected outcome.`,
+  },
+
+  /** Fallback when a label cannot be safely interpolated into generated copy. */
+  labelFallback: 'This option',
+  factorFallback: 'a key assumption',
+
+  axis: {
+    goalWithLimits: { left: '0%', mid: 'chance of meeting goal and limits', right: '100%' },
+    goalOnly: { left: '0%', mid: 'chance of hitting goal', right: '100%' },
+    outcome: { left: 'lower', mid: 'expected outcome', right: 'higher' },
+  } as const,
+
+  caption: {
+    goalWithLimits: 'Each bar is the chance that option meets your goal and limits together.',
+    goalOnly: 'Each bar is the chance that option hits your goal.',
+    outcome: 'Bars show the realistic range of outcomes. Where ranges overlap, treat the order as unsettled.',
+    outcomeTarget: (target: string) => `The dashed line marks your target of ${target}.`,
+  },
+
+  readout: {
+    goalSuffix: 'fit',
+    missing: '—',
+  },
+
+  detail: {
+    whyLabel: 'Why',
+    couldChangeIfLabel: 'Could change if',
+    couldChangeIf: (factor: string, value: string) => `${factor} crosses ${value}.`,
+    winChance: (formatted: string) => `${formatted} chance it is the strongest option overall.`,
+  },
+
+  footer: {
+    mainReason: (factor: string) => `Main reason: ${factor} has the strongest effect on this result.`,
+    focusNext: 'Focus next: review the top actions below.',
+    focusNextAria: 'Scroll to the actions panel below',
+    rerun: 'Re-run analysis',
+  },
+
+  status: {
+    partial: {
+      headline: 'Some analysis steps did not complete',
+      body: 'Results are partial. Run the analysis again to see the full picture here.',
+    },
+    failed: {
+      headline: 'The analysis did not complete',
+      body: 'Run the analysis again to see results here.',
+    },
+    blocked: {
+      headline: 'The analysis could not run',
+      body: 'Resolve the items flagged on the canvas, then run the analysis again.',
+    },
+  },
+
+  /** Screen-reader-only cue so the leader is perceivable without colour. */
+  srLeader: 'Leads on this view',
+} as const

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -57,6 +57,8 @@ export const HERO_COPY = {
   readout: {
     goalSuffix: 'fit',
     missing: '—',
+    /** Mirrors OptionCards' sub-1% display-honesty affordance (UI-SEM-057). */
+    subOnePercent: '< 1%',
   },
 
   detail: {

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -56,6 +56,12 @@ export const HERO_COPY = {
 
   readout: {
     goalSuffix: 'fit',
+    /**
+     * Missing-value placeholder GLYPH — deliberately an em dash, matching
+     * the app-wide convention (src/lib/format.ts `nullPlaceholder: '—'`).
+     * The module's no-em-dash rule applies to prose copy, not this token;
+     * copyHygiene.spec excludes it explicitly for the same reason.
+     */
     missing: '—',
     /** Mirrors OptionCards' sub-1% display-honesty affordance (UI-SEM-057). */
     subOnePercent: '< 1%',

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -76,6 +76,16 @@ export const HERO_COPY = {
 
   footer: {
     mainReason: (factor: string) => `Main reason: ${factor} has the strongest effect on this result.`,
+    /**
+     * Focus-next reconciliation (review-locked): the coaching panel's rows
+     * are composed POSITIONALLY (buildFocusRows: server rows in received
+     * order, then static hygiene rows — "NOT meaning-based ranking"),
+     * while vm.topAction derives from selectHinge (fragile-edge/VOI
+     * priority) — a different signal. The hero therefore names NO specific
+     * action: this neutral line points at the panel as a whole (the scroll
+     * affordance targets the panel container, never a row), so it can
+     * never disagree with whatever the panel's actual top row is.
+     */
     focusNext: 'Focus next: review the top actions below.',
     focusNextAria: 'Scroll to the actions panel below',
     rerun: 'Re-run analysis',

--- a/src/components/results/analysis-hero/heroTypes.ts
+++ b/src/components/results/analysis-hero/heroTypes.ts
@@ -1,0 +1,110 @@
+/**
+ * Analysis hero panel — internal display types.
+ *
+ * These are UI view-model shapes only. Every value they carry is copied
+ * (or formatted for display) from the adapted Results Panel object
+ * (`ResultsSectionDataReturn`) — the hero never computes new quantities,
+ * bands, deltas or thresholds. See buildHeroModel.ts for the mapping rules.
+ */
+
+/**
+ * The two launch lenses. Stability and "What changed" are deliberately NOT
+ * modelled: no per-option producer-supplied robustness label exists (ISL gap)
+ * and no producer-supplied prior-run comparison object exists (PLoT gap).
+ * They unlock upstream, not here.
+ */
+export type HeroLens = 'goal' | 'outcome'
+
+/** Optional, fully-sourced detail lines for one option row. */
+export interface HeroRowDetail {
+  /** Producer story headline (M1 coaching), rendered verbatim. */
+  why?: string
+  /** Generated from producer flip-threshold values only (factor + value). */
+  couldChangeIf?: string
+  /** Formatted producer win probability (display-honesty formatter). */
+  winChance?: string
+}
+
+export interface HeroRowVM {
+  /** Analysed option id (from the adapted results object). */
+  id: string
+  /**
+   * Presentation number (1-based). This is the visible `allOptions[]`
+   * presentation order, NOT graph-node truth — a stable graph index is not
+   * available on the adapted object, and this UI-only task must not add a
+   * graph selector. The number is stable across lens switches because rows
+   * are built once per model, independent of the active lens.
+   */
+  index: number
+  /** Option label for display (encoding notation stripped, rendered as text). */
+  label: string
+  /** Goal-fit lens values (collapsed goalProbability; see buildHeroModel). */
+  goal: {
+    /** Probability 0-1 from the adapted object, or null when absent. */
+    value: number | null
+    /** Formatted readout, '—' when absent. */
+    readout: string
+  }
+  /** Likely-outcome lens values. */
+  outcome: {
+    p10: number | null
+    p90: number | null
+    centre: number | null
+    /** Formatted centre readout, '—' when absent. */
+    readout: string
+  }
+  detail: HeroRowDetail
+  /** True when at least one detail line exists — gates row interactivity. */
+  hasDetail: boolean
+}
+
+/** Interactive chart state — analysis computed with displayable options. */
+export interface HeroChartModel {
+  kind: 'chart'
+  headline: string
+  /** Goal-fit vs strongest-outcome tension line; null when not applicable. */
+  subline: string | null
+  /** Available lenses in display order. Never empty. */
+  lenses: HeroLens[]
+  defaultLens: HeroLens
+  /** True when any option carries constraint analysis — drives copy only. */
+  hasConstraints: boolean
+  rows: HeroRowVM[]
+  /**
+   * Row id highlighted per lens. Goal-fit follows the Results Panel's
+   * recommended option (never an independent argmax); outcome is the highest
+   * existing centre with deterministic first-in-order tie-break.
+   */
+  leaders: Record<HeroLens, string | null>
+  /**
+   * Outcome-axis display domain (layout only — never displayed as data).
+   * Includes the goal threshold ONLY when unit-compatible. Null when the
+   * outcome lens is unavailable.
+   */
+  outcomeDomain: { min: number; max: number } | null
+  /** Goal threshold in outcome units, only when unit-compatible; else null. */
+  targetValue: number | null
+  /** Formatted target for the caption (existing Results Panel formatter). */
+  targetReadout: string | null
+  /** Footer "Main reason" line, or null when no clean driver label exists. */
+  mainReason: string | null
+  isSingleOption: boolean
+}
+
+/** Curated non-chart state for partial / failed / blocked analyses. */
+export interface HeroStatusModel {
+  kind: 'status'
+  variant: 'partial' | 'failed' | 'blocked'
+  headline: string
+  body: string
+}
+
+/**
+ * Nothing to show and the existing tab should stay unchanged
+ * (loading, hook error, or genuinely no analysis yet). Renders null.
+ */
+export interface HeroEmptyModel {
+  kind: 'empty'
+}
+
+export type HeroModel = HeroChartModel | HeroStatusModel | HeroEmptyModel

--- a/src/components/results/analysis-hero/heroTypes.ts
+++ b/src/components/results/analysis-hero/heroTypes.ts
@@ -53,9 +53,8 @@ export interface HeroRowVM {
     /** Formatted centre readout, '—' when absent. */
     readout: string
   }
+  /** Sourced-or-omitted detail lines; an all-empty detail makes the row static. */
   detail: HeroRowDetail
-  /** True when at least one detail line exists — gates row interactivity. */
-  hasDetail: boolean
 }
 
 /** Interactive chart state — analysis computed with displayable options. */
@@ -88,7 +87,6 @@ export interface HeroChartModel {
   targetReadout: string | null
   /** Footer "Main reason" line, or null when no clean driver label exists. */
   mainReason: string | null
-  isSingleOption: boolean
 }
 
 /** Curated non-chart state for partial / failed / blocked analyses. */

--- a/src/components/results/analysis-hero/index.ts
+++ b/src/components/results/analysis-hero/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Analysis hero panel — public surface.
+ *
+ * Only AnalysisHeroContainer is intended for external use, and only by the
+ * ResultsBody mount (see __tests__/inertness.spec.ts).
+ */
+export { AnalysisHeroContainer } from './AnalysisHeroContainer'

--- a/src/components/results/analysis-hero/useAnalysisHero.ts
+++ b/src/components/results/analysis-hero/useAnalysisHero.ts
@@ -1,0 +1,47 @@
+/**
+ * useAnalysisHero — the ONE store/flag-aware file in the analysis-hero
+ * module.
+ *
+ * Receives the SAME adapted object the Results Panel consumes (passed down
+ * from ResultsBody as a prop — no second data path, no fetch, no direct
+ * CEE/PLoT access) and wires the two live concerns the presentational panel
+ * must not own:
+ *   - re-run analysis via the existing useV2Run path (stale Focus-next);
+ *   - whether the coaching panel below is mounted (isFocusNowPanelEnabled),
+ *     which gates the Focus-next scroll affordance so it is never a dead
+ *     link.
+ *
+ * The model is memoised on the data object identity — lens switching and row
+ * disclosure live in the panel as local render state and never re-run this
+ * mapping.
+ */
+import { useCallback, useMemo } from 'react'
+import { useV2Run } from '@/canvas/hooks/useV2Run'
+import { isFocusNowPanelEnabled } from '@/flags'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { buildHeroModel } from './buildHeroModel'
+import type { HeroModel } from './heroTypes'
+
+export interface UseAnalysisHeroReturn {
+  model: HeroModel
+  onRerun: () => void
+  rerunDisabled: boolean
+  focusPanelMounted: boolean
+}
+
+export function useAnalysisHero(data: ResultsSectionDataReturn): UseAnalysisHeroReturn {
+  const { runV2Analysis, isRunning } = useV2Run()
+
+  const model = useMemo(() => buildHeroModel(data), [data])
+
+  const onRerun = useCallback(() => {
+    void runV2Analysis()
+  }, [runV2Analysis])
+
+  return {
+    model,
+    onRerun,
+    rerunDisabled: isRunning,
+    focusPanelMounted: isFocusNowPanelEnabled(),
+  }
+}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -326,6 +326,20 @@ const FLAGS_CONFIG = {
     envKey: 'VITE_FEATURE_ANALYSIS_HERO_COMPARE',
     storageKey: 'feature.analysisHeroCompare',
   },
+  // Analysis hero panel — answer-first lens hero (prototype-v3) mounted ABOVE
+  // the existing hero block on the Analysis tab. Read-only presentation layer
+  // over the adapted Results Panel data (useResultsSectionData) — no second
+  // data path, no UI-computed semantics. See src/components/results/analysis-hero/.
+  //
+  // Rollout: staging-on, production-off. defaultValue stays false (production
+  // safety); staging builds enable it via
+  //   VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"
+  // in netlify.toml [context.staging.environment]. To enable locally:
+  //   localStorage.setItem('feature.analysisHeroPanel', '1')
+  analysisHeroPanel: {
+    envKey: 'VITE_FEATURE_ANALYSIS_HERO_PANEL',
+    storageKey: 'feature.analysisHeroPanel',
+  },
   // AI panel v2 — floating-first Olumi UX.
   // When OFF: existing DraftChat (legacy floating canvas overlay) + standalone
   // OutputsDock render unchanged.
@@ -426,6 +440,7 @@ const flags = {
   deterministicCee: makeFlag(FLAGS_CONFIG.deterministicCee),
   analysisHeroV17: makeFlag(FLAGS_CONFIG.analysisHeroV17),
   analysisHeroCompare: makeFlag(FLAGS_CONFIG.analysisHeroCompare),
+  analysisHeroPanel: makeFlag(FLAGS_CONFIG.analysisHeroPanel),
   focusNowPanel: makeFlag(FLAGS_CONFIG.focusNowPanel),
   aiPanelV2: makeFlag(FLAGS_CONFIG.aiPanelV2),
   v5CanonicalAnalysis: makeFlag(FLAGS_CONFIG.v5CanonicalAnalysis),
@@ -490,6 +505,7 @@ export const isOrchestratorRenderingV2Enabled = flags.orchestratorRenderingV2
 export const isDeterministicCeeEnabled = flags.deterministicCee
 export const isAnalysisHeroV17Enabled = flags.analysisHeroV17
 export const isAnalysisHeroCompareEnabled = flags.analysisHeroCompare
+export const isAnalysisHeroPanelEnabled = flags.analysisHeroPanel
 export const isFocusNowPanelEnabled = flags.focusNowPanel
 export const isAiPanelV2Enabled = flags.aiPanelV2
 export const isV5CanonicalAnalysisEnabled = flags.v5CanonicalAnalysis


### PR DESCRIPTION
# Analysis hero panel — flag-gated, read-only, two-lens launch

Answer-first hero above the existing Analysis-tab hero block, behind `analysisHeroPanel`. Read-only presentation over the same adapted `useResultsSectionData` object the Results Panel consumes — no second fetch, no UI-computed semantics. **Draft pending Paul's staging UI review of placement — do not mark ready-for-review before that.**

## How to view the hero

- **Staging:** merging this PR to `staging` deploys to `staging--olumi.netlify.app` with the hero ON automatically (`VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"` in `netlify.toml` `[context.staging.environment]`). Run an analysis, open the Analysis tab — the hero renders above the existing hero.
- **Any other build (deploy previews, local, production):** the flag defaults OFF. Enable per-browser with `localStorage.setItem('feature.analysisHeroPanel', '1')` and reload. Netlify deploy previews do NOT inherit the staging context, so preview QA needs this override.

## Feature-flag behaviour

| Environment | State | Mechanism |
|---|---|---|
| Production (`main`) | OFF | `defaultValue: false` in `src/flags.ts`; no env var in `[build.environment]` |
| Staging branch deploys | ON | `[context.staging.environment]` in `netlify.toml` (promote to production by adding to `[build.environment]` after sign-off) |
| Deploy previews / local | OFF (override via localStorage) | flag default; kill switch: `localStorage.setItem('feature.analysisHeroPanel', '0')` |

Flag OFF renders the Analysis tab byte-identical to today (regression-tested in `ResultsBody.heroPlacement.spec.tsx`).

## Review item 1 — Focus-next reconciliation: CLOSED (code trace + tests)

**Trace:** the coaching panel composes its rows positionally — `buildFocusRows.ts` puts server rows in received order, then static hygiene rows ("positional composition, NOT meaning-based ranking") — while `vm.topAction` derives from `selectHinge` (fragile-edge/VOI priority, `buildResultsVM.ts`). They are different signals, so the hero deliberately names **no** action: neutral copy ("Focus next: review the top actions below.") whose scroll affordance targets the panel container, never a row. A per-item mismatch is therefore impossible by construction (documented at `heroCopy.ts` `footer.focusNext`).

**Tests (`ResultsBody.heroPlacement.spec.tsx`, `interaction.spec.tsx`):** against the real mounted tree, the hero's focus-next renders the neutral copy, names no coaching row, and scrolls the actual `focus-now-panel` element; with the coaching flag off it degrades to plain text (no button, no dead link); and per the Codex review fix (`14d2c53`), with the flag on but the target element absent (error-boundary case) the panel confirms DOM presence post-commit and degrades to plain text as well — the affordance is asserted to never be an enabled clickable no-op.

## Review item 2 — Target-line/axis-domain guard: CLOSED (tightened + tests)

The guard now requires **both** `isNormalised === false` (outcomes denormalised into the goal node's user units via `goal_threshold_cap` — the same node `goalThreshold`/`goal_threshold_raw` comes from) **and** `outcomeUnit != null` (the shared Results Panel unit convention — the same `outcomeUnit`/`outcomeUnitSymbol` fields `SuccessTargetRow`/`RangeVisualization` format both the threshold and outcome values with — must actually exist). Any uncertainty (`isNormalised` true or undefined, unknown unit) fails closed.

**Tests (`buildHeroModel.spec.ts`):** an incompatible/uncertain threshold is excluded from BOTH the marker rendering and the axis-domain calculation (asserted for `isNormalised: true`, `isNormalised: undefined`, and `outcomeUnit: undefined`); a compatible out-of-range threshold still extends the layout domain.

## Upstream gaps — filed

- #211 — ISL: per-option `robustness_level` / producer stability label → unlocks the Stability lens
- #212 — PLoT: explicit prior-run comparison object → unlocks the What-changed lens
- #213 — Selector: separate goal-alone and joint-goal fields → unlocks the goal-alone marker
- #214 — Producer contract: `alternative_winner_id` on flip thresholds → replaces label-only matching

## Verification

117 tests across the 8 hero/placement spec files, all green; typecheck clean (0 new app-config errors); ESLint clean; DS ratchet Δ+0; CI (Contract Validation) green on every commit, including head `14d2c53`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pDAg5E5qYrXphFBbvyXb1