### PR TITLE
fix(results): Codex R3 folds — complete-metric-set ranking, lens data-gate, flip-marker removal + regression pins

### DIFF
--- a/src/canvas/conversation/__tests__/GuidanceStrip.spec.tsx
+++ b/src/canvas/conversation/__tests__/GuidanceStrip.spec.tsx
@@ -17,6 +17,18 @@ import { GuidanceStrip } from '../GuidanceStrip'
 import { useGuidanceStore, type GuidanceItem } from '../../stores/guidanceStore'
 import { _clearTraces, getInteractionChains } from '../../../lib/debug-state'
 
+// Codex R3-SF5: the overview-ownership dedup (the Decision overview card owns
+// "Olumi's top question"; the strip must not show the same item twice) is
+// flag-gated — make the flag controllable while keeping every other flag real.
+const flagState = { decisionOverview: false }
+vi.mock('@/flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/flags')>()
+  return {
+    ...actual,
+    isDecisionOverviewEnabled: () => flagState.decisionOverview,
+  }
+})
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -53,6 +65,7 @@ beforeEach(() => {
   useGuidanceStore.getState().clearGuidanceItems()
   _clearTraces()
   vi.useFakeTimers()
+  flagState.decisionOverview = false
 })
 
 // ---------------------------------------------------------------------------
