### PR TITLE
fix(canvas): E3 part 2 — edge labels dodge node cards, not just each other

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -505,10 +505,19 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // node card moves onto it (this edge's own props only change when its own
   // endpoints move). Perf posture: only top-strength edges (max 3) compute a
   // signature — every other edge returns '' and never re-renders from node
-  // movement. Positions/dimensions are quantised to a 10px grid, so a drag
-  // triggers a recompute roughly once per 10px of travel instead of every
-  // frame; 10px is well inside the 26px dodge STEP, so the quantisation is
-  // never visible in the resolved offsets.
+  // movement. While a node is DRAGGING its position is quantised to a 10px
+  // grid, so a drag triggers a recompute roughly once per 10px of travel
+  // instead of every frame; 10px is well inside the 26px dodge STEP, so the
+  // quantisation is never visible mid-drag.
+  //
+  // C2 review fix 2: settled positions (and dimensions) feed through EXACTLY.
+  // Quantising at rest meant the final sub-bucket movement of a drag could
+  // leave a permanently stale offset — up to ~10px of clip or spurious dodge
+  // that no later event would ever fix. Settling flips `dragging` off, which
+  // changes the signature from the quantised to the exact form and costs
+  // exactly one extra recompute per drag; non-drag position/dimension changes
+  // are discrete one-off events (layout runs, measurement), so exact values
+  // add no meaningful recompute traffic there either.
   const nodeRectsSignature = useStore((s) => {
     if (!isTopStrengthEdge) return ''
     let sig = ''
@@ -520,7 +529,9 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       if (n.hidden || lensHiddenNodeIds.has(n.id)) continue
       const w = n.measured?.width ?? n.width ?? 200
       const h = n.measured?.height ?? n.height ?? 80
-      sig += `${n.id}:${Math.round(n.position.x / 10)},${Math.round(n.position.y / 10)},${Math.round(w / 10)},${Math.round(h / 10)};`
+      const x = n.dragging ? Math.round(n.position.x / 10) * 10 : n.position.x
+      const y = n.dragging ? Math.round(n.position.y / 10) * 10 : n.position.y
+      sig += `${n.id}:${x},${y},${w},${h};`
     }
     return sig
   })

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -54,6 +54,10 @@ import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 // via the constant rather than a hard-coded literal.
 export const STRUCTURAL_EDGE_COLOUR = '#B8B8B8'
 
+// Stable empty set for the lens-disabled branch of the store selector —
+// a fresh Set per call would defeat useShallow's reference equality.
+const EMPTY_ID_SET: ReadonlySet<string> = new Set<string>()
+
 export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, selected, data }: EdgeProps<EdgeData>) => {
   const isDark = useIsDark()
   const prefersReducedMotion = usePrefersReducedMotion()
@@ -100,6 +104,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   const {
     isLensDimmed, lensMode, lensSensWeight, lensQ25, lensQ75,
     isLensFragile, isLensHidden, causalEdgeParams, evidenceEdgeClass,
+    lensHiddenNodeIds, lensHiddenEdgeIds,
   } = useCanvasStore(
     useShallow(s => {
       if (!lensEnabled) {
@@ -110,6 +115,8 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           isLensFragile: false, isLensHidden: false,
           causalEdgeParams: null as { mean: number; std: number | null; existsProb: number | null } | null,
           evidenceEdgeClass: null as string | null,
+          lensHiddenNodeIds: EMPTY_ID_SET,
+          lensHiddenEdgeIds: EMPTY_ID_SET,
         }
       }
       const active = s.lens.active
@@ -123,6 +130,11 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         isLensHidden: s.lens._hiddenEdgeIds?.has(id) === true,
         causalEdgeParams: active === 'causal' ? (s.lens._causalEdgeParams?.get(id) ?? null) : null,
         evidenceEdgeClass: active === 'evidence' ? (s.lens._evidenceEdgeClass?.get(id) ?? null) : null,
+        // C2 review fix 1: the label-collision pass needs the full hidden
+        // sets — lens hiding is the app's ONLY node-hiding mechanism
+        // (BaseNode returns null; React Flow's `hidden` flag is never set).
+        lensHiddenNodeIds: (s.lens._hiddenNodeIds ?? EMPTY_ID_SET) as ReadonlySet<string>,
+        lensHiddenEdgeIds: (s.lens._hiddenEdgeIds ?? EMPTY_ID_SET) as ReadonlySet<string>,
       }
     }),
   )
@@ -501,7 +513,11 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     if (!isTopStrengthEdge) return ''
     let sig = ''
     for (const n of s.nodes) {
-      if (n.hidden) continue
+      // C2 review fix 1: the app hides nodes via the lens (BaseNode returns
+      // null for ids in lens._hiddenNodeIds) — those cards are invisible and
+      // must not be obstacles. React Flow's `hidden` flag is never set by
+      // this app; the filter stays as belt-and-braces.
+      if (n.hidden || lensHiddenNodeIds.has(n.id)) continue
       const w = n.measured?.width ?? n.width ?? 200
       const h = n.measured?.height ?? n.height ?? 80
       sig += `${n.id}:${Math.round(n.position.x / 10)},${Math.round(n.position.y / 10)},${Math.round(w / 10)},${Math.round(h / 10)};`
@@ -524,6 +540,9 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     const points: Array<{ id: string; x: number; y: number }> = []
     for (const e of allEdges) {
       if (!topStrengthIds.has(e.id)) continue
+      // C2 review fix 1: a lens-hidden edge renders no label (the component
+      // returns null below), so it must not occupy a label slot either.
+      if (lensHiddenEdgeIds.has(e.id)) continue
       const sn = getNode(e.source)
       const tn = getNode(e.target)
       if (!sn || !tn) continue
@@ -534,7 +553,9 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       points.push({ id: e.id, x: (sx + tx) / 2, y: (sy + ty) / 2 })
     }
     const nodeRects = getNodes()
-      .filter((n) => !n.hidden)
+      // C2 review fix 1: lens-hidden cards are invisible — not obstacles.
+      // RF `hidden` kept as belt-and-braces (never set by this app).
+      .filter((n) => !n.hidden && !lensHiddenNodeIds.has(n.id))
       .map((n) => ({
         x: n.position.x,
         y: n.position.y,
@@ -545,7 +566,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     // nodeRectsSignature is the (quantised) recompute trigger for node
     // movement, mirroring how sourceX/sourceY/targetX/targetY already trigger
     // recompute for this edge's own endpoints.
-  }, [isTopStrengthEdge, topStrengthIds, getEdges, getNode, getNodes, id, sourceX, sourceY, targetX, targetY, nodeRectsSignature])
+  }, [isTopStrengthEdge, topStrengthIds, getEdges, getNode, getNodes, id, lensHiddenNodeIds, lensHiddenEdgeIds, sourceX, sourceY, targetX, targetY, nodeRectsSignature])
 
   // Task 9c: Offset persistent labels away from nodes to avoid overlap
   const persistentLabelOffset = useMemo(() => {

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -24,7 +24,7 @@ import { useShallow } from 'zustand/react/shallow'
 import type { EdgeData, EdgePathType } from '../domain/edges'
 import { shouldShowEdgeLabel } from './edgeLabelVisibility'
 import { computeDirectionStroke } from './directionStroke'
-import { resolveLabelCollisionOffsets } from './edgeLabelCollision'
+import { resolvePersistentLabelPlacements, type PlacementEdge } from './edgeLabelCollision'
 import { applyEdgeVisualProps } from '../theme/edges'
 import { formatConfidence, shouldShowLabel, getEdgeConfidence, computeSignedMean } from '../domain/edges'
 import { useIsDark } from '../hooks/useTheme'
@@ -536,20 +536,36 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     return sig
   })
 
-  // E3: label-vs-label collision avoidance. Every persistent-label edge feeds
-  // the SAME anchor basis (straight midpoints of node centres — a stable
-  // approximation of each label's position) into the shared deterministic
-  // resolver, so all edges agree on the global assignment and each applies
-  // its own offset. Only persistent (top-strength) labels participate —
-  // hover/selection labels are transient.
+  // E3: label collision avoidance. Every persistent-label edge feeds the SAME
+  // anchor basis into the shared deterministic resolver, so all edges agree
+  // on the global assignment and each applies its own offset. Only persistent
+  // (top-strength) labels participate — hover/selection labels are transient.
   // E3 part 2: node cards are fixed obstacles in the same pass — a label must
   // not sit under ANY card, because React Flow paints the node layer above
   // the edge-label renderer and the overlapped label is clipped invisibly.
