### PR TITLE
fix(results): Lane 2 — influence-policy bypasses fixed + two-layer guard (Codex R3-B1 class)

### DIFF
--- a/eslint-rules/no-raw-influence-fallback.js
+++ b/eslint-rules/no-raw-influence-fallback.js
@@ -1,0 +1,85 @@
+/**
+ * ESLint rule: no-raw-influence-fallback (Lane 2, Codex R3-B1 class)
+ *
+ * The driver "influence" a surface displays or ranks by MUST come from the
+ * shared display policy (src/components/results/driverDisplayModel.ts —
+ * stamped onto DriverItem.displayInfluence). Reading the RAW metrics
+ * (`influenceScore` / `normalisedInfluence`) as a decision basis silently
+ * mixes incomparable bases under partial producer coverage: the tornado,
+ * the Triage nudge, the strengthen LEHI gate and the model-tab factor map
+ * all had this bug.
+ *
+ * This rule is the FAST-GATE layer (changed-files lint on pre-push): it
+ * flags the raw metric used as a DECISION value —
+ *   - left operand of a `??` fallback chain (the canonical sanctioned chain
+ *     `displayInfluence ?? influenceScore ?? normalisedInfluence` keeps raw
+ *     members as RIGHT operands only, so it does not fire; a wrong-ordered
+ *     chain does),
+ *   - either side of a comparison / arithmetic BinaryExpression (gates,
+ *     thresholds, sort comparators).
+ * Plain property *creation* (adapters mapping wire fields) and presence
+ * probes (`typeof x.influenceScore`, `Number.isFinite(...)`) do not fire.
+ *
+ * The whole-tree enforcing net is the vitest tripwire
+ * (src/components/results/__tests__/no-raw-influence-read.spec.ts), which
+ * also catches bare reads this AST rule deliberately leaves to it.
+ *
+ * Deliberate exception: the V17 dominance GATE (UI-SEM-040) uses absolute /
+ * ratio thresholds over the raw metrics — exempted via inline
+ * eslint-disable with the UI-SEM-040 rationale at the site.
+ */
+
+const RAW_PROPS = new Set(['influenceScore', 'normalisedInfluence'])
+
+function unwrapChain(node) {
+  return node && node.type === 'ChainExpression' ? node.expression : node
+}
+
+function isRawMember(node) {
+  const n = unwrapChain(node)
+  return (
+    n &&
+    n.type === 'MemberExpression' &&
+    !n.computed &&
+    n.property.type === 'Identifier' &&
+    RAW_PROPS.has(n.property.name)
+  )
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Raw influence metrics must not be a decision basis — read displayInfluence (driverDisplayModel policy) instead',
+      recommended: true,
+    },
+    messages: {
+      rawDecision:
+        'Raw "{{prop}}" used as a decision value ({{context}}). Read displayInfluence ' +
+        '(stamped by selectDriverDisplayModel) — raw metrics mix incomparable bases ' +
+        'under partial producer coverage (Codex R3-B1). For a true adapter/gate, add ' +
+        'an inline disable with the rationale (see UI-SEM-040 in buildAnalysisHeroViewModel).',
+    },
+    schema: [],
+  },
+  create(context) {
+    function report(node, ctx) {
+      const n = unwrapChain(node)
+      context.report({
+        node: n,
+        messageId: 'rawDecision',
+        data: { prop: n.property.name, context: ctx },
+      })
+    }
+    return {
+      "LogicalExpression[operator='??']"(node) {
+        if (isRawMember(node.left)) report(node.left, 'first basis of a ?? fallback chain')
+      },
+      BinaryExpression(node) {
+        if (isRawMember(node.left)) report(node.left, 'comparison/arithmetic')
+        if (isRawMember(node.right)) report(node.right, 'comparison/arithmetic')
+      },
+    }
+  },
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import parser from '@typescript-eslint/parser'
 import reactHooks from 'eslint-plugin-react-hooks'
 import noRawColors from './eslint-rules/no-raw-colors.js'
 import noBareLightBg from './eslint-rules/no-bare-light-bg.js'
+import noRawInfluenceFallback from './eslint-rules/no-raw-influence-fallback.js'
 import noPayloadLogging from './eslint-rules/no-payload-logging.js'
 import noDangerousBrowser from './eslint-rules/no-dangerous-browser.js'
 import noCorsWildcard from './eslint-rules/no-cors-wildcard.js'
@@ -176,6 +177,11 @@ export default [
           'no-unsafe-innerhtml': noUnsafeInnerhtml,
         },
       },
+      'driver-policy': {
+        rules: {
+          'no-raw-influence-fallback': noRawInfluenceFallback,
+        },
+      },
       // React Hooks plugin for exhaustive-deps rule
       'react-hooks': reactHooks,
     },
@@ -225,6 +231,15 @@ export default [
       'security/no-cors-wildcard': 'error',
       'security/no-old-imports': 'error',
       'security/no-unsafe-innerhtml': 'error',
+
+      // Lane 2 (Codex R3-B1 class): raw influence metrics must not be a
+      // DECISION basis — the display value comes from driverDisplayModel
+      // (stamped displayInfluence). ERROR severity deliberately (the
+      // pre-push gate runs eslint without --max-warnings, so a warn-level
+      // guard would never block). The whole-tree net is the vitest tripwire
+      // no-raw-influence-read.spec.ts; deliberate exceptions carry inline
+      // disables with a UI-SEM rationale (see buildAnalysisHeroViewModel).
+      'driver-policy/no-raw-influence-fallback': 'error',
     },
   },
   // Tests: allow raw colors, console, and restricted syntax (used in assertions and test output)
@@ -237,6 +252,18 @@ export default [
       'brand-tokens/no-bare-light-bg': 'off',
       'no-console': 'off',
       'no-restricted-syntax': 'off',
+      // Specs/fixtures legitimately build divergent raw/display fixtures.
+      'driver-policy/no-raw-influence-fallback': 'off',
+    },
+  },
+  // Gallery/mock fixture hooks: emulate the PRE-R3 hook (raw fallback chains
+  // by design) and feed only the fixture gallery, never a live surface.
+  // Unifying them onto the policy is the declared Lane 2-F follow-up — until
+  // then the drift risk is test-only.
+  {
+    files: ['src/__fixtures__/**'],
+    rules: {
+      'driver-policy/no-raw-influence-fallback': 'off',
     },
   },
   // Type definition and stub files: ignore unused variable rules

--- a/src/canvas/components/model-tab/__tests__/deriveFactorInfluenceMap.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/deriveFactorInfluenceMap.spec.ts
@@ -50,7 +50,28 @@ describe('deriveFactorInfluenceMap', () => {
     expect(map!.get('fac_market_receptivity')).toBeCloseTo(0.6209677419354838)
   })
 
