### PR TITLE
feat(seamlessness): honest fallback card for unknown block kinds (R7)

### DIFF
--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -321,16 +321,23 @@ function BlockRenderer({
       return <V5UnsupportedBlock block={block} />
 
     default: {
-      // Unknown block type — suppress from user view, log for diagnostics
+      // Unknown block type (seamlessness R7): schema-version skew is the
+      // platform's #1 hazard, and a silent drop reads as the AI saying less
+      // than it said. Render the honest fallback card instead of null.
+      // Telemetry event name kept — it now means "fallback card shown".
       const rawType = (block as { type: string }).type
       if (import.meta.env.DEV) {
-        console.warn('[InlineBlocks] Suppressed unknown block type:', rawType, block)
+        console.warn('[InlineBlocks] Unknown block type (fallback card shown):', rawType, block)
       }
       if (!_trackedUnknownBlockTypes.has(rawType)) {
         _trackedUnknownBlockTypes.add(rawType)
         trackEvent('unknown_block_type_suppressed', { block_type: rawType })
       }
-      return null
+      return (
+        <V5UnsupportedBlock
+          block={{ type: 'v5_unsupported', blockType: rawType, raw: block }}
+        />
+      )
     }
   }
 }

--- a/src/canvas/conversation/__tests__/BlockFallback.spec.tsx
+++ b/src/canvas/conversation/__tests__/BlockFallback.spec.tsx
@@ -2,7 +2,8 @@
  * Tests for InlineBlocks unknown block type fallback
  *
  * Verifies:
- * - Unknown block_type renders nothing visible (suppressed)
+ * - Unknown block_type renders the honest fallback card (seamlessness R7 —
+ *   silent suppression was retired; schema-skew must be visible)
  * - Known blocks still render normally alongside unknown ones
  * - Block budget "Show more" toggle works with 5 blocks
  * - graph_patch with proposed status appears in first 4 visible slots
