### PR TITLE
N3: amber 'edited since analysis' dot on canvas nodes (graph-visuals G2)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS } from './domain/edges'
 import { parseRunHash } from './utils/shareLink'
 import { useInitialLayoutGuard } from './hooks/useInitialLayoutGuard'
 import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
+import { useEditedSinceRun } from './hooks/useEditedSinceRun'
 import { cameraDuration } from './utils/cameraMotion'
 import { neighbourhoodNodeIds } from './utils/focusNeighbourhood'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
@@ -944,6 +945,10 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   // Graph Interaction P1: Enable path highlighting based on node selection
   // Highlights causal paths from selected factor to goal, dims unrelated nodes
   usePathHighlight()
+
+  // N3 (graph-visuals): keep the edited-since-run node set in sync so nodes
+  // can wear the amber "edited since analysis" corner dot.
+  useEditedSinceRun()
 
   // Graph Lens: Compute lens visuals and push to store
   useLensFilter()

--- a/src/canvas/hooks/useEditedSinceRun.ts
+++ b/src/canvas/hooks/useEditedSinceRun.ts
@@ -1,0 +1,41 @@
+/**
+ * useEditedSinceRun — N3 (graph-visuals): keep the store's
+ * editedSinceRunNodeIds in sync with "current canvas vs latest run snapshot".
+ *
+ * Mounted once by ReactFlowGraph (like usePathHighlight). Recomputes when the
+ * canvas nodes change or a new run lands (runsBus), and writes the id set via
+ * setEditedSinceRunNodes (which no-op-skips unchanged sets). BaseNode
+ * subscribes to membership and renders the amber corner dot.
+ *
+ * A fresh run self-clears the dots: the new snapshot equals the current
+ * graph, so the diff is empty — no coupling to the freshness verdict needed
+ * (the strip stays the single freshness OWNER; this is spatial detail).
+ */
+import { useEffect, useSyncExternalStore } from 'react'
+import { useCanvasStore } from '../store'
+import { loadRuns } from '../store/runHistory'
+import * as runsBus from '../store/runsBus'
+import { diffEditedNodeIds } from '../utils/editedSinceRun'
+
+let runsVersion = 0
+const subscribeToRuns = (onStoreChange: () => void) =>
+  runsBus.on(() => {
+    runsVersion++
+    onStoreChange()
+  })
+const getRunsVersion = () => runsVersion
+
+export function useEditedSinceRun(): void {
+  const nodes = useCanvasStore((s) => s.nodes)
+  const version = useSyncExternalStore(subscribeToRuns, getRunsVersion)
+
+  useEffect(() => {
+    const { setEditedSinceRunNodes } = useCanvasStore.getState()
+    // Fail-soft on partial store doubles in specs (same convention as
+    // appliedEditPulse's flush guard).
+    if (typeof setEditedSinceRunNodes !== 'function') return
+    const latest = loadRuns()[0]
+    const edited = diffEditedNodeIds(nodes, latest?.graph?.nodes)
+    setEditedSinceRunNodes([...edited])
+  }, [nodes, version])
+}

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -78,6 +78,9 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
   // on every store update. Selecting the entire Set causes infinite loops since
   // Set references change on each store update.
   const isHighlighted = useCanvasStore(s => s.highlightedNodes.has(id))
+  // N3: edited since the last analysis run (amber corner dot; undefined-safe
+  // for node-spec store doubles without the slice).
+  const isEditedSinceRun = useCanvasStore(s => s.editedSinceRunNodeIds?.has(id) === true)
 
   // Graph Interaction P1: Node dimming for path highlighting
   // Nodes not on the highlighted path are dimmed (opacity ~0.4)
@@ -287,6 +290,17 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         minHeight: isExpanded ? '120px' : undefined,
       }}
     >
+      {/* N3 (graph-visuals): amber corner dot — this node was edited since
+          the last analysis run (device-local diff vs the run snapshot; the
+          freshness strip stays the single freshness owner, this is WHERE).
+          Amber = the warning family per Paul's C2 hue ruling. */}
+      {isEditedSinceRun && (
+        <span
+          data-testid={`edited-since-run-${id}`}
+          title="Edited since the last analysis"
+          className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-warning border border-canvas"
+        />
+      )}
       {/* Phase 2: Node badges for CEE/ISL warnings */}
       <NodeBadge
         nodeId={id}

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -1171,6 +1171,20 @@ describe('N1 — per-type selection ring', () => {
     expect(group.className).toContain('ring-info/60')
   })
 
