### PR TITLE
feat(seamlessness): clickable AI references — R1 target_refs pills + R3 proposal badges

### DIFF
--- a/src/canvas/conversation/__tests__/ProposalBlock.spec.tsx
+++ b/src/canvas/conversation/__tests__/ProposalBlock.spec.tsx
@@ -8,7 +8,7 @@
  * - confirmation_required: true (or absent) shows Apply/Cancel buttons
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { InlineBlocks } from '../InlineBlocks'
 import type { ProposalBlock } from '../types'
@@ -262,5 +262,121 @@ describe('ProposalBlockRenderer — render matrix (all states)', () => {
       expect(screen.queryByTestId('proposal-apply')).not.toBeInTheDocument()
       expect(screen.queryByTestId('proposal-cancel')).not.toBeInTheDocument()
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R3 (UI-SEAMLESSNESS-REVIEW) — target badge click-to-focus.
+//
+// ProposalBlock.changes[].target is a bare string (no id, no kind), so it
+// resolves against the canvas via the RATIFIED string-target rule:
+// exact node/edge id match, else UNIQUE exact node-label match (trimmed,
+// case-sensitive), else the badge stays today's inert <span>. Resolution
+// happens at render time (labels drift while proposals sit on screen).
+// Uses the REAL focusHelpers singleton with registered spies.
+// ---------------------------------------------------------------------------
+
+import { registerFocusHelpers } from '../../utils/focusHelpers'
+import { useCanvasStore } from '../../store'
+
+describe('ProposalBlockRenderer — target badge click-to-focus (R3)', () => {
+  const focusNode = vi.fn()
+  const focusEdge = vi.fn()
+  let unregister: () => void
+
+  beforeEach(() => {
+    focusNode.mockClear()
+    focusEdge.mockClear()
+    unregister = registerFocusHelpers(focusNode, focusEdge)
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'node_reg_risk', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Regulatory Risk' } } as any,
+        { id: 'node_other', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Something Else' } } as any,
+      ],
+      edges: [{ id: 'e7', source: 'node_reg_risk', target: 'node_other' } as any],
+    })
+  })
+
+  afterEach(() => {
+    unregister()
+    useCanvasStore.setState({ nodes: [], edges: [] })
+  })
+
+  function renderProposal(target: string) {
+    const block = makeProposal({
+      changes: [{ operation: 'add', target, detail: 'Change detail' }],
+    })
+    render(<InlineBlocks blocks={[block as unknown as ConversationBlock]} />)
+  }
+
+  it('exact node-id target renders a clickable badge; click focuses the node', () => {
+    renderProposal('node_reg_risk')
+    const btn = screen.getByRole('button', { name: /highlight node_reg_risk on the canvas/i })
+    fireEvent.click(btn)
+    expect(focusNode).toHaveBeenCalledWith('node_reg_risk')
+  })
+
+  it('exact edge-id target focuses the edge', () => {
+    renderProposal('e7')
+    fireEvent.click(screen.getByRole('button', { name: /highlight e7 on the canvas/i }))
+    expect(focusEdge).toHaveBeenCalledWith('e7')
+  })
+
+  it('UNIQUE exact label match resolves to the labelled node', () => {
+    renderProposal('Regulatory Risk')
+    fireEvent.click(screen.getByRole('button', { name: /highlight regulatory risk on the canvas/i }))
+    expect(focusNode).toHaveBeenCalledWith('node_reg_risk')
+  })
+
+  it('label matching is trimmed: surrounding whitespace on the target still resolves', () => {
+    renderProposal('  Regulatory Risk  ')
+    fireEvent.click(screen.getByRole('button'))
+    expect(focusNode).toHaveBeenCalledWith('node_reg_risk')
+  })
+
+  it('label matching is case-sensitive: a case-mismatched target stays an inert span', () => {
+    renderProposal('regulatory risk')
+    expect(screen.queryByRole('button', { name: /highlight/i })).not.toBeInTheDocument()
+    expect(screen.getByText('regulatory risk')).toBeInTheDocument()
+    expect(focusNode).not.toHaveBeenCalled()
+  })
+
+  it('AMBIGUOUS label (two nodes share it) stays an inert span — no guessing', () => {
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'node_reg_risk', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Regulatory Risk' } } as any,
+        { id: 'node_dupe', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Regulatory Risk' } } as any,
+      ],
+      edges: [],
+    })
+    renderProposal('Regulatory Risk')
+    expect(screen.queryByRole('button', { name: /highlight/i })).not.toBeInTheDocument()
+    expect(screen.getByText('Regulatory Risk')).toBeInTheDocument()
+    expect(focusNode).not.toHaveBeenCalled()
+  })
+
+  it('unresolvable target stays an inert span with the copy verbatim', () => {
+    renderProposal('Ghost Target')
+    expect(screen.queryByRole('button', { name: /highlight/i })).not.toBeInTheDocument()
+    expect(screen.getByText('Ghost Target')).toBeInTheDocument()
+  })
+
+  it('resolution is render-time: renaming the node away de-links the badge', () => {
+    const block = makeProposal({
+      changes: [{ operation: 'add', target: 'Regulatory Risk', detail: 'Change detail' }],
+    })
+    const { rerender } = render(
+      <InlineBlocks blocks={[block as unknown as ConversationBlock]} />,
+    )
+    expect(screen.getByRole('button', { name: /highlight regulatory risk/i })).toBeInTheDocument()
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'node_reg_risk', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Renamed Risk' } } as any,
+      ],
+      edges: [],
+    })
+    rerender(<InlineBlocks blocks={[block as unknown as ConversationBlock]} />)
+    expect(screen.queryByRole('button', { name: /highlight regulatory risk/i })).not.toBeInTheDocument()
+    expect(screen.getByText('Regulatory Risk')).toBeInTheDocument()
   })
 })

