### PR TITLE
fix(canvas): factor prior range — no placeholder units, no duplicate range

### DIFF
--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -10,7 +10,7 @@ import { deriveControllability } from '../utils/graphDisplayCalculations'
 import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { hasObservedData, isFactorNeedsInput } from '../utils/observedStateHelpers'
 import { typography } from '../../styles/typography'
-import { cleanFactorLabel, compactFactorLabel, formatInterventionValue, isSuppressedUnit, unwrapInterventionValue } from '../utils/labelUtils'
+import { classifyUnit, cleanFactorLabel, compactFactorLabel, formatInterventionValue, formatRawValueWithUnit, isSuppressedUnit, unwrapInterventionValue } from '../utils/labelUtils'
 import { formatInterventionChange } from '../utils/interventionDisplay'
 import { formatFactorDisplayValue } from '../../utils/formatFactorDisplayValue'
 import { isGraphBadgesEnabled } from '../../flags'
@@ -23,6 +23,52 @@ import { useScienceIcons } from '../hooks/useScienceIcons'
 import { ConnRow, ConnRowsOverflow, Sep, NodeChip, ActionIcons, MetricPills, NodePopover, ScienceIcon, EdgePills } from './shared'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { computeSignedMean } from '../domain/edges'
+
+/**
+ * Parse a display string that is a BARE numeric range ("0.2 to 0.8",
+ * "20 – 80", "20,000-80,000"). Anything else — prose, currency-formatted
+ * ranges ("£20,000 to £80,000"), unit-suffixed values — returns null.
+ * Used only for the prior-range dedupe in priorRangeDisplay below.
+ */
+function parseBareNumericRange(text: string): readonly [number, number] | null {
+  const m = text.trim().match(/^(-?[\d,]*\.?\d+)\s*(?:to|[–—-])\s*(-?[\d,]*\.?\d+)$/i)
+  if (!m) return null
+  const a = Number(m[1].replace(/,/g, ''))
+  const b = Number(m[2].replace(/,/g, ''))
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null
+  return [a, b]
+}
+
+/** Relative-epsilon numeric equality for the dedupe check (never string-fuzzy). */
+function nearlyEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) <= 1e-6 * Math.max(1, Math.abs(a), Math.abs(b))
+}
+
+/**
+ * True when `text` is a bare numeric range that duplicates the prior's
+ * range_min/max — matched NUMERICALLY (lane C3), in either normalised form
+ * ("0.2 to 0.8") or cap-denormalised form ("20 to 80" with cap 100).
+ */
+function bareNumericRangeMatchesPrior(
+  text: string,
+  rangeMin: number,
+  rangeMax: number,
+  cap: number | null | undefined,
+): boolean {
+  const parsed = parseBareNumericRange(text)
+  if (!parsed) return false
+  const [a, b] = parsed
+  if (nearlyEqual(a, rangeMin) && nearlyEqual(b, rangeMax)) return true
+  if (cap != null && cap > 1 && nearlyEqual(a, rangeMin * cap) && nearlyEqual(b, rangeMax * cap)) {
+    return true
+  }
+  return false
+}
+
+/** Normalised (0–1) range end for unitless display: ≤2 dp, trailing zeros trimmed. */
+function formatNormalisedRangeEnd(v: number): string {
+  return Number.isInteger(v) ? String(v) : v.toFixed(2).replace(/\.?0+$/, '')
+}
 
 export const FactorNode = memo((props: NodeProps) => {
   const metadata = NODE_REGISTRY.factor
@@ -240,23 +286,55 @@ export const FactorNode = memo((props: NodeProps) => {
     })
   }, [observedState, cleanedLabel, nodeCategory, topLevelDisplayValue])
 
