### PR TITLE
N1: per-type selection ring (graph-visuals lane G2a)

### DIFF
--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -265,7 +265,7 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         ${isCausalLens ? (causalBorderClass ?? '') : isIncomplete ? 'border-warning border-dashed' : borderClassOverride ?? `${colors.border} ${borderStyle}`}
         transition-all duration-200
         cursor-default
-        ${selected ? 'ring-2 ring-info ring-offset-2' : ''}
+        ${selected && !isHighlighted ? `${colors.selected} ring-offset-2` : ''}
         ${isHighlighted ? 'ring-4 ring-goal/50' : ''}
         ${isLensDimmed ? 'opacity-20' : isDimmed ? 'opacity-60' : ''}
       `}

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -1108,3 +1108,57 @@ describe('OptionNode — is_baseline rendering', () => {
     expect(screen.queryByText(/No changes to factors/i)).toBeNull()
   })
 })
+
+describe('N1 — per-type selection ring', () => {
+  const nodeState = (highlightedIds: string[] = []) => ({
+    hoveredOptionId: null,
+    nodes: [],
+    edges: [],
+    ceeAnalysisReady: null,
+    results: { status: 'idle', report: null },
+    highlightedNodes: new Set(highlightedIds),
+    dimmedNodeIds: new Set(),
+    lens: { _dimmedNodeIds: new Set(), _hiddenNodeIds: new Set(), active: 'full' },
+    goalThreshold: null,
+    goalConstraints: [],
+    setHoveredOption: vi.fn(),
+    runMeta: { ceeReview: null },
+    viewMode: 'expert',
+  })
+  const applyState = (highlightedIds: string[] = []) =>
+    vi.mocked(useCanvasStore).mockImplementation((sel: any) => sel(nodeState(highlightedIds)))
+
+  // @xyflow/react NodeProps require these; baseFactorProps predates that.
+  const selProps = { ...baseFactorProps, selected: true, draggable: false, selectable: true, deletable: true }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null, influence: null, confidence: null, inSensitivityAnalysis: false,
+      achievementProbability: null, stabilityPercentage: null, winRate: null, isResultsMode: false,
+    } as any)
+  })
+
+  it('a selected factor node wears the factor-type ring, not the old hardcoded info ring', () => {
+    applyState()
+    render(<ReactFlowProvider><FactorNode {...selProps} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    const group = screen.getAllByRole('group')[0]
+    expect(group.className).toContain('ring-factor/50')
+    expect(group.className).not.toContain('ring-info')
+  })
+
+  it('a selected risk node wears the danger-type ring', () => {
+    applyState()
+    render(<ReactFlowProvider><RiskNode {...selProps} id="risk-1" type="risk" data={{ label: 'Attrition' }} /></ReactFlowProvider>)
+    const group = screen.getAllByRole('group')[0]
+    expect(group.className).toContain('ring-danger/50')
+  })
+
+  it('selected + AI-highlighted: the highlight ring wins, the per-type selection ring is suppressed', () => {
+    applyState(['factor-1'])
+    render(<ReactFlowProvider><FactorNode {...selProps} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    const group = screen.getAllByRole('group')[0]
+    expect(group.className).toContain('ring-goal/50')
+    expect(group.className).not.toContain('ring-factor/50')
+  })
+})


### PR DESCRIPTION
Second graph-visuals lane (Paul's 2026-07-11 verdict N1).

## What
The selection ring was a hardcoded `ring-2 ring-info` for every node type — so "what am I on?" read the same blue whatever you selected. The DS already defines per-type selection colours (`nodeColors[type].selected`) but they were **defined-but-unused**. This wires them in: a selected factor rings factor-purple, a risk rings danger-red, etc.

## Interaction handled
The AI-highlight ring (goal amber) is also `ring-4`, so I gated the selection ring on `!isHighlighted` — the highlight now deterministically wins when a node is both selected and highlighted (previously it was CSS-source-order luck).

## Pins (render-matrix)
selected factor → `ring-factor/50` not `ring-info`; selected risk → `ring-danger/50`; selected+highlighted → highlight wins, per-type ring suppressed.

## Gates
ci typecheck clean · render-matrix 50/50 · lint 0 errors · wide tsc diff vs base clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)