### PR TITLE
feat(canvas): focus and camera coherence — reduced motion, multi-target fit, neighbourhood zoom, focus dimming

### DIFF
--- a/src/canvas/CanvasToolbar.tsx
+++ b/src/canvas/CanvasToolbar.tsx
@@ -19,6 +19,8 @@ import { useValidationFeedback } from './hooks/useValidationFeedback'
 import { useToast } from './ToastContext'
 import { checkLimits, formatLimitError } from './utils/limitGuard'
 import { computeFitPadding } from './utils/computeFitPadding'
+import { cameraDuration } from './utils/cameraMotion'
+import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
 import { useEngineLimits } from './hooks/useEngineLimits'
 import { Tooltip } from './components/Tooltip'
 import { useRunEligibilityCheck } from './hooks/useRunEligibilityCheck'
@@ -60,6 +62,9 @@ export function CanvasToolbar() {
   const openTemplatesPanel = useCanvasStore((s) => s.openTemplatesPanel)
   const setShowDraftChat = useCanvasStore((s) => s.setShowDraftChat)
   const { fitView, zoomIn, zoomOut } = useReactFlow()
+  // F1 (graph-visuals): the fit button is a camera move — honour
+  // prefers-reduced-motion via the shared cameraDuration guard.
+  const prefersReducedMotion = usePrefersReducedMotion()
   const { run } = useResultsRun()
   const { formatErrors, focusError } = useValidationFeedback()
   const { showToast } = useToast()
@@ -431,7 +436,7 @@ export function CanvasToolbar() {
               wired to the shared panel-aware padding anyway so a future remount reserves
               the OutputsDock/sidebar like the live fit sites. */}
           <button
-            onClick={() => fitView({ padding: computeFitPadding(), duration: 300 })}
+            onClick={() => fitView({ padding: computeFitPadding(), duration: cameraDuration(300, prefersReducedMotion) })}
             className="p-1.5 text-gray-900 bg-white border border-gray-300 rounded hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 shadow-sm"
             aria-label="Fit all nodes in view"
           >

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -13,9 +13,7 @@ import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
 import { useEditedSinceRun } from './hooks/useEditedSinceRun'
 import { LodSync } from './components/LodSync'
 import { cameraDuration } from './utils/cameraMotion'
-import { computeFocusPlan } from './utils/focusNeighbourhood'
-import { readFocusCamera, nodesComfortablyVisible } from './utils/cameraComfort'
-import { createFocusFitSuppressor } from './utils/focusLens'
+import { useFocusCamera } from './hooks/useFocusCamera'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
 import { useFitViewOnLayoutVersion } from './hooks/useFitViewOnLayoutVersion'
 import { nodeTypes } from './nodes/registry'
@@ -62,7 +60,6 @@ import { InfluenceExplainer, useInfluenceExplainer } from '../components/assista
 // floating-first host is mounted as a sibling when the flag is on.
 import { executeCanonicalRun } from './analysis/canonicalRunRegistry'
 import { HighlightLayer } from './highlight/HighlightLayer'
-import { registerFocusHelpers, registerFitNodes } from './utils/focusHelpers'
 import { computeFitPadding } from './utils/computeFitPadding'
 import { usePathHighlight } from './hooks/usePathHighlight'
 import { useLensFilter } from './hooks/useLensFilter'
@@ -354,17 +351,15 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
 
   // Week 3: AI Coaching moved to GuidancePanel in OutputsDock
 
-  const { getViewport, setCenter, fitView, zoomIn, zoomOut, zoomTo, screenToFlowPosition } = useReactFlow()
+  const { getViewport, fitView, zoomIn, zoomOut, zoomTo, screenToFlowPosition } = useReactFlow()
 
   // Brief 36 Fix: Stabilize ReactFlow function references via refs
   // These functions may have unstable references in some ReactFlow versions
   const getViewportRef = useRef(getViewport)
-  const setCenterRef = useRef(setCenter)
   const zoomInRef = useRef(zoomIn)
   const zoomOutRef = useRef(zoomOut)
   const zoomToRef = useRef(zoomTo)
   getViewportRef.current = getViewport
-  setCenterRef.current = setCenter
   zoomInRef.current = zoomIn
   zoomOutRef.current = zoomOut
   zoomToRef.current = zoomTo
@@ -375,10 +370,6 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   const reducedMotionRef = useRef(prefersReducedMotion)
   reducedMotionRef.current = prefersReducedMotion
 
-  // F3: lets handleMoveStart tell focus's OWN fit (keep the lens) apart from
-  // every other camera move, including the app's own zoom/fit buttons, which
-  // are user actions that reach ReactFlow programmatically (see focusLens).
-  const focusFitSuppressorRef = useRef(createFocusFitSuppressor())
 
   // Canvas control actions from store
   const undo = useCanvasStore(s => s.undo)
@@ -888,155 +879,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     setShowFullInspector(true)
   }, [])
 
-  // Focus node handler (for Alt+V validation cycling and Results panel drivers)
-  // Brief 36 Fix: Use refs instead of direct dependencies to prevent re-renders
-  const handleFocusNode = useCallback((nodeId: string) => {
-    const store = useCanvasStore.getState()
-
-    // F2 + F3 (graph-visuals): the whole focus decision is the pure
-    // computeFocusPlan (pinned in focusNeighbourhood.spec.ts); this handler
-    // only applies it — select → dim → conditionally fit.
-    // SAME-FRAME RULE (F2/F4): one camera measurement decides BOTH whether to
-    // move and, below, the frame to move into — a gate that measures against
-    // the panel-aware frame must not hand off to a fit that frames against the
-    // full pane, or an occluded target stays occluded after the camera moves.
-    const camera = readFocusCamera(getViewportRef.current)
-    const plan = computeFocusPlan(nodeId, store.nodes, store.edges, camera)
-    if (!plan) return // fail-closed: id not on the canvas
-
-    // Select node WITHOUT pushing to history (navigation-only, not structural change)
-    store.selectNodeWithoutHistory(nodeId)
-
-    // F3: transient focus dim — every node OUTSIDE the neighbourhood dims via
-    // the same store field BaseNode's dim classes already consume. Cleared by
-    // usePathHighlight on deselect/reselect, by the store boundary when the
-    // focused node is removed, and by handleMoveStart on a manual pan.
-    store.setFocusDim(nodeId, plan.dimNodeIds)
-
-    // F2: fit the node AND its direct neighbours to a readable zoom (capped
-    // so it never disorients), rather than centring at the current zoom —
-    // focusing from a zoomed-out view used to land on something you couldn't
-    // read. No-churn rule: when the whole neighbourhood is already
-    // comfortably visible the camera does NOT move (cameraComfort).
-    if (plan.moveCamera) {
-      const focusNodes = store.nodes.filter(n => plan.focusNodeIds.has(n.id))
-      // F3: this move is focus's own — it must not clear the dim it just set.
-      // Armed here rather than inferred from the move's event, so the app's
-      // own camera buttons (also programmatic) still end the lens.
-      focusFitSuppressorRef.current.begin()
-      fitViewRef.current({
-        nodes: focusNodes,
-        // Same panel-aware frame the no-churn gate just measured against.
-        // Falls back to the old bare-number padding only when the camera is
-        // unmeasurable — which is exactly when the gate fails open and fits.
-        padding: camera?.padding ?? 0.3,
-        maxZoom: 1.2,
-        duration: cameraDuration(400, reducedMotionRef.current),
-      })
-    }
-  }, [])
-
-  // Focus edge handler (for Results panel drivers)
-  // Brief 36 Fix: Use refs instead of direct dependencies to prevent re-renders
-  const handleFocusEdge = useCallback((edgeId: string) => {
-    const store = useCanvasStore.getState()
-    const targetEdge = store.edges.find(e => e.id === edgeId)
-
-    if (!targetEdge) return
-
-    // Find source and target nodes
-    const sourceNode = store.nodes.find(n => n.id === targetEdge.source)
-    const targetNode = store.nodes.find(n => n.id === targetEdge.target)
-
-    if (!sourceNode || !targetNode) return
-
-    // Calculate midpoint between source and target
-    const midX = (sourceNode.position.x + targetNode.position.x) / 2
-    const midY = (sourceNode.position.y + targetNode.position.y) / 2
-
-    // Select edge (not in history, just for visual feedback)
-    useCanvasStore.setState({
-      edges: store.edges.map(e => ({
-        ...e,
-        selected: e.id === edgeId
-      }))
-    })
-
-    // F3: focusing an EDGE ends any node focus lens. This pans the camera away
-    // from the focused node, and the dim must never survive the frame it was
-    // built for. Cleared explicitly rather than left to the setCenter's
-    // move-start below, because a setCenter that does not actually move the
-    // camera emits no move at all. No-op when no focus dim is active.
-    useCanvasStore.getState().clearFocusDim()
-
-    // Center viewport on edge midpoint with smooth animation
-    const viewport = getViewportRef.current()
-    setCenterRef.current(midX, midY, {
-      zoom: viewport.zoom,
-      duration: cameraDuration(300, reducedMotionRef.current),
-    })
-  }, [])
-
-  // Register focus helpers for external use (Results panel)
-  useEffect(() => {
-    return registerFocusHelpers(handleFocusNode, handleFocusEdge)
-  }, [handleFocusNode, handleFocusEdge])
-
-  // F4 (graph-visuals): registered multi-node fit — the applied-edit pulse
-  // choke point (appliedEditPulse.flush) routes every feeder here so pulse
-  // targets are in view before they flash. Fits every target (zoom capped)
-  // with the F1 reduced-motion guard, EXCEPT when all targets are already
-  // comfortably visible (cameraComfort's pinned no-churn rule) — an applied
-  // edit the user can already see must not yank the camera.
-  const handleFitNodes = useCallback((nodeIds: readonly string[]) => {
-    const store = useCanvasStore.getState()
-    const idSet = new Set(nodeIds)
-    const targets = store.nodes.filter(n => idSet.has(n.id))
-    if (targets.length === 0) return
-    const camera = readFocusCamera(getViewportRef.current)
-    if (
-      camera &&
-      nodesComfortablyVisible(
-        targets,
-        camera.viewport,
-        camera.paneWidth,
-        camera.paneHeight,
-        camera.insets,
-      )
-    ) {
-      return
-    }
-    fitViewRef.current({
-      nodes: targets,
-      // Same panel-aware frame the no-churn gate above measured against (see
-      // the SAME-FRAME RULE on FocusCamera.padding). A bare number here framed
-      // against the full pane, so a pulse target under an expanded dock got a
-      // camera move that left it under the dock. Bare-number fallback only
-      // when unmeasurable — the case where the gate already fails open.
-      padding: camera?.padding ?? 0.25,
-      maxZoom: 1.5,
-      duration: cameraDuration(400, reducedMotionRef.current),
-    })
-  }, [])
-  useEffect(() => {
-    return registerFitNodes(handleFitNodes)
-  }, [handleFitNodes])
-
-  // F3 (graph-visuals): ANY camera move ends the focus lens — the transient
-  // dim must never outlive the frame it was built for — EXCEPT the fit focus
-  // itself just ordered.
-  //
-  // This deliberately does NOT filter on the move's event. ReactFlow passes
-  // the gesture for a user drag/wheel and null for a programmatic move, but
-  // the app's own zoom/reset/fit buttons pan programmatically too: an
-  // `if (event)` test swallows them and strands a stale dim over a reframed
-  // camera. The suppressor (armed only around focus's own fit) is the correct
-  // discriminator. clearFocusDim is a no-op unless a focus dim is active, so
-  // ordinary panning stays free of store churn.
-  const handleMoveStart = useCallback(() => {
-    if (focusFitSuppressorRef.current.consume()) return
-    useCanvasStore.getState().clearFocusDim()
-  }, [])
+  // F2/F3/F4 (graph-visuals): the focus + pulse camera seam — focus node,
+  // focus edge, the registered multi-node pulse fit, and the rule that ends
+  // the focus lens on any reframe. Extracted to a hook so it can be exercised
+  // end-to-end (useFocusCamera.spec.tsx), the same reason the layout lifecycle
+  // hooks were extracted; it owns its own registrations.
+  const { onMoveStart: handleMoveStart, focusNode: handleFocusNode } = useFocusCamera()
 
   // Graph Interaction P1: Enable path highlighting based on node selection
   // Highlights causal paths from selected factor to goal, dims unrelated nodes

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -15,6 +15,7 @@ import { LodSync } from './components/LodSync'
 import { cameraDuration } from './utils/cameraMotion'
 import { computeFocusPlan } from './utils/focusNeighbourhood'
 import { readFocusCamera, nodesComfortablyVisible } from './utils/cameraComfort'
+import { createFocusFitSuppressor } from './utils/focusLens'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
 import { useFitViewOnLayoutVersion } from './hooks/useFitViewOnLayoutVersion'
 import { nodeTypes } from './nodes/registry'
@@ -373,6 +374,11 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   const prefersReducedMotion = usePrefersReducedMotion()
   const reducedMotionRef = useRef(prefersReducedMotion)
   reducedMotionRef.current = prefersReducedMotion
+
+  // F3: lets handleMoveStart tell focus's OWN fit (keep the lens) apart from
+  // every other camera move, including the app's own zoom/fit buttons, which
+  // are user actions that reach ReactFlow programmatically (see focusLens).
+  const focusFitSuppressorRef = useRef(createFocusFitSuppressor())
 
   // Canvas control actions from store
   const undo = useCanvasStore(s => s.undo)
@@ -890,12 +896,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     // F2 + F3 (graph-visuals): the whole focus decision is the pure
     // computeFocusPlan (pinned in focusNeighbourhood.spec.ts); this handler
     // only applies it — select → dim → conditionally fit.
-    const plan = computeFocusPlan(
-      nodeId,
-      store.nodes,
-      store.edges,
-      readFocusCamera(getViewportRef.current),
-    )
+    // SAME-FRAME RULE (F2/F4): one camera measurement decides BOTH whether to
+    // move and, below, the frame to move into — a gate that measures against
+    // the panel-aware frame must not hand off to a fit that frames against the
+    // full pane, or an occluded target stays occluded after the camera moves.
+    const camera = readFocusCamera(getViewportRef.current)
+    const plan = computeFocusPlan(nodeId, store.nodes, store.edges, camera)
     if (!plan) return // fail-closed: id not on the canvas
 
     // Select node WITHOUT pushing to history (navigation-only, not structural change)
@@ -914,9 +920,16 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     // comfortably visible the camera does NOT move (cameraComfort).
     if (plan.moveCamera) {
       const focusNodes = store.nodes.filter(n => plan.focusNodeIds.has(n.id))
+      // F3: this move is focus's own — it must not clear the dim it just set.
+      // Armed here rather than inferred from the move's event, so the app's
+      // own camera buttons (also programmatic) still end the lens.
+      focusFitSuppressorRef.current.begin()
       fitViewRef.current({
         nodes: focusNodes,
-        padding: 0.3,
+        // Same panel-aware frame the no-churn gate just measured against.
+        // Falls back to the old bare-number padding only when the camera is
+        // unmeasurable — which is exactly when the gate fails open and fits.
+        padding: camera?.padding ?? 0.3,
         maxZoom: 1.2,
         duration: cameraDuration(400, reducedMotionRef.current),
       })
@@ -948,6 +961,13 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
         selected: e.id === edgeId
       }))
     })
+
+    // F3: focusing an EDGE ends any node focus lens. This pans the camera away
+    // from the focused node, and the dim must never survive the frame it was
+    // built for. Cleared explicitly rather than left to the setCenter's
+    // move-start below, because a setCenter that does not actually move the
+    // camera emits no move at all. No-op when no focus dim is active.
+    useCanvasStore.getState().clearFocusDim()
 
     // Center viewport on edge midpoint with smooth animation
     const viewport = getViewportRef.current()
@@ -988,7 +1008,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     }
     fitViewRef.current({
       nodes: targets,
-      padding: 0.25,
+      // Same panel-aware frame the no-churn gate above measured against (see
+      // the SAME-FRAME RULE on FocusCamera.padding). A bare number here framed
+      // against the full pane, so a pulse target under an expanded dock got a
+      // camera move that left it under the dock. Bare-number fallback only
+      // when unmeasurable — the case where the gate already fails open.
+      padding: camera?.padding ?? 0.25,
       maxZoom: 1.5,
       duration: cameraDuration(400, reducedMotionRef.current),
     })
@@ -997,14 +1022,20 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     return registerFitNodes(handleFitNodes)
   }, [handleFitNodes])
 
