### PR TITLE
E4: surface the top fragility on the default map (graph-visuals G3)

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -31,7 +31,7 @@ import { useEdgeLabelMode } from '../store/edgeLabelMode'
 import { EdgeEditPopover } from './EdgeEditPopover'
 import { useCanvasStore } from '../store'
 import { isGraphLensEnabled } from '../../flags'
-import { isEdgeFragile as isEdgeFragileFn, getFragileEdgeSwitchProbability } from '../utils/fragileEdgeMatch'
+import { isEdgeFragile as isEdgeFragileFn, getFragileEdgeSwitchProbability, isTopFragileEdge as isTopFragileEdgeFn } from '../utils/fragileEdgeMatch'
 import { existenceCertaintyToLineStyle, calculateEdgeImportance, importanceToStrokeWidth, weightMagnitudeToStrokeWidth } from '../utils/graphDisplayCalculations'
 import { typography } from '../../styles/typography'
 import { getStrengthDescription, getProvenanceLabel } from '../ui/inspector-v2/inspectorStrings'
@@ -156,6 +156,16 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     if (!isFragileEdge || !report?.robustness) return null
     const fragileEdges = report.robustness.fragile_edges || []
     return getFragileEdgeSwitchProbability(id, source, target, fragileEdges)
+  }, [isFragileEdge, report, id, source, target])
+
+  // E4 (graph-visuals): the SINGLE most fragile relationship earns a fragility
+  // badge in the default (standard) view too, so the top flip risk is visible
+  // on the map without switching to Detailed. Every fragile edge still badges
+  // in Detailed/Model view (below).
+  const isTopFragileEdge = useMemo(() => {
+    if (!isFragileEdge || !report?.robustness) return false
+    const fragileEdges = report.robustness.fragile_edges || []
+    return isTopFragileEdgeFn(id, source, target, fragileEdges)
   }, [isFragileEdge, report, id, source, target])
 
   // Extract edge data with defaults
@@ -717,10 +727,11 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         </EdgeLabelRenderer>
       )}
 
