### PR TITLE
Lane UI-W5: reference-option disclosure, blocked-status handling, harness testability

### DIFF
--- a/docs/lanes/lane19-disclosure-blocked-testability.md
+++ b/docs/lanes/lane19-disclosure-blocked-testability.md
@@ -1,0 +1,86 @@
+# Lane UI-W5 — disclosure, blocked-status, testability (branch `claude-lane19/disclosure-blocked-testability`)
+
+**Date:** 2026-07-07 · **Base:** `origin/staging` @ `e9832126` (includes #237 / lane UI-W4) · **Repo:** DecisionGuideAI (writes confined here)
+**Producers consumed:** PLoT staging `sensitivity_reference_option_id` (lane PLoT-W4 passthrough of the ISL 9a22a1a+ envelope disclosure). PLoT `display_verdict` deliberately NOT consumed (lands next round per lane brief).
+**Doctrine:** UI renders, never invents; producers own semantics. New wording tagged `provisional_doctrine_v0`. All boundary-adjacent changes ADDITIVE.
+
+## Commits
+
+| Commit | Feature |
+|---|---|
+| `3b70a852` | C — harness testability selectors (SuccessTargetRow + Analysis-tab rerun affordances) |
+| `5d2c2477` | A — reference-option disclosure (`sensitivity_reference_option_id` consumption + caption) |
+| `15d19d15` | B — blocked-status handling (verified trace, blocked fixture coverage, one rendering fix) |
+
+## A — Reference-option disclosure
+
+PLoT `/v2/run` now emits root-level `sensitivity_reference_option_id` — the option the edge/factor sensitivities and fragile-edge classification were computed against (ISL uses the FIRST request option; verified against PLoT staging `src/routes/v2/run.ts` + `src/types/engine-v3.ts`, which also document: omitted when the deployed ISL did not disclose it — honest absence, and excluded from `response_hash`).
+
+**Data path (traced producer → validator → consumer):** PLoT `/v2/run` root `sensitivity_reference_option_id` → `V2RunResponse.sensitivity_reference_option_id` (new OPTIONAL field, `src/adapters/plot/v2/types.ts`) → `mapV2ResponseToReportV1` ADDITIVE pass-through guarded to non-empty strings (survives save + hydrate; same pattern as `flip_thresholds` / `decision_brief`; typed on `ResultsReport`) → `useResultsSectionData`: narrow raw-slot extraction (`rawSensitivityReferenceOptionId`, never subscribes to the whole raw response), mapped-report-preferred precedence, id → label via the canvas options list (`nodeLabelMap`) → `sensitivityReference: { optionId, optionLabel } | null` on the hook return → `ResultsBody` → both render surfaces.
+
+**Caption:** one shared component `SensitivityReferenceCaption` ("Sensitivities computed against `<option label>`", `provisional_doctrine_v0`) rendered where sensitivities / fragile edges render: **DriversSection** (under the ranking explainer) and **StressTestSection** (top of the section content, above sensitive-assumptions + fragile-factors). Panel typography only (`panelMeta text-text-light`), no new colour/idiom.
+
+**Fail-closed contract (pinned):** absent producer field → no caption on either surface; empty-string / non-string wire value → mapper omits the key; id that no longer resolves to a canvas label (deleted node, recovered session) → `optionLabel: null` → caption suppressed rather than leaking an internal node id as user copy.
+
+## B — Blocked-status handling (CEE #358 defensive leg)
+
+CEE synthesises `analysis_ready = { status:'blocked', goal_node_id:'', options:[], bias_findings:[] }` + `computed_at` + `freshness:'unknown'` + `freshness_reason` (`legacy_fact_missing_hash` | `current_graph_hash_unavailable`) at the ENVELOPE ROOT on legacy/unparseable reloads (verified against CEE staging `src/orchestrator-v5/compose/analysis-ready-emit.ts` + `response-finaliser.ts`).
+
+**Exact current behaviour, traced on the live V5 path (`applyV5State` step 4) and pinned with the exact wire shape:**
+
+1. `setAnalysisFreshness(raw)` runs FIRST (before shape validation) → freshness slice takes the verdict: `{ freshness:'unknown', freshnessReason, computedAt }` → display semantic `cannot_confirm`. The blocked/unknown state is NOT silently dropped.
+2. `normaliseV5AnalysisReady` REJECTS the payload on two independent grounds (empty `goal_node_id`, empty `options`) → `setCeeAnalysisReady(null)` clears the readiness slice (READINESS_CLEAR_FIELDS incl. sessionStorage) and the rejection is honestly reported as deferred `analysis_ready_invalid_shape`. No crash.
+3. Results panels: this path never touches `results.report`. On the legacy-reload scenario the report is null → no results body, no completeness claim; `deriveAnalysisDisplayState` (status undefined after the clear, no report) → `not_ready` ("Set up your model"), CTA null. sessionStorage restore of a blocked-shaped payload is independently rejected by `validateCeeAnalysisReady` (`empty_options`).
+4. Freshness surfaces: `AnalysisFreshnessNotice` renders "Cannot confirm whether this analysis is current." (technical reason on `data-freshness-reason` only, never user copy). The OutputsDock `graph-stale-banner` shows the cannot-confirm variant ONLY when a report exists (`analysisNotConfirmedFresh && !isError && report`) — correct for the empty-reload case (no report → no banner, pre-run state instead).
+
+**ONE violation found and FIXED (rendering-level only):** `deriveAnalysisDisplayState.EXPLICIT_NOT_READY_STATUSES` did not include `'blocked'`. The empty-options synthesis never reaches it (rejected upstream), but CEE's Ep2 readiness path can emit `status:'blocked'` WITH populated options, which the deliberately-lenient V5 normaliser passes through to the store — with a prior report held, that state rendered green **"Analysis complete"**. RED→GREEN pinned: `blocked` + prior report now derives `not_ready` (headline "Set up your model", never "Analysis complete"); `blocked` without report unchanged (`not_ready`, no run CTA). Existing behaviours (ready/needs_* transitions, unknown-freshness neutral completion fact) pinned unchanged in the same suite.
+
+**Not changed (explicitly):** the lenient V5 normaliser, the freshness reducer, and run gating (`usePreRunValidation` / `wouldPassStrictAttachContract` narrow on `status === 'ready'`, so blocked never enables Run) — all already honest; only the display mapping needed the fix.
+
+## C — Harness testability
+
+The Playwright acceptance harness could not reach the SuccessTargetRow "Set target" affordance. Test-support attributes only, zero behaviour change (pinned with render tests that also assert the commit path and `isRunning` disable still work):
+
+| Selector | Element | Status |
+|---|---|---|
+| `success-target-row` | SuccessTargetRow container (both branches) | pre-existing, kept |
+| `success-target-set-button` | "Set target" button | **added** |
+| `success-target-input` | target input (aria-label "Edit success target value" KEPT) | **added** |
+| `graph-stale-banner` (+ `data-banner-variant`) | Analysis-tab stale banner | pre-existing, kept |
+| `graph-stale-rerun-button` | Rerun button inside the stale banner | **added** |
+| `results-analysis-footer-action` | AnalysisFooter action button (derives `` `${testId}-action` ``) | **added** |
+
+## Tests & verification
+
+RED→GREEN stash-verified on this worktree for A and B (implementation stashed → failures; restored → green). C is render-only pins per the brief.
+
+| Feature | RED | GREEN | Suites |
+|---|---|---|---|
+| A | mapper positive case failed + 6/6 selector cases failed with impl stashed | 81/81 (incl. full responseMapper suite) | `responseMapper.spec` (UI-W5 describe: verbatim/absent/empty/non-string), `sensitivityReference.selector.spec` (report-preferred, raw fallback, label resolution, fail-closed), `SensitivityReferenceCaption.spec` (component + both surface pins) |
+| B | 1 failure (blocked + prior report claimed "Analysis complete") | 19/19 + 4/4 | `deriveAnalysisDisplayState.spec` (+blocked describe), `applyV5State.blockedAnalysisReady.spec` (exact CEE wire shape through the live ingestion path + freshness surface render) |
+| C | n/a (render pins) | 6/6 + 2/2 | `SuccessTargetRow.testability.spec`, `OutputsDock.testability.spec` |
+
+- Final focused sweep across every touched surface + direct dependents: **22 files / 275 tests passed** (incl. `applyV5State.test`, `analysisFreshness.spec`, `AnalysisFreshnessNotice.spec`, `useAnalysisDisplayState(.orphanGate).spec`, StressTest/Drivers suites, `influence-warnings.wire-to-selector.spec`).
+- Pre-analysis directory sweep (display-state consumers): 1151 passed / 13 skipped, 0 failures.
+- **Typecheck:** `pnpm run typecheck` (tsconfig.ci) clean after every feature. `npx tsc -p tsconfig.app.json --noEmit` error count **2331 == pristine-tree baseline 2331** (stash-compared; the only textual diffs are pre-existing TS2739 fixture lines whose message now lists `sensitivityReference` alongside the already-missing `completeness, autoNoiseProvenance` — same errors, same locations).
+- **Lint:** 0 errors on all 19 changed files; 6 warnings, all pre-existing (none on lines this lane added).
+
+### Pre-existing failures NOT introduced by this lane (verified on the pristine base)
+- `OutputsDock.analysis-run.spec.tsx` fails on a clean `e9832126` checkout in this environment (8/8, `useConversationContext must be called inside <ConversationProvider>` — aiPanelV2 defaults ON and the suite renders without the provider). Identical with and without this lane's changes; the new `OutputsDock.testability.spec` uses the provider-free legacy-host pattern from `OutputsDock.conversationSingleton.spec` instead.
+- `.env.local` copied from the main checkout into the worktree (gitignored, NOT committed) so supabase-importing suites can run at all — same local-env situation lanes 9/12 recorded.
+
+## Boundary audit (additive-only rule)
+
+- `V2RunResponse.sensitivity_reference_option_id` — new OPTIONAL field; nothing existing narrowed.
+- Mapper pass-through — conditional spread; key absent when producer omits it.
+- `ResultsReport.sensitivity_reference_option_id`, `ResultsSectionDataReturn.sensitivityReference` — additive.
+- `DriversSectionProps.sensitivityReferenceLabel`, `StressTestSectionProps.sensitivityReferenceLabel` — new OPTIONAL props; existing callers unchanged (pinned).
+- `deriveAnalysisDisplayState` — one status ADDED to a UI-internal display set (rendering-level; no wire shape touched).
+- data-testid attributes — presentation-only.
+- PLoT `display_verdict` NOT consumed (explicit lane exclusion). No non-additive boundary change was needed; nothing to STOP on.
+
+## Follow-ups (recorded, not done)
+1. Consume PLoT `display_verdict` when it lands next round (explicitly out of scope here).
+2. If the reference option should ALSO be named on the tornado / flip-thresholds surface, that's a product wording call (flip thresholds are per-factor probes, not the same quantity) — needs doctrine review alongside the `provisional_doctrine_v0` caption wording.
+3. Pre-existing red `OutputsDock.analysis-run.spec.tsx` (provider-less render under aiPanelV2 default-ON) deserves its own small fix lane; not touched here to keep the lane additive.
+4. CEE `analysis_ready.status` union in `src/adapters/cee/types.ts` still doesn't name `'blocked'` (UI tolerates via the lenient normaliser + widened checks); typing it is a contract-level change best done alongside an olumi-schemas update, not unilaterally in the UI.

--- a/src/adapters/plot/v2/__tests__/responseMapper.spec.ts
+++ b/src/adapters/plot/v2/__tests__/responseMapper.spec.ts
@@ -1166,3 +1166,34 @@ describe('Lane UI-W4: decision_brief pass-through (PLoT #200)', () => {
     expect('decision_brief' in (report as any)).toBe(false)
   })
 })
