### PR TITLE
fix(v5): guidance derivation reads contract TargetRefSchema kind — wire refs reach target_object

### DIFF
--- a/src/v5/__tests__/extractPhase3FromV5Response.spec.ts
+++ b/src/v5/__tests__/extractPhase3FromV5Response.spec.ts
@@ -330,6 +330,45 @@ describe('extractPhase3FromV5Response — contract target_refs (TargetRefSchema 
       { id: 'z-1', label: 'Future thing' },
     ])
   })
+
+  it('an explicit target_object wins over a kind-bearing target_refs[0] (branch precedence pin)', () => {
+    const response = attachExtensions(baseResponse(), {
+      phase3_blocks: [
+        {
+          type: 'coaching',
+          id: 'c-precedence',
+          title: 'Explicit target wins',
+          target_object: { type: 'edge', id: 'edge-explicit', label: 'Explicit' },
+          target_refs: [{ id: 'node-ref', label: 'From ref', kind: 'factor' }],
+        },
+      ],
+    })
+    const r = extractPhase3FromV5Response(response)
+    expect(r.guidanceItems[0].target_object).toEqual({
+      type: 'edge',
+      id: 'edge-explicit',
+      label: 'Explicit',
+    })
+  })
+
+  it('an empty-string kind marks a contract ref and fails closed — no legacy type fallback', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([{ id: 'n-1', label: 'Empty kind', kind: '', type: 'node' }]),
+    )
+    expect(r.guidanceItems[0].target_object).toBeUndefined()
+  })
+
+  it('an unknown kind beside a legacy type in a related ref fails closed on type (kind wins)', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([
+        { id: 'node-1', label: 'Primary', kind: 'factor' },
+        { id: 'z-2', label: 'Both fields', kind: 'galaxy', type: 'node' },
+      ]),
+    )
+    expect(r.guidanceItems[0].related_elements).toEqual([
+      { id: 'z-2', label: 'Both fields' },
+    ])
+  })
 })
 
 describe('v5ResponseHasRunAnalysisFact', () => {

--- a/src/v5/__tests__/extractPhase3FromV5Response.spec.ts
+++ b/src/v5/__tests__/extractPhase3FromV5Response.spec.ts
@@ -200,6 +200,138 @@ describe('extractPhase3FromV5Response', () => {
   })
 })
 
