### PR TITLE
docs(claude): retire UI-SEM rows citing the deleted HeroSection.tsx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ pnpm run build                      # production build (separate concern)
 | UI-SEM-018 | `src/canvas/components/UnifiedStatusBadge.tsx:49` | Confidence score fabrication (high=0.8, medium=0.5, low=0.3) + status thresholds | Remove when PLoT provides numeric confidence |
 | UI-SEM-019 | `src/components/results/useResultsSectionData.ts:537` | Readiness/confidence taxonomy mapping (varied PLoT labels → strong/fair/needs_work) | Remove when PLoT provides canonical tier enum |
 | UI-SEM-020 | `src/canvas/hooks/useStagePill.ts` | Stage derivation from canvas state (no graph=frame, graph=ideate, complete=evaluate) | Remove when orchestrator provides envelope.stage_indicator |
-| UI-SEM-021 | `src/components/results/HeroSection.tsx:258` | Suppress coaching copy containing "robust"/"ready to proceed" when robustness level is low/very_low | Remove when PLoT/CEE provides robustness-conditioned coaching copy |
+| UI-SEM-021 | _`HeroSection.tsx` removed (288a2b74)_ | Suppress coaching copy containing "robust"/"ready to proceed" when robustness level is low/very_low | **Retired with the component** — the old results hero was deleted; the analysis-hero replacement is producer-gated (coaching copy is not threshold-derived). ID retained for history |
 | UI-SEM-022 | `src/canvas/components/DraftChat.tsx:505` | Direction inference from signed weight when CEE omits effect_direction | Keep — defensive fallback (remove when CEE guarantees direction) |
 | UI-SEM-023 | `src/canvas/components/DraftChat.tsx:519` | Weight magnitude clamped to [0, 2] range | Keep — prevents out-of-range values |
 | UI-SEM-024 | `src/canvas/components/DraftChat.tsx:543` | Belief confidence clamped to [0, 1] | Keep — normalisation |
@@ -204,10 +204,10 @@ pnpm run build                      # production build (separate concern)
 | UI-SEM-038 | `src/canvas/utils/applyDraftResult.ts:74` | Duplicate of UI-SEM-023/024/025 on alternate ingestion path | Keep — normalisation |
 | UI-SEM-039 | `src/components/results/useResultsSectionData.ts:538` | Driver semantic label thresholds (0.50 strong, 0.20 moderate) | Remove when PLoT provides semantic labels per driver |
 | UI-SEM-040 | `src/components/results/useResultsSectionData.ts:1601` | Dominance detection heuristic (>0.5 influence AND ratio >2:1) | Remove when PLoT provides dominant_factor in all responses |
-| UI-SEM-041 | `src/components/results/HeroSection.tsx:175` | Stability UI label thresholds (0.85/0.70/0.55) | Remove when PLoT provides stability labels directly |
-| UI-SEM-042 | `src/components/results/HeroSection.tsx:243` | Fragility ratio threshold (>0.7) for trust reason | Remove when PLoT provides trust reason directly |
-| UI-SEM-043 | `src/components/results/HeroSection.tsx:250` | Evidence quality threshold (<0.5) for trust reason | Remove when PLoT provides trust reason directly |
-| UI-SEM-044 | `src/components/results/HeroSection.tsx:259` | Border colour classification from stability (0.7/0.4) | Remove when PLoT guarantees robustnessLevel |
+| UI-SEM-041 | _`HeroSection.tsx` removed (288a2b74)_ | Stability UI label thresholds (0.85/0.70/0.55) | **Retired with the component** — analysis-hero's Stability lens is producer-gated (no live data), not threshold-derived. ID retained for history |
+| UI-SEM-042 | _`HeroSection.tsx` removed (288a2b74)_ | Fragility ratio threshold (>0.7) for trust reason | **Retired with the component** — analysis-hero consumes a producer `trustLine` (null on the live path, `buildHeroModel.ts`), not a threshold-derived reason. ID retained for history |
+| UI-SEM-043 | _`HeroSection.tsx` removed (288a2b74)_ | Evidence quality threshold (<0.5) for trust reason | **Retired with the component** — analysis-hero consumes a producer `trustLine` (null on the live path), not a threshold-derived reason. ID retained for history |
+| UI-SEM-044 | _`HeroSection.tsx` removed (288a2b74)_ | Border colour classification from stability (0.7/0.4) | **Retired with the component** — the old results hero was deleted; the analysis-hero replacement does not classify its border from stability thresholds (it is producer-gated). ID retained for history |
 | UI-SEM-045 | `src/components/results/DriversSection.tsx:175` | Rank flip warning gate (>0.3) | Remove when PLoT provides visibility gate |
 | UI-SEM-046 | `src/components/results/DriversSection.tsx:212` | Elasticity display scaling (x10, floor 1) | Remove when PLoT provides shift percentage |
 | UI-SEM-047 | `src/components/results/DriversSection.tsx:356` | Confidence clamped to [0, 1] | Keep — normalisation |


### PR DESCRIPTION
Suggested task. UI-SEM-021 and 041-044 cited `src/components/results/HeroSection.tsx`, deleted in 288a2b74 when the old results hero was replaced by the analysis-hero module. Verified (grep) none of the five threshold transforms were carried into analysis-hero as the same logic — the replacement is producer-gated (`trustLine` null live; Stability lens has no live data). So: **retired-with-the-component**, not moved. Marked all five Retired (IDs retained — UI-SEM ids are stable). Re-verified: no remaining UI-SEM row cites a nonexistent file. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)