### PR TITLE
fix(canvas): correct ROADMAP 1.1 fix — Hero target syncs via add_constraint

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -769,25 +769,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     if (canonical) {
       const dispatch = useGuidanceStore.getState()._dispatchAction
       if (dispatch) {
-        // ROADMAP 1.1 fix: the Hero's Success-target field (pre-analysis-v3
-        // HeroSection::commitSuccess) commits a LOCAL-ONLY canvas-store write
-        // (setGoalThresholdAndUpdateNode) — it never round-trips to CEE. This
-        // plain "Analyse first pass" dispatch used to omit `parameters`
-        // entirely, so CEE ran analysis against its own server-side graph,
-        // which never learned the Hero's threshold, and Goal fit could never
-        // unlock from the Hero alone (6b-goal-capture evidence, clause 2).
-        // Fix: thread goal_threshold the same way handleApplyThreshold
-        // already does below (same store field, same wire parameter, same
-        // CEE-accepted shape — no new field invented), keyed off the
-        // canvas-store snapshot taken above so it reflects the latest commit.
-        const goalThreshold = storeState.goalThreshold
         // Fire-and-forget — the dispatcher streams the response and
         // routeV5Response handles all state mutations. We deliberately do
         // NOT await: the OutputsDock UI subscribes to canvas store status
         // for spinner state.
         dispatch({
           action_type: 'run_analysis',
-          parameters: goalThreshold !== null ? { goal_threshold: goalThreshold } : undefined,
           label: 'Run analysis',
           message: 'Run analysis',
           source: 'chip',

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -237,52 +237,6 @@ describe('OutputsDock analyse convergence', () => {
       expect(runV2Analysis).not.toHaveBeenCalled()
     })
 
-    // ROADMAP 1.1 fix (6b-goal-capture evidence, clause 2): the Hero's
-    // Success-target field commits a canvas-store-only write
-    // (setGoalThresholdAndUpdateNode → store.goalThreshold). Before this fix,
-    // the canonical run_analysis dispatch never carried `parameters`, so CEE
-    // ran analysis against its own server-side graph — which never learned
-    // the Hero's threshold — and Goal fit could never unlock from the Hero
-    // alone. This asserts the dispatch now threads goal_threshold the same
-    // way handleApplyThreshold already does (same store field, same wire
-    // shape, no new field invented).
-    it('threads store.goalThreshold onto the dispatch parameters (Hero-set target reaches CEE)', () => {
-      const dispatchAction = vi.fn()
-      const runV2Analysis = vi.fn()
-      mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
-      mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
-      mockIsV5Eligible.mockReturnValue({ eligible: true } as any)
-
-      useCanvasStore.setState({ goalThreshold: 15 } as any)
-      useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
-
-      renderOutputsDock()
-      fireEvent.click(screen.getByTestId('outputs-run-button'))
-
-      expect(dispatchAction).toHaveBeenCalledTimes(1)
-      const call = dispatchAction.mock.calls[0][0]
-      expect(call.action_type).toBe('run_analysis')
-      expect(call.parameters).toEqual({ goal_threshold: 15 })
-    })
-
-    it('omits parameters when no goal threshold is set (does not invent a value)', () => {
-      const dispatchAction = vi.fn()
-      const runV2Analysis = vi.fn()
-      mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
-      mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
-      mockIsV5Eligible.mockReturnValue({ eligible: true } as any)
-
-      useCanvasStore.setState({ goalThreshold: null } as any)
-      useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
-
-      renderOutputsDock()
-      fireEvent.click(screen.getByTestId('outputs-run-button'))
-
-      expect(dispatchAction).toHaveBeenCalledTimes(1)
-      const call = dispatchAction.mock.calls[0][0]
-      expect(call.parameters).toBeUndefined()
-    })
-
     it('falls back to direct V2 when canonical flag is off (control case)', () => {
       const dispatchAction = vi.fn()
       const runV2Analysis = vi.fn()

--- a/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
@@ -438,6 +438,43 @@ describe('no silent failures (diagnose-and-fix pass)', () => {
     expect(screen.getByText('Saved')).toBeInTheDocument()
   })
 
+  // ROADMAP 1.1 fix (Gate 3 blocker, acceptance-evidence/6b-goal-capture):
+  // the Hero's success-target commit above is a LOCAL-ONLY canvas-store
+  // write — it never reached CEE, so a later "Analyse first pass" ran
+  // against CEE's own server-side graph (no threshold) and Goal fit never
+  // unlocked. Saving success must also sync the target to CEE via the same
+  // add_constraint mechanism the working chat path already proves out
+  // (6B evidence clause 3), silently (hidden: true — no chat bubble, since
+  // the user already confirmed via the Hero's own Save button).
+  it('saving a success target also syncs it to CEE via a hidden add_constraint dispatch', () => {
+    const dispatchAction = vi.fn()
+    useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
+    renderPanel()
+    const input = screen.getByLabelText('Success measure')
+    fireEvent.change(input, { target: { value: 'ship 25% faster' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save success' }))
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1)
+    const call = dispatchAction.mock.calls[0][0]
+    expect(call.action_type).toBe('add_constraint')
+    expect(call.source).toBe('chip')
+    expect(call.hidden).toBe(true)
+    expect(typeof call.parameters?.description).toBe('string')
+    expect(call.parameters.description.length).toBeGreaterThan(0)
+    // The descriptive text the user typed should ride along verbatim so
+    // Sonnet has the richest signal to interpret into a real constraint.
+    expect(call.message).toContain('ship 25% faster')
+  })
+
+  it('does not throw when saving a success target with no _dispatchAction registered (graceful degradation)', () => {
+    useGuidanceStore.setState({ _dispatchAction: null } as any)
+    renderPanel()
+    const input = screen.getByLabelText('Success measure')
+    fireEvent.change(input, { target: { value: '25' } })
+    expect(() => fireEvent.click(screen.getByRole('button', { name: 'Save success' }))).not.toThrow()
+    expect(useCanvasStore.getState().goalThreshold).toBe(25)
+  })
+
   it('rows without a value get an Add value affordance, no check tick, and the meta counts them', () => {
     useCanvasStore.setState({
       nodes: [

--- a/src/canvas/components/pre-analysis-v3/hero/HeroSection.tsx
+++ b/src/canvas/components/pre-analysis-v3/hero/HeroSection.tsx
@@ -14,6 +14,7 @@ import { Sparkles } from 'lucide-react'
 import Tooltip from '../../../../components/Tooltip'
 import { typography } from '../../../../styles/typography'
 import { useCanvasStore } from '../../../store'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
 import { NodeShapeIndicator } from '../../../nodes/NodeShapeIndicator'
 import { Pill } from '../../pre-analysis/primitives/Pill'
 import { ATTRIBUTION_COPY, FIELD_FEEDBACK_COPY, HERO_COPY, SPARK_PROMPTS } from '../constants'
@@ -78,9 +79,52 @@ export const HeroSection = memo(function HeroSection({
       const parsed = parseDisplayNumber(raw)
       if (parsed === null) return FIELD_FEEDBACK_COPY.successFormatHint
       useCanvasStore.getState().setGoalThresholdAndUpdateNode(goalNodeId, parsed)
+
+      // ROADMAP 1.1 fix (Gate 3 blocker, acceptance-evidence/6b-goal-capture):
+      // the store write above is LOCAL-ONLY — CEE never learns this target,
+      // so run_analysis (which reads goal_constraints off its OWN server-side
+      // scenario graph, never off anything the client sends — confirmed in
+      // olumi-assistants-service's chip-click-dispatch.ts header comment)
+      // computes goal-fit against a graph with no threshold, and Goal fit
+      // never unlocks. There is no deterministic/structured wire call for
+      // this — `add_constraint`'s handler only accepts parameters that
+      // Sonnet's own ORIENT step produced from a natural-language message
+      // (see add-constraint.ts's resolveParams reading invocation.proposal.
+      // parameters, not the client's chip.parameters). The chat path already
+      // proves this works (6B evidence clause 3): a plain-language message
+      // gets interpreted into a real add_constraint graph_patch. Reuse that
+      // exact mechanism — same action_type, same free-text-description
+      // shape SuccessTarget.tsx already sends (the older, non-v3 panel) —
+      // instead of inventing a new one. `hidden: true` keeps this a silent
+      // background sync (no chat bubble) since the user already "confirmed"
+      // via the Hero's own Save-success button, not the composer.
+      const dispatch = useGuidanceStore.getState()._dispatchAction
+      if (dispatch) {
+        const trimmed = raw.trim()
+        // The user's own text is often already a full sentence (e.g. "Reduce
+        // annual operating costs by at least 15%") — prefer it verbatim so
+        // Sonnet has the richest signal. Bare numbers ("15") get a minimal
+        // templated sentence naming the goal so the constraint isn't
+        // ambiguous about which entity it targets.
+        const isDescriptive = /[a-zA-Z]{3,}/.test(trimmed)
+        const goalLabel = hero.goal?.label?.trim()
+        const message = isDescriptive
+          ? `My success target is: ${trimmed}`
+          : goalLabel
+            ? `My success target for "${goalLabel}" is ${parsed}.`
+            : `My success target is ${parsed}.`
+        dispatch({
+          action_type: 'add_constraint',
+          parameters: { description: message },
+          label: 'Save success',
+          message,
+          source: 'chip',
+          hidden: true,
+        })
+      }
       return true
     },
-    [hero.goalNodeId],
+    [hero.goalNodeId, hero.goal],
   )
 
   // Attribution honesty (lane 35 fix 2): "Olumi estimate" ONLY for values


### PR DESCRIPTION
## Summary
- Follow-up to #253 (merged). A live Playwright retest against the deployed fix, done immediately after merge, proved the `parameters: { goal_threshold }` threading did NOT work: the rerun response still carried zero `goal_threshold`/`probability_of_joint_goal` fields. Evidence in `acceptance-evidence/6b-goal-capture/RETEST/`.
- Root cause: `olumi-assistants-service/src/orchestrator-v5/handlers/chip-click-dispatch.ts` documents in its own header comment that the `run_analysis` handler "reads its scenario state via the injected `scenarioReader` ... NOT from the HTTP request body" — the handler never looks at anything the client sends on the dispatch call. `chip.parameters.goal_threshold` was always a no-op. This PR reverts that dead code and its now-invalid tests.
- Real fix: `HeroSection::commitSuccess` now also fires a hidden `add_constraint` chip dispatch (natural-language description, `hidden: true` — no chat bubble) alongside the existing local canvas-store write. This is the *same* mechanism the working chat path already proves out (6b-goal-capture evidence clause 3) and that a sibling component (`SuccessTarget.tsx`'s `handleAddConstraint`) already uses today — no new wire field invented. By the time the user clicks "Analyse first pass", CEE's server-side scenario graph has the threshold, so `run_analysis`'s `scenarioReader` picks it up.

## Test plan
- [x] RED-first: reverted the fix, confirmed the new `PreAnalysisPanelV3.spec.tsx` test fails (dispatch not called), restored, confirmed green (38/38 passed).
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — 0 errors.
- [x] `npx vitest run --changed --bail=1` — 181 passed.
- [ ] Live Playwright re-run of the 6b-goal-capture harness against deployed staging (fresh disposable scenario) — post-merge, evidence in `acceptance-evidence/6b-goal-capture/RETEST/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)