### PR TITLE
fix(analysis): lift goal_fit_basis/display_verdict/confidence_tier through the live Seam-A mapper + render goal-fit caveat (1.6b, claim-integrity)

### DIFF
--- a/docs/lanes/lane36-seam-1-6b-enrichment-lift.md
+++ b/docs/lanes/lane36-seam-1-6b-enrichment-lift.md
@@ -1,0 +1,155 @@
+# Lane 1.6b — lift goal_fit_basis/display_verdict/confidence_tier through the live Seam-A mapper (claim-integrity)
+
+**Branch:** `claude-ui/seam-1-6b-enrichment-lift` · **Base:** `origin/staging` @ `19094017`
+**Doctrine:** render producer meaning verbatim, never invent/repair; additive only; RED-first.
+**Reference:** `parallel-briefs/UI-BOUNDARY-DATA-INVENTORY.md`.
+
+## Claim-type verification (STEP 1 — done before any fix)
+
+Traced the live conversational analysis render path end-to-end:
+
+- `/orchestrate/v2/turn` response → `useConversation.ts:3007 applyV5State(...)` →
+  `applyV5State.ts:617 mapV5AnalysisToReport(analysisBlock)` → `store.resultsComplete({report, ..., rawV2Response: null})`
+  (the comment at `applyV5State.ts` is explicit: *"V5 carries no V2 envelope; pass
+  null so the canvas store's V2-shaped enrichment / rawV2Response slots are
+  explicitly cleared rather than left to a stale prior write"*).
+- The main Results panel (`OutputsDock.tsx:613`) reads `useResultsSectionData()`,
+  which reads `results?.report` (`useResultsSectionData.ts:975`) — i.e. **Seam A's
+  `mapV5AnalysisToReport` output is the only source on the live path**;
+  `rawV2Response` is null so every Seam-B raw-response fallback in
+  `useResultsSectionData.ts` is inert on this path.
+
+**Verdict: the drop is on the live path and is user-visible.** Seam A
+(`mapV5AnalysisToReport.ts`) is confirmed as the correct and only fix site for the
+render path; Seam B (`responseMapper.ts`) is the secondary/browser-direct-PLoT path
+and was left untouched (out of scope, not needed — see below).
+
+## What was actually ON-WIRE vs what the mapper dropped
+
+Verified against CEE's `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP` (`olumi-schemas` tag
+`v0.14.0:src/boundary/enrichment.ts:599-611`, the 11-key CEE→UI keep-list):
+
+| Field | ON-WIRE (Seam A, CEE keep-list) | Pre-fix mapper behaviour |
+|---|---|---|
+| `robustness.display_verdict` / `display_verdict_reason` | YES — `robustness` is a whole keep-list key | Read via a **subset** spread (`mapV5AnalysisToReport.ts:420-461` pre-fix); these two fields were never in the subset → dropped |
+| `confidence_tier` (top-level scalar) | YES — one of the 11 keep-list keys | Never read at all → `report.confidence_tier` always undefined |
+| `goal_fit_basis` (per-option, `option_comparison[].goal_fit_basis`) | YES — nested inside `option_comparison`, itself a keep-list key | Never read → 0 grep hits anywhere in the UI (confirmed before this lane) |
+| `constraints_status` | **NO** — not one of the 11 keep-list keys; CEE's compose.ts strips it before it ever reaches Seam A | N/A — nothing to lift; see residual below |
+
+`constraints_status` was grouped with the other three in the brief, but tracing the
+actual CEE keep-list showed it is **not currently on the CEE→UI wire at all** on
+Seam A (only reachable via the Seam-B raw V2 response, and even there only feeds a
+CEE-context payload — `useConversation.ts:1925` — not a user render). This is a
+**backend gap** (CEE compose.ts), not a mapper gap. Lifted defensively/forward-
+compatibly in the mapper anyway (harmless, guarded on presence) so no further UI
+change is needed once a CEE lane adds it to the keep-list — but it is currently
+inert on Seam A. Filed as a residual (see below); not claimed as "now live."
+
+## Fix
+
+`src/v5/mapV5AnalysisToReport.ts`:
+- `display_verdict` / `display_verdict_reason` added to the `robustness` spread
+  (verbatim strings, `safeString`-guarded — same passthrough discipline as the
+  existing `level`/`recommended_option_id` fields).
+- Top-level `confidence_tier` lifted from `enrichment.confidence_tier` onto
+  `report.confidence_tier` (verbatim string; the consumer already validates against
+  the closed `strong|fair|needs_work` union).
+- Per-option `goal_fit_basis` (`{scored_from, node_ids}`) lifted from
+  `option_comparison[].goal_fit_basis` into `option_probabilities[optionId]`, via a
+  new `normaliseGoalFitBasis` helper (narrowed, not opaque — matches the mapper's
+  existing convention for nested objects).
+- `constraints_status` lifted defensively (forward-compatible no-op today — see
+  above).
+
+`src/components/results/types.ts`: `ResultsReport.constraints_status` and
+`ResultsOptionProbability.goal_fit_basis` typed; `OptionResult.goalFitIsModelledBasis`
+added (the render-facing boolean).
+
+`src/components/results/useResultsSectionData.ts`: `display_verdict` /
+`display_verdict_reason` needed **no render-site change** —
+`useResultsSectionData.ts:1420-1445` already reads
+`rawRobustnessDisplayVerdict ?? robustness?.display_verdict` where
+`robustness = report.robustness` (`:1349`), i.e. it already has a mapped-report
+fallback for exactly this case (built for the Seam-B saved/hydrated path). Populating
+`report.robustness.display_verdict` in the mapper was sufficient — verified, not
+duplicated (per the brief's STEP 3 instruction). Likewise `confidence_tier` needed no
+render-site change: `getConfidenceTier(report?.confidence_tier, ...)` (`:2028`)
+already reads the mapped-report field directly with no raw-response dependency.
+
+`goal_fit_basis` had **no existing render or consumption anywhere** (confirmed 0 grep
+hits pre-lane), so its caveat needed a new render site:
+- `useResultsSectionData.ts` computes `goalFitIsModelledBasis` per option — true only
+  when the number about to be shown as `goalProbability` **is** the joint-goal figure
+  (mirrors the existing `hasConstraints`/`jointGoalProb` fallback branches exactly,
+  rather than comparing resulting numbers, to avoid a false-match on a coincidental
+  equal value) **and** `goal_fit_basis.scored_from === 'modelled_outcome_distribution'`.
+- `OptionCards.tsx` (the primary per-option "Hits target" card — the clearest,
+  highest-traffic goal-fit render site) renders the caveat immediately below the
+  `StatBar`/low-goal-warning, gated on `option.goalFitIsModelledBasis === true`,
+  using the exact wording the honesty rule in the inventory prescribes.
+
+**Scope note on "wherever the joint number appears":** the inventory's §4 item 3
+says "render the caveat wherever the joint number appears." This lane renders it at
+the primary option-card site (`OptionCards.tsx`). Two secondary sites also read
+`probability_of_joint_goal`-derived values — `useNodeDisplayMetadata.ts` (canvas node
+badge) and `analysis-hero/buildHeroModel.ts` (hero detail line) — left untouched to
+keep this lane additive and minimal per its stated scope
+("the specific render sites for the caveat/verdict... do not touch gratuitously").
+Filed as a follow-up below.
+
+## Verification (what actually ran)
+
+- **RED-first, both layers, verified by `git stash` on the fix files + re-run:**
+  - `mapV5AnalysisToReport.test.ts` new describe block: 3/6 new tests failed pre-fix
+    (live 4-field fixture, goal_fit_basis-only-scored_from, constraints_status
+    forward-compat) — the rest incidentally passed pre-fix (absence-path assertions
+    that are true both before and after).
+  - `useResultsSectionData.seamAEnrichmentLift.spec.ts` (new, builds the store
+    exactly as `applyV5State` does — mapped report + `rawV2Response: null`): 3/4
+    failed pre-fix (confidence tier, goal-fit caveat flag, honest-absence flag
+    default); the display_verdict test passed pre-fix as well as post- because it
+    happened to already flow through the pre-existing raw-response/mapped-report
+    fallback pattern with a partially-populated report in that one shape — the
+    3-field failure set is the true RED signal.
+  - `OptionCards.goalFitBasisCaveat.spec.tsx` (new, component-level): asserts the
+    caveat testid renders only when flagged, never fabricated.
+- **Typecheck:** `pnpm run typecheck` (tsc -p tsconfig.ci.json) — clean.
+- **Targeted vitest** (all touched files + their existing sibling specs in the same
+  area, run together): **285 passed / 0 failed** —
+  `mapV5AnalysisToReport.test.ts` (59), `mapV5AnalysisToReport.influence-warnings.spec.ts`,
+  `useResultsSectionData.seamAEnrichmentLift.spec.ts` (4, new),
+  `useResultsSectionData.goalProbability.spec.ts`, `useResultsSectionData.robustnessVerdict.spec.ts`,
+  `useResultsSectionData.displayHonesty.spec.ts`, `useResultsSectionData.spec.ts`,
+  `OptionCards.spec.tsx`, `OptionCards.displayHonesty.spec.tsx`,
+  `OptionCards.goalFitBasisCaveat.spec.tsx` (2, new), `OptionCards.brief-5_1.spec.tsx`,
+  `OptionCards.showAllCollision.spec.tsx`, `OptionCards.v5-visible-render.spec.tsx`.
+- **`--changed` sweep:** one pre-existing failure
+  (`useConversation.hook.spec.ts > V5 graph re-fetch on analyse response > fetches
+  graph from DB and populates canvas when analyse response arrives with empty
+  canvas`) — verified byte-identical on unmodified `origin/staging` (same assertion,
+  same zero-calls result) via `git stash` on all lane files + re-run. A broader
+  `--changed=origin/staging` sweep (no `-t` filter) additionally surfaced ~49
+  "failed" files under `src/canvas/` and `src/telemetry/` (e.g.
+  `guidanceEvents.spec.tsx` throwing `Cannot read properties of undefined
+  (reading 'some')` in `focusHelpers.ts` via `GuidanceStrip.tsx`) — spot-checked two
+  of these in isolation with the lane's changes stashed and got the **identical**
+  failure/stack trace, confirming pre-existing test-isolation flake unrelated to this
+  lane's additive-only optional-field changes (no removed/renamed exports, no changed
+  function signatures on existing call sites). Not chased per the chronic-CI-red
+  disclosure convention (ROADMAP 1.26 class).
+- Full local suite NOT run (OOMs by policy); "Staging Tests" CI chronic red is
+  pre-existing — disclosed, not chased.
+
+## Residuals (follow-ups, not this lane)
+
+1. **`constraints_status` is not actually on the CEE→UI Seam-A wire.** CEE's
+   `compose.ts` `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP` (11 keys) omits it. This lane's
+   mapper change is forward-compatible but inert until a CEE lane adds it to the
+   keep-list (inventory §4 item 5). No user-facing constraint-status surface exists
+   yet either way.
+2. **Two secondary goal-fit render sites left untouched:** the canvas node badge
+   (`useNodeDisplayMetadata.ts` → some node-badge component) and the analysis-hero
+   detail line (`analysis-hero/buildHeroModel.ts`'s `goalFit` copy) both derive from
+   `probability_of_joint_goal` and could show the same caveat. Not done here to keep
+   the lane additive/minimal; flag for a follow-up UI lane if the hero/node-badge
+   surfaces are judged worth the same honesty treatment.

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -442,6 +442,20 @@ function OptionCard({
               </span>
             </div>
           )}
+          {/* Display-honesty (ROADMAP 1.6b, doctrine B / PLoT #204): the
+              "Hits target" number above is scored from a MODELLED
+              forward-propagated outcome distribution, not a
+              directly-elicited base — the caveat renders adjacent to the
+              number it qualifies, never separately (never invented; the
+              wording mirrors the honesty rule verbatim). */}
+          {option.goalFitIsModelledBasis === true && (
+            <p
+              className={`${typography.panelMeta} text-text-light`}
+              data-testid={`goal-fit-basis-caveat-${option.id}`}
+            >
+              Modelled from the target's projected outcome distribution, not a directly-set starting value.
+            </p>
+          )}
         </div>
       )}
 

