### PR TITLE
fix(canvas): handle .finally()-derived promise rejection in deduplicatedFetch

### DIFF
--- a/src/canvas/hooks/__tests__/useGraphReadiness.dedup.spec.ts
+++ b/src/canvas/hooks/__tests__/useGraphReadiness.dedup.spec.ts
@@ -133,6 +133,39 @@ describe('graph-readiness dedup cache', () => {
     expect(r1.entry).toBe(r2.entry) // same entry object
   })
 
+  it('does not leave an unhandled rejection when the underlying fetch rejects', async () => {
+    // Regression test for #248: promise.finally()'s return value is a
+    // distinct promise that adopts the original rejection. Suppressing
+    // rejection only on the base `promise` (via .catch) is not enough —
+    // the .finally()-derived promise also needs a handler or it surfaces
+    // as an unhandled rejection (crashes vitest workers deterministically,
+    // and fires in production browsers on any real fetch failure).
+    const fetchError = new TypeError('Failed to parse URL from /bff/cee/graph-readiness')
+    fetchSpy.mockRejectedValue(fetchError)
+
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandledRejection)
+
+    try {
+      const result = deduplicatedFetch('/bff/cee/graph-readiness', '{"boom":1}', 'c1')
+
+      // The caller-visible promise still rejects — callers must still see the error.
+      await expect(result.promise).rejects.toThrow('Failed to parse URL')
+
+      // Flush the microtask/macrotask queue so Node has a chance to flag any
+      // orphaned promise (e.g. the .finally()-derived chain) as unhandled.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection)
+    }
+  })
+
   it('reuses in-flight request beyond 750ms dedup window', async () => {
     // Simulate a slow request that takes longer than DEDUP_WINDOW_MS (750ms)
     let resolveSlowFetch!: (res: Response) => void

--- a/src/canvas/hooks/useGraphReadiness.ts
+++ b/src/canvas/hooks/useGraphReadiness.ts
@@ -106,16 +106,22 @@ function deduplicatedFetch(
 
   const entry: InflightEntry = { promise, timestamp: Date.now(), controller, refCount: 1, settled: false }
   inflightCache.set(cacheKey, entry)
-  // Suppress unhandled rejection — callers still get the rejection via `promise`
+  // Suppress unhandled rejection — callers still get the rejection via `promise`.
+  // `.finally()` returns a NEW, distinct promise that adopts the original's
+  // rejection (it does not swallow errors). That derived promise must also
+  // have a rejection handler, or it surfaces as its own unhandled rejection
+  // independently of the `.catch(() => {})` above (#248).
   promise.catch(() => {})
-  promise.finally(() => {
-    entry.settled = true
-    setTimeout(() => {
-      if (inflightCache.get(cacheKey) === entry) {
-        inflightCache.delete(cacheKey)
-      }
-    }, DEDUP_WINDOW_MS)
-  })
+  promise
+    .finally(() => {
+      entry.settled = true
+      setTimeout(() => {
+        if (inflightCache.get(cacheKey) === entry) {
+          inflightCache.delete(cacheKey)
+        }
+      }, DEDUP_WINDOW_MS)
+    })
+    .catch(() => {})
 
   return { promise, entry, isReused: false }
 }


### PR DESCRIPTION
## Summary

- `deduplicatedFetch()` in `src/canvas/hooks/useGraphReadiness.ts` attached `promise.catch(() => {})` to suppress rejection on the base promise, but then called `promise.finally(callback)`. `Promise.prototype.finally()` returns a **distinct** promise that adopts the original rejection — it does not swallow errors. That derived promise had no rejection handler of its own, so it surfaced as an independent unhandled rejection.
- This deterministically crashed vitest workers whenever a spec exercising graph-readiness ran in the same shard as `src/canvas/conversation/__tests__/patchAcceptLogic.spec.tsx` (jsdom resolves the endpoint to a relative URL, so `fetch()` always throws there), and would fire the same way in production browsers on any real network failure to `/bff/cee/graph-readiness`.
- Fix: chain `.catch(() => {})` onto the `.finally()`-derived promise too, so both the base promise and its derived chain are handled. Dedupe semantics, callback timing, and the caller-visible rejection (callers still `await`/`catch` the original `promise`) are unchanged.

Fixes #248.

## Test plan

- [x] RED reproduced first: ran `patchAcceptLogic.spec.tsx` against `origin/staging` tip (`1f9931d9`) — reproduced the exact reported signature (`Unhandled Rejection … useGraphReadiness.ts:76:22`, `Errors 1 error` despite `6 passed (6)`).
- [x] Added a RED-first regression test in `src/canvas/hooks/__tests__/useGraphReadiness.dedup.spec.ts` that stubs `fetch` to reject and asserts no `process.on('unhandledRejection', …)` fires — failed before the fix (captured the rejection), passes after.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — 0 errors (pre-existing repo-wide warnings only, none introduced by this change).
- [x] Targeted vitest: `useGraphReadiness.dedup.spec.ts` (12 tests), `patchAcceptLogic.spec.tsx` (6 tests) — all green, no unhandled-rejection block in output.
- [x] `readinessStore.spec.ts` (nearest consumer) — 13 tests green.
- [x] Fast pre-push gate (`scripts/validate-prepush.sh`) — ALL CHECKS PASSED (typecheck, lint, smoke suite 471 tests, stale-.js, dep audit).
- [ ] CI (full suite) — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)