+  //
+  // C2 review fixes 3 + 4 (see resolvePersistentLabelPlacements): the anchor
+  // basis is the midpoint of the HANDLE points (bottom-centre → top-centre),
+  // matching where the bezier label actually renders — the node-centre
+  // midpoint diverged by (sourceHeight − targetHeight)/4 — and the Task 9c
+  // proximity nudge feeds the resolver rather than being summed afterwards,
+  // so it can never push a cleared label back under a card. The returned
+  // offset is the TOTAL displacement (nudge + collision stack).
   const collisionOffset = useMemo(() => {
     if (!isTopStrengthEdge) return { dx: 0, dy: 0 }
-    const allEdges = getEdges()
-    const points: Array<{ id: string; x: number; y: number }> = []
-    for (const e of allEdges) {
+    const rectOf = (n: {
+      position: { x: number; y: number }
+      measured?: { width?: number; height?: number }
+      width?: number
+      height?: number
+    }) => ({
+      x: n.position.x,
+      y: n.position.y,
+      width: n.measured?.width ?? n.width ?? 200,
+      height: n.measured?.height ?? n.height ?? 80,
+    })
+    const placementEdges: PlacementEdge[] = []
+    for (const e of getEdges()) {
       if (!topStrengthIds.has(e.id)) continue
       // C2 review fix 1: a lens-hidden edge renders no label (the component
       // returns null below), so it must not occupy a label slot either.
@@ -557,55 +573,23 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       const sn = getNode(e.source)
       const tn = getNode(e.target)
       if (!sn || !tn) continue
-      const sx = sn.position.x + ((sn.measured?.width ?? sn.width ?? 200) / 2)
-      const sy = sn.position.y + ((sn.measured?.height ?? sn.height ?? 80) / 2)
-      const tx = tn.position.x + ((tn.measured?.width ?? tn.width ?? 200) / 2)
-      const ty = tn.position.y + ((tn.measured?.height ?? tn.height ?? 80) / 2)
-      points.push({ id: e.id, x: (sx + tx) / 2, y: (sy + ty) / 2 })
+      placementEdges.push({ id: e.id, sourceRect: rectOf(sn), targetRect: rectOf(tn) })
     }
     const nodeRects = getNodes()
       // C2 review fix 1: lens-hidden cards are invisible — not obstacles.
       // RF `hidden` kept as belt-and-braces (never set by this app).
       .filter((n) => !n.hidden && !lensHiddenNodeIds.has(n.id))
-      .map((n) => ({
-        x: n.position.x,
-        y: n.position.y,
-        width: n.measured?.width ?? n.width ?? 200,
-        height: n.measured?.height ?? n.height ?? 80,
-      }))
-    return resolveLabelCollisionOffsets(points, nodeRects).get(id) ?? { dx: 0, dy: 0 }
-    // nodeRectsSignature is the (quantised) recompute trigger for node
-    // movement, mirroring how sourceX/sourceY/targetX/targetY already trigger
-    // recompute for this edge's own endpoints.
-  }, [isTopStrengthEdge, topStrengthIds, getEdges, getNode, getNodes, id, lensHiddenNodeIds, lensHiddenEdgeIds, sourceX, sourceY, targetX, targetY, nodeRectsSignature])
+      .map(rectOf)
+    return resolvePersistentLabelPlacements(placementEdges, nodeRects).get(id) ?? { dx: 0, dy: 0 }
+    // nodeRectsSignature is the recompute trigger for node movement (the
+    // whole placement is derived from node geometry, so it covers this
+    // edge's own endpoints too).
+  }, [isTopStrengthEdge, topStrengthIds, getEdges, getNode, getNodes, id, lensHiddenNodeIds, lensHiddenEdgeIds, nodeRectsSignature])
 
-  // Task 9c: Offset persistent labels away from nodes to avoid overlap
-  const persistentLabelOffset = useMemo(() => {
-    if (!isTopStrengthEdge) return { dx: 0, dy: 0 }
-    const sn = getNode(source)
-    const tn = getNode(target)
-    if (!sn || !tn) return { dx: 0, dy: 0 }
-    // Check if midpoint is within 40px of source or target center
-    const snCx = sn.position.x + ((sn.measured?.width ?? sn.width ?? 200) / 2)
-    const snCy = sn.position.y + ((sn.measured?.height ?? sn.height ?? 80) / 2)
-    const tnCx = tn.position.x + ((tn.measured?.width ?? tn.width ?? 200) / 2)
-    const tnCy = tn.position.y + ((tn.measured?.height ?? tn.height ?? 80) / 2)
-    const distToSource = Math.sqrt((labelX - snCx) ** 2 + (labelY - snCy) ** 2)
-    const distToTarget = Math.sqrt((labelX - tnCx) ** 2 + (labelY - tnCy) ** 2)
-    if (distToSource < 40 || distToTarget < 40) {
-      // Offset perpendicular to the edge direction
-      const edgeDx = targetX - sourceX
-      const edgeDy = targetY - sourceY
-      const len = Math.sqrt(edgeDx * edgeDx + edgeDy * edgeDy) || 1
-      return { dx: (-edgeDy / len) * 20, dy: (edgeDx / len) * 20 }
-    }
-    return { dx: 0, dy: 0 }
-  }, [isTopStrengthEdge, source, target, getNode, labelX, labelY, sourceX, sourceY, targetX, targetY])
-
-  // E3: combined label displacement = node-proximity dodge (Task 9c — computed
-  // since 9c but never applied to the transform until now) + collision stack.
-  const labelOffsetX = persistentLabelOffset.dx + collisionOffset.dx
-  const labelOffsetY = persistentLabelOffset.dy + collisionOffset.dy
+  // Total label displacement (Task 9c proximity nudge + collision stack),
+  // relative to the rendered label anchor (labelX/labelY).
+  const labelOffsetX = collisionOffset.dx
+  const labelOffsetY = collisionOffset.dy
 
   // C1 + E2: label-visibility policy (see edgeLabelVisibility.ts). Top-strength
   // labels surface in the default (standard) view once results exist; the

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -16,7 +16,7 @@
  */
 
 import { memo, useMemo, useState, useRef, useEffect } from 'react'
-import { BaseEdge, EdgeLabelRenderer, getBezierPath, getSmoothStepPath, getStraightPath, type EdgeProps, useReactFlow } from '@xyflow/react'
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, getSmoothStepPath, getStraightPath, type EdgeProps, useReactFlow, useStore } from '@xyflow/react'
 import { Lightbulb, AlertTriangle, Flag } from 'lucide-react'
 import { NodeChip } from '../nodes/shared'
 import { useGuidanceStore } from '../stores/guidanceStore'
@@ -57,7 +57,7 @@ export const STRUCTURAL_EDGE_COLOUR = '#B8B8B8'
 export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, selected, data }: EdgeProps<EdgeData>) => {
   const isDark = useIsDark()
   const prefersReducedMotion = usePrefersReducedMotion()
-  const { getNode, getEdges } = useReactFlow()
+  const { getNode, getEdges, getNodes } = useReactFlow()
 
   // P1 Polish: Edge label mode from Zustand store (live updates, cross-tab sync)
   const labelMode = useEdgeLabelMode(state => state.mode)
@@ -489,12 +489,35 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
 
   const isTopStrengthEdge = !isStructuralEdge && topStrengthIds.has(id)
 
+  // E3 part 2 (C2): subscribe to node geometry so a label re-dodges when ANY
+  // node card moves onto it (this edge's own props only change when its own
+  // endpoints move). Perf posture: only top-strength edges (max 3) compute a
+  // signature — every other edge returns '' and never re-renders from node
+  // movement. Positions/dimensions are quantised to a 10px grid, so a drag
+  // triggers a recompute roughly once per 10px of travel instead of every
+  // frame; 10px is well inside the 26px dodge STEP, so the quantisation is
+  // never visible in the resolved offsets.
+  const nodeRectsSignature = useStore((s) => {
+    if (!isTopStrengthEdge) return ''
+    let sig = ''
+    for (const n of s.nodes) {
+      if (n.hidden) continue
+      const w = n.measured?.width ?? n.width ?? 200
+      const h = n.measured?.height ?? n.height ?? 80
+      sig += `${n.id}:${Math.round(n.position.x / 10)},${Math.round(n.position.y / 10)},${Math.round(w / 10)},${Math.round(h / 10)};`
+    }
+    return sig
+  })
+
   // E3: label-vs-label collision avoidance. Every persistent-label edge feeds
   // the SAME anchor basis (straight midpoints of node centres — a stable
   // approximation of each label's position) into the shared deterministic
   // resolver, so all edges agree on the global assignment and each applies
   // its own offset. Only persistent (top-strength) labels participate —
   // hover/selection labels are transient.
+  // E3 part 2: node cards are fixed obstacles in the same pass — a label must
+  // not sit under ANY card, because React Flow paints the node layer above
+  // the edge-label renderer and the overlapped label is clipped invisibly.
   const collisionOffset = useMemo(() => {
     if (!isTopStrengthEdge) return { dx: 0, dy: 0 }
     const allEdges = getEdges()
@@ -510,8 +533,19 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       const ty = tn.position.y + ((tn.measured?.height ?? tn.height ?? 80) / 2)
       points.push({ id: e.id, x: (sx + tx) / 2, y: (sy + ty) / 2 })
     }
-    return resolveLabelCollisionOffsets(points).get(id) ?? { dx: 0, dy: 0 }
-  }, [isTopStrengthEdge, topStrengthIds, getEdges, getNode, id, sourceX, sourceY, targetX, targetY])
+    const nodeRects = getNodes()
+      .filter((n) => !n.hidden)
+      .map((n) => ({
+        x: n.position.x,
+        y: n.position.y,
+        width: n.measured?.width ?? n.width ?? 200,
+        height: n.measured?.height ?? n.height ?? 80,
+      }))
+    return resolveLabelCollisionOffsets(points, nodeRects).get(id) ?? { dx: 0, dy: 0 }
+    // nodeRectsSignature is the (quantised) recompute trigger for node
+    // movement, mirroring how sourceX/sourceY/targetX/targetY already trigger
+    // recompute for this edge's own endpoints.
+  }, [isTopStrengthEdge, topStrengthIds, getEdges, getNode, getNodes, id, sourceX, sourceY, targetX, targetY, nodeRectsSignature])
 
   // Task 9c: Offset persistent labels away from nodes to avoid overlap
   const persistentLabelOffset = useMemo(() => {

--- a/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
@@ -33,7 +33,10 @@ vi.mock('@xyflow/react', async () => {
     useReactFlow: () => ({
       getNode: () => null,
       getEdges: () => [],
+      getNodes: () => [],
     }),
+    // E3 part 2: StyledEdge subscribes to node geometry via the store
+    useStore: (selector: any) => selector({ nodes: [] }),
   }
 })
 

--- a/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
@@ -26,7 +26,10 @@ vi.mock('@xyflow/react', async () => {
     useReactFlow: () => ({
       getNode: () => null,
       getEdges: () => [],
+      getNodes: () => [],
     }),
+    // E3 part 2: StyledEdge subscribes to node geometry via the store
+    useStore: (selector: any) => selector({ nodes: [] }),
   }
 })
 

