### PR TITLE
feat(results): Wave 1 — Decision overview card + consolidated Actions menu (flag-gated dark)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -34,7 +34,9 @@ import { useShowToastSafe } from '../ToastContext'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource } from '../store'
 import { resolveDisplayedFreshness } from '../store/analysisFreshness'
+import { getScenario } from '../store/scenarios'
 import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
+import { DecisionOverviewCard } from '../../components/results/decision-overview/DecisionOverviewCard'
 import { deriveResultsTabFreshness } from './resultsTabFreshness'
 import { typography, typo } from '../../styles/typography'
 import {
@@ -614,6 +616,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
 
   // Results Panel Redesign: Section data hook for RecommendationSection, DriversSection, ConfidenceSection
   const resultsSectionData = useResultsSectionData()
+  // Wave 1: decision title for the overview card — same source as the
+  // ScenarioSwitcher header (scenario name; null when unsaved/untitled).
+  const overviewScenarioId = useCanvasStore((s) => s.currentScenarioId)
+  const overviewTitle = overviewScenarioId ? (getScenario(overviewScenarioId)?.name ?? null) : null
 
   // Tornado chart: Derive per-factor outcome bounds from driver influence and recommended option range.
   // Each factor's contribution to the outcome swing is proportional to its normalised influence.
@@ -2066,6 +2072,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     Legacy blocks (InsightsPanel, AdvancedSettings, variance warning) removed
                     from Results tab — they are not in the v7 prototype.
                     ====================================================================== */}
+                {/* Wave 1: Decision overview — the orientation surface, first
+                    in the canonical hierarchy (brief §3). Flag-gated
+                    (renders nothing flag-off). */}
+                {!isPreRun && hasInlineSummary && resultsSectionData && (
+                  <DecisionOverviewCard title={overviewTitle} />
+                )}
                 {/* Wave F-B review (a): the sole freshness strip + its Rerun
                     mount ABOVE the dim wrapper at full opacity — the recovery
                     control must never sit inside an aria-disabled region. */}

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -37,6 +37,7 @@ import { resolveDisplayedFreshness } from '../store/analysisFreshness'
 import { getScenario } from '../store/scenarios'
 import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
 import { DecisionOverviewCard } from '../../components/results/decision-overview/DecisionOverviewCard'
