### PR TITLE
fix(results): option badges follow the displayed ranking — one metric per surface

### DIFF
--- a/src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts
@@ -14,6 +14,11 @@
  * order (one metric per surface), while the append-only stability of
  * `assignStableOptionNumbers` is preserved (ordinals freeze after first
  * registration; later reruns and lens switches never renumber).
+ *
+ * The hero-row half of this contract (stable numbers strictly ascending
+ * top-to-bottom on a first run) lives in
+ * `../analysis-hero/__tests__/firstRunNumbering.rankCoherence.spec.ts` —
+ * the inertness guard allows analysis-hero imports only inside the module.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -21,8 +26,6 @@ import { renderHook } from '@testing-library/react'
 import { useResultsSectionData } from '../useResultsSectionData'
 import { useCanvasStore } from '../../../canvas/store'
 import { sortOptionsForDisplay } from '../utils/optionDisplayOrder'
-import { buildHeroModel } from '../analysis-hero/buildHeroModel'
-import type { HeroChartModel } from '../analysis-hero/heroTypes'
 import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
 import type { V2RunResponse } from '../../../adapters/plot/v2/types'
 
@@ -95,11 +98,6 @@ function setStoreWithMappedReport(options: OptionShape[]): void {
   } as any)
 }
 
-function chart(model: ReturnType<typeof buildHeroModel>): HeroChartModel {
-  expect(model.kind).toBe('chart')
-  return model as HeroChartModel
-}
-
 beforeEach(() => {
   useCanvasStore.setState({
     results: null,
@@ -137,21 +135,6 @@ describe('useResultsSectionData — option rank coherence', () => {
     expect(sortOptionsForDisplay(allOptions).map((o) => o.id)).toEqual(
       allOptions.map((o) => o.id),
     )
-  })
-
-  it('hero rows carry strictly ascending stable numbers on a first-run registration (no "4 above 3")', () => {
-    setStoreWithMappedReport(SCREENSHOT_OPTIONS)
-
-    const { result } = renderHook(() => useResultsSectionData())
-    const model = chart(
-      buildHeroModel(result.current, useCanvasStore.getState().optionNumbering),
-    )
-
-    const stableNumbers = model.rows.map((r) => r.stableNumber)
-    expect(stableNumbers).toEqual([1, 2, 3, 4])
-    for (let i = 1; i < stableNumbers.length; i += 1) {
-      expect(stableNumbers[i]!).toBeGreaterThan(stableNumbers[i - 1]!)
-    }
   })
 
   it('keeps ordinals frozen when a later run re-registers in a different order (append-only)', () => {

--- a/src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * useResultsSectionData — option rank coherence (badge metric = sort metric).
+ *
+ * Production screenshot bug: the options list rendered badge "4" ABOVE
+ * badge "3". Mechanism: the hook sorted `allOptions` by EXPECTED VALUE and
+ * registered stable ordinals in that order (append-only, never re-sorted),
+ * but every list surface orders rows via `sortOptionsForDisplay`, which
+ * ranks by WIN PROBABILITY whenever all options carry one. With expected
+ * +36/+30/+18/+12 (ordinals 1/2/3/4) and win probs 78/12/2/8, the display
+ * order was 78/12/8/2 — so the 8% option (badge 4) sat above the 2% option
+ * (badge 3).
+ *
+ * Contract pinned here: registration order = display order = allOptions
+ * order (one metric per surface), while the append-only stability of
+ * `assignStableOptionNumbers` is preserved (ordinals freeze after first
+ * registration; later reruns and lens switches never renumber).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { sortOptionsForDisplay } from '../utils/optionDisplayOrder'
+import { buildHeroModel } from '../analysis-hero/buildHeroModel'
+import type { HeroChartModel } from '../analysis-hero/heroTypes'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+/**
+ * The verified screenshot shape: expected-value order (launch, partner,
+ * outsource, solo) DIVERGES from win-probability order (launch, partner,
+ * solo, outsource).
+ */
+interface OptionShape {
+  id: string
+  label: string
+  mean: number
+  winProbability: number
+}
+
+const SCREENSHOT_OPTIONS: OptionShape[] = [
+  { id: 'opt_launch', label: 'Launch Course', mean: 36, winProbability: 0.78 },
+  { id: 'opt_partner', label: 'Partner Up', mean: 30, winProbability: 0.12 },
+  { id: 'opt_outsource', label: 'Outsource', mean: 18, winProbability: 0.02 },
+  { id: 'opt_solo', label: 'Continue Solo', mean: 12, winProbability: 0.08 },
+]
+
+/** Display order (win probability descending): 78%, 12%, 8%, 2%. */
+const DISPLAY_ORDER_IDS = ['opt_launch', 'opt_partner', 'opt_solo', 'opt_outsource']
+
+function makeV2Response(options: OptionShape[]): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: options.map((o) => ({
+      option_id: o.id,
+      option_label: o.label,
+      confidence_interval: [o.mean - 10, o.mean + 10],
+      win_probability: o.winProbability,
+      outcome: {
+        mean: o.mean, std: 5, p10: o.mean - 10, p50: o.mean, p90: o.mean + 10,
+        n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1,
+      },
+    })),
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    robustness: { fragile_edges: [], robust_edges: ['e1'] },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  }
+}
+
+function optionNodesFor(options: OptionShape[]) {
+  return options.map((o) => ({
+    id: o.id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { kind: 'option', label: o.label },
+  }))
+}
+
+function setStoreWithMappedReport(options: OptionShape[]): void {
+  const report = mapV2ResponseToReportV1(makeV2Response(options), { seed: 42 })
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report } as any,
+    runMeta: {} as any,
+    nodes: optionNodesFor(options) as any,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as any)
+}
+
+function chart(model: ReturnType<typeof buildHeroModel>): HeroChartModel {
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    results: null,
+    rawV2Response: null,
+    nodes: [],
+    edges: [],
+    hasCompletedFirstRun: false,
+    optionNumbering: {},
+  } as any)
+})
+
+describe('useResultsSectionData — option rank coherence', () => {
+  it('registers stable ordinals in the shared display order (win probability), not expected value', () => {
+    setStoreWithMappedReport(SCREENSHOT_OPTIONS)
+
+    renderHook(() => useResultsSectionData())
+
+    // 1 = 78%, 2 = 12%, 3 = 8%, 4 = 2% — the order every list renders in.
+    expect(useCanvasStore.getState().optionNumbering).toEqual({
+      opt_launch: 1,
+      opt_partner: 2,
+      opt_solo: 3,
+      opt_outsource: 4,
+    })
+  })
+
+  it('presents allOptions in the shared display order (one metric per surface)', () => {
+    setStoreWithMappedReport(SCREENSHOT_OPTIONS)
+
+    const { result } = renderHook(() => useResultsSectionData())
+    const allOptions = result.current.recommendation?.allOptions ?? []
+
+    expect(allOptions.map((o) => o.id)).toEqual(DISPLAY_ORDER_IDS)
+    // Self-consistency: the array is already a fixed point of the shared sort.
+    expect(sortOptionsForDisplay(allOptions).map((o) => o.id)).toEqual(
+      allOptions.map((o) => o.id),
+    )
+  })
+
+  it('hero rows carry strictly ascending stable numbers on a first-run registration (no "4 above 3")', () => {
+    setStoreWithMappedReport(SCREENSHOT_OPTIONS)
+
+    const { result } = renderHook(() => useResultsSectionData())
+    const model = chart(
+      buildHeroModel(result.current, useCanvasStore.getState().optionNumbering),
+    )
+
+    const stableNumbers = model.rows.map((r) => r.stableNumber)
+    expect(stableNumbers).toEqual([1, 2, 3, 4])
+    for (let i = 1; i < stableNumbers.length; i += 1) {
+      expect(stableNumbers[i]!).toBeGreaterThan(stableNumbers[i - 1]!)
+    }
+  })
+
+  it('keeps ordinals frozen when a later run re-registers in a different order (append-only)', () => {
+    setStoreWithMappedReport(SCREENSHOT_OPTIONS)
+    renderHook(() => useResultsSectionData())
+    const firstRun = { ...useCanvasStore.getState().optionNumbering }
+
+    // Rerun: win probabilities flip AND a new option appears. Existing ids
+    // must keep their first-run ordinals; only the new id gets the next one.
+    const rerun: OptionShape[] = [
+      { id: 'opt_launch', label: 'Launch Course', mean: 36, winProbability: 0.05 },
+      { id: 'opt_partner', label: 'Partner Up', mean: 30, winProbability: 0.1 },
+      { id: 'opt_outsource', label: 'Outsource', mean: 18, winProbability: 0.6 },
+      { id: 'opt_solo', label: 'Continue Solo', mean: 12, winProbability: 0.05 },
+      { id: 'opt_new', label: 'New Idea', mean: 40, winProbability: 0.2 },
+    ]
+    setStoreWithMappedReport(rerun)
+    renderHook(() => useResultsSectionData())
+
+    expect(useCanvasStore.getState().optionNumbering).toEqual({
+      ...firstRun,
+      opt_new: 5,
+    })
+  })
+
+  it('re-rendering with unchanged options leaves the numbering map reference-equal (no renumbering churn)', () => {
+    setStoreWithMappedReport(SCREENSHOT_OPTIONS)
+    const { rerender } = renderHook(() => useResultsSectionData())
+    const before = useCanvasStore.getState().optionNumbering
+
+    rerender()
+
+    expect(useCanvasStore.getState().optionNumbering).toBe(before)
+  })
+
+  it('falls back to expected-value order for registration when win-probability coverage is partial', () => {
+    // Mixed coverage must not fabricate a win-probability ranking —
+    // sortOptionsForDisplay falls back to expected descending, and the
+    // registration follows the same rule.
+    const partial: OptionShape[] = [
+      { id: 'opt_launch', label: 'Launch Course', mean: 36, winProbability: 0.78 },
+      { id: 'opt_partner', label: 'Partner Up', mean: 30, winProbability: undefined as unknown as number },
+      { id: 'opt_solo', label: 'Continue Solo', mean: 12, winProbability: 0.08 },
+    ]
+    setStoreWithMappedReport(partial)
+
+    renderHook(() => useResultsSectionData())
+
+    expect(useCanvasStore.getState().optionNumbering).toEqual({
+      opt_launch: 1,
+      opt_partner: 2,
+      opt_solo: 3,
+    })
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/firstRunNumbering.rankCoherence.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/firstRunNumbering.rankCoherence.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Hero rows × first-run ordinal registration — rank coherence.
+ *
+ * End-to-end half of the option-rank-coherence contract (hook half in
+ * `../../__tests__/useResultsSectionData.optionRankCoherence.spec.ts`;
+ * this file lives inside the analysis-hero module because the inertness
+ * guard forbids importing the hero from anywhere else).
+ *
+ * Production screenshot bug: badge "4" rendered ABOVE badge "3" because
+ * ordinals were seeded from an expected-value order while the rows sort by
+ * win probability (sortOptionsForDisplay). Pinned here: driving the REAL
+ * hook (mapped report → registration effect → store numbering) and building
+ * the hero model from its output yields stable numbers that ascend strictly
+ * top-to-bottom on a first run.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { buildHeroModel } from '../buildHeroModel'
+import type { HeroChartModel } from '../heroTypes'
+import { useResultsSectionData } from '../../useResultsSectionData'
+import { useCanvasStore } from '../../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../../adapters/plot/v2/types'
+
+/**
+ * The verified screenshot shape: expected-value order (launch, partner,
+ * outsource, solo) diverges from win-probability order (launch, partner,
+ * solo, outsource).
+ */
+const SCREENSHOT_OPTIONS = [
+  { id: 'opt_launch', label: 'Launch Course', mean: 36, winProbability: 0.78 },
+  { id: 'opt_partner', label: 'Partner Up', mean: 30, winProbability: 0.12 },
+  { id: 'opt_outsource', label: 'Outsource', mean: 18, winProbability: 0.02 },
+  { id: 'opt_solo', label: 'Continue Solo', mean: 12, winProbability: 0.08 },
+]
+
+function makeV2Response(): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: SCREENSHOT_OPTIONS.map((o) => ({
+      option_id: o.id,
+      option_label: o.label,
+      confidence_interval: [o.mean - 10, o.mean + 10],
+      win_probability: o.winProbability,
+      outcome: {
+        mean: o.mean, std: 5, p10: o.mean - 10, p50: o.mean, p90: o.mean + 10,
+        n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1,
+      },
+    })),
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    robustness: { fragile_edges: [], robust_edges: ['e1'] },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  }
+}
+
+function chart(model: ReturnType<typeof buildHeroModel>): HeroChartModel {
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+beforeEach(() => {
+  const report = mapV2ResponseToReportV1(makeV2Response(), { seed: 42 })
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report } as any,
+    runMeta: {} as any,
+    nodes: SCREENSHOT_OPTIONS.map((o) => ({
+      id: o.id,
+      type: 'option',
+      position: { x: 0, y: 0 },
+      data: { kind: 'option', label: o.label },
+    })) as any,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+    optionNumbering: {},
+  } as any)
+})
+
+describe('hero rows × first-run registration — rank coherence', () => {
+  it('stable numbers ascend strictly top-to-bottom on a first-run registration (no "4 above 3")', () => {
+    const { result } = renderHook(() => useResultsSectionData())
+    const model = chart(
+      buildHeroModel(result.current, useCanvasStore.getState().optionNumbering),
+    )
+
+    const stableNumbers = model.rows.map((r) => r.stableNumber)
+    expect(stableNumbers).toEqual([1, 2, 3, 4])
+    for (let i = 1; i < stableNumbers.length; i += 1) {
+      expect(stableNumbers[i]!).toBeGreaterThan(stableNumbers[i - 1]!)
+    }
+  })
+
+  it('row order and badge order agree with the win-probability ranking', () => {
+    const { result } = renderHook(() => useResultsSectionData())
+    const model = chart(
+      buildHeroModel(result.current, useCanvasStore.getState().optionNumbering),
+    )
+
+    expect(model.rows.map((r) => r.id)).toEqual([
+      'opt_launch', // 78%
+      'opt_partner', // 12%
+      'opt_solo', // 8%
+      'opt_outsource', // 2%
+    ])
+  })
+})

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -55,6 +55,7 @@ import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
 import { stripEncodingNotation, sanitizeCoachingText } from './utils/cleanFactorLabel'
 import { humaniseCritique } from './utils/humaniseCritique'
 import { selectGoalProbability, type GoalProbabilityInput } from './utils/selectGoalProbability'
