### PR TITLE
fix(canvas): N3 edited-since-analysis dot — ratified accessible name (lane G2 residual)

### DIFF
--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -307,6 +307,8 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
       {isEditedSinceRun && (
         <span
           data-testid={`edited-since-run-${id}`}
+          role="img"
+          aria-label="Edited since the last analysis"
           title="Edited since the last analysis"
           className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-warning border border-canvas"
         />

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -1179,6 +1179,19 @@ describe('N1 — per-type selection ring', () => {
     expect(screen.getByTestId('edited-since-run-factor-1')).toBeInTheDocument()
   })
 
+  it('N3: the edited dot carries the ratified accessible name (screen readers, not just hover)', () => {
+    vi.mocked(useCanvasStore).mockImplementation((sel: any) =>
+      sel({ ...nodeState([]), editedSinceRunNodeIds: new Set(['factor-1']) }),
+    )
+    render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)
+    // A bare span with only `title` has no accessible name for most screen
+    // readers — the ratified N3 spec requires the dot itself to announce
+    // "Edited since the last analysis".
+    expect(screen.getByRole('img', { name: 'Edited since the last analysis' })).toBe(
+      screen.getByTestId('edited-since-run-factor-1'),
+    )
+  })
+
   it('N3: no edited dot when the node is not in the set (and no crash without the slice)', () => {
     applyState([])
     render(<ReactFlowProvider><FactorNode {...selProps} selected={false} data={{ label: 'Capacity' }} /></ReactFlowProvider>)


### PR DESCRIPTION
## Lane G2 re-verification finding (read first)

The brief's three ratified items were re-verified against origin/staging as instructed — **all three already landed there on 2026-07-12**, before this session:

- **N1 — per-type selection ring**: merged as #275. `BaseNode` now renders `nodeColors[type].selected` + `ring-offset-2`, gated on `!isHighlighted` so the AI highlight deterministically wins. The brief's ref (hardcoded `ring-2 ring-info` at BaseNode.tsx:268) describes the pre-#275 file.
- **N2 — real pulse for AI highlights**: merged as #278. Dedicated `ai-highlight-pulse` keyframe in index.css (expanding halo, 1.8s, info hue), explicitly NOT reusing `pulse-fade` (15+ skeleton consumers untouched); `prefers-reduced-motion: reduce` drops the animation and keeps the static ring.
- **N3 — edited-since-analysis marker**: merged as #286. Amber (`bg-warning` token) corner dot, driven by `editedSinceRunNodeIds` — a display-only id set fed by a pure snapshot diff of current nodes vs the latest run's graph (per Paul's 2026-07-12 ruling, the same honestly-labelled device-local mechanism as the What-changed chip). This supersedes the earlier chokepoint-provenance design in the lane brief. A fresh run self-clears (snapshot equals graph → empty diff → **zero dots**), so the freshness strip remains the single freshness owner; the dot adds WHERE, never a second verdict. Note one semantic difference from the older brief: an undo that byte-restores the pre-analysis state clears the dot under the diff mechanism (fingerprints match) rather than keeping it.

All lane pins were already green on staging: 118/118 across render-matrix, editedSinceRun, analysisFreshness, analysisFreshnessDirty and decisionContextClear.

## What this PR actually delivers

One residual ratified requirement was unmet: **the N3 dot must announce itself as "Edited since the last analysis"**. The merged dot is a bare `<span>` with only a `title` attribute — no role, no `aria-label` — which most screen readers ignore entirely, so the marker was sighted-only.

RED first: a `getByRole('img', { name: 'Edited since the last analysis' })` pin in render-matrix failed against staging. Fix: `role="img"` + `aria-label` on the dot; `title` kept for the pointer tooltip. 15 lines, two files.

## Sole-freshness-owner compliance

Untouched by this PR. The dot's mechanics (diff util → once-mounted hook → store set → BaseNode membership) derive nothing about freshness and render no verdict; this change only names the existing marker for assistive tech.

## Colour-collision check (Paul-flagged)

Deliberately checked: `--warning` (#FFA656) also serves negative-edge/fragility chrome. The dot reads as a *marker*, not edge chrome — a 10px filled circle floated off the card's top-right corner (`-top-1 -right-1`) with a canvas-coloured border ring separating it from the card, versus warning used as stroke/dash styling on edges. No shape/position overlap. N1 legibility note: the per-type rings use the DS-defined `/50` tokens; goal yellow (#F5C433) and factor stone (#B0A899) are the lowest-contrast on the light canvas but are the DS's own selected tokens (no colours invented), compensated by ring-4 width + ring-offset-2.

## Tests & gates

- New: `N3: the edited dot carries the ratified accessible name` (RED against staging, GREEN after fix).
- Targeted vitest: render-matrix 59/59 · editedSinceRun 6/6 · analysisFreshness 20/20 · analysisFreshnessDirty · decisionContextClear — **119/119**.
- `pnpm typecheck` (tsc -p tsconfig.ci.json) clean.
- Skipped locally per known machine hang risk: eslint and the full vitest suite — relying on CI for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)