-  // Prior range for external factors (only the range values, no "Variable" prefix)
+  // Prior range for external factors (only the range values, no "Variable"
+  // prefix). Lane C3: prior.range_min/max are NORMALISED 0–1 values. Only a
+  // real-world unit (currency, %, months, …) justifies cap-denormalising and
+  // suffixing a unit; generic placeholder units ("scale", "index", …) must
+  // never render as if measured — "0.5 scale" looks measured but isn't (see
+  // GENERIC_PLACEHOLDER_UNITS doctrine in labelUtils). Classification goes
+  // through the shared classifyUnit, and real-unit formatting through the
+  // shared formatRawValueWithUnit, so this path can no longer drift from the
+  // other formatters (it previously had a local fmt() with its own hardcoded
+  // ['£','$','€','¥'] list that leaked "Range: 20 scale to 80 scale").
   const priorRangeDisplay = useMemo(() => {
     const prior = props.data?.prior as { range_min?: number; range_max?: number } | undefined
     if (nodeCategory !== 'external' || !prior?.range_min || !prior?.range_max) return null
-    const unit = observedState?.unit && !isSuppressedUnit(observedState.unit) ? observedState.unit : null
-    if (!unit) return null
+    const rangeMin = prior.range_min
+    const rangeMax = prior.range_max
     const cap = observedState?.cap
-    const min = cap != null && cap > 1 ? prior.range_min * cap : prior.range_min
-    const max = cap != null && cap > 1 ? prior.range_max * cap : prior.range_max
-    // Format range values
-    const fmt = (v: number) => {
-      if (['£', '$', '€', '¥'].includes(unit)) return `${unit}${Math.round(v).toLocaleString('en-GB')}`
-      if (unit === '%') return `${Math.round(v * 100)}%`
-      return `${Math.round(v)} ${unit}`
+    // Internal factor_type descriptors ('binary', 'normalised', …) must never
+    // display as units — treat as unitless (same guard as valueDisplay above).
+    const rawUnit = observedState?.unit
+    const unit = rawUnit && !isSuppressedUnit(rawUnit) ? rawUnit : null
+    const { kind } = classifyUnit(unit)
+
+    if (kind === 'none' || kind === 'placeholder') {
+      // No real-world calibration: cap-denormalising would fake a measurement,
+      // so render the normalised range unitless — UNLESS the node body already
+      // shows this same range via the CEE-authored display_value (numeric
+      // dedupe against both normalised and cap-denormalised forms). The
+      // display_value line wins because it is CEE-authored copy; the Range
+      // line adds nothing when it repeats the same numbers.
+      if (valueDisplay != null && bareNumericRangeMatchesPrior(valueDisplay, rangeMin, rangeMax, cap)) {
+        return null
+      }
+      return `Range: ${formatNormalisedRangeEnd(rangeMin)} to ${formatNormalisedRangeEnd(rangeMax)}`
     }
-    return `Range: ${fmt(min)} to ${fmt(max)}`
-  }, [nodeCategory, observedState?.unit, observedState?.cap, props.data?.prior])
+
+    // Real unit: the Range line adds calibrated information (e.g. "£20,000 to
+    // £80,000"), so it is kept even alongside a display_value. Denormalise via
+    // cap, then format through the shared classifyUnit-based raw formatter
+    // (symbol prefix "£20,000", ISO prefix "USD 20,000", "%" / "months" suffix).
+    const fmt = (v: number) => {
+      let denormed = cap != null && cap > 1 ? v * cap : v
+      // Percent with no cap: a 0–1 prior is a ratio — scale to percentage
+      // points (0.2 → 20%), mirroring formatFactorDisplayValue's percent rule.
+      // With a cap the denormalised value is already in percentage points.
+      if (kind === 'percent' && denormed > 0 && denormed < 1) denormed *= 100
+      return formatRawValueWithUnit(Math.round(denormed), unit)
+    }
+    return `Range: ${fmt(rangeMin)} to ${fmt(rangeMax)}`
+  }, [nodeCategory, observedState?.unit, observedState?.cap, props.data?.prior, valueDisplay])
 
   const isInferred = observedState?.extractionType === 'inferred'
   const isExplicit = observedState?.extractionType === 'explicit'

