### PR TITLE
feat(results): parity P7a — freshness parity, receipts for everyone, stale non-lockout, drawer at dock root

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -111,6 +111,7 @@ import { derivePostFooterStatus, derivePostFooterMeta } from './utils/postAnalys
 import { DEFAULT_EDGE_DATA } from '../domain/edges'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
 import { useAnalysisStateSource } from '../hooks/useAnalysisStateSource'
+import { AskOlumiDrawer } from '../../components/results/coaching/AskOlumiDrawer'
 
 /**
  * Map API critique format (CritiqueItemV1) to ValidationPanel format
@@ -1517,6 +1518,11 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       aria-label="Outputs dock"
       data-testid="outputs-dock"
     >
+      {/* Parity P7a: the Work-through-it-with-Olumi drawer mounts ONCE at the
+          dock root (fixed-position overlay) so asks routed from ANY tab —
+          graph node sparkles included — surface visibly instead of
+          auto-sending into a conversation the user cannot see. */}
+      <AskOlumiDrawer />
       {effectiveIsOpen && (
         <div
           aria-hidden="true"
@@ -2094,8 +2100,11 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 )}
                 {!isPreRun && hasInlineSummary && resultsSectionData && (
                   <div
-                    style={{ opacity: analysisNotConfirmedFresh && !isError ? 0.6 : 1 }}
-                    aria-disabled={analysisNotConfirmedFresh && !isError ? true : undefined}
+                    // Parity audit: v6 keeps stale results fully readable —
+                    // the freshness strip above carries the warning and the
+                    // recovery action. No dimming, no aria-disabled lockout;
+                    // data-freshness-confirmed preserves the signal for tests.
+                    data-freshness-confirmed={analysisNotConfirmedFresh && !isError ? 'false' : 'true'}
                     data-testid="results-body-stale-wrapper"
                   >
                   <ResultsBody

--- a/src/canvas/components/pre-analysis/DiscussWithAiButton.tsx
+++ b/src/canvas/components/pre-analysis/DiscussWithAiButton.tsx
@@ -18,6 +18,7 @@ import { memo, useCallback } from 'react'
 import { Sparkles } from 'lucide-react'
 import Tooltip from '@/components/Tooltip'
 import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import { openAskOlumi } from '@/components/results/coaching/askOlumiStore'
 import { buildAiDiscussPrompt, type AiDiscussElement } from './buildAiDiscussPrompt'
 
 interface DiscussWithAiButtonProps {
@@ -62,14 +63,18 @@ function DiscussWithAiButtonImpl({ element, onSend, ariaLabel, className, varian
       onSend(text)
       return
     }
-    // Auto-submit preferred: message lands immediately. Fall back to pre-fill
-    // only when sendMessage is not registered (e.g. during onboarding flow).
-    if (sendMessage) {
-      sendMessage(text)
-    } else if (prefillChat) {
-      prefillChat(text)
-    }
-  }, [element, onSend, prefillChat, sendMessage])
+    // Parity P7a: open the Work-through-it-with-Olumi drawer with the prompt
+    // PREFILLED and EDITABLE instead of auto-sending into a conversation on
+    // another tab — the invisible auto-send read as "the button does
+    // nothing" (audit dead-button class). The drawer dispatches on Send and
+    // degrades honestly when no conversation callback is registered.
+    openAskOlumi({
+      context: 'Discuss this part of the model with Olumi.',
+      draft: text,
+      label: 'Discuss with Olumi',
+      source: 'chip',
+    })
+  }, [element, onSend])
 
   // If neither callback is registered and no onSend override, render nothing — no dead button.
   if (!onSend && !sendMessage && !prefillChat) return null