-  // F3 (graph-visuals): a USER-initiated pan/zoom ends the focus lens — the
-  // transient focus dim must never outlive the user taking the camera back.
-  // ReactFlow passes the originating gesture event for user moves and null
-  // for programmatic ones (our own fitView/setCenter), so focus's own camera
-  // move never clears the dim it just set. clearFocusDim is a no-op unless a
-  // focus dim is active, so ordinary panning stays free of store churn.
-  const handleMoveStart = useCallback((event: unknown) => {
-    if (event) useCanvasStore.getState().clearFocusDim()
+  // F3 (graph-visuals): ANY camera move ends the focus lens — the transient
+  // dim must never outlive the frame it was built for — EXCEPT the fit focus
+  // itself just ordered.
+  //
+  // This deliberately does NOT filter on the move's event. ReactFlow passes
+  // the gesture for a user drag/wheel and null for a programmatic move, but
+  // the app's own zoom/reset/fit buttons pan programmatically too: an
+  // `if (event)` test swallows them and strands a stale dim over a reframed
+  // camera. The suppressor (armed only around focus's own fit) is the correct
+  // discriminator. clearFocusDim is a no-op unless a focus dim is active, so
+  // ordinary panning stays free of store churn.
+  const handleMoveStart = useCallback(() => {
+    if (focusFitSuppressorRef.current.consume()) return
+    useCanvasStore.getState().clearFocusDim()
   }, [])
 
   // Graph Interaction P1: Enable path highlighting based on node selection

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -13,7 +13,8 @@ import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
 import { useEditedSinceRun } from './hooks/useEditedSinceRun'
 import { LodSync } from './components/LodSync'
 import { cameraDuration } from './utils/cameraMotion'
-import { neighbourhoodNodeIds } from './utils/focusNeighbourhood'
+import { computeFocusPlan } from './utils/focusNeighbourhood'
+import { readFocusCamera, nodesComfortablyVisible } from './utils/cameraComfort'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
 import { useFitViewOnLayoutVersion } from './hooks/useFitViewOnLayoutVersion'
 import { nodeTypes } from './nodes/registry'
@@ -885,25 +886,41 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   // Brief 36 Fix: Use refs instead of direct dependencies to prevent re-renders
   const handleFocusNode = useCallback((nodeId: string) => {
     const store = useCanvasStore.getState()
-    const targetNode = store.nodes.find(n => n.id === nodeId)
 
-    if (!targetNode) return
+    // F2 + F3 (graph-visuals): the whole focus decision is the pure
+    // computeFocusPlan (pinned in focusNeighbourhood.spec.ts); this handler
+    // only applies it — select → dim → conditionally fit.
+    const plan = computeFocusPlan(
+      nodeId,
+      store.nodes,
+      store.edges,
+      readFocusCamera(getViewportRef.current),
+    )
+    if (!plan) return // fail-closed: id not on the canvas
 
     // Select node WITHOUT pushing to history (navigation-only, not structural change)
     store.selectNodeWithoutHistory(nodeId)
 
-    // F2 (graph-visuals): fit the node AND its direct neighbours to a readable
-    // zoom (capped so it never disorients), rather than centring at the current
-    // zoom — focusing from a zoomed-out view used to land on something you
-    // couldn't read. usePathHighlight dims the rest of the graph.
-    const focusIds = neighbourhoodNodeIds(nodeId, store.edges)
-    const focusNodes = store.nodes.filter(n => focusIds.has(n.id))
-    fitViewRef.current({
-      nodes: focusNodes,
-      padding: 0.3,
-      maxZoom: 1.2,
-      duration: cameraDuration(400, reducedMotionRef.current),
-    })
+    // F3: transient focus dim — every node OUTSIDE the neighbourhood dims via
+    // the same store field BaseNode's dim classes already consume. Cleared by
+    // usePathHighlight on deselect/reselect, by the store boundary when the
+    // focused node is removed, and by handleMoveStart on a manual pan.
+    store.setFocusDim(nodeId, plan.dimNodeIds)
+
+    // F2: fit the node AND its direct neighbours to a readable zoom (capped
+    // so it never disorients), rather than centring at the current zoom —
+    // focusing from a zoomed-out view used to land on something you couldn't
+    // read. No-churn rule: when the whole neighbourhood is already
+    // comfortably visible the camera does NOT move (cameraComfort).
+    if (plan.moveCamera) {
+      const focusNodes = store.nodes.filter(n => plan.focusNodeIds.has(n.id))
+      fitViewRef.current({
+        nodes: focusNodes,
+        padding: 0.3,
+        maxZoom: 1.2,
+        duration: cameraDuration(400, reducedMotionRef.current),
+      })
+    }
   }, [])
 
   // Focus edge handler (for Results panel drivers)
@@ -945,15 +962,30 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     return registerFocusHelpers(handleFocusNode, handleFocusEdge)
   }, [handleFocusNode, handleFocusEdge])
 
