### PR TITLE
fix(analysis): 1.16i rerun UX integrity — authoritative analysing state, swallow guard, visible processing

### DIFF
--- a/src/canvas/components/AnalysisRunningBanner.tsx
+++ b/src/canvas/components/AnalysisRunningBanner.tsx
@@ -1,0 +1,26 @@
+/**
+ * 1.16i — visible processing for the whole analysis turn (Paul's extended
+ * acceptance: the analysis panel must SHOW the run, not just disable
+ * buttons). Rendered by OutputsDock while isRunning && a previous report is
+ * still on screen — the skeleton covers the no-report case. DS v4: bg-panel,
+ * semantic tokens, Lucide only. aria-live announces the state change.
+ */
+import { Loader2 } from 'lucide-react'
+
+import { typography } from '../../styles/typography'
+
+export function AnalysisRunningBanner() {
+  return (
+    <div
+      className="mx-3 mb-2 flex items-center gap-2 rounded-md border border-panel-border bg-panel px-3 py-2"
+      data-testid="analysis-running-banner"
+      role="status"
+      aria-live="polite"
+    >
+      <Loader2 className="h-4 w-4 animate-spin text-info" aria-hidden="true" />
+      <span className={`${typography.bodySmall} text-text-body`}>
+        Running a fresh analysis — the results below update when it completes.
+      </span>
+    </div>
+  )
+}

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -28,6 +28,7 @@ import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, HelpCircle, XCircle
 import { useShallow } from 'zustand/react/shallow'
 import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
+import { AnalysisRunningBanner } from './AnalysisRunningBanner'
 import { registerCanonicalRunner, type CanonicalRunOutcome } from '../analysis/canonicalRunRegistry'
 import { useShowToastSafe } from '../ToastContext'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
@@ -606,8 +607,11 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     }
   }, [_isPersistenceActive, setAnalysisRunning, resetAnalysisStatus, persistAnalysisSuccess, persistAnalysisFailure])
 
-  // P0-UI: V2 run hook for /v2/run endpoint
-  const { runV2Analysis, cancelRun } = useV2Run(v2Persistence)
+  // P0-UI: V2 run hook for /v2/run endpoint. isRunning is the hook's OWN
+  // in-flight flag (true only during a V2 request) — 1.16i gates the Cancel
+  // button on it because cancelRun can only abort the V2 request; rendering
+  // Cancel for a V5 analysing turn would be a dead control.
+  const { runV2Analysis, cancelRun, isRunning: isV2RunInFlight } = useV2Run(v2Persistence)
 
   // Results Panel Redesign: Section data hook for RecommendationSection, DriversSection, ConfidenceSection
   const resultsSectionData = useResultsSectionData()
@@ -1921,8 +1925,15 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     <span className={`${typography.caption} text-text-header`}>{slowRunMessage}</span>
                   </div>
                 )}
