### PR TITLE
fix(results): analysis-tab coherence + schema-skew hardening (assessment P0/P1/P2 safe subset)

### DIFF
--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -320,9 +320,13 @@ export interface V2RobustnessActual {
   level?: string
   /** Human-readable robustness label, when PLoT provides it. */
   label?: string
-  /** Near-tie flag (snake_case) plus the camelCase alias, both read defensively. */
-  near_tie?: boolean
-  nearTie?: boolean
+  /**
+   * Near-tie detail object (snake_case) plus its camelCase alias — the selector
+   * reads is_tie / top_option_id / second_option_id / tied_option_ids / gap /
+   * threshold off it, so it is a Record, not a boolean flag.
+   */
+  near_tie?: Record<string, unknown>
+  nearTie?: Record<string, unknown>
   /** Tipping-point analysis: how much each factor must change to flip the recommendation */
   flip_thresholds?: Array<{
     node_id?: string

--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -307,6 +307,22 @@ export interface V2RobustnessActual {
   ranking_stability?: number
   /** Recommendation stability - how often recommendation stays winner (0-1) */
   recommendation_stability?: number
+  /**
+   * The following are read live by useResultsSectionData / OptionNode and were
+   * previously untyped (`as string` casts / `?? nearTie` fallbacks), so a
+   * producer rename returned undefined with no compiler signal. Declared
+   * optional here for compile-time protection; the runtime reads and their
+   * fallbacks are unchanged.
+   */
+  /** Backend's own recommended option id (preferred winner source over win-max). */
+  recommended_option_id?: string
+  /** Categorical robustness level, when PLoT provides it (else the UI derives one). */
+  level?: string
+  /** Human-readable robustness label, when PLoT provides it. */
+  label?: string
+  /** Near-tie flag (snake_case) plus the camelCase alias, both read defensively. */
+  near_tie?: boolean
+  nearTie?: boolean
   /** Tipping-point analysis: how much each factor must change to flip the recommendation */
   flip_thresholds?: Array<{
     node_id?: string

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -380,6 +380,17 @@ export const OptionNode = memo((props: NodeProps) => {
     if (optionNodes.length < 2) return false
     const visibleOptionIds = new Set(optionNodes.map(n => n.id))
     const report = resultsReport as any
+    // Prefer the backend's own recommendation so the canvas "Leading option"
+    // badge agrees with the Results Panel (which honours recommended_option_id
+    // first) and with this node's own closeCallGapPp/behindReason. Backend
+    // recommendation and win-probability argmax diverge on close/indeterminate
+    // runs — badging the win-max option while the panel recommends another is
+    // the #1-vs-#4 cross-surface disagreement. Win-max is the fallback only
+    // when the producer sends no recommendation (or it is not a visible node).
+    const recommendedId = report?.robustness?.recommended_option_id as string | undefined
+    if (recommendedId && visibleOptionIds.has(recommendedId)) {
+      return props.id === recommendedId
+    }
     const optionProbabilities: Record<string, { win_probability?: number }> = report?.option_probabilities ?? {}
     const allRates = Object.entries(optionProbabilities)
       .filter(([id]) => visibleOptionIds.has(id))
@@ -388,7 +399,7 @@ export const OptionNode = memo((props: NodeProps) => {
     if (allRates.length === 0) return false
     const maxRate = Math.max(...allRates)
     return displayMetadata.winRate >= maxRate - 0.0001
-  }, [displayMetadata.isResultsMode, displayMetadata.winRate, nodes, resultsReport])
+  }, [displayMetadata.isResultsMode, displayMetadata.winRate, nodes, resultsReport, props.id])
 
   const ceeAnalysisReady = useCanvasStore(state => state.ceeAnalysisReady)
   const setHoveredOption = useCanvasStore(state => state.setHoveredOption)

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -216,6 +216,67 @@ describe('OptionNode', () => {
     expect(screen.queryByText('Leading option')).toBeNull()
   })
 
+  // Cross-surface parity: the badge follows the backend recommendation
+  // (recommended_option_id) so it agrees with the Results Panel, which honours
+  // it first. Win-max is only the fallback when no recommendation is sent.
+  it('does not badge the win-max option when the backend recommends another (recommended_option_id wins)', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null, influence: null, confidence: null, inSensitivityAnalysis: false,
+      achievementProbability: null, stabilityPercentage: null, winRate: 0.72, isResultsMode: true,
+      predictedOutcome: null, valueOfInformation: null, voiRank: null,
+    })
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeStoreState({
+        results: {
+          status: 'complete',
+          report: {
+            option_probabilities: {
+              'option-1': { win_probability: 0.72 },
+              'option-2': { win_probability: 0.28 },
+            },
+            robustness: { recommended_option_id: 'option-2' },
+          },
+        },
+        nodes: [
+          { id: 'option-1', type: 'option', data: { type: 'option' } },
+          { id: 'option-2', type: 'option', data: { type: 'option' } },
+        ],
+      }) as any)
+    )
+    // Rendered node is option-1 (the win-max leader) but the backend recommends option-2.
+    renderOption()
+    expect(screen.queryByText('Leading option')).toBeNull()
+  })
+
+  it('badges the recommended option even when it is not the win-max leader (recommended_option_id wins)', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null, influence: null, confidence: null, inSensitivityAnalysis: false,
+      achievementProbability: null, stabilityPercentage: null, winRate: 0.28, isResultsMode: true,
+      predictedOutcome: null, valueOfInformation: null, voiRank: null,
+    })
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeStoreState({
+        results: {
+          status: 'complete',
+          report: {
+            option_probabilities: {
+              'option-1': { win_probability: 0.28 },
+              'option-2': { win_probability: 0.72 },
+            },
+            robustness: { recommended_option_id: 'option-1' },
+          },
+        },
+        nodes: [
+          { id: 'option-1', type: 'option', data: { type: 'option' } },
+          { id: 'option-2', type: 'option', data: { type: 'option' } },
+        ],
+      }) as any)
+    )
+    // Rendered node is option-1, recommended by the backend despite a lower win.
+    renderOption()
+    expect(screen.getByText('Leading option')).toBeDefined()
+  })
+
   // T8: Intervention chips
   it('shows intervention chips from ceeAnalysisReady', () => {
     vi.mocked(useCanvasStore).mockImplementation((selector) =>

--- a/src/components/results/__tests__/useResultsSectionData.reactivity.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.reactivity.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * useResultsSectionData — reactivity + warning-parity regressions.
+ *
+ * Two independent selector fixes are pinned here:
+ *  - P0: the `confidence` memo must recompute when the asynchronous CEE
+ *    review lands (it updates `runMeta.ceeReviewV1` while `report` identity is
+ *    unchanged). The memo reads `ceeReviewV1` for readiness/tier, so it must
+ *    also list it as a dependency — the sibling `completeness` memo already
+ *    does.
+ *  - P1: `recommendation.hasWarnings` must agree with the uncertainties list.
+ *    Advisories emitted as severity 'IMPROVEMENT' + semantic_severity
+ *    'WARNING' (the UI-SEM-069 class) are ingested into uncertainties, so
+ *    hasWarnings must count them too or the panel shows "ready, no warnings"
+ *    while the list simultaneously shows warnings.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+function makeV2Response(overrides: Partial<V2RunResponse> = {}): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [
+      {
+        option_id: 'opt_a',
+        option_label: 'Option A',
+        confidence_interval: [30, 70],
+        win_probability: 0.65,
+        outcome: { mean: 50, std: 12, p10: 30, p50: 50, p90: 70, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1 },
+      },
+      {
+        option_id: 'opt_b',
+        option_label: 'Option B',
+        confidence_interval: [20, 60],
+        win_probability: 0,
+        outcome: { mean: 35, std: 14, p10: 20, p50: 35, p90: 60, n_samples: 1000, n_valid_samples: 998, validity_ratio: 0.998 },
+      },
+    ],
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    robustness: { fragile_edges: [], robust_edges: ['e1'] },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+    ...overrides,
+  }
+}
+
+const OPTION_NODES = [
+  { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option A' } },
+  { id: 'opt_b', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option B' } },
+]
+
+/** Mapped report with confidence_tier stripped so the readiness path decides the tier. */
+function baseReport(critique?: unknown[]): any {
+  const report = mapV2ResponseToReportV1(makeV2Response(), { seed: 42 }) as any
+  report.confidence_tier = undefined
+  report.run = { ...(report.run ?? {}), critique: critique ?? [] }
+  report.robustness = { ...(report.robustness ?? {}), fragile_edges: [] }
+  return report
+}
+
+describe('useResultsSectionData — confidence memo reacts to a late CEE review (P0)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ results: null, runMeta: {} as any, rawV2Response: null, nodes: [], edges: [], hasCompletedFirstRun: false } as any)
+  })
+
+  it('recomputes the confidence tier when runMeta.ceeReviewV1 CHANGES after report (report identity held constant)', () => {
+    // The report has no confidence_tier, so the tier is decided by the CEE
+    // review's readiness level. Start with a low readiness, then let a better
+    // review land — ONLY runMeta.ceeReviewV1 changes; the same `report` object
+    // stays in the store (shallow-merge setState). Without ceeReviewV1 in the
+    // memo deps the tier would stay frozen at 'needs_work'.
+    const report = baseReport()
+    act(() => {
+      useCanvasStore.setState({
+        results: { status: 'complete', progress: 100, report } as any,
+        runMeta: { ceeReviewV1: { readiness: { level: 'not_ready', score: 20 } } } as any,
+        nodes: OPTION_NODES as any, edges: [], hasCompletedFirstRun: true, rawV2Response: null,
+      } as any)
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.confidence?.tier?.tier).toBe('needs_work')
+
+    act(() => {
+      useCanvasStore.setState({ runMeta: { ceeReviewV1: { readiness: { level: 'ready', score: 90 } } } as any } as any)
+    })
+    expect(result.current.confidence?.tier?.tier).toBe('strong')
+  })
+})
+
+describe('useResultsSectionData — hasWarnings ⇄ uncertainties parity (P1, UI-SEM-069)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ results: null, runMeta: {} as any, rawV2Response: null, nodes: [], edges: [], hasCompletedFirstRun: false } as any)
+  })
+
+  function renderWith(critique: unknown[]) {
+    act(() => {
+      useCanvasStore.setState({
+        results: { status: 'complete', progress: 100, report: baseReport(critique) } as any,
+        runMeta: {} as any,
+        nodes: OPTION_NODES as any, edges: [], hasCompletedFirstRun: true, rawV2Response: null,
+      } as any)
+    })
+    return renderHook(() => useResultsSectionData())
+  }
+
+  it('sets hasWarnings for a severity:IMPROVEMENT + semantic_severity:WARNING advisory', () => {
+    const { result } = renderWith([{ severity: 'IMPROVEMENT', semantic_severity: 'WARNING', message: 'Graph is dense' }])
+    expect(result.current.recommendation?.hasWarnings).toBe(true)
+  })
+
+  it('negative control: a plain IMPROVEMENT critique (no semantic WARNING, no fragile edges) does not set hasWarnings', () => {
+    const { result } = renderWith([{ severity: 'IMPROVEMENT', message: 'Consider adding evidence' }])
+    expect(result.current.recommendation?.hasWarnings).toBe(false)
+  })
+
+  it('still sets hasWarnings for a first-class WARNING critique (unchanged behaviour)', () => {
+    const { result } = renderWith([{ severity: 'WARNING', message: 'Low sample validity' }])
+    expect(result.current.recommendation?.hasWarnings).toBe(true)
+  })
+})

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1578,7 +1578,13 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         const critiques = report?.run?.critique || []
         const hasWarningCritiques = critiques.some((c: any) =>
           c.severity === 'WARNING' || c.severity === 'BLOCKER' ||
-          c.severity === 'warning' || c.severity === 'blocker'
+          c.severity === 'warning' || c.severity === 'blocker' ||
+          // UI-SEM-069 bridge: advisories emitted as severity 'IMPROVEMENT'
+          // with semantic_severity 'WARNING' are ingested into uncertainties
+          // below (see the same check on the uncertainties list); hasWarnings
+          // must agree or the panel shows "ready, no warnings" while the
+          // uncertainties list simultaneously shows warnings.
+          c.semantic_severity === 'WARNING'
         )
         // Check for fragile edges
         const fragileEdges = safeArray(report?.robustness?.fragile_edges)
