### PR TITLE
feat(modals): parity Lane M — Define-success + Record-the-decision modals (§7 + §9)

### DIFF
--- a/src/components/results/modals/DecisionRecordModal.tsx
+++ b/src/components/results/modals/DecisionRecordModal.tsx
@@ -1,0 +1,389 @@
+/**
+ * Record-the-decision modal (prototype #decisionModal, build-ready v6).
+ *
+ * Captures chosen option / confidence 0-100 / concise rationale / key
+ * assumption to watch / revisit trigger-or-date into decisionRecordStore
+ * (sessionStorage, scenario-keyed, with the analysed graph hash). The
+ * chosen-option select is populated READ-ONLY from the live analysed
+ * option set (canvas option nodes + the stable optionNumbering map) —
+ * never the prototype's four hardcoded fixtures.
+ *
+ * Fail-closed: with no completed analysis or zero option nodes the form
+ * renders disabled with honest copy — capture never fabricates an option
+ * set. Validation closes the prototype's Number('')===0 hole: confidence
+ * must be NON-EMPTY, finite and 0-100 inclusive.
+ *
+ * HONESTY: no backend persistence exists (blocked on identity + Model
+ * Management) — the note line says the record lives on this device for
+ * this scenario.
+ *
+ * Mount once; open from anywhere via openDecisionRecord() (the commit
+ * rec's INTENDED wiring — the spec flags the prototype's 'ask' routing as
+ * a critical wiring bug not to copy).
+ */
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+
+import { useCanvasStore } from '../../../canvas/store'
+import { typography } from '../../../styles/typography'
+import {
+  FIELD_INPUT_CLASS,
+  FieldError,
+  FieldLabel,
+  GHOST_BUTTON_CLASS,
+  ModalShell,
+  PRIMARY_BUTTON_CLASS,
+  useModalToast,
+} from './ModalShell'
+import { resolveScenarioKey } from './scenarioKey'
+import {
+  selectDecisionRecord,
+  useDecisionRecordStore,
+  type DecisionRecord,
+} from './decisionRecordStore'
+
+export const DECISION_RECORD_COPY = {
+  title: 'Record the decision',
+  subtitle: 'Capture the choice and what would justify revisiting it.',
+  prototypeNote:
+    'Prototype only. Saved on this device for this scenario. Durable saving depends on identity and Model Management.',
+  emptyState:
+    'Run an analysis first. There are no analysed options to record a decision against yet.',
+  chosenOptionLabel: 'Chosen option',
+  confidenceLabel: 'Confidence, 0–100',
+  confidencePlaceholder: 'e.g. 70',
+  revisitLabel: 'Revisit trigger or date',
+  revisitPlaceholder: 'e.g. runway falls below 9 months',
+  rationaleLabel: 'Concise rationale',
+  rationalePlaceholder: 'Why this is the best current choice',
+  assumptionLabel: 'Key assumption to watch',
+  assumptionPlaceholder: 'The assumption most likely to change the choice',
+  cancel: 'Cancel',
+  save: 'Capture prototype record',
+  confidenceError: 'Add a confidence between 0 and 100.',
+  rationaleError: 'Add a concise rationale.',
+  assumptionError: 'Add the assumption most likely to change the choice.',
+  revisitError: 'Add a revisit trigger or date.',
+  toastSaved: 'Prototype decision record captured in this session.',
+} as const
+
+interface AnalysedOption {
+  id: string
+  label: string
+  /** Stable number from optionNumbering, only when EVERY option has one. */
+  number: number | null
+}
+
+function parseConfidence(raw: string): number {
+  // NON-EMPTY strict parse — the prototype accepted '' because
+  // Number('')===0; the spec flags that as a validation hole to close.
+  const trimmed = raw.trim()
+  return trimmed === '' ? NaN : Number(trimmed)
+}
+
+export function DecisionRecordModal() {
+  const isOpen = useDecisionRecordStore((s) => s.isOpen)
+  const close = useDecisionRecordStore((s) => s.close)
+  const { showToast, toastElement } = useModalToast('decision-record-toast')
+
+  // READ-ONLY canvas reads: analysed options exist only once a run has
+  // completed; labels come from the option nodes, numbers from the stable
+  // optionNumbering map (all-or-nothing, mirroring ResultsBody — partial
+  // coverage must not render fabricated numbers).
+  const nodes = useCanvasStore((s) => s.nodes)
+  const resultsStatus = useCanvasStore((s) => s.results.status)
+  const analysisHash = useCanvasStore((s) => s.results.hash ?? null)
+  const numbering = useCanvasStore((s) => s.optionNumbering)
+
+  const options = useMemo<AnalysedOption[]>(() => {
+    if (resultsStatus !== 'complete') return []
+    const optionNodes = nodes.filter(
+      (n) =>
+        n.type === 'option' ||
+        (n.data as Record<string, unknown> | undefined)?.kind === 'option',
+    )
+    if (optionNodes.length === 0) return []
+    const allNumbered = optionNodes.every((n) => numbering[n.id] != null)
+    const mapped = optionNodes.map((n) => {
+      const label = (n.data as Record<string, unknown> | undefined)?.label
+      return {
+        id: n.id,
+        label: typeof label === 'string' && label.trim() !== '' ? label : n.id,
+        number: allNumbered ? numbering[n.id] : null,
+      }
+    })
+    return allNumbered
+      ? [...mapped].sort((a, b) => (a.number as number) - (b.number as number))
+      : mapped
+  }, [nodes, resultsStatus, numbering])
+
+  const hasOptions = options.length > 0
+
+  const titleId = useId()
+  const optionId = useId()
+  const confidenceId = useId()
+  const revisitId = useId()
+  const rationaleId = useId()
+  const assumptionId = useId()
+  const confidenceErrorId = useId()
+  const revisitErrorId = useId()
+  const rationaleErrorId = useId()
+  const assumptionErrorId = useId()
+
+  const [chosenOptionId, setChosenOptionId] = useState('')
+  const [confidence, setConfidence] = useState('')
+  const [revisit, setRevisit] = useState('')
+  const [rationale, setRationale] = useState('')
+  const [assumption, setAssumption] = useState('')
+  const [touched, setTouched] = useState<{
+    confidence?: boolean
+    revisit?: boolean
+    rationale?: boolean
+    assumption?: boolean
+  }>({})
+  const saveFiredRef = useRef(false)
+
+  // Hydrate on open: an existing record for this scenario prefills the form
+  // (its option only if still analysed); otherwise default to the first
+  // analysed option.
+  useEffect(() => {
+    if (!isOpen) return
+    saveFiredRef.current = false
+    const scenarioKey = resolveScenarioKey(useCanvasStore.getState().currentScenarioId)
+    const saved = selectDecisionRecord(useDecisionRecordStore.getState(), scenarioKey)
+    if (saved) {
+      setChosenOptionId(
+        options.some((o) => o.id === saved.optionId) ? saved.optionId : options[0]?.id ?? '',
+      )
+      setConfidence(String(saved.confidence))
+      setRevisit(saved.revisitTrigger)
+      setRationale(saved.rationale)
+      setAssumption(saved.assumptionToWatch)
+    } else {
+      setChosenOptionId(options[0]?.id ?? '')
+      setConfidence('')
+      setRevisit('')
+      setRationale('')
+      setAssumption('')
+    }
+    setTouched({})
+    // options is deliberately read at open time only — a mid-edit analysis
+    // completing must not clobber the user's draft.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+
+  const parsedConfidence = parseConfidence(confidence)
+  const confidenceValid =
+    Number.isFinite(parsedConfidence) && parsedConfidence >= 0 && parsedConfidence <= 100
+  const revisitValid = revisit.trim() !== ''
+  const rationaleValid = rationale.trim() !== ''
+  const assumptionValid = assumption.trim() !== ''
+  const chosenOption = options.find((o) => o.id === chosenOptionId) ?? null
+  const valid =
+    hasOptions &&
+    chosenOption !== null &&
+    confidenceValid &&
+    revisitValid &&
+    rationaleValid &&
+    assumptionValid
+
+  const handleSave = () => {
+    if (!valid || chosenOption === null) {
+      setTouched({ confidence: true, revisit: true, rationale: true, assumption: true })
+      return
+    }
+    if (saveFiredRef.current) return
+    saveFiredRef.current = true
+
+    const scenarioKey = resolveScenarioKey(useCanvasStore.getState().currentScenarioId)
+    const record: DecisionRecord = {
+      optionId: chosenOption.id,
+      optionLabel: chosenOption.label,
+      optionNumber: chosenOption.number,
+      confidence: parsedConfidence,
+      rationale: rationale.trim(),
+      assumptionToWatch: assumption.trim(),
+      revisitTrigger: revisit.trim(),
+      analysisHash,
+      savedAt: Date.now(),
+    }
+    useDecisionRecordStore.getState().saveRecord(scenarioKey, record)
+    close()
+    showToast(DECISION_RECORD_COPY.toastSaved)
+  }
+
+  return (
+    <>
+      <ModalShell
+        isOpen={isOpen}
+        onClose={close}
+        title={DECISION_RECORD_COPY.title}
+        subtitle={DECISION_RECORD_COPY.subtitle}
+        titleId={titleId}
+        testId="decision-record-modal"
+      >
+        <p
+          data-testid="decision-record-note"
+          className={`mt-[10px] rounded-[9px] border border-panel-border bg-panel px-[9px] py-2 ${typography.panelMeta} text-text-light`}
+        >
+          {DECISION_RECORD_COPY.prototypeNote}
+        </p>
+
+        {!hasOptions && (
+          <p
+            data-testid="decision-record-empty"
+            className={`mt-2 ${typography.panelBody} text-text-body`}
+          >
+            {DECISION_RECORD_COPY.emptyState}
+          </p>
+        )}
+
+        <div className="mt-[11px] grid grid-cols-2 gap-2">
+          <div className="col-span-2 flex flex-col gap-1">
+            <FieldLabel htmlFor={optionId}>
+              {DECISION_RECORD_COPY.chosenOptionLabel}
+            </FieldLabel>
+            <select
+              id={optionId}
+              data-autofocus
+              data-testid="decision-record-option"
+              value={chosenOptionId}
+              onChange={(e) => setChosenOptionId(e.target.value)}
+              disabled={!hasOptions}
+              className={FIELD_INPUT_CLASS}
+            >
+              {options.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.number != null ? `${o.number}. ${o.label}` : o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <FieldLabel htmlFor={confidenceId}>
+              {DECISION_RECORD_COPY.confidenceLabel}
+            </FieldLabel>
+            <input
+              id={confidenceId}
+              data-testid="decision-record-confidence"
+              type="text"
+              inputMode="numeric"
+              placeholder={DECISION_RECORD_COPY.confidencePlaceholder}
+              value={confidence}
+              onChange={(e) => setConfidence(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, confidence: true }))}
+              disabled={!hasOptions}
+              aria-invalid={touched.confidence === true && !confidenceValid}
+              aria-describedby={
+                touched.confidence === true && !confidenceValid
+                  ? confidenceErrorId
+                  : undefined
+              }
+              className={FIELD_INPUT_CLASS}
+            />
+            <FieldError
+              id={confidenceErrorId}
+              show={touched.confidence === true && !confidenceValid}
+            >
+              {DECISION_RECORD_COPY.confidenceError}
+            </FieldError>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <FieldLabel htmlFor={revisitId}>{DECISION_RECORD_COPY.revisitLabel}</FieldLabel>
+            <input
+              id={revisitId}
+              data-testid="decision-record-revisit"
+              type="text"
+              placeholder={DECISION_RECORD_COPY.revisitPlaceholder}
+              value={revisit}
+              onChange={(e) => setRevisit(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, revisit: true }))}
+              disabled={!hasOptions}
+              aria-invalid={touched.revisit === true && !revisitValid}
+              aria-describedby={
+                touched.revisit === true && !revisitValid ? revisitErrorId : undefined
+              }
+              className={FIELD_INPUT_CLASS}
+            />
+            <FieldError id={revisitErrorId} show={touched.revisit === true && !revisitValid}>
+              {DECISION_RECORD_COPY.revisitError}
+            </FieldError>
+          </div>
+
+          <div className="col-span-2 flex flex-col gap-1">
+            <FieldLabel htmlFor={rationaleId}>
+              {DECISION_RECORD_COPY.rationaleLabel}
+            </FieldLabel>
+            <textarea
+              id={rationaleId}
+              data-testid="decision-record-rationale"
+              rows={3}
+              placeholder={DECISION_RECORD_COPY.rationalePlaceholder}
+              value={rationale}
+              onChange={(e) => setRationale(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, rationale: true }))}
+              disabled={!hasOptions}
+              aria-invalid={touched.rationale === true && !rationaleValid}
+              aria-describedby={
+                touched.rationale === true && !rationaleValid ? rationaleErrorId : undefined
+              }
+              className={`${FIELD_INPUT_CLASS} min-h-[72px] resize-y`}
+            />
+            <FieldError
+              id={rationaleErrorId}
+              show={touched.rationale === true && !rationaleValid}
+            >
+              {DECISION_RECORD_COPY.rationaleError}
+            </FieldError>
+          </div>
+
+          <div className="col-span-2 flex flex-col gap-1">
+            <FieldLabel htmlFor={assumptionId}>
+              {DECISION_RECORD_COPY.assumptionLabel}
+            </FieldLabel>
+            <input
+              id={assumptionId}
+              data-testid="decision-record-assumption"
+              type="text"
+              placeholder={DECISION_RECORD_COPY.assumptionPlaceholder}
+              value={assumption}
+              onChange={(e) => setAssumption(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, assumption: true }))}
+              disabled={!hasOptions}
+              aria-invalid={touched.assumption === true && !assumptionValid}
+              aria-describedby={
+                touched.assumption === true && !assumptionValid
+                  ? assumptionErrorId
+                  : undefined
+              }
+              className={FIELD_INPUT_CLASS}
+            />
+            <FieldError
+              id={assumptionErrorId}
+              show={touched.assumption === true && !assumptionValid}
+            >
+              {DECISION_RECORD_COPY.assumptionError}
+            </FieldError>
+          </div>
+        </div>
+
+        <div className="mt-[11px] flex justify-end gap-[7px]">
+          <button type="button" onClick={close} className={GHOST_BUTTON_CLASS}>
+            {DECISION_RECORD_COPY.cancel}
+          </button>
+          <button
+            type="button"
+            data-testid="decision-record-save"
+            onClick={handleSave}
+            disabled={!valid}
+            className={PRIMARY_BUTTON_CLASS}
+          >
+            {DECISION_RECORD_COPY.save}
+          </button>
+        </div>
+      </ModalShell>
+      {toastElement}
+    </>
+  )
+}

