### PR TITLE
E3: edge-label collision avoidance with leader lines (graph-visuals G3)

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -24,6 +24,7 @@ import { useShallow } from 'zustand/react/shallow'
 import type { EdgeData, EdgePathType } from '../domain/edges'
 import { shouldShowEdgeLabel } from './edgeLabelVisibility'
 import { computeDirectionStroke } from './directionStroke'
+import { resolveLabelCollisionOffsets } from './edgeLabelCollision'
 import { applyEdgeVisualProps } from '../theme/edges'
 import { formatConfidence, shouldShowLabel, getEdgeConfidence, computeSignedMean } from '../domain/edges'
 import { useIsDark } from '../hooks/useTheme'
@@ -443,8 +444,9 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // Graph Editing Experience Task 9c: Persistent labels on top 3 edges
   // Pre-analysis: rank by |strength.mean|. Post-analysis: rank by composite importance.
   // Structural edges (decision→option) are excluded from ranking.
-  const isTopStrengthEdge = useMemo(() => {
-    if (isStructuralEdge) return false
+  // E3 refactor: the ranking now yields the persistent-label ID SET so both
+  // the per-edge flag AND the label-collision pass share one computation.
+  const topStrengthIds = useMemo((): Set<string> => {
     const allEdges = getEdges()
     // Filter out non-causal edges (structural + intervention) before ranking
     const causalEdges = allEdges.filter(e => {
@@ -456,7 +458,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       if (sk === 'option' && tk === 'factor') return false   // intervention
       return true
     })
-    if (causalEdges.length <= 3) return true // Show all labels if 3 or fewer causal edges
+    if (causalEdges.length <= 3) return new Set(causalEdges.map(e => e.id)) // all labelled when 3 or fewer
 
     if (isResultsMode && report) {
       // Post-analysis: use composite importance (same formula as stroke width)
@@ -473,7 +475,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         }
       })
       scores.sort((a, b) => b.score - a.score)
-      return new Set(scores.slice(0, 3).map(s => s.id)).has(id)
+      return new Set(scores.slice(0, 3).map(s => s.id))
     }
 
     // Pre-analysis: rank by |strength.mean|
@@ -482,8 +484,34 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       strength: Math.abs(computeSignedMean(e.data as Record<string, unknown> | undefined)),
     }))
     strengths.sort((a, b) => b.strength - a.strength)
-    return new Set(strengths.slice(0, 3).map(s => s.id)).has(id)
-  }, [id, isStructuralEdge, getEdges, isResultsMode, report])
+    return new Set(strengths.slice(0, 3).map(s => s.id))
+  }, [getEdges, getNode, isResultsMode, report])
+
+  const isTopStrengthEdge = !isStructuralEdge && topStrengthIds.has(id)
+
+  // E3: label-vs-label collision avoidance. Every persistent-label edge feeds
+  // the SAME anchor basis (straight midpoints of node centres — a stable
+  // approximation of each label's position) into the shared deterministic
+  // resolver, so all edges agree on the global assignment and each applies
+  // its own offset. Only persistent (top-strength) labels participate —
+  // hover/selection labels are transient.
+  const collisionOffset = useMemo(() => {
+    if (!isTopStrengthEdge) return { dx: 0, dy: 0 }
+    const allEdges = getEdges()
+    const points: Array<{ id: string; x: number; y: number }> = []
+    for (const e of allEdges) {
+      if (!topStrengthIds.has(e.id)) continue
+      const sn = getNode(e.source)
+      const tn = getNode(e.target)
+      if (!sn || !tn) continue
+      const sx = sn.position.x + ((sn.measured?.width ?? sn.width ?? 200) / 2)
+      const sy = sn.position.y + ((sn.measured?.height ?? sn.height ?? 80) / 2)
+      const tx = tn.position.x + ((tn.measured?.width ?? tn.width ?? 200) / 2)
+      const ty = tn.position.y + ((tn.measured?.height ?? tn.height ?? 80) / 2)
+      points.push({ id: e.id, x: (sx + tx) / 2, y: (sy + ty) / 2 })
+    }
+    return resolveLabelCollisionOffsets(points).get(id) ?? { dx: 0, dy: 0 }
+  }, [isTopStrengthEdge, topStrengthIds, getEdges, getNode, id, sourceX, sourceY, targetX, targetY])
 
   // Task 9c: Offset persistent labels away from nodes to avoid overlap
   const persistentLabelOffset = useMemo(() => {
@@ -507,6 +535,11 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     }
     return { dx: 0, dy: 0 }
   }, [isTopStrengthEdge, source, target, getNode, labelX, labelY, sourceX, sourceY, targetX, targetY])
