### PR TITLE
fix(v5): V-P0-2 — explain-chips vocabulary aligned on the schema enum (Lane 1c)

### DIFF
--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -33,11 +33,15 @@ import type { ActionChip } from '../types'
 // `dispatchDeterministicChipClick` path bypasses Sonnet ORIENT (~12s saved
 // per click). Without these entries here, the V5 UI's filter below would
 // HIDE the new executable chips, defeating the latency fix entirely.
-const V5_ENABLED_ACTIONS = new Set<string>([
+export const V5_ENABLED_ACTIONS = new Set<string>([
   'run_analysis',
   'edit_graph',
   'draft_graph',
   'explain_results',
+  // V-P0-2 fold: the schema-valid SINGULAR legacy alias dispatches to the
+  // same 'explain' turn (ACTION_TO_TURN_TYPE) — a producer emitting it must
+  // not have its chip silently hidden.
+  'explain_result',
   'what_would_flip',
 ])
 

--- a/src/lib/analysisProducingCeeTurn.ts
+++ b/src/lib/analysisProducingCeeTurn.ts
@@ -70,11 +70,21 @@ export interface SelectorTracedPayload {
  * Turn types that produce analysis state. Drawn from
  * `ACTION_TO_TURN_TYPE` in `useConversation.ts` and the
  * `chip.action_type` discriminator on V5 requests.
+ *
+ * V5 traces carry no turnType — the selector falls back to
+ * `chip.action_type` — so this set must name the CHIP vocabulary too, not
+ * just the mapped turn type: V-P0-2 unhid the explain chips, whose wire
+ * form is `explain_results` (plural; singular is the schema's legacy
+ * alias). Without these entries the debug bundle pins an OLDER
+ * run_analysis/what_would_flip turn as "latest" after an explain click —
+ * the same vocabulary-drift class V-P0-2 fixed, on the diagnostic surface.
  */
 export const ANALYSIS_PRODUCING_ACTION_TYPES: ReadonlySet<string> = new Set([
   'run_analysis',
   'what_would_flip',
   'explain',
+  'explain_results',
+  'explain_result',
 ])
 
 // Round-4 review (IMP): `V5_TURN_ENDPOINT_PATTERN` moved to the

--- a/src/v5/__tests__/explainChips.vocabulary.spec.ts
+++ b/src/v5/__tests__/explainChips.vocabulary.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * V-P0-2 — the explain-chips vocabulary must be ONE vocabulary end-to-end.
+ *
+ * Live staging evidence (2026-07-13, scenario f0acea23, build 9de778ca):
+ * CEE's response offered suggested_actions
+ * `[{action_type:'explain_results', label:'Explain the result'}, …]` and the
+ * UI rendered only the OTHER chip — the parser rewrote the plural to the
+ * singular `explain_result` (an alias written for schemas 0.8.1, whose enum
+ * lacked the plural) while the SuggestedChips V5 filter recognises only the
+ * plural. Each half was spec-pinned in its own vocabulary; the composed
+ * pipeline was broken with both specs green (mock-asserts-mock).
+ *
+ * schemas 0.15 accepts BOTH forms (`ActionType` enum, 9 members), CEE's
+ * backend handler ID is the PLURAL (`useConversation.ts` ACTION_TO_TURN_TYPE
+ * documents the singular as "legacy alias"), so the plural is canonical:
+ * the parser must pass it through, the filter must accept what the parser
+ * emits, and buildPayload's wire allowlist must match the schema enum
+ * exactly so a schema-valid action_type is never silently stripped.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { ActionType } from '@talchain/schemas/boundary'
+
+import { parseV5Response } from '../responseParser'
+import { buildV5Payload, KNOWN_ACTION_TYPES } from '../buildPayload'
+import { V5_ENABLED_ACTIONS } from '../../canvas/conversation/zones/SuggestedChips'
+
+const FIXTURE_PATH = resolve(__dirname, 'fixtures/cee-response-b82c89dd-trimmed.json')
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as Record<string, unknown>
+}
+
+function makeResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('explain-chips vocabulary — parser → filter seam (V-P0-2)', () => {
+  it('the parser passes the schema-valid PLURAL through unrewritten', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    expect(result.response.suggested_actions[0].action_type).toBe('explain_results')
+  })
+
+  it('the V5 filter accepts what the parser emits (composed pipeline, was broken live)', async () => {
+    const result = await parseV5Response(makeResponse(loadFixture()))
+    if (result.kind !== 'response') throw new Error('expected response')
+    for (const action of result.response.suggested_actions) {
+      if (!action.action_type) continue
+      expect(
+        V5_ENABLED_ACTIONS.has(action.action_type),
+        `chip action_type "${action.action_type}" would be HIDDEN by the V5 filter`,
+      ).toBe(true)
+    }
+  })
+
+  it('the filter also accepts the schema-valid SINGULAR legacy alias', () => {
+    // Both forms are in the schema enum and ACTION_TO_TURN_TYPE dispatches
+    // both to the same 'explain' turn — neither may be silently hidden.
+    expect(V5_ENABLED_ACTIONS.has('explain_result')).toBe(true)
+    expect(V5_ENABLED_ACTIONS.has('explain_results')).toBe(true)
+  })
+})
+
+describe('buildPayload wire allowlist — schema parity', () => {
+  it('KNOWN_ACTION_TYPES equals the @talchain/schemas ActionType enum EXACTLY (drift = red)', () => {
+    expect(new Set(KNOWN_ACTION_TYPES)).toEqual(new Set(ActionType.options))
+  })
+
+  it('a schema-valid plural explain_results chip is NOT stripped at the wire', () => {
+    const build = buildV5Payload({
+      turnId: '00000000-0000-4000-8000-000000000001',
+      scenarioId: '00000000-0000-4000-8000-000000000002',
+      stage: 'analyse',
+      turnClass: 'frame',
+      mode: 'user',
+      message: 'Explain the result',
+      source: 'chip',
+      chipMeta: { action_type: 'explain_results' },
+    } as never)
+    if (!build.ok) throw new Error('payload build failed: ' + JSON.stringify(build))
+    const payload = build.payload as { chip?: { action_type?: string } }
+    expect(payload.chip?.action_type).toBe('explain_results')
+  })
+})

--- a/src/v5/__tests__/explainChips.vocabulary.spec.ts
+++ b/src/v5/__tests__/explainChips.vocabulary.spec.ts
@@ -24,8 +24,9 @@ import { resolve } from 'node:path'
 import { ActionType } from '@talchain/schemas/boundary'
 
 import { parseV5Response } from '../responseParser'
-import { buildV5Payload, KNOWN_ACTION_TYPES } from '../buildPayload'
+import { buildV5Payload, KNOWN_ACTION_TYPES, type BuildV5PayloadInput } from '../buildPayload'
 import { V5_ENABLED_ACTIONS } from '../../canvas/conversation/zones/SuggestedChips'
+import { ANALYSIS_PRODUCING_ACTION_TYPES } from '../../lib/analysisProducingCeeTurn'
 
 const FIXTURE_PATH = resolve(__dirname, 'fixtures/cee-response-b82c89dd-trimmed.json')
 
@@ -65,6 +66,32 @@ describe('explain-chips vocabulary — parser → filter seam (V-P0-2)', () => {
     expect(V5_ENABLED_ACTIONS.has('explain_result')).toBe(true)
     expect(V5_ENABLED_ACTIONS.has('explain_results')).toBe(true)
   })
+
+  it('schema-enum values the filter deliberately EXCLUDES are exactly the documented list — a new enum/emitter value forces a decision here', () => {
+    // These are schema-valid on the wire but have no chip affordance:
+    // set_factor_value/add_constraint/adjust_edge_strength/compare_options
+    // have no V5 end-to-end chip handler; explain_from_structure has no
+    // ACTION_TO_TURN_TYPE dispatch mapping yet (rendering it would promise
+    // action and deliver default routing — add filter + mapping together).
+    const excluded = ActionType.options.filter((t) => !V5_ENABLED_ACTIONS.has(t))
+    expect(new Set(excluded)).toEqual(
+      new Set([
+        'set_factor_value',
+        'add_constraint',
+        'adjust_edge_strength',
+        'compare_options',
+        'explain_from_structure',
+      ]),
+    )
+  })
+
+  it('the debug-bundle turn selector recognises the explain chip vocabulary (review fold)', () => {
+    // V5 traces carry no turnType — the selector falls back to
+    // chip.action_type, so the CHIP forms must be in the set or the debug
+    // bundle pins an older turn as "latest" after an explain click.
+    expect(ANALYSIS_PRODUCING_ACTION_TYPES.has('explain_results')).toBe(true)
+    expect(ANALYSIS_PRODUCING_ACTION_TYPES.has('explain_result')).toBe(true)
+  })
 })
 
 describe('buildPayload wire allowlist — schema parity', () => {
@@ -73,7 +100,7 @@ describe('buildPayload wire allowlist — schema parity', () => {
   })
 
   it('a schema-valid plural explain_results chip is NOT stripped at the wire', () => {
-    const build = buildV5Payload({
+    const input: BuildV5PayloadInput = {
       turnId: '00000000-0000-4000-8000-000000000001',
       scenarioId: '00000000-0000-4000-8000-000000000002',
       stage: 'analyse',
@@ -82,7 +109,8 @@ describe('buildPayload wire allowlist — schema parity', () => {
       message: 'Explain the result',
       source: 'chip',
       chipMeta: { action_type: 'explain_results' },
-    } as never)
+    }
+    const build = buildV5Payload(input)
     if (!build.ok) throw new Error('payload build failed: ' + JSON.stringify(build))
     const payload = build.payload as { chip?: { action_type?: string } }
     expect(payload.chip?.action_type).toBe('explain_results')

--- a/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
+++ b/src/v5/__tests__/responseParser.actionTypeAlias.spec.ts
@@ -1,30 +1,28 @@
 /**
- * V5 parser — `suggested_actions[].action_type` alias normalisation.
+ * V5 parser — `suggested_actions[].action_type` alias mechanism.
  *
- * Live CEE staging response (debug bundle b82c89dd, 2026-05-21) carried
- * `suggested_actions[0].action_type = "explain_results"` (plural). The
- * vendored @talchain/schemas@0.8.1 `ActionType` enum only accepts the
- * singular `"explain_result"`, so strict validation rejected the entire
- * response with `parse_failure_kind: 'schema_mismatch'`, even though the
- * backend pipeline (CEE→PLoT→decision_review) completed successfully.
+ * HISTORY: under @talchain/schemas@0.8.1 the enum only accepted the singular
+ * `explain_result`, so a live CEE response carrying the plural (debug bundle
+ * b82c89dd, 2026-05-21) failed strict validation and the parser gained a
+ * plural→singular rewrite. Under schemas 0.15 the enum accepts BOTH forms,
+ * the plural is the backend's native handler ID, and the rewrite actively
+ * HID the "Explain the result" chip from the plural-keyed V5 filter
+ * (V-P0-2, wire-verified live 2026-07-13). The alias table is now EMPTY —
+ * these tests pin the passthrough plus the retained mechanism contracts
+ * (strictness for truly-unknown values; no input mutation). The composed
+ * parser→filter seam is pinned in explainChips.vocabulary.spec.ts.
  *
- * The parser now rewrites known runtime aliases (only the
- * explain_results → explain_result entry today) pre-validation, mirroring
- * the existing ACTION_TO_TURN_TYPE alias map in useConversation.ts. The
- * rewrite is lossless: both forms route to the same backend handler.
- *
- * This spec exercises the trimmed live fixture end-to-end and locks down
- * the eleven brief assertions:
- *   1.  Trimmed fixture parses to kind:'response' (no longer parse_error)
+ * Assertions over the trimmed live fixture:
+ *   1.  Trimmed fixture parses to kind:'response' (plural is schema-valid)
  *   2.  analysis_result block preserved with summary / leading_option_id /
  *       win_probabilities intact
  *   3.  analysis_ready.status === 'ready' + passthrough keys preserved
  *   4.  Phase 3 sidecar carries all 10 review_card+coaching blocks
  *   5.  A Phase 3 coaching block does not break parsing (verified by 1+4)
- *   6.  suggested_actions[0].action_type normalised to 'explain_result';
- *       suggested_actions[1].action_type unchanged ('what_would_flip')
- *   7.  Sidecar `action_type_aliases_applied` records the rewrite
- *   8.  An unknown action_type (not in allowlist) still fails strict
+ *   6.  suggested_actions[0].action_type PASSES THROUGH as the plural
+ *       (pin flip); suggested_actions[1] unchanged ('what_would_flip')
+ *   7.  No `action_type_aliases_applied` sidecar entry (pin flip)
+ *   8.  An unknown action_type (not in the schema enum) still fails strict
  *       validation — strictness preserved
  *   9.  extractPhase3FromV5Response recovers ≥1 review_card rawBlock
  *   10. composePhase3BridgedBlocks (PR #175 bridge) appends review_card
@@ -40,7 +38,6 @@ import {
   ADDITIVE_EXTENSIONS_KEY,
   PHASE3_SIDECAR_BLOCKS_KEY,
   ACTION_TYPE_ALIASES_APPLIED_KEY,
-  type ActionTypeAliasRewrite,
 } from '../responseParser'
 import { extractPhase3FromV5Response } from '../extractPhase3FromV5Response'
 
@@ -130,31 +127,30 @@ describe('parseV5Response — action_type alias normalisation', () => {
     expect(typeof aCoaching?.coaching_kind).toBe('string')
   })
 
-  it('(6) suggested_actions[0].action_type is normalised to "explain_result"; [1] unchanged', async () => {
+  it('(6) DELIBERATE PIN FLIP (V-P0-2): suggested_actions[0] keeps the schema-valid PLURAL; [1] unchanged', async () => {
+    // Under schemas 0.8.1 the plural failed validation and had to be
+    // rewritten to the singular. The 0.15 enum accepts both forms and the
+    // plural is the backend's native handler ID — the rewrite hid the chip
+    // from the plural-keyed V5 filter (live evidence 2026-07-13). The alias
+    // table is now empty; the plural must pass through untouched.
     const result = await parseV5Response(makeResponse(loadFixture()))
     if (result.kind !== 'response') throw new Error('expected response')
     const sa = result.response.suggested_actions
     expect(sa.length).toBe(2)
-    expect(sa[0].action_type).toBe('explain_result')
+    expect(sa[0].action_type).toBe('explain_results')
     expect(sa[0].id).toBe('chip_action_explain_results') // id preserved unchanged
     expect(sa[1].action_type).toBe('what_would_flip')
   })
 
-  it('(7) sidecar records action_type_aliases_applied with from/to/index', async () => {
+  it('(7) DELIBERATE PIN FLIP (V-P0-2): no alias rewrites are recorded — the table is empty under schemas 0.15', async () => {
     const result = await parseV5Response(makeResponse(loadFixture()))
     if (result.kind !== 'response') throw new Error('expected response')
     const sidecar = (result.response as { [ADDITIVE_EXTENSIONS_KEY]?: Record<string, unknown> })[
       ADDITIVE_EXTENSIONS_KEY
     ]
-    expect(sidecar).toBeDefined()
-    const rewrites = sidecar?.[ACTION_TYPE_ALIASES_APPLIED_KEY] as ActionTypeAliasRewrite[]
-    expect(rewrites).toBeDefined()
-    expect(rewrites).toHaveLength(1)
-    expect(rewrites[0]).toEqual({
-      index: 0,
-      from: 'explain_results',
-      to: 'explain_result',
-    })
+    // Sidecar may exist for Phase 3 blocks, but the alias-applied key must
+    // be absent when no rewrite occurred.
+    expect(sidecar?.[ACTION_TYPE_ALIASES_APPLIED_KEY]).toBeUndefined()
   })
 
   it('(8) strictness preserved: unknown action_type (not in allowlist) still fails schema validation', async () => {
@@ -243,13 +239,11 @@ describe('parseV5Response — no rewrites when no aliases present', () => {
 // ─── Contract: parser does NOT mutate the raw input ─────────────────────
 
 describe('parseV5Response — raw input is never mutated', () => {
-  it('after a successful parse with alias rewrite, the original input retains the pre-alias value', async () => {
-    // Hold a reference to the parsed fixture object so we can re-inspect
-    // it after parsing. The parser receives a Response built from
-    // JSON.stringify(fixture); even so, the contract is that any object
-    // surface the parser handles internally must be cloned before
-    // rewriting. This test locks down that contract from the caller's
-    // perspective: the fixture object visible here is untouched.
+  it('the original input object is untouched by parsing (debug-bundle fidelity contract)', async () => {
+    // The alias table is empty under schemas 0.15 so no rewrite occurs, but
+    // the no-input-mutation contract still guards the mechanism: if a future
+    // genuine-drift entry is added, the parser must clone before rewriting,
+    // never reach back into the caller's reference.
     const fixture = loadFixture() as {
       suggested_actions: Array<Record<string, unknown>>
     }
@@ -259,14 +253,8 @@ describe('parseV5Response — raw input is never mutated', () => {
     expect(result.kind).toBe('response')
     if (result.kind !== 'response') return
 
-    // Parsed surface carries the canonical value.
-    expect(result.response.suggested_actions[0].action_type).toBe('explain_result')
-
-    // Original fixture object STILL holds the pre-alias plural value —
-    // the parser must not reach back and rewrite the caller's reference,
-    // either directly or via shared sub-object references. If a future
-    // change starts mutating the input in place, this assertion fails
-    // immediately and the debug-bundle fidelity contract is protected.
+    // Passthrough: the parsed surface carries the producer's value as-is.
+    expect(result.response.suggested_actions[0].action_type).toBe('explain_results')
     expect(fixture.suggested_actions[0].action_type).toBe('explain_results')
   })
 })

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -237,12 +237,20 @@ function stringField(src: Record<string, unknown> | undefined, key: string): str
 // ActionType is a strict enum on the wire. If the UI passes an unknown
 // action_type, we'd fail ingress; drop it to let CEE's classifier dispatch
 // from message text alone.
-const KNOWN_ACTION_TYPES: ReadonlySet<ActionTypeLiteral> = new Set<ActionTypeLiteral>([
+//
+// V-P0-2 fold: this set MUST equal the vendored @talchain/schemas ActionType
+// enum exactly — a hand-copied subset silently strips schema-valid values at
+// the wire (it was 2 generations stale: 7 members vs the 0.15 enum's 9,
+// missing explain_results + explain_from_structure). Parity is pinned by
+// explainChips.vocabulary.spec.ts, which imports the enum and fails on drift.
+export const KNOWN_ACTION_TYPES: ReadonlySet<ActionTypeLiteral> = new Set<ActionTypeLiteral>([
   'run_analysis',
   'set_factor_value',
   'add_constraint',
   'adjust_edge_strength',
   'explain_result',
+  'explain_results',
+  'explain_from_structure',
   'compare_options',
   'what_would_flip',
 ])

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -133,24 +133,24 @@ export const PHASE3_TOLERATED_BLOCK_TYPES: ReadonlySet<Phase3ToleratedBlockType>
 /**
  * Allowlist of known CEE→schema drift in `suggested_actions[].action_type`.
  *
- * The vendored `@talchain/schemas@0.8.1` `ActionType` enum is the SINGULAR
- * `explain_result`, but CEE V5 chip-generator emits the PLURAL
- * `explain_results` (per the Phase-2b handler whitelist documented in
- * `useConversation.ts` ACTION_TO_TURN_TYPE). DGAI's runtime dispatch already
- * aliases both forms to the same `'explain'` turn type, and CEE's backend
- * handler accepts both, so this is a lossless meaning-preserving rewrite
- * applied BEFORE strict schema validation so the parse succeeds.
- *
- * Intentionally tiny and explicit. Any future drift requires explicit
- * entry — broad tolerance is NOT acceptable. Truly unknown action_type
- * values still fail strict validation.
+ * EMPTY under schemas 0.15 — deliberately. The single historical entry
+ * (`explain_results` → `explain_result`) existed because the 0.8.1 enum
+ * lacked the plural and strict validation rejected the whole response. The
+ * 0.15 `ActionType` enum accepts BOTH forms, the V5 backend handler ID is
+ * the PLURAL (see ACTION_TO_TURN_TYPE in useConversation.ts — the singular
+ * is its "legacy alias"), and the SuggestedChips V5 filter keys on the
+ * plural — so the rewrite had become actively harmful: it converted the
+ * producer's canonical value into one the filter hid, silently swallowing
+ * the "Explain the result" chip on live staging (V-P0-2, wire-verified
+ * 2026-07-13). The mechanism is retained for future GENUINE drift (a value
+ * the schema rejects); any entry requires explicit addition — broad
+ * tolerance is NOT acceptable. Truly unknown action_type values still fail
+ * strict validation.
  *
  * Keys are aliases CEE may emit; values are the canonical schema-accepted
  * forms.
  */
-const SUGGESTED_ACTION_TYPE_ALIASES: Readonly<Record<string, string>> = {
-  explain_results: 'explain_result',
-} as const;
+const SUGGESTED_ACTION_TYPE_ALIASES: Readonly<Record<string, string>> = {} as const;
 
 /**
  * A single rewrite recorded by normaliseSuggestedActionTypeAliases for the

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -650,14 +650,14 @@ export async function parseV5Response(res: Response): Promise<V5ParseResult> {
     }
   }
 
-  // Tolerance step 3 (action_type alias drift): the runtime dispatch map
-  // (`ACTION_TO_TURN_TYPE` in useConversation.ts) already aliases known
-  // CEE-side action_type plurals to their canonical schema forms (e.g.
-  // 'explain_results' → 'explain_result'). Apply the same normalisation
-  // pre-validation so the strict schema enum accepts the response. Allowlist
-  // is intentionally tiny; any future drift requires explicit entry. Raw
-  // input is not mutated; rewrites are stashed on the sidecar for the debug
-  // bundle to surface faithfully.
+  // Tolerance step 3 (action_type alias drift): rewrite values the STRICT
+  // SCHEMA REJECTS to their schema-accepted forms. The table is EMPTY under
+  // schemas 0.15 (see SUGGESTED_ACTION_TYPE_ALIASES) — do NOT re-add entries
+  // for values the enum already accepts: rewriting a schema-valid form
+  // breaks downstream consumers keyed on the producer's vocabulary (V-P0-2:
+  // the plural→singular entry hid the explain chip from the V5 filter).
+  // Raw input is not mutated; any rewrites are stashed on the sidecar for
+  // the debug bundle to surface faithfully.
   const aliasNorm = normaliseSuggestedActionTypeAliases(knownForValidation)
   knownForValidation = aliasNorm.known
   const aliasRewrites = aliasNorm.rewrites


### PR DESCRIPTION
## What

Fixes **V-P0-2** from the adversarial verification (wire-proven live): CEE offered an `explain_results` "Explain the result" chip and the UI silently swallowed it. The parser rewrote the plural to the singular (an alias written for schemas **0.8.1**, whose enum lacked the plural and rejected the whole response) while the SuggestedChips V5 filter recognises only the plural. Each half was spec-pinned in its own vocabulary — both specs green, composed pipeline broken (the audit's mock-asserts-mock finding).

Under schemas **0.15** the `ActionType` enum accepts BOTH forms and the plural is the backend's native handler ID (`ACTION_TO_TURN_TYPE` documents the singular as "legacy alias") — the rewrite had become actively harmful.

## Changes

1. **responseParser**: alias table emptied (mechanism retained for future *genuine* drift; strictness for unknown values unchanged — pinned).
2. **SuggestedChips**: `V5_ENABLED_ACTIONS` also accepts the schema-valid singular legacy alias — neither form can be silently hidden.
3. **buildPayload**: `KNOWN_ACTION_TYPES` completed to the full 9-member schema enum (was 2 generations stale at 7 — `explain_results` and `explain_from_structure` were silently stripped at the wire), exported, and **pinned to the enum by a parity test that fails on any future drift**.

Not done deliberately: `explain_from_structure` is NOT added to the chip filter — it has no `ACTION_TO_TURN_TYPE` dispatch mapping yet, so rendering it would produce a chip that promises action and delivers default routing. It is no longer stripped at the wire; the filter entry should land with its dispatch mapping.

## Tests

RED-first: the new `explainChips.vocabulary.spec.ts` (5 tests — parser passthrough, composed parser→filter seam, singular-alias acceptance, schema parity, wire passthrough) all failed before the fix. Deliberate pin flips in `responseParser.actionTypeAlias.spec.ts` marked in place with the V-P0-2 rationale; strictness (8), no-mutation, and Phase-3 tolerance pins unchanged.

## Gates

typecheck clean · changed-set vitest **1534 passed / 0 failed** · lint 0 errors · wide-tsc-diff-vs-base **zero new messages** · fast pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)