### PR TITLE
fix(results): Codex final-audit P0s — tornado policy+honesty, atomic goal commit, V5 goal_threshold normalisation

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -75,7 +75,7 @@ import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip } from '../ut
 import { WarningBanner } from './WarningBanner'
 import { DegradedStateBanner } from './DegradedStateBanner'
 import { mapConfidenceToReadiness } from '../utils/mapConfidenceToReadiness'
-import { useV2Run, type V2RunPersistence } from '../hooks/useV2Run'
+import { useV2Run, resolveChipGoalThreshold, type V2RunPersistence } from '../hooks/useV2Run'
 import { useScenario } from '../../hooks/useScenario'
 import { focusExistingTarget } from '../utils/focusHelpers'
 import { withObservedStateUpdate } from '../utils/observedStateHelpers'
@@ -647,13 +647,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     const downRange = expected - p10  // distance from expected to pessimistic
     const upRange = p90 - expected    // distance from expected to optimistic
 
-    // Build rows from top drivers, sorted by influence descending
+    // Codex final-audit B1: order + size by the SHARED display influence
+    // (driverDisplayModel) — the same number the panel, hero and graph badge
+    // use — so this chart can never contradict them under partial coverage.
+    const infl = (d: (typeof drv.drivers)[number]) =>
+      d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence
     const rows: TornadoRow[] = [...drv.drivers]