--- a/src/components/results/modals/DefineSuccessModal.tsx
+++ b/src/components/results/modals/DefineSuccessModal.tsx
@@ -1,0 +1,384 @@
+/**
+ * Define-success modal (prototype #successModal, build-ready v6).
+ *
+ * The single success-measure flow: metric / direction / threshold / unit /
+ * timeframe / optional baseline, with a live assembled-sentence preview
+ * (authored shape — see measureSentence.ts) and field-level validation
+ * (brief §7.3: inline 11px danger errors + disabled Save — NEVER the hero
+ * editor's silent no-op on invalid input).
+ *
+ * Save persists the FULL structured measure per scenario
+ * (successMeasureStore, sessionStorage) and commits the numeric threshold
+ * through the EXISTING canonical path — ONE setter
+ * (useCanvasStore.setGoalThreshold) + ONE rerun (executeCanonicalRun with
+ * the same source/parameters convention as OutputsDock.handleApplyThreshold)
+ * — never a second rerun pipeline.
+ *
+ * HONESTY: only the threshold number reaches the analysis today
+ * (UI-SEM-058 raw/cap). Direction, metric, timeframe and baseline are
+ * captured for display/record only, and the modal says so.
+ *
+ * Mount once (e.g. next to AskOlumiDrawer); open from anywhere via
+ * openDefineSuccess().
+ */
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+
+import { executeCanonicalRun } from '../../../canvas/analysis/canonicalRunRegistry'
+import { useCanvasStore } from '../../../canvas/store'
+import { typography } from '../../../styles/typography'
+import {
+  FIELD_INPUT_CLASS,
+  FieldError,
+  FieldLabel,
+  GHOST_BUTTON_CLASS,
+  ModalShell,
+  PRIMARY_BUTTON_CLASS,
+  useModalToast,
+} from './ModalShell'
+import {
+  buildMeasureSentence,
+  DIRECTION_OPTIONS,
+  UNIT_OPTIONS,
+} from './measureSentence'
+import { resolveScenarioKey } from './scenarioKey'
+import {
+  selectSuccessMeasure,
+  useSuccessMeasureStore,
+  type SuccessDirection,
+  type SuccessMeasure,
+} from './successMeasureStore'
+
+export const DEFINE_SUCCESS_COPY = {
+  title: 'Define success',
+  subtitle:
+    'Keep the goal in plain language, then give Olumi a measurable test for Goal fit.',
+  metricLabel: 'What outcome should improve?',
+  directionLabel: 'Direction',
+  thresholdLabel: 'Threshold',
+  thresholdPlaceholder: '20',
+  unitLabel: 'Unit',
+  timeframeLabel: 'Timeframe',
+  timeframePlaceholder: 'Within 6 months',
+  baselineLabel: 'Baseline or evidence, optional',
+  baselinePlaceholder: 'Current productivity or source',
+  writeNote:
+    'This updates the analysis success measure and reruns the analysis. It does not change the graph structure.',
+  honestyNote: 'Only the target number affects the analysis today.',
+  cancel: 'Cancel',
+  save: 'Save and rerun',
+  metricError: 'Add the outcome that should improve.',
+  thresholdError: 'Add a number so Olumi can evaluate Goal fit.',
+  timeframeError: 'Add a timeframe so Olumi can evaluate Goal fit.',
+  toastSaved: 'Success measure saved. Rerunning analysis with the current model.',
+  toastAlreadyRunning:
+    'Success measure saved. Analysis is already running; your target applies on the next run.',
+} as const
+
+function parseThreshold(raw: string): number {
+  // STRICT parse (write-boundary gate, same as the hero editor): empty,
+  // partial or trailing-junk input ("", "20%", "abc") must never reach the
+  // canonical apply route — Number() rejects anything that is not a complete
+  // numeric literal. Negatives are legitimate (outcomes can be losses).
+  const trimmed = raw.trim()
+  return trimmed === '' ? NaN : Number(trimmed)
+}
+
+export function DefineSuccessModal() {
+  const isOpen = useSuccessMeasureStore((s) => s.isOpen)
+  const close = useSuccessMeasureStore((s) => s.close)
+  const { showToast, toastElement } = useModalToast('define-success-toast')
+
+  const titleId = useId()
+  const metricId = useId()
+  const directionId = useId()
+  const thresholdId = useId()
+  const unitId = useId()
+  const timeframeId = useId()
+  const baselineId = useId()
+  const metricErrorId = useId()
+  const thresholdErrorId = useId()
+  const timeframeErrorId = useId()
+
+  const [metric, setMetric] = useState('')
+  const [direction, setDirection] = useState<SuccessDirection>('increase_by_at_least')
+  const [threshold, setThreshold] = useState('')
+  const [unit, setUnit] = useState<string>(UNIT_OPTIONS[0])
+  const [timeframe, setTimeframe] = useState('')
+  const [baseline, setBaseline] = useState('')
+  const [touched, setTouched] = useState<{
+    metric?: boolean
+    threshold?: boolean
+    timeframe?: boolean
+  }>({})
+  // Double-fire guard: one canonical commit per save (reset on each open).
+  const saveFiredRef = useRef(false)
+
+  // Hydrate on open: a previously saved measure wins (reopening keeps
+  // values, per spec); otherwise the metric prefills from the live goal
+  // node's label (NOT the prototype's 'Productivity' fixture) and the
+  // threshold from the committed store value when one exists.
+  useEffect(() => {
+    if (!isOpen) return
+    saveFiredRef.current = false
+    const canvas = useCanvasStore.getState()
+    const scenarioKey = resolveScenarioKey(canvas.currentScenarioId)
+    const saved = selectSuccessMeasure(useSuccessMeasureStore.getState(), scenarioKey)
+    if (saved) {
+      setMetric(saved.metric)
+      setDirection(saved.direction)
+      setThreshold(String(saved.threshold))
+      setUnit(saved.unit)
+      setTimeframe(saved.timeframe)
+      setBaseline(saved.baseline ?? '')
+    } else {
+      const goalNode = canvas.nodes.find(
+        (n) =>
+          n.type === 'goal' ||
+          (n.data as Record<string, unknown> | undefined)?.type === 'goal',
+      )
+      const label = (goalNode?.data as Record<string, unknown> | undefined)?.label
+      setMetric(typeof label === 'string' ? label : '')
+      setDirection('increase_by_at_least')
+      setThreshold(canvas.goalThreshold != null ? String(canvas.goalThreshold) : '')
+      setUnit(UNIT_OPTIONS[0])
+      setTimeframe('')
+      setBaseline('')
+    }
+    setTouched({})
+  }, [isOpen])
+
+  const parsedThreshold = parseThreshold(threshold)
+  const metricValid = metric.trim() !== ''
+  const thresholdValid = Number.isFinite(parsedThreshold)
+  const timeframeValid = timeframe.trim() !== ''
+  const valid = metricValid && thresholdValid && timeframeValid
+
+  const sentence = useMemo(
+    () => buildMeasureSentence({ metric, direction, threshold, unit, timeframe }),
+    [metric, direction, threshold, unit, timeframe],
+  )
+
+  // A saved unit from an older session may not be in the fixed option list —
+  // keep it selectable rather than silently swapping the user's unit.
+  const unitOptions = UNIT_OPTIONS.includes(unit) ? UNIT_OPTIONS : [unit, ...UNIT_OPTIONS]
+
+  const handleSave = () => {
+    // Belt-and-braces: Save is disabled while invalid, but this guard makes
+    // silent-close structurally impossible even if the disabled state is
+    // bypassed (e.g. programmatic click).
+    if (!valid) {
+      setTouched({ metric: true, threshold: true, timeframe: true })
+      return
+    }
+    if (saveFiredRef.current) return
+    saveFiredRef.current = true
+
+    const canvas = useCanvasStore.getState()
+    const scenarioKey = resolveScenarioKey(canvas.currentScenarioId)
+    const measure: SuccessMeasure = {
+      metric: metric.trim(),
+      direction,
+      threshold: parsedThreshold,
+      unit,
+      timeframe: timeframe.trim(),
+      baseline: baseline.trim() === '' ? null : baseline.trim(),
+      savedAt: Date.now(),
+    }
+    useSuccessMeasureStore.getState().saveMeasure(scenarioKey, measure)
+
+    // Canonical commit — the SAME single path as the hero footer editor
+    // (OutputsDock.handleApplyThreshold): ONE setter writes the raw
+    // user-unit threshold (UI-SEM-058 normalises at the request boundary),
+    // ONE canonical rerun with the same source/parameters convention.
+    canvas.setGoalThreshold(parsedThreshold)
+    close()
+    void executeCanonicalRun({
+      source: 'define-success-modal',
+      parameters: { goal_threshold: parsedThreshold },
+    }).then((outcome) => {
+      if (outcome.status === 'blocked' || outcome.status === 'unavailable') {
+        // The measure IS saved — say so, then the honest gate reason.
+        showToast(`Success measure saved. ${outcome.reason}`)
+      } else if (outcome.status === 'already-running') {
+        showToast(DEFINE_SUCCESS_COPY.toastAlreadyRunning)
+      } else {
+        showToast(DEFINE_SUCCESS_COPY.toastSaved)
+      }
+    })
+  }
+
+  return (
+    <>
+      <ModalShell
+        isOpen={isOpen}
+        onClose={close}
+        title={DEFINE_SUCCESS_COPY.title}
+        subtitle={DEFINE_SUCCESS_COPY.subtitle}
+        titleId={titleId}
+        testId="define-success-modal"
+      >
+        <div className="mt-[11px] grid grid-cols-2 gap-2">
+          <div className="col-span-2 flex flex-col gap-1">
+            <FieldLabel htmlFor={metricId}>{DEFINE_SUCCESS_COPY.metricLabel}</FieldLabel>
+            <input
+              id={metricId}
+              data-autofocus
+              data-testid="define-success-metric"
+              type="text"
+              value={metric}
+              onChange={(e) => setMetric(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, metric: true }))}
+              aria-invalid={touched.metric === true && !metricValid}
+              aria-describedby={
+                touched.metric === true && !metricValid ? metricErrorId : undefined
+              }
+              className={FIELD_INPUT_CLASS}
+            />
+            <FieldError id={metricErrorId} show={touched.metric === true && !metricValid}>
+              {DEFINE_SUCCESS_COPY.metricError}
+            </FieldError>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <FieldLabel htmlFor={directionId}>
+              {DEFINE_SUCCESS_COPY.directionLabel}
+            </FieldLabel>
+            <select
+              id={directionId}
+              data-testid="define-success-direction"
+              value={direction}
+              onChange={(e) => setDirection(e.target.value as SuccessDirection)}
+              className={FIELD_INPUT_CLASS}
+            >
+              {DIRECTION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <FieldLabel htmlFor={thresholdId}>
+              {DEFINE_SUCCESS_COPY.thresholdLabel}
+            </FieldLabel>
+            <input
+              id={thresholdId}
+              data-testid="define-success-threshold"
+              type="text"
+              inputMode="decimal"
+              placeholder={DEFINE_SUCCESS_COPY.thresholdPlaceholder}
+              value={threshold}
+              onChange={(e) => setThreshold(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, threshold: true }))}
+              aria-invalid={touched.threshold === true && !thresholdValid}
+              aria-describedby={
+                touched.threshold === true && !thresholdValid ? thresholdErrorId : undefined
+              }
+              className={FIELD_INPUT_CLASS}
+            />
+            <FieldError
+              id={thresholdErrorId}
+              show={touched.threshold === true && !thresholdValid}
+            >
+              {DEFINE_SUCCESS_COPY.thresholdError}
+            </FieldError>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <FieldLabel htmlFor={unitId}>{DEFINE_SUCCESS_COPY.unitLabel}</FieldLabel>
+            <select
+              id={unitId}
+              data-testid="define-success-unit"
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              className={FIELD_INPUT_CLASS}
+            >
+              {unitOptions.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <FieldLabel htmlFor={timeframeId}>
+              {DEFINE_SUCCESS_COPY.timeframeLabel}
+            </FieldLabel>
+            <input
+              id={timeframeId}
+              data-testid="define-success-timeframe"
+              type="text"
+              placeholder={DEFINE_SUCCESS_COPY.timeframePlaceholder}
+              value={timeframe}
+              onChange={(e) => setTimeframe(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, timeframe: true }))}
+              aria-invalid={touched.timeframe === true && !timeframeValid}
+              aria-describedby={
+                touched.timeframe === true && !timeframeValid ? timeframeErrorId : undefined
+              }
+              className={FIELD_INPUT_CLASS}
+            />
+            <FieldError
+              id={timeframeErrorId}
+              show={touched.timeframe === true && !timeframeValid}
+            >
+              {DEFINE_SUCCESS_COPY.timeframeError}
+            </FieldError>
+          </div>
+
+          <div className="col-span-2 flex flex-col gap-1">
+            <FieldLabel htmlFor={baselineId}>
+              {DEFINE_SUCCESS_COPY.baselineLabel}
+            </FieldLabel>
+            <input
+              id={baselineId}
+              data-testid="define-success-baseline"
+              type="text"
+              placeholder={DEFINE_SUCCESS_COPY.baselinePlaceholder}
+              value={baseline}
+              onChange={(e) => setBaseline(e.target.value)}
+              className={FIELD_INPUT_CLASS}
+            />
+          </div>
+        </div>
+
+        {/* Live assembled-sentence preview — goal-yellow outlined box
+            (border-only colour treatment per DS; bg stays panel). */}
+        <p
+          data-testid="measure-preview"
+          className={`mt-[9px] rounded-[9px] border border-goal bg-panel px-[9px] py-2 ${typography.panelBody} text-text-body`}
+        >
+          {sentence}
+        </p>
+
+        <p className={`mt-[7px] ${typography.panelMeta} text-text-light`}>
+          {DEFINE_SUCCESS_COPY.writeNote}
+        </p>
+        <p
+          data-testid="define-success-honesty-note"
+          className={`mt-1 ${typography.panelMeta} text-text-light`}
+        >
+          {DEFINE_SUCCESS_COPY.honestyNote}
+        </p>
+
+        <div className="mt-[11px] flex justify-end gap-[7px]">
+          <button type="button" onClick={close} className={GHOST_BUTTON_CLASS}>
+            {DEFINE_SUCCESS_COPY.cancel}
+          </button>
+          <button
+            type="button"
+            data-testid="define-success-save"
+            onClick={handleSave}
+            disabled={!valid}
+            className={PRIMARY_BUTTON_CLASS}
+          >
+            {DEFINE_SUCCESS_COPY.save}
+          </button>
+        </div>
+      </ModalShell>
+      {toastElement}
+    </>
+  )
+}

