### PR TITLE
refactor(results): unify driver-display policy in one shared selector (Codex R3 follow-up)

### DIFF
--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -11,6 +11,7 @@
 import { useMemo } from 'react'
 import { useCanvasStore } from '../store'
 import type { NodeType } from '../domain/nodes'
+import { selectDriverDisplayModel, compareByDisplayModel } from '../../components/results/driverDisplayModel'
 
 interface NodeDisplayMetadata {
   /** Factor sensitivity rank (1-3 for top factors, null otherwise) */
@@ -108,43 +109,28 @@ export function useNodeDisplayMetadata(
         ? report.factor_sensitivity
         : report.enrichment?.sensitivity_analysis?.factors) || []
 
-      const maxAbsElasticity = Math.max(
-        ...factorSensitivity.map((f: any) =>
-          Math.abs(f.elasticity ?? f.sensitivity_score ?? f.importance_score ?? 0),
-        ),
-        0,
-      )
-      const influenceCoverageComplete =
-        factorSensitivity.length > 0 &&
-        factorSensitivity.every(
-          (f: any) => typeof (f.influence_score ?? f.influenceScore) === 'number',
-        )
-      const ranked = [...factorSensitivity]
-        .map((f: any) => {
-          const elasticity = Math.abs(f.elasticity ?? f.sensitivity_score ?? f.importance_score ?? 0)
-          const producerScore = f.influence_score ?? f.influenceScore
-          const influence =
-            influenceCoverageComplete && typeof producerScore === 'number'
-              ? producerScore
-              : maxAbsElasticity > 0
-                ? elasticity / maxAbsElasticity
-                : 0
-          return {
-            id: f.factor_id || f.factorId || f.node_id || f.nodeId,
-            elasticity,
-            influence,
-          }
-        })
-        .sort((a, b) => {
-          // Primary: displayed influence descending
-          if (b.influence !== a.influence) return b.influence - a.influence
-          // Tie-break: elasticity, then node_id alphabetically
-          if (b.elasticity !== a.elasticity) return b.elasticity - a.elasticity
-          return a.id.localeCompare(b.id)
-        })
+      // Codex R3-B1: display value + rank come from the ONE shared policy
+      // (driverDisplayModel), so the badge can never rank or label a factor
+      // on a different basis than the results Drivers panel. Producer
+      // influence_score only when EVERY factor has one; else per-set
+      // normalised |elasticity| for all.
+      const displayEntries: Array<{ key: string; influenceScore: number | undefined; rawElasticity: number }> =
+        (factorSensitivity as any[]).map((f: any) => ({
+          key: (f.factor_id || f.factorId || f.node_id || f.nodeId) as string,
+          influenceScore: (f.influence_score ?? f.influenceScore) as number | undefined,
+          rawElasticity: (f.elasticity ?? f.sensitivity_score ?? f.importance_score ?? 0) as number,
+        }))
+      const displayModel = selectDriverDisplayModel(displayEntries)
+      const ranked = displayEntries
+        .map((e) => ({
+          key: e.key,
+          elasticity: Math.abs(e.rawElasticity),
+          value: displayModel.get(e.key)?.value ?? 0,
+        }))
+        .sort(compareByDisplayModel)
 
       // Find this node's rank (1-indexed)
-      const rank = ranked.findIndex(f => f.id === nodeId) + 1
+      const rank = ranked.findIndex(f => f.key === nodeId) + 1
       sensitivityRank = rank > 0 && rank <= 3 ? rank : null
 
       // VoI rank: top-3 factors by value_of_information
@@ -173,12 +159,13 @@ export function useNodeDisplayMetadata(
           valueOfInformation = rawVoi
         }
 
-        // Influence readout: the ranked entry already resolved the displayed
-        // value under the complete-metric-set policy (Codex R3-B1) — read it
-        // back so the "I: NN%" beside the badge is the number the rank used.
-        const rankedEntry = ranked.find(r => r.id === nodeId)
-        if (rankedEntry && Number.isFinite(rankedEntry.influence)) {
-          influence = rankedEntry.influence
+        // Influence readout: the shared display model already resolved the
+        // displayed value under the complete-metric-set policy (Codex R3-B1)
+        // — read it back so the "I: NN%" beside the badge is the number the
+        // rank used, on the same basis as the panel.
+        const modelEntry = displayModel.get(nodeId)
+        if (modelEntry && Number.isFinite(modelEntry.value)) {
+          influence = modelEntry.value
         }
 
         // Confidence: Direct extraction (already 0-1)

--- a/src/components/results/__tests__/driverDisplayModel.spec.ts
+++ b/src/components/results/__tests__/driverDisplayModel.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * driverDisplayModel — the shared complete-metric-set policy (Codex R3-B1).
+ *
+ * This pins the EXACT partial-coverage scenario from the review that recreated
+ * the "#1 with a lower displayed influence" contradiction, and proves the one
+ * policy resolves it identically regardless of which surface (panel or graph
+ * badge) maps its data into it — because both now consume THIS function.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  selectDriverDisplayModel,
+  compareByDisplayModel,
+  computeNormalisedInfluences,
+} from '../driverDisplayModel'
+
+describe('selectDriverDisplayModel — the exact Codex R3-B1 partial-coverage scenario', () => {
+  // Investor Confidence: elasticity 0.1, influence 90%.
+  // Revenue Potential:   elasticity 0.2, influence ABSENT.
+  // Before the fix: panel ranked Revenue #1 at normalised 100% while the graph
+  // showed Revenue's raw 0.2 as "20%" and Investor's raw 0.9 as "90%" — the
+  // same factor displayed two different numbers and the crown looked wrong.
+  const factors = [
+    { key: 'investor_confidence', influenceScore: 0.9, rawElasticity: 0.1 },
+    { key: 'revenue_potential', rawElasticity: 0.2 }, // influenceScore absent
+  ]
+
+  it('partial coverage → EVERY factor on the normalised-elasticity basis, provenance marked', () => {
+    const model = selectDriverDisplayModel(factors)
+    // max |elasticity| = 0.2 → Revenue normalises to 1.0, Investor to 0.5.
+    expect(model.get('revenue_potential')).toEqual({ value: 1.0, provenance: 'normalised_elasticity' })
+    expect(model.get('investor_confidence')).toEqual({ value: 0.5, provenance: 'normalised_elasticity' })
+    // The producer 0.9 is NOT displayed for Investor — that was the contradiction.
+    expect(model.get('investor_confidence')!.value).not.toBe(0.9)
+  })
+
+  it('rank via the shared comparator crowns Revenue #1 on the same single basis', () => {
+    const model = selectDriverDisplayModel(factors)
+    const ranked = factors
+      .map((f) => ({
+        key: f.key,
+        elasticity: Math.abs(f.rawElasticity),
+        value: model.get(f.key)!.value,
+      }))
+      .sort(compareByDisplayModel)
+    expect(ranked.map((r) => r.key)).toEqual(['revenue_potential', 'investor_confidence'])
+  })
+
+  it('complete coverage → producer influence for all, provenance marked', () => {
+    const model = selectDriverDisplayModel([
+      { key: 'a', influenceScore: 0.9, rawElasticity: 0.1 },
+      { key: 'b', influenceScore: 0.2, rawElasticity: 0.2 },
+    ])
+    expect(model.get('a')).toEqual({ value: 0.9, provenance: 'influence_score' })
+    expect(model.get('b')).toEqual({ value: 0.2, provenance: 'influence_score' })
+  })
+
+  it('a non-finite influence_score does NOT count as coverage (fails closed to normalised)', () => {
+    const model = selectDriverDisplayModel([
+      { key: 'a', influenceScore: Number.NaN, rawElasticity: 0.2 },
+      { key: 'b', influenceScore: 0.5, rawElasticity: 0.1 },
+    ])
+    expect(model.get('a')!.provenance).toBe('normalised_elasticity')
+    expect(model.get('b')!.provenance).toBe('normalised_elasticity')
+  })
+
+  it('degenerate near-zero elasticities map to 0 (direction-only), never fabricated bars', () => {
+    const model = selectDriverDisplayModel([
+      { key: 'a', rawElasticity: 0.0001 },
+      { key: 'b', rawElasticity: 0.0002 },
+    ])
+    expect(model.get('a')!.value).toBe(0)
+    expect(model.get('b')!.value).toBe(0)
+  })
+})
+
+describe('compareByDisplayModel', () => {
+  it('value desc, then |elasticity|, then key', () => {
+    const rows = [
+      { key: 'z', value: 0.5, elasticity: 0.5 },
+      { key: 'a', value: 0.5, elasticity: 0.5 },
+      { key: 'b', value: 0.9, elasticity: 0.1 },
+      { key: 'c', value: 0.5, elasticity: 0.9 },
+    ]
+    expect([...rows].sort(compareByDisplayModel).map((r) => r.key)).toEqual(['b', 'c', 'a', 'z'])
+  })
+})
+
+describe('computeNormalisedInfluences (re-homed, behaviour unchanged)', () => {
+  it('normalises to the max magnitude', () => {
+    const m = computeNormalisedInfluences([
+      { key: 'a', rawElasticity: 0.8 },
+      { key: 'b', rawElasticity: 8.0 },
+    ])
+    expect(m.get('a')).toBeCloseTo(0.1)
+    expect(m.get('b')).toBeCloseTo(1.0)
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -14,7 +14,7 @@ import {
   getRawElasticity,
   computeNormalisedInfluences,
   computeFactorRanks,
-  resolveDisplayInfluences,
+  selectDriverDisplayModel,
   normaliseDirection,
   getFactorDirection,
   getSemanticLabel,
@@ -262,16 +262,14 @@ describe('normaliseLabel', () => {
 // 4. Rank Computation Tests
 // =============================================================================
 
-describe('resolveDisplayInfluences (Codex R3-B1: complete-metric-set policy)', () => {
+describe('selectDriverDisplayModel (Codex R3-B1: complete-metric-set policy, shared by panel + graph)', () => {
   it('adopts producer influence only when EVERY factor carries one', () => {
-    const entries = [
-      { key: 'a', influenceScore: 0.9 },
-      { key: 'b', influenceScore: 0.2 },
-    ]
-    const normalised = new Map([['a', 0.1], ['b', 1.0]])
-    const result = resolveDisplayInfluences(entries, normalised)
-    expect(result.get('a')).toBe(0.9)
-    expect(result.get('b')).toBe(0.2)
+    const model = selectDriverDisplayModel([
+      { key: 'a', influenceScore: 0.9, rawElasticity: 0.1 },
+      { key: 'b', influenceScore: 0.2, rawElasticity: 2.0 },
+    ])
+    expect(model.get('a')).toEqual({ value: 0.9, provenance: 'influence_score' })
+    expect(model.get('b')).toEqual({ value: 0.2, provenance: 'influence_score' })
   })
 
   it('partial coverage: EVERY factor falls back to normalised elasticity — a producer 0.9 must not outrank the elasticity-dominant factor it cannot be compared with', () => {
@@ -279,21 +277,19 @@ describe('resolveDisplayInfluences (Codex R3-B1: complete-metric-set policy)', (
     // but dominant elasticity, C has influence_score 0.2. Mixing bases would
     // rank A #1 on a producer scale B never entered. Under the policy all
     // three resolve on the normalised-elasticity basis: B (1.0) > A > C.
-    const entries = [
-      { key: 'a', influenceScore: 0.9 },
-      { key: 'b' },
-      { key: 'c', influenceScore: 0.2 },
-    ]
-    const normalised = new Map([['a', 0.4], ['b', 1.0], ['c', 0.1]])
-    const result = resolveDisplayInfluences(entries, normalised)
-    expect(result.get('a')).toBe(0.4)
-    expect(result.get('b')).toBe(1.0)
-    expect(result.get('c')).toBe(0.1)
+    const model = selectDriverDisplayModel([
+      { key: 'a', influenceScore: 0.9, rawElasticity: 0.4 },
+      { key: 'b', rawElasticity: 1.0 },
+      { key: 'c', influenceScore: 0.2, rawElasticity: 0.1 },
+    ])
+    expect(model.get('a')).toEqual({ value: 0.4, provenance: 'normalised_elasticity' })
+    expect(model.get('b')).toEqual({ value: 1.0, provenance: 'normalised_elasticity' })
+    expect(model.get('c')).toEqual({ value: 0.1, provenance: 'normalised_elasticity' })
     // And the rank the surfaces crown by follows the same single basis:
     const rankMap = computeFactorRanks([
-      { key: 'a', rawElasticity: 0.4, displayValue: result.get('a') },
-      { key: 'b', rawElasticity: 1.0, displayValue: result.get('b') },
-      { key: 'c', rawElasticity: 0.1, displayValue: result.get('c') },
+      { key: 'a', rawElasticity: 0.4, displayValue: model.get('a')!.value },
+      { key: 'b', rawElasticity: 1.0, displayValue: model.get('b')!.value },
+      { key: 'c', rawElasticity: 0.1, displayValue: model.get('c')!.value },
     ])
     expect(rankMap.get('b')).toBe(1)
     expect(rankMap.get('a')).toBe(2)
@@ -301,11 +297,12 @@ describe('resolveDisplayInfluences (Codex R3-B1: complete-metric-set policy)', (
   })
 
   it('no producer coverage at all: normalised basis for everyone', () => {
-    const entries = [{ key: 'a' }, { key: 'b' }]
-    const normalised = new Map([['a', 1.0], ['b', 0.5]])
-    const result = resolveDisplayInfluences(entries, normalised)
-    expect(result.get('a')).toBe(1.0)
-    expect(result.get('b')).toBe(0.5)
+    const model = selectDriverDisplayModel([
+      { key: 'a', rawElasticity: 2.0 },
+      { key: 'b', rawElasticity: 1.0 },
+    ])
+    expect(model.get('a')).toEqual({ value: 1.0, provenance: 'normalised_elasticity' })
+    expect(model.get('b')).toEqual({ value: 0.5, provenance: 'normalised_elasticity' })
   })
 })
 

--- a/src/components/results/driverDisplayModel.ts
+++ b/src/components/results/driverDisplayModel.ts
@@ -1,0 +1,106 @@
+/**
+ * driverDisplayModel — the SINGLE source of truth for the "which number does a
+ * driver display, and how is it ranked" policy, shared by every surface that
+ * shows factor influence: the results Drivers panel (useResultsSectionData),
+ * the analysis hero (via the panel model), and the canvas graph badge
+ * (useNodeDisplayMetadata).
+ *
+ * Codex R2-B2 / R3-B1 doctrine: the surface says "Influence", so the order,
+ * the rank-1 crown, and the bar must all follow the SAME number — and that
+ * number must be on ONE comparable basis across the whole factor set. Producer
+ * `influence_score` is adopted only when EVERY ranked factor carries a finite
+ * one; under partial coverage every factor falls back to per-set normalised
+ * |elasticity|. Mixing the two (a producer 0.9 ranked against a fallback 0.2)
+ * is exactly the "#1 with a lower displayed influence" contradiction the
+ * review caught — so the policy lives here, once, and both hooks import it
+ * rather than keeping their own copy that can drift.
+ *
+ * `provenance` is returned so a surface can make the basis explicit (e.g. a
+ * debug readout or a future "producer / derived" marker) without re-deriving
+ * the decision.
+ */
+
+export type DriverDisplayProvenance = 'influence_score' | 'normalised_elasticity'
+
+export interface DriverDisplayEntry {
+  /** The 0-1 value the surface displays AND ranks by. */
+  value: number
+  /** Which basis produced `value` — explicit so no consumer re-decides it. */
+  provenance: DriverDisplayProvenance
+}
+
+/**
+ * Normalise raw elasticities to 0-1 relative to the largest magnitude in the
+ * set (top = 1.0, others proportional). Degenerate sets (max |elasticity| <
+ * 0.001) map every factor to 0 so a direction-only display is triggered
+ * instead of misleading ~100% bars. Kept as a named export because several
+ * surfaces consume the normalised value directly for semantic-label thresholds.
+ */
+export function computeNormalisedInfluences(
+  factors: Array<{ key: string; rawElasticity: number }>,
+): Map<string, number> {
+  const result = new Map<string, number>()
+
+  if (factors.length === 0) {
+    return result
+  }
+
+  const absoluteValues = factors.map((f) => Math.abs(f.rawElasticity))
+  const actualMax = Math.max(...absoluteValues)
+
+  // No meaningful magnitude data → all zero (direction-only display upstream).
+  if (actualMax < 0.001) {
+    factors.forEach((f) => result.set(f.key, 0))
+    return result
+  }
+
+  factors.forEach((f) => {
+    const normalised = Math.min(1, Math.abs(f.rawElasticity) / actualMax)
+    result.set(f.key, normalised)
+  })
+
+  return result
+}
+
+/**
+ * Resolve the display value + provenance for every factor under the
+ * complete-metric-set policy. This is THE policy — every driver surface must
+ * render and rank by `value` from this map, never `influenceScore ??
+ * normalisedInfluence` (which mixes bases under partial producer coverage).
+ */
+export function selectDriverDisplayModel(
+  factors: ReadonlyArray<{ key: string; influenceScore?: number | null; rawElasticity: number }>,
+): Map<string, DriverDisplayEntry> {
+  const coverageComplete =
+    factors.length > 0 &&
+    factors.every((f) => typeof f.influenceScore === 'number' && Number.isFinite(f.influenceScore))
+
+  const normalisedMap = computeNormalisedInfluences(
+    factors.map((f) => ({ key: f.key, rawElasticity: f.rawElasticity })),
+  )
+
+  const out = new Map<string, DriverDisplayEntry>()
+  for (const f of factors) {
+    if (coverageComplete && typeof f.influenceScore === 'number') {
+      out.set(f.key, { value: f.influenceScore, provenance: 'influence_score' })
+    } else {
+      out.set(f.key, { value: normalisedMap.get(f.key) ?? 0, provenance: 'normalised_elasticity' })
+    }
+  }
+  return out
+}
+
+/**
+ * Rank comparator on a resolved display model: value descending, then
+ * |elasticity| as the tie-break, then key alphabetically for determinism.
+ * The graph badge ranks with this so its order matches the panel's, both keyed
+ * off the shared `value`.
+ */
+export function compareByDisplayModel(
+  a: { value: number; elasticity: number; key: string },
+  b: { value: number; elasticity: number; key: string },
+): number {
+  if (b.value !== a.value) return b.value - a.value
+  if (b.elasticity !== a.elasticity) return b.elasticity - a.elasticity
+  return a.key.localeCompare(b.key)
+}

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -57,6 +57,7 @@ import { humaniseCritique } from './utils/humaniseCritique'
 import { selectGoalProbability, type GoalProbabilityInput } from './utils/selectGoalProbability'
 import { deriveStabilityLevel } from '../../lib/stability'
 import { deriveResultCompleteness, type ResultCompleteness } from './useResultCompleteness'
+import { computeNormalisedInfluences, selectDriverDisplayModel } from './driverDisplayModel'
 
 // =============================================================================
 // Winner Selection Helper
@@ -463,67 +464,11 @@ export function buildWorthInvestigatingIdSet(voiSuggestions: unknown): Set<strin
  * When NO real elasticity data (all ~0): returns all 0 - UI uses hasMagnitudeData
  * flag to show direction-only view instead.
  */
-function computeNormalisedInfluences(
-  factors: Array<{ key: string; rawElasticity: number }>
-): Map<string, number> {
-  const result = new Map<string, number>()
-
-  if (factors.length === 0) {
-    return result
-  }
-
-  // Extract absolute values
-  const absoluteValues = factors.map(f => Math.abs(f.rawElasticity))
-  const actualMax = Math.max(...absoluteValues)
-
-  // If no meaningful elasticity data, set all to 0
-  // The hasMagnitudeData flag will trigger direction-only display
-  if (actualMax < 0.001) {
-    factors.forEach(f => result.set(f.key, 0))
-    return result
-  }
-
-  // Normalise each factor relative to the max (top = 100%, others proportional)
-  factors.forEach(f => {
-    const normalised = Math.min(1, Math.abs(f.rawElasticity) / actualMax)
-    result.set(f.key, normalised)
-  })
-
-  return result
-}
 
 // =============================================================================
 // Factor Rank Computation (CRITICAL: Single-Pass with Map)
 // =============================================================================
 
-/**
- * Codex R3-B1 — complete-metric-set policy, in one pure place.
- *
- * Resolves the single influence value every surface displays AND ranks by:
- * producer influenceScore is adopted only when EVERY factor carries one
- * (one comparable basis across the whole set); under partial coverage every
- * factor resolves to its elasticity-normalised influence instead. A per-factor
- * `influenceScore ?? normalised` fallback is forbidden — it ranks producer
- * scores against fallback values that are not on the same scale.
- * Mirrored by useNodeDisplayMetadata for the graph badge.
- */
-function resolveDisplayInfluences(
-  entries: Array<{ key: string; influenceScore?: number }>,
-  normalisedMap: Map<string, number>,
-): Map<string, number> {
-  const coverageComplete =
-    entries.length > 0 && entries.every((e) => typeof e.influenceScore === 'number')
-  const out = new Map<string, number>()
-  for (const e of entries) {
-    out.set(
-      e.key,
-      coverageComplete && typeof e.influenceScore === 'number'
-        ? e.influenceScore
-        : normalisedMap.get(e.key) ?? 0,
-    )
-  }
-  return out
-}
 
 /**
  * Compute ranks for all factors based on absolute elasticity.
@@ -1831,11 +1776,13 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     // producer scores and elasticity-normalised fallbacks, which are not
     // comparable. Under partial coverage every factor displays and ranks by
     // normalisedInfluence instead, so the whole surface shares one basis.
-    const displayInfluenceMap = resolveDisplayInfluences(factorsWithKeys, normalisedMap)
+    // Codex R3-B1: display value + provenance from the ONE shared policy
+    // (driverDisplayModel) — the same function the graph badge consumes.
+    const displayModel = selectDriverDisplayModel(factorsWithKeys)
     const rankMap = computeFactorRanks(
       factorsWithKeys.map((f) => ({
         ...f,
-        displayValue: displayInfluenceMap.get(f.key) ?? 0,
+        displayValue: displayModel.get(f.key)?.value ?? 0,
       })),
     )
 
@@ -1990,7 +1937,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           // ISL influence_score (0-1) - use directly for Influence column
           influenceScore: f.raw.influenceScore,
           // Codex R3-B1: single display basis (see DriverItem.displayInfluence)
-          displayInfluence: displayInfluenceMap.get(f.key) ?? 0,
+          displayInfluence: displayModel.get(f.key)?.value ?? 0,
           // Producer influence_rank passthrough (roadmap 1.7, provisional_doctrine_v0)
           influenceRank: f.raw.influenceRank,
           // ISL zero_reason - explains why sensitivity is zero
@@ -2994,7 +2941,7 @@ export {
   getRawElasticity,
   computeNormalisedInfluences,
   computeFactorRanks,
-  resolveDisplayInfluences,
+  selectDriverDisplayModel,
   normalizeOutcomeValues,
   normaliseDirection,
   getFactorDirection,


### PR DESCRIPTION
Closes the one genuinely-actionable item from Codex's R3 review that wasn't fully done in #292.

**Context:** Codex R3 (against the pre-fix head `33ff6d75`) was folded in #292 — all blockers/should-fixes are verified live on the current head `b93819b5` (complete-metric-set policy, lens finite-filter, FlipMarker removal, five regression pins). Codex's remaining recommendation was a single `selectDriverDisplayModel {value, rank, provenance}` consumed by graph + hero + panel. #292 landed the policy but in **two copies** (panel `resolveDisplayInfluences` + a mirrored inline block in the graph badge) — behaviourally identical, both tested, but able to drift.

**This PR** extracts the policy into one leaf module `driverDisplayModel.ts` that both hooks import:
- `selectDriverDisplayModel` returns `{value, provenance}` — the coverage rule lives once.
- `compareByDisplayModel` shared rank comparator; the graph badge's mirrored block is deleted.
- `provenance` ('influence_score' | 'normalised_elasticity') makes the basis explicit.
- New `driverDisplayModel.spec.ts` pins Codex's **exact** partial-coverage scenario (Investor 0.1/90%, Revenue 0.2/absent → both surfaces rank Revenue #1 on the normalised basis).

Behaviour-preserving (graph near-zero elasticities now use the panel's 0.001 direction-only guard — strictly more consistent). Gates: typecheck clean · changed-set 890 tests green (×2, the earlier 2 were flaky) · lint 0 errors · wide-tsc identical to base (2338).

**Not in scope (documented in the handover):** Blocker 2 (`decision_brief` keep-list) is cross-repo (schemas→CEE→DGAI) and routed to the program board; the 390px dock-clipping narrow-layout risk is a pre-existing responsive-layout item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)