### PR TITLE
feat(conversation): Show-reasoning progressive disclosure (ROADMAP 1.42, UI half)

### DIFF
--- a/docs/lanes/lane-reasoning-disclosure.md
+++ b/docs/lanes/lane-reasoning-disclosure.md
@@ -1,0 +1,110 @@
+# Lane — Show-reasoning progressive disclosure (ROADMAP 1.42, UI half)
+
+**Branch:** `claude-ui/reasoning-disclosure` (worktree, base `origin/staging` @ `d991ad5a`)
+**Zone:** Conversation surface only — `src/flags.ts`, `src/canvas/conversation/types.ts`,
+`src/canvas/conversation/useConversation.ts`, `src/canvas/conversation/MessageBubble.tsx`,
+`src/canvas/conversation/Conversation.module.css`.
+
+## Context
+
+Paul ruled **VERBATIM-with-label**: when CEE (built in parallel, same ROADMAP item) sends a
+top-level `_reasoning` string on an assistant turn response, the UI shows it verbatim behind a
+collapsed-by-default disclosure toggle headed exactly "Model reasoning (verbatim)" — no summary,
+no markdown rendering, no editorial framing.
+
+## Contract (verified, no parser change needed)
+
+`_reasoning` is an unknown key at the UI's pinned `@talchain/schemas` (0.13.1). It is not in
+`KNOWN_OLUMI_TOP_LEVEL_KEYS` (`src/v5/responseParser.ts:180-189`), so
+`splitAdditiveExtensions`/`splitBlocksTolerance` demote it into the non-enumerable
+`ADDITIVE_EXTENSIONS_KEY` (`'__additive__'`) sidecar (`responseParser.ts:196-218,697`) rather than
+dropping it. This is the same mechanism that already carries Phase 3 blocks and other additive
+top-level keys — verified by reading, not assumed. **No change to `responseParser.ts` in this
+lane.**
+
+## Implementation (additive only)
+
+1. **`src/flags.ts`** — new flag `reasoningDisclosure` (`isReasoningDisclosureEnabled`), pattern-matched
+   on `isDeterministicCeeEnabled`. `VITE_FEATURE_REASONING_DISCLOSURE` env / `feature.reasoningDisclosure`
+   localStorage. **Default OFF** (no `defaultValue: true`) — sporadic CEE field with no contract
+   guarantee yet.
+2. **`src/canvas/conversation/types.ts`** — `ConversationMessage.reasoning?: string`.
+3. **`src/canvas/conversation/useConversation.ts`** (V5 `addMessage` success site, `text_only` +
+   `blocks` targets):
+   - `extractReasoningSidecar()` reads `(target.response as OlumiResponseWithExtensions)[ADDITIVE_EXTENSIONS_KEY]?.['_reasoning']`
+     — imports `ADDITIVE_EXTENSIONS_KEY` / `OlumiResponseWithExtensions` from `../../v5/responseParser`,
+     never touches the strict `OlumiResponse` surface.
+   - Accepts only a non-empty (post-trim) string; whitespace-only/non-string is rejected.
+   - Length-capped at 20,000 chars with a disclosed `'\n\n[reasoning truncated]'` suffix — the
+     accepted string itself is **never trimmed** (verbatim fidelity; only used to test for
+     emptiness).
+   - Attached as `message.reasoning`, **never merged into `message.content`** — `content` only ever
+     carries `assistant_text` (that field feeds `extractFromRawJson` / clamp-truncation in
+     `MessageBubble.tsx`, which reasoning must bypass entirely).
+   - Gated on `isReasoningDisclosureEnabled()`; when off, the sidecar is never read.
+4. **`src/canvas/conversation/MessageBubble.tsx`** — on assistant messages
+   (`!isUser && message.reasoning && isReasoningDisclosureEnabled()`, defense-in-depth flag check
+   mirroring the existing `isDeterministicCeeEnabled()` gate on `InsightsStrip`), inserted between
+   the prose Show-more toggle and `InsightsStrip`:
+   - A collapsed-by-default toggle (`aria-expanded`, `data-testid="message-show-reasoning"`) mirroring
+     the existing Show-more toggle's expanded-state pattern.
+   - Expands to a muted panel (`bg-panel-hover` + `border-default`, distinct from the answer bubble —
+     no `bg-{colour}-light`, no answer-bubble styling) headed **exactly** "Model reasoning (verbatim)".
+   - Body is a plain React text child (`<p>{message.reasoning}</p>`, `white-space: pre-wrap`) — **no
+     `dangerouslySetInnerHTML`, no markdown pipeline.** React's default text-node escaping makes this
+     XSS-safe by construction (a literal `<script>` string renders as inert text, pinned by test).
+   - Renders nothing when `message.reasoning` is absent (sporadic field) or the flag is off.
+5. **Persistence (`useThreadPersistence.ts`)** — **no code change.** The hook's assistant-message
+   mapping explicitly enumerates the fields it persists (`content`, `blocks`/`structuredBlocks`,
+   `suggested_actions`/`actionChips`, `clientTurnId`, snapshot ids) with no spread of the message
+   object — `reasoning` was never on that list and is naturally excluded. Confirmed by reading the
+   hook, not by adding a guard. Reasoning is therefore ephemeral / session-only by construction: a
+   page reload or thread-hydration replay never resurrects it.
+
+## Tests (RED-first verified below)
+
+- `src/canvas/conversation/__tests__/MessageBubble.reasoning.spec.tsx` (7 tests): collapsed by
+  default; expands with the exact "Model reasoning (verbatim)" header; collapses again on second
+  click; byte-verbatim rendering including a literal `<script>alert(1)</script>` string rendered as
+  escaped/inert text (`panel.querySelector('script')` is null, `innerHTML` contains `&lt;script&gt;`,
+  `textContent` contains the verbatim payload) — pins the XSS-safety property; renders nothing when
+  reasoning is absent (flag on); renders nothing when the flag is off (reasoning present); never
+  renders on user messages.
+- `src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts` (8 tests): sidecar → `message.reasoning`
+  when the flag is on; reasoning never lands in `message.content`; absent sidecar / absent `_reasoning`
+  key / non-string / whitespace-only value all leave `message.reasoning` undefined; oversized value
+  is capped with the disclosed truncation suffix; flag off means `message.reasoning` stays undefined
+  even when CEE sent a valid `_reasoning`.
+
+RED-first: both new spec files were written against the pre-implementation tree state
+(`message.reasoning` typed but never populated, no `MessageBubble` toggle) and failed as expected
+(`message-show-reasoning` / `message.reasoning` not found) before the corresponding implementation
+commit; green after.
+
+## Verification
+
+- **Typecheck:** `pnpm run typecheck` (`tsc -p tsconfig.ci.json --noEmit`) — clean.
+- **Targeted vitest** (both new spec files + 5 sibling `MessageBubble.*.spec.tsx` files, run
+  together): 57 passed / 0 failed.
+- **Lint:** `pnpm run lint` on the touched files — 0 errors (a handful of pre-existing warnings in
+  `useConversation.ts`, none on lines this lane touches).
+- **`--changed` sweep:** 1 pre-existing failure, unrelated to this lane —
+  `useConversation.hook.spec.ts > timeout progression > aborts and shows error at 60s` fails with
+  `No "getV5Endpoint" export is defined on the "../../../v5/v5Adapter" mock` (that spec's
+  hand-rolled `v5Adapter` mock only stubs `callV5Turn`, not `getV5Endpoint`, which the real
+  `sendTurn` now calls unconditionally at `useConversation.ts:2967`). Verified byte-identical on
+  unmodified `origin/staging @ d991ad5a` via `git stash` (41/67 tests fail when the file is run in
+  isolation, on **both** the base commit and this branch) — a pre-existing gap in that spec's mock
+  surface, not a regression from this lane. Not chased (out of scope; global "authoritative gate,
+  don't substitute ad-hoc fixes" doctrine cuts the other way too — fixing someone else's spec mock
+  is a separate lane).
+- Full local suite NOT run (OOMs by policy per repo `CLAUDE.md`).
+
+## Notes for the reviewer
+
+- Flag defaults OFF everywhere (`VITE_FEATURE_REASONING_DISCLOSURE` unset). No user-visible change
+  on staging until CEE ships `_reasoning` **and** the flag is flipped on.
+- No `UI-SEM-*` tag needed — this lane adds no semantic transform; the reasoning string is
+  displayed byte-for-byte, never interpreted.
+- Depends on the CEE-side half of ROADMAP 1.42 (built in parallel) actually emitting `_reasoning`;
+  until then this lane is inert dead code behind the flag.

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -616,6 +616,33 @@
   border-radius: 2px;
 }
 