--- a/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
@@ -1,0 +1,188 @@
+/**
+ * C2 (A2 Experience) — E3 part 2: persistent edge labels dodge node CARDS,
+ * not just each other.
+ *
+ * React Flow paints the node layer above `.react-flow__edgelabel-renderer`
+ * (node wrappers carry inline zIndex ≥ 0; the label renderer has none), so a
+ * label that lands under a card is clipped invisibly — the production bug:
+ * "Moderate boost (uncertain)" truncated behind the "Equity Dilution Regret"
+ * card. These tests mount StyledEdge with a node card sitting exactly on the
+ * label anchor and assert the label renders displaced, with the existing
+ * hairline leader line (>12px displacement rule) pointing back to the anchor.
+ *
+ * Geometry used throughout (graph coordinates):
+ *  - n1 (source) card at (−400,−40) 200×80 → centre (−300, 0)
+ *  - n2 (target) card at ( 200,−40) 200×80 → centre ( 300, 0)
+ *  - label anchor basis = midpoint of node centres = (0, 0); the 160×22 label
+ *    box (±80, ±11) is clear of both endpoint cards.
+ *  - blocker card at (−100,−40) 200×80 spans x −100..100, y −40..40 — dead on
+ *    the anchor. Clearing its bottom edge needs dy ≥ 51.
+ *  - the mocked path functions put the RENDERED anchor at (50, 50).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { StyledEdge } from '../StyledEdge'
+import { Position } from '@xyflow/react'
+
+// ── Node/edge registries — populated per test ───────────────────────────────
+const nodeRegistry: Record<string, any> = {}
+let edgeList: any[] = []
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: ({ style }: any) => <path data-testid="base-edge" style={style} />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) => nodeRegistry[id] ?? null,
+      getEdges: () => edgeList,
+      getNodes: () => Object.values(nodeRegistry),
+    }),
+    // The component subscribes to node geometry via the React Flow store.
+    useStore: (selector: any) => selector({ nodes: Object.values(nodeRegistry) }),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      // Results complete → persistent top-strength labels render (E2 policy)
+      results: { status: 'complete', report: null },
+      highlightedEdges: new Set<string>(),
+      viewMode: 'standard',
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+
+vi.mock('../../hooks/useTheme', () => ({
+  useIsDark: () => false,
+}))
+
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false,
+}))
+
+vi.mock('../../../flags', () => ({
+  isGraphLensEnabled: () => false,
+}))
+
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+
+vi.mock('../../utils/graphDisplayCalculations', () => ({
+  existenceCertaintyToLineStyle: () => undefined,
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 2,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+
+vi.mock('../../theme/edges', () => ({
+  applyEdgeVisualProps: () => ({ strokeWidth: 2, stroke: '#333', curvature: 0.15 }),
+}))
+
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
+  getStrengthDescription: () => 'moderate',
+  getProvenanceLabel: () => '',
+}))
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+const card = (id: string, kind: string, x: number, y: number) => ({
+  id,
+  type: kind,
+  data: {},
+  position: { x, y },
+  measured: { width: 200, height: 80 },
+})
+
+const edgeProps = {
+  id: 'e1',
+  source: 'n1',
+  target: 'n2',
+  sourceX: -200,
+  sourceY: 0,
+  targetX: 200,
+  targetY: 0,
+  sourcePosition: Position.Right,
+  targetPosition: Position.Left,
+  selected: false,
+  data: {
+    weight: 0.6,
+    direction: 'positive' as const,
+    beliefExists: 0.8,
+  },
+}
+
+describe('StyledEdge — E3 part 2: persistent label dodges node cards', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeRegistry)) delete nodeRegistry[k]
+    nodeRegistry.n1 = card('n1', 'factor', -400, -40)
+    nodeRegistry.n2 = card('n2', 'outcome', 200, -40)
+    edgeList = [{ id: 'e1', source: 'n1', target: 'n2', data: { weight: 0.6 } }]
+  })
+
+  it('label under a third node card renders displaced, with a leader line back to the anchor', () => {
+    nodeRegistry.blocker = card('blocker', 'factor', -100, -40)
+
+    const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+    const label = container.querySelector('[role="note"]') as HTMLElement | null
+    expect(label).not.toBeNull()
+
+    // Leader line renders for any displacement > 12px…
+    const leader = container.querySelector('[data-testid="edge-label-leader"]')
+    expect(leader).not.toBeNull()
+    const x1 = Number(leader!.getAttribute('x1'))
+    const y1 = Number(leader!.getAttribute('y1'))
+    const x2 = Number(leader!.getAttribute('x2'))
+    const y2 = Number(leader!.getAttribute('y2'))
+    // …anchored at the (mocked) label anchor
+    expect(x1).toBe(50)
+    expect(y1).toBe(50)
+    // Displaced clear of the blocker card: label top edge must pass the card
+    // bottom (40) plus the 11px label half-height → dy ≥ 51
+    expect(y2 - y1).toBeGreaterThanOrEqual(51)
+    // The label itself renders at the leader's far end
+    expect(label!.style.transform).toContain(`translate(${x2}px,${y2}px)`)
+  })
+
+  it('label clear of every card renders at the anchor with no leader line', () => {
+    nodeRegistry.remote = card('remote', 'factor', 1000, 1000)
+
+    const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+    const label = container.querySelector('[role="note"]') as HTMLElement | null
+    expect(label).not.toBeNull()
+    expect(label!.style.transform).toContain('translate(50px,50px)')
+    expect(container.querySelector('[data-testid="edge-label-leader"]')).toBeNull()
+  })
+
+  it('an unmeasured node card falls back to ~200×80 for the dodge', () => {
+    // No measured/width/height — the rect must fall back to sane defaults
+    nodeRegistry.blocker = { id: 'blocker', type: 'factor', data: {}, position: { x: -100, y: -40 } }
+
+    const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+    const leader = container.querySelector('[data-testid="edge-label-leader"]')
+    expect(leader).not.toBeNull()
+    const dy = Number(leader!.getAttribute('y2')) - Number(leader!.getAttribute('y1'))
+    expect(dy).toBeGreaterThanOrEqual(51)
+  })
+})

--- a/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
@@ -29,6 +29,17 @@ import { Position } from '@xyflow/react'
 const nodeRegistry: Record<string, any> = {}
 let edgeList: any[] = []
 
+// STABLE useReactFlow surface: production useReactFlow returns a stable
+// instance, so the collision memo's [getEdges, getNode, getNodes] deps never
+// change identity. A fresh-object-per-render mock would force the memo to
+// recompute on EVERY render and mask signature-staleness bugs (C2 review
+// finding 2).
+const rfApi = {
+  getNode: (id: string) => nodeRegistry[id] ?? null,
+  getEdges: () => edgeList,
+  getNodes: () => Object.values(nodeRegistry),
+}
+
 vi.mock('@xyflow/react', async () => {
   const actual = await vi.importActual('@xyflow/react')
   return {
@@ -38,15 +49,29 @@ vi.mock('@xyflow/react', async () => {
     getBezierPath: () => ['M0 0 L100 100', 50, 50],
     getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
     getStraightPath: () => ['M0 0 L100 100', 50, 50],
-    useReactFlow: () => ({
-      getNode: (id: string) => nodeRegistry[id] ?? null,
-      getEdges: () => edgeList,
-      getNodes: () => Object.values(nodeRegistry),
-    }),
+    useReactFlow: () => rfApi,
     // The component subscribes to node geometry via the React Flow store.
     useStore: (selector: any) => selector({ nodes: Object.values(nodeRegistry) }),
   }
 })
+
+// ── Graph-lens state — the app's REAL node-hiding mechanism ─────────────────
+// BaseNode returns null for ids in lens._hiddenNodeIds; React Flow's `hidden`
+// flag is never set by this app. Mutable so individual tests can enable the
+// lens and hide nodes/edges.
+let lensEnabled = false
+const makeLens = () => ({
+  active: 'full' as const,
+  _dimmedEdgeIds: new Set<string>(),
+  _hiddenEdgeIds: new Set<string>(),
+  _hiddenNodeIds: new Set<string>(),
+  _fragileEdgeIds: new Set<string>(),
+  _sensitivityWeights: new Map<string, number>(),
+  _sensitivityQuartiles: null as { q25: number; q75: number } | null,
+  _causalEdgeParams: new Map<string, unknown>(),
+  _evidenceEdgeClass: new Map<string, string>(),
+})
+let lensState = makeLens()
 
 vi.mock('../../store', () => ({
   useCanvasStore: vi.fn((selector: any) =>
@@ -57,6 +82,7 @@ vi.mock('../../store', () => ({
       results: { status: 'complete', report: null },
       highlightedEdges: new Set<string>(),
       viewMode: 'standard',
+      lens: lensState,
     })
   ),
 }))
@@ -78,7 +104,7 @@ vi.mock('../../hooks/usePrefersReducedMotion', () => ({
 }))
 
 vi.mock('../../../flags', () => ({
-  isGraphLensEnabled: () => false,
+  isGraphLensEnabled: () => lensEnabled,
 }))
 
 vi.mock('../../utils/fragileEdgeMatch', () => ({
@@ -104,13 +130,38 @@ vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
 }))
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-const card = (id: string, kind: string, x: number, y: number) => ({
+const card = (
+  id: string,
+  kind: string,
+  x: number,
+  y: number,
+  opts: { width?: number; height?: number; hidden?: boolean; dragging?: boolean } = {},
+) => ({
   id,
   type: kind,
   data: {},
   position: { x, y },
-  measured: { width: 200, height: 80 },
+  measured: { width: opts.width ?? 200, height: opts.height ?? 80 },
+  ...(opts.hidden !== undefined ? { hidden: opts.hidden } : {}),
+  ...(opts.dragging !== undefined ? { dragging: opts.dragging } : {}),
 })
+
+const leaderOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="edge-label-leader"]')
+
+/** Total label offset (dx, dy) extracted from the leader-line endpoints. */
+const leaderDelta = (leader: Element) => ({
+  dx: Number(leader.getAttribute('x2')) - Number(leader.getAttribute('x1')),
+  dy: Number(leader.getAttribute('y2')) - Number(leader.getAttribute('y1')),
+})
+
+/** True when a 160×22 label box centred on (cx, cy) is clear of the rect. */
+const labelClearOfRect = (
+  cx: number,
+  cy: number,
+  r: { x: number; y: number; width: number; height: number },
+) =>
+  cx + 80 <= r.x || cx - 80 >= r.x + r.width || cy + 11 <= r.y || cy - 11 >= r.y + r.height
 
 const edgeProps = {
   id: 'e1',
@@ -136,6 +187,8 @@ describe('StyledEdge — E3 part 2: persistent label dodges node cards', () => {
     nodeRegistry.n1 = card('n1', 'factor', -400, -40)
     nodeRegistry.n2 = card('n2', 'outcome', 200, -40)
     edgeList = [{ id: 'e1', source: 'n1', target: 'n2', data: { weight: 0.6 } }]
+    lensEnabled = false
+    lensState = makeLens()
   })
 
   it('label under a third node card renders displaced, with a leader line back to the anchor', () => {
@@ -184,5 +237,203 @@ describe('StyledEdge — E3 part 2: persistent label dodges node cards', () => {
     expect(leader).not.toBeNull()
     const dy = Number(leader!.getAttribute('y2')) - Number(leader!.getAttribute('y1'))
     expect(dy).toBeGreaterThanOrEqual(51)
+  })
+
+  // ── C2 review finding 1: lens-hidden nodes are NOT obstacles ──────────────
+  // The app never sets React Flow's `hidden` flag; nodes disappear when
+  // BaseNode returns null for ids in lens._hiddenNodeIds. An invisible card
+  // must not displace a label (phantom obstacle).
+  describe('lens-hidden nodes and edges are invisible to the collision pass', () => {
+    it('a lens-hidden card on the label anchor causes NO displacement', () => {
+      lensEnabled = true
+      lensState._hiddenNodeIds.add('blocker')
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -40)
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      const label = container.querySelector('[role="note"]') as HTMLElement | null
+      expect(label).not.toBeNull()
+      expect(label!.style.transform).toContain('translate(50px,50px)')
+      expect(leaderOf(container)).toBeNull()
+    })
+
+    it('belt-and-braces: a React-Flow-`hidden` card is still excluded', () => {
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -40, { hidden: true })
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      expect(leaderOf(container)).toBeNull()
+    })
+
+    it('with the lens flag OFF, _hiddenNodeIds is ignored and the card still dodges', () => {
+      lensEnabled = false
+      lensState._hiddenNodeIds.add('blocker') // stale state — flag gates the mechanism
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -40)
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      expect(leaderOf(container)).not.toBeNull()
+    })
+
+    it('a lens-hidden EDGE renders no label, so it must not occupy a label slot', () => {
+      lensEnabled = true
+      // e2 (n3 → n4) is lens-hidden along with its organisational source node.
+      // Its label anchor (0, −10) would collide with e1's anchor (0, 0) — but
+      // no label renders for it, so e1 must stay put.
+      nodeRegistry.n3 = card('n3', 'factor', -200, -300) // bottom handle (−100, −220)
+      nodeRegistry.n4 = card('n4', 'outcome', 0, 200) // top handle (100, 200)
+      edgeList = [...edgeList, { id: 'e2', source: 'n3', target: 'n4', data: { weight: 0.5 } }]
+      lensState._hiddenNodeIds.add('n3')
+      lensState._hiddenEdgeIds.add('e2')
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      const label = container.querySelector('[role="note"]') as HTMLElement | null
+      expect(label).not.toBeNull()
+      expect(label!.style.transform).toContain('translate(50px,50px)')
+      expect(leaderOf(container)).toBeNull()
+    })
+  })
+
+  // ── C2 review finding 2: settled positions always recompute ──────────────
+  // The geometry signature quantises to a 10px grid, so the FINAL sub-bucket
+  // movement of a drag (or any small programmatic move) could otherwise leave
+  // a permanently stale offset — up to ~10px of clip/spurious dodge that no
+  // later event ever fixes.
+  describe('drag-end / settled-position recompute (quantisation gap)', () => {
+    // Blocker at y −94: bottom edge −14 just clears the label box (−11..11).
+    // At y −88: bottom edge −8 overlaps. Both quantise to the same 10px
+    // bucket (round(−9.4) === round(−8.8) === −9).
+    it('a sub-bucket move of a settled card still triggers a recompute', () => {
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -94)
+      const { container, rerender } = render(<StyledEdge {...edgeProps as any} />)
+      expect(leaderOf(container)).toBeNull() // clear at −94
+
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -88)
+      // New data identity defeats React.memo bailout without touching any
+      // collision-memo dependency.
+      rerender(<StyledEdge {...(edgeProps as any)} data={{ ...edgeProps.data }} />)
+
+      const leader = leaderOf(container)
+      expect(leader).not.toBeNull()
+      expect(leaderDelta(leader!).dy).toBeGreaterThanOrEqual(26)
+    })
+
+    it('perf posture: mid-drag sub-bucket movement does NOT recompute', () => {
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -94, { dragging: true })
+      const { container, rerender } = render(<StyledEdge {...edgeProps as any} />)
+      expect(leaderOf(container)).toBeNull()
+
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -88, { dragging: true })
+      rerender(<StyledEdge {...(edgeProps as any)} data={{ ...edgeProps.data }} />)
+
+      // Same 10px bucket while dragging → throttled, still no dodge…
+      expect(leaderOf(container)).toBeNull()
+    })
+
+    it('…but the drag SETTLING at the same sub-bucket position recomputes', () => {
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -94, { dragging: true })
+      const { container, rerender } = render(<StyledEdge {...edgeProps as any} />)
+
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -88, { dragging: true })
+      rerender(<StyledEdge {...(edgeProps as any)} data={{ ...edgeProps.data }} />)
+      expect(leaderOf(container)).toBeNull() // throttled mid-drag
+
+      nodeRegistry.blocker = card('blocker', 'factor', -100, -88, { dragging: false })
+      rerender(<StyledEdge {...(edgeProps as any)} data={{ ...edgeProps.data }} />)
+
+      const leader = leaderOf(container)
+      expect(leader).not.toBeNull()
+      expect(leaderDelta(leader!).dy).toBeGreaterThanOrEqual(26)
+    })
+  })
+
+  // ── C2 review finding 3: collision anchor === render anchor ──────────────
+  // The label renders at the bezier label point = midpoint of the HANDLE
+  // points (source bottom-centre → target top-centre). The collision pass
+  // must test the same point — the midpoint of node CENTRES diverges by
+  // (sourceHeight − targetHeight)/4 for unequal-height cards.
+  describe('anchor basis with unequal-height endpoint cards', () => {
+    beforeEach(() => {
+      // n1 (−400, 0) 200×80 → bottom handle (−300, 80)
+      // n2 (200, 200) 200×160 → top handle (300, 200)
+      // handle-midpoint anchor (0, 140); node-centre midpoint would be (0, 160)
+      nodeRegistry.n1 = card('n1', 'factor', -400, 0)
+      nodeRegistry.n2 = card('n2', 'outcome', 200, 200, { height: 160 })
+    })
+
+    it('a card over the true (handle-midpoint) anchor is dodged', () => {
+      // bottom edge 145: overlaps the 140-anchor box (129..151), clear of the
+      // 160-anchor box (149..171)
+      nodeRegistry.blocker = card('blocker', 'factor', -100, 65)
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      const leader = leaderOf(container)
+      expect(leader).not.toBeNull()
+      const { dx, dy } = leaderDelta(leader!)
+      expect(dx).toBe(0)
+      // Clear of the blocker bottom (145) from cy 140 → dy ≥ 16
+      expect(dy).toBeGreaterThanOrEqual(16)
+      expect(labelClearOfRect(0 + dx, 140 + dy, { x: -100, y: 65, width: 200, height: 80 })).toBe(true)
+    })
+
+    it('a card over the node-centre midpoint (clear of the render anchor) is NOT dodged', () => {
+      // top edge 155: overlaps the 160-anchor box (149..171), clear of the
+      // 140-anchor box (129..151) — dodging it would be a phantom dodge
+      nodeRegistry.blocker = card('blocker', 'factor', -100, 155)
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      const label = container.querySelector('[role="note"]') as HTMLElement | null
+      expect(label).not.toBeNull()
+      expect(label!.style.transform).toContain('translate(50px,50px)')
+      expect(leaderOf(container)).toBeNull()
+    })
+  })
+
+  // ── C2 review finding 4: the 9c proximity nudge is resolver-aware ─────────
+  // The ±20px perpendicular nudge must be applied BEFORE resolution (the
+  // resolver sees nudged anchors), so it can never push a cleared label back
+  // under a card — and it must key off the true anchor, not a stale one.
+  describe('proximity nudge goes through the resolver', () => {
+    it('a nudge keyed off the wrong anchor must not push the label under a card', () => {
+      // n1 (−30, 0) 200×80, n2 (−30, 140) 200×80 → true anchor (70, 110);
+      // the label box (99..121) is clear of both cards, so NO offset at all
+      // is correct. A post-resolution nudge (dy +20) would sink the label box
+      // (119..141) into n2 (top edge 140).
+      nodeRegistry.n1 = card('n1', 'factor', -30, 0)
+      nodeRegistry.n2 = card('n2', 'outcome', -30, 140)
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      const label = container.querySelector('[role="note"]') as HTMLElement | null
+      expect(label).not.toBeNull()
+      const leader = leaderOf(container)
+      const { dx, dy } = leader ? leaderDelta(leader) : { dx: 0, dy: 0 }
+      // Whatever offset is applied, the final label box must clear both cards
+      expect(labelClearOfRect(70 + dx, 110 + dy, { x: -30, y: 0, width: 200, height: 80 })).toBe(true)
+      expect(labelClearOfRect(70 + dx, 110 + dy, { x: -30, y: 140, width: 200, height: 80 })).toBe(true)
+    })
+
+    it('when the nudge fires, the resolver still clears every card AND the nudge survives', () => {
+      // n1 (0, 0) 200×80 (centre (100, 40)), n2 (0, 40) 200×160 (top handle
+      // (100, 40)) → anchor (100, 60) is within 40px of n1's centre → nudge
+      // fires perpendicular to the (vertical) handle direction: dx +20. The
+      // anchor sits inside BOTH cards, so the resolver must then stack the
+      // nudged label clear of both (dy ≥ 151 to pass n2's bottom edge 200).
+      nodeRegistry.n1 = card('n1', 'factor', 0, 0)
+      nodeRegistry.n2 = card('n2', 'outcome', 0, 40, { height: 160 })
+
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+
+      const leader = leaderOf(container)
+      expect(leader).not.toBeNull()
+      const { dx, dy } = leaderDelta(leader!)
+      expect(dx).toBe(20) // the 9c nudge survives, applied pre-resolution
+      expect(dy).toBeGreaterThanOrEqual(151)
+      expect(labelClearOfRect(100 + dx, 60 + dy, { x: 0, y: 0, width: 200, height: 80 })).toBe(true)
+      expect(labelClearOfRect(100 + dx, 60 + dy, { x: 0, y: 40, width: 200, height: 160 })).toBe(true)
+    })
   })
 })

