### PR TITLE
fix(ui): honesty/ingestion batch — goal-threshold quad, warning surfacing, wire-accurate analysis-inputs reads

### DIFF
--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -359,6 +359,13 @@ export interface V2Meta {
   n_samples: number
   detail_level: string
   latency_ms: number
+  /**
+   * ISO 8601 timestamp when analysis computation completed. ROADMAP 1.30b:
+   * confirmed against the captured staging fixture's
+   * `plot_response.meta.computed_at` (golden-path-staging-2026-04-05.json).
+   * Absent on older/cached responses — never fabricated.
+   */
+  computed_at?: string
 }
 
 // ============================================================================

--- a/src/canvas/analysis/__tests__/assembleAnalysisInputsSummary.spec.ts
+++ b/src/canvas/analysis/__tests__/assembleAnalysisInputsSummary.spec.ts
@@ -30,11 +30,14 @@ function makeValidResponse(overrides?: Partial<V2RunResponse>): V2RunResponse {
       },
     ],
     critiques: [],
-    drivers: [
-      { node_id: 'f1', label: 'Revenue growth', contribution: 0.45, direction: 'positive' as const },
-      { node_id: 'f2', label: 'Market share', contribution: 0.30, direction: 'positive' as const },
-      { node_id: 'f3', label: 'Customer churn', contribution: 0.15, direction: 'negative' as const },
-      { node_id: 'f4', label: 'Brand value', contribution: 0.10, direction: 'positive' as const },
+    // ROADMAP 1.30b: `drivers[]` is a legacy field the V2 wire never
+    // populates (see the fix comment in assembleAnalysisInputsSummary.ts) —
+    // real driver data ships as `factor_sensitivity[]`.
+    factor_sensitivity: [
+      { factor_id: 'f1', factor_label: 'Revenue growth', elasticity: 0.45, direction: 'positive' as const },
+      { factor_id: 'f2', factor_label: 'Market share', elasticity: 0.30, direction: 'positive' as const },
+      { factor_id: 'f3', factor_label: 'Customer churn', elasticity: -0.15, direction: 'negative' as const },
+      { factor_id: 'f4', factor_label: 'Brand value', elasticity: 0.10, direction: 'positive' as const },
     ],
     robustness: {
       fragile_edges: [],
@@ -134,13 +137,13 @@ describe('assembleAnalysisInputsSummary', () => {
   it('handles oversized payload via progressive truncation', () => {
     // Create a response with many drivers having very long labels
     const longDrivers = Array.from({ length: 3 }, (_, i) => ({
-      node_id: `f${i}`,
-      label: `A very long factor label that is designed to push the payload over the 2KB limit ${'x'.repeat(200)}`,
-      contribution: 0.3 - i * 0.05,
+      factor_id: `f${i}`,
+      factor_label: `A very long factor label that is designed to push the payload over the 2KB limit ${'x'.repeat(200)}`,
+      elasticity: 0.3 - i * 0.05,
       direction: 'positive' as const,
     }))
 
-    const response = makeValidResponse({ drivers: longDrivers })
+    const response = makeValidResponse({ factor_sensitivity: longDrivers })
     const result = assembleAnalysisInputsSummary(response)
 
     // Should either truncate successfully or return null, but never exceed 2KB
@@ -154,7 +157,7 @@ describe('assembleAnalysisInputsSummary', () => {
     const result = assembleAnalysisInputsSummary(makeValidResponse())
     expect(result).not.toBeNull()
 
-    // Top driver contribution = 0.45, total = 0.45 + 0.30 + 0.15 + 0.10 = 1.0
+    // Top driver elasticity magnitude = 0.45, total = 0.45 + 0.30 + 0.15 + 0.10 = 1.0
     expect(result!.sensitivity_concentration).toBe(0.45)
   })
 
@@ -185,11 +188,113 @@ describe('assembleAnalysisInputsSummary', () => {
   })
 
   it('handles empty drivers gracefully', () => {
-    const response = makeValidResponse({ drivers: [] })
+    const response = makeValidResponse({ factor_sensitivity: [] })
     const result = assembleAnalysisInputsSummary(response)
     expect(result).not.toBeNull()
     expect(result!.top_drivers).toEqual([])
     expect(result!.sensitivity_concentration).toBe(0)
+  })
+
+  // ── ROADMAP 1.30b — structurally-empty reads (wire-accuracy fix) ─────────
+  //
+  // The V2 wire never carries the legacy `drivers[]` field (verified against
+  // the captured staging fixture src/test/fixtures/golden-path-staging-
+  // 2026-04-05.json: `drivers: null` while `factor_sensitivity[]` is
+  // populated — factor_sensitivity is the field useResultsSectionData.ts
+  // already treats as the authoritative PLoT v2 source), a top-level
+  // `completed_at` (real field is nested at `meta.computed_at` — confirmed
+  // against the same fixture's `plot_response.meta.computed_at`), or a
+  // `decision_quality.overall` (the real CEE field is `.level`, enum
+  // 'ready'|'caution'|'not_ready' — DecisionQualityV3 in types/cee.ts; the
+  // function's OWN doc comment already said "if decision_quality provides a
+  // level" while the code checked for `overall`). Before this fix all three
+  // silently produced empty/fallback output on every real response.
+  describe('wire-accurate field reads (ROADMAP 1.30b)', () => {
+    it('builds top_drivers from factor_sensitivity (the field the V2 wire actually carries), not the never-populated legacy drivers field', () => {
+      const response = makeValidResponse({
+        drivers: undefined,
+        factor_sensitivity: [
+          { factor_id: 'fac_a', factor_label: 'Factor A', elasticity: 0.5, importance_rank: 1 },
+          { factor_id: 'fac_b', factor_label: 'Factor B', sensitivity_score: 0.3, importance_rank: 2 },
+          { factor_id: 'fac_c', factor_label: 'Factor C', sensitivity: 0.1, importance_rank: 3 },
+        ],
+      })
+      const result = assembleAnalysisInputsSummary(response)
+      expect(result).not.toBeNull()
+      expect(result!.top_drivers).toEqual([
+        { factor_id: 'fac_a', factor_label: 'Factor A', elasticity: 0.5 },
+        { factor_id: 'fac_b', factor_label: 'Factor B', elasticity: 0.3 },
+        { factor_id: 'fac_c', factor_label: 'Factor C', elasticity: 0.1 },
+      ])
+    })
+
+    it('computes sensitivity_concentration from factor_sensitivity magnitudes', () => {
+      const response = makeValidResponse({
+        drivers: undefined,
+        factor_sensitivity: [
+          { factor_id: 'fac_a', factor_label: 'Factor A', elasticity: 0.6 },
+          { factor_id: 'fac_b', factor_label: 'Factor B', elasticity: 0.3 },
+          { factor_id: 'fac_c', factor_label: 'Factor C', elasticity: 0.1 },
+        ],
+      })
+      const result = assembleAnalysisInputsSummary(response)
+      expect(result).not.toBeNull()
+      // top magnitude 0.6 / total 1.0
+      expect(result!.sensitivity_concentration).toBe(0.6)
+    })
+
+    it('returns empty top_drivers and zero concentration when factor_sensitivity is absent (never fabricates from the dead drivers field)', () => {
+      const response = makeValidResponse({ drivers: undefined, factor_sensitivity: undefined })
+      const result = assembleAnalysisInputsSummary(response)
+      expect(result).not.toBeNull()
+      expect(result!.top_drivers).toEqual([])
+      expect(result!.sensitivity_concentration).toBe(0)
+    })
+
+    it('reads run_metadata.timestamp from meta.computed_at (the real V2 wire field)', () => {
+      const response = makeValidResponse({
+        meta: {
+          seed_used: '42',
+          n_samples: 10000,
+          detail_level: 'deep',
+          latency_ms: 1200,
+          computed_at: '2026-07-08T12:00:00.000Z',
+        } as any,
+      })
+      const result = assembleAnalysisInputsSummary(response)
+      expect(result).not.toBeNull()
+      expect(result!.run_metadata.timestamp).toBe('2026-07-08T12:00:00.000Z')
+    })
+
+    it('leaves run_metadata.timestamp null when meta carries no computed_at (honest absence, no fabrication)', () => {
+      const response = makeValidResponse({
+        meta: { seed_used: '42', n_samples: 10000, detail_level: 'deep', latency_ms: 1200 },
+      })
+      const result = assembleAnalysisInputsSummary(response)
+      expect(result).not.toBeNull()
+      expect(result!.run_metadata.timestamp).toBeNull()
+    })
+
+    it.each([
+      ['ready', 'high'],
+      ['caution', 'medium'],
+      ['not_ready', 'low'],
+    ] as const)('derives confidence_band=%s from decision_quality.level=%s (the real CEE field)', (level, band) => {
+      const response = makeValidResponse({
+        decision_quality: { level, headline: 'x' } as any,
+      })
+      const result = assembleAnalysisInputsSummary(response)
+      expect(result).not.toBeNull()
+      expect(result!.confidence_band).toBe(band)
+    })
+
+    it('falls back to data-availability derivation when decision_quality is absent', () => {
+      const response = makeValidResponse({ decision_quality: undefined })
+      const result = assembleAnalysisInputsSummary(response)
+      expect(result).not.toBeNull()
+      // robustness_status + drivers_status both 'computed' on the default fixture
+      expect(result!.confidence_band).toBe('medium')
+    })
   })
 
   it('returns up to MAX_CONSTRAINTS valid constraints even when empty-label entries appear before them', () => {

--- a/src/canvas/analysis/assembleAnalysisInputsSummary.ts
+++ b/src/canvas/analysis/assembleAnalysisInputsSummary.ts
@@ -8,9 +8,10 @@
  * progressively if the payload exceeds the budget.
  */
 
-import type { V2RunResponse, V2OptionComparison, V2Driver, V2RobustnessActual } from '../../adapters/plot/v2/types'
+import type { V2RunResponse, V2OptionComparison, V2FactorSensitivity, V2RobustnessActual } from '../../adapters/plot/v2/types'
 import type { AnalysisInputsSummary } from '../../types/analysis-inputs-summary'
 import { ANALYSIS_INPUTS_CONTRACT_VERSION } from '../../types/analysis-inputs-summary'
+import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
 
 const MAX_SERIALISED_BYTES = 2048
 const MAX_TOP_DRIVERS = 3
@@ -54,11 +55,16 @@ export function assembleAnalysisInputsSummary(
     win_probability: oc.win_probability as number,
   }))
 
-  // Top drivers — capped at MAX_TOP_DRIVERS
-  const topDrivers = buildTopDrivers(report.drivers, MAX_TOP_DRIVERS)
+  // Top drivers — capped at MAX_TOP_DRIVERS. ROADMAP 1.30b: the V2 wire
+  // never populates the legacy `drivers[]` field (verified against the
+  // captured staging fixture — `drivers: null` while `factor_sensitivity[]`
+  // carries real data); `factor_sensitivity` is the field
+  // useResultsSectionData.ts already treats as the authoritative PLoT v2
+  // driver source.
+  const topDrivers = buildTopDrivers(report.factor_sensitivity, MAX_TOP_DRIVERS)
 
-  // Sensitivity concentration: ratio of top driver contribution to sum of all
-  const sensitivityConcentration = computeSensitivityConcentration(report.drivers)
+  // Sensitivity concentration: ratio of top driver magnitude to sum of all
+  const sensitivityConcentration = computeSensitivityConcentration(report.factor_sensitivity)
 
   // Confidence band — read from decision_quality if available.
   // If decision_quality provides a level, map it; otherwise derive from data availability.
@@ -71,11 +77,14 @@ export function assembleAnalysisInputsSummary(
   // Constraints status — from first option's constraint_analysis
   const constraintsStatus = buildConstraintsStatus(report.option_comparison, MAX_CONSTRAINTS)
 
-  // Run metadata — actual response fields only, no fabrication
+  // Run metadata — actual response fields only, no fabrication. ROADMAP
+  // 1.30b: the V2 wire has no top-level `completed_at` — the real field is
+  // nested at `meta.computed_at` (confirmed against the captured staging
+  // fixture's `plot_response.meta.computed_at`; now typed on V2Meta).
   const runMetadata = {
     seed: report.meta?.seed_used ?? null,
     quality_mode: report.meta?.detail_level ?? null,
-    timestamp: (report as Record<string, unknown>).completed_at as string | null ?? null,
+    timestamp: report.meta?.computed_at ?? null,
   }
 
   let result: AnalysisInputsSummary = {
@@ -119,36 +128,52 @@ function findRecommendation(
   }
 }
 
-function buildTopDrivers(
-  drivers: V2Driver[] | undefined,
-  max: number,
-): AnalysisInputsSummary['top_drivers'] {
-  if (!drivers || drivers.length === 0) return []
-  return drivers.slice(0, max).map(d => ({
-    factor_id: d.node_id,
-    factor_label: d.label,
-    elasticity: d.contribution,
-  }))
+/** Magnitude precedence mirrors normalizeFactorSensitivity (useResultsSectionData.ts):
+ *  elasticity > sensitivity_score > sensitivity > importance_score > 0. */
+function factorMagnitude(fs: V2FactorSensitivity): number {
+  if (typeof fs.elasticity === 'number') return fs.elasticity
+  if (typeof fs.sensitivity_score === 'number') return fs.sensitivity_score
+  if (typeof fs.sensitivity === 'number') return fs.sensitivity
+  if (typeof fs.importance_score === 'number') return fs.importance_score
+  return 0
 }
 
-function computeSensitivityConcentration(drivers: V2Driver[] | undefined): number {
-  if (!drivers || drivers.length === 0) return 0
-  const total = drivers.reduce((sum, d) => sum + Math.abs(d.contribution), 0)
+function buildTopDrivers(
+  factorSensitivity: V2FactorSensitivity[] | undefined,
+  max: number,
+): AnalysisInputsSummary['top_drivers'] {
+  if (!factorSensitivity || factorSensitivity.length === 0) return []
+  return factorSensitivity
+    .map(fs => {
+      const { node_id, label } = normaliseFactorFields(fs as unknown as Record<string, unknown>)
+      return { factor_id: node_id ?? '', factor_label: label ?? '', elasticity: factorMagnitude(fs) }
+    })
+    .filter(d => d.factor_id !== '')
+    .sort((a, b) => Math.abs(b.elasticity) - Math.abs(a.elasticity))
+    .slice(0, max)
+}
+
+function computeSensitivityConcentration(factorSensitivity: V2FactorSensitivity[] | undefined): number {
+  if (!factorSensitivity || factorSensitivity.length === 0) return 0
+  const magnitudes = factorSensitivity.map(fs => Math.abs(factorMagnitude(fs)))
+  const total = magnitudes.reduce((sum, m) => sum + m, 0)
   if (total === 0) return 0
-  const topContribution = Math.abs(drivers[0].contribution)
-  return Math.round((topContribution / total) * 1000) / 1000 // 3 decimal places
+  const topMagnitude = Math.max(...magnitudes)
+  return Math.round((topMagnitude / total) * 1000) / 1000 // 3 decimal places
 }
 
 function deriveConfidenceBand(report: V2RunResponse): AnalysisInputsSummary['confidence_band'] {
-  // Prefer CEE-provided decision quality level when available
+  // Prefer CEE-provided decision quality level when available. ROADMAP
+  // 1.30b: the real field is `decision_quality.level` (DecisionQualityV3 in
+  // types/cee.ts: 'ready' | 'caution' | 'not_ready') — the prior read
+  // checked a non-existent `.overall`, so this branch never fired on any
+  // real response.
   const dq = report.decision_quality
-  if (dq && typeof dq === 'object' && 'overall' in dq) {
-    const overall = (dq as Record<string, unknown>).overall
-    if (typeof overall === 'string') {
-      if (overall === 'strong' || overall === 'high') return 'high'
-      if (overall === 'adequate' || overall === 'medium' || overall === 'moderate') return 'medium'
-      return 'low'
-    }
+  if (dq && typeof dq === 'object' && 'level' in dq) {
+    const level = (dq as Record<string, unknown>).level
+    if (level === 'ready') return 'high'
+    if (level === 'caution') return 'medium'
+    if (level === 'not_ready') return 'low'
   }
   // Fallback: computed robustness + drivers available → medium; else low
   if (report.robustness_status === 'computed' && report.drivers_status === 'computed') {

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -83,7 +83,7 @@ import { MAX_CHIPS_PER_TURN, MAX_SUGGESTED_ACTIONS } from './types'
 import { applyAutoApplyPatch, synthesiseCeeAnalysisReady } from './utils/applyPatch'
 import { applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
 import { loadScenario as loadScenarioFromDb } from '../../services/scenarioService'
-import { applyDraftResult } from '../utils/applyDraftResult'
+import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
 import { getUserId } from '../../lib/supabase'
 import { validateAnalysisReadyContract } from './validateAnalysisReadyContract'
 import { validateResponse, stripRepairLogLines, FALLBACK_TEXT } from './validateResponse'
@@ -3038,6 +3038,14 @@ export function useConversation(): UseConversationReturn {
               {
                 ...v5StoreSnapshot,
                 currentResultsHash: v5StoreSnapshot.results?.hash ?? null,
+                // ROADMAP 1.22: wire the shared backfill helper (writes via
+                // a direct store.setState, not updateNode — see the
+                // V5ApplicatorStore.backfillGoalThreshold doc comment for
+                // why: updateNode's analytical-field-change guard would
+                // otherwise treat CEE echoing its own just-received
+                // threshold back as a user edit and invalidate the fresh
+                // analysis this same turn just set).
+                backfillGoalThreshold: backfillGoalThresholdOntoGoalNode,
               },
               {
                 turnClientId,

--- a/src/components/results/__tests__/InferenceWarningStrip.spec.tsx
+++ b/src/components/results/__tests__/InferenceWarningStrip.spec.tsx
@@ -76,9 +76,11 @@ describe('InferenceWarningStrip', () => {
     expect(strip).toBeInTheDocument()
     const entry = screen.getByTestId('inference-warning-strip-entry')
     expect(entry).toHaveAttribute('data-warning-code', 'CONSTRAINT_TARGET_UNRELIABLE')
-    // V14.3: no code-template match for this code → humaniseCritique's safe
-    // generic fallback title, NOT the raw producer message verbatim.
-    expect(entry).toHaveTextContent("Review this factor's inputs")
+    // ROADMAP 1.12: CONSTRAINT_TARGET_UNRELIABLE now has a CODE_TEMPLATES
+    // entry (humaniseCritique.ts) — a meaningful, code-keyed title, NOT the
+    // raw producer message verbatim and NOT the generic unmapped-code
+    // fallback (superseded by the fix; was "Review this factor's inputs").
+    expect(entry).toHaveTextContent("success target can't be evaluated reliably")
     expect(entry).not.toHaveTextContent(WARNING_CONSTRAINT_TARGET.message as string)
   })
 

--- a/src/components/results/utils/__tests__/humaniseCritique.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.spec.ts
@@ -65,6 +65,34 @@ describe('humaniseCritique', () => {
       const result = humaniseCritique(makeItem({ code: 'EMPTY_COMPUTED_RESULTS' }))
       expect(result.title).toBe('Analysis returned limited results')
     })
+
+    // ROADMAP 1.12 — warning surfacing. CONSTRAINT_TARGET_UNRELIABLE is a
+    // producer WARNING-severity code (PLoT constraint-reliability.ts, lane
+    // P0-C2) naming a goal-fit target whose probabilities were withheld
+    // because the underlying value is unscaled/missing. Before this fix it
+    // had no CODE_TEMPLATES entry, so it fell through to the safe-but-vague
+    // generic fallback ("Review this factor's inputs") — technically honest
+    // but not the meaningful warning the roadmap item calls for.
+    it('CONSTRAINT_TARGET_UNRELIABLE with resolved label', () => {
+      const labels = new Map([['fac_churn', 'Customer churn']])
+      const result = humaniseCritique(
+        makeItem({ code: 'CONSTRAINT_TARGET_UNRELIABLE', affectedNodes: ['fac_churn'] }),
+        labels,
+      )
+      expect(result.title).toContain('Customer churn')
+      expect(result.title).not.toBe("Review this factor's inputs")
+      expect(result.description.length).toBeGreaterThan(0)
+      expect(result.suggestion).toContain('Customer churn')
+      expect(result.factorId).toBe('fac_churn')
+      // Never the raw producer message (V14.3 guard) even though it's mapped.
+      expect(result.title).not.toContain('observed_state')
+      expect(result.title).not.toContain('constraint_fac_churn_max')
+    })
+
+    it('CONSTRAINT_TARGET_UNRELIABLE falls back to "This factor" without a resolved label (no fabricated name)', () => {
+      const result = humaniseCritique(makeItem({ code: 'CONSTRAINT_TARGET_UNRELIABLE', affectedNodes: undefined }))
+      expect(result.title).toContain('This factor')
+    })
   })
 
   describe('unknown code fallback', () => {

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -118,6 +118,18 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
     description: 'Not all factor ranges are derived from the same source. Results may be less consistent.',
     suggestion: 'Review factor data sources',
   }),
+  // ROADMAP 1.12 — warning surfacing. Producer WARNING-severity code (PLoT
+  // constraint-reliability.ts): a goal constraint's target could not be
+  // scaled/evaluated reliably (default-range threshold and/or a defaulted
+  // base), so PLoT withholds goal-fit probabilities for the run rather than
+  // emit a meaningless number. Doctrine rule 6 (defaulted-value disclosure):
+  // names the concrete, actionable fix — set a value/range — never quotes
+  // the withheld number itself.
+  CONSTRAINT_TARGET_UNRELIABLE: (label) => ({
+    title: `${label}'s success target can't be evaluated reliably`,
+    description: 'The value needed to assess this target is missing or unscaled, so goal-fit results were withheld for this run rather than shown as a meaningless number.',
+    suggestion: `Set a value or range for ${label}`,
+  }),
 }
 
 // ─── Internal token detection ────────────────────────────────────────────────

--- a/src/v5/__tests__/applyV5State.test.ts
+++ b/src/v5/__tests__/applyV5State.test.ts
@@ -24,12 +24,16 @@ function makeStore(
   updateEdgeData: ReturnType<typeof vi.fn>
   setRunMeta: ReturnType<typeof vi.fn>
   setCeeAnalysisReady: ReturnType<typeof vi.fn>
+  setGoalConstraints: ReturnType<typeof vi.fn>
+  backfillGoalThreshold: ReturnType<typeof vi.fn>
 } {
   const setCurrentStage = vi.fn()
   const updateNode = vi.fn()
   const updateEdgeData = vi.fn()
   const setRunMeta = vi.fn()
   const setCeeAnalysisReady = vi.fn()
+  const setGoalConstraints = vi.fn()
+  const backfillGoalThreshold = vi.fn()
   return {
     store: {
       setCurrentStage,
@@ -37,6 +41,8 @@ function makeStore(
       updateEdgeData,
       setRunMeta,
       setCeeAnalysisReady,
+      setGoalConstraints,
+      backfillGoalThreshold,
       nodes,
       edges,
     },
@@ -45,6 +51,8 @@ function makeStore(
     updateEdgeData,
     setRunMeta,
     setCeeAnalysisReady,
+    setGoalConstraints,
+    backfillGoalThreshold,
   }
 }
 
@@ -596,6 +604,139 @@ describe('applyV5State — analysis_ready', () => {
     // internally skips setCeeAnalysisReady. Applicator must fill the gap.
     expect(setCeeAnalysisReady).toHaveBeenCalledTimes(1)
     expect(setCeeAnalysisReady.mock.calls[0][0].status).toBe('needs_user_mapping')
+  })
+})
+
+// ROADMAP 1.22 — goal-threshold quad ingestion on the V5 "commit response"
+// path (turns that do NOT flow through applyDraftResult, e.g. follow-up
+// turns on a populated canvas). CEE sends goal_threshold_raw/unit/cap on
+// analysis_ready and goal_constraints at the response root; prior to this
+// fix, applyV5State wrote ceeAnalysisReady (so the bare normalised
+// goal_threshold synced via the store's own setCeeAnalysisReady reducer)
+// but never backfilled goal_threshold_raw/unit/cap onto the goal node's
+// data (read by GoalNode + the debug bundle's full_graph export) and never
+// ingested goal_constraints at all on this path — both showed up all-null
+// in the debug bundle even though CEE persisted real values.
+describe('applyV5State — goal-threshold quad ingestion (ROADMAP 1.22)', () => {
+  const readyOption = {
+    id: 'opt-a',
+    label: 'Option A',
+    status: 'ready',
+    interventions: {},
+  }
+
+  const goalNode = {
+    id: 'goal-1',
+    type: 'goal',
+    position: { x: 0, y: 0 },
+    data: { label: 'Goal', kind: 'goal' },
+  } as unknown as V5ApplicatorStore['nodes'][number]
+
+  function responseWith(
+    analysisReady: Record<string, unknown> | undefined,
+    extra: Record<string, unknown> = {},
+  ): OlumiResponse {
+    return baseResponse({
+      ...(analysisReady !== undefined
+        ? ({ analysis_ready: analysisReady } as unknown as Partial<OlumiResponse>)
+        : {}),
+      ...(extra as unknown as Partial<OlumiResponse>),
+    })
+  }
+
+  // The actual node.data write (and its idempotent / field-presence /
+  // node-existence guards) lives in the shared backfillGoalThresholdOntoGoalNode
+  // helper (applyDraftResult.ts — see applyDraftResult.spec.ts for that
+  // coverage) and is wired at the real call site (useConversation.ts) — NOT
+  // reimplemented here. applyV5State's own contract is just: call the
+  // injected hook with the normalised analysis_ready whenever it sets
+  // ceeAnalysisReady via this (non-inline-owned) branch. Delegating via
+  // store.backfillGoalThreshold rather than store.updateNode is deliberate:
+  // goal_threshold_raw is in ANALYTICAL_NODE_DATA_FIELDS, so updateNode
+  // would treat CEE echoing back its own just-received threshold as a user
+  // edit and invalidate the very analysis this same turn just set fresh.
+  it('calls the injected backfillGoalThreshold hook with the normalised analysis_ready', () => {
+    const { store, backfillGoalThreshold } = makeStore([goalNode])
+    applyV5State(
+      responseWith({
+        status: 'ready',
+        goal_node_id: 'goal-1',
+        options: [readyOption],
+        goal_threshold: 0.8,
+        goal_threshold_raw: 20,
+        goal_threshold_unit: '%',
+        goal_threshold_cap: 25,
+      }),
+      store,
+    )
+
+    expect(backfillGoalThreshold).toHaveBeenCalledWith(
+      expect.objectContaining({
+        goal_node_id: 'goal-1',
+        goal_threshold_raw: 20,
+        goal_threshold_unit: '%',
+        goal_threshold_cap: 25,
+      }),
+    )
+  })
+
+  it('does not call backfillGoalThreshold when analysis_ready is absent', () => {
+    const { store, backfillGoalThreshold } = makeStore([goalNode])
+    applyV5State(responseWith(undefined), store)
+    expect(backfillGoalThreshold).not.toHaveBeenCalled()
+  })
+
+  it('does not call backfillGoalThreshold when analysis_ready fails shape validation', () => {
+    const { store, backfillGoalThreshold } = makeStore([goalNode])
+    applyV5State(
+      responseWith({ status: 'ready', options: [readyOption] /* missing goal_node_id */ }),
+      store,
+    )
+    expect(backfillGoalThreshold).not.toHaveBeenCalled()
+  })
+
+  it('does not call backfillGoalThreshold when the inline-draft path will own the write', () => {
+    const { store, backfillGoalThreshold } = makeStore(/* canvas empty */ [], [])
+    applyV5State(
+      responseWith(
+        { status: 'ready', goal_node_id: 'goal-1', options: [readyOption] },
+        { draft_graph: { nodes: [{}, {}], edges: [], node_count: 2, edge_count: 0 } },
+      ),
+      store,
+    )
+    expect(backfillGoalThreshold).not.toHaveBeenCalled()
+  })
+
+  it('ingests goal_constraints from the response root additively', () => {
+    const { store, setGoalConstraints } = makeStore([goalNode])
+    const constraints = [
+      { constraint_id: 'c1', factor_id: 'f1', label: 'Budget', threshold: 100 },
+    ]
+    applyV5State(
+      responseWith(
+        {
+          status: 'ready',
+          goal_node_id: 'goal-1',
+          options: [readyOption],
+        },
+        { goal_constraints: constraints },
+      ),
+      store,
+    )
+    expect(setGoalConstraints).toHaveBeenCalledWith(constraints)
+  })
+
+  it('does not call setGoalConstraints when the response carries none (additive only — no clearing)', () => {
+    const { store, setGoalConstraints } = makeStore([goalNode])
+    applyV5State(
+      responseWith({
+        status: 'ready',
+        goal_node_id: 'goal-1',
+        options: [readyOption],
+      }),
+      store,
+    )
+    expect(setGoalConstraints).not.toHaveBeenCalled()
   })
 })
 

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -33,7 +33,7 @@ import type { OlumiResponse, StageType } from '@talchain/schemas/boundary'
 import type { Edge, Node } from '@xyflow/react'
 
 import type { ReportV1 } from '../adapters/plot/types'
-import type { CEEAnalysisReady } from '../adapters/cee/types'
+import type { CEEAnalysisReady, CEEGoalConstraint } from '../adapters/cee/types'
 import type { CeeDecisionReviewPayloadV1 } from '../types/cee'
 import type { ScenarioStage } from '../types/scenario'
 import { logV5StateStep } from './debugLog'
@@ -57,6 +57,32 @@ export interface V5ApplicatorStore {
   setRunMeta: (meta: { ceeReviewV1: CeeDecisionReviewPayloadV1 | null }) => void
   /** Write (or clear) the CEE analysis_ready payload that gates the run. */
   setCeeAnalysisReady: (analysisReady: CEEAnalysisReady | null) => void
+  /**
+   * Optional: write goal_constraints (ROADMAP 1.22). CEE places these at the
+   * response root on the V5 "commit response" path — additive only, this
+   * applicator never clears a prior turn's constraints on this slot (mirrors
+   * the V4 envelope path's ADD semantics but without its clear-on-empty-patch
+   * behaviour, which has no V5 equivalent signal to gate on).
+   */
+  setGoalConstraints?: (constraints: CEEGoalConstraint[] | null) => void
+  /**
+   * Optional: backfill goal_threshold_raw/unit/cap onto the goal node's data
+   * (ROADMAP 1.22). Wired at the real call site to the shared
+   * `backfillGoalThresholdOntoGoalNode` helper (applyDraftResult.ts) — that
+   * helper writes via a direct store.setState, NOT store.updateNode, because
+   * `goal_threshold_raw` is in ANALYTICAL_NODE_DATA_FIELDS (analyticalChange.ts):
+   * routing this backfill through updateNode would treat CEE echoing back the
+   * threshold on its OWN just-received analysis_ready as a user edit and
+   * invalidate the very analysis this applicator just marked fresh two lines
+   * above. Injected (rather than called as a bare import) so applyV5State's
+   * own unit tests stay isolated from the real canvas store.
+   */
+  backfillGoalThreshold?: (analysisReady: {
+    goal_node_id?: string
+    goal_threshold_raw?: number | null
+    goal_threshold_unit?: string | null
+    goal_threshold_cap?: number | null
+  }) => void
   /** Optional: update the freshness slice from a raw response.analysis_ready (retain / order / never absence→fresh). */
   setAnalysisFreshness?: (rawAnalysisReady: unknown) => void
   /** Optional: clear the local dirty overlay when a genuinely new analysis run completes (new analysis_result response_hash). */
@@ -522,6 +548,19 @@ export function applyV5State(
   // Freshness slice: retain on absence, order by computed_at, never absence→fresh.
   // Independent of ceeAnalysisReady (which clears on analyse-turns-without-analysis_ready).
   store.setAnalysisFreshness?.(rawAnalysisReady)
+
+  // ROADMAP 1.22 — goal_constraints at the response root. CEE places these
+  // outside analysis_ready (mirrors the V4 envelope path at
+  // useConversation.ts:2376+); goal_constraints is an untyped passthrough
+  // field on OlumiResponse (not in @talchain/schemas), so it is read via
+  // duck-typing. Additive only — a turn with no constraints does not clear
+  // a prior turn's, since (unlike the V4 path) this applicator has no
+  // "a new graph patch was applied" signal to gate a clear on.
+  const rawGoalConstraints = (response as { goal_constraints?: unknown }).goal_constraints
+  if (Array.isArray(rawGoalConstraints) && rawGoalConstraints.length > 0) {
+    store.setGoalConstraints?.(rawGoalConstraints as CEEGoalConstraint[])
+    applied.push('goal_constraints:set')
+  }
   if (rawAnalysisReady !== undefined) {
     const normalised = normaliseV5AnalysisReady(rawAnalysisReady)
     if (normalised) {
@@ -536,6 +575,18 @@ export function applyV5State(
           output_keys: ['ceeAnalysisReady'],
           applied: true,
         })
+
+        // ROADMAP 1.22 — backfill goal_threshold_raw/unit/cap onto the goal
+        // node's data. setCeeAnalysisReady above already syncs the bare
+        // normalised goal_threshold into store.goalThreshold (store.ts
+        // reducer), but GoalNode + the debug bundle's full_graph export read
+        // raw/unit/cap from node.data directly (mirrors
+        // backfillGoalThresholdOntoGoalNode, the applyDraftResult/
+        // mirrorAnalysisReady equivalent for the inline-draft and
+        // graph_patch-block paths — this is the V5 top-level-response
+        // equivalent, which had no backfill at all before this fix).
+        store.backfillGoalThreshold?.(normalised)
+        applied.push('analysis_ready:goal_threshold_backfill_requested')
       } else {
         logV5StateStep({
           step_number: 4,
@@ -729,3 +780,4 @@ function isStaleTurn(options?: ApplyV5StateOptions): boolean {
   if (!current || !incoming) return false
   return incoming !== current
 }
+


### PR DESCRIPTION
## Summary

Three independent honesty/ingestion fixes, each RED-first with its own commit.

**Fix 1 — ROADMAP 1.22: goal-threshold quad ingestion on the commit-response path**
`applyV5State`'s step 4 (the catch-all for V5 turns that don't flow through `applyDraftResult` — e.g. follow-up turns on a populated canvas) wrote `ceeAnalysisReady` but never backfilled `goal_threshold_raw/unit/cap` onto the goal node's data (read by `GoalNode` + the debug bundle's `full_graph` export), and never ingested `goal_constraints` at all. Both showed up all-null in the debug bundle even though CEE persisted real values on the wire.

- Additive `goal_constraints` ingestion from the response root.
- Wires the *existing* `backfillGoalThresholdOntoGoalNode` helper (already used by the inline-draft and graph_patch-block paths) via an injected store hook — **not** `store.updateNode`, because `goal_threshold_raw` is in `ANALYTICAL_NODE_DATA_FIELDS`: routing through `updateNode` would make CEE echoing its own just-received threshold back look like a user edit and invalidate the very analysis this same turn just marked fresh. Caught this in self-review after the first pass used `updateNode`; corrected before push.

**Fix 2 — ROADMAP 1.12: humanise CONSTRAINT_TARGET_UNRELIABLE warnings**
Producer WARNING-severity `inference_warnings` (e.g. `CONSTRAINT_TARGET_UNRELIABLE`, PLoT `constraint-reliability.ts` lane P0-C2) were already ingested end-to-end and mounted via `InferenceWarningStrip`, but had no `humaniseCritique` `CODE_TEMPLATES` entry — falling through to the generic fallback ("Review this factor's inputs"). Adds a code-keyed template (doctrine rule 6: names the concrete fix, never quotes the withheld number) to the shared code map consumed by every critique surface.

**Fix 3 — ROADMAP 1.30b: wire-accurate `assembleAnalysisInputsSummary` reads**
Three structurally-empty reads, verified against the captured staging fixture (`src/test/fixtures/golden-path-staging-2026-04-05.json`):
- `top_drivers`/`sensitivity_concentration` read the legacy `drivers[]` field, which the wire never populates (`drivers: null` in the fixture) — real driver data ships as `factor_sensitivity[]`, already the authoritative source elsewhere in the app.
- `run_metadata.timestamp` read a top-level `completed_at` that has never existed on the V2 wire — the real field is nested at `meta.computed_at` (now typed on `V2Meta`).
- `deriveConfidenceBand` checked `decision_quality.overall`, a field that doesn't exist on `DecisionQualityV3` — the real field is `.level` (`'ready' | 'caution' | 'not_ready'`), which the function's *own* doc comment already said to use. This branch never fired on any real response.

## Test plan
- [x] RED confirmed for every fix before implementing (failing assertions captured pre-fix)
- [x] Targeted suites green post-fix (`applyV5State.test.ts` 38/38, `humaniseCritique`/`InferenceWarningStrip` specs, `assembleAnalysisInputsSummary.spec.ts` 29/29)
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` — 0 errors (pre-existing warning baseline unchanged)
- [x] Full local suite: **1050 files / 15,799 tests passed, 0 failed** (66 skipped, matches baseline)
- [x] Remote branch tip verified via `git ls-remote` against local `HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)