### PR TITLE
UI honesty-hygiene batch: goal-probability unification, infinite-fetch fix, warning copy, comment-integrity

### DIFF
--- a/src/canvas/hooks/__tests__/useFormRecommendations.spec.ts
+++ b/src/canvas/hooks/__tests__/useFormRecommendations.spec.ts
@@ -434,4 +434,81 @@ describe('useFormRecommendations', () => {
       expect(mockFetch).not.toHaveBeenCalled()
     })
   })
+
+  describe('ROADMAP 1.44 — unmemoized-caller infinite-fetch hazard', () => {
+    // Root cause: refetch's useCallback depended on the RAW edges/nodes
+    // array references (not just the content-based edgeHash string). A
+    // store/selector that returns a new edges/nodes array reference on
+    // every render (same values, new reference) forces a new refetch
+    // identity on every render, which re-fires the auto-fetch effect
+    // regardless of whether edgeHash actually changed. Bounded here via
+    // EXPLICIT rerender() calls (not a self-sustaining loop) to reproduce
+    // the symptom safely — see the "Empty edges" test above for why an
+    // inline-recomputed array must never be handed to renderHook directly
+    // in this file (hangs the job).
+    it('issues exactly one fetch when the store returns new edges/nodes array references (same content) across re-renders', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ recommendations: [] }),
+      })
+
+      ;(useCanvasStore as any).mockImplementation((selector: any) => {
+        const state = {
+          edges: [...mockEdges],
+          nodes: [...mockNodes],
+          updateEdgeData: mockUpdateEdgeData,
+        }
+        return selector(state)
+      })
+
+      const { rerender } = renderHook(() =>
+        useFormRecommendations({ autoFetch: true })
+      )
+
+      // Simulate an unmemoized store/selector: same logical content, a
+      // BRAND NEW array reference on every re-render — before the in-flight
+      // mount fetch has had a chance to resolve and latch lastFetchHashRef.
+      for (let i = 0; i < 5; i++) {
+        rerender()
+      }
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+      })
+
+      // Let any pending microtasks/re-renders settle.
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not self-trigger extra renders on empty-edges early return across unmemoized re-renders', () => {
+      ;(useCanvasStore as any).mockImplementation((selector: any) => {
+        const state = {
+          edges: [] as typeof mockEdges,
+          nodes: [...mockNodes],
+          updateEdgeData: mockUpdateEdgeData,
+        }
+        return selector(state)
+      })
+
+      let renderCount = 0
+      const { rerender } = renderHook(() => {
+        renderCount++
+        return useFormRecommendations({ autoFetch: true })
+      })
+
+      const countAfterMount = renderCount
+      for (let i = 0; i < 5; i++) {
+        rerender()
+      }
+
+      // Each explicit rerender must cause exactly one render — the hook
+      // must not schedule an additional self-triggered render (a fresh
+      // empty-array state that's never `===` the previous one, re-firing
+      // the effect) on top of the ones the test asked for.
+      expect(renderCount).toBe(countAfterMount + 5)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/canvas/hooks/__tests__/useFormRecommendations.spec.ts
+++ b/src/canvas/hooks/__tests__/useFormRecommendations.spec.ts
@@ -510,5 +510,45 @@ describe('useFormRecommendations', () => {
       expect(renderCount).toBe(countAfterMount + 5)
       expect(mockFetch).not.toHaveBeenCalled()
     })
+
+    // Review follow-up (1.44): the dep-stabilisation fix above must not
+    // suppress a LEGITIMATE refetch — i.e. edges genuinely changing content,
+    // not just reference. edgeHash itself changes here, so the auto-fetch
+    // effect's `edgeHash !== lastFetchHashRef.current` guard is satisfied
+    // and a second fetch fires, mirroring usePareto.spec.ts's "refetches
+    // when options change" coverage for the equivalent hook.
+    it('still refetches when edges genuinely change content (not just reference)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ recommendations: [] }),
+      })
+
+      let currentEdges = mockEdges
+      ;(useCanvasStore as any).mockImplementation((selector: any) => {
+        const state = {
+          edges: currentEdges,
+          nodes: mockNodes,
+          updateEdgeData: mockUpdateEdgeData,
+        }
+        return selector(state)
+      })
+
+      const { rerender } = renderHook(() => useFormRecommendations({ autoFetch: true }))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+      })
+
+      // Genuine content change: a new edge added, so edgeHash actually differs.
+      currentEdges = [
+        ...mockEdges,
+        { id: 'edge-3', source: 'node-3', target: 'node-1', data: { functionType: 'linear' } },
+      ]
+      rerender()
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 })

