### PR TITLE
D2: level-of-detail at low zoom (graph-visuals G5)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -11,6 +11,7 @@ import { parseRunHash } from './utils/shareLink'
 import { useInitialLayoutGuard } from './hooks/useInitialLayoutGuard'
 import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
 import { useEditedSinceRun } from './hooks/useEditedSinceRun'
+import { LodSync } from './components/LodSync'
 import { cameraDuration } from './utils/cameraMotion'
 import { neighbourhoodNodeIds } from './utils/focusNeighbourhood'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
@@ -2035,6 +2036,8 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
                 </marker>
               </defs>
             </svg>
+            {/* D2: level-of-detail zoom watcher — main canvas only. */}
+            <LodSync />
           </ReactFlow>
         )}
       </div>

--- a/src/canvas/components/LodSync.tsx
+++ b/src/canvas/components/LodSync.tsx
@@ -1,0 +1,29 @@
+/**
+ * LodSync — D2 (graph-visuals): watch the main canvas zoom and flip the
+ * store's level-of-detail flag when it crosses the threshold.
+ *
+ * Mounted as a child of the MAIN <ReactFlow> instance only (the Compare-tab
+ * minis are already simplified views). Selecting the derived boolean — not
+ * the raw zoom — means this component re-renders only when the flag flips,
+ * not on every zoom tick; setLodActive additionally skip-if-same guards the
+ * store write. Renders nothing.
+ */
+import { useEffect } from 'react'
+import { useStore } from '@xyflow/react'
+import { useCanvasStore } from '../store'
+
+/** Below this zoom, full node cards are unreadable soup — simplify (D2). */
+export const LOD_ZOOM_THRESHOLD = 0.5
+
+export function isLodZoom(zoom: number): boolean {
+  return zoom < LOD_ZOOM_THRESHOLD
+}
+
+export function LodSync() {
+  const lod = useStore((s) => isLodZoom(s.transform[2]))
+  useEffect(() => {
+    const { setLodActive } = useCanvasStore.getState()
+    if (typeof setLodActive === 'function') setLodActive(lod)
+  }, [lod])
+  return null
+}

--- a/src/canvas/components/__tests__/LodSync.spec.ts
+++ b/src/canvas/components/__tests__/LodSync.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { isLodZoom, LOD_ZOOM_THRESHOLD } from '../LodSync'
+
+describe('isLodZoom — D2 threshold predicate', () => {
+  it('activates below the threshold, not at or above it', () => {
+    expect(isLodZoom(0.1)).toBe(true)
+    expect(isLodZoom(LOD_ZOOM_THRESHOLD - 0.01)).toBe(true)
+    expect(isLodZoom(LOD_ZOOM_THRESHOLD)).toBe(false)
+    expect(isLodZoom(1)).toBe(false)
+    expect(isLodZoom(4)).toBe(false)
+  })
+})

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -47,6 +47,9 @@ interface BaseNodeProps extends NodeProps {
   nodeType: NodeType
   icon: LucideIcon
   children?: ReactNode
+  /** D2: keep this node's title readable at level-of-detail zoom even though
+   * it is not a goal/decision (e.g. the leading option). */
+  lodKeepLabel?: boolean
   maxWidth?: number
   headerSlot?: ReactNode
   /** Override border colour + style classes (e.g. 'border-info border-dashed'). Replaces entity colour. */
@@ -58,7 +61,7 @@ interface BaseNodeProps extends NodeProps {
  * Includes connection handles and accessibility attributes
  * Click chevron icon to expand/collapse description
  */
-export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, children, maxWidth, headerSlot, borderClassOverride }: BaseNodeProps) => {
+export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, children, maxWidth, headerSlot, borderClassOverride, lodKeepLabel = false }: BaseNodeProps) => {
   const label = typeof data?.label === 'string' && data.label ? data.label : 'Untitled'
   const description = typeof data?.description === 'string' ? data.description : undefined
 
@@ -81,6 +84,13 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
   // N3: edited since the last analysis run (amber corner dot; undefined-safe
   // for node-spec store doubles without the slice).
   const isEditedSinceRun = useCanvasStore(s => s.editedSinceRunNodeIds?.has(id) === true)
+  // D2: level-of-detail — at low zoom nodes simplify to their coloured shape;
+  // only goal / decision / explicitly-kept nodes (the leading option) keep a
+  // readable title. Undefined-safe for spec store doubles without the slice.
+  const lodActive = useCanvasStore(s => s.lodActive === true)
+  const lodKeepsTitle = nodeType === 'goal' || nodeType === 'decision' || lodKeepLabel
+  const lodHideTitle = lodActive && !lodKeepsTitle
+  const lodBoostTitle = lodActive && lodKeepsTitle
 
   // Graph Interaction P1: Node dimming for path highlighting
   // Nodes not on the highlighted path are dimmed (opacity ~0.4)
@@ -390,7 +400,15 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
           {/* line-clamp-3: cap title to 3 lines with ellipsis so ELK can
               rely on uniform-ish node heights. `break-words` preserved so
               long unbroken tokens still wrap before clamping. */}
-          <div className={`${typography.nodeTitle} text-text-body break-words line-clamp-3`}>
+          <div
+            data-testid="node-title"
+            className={
+              lodBoostTitle
+                ? 'text-lg font-semibold text-text-header break-words line-clamp-2'
+                : `${typography.nodeTitle} text-text-body break-words line-clamp-3`
+            }
+            style={lodHideTitle ? { visibility: 'hidden' } : undefined}
+          >
             {label}
           </div>
         </div>
@@ -445,9 +463,12 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         />
       )}
 
