### PR TITLE
feat(results): honest code-keyed templates for the density-wall warning codes

### DIFF
--- a/src/canvas/hooks/__tests__/useV2Run.interventionValidation.spec.ts
+++ b/src/canvas/hooks/__tests__/useV2Run.interventionValidation.spec.ts
@@ -293,6 +293,43 @@ describe('Pre-run intervention validation', () => {
     ])
   })
 
+  it('promotes PLoT 422 GRAPH_TOO_COMPLEX critique so the density wall gets its honest copy (1.54)', async () => {
+    setupCanvasWithOptions({
+      analysisReady: {
+        goal_node_id: 'goal-1',
+        status: 'ready',
+        options: [
+          { id: 'opt-1', label: 'Option A', status: 'ready', interventions: { 'fac-1': 0.5 } },
+        ],
+      },
+    })
+
+    mockExecute.mockResolvedValueOnce({
+      analysis_status: 'blocked',
+      status_reason: 'Graph too complex to analyse',
+      critiques: [
+        {
+          code: 'GRAPH_TOO_COMPLEX',
+          severity: 'blocker',
+          // Producer message leaks engine budget maths — the UI entry's copy
+          // must be used instead (asserted via the code promotion; the
+          // userFriendlyErrors mapping is pinned in its own spec).
+          message: '24 causal nodes × 40 causal edges = 960, above the maximum of 600…',
+          affected_nodes: [],
+        },
+      ],
+      request_id: 'req-test-complexity',
+    })
+
+    const { result } = renderHook(() => useV2Run())
+    await act(async () => {
+      await result.current.runV2Analysis()
+    })
+
+    const storeError = useCanvasStore.getState().results.error
+    expect(storeError?.code).toBe('GRAPH_TOO_COMPLEX')
+  })
+
   it('still renders the coached state when PLoT critique references stale option ids (id fallback)', async () => {
     // Simulate: PLoT critique points at "opt-deleted" which is no longer on the
     // canvas (e.g. user deleted the option between request build and response).

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -581,10 +581,19 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
         // entirely, we have nothing to render and fall back to the generic
         // VALIDATION_BLOCKED path — which is what happens for cycles, missing
         // goal, and other unrelated 422s.
+        // ROADMAP 1.54 (density wall): GRAPH_TOO_COMPLEX gets its own code so
+        // userFriendlyErrors renders the honest simplify-your-model copy —
+        // the producer's message names engine budget maths and must not be
+        // echoed (its raw text stays in the debug panel).
+        const complexityBlocked = (errorResult.critiques || []).some(
+          (c) => c.code === 'GRAPH_TOO_COMPLEX',
+        )
         const promotedCode =
           affectedOptions && affectedOptions.length > 0
             ? interventionCritiques[0].code
-            : 'VALIDATION_BLOCKED'
+            : complexityBlocked
+              ? 'GRAPH_TOO_COMPLEX'
+              : 'VALIDATION_BLOCKED'
 
         trackRunFailed({
           error_code: promotedCode,

--- a/src/components/results/utils/__tests__/humaniseCritique.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.spec.ts
@@ -35,6 +35,27 @@ describe('humaniseCritique', () => {
       expect(result.factorId).toBe('fac_rev')
     })
 
+    // ROADMAP 1.54 density wall (PLoT #209): two new producer codes must have
+    // code-keyed templates (the 1.12 pattern) instead of the generic fallback.
+    it('SAMPLES_REDUCED_FOR_COMPLEXITY discloses the reduced-precision run honestly', () => {
+      const result = humaniseCritique(makeItem({ code: 'SAMPLES_REDUCED_FOR_COMPLEXITY' }))
+      expect(result.title).toBe('Analysis ran at reduced precision')
+      expect(result.description).toContain('fewer simulation samples')
+      expect(result.description).toMatch(/less stable/i)
+      expect(result.suggestion).toMatch(/connections|influences/i)
+      expect(result.displayText).not.toBeNull()
+    })
+
+    it('GRAPH_TOO_COMPLEX names the structural fix, never the internal budget maths', () => {
+      const result = humaniseCritique(makeItem({ code: 'GRAPH_TOO_COMPLEX' }))
+      expect(result.title).toBe('Model too complex to analyse')
+      expect(result.description).toMatch(/connections|complexity/i)
+      expect(result.suggestion).toMatch(/remove|reduce/i)
+      // Never leak engine internals into user copy
+      expect(result.description).not.toMatch(/node.?edge product|complexity budget|n_samples/i)
+      expect(result.displayText).not.toBeNull()
+    })
+
     it('LOW_EVIDENCE', () => {
       const result = humaniseCritique(makeItem({ code: 'LOW_EVIDENCE' }))
       expect(result.title).toBe('Limited evidence available')

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -151,14 +151,18 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
   // engine internals.
   SAMPLES_REDUCED_FOR_COMPLEXITY: () => ({
     title: 'Analysis ran at reduced precision',
-    description: 'This model is dense, so the analysis ran with fewer simulation samples than standard. Results are complete, but probabilities may be slightly less stable than usual.',
-    suggestion: 'Remove weaker or duplicate connections to restore full precision',
+    description: 'This model is dense, so the analysis ran with fewer simulation samples than standard. Results shown were computed at this reduced depth, and probabilities may be slightly less stable than usual.',
+    suggestion: 'Remove weaker or duplicate influences to restore full precision',
   }),
   // Blocker sibling of the above: past the engine's ceiling even at the
-  // minimum reliable depth, the run is refused rather than degraded further.
+  // minimum reliable depth the run is refused up front. FORWARD-PROVISIONING:
+  // the 422-blocked path renders via userFriendlyErrors' GRAPH_TOO_COMPLEX
+  // entry (useV2Run promotes the critique code) — blocker critiques do not
+  // currently flow through this humaniser; the template exists so the copy
+  // stays consistent if that routing ever changes.
   GRAPH_TOO_COMPLEX: () => ({
     title: 'Model too complex to analyse',
-    description: 'This model has more factors and connections than the analysis engine can compute reliably, so the run was stopped rather than returning unstable numbers.',
+    description: "This model has more factors and connections than the analysis engine can compute reliably, so the analysis wasn't run rather than returning unstable numbers.",
     suggestion: 'Remove weaker or duplicate influences, or split the decision into smaller models, then re-run',
   }),
   CONSTRAINT_DIRECTION_ASSUMED: (label) => ({

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -144,6 +144,23 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
     description: "The direction of your target (whether higher or lower is better) couldn't be confirmed for this option, so its goal-fit isn't shown.",
     suggestion: `Review the target direction for ${label}`,
   }),
+  // ROADMAP 1.54 density wall (PLoT #209): dense graphs now analyse at an
+  // adaptively reduced Monte Carlo depth instead of 500ing. The producer
+  // message names both sample depths; the template keeps the honest
+  // substance (reduced precision, results still complete) without quoting
+  // engine internals.
+  SAMPLES_REDUCED_FOR_COMPLEXITY: () => ({
+    title: 'Analysis ran at reduced precision',
+    description: 'This model is dense, so the analysis ran with fewer simulation samples than standard. Results are complete, but probabilities may be slightly less stable than usual.',
+    suggestion: 'Remove weaker or duplicate connections to restore full precision',
+  }),
+  // Blocker sibling of the above: past the engine's ceiling even at the
+  // minimum reliable depth, the run is refused rather than degraded further.
+  GRAPH_TOO_COMPLEX: () => ({
+    title: 'Model too complex to analyse',
+    description: 'This model has more factors and connections than the analysis engine can compute reliably, so the run was stopped rather than returning unstable numbers.',
+    suggestion: 'Remove weaker or duplicate influences, or split the decision into smaller models, then re-run',
+  }),
   CONSTRAINT_DIRECTION_ASSUMED: (label) => ({
     title: `${label}'s target direction was assumed`,
     description: "The direction of your target (whether higher or lower is better) wasn't confirmed, so it was assumed for this run. Goal-fit results for this option may be less reliable.",

--- a/src/lib/__tests__/errors.map.test.ts
+++ b/src/lib/__tests__/errors.map.test.ts
@@ -29,6 +29,8 @@ describe('Error taxonomy mapping (British English)', () => {
 
 // ROADMAP 1.54 density wall — the 422 blocker's user copy comes from THIS
 // entry, never the producer message (which names engine budget maths).
+import { getUserFriendlyError } from '../userFriendlyErrors'
+
 describe('GRAPH_TOO_COMPLEX (density wall, 1.54)', () => {
   it('maps to honest simplify-your-model copy and never echoes the raw message', () => {
     const err = getUserFriendlyError({

--- a/src/lib/__tests__/errors.map.test.ts
+++ b/src/lib/__tests__/errors.map.test.ts
@@ -26,3 +26,19 @@ describe('Error taxonomy mapping (British English)', () => {
     expect(m.primaryAction).toBe('Wait and retry')
   })
 })
+
+// ROADMAP 1.54 density wall — the 422 blocker's user copy comes from THIS
+// entry, never the producer message (which names engine budget maths).
+describe('GRAPH_TOO_COMPLEX (density wall, 1.54)', () => {
+  it('maps to honest simplify-your-model copy and never echoes the raw message', () => {
+    const err = getUserFriendlyError({
+      code: 'GRAPH_TOO_COMPLEX',
+      message: '24 causal nodes × 40 causal edges = 960, above the maximum of 600…',
+      canRetry: false,
+    })
+    expect(err.headline).toBe('Model too complex to analyse')
+    expect(err.explanation).toMatch(/remove|reduce|simplif/i)
+    expect(err.explanation).not.toMatch(/causal nodes|maximum of|×/)
+    expect(err.canRetry).toBe(false)
+  })
+})

--- a/src/lib/userFriendlyErrors.ts
+++ b/src/lib/userFriendlyErrors.ts
@@ -125,6 +125,16 @@ const ERROR_MESSAGES: Record<string, Omit<UserFriendlyError, 'canRetry'>> = {
     severity: 'warning',
   },
 
+  // ROADMAP 1.54 density wall (PLoT #209): graph refused at the engine's
+  // complexity ceiling. Own entry so the copy is ours — the producer
+  // message names node×edge budget maths and is debug-panel-only.
+  'GRAPH_TOO_COMPLEX': {
+    headline: 'Model too complex to analyse',
+    explanation: 'This model has more factors and connections than the analysis engine can compute reliably. Remove weaker or duplicate influences, or split the decision into smaller models, then re-run.',
+    actionText: 'Simplify Model',
+    severity: 'warning',
+  },
+
   // Validation errors from backend (422)
   'VALIDATION_BLOCKED': {
     headline: 'Model needs adjustment',


### PR DESCRIPTION
## What

Experience workstream Lane 7 (orchestrator-requested follow-up to PLoT's density-wall fix, ROADMAP 1.54 / plot#209): honest, code-keyed copy for the two new producer codes — **end-to-end**, after the adversarial review proved the blocker's original template was unreachable.

- **`SAMPLES_REDUCED_FOR_COMPLEXITY`** (warning → InferenceWarningStrip via the live 1.12 route): "Analysis ran at reduced precision" — honest about the adaptive-depth run, never over-claims completeness, fix named.
- **`GRAPH_TOO_COMPLEX`** (blocker on the 422 blocked response): the review traced all three ingestion routes and found blocker critiques NEVER reach `humaniseCritique` — they render via `userFriendlyErrors` under generic `VALIDATION_BLOCKED`. So the honest fix moved to where users actually look: `useV2Run` promotes the critique code (same pattern as the `EMPTY_INTERVENTIONS` promotion) and `userFriendlyErrors` carries the entry ("Model too complex to analyse", actionText "Simplify Model"). The producer's message names engine budget maths and stays debug-panel-only — pinned by test. The humaniser template is kept, annotated FORWARD-PROVISIONING.

Semantics verified against PLoT's emit sites (`routes/v2/run.ts:2333`, `:4066`), not guessed.

## Tests (RED-first, both rounds)

Round 1: 2 RED → GREEN in `humaniseCritique.spec.ts`. Round 2 (review finding 1): 2 RED → GREEN — `useV2Run.interventionValidation.spec.ts` pins the promotion; `errors.map.test.ts` pins the copy + no-budget-maths-echo. 612 changed-set tests green.

## Gates

typecheck clean · `vitest --changed origin/staging` **612 / 0** · british-english green · eslint clean · adversarial review MERGE-SAFE (finding 1 wired end-to-end pre-merge; copy NITs 2/6 folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)