### PR TITLE
fix(hash): complete __proto__ canonicaliser hardening (draft, do-not-merge)

### DIFF
--- a/src/lib/__tests__/canonical-hash.spec.ts
+++ b/src/lib/__tests__/canonical-hash.spec.ts
@@ -93,6 +93,129 @@ describe('canonicalise', () => {
   })
 })
 
+describe('canonicalise — own __proto__ key hardening', () => {
+  // JSON.parse of wire JSON yields an OWN enumerable `__proto__` key when the
+  // payload contains one. A plain `{}` accumulator silently drops it (the
+  // inherited setter fires instead of defining a property), so two
+  // semantically different payloads would canonicalise identically.
+
+  it('preserves an own __proto__ key through canonicalisation', () => {
+    const input = JSON.parse('{"z":1,"__proto__":{"polluted":true},"a":2}')
+    const result = canonicalise(input) as Record<string, unknown>
+
+    expect(Object.keys(result)).toEqual(['__proto__', 'a', 'z'])
+    expect(canonicalJson(input)).toBe('{"__proto__":{"polluted":true},"a":2,"z":1}')
+  })
+
+  it('preserves __proto__ keys in nested objects', () => {
+    const input = JSON.parse('{"outer":{"__proto__":{"x":1},"b":2}}')
+    expect(canonicalJson(input)).toBe('{"outer":{"__proto__":{"x":1},"b":2}}')
+  })
+
+  it('produces DIFFERENT hashes for payloads differing only in an own __proto__ value', async () => {
+    const a = JSON.parse('{"a":1,"__proto__":{"role":"user"}}')
+    const b = JSON.parse('{"a":1,"__proto__":{"role":"admin"}}')
+    const plain = JSON.parse('{"a":1}')
+
+    expect(computePayloadHashSync(a)).not.toBe(computePayloadHashSync(b))
+    expect(computePayloadHashSync(a)).not.toBe(computePayloadHashSync(plain))
+    expect(computePayloadHashSync(b)).not.toBe(computePayloadHashSync(plain))
+
+    const shaA = await computePayloadHash(a)
+    const shaB = await computePayloadHash(b)
+    const shaPlain = await computePayloadHash(plain)
+    expect(shaA).not.toBe(shaB)
+    expect(shaA).not.toBe(shaPlain)
+    expect(shaB).not.toBe(shaPlain)
+  })
+
+  it('does not pollute Object.prototype when canonicalising a __proto__ payload', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.prototype, 'x')).toBeUndefined()
+
+    canonicalise(JSON.parse('{"__proto__":{"x":1}}'))
+    computePayloadHashSync(JSON.parse('{"__proto__":{"x":1}}'))
+
+    expect(Object.getOwnPropertyDescriptor(Object.prototype, 'x')).toBeUndefined()
+    expect(({} as Record<string, unknown>).x).toBeUndefined()
+    expect(Object.prototype).not.toHaveProperty('x')
+  })
+
+  // Regression contract for the hardening: for every payload WITHOUT an own
+  // __proto__ key, output stays byte-identical to the pre-hardening
+  // implementation. These values were computed against the un-hardened
+  // canonicalise (plain `{}` reduce seed) at origin/staging 11a744c3.
+  it('matches pre-hardening pinned hashes for a corpus of normal payloads', async () => {
+    const corpus: Array<[unknown, string, string, string]> = [
+      // [payload, canonicalJson, computePayloadHashSync, computePayloadHash]
+      [{}, '{}', '5465b82508af', '44136fa355b3'],
+      [[], '[]', '741638a5e8ae', '4f53cda18c2b'],
+      [{ z: 1, a: 2, m: 3 }, '{"a":2,"m":3,"z":1}', 'e03c1909bdc2', 'ebba85cfdc0a'],
+      [
+        { outer: { z: 1, a: 2 }, name: 'test' },
+        '{"name":"test","outer":{"a":2,"z":1}}',
+        '9252dc2fda08',
+        '08b91d33cd40',
+      ],
+      [{ a: 1, b: undefined, c: null }, '{"a":1,"c":null}', '6f17e2d363fa', 'b54d39aebdb3'],
+      [
+        { arr: [3, 1, 2], items: [{ z: 1, a: 2 }, { b: 3 }] },
+        '{"arr":[3,1,2],"items":[{"a":2,"z":1},{"b":3}]}',
+        '487d7f233419',
+        '4e5eaad92e87',
+      ],
+      [
+        { mixed: [1, 'two', null, { three: 3 }, [4, 5]] },
+        '{"mixed":[1,"two",null,{"three":3},[4,5]]}',
+        '9b6f7cbc450c',
+        '8650d1a6945b',
+      ],
+      [
+        { emoji: '🚀', chinese: '中文', arabic: 'العربية' },
+        '{"arabic":"العربية","chinese":"中文","emoji":"🚀"}',
+        '27e6de35adb8',
+        '7874b8eaa3d9',
+      ],
+      [{ yes: true, no: false }, '{"no":false,"yes":true}', '2966a54aa14c', '80a5e568f155'],
+      [
+        { at: new Date('2026-07-05T00:00:00.000Z') },
+        '{"at":"2026-07-05T00:00:00.000Z"}',
+        '041848cc35f8',
+        'fa5d548ded3f',
+      ],
+      [
+        new Map<string, number>([
+          ['b', 2],
+          ['a', 1],
+        ]),
+        '{"__type":"Map","entries":[["a",1],["b",2]]}',
+        'aef3871d16e2',
+        'a8403598e06b',
+      ],
+      [new Set([3, 1, 2]), '{"__type":"Set","items":[1,2,3]}', '0f0fca119c1f', '4c2eb768a166'],
+      [
+        {
+          nodes: [
+            { id: '1', type: 'option', data: { label: 'Test' } },
+            { id: '2', type: 'factor', data: { label: 'Factor' } },
+          ],
+          edges: [{ source: '1', target: '2', weight: 0.8 }],
+          options: { seed: 42, mode: 'standard' },
+        },
+        '{"edges":[{"source":"1","target":"2","weight":0.8}],"nodes":[{"data":{"label":"Test"},"id":"1","type":"option"},{"data":{"label":"Factor"},"id":"2","type":"factor"}],"options":{"mode":"standard","seed":42}}',
+        'cbb3545c6f05',
+        '2425eb04c9fe',
+      ],
+      [[42, 's', null, true], '[42,"s",null,true]', '63230847654a', '81e2714969f2'],
+    ]
+
+    for (const [payload, expectedJson, expectedSync, expectedSha] of corpus) {
+      expect(canonicalJson(payload)).toBe(expectedJson)
+      expect(computePayloadHashSync(payload)).toBe(expectedSync)
+      expect(await computePayloadHash(payload)).toBe(expectedSha)
+    }
+  })
+})
+
 describe('canonicalJson', () => {
   it('produces sorted JSON for simple object', () => {
     const input = { z: 1, a: 2, m: 3 }

--- a/src/lib/canonical-hash.ts
+++ b/src/lib/canonical-hash.ts
@@ -80,7 +80,18 @@ export function canonicalise(value: unknown): unknown {
       return { __type: 'Error', name: value.name, message: value.message }
     }
 
-    // Plain object — sort keys, omit undefined, canonicalise values
+    // Plain object — sort keys, omit undefined, canonicalise values.
+    //
+    // The accumulator is a null-prototype object (`Object.create(null)`), NOT
+    // a plain `{}` — mirroring CEE's hardened canonicalizeJson/stableStringify.
+    // `JSON.parse` of wire JSON yields an OWN enumerable `__proto__` key when
+    // the payload contains one, and `Object.keys` enumerates it; on a plain
+    // object `acc['__proto__'] = …` hits the inherited accessor's setter and
+    // the key silently vanishes, so two payloads differing only in `__proto__`
+    // would hash identically (a hash collision). A null-prototype accumulator
+    // has no such setter, so `__proto__` round-trips as a normal own property.
+    // Output is byte-identical to the previous behaviour for every payload
+    // without an own `__proto__` key.
     const obj = value as Record<string, unknown>
     const sortedKeys = Object.keys(obj).sort()
 
@@ -91,7 +102,7 @@ export function canonicalise(value: unknown): unknown {
         acc[key] = canonicalise(v)
       }
       return acc
-    }, {})
+    }, Object.create(null) as Record<string, unknown>)
   }
 
   // Primitives (string, number, boolean) — return as-is


