### PR TITLE
Lane UI-R3: truth rendering — coaching/review_card blocks, factor influence, warning surfacing

### DIFF
--- a/docs/lanes/lane9-truth-rendering.md
+++ b/docs/lanes/lane9-truth-rendering.md
@@ -1,0 +1,57 @@
+# Lane UI-R3 — truth rendering (branch `claude-lane9/truth-rendering`)
+
+**Date:** 2026-07-07 · **Base:** `origin/staging` @ `bd247d3a` · **Repo:** DecisionGuideAI (writes confined here)
+**Scope:** roadmap 2.2 slice-1 (Track C, D-5 approved), 1.7, 1.12 — Paul-approved, accelerated.
+**Doctrine:** UI renders, never invents; producers own semantics. Wording surfaces tagged `provisional_doctrine_v0`. All boundary-adjacent changes ADDITIVE.
+
+## Commits
+
+| Commit | Feature |
+|---|---|
+| `f9b76330` | B (1.7) factor influence passthrough + C (1.12) warning-severity surfacing |
+| `f7709fbc` | A (2.2 slice 1) render 0.13.x `coaching` + `review_card` blocks |
+
+## A — Render coaching + review_card blocks (Track C slice 1)
+
+**Registry/dispatch identified:** parser-side `PHASE3_TOLERATED_BLOCK_TYPES` + `LEGACY_SCHEMA_KNOWN_BLOCK_TYPES` (`src/v5/responseParser.ts`) divert Phase 3 types into the `__additive__` sidecar pre-validation; render dispatch = `mapV5Blocks` → `composePhase3BridgedBlocks` (`useConversation.ts`) → `InlineBlocks` `BlockRenderer`. The parser is UNCHANGED: truly-unknown types keep counting (`unknown_block_type_dropped_pre_validation`).
+
+**What landed:**
+- Typed conversation blocks `v5_review_card` / `v5_coaching` (`src/canvas/conversation/types.ts`) mirroring the vendored 0.13.1 Zod shapes exactly: title, body, severity/card_kind (review) · coaching_kind/source (coaching), target_refs `{id,label,kind}`, priority_rank, freshness, optional action_intent/action_label.
+- Adapters `src/v5/phase3TypedBlocks.ts`: read EXACTLY the typed fields; unknown subfields ignored at every depth; fail-closed → `null` on missing/mistyped required render-relevant fields. Schema-declared metadata (`created_at`, `signal_id`, …) deliberately NOT required — the live staging capture (`cee-response-b82c89dd-trimmed.json`) omits `created_at`, and a producer block must not be suppressed over metadata the UI never shows.
+- Renderers `src/v5/blocks/V5ReviewCardBlock.tsx` / `V5CoachingBlock.tsx` in the existing V5 block idiom (bg-panel card, border via opacity, Lucide icons). Severity drives the visual channel only; card_kind/coaching_kind/freshness/block_id ride `data-*` attributes, never copy. `action_label` renders as a display-only outlined pill (see follow-ups).
+- Bridge (`composePhase3BridgedBlocks`): typed-first — ALL schema-valid coaching/review cards render, producer `priority_rank` ascending (no new ranking invented), deduped by `block_id`, NOT gated on the run_analysis fact (CEE owns emission; coaching legitimately arrives on draft turns). Legacy-shaped review cards keep the ORIGINAL fact-gated top-1 fallback byte-for-byte (`phase3ReviewCardBridge.spec.ts` passes unchanged).
+- Fail-closed counting via `droppedContentCounter` (new source `phase3_block_bridge`): malformed coaching/review_card → `malformed_phase3_block_suppressed`; evidence/exercise → `no_renderer_for_block_type`; unsurfaced legacy cards → `legacy_review_card_suppressed`. Counting never alters composition.
+
+**Superseded test contract (deliberate):** `phase3ReviewCardBridge.liveFixture.spec.ts` previously locked "top-1 legacy review_card, coaching never surfaces". Its fixture blocks are REAL 0.13.x shapes, so they now render via the typed path; the spec was updated to the approved slice-1 contract. The legacy fallback contract remains locked by the untouched unit spec (its fixtures are genuinely legacy-shaped).
+
+## B — Factor-card influence rendering (1.7)
+
+`mapV5AnalysisToReport` narrowed `factor_sensitivity` to `{factor_id, factor_label, sensitivity, direction}`, dropping `influence_score` before the store. Now `influence_score` / `influence_rank` / `zero_reason` pass through additively (verbatim, no defaults, omitted when absent) → `normalizeFactorSensitivity` → `DriverItem`. The existing DriversSection "Influence" column (`driver.influenceScore ?? normalisedInfluence`) therefore now renders the PRODUCER's influence on the V5 path instead of UI-normalised sensitivity (provisional_doctrine_v0: influence ≠ sensitivity; user-facing copy in DriversSection is already "Influence"/"influence", never "sensitive").
+
+Material behaviour fix proven by test: the pinned factor in the live bundle (`fac_marketing_expertise`, `influence_score` 1, `sensitivity_score` 0, `zero_reason` `intervention_override`) was previously dropped by the zero-impact filter on the V5 path; it now stays visible with its influence bar, and its only explanatory copy is the existing zero-reason line "Directly controlled by your options" (no sensitivity-flavoured copy; elasticity copy is gated on `rawElasticity > 0.001`).
+
+## C — Warning surfacing (1.12)
+
+`enrichment.inference_warnings` now passes through the V5 mapper verbatim onto the widened report; the selector keeps producer `severity`; new `InferenceWarningStrip` (`src/components/results/InferenceWarningStrip.tsx`) mounts in `ResultsBody` directly below `AnalysisFreshnessNotice` (same visual idiom). Renders ONLY `severity === 'warning'` entries; copy = producer `message` verbatim; info-severity stays hidden; no message → nothing (no fabricated copy from `code`); renders nothing when empty. Note: entries without a severity are NOT promoted; severities other than `warning` are out of this brief's scope and stay off this strip.
+
+Cross-lane sequencing note: the strip is generic over the EXISTING `inference_warnings` field (present in the captured staging bundle); no code-specific handling of `CONSTRAINT_TARGET_UNRELIABLE` was added — it is only the fixture example of a warning-severity value.
+
+## Tests & verification
+
+Fixtures: real captured shapes from `~/Downloads/olumi-debug-45c9b625-20260707.json` → committed as `src/v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json` (real factor ids/influence values/warning shapes; one synthetic `CONSTRAINT_TARGET_UNRELIABLE` warning-severity entry appended per producer-documented shape — see fixture `_provenance`). Feature A additionally uses the pre-existing live staging fixture `cee-response-b82c89dd-trimmed.json` (real 0.13.x coaching/review cards).
+
+- **RED→GREEN (B+C):** with mapper/selector changes stashed, the new specs fail 6; restored, 15/15 pass (`mapV5AnalysisToReport.influence-warnings.spec.ts`, `influence-warnings.wire-to-selector.spec.tsx`, `InferenceWarningStrip.spec.tsx`).
+- **RED→GREEN (A):** with the bridge change stashed, `phase3TypedBridge.spec.ts` fails 9/10; restored, 82/82 pass across bridge/adapters/renderers/mapV5Blocks/live-fixture suites.
+- **Regression sweep:** 1278 tests across 106 files (lib + parser dropped-content + InlineBlocks DS v5) pass; parser tolerance, counter, block-renderer, blockAdapter/blockSchemaAlignment suites pass (86/86).
+- **Typecheck:** `pnpm run typecheck` (tsconfig.ci) clean; `npx tsc -p tsconfig.app.json --noEmit` error count 2331 == clean-baseline 2331 (measured via stash on the fresh worktree).
+- **Lint (touched files):** 0 errors; 13 warnings, all pre-existing (console statements / exhaustive-deps in untouched regions).
+
+### Pre-existing failures NOT introduced by this lane (verified identical with changes stashed)
+- `ResultsBody.heroPlacement.spec.tsx`: 3 failures on the clean `bd247d3a` tree.
+- `src/canvas/conversation/__tests__` broad-dir run: environment-dependent failures (e.g. `analysisInputsWiring`, `aiPanelTranche1`, `conversation-flow`: 21 failures) — identical counts with and without this lane's changes. Cause: local env — suites importing `src/lib/supabase.ts` need `.env.local` (copied from the main checkout, gitignored, NOT committed), while that same env flips flag-dependent expectations in other suites. CI with its own env remains the authoritative gate.
+
+## Follow-ups (recorded, not done)
+1. Wire `action_intent`/`action_label` on typed Phase 3 blocks to the existing chip/turn dispatch (`ACTION_TO_TURN_TYPE`) — display-only pill this slice; next round.
+2. Evidence/exercise renderers (currently counted `no_renderer_for_block_type`).
+3. Consider surfacing `influence_rank` visually (currently typed + plumbed to `DriverItem.influenceRank`, not rendered; ordering remains rank-by-elasticity as before — changing driver ordering was out of additive scope).
+4. Reload-persistence of rendered Phase 3 blocks (thread hydration path) — Track C acceptance item, separate slice.

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -45,6 +45,8 @@ import { V5GraphPatchBlock } from '../../v5/blocks/V5GraphPatchBlock'
 import { V5ExplanationBlock } from '../../v5/blocks/V5ExplanationBlock'
 import { V5ComparisonBlock } from '../../v5/blocks/V5ComparisonBlock'
 import { V5FlipAnalysisBlock } from '../../v5/blocks/V5FlipAnalysisBlock'
+import { V5ReviewCardBlock } from '../../v5/blocks/V5ReviewCardBlock'
+import { V5CoachingBlock } from '../../v5/blocks/V5CoachingBlock'
 import { V5UnsupportedBlock } from '../../v5/blocks/V5UnsupportedBlock'
 import { safeRichText, plainTextPreview } from '../utils/safeRichText'
 import { isOrchestratorRenderingV2Enabled } from '../../flags'
@@ -83,6 +85,11 @@ function resolveBlockBadgeDotClass(block: ConversationBlock): string | null {
     case 'flip_analysis': return styles.blockBadgeDotDanger
     case 'proposal': return styles.blockBadgeDotGoal
     case 'exercise': return styles.blockBadgeDotInfo
+    // Track C slice 1: typed Phase 3 blocks — severity drives the dot colour
+    // for review cards (visual channel only); coaching is always info.
+    case 'v5_review_card':
+      return block.severity === 'info' ? styles.blockBadgeDotInfo : styles.blockBadgeDotDanger
+    case 'v5_coaching': return styles.blockBadgeDotInfo
     default: return null
   }
 }
