### PR TITLE
fix(analysis): goal-fit caveat on the last 2 residual sites — OutcomeNode + NodeInspector (1.6b tail, honesty seam complete)

### DIFF
--- a/src/canvas/nodes/OutcomeNode.tsx
+++ b/src/canvas/nodes/OutcomeNode.tsx
@@ -12,6 +12,7 @@ import { usePopoverHover } from '../hooks/usePopoverHover'
 import { useScienceIcons } from '../hooks/useScienceIcons'
 import { ConnRow, ConnRowsOverflow, Sep, NodeChip, NodePopover, ScienceIcon } from './shared'
 import { useGuidanceStore } from '../stores/guidanceStore'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 
 export const OutcomeNode = memo((props: NodeProps) => {
   const metadata = NODE_REGISTRY.outcome
@@ -160,6 +161,20 @@ export const OutcomeNode = memo((props: NodeProps) => {
       <p className={`${typography.edgeLabel} text-text-body m-0`}>
         Achievement: {Math.round(displayMetadata.achievementProbability * 100)}%
       </p>
+      {/* Display-honesty (ROADMAP 1.6b tail — goal-fit caveat residuals): the
+          achievement-probability number above is scored from a MODELLED
+          forward-propagated outcome distribution, not a directly-elicited
+          base — same gate + shared wording as GoalNode/OptionCards'
+          caveat (GOAL_FIT_BASIS_CAVEAT_COPY), rendered adjacent to the
+          number it qualifies, never separately, never invented. */}
+      {displayMetadata.achievementProbabilityIsModelledBasis === true && (
+        <p
+          className={`${typography.edgeLabel} text-text-light m-0`}
+          data-testid="goal-fit-basis-caveat-outcome-node"
+        >
+          {GOAL_FIT_BASIS_CAVEAT_COPY}
+        </p>
+      )}
     </>
   ) : null
 

--- a/src/canvas/nodes/__tests__/OutcomeNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OutcomeNode.spec.tsx
@@ -207,6 +207,51 @@ describe('OutcomeNode', () => {
     expect(screen.getByText('Achievement: 68%')).toBeDefined()
   })
 
+  // Display-honesty (ROADMAP 1.6b tail — goal-fit caveat residuals): same
+  // modelled-basis caveat as GoalNode/OptionCards, gated on the
+  // already-computed achievementProbabilityIsModelledBasis flag, rendered
+  // adjacent to the "Achievement:" diagnostic line it qualifies.
+  it('renders the modelled-basis caveat adjacent to the achievement number when flagged', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: 0.68,
+      achievementProbabilityIsModelledBasis: true,
+      stabilityPercentage: null,
+      winRate: null,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    })
+    renderOutcome()
+    expect(screen.getByTestId('goal-fit-basis-caveat-outcome-node')).toHaveTextContent(
+      "Modelled from the target's projected outcome distribution, not a directly-set starting value.",
+    )
+  })
+
+  it('renders no caveat on the achievement line when the flag is absent (honest default)', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: 0.68,
+      achievementProbabilityIsModelledBasis: false,
+      stabilityPercentage: null,
+      winRate: null,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    })
+    renderOutcome()
+    expect(screen.getByText('Achievement: 68%')).toBeDefined()
+    expect(screen.queryByTestId('goal-fit-basis-caveat-outcome-node')).toBeNull()
+  })
+
   // Wireframe v4 OutcomePostDet: Detailed view caps "Depends on:" ConnRows at 3
   // even when more inbound factors exist.
   it('caps Depends on ConnRows at 3 in Detailed post-analysis view', () => {

--- a/src/canvas/ui/NodeInspector.tsx
+++ b/src/canvas/ui/NodeInspector.tsx
@@ -23,6 +23,7 @@ import { detectBaseline } from '../utils/baselineDetection'
 import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { formatWinProbability } from '../utils/labelUtils'
 import { formatTargetValue } from '../../components/results/utils/formatTargetValue'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 
 interface ObservedState {
   value: number
@@ -439,12 +440,29 @@ export const NodeInspector = memo(({ nodeId, onClose }: NodeInspectorProps) => {
       {isGoalNode && displayMetadata.isResultsMode && (
         <div className="mt-3 pt-2 border-t border-panel-border">
           {displayMetadata.achievementProbability !== null ? (
-            <div className="flex items-center justify-between px-2 py-1 bg-panel rounded border border-panel-border">
-              <span className={`${typography.panelMeta} text-text-light`}>Goal probability</span>
-              <span className={`${typography.panelBody} text-text-body tabular-nums`}>
-                {Math.round(displayMetadata.achievementProbability * 100)}%
-              </span>
-            </div>
+            <>
+              <div className="flex items-center justify-between px-2 py-1 bg-panel rounded border border-panel-border">
+                <span className={`${typography.panelMeta} text-text-light`}>Goal probability</span>
+                <span className={`${typography.panelBody} text-text-body tabular-nums`}>
+                  {Math.round(displayMetadata.achievementProbability * 100)}%
+                </span>
+              </div>
+              {/* Display-honesty (ROADMAP 1.6b tail — goal-fit caveat
+                  residuals): the goal-probability readout above is scored
+                  from a MODELLED forward-propagated outcome distribution,
+                  not a directly-elicited base — same gate + shared wording
+                  as GoalNode/OptionCards/OutcomeNode's caveat
+                  (GOAL_FIT_BASIS_CAVEAT_COPY), rendered adjacent to the
+                  number it qualifies, never separately, never invented. */}
+              {displayMetadata.achievementProbabilityIsModelledBasis === true && (
+                <p
+                  className={`${typography.panelMeta} text-text-light mt-1 px-2`}
+                  data-testid="goal-fit-basis-caveat-inspector"
+                >
+                  {GOAL_FIT_BASIS_CAVEAT_COPY}
+                </p>
+              )}
+            </>
           ) : displayMetadata.stabilityPercentage !== null ? (
             <div className="flex items-center justify-between px-2 py-1 bg-panel rounded border border-panel-border">
               <span className={`${typography.panelMeta} text-text-light`}>Result stability</span>

--- a/src/canvas/ui/__tests__/NodeInspector.goalFitBasisCaveat.spec.tsx
+++ b/src/canvas/ui/__tests__/NodeInspector.goalFitBasisCaveat.spec.tsx
@@ -1,0 +1,97 @@
+/**
+ * NodeInspector — goal-fit modelled-basis caveat (ROADMAP 1.6b tail — goal-fit
+ * caveat residuals). Same gate/wording as GoalNode/OptionCards/OutcomeNode:
+ * rendered adjacent to the inspector-panel achievement-probability readout,
+ * gated on the already-computed achievementProbabilityIsModelledBasis flag.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { NodeInspector } from '../NodeInspector'
+import { useCanvasStore } from '../../store'
+
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank: null,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    achievementProbabilityIsModelledBasis: false,
+    stabilityPercentage: null,
+    winRate: null,
+    isResultsMode: false,
+    predictedOutcome: null,
+    valueOfInformation: null,
+    voiRank: null,
+  })),
+}))
+
+import { useNodeDisplayMetadata } from '../../hooks/useNodeDisplayMetadata'
+
+describe('NodeInspector — goal-fit basis caveat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Revenue Target' } },
+      ],
+      edges: [],
+      goalThreshold: 0.5,
+      goalConstraints: [],
+      confirmedNodeIds: new Set(),
+      outcomeNodeId: undefined,
+      touchedNodeIds: new Set(),
+      results: { status: 'complete', report: null },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the modelled-basis caveat adjacent to the goal probability readout when flagged', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: 0.73,
+      achievementProbabilityIsModelledBasis: true,
+      stabilityPercentage: null,
+      winRate: null,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    } as any)
+
+    render(<NodeInspector nodeId="goal-1" onClose={() => {}} />)
+
+    expect(screen.getByText('Goal probability')).toBeDefined()
+    expect(screen.getByTestId('goal-fit-basis-caveat-inspector')).toHaveTextContent(
+      "Modelled from the target's projected outcome distribution, not a directly-set starting value.",
+    )
+  })
+
+  it('renders no caveat when the flag is absent (honest default)', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: 0.73,
+      achievementProbabilityIsModelledBasis: false,
+      stabilityPercentage: null,
+      winRate: null,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    } as any)
+
+    render(<NodeInspector nodeId="goal-1" onClose={() => {}} />)
+
+    expect(screen.getByText('Goal probability')).toBeDefined()
+    expect(screen.queryByTestId('goal-fit-basis-caveat-inspector')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- PR #242 added the `goal_fit_basis` modelled-basis caveat to OptionCards, the analysis hero, and the GoalNode badge, and documented two remaining hook-fed render sites that show the same joint-goal-derived `achievementProbability` without the caveat.
- This closes both: `OutcomeNode.tsx` ("Achievement: X%" diagnostic line, Detailed view) and `NodeInspector.tsx` (inspector-panel goal-probability readout).
- Both reuse the single-sourced `GOAL_FIT_BASIS_CAVEAT_COPY`, gated on the already-computed `achievementProbabilityIsModelledBasis` flag from `useNodeDisplayMetadata` — no new wording, no new computation.
- `GoalPanel.tsx` is correctly excluded (per the #242 reviewer): it sources `report.probability_of_goal`, a different top-level field, and already carries its own "based on the current model" caveat.
- Closes ROADMAP 1.6b tail — the goal-fit honesty seam is now complete across the UI.

## Test plan
- [x] RED-first: added failing tests (`OutcomeNode.spec.tsx`, new `NodeInspector.goalFitBasisCaveat.spec.tsx`) asserting the caveat renders when the flag is `true`, and is absent when `false`/missing.
- [x] Implemented the two ~1-line additions; targeted vitest green (`OutcomeNode.spec.tsx`, `NodeInspector.goalFitBasisCaveat.spec.tsx`, `NodeInspector.inspector-fixes.spec.tsx`, `NodeInspector.icon.spec.tsx`, `GoalNode.spec.tsx`, `OptionCards.goalFitBasisCaveat.spec.tsx` — 6 files, 84 tests passed).
- [x] `pnpm run typecheck` clean.
- [x] `scripts/validate-prepush.sh` (fast gate) passed on push — all checks green. DS v5 hex ratchet delta is report-only/pre-existing (comment-text false positives like `#202`/`#204` PLoT issue references), does not block.
- [ ] Chronic "Staging Tests" CI check is pre-existing red, unrelated to this change — not chased per lane scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)