--- a/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
@@ -23,6 +23,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from '@testing-library/react'
 import { StyledEdge } from '../StyledEdge'
+import { LABEL_HALF_HEIGHT, LABEL_HALF_WIDTH } from '../edgeLabelCollision'
 import { Position } from '@xyflow/react'
 
 // ── Node/edge registries — populated per test ───────────────────────────────
@@ -237,6 +238,44 @@ describe('StyledEdge — E3 part 2: persistent label dodges node cards', () => {
     expect(leader).not.toBeNull()
     const dy = Number(leader!.getAttribute('y2')) - Number(leader!.getAttribute('y1'))
     expect(dy).toBeGreaterThanOrEqual(51)
+  })
+
+  // ── Label-box assumption: the resolver clears a FIXED 160×22 box ──────────
+  // The resolver has no access to the rendered label's real size — it assumes
+  // ±LABEL_HALF_WIDTH / ±LABEL_HALF_HEIGHT around the anchor. That assumption
+  // is only sound because the render caps the label at the same width and
+  // refuses to wrap. These pin the coupling: widening the label (or letting a
+  // long label wrap to a second line) without widening the resolver's box
+  // would silently under-clear every dodge, re-opening the clipping bug for
+  // exactly the long labels that triggered it ("Moderate boost (uncertain)").
+  describe('the rendered label stays inside the box the resolver clears for', () => {
+    const labelStyle = (container: HTMLElement) =>
+      (container.querySelector('[role="note"]') as HTMLElement).style
+
+    it('the label is capped at the resolver\'s assumed width and never wraps', () => {
+      const { container } = render(<StyledEdge {...edgeProps as any} />)
+      const style = labelStyle(container)
+      // Width cap === the resolver's box width (2 × half-extent)
+      expect(style.maxWidth).toBe(`${LABEL_HALF_WIDTH * 2}px`)
+      // …and a long label is ellipsised on ONE line rather than wrapping to a
+      // second, which would break the ±LABEL_HALF_HEIGHT assumption.
+      expect(style.whiteSpace).toBe('nowrap')
+      expect(style.overflow).toBe('hidden')
+      expect(style.textOverflow).toBe('ellipsis')
+    })
+
+    it('a long label text does not widen the rendered box beyond the assumption', () => {
+      const { container } = render(
+        <StyledEdge
+          {...(edgeProps as any)}
+          data={{ ...edgeProps.data, label: 'Moderate boost (uncertain) — a deliberately very long label' }}
+        />,
+      )
+      // Same cap regardless of text length: jsdom does not lay text out, so
+      // the enforceable invariant is the cap itself, not a measured width.
+      expect(labelStyle(container).maxWidth).toBe(`${LABEL_HALF_WIDTH * 2}px`)
+      expect(LABEL_HALF_HEIGHT).toBe(11) // ~22px tall single line (padding included)
+    })
   })
 
   // ── C2 review finding 1: lens-hidden nodes are NOT obstacles ──────────────

