### PR TITLE
fix(analysis): humanise InferenceWarningStrip copy — no raw critique message in JSX

### DIFF
--- a/src/components/results/InferenceWarningStrip.tsx
+++ b/src/components/results/InferenceWarningStrip.tsx
@@ -8,9 +8,13 @@
  *     Info-severity entries stay hidden here (they remain available to the
  *     Advanced/Confidence surfaces and the debug bundle). Entries with no
  *     severity are NOT promoted — the UI never invents a severity.
- *   - Copy is the producer `message` verbatim. The UI adds no interpretation,
- *     no rewording, no code-specific handling. An entry without a usable
- *     message renders nothing (fail-closed; no fabricated copy from `code`).
+ *   - Copy is HUMANISED via the same `humaniseCritique` path every other
+ *     critique surface uses (ConfidenceSection, useResultsSectionData) — the
+ *     UI keys off producer `code`, never renders the raw `message` in JSX
+ *     (V14.3 no-message-render guard). Unmapped codes fall through to
+ *     humaniseCritique's safe generic copy rather than the raw string; an
+ *     entry without a usable message renders nothing (fail-closed; no
+ *     fabricated copy from `code` alone).
  *   - Display-only: never blocks analysis, never mutates state.
  *
  * Visual idiom mirrors AnalysisFreshnessNotice (the strip mounts directly
@@ -19,7 +23,8 @@
  */
 import { AlertTriangle } from 'lucide-react'
 import { typography } from '@/styles/typography'
-import type { InferenceWarning } from './types'
+import { humaniseCritique } from './utils/humaniseCritique'
+import type { InferenceWarning, UncertaintyItem } from './types'
 
 export interface InferenceWarningStripProps {
   /** Producer inference warnings (all severities); the strip filters. */
@@ -32,11 +37,33 @@ export function selectWarningSeverityEntries(
   warnings: InferenceWarning[] | undefined,
 ): InferenceWarning[] {
   return (warnings ?? []).filter(
-    (w) =>
-      w.severity === 'warning' &&
-      typeof w.message === 'string' &&
-      w.message.trim().length > 0,
+    (w) => w.severity === 'warning' && typeof w.message === 'string' && w.message.trim().length > 0,
   )
+}
+
+/** Node-label map for humaniseCritique's factor-label resolution, built from
+ *  the entry's own already-resolved `affected_labels` (never parsed from
+ *  `message`). Returns undefined when no labels are available — humaniseCritique
+ *  falls back to its own ID-derived label in that case. */
+function buildNodeLabelMap(w: InferenceWarning): Map<string, string> | undefined {
+  if (!w.affected_labels || w.affected_labels.length === 0) return undefined
+  const map = new Map<string, string>()
+  w.affected_nodes.forEach((nodeId, i) => {
+    const label = w.affected_labels?.[i]
+    if (label) map.set(nodeId, label)
+  })
+  return map.size > 0 ? map : undefined
+}
+
+/** Humanised, user-safe headline for an inference warning — same
+ *  code-keyed template path every other critique surface uses. */
+function humaniseWarningTitle(w: InferenceWarning): string {
+  const item: UncertaintyItem = {
+    code: w.code,
+    message: w.message ?? '',
+    affectedNodes: w.affected_nodes,
+  }
+  return humaniseCritique(item, buildNodeLabelMap(w)).title
 }
 
 export function InferenceWarningStrip({ warnings, className = '' }: InferenceWarningStripProps) {
@@ -58,8 +85,8 @@ export function InferenceWarningStrip({ warnings, className = '' }: InferenceWar
           className="flex items-center gap-2 rounded-md border px-3 py-2 bg-panel border-warning/30"
         >
           <AlertTriangle size={14} className="flex-none text-warning" aria-hidden="true" />
-          {/* Producer message verbatim — provisional_doctrine_v0: the UI adds no interpretation. */}
-          <span className={`${typography.panelBody} text-text-body`}>{w.message}</span>
+          {/* Humanised copy — never the producer's raw message (V14.3 guard). */}
+          <span className={`${typography.panelBody} text-text-body`}>{humaniseWarningTitle(w)}</span>
         </div>
       ))}
     </div>

--- a/src/components/results/__tests__/InferenceWarningStrip.spec.tsx
+++ b/src/components/results/__tests__/InferenceWarningStrip.spec.tsx
@@ -3,8 +3,9 @@
  *
  * Warning-severity producer inference_warnings surface as a compact
  * honest-caveat strip on the Analysis tab; info-severity entries stay
- * hidden; copy is the producer message verbatim (the UI adds no
- * interpretation). Tagged provisional_doctrine_v0.
+ * hidden. Copy is HUMANISED via humaniseCritique (V14.3 no-message-render
+ * guard) — the UI keys off producer `code`, never the raw `message`.
+ * Tagged provisional_doctrine_v0.
  *
  * Warning shapes mirror the real staging capture (debug bundle
  * olumi-debug-45c9b625-20260707): { code, message, severity }.
@@ -69,14 +70,32 @@ describe('selectWarningSeverityEntries', () => {
 })
 
 describe('InferenceWarningStrip', () => {
-  it('renders the producer message VERBATIM for a warning-severity entry', () => {
+  it('renders HUMANISED copy for a warning-severity entry, never the raw producer message', () => {
     render(<InferenceWarningStrip warnings={[WARNING_CONSTRAINT_TARGET]} />)
     const strip = screen.getByTestId('inference-warning-strip')
     expect(strip).toBeInTheDocument()
     const entry = screen.getByTestId('inference-warning-strip-entry')
     expect(entry).toHaveAttribute('data-warning-code', 'CONSTRAINT_TARGET_UNRELIABLE')
-    // Byte-for-byte producer copy — no rewording, no truncation, no suffix.
-    expect(entry).toHaveTextContent(WARNING_CONSTRAINT_TARGET.message as string)
+    // V14.3: no code-template match for this code → humaniseCritique's safe
+    // generic fallback title, NOT the raw producer message verbatim.
+    expect(entry).toHaveTextContent("Review this factor's inputs")
+    expect(entry).not.toHaveTextContent(WARNING_CONSTRAINT_TARGET.message as string)
+  })
+
+  it('humanises a template-mapped code via the shared code→title map, using the entry\'s own resolved label', () => {
+    const missingObservedState: InferenceWarning = {
+      code: 'MISSING_OBSERVED_STATE',
+      affected_nodes: ['node_marketing_spend'],
+      affected_labels: ['Marketing Spend'],
+      message: "observed_state.value missing for fac_marketing_spend, defaulted",
+      severity: 'warning',
+    }
+    render(<InferenceWarningStrip warnings={[missingObservedState]} />)
+    const entry = screen.getByTestId('inference-warning-strip-entry')
+    // Template-derived, human-readable — uses the producer-resolved label.
+    expect(entry).toHaveTextContent('Marketing Spend is missing a current value')
+    // Never the raw internal-token-bearing message.
+    expect(entry).not.toHaveTextContent(missingObservedState.message as string)
   })
 
   it('renders nothing when only info-severity entries exist (info stays hidden)', () => {

--- a/src/components/results/__tests__/no-message-render.spec.ts
+++ b/src/components/results/__tests__/no-message-render.spec.ts
@@ -125,6 +125,17 @@ const DEFENCE_IN_DEPTH_FILES: Record<string, RegExp> = {
   // not PLoT critique data. Guard: the message must have been filtered for
   // non-empty strings before render.
   'AdvancedSection.tsx': /typeof w\.message === 'string' && w\.message\.trim\(\)\.length > 0/,
+  // InferenceWarningStrip.tsx: the JSX itself renders ONLY humaniseCritique's
+  // sanitised `.title` (never `.message`) — fixed here after the PR #236
+  // regression that rendered `w.message` verbatim. The two remaining matches
+  // the naive brace scanner still flags are non-render code: the
+  // severity+non-empty-message VISIBILITY FILTER (selectWarningSeverityEntries)
+  // and the small object literal that hands `message` to humaniseCritique as
+  // an *input* — humaniseCritique never echoes raw `.message` back out except
+  // through its own internal-token guard. Presence of the filter's literal
+  // predicate is the attestation that the filter (not a raw render) is what
+  // the scanner is tripping on.
+  'InferenceWarningStrip.tsx': /typeof w\.message === 'string' && w\.message\.trim\(\)\.length > 0/,
 }
 
 /** V14.3b: Additional files that render warning/critique-like data */


### PR DESCRIPTION
## Summary
- `InferenceWarningStrip.tsx` rendered a producer `inference_warning`'s raw `.message` verbatim in JSX (regression from #236) — the V14.3 `no-message-render.spec.ts` guard correctly flags this as a claim-safety violation, and it was the only genuine red in the full UI test suite.
- Route the copy through `humaniseCritique` — the same code-keyed template path every other critique surface uses (`ConfidenceSection`, `useResultsSectionData`) — instead of the raw producer string. Unmapped codes fall through to `humaniseCritique`'s safe generic title rather than leaking the raw message.
- Extended the guard's `DEFENCE_IN_DEPTH_FILES` allowlist for this file: the scanner's brace-matching regex also flags the (non-render) severity/non-empty-message visibility filter and the small object literal that hands `message` to `humaniseCritique` as an *input* — same class of false positive already accepted for `AdvancedSection.tsx`.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` (targeted files) — passes (0 errors; 1 pre-existing unrelated warning)
- [x] `no-message-render.spec.ts` — now green for `InferenceWarningStrip.tsx`
- [x] `InferenceWarningStrip.spec.tsx` — updated: asserts humanised copy renders and raw message never appears; added a template-mapped-code case
- [x] Full `src/components/results` suite run locally — 8 pre-existing failures across 4 unrelated files confirmed identical on unmodified `origin/staging` (verified via `git stash`), not touched by this change
- [x] Fast pre-push gate (`scripts/validate-prepush.sh`) — ALL CHECKS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)