### PR TITLE
feat(seamlessness): ui_directive dispatcher — the AI can point at the canvas (R4 UI half)

### DIFF
--- a/src/v5/__tests__/applyV5State.uiDirective.test.ts
+++ b/src/v5/__tests__/applyV5State.uiDirective.test.ts
@@ -1,0 +1,180 @@
+/**
+ * R4 UI half — ui_directive dispatcher (surfacing gates 3–5).
+ *
+ * CEE's first slice (merged dark, CEE PR #408) emits at most ONE directive
+ * per fresh run_analysis turn: verb `highlight`, typed target refs, no free
+ * text. The UI executes it at applyV5State (the once-per-envelope
+ * side-effect site — never render-driven, so re-renders can't re-fire it):
+ *
+ * - `highlight` targets join the SAME coalesced pulse the applied-edit path
+ *   uses (fail-closed in-graph filter, one 2s ring, no viewport movement —
+ *   the AI cannot hijack what the user is doing).
+ * - Rate limit: exactly ONE directive executed per envelope (the producer
+ *   contract); extras are deferred, never silently executed.
+ * - `focus` / `open_inspector` are schema-valid but DEFERRED fail-closed in
+ *   this slice (viewport/panel-moving verbs need their own rate-limit
+ *   design); they must no-op with a deferred record, never crash.
+ * - Directives are instructions, not content: the mapper renders nothing
+ *   (pinned in mapV5Blocks.holds0150.test.ts); execution must be visible
+ *   only as the highlight itself.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+const { pulseMock } = vi.hoisted(() => ({ pulseMock: vi.fn() }))
+vi.mock('../../canvas/utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
+}))
+
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+
+function baseResponse(overrides: Partial<OlumiResponse> = {}): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+    ...overrides,
+  }
+}
+
+function makeStore(
+  nodes: V5ApplicatorStore['nodes'] = [],
+  edges: V5ApplicatorStore['edges'] = [],
+): V5ApplicatorStore {
+  return {
+    setCurrentStage: vi.fn(),
+    updateNode: vi.fn(),
+    updateEdgeData: vi.fn(),
+    setRunMeta: vi.fn(),
+    setCeeAnalysisReady: vi.fn(),
+    setGoalConstraints: vi.fn(),
+    backfillGoalThreshold: vi.fn(),
+    nodes,
+    edges,
+  }
+}
+
+const directive = (verb: string, targets: Array<{ id: string; label: string; kind: string }>) =>
+  ({ type: 'ui_directive', verb, targets }) as never
+
+beforeEach(() => {
+  pulseMock.mockClear()
+})
+
+describe('applyV5State — ui_directive dispatcher (R4)', () => {
+  it('executes a highlight directive: one pulse carrying the target ids', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('highlight', [{ id: 'opt_a', label: 'Option A', kind: 'option' }])],
+      }),
+      makeStore(),
+    )
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    expect(pulseMock.mock.calls[0][0].nodeIds).toContain('opt_a')
+    expect(result.applied).toContain('ui_directive:highlight:opt_a')
+  })
+
+  it('routes edge-kind targets to edgeIds (same collapse rule as the pills)', () => {
+    applyV5State(
+      baseResponse({
+        blocks: [
+          directive('highlight', [
+            { id: 'opt_a', label: 'Option A', kind: 'option' },
+            { id: 'e1', label: 'Influence', kind: 'edge' },
+          ]),
+        ],
+      }),
+      makeStore(),
+    )
+    const arg = pulseMock.mock.calls[0][0]
+    expect(arg.nodeIds).toEqual(['opt_a'])
+    expect(arg.edgeIds).toEqual(['e1'])
+  })
+
+  it('RATE LIMIT: only the FIRST directive in an envelope executes; extras are deferred', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [
+          directive('highlight', [{ id: 'opt_a', label: 'A', kind: 'option' }]),
+          directive('highlight', [{ id: 'opt_b', label: 'B', kind: 'option' }]),
+        ],
+      }),
+      makeStore(),
+    )
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    expect(pulseMock.mock.calls[0][0].nodeIds).toEqual(['opt_a'])
+    expect(
+      result.deferred.some((d) => d.reason === 'ui_directive_rate_limited'),
+    ).toBe(true)
+  })
+
+  it('focus verb is DEFERRED fail-closed (viewport-moving verbs are a later slice)', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('focus', [{ id: 'opt_a', label: 'A', kind: 'option' }])],
+      }),
+      makeStore(),
+    )
+    expect(pulseMock).not.toHaveBeenCalled()
+    expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
+  })
+
+  it('open_inspector verb is DEFERRED fail-closed', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('open_inspector', [{ id: 'opt_a', label: 'A', kind: 'option' }])],
+      }),
+      makeStore(),
+    )
+    expect(pulseMock).not.toHaveBeenCalled()
+    expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
+  })
+
+  it('unknown verb (newer producer) defers without crashing', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('start_tour', [{ id: 'opt_a', label: 'A', kind: 'option' }])],
+      }),
+      makeStore(),
+    )
+    expect(pulseMock).not.toHaveBeenCalled()
+    expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
+  })
+
+  it('a directive with no targets defers and never fires an empty pulse', () => {
+    const result = applyV5State(
+      baseResponse({ blocks: [directive('highlight', [])] }),
+      makeStore(),
+    )
+    expect(pulseMock).not.toHaveBeenCalled()
+    expect(result.deferred.some((d) => d.reason === 'ui_directive_no_targets')).toBe(true)
+  })
+
+  it('a directive pulse coalesces with server-applied patch targets (one pulse per envelope)', () => {
+    const node = { id: 'node-1', data: { label: 'Factor', observedState: {} } } as never
+    applyV5State(
+      baseResponse({
+        blocks: [
+          {
+            type: 'graph_patch',
+            status: 'applied',
+            operation: 'set_factor_value',
+            target_id: 'node-1',
+            after: { value: 42 },
+          } as never,
+          directive('highlight', [{ id: 'opt_a', label: 'A', kind: 'option' }]),
+        ],
+      }),
+      makeStore([node]),
+    )
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    const arg = pulseMock.mock.calls[0][0]
+    expect([...arg.nodeIds].sort()).toEqual(['node-1', 'opt_a'])
+  })
+})

--- a/src/v5/__tests__/applyV5State.uiDirective.test.ts
+++ b/src/v5/__tests__/applyV5State.uiDirective.test.ts
@@ -73,7 +73,7 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
       baseResponse({
         blocks: [directive('highlight', [{ id: 'opt_a', label: 'Option A', kind: 'option' }])],
       }),
-      makeStore(),
+      makeStore([{ id: 'opt_a', data: {} } as never]),
     )
     expect(pulseMock).toHaveBeenCalledTimes(1)
     expect(pulseMock.mock.calls[0][0].nodeIds).toContain('opt_a')
@@ -90,7 +90,10 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
           ]),
         ],
       }),
-      makeStore(),
+      makeStore(
+        [{ id: 'opt_a', data: {} } as never],
+        [{ id: 'e1', source: 'a', target: 'b' } as never],
+      ),
     )
     const arg = pulseMock.mock.calls[0][0]
     expect(arg.nodeIds).toEqual(['opt_a'])
@@ -105,7 +108,10 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
           directive('highlight', [{ id: 'opt_b', label: 'B', kind: 'option' }]),
         ],
       }),
-      makeStore(),
+      makeStore([
+        { id: 'opt_a', data: {} } as never,
+        { id: 'opt_b', data: {} } as never,
+      ]),
     )
     expect(pulseMock).toHaveBeenCalledTimes(1)
     expect(pulseMock.mock.calls[0][0].nodeIds).toEqual(['opt_a'])
@@ -147,6 +153,43 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
     expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
   })
 
+  it('a DEFERRED first directive does not burn the budget — the next valid one executes', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [
+          directive('focus', [{ id: 'opt_a', label: 'A', kind: 'option' }]), // deferred verb
+          directive('highlight', [{ id: 'opt_b', label: 'B', kind: 'option' }]),
+        ],
+      }),
+      makeStore([{ id: 'opt_b', data: {} } as never]),
+    )
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    expect(pulseMock.mock.calls[0][0].nodeIds).toEqual(['opt_b'])
+    expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
+  })
+
+  it('an off-canvas target is recorded as not-found, never as an execution', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [
+          directive('highlight', [
+            { id: 'ghost', label: 'Deleted', kind: 'option' },
+            { id: 'opt_a', label: 'A', kind: 'option' },
+          ]),
+        ],
+      }),
+      makeStore([{ id: 'opt_a', data: {} } as never]),
+    )
+    expect(pulseMock.mock.calls[0][0].nodeIds).toEqual(['opt_a'])
+    expect(result.applied).toContain('ui_directive:highlight:opt_a')
+    expect(result.applied).not.toContain('ui_directive:highlight:ghost')
+    expect(
+      result.deferred.some(
+        (d) => d.reason === 'ui_directive_target_not_found' && d.detail === 'ghost',
+      ),
+    ).toBe(true)
+  })
+
   it('a directive with no targets defers and never fires an empty pulse', () => {
     const result = applyV5State(
       baseResponse({ blocks: [directive('highlight', [])] }),
@@ -171,7 +214,7 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
           directive('highlight', [{ id: 'opt_a', label: 'A', kind: 'option' }]),
         ],
       }),
-      makeStore([node]),
+      makeStore([node, { id: 'opt_a', data: {} } as never]),
     )
     expect(pulseMock).toHaveBeenCalledTimes(1)
     const arg = pulseMock.mock.calls[0][0]

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -497,7 +497,22 @@ export function applyV5State(
         uiDirectiveExecuted = true
         for (const t of targets) {
           if (!t?.id) continue
-          if (t.kind === 'edge') {
+          // Mirror the graph_patch path's honesty: an off-canvas target is
+          // recorded as not-found, never as an execution (the pulse filter
+          // would drop it downstream anyway — this keeps applied[] truthful).
+          const isEdge = t.kind === 'edge'
+          const exists = isEdge
+            ? store.edges.some((e) => e.id === t.id)
+            : store.nodes.some((n) => n.id === t.id)
+          if (!exists) {
+            deferred.push({
+              reason: 'ui_directive_target_not_found',
+              block,
+              detail: t.id,
+            })
+            continue
+          }
+          if (isEdge) {
             pulsedEdgeIds.push(t.id)
           } else {
             pulsedNodeIds.push(t.id)

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -390,6 +390,9 @@ export function applyV5State(
   // the targets that actually apply below and pulse once after the loop.
   const pulsedNodeIds: string[] = []
   const pulsedEdgeIds: string[] = []
+  // R4 dispatcher rate limit: the producer contract is at most ONE
+  // ui_directive per turn — the UI enforces it defensively; extras defer.
+  let uiDirectiveExecuted = false
   for (const block of response.blocks) {
     if (block.type === 'graph_patch') {
       if (block.status !== 'applied') continue
@@ -462,6 +465,44 @@ export function applyV5State(
             block,
             detail: String(_exhaustive),
           })
+        }
+      }
+    } else if (block.type === 'ui_directive') {
+      // R4 UI half (surfacing gate 4): execute directives at the
+      // once-per-envelope side-effect site — never render-driven, so
+      // re-renders cannot re-fire them. Slice 1 executes `highlight` only,
+      // by feeding the SAME coalesced pulse the applied-edit path uses
+      // (fail-closed in-graph filter downstream, one 2s static ring, zero
+      // viewport movement — the AI cannot hijack what the user is doing).
+      // `focus`/`open_inspector` move the viewport/panels and get their own
+      // rate-limit design in a later slice; they defer fail-closed, as do
+      // verbs this build doesn't know. duration_ms is a producer hint not
+      // yet honoured (the ring is fixed 2s).
+      const targets = Array.isArray(block.targets) ? block.targets : []
+      if (block.verb !== 'highlight') {
+        deferred.push({
+          reason: 'ui_directive_verb_deferred',
+          block,
+          detail: String(block.verb),
+        })
+      } else if (targets.length === 0) {
+        deferred.push({ reason: 'ui_directive_no_targets', block })
+      } else if (uiDirectiveExecuted) {
+        deferred.push({
+          reason: 'ui_directive_rate_limited',
+          block,
+          detail: 'producer contract is one directive per turn',
+        })
+      } else {
+        uiDirectiveExecuted = true
+        for (const t of targets) {
+          if (!t?.id) continue
+          if (t.kind === 'edge') {
+            pulsedEdgeIds.push(t.id)
+          } else {
+            pulsedNodeIds.push(t.id)
+          }
+          applied.push(`ui_directive:highlight:${t.id}`)
         }
       }
     } else if (block.type === 'analysis_result') {


### PR DESCRIPTION
## What

The UI half of **R4** (Experience workstream Lane 6) — the outbound directive channel's consumer. CEE's half is merged dark (CEE PR #408, `CEE_UI_DIRECTIVE_EMIT` off): at most ONE `ui_directive` per fresh run_analysis — verb `highlight`, typed target refs, no free text. **This PR is the last gate before the flag flips.**

Dispatcher lives at `applyV5State`'s block loop (the once-per-envelope side-effect site — never render-driven, so re-renders can't re-fire it), per the surfacing-gate checklist (gates 3–5; gate 2 was Lane 5's re-vendor):

- `highlight` targets feed the **same coalesced pulse** as applied AI edits: fail-closed in-graph filter downstream, one static 2s ring, **zero viewport movement** — the AI cannot hijack what the user is doing. Edge-kind targets collapse to edge highlighting. Executions are recorded in `applied[]` (`ui_directive:highlight:<id>`) for the debug bundle.
- **Rate limit**: one directive per envelope (the producer contract, enforced defensively) — extras defer as `ui_directive_rate_limited`, never silently execute.
- `focus` / `open_inspector` / unknown verbs defer fail-closed (`ui_directive_verb_deferred`) — viewport/panel-moving verbs get their own rate-limit design in a later slice. Empty-target directives defer. `duration_ms` is a producer hint not yet honoured.
- Directives stay non-content: the mapper's silent skip (#260) stands — no chat card.

## Tests (RED-first)

RED `df04fd35` (8 failing contracts) → GREEN 8/8: execution + applied-log, edge-kind collapse, rate limit, all three deferral classes, empty-pulse guard, and coalescing with server-applied patch targets into one pulse per envelope.

## Verification

Browser proof on the lane build: a synthetic 0.15.0 response carrying the exact dark-slice directive → `applied` records the execution, the target node ringed in the DOM at 250ms, cleared at 2.3s, nothing deferred, console clean. The live end-to-end (real CEE emission) is the planned joint verify with the orchestrator after the flag flips.

## Gates

typecheck clean · `vitest --changed origin/staging` **935 / 0** · wide tsc diff: line-shift pairs only, zero new · british-english green · eslint clean. Adversarial review running (focus: replay/re-hydration re-fire risk, tolerance-path malformed blocks, rate-limit state). Merge waits on verdict + CI shard logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)