--- a/src/canvas/edges/__tests__/StyledEdge.structural.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.structural.spec.tsx
@@ -44,7 +44,26 @@ vi.mock('@xyflow/react', async () => {
             }
           : null,
       getEdges: () => [],
+      getNodes: () =>
+        Object.entries(nodeKinds).map(([id, kind]) => ({
+          id,
+          type: kind,
+          data: {},
+          position: { x: 0, y: 0 },
+          measured: { width: 200, height: 80 },
+        })),
     }),
+    // E3 part 2: StyledEdge subscribes to node geometry via the store
+    useStore: (selector: any) =>
+      selector({
+        nodes: Object.entries(nodeKinds).map(([id, kind]) => ({
+          id,
+          type: kind,
+          data: {},
+          position: { x: 0, y: 0 },
+          measured: { width: 200, height: 80 },
+        })),
+      }),
   }
 })
 

--- a/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
+++ b/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
@@ -61,3 +61,88 @@ describe('resolveLabelCollisionOffsets — E3 label collision avoidance', () => 
     }
   })
 })
+
+describe('resolveLabelCollisionOffsets — E3 part 2: node cards as fixed obstacles', () => {
+  // A standard node card ~200×80. The rendered label box is 160×22 (see the
+  // module doc comment), i.e. half-extents 80×11 around the anchor point.
+  // CARD is centred on the origin: x spans −100..100, y spans −40..40.
+  const CARD = { x: -100, y: -40, width: 200, height: 80 }
+
+  it('a label whose box overlaps a node card is displaced clear of it (dx stays 0)', () => {
+    const out = resolveLabelCollisionOffsets([{ id: 'a', x: 0, y: 0 }], [CARD])
+    const off = out.get('a')!
+    expect(off.dx).toBe(0)
+    // Clear below the card: label top edge (anchor + dy − 11) must reach the
+    // card's bottom edge (y = 40), i.e. dy ≥ 51.
+    expect(off.dy).toBeGreaterThanOrEqual(51)
+  })
+
+  it('labels clear of every node card are unmoved', () => {
+    const out = resolveLabelCollisionOffsets(
+      [
+        { id: 'far', x: 400, y: 300 },
+        { id: 'below', x: 0, y: 60 }, // label top edge 49 > card bottom 40
+        { id: 'beside', x: 200, y: 0 }, // label left edge 120 > card right 100
+      ],
+      [CARD],
+    )
+    expect(out.get('far')).toEqual({ dx: 0, dy: 0 })
+    expect(out.get('below')).toEqual({ dx: 0, dy: 0 })
+    expect(out.get('beside')).toEqual({ dx: 0, dy: 0 })
+  })
+
+  it('compound: a card-displaced label must not land on another label', () => {
+    const out = resolveLabelCollisionOffsets(
+      [
+        { id: 'a', x: 0, y: 0 }, // inside the card → must stack below it
+        { id: 'b', x: 0, y: 55 }, // already clear of the card, sits where a lands
+      ],
+      [CARD],
+    )
+    const a = out.get('a')!
+    const b = out.get('b')!
+    // a cleared the card…
+    expect(a.dy).toBeGreaterThanOrEqual(51)
+    // …and the FINAL positions are label-vs-label clear (Y_THRESHOLD 24 at same x)
+    expect(Math.abs(a.dy - (55 + b.dy))).toBeGreaterThanOrEqual(24)
+    // b had to move — the pass accounts for card-displaced labels when placing later ones
+    expect(b.dy).toBeGreaterThan(0)
+  })
+
+  it('deterministic with node rects: same input in any order → same assignment', () => {
+    const pts = [
+      { id: 'a', x: 0, y: 0 },
+      { id: 'b', x: 0, y: 55 },
+      { id: 'c', x: 40, y: -10 },
+    ]
+    const rects = [CARD, { x: 300, y: 300, width: 200, height: 80 }]
+    const forward = resolveLabelCollisionOffsets(pts, rects)
+    const reversed = resolveLabelCollisionOffsets([...pts].reverse(), [...rects].reverse())
+    for (const id of ['a', 'b', 'c']) {
+      expect(forward.get(id)).toEqual(reversed.get(id))
+    }
+  })
+
+  it('empty nodeRects (or omitted) is byte-identical to the pre-E3-part-2 behaviour', () => {
+    // Pinned fixture: the crossing pair from the E3 suite stacks exactly 26px.
+    const pts = [
+      { id: 'lower', x: 10, y: 8 },
+      { id: 'upper', x: 0, y: 0 },
+    ]
+    const omitted = resolveLabelCollisionOffsets(pts)
+    const explicitEmpty = resolveLabelCollisionOffsets(pts, [])
+    for (const out of [omitted, explicitEmpty]) {
+      expect(out.get('upper')).toEqual({ dx: 0, dy: 0 })
+      expect(out.get('lower')).toEqual({ dx: 0, dy: 26 })
+    }
+  })
+
+  it('guard still bounds stacking when a label cannot clear a pathological rect', () => {
+    // A 1000px-tall card cannot be cleared within MAX_STACK (10 × 26 = 260)
+    const out = resolveLabelCollisionOffsets(
+      [{ id: 'trapped', x: 0, y: 0 }],
+      [{ x: -100, y: -500, width: 200, height: 1000 }],
+    )
+    expect(out.get('trapped')!.dy).toBeLessThanOrEqual(26 * 10)
+  })
+})

