### PR TITLE
feat(results): parity P1 — Ask-Olumi drawer, universal focus resolver, Strengthen flag promotion

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -77,6 +77,12 @@
   # [build.environment] ONLY after sign-off.
   VITE_FEATURE_DECISION_OVERVIEW = "1"
 
+  # Analysis-tab rebuild Wave 3 (Strengthen your model — adaptive coaching
+  # recommendations). The parity audit found the surface fully merged but
+  # DARK on staging because this promotion was missed at merge time. Promote
+  # to production by adding to [build.environment] ONLY after sign-off.
+  VITE_FEATURE_STRENGTHEN_PANEL = "1"
+
   # Hero fixture gallery — internal-only /dev/hero-gallery route rendering
   # prototype hero states from typed fixtures (visible internal-preview
   # banner on every instance). Staging-only for design review; never add to

--- a/src/canvas/utils/__tests__/focusModelTarget.spec.ts
+++ b/src/canvas/utils/__tests__/focusModelTarget.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Parity P1 — universal model-target focus resolution.
+ *
+ * Strengthen recommendations and guidance items can carry a canvas node id,
+ * a canvas edge id, OR a PLoT edge id (producer edge_id or the synthetic
+ * `${from}->${to}` arrow form). The old focusExistingTarget(id, 'node')
+ * treated everything as a node id, so edge-targeted "Focus on canvas"
+ * buttons silently no-oped (audit broken-function class). focusModelTarget
+ * resolves all three shapes and stays fail-closed for unknowns.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  registerFocusHelpers,
+  unregisterFocusHelpers,
+  focusModelTarget,
+} from '../focusHelpers'
+import { useCanvasStore } from '../../store'
+
+describe('focusModelTarget', () => {
+  const focusNode = vi.fn()
+  const focusEdge = vi.fn()
+
+  beforeEach(() => {
+    focusNode.mockClear()
+    focusEdge.mockClear()
+    registerFocusHelpers(focusNode, focusEdge)
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'fac_price', type: 'factor', position: { x: 0, y: 0 }, data: {} } as any,
+        { id: 'goal_1', type: 'goal', position: { x: 0, y: 0 }, data: {} } as any,
+      ],
+      edges: [
+        { id: 'e1', source: 'fac_price', target: 'goal_1', data: {} } as any,
+        { id: 'e2', source: 'goal_1', target: 'fac_price', data: { edge_id: 'plot_edge_77' } } as any,
+      ],
+    })
+  })
+
+  afterEach(() => {
+    unregisterFocusHelpers()
+  })
+
+  it('resolves a canvas node id', () => {
+    expect(focusModelTarget('fac_price')).toBe(true)
+    expect(focusNode).toHaveBeenCalledWith('fac_price')
+  })
+
+  it('resolves a canvas edge id', () => {
+    expect(focusModelTarget('e1')).toBe(true)
+    expect(focusEdge).toHaveBeenCalledWith('e1')
+  })
+
+  it('resolves the PLoT arrow form to the real canvas edge', () => {
+    expect(focusModelTarget('fac_price->goal_1')).toBe(true)
+    expect(focusEdge).toHaveBeenCalledWith('e1')
+    expect(focusNode).not.toHaveBeenCalled()
+  })
+
+  it('arrow form with an unmatchable side falls back to the endpoint node that exists', () => {
+    // Container fallback builds `${from_id}->${to_label}` — the label side
+    // matches no node, but the from side is a real node.
+    expect(focusModelTarget('fac_price->Higher revenue')).toBe(true)
+    expect(focusNode).toHaveBeenCalledWith('fac_price')
+    expect(focusEdge).not.toHaveBeenCalled()
+  })
+
+  it('resolves a producer edge_id stashed on edge.data', () => {
+    expect(focusModelTarget('plot_edge_77')).toBe(true)
+    expect(focusEdge).toHaveBeenCalledWith('e2')
+  })
+
+  it('fails closed for an unknown id', () => {
+    expect(focusModelTarget('ghost')).toBe(false)
+    expect(focusNode).not.toHaveBeenCalled()
+    expect(focusEdge).not.toHaveBeenCalled()
+  })
+
+  it('fails closed for an empty id', () => {
+    expect(focusModelTarget('')).toBe(false)
+  })
+})

