### PR TITLE
fix(model-tab): factor cards read producer influence_score, not elasticity (ROADMAP 1.7)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -53,7 +53,7 @@ import { dockHostsOlumi } from './olumiSurface'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { focusFloating } from '../hooks/useFloatingFocus'
 import { isV5Eligible } from '../../v5/eligibility'
-import { countFactorsToVerify } from './model-tab/utils'
+import { countFactorsToVerify, deriveFactorInfluenceMap } from './model-tab/utils'
 import { getGoalDirection } from '../utils/getObjectiveText'
 import { deriveVerdict } from '../utils/interpretOutcome'
 import { useDebugShortcut } from '../hooks/useDebugShortcut'
@@ -1125,20 +1125,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
 
   const ceeQuality = useCanvasStore(s => s.ceeQuality)
 
-  const factorInfluenceMap = useMemo(() => {
-    const factors =
-      (report as any)?.enrichment?.sensitivity_analysis?.factors ??
-      (report as any)?.factor_sensitivity ??
-      []
-    if (!Array.isArray(factors) || factors.length === 0) return undefined
-    const map = new Map<string, number>()
-    for (const f of factors) {
-      const id: string | undefined = f.factor_id ?? f.factorId ?? f.node_id ?? f.nodeId
-      const score: number | undefined = f.elasticity ?? f.sensitivity_score ?? f.importance_score
-      if (id && score !== undefined) map.set(id, score)
-    }
-    return map.size > 0 ? map : undefined
-  }, [report])
+  // ROADMAP 1.7: influence_score (producer-owned, ISL/PLoT) takes priority
+  // over elasticity/sensitivity_score/importance_score — see
+  // deriveFactorInfluenceMap doctrine comment (model-tab/utils.ts).
+  const factorInfluenceMap = useMemo(() => deriveFactorInfluenceMap(report), [report])
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/src/canvas/components/model-tab/__tests__/deriveFactorInfluenceMap.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/deriveFactorInfluenceMap.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * deriveFactorInfluenceMap — unit tests (ROADMAP 1.7, honest-render tail).
+ *
+ * OutputsDock feeds this map into FactorsSection's "factor cards sorted by
+ * influence" (model-tab). Before this fix the inline useMemo built the score
+ * from `elasticity ?? sensitivity_score ?? importance_score` only — the
+ * legacy sensitivity-flavoured measures — and never looked at the
+ * producer's `influence_score` (roadmap 1.7; provisional_doctrine_v0:
+ * influence ≠ sensitivity, same distinction already honoured by
+ * mapV5AnalysisToReport / useNodeDisplayMetadata / useResultsSectionData).
+ *
+ * Consequence: a pinned/intervention-overridden factor carries
+ * sensitivity=0 (options fix its value, so perturbing it moves nothing) but
+ * can carry the producer's HIGHEST influence_score (it is structurally the
+ * most causally important factor — the model just isn't free to vary it).
+ * The old code rendered that factor's card at 0% influence — the opposite
+ * of what the producer said.
+ *
+ * Fixture: real staging capture (v5-analysis-result.bundle-45c9b625,
+ * enrichment.factor_sensitivity) — same fixture already locked by
+ * src/v5/__tests__/mapV5AnalysisToReport.influence-warnings.spec.ts for the
+ * mapper layer. fac_marketing_expertise is the real reproduction: rank 1,
+ * influence_score 1, sensitivity_score/elasticity both 0,
+ * zero_reason intervention_override.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { deriveFactorInfluenceMap } from '../utils'
+
+import bundleFixture from '../../../../v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json'
+
+describe('deriveFactorInfluenceMap', () => {
+  it('prefers the producer influence_score over elasticity/sensitivity_score for a pinned factor', () => {
+    const factorSensitivity = (bundleFixture.block as { enrichment: { factor_sensitivity: unknown[] } })
+      .enrichment.factor_sensitivity
+
+    const map = deriveFactorInfluenceMap({ factor_sensitivity: factorSensitivity })
+
+    expect(map).toBeDefined()
+    // Rank-1 producer influence, but sensitivity/elasticity are BOTH zero
+    // (intervention_override) — the old elasticity-first code would read 0.
+    expect(map!.get('fac_marketing_expertise')).toBe(1)
+    // Rank-4 and rank-5 factors are ALSO pinned (zero_reason
+    // intervention_override) — same failure mode, different magnitudes.
+    expect(map!.get('fac_manager_cost')).toBeCloseTo(0.45161290322580644)
+    expect(map!.get('fac_ad_spend')).toBeCloseTo(0.14516129032258066)
+    // A non-pinned factor's influence_score still wins over its own
+    // elasticity (they happen to be equal here, but the read must come
+    // from influence_score, not elasticity, per doctrine).
+    expect(map!.get('fac_market_receptivity')).toBeCloseTo(0.6209677419354838)
+  })
+
+  it('falls back to elasticity/sensitivity_score/importance_score when influence_score is absent (legacy shape)', () => {
+    const map = deriveFactorInfluenceMap({
+      factor_sensitivity: [
+        { factor_id: 'fac_legacy_elasticity', elasticity: 0.4 },
+        { factor_id: 'fac_legacy_sensitivity', sensitivity_score: 0.25 },
+        { factor_id: 'fac_legacy_importance', importance_score: 0.1 },
+      ],
+    })
+
+    expect(map!.get('fac_legacy_elasticity')).toBe(0.4)
+    expect(map!.get('fac_legacy_sensitivity')).toBe(0.25)
+    expect(map!.get('fac_legacy_importance')).toBe(0.1)
+  })
+
+  it('reads from enrichment.sensitivity_analysis.factors when factor_sensitivity is absent', () => {
+    const map = deriveFactorInfluenceMap({
+      enrichment: {
+        sensitivity_analysis: {
+          factors: [{ factor_id: 'fac_alt_path', influence_score: 0.77 }],
+        },
+      },
+    })
+
+    expect(map!.get('fac_alt_path')).toBeCloseTo(0.77)
+  })
+
+  it('returns undefined for an empty or malformed report (no fabrication)', () => {
+    expect(deriveFactorInfluenceMap(undefined)).toBeUndefined()
+    expect(deriveFactorInfluenceMap({})).toBeUndefined()
+    expect(deriveFactorInfluenceMap({ factor_sensitivity: [] })).toBeUndefined()
+  })
+})