--- a/src/components/results/modals/ModalShell.tsx
+++ b/src/components/results/modals/ModalShell.tsx
@@ -1,0 +1,230 @@
+/**
+ * Shared modal scaffold for the Analysis-tab parity dialogs (prototype
+ * `.overlay` + `.modal-card`, build-ready v6): Define success (#successModal)
+ * and Record the decision (#decisionModal).
+ *
+ * Chrome per spec: full-screen scrim rgba(38,38,38,.28) (the prototype's
+ * exact overlay colour — #262626 at 28%; kept as the literal the spec
+ * demands), centred card min(430px,100%), max-height 90vh, padding 13px,
+ * radius 12, bg-panel, shadow-2; head = 14/600 title + subtitle + 28x28
+ * info-blue x icon-button (aria-label "Close").
+ *
+ * Accessibility BEYOND the prototype (its own spec flags all four as gaps to
+ * fix in build): Escape closes, backdrop click closes, Tab is trapped inside
+ * the card, focus moves into the dialog on open ([data-autofocus] first,
+ * else the first enabled focusable) and returns to the invoking element on
+ * close. role="dialog" + aria-modal + aria-labelledby per spec.
+ *
+ * The toast is self-contained (prototype chrome — fixed bottom-centre dark
+ * pill, role="status", auto-hide 1800ms) because ToastProvider is not
+ * mounted in the live results tree — same pattern as AskOlumiDrawer.
+ */
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from 'react'
+import { X } from 'lucide-react'
+
+import { typography } from '../../../styles/typography'
+
+const TOAST_MS = 1800
+
+const FOCUSABLE_SELECTOR =
+  'button, input, select, textarea, a[href], [tabindex]:not([tabindex="-1"])'
+
+function enabledFocusables(card: HTMLElement | null): HTMLElement[] {
+  if (!card) return []
+  return Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute('disabled'),
+  )
+}
+
+/** Prototype `.field` input treatment: radius 9, panel bg, focus border-info. */
+export const FIELD_INPUT_CLASS = `w-full rounded-[9px] border border-panel-border bg-panel px-2 py-[7px] ${typography.panelBody} text-text-header focus:border-info focus:outline-none disabled:cursor-not-allowed disabled:opacity-50`
+
+/** Prototype ghost button (Cancel). */
+export const GHOST_BUTTON_CLASS = `inline-flex items-center gap-1.5 rounded-full border border-panel-border bg-transparent px-2.5 py-1.5 ${typography.panelBody} text-text-body hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`
+
+/** DS v5 primary button: info blue with white text, success-green hover. */
+export const PRIMARY_BUTTON_CLASS = `inline-flex items-center justify-center gap-1.5 rounded-full border border-primary bg-primary px-[11px] py-[7px] ${typography.buttonSmall} text-text-on-color hover:border-primary-hover hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`
+
+export function FieldLabel({
+  htmlFor,
+  children,
+}: {
+  htmlFor: string
+  children: ReactNode
+}) {
+  return (
+    <label htmlFor={htmlFor} className={`${typography.panelMeta} text-text-light`}>
+      {children}
+    </label>
+  )
+}
+
+/** Inline field-level validation error: 11px danger text (brief §7.3). */
+export function FieldError({
+  id,
+  show,
+  children,
+}: {
+  id: string
+  show: boolean
+  children: ReactNode
+}) {
+  if (!show) return null
+  return (
+    <p id={id} className={`${typography.panelMeta} text-danger`} aria-live="polite">
+      {children}
+    </p>
+  )
+}
+
+/**
+ * Self-contained toast (kept OUTSIDE the conditional dialog render so it
+ * survives the modal closing on save).
+ */
+export function useModalToast(testId: string): {
+  showToast: (text: string) => void
+  toastElement: ReactNode
+} {
+  const [toast, setToast] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const showToast = useCallback((text: string) => {
+    setToast(text)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setToast(null), TOAST_MS)
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    [],
+  )
+
+  const toastElement = toast ? (
+    <div
+      role="status"
+      data-testid={testId}
+      className={`pointer-events-none fixed bottom-[18px] left-1/2 z-[40] max-w-[min(90vw,430px)] -translate-x-1/2 rounded-full bg-text-header px-[13px] py-2 ${typography.panelBody} text-text-on-color opacity-95`}
+    >
+      {toast}
+    </div>
+  ) : null
+
+  return { showToast, toastElement }
+}
+
+export interface ModalShellProps {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  subtitle: string
+  titleId: string
+  testId: string
+  children: ReactNode
+}
+
+export function ModalShell({
+  isOpen,
+  onClose,
+  title,
+  subtitle,
+  titleId,
+  testId,
+  children,
+}: ModalShellProps) {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+
+  // Focus management: remember the opener, move focus into the dialog
+  // ([data-autofocus] first — e.g. the first form field), restore on close.
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null
+      const card = cardRef.current
+      const preferred = card?.querySelector<HTMLElement>(
+        '[data-autofocus]:not([disabled])',
+      )
+      const target = preferred ?? enabledFocusables(card)[0]
+      target?.focus()
+    } else {
+      previousFocusRef.current?.focus?.()
+      previousFocusRef.current = null
+    }
+  }, [isOpen])
+
+  // Escape closes (document-level, like AskOlumiDrawer).
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [isOpen, onClose])
+
+  // Tab trap: cycle within the card's enabled focusables.
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab') return
+    const focusables = enabledFocusables(cardRef.current)
+    if (focusables.length === 0) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      data-testid={`${testId}-overlay`}
+      className="fixed inset-0 z-[30] flex items-center justify-center bg-[rgba(38,38,38,0.28)] p-[18px]"
+      onMouseDown={(e) => {
+        // Backdrop click closes; clicks inside the card never do.
+        if (e.target === e.currentTarget) onClose()
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        ref={cardRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-testid={testId}
+        className="max-h-[90vh] w-[min(430px,100%)] overflow-auto rounded-xl border border-panel-border bg-panel p-[13px] shadow-2"
+      >
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <h2 id={titleId} className={`${typography.panelHeader} text-text-header`}>
+              {title}
+            </h2>
+            <p className={`mt-[3px] ${typography.panelBody} text-text-body`}>{subtitle}</p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            title="Close"
+            onClick={onClose}
+            className="flex h-7 w-7 flex-none items-center justify-center rounded-lg border border-panel-border bg-transparent text-info hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info"
+          >
+            <X size={15} aria-hidden="true" />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/results/modals/__tests__/DecisionRecordModal.spec.tsx
+++ b/src/components/results/modals/__tests__/DecisionRecordModal.spec.tsx
@@ -1,0 +1,265 @@
+/**
+ * Record-the-decision modal (prototype #decisionModal) — live analysed
+ * option set (read-only, stable numbering), fail-closed zero-option state,
+ * the closed Number('')===0 confidence hole, scenario-keyed persistence
+ * with the analysed graph hash, and the shared modal a11y contract.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+import { DecisionRecordModal, DECISION_RECORD_COPY } from '../DecisionRecordModal'
+import {
+  openDecisionRecord,
+  selectDecisionRecord,
+  useDecisionRecordStore,
+} from '../decisionRecordStore'
+import { useCanvasStore } from '../../../../canvas/store'
+
+function optionNode(id: string, label: string) {
+  return { id, type: 'option', position: { x: 0, y: 0 }, data: { label } }
+}
+
+function seedAnalysedOptions(opts: { numbering?: Record<string, number> } = {}) {
+  useCanvasStore.setState({
+    nodes: [
+      optionNode('opt_b', 'Hire senior technical lead'),
+      optionNode('opt_a', 'Bring on technical co-founder'),
+    ] as never,
+    results: { status: 'complete', progress: 100, hash: 'hash_run_1' } as never,
+    optionNumbering: opts.numbering ?? { opt_a: 1, opt_b: 2 },
+    currentScenarioId: 'scn_test',
+  } as never)
+}
+
+function seedNoAnalysis() {
+  useCanvasStore.setState({
+    nodes: [optionNode('opt_a', 'Bring on technical co-founder')] as never,
+    results: { status: 'idle', progress: 0 } as never,
+    optionNumbering: {},
+    currentScenarioId: 'scn_test',
+  } as never)
+}
+
+function openModal() {
+  act(() => openDecisionRecord())
+}
+
+function fillValid() {
+  fireEvent.change(screen.getByTestId('decision-record-confidence'), {
+    target: { value: '70' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-revisit'), {
+    target: { value: 'Runway falls below 9 months' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-rationale'), {
+    target: { value: 'Best current choice given hiring constraints.' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-assumption'), {
+    target: { value: 'The hiring market stays open.' },
+  })
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  useDecisionRecordStore.getState()._reset()
+  seedAnalysedOptions()
+})
+
+describe('DecisionRecordModal — chrome and a11y', () => {
+  it('renders nothing until opened', () => {
+    render(<DecisionRecordModal />)
+    expect(screen.queryByTestId('decision-record-modal')).not.toBeInTheDocument()
+  })
+
+  it('opens as an aria-modal dialog labelled by the title, focusing the option select', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    const dialog = screen.getByTestId('decision-record-modal')
+    expect(dialog).toHaveAttribute('role', 'dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    const labelledBy = dialog.getAttribute('aria-labelledby')
+    expect(document.getElementById(labelledBy as string)).toHaveTextContent(
+      DECISION_RECORD_COPY.title,
+    )
+    expect(document.activeElement).toBe(screen.getByTestId('decision-record-option'))
+  })
+
+  it('Escape closes and focus returns to the invoking element', () => {
+    render(
+      <>
+        <button type="button" data-testid="opener">
+          open
+        </button>
+        <DecisionRecordModal />
+      </>,
+    )
+    const opener = screen.getByTestId('opener')
+    opener.focus()
+    openModal()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('decision-record-modal')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(opener)
+  })
+
+  it('shows the honest prototype-persistence note', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    expect(screen.getByTestId('decision-record-note')).toHaveTextContent(
+      'Saved on this device for this scenario.',
+    )
+  })
+})
+
+describe('DecisionRecordModal — analysed option set (read-only)', () => {
+  it('lists the analysed options with stable numbers, sorted by number', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    const select = screen.getByTestId('decision-record-option') as HTMLSelectElement
+    const labels = Array.from(select.options).map((o) => o.textContent)
+    expect(labels).toEqual([
+      '1. Bring on technical co-founder',
+      '2. Hire senior technical lead',
+    ])
+  })
+
+  it('omits numbers (never fabricates) when the numbering map is incomplete', () => {
+    seedAnalysedOptions({ numbering: { opt_a: 1 } })
+    render(<DecisionRecordModal />)
+    openModal()
+    const select = screen.getByTestId('decision-record-option') as HTMLSelectElement
+    const labels = Array.from(select.options).map((o) => o.textContent)
+    expect(labels).toEqual([
+      'Hire senior technical lead',
+      'Bring on technical co-founder',
+    ])
+  })
+
+  it('fail-closed: no completed analysis renders a disabled form with honest copy', () => {
+    seedNoAnalysis()
+    render(<DecisionRecordModal />)
+    openModal()
+    expect(screen.getByTestId('decision-record-empty')).toHaveTextContent(
+      DECISION_RECORD_COPY.emptyState,
+    )
+    expect(screen.getByTestId('decision-record-option')).toBeDisabled()
+    expect(screen.getByTestId('decision-record-confidence')).toBeDisabled()
+    expect(screen.getByTestId('decision-record-rationale')).toBeDisabled()
+    expect(screen.getByTestId('decision-record-save')).toBeDisabled()
+  })
+})
+
+describe('DecisionRecordModal — validation', () => {
+  it('empty confidence blocks Save (the prototype Number("")===0 hole is closed)', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    fillValid()
+    const confidence = screen.getByTestId('decision-record-confidence')
+    fireEvent.change(confidence, { target: { value: '' } })
+    fireEvent.blur(confidence)
+    expect(screen.getByText(DECISION_RECORD_COPY.confidenceError)).toBeInTheDocument()
+    expect(screen.getByTestId('decision-record-save')).toBeDisabled()
+  })
+
+  it.each([['101'], ['-1'], ['abc'], ['70%']])(
+    'confidence %j is rejected with the inline error',
+    (bad) => {
+      render(<DecisionRecordModal />)
+      openModal()
+      fillValid()
+      const confidence = screen.getByTestId('decision-record-confidence')
+      fireEvent.change(confidence, { target: { value: bad } })
+      fireEvent.blur(confidence)
+      expect(screen.getByText(DECISION_RECORD_COPY.confidenceError)).toBeInTheDocument()
+      expect(screen.getByTestId('decision-record-save')).toBeDisabled()
+    },
+  )
+
+  it.each([[0], [100]])('boundary confidence %d passes', (edge) => {
+    render(<DecisionRecordModal />)
+    openModal()
+    fillValid()
+    fireEvent.change(screen.getByTestId('decision-record-confidence'), {
+      target: { value: String(edge) },
+    })
+    expect(screen.getByTestId('decision-record-save')).toBeEnabled()
+  })
+
+  it('rationale, assumption and revisit trigger are each required with their own errors', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    fillValid()
+    for (const [testId, error] of [
+      ['decision-record-rationale', DECISION_RECORD_COPY.rationaleError],
+      ['decision-record-assumption', DECISION_RECORD_COPY.assumptionError],
+      ['decision-record-revisit', DECISION_RECORD_COPY.revisitError],
+    ] as const) {
+      const field = screen.getByTestId(testId)
+      const previous = (field as HTMLInputElement).value
+      fireEvent.change(field, { target: { value: '   ' } })
+      fireEvent.blur(field)
+      expect(screen.getByText(error)).toBeInTheDocument()
+      expect(screen.getByTestId('decision-record-save')).toBeDisabled()
+      fireEvent.change(field, { target: { value: previous } })
+    }
+    expect(screen.getByTestId('decision-record-save')).toBeEnabled()
+  })
+})
+
+describe('DecisionRecordModal — capture', () => {
+  it('saves the scenario-keyed record with the analysed graph hash, toasts the spec copy and closes', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    fireEvent.change(screen.getByTestId('decision-record-option'), {
+      target: { value: 'opt_b' },
+    })
+    fillValid()
+    fireEvent.click(screen.getByTestId('decision-record-save'))
+
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), 'scn_test')
+    expect(record).toMatchObject({
+      optionId: 'opt_b',
+      optionLabel: 'Hire senior technical lead',
+      optionNumber: 2,
+      confidence: 70,
+      rationale: 'Best current choice given hiring constraints.',
+      assumptionToWatch: 'The hiring market stays open.',
+      revisitTrigger: 'Runway falls below 9 months',
+      analysisHash: 'hash_run_1',
+    })
+
+    expect(screen.queryByTestId('decision-record-modal')).not.toBeInTheDocument()
+    expect(screen.getByTestId('decision-record-toast')).toHaveTextContent(
+      DECISION_RECORD_COPY.toastSaved,
+    )
+  })
+
+  it('the selector exposes the record for later "Decision recorded" surfaces, and it survives a simulated reload', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    fillValid()
+    fireEvent.click(screen.getByTestId('decision-record-save'))
+
+    useDecisionRecordStore.setState({ byScenario: {} })
+    useDecisionRecordStore.getState()._rehydrateForTests()
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), 'scn_test')
+    expect(record?.optionId).toBe('opt_a')
+    expect(record?.analysisHash).toBe('hash_run_1')
+  })
+
+  it('reopening prefills from the existing record', () => {
+    render(<DecisionRecordModal />)
+    openModal()
+    fireEvent.change(screen.getByTestId('decision-record-option'), {
+      target: { value: 'opt_b' },
+    })
+    fillValid()
+    fireEvent.click(screen.getByTestId('decision-record-save'))
+
+    openModal()
+    expect(screen.getByTestId('decision-record-option')).toHaveValue('opt_b')
+    expect(screen.getByTestId('decision-record-confidence')).toHaveValue('70')
+    expect(screen.getByTestId('decision-record-rationale')).toHaveValue(
+      'Best current choice given hiring constraints.',
+    )
+  })
+})

--- a/src/components/results/modals/__tests__/DefineSuccessModal.spec.tsx
+++ b/src/components/results/modals/__tests__/DefineSuccessModal.spec.tsx
@@ -1,0 +1,358 @@
+/**
+ * Define-success modal (prototype #successModal) — chrome/a11y, live
+ * assembled-sentence preview, field-level validation (never silent-close),
+ * and the canonical threshold commit: ONE setter + ONE canonical rerun,
+ * the same path as OutputsDock.handleApplyThreshold.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+import { DefineSuccessModal, DEFINE_SUCCESS_COPY } from '../DefineSuccessModal'
+import {
+  openDefineSuccess,
+  selectSuccessMeasure,
+  useSuccessMeasureStore,
+} from '../successMeasureStore'
+import {
+  registerCanonicalRunner,
+  __resetCanonicalRunnerForTests,
+  type CanonicalRunOptions,
+  type CanonicalRunOutcome,
+} from '../../../../canvas/analysis/canonicalRunRegistry'
+import { useCanvasStore } from '../../../../canvas/store'
+
+const originalSetGoalThreshold = useCanvasStore.getState().setGoalThreshold
+
+function seedCanvas(opts: { goalLabel?: string; goalThreshold?: number | null } = {}) {
+  useCanvasStore.setState({
+    nodes: opts.goalLabel
+      ? ([
+          {
+            id: 'goal_1',
+            type: 'goal',
+            position: { x: 0, y: 0 },
+            data: { label: opts.goalLabel },
+          },
+        ] as never)
+      : ([] as never),
+    currentScenarioId: 'scn_test',
+    goalThreshold: opts.goalThreshold ?? null,
+  } as never)
+}
+
+function openModal() {
+  act(() => openDefineSuccess())
+}
+
+function fillValid(threshold = '20') {
+  fireEvent.change(screen.getByTestId('define-success-metric'), {
+    target: { value: 'Productivity' },
+  })
+  fireEvent.change(screen.getByTestId('define-success-threshold'), {
+    target: { value: threshold },
+  })
+  fireEvent.change(screen.getByTestId('define-success-timeframe'), {
+    target: { value: 'Within 6 months' },
+  })
+}
+
+function createRunnerMock() {
+  return vi.fn(
+    async (_opts?: CanonicalRunOptions): Promise<CanonicalRunOutcome> => ({
+      status: 'dispatched',
+    }),
+  )
+}
+
+let runner: ReturnType<typeof createRunnerMock>
+
+beforeEach(() => {
+  sessionStorage.clear()
+  useSuccessMeasureStore.getState()._reset()
+  __resetCanonicalRunnerForTests()
+  runner = createRunnerMock()
+  registerCanonicalRunner(runner)
+  seedCanvas()
+})
+
+afterEach(() => {
+  useCanvasStore.setState({ setGoalThreshold: originalSetGoalThreshold } as never)
+})
+
+describe('DefineSuccessModal — chrome and a11y', () => {
+  it('renders nothing until opened', () => {
+    render(<DefineSuccessModal />)
+    expect(screen.queryByTestId('define-success-modal')).not.toBeInTheDocument()
+  })
+
+  it('opens as an aria-modal dialog labelled by the title, focusing the first field', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    const dialog = screen.getByTestId('define-success-modal')
+    expect(dialog).toHaveAttribute('role', 'dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    const labelledBy = dialog.getAttribute('aria-labelledby')
+    expect(labelledBy).toBeTruthy()
+    expect(document.getElementById(labelledBy as string)).toHaveTextContent(
+      DEFINE_SUCCESS_COPY.title,
+    )
+    expect(document.activeElement).toBe(screen.getByTestId('define-success-metric'))
+  })
+
+  it('Escape closes and focus returns to the invoking element', () => {
+    render(
+      <>
+        <button type="button" data-testid="opener">
+          open
+        </button>
+        <DefineSuccessModal />
+      </>,
+    )
+    const opener = screen.getByTestId('opener')
+    opener.focus()
+    openModal()
+    expect(document.activeElement).not.toBe(opener)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('define-success-modal')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(opener)
+  })
+
+  it('the Close icon-button closes', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.queryByTestId('define-success-modal')).not.toBeInTheDocument()
+  })
+
+  it('backdrop click closes; clicks inside the card do not', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fireEvent.mouseDown(screen.getByTestId('define-success-modal'))
+    expect(screen.getByTestId('define-success-modal')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByTestId('define-success-modal-overlay'))
+    expect(screen.queryByTestId('define-success-modal')).not.toBeInTheDocument()
+  })
+
+  it('renders the write-behaviour note and the honesty meta line', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    expect(screen.getByText(DEFINE_SUCCESS_COPY.writeNote)).toBeInTheDocument()
+    expect(screen.getByTestId('define-success-honesty-note')).toHaveTextContent(
+      'Only the target number affects the analysis today.',
+    )
+  })
+})
+
+describe('DefineSuccessModal — prefill', () => {
+  it('prefills the metric from the live goal node and the threshold from the store', () => {
+    seedCanvas({ goalLabel: 'Team output', goalThreshold: 120 })
+    render(<DefineSuccessModal />)
+    openModal()
+    expect(screen.getByTestId('define-success-metric')).toHaveValue('Team output')
+    expect(screen.getByTestId('define-success-threshold')).toHaveValue('120')
+  })
+
+  it('reopening after a save keeps the saved values', async () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid('42')
+    fireEvent.change(screen.getByTestId('define-success-direction'), {
+      target: { value: 'keep_below' },
+    })
+    fireEvent.change(screen.getByTestId('define-success-baseline'), {
+      target: { value: 'Q1 survey' },
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('define-success-save'))
+    })
+    expect(screen.queryByTestId('define-success-modal')).not.toBeInTheDocument()
+
+    openModal()
+    expect(screen.getByTestId('define-success-metric')).toHaveValue('Productivity')
+    expect(screen.getByTestId('define-success-direction')).toHaveValue('keep_below')
+    expect(screen.getByTestId('define-success-threshold')).toHaveValue('42')
+    expect(screen.getByTestId('define-success-timeframe')).toHaveValue('Within 6 months')
+    expect(screen.getByTestId('define-success-baseline')).toHaveValue('Q1 survey')
+  })
+})
+
+describe('DefineSuccessModal — live preview', () => {
+  it('starts with placeholder tokens and assembles the authored sentence as fields fill', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    expect(screen.getByTestId('measure-preview')).toHaveTextContent(
+      'Success means: increase [outcome] by at least [number]% [timeframe].',
+    )
+    fillValid()
+    expect(screen.getByTestId('measure-preview')).toHaveTextContent(
+      'Success means: increase Productivity by at least 20% within 6 months.',
+    )
+  })
+
+  it('re-assembles per direction change', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid()
+    fireEvent.change(screen.getByTestId('define-success-direction'), {
+      target: { value: 'reach_at_least' },
+    })
+    expect(screen.getByTestId('measure-preview')).toHaveTextContent(
+      'Success means: Productivity reaches at least 20% within 6 months.',
+    )
+    fireEvent.change(screen.getByTestId('define-success-direction'), {
+      target: { value: 'keep_below' },
+    })
+    expect(screen.getByTestId('measure-preview')).toHaveTextContent(
+      'Success means: keep Productivity below 20% within 6 months.',
+    )
+  })
+})
+
+describe('DefineSuccessModal — validation (never silent-close)', () => {
+  it('Save is disabled while fields are empty and no canonical call fires', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    const save = screen.getByTestId('define-success-save')
+    expect(save).toBeDisabled()
+    fireEvent.click(save)
+    expect(screen.getByTestId('define-success-modal')).toBeInTheDocument()
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it.each([['20%'], ['abc'], ['1e'], ['']])(
+    'threshold %j blocks Save with an inline 11px danger error on blur',
+    (bad) => {
+      render(<DefineSuccessModal />)
+      openModal()
+      fillValid()
+      const threshold = screen.getByTestId('define-success-threshold')
+      fireEvent.change(threshold, { target: { value: bad } })
+      fireEvent.blur(threshold)
+      expect(screen.getByText(DEFINE_SUCCESS_COPY.thresholdError)).toBeInTheDocument()
+      expect(screen.getByTestId('define-success-save')).toBeDisabled()
+      expect(threshold).toHaveAttribute('aria-invalid', 'true')
+    },
+  )
+
+  it('negative thresholds are legitimate and pass', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid('-5')
+    expect(screen.getByTestId('define-success-save')).toBeEnabled()
+  })
+
+  it('empty metric and timeframe each block Save with their own field errors', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid()
+    const metric = screen.getByTestId('define-success-metric')
+    fireEvent.change(metric, { target: { value: '  ' } })
+    fireEvent.blur(metric)
+    expect(screen.getByText(DEFINE_SUCCESS_COPY.metricError)).toBeInTheDocument()
+    expect(screen.getByTestId('define-success-save')).toBeDisabled()
+
+    fireEvent.change(metric, { target: { value: 'Productivity' } })
+    const timeframe = screen.getByTestId('define-success-timeframe')
+    fireEvent.change(timeframe, { target: { value: '' } })
+    fireEvent.blur(timeframe)
+    expect(screen.getByText(DEFINE_SUCCESS_COPY.timeframeError)).toBeInTheDocument()
+    expect(screen.getByTestId('define-success-save')).toBeDisabled()
+  })
+
+  it('the baseline is optional', () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid()
+    expect(screen.getByTestId('define-success-save')).toBeEnabled()
+  })
+})
+
+describe('DefineSuccessModal — save commits through the canonical path exactly once', () => {
+  it('persists the full structured measure, calls the ONE setter and ONE canonical rerun, toasts and closes', async () => {
+    const setterSpy = vi.fn(originalSetGoalThreshold)
+    useCanvasStore.setState({ setGoalThreshold: setterSpy } as never)
+
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid('20')
+    fireEvent.change(screen.getByTestId('define-success-direction'), {
+      target: { value: 'reach_at_least' },
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('define-success-save'))
+    })
+
+    // ONE setter call with the raw user-unit number (UI-SEM-058 normalises
+    // downstream at the request boundary, same as the hero editor).
+    expect(setterSpy).toHaveBeenCalledTimes(1)
+    expect(setterSpy).toHaveBeenCalledWith(20)
+    expect(useCanvasStore.getState().goalThreshold).toBe(20)
+
+    // ONE canonical rerun with the same source/parameters convention as
+    // OutputsDock.handleApplyThreshold.
+    expect(runner).toHaveBeenCalledTimes(1)
+    expect(runner).toHaveBeenCalledWith({
+      source: 'define-success-modal',
+      parameters: { goal_threshold: 20 },
+    })
+
+    // Full structured measure persisted per scenario.
+    const saved = selectSuccessMeasure(useSuccessMeasureStore.getState(), 'scn_test')
+    expect(saved).toMatchObject({
+      metric: 'Productivity',
+      direction: 'reach_at_least',
+      threshold: 20,
+      unit: '%',
+      timeframe: 'Within 6 months',
+      baseline: null,
+    })
+
+    expect(screen.queryByTestId('define-success-modal')).not.toBeInTheDocument()
+    expect(screen.getByTestId('define-success-toast')).toHaveTextContent(
+      DEFINE_SUCCESS_COPY.toastSaved,
+    )
+  })
+
+  it('fires the canonical run again on a later save (guard resets per open)', async () => {
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid('20')
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('define-success-save'))
+    })
+    openModal()
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('define-success-save'))
+    })
+    expect(runner).toHaveBeenCalledTimes(2)
+  })
+
+  it('a blocked rerun still saves the measure and toasts the honest gate reason', async () => {
+    runner.mockImplementation(async () => ({ status: 'blocked', reason: 'Add a goal first.' }))
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid('20')
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('define-success-save'))
+    })
+    expect(
+      selectSuccessMeasure(useSuccessMeasureStore.getState(), 'scn_test'),
+    ).not.toBeNull()
+    expect(screen.getByTestId('define-success-toast')).toHaveTextContent(
+      'Success measure saved. Add a goal first.',
+    )
+  })
+
+  it('with NO registered runner the save degrades honestly (toast, no crash)', async () => {
+    __resetCanonicalRunnerForTests()
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid('20')
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('define-success-save'))
+    })
+    expect(screen.getByTestId('define-success-toast')).toHaveTextContent(
+      /Success measure saved\./,
+    )
+  })
+})

--- a/src/components/results/modals/__tests__/decisionRecordStore.spec.ts
+++ b/src/components/results/modals/__tests__/decisionRecordStore.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * decisionRecordStore — scenario-keyed sessionStorage persistence for the
+ * prototype-only decision record (no backend persistence exists).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  selectDecisionRecord,
+  useDecisionRecordStore,
+  type DecisionRecord,
+} from '../decisionRecordStore'
+
+const STORAGE_KEY = 'decisionRecord.v1'
+
+function record(overrides: Partial<DecisionRecord> = {}): DecisionRecord {
+  return {
+    optionId: 'opt_1',
+    optionLabel: 'Bring on technical co-founder',
+    optionNumber: 1,
+    confidence: 70,
+    rationale: 'Best current choice.',
+    assumptionToWatch: 'Hiring market stays open.',
+    revisitTrigger: 'Runway falls below 9 months',
+    analysisHash: 'hash_1',
+    savedAt: 1234,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useDecisionRecordStore.getState()._reset()
+  sessionStorage.clear()
+})
+
+describe('decisionRecordStore', () => {
+  it('saves one record per scenario, latest wins', () => {
+    const store = useDecisionRecordStore.getState()
+    store.saveRecord('scn_a', record())
+    store.saveRecord('scn_a', record({ optionId: 'opt_2', optionLabel: 'Outsource' }))
+    store.saveRecord('scn_b', record({ optionId: 'opt_3' }))
+
+    const state = useDecisionRecordStore.getState()
+    expect(selectDecisionRecord(state, 'scn_a')?.optionId).toBe('opt_2')
+    expect(selectDecisionRecord(state, 'scn_b')?.optionId).toBe('opt_3')
+    expect(selectDecisionRecord(state, 'scn_c')).toBeNull()
+  })
+
+  it('round-trips through sessionStorage (simulated reload) including the analysis hash', () => {
+    useDecisionRecordStore.getState().saveRecord('scn_a', record())
+
+    useDecisionRecordStore.setState({ byScenario: {} })
+    expect(selectDecisionRecord(useDecisionRecordStore.getState(), 'scn_a')).toBeNull()
+
+    useDecisionRecordStore.getState()._rehydrateForTests()
+    const restored = selectDecisionRecord(useDecisionRecordStore.getState(), 'scn_a')
+    expect(restored).toEqual(record())
+    expect(restored?.analysisHash).toBe('hash_1')
+  })
+
+  it('persists a version-keyed payload and ignores unknown versions', () => {
+    useDecisionRecordStore.getState().saveRecord('scn_a', record())
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    expect(JSON.parse(raw as string).version).toBe(1)
+
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 2, byScenario: { scn_a: record() } }),
+    )
+    useDecisionRecordStore.getState()._rehydrateForTests()
+    expect(selectDecisionRecord(useDecisionRecordStore.getState(), 'scn_a')).toBeNull()
+  })
+
+  it('ignores corrupt storage payloads', () => {
+    sessionStorage.setItem(STORAGE_KEY, '¬ not json')
+    useDecisionRecordStore.getState()._rehydrateForTests()
+    expect(useDecisionRecordStore.getState().byScenario).toEqual({})
+  })
+
+  it('_reset clears memory and storage', () => {
+    useDecisionRecordStore.getState().saveRecord('scn_a', record())
+    useDecisionRecordStore.getState()._reset()
+    expect(useDecisionRecordStore.getState().byScenario).toEqual({})
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})

--- a/src/components/results/modals/__tests__/measureSentence.spec.ts
+++ b/src/components/results/modals/__tests__/measureSentence.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Assembled-sentence matrix for the Define-success preview — the AUTHORED
+ * shape (direction phrase split around the metric), not the prototype's
+ * buggy runtime word order.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { buildMeasureSentence, DIRECTION_OPTIONS, UNIT_OPTIONS } from '../measureSentence'
+
+describe('buildMeasureSentence', () => {
+  it('assembles the authored increase shape', () => {
+    expect(
+      buildMeasureSentence({
+        metric: 'Productivity',
+        direction: 'increase_by_at_least',
+        threshold: '20',
+        unit: '%',
+        timeframe: 'Within 6 months',
+      }),
+    ).toBe('Success means: increase Productivity by at least 20% within 6 months.')
+  })
+
+  it('assembles the reach-at-least shape with the metric leading', () => {
+    expect(
+      buildMeasureSentence({
+        metric: 'Revenue',
+        direction: 'reach_at_least',
+        threshold: '120',
+        unit: '£',
+        timeframe: 'Within 12 months',
+      }),
+    ).toBe('Success means: Revenue reaches at least 120£ within 12 months.')
+  })
+
+  it('assembles the keep-below shape with the direction split around the metric', () => {
+    expect(
+      buildMeasureSentence({
+        metric: 'Churn',
+        direction: 'keep_below',
+        threshold: '4',
+        unit: '%',
+        timeframe: 'Within 6 months',
+      }),
+    ).toBe('Success means: keep Churn below 4% within 6 months.')
+  })
+
+  it('falls back to the prototype placeholder tokens when fields are empty', () => {
+    expect(
+      buildMeasureSentence({
+        metric: '',
+        direction: 'increase_by_at_least',
+        threshold: '',
+        unit: '%',
+        timeframe: '',
+      }),
+    ).toBe('Success means: increase [outcome] by at least [number]% [timeframe].')
+  })
+
+  it('lowercases the timeframe and concatenates threshold+unit with no space', () => {
+    const sentence = buildMeasureSentence({
+      metric: 'Output',
+      direction: 'reach_at_least',
+      threshold: '3',
+      unit: 'projects',
+      timeframe: 'By Q3',
+    })
+    expect(sentence).toContain('3projects')
+    expect(sentence).toContain('by q3')
+    expect(sentence).not.toContain('By Q3')
+  })
+
+  it('trims whitespace-only fields down to placeholders', () => {
+    expect(
+      buildMeasureSentence({
+        metric: '   ',
+        direction: 'keep_below',
+        threshold: '  ',
+        unit: 'weeks',
+        timeframe: '  ',
+      }),
+    ).toBe('Success means: keep [outcome] below [number]weeks [timeframe].')
+  })
+
+  it('exposes the spec option lists in prototype order', () => {
+    expect(DIRECTION_OPTIONS.map((d) => d.label)).toEqual([
+      'Increase by at least',
+      'Reach at least',
+      'Keep below',
+    ])
+    expect([...UNIT_OPTIONS]).toEqual(['%', 'projects', 'weeks', '£'])
+  })
+})

--- a/src/components/results/modals/__tests__/successMeasureStore.spec.ts
+++ b/src/components/results/modals/__tests__/successMeasureStore.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * successMeasureStore — scenario-keyed sessionStorage persistence
+ * (strengthenStore pattern: manual, version-keyed, degrade on storage
+ * failure).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  selectSuccessMeasure,
+  useSuccessMeasureStore,
+  type SuccessMeasure,
+} from '../successMeasureStore'
+import { resolveScenarioKey, UNSCOPED_SCENARIO_KEY } from '../scenarioKey'
+
+const STORAGE_KEY = 'defineSuccess.measure.v1'
+
+function measure(overrides: Partial<SuccessMeasure> = {}): SuccessMeasure {
+  return {
+    metric: 'Productivity',
+    direction: 'increase_by_at_least',
+    threshold: 20,
+    unit: '%',
+    timeframe: 'Within 6 months',
+    baseline: null,
+    savedAt: 1234,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useSuccessMeasureStore.getState()._reset()
+  sessionStorage.clear()
+})
+
+describe('successMeasureStore', () => {
+  it('saves per scenario without collisions', () => {
+    const store = useSuccessMeasureStore.getState()
+    store.saveMeasure('scn_a', measure({ metric: 'Revenue' }))
+    store.saveMeasure('scn_b', measure({ metric: 'Churn', direction: 'keep_below' }))
+
+    const state = useSuccessMeasureStore.getState()
+    expect(selectSuccessMeasure(state, 'scn_a')?.metric).toBe('Revenue')
+    expect(selectSuccessMeasure(state, 'scn_b')?.metric).toBe('Churn')
+    expect(selectSuccessMeasure(state, 'scn_c')).toBeNull()
+  })
+
+  it('round-trips through sessionStorage (simulated reload)', () => {
+    useSuccessMeasureStore.getState().saveMeasure('scn_a', measure())
+
+    // Wipe the in-memory copy, then rehydrate from storage.
+    useSuccessMeasureStore.setState({ byScenario: {} })
+    expect(selectSuccessMeasure(useSuccessMeasureStore.getState(), 'scn_a')).toBeNull()
+
+    useSuccessMeasureStore.getState()._rehydrateForTests()
+    expect(selectSuccessMeasure(useSuccessMeasureStore.getState(), 'scn_a')).toEqual(measure())
+  })
+
+  it('persists a version-keyed payload and ignores unknown versions', () => {
+    useSuccessMeasureStore.getState().saveMeasure('scn_a', measure())
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw as string).version).toBe(1)
+
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 99, byScenario: { scn_a: measure() } }),
+    )
+    useSuccessMeasureStore.getState()._rehydrateForTests()
+    expect(selectSuccessMeasure(useSuccessMeasureStore.getState(), 'scn_a')).toBeNull()
+  })
+
+  it('ignores corrupt storage payloads', () => {
+    sessionStorage.setItem(STORAGE_KEY, 'not json {')
+    useSuccessMeasureStore.getState()._rehydrateForTests()
+    expect(useSuccessMeasureStore.getState().byScenario).toEqual({})
+  })
+
+  it('_reset clears memory and storage', () => {
+    useSuccessMeasureStore.getState().saveMeasure('scn_a', measure())
+    useSuccessMeasureStore.getState()._reset()
+    expect(useSuccessMeasureStore.getState().byScenario).toEqual({})
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('open/close drive the modal visibility flag', () => {
+    expect(useSuccessMeasureStore.getState().isOpen).toBe(false)
+    useSuccessMeasureStore.getState().open()
+    expect(useSuccessMeasureStore.getState().isOpen).toBe(true)
+    useSuccessMeasureStore.getState().close()
+    expect(useSuccessMeasureStore.getState().isOpen).toBe(false)
+  })
+})
+
+describe('resolveScenarioKey', () => {
+  it('falls back to the unscoped key for null/empty scenario ids', () => {
+    expect(resolveScenarioKey(null)).toBe(UNSCOPED_SCENARIO_KEY)
+    expect(resolveScenarioKey(undefined)).toBe(UNSCOPED_SCENARIO_KEY)
+    expect(resolveScenarioKey('')).toBe(UNSCOPED_SCENARIO_KEY)
+    expect(resolveScenarioKey('scn_1')).toBe('scn_1')
+  })
+})

--- a/src/components/results/modals/decisionRecordStore.ts
+++ b/src/components/results/modals/decisionRecordStore.ts
@@ -1,0 +1,136 @@
+/**
+ * decisionRecordStore — the prototype-only decision record captured by the
+ * Record-the-decision modal (prototype #decisionModal, build-ready v6).
+ *
+ * HONESTY CONTRACT: NO backend persistence exists — durable saving is
+ * blocked on identity + Model Management (the prototype's own disclaimer).
+ * Records live in sessionStorage on THIS device for THIS scenario and die
+ * with the browser session. Any surface rendering a "Decision recorded"
+ * state from this store must label it accordingly.
+ *
+ * Persistence mirrors strengthenStore: zustand + manual, version-keyed
+ * sessionStorage, keyed per scenario id. The analysed graph hash
+ * (results.hash at capture time) is stored so later surfaces can say
+ * whether the record still matches the current analysis.
+ */
+import { create } from 'zustand'
+
+import { resolveScenarioKey } from './scenarioKey'
+
+export interface DecisionRecord {
+  /** Canvas node id of the chosen option (from the analysed option set). */
+  optionId: string
+  /** Display label snapshot at capture time. */
+  optionLabel: string
+  /** Stable option number (optionNumbering) when the full set was numbered; null otherwise. */
+  optionNumber: number | null
+  /** 0-100 inclusive. Validated non-empty at capture (the prototype's Number('')===0 hole is closed). */
+  confidence: number
+  rationale: string
+  assumptionToWatch: string
+  /** Free text: a trigger condition or a date ("Revisit trigger or date"). */
+  revisitTrigger: string
+  /** results.hash of the completed analysis on screen at capture time, if any. */
+  analysisHash: string | null
+  savedAt: number
+}
+
+export interface DecisionRecordState {
+  isOpen: boolean
+  byScenario: Record<string, DecisionRecord>
+  open: () => void
+  close: () => void
+  saveRecord: (scenarioKey: string, record: DecisionRecord) => void
+  /** Test/reset seam — clears memory AND storage. */
+  _reset: () => void
+  /** Test seam — re-reads sessionStorage (simulates a reload). */
+  _rehydrateForTests: () => void
+}
+
+const STORAGE_KEY = 'decisionRecord.v1'
+
+function loadPersisted(): Pick<DecisionRecordState, 'byScenario'> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return { byScenario: {} }
+    const parsed = JSON.parse(raw)
+    if (parsed?.version !== 1) return { byScenario: {} }
+    return { byScenario: parsed.byScenario ?? {} }
+  } catch {
+    return { byScenario: {} }
+  }
+}
+
+function persist(byScenario: Record<string, DecisionRecord>): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, byScenario }))
+  } catch {
+    // sessionStorage unavailable — the record degrades to in-memory only.
+  }
+}
+
+export const useDecisionRecordStore = create<DecisionRecordState>((set, get) => ({
+  isOpen: false,
+  ...loadPersisted(),
+
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+
+  saveRecord: (scenarioKey, record) => {
+    const byScenario = { ...get().byScenario, [scenarioKey]: record }
+    persist(byScenario)
+    set({ byScenario })
+  },
+
+  _reset: () => {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY)
+    } catch {
+      /* ignore */
+    }
+    set({ isOpen: false, byScenario: {} })
+  },
+
+  _rehydrateForTests: () => {
+    set({ ...loadPersisted() })
+  },
+}))
+
+/**
+ * The captured record for a scenario key, or null. This is the selector the
+ * overview/strengthen surfaces use to render a "Decision recorded" state
+ * (wiring happens in another lane).
+ */
+export function selectDecisionRecord(
+  state: Pick<DecisionRecordState, 'byScenario'>,
+  scenarioKey: string,
+): DecisionRecord | null {
+  return state.byScenario[scenarioKey] ?? null
+}
+
+/**
+ * Open the Record-the-decision modal from any surface without prop drilling
+ * (the commit rec's primary action per the spec's intended wiring — NOT the
+ * prototype's mis-wired 'ask' branch). The modal itself must be mounted
+ * once — see DecisionRecordModal.
+ */
+export function openDecisionRecord(): void {
+  useDecisionRecordStore.getState().open()
+}
+
+export function closeDecisionRecord(): void {
+  useDecisionRecordStore.getState().close()
+}
+
+/**
+ * Reactive record lookup per scenario. Callers subscribe to
+ * `useCanvasStore(s => s.currentScenarioId)` themselves and pass it in —
+ * keeps this store decoupled from the canvas store.
+ */
+export function useDecisionRecordForScenario(
+  scenarioId: string | null | undefined,
+): DecisionRecord | null {
+  return useDecisionRecordStore(
+    (s) => s.byScenario[resolveScenarioKey(scenarioId)] ?? null,
+  )
+}

