### PR TITLE
fix(analysis-hero): render the chart for computed runs missing only optional enrichment

### DIFF
--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -293,13 +293,24 @@ describe('buildHeroModel — states', () => {
     expect(m).toMatchObject({ kind: 'status', variant: 'failed' })
   })
 
-  it('renders the partial status state from completeness', () => {
-    const partial: ResultCompleteness = { ...FULL_COMPLETENESS, status: 'partial' }
+  it('renders the CHART (not partial) when completeness is partial but core data is present', () => {
+    // Staging repro: a fully-computed PLoT run whose OPTIONAL enrichment is
+    // absent (e.g. the decision review is skipped with coaching autofire off)
+    // reads `completeness.status === 'partial'`. The hero consumes none of
+    // that enrichment, so it must render its answer-first chart, NOT the
+    // "some steps did not complete" card. Completeness must not gate the chart.
+    const partial: ResultCompleteness = {
+      ...FULL_COMPLETENESS,
+      status: 'partial',
+      missing: ['decision_review'],
+      reasons: ['decision_review_unavailable'],
+    } as ResultCompleteness
     const m = buildHeroModel(makeHeroData({ completeness: partial }))
-    expect(m).toMatchObject({ kind: 'status', variant: 'partial' })
+    expect(m.kind).toBe('chart')
+    expect((m as HeroChartModel).lenses).toEqual(['goal', 'outcome'])
   })
 
-  it('renders the partial status state from analysisStatus', () => {
+  it('renders the partial status state from a PLoT-reported partial analysisStatus', () => {
     const m = buildHeroModel(makeHeroData({ recommendation: { analysisStatus: 'partial' } }))
     expect(m).toMatchObject({ kind: 'status', variant: 'partial' })
   })

--- a/src/components/results/analysis-hero/__tests__/content.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/content.spec.tsx
@@ -8,7 +8,7 @@ import { render, screen, fireEvent, within } from '@testing-library/react'
 import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
 import { buildHeroModel } from '../buildHeroModel'
 import type { HeroChartModel, HeroStatusModel } from '../heroTypes'
-import { FULL_COMPLETENESS, makeHeroData, makeOption, OPTION_A, OPTION_B } from '../__fixtures__/hero.fixtures'
+import { makeHeroData, makeOption, OPTION_A, OPTION_B } from '../__fixtures__/hero.fixtures'
 
 function chartModel(data = makeHeroData()): HeroChartModel {
   const model = buildHeroModel(data)
@@ -137,12 +137,14 @@ describe('AnalysisHeroPanel — content', () => {
   it.each(['partial', 'failed', 'blocked'] as const)(
     'renders the curated %s non-chart state (no rows, no fabricated numbers)',
     (variant) => {
+      // Non-chart states are driven by the real analysis lifecycle
+      // (analysisStatus / hook error), never by completeness enrichment.
       const data =
         variant === 'blocked'
           ? makeHeroData({ recommendation: { analysisStatus: 'blocked' } })
           : variant === 'failed'
-            ? makeHeroData({ isError: true, completeness: { ...FULL_COMPLETENESS, status: 'failed' } })
-            : makeHeroData({ completeness: { ...FULL_COMPLETENESS, status: 'partial' } })
+            ? makeHeroData({ isError: true })
+            : makeHeroData({ recommendation: { analysisStatus: 'partial' } })
       const model = buildHeroModel(data)
       expect(model.kind).toBe('status')
       renderPanel(model as HeroStatusModel)

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -144,20 +144,24 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
   // never throw — when a caller supplies less than the type promises.
   if (!data?.recommendation?.allOptions) return { kind: 'empty' }
   const { recommendation, drivers, isLoading, isError } = data
-  const completenessStatus = data.completeness?.status
 
-  // Non-chart states first. `completeness` consults SOURCE fields (P0 V5
-  // golden-path repair) and reads 'full' before any run, so these branches
-  // cannot fire on a fresh canvas. Curated copy only — statusReason may carry
-  // internal identifiers, so it is deliberately not interpolated.
+  // Non-chart states fire ONLY on the real analysis lifecycle — loading, a
+  // hook error, or a PLoT-reported blocked/failed/partial run (via
+  // `recommendation.analysisStatus`). They deliberately do NOT key off
+  // `completeness.status`: that verdict turns 'partial' when OPTIONAL
+  // enrichment is absent (e.g. the CEE decision review is skipped when
+  // coaching autofire is off, as on staging — `decision_review_unavailable`),
+  // which has nothing to do with whether the hero can draw its chart. The
+  // hero consumes none of that enrichment; its own per-field gating (lens
+  // availability, "—" readouts, omitted detail lines, empty-when-nothing-
+  // displayable) already degrades honestly. Gating the whole chart on
+  // completeness would show "some steps did not complete" over a perfectly
+  // computed run — the exact false-partial this avoids. Curated copy only —
+  // statusReason may carry internal identifiers, so it is not interpolated.
   if (isLoading) return { kind: 'empty' }
   if (recommendation.analysisStatus === 'blocked') return statusModel('blocked')
-  if (isError || recommendation.analysisStatus === 'failed' || completenessStatus === 'failed') {
-    return statusModel('failed')
-  }
-  if (recommendation.analysisStatus === 'partial' || completenessStatus === 'partial') {
-    return statusModel('partial')
-  }
+  if (isError || recommendation.analysisStatus === 'failed') return statusModel('failed')
+  if (recommendation.analysisStatus === 'partial') return statusModel('partial')
 
   const options = recommendation.allOptions
   // No analysis yet (the hook's pre-run default) — the tab stays unchanged.


### PR DESCRIPTION
# Analysis hero — stop hiding the chart behind optional enrichment

Follow-up to #210, found during staging manual testing. **Single-commit fix (`e35b75d`); hero-only, no shared files, no existing panels touched.**

## The bug (repro'd on staging)

`buildHeroModel` gated the whole hero chart on `completeness.status`. But `useResultCompleteness` returns `partial` whenever an **optional** enrichment is absent — including `decision_review_unavailable`, which happens on every staging run because the CEE decision review is skipped when coaching autofire is off (`v5.decision_review.skipped … reason: "autofire_disabled"`).

Result: a fully-computed PLoT run (`plot_status: "computed"`, leading option, outcomes, goal probability, win probability, stability all present) rendered the **"Some analysis steps did not complete"** card instead of the answer-first chart. In practice the hero **never showed its chart on staging** — it always fell to the false-partial state.

The hero consumes none of that enrichment (no decision review, no robustness, no drivers in the chart itself). Its own per-field gating already degrades honestly — lenses self-omit when their data is absent, readouts show "—", detail lines drop, and it returns empty when nothing is displayable.

## The fix

Non-chart states now fire **only on the real analysis lifecycle** — `isLoading`, hook `isError`, or a PLoT-reported `blocked` / `failed` / `partial` run via `recommendation.analysisStatus` — never on the enrichment-driven `completeness.status`. A computed run missing only optional enrichment renders the chart.

## Tests

- New regression (`buildHeroModel.spec.ts`): a computed run with `completeness.status === 'partial'` + `decision_review` missing now asserts the **chart** renders with both lenses (was: partial card). This is the exact staging scenario.
- Non-chart-state suites (`buildHeroModel.spec.ts`, `content.spec.tsx`) now drive partial/failed via the analysis lifecycle (`analysisStatus` / `isError`) rather than completeness.
- 117 hero/placement tests green; `npm run typecheck` clean; `tsc -p tsconfig.app.json` 0 new errors; DS ratchet Δ+0.

## Scope

Only `src/components/results/analysis-hero/` (mapper + two specs). No change to `useResultsSectionData`, `buildResultsVM`, `completeness`, existing panels, the flag, or `netlify.toml`. Merging this to `staging` redeploys with the hero showing its chart for normal runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pDAg5E5qYrXphFBbvyXb1

---
_Generated by [Claude Code](https://claude.ai/code/session_013pDAg5E5qYrXphFBbvyXb1)_