### PR TITLE
Wave1-L2: staged honest narration during analysis wait (seam D-M)

### DIFF
--- a/src/canvas/components/AnalysisRunningBanner.tsx
+++ b/src/canvas/components/AnalysisRunningBanner.tsx
@@ -4,12 +4,83 @@
  * buttons). Rendered by OutputsDock while isRunning && a previous report is
  * still on screen — the skeleton covers the no-report case. DS v4: bg-panel,
  * semantic tokens, Lucide only. aria-live announces the state change.
+ *
+ * Wave1-L2 (seam D-M) — staged honest narration during the 20-30s wait.
+ * Client-side, time-based staging only: the copy never claims a pipeline
+ * stage, percentage or scenario count we cannot know from the client. The
+ * banner unmounts the moment the run completes or errors (OutputsDock's
+ * isRunning gate), so every timer is cleared in effect cleanup — no stuck
+ * narration. prefers-reduced-motion: static icon and instant text swap
+ * instead of the crossfade.
  */
 import { Loader2 } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { typography } from '../../styles/typography'
 
+/**
+ * Honest, non-specific narration stages keyed by elapsed-second threshold.
+ * Copy rules (ratified experience doctrine): calm, plain-language,
+ * science-grounded; no fabricated progress numbers; no exclamation marks.
+ */
+export const NARRATION_STAGES = [
+  { afterSeconds: 0, message: 'Setting up your analysis…' },
+  { afterSeconds: 6, message: 'Running robustness simulations…' },
+  { afterSeconds: 14, message: 'Weighing what moves your decision…' },
+  { afterSeconds: 22, message: 'Almost there — shaping the results…' },
+] as const
+
+/** Resolve the narration message for a given elapsed time (seconds). */
+export function narrationForElapsed(elapsedSeconds: number): string {
+  // Walk stages in reverse to find the highest threshold that applies
+  for (let i = NARRATION_STAGES.length - 1; i >= 0; i--) {
+    if (elapsedSeconds >= NARRATION_STAGES[i].afterSeconds) {
+      return NARRATION_STAGES[i].message
+    }
+  }
+  return NARRATION_STAGES[0].message
+}
+
+/** Duration of the text crossfade between stages (skipped under reduced motion). */
+const CROSSFADE_MS = 200
+
 export function AnalysisRunningBanner() {
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  // Timer-driven elapsed counter (no Date dependence: the banner is mounted
+  // for the lifetime of the run, so a 1s tick is accurate enough for copy).
+  const [elapsed, setElapsed] = useState(0)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed((s) => s + 1)
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const targetMessage = narrationForElapsed(elapsed)
+
+  // Crossfade: fade the old line out, then swap and fade the new one in.
+  // Under prefers-reduced-motion the swap is instant and static.
+  const [displayed, setDisplayed] = useState(targetMessage)
+  const [fading, setFading] = useState(false)
+  const reducedMotionRef = useRef(prefersReducedMotion)
+  reducedMotionRef.current = prefersReducedMotion
+
+  useEffect(() => {
+    if (targetMessage === displayed) return undefined
+    if (reducedMotionRef.current) {
+      setDisplayed(targetMessage)
+      return undefined
+    }
+    setFading(true)
+    const timeout = setTimeout(() => {
+      setDisplayed(targetMessage)
+      setFading(false)
+    }, CROSSFADE_MS)
+    return () => clearTimeout(timeout)
+  }, [targetMessage, displayed])
+
   return (
     <div
       className="mx-3 mb-2 flex items-center gap-2 rounded-md border border-panel-border bg-panel px-3 py-2"
@@ -17,9 +88,19 @@ export function AnalysisRunningBanner() {
       role="status"
       aria-live="polite"
     >
-      <Loader2 className="h-4 w-4 animate-spin text-info" aria-hidden="true" />
-      <span className={`${typography.bodySmall} text-text-body`}>
-        Running a fresh analysis — the results below update when it completes.
+      <Loader2
+        className={`h-4 w-4 text-info ${prefersReducedMotion ? '' : 'animate-spin'}`}
+        aria-hidden="true"
+      />
+      <span
+        data-testid="analysis-narration"
+        className={`${typography.bodySmall} text-text-body ${
+          prefersReducedMotion
+            ? ''
+            : `transition-opacity duration-200 ${fading ? 'opacity-0' : 'opacity-100'}`
+        }`}
+      >
+        {displayed}
       </span>
     </div>
   )

--- a/src/canvas/components/AnalysisRunningBanner.tsx
+++ b/src/canvas/components/AnalysisRunningBanner.tsx
@@ -7,11 +7,15 @@
  *
  * Wave1-L2 (seam D-M) — staged honest narration during the 20-30s wait.
  * Client-side, time-based staging only: the copy never claims a pipeline
- * stage, percentage or scenario count we cannot know from the client. The
- * banner unmounts the moment the run completes or errors (OutputsDock's
- * isRunning gate), so every timer is cleared in effect cleanup — no stuck
- * narration. prefers-reduced-motion: static icon and instant text swap
- * instead of the crossfade.
+ * stage, percentage, scenario count or completion proximity we cannot know
+ * from the client. The banner unmounts the moment the run completes or errors
+ * (OutputsDock's isRunning gate), so every timer is cleared in effect cleanup
+ * — no stuck narration. prefers-reduced-motion: static icon and instant text
+ * swap instead of the crossfade.
+ *
+ * This banner is the SINGLE run-status live region wherever it mounts: its
+ * stage table subsumes the dock's pre-existing 20s/40s slow-run escalation,
+ * which yields to it. See analysisRunStatus.ts for the reconciliation.
  */
 import { Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
@@ -21,14 +25,30 @@ import { typography } from '../../styles/typography'
 
 /**
  * Honest, non-specific narration stages keyed by elapsed-second threshold.
- * Copy rules (ratified experience doctrine): calm, plain-language,
- * science-grounded; no fabricated progress numbers; no exclamation marks.
+ *
+ * Copy rules (ratified experience doctrine): calm, plain-language; no
+ * fabricated progress numbers; no exclamation marks; and — the binding
+ * honesty invariant — no claim of a pipeline stage, count or completion
+ * proximity the client cannot know.
+ *
+ * Elapsed time is the ONLY input. Every line must therefore be true by
+ * construction of elapsed time alone, and must STAY true for every second
+ * from its own threshold until the run ends — including a run that dies at
+ * the 130s timeout. That rules out the whole "almost there" family: the
+ * client consumes zero run state, so it can never know the run is close to
+ * done. The earlier table claimed "Almost there — shaping the results…" at a
+ * fixed 22s and then held it indefinitely, through timeouts included — a
+ * progress bar stuck at 95%.
+ *
+ * What survives is what elapsed time genuinely licenses: that a run is in
+ * flight, and that it has now been going longer than a typical one. The 20s
+ * and 40s thresholds deliberately match the dock's pre-existing slow-run
+ * escalation, which this table subsumes (see analysisRunStatus.ts).
  */
 export const NARRATION_STAGES = [
-  { afterSeconds: 0, message: 'Setting up your analysis…' },
-  { afterSeconds: 6, message: 'Running robustness simulations…' },
-  { afterSeconds: 14, message: 'Weighing what moves your decision…' },
-  { afterSeconds: 22, message: 'Almost there — shaping the results…' },
+  { afterSeconds: 0, message: 'Analysing your decision…' },
+  { afterSeconds: 20, message: 'This is taking longer than usual — still analysing…' },
+  { afterSeconds: 40, message: 'Still working — complex decisions can take a while…' },
 ] as const
 
 /** Resolve the narration message for a given elapsed time (seconds). */

--- a/src/canvas/components/AnalysisRunningBanner.tsx
+++ b/src/canvas/components/AnalysisRunningBanner.tsx
@@ -16,6 +16,16 @@
  * This banner is the SINGLE run-status live region wherever it mounts: its
  * stage table subsumes the dock's pre-existing 20s/40s slow-run escalation,
  * which yields to it. See analysisRunStatus.ts for the reconciliation.
+ *
+ * Round 2 P1 (REGRESSION) — the clock measures the RUN, not this component.
+ * The first cut started a counter at zero on mount, so "elapsed" meant "how
+ * long this component has existed". Because the banner SUBSUMES the slow-run
+ * region, a banner mounting 25s into a run suppressed a correct "taking
+ * longer" line and replaced it with the fresh-start line — worse than no
+ * banner at all. Elapsed time now derives from `startedAt`, the run's real
+ * start (the store's results.startedAt, set by every path that enters a
+ * running status and durable across remounts), so remounts, tab switches and
+ * a banner appearing mid-run all show the TRUE elapsed time.
  */
 import { Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
@@ -36,19 +46,30 @@ import { typography } from '../../styles/typography'
  * from its own threshold until the run ends — including a run that dies at
  * the 130s timeout. That rules out the whole "almost there" family: the
  * client consumes zero run state, so it can never know the run is close to
- * done. The earlier table claimed "Almost there — shaping the results…" at a
+ * done. An earlier table claimed "Almost there — shaping the results…" at a
  * fixed 22s and then held it indefinitely, through timeouts included — a
  * progress bar stuck at 95%.
  *
- * What survives is what elapsed time genuinely licenses: that a run is in
- * flight, and that it has now been going longer than a typical one. The 20s
- * and 40s thresholds deliberately match the dock's pre-existing slow-run
- * escalation, which this table subsumes (see analysisRunStatus.ts).
+ * Round 2 P1 (HONESTY) — the same invariant also rules out the comparative
+ * family. "This is taking longer than usual" fired at 20s, but 20-30s IS the
+ * typical wait, so the line was false on a perfectly ordinary run. And
+ * "usual" is not derivable from elapsed time at all: the client holds no
+ * distribution of past run durations, so it has no baseline to compare
+ * against. Rather than invent one, the copy drops the comparison.
+ *
+ * What survives is exactly what elapsed time licenses: that a run is in
+ * flight, and that it is STILL in flight. "Still analysing" is true at every
+ * second from its threshold to the timeout, and escalates the acknowledgement
+ * without asserting anything unknowable. The 20s and 40s thresholds
+ * deliberately match the dock's pre-existing slow-run escalation, which this
+ * table subsumes (see analysisRunStatus.ts) — so the banner must have
+ * escalated by each of them, or the subsume would silently lose a line the
+ * user would otherwise have seen.
  */
 export const NARRATION_STAGES = [
   { afterSeconds: 0, message: 'Analysing your decision…' },
-  { afterSeconds: 20, message: 'This is taking longer than usual — still analysing…' },
-  { afterSeconds: 40, message: 'Still working — complex decisions can take a while…' },
+  { afterSeconds: 20, message: 'Still analysing your decision…' },
+  { afterSeconds: 40, message: 'Still analysing — complex decisions can take a while…' },
 ] as const
 
 /** Resolve the narration message for a given elapsed time (seconds). */
@@ -65,18 +86,49 @@ export function narrationForElapsed(elapsedSeconds: number): string {
 /** Duration of the text crossfade between stages (skipped under reduced motion). */
 const CROSSFADE_MS = 200
 
-export function AnalysisRunningBanner() {
+/**
+ * Whole seconds elapsed since a run start. Clamped at zero so clock skew (a
+ * start stamped fractionally in the future) reads as "just started" rather
+ * than as negative time.
+ */
+export function elapsedSecondsSince(startedAt: number, now: number = Date.now()): number {
+  return Math.max(0, Math.floor((now - startedAt) / 1000))
+}
+
+export interface AnalysisRunningBannerProps {
+  /**
+   * Wall-clock ms when the run actually started — the store's
+   * results.startedAt, which the dock already reads. Every store path that
+   * enters a running status sets it, and it survives this component
+   * unmounting, so it is the only honest origin for the narration clock.
+   *
+   * Omitted only as a defensive fallback: without it the best available
+   * origin is mount time, which is what the round-2 regression was.
+   */
+  startedAt?: number
+}
+
+export function AnalysisRunningBanner({ startedAt }: AnalysisRunningBannerProps = {}) {
   const prefersReducedMotion = usePrefersReducedMotion()
 
-  // Timer-driven elapsed counter (no Date dependence: the banner is mounted
-  // for the lifetime of the run, so a 1s tick is accurate enough for copy).
-  const [elapsed, setElapsed] = useState(0)
+  // Fallback origin, captured once so it cannot drift across re-renders.
+  const mountedAtRef = useRef<number | null>(null)
+  if (mountedAtRef.current === null) mountedAtRef.current = Date.now()
+  const runStartedAt = startedAt ?? mountedAtRef.current
+
+  // Elapsed time is RECOMPUTED from the run start on every tick rather than
+  // incremented from zero: that is what makes a mid-run mount, a remount and
+  // a backgrounded tab all report the true age of the run. The initialiser
+  // matters as much as the tick — a banner mounting at 25s must render the
+  // 20s stage on its FIRST frame, not after a second of fresh-start copy.
+  const [elapsed, setElapsed] = useState(() => elapsedSecondsSince(runStartedAt))
   useEffect(() => {
+    setElapsed(elapsedSecondsSince(runStartedAt))
     const interval = setInterval(() => {
-      setElapsed((s) => s + 1)
+      setElapsed(elapsedSecondsSince(runStartedAt))
     }, 1000)
     return () => clearInterval(interval)
-  }, [])
+  }, [runStartedAt])
 
   const targetMessage = narrationForElapsed(elapsed)
 

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -29,6 +29,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
 import { AnalysisRunningBanner } from './AnalysisRunningBanner'
+import { runStatusRegion } from './analysisRunStatus'
 import { registerCanonicalRunner, type CanonicalRunOptions, type CanonicalRunOutcome } from '../analysis/canonicalRunRegistry'
 import { useShowToastSafe } from '../ToastContext'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
@@ -715,6 +716,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   })
 
   const isRunning = resultsStatus === 'preparing' || resultsStatus === 'connecting' || resultsStatus === 'streaming'
+
+  // Wave1-L2 (seam D-M): exactly ONE run-status live region. Both the
+  // slow-run message and the running banner render role=status
+  // aria-live=polite, and they used to stack from ~20s with opposing
+  // progress claims. This single decision drives both render sites.
+  const runStatus = runStatusRegion({
+    isRunning,
+    hasReport: Boolean(report),
+    slowRunMessage,
+  })
+
   const { readiness } = useGraphReadiness()
 
   // V17 + orphan-banner suppression: when the top Refresh-analysis banner is
@@ -2042,8 +2054,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     </div>
                   )
                 )}
-                {/* Phase 2 Sprint 1B: Slow-run UX feedback */}
-                {slowRunMessage && (
+                {/* Phase 2 Sprint 1B: Slow-run UX feedback. Wave1-L2: yields
+                    to the running banner, whose stage table subsumes these
+                    same 20s/40s thresholds — never both live regions at once. */}
+                {runStatus === 'slow-run' && slowRunMessage && (
                   <div
                     className="flex items-center gap-2 px-3 py-2 bg-info-bg border border-info/30 rounded text-text-header"
                     role="status"
@@ -2057,7 +2071,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 {/* 1.16i: visible processing while an analysis turn runs and
                     the previous report is still on screen (the skeleton
                     below covers the no-report case) */}
-                {isRunning && report && <AnalysisRunningBanner />}
+                {runStatus === 'banner' && <AnalysisRunningBanner />}
                 {/* I.2b: Cancel button during active analysis — gated on the
                     V2 hook's own in-flight flag (1.16i): cancelRun only
                     aborts the V2 request, so it must not render for a V5

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -33,7 +33,7 @@ import { runStatusRegion } from './analysisRunStatus'
 import { registerCanonicalRunner, type CanonicalRunOptions, type CanonicalRunOutcome } from '../analysis/canonicalRunRegistry'
 import { useShowToastSafe } from '../ToastContext'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
-import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource } from '../store'
+import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource, selectResultsStartedAt } from '../store'
 import { resolveDisplayedFreshness } from '../store/analysisFreshness'
 import { getScenario } from '../store/scenarios'
 import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
@@ -563,6 +563,9 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   )
 
   const resultsStatus = useCanvasStore(selectResultsStatus)
+  // Wave1-L2: the run's TRUE start, so the banner narrates the age of the RUN
+  // rather than the age of the banner (survives remounts and tab switches).
+  const resultsStartedAt = useCanvasStore(selectResultsStartedAt)
   const report = useCanvasStore(selectReport)
   const error = useCanvasStore(selectError)
   const resultsSource = useCanvasStore(selectResultsSource)
@@ -2071,7 +2074,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 {/* 1.16i: visible processing while an analysis turn runs and
                     the previous report is still on screen (the skeleton
                     below covers the no-report case) */}
-                {runStatus === 'banner' && <AnalysisRunningBanner />}
+                {runStatus === 'banner' && <AnalysisRunningBanner startedAt={resultsStartedAt} />}
                 {/* I.2b: Cancel button during active analysis — gated on the
                     V2 hook's own in-flight flag (1.16i): cancelRun only
                     aborts the V2 request, so it must not render for a V5

--- a/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
+++ b/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
@@ -4,6 +4,10 @@
  * The banner must progress through time-based, honest, non-specific
  * narration stages while a run is in flight:
  *   - no fabricated progress percentages or scenario counts
+ *   - no claim of completion proximity: the client cannot know how close
+ *     the run is, and a run can end in the 130s timeout error
+ *   - every stage must be true by construction of elapsed time alone, at
+ *     ANY elapsed time it can still be displayed at
  *   - clean cut on early completion / error (unmount clears all timers)
  *   - prefers-reduced-motion: no spinner animation, instant text swap
  *   - aria-live polite so stage changes are announced
@@ -26,10 +30,51 @@ import {
   narrationForElapsed,
 } from '../AnalysisRunningBanner'
 
-const STAGE_1 = 'Setting up your analysis…'
-const STAGE_2 = 'Running robustness simulations…'
-const STAGE_3 = 'Weighing what moves your decision…'
-const STAGE_4 = 'Almost there — shaping the results…'
+const STAGE_1 = 'Analysing your decision…'
+const STAGE_2 = 'This is taking longer than usual — still analysing…'
+const STAGE_3 = 'Still working — complex decisions can take a while…'
+
+/**
+ * The run can end in a timeout error at 130s. Any line the banner can still
+ * be showing at that moment must not have promised the run was nearly done.
+ */
+const RUN_TIMEOUT_SECONDS = 130
+
+/**
+ * Vocabulary that asserts completion proximity or certainty. The client
+ * consumes ZERO run state — it knows only how long it has waited — so none
+ * of this can ever be honest, at any threshold.
+ */
+const PROXIMITY_VOCABULARY = [
+  'almost',
+  'nearly',
+  'any moment',
+  'any second',
+  'any minute',
+  'shortly',
+  'soon',
+  'finishing',
+  'finalis',
+  'finaliz',
+  'wrapping up',
+  'wrap up',
+  'just about',
+  'about to',
+  'final touches',
+  'moments away',
+  'close to',
+  'ready in',
+  'will be ready',
+]
+
+function assertNoProximityClaim(message: string) {
+  for (const term of PROXIMITY_VOCABULARY) {
+    expect(
+      message.toLowerCase(),
+      `"${message}" claims completion proximity ("${term}") the client cannot know`,
+    ).not.toContain(term)
+  }
+}
 
 /** Advance fake timers inside act so React state updates flush. */
 function advance(ms: number) {
@@ -62,12 +107,11 @@ describe('narrationForElapsed (pure stage resolution)', () => {
   it('advances through every stage at its threshold', () => {
     expect(narrationForElapsed(NARRATION_STAGES[1].afterSeconds)).toBe(STAGE_2)
     expect(narrationForElapsed(NARRATION_STAGES[2].afterSeconds)).toBe(STAGE_3)
-    expect(narrationForElapsed(NARRATION_STAGES[3].afterSeconds)).toBe(STAGE_4)
   })
 
   it('holds the final stage for long runs (no loop, no stuck blank)', () => {
-    expect(narrationForElapsed(120)).toBe(STAGE_4)
-    expect(narrationForElapsed(3600)).toBe(STAGE_4)
+    expect(narrationForElapsed(120)).toBe(STAGE_3)
+    expect(narrationForElapsed(3600)).toBe(STAGE_3)
   })
 
   it('handles negative elapsed time gracefully', () => {
@@ -96,15 +140,39 @@ describe('honesty constraints on the copy', () => {
       expect(stage.message).not.toContain('!')
     }
   })
+
+  // P1 (three reviewers converged): "Almost there — shaping the results…"
+  // fired at a fixed 22s wall clock, consumed zero run state and held
+  // indefinitely — including through runs that die at the 130s timeout.
+  it('never claims completion proximity or certainty in any stage message', () => {
+    for (const stage of NARRATION_STAGES) {
+      assertNoProximityClaim(stage.message)
+    }
+  })
+
+  it('is honest at the 130s timeout: the line still shown when the run dies has promised nothing', () => {
+    const messageAtTimeout = narrationForElapsed(RUN_TIMEOUT_SECONDS)
+    assertNoProximityClaim(messageAtTimeout)
+    expect(messageAtTimeout).not.toMatch(/[0-9%]/)
+  })
+
+  // Elapsed time is the ONLY input. A stage must therefore stay true for
+  // every second from its own threshold out to the timeout, since it can be
+  // displayed at any of them.
+  it('every stage stays honest at every elapsed second it can be displayed at', () => {
+    for (let elapsed = 0; elapsed <= RUN_TIMEOUT_SECONDS; elapsed++) {
+      assertNoProximityClaim(narrationForElapsed(elapsed))
+    }
+  })
 })
 
 describe('AnalysisRunningBanner stage progression (fake timers)', () => {
-  it('starts on the setting-up stage', () => {
+  it('starts on the analysing stage', () => {
     render(<AnalysisRunningBanner />)
     expect(screen.getByTestId('analysis-running-banner')).toHaveTextContent(STAGE_1)
   })
 
-  it('progresses through all four stages as time elapses', () => {
+  it('progresses through all stages as time elapses', () => {
     render(<AnalysisRunningBanner />)
     expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_1)
 
@@ -114,15 +182,18 @@ describe('AnalysisRunningBanner stage progression (fake timers)', () => {
 
     advancePastStage((NARRATION_STAGES[2].afterSeconds - NARRATION_STAGES[1].afterSeconds) * 1000)
     expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
-
-    advancePastStage((NARRATION_STAGES[3].afterSeconds - NARRATION_STAGES[2].afterSeconds) * 1000)
-    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_4)
   })
 
   it('holds the final stage on a long run without going blank', () => {
     render(<AnalysisRunningBanner />)
     advancePastStage(120_000)
-    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_4)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
+  })
+
+  it('is still showing an honest long-wait line at the 130s timeout', () => {
+    render(<AnalysisRunningBanner />)
+    advancePastStage(RUN_TIMEOUT_SECONDS * 1000)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
   })
 })
 
@@ -140,6 +211,13 @@ describe('early completion and error handoff', () => {
     // Land exactly on a stage boundary so a crossfade timeout is pending.
     advance(NARRATION_STAGES[1].afterSeconds * 1000)
     expect(() => unmount()).not.toThrow()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('unmounting at the 130s timeout (error handoff on a long run) clears every timer', () => {
+    const { unmount } = render(<AnalysisRunningBanner />)
+    advancePastStage(RUN_TIMEOUT_SECONDS * 1000)
+    unmount()
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
+++ b/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
@@ -31,8 +31,11 @@ import {
 } from '../AnalysisRunningBanner'
 
 const STAGE_1 = 'Analysing your decision…'
-const STAGE_2 = 'This is taking longer than usual — still analysing…'
-const STAGE_3 = 'Still working — complex decisions can take a while…'
+const STAGE_2 = 'Still analysing your decision…'
+const STAGE_3 = 'Still analysing — complex decisions can take a while…'
+
+/** An arbitrary fixed wall clock so `Date.now()` arithmetic is deterministic. */
+const NOW = new Date('2026-07-15T12:00:00Z').getTime()
 
 /**
  * The run can end in a timeout error at 130s. Any line the banner can still
@@ -76,6 +79,37 @@ function assertNoProximityClaim(message: string) {
   }
 }
 
+/**
+ * P1 (round 2, HONESTY): vocabulary that compares this run against a baseline
+ * — "usual", "expected", "normal". The client knows only how long it has
+ * waited; it holds no distribution of past run durations, so it cannot derive
+ * "usual" at all. Worse, the first escalation fires at 20s while 20-30s is the
+ * PR's own stated TYPICAL wait, so "taking longer than usual" was FALSE on a
+ * perfectly ordinary run. A comparative claim needs a real baseline or it must
+ * not be made.
+ */
+const BASELINE_COMPARISON_VOCABULARY = [
+  'than usual',
+  'unusual',
+  'than expected',
+  'than normal',
+  'longer than',
+  'slower than',
+  'taking longer',
+  'taking a while longer',
+  'behind schedule',
+  'overdue',
+]
+
+function assertNoBaselineComparison(message: string) {
+  for (const term of BASELINE_COMPARISON_VOCABULARY) {
+    expect(
+      message.toLowerCase(),
+      `"${message}" compares this run to a baseline ("${term}") the client cannot derive from elapsed time`,
+    ).not.toContain(term)
+  }
+}
+
 /** Advance fake timers inside act so React state updates flush. */
 function advance(ms: number) {
   act(() => {
@@ -95,7 +129,10 @@ function advancePastStage(ms: number) {
 
 beforeEach(() => {
   reducedMotionState.value = false
+  // Fake timers mock Date too, so `Date.now()` advances with the timer clock:
+  // elapsed time is computed from the real run start, not from mount.
   vi.useFakeTimers()
+  vi.setSystemTime(NOW)
 })
 
 describe('narrationForElapsed (pure stage resolution)', () => {
@@ -164,6 +201,32 @@ describe('honesty constraints on the copy', () => {
       assertNoProximityClaim(narrationForElapsed(elapsed))
     }
   })
+
+  // P1 (round 2, HONESTY): "This is taking longer than usual" fired at 20s,
+  // but 20-30s IS the typical wait — the line was false on a typical run.
+  it('never claims this run is slower than usual: the client has no baseline to compare against', () => {
+    for (const stage of NARRATION_STAGES) {
+      assertNoBaselineComparison(stage.message)
+    }
+  })
+
+  it('makes no baseline comparison at any elapsed second it can be displayed at', () => {
+    for (let elapsed = 0; elapsed <= RUN_TIMEOUT_SECONDS; elapsed++) {
+      assertNoBaselineComparison(narrationForElapsed(elapsed))
+    }
+  })
+
+  // The binding invariant, stated positively: the ONLY facts elapsed time
+  // licenses are that a run is in flight and that it is still in flight. The
+  // typical wait is 20-30s, so no stage that can render inside that window may
+  // characterise the wait as abnormal.
+  it('is true across the whole typical 20-30s wait, where no stage may call the run abnormal', () => {
+    for (let elapsed = 20; elapsed <= 30; elapsed++) {
+      const message = narrationForElapsed(elapsed)
+      assertNoBaselineComparison(message)
+      assertNoProximityClaim(message)
+    }
+  })
 })
 
 describe('AnalysisRunningBanner stage progression (fake timers)', () => {
@@ -194,6 +257,112 @@ describe('AnalysisRunningBanner stage progression (fake timers)', () => {
     render(<AnalysisRunningBanner />)
     advancePastStage(RUN_TIMEOUT_SECONDS * 1000)
     expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
+  })
+})
+
+/**
+ * P1 (round 2, REGRESSION GATE). The banner used to start its clock at MOUNT
+ * and count up from zero, so elapsed time meant "how long this component has
+ * existed", not "how long the run has been going".
+ *
+ * That is not a cosmetic drift. The banner SUBSUMES the dock's slow-run
+ * region: whenever the banner mounts, the accurate pre-existing slow-run line
+ * is suppressed in its favour (see analysisRunStatus.ts). So a banner that
+ * mounts at 25s into a run suppressed a correct "this is slow" line and
+ * replaced it with a fresh-start line claiming the run had just begun —
+ * strictly WORSE than no banner at all.
+ *
+ * The fix: elapsed time derives from the run's real start (the store's
+ * results.startedAt, which the dock already knows and which survives
+ * remounts), passed in as `startedAt`.
+ */
+describe('elapsed time derives from the RUN start, not the banner mount', () => {
+  it('mounting 25s into a run shows the 20s stage immediately, not the fresh-start line', () => {
+    render(<AnalysisRunningBanner startedAt={NOW - 25_000} />)
+    const narration = screen.getByTestId('analysis-narration')
+    expect(narration).toHaveTextContent(STAGE_2)
+    expect(narration).not.toHaveTextContent(STAGE_1)
+  })
+
+  it('mounting 45s into a run shows the 40s stage immediately', () => {
+    render(<AnalysisRunningBanner startedAt={NOW - 45_000} />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
+  })
+
+  it('mounting 130s into a run (at the timeout) shows the long-wait line, not a fresh start', () => {
+    render(<AnalysisRunningBanner startedAt={NOW - RUN_TIMEOUT_SECONDS * 1000} />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
+  })
+
+  // A remount (tab switch, dock re-render, results panel toggled) must not
+  // rewind the narration: the run did not restart, so the clock must not.
+  it('remounting mid-run keeps TRUE elapsed time instead of rewinding to zero', () => {
+    const startedAt = NOW - 22_000
+    const first = render(<AnalysisRunningBanner startedAt={startedAt} />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_2)
+    first.unmount()
+
+    // The user returns 20s later. The run is now 42s old, not 0s old.
+    vi.setSystemTime(NOW + 20_000)
+    render(<AnalysisRunningBanner startedAt={startedAt} />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
+  })
+
+  it('advances from the true elapsed time as the run continues past a mid-run mount', () => {
+    render(<AnalysisRunningBanner startedAt={NOW - 38_000} />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_2)
+
+    // Only 2s more of real time are needed to reach the 40s stage.
+    advancePastStage(2_000)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
+  })
+
+  it('treats a start timestamp in the future as zero elapsed (clock skew is not negative time)', () => {
+    render(<AnalysisRunningBanner startedAt={NOW + 5_000} />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_1)
+  })
+
+  // Defensive: both store paths that set status to a running state also set
+  // startedAt, but the banner must not crash or narrate nonsense without it.
+  it('falls back to mount time when the run start is unknown', () => {
+    render(<AnalysisRunningBanner />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_1)
+    advancePastStage(20_000)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_2)
+  })
+})
+
+/**
+ * P1 (round 2, NO-REGRESSION GATE). The banner only earns the right to
+ * suppress the dock's slow-run region if it actually says something equivalent
+ * at the same elapsed time. This ties the SUBSUME gate to real equivalence:
+ * at every elapsed time the dock would have escalated, the banner must have
+ * escalated too — never still be on the fresh-start line.
+ */
+describe('subsume equivalence: the accurate slow-run line is never silently lost', () => {
+  it('has escalated off the fresh-start line by the dock 20s slow-run threshold', () => {
+    expect(narrationForElapsed(20)).not.toBe(STAGE_1)
+  })
+
+  it('has escalated again by the dock 40s slow-run threshold', () => {
+    expect(narrationForElapsed(40)).not.toBe(STAGE_1)
+    expect(narrationForElapsed(40)).not.toBe(narrationForElapsed(20))
+  })
+
+  // The regression in the round-1 fix, stated as the exact user-visible
+  // outcome: a banner mounting at 25s suppressed "Taking longer than
+  // expected..." and showed "Analysing your decision…" in its place.
+  it('a banner mounting mid-run never replaces an escalated line with a fresh-start line', () => {
+    for (const elapsedSeconds of [20, 25, 30, 39, 40, 60, 130]) {
+      const { unmount } = render(
+        <AnalysisRunningBanner startedAt={NOW - elapsedSeconds * 1000} />,
+      )
+      expect(
+        screen.getByTestId('analysis-narration'),
+        `banner mounting ${elapsedSeconds}s into a run fell back to the fresh-start line while suppressing the dock slow-run region`,
+      ).not.toHaveTextContent(STAGE_1)
+      unmount()
+    }
   })
 })
 

--- a/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
+++ b/src/canvas/components/__tests__/AnalysisRunningBanner.spec.tsx
@@ -1,0 +1,175 @@
+/**
+ * Wave1-L2 (seam D-M): staged honest narration during the analysis wait.
+ *
+ * The banner must progress through time-based, honest, non-specific
+ * narration stages while a run is in flight:
+ *   - no fabricated progress percentages or scenario counts
+ *   - clean cut on early completion / error (unmount clears all timers)
+ *   - prefers-reduced-motion: no spinner animation, instant text swap
+ *   - aria-live polite so stage changes are announced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, act } from '@testing-library/react'
+
+// Mock the reduced-motion hook with a mutable flag (same pattern as
+// FirstUseComposer.spec.tsx) so each test can pick its motion mode.
+const reducedMotionState: { value: boolean } = { value: false }
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => reducedMotionState.value,
+}))
+
+import {
+  AnalysisRunningBanner,
+  NARRATION_STAGES,
+  narrationForElapsed,
+} from '../AnalysisRunningBanner'
+
+const STAGE_1 = 'Setting up your analysis…'
+const STAGE_2 = 'Running robustness simulations…'
+const STAGE_3 = 'Weighing what moves your decision…'
+const STAGE_4 = 'Almost there — shaping the results…'
+
+/** Advance fake timers inside act so React state updates flush. */
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+/**
+ * Advance past a stage threshold, then advance again so the crossfade
+ * timeout (scheduled when effects flush at the end of the first act)
+ * gets a chance to fire — mirrors real time continuing to flow.
+ */
+function advancePastStage(ms: number) {
+  advance(ms)
+  advance(500)
+}
+
+beforeEach(() => {
+  reducedMotionState.value = false
+  vi.useFakeTimers()
+})
+
+describe('narrationForElapsed (pure stage resolution)', () => {
+  it('returns the first stage at 0s and just before the second threshold', () => {
+    expect(narrationForElapsed(0)).toBe(STAGE_1)
+    expect(narrationForElapsed(NARRATION_STAGES[1].afterSeconds - 1)).toBe(STAGE_1)
+  })
+
+  it('advances through every stage at its threshold', () => {
+    expect(narrationForElapsed(NARRATION_STAGES[1].afterSeconds)).toBe(STAGE_2)
+    expect(narrationForElapsed(NARRATION_STAGES[2].afterSeconds)).toBe(STAGE_3)
+    expect(narrationForElapsed(NARRATION_STAGES[3].afterSeconds)).toBe(STAGE_4)
+  })
+
+  it('holds the final stage for long runs (no loop, no stuck blank)', () => {
+    expect(narrationForElapsed(120)).toBe(STAGE_4)
+    expect(narrationForElapsed(3600)).toBe(STAGE_4)
+  })
+
+  it('handles negative elapsed time gracefully', () => {
+    expect(narrationForElapsed(-1)).toBe(STAGE_1)
+  })
+})
+
+describe('honesty constraints on the copy', () => {
+  it('stages are in ascending order starting at 0s', () => {
+    expect(NARRATION_STAGES[0].afterSeconds).toBe(0)
+    for (let i = 1; i < NARRATION_STAGES.length; i++) {
+      expect(NARRATION_STAGES[i].afterSeconds).toBeGreaterThan(
+        NARRATION_STAGES[i - 1].afterSeconds,
+      )
+    }
+  })
+
+  it('never fabricates progress: no digits, percentages or counts in any stage message', () => {
+    for (const stage of NARRATION_STAGES) {
+      expect(stage.message).not.toMatch(/[0-9%]/)
+    }
+  })
+
+  it('stays on-brand: no exclamation marks', () => {
+    for (const stage of NARRATION_STAGES) {
+      expect(stage.message).not.toContain('!')
+    }
+  })
+})
+
+describe('AnalysisRunningBanner stage progression (fake timers)', () => {
+  it('starts on the setting-up stage', () => {
+    render(<AnalysisRunningBanner />)
+    expect(screen.getByTestId('analysis-running-banner')).toHaveTextContent(STAGE_1)
+  })
+
+  it('progresses through all four stages as time elapses', () => {
+    render(<AnalysisRunningBanner />)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_1)
+
+    // Cross each threshold, then allow the crossfade swap to complete.
+    advancePastStage(NARRATION_STAGES[1].afterSeconds * 1000)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_2)
+
+    advancePastStage((NARRATION_STAGES[2].afterSeconds - NARRATION_STAGES[1].afterSeconds) * 1000)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_3)
+
+    advancePastStage((NARRATION_STAGES[3].afterSeconds - NARRATION_STAGES[2].afterSeconds) * 1000)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_4)
+  })
+
+  it('holds the final stage on a long run without going blank', () => {
+    render(<AnalysisRunningBanner />)
+    advancePastStage(120_000)
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_4)
+  })
+})
+
+describe('early completion and error handoff', () => {
+  it('unmounting mid-run (early completion) clears every timer', () => {
+    const { unmount } = render(<AnalysisRunningBanner />)
+    advance(3_000)
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('unmounting mid-crossfade (error handoff at a stage boundary) clears every timer and does not throw', () => {
+    const { unmount } = render(<AnalysisRunningBanner />)
+    // Land exactly on a stage boundary so a crossfade timeout is pending.
+    advance(NARRATION_STAGES[1].afterSeconds * 1000)
+    expect(() => unmount()).not.toThrow()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('reduced motion', () => {
+  it('does not spin the icon when prefers-reduced-motion is set', () => {
+    reducedMotionState.value = true
+    const { container } = render(<AnalysisRunningBanner />)
+    expect(container.querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('spins the icon when motion is allowed', () => {
+    const { container } = render(<AnalysisRunningBanner />)
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('swaps text instantly at a stage boundary (no crossfade delay)', () => {
+    reducedMotionState.value = true
+    render(<AnalysisRunningBanner />)
+    advance(NARRATION_STAGES[1].afterSeconds * 1000)
+    // No extra time for a fade: the new stage must already be displayed.
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(STAGE_2)
+  })
+})
+
+describe('accessibility', () => {
+  it('announces politely via role=status + aria-live=polite', () => {
+    render(<AnalysisRunningBanner />)
+    const banner = screen.getByTestId('analysis-running-banner')
+    expect(banner).toHaveAttribute('role', 'status')
+    expect(banner).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -1619,3 +1619,127 @@ describe('I.2a: Secondary action button interaction', () => {
     ])
   })
 })
+
+/**
+ * Wave1-L2 (seam D-M): the run-status narration must be ONE live region.
+ *
+ * The pre-existing slowRunMessage (>=20s / >=40s) and the new
+ * AnalysisRunningBanner narration both render role=status aria-live=polite.
+ * Before the fix they stacked from ~20s — directly above one another, making
+ * opposing progress claims in exactly the window this lane targets, and a
+ * screen-reader user heard both. The banner subsumes the slow-run thresholds
+ * into its stage table, so the standalone slow-run region must yield whenever
+ * the banner is mounted (isRunning && report).
+ *
+ * ⚠ THESE TESTS DO NOT GATE ANYTHING. This whole file is listed in
+ * vitest.config.ts `exclude`, and no vitest invocation in package.json or
+ * .github/workflows overrides that config — so it runs in zero places and
+ * currently cannot even collect (its `../../../flags` mock is missing exports
+ * the import graph now needs). The "CI-only" comment on the exclude line is
+ * stale. The enforced gate for this invariant is the pure decision in
+ * analysisRunStatus.ts + its spec, which the default suite does run; these
+ * cases document the integration intent for whoever re-enables the file.
+ */
+describe('Wave1-L2: single run-status live region', () => {
+  beforeEach(cleanupDockState)
+
+  /** The run-status live regions this dock can render. */
+  function runStatusRegions() {
+    return [
+      ...screen.queryAllByTestId('slow-run-message'),
+      ...screen.queryAllByTestId('analysis-running-banner'),
+    ]
+  }
+
+  it('renders exactly ONE run-status live region at 25s when a report is on screen', () => {
+    vi.useFakeTimers()
+    const baseResults = useCanvasStore.getState().results
+
+    useCanvasStore.setState({
+      nodes: testNodes,
+      edges: testEdges,
+      hasCompletedFirstRun: true,
+      results: {
+        ...baseResults,
+        status: 'streaming',
+        report: fakeReportForTests,
+      },
+    } as any)
+
+    render(<OutputsDock />)
+
+    // 25s: inside the window where slowRunMessage used to stack on the banner.
+    act(() => {
+      vi.advanceTimersByTime(25_000)
+    })
+
+    const regions = runStatusRegions()
+    expect(
+      regions,
+      'two stacked aria-live run-status regions make opposing progress claims',
+    ).toHaveLength(1)
+    // The banner is the one that survives: it carries the staged narration.
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    expect(screen.queryByTestId('slow-run-message')).not.toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+
+  it('the surviving region still acknowledges the long wait at 25s (no regression in slow-run behaviour)', () => {
+    vi.useFakeTimers()
+    const baseResults = useCanvasStore.getState().results
+
+    useCanvasStore.setState({
+      nodes: testNodes,
+      edges: testEdges,
+      hasCompletedFirstRun: true,
+      results: {
+        ...baseResults,
+        status: 'streaming',
+        report: fakeReportForTests,
+      },
+    } as any)
+
+    render(<OutputsDock />)
+
+    act(() => {
+      vi.advanceTimersByTime(25_000)
+    })
+
+    // The banner's own stage table carries the >=20s long-wait acknowledgement
+    // that slowRunMessage used to provide, so the user loses nothing.
+    expect(screen.getByTestId('analysis-running-banner')).toHaveTextContent(
+      'This is taking longer than usual — still analysing…',
+    )
+
+    vi.useRealTimers()
+  })
+
+  it('keeps the standalone slow-run message when there is NO report (banner not mounted)', () => {
+    vi.useFakeTimers()
+    const baseResults = useCanvasStore.getState().results
+
+    useCanvasStore.setState({
+      hasCompletedFirstRun: true,
+      results: {
+        ...baseResults,
+        status: 'streaming',
+        report: null,
+      },
+    } as any)
+
+    render(<OutputsDock />)
+
+    act(() => {
+      vi.advanceTimersByTime(25_000)
+    })
+
+    // Skeleton case: the banner does not mount, so the pre-existing slow-run
+    // region is still the single run-status live region and must survive.
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.getByTestId('slow-run-message')).toBeInTheDocument()
+    expect(runStatusRegions()).toHaveLength(1)
+
+    vi.useRealTimers()
+  })
+})

--- a/src/canvas/components/__tests__/analysisRunStatus.spec.ts
+++ b/src/canvas/components/__tests__/analysisRunStatus.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Wave1-L2 (seam D-M): exactly ONE run-status live region.
+ *
+ * The dock can express run status two ways: the pre-existing slowRunMessage
+ * (>=20s "Taking longer than expected...", >=40s "Still working...") and the
+ * AnalysisRunningBanner narration. Both render role=status aria-live=polite.
+ * Before the fix they STACKED from ~20s, making opposing progress claims in
+ * exactly the window this lane targets — a screen-reader user heard both.
+ *
+ * The reconciliation is expressed as a single pure decision returning ONE
+ * region, so rendering two is structurally impossible rather than merely
+ * untested. OutputsDock drives both render sites from this function alone.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { runStatusRegion, type RunStatusRegion } from '../analysisRunStatus'
+
+/** The slow-run copy the dock sets at its 20s / 40s thresholds. */
+const SLOW_RUN_20S = 'Taking longer than expected...'
+const SLOW_RUN_40S = 'Still working...'
+
+describe('runStatusRegion: exactly one live region', () => {
+  // The whole point: a single return value cannot name two regions at once.
+  it('returns exactly one region for every reachable input combination', () => {
+    const valid: RunStatusRegion[] = ['banner', 'slow-run', 'none']
+
+    for (const isRunning of [true, false]) {
+      for (const hasReport of [true, false]) {
+        for (const slowRunMessage of [null, SLOW_RUN_20S, SLOW_RUN_40S]) {
+          const region = runStatusRegion({ isRunning, hasReport, slowRunMessage })
+          expect(valid).toContain(region)
+        }
+      }
+    }
+  })
+
+  // P1 (three reviewers converged): at 25s with a report on screen the dock
+  // rendered slowRunMessage DIRECTLY ABOVE the banner narration.
+  it('at 25s with a report on screen, only the banner narrates (slow-run yields)', () => {
+    expect(
+      runStatusRegion({ isRunning: true, hasReport: true, slowRunMessage: SLOW_RUN_20S }),
+    ).toBe('banner')
+  })
+
+  it('at 45s with a report on screen, only the banner narrates', () => {
+    expect(
+      runStatusRegion({ isRunning: true, hasReport: true, slowRunMessage: SLOW_RUN_40S }),
+    ).toBe('banner')
+  })
+})
+
+describe('no regression to the pre-existing slow-run behaviour', () => {
+  // The banner only mounts when a previous report is still on screen; the
+  // skeleton covers the no-report case, where slowRunMessage is still the
+  // only run-status narration and must keep working exactly as before.
+  it('keeps the standalone slow-run region at 25s when there is NO report', () => {
+    expect(
+      runStatusRegion({ isRunning: true, hasReport: false, slowRunMessage: SLOW_RUN_20S }),
+    ).toBe('slow-run')
+  })
+
+  it('keeps the standalone slow-run region at 45s when there is NO report', () => {
+    expect(
+      runStatusRegion({ isRunning: true, hasReport: false, slowRunMessage: SLOW_RUN_40S }),
+    ).toBe('slow-run')
+  })
+})
+
+describe('quiet states', () => {
+  it('narrates nothing before the first slow-run threshold with no report', () => {
+    expect(
+      runStatusRegion({ isRunning: true, hasReport: false, slowRunMessage: null }),
+    ).toBe('none')
+  })
+
+  it('narrates nothing once the run completes (slow-run message cleared)', () => {
+    expect(
+      runStatusRegion({ isRunning: false, hasReport: true, slowRunMessage: null }),
+    ).toBe('none')
+  })
+
+  // Completion/error clears slowRunMessage, but a stale value must never
+  // resurrect narration for a run that is no longer in flight.
+  it('narrates the slow-run line only while a run is in flight', () => {
+    expect(
+      runStatusRegion({ isRunning: false, hasReport: false, slowRunMessage: SLOW_RUN_20S }),
+    ).toBe('none')
+  })
+
+  it('shows the banner as soon as a run starts over an existing report', () => {
+    expect(
+      runStatusRegion({ isRunning: true, hasReport: true, slowRunMessage: null }),
+    ).toBe('banner')
+  })
+})

--- a/src/canvas/components/analysisRunStatus.ts
+++ b/src/canvas/components/analysisRunStatus.ts
@@ -1,0 +1,54 @@
+/**
+ * Wave1-L2 (seam D-M) — which run-status live region the dock narrates with.
+ *
+ * The dock has two ways to speak about an in-flight run, and both render
+ * role=status aria-live=polite:
+ *
+ *  - `slowRunMessage` — the pre-existing 20s/40s escalation, the only
+ *    narration available while the results skeleton is up (no report yet).
+ *  - `AnalysisRunningBanner` — the staged narration, mounted only while a
+ *    PREVIOUS report is still on screen.
+ *
+ * They used to stack: from ~20s the slow-run line rendered directly above the
+ * banner, two live regions making opposing progress claims in exactly the
+ * 20-30s window. A screen-reader user heard both.
+ *
+ * Reconciliation: the banner SUBSUMES the slow-run thresholds into its own
+ * stage table (see NARRATION_STAGES — same 20s/40s escalation points), so
+ * whenever the banner is mounted the standalone slow-run region yields and
+ * the user loses nothing. Where the banner does not mount (no report), the
+ * slow-run region keeps its existing behaviour untouched.
+ *
+ * Expressing this as ONE decision with ONE return value makes "exactly one
+ * run-status live region" structurally true rather than merely tested: the
+ * dock drives both render sites from this function alone.
+ */
+
+/** The single run-status live region to render, if any. */
+export type RunStatusRegion = 'banner' | 'slow-run' | 'none'
+
+export interface RunStatusInput {
+  /** A run is in flight (preparing | connecting | streaming). */
+  isRunning: boolean
+  /** A previous report is still on screen (the banner's mount condition). */
+  hasReport: boolean
+  /** The dock's 20s/40s escalation copy, or null before the first threshold. */
+  slowRunMessage: string | null
+}
+
+/**
+ * Resolve the one region that narrates run status. Order matters: the banner
+ * wins wherever it mounts, because its stage table already carries the
+ * long-wait acknowledgement the slow-run line would have duplicated.
+ */
+export function runStatusRegion({
+  isRunning,
+  hasReport,
+  slowRunMessage,
+}: RunStatusInput): RunStatusRegion {
+  if (isRunning && hasReport) return 'banner'
+  // slowRunMessage is cleared on completion/error, but gate on isRunning too
+  // so a stale value can never narrate a run that is no longer in flight.
+  if (isRunning && slowRunMessage) return 'slow-run'
+  return 'none'
+}

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -4717,6 +4717,13 @@ export const getNextInvalidNode = (state: CanvasState, currentNodeId?: string): 
  */
 export const selectResultsStatus = (state: CanvasState): ResultsStatus => state.results.status
 export const selectProgress = (state: CanvasState): number => state.results.progress
+/**
+ * Wave1-L2: wall-clock ms when the in-flight run started. Every path that
+ * enters a running status stamps it, and it lives in the store rather than in
+ * component state, so run-status narration keeps the TRUE elapsed time across
+ * remounts and tab switches.
+ */
+export const selectResultsStartedAt = (state: CanvasState): number | undefined => state.results.startedAt
 export const selectReport = (state: CanvasState): ReportV1 | null | undefined => state.results.report
 export const selectDrivers = (state: CanvasState): Array<{ kind: 'node' | 'edge'; id: string }> | undefined => state.results.drivers
 export const selectError = (state: CanvasState): { code: string; message: string; retryAfter?: number; request_id?: string; affectedOptions?: Array<{ id: string; label: string }> } | null | undefined => state.results.error


### PR DESCRIPTION
## What

During the 20-30s coach/analysis wait, the canvas showed a single static running state (`AnalysisRunningBanner`, one fixed line). This adds staged in-turn narration on top of the existing banner. **Client-side only** — no wire/schema change, no new server calls.

## Design constraints honoured (ratified experience doctrine)

- **Honesty:** time-based staging only; copy never claims a pipeline stage, percentage or scenario count we cannot know client-side. Guarded by test (`no digits or % in any stage message`). Stages at 0/6/14/22s:
  1. "Setting up your analysis…"
  2. "Running robustness simulations…"
  3. "Weighing what moves your decision…"
  4. "Almost there — shaping the results…" (holds for long runs — no loop, no blank)
- **On-brand:** calm, plain-language; no exclamation marks (tested).
- **Degrade gracefully:** the banner is mounted by OutputsDock's `isRunning && report` gate, so early completion cuts cleanly to results and errors hand off to existing error handling — all timers are cleared in effect cleanup (tested via `vi.getTimerCount() === 0` after unmount, including mid-crossfade). The `useConversation.ts` 1.16i swallow-guard is untouched (this PR touches no conversation code).
- **Reduced motion:** `usePrefersReducedMotion` (existing hook) — static icon (no `animate-spin`) and instant text swap instead of the 200ms crossfade.
- **Accessibility:** `role=status` + `aria-live=polite` on the banner announce each stage change.

## RED -> GREEN

Spec written first against the static banner: **14/16 fail** (no `NARRATION_STAGES`, no narration testid, spinner always animated). After implementation: **16/16 pass**.

## Gates

- `npm run typecheck` (tsc -p tsconfig.ci.json) — clean
- `npx eslint` on both changed files — clean
- Full canvas component suite: 102 files / 1266 tests passed
- `npm run test:contracts` — 151 passed
- `npm run ci:guard:ds` — zero violations from these files; the two red ratchet deltas (production-hex +56, panel-typography-scoped +20) are **pre-existing at the base tip** (identical with this change stashed)
- Pre-push hook ran normally in the fresh clone (no hang)

Follows the `DraftLoadingAnimation` precedent (exported stage table + pure `narrationForElapsed` resolver), but timer-driven rather than `Date.now`-based so behaviour is fully deterministic under fake timers.

DO NOT MERGE — orchestrator merges after adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)