### PR TITLE
E1: CVD-aware polarity edge recolour — negatives get a distinct hue (graph-visuals G3)

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -23,6 +23,7 @@ import { useGuidanceStore } from '../stores/guidanceStore'
 import { useShallow } from 'zustand/react/shallow'
 import type { EdgeData, EdgePathType } from '../domain/edges'
 import { shouldShowEdgeLabel } from './edgeLabelVisibility'
+import { computeDirectionStroke } from './directionStroke'
 import { applyEdgeVisualProps } from '../theme/edges'
 import { formatConfidence, shouldShowLabel, getEdgeConfidence, computeSignedMean } from '../domain/edges'
 import { useIsDark } from '../hooks/useTheme'
@@ -257,30 +258,13 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     return importanceToStrokeWidth(importance, maxImportance)
   }, [isResultsMode, report, source, edgeData?.beliefExists, weight, getEdges, edgeData?.direction])
 
-  // F.2: Direction-based stroke colour — applies both pre-run and post-run
-  // Yellow is strictly reserved for truly uninitialised edges (no direction AND no weight).
-  // If weight is defined but direction is not, use grey (not yellow).
-  const directionStroke = useMemo(() => {
-    const rawWeight = edgeData?.weight
-    // Truly uninitialised: no direction AND weight is undefined → yellow
-    if (direction === undefined && rawWeight === undefined) {
-      return 'var(--goal)'
-    }
-    // Weight defined but direction not yet set → grey (not yellow)
-    if (direction === undefined) {
-      return isDark ? '#a1a1aa' : '#d4d4d8' // Zinc-400/300
-    }
-    // Direction set with positive weight → green
-    if (direction === 'positive' && weight > 0) {
-      return isDark ? '#bbf7d0' : '#a7f3d0' // Pastel green-200/emerald-200
-    }
-    // Direction set with negative weight → red
-    if (direction === 'negative' && weight > 0) {
-      return isDark ? '#FF6B6B' : '#ef4444' // Risk red (matches risk node border)
-    }
-    // Neutral: weight === 0 (valid user choice)
-    return isDark ? '#a1a1aa' : '#d4d4d8' // Zinc-400/300 (grey/ink)
-  }, [direction, weight, edgeData?.weight, isDark])
+  // F.2 + E1: direction-based stroke colour (see directionStroke.ts for the
+  // CVD-aware polarity palette and the ΔE rationale). Applies pre-run and
+  // post-run; one source of truth shared with directionColour.spec.
+  const directionStroke = useMemo(
+    () => computeDirectionStroke(direction, weight, edgeData?.weight, isDark),
+    [direction, weight, edgeData?.weight, isDark],
+  )
 
   // Decision Graph Display v2: Existence certainty line style
   // Solid: >70%, Dashed: 40-70%, Dotted: <40%

--- a/src/canvas/edges/__tests__/directionColour.spec.ts
+++ b/src/canvas/edges/__tests__/directionColour.spec.ts
@@ -1,89 +1,55 @@
 /**
- * F.2 — Edge direction colour logic (unit tests)
- * Tests the colour rules without rendering StyledEdge (avoids ReactFlow dependency)
+ * F.2 + E1 — Edge direction colour logic (unit tests)
+ * Tests the shared computeDirectionStroke() (no local duplicate — imported from
+ * the same module StyledEdge uses, so the E1 recolour has one source of truth).
  */
 import { describe, it, expect } from 'vitest'
+import { computeDirectionStroke } from '../directionStroke'
 
