### PR TITLE
N2: a real pulse for AI highlights, in the info hue (graph-visuals G2)

### DIFF
--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -266,7 +266,7 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         transition-all duration-200
         cursor-default
         ${selected && !isHighlighted ? `${colors.selected} ring-offset-2` : ''}
-        ${isHighlighted ? 'ring-4 ring-goal/50' : ''}
+        ${isHighlighted ? 'ring-4 ring-info/60 ai-highlight-pulse' : ''}
         ${isLensDimmed ? 'opacity-20' : isDimmed ? 'opacity-60' : ''}
       `}
       style={{

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -1158,7 +1158,23 @@ describe('N1 — per-type selection ring', () => {
     applyState(['factor-1'])
     render(<ReactFlowProvider><FactorNode {...selProps} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
     const group = screen.getAllByRole('group')[0]
-    expect(group.className).toContain('ring-goal/50')
+    // N2: the AI-highlight ring is the info/AI hue (not goal) and wins over selection.
+    expect(group.className).toContain('ring-info/60')
     expect(group.className).not.toContain('ring-factor/50')
+  })
+
+  it('N2: an AI-highlighted node gets the real pulse class (reduced-motion-safe in CSS)', () => {
+    applyState(['factor-1'])
+    render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    const group = screen.getAllByRole('group')[0]
+    expect(group.className).toContain('ai-highlight-pulse')
+    expect(group.className).toContain('ring-info/60')
+  })
+
+  it('N2: a non-highlighted node has no pulse', () => {
+    applyState([])
+    render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    const group = screen.getAllByRole('group')[0]
+    expect(group.className).not.toContain('ai-highlight-pulse')
   })
 })

--- a/src/canvas/utils/appliedEditPulse.ts
+++ b/src/canvas/utils/appliedEditPulse.ts
@@ -15,8 +15,10 @@ import { useCanvasStore } from '../store'
 //   ids not on the canvas (e.g. removals) never pulse. An all-stale flush
 //   writes nothing (never clobbers an existing highlight with emptiness).
 // - Pulse only: no selection, no inspector, no viewport pan — the AI must
-//   not hijack what the user is doing. The ring itself is static (BaseNode
-//   ring-4 / StyledEdge stroke), so it is inherently reduced-motion-safe.
+//   not hijack what the user is doing. The node ring gently pulses (N2,
+//   BaseNode `ai-highlight-pulse`) and the edge stroke is static; both are
+//   reduced-motion-safe (the pulse keyframe is disabled under
+//   prefers-reduced-motion, leaving the static ring).
 
 export const PULSE_COALESCE_MS = 100
 export const PULSE_DURATION_MS = 2000

--- a/src/index.css
+++ b/src/index.css
@@ -411,6 +411,35 @@
   }
 }
 
+/* N2 (graph-visuals): a gentle real pulse when the AI points at a node
+   (applied edits, what-changed, R4 directives). Uses the info/AI colour
+   (--info #52A3C8) so it does not overload the goal channel, and its OWN
+   keyframe — it must NOT reuse pulse-fade, which powers .animate-pulse on
+   15+ skeleton/status components. The Tailwind ring on the node stays
+   visible; this only adds the expanding halo. Reduced-motion drops the
+   animation and leaves the static ring, so the highlight is still legible. */
+@keyframes ai-highlight-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(82, 163, 200, 0.55);
+  }
+  70% {
+    box-shadow: 0 0 0 8px rgba(82, 163, 200, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(82, 163, 200, 0);
+  }
+}
+
+.ai-highlight-pulse {
+  animation: ai-highlight-pulse 1.8s ease-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-highlight-pulse {
+    animation: none;
+  }
+}
+
 .edge-hint-active {
   animation: edge-hint-pulse 1.5s ease-out infinite;
 }


### PR DESCRIPTION
Verdict N2. When the AI points at a node, the 'pulse' was a static ring for 2s — easy to miss. Now a gentle real pulse (expanding halo), and the ring moves off the goal/amber channel onto the **info/AI hue** so an AI action no longer reads as a goal signal.

- New `ai-highlight-pulse` keyframe — its OWN keyframe, NOT a reuse of `pulse-fade` (which powers `.animate-pulse` on 15+ skeletons, concern C1).
- Reduced-motion drops the animation, keeps the static ring (media query).
- Updated the N1 highlight test (goal→info) + `appliedEditPulse`'s stale 'ring is static' comment.

Gates: ci typecheck clean · render-matrix 52/52 · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)