### PR TITLE
fix(debug-bundle): capture recent conversation turns, not just chip turns (ROADMAP 1.31)

### DIFF
--- a/src/components/debug/hooks/useDebugData.ts
+++ b/src/components/debug/hooks/useDebugData.ts
@@ -79,6 +79,13 @@ import {
   findAnalysisProducingPlotTurn,
   type PlotTraceTier,
 } from '../../../lib/analysisProducingPlotTurn'
+// ROADMAP 1.31 (Brief I): most-recent-N V5 CEE turn capture, INCLUDING
+// LLM-authored conversation turns (chat/clarify/draft), independent of
+// the single-turn analysis-producing selector above. See module docs.
+import {
+  selectRecentConversationTurns,
+  type RecentConversationTurnsResult,
+} from '../../../lib/recentConversationTurns'
 import {
   isV5TurnEndpoint,
   matchServiceCaseInsensitive,
@@ -1170,6 +1177,21 @@ export interface DebugData {
 
   /** CEE diagnostic trace from _diagnostic_trace envelope field. Passthrough — UI must not transform. */
   diagnostic_trace: Record<string, unknown> | null
+
+  /**
+   * Recent conversation turns (ROADMAP 1.31, Brief I) — the most-recent
+   * N V5 CEE turns of ANY kind (chat, clarify, draft, chip), each
+   * carrying `assistant_text` + served prompt identity when present.
+   * Independent of `payloads.cee_request`/`cee_response` (which stay
+   * pinned to the single analysis-producing turn via
+   * `findLatestAnalysisProducingCeeTurn`, unchanged) — this field exists
+   * so a bundle from a scenario with real conversation carries at least
+   * one LLM-authored turn even when no analysis-producing turn ran.
+   * Optional (like `payload_trace_store_summary`) so pre-existing
+   * `DebugData` test fixtures that don't set it keep compiling — the
+   * bundle assembler defaults to an empty result when absent.
+   */
+  recent_conversation_turns?: RecentConversationTurnsResult
 }
 
 /**
@@ -3900,6 +3922,10 @@ export function useDebugData(): DebugData {
       currentScenarioId,
       resultsHash,
     )
+    // ROADMAP 1.31 (Brief I): independent multi-turn capture. Does NOT
+    // feed `payloads.cee_request`/`cee_response` — those stay pinned to
+    // `analysisProducing.selected` above, unchanged.
+    const recentConversationTurns = selectRecentConversationTurns(tracedPayloads)
     // Fallback path: when the analysis-producing V5 selector returns
     // undefined, fall through to `findBestPayload` so V1 / non-analysis
     // V5 turns still surface honestly.
@@ -4557,6 +4583,10 @@ export function useDebugData(): DebugData {
 
       // CEE diagnostic trace (passthrough)
       diagnostic_trace,
+
+      // ROADMAP 1.31 (Brief I): recent conversation turns, incl.
+      // LLM-authored text + prompt identity.
+      recent_conversation_turns: recentConversationTurns,
     }
   }, [ceePipelineTrace, nodes, edges, runMeta, tracedPayloads, gatesMap, currentScenarioId, resultsHash])
 }

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -35,6 +35,9 @@ import { getBufferedLogs, type BufferedLog } from '../../../utils/debugLogBuffer
 import { DEBUG_LLM_RAW_MAX_CHARS } from '../../../utils/payloadRedaction'
 import { getUserActions } from '../../../lib/debug-state'
 import type { PayloadInspectionReason } from '../../../lib/payload-trace-store'
+// ROADMAP 1.31 (Brief I): most-recent-N V5 CEE turn capture, INCLUDING
+// LLM-authored conversation turns.
+import type { RecentConversationTurnsResult } from '../../../lib/recentConversationTurns'
 // Round-5 review (P1): use the shared V5 endpoint helper for the
 // service-metadata classification too, so the bundle can't
 // reintroduce substring false positives (e.g. `/turning` or
@@ -1774,6 +1777,17 @@ interface DebugBundle {
   }
 
   /**
+   * ROADMAP 1.31 (Brief I, confirmed 3/3 bundles): most-recent V5 CEE
+   * turns of ANY kind (chat, clarify, draft, chip) — INCLUDING
+   * LLM-authored conversation turns that the single-turn
+   * analysis-producing selector (`payloads.cee_request`/`cee_response`,
+   * unchanged) never surfaces. Precondition for manual acceptance runs
+   * to evidence LLM behaviour (chronicle Gate-0). Defaults to an empty
+   * result when the exporting `DebugData` predates this field.
+   */
+  recent_conversation_turns: RecentConversationTurnsResult
+
+  /**
    * Round-8 diagnostic: PLoT-side selection detail. Mirrors
    * `cee_capture_selection` for the PLoT v1 engine and V2 paths.
    *
@@ -3137,6 +3151,16 @@ export function buildDebugBundle(data: DebugData, options: ExportOptions = {}): 
       user_agent: navigator.userAgent,
     },
     builds: data.builds,
+    // ROADMAP 1.31 (Brief I): defaults to an empty result for DebugData
+    // fixtures that predate this field (same optional-on-input,
+    // required-on-output pattern as `payload_trace_store_summary`).
+    recent_conversation_turns: data.recent_conversation_turns ?? {
+      turns: [],
+      total_available: 0,
+      truncated: false,
+      captured_count: 0,
+      llm_authored_count: 0,
+    },
     payloads: {
       // Fall back to downstream CEE calls (extracted from PLoT response) when
       // CEE wasn't called directly (orchestrator flow nests CEE inside PLoT)

--- a/src/lib/__tests__/recentConversationTurns.spec.ts
+++ b/src/lib/__tests__/recentConversationTurns.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for `selectRecentConversationTurns` (ROADMAP 1.31, Brief I).
+ *
+ * Core claim under test: a bundle built from a scenario with chat turns
+ * must contain at least one LLM-authored turn with text + prompt
+ * identity, even when the scenario also has analysis-producing chip
+ * turns that `findLatestAnalysisProducingCeeTurn` would (correctly,
+ * unchanged) narrow down to a single entry.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  selectRecentConversationTurns,
+  type ConversationTurnSourcePayload,
+} from '../recentConversationTurns'
+import { findLatestAnalysisProducingCeeTurn } from '../analysisProducingCeeTurn'
+
+function v5Turn(
+  overrides: Partial<ConversationTurnSourcePayload> = {},
+): ConversationTurnSourcePayload {
+  return {
+    id: overrides.id ?? 'tp-1',
+    service: 'CEE',
+    endpoint: '/bff/orchestrate/v2/turn',
+    status: 200,
+    completed: true,
+    timestamp: 1000,
+    turnType: 'run_analysis',
+    request: { headers: {}, body: { scenario_id: 'scn-1' } },
+    response: { headers: {}, body: {} },
+    ...overrides,
+  }
+}
+
+describe('selectRecentConversationTurns', () => {
+  it('captures an LLM-authored chat turn with text + prompt identity (RED case: was zero before the fix)', () => {
+    const payloads: ConversationTurnSourcePayload[] = [
+      // Most-recent: a conversational (non-analysis-producing) chat turn
+      // with real assistant text and a served prompt identity.
+      v5Turn({
+        id: 'tp-chat-1',
+        turnType: 'clarify',
+        timestamp: 2000,
+        response: {
+          headers: {},
+          body: {
+            assistant_text: "Could you say more about the budget constraint?",
+            _diagnostic_trace: {
+              prompt_identity: [{ staging_version: 42, pms_id: 'orchestrator-cf-v42' }],
+            },
+          },
+        },
+      }),
+      // Older: the analysis-producing chip turn (the only one the
+      // existing selector would surface).
+      v5Turn({
+        id: 'tp-analysis-1',
+        turnType: 'run_analysis',
+        timestamp: 1000,
+        response: { headers: {}, body: { assistant_text: null } },
+      }),
+    ]
+
+    const result = selectRecentConversationTurns(payloads)
+
+    // The failure mode this fix closes: existing single-turn selection
+    // (analysis-producing only) would carry ZERO LLM-authored turns
+    // whenever the scenario has no run_analysis-adjacent assistant text.
+    // The new multi-turn capture must include the conversational turn.
+    expect(result.llm_authored_count).toBeGreaterThanOrEqual(1)
+    expect(result.captured_count).toBe(2)
+    expect(result.truncated).toBe(false)
+
+    const chatTurn = result.turns.find((t) => t.trace_id === 'tp-chat-1')
+    expect(chatTurn).toBeDefined()
+    expect(chatTurn?.assistant_text).toBe(
+      "Could you say more about the budget constraint?",
+    )
+    expect(chatTurn?.has_assistant_text).toBe(true)
+    expect(chatTurn?.turn_kind).toBe('clarify')
+    expect(chatTurn?.is_analysis_producing).toBe(false)
+    expect(chatTurn?.prompt_identity).toEqual([
+      { staging_version: 42, pms_id: 'orchestrator-cf-v42' },
+    ])
+    expect(chatTurn?.has_prompt_identity).toBe(true)
+  })
+
+  it('reads prompt_identity from the __additive__ sidecar (V5-canonical parsed body shape)', () => {
+    const payloads: ConversationTurnSourcePayload[] = [
+      v5Turn({
+        id: 'tp-additive',
+        turnType: 'explain',
+        response: {
+          headers: {},
+          body: {
+            assistant_text: 'Here is why option A leads.',
+            __additive__: {
+              _diagnostic_trace: {
+                prompt_identity: [{ staging_version: 7 }],
+              },
+            },
+          },
+        },
+      }),
+    ]
+
+    const result = selectRecentConversationTurns(payloads)
+    expect(result.turns[0].prompt_identity).toEqual([{ staging_version: 7 }])
+    expect(result.turns[0].has_prompt_identity).toBe(true)
+  })
+
+  it('reports has_assistant_text: false and prompt_identity: null honestly when absent (no fabrication)', () => {
+    const payloads: ConversationTurnSourcePayload[] = [
+      v5Turn({
+        id: 'tp-empty',
+        turnType: 'system_event',
+        response: { headers: {}, body: {} },
+      }),
+    ]
+
+    const result = selectRecentConversationTurns(payloads)
+    expect(result.turns[0].assistant_text).toBeNull()
+    expect(result.turns[0].has_assistant_text).toBe(false)
+    expect(result.turns[0].prompt_identity).toBeNull()
+    expect(result.turns[0].has_prompt_identity).toBe(false)
+    expect(result.llm_authored_count).toBe(0)
+  })
+
+  it('excludes non-V5 CEE endpoints and non-CEE services', () => {
+    const payloads: ConversationTurnSourcePayload[] = [
+      v5Turn({ id: 'tp-legacy', endpoint: '/bff/cee/draft-graph' }),
+      { ...v5Turn({ id: 'tp-plot' }), service: 'PLoT' as unknown as string },
+    ]
+
+    const result = selectRecentConversationTurns(payloads)
+    expect(result.turns).toHaveLength(0)
+    expect(result.total_available).toBe(0)
+  })
+
+  it('caps capture at the configured N and discloses truncation', () => {
+    const payloads: ConversationTurnSourcePayload[] = Array.from(
+      { length: 5 },
+      (_, i) =>
+        v5Turn({
+          id: `tp-${i}`,
+          timestamp: 5000 - i,
+          response: { headers: {}, body: { assistant_text: `reply ${i}` } },
+        }),
+    )
+
+    const result = selectRecentConversationTurns(payloads, { cap: 3 })
+    expect(result.captured_count).toBe(3)
+    expect(result.total_available).toBe(5)
+    expect(result.truncated).toBe(true)
+    // Most-recent-first order preserved (trace-store convention).
+    expect(result.turns.map((t) => t.trace_id)).toEqual(['tp-0', 'tp-1', 'tp-2'])
+  })
+
+  it('does not change what findLatestAnalysisProducingCeeTurn selects for bundle.payloads.cee_* (existing analysis-turn capture unchanged)', () => {
+    const payloads: ConversationTurnSourcePayload[] = [
+      v5Turn({
+        id: 'tp-chat-1',
+        turnType: 'clarify',
+        timestamp: 2000,
+        response: { headers: {}, body: { assistant_text: 'hi' } },
+      }),
+      v5Turn({
+        id: 'tp-analysis-1',
+        turnType: 'run_analysis',
+        timestamp: 1000,
+        response: { headers: {}, body: { assistant_text: null } },
+      }),
+    ]
+
+    const analysisSelection = findLatestAnalysisProducingCeeTurn(
+      payloads,
+      null,
+      null,
+    )
+    // Unchanged behaviour: the single-turn selector still picks only
+    // the analysis-producing candidate.
+    expect(analysisSelection.selected?.id).toBe('tp-analysis-1')
+
+    // But the new multi-turn capture surfaces BOTH, including the
+    // LLM-authored conversational one the single-turn selector drops.
+    const conversationCapture = selectRecentConversationTurns(payloads)
+    expect(conversationCapture.captured_count).toBe(2)
+    expect(conversationCapture.llm_authored_count).toBe(1)
+  })
+})

--- a/src/lib/recentConversationTurns.ts
+++ b/src/lib/recentConversationTurns.ts
@@ -1,0 +1,194 @@
+/**
+ * Recent-conversation-turns capture — debug bundle (ROADMAP 1.31, Brief I).
+ *
+ * Defect (confirmed 3/3 bundles): `findLatestAnalysisProducingCeeTurn`
+ * (`analysisProducingCeeTurn.ts`) is the ONLY selector feeding
+ * `bundle.payloads.cee_request` / `cee_response`, and it deliberately
+ * narrows to a single V5 turn whose action type is analysis-producing
+ * (`run_analysis` / `what_would_flip` / `explain` — see
+ * `ANALYSIS_PRODUCING_ACTION_TYPES`). A bundle built from a scenario
+ * that only ran chip turns therefore carries ZERO LLM-authored
+ * conversation turns: no `assistant_text`, no served prompt identity —
+ * manual acceptance runs cannot evidence LLM behaviour from it
+ * (chronicle Gate-0 precondition, re-adopted 8 Jul).
+ *
+ * This module ADDS a second, independent capture — it does NOT change
+ * the analysis-producing selector or `bundle.payloads.cee_*`. It
+ * surfaces the most-recent N V5 CEE turns of ANY kind (chat, clarify,
+ * draft, chip — not just analysis-producing), each carrying:
+ *   - `turn_kind`        — the turn/action-type discriminator
+ *   - `assistant_text`   — the LLM-authored reply, verbatim (root
+ *                          `assistant_text` on the OlumiResponse
+ *                          envelope — passthrough only, never
+ *                          re-derived or summarised)
+ *   - `prompt_identity`  — `_diagnostic_trace.prompt_identity` when
+ *                          present on the turn record (passthrough;
+ *                          UI-doctrine: never fabricated)
+ *
+ * The payload trace store itself caps at 20 entries total across ALL
+ * services (`MAX_PAYLOADS` in `payload-trace-store.ts`), so
+ * `RECENT_CONVERSATION_TURNS_CAP` is defensive headroom rather than the
+ * practical ceiling — but the cap and `truncated` flag are still
+ * honoured/reported so a future increase to the trace-store size can't
+ * silently balloon the bundle.
+ *
+ * Pure module — no React, no Zustand. Callers pass a `TracedPayload`
+ * -shaped array (trace-store convention: most-recent first).
+ */
+
+import { isCeeService, isV5TurnEndpoint } from './v5TraceMatching'
+import {
+  ANALYSIS_PRODUCING_ACTION_TYPES,
+  readScenarioId,
+  readTurnOrActionType,
+  type SelectorTracedPayload,
+} from './analysisProducingCeeTurn'
+
+/** Loose shape the selector accepts — subset of `TracedPayload`. */
+export type ConversationTurnSourcePayload = SelectorTracedPayload & {
+  timestamp?: number
+}
+
+/**
+ * Generous cap on captured turns. The payload trace store already caps
+ * at 20 total entries across all services, so this is defensive
+ * headroom, not the expected practical count.
+ */
+export const RECENT_CONVERSATION_TURNS_CAP = 50
+
+export interface RecentConversationTurn {
+  /** Trace-store id, when present. */
+  trace_id: string | null
+  /** Request timestamp (ms epoch) from the trace entry, when present. */
+  timestamp: number | null
+  /** Turn/action-type discriminator (see `readTurnOrActionType`). */
+  turn_kind: string | null
+  /** True when `turn_kind` is one of `ANALYSIS_PRODUCING_ACTION_TYPES`. */
+  is_analysis_producing: boolean
+  completed: boolean
+  status: number | null
+  scenario_id: string | null
+  /**
+   * LLM-authored reply text, verbatim from the root `assistant_text`
+   * field of the captured OlumiResponse envelope. Null when absent
+   * (e.g. a draft-only or failed turn) — never fabricated.
+   */
+  assistant_text: string | null
+  /** True when `assistant_text` is a non-empty string. */
+  has_assistant_text: boolean
+  /**
+   * Passthrough of `_diagnostic_trace.prompt_identity` (served prompt
+   * identity — e.g. staging_version / PMS id — when CEE's diagnostic
+   * trace is enabled and the field is present on the turn record).
+   * Verbatim; UI must not transform. Null when absent.
+   */
+  prompt_identity: unknown | null
+  /** True when `prompt_identity` is present (non-null). */
+  has_prompt_identity: boolean
+}
+
+export interface RecentConversationTurnsResult {
+  /** Captured turns, most-recent first (mirrors trace-store order). */
+  turns: RecentConversationTurn[]
+  /** Total V5 CEE candidate turns available before the cap was applied. */
+  total_available: number
+  /** True when `total_available > turns.length` — the cap engaged. */
+  truncated: boolean
+  /** Count actually captured (`== turns.length`; kept explicit so bundle
+   *  readers don't have to re-derive it). */
+  captured_count: number
+  /**
+   * Of the captured turns, how many carried non-null `assistant_text`.
+   * The honesty signal this module exists to fix (Brief I) — a bundle
+   * from a scenario with real conversation should read > 0 here.
+   */
+  llm_authored_count: number
+}
+
+/**
+ * Read the root `assistant_text` field from a V5 CEE turn's captured
+ * response body. Passthrough only — never re-derived or summarised.
+ */
+function readAssistantText(p: ConversationTurnSourcePayload): string | null {
+  const body = p.response?.body
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  const text = (body as Record<string, unknown>).assistant_text
+  return typeof text === 'string' && text.length > 0 ? text : null
+}
+
+/**
+ * Read `_diagnostic_trace.prompt_identity` from a V5 CEE turn's
+ * captured response body. Mirrors the two documented locations from
+ * `readCeeDiagnosticTrace` (`useDebugData.ts`) — the legacy top-level
+ * `_diagnostic_trace` and the V5 parser's `__additive__._diagnostic_trace`
+ * sidecar (unknown top-level keys, including `_diagnostic_trace`, are
+ * demoted there by strict-schema validation before the trace-store
+ * clone promotes the sidecar to an enumerable key). Duplicated here
+ * (rather than imported) to keep this module free of any dependency on
+ * the `components/debug` layer — same read order, kept in sync
+ * deliberately.
+ */
+function readPromptIdentity(p: ConversationTurnSourcePayload): unknown | null {
+  const body = p.response?.body
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  const root = body as Record<string, unknown>
+
+  const readFrom = (trace: unknown): unknown | null => {
+    if (!trace || typeof trace !== 'object' || Array.isArray(trace)) return null
+    const identity = (trace as Record<string, unknown>).prompt_identity
+    return identity ?? null
+  }
+
+  const topLevel = readFrom(root._diagnostic_trace)
+  if (topLevel !== null) return topLevel
+
+  const additive = root.__additive__
+  if (additive && typeof additive === 'object' && !Array.isArray(additive)) {
+    return readFrom((additive as Record<string, unknown>)._diagnostic_trace)
+  }
+  return null
+}
+
+/**
+ * Select the most-recent N V5 CEE turns (any kind), each carrying
+ * assistant text + prompt identity when present. Does NOT filter to
+ * analysis-producing turns — that remains
+ * `findLatestAnalysisProducingCeeTurn`'s job for `bundle.payloads.cee_*`.
+ */
+export function selectRecentConversationTurns(
+  payloads: ReadonlyArray<ConversationTurnSourcePayload>,
+  options: { cap?: number } = {},
+): RecentConversationTurnsResult {
+  const cap = options.cap ?? RECENT_CONVERSATION_TURNS_CAP
+  const v5Turns = payloads.filter(
+    (p) => isCeeService(p) && isV5TurnEndpoint(p),
+  )
+
+  const turns: RecentConversationTurn[] = v5Turns.slice(0, cap).map((p) => {
+    const turnKind = readTurnOrActionType(p)
+    const assistantText = readAssistantText(p)
+    const promptIdentity = readPromptIdentity(p)
+    return {
+      trace_id: typeof p.id === 'string' ? p.id : null,
+      timestamp: typeof p.timestamp === 'number' ? p.timestamp : null,
+      turn_kind: turnKind,
+      is_analysis_producing:
+        turnKind !== null && ANALYSIS_PRODUCING_ACTION_TYPES.has(turnKind),
+      completed: p.completed === true,
+      status: typeof p.status === 'number' ? p.status : null,
+      scenario_id: readScenarioId(p),
+      assistant_text: assistantText,
+      has_assistant_text: assistantText !== null,
+      prompt_identity: promptIdentity,
+      has_prompt_identity: promptIdentity !== null,
+    }
+  })
+
+  return {
+    turns,
+    total_available: v5Turns.length,
+    truncated: v5Turns.length > turns.length,
+    captured_count: turns.length,
+    llm_authored_count: turns.filter((t) => t.has_assistant_text).length,
+  }
+}


### PR DESCRIPTION
## Summary
- Debug-bundle turn capture (`findLatestAnalysisProducingCeeTurn`) only ever surfaces one V5 CEE turn, and only when it's analysis-producing (run_analysis/what_would_flip/explain) — so bundles from chat-only scenarios carried zero LLM-authored turns (Brief I, confirmed 3/3 bundles), blocking the formal Demo-Gate acceptance runs (ROADMAP 1.2 precondition).
- Adds a second, independent capture — `recent_conversation_turns` on the bundle — surfacing the most-recent N (cap 50; the trace store itself caps at 20 total) V5 CEE turns of any kind, each with `assistant_text`, `turn_kind`, and `_diagnostic_trace.prompt_identity` when present. Passthrough only, honest nulls when absent.
- Does NOT change `bundle.payloads.cee_request`/`cee_response` or the analysis-producing selector — pinned by a regression test.

## Test plan
- [x] RED-first: `src/lib/__tests__/recentConversationTurns.spec.ts` verified failing against a stub (llm_authored_count 0, etc.) before the real implementation landed, then green.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only, none in touched files).
- [x] Full debug-bundle test suite (`src/components/debug`, `src/lib/__tests__/{recentConversationTurns,analysisProducingCeeTurn,v5TraceMatching}.spec.ts`) — 718 passed, 1 pre-existing failure (`exportBundle.displayState.spec.ts` `results_stale`) verified failing identically on clean `origin/staging` via stash run, and already documented as pre-existing in commit `bd247d3a`.
- [x] Fast pre-push gate (`scripts/validate-prepush.sh`) — ALL CHECKS PASSED.
- [ ] Netlify deploy: not directly verifiable (no token). This is debug-panel export tooling only — no user-facing behaviour change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>