--- a/src/canvas/hooks/useFormRecommendations.ts
+++ b/src/canvas/hooks/useFormRecommendations.ts
@@ -60,6 +60,11 @@ export function useFormRecommendations({
 
   // Track last fetched hash to prevent duplicate fetches
   const lastFetchHashRef = useRef<string | null>(null)
+  // ROADMAP 1.44: latest-ref for `loading`, read inside refetch's dedup
+  // guard without needing `loading` in refetch's dependency array (which
+  // would otherwise recreate refetch — and re-fire the auto-fetch effect
+  // below — every time loading toggles).
+  const loadingRef = useRef(false)
 
   /**
    * Generate a hash of edge IDs to detect when edges change
@@ -68,12 +73,34 @@ export function useFormRecommendations({
     return edges.map((e) => e.id).sort().join(',')
   }, [edges])
 
+  // ROADMAP 1.44 — "latest ref" pattern: refetch reads edges/nodes via these
+  // refs (kept fresh every render) instead of closing over the raw arrays
+  // directly. That keeps refetch's identity keyed ONLY on edgeHash (a
+  // content-based primitive), so an unmemoized caller/selector that returns
+  // a new edges/nodes array reference on every render (same values, new
+  // reference) no longer forces a new refetch identity — and therefore no
+  // longer re-fires the auto-fetch effect below on every render.
+  const edgesRef = useRef(edges)
+  edgesRef.current = edges
+  const nodesRef = useRef(nodes)
+  nodesRef.current = nodes
+
   /**
    * Fetch form recommendations from CEE
    */
   const refetch = useCallback(async () => {
+    const edges = edgesRef.current
+    const nodes = nodesRef.current
+
     if (edges.length === 0) {
       setRecommendations([])
+      // Latch the hash even on early return — otherwise an unmemoized
+      // edges/nodes reference (new array, same content, every render) keeps
+      // this guard permanently unsatisfied: every render recreates refetch,
+      // the auto-fetch effect re-fires, this branch re-runs, and the fresh
+      // `[]` literal above (never `===` the previous one) triggers another
+      // render — an infinite loop with no network calls involved at all.
+      lastFetchHashRef.current = edgeHash
       return
     }
 
@@ -81,15 +108,17 @@ export function useFormRecommendations({
     const cached = recommendationsCache.get(edgeHash)
     if (cached) {
       setRecommendations(cached)
+      lastFetchHashRef.current = edgeHash
       return
     }
 
     // Prevent duplicate fetches
-    if (loading || edgeHash === lastFetchHashRef.current) {
+    if (loadingRef.current || edgeHash === lastFetchHashRef.current) {
       return
     }
 
     lastFetchHashRef.current = edgeHash
+    loadingRef.current = true
     setLoading(true)
     setError(null)
 
@@ -147,9 +176,15 @@ export function useFormRecommendations({
         console.warn('[useFormRecommendations] Failed to fetch:', errorMessage)
       }
     } finally {
+      loadingRef.current = false
       setLoading(false)
     }
-  }, [edges, nodes, edgeHash, loading])
+    // ROADMAP 1.44: deps are edgeHash ONLY (a content-based primitive) — NOT
+    // the raw edges/nodes arrays and NOT `loading`. edges/nodes are read via
+    // edgesRef/nodesRef and `loading` via loadingRef (all above) so this
+    // callback's identity is stable whenever edgeHash is unchanged, even if
+    // the caller/selector returns a new array reference on every render.
+  }, [edgeHash])
 
   /**
    * Auto-apply high-confidence forms

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -20,6 +20,7 @@ import { detectBaseline } from '../utils/baselineDetection'
 import { useStaleGuard } from '../ui/inspector-v2/useStaleGuard'
 import { usePopoverHover } from '../hooks/usePopoverHover'
 import { NodeChip, ActionIcons, BriefIcon, MetricPills, NodePopover, ScienceIcon } from './shared'
+import { selectGoalProbability } from '../../components/results/utils/selectGoalProbability'
 
 /** Truncate text at word boundary to avoid mid-word cuts. */
 function truncateAtWord(text: string, maxLength: number): string {
@@ -699,12 +700,16 @@ export const OptionNode = memo((props: NodeProps) => {
     return null
   }, [isPostAnalysis, isRecommended, resultsReport, ceeAnalysisReady, props.id, nodes])
 
-  // Goal probability for warning
+  // Goal probability for warning.
+  // ROADMAP 1.49: uses the shared selectGoalProbability fallback chain (same
+  // one useResultsSectionData applies for OptionCards/hero/GoalNode) so this
+  // badge can't show a different number than those surfaces on a
+  // constrained-goal run.
   const goalProbability = useMemo(() => {
     if (!isPostAnalysis || !resultsReport) return null
     const report = resultsReport as any
     const optionProbs = report?.option_probabilities?.[props.id]
-    return typeof optionProbs?.goal_probability === 'number' ? optionProbs.goal_probability : null
+    return selectGoalProbability(optionProbs).goalProbability
   }, [isPostAnalysis, resultsReport, props.id])
 
   // "Behind:" reason for non-winner options (including status quo).

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -1067,6 +1067,54 @@ describe('OptionNode', () => {
     expect(bar).not.toBeNull()
     expect(bar?.style.width).toBe('max(4px, 2%)')
   })
+
+  // ROADMAP 1.49 — the "chance of target" badge must use the SAME
+  // goal_probability / probability_of_joint_goal fallback as
+  // useResultsSectionData (consumed by OptionCards/hero/GoalNode), not a
+  // narrower goal_probability-only read. On a constrained-goal run where
+  // ISL/PLoT populate probability_of_joint_goal but NOT goal_probability
+  // (constraint_analysis present with constraints — the joint figure IS the
+  // number every other surface shows), the badge must still render using
+  // that joint value rather than silently disappearing.
+  it('shows "chance of target" badge from probability_of_joint_goal when goal_probability is absent (constrained-goal run)', () => {
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: null,
+      stabilityPercentage: null,
+      winRate: 0.5,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    })
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeStoreState({
+        results: {
+          status: 'complete',
+          report: {
+            option_probabilities: {
+              'option-1': {
+                confidence: 0.5,
+                win_probability: 0.5,
+                probability_of_joint_goal: 0.05,
+                constraint_analysis: { constraints: [{ id: 'c1' }], joint_probability: 0.05 },
+              },
+            },
+          },
+        },
+        nodes: [
+          { id: 'option-1', type: 'option', data: { type: 'option' } },
+        ],
+      }) as any)
+    )
+    renderOption()
+    // 5% < 10% threshold → the warning line renders with the joint value,
+    // matching what OptionCards/hero derive via useResultsSectionData.
+    expect(screen.getByText(/5% chance of target\./)).toBeDefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -54,6 +54,7 @@ import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
 import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
 import { stripEncodingNotation, sanitizeCoachingText } from './utils/cleanFactorLabel'
 import { humaniseCritique } from './utils/humaniseCritique'
+import { selectGoalProbability, type GoalProbabilityInput } from './utils/selectGoalProbability'
 import { deriveStabilityLevel } from '../../lib/stability'
 import { deriveResultCompleteness, type ResultCompleteness } from './useResultCompleteness'
 
@@ -1250,23 +1251,10 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // constraint_analysis — the joint value IS the goal probability there,
       // so it is the final fallback. Discarding it hid the run's most
       // decision-relevant fact (every option at 0% chance of the target).
-      const jointGoalProb = typeof (prob as any).probability_of_joint_goal === 'number'
-        ? (prob as any).probability_of_joint_goal as number
-        : null
-      const unconstrained = typeof prob.goal_probability === 'number'
-        ? prob.goal_probability
-        : null
-      const hasConstraints = prob.constraint_analysis?.constraints?.length > 0
-      // Mirrors the goalProbability fallback branches directly below (rather
-      // than comparing resulting numbers, which could false-match on a
-      // coincidental equal value) so we know precisely WHEN the displayed
-      // number is the joint-goal figure the goal_fit_basis caveat qualifies.
-      const goalProbabilityIsJoint = hasConstraints
-        ? jointGoalProb != null
-        : unconstrained == null && jointGoalProb != null
-      const goalProbability = hasConstraints && jointGoalProb != null
-        ? jointGoalProb
-        : (unconstrained ?? jointGoalProb)
+      // ROADMAP 1.49: extracted to selectGoalProbability (utils/) so every
+      // surface (this hook, OptionNode's badge) shares one fallback chain
+      // instead of re-deriving it.
+      const { goalProbability, goalProbabilityIsJoint } = selectGoalProbability(prob as GoalProbabilityInput)
       // Display-honesty (ROADMAP 1.6b, doctrine B / PLoT #204): the
       // provenance caveat renders ONLY when the number just shown is the
       // joint-goal figure AND the producer marked it as scored from a

--- a/src/components/results/utils/__tests__/humaniseCritique.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.spec.ts
@@ -93,6 +93,65 @@ describe('humaniseCritique', () => {
       const result = humaniseCritique(makeItem({ code: 'CONSTRAINT_TARGET_UNRELIABLE', affectedNodes: undefined }))
       expect(result.title).toContain('This factor')
     })
+
+    // 1.52 follow-up — CONSTRAINT_DIRECTION_SUSPECT/ASSUMED are new PLoT
+    // warning codes distinct from CONSTRAINT_TARGET_UNRELIABLE: the target
+    // *value* isn't the problem here, the target's *direction* (higher-is-
+    // better vs lower-is-better) couldn't be confirmed (SUSPECT) or was
+    // assumed without confirmation (ASSUMED). Before this fix neither had a
+    // CODE_TEMPLATES entry, so both fell through to the generic unmapped-code
+    // fallback ("Review this factor's inputs") instead of a meaningful,
+    // direction-specific warning.
+    it('CONSTRAINT_DIRECTION_SUSPECT with resolved label', () => {
+      const labels = new Map([['fac_churn', 'Customer churn']])
+      const result = humaniseCritique(
+        makeItem({ code: 'CONSTRAINT_DIRECTION_SUSPECT', affectedNodes: ['fac_churn'] }),
+        labels,
+      )
+      expect(result.title).toContain('Customer churn')
+      expect(result.title).not.toBe("Review this factor's inputs")
+      expect(result.description).toContain("couldn't be confirmed")
+      expect(result.description.length).toBeGreaterThan(0)
+      expect(result.suggestion).toContain('Customer churn')
+      expect(result.factorId).toBe('fac_churn')
+      expect(result.title).not.toContain('observed_state')
+      expect(result.title).not.toContain('constraint_fac_churn_max')
+    })
+
+    it('CONSTRAINT_DIRECTION_SUSPECT falls back to "This factor" without a resolved label (no fabricated name)', () => {
+      const result = humaniseCritique(makeItem({ code: 'CONSTRAINT_DIRECTION_SUSPECT', affectedNodes: undefined }))
+      expect(result.title).toContain('This factor')
+    })
+
+    it('CONSTRAINT_DIRECTION_ASSUMED with resolved label', () => {
+      const labels = new Map([['fac_rev', 'Revenue']])
+      const result = humaniseCritique(
+        makeItem({ code: 'CONSTRAINT_DIRECTION_ASSUMED', affectedNodes: ['fac_rev'] }),
+        labels,
+      )
+      expect(result.title).toContain('Revenue')
+      expect(result.title).not.toBe("Review this factor's inputs")
+      expect(result.description).toContain('assumed')
+      expect(result.description.length).toBeGreaterThan(0)
+      expect(result.suggestion).toContain('Revenue')
+      expect(result.factorId).toBe('fac_rev')
+      expect(result.title).not.toContain('observed_state')
+    })
+
+    it('CONSTRAINT_DIRECTION_ASSUMED falls back to "This factor" without a resolved label (no fabricated name)', () => {
+      const result = humaniseCritique(makeItem({ code: 'CONSTRAINT_DIRECTION_ASSUMED', affectedNodes: undefined }))
+      expect(result.title).toContain('This factor')
+    })
+
+    it('CONSTRAINT_DIRECTION_SUSPECT and CONSTRAINT_DIRECTION_ASSUMED are distinct from CONSTRAINT_TARGET_UNRELIABLE', () => {
+      const labels = new Map([['fac_churn', 'Customer churn']])
+      const unreliable = humaniseCritique(makeItem({ code: 'CONSTRAINT_TARGET_UNRELIABLE', affectedNodes: ['fac_churn'] }), labels)
+      const suspect = humaniseCritique(makeItem({ code: 'CONSTRAINT_DIRECTION_SUSPECT', affectedNodes: ['fac_churn'] }), labels)
+      const assumed = humaniseCritique(makeItem({ code: 'CONSTRAINT_DIRECTION_ASSUMED', affectedNodes: ['fac_churn'] }), labels)
+      expect(suspect.title).not.toBe(unreliable.title)
+      expect(assumed.title).not.toBe(unreliable.title)
+      expect(suspect.title).not.toBe(assumed.title)
+    })
   })
 
   describe('unknown code fallback', () => {

--- a/src/components/results/utils/__tests__/selectGoalProbability.spec.ts
+++ b/src/components/results/utils/__tests__/selectGoalProbability.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { selectGoalProbability } from '../selectGoalProbability'
+
+describe('selectGoalProbability', () => {
+  it('returns null when neither source is present', () => {
+    expect(selectGoalProbability(undefined)).toEqual({ goalProbability: null, goalProbabilityIsJoint: false })
+    expect(selectGoalProbability({})).toEqual({ goalProbability: null, goalProbabilityIsJoint: false })
+  })
+
+  it('uses goal_probability (unconstrained) when there are no constraints', () => {
+    const result = selectGoalProbability({ goal_probability: 0.42 })
+    expect(result.goalProbability).toBe(0.42)
+    expect(result.goalProbabilityIsJoint).toBe(false)
+  })
+
+  it('prefers probability_of_joint_goal when constraints exist', () => {
+    const result = selectGoalProbability({
+      goal_probability: 0.42,
+      probability_of_joint_goal: 0.07,
+      constraint_analysis: { constraints: [{ id: 'c1' }] },
+    })
+    expect(result.goalProbability).toBe(0.07)
+    expect(result.goalProbabilityIsJoint).toBe(true)
+  })
+
+  it('falls back to probability_of_joint_goal when goal_probability is absent and no constraint_analysis (ISL auto-derived goal threshold)', () => {
+    const result = selectGoalProbability({ probability_of_joint_goal: 0.0 })
+    expect(result.goalProbability).toBe(0)
+    expect(result.goalProbabilityIsJoint).toBe(true)
+  })
+
+  it('does not treat unconstrained goal_probability as joint when constraints are absent', () => {
+    const result = selectGoalProbability({ goal_probability: 0.55, constraint_analysis: { constraints: [] } })
+    expect(result.goalProbability).toBe(0.55)
+    expect(result.goalProbabilityIsJoint).toBe(false)
+  })
+})

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -130,6 +130,25 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
     description: 'The value needed to assess this target is missing or unscaled, so goal-fit results were withheld for this run rather than shown as a meaningless number.',
     suggestion: `Set a value or range for ${label}`,
   }),