--- a/src/components/results/modals/index.ts
+++ b/src/components/results/modals/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Analysis-tab parity modals — public wiring surface.
+ *
+ * Mount `<DefineSuccessModal />` and `<DecisionRecordModal />` ONCE (e.g.
+ * next to AskOlumiDrawer in the results tree), then open them from any
+ * surface via `openDefineSuccess()` / `openDecisionRecord()` — no prop
+ * drilling. Saved state is read back through the exported selectors/hooks.
+ */
+export { DefineSuccessModal, DEFINE_SUCCESS_COPY } from './DefineSuccessModal'
+export { DecisionRecordModal, DECISION_RECORD_COPY } from './DecisionRecordModal'
+export {
+  useSuccessMeasureStore,
+  selectSuccessMeasure,
+  openDefineSuccess,
+  closeDefineSuccess,
+  useSuccessMeasureForScenario,
+  type SuccessMeasure,
+  type SuccessDirection,
+} from './successMeasureStore'
+export {
+  useDecisionRecordStore,
+  selectDecisionRecord,
+  openDecisionRecord,
+  closeDecisionRecord,
+  useDecisionRecordForScenario,
+  type DecisionRecord,
+} from './decisionRecordStore'
+export { buildMeasureSentence, DIRECTION_OPTIONS, UNIT_OPTIONS } from './measureSentence'
+export { resolveScenarioKey, UNSCOPED_SCENARIO_KEY } from './scenarioKey'

