### PR TITLE
feat(results): parity Round-2a — modals wired into strengthen + overview

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -112,6 +112,7 @@ import { DEFAULT_EDGE_DATA } from '../domain/edges'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
 import { useAnalysisStateSource } from '../hooks/useAnalysisStateSource'
 import { AskOlumiDrawer } from '../../components/results/coaching/AskOlumiDrawer'
+import { DefineSuccessModal, DecisionRecordModal } from '../../components/results/modals'
 
 /**
  * Map API critique format (CritiqueItemV1) to ValidationPanel format
@@ -1523,6 +1524,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
           graph node sparkles included — surface visibly instead of
           auto-sending into a conversation the user cannot see. */}
       <AskOlumiDrawer />
+      {/* Round-2 wiring: the parity modals mount once at the same root so
+          openDefineSuccess()/openDecisionRecord() work from any surface. */}
+      <DefineSuccessModal />
+      <DecisionRecordModal />
       {effectiveIsOpen && (
         <div
           aria-hidden="true"

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -24,6 +24,7 @@ import { useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 
 import { useCanvasStore } from '../../../canvas/store'
+import { useSuccessMeasureForScenario } from '../modals'
 import { useGuidanceStore, type GuidanceItem } from '../../../canvas/stores/guidanceStore'
 import { isDecisionOverviewEnabled } from '../../../flags'
 import { typography } from '../../../styles/typography'
@@ -147,6 +148,7 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   const analysisReady = useCanvasStore((s) => s.ceeAnalysisReady)
   // All selectors below return primitives (Zustand inline-selector rule).
   const goalThreshold = useCanvasStore((s) => s.goalThreshold)
+  const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
   const optionCount = useCanvasStore((s) => s.nodes.filter((n) => n.type === 'option').length)
   const constraintCount = useCanvasStore((s) => s.goalConstraints?.length ?? 0)
   const briefPresent = useCanvasStore((s) => Boolean(s.currentBriefText?.trim()))
@@ -261,10 +263,16 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   // count. Options: canvas option count. No diversity/quality claims — the
   // producer option-similarity signal does not exist yet.
   const { unit, symbol } = mapOutcomeUnit(goalUnitRaw)
+  // Round-2 wiring: prefer the FULL saved success measure (Define-success
+  // modal, scenario-keyed) — metric + direction + threshold+unit + timeframe.
+  // Falls back to the bare committed threshold, then to 'missing'.
+  const savedMeasure = useSuccessMeasureForScenario(currentScenarioId)
   const goalNote =
-    goalThreshold == null
-      ? OVERVIEW_COPY.goalNoteMissing
-      : `Success target ≥ ${formatTargetValue(goalThreshold, unit, symbol)}`
+    savedMeasure != null
+      ? `${savedMeasure.metric}: ${savedMeasure.direction === 'decrease_below' ? '≤' : '≥'} ${savedMeasure.threshold}${savedMeasure.unit === 'none' ? '' : savedMeasure.unit}, ${savedMeasure.timeframe}`
+      : goalThreshold == null
+        ? OVERVIEW_COPY.goalNoteMissing
+        : `Success target ≥ ${formatTargetValue(goalThreshold, unit, symbol)}`
   const contextNote = briefPresent ? OVERVIEW_COPY.capturedInBrief : OVERVIEW_COPY.notCaptured
   const constraintsNote =
     constraintCount > 0

--- a/src/components/results/strengthen/StrengthenContainer.tsx
+++ b/src/components/results/strengthen/StrengthenContainer.tsx
@@ -41,6 +41,7 @@ import {
   type RecRecord,
 } from '../../../canvas/stores/strengthenStore'
 import { focusModelTarget } from '../../../canvas/utils/focusHelpers'
+import { openDefineSuccess, openDecisionRecord, useDecisionRecordForScenario } from '../modals'
 import { openAskOlumi } from '../coaching/askOlumiStore'
 import { buildRecommendations } from './buildRecommendations'
 import { STRENGTHEN_COPY as COPY } from './strengthenCopy'
@@ -169,6 +170,21 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
     if (freshnessDirty) useStrengthenStore.getState().markAllStale()
   }, [freshnessDirty])
 
+  // A captured decision record credits the commit rec — same direct-credit
+  // pattern as the success-measure threshold effect above.
+  const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
+  const decisionRecord = useDecisionRecordForScenario(currentScenarioId)
+  useEffect(() => {
+    if (!decisionRecord) return
+    const record = useStrengthenStore.getState().records['strengthen:commit']
+    if (
+      record &&
+      (record.status === 'recommended' || record.status === 'in_progress' || record.status === 'reopened')
+    ) {
+      useStrengthenStore.getState().markAddressed('strengthen:commit', 'decision recorded')
+    }
+  }, [decisionRecord])
+
   // ── §8.8 routing (callbacks read at CLICK time; degrade, never dead-end) ──
   const dispatchAiDialogue = (record: RecRecord) => {
     const rec = record.snapshot
@@ -194,7 +210,11 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
   const onPrimaryAction = (record: RecRecord) => {
     const rec = record.snapshot
     let ok = false
-    if (rec.action.kind === 'ai-dialogue') {
+    if (rec.action.kind === 'open-modal') {
+      if (rec.action.modal === 'define-success') openDefineSuccess()
+      else if (rec.action.modal === 'decision-record') openDecisionRecord()
+      ok = rec.action.modal != null
+    } else if (rec.action.kind === 'ai-dialogue') {
       ok = dispatchAiDialogue(record)
     } else if (rec.action.kind === 'canvas-focus' && rec.targetId) {
       ok = focusModelTarget(rec.targetId)

--- a/src/components/results/strengthen/__tests__/StrengthenContainer.spec.tsx
+++ b/src/components/results/strengthen/__tests__/StrengthenContainer.spec.tsx
@@ -11,12 +11,13 @@
  * - the producer stage signal floats matching recs to the top (UI-SEM-076).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { StrengthenContainer, adaptivePriorityFromStage } from '../StrengthenContainer'
 import { useCanvasStore } from '../../../../canvas/store'
 import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
 import { selectActive, useStrengthenStore } from '../../../../canvas/stores/strengthenStore'
 import { useAskOlumiStore } from '../../coaching/askOlumiStore'
+import { useSuccessMeasureStore, useDecisionRecordStore } from '../../modals'
 import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
 
 const makeData = (over: {
@@ -137,17 +138,55 @@ describe('StrengthenContainer — work-through prefills the Ask-Olumi drawer', (
     )
   })
 
-  it('the primary action still dispatches and marks in progress (two distinct routes)', () => {
+  it('the primary action opens the Define-success MODAL and marks in progress (Round-2 wiring; Olumi stays on the sparkle)', () => {
     const dispatch = vi.fn()
     useGuidanceStore.setState({ _dispatchAction: dispatch } as never)
     render(<StrengthenContainer data={makeData({ goalThreshold: null })} />)
     fireEvent.click(screen.getByRole('button', { name: 'Define success' }))
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ action_type: 'discuss', source: 'strengthen_panel' }),
-    )
+    // The primary DOES the thing: structured modal, not a dialogue dispatch.
+    expect(useSuccessMeasureStore.getState().isOpen).toBe(true)
+    expect(dispatch).not.toHaveBeenCalled()
     expect(useStrengthenStore.getState().records['strengthen:success-measure'].status).toBe(
       'in_progress',
     )
+  })
+})
+
+describe('StrengthenContainer — decision-record wiring (Round 2)', () => {
+  it('a captured decision record credits the commit rec directly', () => {
+    useCanvasStore.setState({ currentScenarioId: 'scn-1' } as never)
+    render(<StrengthenContainer data={makeData({ goalThreshold: 5 })} />)
+    // Seed a commit rec as recommended
+    useStrengthenStore.getState().reconcile(
+      [
+        {
+          id: 'strengthen:commit',
+          helpType: 'commit',
+          title: 'Record the decision and what would trigger a rethink',
+          signal: 's',
+          whyNow: 'w',
+          tryThis: 't',
+          sourceLine: 'src',
+          action: { kind: 'open-modal', modal: 'decision-record', label: 'Create a decision record' },
+          targetId: null,
+          priority: 10,
+        },
+      ] as never,
+      'h-test',
+    )
+    expect(useStrengthenStore.getState().records['strengthen:commit'].status).toBe('recommended')
+    act(() => {
+      useDecisionRecordStore.getState().saveRecord('scn-1', {
+        optionId: 'opt_a',
+        optionLabel: 'Option A',
+        confidence: 70,
+        rationale: 'r',
+        assumption: 'a',
+        revisitTrigger: 'rt',
+        analysedGraphHash: null,
+      } as never)
+    })
+    expect(useStrengthenStore.getState().records['strengthen:commit'].status).toBe('addressed')
   })
 })
 

--- a/src/components/results/strengthen/buildRecommendations.ts
+++ b/src/components/results/strengthen/buildRecommendations.ts
@@ -78,10 +78,12 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
       tryThis: 'Pick the number that would make this decision a win, and the date it matters by.',
       sourceLine: 'Source: your goal has no success threshold (checked directly).',
       action: {
-        kind: 'ai-dialogue',
+        // Round-2 wiring: the primary DOES the thing — the structured
+        // Define-success modal (threshold commits through the canonical
+        // rerun path). The Olumi route stays available on the ✦ affordance.
+        kind: 'open-modal',
+        modal: 'define-success',
         label: 'Define success',
-        actionType: 'discuss',
-        parameters: { topic: 'define_success' },
         prompt: 'Help me define what success looks like for this decision.',
       },
       targetId: null,
@@ -283,10 +285,12 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
       tryThis: 'Note the chosen option, the key assumptions, and the one change that would reopen this.',
       sourceLine: 'Source: robustness analysis (result stable).',
       action: {
-        kind: 'ai-dialogue',
+        // Round-2 wiring: opens the Record-the-decision modal (honest
+        // local-only capture) instead of the prototype's generic-dialogue
+        // wiring bug. Olumi route stays on the ✦ affordance.
+        kind: 'open-modal',
+        modal: 'decision-record',
         label: 'Create a decision record',
-        actionType: 'discuss',
-        parameters: { topic: 'decision_record' },
         prompt: 'Help me record this decision, its key assumptions, and what would trigger a rethink.',
       },
       targetId: null,

--- a/src/components/results/strengthen/strengthenTypes.ts
+++ b/src/components/results/strengthen/strengthenTypes.ts
@@ -14,7 +14,7 @@ export type HelpType = 'clarify' | 'broaden' | 'challenge' | 'evaluate' | 'commi
 export type RecStatus = 'recommended' | 'in_progress' | 'addressed' | 'dismissed' | 'reopened'
 
 /** §8.8 primary action routes. */
-export type RecActionKind = 'inline-edit' | 'ai-dialogue' | 'canvas-focus' | 'rerun'
+export type RecActionKind = 'inline-edit' | 'ai-dialogue' | 'canvas-focus' | 'rerun' | 'open-modal'
 
 export interface RecAction {
   kind: RecActionKind
@@ -24,6 +24,8 @@ export interface RecAction {
    * heuristic — chip_metadata survives only on conversation-typed turns). */
   actionType?: string
   parameters?: Record<string, unknown>
+  /** open-modal routes: which parity modal the primary action opens. */
+  modal?: 'define-success' | 'decision-record'
   /** The prompt sent for ai-dialogue routes (also the _sendMessage degrade).
    * Named 'prompt', not 'message': the V14.3 guard forbids `.message`
    * property access in results components (critique-render protection). */


### PR DESCRIPTION
Wires PR #297's modal pair into the live surfaces: dock-root mounts, strengthen 'open-modal' primaries (Define success / Create a decision record), capture-credits, Goal chip full-measure note.

Gates: typecheck clean · 254 changed-set tests · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)