### PR TITLE
F1: honour prefers-reduced-motion on all graph camera moves (graph-visuals lane G1)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -9,6 +9,8 @@ import { useComparisonStore } from './stores/comparisonStore'
 import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS } from './domain/edges'
 import { parseRunHash } from './utils/shareLink'
 import { useInitialLayoutGuard } from './hooks/useInitialLayoutGuard'
+import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
+import { cameraDuration } from './utils/cameraMotion'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
 import { useFitViewOnLayoutVersion } from './hooks/useFitViewOnLayoutVersion'
 import { nodeTypes } from './nodes/registry'
@@ -359,6 +361,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   zoomInRef.current = zoomIn
   zoomOutRef.current = zoomOut
   zoomToRef.current = zoomTo
+
+  // F1: reduced-motion guard for every imperative camera move below. Mirrored
+  // to a ref so the empty-deps camera callbacks stay reference-stable.
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const reducedMotionRef = useRef(prefersReducedMotion)
+  reducedMotionRef.current = prefersReducedMotion
 
   // Canvas control actions from store
   const undo = useCanvasStore(s => s.undo)
@@ -883,7 +891,7 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     const viewport = getViewportRef.current()
     setCenterRef.current(targetNode.position.x, targetNode.position.y, {
       zoom: viewport.zoom,
-      duration: 300
+      duration: cameraDuration(300, reducedMotionRef.current)
     })
   }, [])
 
@@ -917,7 +925,7 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     const viewport = getViewportRef.current()
     setCenterRef.current(midX, midY, {
       zoom: viewport.zoom,
-      duration: 300,
+      duration: cameraDuration(300, reducedMotionRef.current),
     })
   }, [])
 
@@ -1771,10 +1779,10 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
 
   // Stable callbacks for CanvasViewportControls — declared unconditionally before
   // any debug-mode early returns to satisfy Rules of Hooks.
-  const handleZoomIn = useCallback(() => zoomInRef.current({ duration: 200 }), [])
-  const handleZoomOut = useCallback(() => zoomOutRef.current({ duration: 200 }), [])
-  const handleZoomReset = useCallback(() => zoomToRef.current(1, { duration: 200 }), [])
-  const handleFitView = useCallback(() => fitViewRef.current({ padding: computeFitPadding(), duration: 300 }), [])
+  const handleZoomIn = useCallback(() => zoomInRef.current({ duration: cameraDuration(200, reducedMotionRef.current) }), [])
+  const handleZoomOut = useCallback(() => zoomOutRef.current({ duration: cameraDuration(200, reducedMotionRef.current) }), [])
+  const handleZoomReset = useCallback(() => zoomToRef.current(1, { duration: cameraDuration(200, reducedMotionRef.current) }), [])
+  const handleFitView = useCallback(() => fitViewRef.current({ padding: computeFitPadding(), duration: cameraDuration(300, reducedMotionRef.current) }), [])
 
   // Canvas debug mode: 'blank' short-circuits the full canvas UI so we can
   // quickly determine whether React 185 is coming from inside the canvas

--- a/src/canvas/components/CommandPalette.tsx
+++ b/src/canvas/components/CommandPalette.tsx
@@ -8,6 +8,8 @@ import { ValidationBanner, type ValidationError } from './ValidationBanner'
 import { useValidationFeedback } from '../hooks/useValidationFeedback'
 import { trackRunAttempt } from '../utils/sandboxTelemetry'
 import { computeFitPadding } from '../utils/computeFitPadding'
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
+import { cameraDuration } from '../utils/cameraMotion'
 import { typography } from '../../styles/typography'
 
 interface Action {
@@ -44,6 +46,7 @@ export function CommandPalette({ isOpen, onClose, onOpenInspector }: CommandPale
   const edges = useCanvasStore(s => s.edges)
   const { fitView } = useReactFlow()
   const { formatErrors, focusError } = useValidationFeedback()
+  const prefersReducedMotion = usePrefersReducedMotion() // F1: reduced-motion guard for Zoom to Fit
 
   const actions: Action[] = [
     // Analysis actions
@@ -164,7 +167,7 @@ export function CommandPalette({ isOpen, onClose, onOpenInspector }: CommandPale
       }
     }},
     { id: 'select-all', label: 'Select All', shortcut: '⌘A', execute: () => selectAll() },
-    { id: 'zoom-fit', label: 'Zoom to Fit', execute: () => fitView({ padding: computeFitPadding(), duration: 300 }) },
+    { id: 'zoom-fit', label: 'Zoom to Fit', execute: () => fitView({ padding: computeFitPadding(), duration: cameraDuration(300, prefersReducedMotion) }) },
     { id: 'save-snapshot', label: 'Save Snapshot', shortcut: '⌘S', execute: () => saveSnapshot() },
   ]
 