@@ -15,11 +16,14 @@ import type { ConversationBlock, GraphPatchBlock } from '../types'
 import type { PatchBlockState } from '../useConversation'
 
 describe('InlineBlocks — unknown block type fallback', () => {
-  it('renders nothing visible for unknown block_type, does not throw', () => {
+  it('renders the fallback card for unknown block_type, does not throw', () => {
     const unknownBlock = { type: 'future_block_v99', some_field: 'value' } as unknown as ConversationBlock
-    const { container } = render(<InlineBlocks blocks={[unknownBlock]} />)
-    // Unknown blocks are suppressed — no visible content rendered
-    expect(container.querySelector('[data-testid^="block-unknown"]')).toBeNull()
+    render(<InlineBlocks blocks={[unknownBlock]} />)
+    // R7: unknown blocks surface as the honest fallback card
+    expect(screen.getByTestId('v5-unsupported-block')).toHaveAttribute(
+      'data-block-type',
+      'future_block_v99',
+    )
   })
 
   it('does not render "Unsupported block:" text for unknown types', () => {
@@ -35,8 +39,8 @@ describe('InlineBlocks — unknown block type fallback', () => {
     ]
     render(<InlineBlocks blocks={blocks} />)
     expect(screen.getByText('Hello world')).toBeInTheDocument()
-    // Unknown block suppressed
-    expect(screen.queryByText(/unknown_type_xyz/)).not.toBeInTheDocument()
+    // R7: the unknown block renders as the fallback card, not silence
+    expect(screen.getByTestId('v5-unsupported-block')).toBeInTheDocument()
   })
 })
 

--- a/src/canvas/conversation/__tests__/InlineBlocks.unknownBlock.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.unknownBlock.spec.tsx
@@ -1,0 +1,69 @@
+/**
+ * Seamlessness R7 — unknown block kinds get a VISIBLE fallback card.
+ *
+ * Schema-version skew is the platform's documented #1 hazard: a consumer on
+ * an older schema silently drops content it doesn't know, which presents as
+ * the AI saying less than it said. The InlineBlocks default branch used to
+ * `return null` (verified absence A13) — it must now render the honest
+ * "can't display this part" card while KEEPING the existing telemetry
+ * (event name unchanged — dashboards depend on it; it now means "unknown
+ * block type, fallback card shown").
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+const { trackEventMock } = vi.hoisted(() => ({ trackEventMock: vi.fn() }))
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: trackEventMock,
+}))
+
+import { InlineBlocks } from '../InlineBlocks'
+import type { ConversationBlock } from '../types'
+
+const unknownBlock = (type: string): ConversationBlock =>
+  ({ type, some_field: 'from a newer CEE' }) as unknown as ConversationBlock
+
+beforeEach(() => {
+  trackEventMock.mockClear()
+})
+
+describe('InlineBlocks — unknown block kinds (R7)', () => {
+  it('renders the fallback card instead of silently dropping the block', () => {
+    render(<InlineBlocks blocks={[unknownBlock('shiny_new_kind')]} />)
+    const card = screen.getByTestId('v5-unsupported-block')
+    expect(card).toHaveAttribute('data-block-type', 'shiny_new_kind')
+  })
+
+  it('the card copy is honest user-facing language about the app version', () => {
+    render(<InlineBlocks blocks={[unknownBlock('another_new_kind')]} />)
+    const card = screen.getByTestId('v5-unsupported-block')
+    expect(card.textContent).toMatch(/can.t display/i)
+    expect(card.textContent).toMatch(/app version/i)
+  })
+
+  it('keeps the existing telemetry, once per unknown type', () => {
+    render(
+      <InlineBlocks
+        blocks={[unknownBlock('telemetry_kind_a'), unknownBlock('telemetry_kind_a')]}
+      />,
+    )
+    const calls = trackEventMock.mock.calls.filter(
+      (c) => c[0] === 'unknown_block_type_suppressed' && c[1]?.block_type === 'telemetry_kind_a',
+    )
+    expect(calls).toHaveLength(1)
+  })
+
+  it('renders one card per unknown block, and known blocks are unaffected', () => {
+    render(
+      <InlineBlocks
+        blocks={[
+          unknownBlock('kind_x'),
+          unknownBlock('kind_y'),
+          { type: 'v5_unsupported', blockType: 'wrapped_by_mapper', raw: {} } as unknown as ConversationBlock,
+        ]}
+      />,
+    )
+    expect(screen.getAllByTestId('v5-unsupported-block')).toHaveLength(3)
+  })
+})

--- a/src/v5/blocks/V5UnsupportedBlock.tsx
+++ b/src/v5/blocks/V5UnsupportedBlock.tsx
@@ -44,7 +44,8 @@ export function V5UnsupportedBlock({ block }: V5UnsupportedBlockProps): ReactEle
         {block.blockType}
       </span>
       <p className={typography.panelBody}>
-        This content type is not yet rendered.
+        This app version can&apos;t display this part of the response yet.
+        The rest of the message is unaffected.
       </p>
     </div>
   )


### PR DESCRIPTION
## What

UI-SEAMLESSNESS-REVIEW **R7** (Experience workstream Lane 3): unknown block kinds from a newer CEE no longer vanish. InlineBlocks' default branch (verified absence A13: silent `return null`) now renders the pre-existing `V5UnsupportedBlock` card, and that card's copy becomes honest user-facing language: *"This app version can't display this part of the response yet. The rest of the message is unaffected."*

Schema-version skew is the platform's documented #1 hazard, and it used to present as the AI silently saying less than it said — indistinguishable from a dumb AI. Cheapest integrity win on the list.

- Telemetry kept verbatim (`unknown_block_type_suppressed`, once per type — dashboards depend on the name; it now means "fallback card shown").
- `BlockFallback.spec.tsx` updated — it pinned the old suppression, which R7 retires by design; its other coverage (known-blocks-still-render, block budget) preserved.

## Tests (RED-first)

RED `bdb399ff` (3 failing contracts) → GREEN: fallback card renders with `data-block-type`, honest copy, one card per unknown block, telemetry once per type.

## Gates

typecheck clean · `vitest --changed origin/staging`: **504 passed / 0 failed** · `tsc -p tsconfig.app.json` diff vs base: one pre-existing TS6133 line-number shift only, zero new errors · british-english spec green · eslint 0 errors. No browser run: this is a static RTL-covered render with no runtime seam beyond what the DOM tests exercise — stated honestly rather than performed as theatre.

Adversarial review running; merge waits on verdict + CI shard logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)