+  // 1.52 follow-up — producer WARNING-severity codes (PLoT constraint
+  // direction detection) distinct from CONSTRAINT_TARGET_UNRELIABLE: there
+  // the target *value* is the problem; here the target's *direction*
+  // (higher-is-better vs lower-is-better) is the problem. SUSPECT = PLoT
+  // couldn't confirm the direction so goal-fit isn't shown for this option.
+  // ASSUMED = PLoT proceeded with an assumed direction (goal-fit shown but
+  // built on an unconfirmed assumption). Same pattern as the 1.12 fix
+  // (PR #250): a code-keyed template naming the concrete, actionable fix,
+  // never quoting internal field names.
+  CONSTRAINT_DIRECTION_SUSPECT: (label) => ({
+    title: `${label}'s target direction couldn't be confirmed`,
+    description: "The direction of your target (whether higher or lower is better) couldn't be confirmed for this option, so its goal-fit isn't shown.",
+    suggestion: `Review the target direction for ${label}`,
+  }),
+  CONSTRAINT_DIRECTION_ASSUMED: (label) => ({
+    title: `${label}'s target direction was assumed`,
+    description: "The direction of your target (whether higher or lower is better) wasn't confirmed, so it was assumed for this run. Goal-fit results for this option may be less reliable.",
+    suggestion: `Confirm the target direction for ${label}`,
+  }),
 }
 
 // ─── Internal token detection ────────────────────────────────────────────────

