### PR TITLE
feat(canvas): OptionNode stable-number badge — closes the §6.4 graph numbering leg (Wave 4)

### DIFF
--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -368,6 +368,11 @@ export const OptionNode = memo((props: NodeProps) => {
   const nodes = useCanvasStore(state => state.nodes)
   const resultsReport = useCanvasStore(state => state.results.report)
   const resultsStatus = useCanvasStore(state => state.results.status)
+  // Wave 4 / §6.4: the identity-anchored option number (Wave F-A store),
+  // rendered on the canvas node so it matches the Analysis panel's "Option N"
+  // chip. Subscribed (not the outside-React snapshot) so it re-renders when the
+  // numbering registers. undefined until analysis registers this option.
+  const stableOptionNumber = useCanvasStore(state => state.optionNumbering?.[props.id])
   const isPostAnalysis = resultsStatus === 'complete'
   // Audit §8 P1: canvas result decorations must reflect the same freshness
   // verdict the panels use (StaleGuardBanner / bottom-bar "Analysis stale").
@@ -1048,8 +1053,17 @@ export const OptionNode = memo((props: NodeProps) => {
         {...props}
         nodeType="option"
         icon={metadata.icon}
-        headerSlot={scienceIcons.length > 0 ? (
+        headerSlot={(stableOptionNumber != null || scienceIcons.length > 0) ? (
           <span className="inline-flex items-center gap-1">
+            {stableOptionNumber != null && (
+              <span
+                data-testid={`option-stable-number-${props.id}`}
+                aria-label={`Option ${stableOptionNumber}`}
+                className={`${typography.panelMeta} inline-flex h-4 min-w-[16px] items-center justify-center rounded border border-panel-border px-1 text-text-light`}
+              >
+                {stableOptionNumber}
+              </span>
+            )}
             {scienceIcons.map(si => (
               <ScienceIcon key={si.id} icon={si.icon} tooltip={si.tooltip} action={si.action} colour={si.colour} />
             ))}

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -1945,4 +1945,22 @@ describe('OptionNode — display coherence (audit §8)', () => {
     // …and the duplicated inline list is gone.
     expect(screen.queryByText('Interventions:')).toBeNull()
   })
+
+  it('Wave 4 / §6.4: renders the identity-anchored stable option number badge when registered', () => {
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeStoreState({ optionNumbering: { 'option-1': 2 } }) as any),
+    )
+    renderOption()
+    const badge = screen.getByTestId('option-stable-number-option-1')
+    expect(badge).toHaveTextContent('2')
+    expect(badge).toHaveAttribute('aria-label', 'Option 2')
+  })
+
+  it('renders no stable-number badge before the option is registered', () => {
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeStoreState({ optionNumbering: {} }) as any),
+    )
+    renderOption()
+    expect(screen.queryByTestId('option-stable-number-option-1')).toBeNull()
+  })
 })


### PR DESCRIPTION
Wave F-A shipped identity-anchored option numbers; Wave 2 rendered them on the Analysis panel ('Option N'). This closes the cross-surface leg: the **canvas OptionNode now shows the same number** in its header, so an option reads as 'Option 2' identically on the graph and in the panel (brief §6.4 stable numbering across graph + Analysis).

Subscribes to the store's optionNumbering (re-renders when analysis registers); undefined-safe access so node harnesses without the slice don't crash; suppressed until registered (no analysis → no number).

Gates: ci typecheck clean · OptionNode + render-matrix 121/121 · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)