--- a/src/canvas/components/ComparisonCanvasLayout.tsx
+++ b/src/canvas/components/ComparisonCanvasLayout.tsx
@@ -11,6 +11,8 @@ import { X, Link2, Link2Off, Maximize2, Plus, Minus, RefreshCw, Equal, Target } 
 import { useCanvasStore } from '../store'
 import { useComparisonStore } from '../stores/comparisonStore'
 import { MiniCanvas } from './MiniCanvas'
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
+import { cameraDuration } from '../utils/cameraMotion'
 import { typography } from '../../styles/typography'
 import type { ComparisonResult } from '../snapshots/types'
 
@@ -364,6 +366,11 @@ export function ComparisonCanvasLayout() {
   const [syncEnabled, setSyncEnabled] = useState(true)
   const instancesRef = useRef<Array<ReactFlowInstance | null>>([])
 
+  // F1: reduced-motion guard for the comparison "fit all" camera move.
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const reducedMotionRef = useRef(prefersReducedMotion)
+  reducedMotionRef.current = prefersReducedMotion
+
   const setInstance = useCallback((index: number) => (instance: ReactFlowInstance) => {
     instancesRef.current[index] = instance
   }, [])
@@ -381,7 +388,7 @@ export function ComparisonCanvasLayout() {
 
   const fitAll = useCallback(() => {
     instancesRef.current.forEach((instance) => {
-      instance?.fitView({ padding: 0.12, duration: 200 })
+      instance?.fitView({ padding: 0.12, duration: cameraDuration(200, reducedMotionRef.current) })
     })
   }, [])
 

--- a/src/canvas/hooks/useFitViewOnLayoutVersion.ts
+++ b/src/canvas/hooks/useFitViewOnLayoutVersion.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react'
 import { useReactFlow } from '@xyflow/react'
 import { useCanvasStore } from '../store'
 import { computeFitPadding } from '../utils/computeFitPadding'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+import { cameraDuration } from '../utils/cameraMotion'
 
 /**
  * Schedule a single RAF-synchronised fitView every time `layoutVersion`
@@ -22,10 +24,17 @@ export function useFitViewOnLayoutVersion(): void {
   const fitViewRef = useRef(fitView)
   fitViewRef.current = fitView
 
+  // F1: the post-layout auto-fit fires on every layout change, so honour
+  // reduced-motion here too (mirrored to a ref to keep the effect deps = only
+  // layoutVersion — the fit re-runs on layout, not on a preference flip).
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const reducedMotionRef = useRef(prefersReducedMotion)
+  reducedMotionRef.current = prefersReducedMotion
+
   useEffect(() => {
     if (layoutVersion === 0) return
     const raf = requestAnimationFrame(() => {
-      fitViewRef.current({ padding: computeFitPadding(), duration: 400 })
+      fitViewRef.current({ padding: computeFitPadding(), duration: cameraDuration(400, reducedMotionRef.current) })
     })
     return () => cancelAnimationFrame(raf)
   }, [layoutVersion])

--- a/src/canvas/hooks/useHighlightDispatch.ts
+++ b/src/canvas/hooks/useHighlightDispatch.ts
@@ -20,6 +20,8 @@ import { useReactFlow, type Node } from '@xyflow/react'
 import { useCanvasStore } from '../store'
 import type { Highlight, HighlightGroup } from '../../types/primitives'
 import { mapHighlightIds } from '../../lib/idMapping'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+import { cameraDuration } from '../utils/cameraMotion'
 
 /**
  * Hook return type
@@ -85,6 +87,13 @@ export function useHighlightDispatch(): UseHighlightDispatchReturn {
   // ReactFlow viewport controls
   const { fitView, setCenter, getNodes } = useReactFlow()
 
+  // F1: honour reduced-motion on the panning camera moves below. Mirrored to
+  // a ref so the memoised callbacks stay dependency-stable (they already use
+  // the empty-deps + latest-value pattern for the same reason).
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const reducedMotionRef = useRef(prefersReducedMotion)
+  reducedMotionRef.current = prefersReducedMotion
+
   // Track timeouts for auto-clear
   const timeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
 
@@ -108,7 +117,7 @@ export function useHighlightDispatch(): UseHighlightDispatchReturn {
         fitView({
           nodes: targetNodes,
           padding: 0.2,
-          duration: 300,
+          duration: cameraDuration(300, reducedMotionRef.current),
           maxZoom: 1.5, // Don't zoom in too much
         })
       }
@@ -145,7 +154,7 @@ export function useHighlightDispatch(): UseHighlightDispatchReturn {
       const avgX = connectedNodes.reduce((sum, n) => sum + n.position.x, 0) / connectedNodes.length
       const avgY = connectedNodes.reduce((sum, n) => sum + n.position.y, 0) / connectedNodes.length
 
-      setCenter(avgX, avgY, { duration: 300, zoom: 1 })
+      setCenter(avgX, avgY, { duration: cameraDuration(300, reducedMotionRef.current), zoom: 1 })
     } catch (error) {
       // ReactFlow might not be ready, ignore error
       if (import.meta.env.DEV) {

--- a/src/canvas/hooks/useSyncedViewports.ts
+++ b/src/canvas/hooks/useSyncedViewports.ts
@@ -7,6 +7,8 @@
 
 import { useCallback, useRef, useEffect } from 'react'
 import type { ReactFlowInstance, Viewport, OnMoveEnd } from '@xyflow/react'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+import { cameraDuration } from '../utils/cameraMotion'
 
 interface UseSyncedViewportsOptions {
   /** Debounce delay in ms to prevent sync loops (default: 50) */
@@ -49,6 +51,11 @@ export function useSyncedViewports(
   // Store ReactFlow instances
   const instanceARef = useRef<ReactFlowInstance | null>(null)
   const instanceBRef = useRef<ReactFlowInstance | null>(null)
+
+  // F1: reduced-motion guard for the synced "fit both" camera moves.
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const reducedMotionRef = useRef(prefersReducedMotion)
+  reducedMotionRef.current = prefersReducedMotion
 
   // Track which canvas initiated the last sync to prevent loops
   const syncSourceRef = useRef<'A' | 'B' | null>(null)
@@ -148,8 +155,8 @@ export function useSyncedViewports(
     // Suppress sync so each canvas fits to its own content independently
     suppressSyncRef.current = true
 
-    instanceARef.current?.fitView({ padding: 0.1, duration: 200 })
-    instanceBRef.current?.fitView({ padding: 0.1, duration: 200 })
+    instanceARef.current?.fitView({ padding: 0.1, duration: cameraDuration(200, reducedMotionRef.current) })
+    instanceBRef.current?.fitView({ padding: 0.1, duration: cameraDuration(200, reducedMotionRef.current) })
 
     // Re-enable sync after fit animations complete (200ms duration + buffer)
     setTimeout(() => {

--- a/src/canvas/utils/__tests__/cameraMotion.spec.ts
+++ b/src/canvas/utils/__tests__/cameraMotion.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { cameraDuration } from '../cameraMotion'
+
+describe('cameraDuration — F1 reduced-motion camera guard', () => {
+  it('preserves the base duration when reduced motion is off', () => {
+    expect(cameraDuration(300, false)).toBe(300)
+    expect(cameraDuration(200, false)).toBe(200)
+  })
+
+  it('collapses to an instant jump (0ms) when reduced motion is on', () => {
+    expect(cameraDuration(300, true)).toBe(0)
+    expect(cameraDuration(200, true)).toBe(0)
+    expect(cameraDuration(0, true)).toBe(0)
+  })
+})

--- a/src/canvas/utils/cameraMotion.ts
+++ b/src/canvas/utils/cameraMotion.ts
@@ -1,0 +1,18 @@
+/**
+ * cameraMotion — graph-visuals F1 (Paul's 2026-07-11 verdict): honour the OS
+ * "reduce motion" setting on programmatic camera moves.
+ *
+ * ReactFlow's setCenter/fitView/zoomTo animate for a hardcoded duration
+ * (300ms focus/fit, 200ms zoom). CSS transitions already respect
+ * prefers-reduced-motion, but these imperative camera moves do not — a
+ * motion-sensitive user still gets every focus/fit/zoom animated. This is
+ * the single guard every camera call site routes its duration through, so a
+ * duration of 0 (an instant jump) is used whenever reduced motion is set.
+ *
+ * Pure and side-effect-free: the caller supplies the live reduced-motion
+ * flag (from usePrefersReducedMotion, mirrored to a ref at the imperative
+ * sites) so this stays trivially testable and never reads matchMedia itself.
+ */
+export function cameraDuration(baseMs: number, prefersReducedMotion: boolean): number {
+  return prefersReducedMotion ? 0 : baseMs
+}


### PR DESCRIPTION
First lane of the graph-visuals track (Paul's 2026-07-11 verdicts). **F1** — the a11y camera guard.

## What
ReactFlow's imperative camera moves (setCenter / fitView / zoomTo) animate for a hardcoded duration and ignore the OS 'reduce motion' setting, unlike CSS transitions. A single pure guard `cameraDuration(base, reduced)` routes every camera duration → 0ms (instant jump) under reduced-motion.

## Complete manifest of live animated camera moves guarded
- `ReactFlowGraph`: focus node, focus edge, zoom in/out/reset, fit view
- `useHighlightDispatch`: panToNodes, panToEdges
- `useFitViewOnLayoutVersion`: the post-layout auto-fit (fires on every layout change)
- `CommandPalette`: Zoom to Fit
- `ComparisonCanvasLayout.fitAll` + `useSyncedViewports.fitBoth` (Compare tab)

MiniCanvas already used 0; CanvasToolbar is dead (verified no mounts) so untouched.

## Not in this lane
F2 (neighbourhood-fit focus), F3 (focus dimming — **overlaps** existing `usePathHighlight` dimming), F4 (multi-target fit — **conflicts** with `appliedEditPulse`'s deliberate 'no viewport pan / don't hijack' contract). These have real interactions the scoping pass under-weighted; they get their own careful treatment.

## Gates
ci typecheck clean · cameraMotion unit test + layout-lifecycle (400ms preserved) + RFG dom + comparison specs pass · lint 0 errors · wide tsc diff vs base clean. Base durations unchanged when reduced-motion is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)