--- a/src/components/results/modals/measureSentence.ts
+++ b/src/components/results/modals/measureSentence.ts
@@ -1,0 +1,50 @@
+/**
+ * Assembled-sentence preview for the Define-success modal (prototype
+ * #measurePreview).
+ *
+ * Implements the AUTHORED sentence shape — the direction phrase split around
+ * the metric ("Success means: increase Productivity by at least 20% within
+ * 6 months.") — NOT the prototype's runtime template, whose word order the
+ * spec flags as a bug ("increase by at least Productivity 20%...") and tells
+ * engineers not to copy.
+ *
+ * Prototype-faithful details: fallback tokens [outcome] / [number] /
+ * [timeframe] when a field is empty; the timeframe is lowercased; threshold
+ * and unit concatenate with no space ("20%").
+ */
+import type { SuccessDirection } from './successMeasureStore'
+
+export const DIRECTION_OPTIONS: ReadonlyArray<{
+  value: SuccessDirection
+  label: string
+}> = [
+  { value: 'increase_by_at_least', label: 'Increase by at least' },
+  { value: 'reach_at_least', label: 'Reach at least' },
+  { value: 'keep_below', label: 'Keep below' },
+]
+
+/** Prototype unit select options, in order (first is the default). */
+export const UNIT_OPTIONS: ReadonlyArray<string> = ['%', 'projects', 'weeks', '£']
+
+export interface MeasureSentenceFields {
+  metric: string
+  direction: SuccessDirection
+  threshold: string
+  unit: string
+  timeframe: string
+}
+
+export function buildMeasureSentence(fields: MeasureSentenceFields): string {
+  const metric = fields.metric.trim() || '[outcome]'
+  const amount = `${fields.threshold.trim() || '[number]'}${fields.unit}`
+  const timeframe = fields.timeframe.trim().toLowerCase() || '[timeframe]'
+
+  switch (fields.direction) {
+    case 'increase_by_at_least':
+      return `Success means: increase ${metric} by at least ${amount} ${timeframe}.`
+    case 'reach_at_least':
+      return `Success means: ${metric} reaches at least ${amount} ${timeframe}.`
+    case 'keep_below':
+      return `Success means: keep ${metric} below ${amount} ${timeframe}.`
+  }
+}