--- a/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
+++ b/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveLabelCollisionOffsets } from '../edgeLabelCollision'
+import { resolveLabelCollisionOffsets, resolvePersistentLabelPlacements } from '../edgeLabelCollision'
 
 describe('resolveLabelCollisionOffsets — E3 label collision avoidance', () => {
   it('far-apart labels get no offset', () => {
@@ -144,5 +144,98 @@ describe('resolveLabelCollisionOffsets — E3 part 2: node cards as fixed obstac
       [{ x: -100, y: -500, width: 200, height: 1000 }],
     )
     expect(out.get('trapped')!.dy).toBeLessThanOrEqual(26 * 10)
+  })
+})
+
+describe('resolvePersistentLabelPlacements — C2 review: anchor basis + pre-resolution nudge', () => {
+  const rect = (x: number, y: number, width = 200, height = 80) => ({ x, y, width, height })
+
+  /** True when a 160×22 label box centred on (cx, cy) is clear of the rect. */
+  const clearOf = (cx: number, cy: number, r: { x: number; y: number; width: number; height: number }) =>
+    cx + 80 <= r.x || cx - 80 >= r.x + r.width || cy + 11 <= r.y || cy - 11 >= r.y + r.height
+
+  // Finding 3 fixture: unequal-height endpoints.
+  //  - source (−400, 0) 200×80 → bottom handle (−300, 80)
+  //  - target (200, 200) 200×160 → top handle (300, 200)
+  //  - handle-midpoint anchor (0, 140) — where the bezier label actually
+  //    renders; the node-CENTRE midpoint (0, 160) diverges by
+  //    (sourceHeight − targetHeight)/4 = −20.
+  const source = rect(-400, 0)
+  const target = rect(200, 200, 200, 160)
+
+  it('anchors at the handle midpoint: a card over the render anchor is dodged clear', () => {
+    const blocker = rect(-100, 65) // bottom edge 145 — hits the 140 box (129..151), misses the 160 box
+    const out = resolvePersistentLabelPlacements(
+      [{ id: 'e', sourceRect: source, targetRect: target }],
+      [blocker],
+    )
+    const off = out.get('e')!
+    expect(off.dx).toBe(0)
+    expect(off.dy).toBeGreaterThanOrEqual(16) // label top (140 + dy − 11) must pass 145
+    expect(clearOf(0 + off.dx, 140 + off.dy, blocker)).toBe(true)
+  })
+
+  it('a card over the node-centre midpoint (clear of the render anchor) is NOT dodged', () => {
+    const phantom = rect(-100, 155) // hits the 160 box (149..171), misses the 140 box
+    const out = resolvePersistentLabelPlacements(
+      [{ id: 'e', sourceRect: source, targetRect: target }],
+      [phantom],
+    )
+    expect(out.get('e')).toEqual({ dx: 0, dy: 0 })
+  })
+
+  it('finding 4: the proximity nudge is applied BEFORE resolution and still clears every card', () => {
+    // n1 (0,0) 200×80 (centre (100,40)), n2 (0,40) 200×160 (top handle
+    // (100,40)) → anchor (100,60), within 40px of n1's centre → nudge fires
+    // perpendicular to the vertical handle direction: dx +20. The (nudged)
+    // anchor sits inside both cards, so the resolver must stack it clear.
+    const n1 = rect(0, 0)
+    const n2 = rect(0, 40, 200, 160)
+    const out = resolvePersistentLabelPlacements(
+      [{ id: 'e', sourceRect: n1, targetRect: n2 }],
+      [n1, n2],
+    )
+    const off = out.get('e')!
+    expect(off.dx).toBe(20) // nudge survives in the total offset
+    expect(off.dy).toBeGreaterThanOrEqual(151) // clears n2's bottom edge (200) from cy 60
+    expect(clearOf(100 + off.dx, 60 + off.dy, n1)).toBe(true)
+    expect(clearOf(100 + off.dx, 60 + off.dy, n2)).toBe(true)
+  })
+
+  it('no nudge and no obstacles → zero total offset', () => {
+    const out = resolvePersistentLabelPlacements(
+      [{ id: 'e', sourceRect: rect(-400, -40), targetRect: rect(200, -40) }],
+      [],
+    )
+    expect(out.get('e')).toEqual({ dx: 0, dy: 0 })
+  })
+
+  it('label-vs-label stacking still applies between persistent labels', () => {
+    // Two edges with coincident anchors (0, 0): the deterministic winner
+    // stays, the other stacks a step below.
+    const a = { id: 'a', sourceRect: rect(-400, -40), targetRect: rect(200, -40) }
+    const b = { id: 'b', sourceRect: rect(-400, -120, 200, 240), targetRect: rect(200, -120, 200, 240) }
+    const out = resolvePersistentLabelPlacements([a, b], [])
+    const dys = [out.get('a')!.dy, out.get('b')!.dy].sort((x, y) => x - y)
+    expect(dys[0]).toBe(0)
+    expect(dys[1]).toBeGreaterThanOrEqual(24)
+  })
+
+  it('deterministic: permuted edges and rects produce the identical assignment', () => {
+    const edges = [
+      { id: 'a', sourceRect: rect(-400, -40), targetRect: rect(200, -40) },
+      { id: 'b', sourceRect: rect(-400, -20), targetRect: rect(200, -20) },
+      { id: 'c', sourceRect: rect(-400, 300), targetRect: rect(200, 300) },
+    ]
+    const rects = [rect(-100, -40), rect(300, 300)]
+    const forward = resolvePersistentLabelPlacements(edges, rects)
+    const reversed = resolvePersistentLabelPlacements([...edges].reverse(), [...rects].reverse())
+    for (const id of ['a', 'b', 'c']) {
+      expect(forward.get(id)).toEqual(reversed.get(id))
+    }
+  })
+
+  it('empty edge set → empty map', () => {
+    expect(resolvePersistentLabelPlacements([], [rect(0, 0)]).size).toBe(0)
   })
 })

