### PR TITLE
Wave1-L2: staged honest narration during analysis wait (seam D-M)

### DIFF
--- a/src/canvas/components/AnalysisRunningBanner.tsx
+++ b/src/canvas/components/AnalysisRunningBanner.tsx
@@ -4,12 +4,74 @@
  * buttons). Rendered by OutputsDock while isRunning && a previous report is
  * still on screen — the skeleton covers the no-report case. DS v4: bg-panel,
  * semantic tokens, Lucide only. aria-live announces the state change.
+ *
+ * Wave1-L2 (seam D-M) — staged honest narration during the 20-30s wait.
+ * The message advances on wall-clock time only; we deliberately claim
+ * nothing the client cannot know (no percentages, no scenario counts, no
+ * pipeline-stage telemetry — there is none on this wire). Early completion
+ * or error simply unmounts the banner via OutputsDock's isRunning gate, so
+ * the only obligation here is to clean up timers and never update after
+ * unmount. prefers-reduced-motion drops the text fade (static swap) and
+ * stills the spinner via motion-reduce:animate-none.
  */
+import { useEffect, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 
 import { typography } from '../../styles/typography'
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
+
+/**
+ * Time-based narration stages. Copy is honest and non-specific: it describes
+ * what the analysis genuinely does (robustness simulation, sensitivity
+ * weighing) without fabricating progress. Thresholds pace a typical 20-30s
+ * run; the final stage holds indefinitely for slower runs.
+ */
+export const ANALYSIS_NARRATION_STAGES = [
+  { afterSeconds: 0, message: 'Setting up your analysis…' },
+  { afterSeconds: 6, message: 'Running robustness simulations…' },
+  { afterSeconds: 14, message: 'Weighing what moves your decision…' },
+  { afterSeconds: 22, message: 'Almost there — shaping the results…' },
+] as const
+
+/** Resolve the narration message for a given elapsed time in seconds. */
+export function narrationForElapsed(elapsedSeconds: number): string {
+  for (let i = ANALYSIS_NARRATION_STAGES.length - 1; i >= 0; i--) {
+    if (elapsedSeconds >= ANALYSIS_NARRATION_STAGES[i].afterSeconds) {
+      return ANALYSIS_NARRATION_STAGES[i].message
+    }
+  }
+  return ANALYSIS_NARRATION_STAGES[0].message
+}
+
+const FINAL_STAGE_INDEX = ANALYSIS_NARRATION_STAGES.length - 1
+
+/** Index of the stage active at a given elapsed time in seconds. */
+function stageIndexForElapsed(elapsedSeconds: number): number {
+  for (let i = FINAL_STAGE_INDEX; i >= 0; i--) {
+    if (elapsedSeconds >= ANALYSIS_NARRATION_STAGES[i].afterSeconds) return i
+  }
+  return 0
+}
 
 export function AnalysisRunningBanner() {
+  const [stageIndex, setStageIndex] = useState(0)
+  const startRef = useRef(Date.now())
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  useEffect(() => {
+    startRef.current = Date.now()
+    const interval = setInterval(() => {
+      const elapsedSeconds = (Date.now() - startRef.current) / 1000
+      const next = stageIndexForElapsed(elapsedSeconds)
+      setStageIndex((current) => (next > current ? next : current))
+      // Final stage holds indefinitely — stop ticking once we are there.
+      if (next >= FINAL_STAGE_INDEX) clearInterval(interval)
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const message = ANALYSIS_NARRATION_STAGES[stageIndex].message
+
   return (
     <div
       className="mx-3 mb-2 flex items-center gap-2 rounded-md border border-panel-border bg-panel px-3 py-2"
@@ -17,9 +79,20 @@ export function AnalysisRunningBanner() {
       role="status"
       aria-live="polite"
     >
-      <Loader2 className="h-4 w-4 animate-spin text-info" aria-hidden="true" />
-      <span className={`${typography.bodySmall} text-text-body`}>
-        Running a fresh analysis — the results below update when it completes.
+      <Loader2
+        className="h-4 w-4 animate-spin motion-reduce:animate-none text-info"
+        aria-hidden="true"
+      />
+      <span
+        // Re-key per stage so the fade-in replays on each message swap;
+        // reduced motion gets a plain static text swap instead.
+        key={stageIndex}
+        data-testid="analysis-narration"
+        className={`${typography.bodySmall} text-text-body${
+          prefersReducedMotion ? '' : ' animate-fadeIn'
+        }`}
+      >
+        {message}
       </span>
     </div>
   )

--- a/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
+++ b/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
@@ -1,0 +1,146 @@
+/**
+ * Wave1-L2 (seam D-M) — staged honest narration during the analysis wait.
+ *
+ * The banner must:
+ *  - progress through time-based narration stages (fake timers), with copy
+ *    that never fabricates pipeline progress (no percentages, no counts);
+ *  - hold the final stage without wrapping or going blank on long runs;
+ *  - degrade gracefully on early completion / error: OutputsDock unmounts
+ *    the banner when isRunning flips false (success or error path), so the
+ *    banner must leave no timers running and cause no post-unmount updates;
+ *  - respect prefers-reduced-motion: no fade animation on the narration
+ *    text, spinner carries motion-reduce:animate-none;
+ *  - announce via an aria-live polite status region.
+ */
+
+import { render, screen, act } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AnalysisRunningBanner,
+  ANALYSIS_NARRATION_STAGES,
+  narrationForElapsed,
+} from '../AnalysisRunningBanner'
+
+/** Point window.matchMedia at a given prefers-reduced-motion answer. */
+function mockMatchMedia(reducedMotionMatches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? reducedMotionMatches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+    }),
+  })
+}
+
+afterEach(() => {
+  mockMatchMedia(false)
+})
+
+describe('narrationForElapsed (pure stage resolution)', () => {
+  it('resolves each stage at its threshold and holds the final stage', () => {
+    const [s1, s2, s3, s4] = ANALYSIS_NARRATION_STAGES
+    expect(narrationForElapsed(0)).toBe(s1.message)
+    expect(narrationForElapsed(s2.afterSeconds - 1)).toBe(s1.message)
+    expect(narrationForElapsed(s2.afterSeconds)).toBe(s2.message)
+    expect(narrationForElapsed(s3.afterSeconds)).toBe(s3.message)
+    expect(narrationForElapsed(s4.afterSeconds)).toBe(s4.message)
+    // Long runs hold the last honest message — never wrap, never blank.
+    expect(narrationForElapsed(300)).toBe(s4.message)
+  })
+
+  it('handles negative elapsed time gracefully', () => {
+    expect(narrationForElapsed(-5)).toBe(ANALYSIS_NARRATION_STAGES[0].message)
+  })
+})
+
+describe('honesty constraints on narration copy', () => {
+  it('never claims percentages, counts, or pipeline specifics we cannot know', () => {
+    for (const stage of ANALYSIS_NARRATION_STAGES) {
+      expect(stage.message).not.toMatch(/%|\d/)
+      expect(stage.message).not.toMatch(/!/)
+    }
+  })
+})
+
+describe('AnalysisRunningBanner staged narration', () => {
+  it('progresses through the stages over time and holds the final stage', () => {
+    vi.useFakeTimers()
+    render(<AnalysisRunningBanner />)
+    const [s1, s2, s3, s4] = ANALYSIS_NARRATION_STAGES
+
+    expect(screen.getByTestId('analysis-narration').textContent).toBe(s1.message)
+
+    act(() => vi.advanceTimersByTime(s2.afterSeconds * 1000))
+    expect(screen.getByTestId('analysis-narration').textContent).toBe(s2.message)
+
+    act(() => vi.advanceTimersByTime((s3.afterSeconds - s2.afterSeconds) * 1000))
+    expect(screen.getByTestId('analysis-narration').textContent).toBe(s3.message)
+
+    act(() => vi.advanceTimersByTime((s4.afterSeconds - s3.afterSeconds) * 1000))
+    expect(screen.getByTestId('analysis-narration').textContent).toBe(s4.message)
+
+    // Well past the expected 20-30s window: narration must not wrap or blank.
+    act(() => vi.advanceTimersByTime(120_000))
+    expect(screen.getByTestId('analysis-narration').textContent).toBe(s4.message)
+  })
+
+  it('announces via an aria-live polite status region', () => {
+    render(<AnalysisRunningBanner />)
+    const banner = screen.getByTestId('analysis-running-banner')
+    expect(banner).toHaveAttribute('role', 'status')
+    expect(banner).toHaveAttribute('aria-live', 'polite')
+    expect(banner).toContainElement(screen.getByTestId('analysis-narration'))
+  })
+
+  it('early completion: unmount mid-stage leaves no timers and no post-unmount updates', () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { unmount } = render(<AnalysisRunningBanner />)
+
+    act(() => vi.advanceTimersByTime(7_000))
+    unmount() // OutputsDock drops the banner the moment results land
+
+    expect(vi.getTimerCount()).toBe(0)
+    act(() => vi.advanceTimersByTime(60_000))
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('error handoff: unmount from the final stage is equally clean', () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { unmount } = render(<AnalysisRunningBanner />)
+
+    // Run into the final stage, then simulate the error path unmounting us
+    // (OutputsDock's isRunning flips false; existing error handling owns UX).
+    act(() => vi.advanceTimersByTime(60_000))
+    unmount()
+
+    expect(vi.getTimerCount()).toBe(0)
+    act(() => vi.advanceTimersByTime(60_000))
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('applies a fade class to narration text when motion is allowed', () => {
+    mockMatchMedia(false)
+    render(<AnalysisRunningBanner />)
+    expect(screen.getByTestId('analysis-narration').className).toContain('animate-fadeIn')
+  })
+
+  it('reduced motion: no fade animation on narration text, spinner is motion-reduce safe', () => {
+    mockMatchMedia(true)
+    render(<AnalysisRunningBanner />)
+    expect(screen.getByTestId('analysis-narration').className).not.toContain('animate-fadeIn')
+    const banner = screen.getByTestId('analysis-running-banner')
+    const spinner = banner.querySelector('svg')
+    expect(spinner?.getAttribute('class') ?? '').toContain('motion-reduce:animate-none')
+  })
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -263,10 +263,15 @@ export default {
           from: { opacity: '1' },
           to:   { opacity: '0' },
         },
+        fadeIn: {
+          from: { opacity: '0' },
+          to:   { opacity: '1' },
+        },
       },
       animation: {
         slideDown: 'slideDown 0.2s ease-out',
         fadeOut:   'fadeOut 0.2s ease-out forwards',
+        fadeIn:    'fadeIn 0.3s ease-out',
       },
     },
   },


### PR DESCRIPTION
## What

During the 20-30s coach/analysis wait the canvas showed a static running state. `AnalysisRunningBanner` now advances through four time-based narration stages while a run is in flight. Client-side only — no wire/schema change, no new server calls, no touch to `useConversation.ts` (the 1.16i swallow-guard is untouched).

## Stages (wall-clock, honest copy)

| After | Message |
|---|---|
| 0s | Setting up your analysis… |
| 6s | Running robustness simulations… |
| 14s | Weighing what moves your decision… |
| 22s | Almost there — shaping the results… (holds indefinitely) |

Copy is deliberately non-specific: no fabricated percentages, scenario counts, or pipeline-stage claims — the client has no telemetry for any of that. A spec-level honesty guard asserts no digits/`%`/`!` in any stage message.

## Degrade / accessibility

- **Early completion & error:** OutputsDock's existing `isRunning && report` gate unmounts the banner; the interval is cleared on unmount and stops ticking once the final stage is reached — no stuck narration, no post-unmount updates. Error UX stays with existing handling.
- **prefers-reduced-motion:** static text swap (fade class dropped via `usePrefersReducedMotion`), spinner gains `motion-reduce:animate-none` (matches `LayoutProgressBanner` convention).
- **aria-live:** the existing `role="status" aria-live="polite"` region announces each stage.

## Tests (RED-first)

New `AnalysisRunningBanner.spec.tsx` — written first and shown failing 7/9 against the static banner at base `dbd6be9d`, then green 9/9:
- pure stage resolution incl. negative elapsed + long-run hold
- staged progression under fake timers; 120s past-window no-wrap/no-blank
- early-completion and error-handoff unmounts: `vi.getTimerCount() === 0`, no console errors
- reduced-motion behaviour (matchMedia mocked both ways)
- honesty constraints on copy

## Gates

- `npm run typecheck` (tsc -p tsconfig.ci.json) — clean
- eslint on changed files — clean
- `ci:guard:ds` — pass; `ci:guard:duplicates` — pass; `ci:guard:zustand` — fails identically on clean base (pre-existing `StyledEdge.tsx` hit, not introduced here)
- Full `src/canvas/components/__tests__` suite: 102 files / 1259 tests passed (OutputsDock banner-dependent specs included; they assert the stable `analysis-running-banner` testid, which is preserved)

Do not merge — orchestrator merges after adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)