### PR TITLE
D4: comfortable/compact layout density toggle (graph-visuals G4)

### DIFF
--- a/src/canvas/__tests__/layoutStore.density.spec.ts
+++ b/src/canvas/__tests__/layoutStore.density.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useLayoutStore, densityOf, LAYOUT_DENSITY_PRESETS } from '../layoutStore'
+
+describe('layoutStore — D4 density presets', () => {
+  beforeEach(() => {
+    try { localStorage.clear() } catch { /* ignore */ }
+    useLayoutStore.setState({ nodeSpacing: 15, layerSpacing: 48 })
+  })
+
+  it('densityOf derives compact at/below the compact tier spacing, comfortable above', () => {
+    expect(densityOf(48)).toBe('comfortable')
+    expect(densityOf(30)).toBe('compact')
+    expect(densityOf(20)).toBe('compact')
+    expect(densityOf(31)).toBe('comfortable')
+  })
+
+  it('setDensity(compact) tightens tier spacing to the floor without touching the node-node collision floor', () => {
+    useLayoutStore.getState().setDensity('compact')
+    const s = useLayoutStore.getState()
+    expect(s.layerSpacing).toBe(LAYOUT_DENSITY_PRESETS.compact.layerSpacing)
+    expect(s.nodeSpacing).toBe(LAYOUT_DENSITY_PRESETS.compact.nodeSpacing)
+    // compact never drives node-node spacing below the horizontal collision floor (20).
+    expect(s.nodeSpacing).toBeGreaterThanOrEqual(15)
+    expect(densityOf(s.layerSpacing)).toBe('compact')
+  })
+
+  it('setDensity(comfortable) restores the default air', () => {
+    useLayoutStore.getState().setDensity('compact')
+    useLayoutStore.getState().setDensity('comfortable')
+    const s = useLayoutStore.getState()
+    expect(s.layerSpacing).toBe(LAYOUT_DENSITY_PRESETS.comfortable.layerSpacing)
+    expect(densityOf(s.layerSpacing)).toBe('comfortable')
+  })
+
+  it('setDensity persists so the choice survives a reload', () => {
+    useLayoutStore.getState().setDensity('compact')
+    const saved = JSON.parse(localStorage.getItem('canvas-layout-options-v6') || '{}')
+    expect(saved.layerSpacing).toBe(30)
+  })
+})

