### PR TITLE
fix(results): receipts fail closed — no fabricated Seed/Stable-edges values

### DIFF
--- a/src/adapters/plot/types.ts
+++ b/src/adapters/plot/types.ts
@@ -14,7 +14,12 @@ export interface OptionProbability {
 export interface ReportV1 {
   schema: 'report.v1'
   meta: {
-    seed: number
+    /**
+     * Seed the engine actually used, or null when no real value exists
+     * (e.g. the V5 contract carries no seed field). Receipts fail closed:
+     * consumers hide the Seed row on null rather than fabricating 0.
+     */
+    seed: number | null
     response_id: string
     elapsed_ms: number
   }

--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -371,7 +371,10 @@ export function pickFactorSensitivityForUi(v2Response: V2RunResponse): FactorSen
  */
 export function mapV2ResponseToReportV1(
   v2Response: V2RunResponse,
-  meta: { seed: number; elapsed_ms?: number }
+  // seed: null when the caller has no REAL seed for this response (no
+  // engine echo / provenance). Receipts fail closed — never pass 0 as a
+  // stand-in for "unknown".
+  meta: { seed: number | null; elapsed_ms?: number }
 ): ReportV1 {
   // P0 DIAGNOSTIC: Log input to identify crash source
   if (import.meta.env.DEV) {

--- a/src/canvas/conversation/__tests__/envelopeAnalysisWiring.spec.ts
+++ b/src/canvas/conversation/__tests__/envelopeAnalysisWiring.spec.ts
@@ -63,8 +63,15 @@ vi.mock('../../../adapters/plot/v2', () => ({
     Array.isArray(analysisReady?.options) ? analysisReady.options : [],
 }))
 
+// T2 (receipts fail closed): capture the mapper's options so tests can pin
+// the seed provenance handleEnvelope derives for THIS response. vi.hoisted
+// because vi.mock factories are hoisted above module-level const init.
+const { mockMapV2ResponseToReportV1 } = vi.hoisted(() => ({
+  mockMapV2ResponseToReportV1: vi.fn(() => ({ id: 'mock-report', graph_quality: null })),
+}))
+
 vi.mock('../../../adapters/plot/v2/responseMapper', () => ({
-  mapV2ResponseToReportV1: () => ({ id: 'mock-report', graph_quality: null }),
+  mapV2ResponseToReportV1: mockMapV2ResponseToReportV1,
   createEnrichmentFromV2Response: () => null,
   synthesizeCeeReviewFromV2: () => null,
   synthesizeCeeTraceFromV2: () => null,
@@ -100,6 +107,7 @@ const mockResultsError = vi.fn()
 beforeEach(() => {
   vi.useFakeTimers()
   mockCallTurn.mockReset()
+  mockMapV2ResponseToReportV1.mockClear()
   mockResultsComplete.mockReset()
   mockResultsError.mockReset()
 
@@ -296,5 +304,96 @@ describe('A.9 — provenance preservation', () => {
     // TypeScript ensures this is correct — the type test is a compile-time guarantee.
     // Check the selector exists and returns the right type
     expect(typeof storeActions.resultsComplete).toBe('function')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// T2 — receipts fail closed: seed provenance on the envelope path
+//
+// The Seed receipt row must show the seed of THIS analysis response or
+// nothing at all. The only real source on the envelope path is the engine
+// echo (analysis_response.meta.seed_used). A fabricated 0 and a stale
+// store seed left over from a previous run are both provenance lies.
+// ---------------------------------------------------------------------------
+
+describe('receipts fail closed — envelope seed provenance', () => {
+  it('engine echo meta.seed_used is parsed and passed to the mapper as the real seed', async () => {
+    const v2Response = {
+      ...makeV2Response('hash-seed-echo'),
+      meta: { seed_used: '4242' },
+    }
+    mockCallTurn.mockResolvedValue({
+      assistant_text: 'Analysis complete.',
+      analysis_response: v2Response,
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Run the analysis')
+    })
+
+    expect(mockMapV2ResponseToReportV1).toHaveBeenCalledTimes(1)
+    const options = mockMapV2ResponseToReportV1.mock.calls[0][1] as { seed: number | null }
+    expect(options.seed).toBe(4242)
+  })
+
+  it('no engine echo → seed null (never a fabricated 0)', async () => {
+    const v2Response = makeV2Response('hash-no-echo') // no meta at all
+    mockCallTurn.mockResolvedValue({
+      assistant_text: 'Analysis complete.',
+      analysis_response: v2Response,
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Run the analysis')
+    })
+
+    expect(mockMapV2ResponseToReportV1).toHaveBeenCalledTimes(1)
+    const options = mockMapV2ResponseToReportV1.mock.calls[0][1] as { seed: number | null }
+    expect(options.seed).toBeNull()
+  })
+
+  it('a stale store seed from a previous run is NOT attributed to this response', async () => {
+    // Seed 7 belongs to some earlier direct run; this envelope response
+    // carries no echo, so its seed is unknown → null.
+    useCanvasStore.setState({
+      results: { status: 'complete', hash: 'old-hash', seed: 7 } as any,
+    } as any)
+
+    const v2Response = makeV2Response('hash-stale-store')
+    mockCallTurn.mockResolvedValue({
+      assistant_text: 'Analysis complete.',
+      analysis_response: v2Response,
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Run the analysis')
+    })
+
+    expect(mockMapV2ResponseToReportV1).toHaveBeenCalledTimes(1)
+    const options = mockMapV2ResponseToReportV1.mock.calls[0][1] as { seed: number | null }
+    expect(options.seed).toBeNull()
+  })
+
+  it('malformed echo (non-numeric seed_used) → null, never 0', async () => {
+    const v2Response = {
+      ...makeV2Response('hash-bad-echo'),
+      meta: { seed_used: 'garbage' },
+    }
+    mockCallTurn.mockResolvedValue({
+      assistant_text: 'Analysis complete.',
+      analysis_response: v2Response,
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Run the analysis')
+    })
+
+    expect(mockMapV2ResponseToReportV1).toHaveBeenCalledTimes(1)
+    const options = mockMapV2ResponseToReportV1.mock.calls[0][1] as { seed: number | null }
+    expect(options.seed).toBeNull()
   })
 })

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -2233,7 +2233,15 @@ export function useConversation(): UseConversationReturn {
             // Apply the same validate → sanitize → map pipeline as the direct path
             validateV2RunResponseFull(raw) // soft warnings only; don't block on them
             const result = sanitizeV2RunResponse(raw)
-            const seedUsed = typeof store.results.seed === 'number' ? store.results.seed : 0
+            // Receipts fail closed (T2): the only real seed for THIS
+            // response is the engine echo (meta.seed_used). A fabricated 0
+            // and a stale store.results.seed left over from a previous
+            // direct run are both provenance lies — no echo → null → the
+            // Seed receipt row hides.
+            const echoedSeed = result.meta?.seed_used != null
+              ? Number.parseInt(String(result.meta.seed_used), 10)
+              : Number.NaN
+            const seedUsed = Number.isFinite(echoedSeed) ? echoedSeed : null
             const report = mapV2ResponseToReportV1(result, { seed: seedUsed })
             // SAFETY: V2-derived enrichment has sensitivity_analysis.edges/factors with
             // {elasticity, importance_rank} instead of PLoTEdgeSensitivity shape.

--- a/src/components/results/__tests__/receipts-fail-closed.spec.tsx
+++ b/src/components/results/__tests__/receipts-fail-closed.spec.tsx
@@ -1,0 +1,110 @@
+/**
+ * receipts fail-closed — doctrine pin (T2)
+ *
+ * The "Advanced and receipts → Analysis details" grid renders REAL values
+ * only; every row fails closed (hides) when its value is absent. This spec
+ * pins the doctrine at the component boundary so a future upstream mapper
+ * can never resurrect the "Seed 0" / "Stable edges 0" fabrication bug: the
+ * component treats null/undefined as "no value → no row", while an honest
+ * producer-sent zero still displays.
+ *
+ * Upstream halves of the same doctrine:
+ * - src/v5/__tests__/mapV5AnalysisToReport.test.ts ("receipts fail closed")
+ * - src/hooks/__tests__/hydrateAnalysis.spec.ts (seed null fallbacks)
+ * - src/canvas/conversation/__tests__/envelopeAnalysisWiring.spec.ts
+ *   ("receipts fail closed — envelope seed provenance")
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AdvancedSection } from '../AdvancedSection'
+
+// Mock useRiskProfile hook (same as AdvancedSection.spec.tsx)
+vi.mock('../../../canvas/hooks/useRiskProfile', () => ({
+  useRiskProfile: () => ({
+    profile: null,
+    loading: false,
+    selectPreset: vi.fn(),
+  }),
+  RISK_PRESETS: {
+    risk_averse: { label: 'Risk Averse', description: 'Prefer certainty', icon: '', score: 0.2 },
+    neutral: { label: 'Neutral', description: 'Balance risk', icon: '', score: 0.5 },
+    risk_seeking: { label: 'Risk Seeking', description: 'Accept higher risk', icon: '', score: 0.8 },
+  },
+}))
+
+function expand() {
+  fireEvent.click(screen.getByText('Advanced and receipts'))
+}
+
+describe('receipts fail closed — AdvancedSection Analysis details', () => {
+  it('seedUsed null → no Seed row', () => {
+    render(<AdvancedSection seedUsed={null} expertMode />)
+    expand()
+
+    expect(screen.queryByText('Seed')).not.toBeInTheDocument()
+  })
+
+  it('seedUsed undefined → no Seed row', () => {
+    render(<AdvancedSection expertMode />)
+    expand()
+
+    expect(screen.queryByText('Seed')).not.toBeInTheDocument()
+  })
+
+  it('seedUsed 0 is an honest value → Seed row shows 0', () => {
+    render(<AdvancedSection seedUsed={0} expertMode />)
+    expand()
+
+    expect(screen.getByText('Seed')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('robustEdgeCount undefined → no Stable edges row', () => {
+    render(<AdvancedSection expertMode />)
+    expand()
+
+    expect(screen.queryByText('Stable edges')).not.toBeInTheDocument()
+  })
+
+  it('robustEdgeCount 0 is an honest zero → Stable edges row shows 0', () => {
+    render(<AdvancedSection robustEdgeCount={0} expertMode />)
+    expand()
+
+    expect(screen.getByText('Stable edges')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('fragileEdgeCount undefined → no Sensitive assumptions row', () => {
+    render(<AdvancedSection expertMode />)
+    expand()
+
+    expect(screen.queryByText('Sensitive assumptions')).not.toBeInTheDocument()
+  })
+
+  it('fragileEdgeCount 0 is an honest zero → Sensitive assumptions row shows 0', () => {
+    render(<AdvancedSection fragileEdgeCount={0} expertMode />)
+    expand()
+
+    expect(screen.getByText('Sensitive assumptions')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('a receipts grid with NO real values renders no fabricated rows at all', () => {
+    render(
+      <AdvancedSection
+        seedUsed={null}
+        stability={null}
+        nSamples={null}
+        identifiability={null}
+        responseHash={null}
+        expertMode
+      />,
+    )
+    expand()
+
+    const receipts = screen.getByTestId('analysis-receipts')
+    // The dl grid exists but carries no rows — nothing was fabricated.
+    expect(receipts.querySelectorAll('dt')).toHaveLength(0)
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -1041,8 +1041,13 @@ export interface ResultsReport extends Omit<ReportV1, 'option_probabilities'> {
   // V2 pass-through fields from responseMapper
   factor_sensitivity?: V2FactorSensitivity[]
   robustness?: {
-    fragile_edges: Array<Record<string, unknown>>
-    robust_edges: Array<Record<string, unknown>>
+    // Optional (T2 receipts-honesty): the V5 mapper preserves ABSENCE —
+    // keys exist only when the producer sent an array ([] = honest "none",
+    // absent = "engine said nothing" → receipt rows fail closed). The V4
+    // mapper still always emits both when robustness is present, because
+    // the V2 wire contract requires them (V2RobustnessActual).
+    fragile_edges?: Array<Record<string, unknown>>
+    robust_edges?: Array<Record<string, unknown>>
     ranking_stability?: number
     recommendation_stability?: number
     is_robust?: boolean

--- a/src/hooks/__tests__/hydrateAnalysis.spec.ts
+++ b/src/hooks/__tests__/hydrateAnalysis.spec.ts
@@ -74,8 +74,12 @@ describe('hydrateAnalysisFromV2Response', () => {
     expect(result!.results.progress).toBe(100)
     expect(result!.results.error).toBeUndefined()
     expect(result!.results.hash).toBe('abc123')
-    expect(result!.results.seed).toBe(0) // no provenance, no meta
+    // Receipts fail closed (T2): no provenance and no meta.seed_used means
+    // there is NO real seed — the store slot stays undefined and the mapped
+    // report carries null, so the Seed receipt row hides. Never fabricate 0.
+    expect(result!.results.seed).toBeUndefined()
     expect(result!.results.report).toBeDefined()
+    expect(result!.results.report!.meta.seed).toBeNull()
   })
 
   it('maps seed and hash from provenance when provided', () => {
@@ -112,6 +116,30 @@ describe('hydrateAnalysisFromV2Response', () => {
     const result = hydrateAnalysisFromV2Response(v2, null)
 
     expect(result!.results.seed).toBe(77)
+    expect(result!.results.report!.meta.seed).toBe(77)
+  })
+
+  // T2 — receipts fail closed: a malformed engine echo is NOT a real value.
+  // The old `parseInt(...) || 0` swallowed the NaN into a fabricated seed 0
+  // that then displayed as "Seed 0" in the Analysis details receipts.
+  it('malformed meta.seed_used (non-numeric) → no seed, never a fabricated 0', () => {
+    const v2 = makeMinimalV2Response({
+      meta: { seed_used: 'not-a-number' } as any,
+    })
+    const result = hydrateAnalysisFromV2Response(v2, null)
+
+    expect(result!.results.seed).toBeUndefined()
+    expect(result!.results.report!.meta.seed).toBeNull()
+  })
+
+  it('meta.seed_used "0" is an honest zero and is preserved', () => {
+    const v2 = makeMinimalV2Response({
+      meta: { seed_used: '0' } as any,
+    })
+    const result = hydrateAnalysisFromV2Response(v2, null)
+
+    expect(result!.results.seed).toBe(0)
+    expect(result!.results.report!.meta.seed).toBe(0)
   })
 
   it('populates runMeta.ceeReviewV1 for computed analysis', () => {

--- a/src/hooks/hydrateAnalysis.ts
+++ b/src/hooks/hydrateAnalysis.ts
@@ -103,11 +103,16 @@ export function hydrateAnalysisFromV2Response(
 
   const v2Response = sanitizeV2RunResponse(rawAnalysis as V2RunResponse)
 
-  // Derive seed: prefer provenance (numeric), fallback to response meta (string→number)
-  const seedUsed: number = provenance?.seed_used
-    ?? (v2Response.meta?.seed_used
-      ? (parseInt(String(v2Response.meta.seed_used), 10) || 0)
-      : 0)
+  // Derive seed: prefer provenance (numeric), fallback to response meta
+  // (string→number). Receipts fail closed (T2): no real value → null —
+  // never a fabricated 0. In particular, a malformed meta.seed_used parses
+  // to NaN and becomes null (the old `|| 0` swallowed the NaN into a
+  // fabricated seed that displayed as "Seed 0").
+  const parsedMetaSeed = v2Response.meta?.seed_used != null
+    ? Number.parseInt(String(v2Response.meta.seed_used), 10)
+    : Number.NaN
+  const seedUsed: number | null = provenance?.seed_used
+    ?? (Number.isFinite(parsedMetaSeed) ? parsedMetaSeed : null)
 
   // Map V2RunResponse → ReportV1
   const report = mapV2ResponseToReportV1(v2Response, { seed: seedUsed })
@@ -134,7 +139,10 @@ export function hydrateAnalysisFromV2Response(
     results: {
       status: 'complete',
       progress: 100,
-      seed: seedUsed,
+      // Store slot uses undefined for absence (ResultsState.seed?: number);
+      // the store's own guards (`!= null` / `!== undefined`) then skip
+      // seed-dependent bookkeeping instead of recording a fabricated 0.
+      seed: seedUsed ?? undefined,
       hash: responseHash,
       report,
       enrichment: enrichment ?? undefined,

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -955,7 +955,9 @@ describe('mapV5AnalysisToReport — deterministic hash + minimal envelope', () =
 
     const report = mapV5AnalysisToReport(block)
     expect(report.schema).toBe('report.v1')
-    expect(report.meta.seed).toBe(0)
+    // Receipts fail closed: the V5 contract carries no seed field, so a
+    // caller-less mapping must carry null (row hides), never a fabricated 0.
+    expect(report.meta.seed).toBeNull()
     expect(report.meta.response_id).toMatch(/^v5:[0-9a-f]{16}$/)
     expect(report.model_card.response_hash).toBe(report.meta.response_id)
     expect(report.confidence.level).toBe('medium')
@@ -1182,5 +1184,69 @@ describe('mapV5AnalysisToReport — display_verdict / confidence_tier / goal_fit
       baseBlock({ enrichment: { robustness: { fragile_edges: [], robust_edges: [] } } }),
     ) as ReturnType<typeof mapV5AnalysisToReport> & { constraints_status?: string }
     expect(withoutStatus.constraints_status).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// T2 — receipts fail closed (no fabricated Seed / Stable-edges defaults)
+//
+// Doctrine (AdvancedSection.tsx "Analysis details" receipts): real values
+// only; rows fail closed when absent. The mapper must therefore preserve
+// ABSENCE — a missing seed becomes null (not 0) and missing robustness
+// arrays stay off the report (not []) — while an honest producer-sent
+// zero/empty value still flows through and displays.
+// ---------------------------------------------------------------------------
+
+describe('mapV5AnalysisToReport — receipts fail closed (no fabricated defaults)', () => {
+  it('no options.seed → meta.seed is null (V5 contract carries no seed; Seed row hides)', () => {
+    const report = mapV5AnalysisToReport(baseBlock({}))
+    expect(report.meta.seed).toBeNull()
+  })
+
+  it('options.seed 0 is an honest value and is preserved (not confused with absence)', () => {
+    const report = mapV5AnalysisToReport(baseBlock({}), { seed: 0 })
+    expect(report.meta.seed).toBe(0)
+  })
+
+  it('robustness present without robust_edges/fragile_edges → keys ABSENT, not fabricated []', () => {
+    const report = mapV5AnalysisToReport(
+      baseBlock({ enrichment: { robustness: { ranking_stability: 0.9 } } as never }),
+    ) as ReturnType<typeof mapV5AnalysisToReport> & {
+      robustness?: Record<string, unknown>
+    }
+    expect(report.robustness).toBeDefined()
+    expect('robust_edges' in report.robustness!).toBe(false)
+    expect('fragile_edges' in report.robustness!).toBe(false)
+  })
+
+  it('malformed (non-array) robust_edges/fragile_edges → keys ABSENT, not coerced to []', () => {
+    const report = mapV5AnalysisToReport(
+      baseBlock({
+        enrichment: {
+          robustness: {
+            ranking_stability: 0.5,
+            robust_edges: 'not-an-array',
+            fragile_edges: { nope: true },
+          },
+        } as never,
+      }),
+    ) as ReturnType<typeof mapV5AnalysisToReport> & {
+      robustness?: Record<string, unknown>
+    }
+    expect(report.robustness).toBeDefined()
+    expect('robust_edges' in report.robustness!).toBe(false)
+    expect('fragile_edges' in report.robustness!).toBe(false)
+  })
+
+  it('producer-sent EMPTY arrays are honest zeros: keys present with length 0 (row shows 0)', () => {
+    const report = mapV5AnalysisToReport(
+      baseBlock({
+        enrichment: { robustness: { fragile_edges: [], robust_edges: [] } } as never,
+      }),
+    ) as ReturnType<typeof mapV5AnalysisToReport> & {
+      robustness?: { fragile_edges?: unknown[]; robust_edges?: unknown[] }
+    }
+    expect(report.robustness?.robust_edges).toEqual([])
+    expect(report.robustness?.fragile_edges).toEqual([])
   })
 })

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -290,8 +290,13 @@ function resolveOptionEntries(
 // ─── Public mapper ─────────────────────────────────────────────────────
 
 export interface MapV5AnalysisOptions {
-  /** Seed used for the run. Defaults to 0 when caller has none. */
-  seed?: number
+  /**
+   * Seed used for the run. The V5 contract carries NO seed field, so when
+   * the caller has no real value the report carries null and the Seed
+   * receipt row fails closed (hides). Never default to 0 — a fabricated
+   * seed is a provenance lie (T2 receipts-honesty).
+   */
+  seed?: number | null
   /**
    * Optional override for response_hash. When omitted the hash is derived
    * deterministically from the block (summary + leading_option_id +
@@ -316,7 +321,11 @@ export function mapV5AnalysisToReport(
   block: AnalysisResultBlock,
   options: MapV5AnalysisOptions = {},
 ): ReportV1 {
-  const seed = options.seed ?? 0
+  // Receipts fail closed: no real seed → null (Seed row hides), never 0.
+  // NOTE: meta.seed does NOT feed the deriveBlockHash `v5:` digest — that
+  // hashes summary/leading_option_id/win_probabilities/enrichment only —
+  // so this change cannot perturb dedupe or hash stability.
+  const seed = options.seed ?? null
   const enrichment = isPlainObject(block.enrichment) ? block.enrichment : undefined
 
   // Factor sensitivity — collected and ranked once; reused for drivers + factor_sensitivity passthrough.
@@ -464,12 +473,17 @@ export function mapV5AnalysisToReport(
     : undefined
   const robustness = robustnessRaw
     ? {
-        fragile_edges: Array.isArray(robustnessRaw.fragile_edges)
-          ? robustnessRaw.fragile_edges
-          : [],
-        robust_edges: Array.isArray(robustnessRaw.robust_edges)
-          ? robustnessRaw.robust_edges
-          : [],
+        // Receipts fail closed (T2): preserve ABSENCE. Keys are emitted
+        // only when the producer sent a real array — a producer-sent []
+        // is an honest "none stable/fragile" (row shows 0), while an
+        // absent or malformed field stays off the report so counts read
+        // undefined and receipt rows hide. Never coerce absence to [].
+        ...(Array.isArray(robustnessRaw.fragile_edges)
+          ? { fragile_edges: robustnessRaw.fragile_edges }
+          : {}),
+        ...(Array.isArray(robustnessRaw.robust_edges)
+          ? { robust_edges: robustnessRaw.robust_edges }
+          : {}),
         ...(safeFiniteNumber(robustnessRaw.ranking_stability) !== undefined
           ? { ranking_stability: safeFiniteNumber(robustnessRaw.ranking_stability) }
           : {}),


### PR DESCRIPTION
## What
The Advanced receipts panel displayed "Seed 0" and "Stable edges 0" as if they were data. The component guards were already fail-closed (`seedUsed != null`), but upstream fabricated values so the guards passed:
- **Seed**: the V5 contract carries no seed at all — `mapV5AnalysisToReport` defaulted `options.seed ?? 0` into `meta.seed` (the `v5:` hash prefix proves production runs use this path). V4 paths (`useConversation`, `hydrateAnalysis`) had the same `: 0` fallback class and ignored the engine echo.
- **Stable edges**: absent `robustness.robust_edges` became `[]`, indistinguishable from a genuine empty array.

## Fix
Seed is `number | null` end-to-end: V5 maps to null (no fabrication possible); V4 prefers the engine echo (`seed_used`) and falls back to null, never 0; hydration drops the `|| 0` NaN-swallow. Robustness arrays preserve absence (conditional emission) so `robustEdgeCount`/`fragileEdgeCount` are undefined when the producer omitted the field, and honest 0 when it sent `[]`.

## Tests (RED-first)
Commit 1 = 4 spec files (incl. new `receipts-fail-closed.spec.tsx` doctrine pin) — bug-facing assertions RED against staging. Commit 2 = fix, all green. Targeted run: **109/109 pass**; `pnpm typecheck` (tsconfig.ci.json) clean.

## Provenance note
The implementing agent hit the account session limit after reaching GREEN but before commit; work was rescued from the worktree by explicit path per the workstream handover protocol, then typechecked and re-verified before push. Full CI is the authoritative gate; local eslint/full-suite deliberately deferred to CI (known local hang class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)