+describe('extractPhase3FromV5Response — contract target_refs (TargetRefSchema {id,label,kind})', () => {
+  // The wire contract (@talchain/schemas TargetRefSchema §0.1, strict) emits
+  // `kind` ∈ factor|option|edge|goal|risk|constraint|outcome — NOT the legacy
+  // `type` ∈ node|edge|option|graph|framing convention this extractor
+  // originally read. These tests pin the contract convention end-to-end.
+
+  function coachingWithRefs(target_refs: unknown[]): OlumiResponseWithExtensions {
+    return attachExtensions(baseResponse(), {
+      phase3_blocks: [
+        {
+          type: 'coaching',
+          id: 'c-refs',
+          title: 'Check this element',
+          target_refs,
+        },
+      ],
+    })
+  }
+
+  it('derives target_object from a contract ref: kind=factor maps to node', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([{ id: 'node-77', label: 'Pricing', kind: 'factor' }]),
+    )
+    expect(r.guidanceItems).toHaveLength(1)
+    expect(r.guidanceItems[0].target_object).toEqual({
+      type: 'node',
+      id: 'node-77',
+      label: 'Pricing',
+    })
+  })
+
+  it('maps kind=edge to edge and kind=option to option', () => {
+    const edge = extractPhase3FromV5Response(
+      coachingWithRefs([{ id: 'edge-3', label: 'Price → Churn', kind: 'edge' }]),
+    )
+    expect(edge.guidanceItems[0].target_object).toEqual({
+      type: 'edge',
+      id: 'edge-3',
+      label: 'Price → Churn',
+    })
+
+    const option = extractPhase3FromV5Response(
+      coachingWithRefs([{ id: 'opt-1', label: 'Acquire', kind: 'option' }]),
+    )
+    expect(option.guidanceItems[0].target_object).toEqual({
+      type: 'option',
+      id: 'opt-1',
+      label: 'Acquire',
+    })
+  })
+
+  it.each(['goal', 'risk', 'constraint', 'outcome'] as const)(
+    'maps kind=%s to node (all non-edge, non-option kinds are canvas nodes)',
+    (kind) => {
+      const r = extractPhase3FromV5Response(
+        coachingWithRefs([{ id: `el-${kind}`, label: `The ${kind}`, kind }]),
+      )
+      expect(r.guidanceItems[0].target_object).toEqual({
+        type: 'node',
+        id: `el-${kind}`,
+        label: `The ${kind}`,
+      })
+    },
+  )
+
+  it('fails closed on an unknown kind — no target_object fabricated', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([{ id: 'x-1', label: 'Mystery', kind: 'galaxy' }]),
+    )
+    expect(r.guidanceItems).toHaveLength(1)
+    expect(r.guidanceItems[0].target_object).toBeUndefined()
+  })
+
+  it('prefers contract kind over a stray legacy type when both are present', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([{ id: 'n-9', label: 'Both', kind: 'factor', type: 'edge' }]),
+    )
+    expect(r.guidanceItems[0].target_object).toEqual({
+      type: 'node',
+      id: 'n-9',
+      label: 'Both',
+    })
+  })
+
+  it('keeps the legacy type convention working when kind is absent', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([{ id: 'node-A', label: 'Legacy', type: 'node' }]),
+    )
+    expect(r.guidanceItems[0].target_object).toEqual({
+      type: 'node',
+      id: 'node-A',
+      label: 'Legacy',
+    })
+  })
+
+  it('tolerates a contract ref without id (label-only), matching the legacy branch', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([{ label: 'Label only', kind: 'factor' }]),
+    )
+    expect(r.guidanceItems[0].target_object).toEqual({
+      type: 'node',
+      label: 'Label only',
+    })
+  })
+
+  it('maps kind onto related_elements type for refs beyond the first', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([
+        { id: 'node-1', label: 'Primary', kind: 'factor' },
+        { id: 'edge-2', label: 'Linked edge', kind: 'edge' },
+        { id: 'risk-3', label: 'Linked risk', kind: 'risk' },
+      ]),
+    )
+    expect(r.guidanceItems[0].related_elements).toEqual([
+      { id: 'edge-2', type: 'edge', label: 'Linked edge' },
+      { id: 'risk-3', type: 'node', label: 'Linked risk' },
+    ])
+  })
+
+  it('omits related_elements type for an unknown kind but keeps id and label', () => {
+    const r = extractPhase3FromV5Response(
+      coachingWithRefs([
+        { id: 'node-1', label: 'Primary', kind: 'factor' },
+        { id: 'z-1', label: 'Future thing', kind: 'galaxy' },
+      ]),
+    )
+    expect(r.guidanceItems[0].related_elements).toEqual([
+      { id: 'z-1', label: 'Future thing' },
+    ])
+  })
+})
+
 describe('v5ResponseHasRunAnalysisFact', () => {
   it('returns true when CEE explicitly emits has_run_analysis_fact=true', () => {
     const response = attachExtensions(

--- a/src/v5/extractPhase3FromV5Response.ts
+++ b/src/v5/extractPhase3FromV5Response.ts
@@ -204,8 +204,10 @@ function collectFromContainer(
 function guidanceTargetType(
   ref: Record<string, unknown>,
 ): NonNullable<DerivedGuidanceItem['target_object']>['type'] | undefined {
-  const kind = safeString(ref.kind)
-  if (kind) {
+  if (typeof ref.kind === 'string') {
+    // Any string `kind` — including empty — marks a contract ref: unknown
+    // or empty kinds fail closed here, never fall back to legacy `type`.
+    const kind = ref.kind
     if (kind === 'edge') return 'edge'
     if (kind === 'option') return 'option'
     if (

--- a/src/v5/extractPhase3FromV5Response.ts
+++ b/src/v5/extractPhase3FromV5Response.ts
@@ -187,6 +187,44 @@ function collectFromContainer(
 }
 
 /**
+ * Map one target_refs entry onto the legacy GuidanceItem target vocabulary
+ * ('node' | 'edge' | 'option' | 'graph' | 'framing').
+ *
+ * Two emission conventions exist:
+ *   1. The wire contract (TargetRefSchema §0.1, strict `{id,label,kind}`,
+ *      kind ∈ factor|option|edge|goal|risk|constraint|outcome). All
+ *      non-edge, non-option kinds are nodes on the canvas — same collapse
+ *      as focusByTarget/TargetRefPill. Unknown kinds fail closed
+ *      (undefined) rather than guessing.
+ *   2. The legacy `type` convention (node|edge|option|graph|framing),
+ *      kept as the fallback when `kind` is absent.
+ * When `kind` is present it wins — a ref that names the contract field is
+ * a contract ref, whatever else rides along.
+ */
+function guidanceTargetType(
+  ref: Record<string, unknown>,
+): NonNullable<DerivedGuidanceItem['target_object']>['type'] | undefined {
+  const kind = safeString(ref.kind)
+  if (kind) {
+    if (kind === 'edge') return 'edge'
+    if (kind === 'option') return 'option'
+    if (
+      kind === 'factor' || kind === 'goal' || kind === 'risk' ||
+      kind === 'constraint' || kind === 'outcome'
+    ) {
+      return 'node'
+    }
+    return undefined
+  }
+  const ttype = safeString(ref.type)
+  if (ttype === 'node' || ttype === 'edge' || ttype === 'option' ||
+      ttype === 'graph' || ttype === 'framing') {
+    return ttype
+  }
+  return undefined
+}
+
+/**
  * Derive a GuidanceItem from a Phase 3 block. Lossless: the raw block stays
  * in Phase3Extraction.rawBlocks, so consumers who need freshness /
  * action_intent / priority_rank / target_refs / graph_hash_at_generation
@@ -234,8 +272,8 @@ function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
         ? Math.max(0, Math.min(100, 100 - rank))
         : 50
 
-  // target_object: prefer explicit, else read first entry from target_refs
-  // when emitted in that convention.
+  // target_object: prefer explicit, else read the first target_refs entry —
+  // contract `kind` or legacy `type` convention, via guidanceTargetType.
   let target_object: DerivedGuidanceItem['target_object']
   if (isPlainObject(r.target_object)) {
     const t = r.target_object
@@ -251,9 +289,8 @@ function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
   } else if (Array.isArray(r.target_refs) && r.target_refs.length > 0) {
     const first = r.target_refs[0]
     if (isPlainObject(first)) {
-      const ttype = safeString(first.type)
-      if (ttype === 'node' || ttype === 'edge' || ttype === 'option' ||
-          ttype === 'graph' || ttype === 'framing') {
+      const ttype = guidanceTargetType(first)
+      if (ttype) {
         target_object = {
           type: ttype,
           ...(safeString(first.id) ? { id: safeString(first.id) } : {}),
@@ -264,15 +301,18 @@ function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
   }
 
   // related_elements: pass through additional target_refs beyond the first.
+  // `type` carries the mapped vocabulary (contract kind or legacy type);
+  // unmappable refs keep their id/label so id-based matching still works.
   let related_elements: DerivedGuidanceItem['related_elements']
   if (Array.isArray(r.target_refs) && r.target_refs.length > 1) {
     related_elements = []
     for (let i = 1; i < r.target_refs.length; i++) {
       const ref = r.target_refs[i]
       if (!isPlainObject(ref)) continue
+      const mapped = guidanceTargetType(ref)
       related_elements.push({
         ...(safeString(ref.id) ? { id: safeString(ref.id) } : {}),
-        ...(safeString(ref.type) ? { type: safeString(ref.type) } : {}),
+        ...(mapped ? { type: mapped } : {}),
         ...(safeString(ref.label) ? { label: safeString(ref.label) } : {}),
       })
     }


### PR DESCRIPTION
## What

`extractPhase3FromV5Response.deriveGuidance` read `target_refs[0].type` with the legacy `node|edge|option|graph|framing` vocabulary. The wire contract (`TargetRefSchema` §0.1 in @talchain/schemas 0.15.0 — strict `{id, label, kind}`, `kind ∈ factor|option|edge|goal|risk|constraint|outcome`, verified in the vendored tarball on this repo's staging tip) has neither that field name nor that vocabulary. Since CEE #411, phase-3 `target_refs` are populated on the wire (R4 live-proof) — and every one of them was silently dropped from `target_object`, leaving guidance surfaces (inspector coaching match, guidance pulse/focus) blind to them.

Routed-in follow-up from the R4 live-verify (weekend sprint plan, A2 kickoff).

## How

- New module-private `guidanceTargetType(ref)`: contract `kind` preferred (edge→`edge`, option→`option`, factor/goal/risk/constraint/outcome→`node` — the same collapse as `focusByTarget`/`TargetRefPill`); **unknown kinds fail closed** (no `target_object`); legacy `type` convention retained as fallback when `kind` is absent.
- `related_elements` entries get the same mapping. Deliberate tightening: previously any string in a legacy `type` passed through verbatim; now only the known vocabularies do — unmappable refs keep `id`/`label` so id-based matching (InspectorCoaching) still works.
- Consistency sweep: `phase3TypedBlocks.ts` and `TargetRefPill` already read `kind` — `deriveGuidance` was the only wrong-field consumer.

## Dedupe policy (decided in-lane, as asked)

None needed: `guidanceItems` (inspector/guidance surfaces) and R1's render-time `TargetRefPill` (inline block pills) are distinct surfaces, both fail-closed at interaction time via `focusExistingTarget`. This fix makes the two surfaces consistent, not duplicative.

## Tests

RED-first (`5501b4f8`): 12 new contracts — 9 RED (kind→type mapping for all 7 kinds, kind-over-type precedence, related_elements mapping, label-only tolerance) + 3 behaviour pins (fail-closed unknown kind, legacy convention, unmappable related ref keeps id/label). GREEN 24/24.

## Gates

- typecheck (tsconfig.ci) clean · `vitest --changed origin/staging` **889 passed / 0 failed** (68 files) · wide `tsc -p tsconfig.app.json` — 0 errors in changed files (4040-line pre-existing baseline) · eslint clean · fast pre-push gate ALL CHECKS PASSED
- Browser proof: not meaningful for this slice — the change is observable only with a live CEE response carrying populated phase-3 refs; unit contracts + the R4 live-proof of populated wire refs are the evidence. Stated honestly.

## Adversarial review (done): MERGE-SAFE, 0 blockers

Complete consumer manifest verified (guidanceStore clear, pulse hook, GuidanceStrip/Inspector focus, InspectorCoaching id-match, OutputsDock results filter, useConversation base-rate chips): every changed outcome is either identical to pre-fix or the documented intent. Contract vocabulary re-verified against the vendored tarball (exact 7-value match). RED genuinely fails 9/12 against pre-fix source. Folds applied in `d6d28b47`: explicit-target_object precedence pin (SHOULD-FIX 1), empty-string kind fails closed + pin (NIT 3), kind-beside-type related-ref pin (NIT 4).

**Visible product change (review NIT 5, deliberate):** factor/goal/risk/constraint/outcome-targeted guidance items now leave the results-panel "Your next steps" list (`OutputsDock.tsx:414` filters out node/edge-targeted items by documented contract — they were only leaking in because target_object was silently dropped) and surface element-scoped instead (inspector coaching, guidance pulse/focus).

**Follow-up filed (review SHOULD-FIX 2, consumer-side, not this diff):** `option`-targeted guidance items now surface element-scoped but have no lifecycle — `clearItemsByTargetIds` never clears type 'option', and pulse/focus skip it, while `applyV5State`/`TargetRefPill` treat option refs as canvas nodes. Consumers should either add 'option' to CLEARABLE_TYPES/pulse/focus or document the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)