-  it('falls back to elasticity/sensitivity_score/importance_score when influence_score is absent (legacy shape)', () => {
+  it('Lane 2 (R3-B1): PARTIAL producer coverage falls back to per-set normalised elasticity for EVERY factor — no mixed basis', () => {
+    // The complete-metric-set doctrine (driverDisplayModel): adopting the
+    // producer score for SOME factors while others use elasticity mixes two
+    // incomparable bases in one ranking — the exact bug the panel, badge,
+    // hero and tornado were cured of. The model-tab card sits next to the
+    // graph badge for the SAME node; they must agree.
+    const map = deriveFactorInfluenceMap({
+      factor_sensitivity: [
+        { factor_id: 'fac_a', influence_score: 0.9, elasticity: 0.1 },
+        { factor_id: 'fac_b', elasticity: 0.4 },
+      ],
+    })
+
+    expect(map!.get('fac_a')).toBeCloseTo(0.25) // 0.1 / 0.4 — NOT the lone 0.9
+    expect(map!.get('fac_b')).toBeCloseTo(1.0)
+  })
+
+  it('DELIBERATE PIN FLIP (Lane 2): the legacy shape (no influence_score anywhere) now yields SET-NORMALISED values via the shared policy', () => {
+    // Previously raw passthrough (0.4 / 0.25 / 0.1). Under the shared
+    // driverDisplayModel the no-producer-coverage case normalises to the
+    // set's max |elasticity| — the same numbers the graph badge shows for
+    // these factors.
     const map = deriveFactorInfluenceMap({
       factor_sensitivity: [
         { factor_id: 'fac_legacy_elasticity', elasticity: 0.4 },
@@ -59,9 +80,9 @@ describe('deriveFactorInfluenceMap', () => {
       ],
     })
 
-    expect(map!.get('fac_legacy_elasticity')).toBe(0.4)
-    expect(map!.get('fac_legacy_sensitivity')).toBe(0.25)
-    expect(map!.get('fac_legacy_importance')).toBe(0.1)
+    expect(map!.get('fac_legacy_elasticity')).toBeCloseTo(1.0)
+    expect(map!.get('fac_legacy_sensitivity')).toBeCloseTo(0.625)
+    expect(map!.get('fac_legacy_importance')).toBeCloseTo(0.25)
   })
 
   it('reads from enrichment.sensitivity_analysis.factors when factor_sensitivity is absent', () => {

--- a/src/canvas/components/model-tab/__tests__/deriveFactorInfluenceMap.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/deriveFactorInfluenceMap.spec.ts
@@ -85,6 +85,39 @@ describe('deriveFactorInfluenceMap', () => {
     expect(map!.get('fac_legacy_importance')).toBeCloseTo(0.25)
   })
 
+  it('Lane 2 review fold: factor_sensitivity WINS over the enrichment passthrough when both exist (badge parity)', () => {
+    // useNodeDisplayMetadata (the graph badge) prefers certified
+    // factor_sensitivity; if this map preferred the untyped enrichment seam
+    // the two surfaces could rank different row-sets for the same node.
+    const map = deriveFactorInfluenceMap({
+      factor_sensitivity: [{ factor_id: 'fac_x', influence_score: 0.9 }],
+      enrichment: {
+        sensitivity_analysis: {
+          factors: [{ factor_id: 'fac_x', influence_score: 0.1 }],
+        },
+      },
+    })
+
+    expect(map!.get('fac_x')).toBeCloseTo(0.9)
+  })
+
+  it('Lane 2 review fold: camelCase influenceScore is IGNORED (panel parity — snake_case only decides coverage)', () => {
+    // The panel reads snake_case influence_score only; a feeder accepting
+    // camelCase would compute a different coverage-complete verdict for the
+    // same rows. Camel-only rows fall back to the elasticity chain.
+    const map = deriveFactorInfluenceMap({
+      factor_sensitivity: [
+        { factor_id: 'fac_camel', influenceScore: 0.9, elasticity: 0.1 },
+        { factor_id: 'fac_snake', influence_score: 0.5, elasticity: 0.4 },
+      ],
+    })
+
+    // fac_camel has NO snake producer score → partial coverage → both
+    // normalise to the set max |elasticity| (0.4).
+    expect(map!.get('fac_camel')).toBeCloseTo(0.25)
+    expect(map!.get('fac_snake')).toBeCloseTo(1.0)
+  })
+
   it('reads from enrichment.sensitivity_analysis.factors when factor_sensitivity is absent', () => {
     const map = deriveFactorInfluenceMap({
       enrichment: {

--- a/src/canvas/components/model-tab/utils.ts
+++ b/src/canvas/components/model-tab/utils.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ObservedState } from './types'
-import { selectDriverDisplayModel } from '../../../components/results/driverDisplayModel'
+import { selectDriverDisplayModel, extractPolicyRow } from '../../../components/results/driverDisplayModel'
 import {
   GENERIC_PLACEHOLDER_UNITS,
   CURRENCY_SYMBOLS,
@@ -138,28 +138,20 @@ export function deriveFactorInfluenceMap(report: unknown): Map<string, number> |
   const r = report as Record<string, unknown>
   const enrichment = r.enrichment as Record<string, unknown> | undefined
   const sensitivityAnalysis = enrichment?.sensitivity_analysis as Record<string, unknown> | undefined
-  const factors = (sensitivityAnalysis?.factors as unknown[] | undefined) ??
-    (r.factor_sensitivity as unknown[] | undefined) ??
+  // Source precedence matches the graph badge (useNodeDisplayMetadata):
+  // certified factor_sensitivity FIRST, the untyped enrichment passthrough
+  // as fallback (Lane 2 review fold — the two surfaces must rank the same
+  // row-set for the same node).
+  const factors = (r.factor_sensitivity as unknown[] | undefined) ??
+    (sensitivityAnalysis?.factors as unknown[] | undefined) ??
     []
   if (!Array.isArray(factors) || factors.length === 0) return undefined
 
-  const rows: Array<{ key: string; influenceScore?: number | null; rawElasticity: number }> = []
-  for (const raw of factors) {
-    if (raw == null || typeof raw !== 'object') continue
-    const f = raw as Record<string, unknown>
-    const id = (f.factor_id ?? f.factorId ?? f.node_id ?? f.nodeId) as string | undefined
-    if (!id) continue
-    const producer = (f.influence_score ?? f.influenceScore) as number | undefined
-    const legacy = (f.elasticity ?? f.sensitivity_score ?? f.importance_score) as number | undefined
-    const hasProducer = typeof producer === 'number' && Number.isFinite(producer)
-    const hasLegacy = typeof legacy === 'number' && Number.isFinite(legacy)
-    if (!hasProducer && !hasLegacy) continue // no usable metric — absent, never defaulted
-    rows.push({
-      key: id,
-      influenceScore: hasProducer ? producer : null,
-      rawElasticity: hasLegacy ? legacy : 0,
-    })
-  }
+  // Rows come from the SHARED extractor (panel-parity field semantics) so
+  // the coverage-complete verdict cannot skew per surface.
+  const rows = factors
+    .map((raw) => extractPolicyRow(raw))
+    .filter((row): row is NonNullable<ReturnType<typeof extractPolicyRow>> => row != null)
   if (rows.length === 0) return undefined
 
   const displayModel = selectDriverDisplayModel(rows)

--- a/src/canvas/components/model-tab/utils.ts
+++ b/src/canvas/components/model-tab/utils.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ObservedState } from './types'
+import { selectDriverDisplayModel } from '../../../components/results/driverDisplayModel'
 import {
   GENERIC_PLACEHOLDER_UNITS,
   CURRENCY_SYMBOLS,
@@ -111,20 +112,26 @@ export { getStrengthLabel as strengthSemanticLabel } from './strengthBands'
 
 /**
  * Derive a factor_id → influence score map for the model-tab "factor cards
- * sorted by influence" (FactorsSection). ROADMAP 1.7 (provisional_doctrine_v0):
- * `influence_score` (producer-owned, ISL/PLoT) is a DISTINCT measure from
- * sensitivity/elasticity — a pinned/intervention-overridden factor can carry
- * sensitivity 0 (options fix its value, so perturbing it moves nothing) while
- * still being the model's single most causally influential factor. Reading
- * elasticity/sensitivity_score/importance_score FIRST (the pre-fix
- * behaviour) rendered those factors' cards at 0%, the opposite of what the
- * producer said.
+ * sorted by influence" (FactorsSection) — THROUGH the shared display policy.
  *
- * Priority mirrors the doctrine already applied at
- * useNodeDisplayMetadata.ts / mapV5AnalysisToReport.ts / useResultsSectionData.ts:
- * influence_score (0-1, direct) before the legacy elasticity-flavoured
- * fallbacks. Additive read only — never derived, never defaulted; a factor
- * with no usable score is simply absent from the map.
+ * Lane 2 (Codex R3-B1 class): this function previously adopted the producer
+ * `influence_score` PER-FACTOR with elasticity-flavoured fallbacks — under
+ * partial producer coverage that mixes two incomparable bases in one
+ * ranking, and the model-tab card could contradict the graph badge for the
+ * SAME node (useNodeDisplayMetadata already ranks via selectDriverDisplayModel).
+ * Now both feed the one policy: producer influence_score is adopted only
+ * when EVERY factor carries it (complete-metric-set); otherwise every factor
+ * falls back to per-set normalised |elasticity|.
+ *
+ * ROADMAP 1.7 note (superseded in the partial case, honoured in the complete
+ * case): a pinned/intervention-overridden factor carries sensitivity 0 while
+ * being the model's most influential — with COMPLETE producer coverage (the
+ * normal staging path) its influence_score still wins, values unchanged.
+ * Under PARTIAL coverage the policy's no-mixed-basis rule wins, matching the
+ * badge/panel/hero/tornado — the trade-off the repo accepted in PR #292/#301.
+ *
+ * Absence semantics preserved: never derived, never defaulted — a factor
+ * row with NO finite metric at all is simply absent from the map.
  */
 export function deriveFactorInfluenceMap(report: unknown): Map<string, number> | undefined {
   if (report == null || typeof report !== 'object') return undefined
@@ -136,17 +143,30 @@ export function deriveFactorInfluenceMap(report: unknown): Map<string, number> |
     []
   if (!Array.isArray(factors) || factors.length === 0) return undefined
 
-  const map = new Map<string, number>()
+  const rows: Array<{ key: string; influenceScore?: number | null; rawElasticity: number }> = []
   for (const raw of factors) {
     if (raw == null || typeof raw !== 'object') continue
     const f = raw as Record<string, unknown>
     const id = (f.factor_id ?? f.factorId ?? f.node_id ?? f.nodeId) as string | undefined
-    const score = (f.influence_score ?? f.influenceScore ?? f.elasticity ?? f.sensitivity_score ?? f.importance_score) as
-      | number
-      | undefined
-    if (id && typeof score === 'number' && Number.isFinite(score)) {
-      map.set(id, score)
-    }
+    if (!id) continue
+    const producer = (f.influence_score ?? f.influenceScore) as number | undefined
+    const legacy = (f.elasticity ?? f.sensitivity_score ?? f.importance_score) as number | undefined
+    const hasProducer = typeof producer === 'number' && Number.isFinite(producer)
+    const hasLegacy = typeof legacy === 'number' && Number.isFinite(legacy)
+    if (!hasProducer && !hasLegacy) continue // no usable metric — absent, never defaulted
+    rows.push({
+      key: id,
+      influenceScore: hasProducer ? producer : null,
+      rawElasticity: hasLegacy ? legacy : 0,
+    })
+  }
+  if (rows.length === 0) return undefined
+
+  const displayModel = selectDriverDisplayModel(rows)
+  const map = new Map<string, number>()
+  for (const row of rows) {
+    const entry = displayModel.get(row.key)
+    if (entry) map.set(row.key, entry.value)
   }
   return map.size > 0 ? map : undefined
 }

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -7,7 +7,7 @@ import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { useScienceIcons } from '../hooks/useScienceIcons'
 import { useCanvasStore } from '../store'
 import { focusExistingTarget } from '../utils/focusHelpers'
-import { selectDriverDisplayModel } from '../../components/results/driverDisplayModel'
+import { selectDriverDisplayModel, compareByDisplayModel, extractPolicyRow } from '../../components/results/driverDisplayModel'
 import { typography } from '../../styles/typography'
 import { cleanFactorLabel, compactFactorLabel, formatInterventionValue, denormaliseInterventionValue, inferInterventionScaleBase, isSuppressedUnit, unwrapInterventionValue, classifyUnit, formatWinProbability, isTierLabel } from '../utils/labelUtils'
 import {
@@ -679,35 +679,36 @@ export const OptionNode = memo((props: NodeProps) => {
   const winsVia = useMemo(() => {
     if (!isPostAnalysis || !isRecommended || !resultsReport) return null
     const report = resultsReport as any
-    const sensitivity = report?.enrichment?.sensitivity_analysis?.factors ?? report?.factor_sensitivity ?? []
+    // Source precedence matches the graph badge (useNodeDisplayMetadata):
+    // certified factor_sensitivity FIRST, the untyped enrichment passthrough
+    // as fallback — so this card can never rank a different row-set than the
+    // badge on the same canvas (Lane 2 review fold).
+    const sensitivity = report?.factor_sensitivity ?? report?.enrichment?.sensitivity_analysis?.factors ?? []
     if (!Array.isArray(sensitivity) || sensitivity.length === 0) return null
 
     // Lane 2 (policy + honesty): rank via the SHARED driver display policy —
     // this previously ranked by raw |elasticity| (option-scoped) and then
     // asserted a GLOBAL "#1 driver", crowning a factor the same screen's
-    // drivers panel ranked 4th at 17% (live 2026-07-13). The copy may claim
-    // "#1 driver" ONLY when the chosen lever IS the policy's global #1;
-    // otherwise it is honestly the option's biggest lever.
+    // drivers panel ranked 4th at 17% (live 2026-07-13). Rows come from the
+    // SHARED extractor so the coverage verdict cannot skew per surface. The
+    // copy may claim "#1 driver" ONLY when the chosen lever IS the policy's
+    // global #1 (shared tie-break, non-zero); otherwise it is honestly the
+    // option's biggest lever.
     const rows = sensitivity
-      .map((f: any) => {
-        const id = (f.factor_id || f.factorId || f.node_id || f.nodeId) as string | undefined
-        if (!id) return null
-        const producer = f.influence_score ?? f.influenceScore
-        return {
-          key: id,
-          influenceScore:
-            typeof producer === 'number' && Number.isFinite(producer) ? producer : null,
-          rawElasticity: Math.abs(f.elasticity ?? f.sensitivity_score ?? f.importance_score ?? 0),
-        }
-      })
-      .filter((r: { key: string } | null): r is { key: string; influenceScore: number | null; rawElasticity: number } => r != null)
+      .map((f: unknown) => extractPolicyRow(f))
+      .filter((r: ReturnType<typeof extractPolicyRow>): r is NonNullable<ReturnType<typeof extractPolicyRow>> => r != null)
     if (rows.length === 0) return null
 
     const displayModel = selectDriverDisplayModel(rows)
     const ranked = rows
-      .map((r) => ({ id: r.key, value: displayModel.get(r.key)?.value ?? 0 }))
-      .sort((a, b) => b.value - a.value)
-    const globalTopId = ranked[0]?.id
+      .map((r) => ({
+        id: r.key,
+        value: displayModel.get(r.key)?.value ?? 0,
+        elasticity: r.rawElasticity,
+        key: r.key,
+      }))
+      .sort(compareByDisplayModel)
+    const globalTopId = ranked[0] && ranked[0].value > 0 ? ranked[0].id : null
 
     const ceeOption = ceeAnalysisReady?.options?.find(opt => opt.id === props.id)
     const interventionKeys = new Set(Object.keys(ceeOption?.interventions ?? {}))
@@ -719,7 +720,7 @@ export const OptionNode = memo((props: NodeProps) => {
           return {
             id: f.id,
             label: cleanFactorLabel((factorNode.data?.label as string) ?? '') || ((factorNode.data?.label as string) ?? ''),
-            isGlobalTop: f.id === globalTopId,
+            isGlobalTop: globalTopId !== null && f.id === globalTopId,
           }
         }
       }

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -7,6 +7,7 @@ import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { useScienceIcons } from '../hooks/useScienceIcons'
 import { useCanvasStore } from '../store'
 import { focusExistingTarget } from '../utils/focusHelpers'
+import { selectDriverDisplayModel } from '../../components/results/driverDisplayModel'
 import { typography } from '../../styles/typography'
 import { cleanFactorLabel, compactFactorLabel, formatInterventionValue, denormaliseInterventionValue, inferInterventionScaleBase, isSuppressedUnit, unwrapInterventionValue, classifyUnit, formatWinProbability, isTierLabel } from '../utils/labelUtils'
 import {
@@ -681,23 +682,44 @@ export const OptionNode = memo((props: NodeProps) => {
     const sensitivity = report?.enrichment?.sensitivity_analysis?.factors ?? report?.factor_sensitivity ?? []
     if (!Array.isArray(sensitivity) || sensitivity.length === 0) return null
 
-    const rankedFactors = [...sensitivity]
-      .map((f: any) => ({
-        id: (f.factor_id || f.factorId || f.node_id || f.nodeId) as string | undefined,
-        score: Math.abs(f.elasticity ?? f.sensitivity_score ?? f.importance_score ?? 0),
-      }))
-      .sort((a, b) => b.score - a.score)
+    // Lane 2 (policy + honesty): rank via the SHARED driver display policy —
+    // this previously ranked by raw |elasticity| (option-scoped) and then
+    // asserted a GLOBAL "#1 driver", crowning a factor the same screen's
+    // drivers panel ranked 4th at 17% (live 2026-07-13). The copy may claim
+    // "#1 driver" ONLY when the chosen lever IS the policy's global #1;
+    // otherwise it is honestly the option's biggest lever.
+    const rows = sensitivity
+      .map((f: any) => {
+        const id = (f.factor_id || f.factorId || f.node_id || f.nodeId) as string | undefined
+        if (!id) return null
+        const producer = f.influence_score ?? f.influenceScore
+        return {
+          key: id,
+          influenceScore:
+            typeof producer === 'number' && Number.isFinite(producer) ? producer : null,
+          rawElasticity: Math.abs(f.elasticity ?? f.sensitivity_score ?? f.importance_score ?? 0),
+        }
+      })
+      .filter((r: { key: string } | null): r is { key: string; influenceScore: number | null; rawElasticity: number } => r != null)
+    if (rows.length === 0) return null
+
+    const displayModel = selectDriverDisplayModel(rows)
+    const ranked = rows
+      .map((r) => ({ id: r.key, value: displayModel.get(r.key)?.value ?? 0 }))
+      .sort((a, b) => b.value - a.value)
+    const globalTopId = ranked[0]?.id
 
     const ceeOption = ceeAnalysisReady?.options?.find(opt => opt.id === props.id)
     const interventionKeys = new Set(Object.keys(ceeOption?.interventions ?? {}))
 
-    for (const f of rankedFactors) {
-      if (f.id && interventionKeys.has(f.id)) {
+    for (const f of ranked) {
+      if (interventionKeys.has(f.id)) {
         const factorNode = nodes.find(n => n.id === f.id)
         if (factorNode) {
           return {
             id: f.id,
             label: cleanFactorLabel((factorNode.data?.label as string) ?? '') || ((factorNode.data?.label as string) ?? ''),
+            isGlobalTop: f.id === globalTopId,
           }
         }
       }
@@ -1104,7 +1126,7 @@ export const OptionNode = memo((props: NodeProps) => {
             >
               {winsVia.label.length > 22 ? `${winsVia.label.slice(0, 22)}...` : winsVia.label}
             </button>
-            , the #1 driver
+            {winsVia.isGlobalTop ? ', the #1 driver' : ', its biggest lever'}
           </p>
         )}
 

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -1964,3 +1964,115 @@ describe('OptionNode — display coherence (audit §8)', () => {
     expect(screen.queryByTestId('option-stable-number-option-1')).toBeNull()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Lane 2 — winsVia honesty (live 2026-07-13 contradiction): the leader node
+// claimed "Leads via Design Change Scope, the #1 driver" while the SAME
+// screen's drivers panel ranked that factor 4th at 17% (real #1: Pricing
+// Page Clarity, 100%). winsVia ranked by raw elasticity, option-scoped —
+// then asserted a GLOBAL rank. It must rank via the shared display policy
+// and only claim "#1 driver" when the chosen factor IS the policy's #1.
+// ---------------------------------------------------------------------------
+
+describe('OptionNode — winsVia ranks via the display policy and never overclaims (Lane 2)', () => {
+  const FACTOR_NODES = [
+    { id: 'fac_clarity', type: 'factor', data: { label: 'Pricing Page Clarity', type: 'factor' } },
+    { id: 'fac_scope', type: 'factor', data: { label: 'Design Change Scope', type: 'factor' } },
+    { id: 'option-1', type: 'option', data: { label: 'Keep Current Page', type: 'option' } },
+    { id: 'option-2', type: 'option', data: { label: 'Full Redesign', type: 'option' } },
+  ]
+
+  const winsViaState = (opts: {
+    factors: unknown[]
+    interventions: Record<string, number>
+  }) =>
+    makeStoreState({
+      nodes: FACTOR_NODES,
+      results: {
+        status: 'complete',
+        report: {
+          robustness: { recommended_option_id: 'option-1' },
+          option_probabilities: {
+            'option-1': { win_probability: 0.54 },
+            'option-2': { win_probability: 0.45 },
+          },
+          factor_sensitivity: opts.factors,
+        },
+      },
+      ceeAnalysisReady: {
+        goal_node_id: 'goal_1',
+        options: [
+          { id: 'option-1', label: 'Keep Current Page', interventions: opts.interventions },
+          { id: 'option-2', label: 'Full Redesign', interventions: {} },
+        ],
+      },
+    })
+
+  const mountLeader = (state: ReturnType<typeof makeStoreState>) => {
+    vi.mocked(useCanvasStore).mockImplementation((selector) => selector(state as any))
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: null,
+      influence: null,
+      confidence: null,
+      inSensitivityAnalysis: false,
+      achievementProbability: null,
+      stabilityPercentage: null,
+      winRate: 0.54,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    } as never)
+    renderOption()
+  }
+
+  it('does NOT claim "#1 driver" when the leader\'s lever is not the policy #1 (live repro)', () => {
+    mountLeader(
+      winsViaState({
+        factors: [
+          // Complete producer coverage: policy adopts influence_score.
+          // Global #1 = fac_clarity (1.0); the leader only intervenes on
+          // fac_scope (0.17, rank 4-ish).
+          { factor_id: 'fac_clarity', influence_score: 1.0, elasticity: 0.9 },
+          { factor_id: 'fac_scope', influence_score: 0.17, elasticity: 0.93 },
+        ],
+        interventions: { fac_scope: 0 },
+      }),
+    )
+    expect(screen.getByText(/Leads via/)).toBeInTheDocument()
+    expect(screen.getByText('Design Change Scope')).toBeInTheDocument()
+    expect(screen.queryByText(/the #1 driver/)).toBeNull()
+    expect(screen.getByText(/its biggest lever/)).toBeInTheDocument()
+  })
+
+  it('claims "#1 driver" only when the lever IS the policy #1', () => {
+    mountLeader(
+      winsViaState({
+        factors: [
+          { factor_id: 'fac_clarity', influence_score: 1.0, elasticity: 0.9 },
+          { factor_id: 'fac_scope', influence_score: 0.17, elasticity: 0.93 },
+        ],
+        interventions: { fac_clarity: 1 },
+      }),
+    )
+    expect(screen.getByText('Pricing Page Clarity')).toBeInTheDocument()
+    expect(screen.getByText(/the #1 driver/)).toBeInTheDocument()
+  })
+
+  it('ranks candidate levers by the POLICY value, not raw elasticity', () => {
+    mountLeader(
+      winsViaState({
+        factors: [
+          // Complete coverage: policy = influence_score. Raw elasticity
+          // order is scope > clarity (0.93 > 0.9) — the OLD code picked by
+          // that and would choose fac_scope; the policy picks fac_clarity.
+          { factor_id: 'fac_clarity', influence_score: 1.0, elasticity: 0.9 },
+          { factor_id: 'fac_scope', influence_score: 0.17, elasticity: 0.93 },
+        ],
+        interventions: { fac_clarity: 1, fac_scope: 0 },
+      }),
+    )
+    expect(screen.getByText('Pricing Page Clarity')).toBeInTheDocument()
+    expect(screen.queryByText('Design Change Scope')).toBeNull()
+  })
+})

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -318,7 +318,20 @@ function T1DominantNudge({
   const topInfluence = topDriver
     ? (topDriver.displayInfluence ?? topDriver.influenceScore ?? topDriver.normalisedInfluence ?? 0)
     : 0
-  const showNudge = topInfluence >= 0.8
+  // Review fold: "drives NN% of the outcome" is an ABSOLUTE causal claim —
+  // honest only on the producer influence_score basis. Under partial
+  // coverage the display value is set-relative (top driver ≡ 1.0 by
+  // construction), so the nudge would fire on EVERY such run claiming
+  // "100% of the outcome", contradicting the V17 dominance gate
+  // (UI-SEM-040, deliberately absolute) on the same screen. No provenance
+  // marker (legacy fixture) falls back to "a finite raw producer score
+  // exists" — the pre-fold absolute semantic.
+  const absoluteBasis = topDriver
+    ? (topDriver.displayProvenance
+        ? topDriver.displayProvenance === 'influence_score'
+        : typeof topDriver.influenceScore === 'number')
+    : false
+  const showNudge = absoluteBasis && topInfluence >= 0.8
   const rawLabel = drivers.dominantFactorLabel ?? topDriver?.factorLabel ?? ''
   const dominantLabel = cleanFactorLabel(rawLabel).label
   if (!showNudge || !dominantLabel) return null

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -311,8 +311,12 @@ function T1DominantNudge({
 }) {
   const drivers = data.drivers
   const topDriver = drivers.topDrivers?.[0] ?? drivers.drivers?.[0]
+  // Lane 2 (policy): gate and phrase the nudge on the SAME display influence
+  // the panel/hero/graph/tornado show (driverDisplayModel via the stamped
+  // displayInfluence) — a raw-score read here claimed dominance the panel's
+  // own bars contradicted under partial producer coverage (Codex R3-B1 class).
   const topInfluence = topDriver
-    ? (topDriver.influenceScore ?? topDriver.normalisedInfluence ?? 0)
+    ? (topDriver.displayInfluence ?? topDriver.influenceScore ?? topDriver.normalisedInfluence ?? 0)
     : 0
   const showNudge = topInfluence >= 0.8
   const rawLabel = drivers.dominantFactorLabel ?? topDriver?.factorLabel ?? ''

--- a/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
@@ -249,7 +249,11 @@ describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + chec
       <DecisionConfidencePanel
         data={makeData({
           drivers: [
-            makeDriver({ influenceScore: 0.95, displayInfluence: 0.6 }),
+            makeDriver({
+              influenceScore: 0.95,
+              displayInfluence: 0.6,
+              displayProvenance: 'normalised_elasticity',
+            }),
           ],
           dominantFactorLabel: 'Pricing',
         })}
@@ -258,12 +262,39 @@ describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + chec
     expect(screen.queryByTestId('t1-dominant-nudge')).not.toBeInTheDocument()
   })
 
-  it('Lane 2 (policy divergence): nudge copy follows displayInfluence — raw 0.3 / display 0.85 → fires with "85% of the outcome"', () => {
+  it('Lane 2 (review fold): a SET-RELATIVE display value never fires the absolute dominance claim — display 1.0 (partial coverage) → suppressed', () => {
+    // Under partial coverage the top driver's display value is 1.0 BY
+    // CONSTRUCTION (set-normalised). "Drives 100% of the outcome" from that
+    // basis is a fabricated causal share — and would contradict the V17
+    // dominance gate (UI-SEM-040, absolute) on the same screen.
     render(
       <DecisionConfidencePanel
         data={makeData({
           drivers: [
-            makeDriver({ influenceScore: 0.3, displayInfluence: 0.85 }),
+            makeDriver({
+              influenceScore: 0.3,
+              displayInfluence: 1.0,
+              displayProvenance: 'normalised_elasticity',
+            }),
+          ],
+          dominantFactorLabel: 'Pricing',
+          dominantFactorId: 'node_pricing',
+        })}
+      />,
+    )
+    expect(screen.queryByTestId('t1-dominant-nudge')).not.toBeInTheDocument()
+  })
+
+  it('Lane 2 (review fold): the absolute claim fires on the PRODUCER basis — display 0.85 with influence_score provenance → "85% of the outcome"', () => {
+    render(
+      <DecisionConfidencePanel
+        data={makeData({
+          drivers: [
+            makeDriver({
+              influenceScore: 0.85,
+              displayInfluence: 0.85,
+              displayProvenance: 'influence_score',
+            }),
           ],
           dominantFactorLabel: 'Pricing',
           dominantFactorId: 'node_pricing',

--- a/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.t1D2c.spec.tsx
@@ -239,6 +239,41 @@ describe('DecisionConfidencePanel — Brief 5.8B D2c T1 flip-risk + nudge + chec
     expect(screen.queryByTestId('t1-dominant-nudge')).not.toBeInTheDocument()
   })
 
+  it('Lane 2 (policy divergence): nudge gates on displayInfluence, not raw influenceScore — raw 0.95 / display 0.6 → suppressed', () => {
+    // Under partial producer coverage the shared driverDisplayModel falls
+    // back to normalised elasticity for EVERY driver; the panel bar shows
+    // displayInfluence. A nudge keyed on the raw score would then claim a
+    // dominance the same panel's bars contradict (the tornado had exactly
+    // this bug — Codex final-audit B1).
+    render(
+      <DecisionConfidencePanel
+        data={makeData({
+          drivers: [
+            makeDriver({ influenceScore: 0.95, displayInfluence: 0.6 }),
+          ],
+          dominantFactorLabel: 'Pricing',
+        })}
+      />,
+    )
+    expect(screen.queryByTestId('t1-dominant-nudge')).not.toBeInTheDocument()
+  })
+
+  it('Lane 2 (policy divergence): nudge copy follows displayInfluence — raw 0.3 / display 0.85 → fires with "85% of the outcome"', () => {
+    render(
+      <DecisionConfidencePanel
+        data={makeData({
+          drivers: [
+            makeDriver({ influenceScore: 0.3, displayInfluence: 0.85 }),
+          ],
+          dominantFactorLabel: 'Pricing',
+          dominantFactorId: 'node_pricing',
+        })}
+      />,
+    )
+    const nudge = screen.getByTestId('t1-dominant-nudge')
+    expect(nudge).toHaveTextContent(/85% of the outcome/)
+  })
+
   it('DriversSection no longer renders any dominant-factor warning (legacy testid is gone)', () => {
     const drivers: DriverItem[] = [makeDriver({ influenceScore: 0.95 })]
     const driversData: DriversSectionData = {

--- a/src/components/results/__tests__/driverDisplayModel.spec.ts
+++ b/src/components/results/__tests__/driverDisplayModel.spec.ts
@@ -11,6 +11,7 @@ import {
   selectDriverDisplayModel,
   compareByDisplayModel,
   computeNormalisedInfluences,
+  extractPolicyRow,
 } from '../driverDisplayModel'
 
 describe('selectDriverDisplayModel — the exact Codex R3-B1 partial-coverage scenario', () => {
@@ -93,5 +94,30 @@ describe('computeNormalisedInfluences (re-homed, behaviour unchanged)', () => {
     ])
     expect(m.get('a')).toBeCloseTo(0.1)
     expect(m.get('b')).toBeCloseTo(1.0)
+  })
+})
+
+describe('extractPolicyRow — panel-parity field semantics (Lane 2 review fold)', () => {
+  it('reads snake_case influence_score only — camelCase does not decide coverage', () => {
+    expect(extractPolicyRow({ factor_id: 'a', influenceScore: 0.9, elasticity: 0.2 })).toEqual({
+      key: 'a',
+      influenceScore: null,
+      rawElasticity: 0.2,
+    })
+  })
+
+  it('magnitude chain matches the panel: elasticity → sensitivity_score → sensitivity → importance_score', () => {
+    expect(extractPolicyRow({ factor_id: 'a', sensitivity: 0.5 })!.rawElasticity).toBe(0.5)
+    expect(
+      extractPolicyRow({ factor_id: 'a', sensitivity: 0.5, sensitivity_score: 0.3 })!.rawElasticity,
+    ).toBe(0.3)
+    expect(extractPolicyRow({ factor_id: 'a', elasticity: -0.7, sensitivity: 0.5 })!.rawElasticity).toBe(0.7)
+    expect(extractPolicyRow({ factor_id: 'a', importance_score: 0.1 })!.rawElasticity).toBe(0.1)
+  })
+
+  it('returns null for id-less or metric-less rows (absence never defaulted)', () => {
+    expect(extractPolicyRow({ elasticity: 0.4 })).toBeNull()
+    expect(extractPolicyRow({ factor_id: 'a' })).toBeNull()
+    expect(extractPolicyRow(null)).toBeNull()
   })
 })

--- a/src/components/results/__tests__/no-raw-influence-read.spec.ts
+++ b/src/components/results/__tests__/no-raw-influence-read.spec.ts
@@ -93,6 +93,9 @@ function isSanctionedChain(lines: string[], i: number, matchIndex: number): bool
   const line = lines[i]
   const before = line.slice(0, matchIndex)
   if (before.includes('displayInfluence')) return true
+  // Presence probes are not decisions (same exemption as the ESLint rule):
+  // `typeof x.influenceScore` checks existence, never consumes the value.
+  if (/typeof\s+$/.test(before)) return true
   // Wrapped chains: `d.displayInfluence ??` on the previous line.
   const prev = i > 0 ? lines[i - 1] : ''
   return /displayInfluence[^]*\?\?\s*$/.test(prev.trimEnd())

--- a/src/components/results/__tests__/no-raw-influence-read.spec.ts
+++ b/src/components/results/__tests__/no-raw-influence-read.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Driver-display policy tripwire — no raw influence reads outside the policy.
+ *
+ * The July-13 Codex final audit found the tornado ordering by
+ * `influenceScore ?? normalisedInfluence`, bypassing the shared
+ * `driverDisplayModel` policy (R3-B1) — the FOURTH surface to do so — and the
+ * same evening's adversarial verification found three MORE live bypasses
+ * (TriageActionCards nudge, strengthen LEHI ranking, model-tab factor map).
+ * "Shared policy" means nothing without a net: this spec scans the results +
+ * canvas source trees and fails on any line that reads the RAW metrics
+ * (`influenceScore` / `normalisedInfluence`) without going through the policy.
+ *
+ * SAFE line: `displayInfluence` appears EARLIER on the same (or previous)
+ * line — this sanctions exactly the canonical consumer chain
+ * `displayInfluence ?? influenceScore ?? normalisedInfluence` (raw only as
+ * legacy fallback; runtime-dead, fixture-only — see Lane 2 PR) while a
+ * WRONG-ORDERED chain (`influenceScore ?? displayInfluence`) still fails.
+ *
+ * ALLOWLIST (attestation-guarded, DEFENCE_IN_DEPTH style): the policy module
+ * itself, the two adapters that FEED the policy, and the V17 dominance GATE
+ * (UI-SEM-040 — deliberately absolute-threshold semantics, not display
+ * ranking). Each entry names a regex that must still be present in the file;
+ * if the attestation disappears the exemption dies with it.
+ *
+ * Out of scope (documented, not silent): the elasticity/sensitivity_score
+ * field family (a 6th bypass of that family — OptionNode winsVia — is fixed
+ * and spec-pinned in this same lane); fixtures/specs/stories; the debug
+ * bundle (outside both scan roots).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join, relative } from 'path'
+
+const REPO_SRC = join(__dirname, '..', '..', '..')
+const SCAN_ROOTS = [
+  join(REPO_SRC, 'components', 'results'),
+  join(REPO_SRC, 'canvas'),
+]
+
+/** Skip dirs/files with no production render path. */
+const SKIP_DIR = /^(__tests__|__fixtures__|__mocks__|Debug|Advanced)$/
+const SKIP_FILE = /(\.spec\.|\.test\.|\.stories\.)/
+
+function getSourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.') || SKIP_DIR.test(entry)) continue
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      files.push(...getSourceFiles(full))
+    } else if (/\.(ts|tsx)$/.test(entry) && !SKIP_FILE.test(entry)) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+/** A raw-metric member read: `x.influenceScore`, `d?.normalisedInfluence`. */
+const RAW_MEMBER_READ = /\b[\w$)\]]+\??\.(influenceScore|normalisedInfluence)\b/
+/** Destructuring / shorthand pickup of the raw keys: `{ influenceScore }`. */
+const RAW_DESTRUCTURE = /[{,]\s*(influenceScore|normalisedInfluence)\s*[,}]/
+
+/**
+ * Allowlisted files (path RELATIVE to src/) → attestation regex that must
+ * still hold in the file source for the exemption to stand.
+ */
+const ALLOWLIST: Record<string, RegExp> = {
+  // THE policy — the only module allowed to interpret the raw metrics.
+  'components/results/driverDisplayModel.ts': /export function selectDriverDisplayModel/,
+  // Producer/adapter: builds DriverItems from the wire and stamps
+  // displayInfluence via the policy; also reads normalisedInfluence for the
+  // semantic-label thresholds the policy header explicitly sanctions.
+  'components/results/useResultsSectionData.ts': /selectDriverDisplayModel/,
+  // Graph-badge adapter: feeds raw metrics INTO the policy.
+  'canvas/hooks/useNodeDisplayMetadata.ts': /selectDriverDisplayModel/,
+  // V17 hero dominance GATE (UI-SEM-040): absolute/ratio thresholds over the
+  // raw metrics — deliberately NOT the display-ranking policy. The marker
+  // comment is the attestation; if the gate is rewritten, re-decide.
+  'components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts': /UI-SEM-040/,
+  // Model-tab factor map: post-Lane-2 an adapter that feeds the policy
+  // (reads the wire-shape camelCase fallback on its input rows).
+  'canvas/components/model-tab/utils.ts': /selectDriverDisplayModel/,
+  // OptionNode winsVia: post-Lane-2 an adapter that feeds the policy (reads
+  // the wire-shape camelCase fallback on its sensitivity rows) and claims
+  // "#1 driver" only when the lever IS the policy's global top.
+  'canvas/nodes/OptionNode.tsx': /selectDriverDisplayModel/,
+}
+
+/** SAFE when displayInfluence appears EARLIER on the same or previous line. */
+function isSanctionedChain(lines: string[], i: number, matchIndex: number): boolean {
+  const line = lines[i]
+  const before = line.slice(0, matchIndex)
+  if (before.includes('displayInfluence')) return true
+  // Wrapped chains: `d.displayInfluence ??` on the previous line.
+  const prev = i > 0 ? lines[i - 1] : ''
+  return /displayInfluence[^]*\?\?\s*$/.test(prev.trimEnd())
+}
+
+describe('driver-display policy: no raw influence reads outside the policy', () => {
+  const sourceFiles = SCAN_ROOTS.flatMap((root) => getSourceFiles(root))
+  expect(sourceFiles.length).toBeGreaterThan(50) // scan actually ran
+
+  for (const filePath of sourceFiles) {
+    const rel = relative(REPO_SRC, filePath)
+
+    it(`${rel} reads influence only through the display policy`, () => {
+      const content = readFileSync(filePath, 'utf-8')
+      // Cheap pre-filter — most files never mention the raw fields.
+      if (!/influenceScore|normalisedInfluence/.test(content)) return
+
+      const allow = ALLOWLIST[rel]
+      if (allow) {
+        if (!allow.test(content)) {
+          throw new Error(
+            `${rel} is allowlisted for raw influence reads but its attestation ` +
+              `(${allow}) is gone. Either restore it or route the file through ` +
+              `driverDisplayModel and drop the allowlist entry.`,
+          )
+        }
+        return
+      }
+
+      const lines = content.split('\n')
+      const violations: string[] = []
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+        const member = RAW_MEMBER_READ.exec(line)
+        if (member && !isSanctionedChain(lines, i, member.index)) {
+          violations.push(`  L${i + 1}: ${line.trim()}`)
+          continue
+        }
+        if (RAW_DESTRUCTURE.test(line)) {
+          violations.push(`  L${i + 1}: ${line.trim()} (destructured raw key)`)
+        }
+      }
+
+      if (violations.length > 0) {
+        throw new Error(
+          `Raw influence read(s) outside driverDisplayModel in ${rel}:\n` +
+            violations.join('\n') +
+            `\n\nRead displayInfluence (stamped by selectDriverDisplayModel) — or, ` +
+            `for a true adapter/gate, add an attestation-guarded allowlist entry ` +
+            `in no-raw-influence-read.spec.ts with the rationale.`,
+        )
+      }
+    })
+  }
+})

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -241,16 +241,22 @@ function buildDependencyLine(data: ResultsSectionDataReturn): string | null {
   const top1 = sorted[0]
   if (!top1 || top1.factorKey !== id) return null
 
-  // Dominance gate.
+  // Dominance gate (UI-SEM-040): deliberately reads the RAW metrics —
+  // absolute producer-scale threshold (0.5) and top-1:top-2 ratio (2.0) are
+  // GATE semantics, not display ranking, so the driverDisplayModel policy
+  // does not apply. This is the attestation the no-raw-influence-read
+  // tripwire keys on; if this gate is rewritten, re-decide the exemption.
   let isDominant = false
   if (typeof top1.influenceScore === 'number' && Number.isFinite(top1.influenceScore)) {
     // Absolute scale (ISL structural causal influence): 0.5 floor.
+    // eslint-disable-next-line driver-policy/no-raw-influence-fallback -- UI-SEM-040 dominance GATE: absolute producer-scale threshold, not display ranking
     isDominant = top1.influenceScore >= 0.5
   } else {
     // Relative-only data: require a clear gap between top-1 and top-2.
     const ni1 = top1.normalisedInfluence
     if (!Number.isFinite(ni1) || ni1 <= 0) return null
     const top2 = sorted[1]
+    // eslint-disable-next-line driver-policy/no-raw-influence-fallback -- UI-SEM-040 dominance GATE: top-1:top-2 ratio over the raw metric, not display ranking
     const ni2 = top2?.normalisedInfluence ?? 0
     if (ni2 > 0) {
       isDominant = (ni1 / ni2) >= 2.0

--- a/src/components/results/driverDisplayModel.ts
+++ b/src/components/results/driverDisplayModel.ts
@@ -68,6 +68,48 @@ export function computeNormalisedInfluences(
  * render and rank by `value` from this map, never `influenceScore ??
  * normalisedInfluence` (which mixes bases under partial producer coverage).
  */
+/**
+ * Shared wire-row → policy-input extractor (Lane 2 review fold): the policy
+ * FUNCTION being shared means nothing if each surface feeds it different
+ * inputs — the coverage-complete verdict and the normalisation base must be
+ * computed from the SAME fields everywhere.
+ *
+ * Field semantics mirror the drivers panel (useResultsSectionData
+ * normaliseFactorSensitivity, the reference implementation):
+ * - producer influence: snake_case `influence_score` ONLY (the panel never
+ *   reads camelCase, so accepting it elsewhere flips the coverage verdict
+ *   per surface);
+ * - magnitude chain: `elasticity` → `sensitivity_score` → `sensitivity` →
+ *   `importance_score` (the panel includes `sensitivity` third; feeders that
+ *   omitted it ranked a different row-set).
+ * Returns null when the row has no id or no finite metric at all (absence is
+ * never defaulted).
+ */
+export function extractPolicyRow(
+  raw: unknown,
+): { key: string; influenceScore: number | null; rawElasticity: number } | null {
+  if (raw == null || typeof raw !== 'object') return null
+  const f = raw as Record<string, unknown>
+  const key = (f.factor_id ?? f.factorId ?? f.node_id ?? f.nodeId) as string | undefined
+  if (!key) return null
+  const producer =
+    typeof f.influence_score === 'number' && Number.isFinite(f.influence_score)
+      ? f.influence_score
+      : null
+  const magnitude =
+    typeof f.elasticity === 'number' ? f.elasticity
+      : typeof f.sensitivity_score === 'number' ? f.sensitivity_score
+        : typeof f.sensitivity === 'number' ? f.sensitivity
+          : typeof f.importance_score === 'number' ? f.importance_score
+            : null
+  if (producer === null && magnitude === null) return null
+  return {
+    key,
+    influenceScore: producer,
+    rawElasticity: magnitude === null || !Number.isFinite(magnitude) ? 0 : Math.abs(magnitude),
+  }
+}
+
 export function selectDriverDisplayModel(
   factors: ReadonlyArray<{ key: string; influenceScore?: number | null; rawElasticity: number }>,
 ): Map<string, DriverDisplayEntry> {

--- a/src/components/results/strengthen/StrengthenContainer.tsx
+++ b/src/components/results/strengthen/StrengthenContainer.tsx
@@ -107,7 +107,11 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
       factors: data.drivers.drivers.map((d) => ({
         factorId: d.matchedNodeId ?? d.factorKey,
         label: d.factorLabel,
-        influenceScore: d.influenceScore,
+        // Lane 2 (policy): the engine ranks/gates on the SAME display value
+        // the panel bars show — displayInfluence is stamped by
+        // selectDriverDisplayModel; raw influenceScore only as legacy
+        // fallback (runtime-dead, fixture-only).
+        influence: d.displayInfluence ?? d.influenceScore,
         confidence: d.confidence ?? null,
         // Producer flag threaded through the drivers VM (factor_sensitivity
         // row or robustness VOI suggestion joined by factor id) — strict

--- a/src/components/results/strengthen/__tests__/StrengthenContainer.spec.tsx
+++ b/src/components/results/strengthen/__tests__/StrengthenContainer.spec.tsx
@@ -95,6 +95,59 @@ describe('StrengthenContainer — worth_investigating threading', () => {
   })
 })
 
+describe('StrengthenContainer — LEHI keys on the DISPLAY influence policy (Lane 2)', () => {
+  it('policy divergence: raw 0.9 / display 0.2 → below the LEHI floor, no rec', () => {
+    // Under partial producer coverage the shared driverDisplayModel ranks by
+    // normalised elasticity; a LEHI gate on the raw score would flag a
+    // factor the panel's own bars show as weak (Codex R3-B1 class).
+    render(
+      <StrengthenContainer
+        data={makeData({
+          goalThreshold: 62,
+          drivers: [
+            {
+              factorKey: 'fac_div',
+              factorLabel: 'Divergent',
+              displayInfluence: 0.2,
+              influenceScore: 0.9,
+              confidence: 0.2,
+              canFocus: true,
+            },
+          ],
+        })}
+      />,
+    )
+    const lehi = selectActive(useStrengthenStore.getState()).find((r) =>
+      r.id.startsWith('strengthen:lehi:'),
+    )
+    expect(lehi).toBeUndefined()
+  })
+
+  it('policy divergence: raw 0.1 / display 0.9 → clears the floor, rec exists', () => {
+    render(
+      <StrengthenContainer
+        data={makeData({
+          goalThreshold: 62,
+          drivers: [
+            {
+              factorKey: 'fac_div2',
+              factorLabel: 'Divergent2',
+              displayInfluence: 0.9,
+              influenceScore: 0.1,
+              confidence: 0.2,
+              canFocus: true,
+            },
+          ],
+        })}
+      />,
+    )
+    const lehi = selectActive(useStrengthenStore.getState()).find((r) =>
+      r.id.startsWith('strengthen:lehi:'),
+    )
+    expect(lehi).toBeDefined()
+  })
+})
+
 describe('StrengthenContainer — producer bias signal gates broaden', () => {
   it('a CEE narrow_framing bias signal admits the broaden rec', () => {
     useCanvasStore.setState({

--- a/src/components/results/strengthen/__tests__/buildRecommendations.spec.ts
+++ b/src/components/results/strengthen/__tests__/buildRecommendations.spec.ts
@@ -62,7 +62,7 @@ describe('buildRecommendations — trigger grounding (§8.6)', () => {
     const withConfidence: StrengthenInputs = {
       ...base,
       factors: [
-        { factorId: 'f1', label: 'Engineering capacity', influenceScore: 0.8, confidence: 0.25, canFocus: true },
+        { factorId: 'f1', label: 'Engineering capacity', influence: 0.8, confidence: 0.25, canFocus: true },
       ],
     }
     const recs = buildRecommendations(withConfidence)
@@ -74,7 +74,7 @@ describe('buildRecommendations — trigger grounding (§8.6)', () => {
     // Same factor WITHOUT producer confidence → never fires (no beliefExists fallback).
     const noConfidence: StrengthenInputs = {
       ...base,
-      factors: [{ factorId: 'f1', label: 'Engineering capacity', influenceScore: 0.8, confidence: null, canFocus: true }],
+      factors: [{ factorId: 'f1', label: 'Engineering capacity', influence: 0.8, confidence: null, canFocus: true }],
     }
     expect(ids(noConfidence)).not.toContain('strengthen:lehi:f1')
   })
@@ -82,12 +82,12 @@ describe('buildRecommendations — trigger grounding (§8.6)', () => {
   it('lehi: high confidence or low influence suppresses', () => {
     const confident: StrengthenInputs = {
       ...base,
-      factors: [{ factorId: 'f1', label: 'X', influenceScore: 0.8, confidence: 0.9, canFocus: true }],
+      factors: [{ factorId: 'f1', label: 'X', influence: 0.8, confidence: 0.9, canFocus: true }],
     }
     expect(ids(confident)).not.toContain('strengthen:lehi:f1')
     const weak: StrengthenInputs = {
       ...base,
-      factors: [{ factorId: 'f1', label: 'X', influenceScore: 0.1, confidence: 0.25, canFocus: true }],
+      factors: [{ factorId: 'f1', label: 'X', influence: 0.1, confidence: 0.25, canFocus: true }],
     }
     expect(ids(weak)).not.toContain('strengthen:lehi:f1')
   })

--- a/src/components/results/strengthen/buildRecommendations.ts
+++ b/src/components/results/strengthen/buildRecommendations.ts
@@ -161,9 +161,9 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
         (f) =>
           typeof f.confidence === 'number' && // producer confidence ONLY
           f.confidence < LEHI_CONFIDENCE_CEILING &&
-          (f.influenceScore ?? 0) > LEHI_INFLUENCE_FLOOR,
+          (f.influence ?? 0) > LEHI_INFLUENCE_FLOOR,
       )
-      .sort((a, b) => (b.influenceScore ?? 0) - (a.influenceScore ?? 0))[0]
+      .sort((a, b) => (b.influence ?? 0) - (a.influence ?? 0))[0]
     if (lehi) {
       recs.push({
         id: `strengthen:lehi:${lehi.factorId}`,

--- a/src/components/results/strengthen/strengthenTypes.ts
+++ b/src/components/results/strengthen/strengthenTypes.ts
@@ -65,7 +65,13 @@ export interface StrengthenFragileEdge {
 export interface StrengthenFactor {
   factorId: string
   label: string
-  influenceScore?: number
+  /**
+   * The driver DISPLAY-POLICY value (driverDisplayModel via the stamped
+   * DriverItem.displayInfluence) — NOT raw producer influence_score. Named
+   * `influence` so a raw-metric read cannot hide behind the field name
+   * (Lane 2, Codex R3-B1 class).
+   */
+  influence?: number
   /** Producer per-factor confidence (present only on newer wires). */
   confidence?: number | null
   /** True when the producer explicitly flagged this factor worth investigating. */

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -515,6 +515,12 @@ export interface DriverItem {
    *  which mixes bases under partial producer coverage. Optional only for legacy
    *  fixtures — the live pipeline always sets it. */
   displayInfluence?: number
+  /** Which basis produced displayInfluence ('influence_score' = absolute producer
+   *  scale; 'normalised_elasticity' = set-relative). Lane 2 review fold: surfaces
+   *  making ABSOLUTE claims ("drives NN% of the outcome") must gate on this —
+   *  a set-relative 1.0 is "largest in this set", not a causal share. Optional
+   *  only for legacy fixtures — the live pipeline always sets it. */
+  displayProvenance?: 'influence_score' | 'normalised_elasticity'
   /** Producer influence_rank (1 = most influential). Additive; roadmap 1.7 (provisional_doctrine_v0). */
   influenceRank?: number
   /** ISL zero_reason - explains why sensitivity is zero for intervention factors */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1938,6 +1938,10 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           influenceScore: f.raw.influenceScore,
           // Codex R3-B1: single display basis (see DriverItem.displayInfluence)
           displayInfluence: displayModel.get(f.key)?.value ?? 0,
+          // Lane 2 review fold: basis marker so absolute-claim surfaces
+          // (Triage dominance nudge) can distinguish a producer causal share
+          // from a set-relative fallback value.
+          displayProvenance: displayModel.get(f.key)?.provenance,
           // Producer influence_rank passthrough (roadmap 1.7, provisional_doctrine_v0)
           influenceRank: f.raw.influenceRank,
           // ISL zero_reason - explains why sensitivity is zero

--- a/tests/eslint-rules/no-raw-influence-fallback.spec.ts
+++ b/tests/eslint-rules/no-raw-influence-fallback.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for driver-policy/no-raw-influence-fallback (Lane 2, Codex R3-B1
+ * class). Uses the runner-agnostic Linter API — NOTE: eslint-rules/__tests__/
+ * is NOT covered by any vitest include glob (the RuleTester spec there is
+ * never executed); tests/eslint-rules/ is the location that runs.
+ */
+import { Linter } from 'eslint'
+import { describe, it, expect } from 'vitest'
+import rule from '../../eslint-rules/no-raw-influence-fallback.js'
+
+const linter = new Linter()
+function lint(code: string) {
+  return linter.verify(code, {
+    languageOptions: { ecmaVersion: 2021, sourceType: 'module' },
+    plugins: { 'driver-policy': { rules: { 'no-raw-influence-fallback': rule } } },
+    rules: { 'driver-policy/no-raw-influence-fallback': 'error' },
+  })
+}
+
+describe('driver-policy/no-raw-influence-fallback', () => {
+  it('stays silent on the canonical sanctioned chain (raw members as RIGHT operands)', () => {
+    expect(lint('const v = d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence')).toHaveLength(0)
+  })
+
+  it('stays silent on adapter property creation and presence probes', () => {
+    expect(lint('const row = { influenceScore: f.influence_score ?? null }')).toHaveLength(0)
+    expect(lint("const has = typeof f.influenceScore === 'number'")).toHaveLength(0)
+    expect(lint('const fin = Number.isFinite(f.influenceScore)')).toHaveLength(0)
+    expect(lint('const fires = (d.displayInfluence ?? 0) >= 0.8')).toHaveLength(0)
+  })
+
+  it('flags the raw metric as FIRST basis of a ?? chain (tornado/Triage shape)', () => {
+    expect(lint('const v = d.influenceScore ?? d.normalisedInfluence ?? 0')).toHaveLength(1)
+    expect(lint('const v = d.influenceScore ?? d.displayInfluence')).toHaveLength(1)
+    expect(lint('const v = top2?.normalisedInfluence ?? 0')).toHaveLength(1)
+  })
+
+  it('flags threshold gates and sort arithmetic on the raw metric (LEHI/nudge shape)', () => {
+    expect(lint('const fires = f.influenceScore > FLOOR')).toHaveLength(1)
+    expect(lint('rows.sort((a, b) => b.influenceScore - a.influenceScore)')).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## What

Closes the bug class the July-13 audits kept finding one instance at a time. The adversarial verification proved the "nothing stops a 5th site" worry was already real: **three live bypasses** of the shared `driverDisplayModel` policy, plus a **6th in a different field family** visible on staging — the leader node crowned the 4th-ranked driver (17%) as "the #1 driver" while the same screen's drivers panel showed the real #1 at 100%.

## Fixes (each RED-first — divergence specs failed before the fix)

1. **A1 `TriageActionCardsBody`** — the ≥0.8 dominant-factor nudge gated and phrased ("drives NN% of the outcome") on raw `influenceScore ?? normalisedInfluence`; now the sanctioned `displayInfluence`-first chain. Same class as the #302 tornado P0.
2. **A2 strengthen** — the LEHI gate/rank keyed on raw score; now the policy value, and `StrengthenFactor.influenceScore` is **renamed `influence`** so a raw read can't hide behind the field name.
3. **A3 `deriveFactorInfluenceMap`** — was an independent influence policy (per-factor producer adoption, no coverage gate); now feeds `selectDriverDisplayModel`. Complete coverage (the normal staging path): **flagship fixture values unchanged**. Partial coverage: per-set normalised elasticity for every factor — the model-tab card now agrees with the graph badge for the same node. Deliberate legacy-shape pin flip documented in the spec (supersedes the ROADMAP-1.7 per-factor doctrine only in the partial case; comment rewritten honestly).
4. **A4 `OptionNode.winsVia`** — ranked by raw |elasticity| (option-scoped) then asserted a GLOBAL "#1 driver". Now ranks via the shared policy and claims "#1 driver" **only when the lever IS the policy's global top**; otherwise "its biggest lever". Live-repro pinned.

## The guard (two layers)

- **Vitest tripwire** `no-raw-influence-read.spec.ts` — walks results+canvas (864 files/test-run), flags raw member reads unless `displayInfluence` appears **earlier** on the line (a wrong-ordered chain fails) plus destructured raw keys; attestation-guarded allowlist (policy module, the two adapters, the UI-SEM-040 gate, the two new adapter sites). The **RED run flagged exactly the known bypass set** before the fixes (output in the commit narrative) — the net demonstrably catches the class.
- **ESLint `driver-policy/no-raw-influence-fallback`** (ERROR severity — deliberately not `no-restricted-syntax`, whose existing entry is warn and the pre-push gate has no `--max-warnings`): raw metric as the first `??` basis or in comparison/arithmetic. The sanctioned chain keeps raw members as right operands, so zero false positives; full `npx eslint .` is clean. V17's dominance gate carries inline disables with the UI-SEM-040 rationale; the legacy gallery fixture hooks are config-exempted pending the declared 2-F follow-up (make `displayInfluence` required, remove the tails, tighten both layers).

**Test-infra discovery:** `eslint-rules/__tests__/` is covered by NO vitest include glob — the existing `no-payload-logging.spec.js` there has never run. My RuleTester spec lives at `tests/eslint-rules/` (the location that runs); the dead spec is flagged for the backlog rather than silently moved in this lane.

## Out of scope (documented in the tripwire header)

The `elasticity`/`sensitivity_score` field family guard (A4's family) — the fix landed with a spec pin; extending the tripwire regex to that family needs its own audit of legitimate adapter reads.

## Gates

typecheck pass · changed-set vitest **1760/0** · full `npx eslint .` **0 errors** · wide-tsc-diff-vs-base **zero new messages** · fast pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)