### PR TITLE
feat(seamlessness): resurrect WhatChangedChip — run-delta chip, mounted + clickable (R6)

### DIFF
--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -18,7 +18,9 @@
  * on every run). Edge "modified" = weight or belief change.
  */
 
+import { useMemo, useSyncExternalStore } from 'react'
 import { loadRuns } from '../store/runHistory'
+import * as runsBus from '../store/runsBus'
 import { pulseAppliedTargets } from '../utils/appliedEditPulse'
 import type { Node, Edge } from '@xyflow/react'
 import { ArrowUpDown } from 'lucide-react'
@@ -81,18 +83,35 @@ function formatCounts(label: string, c: { added: string[]; removed: string[]; mo
   return parts.length > 0 ? `${label}: ${parts.join(', ')}` : null
 }
 
+// The runs list changes only when runsBus emits (add/consolidate/delete).
+// A module-level version + useSyncExternalStore keys the memoised parse so
+// the analysis tab's frequent re-renders (node drags re-render the dock)
+// never re-run loadRuns()'s localStorage JSON.parse of full run payloads.
+let runsVersion = 0
+const subscribeToRuns = (onStoreChange: () => void) =>
+  runsBus.on(() => {
+    runsVersion++
+    onStoreChange()
+  })
+const getRunsVersion = () => runsVersion
+
 export function WhatChangedChip() {
-  // Recomputed per render: the parent (analysis tab) re-renders when a new
-  // run's results land, which is exactly when the stored-run list changes.
-  const runs = loadRuns()
+  const version = useSyncExternalStore(subscribeToRuns, getRunsVersion)
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- version is the cache key for the localStorage read
+  const runs = useMemo(() => loadRuns(), [version])
   if (runs.length < 2) return null
 
   const [latest, previous] = runs // newest-first per loadRuns()'s sort
+  // A run without a graph snapshot (legacy pre-v1.2 entries) is
+  // NON-COMPARABLE, not empty — diffing against [] would fabricate an
+  // "everything added/removed" delta. Same rule as computeRunSummary's
+  // "Snapshot unavailable" precedent: hide instead.
+  if (!latest.graph || !previous.graph) return null
   const diff = computeGraphDiff(
-    latest.graph?.nodes ?? [],
-    latest.graph?.edges ?? [],
-    previous.graph?.nodes ?? [],
-    previous.graph?.edges ?? []
+    latest.graph.nodes ?? [],
+    latest.graph.edges ?? [],
+    previous.graph.nodes ?? [],
+    previous.graph.edges ?? []
   )
 
   const parts = [formatCounts('Nodes', diff.nodes), formatCounts('Edges', diff.edges)].filter(

--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -1,30 +1,32 @@
 /**
- * S6-COMPARE: What Changed Chip
+ * WhatChangedChip — run-over-run graph delta chip (seamlessness R6; first
+ * shippable slice of ROADMAP 2.1 what-changed/compare/timeline).
  *
- * Shows summary of graph changes from previous run:
- * - Nodes: +2, -1, ~3 (added, removed, modified)
- * - Edges: +1, ~2
+ * Diffs the LATEST stored run's graph snapshot against the PREVIOUS run's
+ * (loadRuns() returns newest-first → runs[0] vs runs[1]; the original
+ * orphaned version indexed runs[length-2], the second-OLDEST run). The diff
+ * is CLIENT-SIDE over cached runs only — the copy says so; an engine-backed
+ * run delta is a later contract.
  *
- * Clickable to highlight changes on canvas
+ * Click pulses the added+modified elements via pulseAppliedTargets (same
+ * 2s ring as applied AI edits). Removed elements no longer exist on the
+ * canvas and are excluded — the pulse util would filter them fail-closed
+ * anyway.
+ *
+ * Node "modified" = label change only. Position moves are layout, not an
+ * analytical delta (auto-layout would otherwise mark every node modified
+ * on every run). Edge "modified" = weight or belief change.
  */
 
-import { useCanvasStore } from '../store'
 import { loadRuns } from '../store/runHistory'
-import { useMemo } from 'react'
+import { pulseAppliedTargets } from '../utils/appliedEditPulse'
 import type { Node, Edge } from '@xyflow/react'
+import { ArrowUpDown } from 'lucide-react'
 import { typography } from '../../styles/typography'
 
 interface GraphDiff {
-  nodes: {
-    added: number
-    removed: number
-    modified: number
-  }
-  edges: {
-    added: number
-    removed: number
-    modified: number
-  }
+  nodes: { added: string[]; removed: string[]; modified: string[] }
+  edges: { added: string[]; removed: string[]; modified: string[] }
 }
 
 function computeGraphDiff(
@@ -34,124 +36,96 @@ function computeGraphDiff(
   previousEdges: Edge[]
 ): GraphDiff {
   const diff: GraphDiff = {
-    nodes: { added: 0, removed: 0, modified: 0 },
-    edges: { added: 0, removed: 0, modified: 0 }
+    nodes: { added: [], removed: [], modified: [] },
+    edges: { added: [], removed: [], modified: [] },
   }
 
-  // Build maps for efficient lookup
   const currentNodeMap = new Map(currentNodes.map(n => [n.id, n]))
   const previousNodeMap = new Map(previousNodes.map(n => [n.id, n]))
 
-  // Check nodes
   for (const node of currentNodes) {
-    if (!previousNodeMap.has(node.id)) {
-      diff.nodes.added++
-    } else {
-      // Check if modified (label or position changed)
-      const prev = previousNodeMap.get(node.id)!
-      const labelChanged = node.data?.label !== prev.data?.label
-      const posChanged = node.position.x !== prev.position.x || node.position.y !== prev.position.y
-      if (labelChanged || posChanged) {
-        diff.nodes.modified++
-      }
+    const prev = previousNodeMap.get(node.id)
+    if (!prev) {
+      diff.nodes.added.push(node.id)
+    } else if (node.data?.label !== prev.data?.label) {
+      diff.nodes.modified.push(node.id)
     }
   }
-
   for (const node of previousNodes) {
-    if (!currentNodeMap.has(node.id)) {
-      diff.nodes.removed++
-    }
+    if (!currentNodeMap.has(node.id)) diff.nodes.removed.push(node.id)
   }
 
-  // Build edge maps
   const currentEdgeMap = new Map(currentEdges.map(e => [e.id, e]))
   const previousEdgeMap = new Map(previousEdges.map(e => [e.id, e]))
 
-  // Check edges
   for (const edge of currentEdges) {
-    if (!previousEdgeMap.has(edge.id)) {
-      diff.edges.added++
-    } else {
-      // Check if modified (weight or belief changed)
-      const prev = previousEdgeMap.get(edge.id)!
-      const weightChanged = edge.data?.weight !== prev.data?.weight
-      const beliefChanged = edge.data?.belief !== prev.data?.belief
-      if (weightChanged || beliefChanged) {
-        diff.edges.modified++
-      }
+    const prev = previousEdgeMap.get(edge.id)
+    if (!prev) {
+      diff.edges.added.push(edge.id)
+    } else if (edge.data?.weight !== prev.data?.weight || edge.data?.belief !== prev.data?.belief) {
+      diff.edges.modified.push(edge.id)
     }
   }
-
   for (const edge of previousEdges) {
-    if (!currentEdgeMap.has(edge.id)) {
-      diff.edges.removed++
-    }
+    if (!currentEdgeMap.has(edge.id)) diff.edges.removed.push(edge.id)
   }
 
   return diff
 }
 
-export function WhatChangedChip() {
-  // React #185 FIX: Use shallow comparison for array selectors
-  const nodes = useCanvasStore(s => s.nodes)
-  const edges = useCanvasStore(s => s.edges)
-
-  const diff = useMemo(() => {
-    const runs = loadRuns()
-    if (runs.length < 2) {
-      return null // Need at least 2 runs to compare
-    }
-
-    // Compare current graph with previous run
-    const previousRun = runs[runs.length - 2] // Second to last run
-    const previousNodes = previousRun.graph?.nodes ?? []
-    const previousEdges = previousRun.graph?.edges ?? []
-
-    return computeGraphDiff(nodes, edges, previousNodes, previousEdges)
-  }, [nodes, edges])
-
-  if (!diff) {
-    return null // No previous run to compare
-  }
-
-  const totalChanges =
-    diff.nodes.added + diff.nodes.removed + diff.nodes.modified +
-    diff.edges.added + diff.edges.removed + diff.edges.modified
-
-  if (totalChanges === 0) {
-    return null // No changes
-  }
-
-  // Format change summary
+function formatCounts(label: string, c: { added: string[]; removed: string[]; modified: string[] }): string | null {
   const parts: string[] = []
+  if (c.added.length > 0) parts.push(`+${c.added.length}`)
+  if (c.removed.length > 0) parts.push(`-${c.removed.length}`)
+  if (c.modified.length > 0) parts.push(`~${c.modified.length}`)
+  return parts.length > 0 ? `${label}: ${parts.join(', ')}` : null
+}
 
-  if (diff.nodes.added > 0 || diff.nodes.removed > 0 || diff.nodes.modified > 0) {
-    const nodeParts: string[] = []
-    if (diff.nodes.added > 0) nodeParts.push(`+${diff.nodes.added}`)
-    if (diff.nodes.removed > 0) nodeParts.push(`-${diff.nodes.removed}`)
-    if (diff.nodes.modified > 0) nodeParts.push(`~${diff.nodes.modified}`)
-    parts.push(`Nodes: ${nodeParts.join(', ')}`)
-  }
+export function WhatChangedChip() {
+  // Recomputed per render: the parent (analysis tab) re-renders when a new
+  // run's results land, which is exactly when the stored-run list changes.
+  const runs = loadRuns()
+  if (runs.length < 2) return null
 
-  if (diff.edges.added > 0 || diff.edges.removed > 0 || diff.edges.modified > 0) {
-    const edgeParts: string[] = []
-    if (diff.edges.added > 0) edgeParts.push(`+${diff.edges.added}`)
-    if (diff.edges.removed > 0) edgeParts.push(`-${diff.edges.removed}`)
-    if (diff.edges.modified > 0) edgeParts.push(`~${diff.edges.modified}`)
-    parts.push(`Edges: ${edgeParts.join(', ')}`)
+  const [latest, previous] = runs // newest-first per loadRuns()'s sort
+  const diff = computeGraphDiff(
+    latest.graph?.nodes ?? [],
+    latest.graph?.edges ?? [],
+    previous.graph?.nodes ?? [],
+    previous.graph?.edges ?? []
+  )
+
+  const parts = [formatCounts('Nodes', diff.nodes), formatCounts('Edges', diff.edges)].filter(
+    (p): p is string => p !== null
+  )
+  if (parts.length === 0) return null
+
+  const handleClick = () => {
+    // Removed elements are gone from the canvas — only surviving changes
+    // can be highlighted.
+    pulseAppliedTargets({
+      nodeIds: [...diff.nodes.added, ...diff.nodes.modified],
+      edgeIds: [...diff.edges.added, ...diff.edges.modified],
+    })
   }
 
   return (
-    <div
-      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-panel border border-info/30 text-info ${typography.caption} font-medium`}
-      role="status"
-      aria-label={`Graph changed: ${parts.join(' • ')}`}
+    <button
+      type="button"
+      onClick={handleClick}
+      className={[
+        'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full',
+        'bg-transparent border border-info/30 text-text-body',
+        typography.caption,
+        'font-medium cursor-pointer hover:border-info/50 hover:underline',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-info',
+      ].join(' ')}
+      aria-label={`Since your last run: ${parts.join(', ')}. Highlight the changes on the canvas.`}
+      title="Compared with the previous analysis stored on this device"
       data-testid="what-changed-chip"
     >
-      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
-      </svg>
-      <span>What changed: {parts.join(' • ')}</span>
-    </div>
+      <ArrowUpDown size={14} className="text-info flex-none" aria-hidden="true" />
+      <span>Since your last run: {parts.join(' • ')}</span>
+    </button>
   )
 }

--- a/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
@@ -1,631 +1,199 @@
 /**
- * S6-COMPARE: WhatChangedChip Tests
+ * WhatChangedChip (seamlessness R6 / ROADMAP 2.1 first slice) — run-over-run
+ * graph delta chip.
  *
- * Tests the "What changed" chip that shows graph differences from previous run
- * Requirements: ≥8 test assertions
+ * Contract:
+ * - Diffs the LATEST stored run's graph snapshot against the PREVIOUS run's.
+ *   loadRuns() returns newest-first, so that is runs[0] vs runs[1] — the
+ *   original orphaned component read runs[length-2] (the second-OLDEST run;
+ *   the old spec masked this by mocking runs oldest-first), which this spec
+ *   pins against regression.
+ * - The diff is id-precise: click pulses the added+modified elements via
+ *   pulseAppliedTargets. Removed elements no longer exist and cannot be
+ *   highlighted (fail-closed downstream).
+ * - Node "modified" = label change. Position-only moves are layout, not an
+ *   analytical delta, and must NOT count (auto-layout would otherwise mark
+ *   every node modified on every run).
+ * - Copy is honest about the client-side cached-run basis ("since your last
+ *   run") — the engine-backed delta is a later contract (ROADMAP 2.1).
+ * - Hidden entirely (<2 runs, or zero delta). Ignores the LIVE canvas —
+ *   the delta is between analyses, not live edits.
  */
-
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { WhatChangedChip } from '../WhatChangedChip'
-import { useCanvasStore } from '../../store'
-import * as runHistoryModule from '../../store/runHistory'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import type { Node, Edge } from '@xyflow/react'
-import type { StoredRun } from '../../store/runHistory'
 
-// Mock loadRuns from runHistory
-vi.mock('../../store/runHistory', () => ({
-  loadRuns: vi.fn()
+const { loadRunsMock, pulseMock } = vi.hoisted(() => ({
+  loadRunsMock: vi.fn(),
+  pulseMock: vi.fn(),
+}))
+vi.mock('../../store/runHistory', () => ({ loadRuns: loadRunsMock }))
+vi.mock('../../utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
 }))
 
-describe('S6-COMPARE: WhatChangedChip', () => {
-  const mockLoadRuns = vi.mocked(runHistoryModule.loadRuns)
+import { WhatChangedChip } from '../WhatChangedChip'
 
+const node = (id: string, label: string, x = 0, y = 0): Node =>
+  ({ id, type: 'factor', position: { x, y }, data: { label } }) as Node
+const edge = (id: string, weight: number, belief = 0.7): Edge =>
+  ({ id, source: 'a', target: 'b', data: { weight, belief } }) as Edge
+
+let runSeq = 0
+/** Runs are supplied NEWEST-FIRST, matching loadRuns()'s sort. */
+const run = (graph: { nodes: Node[]; edges: Edge[] }) => ({
+  id: `run-${++runSeq}`,
+  ts: 1000 - runSeq,
+  graph,
+})
+
+beforeEach(() => {
+  loadRunsMock.mockReset()
+  pulseMock.mockReset()
+})
+afterEach(() => cleanup())
+
+describe('WhatChangedChip — visibility', () => {
+  it('renders nothing with fewer than 2 runs', () => {
+    loadRunsMock.mockReturnValue([run({ nodes: [node('a', 'A')], edges: [] })])
+    render(<WhatChangedChip />)
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when the last two runs are identical', () => {
+    const g = { nodes: [node('a', 'A')], edges: [edge('e1', 0.5)] }
+    loadRunsMock.mockReturnValue([run(g), run(g)])
+    render(<WhatChangedChip />)
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when a run lacks a graph snapshot (older stored runs)', () => {
+    loadRunsMock.mockReturnValue([
+      { id: 'r-nograph-1', ts: 2 },
+      { id: 'r-nograph-2', ts: 1 },
+    ])
+    render(<WhatChangedChip />)
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
+})
+
+describe('WhatChangedChip — diffs the last two runs (newest-first order)', () => {
+  it('compares runs[0] against runs[1], NOT the oldest runs', () => {
+    // Newest-first: latest adds node 'c' vs previous. The two OLDER runs
+    // differ wildly — the pre-R6 component indexed runs[length-2] (the
+    // second-oldest) and would report that delta instead.
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A'), node('b', 'B'), node('c', 'C')], edges: [] }), // latest
+      run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }), // previous
+      run({ nodes: [], edges: [] }), // second-oldest (the buggy index)
+      run({ nodes: [node('z', 'Z')], edges: [edge('ez', 1)] }), // oldest
+    ])
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/Nodes: \+1/)
+    expect(chip.textContent).not.toMatch(/-\d/) // no removals in run0-vs-run1
+  })
+
+  it('counts added, removed, and label-modified nodes', () => {
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A renamed'), node('c', 'C')], edges: [] }),
+      run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }),
+    ])
+    render(<WhatChangedChip />)
+    expect(screen.getByTestId('what-changed-chip').textContent).toMatch(/Nodes: \+1, -1, ~1/)
+  })
+
+  it('position-only moves are NOT counted as modified (layout is not an analytical delta)', () => {
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A', 500, 500)], edges: [] }),
+      run({ nodes: [node('a', 'A', 0, 0)], edges: [] }),
+    ])
+    render(<WhatChangedChip />)
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
+
+  it('counts edge weight/belief changes as modified', () => {
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A')], edges: [edge('e1', 0.9), edge('e2', 0.5, 0.2)] }),
+      run({ nodes: [node('a', 'A')], edges: [edge('e1', 0.5), edge('e2', 0.5, 0.9)] }),
+    ])
+    render(<WhatChangedChip />)
+    expect(screen.getByTestId('what-changed-chip').textContent).toMatch(/Edges: ~2/)
+  })
+
+  it('ignores the live canvas — the delta is between stored analyses', () => {
+    // No canvas store seeding at all: chip output must come from runs alone.
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A'), node('n2', 'New')], edges: [] }),
+      run({ nodes: [node('a', 'A')], edges: [] }),
+    ])
+    render(<WhatChangedChip />)
+    expect(screen.getByTestId('what-changed-chip').textContent).toMatch(/Nodes: \+1/)
+  })
+})
+
+describe('WhatChangedChip — click-to-highlight (the docstring promise, now real)', () => {
+  it('is a button; click pulses the added+modified element ids', () => {
+    loadRunsMock.mockReturnValue([
+      run({
+        nodes: [node('a', 'A renamed'), node('c', 'C')],
+        edges: [edge('e1', 0.9), edge('e-new', 0.4)],
+      }),
+      run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [edge('e1', 0.5)] }),
+    ])
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.tagName).toBe('BUTTON')
+    fireEvent.click(chip)
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    const arg = pulseMock.mock.calls[0][0]
+    expect([...arg.nodeIds].sort()).toEqual(['a', 'c']) // modified + added; removed 'b' excluded
+    expect([...arg.edgeIds].sort()).toEqual(['e-new', 'e1'])
+  })
+
+  it('a removals-only delta still shows the chip but the click pulses nothing', () => {
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A')], edges: [] }),
+      run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }),
+    ])
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/Nodes: -1/)
+    fireEvent.click(chip)
+    expect(pulseMock).toHaveBeenCalledWith({ nodeIds: [], edgeIds: [] })
+  })
+})
+
+describe('WhatChangedChip — honesty + a11y + DS', () => {
   beforeEach(() => {
-    // Reset store to clean state
-    useCanvasStore.setState({
-      nodes: [],
-      edges: []
-    })
-
-    // Reset mock
-    mockLoadRuns.mockReturnValue([])
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A'), node('c', 'C')], edges: [] }),
+      run({ nodes: [node('a', 'A')], edges: [] }),
+    ])
   })
 
-  describe('Visibility Conditions', () => {
-    it('should not render when there are fewer than 2 runs', () => {
-      // Only 1 run in history
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now(),
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        }
-      ])
-
-      const { container } = render(<WhatChangedChip />)
-      expect(container.firstChild).toBeNull()
-    })
-
-    it('should not render when there are no changes between runs', () => {
-      const sameGraph = {
-        nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }] as Node[],
-        edges: [{ id: 'e1', source: '1', target: '2' }] as Edge[]
-      }
-
-      // Two runs with identical graphs
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: sameGraph
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: sameGraph
-        }
-      ])
-
-      // Set current graph to match history
-      useCanvasStore.setState({
-        nodes: sameGraph.nodes,
-        edges: sameGraph.edges
-      })
-
-      const { container } = render(<WhatChangedChip />)
-      expect(container.firstChild).toBeNull()
-    })
-
-    it('should render when there are changes between current and previous run', () => {
-      // Previous run had 1 node
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        }
-      ])
-
-      // Current graph has 2 nodes (matches run-2)
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByTestId('what-changed-chip')).toBeInTheDocument()
-    })
+  it('copy states the client-side previous-run basis', () => {
+    render(<WhatChangedChip />)
+    expect(screen.getByTestId('what-changed-chip').textContent).toMatch(/since your last run/i)
   })
 
-  describe('Node Changes Display', () => {
-    it('should show added nodes', () => {
-      // Previous run: 1 node
-      // Current run: 2 nodes (1 added)
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Nodes: \+1/)).toBeInTheDocument()
-    })
-
-    it('should show removed nodes', () => {
-      // Previous run: 2 nodes
-      // Current run: 1 node (1 removed)
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Nodes: -1/)).toBeInTheDocument()
-    })
-
-    it('should show modified nodes', () => {
-      // Previous run: 1 node with label "Old Label"
-      // Current run: Same node with label "New Label" (modified)
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Old Label' } }],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'New Label' } }],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'New Label' } }],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Nodes: ~1/)).toBeInTheDocument()
-    })
-
-    it('should show combined node changes', () => {
-      // Previous run: nodes 1, 2, 3
-      // Current run: nodes 1 (modified), 3, 4 (node 2 removed, node 4 added, node 1 modified)
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1 Old' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } },
-              { id: '3', type: 'decision', position: { x: 200, y: 0 }, data: { label: 'Node 3' } }
-            ],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1 New' } },
-              { id: '3', type: 'decision', position: { x: 200, y: 0 }, data: { label: 'Node 3' } },
-              { id: '4', type: 'decision', position: { x: 300, y: 0 }, data: { label: 'Node 4' } }
-            ],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1 New' } },
-          { id: '3', type: 'decision', position: { x: 200, y: 0 }, data: { label: 'Node 3' } },
-          { id: '4', type: 'decision', position: { x: 300, y: 0 }, data: { label: 'Node 4' } }
-        ],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Nodes: \+1, -1, ~1/)).toBeInTheDocument()
-    })
+  it('has an accessible label naming the delta and the highlight action', () => {
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip).toHaveAttribute('aria-label', expect.stringMatching(/highlight/i))
+    expect(chip).toHaveAttribute('type', 'button')
   })
 
-  describe('Edge Changes Display', () => {
-    it('should show added edges', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: [{ id: 'e1-2', source: '1', target: '2' }]
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: [{ id: 'e1-2', source: '1', target: '2' }]
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Edges: \+1/)).toBeInTheDocument()
-    })
-
-    it('should show modified edges', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: [{ id: 'e1-2', source: '1', target: '2', data: { weight: 0.5 } }]
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: [{ id: 'e1-2', source: '1', target: '2', data: { weight: 0.8 } }]
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: [{ id: 'e1-2', source: '1', target: '2', data: { weight: 0.8 } }]
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Edges: ~1/)).toBeInTheDocument()
-    })
-
-    it('should show combined node and edge changes', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } },
-              { id: '3', type: 'decision', position: { x: 200, y: 0 }, data: { label: 'Node 3' } }
-            ],
-            edges: [
-              { id: 'e1-2', source: '1', target: '2' },
-              { id: 'e2-3', source: '2', target: '3' }
-            ]
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } },
-          { id: '3', type: 'decision', position: { x: 200, y: 0 }, data: { label: 'Node 3' } }
-        ],
-        edges: [
-          { id: 'e1-2', source: '1', target: '2' },
-          { id: 'e2-3', source: '2', target: '3' }
-        ]
-      })
-
-      render(<WhatChangedChip />)
-      const chip = screen.getByTestId('what-changed-chip')
-      expect(chip).toHaveTextContent(/Nodes: \+1/)
-      expect(chip).toHaveTextContent(/Edges: \+2/)
-    })
-  })
-
-  describe('Accessibility and UI', () => {
-    it('should have correct ARIA label', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      const chip = screen.getByTestId('what-changed-chip')
-      expect(chip).toHaveAttribute('role', 'status')
-      expect(chip).toHaveAttribute('aria-label', 'Graph changed: Nodes: +1')
-    })
-
-    it('should have correct test ID', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByTestId('what-changed-chip')).toBeInTheDocument()
-    })
-
-    it('should display change icon', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: []
-      })
-
-      const { container } = render(<WhatChangedChip />)
-      const svg = container.querySelector('svg')
-      expect(svg).toBeInTheDocument()
-      expect(svg).toHaveClass('w-3.5', 'h-3.5')
-    })
-  })
-
-  describe('Edge Cases', () => {
-    it('should handle position changes as modifications', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [{ id: '1', type: 'goal', position: { x: 100, y: 50 }, data: { label: 'Node 1' } }],
-            edges: []
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [{ id: '1', type: 'goal', position: { x: 100, y: 50 }, data: { label: 'Node 1' } }],
-        edges: []
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Nodes: ~1/)).toBeInTheDocument()
-    })
-
-    it('should handle belief changes in edges as modifications', () => {
-      mockLoadRuns.mockReturnValue([
-        {
-          id: 'run-1',
-          timestamp: Date.now() - 1000,
-          hash: 'hash-1',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: [{ id: 'e1-2', source: '1', target: '2', data: { weight: 0.5, belief: 0.5 } }]
-          }
-        },
-        {
-          id: 'run-2',
-          timestamp: Date.now(),
-          hash: 'hash-2',
-          seed: 1234,
-          graph: {
-            nodes: [
-              { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-              { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-            ],
-            edges: [{ id: 'e1-2', source: '1', target: '2', data: { weight: 0.5, belief: 0.8 } }]
-          }
-        }
-      ])
-
-      useCanvasStore.setState({
-        nodes: [
-          { id: '1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-          { id: '2', type: 'decision', position: { x: 100, y: 0 }, data: { label: 'Node 2' } }
-        ],
-        edges: [{ id: 'e1-2', source: '1', target: '2', data: { weight: 0.5, belief: 0.8 } }]
-      })
-
-      render(<WhatChangedChip />)
-      expect(screen.getByText(/Edges: ~1/)).toBeInTheDocument()
-    })
+  it('keeps the outlined-pill DS identity (no filled pill, no text-colour copy token)', () => {
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.className).toContain('bg-transparent')
+    expect(chip.className).toContain('border-info/30')
+    expect(chip.className).toContain('text-text-body')
+    expect(chip.className).not.toMatch(/(^| )text-info( |$)/)
   })
 })

--- a/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
@@ -79,6 +79,24 @@ describe('WhatChangedChip — visibility', () => {
     render(<WhatChangedChip />)
     expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
   })
+
+  it('hides on a SINGLE-SIDED missing snapshot — never fabricates an everything-added delta', () => {
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }), // latest has a graph
+      { id: 'r-legacy', ts: 1 }, // previous predates v1.2 snapshots
+    ])
+    render(<WhatChangedChip />)
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
+
+  it('hides when only the LATEST run lacks a snapshot (reverse single-sided case)', () => {
+    loadRunsMock.mockReturnValue([
+      { id: 'r-legacy', ts: 2 },
+      run({ nodes: [node('a', 'A')], edges: [] }),
+    ])
+    render(<WhatChangedChip />)
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
 })
 
 describe('WhatChangedChip — diffs the last two runs (newest-first order)', () => {

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -29,6 +29,7 @@ import { DecisionConfidencePanel } from './DecisionConfidencePanel'
 import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
 import { AnalysisFreshnessNotice } from './AnalysisFreshnessNotice'
+import { WhatChangedChip } from '../../canvas/components/WhatChangedChip'
 import { InferenceWarningStrip } from './InferenceWarningStrip'
 import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
 import { AnalysisHeroContainer } from './analysis-hero'
@@ -239,6 +240,11 @@ export const ResultsBody = memo(function ResultsBody({
           the freshness area. Producer message verbatim; info-severity stays
           hidden; renders nothing when no warning-severity entries exist. */}
       <InferenceWarningStrip warnings={resultsSectionData.confidence.inferenceWarnings} />
+
+      {/* Seamlessness R6 / ROADMAP 2.1 slice 1: run-over-run delta chip.
+          Client-side diff of the two most recent stored runs; self-hides on
+          first runs or zero delta; click pulses the surviving changes. */}
+      <WhatChangedChip />
 
       {/* ── ANALYSIS HERO (answer-first lens hero) ─────────────────
           Feature-flagged (staging-on, production-off). Read-only

--- a/src/components/results/__tests__/ResultsBody.whatChanged.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.whatChanged.spec.tsx
@@ -1,0 +1,165 @@
+/**
+ * ResultsBody — WhatChangedChip mount (seamlessness R6 / ROADMAP 2.1 slice 1).
+ *
+ * The run-delta chip mounts in the analysis-tab header stack, after the
+ * freshness notice slot and above the hero block. It self-hides (<2 stored
+ * runs or zero delta), so mounting it must be a no-op for first runs.
+ * Fixture pattern mirrors ResultsBody.heroPlacement.spec.tsx.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+}))
+
+const { loadRunsMock, pulseMock } = vi.hoisted(() => ({
+  loadRunsMock: vi.fn(),
+  pulseMock: vi.fn(),
+}))
+vi.mock('../../../canvas/store/runHistory', () => ({ loadRuns: loadRunsMock }))
+vi.mock('../../../canvas/utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }
+})
+
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+  } as unknown as OptionResult
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner],
+    goalLabel: 'Maximise success',
+    goalThreshold: 0.6,
+    isSingleOption: true,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+const nodeFx = (id: string, label: string) =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label } }) as any
+
+const runFx = (nodes: any[], seq: number) => ({ id: `run-${seq}`, ts: 100 - seq, graph: { nodes, edges: [] } })
+
+function renderBody() {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+const before = (a: HTMLElement, b: HTMLElement) =>
+  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+beforeEach(() => {
+  loadRunsMock.mockReset()
+  pulseMock.mockReset()
+  useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+  useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+})
+
+describe('ResultsBody — WhatChangedChip mount (R6)', () => {
+  it('mounts the chip in the header stack when the last two runs differ', () => {
+    loadRunsMock.mockReturnValue([
+      runFx([nodeFx('a', 'A'), nodeFx('b', 'B')], 1), // latest
+      runFx([nodeFx('a', 'A')], 2), // previous
+    ])
+    renderBody()
+    const chip = screen.getByTestId('what-changed-chip')
+    const existingHero = screen.getByTestId('decision-confidence-panel')
+    expect(before(chip, existingHero), 'chip must precede the hero block').toBe(true)
+  })
+
+  it('renders no chip on a first run (fewer than 2 stored runs)', () => {
+    loadRunsMock.mockReturnValue([runFx([nodeFx('a', 'A')], 1)])
+    renderBody()
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
+
+  it('renders no chip when nothing changed between runs', () => {
+    const same = [nodeFx('a', 'A')]
+    loadRunsMock.mockReturnValue([runFx(same, 1), runFx(same, 2)])
+    renderBody()
+    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+  })
+})

--- a/tools/ci-guards/ds-compliance-baseline.json
+++ b/tools/ci-guards/ds-compliance-baseline.json
@@ -5066,7 +5066,6 @@
         "src/canvas/components/PropertiesPanel.tsx": 1,
         "src/canvas/components/ScenarioSwitcher.tsx": 1,
         "src/canvas/components/ValidationSuggestions.tsx": 1,
-        "src/canvas/components/WhatChangedChip.tsx": 1,
         "src/canvas/components/pre-analysis/primitives/BiasIcon.tsx": 1,
         "src/canvas/components/pre-analysis/primitives/NodeLink.tsx": 1,
         "src/canvas/conversation/zones/SuggestedChips.tsx": 1,
@@ -5446,12 +5445,6 @@
         "production-hex :: src/canvas/components/ValidationSuggestions.tsx :: #185": {
           "count": 1,
           "file": "src/canvas/components/ValidationSuggestions.tsx",
-          "token": "#185",
-          "sample": "// React #185 FIX: Use shallow comparison for array selectors"
-        },
-        "production-hex :: src/canvas/components/WhatChangedChip.tsx :: #185": {
-          "count": 1,
-          "file": "src/canvas/components/WhatChangedChip.tsx",
           "token": "#185",
           "sample": "// React #185 FIX: Use shallow comparison for array selectors"
         },

--- a/tools/ci-guards/ds-compliance-baseline.json
+++ b/tools/ci-guards/ds-compliance-baseline.json
@@ -4994,7 +4994,7 @@
     "production-hex": {
       "mode": "ratchet",
       "description": "Raw hex colour literals in production .ts/.tsx (excl. debug/poc/theme/tests + var() fallbacks)",
-      "total": 437,
+      "total": 436,
       "byFile": {
         "src/components/ContractInspector.tsx": 67,
         "src/canvas/export/decisionBrief.ts": 33,


### PR DESCRIPTION
## What

UI-SEAMLESSNESS-REVIEW **R6** / first shippable slice of **ROADMAP 2.1** (Experience workstream Lane 4): the orphaned `WhatChangedChip` (verified absence A6 — never mounted, no onClick despite its docstring's promise) becomes real.

- **Index bug fixed**: `loadRuns()` sorts newest-first; the previous run is `runs[1]`. The orphaned code diffed against `runs[length-2]` — the second-*oldest* run — masked by its spec's unsorted mocks. Pinned by a regression test with 4 runs.
- **Run-over-run semantics**: diffs `runs[0].graph` vs `runs[1].graph` (the live canvas is no longer an input — the delta is between analyses). Node "modified" = label change only; position-only moves are layout noise and no longer count.
- **Click-to-highlight delivered**: id-precise diff → `pulseAppliedTargets` (the R2 primitive: coalesced, fail-closed, same 2s ring). Removed elements are excluded — they no longer exist to highlight; a removals-only delta still shows the chip.
- **Honest copy**: "Since your last run: Nodes: +2, -1, ~1 • Edges: ~2" + title naming the on-device basis. Client-side cached diff only — the engine-backed delta is a later contract (2.1's remaining scope).
- **DS compliance on mount**: outlined pill (`bg-transparent`/`text-text-body`; was a filled `text-info` pill), Lucide `ArrowUpDown` replaces a raw inline SVG. Colour rides the icon only.
- **Mounted** in ResultsBody's header stack (after the freshness area, above the hero). Self-hides on first runs / zero delta / missing snapshots.
- DS baseline: two false-positive `#185` hex entries for this file dropped (their matched comment was removed).

**Bonus**: the rewrite removes **42 pre-existing `tsc-app-config` errors** (the orphaned chip + old spec were type-broken at base). Zero new errors (one pre-existing ResultsBody error shifts 349→355 from the 6-line mount insert).

## Tests (RED-first)

RED `274a9541` (12 failing contracts) → GREEN 16/16. Old 631-line spec replaced wholesale; coverage classes preserved (visibility, node/edge counts, a11y, edge cases) with corrected semantics + new pins: newest-first indexing, position-only exclusion, click payload ids, removals-only click no-op, since-your-last-run copy, DS pill identity, ResultsBody mount/self-hide.

## Gates

typecheck clean · `vitest --changed origin/staging` **187 passed / 0 failed** · wide tsc diff: −42 pre-existing, +0 new · british-english green · eslint clean. Browser: the pulse→ring path was browser-proven in #257 and the chip→pulse call + mount are RTL-pinned; no separate browser drive for this slice (a full drive needs two live analysis runs) — stated honestly.

Adversarial review running; merge waits on verdict + CI shard logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)