+
+describe('Lane UI-W5: sensitivity_reference_option_id pass-through (reference-option disclosure)', () => {
+  it('passes sensitivity_reference_option_id through verbatim when present', () => {
+    const v2Response = makeSuccessResponse({
+      sensitivity_reference_option_id: 'opt1',
+    })
+    const report = mapV2ResponseToReportV1(v2Response, { seed: 42 })
+    expect((report as any).sensitivity_reference_option_id).toBe('opt1')
+  })
+
+  it('omits the key when absent from the V2 response (honest absence — no fabricated baseline)', () => {
+    const report = mapV2ResponseToReportV1(makeSuccessResponse(), { seed: 42 })
+    expect('sensitivity_reference_option_id' in (report as any)).toBe(false)
+  })
+
+  it('omits the key when the wire value is an empty string (guarded pass-through)', () => {
+    const v2Response = makeSuccessResponse({
+      sensitivity_reference_option_id: '' as unknown as string,
+    })
+    const report = mapV2ResponseToReportV1(v2Response, { seed: 42 })
+    expect('sensitivity_reference_option_id' in (report as any)).toBe(false)
+  })
+
+  it('omits the key when the wire value is not a string (trust boundary)', () => {
+    const v2Response = makeSuccessResponse({
+      sensitivity_reference_option_id: 42 as unknown as string,
+    })
+    const report = mapV2ResponseToReportV1(v2Response, { seed: 42 })
+    expect('sensitivity_reference_option_id' in (report as any)).toBe(false)
+  })
+})

--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -714,6 +714,16 @@ export function mapV2ResponseToReportV1(
     // flip_thresholds above). No field is reshaped here; the fail-closed
     // trust boundary is normalizeHeadlineBanded at the selector.
     ...(v2Response.decision_brief ? { decision_brief: v2Response.decision_brief } : {}),
+    // Lane UI-W5 (reference-option disclosure): pass through the option ID
+    // the sensitivities / fragile edges were computed against, ADDITIVELY
+    // and verbatim, so the disclosure caption survives a save + hydrate
+    // cycle (selector reads mapped report first, raw response second —
+    // same pattern as flip_thresholds / decision_brief above). Guarded to
+    // non-empty strings only; absent → key omitted (honest absence).
+    ...(typeof v2Response.sensitivity_reference_option_id === 'string' &&
+      v2Response.sensitivity_reference_option_id.length > 0
+      ? { sensitivity_reference_option_id: v2Response.sensitivity_reference_option_id }
+      : {}),
   }
 }
 

