### PR TITLE
feat(results): parity Round-2b — hero Define-success wiring

### DIFF
--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -33,6 +33,7 @@ import { StrengthenContainer } from './strengthen/StrengthenContainer'
 import { InferenceWarningStrip } from './InferenceWarningStrip'
 import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
 import { AnalysisHeroContainer } from './analysis-hero'
+import { openDefineSuccess } from './modals'
 import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled, isAnalysisHeroPanelEnabled, isStrengthenPanelEnabled } from '@/flags'
 
 export interface StrengthCorrectionDisplay {
@@ -270,6 +271,7 @@ export const ResultsBody = memo(function ResultsBody({
       {isAnalysisHeroPanelEnabled() && (
         <SectionErrorBoundary section="Analysis hero">
           <AnalysisHeroContainer
+            onDefineSuccess={openDefineSuccess}
             data={resultsSectionData}
             isStale={isStale}
             onApplyTarget={onApplyThreshold}

--- a/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
@@ -29,6 +29,7 @@ vi.mock('../../../canvas/utils/focusHelpers', () => ({
   focusNodeById: vi.fn(),
   focusByTarget: vi.fn(),
   focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
 }))
 
 vi.mock('@/flags', async () => {


### PR DESCRIPTION
Final cross-surface wire: goal-lens inline 'Define success' → the structured modal. Plus Lane H's flagged mock gap. Gates: typecheck clean, 185 changed-set tests, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)