### PR TITLE
fix(canvas): sync Hero-set goal threshold to CEE so Goal fit unlocks

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -769,12 +769,25 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     if (canonical) {
       const dispatch = useGuidanceStore.getState()._dispatchAction
       if (dispatch) {
+        // ROADMAP 1.1 fix: the Hero's Success-target field (pre-analysis-v3
+        // HeroSection::commitSuccess) commits a LOCAL-ONLY canvas-store write
+        // (setGoalThresholdAndUpdateNode) — it never round-trips to CEE. This
+        // plain "Analyse first pass" dispatch used to omit `parameters`
+        // entirely, so CEE ran analysis against its own server-side graph,
+        // which never learned the Hero's threshold, and Goal fit could never
+        // unlock from the Hero alone (6b-goal-capture evidence, clause 2).
+        // Fix: thread goal_threshold the same way handleApplyThreshold
+        // already does below (same store field, same wire parameter, same
+        // CEE-accepted shape — no new field invented), keyed off the
+        // canvas-store snapshot taken above so it reflects the latest commit.
+        const goalThreshold = storeState.goalThreshold
         // Fire-and-forget — the dispatcher streams the response and
         // routeV5Response handles all state mutations. We deliberately do
         // NOT await: the OutputsDock UI subscribes to canvas store status
         // for spinner state.
         dispatch({
           action_type: 'run_analysis',
+          parameters: goalThreshold !== null ? { goal_threshold: goalThreshold } : undefined,
           label: 'Run analysis',
           message: 'Run analysis',
           source: 'chip',

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -237,6 +237,52 @@ describe('OutputsDock analyse convergence', () => {
       expect(runV2Analysis).not.toHaveBeenCalled()
     })
 
+    // ROADMAP 1.1 fix (6b-goal-capture evidence, clause 2): the Hero's
+    // Success-target field commits a canvas-store-only write
+    // (setGoalThresholdAndUpdateNode → store.goalThreshold). Before this fix,
+    // the canonical run_analysis dispatch never carried `parameters`, so CEE
+    // ran analysis against its own server-side graph — which never learned
+    // the Hero's threshold — and Goal fit could never unlock from the Hero
+    // alone. This asserts the dispatch now threads goal_threshold the same
+    // way handleApplyThreshold already does (same store field, same wire
+    // shape, no new field invented).
+    it('threads store.goalThreshold onto the dispatch parameters (Hero-set target reaches CEE)', () => {
+      const dispatchAction = vi.fn()
+      const runV2Analysis = vi.fn()
+      mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
+      mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
+      mockIsV5Eligible.mockReturnValue({ eligible: true } as any)
+
+      useCanvasStore.setState({ goalThreshold: 15 } as any)
+      useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
+
+      renderOutputsDock()
+      fireEvent.click(screen.getByTestId('outputs-run-button'))
+
+      expect(dispatchAction).toHaveBeenCalledTimes(1)
+      const call = dispatchAction.mock.calls[0][0]
+      expect(call.action_type).toBe('run_analysis')
+      expect(call.parameters).toEqual({ goal_threshold: 15 })
+    })
+
+    it('omits parameters when no goal threshold is set (does not invent a value)', () => {
+      const dispatchAction = vi.fn()
+      const runV2Analysis = vi.fn()
+      mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
+      mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
+      mockIsV5Eligible.mockReturnValue({ eligible: true } as any)
+
+      useCanvasStore.setState({ goalThreshold: null } as any)
+      useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
+
+      renderOutputsDock()
+      fireEvent.click(screen.getByTestId('outputs-run-button'))
+
+      expect(dispatchAction).toHaveBeenCalledTimes(1)
+      const call = dispatchAction.mock.calls[0][0]
+      expect(call.parameters).toBeUndefined()
+    })
+
     it('falls back to direct V2 when canonical flag is off (control case)', () => {
       const dispatchAction = vi.fn()
       const runV2Analysis = vi.fn()

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -63,7 +63,22 @@ export const GoalNode = memo((props: NodeProps) => {
     return { stability, level }
   }, [report, isPostAnalysis])
 
-  const thresholdRaw = props.data?.goal_threshold_raw as string | number | null | undefined
+  // ROADMAP 1.1 fix (6b-goal-capture evidence, finding b): the pre-analysis-v3
+  // Hero's Success-target field commits via setGoalThresholdAndUpdateNode,
+  // which writes `success_threshold` + `threshold_source: 'user'` onto the
+  // goal node's data (see computeSuccessState.ts, the Hero's own selector,
+  // which already treats this as the highest-priority "is set" signal). This
+  // node's badge previously checked `goal_threshold_raw` ONLY — a CEE-backfilled
+  // field (applyDraftResult.ts) that a Hero-only commit never populates — so
+  // the canvas badge kept reading "no target" even after the Hero (or a
+  // reconciled CEE round-trip) set one. Mirror computeSuccessState's priority:
+  // a user-set success_threshold counts as "set" first; fall back to the
+  // CEE-derived goal_threshold_raw.
+  const userThreshold = props.data?.threshold_source === 'user'
+    ? (props.data?.success_threshold as number | null | undefined)
+    : undefined
+  const ceeThresholdRaw = props.data?.goal_threshold_raw as string | number | null | undefined
+  const thresholdRaw = userThreshold != null ? userThreshold : ceeThresholdRaw
   const thresholdUnit = props.data?.goal_threshold_unit as string | undefined
   const hasThreshold = thresholdRaw != null && String(thresholdRaw).trim() !== ''
 

--- a/src/canvas/nodes/__tests__/GoalNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/GoalNode.spec.tsx
@@ -355,6 +355,35 @@ describe('GoalNode', () => {
     expect(screen.getByText(/Help me set a target/)).toBeDefined()
   })
 
+  // ROADMAP 1.1 fix (6b-goal-capture evidence, finding b): the pre-analysis-v3
+  // Hero's Success-target field writes `success_threshold` +
+  // `threshold_source: 'user'` onto the goal node's data (setGoalThresholdAndUpdateNode)
+  // — never `goal_threshold_raw` (that field is CEE-backfilled only, see
+  // applyDraftResult.ts). The badge previously checked goal_threshold_raw
+  // ONLY, so it kept reading "no target" even after the Hero set one. This
+  // mirrors the Hero's own selector (computeSuccessState.ts), which already
+  // treats a user-set success_threshold as "set".
+  it('treats a Hero-set success_threshold (threshold_source=user) as a set target, no goal_threshold_raw needed', () => {
+    renderGoal({ success_threshold: 15, threshold_source: 'user', goal_threshold_raw: null })
+    expect(screen.getByText(/Target:/)).toBeDefined()
+    expect(screen.queryByText(/Help me set a target/)).toBeNull()
+  })
+
+  it('post-analysis: Hero-set success_threshold suppresses the "Analysis complete. Set a target" badge', () => {
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeStoreState({ results: { status: 'complete', report: {} } }) as any)
+    )
+    renderGoal({ success_threshold: 15, threshold_source: 'user', goal_threshold_raw: null })
+    expect(screen.queryByText('Analysis complete. Set a target to see your chances.')).toBeNull()
+    expect(screen.getByText(/Target:/)).toBeDefined()
+  })
+
+  it('does not treat success_threshold as set when threshold_source is not user (e.g. CEE default)', () => {
+    renderGoal({ success_threshold: 15, threshold_source: undefined, goal_threshold_raw: null })
+    expect(screen.queryByText(/Target:/)).toBeNull()
+    expect(screen.getByText(/Help me set a target/)).toBeDefined()
+  })
+
   // P0.3: Provenance icons removed in v1.1 — verify target still renders with brief source
   it('renders target value when source is brief_extraction (provenance icon removed in v1.1)', () => {
     renderGoal({ observedState: { source: 'brief_extraction' }, goal_threshold_raw: 100, goal_threshold_unit: '%' })


### PR DESCRIPTION
## Summary
- ROADMAP 1.1 / Gate 3 blocker (`acceptance-evidence/6b-goal-capture/00-SUMMARY.md`): the pre-analysis-v3 Hero's Success-target field commits a canvas-store-only write that never reaches CEE, and the plain "Analyse first pass" `run_analysis` chip dispatch carried no `parameters` at all — so Goal fit could never unlock from the Hero alone.
- Fix threads `store.goalThreshold` onto the canonical `run_analysis` dispatch (`OutputsDock.tsx::runCanonicalAnalysis`) the same way the older, unwired `handleApplyThreshold` path already does — same store field, same `parameters: { goal_threshold }` wire shape CEE already accepts. No new field invented.
- Also fixes the canvas goal-node badge staying "Help me set a target" after a Hero commit (evidence finding b): `GoalNode.tsx`'s `hasThreshold` only read the CEE-backfilled `goal_threshold_raw` field, never the Hero's own `success_threshold` + `threshold_source: 'user'` write. Mirrors the priority `computeSuccessState.ts` already uses for the Hero's own display.

## Test plan
- [x] RED-first: reverted each fix in isolation, confirmed the new tests fail without it, restored, confirmed green.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only, none in touched files).
- [x] `npx vitest run --changed --bail=1` — 243 passed.
- [ ] Live Playwright re-run of the 6b-goal-capture harness against deployed staging (fresh disposable scenario) — post-merge, evidence in `acceptance-evidence/6b-goal-capture/RETEST/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)