--- a/src/components/results/modals/scenarioKey.ts
+++ b/src/components/results/modals/scenarioKey.ts
@@ -1,0 +1,14 @@
+/**
+ * Scenario keying for the modal stores (Define success + Record the decision).
+ *
+ * Both stores persist per scenario in sessionStorage (same scope as the
+ * unpersisted scenario identity — see strengthenStore's persistence note).
+ * `currentScenarioId` can be null before the first scenario exists, so a
+ * stable fallback key keeps pre-scenario captures from colliding with real
+ * scenario ids (which are generated ids, never this literal).
+ */
+export const UNSCOPED_SCENARIO_KEY = '__unscoped__'
+
+export function resolveScenarioKey(scenarioId: string | null | undefined): string {
+  return scenarioId != null && scenarioId !== '' ? scenarioId : UNSCOPED_SCENARIO_KEY
+}

--- a/src/components/results/modals/successMeasureStore.ts
+++ b/src/components/results/modals/successMeasureStore.ts
@@ -1,0 +1,139 @@
+/**
+ * successMeasureStore — the structured success measure captured by the
+ * Define-success modal (prototype #successModal, build-ready v6).
+ *
+ * HONESTY CONTRACT: only the numeric `threshold` flows into the analysis
+ * request today, through the EXISTING canonical path (canvas
+ * store.setGoalThreshold → executeCanonicalRun → UI-SEM-058 raw/cap
+ * normalisation in useV2Run/httpV1Adapter). The richer fields — metric,
+ * direction, unit, timeframe, baseline — are DISPLAY/RECORD ONLY: nothing in
+ * the store, request adapters, or wire contract can represent them yet (a
+ * "keep churn below 4% within 6 months" measure is not expressible). The
+ * modal states this to the user; consumers of this store must not pretend
+ * otherwise.
+ *
+ * Persistence mirrors strengthenStore: zustand + manual, version-keyed
+ * sessionStorage (survives reloads, dies with the session — matching the
+ * unpersisted scenario identity's scope), keyed per scenario id.
+ */
+import { create } from 'zustand'
+
+import { resolveScenarioKey } from './scenarioKey'
+
+export type SuccessDirection =
+  | 'increase_by_at_least'
+  | 'reach_at_least'
+  | 'keep_below'
+
+export interface SuccessMeasure {
+  /** "What outcome should improve?" — display/record only. */
+  metric: string
+  /** Display/record only — NOT representable on the analysis wire today. */
+  direction: SuccessDirection
+  /** The ONE field that affects the analysis (via the canonical goal-threshold path). Raw user units. */
+  threshold: number
+  /** Display/record only. */
+  unit: string
+  /** Display/record only. */
+  timeframe: string
+  /** Optional baseline or evidence — display/record only. */
+  baseline: string | null
+  savedAt: number
+}
+
+export interface SuccessMeasureState {
+  isOpen: boolean
+  byScenario: Record<string, SuccessMeasure>
+  open: () => void
+  close: () => void
+  saveMeasure: (scenarioKey: string, measure: SuccessMeasure) => void
+  /** Test/reset seam — clears memory AND storage. */
+  _reset: () => void
+  /** Test seam — re-reads sessionStorage (simulates a reload). */
+  _rehydrateForTests: () => void
+}
+
+const STORAGE_KEY = 'defineSuccess.measure.v1'
+
+function loadPersisted(): Pick<SuccessMeasureState, 'byScenario'> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return { byScenario: {} }
+    const parsed = JSON.parse(raw)
+    if (parsed?.version !== 1) return { byScenario: {} }
+    return { byScenario: parsed.byScenario ?? {} }
+  } catch {
+    return { byScenario: {} }
+  }
+}
+
+function persist(byScenario: Record<string, SuccessMeasure>): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, byScenario }))
+  } catch {
+    // sessionStorage unavailable — the measure degrades to in-memory only.
+  }
+}
+
+export const useSuccessMeasureStore = create<SuccessMeasureState>((set, get) => ({
+  isOpen: false,
+  ...loadPersisted(),
+
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+
+  saveMeasure: (scenarioKey, measure) => {
+    const byScenario = { ...get().byScenario, [scenarioKey]: measure }
+    persist(byScenario)
+    set({ byScenario })
+  },
+
+  _reset: () => {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY)
+    } catch {
+      /* ignore */
+    }
+    set({ isOpen: false, byScenario: {} })
+  },
+
+  _rehydrateForTests: () => {
+    set({ ...loadPersisted() })
+  },
+}))
+
+/** The saved measure for a scenario key, or null. */
+export function selectSuccessMeasure(
+  state: Pick<SuccessMeasureState, 'byScenario'>,
+  scenarioKey: string,
+): SuccessMeasure | null {
+  return state.byScenario[scenarioKey] ?? null
+}
+
+/**
+ * Open the Define-success modal from any surface without prop drilling
+ * (rec-card primary action, goal-lens empty state, brief chip...).
+ * The modal itself must be mounted once — see DefineSuccessModal.
+ */
+export function openDefineSuccess(): void {
+  useSuccessMeasureStore.getState().open()
+}
+
+export function closeDefineSuccess(): void {
+  useSuccessMeasureStore.getState().close()
+}
+
+/**
+ * Reactive saved-measure lookup for the CURRENT scenario — for the surfaces
+ * that render the measure summary (goal brief chip, goal-lens caption).
+ * Deliberately takes the scenario id as an argument so this store stays
+ * decoupled from the canvas store; callers subscribe to
+ * `useCanvasStore(s => s.currentScenarioId)` themselves.
+ */
+export function useSuccessMeasureForScenario(
+  scenarioId: string | null | undefined,
+): SuccessMeasure | null {
+  return useSuccessMeasureStore(
+    (s) => s.byScenario[resolveScenarioKey(scenarioId)] ?? null,
+  )
+}


### PR DESCRIPTION
Self-contained modal pair; wiring lands in the follow-up round-2 lane.

- **Define success** (brief §7): metric/direction/threshold/unit/timeframe/baseline, live assembled-sentence preview, §7.3 validation (inline errors, never silent-close), saves the FULL measure (scenario-keyed sessionStorage) then commits the numeric threshold through the EXISTING canonical setter + single canonical rerun; honest meta line 'Only the target number affects the analysis today.'
- **Record the decision** (brief §9): chosen option (real analysed options, stable ordinals, all-or-nothing), confidence 0-100, rationale, assumption, revisit trigger; honest 'Prototype only. Saved on this device for this scenario.'; zero-option fail-closed.
- Shared ModalShell: scrim, focus trap, Escape/backdrop close, focus restore.
- Public API: openDefineSuccess()/openDecisionRecord() + scenario-keyed selectors for later surfaces.
- Contract gap flagged for ROADMAP: wire is threshold-only — direction/timeframe don't reach the analysis.

13 new files, 59 tests, typecheck + lint clean, no foreign files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)