### PR TITLE
E2: show key edge labels in the default view (graph-visuals lane G3, part 1)

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -22,6 +22,7 @@ import { NodeChip } from '../nodes/shared'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { useShallow } from 'zustand/react/shallow'
 import type { EdgeData, EdgePathType } from '../domain/edges'
+import { shouldShowEdgeLabel } from './edgeLabelVisibility'
 import { applyEdgeVisualProps } from '../theme/edges'
 import { formatConfidence, shouldShowLabel, getEdgeConfidence, computeSignedMean } from '../domain/edges'
 import { useIsDark } from '../hooks/useTheme'
@@ -513,9 +514,20 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     return { dx: 0, dy: 0 }
   }, [isTopStrengthEdge, source, target, getNode, labelX, labelY, sourceX, sourceY, targetX, targetY])
 
-  // C1: Edge labels only in Detailed view, post-analysis
-  // Structural edges (decision→option, option→factor) never show causal labels
-  const showLabel = viewMode !== 'standard' && isResultsMode && !isStructuralEdge && (selected || isHovered || hasSuggestion || (isFirstEdge && showEdgeHint) || isTopStrengthEdge)
+  // C1 + E2: label-visibility policy (see edgeLabelVisibility.ts). Top-strength
+  // labels surface in the default (standard) view once results exist; the
+  // interaction-driven triggers stay Detailed/Model-only.
+  const showLabel = shouldShowEdgeLabel({
+    viewMode,
+    isResultsMode,
+    isStructuralEdge,
+    isTopStrengthEdge,
+    selected: Boolean(selected),
+    isHovered,
+    hasSuggestion,
+    isFirstEdge,
+    showEdgeHint: Boolean(showEdgeHint),
+  })
 
   // Causal lens: hide structural edges entirely
   if (isLensHidden) return null

--- a/src/canvas/edges/__tests__/edgeLabelVisibility.spec.ts
+++ b/src/canvas/edges/__tests__/edgeLabelVisibility.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowEdgeLabel, type EdgeLabelVisibilityInput } from '../edgeLabelVisibility'
+
+const base: EdgeLabelVisibilityInput = {
+  viewMode: 'standard',
+  isResultsMode: true,
+  isStructuralEdge: false,
+  isTopStrengthEdge: false,
+  selected: false,
+  isHovered: false,
+  hasSuggestion: false,
+  isFirstEdge: false,
+  showEdgeHint: false,
+}
+
+describe('shouldShowEdgeLabel — E2 top-strength labels in the default view', () => {
+  it('E2: a top-strength edge shows its label in the standard view once results exist', () => {
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'standard', isTopStrengthEdge: true })).toBe(true)
+  })
+
+  it('a non-top-strength edge stays unlabelled in the standard view (no clutter)', () => {
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'standard', selected: true, isHovered: true })).toBe(false)
+  })
+
+  it('requires a completed run — no labels before results, even for top-strength', () => {
+    expect(shouldShowEdgeLabel({ ...base, isResultsMode: false, isTopStrengthEdge: true })).toBe(false)
+  })
+
+  it('structural edges never show a causal label', () => {
+    expect(shouldShowEdgeLabel({ ...base, isStructuralEdge: true, isTopStrengthEdge: true })).toBe(false)
+  })
+
+  it('Detailed view keeps the interaction-driven triggers (unchanged)', () => {
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'expert', selected: true })).toBe(true)
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'expert', isHovered: true })).toBe(true)
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'expert', hasSuggestion: true })).toBe(true)
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'expert', isFirstEdge: true, showEdgeHint: true })).toBe(true)
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'expert' })).toBe(false)
+  })
+
+  it('Detailed view still shows top-strength labels too', () => {
+    expect(shouldShowEdgeLabel({ ...base, viewMode: 'expert', isTopStrengthEdge: true })).toBe(true)
+  })
+})

--- a/src/canvas/edges/edgeLabelVisibility.ts
+++ b/src/canvas/edges/edgeLabelVisibility.ts
@@ -1,0 +1,41 @@
+/**
+ * edgeLabelVisibility — the single policy for when a causal edge renders its
+ * strength label. Extracted from StyledEdge so the rule is explicit and
+ * unit-testable (the component's own render path needs the full ReactFlow +
+ * store harness).
+ *
+ * Baseline (C1): labels require a completed run and a non-structural edge; in
+ * Detailed/Model view the interaction-driven triggers (selection, hover,
+ * pending suggestion, first-edge hint) also show a label.
+ *
+ * E2 (graph-visuals 2026-07-11): the top-strength labels ALSO surface in the
+ * default (standard) view once results exist, so the few key relationships are
+ * legible without switching views. The interaction-driven triggers stay
+ * Detailed-only to keep the default map uncluttered.
+ */
+export interface EdgeLabelVisibilityInput {
+  /** The active graph view mode ('standard' = the default map). */
+  viewMode: string
+  /** True once an analysis run has completed (results.status === 'complete'). */
+  isResultsMode: boolean
+  /** Structural edges (decision→option, option→factor) never show causal labels. */
+  isStructuralEdge: boolean
+  /** True when this edge is among the top-strength causal edges (or ≤3 exist). */
+  isTopStrengthEdge: boolean
+  selected: boolean
+  isHovered: boolean
+  hasSuggestion: boolean
+  isFirstEdge: boolean
+  showEdgeHint: boolean
+}
+
+export function shouldShowEdgeLabel(input: EdgeLabelVisibilityInput): boolean {
+  if (!input.isResultsMode || input.isStructuralEdge) return false
+  // E2: top-strength labels surface in EITHER view once results exist.
+  if (input.isTopStrengthEdge) return true
+  // Interaction-driven triggers remain Detailed/Model-only.
+  return (
+    input.viewMode !== 'standard' &&
+    (input.selected || input.isHovered || input.hasSuggestion || (input.isFirstEdge && input.showEdgeHint))
+  )
+}


### PR DESCRIPTION
Graph-visuals verdict E2 (Paul 2026-07-11).

## What
In the default (standard) view, edge strength labels never rendered — they only appeared in Model/Detailed views. So the key relationships were invisible on the map most users look at. Now the **top-strength labels surface in the standard view once results exist**; the interaction-driven triggers (selection, hover, suggestion, first-edge hint) stay Detailed-only to keep the default map uncluttered.

## How
Extracted the label-visibility rule into a pure `shouldShowEdgeLabel()` predicate (`edgeLabelVisibility.ts`) — the policy is now explicit and unit-testable without StyledEdge's full ReactFlow+store harness, and gives E3 (label collision avoidance) a clean seam. Wide-tsc caught two loosely-typed EdgeProps fields (`selected`, `showEdgeHint` typed `{}`) that the boolean interface rejected — coerced at the call site.

## Lane note
Part 1 of G3 (edges). E3/E4 follow (StyledEdge, sequential). **E1 (recolour) is blocked** on your distinct-hue decision + ΔE validation.

## Gates
ci typecheck clean · edgeLabelVisibility 6/6 · existing StyledEdge specs 17/17 · lint 0 errors · wide tsc diff vs base clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)