--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -298,42 +298,71 @@ export const FactorNode = memo((props: NodeProps) => {
   // ['£','$','€','¥'] list that leaked "Range: 20 scale to 80 scale").
   const priorRangeDisplay = useMemo(() => {
     const prior = props.data?.prior as { range_min?: number; range_max?: number } | undefined
-    if (nodeCategory !== 'external' || !prior?.range_min || !prior?.range_max) return null
-    const rangeMin = prior.range_min
-    const rangeMax = prior.range_max
+    const rangeMin = prior?.range_min
+    const rangeMax = prior?.range_max
+    // Both endpoints must be finite numbers: `!range_min` truthiness would
+    // drop the line for range_min === 0 (a perfectly good lower bound), and
+    // Infinity/NaN must never render ("Range: Infinity to …").
+    if (
+      nodeCategory !== 'external' ||
+      typeof rangeMin !== 'number' || !Number.isFinite(rangeMin) ||
+      typeof rangeMax !== 'number' || !Number.isFinite(rangeMax)
+    ) return null
     const cap = observedState?.cap
     // Internal factor_type descriptors ('binary', 'normalised', …) must never
     // display as units — treat as unitless (same guard as valueDisplay above).
     const rawUnit = observedState?.unit
     const unit = rawUnit && !isSuppressedUnit(rawUnit) ? rawUnit : null
     const { kind } = classifyUnit(unit)
+    // Only a cap > 1 can turn the normalised 0–1 prior back into real-world
+    // magnitude. Percent is the one exception: a 0–1 ratio converts to
+    // percentage points (×100) with no cap at all.
+    const canCalibrate = cap != null && cap > 1
 
-    if (kind === 'none' || kind === 'placeholder') {
+    if (kind === 'none' || kind === 'placeholder' || (kind !== 'percent' && !canCalibrate)) {
       // No real-world calibration: cap-denormalising would fake a measurement,
       // so render the normalised range unitless — UNLESS the node body already
       // shows this same range via the CEE-authored display_value (numeric
       // dedupe against both normalised and cap-denormalised forms). The
       // display_value line wins because it is CEE-authored copy; the Range
       // line adds nothing when it repeats the same numbers.
+      // A real unit WITHOUT a usable cap lands here too: prefixing a
+      // normalised 0–1 endpoint with "£" fakes calibration exactly like a
+      // placeholder unit would (and Math.round would grind it to "£0 to £1").
       if (valueDisplay != null && bareNumericRangeMatchesPrior(valueDisplay, rangeMin, rangeMax, cap)) {
         return null
       }
       return `Range: ${formatNormalisedRangeEnd(rangeMin)} to ${formatNormalisedRangeEnd(rangeMax)}`
     }
 
-    // Real unit: the Range line adds calibrated information (e.g. "£20,000 to
-    // £80,000"), so it is kept even alongside a display_value. Denormalise via
-    // cap, then format through the shared classifyUnit-based raw formatter
-    // (symbol prefix "£20,000", ISO prefix "USD 20,000", "%" / "months" suffix).
+    // Real unit with calibration (or percent): the Range line adds calibrated
+    // information (e.g. "£20,000 to £80,000"). Denormalise via cap, then
+    // format through the shared classifyUnit-based raw formatter (symbol
+    // prefix "£20,000", ISO prefix "USD 20,000", "%" / "months" suffix).
     const fmt = (v: number) => {
-      let denormed = cap != null && cap > 1 ? v * cap : v
-      // Percent with no cap: a 0–1 prior is a ratio — scale to percentage
-      // points (0.2 → 20%), mirroring formatFactorDisplayValue's percent rule.
-      // With a cap the denormalised value is already in percentage points.
-      if (kind === 'percent' && denormed > 0 && denormed < 1) denormed *= 100
-      return formatRawValueWithUnit(Math.round(denormed), unit)
+      let denormed = canCalibrate ? v * cap : v
+      // Percent with no usable cap: the 0–1 prior is a ratio — scale to
+      // percentage points (0.2 → 20%, 1 → 100%), mirroring
+      // formatFactorDisplayValue's percent rule. Keyed on CAP PRESENCE, not
+      // value magnitude: a cap-denormalised value is already in percentage
+      // points and must never be re-scaled (cap 100, range_min 0.005
+      // denormalises to 0.5, meaning 0.5% — not 50%).
+      if (kind === 'percent' && !canCalibrate) denormed *= 100
+      // Integer rounding is only honest at magnitude ≥ 1; sub-1 calibrated
+      // values (0.5 percentage points) keep two decimal places.
+      const rounded = Math.abs(denormed) >= 1 ? Math.round(denormed) : Math.round(denormed * 100) / 100
+      return formatRawValueWithUnit(rounded, unit)
     }
-    return `Range: ${fmt(rangeMin)} to ${fmt(rangeMax)}`
+    const rendered = `${fmt(rangeMin)} to ${fmt(rangeMax)}`
+    // Dedupe: a CEE-authored display_value that is EXACTLY the calibrated
+    // range text (e.g. "£20,000 to £80,000") makes the Range line pure
+    // repetition. Exact-string equality only — both sides must have come
+    // through the same formatter to collide, so this is numerically faithful
+    // and can never fuzzy-match prose or differently-scaled values. A bare
+    // numeric display_value ("20000 to 80000") deliberately does NOT dedupe
+    // here: the calibrated Range line still adds the unit information.
+    if (valueDisplay != null && valueDisplay.trim() === rendered) return null
+    return `Range: ${rendered}`
   }, [nodeCategory, observedState?.unit, observedState?.cap, props.data?.prior, valueDisplay])
 
   const isInferred = observedState?.extractionType === 'inferred'

--- a/src/canvas/nodes/__tests__/FactorNode.priorRange.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.priorRange.spec.tsx
@@ -20,7 +20,17 @@
  *   - no cap-denormalisation for placeholder/no unit (cap-scaling is only
  *     meaningful for real-world units).
  *   - real units keep the Range line (calibrated information) formatted via
- *     the shared classifyUnit path: "£20,000", "USD 20,000", "20%".
+ *     the shared classifyUnit path: "£20,000", "USD 20,000", "20%" — but only
+ *     when a cap > 1 makes calibration possible. A real unit WITHOUT a usable
+ *     cap falls back to the unitless normalised form (a "£" prefix on a
+ *     normalised 0–1 value would fake a measurement). Percent is the
+ *     exception: a 0–1 ratio converts to percentage points (×100) with no
+ *     cap; with a cap the denormalised value is already percentage points
+ *     and is never re-scaled.
+ *   - a display_value that is EXACTLY the calibrated Range text dedupes the
+ *     Range line (exact-string only, never fuzzy).
+ *   - both prior endpoints must be finite numbers; range_min === 0 is a
+ *     valid lower bound and keeps the line.
  *   - internal factor_type descriptors ('binary', …) never display as units.
  *   - the qualitative/prose display path is untouched.
  */
@@ -228,6 +238,176 @@ describe('FactorNode prior range (lane C3)', () => {
     expect(countOccurrences(container, 'Range: 20% to 80%')).toBe(1)
     expect(text).not.toContain('2000%')
     expect(text).not.toContain('8000%')
+  })
+
+  it('percent unit WITHOUT cap: 0–1 ratio scales to percentage points, including an endpoint at exactly 1', () => {
+    // Review fold (PR #320): the ×100 rescale was keyed on VALUE MAGNITUDE
+    // (denormed > 0 && denormed < 1), so a capless prior {0.2, 1} rendered
+    // "Range: 20% to 1%" — two endpoints of one range in different unit
+    // systems (staging rendered "20% to 100%"). The rescale is keyed on CAP
+    // PRESENCE: no usable cap → the 0–1 prior is a ratio, ×100 both ends.
+    const { container } = renderFactor({
+      label: 'Market Adoption Rate',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 1 },
+      observedState: { value: 0.5, unit: '%', factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, 'Range: 20% to 100%')).toBe(1)
+    expect(text).not.toContain('to 1%')
+  })
+
+  it('percent unit WITH cap: a sub-1 cap-denormalised value is already percentage points — never re-scaled', () => {
+    // cap 100, range_min 0.005 → denormalised 0.5 means 0.5 percentage
+    // points. The old magnitude-keyed guard re-multiplied it to "50%".
+    const { container } = renderFactor({
+      label: 'Market Adoption Rate',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.005, range_max: 0.8 },
+      observedState: { value: 0.5, unit: '%', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, 'Range: 0.5% to 80%')).toBe(1)
+    expect(text).not.toContain('50%')
+  })
+
+  it('percent unit WITH cap: a denormalised value of exactly 1 stays "1%"', () => {
+    // Preserve pin: cap 100, range_min 0.01 → 1 percentage point.
+    const { container } = renderFactor({
+      label: 'Market Adoption Rate',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.01, range_max: 0.8 },
+      observedState: { value: 0.5, unit: '%', cap: 100, factor_type: 'external' },
+    })
+    expect(countOccurrences(container, 'Range: 1% to 80%')).toBe(1)
+  })
+
+  it('range_min of exactly 0 still renders the Range line (0 is a real lower bound)', () => {
+    // Review fold (PR #320): `!prior?.range_min` truthiness dropped the whole
+    // line for range_min === 0.
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0, range_max: 0.8 },
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, 'Range: 0 to 0.8')).toBe(1)
+    expect(text).not.toContain('scale')
+  })
+
+  it('non-finite range endpoints render no Range line (no "Range: Infinity to …")', () => {
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: Infinity, range_max: 0.8 },
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(text).not.toContain('Range:')
+    expect(text).not.toContain('Infinity')
+  })
+
+  it('numeric MISMATCH is never deduped: a parseable display_value with different numbers keeps BOTH lines', () => {
+    // Mutation pin (PR #320 review): replacing the numeric comparison with
+    // "suppress on any parseable range" passed the whole suite. display_value
+    // 0.1–0.5 does NOT duplicate prior 0.2–0.8 — both must render.
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: '0.1 to 0.5',
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, '0.1 to 0.5')).toBe(1)
+    expect(countOccurrences(container, 'Range: 0.2 to 0.8')).toBe(1)
+    expect(text).not.toContain('scale')
+  })
+
+  it('dedupe parses the en-dash form: display_value "20 – 80" suppresses the cap-denormalised Range line', () => {
+    // Mutation pin: restricting parseBareNumericRange to plain "X to Y"
+    // passed the suite.
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: '20 – 80',
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, '20 – 80')).toBe(1)
+    expect(text).not.toContain('Range:')
+  })
+
+  it('dedupe parses comma-thousands: display_value "20,000-80,000" suppresses the cap-denormalised Range line', () => {
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: '20,000-80,000',
+      observedState: { value: 0.5, unit: 'scale', cap: 100000, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, '20,000-80,000')).toBe(1)
+    expect(text).not.toContain('Range:')
+  })
+
+  it('real unit WITHOUT cap: falls back to the unitless normalised range (no "£0 to £1" garbage)', () => {
+    // Review fold (PR #320): with no cap the normalised 0–1 endpoints were
+    // Math.round-ed to "Range: £0 to £1". A currency prefix on a normalised
+    // value fakes calibration exactly like a placeholder unit would, so the
+    // capless real-unit path renders unitless-normalised instead.
+    const { container } = renderFactor({
+      label: 'Competitor Ad Spend',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      observedState: { value: 0.5, unit: '£', factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, 'Range: 0.2 to 0.8')).toBe(1)
+    expect(text).not.toContain('£0')
+    expect(text).not.toContain('£1')
+  })
+
+  it('real unit + display_value identical to the calibrated range: Range line suppressed', () => {
+    // Review fold (PR #320): the real-unit branch had no dedupe, so a
+    // CEE-authored display_value "£20,000 to £80,000" duplicated the Range
+    // line verbatim. Exact-rendered-string dedupe only — a display_value in
+    // any other format keeps the calibrated Range line (see next pin).
+    const { container } = renderFactor({
+      label: 'Competitor Ad Spend',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: '£20,000 to £80,000',
+      observedState: { value: 0.5, unit: '£', cap: 100000, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, '£20,000 to £80,000')).toBe(1)
+    expect(text).not.toContain('Range:')
+  })
+
+  it('real unit + display_value with DIFFERENT numbers: both lines render (dedupe is exact, never fuzzy)', () => {
+    const { container } = renderFactor({
+      label: 'Competitor Ad Spend',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: '£10,000 to £90,000',
+      observedState: { value: 0.5, unit: '£', cap: 100000, factor_type: 'external' },
+    })
+    expect(countOccurrences(container, '£10,000 to £90,000')).toBe(1)
+    expect(countOccurrences(container, 'Range: £20,000 to £80,000')).toBe(1)
   })
 
   it('suppressed internal descriptor unit (binary): never displayed, range renders unitless', () => {

--- a/src/canvas/nodes/__tests__/FactorNode.priorRange.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.priorRange.spec.tsx
@@ -1,0 +1,285 @@
+/**
+ * FactorNode prior-range display (lane C3).
+ *
+ * Verified staging bug (origin/staging dbd6be9d): an external factor with a
+ * placeholder unit ("scale"), cap 100, prior { range_min: 0.2, range_max: 0.8 }
+ * and CEE display_value "0.2 to 0.8" rendered the SAME range twice in two unit
+ * systems:
+ *   line 1 — "0.2 to 0.8"                    (display_value, verbatim)
+ *   line 2 — "Range: 20 scale to 80 scale"   (priorRangeDisplay's local fmt())
+ * The local formatter bypassed classifyUnit — 'scale' is a generic placeholder
+ * unit ("'0.5 scale' looks measured but isn't", labelUtils doctrine) that every
+ * other formatter suppresses — and cap-denormalised a normalised prior as if it
+ * were a real-world measurement.
+ *
+ * Contract pinned here:
+ *   - placeholder/no unit → the range renders ONCE. If the CEE display_value
+ *     already shows it (bare numeric range matching the prior numerically, in
+ *     normalised or cap-denormalised form), the Range line is suppressed;
+ *     otherwise the Range line renders unitless-normalised ("Range: 0.2 to 0.8").
+ *   - no cap-denormalisation for placeholder/no unit (cap-scaling is only
+ *     meaningful for real-world units).
+ *   - real units keep the Range line (calibrated information) formatted via
+ *     the shared classifyUnit path: "£20,000", "USD 20,000", "20%".
+ *   - internal factor_type descriptors ('binary', …) never display as units.
+ *   - the qualitative/prose display path is untouched.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { FactorNode } from '../FactorNode'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector) =>
+    selector({
+      hoveredOptionId: null,
+      nodes: [],
+      edges: [],
+      ceeAnalysisReady: null,
+      results: { status: 'idle', report: null },
+      highlightedNodes: new Set(),
+      dimmedNodeIds: new Set(),
+      goalThreshold: null,
+      goalConstraints: [],
+      viewMode: 'expert',
+    })
+  ),
+}))
+
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank: null,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    stabilityPercentage: null,
+    winRate: null,
+    isResultsMode: false,
+    predictedOutcome: null,
+    valueOfInformation: null,
+    voiRank: null,
+  })),
+}))
+
+vi.mock('../../../hooks/useCEEInsights', () => ({
+  useCEEInsights: vi.fn(() => ({ data: null })),
+}))
+
+vi.mock('../../../hooks/useISLValidation', () => ({
+  useISLValidation: vi.fn(() => ({ data: null })),
+}))
+
+vi.mock('../../hooks/useScienceIcons', () => ({
+  useScienceIcons: vi.fn(() => []),
+}))
+
+vi.mock('../shared/NodePopover', () => ({
+  NodePopover: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="factor-node-popover">{children}</div>
+  ),
+}))
+
+vi.mock('../../../flags', () => ({
+  isGraphBadgesEnabled: vi.fn(() => false),
+  isCrossHighlightEnabled: vi.fn(() => false),
+  isGraphLensEnabled: vi.fn(() => false),
+}))
+
+const baseProps = {
+  id: 'factor-1',
+  type: 'factor',
+  position: { x: 0, y: 0 },
+  selected: false,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+}
+
+const renderFactor = (data: Record<string, unknown>) =>
+  render(
+    <ReactFlowProvider>
+      <FactorNode {...baseProps} data={data} />
+    </ReactFlowProvider>
+  )
+
+/** Count non-overlapping occurrences of `needle` in the rendered text. */
+const countOccurrences = (container: HTMLElement, needle: string): number =>
+  (container.textContent ?? '').split(needle).length - 1
+
+describe('FactorNode prior range (lane C3)', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('placeholder unit + duplicating display_value: range renders exactly once, no fake units', () => {
+    // The verified staging shape (Market Timing Pressure).
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: '0.2 to 0.8',
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    // The one underlying range appears exactly once (the CEE-authored line).
+    expect(countOccurrences(container, '0.2 to 0.8')).toBe(1)
+    // The redundant Range line is suppressed entirely.
+    expect(text).not.toContain('Range:')
+    // The placeholder unit never leaks as if measured, in any form.
+    expect(text).not.toContain('20 scale')
+    expect(text).not.toContain('80 scale')
+    expect(text).not.toContain('scale')
+  })
+
+  it('placeholder unit + display_value duplicating the CAP-DENORMALISED range: Range line suppressed', () => {
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: '20 to 80',
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, '20 to 80')).toBe(1)
+    expect(text).not.toContain('Range:')
+    expect(text).not.toContain('scale')
+  })
+
+  it('placeholder unit + display_value ABSENT: unitless normalised Range line, rendered once', () => {
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    // Pinned decision: render the prior once, unitless and NOT cap-denormalised.
+    expect(countOccurrences(container, 'Range: 0.2 to 0.8')).toBe(1)
+    expect(text).not.toContain('20 scale')
+    expect(text).not.toContain('80 scale')
+    expect(text).not.toContain('scale')
+  })
+
+  it('placeholder unit + prose display_value: prose kept, Range line unitless (no dedupe)', () => {
+    const { container } = renderFactor({
+      label: 'Market Timing Pressure',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: 'Volatile launch window',
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(screen.getByText('Volatile launch window')).toBeDefined()
+    expect(countOccurrences(container, 'Range: 0.2 to 0.8')).toBe(1)
+    expect(text).not.toContain('scale')
+  })
+
+  it('real currency symbol unit (£, cap present) + non-duplicating display_value: calibrated Range line preserved', () => {
+    const { container } = renderFactor({
+      label: 'Competitor Ad Spend',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      display_value: 'Roughly mid-market spend',
+      observedState: { value: 0.5, unit: '£', cap: 100000, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(screen.getByText('Roughly mid-market spend')).toBeDefined()
+    expect(countOccurrences(container, 'Range: £20,000 to £80,000')).toBe(1)
+    expect(text).not.toContain('Range: 0.2 to 0.8')
+  })
+
+  it('ISO currency code unit (USD): Range line uses the shared ISO prefix formatting', () => {
+    // The old local fmt() only knew ['£','$','€','¥'] and rendered
+    // "20000 USD" suffix-style — the shared classifyUnit path renders
+    // "USD 20,000" like every other formatter.
+    const { container } = renderFactor({
+      label: 'Competitor Ad Spend',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      observedState: { value: 0.5, unit: 'USD', cap: 100000, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, 'Range: USD 20,000 to USD 80,000')).toBe(1)
+    expect(text).not.toContain('20000 USD')
+  })
+
+  it('percent unit with cap: Range line renders percentage points once, not double-scaled', () => {
+    // The old local fmt() multiplied by cap AND by 100 → "2000% to 8000%".
+    const { container } = renderFactor({
+      label: 'Market Adoption Rate',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      observedState: { value: 0.5, unit: '%', cap: 100, factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, 'Range: 20% to 80%')).toBe(1)
+    expect(text).not.toContain('2000%')
+    expect(text).not.toContain('8000%')
+  })
+
+  it('suppressed internal descriptor unit (binary): never displayed, range renders unitless', () => {
+    const { container } = renderFactor({
+      label: 'Regulatory Approval',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.1, range_max: 0.9 },
+      observedState: { value: 0.5, unit: 'binary', factor_type: 'external' },
+    })
+    const text = container.textContent ?? ''
+    expect(countOccurrences(container, 'Range: 0.1 to 0.9')).toBe(1)
+    expect(text).not.toContain('binary')
+  })
+
+  it('no observedState at all (fixture wire shape): prior renders once, unitless', () => {
+    // Mirrors fac_market_receptivity in
+    // src/components/debug/__tests__/fixtures/staging-bundles/
+    // olumi-debug-50b336a6-20260510.pre-fix.json — top-level display_value,
+    // no observed_state. The body value line requires observedState, so the
+    // Range line is the only honest place to surface the prior.
+    const { container } = renderFactor({
+      label: 'Market Receptivity to Feature',
+      type: 'factor',
+      category: 'external',
+      prior: { range_min: 0.3, range_max: 0.8 },
+      display_value: '0.3 to 0.8',
+    })
+    expect(countOccurrences(container, '0.3 to 0.8')).toBe(1)
+  })
+
+  it('regression pin: qualitative prose factor (non-external) is untouched — no Range line', () => {
+    const { container } = renderFactor({
+      label: 'Marketing Expertise Applied',
+      type: 'factor',
+      category: 'controllable',
+      display_value: 'Low expertise (owner-led)',
+      observedState: { value: 0.15, unit: 'scale', factor_type: 'quality' },
+    })
+    const text = container.textContent ?? ''
+    expect(screen.getByText('Low expertise (owner-led)')).toBeDefined()
+    expect(text).not.toContain('Range:')
+    expect(text).not.toContain('scale')
+  })
+
+  it('regression pin: external without prior renders no Range line', () => {
+    const { container } = renderFactor({
+      label: 'Market rate',
+      type: 'factor',
+      category: 'external',
+      observedState: { value: 0.5, unit: 'scale', cap: 100, factor_type: 'external' },
+    })
+    expect(container.textContent ?? '').not.toContain('Range:')
+  })
+})


### PR DESCRIPTION
## Lane C3 (A2 Experience) — factor prior range: placeholder units + duplicate range

### The bug (verified against origin/staging dbd6be9d)

The "Market Timing Pressure" external factor node displayed BOTH `0.2 to 0.8` AND `Range: 20 scale to 80 scale` — one underlying prior rendered twice in two unit systems, with a placeholder unit leaked as if measured.

**Mechanism:**
- Line 1: the CEE-authored `display_value` ("0.2 to 0.8") is returned verbatim by `formatFactorDisplayValue` because unit `scale` classifies as placeholder, so the raw_value+unit path is skipped.
- Line 2: `priorRangeDisplay` in `FactorNode.tsx` re-formatted the SAME `prior.range_min/max` via a local ad-hoc `fmt()` that (a) gated units only through `isSuppressedUnit()` (internal factor_type descriptors — `scale` is not in that set; it lives in `GENERIC_PLACEHOLDER_UNITS`, which every other formatter suppresses via `classifyUnit`); (b) cap-denormalised the normalised prior (0.2 × 100 = 20); (c) appended the raw unit → "Range: 20 scale to 80 scale". The codebase's own doctrine (labelUtils): "'0.5 scale' looks measured but isn't". This was the ONE formatter bypassing `classifyUnit` — it even resurrected the hardcoded `['£','$','€','¥']` list that `formatFactorDisplayValue` had already removed.

### Fix decisions (which line wins and why)

1. **Placeholder / no unit → never cap-denormalise, never suffix a unit.** Cap-scaling is only meaningful for real-world units; a normalised prior renders unitless: `Range: 0.2 to 0.8`.
2. **Dedupe — display_value wins.** When the rendered `display_value` is a *bare numeric range* matching `prior.range_min/max` numerically (normalised OR cap-denormalised form; never string-fuzzy), the Range line is suppressed: the CEE-authored line is the copy surface, and a second line repeating the same numbers adds nothing. Prose `display_value` does not dedupe — the unitless Range line renders beneath it.
3. **Real units keep the Range line** — it adds calibrated information (`Range: £20,000 to £80,000`) — now formatted through the shared `formatRawValueWithUnit`/`classifyUnit` path. This also fixes two latent defects in the old local `fmt()`: ISO codes now render as prefixes (`USD 20,000`, not `20000 USD`) and percent-with-cap no longer double-scales (`20%`, not `2000%`).
4. **`display_value` ABSENT + placeholder unit → unitless once** (`Range: 0.2 to 0.8`), pinned in the spec. This also surfaces the prior for externals with no `observedState` at all (the staging-fixture wire shape), which previously showed nothing.
5. **Untouched:** the qualitative/prose display path, `formatFactorDisplayValue`'s own logic, `isSuppressedUnit` semantics (internal descriptors like `binary` still never display — they now fall to the unitless path instead of vanishing).

### Tests (RED-first)

Commit 1 (`3c2a4b34`) adds `src/canvas/nodes/__tests__/FactorNode.priorRange.spec.tsx` — 8 of 11 specs FAIL against origin/staging (the 3 passers are regression pins: £ Range line, qualitative prose, no-prior external). Commit 2 (`92a4c7e1`) is the fix; all 11 pass:

- placeholder unit + duplicating `display_value` → range exactly once; `20 scale` / `80 scale` / `scale` appear nowhere
- placeholder unit + `display_value` duplicating the cap-denormalised form (`20 to 80`) → Range line suppressed
- placeholder unit + `display_value` absent → `Range: 0.2 to 0.8` once, unitless
- placeholder unit + prose `display_value` → prose kept + unitless Range line (no dedupe)
- `£` + cap + non-duplicating `display_value` → `Range: £20,000 to £80,000` preserved
- `USD` → shared ISO prefix formatting
- `%` + cap → `Range: 20% to 80%`, not `2000%`
- suppressed descriptor unit (`binary`) → unitless, never displayed
- fixture wire shape (no `observedState`) → prior renders once
- qualitative prose factor (non-external) → untouched, no Range line
- external without prior → no Range line

### Gates

- Targeted vitest: new spec + all `src/canvas/nodes/__tests__/` + `formatFactorDisplayValue.spec.ts` + `labelUtils.spec.ts` + `unitClassifier.spec.ts` → **20 files, 712 tests, all pass**
- CI-matching typecheck (`pnpm run typecheck` = `tsc -p tsconfig.ci.json --noEmit`) → **clean**
- Skipped per machine gotchas: local eslint and full vitest (known to hang at 0% CPU on this machine) — relying on CI for those.

### Files changed

- `src/canvas/nodes/FactorNode.tsx` — `priorRangeDisplay` memo + 4 module-scope helpers (bare-numeric-range parse/match, normalised-range-end format); imports `classifyUnit` + `formatRawValueWithUnit` from labelUtils
- `src/canvas/nodes/__tests__/FactorNode.priorRange.spec.tsx` — new

### Adjacent findings (not fixed here)

- `priorRangeDisplay`'s guard uses truthiness (`!prior?.range_min`), so a legitimate `range_min: 0` (e.g. uniform prior "0 to 0.6") suppresses the Range line entirely. Pre-existing; preserved to keep this diff scoped.
- Cross-repo (asks ledger): CEE should author prose `display_value` for externals — `"0.3 to 0.8"` as authored copy duplicates the prior it ships alongside (see `olumi-debug-50b336a6-20260510.pre-fix.json`, `fac_market_receptivity`), and the UI now has to numeric-match to avoid double-rendering it. A prose line ("Broad uncertainty about market receptivity") plus the structured prior would remove the dedupe heuristic entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