--- a/src/components/results/utils/selectGoalProbability.ts
+++ b/src/components/results/utils/selectGoalProbability.ts
@@ -1,0 +1,53 @@
+/**
+ * selectGoalProbability — single source of truth for the goal_probability /
+ * probability_of_joint_goal fallback chain.
+ *
+ * ROADMAP 1.49: OptionNode.tsx's per-option "chance of target" badge used to
+ * read option_probabilities[id].goal_probability directly, with NO
+ * probability_of_joint_goal fallback — unlike useResultsSectionData (the
+ * hook feeding OptionCards, the analysis hero, and GoalNode), which prefers
+ * probability_of_joint_goal (constrained) over goal_probability
+ * (unconstrained) when constraints exist, and falls back to the joint value
+ * when it's the only number the run carries at all (ISL-auto-derived goal
+ * threshold case — see T6 P0-3). The two surfaces could therefore show a
+ * different number for the SAME option on a constrained-goal run. Extracted
+ * here so every surface calls one function instead of re-deriving the same
+ * fallback logic.
+ */
+
+export interface GoalProbabilityInput {
+  goal_probability?: number
+  probability_of_joint_goal?: number
+  constraint_analysis?: { constraints?: unknown[] } | null
+}
+
+export interface GoalProbabilitySelection {
+  /** The number to display, or null when neither source is present. */
+  goalProbability: number | null
+  /** True when `goalProbability` is the joint-goal (constrained) figure. */
+  goalProbabilityIsJoint: boolean
+}
+
+export function selectGoalProbability(
+  prob: GoalProbabilityInput | null | undefined,
+): GoalProbabilitySelection {
+  const jointGoalProb =
+    typeof prob?.probability_of_joint_goal === 'number' ? prob.probability_of_joint_goal : null
+  const unconstrained =
+    typeof prob?.goal_probability === 'number' ? prob.goal_probability : null
+  const hasConstraints = (prob?.constraint_analysis?.constraints?.length ?? 0) > 0
+
+  // Mirrors the goalProbability branch directly below (rather than comparing
+  // resulting numbers, which could false-match on a coincidental equal
+  // value) so callers know precisely WHEN the displayed number is the
+  // joint-goal figure the goal_fit_basis caveat qualifies.
+  const goalProbabilityIsJoint = hasConstraints
+    ? jointGoalProb != null
+    : unconstrained == null && jointGoalProb != null
+
+  const goalProbability = hasConstraints && jointGoalProb != null
+    ? jointGoalProb
+    : (unconstrained ?? jointGoalProb)
+
+  return { goalProbability, goalProbabilityIsJoint }
+}