+import { isDecisionOverviewEnabled } from '../../flags'
 import { deriveResultsTabFreshness } from './resultsTabFreshness'
 import { typography, typo } from '../../styles/typography'
 import {
@@ -618,8 +619,14 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const resultsSectionData = useResultsSectionData()
   // Wave 1: decision title for the overview card — same source as the
   // ScenarioSwitcher header (scenario name; null when unsaved/untitled).
+  // Memoised: getScenario parses the whole scenarios localStorage blob, so
+  // it must never run per render (review B1); flag-off renders skip it via
+  // the mount-site gate below.
   const overviewScenarioId = useCanvasStore((s) => s.currentScenarioId)
-  const overviewTitle = overviewScenarioId ? (getScenario(overviewScenarioId)?.name ?? null) : null
+  const overviewTitle = useMemo(
+    () => (isDecisionOverviewEnabled() && overviewScenarioId ? (getScenario(overviewScenarioId)?.name ?? null) : null),
+    [overviewScenarioId],
+  )
 
   // Tornado chart: Derive per-factor outcome bounds from driver influence and recommended option range.
   // Each factor's contribution to the outcome swing is proportional to its normalised influence.
@@ -2073,9 +2080,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     from Results tab — they are not in the v7 prototype.
                     ====================================================================== */}
                 {/* Wave 1: Decision overview — the orientation surface, first
-                    in the canonical hierarchy (brief §3). Flag-gated
-                    (renders nothing flag-off). */}
-                {!isPreRun && hasInlineSummary && resultsSectionData && (
+                    in the canonical hierarchy (brief §3). Mount-site gated
+                    (house pattern, review B1): flag-off renders NOTHING and
+                    pays no subscription or parsing cost. */}
+                {isDecisionOverviewEnabled() && !isPreRun && hasInlineSummary && resultsSectionData && (
                   <DecisionOverviewCard title={overviewTitle} />
                 )}
                 {/* Wave F-B review (a): the sole freshness strip + its Rerun

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -335,6 +335,42 @@ describe('OutputsDock analyse convergence', () => {
     expect(screen.queryByText('Compare available in the tab bar')).not.toBeInTheDocument()
   })
 
+  describe('Wave 1: Decision overview mount', () => {
+    const fakeReport: any = {
+      results: { conservative: 10, likely: 20, optimistic: 30, units: 'percent', unitSymbol: '%' },
+      run: { bands: { p10: 10, p50: 20, p90: 30 } },
+    }
+    function seedPostRun() {
+      const baseResults = useCanvasStore.getState().results
+      useCanvasStore.setState({
+        hasCompletedFirstRun: true,
+        results: { ...baseResults, status: 'complete', report: fakeReport },
+      } as any)
+    }
+
+    it('flag OFF: no overview card (byte-identical)', () => {
+      localStorage.removeItem('feature.decisionOverview')
+      seedPostRun()
+      renderOutputsDock()
+      expect(screen.queryByTestId('decision-overview')).not.toBeInTheDocument()
+    })
+
+    it('flag ON: the overview mounts FIRST, above the freshness strip (canonical hierarchy)', () => {
+      localStorage.setItem('feature.decisionOverview', '1')
+      const baseResults = useCanvasStore.getState().results
+      useCanvasStore.setState({
+        hasCompletedFirstRun: true,
+        results: { ...baseResults, status: 'complete', report: fakeReport },
+        analysisFreshness: { freshness: 'stale', freshnessReason: 'graph_changed', computedAt: 1 },
+      } as any)
+      renderOutputsDock()
+      const overview = screen.getByTestId('decision-overview')
+      const strip = screen.getByTestId('analysis-freshness-notice')
+      expect(overview.compareDocumentPosition(strip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      localStorage.removeItem('feature.decisionOverview')
+    })
+  })
+
   describe('Wave F-B: one freshness owner — duplicate stale surfaces retired', () => {
     const fakeReport: any = {
       results: { conservative: 10, likely: 20, optimistic: 30, units: 'percent', unitSymbol: '%' },

--- a/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
@@ -48,6 +48,7 @@ vi.mock('../../../flags', () => ({
   isTelemetryEnabled: () => false,
   isCompareEnabled: () => false,
   isRequireLoginEnabled: () => false, // login 3.4 — lib/poc.ts reads it
+  isDecisionOverviewEnabled: () => false, // Wave 1 — OutputsDock mount gate reads it
   isOrchestratorV2Enabled: () => false,
   isLegacyDirectRunEnabled: () => true,
   isJourneyTabEnabled: () => false,

--- a/src/canvas/conversation/__tests__/cee-request-contracts.spec.ts
+++ b/src/canvas/conversation/__tests__/cee-request-contracts.spec.ts
@@ -33,6 +33,7 @@ import type {
   ExplainAnalysisStatePayload,
 } from '../../../services/turn-request-builder'
 import type { CEEGoalConstraint } from '../../../adapters/cee/types'
+import { ACTION_TO_TURN_TYPE } from '../useConversation'
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -846,6 +847,28 @@ describe('T7 — Chip metadata transport', () => {
     })
     // Should not throw — validateTurnRequestBoundary would strip unknown fields
     expect(req.chip_metadata).toEqual({ action_type: 'run_analysis' })
+  })
+
+  it("Wave 1 pin: action_type 'discuss' resolves to a CONVERSATION turn so chip_metadata survives (Actions menu contract)", () => {
+    // The consolidated Actions menu dispatches methods with
+    // action_type 'discuss' + {method_id} parameters. Metadata is
+    // allowlisted ONLY on conversation turns — 'discuss' must stay OUT of
+    // ACTION_TO_TURN_TYPE (mapping it to e.g. 'explain' would silently
+    // drop the contextual-session payload). Review S7 pin.
+    expect(ACTION_TO_TURN_TYPE['discuss']).toBeUndefined()
+    const req = buildConversationTurnRequest({
+      scenario_id: SCENARIO_ID,
+      conversation_history: [],
+      message: 'Run a pre-mortem with me.',
+      graph_state: POPULATED_GRAPH,
+      chip_metadata: { action_type: 'discuss', parameters: { method_id: 'pre_mortem' } },
+    })
+    expect(req._turn_type).toBe('conversation')
+    const wire = stripTurnType(req) as Record<string, unknown>
+    expect(wire.chip_metadata).toEqual({
+      action_type: 'discuss',
+      parameters: { method_id: 'pre_mortem' },
+    })
   })
 })
 

--- a/src/components/results/decision-overview/ActionsMenu.tsx
+++ b/src/components/results/decision-overview/ActionsMenu.tsx
@@ -30,13 +30,45 @@ export function ActionsMenu() {
     if (restoreFocus) triggerRef.current?.focus()
   }, [])
 
+  const menuRef = useRef<HTMLDivElement | null>(null)
+
+  // Review S5: real menu keyboard model — Escape closes with focus restore;
+  // Arrow/Home/End rove focus across menuitems; first item focused on open;
+  // clicking outside closes.
   useEffect(() => {
     if (!open) return
+    const items = () =>
+      Array.from(
+        menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)') ?? [],
+      )
+    items()[0]?.focus()
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close(true)
+      if (e.key === 'Escape') {
+        close(true)
+        return
+      }
+      if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key)) return
+      const list = items()
+      if (list.length === 0) return
+      e.preventDefault()
+      const current = list.indexOf(document.activeElement as HTMLButtonElement)
+      const next =
+        e.key === 'Home' ? 0
+        : e.key === 'End' ? list.length - 1
+        : e.key === 'ArrowDown' ? (current + 1 + list.length) % list.length
+        : (current - 1 + list.length) % list.length
+      list[next]?.focus()
+    }
+    const onPointerDown = (e: MouseEvent) => {
+      const t = e.target as Node
+      if (!menuRef.current?.contains(t) && !triggerRef.current?.contains(t)) close(false)
     }
     document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onPointerDown)
+    }
   }, [open, close])
 
   const runMethod = (method: MethodEntry) => {
@@ -88,6 +120,7 @@ export function ActionsMenu() {
       </button>
       {open && (
         <div
+          ref={menuRef}
           role="menu"
           aria-label="Methods and global actions"
           className="absolute right-0 top-full z-20 mt-1 w-64 rounded-md border border-panel-border bg-panel p-1.5 shadow-2"
@@ -109,18 +142,26 @@ export function ActionsMenu() {
           ))}
           <div className="my-1 h-px bg-panel-border" aria-hidden="true" />
           <p className={`${typography.panelMeta} px-2 pb-1 text-text-light`}>Global actions</p>
-          {GLOBAL_ACTIONS.map((a) => (
+          {GLOBAL_ACTIONS.map((a) => {
+            // Review S6: brief-review routes need a registered chat; rerun
+            // does not. Never render dead controls.
+            const needsChat = a.id !== 'rerun_analysis'
+            const enabled = !needsChat || sendMessage !== null
+            return (
             <button
               key={a.id}
               type="button"
               role="menuitem"
+              disabled={!enabled}
+              title={enabled ? undefined : 'Open the Olumi panel to use this'}
               onClick={() => runGlobal(a.id)}
-              className="block w-full rounded-md px-2 py-1.5 text-left hover:bg-panel-hover"
+              className="block w-full rounded-md px-2 py-1.5 text-left hover:bg-panel-hover disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <span className={`${typography.panelBody} block font-semibold text-text-header`}>{a.title}</span>
               <span className={`${typography.panelMeta} block text-text-light`}>{a.description}</span>
             </button>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/components/results/decision-overview/ActionsMenu.tsx
+++ b/src/components/results/decision-overview/ActionsMenu.tsx
@@ -1,0 +1,7 @@
+/**
+ * Wave 1 — consolidated Actions menu (brief §4.7).
+ * STUB (RED phase): renders nothing until the GREEN commit.
+ */
+export function ActionsMenu(): null {
+  return null
+}

--- a/src/components/results/decision-overview/ActionsMenu.tsx
+++ b/src/components/results/decision-overview/ActionsMenu.tsx
@@ -1,7 +1,128 @@
 /**
  * Wave 1 — consolidated Actions menu (brief §4.7).
- * STUB (RED phase): renders nothing until the GREEN commit.
+ *
+ * ONE persistent menu owning user-invoked science-grounded methods +
+ * global utilities. Methods open CONTEXTUAL AI sessions via dispatchAction
+ * as conversation-typed turns (chip_metadata carries {method_id} — it is
+ * dropped on every other turn type); they disable honestly when no chat is
+ * registered (never dead controls). Rerun routes through the canonical
+ * runner. Keyboard-complete: Escape closes and focus returns to the
+ * trigger (fixes the harvested HeroActionsMenu gap).
  */
-export function ActionsMenu(): null {
-  return null
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import { executeCanonicalRun } from '../../../canvas/analysis/canonicalRunRegistry'
+import { useShowToastSafe } from '../../../canvas/ToastContext'
+import { typography } from '../../../styles/typography'
+import { METHOD_CATALOGUE, GLOBAL_ACTIONS, type MethodEntry } from './actionsCatalogue'
+
+export function ActionsMenu() {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const dispatchAction = useGuidanceStore((s) => s._dispatchAction)
+  const sendMessage = useGuidanceStore((s) => s._sendMessage)
+  const showToast = useShowToastSafe()
+
+  const close = useCallback((restoreFocus: boolean) => {
+    setOpen(false)
+    if (restoreFocus) triggerRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close(true)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, close])
+
+  const runMethod = (method: MethodEntry) => {
+    close(true)
+    // Conversation-typed turn: chip_metadata (the contextual-session
+    // carrier) survives ONLY on this turn type.
+    void dispatchAction?.({
+      action_type: 'discuss',
+      parameters: { method_id: method.id },
+      label: method.title,
+      message: method.prompt,
+      source: 'chip',
+    })
+  }
+
+  const runGlobal = (id: string) => {
+    close(true)
+    if (id === 'rerun_analysis') {
+      void executeCanonicalRun({ source: 'actions-menu' }).then((outcome) => {
+        if (outcome.status === 'blocked' || outcome.status === 'unavailable') {
+          showToast(outcome.reason)
+        }
+      })
+      return
+    }
+    if (id === 'edit_brief') {
+      sendMessage?.('Review my decision brief with me: challenge the goal, context, constraints and options.')
+      return
+    }
+    if (id === 'review_inputs') {
+      sendMessage?.('Walk me through all the current model inputs without changing anything.')
+    }
+  }
+
+  const methodsEnabled = dispatchAction !== null
+
+  return (
+    <div className="relative flex-none">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => (open ? close(true) : setOpen(true))}
+        className={`${typography.panelBody} inline-flex items-center gap-1 rounded-pill border border-panel-border px-3 py-1 text-text-body hover:bg-panel-hover`}
+      >
+        Actions
+        <ChevronDown size={12} aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Methods and global actions"
+          className="absolute right-0 top-full z-20 mt-1 w-64 rounded-md border border-panel-border bg-panel p-1.5 shadow-2"
+        >
+          <p className={`${typography.panelMeta} px-2 pb-1 pt-0.5 text-text-light`}>Methods</p>
+          {METHOD_CATALOGUE.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              role="menuitem"
+              disabled={!methodsEnabled}
+              title={methodsEnabled ? undefined : 'Open the Olumi panel to use methods'}
+              onClick={() => runMethod(m)}
+              className="block w-full rounded-md px-2 py-1.5 text-left hover:bg-panel-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span className={`${typography.panelBody} block font-semibold text-text-header`}>{m.title}</span>
+              <span className={`${typography.panelMeta} block text-text-light`}>{m.description}</span>
+            </button>
+          ))}
+          <div className="my-1 h-px bg-panel-border" aria-hidden="true" />
+          <p className={`${typography.panelMeta} px-2 pb-1 text-text-light`}>Global actions</p>
+          {GLOBAL_ACTIONS.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              role="menuitem"
+              onClick={() => runGlobal(a.id)}
+              className="block w-full rounded-md px-2 py-1.5 text-left hover:bg-panel-hover"
+            >
+              <span className={`${typography.panelBody} block font-semibold text-text-header`}>{a.title}</span>
+              <span className={`${typography.panelMeta} block text-text-light`}>{a.description}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -1,8 +1,55 @@
 /**
- * Wave 1 — Decision overview card (brief §4).
- * STUB (RED phase): renders nothing until the GREEN commit.
+ * Wave 1 — Decision overview card (brief §4): the orientation surface.
+ *
+ * Owns framing quality (the four canonical dimensions), ONE producer-backed
+ * framing question, and hosts the persistent Actions menu. It shows no
+ * analysis outcomes (§4.1). Four-state machine; only ready and needs-input
+ * are reachable live (analysis_ready.status) — thin / contradictory /
+ * unverified render only via stateOverride for the fixture gallery (plan
+ * review B3: fixture states never mount dark on product). No decision
+ * classification pills (contract-absent; deferred to Wave 5).
+ *
+ * DS v4/5: bg-panel card, panel typography tokens only, Lucide, sentence
+ * case, en-GB, no em dashes in prose.
  */
+import { useEffect, useState } from 'react'
+import { AlertTriangle, CheckCircle2, ChevronDown, HelpCircle } from 'lucide-react'
+
+import { useCanvasStore } from '../../../canvas/store'
+import { useGuidanceStore, selectTopItem } from '../../../canvas/stores/guidanceStore'
+import { isDecisionOverviewEnabled } from '../../../flags'
+import { typography } from '../../../styles/typography'
+import { ActionsMenu } from './ActionsMenu'
+
 export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
+
+type BriefState = 'ready' | 'needs_input' | BriefStateOverride
+
+export const OVERVIEW_COPY = {
+  metaLabel: 'Decision overview',
+  ready: 'Framing has the basics',
+  readyNote: 'Goal, context, constraints and options',
+  needsInput: 'Olumi needs a little more from you',
+  needsInputNote: 'Answer the questions below to sharpen the framing',
+  thin: 'Framing needs one clarification',
+  thinNote: 'The goal is broad or important context is missing',
+  contradictory: 'The brief contains a conflict',
+  contradictoryNote: 'Resolve it before relying on the read',
+  unverified: 'One claim in the brief is unverified',
+  unverifiedNote: 'Add a source, correct it or confirm it',
+  framingLabel: "Olumi's framing question",
+  workThrough: 'Work through with Olumi',
+} as const
+
+const STATE_COPY: Record<BriefState, { line: string; note: string }> = {
+  ready: { line: OVERVIEW_COPY.ready, note: OVERVIEW_COPY.readyNote },
+  needs_input: { line: OVERVIEW_COPY.needsInput, note: OVERVIEW_COPY.needsInputNote },
+  thin: { line: OVERVIEW_COPY.thin, note: OVERVIEW_COPY.thinNote },
+  contradictory: { line: OVERVIEW_COPY.contradictory, note: OVERVIEW_COPY.contradictoryNote },
+  unverified: { line: OVERVIEW_COPY.unverified, note: OVERVIEW_COPY.unverifiedNote },
+}
+
+const DIMENSIONS = ['Goal', 'Context', 'Constraints', 'Options'] as const
 
 export interface DecisionOverviewCardProps {
   title?: string | null
@@ -10,6 +57,112 @@ export interface DecisionOverviewCardProps {
   stateOverride?: BriefStateOverride
 }
 
-export function DecisionOverviewCard(_props: DecisionOverviewCardProps): null {
-  return null
+export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewCardProps) {
+  const analysisReady = useCanvasStore((s) => s.ceeAnalysisReady)
+  const topGuidance = useGuidanceStore(selectTopItem)
+  const sendMessage = useGuidanceStore((s) => s._sendMessage)
+
+  // Live state derivation: ONLY ready / needs-input can fire from the wire
+  // (analysis_ready.status). The gallery states arrive via stateOverride.
+  const liveState: BriefState =
+    analysisReady && analysisReady.status !== 'ready' ? 'needs_input' : 'ready'
+  const state: BriefState = stateOverride ?? liveState
+  const autoExpand = state !== 'ready'
+
+  const [expanded, setExpanded] = useState(autoExpand)
+  useEffect(() => setExpanded(autoExpand), [autoExpand])
+
+  if (!isDecisionOverviewEnabled()) return null
+
+  const copy = STATE_COPY[state]
+  const StateIcon =
+    state === 'ready' ? CheckCircle2 : state === 'contradictory' ? AlertTriangle : HelpCircle
+  const iconTone =
+    state === 'ready' ? 'text-text-light' : state === 'contradictory' ? 'text-danger' : 'text-warning'
+  const questions = (analysisReady?.user_questions ?? []).slice(0, 3)
+
+  return (
+    <section
+      data-testid="decision-overview"
+      className="rounded-md border border-panel-border bg-panel"
+    >
+      <div className="flex items-start gap-2 px-3 pt-3">
+        <div className="min-w-0 flex-1">
+          <p className={`${typography.panelMeta} text-text-light`}>{OVERVIEW_COPY.metaLabel}</p>
+          {title ? (
+            <h2 className={`${typography.panelHeader} text-text-header truncate`}>{title}</h2>
+          ) : null}
+        </div>
+        <ActionsMenu />
+      </div>
+
+      <button
+        type="button"
+        data-testid="brief-bar"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((e) => !e)}
+        className="mt-2 flex w-full items-center gap-2 border-t border-panel-border px-3 py-2 text-left hover:bg-panel-hover"
+      >
+        <StateIcon size={14} className={`flex-none ${iconTone}`} aria-hidden="true" />
+        <span className="min-w-0 flex-1">
+          <span className={`${typography.panelBody} block font-semibold text-text-header`}>{copy.line}</span>
+          <span className={`${typography.panelMeta} block text-text-light`}>{copy.note}</span>
+        </span>
+        <ChevronDown
+          size={14}
+          className={`flex-none text-text-light transition-transform duration-fast ${expanded ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {expanded && (
+        <div className="border-t border-panel-border px-3 py-2">
+          <div className="grid grid-cols-2 gap-1.5">
+            {DIMENSIONS.map((dim) => (
+              <div
+                key={dim}
+                className="rounded-md border border-panel-border px-2 py-1.5"
+                data-testid={`brief-dim-${dim.toLowerCase()}`}
+              >
+                <span className={`${typography.panelBody} block font-semibold text-text-header`}>{dim}</span>
+              </div>
+            ))}
+          </div>
+
+          {state === 'needs_input' && questions.length > 0 && (
+            <ul className="mt-2 space-y-1" data-testid="brief-questions">
+              {questions.map((q) => (
+                <li key={q} className={`${typography.panelBody} text-text-body`}>
+                  {q}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {topGuidance && (
+            <div className="mt-2 border-t border-panel-border pt-2" data-testid="framing-question">
+              <p className={`${typography.panelMeta} text-text-light`}>{OVERVIEW_COPY.framingLabel}</p>
+              <p className={`${typography.panelBody} mt-0.5 text-text-header`}>{topGuidance.title}</p>
+              <button
+                type="button"
+                disabled={!sendMessage}
+                onClick={() =>
+                  sendMessage?.(
+                    // primary_action is a union; only 'discuss' carries a
+                    // prompt — fall back to working through the title.
+                    topGuidance.primary_action.type === 'discuss'
+                      ? topGuidance.primary_action.prompt
+                      : `Help me work through: ${topGuidance.title}`,
+                  )
+                }
+                className={`${typography.panelBody} mt-1.5 rounded-pill border border-panel-border px-3 py-1 text-text-body hover:bg-panel-hover disabled:opacity-50 disabled:cursor-not-allowed`}
+              >
+                {OVERVIEW_COPY.workThrough}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
 }

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -1,0 +1,15 @@
+/**
+ * Wave 1 — Decision overview card (brief §4).
+ * STUB (RED phase): renders nothing until the GREEN commit.
+ */
+export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
+
+export interface DecisionOverviewCardProps {
+  title?: string | null
+  /** Fixture-gallery-only states (plan review B3) — never set on product. */
+  stateOverride?: BriefStateOverride
+}
+
+export function DecisionOverviewCard(_props: DecisionOverviewCardProps): null {
+  return null
+}

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -16,14 +16,14 @@ import { useEffect, useState } from 'react'
 import { AlertTriangle, CheckCircle2, ChevronDown, HelpCircle } from 'lucide-react'
 
 import { useCanvasStore } from '../../../canvas/store'
-import { useGuidanceStore, selectTopItem } from '../../../canvas/stores/guidanceStore'
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
 import { isDecisionOverviewEnabled } from '../../../flags'
 import { typography } from '../../../styles/typography'
 import { ActionsMenu } from './ActionsMenu'
 
 export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
 
-type BriefState = 'ready' | 'needs_input' | BriefStateOverride
+type BriefState = 'ready' | 'needs_input' | 'unassessed' | BriefStateOverride
 
 export const OVERVIEW_COPY = {
   metaLabel: 'Decision overview',
@@ -31,19 +31,23 @@ export const OVERVIEW_COPY = {
   readyNote: 'Goal, context, constraints and options',
   needsInput: 'Olumi needs a little more from you',
   needsInputNote: 'Answer the questions below to sharpen the framing',
+  needsInputNoQuestions: 'Work through the gaps with Olumi when you are ready',
+  unassessed: 'Framing not yet assessed',
+  unassessedNote: 'Draft or run an analysis to get an assessment',
   thin: 'Framing needs one clarification',
   thinNote: 'The goal is broad or important context is missing',
   contradictory: 'The brief contains a conflict',
   contradictoryNote: 'Resolve it before relying on the read',
   unverified: 'One claim in the brief is unverified',
   unverifiedNote: 'Add a source, correct it or confirm it',
-  framingLabel: "Olumi's framing question",
+  framingLabel: "Olumi's top question",
   workThrough: 'Work through with Olumi',
 } as const
 
 const STATE_COPY: Record<BriefState, { line: string; note: string }> = {
   ready: { line: OVERVIEW_COPY.ready, note: OVERVIEW_COPY.readyNote },
   needs_input: { line: OVERVIEW_COPY.needsInput, note: OVERVIEW_COPY.needsInputNote },
+  unassessed: { line: OVERVIEW_COPY.unassessed, note: OVERVIEW_COPY.unassessedNote },
   thin: { line: OVERVIEW_COPY.thin, note: OVERVIEW_COPY.thinNote },
   contradictory: { line: OVERVIEW_COPY.contradictory, note: OVERVIEW_COPY.contradictoryNote },
   unverified: { line: OVERVIEW_COPY.unverified, note: OVERVIEW_COPY.unverifiedNote },
@@ -59,28 +63,50 @@ export interface DecisionOverviewCardProps {
 
 export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewCardProps) {
   const analysisReady = useCanvasStore((s) => s.ceeAnalysisReady)
-  const topGuidance = useGuidanceStore(selectTopItem)
+  // Review S3: promote only DISCUSSION challenges (never mechanical-fix
+  // items like approve_patch/open_inspector) — closest honest v1 to the
+  // brief's "highest-value framing challenge"; an explicit producer
+  // framing-question signal is a routed ask.
+  const topGuidance = useGuidanceStore((s) => {
+    const items = s.guidanceItems.filter((i) => i.primary_action.type === 'discuss')
+    if (items.length === 0) return null
+    return items.reduce((best, i) => (i.priority > best.priority ? i : best), items[0])
+  })
   const sendMessage = useGuidanceStore((s) => s._sendMessage)
 
-  // Live state derivation: ONLY ready / needs-input can fire from the wire
+  // Live state derivation (review S2): with NO CEE assessment at all the
+  // card must not claim the basics are present — 'unassessed' is a quiet
+  // no-claim state. ONLY ready / needs-input can fire from the wire
   // (analysis_ready.status). The gallery states arrive via stateOverride.
-  const liveState: BriefState =
-    analysisReady && analysisReady.status !== 'ready' ? 'needs_input' : 'ready'
+  const liveState: BriefState = !analysisReady
+    ? 'unassessed'
+    : analysisReady.status !== 'ready'
+      ? 'needs_input'
+      : 'ready'
   const state: BriefState = stateOverride ?? liveState
-  const autoExpand = state !== 'ready'
+  // Unassessed is a QUIET no-claim state — collapsed like ready (review S2).
+  const autoExpand = state !== 'ready' && state !== 'unassessed'
 
   const [expanded, setExpanded] = useState(autoExpand)
   useEffect(() => setExpanded(autoExpand), [autoExpand])
 
   if (!isDecisionOverviewEnabled()) return null
 
-  const copy = STATE_COPY[state]
+  const questions = (analysisReady?.user_questions ?? []).slice(0, 3)
+  // Review S1: never promise "questions below" when the producer sent none
+  // (needs_encoding / needs_user_mapping often carry no user_questions).
+  const copy =
+    state === 'needs_input' && questions.length === 0
+      ? { line: OVERVIEW_COPY.needsInput, note: OVERVIEW_COPY.needsInputNoQuestions }
+      : STATE_COPY[state]
   const StateIcon =
     state === 'ready' ? CheckCircle2 : state === 'contradictory' ? AlertTriangle : HelpCircle
   const iconTone =
-    state === 'ready' ? 'text-text-light' : state === 'contradictory' ? 'text-danger' : 'text-warning'
-  const questions = (analysisReady?.user_questions ?? []).slice(0, 3)
-
+    state === 'ready' || state === 'unassessed'
+      ? 'text-text-light'
+      : state === 'contradictory'
+        ? 'text-danger'
+        : 'text-warning'
   return (
     <section
       data-testid="decision-overview"
@@ -131,8 +157,8 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
 
           {state === 'needs_input' && questions.length > 0 && (
             <ul className="mt-2 space-y-1" data-testid="brief-questions">
-              {questions.map((q) => (
-                <li key={q} className={`${typography.panelBody} text-text-body`}>
+              {questions.map((q, i) => (
+                <li key={`${i}-${q}`} className={`${typography.panelBody} text-text-body`}>
                   {q}
                 </li>
               ))}

--- a/src/components/results/decision-overview/__tests__/ActionsMenu.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/ActionsMenu.spec.tsx
@@ -1,0 +1,84 @@
+/**
+ * Wave 1 — consolidated Actions menu (brief §4.7): ONE stable catalogue of
+ * science-grounded methods + global utilities, persistent, contextual AI
+ * sessions via dispatchAction (conversation-typed — chip_metadata drops on
+ * every other turn type), canonical rerun, keyboard-complete with focus
+ * restore (fixes the HeroActionsMenu gap).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { ActionsMenu } from '../ActionsMenu'
+import { METHOD_CATALOGUE, GLOBAL_ACTIONS } from '../actionsCatalogue'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import {
+  registerCanonicalRunner,
+  __resetCanonicalRunnerForTests,
+} from '../../../../canvas/analysis/canonicalRunRegistry'
+
+beforeEach(() => {
+  __resetCanonicalRunnerForTests()
+  useGuidanceStore.setState({ _dispatchAction: null } as never)
+})
+
+describe('Actions catalogue (brief §4.7 — one recognisable set)', () => {
+  it('carries the seven methods and three global actions', () => {
+    expect(METHOD_CATALOGUE.map((m) => m.title)).toEqual([
+      'Reframe the problem',
+      'Generate a materially different option',
+      'Consider the opposite',
+      'Apply the outside view',
+      'Run a pre-mortem',
+      'Explore trade-offs',
+      'Review a possible bias',
+    ])
+    expect(GLOBAL_ACTIONS.map((a) => a.title)).toEqual([
+      'Edit decision brief',
+      'Review all inputs',
+      'Rerun analysis',
+    ])
+  })
+})
+
+describe('ActionsMenu', () => {
+  it('opens with the grouped catalogue and closes on Escape with focus restored', () => {
+    render(<ActionsMenu />)
+    const trigger = screen.getByRole('button', { name: /actions/i })
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Run a pre-mortem')).toBeInTheDocument()
+    expect(screen.getByText('Rerun analysis')).toBeInTheDocument()
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('a method opens a contextual session: dispatchAction with method identity in parameters', () => {
+    const dispatch = vi.fn()
+    useGuidanceStore.setState({ _dispatchAction: dispatch } as never)
+    render(<ActionsMenu />)
+    fireEvent.click(screen.getByRole('button', { name: /actions/i }))
+    fireEvent.click(screen.getByText('Run a pre-mortem'))
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    const call = dispatch.mock.calls[0][0]
+    expect(call.parameters).toMatchObject({ method_id: 'pre_mortem' })
+    expect(typeof call.message).toBe('string')
+    expect(call.message.length).toBeGreaterThan(0)
+  })
+
+  it('methods are disabled with honest hint when no chat can receive them (never dead controls)', () => {
+    render(<ActionsMenu />)
+    fireEvent.click(screen.getByRole('button', { name: /actions/i }))
+    const method = screen.getByText('Run a pre-mortem').closest('button')!
+    expect(method).toBeDisabled()
+  })
+
+  it('"Rerun analysis" routes through the canonical runner', async () => {
+    const runner = vi.fn(async (_opts?: import('../../../../canvas/analysis/canonicalRunRegistry').CanonicalRunOptions) => ({ status: 'dispatched' as const }))
+    registerCanonicalRunner(runner)
+    render(<ActionsMenu />)
+    fireEvent.click(screen.getByRole('button', { name: /actions/i }))
+    fireEvent.click(screen.getByText('Rerun analysis'))
+    await vi.waitFor(() => expect(runner).toHaveBeenCalledTimes(1))
+  })
+})

--- a/src/components/results/decision-overview/__tests__/ActionsMenu.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/ActionsMenu.spec.tsx
@@ -18,7 +18,7 @@ import {
 
 beforeEach(() => {
   __resetCanonicalRunnerForTests()
-  useGuidanceStore.setState({ _dispatchAction: null } as never)
+  useGuidanceStore.setState({ _dispatchAction: null, _sendMessage: null } as never)
 })
 
 describe('Actions catalogue (brief §4.7 — one recognisable set)', () => {
@@ -71,6 +71,29 @@ describe('ActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: /actions/i }))
     const method = screen.getByText('Run a pre-mortem').closest('button')!
     expect(method).toBeDisabled()
+  })
+
+  it('S5: arrow keys rove focus across menu items and outside click closes', () => {
+    // All items enabled: chat + dispatch registered.
+    useGuidanceStore.setState({ _dispatchAction: vi.fn(), _sendMessage: vi.fn() } as never)
+    render(<ActionsMenu />)
+    fireEvent.click(screen.getByRole('button', { name: /actions/i }))
+    const items = screen.getAllByRole('menuitem')
+    expect(document.activeElement).toBe(items[0])
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(items[1])
+    fireEvent.keyDown(document.activeElement!, { key: 'End' })
+    expect(document.activeElement).toBe(items[items.length - 1])
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('S6: brief-review globals disable honestly when no chat is registered (rerun stays live)', () => {
+    render(<ActionsMenu />)
+    fireEvent.click(screen.getByRole('button', { name: /actions/i }))
+    expect(screen.getByText('Edit decision brief').closest('button')).toBeDisabled()
+    expect(screen.getByText('Review all inputs').closest('button')).toBeDisabled()
+    expect(screen.getByText('Rerun analysis').closest('button')).not.toBeDisabled()
   })
 
   it('"Rerun analysis" routes through the canonical runner', async () => {

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
@@ -89,6 +89,40 @@ describe('DecisionOverviewCard — needs-input state (live)', () => {
   })
 })
 
+describe('DecisionOverviewCard — review folds (S1/S2/S3)', () => {
+  beforeEach(() => flagOn())
+
+  it('S2: NO CEE assessment → quiet no-claim state, never "has the basics"', () => {
+    useCanvasStore.setState({ ceeAnalysisReady: null } as never)
+    render(<DecisionOverviewCard title="t" />)
+    expect(screen.getByText('Framing not yet assessed')).toBeInTheDocument()
+    expect(screen.queryByText('Framing has the basics')).not.toBeInTheDocument()
+    expect(screen.getByTestId('brief-bar')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('S1: needs-input WITHOUT producer questions never promises "questions below"', () => {
+    useCanvasStore.setState({
+      ceeAnalysisReady: { status: 'needs_encoding', options: [], goal_node_id: 'g1' },
+    } as never)
+    render(<DecisionOverviewCard title="t" />)
+    expect(screen.queryByText(/questions below/i)).not.toBeInTheDocument()
+    expect(screen.getByText('Work through the gaps with Olumi when you are ready')).toBeInTheDocument()
+  })
+
+  it('S3: only DISCUSSION items are promoted — a mechanical top item is not a question', () => {
+    useCanvasStore.setState({ ceeAnalysisReady: READY } as never)
+    useGuidanceStore.setState({
+      guidanceItems: [
+        { item_id: 'g1', signal_code: 's', category: 'must_fix', source: 'structural', title: 'Connect the isolated risk', primary_action: { type: 'open_inspector', target_id: 'n1' }, priority: 95 },
+      ],
+      _sendMessage: () => {},
+    } as never)
+    render(<DecisionOverviewCard title="t" />)
+    fireEvent.click(screen.getByTestId('brief-bar'))
+    expect(screen.queryByTestId('framing-question')).not.toBeInTheDocument()
+  })
+})
+
 describe('DecisionOverviewCard — gallery-only states (stateOverride)', () => {
   beforeEach(() => flagOn())
 

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
@@ -1,0 +1,141 @@
+/**
+ * Wave 1 (Analysis-tab rebuild) — Decision overview card (brief §4).
+ *
+ * Orientation surface: framing quality + one framing question + the
+ * persistent Actions menu. Four-state machine designed; only ready and
+ * needs-input are reachable LIVE (analysis_ready.status). Thin /
+ * contradictory / unverified exist in code + copy but are reachable only
+ * via stateOverride (fixture gallery) — no dark product mounts (plan review
+ * B3). No classification pills anywhere (deferred to Wave 5).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { DecisionOverviewCard } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+
+function flagOn() {
+  localStorage.setItem('feature.decisionOverview', '1')
+}
+
+const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
+const NEEDS_INPUT = {
+  status: 'needs_user_input',
+  options: [],
+  goal_node_id: 'g1',
+  user_questions: ['What does success look like?', 'Which options are realistic?', 'Q3', 'Q4'],
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  useCanvasStore.setState({ ceeAnalysisReady: null } as never)
+  useGuidanceStore.setState({ guidanceItems: [], _sendMessage: null } as never)
+})
+
+describe('DecisionOverviewCard — flag gate', () => {
+  it('renders NOTHING when the flag is off (byte-identical pin)', () => {
+    useCanvasStore.setState({ ceeAnalysisReady: READY } as never)
+    const { container } = render(<DecisionOverviewCard title="Launch decision" />)
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('DecisionOverviewCard — ready state (live)', () => {
+  beforeEach(() => {
+    flagOn()
+    useCanvasStore.setState({ ceeAnalysisReady: READY } as never)
+  })
+
+  it('collapsed and quiet: meta label, title, framing-has-the-basics line', () => {
+    render(<DecisionOverviewCard title="Launch decision" />)
+    expect(screen.getByText('Decision overview')).toBeInTheDocument()
+    expect(screen.getByText('Launch decision')).toBeInTheDocument()
+    expect(screen.getByText('Framing has the basics')).toBeInTheDocument()
+    // Collapsed by default: dimension chips hidden until expanded.
+    expect(screen.queryByText('Constraints')).not.toBeInTheDocument()
+    const bar = screen.getByTestId('brief-bar')
+    expect(bar.tagName).toBe('BUTTON')
+    expect(bar).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands to the four canonical dimensions (Goal, Context, Constraints, Options)', () => {
+    render(<DecisionOverviewCard title="Launch decision" />)
+    fireEvent.click(screen.getByTestId('brief-bar'))
+    expect(screen.getByTestId('brief-bar')).toHaveAttribute('aria-expanded', 'true')
+    for (const dim of ['Goal', 'Context', 'Constraints', 'Options']) {
+      expect(screen.getByText(dim)).toBeInTheDocument()
+    }
+  })
+
+  it('never says "good framing" or implies objective correctness', () => {
+    render(<DecisionOverviewCard title="t" />)
+    expect(screen.queryByText(/good framing|good enough/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('DecisionOverviewCard — needs-input state (live)', () => {
+  beforeEach(() => {
+    flagOn()
+    useCanvasStore.setState({ ceeAnalysisReady: NEEDS_INPUT } as never)
+  })
+
+  it('auto-expands and shows at most three focused questions', () => {
+    render(<DecisionOverviewCard title="t" />)
+    expect(screen.getByTestId('brief-bar')).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('What does success look like?')).toBeInTheDocument()
+    expect(screen.getByText('Which options are realistic?')).toBeInTheDocument()
+    expect(screen.queryByText('Q4')).not.toBeInTheDocument()
+  })
+})
+
+describe('DecisionOverviewCard — gallery-only states (stateOverride)', () => {
+  beforeEach(() => flagOn())
+
+  it('contradictory: auto-expands and pauses reliance on the read', () => {
+    render(<DecisionOverviewCard title="t" stateOverride="contradictory" />)
+    expect(screen.getByText('The brief contains a conflict')).toBeInTheDocument()
+    expect(screen.getByTestId('brief-bar')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('thin: auto-expands with the one-clarification line', () => {
+    render(<DecisionOverviewCard title="t" stateOverride="thin" />)
+    expect(screen.getByText('Framing needs one clarification')).toBeInTheDocument()
+  })
+
+  it('unverified: labels the claim as unverified, never asserts it is false', () => {
+    render(<DecisionOverviewCard title="t" stateOverride="unverified" />)
+    expect(screen.getByText(/unverified/i)).toBeInTheDocument()
+    expect(screen.queryByText(/false|wrong|incorrect/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('DecisionOverviewCard — framing question (producer-backed)', () => {
+  beforeEach(() => {
+    flagOn()
+    useCanvasStore.setState({ ceeAnalysisReady: READY } as never)
+  })
+
+  it('promotes the TOP guidance item as the one framing question with a work-through route', () => {
+    const sendMessage = vi.fn()
+    useGuidanceStore.setState({
+      guidanceItems: [
+        { item_id: 'g2', signal_code: 's', category: 'should_fix', source: 'analysis', title: 'Lower-priority', primary_action: { type: 'discuss', prompt: 'x' }, priority: 10 },
+        { item_id: 'g1', signal_code: 's', category: 'must_fix', source: 'analysis', title: 'What would make option B clearly better?', primary_action: { type: 'discuss', prompt: 'Work through the framing question' }, priority: 90 },
+      ],
+      _sendMessage: sendMessage,
+    } as never)
+    render(<DecisionOverviewCard title="t" />)
+    fireEvent.click(screen.getByTestId('brief-bar'))
+    expect(screen.getByText('What would make option B clearly better?')).toBeInTheDocument()
+    expect(screen.queryByText('Lower-priority')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /work through with olumi/i }))
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders NO framing question when no guidance exists (never fabricates)', () => {
+    render(<DecisionOverviewCard title="t" />)
+    fireEvent.click(screen.getByTestId('brief-bar'))
+    expect(screen.queryByText(/framing question/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/results/decision-overview/__tests__/copyHygiene.spec.ts
+++ b/src/components/results/decision-overview/__tests__/copyHygiene.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Wave 1 — copy hygiene for the Decision overview surface (house pattern:
+ * per-surface spec over centralised copy; no repo-wide guard exists).
+ * Rules (brief §13.4): sentence case (no shouting caps), no em dashes in
+ * prose, en-GB, no internal analytical terms in user-facing strings.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { OVERVIEW_COPY } from '../DecisionOverviewCard'
+import { METHOD_CATALOGUE, GLOBAL_ACTIONS } from '../actionsCatalogue'
+
+const BANNED_TERMS = /\b(node|edge|coefficient|elasticity|normalised value|graph hash|winner|validate)\b/i
+const AMERICAN = /\b(analyze|optimize|color|behavior|center|favorite)\w*/i
+
+function allStrings(): string[] {
+  return [
+    ...Object.values(OVERVIEW_COPY),
+    ...METHOD_CATALOGUE.flatMap((m) => [m.title, m.description, m.prompt]),
+    ...GLOBAL_ACTIONS.flatMap((a) => [a.title, a.description]),
+  ]
+}
+
+describe('Decision overview copy hygiene', () => {
+  it('contains no em dashes in prose', () => {
+    for (const s of allStrings()) expect(s, s).not.toContain('—')
+  })
+
+  it('contains no shouting caps', () => {
+    for (const s of allStrings()) {
+      const shouting = s.match(/\b[A-Z]{2,}\b/g)?.filter((w) => w !== 'AGAINST') ?? []
+      expect(shouting, s).toEqual([])
+    }
+  })
+
+  it('avoids internal analytical vocabulary and American spellings', () => {
+    for (const s of allStrings()) {
+      expect(s, s).not.toMatch(BANNED_TERMS)
+      expect(s, s).not.toMatch(AMERICAN)
+    }
+  })
+})

--- a/src/components/results/decision-overview/actionsCatalogue.ts
+++ b/src/components/results/decision-overview/actionsCatalogue.ts
@@ -1,6 +1,11 @@
 /**
  * Wave 1 — the ONE stable Actions catalogue (brief §4.7).
- * STUB (RED phase): entries land in the GREEN commit.
+ *
+ * Methods are user-invoked science-grounded moves; global actions are
+ * utilities. The catalogue stays recognisable across contexts (ordering may
+ * adapt later, membership does not). Every method opens a CONTEXTUAL AI
+ * session (dispatchAction, conversation-typed so chip_metadata survives the
+ * wire) rather than a blank chat. Copy: sentence case, en-GB, no em dashes.
  */
 export interface MethodEntry {
   id: string
@@ -16,5 +21,65 @@ export interface GlobalActionEntry {
   description: string
 }
 
-export const METHOD_CATALOGUE: MethodEntry[] = []
-export const GLOBAL_ACTIONS: GlobalActionEntry[] = []
+export const METHOD_CATALOGUE: MethodEntry[] = [
+  {
+    id: 'reframe_problem',
+    title: 'Reframe the problem',
+    description: 'Check whether the current question is too narrow.',
+    prompt: 'Help me reframe this decision. Is the question we are asking too narrow, and what alternative framings should we consider?',
+  },
+  {
+    id: 'different_option',
+    title: 'Generate a materially different option',
+    description: 'Use divergent thinking before narrowing.',
+    prompt: 'Help me generate an option that works through a materially different mechanism from the ones already on the canvas.',
+  },
+  {
+    id: 'consider_opposite',
+    title: 'Consider the opposite',
+    description: 'Build the strongest case against the current leader.',
+    prompt: 'Build the strongest honest case AGAINST the currently leading option. What evidence or reasoning would change my mind?',
+  },
+  {
+    id: 'outside_view',
+    title: 'Apply the outside view',
+    description: 'Compare with a relevant reference class.',
+    prompt: 'Apply the outside view to this decision. What reference class does it belong to, and what do base rates suggest?',
+  },
+  {
+    id: 'pre_mortem',
+    title: 'Run a pre-mortem',
+    description: 'Imagine failure and capture plausible causes.',
+    prompt: 'Run a pre-mortem with me: imagine this decision failed a year from now. What plausibly went wrong, and which risks should we add to the model?',
+  },
+  {
+    id: 'explore_tradeoffs',
+    title: 'Explore trade-offs',
+    description: 'Make gains and sacrifices explicit.',
+    prompt: 'Walk me through the real trade-offs between the leading options: what each gains, gives up and depends on.',
+  },
+  {
+    id: 'review_bias',
+    title: 'Review a possible bias',
+    description: 'Use only biases grounded in this brief or model.',
+    prompt: 'Review this decision for reasoning biases that are actually grounded in the current brief and model, and how to test for them.',
+  },
+]
+
+export const GLOBAL_ACTIONS: GlobalActionEntry[] = [
+  {
+    id: 'edit_brief',
+    title: 'Edit decision brief',
+    description: 'Review goal, context, constraints and options.',
+  },
+  {
+    id: 'review_inputs',
+    title: 'Review all inputs',
+    description: 'Inspect the current model inputs without changing them.',
+  },
+  {
+    id: 'rerun_analysis',
+    title: 'Rerun analysis',
+    description: 'Run the analysis against the current model.',
+  },
+]

--- a/src/components/results/decision-overview/actionsCatalogue.ts
+++ b/src/components/results/decision-overview/actionsCatalogue.ts
@@ -1,0 +1,20 @@
+/**
+ * Wave 1 — the ONE stable Actions catalogue (brief §4.7).
+ * STUB (RED phase): entries land in the GREEN commit.
+ */
+export interface MethodEntry {
+  id: string
+  title: string
+  description: string
+  /** Opening message for the contextual AI session. */
+  prompt: string
+}
+
+export interface GlobalActionEntry {
+  id: string
+  title: string
+  description: string
+}
+
+export const METHOD_CATALOGUE: MethodEntry[] = []
+export const GLOBAL_ACTIONS: GlobalActionEntry[] = []

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -417,6 +417,13 @@ const FLAGS_CONFIG = {
     envKey: 'VITE_REQUIRE_LOGIN',
     storageKey: 'feature.requireLogin',
   },
+  // Analysis-tab rebuild Wave 1 (DEV-PLAN-2026-07-12): the Decision overview
+  // card + consolidated Actions menu. Default OFF; staging-on by netlify.toml
+  // promotion after wave acceptance; flag-off is byte-identical (pinned).
+  decisionOverview: {
+    envKey: 'VITE_FEATURE_DECISION_OVERVIEW',
+    storageKey: 'feature.decisionOverview',
+  },
 } as const
 
 // ============================================================================
@@ -489,6 +496,7 @@ const flags = {
   v5CanonicalAnalysis: makeFlag(FLAGS_CONFIG.v5CanonicalAnalysis),
   reasoningDisclosure: makeFlag(FLAGS_CONFIG.reasoningDisclosure),
   requireLogin: makeFlag(FLAGS_CONFIG.requireLogin),
+  decisionOverview: makeFlag(FLAGS_CONFIG.decisionOverview),
 }
 
 // Export with original naming convention for backward compatibility
@@ -559,6 +567,7 @@ export const diagnoseV5CanonicalAnalysis = () =>
   diagnoseFlagState(FLAGS_CONFIG.v5CanonicalAnalysis)
 export const isReasoningDisclosureEnabled = flags.reasoningDisclosure
 export const isRequireLoginEnabled = flags.requireLogin
+export const isDecisionOverviewEnabled = flags.decisionOverview
 
 
 // ============================================================================


### PR DESCRIPTION
## What (Analysis-tab rebuild lane 3 — DEV-PLAN v2 §3 Wave 1; brief §4)

First **visible** surface of the rebuild, dark behind `VITE_FEATURE_DECISION_OVERVIEW` (default off; flag-off pinned byte-identical).

- **DecisionOverviewCard** — the orientation surface, mounted FIRST in the canonical hierarchy (above the freshness strip): meta label + decision title (scenario name), collapsible brief bar with the four canonical dimensions (Goal/Context/Constraints/Options). Four-state machine with only **ready / needs-input reachable live** (`analysis_ready.status`; needs-input auto-expands with at most three focused `user_questions`). Thin/contradictory/unverified exist in code + copy but render **only via `stateOverride`** for the fixture gallery (plan review B3 — fixture states never mount dark on product). ONE producer-backed framing question promoted from the top guidance item — never fabricated; absent when no guidance exists. **No classification pills anywhere** (contract-absent; deferred to Wave 5 per §4.3).
- **ActionsMenu (§4.7)** — the ONE persistent catalogue: 7 science-grounded methods + 3 global actions (pinned exactly). Methods open **contextual AI sessions** via `dispatchAction` as conversation-typed turns carrying `{method_id}` in `chip_metadata.parameters` (the only turn type that keeps metadata on the wire); they disable honestly when no chat is registered. `Rerun analysis` routes through the canonical runner with honest blocked feedback. Keyboard-complete: Escape closes with focus restored (fixes the harvested HeroActionsMenu gap).
- Per-surface copyHygiene spec (no em dashes, no shouting caps, no internal vocabulary, en-GB) per the house pattern.

## Tests
RED-first (13 red / 2 pins, compiling stubs) → GREEN 18/18 + mount pins (flag-off absent; flag-on mounts ABOVE the strip) + catalogue pin + copy hygiene.

## Gates
typecheck clean · `vitest --changed origin/staging` **5861/0** · wide tsc diff vs base **zero** · eslint clean · fast gate ×2.
**Browser proof (live dev server):** flag off → no card, results byte-identical; flag on → card renders first in the hierarchy with all four dimensions, the full 10-item Actions catalogue opens (screenshot in session), framing question honestly absent with no guidance items, and clicking `Run a pre-mortem` dispatched a real contextual turn (thinking state observed). Console clean throughout.

## Adversarial review (done): NOT-MERGE-SAFE → blocker + promotion-grade folds applied (`8ed35bd2`, `+1`)

- **B1 (blocker, folded):** the mount was gated inside the component after hooks ran, and the title derivation parsed the whole scenarios localStorage blob per dock render, flag-off. Now mount-site gated (house pattern) + memoised — flag-off pays zero cost.
- **Folded should-fixes:** null-assessment → quiet 'Framing not yet assessed' (never claims the basics without a CEE assessment); needs-input without questions never promises 'questions below'; only DISCUSSION items promote to the (relabelled) 'Olumi's top question' slot; real menu keyboard model (focus-first, Arrow/Home/End roving skipping disabled, outside-click close); brief-review globals disable honestly without a chat; wire pin that `action_type 'discuss'` stays a conversation turn so chip_metadata survives (T7).
- **Promotion gates declared (before staging-on, not merge):** S4 — the question slot and GuidanceStrip currently promote the same top item (§2.2); disposition needed (suppress one side or Paul ruling). S8 — `method_id` has no CEE consumer yet; the contextual session is the hardcoded opening prompt + standard context — declared deviation, producer ask routed (method-identity handling + entity_refs/grounding per §11.3). N1/N2 (per-dimension notes + 'Answer directly' route) deferred with the contract gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)