### PR TITLE
fix(canvas): edit-journey display closure — reload stale-hash + applied-edit ingestion (POC Lanes A+C)

### DIFF
--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -2227,6 +2227,174 @@ describe('V5 inline graph from response.draft_graph', () => {
 })
 
 // ---------------------------------------------------------------------------
+// V5 applied-edit receipt ingestion on a NON-EMPTY canvas (POC Lane C,
+// WEEKEND-SPRINT-PLAN-2026-07-11). CEE #414/#424 attach the FULL committed
+// post-mutation graph to applied-edit receipts via the EXISTING top-level
+// `draft_graph` wire field. The fresh-draft dispatch on the CEE side is gated
+// on `graphState == null` (route-v2 isDraftGraphShape), and this client always
+// sends graph_state, so draft_graph arriving while the canvas is non-empty is
+// unambiguously an applied-edit receipt — the UI must ingest the additions or
+// a confirmed added factor does not appear until reload.
+// ---------------------------------------------------------------------------
+
+describe('V5 applied-edit receipt ingestion (draft_graph on a non-empty canvas)', () => {
+  const SCENARIO_ID = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+
+  /** Canvas state before the edit turn: goal + factor, one edge. */
+  const EXISTING_NODES = [
+    {
+      id: 'goal-1',
+      type: 'goal',
+      position: { x: 400, y: 40 },
+      data: { kind: 'goal', label: 'Revenue' },
+    },
+    {
+      id: 'factor-1',
+      type: 'factor',
+      position: { x: 40, y: 200 },
+      data: { kind: 'factor', label: 'Spend', observedState: { value: 100 } },
+    },
+  ]
+  const EXISTING_EDGES = [
+    {
+      id: 'e1',
+      source: 'factor-1',
+      target: 'goal-1',
+      type: 'styled',
+      data: { weight: 0.7, direction: 'positive' },
+    },
+  ]
+
+  /**
+   * The applied-edit receipt: full post-mutation graph = the two existing
+   * nodes + the newly added factor and its edge (CEE wire shape: kind/from/to).
+   */
+  const APPLIED_RECEIPT_GRAPH = {
+    nodes: [
+      { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+      { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+      { id: 'factor-2', kind: 'factor', label: 'Churn rate', observed_state: { value: 0.05 } },
+    ],
+    edges: [
+      { id: 'e1', from: 'factor-1', to: 'goal-1', weight: 0.7 },
+      { id: 'factor-2::goal-1::0', from: 'factor-2', to: 'goal-1', weight: -0.4 },
+    ],
+    node_count: 3,
+    edge_count: 2,
+  }
+
+  const makeAppliedEditReceipt = (graph = APPLIED_RECEIPT_GRAPH) => ({
+    kind: 'response' as const,
+    response: {
+      response_version: 2,
+      assistant_text: "Added 'Churn rate' and linked it to Revenue.",
+      blocks: [] as unknown[],
+      suggested_actions: [] as unknown[],
+      insights: [] as unknown[],
+      stage_indicator: 'frame',
+      draft_graph: graph,
+    },
+  })
+
+  beforeEach(() => {
+    mockIsV5Eligible.mockReturnValue({ eligible: true })
+    useCanvasStore.setState({
+      currentScenarioId: SCENARIO_ID,
+      nodes: EXISTING_NODES as any,
+      edges: EXISTING_EDGES as any,
+      results: { status: 'idle' } as any,
+      currentScenarioLastResultHash: null,
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    })
+  })
+
+  it('ingests a confirmed added factor + edge from the applied-edit receipt (no reload required)', async () => {
+    mockGetUserId.mockResolvedValue('user-uuid-1234')
+    mockCallV5Turn.mockResolvedValue(makeAppliedEditReceipt())
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('add a churn rate factor that hurts revenue')
+    })
+
+    const nodes = useCanvasStore.getState().nodes
+    const edges = useCanvasStore.getState().edges
+    // RED today: draft_graph ingestion is gated on canvasIsEmpty, so the
+    // confirmed added factor never reaches the canvas until a full reload.
+    expect(nodes.map((n) => n.id)).toContain('factor-2')
+    expect(edges.some((e) => e.source === 'factor-2' && e.target === 'goal-1')).toBe(true)
+    // Additive merge only — existing elements are untouched, nothing duplicated.
+    expect(nodes).toHaveLength(3)
+    expect(edges).toHaveLength(2)
+  })
+
+  it('preserves existing node positions and local data on merge (additive, never a replace)', async () => {
+    mockGetUserId.mockResolvedValue('user-uuid-1234')
+    mockCallV5Turn.mockResolvedValue(makeAppliedEditReceipt())
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('add a churn rate factor that hurts revenue')
+    })
+
+    const factor1 = useCanvasStore.getState().nodes.find((n) => n.id === 'factor-1') as any
+    expect(factor1?.position).toEqual({ x: 40, y: 200 })
+    expect(factor1?.data?.label).toBe('Spend')
+  })
+
+  it('is a no-op when the receipt graph carries nothing new (value-only receipt)', async () => {
+    mockGetUserId.mockResolvedValue('user-uuid-1234')
+    // Receipt whose graph matches the canvas exactly (e.g. a value edit whose
+    // graph_patch block already merged via applyV5State).
+    mockCallV5Turn.mockResolvedValue(
+      makeAppliedEditReceipt({
+        nodes: [
+          { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+          { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 250 } },
+        ],
+        edges: [{ id: 'e1', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+        node_count: 2,
+        edge_count: 1,
+      }),
+    )
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('set spend to 250')
+    })
+
+    const nodes = useCanvasStore.getState().nodes
+    expect(nodes).toHaveLength(2)
+    // No duplicate edge either.
+    expect(useCanvasStore.getState().edges).toHaveLength(1)
+  })
+
+  it('skips the merge when the scenario changed between dispatch and response', async () => {
+    mockGetUserId.mockResolvedValue('user-uuid-1234')
+    let resolveTurn!: (v: unknown) => void
+    mockCallV5Turn.mockReturnValue(new Promise((res) => { resolveTurn = res }))
+
+    const { result } = renderHook(() => useConversation())
+    let sendPromise!: Promise<unknown>
+    await act(async () => {
+      sendPromise = result.current.sendMessage('add a churn rate factor')
+    })
+
+    // Scenario switch while the turn is in-flight.
+    act(() => {
+      useCanvasStore.setState({ currentScenarioId: 'different-scenario-uuid-here' })
+    })
+
+    resolveTurn(makeAppliedEditReceipt())
+    await act(async () => {
+      await sendPromise
+    })
+
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).not.toContain('factor-2')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // V1 leakage regression test (Task 7)
 // ---------------------------------------------------------------------------
 

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -3200,11 +3200,15 @@ export function useConversation(): UseConversationReturn {
               // POC Lane C (edit-journey display closure): applied-edit
               // receipt ingestion. CEE #414/#424 attach the FULL committed
               // post-mutation graph to applied-edit receipts via the same
-              // top-level draft_graph field, post-commit only. A non-empty
-              // canvas can never receive a fresh-draft draft_graph (CEE's
-              // draft dispatch requires graphState == null and this client
-              // sends graph_state every turn), so this branch is exactly the
-              // applied-structural-edit case: merge ADDITIVELY so a confirmed
+              // top-level draft_graph field, post-commit only. The V5 payload
+              // carries NO graph_state (buildPayload.ts — CEE's
+              // extensions.graphState is null on every V5 turn), so what
+              // keeps a fresh-draft draft_graph away from a non-empty canvas
+              // is CEE's continuation guard (route-v2 isDraftGraphShape
+              // requires no prior committed turns on the scenario) — plus the
+              // client-side zero-overlap guard inside mergeAppliedGraphAdditive
+              // for the residual misfire (fresh scenario_id + populated canvas
+              // + first brief-shaped message). Merge ADDITIVELY so a confirmed
               // added factor/edge appears without a reload. Existing elements
               // are never repositioned or rewritten; a receipt with nothing
               // new is a strict no-op (see mergeAppliedGraphAdditive).

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -84,6 +84,7 @@ import { applyAutoApplyPatch, synthesiseCeeAnalysisReady } from './utils/applyPa
 import { applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
 import { loadScenario as loadScenarioFromDb } from '../../services/scenarioService'
 import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
+import { mergeAppliedGraphAdditive } from '../utils/mergeAppliedGraph'
 import { getUserId } from '../../lib/supabase'
 import { validateAnalysisReadyContract } from './validateAnalysisReadyContract'
 import { validateResponse, stripRepairLogLines, FALLBACK_TEXT } from './validateResponse'
@@ -3193,6 +3194,27 @@ export function useConversation(): UseConversationReturn {
                 draftAppliedThisTurn = true
                 if (import.meta.env.DEV) {
                   console.log('[sendTurn V5] graph applied from inline response:', inlineNodeCount, 'nodes')
+                }
+              }
+            } else if (inlineGraph && inlineNodeCount > 0 && !canvasIsEmpty) {
+              // POC Lane C (edit-journey display closure): applied-edit
+              // receipt ingestion. CEE #414/#424 attach the FULL committed
+              // post-mutation graph to applied-edit receipts via the same
+              // top-level draft_graph field, post-commit only. A non-empty
+              // canvas can never receive a fresh-draft draft_graph (CEE's
+              // draft dispatch requires graphState == null and this client
+              // sends graph_state every turn), so this branch is exactly the
+              // applied-structural-edit case: merge ADDITIVELY so a confirmed
+              // added factor/edge appears without a reload. Existing elements
+              // are never repositioned or rewritten; a receipt with nothing
+              // new is a strict no-op (see mergeAppliedGraphAdditive).
+              if (useCanvasStore.getState().currentScenarioId === scenarioIdAtDispatch) {
+                const merged = mergeAppliedGraphAdditive(inlineGraph as any)
+                if (import.meta.env.DEV && (merged.addedNodeCount > 0 || merged.addedEdgeCount > 0)) {
+                  console.log(
+                    '[sendTurn V5] applied-edit receipt merged into canvas:',
+                    merged.addedNodeCount, 'nodes,', merged.addedEdgeCount, 'edges',
+                  )
                 }
               }
             } else if (!inlineGraph && stateApply.applied.includes('stage:analyse') && canvasIsEmpty) {

--- a/src/canvas/hooks/__tests__/useAutosave.staleValueHash.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.staleValueHash.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Lane A (edit-journey display closure) — RED fixture for the reload
+ * visual-revert bug.
+ *
+ * Diagnosis (1.16 run-3 + DB probe, WEEKEND-SPRINT-PLAN-2026-07-11 Lane A):
+ * useAutosave's computeGraphHash covers only id/kind/label/x/y plus edge
+ * endpoints/weight. A conversational value edit (V5 graph_patch
+ * set_factor_value → updateNode merge into node.data.observedState, or an
+ * adjust_edge_strength → updateEdgeData direction/weight write) changes NONE
+ * of those fields, so the dirty hash never flips, the autosave skips, and
+ * localStorage keeps the PRE-EDIT values. On reload, the recovery path
+ * (ReactFlowGraph.tsx autosave-vs-scenario timestamp comparison) can hydrate
+ * the stale localStorage graph while the server copy is correct — the user
+ * SEES old values after an edit the assistant confirmed.
+ *
+ * These tests reproduce the stale-save path: after a value-bearing data
+ * change, the next autosave interval MUST write the new values.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAutosave } from '../useAutosave'
+import { useCanvasStore } from '../../store'
+
+// ---------------------------------------------------------------------------
+// Mocks — intercept the localStorage persistence boundary only; everything
+// else in store/scenarios stays real (the canvas store imports it too).
+// ---------------------------------------------------------------------------
+
+const mockSaveAutosave = vi.fn()
+const mockLoadAutosave = vi.fn()
+
+vi.mock('../../store/scenarios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../store/scenarios')>()
+  return {
+    ...actual,
+    saveAutosave: (...args: unknown[]) => mockSaveAutosave(...args),
+    loadAutosave: (...args: unknown[]) => mockLoadAutosave(...args),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SCENARIO_ID = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+
+const AUTOSAVE_INTERVAL_MS = 30 * 1000
+const DEBOUNCE_MS = 500
+
+function seedCanvas() {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      {
+        id: 'goal-1',
+        type: 'goal',
+        position: { x: 400, y: 40 },
+        data: { kind: 'goal', label: 'Revenue' },
+      },
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { x: 40, y: 200 },
+        data: {
+          kind: 'factor',
+          label: 'Price',
+          observedState: { value: 100, baseline: 100, unit: 'GBP' },
+        },
+      },
+      {
+        id: 'option-1',
+        type: 'option',
+        position: { x: 40, y: 400 },
+        data: {
+          kind: 'option',
+          label: 'Raise price',
+          interventions: { 'factor-1': 120 },
+        },
+      },
+    ] as any,
+    edges: [
+      {
+        id: 'e1',
+        source: 'factor-1',
+        target: 'goal-1',
+        type: 'styled',
+        data: { weight: 0.7, direction: 'positive', confidence: 0.8 },
+      },
+    ] as any,
+  })
+}
+
+/** Run one full autosave cycle: interval tick + debounce flush. */
+function advanceOneAutosaveCycle() {
+  act(() => {
+    vi.advanceTimersByTime(AUTOSAVE_INTERVAL_MS)
+  })
+  act(() => {
+    vi.advanceTimersByTime(DEBOUNCE_MS)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockSaveAutosave.mockReset()
+  // No competing tab — the multi-tab guard must not block the write.
+  mockLoadAutosave.mockReset()
+  mockLoadAutosave.mockReturnValue(null)
+  seedCanvas()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAutosave — value-bearing data changes must flip the dirty hash', () => {
+  it('saves again after a node observedState value change (graph_patch set_factor_value path)', () => {
+    renderHook(() => useAutosave())
+
+    // Baseline save with the pre-edit values.
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+    // Conversational value edit — the exact write applyV5State performs for
+    // graph_patch set_factor_value: merge into node.data.observedState.
+    // Position, label, kind, and id all stay identical.
+    act(() => {
+      const s = useCanvasStore.getState()
+      useCanvasStore.setState({
+        nodes: s.nodes.map((n: any) =>
+          n.id === 'factor-1'
+            ? {
+                ...n,
+                data: {
+                  ...n.data,
+                  observedState: { ...(n.data?.observedState ?? {}), value: 250 },
+                },
+              }
+            : n,
+        ) as any,
+      })
+    })
+
+    advanceOneAutosaveCycle()
+
+    // RED today: the hash ignores observedState, the save is skipped, and
+    // localStorage keeps value=100 — the reload visual revert.
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(2)
+    const lastCall = mockSaveAutosave.mock.calls.at(-1)?.[0] as {
+      nodes: Array<{ id: string; data?: { observedState?: { value?: number } } }>
+    }
+    const savedFactor = lastCall.nodes.find((n) => n.id === 'factor-1')
+    expect(savedFactor?.data?.observedState?.value).toBe(250)
+  })
+
+  it('saves again after an option interventions change', () => {
+    renderHook(() => useAutosave())
+
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+    // Intervention backfill / edit writes node.data.interventions only.
+    act(() => {
+      const s = useCanvasStore.getState()
+      useCanvasStore.setState({
+        nodes: s.nodes.map((n: any) =>
+          n.id === 'option-1'
+            ? { ...n, data: { ...n.data, interventions: { 'factor-1': 300 } } }
+            : n,
+        ) as any,
+      })
+    })
+
+    advanceOneAutosaveCycle()
+
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(2)
+    const lastCall = mockSaveAutosave.mock.calls.at(-1)?.[0] as {
+      nodes: Array<{ id: string; data?: { interventions?: Record<string, number> } }>
+    }
+    const savedOption = lastCall.nodes.find((n) => n.id === 'option-1')
+    expect(savedOption?.data?.interventions?.['factor-1']).toBe(300)
+  })
+
+  it('saves again after an edge direction flip (graph_patch adjust_edge_strength path)', () => {
+    renderHook(() => useAutosave())
+
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+    // adjust_edge_strength writes weight/direction into edge.data via
+    // updateEdgeData; endpoints stay identical. A direction flip with the
+    // same magnitude is invisible to the legacy hash (confidence ?? weight).
+    act(() => {
+      const s = useCanvasStore.getState()
+      useCanvasStore.setState({
+        edges: s.edges.map((e: any) =>
+          e.id === 'e1' ? { ...e, data: { ...e.data, direction: 'negative' } } : e,
+        ) as any,
+      })
+    })
+
+    advanceOneAutosaveCycle()
+
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(2)
+    const lastCall = mockSaveAutosave.mock.calls.at(-1)?.[0] as {
+      edges: Array<{ id: string; data?: { direction?: string } }>
+    }
+    const savedEdge = lastCall.edges.find((e) => e.id === 'e1')
+    expect(savedEdge?.data?.direction).toBe('negative')
+  })
+
+  it('does NOT re-save when nothing changed (dirty-hash guard intact)', () => {
+    renderHook(() => useAutosave())
+
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+    // Two more full cycles with no state change — no further writes.
+    advanceOneAutosaveCycle()
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -27,6 +27,16 @@ const DEBOUNCE_MS = 500 // Debounce writes to reduce localStorage contention
  * P1 Fix: Compute a canonical hash of graph state for dirty detection.
  * Includes node kind, label, position and edge source/target/weight.
  * Sorted to ensure consistent ordering.
+ *
+ * Lane A fix (edit-journey display closure, 2026-07-11): the hash must also
+ * cover VALUE-BEARING data. Conversational edits (V5 graph_patch
+ * set_factor_value → node.data.observedState merge; adjust_edge_strength →
+ * edge.data weight/direction write; intervention / goal-threshold backfill)
+ * change none of id/kind/label/position or edge endpoints, so the legacy
+ * hash never flipped, the autosave skipped, and localStorage kept the
+ * PRE-EDIT values — on reload the recovery path could hydrate the stale
+ * graph while the server copy was correct (the "reload visual revert").
+ * Extra fields here can only cause an extra save, never a missed one.
  */
 function computeGraphHash(nodes: any[], edges: any[]): string {
   const canonical = {
@@ -37,6 +47,13 @@ function computeGraphHash(nodes: any[], edges: any[]): string {
         label: n.data?.label ?? '',
         x: Math.round(n.position?.x ?? 0),
         y: Math.round(n.position?.y ?? 0),
+        // Value-bearing node data (see doc comment above).
+        os: n.data?.observedState ?? null,
+        iv: n.data?.interventions ?? null,
+        base: n.data?.is_baseline ?? null,
+        gtRaw: n.data?.goal_threshold_raw ?? null,
+        gtUnit: n.data?.goal_threshold_unit ?? null,
+        gtCap: n.data?.goal_threshold_cap ?? null,
       }))
       .sort((a, b) => a.id.localeCompare(b.id)),
     edges: edges
@@ -44,6 +61,13 @@ function computeGraphHash(nodes: any[], edges: any[]): string {
         from: e.source,
         to: e.target,
         weight: e.data?.confidence ?? e.data?.weight ?? '',
+        // Value-bearing edge data — adjust_edge_strength writes these via
+        // updateEdgeData without touching the endpoints.
+        w: e.data?.weight ?? null,
+        dir: e.data?.direction ?? null,
+        conf: e.data?.confidence ?? null,
+        be: e.data?.beliefExists ?? null,
+        std: e.data?.strengthStd ?? null,
       }))
       .sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to)),
   }

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for mergeAppliedGraphAdditive (POC Lane C — applied-edit receipt
+ * ingestion on a non-empty canvas).
+ *
+ * Uses the REAL canvas store (mirrors the hook-level fixture in
+ * useConversation.hook.spec.ts) so history, validation, and setState
+ * behaviour are exercised for real.
+ *
+ * Covers:
+ * - additive merge: missing wire nodes/edges added, existing untouched
+ * - draft-path mapper parity (observed_state → observedState, kind → type)
+ * - endpoint-pair dedupe (locally rewritten edge ids don't re-add)
+ * - dangling-edge fail-closed drop
+ * - fallback edge id collision handling
+ * - strict no-op when the receipt carries nothing new
+ * - deterministic placement right of the existing bounding box
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mergeAppliedGraphAdditive } from '../mergeAppliedGraph'
+import { useCanvasStore } from '../../store'
+
+const EXISTING_NODES = [
+  {
+    id: 'goal-1',
+    type: 'goal',
+    position: { x: 400, y: 40 },
+    data: { kind: 'goal', label: 'Revenue' },
+  },
+  {
+    id: 'factor-1',
+    type: 'factor',
+    position: { x: 40, y: 200 },
+    data: { kind: 'factor', label: 'Spend', observedState: { value: 100 } },
+  },
+]
+
+const EXISTING_EDGES = [
+  {
+    id: 'e-0', // locally rewritten fallback id (draft-path mapper)
+    source: 'factor-1',
+    target: 'goal-1',
+    type: 'styled',
+    data: { weight: 0.7, direction: 'positive' },
+  },
+]
+
+function seedCanvas() {
+  useCanvasStore.setState({
+    currentScenarioId: 'scenario-1',
+    nodes: structuredClone(EXISTING_NODES) as any,
+    edges: structuredClone(EXISTING_EDGES) as any,
+    ceeAnalysisReady: null,
+  } as any)
+}
+
+beforeEach(() => {
+  seedCanvas()
+})
+
+describe('mergeAppliedGraphAdditive', () => {
+  it('adds wire nodes/edges missing from the canvas and leaves existing elements untouched', () => {
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+        { id: 'factor-2', kind: 'factor', label: 'Churn rate', observed_state: { value: 0.05 } },
+      ],
+      edges: [
+        { id: 'factor-1::goal-1::0', from: 'factor-1', to: 'goal-1', weight: 0.7 },
+        { id: 'factor-2::goal-1::0', from: 'factor-2', to: 'goal-1', weight: -0.4 },
+      ],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 1 })
+
+    const { nodes, edges } = useCanvasStore.getState()
+    expect(nodes).toHaveLength(3)
+    expect(edges).toHaveLength(2)
+
+    // Draft-path mapper parity on the added node.
+    const added = nodes.find((n) => n.id === 'factor-2') as any
+    expect(added?.type).toBe('factor')
+    expect(added?.data?.kind).toBe('factor')
+    expect(added?.data?.label).toBe('Churn rate')
+    expect(added?.data?.observedState).toEqual({ value: 0.05 })
+
+    // Added edge mapped with direction inference from the signed weight.
+    const addedEdge = edges.find((e) => e.source === 'factor-2') as any
+    expect(addedEdge?.target).toBe('goal-1')
+    expect(addedEdge?.data?.direction).toBe('negative')
+    expect(addedEdge?.data?.weight).toBeCloseTo(0.4)
+
+    // Existing elements untouched (position AND local data preserved).
+    const factor1 = nodes.find((n) => n.id === 'factor-1') as any
+    expect(factor1?.position).toEqual({ x: 40, y: 200 })
+    expect(factor1?.data?.observedState).toEqual({ value: 100 })
+  })
+
+  it('places added nodes right of the existing bounding box (no re-layout of existing nodes)', () => {
+    mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'factor-2', kind: 'factor', label: 'A' },
+        { id: 'factor-3', kind: 'factor', label: 'B' },
+      ],
+      edges: [],
+    } as any)
+
+    const { nodes } = useCanvasStore.getState()
+    const maxExistingX = 400
+    const added2 = nodes.find((n) => n.id === 'factor-2') as any
+    const added3 = nodes.find((n) => n.id === 'factor-3') as any
+    expect(added2.position.x).toBeGreaterThan(maxExistingX)
+    expect(added3.position.x).toBe(added2.position.x)
+    expect(added3.position.y).toBeGreaterThan(added2.position.y)
+    // Existing nodes did not move.
+    expect((nodes.find((n) => n.id === 'goal-1') as any).position).toEqual({ x: 400, y: 40 })
+  })
+
+  it('does not re-add an existing edge whose local id differs from the wire id (endpoint-pair dedupe)', () => {
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+      ],
+      // Same endpoints as canvas edge 'e-0', but under CEE's composite id.
+      edges: [{ id: 'factor-1::goal-1::0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(useCanvasStore.getState().edges).toHaveLength(1)
+  })
+
+  it('drops a dangling wire edge fail-closed (endpoint not on canvas and not being added)', () => {
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+      ],
+      // 'ghost-1' is neither on the canvas nor in the wire node list.
+      edges: [{ id: 'ghost-1::goal-1::0', from: 'ghost-1', to: 'goal-1', weight: 0.5 }],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(useCanvasStore.getState().edges).toHaveLength(1)
+  })
+
+  it('uniquifies the mapper fallback edge id against existing canvas ids', () => {
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'factor-2', kind: 'factor', label: 'Churn rate' },
+      ],
+      // No id on the wire edge → mapper falls back to `e-0`, which the
+      // canvas already uses for a DIFFERENT edge.
+      edges: [{ from: 'factor-2', to: 'goal-1', weight: 0.3 }],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 1 })
+    const { edges } = useCanvasStore.getState()
+    expect(edges).toHaveLength(2)
+    const ids = edges.map((e) => e.id)
+    expect(new Set(ids).size).toBe(2)
+    const addedEdge = edges.find((e) => e.source === 'factor-2') as any
+    expect(addedEdge.id).not.toBe('e-0')
+  })
+
+  it('is a strict no-op (no history entry) when the receipt carries nothing new', () => {
+    const historyBefore = (useCanvasStore.getState() as any).history?.past?.length ?? 0
+    const nodesBefore = useCanvasStore.getState().nodes
+
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 250 } },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    const historyAfter = (useCanvasStore.getState() as any).history?.past?.length ?? 0
+    expect(historyAfter).toBe(historyBefore)
+    // Node identity preserved — no store write at all.
+    expect(useCanvasStore.getState().nodes).toBe(nodesBefore)
+  })
+
+  it('handles the nested graph shape ({ graph: { nodes, edges } })', () => {
+    const result = mergeAppliedGraphAdditive({
+      graph: {
+        nodes: [
+          { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+          { id: 'factor-1', kind: 'factor', label: 'Spend' },
+          { id: 'risk-1', kind: 'risk', label: 'Regulation' },
+        ],
+        edges: [],
+      },
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 0 })
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toContain('risk-1')
+  })
+})

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -16,9 +16,10 @@
  * - deterministic placement right of the existing bounding box
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mergeAppliedGraphAdditive } from '../mergeAppliedGraph'
 import { useCanvasStore } from '../../store'