@@ -2761,7 +2767,11 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         return enriched
       })(),
     }
-  }, [report, m1Coaching, drivers, reviewStatus, m1ReviewAssumptions, nodeLabelMap])
+    // runMeta?.ceeReviewV1 is a genuine input (graphReadiness, evidence
+    // quality, bias/quality/improvement guidance all read it); the CEE review
+    // lands asynchronously after `report`, so omitting it froze the tier at
+    // its pre-review value. The sibling `completeness` memo already lists it.
+  }, [report, m1Coaching, drivers, reviewStatus, m1ReviewAssumptions, nodeLabelMap, runMeta?.ceeReviewV1])
 
   // ==========================================================================
   // Improvements Section Data (Legacy - now merged into confidence)


### PR DESCRIPTION
Implements the **safe, surgical subset** of the analysis-tab assessment. UI codebase only — no producer/PLoT/CEE/ISL changes, no graph/schema/migration/write-action changes. Each fix is re-verified against current staging (the tab has moved under active Lane UI-W4/W5 work) and carries tests.

## Fixes (4)

**P0 — confidence panel froze on a late CEE review.** `useResultsSectionData` confidence memo read `runMeta.ceeReviewV1` (readiness, evidence quality, bias/quality/improvement guidance) but omitted it from its deps, while the CEE review lands async after `report`. Added the dep (the sibling `completeness` memo already had it; ESLint exhaustive-deps now clears the confidence memo). Test pins the tier transition on a `ceeReviewV1` change with report identity held constant.