+
+  // E3: combined label displacement = node-proximity dodge (Task 9c — computed
+  // since 9c but never applied to the transform until now) + collision stack.
+  const labelOffsetX = persistentLabelOffset.dx + collisionOffset.dx
+  const labelOffsetY = persistentLabelOffset.dy + collisionOffset.dy
 
   // C1 + E2: label-visibility policy (see edgeLabelVisibility.ts). Top-strength
   // labels surface in the default (standard) view once results exist; the
@@ -764,13 +797,28 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         </EdgeLabelRenderer>
       )}
 
+      {/* E3: hairline leader from the edge midpoint to a displaced label so a
+          dodged label still reads as belonging to its edge. SVG sibling of the
+          edge path (EdgeLabelRenderer portals to HTML, so the line lives here). */}
+      {showLabel && (Math.abs(labelOffsetX) + Math.abs(labelOffsetY)) > 12 && (
+        <line
+          x1={labelX}
+          y1={labelY}
+          x2={labelX + labelOffsetX}
+          y2={labelY + labelOffsetY}
+          stroke="var(--border-default, #d4d4d8)"
+          strokeWidth={1}
+          data-testid="edge-label-leader"
+        />
+      )}
+
       {/* C1: Edge label - only show when selected, hovered, or has pending suggestions */}
       {showLabel && (
         <EdgeLabelRenderer>
           <div
             style={{
               position: 'absolute',
-              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              transform: `translate(-50%, -50%) translate(${labelX + labelOffsetX}px,${labelY + labelOffsetY}px)`,
               pointerEvents: 'all',
               padding: '3px 8px',
               borderRadius: '4px',

--- a/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
+++ b/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { resolveLabelCollisionOffsets } from '../edgeLabelCollision'
+
+describe('resolveLabelCollisionOffsets — E3 label collision avoidance', () => {
+  it('far-apart labels get no offset', () => {
+    const out = resolveLabelCollisionOffsets([
+      { id: 'a', x: 0, y: 0 },
+      { id: 'b', x: 400, y: 300 },
+    ])
+    expect(out.get('a')).toEqual({ dx: 0, dy: 0 })
+    expect(out.get('b')).toEqual({ dx: 0, dy: 0 })
+  })
+
+  it('two labels at a crossing: the topmost stays, the second stacks below', () => {
+    const out = resolveLabelCollisionOffsets([
+      { id: 'lower', x: 10, y: 8 },
+      { id: 'upper', x: 0, y: 0 },
+    ])
+    expect(out.get('upper')).toEqual({ dx: 0, dy: 0 })
+    expect(out.get('lower')!.dy).toBeGreaterThanOrEqual(16) // pushed clear
+  })
+
+  it('three coincident labels stack deterministically (0, step, 2×step spacing)', () => {
+    const out = resolveLabelCollisionOffsets([
+      { id: 'c', x: 0, y: 0 },
+      { id: 'a', x: 0, y: 0 },
+      { id: 'b', x: 0, y: 0 },
+    ])
+    const dys = ['a', 'b', 'c'].map((id) => out.get(id)!.dy).sort((x, y) => x - y)
+    expect(dys[0]).toBe(0)
+    expect(dys[1]).toBeGreaterThan(0)
+    expect(dys[2]).toBeGreaterThan(dys[1])
+  })
+
+  it('is deterministic regardless of input order (every edge computes the same assignment)', () => {
+    const pts = [
+      { id: 'a', x: 5, y: 2 },
+      { id: 'b', x: 0, y: 0 },
+      { id: 'c', x: 60, y: 10 },
+    ]
+    const forward = resolveLabelCollisionOffsets(pts)
+    const reversed = resolveLabelCollisionOffsets([...pts].reverse())
+    for (const id of ['a', 'b', 'c']) {
+      expect(forward.get(id)).toEqual(reversed.get(id))
+    }
+  })
+
+  it('vertical near-misses outside the y-threshold do not offset', () => {
+    const out = resolveLabelCollisionOffsets([
+      { id: 'a', x: 0, y: 0 },
+      { id: 'b', x: 0, y: 40 }, // 40 > Y_THRESHOLD 24
+    ])
+    expect(out.get('b')).toEqual({ dx: 0, dy: 0 })
+  })
+
+  it('bounded stacking on pathological coincident input (never unbounded)', () => {
+    const pts = Array.from({ length: 20 }, (_, i) => ({ id: `p${i}`, x: 0, y: 0 }))
+    const out = resolveLabelCollisionOffsets(pts)
+    for (const { id } of pts) {
+      expect(out.get(id)!.dy).toBeLessThanOrEqual(26 * 10)
+    }
+  })
+})

--- a/src/canvas/edges/edgeLabelCollision.ts
+++ b/src/canvas/edges/edgeLabelCollision.ts
@@ -1,0 +1,56 @@
+/**
+ * edgeLabelCollision — E3 (graph-visuals): keep persistent edge labels
+ * readable when they land near each other (e.g. two labels at a crossing).
+ *
+ * Pure, deterministic resolver: given every persistent label's anchor point,
+ * assign each a vertical offset so no two overlap. Labels are processed in
+ * spatial order (top-to-bottom, then left-to-right, then id) so the topmost
+ * label stays anchored and later ones stack downward — the same input set
+ * always produces the same assignment, and every edge computes the SAME
+ * global assignment (each edge feeds the same approximated anchor set in,
+ * then applies its own offset).
+ *
+ * Collision box ≈ a rendered label (maxWidth 160px, ~22px tall with padding):
+ * two anchors closer than the thresholds on BOTH axes overlap.
+ */
+export interface LabelPoint {
+  id: string
+  x: number
+  y: number
+}
+
+export interface LabelOffset {
+  dx: number
+  dy: number
+}
+
+const X_THRESHOLD = 90
+const Y_THRESHOLD = 24
+const STEP = 26
+const MAX_STACK = 10 // guard: never loop unbounded on pathological input
+
+export function resolveLabelCollisionOffsets(
+  points: readonly LabelPoint[],
+): Map<string, LabelOffset> {
+  const sorted = [...points].sort(
+    (a, b) => a.y - b.y || a.x - b.x || a.id.localeCompare(b.id),
+  )
+  const placed: Array<{ x: number; y: number }> = []
+  const out = new Map<string, LabelOffset>()
+  for (const p of sorted) {
+    let dy = 0
+    let guard = 0
+    while (
+      placed.some(
+        (q) => Math.abs(q.x - p.x) < X_THRESHOLD && Math.abs(q.y - (p.y + dy)) < Y_THRESHOLD,
+      ) &&
+      guard < MAX_STACK
+    ) {
+      dy += STEP
+      guard++
+    }
+    placed.push({ x: p.x, y: p.y + dy })
+    out.set(p.id, { dx: 0, dy })
+  }
+  return out
+}


### PR DESCRIPTION
Verdict E3. Labels only dodged nodes — two labels near a crossing overlapped. Persistent labels now dodge each other via a pure deterministic resolver (topmost stays; colliding labels stack downward; every edge feeds the same anchor basis so all edges agree on one global assignment), with a hairline leader tying a displaced label to its edge.

**Latent bug fixed in passing:** the Task-9c node-proximity offset was computed but never applied to the label transform — now the combined displacement actually renders.

Refactor: top-3 ranking yields the shared `topStrengthIds` set (one computation for the flag + collision pass); behaviour preserved.

Gates: ci typecheck clean · edge suites 115/115 (6 new resolver tests) · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)