### PR TITLE
fix(results): D-U — visible lever badge for producer-suppressed sensitivity

### DIFF
--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -102,11 +102,16 @@ function gridCols(showConfidence: boolean): string {
 }
 const GRID_COLS = gridCols(DISPLAY_SAFE_DRIVER_CONFIDENCE)
 
-// Zero reason display messages - explains why sensitivity is zero
-const ZERO_REASON_MESSAGES: Record<string, string> = {
-  intervention_override: 'Directly controlled by your options',
-  disconnected: 'No causal path to goal',
-  zero_outcome_diff: "Changes don't affect outcome",
+// Zero-reason badge labels — the producer suppresses a factor's sensitivity and
+// stamps WHY (zero_reason). D-U ruling: surface that reason as a VISIBLE badge on
+// the row, not a hover-only tooltip, so an influence bar with no sensitivity is
+// never left unexplained. Display/label only — the badge reflects the producer's
+// stamp verbatim; it never fabricates or recomputes a value (a suppressed value
+// shows the badge, never a 0).
+const ZERO_REASON_BADGE_LABELS: Record<string, string> = {
+  intervention_override: 'Controlled by your options',
+  disconnected: 'No path to the goal',
+  zero_outcome_diff: "Doesn't change the outcome",
 }
 
 /**
@@ -324,15 +329,18 @@ function DriverRow({
         : null
   const showQualityHint = typeof driver.valueOfInformation === 'number' && driver.valueOfInformation > 0.05
   const hasEnrichment = driver.enrichment && hasEnrichmentContent(driver.enrichment)
-  const hasZeroReason = driver.zeroReason && ZERO_REASON_MESSAGES[driver.zeroReason]
+  // Producer zero_reason stamp → visible badge label (rendered in the row body,
+  // NOT the tooltip). Undefined when the producer left no stamp.
+  const leverBadgeLabel = driver.zeroReason ? ZERO_REASON_BADGE_LABELS[driver.zeroReason] : undefined
   // Task 7c: ranking shift + technique added to tooltip — must be computed before this line
   // (rankingShiftWarn and techniqueSuggestion are computed after this block, so use inline checks)
   // The (i) info icon must appear only when the tooltip has VISIBLE content.
   // Confidence/evidence/fragility lines (decisionChangeRisk, rankingShiftWarn,
   // qualityHint) are gated off today, so they contribute to the icon only when
-  // their gate is on. Enrichment + zero-reason (an influence explanation) are
-  // always-visible. The technique chip moved out of the tooltip to a body chip.
-  const hasTooltipContent = hasEnrichment || hasZeroReason
+  // their gate is on. Enrichment is always-visible. The zero-reason (lever)
+  // explanation moved OUT of the tooltip to a visible body badge (D-U); the
+  // technique chip likewise moved out to a body chip.
+  const hasTooltipContent = hasEnrichment
     || (DISPLAY_SAFE_DRIVER_CONFIDENCE && showQualityHint)
     || (SHOW_FRAGILITY_IN_DRIVER_SECTION && (
           !!decisionChangeRisk
@@ -419,13 +427,9 @@ function DriverRow({
           Could benefit from more evidence
         </p>
       )}
-      {/* Zero reason */}
-      {hasZeroReason && (
-        <p className="flex items-center gap-1">
-          <span aria-hidden="true">ℹ️</span>
-          {ZERO_REASON_MESSAGES[driver.zeroReason!]}
-        </p>
-      )}
+      {/* Zero reason moved OUT of the tooltip to a visible body badge (D-U): a
+          suppressed-sensitivity factor must SHOW why (e.g. "Controlled by your
+          options"), never hide the reason behind hover on the top row only. */}
       {/* Ranking shift warning (tooltip variant) — HIDDEN: a ranking-shift /
           fragility claim. Fragility ("could change the result") belongs in the
           fragile-factors section, not the driver section
@@ -622,13 +626,26 @@ function DriverRow({
         // prominence, NOT confidence/quality (outlined, text-text-body per DS).
         const emphasised = driver.semanticLabel === 'biggest' || driver.semanticLabel === 'strong'
         return (
-          <div className="flex items-center gap-1.5 px-3 pb-1">
+          <div className="flex items-center gap-1.5 px-3 pb-1 flex-wrap">
             <span
               className={`${typography.panelMeta} px-1.5 py-0.5 rounded-full bg-transparent text-text-body border ${emphasised ? 'border-info/30' : 'border-panel-border'}`}
               data-testid={`driver-influence-pill-${driver.factorKey}`}
             >
               {pillText}
             </span>
+            {/* Lever badge (D-U): visible, on every row (not tooltip / not
+                top-only). Honours the producer's zero_reason stamp — display
+                only, no value is fabricated or recomputed. */}
+            {leverBadgeLabel && (
+              <span
+                className={`${typography.panelMeta} inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-transparent text-text-light border border-panel-border`}
+                data-testid={`driver-lever-badge-${driver.factorKey}`}
+                title={leverBadgeLabel}
+              >
+                <Info className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                {leverBadgeLabel}
+              </span>
+            )}
             {/* No inline action here: the pill is an influence LABEL only. Per-factor
                 discussion is the bottom-right DiscussWithAiButton sparkle (kept as the
                 single, app-consistent "discuss this factor" affordance); node focus is

--- a/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.influenceOnlyGuard.spec.tsx
@@ -162,9 +162,10 @@ describe('DriversSection — influence-only guard', () => {
   })
 
   it('does NOT render the decision-flip line even with the tooltip OPEN (decisionChangeRisk gated)', () => {
-    // Force the (i) info icon to appear via a zero-reason line (an influence
-    // explanation that is always visible), so we can open the top-driver tooltip
-    // and prove the fragility/decision-flip line is gated off inside it.
+    // Force the (i) info icon to appear via enrichment (an always-visible
+    // influence explanation), so we can open the top-driver tooltip and prove
+    // the fragility/decision-flip line is gated off inside it. (The zero-reason
+    // lever line now renders as a visible body badge, not in the tooltip — D-U.)
     render(
       <DriversSection
         data={makeData([
@@ -174,7 +175,12 @@ describe('DriversSection — influence-only guard', () => {
             influenceScore: 0.9,
             flipRiskCategory: 'isolated',
             fragileEdgeInfo: { switchProbability: 0.35, alternativeWinnerLabel: 'Option B' },
-            zeroReason: 'disconnected',
+            enrichment: {
+              factor_id: 'fac',
+              factor_label: 'fac',
+              observations: ['An always-visible enrichment observation'],
+              perspectives: [],
+            },
           } as DriverItem),
         ])}
         goalLabel="test"
@@ -182,10 +188,32 @@ describe('DriversSection — influence-only guard', () => {
     )
     // Open the tooltip via the info button.
     fireEvent.click(screen.getByRole('button', { name: /more information/i }))
-    // The tooltip is open (the influence zero-reason line shows)...
-    expect(screen.getByText(/No causal path to goal/i)).toBeInTheDocument()
+    // The tooltip is open (the enrichment "Insights" disclosure shows)...
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    expect(screen.getByText('Insights')).toBeInTheDocument()
     // ...but the decision-flip / fragility line is hidden.
     expect(screen.queryByText(/becomes the better choice/i)).toBeNull()
     expect(screen.queryByText(/can change which option is best/i)).toBeNull()
+  })
+
+  it('renders the zero-reason lever explanation as a VISIBLE badge, not inside the tooltip (D-U)', () => {
+    render(
+      <DriversSection
+        data={makeData([
+          makeDriver({
+            factorKey: 'fac',
+            semanticLabel: 'biggest',
+            influenceScore: 0.9,
+            zeroReason: 'intervention_override',
+          } as DriverItem),
+        ])}
+        goalLabel="test"
+      />,
+    )
+    // The badge is visible without any hover/click.
+    const badge = screen.getByTestId('driver-lever-badge-fac')
+    expect(badge).toHaveTextContent(/controlled by your options/i)
+    // No tooltip trigger is forced into existence by the zero-reason alone.
+    expect(screen.queryByRole('button', { name: /more information/i })).toBeNull()
   })
 })

--- a/src/components/results/__tests__/DriversSection.leverBadge.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.leverBadge.spec.tsx
@@ -1,0 +1,95 @@
+/**
+ * DriversSection — lever badge VISIBLE (D-U display residual).
+ *
+ * The producer stamps zero_reason='intervention_override' on factors whose
+ * sensitivity is suppressed because they are directly controlled by the
+ * decision options (levers). Per the D-U ruling this must be surfaced as a
+ * VISIBLE badge on the factor row — not buried in a hover-only tooltip that
+ * appears solely on the top driver. This is the display half of the
+ * "numbers argue with each other" wound: an influence bar with no explanation
+ * of why its sensitivity is absent.
+ *
+ * These tests assert:
+ *  - a lever factor renders a visible "Controlled by your options" badge;
+ *  - the badge appears on lever rows that are NOT the top driver too;
+ *  - non-lever factors get no badge;
+ *  - the influence column is labelled "Influence", never "Sensitivity"
+ *    (per the ruling — influence_score is not sensitivity).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { DriversSection } from '../DriversSection'
+import type { DriversSectionData, DriverItem } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+}))
+
+function makeDriver(overrides: Partial<DriverItem> = {}): DriverItem {
+  return {
+    factorKey: 'f1',
+    factorLabel: 'Marketing Spend',
+    rawElasticity: 0.8,
+    normalisedInfluence: 0.8,
+    influenceScore: 0.8,
+    displayInfluence: 0.8,
+    rank: 1,
+    direction: 'positive',
+    semanticLabel: 'biggest',
+    canFocus: true,
+    matchedNodeId: 'n1',
+    confidence: 0.6,
+    ...overrides,
+  }
+}
+
+function makeData(drivers: DriverItem[]): DriversSectionData {
+  return {
+    drivers,
+    topDrivers: drivers.slice(0, 3),
+    driversStatus: 'computed',
+    totalCount: drivers.length,
+    hasMagnitudeData: true,
+  }
+}
+
+describe('DriversSection — lever badge (zero_reason intervention_override) is visible', () => {
+  it('renders a visible "Controlled by your options" badge on a lever factor', () => {
+    render(
+      <DriversSection
+        data={makeData([makeDriver({ zeroReason: 'intervention_override' })])}
+      />,
+    )
+    const badge = screen.getByTestId('driver-lever-badge-f1')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveTextContent(/controlled by your options/i)
+  })
+
+  it('shows the badge on a lever row even when it is NOT the top driver', () => {
+    const top = makeDriver({ factorKey: 'f1', rank: 1, semanticLabel: 'biggest', influenceScore: 0.9, displayInfluence: 0.9 })
+    const lever = makeDriver({
+      factorKey: 'f2', rank: 2, semanticLabel: 'strong',
+      factorLabel: 'Price Point', influenceScore: 0.5, displayInfluence: 0.5,
+      zeroReason: 'intervention_override',
+    })
+    render(<DriversSection data={makeData([top, lever])} />)
+    // Top (non-lever) has no badge; the second row (lever) does.
+    expect(screen.queryByTestId('driver-lever-badge-f1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('driver-lever-badge-f2')).toBeInTheDocument()
+  })
+
+  it('does NOT render a lever badge on a factor without a zero_reason', () => {
+    render(<DriversSection data={makeData([makeDriver({ zeroReason: undefined })])} />)
+    expect(screen.queryByTestId('driver-lever-badge-f1')).not.toBeInTheDocument()
+  })
+
+  it('labels the influence column "Influence", never "Sensitivity"', () => {
+    render(<DriversSection data={makeData([makeDriver({ zeroReason: 'intervention_override' })])} />)
+    const list = screen.getByTestId('drivers-list')
+    expect(within(list).getByText('Influence')).toBeInTheDocument()
+    expect(within(list).queryByText('Sensitivity')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Lane U — D-U credibility DISPLAY residual

The D-U "levers" ruling is adopted and the **producer fix is already merged** (ISL unions all options' interventions + stamps `zero_reason='intervention_override'`; sensitivity/EVPI suppressed producer-side on option-set factors, `influence_score` kept). This PR closes the **display-side** gap — the visible half of the "numbers argue with each other" wound.

### Verified live first (build nothing already-fixed)
Re-anchored the three claimed residuals against `origin/staging`:
- **(a) influence_score labelled "Sensitivity"** — ALREADY FIXED. The Drivers column header is `Influence` (v7.10 T9); `FactorsSection`/`SensitivityList` "Sensitivity" wording labels genuine sensitivity metrics (flip thresholds / EVPI / elasticity), not `influence_score`; the `LensDropdown` "Sensitivity" entry is a lens mode. No change made.
- **(b) crown ordered by abs-elasticity** — ALREADY FIXED. `computeFactorRanks` + `selectDriverDisplayModel` (Codex B2/R3, #292/#301) rank by displayed influence (`influence_score` under complete coverage, else normalised elasticity), elasticity only as tie-break. No change made.
- **(c) lever stamp is tooltip-only** — **LIVE.** `zeroReason` rendered only inside the hover tooltip, and the (i) trigger only appeared on the top driver → a suppressed-sensitivity factor's influence bar was left unexplained.

### Fix (display / copy only)
- Render a **visible** "Controlled by your options" badge on every driver row carrying a producer `zero_reason` stamp (not tooltip-only, not top-driver-only).
- Move the zero-reason line out of the tooltip; the (i) icon now gates on enrichment only.

### Safety invariant
No producer number changed — no sensitivity / EVPI / win_probability value is recomputed or fabricated. The badge shows the producer's stamp **verbatim as text**; a suppressed value shows the badge, **never a 0**. Influence bars, ordering, and the "Influence" label are untouched.

### RED-first tests
- New `DriversSection.leverBadge.spec.tsx`: visible badge on lever rows incl. non-top; no badge without a stamp; "Influence" (never "Sensitivity") column label.
- Updated `DriversSection.influenceOnlyGuard.spec.tsx`: forces the tooltip open via enrichment (not the relocated zero-reason) and pins badge-not-tooltip behaviour.

### Gates
- `pnpm run typecheck` — clean.
- `pnpm exec vitest run src/components/results` — 145 files / 2216 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)