+import { logger } from '../../../lib/logger'
 
 const EXISTING_NODES = [
   {
@@ -201,5 +202,111 @@ describe('mergeAppliedGraphAdditive', () => {
 
     expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 0 })
     expect(useCanvasStore.getState().nodes.map((n) => n.id)).toContain('risk-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fixup round (adversarial review on PR #266)
+// ---------------------------------------------------------------------------
+
+describe('mergeAppliedGraphAdditive — zero-overlap structural guard', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('DROPS the merge and warns when the wire graph shares zero node ids with the canvas', () => {
+    // An applied receipt always contains the committed graph, which supersets
+    // the canvas (minus removals) — zero id overlap means this draft_graph is
+    // a misdrafted FRESH graph (fresh scenario_id + populated canvas + first
+    // brief-shaped message slips past CEE's continuation guard). Grafting it
+    // would union two unrelated graphs.
+    const nodesBefore = useCanvasStore.getState().nodes
+    const edgesBefore = useCanvasStore.getState().edges
+
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal_1', kind: 'goal', label: 'Unrelated goal' },
+        { id: 'opt_1', kind: 'option', label: 'Unrelated option' },
+        { id: 'out_1', kind: 'outcome', label: 'Unrelated outcome' },
+      ],
+      edges: [{ id: 'opt_1::out_1::0', from: 'opt_1', to: 'out_1', weight: 0.5 }],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    // Store untouched — identity preserved, nothing grafted.
+    expect(useCanvasStore.getState().nodes).toBe(nodesBefore)
+    expect(useCanvasStore.getState().edges).toBe(edgesBefore)
+    // Warn fired (structured logging, house pattern).
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toBe('merge_applied_graph.zero_overlap_drop')
+  })
+
+  it('still merges the normal superset receipt (overlap present) without warning', () => {
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'factor-2', kind: 'factor', label: 'Churn rate' },
+      ],
+      edges: [],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 0 })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, staleness flags)', () => {
+  it('dedupes two NEW wire edges sharing the same endpoint pair against each other', () => {
+    // Direct setState bypasses addEdge's duplicate guard, so the merge must
+    // self-dedupe wire edges that share an endpoint pair.
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'factor-2', kind: 'factor', label: 'Churn rate' },
+      ],
+      edges: [
+        { id: 'factor-2::goal-1::0', from: 'factor-2', to: 'goal-1', weight: 0.3 },
+        { id: 'factor-2::goal-1::1', from: 'factor-2', to: 'goal-1', weight: 0.9 },
+      ],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 1 })
+    const pairs = useCanvasStore
+      .getState()
+      .edges.filter((e) => e.source === 'factor-2' && e.target === 'goal-1')
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('flips graphEditedSinceLastRun/analysisStateReady even when pushHistory dedupes the snapshot', () => {
+    // pushToHistory early-returns (without flipping the flags) when the
+    // current state equals the last history snapshot — reachable when a
+    // prior push already snapshotted the exact pre-merge state. The merge
+    // must set the staleness flags explicitly, not rely on the push.
+    useCanvasStore.getState().pushHistory()
+    useCanvasStore.setState({
+      graphEditedSinceLastRun: false,
+      analysisStateReady: true,
+    } as any)
+
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'factor-2', kind: 'factor', label: 'Churn rate' },
+      ],
+      edges: [],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 0 })
+    expect(useCanvasStore.getState().graphEditedSinceLastRun).toBe(true)
+    expect(useCanvasStore.getState().analysisStateReady).toBe(false)
   })
 })

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -23,6 +23,114 @@ import { devLog } from '../../utils/debugLog'
 import { detectBaseline } from './baselineDetection'
 
 /**
+ * Map one CEE wire node → React Flow canvas node.
+ *
+ * Extracted from applyDraftResult (Lane C, edit-journey display closure) so
+ * the applied-edit additive merge path (mergeAppliedGraph.ts) converts added
+ * nodes with EXACTLY the same treatment as the draft path — kind/type
+ * mapping, observed_state → observedState, interventionKeys derivation.
+ */
+export function mapDraftNodeToCanvas(n: any): any {
+  const { id, kind, type: nodeType, label, observed_state, ...rest } = n
+
+  // Derive interventionKeys when interventions object is present (e.g. from CEE add_node)
+  const interventions = rest.interventions as Record<string, unknown> | undefined
+  const interventionKeys = interventions && typeof interventions === 'object' && !Array.isArray(interventions)
+    ? Object.keys(interventions)
+    : undefined
+
+  return {
+    id,
+    type: kind || nodeType,
+    position: { x: 0, y: 0 },
+    data: {
+      ...rest,
+      label,
+      kind: kind || nodeType,
+      ...(observed_state ? { observedState: observed_state } : {}),
+      ...(interventionKeys ? { interventionKeys } : {}),
+    },
+  }
+}
+
+/**
+ * Map one CEE wire edge → React Flow canvas edge. Same extraction rationale
+ * as mapDraftNodeToCanvas. `i` feeds the fallback id (`e-${i}`) for wire
+ * edges without one — merge callers must dedupe that fallback against
+ * existing canvas ids.
+ */
+export function mapDraftEdgeToCanvas(e: any, i: number): any {
+  const id =
+    typeof e.id === 'string' && e.id.trim().length > 0 ? e.id : `e-${i}`
+
+  // Weight priority: strength.mean > strength_mean > weight > default
+  const rawWeight: number =
+    typeof e.strength?.mean === 'number'
+      ? e.strength.mean
+      : typeof e.strength_mean === 'number'
+        ? e.strength_mean
+        : typeof e.weight === 'number'
+          ? e.weight
+          : DEFAULT_EDGE_DATA.weight
+
+  // Direction inference
+  const directionFromEdge: EffectDirection | undefined =
+    e.effect_direction === 'positive' || e.effect_direction === 'negative'
+      ? e.effect_direction
+      : undefined
+  const direction: EffectDirection =
+    directionFromEdge ?? (rawWeight < 0 ? 'negative' : 'positive')
+
+  // UI-SEM-038: Duplicate of UI-SEM-023/024/025 on alternate ingestion path.
+  const weight = Math.max(0, Math.min(2, Math.abs(rawWeight)))
+  const confidence =
+    typeof e.belief === 'number'
+      ? Math.max(0, Math.min(1, e.belief))
+      : undefined
+  const beliefExists =
+    typeof e.belief_exists === 'number'
+      ? Math.max(0, Math.min(1, e.belief_exists))
+      : typeof e.exists_probability === 'number'
+        ? Math.max(0, Math.min(1, e.exists_probability))
+        : confidence
+  const strengthStd: number | undefined =
+    typeof e.strength?.std === 'number'
+      ? e.strength.std
+      : typeof e.strength_std === 'number'
+        ? e.strength_std
+        : undefined
+
+  // V3 edge metadata — explicitly extract known fields (no blind spread)
+  const edgeType = typeof e.edge_type === 'string' ? e.edge_type : undefined
+  const provenanceSource = typeof e.provenance_source === 'string' ? e.provenance_source : undefined
+  const existsProbability =
+    typeof e.exists_probability === 'number'
+      ? Math.max(0, Math.min(1, e.exists_probability))
+      : undefined
+
+  return {
+    id,
+    source: e.from,
+    target: e.to,
+    type: 'styled' as const,
+    data: {
+      ...DEFAULT_EDGE_DATA,
+      weight,
+      pathType: 'bezier' as const,
+      confidence,
+      beliefExists,
+      ...(direction ? { direction } : {}),
+      ...(strengthStd !== undefined ? { strengthStd } : {}),
+      ...(edgeType !== undefined ? { edge_type: edgeType } : {}),
+      ...(provenanceSource !== undefined ? { provenance_source: provenanceSource } : {}),
+      ...(existsProbability !== undefined ? { exists_probability: existsProbability } : {}),
+      // CEE display provenance (snake_case → camelCase). Distinct from `provenance_source`.
+      ...edgeProvenanceDisplayPatch(e),
+    },
+  }
+}
+
+/**
  * Apply a CEE draft response to the canvas, replacing the current graph.
  *
  * This function replaces all existing nodes/edges, pushes history, triggers
@@ -38,100 +146,10 @@ export function applyDraftResult(
   if (!rawNodes.length) return { nodeCount: 0, edgeCount: 0 }
 
   // --- Map nodes ---
-  const nodes = rawNodes.map((n: any) => {
-    const { id, kind, type: nodeType, label, observed_state, ...rest } = n
-
-    // Derive interventionKeys when interventions object is present (e.g. from CEE add_node)
-    const interventions = rest.interventions as Record<string, unknown> | undefined
-    const interventionKeys = interventions && typeof interventions === 'object' && !Array.isArray(interventions)
-      ? Object.keys(interventions)
-      : undefined
-
-    return {
-      id,
-      type: kind || nodeType,
-      position: { x: 0, y: 0 },
-      data: {
-        ...rest,
-        label,
-        kind: kind || nodeType,
-        ...(observed_state ? { observedState: observed_state } : {}),
-        ...(interventionKeys ? { interventionKeys } : {}),
-      },
-    }
-  })
+  const nodes = rawNodes.map((n: any) => mapDraftNodeToCanvas(n))
 
   // --- Map edges ---
-  const edges = rawEdges.map((e: any, i: number) => {
-    const id =
-      typeof e.id === 'string' && e.id.trim().length > 0 ? e.id : `e-${i}`
-
-    // Weight priority: strength.mean > strength_mean > weight > default
-    const rawWeight: number =
-      typeof e.strength?.mean === 'number'
-        ? e.strength.mean
-        : typeof e.strength_mean === 'number'
-          ? e.strength_mean
-          : typeof e.weight === 'number'
-            ? e.weight
-            : DEFAULT_EDGE_DATA.weight
-
-    // Direction inference
-    const directionFromEdge: EffectDirection | undefined =
-      e.effect_direction === 'positive' || e.effect_direction === 'negative'
-        ? e.effect_direction
-        : undefined
-    const direction: EffectDirection =
-      directionFromEdge ?? (rawWeight < 0 ? 'negative' : 'positive')
-
-    // UI-SEM-038: Duplicate of UI-SEM-023/024/025 on alternate ingestion path.
-    const weight = Math.max(0, Math.min(2, Math.abs(rawWeight)))
-    const confidence =
-      typeof e.belief === 'number'
-        ? Math.max(0, Math.min(1, e.belief))
-        : undefined
-    const beliefExists =
-      typeof e.belief_exists === 'number'
-        ? Math.max(0, Math.min(1, e.belief_exists))
-        : typeof e.exists_probability === 'number'
-          ? Math.max(0, Math.min(1, e.exists_probability))
-          : confidence
-    const strengthStd: number | undefined =
-      typeof e.strength?.std === 'number'
-        ? e.strength.std
-        : typeof e.strength_std === 'number'
-          ? e.strength_std
-          : undefined
-
-    // V3 edge metadata — explicitly extract known fields (no blind spread)
-    const edgeType = typeof e.edge_type === 'string' ? e.edge_type : undefined
-    const provenanceSource = typeof e.provenance_source === 'string' ? e.provenance_source : undefined
-    const existsProbability =
-      typeof e.exists_probability === 'number'
-        ? Math.max(0, Math.min(1, e.exists_probability))
-        : undefined
-
-    return {
-      id,
-      source: e.from,
-      target: e.to,
-      type: 'styled' as const,
-      data: {
-        ...DEFAULT_EDGE_DATA,
-        weight,
-        pathType: 'bezier' as const,
-        confidence,
-        beliefExists,
-        ...(direction ? { direction } : {}),
-        ...(strengthStd !== undefined ? { strengthStd } : {}),
-        ...(edgeType !== undefined ? { edge_type: edgeType } : {}),
-        ...(provenanceSource !== undefined ? { provenance_source: provenanceSource } : {}),
-        ...(existsProbability !== undefined ? { exists_probability: existsProbability } : {}),
-        // CEE display provenance (snake_case → camelCase). Distinct from `provenance_source`.
-        ...edgeProvenanceDisplayPatch(e),
-      },
-    }
-  })
+  const edges = rawEdges.map((e: any, i: number) => mapDraftEdgeToCanvas(e, i))
 
   // --- Apply to store ---
   const store = useCanvasStore.getState()

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -1,0 +1,178 @@
+/**
+ * mergeAppliedGraphAdditive — ingest an applied-edit receipt's graph into a
+ * NON-EMPTY canvas (POC Lane C, edit-journey display closure, 2026-07-11).
+ *
+ * Wire contract: CEE #414/#424 attach the FULL committed post-mutation graph
+ * to applied-edit receipts via the EXISTING top-level `draft_graph` field
+ * (OlumiResponseSchema 0.8.0+, unchanged at the pinned 0.15.0), post-commit
+ * only — see olumi-assistants-service
+ * src/orchestrator-v5/compose/applied-graph-emit.ts. The UI's only inline
+ * ingestion path (applyDraftResult via useConversation) was gated on
+ * canvasIsEmpty, so a confirmed structural edit (add factor / add edge) never
+ * reached a populated canvas until a full reload.
+ *
+ * Why the gate "draft_graph + non-empty canvas ⇒ applied-edit receipt" is
+ * sound: CEE's fresh-draft dispatch fires only when the request carries NO
+ * graph_state (route-v2 `isDraftGraphShape` requires
+ * `extensions.graphState == null`), and this client sends graph_state on
+ * every turn. A non-empty canvas therefore can never receive a fresh-draft
+ * draft_graph — only the post-mutation receipt shape.
+ *
+ * Semantics — ADDITIVE ONLY:
+ *   - Wire nodes/edges missing from the canvas are added, converted with the
+ *     SAME mappers as the draft path (mapDraftNodeToCanvas /
+ *     mapDraftEdgeToCanvas), then pulsed with the applied-edit highlight.
+ *   - Existing canvas elements are never repositioned, rewritten, or removed.
+ *     Value updates on existing elements arrive separately as graph_patch
+ *     blocks (applyV5State); removals have no ingestion path yet (known
+ *     residual, same class as applyV5State's missing delete case).
+ *   - No full re-layout: added nodes are placed in a column to the right of
+ *     the current graph's bounding box so the user's layout is untouched.
+ *   - A receipt whose graph carries nothing new (e.g. a value-only edit) is a
+ *     strict no-op — no history entry, no store write, no autosave.
+ *
+ * Freshness: deliberately NOT marking the local dirty overlay here. The same
+ * response carries CEE's post-apply analysis_ready.freshness verdict (routed
+ * through applyV5State step 4 setAnalysisFreshness before this merge runs);
+ * that verdict is authoritative for exactly this graph — the overlay exists
+ * for local writes CEE has not seen. pushHistory below still flips
+ * graphEditedSinceLastRun / analysisStateReady=false, which is true: the
+ * graph changed since the last analysis run.
+ */
+
+import { useCanvasStore } from '../store'
+import { validateNodesBatch } from '../domain/nodes'
+import { saveAutosave } from '../store/scenarios'
+import { pulseAppliedTargets } from './appliedEditPulse'
+import {
+  backfillInterventionsOntoOptionNodes,
+  mapDraftEdgeToCanvas,
+  mapDraftNodeToCanvas,
+} from './applyDraftResult'
+import type { CEEDraftResponse, CEEv2Response, CEEv3Response } from '../../adapters/cee/types'
+
+/** Horizontal gap between the current bounding box and the added column. */
+const ADDED_COLUMN_X_GAP = 260
+/** Vertical spacing between stacked added nodes. */
+const ADDED_COLUMN_Y_STEP = 140
+
+export interface MergeAppliedGraphResult {
+  addedNodeCount: number
+  addedEdgeCount: number
+}
+
+export function mergeAppliedGraphAdditive(
+  draftData: CEEDraftResponse | CEEv2Response | CEEv3Response
+): MergeAppliedGraphResult {
+  const rawNodes: any[] =
+    (draftData as any)?.nodes ?? (draftData as any)?.graph?.nodes ?? []
+  const rawEdges: any[] =
+    (draftData as any)?.edges ?? (draftData as any)?.graph?.edges ?? []
+
+  const store = useCanvasStore.getState()
+  const existingNodeIds = new Set(store.nodes.map((n) => n.id))
+  const existingEdgeIds = new Set(store.edges.map((e) => e.id))
+  // Endpoint-pair dedupe: an existing edge whose id was locally rewritten
+  // (fallback `e-${i}` ids from an earlier draft) must not be re-added under
+  // the wire's id. Parallel edges between the same pair are not a supported
+  // canvas shape today, so the pair key is a safe identity fallback.
+  const existingEdgePairs = new Set(
+    store.edges.map((e) => `${e.source}\u0000${e.target}`)
+  )
+
+  // --- Added nodes: on the wire, not on the canvas ---
+  const missingRawNodes = rawNodes.filter(
+    (n: any) =>
+      n != null &&
+      typeof n.id === 'string' &&
+      n.id.length > 0 &&
+      !existingNodeIds.has(n.id)
+  )
+  const addedNodes = missingRawNodes.map((n: any) => mapDraftNodeToCanvas(n))
+
+  // Deterministic placement: a column to the right of the current bounding
+  // box. Never re-layouts the user's existing nodes.
+  if (addedNodes.length > 0) {
+    const xs = store.nodes.map((n) => n.position?.x ?? 0)
+    const ys = store.nodes.map((n) => n.position?.y ?? 0)
+    const baseX = (xs.length ? Math.max(...xs) : 0) + ADDED_COLUMN_X_GAP
+    const baseY = ys.length ? Math.min(...ys) : 0
+    addedNodes.forEach((n: any, idx: number) => {
+      n.position = { x: baseX, y: baseY + idx * ADDED_COLUMN_Y_STEP }
+    })
+  }
+
+  // --- Added edges: on the wire, not on the canvas, endpoints resolvable ---
+  const unionNodeIds = new Set<string>([
+    ...existingNodeIds,
+    ...addedNodes.map((n: any) => n.id as string),
+  ])
+  const missingRawEdges = rawEdges.filter((e: any) => {
+    if (e == null) return false
+    const from = e.from ?? e.source
+    const to = e.to ?? e.target
+    if (typeof from !== 'string' || typeof to !== 'string') return false
+    if (typeof e.id === 'string' && existingEdgeIds.has(e.id)) return false
+    if (existingEdgePairs.has(`${from}\u0000${to}`)) return false
+    // Fail-closed: never add a dangling edge (e.g. wire endpoint the user
+    // deleted locally and the receipt re-references).
+    return unionNodeIds.has(from) && unionNodeIds.has(to)
+  })
+  const usedEdgeIds = new Set<string>(existingEdgeIds)
+  const addedEdges = missingRawEdges.map((e: any, i: number) => {
+    const mapped = mapDraftEdgeToCanvas(e, i)
+    // The mapper's fallback id (`e-${i}`) indexes the wire array — make it
+    // collision-proof against edges already on the canvas.
+    let id: string = mapped.id
+    while (usedEdgeIds.has(id)) id = `${id}-a`
+    usedEdgeIds.add(id)
+    return { ...mapped, id }
+  })
+
+  if (addedNodes.length === 0 && addedEdges.length === 0) {
+    return { addedNodeCount: 0, addedEdgeCount: 0 }
+  }
+
+  // --- Commit: one history entry, additive store write ---
+  const canvas = useCanvasStore.getState()
+  canvas.pushHistory()
+  useCanvasStore.setState({
+    nodes: [...canvas.nodes, ...addedNodes],
+    edges: [...canvas.edges, ...addedEdges],
+  })
+
+  // Warning-only schema validation on the added nodes (mirrors applyDraftResult).
+  validateNodesBatch(addedNodes)
+
+  // Seamlessness R2: acknowledge the AI's applied edit with the SAME
+  // coalesced 2s highlight the graph_patch path uses — pulse only, no
+  // selection/viewport hijack. Fail-closed downstream against the canvas.
+  pulseAppliedTargets({
+    nodeIds: addedNodes.map((n: any) => n.id as string),
+    edgeIds: addedEdges.map((e: any) => e.id as string),
+  })
+
+  // Newly added option nodes need node.data.interventions mirrored from
+  // analysis_ready (OptionNode render, islRequestAdapter fallback readers).
+  // applyV5State step 4 wrote ceeAnalysisReady BEFORE this merge ran, when
+  // the option node did not yet exist — close the loop now. Idempotent.
+  const analysisReady = useCanvasStore.getState().ceeAnalysisReady
+  if (analysisReady) {
+    backfillInterventionsOntoOptionNodes(analysisReady)
+  }
+
+  // Immediate autosave for crash resilience (mirrors applyDraftResult).
+  try {
+    const current = useCanvasStore.getState()
+    saveAutosave({
+      timestamp: Date.now(),
+      scenarioId: current.currentScenarioId || undefined,
+      nodes: current.nodes,
+      edges: current.edges,
+    })
+  } catch {
+    // Non-critical — swallow save errors
+  }
+
+  return { addedNodeCount: addedNodes.length, addedEdgeCount: addedEdges.length }
+}

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -11,12 +11,21 @@
  * canvasIsEmpty, so a confirmed structural edit (add factor / add edge) never
  * reached a populated canvas until a full reload.
  *