+import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
 import { deriveStabilityLevel } from '../../lib/stability'
 import { deriveResultCompleteness, type ResultCompleteness } from './useResultCompleteness'
 import { computeNormalisedInfluences, selectDriverDisplayModel } from './driverDisplayModel'
@@ -1327,12 +1328,15 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       backendRecommendedId
     )
 
-    // Sort by expected value descending for display order (independent of winner selection)
-    const sortedOptions = [...unsortedOptions].sort((a, b) => {
-      const aValue = a.expected ?? a.goalProbability ?? -Infinity
-      const bValue = b.expected ?? b.goalProbability ?? -Infinity
-      return bValue - aValue
-    })
+    // Order by the SHARED display sort (win probability when every option
+    // carries one, else expected value — sortOptionsForDisplay), independent
+    // of winner selection. This must be the same comparator the rendering
+    // surfaces use (OptionCards, WinGauge, analysis hero): the staging trust
+    // review found badge "4" rendering ABOVE badge "3" because ordinals were
+    // seeded from an expected-value order while every list sorted by win
+    // probability — one metric per surface, so allOptions order, ordinal
+    // registration order and row order must be one.
+    const sortedOptions = sortOptionsForDisplay(unsortedOptions)
 
     // Task 2.1: Resolve baseline option with precedence (PLoT > user > heuristic)
     // Note: userSelectedBaselineId would come from state if we add baseline selection UI