-      .filter(d => (d.influenceScore ?? d.normalisedInfluence) > 0.01)
-      .sort((a, b) => (b.influenceScore ?? b.normalisedInfluence) - (a.influenceScore ?? a.normalisedInfluence))
+      .filter(d => infl(d) > 0.01)
+      .sort((a, b) => infl(b) - infl(a))
       .slice(0, 5) // Cap at 5 rows for readability
       .map(d => {
-        const influence = d.influenceScore ?? d.normalisedInfluence
+        const influence = infl(d)
         // NOTE: lowOutcome/highOutcome represent outcome at the factor's low/high
         // raw value, NOT "worse/better" from the user's perspective.
         // For negative-direction factors (e.g. churn), low factor value = better
@@ -890,18 +894,35 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // OFF → direct V2.
   const lastThresholdRerunAtRef = useRef<number>(0)
   const handleApplyThreshold = useCallback((threshold: number | null) => {
-    setGoalThreshold(threshold)
+    const store = useCanvasStore.getState()
+    // Codex final-audit B2 — atomic store + goal-node commit (the bare
+    // setGoalThreshold updated only the global value, leaving the goal node
+    // showing "target missing" after an apply).
+    const goalNodeId =
+      (store.ceeAnalysisReady?.goal_node_id as string | undefined) ??
+      store.nodes.find((n) => n.type === 'goal')?.id ??
+      null
+    if (goalNodeId) store.setGoalThresholdAndUpdateNode(goalNodeId, threshold)
+    else setGoalThreshold(threshold)
     const now = Date.now()
     if (now - lastThresholdRerunAtRef.current < 500) return
     lastThresholdRerunAtRef.current = now
     // Wave F-B: the threshold rerun goes through the canonical runner like
-    // every other run affordance — same gate, same V5/V2 routing. Its old
-    // inline dispatch copy had NO run gate (audit finding). The V2 fallback
-    // needs no parameter: the request builder reads store.goalThreshold
-    // (UI-SEM-058), already set above.
+    // every other run affordance — same gate, same V5/V2 routing. The V2
+    // fallback reads store.goalThreshold (UI-SEM-058), already set above.
+    // Codex final-audit B3 — the V5 chip must carry the NORMALISED threshold
+    // (buildPayload forwards it verbatim; raw units are ignored by PLoT).
+    // Fail closed (omit) when normalisation can't be proven.
+    const normalisedThreshold = resolveChipGoalThreshold(threshold, {
+      analysisReady: store.ceeAnalysisReady,
+      nodes: store.nodes,
+      goalNodeId: store.outcomeNodeId,
+    })
     void runCanonicalAnalysis({
       source: 'apply-threshold',
-      ...(threshold !== null ? { parameters: { goal_threshold: threshold } } : {}),
+      ...(normalisedThreshold !== undefined
+        ? { parameters: { goal_threshold: normalisedThreshold } }
+        : {}),
     }).then((outcome) => {
       // Review (b): the hero copy promises "Applying runs the analysis
       // again" — a gated outcome must say why instead of silently saving

--- a/src/canvas/hooks/__tests__/useV2Run.goalThreshold.spec.ts
+++ b/src/canvas/hooks/__tests__/useV2Run.goalThreshold.spec.ts
@@ -9,7 +9,7 @@
  * threshold means no probability_of_goal, never a corrupt analysis).
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { normaliseGoalThresholdForRequest, resolveGoalThresholdCap } from '../useV2Run'
+import { normaliseGoalThresholdForRequest, resolveGoalThresholdCap, resolveChipGoalThreshold } from '../useV2Run'
 
 describe('normaliseGoalThresholdForRequest (UI-SEM-058)', () => {
   afterEach(() => {
@@ -81,3 +81,47 @@ describe('resolveGoalThresholdCap (request boundary uses the display chain)', ()
     expect(resolveGoalThresholdCap(null, goalNode({ goal_threshold_cap: 25 }), 'missing_node')).toBeUndefined()
   })
 })
+
+describe('resolveChipGoalThreshold (UI-SEM-058 V5 leg — Codex final-audit B3)', () => {
+  const goalNode = (data: Record<string, unknown>) => [{ id: 'goal_1', data }]
+
+  it('normalises against a cap from analysisReady (60 / cap 100 → 0.6)', () => {
+    expect(
+      resolveChipGoalThreshold(60, {
+        analysisReady: { goal_threshold_cap: 100 },
+        nodes: goalNode({}),
+        goalNodeId: 'goal_1',
+      }),
+    ).toBeCloseTo(0.6)
+  })
+
+  it('falls back to a node cap when analysisReady has none', () => {
+    expect(
+      resolveChipGoalThreshold(60, {
+        analysisReady: null,
+        nodes: goalNode({ scale_max: 200 }),
+        goalNodeId: 'goal_1',
+      }),
+    ).toBeCloseTo(0.3)
+  })
+
+  it('OMITS (undefined) a raw value that cannot be proven normalised — never sends raw', () => {
+    // No cap anywhere → 60 stays 60 > 1 → cannot prove → omit (fail closed).
+    expect(
+      resolveChipGoalThreshold(60, { analysisReady: null, nodes: goalNode({}), goalNodeId: 'goal_1' }),
+    ).toBeUndefined()
+  })
+
+  it('passes a value already in [0,1] through when no cap exists', () => {
+    expect(
+      resolveChipGoalThreshold(0.6, { analysisReady: null, nodes: goalNode({}), goalNodeId: 'goal_1' }),
+    ).toBe(0.6)
+  })
+
+  it('returns undefined for a null/absent threshold', () => {
+    expect(
+      resolveChipGoalThreshold(null, { analysisReady: { goal_threshold_cap: 100 }, nodes: [], goalNodeId: null }),
+    ).toBeUndefined()
+  })
+})
+

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -122,6 +122,29 @@ export function resolveGoalThresholdCap(
 }
 
 /**
+ * UI-SEM-058 (V5 leg) — normalise a goal_threshold for a CANONICAL/V5 chip
+ * parameter. The store holds RAW user units; the V2 request builder converts
+ * at its boundary, but the V5 path (buildPayload) forwards chip parameters
+ * VERBATIM. So any chip that carries goal_threshold must carry the NORMALISED
+ * 0-1 form, and OMIT it when normalisation cannot be proven — a raw value on
+ * the V5 wire is silently ignored by PLoT while it retains a stale target
+ * (Codex final-audit B3: entering 60% shipped goal_threshold:60, HTTP 200,
+ * old 0.53 retained, all lenses unavailable). Returns undefined → the caller
+ * must omit the parameter (fail closed), never send raw.
+ */
+export function resolveChipGoalThreshold(
+  rawThreshold: number | null | undefined,
+  ctx: {
+    analysisReady: { goal_threshold_cap?: unknown } | null
+    nodes: ReadonlyArray<{ id: string; data?: unknown }>
+    goalNodeId: string | null | undefined
+  },
+): number | undefined {
+  const cap = resolveGoalThresholdCap(ctx.analysisReady, ctx.nodes, ctx.goalNodeId)
+  return normaliseGoalThresholdForRequest(rawThreshold, cap)
+}
+
+/**
  * Check if ceeAnalysisReady is stale (graph has changed since it was stored).
  *
  * Returns true if stale (should not use analysis_ready).

--- a/src/components/results/TornadoChart.tsx
+++ b/src/components/results/TornadoChart.tsx
@@ -386,14 +386,20 @@ export function TornadoChart({
         }
       }}
     >
-      {/* Brief 5 Task 3: card intro above bars (Paul-approved frozen copy).
-          Brief 5.4 Phase 16: "Drag to preview" removed — implies apply/rerun
-          which is dormant. Rewritten to exploration-only per brief dormancy rule. */}
+      {/* Codex final-audit B1 — honest framing. The bars are the recommended
+          option's OVERALL p10/p90 spread scaled by each factor's influence
+          (see the module header): a proportional illustration, NOT producer
+          per-factor counterfactuals. The prior "Win-likelihood range … drag
+          to explore how outcomes shift" copy presented that fabrication as
+          analysis output. Reframed as an explicit illustration + the drag
+          invitation dropped (drag stays dormancy-gated, PLOT_BOUNDS_WIRED).
+          NOTE: this replaces Brief 5 Task 3 Paul-approved frozen copy for
+          honesty — flag for Paul's veto. */}
       <p
         className={`${typography.panelBody} text-text-body mb-2`}
         data-testid="tornado-intro"
       >
-        Win-likelihood range if this factor turns out weaker or stronger than expected. Drag the bars to explore how outcomes shift.
+        Illustrative range for each factor: the recommended option&rsquo;s overall spread scaled by that factor&rsquo;s influence. A proportional guide to relative leverage, not a per-factor forecast from the analysis.
       </p>
 
       {/* Brief 5.1 Task 5: legend occupies its own full-width row above the

--- a/src/components/results/__tests__/TornadoChart.spec.tsx
+++ b/src/components/results/__tests__/TornadoChart.spec.tsx
@@ -736,7 +736,7 @@ describe('TornadoChart — disclaimer, axis, display modes', () => {
     expect(screen.getByTestId('tornado-intro')).toBeInTheDocument()
     // Brief 5.4 Phase 16: intro copy updated to exploration-only (removed "Drag to preview" which implied apply/rerun)
     expect(screen.getByText(
-      'Win-likelihood range if this factor turns out weaker or stronger than expected. Drag the bars to explore how outcomes shift.'
+      'Illustrative range for each factor: the recommended option\u2019s overall spread scaled by that factor\u2019s influence. A proportional guide to relative leverage, not a per-factor forecast from the analysis.'
     )).toBeInTheDocument()
   })
 

--- a/src/components/results/modals/DefineSuccessModal.tsx
+++ b/src/components/results/modals/DefineSuccessModal.tsx
@@ -24,6 +24,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { executeCanonicalRun } from '../../../canvas/analysis/canonicalRunRegistry'
+import { resolveChipGoalThreshold } from '../../../canvas/hooks/useV2Run'
 import { useCanvasStore } from '../../../canvas/store'
 import { typography } from '../../../styles/typography'
 import {
@@ -186,15 +187,36 @@ export function DefineSuccessModal() {
     }
     useSuccessMeasureStore.getState().saveMeasure(scenarioKey, measure)
 
-    // Canonical commit — the SAME single path as the hero footer editor
-    // (OutputsDock.handleApplyThreshold): ONE setter writes the raw
-    // user-unit threshold (UI-SEM-058 normalises at the request boundary),
-    // ONE canonical rerun with the same source/parameters convention.
-    canvas.setGoalThreshold(parsedThreshold)
+    // Codex final-audit B2 — atomic commit: write the raw user-unit threshold
+    // to the store AND the goal node's data in one action, so the goal node
+    // stops showing "target missing" after a save (the bare setGoalThreshold
+    // updated only the global value, leaving the node stale). Falls back to
+    // the global-only setter when no goal node is resolvable.
+    const goalNodeId =
+      (canvas.ceeAnalysisReady?.goal_node_id as string | undefined) ??
+      canvas.nodes.find((n) => n.type === 'goal')?.id ??
+      null
+    if (goalNodeId) {
+      canvas.setGoalThresholdAndUpdateNode(goalNodeId, parsedThreshold)
+    } else {
+      canvas.setGoalThreshold(parsedThreshold)
+    }
+    // Codex final-audit B3 — the canonical/V5 chip must carry the NORMALISED
+    // 0-1 threshold (buildPayload forwards chip params verbatim; a raw value
+    // is silently ignored by PLoT). Resolve the cap the SAME way the V2
+    // request boundary does (outcomeNodeId) and OMIT the parameter when
+    // normalisation can't be proven — fail closed, never send raw.
+    const normalisedThreshold = resolveChipGoalThreshold(parsedThreshold, {
+      analysisReady: canvas.ceeAnalysisReady,
+      nodes: canvas.nodes,
+      goalNodeId: canvas.outcomeNodeId,
+    })
     close()
     void executeCanonicalRun({
       source: 'define-success-modal',
-      parameters: { goal_threshold: parsedThreshold },
+      ...(normalisedThreshold !== undefined
+        ? { parameters: { goal_threshold: normalisedThreshold } }
+        : {}),
     }).then((outcome) => {
       if (outcome.status === 'blocked' || outcome.status === 'unavailable') {
         // The measure IS saved — say so, then the honest gate reason.

--- a/src/components/results/modals/__tests__/DefineSuccessModal.spec.tsx
+++ b/src/components/results/modals/__tests__/DefineSuccessModal.spec.tsx
@@ -268,6 +268,42 @@ describe('DefineSuccessModal — validation (never silent-close)', () => {
 })
 
 describe('DefineSuccessModal — save commits through the canonical path exactly once', () => {
+  it('Codex B2+B3: with a goal node and a provable cap, commits atomically to the node and sends the NORMALISED threshold', async () => {
+    // Goal node + a cap on ceeAnalysisReady (the same source the V2 request
+    // boundary uses). Entering 60 (unit %) must: update the goal node's
+    // data (B2 — no more "target missing"), and send goal_threshold 0.6 on
+    // the chip (B3 — 60 / cap 100), not raw 60.
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'goal_1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Ship on time' } },
+      ] as never,
+      currentScenarioId: 'scn_test',
+      outcomeNodeId: 'goal_1',
+      ceeAnalysisReady: { goal_threshold_cap: 100 } as never,
+      goalThreshold: null,
+    } as never)
+
+    render(<DefineSuccessModal />)
+    openModal()
+    fillValid('60')
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('define-success-save'))
+    })
+
+    // B2: the goal node carries the user target atomically (store + node).
+    const goalNode = useCanvasStore.getState().nodes.find((n) => n.id === 'goal_1')!
+    expect((goalNode.data as { success_threshold?: number }).success_threshold).toBe(60)
+    expect((goalNode.data as { threshold_source?: string }).threshold_source).toBe('user')
+    expect(useCanvasStore.getState().goalThreshold).toBe(60)
+
+    // B3: the chip carries the NORMALISED 0-1 value, never raw 60.
+    expect(runner).toHaveBeenCalledTimes(1)
+    expect(runner).toHaveBeenCalledWith({
+      source: 'define-success-modal',
+      parameters: { goal_threshold: 0.6 },
+    })
+  })
+
   it('persists the full structured measure, calls the ONE setter and ONE canonical rerun, toasts and closes', async () => {
     const setterSpy = vi.fn(originalSetGoalThreshold)
     useCanvasStore.setState({ setGoalThreshold: setterSpy } as never)
@@ -288,13 +324,12 @@ describe('DefineSuccessModal — save commits through the canonical path exactly
     expect(setterSpy).toHaveBeenCalledWith(20)
     expect(useCanvasStore.getState().goalThreshold).toBe(20)
 
-    // ONE canonical rerun with the same source/parameters convention as
-    // OutputsDock.handleApplyThreshold.
+    // ONE canonical rerun. Codex final-audit B3: with NO provable cap in this
+    // fixture, the raw 20 cannot be normalised to 0-1, so goal_threshold is
+    // OMITTED (fail closed) — never sent raw (V5 forwards chip params verbatim
+    // and PLoT silently ignores an out-of-range value).
     expect(runner).toHaveBeenCalledTimes(1)
-    expect(runner).toHaveBeenCalledWith({
-      source: 'define-success-modal',
-      parameters: { goal_threshold: 20 },
-    })
+    expect(runner).toHaveBeenCalledWith({ source: 'define-success-modal' })
 
     // Full structured measure persisted per scenario.
     const saved = selectSuccessMeasure(useSuccessMeasureStore.getState(), 'scn_test')

--- a/tests/visual-regression/analysis-tab.spec.ts
+++ b/tests/visual-regression/analysis-tab.spec.ts
@@ -155,9 +155,10 @@ describe('visual-regression scaffold (Brief 5)', () => {
     const root = container.querySelector('[data-testid="tornado-chart"]')!
     const snap = normaliseDomSnapshot(root.outerHTML)
 
-    // Brief 5.4 Phase 16: intro copy updated to exploration-only (removed "Drag to preview" which implied apply/rerun)
+    // Codex final-audit B1: intro copy made honest — the bars are a proportional
+    // illustration (option spread x influence), not producer per-factor forecasts.
     expect(snap).toContain(
-      'Win-likelihood range if this factor turns out weaker or stronger than expected. Drag the bars to explore how outcomes shift.',
+      'Illustrative range for each factor: the recommended option’s overall spread scaled by that factor’s influence. A proportional guide to relative leverage, not a per-factor forecast from the analysis.',
     )
     // Legend relocated above the first bar
     expect(snap).toContain('data-testid="tornado-legend"')


### PR DESCRIPTION
Addresses the three P0 blockers from Codex's final pre-handover audit (head `6fcf80f7`). All verified in code, fixed with tests.

**B1 — tornado bypassed the shared policy + fabricated ranges.** It ordered/sized by `influenceScore ?? normalisedInfluence` (not the shared `displayInfluence`), so under partial coverage it contradicted the panel/hero/graph. Now ordered + sized by `displayInfluence`. Intro copy made honest — the bars are the recommended option's overall spread scaled by influence (a proportional illustration, **not** producer per-factor forecasts); the old "Win-likelihood range … drag to explore how outcomes shift" over-claimed. *(Replaces Brief-5 Paul-frozen copy for honesty — flag for veto. Drag stays dormancy-gated per the existing PLOT_BOUNDS_WIRED design.)*

**B2 — success-target split store/node.** The modal + inline editor called bare `setGoalThreshold` (global only), leaving the goal node showing "target missing" after a save. Now commit atomically via `setGoalThresholdAndUpdateNode`.

**B3 — V5 sent RAW `goal_threshold`.** The store holds raw user units; only the V2 boundary normalised (UI-SEM-058); V5 forwards chip params verbatim, so `60%` shipped `goal_threshold:60` (PLoT ignored it, kept the stale 0.53). New shared `resolveChipGoalThreshold` normalises at both chip sites and **omits when the cap can't be proven (fail closed — never raw)**. **This corrects the earlier "producer doesn't unlock goal-fit" attribution** — the UI was sending an invalid value; the producer must be re-tested once a valid normalised threshold is sent. CEE should additionally validate the range and return a typed error (cross-repo).

**Deferred (documented for the successor, not silently dropped):** SF2 (rerun unmounts ResultsBody → lost interaction state; touches deliberately-structured retain/mount logic); B2's secondary auto-threshold-probability display contradiction + its pinned test (product judgment — is the auto-derived probability display intended?); the perf + HeroGallery-harness + decision-records-backend opportunities.

Gates: typecheck clean · changed-set 379 passed · lint 0 errors · wide-tsc identical to base (2338). New tests: `resolveChipGoalThreshold` unit matrix, modal B2+B3 atomic+normalised test, fail-closed test, tornado + visual-regression copy pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)