### PR TITLE
fix(analysis): complete goal-fit modelled-basis caveat — hero + node badge (1.6b follow-up, claim-integrity)

### DIFF
--- a/docs/lanes/lane37-goalfit-caveat-completeness.md
+++ b/docs/lanes/lane37-goalfit-caveat-completeness.md
@@ -1,0 +1,115 @@
+# Lane 37 — goal-fit modelled-basis caveat completeness (1.6b follow-up, claim-integrity)
+
+**Branch:** `claude-ui/goalfit-caveat-completeness` (worktree, base `origin/staging` @ `fc14e794`, tip includes #241/#240)
+**Zone:** spans Zone A (canvas — `useNodeDisplayMetadata.ts`, `GoalNode.tsx`) and Zone B (analysis tab —
+`analysis-hero/buildHeroModel.ts`, `HeroOptionRow.tsx`). **Both incoming zone-owner lanes should rebase
+past this branch** before continuing work in either file.
+
+## Context
+
+PR #241 (1.6b) added the `goal_fit_basis` modelled-basis caveat to `OptionCards.tsx`, gated on
+`option.goalFitIsModelledBasis === true` (itself gated in `useResultsSectionData.ts` on the
+number shown being the joint-goal figure AND `goal_fit_basis.scored_from ===
+'modelled_outcome_distribution'`). That lane's own residuals section flagged two secondary
+render sites, deliberately left untouched to keep the lane minimal:
+
+1. The analysis-hero detail line (`analysis-hero/buildHeroModel.ts`'s `goalFit` copy,
+   rendered by `HeroOptionRow.tsx`).
+2. "the canvas node badge (`useNodeDisplayMetadata.ts` → **some** node-badge component)" —
+   the lane doc itself left the exact consuming component unidentified.
+
+Both derive from `probability_of_joint_goal` and showed the number with no caveat — the same
+honesty gap 1.6b closed at the primary site.
+
+## STEP 1 — confirming the two sites
+
+- **Hero:** `buildHeroModel.ts` builds `detail.goalFit` from `o.goalProbability` (the already-collapsed
+  joint/unconstrained value `OptionResult.goalFitIsModelledBasis` already flags — computed once by
+  `useResultsSectionData.ts`, unchanged by this lane) and `HeroOptionRow.tsx` renders it verbatim
+  with `data-testid="hero-detail-goal-fit"`. Confirmed: a real goal-fit number render site, no caveat.
+- **Canvas node badge:** `useNodeDisplayMetadata.ts` independently derives `achievementProbability`
+  from the canvas store's `report.option_probabilities[recommendedOptionId]` (a different read path
+  than `useResultsSectionData.ts` — this hook is NOT shape-touched by this lane) using its own
+  `hasConstraints && jointProb != null` branch, but never read `goal_fit_basis` at all. Of its three
+  consumers (`GoalNode.tsx`'s "X% chance of reaching target", `OutcomeNode.tsx`'s "Achievement: X%"
+  diagnostic, `NodeInspector.tsx`'s inspector-panel readout), **`GoalNode.tsx` is treated as THE
+  primary node-badge** for this lane — it is the direct canvas analogue of OptionCards' "Hits target"
+  claim (a goal node's own on-canvas achievement-probability display), matching the "primary,
+  highest-traffic render site" precedent 1.6b itself set for OptionCards vs. other panels.
+  `OutcomeNode.tsx`'s secondary diagnostic line and `NodeInspector.tsx`'s panel readout are NOT
+  touched here — same claim-integrity gap, filed as a residual below rather than expanded into
+  gratuitously per this lane's additive/minimal scope.
+
+Both confirmed sites render a real goal-fit number with no caveat before this lane. No invented
+caveats — every gate mirrors an existing branch exactly (see below).
+
+## STEP 2 — implementation (additive only)
+
+- **Shared copy, single source:** `src/components/results/utils/goalFitBasisCaveatCopy.ts` exports
+  `GOAL_FIT_BASIS_CAVEAT_COPY` — the exact sentence OptionCards used inline. OptionCards.tsx now
+  imports it too (no wording drift possible across sites).
+- **Hero (`buildHeroModel.ts` + `heroTypes.ts` + `HeroOptionRow.tsx`):** added `HeroRowDetail.goalFitCaveat?:
+  string`, computed as `goalValue != null && o.goalFitIsModelledBasis === true ? GOAL_FIT_BASIS_CAVEAT_COPY
+  : undefined` — i.e. gated on the SAME `goalFitIsModelledBasis` flag OptionCards gates on, additionally
+  requiring the goal number is actually shown (`goalValue != null`, honouring UI-SEM-071's
+  null-user-target suppression). Rendered by `HeroOptionRow.tsx` immediately below `detail.goalFit`,
+  `data-testid="hero-detail-goal-fit-caveat"`.
+- **Canvas node badge (`useNodeDisplayMetadata.ts` + `GoalNode.tsx`):** added
+  `achievementProbabilityIsModelledBasis: boolean` to the hook's return, computed by mirroring the
+  hook's OWN existing `isJoint = hasConstraints && jointProb != null` branch (not
+  `useResultsSectionData.ts`'s — a different read path, no shape change to either) AND
+  `rec.goal_fit_basis?.scored_from === 'modelled_outcome_distribution'`. `GoalNode.tsx` renders the
+  shared caveat copy immediately below the "X% chance of reaching target" line when both
+  `achievementProbability !== null` and the new flag are true, `data-testid="goal-fit-basis-caveat-node"`.
+- No changes to `useResultsSectionData.ts`'s shape, `mapV5AnalysisToReport.ts`, the schemas pin, or
+  `canvas/store` — the hero reads an already-existing field, the node-badge hook computes its own
+  flag from data it already reads.
+
+## STEP 3 — RED-first, verified via `git stash`
+
+Three independent stash/re-run cycles (fix files only, tests untouched):
+
+1. `buildHeroModel.goalFitBasisCaveat.spec.tsx` (new) — stashing `buildHeroModel.ts` +
+   `heroTypes.ts` + `HeroOptionRow.tsx`: 1 of 3 mapper-level tests failed pre-fix (`goalFitCaveat`
+   undefined instead of the copy string; the honest-absence and null-target-suppression cases pass
+   both sides, as expected of an absence assertion) + 1 of 2 component-render tests failed
+   (`getByTestId('hero-detail-goal-fit-caveat')` not found). Both green after restoring.
+2. `useNodeDisplayMetadata.spec.ts` (extended) — stashing `useNodeDisplayMetadata.ts`: all 4 new
+   `achievementProbabilityIsModelledBasis` tests failed pre-fix (`undefined` vs. the expected
+   boolean). Green after restoring.
+3. `GoalNode.spec.tsx` (extended) — stashing `GoalNode.tsx`: the "renders caveat when flagged" test
+   failed pre-fix (`getByTestId('goal-fit-basis-caveat-node')` not found); the "no caveat when absent"
+   case passed both sides (honest-absence). Green after restoring.
+
+## Verification
+
+- **Typecheck:** `pnpm run typecheck` (`tsc -p tsconfig.ci.json --noEmit`) — clean.
+- **Targeted vitest** (all touched files + siblings, run together): **465 passed / 0 failed** across
+  16 files — `OptionCards.spec.tsx`, `OptionCards.goalFitBasisCaveat.spec.tsx`,
+  `OptionCards.displayHonesty.spec.tsx`, `OptionCards.brief-5_1.spec.tsx`,
+  `OptionCards.showAllCollision.spec.tsx`, `OptionCards.v5-visible-render.spec.tsx`,
+  `buildHeroModel.spec.ts`, `buildHeroModel.goalFitBasisCaveat.spec.tsx` (new), `content.spec.tsx`,
+  `interaction.spec.tsx`, `useNodeDisplayMetadata.spec.ts`, `GoalNode.spec.tsx`,
+  `OutcomeNode.spec.tsx`, `OptionNode.spec.tsx`, `RiskNode.spec.tsx`, `FactorNode.spec.tsx`.
+- **`--changed` sweep:** 2 pre-existing failures, both verified byte-identical (same failing count,
+  same messages) on unmodified `origin/staging` via `git stash` on all lane files + re-run:
+  - `ResultsBody.heroPlacement.spec.tsx` — 3/7 tests fail in isolation both with and without this
+    lane's changes (test-isolation flake independent of this diff — the file also produced a
+    *different* failure count when run bundled with unrelated suites in the full `--changed` sweep,
+    confirming cross-file pollution rather than a real regression).
+  - `OutputsDock.analysis-run.spec.tsx` — fails at import time with "Missing Supabase environment
+    variables" (`src/lib/supabase.ts`), an environment/config issue unrelated to any file this lane
+    touches.
+  Neither chased, per the chronic-CI-red disclosure convention (ROADMAP 1.26 class). "Staging Tests"
+  CI chronic red is also pre-existing — disclosed, not chased.
+- Full local suite NOT run (OOMs by policy).
+
+## Residuals (follow-ups, not this lane)
+
+1. **`OutcomeNode.tsx`'s "Achievement: X%" diagnostic line and `NodeInspector.tsx`'s inspector-panel
+   readout** both consume the same `useNodeDisplayMetadata.ts` `achievementProbability` /
+   `achievementProbabilityIsModelledBasis` pair this lane now computes, but neither renders the
+   caveat — left untouched to keep this lane's canvas-side scope to the one primary node-badge site
+   (`GoalNode.tsx`), matching 1.6b's own precedent of shipping the primary render site first. Both
+   are one-line additions once a follow-up lane decides they're worth the same honesty treatment
+   (the flag is already computed and available on the hook's return).

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
@@ -164,6 +164,107 @@ describe('useNodeDisplayMetadata — achievementProbability', () => {
 })
 
 // ---------------------------------------------------------------------------
+// achievementProbabilityIsModelledBasis — goal_fit_basis caveat flag
+// (ROADMAP 1.6b follow-up, claim-integrity). Mirrors OptionCards'
+// goalFitIsModelledBasis gate: true ONLY when the displayed number is the
+// joint-goal figure (hasConstraints && jointProb != null) AND the producer
+// marked it scored_from === 'modelled_outcome_distribution'.
+// ---------------------------------------------------------------------------
+describe('useNodeDisplayMetadata — achievementProbabilityIsModelledBasis', () => {
+  it('is true when the joint figure is shown and goal_fit_basis is modelled', () => {
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          robustness: { recommended_option_id: 'option-1' },
+          option_probabilities: {
+            'option-1': {
+              goal_probability: 0.5,
+              probability_of_joint_goal: 0.73,
+              confidence: 0.5,
+              constraint_analysis: { constraints: [{ id: 'c1' }] },
+              goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+            },
+          },
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
+    expect(result.current.achievementProbability).toBeCloseTo(0.73)
+    expect(result.current.achievementProbabilityIsModelledBasis).toBe(true)
+  })
+
+  it('is false (honest default) when goal_fit_basis is absent', () => {
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          robustness: { recommended_option_id: 'option-1' },
+          option_probabilities: {
+            'option-1': {
+              goal_probability: 0.5,
+              probability_of_joint_goal: 0.73,
+              confidence: 0.5,
+              constraint_analysis: { constraints: [{ id: 'c1' }] },
+            },
+          },
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
+    expect(result.current.achievementProbability).toBeCloseTo(0.73)
+    expect(result.current.achievementProbabilityIsModelledBasis).toBe(false)
+  })
+
+  it('is false when the displayed number is the unconstrained goal_probability, even if flagged', () => {
+    // No constraints -> achievementProbability falls to goal_probability, NOT
+    // the joint figure the caveat qualifies -- the flag must never leak onto
+    // the unconstrained number even if goal_fit_basis happens to be present.
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          robustness: { recommended_option_id: 'option-1' },
+          option_probabilities: {
+            'option-1': {
+              goal_probability: 0.5,
+              probability_of_joint_goal: 0.73,
+              confidence: 0.5,
+              goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+            },
+          },
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
+    expect(result.current.achievementProbability).toBeCloseTo(0.5)
+    expect(result.current.achievementProbabilityIsModelledBasis).toBe(false)
+  })
+
+  it('is false when scored_from is a different (non-modelled) value', () => {
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          robustness: { recommended_option_id: 'option-1' },
+          option_probabilities: {
+            'option-1': {
+              goal_probability: 0.5,
+              probability_of_joint_goal: 0.73,
+              confidence: 0.5,
+              constraint_analysis: { constraints: [{ id: 'c1' }] },
+              goal_fit_basis: { scored_from: 'directly_elicited' },
+            },
+          },
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
+    expect(result.current.achievementProbabilityIsModelledBasis).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Factor sensitivity rank — sanity path
 // ---------------------------------------------------------------------------
 describe('useNodeDisplayMetadata — factor sensitivityRank', () => {

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -23,6 +23,17 @@ interface NodeDisplayMetadata {
   inSensitivityAnalysis: boolean
   /** Outcome/Goal achievement probability (0-1) */
   achievementProbability: number | null
+  /**
+   * Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): true ONLY
+   * when `achievementProbability` above IS the joint-goal figure (mirrors
+   * the hook's own `hasConstraints && jointProb != null` branch that
+   * selects it, exactly as OptionCards' `goalFitIsModelledBasis` mirrors
+   * useResultsSectionData.ts's branches) AND the producer marked it as
+   * scored from a modelled outcome distribution
+   * (`goal_fit_basis.scored_from === 'modelled_outcome_distribution'`).
+   * Never inferred, never applied to the unconstrained goal_probability.
+   */
+  achievementProbabilityIsModelledBasis: boolean
   /** Recommendation stability (0-1) - fallback for Goal nodes when probability unavailable */
   stabilityPercentage: number | null
   /** Win rate for options (0-1) */
@@ -66,6 +77,7 @@ export function useNodeDisplayMetadata(
         confidence: null,
         inSensitivityAnalysis: false,
         achievementProbability: null,
+        achievementProbabilityIsModelledBasis: false,
         stabilityPercentage: null,
         winRate: null,
         predictedOutcome: null,
@@ -164,6 +176,7 @@ export function useNodeDisplayMetadata(
     // Task 8 & 10: Outcome/Goal achievement probability
     // Read from option_probabilities (the field the responseMapper actually populates)
     let achievementProbability: number | null = null
+    let achievementProbabilityIsModelledBasis = false
     let stabilityPercentage: number | null = null
 
     if (nodeType === 'outcome' || nodeType === 'goal') {
@@ -180,9 +193,23 @@ export function useNodeDisplayMetadata(
           const jointProb = typeof rec.probability_of_joint_goal === 'number'
             ? rec.probability_of_joint_goal : null
           const hasConstraints = rec.constraint_analysis?.constraints?.length > 0
-          achievementProbability = hasConstraints && jointProb != null
+          const isJoint = hasConstraints && jointProb != null
+          achievementProbability = isJoint
             ? jointProb
             : (rec.goal_probability ?? null)
+          // Display-honesty (ROADMAP 1.6b follow-up, claim-integrity):
+          // mirrors the `isJoint` branch immediately above exactly (rather
+          // than comparing resulting numbers, which could false-match on a
+          // coincidental equal value) so we know precisely WHEN the
+          // achievementProbability just set IS the joint-goal figure the
+          // caveat qualifies — never inferred, never applied to the
+          // unconstrained goal_probability branch.
+          const goalFitBasisScoredFrom =
+            typeof rec.goal_fit_basis?.scored_from === 'string'
+              ? (rec.goal_fit_basis.scored_from as string)
+              : null
+          achievementProbabilityIsModelledBasis =
+            isJoint && goalFitBasisScoredFrom === 'modelled_outcome_distribution'
         }
       }
 
@@ -220,6 +247,7 @@ export function useNodeDisplayMetadata(
       confidence,
       inSensitivityAnalysis,
       achievementProbability,
+      achievementProbabilityIsModelledBasis,
       stabilityPercentage,
       winRate,
       predictedOutcome,

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -23,6 +23,7 @@ import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { useCanvasStore } from '../store'
 import { typography } from '../../styles/typography'
 import { formatTargetValue } from '../../components/results/utils/formatTargetValue'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 import { DataBar, type DataBarColour } from '../ui/shared/DataBar'
 import { getStabilityClassification } from '../../lib/stability'
 import { isCurrencyUnit } from '../utils/labelUtils'
@@ -294,6 +295,23 @@ export const GoalNode = memo((props: NodeProps) => {
             )}
           </div>
         )}
+
+        {/* Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): the
+            achievement-probability number above is scored from a MODELLED
+            forward-propagated outcome distribution, not a directly-elicited
+            base — same gate + shared wording as OptionCards' caveat
+            (GOAL_FIT_BASIS_CAVEAT_COPY), rendered adjacent to the number it
+            qualifies, never separately, never invented. */}
+        {displayMetadata.isResultsMode &&
+          displayMetadata.achievementProbability !== null &&
+          displayMetadata.achievementProbabilityIsModelledBasis === true && (
+            <p
+              className={`${typography.edgeLabel} text-text-light mt-0.5 m-0`}
+              data-testid="goal-fit-basis-caveat-node"
+            >
+              {GOAL_FIT_BASIS_CAVEAT_COPY}
+            </p>
+          )}
 
         {/* Actionable guidance for low probability */}
         {isPostAnalysis && displayMetadata.achievementProbability !== null && displayMetadata.achievementProbability < 0.10 && (

--- a/src/canvas/nodes/__tests__/GoalNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/GoalNode.spec.tsx
@@ -125,6 +125,48 @@ describe('GoalNode', () => {
     expect(screen.getByText(/73.*% chance of reaching target/)).toBeDefined()
   })
 
+  // Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): modelled-basis
+  // caveat, same gate/wording as OptionCards' goal_fit_basis caveat.
+  it('renders the modelled-basis caveat adjacent to the number when flagged', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: 0.73,
+      achievementProbabilityIsModelledBasis: true,
+      stabilityPercentage: null,
+      winRate: null,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    })
+    renderGoal()
+    expect(screen.getByTestId('goal-fit-basis-caveat-node')).toHaveTextContent(
+      "Modelled from the target's projected outcome distribution, not a directly-set starting value.",
+    )
+  })
+
+  it('renders no caveat when the flag is absent (honest default)', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: 0.73,
+      achievementProbabilityIsModelledBasis: false,
+      stabilityPercentage: null,
+      winRate: null,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    })
+    renderGoal()
+    expect(screen.queryByTestId('goal-fit-basis-caveat-node')).toBeNull()
+  })
+
   // T10: Stability bar
   it('shows stability bar with percentage from report robustness', () => {
     vi.mocked(useCanvasStore).mockImplementation((selector) =>

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -28,6 +28,7 @@ import { formatOptionLabelForCard } from './utils/cleanFactorLabel'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
 import { formatRangeValue } from './utils/formatRangeValue'
 import { SUB_ONE_PERCENT_FLOOR } from './utils/displayFloors'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from './utils/goalFitBasisCaveatCopy'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
 import { useCanvasStore, selectResultsStatus } from '../../canvas/store'
 import { isGraphLensEnabled } from '../../flags'
@@ -453,7 +454,7 @@ function OptionCard({
               className={`${typography.panelMeta} text-text-light`}
               data-testid={`goal-fit-basis-caveat-${option.id}`}
             >
-              Modelled from the target's projected outcome distribution, not a directly-set starting value.
+              {GOAL_FIT_BASIS_CAVEAT_COPY}
             </p>
           )}
         </div>

--- a/src/components/results/analysis-hero/HeroOptionRow.tsx
+++ b/src/components/results/analysis-hero/HeroOptionRow.tsx
@@ -399,6 +399,18 @@ export function HeroOptionRow({
               {row.detail.goalFit}
             </p>
           )}
+          {/* Display-honesty (ROADMAP 1.6b follow-up, claim-integrity):
+              modelled-basis caveat, rendered adjacent to the goalFit line it
+              qualifies — never separately. Same shared wording OptionCards'
+              caveat uses (GOAL_FIT_BASIS_CAVEAT_COPY, via buildHeroModel). */}
+          {row.detail.goalFitCaveat && (
+            <p
+              className={`${typography.panelMeta} text-text-light`}
+              data-testid="hero-detail-goal-fit-caveat"
+            >
+              {row.detail.goalFitCaveat}
+            </p>
+          )}
           {row.detail.couldChangeIf && (
             <p
               className={`${typography.panelBody} text-text-body`}

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.goalFitBasisCaveat.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.goalFitBasisCaveat.spec.tsx
@@ -1,0 +1,91 @@
+/**
+ * buildHeroModel — goal_fit_basis modelled-basis caveat on the hero detail
+ * line (ROADMAP 1.6b follow-up, claim-integrity).
+ *
+ * Honesty rule (UI-BOUNDARY-DATA-INVENTORY.md §5): when
+ * probability_of_joint_goal is shown and goal_fit_basis.scored_from is
+ * 'modelled_outcome_distribution', the caveat MUST render adjacent to the
+ * number — a bare number is false precision. The caveat must NEVER appear
+ * for a row that doesn't carry the flag (no invention), matching
+ * OptionCards' gate on `goalFitIsModelledBasis` exactly.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { buildHeroModel } from '../buildHeroModel'
+import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../utils/goalFitBasisCaveatCopy'
+import type { HeroChartModel } from '../heroTypes'
+import { makeHeroData, makeOption, OPTION_A, OPTION_B } from '../__fixtures__/hero.fixtures'
+
+function chart(model: ReturnType<typeof buildHeroModel>): HeroChartModel {
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+describe('buildHeroModel — goal_fit_basis caveat', () => {
+  it('renders the modelled-basis caveat adjacent to the goalFit line when flagged', () => {
+    const a = makeOption({ ...OPTION_A, goalFitIsModelledBasis: true })
+    const b = makeOption({ ...OPTION_B, goalFitIsModelledBasis: false })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
+    expect(m.rows[0].detail.goalFit).toBeTruthy()
+    expect(m.rows[0].detail.goalFitCaveat).toBe(GOAL_FIT_BASIS_CAVEAT_COPY)
+    expect(m.rows[1].detail.goalFitCaveat).toBeUndefined()
+  })
+
+  it('renders no caveat for any row when the flag is absent (honest default)', () => {
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.rows[0].detail.goalFit).toBeTruthy()
+    expect(m.rows[0].detail.goalFitCaveat).toBeUndefined()
+    expect(m.rows[1].detail.goalFitCaveat).toBeUndefined()
+  })
+
+  it('withholds the caveat when no user target exists, even if flagged (UI-SEM-071 suppression)', () => {
+    // Without a user target, goalValue is nulled at source, so the caveat
+    // must not appear even though the row carries the modelled-basis flag —
+    // the caveat qualifies a number that isn't shown.
+    const a = makeOption({ ...OPTION_A, goalFitIsModelledBasis: true })
+    const b = makeOption({ ...OPTION_B, goalFitIsModelledBasis: true })
+    const m = chart(
+      buildHeroModel(makeHeroData({ recommendation: { goalThreshold: null }, options: [a, b] })),
+    )
+    expect(m.rows[0].goal.value).toBeNull()
+    expect(m.rows[0].detail.goalFitCaveat).toBeUndefined()
+    expect(m.rows[1].detail.goalFitCaveat).toBeUndefined()
+  })
+})
+
+describe('AnalysisHeroPanel — goal_fit_basis caveat render', () => {
+  it('renders the caveat inside the opened option detail when flagged', () => {
+    const a = makeOption({ ...OPTION_A, goalFitIsModelledBasis: true })
+    const b = makeOption({ ...OPTION_B, goalFitIsModelledBasis: false })
+    const model = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
+    render(
+      <AnalysisHeroPanel
+        model={model}
+        isStale={false}
+        onRerun={() => {}}
+        rerunDisabled={false}
+        focusPanelMounted={false}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Two developers/ }))
+    expect(screen.getByTestId('hero-detail-goal-fit-caveat')).toHaveTextContent(
+      GOAL_FIT_BASIS_CAVEAT_COPY,
+    )
+  })
+
+  it('renders no caveat testid anywhere when no row is flagged', () => {
+    const model = chart(buildHeroModel(makeHeroData()))
+    render(
+      <AnalysisHeroPanel
+        model={model}
+        isStale={false}
+        onRerun={() => {}}
+        rerunDisabled={false}
+        focusPanelMounted={false}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Two developers/ }))
+    expect(screen.queryByTestId('hero-detail-goal-fit-caveat')).toBeNull()
+  })
+})

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -49,6 +49,7 @@ import { formatThreshold } from '../RangeVisualization'
 import { stripEncodingNotation } from '../utils/cleanFactorLabel'
 import { sortOptionsForDisplay } from '../utils/optionDisplayOrder'
 import { SUB_ONE_PERCENT_FLOOR } from '../utils/displayFloors'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../utils/goalFitBasisCaveatCopy'
 import {
   getExpectedValue,
   getMedian,
@@ -279,6 +280,17 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
           ? HERO_COPY.detail.goalFitWithLimits(goalReadout(goalValue))
           : HERO_COPY.detail.goalFit(goalReadout(goalValue))
         : undefined
+    // Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): the caveat
+    // renders ONLY when the goalFit number just above it is actually shown
+    // (goalValue != null) AND the row's own goalFitIsModelledBasis flag is
+    // set — computed by useResultsSectionData.ts using the exact same
+    // hasConstraints/jointGoalProb branches OptionCards' caveat gates on
+    // (o.goalFitIsModelledBasis), never re-derived here. Shared wording
+    // (GOAL_FIT_BASIS_CAVEAT_COPY) — never invented, never a separate claim.
+    const goalFitCaveat =
+      goalValue != null && o.goalFitIsModelledBasis === true
+        ? GOAL_FIT_BASIS_CAVEAT_COPY
+        : undefined
     return {
       id: o.id,
       index: i + 1,
@@ -296,7 +308,7 @@ export function buildHeroModel(data: ResultsSectionDataReturn): HeroModel {
             ? formatThreshold(centre, outcomeUnit, outcomeUnitSymbol, isNormalised)
             : HERO_COPY.readout.missing,
       },
-      detail: { why, couldChangeIf, winChance, range, goalFit },
+      detail: { why, couldChangeIf, winChance, range, goalFit, goalFitCaveat },
     }
   })
 

--- a/src/components/results/analysis-hero/heroTypes.ts
+++ b/src/components/results/analysis-hero/heroTypes.ts
@@ -47,6 +47,16 @@ export interface HeroRowDetail {
   /** Goal-fit line from the row's own goalProbability (constraint-aware wording). */
   goalFit?: string
   /**
+   * Modelled-basis provenance caveat for `goalFit` (ROADMAP 1.6b follow-up,
+   * claim-integrity) — set ONLY when the goal-fit number just shown IS the
+   * joint-goal figure (`o.goalFitIsModelledBasis`, computed identically to
+   * OptionCards' gate in useResultsSectionData.ts) AND the producer marked
+   * it as scored from a modelled outcome distribution. Rendered adjacent to
+   * `goalFit`, never separately — same shared wording as OptionCards
+   * (GOAL_FIT_BASIS_CAVEAT_COPY), never invented.
+   */
+  goalFitCaveat?: string
+  /**
    * "Watch" line — requires option-attributed producer narrative (issue
    * 217). The live adapter NEVER sets it; fixture-only until the producer
    * field exists.

--- a/src/components/results/utils/goalFitBasisCaveatCopy.ts
+++ b/src/components/results/utils/goalFitBasisCaveatCopy.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared modelled-basis caveat copy (ROADMAP 1.6b + follow-up,
+ * claim-integrity). Single source of the exact wording so every render
+ * site that shows a `probability_of_joint_goal`-derived number gated on
+ * `goal_fit_basis.scored_from === 'modelled_outcome_distribution'` says
+ * the same thing — OptionCards.tsx (the original 1.6b site), the
+ * analysis-hero detail line, and the canvas goal-node badge all import
+ * this constant rather than re-specifying the sentence.
+ */
+export const GOAL_FIT_BASIS_CAVEAT_COPY =
+  "Modelled from the target's projected outcome distribution, not a directly-set starting value."


### PR DESCRIPTION
## Summary

PR #241 (1.6b) added the `goal_fit_basis` modelled-basis caveat to `OptionCards.tsx` (gated on `goal_fit_basis.scored_from === 'modelled_outcome_distribution'`, rendered adjacent to the joint-goal number) but deliberately left two secondary render sites untouched, documented in its own residuals section:

1. The analysis-hero detail line (`analysis-hero/buildHeroModel.ts`'s `goalFit` copy).
2. The canvas node badge fed by `useNodeDisplayMetadata.ts`.

Both show a `probability_of_joint_goal`-derived number with no caveat — the same claim-integrity gap 1.6b closed at the primary OptionCards site. This lane closes both.

- Extracted the caveat wording into a single shared constant (`GOAL_FIT_BASIS_CAVEAT_COPY`, `src/components/results/utils/goalFitBasisCaveatCopy.ts`) — OptionCards, the hero, and the goal node all import it rather than re-specifying the sentence.
- **Hero:** gates on the existing `OptionResult.goalFitIsModelledBasis` flag (computed once by `useResultsSectionData.ts`, unchanged here) plus the goal value actually being shown (honours the UI-SEM-071 null-target suppression).
- **Canvas node badge:** `useNodeDisplayMetadata.ts` computes a new `achievementProbabilityIsModelledBasis` flag by mirroring its own existing `hasConstraints && jointProb != null` branch (a different, independent read path from `useResultsSectionData.ts`) and reading `goal_fit_basis.scored_from` for the first time. `GoalNode.tsx` — treated as the primary node-badge for this lane (the direct canvas analogue of OptionCards' "Hits target" claim) — renders the caveat adjacent to its "X% chance of reaching target" line when both are true.
- Additive only: no changes to `useResultsSectionData.ts`'s shape, `mapV5AnalysisToReport.ts`, the schemas pin, or `canvas/store`.
- `OutcomeNode.tsx`'s secondary "Achievement: X%" diagnostic and `NodeInspector.tsx`'s panel readout consume the same new hook fields but are **not** wired up here — filed as a residual (see lane doc) to keep this lane's canvas-side scope to one primary site, matching 1.6b's own precedent.

Full trace, RED-first verification detail, and residuals: `docs/lanes/lane37-goalfit-caveat-completeness.md`.

**Zone note:** this branch touches files in both Zone A (canvas — `useNodeDisplayMetadata.ts`, `GoalNode.tsx`) and Zone B (analysis tab — `analysis-hero/buildHeroModel.ts`, `HeroOptionRow.tsx`). The incoming UI zone-owner lanes should rebase past this branch.

## Test plan

- [x] Typecheck (`pnpm run typecheck`, `tsc -p tsconfig.ci.json --noEmit`) — clean.
- [x] RED-first via `git stash` on each fix file in isolation (hero mapper + component-render tests, `useNodeDisplayMetadata` flag tests, `GoalNode` render tests) — all fail pre-fix, pass after.
- [x] Targeted vitest (touched files + siblings, 16 files): 465/465 green.
- [x] `--changed` sweep: 2 pre-existing failures (`ResultsBody.heroPlacement` test-isolation flake, `OutputsDock.analysis-run` Supabase-env-var import failure), verified byte-identical on unmodified `origin/staging` via `git stash` — disclosed, not chased.
- [x] Fast pre-push gate (`scripts/validate-prepush.sh`) — all checks passed (typecheck, lint, 471-test smoke suite, stale-.js check, dependency audit, schemas tarball SHA).
- [ ] Full ~6,284-test CI suite (`staging-full-tests.yml`) — pending, chronic "Staging Tests" red is pre-existing per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)