### PR DESCRIPTION
**Do not merge — review-only draft.** Completes backlog item B (UI half); pairs with the olumi-assistants-service branch of the same name.

**Problem.** `canonicalise()` (src/lib/canonical-hash.ts) — the UI mirror of CEE's `canonicalizeJson`, feeding `computePayloadHash`/`computePayloadHashSync` and the `x-olumi-payload-hash` cross-service tracing header — rebuilt objects into a plain `{}` reduce seed. An own `__proto__` key parsed from wire JSON silently vanishes, so two different payloads hash identically.

**Fix.** Same null-prototype-accumulator hardening as CEE (`Object.create(null)` reduce seed). No change to which fields any hash includes — `generateGraphHash` untouched (label divergence is a separate tracked item). package.json/vendor/lockfiles untouched (concurrent schemas re-vendor lane).

**Proof.** Same 4-shape suite as CEE: `__proto__` survival (top-level + nested), hash divergence for `__proto__`-only differences (both sync and SHA paths), 14-payload pinned corpus byte-identical to the un-hardened implementation at base `11a744c3` (incl. Date/Map/Set special types), no prototype pollution.

**Gates.** canonical-hash spec 37/37 · src/lib suites 1,246/0 · `pnpm typecheck` clean · lint clean · `scripts/validate-prepush.sh` all checks pass · `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)