--- a/src/canvas/utils/focusHelpers.ts
+++ b/src/canvas/utils/focusHelpers.ts
@@ -160,6 +160,58 @@ export function focusExistingTarget(
   return true
 }
 
+/**
+ * Parity P1 (audit: broken-function) — universal model-target resolver.
+ *
+ * Guidance items and Strengthen recommendations carry ids that may be a
+ * canvas node id, a canvas edge id, OR a PLoT edge id (often the synthetic
+ * `${source}->${target}` form) that no canvas element carries verbatim.
+ * focusExistingTarget(id, 'node') silently no-ops on those — the audit's
+ * "Focus on canvas does nothing" class of dead buttons.
+ *
+ * Resolution order (fail-closed, returns false when nothing focusable):
+ *  1. exact canvas node id
+ *  2. exact canvas edge id
+ *  3. arrow-form edge id: resolve endpoints to the real canvas edge,
+ *     else fall back to whichever endpoint node exists
+ *  4. producer edge id stashed on edge.data (edge_id / plot_edge_id)
+ */
+export function focusModelTarget(targetId: string): boolean {
+  if (!targetId) return false
+  const { nodes, edges } = useCanvasStore.getState()
+  if (nodes.some((n) => n.id === targetId)) {
+    focusByTarget(targetId, 'node')
+    return true
+  }
+  if (edges.some((e) => e.id === targetId)) {
+    focusByTarget(targetId, 'edge')
+    return true
+  }
+  const parts = targetId.split(/->|\u2192/)
+  if (parts.length === 2) {
+    const [from, to] = parts.map((x) => x.trim())
+    const edge = edges.find((e) => e.source === from && e.target === to)
+    if (edge) {
+      focusByTarget(edge.id, 'edge')
+      return true
+    }
+    const endpoint = [from, to].find((id) => nodes.some((n) => n.id === id))
+    if (endpoint) {
+      focusByTarget(endpoint, 'node')
+      return true
+    }
+  }
+  const byData = edges.find((e) => {
+    const d = e.data as Record<string, unknown> | undefined
+    return d?.edge_id === targetId || d?.plot_edge_id === targetId
+  })
+  if (byData) {
+    focusByTarget(byData.id, 'edge')
+    return true
+  }
+  return false
+}
+
 export function focusByTarget(
   targetId: string,
   targetType?: FocusTargetType

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -28,6 +28,7 @@ import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWit
 import { DecisionConfidencePanel } from './DecisionConfidencePanel'
 import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
+import { AskOlumiDrawer } from './coaching/AskOlumiDrawer'
 import { WhatChangedChip } from '../../canvas/components/WhatChangedChip'
 import { StrengthenContainer } from './strengthen/StrengthenContainer'
 import { InferenceWarningStrip } from './InferenceWarningStrip'
@@ -238,6 +239,11 @@ export const ResultsBody = memo(function ResultsBody({
 
   return (
     <div className="flex flex-col gap-4" data-testid="outputs-results-redesign">
+
+      {/* Parity P1: the "Work through it with Olumi" drawer — one instance
+          for every routed ask on this tab (methods, pills, framing question,
+          Strengthen work-through). Renders nothing until opened. */}
+      <AskOlumiDrawer />
 
       {/* Orphan banner — Results from a non-CEE path with no run_analysis
           fact for the scenario. Renders only when canonical flag is ON and

--- a/src/components/results/coaching/AskOlumiDrawer.tsx
+++ b/src/components/results/coaching/AskOlumiDrawer.tsx
@@ -1,0 +1,194 @@
+/**
+ * Parity P1 — "Work through it with Olumi" drawer (prototype #olumiDrawer,
+ * build-ready v6).
+ *
+ * Anatomy per spec: fixed bottom-right, min(370px, 100vw−36px), radius 12,
+ * shadow-2; head = 14/600 title + × icon-button; body = context box with an
+ * info border (radius 9), prefilled EDITABLE textarea (min-height 64px),
+ * right-aligned actions "Focus on canvas" (ghost, only when the target
+ * resolves) + "Send" (primary).
+ *
+ * Send dispatches a conversation-typed turn via the guidance store degrade
+ * chain (_dispatchAction → _sendMessage); when neither callback is
+ * registered the Send button is disabled with an honest hint rather than a
+ * silent no-op (the audit's dead-button class). Focus on canvas resolves
+ * node/edge/PLoT-arrow ids via focusModelTarget (fail-closed).
+ *
+ * Accessibility beyond the prototype (its own spec flags these as gaps to
+ * fix in build): Escape closes, focus moves to the textarea on open and
+ * returns to the prior element on close.
+ *
+ * Toast: self-contained (prototype chrome — fixed bottom-centre dark pill,
+ * role="status", auto-hide 1800ms) because ToastProvider is not mounted in
+ * the live results tree.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import { focusModelTarget } from '../../../canvas/utils/focusHelpers'
+import { useAskOlumiStore } from './askOlumiStore'
+
+const TOAST_MS = 1800
+
+export function AskOlumiDrawer() {
+  const isOpen = useAskOlumiStore((s) => s.isOpen)
+  const context = useAskOlumiStore((s) => s.context)
+  const draft = useAskOlumiStore((s) => s.draft)
+  const label = useAskOlumiStore((s) => s.label)
+  const targetId = useAskOlumiStore((s) => s.targetId)
+  const parameters = useAskOlumiStore((s) => s.parameters)
+  const source = useAskOlumiStore((s) => s.source)
+  const setDraft = useAskOlumiStore((s) => s.setDraft)
+  const close = useAskOlumiStore((s) => s.close)
+
+  const dispatchAction = useGuidanceStore((s) => s._dispatchAction)
+  const sendMessage = useGuidanceStore((s) => s._sendMessage)
+  const canSend = dispatchAction !== null || sendMessage !== null
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const showToast = useCallback((message: string) => {
+    setToast(message)
+    if (toastTimer.current) clearTimeout(toastTimer.current)
+    toastTimer.current = setTimeout(() => setToast(null), TOAST_MS)
+  }, [])
+
+  useEffect(() => () => {
+    if (toastTimer.current) clearTimeout(toastTimer.current)
+  }, [])
+
+  // Focus management: remember the opener, focus the textarea, restore on close.
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null
+      textareaRef.current?.focus()
+    } else {
+      previousFocusRef.current?.focus?.()
+      previousFocusRef.current = null
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [isOpen, close])
+
+  const handleSend = () => {
+    const text = draft.trim()
+    if (!text || !canSend) return
+    if (dispatchAction) {
+      // Conversation-typed turn: chip_metadata (the contextual-session
+      // carrier) survives ONLY on this turn type.
+      void dispatchAction({
+        action_type: 'discuss',
+        parameters,
+        label,
+        message: text,
+        source,
+      })
+    } else if (sendMessage) {
+      sendMessage(text)
+    }
+    showToast('Sent to Olumi with the relevant model context')
+    close()
+  }
+
+  const handleFocusCanvas = () => {
+    if (!targetId) return
+    const ok = focusModelTarget(targetId)
+    showToast(
+      ok
+        ? 'Focused the relevant model elements on the canvas'
+        : 'That element is no longer on the canvas',
+    )
+  }
+
+  const targetResolvable = targetId !== null && targetId !== ''
+
+  return (
+    <>
+      {isOpen && (
+        <aside
+          data-testid="ask-olumi-drawer"
+          role="dialog"
+          aria-label="Work through it with Olumi"
+          className="fixed bottom-[18px] right-[18px] z-[25] w-[min(370px,calc(100vw-36px))] rounded-xl border border-panel-border bg-panel shadow-2"
+        >
+          <div className="flex items-center gap-2 px-[11px] pt-[10px]">
+            <h2 className="flex-1 text-sm font-semibold text-text-header">
+              Work through it with Olumi
+            </h2>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={close}
+              className="rounded-lg p-1 text-text-light hover:bg-panel-hover hover:text-text-header"
+            >
+              <X size={15} aria-hidden="true" />
+            </button>
+          </div>
+          <div className="px-[11px] pb-[10px] pt-2">
+            {context && (
+              <p
+                data-testid="ask-olumi-context"
+                className="mb-2 rounded-[9px] border border-info px-2.5 py-2 text-xs text-text-body"
+              >
+                {context}
+              </p>
+            )}
+            <textarea
+              ref={textareaRef}
+              data-testid="ask-olumi-draft"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={3}
+              className="min-h-[64px] w-full resize-y rounded-[9px] border border-panel-border bg-transparent px-2.5 py-2 text-xs text-text-body focus:border-info focus:outline-none"
+            />
+            {!canSend && (
+              <p className="mt-1 text-[11px] leading-snug text-text-light">
+                Open the Olumi chat to send this — the conversation is not
+                available right now.
+              </p>
+            )}
+            <div className="mt-2 flex items-center justify-end gap-2">
+              {targetResolvable && (
+                <button
+                  type="button"
+                  onClick={handleFocusCanvas}
+                  className="rounded-full border border-panel-border bg-transparent px-2.5 py-1.5 text-xs text-text-body hover:bg-panel-hover"
+                >
+                  Focus on canvas
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={!canSend || draft.trim() === ''}
+                className="inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary px-[11px] py-[7px] text-xs font-semibold text-text-on-color hover:border-primary-hover hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Send
+              </button>
+            </div>
+          </div>
+        </aside>
+      )}
+      {toast && (
+        <div
+          role="status"
+          data-testid="ask-olumi-toast"
+          className="pointer-events-none fixed bottom-[18px] left-1/2 z-[30] max-w-[min(90vw,430px)] -translate-x-1/2 rounded-full bg-text-header px-[13px] py-2 text-xs text-text-on-color opacity-95"
+        >
+          {toast}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/results/coaching/__tests__/AskOlumiDrawer.spec.tsx
+++ b/src/components/results/coaching/__tests__/AskOlumiDrawer.spec.tsx
@@ -1,0 +1,118 @@
+/**
+ * Parity P1 — "Work through it with Olumi" drawer (prototype #olumiDrawer).
+ *
+ * The audit's dead-button fix: routed asks open this drawer with a
+ * prefilled EDITABLE draft; Send dispatches a conversation-typed turn via
+ * the guidance degrade chain; when no conversation callback is registered
+ * the Send button is honestly disabled instead of silently no-oping.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+import { AskOlumiDrawer } from '../AskOlumiDrawer'
+import { useAskOlumiStore, openAskOlumi } from '../askOlumiStore'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import {
+  registerFocusHelpers,
+  unregisterFocusHelpers,
+} from '../../../../canvas/utils/focusHelpers'
+import { useCanvasStore } from '../../../../canvas/store'
+
+const payload = {
+  context: 'Help me check whether this decision classification is right.',
+  draft: 'Help me work through: Review risk',
+  label: 'Review risk',
+  parameters: { classification: 'risk' },
+}
+
+beforeEach(() => {
+  useAskOlumiStore.setState({ isOpen: false, context: '', draft: '', label: '', targetId: null })
+  useGuidanceStore.setState({ _dispatchAction: null, _sendMessage: null } as never)
+  unregisterFocusHelpers()
+})
+
+describe('AskOlumiDrawer', () => {
+  it('renders nothing until opened', () => {
+    render(<AskOlumiDrawer />)
+    expect(screen.queryByTestId('ask-olumi-drawer')).not.toBeInTheDocument()
+  })
+
+  it('opens with the context line and a prefilled editable draft', () => {
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi(payload))
+    expect(screen.getByTestId('ask-olumi-drawer')).toBeInTheDocument()
+    expect(screen.getByText(payload.context)).toBeInTheDocument()
+    const textarea = screen.getByTestId('ask-olumi-draft') as HTMLTextAreaElement
+    expect(textarea.value).toBe(payload.draft)
+    fireEvent.change(textarea, { target: { value: 'My own words' } })
+    expect((screen.getByTestId('ask-olumi-draft') as HTMLTextAreaElement).value).toBe('My own words')
+  })
+
+  it('Send dispatches a conversation-typed turn with the EDITED draft, toasts, and closes', () => {
+    const dispatch = vi.fn()
+    useGuidanceStore.setState({ _dispatchAction: dispatch } as never)
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi(payload))
+    fireEvent.change(screen.getByTestId('ask-olumi-draft'), { target: { value: 'Edited ask' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action_type: 'discuss',
+        message: 'Edited ask',
+        label: 'Review risk',
+        parameters: { classification: 'risk' },
+        source: 'chip',
+      }),
+    )
+    expect(screen.queryByTestId('ask-olumi-drawer')).not.toBeInTheDocument()
+    expect(screen.getByTestId('ask-olumi-toast')).toHaveTextContent(
+      'Sent to Olumi with the relevant model context',
+    )
+  })
+
+  it('degrades to _sendMessage when dispatch is unavailable', () => {
+    const send = vi.fn()
+    useGuidanceStore.setState({ _sendMessage: send } as never)
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi(payload))
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(send).toHaveBeenCalledWith(payload.draft)
+  })
+
+  it('with NO conversation callbacks Send is disabled with an honest hint — never a silent no-op', () => {
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi(payload))
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
+    expect(screen.getByText(/conversation is not available/i)).toBeInTheDocument()
+  })
+
+  it('Escape closes the drawer', () => {
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi(payload))
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('ask-olumi-drawer')).not.toBeInTheDocument()
+  })
+
+  it('shows Focus on canvas only when a target is carried, and resolves it', () => {
+    const focusNode = vi.fn()
+    const focusEdge = vi.fn()
+    registerFocusHelpers(focusNode, focusEdge)
+    useCanvasStore.setState({
+      nodes: [{ id: 'fac_1', type: 'factor', position: { x: 0, y: 0 }, data: {} } as any],
+      edges: [],
+    })
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi({ ...payload, targetId: 'fac_1' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Focus on canvas' }))
+    expect(focusNode).toHaveBeenCalledWith('fac_1')
+    expect(screen.getByTestId('ask-olumi-toast')).toHaveTextContent(
+      'Focused the relevant model elements on the canvas',
+    )
+  })
+
+  it('hides Focus on canvas when no target is carried', () => {
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi(payload))
+    expect(screen.queryByRole('button', { name: 'Focus on canvas' })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/results/coaching/askOlumiStore.ts
+++ b/src/components/results/coaching/askOlumiStore.ts
@@ -1,0 +1,67 @@
+/**
+ * Parity P1 — the "Work through it with Olumi" drawer state (prototype
+ * #olumiDrawer). One drawer per app; every routed ask on the Analysis tab
+ * (decision pills, Actions methods, framing question, Strengthen
+ * work-through, hero prompts) opens it with a context line and a PREFILLED,
+ * EDITABLE draft instead of auto-sending a hidden message — the audit's
+ * "routed asks never surface the conversation" fix.
+ *
+ * Plain zustand store so non-React call sites (menu handlers) can open it
+ * via useAskOlumiStore.getState().openAsk(...).
+ */
+import { create } from 'zustand'
+
+export interface AskOlumiPayload {
+  /** Drawer context line, e.g. the method description or classification hint */
+  context: string
+  /** Prefilled editable draft for the textarea */
+  draft: string
+  /** Short label describing the ask (used as the dispatch label) */
+  label: string
+  /** Optional model target for the "Focus on canvas" action */
+  targetId?: string
+  /** Dispatch parameters forwarded on send (e.g. { method_id }) */
+  parameters?: Record<string, unknown>
+  /** Dispatch source tag (defaults to 'chip' — conversation-typed turn) */
+  source?: string
+}
+
+interface AskOlumiState {
+  isOpen: boolean
+  context: string
+  draft: string
+  label: string
+  targetId: string | null
+  parameters: Record<string, unknown> | undefined
+  source: string
+  openAsk: (payload: AskOlumiPayload) => void
+  setDraft: (draft: string) => void
+  close: () => void
+}
+
+export const useAskOlumiStore = create<AskOlumiState>((set) => ({
+  isOpen: false,
+  context: '',
+  draft: '',
+  label: '',
+  targetId: null,
+  parameters: undefined,
+  source: 'chip',
+  openAsk: (payload) =>
+    set({
+      isOpen: true,
+      context: payload.context,
+      draft: payload.draft,
+      label: payload.label,
+      targetId: payload.targetId ?? null,
+      parameters: payload.parameters,
+      source: payload.source ?? 'chip',
+    }),
+  setDraft: (draft) => set({ draft }),
+  close: () => set({ isOpen: false }),
+}))
+
+/** Convenience for non-React call sites. */
+export function openAskOlumi(payload: AskOlumiPayload): void {
+  useAskOlumiStore.getState().openAsk(payload)
+}

--- a/src/components/results/strengthen/StrengthenContainer.tsx
+++ b/src/components/results/strengthen/StrengthenContainer.tsx
@@ -16,7 +16,8 @@
  *   null and go transiently null across host remounts): ai-dialogue via
  *   _dispatchAction with an EXPLICIT action_type (chip_metadata survives
  *   only conversation-typed turns), degrading to _sendMessage with a DEV
- *   warn; canvas focus via the fail-closed focusExistingTarget.
+ *   warn; canvas focus via the fail-closed focusModelTarget (resolves
+ *   node ids, canvas edge ids and PLoT arrow-form edge ids).
  * - suppress any panel-local freshness banner (AnalysisFreshnessNotice owns
  *   the tab's freshness surface — same contract as FocusNowContainer).
  */
@@ -29,7 +30,7 @@ import {
   useStrengthenStore,
   type RecRecord,
 } from '../../../canvas/stores/strengthenStore'
-import { focusExistingTarget } from '../../../canvas/utils/focusHelpers'
+import { focusModelTarget } from '../../../canvas/utils/focusHelpers'
 import { buildRecommendations } from './buildRecommendations'
 import type { StrengthenInputs } from './strengthenTypes'
 import { StrengthenPanel } from './StrengthenPanel'
@@ -141,9 +142,9 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
     if (rec.action.kind === 'ai-dialogue') {
       ok = dispatchAiDialogue(record)
     } else if (rec.action.kind === 'canvas-focus' && rec.targetId) {
-      ok = focusExistingTarget(rec.targetId, 'node')
+      ok = focusModelTarget(rec.targetId)
     } else if (rec.action.kind === 'inline-edit' && rec.targetId) {
-      ok = focusExistingTarget(rec.targetId, 'node')
+      ok = focusModelTarget(rec.targetId)
     }
     // §8.8: close only after the action genuinely succeeds — a successful
     // dispatch marks IN PROGRESS (the user confirms addressed themselves).
@@ -158,7 +159,7 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
 
   const onFocusCanvas = (record: RecRecord) => {
     if (record.snapshot.targetId) {
-      focusExistingTarget(record.snapshot.targetId, 'node')
+      focusModelTarget(record.snapshot.targetId)
     }
   }
 


### PR DESCRIPTION
Foundation lane for the prototype-parity rebuild (audit: 88 items / 5 surfaces).

- **Ask-Olumi drawer** (prototype #olumiDrawer) — the audit's dead-button root-cause fix: routed asks open a drawer with a prefilled **editable** draft instead of auto-sending into a possibly-unregistered conversation; Send uses the guidance degrade chain, disabled with an honest hint when no callback exists. Escape + focus management included.
- **focusModelTarget** — resolves node ids, canvas edge ids, PLoT `from->to` arrow ids and producer `edge_id` on edge.data; Strengthen 'Focus on canvas' rewired (was silently no-oping on every edge-targeted recommendation).
- **VITE_FEATURE_STRENGTHEN_PANEL=1 on staging** — the audit found Wave 3 merged but dark; this is why the Strengthen card was invisible on staging.

Gates: typecheck clean; 1,868 changed-set tests passed; 15 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)