+  it('N3: a node in editedSinceRunNodeIds wears the amber edited dot', () => {
+    vi.mocked(useCanvasStore).mockImplementation((sel: any) =>
+      sel({ ...nodeState([]), editedSinceRunNodeIds: new Set(['factor-1']) }),
+    )
+    render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    expect(screen.getByTestId('edited-since-run-factor-1')).toBeInTheDocument()
+  })
+
+  it('N3: no edited dot when the node is not in the set (and no crash without the slice)', () => {
+    applyState([])
+    render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    expect(screen.queryByTestId('edited-since-run-factor-1')).toBeNull()
+  })
+
   it('N2: a non-highlighted node has no pulse', () => {
     applyState([])
     render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -436,6 +436,11 @@ interface CanvasState {
   highlightedNodes: Set<string>
   highlightedEdges: Set<string>
   dimmedNodeIds: Set<string>
+  /** N3 (graph-visuals): nodes edited since the last analysis run — computed
+   * by useEditedSinceRun (device-local diff vs the latest run snapshot,
+   * same mechanism class as the What-changed chip). Drives the amber
+   * corner dot on canvas nodes. */
+  editedSinceRunNodeIds: Set<string>
   // S.4: Session-only "user-reviewed" tracking — resets on page refresh
   confirmedNodeIds: Set<string>
   // Decision Graph Display v2 Task 11: Option hover state for intervention highlighting
@@ -700,6 +705,8 @@ interface CanvasState {
   setHighlightedNodes: (ids: string[]) => void
   setHighlightedEdges: (ids: string[]) => void
   setDimmedNodes: (ids: string[]) => void
+  /** N3: replace the edited-since-run set (called by the useEditedSinceRun effect). */
+  setEditedSinceRunNodes: (ids: string[]) => void
   // S.4: Toggle "user-reviewed" confirmation on a node (session-only)
   toggleConfirmedNode: (nodeId: string) => void
   // Decision Graph Display v2 Task 11: Option hover for intervention highlighting
@@ -1285,6 +1292,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   highlightedNodes: new Set<string>(),
   highlightedEdges: new Set<string>(),
   dimmedNodeIds: new Set<string>(),
+  editedSinceRunNodeIds: new Set<string>(),
   confirmedNodeIds: new Set<string>(),
   hoveredOptionId: null,
   // Graph Lens: ephemeral canvas filtering state.
@@ -3718,6 +3726,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   },
   setDimmedNodes: (ids: string[]) => {
     set({ dimmedNodeIds: new Set(ids) })
+  },
+  setEditedSinceRunNodes: (ids: string[]) => {
+    // No-op set-skip when unchanged so the effect's recompute on every node
+    // edit doesn't re-render all nodes needlessly.
+    const prev = get().editedSinceRunNodeIds
+    if (prev.size === ids.length && ids.every((id) => prev.has(id))) return
+    set({ editedSinceRunNodeIds: new Set(ids) })
   },
   // S.4: Toggle "user-reviewed" confirmation (session-only, resets on refresh)
   toggleConfirmedNode: (nodeId: string) => {

--- a/src/canvas/utils/__tests__/editedSinceRun.spec.ts
+++ b/src/canvas/utils/__tests__/editedSinceRun.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { Node } from '@xyflow/react'
+import { diffEditedNodeIds } from '../editedSinceRun'
+
+const node = (id: string, data: Record<string, unknown>, x = 0, y = 0): Node =>
+  ({ id, position: { x, y }, data } as unknown as Node)
+
+describe('diffEditedNodeIds — N3 edited-since-run', () => {
+  const snapshot = [
+    node('a', { label: 'Team capacity', observedState: { value: 40, unit: '%' } }),
+    node('b', { label: 'Salary cost', value: 120000 }),
+    node('c', { label: 'Risk of churn' }),
+  ]
+
+  it('a label change marks the node edited', () => {
+    const current = [
+      node('a', { label: 'Team capacity (revised)', observedState: { value: 40, unit: '%' } }),
+      node('b', { label: 'Salary cost', value: 120000 }),
+      node('c', { label: 'Risk of churn' }),
+    ]
+    expect(diffEditedNodeIds(current, snapshot)).toEqual(new Set(['a']))
+  })
+
+  it('an observed-state / value change marks the node edited', () => {
+    const current = [
+      node('a', { label: 'Team capacity', observedState: { value: 55, unit: '%' } }),
+      node('b', { label: 'Salary cost', value: 130000 }),
+      node('c', { label: 'Risk of churn' }),
+    ]
+    expect(diffEditedNodeIds(current, snapshot)).toEqual(new Set(['a', 'b']))
+  })
+
+  it('a node added since the run is edited; removed nodes are simply absent', () => {
+    const current = [
+      node('a', { label: 'Team capacity', observedState: { value: 40, unit: '%' } }),
+      node('d', { label: 'New factor' }),
+    ]
+    expect(diffEditedNodeIds(current, snapshot)).toEqual(new Set(['d']))
+  })
+
+  it('position-only moves are layout, not edits', () => {
+    const current = [
+      node('a', { label: 'Team capacity', observedState: { value: 40, unit: '%' } }, 500, 900),
+      node('b', { label: 'Salary cost', value: 120000 }, -50, 10),
+      node('c', { label: 'Risk of churn' }, 3, 4),
+    ]
+    expect(diffEditedNodeIds(current, snapshot)).toEqual(new Set())
+  })
+
+  it('fail-closed: no snapshot yields an empty set (never everything-edited)', () => {
+    expect(diffEditedNodeIds(snapshot, undefined)).toEqual(new Set())
+  })
+
+  it('identical graph yields an empty set (a fresh run self-clears the dots)', () => {
+    expect(diffEditedNodeIds(snapshot, snapshot)).toEqual(new Set())
+  })
+})

--- a/src/canvas/utils/editedSinceRun.ts
+++ b/src/canvas/utils/editedSinceRun.ts
@@ -1,0 +1,51 @@
+/**
+ * editedSinceRun — N3 (graph-visuals): which nodes have been edited since the
+ * last analysis run. The freshness strip says "the model changed"; the amber
+ * corner dot makes that spatial by marking WHERE.
+ *
+ * Device-local comparison of the CURRENT canvas nodes against the latest
+ * stored run's graph snapshot (runHistory) — the same honestly-labelled
+ * client-side mechanism as the What-changed chip (Paul's 2026-07-12 ruling).
+ *
+ * "Edited" means an ANALYSIS-RELEVANT change:
+ *   - the node was added since the run (no snapshot counterpart), or
+ *   - its label changed (the chip's node-modified rule), or
+ *   - its observed state / value changed (what actually invalidates results).
+ * Position moves are layout, not edits (auto-arrange would otherwise mark
+ * every node). Removed nodes are gone from the canvas — nothing to dot.
+ *
+ * Fail-closed: no runs, or a legacy run without a graph snapshot, yields an
+ * empty set (never "everything is edited").
+ */
+import type { Node } from '@xyflow/react'
+
+/** Stable stringify of the analysis-relevant slice of node data. */
+function analyticalFingerprint(node: Node): string {
+  const data = (node.data ?? {}) as Record<string, unknown>
+  // label + observed state/value fields; everything else (position, ui flags,
+  // coaching decorations) is not an analytical edit.
+  return JSON.stringify({
+    label: data.label ?? null,
+    observedState: data.observedState ?? null,
+    value: data.value ?? null,
+    threshold: data.threshold ?? null,
+  })
+}
+
+export function diffEditedNodeIds(
+  currentNodes: readonly Node[],
+  snapshotNodes: readonly Node[] | undefined,
+): Set<string> {
+  if (!snapshotNodes) return new Set()
+  const snapshot = new Map(snapshotNodes.map((n) => [n.id, analyticalFingerprint(n)]))
+  const edited = new Set<string>()
+  for (const node of currentNodes) {
+    const before = snapshot.get(node.id)
+    if (before === undefined) {
+      edited.add(node.id) // added since the run
+    } else if (before !== analyticalFingerprint(node)) {
+      edited.add(node.id) // label / observed-state change
+    }
+  }
+  return edited
+}


### PR DESCRIPTION
Verdict N3. The freshness strip says 'the model changed' — the canvas now shows **where**: nodes edited since the last run wear a small amber corner dot (amber = warning family per Paul's C2 ruling).

Device-local diff of current canvas vs the latest run snapshot (same honestly-labelled mechanism class as the What-changed chip). 'Edited' = analysis-relevant only (added / label / observed-state); position moves are layout. Fail-closed (no runs → no dots); a fresh run self-clears, so the strip remains the single freshness owner.

Plumbing mirrors usePathHighlight: pure diff util → once-mounted hook → store set (set-skip) → BaseNode membership.

Wide-tsc note: the useConversation V5ApplicatorStore error in the textual diff is pre-existing (only its printed '…N more…' count shifted from the +2 store fields).

Gates: ci typecheck clean · 6/6 + 54/54 + 93/93 specs · lint 0 errors · wide tsc clean (see note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)