--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -479,6 +479,20 @@ export interface V2RunResponse {
   }
 
   /**
+   * Reference-option disclosure (additive, Lane UI-W5; PLoT lane W4,
+   * ISL build 9a22a1a+): the option ID that edge sensitivity, factor
+   * sensitivity, and the fragile-edge classification were computed
+   * against (ISL currently uses the FIRST option in the request).
+   * Emitted at the /v2/run response root as a verbatim passthrough of
+   * the ISL envelope field (see plot-lite-service routes/v2/run.ts —
+   * omitted when the deployed ISL did not disclose it, honest absence).
+   * Disclosure only: the UI surfaces a caption naming this option where
+   * sensitivities / fragile edges render; absent field → no caption,
+   * never a UI-invented baseline. provisional_doctrine_v0.
+   */
+  sensitivity_reference_option_id?: string
+
+  /**
    * Display-honesty: top-level flip_thresholds[] array as emitted by
    * PLoT v2/run. Legacy responses also nested it under
    * `robustness.flip_thresholds` — both shapes are accepted by the

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2069,6 +2069,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                         onClick={handleRunAnalysis}
                         disabled={isRunning || !canRunAnalysis}
                         className={`${typography.panelBody} bg-primary text-text-on-color rounded-md px-3 py-1 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0`}
+                        data-testid="graph-stale-rerun-button"
                       >
                         Rerun analysis
                       </button>

--- a/src/canvas/components/__tests__/OutputsDock.testability.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.testability.spec.tsx
@@ -1,0 +1,166 @@
+/**
+ * OutputsDock harness-testability pins (Lane UI-W5, feature C).
+ *
+ * Pins the stable selectors the Playwright acceptance harness needs on the
+ * Analysis (Results) tab:
+ *   - stale banner:        data-testid="graph-stale-banner"        (pre-existing)
+ *   - its Rerun button:    data-testid="graph-stale-rerun-button"  (added)
+ *   - footer Rerun action: data-testid="results-analysis-footer-action"
+ *     (AnalysisFooter now stamps `${testId}-action` on its action button)
+ *
+ * Test-support attributes only — zero behaviour change. Scaffolding mirrors
+ * OutputsDock.conversationSingleton.spec.tsx (stable useConversation stub;
+ * aiPanelV2 forced OFF so the dock renders without the canvas-root
+ * ConversationProvider).
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => vi.fn()),
+  }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isCompareEnabled: () => true,
+    isOrchestratorV2Enabled: () => true,
+    isLegacyDirectRunEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    // Legacy host path: no <ConversationProvider> needed (useConversation is
+    // stubbed below) — the Results-tab surface under test is identical.
+    isAiPanelV2Enabled: () => false,
+    isV5CanonicalAnalysisEnabled: () => false,
+  }
+})
+
+vi.mock('../../hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() }),
+}))
+
+// Stable conversation stub (shape mirrors the singleton spec's stub).
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    lastFailedInput: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../../ui/inspector-v2/useStaleGuard', () => ({
+  useStaleGuard: () => ({ analysisState: 'none', isStale: false }),
+}))
+
+// PreAnalysisPanel pulls ToastProvider + readiness fetches that fail outside
+// the full app shell; post-run surface under test never renders it.
+vi.mock('../pre-analysis', () => ({
+  PreAnalysisPanel: () => null,
+}))
+
+// Readiness store fetches /bff/cee/graph-readiness which jsdom can't parse
+// as a relative URL.
+vi.mock('../../hooks/useGraphReadiness', () => ({
+  useGraphReadiness: () => ({ readiness: { state: 'ready' } }),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+const fakeReport: Record<string, unknown> = {
+  results: {
+    conservative: 10,
+    likely: 20,
+    optimistic: 30,
+    units: 'percent',
+    unitSymbol: '%',
+  },
+  run: {
+    bands: { p10: 10, p50: 20, p90: 30 },
+  },
+  robustness: {
+    recommendation_stability: 0.87,
+  },
+}
+
+describe('OutputsDock testability selectors (Analysis tab)', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    try {
+      sessionStorage.clear()
+    } catch {
+      /* jsdom quirk — never block the suite */
+    }
+
+    useCanvasStore.setState({
+      currentScenarioFraming: null,
+      currentScenarioLastResultHash: null,
+      hasCompletedFirstRun: true,
+      nodes: [
+        { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+        { id: 'opt-a', type: 'option', data: { label: 'Option A', kind: 'option' }, position: { x: 50, y: 0 } },
+        { id: 'factor-1', type: 'factor', data: { label: 'Factor', kind: 'factor' }, position: { x: 100, y: 0 } },
+      ],
+      edges: [{ id: 'e1', source: 'factor-1', target: 'goal-1', data: { weight: 0.7, direction: 'positive' } }],
+      graphHealth: { status: 'healthy', score: 100, issues: [] },
+      results: { status: 'complete', report: fakeReport },
+      // CEE 'stale' verdict → graph-stale-banner renders alongside the report
+      analysisFreshness: { freshness: 'stale', computedAt: '2026-07-07T00:00:00.000Z' },
+      analysisFreshnessDirty: false,
+      showDraftChat: false,
+    } as never)
+  })
+
+  it('stale banner and its Rerun button are reachable via data-testid', () => {
+    render(<OutputsDock />)
+
+    expect(screen.getByTestId('graph-stale-banner')).toBeInTheDocument()
+    const rerun = screen.getByTestId('graph-stale-rerun-button')
+    expect(rerun).toBeInTheDocument()
+    expect(rerun).toHaveTextContent('Rerun analysis')
+  })
+
+  it('AnalysisFooter action button derives `${testId}-action`', () => {
+    render(<OutputsDock />)
+
+    expect(screen.getByTestId('results-analysis-footer')).toBeInTheDocument()
+    expect(screen.getByTestId('results-analysis-footer-action')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/shared/AnalysisFooter.tsx
+++ b/src/canvas/shared/AnalysisFooter.tsx
@@ -90,6 +90,7 @@ export function AnalysisFooter({
             aria-label={actionAriaLabel ?? actionLabel}
             title={actionTitle}
             data-action-variant={actionVariant}
+            data-testid={`${testId}-action`}
             className={`
               min-h-8 rounded-full px-4 ${typography.panelBody}
               inline-flex items-center justify-center gap-2 transition-colors

--- a/src/canvas/utils/__tests__/deriveAnalysisDisplayState.spec.ts
+++ b/src/canvas/utils/__tests__/deriveAnalysisDisplayState.spec.ts
@@ -250,4 +250,32 @@ describe('deriveAnalysisDisplayState', () => {
       expect(after.state).toBe('not_ready')
     })
   })
+
+  // Lane UI-W5 (feature B): CEE can emit analysis_ready status 'blocked'
+  // ("validation failure prevents analysis — invalid graph structure";
+  // synthesised with empty options on legacy/unparseable reloads per CEE
+  // #358, and produced with populated options by the Ep2 readiness path).
+  // 'blocked' must NEVER render "Analysis complete" — it belongs with the
+  // explicit non-analysable statuses.
+  describe("blocked (CEE #358 defensive leg)", () => {
+    it("status 'blocked' with a prior report must NOT claim 'Analysis complete'", () => {
+      const view = deriveAnalysisDisplayState(
+        makeInput({
+          ceeAnalysisReadyStatus: 'blocked',
+          hasReport: true,
+          analysisChanged: false,
+        }),
+      )
+      expect(view.state).toBe('not_ready')
+      expect(view.headline).not.toBe('Analysis complete')
+    })
+
+    it("status 'blocked' with no report → not_ready (no completeness claim, no run CTA)", () => {
+      const view = deriveAnalysisDisplayState(
+        makeInput({ ceeAnalysisReadyStatus: 'blocked' }),
+      )
+      expect(view.state).toBe('not_ready')
+      expect(view.cta).toBeNull()
+    })
+  })
 })

--- a/src/canvas/utils/deriveAnalysisDisplayState.ts
+++ b/src/canvas/utils/deriveAnalysisDisplayState.ts
@@ -63,11 +63,21 @@ export interface AnalysisDisplayStateView {
  * readiness (CEE response in flight, slice transiently null during scenario
  * load). A genuinely complete prior result should remain visible during
  * those windows.
+ *
+ * 'blocked' (Lane UI-W5, CEE #358 defensive leg): CEE's documented
+ * semantics are "validation failure prevents analysis — invalid graph
+ * structure". The empty-options synthesis on legacy/unparseable reloads is
+ * rejected by the V5 normaliser before it reaches this helper (store slice
+ * cleared → status undefined), but the Ep2 readiness path can emit
+ * 'blocked' WITH populated options, which the lenient normaliser passes
+ * through — without this entry that state would render green "Analysis
+ * complete" whenever a prior report is held. Rendering-level mapping only.
  */
 const EXPLICIT_NOT_READY_STATUSES: ReadonlySet<string> = new Set([
   'needs_encoding',
   'needs_user_mapping',
   'needs_user_input',
+  'blocked',
 ])
 
 function isExplicitNotReady(status: string | undefined): boolean {

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -33,6 +33,7 @@ import { DataBar } from '../../canvas/ui/shared/DataBar'
 import Tooltip from '../../components/Tooltip'
 import { DiscussWithAiButton } from '../../canvas/components/pre-analysis/DiscussWithAiButton'
 import { ExpertBlock } from './ExpertBlock'
+import { SensitivityReferenceCaption } from './SensitivityReferenceCaption'
 import { ExpandableCoachingText } from '../../components/shared/ExpandableCoachingText'
 import { isExpertField } from './utils/isExpertField'
 
@@ -56,6 +57,11 @@ interface DriversSectionProps {
   onSendMessage?: (text: string) => void
   /** Whether expert mode is active (shows technical details) */
   expertMode?: boolean
+  /**
+   * Lane UI-W5 (reference-option disclosure): resolved label of the option
+   * the sensitivities were computed against. Null/absent → no caption.
+   */
+  sensitivityReferenceLabel?: string | null
 }
 
 // Bar colors — use design system tokens, no hex literals
@@ -761,6 +767,7 @@ export function DriversSection({
   isNormalised: _isNormalised,
   onSendMessage,
   expertMode,
+  sensitivityReferenceLabel,
 }: DriversSectionProps) {
   const [showAll, setShowAll] = useState(false)
   const { drivers, driversStatus, hasMagnitudeData, islError, hiddenZeroImpactCount } = data
@@ -855,6 +862,10 @@ export function DriversSection({
     <div className="space-y-4">
       {/* Ranking explainer */}
       <p className={`${typography.panelMeta} text-text-light`}>Ranked by how much each factor affects the outcome</p>
+
+      {/* Lane UI-W5: reference-option disclosure — renders nothing when the
+          producer did not disclose a reference option (fail-closed). */}
+      <SensitivityReferenceCaption optionLabel={sensitivityReferenceLabel} />
 
       {/* Brief 5 Task 2: headers + rows share one wrapper so column positions
           are structural, not visual-approximation. Headers mirror the row grid

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -362,6 +362,7 @@ export const ResultsBody = memo(function ResultsBody({
             outcomeUnit={resultsSectionData.recommendation.outcomeUnit}
             outcomeUnitSymbol={resultsSectionData.recommendation.outcomeUnitSymbol}
             isNormalised={resultsSectionData.recommendation.isNormalised}
+            sensitivityReferenceLabel={resultsSectionData.sensitivityReference?.optionLabel ?? null}
           />
         </SectionErrorBoundary>
       </Accordion>
@@ -457,6 +458,7 @@ export const ResultsBody = memo(function ResultsBody({
                   onFocusNode={onFocusNode}
                   onSendMessage={onSendMessage}
                   expertMode={expertMode}
+                  sensitivityReferenceLabel={resultsSectionData.sensitivityReference?.optionLabel ?? null}
                 />
               )
             })()}

--- a/src/components/results/SensitivityReferenceCaption.tsx
+++ b/src/components/results/SensitivityReferenceCaption.tsx
@@ -1,0 +1,54 @@
+/**
+ * SensitivityReferenceCaption — reference-option disclosure (Lane UI-W5).
+ *
+ * PLoT /v2/run now discloses `sensitivity_reference_option_id`: the option
+ * that edge/factor sensitivities and the fragile-edge classification were
+ * computed against (ISL currently uses the first option in the request).
+ * This caption surfaces that fact honestly wherever sensitivities or
+ * fragile edges render, so per-factor influence is never read as
+ * option-neutral.
+ *
+ * One component reused across surfaces (DriversSection, StressTestSection).
+ *
+ * Fail-closed rendering contract:
+ *   - absent field (older PLoT/ISL builds) → parent passes null → renders
+ *     nothing (honest absence — never invent a baseline);
+ *   - id present but unresolvable to a label on this canvas (deleted node,
+ *     recovered session with different ids) → renders nothing rather than
+ *     leaking an internal node id as user copy.
+ *
+ * Copy is provisional_doctrine_v0 — wording pending doctrine review.
+ */
+
+import { typography } from '../../styles/typography'
+
+export interface SensitivityReferenceCaptionProps {
+  /**
+   * Resolved reference-option label. Null/undefined/empty → no caption
+   * (see fail-closed contract above).
+   */
+  optionLabel?: string | null
+  className?: string
+}
+
+export function SensitivityReferenceCaption({
+  optionLabel,
+  className = '',
+}: SensitivityReferenceCaptionProps) {
+  if (typeof optionLabel !== 'string' || optionLabel.trim().length === 0) {
+    return null
+  }
+
+  return (
+    <p
+      role="note"
+      data-testid="sensitivity-reference-caption"
+      className={`${typography.panelMeta} text-text-light ${className}`.trim()}
+    >
+      {/* provisional_doctrine_v0: disclosure wording pending doctrine review */}
+      Sensitivities computed against {optionLabel}
+    </p>
+  )
+}
+
+export default SensitivityReferenceCaption

--- a/src/components/results/StressTestSection.tsx
+++ b/src/components/results/StressTestSection.tsx
@@ -40,6 +40,7 @@ import {
   buildDisconfirmationCard,
   buildOutsideViewCard,
 } from './utils/stressTestTemplates'
+import { SensitivityReferenceCaption } from './SensitivityReferenceCaption'
 import type { DriverItem } from './types'
 
 const RANK_FLIP_THRESHOLD = 0.15
@@ -71,6 +72,12 @@ export interface StressTestSectionProps {
   onFocusNode?: (nodeId: string) => void
   onSendMessage?: (text: string) => void
   expertMode?: boolean
+  /**
+   * Lane UI-W5 (reference-option disclosure): resolved label of the option
+   * the sensitivities / fragile edges were computed against. Null/absent →
+   * no caption.
+   */
+  sensitivityReferenceLabel?: string | null
 }
 
 interface SensitiveFactor {
@@ -181,6 +188,7 @@ export const StressTestSection = memo(function StressTestSection({
   onFocusNode,
   onSendMessage,
   expertMode,
+  sensitivityReferenceLabel,
 }: StressTestSectionProps) {
   // ── Sensitive assumptions (node-based) ───────────────────────────────────
   const sensitiveFactors = selectSensitiveFactors(drivers)
@@ -254,6 +262,10 @@ export const StressTestSection = memo(function StressTestSection({
       }
     >
       <div className="space-y-3" data-testid="stress-test-section">
+        {/* Lane UI-W5: reference-option disclosure — renders nothing when
+            the producer did not disclose a reference option (fail-closed). */}
+        <SensitivityReferenceCaption optionLabel={sensitivityReferenceLabel} />
+
         {/* ── Sensitive assumptions ─────────────────────────────────── */}
         {sensitiveCount > 0 && (
           <div className="space-y-1.5" data-testid="stress-test-sensitive-subsection">

--- a/src/components/results/SuccessTargetRow.tsx
+++ b/src/components/results/SuccessTargetRow.tsx
@@ -215,6 +215,7 @@ export function SuccessTargetRow({
               disabled={isRunning}
               className={`w-[100px] px-2 py-1 ${typography.panelBody} border border-info rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info tabular-nums`}
               aria-label="Edit success target value"
+              data-testid="success-target-input"
             />
             <button
               type="button"
@@ -237,6 +238,7 @@ export function SuccessTargetRow({
             onClick={handleStartEdit}
             disabled={isRunning}
             className={`${typography.panelBody} text-info hover:underline cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed`}
+            data-testid="success-target-set-button"
           >
             Set target
           </button>

--- a/src/components/results/__tests__/SensitivityReferenceCaption.spec.tsx
+++ b/src/components/results/__tests__/SensitivityReferenceCaption.spec.tsx
@@ -1,0 +1,136 @@
+/**
+ * Lane UI-W5 (feature A): reference-option disclosure caption.
+ *
+ * PLoT /v2/run discloses `sensitivity_reference_option_id` — the option the
+ * edge/factor sensitivities and fragile-edge classification were computed
+ * against. One caption component is reused across the surfaces where those
+ * render (DriversSection, StressTestSection).
+ *
+ * Contract under test:
+ *  - caption renders "Sensitivities computed against <label>" when a label
+ *    resolves (provisional_doctrine_v0 wording);
+ *  - fail-closed: no label (absent producer field, unresolvable id) → no
+ *    caption — never an invented baseline, never a leaked internal id;
+ *  - both surfaces render it from the same shared component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { SensitivityReferenceCaption } from '../SensitivityReferenceCaption'
+import { DriversSection } from '../DriversSection'
+import { StressTestSection } from '../StressTestSection'
+import type { DriversSectionData, DriverItem } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(() => true),
+}))
+
+function makeDriver(overrides: Partial<DriverItem> = {}): DriverItem {
+  return {
+    factorKey: 'factor-1',
+    factorLabel: 'Customer Churn',
+    rawElasticity: 0.8,
+    normalisedInfluence: 1.0,
+    influenceScore: 0.9,
+    rank: 1,
+    direction: 'negative',
+    semanticLabel: 'biggest',
+    canFocus: false,
+    ...overrides,
+  }
+}
+
+function makeData(drivers: DriverItem[]): DriversSectionData {
+  return {
+    drivers,
+    topDrivers: drivers.slice(0, 3),
+    driversStatus: 'computed',
+    totalCount: drivers.length,
+    hasMagnitudeData: true,
+  }
+}
+
+describe('SensitivityReferenceCaption (shared component)', () => {
+  it('renders the disclosure copy with the resolved option label', () => {
+    render(<SensitivityReferenceCaption optionLabel="Hire a contractor" />)
+    const caption = screen.getByTestId('sensitivity-reference-caption')
+    expect(caption).toHaveTextContent('Sensitivities computed against Hire a contractor')
+  })
+
+  it('renders nothing when the label is null (absent producer field)', () => {
+    render(<SensitivityReferenceCaption optionLabel={null} />)
+    expect(screen.queryByTestId('sensitivity-reference-caption')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when the label is undefined', () => {
+    render(<SensitivityReferenceCaption />)
+    expect(screen.queryByTestId('sensitivity-reference-caption')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for a whitespace-only label (fail-closed)', () => {
+    render(<SensitivityReferenceCaption optionLabel="   " />)
+    expect(screen.queryByTestId('sensitivity-reference-caption')).not.toBeInTheDocument()
+  })
+})
+
+describe('DriversSection surface', () => {
+  it('shows the caption when a reference label is provided', () => {
+    render(
+      <DriversSection
+        data={makeData([makeDriver()])}
+        goalLabel="Revenue"
+        sensitivityReferenceLabel="Hire a contractor"
+      />,
+    )
+    expect(screen.getByTestId('sensitivity-reference-caption')).toHaveTextContent(
+      'Sensitivities computed against Hire a contractor',
+    )
+  })
+
+  it('shows no caption when the label is null (absent field → no caption)', () => {
+    render(
+      <DriversSection
+        data={makeData([makeDriver()])}
+        goalLabel="Revenue"
+        sensitivityReferenceLabel={null}
+      />,
+    )
+    expect(screen.queryByTestId('sensitivity-reference-caption')).not.toBeInTheDocument()
+  })
+
+  it('shows no caption when the prop is omitted entirely (older callers unchanged)', () => {
+    render(<DriversSection data={makeData([makeDriver()])} goalLabel="Revenue" />)
+    expect(screen.queryByTestId('sensitivity-reference-caption')).not.toBeInTheDocument()
+  })
+})
+
+describe('StressTestSection surface', () => {
+  it('shows the caption when a reference label is provided', () => {
+    render(
+      <StressTestSection
+        drivers={[makeDriver()]}
+        winnerLabel="Option A"
+        alternativeLabel="Option B"
+        sensitivityReferenceLabel="Hire a contractor"
+      />,
+    )
+    expect(screen.getByTestId('sensitivity-reference-caption')).toHaveTextContent(
+      'Sensitivities computed against Hire a contractor',
+    )
+  })
+
+  it('shows no caption when the label is null', () => {
+    render(
+      <StressTestSection
+        drivers={[makeDriver()]}
+        winnerLabel="Option A"
+        alternativeLabel="Option B"
+        sensitivityReferenceLabel={null}
+      />,
+    )
+    expect(screen.queryByTestId('sensitivity-reference-caption')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/SuccessTargetRow.testability.spec.tsx
+++ b/src/components/results/__tests__/SuccessTargetRow.testability.spec.tsx
@@ -1,0 +1,69 @@
+/**
+ * SuccessTargetRow harness-testability pins (Lane UI-W5, feature C).
+ *
+ * The Playwright acceptance harness could not reach the "Set target"
+ * affordance because only the container carried a stable selector. These
+ * pins fix the selector contract:
+ *   - container:            data-testid="success-target-row"   (pre-existing)
+ *   - "Set target" button:  data-testid="success-target-set-button"
+ *   - target input:         data-testid="success-target-input"
+ *     with aria-label "Edit success target value" (kept — harness + a11y
+ *     both rely on it).
+ *
+ * Test-support attributes only — these pins assert PRESENCE of selectors
+ * and that behaviour is unchanged (same handlers, same copy).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SuccessTargetRow } from '../SuccessTargetRow'
+
+describe('SuccessTargetRow testability selectors', () => {
+  it('container keeps data-testid="success-target-row"', () => {
+    render(<SuccessTargetRow />)
+    expect(screen.getByTestId('success-target-row')).toBeInTheDocument()
+  })
+
+  it('"Set target" button carries data-testid="success-target-set-button"', () => {
+    render(<SuccessTargetRow />)
+    const button = screen.getByTestId('success-target-set-button')
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveTextContent('Set target')
+  })
+
+  it('target input carries data-testid="success-target-input" and keeps its aria-label', () => {
+    render(<SuccessTargetRow />)
+    // Enter edit mode via the harness selector — proves the click path works
+    fireEvent.click(screen.getByTestId('success-target-set-button'))
+
+    const input = screen.getByTestId('success-target-input')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveAttribute('aria-label', 'Edit success target value')
+  })
+
+  it('behaviour unchanged: committing a value through the pinned selectors calls onApplyThreshold', () => {
+    const onApplyThreshold = vi.fn()
+    render(<SuccessTargetRow onApplyThreshold={onApplyThreshold} />)
+
+    fireEvent.click(screen.getByTestId('success-target-set-button'))
+    const input = screen.getByTestId('success-target-input')
+    fireEvent.change(input, { target: { value: '250' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onApplyThreshold).toHaveBeenCalledWith(250)
+  })
+
+  it('behaviour unchanged: set-target affordance still respects isRunning disable', () => {
+    render(<SuccessTargetRow isRunning />)
+    expect(screen.getByTestId('success-target-set-button')).toBeDisabled()
+  })
+
+  it('input testid appears when editing an EXISTING target too (edit-value path)', () => {
+    render(<SuccessTargetRow goalThreshold={100} />)
+    // No "Set target" button when a target exists — edit via the value button
+    expect(screen.queryByTestId('success-target-set-button')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Edit success target: 100'))
+    expect(screen.getByTestId('success-target-input')).toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/sensitivityReference.selector.spec.tsx
+++ b/src/components/results/__tests__/sensitivityReference.selector.spec.tsx
@@ -1,0 +1,113 @@
+/**
+ * Lane UI-W5 (feature A): sensitivity reference selector resolution.
+ *
+ * useResultsSectionData resolves `sensitivity_reference_option_id` with the
+ * same precedence as flip_thresholds / headline_banded:
+ *   mapped report (survives save + hydrate) → raw V2 response (fresh run)
+ * and resolves id → label from the canvas options list (nodeLabelMap).
+ *
+ * Fail-closed pins:
+ *  - neither source discloses → sensitivityReference is null;
+ *  - id present but no matching canvas node → optionId kept, optionLabel
+ *    null (caption suppressed downstream — internal ids never become copy).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useCanvasStore } from '../../../canvas/store'
+import { useResultsSectionData } from '../useResultsSectionData'
+
+const NODES = [
+  { id: 'goal-1', type: 'goal', data: { label: 'Revenue', kind: 'goal' }, position: { x: 0, y: 0 } },
+  { id: 'opt_contractor', type: 'option', data: { label: 'Hire a contractor', kind: 'option' }, position: { x: 1, y: 0 } },
+  { id: 'opt_diy', type: 'option', data: { label: 'Do it yourself', kind: 'option' }, position: { x: 2, y: 0 } },
+]
+
+const BASE_REPORT = {
+  schema: 'report.v1',
+  results: { conservative: 10, likely: 20, optimistic: 30 },
+  option_probabilities: {},
+}
+
+function setStore(overrides: Record<string, unknown>): void {
+  useCanvasStore.setState({
+    nodes: NODES,
+    edges: [],
+    hasCompletedFirstRun: true,
+    currentScenarioFraming: null,
+    runMeta: {},
+    ceeAnalysisReady: undefined,
+    results: { status: 'complete', progress: 100, report: BASE_REPORT },
+    rawV2Response: null,
+    ...overrides,
+  } as never)
+}
+
+describe('useResultsSectionData.sensitivityReference', () => {
+  beforeEach(() => {
+    setStore({})
+  })
+
+  it('is null when neither the mapped report nor the raw response discloses a reference option', () => {
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.sensitivityReference).toBeNull()
+  })
+
+  it('resolves from the mapped report and maps id → canvas option label', () => {
+    setStore({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: { ...BASE_REPORT, sensitivity_reference_option_id: 'opt_contractor' },
+      },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.sensitivityReference).toEqual({
+      optionId: 'opt_contractor',
+      optionLabel: 'Hire a contractor',
+    })
+  })
+
+  it('falls back to the raw V2 response on fresh runs (report not yet carrying the field)', () => {
+    setStore({
+      rawV2Response: { sensitivity_reference_option_id: 'opt_diy' },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.sensitivityReference).toEqual({
+      optionId: 'opt_diy',
+      optionLabel: 'Do it yourself',
+    })
+  })
+
+  it('prefers the mapped report over the raw response when both are present', () => {
+    setStore({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: { ...BASE_REPORT, sensitivity_reference_option_id: 'opt_contractor' },
+      },
+      rawV2Response: { sensitivity_reference_option_id: 'opt_diy' },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.sensitivityReference?.optionId).toBe('opt_contractor')
+  })
+
+  it('fail-closed label: unresolvable id keeps optionId but yields optionLabel null', () => {
+    setStore({
+      rawV2Response: { sensitivity_reference_option_id: 'opt_deleted' },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.sensitivityReference).toEqual({
+      optionId: 'opt_deleted',
+      optionLabel: null,
+    })
+  })
+
+  it('treats an empty-string disclosure as absent', () => {
+    setStore({
+      rawV2Response: { sensitivity_reference_option_id: '' },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.sensitivityReference).toBeNull()
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -1022,6 +1022,12 @@ export interface ResultsReport extends Omit<ReportV1, 'option_probabilities'> {
   confidence_tier?: 'strong' | 'fair' | 'needs_work'
   /** PLoT-classified dominant factor (B2, optional for cached pre-B1 results) */
   dominant_factor?: { factor_id: string; factor_label: string }
+  /**
+   * Reference-option disclosure (Lane UI-W5): option ID the sensitivities /
+   * fragile edges were computed against. Mapper pass-through of the /v2/run
+   * root field; absent on older PLoT/ISL builds. provisional_doctrine_v0.
+   */
+  sensitivity_reference_option_id?: string
   drivers_error?: string
   sensitivity?: { factors?: Array<Record<string, unknown>>; error?: string }
   isl_error?: string

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -887,6 +887,14 @@ export interface ResultsSectionDataReturn {
    * `autoNoiseProvenance?.applied && autoNoiseProvenance?.isProvisional`.
    */
   autoNoiseProvenance: import('./types').AutoNoiseProvenance | null
+  /**
+   * Lane UI-W5 (reference-option disclosure): the option the edge/factor
+   * sensitivities and fragile edges were computed against, resolved to a
+   * canvas label where possible. `null` when the producer did not
+   * disclose it (older PLoT/ISL builds); `optionLabel` null when the id
+   * no longer resolves on this canvas (caption suppressed, fail-closed).
+   */
+  sensitivityReference: { optionId: string; optionLabel: string | null } | null
 }
 
 export function useResultsSectionData(): ResultsSectionDataReturn {
@@ -908,6 +916,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     rawFlipThresholdsStatusReason,
     rawMetaNSamples,
     rawHeadlineBanded,
+    rawSensitivityReferenceOptionId,
   } = useCanvasStore(
     useShallow((s) => ({
       results: s.results,
@@ -955,6 +964,12 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // is the fresh-run fallback — same pattern as rawV2FlipThresholds.
       rawHeadlineBanded:
         s.rawV2Response?.decision_brief?.headline_banded ?? null,
+      // Lane UI-W5 (reference-option disclosure): option ID the
+      // sensitivities / fragile edges were computed against. Extracted
+      // narrowly; mapped report preferred below, this raw slot is the
+      // fresh-run fallback — same pattern as rawHeadlineBanded.
+      rawSensitivityReferenceOptionId:
+        s.rawV2Response?.sensitivity_reference_option_id ?? null,
     }))
   )
 
@@ -1089,6 +1104,29 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     })
     return map
   }, [nodes])
+
+  // Lane UI-W5 (reference-option disclosure): resolve the disclosed
+  // reference-option ID to its canvas label for the shared
+  // SensitivityReferenceCaption. Mapped report preferred (survives
+  // save + hydrate), raw response is the fresh-run fallback — same
+  // precedence as flip_thresholds / headline_banded. Fail-closed:
+  // absent field → null (no caption); id that no longer resolves to a
+  // canvas label → optionLabel null (caption suppressed rather than
+  // leaking an internal id as user copy). provisional_doctrine_v0.
+  const sensitivityReference = useMemo<
+    { optionId: string; optionLabel: string | null } | null
+  >(() => {
+    const fromReport = report?.sensitivity_reference_option_id
+    const raw =
+      typeof fromReport === 'string' && fromReport.length > 0
+        ? fromReport
+        : typeof rawSensitivityReferenceOptionId === 'string' &&
+            rawSensitivityReferenceOptionId.length > 0
+          ? rawSensitivityReferenceOptionId
+          : null
+    if (!raw) return null
+    return { optionId: raw, optionLabel: nodeLabelMap.get(raw) ?? null }
+  }, [report, rawSensitivityReferenceOptionId, nodeLabelMap])
 
   // Get outcome node IDs for direction derivation
   const outcomeNodeIds = useMemo(
@@ -2762,6 +2800,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     goalNodeId,
     completeness,
     autoNoiseProvenance,
+    sensitivityReference,
   }
 }
 

--- a/src/v5/__tests__/applyV5State.blockedAnalysisReady.spec.tsx
+++ b/src/v5/__tests__/applyV5State.blockedAnalysisReady.spec.tsx
@@ -1,0 +1,146 @@
+/**
+ * Lane UI-W5 (feature B): blocked-status handling — CEE #358 defensive leg.
+ *
+ * On legacy/unparseable reloads CEE's response finaliser synthesises a
+ * freshness-only analysis_ready block (olumi-assistants-service
+ * src/orchestrator-v5/compose/analysis-ready-emit.ts):
+ *
+ *   { status: 'blocked', goal_node_id: '', options: [], bias_findings: [] }
+ *
+ * stamped by attachComputedAt with computed_at + freshness: 'unknown' +
+ * freshness_reason ('legacy_fact_missing_hash' | 'current_graph_hash_
+ * unavailable'). This spec pins what the live V5 ingestion path
+ * (applyV5State step 4) does with that exact wire shape:
+ *
+ *  1. no crash;
+ *  2. the readiness slice is CLEARED (normaliseV5AnalysisReady rejects the
+ *     empty goal_node_id / empty options) → no surface can claim readiness
+ *     or completeness from it; the rejection is reported honestly as a
+ *     deferred 'analysis_ready_invalid_shape';
+ *  3. the freshness slice STILL consumes the payload (setAnalysisFreshness
+ *     runs before shape validation) → verdict 'unknown' with the reason
+ *     preserved — the blocked/unknown state is shown honestly, not
+ *     silently dropped;
+ *  4. the freshness surface (AnalysisFreshnessNotice) renders the honest
+ *     cannot-confirm copy — never "Analysis reflects the current model",
+ *     never "Analysis complete".
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+import {
+  deriveAnalysisFreshnessUpdate,
+  classifyFreshnessForDisplay,
+  type AnalysisFreshnessState,
+} from '../../canvas/store/analysisFreshness'
+import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
+
+/** Exact CEE wire shape (synthesiseFreshnessOnlyAnalysisReady + attachComputedAt). */
+const BLOCKED_ANALYSIS_READY = {
+  status: 'blocked',
+  goal_node_id: '',
+  options: [] as unknown[],
+  bias_findings: [] as unknown[],
+  computed_at: '2026-07-07T10:00:00.000Z',
+  freshness: 'unknown',
+  freshness_reason: 'legacy_fact_missing_hash',
+}
+
+function baseResponse(overrides: Partial<OlumiResponse> = {}): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+    ...overrides,
+  }
+}
+
+function makeStore(): {
+  store: V5ApplicatorStore
+  setCeeAnalysisReady: ReturnType<typeof vi.fn>
+  setAnalysisFreshness: ReturnType<typeof vi.fn>
+} {
+  const setCeeAnalysisReady = vi.fn()
+  const setAnalysisFreshness = vi.fn()
+  return {
+    store: {
+      setCurrentStage: vi.fn(),
+      updateNode: vi.fn(),
+      updateEdgeData: vi.fn(),
+      setRunMeta: vi.fn(),
+      setCeeAnalysisReady,
+      setAnalysisFreshness,
+      nodes: [],
+      edges: [],
+    },
+    setCeeAnalysisReady,
+    setAnalysisFreshness,
+  }
+}
+
+function blockedResponse(): OlumiResponse {
+  return baseResponse({
+    analysis_ready: BLOCKED_ANALYSIS_READY,
+  } as unknown as Partial<OlumiResponse>)
+}
+
+describe('applyV5State — CEE blocked analysis_ready (empty options, legacy reload)', () => {
+  it('does not crash and clears the readiness slice (no readiness/completeness claim survives)', () => {
+    const { store, setCeeAnalysisReady } = makeStore()
+    const result = applyV5State(blockedResponse(), store)
+
+    // Shape rejected (goal_node_id '' + options []) → store cleared, honestly deferred.
+    expect(setCeeAnalysisReady).toHaveBeenCalledWith(null)
+    expect(result.applied).not.toContain('analysis_ready:set')
+    expect(
+      result.deferred.some((d) => d.reason === 'analysis_ready_invalid_shape'),
+    ).toBe(true)
+  })
+
+  it('still routes the payload into the freshness slice (blocked state is not silently dropped)', () => {
+    const { store, setAnalysisFreshness } = makeStore()
+    applyV5State(blockedResponse(), store)
+
+    expect(setAnalysisFreshness).toHaveBeenCalledTimes(1)
+    expect(setAnalysisFreshness).toHaveBeenCalledWith(BLOCKED_ANALYSIS_READY)
+  })
+
+  it('freshness reducer derives an honest unknown verdict (reason + computed_at preserved)', () => {
+    const next = deriveAnalysisFreshnessUpdate(null, BLOCKED_ANALYSIS_READY)
+
+    expect(next).toEqual({
+      freshness: 'unknown',
+      freshnessReason: 'legacy_fact_missing_hash',
+      graphHashAtRun: undefined,
+      currentGraphHash: undefined,
+      computedAt: '2026-07-07T10:00:00.000Z',
+    })
+    // Display semantic: cannot-confirm — NEVER 'current', NEVER 'changed'
+    // (the user did not edit anything; CEE could not determine freshness).
+    expect(classifyFreshnessForDisplay(next, false)).toBe('cannot_confirm')
+  })
+
+  it('freshness surface renders the honest cannot-confirm copy, not a currentness or completeness claim', () => {
+    const state = deriveAnalysisFreshnessUpdate(
+      null,
+      BLOCKED_ANALYSIS_READY,
+    ) as AnalysisFreshnessState
+
+    render(<AnalysisFreshnessNotice state={state} dirty={false} />)
+
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).toHaveAttribute('data-freshness', 'unknown')
+    expect(notice).toHaveTextContent('Cannot confirm whether this analysis is current.')
+    expect(notice).not.toHaveTextContent('Analysis reflects the current model')
+    expect(notice).not.toHaveTextContent(/analysis complete/i)
+    // Technical reason rides on a data-attribute only — never user copy.
+    expect(notice).toHaveAttribute('data-freshness-reason', 'legacy_fact_missing_hash')
+    expect(notice).not.toHaveTextContent('legacy_fact_missing_hash')
+  })
+})


### PR DESCRIPTION
Lane UI-W5 — three small features on base `e9832126` (includes #237). Writes confined to DecisionGuideAI; all boundary-adjacent changes ADDITIVE. Evidence report: `docs/lanes/lane19-disclosure-blocked-testability.md`.

## A — Reference-option disclosure (`sensitivity_reference_option_id`)
PLoT `/v2/run` (lane PLoT-W4, ISL 9a22a1a+) now discloses which option the edge/factor sensitivities + fragile edges were computed against. Consumed additively:
- `V2RunResponse.sensitivity_reference_option_id?` (root field) + guarded ADDITIVE mapper pass-through (survives save + hydrate; same pattern as `flip_thresholds` / `decision_brief`).
- `useResultsSectionData`: narrow raw-slot extraction, mapped-report-preferred, id→label from the canvas options list.
- One shared `SensitivityReferenceCaption` ("Sensitivities computed against &lt;option label&gt;", `provisional_doctrine_v0`) on both surfaces where sensitivities/fragile edges render: DriversSection + StressTestSection. Fail-closed: absent field → no caption; unresolvable id → suppressed (internal ids never become copy).

## B — Blocked-status handling (#358 merge condition, defensive leg)
Traced the exact CEE-synthesised shape (`{status:'blocked', goal_node_id:'', options:[], …, freshness:'unknown'}` at the envelope root) through the live V5 ingestion path and pinned it:
- No crash; readiness slice cleared (shape rejected, honestly deferred `analysis_ready_invalid_shape`) → no readiness/completeness claim; freshness slice still takes the verdict → `cannot_confirm`; `AnalysisFreshnessNotice` renders the honest copy; no results panel (no report on this path).
- **One violation found + fixed (rendering-level only):** `'blocked'` was missing from `EXPLICIT_NOT_READY_STATUSES`, so a blocked verdict WITH populated options (Ep2 path, passes the lenient normaliser) rendered green "Analysis complete" when a prior report was held. RED→GREEN: blocked now derives `not_ready`, never "Analysis complete".

## C — Harness testability (zero behaviour change, render-pinned)
- SuccessTargetRow: `success-target-set-button`, `success-target-input` added; container `success-target-row` + aria-label "Edit success target value" kept.
- Analysis tab: `graph-stale-banner` pre-existing; `graph-stale-rerun-button` added; AnalysisFooter action button now stamps `${testId}-action` (`results-analysis-footer-action`).

## Verification
- RED→GREEN stash-verified for A (mapper + 6 selector cases) and B (blocked+report claimed "Analysis complete" pre-fix).
- Focused sweep: 22 files / 275 tests green; pre-analysis consumer sweep 1151 green.
- `pnpm run typecheck` clean; `tsc -p tsconfig.app.json` error count 2331 == pristine baseline 2331 (stash-compared); lint 0 errors on changed files.
- Pre-existing, NOT introduced: `OutputsDock.analysis-run.spec.tsx` fails identically on the clean base in this env (provider-less render under aiPanelV2 default-ON); recorded as follow-up.

Explicitly NOT consumed: PLoT `display_verdict` (lands next round per lane brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
