### PR TITLE
test(goal-threshold): Lane 1 seam pins — chip→wire body, dispatch→payload link, V2/V5 parity grid

### DIFF
--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -2503,6 +2503,60 @@ describe('login 3.4 — V5 turn auth headers', () => {
 // for the whole turn, and re-clicks must not abort/re-mint the in-flight run)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Lane 1 seam pin — dispatchAction chip parameters reach the REAL V5 payload
+// (this dispatch→payload link was the untested hop in the July-13 P0 chain:
+// coverage stopped at the runner-mock boundary on one side and a hand-built
+// payload on the other).
+// ---------------------------------------------------------------------------
+
+describe('dispatchAction — chip parameters ride the real V5 payload', () => {
+  beforeEach(() => {
+    mockIsV5Eligible.mockReturnValue({ eligible: true })
+    useCanvasStore.getState().resultsReset()
+    mockCallV5Turn.mockResolvedValue(makeV5SuccessResult())
+  })
+
+  it('forwards parameters.goal_threshold verbatim into payload.chip', async () => {
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.dispatchAction({
+        action_type: 'run_analysis',
+        parameters: { goal_threshold: 0.2 },
+        label: 'Run analysis',
+        message: 'Run analysis',
+        source: 'chip' as const,
+      })
+    })
+
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    const payload = mockCallV5Turn.mock.calls[0][0] as {
+      chip?: { action_type?: string; parameters?: Record<string, unknown> }
+    }
+    expect(payload.chip).toEqual({
+      action_type: 'run_analysis',
+      parameters: { goal_threshold: 0.2 },
+    })
+  })
+
+  it('a dispatch WITHOUT parameters builds a chip with NO parameters key (omission survives to the payload)', async () => {
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.dispatchAction({
+        action_type: 'run_analysis',
+        label: 'Run analysis',
+        message: 'Run analysis',
+        source: 'chip' as const,
+      })
+    })
+
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    const payload = mockCallV5Turn.mock.calls[0][0] as { chip?: Record<string, unknown> }
+    expect(payload.chip).toBeDefined()
+    expect(payload.chip).not.toHaveProperty('parameters')
+  })
+})
+
 describe('1.16i — rerun UX integrity', () => {
   beforeEach(() => {
     mockIsV5Eligible.mockReturnValue({ eligible: true })

--- a/src/canvas/hooks/__tests__/goalThreshold.chipToWire.spec.ts
+++ b/src/canvas/hooks/__tests__/goalThreshold.chipToWire.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Lane 1 seam pin — chip-committed goal_threshold to the ACTUAL HTTP body.
+ *
+ * The July-13 P0s lived exactly in the untested gap between the unit-tested
+ * halves: DefineSuccessModal.spec stopped at the runner-mock boundary and
+ * v5Adapter.test asserted a hand-built payload, so "the normalised value
+ * reaches the wire" was never one test. This spec composes the REAL pieces —
+ * resolveChipGoalThreshold → buildV5Payload → callV5Turn(fetchImpl) — and
+ * asserts on JSON.parse(init.body). The wire is the truth; unit and parity
+ * specs are supporting pins.
+ *
+ * PLACEMENT: lives under canvas/hooks (NOT src/v5/__tests__) deliberately —
+ * tsconfig.ci.json's typecheck scope includes src/v5/**, and a v5-located
+ * spec importing useV2Run would drag the whole canvas/adapter graph into
+ * that scope, surfacing its pre-existing wide-baseline type errors (same
+ * constraint documented in responseParser.actionTypeAlias.spec.ts).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import {
+  resolveChipGoalThreshold,
+  resolveMeasureUnitCap,
+} from '../useV2Run'
+import { buildV5Payload, type BuildV5PayloadInput } from '../../../v5/buildPayload'
+import { callV5Turn } from '../../../v5/v5Adapter'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function makeFetchImpl() {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ response_version: 1, assistant_text: 'ok', blocks: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}
+
+async function wireBodyForThreshold(
+  normalised: number | undefined,
+): Promise<{ chip?: { action_type?: string; parameters?: Record<string, unknown> } }> {
+  const input: BuildV5PayloadInput = {
+    turnId: '00000000-0000-4000-8000-000000000001',
+    scenarioId: '00000000-0000-4000-8000-000000000002',
+    stage: 'analyse',
+    turnClass: 'frame',
+    mode: 'user',
+    message: 'Run analysis',
+    source: 'chip',
+    chipMeta: {
+      action_type: 'run_analysis',
+      // The SAME spread-omit convention every commit site uses.
+      ...(normalised !== undefined ? { parameters: { goal_threshold: normalised } } : {}),
+    },
+  }
+  const build = buildV5Payload(input)
+  if (!build.ok) throw new Error('payload build failed: ' + JSON.stringify(build))
+  const fetchImpl = makeFetchImpl()
+  await callV5Turn(build.payload, { fetchImpl })
+  expect(fetchImpl).toHaveBeenCalledTimes(1)
+  const init = fetchImpl.mock.calls[0][1] as { body: string }
+  return JSON.parse(init.body) as {
+    chip?: { action_type?: string; parameters?: Record<string, unknown> }
+  }
+}
+
+describe('goal_threshold chip → HTTP body (the wire is the truth)', () => {
+  const goalNode = (data: Record<string, unknown>) => [{ id: 'goal_1', data }]
+
+  it('producer cap: raw 200 with analysis_ready cap 1000 reaches the body as EXACTLY 0.2', async () => {
+    const normalised = resolveChipGoalThreshold(200, {
+      analysisReady: { goal_threshold_cap: 1000 },
+      nodes: goalNode({}),
+      goalNodeId: 'goal_1',
+    })
+    const body = await wireBodyForThreshold(normalised)
+    expect(body.chip?.parameters?.goal_threshold).toBe(0.2)
+  })
+
+  it('node cap: raw 60 with goal-node scale_max 100 reaches the body as 0.6', async () => {
+    const normalised = resolveChipGoalThreshold(60, {
+      analysisReady: null,
+      nodes: goalNode({ scale_max: 100 }),
+      goalNodeId: 'goal_1',
+    })
+    const body = await wireBodyForThreshold(normalised)
+    expect(body.chip?.parameters?.goal_threshold).toBe(0.6)
+  })
+
+  it('unit cap (UI-SEM-081, provenance-guarded): raw 60 with a saved 60-% measure reaches the body as 0.6', async () => {
+    const normalised = resolveChipGoalThreshold(60, {
+      analysisReady: null,
+      nodes: goalNode({}),
+      goalNodeId: 'goal_1',
+      unitCap: resolveMeasureUnitCap({ threshold: 60, unit: '%' }, 60),
+    })
+    const body = await wireBodyForThreshold(normalised)
+    expect(body.chip?.parameters?.goal_threshold).toBe(0.6)
+  })
+
+  it('fail-closed omission: raw 60 with NO cap → the body carries NO parameters key at all (never raw)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const normalised = resolveChipGoalThreshold(60, {
+      analysisReady: null,
+      nodes: goalNode({}),
+      goalNodeId: 'goal_1',
+    })
+    expect(normalised).toBeUndefined()
+    const body = await wireBodyForThreshold(normalised)
+    expect(body.chip).toBeDefined()
+    expect(body.chip).not.toHaveProperty('parameters')
+    expect(JSON.stringify(body)).not.toContain('goal_threshold')
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('ULP boundary: a threshold exactly at the cap reaches the body as exactly 1', async () => {
+    const normalised = resolveChipGoalThreshold(0.1 + 0.2, {
+      analysisReady: { goal_threshold_cap: 0.3 },
+      nodes: goalNode({}),
+      goalNodeId: 'goal_1',
+    })
+    const body = await wireBodyForThreshold(normalised)
+    expect(body.chip?.parameters?.goal_threshold).toBe(1)
+  })
+})

--- a/src/canvas/hooks/__tests__/goalThreshold.parity.spec.ts
+++ b/src/canvas/hooks/__tests__/goalThreshold.parity.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Lane 1 — V2/V5 goal-threshold parity REGRESSION PIN.
+ *
+ * Both legs are compositions of the same helpers today, so this grid is
+ * tautological by construction — that is the point: it fails the day
+ * someone forks one leg (adds rounding, changes the cap chain, forgets the
+ * measure unit-cap on one side), which is exactly how the July-13 P0 class
+ * arose (the V5 leg was added without the V2 leg's normalisation, then the
+ * V2 leg initially missed the unit cap the V5 leg gained). This pin is NOT
+ * the canonical spec — two matching legs can both be wrong; the wire test
+ * (goalThreshold.chipToWire.spec.ts) is the truth.
+ *
+ * V2 leg (useV2Run.runV2Analysis): normaliseGoalThresholdForRequest(raw,
+ *   resolveGoalThresholdCap(...) ?? resolveMeasureUnitCap(measure, raw))
+ * V5 leg (commit sites + canonical default-attach):
+ *   resolveChipGoalThreshold(raw, { ..., unitCap: resolveMeasureUnitCap(measure, raw) })
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import {
+  normaliseGoalThresholdForRequest,
+  resolveGoalThresholdCap,
+  resolveChipGoalThreshold,
+  resolveMeasureUnitCap,
+} from '../useV2Run'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+type Case = {
+  name: string
+  raw: number | null
+  analysisReady: { goal_threshold_cap?: unknown } | null
+  nodeData: Record<string, unknown>
+  measure: { threshold: number; unit: string } | null
+  expected: number | undefined
+}
+
+const CASES: Case[] = [
+  { name: 'producer cap (200 / 1000)', raw: 200, analysisReady: { goal_threshold_cap: 1000 }, nodeData: {}, measure: null, expected: 0.2 },
+  { name: 'node scale_max cap (60 / 100)', raw: 60, analysisReady: null, nodeData: { scale_max: 100 }, measure: null, expected: 0.6 },
+  { name: 'node threshold_cap beats scale_max', raw: 30, analysisReady: null, nodeData: { threshold_cap: 60, scale_max: 100 }, measure: null, expected: 0.5 },
+  { name: 'at-cap → exactly 1', raw: 25, analysisReady: { goal_threshold_cap: 25 }, nodeData: {}, measure: null, expected: 1 },
+  { name: 'ULP at cap → exactly 1', raw: 0.1 + 0.2, analysisReady: { goal_threshold_cap: 0.3 }, nodeData: {}, measure: null, expected: 1 },
+  { name: 'above cap → both omit', raw: 30, analysisReady: { goal_threshold_cap: 25 }, nodeData: {}, measure: null, expected: undefined },
+  { name: 'already normalised, no cap → passthrough', raw: 0.6, analysisReady: null, nodeData: {}, measure: null, expected: 0.6 },
+  { name: 'raw with no cap → both omit (fail closed)', raw: 60, analysisReady: null, nodeData: {}, measure: null, expected: undefined },
+  { name: 'unit cap with provenance (60 + 60-% measure)', raw: 60, analysisReady: null, nodeData: {}, measure: { threshold: 60, unit: '%' }, expected: 0.6 },
+  { name: 'unit cap DENIED without provenance (0.6 vs 60-% measure) → passthrough not ÷100', raw: 0.6, analysisReady: null, nodeData: {}, measure: { threshold: 60, unit: '%' }, expected: 0.6 },
+  { name: 'producer cap WINS over unit cap', raw: 60, analysisReady: { goal_threshold_cap: 200 }, nodeData: {}, measure: { threshold: 60, unit: '%' }, expected: 0.3 },
+  { name: 'null threshold → both omit', raw: null, analysisReady: { goal_threshold_cap: 100 }, nodeData: {}, measure: null, expected: undefined },
+]
+
+describe('V2 leg ≡ V5 leg for every (raw, cap-context, measure)', () => {
+  it.each(CASES)('$name', ({ raw, analysisReady, nodeData, measure, expected }) => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const nodes = [{ id: 'goal_1', data: nodeData }]
+    const unitCap = resolveMeasureUnitCap(measure, raw)
+
+    // V2 leg — the exact composition runV2Analysis performs.
+    const v2 = normaliseGoalThresholdForRequest(
+      raw,
+      resolveGoalThresholdCap(analysisReady, nodes, 'goal_1') ?? unitCap,
+    )
+    // V5 leg — the exact composition the chip sites perform.
+    const v5 = resolveChipGoalThreshold(raw, {
+      analysisReady,
+      nodes,
+      goalNodeId: 'goal_1',
+      unitCap,
+    })
+
+    expect(Object.is(v2, v5)).toBe(true)
+    expect(v5).toBe(expected)
+  })
+})


### PR DESCRIPTION
## What

Pure test adds (no product code) closing the exact coverage gaps the July-13 audits named — the P0s (raw units B3, V-P0-1) lived **between** the unit-tested halves: modal specs stopped at the runner-mock boundary, wire specs asserted hand-built payloads, and no test tied a chip commit to the actual HTTP body.

1. **`goalThreshold.chipToWire.spec.ts`** — the canonical seam test: real `resolveChipGoalThreshold` → real `buildV5Payload` → real `callV5Turn(fetchImpl)`, asserting on `JSON.parse(init.body)`. Cases: producer cap (0.2 exact), node `scale_max` cap, provenance-guarded unit cap (UI-SEM-081), **fail-closed omission** (no `parameters` key; `goal_threshold` absent from the raw body string), ULP-at-cap → exactly 1.
   *Placement note:* lives under `canvas/hooks/__tests__` deliberately — a `src/v5`-located spec importing `useV2Run` drags the canvas/adapter graph into `tsconfig.ci.json`'s scope and surfaces its pre-existing wide-baseline errors (the same documented constraint as `responseParser.actionTypeAlias.spec.ts`). Header comment records this.
2. **`useConversation.hook.spec.ts`** (+2 tests) — `dispatchAction` → **real** V5 payload: `parameters.goal_threshold` rides `payload.chip` verbatim; a no-parameters dispatch builds a chip with NO `parameters` key. This dispatch→payload hop previously had zero coverage (the audit's finding).
3. **`goalThreshold.parity.spec.ts`** — 12-case grid pinning V2 leg ≡ V5 leg (`Object.is`), including the unit-cap provenance cases from #304's review folds. Explicitly a **regression pin** against the legs forking — not the canonical spec (two matching legs can both be wrong; the wire test is the truth).

## Outcome

All pins are **green on current behaviour** — per the approved plan, RED here would have meant a newly discovered bug (stop-and-flag). The store↔node atomic pins from this lane's original scope landed early in #304.

## Gates

typecheck pass · targeted suites 17+58 green · changed-set vitest green · lint 0 errors · fast pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)