- * Why the gate "draft_graph + non-empty canvas ⇒ applied-edit receipt" is
- * sound: CEE's fresh-draft dispatch fires only when the request carries NO
- * graph_state (route-v2 `isDraftGraphShape` requires
- * `extensions.graphState == null`), and this client sends graph_state on
- * every turn. A non-empty canvas therefore can never receive a fresh-draft
- * draft_graph — only the post-mutation receipt shape.
+ * Why "draft_graph + non-empty canvas" is treated as an applied-edit receipt:
+ * the V5 payload carries NO graph_state (buildPayload.ts — MessageTurnPayload
+ * is turn ids/stage/message/source/chip only), so CEE's
+ * `extensions.graphState` is null on EVERY V5 turn and does not discriminate.
+ * The actual server-side suppression of the fresh-draft dispatch is the
+ * continuation guard: route-v2 `isDraftGraphShape` requires
+ * `!isContinuationScenario` (loadHasPriorTurns on the scenario), and a
+ * non-empty canvas normally belongs to a scenario with prior committed turns.
+ * The reachable misfire — a FRESH scenario_id with a populated canvas whose
+ * first message is a ≥30-char brief-shaped text — slips past that guard and
+ * returns a misdrafted fresh graph; the zero-overlap guard below drops it
+ * client-side (an applied receipt always supersets the committed graph, so
+ * zero node-id overlap with the canvas is diagnostic). CEE also COMMITS that
+ * misdrafted graph server-side — a pre-existing CEE bug filed as its own
+ * follow-up lane (see PR #266 body).
  *
  * Semantics — ADDITIVE ONLY:
  *   - Wire nodes/edges missing from the canvas are added, converted with the
@@ -30,18 +39,23 @@
  *     the current graph's bounding box so the user's layout is untouched.
  *   - A receipt whose graph carries nothing new (e.g. a value-only edit) is a
  *     strict no-op — no history entry, no store write, no autosave.
+ *   - Zero node-id overlap with a non-empty canvas ⇒ DROP + structured warn
+ *     (never graft an unrelated graph).
  *
  * Freshness: deliberately NOT marking the local dirty overlay here. The same
  * response carries CEE's post-apply analysis_ready.freshness verdict (routed
  * through applyV5State step 4 setAnalysisFreshness before this merge runs);
  * that verdict is authoritative for exactly this graph — the overlay exists