--- a/src/canvas/layoutStore.ts
+++ b/src/canvas/layoutStore.ts
@@ -19,6 +19,8 @@ interface LayoutOptions {
   setDirection: (dir: Direction) => void
   setNodeSpacing: (spacing: number) => void
   setLayerSpacing: (spacing: number) => void
+  /** D4: apply a comfortable/compact spacing preset (persists like the setters). */
+  setDensity: (preset: LayoutDensity) => void
   setRespectLocked: (respect: boolean) => void
   setCanvasSize: (size: CanvasSize) => void
   setLayoutNodeWidth: (width: number) => void
@@ -51,6 +53,25 @@ interface LayoutOptions {
 // v3: layerSpacing reduced 90 → 48 (cumulative −47 % across two passes:
 // 90 → 68 (−25 %), then 68 → 48 (−30 %)) so tiers sit closer vertically.
 // Earlier bump: v1 → v2 changed 80/120 → 60/90.
+/**
+ * D4 (graph-visuals): comfortable / compact layout density presets. Compact
+ * trades vertical air for overview by tightening the tier (layer) spacing to
+ * the layout floor (30) — it deliberately does NOT touch node-node spacing,
+ * whose Math.max(20, …) / COLLISION_GAP floor exists to prevent horizontal
+ * overlap, so compact never risks a collision. Comfortable is the current
+ * default (nodeSpacing 15, layerSpacing 48).
+ */
+export const LAYOUT_DENSITY_PRESETS = {
+  comfortable: { nodeSpacing: 15, layerSpacing: 48 },
+  compact: { nodeSpacing: 15, layerSpacing: 30 },
+} as const
+export type LayoutDensity = keyof typeof LAYOUT_DENSITY_PRESETS
+
+/** Derive the active density from the persisted layerSpacing (no separate field). */
+export function densityOf(layerSpacing: number): LayoutDensity {
+  return layerSpacing <= LAYOUT_DENSITY_PRESETS.compact.layerSpacing ? 'compact' : 'comfortable'
+}
+
 const KEY = 'canvas-layout-options-v6'
 const KEY_V5 = 'canvas-layout-options-v5'
 const KEY_V4 = 'canvas-layout-options-v4'
@@ -141,6 +162,11 @@ export const useLayoutStore = create<LayoutOptions>((set, get) => ({
   },
   setLayerSpacing: (spacing) => {
     set({ layerSpacing: spacing })
+    persist(get())
+  },
+  setDensity: (preset) => {
+    const p = LAYOUT_DENSITY_PRESETS[preset]
+    set({ nodeSpacing: p.nodeSpacing, layerSpacing: p.layerSpacing })
     persist(get())
   },
   setRespectLocked: (respect) => {

--- a/src/components/layout/CanvasViewportControls.tsx
+++ b/src/components/layout/CanvasViewportControls.tsx
@@ -6,10 +6,11 @@
  */
 
 import { memo } from 'react'
-import { ZoomOut, ZoomIn, Maximize2, LayoutGrid } from 'lucide-react'
+import { ZoomOut, ZoomIn, Maximize2, LayoutGrid, Rows3, Rows4 } from 'lucide-react'
 import { useStore } from '@xyflow/react'
 import Tooltip from '../Tooltip'
 import { CanvasLegendPopover } from '../../canvas/components/CanvasLegendPopover'
+import { useLayoutStore, densityOf } from '../../canvas/layoutStore'
 
 interface CanvasViewportControlsProps {
   onZoomIn: () => void
@@ -28,6 +29,16 @@ export const CanvasViewportControls = memo(function CanvasViewportControls({
 }: CanvasViewportControlsProps) {
   const zoom = useStore(s => s.transform[2])
   const zoomPct = `${Math.round(zoom * 100)}%`
+
+  // D4: comfortable/compact density is derived from the persisted tier spacing.
+  const layerSpacing = useLayoutStore(s => s.layerSpacing)
+  const setDensity = useLayoutStore(s => s.setDensity)
+  const density = densityOf(layerSpacing)
+  const nextDensity = density === 'compact' ? 'comfortable' : 'compact'
+  const toggleDensity = () => {
+    setDensity(nextDensity)
+    onAutoArrange() // re-run layout with the new spacing
+  }
 
   return (
     <nav
@@ -102,6 +113,22 @@ export const CanvasViewportControls = memo(function CanvasViewportControls({
           onClick={onAutoArrange}
         >
           <LayoutGrid size={16} aria-hidden="true" />
+        </button>
+      </Tooltip>
+
+      {/* D4: layout density — comfortable ⇄ compact (tighter tier spacing) */}
+      <Tooltip content={density === 'compact' ? 'Comfortable spacing' : 'Compact spacing'}>
+        <button
+          type="button"
+          className="w-7 h-7 inline-flex items-center justify-center rounded-full text-text-light hover:text-text-body transition-colors focus-visible:outline-2 focus-visible:outline-info focus-visible:outline-offset-2"
+          aria-label={`Layout density: ${density}. Switch to ${nextDensity}.`}
+          aria-pressed={density === 'compact'}
+          data-testid="layout-density-toggle"
+          onClick={toggleDensity}
+        >
+          {density === 'compact'
+            ? <Rows3 size={16} aria-hidden="true" />
+            : <Rows4 size={16} aria-hidden="true" />}
         </button>
       </Tooltip>
 


### PR DESCRIPTION
Verdict D4. A comfortable ⇄ compact toggle in the viewport pill so big graphs can trade air for overview. Compact tightens tier (layer) spacing to the layout floor (48→30, ~37% less vertical air) and deliberately does NOT touch node-node spacing (its Math.max(20,…)/COLLISION_GAP floor prevents horizontal overlap) — so compact never risks a collision, the constraint the scope flagged. Density is derived from the persisted layerSpacing (no new field); the toggle re-runs the existing auto-arrange.

Gates: ci typecheck clean · density 4/4 + existing store spec 18/18 · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)