@@ -285,6 +292,14 @@ function BlockRenderer({
 
     case 'v5_flip_analysis':
       return <V5FlipAnalysisBlock block={block} />
+
+    // Track C slice 1 (D-5): 0.13.x-typed Phase 3 blocks. All copy is
+    // producer-owned and rendered verbatim (provisional_doctrine_v0).
+    case 'v5_review_card':
+      return <V5ReviewCardBlock block={block} />
+
+    case 'v5_coaching':
+      return <V5CoachingBlock block={block} />
 
     case 'v5_unsupported':
       return <V5UnsupportedBlock block={block} />

--- a/src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts
+++ b/src/canvas/conversation/__tests__/phase3ReviewCardBridge.liveFixture.spec.ts
@@ -1,11 +1,21 @@
 /**
- * PR #175 bridge — end-to-end wiring against the live CEE staging fixture
+ * Phase 3 bridge — end-to-end wiring against the live CEE staging fixture
  * (debug bundle b82c89dd).
  *
  * Complements `phase3ReviewCardBridge.spec.ts` (unit tests on the composition
- * function) and `src/v5/__tests__/responseParser.actionTypeAlias.spec.ts`
- * (parser-side assertions). This spec proves the parse→extract→bridge chain
- * works end-to-end on the trimmed live fixture.
+ * function; legacy-shape fallback contract) and
+ * `src/v5/__tests__/responseParser.actionTypeAlias.spec.ts` (parser-side
+ * assertions). This spec proves the parse→extract→bridge chain works
+ * end-to-end on the trimmed live fixture.
+ *
+ * UPDATED for Track C slice 1 (Lane UI-R3, approved D-5): the fixture's
+ * review_card and coaching blocks are REAL 0.13.x-shaped payloads, so they
+ * now render through the TYPED path (v5_review_card / v5_coaching — all
+ * copy producer-verbatim) instead of the superseded legacy top-1 bridge.
+ * The pre-slice-1 expectations ("exactly one legacy review_card"; "coaching
+ * never surfaces") are superseded by this approved feature; the legacy
+ * fallback contract remains locked by phase3ReviewCardBridge.spec.ts, whose
+ * fixtures are genuinely legacy-shaped.
  *
  * Lives in `src/canvas/conversation/__tests__/` rather than in `src/v5/__tests__/`
  * deliberately. Importing `useConversation.ts` (where the bridge composition
@@ -23,7 +33,7 @@ import {
   composePhase3BridgedBlocks,
   adaptPhase3ReviewCard,
 } from '../useConversation'
-import type { ConversationBlock } from '../types'
+import type { ConversationBlock, V5CoachingBlock, V5ReviewCardBlock } from '../types'
 
 const FIXTURE_PATH = resolve(
   __dirname,
@@ -48,20 +58,20 @@ const V5_ANALYSIS_RESULT_BLOCK: ConversationBlock = {
   win_probabilities: { 'Hire One Tech Lead': 0.94325 },
 }
 
-describe('PR #175 bridge — live fixture (cee-response-b82c89dd)', () => {
-  it('parse → extract → bridge appends the highest-priority review_card after v5_analysis_result', async () => {
+describe('Track C slice 1 — live fixture (cee-response-b82c89dd), typed Phase 3 rendering', () => {
+  it('parse → extract → bridge renders ALL 0.13.x review_card + coaching blocks as typed blocks, mapped blocks first', async () => {
     // Full live chain. The live response carries 4 review_card top-level
     // blocks (priority_rank 71-74) and 6 coaching blocks (priority_rank
-    // 101-202), all with non-empty body content. The bridge picks the
-    // lowest-priority_rank (= highest priority) review_card and appends
-    // it after the V5 mapped blocks.
+    // 101-202), all 0.13.x-shaped with non-empty producer copy. Slice 1
+    // renders every schema-valid block; ordering is producer-owned
+    // (priority_rank ascending).
     const result = await parseV5Response(makeResponse(loadFixture()))
     expect(result.kind).toBe('response')
     if (result.kind !== 'response') return
 
     const phase3 = extractPhase3FromV5Response(result.response)
-    const reviewCards = phase3.rawBlocks.filter((b) => b.type === 'review_card')
-    expect(reviewCards).toHaveLength(4)
+    expect(phase3.rawBlocks.filter((b) => b.type === 'review_card')).toHaveLength(4)
+    expect(phase3.rawBlocks.filter((b) => b.type === 'coaching')).toHaveLength(6)
 
     const finalBlocks = composePhase3BridgedBlocks(
       true,
@@ -69,44 +79,71 @@ describe('PR #175 bridge — live fixture (cee-response-b82c89dd)', () => {
       [V5_ANALYSIS_RESULT_BLOCK],
     )
 
-    // Order: v5_analysis_result first (preserved), review_card appended.
-    expect(finalBlocks.map((b) => b.type)).toEqual([
-      'v5_analysis_result',
-      'review_card',
-    ])
+    // Mapped blocks stay first; every typed Phase 3 block follows.
+    expect(finalBlocks[0]?.type).toBe('v5_analysis_result')
+    const typedReviewCards = finalBlocks.filter(
+      (b): b is V5ReviewCardBlock => b.type === 'v5_review_card',
+    )
+    const typedCoaching = finalBlocks.filter(
+      (b): b is V5CoachingBlock => b.type === 'v5_coaching',
+    )
+    expect(typedReviewCards).toHaveLength(4)
+    expect(typedCoaching).toHaveLength(6)
+    // No legacy-adapted review_card is emitted for 0.13.x-shaped cards.
+    expect(finalBlocks.filter((b) => b.type === 'review_card')).toHaveLength(0)
 
-    // The bridge selects priority_rank 71 (lowest = highest priority) and
-    // adapts the verbatim CEE shape to the typed ReviewCardBlock.
-    const card = finalBlocks[1] as {
-      type: 'review_card'
-      title: string
-      body: string
-      variant: 'info' | 'alert'
-    }
-    expect(card.title).toBe('A load-bearing assumption')
-    expect(card.body).toBe(
+    // Producer-owned ordering: priority_rank ascending across the typed run.
+    const typedRanks = finalBlocks
+      .filter(
+        (b): b is V5ReviewCardBlock | V5CoachingBlock =>
+          b.type === 'v5_review_card' || b.type === 'v5_coaching',
+      )
+      .map((b) => b.priority_rank)
+    expect(typedRanks).toEqual([...typedRanks].sort((a, b) => a - b))
+
+    // Highest-priority card first, copy verbatim from the live payload.
+    const top = typedReviewCards[0]
+    expect(top.priority_rank).toBe(71)
+    expect(top.title).toBe('A load-bearing assumption')
+    expect(top.body).toBe(
       'The relationship between Technical Leadership Capacity and overall throughput remains stable.',
     )
-    // No tone/variant emitted on this CEE response → defaults to 'info'
-    // per the bridge's wrapped-block-parity defaults.
-    expect(card.variant).toBe('info')
+    expect(top.severity).toBe('info')
+    expect(top.card_kind).toBe('assumption')
+    expect(top.freshness).toBe('fresh')
   })
 
-  it('cap respected end-to-end: only one review_card surfaces even though 4 are available', async () => {
+  it('coaching blocks carry the producer action refs verbatim (action_intent + action_label)', async () => {
     const result = await parseV5Response(makeResponse(loadFixture()))
     if (result.kind !== 'response') throw new Error('expected response')
     const phase3 = extractPhase3FromV5Response(result.response)
-    const finalBlocks = composePhase3BridgedBlocks(
-      true,
-      phase3.rawBlocks,
-      [V5_ANALYSIS_RESULT_BLOCK],
+    const finalBlocks = composePhase3BridgedBlocks(true, phase3.rawBlocks, [])
+    const coaching = finalBlocks.filter(
+      (b): b is V5CoachingBlock => b.type === 'v5_coaching',
     )
-    expect(finalBlocks.filter((b) => b.type === 'review_card')).toHaveLength(1)
+    expect(coaching).toHaveLength(6)
+    const assumptionCheck = coaching.find((c) => c.priority_rank === 101)
+    expect(assumptionCheck?.coaching_kind).toBe('assumption_check')
+    expect(assumptionCheck?.source).toBe('decision_review')
+    expect(assumptionCheck?.action_intent).toBe('confirm_factor')
+    expect(assumptionCheck?.action_label).toBe('Confirm this assumption')
   })
 
-  it('negative — synthetic null-body card is refused (no fabricated copy)', () => {
-    // Unit assertion of the bridge's empty-body refusal, independent of
-    // the live fixture. Kept here as a guard so a future regression that
+  it('typed blocks render on non-analysis turns too (factPresent=false does NOT gate 0.13.x blocks)', async () => {
+    // CEE owns when to emit typed Phase 3 content — coaching legitimately
+    // arrives on draft turns that carry no run_analysis fact. Only the
+    // LEGACY fallback stays fact-gated (locked in the unit spec).
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    const phase3 = extractPhase3FromV5Response(result.response)
+    const finalBlocks = composePhase3BridgedBlocks(false, phase3.rawBlocks, [])
+    expect(finalBlocks.filter((b) => b.type === 'v5_review_card')).toHaveLength(4)
+    expect(finalBlocks.filter((b) => b.type === 'v5_coaching')).toHaveLength(6)
+  })
+
+  it('negative — synthetic null-body card is refused by the LEGACY adapter (no fabricated copy)', () => {
+    // Unit assertion of the legacy bridge's empty-body refusal, independent
+    // of the live fixture. Kept as a guard so a future regression that
     // started fabricating body content would be caught.
     const adapted = adaptPhase3ReviewCard({
       title: 'A load-bearing assumption',

--- a/src/canvas/conversation/__tests__/phase3TypedBridge.spec.ts
+++ b/src/canvas/conversation/__tests__/phase3TypedBridge.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * Lane UI-R3 (truth rendering) — Track C slice 1: typed Phase 3 bridge
+ * behaviour of composePhase3BridgedBlocks.
+ *
+ * New contract under test (approved D-5; provisional_doctrine_v0):
+ *   1. 0.13.x-valid coaching + review_card raw blocks render as typed
+ *      v5_coaching / v5_review_card conversation blocks, mapped blocks
+ *      first, producer priority_rank ascending.
+ *   2. Typed blocks are NOT gated on factPresent (coaching arrives on
+ *      draft turns).
+ *   3. Fail-closed: malformed coaching → counted + suppressed, never
+ *      crashes composition.
+ *   4. evidence / exercise keep counting ('no_renderer_for_block_type')
+ *      and stay unrendered.
+ *   5. Legacy-shaped review_card falls back to the ORIGINAL bridge rules
+ *      (factPresent gate + top-1 cap + adaptPhase3ReviewCard) — locked in
+ *      detail by phase3ReviewCardBridge.spec.ts; spot-checked here.
+ *   6. Dedupe by block_id across the typed path.
+ *
+ * Counting assertions use the real dropped-content counter snapshot
+ * (session-scoped; reset per test).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { composePhase3BridgedBlocks } from '../useConversation'
+import type { ConversationBlock, V5CoachingBlock, V5ReviewCardBlock } from '../types'
+import type { Phase3RawBlock } from '../../../v5/extractPhase3FromV5Response'
+import {
+  _resetDroppedContentCounter,
+  getDroppedContentSnapshot,
+} from '../../../lib/droppedContentCounter'
+
+// ─── Fixtures: 0.13.x-shaped raw payloads (field set mirrors the live
+//     staging capture cee-response-b82c89dd-trimmed.json) ────────────────
+
+function typedReviewCardRaw(overrides: Record<string, unknown> = {}): Phase3RawBlock {
+  const raw: Record<string, unknown> = {
+    type: 'review_card',
+    block_id: 'rc-typed-1',
+    signal_id: 'review:assumption:1:hash',
+    source_handler: 'decision_review_enricher',
+    graph_hash_at_generation: 'hash-1',
+    freshness: 'fresh',
+    card_kind: 'assumption',
+    title: 'A load-bearing assumption',
+    body: 'The relationship between X and Y remains stable.',
+    severity: 'info',
+    priority_rank: 71,
+    target_refs: [],
+    ...overrides,
+  }
+  return {
+    type: 'review_card',
+    id: String(raw.block_id ?? 'rc-typed-1'),
+    source: 'sidecar_blocks_array',
+    raw,
+  }
+}
+
+function typedCoachingRaw(overrides: Record<string, unknown> = {}): Phase3RawBlock {
+  const raw: Record<string, unknown> = {
+    type: 'coaching',
+    block_id: 'co-typed-1',
+    signal_id: 'coach:assumption:1:hash',
+    source_handler: 'decision_review_enricher',
+    graph_hash_at_generation: 'hash-1',
+    freshness: 'fresh',
+    coaching_kind: 'assumption_check',
+    title: 'An assumption to check',
+    body: 'Check that the relationship between X and Y is stable.',
+    source: 'decision_review',
+    action_intent: 'confirm_factor',
+    action_label: 'Confirm this assumption',
+    priority_rank: 101,
+    target_refs: [],
+    ...overrides,
+  }
+  return {
+    type: 'coaching',
+    id: String(raw.block_id ?? 'co-typed-1'),
+    source: 'sidecar_blocks_array',
+    raw,
+  }
+}
+
+function legacyReviewCardRaw(id: string): Phase3RawBlock {
+  return {
+    type: 'review_card',
+    id,
+    source: 'sidecar_blocks_array',
+    raw: {
+      type: 'review_card',
+      block_id: id,
+      title: 'Legacy decision review',
+      summary: 'Legacy body under summary field.',
+      freshness: 'fresh',
+    },
+  }
+}
+
+const MAPPED: ConversationBlock[] = [
+  {
+    type: 'v5_analysis_result',
+    summary: 'Ran analysis.',
+    leading_option_id: 'opt_a',
+  },
+]
+
+beforeEach(() => {
+  _resetDroppedContentCounter()
+})
+
+describe('composePhase3BridgedBlocks — typed path (slice 1)', () => {
+  it('renders schema-valid coaching AND review_card as typed blocks after mapped blocks, priority_rank ascending', () => {
+    const out = composePhase3BridgedBlocks(
+      true,
+      [typedCoachingRaw(), typedReviewCardRaw()],
+      MAPPED,
+    )
+    expect(out.map((b) => b.type)).toEqual([
+      'v5_analysis_result',
+      'v5_review_card', // rank 71 outranks coaching rank 101
+      'v5_coaching',
+    ])
+    const card = out[1] as V5ReviewCardBlock
+    expect(card.title).toBe('A load-bearing assumption')
+    expect(card.body).toBe('The relationship between X and Y remains stable.')
+    const coaching = out[2] as V5CoachingBlock
+    expect(coaching.action_label).toBe('Confirm this assumption')
+  })
+
+  it('does NOT gate typed blocks on factPresent (coaching on draft turns renders)', () => {
+    const out = composePhase3BridgedBlocks(false, [typedCoachingRaw()], [])
+    expect(out.map((b) => b.type)).toEqual(['v5_coaching'])
+  })
+
+  it('fail-closed: malformed coaching is counted + suppressed, composition never crashes', () => {
+    const malformed = typedCoachingRaw({ body: undefined })
+    const out = composePhase3BridgedBlocks(true, [malformed, typedReviewCardRaw()], MAPPED)
+    expect(out.map((b) => b.type)).toEqual(['v5_analysis_result', 'v5_review_card'])
+
+    const snapshot = getDroppedContentSnapshot()
+    expect(snapshot.total_dropped).toBe(1)
+    expect(snapshot.entries[0]).toMatchObject({
+      block_type: 'coaching',
+      source: 'phase3_block_bridge',
+      rationale: 'malformed_phase3_block_suppressed',
+      count: 1,
+    })
+  })
+
+  it('evidence and exercise keep counting and stay unrendered', () => {
+    const evidence: Phase3RawBlock = {
+      type: 'evidence',
+      id: 'ev-1',
+      source: 'sidecar_blocks_array',
+      raw: { type: 'evidence', block_id: 'ev-1' },
+    }
+    const exercise: Phase3RawBlock = {
+      type: 'exercise',
+      id: 'ex-1',
+      source: 'sidecar_blocks_array',
+      raw: { type: 'exercise', block_id: 'ex-1' },
+    }
+    const out = composePhase3BridgedBlocks(true, [evidence, exercise], MAPPED)
+    expect(out.map((b) => b.type)).toEqual(['v5_analysis_result'])
+
+    const snapshot = getDroppedContentSnapshot()
+    expect(snapshot.total_dropped).toBe(2)
+    const byType = new Map(snapshot.entries.map((e) => [e.block_type, e]))
+    expect(byType.get('evidence')).toMatchObject({
+      source: 'phase3_block_bridge',
+      rationale: 'no_renderer_for_block_type',
+    })
+    expect(byType.get('exercise')).toMatchObject({
+      source: 'phase3_block_bridge',
+      rationale: 'no_renderer_for_block_type',
+    })
+  })
+
+  it('dedupes typed blocks by block_id (same card harvested twice renders once)', () => {
+    const out = composePhase3BridgedBlocks(
+      true,
+      [typedReviewCardRaw(), typedReviewCardRaw()],
+      [],
+    )
+    expect(out.filter((b) => b.type === 'v5_review_card')).toHaveLength(1)
+  })
+
+  it('renders ALL typed review cards (no top-1 cap on the typed path)', () => {
+    const out = composePhase3BridgedBlocks(
+      true,
+      [
+        typedReviewCardRaw({ block_id: 'rc-1', priority_rank: 73 }),
+        typedReviewCardRaw({ block_id: 'rc-2', priority_rank: 71 }),
+        typedReviewCardRaw({ block_id: 'rc-3', priority_rank: 72 }),
+      ],
+      [],
+    )
+    const ranks = out
+      .filter((b): b is V5ReviewCardBlock => b.type === 'v5_review_card')
+      .map((b) => b.priority_rank)
+    expect(ranks).toEqual([71, 72, 73])
+  })
+})
+
+describe('composePhase3BridgedBlocks — legacy fallback preserved', () => {
+  it('legacy-shaped review_card still renders through the fact-gated top-1 legacy bridge', () => {
+    const out = composePhase3BridgedBlocks(true, [legacyReviewCardRaw('rc-legacy-1')], MAPPED)
+    expect(out.map((b) => b.type)).toEqual(['v5_analysis_result', 'review_card'])
+  })
+
+  it('legacy card suppressed when factPresent=false, and the suppression is counted', () => {
+    const out = composePhase3BridgedBlocks(false, [legacyReviewCardRaw('rc-legacy-1')], MAPPED)
+    expect(out.map((b) => b.type)).toEqual(['v5_analysis_result'])
+
+    const snapshot = getDroppedContentSnapshot()
+    expect(snapshot.entries[0]).toMatchObject({
+      block_type: 'review_card',
+      source: 'phase3_block_bridge',
+      rationale: 'legacy_review_card_suppressed',
+      count: 1,
+    })
+  })
+
+  it('legacy top-1 cap: the non-selected legacy cards are counted as suppressed', () => {
+    const out = composePhase3BridgedBlocks(
+      true,
+      [legacyReviewCardRaw('rc-legacy-1'), legacyReviewCardRaw('rc-legacy-2')],
+      MAPPED,
+    )
+    expect(out.filter((b) => b.type === 'review_card')).toHaveLength(1)
+    const snapshot = getDroppedContentSnapshot()
+    expect(snapshot.total_dropped).toBe(1)
+    expect(snapshot.entries[0]).toMatchObject({
+      block_type: 'review_card',
+      rationale: 'legacy_review_card_suppressed',
+    })
+  })
+
+  it('typed and legacy cards can coexist on one turn: typed renders typed, legacy renders top-1', () => {
+    const out = composePhase3BridgedBlocks(
+      true,
+      [typedReviewCardRaw(), legacyReviewCardRaw('rc-legacy-1')],
+      MAPPED,
+    )
+    expect(out.map((b) => b.type)).toEqual([
+      'v5_analysis_result',
+      'v5_review_card',
+      'review_card',
+    ])
+  })
+})

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -109,6 +109,8 @@ export type ConversationBlock =
   | V5ExplanationBlock
   | V5ComparisonBlock
   | V5FlipAnalysisBlock
+  | V5ReviewCardBlock
+  | V5CoachingBlock
   | V5UnsupportedBlock
 
 /**
@@ -171,6 +173,62 @@ export interface V5FlipAnalysisBlock {
   narrative: string
   flip_scenarios: V5FlipScenario[]
   enrichment?: Record<string, unknown>
+}
+
+/**
+ * Target reference carried on 0.13.x Phase 3 blocks (review_card /
+ * coaching). Fields are the producer's typed shape verbatim; `kind` is
+ * widened to string so future producer kinds pass through without a UI
+ * release (unknown kinds render the label exactly the same way).
+ */
+export interface V5BlockTargetRef {
+  id: string
+  label: string
+  kind: string
+}
+
+/** 0.13.x Phase 3 block freshness enum (producer-owned). */
+export type V5Phase3Freshness = 'fresh' | 'stale' | 'pending' | 'failed'
+
+/**
+ * Track C slice 1 (D-5): typed review_card conversation block mirroring the
+ * 0.13.x ReviewCardBlockSchema render-relevant fields EXACTLY. All copy
+ * (title, body, target_refs labels, action_label) is producer-owned and
+ * rendered verbatim — the UI adds no labels and no interpretation
+ * (provisional_doctrine_v0). Distinct from the legacy `review_card`
+ * ConversationBlock, which carries the V4-era tone/variant shape.
+ */
+export interface V5ReviewCardBlock {
+  type: 'v5_review_card'
+  block_id: string
+  title: string
+  body: string
+  severity: 'info' | 'warning' | 'critical'
+  card_kind: string
+  target_refs: V5BlockTargetRef[]
+  priority_rank: number
+  freshness: V5Phase3Freshness
+  action_intent?: string
+  action_label?: string
+}
+
+/**
+ * Track C slice 1 (D-5): typed coaching conversation block mirroring the
+ * 0.13.x CoachingBlockSchema render-relevant fields EXACTLY. Same
+ * verbatim-copy contract as V5ReviewCardBlock (provisional_doctrine_v0).
+ */
+export interface V5CoachingBlock {
+  type: 'v5_coaching'
+  block_id: string
+  title: string
+  body: string
+  coaching_kind: string
+  source: string
+  target_refs: V5BlockTargetRef[]
+  priority_rank: number
+  freshness: V5Phase3Freshness
+  action_intent?: string
+  action_label?: string
 }
 
 /**

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -31,6 +31,14 @@ import {
   v5ResponseHasRunAnalysisFact,
   type Phase3RawBlock,
 } from '../../v5/extractPhase3FromV5Response'
+import {
+  adaptTypedReviewCardBlock,
+  adaptTypedCoachingBlock,
+} from '../../v5/phase3TypedBlocks'
+// Track C slice 1 (D-5): the bridge counts every Phase 3 block it does NOT
+// surface (malformed / no renderer / legacy suppression). Counting only —
+// recordDroppedContent never throws and never changes composition output.
+import { recordDroppedContent } from '../../lib/droppedContentCounter'
 import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled } from '../../flags'
 import { maybeBuildModelReceiptBlock } from '../adapters/modelCardAdapter'
@@ -901,50 +909,130 @@ export function selectTopPhase3ReviewCard(
 }
 
 /**
- * composePhase3BridgedBlocks — pure composition of the Phase 3 review_card
- * bridge applied at the V5 assistant-turn rendering site.
+ * composePhase3BridgedBlocks — composition of the Phase 3 rendering bridge
+ * applied at the V5 assistant-turn rendering site (Track C slice 1,
+ * approved D-5; provisional_doctrine_v0).
  *
  * Inputs:
  *   - factPresent: whether the current response carries a successful
- *     run_analysis fact (computed by v5ResponseHasRunAnalysisFact).
+ *     run_analysis fact (computed by v5ResponseHasRunAnalysisFact). Gates
+ *     ONLY the legacy review_card fallback below — 0.13.x-typed blocks are
+ *     per-turn producer content and render on the turn CEE emitted them
+ *     (coaching legitimately arrives on draft turns, which carry no
+ *     run_analysis fact).
  *   - phase3RawBlocks: verbatim Phase 3 blocks harvested by
  *     extractPhase3FromV5Response.
  *   - mappedBlocks: V5 schema-strict blocks already produced by mapV5Blocks.
  *
  * Returns the final ordered blocks array for the assistant turn:
- *   [...mappedBlocks, ...top-1 review_card when eligible]
+ *   [...mappedBlocks,
+ *    ...schema-typed coaching/review_card (producer priority_rank asc,
+ *       ties by harvest order; deduped by block_id),
+ *    ...legacy top-1 review_card fallback when eligible]
  *
- * Eligibility:
- *   - factPresent must be true (gates out conversational follow-ups and stale
- *     responses).
- *   - At least one rawBlock of type 'review_card' must adapt to a usable
- *     ReviewCardBlock (non-empty title + body).
- *   - No review_card is already present in mappedBlocks (defensive dedupe;
- *     mapV5Blocks does not emit review_card today, so this branch is
- *     unreachable in practice. If a future V5 schema change makes
- *     mapV5Blocks emit a legitimately different review_card alongside a
- *     Phase 3 candidate, refine this check to dedupe by block_id rather
- *     than by type so both surfaces remain available.).
+ * Typed path (NEW, slice 1): raw blocks of type 'coaching'/'review_card'
+ * that adapt cleanly against the 0.13.x typed shapes render as first-class
+ * v5_coaching / v5_review_card blocks — exactly the typed fields, all copy
+ * producer-verbatim. Fail-closed: a malformed block is COUNTED (dropped-
+ * content counter) and suppressed; it never crashes composition and never
+ * renders with invented fields.
  *
- * Cap: 1 review_card (top by priority_rank, ties by harvest order).
+ * Legacy fallback (unchanged behaviour): review_card blocks that are NOT
+ * 0.13.x-shaped go through the original bridge — factPresent gate, top-1
+ * cap by priority_rank, adaptPhase3ReviewCard defaults, dedupe against an
+ * existing legacy review_card in mappedBlocks. Legacy cards not surfaced
+ * are counted ('legacy_review_card_suppressed').
  *
- * Evidence and coaching rawBlocks are intentionally NOT surfaced:
- *   - evidence: v1.3 shape mismatch with EvidenceBlockRenderer (tracked as a
- *     follow-up issue).
- *   - coaching: no InlineBlocks renderer; remains in GuidanceStore.
+ * Evidence and exercise rawBlocks remain unsurfaced this slice (no
+ * renderer) and are counted ('no_renderer_for_block_type').
  */
 export function composePhase3BridgedBlocks(
   factPresent: boolean,
   phase3RawBlocks: readonly Phase3RawBlock[],
   mappedBlocks: readonly ConversationBlock[],
 ): ConversationBlock[] {
-  if (!factPresent) return [...mappedBlocks]
-  const topReview = selectTopPhase3ReviewCard(phase3RawBlocks)
-  if (!topReview) return [...mappedBlocks]
+  const out: ConversationBlock[] = [...mappedBlocks]
+
+  // ── Typed path: 0.13.x coaching + review_card ─────────────────────────
+  const typed: Array<{ block: ConversationBlock; rank: number; order: number }> = []
+  const legacyReviewCandidates: Phase3RawBlock[] = []
+  const seenTypedBlockIds = new Set<string>(
+    mappedBlocks.flatMap((b) =>
+      (b.type === 'v5_review_card' || b.type === 'v5_coaching') ? [b.block_id] : [],
+    ),
+  )
+  let order = 0
+  for (const rb of phase3RawBlocks) {
+    if (rb.type === 'review_card') {
+      const adapted = adaptTypedReviewCardBlock(rb.raw)
+      if (adapted) {
+        if (!seenTypedBlockIds.has(adapted.block_id)) {
+          seenTypedBlockIds.add(adapted.block_id)
+          typed.push({ block: adapted, rank: adapted.priority_rank, order: order++ })
+        }
+        continue
+      }
+      // Not 0.13.x-shaped — hand to the legacy bridge below.
+      legacyReviewCandidates.push(rb)
+      continue
+    }
+    if (rb.type === 'coaching') {
+      const adapted = adaptTypedCoachingBlock(rb.raw)
+      if (adapted) {
+        if (!seenTypedBlockIds.has(adapted.block_id)) {
+          seenTypedBlockIds.add(adapted.block_id)
+          typed.push({ block: adapted, rank: adapted.priority_rank, order: order++ })
+        }
+        continue
+      }
+      // Fail-closed: malformed coaching → counted + suppressed, never crash.
+      recordDroppedContent({
+        blockType: 'coaching',
+        source: 'phase3_block_bridge',
+        rationale: 'malformed_phase3_block_suppressed',
+      })
+      continue
+    }
+    // evidence / exercise: tolerated types without a renderer this slice.
+    recordDroppedContent({
+      blockType: rb.type,
+      source: 'phase3_block_bridge',
+      rationale: 'no_renderer_for_block_type',
+    })
+  }
+  // Producer-owned ordering: priority_rank ascending (lower = higher
+  // priority, per CEE v1.3 §0); ties preserve harvest order. No new
+  // ranking is invented.
+  typed.sort((a, b) => a.rank - b.rank || a.order - b.order)
+  out.push(...typed.map((t) => t.block))
+
+  // ── Legacy fallback: pre-0.13.x review_card bridge (unchanged rules) ──
+  const countLegacySuppressed = (n: number): void => {
+    if (n <= 0) return
+    recordDroppedContent({
+      blockType: 'review_card',
+      source: 'phase3_block_bridge',
+      rationale: 'legacy_review_card_suppressed',
+      count: n,
+    })
+  }
+  if (legacyReviewCandidates.length === 0) return out
+  if (!factPresent) {
+    countLegacySuppressed(legacyReviewCandidates.length)
+    return out
+  }
+  const topReview = selectTopPhase3ReviewCard(legacyReviewCandidates)
+  if (!topReview) {
+    countLegacySuppressed(legacyReviewCandidates.length)
+    return out
+  }
   const adapted = adaptPhase3ReviewCard(topReview.raw)
-  if (!adapted) return [...mappedBlocks]
-  if (mappedBlocks.some((b) => b.type === 'review_card')) return [...mappedBlocks]
-  return [...mappedBlocks, adapted]
+  if (!adapted || mappedBlocks.some((b) => b.type === 'review_card')) {
+    countLegacySuppressed(legacyReviewCandidates.length)
+    return out
+  }
+  countLegacySuppressed(legacyReviewCandidates.length - 1)
+  return [...out, adapted]
 }
 
 export function adaptCEEBlock(raw: unknown): ConversationBlock {
@@ -3040,11 +3128,12 @@ export function useConversation(): UseConversationReturn {
             const mappedBlocks =
               target.kind === 'blocks' ? mapV5Blocks(target.response.blocks) : []
 
-            // Phase 3 review_card bridge — surface CEE-produced post-analysis
-            // review_card prose in the AI panel after Run analysis. Reuses the
-            // existing ReviewCardBlockRenderer; no schema / parser / CEE change.
-            // Gating, cap, dedupe, and evidence/coaching exclusion documented
-            // on composePhase3BridgedBlocks above.
+            // Phase 3 rendering bridge (Track C slice 1, D-5) — surface
+            // CEE-produced 0.13.x coaching + review_card blocks as typed
+            // conversation blocks (producer copy verbatim), with the legacy
+            // top-1 review_card fallback for pre-0.13.x shapes. Malformed /
+            // renderer-less blocks are counted + suppressed (fail-closed).
+            // Full rules documented on composePhase3BridgedBlocks above.
             const finalBlocks = composePhase3BridgedBlocks(
               factPresent,
               phase3.rawBlocks,

--- a/src/components/results/InferenceWarningStrip.tsx
+++ b/src/components/results/InferenceWarningStrip.tsx
@@ -1,0 +1,69 @@
+/**
+ * InferenceWarningStrip — compact honest-caveat strip for warning-severity
+ * producer `inference_warnings` on the Analysis tab (roadmap 1.12; tagged
+ * provisional_doctrine_v0).
+ *
+ * Contract:
+ *   - Renders ONLY entries whose producer `severity` is exactly 'warning'.
+ *     Info-severity entries stay hidden here (they remain available to the
+ *     Advanced/Confidence surfaces and the debug bundle). Entries with no
+ *     severity are NOT promoted — the UI never invents a severity.
+ *   - Copy is the producer `message` verbatim. The UI adds no interpretation,
+ *     no rewording, no code-specific handling. An entry without a usable
+ *     message renders nothing (fail-closed; no fabricated copy from `code`).
+ *   - Display-only: never blocks analysis, never mutates state.
+ *
+ * Visual idiom mirrors AnalysisFreshnessNotice (the strip mounts directly
+ * below it in ResultsBody): bg-panel card, border via opacity token,
+ * lucide icon, panelBody typography.
+ */
+import { AlertTriangle } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import type { InferenceWarning } from './types'
+
+export interface InferenceWarningStripProps {
+  /** Producer inference warnings (all severities); the strip filters. */
+  warnings?: InferenceWarning[]
+  className?: string
+}
+
+/** Entries the strip will show: severity === 'warning' AND a non-empty producer message. */
+export function selectWarningSeverityEntries(
+  warnings: InferenceWarning[] | undefined,
+): InferenceWarning[] {
+  return (warnings ?? []).filter(
+    (w) =>
+      w.severity === 'warning' &&
+      typeof w.message === 'string' &&
+      w.message.trim().length > 0,
+  )
+}
+
+export function InferenceWarningStrip({ warnings, className = '' }: InferenceWarningStripProps) {
+  const visible = selectWarningSeverityEntries(warnings)
+  if (visible.length === 0) return null
+
+  return (
+    <div
+      data-testid="inference-warning-strip"
+      className={`flex flex-col gap-1 ${className}`.trim()}
+      aria-label="Analysis caveats"
+    >
+      {visible.map((w, i) => (
+        <div
+          key={`${w.code}-${i}`}
+          data-testid="inference-warning-strip-entry"
+          data-warning-code={w.code}
+          data-warning-severity={w.severity}
+          className="flex items-center gap-2 rounded-md border px-3 py-2 bg-panel border-warning/30"
+        >
+          <AlertTriangle size={14} className="flex-none text-warning" aria-hidden="true" />
+          {/* Producer message verbatim — provisional_doctrine_v0: the UI adds no interpretation. */}
+          <span className={`${typography.panelBody} text-text-body`}>{w.message}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default InferenceWarningStrip

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -29,6 +29,7 @@ import { DecisionConfidencePanel } from './DecisionConfidencePanel'
 import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
 import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
+import { InferenceWarningStrip } from './InferenceWarningStrip'
 import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
 import { AnalysisHeroContainer } from './analysis-hero'
 import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled, isAnalysisHeroPanelEnabled } from '@/flags'
@@ -232,6 +233,12 @@ export const ResultsBody = memo(function ResultsBody({
       {/* Freshness/staleness — CEE analysis_ready.freshness verdict. Renders
           nothing until a verdict exists; never asserts a state we don't hold. */}
       <AnalysisFreshnessNotice />
+
+      {/* Roadmap 1.12 (provisional_doctrine_v0): warning-severity producer
+          inference_warnings surface as a compact honest-caveat strip beside
+          the freshness area. Producer message verbatim; info-severity stays
+          hidden; renders nothing when no warning-severity entries exist. */}
+      <InferenceWarningStrip warnings={resultsSectionData.confidence.inferenceWarnings} />
 
       {/* ── ANALYSIS HERO (answer-first lens hero) ─────────────────
           Feature-flagged (staging-on, production-off). Read-only

--- a/src/components/results/__tests__/InferenceWarningStrip.spec.tsx
+++ b/src/components/results/__tests__/InferenceWarningStrip.spec.tsx
@@ -1,0 +1,110 @@
+/**
+ * Lane UI-R3 (truth rendering) — roadmap 1.12: InferenceWarningStrip.
+ *
+ * Warning-severity producer inference_warnings surface as a compact
+ * honest-caveat strip on the Analysis tab; info-severity entries stay
+ * hidden; copy is the producer message verbatim (the UI adds no
+ * interpretation). Tagged provisional_doctrine_v0.
+ *
+ * Warning shapes mirror the real staging capture (debug bundle
+ * olumi-debug-45c9b625-20260707): { code, message, severity }.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { InferenceWarningStrip, selectWarningSeverityEntries } from '../InferenceWarningStrip'
+import type { InferenceWarning } from '../types'
+
+const INFO_EDGE_SENSITIVITY: InferenceWarning = {
+  code: 'EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE',
+  affected_nodes: [],
+  message:
+    'Edge-level sensitivity was requested but the ISL V2 response format does not carry it — edge_sensitivity is empty by wire contract, not by computation failure. Factor-level sensitivity is unaffected.',
+  severity: 'info',
+}
+
+const INFO_CONSTRAINT_BASE: InferenceWarning = {
+  code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+  affected_nodes: [],
+  message:
+    "Node 'out_campaign_effectiveness' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable",
+  severity: 'info',
+}
+
+const WARNING_CONSTRAINT_TARGET: InferenceWarning = {
+  code: 'CONSTRAINT_TARGET_UNRELIABLE',
+  affected_nodes: [],
+  message:
+    "The target for 'out_campaign_effectiveness' could not be reliably assessed - set an explicit range for this outcome to make the target meaningful.",
+  severity: 'warning',
+}
+
+describe('selectWarningSeverityEntries', () => {
+  it('keeps only severity === "warning" entries with a non-empty message', () => {
+    const picked = selectWarningSeverityEntries([
+      INFO_EDGE_SENSITIVITY,
+      INFO_CONSTRAINT_BASE,
+      WARNING_CONSTRAINT_TARGET,
+    ])
+    expect(picked).toEqual([WARNING_CONSTRAINT_TARGET])
+  })
+
+  it('never promotes entries with missing severity (UI does not invent severity)', () => {
+    const noSeverity: InferenceWarning = {
+      code: 'SOMETHING',
+      affected_nodes: [],
+      message: 'A message with no severity field.',
+    }
+    expect(selectWarningSeverityEntries([noSeverity])).toEqual([])
+  })
+
+  it('drops warning-severity entries without a usable message (no fabricated copy from code)', () => {
+    const noMessage: InferenceWarning = {
+      code: 'CONSTRAINT_TARGET_UNRELIABLE',
+      affected_nodes: [],
+      severity: 'warning',
+    }
+    expect(selectWarningSeverityEntries([noMessage])).toEqual([])
+  })
+})
+
+describe('InferenceWarningStrip', () => {
+  it('renders the producer message VERBATIM for a warning-severity entry', () => {
+    render(<InferenceWarningStrip warnings={[WARNING_CONSTRAINT_TARGET]} />)
+    const strip = screen.getByTestId('inference-warning-strip')
+    expect(strip).toBeInTheDocument()
+    const entry = screen.getByTestId('inference-warning-strip-entry')
+    expect(entry).toHaveAttribute('data-warning-code', 'CONSTRAINT_TARGET_UNRELIABLE')
+    // Byte-for-byte producer copy — no rewording, no truncation, no suffix.
+    expect(entry).toHaveTextContent(WARNING_CONSTRAINT_TARGET.message as string)
+  })
+
+  it('renders nothing when only info-severity entries exist (info stays hidden)', () => {
+    const { container } = render(
+      <InferenceWarningStrip warnings={[INFO_EDGE_SENSITIVITY, INFO_CONSTRAINT_BASE]} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when warnings are absent or empty', () => {
+    const { container: empty } = render(<InferenceWarningStrip warnings={[]} />)
+    expect(empty.firstChild).toBeNull()
+    const { container: absent } = render(<InferenceWarningStrip />)
+    expect(absent.firstChild).toBeNull()
+  })
+
+  it('shows every warning-severity entry when several arrive (no silent cap)', () => {
+    const second: InferenceWarning = {
+      code: 'CONSTRAINT_TARGET_UNRELIABLE',
+      affected_nodes: [],
+      message: "The target for 'out_roi' could not be reliably assessed - set an explicit range for this outcome to make the target meaningful.",
+      severity: 'warning',
+    }
+    render(
+      <InferenceWarningStrip
+        warnings={[INFO_EDGE_SENSITIVITY, WARNING_CONSTRAINT_TARGET, second]}
+      />,
+    )
+    expect(screen.getAllByTestId('inference-warning-strip-entry')).toHaveLength(2)
+  })
+})

--- a/src/components/results/__tests__/influence-warnings.wire-to-selector.spec.tsx
+++ b/src/components/results/__tests__/influence-warnings.wire-to-selector.spec.tsx
@@ -1,0 +1,136 @@
+/**
+ * Lane UI-R3 (truth rendering) — roadmap 1.7 + 1.12 wire-to-selector proof.
+ *
+ * Chain under test (same five links as
+ * v5-analysis-to-results-panel.wire-to-selector.spec.ts):
+ *
+ *   real bundle-shaped V5 envelope → applyV5State (mapV5AnalysisToReport)
+ *     → resultsComplete payload → useCanvasStore.results.report
+ *     → useResultsSectionData selector
+ *
+ * Feature B (1.7): the producer's influence_score / influence_rank /
+ * zero_reason survive to DriverItem — in particular the PINNED factor
+ * (zero_reason intervention_override, sensitivity 0, influence_score 1)
+ * must stay VISIBLE with its influence, instead of being dropped as
+ * zero-impact when influence_score was narrowed away.
+ *
+ * Feature C (1.12): warning-severity inference_warnings reach
+ * confidence.inferenceWarnings WITH their severity so the Analysis-tab
+ * strip can filter on it.
+ *
+ * Fixture: real staging capture (debug bundle olumi-debug-45c9b625-20260707).
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+import { applyV5State, type V5ApplicatorStore } from '../../../v5/applyV5State'
+import { useCanvasStore } from '../../../canvas/store'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { selectWarningSeverityEntries } from '../InferenceWarningStrip'
+
+import bundleFixture from '../../../v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json'
+
+function hydrateStoreFromBundle(): void {
+  const envelope = {
+    response_version: 2,
+    assistant_text: 'Analysis complete.',
+    blocks: [bundleFixture.block],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+  } as unknown as OlumiResponse
+
+  const captured: Array<{ report: unknown; hash: string }> = []
+  const applicatorStore: V5ApplicatorStore = {
+    setCurrentStage: vi.fn(),
+    updateNode: vi.fn(),
+    updateEdgeData: vi.fn(),
+    setRunMeta: vi.fn(),
+    setCeeAnalysisReady: vi.fn(),
+    nodes: [],
+    edges: [],
+    resultsComplete: (params) => {
+      captured.push({ report: params.report, hash: params.hash })
+    },
+    currentResultsHash: null,
+  }
+  const apply = applyV5State(envelope, applicatorStore)
+  expect(apply.applied).toContain('analysis_result:results_hydrated')
+  expect(captured).toHaveLength(1)
+
+  useCanvasStore.setState({
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: captured[0].report,
+      hash: captured[0].hash,
+    } as unknown as ReturnType<typeof useCanvasStore.getState>['results'],
+    hasCompletedFirstRun: true,
+  } as Partial<ReturnType<typeof useCanvasStore.getState>>)
+}
+
+describe('bundle 45c9b625 → Results selector: influence + warnings truth rendering', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 } as unknown as ReturnType<
+        typeof useCanvasStore.getState
+      >['results'],
+      runMeta: {} as ReturnType<typeof useCanvasStore.getState>['runMeta'],
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      currentScenarioFraming: null,
+      ceeAnalysisReady: undefined,
+    })
+  })
+
+  it('driver rows expose the producer influence_score and influence_rank (1.7)', () => {
+    hydrateStoreFromBundle()
+    const { result } = renderHook(() => useResultsSectionData())
+    const drivers = result.current.drivers.drivers
+    const byKey = new Map(drivers.map((d) => [d.factorKey, d]))
+
+    const receptivity = byKey.get('fac_market_receptivity')
+    expect(receptivity?.influenceScore).toBe(0.6209677419354838)
+    expect(receptivity?.influenceRank).toBe(2)
+
+    const founderTime = byKey.get('fac_founder_time')
+    expect(founderTime?.influenceScore).toBe(0.4838709677419354)
+    expect(founderTime?.influenceRank).toBe(3)
+  })
+
+  it('pinned factor stays visible with influence (not dropped as zero-impact) and carries zero_reason (1.7)', () => {
+    hydrateStoreFromBundle()
+    const { result } = renderHook(() => useResultsSectionData())
+    const drivers = result.current.drivers.drivers
+    const pinned = drivers.find((d) => d.factorKey === 'fac_marketing_expertise')
+
+    expect(pinned).toBeDefined()
+    expect(pinned?.influenceScore).toBe(1)
+    expect(pinned?.influenceRank).toBe(1)
+    expect(pinned?.zeroReason).toBe('intervention_override')
+    // Zero-impact filter keys off influenceScore ?? normalisedInfluence —
+    // with influence_score present the pinned factor is NOT zero-impact.
+    // (Sensitivity is 0 by producer decree: intervention_override.)
+    expect(pinned?.rawElasticity).toBe(0)
+  })
+
+  it('inferenceWarnings reach the selector with severity; the strip filter picks exactly the warning-severity entry (1.12)', () => {
+    hydrateStoreFromBundle()
+    const { result } = renderHook(() => useResultsSectionData())
+    const warnings = result.current.confidence.inferenceWarnings
+    expect(warnings).toBeDefined()
+    expect(warnings).toHaveLength(3)
+    expect(warnings?.map((w) => w.severity)).toEqual(['info', 'info', 'warning'])
+
+    const visible = selectWarningSeverityEntries(warnings)
+    expect(visible).toHaveLength(1)
+    expect(visible[0].code).toBe('CONSTRAINT_TARGET_UNRELIABLE')
+    // Producer message verbatim — the caveat copy the strip will render.
+    expect(visible[0].message).toBe(
+      "The target for 'out_campaign_effectiveness' could not be reliably assessed - set an explicit range for this outcome to make the target meaningful.",
+    )
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -415,6 +415,8 @@ export interface DriverItem {
   normalisedInfluence: number
   /** ISL influence_score (0-1) - structural causal influence, used for Influence column */
   influenceScore?: number
+  /** Producer influence_rank (1 = most influential). Additive; roadmap 1.7 (provisional_doctrine_v0). */
+  influenceRank?: number
   /** ISL zero_reason - explains why sensitivity is zero for intervention factors */
   zeroReason?: ZeroReasonCode
   /** 1-indexed rank by absolute elasticity */
@@ -610,6 +612,12 @@ export interface InferenceWarning {
   affected_labels?: string[]
   /** Human-readable message */
   message?: string
+  /**
+   * Producer severity ('info' | 'warning' | …) carried verbatim. Roadmap
+   * 1.12: warning-severity entries surface on the Analysis tab; info stays
+   * hidden. Optional/additive — absent when the producer omitted it.
+   */
+  severity?: string
 }
 
 export interface ConfidenceSectionData {
@@ -763,6 +771,8 @@ export interface RawFactorSensitivity {
   importance_score?: number
   /** ISL influence_score (0-1) - structural causal influence */
   influence_score?: number
+  /** Producer influence_rank (1 = most influential). Additive passthrough; roadmap 1.7 (provisional_doctrine_v0). */
+  influence_rank?: number
   /** ISL zero_reason - explains why sensitivity is zero for intervention factors */
   zero_reason?: ZeroReasonCode
   direction?: string
@@ -798,6 +808,8 @@ export interface UiFactorSensitivity {
   importanceRank: number
   /** ISL influence_score (0-1) - structural causal influence */
   influenceScore?: number
+  /** Producer influence_rank (1 = most influential). Additive; roadmap 1.7 (provisional_doctrine_v0). */
+  influenceRank?: number
   /** ISL zero_reason - explains why sensitivity is zero */
   zeroReason?: ZeroReasonCode
   /** ISL value_of_information (0-1) - whether gathering more data could change the decision */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -342,6 +342,10 @@ export function normalizeFactorSensitivity(raw: unknown, nodeLabelMap: Map<strin
   // ISL influence_score (0-1) - structural causal influence
   const influenceScore = typeof typed.influence_score === 'number' ? typed.influence_score : undefined
 
+  // Producer influence_rank (1 = most influential). Additive passthrough;
+  // roadmap 1.7 (provisional_doctrine_v0: influence ≠ sensitivity).
+  const influenceRank = typeof typed.influence_rank === 'number' ? typed.influence_rank : undefined
+
   // ISL zero_reason - explains why sensitivity is zero for intervention factors
   const zeroReason = typed.zero_reason as UiFactorSensitivity['zeroReason']
 
@@ -398,6 +402,7 @@ export function normalizeFactorSensitivity(raw: unknown, nodeLabelMap: Map<strin
     confidence,
     importanceRank: typeof typed.importance_rank === 'number' ? typed.importance_rank : 0,
     influenceScore,
+    influenceRank,
     zeroReason,
     valueOfInformation,
     flipRiskCategory,
@@ -1779,6 +1784,8 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           normalisedInfluence,
           // ISL influence_score (0-1) - use directly for Influence column
           influenceScore: f.raw.influenceScore,
+          // Producer influence_rank passthrough (roadmap 1.7, provisional_doctrine_v0)
+          influenceRank: f.raw.influenceRank,
           // ISL zero_reason - explains why sensitivity is zero
           zeroReason: f.raw.zeroReason,
           rank,
@@ -2625,6 +2632,10 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
             affected_nodes: nodeIds,
             affected_labels: nodeIds.map(id => nodeLabelMap.get(id) ?? id),
             message: w.message ? String(w.message) : undefined,
+            // Roadmap 1.12: producer severity carried verbatim (never
+            // defaulted). Warning-severity entries surface on the Analysis
+            // tab; info-severity stays hidden there.
+            severity: typeof w.severity === 'string' ? w.severity : undefined,
           }
         })
       })(),

--- a/src/lib/droppedContentCounter.ts
+++ b/src/lib/droppedContentCounter.ts
@@ -23,18 +23,32 @@
  *     strict validation (rationale
  *     'unknown_block_type_dropped_pre_validation'). Dropped != rendered:
  *     tolerance is a safety net, not a rendering contract.
+ *   - 'phase3_block_bridge': Phase 3 blocks harvested from the parser
+ *     sidecar that the render bridge (composePhase3BridgedBlocks in
+ *     useConversation.ts) did NOT surface. Track C slice 1 renders
+ *     schema-valid 'coaching' + 'review_card'; everything else here is
+ *     counted with a precise rationale:
+ *       - 'malformed_phase3_block_suppressed': a coaching/review_card that
+ *         failed 0.13.x typed-field adaptation (fail-closed — counted +
+ *         suppressed, never crashes, never rendered with invented fields).
+ *       - 'no_renderer_for_block_type': evidence / exercise — tolerated
+ *         types with no renderer in this slice.
+ *       - 'legacy_review_card_suppressed': a legacy-shaped (pre-0.13.x)
+ *         review_card not surfaced by the legacy top-1/fact-gated bridge.
  *
- * Future sources (e.g. renderer-level "schema-known but no renderer")
- * should add a new source/rationale literal here rather than reusing the
- * parser ones, so by-source counts stay attributable.
+ * Future sources should add a new source/rationale literal here rather
+ * than reusing existing ones, so by-source counts stay attributable.
  */
 
 /** Where the drop happened. */
-export type DroppedContentSource = 'v5_response_parser'
+export type DroppedContentSource = 'v5_response_parser' | 'phase3_block_bridge'
 
 /** Tracked rationale — WHY the content was not rendered. */
 export type DroppedContentRationale =
   | 'unknown_block_type_dropped_pre_validation'
+  | 'malformed_phase3_block_suppressed'
+  | 'no_renderer_for_block_type'
+  | 'legacy_review_card_suppressed'
 
 /** One aggregated counter row (type+source+rationale). */
 export interface DroppedContentEntry {

--- a/src/v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json
+++ b/src/v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json
@@ -1,0 +1,570 @@
+{
+ "_provenance": "Extracted from debug bundle olumi-debug-45c9b625-20260707.json (payloads.cee_response.blocks[0]); real staging capture 2026-07-07. inference_warnings[2] (CONSTRAINT_TARGET_UNRELIABLE, severity=warning) appended synthetically per its producer-documented shape to exercise the warning-severity path; entries [0..1] are verbatim staging.",
+ "assistant_text": "redacted",
+ "block": {
+  "type": "analysis_result",
+  "summary": "Hire Marketing Manager currently leads by 76 percentage points because Market Receptivity to Feature is the strongest driver.",
+  "leading_option_id": "opt_hire",
+  "win_probabilities": {
+   "AI Tool + Increased Ad Spend": 0.0989375,
+   "Hire Marketing Manager": 0.8541875,
+   "Freelance Consultant + AI Tool": 0.0184375,
+   "Handle Marketing Internally (Status Quo)": 0.0284375
+  },
+  "enrichment": {
+   "option_comparison": [
+    {
+     "option_id": "opt_ai",
+     "option_label": "AI Tool + Increased Ad Spend",
+     "id": "opt_ai",
+     "label": "AI Tool + Increased Ad Spend",
+     "outcome": {
+      "mean": 0.041151052415336425,
+      "std": 0.13720303104077483,
+      "p10": -0.138962887737842,
+      "p50": 0.04345842077645033,
+      "p90": 0.21641243662444515,
+      "n_samples": 4000,
+      "n_valid_samples": 4000,
+      "validity_ratio": 1
+     },
+     "status": "computed",
+     "win_probability": 0.0989375,
+     "probability_of_joint_goal": 0,
+     "constraint_probabilities": {
+      "gc-3841ab4f-6018-4cba-9f45-67108bba9737": 0
+     }
+    },
+    {
+     "option_id": "opt_hire",
+     "option_label": "Hire Marketing Manager",
+     "id": "opt_hire",
+     "label": "Hire Marketing Manager",
+     "outcome": {
+      "mean": 0.16591699331059176,
+      "std": 0.1312599933658644,
+      "p10": -0.0054883734393600695,
+      "p50": 0.16839926764621432,
+      "p90": 0.33233612212519054,
+      "n_samples": 4000,
+      "n_valid_samples": 4000,
+      "validity_ratio": 1
+     },
+     "status": "computed",
+     "win_probability": 0.8541875,
+     "probability_of_joint_goal": 0,
+     "constraint_probabilities": {
+      "gc-3841ab4f-6018-4cba-9f45-67108bba9737": 0
+     }
+    },
+    {
+     "option_id": "opt_hybrid",
+     "option_label": "Freelance Consultant + AI Tool",
+     "id": "opt_hybrid",
+     "label": "Freelance Consultant + AI Tool",
+     "outcome": {
+      "mean": 0.11652315834343036,
+      "std": 0.12549804509568754,
+      "p10": -0.047061402867295564,
+      "p50": 0.11635770100190579,
+      "p90": 0.27740956559897406,
+      "n_samples": 4000,
+      "n_valid_samples": 4000,
+      "validity_ratio": 1
+     },
+     "status": "computed",
+     "win_probability": 0.0184375,
+     "probability_of_joint_goal": 0,
+     "constraint_probabilities": {
+      "gc-3841ab4f-6018-4cba-9f45-67108bba9737": 0
+     }
+    },
+    {
+     "option_id": "opt_status_quo",
+     "option_label": "Handle Marketing Internally (Status Quo)",
+     "id": "opt_status_quo",
+     "label": "Handle Marketing Internally (Status Quo)",
+     "outcome": {
+      "mean": -0.013004926124831258,
+      "std": 0.0625866969749598,
+      "p10": -0.09356175665750582,
+      "p50": -0.011886214909537427,
+      "p90": 0.06493418843836848,
+      "n_samples": 4000,
+      "n_valid_samples": 4000,
+      "validity_ratio": 1
+     },
+     "status": "computed",
+     "win_probability": 0.0284375,
+     "probability_of_joint_goal": 0,
+     "constraint_probabilities": {
+      "gc-3841ab4f-6018-4cba-9f45-67108bba9737": 0
+     }
+    }
+   ],
+   "factor_sensitivity": [
+    {
+     "factor_id": "fac_marketing_expertise",
+     "factor_label": "Marketing Strategy Quality",
+     "influence_score": 1,
+     "influence_rank": 1,
+     "sensitivity_score": 0,
+     "elasticity": 0,
+     "direction": "positive",
+     "importance_rank": 1,
+     "value_of_information": 0,
+     "confidence": 0.3,
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "confidence_provenance": {
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "is_provisional": true,
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "input_quality": "standard"
+     },
+     "confidence_components": {
+      "structural_certainty": 0.5,
+      "sampling_stability": 0
+     },
+     "zero_reason": "intervention_override",
+     "source": "graph",
+     "flip_risk_category": "correlated",
+     "attribution_stability": "negligible",
+     "elasticity_std": 0,
+     "rank_flip_rate": 0,
+     "stability_method": "bootstrap_20",
+     "range_derivation_source": "inferred_spread"
+    },
+    {
+     "factor_id": "fac_market_receptivity",
+     "factor_label": "Market Receptivity to Feature",
+     "influence_score": 0.6209677419354838,
+     "influence_rank": 2,
+     "sensitivity_score": 0.1925,
+     "elasticity": 0.6209677419354838,
+     "direction": "positive",
+     "importance_rank": 2,
+     "value_of_information": 0,
+     "confidence": 0.44384999999999997,
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "confidence_provenance": {
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "is_provisional": true,
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "input_quality": "standard"
+     },
+     "confidence_components": {
+      "structural_certainty": 0.5,
+      "sampling_stability": 0.25
+     },
+     "source": "graph",
+     "flip_risk_category": "correlated",
+     "attribution_stability": "low",
+     "elasticity_std": 0.02286953,
+     "rank_flip_rate": 0.05,
+     "stability_method": "bootstrap_20",
+     "value_defaulted": true,
+     "evpi_percentage_points": 0,
+     "evpi_method": "heuristic",
+     "range_derivation_source": "default"
+    },
+    {
+     "factor_id": "fac_founder_time",
+     "factor_label": "Founder Time on Marketing",
+     "influence_score": 0.4838709677419354,
+     "influence_rank": 3,
+     "sensitivity_score": -0.15,
+     "elasticity": 0.4838709677419354,
+     "direction": "negative",
+     "importance_rank": 3,
+     "value_of_information": 0,
+     "confidence": 0.44045,
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "confidence_provenance": {
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "is_provisional": true,
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "input_quality": "standard"
+     },
+     "confidence_components": {
+      "structural_certainty": 0.5,
+      "sampling_stability": 0.25
+     },
+     "source": "graph",
+     "flip_risk_category": "correlated",
+     "attribution_stability": "low",
+     "elasticity_std": 0.010763087099999999,
+     "rank_flip_rate": 0.25,
+     "stability_method": "bootstrap_20",
+     "evpi_percentage_points": 0,
+     "evpi_method": "heuristic",
+     "range_derivation_source": "explicit_cap"
+    },
+    {
+     "factor_id": "fac_manager_cost",
+     "factor_label": "Marketing Personnel Cost",
+     "influence_score": 0.45161290322580644,
+     "influence_rank": 4,
+     "sensitivity_score": 0,
+     "elasticity": 0,
+     "direction": "negative",
+     "importance_rank": 4,
+     "value_of_information": 0,
+     "confidence": 0.3,
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "confidence_provenance": {
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "is_provisional": true,
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "input_quality": "standard"
+     },
+     "confidence_components": {
+      "structural_certainty": 0.5,
+      "sampling_stability": 0
+     },
+     "zero_reason": "intervention_override",
+     "source": "graph",
+     "flip_risk_category": "correlated",
+     "attribution_stability": "negligible",
+     "elasticity_std": 0,
+     "rank_flip_rate": 0,
+     "stability_method": "bootstrap_20",
+     "range_derivation_source": "explicit_cap"
+    },
+    {
+     "factor_id": "fac_ad_spend",
+     "factor_label": "Paid Advertising Budget",
+     "influence_score": 0.14516129032258066,
+     "influence_rank": 5,
+     "sensitivity_score": 0,
+     "elasticity": 0,
+     "direction": "positive",
+     "importance_rank": 5,
+     "value_of_information": 0,
+     "confidence": 0.3,
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "confidence_provenance": {
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "is_provisional": true,
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "input_quality": "standard"
+     },
+     "confidence_components": {
+      "structural_certainty": 0.5,
+      "sampling_stability": 0
+     },
+     "zero_reason": "intervention_override",
+     "source": "graph",
+     "flip_risk_category": "correlated",
+     "attribution_stability": "negligible",
+     "elasticity_std": 0,
+     "rank_flip_rate": 0.05,
+     "stability_method": "bootstrap_20",
+     "range_derivation_source": "explicit_cap"
+    }
+   ],
+   "robustness": {
+    "fragile_edges": [
+     {
+      "edge_id": "out_launch_reach->goal_launch",
+      "from_id": "out_launch_reach",
+      "to_id": "goal_launch",
+      "switch_probability": 0.058,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_status_quo",
+      "from_label": "Feature Launch Reach and Awareness",
+      "to_label": "Successful Product Feature Launch Within Budget",
+      "severity": "warning",
+      "alternative_winner_label": "Handle Marketing Internally (Status Quo)"
+     },
+     {
+      "edge_id": "fac_ad_spend->out_launch_reach",
+      "from_id": "fac_ad_spend",
+      "to_id": "out_launch_reach",
+      "switch_probability": 0.053,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_status_quo",
+      "from_label": "Paid Advertising Budget",
+      "to_label": "Feature Launch Reach and Awareness",
+      "severity": "warning",
+      "alternative_winner_label": "Handle Marketing Internally (Status Quo)"
+     },
+     {
+      "edge_id": "fac_ad_spend->risk_budget_overrun",
+      "from_id": "fac_ad_spend",
+      "to_id": "risk_budget_overrun",
+      "switch_probability": 0.164,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Paid Advertising Budget",
+      "to_label": "Annual Budget Overrun",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "risk_budget_overrun->goal_launch",
+      "from_id": "risk_budget_overrun",
+      "to_id": "goal_launch",
+      "switch_probability": 0.051,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Annual Budget Overrun",
+      "to_label": "Successful Product Feature Launch Within Budget",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "fac_founder_time->risk_founder_distraction",
+      "from_id": "fac_founder_time",
+      "to_id": "risk_founder_distraction",
+      "switch_probability": 0.096,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Founder Time on Marketing",
+      "to_label": "Founder Distraction from Core Work",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "fac_marketing_expertise->out_campaign_effectiveness",
+      "from_id": "fac_marketing_expertise",
+      "to_id": "out_campaign_effectiveness",
+      "switch_probability": 0.24,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Marketing Strategy Quality",
+      "to_label": "Campaign Conversion Effectiveness",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "out_campaign_effectiveness->goal_launch",
+      "from_id": "out_campaign_effectiveness",
+      "to_id": "goal_launch",
+      "switch_probability": 0.213,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Campaign Conversion Effectiveness",
+      "to_label": "Successful Product Feature Launch Within Budget",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "fac_market_receptivity->out_campaign_effectiveness",
+      "from_id": "fac_market_receptivity",
+      "to_id": "out_campaign_effectiveness",
+      "switch_probability": 0.11649580615097857,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Market Receptivity to Feature",
+      "to_label": "Campaign Conversion Effectiveness",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "risk_founder_distraction->goal_launch",
+      "from_id": "risk_founder_distraction",
+      "to_id": "goal_launch",
+      "switch_probability": 0.05,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Founder Distraction from Core Work",
+      "to_label": "Successful Product Feature Launch Within Budget",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "fac_marketing_expertise->risk_founder_distraction",
+      "from_id": "fac_marketing_expertise",
+      "to_id": "risk_founder_distraction",
+      "switch_probability": 0.058,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Marketing Strategy Quality",
+      "to_label": "Founder Distraction from Core Work",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "fac_manager_cost->risk_founder_distraction",
+      "from_id": "fac_manager_cost",
+      "to_id": "risk_founder_distraction",
+      "switch_probability": 0.099,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Marketing Personnel Cost",
+      "to_label": "Founder Distraction from Core Work",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "fac_market_receptivity->out_launch_reach",
+      "from_id": "fac_market_receptivity",
+      "to_id": "out_launch_reach",
+      "switch_probability": 0.099,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Market Receptivity to Feature",
+      "to_label": "Feature Launch Reach and Awareness",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     },
+     {
+      "edge_id": "fac_manager_cost->risk_budget_overrun",
+      "from_id": "fac_manager_cost",
+      "to_id": "risk_budget_overrun",
+      "switch_probability": 0.092,
+      "marginal_switch_probability": 0,
+      "alternative_winner_id": "opt_ai",
+      "from_label": "Marketing Personnel Cost",
+      "to_label": "Annual Budget Overrun",
+      "severity": "warning",
+      "alternative_winner_label": "AI Tool + Increased Ad Spend"
+     }
+    ],
+    "robust_edges": [],
+    "recommendation_stability": 0.8541875,
+    "is_robust": true,
+    "level": "high",
+    "confidence": 0.8406816097557746,
+    "recommended_option_id": "opt_hire",
+    "recommended_option_label": "Hire Marketing Manager",
+    "near_tie": {
+     "is_tie": false,
+     "top_option_id": "opt_hire",
+     "second_option_id": "opt_ai",
+     "tied_option_ids": [
+      "opt_hire"
+     ],
+     "gap": 0.75525,
+     "threshold": 0.1
+    }
+   },
+   "option_comparison_status": "computed",
+   "conditional_probabilities": [],
+   "edge_e_values": [
+    {
+     "edge_id": "fac_ad_spend::risk_budget_overrun",
+     "from_id": "fac_ad_spend",
+     "to_id": "risk_budget_overrun",
+     "from_label": "Paid Advertising Budget",
+     "to_label": "Annual Budget Overrun",
+     "e_value": 1,
+     "flip_direction": "decrease",
+     "current_mean": 0.45,
+     "flip_mean": -0.397828
+    },
+    {
+     "edge_id": "fac_marketing_expertise::out_campaign_effectiveness",
+     "from_id": "fac_marketing_expertise",
+     "to_id": "out_campaign_effectiveness",
+     "from_label": "Marketing Strategy Quality",
+     "to_label": "Campaign Conversion Effectiveness",
+     "e_value": 1,
+     "flip_direction": "decrease",
+     "current_mean": 0.55,
+     "flip_mean": -0.102829
+    },
+    {
+     "edge_id": "fac_marketing_expertise::risk_founder_distraction",
+     "from_id": "fac_marketing_expertise",
+     "to_id": "risk_founder_distraction",
+     "from_label": "Marketing Strategy Quality",
+     "to_label": "Founder Distraction from Core Work",
+     "e_value": 2.2528,
+     "flip_direction": "increase",
+     "current_mean": -0.3,
+     "flip_mean": 0.675854
+    },
+    {
+     "edge_id": "out_campaign_effectiveness::goal_launch",
+     "from_id": "out_campaign_effectiveness",
+     "to_id": "goal_launch",
+     "from_label": "Campaign Conversion Effectiveness",
+     "to_label": "Successful Product Feature Launch Within Budget",
+     "e_value": 1,
+     "flip_direction": "decrease",
+     "current_mean": 0.4,
+     "flip_mean": -0.074784
+    },
+    {
+     "edge_id": "risk_budget_overrun::goal_launch",
+     "from_id": "risk_budget_overrun",
+     "to_id": "goal_launch",
+     "from_label": "Annual Budget Overrun",
+     "to_label": "Successful Product Feature Launch Within Budget",
+     "e_value": 1,
+     "flip_direction": "increase",
+     "current_mean": -0.5,
+     "flip_mean": 0.442056
+    },
+    {
+     "edge_id": "risk_founder_distraction::goal_launch",
+     "from_id": "risk_founder_distraction",
+     "to_id": "goal_launch",
+     "from_label": "Founder Distraction from Core Work",
+     "to_label": "Successful Product Feature Launch Within Budget",
+     "e_value": 2.2528,
+     "flip_direction": "increase",
+     "current_mean": -0.3,
+     "flip_mean": 0.675843
+    }
+   ],
+   "inference_warnings": [
+    {
+     "code": "EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE",
+     "message": "Edge-level sensitivity was requested but the ISL V2 response format does not carry it \u2014 edge_sensitivity is empty by wire contract, not by computation failure. Factor-level sensitivity is unaffected.",
+     "severity": "info"
+    },
+    {
+     "code": "CONSTRAINT_NODE_DEFAULT_BASE",
+     "message": "Node 'out_campaign_effectiveness' has no ParameterUncertainty \u2014 defaulted to base=0.0, constraint probability may be unreliable",
+     "severity": "info"
+    },
+    {
+     "code": "CONSTRAINT_TARGET_UNRELIABLE",
+     "message": "The target for 'out_campaign_effectiveness' could not be reliably assessed - set an explicit range for this outcome to make the target meaningful.",
+     "severity": "warning"
+    }
+   ],
+   "confidence_tier": "needs_work",
+   "flip_thresholds": [
+    {
+     "factor_id": "fac_founder_time",
+     "factor_label": "Founder Time on Marketing",
+     "current_value": 50,
+     "flip_value": null,
+     "direction": "increase",
+     "unit": "%",
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "flip_reason": "no_effect_within_bounds",
+     "iterations_used": 0,
+     "probes_used": 3,
+     "margin_sensitivity": {
+      "movement": "none",
+      "threshold": 0.05,
+      "baseline_leading_option_id": "opt_hire",
+      "baseline_runner_up_option_id": "opt_ai",
+      "baseline_margin": 0.756,
+      "min_probe_margin": 0.756,
+      "max_probe_margin": 0.756,
+      "min_probe_delta": 0,
+      "max_probe_delta": 0,
+      "strongest_direction": "none",
+      "strongest_probe_value": null,
+      "value_scale": "display",
+      "strongest_delta": null,
+      "strongest_delta_abs": null,
+      "strongest_delta_percentage_points": null,
+      "display_value_available": false
+     }
+    }
+   ]
+  }
+ }
+}

--- a/src/v5/__tests__/mapV5AnalysisToReport.influence-warnings.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.influence-warnings.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Lane UI-R3 (truth rendering) — roadmap 1.7 + 1.12 mapper contract.
+ *
+ * Feature B (1.7): mapV5AnalysisToReport previously narrowed
+ * `enrichment.factor_sensitivity[]` to { factor_id, factor_label,
+ * sensitivity, direction }, DROPPING the producer's influence_score /
+ * influence_rank / zero_reason before the store. These tests lock the
+ * additive passthrough (provisional_doctrine_v0: influence ≠ sensitivity).
+ *
+ * Feature C (1.12): `enrichment.inference_warnings[]` previously never left
+ * the mapper, so warning-severity entries could not reach any user surface.
+ * These tests lock the verbatim passthrough onto the widened report.
+ *
+ * Fixture: real staging capture (debug bundle olumi-debug-45c9b625-20260707,
+ * payloads.cee_response.blocks[0]) — real factor ids, real influence values,
+ * real warning shapes. See fixture _provenance for the one synthetic
+ * warning-severity entry.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+import bundleFixture from './fixtures/v5-analysis-result.bundle-45c9b625.json'
+
+type WidenedReport = ReturnType<typeof mapV5AnalysisToReport> & Record<string, unknown>
+
+interface FactorRow {
+  factor_id: string
+  factor_label: string
+  sensitivity: number
+  direction: 'positive' | 'negative'
+  influence_score?: number
+  influence_rank?: number
+  zero_reason?: string
+}
+
+function mapBundleBlock(): WidenedReport {
+  const block = bundleFixture.block as unknown as AnalysisResultBlock
+  return mapV5AnalysisToReport(block) as WidenedReport
+}
+
+function factorById(report: WidenedReport, id: string): FactorRow {
+  const rows = report.factor_sensitivity as FactorRow[]
+  const row = rows.find((f) => f.factor_id === id)
+  expect(row, `factor ${id} present in widened.factor_sensitivity`).toBeDefined()
+  return row as FactorRow
+}
+
+describe('mapV5AnalysisToReport — influence passthrough (roadmap 1.7)', () => {
+  it('carries producer influence_score and influence_rank verbatim onto factor_sensitivity rows', () => {
+    const report = mapBundleBlock()
+
+    // Real staging values from the captured bundle.
+    const receptivity = factorById(report, 'fac_market_receptivity')
+    expect(receptivity.influence_score).toBe(0.6209677419354838)
+    expect(receptivity.influence_rank).toBe(2)
+
+    const founderTime = factorById(report, 'fac_founder_time')
+    expect(founderTime.influence_score).toBe(0.4838709677419354)
+    expect(founderTime.influence_rank).toBe(3)
+
+    const adSpend = factorById(report, 'fac_ad_spend')
+    expect(adSpend.influence_score).toBe(0.14516129032258066)
+    expect(adSpend.influence_rank).toBe(5)
+  })
+
+  it('pinned factor (zero_reason intervention_override) keeps influence_score 1 despite sensitivity 0', () => {
+    const report = mapBundleBlock()
+    const pinned = factorById(report, 'fac_marketing_expertise')
+    // Producer says: maximum structural influence, zero sensitivity because
+    // the options pin it. Both truths must reach the store unaltered.
+    expect(pinned.influence_score).toBe(1)
+    expect(pinned.influence_rank).toBe(1)
+    expect(pinned.sensitivity).toBe(0)
+    expect(pinned.zero_reason).toBe('intervention_override')
+  })
+
+  it('omits influence fields when the producer omits them (no defaults, no derivation)', () => {
+    const block = {
+      type: 'analysis_result',
+      summary: 'legacy shape without influence fields',
+      leading_option_id: null,
+      win_probabilities: { opt_a: 0.6 },
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_x', factor_label: 'X', sensitivity_score: 0.4, direction: 'positive' },
+        ],
+      },
+    } as unknown as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as WidenedReport
+    const row = (report.factor_sensitivity as FactorRow[])[0]
+    expect(row.factor_id).toBe('fac_x')
+    expect('influence_score' in row).toBe(false)
+    expect('influence_rank' in row).toBe(false)
+    expect('zero_reason' in row).toBe(false)
+  })
+})
+
+describe('mapV5AnalysisToReport — inference_warnings passthrough (roadmap 1.12)', () => {
+  it('passes enrichment.inference_warnings through verbatim onto the widened report', () => {
+    const report = mapBundleBlock()
+    const warnings = report.inference_warnings as Array<Record<string, unknown>>
+    expect(Array.isArray(warnings)).toBe(true)
+    expect(warnings).toHaveLength(3)
+
+    // Real staging entries — byte-identical passthrough (code, message, severity).
+    expect(warnings[0].code).toBe('EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE')
+    expect(warnings[0].severity).toBe('info')
+    expect(warnings[1].code).toBe('CONSTRAINT_NODE_DEFAULT_BASE')
+    expect(warnings[1].severity).toBe('info')
+    expect(warnings[1].message).toBe(
+      "Node 'out_campaign_effectiveness' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable",
+    )
+
+    // Warning-severity entry (per producer-documented CONSTRAINT_TARGET_UNRELIABLE shape).
+    expect(warnings[2].code).toBe('CONSTRAINT_TARGET_UNRELIABLE')
+    expect(warnings[2].severity).toBe('warning')
+    expect(typeof warnings[2].message).toBe('string')
+
+    // Verbatim: the mapped array is the fixture array's content, unrewritten.
+    expect(warnings).toEqual(
+      (bundleFixture.block as { enrichment: { inference_warnings: unknown[] } }).enrichment
+        .inference_warnings,
+    )
+  })
+
+  it('emits no inference_warnings key when the enrichment carries none', () => {
+    const block = {
+      type: 'analysis_result',
+      summary: 'no warnings',
+      leading_option_id: null,
+      win_probabilities: { opt_a: 0.6 },
+      enrichment: {},
+    } as unknown as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as WidenedReport
+    expect('inference_warnings' in report).toBe(false)
+  })
+})

--- a/src/v5/__tests__/phase3TypedBlocks.spec.ts
+++ b/src/v5/__tests__/phase3TypedBlocks.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Lane UI-R3 (truth rendering) — Track C slice 1: 0.13.x typed Phase 3
+ * block adapters (coaching / review_card).
+ *
+ * Contract under test (provisional_doctrine_v0):
+ *   - EXACTLY the typed fields are read; unknown subfields at any depth are
+ *     ignored (additive producer evolution never breaks rendering).
+ *   - Fail-closed: missing/mistyped required render-relevant fields → null
+ *     (caller counts + suppresses; nothing is invented or repaired).
+ *   - Copy is producer-verbatim.
+ *
+ * Shapes mirror the REAL live staging fixture
+ * (cee-response-b82c89dd-trimmed.json) — including its omission of the
+ * schema-declared `created_at`, which must NOT cause suppression.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  adaptTypedCoachingBlock,
+  adaptTypedReviewCardBlock,
+} from '../phase3TypedBlocks'
+
+const FIXTURE_PATH = resolve(__dirname, 'fixtures/cee-response-b82c89dd-trimmed.json')
+
+function liveBlocks(): Array<Record<string, unknown>> {
+  const fixture = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as {
+    blocks: Array<Record<string, unknown>>
+  }
+  return fixture.blocks
+}
+
+function liveReviewCard(): Record<string, unknown> {
+  const block = liveBlocks().find((b) => b.type === 'review_card')
+  if (!block) throw new Error('fixture review_card missing')
+  return block
+}
+
+function liveCoaching(): Record<string, unknown> {
+  const block = liveBlocks().find((b) => b.type === 'coaching')
+  if (!block) throw new Error('fixture coaching missing')
+  return block
+}
+
+describe('adaptTypedReviewCardBlock', () => {
+  it('adapts a REAL live 0.13.x review_card verbatim (created_at absent on the live wire)', () => {
+    const raw = liveReviewCard()
+    const adapted = adaptTypedReviewCardBlock(raw)
+    expect(adapted).not.toBeNull()
+    expect(adapted).toMatchObject({
+      type: 'v5_review_card',
+      block_id: raw.block_id,
+      title: raw.title,
+      body: raw.body,
+      severity: raw.severity,
+      card_kind: raw.card_kind,
+      priority_rank: raw.priority_rank,
+      freshness: raw.freshness,
+    })
+  })
+
+  it('ignores unknown subfields (top level AND inside target_refs)', () => {
+    const adapted = adaptTypedReviewCardBlock({
+      ...liveReviewCard(),
+      some_future_field: { nested: true },
+      target_refs: [
+        { id: 'fac_x', label: 'Factor X', kind: 'factor', future_ref_field: 42 },
+      ],
+    })
+    expect(adapted).not.toBeNull()
+    expect(adapted?.target_refs).toEqual([{ id: 'fac_x', label: 'Factor X', kind: 'factor' }])
+    expect('some_future_field' in (adapted as object)).toBe(false)
+  })
+
+  it.each([
+    ['missing body', { body: undefined }],
+    ['empty title', { title: '   ' }],
+    ['invalid severity', { severity: 'catastrophic' }],
+    ['missing severity', { severity: undefined }],
+    ['non-numeric priority_rank', { priority_rank: 'first' }],
+    ['invalid freshness', { freshness: 'ancient' }],
+    ['target_refs not an array', { target_refs: 'none' }],
+    ['wrong type discriminator', { type: 'coaching' }],
+  ])('fail-closed: %s → null (counted+suppressed by caller, never crash)', (_name, overrides) => {
+    const adapted = adaptTypedReviewCardBlock({ ...liveReviewCard(), ...overrides })
+    expect(adapted).toBeNull()
+  })
+
+  it('legacy-shaped card (summary instead of body, no severity) → null so the legacy bridge handles it', () => {
+    const adapted = adaptTypedReviewCardBlock({
+      type: 'review_card',
+      block_id: 'rc-legacy',
+      title: 'Legacy card',
+      summary: 'Legacy body text lives under summary.',
+      freshness: 'fresh',
+      card_kind: 'narrative',
+      target_refs: [],
+    })
+    expect(adapted).toBeNull()
+  })
+
+  it('skips malformed individual target_refs entries but keeps valid ones', () => {
+    const adapted = adaptTypedReviewCardBlock({
+      ...liveReviewCard(),
+      target_refs: [
+        { id: 'fac_ok', label: 'OK', kind: 'factor' },
+        { id: 'fac_missing_label', kind: 'factor' },
+        'not-an-object',
+      ],
+    })
+    expect(adapted?.target_refs).toEqual([{ id: 'fac_ok', label: 'OK', kind: 'factor' }])
+  })
+})
+
+describe('adaptTypedCoachingBlock', () => {
+  it('adapts a REAL live 0.13.x coaching block verbatim, including action refs', () => {
+    const raw = liveCoaching()
+    const adapted = adaptTypedCoachingBlock(raw)
+    expect(adapted).not.toBeNull()
+    expect(adapted).toMatchObject({
+      type: 'v5_coaching',
+      block_id: raw.block_id,
+      title: raw.title,
+      body: raw.body,
+      coaching_kind: raw.coaching_kind,
+      source: raw.source,
+      priority_rank: raw.priority_rank,
+      freshness: raw.freshness,
+      action_intent: raw.action_intent,
+      action_label: raw.action_label,
+    })
+  })
+
+  it('omits optional action fields when absent (no defaults)', () => {
+    const raw = { ...liveCoaching() }
+    delete raw.action_intent
+    delete raw.action_label
+    const adapted = adaptTypedCoachingBlock(raw)
+    expect(adapted).not.toBeNull()
+    expect('action_intent' in (adapted as object)).toBe(false)
+    expect('action_label' in (adapted as object)).toBe(false)
+  })
+
+  it.each([
+    ['missing body', { body: undefined }],
+    ['missing coaching_kind', { coaching_kind: undefined }],
+    ['missing source', { source: undefined }],
+    ['missing block_id', { block_id: '' }],
+    ['invalid freshness', { freshness: 'brand-new' }],
+    ['wrong type discriminator', { type: 'review_card' }],
+    ['non-object payload', null],
+  ])('fail-closed: %s → null', (_name, overrides) => {
+    const raw = overrides === null ? null : { ...liveCoaching(), ...overrides }
+    expect(adaptTypedCoachingBlock(raw)).toBeNull()
+  })
+})

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -1,0 +1,88 @@
+/**
+ * V5CoachingBlock — renders a 0.13.x-typed CEE coaching block
+ * (Track C slice 1, approved D-5; provisional_doctrine_v0).
+ *
+ * Truth-rendering contract (same as V5ReviewCardBlock):
+ *   - Every visible string is the producer's, verbatim: title, body,
+ *     target_refs[].label, action_label. The UI adds NO labels and NO
+ *     interpretation.
+ *   - Coaching is facilitator-voice content → info visual channel
+ *     (border-info/30 + Lightbulb), matching the existing coaching-card
+ *     idiom (DS: bg-panel, never bg-*-light on cards).
+ *   - `coaching_kind` / `source` / `freshness` / `block_id` ride as data-*
+ *     attributes only — never rendered as copy.
+ *   - `action_label` renders as a display-only outlined pill this slice;
+ *     wiring `action_intent` to turn dispatch is a recorded follow-up.
+ */
+import { type ReactElement } from 'react'
+import { Lightbulb } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import type { V5CoachingBlock as V5CoachingBlockType } from '../../canvas/conversation/types'
+
+export interface V5CoachingBlockProps {
+  block: V5CoachingBlockType
+}
+
+export function V5CoachingBlock({ block }: V5CoachingBlockProps): ReactElement {
+  return (
+    <div
+      data-testid="v5-coaching"
+      data-block-id={block.block_id}
+      data-coaching-kind={block.coaching_kind}
+      data-coaching-source={block.source}
+      data-freshness={block.freshness}
+      className="rounded-xl border border-info/30 bg-panel p-4 space-y-2"
+    >
+      <div className="flex items-start gap-2">
+        <Lightbulb size={16} className="flex-none mt-0.5 text-info" aria-hidden="true" />
+        <h3 className={typography.panelHeader} data-testid="v5-coaching-title">
+          {block.title}
+        </h3>
+      </div>
+      <p className={typography.panelBody} data-testid="v5-coaching-body">
+        {block.body}
+      </p>
+      {block.target_refs.length > 0 && (
+        <div
+          className="flex flex-wrap gap-2"
+          role="list"
+          aria-label="Referenced elements"
+          data-testid="v5-coaching-refs"
+        >
+          {block.target_refs.map((ref) => (
+            <span
+              key={ref.id}
+              role="listitem"
+              data-ref-id={ref.id}
+              data-ref-kind={ref.kind}
+              className={[
+                'inline-flex items-center rounded-full px-2.5 py-0.5',
+                'bg-transparent border border-panel-border text-text-body',
+                typography.panelMeta,
+              ].join(' ')}
+            >
+              {ref.label}
+            </span>
+          ))}
+        </div>
+      )}
+      {block.action_label && (
+        <div className="flex">
+          <span
+            data-testid="v5-coaching-action"
+            {...(block.action_intent ? { 'data-action-intent': block.action_intent } : {})}
+            className={[
+              'inline-flex items-center rounded-full px-2.5 py-0.5',
+              'bg-transparent border border-info/30 text-text-body',
+              typography.panelMeta,
+            ].join(' ')}
+          >
+            {block.action_label}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default V5CoachingBlock

--- a/src/v5/blocks/V5ReviewCardBlock.tsx
+++ b/src/v5/blocks/V5ReviewCardBlock.tsx
@@ -1,0 +1,106 @@
+/**
+ * V5ReviewCardBlock — renders a 0.13.x-typed CEE review_card block
+ * (Track C slice 1, approved D-5; provisional_doctrine_v0).
+ *
+ * Truth-rendering contract:
+ *   - Every visible string is the producer's, verbatim: title, body,
+ *     target_refs[].label, action_label. The UI adds NO labels, NO
+ *     science interpretation, NO severity copy.
+ *   - `severity` drives the visual channel only (border/icon colour per
+ *     the DS three-channel rule): info → info, warning → warning,
+ *     critical → danger.
+ *   - `card_kind` / `freshness` / `block_id` ride as data-* attributes for
+ *     tests + diagnostics; they are never rendered as copy.
+ *   - `action_label` renders as a display-only outlined pill this slice;
+ *     wiring `action_intent` to turn dispatch is a recorded follow-up
+ *     (next round), not invented here.
+ */
+import { type ReactElement } from 'react'
+import { AlertTriangle, Lightbulb } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import type { V5ReviewCardBlock as V5ReviewCardBlockType } from '../../canvas/conversation/types'
+
+export interface V5ReviewCardBlockProps {
+  block: V5ReviewCardBlockType
+}
+
+const SEVERITY_BORDER: Record<V5ReviewCardBlockType['severity'], string> = {
+  info: 'border-info/30',
+  warning: 'border-warning/30',
+  critical: 'border-danger/30',
+}
+
+const SEVERITY_ICON_COLOUR: Record<V5ReviewCardBlockType['severity'], string> = {
+  info: 'text-info',
+  warning: 'text-warning',
+  critical: 'text-danger',
+}
+
+export function V5ReviewCardBlock({ block }: V5ReviewCardBlockProps): ReactElement {
+  const Icon = block.severity === 'info' ? Lightbulb : AlertTriangle
+  return (
+    <div
+      data-testid="v5-review-card"
+      data-block-id={block.block_id}
+      data-card-kind={block.card_kind}
+      data-severity={block.severity}
+      data-freshness={block.freshness}
+      className={`rounded-xl border ${SEVERITY_BORDER[block.severity]} bg-panel p-4 space-y-2`}
+    >
+      <div className="flex items-start gap-2">
+        <Icon
+          size={16}
+          className={`flex-none mt-0.5 ${SEVERITY_ICON_COLOUR[block.severity]}`}
+          aria-hidden="true"
+        />
+        <h3 className={typography.panelHeader} data-testid="v5-review-card-title">
+          {block.title}
+        </h3>
+      </div>
+      <p className={typography.panelBody} data-testid="v5-review-card-body">
+        {block.body}
+      </p>
+      {block.target_refs.length > 0 && (
+        <div
+          className="flex flex-wrap gap-2"
+          role="list"
+          aria-label="Referenced elements"
+          data-testid="v5-review-card-refs"
+        >
+          {block.target_refs.map((ref) => (
+            <span
+              key={ref.id}
+              role="listitem"
+              data-ref-id={ref.id}
+              data-ref-kind={ref.kind}
+              className={[
+                'inline-flex items-center rounded-full px-2.5 py-0.5',
+                'bg-transparent border border-panel-border text-text-body',
+                typography.panelMeta,
+              ].join(' ')}
+            >
+              {ref.label}
+            </span>
+          ))}
+        </div>
+      )}
+      {block.action_label && (
+        <div className="flex">
+          <span
+            data-testid="v5-review-card-action"
+            {...(block.action_intent ? { 'data-action-intent': block.action_intent } : {})}
+            className={[
+              'inline-flex items-center rounded-full px-2.5 py-0.5',
+              'bg-transparent border border-info/30 text-text-body',
+              typography.panelMeta,
+            ].join(' ')}
+          >
+            {block.action_label}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default V5ReviewCardBlock

--- a/src/v5/blocks/__tests__/V5Phase3Blocks.spec.tsx
+++ b/src/v5/blocks/__tests__/V5Phase3Blocks.spec.tsx
@@ -1,0 +1,112 @@
+/**
+ * Lane UI-R3 (truth rendering) — Track C slice 1: DOM contracts for the
+ * typed Phase 3 renderers (V5ReviewCardBlock / V5CoachingBlock).
+ *
+ * Doctrine (provisional_doctrine_v0):
+ *   - Every visible string is producer copy verbatim (title, body,
+ *     target_refs labels, action_label). NO invented labels, NO science
+ *     interpretation, NO severity/kind words rendered as text.
+ *   - severity drives the visual channel only (data-severity + styling).
+ *   - kind/freshness/block_id ride as data-* attributes, never as copy.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { V5ReviewCardBlock } from '../V5ReviewCardBlock'
+import { V5CoachingBlock } from '../V5CoachingBlock'
+import type {
+  V5CoachingBlock as V5CoachingBlockType,
+  V5ReviewCardBlock as V5ReviewCardBlockType,
+} from '../../../canvas/conversation/types'
+
+const REVIEW: V5ReviewCardBlockType = {
+  type: 'v5_review_card',
+  block_id: 'e2f8988e-ccf0-5d10-ad58-99c45ec5230c',
+  title: 'A load-bearing assumption',
+  body: 'The relationship between Technical Leadership Capacity and overall throughput remains stable.',
+  severity: 'info',
+  card_kind: 'assumption',
+  target_refs: [{ id: 'fac_tech_lead', label: 'Technical Leadership Capacity', kind: 'factor' }],
+  priority_rank: 71,
+  freshness: 'fresh',
+}
+
+const COACHING: V5CoachingBlockType = {
+  type: 'v5_coaching',
+  block_id: '7e0855c7-d79d-5d16-9fee-19e68ece297d',
+  title: 'An assumption to check',
+  body: 'The relationship between Technical Leadership Capacity and overall throughput remains stable.',
+  coaching_kind: 'assumption_check',
+  source: 'decision_review',
+  target_refs: [],
+  priority_rank: 101,
+  freshness: 'fresh',
+  action_intent: 'confirm_factor',
+  action_label: 'Confirm this assumption',
+}
+
+describe('V5ReviewCardBlock', () => {
+  it('renders producer title, body, and target_refs labels VERBATIM', () => {
+    render(<V5ReviewCardBlock block={REVIEW} />)
+    expect(screen.getByTestId('v5-review-card-title')).toHaveTextContent(REVIEW.title)
+    expect(screen.getByTestId('v5-review-card-body')).toHaveTextContent(REVIEW.body)
+    expect(screen.getByTestId('v5-review-card-refs')).toHaveTextContent(
+      'Technical Leadership Capacity',
+    )
+  })
+
+  it('exposes severity / card_kind / freshness as data-* only — never as visible copy', () => {
+    render(<V5ReviewCardBlock block={REVIEW} />)
+    const card = screen.getByTestId('v5-review-card')
+    expect(card).toHaveAttribute('data-severity', 'info')
+    expect(card).toHaveAttribute('data-card-kind', 'assumption')
+    expect(card).toHaveAttribute('data-freshness', 'fresh')
+    // Enum tokens must not leak into visible text.
+    expect(card.textContent).not.toMatch(/assumption_check|\binfo\b|\bfresh\b/)
+  })
+
+  it('warning/critical severity switches the visual channel (data-severity), copy unchanged', () => {
+    render(<V5ReviewCardBlock block={{ ...REVIEW, severity: 'critical' }} />)
+    expect(screen.getByTestId('v5-review-card')).toHaveAttribute('data-severity', 'critical')
+    expect(screen.getByTestId('v5-review-card-body')).toHaveTextContent(REVIEW.body)
+  })
+
+  it('renders no action pill when the producer sent no action refs', () => {
+    render(<V5ReviewCardBlock block={REVIEW} />)
+    expect(screen.queryByTestId('v5-review-card-action')).not.toBeInTheDocument()
+  })
+
+  it('renders the producer action_label verbatim when present', () => {
+    render(
+      <V5ReviewCardBlock
+        block={{ ...REVIEW, action_intent: 'confirm_factor', action_label: 'Confirm this assumption' }}
+      />,
+    )
+    const action = screen.getByTestId('v5-review-card-action')
+    expect(action).toHaveTextContent('Confirm this assumption')
+    expect(action).toHaveAttribute('data-action-intent', 'confirm_factor')
+  })
+})
+
+describe('V5CoachingBlock', () => {
+  it('renders producer title, body, and action_label VERBATIM', () => {
+    render(<V5CoachingBlock block={COACHING} />)
+    expect(screen.getByTestId('v5-coaching-title')).toHaveTextContent(COACHING.title)
+    expect(screen.getByTestId('v5-coaching-body')).toHaveTextContent(COACHING.body)
+    expect(screen.getByTestId('v5-coaching-action')).toHaveTextContent('Confirm this assumption')
+  })
+
+  it('exposes coaching_kind / source / freshness as data-* only — never as visible copy', () => {
+    render(<V5CoachingBlock block={COACHING} />)
+    const card = screen.getByTestId('v5-coaching')
+    expect(card).toHaveAttribute('data-coaching-kind', 'assumption_check')
+    expect(card).toHaveAttribute('data-coaching-source', 'decision_review')
+    expect(card).toHaveAttribute('data-freshness', 'fresh')
+    expect(card.textContent).not.toMatch(/assumption_check|decision_review|\bfresh\b/)
+  })
+
+  it('renders no refs list when target_refs is empty', () => {
+    render(<V5CoachingBlock block={COACHING} />)
+    expect(screen.queryByTestId('v5-coaching-refs')).not.toBeInTheDocument()
+  })
+})

--- a/src/v5/blocks/mapV5Blocks.ts
+++ b/src/v5/blocks/mapV5Blocks.ts
@@ -85,14 +85,48 @@ export function mapV5Block(block: V5Block): ConversationBlock | null {
         ...(block.enrichment ? { enrichment: block.enrichment } : {}),
       }
     case 'review_card':
+      // Track C slice 1 (D-5): 0.13.x-typed Phase 3 review_card. At runtime
+      // these normally arrive via the parser sidecar (splitBlocksTolerance
+      // lifts them out of blocks[] pre-validation) and are surfaced by
+      // composePhase3BridgedBlocks; this branch keeps the mapper coherent
+      // for any future path where a schema-validated block reaches it
+      // directly. Fields are typed by the 0.13.x schema — copied verbatim.
+      return {
+        type: 'v5_review_card',
+        block_id: block.block_id,
+        title: block.title,
+        body: block.body,
+        severity: block.severity,
+        card_kind: block.card_kind,
+        target_refs: block.target_refs,
+        priority_rank: block.priority_rank,
+        freshness: block.freshness,
+        ...(block.action_intent ? { action_intent: block.action_intent } : {}),
+        ...(block.action_label ? { action_label: block.action_label } : {}),
+      }
     case 'coaching':
+      // Track C slice 1 (D-5): 0.13.x-typed Phase 3 coaching. Same note as
+      // review_card above.
+      return {
+        type: 'v5_coaching',
+        block_id: block.block_id,
+        title: block.title,
+        body: block.body,
+        coaching_kind: block.coaching_kind,
+        source: block.source,
+        target_refs: block.target_refs,
+        priority_rank: block.priority_rank,
+        freshness: block.freshness,
+        ...(block.action_intent ? { action_intent: block.action_intent } : {}),
+        ...(block.action_label ? { action_label: block.action_label } : {}),
+      }
     case 'evidence':
     case 'exercise':
-      // 0.13.1 re-vendor: Phase 3 types are now schema-declared, but the
-      // parser tolerance layer stashes them in the sidecar BEFORE strict
-      // validation (splitBlocksTolerance), so they never reach this mapper
-      // at runtime. Type-level only: behaviour matches 0.8.1, where these
-      // types were schema-unknown and hit the defensive default below.
+      // 0.13.1 re-vendor: schema-declared but still without a renderer in
+      // this slice. The parser tolerance layer stashes them in the sidecar
+      // BEFORE strict validation, so they never reach this mapper at
+      // runtime; the bridge counts them via the dropped-content counter
+      // (rationale 'no_renderer_for_block_type').
       return {
         type: 'v5_unsupported',
         blockType: block.type,

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -54,6 +54,21 @@ interface NormalisedFactor {
   factor_label: string
   sensitivity: number // absolute magnitude
   direction: 'positive' | 'negative'
+  /**
+   * Producer influence_score (0-1) — structural causal influence, a DISTINCT
+   * measure from sensitivity (roadmap 1.7; provisional_doctrine_v0:
+   * influence ≠ sensitivity). Additive passthrough only — never derived,
+   * never defaulted; absent when the producer omitted it.
+   */
+  influence_score?: number
+  /** Producer influence_rank (1 = most influential). Additive passthrough. */
+  influence_rank?: number
+  /**
+   * Producer zero_reason (e.g. 'intervention_override' for pinned factors).
+   * Additive passthrough so the DriversSection can show influence WITHOUT
+   * sensitivity-flavoured copy for pinned factors.
+   */
+  zero_reason?: string
 }
 
 /**
@@ -96,11 +111,22 @@ function normaliseFactorEntry(entry: unknown): NormalisedFactor | null {
   const direction: 'positive' | 'negative' =
     explicitDirection ?? (rawMagnitude >= 0 ? 'positive' : 'negative')
 
+  // Roadmap 1.7 (provisional_doctrine_v0): influence_score / influence_rank /
+  // zero_reason are producer-owned fields carried through verbatim. No
+  // derivation, no defaults — undefined when absent so downstream consumers
+  // can distinguish "not provided" from any real value.
+  const influenceScore = safeFiniteNumber(entry.influence_score)
+  const influenceRank = safeFiniteNumber(entry.influence_rank)
+  const zeroReason = safeString(entry.zero_reason)
+
   return {
     factor_id: factorId,
     factor_label: factorLabel,
     sensitivity: Math.abs(rawMagnitude),
     direction,
+    ...(influenceScore !== undefined ? { influence_score: influenceScore } : {}),
+    ...(influenceRank !== undefined ? { influence_rank: influenceRank } : {}),
+    ...(zeroReason !== undefined ? { zero_reason: zeroReason } : {}),
   }
 }
 
@@ -443,6 +469,17 @@ export function mapV5AnalysisToReport(
     : undefined
   const conditionalProbabilities = enrichment?.conditional_probabilities
 
+  // Roadmap 1.12: producer inference_warnings ({ code, message, severity })
+  // pass through verbatim so the Analysis tab can surface warning-severity
+  // entries. Top-level `enrichment.inference_warnings` is the live V5 wire
+  // location (captured bundle olumi-debug-45c9b625-20260707); the V4 mapper
+  // reads the same field from robustness (responseMapper.ts:563) and the
+  // selector accepts both slots. Passthrough only — the UI never rewrites
+  // codes, messages, or severities.
+  const inferenceWarnings = Array.isArray(enrichment?.inference_warnings)
+    ? (enrichment!.inference_warnings as unknown[])
+    : undefined
+
   // Deterministic response_hash when caller has none. Stable across identical
   // blocks so the store's hash-dedupe in resultsComplete works.
   //
@@ -536,11 +573,20 @@ export function mapV5AnalysisToReport(
       factor_label: f.factor_label,
       sensitivity: f.sensitivity,
       direction: f.direction,
+      // Roadmap 1.7 additive passthrough (provisional_doctrine_v0):
+      // influence_score / influence_rank / zero_reason reach the store so
+      // the DriversSection "Influence" column renders the PRODUCER's
+      // influence measure instead of falling back to a UI-normalised
+      // sensitivity (influence ≠ sensitivity). Omitted when absent.
+      ...(f.influence_score !== undefined ? { influence_score: f.influence_score } : {}),
+      ...(f.influence_rank !== undefined ? { influence_rank: f.influence_rank } : {}),
+      ...(f.zero_reason !== undefined ? { zero_reason: f.zero_reason } : {}),
     }))
   }
   if (robustness) widened.robustness = robustness
   if (topLevelFlipThresholds) widened.flip_thresholds = topLevelFlipThresholds
   if (topLevelEdgeEValues) widened.edge_e_values = topLevelEdgeEValues
+  if (inferenceWarnings) widened.inference_warnings = inferenceWarnings
   if (conditionalProbabilities !== undefined) {
     widened.conditional_probabilities = conditionalProbabilities
   }

--- a/src/v5/phase3TypedBlocks.ts
+++ b/src/v5/phase3TypedBlocks.ts
@@ -1,0 +1,169 @@
+/**
+ * phase3TypedBlocks — adapt verbatim Phase 3 raw payloads (coaching /
+ * review_card) to the UI's typed V5 conversation blocks per the 0.13.x
+ * @talchain/schemas shapes (Track C slice 1, approved D-5).
+ *
+ * Contract (provisional_doctrine_v0):
+ *   - Reads EXACTLY the 0.13.x typed fields (dist/boundary/blocks.d.ts in
+ *     the vendored tarball): title, body, severity/card_kind (review_card),
+ *     coaching_kind/source (coaching), target_refs, priority_rank,
+ *     freshness, action_intent?, action_label?. Unknown subfields are
+ *     IGNORED at every depth — additive producer fields never break
+ *     rendering.
+ *   - Fail-closed: a block missing/mistyping any required render-relevant
+ *     field adapts to `null`. The caller counts it (dropped-content
+ *     counter) and suppresses it — never crashes, never renders a card
+ *     with invented fields.
+ *   - No invented copy: every rendered string is the producer's, verbatim.
+ *
+ * Field-presence notes from live staging captures (fixture
+ * cee-response-b82c89dd-trimmed.json): blocks omit `created_at` even
+ * though the schema declares it, and review_card may omit the optional
+ * action fields. Adaptation therefore requires only the render-relevant
+ * fields and deliberately ignores schema-required-but-render-irrelevant
+ * metadata (signal_id, created_at, source_handler,
+ * graph_hash_at_generation) — a real producer block must not be
+ * suppressed over metadata the UI never shows.
+ *
+ * Validation-strictness choices:
+ *   - `severity` (review_card) must be one of the 0.13.x enum values —
+ *     it drives the visual variant, and the UI never guesses severity.
+ *   - `card_kind` / `coaching_kind` / `source` are required non-empty
+ *     strings but NOT enum-checked: they are pass-through discriminators
+ *     (exposed as data-* attributes only), so a new producer kind renders
+ *     fine without a UI release.
+ *   - `target_refs` must be an array; entries missing the typed
+ *     {id,label,kind} strings are skipped individually (they are
+ *     supplementary reference pills, not core content).
+ */
+import type {
+  V5BlockTargetRef,
+  V5CoachingBlock,
+  V5Phase3Freshness,
+  V5ReviewCardBlock,
+} from '../canvas/conversation/types'
+
+// ─── Field helpers ─────────────────────────────────────────────────────
+
+function nonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined
+}
+
+function finiteNumber(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v)
+}
+
+const FRESHNESS_VALUES: ReadonlySet<string> = new Set(['fresh', 'stale', 'pending', 'failed'])
+
+function freshness(v: unknown): V5Phase3Freshness | undefined {
+  return typeof v === 'string' && FRESHNESS_VALUES.has(v) ? (v as V5Phase3Freshness) : undefined
+}
+
+const REVIEW_SEVERITIES: ReadonlySet<string> = new Set(['info', 'warning', 'critical'])
+
+/**
+ * Extract the typed target_refs. The FIELD must be an array (schema-required);
+ * individual entries are kept only when they carry the full typed
+ * {id, label, kind} string triple — partial entries are skipped, not repaired.
+ */
+function targetRefs(v: unknown): V5BlockTargetRef[] | undefined {
+  if (!Array.isArray(v)) return undefined
+  const out: V5BlockTargetRef[] = []
+  for (const entry of v) {
+    if (!isPlainObject(entry)) continue
+    const id = nonEmptyString(entry.id)
+    const label = nonEmptyString(entry.label)
+    const kind = nonEmptyString(entry.kind)
+    if (id && label && kind) out.push({ id, label, kind })
+  }
+  return out
+}
+
+// ─── Adapters ──────────────────────────────────────────────────────────
+
+/**
+ * Adapt a verbatim raw payload to a typed v5_review_card block.
+ * Returns null when the payload is not a well-formed 0.13.x review_card
+ * (fail-closed; the caller counts + suppresses).
+ */
+export function adaptTypedReviewCardBlock(raw: unknown): V5ReviewCardBlock | null {
+  if (!isPlainObject(raw)) return null
+  if (raw.type !== 'review_card') return null
+
+  const blockId = nonEmptyString(raw.block_id)
+  const title = nonEmptyString(raw.title)
+  const body = nonEmptyString(raw.body)
+  const severityRaw = raw.severity
+  const cardKind = nonEmptyString(raw.card_kind)
+  const rank = finiteNumber(raw.priority_rank)
+  const fresh = freshness(raw.freshness)
+  const refs = targetRefs(raw.target_refs)
+
+  if (
+    !blockId || !title || !body || !cardKind || rank === undefined || !fresh || refs === undefined ||
+    typeof severityRaw !== 'string' || !REVIEW_SEVERITIES.has(severityRaw)
+  ) {
+    return null
+  }
+
+  const actionIntent = nonEmptyString(raw.action_intent)
+  const actionLabel = nonEmptyString(raw.action_label)
+
+  return {
+    type: 'v5_review_card',
+    block_id: blockId,
+    title,
+    body,
+    severity: severityRaw as V5ReviewCardBlock['severity'],
+    card_kind: cardKind,
+    target_refs: refs,
+    priority_rank: rank,
+    freshness: fresh,
+    ...(actionIntent ? { action_intent: actionIntent } : {}),
+    ...(actionLabel ? { action_label: actionLabel } : {}),
+  }
+}
+
+/**
+ * Adapt a verbatim raw payload to a typed v5_coaching block.
+ * Returns null when the payload is not a well-formed 0.13.x coaching block
+ * (fail-closed; the caller counts + suppresses).
+ */
+export function adaptTypedCoachingBlock(raw: unknown): V5CoachingBlock | null {
+  if (!isPlainObject(raw)) return null
+  if (raw.type !== 'coaching') return null
+
+  const blockId = nonEmptyString(raw.block_id)
+  const title = nonEmptyString(raw.title)
+  const body = nonEmptyString(raw.body)
+  const coachingKind = nonEmptyString(raw.coaching_kind)
+  const source = nonEmptyString(raw.source)
+  const rank = finiteNumber(raw.priority_rank)
+  const fresh = freshness(raw.freshness)
+  const refs = targetRefs(raw.target_refs)
+
+  if (!blockId || !title || !body || !coachingKind || !source || rank === undefined || !fresh || refs === undefined) {
+    return null
+  }
+
+  const actionIntent = nonEmptyString(raw.action_intent)
+  const actionLabel = nonEmptyString(raw.action_label)
+
+  return {
+    type: 'v5_coaching',
+    block_id: blockId,
+    title,
+    body,
+    coaching_kind: coachingKind,
+    source,
+    target_refs: refs,
+    priority_rank: rank,
+    freshness: fresh,
+    ...(actionIntent ? { action_intent: actionIntent } : {}),
+    ...(actionLabel ? { action_label: actionLabel } : {}),
+  }
+}


### PR DESCRIPTION
## Lane UI-R3 (branch `claude-lane9/truth-rendering`, base `origin/staging` @ `bd247d3a`)

Three coherent truth-rendering features (roadmap 2.2 slice-1 / 1.7 / 1.12 — Paul-approved, accelerated). All boundary-adjacent changes ADDITIVE; producers own semantics; wording surfaces tagged `provisional_doctrine_v0`. Full evidence report: `docs/lanes/lane9-truth-rendering.md`.

### A — Render 0.13.x `coaching` + `review_card` blocks (Track C slice 1, D-5)
- New typed conversation blocks `v5_review_card` / `v5_coaching` mirroring the vendored 0.13.1 Zod shapes exactly; all copy producer-verbatim (titles, body, target_refs labels, action_label); enum tokens ride `data-*` only.
- Adapters (`src/v5/phase3TypedBlocks.ts`): exactly the typed fields, unknown subfields ignored at any depth, fail-closed → counted + suppressed (dropped-content counter, new source `phase3_block_bridge`), never crash.
- Bridge: typed-first (all schema-valid blocks, producer `priority_rank` asc, dedupe by `block_id`); legacy-shaped review cards keep the original fact-gated top-1 fallback unchanged; evidence/exercise counted (`no_renderer_for_block_type`); parser unknown-type counting untouched.
- `phase3ReviewCardBridge.liveFixture.spec.ts` updated to the approved slice-1 contract (its fixture cards are real 0.13.x shapes); the legacy unit spec passes unchanged.

### B — Factor-card influence rendering (1.7)
- `mapV5AnalysisToReport` no longer drops `influence_score` / `influence_rank` / `zero_reason` from `factor_sensitivity`; additive passthrough → store → existing DriversSection "Influence" column now shows the PRODUCER's influence on the V5 path (influence ≠ sensitivity).
- Pinned factors (`zero_reason: intervention_override`) stay visible with influence and never get sensitivity-flavoured copy.

### C — Warning surfacing (1.12)
- `enrichment.inference_warnings` passes through the V5 mapper verbatim; selector keeps producer `severity`; new `InferenceWarningStrip` on the Analysis tab (below the freshness notice) renders warning-severity entries with the producer message VERBATIM. Info-severity stays hidden; no message → nothing rendered.

### Verification
- RED→GREEN per feature with bundle-shaped fixtures (real capture `olumi-debug-45c9b625-20260707`): B+C 6 RED → 15/15 GREEN; A 9/10 RED → 82/82 GREEN.
- Regression sweep: 1278 tests / 106 files green; parser tolerance + counter + block renderer suites green.
- `pnpm run typecheck` clean; `tsc -p tsconfig.app.json` error count 2331 == clean baseline; lint 0 errors on touched files; pre-push fast gate ALL CHECKS PASSED.
- Pre-existing failures NOT from this lane (identical with changes stashed): `ResultsBody.heroPlacement.spec` (3), env-dependent conversation-dir suites (see evidence report).

### Follow-ups (next round)
- Wire `action_intent` on typed Phase 3 blocks to chip/turn dispatch (display-only pill this slice).
- Evidence/exercise renderers; reload-persistence of rendered Phase 3 blocks; optional visual use of `influence_rank`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)