@@ -2910,7 +2914,11 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
   // accepted schema does not forbid any character in an id, so ANY separator
   // can split a legitimate id into fragments that register wrongly. The dep
   // key is canonical JSON (collision-free) and the ORIGINAL array registers.
-  const optionIds = recommendation.allOptions.map((o) => o.id)
+  // Registration goes through sortOptionsForDisplay explicitly (allOptions
+  // already carries that order, but first-seen ordinals are frozen forever,
+  // so the seeding order must be guaranteed at the registration site, not
+  // inherited): badge numbers then match the order every list renders in.
+  const optionIds = sortOptionsForDisplay(recommendation.allOptions).map((o) => o.id)
   const optionIdsKey = JSON.stringify(optionIds)
   useEffect(() => {
     if (optionIds.length === 0) return


### PR DESCRIPTION
## The bug

Production screenshot: the options list rendered badge **4 above badge 3**. The badge metric and the sort metric were different numbers:

- `useResultsSectionData` sorted `recommendation.allOptions` by **expected value** descending, then registered those ids append-only into the store's `optionNumbering` (`registerOptionNumbering` → `assignStableOptionNumbers`, first-seen ordinals, frozen forever).
- Every list surface (analysis hero rows, OptionCards, WinGauge) orders rows via the shared `sortOptionsForDisplay`, which ranks by **win probability** whenever all options carry one.
- With expected +36/+30/+18/+12 → ordinals 1/2/3/4, but win probs 78/12/2/8 → display order 78/12/8/2: the 8% option (badge 4, "Continue Solo") rendered above the 2% option (badge 3, "Outsource").

The prior trust review (doc comment on `optionDisplayOrder.ts`) fixed row ORDER with the shared sort but not badge SEEDING.

## The fix

One metric per surface — registration order = allOptions order = display order, both routed through the shared comparator:

1. **`useResultsSectionData.ts` option sort** now uses `sortOptionsForDisplay` (win probability when every option carries one, else expected value — the identical fallback to the old comparator) instead of the local expected-value sort.
2. **Ordinal registration** sorts explicitly via `sortOptionsForDisplay(recommendation.allOptions)` at the registration site — first-seen ordinals are frozen forever, so the seeding order is guaranteed where it matters, not inherited.

`assignStableOptionNumbers` is untouched: append-only stability and the per-scenario `hydrateGraphSlice` reset behave exactly as before (pinned in tests).

**Consumer manifest** (every non-test reader of `recommendation.allOptions`, scope: `grep -rn "recommendation.allOptions|recommendation?.allOptions" src` excluding tests/fixtures): OptionCards, WinGauge, buildHeroModel, `computeGapTop2`, both runner-up pickers and `lensComparison` all re-sort internally; the rest are order-insensitive (`length` / `find` / `filter`+`reduce` / by-id map). No consumer depends on expected-value order, so aligning the sort is safe.

## Tests (RED-first: commit 05dbeb49 RED, ae26baef GREEN)

**New: `src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts`** (6 tests, hook-level through a mapped V2 report — the screenshot shape, expected 36/30/18/12 vs win probs 78/12/2/8):
- registration produces ordinals in display order (1=78%, 2=12%, 3=8%, 4=2%) — was RED
- `allOptions` is a fixed point of `sortOptionsForDisplay` — was RED
- ordinals stay frozen when a rerun re-registers in a different order; a new option appends as 5 (append-only pin)
- re-render with unchanged options leaves the numbering map reference-equal (loop-guard pin)
- partial win-probability coverage falls back to expected-value order (no fabricated ranking)

**New: `src/components/results/analysis-hero/__tests__/firstRunNumbering.rankCoherence.spec.ts`** (2 tests — lives inside the module because the inertness guard forbids importing the hero elsewhere):
- hero rows carry stable numbers strictly ascending top-to-bottom on a first-run registration (observed `[1, 2, 4, 3]` before the fix — the literal "4 above 3") — was RED
- row order and badges agree with the win-probability ranking

Existing pins kept green: `optionNumberingStore.spec` (append-only, flipped re-registration, hydrate reset), `buildHeroModel.spec` Wave 2 stable-number suite (rerun rank flip keeps `stableNumber` anchored to the id — lens switches never renumber), `optionDisplayOrder.spec`, `OptionNode.spec`, `golden-payload.spec`.

## Gates run

- Targeted vitest — new specs: **8/8 passed**
- Targeted vitest — full `src/components/results` directory + `results-panel-contract.test.ts` + `OutputsDock.rerunContinuity.spec.tsx` + `OptionNode.spec.tsx`: **151 files, 3,227 tests passed** (includes the analysis-hero inertness guard, which forced the two-file test split)
- `pnpm typecheck` (`tsc -p tsconfig.ci.json --noEmit`, the CI-matching script): **clean**
- Targeted eslint on the three changed files: **0 errors**, 2 pre-existing `react-hooks/exhaustive-deps` warnings in untouched regions of `useResultsSectionData.ts` (lines 1664, 2075)
- Full-suite vitest and full eslint deliberately not run locally (known 0%-CPU hangs on this machine) — relying on CI's TypeScript+Lint and 4 test shards

## Files changed

- `src/components/results/useResultsSectionData.ts` — shared display sort + explicit display-ordered registration
- `src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts` — new
- `src/components/results/analysis-hero/__tests__/firstRunNumbering.rankCoherence.spec.ts` — new

🤖 Generated with [Claude Code](https://claude.com/claude-code)