--- a/src/canvas/components/model-tab/utils.ts
+++ b/src/canvas/components/model-tab/utils.ts
@@ -106,3 +106,47 @@ export function countFactorsToVerify(factorNodes: ReadonlyArray<{ data: unknown 
 // ── Strength semantic labels ──────────────────────────────────────────────────
 // Re-export from strengthBands.ts (canonical thresholds from validation_ui_data_contract_v1.1).
 export { getStrengthLabel as strengthSemanticLabel } from './strengthBands'
+
+// ── Factor influence (model-tab factor cards) ───────────────────────────────
+
+/**
+ * Derive a factor_id → influence score map for the model-tab "factor cards
+ * sorted by influence" (FactorsSection). ROADMAP 1.7 (provisional_doctrine_v0):
+ * `influence_score` (producer-owned, ISL/PLoT) is a DISTINCT measure from
+ * sensitivity/elasticity — a pinned/intervention-overridden factor can carry
+ * sensitivity 0 (options fix its value, so perturbing it moves nothing) while
+ * still being the model's single most causally influential factor. Reading
+ * elasticity/sensitivity_score/importance_score FIRST (the pre-fix
+ * behaviour) rendered those factors' cards at 0%, the opposite of what the
+ * producer said.
+ *
+ * Priority mirrors the doctrine already applied at
+ * useNodeDisplayMetadata.ts / mapV5AnalysisToReport.ts / useResultsSectionData.ts:
+ * influence_score (0-1, direct) before the legacy elasticity-flavoured
+ * fallbacks. Additive read only — never derived, never defaulted; a factor
+ * with no usable score is simply absent from the map.
+ */
+export function deriveFactorInfluenceMap(report: unknown): Map<string, number> | undefined {
+  if (report == null || typeof report !== 'object') return undefined
+  const r = report as Record<string, unknown>
+  const enrichment = r.enrichment as Record<string, unknown> | undefined
+  const sensitivityAnalysis = enrichment?.sensitivity_analysis as Record<string, unknown> | undefined
+  const factors = (sensitivityAnalysis?.factors as unknown[] | undefined) ??
+    (r.factor_sensitivity as unknown[] | undefined) ??
+    []
+  if (!Array.isArray(factors) || factors.length === 0) return undefined
+
+  const map = new Map<string, number>()
+  for (const raw of factors) {
+    if (raw == null || typeof raw !== 'object') continue
+    const f = raw as Record<string, unknown>
+    const id = (f.factor_id ?? f.factorId ?? f.node_id ?? f.nodeId) as string | undefined
+    const score = (f.influence_score ?? f.influenceScore ?? f.elasticity ?? f.sensitivity_score ?? f.importance_score) as
+      | number
+      | undefined
+    if (id && typeof score === 'number' && Number.isFinite(score)) {
+      map.set(id, score)
+    }
+  }
+  return map.size > 0 ? map : undefined
+}


### PR DESCRIPTION
## Summary
- OutputsDock's factor-card influence map (`FactorsSection`, sorted by influence) built its score from `elasticity ?? sensitivity_score ?? importance_score` only — never `influence_score`, the producer-owned field the mapper/hook/DriversSection layers already prioritise (`provisional_doctrine_v0: influence != sensitivity`).
- A pinned/intervention-overridden factor carries `sensitivity 0` (options fix its value, so perturbing it moves nothing structurally) while still being the model's single most causally influential factor per `influence_score`. The old read rendered that factor's card at 0% influence — the opposite of what the producer said. Real staging fixture (`bundle-45c9b625`) reproduces it directly: `fac_marketing_expertise` is rank 1 with `influence_score 1`, but `elasticity`/`sensitivity_score` are both 0.
- Extracted the map-building logic to `deriveFactorInfluenceMap` (`model-tab/utils.ts`) so it is unit-testable without rendering `OutputsDock`, matching the doctrine already codified at `useNodeDisplayMetadata.ts` / `mapV5AnalysisToReport.ts` / `useResultsSectionData.ts`.
- `DriversSection`, `FactorNode` canvas cards, and `NodeInspector`'s `ImportanceBar` were independently verified already correct (they read `influence_score` via `useNodeDisplayMetadata`/`useResultsSectionData`) — this was the one remaining "factor card" render site still on the elasticity-first read.

## Test plan
- [x] RED-first: new `deriveFactorInfluenceMap.spec.ts` fails against `main` (function doesn't exist), passes once the extraction lands.
- [x] Fast gate (`scripts/validate-prepush.sh`, typecheck + lint + 8-file smoke) — PASS, ran automatically on push.
- [x] Full gate (`scripts/pre-push-validate.sh`, bail=1) — PASS.
- [x] Full non-bail suite run (`npx vitest run`, no bail) for genuine-green verification: 9 failed test files / 52 failed tests, all in `src/canvas/conversation/__tests__/` (turn/orchestrator flow), **none touching the changed files**. Confirmed identical pre-existing failure cluster reproduces on a clean `origin/staging` checkout (12 failed files / 59 failed tests that run — same core set plus a few additional flaky files), so this is order-dependent pre-existing test-isolation flakiness, not a regression from this change.
- [x] `deriveFactorInfluenceMap.spec.ts` (4 tests) and all `OutputsDock`/`model-tab` suites pass cleanly on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)