### PR TITLE
fix(goal-threshold): Lane 5 — representation tagging + decision-context isolation + one goal resolver (Codex no-go P0s)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -75,7 +75,7 @@ import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip } from '../ut
 import { WarningBanner } from './WarningBanner'
 import { DegradedStateBanner } from './DegradedStateBanner'
 import { mapConfidenceToReadiness } from '../utils/mapConfidenceToReadiness'
-import { useV2Run, resolveChipGoalThreshold, resolveMeasureUnitCap, type V2RunPersistence } from '../hooks/useV2Run'
+import { useV2Run, resolveChipGoalThreshold, resolveMeasureUnitCap, resolveActiveGoalNodeId, type V2RunPersistence } from '../hooks/useV2Run'
 import {
   useSuccessMeasureStore,
   selectSuccessMeasure,
@@ -815,15 +815,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
           const storeThreshold = resolveChipGoalThreshold(storeState.goalThreshold, {
             analysisReady: storeState.ceeAnalysisReady,
             nodes: storeState.nodes,
-            goalNodeId:
-              (storeState.ceeAnalysisReady?.goal_node_id as string | undefined) ??
-              storeState.nodes.find((n) => n.type === 'goal')?.id ??
-              null,
+            // Lane 5: one shared goal-node resolution (validated to exist) for
+            // request + cap, so V2 and V5 can never resolve different nodes.
+            goalNodeId: resolveActiveGoalNodeId(storeState),
             // Provenance-guarded (review blocker): the measure's "%" may cap
             // ONLY a store value that came from that measure — the store field
             // also receives capless NORMALISED values from CEE-sync, which a
             // blind ÷100 would shrink 100×.
             unitCap: resolveMeasureUnitCap(savedMeasure, storeState.goalThreshold),
+            // Lane 5 (Codex P0-1): a store value the bare-sync tagged
+            // 'normalised' is already 0-1 — pass it through, never divide by
+            // the node cap (that was the 0.6 → 0.006 live corruption).
+            representation: storeState.goalThresholdRepresentation,
           })
           if (storeThreshold !== undefined) {
             parameters = { goal_threshold: storeThreshold }
@@ -935,11 +938,9 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     const store = useCanvasStore.getState()
     // Codex final-audit B2 — atomic store + goal-node commit (the bare
     // setGoalThreshold updated only the global value, leaving the goal node
-    // showing "target missing" after an apply).
-    const goalNodeId =
-      (store.ceeAnalysisReady?.goal_node_id as string | undefined) ??
-      store.nodes.find((n) => n.type === 'goal')?.id ??
-      null
+    // showing "target missing" after an apply). Lane 5: one shared
+    // goal-node resolution (validated to exist).
+    const goalNodeId = resolveActiveGoalNodeId(store)
     if (goalNodeId) store.setGoalThresholdAndUpdateNode(goalNodeId, threshold)
     else setGoalThreshold(threshold)
     const now = Date.now()
@@ -967,6 +968,9 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       // scale than the saved measure — the "%" cap applies only when the
       // applied value IS the measure's value.
       unitCap: resolveMeasureUnitCap(savedMeasure, threshold),
+      // Lane 5: the inline editor commits a fresh RAW user number → keep the
+      // cap-chain conversion (never treated as pre-normalised).
+      representation: 'raw',
     })
     void runCanonicalAnalysis({
       source: 'apply-threshold',

--- a/src/canvas/hooks/__tests__/goalThreshold.representation.spec.ts
+++ b/src/canvas/hooks/__tests__/goalThreshold.representation.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Lane 5 (Codex P0-1) — goal-threshold REPRESENTATION tagging.
+ *
+ * Codex captured a live staging corruption (batch 9de778ca..7f360e84):
+ *   - CEE analysis_ready: bare NORMALISED goal_threshold 0.6 (no raw, no cap)
+ *   - goal node: raw 60, unit %, cap 100
+ * The store's bare-sync writes 0.6 into the raw-units goalThreshold field
+ * ("stored only capless, where raw ≡ normalised" — FALSE: the NODE carries
+ * the cap), then the request boundary's cap chain finds the node's cap 100
+ * and divides: 0.6 / 100 = 0.006. UI shows "Target: 60%", analysis runs at
+ * 0.6%.
+ *
+ * Root cause: raw and normalised share one untagged scalar; representation
+ * is inferred from "is a cap available", which is wrong when the cap lives
+ * on the node rather than on the value's own producer. The fix is an
+ * explicit `goalThresholdRepresentation` tag: a value tagged 'normalised'
+ * is passed through iff ∈[0,1] and NEVER divided by any cap.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { resolveChipGoalThreshold } from '../useV2Run'
+
+afterEach(() => vi.restoreAllMocks())
+
+const nodeWithCap = [{ id: 'goal_1', data: { success_threshold: 60, scale_max: 100 } }]
+
+describe('resolveChipGoalThreshold — representation-aware (Codex P0-1)', () => {
+  it('REPRODUCES the corruption when representation is unknown: a bare 0.6 + node cap 100 → 0.006', () => {
+    // Legacy/absent representation → the old cap-chain behaviour. This is
+    // the live bug: a normalised value gets divided by the node cap.
+    const result = resolveChipGoalThreshold(0.6, {
+      analysisReady: null,
+      nodes: nodeWithCap,
+      goalNodeId: 'goal_1',
+    })
+    expect(result).toBeCloseTo(0.006)
+  })
+
+  it("a value tagged 'normalised' is passed through, NEVER divided by the node cap", () => {
+    const result = resolveChipGoalThreshold(0.6, {
+      analysisReady: null,
+      nodes: nodeWithCap,
+      goalNodeId: 'goal_1',
+      representation: 'normalised',
+    })
+    expect(result).toBe(0.6)
+  })
+
+  it("a 'normalised' value outside [0,1] fails closed (omitted), never sent", () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(
+      resolveChipGoalThreshold(60, {
+        analysisReady: null,
+        nodes: nodeWithCap,
+        goalNodeId: 'goal_1',
+        representation: 'normalised',
+      }),
+    ).toBeUndefined()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it("a value tagged 'raw' keeps the cap-chain conversion (60 raw / cap 100 → 0.6)", () => {
+    const result = resolveChipGoalThreshold(60, {
+      analysisReady: null,
+      nodes: nodeWithCap,
+      goalNodeId: 'goal_1',
+      representation: 'raw',
+    })
+    expect(result).toBeCloseTo(0.6)
+  })
+
+  it("a 'normalised' value ignores even a unit cap (never double-normalises)", () => {
+    const result = resolveChipGoalThreshold(0.6, {
+      analysisReady: null,
+      nodes: [{ id: 'goal_1', data: {} }],
+      goalNodeId: 'goal_1',
+      unitCap: 100,
+      representation: 'normalised',
+    })
+    expect(result).toBe(0.6)
+  })
+})

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -97,6 +97,34 @@ export function normaliseGoalThresholdForRequest(
 }
 
 /**
+ * Lane 5 (Codex P1) — the ONE goal-node resolution used for request
+ * construction, cap lookup and threshold commitment across V2 and V5, so the
+ * legs can never resolve different nodes. Precedence: the CEE-certified
+ * `analysis_ready.goal_node_id`, then the store's `outcomeNodeId`, then the
+ * first goal node — but each candidate is validated to EXIST in the current
+ * graph, so a stale `outcomeNodeId` (retained across a scenario replacement)
+ * is skipped rather than silently resolved to a reseeded-away id.
+ *
+ * Before this, the V2 cap used `outcomeNodeId` while the adapter + V5 chip
+ * preferred `analysis_ready.goal_node_id`: with divergent ids and caps, V2
+ * could normalise against one node's cap while the request named the other.
+ */
+export function resolveActiveGoalNodeId(state: {
+  ceeAnalysisReady?: { goal_node_id?: string | null } | null
+  outcomeNodeId?: string | null
+  nodes: ReadonlyArray<{ id: string; type?: string; data?: unknown }>
+}): string | null {
+  const exists = (id: string | null | undefined): id is string =>
+    !!id && state.nodes.some((n) => n.id === id)
+  if (exists(state.ceeAnalysisReady?.goal_node_id)) return state.ceeAnalysisReady!.goal_node_id!
+  if (exists(state.outcomeNodeId)) return state.outcomeNodeId!
+  const goalNode = state.nodes.find(
+    (n) => n.type === 'goal' || (n.data as { type?: string } | undefined)?.type === 'goal',
+  )
+  return goalNode?.id ?? null
+}
+
+/**
  * Resolve the goal-threshold scale cap for the request boundary using the
  * SAME fallback chain the display path uses (useResultsSectionData
  * goalThresholdCap: analysis_ready first, then the goal node's data — CEE
@@ -171,6 +199,13 @@ export function resolveMeasureUnitCap(
  * yields no cap — live staging drafts carry neither `goal_threshold_cap` nor
  * `scale_max`, which silently swallowed every %-unit target (V-P0-1,
  * 2026-07-13 wire evidence).
+ *
+ * ctx.representation (Lane 5, Codex P0-1) makes the value's UNITS EXPLICIT
+ * rather than inferred from cap availability. A value tagged 'normalised'
+ * (the store's bare-sync writes CEE's already-0-1 goal_threshold) is passed
+ * through iff ∈[0,1] and NEVER divided by any cap — inferring "raw because a
+ * cap exists" divided a normalised 0.6 by the node's cap 100 → 0.006. A
+ * 'raw' or absent tag keeps the cap-chain conversion (backward compatible).
  */
 export function resolveChipGoalThreshold(
   rawThreshold: number | null | undefined,
@@ -179,8 +214,14 @@ export function resolveChipGoalThreshold(
     nodes: ReadonlyArray<{ id: string; data?: unknown }>
     goalNodeId: string | null | undefined
     unitCap?: number
+    representation?: 'raw' | 'normalised' | null
   },
 ): number | undefined {
+  // Lane 5: an explicitly-normalised value is already 0-1 — validate and
+  // pass through, never apply a cap (cap division is a raw→normalised op).
+  if (ctx.representation === 'normalised') {
+    return normaliseGoalThresholdForRequest(rawThreshold, undefined)
+  }
   const chainCap = resolveGoalThresholdCap(ctx.analysisReady, ctx.nodes, ctx.goalNodeId)
   const unitCap =
     typeof ctx.unitCap === 'number' && Number.isFinite(ctx.unitCap) && ctx.unitCap > 0
@@ -324,6 +365,7 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
       edges,
       outcomeNodeId,
       goalThreshold,
+      goalThresholdRepresentation,
       currentScenarioFraming: framing,
       ceeAnalysisReady,
       ceeAnalysisReadyNodeIds,
@@ -558,25 +600,30 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
       // P0 Fix: Pass computed seed to avoid hardcoded "42" default
       // Audit F-01: framing removed from PLoT request (PLoT rejects it with 400).
       // P0 Fix: Include brief for PLoT context
-      // UI-SEM-058: the store threshold is raw user units; the request wants
-      // normalised 0-1. Convert against the resolved cap (analysis_ready, then
-      // the goal node's data — the same chain the display path uses).
-      // UI-SEM-081 (review fold): the saved measure's unit is the last-resort
-      // cap here too — otherwise the V2 fallback DISAGREES with the V5 chip
-      // legs and clears the very %-target the chip carries. Provenance-guarded.
-      const goalThresholdCap = resolveGoalThresholdCap(
-        effectiveAnalysisReady as { goal_threshold_cap?: unknown } | null,
-        nodes,
-        outcomeNodeId,
-      )
+      // Lane 5: the V2 leg resolves the threshold through the SAME function as
+      // the V5 chip legs (resolveChipGoalThreshold) so the two can never
+      // disagree — same goal-node resolution (validated to exist), same cap
+      // chain (analysis_ready → node → saved-measure unit, provenance-guarded),
+      // and the same representation short-circuit (a bare-synced 'normalised'
+      // value passes through, never divided by the node cap → the 0.6/100 =
+      // 0.006 live corruption). UI-SEM-058/081 semantics preserved.
+      // Lane 5 (Codex P1): resolve the goal node ONCE and use it for BOTH the
+      // cap lookup and the request's outcome/goal node, so the threshold can
+      // never be normalised against one node's cap while the request names
+      // another. Prefers analysis_ready.goal_node_id (what the adapter also
+      // prefers), validates existence, falls back to outcome/first-goal.
+      const activeGoalNodeId = resolveActiveGoalNodeId(useCanvasStore.getState())
       const measureForScenario = selectSuccessMeasure(
         useSuccessMeasureStore.getState(),
         resolveScenarioKey(useCanvasStore.getState().currentScenarioId),
       )
-      const normalisedGoalThreshold = normaliseGoalThresholdForRequest(
-        goalThreshold,
-        goalThresholdCap ?? resolveMeasureUnitCap(measureForScenario, goalThreshold),
-      )
+      const normalisedGoalThreshold = resolveChipGoalThreshold(goalThreshold, {
+        analysisReady: effectiveAnalysisReady as { goal_threshold_cap?: unknown } | null,
+        nodes,
+        goalNodeId: activeGoalNodeId,
+        unitCap: resolveMeasureUnitCap(measureForScenario, goalThreshold),
+        representation: goalThresholdRepresentation,
+      })
       // A store threshold that EXISTS but cannot be proven normalised must
       // CLEAR the request threshold (null → adapter deletes the builder's
       // baked analysisReady.goal_threshold): the baked value predates the
@@ -595,7 +642,8 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
         nodes,
         edges,
         effectiveAnalysisReady,
-        outcomeNodeId,
+        // Lane 5 (Codex P1): the SAME resolved goal node the cap used above.
+        activeGoalNodeId ?? outcomeNodeId,
         requestId,
         requestGoalThreshold,
         seed,

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -321,6 +321,14 @@ interface CanvasState {
   // The one normalised consumer (PLoT request goal_threshold, 0-1) converts
   // at the boundary in useV2Run (UI-SEM-058).
   goalThreshold: number | null
+  // Lane 5 (Codex P0-1): explicit representation of the goalThreshold scalar.
+  // The field usually holds RAW user units, but the CEE bare-sync can store a
+  // value that is already NORMALISED 0-1 (CEE's goal_threshold with no raw/cap
+  // of its own). Inferring "raw because a cap exists" divided a normalised 0.6
+  // by the goal node's cap 100 → 0.006 on the wire. The request boundary
+  // consults this tag: 'normalised' passes through iff ∈[0,1], never divided;
+  // 'raw' (or null/legacy) keeps the cap-chain conversion.
+  goalThresholdRepresentation: 'raw' | 'normalised' | null
   nextNodeId: number
   nextEdgeId: number
   _internal: { lastHistoryHash: string }
@@ -599,7 +607,10 @@ interface CanvasState {
   // Outcome node
   setOutcomeNode: (nodeId: string | null) => void
   // Goal threshold for probability_of_goal
-  setGoalThreshold: (threshold: number | null, opts?: { fromCeeSync?: boolean }) => void
+  setGoalThreshold: (
+    threshold: number | null,
+    opts?: { fromCeeSync?: boolean; representation?: 'raw' | 'normalised' },
+  ) => void
   /** Unified threshold + node data update. Prefer over calling setGoalThreshold + updateNode separately. */
   setGoalThresholdAndUpdateNode: (goalNodeId: string, value: number | null) => void
   // Results actions
@@ -999,6 +1010,25 @@ const READINESS_CLEAR_FIELDS = {
 } as const
 
 /**
+ * Lane 5 (Codex P0-2): the per-decision "goal context" — target, its
+ * representation, the CEE readiness payload, and the outcome-node selection.
+ * ANY full-context replacement (new scenario load, canvas import, reset)
+ * must clear these, or the previous decision's target / goal node rides the
+ * next decision's runs (the canonical default-attach now sends the store
+ * threshold on every run, so a stale value corrupts the wire). Applied at
+ * hydrateGraphSlice, importCanvas and resetCanvas (incl. the empty-graph
+ * early return). Readiness is also re-restored by loaders that carry their
+ * own analysis, so clearing first is safe.
+ */
+const DECISION_CONTEXT_CLEAR = {
+  goalThreshold: null,
+  goalThresholdRepresentation: null,
+  ceeAnalysisReady: null,
+  ceeAnalysisReadyNodeIds: null,
+  outcomeNodeId: null,
+} as const
+
+/**
  * Observability hook for constraint passthrough investigation.
  * Logs when goalConstraints are about to be cleared so we can correlate
  * the clearing trigger with the downstream PLoT auto_goal_threshold symptom.
@@ -1227,6 +1257,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   touchedNodeIds: new Set(),
   outcomeNodeId: null,
   goalThreshold: null,
+  goalThresholdRepresentation: null,
   nextNodeId: 1,
   nextEdgeId: 1,
   results: {
@@ -2137,6 +2168,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // overlay (no pending edit applies to a brand-new graph).
       analysisFreshness: null,
       analysisFreshnessDirty: false,
+      // Lane 5 (Codex P0-2): a full import is a new decision context — clear the
+      // target, its representation, readiness and outcome selection so the
+      // imported model never runs against the previous decision's goal state.
+      ...DECISION_CONTEXT_CLEAR,
       // Graph Lens: auto-reset on canvas import (full graph replaced)
       lens: createDefaultLensState(),
     })
@@ -2338,7 +2373,19 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
   resetCanvas: () => {
     const { nodes, edges } = get()
-    if (nodes.length === 0 && edges.length === 0) return
+    if (nodes.length === 0 && edges.length === 0) {
+      // Lane 5 (Codex P0-2): the graph is already empty, but a previous
+      // decision's threshold / readiness / outcome can still be in the store
+      // (e.g. "start fresh" right after loading a decision) — clearing them
+      // only inside the set() below meant an empty-graph reset LEAKED them
+      // into the next decision's runs. Clear the decision context here too.
+      // (The scenario-keyed success measure needs no clear: its only wire
+      // influence is the unit cap, which resolveMeasureUnitCap gates on
+      // measure.threshold === store.goalThreshold — nulling the threshold
+      // breaks that, so a leaked measure can't cap a cleared value.)
+      set({ ...DECISION_CONTEXT_CLEAR })
+      return
+    }
 
     pushToHistory(get, set)
 
@@ -2354,11 +2401,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       touchedNodeIds: new Set(),
       nextNodeId: 1,
       nextEdgeId: 1,
-      // Clear CEE analysis_ready payload, pipeline trace, quality, and constraints
-      ceeAnalysisReady: null,
+      // Clear CEE analysis_ready payload, pipeline trace, quality, and
+      // constraints. (ceeAnalysisReady + ceeAnalysisReadyNodeIds are cleared
+      // via DECISION_CONTEXT_CLEAR below — Lane 5.)
       analysisFreshness: null,
       analysisFreshnessDirty: false,
-      ceeAnalysisReadyNodeIds: null,
       // V5 canonical analysis fact — clear on scenario reset (the fact does
       // not survive a graph reset; rerun analysis to mint a fresh one).
       v5AnalysisFact: null,
@@ -2376,10 +2423,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // Clear results and analysis state
       previousReport: null, // A1: Clear stale deltas on canvas reset
       results: { status: 'idle', progress: 0 },
-      // Lane 1b review fold: the goal threshold is per-decision state — left
-      // standing it rides the NEXT decision's runs (V2 boundary reads it every
-      // run; canonical V5 runs now default-attach it when provable).
-      goalThreshold: null,
+      // Lane 1b/5 review folds: the goal threshold, its representation and the
+      // outcome-node selection are per-decision — left standing they ride the
+      // NEXT decision's runs (the canonical run default-attaches the store
+      // threshold). ceeAnalysisReady/-NodeIds are already cleared above.
+      ...DECISION_CONTEXT_CLEAR,
       runMeta: {},
       hasCompletedFirstRun: false,
       graphEditedSinceLastRun: false,
@@ -2535,13 +2583,20 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // → dirty the freshness overlay on a real change. The CEE-sync caller inside
     // setCeeAnalysisReady passes { fromCeeSync: true } so an ingestion write does
     // NOT self-dirty.
+    // Lane 5: default to 'raw' (every user/editor writer stores raw units); the
+    // bare-sync passes representation: 'normalised' when it stores CEE's already
+    // 0-1 value. A null threshold clears the tag.
     const changed = get().goalThreshold !== threshold
-    set({ goalThreshold: threshold })
+    set({
+      goalThreshold: threshold,
+      goalThresholdRepresentation: threshold == null ? null : opts?.representation ?? 'raw',
+    })
     if (changed && !opts?.fromCeeSync) markAnalysisFreshnessDirty(get, set)
   },
 
   setGoalThresholdAndUpdateNode: (goalNodeId, value) => {
-    set({ goalThreshold: value })
+    // User commit → raw user units (Lane 5).
+    set({ goalThreshold: value, goalThresholdRepresentation: value == null ? null : 'raw' })
     pushToHistory(get, set)
     if (!get().nodes.some(n => n.id === goalNodeId)) {
       // The whole point of this action is the atomic store+node pair (Codex
@@ -3124,8 +3179,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // scenario's target must not ride this scenario's runs (the V2 boundary
       // reads it every run; canonical V5 runs default-attach it when provable).
       // The CEE-sync (bare goal_threshold on analysis_ready ingestion) or a
-      // fresh user commit repopulates it for THIS scenario.
+      // fresh user commit repopulates it for THIS scenario. (loadScenario
+      // restores ceeAnalysisReady/outcomeNodeId from the saved scenario, so
+      // it clears the threshold pair narrowly rather than the full context.)
       goalThreshold: null,
+      goalThresholdRepresentation: null,
     })
 
     // Exit comparison mode when switching scenarios (lives in useComparisonStore as of C3-3)
@@ -3487,22 +3545,36 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // the goalThreshold field comment). goal_threshold is normalised 0-1 — syncing
       // it here painted the Results target line at 0.8 when the real target was
       // 20% (staging trust review, 2026-07). When raw is absent but a cap exists,
-      // derive raw from the producer's own pair (norm × cap) — storing the bare
-      // normalised value beside a cap would double-normalise at the request
-      // boundary (0.8/25 → 0.032). Bare goal_threshold is stored only capless,
-      // where raw ≡ normalised by construction.
+      // derive raw from the producer's own pair (norm × cap) — a genuine RAW
+      // value. When neither raw nor an analysis_ready cap exists, the value is
+      // bare NORMALISED 0-1 — Lane 5 (Codex P0-1) TAGS it 'normalised' rather
+      // than storing it as raw: the old code assumed "capless ⇒ raw ≡
+      // normalised", but the GOAL NODE can carry a cap the request boundary
+      // then divides by (0.6 / 100 → 0.006 on the live wire). The explicit tag
+      // makes the request boundary pass a normalised value through untouched.
       const ceeRaw = (analysisReady as any).goal_threshold_raw
       const ceeNorm = (analysisReady as any).goal_threshold
       const ceeCap = (analysisReady as any).goal_threshold_cap
-      const ceeThreshold = ceeRaw ?? (
-        typeof ceeNorm === 'number' && typeof ceeCap === 'number' && Number.isFinite(ceeCap) && ceeCap > 0
-          ? ceeNorm * ceeCap
-          : ceeNorm
-      )
+      const hasCap = typeof ceeCap === 'number' && Number.isFinite(ceeCap) && ceeCap > 0
+      let ceeThreshold: number | null | undefined
+      let ceeRepresentation: 'raw' | 'normalised'
+      if (ceeRaw != null) {
+        ceeThreshold = ceeRaw
+        ceeRepresentation = 'raw'
+      } else if (typeof ceeNorm === 'number' && hasCap) {
+        ceeThreshold = ceeNorm * ceeCap // derived raw from the producer's own pair
+        ceeRepresentation = 'raw'
+      } else {
+        ceeThreshold = ceeNorm // bare, already 0-1
+        ceeRepresentation = 'normalised'
+      }
       if (ceeThreshold != null && get().goalThreshold == null) {
         // Producer write (syncing the threshold FROM the analysis) — must not
         // self-dirty the freshness overlay.
-        get().setGoalThreshold(typeof ceeThreshold === 'number' ? ceeThreshold : Number(ceeThreshold), { fromCeeSync: true })
+        get().setGoalThreshold(
+          typeof ceeThreshold === 'number' ? ceeThreshold : Number(ceeThreshold),
+          { fromCeeSync: true, representation: ceeRepresentation },
+        )
       }
       // Persist to sessionStorage for tab-refresh survival (with node IDs for validation)
       try {
@@ -4404,6 +4476,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // dirty overlay so neither leaks from the previous graph/scenario.
       updates.analysisFreshness = null
       updates.analysisFreshnessDirty = false
+      // Lane 5 (Codex P0-2): this is the PRODUCTION scenario-load path
+      // (useScenario → hydrateGraphSlice). Before this, it cleared freshness
+      // but RETAINED goalThreshold / ceeAnalysisReady / outcomeNodeId, so the
+      // canonical default-attach could send the previous decision's target on
+      // the newly-loaded scenario's run. Callers that carry their own analysis
+      // re-restore readiness AFTER this (fresh overwrite).
+      Object.assign(updates, DECISION_CONTEXT_CLEAR)
     }
 
     // Apply updates without clobbering panels/results/other slices

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -1029,6 +1029,24 @@ const DECISION_CONTEXT_CLEAR = {
 } as const
 
 /**
+ * Lane 5 (review fold) — the goal/outcome node of a specific graph. On a
+ * full-context replacement the outcome selection must be RE-DERIVED to the
+ * NEW graph's goal node, not cleared to null (leaves the goal selector
+ * empty) and not left stale (a previous scenario's id can collide with a
+ * same-id node in the loaded graph, since reseedIds does not rewrite loaded
+ * ids — resolveActiveGoalNodeId's existence check would then pass on the
+ * wrong node). Returns null when the graph has no goal node.
+ */
+function firstGoalNodeId(
+  nodes: ReadonlyArray<{ id: string; type?: string; data?: unknown }> | undefined,
+): string | null {
+  const goal = nodes?.find(
+    (n) => n.type === 'goal' || (n.data as { type?: string } | undefined)?.type === 'goal',
+  )
+  return goal?.id ?? null
+}
+
+/**
  * Observability hook for constraint passthrough investigation.
  * Logs when goalConstraints are about to be cleared so we can correlate
  * the clearing trigger with the downstream PLoT auto_goal_threshold symptom.
@@ -2172,6 +2190,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // target, its representation, readiness and outcome selection so the
       // imported model never runs against the previous decision's goal state.
       ...DECISION_CONTEXT_CLEAR,
+      // Review fold: re-derive the outcome selection to the imported graph's
+      // own goal node (the DECISION_CONTEXT_CLEAR null is overridden here).
+      outcomeNodeId: firstGoalNodeId(imported.nodes),
       // Graph Lens: auto-reset on canvas import (full graph replaced)
       lens: createDefaultLensState(),
     })
@@ -3175,15 +3196,18 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // Composer draft is scoped to a scenario — clear it on switch so a draft
       // for "buy vs build" can't bleed into "hire vs contract".
       draftComposerText: null,
-      // Lane 1b review fold: the goal threshold is per-decision — the previous
-      // scenario's target must not ride this scenario's runs (the V2 boundary
-      // reads it every run; canonical V5 runs default-attach it when provable).
-      // The CEE-sync (bare goal_threshold on analysis_ready ingestion) or a
-      // fresh user commit repopulates it for THIS scenario. (loadScenario
-      // restores ceeAnalysisReady/outcomeNodeId from the saved scenario, so
-      // it clears the threshold pair narrowly rather than the full context.)
+      // Lane 1b/5 review folds: the goal threshold is per-decision — the
+      // previous scenario's target must not ride this scenario's runs (the V2
+      // boundary reads it every run; canonical V5 runs default-attach it). The
+      // CEE-sync (bare goal_threshold on analysis_ready ingestion) or a fresh
+      // user commit repopulates the threshold for THIS scenario.
       goalThreshold: null,
       goalThresholdRepresentation: null,
+      // loadScenario restores ceeAnalysisReady below, but outcomeNodeId is
+      // NEITHER persisted NOR restored (review fold: the earlier comment was
+      // wrong) — re-derive it to the LOADED graph's goal node so a stale id
+      // from the previous scenario cannot collide with a same-id node here.
+      outcomeNodeId: firstGoalNodeId(nodes),
     })
 
     // Exit comparison mode when switching scenarios (lives in useComparisonStore as of C3-3)
@@ -3510,6 +3534,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       draftChatPreDraftSnapshot: null,
       // Clear full readiness bundle + pipeline trace on draft undo
       ...READINESS_CLEAR_FIELDS,
+      // Lane 5 (review fold): undo reverts to the pre-draft graph — the
+      // drafted decision's target must not survive onto it. Clear the
+      // threshold pair (consistent with clearing readiness above) and
+      // re-derive the outcome selection to the reverted graph's goal node.
+      goalThreshold: null,
+      goalThresholdRepresentation: null,
+      outcomeNodeId: firstGoalNodeId(draftChatPreDraftSnapshot.nodes),
       // Verdict is retained → reverted graph no longer matches it → dirty overlay.
       analysisFreshnessDirty: true,
       ceePipelineTrace: null,
@@ -4480,9 +4511,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // (useScenario → hydrateGraphSlice). Before this, it cleared freshness
       // but RETAINED goalThreshold / ceeAnalysisReady / outcomeNodeId, so the
       // canonical default-attach could send the previous decision's target on
-      // the newly-loaded scenario's run. Callers that carry their own analysis
-      // re-restore readiness AFTER this (fresh overwrite).
+      // the newly-loaded scenario's run. The Supabase loader does NOT restore
+      // these afterwards (review fold: the earlier claim was wrong) — so the
+      // threshold/readiness are cleared and the outcome selection is
+      // RE-DERIVED to the loaded graph's own goal node (not left null, which
+      // empties the goal selector, nor left stale).
       Object.assign(updates, DECISION_CONTEXT_CLEAR)
+      updates.outcomeNodeId = firstGoalNodeId(loaded.nodes)
     }
 
     // Apply updates without clobbering panels/results/other slices

--- a/src/canvas/store/__tests__/decisionContextClear.spec.ts
+++ b/src/canvas/store/__tests__/decisionContextClear.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Lane 5 (Codex P0-2 + P1) — decision-context isolation across full-context
+ * replacements, and the shared active-goal-node resolver.
+ *
+ * Codex's adversarial store test showed graph hydration for a NEW scenario
+ * RETAINED the old goalThreshold, outcomeNodeId and ceeAnalysisReady, so the
+ * canonical default-attach could send the previous decision's target on the
+ * next decision's run. Every full-context entry point — hydrateGraphSlice
+ * (the production Supabase loader), importCanvas, and resetCanvas (incl. the
+ * empty-graph early return) — must clear the decision context.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { resolveActiveGoalNodeId, resolveChipGoalThreshold } from '../../hooks/useV2Run'
+
+function seedForeignContext() {
+  useCanvasStore.setState({
+    goalThreshold: 60,
+    goalThresholdRepresentation: 'raw',
+    ceeAnalysisReady: { goal_node_id: 'old_goal', options: [] } as never,
+    ceeAnalysisReadyNodeIds: ['old_goal'],
+    outcomeNodeId: 'old_goal',
+    nodes: [{ id: 'old_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Old' } }] as never,
+  } as never)
+}
+
+function expectContextCleared() {
+  const s = useCanvasStore.getState()
+  expect(s.goalThreshold).toBeNull()
+  expect(s.goalThresholdRepresentation).toBeNull()
+  expect(s.ceeAnalysisReady).toBeNull()
+  expect(s.outcomeNodeId).toBeNull()
+}
+
+describe('decision-context clear on full-context replacement (Codex P0-2)', () => {
+  beforeEach(() => useCanvasStore.getState().reset())
+
+  it('hydrateGraphSlice (production scenario load) clears the previous decision context', () => {
+    seedForeignContext()
+    useCanvasStore.getState().hydrateGraphSlice({
+      nodes: [{ id: 'new_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'New' } }] as never,
+      edges: [],
+      currentScenarioId: 'scn_new',
+    })
+    expectContextCleared()
+  })
+
+  it('importCanvas clears the previous decision context', () => {
+    seedForeignContext()
+    useCanvasStore.getState().importCanvas(
+      JSON.stringify({ nodes: [{ id: 'imp_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Imported' } }], edges: [] }),
+    )
+    expectContextCleared()
+  })
+
+  it('resetCanvas clears the decision context EVEN when the graph is already empty (early-return leak)', () => {
+    useCanvasStore.setState({
+      nodes: [] as never,
+      edges: [] as never,
+      goalThreshold: 60,
+      goalThresholdRepresentation: 'raw',
+      ceeAnalysisReady: { goal_node_id: 'old_goal', options: [] } as never,
+      outcomeNodeId: 'old_goal',
+    } as never)
+    useCanvasStore.getState().resetCanvas()
+    expectContextCleared()
+  })
+})
+
+describe('resolveActiveGoalNodeId — one validated resolution (Codex P1)', () => {
+  const nodes = [
+    { id: 'g_ready', type: 'goal', data: {} },
+    { id: 'g_outcome', type: 'goal', data: {} },
+    { id: 'g_first', type: 'goal', data: {} },
+  ]
+
+  it('prefers analysis_ready.goal_node_id when it exists', () => {
+    expect(
+      resolveActiveGoalNodeId({ ceeAnalysisReady: { goal_node_id: 'g_ready' }, outcomeNodeId: 'g_outcome', nodes }),
+    ).toBe('g_ready')
+  })
+
+  it('SKIPS a stale analysis_ready id that is not in the graph, falls to outcomeNodeId', () => {
+    expect(
+      resolveActiveGoalNodeId({ ceeAnalysisReady: { goal_node_id: 'gone' }, outcomeNodeId: 'g_outcome', nodes }),
+    ).toBe('g_outcome')
+  })
+
+  it('SKIPS a stale outcomeNodeId (reseeded away), falls to the FIRST goal node in the graph', () => {
+    expect(
+      resolveActiveGoalNodeId({ ceeAnalysisReady: null, outcomeNodeId: 'gone', nodes }),
+    ).toBe('g_ready') // g_ready is nodes[0] — the first goal node
+  })
+
+  it('returns null when no goal node exists', () => {
+    expect(
+      resolveActiveGoalNodeId({ ceeAnalysisReady: null, outcomeNodeId: null, nodes: [{ id: 'f', type: 'factor', data: {} }] }),
+    ).toBeNull()
+  })
+})
+
+describe('end-to-end: the live 0.006 corruption is fixed through the store', () => {
+  beforeEach(() => useCanvasStore.getState().reset())
+
+  it('bare-synced 0.6 + a goal node with cap 100 resolves to 0.6 on the wire, not 0.006', () => {
+    // Reproduce the captured live state: goal node carries raw 60 / cap 100;
+    // analysis_ready carries bare normalised 0.6 (no raw, no cap).
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'goal_1', type: 'goal', position: { x: 0, y: 0 }, data: { success_threshold: 60, scale_max: 100 } },
+      ] as never,
+      goalThreshold: null,
+    } as never)
+    useCanvasStore.getState().setCeeAnalysisReady({
+      goal_node_id: 'goal_1',
+      options: [],
+      goal_threshold: 0.6,
+    } as never)
+
+    const s = useCanvasStore.getState()
+    // The bare-sync stored 0.6 tagged normalised.
+    expect(s.goalThreshold).toBe(0.6)
+    expect(s.goalThresholdRepresentation).toBe('normalised')
+
+    // The canonical default-attach resolution (same call OutputsDock makes).
+    const wire = resolveChipGoalThreshold(s.goalThreshold, {
+      analysisReady: s.ceeAnalysisReady,
+      nodes: s.nodes,
+      goalNodeId: resolveActiveGoalNodeId(s),
+      representation: s.goalThresholdRepresentation,
+    })
+    expect(wire).toBe(0.6)
+  })
+})

--- a/src/canvas/store/__tests__/decisionContextClear.spec.ts
+++ b/src/canvas/store/__tests__/decisionContextClear.spec.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useCanvasStore } from '../../store'
 import { resolveActiveGoalNodeId, resolveChipGoalThreshold } from '../../hooks/useV2Run'
+import { applyDraftResult } from '../../utils/applyDraftResult'
 
 function seedForeignContext() {
   useCanvasStore.setState({
@@ -24,33 +25,43 @@ function seedForeignContext() {
   } as never)
 }
 
-function expectContextCleared() {
+function expectContextCleared(expectedOutcome: string | null) {
   const s = useCanvasStore.getState()
   expect(s.goalThreshold).toBeNull()
   expect(s.goalThresholdRepresentation).toBeNull()
   expect(s.ceeAnalysisReady).toBeNull()
-  expect(s.outcomeNodeId).toBeNull()
+  // Review fold: outcomeNodeId is RE-DERIVED to the new graph's goal node
+  // (not cleared to null, not left stale) — assert the derived id explicitly.
+  expect(s.outcomeNodeId).toBe(expectedOutcome)
 }
 
 describe('decision-context clear on full-context replacement (Codex P0-2)', () => {
   beforeEach(() => useCanvasStore.getState().reset())
 
-  it('hydrateGraphSlice (production scenario load) clears the previous decision context', () => {
+  it('hydrateGraphSlice (production scenario load) clears the target + re-derives the outcome to the loaded goal', () => {
     seedForeignContext()
     useCanvasStore.getState().hydrateGraphSlice({
       nodes: [{ id: 'new_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'New' } }] as never,
       edges: [],
       currentScenarioId: 'scn_new',
     })
-    expectContextCleared()
+    expectContextCleared('new_goal') // re-derived, not the stale 'old_goal' nor null
   })
 
-  it('importCanvas clears the previous decision context', () => {
+  it('importCanvas clears the target/readiness and never leaves the stale outcome id', () => {
+    // importCanvas routes nodes through importSnapshot (v1→v2 migration), so
+    // the exact re-derived id is transform-dependent; the contract that
+    // matters is: the previous decision's target/readiness are gone and the
+    // stale outcome id does not survive.
     seedForeignContext()
     useCanvasStore.getState().importCanvas(
       JSON.stringify({ nodes: [{ id: 'imp_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Imported' } }], edges: [] }),
     )
-    expectContextCleared()
+    const s = useCanvasStore.getState()
+    expect(s.goalThreshold).toBeNull()
+    expect(s.goalThresholdRepresentation).toBeNull()
+    expect(s.ceeAnalysisReady).toBeNull()
+    expect(s.outcomeNodeId).not.toBe('old_goal')
   })
 
   it('resetCanvas clears the decision context EVEN when the graph is already empty (early-return leak)', () => {
@@ -63,7 +74,44 @@ describe('decision-context clear on full-context replacement (Codex P0-2)', () =
       outcomeNodeId: 'old_goal',
     } as never)
     useCanvasStore.getState().resetCanvas()
-    expectContextCleared()
+    expectContextCleared(null) // empty graph has no goal node
+  })
+
+  it('applyDraftResult clears the stale target so the NEW draft goal_threshold syncs (Codex P0-2 review fold)', () => {
+    // A stale non-null threshold made setCeeAnalysisReady drop the draft's own
+    // goal_threshold (sync gates on store == null) AND ride the new graph.
+    useCanvasStore.setState({ goalThreshold: 99, goalThresholdRepresentation: 'raw' } as never)
+    applyDraftResult({
+      nodes: [{ id: 'd_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Drafted' } }],
+      edges: [],
+      analysis_ready: {
+        goal_node_id: 'd_goal',
+        options: [{ id: 'opt', label: 'A', status: 'ready', interventions: {} }],
+        goal_threshold: 0.4,
+      },
+    } as never)
+    const s = useCanvasStore.getState()
+    // The draft's own threshold synced (0.4, tagged normalised) — not the stale 99.
+    expect(s.goalThreshold).toBe(0.4)
+    expect(s.goalThresholdRepresentation).toBe('normalised')
+    // The single goal node is auto-selected.
+    expect(s.outcomeNodeId).toBe('d_goal')
+  })
+
+  it('undoDraft reverts to the pre-draft graph and clears the drafted target', () => {
+    useCanvasStore.setState({
+      goalThreshold: 60,
+      goalThresholdRepresentation: 'raw',
+      draftChatPreDraftSnapshot: {
+        nodes: [{ id: 'pre_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Pre' } }],
+        edges: [],
+      },
+    } as never)
+    useCanvasStore.getState().undoDraft()
+    const s = useCanvasStore.getState()
+    expect(s.goalThreshold).toBeNull()
+    expect(s.goalThresholdRepresentation).toBeNull()
+    expect(s.outcomeNodeId).toBe('pre_goal')
   })
 })
 

--- a/src/canvas/store/__tests__/goalThresholdSync.spec.ts
+++ b/src/canvas/store/__tests__/goalThresholdSync.spec.ts
@@ -28,25 +28,32 @@ describe('Canvas Store – setCeeAnalysisReady goal-threshold sync (unit contrac
     useCanvasStore.setState({ goalThreshold: null })
   })
 
-  it('prefers goal_threshold_raw (user units) over normalised goal_threshold', () => {
+  it('prefers goal_threshold_raw (user units) over normalised goal_threshold — tagged raw', () => {
     useCanvasStore.getState().setCeeAnalysisReady(
       analysisReady({ goal_threshold: 0.8, goal_threshold_raw: 20, goal_threshold_cap: 25 }),
     )
     expect(useCanvasStore.getState().goalThreshold).toBe(20)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
   })
 
-  it('falls back to goal_threshold when raw is absent (raw ≡ normalised without a cap)', () => {
-    useCanvasStore.getState().setCeeAnalysisReady(analysisReady({ goal_threshold: 0.8 }))
-    expect(useCanvasStore.getState().goalThreshold).toBe(0.8)
+  it('Lane 5 (Codex P0-1): a BARE normalised goal_threshold is stored as-is and TAGGED normalised', () => {
+    // This is the live-corruption input: analysis_ready carries 0.6 with no
+    // raw and no cap of its OWN, but the goal node carries a cap. Storing it
+    // untagged let the request boundary divide by the node cap (0.6/100 =
+    // 0.006). The tag makes the boundary pass it through untouched.
+    useCanvasStore.getState().setCeeAnalysisReady(analysisReady({ goal_threshold: 0.6 }))
+    expect(useCanvasStore.getState().goalThreshold).toBe(0.6)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('normalised')
   })
 
-  it('derives raw from norm × cap when raw is absent but a cap exists (never stores normalised beside a cap)', () => {
+  it('derives raw from norm × cap when raw is absent but a cap exists — tagged raw', () => {
     // Storing 0.8 beside cap 25 would double-normalise at the request
     // boundary (0.8 / 25 = 0.032) and paint the target at 0.8 user units.
     useCanvasStore.getState().setCeeAnalysisReady(
       analysisReady({ goal_threshold: 0.8, goal_threshold_cap: 25 }),
     )
     expect(useCanvasStore.getState().goalThreshold).toBe(20)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
   })
 
   it('ignores an invalid cap when deriving (zero/negative caps cannot scale)', () => {

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -157,6 +157,17 @@ export function applyDraftResult(
   useCanvasStore.setState({
     nodes,
     edges,
+    // Lane 5 (review fold, Codex P0-2 class): a draft-graph apply is a
+    // wholesale graph replacement — clear the previous decision's goal
+    // target + its representation + outcome selection so they cannot ride
+    // the new graph's runs. The threshold clear is load-bearing: the
+    // setCeeAnalysisReady below only syncs the DRAFT's own goal_threshold
+    // when the store value is null, so a stale non-null value both dropped
+    // the draft's target AND rode the replacement. The goal node is
+    // auto-selected just below for the single-goal case.
+    goalThreshold: null,
+    goalThresholdRepresentation: null,
+    outcomeNodeId: null,
   })
 
   // Warning-only schema validation at the mutation boundary. Non-throwing —

--- a/src/components/results/modals/DefineSuccessModal.tsx
+++ b/src/components/results/modals/DefineSuccessModal.tsx
@@ -24,7 +24,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { executeCanonicalRun } from '../../../canvas/analysis/canonicalRunRegistry'
-import { capForUnit, resolveChipGoalThreshold } from '../../../canvas/hooks/useV2Run'
+import { capForUnit, resolveChipGoalThreshold, resolveActiveGoalNodeId } from '../../../canvas/hooks/useV2Run'
 import { useCanvasStore } from '../../../canvas/store'
 import { typography } from '../../../styles/typography'
 import {
@@ -196,11 +196,9 @@ export function DefineSuccessModal() {
     // to the store AND the goal node's data in one action, so the goal node
     // stops showing "target missing" after a save (the bare setGoalThreshold
     // updated only the global value, leaving the node stale). Falls back to
-    // the global-only setter when no goal node is resolvable.
-    const goalNodeId =
-      (canvas.ceeAnalysisReady?.goal_node_id as string | undefined) ??
-      canvas.nodes.find((n) => n.type === 'goal')?.id ??
-      null
+    // the global-only setter when no goal node is resolvable. Lane 5: the ONE
+    // shared, existence-validated resolver (never commits to a stale id).
+    const goalNodeId = resolveActiveGoalNodeId(canvas)
     if (goalNodeId) {
       canvas.setGoalThresholdAndUpdateNode(goalNodeId, parsedThreshold)
     } else {


### PR DESCRIPTION
## What

Fixes the **two P0s + P1** from Codex's **no-go** review of the goal-threshold batch (`9de778ca..7f360e84`). Codex refuted the Lane-1b provenance guard exactly where the review brief asked it to pressure-test.

> **Stacked on #308** (base = `claude-ui/lane3-sf2-rerun-continuity`); retarget to `staging` once #308 merges. Both touch store.ts/useV2Run.ts/OutputsDock.tsx.

### P0-1 — a 60% target reached the live wire as `0.006`
CEE `analysis_ready` carries a **bare normalised** `goal_threshold: 0.6` (no raw/cap of its own) while the goal node carries raw 60 / % / cap 100. The bare-sync stored `0.6` as raw ("capless ⇒ raw ≡ normalised" — **false when the NODE holds the cap**), then the request boundary's cap chain divided `0.6 / 100`. UI showed "Target: 60%"; analysis ran at 0.6%.
**Fix:** explicit `goalThresholdRepresentation: 'raw' | 'normalised' | null`. The bare-sync tags a bare normalised value `'normalised'`; every user/editor writer and the norm×cap derivation stay `'raw'`. `resolveChipGoalThreshold` short-circuits a `'normalised'` value: pass through iff ∈[0,1], **never divided by any cap**. Representation is now explicit, not inferred from cap availability (Codex's recommended shape).

### P0-2 — scenario replacement retained the previous decision's target
The production Supabase loader (`useScenario` → `hydrateGraphSlice`), `importCanvas`, and `resetCanvas`'s empty-graph early return all retained `goalThreshold` / `ceeAnalysisReady` / `outcomeNodeId` — so the canonical default-attach could send the old decision's target on the next run.
**Fix:** shared `DECISION_CONTEXT_CLEAR` applied at all three (including the early return).

### P1 — V2/V5 resolved different goal nodes
V2's cap used `outcomeNodeId` while the adapter/V5 preferred `analysis_ready.goal_node_id`.
**Fix:** shared `resolveActiveGoalNodeId` (prefers `analysis_ready.goal_node_id`, **validates node existence** so a stale `outcomeNodeId` is skipped) drives the cap, the request, and commitment. The V2 leg now resolves the threshold through the **same `resolveChipGoalThreshold`** as the V5 chip legs — real parity, replacing the tautological pin Codex flagged.

## Tests (RED-first)
- `goalThreshold.representation.spec` — reproduces `0.006` then pins the short-circuit.
- `decisionContextClear.spec` — all three clears, the resolver precedence + node-existence validation, and the **end-to-end 0.6-not-0.006 through the real store**.
- `goalThresholdSync` — gains representation-tag assertions on all three sync paths.

## Gates
ci-typecheck **PASS** · **786** canvas+store tests green · all **46** goal-threshold hook specs green (the parity grid now exercises the shared resolver on both legs) · wide-tsc-diff-vs-base **zero new**. Local eslint/`--changed` hang environmentally today — **CI is the authoritative lint+full-suite verdict**. An adversarial review of this diff is running; findings will be folded before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)