-  // F4 (graph-visuals): registered multi-node fit for USER-INITIATED
-  // surfaces (What-changed chip). Fits every target into view (zoom capped)
-  // with the F1 reduced-motion guard. The AI's autonomous pulse still never
-  // pans — this seam is only reachable from explicit user clicks.
+  // F4 (graph-visuals): registered multi-node fit — the applied-edit pulse
+  // choke point (appliedEditPulse.flush) routes every feeder here so pulse
+  // targets are in view before they flash. Fits every target (zoom capped)
+  // with the F1 reduced-motion guard, EXCEPT when all targets are already
+  // comfortably visible (cameraComfort's pinned no-churn rule) — an applied
+  // edit the user can already see must not yank the camera.
   const handleFitNodes = useCallback((nodeIds: readonly string[]) => {
     const store = useCanvasStore.getState()
     const idSet = new Set(nodeIds)
     const targets = store.nodes.filter(n => idSet.has(n.id))
     if (targets.length === 0) return
+    const camera = readFocusCamera(getViewportRef.current)
+    if (
+      camera &&
+      nodesComfortablyVisible(
+        targets,
+        camera.viewport,
+        camera.paneWidth,
+        camera.paneHeight,
+        camera.insets,
+      )
+    ) {
+      return
+    }
     fitViewRef.current({
       nodes: targets,
       padding: 0.25,
@@ -964,6 +996,16 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   useEffect(() => {
     return registerFitNodes(handleFitNodes)
   }, [handleFitNodes])
+
+  // F3 (graph-visuals): a USER-initiated pan/zoom ends the focus lens — the
+  // transient focus dim must never outlive the user taking the camera back.
+  // ReactFlow passes the originating gesture event for user moves and null
+  // for programmatic ones (our own fitView/setCenter), so focus's own camera
+  // move never clears the dim it just set. clearFocusDim is a no-op unless a
+  // focus dim is active, so ordinary panning stays free of store churn.
+  const handleMoveStart = useCallback((event: unknown) => {
+    if (event) useCanvasStore.getState().clearFocusDim()
+  }, [])
 
   // Graph Interaction P1: Enable path highlighting based on node selection
   // Highlights causal paths from selected factor to goal, dims unrelated nodes
@@ -2015,6 +2057,7 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
             onConnectEnd={onConnectEnd}
             isValidConnection={isValidConnection}
             onSelectionChange={handleSelectionChange}
+            onMoveStart={handleMoveStart}
             onNodeClick={handleNodeClick}
             onNodeDoubleClick={handleNodeDoubleClick}
             onEdgeClick={handleEdgeClick}

--- a/src/canvas/__tests__/cameraMotion.sourceScan.spec.ts
+++ b/src/canvas/__tests__/cameraMotion.sourceScan.spec.ts
@@ -1,17 +1,25 @@
 /**
  * F1 (graph-visuals) — "one guard, EVERY call site" enforced structurally.
  *
- * Every ANIMATED viewport move (`duration: <non-zero literal>` in an options
- * object) under src/canvas must route through cameraMotion.cameraDuration so
- * prefers-reduced-motion collapses it to an instant jump. A hardcoded
- * non-zero duration literal is exactly the class of regression that shipped
- * three unguarded sites past #274 (CanvasToolbar's fit button and both
- * useValidationFeedback setCenter calls) — this scan makes the next one fail
- * a test instead of a motion-sensitive user.
+ * THE RULE: every camera move under src/canvas (fitView / setCenter /
+ * setViewport / zoomIn / zoomOut / zoomTo) must express its `duration` as
+ * either `cameraDuration(...)` — the single reduced-motion guard — or the
+ * literal `0` (an instant jump is already reduced-motion-safe). Omitting
+ * `duration` is fine: xyflow defaults to an instant move.
  *
- * Scope: all non-test .ts/.tsx under src/canvas. `duration: 0` is exempt
- * (an instant jump is already reduced-motion-safe), as are comment lines and
- * non-literal durations (cameraDuration(...) calls, *_DURATION_MS constants).
+ * ANY OTHER duration expression is a violation, INCLUDING a named constant.
+ * The earlier version of this scan matched only `duration:\s*[1-9]` and its
+ * docstring waved through "non-literal durations (*_DURATION_MS constants)" —
+ * so `duration: FOCUS_MS` sailed past the very gate meant to stop it. A guard
+ * with a documented way around it is not a guard: the point is that a
+ * motion-sensitive user's animation cannot be reintroduced by ANY spelling.
+ * `cameraDuration(FOCUS_MS, reduced)` is how a named constant stays legal.
+ *
+ * Scope: all non-test .ts/.tsx under src/canvas, comments stripped. The scan
+ * is call-site-directed, not line-directed — it reads the arguments of camera
+ * moves only, so unrelated `duration:` fields (layout engine timings,
+ * telemetry elapsed ms, type declarations) are correctly ignored rather than
+ * suppressed by hand.
  */
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
@@ -21,6 +29,9 @@ import { fileURLToPath } from 'node:url'
 const CANVAS_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
 const EXCLUDED_DIR_NAMES = new Set(['__tests__', '__fixtures__', '__helpers__', '__mocks__'])
+
+/** Imperative viewport moves — the calls whose `duration` animates the camera. */
+const CAMERA_MOVES = ['fitView', 'setCenter', 'setViewport', 'zoomIn', 'zoomOut', 'zoomTo']
 
 function sourceFiles(dir: string): string[] {
   const out: string[] = []
@@ -38,22 +49,160 @@ function sourceFiles(dir: string): string[] {
   return out
 }
 
-const isCommentLine = (line: string): boolean => {
-  const trimmed = line.trim()
-  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')
+/**
+ * Blank out comments and string/template bodies, preserving offsets and
+ * newlines. Prose about camera moves (this file's own docstring, the contract
+ * note in useFitViewOnLayoutVersion) must not read as a call site.
+ */
+export function blankNonCode(src: string): string {
+  const out = src.split('')
+  let i = 0
+  const blankTo = (end: number) => {
+    for (let k = i; k < end && k < src.length; k++) if (out[k] !== '\n') out[k] = ' '
+  }
+  while (i < src.length) {
+    const two = src.slice(i, i + 2)
+    if (two === '//') {
+      let end = src.indexOf('\n', i)
+      if (end === -1) end = src.length
+      blankTo(end)
+      i = end
+    } else if (two === '/*') {
+      let end = src.indexOf('*/', i + 2)
+      end = end === -1 ? src.length : end + 2
+      blankTo(end)
+      i = end
+    } else if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
+      const quote = src[i]
+      let j = i + 1
+      while (j < src.length && src[j] !== quote) {
+        if (src[j] === '\\') j++
+        j++
+      }
+      i++ // keep the opening quote so the token still parses as a value
+      blankTo(j)
+      i = Math.min(j + 1, src.length)
+    } else {
+      i++
+    }
+  }
+  return out.join('')
 }
 
-describe('F1 — no hardcoded animated camera durations in src/canvas', () => {
-  it('every non-zero `duration:` literal routes through cameraDuration (violations must be [])', () => {
+/** Extract the balanced `(...)` argument text starting at `openIdx`. */
+function argsAt(src: string, openIdx: number): string {
+  let depth = 0
+  for (let i = openIdx; i < src.length; i++) {
+    if (src[i] === '(') depth++
+    else if (src[i] === ')') {
+      depth--
+      if (depth === 0) return src.slice(openIdx + 1, i)
+    }
+  }
+  return src.slice(openIdx + 1)
+}
+
+/** The value expression of `duration:` at `from`, up to the depth-0 `,` or `}`. */
+function durationValueAt(args: string, from: number): string {
+  let depth = 0
+  for (let i = from; i < args.length; i++) {
+    const c = args[i]
+    if (c === '(' || c === '[' || c === '{') depth++
+    else if (c === ')' || c === ']' || c === '}') {
+      if (depth === 0) return args.slice(from, i).trim()
+      depth--
+    } else if (c === ',' && depth === 0) return args.slice(from, i).trim()
+  }
+  return args.slice(from).trim()
+}
+
+const isGuarded = (value: string): boolean =>
+  value === '0' || /^cameraDuration\s*\(/.test(value)
+
+/**
+ * Every camera-move `duration` in `src` that is neither `cameraDuration(...)`
+ * nor literal `0`. Exported shape: `<move>(... duration: <expr> ...)`.
+ */
+export function findUnguardedCameraDurations(src: string): string[] {
+  const code = blankNonCode(src)
+  const violations: string[] = []
+  for (const move of CAMERA_MOVES) {
+    // No trailing \b: the ReactFlowGraph sites are called through stabilised
+    // refs (`fitViewRef.current(...)`), and a trailing boundary would make the
+    // scan blind to exactly those.
+    const re = new RegExp(`\\b${move}`, 'g')
+    let m: RegExpExecArray | null
+    while ((m = re.exec(code)) !== null) {
+      // Walk to the call's `(`, allowing only a ref/optional-chain hop
+      // (`fitViewRef.current?.(`), so a mere mention is not a call site.
+      let j = m.index + move.length
+      while (j < code.length && /[\w.?\s]/.test(code[j]!)) j++
+      if (code[j] !== '(') continue
+      const args = argsAt(code, j)
+      const dre = /\bduration\s*:\s*/g
+      let d: RegExpExecArray | null
+      while ((d = dre.exec(args)) !== null) {
+        const value = durationValueAt(args, d.index + d[0].length)
+        if (!isGuarded(value)) violations.push(`${move}(… duration: ${value} …)`)
+      }
+    }
+  }
+  return violations
+}
+
+describe('F1 — the scan itself bites (detector contract)', () => {
+  it('catches a NAMED CONSTANT duration — the bypass the old scan sanctioned', () => {
+    expect(findUnguardedCameraDurations('fitView({ duration: FOCUS_MS })')).toEqual([
+      'fitView(… duration: FOCUS_MS …)',
+    ])
+  })
+
+  it('catches a hardcoded numeric duration', () => {
+    expect(findUnguardedCameraDurations('setCenter(x, y, { duration: 300 })')).toEqual([
+      'setCenter(… duration: 300 …)',
+    ])
+  })
+
+  it('catches an unguarded duration in a multi-line options object', () => {
+    const src = ['fitViewRef.current({', '  padding: 0.3,', '  duration: ANIM_MS,', '})'].join('\n')
+    expect(findUnguardedCameraDurations(src)).toEqual(['fitView(… duration: ANIM_MS …)'])
+  })
+
+  it('catches an arithmetic/ternary duration expression', () => {
+    expect(findUnguardedCameraDurations('zoomTo(1, { duration: reduced ? 0 : 200 })')).toHaveLength(1)
+  })
+
+  it('allows cameraDuration(...) — including around a named constant', () => {
+    expect(
+      findUnguardedCameraDurations('fitView({ duration: cameraDuration(FOCUS_MS, reduced) })'),
+    ).toEqual([])
+  })
+
+  it('allows literal 0 and an omitted duration', () => {
+    expect(findUnguardedCameraDurations('setViewport(v, { duration: 0 })')).toEqual([])
+    expect(findUnguardedCameraDurations('fitView({ padding: 0.1 })')).toEqual([])
+  })
+
+  it('ignores non-camera `duration:` fields (layout timings, telemetry)', () => {
+    expect(findUnguardedCameraDurations('return { positions, duration: performance.now() - start }')).toEqual([])
+    expect(findUnguardedCameraDurations('track("run", { duration: elapsedMs })')).toEqual([])
+    expect(findUnguardedCameraDurations('interface R { duration: number }')).toEqual([])
+  })
+
+  it('ignores camera moves written in comments and strings', () => {
+    expect(findUnguardedCameraDurations('// contract: fitView({ duration: 400 })')).toEqual([])
+    expect(findUnguardedCameraDurations('/* fitView({ duration: 400 }) */')).toEqual([])
+    expect(findUnguardedCameraDurations('const doc = "fitView({ duration: 400 })"')).toEqual([])
+  })
+})
+
+describe('F1 — no unguarded camera durations in src/canvas', () => {
+  it('every camera-move duration routes through cameraDuration (violations must be [])', () => {
     const violations: string[] = []
     for (const file of sourceFiles(CANVAS_ROOT)) {
-      const lines = readFileSync(file, 'utf8').split('\n')
-      lines.forEach((line, i) => {
-        if (isCommentLine(line)) return
-        if (/duration:\s*[1-9]/.test(line)) {
-          violations.push(`${relative(CANVAS_ROOT, file)}:${i + 1} → ${line.trim()}`)
-        }
-      })
+      for (const v of findUnguardedCameraDurations(readFileSync(file, 'utf8'))) {
+        violations.push(`${relative(CANVAS_ROOT, file)} → ${v}`)
+      }
     }
     expect(violations).toEqual([])
   })

--- a/src/canvas/__tests__/cameraMotion.sourceScan.spec.ts
+++ b/src/canvas/__tests__/cameraMotion.sourceScan.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * F1 (graph-visuals) — "one guard, EVERY call site" enforced structurally.
+ *
+ * Every ANIMATED viewport move (`duration: <non-zero literal>` in an options
+ * object) under src/canvas must route through cameraMotion.cameraDuration so
+ * prefers-reduced-motion collapses it to an instant jump. A hardcoded
+ * non-zero duration literal is exactly the class of regression that shipped
+ * three unguarded sites past #274 (CanvasToolbar's fit button and both
+ * useValidationFeedback setCenter calls) — this scan makes the next one fail
+ * a test instead of a motion-sensitive user.
+ *
+ * Scope: all non-test .ts/.tsx under src/canvas. `duration: 0` is exempt
+ * (an instant jump is already reduced-motion-safe), as are comment lines and
+ * non-literal durations (cameraDuration(...) calls, *_DURATION_MS constants).
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CANVAS_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const EXCLUDED_DIR_NAMES = new Set(['__tests__', '__fixtures__', '__helpers__', '__mocks__'])
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stats = statSync(full)
+    if (stats.isDirectory()) {
+      if (!EXCLUDED_DIR_NAMES.has(entry)) out.push(...sourceFiles(full))
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue
+    if (/\.(spec|test)\.(ts|tsx)$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+const isCommentLine = (line: string): boolean => {
+  const trimmed = line.trim()
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')
+}
+
+describe('F1 — no hardcoded animated camera durations in src/canvas', () => {
+  it('every non-zero `duration:` literal routes through cameraDuration (violations must be [])', () => {
+    const violations: string[] = []
+    for (const file of sourceFiles(CANVAS_ROOT)) {
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (isCommentLine(line)) return
+        if (/duration:\s*[1-9]/.test(line)) {
+          violations.push(`${relative(CANVAS_ROOT, file)}:${i + 1} → ${line.trim()}`)
+        }
+      })
+    }
+    expect(violations).toEqual([])
+  })
+})

--- a/src/canvas/__tests__/store.focusDim.spec.ts
+++ b/src/canvas/__tests__/store.focusDim.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * F3 (graph-visuals, Paul-ratified) — the transient focus-dim store seam.
+ *
+ * When the user focuses a node (driver row, chat pill, Alt+V cycling), every
+ * node OUTSIDE the focus neighbourhood dims via the SAME store field the
+ * node dim classes already consume (dimmedNodeIds → BaseNode opacity-60 —
+ * no BaseNode edits). The dim is TRANSIENT and must never survive after
+ * focus ends:
+ * - setFocusDim(sourceId, ids) marks the dim as focus-owned and writes it
+ * - clearFocusDim() empties the dim — but ONLY when focus-owned, so it can
+ *   never clobber the selection path-dim (usePathHighlight's write)
+ * - removing the focused node by ANY path (delete action, AI patch replacing
+ *   nodes wholesale) clears the dim — a dim without its focus source is a
+ *   stuck lens
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../store'
+
+const node = (id: string) =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id } }) as any
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    nodes: [node('a'), node('b'), node('c')],
+    edges: [],
+    dimmedNodeIds: new Set<string>(),
+    focusDimSourceId: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as any)
+})
+
+describe('store focus dim — F3 transient dim seam', () => {
+  it('setFocusDim writes the dim set through dimmedNodeIds and records the focus source', () => {
+    useCanvasStore.getState().setFocusDim('a', ['b', 'c'])
+    const s = useCanvasStore.getState()
+    expect([...s.dimmedNodeIds].sort()).toEqual(['b', 'c'])
+    expect(s.focusDimSourceId).toBe('a')
+  })
+
+  it('clearFocusDim empties the dim and the source (blur/deselect/manual pan path)', () => {
+    useCanvasStore.getState().setFocusDim('a', ['b', 'c'])
+    useCanvasStore.getState().clearFocusDim()
+    const s = useCanvasStore.getState()
+    expect(s.dimmedNodeIds.size).toBe(0)
+    expect(s.focusDimSourceId).toBeNull()
+  })
+
+  it('clearFocusDim is a no-op when focus dim is not active — never clobbers the selection path-dim', () => {
+    useCanvasStore.getState().setDimmedNodes(['c']) // usePathHighlight's write
+    useCanvasStore.getState().clearFocusDim()
+    expect([...useCanvasStore.getState().dimmedNodeIds]).toEqual(['c'])
+  })
+
+  it('deleting the focused node clears the dim (deleteNodeById path)', () => {
+    useCanvasStore.getState().setFocusDim('a', ['b', 'c'])
+    useCanvasStore.getState().deleteNodeById('a')
+    const s = useCanvasStore.getState()
+    expect(s.focusDimSourceId).toBeNull()
+    expect(s.dimmedNodeIds.size).toBe(0)
+  })
+
+  it('a wholesale nodes replacement that drops the focused node clears the dim (AI patch path)', () => {
+    useCanvasStore.getState().setFocusDim('a', ['b', 'c'])
+    useCanvasStore.setState({ nodes: [node('b'), node('c')] })
+    const s = useCanvasStore.getState()
+    expect(s.focusDimSourceId).toBeNull()
+    expect(s.dimmedNodeIds.size).toBe(0)
+  })
+
+  it('a nodes change that KEEPS the focused node leaves the dim alone', () => {
+    useCanvasStore.getState().setFocusDim('a', ['b', 'c'])
+    useCanvasStore.setState({ nodes: [node('a'), node('b'), node('c'), node('d')] })
+    const s = useCanvasStore.getState()
+    expect(s.focusDimSourceId).toBe('a')
+    expect([...s.dimmedNodeIds].sort()).toEqual(['b', 'c'])
+  })
+})

--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -22,7 +22,6 @@ import { useMemo, useSyncExternalStore } from 'react'
 import { loadRuns } from '../store/runHistory'
 import * as runsBus from '../store/runsBus'
 import { pulseAppliedTargets } from '../utils/appliedEditPulse'
-import { fitNodesOnCanvas } from '../utils/focusHelpers'
 import type { Node, Edge } from '@xyflow/react'
 import { GitCompareArrows } from 'lucide-react'
 import { typography } from '../../styles/typography'
@@ -121,14 +120,12 @@ export function WhatChangedChip() {
   if (parts.length === 0) return null
 
   const handleClick = () => {
-    // F4 (graph-visuals): a chip click is USER-INITIATED, so panning is the
-    // user's intent — fit every surviving changed node into view before the
-    // pulse fires (previously targets often pulsed off-screen). The AI's
-    // autonomous applied-edit pulse still never pans (appliedEditPulse
-    // contract); this fit is reachable only from this click.
-    fitNodesOnCanvas([...diff.nodes.added, ...diff.nodes.modified])
-    // Removed elements are gone from the canvas — only surviving changes
-    // can be highlighted.
+    // F4 (graph-visuals): fit-before-pulse lives at the pulse choke point —
+    // appliedEditPulse's flush fits every surviving target into view before
+    // the ring fires, for EVERY feeder (applyPatch, applyV5State, this chip).
+    // A chip-local fit on top would double the camera move, so the chip
+    // delegates. Removed elements are gone from the canvas — only surviving
+    // changes can be highlighted (the flush filters fail-closed anyway).
     pulseAppliedTargets({
       nodeIds: [...diff.nodes.added, ...diff.nodes.modified],
       edgeIds: [...diff.edges.added, ...diff.edges.modified],

--- a/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
@@ -241,19 +241,21 @@ describe("Paul's ruling (2026-07-12): keep + improve — honest basis, clear ico
   })
 })
 
-describe('F4 — chip click fits changed nodes into view (user-initiated pan)', () => {
-  it('clicking the chip fits the surviving changed nodes, before the pulse fires', () => {
+describe('F4 — fit-before-pulse now lives at the pulse choke point, not in the chip', () => {
+  it('the chip does NOT fit directly — pulseAppliedTargets receives the full set and its flush fits pre-pulse', () => {
+    // The coalescing pulse util (appliedEditPulse.spec.ts, F4 block) fits every
+    // surviving target into view before the ring fires — for EVERY feeder
+    // (applyPatch, applyV5State, this chip). A second chip-local fit would
+    // double the camera move, so the chip must delegate.
     loadRunsMock.mockReturnValue([
       run({ nodes: [node('a', 'A2'), node('b', 'B'), node('c', 'C')], edges: [] }),
       run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }),
     ])
     render(<WhatChangedChip />)
     fireEvent.click(screen.getByTestId('what-changed-chip'))
-    // a = label-modified, c = added; both fit into view…
-    expect(fitMock).toHaveBeenCalledTimes(1)
-    expect([...fitMock.mock.calls[0][0]].sort()).toEqual(['a', 'c'])
-    // …and the fit happens BEFORE the pulse (targets on-screen when they flash).
-    expect(fitMock.mock.invocationCallOrder[0]).toBeLessThan(pulseMock.mock.invocationCallOrder[0])
+    expect(fitMock).not.toHaveBeenCalled()
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+    expect([...pulseMock.mock.calls[0][0].nodeIds].sort()).toEqual(['a', 'c'])
   })
 })
 

--- a/src/canvas/hooks/__tests__/useFocusCamera.spec.tsx
+++ b/src/canvas/hooks/__tests__/useFocusCamera.spec.tsx
@@ -1,0 +1,289 @@
+/**
+ * useFocusCamera — the focus/pulse camera seam, end to end.
+ *
+ * Covers the three adversarial-review findings that lived here unpinned:
+ *  - finding 1: the lens must end on ANY reframe except focus's own fit —
+ *    including the app's own camera buttons, which reach ReactFlow
+ *    PROGRAMMATICALLY (event === null). The old `if (event)` filter swallowed
+ *    exactly those.
+ *  - finding 3: focusing an EDGE pans away, so it must end the lens too.
+ *  - finding 4: the no-churn gate and the fit it gates must frame against the
+ *    SAME rect — a panel-aware gate handing off to a bare-number fit moves the
+ *    camera and leaves the target under the panel.
+ *  - finding 5: the pan→clear wiring and the programmatic-move exemption.
+ *
+ * `@xyflow/react` is mocked (its hooks need a Provider, and mounting one would
+ * load the whole canvas) — the layoutLifecycle.integration precedent. But
+ * readFocusCamera and computeFitPadding are the REAL ones (finding 7: every
+ * other fit-seam test spies over the bridge, so it never ran). Only the
+ * element rects are faked.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCanvasStore } from '../../store'
+import { useFocusCamera } from '../useFocusCamera'
+import { focusNodeById, focusEdgeById, fitNodesOnCanvas } from '../../utils/focusHelpers'
+
+const fitViewSpy = vi.fn()
+const setCenterSpy = vi.fn()
+let mockViewport = { x: 0, y: 0, zoom: 1 }
+
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({
+    getViewport: () => mockViewport,
+    setCenter: setCenterSpy,
+    fitView: fitViewSpy,
+  }),
+}))
+
+let mockReducedMotion = false
+vi.mock('../usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => mockReducedMotion,
+}))
+
+// ---- DOM rects the REAL computeFitPadding / readFocusCamera measure --------
+function fakeEl(rect: Partial<DOMRect>): HTMLElement {
+  const full = {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    toJSON: () => ({}),
+    ...rect,
+  } as DOMRect
+  return { getBoundingClientRect: () => full } as unknown as HTMLElement
+}
+
+const FLOW = '.react-flow'
+const DOCK = 'aside[aria-label="Outputs dock"]'
+const PANE = { width: 1440, height: 900, left: 0, right: 1440, top: 0, bottom: 900 }
+/** An EXPANDED dock: overlaps the pane's right 428px, so it occludes. */
+const EXPANDED_DOCK = { width: 416, height: 900, left: 1012, right: 1428 }
+/** Base margin with nothing occluding: floor((1440 - 1440/1.2) * 0.5) = 120. */
+const BASE_X = 120
+
+function stubCanvas(opts: { dock?: boolean; pane?: Partial<DOMRect> | null } = {}) {
+  const map: Record<string, HTMLElement | null> = {}
+  if (opts.pane !== null) map[FLOW] = fakeEl({ ...PANE, ...(opts.pane ?? {}) })
+  if (opts.dock) map[DOCK] = fakeEl(EXPANDED_DOCK)
+  vi.spyOn(document, 'querySelector').mockImplementation(
+    (sel: string) => (sel in map ? map[sel] : null) as Element | null,
+  )
+}
+
+const node = (id: string, x: number, y: number) =>
+  ({
+    id,
+    type: 'factor',
+    position: { x, y },
+    measured: { width: 200, height: 80 },
+    data: { label: id, kind: 'factor' },
+  }) as any
+
+// a—b adjacent and comfortably in the clear; 'far' is way off-screen.
+const NODES = [node('a', 300, 300), node('b', 600, 300), node('far', 9000, 9000)]
+const EDGES = [{ id: 'e1', source: 'a', target: 'b' }] as any
+
+function setGraph() {
+  useCanvasStore.setState({
+    nodes: NODES,
+    edges: EDGES,
+    dimmedNodeIds: new Set<string>(),
+    focusDimSourceId: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as any)
+}
+
+/**
+ * ReactFlow calls onMoveStart(event, viewport): the originating gesture for a
+ * user drag/wheel, and NULL for any programmatic move — which is how the app's
+ * own zoom/reset/fit buttons arrive.
+ */
+function emitMoveStart(onMoveStart: () => void, event: unknown = null) {
+  ;(onMoveStart as unknown as (e: unknown, v: unknown) => void)(event, mockViewport)
+}
+
+const focusDim = () => useCanvasStore.getState().focusDimSourceId
+const dimmed = () => [...useCanvasStore.getState().dimmedNodeIds].sort()
+
+beforeEach(() => {
+  fitViewSpy.mockClear()
+  setCenterSpy.mockClear()
+  mockViewport = { x: 0, y: 0, zoom: 1 }
+  mockReducedMotion = false
+  setGraph()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useFocusCamera — F3 lens ends on any reframe (finding 1 + 5)', () => {
+  it('focusing a node dims the non-neighbours and records the focus source', () => {
+    stubCanvas()
+    renderHook(() => useFocusCamera())
+    act(() => focusNodeById('a'))
+    expect(focusDim()).toBe('a')
+    // a's neighbourhood is {a, b}; only 'far' is outside it.
+    expect(dimmed()).toEqual(['far'])
+  })
+
+  it('focus’s OWN fit does not clear the dim it just set', () => {
+    // 'far' is off-screen, so the plan fits — and that fit emits a move-start.
+    stubCanvas()
+    const { result } = renderHook(() => useFocusCamera())
+    act(() => focusNodeById('far'))
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    act(() => emitMoveStart(result.current.onMoveStart))
+    expect(focusDim()).toBe('far')
+  })
+
+  it('an APP CAMERA BUTTON move clears the dim — a programmatic move is still a user action', () => {
+    // THE finding-1 regression: zoom in/out/reset/fit call ReactFlow directly,
+    // so onMoveStart arrives with a null event. Filtering on the event left a
+    // stale lens over a camera the user had just reframed.
+    stubCanvas()
+    const { result } = renderHook(() => useFocusCamera())
+    act(() => useCanvasStore.getState().setFocusDim('a', ['far']))
+    act(() => emitMoveStart(result.current.onMoveStart, null))
+    expect(focusDim()).toBeNull()
+  })
+
+  it('a user drag clears the dim', () => {
+    stubCanvas()
+    const { result } = renderHook(() => useFocusCamera())
+    act(() => useCanvasStore.getState().setFocusDim('a', ['far']))
+    act(() => emitMoveStart(result.current.onMoveStart, new MouseEvent('mousedown')))
+    expect(focusDim()).toBeNull()
+  })
+
+  it('the SECOND move after focus’s fit clears — the exemption covers one move only', () => {
+    stubCanvas()
+    const { result } = renderHook(() => useFocusCamera())
+    act(() => focusNodeById('far'))
+    act(() => emitMoveStart(result.current.onMoveStart)) // focus's own fit
+    expect(focusDim()).toBe('far')
+    act(() => emitMoveStart(result.current.onMoveStart)) // the user's next pan
+    expect(focusDim()).toBeNull()
+  })
+
+  it('a no-churn focus arms nothing, so the next move still clears', () => {
+    // {a,b} are already comfortably visible → no fit → no exemption to spend.
+    stubCanvas()
+    const { result } = renderHook(() => useFocusCamera())
+    act(() => focusNodeById('a'))
+    expect(fitViewSpy).not.toHaveBeenCalled()
+    act(() => emitMoveStart(result.current.onMoveStart))
+    expect(focusDim()).toBeNull()
+  })
+})
+
+describe('useFocusCamera — F3 an edge focus ends the lens (finding 3)', () => {
+  it('focusing an edge clears a live focus dim', () => {
+    stubCanvas()
+    renderHook(() => useFocusCamera())
+    act(() => focusNodeById('a'))
+    expect(focusDim()).toBe('a')
+    act(() => focusEdgeById('e1'))
+    expect(focusDim()).toBeNull()
+    expect(dimmed()).toEqual([])
+  })
+
+  it('still pans to the edge midpoint (the clear does not skip the move)', () => {
+    stubCanvas()
+    renderHook(() => useFocusCamera())
+    act(() => focusEdgeById('e1'))
+    expect(setCenterSpy).toHaveBeenCalledWith(450, 300, expect.objectContaining({ zoom: 1 }))
+  })
+})
+
+describe('useFocusCamera — F2/F4 the gate and the fit share one frame (finding 4)', () => {
+  it('the focus fit uses the PANEL-AWARE padding, not a bare number', () => {
+    // A bare number is a FRACTION of the full pane, so the fit would reframe
+    // the target straight back under the expanded dock the gate just measured.
+    stubCanvas({ dock: true })
+    renderHook(() => useFocusCamera())
+    act(() => focusNodeById('far'))
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    const { padding } = fitViewSpy.mock.calls[0]![0]
+    expect(padding).toEqual({
+      top: expect.stringMatching(/px$/),
+      right: '444px', // overlap 428 + 16px gap — clear of the dock
+      bottom: expect.stringMatching(/px$/),
+      left: `${BASE_X}px`,
+    })
+  })
+
+  it('the F4 pulse fit uses the same panel-aware padding', () => {
+    stubCanvas({ dock: true })
+    renderHook(() => useFocusCamera())
+    act(() => {
+      fitNodesOnCanvas(['far'])
+    })
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    expect(fitViewSpy.mock.calls[0]![0].padding).toMatchObject({ right: '444px' })
+  })
+
+  it('falls back to bare-number padding only when the camera is unmeasurable', () => {
+    // No .react-flow → readFocusCamera returns null → the gate fails open and
+    // fits, and there is no measured frame to fit into.
+    stubCanvas({ pane: null })
+    renderHook(() => useFocusCamera())
+    act(() => focusNodeById('a'))
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    expect(fitViewSpy.mock.calls[0]![0].padding).toBe(0.3)
+  })
+})
+
+describe('useFocusCamera — F4 no-churn through the real bridge (finding 7)', () => {
+  it('does NOT move the camera when the pulse target is already comfortable', () => {
+    stubCanvas()
+    renderHook(() => useFocusCamera())
+    act(() => {
+      fitNodesOnCanvas(['a'])
+    })
+    expect(fitViewSpy).not.toHaveBeenCalled()
+  })
+
+  it('DOES fit when the same target is occluded by an expanded dock', () => {
+    // Same node, same viewport — only the dock differs. This is the bridge
+    // doing real work: measurement → panel-aware gate → fit.
+    useCanvasStore.setState({ nodes: [node('under', 1100, 300)] } as any)
+    stubCanvas({ dock: true })
+    renderHook(() => useFocusCamera())
+    act(() => {
+      fitNodesOnCanvas(['under'])
+    })
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fit that same node when nothing occludes it', () => {
+    useCanvasStore.setState({ nodes: [node('under', 1100, 300)] } as any)
+    stubCanvas({ dock: false })
+    renderHook(() => useFocusCamera())
+    act(() => {
+      fitNodesOnCanvas(['under'])
+    })
+    expect(fitViewSpy).not.toHaveBeenCalled()
+  })
+
+  it('F1: reduced motion collapses the focus fit to an instant jump', () => {
+    mockReducedMotion = true
+    stubCanvas()
+    renderHook(() => useFocusCamera())
+    act(() => focusNodeById('far'))
+    expect(fitViewSpy.mock.calls[0]![0].duration).toBe(0)
+  })
+
+  it('F1: reduced motion collapses the edge pan too', () => {
+    mockReducedMotion = true
+    stubCanvas()
+    renderHook(() => useFocusCamera())
+    act(() => focusEdgeById('e1'))
+    expect(setCenterSpy.mock.calls[0]![2].duration).toBe(0)
+  })
+})

--- a/src/canvas/hooks/__tests__/usePathHighlight.spec.ts
+++ b/src/canvas/hooks/__tests__/usePathHighlight.spec.ts
@@ -540,6 +540,37 @@ describe('usePathHighlight × focus dim (F3)', () => {
     expect([...state.dimmedNodeIds].sort()).toEqual(['factor_a', 'iso'])
   })
 
+  it('ending the lens from OUTSIDE restores the selected node’s path dim (finding 2)', () => {
+    // The regression: clearFocusDim (a camera move, an edge focus, the focused
+    // node being removed) wipes dimmedNodeIds, but the selection has NOT
+    // changed — so nothing re-ran and the path dim was gone for good. The user
+    // pans once and loses path dimming until they reselect.
+    const { nodes, edges } = graph()
+    useCanvasStore.setState({
+      nodes,
+      edges,
+      selection: { nodeIds: new Set(['factor_a']), edgeIds: new Set(), anchorPosition: null },
+      ceeAnalysisReady: { goal_node_id: 'goal', options: [] } as any,
+      focusDimSourceId: 'factor_a',
+      dimmedNodeIds: new Set(['goal', 'iso']),
+    } as any)
+
+    renderHook(() => usePathHighlight())
+
+    // A camera move ends the lens — selection untouched.
+    act(() => {
+      useCanvasStore.getState().clearFocusDim()
+    })
+
+    const state = useCanvasStore.getState()
+    expect((state as any).focusDimSourceId).toBeNull()
+    // factor_a is still selected, so its path dim must be back: the path is
+    // factor_a → outcome → goal, leaving only iso dimmed.
+    expect([...state.dimmedNodeIds]).toEqual(['iso'])
+    expect(state.highlightedEdges.has('e1')).toBe(true)
+    expect(state.highlightedEdges.has('e2')).toBe(true)
+  })
+
   it('clears the focus dim on deselect — it never survives after focus ends', () => {
     const { nodes, edges } = graph()
     useCanvasStore.setState({

--- a/src/canvas/hooks/__tests__/usePathHighlight.spec.ts
+++ b/src/canvas/hooks/__tests__/usePathHighlight.spec.ts
@@ -436,3 +436,131 @@ describe('usePathHighlight', () => {
     })
   })
 })
+
+/**
+ * F3 (graph-visuals) — focus dim interplay.
+ *
+ * While a focus dim is active FOR THE SELECTED NODE, this hook must not
+ * overwrite dimmedNodeIds (the focus dim owns it; path edges still
+ * highlight). The moment selection moves away — reselect, deselect, blur —
+ * the hook clears the focus dim so it can NEVER survive after focus ends,
+ * then resumes normal path dimming.
+ */
+describe('usePathHighlight × focus dim (F3)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      nodes: [],
+      edges: [],
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+      highlightedEdges: new Set(),
+      dimmedNodeIds: new Set(),
+      focusDimSourceId: null,
+      ceeAnalysisReady: null,
+    } as any)
+  })
+
+  const graph = () => {
+    // factor_a → outcome → goal, with iso disconnected
+    const nodes = [
+      createNode('factor_a', 'factor'),
+      createNode('outcome', 'outcome'),
+      createNode('goal', 'goal'),
+      createNode('iso', 'factor'),
+    ]
+    const edges = [
+      createEdge('e1', 'factor_a', 'outcome'),
+      createEdge('e2', 'outcome', 'goal'),
+    ]
+    return { nodes, edges }
+  }
+
+  it('leaves an active focus dim for the selected node untouched (path dim must not clobber it)', () => {
+    const { nodes, edges } = graph()
+    useCanvasStore.setState({
+      nodes,
+      edges,
+      selection: { nodeIds: new Set(['factor_a']), edgeIds: new Set(), anchorPosition: null },
+      ceeAnalysisReady: { goal_node_id: 'goal', options: [] } as any,
+      // Focus dim from handleFocusNode: non-neighbours of factor_a = {goal, iso}
+      focusDimSourceId: 'factor_a',
+      dimmedNodeIds: new Set(['goal', 'iso']),
+    } as any)
+
+    renderHook(() => usePathHighlight())
+
+    const state = useCanvasStore.getState()
+    // Path dim would have been {iso} only — the focus dim must win while active
+    expect([...state.dimmedNodeIds].sort()).toEqual(['goal', 'iso'])
+    expect((state as any).focusDimSourceId).toBe('factor_a')
+    // The causal path still highlights (edges are not dim state)
+    expect(state.highlightedEdges.has('e1')).toBe(true)
+    expect(state.highlightedEdges.has('e2')).toBe(true)
+  })
+
+  it('preserves the focus dim in a goal-less graph (the early clear must not wipe it)', () => {
+    const { nodes, edges } = graph()
+    useCanvasStore.setState({
+      nodes: nodes.filter((n) => n.id !== 'goal'),
+      edges: edges.filter((e) => e.target !== 'goal'),
+      selection: { nodeIds: new Set(['factor_a']), edgeIds: new Set(), anchorPosition: null },
+      ceeAnalysisReady: null, // no goal anywhere → the hook's early-clear branch
+      focusDimSourceId: 'factor_a',
+      dimmedNodeIds: new Set(['iso']),
+    } as any)
+
+    renderHook(() => usePathHighlight())
+
+    const state = useCanvasStore.getState()
+    expect([...state.dimmedNodeIds]).toEqual(['iso'])
+    expect((state as any).focusDimSourceId).toBe('factor_a')
+  })
+
+  it('clears the focus dim when selection moves to another node, then applies normal path dim', () => {
+    const { nodes, edges } = graph()
+    useCanvasStore.setState({
+      nodes,
+      edges,
+      selection: { nodeIds: new Set(['factor_a']), edgeIds: new Set(), anchorPosition: null },
+      ceeAnalysisReady: { goal_node_id: 'goal', options: [] } as any,
+      focusDimSourceId: 'factor_a',
+      dimmedNodeIds: new Set(['goal', 'iso']),
+    } as any)
+
+    renderHook(() => usePathHighlight())
+
+    act(() => {
+      useCanvasStore.setState({
+        selection: { nodeIds: new Set(['outcome']), edgeIds: new Set(), anchorPosition: null },
+      })
+    })
+
+    const state = useCanvasStore.getState()
+    expect((state as any).focusDimSourceId).toBeNull()
+    // Normal path dim for outcome→goal: factor_a and iso are off the path
+    expect([...state.dimmedNodeIds].sort()).toEqual(['factor_a', 'iso'])
+  })
+
+  it('clears the focus dim on deselect — it never survives after focus ends', () => {
+    const { nodes, edges } = graph()
+    useCanvasStore.setState({
+      nodes,
+      edges,
+      selection: { nodeIds: new Set(['factor_a']), edgeIds: new Set(), anchorPosition: null },
+      ceeAnalysisReady: { goal_node_id: 'goal', options: [] } as any,
+      focusDimSourceId: 'factor_a',
+      dimmedNodeIds: new Set(['goal', 'iso']),
+    } as any)
+
+    renderHook(() => usePathHighlight())
+
+    act(() => {
+      useCanvasStore.setState({
+        selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+      })
+    })
+
+    const state = useCanvasStore.getState()
+    expect((state as any).focusDimSourceId).toBeNull()
+    expect(state.dimmedNodeIds.size).toBe(0)
+  })
+})

--- a/src/canvas/hooks/__tests__/useValidationFeedback.cameraMotion.spec.ts
+++ b/src/canvas/hooks/__tests__/useValidationFeedback.cameraMotion.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * F1 (graph-visuals) — useValidationFeedback's "Fix now" focus is a camera
+ * move and must honour prefers-reduced-motion like every other camera call
+ * site (cameraMotion.cameraDuration guard). #274 guarded the graph's own
+ * fit/zoom/focus sites but missed this hook's two setCenter calls.
+ *
+ * Pins:
+ * - default: setCenter animates with the site's base duration (400ms), zoom 1.5
+ * - reduced motion: duration 0 (instant jump), both the node and edge paths
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { setCenterMock, getNodeMock, getEdgeMock, prefersReducedMotionMock } = vi.hoisted(() => ({
+  setCenterMock: vi.fn(),
+  getNodeMock: vi.fn(),
+  getEdgeMock: vi.fn(),
+  prefersReducedMotionMock: vi.fn(() => false),
+}))
+
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({
+    setCenter: setCenterMock,
+    getNode: getNodeMock,
+    getEdge: getEdgeMock,
+  }),
+}))
+
+vi.mock('../usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: prefersReducedMotionMock,
+}))
+
+import { useValidationFeedback } from '../useValidationFeedback'
+
+const nodeError = { code: 'X', message: 'm', node_id: 'n1' } as any
+const edgeError = { code: 'X', message: 'm', edge_id: 'e1' } as any
+
+beforeEach(() => {
+  setCenterMock.mockReset()
+  getNodeMock.mockReset()
+  getEdgeMock.mockReset()
+  prefersReducedMotionMock.mockReset()
+  prefersReducedMotionMock.mockReturnValue(false)
+  getNodeMock.mockImplementation((id: string) =>
+    id === 'n1' || id === 'src' ? { id, position: { x: 10, y: 20 } } : undefined,
+  )
+  getEdgeMock.mockImplementation((id: string) =>
+    id === 'e1' ? { id, source: 'src', target: 'tgt' } : undefined,
+  )
+})
+
+describe('useValidationFeedback — F1 reduced-motion on focusError camera moves', () => {
+  it('default: node focus animates at the pinned 400ms', () => {
+    const { result } = renderHook(() => useValidationFeedback())
+    result.current.focusError(nodeError)
+    expect(setCenterMock).toHaveBeenCalledTimes(1)
+    expect(setCenterMock).toHaveBeenCalledWith(10, 20, { zoom: 1.5, duration: 400 })
+  })
+
+  it('reduced motion: node focus jumps instantly (duration 0)', () => {
+    prefersReducedMotionMock.mockReturnValue(true)
+    const { result } = renderHook(() => useValidationFeedback())
+    result.current.focusError(nodeError)
+    expect(setCenterMock).toHaveBeenCalledWith(10, 20, { zoom: 1.5, duration: 0 })
+  })
+
+  it('reduced motion: the edge (source-node proxy) path also jumps instantly', () => {
+    prefersReducedMotionMock.mockReturnValue(true)
+    const { result } = renderHook(() => useValidationFeedback())
+    result.current.focusError(edgeError)
+    expect(setCenterMock).toHaveBeenCalledTimes(1)
+    expect(setCenterMock.mock.calls[0][2]).toMatchObject({ duration: 0 })
+  })
+})