@@ -80,6 +93,52 @@ describe('GuidanceStrip — render conditions', () => {
     render(<GuidanceStrip {...makeProps()} />)
     expect(screen.getByText('High priority')).toBeInTheDocument()
     expect(screen.queryByText('Low priority')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Overview ownership (Wave SF11 / Codex R3-SF5 regression pin)
+// ---------------------------------------------------------------------------
+
+describe('GuidanceStrip — decision-overview ownership dedup', () => {
+  const overviewOwned = () =>
+    makeItem({ item_id: 'top-q', title: 'Top question', priority: 90, primary_action: { type: 'discuss', prompt: 'Discuss this.' } })
+  const nextItem = () =>
+    makeItem({ item_id: 'second', title: 'Second item', priority: 40, primary_action: { type: 'discuss', prompt: 'Also this.' } })
+
+  it('flag ON: skips the overview-owned top discuss item and shows the next one', () => {
+    flagState.decisionOverview = true
+    useGuidanceStore.getState().setGuidanceItems([overviewOwned(), nextItem()])
+    render(<GuidanceStrip {...makeProps()} />)
+    expect(screen.queryByText('Top question')).not.toBeInTheDocument()
+    expect(screen.getByText('Second item')).toBeInTheDocument()
+  })
+
+  it('flag OFF: the strip keeps showing the top discuss item (no double-gating)', () => {
+    flagState.decisionOverview = false
+    useGuidanceStore.getState().setGuidanceItems([overviewOwned(), nextItem()])
+    render(<GuidanceStrip {...makeProps()} />)
+    expect(screen.getByText('Top question')).toBeInTheDocument()
+  })
+
+  it('flag ON but the top item is not the overview-owned discuss item: shown unchanged', () => {
+    flagState.decisionOverview = true
+    const warnTop = makeItem({
+      item_id: 'warn-top',
+      title: 'A structural warning',
+      priority: 95,
+      primary_action: { type: 'open_inspector', node_id: 'node-1' },
+    })
+    useGuidanceStore.getState().setGuidanceItems([warnTop, overviewOwned()])
+    render(<GuidanceStrip {...makeProps()} />)
+    expect(screen.getByText('A structural warning')).toBeInTheDocument()
+  })
+
+  it('flag ON with only the overview-owned item: strip renders nothing rather than duplicating it', () => {
+    flagState.decisionOverview = true
+    useGuidanceStore.getState().setGuidanceItems([overviewOwned()])
+    render(<GuidanceStrip {...makeProps()} />)
+    expect(screen.queryByTestId('guidance-strip')).not.toBeInTheDocument()
   })
 })
 

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -99,8 +99,11 @@ export function useNodeDisplayMetadata(
       // untyped enrichment passthrough is a fallback only — it must never
       // silently drive a different #1 than the panel), and rank by the
       // DISPLAYED influence metric so the badge order matches the "I: NN%"
-      // readout beside it: producer influence_score when present, else the
-      // per-array-normalised elasticity the readout falls back to.
+      // readout beside it. Codex R3-B1: complete-metric-set policy — producer
+      // influence_score is used only when EVERY factor in the array carries
+      // one; under partial coverage every factor uses per-array-normalised
+      // elasticity, so ranks never compare producer scores against fallbacks.
+      // Mirrors the identical policy in useResultsSectionData (panel side).
       const factorSensitivity = (report.factor_sensitivity?.length
         ? report.factor_sensitivity
         : report.enrichment?.sensitivity_analysis?.factors) || []
@@ -111,12 +114,18 @@ export function useNodeDisplayMetadata(
         ),
         0,
       )
+      const influenceCoverageComplete =
+        factorSensitivity.length > 0 &&
+        factorSensitivity.every(
+          (f: any) => typeof (f.influence_score ?? f.influenceScore) === 'number',
+        )
       const ranked = [...factorSensitivity]
         .map((f: any) => {
           const elasticity = Math.abs(f.elasticity ?? f.sensitivity_score ?? f.importance_score ?? 0)
+          const producerScore = f.influence_score ?? f.influenceScore
           const influence =
-            typeof f.influence_score === 'number'
-              ? f.influence_score
+            influenceCoverageComplete && typeof producerScore === 'number'
+              ? producerScore
               : maxAbsElasticity > 0
                 ? elasticity / maxAbsElasticity
                 : 0
@@ -164,21 +173,12 @@ export function useNodeDisplayMetadata(
           valueOfInformation = rawVoi
         }
 
-        // Influence: Use influence_score if available, otherwise normalize elasticity
-        const rawInfluence = factorData.influence_score ??
-                            factorData.influenceScore ??
-                            factorData.elasticity ??
-                            factorData.sensitivity_score ??
-                            factorData.importance_score
-
-        if (typeof rawInfluence === 'number') {
-          // If already 0-1 (influence_score), use directly; otherwise it's elasticity (needs normalization)
-          if (rawInfluence >= 0 && rawInfluence <= 1) {
-            influence = rawInfluence
-          } else if (ranked.length > 0 && ranked[0].elasticity > 0) {
-            // Normalize against max elasticity
-            influence = Math.abs(rawInfluence) / ranked[0].elasticity
-          }
+        // Influence readout: the ranked entry already resolved the displayed
+        // value under the complete-metric-set policy (Codex R3-B1) — read it
+        // back so the "I: NN%" beside the badge is the number the rank used.
+        const rankedEntry = ranked.find(r => r.id === nodeId)
+        if (rankedEntry && Number.isFinite(rankedEntry.influence)) {
+          influence = rankedEntry.influence
         }
 
         // Confidence: Direct extraction (already 0-1)

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -304,7 +304,7 @@ function DriverRow({
       : 'neutral'
 
   // Use ISL influence_score (0-1) directly for Sensitivity column
-  const sensitivityValue = driver.influenceScore ?? driver.normalisedInfluence
+  const sensitivityValue = driver.displayInfluence ?? driver.influenceScore ?? driver.normalisedInfluence
   const hasSensitivityData = sensitivityValue != null && sensitivityValue >= 0
 
   // Confidence value (0-1)
@@ -393,7 +393,7 @@ function DriverRow({
   })()
 
   const techniqueSuggestion = (() => {
-    const influence = driver.influenceScore ?? driver.normalisedInfluence
+    const influence = driver.displayInfluence ?? driver.influenceScore ?? driver.normalisedInfluence
     const conf = typeof driver.confidence === 'number' ? driver.confidence : null
     if (typeof influence !== 'number' || conf === null) return null
     return influence > 0.6 && conf < 0.5 ? 'Try: reference class forecasting' : null
@@ -646,7 +646,7 @@ function DriverRow({
           <div className={`${typography.panelMeta} text-text-light flex gap-3`}>
             <span>elasticity: {typeof driver.rawElasticity === 'number' ? driver.rawElasticity.toFixed(3) : '-'}</span>
             <span>stability: {driver.attributionStability ?? '-'}</span>
-            <span>influence: {typeof (driver.influenceScore ?? driver.normalisedInfluence) === 'number' ? ((driver.influenceScore ?? driver.normalisedInfluence)! * 100).toFixed(1) + '%' : '-'}</span>
+            <span>influence: {typeof (driver.displayInfluence ?? driver.influenceScore ?? driver.normalisedInfluence) === 'number' ? ((driver.displayInfluence ?? driver.influenceScore ?? driver.normalisedInfluence)! * 100).toFixed(1) + '%' : '-'}</span>
           </div>
         </ExpertBlock>
       )}
@@ -830,7 +830,7 @@ export function DriversSection({
   // This ensures badge count, card rendering, "Show more/fewer", and tornado all use the same filtered set
   const INFLUENCE_THRESHOLD = 0.01
   const visibleDrivers = drivers.filter(d => {
-    const influence = d.influenceScore ?? d.normalisedInfluence
+    const influence = d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence
     return typeof influence === 'number' && influence >= INFLUENCE_THRESHOLD
   })
 
@@ -920,7 +920,7 @@ export function DriversSection({
 
         {/* v7.10 T9: Equal-influence note when all visible drivers are within ±0.01 */}
         {visibleDrivers.length >= 2 && (() => {
-          const scores = visibleDrivers.map(d => d.influenceScore ?? d.normalisedInfluence ?? 0)
+          const scores = visibleDrivers.map(d => d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence ?? 0)
           const max = Math.max(...scores)
           const min = Math.min(...scores)
           return (max - min) <= 0.01 ? (

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -148,18 +148,21 @@ export const ResultsBody = memo(function ResultsBody({
   // Risk appetite toggle — Conservative: highest p10, Neutral: highest win prob, Aggressive: highest p90
   const [riskAppetite, setRiskAppetite] = useState<RiskAppetite>('neutral')
 
-  const riskWinnerId = useMemo(() => {
+  // Codex R3-SF3: a lens comparison needs DATA — options missing the lens
+  // metric are excluded (never defaulted to 0, which let a data-less option
+  // "win" the cautious view), and with fewer than two comparable options the
+  // lens states that comparison is unavailable instead of crowning anyone.
+  const lensComparison = useMemo(() => {
     const opts = resultsSectionData.recommendation.allOptions
-    if (opts.length <= 1) return resultsSectionData.recommendation.recommendedOption?.id
-    if (riskAppetite === 'conservative') {
-      const best = [...opts].sort((a, b) => (b.outcome?.p10 ?? b.p10 ?? 0) - (a.outcome?.p10 ?? a.p10 ?? 0))[0]
-      return best?.id
+    const metric = (o: (typeof opts)[number]) =>
+      riskAppetite === 'conservative' ? (o.outcome?.p10 ?? o.p10) : (o.outcome?.p90 ?? o.p90)
+    if (riskAppetite === 'neutral' || opts.length <= 1) {
+      return { id: resultsSectionData.recommendation.recommendedOption?.id, comparable: true }
     }
-    if (riskAppetite === 'aggressive') {
-      const best = [...opts].sort((a, b) => (b.outcome?.p90 ?? b.p90 ?? 0) - (a.outcome?.p90 ?? a.p90 ?? 0))[0]
-      return best?.id
-    }
-    return resultsSectionData.recommendation.recommendedOption?.id
+    const withData = opts.filter((o) => Number.isFinite(metric(o)))
+    if (withData.length < 2) return { id: undefined, comparable: false }
+    const best = [...withData].sort((a, b) => (metric(b) as number) - (metric(a) as number))[0]
+    return { id: best?.id, comparable: true }
   }, [riskAppetite, resultsSectionData.recommendation])
 
   // Wave 2 (§6.4): identity-anchored ordinals for the option cards — the
@@ -348,9 +351,11 @@ export const ResultsBody = memo(function ResultsBody({
                 data-testid="risk-lens-label"
                 className={`${typography.panelMeta} text-text-light`}
               >
-                {riskAppetite === 'conservative'
-                  ? 'Lens: cautious view, highlighting the option with the strongest downside. The recommendation above is unchanged.'
-                  : 'Lens: bold view, highlighting the option with the strongest upside. The recommendation above is unchanged.'}
+                {!lensComparison.comparable
+                  ? 'Not enough range data to compare options under this lens.'
+                  : riskAppetite === 'conservative'
+                    ? 'Lens: cautious view, highlighting the option with the strongest downside. The recommendation above is unchanged.'
+                    : 'Lens: bold view, highlighting the option with the strongest upside. The recommendation above is unchanged.'}
               </p>
             )}
             {/* WinGauge — moved from hero to top of options section */}
@@ -372,7 +377,7 @@ export const ResultsBody = memo(function ResultsBody({
               options={resultsSectionData.recommendation.allOptions}
               winnerId={resultsSectionData.recommendation.recommendedOption?.id}
               lensActive={riskAppetite !== 'neutral'}
-              lensHighlightedId={riskAppetite !== 'neutral' ? riskWinnerId : undefined}
+              lensHighlightedId={riskAppetite !== 'neutral' && lensComparison.comparable ? lensComparison.id : undefined}
               stableNumbers={stableNumbersForCards}
               onSendMessage={onSendMessage}
               hasGoalThreshold={resultsSectionData.recommendation.goalThreshold != null}

--- a/src/components/results/TornadoChart.tsx
+++ b/src/components/results/TornadoChart.tsx
@@ -132,7 +132,10 @@ export interface TornadoChartProps {
   isNormalised?: boolean
   /** Goal direction — determines bar colour semantics (higher outcome = green for maximize, orange for minimize) */
   goalDirection?: 'maximize' | 'minimize'
-  /** A4: Flip threshold data for marker annotations */
+  /** A4: Flip threshold data — accepted but not rendered. The flip marker was
+   *  removed (Codex R3-SF4): flip_value is a factor-space value and the bars are
+   *  outcome-space, so positioning it on the bar was an invalid coordinate mapping.
+   *  Re-add rendering only when factor-space bounds (factorLow/factorHigh) exist. */
   flipThresholds?: FlipThreshold[]
   /** Task 4: Factor IDs with contested inbound edges — highlighted with dashed border */
   contestedFactorIds?: string[]
@@ -202,52 +205,6 @@ function formatExpectedLabel(
   return `Expected: ${formatted}`
 }
 
-// ─── FlipMarker (A4) ────────────────────────────────────────────────────────
-
-interface FlipMarkerProps {
-  row: TornadoRow
-  flipThresholds: FlipThreshold[] | undefined
-  totalRange: number
-  minVal: number
-}
-
-function FlipMarker({ row, flipThresholds, totalRange, minVal }: FlipMarkerProps) {
-  const flipThreshold = flipThresholds?.find(ft => ft.node_id === row.factorKey)
-  const hasFlip = flipThreshold?.flip_value != null
-    && flipThreshold.flip_reason !== 'heuristic'
-    && flipThreshold.flip_reason !== 'no_bracket'
-  if (!hasFlip || flipThreshold?.flip_value == null) return null
-
-  const flipVal = flipThreshold.flip_value
-  const range = row.highOutcome - row.lowOutcome
-  if (range === 0) return null
-
-  const rawPct = ((flipVal - row.lowOutcome) / range) * 100
-  const rowLowPct = totalRange > 0 ? ((row.lowOutcome - minVal) / totalRange) * 100 : 0
-  const rowHighPct = totalRange > 0 ? ((row.highOutcome - minVal) / totalRange) * 100 : 0
-  const clampedLocalPct = Math.max(0, Math.min(100, rawPct))
-  const chartPct = rowLowPct + (clampedLocalPct / 100) * (rowHighPct - rowLowPct)
-
-  const formattedFlip = flipThreshold.unit
-    ? `${flipThreshold.unit}${Math.round(flipVal).toLocaleString()}`
-    : Math.abs(flipVal) >= 10
-      ? Math.round(flipVal).toLocaleString()
-      : flipVal.toFixed(1)
-
-  return (
-    <div
-      className="absolute top-1/2 -translate-y-1/2 flex flex-col items-center pointer-events-none z-10"
-      style={{ left: `${chartPct}%` }}
-      data-testid="flip-marker"
-      title={`Flips at ${formattedFlip}`}
-    >
-      <div className="w-[6px] h-[6px] bg-danger rotate-45" aria-hidden="true" />
-      <span className={`${typography.panelMeta} text-danger whitespace-nowrap absolute top-full mt-0.5`}>
-        Flips at {formattedFlip}
-      </span>
-    </div>
-  )
-}
 
 // ─── Drag state management ──────────────────────────────────────────────────
 
@@ -281,7 +238,6 @@ export function TornadoChart({
   onFocusNode,
   isNormalised,
   goalDirection,
-  flipThresholds,
   contestedFactorIds,
 }: TornadoChartProps) {
   const contestedSet = new Set(contestedFactorIds ?? [])
@@ -656,9 +612,6 @@ export function TornadoChart({
                     </div>
                   </div>
                 )}
-
-                {/* A4: Flip-point marker — diamond on bar showing where recommendation changes */}
-                <FlipMarker row={row} flipThresholds={flipThresholds} totalRange={totalRange} minVal={minVal} />
 
                 {/* Low value label — hidden when left bar is collapsed.
                     Brief 5.4 closeout item 8: clamped to min 1% from left so the

--- a/src/components/results/__tests__/OptionCards.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.spec.tsx
@@ -736,4 +736,3 @@ describe('Codex B1 — a lens never re-crowns leader SEMANTICS', () => {
     expect(canonicalCard.textContent).toMatch(/What makes this/i)
   })
 })
-

--- a/src/components/results/__tests__/TornadoChart.flipMarkers.test.tsx
+++ b/src/components/results/__tests__/TornadoChart.flipMarkers.test.tsx
@@ -19,8 +19,18 @@ const rows: TornadoRow[] = [
   { factorKey: 'factor-2', label: 'Factor Two', lowOutcome: 200, highOutcome: 400, canFocus: true },
 ]
 
-describe('TornadoChart flip markers (A4)', () => {
-  it('renders flip marker when flip_value is present', () => {
+/**
+ * Codex R3-SF4: the flip marker was REMOVED. flip_value is a factor-space
+ * value; the tornado bars span outcome-space (the recommended option's
+ * p10–p90). Positioning one against the other was an invalid coordinate
+ * mapping that placed the "Flips at" diamond at a meaningless point. These
+ * tests pin the removal: no marker renders even with fully valid producer
+ * flip data. Re-enable rendering only when factor-space bounds
+ * (factorLow/factorHigh) are threaded through the tornado data pipeline —
+ * see the header comment in TornadoChart.tsx.
+ */
+describe('TornadoChart flip markers (removed — Codex R3-SF4)', () => {
+  it('renders NO marker even when flip_value is present and certified', () => {
     const flipThresholds: FlipThreshold[] = [
       { label: 'Factor One', node_id: 'factor-1', current_value: 300, flip_value: 400, unit: '$' },
     ]
@@ -33,44 +43,11 @@ describe('TornadoChart flip markers (A4)', () => {
       />,
     )
 
-    const markers = screen.getAllByTestId('flip-marker')
-    expect(markers).toHaveLength(1)
-    expect(markers[0]).toHaveAttribute('title', 'Flips at $400')
-  })
-
-  it('does not render marker when flip_value is null', () => {
-    const flipThresholds: FlipThreshold[] = [
-      { label: 'Factor Two', node_id: 'factor-2', current_value: 300, flip_value: null, flip_reason: 'no_bracket' },
-    ]
-
-    render(
-      <TornadoChart
-        rows={rows}
-        expectedOutcome={300}
-        flipThresholds={flipThresholds}
-      />,
-    )
-
     expect(screen.queryByTestId('flip-marker')).toBeNull()
+    expect(screen.queryByTitle(/Flips at/)).toBeNull()
   })
 
-  it('does not render marker when flip_reason is heuristic', () => {
-    const flipThresholds: FlipThreshold[] = [
-      { label: 'Factor One', node_id: 'factor-1', current_value: 300, flip_value: 400, flip_reason: 'heuristic' as any },
-    ]
-
-    render(
-      <TornadoChart
-        rows={rows}
-        expectedOutcome={300}
-        flipThresholds={flipThresholds}
-      />,
-    )
-
-    expect(screen.queryByTestId('flip-marker')).toBeNull()
-  })
-
-  it('renders markers for multiple rows with valid flip data', () => {
+  it('renders NO markers for multiple rows with valid flip data', () => {
     const flipThresholds: FlipThreshold[] = [
       { label: 'Factor One', node_id: 'factor-1', current_value: 300, flip_value: 400 },
       { label: 'Factor Two', node_id: 'factor-2', current_value: 300, flip_value: 350 },
@@ -84,7 +61,24 @@ describe('TornadoChart flip markers (A4)', () => {
       />,
     )
 
-    const markers = screen.getAllByTestId('flip-marker')
-    expect(markers).toHaveLength(2)
+    expect(screen.queryByTestId('flip-marker')).toBeNull()
+  })
+
+  it('accepting flipThresholds without rendering markers does not break the chart', () => {
+    const flipThresholds: FlipThreshold[] = [
+      { label: 'Factor Two', node_id: 'factor-2', current_value: 300, flip_value: null, flip_reason: 'no_bracket' },
+    ]
+
+    render(
+      <TornadoChart
+        rows={rows}
+        expectedOutcome={300}
+        flipThresholds={flipThresholds}
+      />,
+    )
+
+    expect(screen.getByTestId('tornado-chart')).toBeInTheDocument()
+    expect(screen.getByText('Factor One')).toBeInTheDocument()
+    expect(screen.getByText('Factor Two')).toBeInTheDocument()
   })
 })

--- a/src/components/results/__tests__/useResultsSectionData.reactivity.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.reactivity.spec.ts
@@ -136,4 +136,27 @@ describe('Wave F-A/W2 integration: option-numbering registration reaches the sto
     // No fragmentation artefacts: exactly the analysed ids, nothing else.
     expect(Object.keys(numbering).sort()).toEqual(['opt_a', 'opt_b'])
   })
+
+  it('ids containing control characters register intact (Codex R2: the dep key is JSON-encoded, not delimiter-joined)', () => {
+    const weirdIds = ['opt_\u0000weird', 'opt_b']
+    act(() => {
+      useCanvasStore.setState({
+        nodes: weirdIds.map((id, i) => ({
+          id,
+          type: 'option',
+          position: { x: 0, y: i * 100 },
+          data: { label: `Option ${i + 1}`, kind: 'option' },
+        })) as any,
+      } as any)
+    })
+    renderHook(() => useResultsSectionData())
+    const numbering = useCanvasStore.getState().optionNumbering
+    // The regression: a delimiter-joined dep key fragmented ids on the
+    // delimiter. The id must register as ONE intact key with an ordinal,
+    // with no fragment artefacts alongside it.
+    expect(numbering['opt_\u0000weird']).toBeGreaterThan(0)
+    const keys = Object.keys(numbering)
+    expect(keys).not.toContain('opt_')
+    expect(keys).not.toContain('weird')
+  })
 })

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -14,6 +14,7 @@ import {
   getRawElasticity,
   computeNormalisedInfluences,
   computeFactorRanks,
+  resolveDisplayInfluences,
   normaliseDirection,
   getFactorDirection,
   getSemanticLabel,
@@ -260,6 +261,53 @@ describe('normaliseLabel', () => {
 // =============================================================================
 // 4. Rank Computation Tests
 // =============================================================================
+
+describe('resolveDisplayInfluences (Codex R3-B1: complete-metric-set policy)', () => {
+  it('adopts producer influence only when EVERY factor carries one', () => {
+    const entries = [
+      { key: 'a', influenceScore: 0.9 },
+      { key: 'b', influenceScore: 0.2 },
+    ]
+    const normalised = new Map([['a', 0.1], ['b', 1.0]])
+    const result = resolveDisplayInfluences(entries, normalised)
+    expect(result.get('a')).toBe(0.9)
+    expect(result.get('b')).toBe(0.2)
+  })
+
+  it('partial coverage: EVERY factor falls back to normalised elasticity — a producer 0.9 must not outrank the elasticity-dominant factor it cannot be compared with', () => {
+    // Codex R3-B1 scenario: A has influence_score 0.9, B has NO producer score
+    // but dominant elasticity, C has influence_score 0.2. Mixing bases would
+    // rank A #1 on a producer scale B never entered. Under the policy all
+    // three resolve on the normalised-elasticity basis: B (1.0) > A > C.
+    const entries = [
+      { key: 'a', influenceScore: 0.9 },
+      { key: 'b' },
+      { key: 'c', influenceScore: 0.2 },
+    ]
+    const normalised = new Map([['a', 0.4], ['b', 1.0], ['c', 0.1]])
+    const result = resolveDisplayInfluences(entries, normalised)
+    expect(result.get('a')).toBe(0.4)
+    expect(result.get('b')).toBe(1.0)
+    expect(result.get('c')).toBe(0.1)
+    // And the rank the surfaces crown by follows the same single basis:
+    const rankMap = computeFactorRanks([
+      { key: 'a', rawElasticity: 0.4, displayValue: result.get('a') },
+      { key: 'b', rawElasticity: 1.0, displayValue: result.get('b') },
+      { key: 'c', rawElasticity: 0.1, displayValue: result.get('c') },
+    ])
+    expect(rankMap.get('b')).toBe(1)
+    expect(rankMap.get('a')).toBe(2)
+    expect(rankMap.get('c')).toBe(3)
+  })
+
+  it('no producer coverage at all: normalised basis for everyone', () => {
+    const entries = [{ key: 'a' }, { key: 'b' }]
+    const normalised = new Map([['a', 1.0], ['b', 0.5]])
+    const result = resolveDisplayInfluences(entries, normalised)
+    expect(result.get('a')).toBe(1.0)
+    expect(result.get('b')).toBe(0.5)
+  })
+})
 
 describe('computeFactorRanks', () => {
   it('ranks by absolute elasticity descending', () => {
@@ -1615,4 +1663,3 @@ describe('Codex B2 — ranking doctrine: order and crown follow the DISPLAYED in
     expect(rankMap.get('b')).toBe(2)
   })
 })
-

--- a/src/components/results/decision-overview/__tests__/ActionsMenu.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/ActionsMenu.spec.tsx
@@ -53,6 +53,23 @@ describe('ActionsMenu', () => {
     expect(document.activeElement).toBe(trigger)
   })
 
+  it('closes on Tab without trapping focus (Codex SF8: disclosure, not a focus trap)', () => {
+    render(<ActionsMenu />)
+    const trigger = screen.getByRole('button', { name: /actions/i })
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Tab' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('closes on Shift+Tab the same way', () => {
+    render(<ActionsMenu />)
+    const trigger = screen.getByRole('button', { name: /actions/i })
+    fireEvent.click(trigger)
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Tab', shiftKey: true })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+  })
+
   it('a method opens a contextual session: dispatchAction with method identity in parameters', () => {
     const dispatch = vi.fn()
     useGuidanceStore.setState({ _dispatchAction: dispatch } as never)

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -508,6 +508,13 @@ export interface DriverItem {
   normalisedInfluence: number
   /** ISL influence_score (0-1) - structural causal influence, used for Influence column */
   influenceScore?: number
+  /** Codex R3-B1: the value every surface displays AND ranks by, resolved under the
+   *  complete-metric-set policy — producer influenceScore only when EVERY ranked factor
+   *  carries one (a single comparable basis), otherwise normalisedInfluence for every
+   *  factor. Consumers must render/sort this, not influenceScore ?? normalisedInfluence,
+   *  which mixes bases under partial producer coverage. Optional only for legacy
+   *  fixtures — the live pipeline always sets it. */
+  displayInfluence?: number
   /** Producer influence_rank (1 = most influential). Additive; roadmap 1.7 (provisional_doctrine_v0). */
   influenceRank?: number
   /** ISL zero_reason - explains why sensitivity is zero for intervention factors */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -467,6 +467,35 @@ function computeNormalisedInfluences(
 // =============================================================================
 
 /**
+ * Codex R3-B1 — complete-metric-set policy, in one pure place.
+ *
+ * Resolves the single influence value every surface displays AND ranks by:
+ * producer influenceScore is adopted only when EVERY factor carries one
+ * (one comparable basis across the whole set); under partial coverage every
+ * factor resolves to its elasticity-normalised influence instead. A per-factor
+ * `influenceScore ?? normalised` fallback is forbidden — it ranks producer
+ * scores against fallback values that are not on the same scale.
+ * Mirrored by useNodeDisplayMetadata for the graph badge.
+ */
+function resolveDisplayInfluences(
+  entries: Array<{ key: string; influenceScore?: number }>,
+  normalisedMap: Map<string, number>,
+): Map<string, number> {
+  const coverageComplete =
+    entries.length > 0 && entries.every((e) => typeof e.influenceScore === 'number')
+  const out = new Map<string, number>()
+  for (const e of entries) {
+    out.set(
+      e.key,
+      coverageComplete && typeof e.influenceScore === 'number'
+        ? e.influenceScore
+        : normalisedMap.get(e.key) ?? 0,
+    )
+  }
+  return out
+}
+
+/**
  * Compute ranks for all factors based on absolute elasticity.
  * Returns map of factorKey -> rank (1-indexed)
  */
@@ -763,13 +792,13 @@ function classifySeverityLegacy(
  * @deprecated Remove after 2026-05-12 — PLoT B1 now provides dominant_factor on the response.
  */
 function detectDominantFactorLegacy(
-  nonZeroImpactDrivers: Array<{ factorKey: string; factorLabel: string; influenceScore?: number; normalisedInfluence?: number }>
+  nonZeroImpactDrivers: Array<{ factorKey: string; factorLabel: string; displayInfluence?: number; influenceScore?: number; normalisedInfluence?: number }>
 ): { dominantFactorId: string; dominantFactorLabel: string } | undefined {
   if (nonZeroImpactDrivers.length < 2) return undefined
   const top1 = nonZeroImpactDrivers[0]
   const top2 = nonZeroImpactDrivers[1]
-  const top1Influence = top1.influenceScore ?? top1.normalisedInfluence
-  const top2Influence = top2.influenceScore ?? top2.normalisedInfluence
+  const top1Influence = top1.displayInfluence ?? top1.influenceScore ?? top1.normalisedInfluence
+  const top2Influence = top2.displayInfluence ?? top2.influenceScore ?? top2.normalisedInfluence
   if (typeof top1Influence !== 'number' || typeof top2Influence !== 'number') return undefined
   const isDominant = top1Influence > 0.5 && (top2Influence > 0 ? top1Influence / top2Influence > 2 : true)
   if (isDominant) {
@@ -1766,13 +1795,17 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
 
     // Step 3: Compute ranks by the DISPLAYED metric (Codex B2 doctrine fix:
     // the surface says "Influence", so the order and the rank-1 crown follow
-    // the same number the bar renders — producer influence_score when
-    // present, else the elasticity-derived normalisedInfluence the bar
-    // falls back to. Ordering and label can no longer contradict the bar.)
+    // the same number the bar renders. Codex R3-B1 tightens this to a
+    // complete-metric-set policy: producer influence_score is used only when
+    // EVERY factor carries one — a partial set would rank a mixture of
+    // producer scores and elasticity-normalised fallbacks, which are not
+    // comparable. Under partial coverage every factor displays and ranks by
+    // normalisedInfluence instead, so the whole surface shares one basis.
+    const displayInfluenceMap = resolveDisplayInfluences(factorsWithKeys, normalisedMap)
     const rankMap = computeFactorRanks(
       factorsWithKeys.map((f) => ({
         ...f,
-        displayValue: f.influenceScore ?? normalisedMap.get(f.key) ?? 0,
+        displayValue: displayInfluenceMap.get(f.key) ?? 0,
       })),
     )
 
@@ -1918,6 +1951,8 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           normalisedInfluence,
           // ISL influence_score (0-1) - use directly for Influence column
           influenceScore: f.raw.influenceScore,
+          // Codex R3-B1: single display basis (see DriverItem.displayInfluence)
+          displayInfluence: displayInfluenceMap.get(f.key) ?? 0,
           // Producer influence_rank passthrough (roadmap 1.7, provisional_doctrine_v0)
           influenceRank: f.raw.influenceRank,
           // ISL zero_reason - explains why sensitivity is zero
@@ -1970,7 +2005,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     // These are filtered from default view but included in "See all factors"
     const ZERO_IMPACT_THRESHOLD = 0.01
     const isZeroImpact = (d: DriverItem) => {
-      const influence = d.influenceScore ?? d.normalisedInfluence
+      const influence = d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence
       // Bug fix: Handle undefined influence - treat as zero if missing
       const effectiveInfluence = typeof influence === 'number' ? influence : 0
       // v7.2: Zero impact = influence < 0.01 (confidence not checked)
@@ -2912,6 +2947,7 @@ export {
   getRawElasticity,
   computeNormalisedInfluences,
   computeFactorRanks,
+  resolveDisplayInfluences,
   normalizeOutcomeValues,
   normaliseDirection,
   getFactorDirection,

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -20,6 +20,39 @@ const baseBlock = (overrides: Partial<AnalysisResultBlock> = {}): AnalysisResult
   ...overrides,
 })
 
+describe('mapV5AnalysisToReport — decision_brief passthrough (Codex SF7/R3-SF5)', () => {
+  it('carries enrichment.decision_brief verbatim onto the widened report (live V5 path)', () => {
+    const decisionBrief = {
+      headline_banded: {
+        band: 'clearly_ahead',
+        leader_id: 'opt_a',
+        robustness_gated: false,
+      },
+    }
+    const block = baseBlock({
+      win_probabilities: { opt_a: 0.8, opt_b: 0.2 },
+      enrichment: { decision_brief: decisionBrief } as never,
+    })
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> &
+      Record<string, unknown>
+    expect(report.decision_brief).toEqual(decisionBrief)
+  })
+
+  it('absent decision_brief leaves no key on the report (no fabricated band)', () => {
+    const block = baseBlock({ enrichment: {} as never })
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> &
+      Record<string, unknown>
+    expect('decision_brief' in report).toBe(false)
+  })
+
+  it('non-object decision_brief is dropped, not passed through', () => {
+    const block = baseBlock({ enrichment: { decision_brief: 'clearly_ahead' } as never })
+    const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> &
+      Record<string, unknown>
+    expect('decision_brief' in report).toBe(false)
+  })
+})
+
 describe('mapV5AnalysisToReport — option IDs and probabilities', () => {
   it('option_probabilities keys match win_probabilities keys exactly (no synthesised opt_0/opt_1)', () => {
     const block = baseBlock({


### PR DESCRIPTION
## Codex round-3 folds (critically analysed; all verified in code before fixing)

### Blocker 1 — mixed influence bases under partial coverage → FIXED
`resolveDisplayInfluences` (pure, exported, tested with Codex's exact scenario): producer `influence_score` is adopted only when **every** factor carries one; otherwise every factor displays and ranks on `normalisedInfluence`. One basis across bars, sort, crown, zero-impact gate, dominance heuristic, graph badge rank **and** graph readout.

### Blocker 2 — decision_brief stripped by schema keep-list → VERIFIED + ROUTED
Confirmed in the pinned vendored schema: `CEE_UI_ENRICHMENT_KEEP_LIST` (11 keys) lacks `decision_brief`, so a conforming CEE projection strips it before the UI mapper. That fix lives in **olumi-schemas + CEE** (cross-repo — routed via handover/program board). UI side is ready and now contract-pinned so it lights up the moment transport lands.

### SF3 — lens crowned data-less options → FIXED
Options missing p10/p90 are excluded from the cautious/bold comparison (previously `?? 0` let them win); fewer than 2 comparable options → no crown, honest 'Not enough range data to compare options under this lens.'

### SF4 — flip markers in wrong coordinate space → REMOVED
`flip_value` is factor-space; the bars are outcome-space. Marker removed (with the reversed `%10` format); prop retained + documented for future factor-space bounds. Old marker tests flipped to pin the removal.

### SF5 — regression pins now committed
- Partial-coverage policy (exact R3 scenario, rank + value assertions)
- ActionsMenu Tab/Shift+Tab closes without trapping focus
- GuidanceStrip overview-ownership dedup (flag on/off/non-discuss/sole-item)
- V5 `decision_brief` passthrough (present/absent/non-object)
- NUL-containing option ids register intact

### Nits
EOF blank lines fixed in both spec files.

## Gates
- typecheck (ci) clean; wide-tsc (app) diffed vs origin/staging count-normalised: **identical count (4053), only line shifts + one error removed** (the FlipMarker TS2367)
- changed-set tests vs origin/staging: **79 files, 1231 passed** (after flipping the marker suite + fixing an over-strict new assertion)
- lint: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)