+/* ROADMAP 1.42 — Show-reasoning progressive disclosure (verbatim, labelled).
+   Muted, visually distinct from the answer bubble: NOT a coloured pill/card,
+   just a quieter panel bg with a border, clearly a different register from
+   the assistant's prose above it. */
+.reasoningPanel {
+  margin-top: 8px;
+  padding: 10px 12px;
+  background: var(--bg-panel-hover, #FEF9F3);
+  border: 1px solid var(--border-default, #EEE6D8);
+  border-radius: 6px;
+}
+.reasoningPanelHeading {
+  font-size: 11px; /* typography.panelMeta */
+  font-weight: 600;
+  color: var(--text-light, #908D8D);
+  margin: 0 0 6px 0;
+  text-transform: none;
+}
+.reasoningPanelBody {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-body, #4A4642);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
 /* ---------------------------------------------------------------------------
  * § 4c — FramingBlock
  * ---------------------------------------------------------------------------*/

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -24,7 +24,7 @@ import { ChevronDown, ChevronUp, ListPlus, AlignLeft } from 'lucide-react'
 import { BaseRateChipRow } from './BaseRateChipRow'
 import { FeedbackRow } from './FeedbackRow'
 import { StalenessPill, type StalenessFreshness } from './StalenessPill'
-import { isOrchestratorRenderingV2Enabled, isDeterministicCeeEnabled, isAiPanelV2Enabled } from '../../flags'
+import { isOrchestratorRenderingV2Enabled, isDeterministicCeeEnabled, isAiPanelV2Enabled, isReasoningDisclosureEnabled } from '../../flags'
 import { useCanvasStore } from '../store'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { FALLBACK_TEXT } from './validateResponse'
@@ -192,6 +192,9 @@ export const MessageBubble = memo(function MessageBubble({
   const truncatedContent = canTruncate ? findNaturalTruncation(displayContent) : null
   const [expanded, setExpanded] = useState(false)
 
+  // ROADMAP 1.42: Show-reasoning progressive disclosure — collapsed by default.
+  const [reasoningExpanded, setReasoningExpanded] = useState(false)
+
   // Freshness pill: derive from the first graph_patch block whose
   // analysis_ready.freshness is 'stale' or 'unknown'. Fresh/none/absent → no pill.
   // User messages and the streaming-thinking placeholder bypass this branch.
@@ -273,6 +276,32 @@ export const MessageBubble = memo(function MessageBubble({
         >
           {expanded ? <><ChevronUp size={12} /> Show less</> : <><ChevronDown size={12} /> Show more</>}
         </button>
+      )}
+      {/* ROADMAP 1.42: Show-reasoning progressive disclosure — Paul ruled
+        * VERBATIM-with-label. Collapsed by default; renders nothing when
+        * reasoning is absent (sporadic CEE field) or the flag is off
+        * (defense in depth — useConversation also gates attachment). Plain
+        * text via a text node (no dangerouslySetInnerHTML, no markdown
+        * pipeline) so the panel can never execute injected markup. */}
+      {!isUser && message.reasoning && isReasoningDisclosureEnabled() && (
+        <>
+          <button
+            type="button"
+            className={styles.inlineDisclosureToggle}
+            onClick={() => setReasoningExpanded(v => !v)}
+            data-testid="message-show-reasoning"
+            aria-expanded={reasoningExpanded}
+            aria-label={reasoningExpanded ? 'Hide model reasoning' : 'Show model reasoning'}
+          >
+            {reasoningExpanded ? <><ChevronUp size={12} /> Hide reasoning</> : <><ChevronDown size={12} /> Show reasoning</>}
+          </button>
+          {reasoningExpanded && (
+            <div className={styles.reasoningPanel} data-testid="message-reasoning-panel">
+              <p className={styles.reasoningPanelHeading}>Model reasoning (verbatim)</p>
+              <p className={styles.reasoningPanelBody}>{message.reasoning}</p>
+            </div>
+          )}
+        </>
       )}
       {message.insights && message.insights.length > 0 && isDeterministicCeeEnabled() && (
         <InsightsStrip insights={message.insights} onSendMessage={onArtefactMessage} />

--- a/src/canvas/conversation/__tests__/MessageBubble.reasoning.spec.tsx
+++ b/src/canvas/conversation/__tests__/MessageBubble.reasoning.spec.tsx
@@ -1,0 +1,127 @@
+/**
+ * ROADMAP 1.42 — Show-reasoning progressive disclosure (Paul ruled
+ * VERBATIM-with-label).
+ *
+ * Verifies:
+ *  - collapsed by default when `message.reasoning` is present and the flag
+ *    is on
+ *  - expands on click, header reads EXACTLY "Model reasoning (verbatim)"
+ *  - byte-verbatim rendering, including a literal `<script>` string —
+ *    rendered as inert TEXT, never executed (pins the XSS-safety property:
+ *    no dangerouslySetInnerHTML / markdown pipeline for this panel)
+ *  - absent `reasoning` renders nothing, even with the flag on
+ *  - flag off renders nothing, even with `reasoning` present
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+let mockReasoningDisclosureEnabled = true
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isReasoningDisclosureEnabled: () => mockReasoningDisclosureEnabled,
+  }
+})
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MessageBubble } from '../MessageBubble'
+import type { ConversationMessage } from '../types'
+
+function makeMsg(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: 'The answer is 42.',
+    timestamp: new Date(),
+    ...overrides,
+  }
+}
+
+const noop = async () => {}
+
+describe('MessageBubble — reasoning disclosure (ROADMAP 1.42)', () => {
+  it('collapsed by default: toggle renders, panel does not', () => {
+    mockReasoningDisclosureEnabled = true
+    render(
+      <MessageBubble message={makeMsg({ reasoning: 'Because X implies Y.' })} onChipClick={noop} />,
+    )
+    expect(screen.getByTestId('message-show-reasoning')).toBeTruthy()
+    expect(screen.getByTestId('message-show-reasoning').getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByTestId('message-reasoning-panel')).toBeNull()
+  })
+
+  it('expands on click, with the exact "Model reasoning (verbatim)" header', () => {
+    mockReasoningDisclosureEnabled = true
+    render(
+      <MessageBubble message={makeMsg({ reasoning: 'Because X implies Y.' })} onChipClick={noop} />,
+    )
+    const toggle = screen.getByTestId('message-show-reasoning')
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    const panel = screen.getByTestId('message-reasoning-panel')
+    expect(panel).toBeTruthy()
+    expect(panel.textContent).toContain('Model reasoning (verbatim)')
+    // Exact header text, not a substring match on a longer heading.
+    const heading = Array.from(panel.querySelectorAll('p')).find(
+      (p) => p.textContent === 'Model reasoning (verbatim)',
+    )
+    expect(heading).toBeTruthy()
+  })
+
+  it('collapses again on a second click', () => {
+    mockReasoningDisclosureEnabled = true
+    render(
+      <MessageBubble message={makeMsg({ reasoning: 'Because X implies Y.' })} onChipClick={noop} />,
+    )
+    const toggle = screen.getByTestId('message-show-reasoning')
+    fireEvent.click(toggle)
+    expect(screen.getByTestId('message-reasoning-panel')).toBeTruthy()
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByTestId('message-reasoning-panel')).toBeNull()
+  })
+
+  it('renders reasoning byte-verbatim, including a literal <script> tag shown as inert text (not executed)', () => {
+    mockReasoningDisclosureEnabled = true
+    const payload = 'Step 1: assume X.\n\nStep 2: <script>alert(1)</script> therefore Y.'
+    render(<MessageBubble message={makeMsg({ reasoning: payload })} onChipClick={noop} />)
+    fireEvent.click(screen.getByTestId('message-show-reasoning'))
+    const panel = screen.getByTestId('message-reasoning-panel')
+    // The panel's innerHTML must show the tag as ESCAPED text (&lt;script&gt;),
+    // never as a literal, parseable <script> element — proof no
+    // dangerouslySetInnerHTML / markdown pipeline touched this string.
+    expect(panel.querySelector('script')).toBeNull()
+    expect(panel.innerHTML).toContain('&lt;script&gt;')
+    // And the textContent is exactly the source string (verbatim), whitespace
+    // and all — no markdown transform, no trimming, no collapsing of blank lines.
+    expect(panel.textContent).toContain(payload)
+  })
+
+  it('renders nothing when reasoning is absent, even with the flag on', () => {
+    mockReasoningDisclosureEnabled = true
+    render(<MessageBubble message={makeMsg()} onChipClick={noop} />)
+    expect(screen.queryByTestId('message-show-reasoning')).toBeNull()
+    expect(screen.queryByTestId('message-reasoning-panel')).toBeNull()
+  })
+
+  it('renders nothing when the flag is off, even with reasoning present', () => {
+    mockReasoningDisclosureEnabled = false
+    render(
+      <MessageBubble message={makeMsg({ reasoning: 'Because X implies Y.' })} onChipClick={noop} />,
+    )
+    expect(screen.queryByTestId('message-show-reasoning')).toBeNull()
+    expect(screen.queryByTestId('message-reasoning-panel')).toBeNull()
+  })
+
+  it('never renders the reasoning toggle on user messages', () => {
+    mockReasoningDisclosureEnabled = true
+    render(
+      <MessageBubble
+        message={makeMsg({ role: 'user', reasoning: 'Should never appear' })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('message-show-reasoning')).toBeNull()
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
@@ -56,6 +56,19 @@ vi.mock('../../../v5/v5Adapter', () => ({
   getV5Endpoint: () => 'https://cee.test/orchestrate/v2/turn',
 }))
 
+// Force the V5-eligibility gate on, independent of VITE_ENABLE_V5_ORCHESTRATOR.
+// sendMessage's V5 routing (useConversation.ts) reads
+// import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR directly and passes it through
+// isV5Eligible — Vite's loadEnv pulls that var in from the developer's
+// untracked .env.local, so this suite silently depended on a machine-local
+// file (passes when .env.local sets VITE_ENABLE_V5_ORCHESTRATOR=true, fails
+// on a clean checkout where the flag is undefined and sendMessage takes the
+// V4 path instead, so mockCallV5Turn is never invoked). Mocking the gate
+// itself makes the suite self-contained.
+vi.mock('../../../v5/eligibility', () => ({
+  isV5Eligible: () => ({ eligible: true as const }),
+}))
+
 const mockGetUserId = vi.fn<[], Promise<string | null>>()
 vi.mock('../../../lib/supabase', () => ({
   getUserId: (...args: unknown[]) => mockGetUserId(...(args as [])),

--- a/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
@@ -1,0 +1,272 @@
+/**
+ * ROADMAP 1.42 — Show-reasoning progressive disclosure (Paul ruled
+ * VERBATIM-with-label).
+ *
+ * Verifies the addMessage success-site sidecar extraction in
+ * useConversation.ts:
+ *  - CEE's `_reasoning` additive-extension sidecar (attached by
+ *    responseParser's splitAdditiveExtensions under ADDITIVE_EXTENSIONS_KEY)
+ *    is read into `message.reasoning` when the flag is on
+ *  - reasoning NEVER lands in `message.content` (that field only ever
+ *    carries `assistant_text` — content feeds extractFromRawJson/truncation
+ *    in MessageBubble, which reasoning must bypass)
+ *  - absent sidecar / absent `_reasoning` → `message.reasoning` stays undefined
+ *  - flag off → sidecar is never read, `message.reasoning` stays undefined
+ *    even when CEE sent `_reasoning`
+ *  - non-string / empty-string `_reasoning` is rejected defensively
+ *  - an oversized `_reasoning` is capped with a disclosed truncation suffix
+ *
+ * Mirrors the mocking harness in useConversation.hook.spec.ts (turnService,
+ * v5Adapter, supabase, scenarioService) trimmed to only what the V5
+ * happy-path (`sendMessage` → `callV5Turn` → `routeV5Response` → `addMessage`)
+ * needs to resolve deterministically.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import { useResultsStore } from '../../stores/resultsStore'
+import { ADDITIVE_EXTENSIONS_KEY } from '../../../v5/responseParser'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockCallTurn = vi.fn()
+const mockStreamTurn = vi.fn()
+
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockStreamTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+const mockCallV5Turn = vi.fn()
+vi.mock('../../../v5/v5Adapter', () => ({
+  callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+  getV5Endpoint: () => 'https://cee.test/orchestrate/v2/turn',
+}))
+
+const mockGetUserId = vi.fn<[], Promise<string | null>>()
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: (...args: unknown[]) => mockGetUserId(...(args as [])),
+}))
+
+const mockLoadScenario = vi.fn<[string], Promise<unknown>>()
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: (...args: unknown[]) => mockLoadScenario(...(args as [string])),
+}))
+
+// Flag control: reasoningDisclosure toggled per-test; streaming/orchestratorV2
+// pinned like the sibling hook spec so sendMessage resolves deterministically.
+let mockReasoningDisclosureEnabled = true
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isOrchestratorStreamingEnabled: () => true,
+    isOrchestratorV2Enabled: () => true,
+    isReasoningDisclosureEnabled: () => mockReasoningDisclosureEnabled,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal V5 "response" call-result. When `reasoning` is provided, it is
+ * attached under ADDITIVE_EXTENSIONS_KEY exactly as the real parser's
+ * splitAdditiveExtensions does (responseParser.ts:657-697) — proving the
+ * useConversation extraction reads the sidecar, not the strict surface.
+ */
+function makeV5Result(opts: { text?: string; reasoning?: unknown; noSidecar?: boolean } = {}) {
+  const { text = 'The answer is 42.', reasoning, noSidecar = false } = opts
+  const response: Record<string, unknown> = {
+    response_version: 2,
+    assistant_text: text,
+    blocks: [] as unknown[],
+    suggested_actions: [] as unknown[],
+    insights: [] as unknown[],
+    stage_indicator: 'frame',
+  }
+  if (!noSidecar && reasoning !== undefined) {
+    response[ADDITIVE_EXTENSIONS_KEY] = { _reasoning: reasoning }
+  }
+  return { kind: 'response' as const, response }
+}
+
+beforeEach(() => {
+  mockReasoningDisclosureEnabled = true
+  mockCallTurn.mockReset()
+  mockStreamTurn.mockReset()
+  mockCallV5Turn.mockReset()
+  mockGetUserId.mockReset()
+  mockGetUserId.mockResolvedValue(null)
+  mockLoadScenario.mockReset()
+  mockLoadScenario.mockResolvedValue(null)
+
+  useResultsStore.setState({
+    results: {
+      status: 'idle',
+      progress: 0,
+      analysisSummary: undefined,
+      lastSnapshotId: undefined,
+    },
+  } as any)
+
+  useCanvasStore.setState({
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' } as any,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function lastAssistantMessage(messages: ReturnType<typeof useConversation>['messages']) {
+  return [...messages].reverse().find((m) => m.role === 'assistant')
+}
+
+describe('useConversation — reasoning sidecar extraction (ROADMAP 1.42)', () => {
+  it('reads _reasoning from the additive sidecar into message.reasoning when the flag is on', async () => {
+    mockCallV5Turn.mockResolvedValue(
+      makeV5Result({ text: 'Here is my answer.', reasoning: 'Because X implies Y, and Y implies Z.' }),
+    )
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg).toBeDefined()
+    expect(msg!.reasoning).toBe('Because X implies Y, and Y implies Z.')
+  })
+
+  it('never places reasoning content into message.content', async () => {
+    const reasoning = 'SECRET_REASONING_TOKEN should never leak into content'
+    mockCallV5Turn.mockResolvedValue(
+      makeV5Result({ text: 'Here is my answer.', reasoning }),
+    )
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg!.content).toBe('Here is my answer.')
+    expect(msg!.content).not.toContain('SECRET_REASONING_TOKEN')
+  })
+
+  it('leaves message.reasoning undefined when CEE sends no sidecar at all', async () => {
+    mockCallV5Turn.mockResolvedValue(makeV5Result({ text: 'Plain answer, no reasoning.' }))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg!.reasoning).toBeUndefined()
+  })
+
+  it('leaves message.reasoning undefined when the sidecar carries other additive keys but not _reasoning', async () => {
+    mockCallV5Turn.mockResolvedValue({
+      kind: 'response' as const,
+      response: {
+        response_version: 2,
+        assistant_text: 'Answer.',
+        blocks: [],
+        suggested_actions: [],
+        insights: [],
+        stage_indicator: 'frame',
+        [ADDITIVE_EXTENSIONS_KEY]: { some_other_extension: 'value' },
+      },
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg!.reasoning).toBeUndefined()
+  })
+
+  it('rejects a non-string _reasoning value defensively', async () => {
+    mockCallV5Turn.mockResolvedValue(
+      makeV5Result({ text: 'Answer.', reasoning: { not: 'a string' } }),
+    )
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg!.reasoning).toBeUndefined()
+  })
+
+  it('rejects an empty/whitespace-only _reasoning value', async () => {
+    mockCallV5Turn.mockResolvedValue(
+      makeV5Result({ text: 'Answer.', reasoning: '   \n  ' }),
+    )
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg!.reasoning).toBeUndefined()
+  })
+
+  it('caps an oversized _reasoning at 20000 chars with a disclosed truncation suffix', async () => {
+    const huge = 'A'.repeat(25_000)
+    mockCallV5Turn.mockResolvedValue(makeV5Result({ text: 'Answer.', reasoning: huge }))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg!.reasoning).toBeDefined()
+    expect(msg!.reasoning!.length).toBeLessThan(huge.length)
+    expect(msg!.reasoning).toContain('[reasoning truncated]')
+    expect(msg!.reasoning!.startsWith('A'.repeat(100))).toBe(true)
+  })
+
+  it('does not attach reasoning when the flag is off, even though CEE sent it', async () => {
+    mockReasoningDisclosureEnabled = false
+    mockCallV5Turn.mockResolvedValue(
+      makeV5Result({ text: 'Answer.', reasoning: 'Because X implies Y.' }),
+    )
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('question')
+    })
+
+    const msg = lastAssistantMessage(result.current.messages)
+    expect(msg!.reasoning).toBeUndefined()
+    // Content is unaffected by the flag either way.
+    expect(msg!.content).toBe('Answer.')
+  })
+})

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -56,6 +56,15 @@ export interface ConversationMessage {
    * persist — late chunks arriving after abort MUST NOT clear it.
    */
   stoppedByUser?: boolean
+  /**
+   * ROADMAP 1.42 (Show-reasoning progressive disclosure — verbatim, labelled):
+   * CEE's `_reasoning` additive-extension sidecar field, verbatim plain text.
+   * Only populated when VITE_FEATURE_REASONING_DISCLOSURE is on and the field
+   * is a non-empty string (length-capped, see useConversation). Never fed into
+   * `content` — rendered separately, unprocessed, behind a collapsed toggle.
+   * Ephemeral: excluded from thread persistence (session-only).
+   */
+  reasoning?: string
 }
 
 /** A set of frequency-framed chips for a single factor's base rate elicitation */

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -42,7 +42,8 @@ import {
 // recordDroppedContent never throws and never changes composition output.
 import { recordDroppedContent } from '../../lib/droppedContentCounter'
 import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
-import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled } from '../../flags'
+import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled, isReasoningDisclosureEnabled } from '../../flags'
+import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
 import { maybeBuildModelReceiptBlock } from '../adapters/modelCardAdapter'
 import { assembleAnalysisInputsSummary } from '../analysis/assembleAnalysisInputsSummary'
 import { useResultsStore } from '../stores/resultsStore'
@@ -654,6 +655,34 @@ function asOptionalString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * ROADMAP 1.42 (Show-reasoning progressive disclosure — verbatim, labelled):
+ * `_reasoning` is an unknown top-level key at the pinned schema (0.13.1), so
+ * the parser's `splitAdditiveExtensions`/`splitBlocksTolerance` demote it into
+ * the non-enumerable `ADDITIVE_EXTENSIONS_KEY` sidecar (responseParser.ts)
+ * rather than validating it on the strict OlumiResponse surface. Read it from
+ * there. Defensive: only a non-empty string is accepted, and it is capped at
+ * REASONING_MAX_CHARS with a disclosed truncation suffix — CEE is a separate
+ * service on its own deploy cadence and this field carries no contract yet.
+ */
+const REASONING_MAX_CHARS = 20000
+const REASONING_TRUNCATION_SUFFIX = '\n\n[reasoning truncated]'
+
+function extractReasoningSidecar(response: unknown): string | undefined {
+  const additive = (response as OlumiResponseWithExtensions)?.[ADDITIVE_EXTENSIONS_KEY]
+  const raw = additive?.['_reasoning']
+  if (typeof raw !== 'string') return undefined
+  // Verbatim: only whitespace-only strings are rejected as "empty"; the
+  // accepted string itself is never trimmed/altered (Paul's ruling —
+  // VERBATIM-with-label — the rendered panel must match CEE byte-for-byte,
+  // short of the disclosed truncation below).
+  if (raw.trim().length === 0) return undefined
+  if (raw.length > REASONING_MAX_CHARS) {
+    return raw.slice(0, REASONING_MAX_CHARS) + REASONING_TRUNCATION_SUFFIX
+  }
+  return raw
 }
 
 function humaniseToken(token: string): string {
@@ -3205,12 +3234,25 @@ export function useConversation(): UseConversationReturn {
               message: a.message,
               ...(a.action_type ? { action_type: a.action_type } : {}),
             }))
+            // ROADMAP 1.42 (Show-reasoning progressive disclosure — verbatim,
+            // labelled): CEE MAY carry a top-level `_reasoning` string. At the
+            // pinned schema (0.13.1) this unknown key is auto-demoted by the
+            // parser's additive-extensions sidecar (responseParser.ts) rather
+            // than validated — read it from there, never from the strict
+            // OlumiResponse surface. Sporadic field: accept only a non-empty
+            // string, defensively length-capped. NEVER merged into `content`
+            // (that feeds extractFromRawJson/truncation) — attached as its own
+            // field, rendered separately, verbatim.
+            const reasoning = isReasoningDisclosureEnabled()
+              ? extractReasoningSidecar(target.response)
+              : undefined
             addMessage({
               id: crypto.randomUUID(),
               role: 'assistant',
               content: target.response.assistant_text,
               ...(renderBlocks.length > 0 ? { blocks: renderBlocks } : {}),
               ...(actionChips.length > 0 ? { actionChips } : {}),
+              ...(reasoning ? { reasoning } : {}),
               timestamp: new Date(),
             })
           } else if (target.kind === 'empty') {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -392,6 +392,16 @@ const FLAGS_CONFIG = {
     envKey: 'VITE_V5_CANONICAL_ANALYSIS',
     storageKey: 'feature.v5CanonicalAnalysis',
   },
+  // ROADMAP 1.42: Show-reasoning progressive disclosure — verbatim, labelled.
+  // When ON: assistant messages carrying a `_reasoning` string (CEE additive
+  // extension, sidecar-parsed by responseParser at schema pin 0.13.1) render a
+  // collapsed-by-default "Show reasoning" toggle. Verbatim plain text, never
+  // fed through the markdown/content pipeline. Off by default — sporadic CEE
+  // field, no contract guarantee yet.
+  reasoningDisclosure: {
+    envKey: 'VITE_FEATURE_REASONING_DISCLOSURE',
+    storageKey: 'feature.reasoningDisclosure',
+  },
 } as const
 
 // ============================================================================
@@ -462,6 +472,7 @@ const flags = {
   focusNowPanel: makeFlag(FLAGS_CONFIG.focusNowPanel),
   aiPanelV2: makeFlag(FLAGS_CONFIG.aiPanelV2),
   v5CanonicalAnalysis: makeFlag(FLAGS_CONFIG.v5CanonicalAnalysis),
+  reasoningDisclosure: makeFlag(FLAGS_CONFIG.reasoningDisclosure),
 }
 
 // Export with original naming convention for backward compatibility
@@ -530,6 +541,7 @@ export const isAiPanelV2Enabled = flags.aiPanelV2
 export const isV5CanonicalAnalysisEnabled = flags.v5CanonicalAnalysis
 export const diagnoseV5CanonicalAnalysis = () =>
   diagnoseFlagState(FLAGS_CONFIG.v5CanonicalAnalysis)
+export const isReasoningDisclosureEnabled = flags.reasoningDisclosure
 
 
 // ============================================================================


### PR DESCRIPTION
## Summary

UI half of ROADMAP 1.42 (Show-reasoning progressive disclosure). Paul ruled **VERBATIM-with-label**.
CEE's side is built in parallel — this PR is inert until CEE ships `_reasoning` on the turn response
AND the flag below is flipped on.

- New flag `isReasoningDisclosureEnabled` (`VITE_FEATURE_REASONING_DISCLOSURE`), **default OFF**.
- `ConversationMessage.reasoning?: string` — populated only when the flag is on and CEE's
  `_reasoning` additive-extension sidecar carries a non-empty string. No `responseParser.ts` change
  needed: `_reasoning` is already an unknown top-level key at the pinned schema (0.13.1), so the
  existing tolerance (`splitAdditiveExtensions`, `KNOWN_OLUMI_TOP_LEVEL_KEYS`) auto-demotes it into
  the `__additive__` sidecar — verified by reading, not assumed.
- `useConversation.ts` reads the sidecar at the V5 `addMessage` success site, never merges it into
  `message.content` (that field feeds `extractFromRawJson`/clamp-truncation), defensively caps it at
  20,000 chars with a disclosed truncation suffix, and never trims the accepted string itself
  (verbatim fidelity).
- `MessageBubble.tsx` renders a collapsed-by-default "Show reasoning" toggle (between the prose
  Show-more toggle and InsightsStrip) that expands to a muted panel headed **exactly** "Model
  reasoning (verbatim)" — plain text via a React text child, `white-space: pre-wrap`, **no
  `dangerouslySetInnerHTML`, no markdown pipeline**. Renders nothing when reasoning is absent or the
  flag is off.
- Persistence: **no code change** — `useThreadPersistence.ts`'s assistant-message mapping already
  enumerates its own field list with no spread, so `reasoning` was never on it. Ephemeral by
  construction, documented in the lane doc rather than added as a new guard.

Full trace + verification detail: `docs/lanes/lane-reasoning-disclosure.md`.

## Test plan

- [x] `MessageBubble.reasoning.spec.tsx` (7 tests): collapsed by default; expands with the exact
      header; byte-verbatim rendering including a literal `<script>alert(1)</script>` shown as inert
      escaped text (pins XSS-safety); absent reasoning / flag-off both render nothing; never on user
      messages.
- [x] `useConversation.reasoning.spec.ts` (8 tests): sidecar → `message.reasoning`; reasoning never
      in `message.content`; absent sidecar / wrong key / non-string / whitespace-only all rejected;
      oversized value truncated with disclosed suffix; flag-off leaves it undefined.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` on touched files — 0 errors.
- [x] Both new spec files + 5 sibling `MessageBubble.*.spec.tsx` files run together — 57/57 pass.
- [x] Fast pre-push gate (`scripts/validate-prepush.sh`) — all checks passed.
- [ ] **Known pre-existing, unrelated failure** in `--changed`:
      `useConversation.hook.spec.ts > timeout progression > aborts and shows error at 60s` throws
      `No "getV5Endpoint" export is defined on the "../../../v5/v5Adapter" mock` — that spec's own
      hand-rolled mock only stubs `callV5Turn`. Verified byte-identical (same 41/67 failures) on
      unmodified `origin/staging @ d991ad5a` via `git stash`. Not touched by this PR; not chased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)