### PR TITLE
F2: focus fits the node + neighbourhood to a readable zoom (graph-visuals G1)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -11,6 +11,7 @@ import { parseRunHash } from './utils/shareLink'
 import { useInitialLayoutGuard } from './hooks/useInitialLayoutGuard'
 import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
 import { cameraDuration } from './utils/cameraMotion'
+import { neighbourhoodNodeIds } from './utils/focusNeighbourhood'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
 import { useFitViewOnLayoutVersion } from './hooks/useFitViewOnLayoutVersion'
 import { nodeTypes } from './nodes/registry'
@@ -887,11 +888,17 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     // Select node WITHOUT pushing to history (navigation-only, not structural change)
     store.selectNodeWithoutHistory(nodeId)
 
-    // Center viewport on the node with smooth animation
-    const viewport = getViewportRef.current()
-    setCenterRef.current(targetNode.position.x, targetNode.position.y, {
-      zoom: viewport.zoom,
-      duration: cameraDuration(300, reducedMotionRef.current)
+    // F2 (graph-visuals): fit the node AND its direct neighbours to a readable
+    // zoom (capped so it never disorients), rather than centring at the current
+    // zoom — focusing from a zoomed-out view used to land on something you
+    // couldn't read. usePathHighlight dims the rest of the graph.
+    const focusIds = neighbourhoodNodeIds(nodeId, store.edges)
+    const focusNodes = store.nodes.filter(n => focusIds.has(n.id))
+    fitViewRef.current({
+      nodes: focusNodes,
+      padding: 0.3,
+      maxZoom: 1.2,
+      duration: cameraDuration(400, reducedMotionRef.current),
     })
   }, [])
 

--- a/src/canvas/utils/__tests__/focusNeighbourhood.spec.ts
+++ b/src/canvas/utils/__tests__/focusNeighbourhood.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { neighbourhoodNodeIds } from '../focusNeighbourhood'
+
+const edges = [
+  { source: 'a', target: 'g' },
+  { source: 'b', target: 'g' },
+  { source: 'c', target: 'a' },
+  { source: 'd', target: 'e' },
+]
+
+describe('neighbourhoodNodeIds — F2 focus neighbourhood', () => {
+  it('includes the node itself plus every directly connected node (either direction)', () => {
+    // a → g (out), c → a (in) ⇒ {a, g, c}
+    expect([...neighbourhoodNodeIds('a', edges)].sort()).toEqual(['a', 'c', 'g'])
+  })
+
+  it('collects neighbours across multiple incident edges', () => {
+    // g receives a and b ⇒ {g, a, b}
+    expect([...neighbourhoodNodeIds('g', edges)].sort()).toEqual(['a', 'b', 'g'])
+  })
+
+  it('returns just the node when it has no incident edges', () => {
+    expect([...neighbourhoodNodeIds('lonely', edges)]).toEqual(['lonely'])
+  })
+
+  it('handles an empty graph', () => {
+    expect([...neighbourhoodNodeIds('x', [])]).toEqual(['x'])
+  })
+})

--- a/src/canvas/utils/focusNeighbourhood.ts
+++ b/src/canvas/utils/focusNeighbourhood.ts
@@ -1,0 +1,19 @@
+/**
+ * focusNeighbourhood — F2 (graph-visuals): when the user focuses a node (from a
+ * driver row, a chat pill, or Alt+V validation cycling), the camera should fit
+ * the node AND its direct neighbours to a readable zoom, rather than centre on
+ * it at whatever zoom the user happened to be at. This returns the id set to
+ * fit; the caller passes the matching node objects to ReactFlow's fitView with
+ * a maxZoom cap so it never disorients.
+ */
+export function neighbourhoodNodeIds(
+  nodeId: string,
+  edges: ReadonlyArray<{ source: string; target: string }>,
+): Set<string> {
+  const ids = new Set<string>([nodeId])
+  for (const e of edges) {
+    if (e.source === nodeId) ids.add(e.target)
+    if (e.target === nodeId) ids.add(e.source)
+  }
+  return ids
+}


### PR DESCRIPTION
Verdict F2. Focus centred the node but kept your current zoom — from zoomed-out you focused on something unreadable. Now focus **fits the node and its direct neighbours** to a readable zoom, capped (maxZoom 1.2) so it never disorients; `usePathHighlight` already dims the rest. New pure `neighbourhoodNodeIds()` helper.

**F3 already delivered** (usePathHighlight dims off-path nodes on selection; focus selects). **F4 deferred** — conflicts with appliedEditPulse's explicit no-hijack contract; needs the pan-only-on-user-initiated reconciliation, not quick wiring.

Gates: ci typecheck clean · focusNeighbourhood 4/4 · RFG specs 6/6 · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)