### PR TITLE
fix(results): disclose the relative influence scale (top driver = 100% by construction)

### DIFF
--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
@@ -384,6 +384,81 @@ describe('useNodeDisplayMetadata — influenceProvenance (lane C4)', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// C4 fix 2 (adversarial review, verifier-reproduced): the hook must consume
+// THE SAME row feed as the Drivers panel (selectDriverPolicyFeed — the
+// five-source merge that KEEPS metric-less rows), or the coverage verdict
+// forks per surface: the panel keeps a metric-less row (coverage incomplete →
+// set-relative fallback for ALL rows) while the hook's old private feed
+// dropped it via extractPolicyRow (coverage complete → absolute producer
+// scale) — the pill said "absolute" while the panel said "relative, top
+// always 100%" for the SAME report.
+// ---------------------------------------------------------------------------
+describe('useNodeDisplayMetadata — unified row feed (C4 fix 2)', () => {
+  it('review fixture: a metric-less row flips coverage for the canvas exactly as it does for the panel', () => {
+    // Row B carries only confidence — no id-less drop, no finite metric. The
+    // panel keeps it (rawElasticity defaults to 0), so producer coverage is
+    // INCOMPLETE and every row falls back to set-relative normalisation:
+    // A displays 1.0 on 'normalised_elasticity', NOT 0.6 on 'influence_score'.
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          factor_sensitivity: [
+            { factor_id: 'A', influence_score: 0.6, elasticity: 0.5 },
+            { factor_id: 'B', confidence: 0.7 },
+          ],
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('A', 'factor'))
+    expect(result.current.influenceProvenance).toBe('normalised_elasticity')
+    expect(result.current.influence).toBe(1)
+  })
+
+  it('review fixture: the metric-less row itself stays in the analysis set with a zero display value', () => {
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          factor_sensitivity: [
+            { factor_id: 'A', influence_score: 0.6, elasticity: 0.5 },
+            { factor_id: 'B', confidence: 0.7 },
+          ],
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('B', 'factor'))
+    expect(result.current.inSensitivityAnalysis).toBe(true)
+    expect(result.current.confidence).toBeCloseTo(0.7)
+    expect(result.current.influence).toBe(0)
+    expect(result.current.influenceProvenance).toBe('normalised_elasticity')
+  })
+
+  it('drivers_payload-only report: the canvas sees the rows the panel renders (same verdict both surfaces)', () => {
+    // No factor_sensitivity at all — the panel's merge picks the rows up from
+    // report.drivers_payload.drivers; the hook's old private feed saw nothing.
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          drivers_payload: {
+            drivers: [
+              { node_id: 'X', elasticity: 0.7 },
+              { node_id: 'Y', elasticity: 0.35 },
+            ],
+          },
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('X', 'factor'))
+    expect(result.current.inSensitivityAnalysis).toBe(true)
+    expect(result.current.sensitivityRank).toBe(1)
+    expect(result.current.influence).toBe(1)
+    expect(result.current.influenceProvenance).toBe('normalised_elasticity')
+  })
+})
+
 describe('useNodeDisplayMetadata — partial influence coverage (P0-2)', () => {
   it('ranks by `sensitivity` magnitude, not alphabetically, when influence_score coverage is partial', () => {
     // A carries influence_score but a SMALL sensitivity; B carries only a LARGE

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
@@ -324,6 +324,66 @@ describe('useNodeDisplayMetadata — factor sensitivityRank', () => {
 // key). The prior inline map omitted `sensitivity`, so every row collapsed to 0
 // and the badge fell back to alphabetical order.
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Lane C4 (influence-scale disclosure): the hook must surface WHICH basis
+// produced `influence` (the shared display model already resolves it) so the
+// canvas "I: NN%" pill can disclose the set-relative scale exactly like the
+// Drivers panel. Before C4 the provenance was resolved and then dropped.
+// ---------------------------------------------------------------------------
+describe('useNodeDisplayMetadata — influenceProvenance (lane C4)', () => {
+  it('reports normalised_elasticity under partial influence_score coverage (fallback basis)', () => {
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          factor_sensitivity: [
+            { factor_id: 'A', sensitivity: 0.2, influence_score: 0.9 },
+            { factor_id: 'B', sensitivity: 0.8 },
+          ],
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('B', 'factor'))
+    expect(result.current.influenceProvenance).toBe('normalised_elasticity')
+    // The fallback basis is set-relative: the top factor is 1.0 by construction.
+    expect(result.current.influence).toBe(1)
+  })
+
+  it('reports influence_score when EVERY factor carries a finite producer score', () => {
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          factor_sensitivity: [
+            { factor_id: 'A', sensitivity: 0.2, influence_score: 0.62 },
+            { factor_id: 'B', sensitivity: 0.8, influence_score: 0.31 },
+          ],
+        }),
+      },
+    }
+    const { result } = renderHook(() => useNodeDisplayMetadata('A', 'factor'))
+    expect(result.current.influenceProvenance).toBe('influence_score')
+    expect(result.current.influence).toBeCloseTo(0.62)
+  })
+
+  it('is null outside results mode and for nodes not in the analysis', () => {
+    const { result: idle } = renderHook(() => useNodeDisplayMetadata('A', 'factor'))
+    expect(idle.current.influenceProvenance).toBeNull()
+
+    mockState = {
+      results: {
+        status: 'complete',
+        report: makeReport({
+          factor_sensitivity: [{ factor_id: 'A', elasticity: 0.9 }],
+        }),
+      },
+    }
+    const { result: missing } = renderHook(() => useNodeDisplayMetadata('not-there', 'factor'))
+    expect(missing.current.influenceProvenance).toBeNull()
+    expect(missing.current.influence).toBeNull()
+  })
+})
+
 describe('useNodeDisplayMetadata — partial influence coverage (P0-2)', () => {
   it('ranks by `sensitivity` magnitude, not alphabetically, when influence_score coverage is partial', () => {
     // A carries influence_score but a SMALL sensitivity; B carries only a LARGE

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -12,12 +12,22 @@ import { useMemo } from 'react'
 import { useCanvasStore } from '../store'
 import type { NodeType } from '../domain/nodes'
 import { selectDriverDisplayModel, compareByDisplayModel, extractPolicyRow } from '../../components/results/driverDisplayModel'
+import type { DriverDisplayProvenance } from '../../components/results/driverDisplayModel'
 
 interface NodeDisplayMetadata {
   /** Factor sensitivity rank (1-3 for top factors, null otherwise) */
   sensitivityRank: number | null
   /** Factor influence score (0-1, normalized) - Task 3 */
   influence: number | null
+  /**
+   * Lane C4 (influence-scale disclosure): which basis produced `influence`,
+   * read straight off the shared display model entry ('influence_score' =
+   * absolute producer scale; 'normalised_elasticity' = set-relative, top
+   * driver ≡ 1.0 by construction). Surfaces rendering the number (the
+   * MetricPills "I: NN%" chip) use this to disclose the scale exactly like
+   * the Drivers panel. Null whenever `influence` is null.
+   */
+  influenceProvenance: DriverDisplayProvenance | null
   /** Factor confidence score (0-1) - Task 3 */
   confidence: number | null
   /** Whether this factor was found in the sensitivity analysis (false for root nodes like "Value") */
@@ -75,6 +85,7 @@ export function useNodeDisplayMetadata(
       return {
         sensitivityRank: null,
         influence: null,
+        influenceProvenance: null,
         confidence: null,
         inSensitivityAnalysis: false,
         achievementProbability: null,
@@ -91,6 +102,7 @@ export function useNodeDisplayMetadata(
     // Task 5 & 3: Factor sensitivity rank (top 3 only) and influence/confidence
     let sensitivityRank: number | null = null
     let influence: number | null = null
+    let influenceProvenance: DriverDisplayProvenance | null = null
     let confidence: number | null = null
     let inSensitivityAnalysis = false
     let valueOfInformation: number | null = null
@@ -166,10 +178,13 @@ export function useNodeDisplayMetadata(
         // Influence readout: the shared display model already resolved the
         // displayed value under the complete-metric-set policy (Codex R3-B1)
         // — read it back so the "I: NN%" beside the badge is the number the
-        // rank used, on the same basis as the panel.
+        // rank used, on the same basis as the panel. Lane C4: carry the
+        // model's provenance out with the value so the pill can disclose
+        // the basis (set-relative top ≡ 100% vs absolute producer score).
         const modelEntry = displayModel.get(nodeId)
         if (modelEntry && Number.isFinite(modelEntry.value)) {
           influence = modelEntry.value
+          influenceProvenance = modelEntry.provenance
         }
 
         // Confidence: Direct extraction (already 0-1)
@@ -254,6 +269,7 @@ export function useNodeDisplayMetadata(
     return {
       sensitivityRank,
       influence,
+      influenceProvenance,
       confidence,
       inSensitivityAnalysis,
       achievementProbability,

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -11,8 +11,10 @@
 import { useMemo } from 'react'
 import { useCanvasStore } from '../store'
 import type { NodeType } from '../domain/nodes'
-import { selectDriverDisplayModel, compareByDisplayModel, extractPolicyRow } from '../../components/results/driverDisplayModel'
+import { compareByDisplayModel } from '../../components/results/driverDisplayModel'
 import type { DriverDisplayProvenance } from '../../components/results/driverDisplayModel'
+import { selectDriverPolicyFeed } from '../../components/results/useResultsSectionData'
+import type { ResultsReport } from '../../components/results/types'
 
 interface NodeDisplayMetadata {
   /** Factor sensitivity rank (1-3 for top factors, null otherwise) */
@@ -108,35 +110,23 @@ export function useNodeDisplayMetadata(
     let valueOfInformation: number | null = null
     let voiRank: number | null = null
     if (nodeType === 'factor') {
-      // Codex B2: rank off the CERTIFIED factor_sensitivity array first (the
-      // untyped enrichment passthrough is a fallback only — it must never
-      // silently drive a different #1 than the panel), and rank by the
-      // DISPLAYED influence metric so the badge order matches the "I: NN%"
-      // readout beside it. Codex R3-B1: complete-metric-set policy — producer
-      // influence_score is used only when EVERY factor in the array carries
-      // one; under partial coverage every factor uses per-array-normalised
-      // elasticity, so ranks never compare producer scores against fallbacks.
-      // Mirrors the identical policy in useResultsSectionData (panel side).
-      const factorSensitivity = (report.factor_sensitivity?.length
-        ? report.factor_sensitivity
-        : report.enrichment?.sensitivity_analysis?.factors) || []
-
-      // Codex R3-B1 + P0-2 (external review 2026-07-14): display value + rank
-      // come from the ONE shared policy ROW (extractPolicyRow), so the badge
-      // can never rank or label a factor on a different basis than the results
-      // Drivers panel. The prior inline map OMITTED `sensitivity` from the
-      // magnitude chain — the exact key the V5 mapper writes — and accepted
-      // camelCase influenceScore, so under partial influence coverage every row
-      // collapsed to 0 and the badge fell back to alphabetical order while the
-      // panel ranked correctly by magnitude. extractPolicyRow includes
-      // `sensitivity`, reads snake-only influence_score, and drops rows with no
-      // id / no finite metric. Producer influence_score is used only when EVERY
-      // factor has one (selectDriverDisplayModel coverage rule); else per-set
-      // normalised |magnitude| for all.
-      const rows = (factorSensitivity as unknown[])
-        .map(extractPolicyRow)
-        .filter((r): r is NonNullable<ReturnType<typeof extractPolicyRow>> => r != null)
-      const displayModel = selectDriverDisplayModel(rows)
+      // C4 fix 2 (adversarial review, verifier-reproduced): read THE shared
+      // row feed — the same merge the Drivers panel renders from. Sharing the
+      // policy FUNCTION (selectDriverDisplayModel) was not enough: this hook
+      // used to build a PRIVATE factor_sensitivity-only feed through
+      // extractPolicyRow, which DROPS rows carrying no finite metric, while
+      // the panel's merge KEEPS them. Because producer influence_score is
+      // adopted only when EVERY row carries one, dropping a metric-less row
+      // flipped coverage to complete for the canvas and left it incomplete
+      // for the panel — so the pill disclosed an "absolute causal influence
+      // score" while the panel disclosed "relative, top always 100%", for the
+      // SAME report. One feed makes that fork unrepresentable. The feed also
+      // subsumes the certified-array-first / enrichment-fallback precedence
+      // this hook used to apply, and is memoised per REPORT (not per node),
+      // so running it for every factor node stays O(1) after the first.
+      const feed = selectDriverPolicyFeed(report as unknown as ResultsReport)
+      const rows = feed.policyRows
+      const displayModel = feed.displayModel
       const ranked = rows
         .map((r) => ({
           key: r.key,
@@ -149,28 +139,26 @@ export function useNodeDisplayMetadata(
       const rank = ranked.findIndex(f => f.key === nodeId) + 1
       sensitivityRank = rank > 0 && rank <= 3 ? rank : null
 
-      // VoI rank: top-3 factors by value_of_information
-      const rankedByVoi = [...factorSensitivity]
-        .map((f: any) => ({
-          id: (f.factor_id || f.factorId || f.node_id || f.nodeId) as string,
-          voi: (f.value_of_information ?? f.valueOfInformation ?? 0) as number,
-        }))
+      // VoI rank: top-3 factors by value_of_information. Keyed off the shared
+      // feed's canonical key (node_id → factor_id → id → label), so a row
+      // carrying several differing id fields can no longer rank under one id
+      // here and another in the panel.
+      const rankedByVoi = rows
+        .map((r) => ({ id: r.key, voi: r.valueOfInformation ?? 0 }))
         .filter(f => typeof f.voi === 'number' && f.voi > 0)
         .sort((a, b) => b.voi - a.voi)
       const voiPos = rankedByVoi.findIndex(f => f.id === nodeId) + 1
       if (voiPos > 0 && voiPos <= 3) voiRank = voiPos
 
       // Task 3: Extract influence, confidence, and VoI for this factor
-      const factorData = factorSensitivity.find((f: any) =>
-        (f.factor_id || f.factorId || f.node_id || f.nodeId) === nodeId
-      )
+      const factorRow = rows.find((r) => r.key === nodeId)
 
-      if (factorData) {
+      if (factorRow) {
         // Factor found in sensitivity analysis
         inSensitivityAnalysis = true
 
         // VoI: value_of_information is a direct 0-1 score
-        const rawVoi = (factorData.value_of_information ?? factorData.valueOfInformation) as number | undefined
+        const rawVoi = factorRow.valueOfInformation
         if (typeof rawVoi === 'number' && rawVoi >= 0 && rawVoi <= 1) {
           valueOfInformation = rawVoi
         }
@@ -190,7 +178,7 @@ export function useNodeDisplayMetadata(
         // Confidence: Direct extraction (already 0-1)
         // Note: Intentionally NOT using value_of_information as fallback - VOI is semantically
         // different from confidence (it measures value of learning more, not certainty)
-        const rawConfidence = factorData.confidence
+        const rawConfidence = factorRow.confidence
 
         if (typeof rawConfidence === 'number' && rawConfidence >= 0 && rawConfidence <= 1) {
           confidence = rawConfidence

--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -16,6 +16,7 @@ import { formatFactorDisplayValue } from '../../utils/formatFactorDisplayValue'
 import { isGraphBadgesEnabled } from '../../flags'
 import { SlidersHorizontal, Eye, Cloud } from 'lucide-react'
 import { DataBar } from '../ui/shared/DataBar'
+import { influenceExplanation, influenceBarAriaLabel } from '../../components/results/influenceScaleCopy'
 import { CoachingCard } from '../components/CoachingCard'
 import { useNodeConnections } from '../hooks/useNodeConnections'
 import { usePopoverHover } from '../hooks/usePopoverHover'
@@ -484,11 +485,27 @@ export const FactorNode = memo((props: NodeProps) => {
       {/* Influence & Confidence bars */}
       {(influencePct != null && influencePct > 0 || confidencePct != null && confidencePct > 0) && (
         <div className="space-y-1.5 mb-1">
+          {/* Review fix 4: the detailed view renders the SAME display-model
+              number as the Standard-view pill one level up, so it carries the
+              same misread risk — on the fallback basis the top driver shows
+              100% BY CONSTRUCTION. Disclose the basis here too: `title` for
+              pointer users, and the DataBar's accessible name (its
+              role="progressbar" announces the value via aria-valuenow, so the
+              name carries the basis only). Copy from the ONE shared module, so
+              this row cannot drift from the pill or the panel. Fail-closed: no
+              provenance → generic wording, never a basis claim. */}
           {influencePct != null && influencePct > 0 && (
-            <div className="flex items-center gap-1.5">
+            <div
+              className="flex items-center gap-1.5"
+              title={influenceExplanation(displayMetadata.influenceProvenance)}
+            >
               <span className={`${typography.edgeLabel} text-text-light w-14 shrink-0`}>Influence</span>
               <div className="flex-1 min-w-0">
-                <DataBar value={influencePct / 100} label="Influence" colour="info" />
+                <DataBar
+                  value={influencePct / 100}
+                  label={influenceBarAriaLabel(displayMetadata.influenceProvenance)}
+                  colour="info"
+                />
               </div>
               <span className={`${typography.edgeLabel} text-text-light w-7 text-right shrink-0`}>{influencePct}%</span>
             </div>

--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -695,10 +695,13 @@ export const FactorNode = memo((props: NodeProps) => {
           </p>
         )}
 
-        {/* Post-analysis: MetricPills */}
+        {/* Post-analysis: MetricPills. Lane C4: pass the display model's
+            provenance through so the "I: NN%" pill discloses the basis
+            (set-relative top ≡ 100% vs absolute producer score). */}
         {isPostAnalysis && (
           <MetricPills
             influencePct={influencePct}
+            influenceProvenance={displayMetadata.influenceProvenance}
             confidencePct={confidencePct}
           />
         )}

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -683,6 +683,51 @@ describe('FactorNode', () => {
     const { container } = renderFactor({ label: 'Revenue', type: 'factor' })
     expect(container.querySelectorAll('[role="progressbar"]').length).toBe(0)
   })
+
+  // Lane C4 (influence-scale disclosure): the "I: NN%" pill shares the panel's
+  // display number; when the shared model resolved it on the fallback
+  // (set-relative) basis, FactorNode must pass that provenance through so the
+  // pill discloses "top driver always shows 100%" instead of reading as an
+  // absolute causal share.
+  it('passes influence provenance to MetricPills so the pill discloses the relative scale (C4)', () => {
+    vi.mocked(useCanvasStore).mockImplementation((selector: any) =>
+      selector({
+        hoveredOptionId: null,
+        nodes: [],
+        edges: [],
+        ceeAnalysisReady: null,
+        results: { status: 'complete', report: null },
+        highlightedNodes: new Set(),
+        dimmedNodeIds: new Set(),
+        goalThreshold: null,
+        goalConstraints: [],
+        viewMode: 'standard',
+      })
+    )
+    vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+      sensitivityRank: 1,
+      influence: 1,
+      influenceProvenance: 'normalised_elasticity',
+      confidence: null,
+      inSensitivityAnalysis: true,
+      achievementProbability: null,
+      achievementProbabilityIsModelledBasis: false,
+      stabilityPercentage: null,
+      winRate: null,
+      isResultsMode: true,
+      predictedOutcome: null,
+      valueOfInformation: null,
+      voiRank: null,
+    })
+    renderFactor({ label: 'Technical Leadership Capability', type: 'factor', observedState: { value: 0.5 } })
+    const pill = screen.getByText('I: 100%')
+    expect(pill.getAttribute('title')).toBe(
+      'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+    )
+    expect(pill.getAttribute('aria-label')).toBe(
+      'Influence 100%, relative to the strongest factor — the top driver always shows 100%'
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -722,10 +722,10 @@ describe('FactorNode', () => {
     renderFactor({ label: 'Technical Leadership Capability', type: 'factor', observedState: { value: 0.5 } })
     const pill = screen.getByText('I: 100%')
     expect(pill.getAttribute('title')).toBe(
-      'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+      'Influence: how much this factor affects the outcome, relative to the strongest. The top driver always shows 100%.'
     )
     expect(pill.getAttribute('aria-label')).toBe(
-      'Influence 100%, relative to the strongest factor — the top driver always shows 100%'
+      'Influence 100%, relative to the strongest factor. The top driver always shows 100%'
     )
   })
 })

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -728,6 +728,88 @@ describe('FactorNode', () => {
       'Influence 100%, relative to the strongest factor. The top driver always shows 100%'
     )
   })
+
+  // -------------------------------------------------------------------------
+  // Review fix 4: the DETAILED view renders the same display-model number one
+  // level up from the pill ('Influence' + DataBar + 'NN%') and had NO basis
+  // disclosure at all — the identical misread class the pill fix addressed.
+  // The bar's accessible name carries the basis (its role="progressbar"
+  // announces the value via aria-valuenow); `title` carries it for pointer
+  // users. Both bases pinned, plus the fail-closed no-provenance case.
+  // -------------------------------------------------------------------------
+  describe('detailed-view Influence row discloses the basis (review fix 4)', () => {
+    function renderDetailedWithProvenance(
+      influenceProvenance: 'normalised_elasticity' | 'influence_score' | null,
+      influence: number,
+    ) {
+      vi.mocked(useCanvasStore).mockImplementation((selector: any) =>
+        selector({
+          hoveredOptionId: null,
+          nodes: [],
+          edges: [],
+          ceeAnalysisReady: null,
+          results: { status: 'complete', report: null },
+          highlightedNodes: new Set(),
+          dimmedNodeIds: new Set(),
+          goalThreshold: null,
+          goalConstraints: [],
+          viewMode: 'expert', // Detailed → Layer 2 inline
+        })
+      )
+      vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+        sensitivityRank: 1,
+        influence,
+        influenceProvenance,
+        confidence: null,
+        inSensitivityAnalysis: true,
+        achievementProbability: null,
+        achievementProbabilityIsModelledBasis: false,
+        stabilityPercentage: null,
+        winRate: null,
+        isResultsMode: true,
+        predictedOutcome: null,
+        valueOfInformation: null,
+        voiRank: null,
+      } as any)
+      return renderFactor({ label: 'Revenue', type: 'factor', observedState: { value: 0.5 } })
+    }
+
+    it('fallback basis: the row discloses that the top driver always shows 100%', () => {
+      renderDetailedWithProvenance('normalised_elasticity', 1)
+      const bar = screen.getByRole('progressbar', {
+        name: 'Influence, relative to the strongest factor. The top driver always shows 100%',
+      })
+      expect(bar.getAttribute('aria-valuenow')).toBe('100')
+      // Pointer users get the same disclosure on the row.
+      const row = screen.getByText('Influence').closest('div')
+      expect(row?.getAttribute('title')).toBe(
+        'Influence: how much this factor affects the outcome, relative to the strongest. The top driver always shows 100%.'
+      )
+    })
+
+    it('producer basis: the row discloses the absolute causal influence score', () => {
+      renderDetailedWithProvenance('influence_score', 0.6)
+      const bar = screen.getByRole('progressbar', {
+        name: 'Influence, an absolute causal influence score from the analysis',
+      })
+      expect(bar.getAttribute('aria-valuenow')).toBe('60')
+      const row = screen.getByText('Influence').closest('div')
+      expect(row?.getAttribute('title')).toBe(
+        'Influence: how much this factor affects the outcome, as an absolute causal influence score from the analysis.'
+      )
+    })
+
+    it('no provenance stamp: fails closed to generic wording, claiming no basis', () => {
+      renderDetailedWithProvenance(null, 0.6)
+      const bar = screen.getByRole('progressbar', { name: 'Influence' })
+      expect(bar.getAttribute('aria-valuenow')).toBe('60')
+      const row = screen.getByText('Influence').closest('div')
+      expect(row?.getAttribute('title')).toBe(
+        'Influence: how much this factor affects the outcome'
+      )
+      expect(row?.getAttribute('title')).not.toContain('100%')
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/nodes/shared/MetricPills.tsx
+++ b/src/canvas/nodes/shared/MetricPills.tsx
@@ -11,11 +11,14 @@
  * tooltip idiom — same as the sibling EdgePills strength pill; the floating
  * DS Tooltip is not used inside React Flow node chrome). Fail-closed: with no
  * provenance passed, the pill keeps a generic honest label and never claims a
- * basis it was not given. Copy mirrors DriversSection.tsx — keep in step.
+ * basis it was not given. Copy comes from the ONE shared module
+ * (influenceScaleCopy) DriversSection consumes too, so the surfaces cannot
+ * drift (review fix 3).
  */
 import { BiasIcon } from './BiasIcon'
 import type { ComponentProps } from 'react'
 import type { DriverDisplayProvenance } from '../../../components/results/driverDisplayModel'
+import { influenceExplanation, influencePillAriaLabel } from '../../../components/results/influenceScaleCopy'
 
 type BiasIconProps = ComponentProps<typeof BiasIcon>
 
@@ -37,18 +40,8 @@ export function MetricPills({ influencePct, influenceProvenance, confidencePct, 
 
   if (!hasInfluence && !hasConfidence && !hasBias) return null
 
-  const influenceTitle =
-    influenceProvenance === 'normalised_elasticity'
-      ? 'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
-      : influenceProvenance === 'influence_score'
-        ? 'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
-        : 'Influence: how much this factor affects the outcome'
-  const influenceAria =
-    influenceProvenance === 'normalised_elasticity'
-      ? `Influence ${influencePct}%, relative to the strongest factor — the top driver always shows 100%`
-      : influenceProvenance === 'influence_score'
-        ? `Influence ${influencePct}% — an absolute causal influence score from the analysis`
-        : `Influence ${influencePct}%`
+  const influenceTitle = influenceExplanation(influenceProvenance)
+  const influenceAria = influencePillAriaLabel(influencePct ?? 0, influenceProvenance)
 
   return (
     <div className="flex gap-[3px] mt-1.5 items-center flex-wrap">

--- a/src/canvas/nodes/shared/MetricPills.tsx
+++ b/src/canvas/nodes/shared/MetricPills.tsx
@@ -49,6 +49,13 @@ export function MetricPills({ influencePct, influenceProvenance, confidencePct, 
         <span
           className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-info/40 text-text-body"
           title={influenceTitle}
+          // Review fix 5: aria-label on a role-less <span> is unreliably
+          // announced (generic role), and `title` alone is keyboard/touch
+          // unreachable. role="img" gives the label a semantic anchor that
+          // AT consistently announces — the codebase's ratified idiom for
+          // meaningful static markers (see ReadinessColourStrip.tsx for the
+          // rationale).
+          role="img"
           aria-label={influenceAria}
         >
           I: {influencePct}%

--- a/src/canvas/nodes/shared/MetricPills.tsx
+++ b/src/canvas/nodes/shared/MetricPills.tsx
@@ -2,14 +2,27 @@
  * MetricPills — compact row of small outlined pills at the bottom of Standard view nodes.
  * Three pill types: Influence (I:%), Confidence (C:%), and optional bias icon.
  * Font 10px (edgeLabel). Pill padding 1px 5px. Border-radius 10px. Gap 3px.
+ *
+ * Lane C4 (influence-scale disclosure): the influence number comes from the
+ * shared display model (useNodeDisplayMetadata → driverDisplayModel), which on
+ * the fallback basis ('normalised_elasticity') is per-set normalised
+ * |elasticity| — the top driver shows 100% BY CONSTRUCTION. The pill therefore
+ * discloses the basis via native `title` + `aria-label` (the canvas-node
+ * tooltip idiom — same as the sibling EdgePills strength pill; the floating
+ * DS Tooltip is not used inside React Flow node chrome). Fail-closed: with no
+ * provenance passed, the pill keeps a generic honest label and never claims a
+ * basis it was not given. Copy mirrors DriversSection.tsx — keep in step.
  */
 import { BiasIcon } from './BiasIcon'
 import type { ComponentProps } from 'react'
+import type { DriverDisplayProvenance } from '../../../components/results/driverDisplayModel'
 
 type BiasIconProps = ComponentProps<typeof BiasIcon>
 
 interface MetricPillsProps {
   influencePct?: number | null
+  /** Which basis produced influencePct (see driverDisplayModel). Absent → generic copy. */
+  influenceProvenance?: DriverDisplayProvenance | null
   confidencePct?: number | null
   biasType?: BiasIconProps['bias']
   biasTip?: string
@@ -17,17 +30,34 @@ interface MetricPillsProps {
   biasLinkMessage?: string
 }
 
-export function MetricPills({ influencePct, confidencePct, biasType, biasTip, biasLinkLabel, biasLinkMessage }: MetricPillsProps) {
+export function MetricPills({ influencePct, influenceProvenance, confidencePct, biasType, biasTip, biasLinkLabel, biasLinkMessage }: MetricPillsProps) {
   const hasInfluence = influencePct != null && influencePct > 0
   const hasConfidence = confidencePct != null && confidencePct > 0
   const hasBias = biasType && biasTip
 
   if (!hasInfluence && !hasConfidence && !hasBias) return null
 
+  const influenceTitle =
+    influenceProvenance === 'normalised_elasticity'
+      ? 'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+      : influenceProvenance === 'influence_score'
+        ? 'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
+        : 'Influence: how much this factor affects the outcome'
+  const influenceAria =
+    influenceProvenance === 'normalised_elasticity'
+      ? `Influence ${influencePct}%, relative to the strongest factor — the top driver always shows 100%`
+      : influenceProvenance === 'influence_score'
+        ? `Influence ${influencePct}% — an absolute causal influence score from the analysis`
+        : `Influence ${influencePct}%`
+
   return (
     <div className="flex gap-[3px] mt-1.5 items-center flex-wrap">
       {hasInfluence && (
-        <span className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-info/40 text-text-body">
+        <span
+          className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-info/40 text-text-body"
+          title={influenceTitle}
+          aria-label={influenceAria}
+        >
           I: {influencePct}%
         </span>
       )}

--- a/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
@@ -1,0 +1,62 @@
+/**
+ * MetricPills — influence-scale disclosure (lane C4).
+ *
+ * The "I: NN%" chip shares its number with the Drivers panel via the shared
+ * display model (useNodeDisplayMetadata → driverDisplayModel), but rendered it
+ * bare — no tooltip, no accessible name. On the fallback basis
+ * ('normalised_elasticity') that number is set-relative (top driver ≡ 100% by
+ * construction), so the chip must disclose the scale the same way the panel
+ * does. Canvas-node idiom: native `title` + `aria-label` on the pill span
+ * (same as the sibling EdgePills strength pill — audit §8 P0-4).
+ *
+ * Fail-closed: with no provenance passed (legacy callers/fixtures) the chip
+ * keeps a generic honest label and never claims a basis it was not given.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MetricPills } from '../MetricPills'
+
+const RELATIVE_TITLE =
+  'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+const ABSOLUTE_TITLE =
+  'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
+const GENERIC_TITLE = 'Influence: how much this factor affects the outcome'
+
+describe('MetricPills — influence-scale disclosure (lane C4)', () => {
+  it('relative basis: pill carries the relative-scale title and aria-label', () => {
+    render(<MetricPills influencePct={100} influenceProvenance="normalised_elasticity" />)
+    const pill = screen.getByText('I: 100%')
+    expect(pill.getAttribute('title')).toBe(RELATIVE_TITLE)
+    expect(pill.getAttribute('aria-label')).toBe(
+      'Influence 100%, relative to the strongest factor — the top driver always shows 100%',
+    )
+  })
+
+  it('producer basis: pill carries the absolute-basis wording, never the relative claim', () => {
+    render(<MetricPills influencePct={62} influenceProvenance="influence_score" />)
+    const pill = screen.getByText('I: 62%')
+    expect(pill.getAttribute('title')).toBe(ABSOLUTE_TITLE)
+    expect(pill.getAttribute('aria-label')).toBe(
+      'Influence 62% — an absolute causal influence score from the analysis',
+    )
+    expect(pill.getAttribute('title')).not.toContain('always shows 100%')
+  })
+
+  it('no provenance (fail-closed): generic honest label, no basis claim', () => {
+    render(<MetricPills influencePct={80} />)
+    const pill = screen.getByText('I: 80%')
+    expect(pill.getAttribute('title')).toBe(GENERIC_TITLE)
+    expect(pill.getAttribute('aria-label')).toBe('Influence 80%')
+  })
+
+  it('unchanged behaviour: renders nothing when no metric is present', () => {
+    const { container } = render(<MetricPills />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('unchanged behaviour: confidence pill renders without an influence disclosure', () => {
+    render(<MetricPills confidencePct={45} />)
+    expect(screen.getByText('C: 45%')).toBeDefined()
+    expect(screen.queryByText(/^I: /)).toBeNull()
+  })
+})

--- a/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
@@ -16,10 +16,13 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MetricPills } from '../MetricPills'
 
+// Deliberately hard-coded (not imported from influenceScaleCopy) so a copy
+// change is a conscious, visible decision in this spec. No em dashes (DS ban,
+// review fix 3 — policed by influenceScaleCopy.copyHygiene.spec.ts).
 const RELATIVE_TITLE =
-  'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+  'Influence: how much this factor affects the outcome, relative to the strongest. The top driver always shows 100%.'
 const ABSOLUTE_TITLE =
-  'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
+  'Influence: how much this factor affects the outcome, as an absolute causal influence score from the analysis.'
 const GENERIC_TITLE = 'Influence: how much this factor affects the outcome'
 
 describe('MetricPills — influence-scale disclosure (lane C4)', () => {
@@ -28,7 +31,7 @@ describe('MetricPills — influence-scale disclosure (lane C4)', () => {
     const pill = screen.getByText('I: 100%')
     expect(pill.getAttribute('title')).toBe(RELATIVE_TITLE)
     expect(pill.getAttribute('aria-label')).toBe(
-      'Influence 100%, relative to the strongest factor — the top driver always shows 100%',
+      'Influence 100%, relative to the strongest factor. The top driver always shows 100%',
     )
   })
 
@@ -37,7 +40,7 @@ describe('MetricPills — influence-scale disclosure (lane C4)', () => {
     const pill = screen.getByText('I: 62%')
     expect(pill.getAttribute('title')).toBe(ABSOLUTE_TITLE)
     expect(pill.getAttribute('aria-label')).toBe(
-      'Influence 62% — an absolute causal influence score from the analysis',
+      'Influence 62%, an absolute causal influence score from the analysis',
     )
     expect(pill.getAttribute('title')).not.toContain('always shows 100%')
   })

--- a/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
@@ -26,30 +26,35 @@ const ABSOLUTE_TITLE =
 const GENERIC_TITLE = 'Influence: how much this factor affects the outcome'
 
 describe('MetricPills — influence-scale disclosure (lane C4)', () => {
-  it('relative basis: pill carries the relative-scale title and aria-label', () => {
+  // Review fix 5: aria-label on a role-less <span> is unreliably announced
+  // (generic role). The pill must use the codebase's ratified idiom for
+  // meaningful static markers — role="img" + aria-label (see
+  // ReadinessColourStrip.tsx for the rationale) — so every assertion below
+  // resolves the pill BY that role and accessible name.
+  it('relative basis: pill is a role="img" named with the relative-scale disclosure, plus a title', () => {
     render(<MetricPills influencePct={100} influenceProvenance="normalised_elasticity" />)
-    const pill = screen.getByText('I: 100%')
+    const pill = screen.getByRole('img', {
+      name: 'Influence 100%, relative to the strongest factor. The top driver always shows 100%',
+    })
+    expect(pill.textContent).toBe('I: 100%')
     expect(pill.getAttribute('title')).toBe(RELATIVE_TITLE)
-    expect(pill.getAttribute('aria-label')).toBe(
-      'Influence 100%, relative to the strongest factor. The top driver always shows 100%',
-    )
   })
 
   it('producer basis: pill carries the absolute-basis wording, never the relative claim', () => {
     render(<MetricPills influencePct={62} influenceProvenance="influence_score" />)
-    const pill = screen.getByText('I: 62%')
+    const pill = screen.getByRole('img', {
+      name: 'Influence 62%, an absolute causal influence score from the analysis',
+    })
+    expect(pill.textContent).toBe('I: 62%')
     expect(pill.getAttribute('title')).toBe(ABSOLUTE_TITLE)
-    expect(pill.getAttribute('aria-label')).toBe(
-      'Influence 62%, an absolute causal influence score from the analysis',
-    )
     expect(pill.getAttribute('title')).not.toContain('always shows 100%')
   })
 
   it('no provenance (fail-closed): generic honest label, no basis claim', () => {
     render(<MetricPills influencePct={80} />)
-    const pill = screen.getByText('I: 80%')
+    const pill = screen.getByRole('img', { name: 'Influence 80%' })
+    expect(pill.textContent).toBe('I: 80%')
     expect(pill.getAttribute('title')).toBe(GENERIC_TITLE)
-    expect(pill.getAttribute('aria-label')).toBe('Influence 80%')
   })
 
   it('unchanged behaviour: renders nothing when no metric is present', () => {

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -886,7 +886,7 @@ export function DriversSection({
   // shows 100% BY CONSTRUCTION — that must be disclosed (the "Relative
   // influence" wording was dropped in v7.10 T9). On the producer basis
   // ('influence_score') the value is an absolute structural-causal-influence
-  // score (types.ts DriverItem.influenceScore) — say that instead. No stamp
+  // score from the producer (see the DriverItem type) — say that instead. No stamp
   // (legacy fixtures / cached payloads) → fail-closed: keep the generic
   // wording; never claim a basis the pipeline did not stamp. Derived from the
   // FULL drivers list (same belt-and-braces as anyConfidenceProvisional).

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -878,14 +878,59 @@ export function DriversSection({
   // place. DriversSection still surfaces per-row sensitivity / confidence;
   // the cross-driver dominance signal is owned by T1.
 
+  // Lane C4 (influence-scale disclosure): the shared display model
+  // (driverDisplayModel.selectDriverDisplayModel) resolves ONE basis for the
+  // entire ranked set — so any stamped row's `displayProvenance` describes
+  // the whole panel. On the fallback basis ('normalised_elasticity') the
+  // displayed value is per-set normalised |elasticity| and the top driver
+  // shows 100% BY CONSTRUCTION — that must be disclosed (the "Relative
+  // influence" wording was dropped in v7.10 T9). On the producer basis
+  // ('influence_score') the value is an absolute structural-causal-influence
+  // score (types.ts DriverItem.influenceScore) — say that instead. No stamp
+  // (legacy fixtures / cached payloads) → fail-closed: keep the generic
+  // wording; never claim a basis the pipeline did not stamp. Derived from the
+  // FULL drivers list (same belt-and-braces as anyConfidenceProvisional).
+  const influenceBasis: 'relative' | 'absolute' | 'unknown' =
+    drivers.some(d => d.displayProvenance === 'normalised_elasticity')
+      ? 'relative'
+      : drivers.some(d => d.displayProvenance === 'influence_score')
+        ? 'absolute'
+        : 'unknown'
+  // Copy note: the pill in canvas MetricPills.tsx mirrors these strings —
+  // keep them in step (pinned by both surfaces' specs).
+  const influenceTooltipContent =
+    influenceBasis === 'relative'
+      ? 'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+      : influenceBasis === 'absolute'
+        ? 'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
+        : 'Influence: how much this factor affects the outcome'
+
   return (
     <div className="space-y-4">
-      {/* Ranking explainer */}
-      <p className={`${typography.panelMeta} text-text-light`}>Ranked by how much each factor affects the outcome</p>
+      {/* Ranking explainer — carries the relative framing on the fallback basis (C4) */}
+      <p className={`${typography.panelMeta} text-text-light`}>
+        {influenceBasis === 'relative'
+          ? 'Ranked by how much each factor affects the outcome, relative to the strongest factor'
+          : 'Ranked by how much each factor affects the outcome'}
+      </p>
 
       {/* Lane UI-W5: reference-option disclosure — renders nothing when the
           producer did not disclose a reference option (fail-closed). */}
       <SensitivityReferenceCaption optionLabel={sensitivityReferenceLabel} />
+
+      {/* Lane C4: relative-scale caption — visible (not hover-only) whenever
+          the fallback basis is active, following the SensitivityReferenceCaption
+          idiom (role="note", panelMeta). Absent on the producer basis and on
+          unstamped legacy payloads. */}
+      {influenceBasis === 'relative' && (
+        <p
+          role="note"
+          data-testid="influence-scale-caption"
+          className={`${typography.panelMeta} text-text-light`}
+        >
+          Influence is relative to the strongest factor — the top driver always shows 100%.
+        </p>
+      )}
 
       {/* Brief 5 Task 2: headers + rows share one wrapper so column positions
           are structural, not visual-approximation. Headers mirror the row grid
@@ -896,8 +941,10 @@ export function DriversSection({
         <div className={`grid ${GRID_COLS} gap-2 items-center px-3 pb-3`}>
           {/* Empty cell for factor name column */}
           <div aria-hidden="true" />
-          {/* v7.10 T9: Renamed "Relative influence" → "Influence" for brevity */}
-          <Tooltip content="Influence: how much this factor affects the outcome">
+          {/* v7.10 T9 renamed "Relative influence" → "Influence" for brevity;
+              lane C4 restores the relative-scale disclosure in the tooltip
+              (basis-aware — see influenceTooltipContent above). */}
+          <Tooltip content={influenceTooltipContent}>
             <div
               className={`${typography.panelBody} text-text-light text-right cursor-help`}
             >

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -898,12 +898,26 @@ export function DriversSection({
   // (legacy fixtures / cached payloads) → fail-closed: keep the generic
   // wording; never claim a basis the pipeline did not stamp. Derived from the
   // FULL drivers list (same belt-and-braces as anyConfidenceProvisional).
-  const influenceBasis: 'relative' | 'absolute' | 'unknown' =
+  const influenceBasisStamped: 'relative' | 'absolute' | 'unknown' =
     drivers.some(d => d.displayProvenance === 'normalised_elasticity')
       ? 'relative'
       : drivers.some(d => d.displayProvenance === 'influence_score')
         ? 'absolute'
         : 'unknown'
+  // Review fix 1 (degenerate-state false caption): never claim "the top
+  // driver always shows 100%" when the claim has nothing to point at. In the
+  // degenerate state (max magnitude below the data layer's 0.001 floor)
+  // every normalised value is 0 — rows keep the fallback provenance stamp,
+  // but the >=0.01 visibility filter empties the rendered list, so the
+  // caption/explainer would assert a 100% top driver over ZERO rows.
+  // hasMagnitudeData is the data layer's own flag for that floor;
+  // visibleDrivers.length is the belt-and-braces for any other all-hidden
+  // set. Fail closed to the generic wording (same doctrine as the unstamped
+  // branch).
+  const influenceBasis: 'relative' | 'absolute' | 'unknown' =
+    influenceBasisStamped === 'relative' && (!hasMagnitudeData || visibleDrivers.length === 0)
+      ? 'unknown'
+      : influenceBasisStamped
   // Copy comes from the ONE shared module (influenceScaleCopy) the canvas
   // pill consumes too — surfaces cannot drift (review fix 3: the strings are
   // also policed there for the DS em-dash ban).

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -34,6 +34,14 @@ import Tooltip from '../../components/Tooltip'
 import { DiscussWithAiButton } from '../../canvas/components/pre-analysis/DiscussWithAiButton'
 import { ExpertBlock } from './ExpertBlock'
 import { SensitivityReferenceCaption } from './SensitivityReferenceCaption'
+import {
+  INFLUENCE_EXPLANATION_GENERIC,
+  INFLUENCE_EXPLANATION_RELATIVE,
+  INFLUENCE_EXPLANATION_ABSOLUTE,
+  INFLUENCE_RANKING_EXPLAINER_GENERIC,
+  INFLUENCE_RANKING_EXPLAINER_RELATIVE,
+  INFLUENCE_SCALE_CAPTION,
+} from './influenceScaleCopy'
 import { ExpandableCoachingText } from '../../components/shared/ExpandableCoachingText'
 import { isExpertField } from './utils/isExpertField'
 
@@ -896,22 +904,23 @@ export function DriversSection({
       : drivers.some(d => d.displayProvenance === 'influence_score')
         ? 'absolute'
         : 'unknown'
-  // Copy note: the pill in canvas MetricPills.tsx mirrors these strings —
-  // keep them in step (pinned by both surfaces' specs).
+  // Copy comes from the ONE shared module (influenceScaleCopy) the canvas
+  // pill consumes too — surfaces cannot drift (review fix 3: the strings are
+  // also policed there for the DS em-dash ban).
   const influenceTooltipContent =
     influenceBasis === 'relative'
-      ? 'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+      ? INFLUENCE_EXPLANATION_RELATIVE
       : influenceBasis === 'absolute'
-        ? 'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
-        : 'Influence: how much this factor affects the outcome'
+        ? INFLUENCE_EXPLANATION_ABSOLUTE
+        : INFLUENCE_EXPLANATION_GENERIC
 
   return (
     <div className="space-y-4">
       {/* Ranking explainer — carries the relative framing on the fallback basis (C4) */}
       <p className={`${typography.panelMeta} text-text-light`}>
         {influenceBasis === 'relative'
-          ? 'Ranked by how much each factor affects the outcome, relative to the strongest factor'
-          : 'Ranked by how much each factor affects the outcome'}
+          ? INFLUENCE_RANKING_EXPLAINER_RELATIVE
+          : INFLUENCE_RANKING_EXPLAINER_GENERIC}
       </p>
 
       {/* Lane UI-W5: reference-option disclosure — renders nothing when the
@@ -928,7 +937,7 @@ export function DriversSection({
           data-testid="influence-scale-caption"
           className={`${typography.panelMeta} text-text-light`}
         >
-          Influence is relative to the strongest factor — the top driver always shows 100%.
+          {INFLUENCE_SCALE_CAPTION}
         </p>
       )}
 

--- a/src/components/results/__tests__/DriversSection.influenceScaleDisclosure.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.influenceScaleDisclosure.spec.tsx
@@ -116,6 +116,55 @@ function producerBasisData(): DriversSectionData {
   ])
 }
 
+/**
+ * Degenerate magnitude set (review fix 1): elasticities 0.0005/0.0002/0.0001
+ * all sit below computeNormalisedInfluences' 0.001 floor, so the data layer
+ * stamps every row provenance 'normalised_elasticity' with displayInfluence 0
+ * and hasMagnitudeData false; influence_score on ONE row keeps producer
+ * coverage incomplete (so the fallback basis is genuinely active). The >=0.01
+ * visibility filter then empties the rendered list — a "top driver always
+ * shows 100%" claim over ZERO rows would be false.
+ */
+function degenerateRelativeData(): DriversSectionData {
+  return {
+    drivers: [
+      makeDriver({
+        factorKey: 'fac_a',
+        factorLabel: 'Factor A',
+        rawElasticity: 0.0005,
+        normalisedInfluence: 0,
+        displayInfluence: 0,
+        displayProvenance: 'normalised_elasticity',
+        influenceScore: 0.4,
+      }),
+      makeDriver({
+        factorKey: 'fac_b',
+        factorLabel: 'Factor B',
+        rawElasticity: 0.0002,
+        normalisedInfluence: 0,
+        displayInfluence: 0,
+        displayProvenance: 'normalised_elasticity',
+        rank: 2,
+        semanticLabel: 'weak',
+      }),
+      makeDriver({
+        factorKey: 'fac_c',
+        factorLabel: 'Factor C',
+        rawElasticity: 0.0001,
+        normalisedInfluence: 0,
+        displayInfluence: 0,
+        displayProvenance: 'normalised_elasticity',
+        rank: 3,
+        semanticLabel: 'weak',
+      }),
+    ],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+}
+
 /** Legacy fixture shape: displayInfluence/displayProvenance never stamped. */
 function legacyData(): DriversSectionData {
   return makeDriversData([
@@ -188,6 +237,34 @@ describe('DriversSection influence-scale disclosure (lane C4)', () => {
       const tooltip = screen.getByRole('tooltip')
       expect(tooltip.textContent).toContain(ABSOLUTE_TOOLTIP)
       expect(tooltip.textContent).not.toContain('always shows 100%')
+    })
+  })
+
+  describe('degenerate magnitude set (review fix 1) — never claim "top shows 100%" over zero rows', () => {
+    it('renders no relative-scale caption when every normalised value collapsed to 0', () => {
+      render(<DriversSection data={degenerateRelativeData()} goalLabel="test" />)
+      expect(screen.queryByTestId('influence-scale-caption')).toBeNull()
+    })
+
+    it('keeps the generic explainer (no relative clause) in the degenerate state', () => {
+      render(<DriversSection data={degenerateRelativeData()} goalLabel="test" />)
+      expect(screen.getByText(GENERIC_EXPLAINER)).toBeDefined()
+      expect(screen.queryByText(RELATIVE_EXPLAINER)).toBeNull()
+    })
+
+    it('header tooltip falls back to the generic wording, not the 100% claim', () => {
+      render(<DriversSection data={degenerateRelativeData()} goalLabel="test" />)
+      hoverInfluenceHeader()
+      const tooltip = screen.getByRole('tooltip')
+      expect(tooltip.textContent).toBe(GENERIC_TOOLTIP)
+      expect(tooltip.textContent).not.toContain('always shows 100%')
+    })
+
+    it('sanity: the fixture really does render zero driver rows', () => {
+      render(<DriversSection data={degenerateRelativeData()} goalLabel="test" />)
+      expect(screen.queryByText('Factor A')).toBeNull()
+      expect(screen.queryByText('Factor B')).toBeNull()
+      expect(screen.queryByText('Factor C')).toBeNull()
     })
   })
 

--- a/src/components/results/__tests__/DriversSection.influenceScaleDisclosure.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.influenceScaleDisclosure.spec.tsx
@@ -1,0 +1,206 @@
+/**
+ * DriversSection influence-scale disclosure (lane C4).
+ *
+ * Verified gap: on the fallback basis ('normalised_elasticity') the displayed
+ * influence is per-set normalised |elasticity| — the top driver shows 100% BY
+ * CONSTRUCTION (driverDisplayModel.ts computeNormalisedInfluences), yet no
+ * surface disclosed it. The "Relative influence" wording was dropped in
+ * v7.10 T9 ("Renamed \"Relative influence\" → \"Influence\" for brevity"),
+ * leaving "Influence: how much this factor affects the outcome" — read as an
+ * absolute causal share.
+ *
+ * Fix under test (copy/caption only — numbers and ranking policy untouched):
+ * - provenance 'normalised_elasticity' → header tooltip + explainer carry the
+ *   relative-scale wording, and a visible caption disclosing "top driver
+ *   always shows 100%" renders near the panel;
+ * - provenance 'influence_score' → honest absolute-basis wording (types.ts:
+ *   influence_score is "structural causal influence"), NO relative caption;
+ * - no provenance stamp (legacy fixtures / cached payloads) → fail-closed:
+ *   today's generic wording, no caption — never claim a basis the pipeline
+ *   did not stamp.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DriversSection } from '../DriversSection'
+import type { DriversSectionData, DriverItem } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+}))
+
+const RELATIVE_TOOLTIP =
+  'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+const ABSOLUTE_TOOLTIP =
+  'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
+const GENERIC_TOOLTIP = 'Influence: how much this factor affects the outcome'
+const RELATIVE_EXPLAINER =
+  'Ranked by how much each factor affects the outcome, relative to the strongest factor'
+const GENERIC_EXPLAINER = 'Ranked by how much each factor affects the outcome'
+const CAPTION_COPY =
+  'Influence is relative to the strongest factor — the top driver always shows 100%.'
+
+function makeDriver(overrides: Partial<DriverItem> & { factorKey: string }): DriverItem {
+  return {
+    factorLabel: overrides.factorKey,
+    rawElasticity: 0.5,
+    normalisedInfluence: 0.5,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: false,
+    direction: 'positive',
+    ...overrides,
+  }
+}
+
+function makeDriversData(drivers: DriverItem[]): DriversSectionData {
+  return {
+    drivers,
+    topDrivers: drivers.slice(0, 3),
+    driversStatus: 'computed',
+    totalCount: drivers.length,
+    hasMagnitudeData: true,
+  }
+}
+
+/** Two-driver set on the fallback basis: top ≡ 1.0 by construction. */
+function relativeBasisData(): DriversSectionData {
+  return makeDriversData([
+    makeDriver({
+      factorKey: 'fac_a',
+      factorLabel: 'Technical Leadership Capability',
+      rawElasticity: 0.9,
+      normalisedInfluence: 1,
+      displayInfluence: 1,
+      displayProvenance: 'normalised_elasticity',
+    }),
+    makeDriver({
+      factorKey: 'fac_b',
+      factorLabel: 'Market Timing',
+      rawElasticity: 0.45,
+      normalisedInfluence: 0.5,
+      displayInfluence: 0.5,
+      displayProvenance: 'normalised_elasticity',
+      rank: 2,
+      semanticLabel: 'moderate',
+    }),
+  ])
+}
+
+/** Full producer coverage: every factor carries a raw influence_score. */
+function producerBasisData(): DriversSectionData {
+  return makeDriversData([
+    makeDriver({
+      factorKey: 'fac_a',
+      factorLabel: 'Technical Leadership Capability',
+      rawElasticity: 0.9,
+      normalisedInfluence: 1,
+      influenceScore: 0.62,
+      displayInfluence: 0.62,
+      displayProvenance: 'influence_score',
+    }),
+    makeDriver({
+      factorKey: 'fac_b',
+      factorLabel: 'Market Timing',
+      rawElasticity: 0.45,
+      normalisedInfluence: 0.5,
+      influenceScore: 0.31,
+      displayInfluence: 0.31,
+      displayProvenance: 'influence_score',
+      rank: 2,
+      semanticLabel: 'moderate',
+    }),
+  ])
+}
+
+/** Legacy fixture shape: displayInfluence/displayProvenance never stamped. */
+function legacyData(): DriversSectionData {
+  return makeDriversData([
+    makeDriver({ factorKey: 'fac_a', factorLabel: 'Factor A', normalisedInfluence: 1 }),
+    makeDriver({
+      factorKey: 'fac_b',
+      factorLabel: 'Factor B',
+      normalisedInfluence: 0.5,
+      rank: 2,
+      semanticLabel: 'moderate',
+    }),
+  ])
+}
+
+function hoverInfluenceHeader(): void {
+  // The Tooltip component wraps its child in the floating-ui reference div —
+  // hover that wrapper (same pattern as BaselineTargetRow.spec).
+  const header = screen.getByText('Influence')
+  fireEvent.mouseEnter(header.parentElement!)
+}
+
+describe('DriversSection influence-scale disclosure (lane C4)', () => {
+  describe('fallback basis (normalised_elasticity) — top driver ≡ 100% by construction', () => {
+    it('renders the relative-scale caption near the panel', () => {
+      render(<DriversSection data={relativeBasisData()} goalLabel="test" />)
+      const caption = screen.getByTestId('influence-scale-caption')
+      expect(caption.textContent).toBe(CAPTION_COPY)
+    })
+
+    it('explainer carries the relative framing', () => {
+      render(<DriversSection data={relativeBasisData()} goalLabel="test" />)
+      expect(screen.getByText(RELATIVE_EXPLAINER)).toBeDefined()
+    })
+
+    it('Influence header tooltip discloses the relative scale', () => {
+      render(<DriversSection data={relativeBasisData()} goalLabel="test" />)
+      hoverInfluenceHeader()
+      const tooltip = screen.getByRole('tooltip')
+      expect(tooltip.textContent).toContain(RELATIVE_TOOLTIP)
+    })
+
+    it('does not change the displayed numbers (top driver still shows its 100% bar)', () => {
+      const { container } = render(
+        <DriversSection data={relativeBasisData()} goalLabel="test" />,
+      )
+      // The disclosure is copy-only: the top row's bar value stays the shared
+      // display model's 1.0 (rendered as a 100%-valued progressbar).
+      const bars = container.querySelectorAll('[role="progressbar"]')
+      expect(bars.length).toBeGreaterThan(0)
+      const values = Array.from(bars).map((b) => Number(b.getAttribute('aria-valuenow')))
+      expect(Math.max(...values)).toBe(100)
+    })
+  })
+
+  describe('producer basis (influence_score) — absolute scale', () => {
+    it('does NOT render the relative-scale caption', () => {
+      render(<DriversSection data={producerBasisData()} goalLabel="test" />)
+      expect(screen.queryByTestId('influence-scale-caption')).toBeNull()
+    })
+
+    it('explainer keeps the generic wording (no relative clause)', () => {
+      render(<DriversSection data={producerBasisData()} goalLabel="test" />)
+      expect(screen.getByText(GENERIC_EXPLAINER)).toBeDefined()
+      expect(screen.queryByText(RELATIVE_EXPLAINER)).toBeNull()
+    })
+
+    it('Influence header tooltip uses the absolute-basis wording, not the relative claim', () => {
+      render(<DriversSection data={producerBasisData()} goalLabel="test" />)
+      hoverInfluenceHeader()
+      const tooltip = screen.getByRole('tooltip')
+      expect(tooltip.textContent).toContain(ABSOLUTE_TOOLTIP)
+      expect(tooltip.textContent).not.toContain('always shows 100%')
+    })
+  })
+
+  describe('no provenance stamp (legacy fixtures / cached payloads) — fail-closed', () => {
+    it('keeps the pre-existing generic tooltip copy and renders no caption', () => {
+      render(<DriversSection data={legacyData()} goalLabel="test" />)
+      expect(screen.queryByTestId('influence-scale-caption')).toBeNull()
+      hoverInfluenceHeader()
+      const tooltip = screen.getByRole('tooltip')
+      expect(tooltip.textContent).toBe(GENERIC_TOOLTIP)
+    })
+
+    it('keeps the generic explainer', () => {
+      render(<DriversSection data={legacyData()} goalLabel="test" />)
+      expect(screen.getByText(GENERIC_EXPLAINER)).toBeDefined()
+      expect(screen.queryByText(RELATIVE_EXPLAINER)).toBeNull()
+    })
+  })
+})

--- a/src/components/results/__tests__/DriversSection.influenceScaleDisclosure.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.influenceScaleDisclosure.spec.tsx
@@ -29,16 +29,19 @@ vi.mock('../../../canvas/utils/focusHelpers', () => ({
   focusNodeById: vi.fn(),
 }))
 
+// Deliberately hard-coded (not imported from influenceScaleCopy) so a copy
+// change is a conscious, visible decision in this spec. No em dashes (DS ban,
+// review fix 3 — policed by influenceScaleCopy.copyHygiene.spec.ts).
 const RELATIVE_TOOLTIP =
-  'Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%.'
+  'Influence: how much this factor affects the outcome, relative to the strongest. The top driver always shows 100%.'
 const ABSOLUTE_TOOLTIP =
-  'Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis.'
+  'Influence: how much this factor affects the outcome, as an absolute causal influence score from the analysis.'
 const GENERIC_TOOLTIP = 'Influence: how much this factor affects the outcome'
 const RELATIVE_EXPLAINER =
   'Ranked by how much each factor affects the outcome, relative to the strongest factor'
 const GENERIC_EXPLAINER = 'Ranked by how much each factor affects the outcome'
 const CAPTION_COPY =
-  'Influence is relative to the strongest factor — the top driver always shows 100%.'
+  'Influence is relative to the strongest factor. The top driver always shows 100%.'
 
 function makeDriver(overrides: Partial<DriverItem> & { factorKey: string }): DriverItem {
   return {

--- a/src/components/results/__tests__/driverPolicyFeed.parity.spec.tsx
+++ b/src/components/results/__tests__/driverPolicyFeed.parity.spec.tsx
@@ -1,0 +1,175 @@
+/**
+ * C4 fix 2 — cross-surface basis parity (adversarial review, both findings
+ * verifier-reproduced against the real store).
+ *
+ * The Drivers panel (useResultsSectionData) and the canvas hook
+ * (useNodeDisplayMetadata) disclosed CONTRADICTORY bases for the SAME report:
+ * the panel fed selectDriverDisplayModel its five-source merge (which KEEPS
+ * metric-less rows → coverage incomplete → set-relative fallback), while the
+ * hook fed it a private factor_sensitivity-only feed filtered through
+ * extractPolicyRow (drops no-finite-metric rows → coverage complete →
+ * absolute producer scale). Result: the canvas pill said "absolute" while the
+ * panel said "relative, top always 100%".
+ *
+ * Fix under test (build-brief §12.4 single-selector doctrine): ONE shared row
+ * feed — selectDriverPolicyFeed, the panel's merge extracted into a pure
+ * per-report-memoised function — consumed by BOTH surfaces. These specs drive
+ * the REAL canvas store and both REAL hooks, then assert basis AND value
+ * agree, for the exact review fixture and for a drivers_payload-only report.
+ *
+ * Also pinned here (fix 1 integration truth): the degenerate wire fixture
+ * flows through the real data layer into DriversSection and renders NO
+ * relative-scale caption.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import { useResultsSectionData, selectDriverPolicyFeed } from '../useResultsSectionData'
+import { useNodeDisplayMetadata } from '../../../canvas/hooks/useNodeDisplayMetadata'
+import { useCanvasStore } from '../../../canvas/store'
+import { DriversSection } from '../DriversSection'
+import type { ResultsReport } from '../types'
+
+function setCompleteReport(report: Record<string, unknown>): void {
+  act(() => {
+    useCanvasStore.setState({
+      results: { status: 'complete', progress: 100, report } as never,
+      runMeta: {} as never,
+      nodes: [] as never,
+      edges: [] as never,
+      hasCompletedFirstRun: true,
+      rawV2Response: null,
+    } as never)
+  })
+}
+
+const baseReport = (overrides: Record<string, unknown>): Record<string, unknown> => ({
+  schema: 'report.v1',
+  meta: { seed: 1, elapsed_ms: 100 },
+  drivers_status: 'computed',
+  ...overrides,
+})
+
+beforeEach(() => {
+  act(() => {
+    useCanvasStore.setState({
+      results: { status: 'idle' } as never,
+      runMeta: {} as never,
+      nodes: [] as never,
+      edges: [] as never,
+      hasCompletedFirstRun: false,
+      rawV2Response: null,
+    } as never)
+  })
+})
+
+describe('C4 fix 2 — panel and canvas resolve the SAME basis and value from one feed', () => {
+  it('review fixture (A with influence_score + metric-less B): both surfaces say relative, A = 1.0', () => {
+    setCompleteReport(baseReport({
+      factor_sensitivity: [
+        { factor_id: 'A', influence_score: 0.6, elasticity: 0.5 },
+        { factor_id: 'B', confidence: 0.7 },
+      ],
+    }))
+
+    const panel = renderHook(() => useResultsSectionData())
+    const rowA = panel.result.current.drivers.drivers.find(d => d.factorKey === 'A')
+    expect(rowA?.displayProvenance).toBe('normalised_elasticity')
+    expect(rowA?.displayInfluence).toBe(1)
+
+    const canvas = renderHook(() => useNodeDisplayMetadata('A', 'factor'))
+    expect(canvas.result.current.influenceProvenance).toBe(rowA?.displayProvenance)
+    expect(canvas.result.current.influence).toBe(rowA?.displayInfluence)
+  })
+
+  it('drivers_payload-only report: both surfaces agree on the verdict for the same row', () => {
+    setCompleteReport(baseReport({
+      drivers_payload: {
+        drivers: [
+          { node_id: 'X', elasticity: 0.7 },
+          { node_id: 'Y', elasticity: 0.35 },
+        ],
+      },
+    }))
+
+    const panel = renderHook(() => useResultsSectionData())
+    const rowX = panel.result.current.drivers.drivers.find(d => d.factorKey === 'X')
+    expect(rowX?.displayProvenance).toBe('normalised_elasticity')
+    expect(rowX?.displayInfluence).toBe(1)
+
+    const canvas = renderHook(() => useNodeDisplayMetadata('X', 'factor'))
+    expect(canvas.result.current.influenceProvenance).toBe(rowX?.displayProvenance)
+    expect(canvas.result.current.influence).toBe(rowX?.displayInfluence)
+    expect(canvas.result.current.sensitivityRank).toBe(1)
+  })
+
+  it('full producer coverage: both surfaces say absolute with the producer value', () => {
+    setCompleteReport(baseReport({
+      factor_sensitivity: [
+        { factor_id: 'A', influence_score: 0.6, elasticity: 0.5 },
+        { factor_id: 'B', influence_score: 0.3, elasticity: 0.2, confidence: 0.7 },
+      ],
+    }))
+
+    const panel = renderHook(() => useResultsSectionData())
+    const rowA = panel.result.current.drivers.drivers.find(d => d.factorKey === 'A')
+    expect(rowA?.displayProvenance).toBe('influence_score')
+    expect(rowA?.displayInfluence).toBeCloseTo(0.6)
+
+    const canvas = renderHook(() => useNodeDisplayMetadata('A', 'factor'))
+    expect(canvas.result.current.influenceProvenance).toBe('influence_score')
+    expect(canvas.result.current.influence).toBeCloseTo(0.6)
+  })
+})
+
+describe('selectDriverPolicyFeed — feed contract', () => {
+  it('is memoised per report object (same identity for repeated reads)', () => {
+    const report = baseReport({
+      factor_sensitivity: [{ factor_id: 'A', elasticity: 0.5 }],
+    }) as ResultsReport
+    const first = selectDriverPolicyFeed(report)
+    const second = selectDriverPolicyFeed(report)
+    expect(second).toBe(first)
+    expect(first.policyRows).toHaveLength(1)
+  })
+
+  it('keeps metric-less rows (the coverage-verdict input the old private feed dropped)', () => {
+    const report = baseReport({
+      factor_sensitivity: [
+        { factor_id: 'A', influence_score: 0.6, elasticity: 0.5 },
+        { factor_id: 'B', confidence: 0.7 },
+      ],
+    }) as ResultsReport
+    const feed = selectDriverPolicyFeed(report)
+    expect(feed.policyRows.map(r => r.key)).toEqual(['A', 'B'])
+    expect(feed.displayModel.get('A')?.provenance).toBe('normalised_elasticity')
+    expect(feed.displayModel.get('A')?.value).toBe(1)
+    expect(feed.displayModel.get('B')?.value).toBe(0)
+  })
+
+  it('returns an empty feed for a missing report', () => {
+    expect(selectDriverPolicyFeed(null).policyRows).toHaveLength(0)
+    expect(selectDriverPolicyFeed(undefined).rawFactors).toHaveLength(0)
+  })
+})
+
+describe('C4 fix 1 integration truth — degenerate wire fixture through the real data layer', () => {
+  it('renders no relative-scale caption when the real data layer collapses every value to 0', () => {
+    setCompleteReport(baseReport({
+      factor_sensitivity: [
+        { factor_id: 'A', elasticity: 0.0005, influence_score: 0.4 },
+        { factor_id: 'B', elasticity: 0.0002 },
+        { factor_id: 'C', elasticity: 0.0001 },
+      ],
+    }))
+
+    const panel = renderHook(() => useResultsSectionData())
+    const data = panel.result.current.drivers
+    expect(data.hasMagnitudeData).toBe(false)
+    expect(data.drivers.every(d => d.displayInfluence === 0)).toBe(true)
+
+    render(<DriversSection data={data} goalLabel="test" />)
+    expect(screen.queryByTestId('influence-scale-caption')).toBeNull()
+    expect(screen.queryByText(/always shows 100%/)).toBeNull()
+  })
+})

--- a/src/components/results/__tests__/driverPolicyFeed.parity.spec.tsx
+++ b/src/components/results/__tests__/driverPolicyFeed.parity.spec.tsx
@@ -122,6 +122,97 @@ describe('C4 fix 2 — panel and canvas resolve the SAME basis and value from on
   })
 })
 
+/**
+ * C4 re-review fold — cross-surface ORDER parity.
+ *
+ * The specs above pin the disclosed BASIS and the VALUE, and that is exactly
+ * why they missed a regression this fold introduced: two surfaces can agree
+ * that a driver shows 44% on a set-relative scale and still ROW-ORDER it
+ * differently. The shared feed handed the canvas a SIGNED magnitude, while
+ * the panel abs'd its own before ranking; the canvas tie-break sorts on the
+ * raw number, so a positive driver outranked an equal-magnitude negative one
+ * on the canvas and lost to it in the panel. Same feed, same number, opposite
+ * order — the fork this fold exists to close, reopened one layer down.
+ *
+ * These pins assert the two surfaces produce the SAME ORDER, not merely the
+ * same value. Both fixtures are chosen so LABEL-alphabetical and
+ * KEY-alphabetical agree, keeping them blind to the known (pre-existing,
+ * out-of-scope) label-vs-key final tie-break divergence — they fail for the
+ * sign reason alone.
+ */
+describe('C4 re-review — panel and canvas resolve the SAME ORDER, not just the same value', () => {
+  it('set-relative basis: an equal-magnitude negative driver ranks the same on both surfaces', () => {
+    setCompleteReport(baseReport({
+      factor_sensitivity: [
+        { node_id: 'n_down', label: 'Attrition risk', elasticity: -0.4 },
+        { node_id: 'n_up', label: 'Zeta uplift', elasticity: 0.4 },
+        { node_id: 'n_big', label: 'Market size', elasticity: 0.9 },
+      ],
+    }))
+
+    const panel = renderHook(() => useResultsSectionData())
+    const rowsByKey = new Map(panel.result.current.drivers.drivers.map(d => [d.factorKey, d]))
+
+    // Precondition: the surfaces agree on basis and value — so ORDER is the
+    // only thing these assertions can be catching.
+    expect(rowsByKey.get('n_down')?.displayProvenance).toBe('normalised_elasticity')
+    expect(rowsByKey.get('n_down')?.displayInfluence).toBeCloseTo(4 / 9)
+    expect(rowsByKey.get('n_up')?.displayInfluence).toBeCloseTo(4 / 9)
+
+    for (const key of ['n_big', 'n_down', 'n_up']) {
+      const canvas = renderHook(() => useNodeDisplayMetadata(key, 'factor'))
+      expect(canvas.result.current.influence).toBeCloseTo(rowsByKey.get(key)!.displayInfluence!)
+      expect(canvas.result.current.sensitivityRank).toBe(rowsByKey.get(key)!.rank)
+    }
+
+    // Pinned concretely: the tie resolves by the shared key tie-break, and the
+    // sign of the magnitude does not enter the ordering on either surface.
+    expect(rowsByKey.get('n_big')?.rank).toBe(1)
+    expect(rowsByKey.get('n_down')?.rank).toBe(2)
+    expect(rowsByKey.get('n_up')?.rank).toBe(3)
+  })
+
+  it('producer basis: the top-driver crown lands on the same row on both surfaces', () => {
+    setCompleteReport(baseReport({
+      factor_sensitivity: [
+        { node_id: 'a_pos', label: 'Alpha uplift', influence_score: 0.5, elasticity: 0.3 },
+        { node_id: 'b_neg', label: 'Beta drag', influence_score: 0.5, elasticity: -0.9 },
+      ],
+    }))
+
+    const panel = renderHook(() => useResultsSectionData())
+    const rowsByKey = new Map(panel.result.current.drivers.drivers.map(d => [d.factorKey, d]))
+
+    // Both rows carry a producer score, and the SAME one — so the crown is
+    // decided purely by the elasticity tie-break.
+    expect(rowsByKey.get('a_pos')?.displayProvenance).toBe('influence_score')
+    expect(rowsByKey.get('a_pos')?.displayInfluence).toBeCloseTo(0.5)
+    expect(rowsByKey.get('b_neg')?.displayInfluence).toBeCloseTo(0.5)
+
+    for (const key of ['a_pos', 'b_neg']) {
+      const canvas = renderHook(() => useNodeDisplayMetadata(key, 'factor'))
+      expect(canvas.result.current.sensitivityRank).toBe(rowsByKey.get(key)!.rank)
+    }
+
+    // The larger MAGNITUDE wins the tie on both surfaces, negative or not.
+    expect(rowsByKey.get('b_neg')?.rank).toBe(1)
+    expect(rowsByKey.get('a_pos')?.rank).toBe(2)
+  })
+
+  it('feed contract: policyRows carry an unsigned magnitude, as the field documents', () => {
+    const report = baseReport({
+      factor_sensitivity: [
+        { node_id: 'n_down', elasticity: -0.4 },
+        { node_id: 'n_up', elasticity: 0.4 },
+      ],
+    }) as ResultsReport
+    const feed = selectDriverPolicyFeed(report)
+    // Pinned at the PRODUCER: the one consumer that ranks on this field sorts
+    // it raw, so a signed value here is an ordering fork waiting to happen.
+    expect(feed.policyRows.map(r => r.rawElasticity)).toEqual([0.4, 0.4])
+  })
+})
+
 describe('selectDriverPolicyFeed — feed contract', () => {
   it('is memoised per report object (same identity for repeated reads)', () => {
     const report = baseReport({

--- a/src/components/results/__tests__/driverPolicyFeed.parity.spec.tsx
+++ b/src/components/results/__tests__/driverPolicyFeed.parity.spec.tsx
@@ -205,7 +205,7 @@ describe('C4 re-review — panel and canvas resolve the SAME ORDER, not just the
         { node_id: 'n_down', elasticity: -0.4 },
         { node_id: 'n_up', elasticity: 0.4 },
       ],
-    }) as ResultsReport
+    }) as unknown as ResultsReport
     const feed = selectDriverPolicyFeed(report)
     // Pinned at the PRODUCER: the one consumer that ranks on this field sorts
     // it raw, so a signed value here is an ordering fork waiting to happen.

--- a/src/components/results/__tests__/influenceScaleCopy.copyHygiene.spec.ts
+++ b/src/components/results/__tests__/influenceScaleCopy.copyHygiene.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Copy hygiene for the influence-scale disclosure strings (lane C4, review
+ * fix 3 — house pattern: per-surface spec over centralised copy; no repo-wide
+ * guard exists; same rules as decision-overview/__tests__/copyHygiene.spec.ts,
+ * brief §13.4): no em dashes in prose (DS ban, U+2014), sentence case (no
+ * shouting caps), en-GB, no internal analytical terms in user-facing strings.
+ *
+ * Every surface (DriversSection tooltip/explainer/caption, MetricPills pill
+ * title/aria, FactorNode detailed Influence row) imports these strings from
+ * influenceScaleCopy.ts, so policing the module polices every surface.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  INFLUENCE_EXPLANATION_GENERIC,
+  INFLUENCE_EXPLANATION_RELATIVE,
+  INFLUENCE_EXPLANATION_ABSOLUTE,
+  INFLUENCE_RANKING_EXPLAINER_GENERIC,
+  INFLUENCE_RANKING_EXPLAINER_RELATIVE,
+  INFLUENCE_SCALE_CAPTION,
+  influenceExplanation,
+  influencePillAriaLabel,
+  influenceBarAriaLabel,
+} from '../influenceScaleCopy'
+
+const BANNED_TERMS = /\b(node|edge|coefficient|elasticity|normalised value|graph hash|winner|validate)\b/i
+const AMERICAN = /\b(analyze|optimize|color|behavior|center|favorite)\w*/i
+
+const PROVENANCES = ['normalised_elasticity', 'influence_score', null] as const
+
+function allStrings(): string[] {
+  return [
+    INFLUENCE_EXPLANATION_GENERIC,
+    INFLUENCE_EXPLANATION_RELATIVE,
+    INFLUENCE_EXPLANATION_ABSOLUTE,
+    INFLUENCE_RANKING_EXPLAINER_GENERIC,
+    INFLUENCE_RANKING_EXPLAINER_RELATIVE,
+    INFLUENCE_SCALE_CAPTION,
+    // Exercise the builders across every basis so template output is policed
+    // too (aria-labels are user-facing copy for screen-reader users).
+    ...PROVENANCES.flatMap((p) => [
+      influenceExplanation(p),
+      influencePillAriaLabel(62, p),
+      influenceBarAriaLabel(p),
+    ]),
+  ]
+}
+
+describe('influence-scale disclosure copy hygiene (C4 fix 3)', () => {
+  it('contains no em dashes (U+2014) in any user-facing string', () => {
+    for (const s of allStrings()) expect(s, s).not.toContain('—')
+  })
+
+  it('contains no shouting caps', () => {
+    for (const s of allStrings()) {
+      const shouting = s.match(/\b[A-Z]{2,}\b/g) ?? []
+      expect(shouting, s).toEqual([])
+    }
+  })
+
+  it('avoids internal analytical vocabulary and American spellings', () => {
+    for (const s of allStrings()) {
+      expect(s, s).not.toMatch(BANNED_TERMS)
+      expect(s, s).not.toMatch(AMERICAN)
+    }
+  })
+})

--- a/src/components/results/__tests__/no-raw-influence-read.spec.ts
+++ b/src/components/results/__tests__/no-raw-influence-read.spec.ts
@@ -73,8 +73,13 @@ const ALLOWLIST: Record<string, RegExp> = {
   // displayInfluence via the policy; also reads normalisedInfluence for the
   // semantic-label thresholds the policy header explicitly sanctions.
   'components/results/useResultsSectionData.ts': /selectDriverDisplayModel/,
-  // Graph-badge adapter: feeds raw metrics INTO the policy.
-  'canvas/hooks/useNodeDisplayMetadata.ts': /selectDriverDisplayModel/,
+  // (C4 fix 2) canvas/hooks/useNodeDisplayMetadata.ts is deliberately NO
+  // LONGER allowlisted: it stopped being an adapter that feeds raw metrics
+  // into the policy and now consumes the shared row feed
+  // (selectDriverPolicyFeed), which hands it an already-resolved display
+  // model. It reads no raw metric at all, so it must be policed like any
+  // other consumer — an exemption kept "just in case" would silently sanction
+  // the next raw read added there.
   // V17 hero dominance GATE (UI-SEM-040): absolute/ratio thresholds over the
   // raw metrics — deliberately NOT the display-ranking policy. The marker
   // comment is the attestation; if the gate is rewritten, re-decide.

--- a/src/components/results/driverDisplayModel.ts
+++ b/src/components/results/driverDisplayModel.ts
@@ -134,9 +134,19 @@ export function selectDriverDisplayModel(
 
 /**
  * Rank comparator on a resolved display model: value descending, then
- * |elasticity| as the tie-break, then key alphabetically for determinism.
+ * elasticity as the tie-break, then key alphabetically for determinism.
  * The graph badge ranks with this so its order matches the panel's, both keyed
  * off the shared `value`.
+ *
+ * PRECONDITION: `elasticity` must be an UNSIGNED magnitude. This sorts the
+ * number as given — it does not abs — so a signed input silently ranks a
+ * positive driver above an equal-magnitude negative one, which is how the
+ * canvas once forked from the panel on rows both surfaces valued identically.
+ * Every feeder abs's at construction (extractPolicyRow below;
+ * DriverPolicyRow.rawElasticity in useResultsSectionData). Deliberately NOT
+ * abs'd here: absorbing a signed value would mask the producer-side contract
+ * break rather than surface it, and would blind the cross-surface order pins
+ * to exactly the regression they exist to catch.
  */
 export function compareByDisplayModel(
   a: { value: number; elasticity: number; key: string },

--- a/src/components/results/influenceScaleCopy.ts
+++ b/src/components/results/influenceScaleCopy.ts
@@ -1,0 +1,87 @@
+/**
+ * influenceScaleCopy — the ONE home for influence-scale disclosure wording
+ * (lane C4), shared by every surface that renders the display model's
+ * influence number: the results Drivers panel (DriversSection header tooltip,
+ * ranking explainer, visible caption) and the canvas surfaces (MetricPills
+ * "I: NN%" pill, FactorNode detailed-view Influence row). Centralised so the
+ * surfaces cannot drift ("keep in step" comments are not a mechanism) and so
+ * the copy-hygiene spec has one import to police.
+ *
+ * Basis semantics (driverDisplayModel): 'normalised_elasticity' is the
+ * set-relative fallback (top driver shows 100% by construction) and MUST be
+ * disclosed; 'influence_score' is the producer's absolute causal influence
+ * score; no provenance (legacy fixtures / cached payloads) fails closed to
+ * the generic wording, never claiming a basis the pipeline did not stamp.
+ *
+ * Copy hygiene (influenceScaleCopy.copyHygiene.spec.ts): sentence case,
+ * en-GB, no internal analytical vocabulary, and NO em dashes (DS ban) in any
+ * user-facing string exported here.
+ */
+import type { DriverDisplayProvenance } from './driverDisplayModel'
+
+/** Header tooltip / pill title — no basis stamped (fail-closed). */
+export const INFLUENCE_EXPLANATION_GENERIC =
+  'Influence: how much this factor affects the outcome'
+
+/** Header tooltip / pill title — set-relative fallback basis. */
+export const INFLUENCE_EXPLANATION_RELATIVE =
+  'Influence: how much this factor affects the outcome, relative to the strongest. The top driver always shows 100%.'
+
+/** Header tooltip / pill title — absolute producer basis. */
+export const INFLUENCE_EXPLANATION_ABSOLUTE =
+  'Influence: how much this factor affects the outcome, as an absolute causal influence score from the analysis.'
+
+/** Drivers panel ranking explainer — generic (absolute or unstamped basis). */
+export const INFLUENCE_RANKING_EXPLAINER_GENERIC =
+  'Ranked by how much each factor affects the outcome'
+
+/** Drivers panel ranking explainer — set-relative fallback basis. */
+export const INFLUENCE_RANKING_EXPLAINER_RELATIVE =
+  'Ranked by how much each factor affects the outcome, relative to the strongest factor'
+
+/** Drivers panel always-visible caption — set-relative fallback basis only. */
+export const INFLUENCE_SCALE_CAPTION =
+  'Influence is relative to the strongest factor. The top driver always shows 100%.'
+
+/**
+ * Basis-aware explanation for tooltips / native titles. Fail-closed: an
+ * absent provenance yields the generic wording.
+ */
+export function influenceExplanation(
+  provenance: DriverDisplayProvenance | null | undefined,
+): string {
+  return provenance === 'normalised_elasticity'
+    ? INFLUENCE_EXPLANATION_RELATIVE
+    : provenance === 'influence_score'
+      ? INFLUENCE_EXPLANATION_ABSOLUTE
+      : INFLUENCE_EXPLANATION_GENERIC
+}
+
+/**
+ * Accessible name for the "I: NN%" pill. The pill's visible text is cryptic,
+ * so the name carries both the number and the basis.
+ */
+export function influencePillAriaLabel(
+  pct: number,
+  provenance: DriverDisplayProvenance | null | undefined,
+): string {
+  return provenance === 'normalised_elasticity'
+    ? `Influence ${pct}%, relative to the strongest factor. The top driver always shows 100%`
+    : provenance === 'influence_score'
+      ? `Influence ${pct}%, an absolute causal influence score from the analysis`
+      : `Influence ${pct}%`
+}
+
+/**
+ * Accessible name for the detailed-view Influence DataBar. The value is
+ * announced separately via aria-valuenow, so the name carries the basis only.
+ */
+export function influenceBarAriaLabel(
+  provenance: DriverDisplayProvenance | null | undefined,
+): string {
+  return provenance === 'normalised_elasticity'
+    ? 'Influence, relative to the strongest factor. The top driver always shows 100%'
+    : provenance === 'influence_score'
+      ? 'Influence, an absolute causal influence score from the analysis'
+      : 'Influence'
+}

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -462,7 +462,14 @@ export interface DriverPolicyRow {
   key: string
   /** Producer influence score — snake-case wire field only; undefined when absent. */
   influenceScore: number | undefined
-  /** Resolved magnitude (normaliseFactorSensitivity chain; 0 when absent). */
+  /**
+   * Resolved magnitude (normaliseFactorSensitivity chain; 0 when absent).
+   * UNSIGNED — always `Math.abs`'d at construction. Consumers rank on this
+   * field with a comparator that sorts it as given, so the sign must not
+   * survive into the feed: it would order equal-magnitude drivers by
+   * direction on one surface and by magnitude on another. Read `rawFactors`
+   * for the signed wire value when disclosing direction.
+   */
   rawElasticity: number
   /** Factor confidence (0-1) when the wire carried one. */
   confidence: number | null
@@ -614,7 +621,17 @@ export function selectDriverPolicyFeed(
     return {
       key: getFactorKey(norm, index),
       influenceScore: norm.influenceScore,
-      rawElasticity: getRawElasticity(norm),
+      // Math.abs is load-bearing, not defensive: this field is a MAGNITUDE
+      // (see DriverPolicyRow), and the sole consumer ranks on it via
+      // compareByDisplayModel, whose tie-break sorts the number as given. A
+      // signed value here silently re-opens the very fork this feed closes —
+      // two surfaces agreeing on the basis AND the displayed value, then
+      // ordering equal-magnitude drivers differently by sign. The panel abs's
+      // its own copy before ranking, and extractPolicyRow (the sibling
+      // producer feeding the same comparator) abs's too; this keeps all
+      // feeders on one semantics. Direction is NOT lost — surfaces that
+      // disclose it read the signed wire row from `rawFactors`.
+      rawElasticity: Math.abs(getRawElasticity(norm)),
       confidence: norm.confidence,
       valueOfInformation: norm.valueOfInformation,
     }

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -453,6 +453,149 @@ export function buildWorthInvestigatingIdSet(voiSuggestions: unknown): Set<strin
 }
 
 // =============================================================================
+// Shared driver policy feed (C4 fix 2 — ONE row feed for every surface)
+// =============================================================================
+
+/** Policy input for one merged driver row (same index as `rawFactors`). */
+export interface DriverPolicyRow {
+  /** Canonical factor key (getFactorKey over the normalised row). */
+  key: string
+  /** Producer influence score — snake-case wire field only; undefined when absent. */
+  influenceScore: number | undefined
+  /** Resolved magnitude (normaliseFactorSensitivity chain; 0 when absent). */
+  rawElasticity: number
+  /** Factor confidence (0-1) when the wire carried one. */
+  confidence: number | null
+  /** value_of_information (snake or camel wire field) when present. */
+  valueOfInformation: number | undefined
+}
+
+export interface DriverPolicyFeed {
+  /** Merged + de-duped raw rows (sources 1-5, panel reference order). */
+  rawFactors: RawFactorSensitivity[]
+  /** Policy input per raw row (same index as rawFactors). */
+  policyRows: DriverPolicyRow[]
+  /** THE resolved display model every surface renders AND ranks from. */
+  displayModel: ReturnType<typeof selectDriverDisplayModel>
+}
+
+const EMPTY_DRIVER_POLICY_FEED: DriverPolicyFeed = Object.freeze({
+  rawFactors: [],
+  policyRows: [],
+  displayModel: new Map(),
+})
+
+/** Labels play no part in policy keys/metrics (getFactorKey resolves ids
+ * before labels, and the label-map fallback needs an id anyway), so the feed
+ * normalises with an empty map; the panel re-normalises with the real
+ * nodeLabelMap for display labels only. */
+const EMPTY_NODE_LABEL_MAP = new Map<string, string>()
+
+/** Per-report memo (C4 review: memoise per REPORT, not per node — the canvas
+ * hook runs once per node and must not rebuild the merge each time). */
+const driverPolicyFeedCache = new WeakMap<object, DriverPolicyFeed>()
+
+/**
+ * The panel's five-source row merge, extracted VERBATIM into a pure function
+ * so the Drivers panel and the canvas hook (useNodeDisplayMetadata) consume
+ * the SAME rows (build-brief §12.4 single-selector doctrine).
+ *
+ * C4 fix 2 (adversarial review, verifier-reproduced): sharing the policy
+ * FUNCTION (selectDriverDisplayModel) was not enough — the hook fed it a
+ * private factor_sensitivity-only feed that DROPPED metric-less rows
+ * (extractPolicyRow), while the panel's merge KEEPS them. The coverage
+ * verdict (producer scores adopted only when EVERY row carries one) then
+ * flipped per surface, so the canvas pill disclosed "absolute" while the
+ * panel disclosed "relative, top always 100%" for the SAME report. The feed
+ * being shared makes that fork impossible.
+ *
+ * Note the merge deliberately KEEPS rows with no finite metric: their absence
+ * of a producer score IS the signal that flips the whole set onto the
+ * comparable fallback basis.
+ */
+export function selectDriverPolicyFeed(
+  report: ResultsReport | null | undefined,
+): DriverPolicyFeed {
+  if (!report || typeof report !== 'object') return EMPTY_DRIVER_POLICY_FEED
+  const cached = driverPolicyFeedCache.get(report)
+  if (cached) return cached
+
+  // Collect raw factors from multiple sources (moved from the drivers memo)
+  const rawFactors: RawFactorSensitivity[] = []
+
+  // Source 1: factor_sensitivity (PLoT v2)
+  const factorSensitivity = report.factor_sensitivity || []
+  factorSensitivity.forEach((f: RawFactorSensitivity) => rawFactors.push(f))
+
+  // Precompute keys in a Set for O(1) duplicate detection
+  const seenKeys = new Set<string>()
+  rawFactors.forEach((f, index) => seenKeys.add(getFactorKey(f, index)))
+
+  // Source 2: drivers array (legacy) — canonical de-dupe via getFactorKey
+  const legacyDrivers = report.drivers || []
+  legacyDrivers.forEach((d, idx: number) => {
+    const candidate: RawFactorSensitivity = {
+      node_id: d.nodeId,
+      id: (d as { id?: string }).id,
+      label: d.label,
+      sensitivity: d.contribution,
+      direction: d.polarity === 'down' ? 'negative' : 'positive',
+    }
+    const key = getFactorKey(candidate, rawFactors.length + idx)
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key)
+      rawFactors.push(candidate)
+    }
+  })
+
+  // Source 3: drivers_payload
+  const driversPayload = report.drivers_payload?.drivers || []
+  driversPayload.forEach((pd: RawFactorSensitivity, idx: number) => {
+    const key = getFactorKey(pd, rawFactors.length + idx)
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key)
+      rawFactors.push(pd)
+    }
+  })
+
+  // Source 4: sensitivity.factors (alternative path)
+  const sensitivityFactors = report.sensitivity?.factors || []
+  sensitivityFactors.forEach((sf, idx: number) => {
+    const key = getFactorKey(sf as RawFactorSensitivity, rawFactors.length + idx)
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key)
+      rawFactors.push(sf as RawFactorSensitivity)
+    }
+  })
+
+  // Source 5: factors array (direct)
+  const directFactors = report.factors || []
+  directFactors.forEach((df, idx: number) => {
+    const key = getFactorKey(df as RawFactorSensitivity, rawFactors.length + idx)
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key)
+      rawFactors.push(df as RawFactorSensitivity)
+    }
+  })
+
+  const policyRows: DriverPolicyRow[] = rawFactors.map((f, index) => {
+    const norm = normalizeFactorSensitivity(f, EMPTY_NODE_LABEL_MAP)
+    return {
+      key: getFactorKey(norm, index),
+      influenceScore: norm.influenceScore,
+      rawElasticity: getRawElasticity(norm),
+      confidence: norm.confidence,
+      valueOfInformation: norm.valueOfInformation,
+    }
+  })
+
+  const displayModel = selectDriverDisplayModel(policyRows)
+  const feed: DriverPolicyFeed = { rawFactors, policyRows, displayModel }
+  driverPolicyFeedCache.set(report, feed)
+  return feed
+}
+
+// =============================================================================
 // Dynamic Normalisation (CRITICAL: Fix for arbitrary div-by-2)
 // =============================================================================
 

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -473,6 +473,8 @@ export interface DriverPolicyRow {
 export interface DriverPolicyFeed {
   /** Merged + de-duped raw rows (sources 1-5, panel reference order). */
   rawFactors: RawFactorSensitivity[]
+  /** True when source 1 resolved via the untyped enrichment passthrough. */
+  usedEnrichmentFallback: boolean
   /** Policy input per raw row (same index as rawFactors). */
   policyRows: DriverPolicyRow[]
   /** THE resolved display model every surface renders AND ranks from. */
@@ -481,9 +483,28 @@ export interface DriverPolicyFeed {
 
 const EMPTY_DRIVER_POLICY_FEED: DriverPolicyFeed = Object.freeze({
   rawFactors: [],
+  usedEnrichmentFallback: false,
   policyRows: [],
   displayModel: new Map(),
 })
+
+/**
+ * Untyped `enrichment.sensitivity_analysis.factors` passthrough. NOT declared
+ * on ReportV1 — every reader of it (this feed, OptionNode, StyledEdge) probes
+ * it speculatively, and no writer in the repo puts `enrichment` ON a report
+ * (the store keeps it as a SIBLING of `report`, and every resultsComplete
+ * caller passes the two separately). We nonetheless keep it as the source-1
+ * fallback rather than delete it: proving it unreachable across every
+ * hydration path (live map, conversation envelope, V5 apply, history restore)
+ * is a negative we cannot fully evidence, and keeping it costs nothing —
+ * because it now lives in the SHARED feed, reachable or not, BOTH surfaces
+ * resolve the identical rows and the basis cannot fork.
+ */
+function readEnrichmentFactors(report: ResultsReport): unknown[] | null {
+  const probe = report as { enrichment?: { sensitivity_analysis?: { factors?: unknown } } }
+  const factors = probe.enrichment?.sensitivity_analysis?.factors
+  return Array.isArray(factors) ? factors : null
+}
 
 /** Labels play no part in policy keys/metrics (getFactorKey resolves ids
  * before labels, and the label-map fallback needs an id anyway), so the feed
@@ -523,9 +544,19 @@ export function selectDriverPolicyFeed(
   // Collect raw factors from multiple sources (moved from the drivers memo)
   const rawFactors: RawFactorSensitivity[] = []
 
-  // Source 1: factor_sensitivity (PLoT v2)
-  const factorSensitivity = report.factor_sensitivity || []
-  factorSensitivity.forEach((f: RawFactorSensitivity) => rawFactors.push(f))
+  // Source 1: factor_sensitivity (PLoT v2), else the untyped enrichment
+  // passthrough. Precedence (certified array FIRST, enrichment only when the
+  // certified array is empty) is the canvas hook's existing rule and the same
+  // one OptionNode/StyledEdge apply — preserved here verbatim so folding the
+  // hook onto this feed changes no behaviour, and so the panel stops being
+  // the only surface blind to the fallback.
+  const certifiedFactors = (report.factor_sensitivity ?? []) as RawFactorSensitivity[]
+  const enrichmentFactors = certifiedFactors.length === 0 ? readEnrichmentFactors(report) : null
+  const usedEnrichmentFallback = enrichmentFactors !== null && enrichmentFactors.length > 0
+  const factorSensitivity: RawFactorSensitivity[] = certifiedFactors.length > 0
+    ? certifiedFactors
+    : ((enrichmentFactors ?? []) as RawFactorSensitivity[])
+  factorSensitivity.forEach((f) => rawFactors.push(f))
 
   // Precompute keys in a Set for O(1) duplicate detection
   const seenKeys = new Set<string>()
@@ -590,7 +621,7 @@ export function selectDriverPolicyFeed(
   })
 
   const displayModel = selectDriverDisplayModel(policyRows)
-  const feed: DriverPolicyFeed = { rawFactors, policyRows, displayModel }
+  const feed: DriverPolicyFeed = { rawFactors, usedEnrichmentFallback, policyRows, displayModel }
   driverPolicyFeedCache.set(report, feed)
   return feed
 }
@@ -1808,19 +1839,21 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
   const drivers = useMemo<DriversSectionData>(() => {
     const driversStatus = report?.drivers_status || 'unavailable'
 
-    // Collect raw factors from multiple sources
-    const rawFactors: RawFactorSensitivity[] = []
+    // C4 fix 2: the row merge lives in selectDriverPolicyFeed — THE one feed
+    // this panel and the canvas hook (useNodeDisplayMetadata) both read, so
+    // the coverage verdict (and therefore the disclosed basis) cannot fork
+    // between the two surfaces for the same report.
+    const feed = selectDriverPolicyFeed(report)
+    const rawFactors = feed.rawFactors
 
-    // Source 1: factor_sensitivity (PLoT v2)
-    const factorSensitivity = report?.factor_sensitivity || []
-
-    // P0 DIAGNOSTIC: Log raw factor_sensitivity data to verify field mapping
+    // P0 DIAGNOSTIC: Log the resolved source-1 rows to verify field mapping
     // Fix 3: Guard window access for SSR, Fix 5: Gate behind debug toggle
-    if (typeof window !== 'undefined' && (window as any).__OLUMI_DEBUG && factorSensitivity.length > 0) {
-      console.warn('[useResultsSectionData] Raw factor_sensitivity from PLoT:', {
-        count: factorSensitivity.length,
-        sample: factorSensitivity[0],
-        allFields: factorSensitivity.map((f: any) => ({
+    if (typeof window !== 'undefined' && (window as any).__OLUMI_DEBUG && rawFactors.length > 0) {
+      console.warn('[useResultsSectionData] Merged driver rows:', {
+        count: rawFactors.length,
+        sample: rawFactors[0],
+        usedEnrichmentFallback: feed.usedEnrichmentFallback,
+        allFields: rawFactors.map((f: any) => ({
           node_id: f.node_id,
           label: f.label,
           sensitivity_score: f.sensitivity_score,
@@ -1831,60 +1864,6 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         })),
       })
     }
-
-    factorSensitivity.forEach((f: any) => rawFactors.push(f))
-
-    // Fix 2: Precompute keys in a Set for O(1) duplicate detection
-    const seenKeys = new Set<string>()
-    rawFactors.forEach((f, index) => seenKeys.add(getFactorKey(f, index)))
-
-    // Source 2: drivers array (legacy)
-    // Fix 2: Use getFactorKey for canonical de-dupe (not d.nodeId || d.id)
-    const legacyDrivers = report?.drivers || []
-    legacyDrivers.forEach((d: any, idx: number) => {
-      const candidate: RawFactorSensitivity = {
-        node_id: d.nodeId,
-        id: d.id,
-        label: d.label,
-        sensitivity: d.contribution,
-        direction: d.polarity === 'down' ? 'negative' : 'positive',
-      }
-      const key = getFactorKey(candidate, rawFactors.length + idx)
-      if (!seenKeys.has(key)) {
-        seenKeys.add(key)
-        rawFactors.push(candidate)
-      }
-    })
-
-    // Source 3: drivers_payload
-    const driversPayload = report?.drivers_payload?.drivers || []
-    driversPayload.forEach((pd: any, idx: number) => {
-      const key = getFactorKey(pd, rawFactors.length + idx)
-      if (!seenKeys.has(key)) {
-        seenKeys.add(key)
-        rawFactors.push(pd)
-      }
-    })
-
-    // Source 4: sensitivity.factors (alternative path)
-    const sensitivityFactors = report?.sensitivity?.factors || []
-    sensitivityFactors.forEach((sf: any, idx: number) => {
-      const key = getFactorKey(sf, rawFactors.length + idx)
-      if (!seenKeys.has(key)) {
-        seenKeys.add(key)
-        rawFactors.push(sf)
-      }
-    })
-
-    // Source 5: factors array (direct)
-    const directFactors = report?.factors || []
-    directFactors.forEach((df: any, idx: number) => {
-      const key = getFactorKey(df, rawFactors.length + idx)
-      if (!seenKeys.has(key)) {
-        seenKeys.add(key)
-        rawFactors.push(df)
-      }
-    })
 
     if (rawFactors.length === 0) {
       return {
@@ -1921,7 +1900,12 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     // normalisedInfluence instead, so the whole surface shares one basis.
     // Codex R3-B1: display value + provenance from the ONE shared policy
     // (driverDisplayModel) — the same function the graph badge consumes.
-    const displayModel = selectDriverDisplayModel(factorsWithKeys)
+    // C4 fix 2: read the model off the shared FEED rather than recomputing it
+    // from this panel's own rows. Sharing the policy function alone still let
+    // the verdict fork, because each surface fed it a different row set; the
+    // keys are identical (getFactorKey resolves ids before labels, so the
+    // feed's label-free normalisation yields the same key per row).
+    const displayModel = feed.displayModel
     const rankMap = computeFactorRanks(
       factorsWithKeys.map((f) => ({
         ...f,


### PR DESCRIPTION
## The gap (verified against origin/staging dbd6be9d)

"What's driving this" showed **Technical Leadership Capability at 100% influence** — and that 100% is **by construction**, with nothing disclosing it.

`src/components/results/driverDisplayModel.ts` (`selectDriverDisplayModel`) is the single shared source for the drivers panel, the analysis hero, and the canvas node chips. It has two paths:

- producer `influence_score` shown raw **only** when every ranked factor carries a finite one;
- otherwise **all** factors show per-set normalised `|elasticity|` (`Math.abs(rawElasticity)/actualMax`) — the top driver is **always exactly 1.0**.

The authors knew the misread risk: a degenerate-set guard (max |elasticity| < 0.001 → direction-only view) exists precisely to avoid "misleading ~100% bars". And a provenance marker (`DriverItem.displayProvenance`: `'influence_score' | 'normalised_elasticity'`) was already plumbed "so a surface can make the basis explicit" — but no surface consumed it for user copy.

## Where the disclosure was dropped

`DriversSection.tsx` — **v7.10 T9**: *Renamed "Relative influence" → "Influence" for brevity*. The tooltip became "Influence: how much this factor affects the outcome" and the explainer "Ranked by how much each factor affects the outcome" — absolute-sounding copy on a set-relative number. The canvas chip (`MetricPills.tsx`) rendered a bare `I: NN%` with no tooltip at all.

## The fix — disclose the basis; numbers and policy untouched

Basis-aware copy driven by the existing `displayProvenance` (the shared model resolves ONE basis for the whole ranked set, so any stamped row describes the panel):

| Surface | `normalised_elasticity` (fallback) | `influence_score` (producer) | no stamp (legacy/cached) |
|---|---|---|---|
| Influence header tooltip | "Influence: how much this factor affects the outcome, relative to the strongest — the top driver always shows 100%." | "Influence: how much this factor affects the outcome — an absolute causal influence score from the analysis." | unchanged generic copy (fail-closed) |
| Explainer | "Ranked by how much each factor affects the outcome, relative to the strongest factor" | unchanged | unchanged |
| Panel caption (new, `role="note"`, `influence-scale-caption`, SensitivityReferenceCaption idiom) | "Influence is relative to the strongest factor — the top driver always shows 100%." | absent | absent |
| Canvas `I: NN%` chip (`title` + `aria-label`, EdgePills native-tooltip idiom — DS floating Tooltip is not used inside React Flow node chrome) | title as tooltip above; aria "Influence NN%, relative to the strongest factor — the top driver always shows 100%" | title as tooltip above; aria "Influence NN% — an absolute causal influence score from the analysis" | generic title; aria "Influence NN%" |

Plumbing: `useNodeDisplayMetadata` now returns `influenceProvenance` (read off the same display-model entry that already supplies `influence`); `FactorNode` passes it to `MetricPills`. No change to `driverDisplayModel` computation, `semanticLabel` logic, `DataBar`, or `FactorNode.priorRangeDisplay` (lane C3).

## Tests (RED-first — all 10 new disclosure assertions failed before the fix)

New:
- `src/components/results/__tests__/DriversSection.influenceScaleDisclosure.spec.tsx` (9) — caption/tooltip/explainer per provenance incl. fail-closed legacy path, and displayed numbers unchanged (top bar still 100%)
- `src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx` (5) — pill title/aria per provenance, fail-closed default, unchanged null/confidence-only behaviour
- `useNodeDisplayMetadata.spec.ts` +3 — provenance under partial vs full coverage, null outside results mode
- `FactorNode.spec.tsx` +1 — provenance passthrough to the pill

Existing suites green untouched: all 11 `DriversSection.*` specs, `driverDisplayModel.spec.ts`, `DataBar.spec.tsx`, `FactorNode.spec.tsx` (100), `FactorNode.optionTable/baseline.regression`, `EdgePills.spec.tsx`, plus indirect consumers (`DecisionConfidencePanel.*`, `ResultsBody.*`, `HeroFooterAlignment.matrix`, `PreAnalysisPanel`, `SensitivityReferenceCaption`) — 442 tests passed, 1 pre-existing skip.

## Gates

- Targeted vitest (above): pass
- `pnpm run typecheck` (tsconfig.ci.json, CI-matching): pass — note this config does not include the touched files (narrow include list by design)
- Targeted eslint on touched files: 0 errors (3 pre-existing unused-import warnings in `FactorNode.tsx`, untouched)
- Hang-skips per machine gotchas: full `eslint .` and full vitest suite not run locally (known to hang at 0% CPU) — relying on CI for the full-suite runs

## Review fold + re-review — scope of the unification claim (corrected)

The review fold unified the row feed behind `selectDriverPolicyFeed`, so the **Drivers panel** and the **factor-node chip** (`useNodeDisplayMetadata`) resolve their rows, coverage verdict and disclosed basis from one merge. That much holds and is pinned by `driverPolicyFeed.parity.spec.tsx`.

**Correction.** An earlier fold comment on this PR claimed "One feed makes that fork unrepresentable" and "the fork is now *unrepresentable*, not merely fixed". Both overclaim, in two ways. They are corrected here and stand as scoped below.

1. **Two surfaces share the feed, not three.** `OptionNode` (`winsVia` / the "Behind:" card) still builds a **private** feed over `report.factor_sensitivity ?? report.enrichment.sensitivity_analysis.factors`, filtered through `extractPolicyRow`, which **drops** metric-less rows. The panel and chip read the five-source merge, which **keeps** them. So OptionNode can still resolve a different row set, and therefore a different coverage verdict, from the same report. This is **pre-existing** (it is why `extractPolicyRow` is still live) and is deliberately **not** changed in this lane, but it means the fork is narrowed to two surfaces, not made unrepresentable across the product. Two comments in `OptionNode.tsx` now overstate this: they claim it ranks "on the SAME basis as winsVia / the Drivers panel" and that its "source precedence matches the graph badge (`useNodeDisplayMetadata`)". The fold made both false, since the badge moved to the merge. Carried to the follow-up ledger.

2. **One feed was not sufficient for one ORDER.** The shared feed passed a **signed** magnitude, while the panel abs'd its own copy before ranking. `compareByDisplayModel` sorts its elasticity tie-break as given, so two drivers agreeing on basis and on displayed value still ordered differently by sign. That was a regression introduced by the fold and is fixed in this lane (see the re-review commit): the feed now carries an unsigned magnitude, matching the field's documented "Resolved magnitude" contract and its sibling producer `extractPolicyRow`. The parity spec asserted basis and value but never order, which is why it missed this; cross-surface **order** pins now cover it.

**Accurate claim:** the panel and the factor-node chip share one feed, so they cannot disclose contradictory bases, values **or order** for the same report. `OptionNode` remains a known third surface with its own feed.

Known and out of scope (ledger): the panel's final tie-break is **label** alphabetical while the canvas's is **key** alphabetical, so a report whose label order and key order disagree can still fork on that last tie-break. Verified identical on staging, so pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