--- a/src/components/results/__tests__/OptionCards.goalFitBasisCaveat.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.goalFitBasisCaveat.spec.tsx
@@ -1,0 +1,62 @@
+/**
+ * OptionCards — goal_fit_basis caveat rendering (ROADMAP 1.6b,
+ * claim-integrity, shared-seam UI lane).
+ *
+ * Honesty rule (UI-BOUNDARY-DATA-INVENTORY.md §5): when
+ * probability_of_joint_goal is shown and goal_fit_basis.scored_from
+ * is 'modelled_outcome_distribution', the caveat MUST render adjacent
+ * to the number — a bare number is false precision. The caveat must
+ * NEVER appear for an option that doesn't carry the flag (no invention).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import type { OptionResult } from '../types'
+
+function makeOption(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: 'option-a',
+    label: 'Option A',
+    expected: 50,
+    outcome: { mean: 50, p10: 20, p50: 50, p90: 80 },
+    p10: 20,
+    p50: 50,
+    p90: 80,
+    isRecommended: true,
+    winProbability: 0.65,
+    goalProbability: 0.42,
+    rank: 1,
+    ...overrides,
+  }
+}
+
+describe('OptionCards — goal_fit_basis caveat', () => {
+  it('renders the modelled-basis caveat adjacent to the goal-fit number when flagged', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', goalProbability: 0.42, goalFitIsModelledBasis: true }),
+      makeOption({
+        id: 'b',
+        label: 'B',
+        goalProbability: 0.3,
+        goalFitIsModelledBasis: false,
+        isRecommended: false,
+      }),
+    ]
+    render(<OptionCards options={options} winnerId="a" hasGoalThreshold />)
+
+    expect(screen.getByTestId('goal-fit-basis-caveat-a')).toBeTruthy()
+    expect(screen.queryByTestId('goal-fit-basis-caveat-b')).toBeNull()
+  })
+
+  it('renders no caveat for any option when the flag is absent (honest default)', () => {
+    const options: OptionResult[] = [
+      makeOption({ id: 'a', label: 'A', goalProbability: 0.42 }),
+      makeOption({ id: 'b', label: 'B', goalProbability: 0.3, isRecommended: false }),
+    ]
+    render(<OptionCards options={options} winnerId="a" hasGoalThreshold />)
+
+    expect(screen.queryByTestId('goal-fit-basis-caveat-a')).toBeNull()
+    expect(screen.queryByTestId('goal-fit-basis-caveat-b')).toBeNull()
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.seamAEnrichmentLift.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.seamAEnrichmentLift.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * useResultsSectionData — Seam-A (live conversational) enrichment lift
+ * (ROADMAP 1.6b, claim-integrity, shared-seam UI lane).
+ *
+ * Builds the store exactly as the live path does: `mapV5AnalysisToReport`
+ * produces `report`, and `rawV2Response` is explicitly `null` (see
+ * applyV5State.ts:617-627 — "V5 carries no V2 envelope; pass null so the
+ * canvas store's V2-shaped enrichment / rawV2Response slots are explicitly
+ * cleared"). Before this lane, `display_verdict`, `display_verdict_reason`,
+ * `confidence_tier`, and the per-option `goal_fit_basis` caveat never
+ * reached this render path even though CEE's keep-list carries them —
+ * the mapper simply never read them. UI-BOUNDARY-DATA-INVENTORY.md §4.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV5AnalysisToReport } from '../../../v5/mapV5AnalysisToReport'
+
+const OPTION_NODES = [
+  { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option A' } },
+  { id: 'opt_b', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option B' } },
+]
+
+function setStoreFromLiveSeamABlock(block: AnalysisResultBlock): void {
+  const report = mapV5AnalysisToReport(block, { seed: 42 })
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report } as any,
+    runMeta: {} as any,
+    nodes: OPTION_NODES as any,
+    edges: [],
+    hasCompletedFirstRun: true,
+    // Matches applyV5State.ts:617-627 exactly — the live path always nulls
+    // rawV2Response, so any render-path assertion here is proof the Seam-A
+    // mapped report ALONE carries the field, not a raw-response fallback.
+    rawV2Response: null,
+  } as any)
+}
+
+describe('useResultsSectionData — Seam-A live fixture carrying the 4 lifted fields', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+    } as any)
+  })
+
+  it('display_verdict + display_verdict_reason render verbatim from a live Seam-A turn', () => {
+    setStoreFromLiveSeamABlock({
+      type: 'analysis_result',
+      summary: 'Option A leads',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+      enrichment: {
+        robustness: {
+          fragile_edges: [],
+          robust_edges: ['e1'],
+          display_verdict: 'robust',
+          display_verdict_reason: 'No edge flips the winner within the tested range.',
+        },
+      },
+    } as unknown as AnalysisResultBlock)
+
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.recommendation?.robustnessVerdict).toBe('robust')
+    expect(result.current.recommendation?.robustnessVerdictReason).toBe(
+      'No edge flips the winner within the tested range.',
+    )
+  })
+
+  it('confidence_tier renders as the producer-classified tier, not the legacy cascade', () => {
+    setStoreFromLiveSeamABlock({
+      type: 'analysis_result',
+      summary: 'Option A leads',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 1 },
+      enrichment: { confidence_tier: 'fair' },
+    } as unknown as AnalysisResultBlock)
+
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.confidence.tier.tier).toBe('fair')
+  })
+
+  it('goal_fit_basis caveat flag is true ONLY for the option whose displayed number is the modelled joint-goal figure', () => {
+    setStoreFromLiveSeamABlock({
+      type: 'analysis_result',
+      summary: 'Option A leads',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+      enrichment: {
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            win_probability: 0.6,
+            probability_of_joint_goal: 0.42,
+            goal_fit_basis: {
+              scored_from: 'modelled_outcome_distribution',
+              node_ids: ['node_budget'],
+            },
+          },
+          {
+            // No goal_fit_basis at all — must not acquire a fabricated caveat.
+            option_id: 'opt_b',
+            win_probability: 0.4,
+            probability_of_goal: 0.55,
+          },
+        ],
+      },
+    } as unknown as AnalysisResultBlock)
+
+    const { result } = renderHook(() => useResultsSectionData())
+    const byId = new Map(
+      (result.current.recommendation?.allOptions ?? []).map((o) => [o.id, o]),
+    )
+    expect(byId.get('opt_a')?.goalProbability).toBe(0.42)
+    expect(byId.get('opt_a')?.goalFitIsModelledBasis).toBe(true)
+    expect(byId.get('opt_b')?.goalProbability).toBe(0.55)
+    expect(byId.get('opt_b')?.goalFitIsModelledBasis).toBe(false)
+  })
+
+  it('a live Seam-A turn WITHOUT the four fields renders honest absence — no invention, no crash', () => {
+    setStoreFromLiveSeamABlock({
+      type: 'analysis_result',
+      summary: 'Option A leads',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.5, opt_b: 0.5 },
+      enrichment: {
+        robustness: { fragile_edges: [], robust_edges: [] },
+        option_comparison: [
+          { option_id: 'opt_a', win_probability: 0.5, probability_of_goal: 0.3 },
+          { option_id: 'opt_b', win_probability: 0.5 },
+        ],
+      },
+    } as unknown as AnalysisResultBlock)
+
+    const { result } = renderHook(() => useResultsSectionData())
+    // display_verdict absent → honest "Robustness unknown" state, not upgraded.
+    expect(result.current.recommendation?.robustnessVerdict).toBeUndefined()
+    // confidence_tier absent → falls to the legacy cascade (not 'strong'/'fair'/'needs_work'
+    // fabricated from nothing); the hook must not throw.
+    expect(['strong', 'fair', 'needs_work', 'unknown']).toContain(result.current.confidence.tier.tier)
+    const byId = new Map(
+      (result.current.recommendation?.allOptions ?? []).map((o) => [o.id, o]),
+    )
+    expect(byId.get('opt_a')?.goalFitIsModelledBasis).toBe(false)
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -137,6 +137,15 @@ export interface OptionResult {
   rank?: number
   /** Multi-constraint analysis: per-option constraint satisfaction from ISL */
   constraintAnalysis?: ConstraintAnalysis