-      {/* Optional children (description, metrics, etc.) — hidden in causal/evidence lens */}
+      {/* Optional children (description, metrics, etc.) — hidden in causal/evidence lens.
+          D2: at level-of-detail zoom the body hides via visibility (box keeps
+          its dimensions so ELK/edge anchors stay stable) — the node reads as
+          its coloured shape. */}
       {!isCausalLens && !isEvidenceLens && children ? (
-        <div className="text-left">
+        <div className="text-left" style={lodActive ? { visibility: 'hidden' } : undefined} data-lod-hidden={lodActive || undefined}>
           {children as ReactNode}
         </div>
       ) : null}

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -1053,6 +1053,7 @@ export const OptionNode = memo((props: NodeProps) => {
         {...props}
         nodeType="option"
         icon={metadata.icon}
+        lodKeepLabel={isRecommended}
         headerSlot={(stableOptionNumber != null || scienceIcons.length > 0) ? (
           <span className="inline-flex items-center gap-1">
             {stableOptionNumber != null && (

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -1185,6 +1185,33 @@ describe('N1 — per-type selection ring', () => {
     expect(screen.queryByTestId('edited-since-run-factor-1')).toBeNull()
   })
 
+  it('D2: at LOD zoom a factor node hides its title and body (shape only)', () => {
+    vi.mocked(useCanvasStore).mockImplementation((sel: any) =>
+      sel({ ...nodeState([]), lodActive: true }),
+    )
+    render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    const title = screen.getAllByTestId('node-title')[0]
+    expect(title).toHaveStyle({ visibility: 'hidden' })
+  })
+
+  it('D2: at LOD zoom a goal node keeps a boosted, visible title', () => {
+    vi.mocked(useCanvasStore).mockImplementation((sel: any) =>
+      sel({ ...nodeState([]), lodActive: true }),
+    )
+    render(<ReactFlowProvider><GoalNode {...selProps} id="goal-1" type="goal" selected={false} data={{ label: 'Ship the roadmap' }} /></ReactFlowProvider>)
+    const title = screen.getAllByTestId('node-title')[0]
+    expect(title).not.toHaveStyle({ visibility: 'hidden' })
+    expect(title.className).toContain('font-semibold')
+  })
+
+  it('D2: at normal zoom titles render exactly as before (no LOD classes)', () => {
+    applyState([])
+    render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    const title = screen.getAllByTestId('node-title')[0]
+    expect(title).not.toHaveStyle({ visibility: 'hidden' })
+    expect(title.className).not.toContain('text-lg')
+  })
+
   it('N2: a non-highlighted node has no pulse', () => {
     applyState([])
     render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -436,6 +436,9 @@ interface CanvasState {
   highlightedNodes: Set<string>
   highlightedEdges: Set<string>
   dimmedNodeIds: Set<string>
+  /** D2 (graph-visuals): level-of-detail — true when the main canvas zoom is
+   * below the LOD threshold; nodes simplify (body hidden, only key labels). */
+  lodActive: boolean
   /** N3 (graph-visuals): nodes edited since the last analysis run — computed
    * by useEditedSinceRun (device-local diff vs the latest run snapshot,
    * same mechanism class as the What-changed chip). Drives the amber
@@ -707,6 +710,8 @@ interface CanvasState {
   setDimmedNodes: (ids: string[]) => void
   /** N3: replace the edited-since-run set (called by the useEditedSinceRun effect). */
   setEditedSinceRunNodes: (ids: string[]) => void
+  /** D2: set by the LodSync zoom watcher (skip-if-same). */
+  setLodActive: (active: boolean) => void
   // S.4: Toggle "user-reviewed" confirmation on a node (session-only)
   toggleConfirmedNode: (nodeId: string) => void
   // Decision Graph Display v2 Task 11: Option hover for intervention highlighting
@@ -1293,6 +1298,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   highlightedEdges: new Set<string>(),
   dimmedNodeIds: new Set<string>(),
   editedSinceRunNodeIds: new Set<string>(),
+  lodActive: false,
   confirmedNodeIds: new Set<string>(),
   hoveredOptionId: null,
   // Graph Lens: ephemeral canvas filtering state.
@@ -3726,6 +3732,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   },
   setDimmedNodes: (ids: string[]) => {
     set({ dimmedNodeIds: new Set(ids) })
+  },
+  setLodActive: (active: boolean) => {
+    if (get().lodActive === active) return
+    set({ lodActive: active })
   },
   setEditedSinceRunNodes: (ids: string[]) => {
     // No-op set-skip when unchanged so the effect's recompute on every node


### PR DESCRIPTION
Verdict D2. Below zoom 0.5, nodes simplify map-style: body + non-key titles hide via **visibility** (box dims stay stable → ELK/edge anchors unaffected), leaving coloured shapes; **goal / decision / leading option keep a boosted title** as landmarks.

`LodSync` (main canvas only) selects the derived boolean — re-renders only on threshold flips, never per zoom tick; store write is skip-if-same. Normal zoom is byte-identical (pinned).

Gates: ci typecheck clean · node+RFG suites 427/427 · lint 0 errors · wide tsc clean (count-normalised diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)