### PR TITLE
F4: What-changed chip click fits changed nodes into view (graph-visuals G1)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -59,7 +59,7 @@ import { InfluenceExplainer, useInfluenceExplainer } from '../components/assista
 // floating-first host is mounted as a sibling when the flag is on.
 import { executeCanonicalRun } from './analysis/canonicalRunRegistry'
 import { HighlightLayer } from './highlight/HighlightLayer'
-import { registerFocusHelpers } from './utils/focusHelpers'
+import { registerFocusHelpers, registerFitNodes } from './utils/focusHelpers'
 import { computeFitPadding } from './utils/computeFitPadding'
 import { usePathHighlight } from './hooks/usePathHighlight'
 import { useLensFilter } from './hooks/useLensFilter'
@@ -941,6 +941,26 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   useEffect(() => {
     return registerFocusHelpers(handleFocusNode, handleFocusEdge)
   }, [handleFocusNode, handleFocusEdge])
+
+  // F4 (graph-visuals): registered multi-node fit for USER-INITIATED
+  // surfaces (What-changed chip). Fits every target into view (zoom capped)
+  // with the F1 reduced-motion guard. The AI's autonomous pulse still never
+  // pans — this seam is only reachable from explicit user clicks.
+  const handleFitNodes = useCallback((nodeIds: readonly string[]) => {
+    const store = useCanvasStore.getState()
+    const idSet = new Set(nodeIds)
+    const targets = store.nodes.filter(n => idSet.has(n.id))
+    if (targets.length === 0) return
+    fitViewRef.current({
+      nodes: targets,
+      padding: 0.25,
+      maxZoom: 1.5,
+      duration: cameraDuration(400, reducedMotionRef.current),
+    })
+  }, [])
+  useEffect(() => {
+    return registerFitNodes(handleFitNodes)
+  }, [handleFitNodes])
 
   // Graph Interaction P1: Enable path highlighting based on node selection
   // Highlights causal paths from selected factor to goal, dims unrelated nodes

--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -22,6 +22,7 @@ import { useMemo, useSyncExternalStore } from 'react'
 import { loadRuns } from '../store/runHistory'
 import * as runsBus from '../store/runsBus'
 import { pulseAppliedTargets } from '../utils/appliedEditPulse'
+import { fitNodesOnCanvas } from '../utils/focusHelpers'
 import type { Node, Edge } from '@xyflow/react'
 import { GitCompareArrows } from 'lucide-react'
 import { typography } from '../../styles/typography'
@@ -120,6 +121,12 @@ export function WhatChangedChip() {
   if (parts.length === 0) return null
 
   const handleClick = () => {
+    // F4 (graph-visuals): a chip click is USER-INITIATED, so panning is the
+    // user's intent — fit every surviving changed node into view before the
+    // pulse fires (previously targets often pulsed off-screen). The AI's
+    // autonomous applied-edit pulse still never pans (appliedEditPulse
+    // contract); this fit is reachable only from this click.
+    fitNodesOnCanvas([...diff.nodes.added, ...diff.nodes.modified])
     // Removed elements are gone from the canvas — only surviving changes
     // can be highlighted.
     pulseAppliedTargets({

--- a/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
@@ -24,11 +24,13 @@ import '@testing-library/jest-dom/vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import type { Node, Edge } from '@xyflow/react'
 
-const { loadRunsMock, pulseMock } = vi.hoisted(() => ({
+const { loadRunsMock, pulseMock, fitMock } = vi.hoisted(() => ({
   loadRunsMock: vi.fn(),
   pulseMock: vi.fn(),
+  fitMock: vi.fn(),
 }))
 vi.mock('../../store/runHistory', () => ({ loadRuns: loadRunsMock }))
+vi.mock('../../utils/focusHelpers', () => ({ fitNodesOnCanvas: fitMock }))
 vi.mock('../../utils/appliedEditPulse', () => ({
   pulseAppliedTargets: pulseMock,
   __resetAppliedEditPulseForTests: vi.fn(),
@@ -54,6 +56,7 @@ const run = (graph: { nodes: Node[]; edges: Edge[] }) => ({
 beforeEach(() => {
   loadRunsMock.mockReset()
   pulseMock.mockReset()
+  fitMock.mockReset()
 })
 afterEach(() => cleanup())
 
@@ -237,3 +240,20 @@ describe("Paul's ruling (2026-07-12): keep + improve — honest basis, clear ico
     expect(chip.querySelector('svg')).not.toBeNull()
   })
 })
+
+describe('F4 — chip click fits changed nodes into view (user-initiated pan)', () => {
+  it('clicking the chip fits the surviving changed nodes, before the pulse fires', () => {
+    loadRunsMock.mockReturnValue([
+      run({ nodes: [node('a', 'A2'), node('b', 'B'), node('c', 'C')], edges: [] }),
+      run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }),
+    ])
+    render(<WhatChangedChip />)
+    fireEvent.click(screen.getByTestId('what-changed-chip'))
+    // a = label-modified, c = added; both fit into view…
+    expect(fitMock).toHaveBeenCalledTimes(1)
+    expect([...fitMock.mock.calls[0][0]].sort()).toEqual(['a', 'c'])
+    // …and the fit happens BEFORE the pulse (targets on-screen when they flash).
+    expect(fitMock.mock.invocationCallOrder[0]).toBeLessThan(pulseMock.mock.invocationCallOrder[0])
+  })
+})
+

--- a/src/canvas/utils/focusHelpers.ts
+++ b/src/canvas/utils/focusHelpers.ts
@@ -37,6 +37,34 @@ export function registerFocusHelpers(
   }
 }
 
+type FitNodesFn = (nodeIds: readonly string[]) => void
+let fitNodesImpl: FitNodesFn | null = null
+
+/**
+ * Register the multi-node fit (F4 — called by ReactFlowGraph on mount).
+ * Same ownership-guarded unregister rule as registerFocusHelpers.
+ */
+export function registerFitNodes(fitNodes: FitNodesFn): () => void {
+  fitNodesImpl = fitNodes
+  return () => {
+    if (fitNodesImpl === fitNodes) fitNodesImpl = null
+  }
+}
+
+/**
+ * F4 (graph-visuals): fit the viewport so EVERY given node is visible —
+ * used by USER-INITIATED actions only (e.g. clicking the What-changed
+ * chip) so off-screen targets are brought into view before they pulse.
+ * The AI's autonomous applied-edit pulse deliberately never pans
+ * (appliedEditPulse contract: the AI must not hijack the viewport).
+ * Fail-closed: returns false (no-op) when the canvas is not mounted.
+ */
+export function fitNodesOnCanvas(nodeIds: readonly string[]): boolean {
+  if (!fitNodesImpl || nodeIds.length === 0) return false
+  fitNodesImpl(nodeIds)
+  return true
+}
+
 /**
  * Unregister focus implementations unconditionally.
  * @deprecated Use the unregister function returned by registerFocusHelpers —


### PR DESCRIPTION
Verdict F4, reconciled with the appliedEditPulse no-hijack contract: a **chip click is user-initiated**, so panning is the user's intent. Clicking the What-changed chip now fits every surviving changed node into view (zoom capped, reduced-motion guarded) **before** the pulse — targets no longer flash off-screen. The AI's autonomous pulse still never pans.

Plumbing: `registerFitNodes`/`fitNodesOnCanvas` on the existing focusHelpers singleton (ownership-guarded unregister), implemented over fitViewRef in RFG; fail-closed when unmounted. Pinned: exact target ids + fit-before-pulse ordering.

Gates: ci typecheck clean · chip 18/18 + RFG/focus specs · lint 0 errors · wide tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)