--- a/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
+++ b/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
@@ -19,6 +19,7 @@ import { typography } from '../../../styles/typography'
 import { useCanvasStore } from '../../store'
 import { isAiPanelV2Enabled } from '../../../flags'
 import { EntityLink } from '../components/EntityLink'
+import { TargetRefPill } from '../components/TargetRefPill'
 import type {
   GraphPatchBlock as GraphPatchBlockType,
   ProposalBlock as ProposalBlockType,
@@ -631,6 +632,30 @@ export function ProposalBlockRenderer({
   )
   const needsButtons = block.confirmation_required === true && state === 'pending'
 
+  // Seamlessness R3: proposal change targets arrive as bare strings (no id,
+  // no kind), so they resolve against the canvas via the ratified
+  // string-target rule — exact node/edge id match, else UNIQUE exact
+  // node-label match (trimmed, case-sensitive), else the badge stays inert.
+  // Subscribing to nodes/edges makes resolution render-time: labels drift
+  // while a proposal sits on screen, and a badge must never point at a
+  // guess. TargetRefPill re-checks existence on click, so a resolved badge
+  // is safe even if the element vanishes between render and click.
+  const nodes = useCanvasStore((s) => s.nodes)
+  const edges = useCanvasStore((s) => s.edges)
+  const resolveTarget = useCallback(
+    (target: string): { id: string; kind: 'node' | 'edge' } | null => {
+      const t = target.trim()
+      if (!t) return null
+      if (nodes.some((n) => n.id === t)) return { id: t, kind: 'node' }
+      if (edges.some((e) => e.id === t)) return { id: t, kind: 'edge' }
+      const byLabel = nodes.filter(
+        (n) => typeof n.data?.label === 'string' && n.data.label.trim() === t,
+      )
+      return byLabel.length === 1 ? { id: byLabel[0].id, kind: 'node' } : null
+    },
+    [nodes, edges],
+  )
+
   const cardState = state === 'accepted' ? 'accepted' as const
     : state === 'cancelled' ? 'dismissed' as const
     : 'proposed' as const
@@ -649,19 +674,30 @@ export function ProposalBlockRenderer({
       <p className={`${typography.panelBody} ${styles.graphPatchProposalDescription}`}>{block.description}</p>
       {block.changes.length > 0 && (
         <div className={styles.graphPatchProposalList}>
-          {block.changes.map((c, i) => (
-            <div key={`${c.target}-${i}`} className={styles.graphPatchProposalItem}>
-              <span className={typography.panelBody}>{c.detail}</span>
-              <div className="flex gap-1">
-                {c.operation && (
-                  <span className={`${typography.panelMeta} ${styles.outlinedPill}`}>{c.operation}</span>
-                )}
-                {c.target && (
-                  <span className={`${typography.panelMeta} ${styles.graphPatchProposalBadge}`}>{c.target}</span>
-                )}
+          {block.changes.map((c, i) => {
+            const resolved = c.target ? resolveTarget(c.target) : null
+            return (
+              <div key={`${c.target}-${i}`} className={styles.graphPatchProposalItem}>
+                <span className={typography.panelBody}>{c.detail}</span>
+                <div className="flex gap-1">
+                  {c.operation && (
+                    <span className={`${typography.panelMeta} ${styles.outlinedPill}`}>{c.operation}</span>
+                  )}
+                  {c.target && resolved && (
+                    <TargetRefPill
+                      id={resolved.id}
+                      kind={resolved.kind}
+                      label={c.target}
+                      className={`${typography.panelMeta} ${styles.graphPatchProposalBadge}`}
+                    />
+                  )}
+                  {c.target && !resolved && (
+                    <span className={`${typography.panelMeta} ${styles.graphPatchProposalBadge}`}>{c.target}</span>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
       {block.consequences && block.consequences.length > 0 && (

--- a/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
+++ b/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
@@ -638,8 +638,10 @@ export function ProposalBlockRenderer({
   // node-label match (trimmed, case-sensitive), else the badge stays inert.
   // Subscribing to nodes/edges makes resolution render-time: labels drift
   // while a proposal sits on screen, and a badge must never point at a
-  // guess. TargetRefPill re-checks existence on click, so a resolved badge
-  // is safe even if the element vanishes between render and click.
+  // guess. If the element vanishes after render, the store subscription
+  // re-renders the badge inert, and ReactFlowGraph's registered focus
+  // handler no-ops on ids it can't find — TargetRefPill itself does not
+  // re-check on click.
   const nodes = useCanvasStore((s) => s.nodes)
   const edges = useCanvasStore((s) => s.edges)
   const resolveTarget = useCallback(

--- a/src/canvas/conversation/components/TargetRefPill.tsx
+++ b/src/canvas/conversation/components/TargetRefPill.tsx
@@ -69,7 +69,10 @@ export const TargetRefPill = memo(function TargetRefPill({
   }
 
   return (
-    <span {...(role ? { role } : {})} className="inline-flex">
+    // shrink-0 keeps flex-item behavior identical to the inert state when the
+    // caller's classes carry flex-shrink: 0 (the proposal badge row is
+    // flex-nowrap); it is a no-op in the flex-wrap refs rows.
+    <span {...(role ? { role } : {})} className="inline-flex shrink-0">
       <button
         type="button"
         onClick={handleClick}

--- a/src/canvas/conversation/components/TargetRefPill.tsx
+++ b/src/canvas/conversation/components/TargetRefPill.tsx
@@ -1,0 +1,49 @@
+import { memo } from 'react'
+
+// TargetRefPill — a conversation-block reference pill (target_refs / proposal
+// change targets) that pans + highlights its canvas element on click.
+//
+// Fail-closed contract (UI-SEAMLESSNESS-REVIEW R1/R3): the pill is clickable
+// ONLY while the referenced element exists on the canvas — checked against
+// the canvas store at render time, scoped by kind (edge ids never resolve
+// against nodes and vice versa). When the target is stale/unknown the pill
+// renders as today's inert <span>, byte-identical styling, so a dead
+// reference never advertises an affordance it can't honour.
+//
+// DS: the caller supplies the pill classes — pills keep their outlined
+// identity (bg-transparent border, text-text-body); this is NOT restyled to
+// EntityLink's text-link look. No telemetry (mirrors EntityLink).
+
+export interface TargetRefPillProps {
+  id: string
+  label: string
+  /** Producer-owned kind string ('factor'/'goal'/'option'/'risk'/'edge'/…).
+   * Only 'edge' routes to edge focus; all other kinds are canvas nodes. */
+  kind?: string
+  /** Pill classes, applied in both the clickable and inert states. */
+  className?: string
+  /** Set to 'listitem' when rendered inside a role="list" refs container. */
+  role?: string
+}
+
+export const TargetRefPill = memo(function TargetRefPill({
+  id,
+  label,
+  kind = 'node',
+  className,
+  role,
+}: TargetRefPillProps) {
+  // RED-checkpoint stub: inert rendering only; click-to-focus lands next commit.
+  return (
+    <span
+      {...(role ? { role } : {})}
+      data-ref-id={id}
+      data-ref-kind={kind}
+      className={className}
+    >
+      {label}
+    </span>
+  )
+})
+
+export default TargetRefPill

--- a/src/canvas/conversation/components/TargetRefPill.tsx
+++ b/src/canvas/conversation/components/TargetRefPill.tsx
@@ -1,4 +1,6 @@
-import { memo } from 'react'
+import { memo, useCallback } from 'react'
+import { useCanvasStore } from '../../store'
+import { focusByTarget } from '../../utils/focusHelpers'
 
 // TargetRefPill — a conversation-block reference pill (target_refs / proposal
 // change targets) that pans + highlights its canvas element on click.
@@ -7,8 +9,12 @@ import { memo } from 'react'
 // ONLY while the referenced element exists on the canvas — checked against
 // the canvas store at render time, scoped by kind (edge ids never resolve
 // against nodes and vice versa). When the target is stale/unknown the pill
-// renders as today's inert <span>, byte-identical styling, so a dead
-// reference never advertises an affordance it can't honour.
+// renders as the same inert <span> it was before this component existed, so
+// a dead reference never advertises an affordance it can't honour.
+//
+// When the target exists but ReactFlow is not mounted (no focus handler
+// registered), a click warns and no-ops inside focusHelpers — identical to
+// EntityLink; pinned by TargetRefPill.noHandler.spec.tsx.
 //
 // DS: the caller supplies the pill classes — pills keep their outlined
 // identity (bg-transparent border, text-text-body); this is NOT restyled to
@@ -22,9 +28,14 @@ export interface TargetRefPillProps {
   kind?: string
   /** Pill classes, applied in both the clickable and inert states. */
   className?: string
-  /** Set to 'listitem' when rendered inside a role="list" refs container. */
+  /** Set to 'listitem' when rendered inside a role="list" refs container.
+   * In the clickable state the role goes on a wrapper span so the inner
+   * <button> keeps its native role and list semantics stay valid. */
   role?: string
 }
+
+const INTERACTIVE_CLASSES =
+  'cursor-pointer hover:border-info/50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-info'
 
 export const TargetRefPill = memo(function TargetRefPill({
   id,
@@ -33,15 +44,43 @@ export const TargetRefPill = memo(function TargetRefPill({
   className,
   role,
 }: TargetRefPillProps) {
-  // RED-checkpoint stub: inert rendering only; click-to-focus lands next commit.
+  const isEdge = kind === 'edge'
+  const exists = useCanvasStore((s) =>
+    isEdge ? s.edges.some((e) => e.id === id) : s.nodes.some((n) => n.id === id),
+  )
+
+  const handleClick = useCallback(() => {
+    // Same kind collapse as EntityLink: all non-edge targets are canvas
+    // nodes. Reduced-motion is handled inside the focus helper.
+    focusByTarget(id, isEdge ? 'edge' : 'node')
+  }, [id, isEdge])
+
+  if (!exists) {
+    return (
+      <span
+        {...(role ? { role } : {})}
+        data-ref-id={id}
+        data-ref-kind={kind}
+        className={className}
+      >
+        {label}
+      </span>
+    )
+  }
+
   return (
-    <span
-      {...(role ? { role } : {})}
-      data-ref-id={id}
-      data-ref-kind={kind}
-      className={className}
-    >
-      {label}
+    <span {...(role ? { role } : {})} className="inline-flex">
+      <button
+        type="button"
+        onClick={handleClick}
+        data-ref-id={id}
+        data-ref-kind={kind}
+        data-testid={`target-ref-pill-${id}`}
+        aria-label={`Highlight ${label} on the canvas`}
+        className={[className, INTERACTIVE_CLASSES].filter(Boolean).join(' ')}
+      >
+        {label}
+      </button>
     </span>
   )
 })

--- a/src/canvas/conversation/components/TargetRefPill.tsx
+++ b/src/canvas/conversation/components/TargetRefPill.tsx
@@ -69,7 +69,7 @@ export const TargetRefPill = memo(function TargetRefPill({
   }
 
   return (
-    // shrink-0 keeps flex-item behavior identical to the inert state when the
+    // shrink-0 keeps flex-item behaviour identical to the inert state when the
     // caller's classes carry flex-shrink: 0 (the proposal badge row is
     // flex-nowrap); it is a no-op in the flex-wrap refs rows.
     <span {...(role ? { role } : {})} className="inline-flex shrink-0">

--- a/src/canvas/conversation/components/__tests__/TargetRefPill.noHandler.spec.tsx
+++ b/src/canvas/conversation/components/__tests__/TargetRefPill.noHandler.spec.tsx
@@ -1,0 +1,47 @@
+/**
+ * Pin (orchestrator correction 2, Lane R1+R3): store-existence is not the
+ * whole fail-closed story. When the target EXISTS but no canvas focus
+ * handler is registered (ReactFlowGraph not mounted — e.g. a conversation
+ * surface rendered without the canvas), the pill is still clickable and a
+ * click warns + no-ops. This mirrors EntityLink's existing behaviour
+ * EXACTLY (focusByTarget → focusNodeById warns "before ReactFlow mounted"
+ * and returns). Decision, not accident: if this ever needs to change, it
+ * changes for EntityLink and TargetRefPill together, in their own lane.
+ *
+ * Uses the REAL focusHelpers module (no vi.mock) — that's the point.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { TargetRefPill } from '../TargetRefPill'
+import { useCanvasStore } from '../../../store'
+import { unregisterFocusHelpers } from '../../../utils/focusHelpers'
+
+beforeEach(() => {
+  unregisterFocusHelpers()
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor X' } } as any,
+    ],
+    edges: [],
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  useCanvasStore.setState({ nodes: [], edges: [] })
+  vi.restoreAllMocks()
+})
+
+describe('TargetRefPill with no registered focus handler', () => {
+  it('click warns and no-ops — never throws (EntityLink-parity)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(<TargetRefPill id="n1" label="Factor X" kind="factor" />)
+    const btn = screen.getByRole('button', { name: /highlight factor x on the canvas/i })
+    expect(() => btn.click()).not.toThrow()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('before ReactFlow mounted'),
+    )
+  })
+})

--- a/src/canvas/conversation/components/__tests__/TargetRefPill.spec.tsx
+++ b/src/canvas/conversation/components/__tests__/TargetRefPill.spec.tsx
@@ -60,7 +60,19 @@ describe('TargetRefPill (R1/R3 click-to-focus, fail-closed)', () => {
     expect(pill.tagName).toBe('SPAN')
     expect(pill).toHaveAttribute('data-ref-id', 'ghost')
     expect(pill).toHaveAttribute('data-ref-kind', 'factor')
+    // Byte-parity pin: the inert span carries EXACTLY the caller's classes.
+    expect(pill.className).toBe(PILL_CLASSES)
     expect(focusByTargetMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the caller pill classes on the clickable button (DS outlined-pill identity)', () => {
+    render(<TargetRefPill id="n1" label="Factor X" kind="factor" className={PILL_CLASSES} />)
+    const btn = screen.getByRole('button')
+    for (const cls of PILL_CLASSES.split(' ')) {
+      expect(btn.classList.contains(cls)).toBe(true)
+    }
+    // Interactive affordances are appended, never replacing the pill identity.
+    expect(btn.classList.contains('cursor-pointer')).toBe(true)
   })
 
   it('existence check is kind-scoped: a node id declared as kind "edge" stays inert', () => {

--- a/src/canvas/conversation/components/__tests__/TargetRefPill.spec.tsx
+++ b/src/canvas/conversation/components/__tests__/TargetRefPill.spec.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+const { focusByTargetMock } = vi.hoisted(() => ({ focusByTargetMock: vi.fn() }))
+vi.mock('../../../utils/focusHelpers', () => ({
+  focusByTarget: focusByTargetMock,
+}))
+
+import { TargetRefPill } from '../TargetRefPill'
+import { useCanvasStore } from '../../../store'
+
+const PILL_CLASSES =
+  'inline-flex items-center rounded-full px-2.5 py-0.5 bg-transparent border border-panel-border text-text-body'
+
+beforeEach(() => {
+  focusByTargetMock.mockReset()
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor X' } } as any,
+    ],
+    edges: [{ id: 'e1', source: 'n1', target: 'n1' } as any],
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  useCanvasStore.setState({ nodes: [], edges: [] })
+})
+
+describe('TargetRefPill (R1/R3 click-to-focus, fail-closed)', () => {
+  it('renders a clickable button when the target node exists; click focuses it', () => {
+    render(<TargetRefPill id="n1" label="Factor X" kind="factor" className={PILL_CLASSES} />)
+    const btn = screen.getByRole('button', { name: /highlight factor x on the canvas/i })
+    expect(btn).toHaveTextContent('Factor X')
+    btn.click()
+    expect(focusByTargetMock).toHaveBeenCalledWith('n1', 'node')
+  })
+
+  it.each(['factor', 'goal', 'option', 'risk', 'outcome'] as const)(
+    'collapses non-edge kind %s to node focus',
+    (kind) => {
+      render(<TargetRefPill id="n1" label="Factor X" kind={kind} className={PILL_CLASSES} />)
+      screen.getByRole('button').click()
+      expect(focusByTargetMock).toHaveBeenCalledWith('n1', 'node')
+    },
+  )
+
+  it('routes kind "edge" through edge focus when the edge exists', () => {
+    render(<TargetRefPill id="e1" label="Influence" kind="edge" className={PILL_CLASSES} />)
+    screen.getByRole('button').click()
+    expect(focusByTargetMock).toHaveBeenCalledWith('e1', 'edge')
+  })
+
+  it('fails closed to an inert span when the target id is not on the canvas', () => {
+    render(<TargetRefPill id="ghost" label="Deleted thing" kind="factor" className={PILL_CLASSES} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    // Label copy still renders verbatim, styling classes intact.
+    const pill = screen.getByText('Deleted thing')
+    expect(pill.tagName).toBe('SPAN')
+    expect(pill).toHaveAttribute('data-ref-id', 'ghost')
+    expect(pill).toHaveAttribute('data-ref-kind', 'factor')
+    expect(focusByTargetMock).not.toHaveBeenCalled()
+  })
+
+  it('existence check is kind-scoped: a node id declared as kind "edge" stays inert', () => {
+    render(<TargetRefPill id="n1" label="Mislabelled" kind="edge" className={PILL_CLASSES} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Mislabelled').tagName).toBe('SPAN')
+  })
+
+  it('re-resolves at render time: the pill goes inert after the target is removed from the store', () => {
+    const { rerender } = render(
+      <TargetRefPill id="n1" label="Factor X" kind="factor" className={PILL_CLASSES} />,
+    )
+    expect(screen.getByRole('button')).toBeInTheDocument()
+    useCanvasStore.setState({ nodes: [], edges: [] })
+    rerender(<TargetRefPill id="n1" label="Factor X" kind="factor" className={PILL_CLASSES} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Factor X').tagName).toBe('SPAN')
+  })
+
+  it('preserves data-ref attributes and the verbatim producer kind on the clickable pill', () => {
+    render(<TargetRefPill id="n1" label="Factor X" kind="goal" className={PILL_CLASSES} />)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveAttribute('data-ref-id', 'n1')
+    expect(btn).toHaveAttribute('data-ref-kind', 'goal')
+    expect(btn).toHaveAttribute('type', 'button')
+  })
+
+  it('marks the wrapper as a listitem when role="listitem" is passed (refs containers are role="list")', () => {
+    render(
+      <div role="list">
+        <TargetRefPill id="n1" label="Factor X" kind="factor" className={PILL_CLASSES} role="listitem" />
+      </div>,
+    )
+    const item = screen.getByRole('listitem')
+    expect(item).toHaveTextContent('Factor X')
+    // The clickable control lives inside the listitem, keeping list semantics valid.
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+})

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -13,10 +13,14 @@
  *     attributes only — never rendered as copy.
  *   - `action_label` renders as a display-only outlined pill this slice;
  *     wiring `action_intent` to turn dispatch is a recorded follow-up.
+ *   - target_refs pills are click-to-focus (seamlessness R1): clickable only
+ *     while the target exists on the canvas (fail-closed in TargetRefPill),
+ *     label copy verbatim either way.
  */
 import { type ReactElement } from 'react'
 import { Lightbulb } from 'lucide-react'
 import { typography } from '../../styles/typography'
+import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
 import type { V5CoachingBlock as V5CoachingBlockType } from '../../canvas/conversation/types'
 
 export interface V5CoachingBlockProps {
@@ -50,19 +54,18 @@ export function V5CoachingBlock({ block }: V5CoachingBlockProps): ReactElement {
           data-testid="v5-coaching-refs"
         >
           {block.target_refs.map((ref) => (
-            <span
+            <TargetRefPill
               key={ref.id}
               role="listitem"
-              data-ref-id={ref.id}
-              data-ref-kind={ref.kind}
+              id={ref.id}
+              label={ref.label}
+              kind={ref.kind}
               className={[
                 'inline-flex items-center rounded-full px-2.5 py-0.5',
                 'bg-transparent border border-panel-border text-text-body',
                 typography.panelMeta,
               ].join(' ')}
-            >
-              {ref.label}
-            </span>
+            />
           ))}
         </div>
       )}

--- a/src/v5/blocks/V5EvidenceBlock.tsx
+++ b/src/v5/blocks/V5EvidenceBlock.tsx
@@ -23,6 +23,7 @@
 import { type ReactElement } from 'react'
 import { AlertTriangle, Search } from 'lucide-react'
 import { typography } from '../../styles/typography'
+import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
 import type { V5EvidenceBlock as V5EvidenceBlockType } from '../../canvas/conversation/types'
 
 export interface V5EvidenceBlockProps {
@@ -83,19 +84,18 @@ export function V5EvidenceBlock({ block }: V5EvidenceBlockProps): ReactElement {
           data-testid="v5-evidence-refs"
         >
           {block.target_refs.map((ref) => (
-            <span
+            <TargetRefPill
               key={ref.id}
               role="listitem"
-              data-ref-id={ref.id}
-              data-ref-kind={ref.kind}
+              id={ref.id}
+              label={ref.label}
+              kind={ref.kind}
               className={[
                 'inline-flex items-center rounded-full px-2.5 py-0.5',
                 'bg-transparent border border-panel-border text-text-body',
                 typography.panelMeta,
               ].join(' ')}
-            >
-              {ref.label}
-            </span>
+            />
           ))}
         </div>
       )}

--- a/src/v5/blocks/V5ExerciseBlock.tsx
+++ b/src/v5/blocks/V5ExerciseBlock.tsx
@@ -23,6 +23,7 @@
 import { type ReactElement } from 'react'
 import { ClipboardList } from 'lucide-react'
 import { typography } from '../../styles/typography'
+import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
 import type {
   V5BlockTargetRef,
   V5ExerciseBlock as V5ExerciseBlockType,
@@ -102,19 +103,18 @@ export function V5ExerciseBlock({ block }: V5ExerciseBlockProps): ReactElement {
           data-testid="v5-exercise-refs"
         >
           {refs.map((ref) => (
-            <span
+            <TargetRefPill
               key={ref.id}
               role="listitem"
-              data-ref-id={ref.id}
-              data-ref-kind={ref.kind}
+              id={ref.id}
+              label={ref.label}
+              kind={ref.kind}
               className={[
                 'inline-flex items-center rounded-full px-2.5 py-0.5',
                 'bg-transparent border border-panel-border text-text-body',
                 typography.panelMeta,
               ].join(' ')}
-            >
-              {ref.label}
-            </span>
+            />
           ))}
         </div>
       )}

--- a/src/v5/blocks/V5ReviewCardBlock.tsx
+++ b/src/v5/blocks/V5ReviewCardBlock.tsx
@@ -18,6 +18,7 @@
 import { type ReactElement } from 'react'
 import { AlertTriangle, Lightbulb } from 'lucide-react'
 import { typography } from '../../styles/typography'
+import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
 import type { V5ReviewCardBlock as V5ReviewCardBlockType } from '../../canvas/conversation/types'
 
 export interface V5ReviewCardBlockProps {
@@ -68,19 +69,18 @@ export function V5ReviewCardBlock({ block }: V5ReviewCardBlockProps): ReactEleme
           data-testid="v5-review-card-refs"
         >
           {block.target_refs.map((ref) => (
-            <span
+            <TargetRefPill
               key={ref.id}
               role="listitem"
-              data-ref-id={ref.id}
-              data-ref-kind={ref.kind}
+              id={ref.id}
+              label={ref.label}
+              kind={ref.kind}
               className={[
                 'inline-flex items-center rounded-full px-2.5 py-0.5',
                 'bg-transparent border border-panel-border text-text-body',
                 typography.panelMeta,
               ].join(' ')}
-            >
-              {ref.label}
-            </span>
+            />
           ))}
         </div>
       )}

--- a/src/v5/blocks/__tests__/V5Phase3Blocks.spec.tsx
+++ b/src/v5/blocks/__tests__/V5Phase3Blocks.spec.tsx
@@ -9,7 +9,7 @@
  *   - severity drives the visual channel only (data-severity + styling).
  *   - kind/freshness/block_id ride as data-* attributes, never as copy.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 import { V5ReviewCardBlock } from '../V5ReviewCardBlock'
@@ -261,5 +261,103 @@ describe('V5ExerciseBlock', () => {
   it('renders no refs list when neither target_element_ref nor target_refs exist', () => {
     render(<V5ExerciseBlock block={{ ...EXERCISE, target_refs: [] }} />)
     expect(screen.queryByTestId('v5-exercise-refs')).not.toBeInTheDocument()
+  })
+})
+
+// ─── R1 (UI-SEAMLESSNESS-REVIEW): target_refs pills are click-to-focus ─────
+//
+// Uses the REAL focusHelpers singleton with registered spies (the
+// focusHelpers.failClosed.spec.ts pattern) so the assertion covers the whole
+// path: pill click → focusByTarget → focusNodeById → registered impl.
+
+import { registerFocusHelpers } from '../../../canvas/utils/focusHelpers'
+import { useCanvasStore } from '../../../canvas/store'
+
+describe('Phase-3 target_refs pills — click-to-focus (R1)', () => {
+  const focusNode = vi.fn()
+  const focusEdge = vi.fn()
+  let unregister: () => void
+
+  beforeEach(() => {
+    focusNode.mockClear()
+    focusEdge.mockClear()
+    unregister = registerFocusHelpers(focusNode, focusEdge)
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'fac_tech_lead', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Technical Leadership Capacity' } } as any,
+        { id: 'opt_paid_ads', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Paid Advertising' } } as any,
+        { id: 'opt_migrate', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Migrate to the new platform' } } as any,
+        { id: 'fac_cost', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Total Cost' } } as any,
+      ],
+      edges: [],
+    })
+  })
+
+  afterEach(() => {
+    unregister()
+    useCanvasStore.setState({ nodes: [], edges: [] })
+  })
+
+  it('review card: an on-canvas ref renders as a button; click focuses the node', () => {
+    render(<V5ReviewCardBlock block={REVIEW} />)
+    const btn = screen.getByRole('button', {
+      name: /highlight technical leadership capacity on the canvas/i,
+    })
+    btn.click()
+    expect(focusNode).toHaveBeenCalledWith('fac_tech_lead')
+  })
+
+  it('coaching: an on-canvas ref renders as a button; click focuses the node', () => {
+    render(
+      <V5CoachingBlock
+        block={{
+          ...COACHING,
+          target_refs: [{ id: 'fac_tech_lead', label: 'Technical Leadership Capacity', kind: 'factor' }],
+        }}
+      />,
+    )
+    screen
+      .getByRole('button', { name: /highlight technical leadership capacity on the canvas/i })
+      .click()
+    expect(focusNode).toHaveBeenCalledWith('fac_tech_lead')
+  })
+
+  it('evidence: option-kind refs also focus (all non-edge kinds are canvas nodes)', () => {
+    render(<V5EvidenceBlock block={EVIDENCE} />)
+    screen.getByRole('button', { name: /highlight paid advertising on the canvas/i }).click()
+    expect(focusNode).toHaveBeenCalledWith('opt_paid_ads')
+  })
+
+  it('exercise: the merged target_element_ref pill focuses too', () => {
+    render(
+      <V5ExerciseBlock
+        block={{
+          ...EXERCISE,
+          target_element_ref: { id: 'fac_cost', label: 'Total Cost', kind: 'factor' },
+        }}
+      />,
+    )
+    screen.getByRole('button', { name: /highlight total cost on the canvas/i }).click()
+    expect(focusNode).toHaveBeenCalledWith('fac_cost')
+  })
+
+  it('fails closed: a ref whose id is NOT on the canvas stays an inert span, copy verbatim', () => {
+    render(
+      <V5ReviewCardBlock
+        block={{
+          ...REVIEW,
+          target_refs: [{ id: 'fac_ghost', label: 'Deleted Factor', kind: 'factor' }],
+        }}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /highlight deleted factor/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId('v5-review-card-refs')).toHaveTextContent('Deleted Factor')
+    expect(focusNode).not.toHaveBeenCalled()
+  })
+
+  it('refs containers keep list semantics (listitem per pill) in the clickable state', () => {
+    render(<V5ReviewCardBlock block={REVIEW} />)
+    const refs = screen.getByTestId('v5-review-card-refs')
+    expect(refs.querySelectorAll('[role="listitem"]')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## What

UI-SEAMLESSNESS-REVIEW **R1 + R3** (one seam, approved set R1–R10; Experience workstream Lane 1): every AI reference to the graph in the conversational surface becomes a canvas navigator.

- **New `TargetRefPill`** (`src/canvas/conversation/components/TargetRefPill.tsx`): click → `focusByTarget` pan+select+highlight. **Fail-closed at render time** — kind-scoped canvas-store existence check; stale/unknown targets render the exact pre-change inert `<span>`. DS pill identity preserved in both states (outlined, `text-text-body`); clickable state adds hover/focus affordances only. No-handler click (ReactFlow unmounted) warns + no-ops — EntityLink parity, pinned by a dedicated spec. No telemetry (mirrors EntityLink).
- **R1**: the four V5 phase-3 blocks (`V5CoachingBlock`, `V5EvidenceBlock`, `V5ExerciseBlock`, `V5ReviewCardBlock`) render `target_refs` through TargetRefPill (13–15 blocks per run_analysis turn since 9 Jul were inert spans).
- **R3**: `ProposalBlockRenderer` change targets (bare strings, no id/kind on the wire) resolve via the **ratified string-target rule**: exact node/edge id → else UNIQUE exact trimmed case-sensitive node-label → else inert. Render-time resolution, so label drift de-links. Ambiguity never guesses.

## Tests (RED-first)

RED commit `40330598` pinned 20 failing contracts; GREEN commit makes them pass (57/57 across the four spec files):
- `TargetRefPill.spec.tsx` — click routing per kind, fail-closed inert, kind-scoped existence, render-time re-resolution, a11y, list semantics
- `TargetRefPill.noHandler.spec.tsx` — unregistered-handler pin (real focusHelpers, no mock)
- `V5Phase3Blocks.spec.tsx` — per-block click-to-focus through the REAL focusHelpers path + fail-closed case
- `ProposalBlock.spec.tsx` — id match, edge-id match, unique-label, trim, case-sensitivity, **ambiguity → inert**, unresolvable → inert, render-time de-link

## Gates run

- typecheck (ci config) clean · `npx vitest run --changed origin/staging`: **537 passed / 0 failed** (45 files; 15 initial collection failures were the lane worktree's missing `.env.local`, an environment artefact — resolved and re-run green)
- `tsc -p tsconfig.app.json --noEmit` output **identical** to the origin/staging baseline (4077 pre-existing lines, zero new)
- eslint clean on touched files (one pre-existing `exhaustive-deps` warning in untouched `handleRevealChanges`, noted for the R2 lane)
- Browser verification on the lane branch: app boots clean (no console errors); `focusByTarget` driven through ReactFlowGraph's real registered handler selects+centers a seeded node end-to-end

Independent adversarial review of the full diff is running; merge waits on its verdict + CI shard logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)