### PR TITLE
feat(auth): login UI half — VITE_REQUIRE_LOGIN dark build (flag gate, Bearer on turns, guest-draft import, CSP)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -90,8 +90,11 @@
   #   Tailwind and component libraries inject runtime styles that cannot use nonces
   # connect-src: Pinned to specific Render subdomains (tightened from *.onrender.com).
   # In production, all service calls route through /bff/* (same-origin) via Netlify redirects/edge functions.
-  # These explicit entries cover local dev overrides (VITE_CEE_DRAFT_BASE, VITE_ISL_BFF_BASE).
-  Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://plot-lite-service-staging.onrender.com https://olumi-assistants-service.onrender.com https://cee-staging.onrender.com https://isl-staging.onrender.com https://*.supabase.co https://api.openai.com wss://*.supabase.co; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+  # These explicit entries cover local dev overrides (VITE_CEE_DRAFT_BASE).
+  # isl-staging removed (login 3.4 item 4): the browser has no legitimate
+  # direct ISL path — all ISL traffic is same-origin /bff/isl via the edge
+  # proxy (adapters/isl/client.ts), which browser CSP does not govern.
+  Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://plot-lite-service-staging.onrender.com https://olumi-assistants-service.onrender.com https://cee-staging.onrender.com https://*.supabase.co https://api.openai.com wss://*.supabase.co; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
   # Prevent clickjacking
   X-Frame-Options = "DENY"
   # Prevent MIME sniffing