--- a/src/hooks/__tests__/usePareto.spec.ts
+++ b/src/hooks/__tests__/usePareto.spec.ts
@@ -282,4 +282,68 @@ describe('usePareto', () => {
       })
     })
   })
+
+  describe('ROADMAP 1.44 — unmemoized-caller infinite-fetch hazard', () => {
+    // Root cause: fetchPareto's useCallback depended on the RAW options/
+    // criteria array references (not just the content-based requestHash
+    // string). An unmemoized caller that recreates the options/criteria
+    // array on every render (same values, new reference — e.g. an inline
+    // `.filter()`/`.map()`/spread, a routine caller-side pattern) forces a
+    // new fetchPareto identity on every render, which re-fires the
+    // auto-fetch effect regardless of whether requestHash actually changed.
+    // Bounded here via EXPLICIT rerender() calls (not a self-sustaining
+    // loop) to reproduce the symptom safely — see the validation describe
+    // block above for why an inline-recomputed array must never be passed
+    // directly to renderHook's callback in this file (hangs the job).
+    it('issues exactly one fetch when options/criteria are unmemoized (new array reference, same content, across re-renders)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockParetoResponse),
+      })
+
+      const { rerender } = renderHook(
+        ({ options, criteria }) => usePareto({ options, criteria }),
+        { initialProps: { options: [...mockOptions], criteria: [...mockCriteria] } }
+      )
+
+      // Simulate an unmemoized caller: same logical content, a BRAND NEW
+      // array reference on every re-render — before the in-flight mount
+      // fetch has had a chance to resolve and latch lastRequestHashRef.
+      for (let i = 0; i < 5; i++) {
+        rerender({ options: [...mockOptions], criteria: [...mockCriteria] })
+      }
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+      })
+
+      // Let any pending microtasks/re-renders settle.
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not self-trigger extra renders on insufficient-data early return across unmemoized re-renders', () => {
+      let renderCount = 0
+      const { rerender } = renderHook(
+        ({ options, criteria }) => {
+          renderCount++
+          return usePareto({ options, criteria })
+        },
+        { initialProps: { options: mockOptions.slice(0, 2), criteria: [...mockCriteria] } }
+      )
+
+      const countAfterMount = renderCount
+      for (let i = 0; i < 5; i++) {
+        rerender({ options: mockOptions.slice(0, 2), criteria: [...mockCriteria] })
+      }
+
+      // Each explicit rerender must cause exactly one render — the hook
+      // must not schedule an additional self-triggered render (a fresh
+      // empty-array state that's never `===` the previous one, re-firing
+      // the effect) on top of the ones the test asked for.
+      expect(renderCount).toBe(countAfterMount + 5)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/hooks/usePareto.ts
+++ b/src/hooks/usePareto.ts
@@ -87,13 +87,37 @@ export function usePareto({
   // Create hash of request params to detect changes
   const requestHash = JSON.stringify({ options, criteria })
 
+  // ROADMAP 1.44 — "latest ref" pattern: fetchPareto reads options/criteria
+  // via these refs (kept fresh every render) instead of closing over the raw
+  // arrays directly. That keeps fetchPareto's identity keyed ONLY on
+  // requestHash (a content-based primitive), so an unmemoized caller that
+  // recreates the options/criteria array on every render (same values, new
+  // reference — a routine pattern, not unique to any one caller) no longer
+  // forces a new fetchPareto identity — and therefore no longer re-fires the
+  // auto-fetch effect below on every render.
+  const optionsRef = useRef(options)
+  optionsRef.current = options
+  const criteriaRef = useRef(criteria)
+  criteriaRef.current = criteria
+
   const fetchPareto = useCallback(async () => {
+    const options = optionsRef.current
+    const criteria = criteriaRef.current
+
     // Validation: Need ≥3 options and ≥2 criteria for meaningful Pareto analysis
     if (options.length < 3) {
       setFrontier([])
       setDominated([])
       setDominancePairs([])
       setError(null)
+      // Latch the hash even on early return — otherwise an unmemoized
+      // caller (new options/criteria array reference every render, same
+      // content) keeps this guard permanently unsatisfied: every render
+      // recreates fetchPareto, the effect re-fires, this branch re-runs,
+      // and the fresh `[]` literals above (never `===` the previous ones)
+      // trigger another render — an infinite loop with no network calls
+      // involved at all.
+      lastRequestHashRef.current = requestHash
       return
     }
 
@@ -102,6 +126,7 @@ export function usePareto({
       setDominated([])
       setDominancePairs([])
       setError(null)
+      lastRequestHashRef.current = requestHash
       return
     }
 
@@ -192,7 +217,13 @@ export function usePareto({
     } finally {
       setIsLoading(false)
     }
-  }, [options, criteria, requestHash])
+    // ROADMAP 1.44: deps are requestHash ONLY (a content-based primitive) —
+    // NOT the raw options/criteria arrays. options/criteria are read via
+    // optionsRef/criteriaRef above so this callback's identity is stable
+    // whenever the caller's array content is unchanged, even if the caller
+    // passes a new array reference (e.g. `.filter()`/`.map()`/spread) on
+    // every render.
+  }, [requestHash])
 
   // Auto-fetch when enabled and params change
   useEffect(() => {

--- a/src/styles/__tests__/brand-css-comment-integrity.spec.ts
+++ b/src/styles/__tests__/brand-css-comment-integrity.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Claim-integrity check (ROADMAP 1.51b) — src/styles/brand.css:71's comment
+ * previously claimed --info (#52A3C8) was "Updated ... for WCAG AA 3:1"
+ * contrast on white. That claim is false: #52A3C8 on white computes to a
+ * 2.83:1 contrast ratio (WCAG relative-luminance formula), which FAILS the
+ * 3:1 UI-component threshold. This test asserts the comment states the
+ * truth instead of the false compliance claim. The colour itself is
+ * deliberately NOT changed here — that's a product colour decision
+ * (tracked separately in ROADMAP 1.51) — only the comment's claim.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('brand.css --info comment claim integrity (1.51b)', () => {
+  const css = readFileSync(join(__dirname, '../brand.css'), 'utf-8')
+
+  it('does NOT claim #52A3C8 meets WCAG AA 3:1', () => {
+    // The false claim asserted compliance ("Updated ... for WCAG AA 3:1").
+    // Any comment near --info must not repeat that pass/compliance claim.
+    expect(css).not.toMatch(/Updated to #52A3C8 for WCAG AA 3:1/)
+  })
+
+  it('states the true contrast ratio (2.83:1) and that it fails the 3:1 threshold', () => {
+    const infoCommentMatch = css.match(/\/\*\s*Info[\s\S]{0,400}?\*\//)
+    expect(infoCommentMatch).not.toBeNull()
+    const infoComment = infoCommentMatch![0]
+    expect(infoComment).toMatch(/fails WCAG AA 3:1/i)
+    expect(infoComment).toContain('2.83:1')
+    expect(infoComment).toMatch(/ROADMAP 1\.51/)
+  })
+})

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -68,7 +68,9 @@
   /* Border: rgba(103, 200, 158, 0.3) */
 
   /* Info / Decision / Navigation (Blue)
-     A11y: Updated to #52A3C8 for WCAG AA 3:1 UI-component contrast on white.
+     A11y: #52A3C8 fails WCAG AA 3:1 UI-component contrast on white (computes
+     to 2.83:1). A compliant replacement is pending a product colour decision
+     — see ROADMAP 1.51. Do not re-claim compliance here until that lands.
      Light shade kept for canvas node fills and selection backgrounds. */
   --info: #52A3C8;
   --info-light: #BAD7E4;


### PR DESCRIPTION
## Summary

Four independent honesty-hygiene fixes, reviewed adversarially before merge:

- **1.52 follow-up** — humanise `CONSTRAINT_DIRECTION_SUSPECT`/`CONSTRAINT_DIRECTION_ASSUMED` PLoT warning codes (previously fell through to the generic "Review this factor's inputs" fallback).
- **1.51b** — correct a false WCAG-AA-3:1-compliance claim in `brand.css`'s `--info` comment (`#52A3C8` on white computes to 2.83:1, which fails the 3:1 UI-component threshold). Colour value unchanged — a compliant replacement is a separate product decision (ROADMAP 1.51).
- **1.49** — extract the `goal_probability` / `probability_of_joint_goal` fallback chain into `selectGoalProbability()` so `OptionNode`'s per-option badge and `useResultsSectionData` (feeding OptionCards/hero/GoalNode) share one derivation instead of two that could drift on constrained-goal runs.
- **1.44** — stabilise `usePareto`/`useFormRecommendations` auto-fetch `useCallback` deps to a single content-based hash (via "latest ref" pattern), closing an infinite-fetch hazard triggered by unmemoized callers that recreate array references every render. Early-return branches now latch the last-fetched hash too.

## Review notes

- Traced `selectGoalProbability`'s extracted logic against the original inline branches in `useResultsSectionData.ts` — logically identical (added `?.` null-safety is a no-op since the caller always passes `optionProbs[nodeId] || {}`). No regression risk on the primary unconstrained-run path.
- Verified the 1.44 dep-stabilisation doesn't suppress legitimate refetches: both hooks' auto-fetch `useEffect` still depends on the content hash directly (`requestHash`/`edgeHash`), so genuine content changes still differ from the latched hash and still fire. `usePareto.spec.ts` already had "refetches when options change" coverage for this direction; added the missing symmetric test to `useFormRecommendations.spec.ts` (commit 320ed1c1) since only the unmemoized-caller direction was covered there.
- Confirmed the new `humaniseCritique` templates pass the V14.3 no-raw-message guard (`INTERNAL_TOKEN_REGEX`) and read as plain user language.
- Recomputed the WCAG contrast ratio independently (relative-luminance formula): #52A3C8 on white = 2.83:1, confirming the corrected comment's claim.

## Test plan

- [x] `npx vitest run` on all 6 touched spec files — 133 tests passed
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only, unrelated)
- [x] Fast pre-push gate (`scripts/validate-prepush.sh`) — all checks passed
- [ ] CI full suite (required check) — awaiting green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)