### PR TITLE
docs(v5): fix stale schemas-version comment in buildPayload (0.7.0 → 0.15.0)

### DIFF
--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -15,7 +15,8 @@
  *      Other UI system events that V5 rejects (feedback_submitted) return null
  *      so callers can pre-filter.
  *
- * CEE contract: @talchain/schemas@0.7.0.
+ * CEE contract: @talchain/schemas — the UI pins 0.15.0 (see package.json for
+ * the authoritative version; CEE pins 0.16.0, and the pins can drift).
  */
 
 import type {


### PR DESCRIPTION
## What / why (external review nit)

`buildPayload.ts`'s header described the CEE contract as `@talchain/schemas@0.7.0`, but the app pins **0.15.0** (`file:./vendor/talchain-schemas-0.15.0.tgz`). This points at `package.json` as the authoritative source (and notes CEE pins 0.16.0) so the comment can't silently rot when the pin bumps.

Comment-only — **no behaviour change**. Base = staging `e27b10ae`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)