--- a/src/canvas/hooks/useFocusCamera.ts
+++ b/src/canvas/hooks/useFocusCamera.ts
@@ -1,0 +1,205 @@
+/**
+ * useFocusCamera — the focus/pulse camera seam (F2 fit, F3 lens, F4 pulse fit).
+ *
+ * Extracted from ReactFlowGraph for the same reason useMeasureThenLayout and
+ * useFitViewOnLayoutVersion were: inside a 2000-line component that needs a
+ * live ReactFlow provider, this logic could not be exercised end-to-end, and
+ * an adversarial review found three real bugs sitting in the untested seam.
+ * Behaviour is unchanged by the extraction itself; the handlers are the ones
+ * ReactFlowGraph registered before.
+ *
+ * The decisions stay pure and pinned elsewhere — computeFocusPlan
+ * (focusNeighbourhood), nodesComfortablyVisible + readFocusCamera
+ * (cameraComfort), cameraDuration (cameraMotion), the lens-end rule
+ * (focusLens). This hook only APPLIES them and owns the registrations.
+ */
+
+import { useCallback, useEffect, useRef } from 'react'
+import { useReactFlow } from '@xyflow/react'
+import { useCanvasStore } from '../store'
+import { cameraDuration } from '../utils/cameraMotion'
+import { computeFocusPlan } from '../utils/focusNeighbourhood'
+import { readFocusCamera, nodesComfortablyVisible } from '../utils/cameraComfort'
+import { createFocusFitSuppressor } from '../utils/focusLens'
+import { registerFocusHelpers, registerFitNodes } from '../utils/focusHelpers'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+
+export interface FocusCameraHandlers {
+  /** Wire to ReactFlow's `onMoveStart` — ends the focus lens on any reframe. */
+  onMoveStart: () => void
+  /**
+   * The same handler registered for the Results panel, returned for the
+   * in-component consumers (Alt+V keyboard cycling, the Provenance hub).
+   */
+  focusNode: (nodeId: string) => void
+}
+
+export function useFocusCamera(): FocusCameraHandlers {
+  const { getViewport, setCenter, fitView } = useReactFlow()
+
+  // Brief 36 Fix: stabilise ReactFlow function references via refs so the
+  // empty-deps callbacks below stay reference-stable.
+  const getViewportRef = useRef(getViewport)
+  const setCenterRef = useRef(setCenter)
+  const fitViewRef = useRef(fitView)
+  getViewportRef.current = getViewport
+  setCenterRef.current = setCenter
+  fitViewRef.current = fitView
+
+  // F1: reduced-motion guard for every imperative camera move below.
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const reducedMotionRef = useRef(prefersReducedMotion)
+  reducedMotionRef.current = prefersReducedMotion
+
+  // F3: lets onMoveStart tell focus's OWN fit (keep the lens) apart from every
+  // other camera move, including the app's own zoom/fit buttons, which are
+  // user actions that reach ReactFlow programmatically (see focusLens).
+  const focusFitSuppressorRef = useRef(createFocusFitSuppressor())
+
+  // Focus node handler (for Alt+V validation cycling and Results panel drivers)
+  const handleFocusNode = useCallback((nodeId: string) => {
+    const store = useCanvasStore.getState()
+
+    // F2 + F3 (graph-visuals): the whole focus decision is the pure
+    // computeFocusPlan (pinned in focusNeighbourhood.spec.ts); this handler
+    // only applies it — select → dim → conditionally fit.
+    // SAME-FRAME RULE (F2/F4): one camera measurement decides BOTH whether to
+    // move and, below, the frame to move into — a gate that measures against
+    // the panel-aware frame must not hand off to a fit that frames against the
+    // full pane, or an occluded target stays occluded after the camera moves.
+    const camera = readFocusCamera(getViewportRef.current)
+    const plan = computeFocusPlan(nodeId, store.nodes, store.edges, camera)
+    if (!plan) return // fail-closed: id not on the canvas
+
+    // Select node WITHOUT pushing to history (navigation-only, not structural change)
+    store.selectNodeWithoutHistory(nodeId)
+
+    // F3: transient focus dim — every node OUTSIDE the neighbourhood dims via
+    // the same store field BaseNode's dim classes already consume. Cleared by
+    // usePathHighlight on deselect/reselect, by the store boundary when the
+    // focused node is removed, by an edge focus, and by onMoveStart on any
+    // other camera move.
+    store.setFocusDim(nodeId, plan.dimNodeIds)
+
+    // F2: fit the node AND its direct neighbours to a readable zoom (capped
+    // so it never disorients), rather than centring at the current zoom —
+    // focusing from a zoomed-out view used to land on something you couldn't
+    // read. No-churn rule: when the whole neighbourhood is already
+    // comfortably visible the camera does NOT move (cameraComfort).
+    if (plan.moveCamera) {
+      const focusNodes = store.nodes.filter((n) => plan.focusNodeIds.has(n.id))
+      // F3: this move is focus's own — it must not clear the dim it just set.
+      // Armed here rather than inferred from the move's event, so the app's
+      // own camera buttons (also programmatic) still end the lens.
+      focusFitSuppressorRef.current.begin()
+      fitViewRef.current({
+        nodes: focusNodes,
+        // Same panel-aware frame the no-churn gate just measured against.
+        // Falls back to the old bare-number padding only when the camera is
+        // unmeasurable — which is exactly when the gate fails open and fits.
+        padding: camera?.padding ?? 0.3,
+        maxZoom: 1.2,
+        duration: cameraDuration(400, reducedMotionRef.current),
+      })
+    }
+  }, [])
+
+  // Focus edge handler (for Results panel drivers)
+  const handleFocusEdge = useCallback((edgeId: string) => {
+    const store = useCanvasStore.getState()
+    const targetEdge = store.edges.find((e) => e.id === edgeId)
+    if (!targetEdge) return
+
+    const sourceNode = store.nodes.find((n) => n.id === targetEdge.source)
+    const targetNode = store.nodes.find((n) => n.id === targetEdge.target)
+    if (!sourceNode || !targetNode) return
+
+    // Calculate midpoint between source and target
+    const midX = (sourceNode.position.x + targetNode.position.x) / 2
+    const midY = (sourceNode.position.y + targetNode.position.y) / 2
+
+    // Select edge (not in history, just for visual feedback)
+    useCanvasStore.setState({
+      edges: store.edges.map((e) => ({ ...e, selected: e.id === edgeId })),
+    })
+
+    // F3: focusing an EDGE ends any node focus lens. This pans the camera away
+    // from the focused node, and the dim must never survive the frame it was
+    // built for. Cleared explicitly rather than left to the setCenter's
+    // move-start below, because a setCenter that does not actually move the
+    // camera emits no move at all. No-op when no focus dim is active.
+    useCanvasStore.getState().clearFocusDim()
+
+    // Center viewport on edge midpoint with smooth animation
+    const viewport = getViewportRef.current()
+    setCenterRef.current(midX, midY, {
+      zoom: viewport.zoom,
+      duration: cameraDuration(300, reducedMotionRef.current),
+    })
+  }, [])
+
+  // Register focus helpers for external use (Results panel)
+  useEffect(() => {
+    return registerFocusHelpers(handleFocusNode, handleFocusEdge)
+  }, [handleFocusNode, handleFocusEdge])
+
+  // F4 (graph-visuals): registered multi-node fit — the applied-edit pulse
+  // choke point (appliedEditPulse.flush) routes every feeder here so pulse
+  // targets are in view before they flash. Fits every target (zoom capped)
+  // with the F1 reduced-motion guard, EXCEPT when all targets are already
+  // comfortably visible (cameraComfort's pinned no-churn rule) — an applied
+  // edit the user can already see must not yank the camera.
+  const handleFitNodes = useCallback((nodeIds: readonly string[]) => {
+    const store = useCanvasStore.getState()
+    const idSet = new Set(nodeIds)
+    const targets = store.nodes.filter((n) => idSet.has(n.id))
+    if (targets.length === 0) return
+    const camera = readFocusCamera(getViewportRef.current)
+    if (
+      camera &&
+      nodesComfortablyVisible(
+        targets,
+        camera.viewport,
+        camera.paneWidth,
+        camera.paneHeight,
+        camera.insets,
+      )
+    ) {
+      return
+    }
+    fitViewRef.current({
+      nodes: targets,
+      // Same panel-aware frame the no-churn gate above measured against (see
+      // the SAME-FRAME RULE on FocusCamera.padding). A bare number here framed
+      // against the full pane, so a pulse target under an expanded dock got a
+      // camera move that left it under the dock. Bare-number fallback only
+      // when unmeasurable — the case where the gate already fails open.
+      padding: camera?.padding ?? 0.25,
+      maxZoom: 1.5,
+      duration: cameraDuration(400, reducedMotionRef.current),
+    })
+  }, [])
+  useEffect(() => {
+    return registerFitNodes(handleFitNodes)
+  }, [handleFitNodes])
+
+  // F3 (graph-visuals): ANY camera move ends the focus lens — the transient
+  // dim must never outlive the frame it was built for — EXCEPT the fit focus
+  // itself just ordered.
+  //
+  // This deliberately does NOT filter on the move's event. ReactFlow passes
+  // the gesture for a user drag/wheel and null for a programmatic move, but
+  // the app's own zoom/reset/fit buttons pan programmatically too: an
+  // `if (event)` test swallows them and strands a stale dim over a reframed
+  // camera. The suppressor (armed only around focus's own fit) is the correct
+  // discriminator. clearFocusDim is a no-op unless a focus dim is active, so
+  // ordinary panning stays free of store churn.
+  const handleMoveStart = useCallback(() => {
+    if (focusFitSuppressorRef.current.consume()) return
+    useCanvasStore.getState().clearFocusDim()
+  }, [])
+
+  return { onMoveStart: handleMoveStart, focusNode: handleFocusNode }
+}
+
+export default useFocusCamera