--- a/src/canvas/components/pre-analysis/__tests__/MissingKnowledgePrompt.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/MissingKnowledgePrompt.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MissingKnowledgePrompt } from '@/components/shared/MissingKnowledgePrompt'
 import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWithAiButton'
 import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import { useAskOlumiStore } from '@/components/results/coaching/askOlumiStore'
 
 describe('MissingKnowledgePrompt', () => {
   const sendMock = vi.fn()
@@ -11,6 +12,7 @@ describe('MissingKnowledgePrompt', () => {
     sendMock.mockClear()
     // Register _sendMessage so DiscussWithAiButton renders
     useGuidanceStore.setState({ _sendMessage: sendMock })
+    useAskOlumiStore.setState({ isOpen: false, draft: '' })
   })
 
   // Helper: renders with the DiscussWithAiButton passed as aiAffordance prop
@@ -25,15 +27,18 @@ describe('MissingKnowledgePrompt', () => {
     expect(screen.getByTestId('discuss-with-ai')).toBeInTheDocument()
   })
 
-  it('sends pre-filled message when sparkle is clicked', () => {
+  // Parity P7a: the sparkle no longer auto-sends into a conversation the
+  // user may not see — it opens the Work-through-it-with-Olumi drawer with
+  // the prompt PREFILLED and EDITABLE. Send happens in the drawer.
+  it('opens the Ask-Olumi drawer prefilled when sparkle is clicked (no invisible auto-send)', () => {
     render(<MissingKnowledgePrompt context="model" aiAffordance={aiAffordance} />)
 
     fireEvent.click(screen.getByTestId('discuss-with-ai'))
 
-    expect(sendMock).toHaveBeenCalledTimes(1)
-    expect(sendMock).toHaveBeenCalledWith(
-      expect.stringContaining('add something to the model'),
-    )
+    expect(sendMock).not.toHaveBeenCalled()
+    const drawer = useAskOlumiStore.getState()
+    expect(drawer.isOpen).toBe(true)
+    expect(drawer.draft).toContain('add something to the model')
   })
 
   it('does not render sparkle when no aiAffordance passed', () => {

--- a/src/canvas/components/pre-analysis/__tests__/TriageCard.aiDiscussSlot.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/TriageCard.aiDiscussSlot.spec.tsx
@@ -19,12 +19,14 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { TriageCard } from '@/components/shared/TriageCard'
 import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWithAiButton'
 import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import { useAskOlumiStore } from '@/components/results/coaching/askOlumiStore'
 
 describe('TriageCard × DiscussWithAiButton aiDiscussSlot integration', () => {
   const sendMock = vi.fn()
 
   beforeEach(() => {
     sendMock.mockClear()
+    useAskOlumiStore.setState({ isOpen: false, draft: '' })
     // Register _sendMessage so DiscussWithAiButton actually renders + fires.
     useGuidanceStore.setState({ _sendMessage: sendMock, _prefillChat: null })
   })
@@ -58,12 +60,14 @@ describe('TriageCard × DiscussWithAiButton aiDiscussSlot integration', () => {
 
     fireEvent.click(button)
 
-    expect(sendMock).toHaveBeenCalledTimes(1)
-    // Prompt text built by buildAiDiscussPrompt for a factor element should
-    // mention the factor label. The exact wording is owned by
+    // Parity P7a: the click now opens the Ask-Olumi drawer PREFILLED instead
+    // of auto-sending into a conversation on another tab (invisible sends
+    // read as dead buttons). Prompt wording still owned by
     // buildAiDiscussPrompt; we assert containment, not equality.
-    const [prompt] = sendMock.mock.calls[0] as [string]
-    expect(prompt).toContain('Engineering velocity')
+    expect(sendMock).not.toHaveBeenCalled()
+    const drawer = useAskOlumiStore.getState()
+    expect(drawer.isOpen).toBe(true)
+    expect(drawer.draft).toContain('Engineering velocity')
   })
 
   it('renders no discuss button when aiDiscussSlot is undefined, even with a registered store handler', () => {

--- a/src/components/results/AdvancedSection.tsx
+++ b/src/components/results/AdvancedSection.tsx
@@ -15,7 +15,6 @@ import { typography } from '../../styles/typography'
 import { evaluativeVar } from '../../styles/evaluative'
 import { Accordion } from './Accordion'
 import { useRiskProfile, RISK_PRESETS } from '../../canvas/hooks/useRiskProfile'
-import { ExpertBlock } from './ExpertBlock'
 
 type RiskPresetKey = keyof typeof RISK_PRESETS
 
@@ -137,7 +136,7 @@ export function AdvancedSection({
 
   return (
     <Accordion
-      title="Advanced"
+      title="Advanced and receipts"
       defaultExpanded={hasInferenceWarnings}
       testId="accordion-advanced"
     >
@@ -317,9 +316,11 @@ export function AdvancedSection({
           </div>
         </div>
 
-        {/* ── Analysis Details — expert mode only (Task 10) ──────────── */}
-        {expertMode && (
-        <ExpertBlock>
+        {/* ── Analysis details (receipts) ──────────────────────────────
+            Parity audit: the prototype's receipts are for EVERYONE — the
+            expert-mode gate hid simulations/stability/graph-size from
+            normal users. Real values only; rows fail closed when absent. */}
+        <div data-testid="analysis-receipts">
           <h4 className={`${typography.panelHeader} text-text-header mb-1`}>
             Analysis details
           </h4>
@@ -394,8 +395,7 @@ export function AdvancedSection({
               </div>
             )}
           </dl>
-        </ExpertBlock>
-        )}
+        </div>
       </div>
     </Accordion>
   )

--- a/src/components/results/AnalysisFreshnessNotice.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.tsx
@@ -12,7 +12,8 @@
  * v5AnalysisFact, useStaleGuard, or any local graph-hash computation, and it
  * never shows the technical reason/hash fields as copy (they ride on data-*).
  */
-import { AlertTriangle, CheckCircle2, HelpCircle, RefreshCw } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { RefreshCw } from 'lucide-react'
 import { useCanvasStore } from '@/canvas/store'
 import { typography } from '@/styles/typography'
 import {
@@ -31,11 +32,14 @@ export const FRESHNESS_COPY: Record<AnalysisFreshnessValue, string> = {
   none: 'No analysis yet.',
 }
 
-const ICON: Record<AnalysisFreshnessValue, typeof AlertTriangle> = {
-  fresh: CheckCircle2,
-  stale: AlertTriangle,
-  unknown: HelpCircle,
-  none: HelpCircle,
+// Prototype v6 dot vocabulary: the status indicator is a colour-only dot —
+// no shape change between states (parity audit: icon-shape swapping added a
+// second channel the prototype deliberately avoids).
+const DOT_COLOUR: Record<AnalysisFreshnessValue, string> = {
+  fresh: 'bg-success',
+  stale: 'bg-warning',
+  unknown: 'bg-text-light',
+  none: 'bg-text-light',
 }
 
 export interface AnalysisFreshnessNoticeProps {
@@ -56,6 +60,22 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
   const isRunning =
     resultsStatus === 'preparing' || resultsStatus === 'connecting' || resultsStatus === 'streaming'
 
+  // Parity audit: the prototype confirms a completed rerun ('Analysis rerun
+  // completed with the current model'). Watch the running→complete
+  // transition; the strip is the canonical freshness owner so the toast
+  // lives here (single mount — no double-fire).
+  const wasRunningRef = useRef(false)
+  useEffect(() => {
+    if (isRunning) {
+      wasRunningRef.current = true
+    } else if (wasRunningRef.current) {
+      wasRunningRef.current = false
+      if (resultsStatus === 'complete') {
+        showToast('Analysis rerun completed with the current model')
+      }
+    }
+  }, [isRunning, resultsStatus, showToast])
+
   // No verdict yet → no notice (never claim a freshness state we don't hold).
   if (!state) return null
 
@@ -67,8 +87,10 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
   // and a cannot-confirm 'unknown' (e.g. recovered session, local edit
   // downgrade). The old top-level banner offered Rerun for both — the strip
   // must not drop that affordance. 'none' has nothing to rerun.
-  const offersRerun = freshness === 'stale' || freshness === 'unknown'
-  const Icon = ICON[freshness]
+  // Parity audit: the prototype offers Rerun in the FRESH state too (rerun
+  // against the current model is always a legitimate action); only 'none'
+  // (nothing analysed yet) has nothing to rerun.
+  const offersRerun = freshness !== 'none'
   // Mark when the displayed verdict differs from CEE's because of a local edit —
   // technical signal for tests/debug only, not user copy.
   const downgraded = state.freshness === 'fresh' && freshness === 'unknown'
@@ -82,13 +104,17 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
       data-freshness-reason={state.freshnessReason}
       className={`flex items-center gap-2 rounded-md border px-3 py-2 bg-panel ${isStale ? 'border-warning/30' : 'border-panel-border'} ${className}`.trim()}
     >
-      <Icon
-        size={14}
-        className={`flex-none ${isStale ? 'text-warning' : 'text-text-light'}`}
+      <span
+        className={`flex-none w-2 h-2 rounded-full ${isRunning ? 'bg-info' : DOT_COLOUR[freshness]}`}
         aria-hidden="true"
+        data-testid="freshness-dot"
       />
-      {/* Live region on the copy only (review c) — never around the button. */}
-      <span role="status" className={`${typography.panelBody} text-text-body flex-1`}>{FRESHNESS_COPY[freshness]}</span>
+      {/* Live region on the copy only (review c) — never around the button.
+          Stale message renders in header colour per the prototype's heavier
+          emphasis; a run in flight states so honestly. */}
+      <span role="status" className={`${typography.panelBody} ${isStale ? 'text-text-header' : 'text-text-body'} flex-1`}>
+        {isRunning ? 'Rerunning the analysis with the current model…' : FRESHNESS_COPY[freshness]}
+      </span>
       {offersRerun && (
         // Wave F-B (brief §5.2): the strip is the sole stale owner and carries
         // THE recovery action — canonical-runner routed, never a private

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -28,7 +28,6 @@ import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWit
 import { DecisionConfidencePanel } from './DecisionConfidencePanel'
 import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { AnalysisOrphanBanner } from './AnalysisOrphanBanner'
-import { AskOlumiDrawer } from './coaching/AskOlumiDrawer'
 import { WhatChangedChip } from '../../canvas/components/WhatChangedChip'
 import { StrengthenContainer } from './strengthen/StrengthenContainer'
 import { InferenceWarningStrip } from './InferenceWarningStrip'
@@ -242,11 +241,6 @@ export const ResultsBody = memo(function ResultsBody({
 
   return (
     <div className="flex flex-col gap-4" data-testid="outputs-results-redesign">
-
-      {/* Parity P1: the "Work through it with Olumi" drawer — one instance
-          for every routed ask on this tab (methods, pills, framing question,
-          Strengthen work-through). Renders nothing until opened. */}
-      <AskOlumiDrawer />
 
       {/* Orphan banner — Results from a non-CEE path with no run_analysis
           fact for the scenario. Renders only when canonical flag is ON and

--- a/src/components/results/__tests__/AdvancedSection.spec.tsx
+++ b/src/components/results/__tests__/AdvancedSection.spec.tsx
@@ -17,17 +17,17 @@ vi.mock('../../../canvas/hooks/useRiskProfile', () => ({
 }))
 
 describe('AdvancedSection', () => {
-  it('renders accordion with "Advanced" title', () => {
+  it('renders accordion with "Advanced and receipts" title', () => {
     render(<AdvancedSection />)
 
-    expect(screen.getByText('Advanced')).toBeInTheDocument()
+    expect(screen.getByText('Advanced and receipts')).toBeInTheDocument()
   })
 
   it('renders risk profile preset buttons', () => {
     render(<AdvancedSection />)
 
     // Expand accordion first
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByRole('radio', { name: /Risk Averse/i })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: /Neutral/i })).toBeInTheDocument()
@@ -40,7 +40,7 @@ describe('AdvancedSection', () => {
   // docs/brief-5-preflight-findings.md.
   it('risk-profile control uses Paul-frozen label + helper copy', () => {
     const { container } = render(<AdvancedSection />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     const control = container.querySelector('[data-testid="risk-profile-control"]')
     expect(control).toBeTruthy()
@@ -59,7 +59,7 @@ describe('AdvancedSection', () => {
 
   it('renders stability percentage when provided', () => {
     render(<AdvancedSection stability={0.85} expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Stability')).toBeInTheDocument()
     expect(screen.getByText('85%')).toBeInTheDocument()
@@ -67,7 +67,7 @@ describe('AdvancedSection', () => {
 
   it('renders convergence sample count', () => {
     render(<AdvancedSection nSamples={10000} expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Simulation quality')).toBeInTheDocument()
     expect(screen.getByText('10,000 simulations')).toBeInTheDocument()
@@ -75,7 +75,7 @@ describe('AdvancedSection', () => {
 
   it('renders fragile and stable edge counts', () => {
     render(<AdvancedSection fragileEdgeCount={3} robustEdgeCount={12} expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Sensitive assumptions')).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
@@ -85,7 +85,7 @@ describe('AdvancedSection', () => {
 
   it('renders graph size with node and edge counts', () => {
     render(<AdvancedSection nodeCount={15} edgeCount={22} expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Graph size')).toBeInTheDocument()
     expect(screen.getByText('15 nodes, 22 edges')).toBeInTheDocument()
@@ -93,7 +93,7 @@ describe('AdvancedSection', () => {
 
   it('renders identifiability tag', () => {
     render(<AdvancedSection identifiability="identifiable" expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Identifiability')).toBeInTheDocument()
     expect(screen.getByText('Identifiable')).toBeInTheDocument()
@@ -101,14 +101,14 @@ describe('AdvancedSection', () => {
 
   it('formats underscored identifiability tag', () => {
     render(<AdvancedSection identifiability="not_identifiable" expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Not identifiable')).toBeInTheDocument()
   })
 
   it('renders seed value', () => {
     render(<AdvancedSection seedUsed={42} expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Seed')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
@@ -116,7 +116,7 @@ describe('AdvancedSection', () => {
 
   it('renders truncated hash with copy button', () => {
     render(<AdvancedSection responseHash="abc123def456ghi789" expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Hash')).toBeInTheDocument()
     expect(screen.getByText('abc123def456…')).toBeInTheDocument()
@@ -126,47 +126,31 @@ describe('AdvancedSection', () => {
   // Brief 5 Phase 1 (Task 4): DS v5 icon-only interactive — both aria-label AND tooltip.
   it('copy-hash button has both aria-label and native title (DS v5 a11y parity)', () => {
     render(<AdvancedSection responseHash="abc123def456ghi789" expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     const copyBtn = screen.getByLabelText('Copy hash to clipboard')
     expect(copyBtn).toHaveAttribute('aria-label', 'Copy hash to clipboard')
     expect(copyBtn).toHaveAttribute('title', 'Copy hash to clipboard')
   })
 
-  // Brief 5 Phase 1 (Task 4): hash must stay gated behind expert mode.
-  it('does NOT render hash when expertMode is false, even when responseHash is supplied', () => {
+  // Parity rebuild 2026-07-13: receipts are for EVERYONE per the prototype
+  // ('Result hash — 8ce04678…' is a first-class receipt row). This REVERSES
+  // the Brief 5 Phase 1 Task 4 expert-mode gate — deliberate, called out in
+  // the lane report for veto. The hash stays truncated with a copy control.
+  it('renders the truncated hash WITHOUT expertMode (receipts for everyone)', () => {
     render(<AdvancedSection responseHash="abc123def456ghi789" />)
-    fireEvent.click(screen.getByText('Advanced'))
-
-    expect(screen.queryByText('Hash')).not.toBeInTheDocument()
-    expect(screen.queryByText('abc123def456…')).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Copy hash to clipboard')).not.toBeInTheDocument()
-    // Brief 5.2 Task 2: precise testid assertion — no hex token leaks regardless of accordion state.
-    expect(screen.queryByTestId('advanced-hash-row')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Advanced and receipts'))
+    expect(screen.getByTestId('advanced-hash-row')).toBeInTheDocument()
+    expect(screen.getByText('abc123def456…')).toBeInTheDocument()
   })
 
-  // Brief 5.2 Task 2: inferenceWarnings auto-expands the accordion. The hash
-  // row must stay hidden in standard view even when the section is expanded
-  // by default. Staging QA screenshot "9b1634d" appears to match the Brief
-  // 5.1 merge SHA; this test verifies the gate holds in that scenario.
-  it('does NOT render hash when expertMode is false and accordion is auto-expanded by inferenceWarnings', () => {
+  it('renders the hash row when the accordion auto-expands via inferenceWarnings', () => {
     render(
       <AdvancedSection
         responseHash="9b1634d2abcdef"
         inferenceWarnings={[{ code: 'weak_evidence', message: 'Low evidence on 3 factors' }]}
       />,
     )
-    // No click needed — accordion defaultExpanded={true} due to inferenceWarnings.
-    expect(screen.queryByTestId('advanced-hash-row')).not.toBeInTheDocument()
-    expect(screen.queryByText('Hash')).not.toBeInTheDocument()
-    expect(screen.queryByText('9b1634d2abcd…')).not.toBeInTheDocument()
-  })
-
-  // Brief 5.2 Task 2: testid-based regression guard — exact scoping beats a
-  // loose 7-hex regex on the whole DOM.
-  it('renders advanced-hash-row testid when expertMode is true', () => {
-    render(<AdvancedSection responseHash="abc123def456ghi789" expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
     expect(screen.getByTestId('advanced-hash-row')).toBeInTheDocument()
   })
 
@@ -175,7 +159,7 @@ describe('AdvancedSection', () => {
   // refactors don't quietly drop it.
   it('Risk profile heading renders the Gauge icon (Brief 5.1 Task 6 / Brief 5.2 Task 8c)', () => {
     const { container } = render(<AdvancedSection />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
     const heading = container.querySelector('[data-testid="risk-profile-control"] h4')
     expect(heading).toBeTruthy()
     // Heading contains an SVG (the Lucide Gauge). aria-hidden so it does not
@@ -187,19 +171,20 @@ describe('AdvancedSection', () => {
 
   it('hides detail rows when values are not provided', () => {
     render(<AdvancedSection expertMode />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.queryByText('Stability')).not.toBeInTheDocument()
     expect(screen.queryByText('Simulation quality')).not.toBeInTheDocument()
     expect(screen.queryByText('Hash')).not.toBeInTheDocument()
   })
 
-  it('hides analysis details section in default (non-expert) mode', () => {
+  it('renders analysis details in default (non-expert) mode — receipts are for everyone', () => {
     render(<AdvancedSection stability={0.85} nSamples={5000} />)
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
-    expect(screen.queryByText('Analysis details')).not.toBeInTheDocument()
-    expect(screen.queryByText('Stability')).not.toBeInTheDocument()
+    expect(screen.getByText('Analysis details')).toBeInTheDocument()
+    expect(screen.getByText('Stability')).toBeInTheDocument()
+    expect(screen.getByText('85%')).toBeInTheDocument()
   })
 
   it('renders all analysis details together', () => {
@@ -217,7 +202,7 @@ describe('AdvancedSection', () => {
         expertMode
       />
     )
-    fireEvent.click(screen.getByText('Advanced'))
+    fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('72%')).toBeInTheDocument()
     expect(screen.getByText('5,000 simulations')).toBeInTheDocument()

--- a/src/components/results/__tests__/AnalysisFreshnessNotice.rerun.spec.tsx
+++ b/src/components/results/__tests__/AnalysisFreshnessNotice.rerun.spec.tsx
@@ -37,9 +37,12 @@ describe('AnalysisFreshnessNotice — strip Rerun (Wave F-B)', () => {
     expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
   })
 
-  it('fresh / none → no Rerun affordance on the strip', () => {
+  // Parity rebuild 2026-07-13: the prototype offers Rerun in the FRESH state
+  // too (rerunning against the current model is always legitimate); only
+  // 'none' — nothing analysed yet — has no rerun affordance.
+  it('fresh → Rerun offered; none → no Rerun affordance', () => {
     const { rerender } = render(<AnalysisFreshnessNotice state={FRESH as never} dirty={false} />)
-    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+    expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
     rerender(<AnalysisFreshnessNotice state={{ freshness: 'none', freshnessReason: null, computedAt: 1 } as never} dirty={false} />)
     expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
Unowned-file parity lane (runs alongside the four surface lanes).

- **Freshness strip**: prototype dot vocabulary (colour-only), Rerun in FRESH state, running copy, completion toast on running→complete.
- **Advanced and receipts**: receipts dl for everyone — deliberately reverses the Brief-5 expert-mode hash gate per the parity mandate (**flagged for veto**; hash stays truncated + copy control).
- **Stale non-lockout**: dim/aria-disabled wrapper removed; strip owns the warning (prototype behaviour).
- **Drawer at dock root** + **graph sparkles open the drawer prefilled** — kills the invisible auto-send ('button does nothing').

Gates: typecheck clean · 719 changed-set tests · lint 0 errors · wide-tsc: only delta was an unused import, removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)