-/**
- * Pure function replicating the direction stroke logic from StyledEdge.tsx (F.2)
- * Extracted here so the rules can be tested without a full React render.
- * Yellow is strictly reserved for truly uninitialised edges (no direction AND no weight).
- */
-function computeDirectionStroke(
-  direction: 'positive' | 'negative' | undefined,
-  weight: number,
-  rawWeight: number | undefined,
-  isDark: boolean,
-): string {
-  // Truly uninitialised: no direction AND weight is undefined → yellow
-  if (direction === undefined && rawWeight === undefined) {
-    return 'var(--goal)'
-  }
-  // Weight defined but direction not yet set → grey (not yellow)
-  if (direction === undefined) {
-    return isDark ? '#a1a1aa' : '#d4d4d8'
-  }
-  // Direction set with positive weight → green
-  if (direction === 'positive' && weight > 0) {
-    return isDark ? '#bbf7d0' : '#a7f3d0'
-  }
-  // Direction set with negative weight → red
-  if (direction === 'negative' && weight > 0) {
-    return isDark ? '#FF6B6B' : '#ef4444'
-  }
-  // Neutral: weight === 0 (valid user choice)
-  return isDark ? '#a1a1aa' : '#d4d4d8'
-}
-
-describe('directionStroke colour logic (F.2)', () => {
+describe('directionStroke colour logic (F.2 + E1)', () => {
   it('weight=0, direction="positive" → grey (neutral), NOT yellow', () => {
-    const result = computeDirectionStroke('positive', 0, 0, false)
-    expect(result).toBe('#d4d4d8') // Zinc-300 (grey)
+    expect(computeDirectionStroke('positive', 0, 0, false)).toBe('#d4d4d8')
   })
 
   it('weight=undefined, direction=undefined → yellow (truly uninitialised)', () => {
-    const result = computeDirectionStroke(undefined, 1.0, undefined, false)
-    expect(result).toBe('var(--goal)')
+    expect(computeDirectionStroke(undefined, 1.0, undefined, false)).toBe('var(--goal)')
   })
 
-  it('weight=0.5, direction="positive" → green', () => {
-    const result = computeDirectionStroke('positive', 0.5, 0.5, false)
-    expect(result).toBe('#a7f3d0') // emerald-200
+  it('E1: weight=0.5, direction="positive" → the #62B290 green', () => {
+    expect(computeDirectionStroke('positive', 0.5, 0.5, false)).toBe('#62B290')
   })
 
-  it('weight=0.5, direction="negative" → red', () => {
-    const result = computeDirectionStroke('negative', 0.5, 0.5, false)
-    expect(result).toBe('#ef4444') // red-500
+  it('E1: weight=0.5, direction="negative" → rose #D6336C (distinct from amber warning + risk node)', () => {
+    expect(computeDirectionStroke('negative', 0.5, 0.5, false)).toBe('#D6336C')
+    // Guard the C2 ruling: negative must NOT be the amber warning hue, and must
+    // not be the old #ef4444 that collided with the risk-node border.
+    expect(computeDirectionStroke('negative', 0.5, 0.5, false)).not.toBe('#FFA656')
+    expect(computeDirectionStroke('negative', 0.5, 0.5, false)).not.toBe('#ef4444')
   })
 
-  it('weight=0, direction="negative" → grey (neutral), NOT red', () => {
-    const result = computeDirectionStroke('negative', 0, 0, false)
-    expect(result).toBe('#d4d4d8')
+  it('weight=0, direction="negative" → grey (neutral), NOT the polarity colour', () => {
+    expect(computeDirectionStroke('negative', 0, 0, false)).toBe('#d4d4d8')
   })
 
   it('weight=0.5, direction=undefined, rawWeight=0.5 → grey (no direction set)', () => {
-    const result = computeDirectionStroke(undefined, 0.5, 0.5, false)
-    expect(result).toBe('#d4d4d8')
+    expect(computeDirectionStroke(undefined, 0.5, 0.5, false)).toBe('#d4d4d8')
   })
 
   it('weight=0, direction=undefined, rawWeight=0 → grey (weight defined, no direction), NOT yellow', () => {
-    const result = computeDirectionStroke(undefined, 0, 0, false)
-    expect(result).toBe('#d4d4d8')
+    expect(computeDirectionStroke(undefined, 0, 0, false)).toBe('#d4d4d8')
   })
 
   // Dark mode variants
-  it('dark mode: positive → dark green', () => {
-    const result = computeDirectionStroke('positive', 0.5, 0.5, true)
-    expect(result).toBe('#bbf7d0')
+  it('E1: dark mode positive → dark green', () => {
+    expect(computeDirectionStroke('positive', 0.5, 0.5, true)).toBe('#bbf7d0')
   })
 
-  it('dark mode: negative → bright red', () => {
-    const result = computeDirectionStroke('negative', 0.5, 0.5, true)
-    expect(result).toBe('#FF6B6B')
+  it('E1: dark mode negative → rose #F06595 (distinct from the dark risk border #FF6B6B)', () => {
+    expect(computeDirectionStroke('negative', 0.5, 0.5, true)).toBe('#F06595')
+    expect(computeDirectionStroke('negative', 0.5, 0.5, true)).not.toBe('#FF6B6B')
   })
 
   it('dark mode: neutral → zinc-400', () => {
-    const result = computeDirectionStroke('positive', 0, 0, true)
-    expect(result).toBe('#a1a1aa')
+    expect(computeDirectionStroke('positive', 0, 0, true)).toBe('#a1a1aa')
   })
 })

--- a/src/canvas/edges/directionStroke.ts
+++ b/src/canvas/edges/directionStroke.ts
@@ -1,0 +1,44 @@
+/**
+ * directionStroke — the single source of truth for a causal edge's polarity
+ * colour (F.2). Extracted from StyledEdge so the rule can be unit-tested
+ * without a ReactFlow render and so the E1 recolour lives in one place (the
+ * spec previously kept a hand-copied duplicate that had to be edited in
+ * lockstep).
+ *
+ * E1 (graph-visuals 2026-07-11) — CVD-aware polarity palette. The +/− glyph is
+ * the second cue; these hues are the primary. Positive → the #62B290 green
+ * Paul selected. Negative → rose #D6336C, chosen over the pack's amber #FFA656
+ * (Paul's C2 ruling reserves amber for the warning/fragility family). ΔE-
+ * validated: rose sits ΔE 99.7 from the positive green, 66.9 from the amber
+ * warning family, and 48.4 from the risk-node border (#EA7B4B) — the old
+ * #ef4444 negative was only ΔE 27.6 from that border, the collision this
+ * fixes. Dark negative #F06595 is likewise distinct from the dark risk border
+ * (#FF6B6B). Yellow (var(--goal)) stays reserved for truly uninitialised
+ * edges (no direction AND no weight); grey for weight-set-but-no-direction and
+ * for the neutral weight === 0 choice.
+ */
+export function computeDirectionStroke(
+  direction: 'positive' | 'negative' | undefined,
+  weight: number,
+  rawWeight: number | undefined,
+  isDark: boolean,
+): string {
+  // Truly uninitialised: no direction AND weight is undefined → yellow
+  if (direction === undefined && rawWeight === undefined) {
+    return 'var(--goal)'
+  }
+  // Weight defined but direction not yet set → grey (not yellow)
+  if (direction === undefined) {
+    return isDark ? '#a1a1aa' : '#d4d4d8'
+  }
+  // Direction set with positive weight → green
+  if (direction === 'positive' && weight > 0) {
+    return isDark ? '#bbf7d0' : '#62B290'
+  }
+  // Direction set with negative weight → rose (E1: distinct from amber warning)
+  if (direction === 'negative' && weight > 0) {
+    return isDark ? '#F06595' : '#D6336C'
+  }
+  // Neutral: weight === 0 (valid user choice)
+  return isDark ? '#a1a1aa' : '#d4d4d8'
+}


### PR DESCRIPTION
Verdict E1 + Paul's C2 ruling. Positive edges → #62B290 green; negative edges → **rose #D6336C** (dark #F06595), a distinct hue rather than the pack's amber #FFA656 (Paul reserved amber for the warning/fragility family). +/− glyph stays the second cue.

**Hue chosen by ΔE validation** (matching the DS validator, pair-scored 27.9): rose is ΔE 99.7 from the green, 66.9 from the amber warning, 48.4 from the risk-node border #EA7B4B — the old #ef4444 negative was only ΔE **27.6** from that border, so negative edges (which terminate at risk nodes) blended into the node body. Dark #F06595 also resolves the pre-existing dark #FF6B6B collision.

Extracted `computeDirectionStroke()` so StyledEdge + directionColour.spec share ONE source of truth (killed the hand-copied duplicate). Scope: edge stroke only; glyph/popover/export re-standardisation is a cross-surface follow-up.

Gates: ci typecheck clean · directionColour + StyledEdge specs 27/27 · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)