-      {/* Decision Graph Display v2 Task 4: Fragile edge warning badge (Results mode, Model view only) */}
-      {/* Decision view: no fragile badges (Phase 1) */}
-      {/* Structural edges are not analysed — fragility is meaningless. */}
-      {viewMode !== 'standard' && isFragileEdge && !isStructuralEdge && (
+      {/* Fragile edge warning badge. Detailed/Model view: every fragile edge.
+          E4 (graph-visuals): the default (standard) view shows the SINGLE top
+          fragile relationship so the key flip risk is on the map by default,
+          uncluttered. Structural edges are not analysed — never badged. */}
+      {(viewMode !== 'standard' ? isFragileEdge : isTopFragileEdge) && !isStructuralEdge && (
         <EdgeLabelRenderer>
           <div
             style={{

--- a/src/canvas/utils/__tests__/fragileEdgeMatch.spec.ts
+++ b/src/canvas/utils/__tests__/fragileEdgeMatch.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { isEdgeFragile, getFragileEdgeSwitchProbability, type FragileEdgeCandidate } from '../fragileEdgeMatch'
+import { isEdgeFragile, getFragileEdgeSwitchProbability, isTopFragileEdge, type FragileEdgeCandidate } from '../fragileEdgeMatch'
 
 const ABOVE = 0.42
 const AT_THRESHOLD = 0.15 // Spec Section 6.3: threshold = 0.15
@@ -112,3 +112,42 @@ describe('fragileEdgeMatch — QA Brief G-series boundary cases', () => {
     expect(Math.round((prob ?? 0) * 100)).toBe(42)
   })
 })
+
+describe('isTopFragileEdge — E4 single default-view fragility badge', () => {
+  const set: FragileEdgeCandidate[] = [
+    { edge_id: 'e1', switch_probability: 0.35 },
+    { edge_id: 'e2', switch_probability: 0.62 },
+    { edge_id: 'e3', switch_probability: 0.4 },
+  ]
+
+  it('is true only for the highest-switch-probability fragile edge', () => {
+    expect(isTopFragileEdge('e2', 'a', 'b', set)).toBe(true)
+    expect(isTopFragileEdge('e1', 'a', 'b', set)).toBe(false)
+    expect(isTopFragileEdge('e3', 'a', 'b', set)).toBe(false)
+  })
+
+  it('ignores entries below the visibility floor when picking the top', () => {
+    const withBelowFloor: FragileEdgeCandidate[] = [
+      { edge_id: 'e1', switch_probability: 0.9 } as FragileEdgeCandidate, // below floor? no — 0.9 is above
+    ]
+    // A single above-floor entry is the top.
+    expect(isTopFragileEdge('e1', 'a', 'b', withBelowFloor)).toBe(true)
+    // An edge that is only below-floor is never the top.
+    expect(isTopFragileEdge('e9', 'x', 'y', [{ edge_id: 'e9', switch_probability: 0.1 }])).toBe(false)
+  })
+
+  it('returns false when nothing is fragile above the floor', () => {
+    expect(isTopFragileEdge('e1', 'a', 'b', [])).toBe(false)
+    expect(isTopFragileEdge('e1', 'a', 'b', [{ edge_id: 'e1', switch_probability: 0.05 }])).toBe(false)
+  })
+
+  it('matches by source/target pair when edge_id is absent', () => {
+    const bySrcTgt: FragileEdgeCandidate[] = [
+      { from_id: 'a', to_id: 'b', switch_probability: 0.7 },
+      { from_id: 'c', to_id: 'd', switch_probability: 0.5 },
+    ]
+    expect(isTopFragileEdge('anyid', 'a', 'b', bySrcTgt)).toBe(true)
+    expect(isTopFragileEdge('anyid', 'c', 'd', bySrcTgt)).toBe(false)
+  })
+})
+

--- a/src/canvas/utils/fragileEdgeMatch.ts
+++ b/src/canvas/utils/fragileEdgeMatch.ts
@@ -49,6 +49,37 @@ export function isEdgeFragile(
   })
 }
 
+/** The switch probability an entry reports (above the visibility floor), else null. */
+function entrySwitchProb(fe: FragileEdgeCandidate): number | null {
+  const p = fe.switch_probability ?? fe.switchProbability ??
+            fe.marginal_switch_probability ?? fe.marginalSwitchProbability
+  return typeof p === 'number' && p > THRESHOLDS.FRAGILE_EDGE_FILTER ? p : null
+}
+
+/**
+ * Whether this edge is THE single top fragile relationship — the one with the
+ * highest switch probability above the visibility floor. Used to surface one
+ * fragility badge in the default (standard) view (E4 graph-visuals) without
+ * cluttering the map with every fragile edge. On a tie, the first entry wins
+ * (deterministic — a >, not >=, comparison). Returns false when nothing is
+ * fragile above the floor.
+ */
+export function isTopFragileEdge(
+  edgeId: string,
+  edgeSource: string,
+  edgeTarget: string,
+  fragileEdges: FragileEdgeCandidate[],
+): boolean {
+  let top: FragileEdgeCandidate | null = null
+  let topProb = -Infinity
+  for (const fe of fragileEdges) {
+    const p = entrySwitchProb(fe)
+    if (p != null && p > topProb) { topProb = p; top = fe }
+  }
+  if (!top) return false
+  return isEdgeFragile(edgeId, edgeSource, edgeTarget, [top])
+}
+
 /**
  * Return the switch_probability for a matching fragile edge, or null if not found.
  * Used to display the numeric sensitivity detail (Task 7).


### PR DESCRIPTION
Verdict E4. The fragile-edge badge only rendered in Model/Detailed view; the default map never warned. Now the **single most fragile relationship** (highest switch probability above the floor) badges in the standard view too — the top flip risk on the map by default, uncluttered. Detailed view still badges every fragile edge. New pure `isTopFragileEdge()` (reuses `isEdgeFragile` matching; first-wins ties). Pairs with the analysis panel's 'Top flip risk' quick link.

Gates: ci typecheck clean · fragileEdgeMatch + StyledEdge specs 38/38 · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)