### PR TITLE
feat(seamlessness): AI edits visibly land — auto-pulse applied graph patches (R2)

### DIFF
--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -232,7 +232,7 @@ export const ConversationPanel = memo(function ConversationPanel({
             try {
               if (validatedGraph?.nodes && validatedGraph?.edges) {
                 // Runs warning-only schema validation at the mutation boundary.
-                applyValidatedGraph({ nodes: validatedGraph.nodes, edges: validatedGraph.edges })
+                applyValidatedGraph({ nodes: validatedGraph.nodes, edges: validatedGraph.edges }, block.operations)
               } else {
                 if (import.meta.env.DEV) {
                   console.warn('[olumi] op-replay fallback: PLoT did not return full graph, applying operations individually')

--- a/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
+++ b/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
@@ -322,7 +322,7 @@ export function GraphPatchBlockRenderer({
         useCanvasStore.getState().setHighlightedEdges([])
       }, 2000))
     }
-  }, [clearHighlightTimeouts, edgeIds, nodeIds])
+  }, [clearHighlightTimeouts, edgeIds, uniqueTargetNodeIds])
 
   return (
     <div

--- a/src/canvas/conversation/utils/__tests__/applyPatch.pulse.spec.ts
+++ b/src/canvas/conversation/utils/__tests__/applyPatch.pulse.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Seamlessness R2 — the apply choke points fire the applied-edit pulse.
+ *
+ * applyAutoApplyPatch / applyValidatedGraph must call pulseAppliedTargets
+ * with the patch's target ids so the canvas visibly acknowledges AI edits
+ * the moment they land (no "Reveal changes" click needed). The pulse util's
+ * own behaviour (coalescing, fail-closed filtering, 2s clear) is covered by
+ * appliedEditPulse.spec.ts — here we assert the WIRING only.
+ *
+ * Full-draft suppression: the initial brief response auto-applies a patch
+ * that builds the whole graph. Pulsing every node of a fresh draft is noise,
+ * not acknowledgement — suppressed using the SAME >=3-added-nodes threshold
+ * the codebase already uses for the full_draft signal (useConversation).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { pulseMock } = vi.hoisted(() => ({ pulseMock: vi.fn() }))
+vi.mock('../../../utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
+}))
+
+// Store mock (same shape as applyPatch.v3Fields.spec.ts)
+let storeNodes: any[] = []
+let storeEdges: any[] = []
+
+vi.mock('../../../store', () => ({
+  useCanvasStore: Object.assign(vi.fn(), {
+    getState: () => ({
+      nodes: storeNodes,
+      edges: storeEdges,
+      outcomeNodeId: null,
+      ceeAnalysisReady: null,
+      applyLayout: vi.fn(() => Promise.resolve()),
+      setPendingLayout: vi.fn(),
+      setOutcomeNode: vi.fn(),
+      currentScenarioId: null,
+      pushHistory: vi.fn(),
+      markAnalysisFreshnessDirty: vi.fn(),
+    }),
+    setState: vi.fn((update: any) => {
+      if (update.nodes) storeNodes = update.nodes
+      if (update.edges) storeEdges = update.edges
+    }),
+  }),
+}))
+
+vi.mock('../../../store/scenarios', () => ({
+  saveAutosave: vi.fn(),
+}))
+
+import { applyAutoApplyPatch, applyValidatedGraph } from '../applyPatch'
+import type { GraphPatchBlock } from '../../types'
+
+const addNodeOp = (id: string) => ({
+  op: 'add_node',
+  target_id: id,
+  data: { label: id, type: 'factor' },
+})
+
+const makeBlock = (operations: any[]): GraphPatchBlock =>
+  ({
+    block_type: 'graph_patch',
+    auto_apply: true,
+    operations,
+  }) as unknown as GraphPatchBlock
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storeNodes = [
+    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } },
+    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+  ]
+  storeEdges = []
+})
+
+describe('applyAutoApplyPatch → pulse wiring', () => {
+  it('pulses the op targets for a small incremental patch', () => {
+    applyAutoApplyPatch(makeBlock([addNodeOp('f2')]))
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    const arg = pulseMock.mock.calls[0][0]
+    expect(arg.nodeIds).toEqual(['f2'])
+  })
+
+  it('pulses update_node targets too', () => {
+    applyAutoApplyPatch(
+      makeBlock([{ op: 'update_node', target_id: 'f1', data: { label: 'A2' } }]),
+    )
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    expect(pulseMock.mock.calls[0][0].nodeIds).toEqual(['f1'])
+  })
+
+  it('includes edge targets under edgeIds', () => {
+    applyAutoApplyPatch(
+      makeBlock([
+        {
+          op: 'add_edge',
+          target_id: 'e-new',
+          data: { from: 'f1', to: 'g1', weight: 0.5 },
+        },
+      ]),
+    )
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    expect(pulseMock.mock.calls[0][0].edgeIds).toEqual(['e-new'])
+  })
+
+  it('SUPPRESSES the pulse for a full draft (>=3 added nodes — the existing full_draft threshold)', () => {
+    applyAutoApplyPatch(makeBlock([addNodeOp('d1'), addNodeOp('d2'), addNodeOp('d3')]))
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('still pulses at 2 added nodes (below the full-draft threshold)', () => {
+    applyAutoApplyPatch(makeBlock([addNodeOp('d1'), addNodeOp('d2')]))
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('applyValidatedGraph → pulse wiring', () => {
+  const validated = {
+    nodes: [{ id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: {} }],
+    edges: [],
+  }
+
+  it('pulses the supplied applied-op targets', () => {
+    applyValidatedGraph(validated, [
+      { op: 'update_node', target_id: 'f1', data: { label: 'B' } } as any,
+    ])
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    expect(pulseMock.mock.calls[0][0].nodeIds).toEqual(['f1'])
+  })
+
+  it('does not pulse when no ops are supplied (legacy callers unchanged)', () => {
+    applyValidatedGraph(validated)
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -9,6 +9,8 @@
 import { useCanvasStore } from '../../store'
 import { DEFAULT_EDGE_DATA } from '../../domain/edges'
 import { saveAutosave } from '../../store/scenarios'
+import { pulseAppliedTargets } from '../../utils/appliedEditPulse'
+import { extractTargetIdsFromPatch } from './extractTargetIds'
 import { validateNodesBatch } from '../../domain/nodes'
 import { hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from '../../domain/analyticalChange'
 import type { PatchOperation, GraphPatchBlock } from '../types'
@@ -405,6 +407,16 @@ export function applyAutoApplyPatch(patchBlock: GraphPatchBlock): ApplyPatchResu
     useCanvasStore.getState().markAnalysisFreshnessDirty?.()
   }
 
+  // Seamlessness R2: the canvas acknowledges applied AI edits with the same
+  // 2s highlight the "Reveal changes" button fires — pulse the op targets
+  // (removed/absent ids are filtered fail-closed at flush inside the util).
+  // Suppressed for full drafts (>=3 added nodes, the same threshold the
+  // full_draft auto-collapse signal uses) — pulsing an entire freshly
+  // drafted graph is noise, not acknowledgement.
+  if (result.addedNodeCount < 3) {
+    pulseAppliedTargets(extractTargetIdsFromPatch(patchBlock.operations))
+  }
+
   return result
 }
 
@@ -416,7 +428,10 @@ export function applyAutoApplyPatch(patchBlock: GraphPatchBlock): ApplyPatchResu
  * at the mutation boundary. Caller is responsible for wrapping in
  * beginExternalGraphMutation / endExternalGraphMutation when needed.
  */
-export function applyValidatedGraph(validated: { nodes: unknown[]; edges: unknown[] }): void {
+export function applyValidatedGraph(
+  validated: { nodes: unknown[]; edges: unknown[] },
+  appliedOps?: PatchOperation[],
+): void {
   const store = useCanvasStore.getState()
   store.pushHistory()
   useCanvasStore.setState({
@@ -424,6 +439,12 @@ export function applyValidatedGraph(validated: { nodes: unknown[]; edges: unknow
     edges: validated.edges as any,
   })
   validateNodesBatch(validated.nodes as any)
+  // Seamlessness R2 (see applyAutoApplyPatch): when the caller supplies the
+  // accepted patch's operations, pulse their targets. The full-graph replace
+  // itself carries no op list, so legacy callers without ops are unchanged.
+  if (appliedOps && appliedOps.length > 0) {
+    pulseAppliedTargets(extractTargetIdsFromPatch(appliedOps))
+  }
   // This full-graph replace bypasses the edit chokepoints (bare setState), so the
   // freshness overlay must be marked dirty here. applyAnalysisReadyPatch (called
   // after accept) clears it iff the patch supplies a fresh new verdict.

--- a/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
+++ b/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
@@ -99,6 +99,27 @@ describe('pulseAppliedTargets', () => {
     expect(highlighted().nodes).toEqual([])
   })
 
+  it('fails soft when the store lacks the highlight setters (partial store doubles)', () => {
+    const original = {
+      setHighlightedNodes: useCanvasStore.getState().setHighlightedNodes,
+      setHighlightedEdges: useCanvasStore.getState().setHighlightedEdges,
+    }
+    try {
+      useCanvasStore.setState({
+        setHighlightedNodes: undefined as any,
+        setHighlightedEdges: undefined as any,
+      })
+      pulseAppliedTargets({ nodeIds: ['n1'] })
+      // A leaked flush against a partial store must no-op, never throw
+      expect(() => vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)).not.toThrow()
+    } finally {
+      useCanvasStore.setState(original)
+    }
+    // Buffer was discarded — a later flush does not resurrect the stale pulse
+    vi.advanceTimersByTime(PULSE_DURATION_MS + 1)
+    expect(highlighted().nodes).toEqual([])
+  })
+
   it('never touches selection or inspector state', () => {
     const before = {
       selected: useCanvasStore.getState().nodes.map((n: any) => n.selected ?? false),

--- a/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
+++ b/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * appliedEditPulse (seamlessness R2) — behavioral contract against the REAL
+ * canvas store with fake timers.
+ *
+ * The pulse must: coalesce a burst of apply events into ONE highlight over
+ * the union of targets; filter stale ids at flush time (fail-closed); clear
+ * both sets after PULSE_DURATION_MS; never write an empty highlight over an
+ * existing one; and never touch selection/inspector/viewport state.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  pulseAppliedTargets,
+  __resetAppliedEditPulseForTests,
+  PULSE_COALESCE_MS,
+  PULSE_DURATION_MS,
+} from '../appliedEditPulse'
+import { useCanvasStore } from '../../store'
+
+const node = (id: string) =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id } }) as any
+const edge = (id: string) => ({ id, source: 'n1', target: 'n2' }) as any
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  __resetAppliedEditPulseForTests()
+  useCanvasStore.setState({
+    nodes: [node('n1'), node('n2')],
+    edges: [edge('e1')],
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+  })
+})
+
+afterEach(() => {
+  __resetAppliedEditPulseForTests()
+  vi.useRealTimers()
+  useCanvasStore.setState({
+    nodes: [],
+    edges: [],
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+  })
+})
+
+const highlighted = () => ({
+  nodes: [...useCanvasStore.getState().highlightedNodes].sort(),
+  edges: [...useCanvasStore.getState().highlightedEdges].sort(),
+})
+
+describe('pulseAppliedTargets', () => {
+  it('pulses an in-graph node after the coalesce window', () => {
+    pulseAppliedTargets({ nodeIds: ['n1'] })
+    // Nothing before the window closes (coalescing, not instant)
+    expect(highlighted().nodes).toEqual([])
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(highlighted().nodes).toEqual(['n1'])
+  })
+
+  it('coalesces a burst into ONE union pulse (nodes + edges)', () => {
+    pulseAppliedTargets({ nodeIds: ['n1'] })
+    pulseAppliedTargets({ nodeIds: ['n2'], edgeIds: ['e1'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(highlighted()).toEqual({ nodes: ['n1', 'n2'], edges: ['e1'] })
+  })
+
+  it('clears both sets after PULSE_DURATION_MS', () => {
+    pulseAppliedTargets({ nodeIds: ['n1'], edgeIds: ['e1'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(highlighted().nodes).toEqual(['n1'])
+    vi.advanceTimersByTime(PULSE_DURATION_MS + 1)
+    expect(highlighted()).toEqual({ nodes: [], edges: [] })
+  })
+
+  it('filters ids that are not on the canvas (fail-closed, kind-scoped)', () => {
+    // 'ghost' unknown; 'e1' passed as a NODE id must not pulse as a node
+    pulseAppliedTargets({ nodeIds: ['n1', 'ghost', 'e1'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(highlighted().nodes).toEqual(['n1'])
+  })
+
+  it('an all-stale flush writes nothing — an existing highlight survives', () => {
+    useCanvasStore.setState({ highlightedNodes: new Set(['n2']) })
+    pulseAppliedTargets({ nodeIds: ['ghost'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + PULSE_DURATION_MS + 2)
+    expect(highlighted().nodes).toEqual(['n2'])
+  })
+
+  it('a second pulse during an active one replaces the highlight and restarts the clear timer', () => {
+    pulseAppliedTargets({ nodeIds: ['n1'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    vi.advanceTimersByTime(1000)
+    pulseAppliedTargets({ nodeIds: ['n2'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(highlighted().nodes).toEqual(['n2'])
+    // The ORIGINAL clear timer (due ~900ms from now) must not cut this short
+    vi.advanceTimersByTime(1000)
+    expect(highlighted().nodes).toEqual(['n2'])
+    vi.advanceTimersByTime(PULSE_DURATION_MS)
+    expect(highlighted().nodes).toEqual([])
+  })
+
+  it('never touches selection or inspector state', () => {
+    const before = {
+      selected: useCanvasStore.getState().nodes.map((n: any) => n.selected ?? false),
+      inspector: (useCanvasStore.getState() as any).showInspectorPanel,
+    }
+    pulseAppliedTargets({ nodeIds: ['n1'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(useCanvasStore.getState().nodes.map((n: any) => n.selected ?? false)).toEqual(
+      before.selected,
+    )
+    expect((useCanvasStore.getState() as any).showInspectorPanel).toBe(before.inspector)
+  })
+})

--- a/src/canvas/utils/appliedEditPulse.ts
+++ b/src/canvas/utils/appliedEditPulse.ts
@@ -1,3 +1,5 @@
+import { useCanvasStore } from '../store'
+
 // appliedEditPulse — seamlessness R2: when the AI's graph edits land on the
 // canvas (accepted patch, auto-applied patch, or V5 server-applied patch),
 // the canvas acknowledges it immediately with the SAME 2s highlight ring the
@@ -24,9 +26,46 @@ export interface PulseTargets {
   edgeIds?: string[]
 }
 
-export function pulseAppliedTargets(_targets: PulseTargets): void {
-  // RED-checkpoint stub: behaviour lands in the GREEN commit.
+let pendingNodeIds = new Set<string>()
+let pendingEdgeIds = new Set<string>()
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+let clearTimer: ReturnType<typeof setTimeout> | null = null
+
+function flush(): void {
+  flushTimer = null
+  const { nodes, edges, setHighlightedNodes, setHighlightedEdges } =
+    useCanvasStore.getState()
+  const nodeIds = [...pendingNodeIds].filter((id) => nodes.some((n) => n.id === id))
+  const edgeIds = [...pendingEdgeIds].filter((id) => edges.some((e) => e.id === id))
+  pendingNodeIds = new Set()
+  pendingEdgeIds = new Set()
+  if (nodeIds.length === 0 && edgeIds.length === 0) return
+
+  setHighlightedNodes(nodeIds)
+  setHighlightedEdges(edgeIds)
+  if (clearTimer !== null) clearTimeout(clearTimer)
+  clearTimer = setTimeout(() => {
+    clearTimer = null
+    const store = useCanvasStore.getState()
+    store.setHighlightedNodes([])
+    store.setHighlightedEdges([])
+  }, PULSE_DURATION_MS)
+}
+
+export function pulseAppliedTargets(targets: PulseTargets): void {
+  for (const id of targets.nodeIds ?? []) pendingNodeIds.add(id)
+  for (const id of targets.edgeIds ?? []) pendingEdgeIds.add(id)
+  if (flushTimer === null) {
+    flushTimer = setTimeout(flush, PULSE_COALESCE_MS)
+  }
 }
 
 /** Test-only: cancel pending timers and clear the coalesce buffers. */
-export function __resetAppliedEditPulseForTests(): void {}
+export function __resetAppliedEditPulseForTests(): void {
+  if (flushTimer !== null) clearTimeout(flushTimer)
+  if (clearTimer !== null) clearTimeout(clearTimer)
+  flushTimer = null
+  clearTimer = null
+  pendingNodeIds = new Set()
+  pendingEdgeIds = new Set()
+}

--- a/src/canvas/utils/appliedEditPulse.ts
+++ b/src/canvas/utils/appliedEditPulse.ts
@@ -1,0 +1,32 @@
+// appliedEditPulse — seamlessness R2: when the AI's graph edits land on the
+// canvas (accepted patch, auto-applied patch, or V5 server-applied patch),
+// the canvas acknowledges it immediately with the SAME 2s highlight ring the
+// "Reveal changes" button uses — no click required.
+//
+// Contract:
+// - Coalescing: multiple patches can apply in one turn (the auto-apply loop
+//   iterates blocks). setHighlightedNodes REPLACES the set, so naive
+//   per-patch pulses clobber each other and earlier clear-timers wipe later
+//   highlights. Calls within the coalesce window merge into ONE pulse over
+//   the union of targets, with a single clear timer.
+// - Fail-closed: ids are filtered against the canvas store at flush time;
+//   ids not on the canvas (e.g. removals) never pulse. An all-stale flush
+//   writes nothing (never clobbers an existing highlight with emptiness).
+// - Pulse only: no selection, no inspector, no viewport pan — the AI must
+//   not hijack what the user is doing. The ring itself is static (BaseNode
+//   ring-4 / StyledEdge stroke), so it is inherently reduced-motion-safe.
+
+export const PULSE_COALESCE_MS = 100
+export const PULSE_DURATION_MS = 2000
+
+export interface PulseTargets {
+  nodeIds?: string[]
+  edgeIds?: string[]
+}
+
+export function pulseAppliedTargets(_targets: PulseTargets): void {
+  // RED-checkpoint stub: behaviour lands in the GREEN commit.
+}
+
+/** Test-only: cancel pending timers and clear the coalesce buffers. */
+export function __resetAppliedEditPulseForTests(): void {}

--- a/src/canvas/utils/appliedEditPulse.ts
+++ b/src/canvas/utils/appliedEditPulse.ts
@@ -35,6 +35,20 @@ function flush(): void {
   flushTimer = null
   const { nodes, edges, setHighlightedNodes, setHighlightedEdges } =
     useCanvasStore.getState()
+  // Fail-soft on partial store doubles (same convention as the apply path's
+  // optional-chained markAnalysisFreshnessDirty): specs that mock the store
+  // without the highlight setters must not crash when a leaked coalesce
+  // timer fires after their test body.
+  if (
+    typeof setHighlightedNodes !== 'function' ||
+    typeof setHighlightedEdges !== 'function' ||
+    !Array.isArray(nodes) ||
+    !Array.isArray(edges)
+  ) {
+    pendingNodeIds = new Set()
+    pendingEdgeIds = new Set()
+    return
+  }
   const nodeIds = [...pendingNodeIds].filter((id) => nodes.some((n) => n.id === id))
   const edgeIds = [...pendingEdgeIds].filter((id) => edges.some((e) => e.id === id))
   pendingNodeIds = new Set()

--- a/src/v5/__tests__/applyV5State.pulse.test.ts
+++ b/src/v5/__tests__/applyV5State.pulse.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Seamlessness R2 — V5 server-applied graph_patch blocks fire the
+ * applied-edit pulse (wiring only; behaviour covered by
+ * appliedEditPulse.spec.ts). V5 patches arrive already applied — the exact
+ * "AI edited your graph silently" moment R2 exists for.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+const { pulseMock } = vi.hoisted(() => ({ pulseMock: vi.fn() }))
+vi.mock('../../canvas/utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
+}))
+
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+
+function baseResponse(overrides: Partial<OlumiResponse> = {}): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+    ...overrides,
+  }
+}
+
+function makeStore(
+  nodes: V5ApplicatorStore['nodes'] = [],
+  edges: V5ApplicatorStore['edges'] = [],
+): V5ApplicatorStore {
+  return {
+    setCurrentStage: vi.fn(),
+    updateNode: vi.fn(),
+    updateEdgeData: vi.fn(),
+    setRunMeta: vi.fn(),
+    setCeeAnalysisReady: vi.fn(),
+    setGoalConstraints: vi.fn(),
+    backfillGoalThreshold: vi.fn(),
+    nodes,
+    edges,
+  }
+}
+
+const factorNode = { id: 'node-1', data: { label: 'Factor', observedState: {} } } as any
+const anEdge = { id: 'edge-1', source: 'node-1', target: 'node-2', data: {} } as any
+
+beforeEach(() => {
+  pulseMock.mockClear()
+})
+
+describe('applyV5State — applied-edit pulse wiring', () => {
+  it('pulses ONCE with the union of applied node and edge targets', () => {
+    const store = makeStore([factorNode], [anEdge])
+    applyV5State(
+      baseResponse({
+        blocks: [
+          {
+            type: 'graph_patch',
+            status: 'applied',
+            operation: 'set_factor_value',
+            target_id: 'node-1',
+            after: { value: 42 },
+          } as any,
+          {
+            type: 'graph_patch',
+            status: 'applied',
+            operation: 'adjust_edge_strength',
+            target_id: 'edge-1',
+            after: { weight: 0.8 },
+          } as any,
+        ],
+      }),
+      store,
+    )
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    const arg = pulseMock.mock.calls[0][0]
+    expect(arg.nodeIds).toEqual(['node-1'])
+    expect(arg.edgeIds).toEqual(['edge-1'])
+  })
+
+  it('does not pulse when no graph_patch block actually applied', () => {
+    const store = makeStore([factorNode], [])
+    applyV5State(
+      baseResponse({
+        blocks: [
+          // status not 'applied' → skipped by the applicator → no pulse
+          {
+            type: 'graph_patch',
+            status: 'proposed',
+            operation: 'set_factor_value',
+            target_id: 'node-1',
+            after: { value: 42 },
+          } as any,
+          // applied but target missing → deferred, not applied → no pulse
+          {
+            type: 'graph_patch',
+            status: 'applied',
+            operation: 'set_factor_value',
+            target_id: 'ghost',
+            after: { value: 1 },
+          } as any,
+        ],
+      }),
+      store,
+    )
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -37,6 +37,7 @@ import type { CEEAnalysisReady, CEEGoalConstraint } from '../adapters/cee/types'
 import type { CeeDecisionReviewPayloadV1 } from '../types/cee'
 import type { ScenarioStage } from '../types/scenario'
 import { logV5StateStep } from './debugLog'
+import { pulseAppliedTargets } from '../canvas/utils/appliedEditPulse'
 import { extractDecisionReview } from './decisionReviewAdapter'
 import { mapV5AnalysisToReport } from './mapV5AnalysisToReport'
 import { v5StageToScenarioStage } from './stageMapper'
@@ -384,6 +385,11 @@ export function applyV5State(
   for (const block of response.blocks) {
     blockTypeCounts[block.type] = (blockTypeCounts[block.type] ?? 0) + 1
   }
+  // Seamlessness R2: V5 graph_patch blocks arrive already applied
+  // server-side — the exact "AI edited your graph silently" moment. Collect
+  // the targets that actually apply below and pulse once after the loop.
+  const pulsedNodeIds: string[] = []
+  const pulsedEdgeIds: string[] = []
   for (const block of response.blocks) {
     if (block.type === 'graph_patch') {
       if (block.status !== 'applied') continue
@@ -417,6 +423,7 @@ export function applyV5State(
             } as typeof node.data,
           })
           applied.push(`graph_patch:set_factor_value:${target}`)
+          pulsedNodeIds.push(target)
           break
         }
         case 'adjust_edge_strength': {
@@ -433,6 +440,7 @@ export function applyV5State(
           // CEE's adjust_edge_strength carries weight/direction in `after`.
           store.updateEdgeData(target, after as Record<string, unknown>)
           applied.push(`graph_patch:adjust_edge_strength:${target}`)
+          pulsedEdgeIds.push(target)
           break
         }
         case 'add_constraint': {
@@ -479,6 +487,9 @@ export function applyV5State(
     }
     // Other block kinds (text, error, explanation, comparison, flip_analysis)
     // are render-only — no side effects.
+  }
+  if (pulsedNodeIds.length > 0 || pulsedEdgeIds.length > 0) {
+    pulseAppliedTargets({ nodeIds: pulsedNodeIds, edgeIds: pulsedEdgeIds })
   }
   const blockAppliedCount = applied.length - appliedCountBeforeBlocks
   logV5StateStep({


### PR DESCRIPTION
## What

UI-SEAMLESSNESS-REVIEW **R2** (Experience workstream Lane 2): when the AI's graph edits land on the canvas — user-accepted patch, auto-applied patch, or V5 server-applied patch — the canvas acknowledges it **immediately** with the same 2s highlight ring "Reveal changes" fires, no click required. Verified absence premise A5 (no ambient recently-changed system existed).

- **New `appliedEditPulse` util**: coalesces a burst of applies (the auto-apply loop iterates blocks; `setHighlightedNodes` REPLACES, so naive per-patch pulses clobber each other) into ONE pulse over the union of targets with a single 2s clear. Fail-closed in-graph filter at flush; an all-stale flush writes nothing. **Pulse only** — no selection/inspector/viewport hijack; the ring is the existing static visual (inherently reduced-motion-safe).
- Wired at every apply choke point: `applyAutoApplyPatch` (accepted op-replay + no-adapter accept + auto-apply envelope loop), `applyValidatedGraph` (new optional `appliedOps` param; ConversationPanel passes the accepted block's operations), `applyV5State` (server-applied `set_factor_value`/`adjust_edge_strength` targets, one pulse after the loop).
- **Full-draft suppression**: no pulse for patches adding ≥3 nodes (the codebase's existing `full_draft` threshold) — pulsing an entire freshly-drafted graph is noise, not acknowledgement.
- Fixes the pre-existing `exhaustive-deps` warning in `handleRevealChanges` (deps listed `nodeIds`; the body reads `uniqueTargetNodeIds`).

## Tests (RED-first)

RED `86e08c5e` pinned 11 failing contracts; GREEN makes all 16 pass: util behaviour against the REAL store with fake timers (coalescing, kind-scoped stale filter, clear timing, re-pulse restart, no selection/inspector writes) + wiring specs at both choke points (including suppression above/below the threshold and V5 skipped/deferred blocks never pulsing).

## Gates run

- typecheck clean · `vitest --changed origin/staging`: **1155 passed / 0 failed** (51 initial failures were the worktree `.env.local` leaking `VITE_ENABLE_V5_ORCHESTRATOR=true` into vitest and rerouting V4-path hook specs — an environment artefact; flag stripped, all green; CI carries no `.env.local`)
- `tsc -p tsconfig.app.json` output identical to the `77112bd8` baseline · eslint 0 errors (5 pre-existing ConversationPanel warnings untouched; the GraphPatchBlockRenderer one is fixed) · british-english spec green
- Browser proof on the lane build: seeded canvas, drove `applyAutoApplyPatch` with an update+add_edge patch — highlight empty before the coalesce window, node+edge highlighted at 250ms **with the ring class present in the DOM**, both cleared after 2s; zero console errors

Independent adversarial review is running; merge waits on its verdict + CI shard logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)