**P1 — `hasWarnings` disagreed with the uncertainties list.** The UI-SEM-069 bridge ingests `severity:'IMPROVEMENT'` + `semantic_severity:'WARNING'` advisories into uncertainties, but `hasWarnings` keyed only on `severity` → "ready, no warnings" while the list showed warnings. `hasWarnings` now also counts `semantic_severity === 'WARNING'`. Tests: parity + negative control + unchanged first-class WARNING.

**P0 — canvas "Leading option" badge disagreed with the panel.** `OptionNode.isRecommended` was pure win-max while the panel and the same node's `closeCallGapPp`/`behindReason` honour `recommended_option_id` first — the #1-vs-#4 cross-surface disagreement on close runs. Badge now follows `recommended_option_id` when present (mapping to a visible option), win-max fallback otherwise. No existing test set `recommended_option_id`, so all win-max cases are unchanged; two new tests pin both directions.

**P2 — schema-skew: untyped robustness reads.** `robustness.recommended_option_id/.level/.label/.near_tie` were read live with `as string` casts but absent from `V2RobustnessActual`, so a producer rename returned undefined with no compile signal. Declared them optional (compiler-only; zero new typecheck errors).

## Verification
- Typecheck: my files clean (see note below). Reactivity spec (4) + OptionNode suite (66) + focused results/hero regression net (250/251) green.
- The one failing test in the net (`DecisionConfidencePanel.polishD4` dominant-nudge copy) is **pre-existing on clean `origin/staging`**, not from this PR.