--- a/src/canvas/hooks/usePathHighlight.ts
+++ b/src/canvas/hooks/usePathHighlight.ts
@@ -63,6 +63,15 @@ export function usePathHighlight(): void {
   // Using primitive count to avoid reference-based re-renders
   const edgeCount = useCanvasStore((s) => s.edges.length)
 
+  // F3 (graph-visuals): the focus dim BORROWS dimmedNodeIds from the path dim,
+  // so this hook must re-run when that ownership changes — in particular when
+  // the focus lens is ended from OUTSIDE (a camera move, an edge focus, the
+  // focused node being removed) with the selection unchanged. Without this dep
+  // nothing below re-runs on that path, and clearFocusDim's wipe of
+  // dimmedNodeIds would leave the selected node's path dim gone for good.
+  // Primitive selector (React #185 rule above).
+  const focusDimSourceId = useCanvasStore((s) => s.focusDimSourceId)
+
   useEffect(() => {
     // Access store actions and state via getState() to avoid dependency array issues
     const {
@@ -71,7 +80,6 @@ export function usePathHighlight(): void {
       setHighlightedEdges,
       setDimmedNodes,
       ceeAnalysisReady,
-      focusDimSourceId,
       clearFocusDim,
     } = useCanvasStore.getState()
 
@@ -81,6 +89,12 @@ export function usePathHighlight(): void {
     // away — deselect, multi-select, reselect another node — the focus dim
     // is cleared HERE, so it can never survive after focus ends, and normal
     // path dimming resumes.
+    //
+    // When the lens is instead ended from OUTSIDE with the selection intact
+    // (camera move / edge focus / focused node removed), focusDimSourceId
+    // drops to null and re-runs this effect: ownership returns here and the
+    // path dim below is recomputed, so ending the lens RESTORES the selected
+    // node's path dim rather than leaving the graph permanently undimmed.
     const focusDimOwnsDimming =
       focusDimSourceId !== null && selectionSize === 1 && selectedId === focusDimSourceId
     if (focusDimSourceId !== null && !focusDimOwnsDimming) {
@@ -149,7 +163,7 @@ export function usePathHighlight(): void {
 
     // No cleanup needed - we want highlights to persist until selection changes
     // The next effect run will update or clear highlights as appropriate
-  }, [selectionSize, selectedId, goalNodeId, edgeCount])
+  }, [selectionSize, selectedId, goalNodeId, edgeCount, focusDimSourceId])
 }
 
 export default usePathHighlight

--- a/src/canvas/hooks/usePathHighlight.ts
+++ b/src/canvas/hooks/usePathHighlight.ts
@@ -11,6 +11,8 @@
  * - Dims nodes not on highlighted paths (opacity ~0.4)
  * - Clears highlights on selection change (no timer-based auto-clear)
  * - Multi-select clears all highlights to prevent stale state
+ * - F3 (graph-visuals): defers to an active focus dim (store.focusDimSourceId)
+ *   for the selected node — and clears it the moment selection moves away
  *
  * IMPORTANT: Uses canonical sources for goal_node_id and options:
  * - Goal node ID: ceeAnalysisReady.goal_node_id
@@ -69,7 +71,21 @@ export function usePathHighlight(): void {
       setHighlightedEdges,
       setDimmedNodes,
       ceeAnalysisReady,
+      focusDimSourceId,
+      clearFocusDim,
     } = useCanvasStore.getState()
+
+    // F3 (graph-visuals): while a TRANSIENT focus dim is active for the
+    // selected node, it owns dimmedNodeIds — the path dim must not clobber
+    // it (path edges still highlight below). The moment selection moves
+    // away — deselect, multi-select, reselect another node — the focus dim
+    // is cleared HERE, so it can never survive after focus ends, and normal
+    // path dimming resumes.
+    const focusDimOwnsDimming =
+      focusDimSourceId !== null && selectionSize === 1 && selectedId === focusDimSourceId
+    if (focusDimSourceId !== null && !focusDimOwnsDimming) {
+      clearFocusDim()
+    }
 
     const options = ceeAnalysisReady?.options ?? []
 
@@ -77,14 +93,14 @@ export function usePathHighlight(): void {
     // Multi-select explicitly clears to prevent stale state
     if (selectionSize !== 1 || !selectedId || !goalNodeId) {
       setHighlightedEdges([])
-      setDimmedNodes([])
+      if (!focusDimOwnsDimming) setDimmedNodes([])
       return
     }
 
     const selectedNode = nodes.find((n) => n.id === selectedId)
     if (!selectedNode) {
       setHighlightedEdges([])
-      setDimmedNodes([])
+      if (!focusDimOwnsDimming) setDimmedNodes([])
       return
     }
 
@@ -128,7 +144,8 @@ export function usePathHighlight(): void {
 
     const dimmedIds = nodes.filter((n) => !nodesOnPath.has(n.id)).map((n) => n.id)
 
-    setDimmedNodes(dimmedIds)
+    // F3: the focus dim owns dimmedNodeIds while active (see above).
+    if (!focusDimOwnsDimming) setDimmedNodes(dimmedIds)
 
     // No cleanup needed - we want highlights to persist until selection changes
     // The next effect run will update or clear highlights as appropriate

--- a/src/canvas/hooks/useValidationFeedback.ts
+++ b/src/canvas/hooks/useValidationFeedback.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react'
 import { useCanvasStore } from '../store'
 import { useReactFlow } from '@xyflow/react'
 import type { ValidationError } from '../components/ValidationBanner'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+import { cameraDuration } from '../utils/cameraMotion'
 
 /**
  * Hook for handling validation feedback across all run entry points
@@ -14,6 +16,9 @@ import type { ValidationError } from '../components/ValidationBanner'
 export function useValidationFeedback() {
   const selectNodeWithoutHistory = useCanvasStore(s => s.selectNodeWithoutHistory)
   const { setCenter, getNode, getEdge } = useReactFlow()
+  // F1 (graph-visuals): "Fix now" focus is a camera move — honour
+  // prefers-reduced-motion like every other call site (cameraDuration guard).
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   /**
    * Focus on the first invalid element (node or edge)
@@ -27,7 +32,7 @@ export function useValidationFeedback() {
         selectNodeWithoutHistory(error.node_id)
         setCenter(node.position.x, node.position.y, {
           zoom: 1.5,
-          duration: 400,
+          duration: cameraDuration(400, prefersReducedMotion),
         })
       }
     } else if (error.edge_id) {
@@ -41,12 +46,12 @@ export function useValidationFeedback() {
           selectNodeWithoutHistory(edge.source)
           setCenter(sourceNode.position.x, sourceNode.position.y, {
             zoom: 1.5,
-            duration: 400,
+            duration: cameraDuration(400, prefersReducedMotion),
           })
         }
       }
     }
-  }, [getNode, getEdge, selectNodeWithoutHistory, setCenter])
+  }, [getNode, getEdge, selectNodeWithoutHistory, setCenter, prefersReducedMotion])
 
   /**
    * Format validation errors with helpful context

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -452,6 +452,11 @@ interface CanvasState {
   highlightedNodes: Set<string>
   highlightedEdges: Set<string>
   dimmedNodeIds: Set<string>
+  /** F3 (graph-visuals): non-null while a TRANSIENT focus dim owns
+   * dimmedNodeIds — set by handleFocusNode (dim = non-neighbours of the
+   * focused node), cleared on blur/deselect/manual pan/node removal. While
+   * active, usePathHighlight must not overwrite dimmedNodeIds. */
+  focusDimSourceId: string | null
   /** D2 (graph-visuals): level-of-detail — true when the main canvas zoom is
    * below the LOD threshold; nodes simplify (body hidden, only key labels). */
   lodActive: boolean
@@ -732,6 +737,13 @@ interface CanvasState {
   setHighlightedNodes: (ids: string[]) => void
   setHighlightedEdges: (ids: string[]) => void
   setDimmedNodes: (ids: string[]) => void
+  /** F3: start a transient focus dim — dims `dimmedIds` and marks the dim as
+   * owned by the focus on `sourceId` until clearFocusDim(). */
+  setFocusDim: (sourceId: string, dimmedIds: string[]) => void
+  /** F3: end the focus dim (blur/deselect/manual pan/node removal). No-op
+   * when no focus dim is active, so it never clobbers the selection
+   * path-dim written via setDimmedNodes. */
+  clearFocusDim: () => void
   /** N3: replace the edited-since-run set (called by the useEditedSinceRun effect). */
   setEditedSinceRunNodes: (ids: string[]) => void
   /** D2: set by the LodSync zoom watcher (skip-if-same). */
@@ -1398,6 +1410,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   highlightedNodes: new Set<string>(),
   highlightedEdges: new Set<string>(),
   dimmedNodeIds: new Set<string>(),
+  focusDimSourceId: null,
   editedSinceRunNodeIds: new Set<string>(),
   lodActive: false,
   confirmedNodeIds: new Set<string>(),
@@ -3969,6 +3982,18 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   setDimmedNodes: (ids: string[]) => {
     set({ dimmedNodeIds: new Set(ids) })
   },
+  // F3 (graph-visuals): transient focus dim. Flows through the SAME
+  // dimmedNodeIds field BaseNode's dim classes already consume — no new
+  // node-side consumer. focusDimSourceId marks the dim as focus-owned so
+  // usePathHighlight leaves it alone and clearFocusDim can't clobber a
+  // selection path-dim.
+  setFocusDim: (sourceId: string, dimmedIds: string[]) => {
+    set({ focusDimSourceId: sourceId, dimmedNodeIds: new Set(dimmedIds) })
+  },
+  clearFocusDim: () => {
+    if (get().focusDimSourceId === null) return
+    set({ focusDimSourceId: null, dimmedNodeIds: new Set<string>() })
+  },
   setLodActive: (active: boolean) => {
     if (get().lodActive === active) return
     set({ lodActive: active })
@@ -4671,6 +4696,20 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 if (typeof window !== 'undefined') {
   ;(window as any).useCanvasStore = useCanvasStore
 }
+
+// F3 (graph-visuals): the focus dim must never survive its focused node.
+// Nodes can be removed by MANY paths (delete action, AI patch, undo, full
+// graph replacement), so the invariant lives at the store boundary rather
+// than in each mutation: whenever the nodes array changes while a focus dim
+// is active, clear the dim if its source node is gone. Near-zero cost — the
+// guard exits on the first check unless a focus dim is active.
+useCanvasStore.subscribe((state, prevState) => {
+  const sourceId = state.focusDimSourceId
+  if (sourceId === null || state.nodes === prevState.nodes) return
+  if (!state.nodes.some((n) => n.id === sourceId)) {
+    state.clearFocusDim()
+  }
+})
 
 // React #185 DEBUG: Internal set() instrumentation is now done at store creation time
 // (see createDebugSet function above) - this captures ALL store updates including

--- a/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
+++ b/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
@@ -1,11 +1,20 @@
 /**
- * appliedEditPulse (seamlessness R2) — behavioral contract against the REAL
- * canvas store with fake timers.
+ * appliedEditPulse (seamlessness R2 + graph-visuals F4) — behavioral contract
+ * against the REAL canvas store with fake timers.
  *
  * The pulse must: coalesce a burst of apply events into ONE highlight over
  * the union of targets; filter stale ids at flush time (fail-closed); clear
  * both sets after PULSE_DURATION_MS; never write an empty highlight over an
- * existing one; and never touch selection/inspector/viewport state.
+ * existing one; and never touch selection or inspector state.
+ *
+ * F4 (Paul-ratified): the flush brings EVERY surviving pulse target into view
+ * BEFORE the highlight is written — an applied edit the user cannot see is a
+ * silent edit. The camera move goes through the registered fit seam
+ * (focusHelpers.fitNodesOnCanvas → ReactFlowGraph), which itself skips the
+ * pan when everything is already comfortably visible and honours
+ * prefers-reduced-motion (F1). This spec pins the choke point: one fit call,
+ * full surviving target set (nodes + pulsed edges' endpoints), before the
+ * highlight write. Selection/inspector hijack remains banned.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
@@ -14,6 +23,7 @@ import {
   PULSE_COALESCE_MS,
   PULSE_DURATION_MS,
 } from '../appliedEditPulse'
+import { registerFitNodes } from '../focusHelpers'
 import { useCanvasStore } from '../../store'
 
 const node = (id: string) =>
@@ -131,5 +141,62 @@ describe('pulseAppliedTargets', () => {
       before.selected,
     )
     expect((useCanvasStore.getState() as any).showInspectorPanel).toBe(before.inspector)
+  })
+})
+
+describe('F4 — the flush fits every surviving target into view BEFORE the pulse fires', () => {
+  let fitSpy: ReturnType<typeof vi.fn>
+  let highlightsAtFitTime: string[] | null
+  let unregister: (() => void) | null = null
+
+  beforeEach(() => {
+    highlightsAtFitTime = null
+    fitSpy = vi.fn(() => {
+      // Capture the highlight state AT fit time to pin the ordering.
+      highlightsAtFitTime = [...useCanvasStore.getState().highlightedNodes]
+    })
+    unregister = registerFitNodes(fitSpy as any)
+  })
+
+  afterEach(() => {
+    unregister?.()
+    unregister = null
+  })
+
+  it('fits the full surviving union — node targets plus pulsed edges’ endpoint nodes', () => {
+    pulseAppliedTargets({ nodeIds: ['n1'] })
+    pulseAppliedTargets({ edgeIds: ['e1'] }) // e1 runs n1 → n2
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(fitSpy).toHaveBeenCalledTimes(1)
+    expect([...fitSpy.mock.calls[0][0]].sort()).toEqual(['n1', 'n2'])
+  })
+
+  it('the fit happens BEFORE the highlight write (targets are on their way into view when they flash)', () => {
+    pulseAppliedTargets({ nodeIds: ['n1', 'n2'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(fitSpy).toHaveBeenCalledTimes(1)
+    expect(highlightsAtFitTime).toEqual([]) // highlight not yet written at fit time
+    expect([...useCanvasStore.getState().highlightedNodes].sort()).toEqual(['n1', 'n2'])
+  })
+
+  it('stale ids never reach the fit (fail-closed, same filter as the highlight)', () => {
+    pulseAppliedTargets({ nodeIds: ['n1', 'ghost'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(fitSpy).toHaveBeenCalledTimes(1)
+    expect([...fitSpy.mock.calls[0][0]]).toEqual(['n1'])
+  })
+
+  it('an all-stale flush fits nothing (no highlight, no camera move)', () => {
+    pulseAppliedTargets({ nodeIds: ['ghost'] })
+    vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)
+    expect(fitSpy).not.toHaveBeenCalled()
+  })
+
+  it('flush still highlights when no canvas fit is registered (fail-closed seam)', () => {
+    unregister?.()
+    unregister = null
+    pulseAppliedTargets({ nodeIds: ['n1'] })
+    expect(() => vi.advanceTimersByTime(PULSE_COALESCE_MS + 1)).not.toThrow()
+    expect([...useCanvasStore.getState().highlightedNodes]).toEqual(['n1'])
   })
 })

--- a/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
+++ b/src/canvas/utils/__tests__/appliedEditPulse.spec.ts
@@ -17,6 +17,7 @@
  * highlight write. Selection/inspector hijack remains banned.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
 import {
   pulseAppliedTargets,
   __resetAppliedEditPulseForTests,
@@ -145,17 +146,21 @@ describe('pulseAppliedTargets', () => {
 })
 
 describe('F4 — the flush fits every surviving target into view BEFORE the pulse fires', () => {
-  let fitSpy: ReturnType<typeof vi.fn>
+  // Typed to the real seam signature: `ReturnType<typeof vi.fn>` is
+  // Mock<any[], unknown>, which the zero-arg implementation below is not
+  // assignable to (tsc -p tsconfig.app.json; tsconfig.ci.json does not cover
+  // this file, so CI never surfaced it).
+  let fitSpy: Mock<[readonly string[]], void>
   let highlightsAtFitTime: string[] | null
   let unregister: (() => void) | null = null
 
   beforeEach(() => {
     highlightsAtFitTime = null
-    fitSpy = vi.fn(() => {
+    fitSpy = vi.fn((_nodeIds: readonly string[]) => {
       // Capture the highlight state AT fit time to pin the ordering.
       highlightsAtFitTime = [...useCanvasStore.getState().highlightedNodes]
     })
-    unregister = registerFitNodes(fitSpy as any)
+    unregister = registerFitNodes(fitSpy)
   })
 
   afterEach(() => {

--- a/src/canvas/utils/__tests__/cameraComfort.spec.ts
+++ b/src/canvas/utils/__tests__/cameraComfort.spec.ts
@@ -13,10 +13,11 @@
  * Fail-open to fitting: an unmeasurable pane (jsdom, pre-mount) or an empty
  * target list is NOT comfortable, so callers fall back to today's fit.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import {
   nodesComfortablyVisible,
   paddingToInsets,
+  readFocusCamera,
   MIN_READABLE_ZOOM,
   COMFORT_SLACK_PX,
   DEFAULT_NODE_WIDTH,
@@ -155,5 +156,109 @@ describe('paddingToInsets — bridges computeFitPadding px strings to numeric in
     expect(
       paddingToInsets({ top: '10px', right: '428px', bottom: '10px', left: '68px' }),
     ).toEqual({ top: 10, right: 428, bottom: 10, left: 68 })
+  })
+})
+
+/**
+ * readFocusCamera — the DOM measurement bridge BOTH F2 and F4 depend on for
+ * the no-churn decision (adversarial review finding 7: every fit-seam test
+ * replaces it with a spy, so the real bridge never executed under test).
+ *
+ * Exercised here against the REAL computeFitPadding — only the element rects
+ * are faked — so the panel-aware measurement is genuinely run.
+ */
+function fakeEl(rect: Partial<DOMRect>): HTMLElement {
+  const full = {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    toJSON: () => ({}),
+    ...rect,
+  } as DOMRect
+  return { getBoundingClientRect: () => full } as unknown as HTMLElement
+}
+
+function stubSelectors(map: Record<string, HTMLElement | null>) {
+  vi.spyOn(document, 'querySelector').mockImplementation(
+    (sel: string) => (sel in map ? map[sel] : null) as Element | null,
+  )
+}
+
+const FLOW = '.react-flow'
+const DOCK = 'aside[aria-label="Outputs dock"]'
+const VIEWPORT = { x: 12, y: 34, zoom: 0.9 }
+const getViewport = () => VIEWPORT
+
+describe('readFocusCamera — the live camera measurement bridge', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when there is no .react-flow element (pre-mount)', () => {
+    stubSelectors({})
+    expect(readFocusCamera(getViewport)).toBeNull()
+  })
+
+  it('returns null when the pane is unmeasurable (0×0, e.g. jsdom) — callers fail open and fit', () => {
+    stubSelectors({ [FLOW]: fakeEl({ width: 0, height: 0 }) })
+    expect(readFocusCamera(getViewport)).toBeNull()
+  })
+
+  it('reports the caller’s viewport and the measured pane size', () => {
+    stubSelectors({ [FLOW]: fakeEl({ width: 1440, height: 900, left: 0, right: 1440 }) })
+    const camera = readFocusCamera(getViewport)
+    expect(camera?.viewport).toEqual(VIEWPORT)
+    expect(camera?.paneWidth).toBe(1440)
+    expect(camera?.paneHeight).toBe(900)
+  })
+
+  it('SAME-FRAME RULE: insets are exactly the parsed form of the padding it hands the fit', () => {
+    // Finding 4's regression in one assertion — the gate (insets) and the fit
+    // (padding) must describe ONE rect. If they ever diverge, the camera moves
+    // and leaves an occluded target occluded.
+    stubSelectors({
+      [FLOW]: fakeEl({ width: 1440, height: 900, left: 0, right: 1440 }),
+      [DOCK]: fakeEl({ width: 416, height: 900, left: 1012, right: 1428 }),
+    })
+    const camera = readFocusCamera(getViewport)
+    expect(camera).not.toBeNull()
+    expect(paddingToInsets(camera!.padding)).toEqual(camera!.insets)
+  })
+
+  it('is panel-aware: an expanded dock reserves the right side it occludes', () => {
+    stubSelectors({
+      [FLOW]: fakeEl({ width: 1440, height: 900, left: 0, right: 1440 }),
+      [DOCK]: fakeEl({ width: 416, height: 900, left: 1012, right: 1428 }),
+    })
+    const camera = readFocusCamera(getViewport)
+    // overlap = flowRect.right - dock.left = 428, plus the 16px gap.
+    expect(camera?.insets.right).toBe(444)
+    expect(camera?.padding.right).toBe('444px')
+    // Base margin is untouched on the unoccluded left: floor((1440 - 1440/1.2) * 0.5).
+    expect(camera?.insets.left).toBe(120)
+  })
+
+  it('a node under the expanded dock is NOT comfortable through the real bridge (F2/F4 end to end)', () => {
+    // The whole point of the bridge: measurement → gate. A node sitting under
+    // the dock must read as uncomfortable so focus/pulse actually fits it.
+    stubSelectors({
+      [FLOW]: fakeEl({ width: 1440, height: 900, left: 0, right: 1440 }),
+      [DOCK]: fakeEl({ width: 416, height: 900, left: 1012, right: 1428 }),
+    })
+    const camera = readFocusCamera(() => ({ x: 0, y: 0, zoom: 1 }))!
+    const underDock = sized(1100, 300)
+    expect(
+      nodesComfortablyVisible([underDock], camera.viewport, camera.paneWidth, camera.paneHeight, camera.insets),
+    ).toBe(false)
+    // ...while the same node in the clear reads comfortable.
+    const inTheClear = sized(300, 300)
+    expect(
+      nodesComfortablyVisible([inTheClear], camera.viewport, camera.paneWidth, camera.paneHeight, camera.insets),
+    ).toBe(true)
   })
 })

--- a/src/canvas/utils/__tests__/cameraComfort.spec.ts
+++ b/src/canvas/utils/__tests__/cameraComfort.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * cameraComfort — the pinned "no camera churn" rule shared by F2 (focus) and
+ * F4 (pulse fit).
+ *
+ * THE RULE (Paul-ratified F2/F4, graph-visuals): the camera must NOT move
+ * when every target node is already comfortably visible — meaning each
+ * target's rect sits fully inside the panel-aware fit frame (the pane inset
+ * by computeFitPadding's per-side margins, with a small slack so a frame the
+ * camera just fitted still counts) AT a readable zoom (>= MIN_READABLE_ZOOM).
+ * Anything less — a target off-screen, under an occluding panel, or rendered
+ * unreadably small — and the camera fits.
+ *
+ * Fail-open to fitting: an unmeasurable pane (jsdom, pre-mount) or an empty
+ * target list is NOT comfortable, so callers fall back to today's fit.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  nodesComfortablyVisible,
+  paddingToInsets,
+  MIN_READABLE_ZOOM,
+  COMFORT_SLACK_PX,
+  DEFAULT_NODE_WIDTH,
+  DEFAULT_NODE_HEIGHT,
+} from '../cameraComfort'
+
+const PANE_W = 1000
+const PANE_H = 800
+const INSETS = { top: 80, right: 80, bottom: 80, left: 80 }
+
+const sized = (x: number, y: number, width = 200, height = 80) => ({
+  position: { x, y },
+  measured: { width, height },
+})
+
+describe('nodesComfortablyVisible — the pinned no-churn rule', () => {
+  it('a node fully inside the fit frame at zoom 1 is comfortable', () => {
+    const node = sized(200, 200)
+    expect(
+      nodesComfortablyVisible([node], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(true)
+  })
+
+  it('below MIN_READABLE_ZOOM is NEVER comfortable, even fully in frame', () => {
+    const node = sized(400, 300, 100, 40)
+    expect(
+      nodesComfortablyVisible(
+        [node],
+        { x: 0, y: 0, zoom: MIN_READABLE_ZOOM - 0.1 },
+        PANE_W,
+        PANE_H,
+        INSETS,
+      ),
+    ).toBe(false)
+  })
+
+  it('exactly MIN_READABLE_ZOOM counts as readable (>= boundary)', () => {
+    const node = sized(400, 300, 100, 40)
+    expect(
+      nodesComfortablyVisible(
+        [node],
+        { x: 0, y: 0, zoom: MIN_READABLE_ZOOM },
+        PANE_W,
+        PANE_H,
+        INSETS,
+      ),
+    ).toBe(true)
+  })
+
+  it('a node poking past the right frame edge is not comfortable', () => {
+    // 780 + 200 = 980 > 1000 - 80 (right inset) → outside the frame
+    const node = sized(780, 200)
+    expect(
+      nodesComfortablyVisible([node], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(false)
+  })
+
+  it('a node under an expanded panel inset (occluded) is not comfortable', () => {
+    // Node at x 600..800 would clear an 80px inset but NOT a 320px dock inset
+    const node = sized(600, 200)
+    const dockInsets = { ...INSETS, right: 320 }
+    expect(
+      nodesComfortablyVisible([node], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, dockInsets),
+    ).toBe(false)
+  })
+
+  it('a node off-screen above (negative screen y) is not comfortable', () => {
+    const node = sized(200, -400)
+    expect(
+      nodesComfortablyVisible([node], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(false)
+  })
+
+  it('viewport translation is applied: an off-origin node panned into frame IS comfortable', () => {
+    // Flow position (1000, 1000) with viewport x/y -800 → screen (200, 200)
+    const node = sized(1000, 1000)
+    expect(
+      nodesComfortablyVisible([node], { x: -800, y: -800, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(true)
+  })
+
+  it('ALL targets must be in frame — one stray neighbour breaks comfort', () => {
+    const inFrame = sized(200, 200)
+    const stray = sized(2000, 200)
+    expect(
+      nodesComfortablyVisible([inFrame, stray], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(false)
+  })
+
+  it('an empty target list is not comfortable (nothing to be comfortable about)', () => {
+    expect(nodesComfortablyVisible([], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS)).toBe(
+      false,
+    )
+  })
+
+  it('an unmeasurable pane (0×0, e.g. jsdom) is not comfortable — callers fall back to fitting', () => {
+    const node = sized(200, 200)
+    expect(nodesComfortablyVisible([node], { x: 0, y: 0, zoom: 1 }, 0, 0, INSETS)).toBe(false)
+  })
+
+  it('a missing viewport is not comfortable', () => {
+    const node = sized(200, 200)
+    expect(nodesComfortablyVisible([node], null, PANE_W, PANE_H, INSETS)).toBe(false)
+  })
+
+  it('falls back to DEFAULT_NODE_WIDTH/HEIGHT when a node has no measured dims', () => {
+    // With default dims the node at x=850 overflows the right frame edge;
+    // if unmeasured nodes were treated as 0-sized this would wrongly pass.
+    const unmeasured = { position: { x: PANE_W - INSETS.right - DEFAULT_NODE_WIDTH + 40, y: 200 } }
+    expect(
+      nodesComfortablyVisible([unmeasured], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(false)
+    const wellInside = { position: { x: 300, y: 300 } }
+    expect(DEFAULT_NODE_HEIGHT).toBeGreaterThan(0)
+    expect(
+      nodesComfortablyVisible([wellInside], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(true)
+  })
+
+  it('COMFORT_SLACK_PX: a node exactly on the fit-frame boundary still counts (a just-fitted frame is comfortable)', () => {
+    // Node left edge lands exactly at the inset → inside thanks to slack
+    const node = sized(INSETS.left, INSETS.top, 200, 80)
+    expect(
+      nodesComfortablyVisible([node], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(true)
+    // …and a couple of px of animation-end drift is also forgiven
+    const drifted = sized(INSETS.left - (COMFORT_SLACK_PX - 2), INSETS.top, 200, 80)
+    expect(
+      nodesComfortablyVisible([drifted], { x: 0, y: 0, zoom: 1 }, PANE_W, PANE_H, INSETS),
+    ).toBe(true)
+  })
+})
+
+describe('paddingToInsets — bridges computeFitPadding px strings to numeric insets', () => {
+  it('parses per-side px strings', () => {
+    expect(
+      paddingToInsets({ top: '10px', right: '428px', bottom: '10px', left: '68px' }),
+    ).toEqual({ top: 10, right: 428, bottom: 10, left: 68 })
+  })
+})

--- a/src/canvas/utils/__tests__/focusLens.spec.ts
+++ b/src/canvas/utils/__tests__/focusLens.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * focusLens — F3: the rule for WHEN the transient focus lens ends.
+ *
+ * THE RULE (adversarial review finding 1): any camera move ends the lens
+ * EXCEPT the fit focus itself just ordered. The discriminator is NOT the
+ * move's event — the app's own zoom/reset/fit buttons move the camera
+ * programmatically (event === null) and are exactly the user actions that
+ * MUST end the lens. These pin the suppressor's contract; useFocusCamera.spec
+ * pins that onMoveStart actually consults it.
+ */
+import { describe, it, expect } from 'vitest'
+import { createFocusFitSuppressor, FOCUS_FIT_SUPPRESS_MS } from '../focusLens'
+
+/** Fake clock so the window is pinned without timers. */
+function clockAt(t: { now: number }) {
+  return () => t.now
+}
+
+describe('createFocusFitSuppressor — F3 lens-end rule', () => {
+  it('an unarmed move is NOT focus’s own — the lens ends', () => {
+    const s = createFocusFitSuppressor()
+    expect(s.consume()).toBe(false)
+  })
+
+  it('the move right after focus’s own fit IS claimed — the lens survives', () => {
+    const t = { now: 1000 }
+    const s = createFocusFitSuppressor(clockAt(t))
+    s.begin()
+    expect(s.consume()).toBe(true)
+  })
+
+  it('claims only ONE move: the SECOND move after a fit ends the lens', () => {
+    // The regression this guards: a suppression flag that stays set would make
+    // focus's fit swallow the user's next real pan too.
+    const t = { now: 1000 }
+    const s = createFocusFitSuppressor(clockAt(t))
+    s.begin()
+    expect(s.consume()).toBe(true)
+    expect(s.consume()).toBe(false)
+  })
+
+  it('a stale arming does NOT claim a later move (a fit that never moved the camera)', () => {
+    // A fit whose camera is already at the target emits no move at all. Without
+    // the time box the arming would lie in wait and swallow a genuine user pan.
+    const t = { now: 1000 }
+    const s = createFocusFitSuppressor(clockAt(t))
+    s.begin()
+    t.now = 1000 + FOCUS_FIT_SUPPRESS_MS + 1
+    expect(s.consume()).toBe(false)
+  })
+
+  it('a stale arming is consumed, so it cannot claim any subsequent move either', () => {
+    const t = { now: 1000 }
+    const s = createFocusFitSuppressor(clockAt(t))
+    s.begin()
+    t.now = 5000
+    expect(s.consume()).toBe(false)
+    t.now = 5001
+    expect(s.consume()).toBe(false)
+  })
+
+  it('the window boundary is inclusive', () => {
+    const t = { now: 1000 }
+    const s = createFocusFitSuppressor(clockAt(t))
+    s.begin()
+    t.now = 1000 + FOCUS_FIT_SUPPRESS_MS
+    expect(s.consume()).toBe(true)
+  })
+
+  it('re-arming refreshes the window — consecutive focuses each keep their own fit', () => {
+    const t = { now: 1000 }
+    const s = createFocusFitSuppressor(clockAt(t))
+    s.begin()
+    expect(s.consume()).toBe(true)
+    t.now = 9000
+    s.begin()
+    expect(s.consume()).toBe(true)
+  })
+})

--- a/src/canvas/utils/__tests__/focusNeighbourhood.spec.ts
+++ b/src/canvas/utils/__tests__/focusNeighbourhood.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { neighbourhoodNodeIds, computeFocusPlan } from '../focusNeighbourhood'
+import type { FocusCamera } from '../cameraComfort'
 
 const edges = [
   { source: 'a', target: 'g' },
@@ -57,11 +58,17 @@ const planNodes = [
   planNode('lonely', 200, 600),
 ]
 
-const comfortableCamera = {
+// `padding` is the px-string form of `insets` — readFocusCamera derives both
+// from ONE computeFitPadding call so the no-churn gate and the fit it gates
+// frame against the same rect (the SAME-FRAME RULE on FocusCamera). The plan
+// only reads `insets`; the fixtures keep the pair consistent so they cannot
+// pin a camera shape the real bridge would never produce.
+const comfortableCamera: FocusCamera = {
   viewport: { x: 0, y: 0, zoom: 1 },
   paneWidth: 1200,
   paneHeight: 900,
   insets: { top: 40, right: 40, bottom: 40, left: 40 },
+  padding: { top: '40px', right: '40px', bottom: '40px', left: '40px' },
 }
 
 describe('computeFocusPlan — F3 dim set (non-neighbours only)', () => {

--- a/src/canvas/utils/__tests__/focusNeighbourhood.spec.ts
+++ b/src/canvas/utils/__tests__/focusNeighbourhood.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { neighbourhoodNodeIds } from '../focusNeighbourhood'
+import { neighbourhoodNodeIds, computeFocusPlan } from '../focusNeighbourhood'
 
 const edges = [
   { source: 'a', target: 'g' },
@@ -25,5 +25,90 @@ describe('neighbourhoodNodeIds — F2 focus neighbourhood', () => {
 
   it('handles an empty graph', () => {
     expect([...neighbourhoodNodeIds('x', [])]).toEqual(['x'])
+  })
+})
+
+/**
+ * computeFocusPlan — the single focus decision (F2 camera + F3 dim), pure and
+ * pinned here; ReactFlowGraph's handleFocusNode only applies the plan.
+ *
+ * Pins:
+ * - F3: dimNodeIds = every node OUTSIDE the neighbourhood; the target and its
+ *   direct neighbours are never dimmed.
+ * - F2 no-churn: moveCamera is false when the whole neighbourhood is already
+ *   comfortably visible (see cameraComfort.spec.ts for the rule itself), true
+ *   from far zoom / off-screen, and true (fail-open to fitting) when the
+ *   camera cannot be measured.
+ */
+const planNode = (id: string, x: number, y: number) => ({
+  id,
+  position: { x, y },
+  measured: { width: 200, height: 80 },
+})
+
+// a → g, c → a; d–e off in their own corner; 'lonely' disconnected.
+const planNodes = [
+  planNode('a', 200, 200),
+  planNode('g', 500, 200),
+  planNode('c', 200, 400),
+  planNode('b', 500, 400),
+  planNode('d', 3000, 3000),
+  planNode('e', 3300, 3000),
+  planNode('lonely', 200, 600),
+]
+
+const comfortableCamera = {
+  viewport: { x: 0, y: 0, zoom: 1 },
+  paneWidth: 1200,
+  paneHeight: 900,
+  insets: { top: 40, right: 40, bottom: 40, left: 40 },
+}
+
+describe('computeFocusPlan — F3 dim set (non-neighbours only)', () => {
+  it('dims every node outside the neighbourhood; target + neighbours stay undimmed', () => {
+    const plan = computeFocusPlan('a', planNodes, edges, null)
+    expect(plan).not.toBeNull()
+    expect([...plan!.focusNodeIds].sort()).toEqual(['a', 'c', 'g'])
+    expect([...plan!.dimNodeIds].sort()).toEqual(['b', 'd', 'e', 'lonely'])
+  })
+
+  it('a disconnected focus target dims everything else', () => {
+    const plan = computeFocusPlan('lonely', planNodes, edges, null)
+    expect([...plan!.focusNodeIds]).toEqual(['lonely'])
+    expect([...plan!.dimNodeIds].sort()).toEqual(['a', 'b', 'c', 'd', 'e', 'g'])
+  })
+
+  it('returns null for an id that is not on the canvas (fail-closed)', () => {
+    expect(computeFocusPlan('ghost', planNodes, edges, null)).toBeNull()
+  })
+})
+
+describe('computeFocusPlan — F2 no-churn camera decision', () => {
+  it('does NOT move the camera when the whole neighbourhood is already comfortably readable', () => {
+    const plan = computeFocusPlan('a', planNodes, edges, comfortableCamera)
+    expect(plan!.moveCamera).toBe(false)
+  })
+
+  it('moves the camera from a far zoom (target would be unreadable)', () => {
+    const plan = computeFocusPlan('a', planNodes, edges, {
+      ...comfortableCamera,
+      viewport: { x: 0, y: 0, zoom: 0.2 },
+    })
+    expect(plan!.moveCamera).toBe(true)
+  })
+
+  it('moves the camera when a neighbour is off-screen, even if the target itself is visible', () => {
+    // d is visible at this viewport; its neighbour e (d→e) is pushed off-pane.
+    const plan = computeFocusPlan('d', planNodes, edges, {
+      ...comfortableCamera,
+      viewport: { x: -2900, y: -2800, zoom: 1 },
+      paneWidth: 500,
+      paneHeight: 500,
+    })
+    expect(plan!.moveCamera).toBe(true)
+  })
+
+  it('moves the camera when the camera state cannot be measured (fail-open to fitting)', () => {
+    expect(computeFocusPlan('a', planNodes, edges, null)!.moveCamera).toBe(true)
   })
 })

--- a/src/canvas/utils/appliedEditPulse.ts
+++ b/src/canvas/utils/appliedEditPulse.ts
@@ -1,4 +1,5 @@
 import { useCanvasStore } from '../store'
+import { fitNodesOnCanvas } from './focusHelpers'
 
 // appliedEditPulse — seamlessness R2: when the AI's graph edits land on the
 // canvas (accepted patch, auto-applied patch, or V5 server-applied patch),
@@ -14,9 +15,17 @@ import { useCanvasStore } from '../store'
 // - Fail-closed: ids are filtered against the canvas store at flush time;
 //   ids not on the canvas (e.g. removals) never pulse. An all-stale flush
 //   writes nothing (never clobbers an existing highlight with emptiness).
-// - Pulse only: no selection, no inspector, no viewport pan — the AI must
-//   not hijack what the user is doing. The node ring gently pulses (N2,
-//   BaseNode `ai-highlight-pulse`) and the edge stroke is static; both are
+// - F4 (graph-visuals, Paul-ratified): the flush fits EVERY surviving target
+//   (nodes + pulsed edges' endpoint nodes) into view BEFORE the ring fires —
+//   an applied edit the user cannot see is a silent edit. This is the ONE
+//   choke point for every feeder (applyPatch, applyV5State, mergeAppliedGraph,
+//   the What-changed chip). The camera move goes through the registered fit
+//   seam (fitNodesOnCanvas → ReactFlowGraph), which skips the pan when the
+//   targets are already comfortably visible (cameraComfort no-churn rule) and
+//   honours prefers-reduced-motion (F1).
+// - No selection, no inspector hijack — the AI must not steal what the user
+//   is editing. The node ring gently pulses (N2, BaseNode
+//   `ai-highlight-pulse`) and the edge stroke is static; both are
 //   reduced-motion-safe (the pulse keyframe is disabled under
 //   prefers-reduced-motion, leaving the static ring).
 
@@ -56,6 +65,21 @@ function flush(): void {
   pendingNodeIds = new Set()
   pendingEdgeIds = new Set()
   if (nodeIds.length === 0 && edgeIds.length === 0) return
+
+  // F4: fit the full surviving union — node targets plus pulsed edges'
+  // endpoint nodes — into view BEFORE the highlight is written, so targets
+  // are on their way on-screen when they flash. Fail-closed at the seam:
+  // when no canvas fit is registered (jsdom, pre-mount) this no-ops and the
+  // pulse still fires.
+  const fitIds = new Set(nodeIds)
+  for (const id of edgeIds) {
+    const edge = edges.find((e) => e.id === id)
+    if (!edge) continue
+    for (const endpoint of [edge.source, edge.target]) {
+      if (nodes.some((n) => n.id === endpoint)) fitIds.add(endpoint)
+    }
+  }
+  fitNodesOnCanvas([...fitIds])
 
   setHighlightedNodes(nodeIds)
   setHighlightedEdges(edgeIds)

--- a/src/canvas/utils/cameraComfort.ts
+++ b/src/canvas/utils/cameraComfort.ts
@@ -1,0 +1,120 @@
+/**
+ * cameraComfort — the pinned "no camera churn" rule shared by F2 (focus
+ * fits the neighbourhood) and F4 (the applied-edit pulse fits its targets).
+ *
+ * THE RULE: the camera must NOT move when every target node is already
+ * comfortably visible — each target's rect fully inside the panel-aware fit
+ * frame (the pane inset by computeFitPadding's per-side margins, minus a
+ * small slack so a frame the camera just fitted still counts) at a readable
+ * zoom (>= MIN_READABLE_ZOOM). Anything less — a target off-screen, under an
+ * occluding panel, or rendered unreadably small — and the caller fits.
+ *
+ * Fail-open to fitting: an unmeasurable pane/viewport (jsdom, pre-mount) or
+ * an empty target list is NOT comfortable, so callers fall back to the
+ * previous always-fit behaviour.
+ *
+ * Pure by design (cameraMotion precedent): callers supply the viewport, pane
+ * size and insets; only readFocusCamera below touches the DOM, mirroring
+ * computeFitPadding's measurement approach.
+ */
+
+import { computeFitPadding, type FitPadding } from './computeFitPadding'
+
+/** Below this zoom a node's label is not readably rendered — never "comfortable". */
+export const MIN_READABLE_ZOOM = 0.5
+/** Forgives animation-end drift and lets an exactly-fitted frame count as comfortable. */
+export const COMFORT_SLACK_PX = 8
+/** Fallbacks for nodes that have not reported measured dimensions yet. */
+export const DEFAULT_NODE_WIDTH = 200
+export const DEFAULT_NODE_HEIGHT = 80
+
+export interface ViewportLike {
+  x: number
+  y: number
+  zoom: number
+}
+
+export interface ComfortInsets {
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+export interface SizedNodeLike {
+  position: { x: number; y: number }
+  measured?: { width?: number; height?: number }
+  width?: number
+  height?: number
+}
+
+/** Bridge computeFitPadding's `'<n>px'` strings to numeric insets. */
+export function paddingToInsets(padding: FitPadding): ComfortInsets {
+  return {
+    top: parseFloat(padding.top),
+    right: parseFloat(padding.right),
+    bottom: parseFloat(padding.bottom),
+    left: parseFloat(padding.left),
+  }
+}
+
+export function nodesComfortablyVisible(
+  nodes: ReadonlyArray<SizedNodeLike>,
+  viewport: ViewportLike | null | undefined,
+  paneWidth: number,
+  paneHeight: number,
+  insets: ComfortInsets,
+): boolean {
+  if (nodes.length === 0) return false
+  if (!viewport) return false
+  if (!(paneWidth > 0) || !(paneHeight > 0)) return false
+  if (viewport.zoom < MIN_READABLE_ZOOM) return false
+
+  const frameLeft = Math.max(0, insets.left - COMFORT_SLACK_PX)
+  const frameTop = Math.max(0, insets.top - COMFORT_SLACK_PX)
+  const frameRight = paneWidth - Math.max(0, insets.right - COMFORT_SLACK_PX)
+  const frameBottom = paneHeight - Math.max(0, insets.bottom - COMFORT_SLACK_PX)
+  if (frameRight <= frameLeft || frameBottom <= frameTop) return false
+
+  for (const node of nodes) {
+    const width = node.measured?.width ?? node.width ?? DEFAULT_NODE_WIDTH
+    const height = node.measured?.height ?? node.height ?? DEFAULT_NODE_HEIGHT
+    const screenX = node.position.x * viewport.zoom + viewport.x
+    const screenY = node.position.y * viewport.zoom + viewport.y
+    if (
+      screenX < frameLeft ||
+      screenY < frameTop ||
+      screenX + width * viewport.zoom > frameRight ||
+      screenY + height * viewport.zoom > frameBottom
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+export interface FocusCamera {
+  viewport: ViewportLike
+  paneWidth: number
+  paneHeight: number
+  insets: ComfortInsets
+}
+
+/**
+ * Measure the live camera for the main canvas: viewport from the caller's
+ * ReactFlow instance, pane + panel-aware insets from the `.react-flow`
+ * element (same single-canvas scope caveat as computeFitPadding). Returns
+ * null when unmeasurable — callers treat that as "not comfortable" and fit.
+ */
+export function readFocusCamera(getViewport: () => ViewportLike): FocusCamera | null {
+  if (typeof document === 'undefined') return null
+  const el = document.querySelector('.react-flow')
+  const rect = el?.getBoundingClientRect()
+  if (!rect || rect.width <= 0 || rect.height <= 0) return null
+  return {
+    viewport: getViewport(),
+    paneWidth: rect.width,
+    paneHeight: rect.height,
+    insets: paddingToInsets(computeFitPadding(el)),
+  }
+}

--- a/src/canvas/utils/cameraComfort.ts
+++ b/src/canvas/utils/cameraComfort.ts
@@ -98,6 +98,19 @@ export interface FocusCamera {
   paneWidth: number
   paneHeight: number
   insets: ComfortInsets
+  /**
+   * SAME-FRAME RULE: the padding the gated fit MUST pass to fitView, derived
+   * from the very computeFitPadding call `insets` was parsed from. The gate
+   * (nodesComfortablyVisible, via `insets`) and the fit it gates therefore
+   * measure against ONE frame.
+   *
+   * A bare-number padding here would reintroduce the bug this field exists to
+   * kill: bare numbers are a FRACTION of the full pane (see computeFitPadding),
+   * so the gate would ask "is the target clear of the expanded dock?" and the
+   * fit would then frame against the whole pane and re-park it under that same
+   * dock — the camera moves and the target is still occluded.
+   */
+  padding: FitPadding
 }
 
 /**
@@ -111,10 +124,13 @@ export function readFocusCamera(getViewport: () => ViewportLike): FocusCamera | 
   const el = document.querySelector('.react-flow')
   const rect = el?.getBoundingClientRect()
   if (!rect || rect.width <= 0 || rect.height <= 0) return null
+  // ONE measurement feeds both the gate (insets) and the fit (padding).
+  const padding = computeFitPadding(el)
   return {
     viewport: getViewport(),
     paneWidth: rect.width,
     paneHeight: rect.height,
-    insets: paddingToInsets(computeFitPadding(el)),
+    insets: paddingToInsets(padding),
+    padding,
   }
 }

--- a/src/canvas/utils/focusHelpers.ts
+++ b/src/canvas/utils/focusHelpers.ts
@@ -52,11 +52,14 @@ export function registerFitNodes(fitNodes: FitNodesFn): () => void {
 }
 
 /**
- * F4 (graph-visuals): fit the viewport so EVERY given node is visible —
- * used by USER-INITIATED actions only (e.g. clicking the What-changed
- * chip) so off-screen targets are brought into view before they pulse.
- * The AI's autonomous applied-edit pulse deliberately never pans
- * (appliedEditPulse contract: the AI must not hijack the viewport).
+ * F4 (graph-visuals, Paul-ratified): fit the viewport so EVERY given node
+ * is visible — called by the applied-edit pulse choke point
+ * (appliedEditPulse's flush) so off-screen targets are brought into view
+ * before they pulse, for every feeder (applyPatch, applyV5State, the
+ * What-changed chip). The registered implementation (ReactFlowGraph)
+ * applies the cameraComfort no-churn rule — no camera move when every
+ * target is already comfortably visible — and honours
+ * prefers-reduced-motion (F1). Selection/inspector hijack stays banned.
  * Fail-closed: returns false (no-op) when the canvas is not mounted.
  */
 export function fitNodesOnCanvas(nodeIds: readonly string[]): boolean {

--- a/src/canvas/utils/focusLens.ts
+++ b/src/canvas/utils/focusLens.ts
@@ -1,0 +1,61 @@
+/**
+ * focusLens — F3 (graph-visuals): the rule for WHEN the transient focus lens ends.
+ *
+ * THE RULE: the focus dim must not outlive the camera it was framed against.
+ * Any camera move ends the lens EXCEPT the one focus itself just ordered.
+ *
+ * Why this is not simply `if (event)`: ReactFlow hands onMoveStart the
+ * originating gesture for a user drag/wheel and `null` for a programmatic
+ * move. But the app's OWN camera controls (the zoom in/out/reset/fit buttons)
+ * move the camera programmatically too — they are user ACTIONS that arrive as
+ * `null` events. Filtering on the event therefore swallows the very moves that
+ * most need to end the lens, stranding a stale dim over a reframed camera.
+ *
+ * So the discriminator is not "did an event come with it" but "did FOCUS order
+ * this move": handleFocusNode arms the suppressor immediately before its own
+ * fit, and the first move-start to arrive consumes the arming.
+ *
+ * Time-boxed AND consume-once, deliberately:
+ *  - consume-once, so the arming can never cover a second, later move;
+ *  - time-boxed, because a fit whose camera is already at the target emits NO
+ *    move at all, which would otherwise leave the arming set forever and make
+ *    the next genuine user pan the one that gets swallowed.
+ * The residual window is a user pan landing inside `windowMs` of focus's own
+ * fit — during which the camera is mid-animation anyway.
+ *
+ * Pure by design (cameraMotion/cameraComfort precedent): the clock is injected,
+ * so there are no timers to leak and the contract is pinned with a fake clock.
+ */
+
+/** How long focus's own fit may claim a move-start before the arming goes stale. */
+export const FOCUS_FIT_SUPPRESS_MS = 150
+
+export interface FocusFitSuppressor {
+  /** Arm: call immediately BEFORE focus's own programmatic fit. */
+  begin: () => void
+  /**
+   * Ask, from onMoveStart: was this move focus's own fit (so KEEP the lens)?
+   * Consumes the arming, so only the first move-start can claim it.
+   */
+  consume: () => boolean
+}
+
+export function createFocusFitSuppressor(
+  nowMs: () => number = () => Date.now(),
+  windowMs: number = FOCUS_FIT_SUPPRESS_MS,
+): FocusFitSuppressor {
+  let armedAt: number | null = null
+  return {
+    begin: () => {
+      armedAt = nowMs()
+    },
+    consume: () => {
+      if (armedAt === null) return false
+      const withinWindow = nowMs() - armedAt <= windowMs
+      // Consume even when stale: a fit that never moved the camera must not
+      // leave the arming lying in wait for a genuine user pan.
+      armedAt = null
+      return withinWindow
+    },
+  }
+}

--- a/src/canvas/utils/focusNeighbourhood.ts
+++ b/src/canvas/utils/focusNeighbourhood.ts
@@ -6,6 +6,12 @@
  * fit; the caller passes the matching node objects to ReactFlow's fitView with
  * a maxZoom cap so it never disorients.
  */
+
+import {
+  nodesComfortablyVisible,
+  type FocusCamera,
+  type SizedNodeLike,
+} from './cameraComfort'
 export function neighbourhoodNodeIds(
   nodeId: string,
   edges: ReadonlyArray<{ source: string; target: string }>,
@@ -16,4 +22,51 @@ export function neighbourhoodNodeIds(
     if (e.target === nodeId) ids.add(e.source)
   }
   return ids
+}
+
+/**
+ * computeFocusPlan — the single focus decision (F2 camera + F3 dim), pure so
+ * the contract is pinned in unit tests; ReactFlowGraph's handleFocusNode
+ * only applies the plan (select → dim → conditionally fit).
+ *
+ * - focusNodeIds: the target and its direct neighbours (the F2 fit set).
+ * - dimNodeIds: every node OUTSIDE the neighbourhood (the F3 transient dim,
+ *   written through the store field BaseNode's dim classes already consume).
+ * - moveCamera: false only when the whole neighbourhood is already
+ *   comfortably visible (cameraComfort's pinned no-churn rule); an
+ *   unmeasurable camera fails open to fitting.
+ *
+ * Returns null when the node is not on the canvas (fail-closed, same rule
+ * as focusExistingTarget).
+ */
+export function computeFocusPlan(
+  nodeId: string,
+  nodes: ReadonlyArray<SizedNodeLike & { id: string }>,
+  edges: ReadonlyArray<{ source: string; target: string }>,
+  camera: FocusCamera | null,
+): FocusPlan | null {
+  if (!nodes.some((n) => n.id === nodeId)) return null
+  const focusNodeIds = neighbourhoodNodeIds(nodeId, edges)
+  const dimNodeIds: string[] = []
+  const focusNodes: Array<SizedNodeLike & { id: string }> = []
+  for (const node of nodes) {
+    if (focusNodeIds.has(node.id)) focusNodes.push(node)
+    else dimNodeIds.push(node.id)
+  }
+  const moveCamera =
+    camera === null ||
+    !nodesComfortablyVisible(
+      focusNodes,
+      camera.viewport,
+      camera.paneWidth,
+      camera.paneHeight,
+      camera.insets,
+    )
+  return { focusNodeIds, dimNodeIds, moveCamera }
+}
+
+export interface FocusPlan {
+  focusNodeIds: Set<string>
+  dimNodeIds: string[]
+  moveCamera: boolean
 }


### PR DESCRIPTION
Lane G1 of the graph-visuals programme (Paul-ratified F1+F4+F2+F3). TDD: RED contracts first (8f1d3db), implementation to GREEN on top.

**Rescue provenance:** the original G1 agent was killed by a session limit mid-implementation; its partial GREEN (cameraComfort util, focusNeighbourhood plan, store dim seam, usePathHighlight focus-dim awareness) was rescued as WIP commit d707d44 and this PR resumes from there. Nothing was rebased; the rescue is built on, not rewritten.

## Per-item

### F1 — reduced-motion guard on EVERY camera move
- The three call sites that shipped past #274 unguarded now route through `cameraMotion.cameraDuration`: **CanvasToolbar's fit button** and **both `useValidationFeedback.focusError` setCenter calls** (node and edge-proxy paths).
- A new **source scan spec** walks every non-test `.ts/.tsx` under `src/canvas` and fails on any hardcoded non-zero `duration:` literal — the next unguarded site fails a test instead of a motion-sensitive user. Scan is clean; all other animated sites (ReactFlowGraph, useHighlightDispatch, useFitViewOnLayoutVersion) were already guarded.

### F4 — pulse flush fits every surviving target before the ring fires
- `appliedEditPulse.flush` is now the **single fit-before-pulse choke point** for every feeder: applyPatch's accept + auto-apply paths, applyV5State's graph_patch `applied`, mergeAppliedGraph, and the What-changed chip. The flush fits the full surviving union (node targets + pulsed edges' endpoint nodes) through the registered fit seam (`fitNodesOnCanvas` → ReactFlowGraph) **before** the highlight write; stale ids never reach the fit; an all-stale flush moves nothing; an unregistered seam no-ops and the pulse still fires.
- **What #289 already covered:** the chip's direct `fitNodesOnCanvas` call (user-initiated leg only). That direct fit is now **retired** — with the choke point in place it would double the camera move — and the chip delegates to `pulseAppliedTargets`. The applyPatch and applyV5State legs were NOT covered by #289 and are covered now via the choke point.
- The registered seam itself (ReactFlowGraph `handleFitNodes`) gained the no-churn guard: no camera move when every target is already comfortably visible.

### F2 — focus fits node + 1-hop neighbourhood at readable zoom, with the no-churn rule
- `handleFocusNode` applies the pure `computeFocusPlan` (select → dim → conditionally fit): fits the node and its direct neighbours at `padding 0.3, maxZoom 1.2`, F1-guarded duration.
- **No-churn rule (pinned in `cameraComfort.spec.ts`):** the camera must NOT move when every target rect is fully inside the panel-aware fit frame (pane inset by `computeFitPadding`, 8px slack for a just-fitted frame) at a readable zoom (>= 0.5). Anything less — off-screen, under an occluding panel, unreadably small — and it fits. Fail-open: an unmeasurable pane/viewport (jsdom, pre-mount) or empty target list is never "comfortable", so callers fall back to fitting.

### F3 — transient focus-mode dimming
- `setFocusDim(sourceId, ids)` / `clearFocusDim()` on the store; the dim flows through the existing `dimmedNodeIds` field BaseNode already consumes — **zero BaseNode edits** (read-only, as preferred).
- Lifecycle — the dim never survives focus end:
  - deselect / reselect another node → `usePathHighlight` clears it and resumes normal path dimming (focus dim owns `dimmedNodeIds` while active; path edges still highlight)
  - focused node removed by ANY path (delete, AI patch, wholesale replacement) → store-boundary subscription clears it
  - user-initiated pan/zoom → new `onMoveStart` handler clears it (ReactFlow passes `null` for programmatic moves, so focus's own fit never clears the dim it just set)
  - `clearFocusDim` is a no-op when no focus dim is active, so it can never clobber the selection path-dim
- No timer-based auto-clear was added: `usePathHighlight` has a pinned "no auto-clear on timer" contract and the RED contracts pin no dim timeout; the pan/blur/removal paths bound the dim's life to the focus itself.

## Tests
RED pins (8f1d3db) all GREEN:
- `cameraMotion.sourceScan.spec.ts` — 1 test
- `useValidationFeedback.cameraMotion.spec.ts` — 3
- `cameraComfort.spec.ts` — 14
- `focusNeighbourhood.spec.ts` — 11 (incl. computeFocusPlan dim + no-churn pins)
- `store.focusDim.spec.ts` — 6
- `usePathHighlight.spec.ts` — 19 (incl. 4 focus-dim interplay pins)
- `appliedEditPulse.spec.ts` — 13 (incl. 5 F4 fit-choke-point pins)
- `WhatChangedChip.spec.tsx` — 18 (chip delegation pin)

Neighbouring gates (targeted vitest, all green — 222 tests across 16 files + 6 across the ReactFlowGraph dom/integration files): `store.spec`, `store.selection.spec`, `store.initialState.spec`, `useGuidancePulseHighlight.spec`, `mergeAppliedGraph.spec`, `applyPatch.pulse.spec`, `autoApplyPatch.spec`, `applyV5State.pulse.test`, `ReactFlowGraph.layoutLifecycle.integration.spec`, `ReactFlowGraph.keyboard-run.telemetry.dom.spec`.

## Gates
- Targeted vitest: **228 passed, 0 failed** (suites above)
- `tsc -p tsconfig.ci.json --noEmit` (the `pnpm typecheck` config): **clean** (invoked via npx because the machine's near-full /tmp broke the pnpm wrapper's cwd helper, not tsc)

## Hang-skips / exclusions
- None hung. `ReactFlowGraph.layout.dom.spec.tsx` did not run because it is **already excluded in the repo's vitest config** (pre-existing exclusion alongside `canvas.run-gating.dom.spec.tsx` and `OutputsDock.dom.spec.tsx`) — not a skip introduced by this lane.

## Scope notes
- `useHighlightDispatch.panToNodes` untouched — already F1-guarded; no spec exercises the hook directly.
- Out-of-lane files untouched: StyledEdge (#324 in flight), FactorNode/MetricPills/DriversSection (#325 in flight), OutputsDock/AnalysisHeroPanel (C1 lane), results components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