+  /**
+   * Display-honesty (ROADMAP 1.6b): true when the rendered `goalProbability`
+   * IS the joint-goal number AND its producer-owned `goal_fit_basis.scored_from`
+   * is 'modelled_outcome_distribution' — i.e. the number was scored from a
+   * MODELLED forward-propagated outcome distribution rather than a
+   * directly-elicited base. Render sites showing `goalProbability` MUST
+   * surface a caveat when this is true (UI-BOUNDARY-DATA-INVENTORY.md §5).
+   */
+  goalFitIsModelledBasis?: boolean
 }
 
 /** Outcome unit type for formatting - from goal node observed_state.unit */
@@ -1045,6 +1054,13 @@ export interface ResultsReport extends Omit<ReportV1, 'option_probabilities'> {
   analysis_state?: string
   /** PLoT-classified confidence tier (B2, optional for cached pre-B1 results) */
   confidence_tier?: 'strong' | 'fair' | 'needs_work'
+  /**
+   * Constraint-evaluation feature status (PLoT #205). NOT on the CEE→UI
+   * Seam-A wire today (absent from compose.ts's keep-list) — declared here
+   * so the mapper's forward-compatible passthrough is typed; expect
+   * undefined until a CEE lane adds it to the keep-list.
+   */
+  constraints_status?: 'computed' | 'unavailable' | 'skipped' | 'error'
   /** PLoT-classified dominant factor (B2, optional for cached pre-B1 results) */
   dominant_factor?: { factor_id: string; factor_label: string }
   /**
@@ -1076,6 +1092,17 @@ export interface ResultsOptionProbability extends OptionProbability {
   }
   bands?: { p10?: number | null; p50?: number | null; p90?: number | null }
   constraint_analysis?: ConstraintAnalysis
+  /**
+   * Provenance caveat for probability_of_joint_goal (PLoT #204, doctrine
+   * B): present when the joint-goal number was scored from the
+   * constraint-target node's MODELLED forward-propagated outcome
+   * distribution rather than a directly-elicited base. `scored_from` is
+   * producer-owned open vocabulary (currently always
+   * 'modelled_outcome_distribution'). Render sites that show the
+   * joint-goal number MUST surface this caveat alongside it — see
+   * UI-BOUNDARY-DATA-INVENTORY.md §5.
+   */
+  goal_fit_basis?: { scored_from?: string; node_ids?: string[] }
 }
 
 /**

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1257,9 +1257,27 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         ? prob.goal_probability
         : null
       const hasConstraints = prob.constraint_analysis?.constraints?.length > 0
+      // Mirrors the goalProbability fallback branches directly below (rather
+      // than comparing resulting numbers, which could false-match on a
+      // coincidental equal value) so we know precisely WHEN the displayed
+      // number is the joint-goal figure the goal_fit_basis caveat qualifies.
+      const goalProbabilityIsJoint = hasConstraints
+        ? jointGoalProb != null
+        : unconstrained == null && jointGoalProb != null
       const goalProbability = hasConstraints && jointGoalProb != null
         ? jointGoalProb
         : (unconstrained ?? jointGoalProb)
+      // Display-honesty (ROADMAP 1.6b, doctrine B / PLoT #204): the
+      // provenance caveat renders ONLY when the number just shown is the
+      // joint-goal figure AND the producer marked it as scored from a
+      // modelled outcome distribution — never inferred, never applied to
+      // the unconstrained probability_of_goal number.
+      const goalFitBasisScoredFrom =
+        typeof (prob as any).goal_fit_basis?.scored_from === 'string'
+          ? ((prob as any).goal_fit_basis.scored_from as string)
+          : null
+      const goalFitIsModelledBasis =
+        goalProbabilityIsJoint && goalFitBasisScoredFrom === 'modelled_outcome_distribution'
 
       // Display-honesty: per-option valid sample count for resolution-aware
       // probability formatting. Fallback chain prefers per-option signal,
@@ -1296,6 +1314,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         winProbability: prob.win_probability,
         nValidSamples,
         goalProbability,
+        goalFitIsModelledBasis,
         // Multi-constraint analysis (from ISL when goal_constraints were provided)
         constraintAnalysis: prob.constraint_analysis,
       }

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -1012,3 +1012,142 @@ describe('mapV5AnalysisToReport — deterministic hash + minimal envelope', () =
     expect(report.meta.seed).toBe(42)
   })
 })
+
+// ROADMAP 1.6b (claim-integrity, shared-seam UI lane): display_verdict,
+// display_verdict_reason, confidence_tier, and goal_fit_basis are all
+// ON-WIRE on Seam A (CEE compose.ts P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP
+// carries `robustness` and `confidence_tier` whole) but were previously
+// never read by this mapper — the live conversational path showed
+// "Robustness unknown" / the legacy confidence cascade / no goal-fit
+// caveat regardless of what the producer sent. UI-BOUNDARY-DATA-INVENTORY.md
+// §3.4/§3.5/§3.2/§4.
+describe('mapV5AnalysisToReport — display_verdict / confidence_tier / goal_fit_basis (ROADMAP 1.6b)', () => {
+  it('a live-shaped fixture carrying all four fields survives the mapper verbatim', () => {
+    const block = baseBlock({
+      win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+      enrichment: {
+        confidence_tier: 'fair',
+        robustness: {
+          fragile_edges: [],
+          robust_edges: [],
+          is_robust: true,
+          level: 'high',
+          display_verdict: 'robust',
+          display_verdict_reason: 'No edge flips the winner within the tested range.',
+        },
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            win_probability: 0.6,
+            probability_of_joint_goal: 0.42,
+            goal_fit_basis: {
+              scored_from: 'modelled_outcome_distribution',
+              node_ids: ['node_budget'],
+            },
+          },
+          { option_id: 'opt_b', win_probability: 0.4 },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      confidence_tier?: string
+      robustness?: { display_verdict?: string; display_verdict_reason?: string }
+      option_probabilities?: Record<
+        string,
+        { goal_fit_basis?: { scored_from?: string; node_ids?: string[] } }
+      >
+    }
+
+    expect(report.confidence_tier).toBe('fair')
+    expect(report.robustness?.display_verdict).toBe('robust')
+    expect(report.robustness?.display_verdict_reason).toBe(
+      'No edge flips the winner within the tested range.',
+    )
+    expect(report.option_probabilities?.opt_a?.goal_fit_basis).toEqual({
+      scored_from: 'modelled_outcome_distribution',
+      node_ids: ['node_budget'],
+    })
+    // The unqualified option must NOT acquire a fabricated caveat.
+    expect(report.option_probabilities?.opt_b?.goal_fit_basis).toBeUndefined()
+  })
+
+  it('a fixture WITHOUT the four fields produces honest absence — no invention, no crash', () => {
+    const block = baseBlock({
+      win_probabilities: { opt_a: 1 },
+      enrichment: {
+        robustness: { fragile_edges: [], robust_edges: [] },
+        option_comparison: [{ option_id: 'opt_a', win_probability: 1 }],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      confidence_tier?: string
+      robustness?: { display_verdict?: string; display_verdict_reason?: string }
+      option_probabilities?: Record<string, { goal_fit_basis?: unknown }>
+    }
+
+    expect(report.confidence_tier).toBeUndefined()
+    expect(report.robustness?.display_verdict).toBeUndefined()
+    expect(report.robustness?.display_verdict_reason).toBeUndefined()
+    expect(report.option_probabilities?.opt_a?.goal_fit_basis).toBeUndefined()
+  })
+
+  it('non-string display_verdict / confidence_tier values are dropped, not coerced', () => {
+    const block = baseBlock({
+      enrichment: {
+        confidence_tier: 42,
+        robustness: { fragile_edges: [], robust_edges: [], display_verdict: null },
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      confidence_tier?: string
+      robustness?: { display_verdict?: string }
+    }
+
+    expect(report.confidence_tier).toBeUndefined()
+    expect(report.robustness?.display_verdict).toBeUndefined()
+  })
+
+  it('goal_fit_basis with only scored_from (no node_ids) is preserved partially, not dropped wholesale', () => {
+    const block = baseBlock({
+      enrichment: {
+        option_comparison: [
+          {
+            option_id: 'opt_a',
+            probability_of_joint_goal: 0.1,
+            goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+          },
+        ],
+      },
+    })
+
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+      option_probabilities?: Record<
+        string,
+        { goal_fit_basis?: { scored_from?: string; node_ids?: string[] } }
+      >
+    }
+
+    expect(report.option_probabilities?.opt_a?.goal_fit_basis).toEqual({
+      scored_from: 'modelled_outcome_distribution',
+    })
+  })
+
+  it('constraints_status: forward-compatible passthrough when present, absent by default (NOT on CEE keep-list today)', () => {
+    // Documents the residual: CEE's compose.ts P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP
+    // does not include constraints_status, so a real Seam-A payload never
+    // carries it — this fixture simulates a FUTURE keep-list extension to
+    // prove the mapper is ready without overclaiming today's wire shape.
+    const withStatus = mapV5AnalysisToReport(
+      baseBlock({ enrichment: { constraints_status: 'unavailable' } }),
+    ) as ReturnType<typeof mapV5AnalysisToReport> & { constraints_status?: string }
+    expect(withStatus.constraints_status).toBe('unavailable')
+
+    const withoutStatus = mapV5AnalysisToReport(
+      baseBlock({ enrichment: { robustness: { fragile_edges: [], robust_edges: [] } } }),
+    ) as ReturnType<typeof mapV5AnalysisToReport> & { constraints_status?: string }
+    expect(withoutStatus.constraints_status).toBeUndefined()
+  })
+})

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -47,6 +47,29 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return v != null && typeof v === 'object' && !Array.isArray(v)
 }
 
+/**
+ * Normalise a raw `goal_fit_basis` entry (PLoT #204, doctrine B).
+ * `.passthrough()` on the schema side — only `scored_from` (open-vocab
+ * string) and `node_ids` (string array) are read; unknown extra keys are
+ * dropped rather than carried opaquely, matching this mapper's "narrowed,
+ * never opaque" convention for nested objects (see the option_comparison
+ * shape below). Returns undefined when neither field is present.
+ */
+function normaliseGoalFitBasis(
+  raw: { scored_from?: unknown; node_ids?: unknown } | undefined,
+): { scored_from?: string; node_ids?: string[] } | undefined {
+  if (!raw) return undefined
+  const scoredFrom = safeString(raw.scored_from)
+  const nodeIds = Array.isArray(raw.node_ids)
+    ? raw.node_ids.filter((v): v is string => typeof v === 'string')
+    : undefined
+  if (scoredFrom === undefined && nodeIds === undefined) return undefined
+  return {
+    ...(scoredFrom !== undefined ? { scored_from: scoredFrom } : {}),
+    ...(nodeIds !== undefined ? { node_ids: nodeIds } : {}),
+  }
+}
+
 // ─── Factor sensitivity normalisation ──────────────────────────────────
 
 interface NormalisedFactor {
@@ -219,6 +242,14 @@ interface RawOptionEnrichmentEntry {
   confidence_interval?: unknown
   expected_outcome?: unknown
   outcome?: { mean?: unknown; p10?: unknown; p50?: unknown; p90?: unknown }
+  /**
+   * Provenance caveat (PLoT #204, doctrine B): present when
+   * probability_of_joint_goal was scored from the constraint-target node's
+   * MODELLED forward-propagated outcome distribution rather than a
+   * directly-elicited base. `.passthrough()` on the schema side — carried
+   * verbatim, never derived. UI-BOUNDARY-DATA-INVENTORY.md §3.2/§5.
+   */
+  goal_fit_basis?: { scored_from?: unknown; node_ids?: unknown }
 }
 
 interface ResolvedOptionEntry {
@@ -328,6 +359,14 @@ export function mapV5AnalysisToReport(
       p50?: number | null
       p90?: number | null
     }
+    /**
+     * Provenance caveat for probability_of_joint_goal — see
+     * RawOptionEnrichmentEntry.goal_fit_basis above. Carried verbatim
+     * (scored_from is producer-owned open vocabulary; UI never rewrites
+     * it). Render sites MUST show this alongside the joint-goal number
+     * per the honesty rule in UI-BOUNDARY-DATA-INVENTORY.md §5.
+     */
+    goal_fit_basis?: { scored_from?: string; node_ids?: string[] }
   }
   const option_probabilities: Record<string, ResultsOptionProbability> = {}
 
@@ -389,6 +428,8 @@ export function mapV5AnalysisToReport(
     const p50 = safeFiniteNumber(outcome?.p50) ?? null
     const p90 = safeFiniteNumber(outcome?.p90) ?? ciHigh
 
+    const goalFitBasis = normaliseGoalFitBasis(enriched?.goal_fit_basis)
+
     option_probabilities[optionId] = {
       // No silent defaults — undefined when missing.
       ...(safeFiniteNumber(enriched?.probability_of_goal) !== undefined
@@ -401,6 +442,10 @@ export function mapV5AnalysisToReport(
             ),
           }
         : {}),
+      // Provenance caveat for probability_of_joint_goal — see
+      // normaliseGoalFitBasis. Carried alongside the number it qualifies;
+      // render sites must show both together (UI-BOUNDARY-DATA-INVENTORY §5).
+      ...(goalFitBasis !== undefined ? { goal_fit_basis: goalFitBasis } : {}),
       confidence: 0.5,
       ...(winProb !== undefined ? { win_probability: winProb } : {}),
       ...(expected !== undefined ? { expected } : {}),
@@ -457,6 +502,24 @@ export function mapV5AnalysisToReport(
         ...(Array.isArray(robustnessRaw.conditional_winners)
           ? { conditional_winners: robustnessRaw.conditional_winners }
           : {}),
+        // Display-honesty (ROADMAP 1.6b; producer PLoT #202): display-safe
+        // verdict + producer-owned reason, rendered VERBATIM. ON-WIRE on
+        // Seam A (CEE compose.ts keep-list carries `robustness` whole) but
+        // previously dropped here — the whole conversational path fell to
+        // "Robustness unknown". useResultsSectionData.ts already reads
+        // report.robustness.display_verdict as its Seam-B-absent fallback
+        // (rawRobustnessDisplayVerdict ?? robustness?.display_verdict), so
+        // populating this slot is sufficient — no render-site change needed.
+        ...(safeString(robustnessRaw.display_verdict) !== undefined
+          ? { display_verdict: safeString(robustnessRaw.display_verdict) }
+          : {}),
+        ...(safeString(robustnessRaw.display_verdict_reason) !== undefined
+          ? {
+              display_verdict_reason: safeString(
+                robustnessRaw.display_verdict_reason,
+              ),
+            }
+          : {}),
       }
     : undefined
 
@@ -479,6 +542,28 @@ export function mapV5AnalysisToReport(
   const inferenceWarnings = Array.isArray(enrichment?.inference_warnings)
     ? (enrichment!.inference_warnings as unknown[])
     : undefined
+
+  // Display-honesty (ROADMAP 1.6b; producer PLoT #202): top-level
+  // producer-classified confidence tier. ON-WIRE on Seam A (`confidence_tier`
+  // is one of the 11 keys in CEE's P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP
+  // compose.ts keep-list) but previously never read here, so
+  // useResultsSectionData's getConfidenceTier(report?.confidence_tier, ...)
+  // always fell to the legacy readiness cascade on the conversational path.
+  // Carried verbatim; the consumer already gates to the closed
+  // strong/fair/needs_work union before trusting it.
+  const confidenceTier = safeString(enrichment?.confidence_tier)
+
+  // constraints_status (PLoT #205): per-run constraint-evaluation feature
+  // status. Read defensively for forward-compatibility, but AS OF THIS
+  // LANE it is NOT on the CEE→UI wire for Seam A — constraints_status is
+  // absent from CEE's compose.ts P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP
+  // (verified against the 11-key list; only reaches the UI today via the
+  // Seam-B raw V2 response, see useConversation.ts:1925 which reads it for
+  // CEE-context building, not user display). This line is a no-op until a
+  // CEE lane adds constraints_status to the keep-list — tracked as a
+  // residual (UI-BOUNDARY-DATA-INVENTORY.md §4 item 5). Kept here so no
+  // further UI change is needed once that lands.
+  const constraintsStatus = safeString(enrichment?.constraints_status)
 
   // Deterministic response_hash when caller has none. Stable across identical
   // blocks so the store's hash-dedupe in resultsComplete works.
@@ -586,6 +671,8 @@ export function mapV5AnalysisToReport(
   if (robustness) widened.robustness = robustness
   if (topLevelFlipThresholds) widened.flip_thresholds = topLevelFlipThresholds
   if (topLevelEdgeEValues) widened.edge_e_values = topLevelEdgeEValues
+  if (confidenceTier !== undefined) widened.confidence_tier = confidenceTier
+  if (constraintsStatus !== undefined) widened.constraints_status = constraintsStatus
   if (inferenceWarnings) widened.inference_warnings = inferenceWarnings
   if (conditionalProbabilities !== undefined) {
     widened.conditional_probabilities = conditionalProbabilities


### PR DESCRIPTION
## Summary

Orchestrator-owned shared-seam UI lane (ROADMAP 1.6b + 1.6). Claim-verification first (STEP 1), then a scoped fix.

**Claim-type verification (done before any fix):** traced the live conversational analysis render path end-to-end — `/orchestrate/v2/turn` → `useConversation.ts:3007 applyV5State` → `applyV5State.ts:617 mapV5AnalysisToReport` → `store.report`, with `rawV2Response` explicitly `null` on this path. `OutputsDock.tsx` → `useResultsSectionData()` reads `results?.report` as the only source here. **Verdict: Seam A (`mapV5AnalysisToReport.ts`) is the live, user-visible path** — confirmed as the correct fix site.

**What was ON-WIRE (verified against CEE's 11-key `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP` keep-list) vs what the mapper dropped:**
- `robustness.display_verdict` / `display_verdict_reason` — ON-WIRE, dropped by a subset spread in the mapper. Fixed.
- `confidence_tier` (top-level scalar) — ON-WIRE, never read at all. Fixed.
- `goal_fit_basis` (per-option) — ON-WIRE (nested in `option_comparison`), zero consumption anywhere in the UI pre-lane. Fixed + new caveat render.
- `constraints_status` — **NOT actually on the Seam-A wire** (absent from CEE's keep-list; a backend gap, not a mapper gap). Lifted defensively/forward-compatibly but documented as currently inert — not claimed as live. See lane doc.

**Fix (additive only):**
- `mapV5AnalysisToReport.ts`: lifts the 3 live fields + defensive `constraints_status`.
- `display_verdict`/`display_verdict_reason`/`confidence_tier` needed **no render-site change** — existing consumers (`useResultsSectionData.ts`) already had a mapped-report fallback slot (built for Seam B), now populated. Verified, not duplicated.
- `goal_fit_basis` had zero prior consumption, so added a new caveat render in `OptionCards.tsx` — gated precisely on the displayed number being the joint-goal figure the caveat qualifies (mirrors the existing goalProbability fallback branches rather than comparing numbers, to avoid a false match).

Full trace, wire-vs-dropped table, and residuals in `docs/lanes/lane36-seam-1-6b-enrichment-lift.md`.

## Test plan

- [x] RED-first: 3 new mapper tests + 3 new render-hook tests fail against pre-fix code (verified via `git stash` + re-run), pass after.
- [x] `pnpm run typecheck` (tsc -p tsconfig.ci.json) — clean.
- [x] Targeted vitest across all touched files + existing sibling specs: 285/285 passed.
- [x] `--changed` sweep: one pre-existing failure (`useConversation.hook.spec.ts` scenario re-fetch test), verified byte-identical on unmodified `origin/staging`. A broader `--changed=origin/staging` sweep surfaced ~49 unrelated "failed" files in `src/canvas/`/`src/telemetry/`; spot-checked as identical pre-existing failures with this lane's changes stashed.
- [x] Fast pre-push gate (typecheck + lint + smoke + stale-.js + dep audit) — all green on push.
- [ ] Full ~6,284-test suite runs in CI (`staging-full-tests.yml`) — not run locally per policy.

Note: the pre-push Design System v5 ratchet flagged `production-hex` Δ+33 net-new (report-only, non-blocking) — these are false-positive matches on `#202`/`#204`/`#205`/`#200` PR-number references inside code comments (the doc-convention this repo already uses throughout `useResultsSectionData.ts`/`responseMapper.ts`), not actual hex colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)