--- a/netlify/edge-functions/orchestrator-proxy.ts
+++ b/netlify/edge-functions/orchestrator-proxy.ts
@@ -95,10 +95,16 @@ export default async function handler(request: Request, _context: Context) {
   const targetPath = url.pathname.replace(/^\/bff\/orchestrate/, '/orchestrate')
   const targetUrl = `${CEE_TARGET}${targetPath}${url.search}`
 
-  // SECURITY: Build headers from scratch with explicit allowlist
+  // SECURITY: Build headers from scratch with explicit allowlist.
+  // 'authorization' carries the user's Supabase access token (login 3.4 —
+  // LOGIN-CEE-HALF-SPEC item 4: the DGAI edge function passes the user
+  // token through so CEE's flag-gated JWT half can verify identity). It is
+  // the USER token; the caller-auth X-Olumi-Assist-Key is injected
+  // separately below and never collides.
   const ALLOWED_FORWARD_HEADERS = [
     'content-type',
     'accept',
+    'authorization',
     'x-correlation-id',
     'x-request-id',
     'x-user-id',

--- a/src/__tests__/netlifyCsp.spec.ts
+++ b/src/__tests__/netlifyCsp.spec.ts
@@ -13,8 +13,10 @@ import { resolve } from 'node:path'
 
 function connectSrc(): string {
   const toml = readFileSync(resolve(process.cwd(), 'netlify.toml'), 'utf8')
-  const match = toml.match(/connect-src[^;"]*/)
-  expect(match, 'netlify.toml must declare a connect-src').not.toBeNull()
+  const cspLine = toml.match(/Content-Security-Policy\s*=\s*"([^"]*)"/)
+  expect(cspLine, 'netlify.toml must declare a Content-Security-Policy').not.toBeNull()
+  const match = cspLine![1].match(/connect-src[^;]*/)
+  expect(match, 'the CSP must declare a connect-src').not.toBeNull()
   return match![0]
 }
 

--- a/src/__tests__/netlifyCsp.spec.ts
+++ b/src/__tests__/netlifyCsp.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Login UI half (3.4) item 4 — CSP hygiene pin.
+ *
+ * The browser has NO legitimate direct path to ISL (all ISL traffic is
+ * same-origin /bff/isl → server-side edge proxy, adapters/isl/client.ts:29),
+ * so isl-staging.onrender.com must not appear in connect-src. The other
+ * service origins stay: they can be direct browser targets via VITE_ base
+ * overrides.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function connectSrc(): string {
+  const toml = readFileSync(resolve(process.cwd(), 'netlify.toml'), 'utf8')
+  const match = toml.match(/connect-src[^;"]*/)
+  expect(match, 'netlify.toml must declare a connect-src').not.toBeNull()
+  return match![0]
+}
+
+describe('netlify.toml CSP connect-src', () => {
+  it('does not allow direct browser connections to ISL', () => {
+    expect(connectSrc()).not.toContain('isl-staging.onrender.com')
+  })
+
+  it('keeps the legitimate service origins', () => {
+    const src = connectSrc()
+    expect(src).toContain("'self'")
+    expect(src).toContain('plot-lite-service-staging.onrender.com')
+    expect(src).toContain('olumi-assistants-service.onrender.com')
+    expect(src).toContain('cee-staging.onrender.com')
+    expect(src).toContain('supabase.co')
+  })
+})

--- a/src/__tests__/orchestratorProxyHeaders.spec.ts
+++ b/src/__tests__/orchestratorProxyHeaders.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Login UI half (3.4) — orchestrator edge-proxy forward-allowlist pin.
+ *
+ * The proxy builds forwarded headers FROM SCRATCH against an explicit
+ * allowlist, so any header missing from it is silently stripped before CEE
+ * ever sees the request. The review of PR #268 caught exactly that failure:
+ * the Authorization Bearer (the whole point of the login coordination
+ * contract) was preflight-permitted but forward-stripped. This spec pins
+ * the allowlist so the contract cannot silently regress.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function allowlist(): string {
+  const src = readFileSync(
+    resolve(process.cwd(), 'netlify/edge-functions/orchestrator-proxy.ts'),
+    'utf8',
+  )
+  const match = src.match(/ALLOWED_FORWARD_HEADERS\s*=\s*\[([^\]]*)\]/)
+  expect(match, 'orchestrator-proxy must declare ALLOWED_FORWARD_HEADERS').not.toBeNull()
+  return match![1]
+}
+
+describe('orchestrator-proxy ALLOWED_FORWARD_HEADERS', () => {
+  it("forwards the user's Authorization Bearer to CEE (login 3.4 contract)", () => {
+    expect(allowlist()).toContain("'authorization'")
+  })
+
+  it('keeps x-user-id until CEE confirms server-side derivation (skew-safe order)', () => {
+    expect(allowlist()).toContain("'x-user-id'")
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
@@ -47,6 +47,7 @@ const flagState = { aiPanelV2: false }
 vi.mock('../../../flags', () => ({
   isTelemetryEnabled: () => false,
   isCompareEnabled: () => false,
+  isRequireLoginEnabled: () => false, // login 3.4 — lib/poc.ts reads it
   isOrchestratorV2Enabled: () => false,
   isLegacyDirectRunEnabled: () => true,
   isJourneyTabEnabled: () => false,

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -88,6 +88,13 @@ const mockGetUserId = vi.fn<[], Promise<string | null>>()
 
 vi.mock('../../../lib/supabase', () => ({
   getUserId: (...args: unknown[]) => mockGetUserId(...args as []),
+  // Login 3.4: useConversation resolves identity via getSessionIdentity
+  // (userId + access token in one getSession call). Backed by the same
+  // mock so each test's userId intent carries over; no token in tests.
+  getSessionIdentity: async () => ({
+    userId: (await mockGetUserId()) ?? null,
+    accessToken: null,
+  }),
 }))
 
 // Mock scenarioService loadScenario: vi.fn() so tests can return graph data.

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -86,14 +86,18 @@ vi.mock('../../../v5/eligibility', () => ({
 // Default: null (no auth session in test environment).
 const mockGetUserId = vi.fn<[], Promise<string | null>>()
 
+// Login 3.4: token knob for the getSessionIdentity bridge — tests that
+// exercise the Bearer path set .value; everything else runs token-less.
+const mockAccessToken = { value: null as string | null }
+
 vi.mock('../../../lib/supabase', () => ({
   getUserId: (...args: unknown[]) => mockGetUserId(...args as []),
   // Login 3.4: useConversation resolves identity via getSessionIdentity
   // (userId + access token in one getSession call). Backed by the same
-  // mock so each test's userId intent carries over; no token in tests.
+  // mock so each test's userId intent carries over.
   getSessionIdentity: async () => ({
     userId: (await mockGetUserId()) ?? null,
-    accessToken: null,
+    accessToken: mockAccessToken.value,
   }),
 }))
 
@@ -2436,5 +2440,53 @@ describe('V1 leakage regression — V5 flag prevents V4 streaming path', () => {
     const assistantMsg = result.current.messages.find((m) => m.role === 'assistant')
     expect(assistantMsg).toBeDefined()
     expect(assistantMsg?.content).toBe(V5_TEXT)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Login 3.4 — turn auth headers through the real hook (PR #268 review S4:
+// the pure buildTurnAuthHeaders unit alone could not catch a regression
+// that drops the Bearer from the actual turn call)
+// ---------------------------------------------------------------------------
+
+describe('login 3.4 — V5 turn auth headers', () => {
+  beforeEach(() => {
+    mockIsV5Eligible.mockReturnValue({ eligible: true })
+  })
+
+  afterEach(() => {
+    mockAccessToken.value = null
+  })
+
+  it('sends Authorization Bearer alongside X-User-Id when a session exists', async () => {
+    mockGetUserId.mockResolvedValue('user-abc')
+    mockAccessToken.value = 'tok-123'
+    mockCallV5Turn.mockResolvedValue(makeV5SuccessResult('ok'))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('auth header pin')
+    })
+
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    const opts = mockCallV5Turn.mock.calls[0][1] as { headers?: Record<string, string> }
+    expect(opts.headers).toMatchObject({
+      'X-User-Id': 'user-abc',
+      Authorization: 'Bearer tok-123',
+    })
+  })
+
+  it('sends NO auth headers for a guest (no session) — byte-identical pin', async () => {
+    mockGetUserId.mockResolvedValue(null)
+    mockCallV5Turn.mockResolvedValue(makeV5SuccessResult('ok'))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('guest header pin')
+    })
+
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    const opts = mockCallV5Turn.mock.calls[0][1] as { headers?: Record<string, string> }
+    expect(opts.headers).toEqual({})
   })
 })

--- a/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
@@ -72,6 +72,11 @@ vi.mock('../../../v5/eligibility', () => ({
 const mockGetUserId = vi.fn<[], Promise<string | null>>()
 vi.mock('../../../lib/supabase', () => ({
   getUserId: (...args: unknown[]) => mockGetUserId(...(args as [])),
+  // Login 3.4: see useConversation.hook.spec.ts — same mock bridge.
+  getSessionIdentity: async () => ({
+    userId: (await mockGetUserId()) ?? null,
+    accessToken: null,
+  }),
 }))
 
 const mockLoadScenario = vi.fn<[string], Promise<unknown>>()

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -85,7 +85,8 @@ import { applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
 import { loadScenario as loadScenarioFromDb } from '../../services/scenarioService'
 import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
 import { mergeAppliedGraphAdditive } from '../utils/mergeAppliedGraph'
-import { getUserId } from '../../lib/supabase'
+import { getSessionIdentity } from '../../lib/supabase'
+import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 import { validateAnalysisReadyContract } from './validateAnalysisReadyContract'
 import { validateResponse, stripRepairLogLines, FALLBACK_TEXT } from './validateResponse'
 import type { CEEAnalysisReady, CEEGoalConstraint } from '../../adapters/cee/types'
@@ -3025,11 +3026,12 @@ export function useConversation(): UseConversationReturn {
         }
 
         try {
-          // Resolve user ID once — used for both the X-User-Id request header
-          // and the post-response graph re-fetch auth guard. A single call
-          // avoids two getSession() round-trips per turn.
-          const v5UserId = await getUserId()
-          const v5Headers: Record<string, string> = v5UserId ? { 'X-User-Id': v5UserId } : {}
+          // Resolve session identity once — X-User-Id + Authorization Bearer
+          // (login 3.4 UI half) and the post-response graph re-fetch auth
+          // guard. A single call avoids two getSession() round-trips per turn.
+          const v5Identity = await getSessionIdentity()
+          const v5UserId = v5Identity.userId
+          const v5Headers: Record<string, string> = buildTurnAuthHeaders(v5Identity)
           const v5Result = await callV5Turn(build.payload, { signal: controller.signal, headers: v5Headers })
           clearLifecycleTimers()
 

--- a/src/components/auth/GuestDraftImportBanner.tsx
+++ b/src/components/auth/GuestDraftImportBanner.tsx
@@ -1,8 +1,89 @@
 /**
  * Guest-draft import banner — login UI half (3.4).
  *
- * STUB (RED phase): renders nothing until the lane's GREEN commit.
+ * One-time offer on the scenario hub (the post-login landing): a guest who
+ * built a draft before signing in can save it to their account. Renders
+ * nothing unless loginDraftImport says the offer is due (flag-gated dark).
+ * DS v4: bg-panel card, semantic tokens, rounded-pill buttons, Lucide only.
  */
-export function GuestDraftImportBanner(): null {
-  return null
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { FileUp, Loader2 } from 'lucide-react'
+
+import { useAuth } from '../../contexts/AuthContext'
+import { typography } from '../../styles/typography'
+import {
+  shouldOfferDraftImport,
+  importGuestDraft,
+  dismissDraftImport,
+} from '../../lib/loginDraftImport'
+
+export function GuestDraftImportBanner() {
+  const { user, authenticated } = useAuth()
+  const navigate = useNavigate()
+  const [hidden, setHidden] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (hidden || !shouldOfferDraftImport(user, authenticated)) return null
+
+  const handleSave = async () => {
+    if (!user || saving) return
+    setSaving(true)
+    setError(null)
+    try {
+      const scenarioId = await importGuestDraft(user.id)
+      navigate(`/scenario/${scenarioId}`)
+    } catch {
+      setError("Couldn't save your draft — please try again.")
+      setSaving(false)
+    }
+  }
+
+  const handleDismiss = () => {
+    dismissDraftImport()
+    setHidden(true)
+  }
+
+  return (
+    <div
+      className="mb-4 flex items-start gap-3 rounded-md border border-panel-border bg-panel p-4"
+      data-testid="guest-draft-import-banner"
+    >
+      <FileUp className="mt-0.5 h-5 w-5 flex-shrink-0 text-info" aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <p className={`${typography.label} text-text-header`}>
+          Save your draft to your account
+        </p>
+        <p className={`${typography.bodySmall} mt-1 text-text-body`}>
+          You built a draft before signing in. Save it to keep working on it —
+          otherwise it stays only in this browser.
+        </p>
+        {error && (
+          <p className={`${typography.bodySmall} mt-2 text-danger`} role="alert">
+            {error}
+          </p>
+        )}
+        <div className="mt-3 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className={`${typography.button} inline-flex items-center gap-1.5 px-4 py-1.5 rounded-pill bg-primary text-text-on-color hover:bg-primary-hover disabled:bg-primary-disabled disabled:cursor-not-allowed transition-colors duration-fast`}
+          >
+            {saving && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+            Save draft
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            disabled={saving}
+            className={`${typography.button} px-4 py-1.5 rounded-pill text-text-body hover:text-text-header disabled:cursor-not-allowed transition-colors duration-fast`}
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/components/auth/GuestDraftImportBanner.tsx
+++ b/src/components/auth/GuestDraftImportBanner.tsx
@@ -1,0 +1,8 @@
+/**
+ * Guest-draft import banner — login UI half (3.4).
+ *
+ * STUB (RED phase): renders nothing until the lane's GREEN commit.
+ */
+export function GuestDraftImportBanner(): null {
+  return null
+}

--- a/src/components/auth/GuestDraftImportBanner.tsx
+++ b/src/components/auth/GuestDraftImportBanner.tsx
@@ -47,7 +47,7 @@ export function GuestDraftImportBanner() {
 
   return (
     <div
-      className="mb-4 flex items-start gap-3 rounded-md border border-panel-border bg-panel p-4"
+      className="mt-4 mb-4 flex items-start gap-3 rounded-md border border-panel-border bg-panel p-4"
       data-testid="guest-draft-import-banner"
     >
       <FileUp className="mt-0.5 h-5 w-5 flex-shrink-0 text-info" aria-hidden="true" />

--- a/src/components/auth/__tests__/GuestDraftImportBanner.spec.tsx
+++ b/src/components/auth/__tests__/GuestDraftImportBanner.spec.tsx
@@ -1,0 +1,90 @@
+/**
+ * Login UI half (3.4) — guest-draft import banner (one-time offer).
+ *
+ * Mounted on the scenario hub (post-login landing). Renders nothing unless
+ * loginDraftImport says an offer is due; accept imports then navigates to
+ * the new scenario; decline dismisses permanently.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+let mockAuth: { user: { id: string } | null; authenticated: boolean }
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+const shouldOfferDraftImport = vi.fn()
+const importGuestDraft = vi.fn()
+const dismissDraftImport = vi.fn()
+vi.mock('../../../lib/loginDraftImport', () => ({
+  shouldOfferDraftImport: (...args: unknown[]) => shouldOfferDraftImport(...args),
+  importGuestDraft: (...args: unknown[]) => importGuestDraft(...args),
+  dismissDraftImport: (...args: unknown[]) => dismissDraftImport(...args),
+}))
+
+import { GuestDraftImportBanner } from '../GuestDraftImportBanner'
+
+beforeEach(() => {
+  mockNavigate.mockReset()
+  shouldOfferDraftImport.mockReset()
+  importGuestDraft.mockReset()
+  dismissDraftImport.mockReset()
+  mockAuth = { user: { id: 'user-1' }, authenticated: true }
+})
+
+describe('GuestDraftImportBanner', () => {
+  it('renders nothing when no offer is due', () => {
+    shouldOfferDraftImport.mockReturnValue(false)
+    const { container } = render(<GuestDraftImportBanner />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('offers to save the draft when due', () => {
+    shouldOfferDraftImport.mockReturnValue(true)
+    render(<GuestDraftImportBanner />)
+    expect(screen.getByText(/save your draft to your account/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save draft/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /not now/i })).toBeInTheDocument()
+  })
+
+  it('accept: imports the draft then navigates to the new scenario', async () => {
+    shouldOfferDraftImport.mockReturnValue(true)
+    importGuestDraft.mockResolvedValue('scn-42')
+    render(<GuestDraftImportBanner />)
+    await userEvent.click(screen.getByRole('button', { name: /save draft/i }))
+    await waitFor(() => {
+      expect(importGuestDraft).toHaveBeenCalledWith('user-1')
+      expect(mockNavigate).toHaveBeenCalledWith('/scenario/scn-42')
+    })
+  })
+
+  it('decline: dismisses permanently and hides without importing', async () => {
+    shouldOfferDraftImport.mockReturnValue(true)
+    render(<GuestDraftImportBanner />)
+    await userEvent.click(screen.getByRole('button', { name: /not now/i }))
+    expect(dismissDraftImport).toHaveBeenCalledTimes(1)
+    expect(importGuestDraft).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.queryByText(/save your draft to your account/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('failed import surfaces an honest error and keeps the offer visible', async () => {
+    shouldOfferDraftImport.mockReturnValue(true)
+    importGuestDraft.mockRejectedValue(new Error('save failed'))
+    render(<GuestDraftImportBanner />)
+    await userEvent.click(screen.getByRole('button', { name: /save draft/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't save your draft/i)).toBeInTheDocument()
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /save draft/i })).toBeInTheDocument()
+  })
+})

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -402,6 +402,15 @@ const FLAGS_CONFIG = {
     envKey: 'VITE_FEATURE_REASONING_DISCLOSURE',
     storageKey: 'feature.reasoningDisclosure',
   },
+  // Login 3.4 UI half: when ON, no guest user is minted (lib/poc.ts
+  // isGuestAuth) and unauthenticated visitors land on LoginPage via the
+  // already-mounted AuthGuard. Default OFF — the live flip is Paul-gated
+  // (UX approval + integration verify); flag-off is pinned byte-identical
+  // to guest-mode-today in lib/__tests__/poc.requireLogin.spec.ts.
+  requireLogin: {
+    envKey: 'VITE_REQUIRE_LOGIN',
+    storageKey: 'feature.requireLogin',
+  },
 } as const
 
 // ============================================================================
@@ -473,6 +482,7 @@ const flags = {
   aiPanelV2: makeFlag(FLAGS_CONFIG.aiPanelV2),
   v5CanonicalAnalysis: makeFlag(FLAGS_CONFIG.v5CanonicalAnalysis),
   reasoningDisclosure: makeFlag(FLAGS_CONFIG.reasoningDisclosure),
+  requireLogin: makeFlag(FLAGS_CONFIG.requireLogin),
 }
 
 // Export with original naming convention for backward compatibility
@@ -542,6 +552,7 @@ export const isV5CanonicalAnalysisEnabled = flags.v5CanonicalAnalysis
 export const diagnoseV5CanonicalAnalysis = () =>
   diagnoseFlagState(FLAGS_CONFIG.v5CanonicalAnalysis)
 export const isReasoningDisclosureEnabled = flags.reasoningDisclosure
+export const isRequireLoginEnabled = flags.requireLogin
 
 
 // ============================================================================

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -407,6 +407,12 @@ const FLAGS_CONFIG = {
   // already-mounted AuthGuard. Default OFF — the live flip is Paul-gated
   // (UX approval + integration verify); flag-off is pinned byte-identical
   // to guest-mode-today in lib/__tests__/poc.requireLogin.spec.ts.
+  // ⚠ FLIP RUNBOOK: this flag alone is NOT sufficient in a guest-env
+  // BUILD — vite.config.ts aliases @supabase/supabase-js to a stub when
+  // VITE_AUTH_MODE=guest at build time (staging's netlify.toml pins it),
+  // so flag-on there renders LoginPage but sign-in silently no-ops. The
+  // real flip needs the build env switched to real-auth (VITE_AUTH_MODE
+  // unset/real + real Supabase env) IN ADDITION to this flag.
   requireLogin: {
     envKey: 'VITE_REQUIRE_LOGIN',
     storageKey: 'feature.requireLogin',

--- a/src/lib/__tests__/loginDraftImport.spec.ts
+++ b/src/lib/__tests__/loginDraftImport.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Login UI half (3.4) — one-time guest-draft import.
+ *
+ * The UI's localStorage half of guest-claim (the server half is CEE's
+ * claim_guest_scenario RPC — service_role-only; the browser NEVER calls it).
+ * Routes through the EXISTING authenticated create/persist path
+ * (scenarioService.createScenario + saveGraph), no new persistence machinery.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const createScenario = vi.fn()
+const saveGraph = vi.fn()
+
+vi.mock('../../services/scenarioService', () => ({
+  createScenario: (...args: unknown[]) => createScenario(...args),
+  saveGraph: (...args: unknown[]) => saveGraph(...args),
+}))
+
+import {
+  DRAFT_IMPORT_MARKER_KEY,
+  shouldOfferDraftImport,
+  dismissDraftImport,
+  importGuestDraft,
+} from '../loginDraftImport'
+
+const REAL_USER = { id: '5b6f0f0e-2c1a-4b3d-9d1e-aaaaaaaaaaaa' }
+const GUEST_USER = { id: 'guest' }
+
+function seedDraft(nodes: unknown[] = [{ id: 'n1', position: { x: 0, y: 0 }, data: { label: 'Goal' } }]) {
+  localStorage.setItem(
+    'canvas-storage',
+    JSON.stringify({ version: 1, timestamp: 1234567890, nodes, edges: [] }),
+  )
+}
+
+function flagOn() {
+  localStorage.setItem('feature.requireLogin', '1')
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  createScenario.mockReset()
+  saveGraph.mockReset()
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+describe('shouldOfferDraftImport', () => {
+  it('offers when: flag on + real authenticated user + draft exists + no marker', () => {
+    flagOn()
+    seedDraft()
+    expect(shouldOfferDraftImport(REAL_USER, true)).toBe(true)
+  })
+
+  it('never offers when the flag is off (dark by default)', () => {
+    seedDraft()
+    expect(shouldOfferDraftImport(REAL_USER, true)).toBe(false)
+  })
+
+  it('never offers to the guest user', () => {
+    flagOn()
+    seedDraft()
+    expect(shouldOfferDraftImport(GUEST_USER, true)).toBe(false)
+  })
+
+  it('never offers when unauthenticated or user is null', () => {
+    flagOn()
+    seedDraft()
+    expect(shouldOfferDraftImport(REAL_USER, false)).toBe(false)
+    expect(shouldOfferDraftImport(null, true)).toBe(false)
+  })
+
+  it('never offers when there is no stored draft', () => {
+    flagOn()
+    expect(shouldOfferDraftImport(REAL_USER, true)).toBe(false)
+  })
+
+  it('never offers an empty draft (zero nodes)', () => {
+    flagOn()
+    seedDraft([])
+    expect(shouldOfferDraftImport(REAL_USER, true)).toBe(false)
+  })
+
+  it('is one-time: no re-offer after import or dismissal', () => {
+    flagOn()
+    seedDraft()
+    localStorage.setItem(DRAFT_IMPORT_MARKER_KEY, 'imported')
+    expect(shouldOfferDraftImport(REAL_USER, true)).toBe(false)
+    localStorage.setItem(DRAFT_IMPORT_MARKER_KEY, 'dismissed')
+    expect(shouldOfferDraftImport(REAL_USER, true)).toBe(false)
+  })
+})
+
+describe('dismissDraftImport', () => {
+  it('persists the dismissed marker', () => {
+    dismissDraftImport()
+    expect(localStorage.getItem(DRAFT_IMPORT_MARKER_KEY)).toBe('dismissed')
+  })
+})
+
+describe('importGuestDraft', () => {
+  it('creates a scenario via the existing path, saves the draft graph, marks imported, returns the id', async () => {
+    seedDraft()
+    createScenario.mockResolvedValue({ id: 'scn-1' })
+    saveGraph.mockResolvedValue(undefined)
+
+    const id = await importGuestDraft(REAL_USER.id)
+
+    expect(id).toBe('scn-1')
+    // createScenario(userId, eventId, title?) — real user id + a UUID event id
+    expect(createScenario).toHaveBeenCalledTimes(1)
+    const [userId, eventId] = createScenario.mock.calls[0]
+    expect(userId).toBe(REAL_USER.id)
+    expect(eventId).toMatch(/^[0-9a-f-]{36}$/)
+    // The draft graph is persisted into the new row BEFORE any navigation,
+    // so the /scenario/:id server-hydration loads the draft, not an empty graph.
+    expect(saveGraph).toHaveBeenCalledTimes(1)
+    const [scenarioId, graph] = saveGraph.mock.calls[0]
+    expect(scenarioId).toBe('scn-1')
+    expect((graph as { nodes: unknown[] }).nodes).toHaveLength(1)
+    expect(localStorage.getItem(DRAFT_IMPORT_MARKER_KEY)).toBe('imported')
+  })
+
+  it('keeps the localStorage draft after import (never deletes user data)', async () => {
+    seedDraft()
+    createScenario.mockResolvedValue({ id: 'scn-1' })
+    saveGraph.mockResolvedValue(undefined)
+    await importGuestDraft(REAL_USER.id)
+    expect(localStorage.getItem('canvas-storage')).not.toBeNull()
+  })
+
+  it('throws and sets NO marker when there is no draft to import', async () => {
+    await expect(importGuestDraft(REAL_USER.id)).rejects.toThrow()
+    expect(createScenario).not.toHaveBeenCalled()
+    expect(localStorage.getItem(DRAFT_IMPORT_MARKER_KEY)).toBeNull()
+  })
+
+  it('does NOT mark imported when persistence fails (offer can retry)', async () => {
+    seedDraft()
+    createScenario.mockResolvedValue({ id: 'scn-1' })
+    saveGraph.mockRejectedValue(new Error('save failed'))
+    await expect(importGuestDraft(REAL_USER.id)).rejects.toThrow('save failed')
+    expect(localStorage.getItem(DRAFT_IMPORT_MARKER_KEY)).toBeNull()
+  })
+})

--- a/src/lib/__tests__/poc.requireLogin.spec.ts
+++ b/src/lib/__tests__/poc.requireLogin.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Login UI half (3.4) — VITE_REQUIRE_LOGIN gates guest-minting.
+ *
+ * poc.ts computes isGuestAuth at module load from import.meta.env, so every
+ * case stubs env + resets modules + re-imports (the flagFactory snapshot
+ * pattern — see flags.v5CanonicalAnalysis.spec.ts).
+ *
+ * Flag OFF must be byte-identical to today: guest mode remains the default.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+async function importPoc() {
+  return await import('../poc')
+}
+
+describe('poc.ts × VITE_REQUIRE_LOGIN', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    localStorage.clear()
+  })
+
+  it('flag OFF (unset): guest auth stays the default — byte-identical pin', async () => {
+    vi.stubEnv('VITE_REQUIRE_LOGIN', '')
+    vi.stubEnv('VITE_AUTH_MODE', '')
+    const { isGuestAuth } = await importPoc()
+    expect(isGuestAuth).toBe(true)
+  })
+
+  it('flag OFF explicit false: guest auth stays on under VITE_AUTH_MODE=guest', async () => {
+    vi.stubEnv('VITE_REQUIRE_LOGIN', 'false')
+    vi.stubEnv('VITE_AUTH_MODE', 'guest')
+    const { isGuestAuth } = await importPoc()
+    expect(isGuestAuth).toBe(true)
+  })
+
+  it('flag ON: no guest user is minted even with VITE_AUTH_MODE=guest', async () => {
+    vi.stubEnv('VITE_REQUIRE_LOGIN', 'true')
+    vi.stubEnv('VITE_AUTH_MODE', 'guest')
+    const { isGuestAuth } = await importPoc()
+    expect(isGuestAuth).toBe(false)
+  })
+
+  it('flag ON beats VITE_POC_ONLY=1', async () => {
+    vi.stubEnv('VITE_REQUIRE_LOGIN', 'true')
+    vi.stubEnv('VITE_POC_ONLY', '1')
+    const { isGuestAuth } = await importPoc()
+    expect(isGuestAuth).toBe(false)
+  })
+
+  it('flag ON via localStorage override (feature.requireLogin) also gates guest auth', async () => {
+    localStorage.setItem('feature.requireLogin', '1')
+    vi.stubEnv('VITE_AUTH_MODE', 'guest')
+    const { isGuestAuth } = await importPoc()
+    expect(isGuestAuth).toBe(false)
+  })
+
+  it('flag ON does not disturb isPocOnly itself (only the auth consequence)', async () => {
+    vi.stubEnv('VITE_REQUIRE_LOGIN', 'true')
+    vi.stubEnv('VITE_POC_ONLY', '1')
+    const { isPocOnly } = await importPoc()
+    expect(isPocOnly).toBe(true)
+  })
+})
+
+describe('flags × isRequireLoginEnabled', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    localStorage.clear()
+  })
+
+  it('defaults OFF when env is unset', async () => {
+    const { isRequireLoginEnabled } = await import('../../flags')
+    expect(isRequireLoginEnabled()).toBe(false)
+  })
+
+  it('turns ON via VITE_REQUIRE_LOGIN=true', async () => {
+    vi.stubEnv('VITE_REQUIRE_LOGIN', 'true')
+    const { isRequireLoginEnabled } = await import('../../flags')
+    expect(isRequireLoginEnabled()).toBe(true)
+  })
+
+  it('localStorage kill-switch wins over env', async () => {
+    vi.stubEnv('VITE_REQUIRE_LOGIN', 'true')
+    localStorage.setItem('feature.requireLogin', '0')
+    const { isRequireLoginEnabled } = await import('../../flags')
+    expect(isRequireLoginEnabled()).toBe(false)
+  })
+})

--- a/src/lib/__tests__/poc.requireLogin.spec.ts
+++ b/src/lib/__tests__/poc.requireLogin.spec.ts
@@ -25,8 +25,10 @@ describe('poc.ts × VITE_REQUIRE_LOGIN', () => {
   })
 
   it('flag OFF (unset): guest auth stays the default — byte-identical pin', async () => {
-    vi.stubEnv('VITE_REQUIRE_LOGIN', '')
-    vi.stubEnv('VITE_AUTH_MODE', '')
+    // VITE_REQUIRE_LOGIN and VITE_AUTH_MODE both genuinely unset (the
+    // worktree .env.local carries neither): the `?? 'guest'` default must
+    // keep minting the guest. Deliberately NO stubs — an empty-string stub
+    // would defeat the nullish default and test a different reality.
     const { isGuestAuth } = await importPoc()
     expect(isGuestAuth).toBe(true)
   })

--- a/src/lib/loginDraftImport.ts
+++ b/src/lib/loginDraftImport.ts
@@ -70,6 +70,16 @@ export function dismissDraftImport(): void {
  * draft itself is deliberately NOT deleted (never destroy user data); the
  * marker is what prevents re-offers. Throws on failure WITHOUT marking, so
  * the offer can retry.
+ *
+ * ACCEPTED side effect (review S3): if createScenario succeeds but a later
+ * step fails, the created row is orphaned and a retry creates another —
+ * visible in the hub and user-deletable. Accepted for the POC over
+ * carrying retry state; revisit if real users hit it.
+ *
+ * DELIBERATE (review S5): the marker is browser-global, not user-scoped —
+ * the draft is BROWSER-owned (guest state), so one import consumes it for
+ * the browser, and a dismissal speaks for the browser too. A second user
+ * on a shared browser inheriting a dismissal is accepted POC behaviour.
  */
 export async function importGuestDraft(userId: string): Promise<string> {
   const draft = loadState()

--- a/src/lib/loginDraftImport.ts
+++ b/src/lib/loginDraftImport.ts
@@ -1,0 +1,23 @@
+/**
+ * One-time guest-draft import — login UI half (3.4).
+ *
+ * STUB (RED phase): inert until the lane's GREEN commit.
+ */
+export const DRAFT_IMPORT_MARKER_KEY = 'login.draftImport.v1'
+
+export type DraftImportMarker = 'imported' | 'dismissed'
+
+export function shouldOfferDraftImport(
+  _user: { id: string } | null,
+  _authenticated: boolean,
+): boolean {
+  return false
+}
+
+export function dismissDraftImport(): void {
+  // inert
+}
+
+export async function importGuestDraft(_userId: string): Promise<string> {
+  throw new Error('not implemented')
+}

--- a/src/lib/loginDraftImport.ts
+++ b/src/lib/loginDraftImport.ts
@@ -1,23 +1,84 @@
 /**
  * One-time guest-draft import — login UI half (3.4).
  *
- * STUB (RED phase): inert until the lane's GREEN commit.
+ * The UI's localStorage half of guest-claim. The server half is CEE's
+ * `claim_guest_scenario` RPC (olumi-assistants-service migration
+ * 20260710190000): service_role-only by design — its caller contract
+ * requires the JWT-verified `sub`, so the browser NEVER calls it. What the
+ * browser owns is the draft that only exists locally: the `canvas-storage`
+ * graph a guest built before signing in. This module offers a one-time
+ * import of that draft through the EXISTING authenticated create/persist
+ * path (scenarioService.createScenario + saveGraph) — no new persistence
+ * machinery, real user_id stamped by the existing seam.
+ *
+ * Order matters: the draft graph is saved into the new scenario row BEFORE
+ * any navigation, because /scenario/:id hydrates the canvas store from the
+ * server row (useScenario.loadScenario) — navigating first would wipe the
+ * draft with an empty server graph.
  */
+import { loadState } from '../canvas/persist'
+import * as scenarioService from '../services/scenarioService'
+import { isRequireLoginEnabled } from '../flags'
+
 export const DRAFT_IMPORT_MARKER_KEY = 'login.draftImport.v1'
 
 export type DraftImportMarker = 'imported' | 'dismissed'
 
+function getMarker(): DraftImportMarker | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_IMPORT_MARKER_KEY)
+    return raw === 'imported' || raw === 'dismissed' ? raw : null
+  } catch {
+    return null
+  }
+}
+
+function setMarker(marker: DraftImportMarker): void {
+  try {
+    localStorage.setItem(DRAFT_IMPORT_MARKER_KEY, marker)
+  } catch {
+    // Storage unavailable — the offer may reappear next session; harmless.
+  }
+}
+
+/**
+ * The offer is due only when ALL hold: the login flag is on (dark
+ * otherwise), a real authenticated user is present (never the guest
+ * sentinel), a non-empty draft exists in canvas-storage, and the one-time
+ * marker is unset (neither imported nor dismissed before).
+ */
 export function shouldOfferDraftImport(
-  _user: { id: string } | null,
-  _authenticated: boolean,
+  user: { id: string } | null,
+  authenticated: boolean,
 ): boolean {
-  return false
+  if (!isRequireLoginEnabled()) return false
+  if (!authenticated || !user || user.id === 'guest') return false
+  if (getMarker() !== null) return false
+  const draft = loadState()
+  return !!draft && draft.nodes.length > 0
 }
 
+/** Decline permanently — the one-time offer never reappears. */
 export function dismissDraftImport(): void {
-  // inert
+  setMarker('dismissed')
 }
 
-export async function importGuestDraft(_userId: string): Promise<string> {
-  throw new Error('not implemented')
+/**
+ * Import the guest draft: create a scenario (existing authenticated path —
+ * stamps the real user_id and appends the scenario_created journey event),
+ * persist the draft graph into it, then mark imported. The localStorage
+ * draft itself is deliberately NOT deleted (never destroy user data); the
+ * marker is what prevents re-offers. Throws on failure WITHOUT marking, so
+ * the offer can retry.
+ */
+export async function importGuestDraft(userId: string): Promise<string> {
+  const draft = loadState()
+  if (!draft || draft.nodes.length === 0) {
+    throw new Error('No guest draft to import')
+  }
+  const eventId = crypto.randomUUID()
+  const row = await scenarioService.createScenario(userId, eventId, 'Imported draft')
+  await scenarioService.saveGraph(row.id, { nodes: draft.nodes, edges: draft.edges })
+  setMarker('imported')
+  return row.id
 }

--- a/src/lib/poc.ts
+++ b/src/lib/poc.ts
@@ -1,10 +1,20 @@
 // src/lib/poc.ts
 // PoC-only mode: renders only the Scenario Sandbox with no login/nav/landing
 
-export const isPocOnly = 
+import { isRequireLoginEnabled } from '../flags'
+
+export const isPocOnly =
   (import.meta.env.VITE_POC_ONLY ?? '0') === '1'
 
-export const isGuestAuth = 
-  isPocOnly ||
-  (import.meta.env.VITE_AUTH_MODE ?? 'guest') === 'guest' ||
-  String(import.meta.env.VITE_SUPABASE_URL || '').includes('/dummy')
+// Login 3.4 UI half: VITE_REQUIRE_LOGIN (default off) retires the guest
+// branch — when ON, no guest user is minted regardless of PoC/guest env,
+// so the real-auth path in AuthContext runs and the already-mounted
+// AuthGuard routes unauthenticated visitors to LoginPage. Flag OFF is
+// byte-identical to the pre-flag behaviour (pinned in
+// lib/__tests__/poc.requireLogin.spec.ts).
+export const isGuestAuth =
+  !isRequireLoginEnabled() && (
+    isPocOnly ||
+    (import.meta.env.VITE_AUTH_MODE ?? 'guest') === 'guest' ||
+    String(import.meta.env.VITE_SUPABASE_URL || '').includes('/dummy')
+  )

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -73,20 +73,36 @@ export const supabase = createClient<Database>(
 // ---------------- Auth Helpers ----------------
 
 export async function getUserId(): Promise<string | null> {
+  const { userId } = await getSessionIdentity()
+  return userId
+}
+
+/**
+ * Login 3.4 UI half: single-getSession identity read — user id for the
+ * X-User-Id header plus the access token for `Authorization: Bearer`
+ * (LOGIN-CEE-HALF-SPEC coordination contract). One call per turn; callers
+ * must never make a second getSession() round-trip for the token.
+ */
+export async function getSessionIdentity(): Promise<{
+  userId: string | null
+  accessToken: string | null
+}> {
   const { data, error } = await supabase.auth.getSession()
   // Security: Never log session objects (contain access_token/refresh_token)
   // Only log safe metadata via explicit debug flag
-  debugLog('logAuth', '[getUserId] supabase.auth.getSession →', {
+  debugLog('logAuth', '[getSessionIdentity] supabase.auth.getSession →', {
     hasSession: !!data?.session,
     userId: data?.session?.user?.id ?? null,
     error: error?.message ?? null,
   })
-  const userId = data?.session?.user?.id
-  if (error || !userId) {
+  if (error || !data?.session) {
     debugLog('logAuth', '[Supabase] getSession error:', error?.message)
-    return null
+    return { userId: null, accessToken: null }
   }
-  return userId
+  return {
+    userId: data.session.user?.id ?? null,
+    accessToken: data.session.access_token ?? null,
+  }
 }
 
 // ---------------- Profile Management ----------------

--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -370,10 +370,10 @@ export default function ScenarioListPage() {
         {/* Login 3.4: one-time guest-draft import offer (flag-gated dark).
             Above the first-run ternary deliberately — a guest who signs in
             fresh has zero scenarios, so the draft offer must survive the
-            welcome state. */}
-        <div className="mt-4">
-          <GuestDraftImportBanner />
-        </div>
+            welcome state. NO wrapper element: the banner returns null when
+            no offer is due, so flag-off renders zero extra DOM (review S1 —
+            an unconditional wrapper shifted the first-run state 16px). */}
+        <GuestDraftImportBanner />
         {isFirstRun ? (
           /* ---- First-run welcome ---- */
           <div className="text-center py-20" data-testid="first-run">

--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -13,6 +13,7 @@ import {
   Pin, MoreVertical, Copy, Archive, ArchiveRestore,
 } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
+import { GuestDraftImportBanner } from '../components/auth/GuestDraftImportBanner'
 import { useScenario } from '../hooks/useScenario'
 import * as scenarioService from '../services/scenarioService'
 import type { ScenarioListItem, ScenarioStage, AnalysisStatus, ScenarioEvent } from '../types/scenario'
@@ -366,6 +367,13 @@ export default function ScenarioListPage() {
       </header>
 
       <main className="max-w-3xl mx-auto px-6 pb-12 sm:px-8">
+        {/* Login 3.4: one-time guest-draft import offer (flag-gated dark).
+            Above the first-run ternary deliberately — a guest who signs in
+            fresh has zero scenarios, so the draft offer must survive the
+            welcome state. */}
+        <div className="mt-4">
+          <GuestDraftImportBanner />
+        </div>
         {isFirstRun ? (
           /* ---- First-run welcome ---- */
           <div className="text-center py-20" data-testid="first-run">

--- a/src/v5/__tests__/turnAuthHeaders.spec.ts
+++ b/src/v5/__tests__/turnAuthHeaders.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Login UI half (3.4) — turn auth headers.
+ *
+ * Coordination contract (LOGIN-CEE-HALF-SPEC): `Authorization: Bearer
+ * <supabase access token>` rides every turn call; `X-User-Id` KEEPS being
+ * sent until CEE confirms server-side derivation is live (skew-safe order:
+ * add JWT now, CEE switches source, then drop x-user-id).
+ */
+import { describe, it, expect } from 'vitest'
+
+import { buildTurnAuthHeaders } from '../turnAuthHeaders'
+
+describe('buildTurnAuthHeaders', () => {
+  it('sends both X-User-Id and Authorization when a full session exists', () => {
+    expect(
+      buildTurnAuthHeaders({ userId: 'user-123', accessToken: 'tok-abc' }),
+    ).toEqual({
+      'X-User-Id': 'user-123',
+      Authorization: 'Bearer tok-abc',
+    })
+  })
+
+  it('sends only X-User-Id when no access token is available', () => {
+    expect(buildTurnAuthHeaders({ userId: 'user-123', accessToken: null })).toEqual({
+      'X-User-Id': 'user-123',
+    })
+  })
+
+  it('sends only Authorization when a token exists without a user id', () => {
+    expect(buildTurnAuthHeaders({ userId: null, accessToken: 'tok-abc' })).toEqual({
+      Authorization: 'Bearer tok-abc',
+    })
+  })
+
+  it('sends no auth headers for a guest (no session at all) — byte-identical pin', () => {
+    expect(buildTurnAuthHeaders({ userId: null, accessToken: null })).toEqual({})
+  })
+
+  it('never emits an empty Bearer', () => {
+    expect(buildTurnAuthHeaders({ userId: 'user-123', accessToken: '' })).toEqual({
+      'X-User-Id': 'user-123',
+    })
+  })
+})

--- a/src/v5/turnAuthHeaders.ts
+++ b/src/v5/turnAuthHeaders.ts
@@ -1,13 +1,23 @@
 /**
  * Turn auth headers — login UI half (3.4).
  *
- * STUB (RED phase): inert until the lane's GREEN commit.
+ * Coordination contract (LOGIN-CEE-HALF-SPEC): every turn call carries
+ * `Authorization: Bearer <supabase access token>` so CEE's flag-gated JWT
+ * half can verify the user and derive identity server-side. `X-User-Id`
+ * KEEPS being sent until CEE confirms derivation is live — skew-safe
+ * order: add JWT now, CEE switches source, then drop x-user-id.
+ *
+ * Guests have no Supabase session → both values null → no auth headers,
+ * byte-identical to today.
  */
 export interface SessionIdentity {
   userId: string | null
   accessToken: string | null
 }
 
-export function buildTurnAuthHeaders(_identity: SessionIdentity): Record<string, string> {
-  return {}
+export function buildTurnAuthHeaders(identity: SessionIdentity): Record<string, string> {
+  return {
+    ...(identity.userId ? { 'X-User-Id': identity.userId } : {}),
+    ...(identity.accessToken ? { Authorization: `Bearer ${identity.accessToken}` } : {}),
+  }
 }

--- a/src/v5/turnAuthHeaders.ts
+++ b/src/v5/turnAuthHeaders.ts
@@ -1,0 +1,13 @@
+/**
+ * Turn auth headers — login UI half (3.4).
+ *
+ * STUB (RED phase): inert until the lane's GREEN commit.
+ */
+export interface SessionIdentity {
+  userId: string | null
+  accessToken: string | null
+}
+
+export function buildTurnAuthHeaders(_identity: SessionIdentity): Record<string, string> {
+  return {}
+}

--- a/src/v5/v5Adapter.ts
+++ b/src/v5/v5Adapter.ts
@@ -52,7 +52,10 @@ export async function callV5Turn(
   const requestId = crypto.randomUUID();
   const requestedAt = Date.now();
 
-  // TODO: redact auth headers when auth is enabled
+  // Auth headers are already redacted downstream: the trace store runs
+  // headers through redactPayload, whose default sensitiveKeys include
+  // 'authorization' (case-insensitive) plus free-form Bearer/JWT scrubbing
+  // (src/utils/payloadRedaction.ts) — verified in the PR #268 review.
   recordRequestPayload({
     id: requestId,
     endpoint: url,


### PR DESCRIPTION
## What (login 3.4 UI half — dark build; the live flip stays Paul-gated)

Per `LOGIN-UI-HALF-SPEC-2026-07-10.md` + the `LOGIN-CEE-HALF-SPEC` coordination contract; grounded by `parallel-briefs/LOGIN-UI-HALF-BUILDMAP-2026-07-12.md` (verified file:line, two spec corrections).

1. **`VITE_REQUIRE_LOGIN` flag (default OFF)** — registered in flagFactory; gates guest-minting at `lib/poc.ts` `isGuestAuth`. Flag-on: no guest user → the real-auth path runs → the **already-mounted AuthGuard** (AppPoC routes) redirects unauthenticated visitors to the existing LoginPage. Zero route rewiring. **Flag-off pinned byte-identical** to guest-mode-today.
2. **Bearer on turns** — `useConversation` resolves identity once per turn via new `getSessionIdentity` (single `getSession`, honouring the existing no-double-round-trip comment) and sends `Authorization: Bearer <access token>` alongside `X-User-Id` via the pure `buildTurnAuthHeaders`. Skew-safe order per the CEE spec: add JWT now → CEE switches source → drop x-user-id later. Guests have no session → no auth headers (pinned).
3. **One-time guest-draft import** ("Save your draft to your account", scenario hub, flag-gated) — reads `canvas-storage` (the real key; the spec's `canvas-state-v1` doesn't exist), routes through the EXISTING `scenarioService.createScenario` + `saveGraph` (real user_id + journey event), and **saves BEFORE navigating** so `/scenario/:id` server-hydration loads the draft instead of wiping it. Decline = permanent marker; failure = no marker (retryable); localStorage draft never deleted.
   **Deliberate non-goal:** the UI never calls `claim_guest_scenario` — verified against the **live DB grants** (postgres + service_role only, explicit REVOKE from authenticated) and CEE migration `20260710190000`'s binding caller contract (p_user_id = JWT-verified `sub`). The UI's whole claim contribution is the Bearer token + this import. *(Heads-up filed in report 8: CEE has no src call site for the RPC yet.)*
4. **CSP hygiene** — `isl-staging.onrender.com` removed from `netlify.toml` connect-src; no browser→ISL path exists (all ISL traffic is same-origin `/bff/isl` via the edge proxy). Pinned by a spec.

## Tests

RED-first `1d77b627` (compiling inert stubs, 18 genuinely red) → GREEN `226e47b1` (33/33 lane specs). Spec-mock maintenance: three suites' explicit `vi.mock` factories extended (supabase `getSessionIdentity` bridge ×2, flags `isRequireLoginEnabled` ×1) — all three verified fully green at base and fully green after.

## Gates

- typecheck clean · `vitest --changed origin/staging` **5811 passed / 0 failed** (464 files — flags.ts pulls a near-full-suite cone) · wide `tsc -p tsconfig.app.json` position-insensitive diff vs base **EMPTY** · eslint **0 errors** (15 pre-existing warnings in untouched regions)
- **Browser proof** (real dev server from the lane worktree): flag OFF → `#/canvas` renders the guest canvas; flag ON (localStorage override) → redirect to `#/login` with the real "Sign in to Olumi" page; flag removed → guest canvas returns. Console clean throughout.

## Adversarial review (done): NOT-MERGE-SAFE → all gates FOLDED in `77e61e53`

The review independently re-verified: no import cycle from the poc.ts→flags.ts edge; the three mock-extended suites green at base (reproduced in a throwaway worktree); the CSP removal safe against the complete 65-chunk deployed-bundle manifest; DS compliance of the banner. Its two gating finds, both folded:

- **B1 (BLOCKER, real catch):** the orchestrator edge proxy builds forwarded headers from an explicit allowlist that lacked `authorization` — the Bearer was CORS-preflight-permitted but **forward-stripped**, so CEE could never have observed it in any deployed environment and the skew-safe ladder could never progress. Fixed (one allowlist entry — exactly the DGAI-half action LOGIN-CEE-HALF-SPEC item 4 assigns) + `orchestratorProxyHeaders.spec.ts` pins the allowlist.
- **S1:** unconditional banner wrapper div rendered an extra DOM node flag-off (+16px first-run shift) — removed; flag-off now renders zero extra DOM.
- **S2 (runbook, important for the Sunday flip):** `VITE_REQUIRE_LOGIN` alone cannot deliver working sign-in on staging — the staging BUILD pins `VITE_AUTH_MODE=guest`, which aliases supabase-js to a stub at build time; flag-on there renders LoginPage but sign-in no-ops. **The real flip needs the build env switched to real-auth in addition to the flag.** Documented in the flag comment.
- **S3/S5 (documented policy):** orphan scenario row on partial-failure retry = accepted POC behaviour (user-deletable); marker is deliberately browser-global (the draft is browser-owned).
- **S4:** hook-level pins added — Authorization+X-User-Id verified reaching the actual `callV5Turn`; guests still send `{}`.
- **N2:** stale redact-TODO replaced (redactPayload already scrubs authorization/Bearer — review-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)