## ⚠️ Staging-state note — CORRECTED by orchestrator verification (7 Jul, fresh worktree at `7d4ca96f`)
An earlier version of this section claimed staging HEAD had **63 typecheck errors** (`mapV5Blocks.ts` + `phase3TypedBlocks.spec.ts`) introduced by #237/#238. Re-verification found this is **not the case**: the repo's authoritative typecheck gate (`pnpm run typecheck` = `tsc -p tsconfig.ci.json`) is **GREEN** on staging, and both named files carry **zero** errors under either tsconfig. The `polishD4` failure IS real but **pre-existing since ~2026-05-15** (its expected copy was retired in PR #145) — not introduced by #237/#238. The chronic "Staging Tests" full-suite red (vitest OOM truncation, ~11 red files) predates #237/#238 by ≥5 pushes and is tracked separately on the program board. This PR's own gate evidence: `tsc -p tsconfig.ci.json` exit 0 at PR head; reactivity + OptionNode suites 70/70; the 4 new tests fail exactly on unfixed staging source (adversarially checked).

## Deferred (not surgical / higher-risk / structural — see assessment)
Not done here on purpose, to stay safe amid the active churn: goal_threshold_cap "% shift" normalisation honesty (core display-path change), win-probability matcher unification (partly debug-tooling), the two-hero verdict/dominant-factor/flip-risk convergence and V17 stale-gating (assessment recommends V17 retirement/dedupe over patching), and OptionNode's two factor-ranking orders (no clearly-canonical order). Each is documented in the assessment with rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pDAg5E5qYrXphFBbvyXb1

---
_Generated by [Claude Code](https://claude.ai/code/session_013pDAg5E5qYrXphFBbvyXb1)_