--- a/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
+++ b/src/canvas/edges/__tests__/edgeLabelCollision.spec.ts
@@ -202,6 +202,40 @@ describe('resolvePersistentLabelPlacements — C2 review: anchor basis + pre-res
     expect(clearOf(100 + off.dx, 60 + off.dy, n2)).toBe(true)
   })
 
+  // The discriminating finding-4 pin. The pins above happen to survive a
+  // post-resolution nudge (their nudge is horizontal and their cards are wide
+  // enough that ±20px never changes the intersection verdict), so they do not
+  // actually distinguish the two orderings. This fixture does: the UN-nudged
+  // anchor is clear of every card, so a post-resolution nudge resolves to
+  // dy 0 and then slides the label sideways INTO a card — precisely the bug.
+  //
+  //  - source (90, 0) 20×10   → bottom handle (100, 10), centre (100, 5)
+  //  - target (90, 60) 20×10  → top handle   (100, 60), centre (100, 65)
+  //  - anchor (100, 35): within 40px of the source centre → nudge fires,
+  //    perpendicular to the (vertical) handle direction → dx −20.
+  //  - blocker (−100, 20) 110×30 spans x −100..10, y 20..50: the un-nudged
+  //    label box (x 20..180) clears it by 10px; the nudged box (x 0..160)
+  //    overlaps it.
+  it('finding 4: a nudge that moves the label INTO a card is resolved, not applied after clearance', () => {
+    const src = rect(90, 0, 20, 10)
+    const tgt = rect(90, 60, 20, 10)
+    const blocker = rect(-100, 20, 110, 30)
+    const out = resolvePersistentLabelPlacements(
+      [{ id: 'e', sourceRect: src, targetRect: tgt }],
+      [src, tgt, blocker],
+    )
+    const off = out.get('e')!
+    // The nudge itself is unchanged by the fix — it still fires and survives.
+    expect(off.dx).toBe(-20)
+    // Post-resolution ordering would leave dy 0 (the un-nudged anchor is
+    // clear) and park the label at (80, 35) — inside the blocker.
+    expect(off.dy).toBeGreaterThan(0)
+    // The FINAL box (nudge + stack applied) clears every card.
+    for (const r of [src, tgt, blocker]) {
+      expect(clearOf(100 + off.dx, 35 + off.dy, r)).toBe(true)
+    }
+  })
+
   it('no nudge and no obstacles → zero total offset', () => {
     const out = resolvePersistentLabelPlacements(
       [{ id: 'e', sourceRect: rect(-400, -40), targetRect: rect(200, -40) }],

--- a/src/canvas/edges/edgeLabelCollision.ts
+++ b/src/canvas/edges/edgeLabelCollision.ts
@@ -61,6 +61,83 @@ function labelIntersectsRect(cx: number, cy: number, r: NodeRect): boolean {
   )
 }
 
+/** An edge whose persistent label participates in the placement pass. */
+export interface PlacementEdge {
+  id: string
+  sourceRect: NodeRect
+  targetRect: NodeRect
+}
+
+// Task 9c proximity nudge: when a label anchor sits within NODE_PROXIMITY px
+// of either endpoint card's centre, nudge it NUDGE_DISTANCE px perpendicular
+// to the edge direction before resolution.
+const NODE_PROXIMITY = 40
+const NUDGE_DISTANCE = 20
+
+/**
+ * C2 review (findings 3 + 4): one deterministic pass from node rects to each
+ * persistent label's TOTAL offset (proximity nudge + collision stack).
+ *
+ * Anchor basis (finding 3): every node component places its source handle at
+ * bottom-centre and its target handle at top-centre, so the bezier label
+ * point (labelX/labelY — where StyledEdge renders the label) is the midpoint
+ * of those two HANDLE points. The previous basis — midpoint of the node
+ * CENTRES — diverges from the render anchor by (sourceHeight −
+ * targetHeight)/4, so unequal-height cards were collision-tested at a point
+ * the label does not occupy. Deriving the anchor from node rects (rather
+ * than each edge's own props) keeps the pass consistent: every edge computes
+ * the SAME anchor for every label and therefore the same global assignment.
+ *
+ * Nudge order (finding 4): the Task 9c ±NUDGE_DISTANCE perpendicular nudge
+ * is applied BEFORE resolution — the resolver sees nudged anchors — so it
+ * can never push a card-cleared label back under a card. The nudge survives
+ * in the returned total offset.
+ */
+export function resolvePersistentLabelPlacements(
+  edges: readonly PlacementEdge[],
+  nodeRects: readonly NodeRect[] = [],
+): Map<string, LabelOffset> {
+  const nudges = new Map<string, LabelOffset>()
+  const points: LabelPoint[] = []
+  for (const e of edges) {
+    // Handle points: source bottom-centre → target top-centre
+    const shx = e.sourceRect.x + e.sourceRect.width / 2
+    const shy = e.sourceRect.y + e.sourceRect.height
+    const thx = e.targetRect.x + e.targetRect.width / 2
+    const thy = e.targetRect.y
+    // Render anchor = midpoint of the handle points
+    const ax = (shx + thx) / 2
+    const ay = (shy + thy) / 2
+    // Task 9c proximity nudge, keyed off the true anchor
+    const scy = e.sourceRect.y + e.sourceRect.height / 2
+    const tcy = e.targetRect.y + e.targetRect.height / 2
+    let ndx = 0
+    let ndy = 0
+    if (
+      Math.hypot(ax - shx, ay - scy) < NODE_PROXIMITY ||
+      Math.hypot(ax - thx, ay - tcy) < NODE_PROXIMITY
+    ) {
+      const ex = thx - shx
+      const ey = thy - shy
+      const len = Math.hypot(ex, ey) || 1
+      ndx = (-ey / len) * NUDGE_DISTANCE
+      ndy = (ex / len) * NUDGE_DISTANCE
+    }
+    nudges.set(e.id, { dx: ndx, dy: ndy })
+    points.push({ id: e.id, x: ax + ndx, y: ay + ndy })
+  }
+  const resolved = resolveLabelCollisionOffsets(points, nodeRects)
+  const out = new Map<string, LabelOffset>()
+  for (const e of edges) {
+    const nudge = nudges.get(e.id)!
+    const stack = resolved.get(e.id)!
+    // (+ 0 is unnecessary: −0 from the perpendicular maths normalises to +0
+    // through the addition below)
+    out.set(e.id, { dx: nudge.dx + stack.dx, dy: nudge.dy + stack.dy })
+  }
+  return out
+}
+
 export function resolveLabelCollisionOffsets(
   points: readonly LabelPoint[],
   nodeRects: readonly NodeRect[] = [],

--- a/src/canvas/edges/edgeLabelCollision.ts
+++ b/src/canvas/edges/edgeLabelCollision.ts
@@ -49,8 +49,15 @@ const MAX_STACK = 10 // guard: never loop unbounded on pathological input
 
 // Label box half-extents — the rendered label's maxWidth 160px / ~22px tall
 // (the same box the label-vs-label thresholds above approximate).
-const LABEL_HALF_WIDTH = 80
-const LABEL_HALF_HEIGHT = 11
+//
+// Exported because StyledEdge's rendered label must stay INSIDE this box for
+// the assumption to hold: the label div is capped at `maxWidth: 2 ×
+// LABEL_HALF_WIDTH` with nowrap + ellipsis, so however long the label text
+// is, it can never exceed the width the resolver clears for. A spec pins the
+// render against these constants — widening the label without widening the
+// box here would silently under-clear every dodge.
+export const LABEL_HALF_WIDTH = 80
+export const LABEL_HALF_HEIGHT = 11
 
 function labelIntersectsRect(cx: number, cy: number, r: NodeRect): boolean {
   return (

--- a/src/canvas/edges/edgeLabelCollision.ts
+++ b/src/canvas/edges/edgeLabelCollision.ts
@@ -12,6 +12,16 @@
  *
  * Collision box ≈ a rendered label (maxWidth 160px, ~22px tall with padding):
  * two anchors closer than the thresholds on BOTH axes overlap.
+ *
+ * E3 part 2 (C2): node cards are fixed obstacles too. React Flow paints the
+ * node layer ABOVE the edge-label renderer (node wrappers carry inline
+ * zIndex ≥ 0; `.react-flow__edgelabel-renderer` has none), so a label that
+ * lands under a card is clipped invisibly rather than layered on top.
+ * Callers pass every node's rect; a label whose box (the same 160×22
+ * assumption, as half-extents around the anchor) intersects any rect stacks
+ * downward by the same STEP until it clears both the node rects AND the
+ * labels placed before it. With no node rects the resolver behaves exactly
+ * as before.
  */
 export interface LabelPoint {
   id: string
@@ -24,13 +34,36 @@ export interface LabelOffset {
   dy: number
 }
 
+/** A node card's bounding box in graph coordinates. */
+export interface NodeRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 const X_THRESHOLD = 90
 const Y_THRESHOLD = 24
 const STEP = 26
 const MAX_STACK = 10 // guard: never loop unbounded on pathological input
 
+// Label box half-extents — the rendered label's maxWidth 160px / ~22px tall
+// (the same box the label-vs-label thresholds above approximate).
+const LABEL_HALF_WIDTH = 80
+const LABEL_HALF_HEIGHT = 11
+
+function labelIntersectsRect(cx: number, cy: number, r: NodeRect): boolean {
+  return (
+    cx + LABEL_HALF_WIDTH > r.x &&
+    cx - LABEL_HALF_WIDTH < r.x + r.width &&
+    cy + LABEL_HALF_HEIGHT > r.y &&
+    cy - LABEL_HALF_HEIGHT < r.y + r.height
+  )
+}
+
 export function resolveLabelCollisionOffsets(
   points: readonly LabelPoint[],
+  nodeRects: readonly NodeRect[] = [],
 ): Map<string, LabelOffset> {
   const sorted = [...points].sort(
     (a, b) => a.y - b.y || a.x - b.x || a.id.localeCompare(b.id),
@@ -41,9 +74,10 @@ export function resolveLabelCollisionOffsets(
     let dy = 0
     let guard = 0
     while (
-      placed.some(
+      (placed.some(
         (q) => Math.abs(q.x - p.x) < X_THRESHOLD && Math.abs(q.y - (p.y + dy)) < Y_THRESHOLD,
-      ) &&
+      ) ||
+        nodeRects.some((r) => labelIntersectsRect(p.x, p.y + dy, r))) &&
       guard < MAX_STACK
     ) {
       dy += STEP


### PR DESCRIPTION
## Mechanism (why the label vanishes)

Two things combine to clip persistent edge labels invisibly behind node cards (production example: "Moderate boost (uncertain)" truncated to "…erate boost (uncertain)" behind the "Equity Dilution Regret" card):

1. **Layering**: React Flow (@xyflow/react 12.10.2) renders `.react-flow__edgelabel-renderer` *before* the NodeRenderer with no z-index, and node wrappers carry inline `zIndex ≥ 0` — so node cards always paint over edge labels. An overlapped label is clipped, not layered.
2. **Resolver blind spot**: the E3 collision pass (#287, `edgeLabelCollision.ts`) receives only label anchor points — it resolves label-vs-label overlap but never sees node rects. The only node-awareness was `persistentLabelOffset` (40px centre-proximity against the edge's OWN two endpoints, 20px perpendicular nudge), far smaller than a ~200×80 card and blind to every other node.

## Fix

- **`edgeLabelCollision.ts`** — `resolveLabelCollisionOffsets` accepts an optional `nodeRects` argument. A label whose 160×22 box (the module's existing label-box assumption, as ±80/±11 half-extents around the anchor) intersects any card stacks downward by the same deterministic 26px `STEP` until clear of both the cards *and* the labels placed before it. `dx` stays 0, the `MAX_STACK` guard is unchanged, and omitted/empty `nodeRects` is byte-identical to the previous behaviour (pinned by fixture). Deliberately **no** z-index change: painting labels above nodes would trade clipping for labels obscuring card content.
- **`StyledEdge.tsx`** — the collision memo builds rects for all (non-hidden) nodes from React Flow's store using measured `width`/`height` with 200×80 fallbacks, and passes them to the resolver. The existing >12px displacement rule then draws the hairline leader for node-dodged labels with no further change (component spec asserts it).

## Perf reasoning

The resolver still runs only for `isTopStrengthEdge` labels (max 3, or all when ≤3 causal edges) — that gate is preserved. The new node-geometry subscription is a `useStore` selector that returns a **10px-quantised signature string**, and only for top-strength edges; every other edge returns a constant `''` and never re-renders from node movement. During a drag, a top-strength edge therefore recomputes roughly once per 10px of travel rather than every frame, and 10px quantisation is well inside the 26px dodge step, so it is never visible in the resolved offsets. The signature acts as the memo's recompute trigger exactly the way `sourceX/sourceY/targetX/targetY` already do for the edge's own endpoints.

## Tests (RED-first)

RED commit (7f1129ce) added the failing specs before the fix; GREEN commit (2b3926d8) makes them pass.

Pure resolver (`edgeLabelCollision.spec.ts`, +6 specs):
- label overlapping a card → displaced clear of it (dx 0)
- labels clear of every card → unmoved
- compound: a card-displaced label must not land on another label (later label makes room)
- determinism with rects: any input order → same assignment
- empty/omitted `nodeRects` → byte-identical to current behaviour (pinned fixture: crossing pair stacks exactly 26px)
- `MAX_STACK` guard still bounds pathological (unclearable) rects

Component (`StyledEdge.labelNodeDodge.spec.tsx`, new, follows the structural/hover spec harness):
- card on the label anchor → label renders displaced ≥51px with leader line ending at the label
- no colliding card → label at anchor, no leader (current-behaviour control; passed at RED)
- unmeasured card → 200×80 fallback still dodges

## Gates

- Targeted vitest — all 11 files under `src/canvas/edges`: **124/124 pass** (includes the new specs plus existing edgeLabelCollision, StyledEdge structural/contested/hover, edgeLabelVisibility, directionColour, hoverPopoverTimer)
- `ReactFlowGraph.layoutLifecycle.integration.spec.tsx` (real ReactFlowProvider, so the new `useStore` call runs unmocked): **4/4 pass**
- CI-matching typecheck `pnpm typecheck` (`tsc -p tsconfig.ci.json --noEmit`): **clean**
- Skipped locally per machine gotchas (known to hang at 0% CPU): full-suite vitest and local eslint — relying on CI for both.

## Scope notes

- The three existing StyledEdge spec harnesses gained the new mock surface (`useStore` + `getNodes`) — no assertion changes.
- The second occluded label in the production screenshot sat under the floating chat panel — that is by-design overlay stacking (zIndex 300 portal) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)