-                {/* I.2b: Cancel button during active analysis */}
-                {isRunning && (
+                {/* 1.16i: visible processing while an analysis turn runs and
+                    the previous report is still on screen (the skeleton
+                    below covers the no-report case) */}
+                {isRunning && report && <AnalysisRunningBanner />}
+                {/* I.2b: Cancel button during active analysis — gated on the
+                    V2 hook's own in-flight flag (1.16i): cancelRun only
+                    aborts the V2 request, so it must not render for a V5
+                    analysing turn. */}
+                {isV2RunInFlight && (
                   <div className="flex justify-end px-3">
                     <button
                       type="button"

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -333,4 +333,58 @@ describe('OutputsDock analyse convergence', () => {
     expect(footer).not.toHaveTextContent('87%')
     expect(screen.queryByText('Compare available in the tab bar')).not.toBeInTheDocument()
   })
+
+  describe('1.16i: visible processing during an analysing turn', () => {
+    const fakeReport: any = {
+      results: { conservative: 10, likely: 20, optimistic: 30, units: 'percent', unitSymbol: '%' },
+      run: { bands: { p10: 10, p50: 20, p90: 30 } },
+    }
+
+    function seedPreparingWithReport() {
+      const baseResults = useCanvasStore.getState().results
+      useCanvasStore.setState({
+        hasCompletedFirstRun: true,
+        results: { ...baseResults, status: 'preparing', report: fakeReport },
+      } as any)
+    }
+
+    it('shows the running banner while status is preparing with a prior report on screen', () => {
+      seedPreparingWithReport()
+      renderOutputsDock()
+      expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    })
+
+    it('shows NO dead Cancel button for a V5 analysing turn (no V2 run in flight)', () => {
+      seedPreparingWithReport()
+      renderOutputsDock()
+      expect(screen.queryByTestId('cancel-analysis-button')).not.toBeInTheDocument()
+    })
+
+    it('a Run click during an analysing turn dispatches nothing (gate holds)', () => {
+      const dispatchAction = vi.fn()
+      const runV2Analysis = vi.fn()
+      mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() } as any)
+      mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
+      mockIsV5Eligible.mockReturnValue({ eligible: true } as any)
+      useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
+      seedPreparingWithReport()
+
+      renderOutputsDock()
+      const rerun = screen.queryByTestId('outputs-run-button')
+      if (rerun) fireEvent.click(rerun)
+
+      expect(dispatchAction).not.toHaveBeenCalled()
+      expect(runV2Analysis).not.toHaveBeenCalled()
+    })
+
+    it('banner absent when analysis is complete (control)', () => {
+      const baseResults = useCanvasStore.getState().results
+      useCanvasStore.setState({
+        hasCompletedFirstRun: true,
+        results: { ...baseResults, status: 'complete', report: fakeReport },
+      } as any)
+      renderOutputsDock()
+      expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -1414,8 +1414,17 @@ describe('I.1: Model tab auto-switch guard', () => {
 
 describe('I.2b: Cancel button during analysis', () => {
   beforeEach(cleanupDockState)
-  it('shows cancel button when analysis is running', () => {
+  it('shows cancel button when a V2 run is in flight (the run cancelRun can actually cancel)', () => {
     const baseResults = useCanvasStore.getState().results
+
+    // 1.16i: Cancel is gated on useV2Run's OWN in-flight flag, not the
+    // derived store status — cancelRun only aborts the V2 request, so a
+    // Cancel rendered for a V5 turn would be a dead control.
+    mockUseV2Run.mockReturnValue({
+      runV2Analysis: vi.fn(),
+      cancelRun: vi.fn(),
+      isRunning: true,
+    } as any)
 
     useCanvasStore.setState({
       nodes: testNodes,
@@ -1433,6 +1442,26 @@ describe('I.2b: Cancel button during analysis', () => {
     const cancelButton = screen.getByTestId('cancel-analysis-button')
     expect(cancelButton).toBeInTheDocument()
     expect(cancelButton).toHaveTextContent('Cancel')
+  })
+
+  it('1.16i: NO cancel button on a V5 analysing turn (preparing without a V2 run) — but the running banner shows', () => {
+    const baseResults = useCanvasStore.getState().results
+
+    useCanvasStore.setState({
+      nodes: testNodes,
+      edges: testEdges,
+      hasCompletedFirstRun: true,
+      results: {
+        ...baseResults,
+        status: 'preparing',
+        report: fakeReportForTests,
+      },
+    } as any)
+
+    render(<OutputsDock />)
+
+    expect(screen.queryByTestId('cancel-analysis-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
   })
 
   it('hides cancel button when analysis is complete', () => {

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -82,6 +82,12 @@ vi.mock('../../../v5/eligibility', () => ({
   isV5Eligible: (...args: unknown[]) => mockIsV5Eligible(...(args as [{ flag: string | undefined }])),
 }))
 
+// 1.16i: telemetry sink for the run-click swallow guard.
+const mockTrackEvent = vi.fn()
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
+
 // Mock Supabase getUserId: vi.fn() so tests can reconfigure per-scenario.
 // Default: null (no auth session in test environment).
 const mockGetUserId = vi.fn<[], Promise<string | null>>()
@@ -2488,5 +2494,97 @@ describe('login 3.4 — V5 turn auth headers', () => {
     expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
     const opts = mockCallV5Turn.mock.calls[0][1] as { headers?: Record<string, string> }
     expect(opts.headers).toEqual({})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 1.16i — rerun UX integrity: authoritative analysing state + swallow guard
+// (re-plan Program A lane A1; Paul's extended acceptance = visible processing
+// for the whole turn, and re-clicks must not abort/re-mint the in-flight run)
+// ---------------------------------------------------------------------------
+
+describe('1.16i — rerun UX integrity', () => {
+  beforeEach(() => {
+    mockIsV5Eligible.mockReturnValue({ eligible: true })
+    mockTrackEvent.mockReset()
+    useCanvasStore.getState().resultsReset()
+  })
+
+  const RUN_ACTION = {
+    action_type: 'run_analysis',
+    label: 'Run analysis',
+    message: 'Run analysis',
+    source: 'chip' as const,
+  }
+
+  it('sets results.status=preparing at dispatch and settles on a text-only envelope', async () => {
+    let resolveTurn!: (v: unknown) => void
+    mockCallV5Turn.mockReturnValue(new Promise((res) => { resolveTurn = res }))
+
+    const { result } = renderHook(() => useConversation())
+    let dispatchPromise!: Promise<void>
+    act(() => {
+      dispatchPromise = result.current.dispatchAction(RUN_ACTION)
+    })
+
+    // The authoritative analysing state is set synchronously at dispatch —
+    // this is what makes isRunning true for the whole 20-30s turn.
+    expect(useCanvasStore.getState().results.status).toBe('preparing')
+
+    resolveTurn(makeV5SuccessResult('no analysis result this turn'))
+    await act(async () => { await dispatchPromise })
+
+    // Text-only envelope + no prior report → settles to idle, never stuck.
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+  })
+
+  it('swallows a run re-click while a run is in flight: one request, no abort, telemetry', async () => {
+    let resolveTurn!: (v: unknown) => void
+    mockCallV5Turn.mockReturnValue(new Promise((res) => { resolveTurn = res }))
+
+    const { result } = renderHook(() => useConversation())
+    let firstDispatch!: Promise<void>
+    act(() => {
+      firstDispatch = result.current.dispatchAction(RUN_ACTION)
+    })
+    expect(useCanvasStore.getState().results.status).toBe('preparing')
+
+    // Re-click while in flight: must NOT preempt-abort, must NOT mint a
+    // second turn — swallowed with telemetry.
+    await act(async () => {
+      await result.current.dispatchAction(RUN_ACTION)
+    })
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    expect(mockTrackEvent).toHaveBeenCalledWith('run_click_swallowed', expect.any(Object))
+
+    // The first turn still completes normally (it was not aborted).
+    const V5_TEXT = 'first run completed'
+    resolveTurn(makeV5SuccessResult(V5_TEXT))
+    await act(async () => { await firstDispatch })
+    expect(result.current.messages.some((m) => m.role === 'assistant' && m.content === V5_TEXT)).toBe(true)
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+  })
+
+  it('a failed run settles the analysing state (never stuck preparing)', async () => {
+    mockCallV5Turn.mockRejectedValue(new Error('boom'))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.dispatchAction(RUN_ACTION)
+    })
+
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+  })
+
+  it('non-run turns never touch the analysing state', async () => {
+    mockCallV5Turn.mockResolvedValue(makeV5SuccessResult('plain answer'))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('a plain question')
+    })
+
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+    expect(mockTrackEvent).not.toHaveBeenCalledWith('run_click_swallowed', expect.any(Object))
   })
 })

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -2587,4 +2587,43 @@ describe('1.16i — rerun UX integrity', () => {
     expect(useCanvasStore.getState().results.status).toBe('idle')
     expect(mockTrackEvent).not.toHaveBeenCalledWith('run_click_swallowed', expect.any(Object))
   })
+
+  it("a preempt-aborted run's late cleanup settles ITS OWN state and a fresh run recovers", async () => {
+    // Reality check pinned here: after a preempt-abort, the isThinking guard
+    // blocks ANY new turn until the aborted turn's finally runs — so a newer
+    // run can never hold 'preparing' while the old one is pending, and the
+    // finally's ownership guard (settle only while owning the run slot) is
+    // defensive. This pins the reachable semantics end-to-end: the aborted
+    // run's late cleanup settles its own analysing state, and a subsequent
+    // run enters and exits 'preparing' normally.
+    //
+    // The preempt rule reads import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR at
+    // CALL time — stub it for this test only so the plain send preempts.
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+    let resolveA!: (v: unknown) => void
+    mockCallV5Turn.mockReturnValueOnce(new Promise((res) => { resolveA = res }))
+
+    const { result } = renderHook(() => useConversation())
+
+    let runA!: Promise<void>
+    act(() => { runA = result.current.dispatchAction(RUN_ACTION) })
+    expect(useCanvasStore.getState().results.status).toBe('preparing')
+
+    // Plain user send preempts (aborts) run A per the standing preempt rule.
+    let chatC!: Promise<void>
+    act(() => { chatC = result.current.sendMessage('changed my mind, question first') })
+    await act(async () => { await chatC })
+
+    // A's stale response lands; the post-abort guard returns via the finally,
+    // which owns the run slot and settles the analysing state (no report -> idle).
+    resolveA(makeV5SuccessResult('stale A response'))
+    await act(async () => { await runA })
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+
+    // A fresh run afterwards enters and exits the analysing state normally.
+    mockCallV5Turn.mockResolvedValueOnce(makeV5SuccessResult('run B text-only'))
+    await act(async () => { await result.current.dispatchAction(RUN_ACTION) })
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+    vi.unstubAllEnvs()
+  })
 })

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -3435,10 +3435,11 @@ export function useConversation(): UseConversationReturn {
           // 1.16i: every-exit settle for the analysing state (success
           // without an analysis_result, typed error, thrown error, abort,
           // timeout). No-ops when applyV5State already flipped 'complete'.
-          if (isRunAnalysisTurn) {
-            if (activeRunTurnIdRef.current === turnClientId) {
-              activeRunTurnIdRef.current = null
-            }
+          // OWNERSHIP GUARD: settle only while this turn still owns the run
+          // slot — a preempt-aborted run's late finally must never settle a
+          // NEWER run turn's 'preparing' (that run manages its own exit).
+          if (isRunAnalysisTurn && activeRunTurnIdRef.current === turnClientId) {
+            activeRunTurnIdRef.current = null
             useCanvasStore.getState().resultsSettle()
           }
         }

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -86,6 +86,7 @@ import { loadScenario as loadScenarioFromDb } from '../../services/scenarioServi
 import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
 import { mergeAppliedGraphAdditive } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
+import { trackEvent } from '../../lib/posthog'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 import { validateAnalysisReadyContract } from './validateAnalysisReadyContract'
 import { validateResponse, stripRepairLogLines, FALLBACK_TEXT } from './validateResponse'
@@ -1580,6 +1581,11 @@ export function useConversation(): UseConversationReturn {
   // Updated at dispatch time at every sendTurn site; read in the response
   // handler to decide whether the arriving response is the current turn.
   const activeV5TurnIdRef = useRef<string | null>(null)
+  // 1.16i: client turn id of the in-flight run_analysis turn, when one is.
+  // Set at V5 run dispatch, cleared in that turn's finally. Read by the
+  // swallow guard so a run re-click neither preempt-aborts the running
+  // analysis nor mints a fresh turn id (which would defeat CEE's coalescing).
+  const activeRunTurnIdRef = useRef<string | null>(null)
   // Mirror messages state into a ref so buildRequest always reads the latest
   // committed value — avoids stale closure when addMessage + buildRequest run
   // in the same synchronous block (React batches the state update).
@@ -2766,6 +2772,26 @@ export function useConversation(): UseConversationReturn {
         chipInitiated,
       } = opts
 
+      // 1.16i swallow guard: a run_analysis (re-)click while a run turn is
+      // ALREADY in flight is swallowed — no preempt-abort of the running
+      // analysis, no fresh turn id, one telemetry event. This is what stops
+      // the re-click storm (each old re-click aborted the in-flight request
+      // and minted a new client_turn_id, defeating CEE's coalescing). A
+      // non-run turn in flight is NOT swallowed — the user may still
+      // deliberately preempt a chat turn with a run (pre-existing rule).
+      const isRunAnalysisSend =
+        !systemEvent && resolveUserTurnType(source, hidden, turnType) === 'run_analysis'
+      if (inFlightRef.current && isRunAnalysisSend && activeRunTurnIdRef.current) {
+        trackEvent('run_click_swallowed', {
+          inflight_turn_id: activeRunTurnIdRef.current,
+          source: source ?? 'unknown',
+        })
+        if (import.meta.env.DEV) {
+          console.warn('[sendTurn] Run re-click swallowed — analysis turn already in flight')
+        }
+        return
+      }
+
       // Synchronous in-flight lock — prevents duplicate dispatch from rapid
       // double-clicks before React re-renders the isThinking state guard.
       //
@@ -2910,6 +2936,17 @@ export function useConversation(): UseConversationReturn {
         const resolvedTurnType: TurnType = isSystemEvent
           ? 'system_event'
           : resolveUserTurnType(source, hidden, turnType)
+
+        // 1.16i: authoritative analysing state — set synchronously at run
+        // dispatch so every isRunning gate (OutputsDock, ConversationPanel)
+        // and the visible processing furniture hold for the whole turn.
+        // Settled in this turn's finally; a landed analysis_result flips
+        // 'complete' via applyV5State before the settle no-ops.
+        const isRunAnalysisTurn = resolvedTurnType === 'run_analysis'
+        if (isRunAnalysisTurn) {
+          useCanvasStore.getState().resultsAnalysing()
+          activeRunTurnIdRef.current = turnClientId
+        }
 
         // Derive stage from canvas state (UI-SEM-020 pattern). turn_class
         // stays advisory ('frame') — CEE types.ts notes propose/decide/review
@@ -3395,6 +3432,15 @@ export function useConversation(): UseConversationReturn {
           setIsThinking(false)
           useDraftStore.getState().setIsGenerating(false)
           releaseInFlightLockIfOwned()
+          // 1.16i: every-exit settle for the analysing state (success
+          // without an analysis_result, typed error, thrown error, abort,
+          // timeout). No-ops when applyV5State already flipped 'complete'.
+          if (isRunAnalysisTurn) {
+            if (activeRunTurnIdRef.current === turnClientId) {
+              activeRunTurnIdRef.current = null
+            }
+            useCanvasStore.getState().resultsSettle()
+          }
         }
         return
       }

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -614,6 +614,15 @@ interface CanvasState {
   clearErrorDetails: () => void
   resultsCancelled: () => void
   resultsReset: () => void
+  /** 1.16i: authoritative analysing state for the live V5 run turn — sets
+   * 'preparing' at dispatch while preserving the prior report/hash/seed/
+   * drivers (unlike resultsStart, no seed is known yet). */
+  resultsAnalysing: () => void
+  /** 1.16i: every-exit cleanup for the V5 run turn — from 'preparing',
+   * returns to 'complete' when a preserved report exists (restoring
+   * analysisStateReady) or 'idle' when none does; no-op otherwise. A landed
+   * analysis_result has already flipped 'complete' via resultsComplete. */
+  resultsSettle: () => void
   resultsLoadHistorical: (run: StoredRun) => void
   /** Hydrate results from Supabase row.analysis (V2RunResponse already mapped to store shape) */
   resultsHydrateFromSupabase: (hydrated: {
@@ -2777,6 +2786,50 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // never landed, so don't send stale analysis_state on subsequent turns.
       analysisStateReady: false,
     }))
+  },
+
+  resultsAnalysing: () => {
+    set(s => ({
+      results: {
+        ...s.results,
+        status: 'preparing',
+        progress: 0,
+        startedAt: Date.now(),
+        finishedAt: undefined,
+        error: undefined,
+        // Everything else (report/hash/seed/drivers) preserved so a
+        // settle-back after a resultless turn restores the prior run intact.
+      },
+      // Graph Lens: auto-reset on new analysis run (resultsStart parity).
+      lens: createDefaultLensState(),
+      // A new run is in flight — same contract as resultsStart: the previous
+      // snapshot must not be sent to CEE while the new one is pending.
+      analysisStateReady: false,
+    }))
+  },
+
+  resultsSettle: () => {
+    const s = get()
+    if (s.results.status !== 'preparing') return
+    if (s.results.report) {
+      set(st => ({
+        results: {
+          ...st.results,
+          status: 'complete',
+          progress: 100,
+        },
+        // The preserved snapshot is (again) the latest valid analysis.
+        analysisStateReady: true,
+      }))
+    } else {
+      set(st => ({
+        results: {
+          ...st.results,
+          status: 'idle',
+          progress: 0,
+        },
+      }))
+    }
   },
 
   resultsLoadHistorical: (run: StoredRun) => {

--- a/src/canvas/store/__tests__/resultsSettle.spec.ts
+++ b/src/canvas/store/__tests__/resultsSettle.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * 1.16i rerun UX — resultsSettle store action.
+ *
+ * The live V5 run path sets status 'preparing' at dispatch (authoritative
+ * analysing state). Not every V5 envelope carries a fresh analysis_result
+ * (clarifying question, unchanged hash, error) — resultsSettle is the
+ * every-exit cleanup: from 'preparing' it returns to 'complete' when a
+ * preserved report exists (restoring analysisStateReady) or 'idle' when
+ * none does, and NEVER disturbs any other status.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { useCanvasStore } from '../../store'
+
+describe('resultsSettle', () => {
+  beforeEach(() => {
+    useCanvasStore.getState().resultsReset()
+  })
+
+  it('settles preparing → idle when no prior report exists', () => {
+    useCanvasStore.getState().resultsStart({ seed: undefined, wasForced: false })
+    expect(useCanvasStore.getState().results.status).toBe('preparing')
+
+    useCanvasStore.getState().resultsSettle()
+
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+  })
+
+  it('settles preparing → complete when a prior report is preserved, restoring analysisStateReady', () => {
+    // Seed a completed run, then start a re-run (resultsStart preserves report).
+    useCanvasStore.setState((s) => ({
+      results: {
+        ...s.results,
+        status: 'complete',
+        progress: 100,
+        report: { summary: 'prior run' } as never,
+        hash: 'hash-1',
+      },
+      analysisStateReady: true,
+    }))
+    useCanvasStore.getState().resultsStart({ seed: undefined, wasForced: false })
+    expect(useCanvasStore.getState().results.status).toBe('preparing')
+    expect(useCanvasStore.getState().analysisStateReady).toBe(false)
+
+    useCanvasStore.getState().resultsSettle()
+
+    const state = useCanvasStore.getState()
+    expect(state.results.status).toBe('complete')
+    expect(state.results.report).toEqual({ summary: 'prior run' })
+    expect(state.analysisStateReady).toBe(true)
+  })
+
+  it('no-ops on every non-preparing status', () => {
+    for (const status of ['idle', 'connecting', 'streaming', 'complete', 'error', 'cancelled'] as const) {
+      useCanvasStore.setState((s) => ({ results: { ...s.results, status } }))
+      useCanvasStore.getState().resultsSettle()
+      expect(useCanvasStore.getState().results.status).toBe(status)
+    }
+  })
+})


### PR DESCRIPTION
## What (ROADMAP 1.16i — re-plan Program A lane A1; Paul's extended acceptance)

The live V5 run dispatch was fire-and-forget (`OutputsDock.tsx` canonical runner): nothing set the analysing state, so every `isRunning` gate stayed false for the whole 20-30s turn — Run stayed clickable, each re-click preempt-aborted the in-flight request and minted a fresh `client_turn_id` (defeating CEE's coalescing, `route-v2.ts:91-110`), and nothing on screen acknowledged the click. Paul reproduced this independently; A1's 10-agent verification pinned the loci.

## How

- **`resultsAnalysing()`** (new store action): `'preparing'` set **synchronously at the sendTurn choke point** for `run_analysis` turns — covers the dock pill, composer, palette, canvas shortcut AND chat chips in one place. Preserves the prior report/hash/**seed** (unlike `resultsStart`, which requires a seed and clobbers it); `analysisStateReady:false` while pending + Graph-Lens reset (resultsStart parity).
- **`resultsSettle()`**: every-exit cleanup in the turn's `finally` — back to `'complete'` (restoring `analysisStateReady`) when a preserved report exists, `'idle'` otherwise; no-op when `applyV5State` already landed the fresh result. Covers text-only envelopes, **unchanged-hash reruns**, typed errors, throws, aborts, timeouts.
- **Swallow guard** ahead of the preempt rule: a run (re-)click while a run turn is in flight is swallowed — one request, no abort, no fresh turn id — with `run_click_swallowed` telemetry. Non-run preemption (user sends chat during a run) unchanged.
- **Visible processing** (Paul's acceptance — "not just disabled buttons"): new `AnalysisRunningBanner` in the dock while running with a prior report on screen; the skeleton covers the no-report case; all existing `isRunning` furniture (pre-analysis "Analysing…" label, footer "Running analysis…" + spinner, 20s/40s slow-run messages) now lights up on V5 turns for free.
- **Honest Cancel**: the Cancel button is gated on `useV2Run`'s own in-flight flag — `cancelRun` can only abort the V2 request, so rendering it for a V5 turn was a dead control (I.2b pin updated deliberately).

## Tests

RED `3254e404` → GREEN `5a37732c`. New contracts: `resultsSettle` store unit (3); hook-level 1.16i suite (preparing-at-dispatch, swallow with telemetry + first-turn-unharmed, failed-run settle, non-run turns untouched); dock pins (banner shown while preparing-with-report, no dead Cancel on V5 turns, Run click during analysing dispatches nothing, banner absent on complete — duplicated into the locally-excluded dom.spec for CI).

## Gates

- typecheck clean · `vitest --changed origin/staging` **5441/0** (405 files) · wide tsc position-insensitive diff vs base = **net −3 errors** (RED-spec errors resolved; residual diff is count-text drift inside pre-existing error messages from the 2 new store actions) · eslint 0 errors (warnings pre-existing, new files clean)
- **Browser proof (live loop against staging CEE from the lane worktree):** draft → Run: affordance flips to "Running analysis…" disabled + skeleton within one frame, **zero clickable run affordances for the whole ~20s turn**, envelope lands → results render, Rerun returns. Rerun with prior report: **banner visible at +250ms and +500ms, cleared by +750ms** when the fast (server-deduped) rerun settled — live-proving the unchanged-hash settle path. Console clean throughout.

## Adversarial review disposition

The background review agent was cancelled mid-run by a session interrupt; its attack plan was executed **inline** instead. Verified: the swallow discriminator cannot disagree with the V5 branch's resolvedTurnType (same pure function, same inputs); a run-retry while another run is in flight is correctly swallowed (redundant by definition); the V4 path is byte-identical (the run-slot ref is only ever set in the V5 branch, so the entry guard can never fire); `isRunAnalysisTurn` is in scope for the finally (typecheck + green suite). One real finding, fixed in `1a074a37`: the every-exit settle ran unconditionally — now **ownership-guarded** (settle only while the turn still owns the run slot). Empirical bonus: the hypothesised newer-run race is unreachable via public APIs (the V5 isThinking guard blocks any new turn until the aborted turn's finally clears) — pinned by a lifecycle test of the reachable semantics.

**Pre-existing follow-up found (NOT this lane):** a preempting user send aborts the in-flight V5 run but is then itself blocked by the isThinking guard (`useConversation.ts:2880`) — the user's message is silently dropped with only a DEV warn, contradicting the preempt design comment ("abort … rather than drop the send"). Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)