- * for local writes CEE has not seen. pushHistory below still flips
- * graphEditedSinceLastRun / analysisStateReady=false, which is true: the
- * graph changed since the last analysis run.
+ * for local writes CEE has not seen. graphEditedSinceLastRun /
+ * analysisStateReady are set EXPLICITLY in the commit below (true / false):
+ * pushHistory alone cannot be relied on for them, because pushToHistory
+ * early-returns without flipping either flag when the pre-merge state equals
+ * the last history snapshot.
  */
 
 import { useCanvasStore } from '../store'
 import { validateNodesBatch } from '../domain/nodes'
+import { logger } from '../../lib/logger'
 import { saveAutosave } from '../store/scenarios'
 import { pulseAppliedTargets } from './appliedEditPulse'
 import {
@@ -72,6 +86,26 @@ export function mergeAppliedGraphAdditive(
   const store = useCanvasStore.getState()
   const existingNodeIds = new Set(store.nodes.map((n) => n.id))
   const existingEdgeIds = new Set(store.edges.map((e) => e.id))
+
+  // Structural guard (PR #266 review): an applied-edit receipt's graph is the
+  // COMMITTED canvas graph plus/minus the edit, so it always shares node ids
+  // with a non-empty canvas. Zero overlap means this draft_graph is a
+  // misdrafted FRESH graph (fresh scenario_id + populated canvas + first
+  // brief-shaped message slips past CEE's continuation guard) — grafting it
+  // would union two unrelated graphs. Drop and warn instead.
+  if (store.nodes.length > 0 && rawNodes.length > 0) {
+    const hasOverlap = rawNodes.some(
+      (n: any) => n != null && typeof n.id === 'string' && existingNodeIds.has(n.id)
+    )
+    if (!hasOverlap) {
+      logger.warn('merge_applied_graph.zero_overlap_drop', {
+        scenarioId: store.currentScenarioId ?? null,
+        canvasNodeCount: store.nodes.length,
+        wireNodeCount: rawNodes.length,
+      })
+      return { addedNodeCount: 0, addedEdgeCount: 0 }
+    }
+  }
   // Endpoint-pair dedupe: an existing edge whose id was locally rewritten
   // (fallback `e-${i}` ids from an earlier draft) must not be re-added under
   // the wire's id. Parallel edges between the same pair are not a supported
@@ -107,16 +141,23 @@ export function mergeAppliedGraphAdditive(
     ...existingNodeIds,
     ...addedNodes.map((n: any) => n.id as string),
   ])
+  // Track endpoint pairs already taken — by existing canvas edges AND by
+  // earlier NEW edges in this same receipt. The commit below writes via a
+  // direct setState (bypassing addEdge's duplicate guard), so two wire edges
+  // sharing a pair must self-dedupe here (first wins).
+  const seenEdgePairs = new Set(existingEdgePairs)
   const missingRawEdges = rawEdges.filter((e: any) => {
     if (e == null) return false
     const from = e.from ?? e.source
     const to = e.to ?? e.target
     if (typeof from !== 'string' || typeof to !== 'string') return false
     if (typeof e.id === 'string' && existingEdgeIds.has(e.id)) return false
-    if (existingEdgePairs.has(`${from}\u0000${to}`)) return false
+    if (seenEdgePairs.has(`${from}\u0000${to}`)) return false
     // Fail-closed: never add a dangling edge (e.g. wire endpoint the user
     // deleted locally and the receipt re-references).
-    return unionNodeIds.has(from) && unionNodeIds.has(to)
+    if (!unionNodeIds.has(from) || !unionNodeIds.has(to)) return false
+    seenEdgePairs.add(`${from}\u0000${to}`)
+    return true
   })
   const usedEdgeIds = new Set<string>(existingEdgeIds)
   const addedEdges = missingRawEdges.map((e: any, i: number) => {
@@ -139,6 +180,12 @@ export function mergeAppliedGraphAdditive(
   useCanvasStore.setState({
     nodes: [...canvas.nodes, ...addedNodes],
     edges: [...canvas.edges, ...addedEdges],
+    // Set the staleness flags EXPLICITLY: pushToHistory sets them too, but
+    // early-returns without flipping either when the pre-merge state equals
+    // the last history snapshot (dedupe guard, store.ts) — and a structural
+    // add always makes the last analysis snapshot stale.
+    graphEditedSinceLastRun: true,
+    analysisStateReady: false,
   })
 
   // Warning-only schema validation on the added nodes (mirrors applyDraftResult).


### PR DESCRIPTION
Closes the last two POC display gaps in the edit journey (WEEKEND-SPRINT-PLAN-2026-07-11, Lanes A + C — pulled in-house from the stalled A2 queue). Base: staging tip d085995c, fresh worktree.

## Lane A — reload visual revert (one-file fix)

`useAutosave.ts` `computeGraphHash` covered only id/kind/label/x/y + edge endpoints/weight. A conversational value edit (V5 `graph_patch` `set_factor_value` → `node.data.observedState` merge; `adjust_edge_strength` → edge `weight`/`direction` write; intervention / goal-threshold backfills) changed none of those fields, so the dirty hash never flipped, the autosave skipped, and localStorage kept PRE-EDIT values — on reload the recovery path (`ReactFlowGraph.tsx` autosave-vs-scenario timestamp comparison) could hydrate the stale graph while the server copy was correct (verified by DB probe, p0b-evidence/run3).

**Fix:** hash now includes value-bearing node data (`observedState`, `interventions`, `is_baseline`, `goal_threshold_*`) and edge data (`weight`, `direction`, `confidence`, `beliefExists`, `strengthStd`). Extra hash fields can only cause an extra save, never a missed one.

## Lane C — applied-edit ingestion on a non-empty canvas

CEE #414/#424 (merged, staging) attach the FULL committed post-mutation graph to applied-edit receipts via the existing top-level `draft_graph` wire field — but the UI's only inline ingestion path was gated on `canvasIsEmpty` (`useConversation.ts:3190`) and `applyV5State` has no add case, so a confirmed added factor/edge did not appear until reload.

**Fix:** new `mergeAppliedGraphAdditive` (`src/canvas/utils/mergeAppliedGraph.ts`), wired at the same gate behind the same scenario-match guard:

- **Gate rationale (corrected in review round 1):** the V5 payload carries NO `graph_state` (`buildPayload.ts` — `MessageTurnPayload` has no such field), so CEE's `extensions.graphState` is null on every V5 turn and does not discriminate. What actually keeps a fresh-draft `draft_graph` away from a non-empty canvas is **CEE's continuation guard** (route-v2 `isDraftGraphShape` requires `!isContinuationScenario` — no prior committed turns on the scenario). The residual misfire — fresh scenario_id + populated canvas + first ≥30-char brief-shaped message — is caught client-side by the zero-overlap guard (below).
- **Zero-overlap structural guard (review round 1):** applied receipts always superset the committed graph, so a wire graph sharing ZERO node ids with the canvas is a misdrafted fresh graph — the merge DROPS it and emits `logger.warn('merge_applied_graph.zero_overlap_drop', …)` instead of grafting an unrelated graph.
- **Additive only:** wire elements missing from the canvas are added via the SAME mappers as the draft path (`mapDraftNodeToCanvas`/`mapDraftEdgeToCanvas`, extracted from `applyDraftResult` — pure refactor, draft behaviour unchanged). Existing elements are never repositioned/rewritten/removed; no full re-layout (added nodes placed right of the current bounding box); endpoint-pair dedupe against the canvas AND between new wire edges (review round 1 — direct setState bypasses `addEdge`'s duplicate guard); dangling edges dropped fail-closed; fallback edge-id collisions uniquified; nothing-new receipts are a strict no-op (no history entry).
- Added elements get the applied-edit pulse (seamlessness R2); intervention backfill loop closed for newly added option nodes; immediate autosave; freshness left to the receipt's own `analysis_ready` verdict (rationale in the module doc). `graphEditedSinceLastRun`/`analysisStateReady` are set explicitly in the commit setState (review round 1 — `pushToHistory` early-returns without flipping them when the pre-merge state equals the last history snapshot).

## RED evidence

Initial (commit 28da4b2e):
- Lane A: `useAutosave.staleValueHash.spec.ts` — 3 failed (`expected "spy" to be called 2 times, but got 1 times` for observedState / interventions / edge-direction); no-change guard green.
- Lane C: `useConversation.hook.spec.ts` "applied-edit receipt" — 1 failed (`expected [ 'goal-1', 'factor-1' ] to include 'factor-2'`).

Review round 1 (commit 6db853ec):
- Zero-overlap guard, edge-pair self-dedupe, staleness flags — 3 failed | 8 passed (`mergeAppliedGraph.spec.ts`): unguarded code grafted 3 unrelated nodes, added a duplicate endpoint-pair edge, and left `graphEditedSinceLastRun` false on history dedupe.

## Gates (after review round 1, head 6afedf3d)

- `pnpm run typecheck` (tsconfig.ci.json): clean.
- Targeted vitest (touched files + neighbours): 6 files, **119 passed / 0 failed** (`useConversation.hook.spec.ts`, `applyDraftResult.spec.ts`, `draftIngestion.spec.ts`, `mergeAppliedGraph.spec.ts` 11/11, `appliedEditPulse.spec.ts`, `useAutosave.staleValueHash.spec.ts` 4/4).
- Pre-push fast gate (validate-prepush.sh): ALL CHECKS PASSED (both pushes).
- Full suite not run locally (OOMs by design — CI covers it). The chronically-red "Staging Tests" CI is pre-existing, not from this branch.

## Filed follow-ups (out of scope here)

- **CEE bug (needs its own CEE lane):** on the misfire path (fresh scenario_id + populated canvas + first brief-shaped message), CEE's fresh-draft dispatch not only returns a misdrafted `draft_graph` — it **commits it to `scenarios.graph` server-side** (`dispatchDraftGraph` → `commitPerformed`), clobbering nothing today only because the scenario row is new, but permanently diverging the server copy from the user's populated canvas. The UI's zero-overlap guard protects the display; the server-side commit needs a CEE-side guard (e.g. suppress draft dispatch when the turn's scenario has a non-empty committed graph, or require an explicit draft intent).
- **Removals** still have no ingestion path (merge is additive by spec; same class as `applyV5State`'s missing delete case).
- **TargetRef extractor seam** (`src/v5/extractPhase3FromV5Response.ts:251-262` reads `type` with `node|edge|option|graph|framing`; contract `TargetRefSchema` emits `kind` with `factor|option|edge|goal|risk|constraint|outcome`) — confirmed still present, NOT in this PR's touched files; stays routed to A2 per the weekend-plan kickoff.
- A receipt arriving after the user locally deleted an element the wire still carries would re-add it (additive merge trusts the committed server graph); acceptable for POC — flagged for the doctrine queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)