### PR TITLE
test(canvas): G3 edge legibility — E1/E2/E4 were already shipped; land the CVD validation E1 lacked

### DIFF
--- a/src/canvas/edges/__tests__/polarityContrast.spec.ts
+++ b/src/canvas/edges/__tests__/polarityContrast.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * E1 follow-up — the CVD validation the recolour shipped without.
+ *
+ * PR #282 titled itself "CVD-aware polarity edge recolour" and justified the
+ * rose negative with ΔE figures (99.7 from green, 66.9 from amber, 48.4 from
+ * the risk border, 27.6 for the old red). Those figures reproduce EXACTLY as
+ * CIE76 in NORMAL vision — no colour-vision deficiency was simulated, and no
+ * validator was ever committed, so nothing held the numbers in place.
+ *
+ * These pins measure what was actually claimed: separation as a dichromat sees
+ * it. They exist to keep the polarity palette honest, not to re-litigate the
+ * hues — the shipped values are Paul's call.
+ */
+import { describe, it, expect } from 'vitest'
+import { deltaE2000, deltaE76, POLARITY_POSITIVE, POLARITY_NEGATIVE } from '../cvdContrast'
+
+/** Below this, two strokes read as "more similar than different" to that viewer. */
+const CLEARLY_DISTINCT = 20
+
+describe('polarity edge colours — normal-vision ΔE (reproduces PR #282 prose)', () => {
+  it('reproduces the #282 CIE76 figure for green vs the shipped rose (99.7)', () => {
+    expect(deltaE76('#62B290', '#D6336C', 'normal')).toBeCloseTo(99.7, 0)
+  })
+
+  it('reproduces the #282 CIE76 figure for the old red vs the risk-node border (27.6)', () => {
+    expect(deltaE76('#ef4444', '#EA7B4B', 'normal')).toBeCloseTo(27.6, 0)
+  })
+
+  it('the shipped rose does clear the risk-node border in normal vision (#282 48.4)', () => {
+    expect(deltaE76('#D6336C', '#EA7B4B', 'normal')).toBeCloseTo(48.4, 0)
+  })
+})
+
+describe('polarity edge colours — CVD separation (what #282 never measured)', () => {
+  it("Paul's amber pair collapses under protanopia (ΔE2000 ~14.5, ΔL* ~1.7)", () => {
+    // #FFA656 was Paul's original E1 ruling for negative. Under protanopia it
+    // lands within ~2 L* of the green: two muddy tans of near-identical
+    // lightness. Recorded, not shipped — the palette shipped rose instead.
+    const d = deltaE2000('#62B290', '#FFA656', 'protan')
+    expect(d).toBeCloseTo(14.5, 0)
+    expect(d).toBeLessThan(CLEARLY_DISTINCT)
+  })
+
+  it('the SHIPPED rose pair collapses under deuteranopia (ΔE2000 ~12.2)', () => {
+    // Deuteranopia is the most common CVD. This is the shipped palette's
+    // worst case and it is worse than the amber it was chosen over.
+    const d = deltaE2000('#62B290', '#D6336C', 'deutan')
+    expect(d).toBeCloseTo(12.2, 0)
+    expect(d).toBeLessThan(CLEARLY_DISTINCT)
+  })
+
+  it('the OLD green/red pair separated BETTER under CVD than either new pair', () => {
+    // The regression is driven by lightness, not hue: the old green #a7f3d0
+    // sat at L* 90.3, the new #62B290 at L* 66.9. Dichromats lean on
+    // lightness, and 23 L* points of it were spent on the recolour.
+    const oldWorst = Math.min(
+      deltaE2000('#a7f3d0', '#ef4444', 'protan'),
+      deltaE2000('#a7f3d0', '#ef4444', 'deutan'),
+    )
+    const shippedWorst = Math.min(
+      deltaE2000('#62B290', '#D6336C', 'protan'),
+      deltaE2000('#62B290', '#D6336C', 'deutan'),
+    )
+    expect(oldWorst).toBeCloseTo(29.6, 0)
+    expect(shippedWorst).toBeCloseTo(12.2, 0)
+    expect(shippedWorst).toBeLessThan(oldWorst)
+  })
+
+  it('records the worst-case ranking across both red-green deficiencies', () => {
+    const worst = (a: string, b: string) =>
+      Math.min(deltaE2000(a, b, 'protan'), deltaE2000(a, b, 'deutan'))
+    // Amber (Paul's ruling) is marginally better worst-case than the shipped
+    // rose; both sit well under the old pair. Neither clears CLEARLY_DISTINCT.
+    expect(worst('#62B290', '#FFA656')).toBeCloseTo(14.5, 0)
+    expect(worst('#62B290', '#D6336C')).toBeCloseTo(12.2, 0)
+    expect(worst('#a7f3d0', '#ef4444')).toBeCloseTo(29.6, 0)
+  })
+
+  it('neither shipped polarity hue is safe on colour alone — the glyph is load-bearing', () => {
+    // The DS a11y rule (never colour alone) is not a nicety here: at ΔE2000 12
+    // the +/- glyph is the cue actually carrying polarity for a dichromat.
+    const worstShipped = Math.min(
+      deltaE2000(POLARITY_POSITIVE, POLARITY_NEGATIVE, 'protan'),
+      deltaE2000(POLARITY_POSITIVE, POLARITY_NEGATIVE, 'deutan'),
+    )
+    expect(worstShipped).toBeLessThan(CLEARLY_DISTINCT)
+  })
+})
+
+describe('cvdContrast validator — method sanity', () => {
+  it('simulates the textbook dichromat confusions', () => {
+    // Blue is untouched by red-green deficiency; identical colours are ΔE 0.
+    expect(deltaE2000('#0000ff', '#0000ff', 'protan')).toBe(0)
+    // Red loses far more luminance for a protan than a deutan (the defining
+    // difference between the two deficiencies).
+    expect(deltaE2000('#ff0000', '#000000', 'protan'))
+      .toBeLessThan(deltaE2000('#ff0000', '#000000', 'deutan'))
+  })
+
+  it('is symmetric and zero on identity', () => {
+    expect(deltaE2000('#62B290', '#62B290', 'normal')).toBe(0)
+    expect(deltaE2000('#62B290', '#D6336C', 'deutan'))
+      .toBeCloseTo(deltaE2000('#D6336C', '#62B290', 'deutan'), 6)
+  })
+})

--- a/src/canvas/edges/__tests__/polarityContrast.spec.ts
+++ b/src/canvas/edges/__tests__/polarityContrast.spec.ts
@@ -17,11 +17,20 @@ import {
   deltaE76,
   toLab,
   lightness,
-  POLARITY_POSITIVE,
-  POLARITY_NEGATIVE,
   RGB_TO_LMS,
   LMS_TO_RGB,
 } from '../cvdContrast'
+
+/**
+ * The shipped polarity strokes (light theme). These are deliberate PINNED
+ * COPIES of brand.css's --edge-positive/--edge-negative: cvdContrast is
+ * palette-agnostic and the DS ratchet forbids hex duplicates in production
+ * source, so the spec carries the values. If a palette ruling changes the
+ * tokens, update these AND re-derive every figure in this file — that is
+ * the point of the pins.
+ */
+const POLARITY_POSITIVE = '#62B290'
+const POLARITY_NEGATIVE = '#D6336C'
 
 /** Below this, two strokes read as "more similar than different" to that viewer. */
 const CLEARLY_DISTINCT = 20

--- a/src/canvas/edges/__tests__/polarityContrast.spec.ts
+++ b/src/canvas/edges/__tests__/polarityContrast.spec.ts
@@ -12,7 +12,14 @@
  * hues — the shipped values are Paul's call.
  */
 import { describe, it, expect } from 'vitest'
-import { deltaE2000, deltaE76, POLARITY_POSITIVE, POLARITY_NEGATIVE } from '../cvdContrast'
+import {
+  deltaE2000,
+  deltaE76,
+  POLARITY_POSITIVE,
+  POLARITY_NEGATIVE,
+  RGB_TO_LMS,
+  LMS_TO_RGB,
+} from '../cvdContrast'
 
 /** Below this, two strokes read as "more similar than different" to that viewer. */
 const CLEARLY_DISTINCT = 20
@@ -32,20 +39,20 @@ describe('polarity edge colours — normal-vision ΔE (reproduces PR #282 prose)
 })
 
 describe('polarity edge colours — CVD separation (what #282 never measured)', () => {
-  it("Paul's amber pair collapses under protanopia (ΔE2000 ~14.5, ΔL* ~1.7)", () => {
+  it("Paul's amber pair collapses under protanopia (ΔE2000 ~13.8, ΔL* ~1.8)", () => {
     // #FFA656 was Paul's original E1 ruling for negative. Under protanopia it
     // lands within ~2 L* of the green: two muddy tans of near-identical
     // lightness. Recorded, not shipped — the palette shipped rose instead.
     const d = deltaE2000('#62B290', '#FFA656', 'protan')
-    expect(d).toBeCloseTo(14.5, 0)
+    expect(d).toBeCloseTo(13.8, 0)
     expect(d).toBeLessThan(CLEARLY_DISTINCT)
   })
 
-  it('the SHIPPED rose pair collapses under deuteranopia (ΔE2000 ~12.2)', () => {
+  it('the SHIPPED rose pair collapses under deuteranopia (ΔE2000 ~11.7)', () => {
     // Deuteranopia is the most common CVD. This is the shipped palette's
     // worst case and it is worse than the amber it was chosen over.
     const d = deltaE2000('#62B290', '#D6336C', 'deutan')
-    expect(d).toBeCloseTo(12.2, 0)
+    expect(d).toBeCloseTo(11.7, 0)
     expect(d).toBeLessThan(CLEARLY_DISTINCT)
   })
 
@@ -61,8 +68,8 @@ describe('polarity edge colours — CVD separation (what #282 never measured)', 
       deltaE2000('#62B290', '#D6336C', 'protan'),
       deltaE2000('#62B290', '#D6336C', 'deutan'),
     )
-    expect(oldWorst).toBeCloseTo(29.6, 0)
-    expect(shippedWorst).toBeCloseTo(12.2, 0)
+    expect(oldWorst).toBeCloseTo(28.3, 0)
+    expect(shippedWorst).toBeCloseTo(11.7, 0)
     expect(shippedWorst).toBeLessThan(oldWorst)
   })
 
@@ -71,9 +78,9 @@ describe('polarity edge colours — CVD separation (what #282 never measured)', 
       Math.min(deltaE2000(a, b, 'protan'), deltaE2000(a, b, 'deutan'))
     // Amber (Paul's ruling) is marginally better worst-case than the shipped
     // rose; both sit well under the old pair. Neither clears CLEARLY_DISTINCT.
-    expect(worst('#62B290', '#FFA656')).toBeCloseTo(14.5, 0)
-    expect(worst('#62B290', '#D6336C')).toBeCloseTo(12.2, 0)
-    expect(worst('#a7f3d0', '#ef4444')).toBeCloseTo(29.6, 0)
+    expect(worst('#62B290', '#FFA656')).toBeCloseTo(13.8, 0)
+    expect(worst('#62B290', '#D6336C')).toBeCloseTo(11.7, 0)
+    expect(worst('#a7f3d0', '#ef4444')).toBeCloseTo(28.3, 0)
   })
 
   it('neither shipped polarity hue is safe on colour alone — the glyph is load-bearing', () => {
@@ -88,6 +95,29 @@ describe('polarity edge colours — CVD separation (what #282 never measured)', 
 })
 
 describe('cvdContrast validator — method sanity', () => {
+  it('LMS_TO_RGB is the inverse of RGB_TO_LMS (RGB→LMS→RGB round-trips)', () => {
+    // The simulation is RGB → LMS → projection → RGB, so LMS_TO_RGB must be
+    // the true matrix inverse or every ΔE this module reports is biased.
+    // This is not hypothetical: the first cut shipped [1][0] mistranscribed
+    // as -0.011248 (true value -0.0102485335), which put ~4.9e-2 of error
+    // into linear G on every round-trip and moved the headline figures by
+    // 0.5–1.3 ΔE (12.2→11.7, 14.5→13.8, 29.6→28.3).
+    //
+    // Tolerance: the published Viénot coefficients are quoted to ~6
+    // significant figures, so the product deviates from identity by ~1.4e-5,
+    // not machine epsilon. 1e-4 gives 7x headroom over that quotation noise
+    // while sitting 400x below the 4.4e-2 deviation of the transcription bug.
+    for (let i = 0; i < 3; i++) {
+      for (let j = 0; j < 3; j++) {
+        const product =
+          LMS_TO_RGB[i][0] * RGB_TO_LMS[0][j] +
+          LMS_TO_RGB[i][1] * RGB_TO_LMS[1][j] +
+          LMS_TO_RGB[i][2] * RGB_TO_LMS[2][j]
+        expect(Math.abs(product - (i === j ? 1 : 0))).toBeLessThan(1e-4)
+      }
+    }
+  })
+
   it('simulates the textbook dichromat confusions', () => {
     // Blue is untouched by red-green deficiency; identical colours are ΔE 0.
     expect(deltaE2000('#0000ff', '#0000ff', 'protan')).toBe(0)

--- a/src/canvas/edges/__tests__/polarityContrast.spec.ts
+++ b/src/canvas/edges/__tests__/polarityContrast.spec.ts
@@ -15,6 +15,8 @@ import { describe, it, expect } from 'vitest'
 import {
   deltaE2000,
   deltaE76,
+  toLab,
+  lightness,
   POLARITY_POSITIVE,
   POLARITY_NEGATIVE,
   RGB_TO_LMS,
@@ -131,5 +133,18 @@ describe('cvdContrast validator — method sanity', () => {
     expect(deltaE2000('#62B290', '#62B290', 'normal')).toBe(0)
     expect(deltaE2000('#62B290', '#D6336C', 'deutan'))
       .toBeCloseTo(deltaE2000('#D6336C', '#62B290', 'deutan'), 6)
+  })
+
+  it('REFUSES tritan simulation instead of returning invalid figures', () => {
+    // The Viénot 1999 single-plane projection is protan/deutan-only;
+    // tritanopia needs Brettel 1997's two-plane method. An earlier cut
+    // carried a single-plane "tritan" matrix and would happily return an
+    // authoritative-looking ΔE (66.8 for the shipped pair) that no method
+    // stood behind. Unsupported must stay LOUD — a silent number here would
+    // feed a palette ruling.
+    expect(() => deltaE2000('#62B290', '#D6336C', 'tritan')).toThrow(/tritan/i)
+    expect(() => deltaE76('#62B290', '#D6336C', 'tritan')).toThrow(/tritan/i)
+    expect(() => toLab('#62B290', 'tritan')).toThrow(/tritan/i)
+    expect(() => lightness('#62B290', 'tritan')).toThrow(/tritan/i)
   })
 })

--- a/src/canvas/edges/cvdContrast.ts
+++ b/src/canvas/edges/cvdContrast.ts
@@ -36,9 +36,14 @@ export type VisionType = 'normal' | 'protan' | 'deutan' | 'tritan'
 type Vec3 = [number, number, number]
 type Mat3 = [Vec3, Vec3, Vec3]
 
-/** The shipped polarity strokes (light theme) — see directionStroke.ts. */
-export const POLARITY_POSITIVE = '#62B290'
-export const POLARITY_NEGATIVE = '#D6336C'
+/*
+ * This module is palette-agnostic on purpose: it measures whatever hexes it
+ * is handed. The shipped polarity VALUES live in brand.css
+ * (--edge-positive/--edge-negative; rule in directionStroke.ts) and the
+ * DS ratchet forbids duplicating them into production source — the pinned
+ * copies live in polarityContrast.spec, which is where a value change
+ * should fail first anyway.
+ */
 
 /** Exported only for the inverse-identity pin in polarityContrast.spec. */
 export const RGB_TO_LMS: Mat3 = [

--- a/src/canvas/edges/cvdContrast.ts
+++ b/src/canvas/edges/cvdContrast.ts
@@ -29,15 +29,25 @@ type Mat3 = [Vec3, Vec3, Vec3]
 export const POLARITY_POSITIVE = '#62B290'
 export const POLARITY_NEGATIVE = '#D6336C'
 
-const RGB_TO_LMS: Mat3 = [
+/** Exported only for the inverse-identity pin in polarityContrast.spec. */
+export const RGB_TO_LMS: Mat3 = [
   [17.8824, 43.5161, 4.11935],
   [3.45565, 27.1554, 3.86714],
   [0.0299566, 0.184309, 1.46709],
 ]
 
-const LMS_TO_RGB: Mat3 = [
+/**
+ * MUST be the matrix inverse of RGB_TO_LMS — the simulation is
+ * RGB → LMS → (projection) → RGB, and any drift here biases every ΔE this
+ * module reports. The first cut of this file shipped [1][0] as -0.011248
+ * (a mistranscription, 9.75% off the true -0.0102485335); the round-trip
+ * error that introduced was ~4.9e-2 in linear G — enough to move the
+ * headline figures by ~0.5–1.3 ΔE. The inverse-identity test in
+ * polarityContrast.spec pins this permanently.
+ */
+export const LMS_TO_RGB: Mat3 = [
   [0.080944, -0.130504, 0.116721],
-  [-0.011248, 0.0540193, -0.113615],
+  [-0.0102485335, 0.0540193266, -0.113614708],
   [-0.000365, -0.0041216, 0.693513],
 ]
 

--- a/src/canvas/edges/cvdContrast.ts
+++ b/src/canvas/edges/cvdContrast.ts
@@ -1,0 +1,181 @@
+/**
+ * cvdContrast — colour-vision-deficiency separation for the canvas palette.
+ *
+ * Why this exists: E1 (#282) shipped a "CVD-aware" polarity recolour whose ΔE
+ * figures were quoted in a prose comment with no tooling behind them. They
+ * reproduce exactly as CIE76 in NORMAL vision — the deficiency was never
+ * simulated. This module makes such claims reproducible and regression-pinned,
+ * so a future palette decision can be measured rather than asserted.
+ *
+ * Method (the standard one, no dependencies):
+ *  1. sRGB → linear RGB
+ *  2. linear RGB → LMS cone response (Viénot, Brettel & Mollon 1999)
+ *  3. project onto the dichromat's surviving plane (protan/deutan/tritan)
+ *  4. back to linear RGB → CIEXYZ (D65) → CIELAB
+ *  5. ΔE between the two simulated Labs — CIEDE2000 by default, CIE76 available
+ *     because that is what the earlier figures were computed with.
+ *
+ * Reading the numbers: ΔE2000 under ~10 means two strokes read as more similar
+ * than different to that viewer; the +/- glyph, not the hue, is then carrying
+ * the meaning. That is precisely why the DS forbids colour as the only cue.
+ */
+
+export type VisionType = 'normal' | 'protan' | 'deutan' | 'tritan'
+
+type Vec3 = [number, number, number]
+type Mat3 = [Vec3, Vec3, Vec3]
+
+/** The shipped polarity strokes (light theme) — see directionStroke.ts. */
+export const POLARITY_POSITIVE = '#62B290'
+export const POLARITY_NEGATIVE = '#D6336C'
+
+const RGB_TO_LMS: Mat3 = [
+  [17.8824, 43.5161, 4.11935],
+  [3.45565, 27.1554, 3.86714],
+  [0.0299566, 0.184309, 1.46709],
+]
+
+const LMS_TO_RGB: Mat3 = [
+  [0.080944, -0.130504, 0.116721],
+  [-0.011248, 0.0540193, -0.113615],
+  [-0.000365, -0.0041216, 0.693513],
+]
+
+/** Each dichromat loses one cone; the surviving two reconstruct the lost signal. */
+const DICHROMAT_PROJECTION: Record<Exclude<VisionType, 'normal'>, Mat3> = {
+  protan: [[0, 2.02344, -2.52581], [0, 1, 0], [0, 0, 1]],
+  deutan: [[1, 0, 0], [0.494207, 0, 1.24827], [0, 0, 1]],
+  tritan: [[1, 0, 0], [0, 1, 0], [-0.395913, 0.801109, 0]],
+}
+
+const LINEAR_RGB_TO_XYZ: Mat3 = [
+  [0.4124564, 0.3575761, 0.1804375],
+  [0.2126729, 0.7151522, 0.0721750],
+  [0.0193339, 0.1191920, 0.9503041],
+]
+
+/** D65 white point. */
+const WHITE: Vec3 = [0.95047, 1.0, 1.08883]
+
+const multiply = (m: Mat3, v: Vec3): Vec3 => [
+  m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+  m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+  m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+]
+
+const clamp01 = (c: number) => Math.min(1, Math.max(0, c))
+
+function hexToRgb(hex: string): Vec3 {
+  const s = hex.replace('#', '').trim()
+  if (!/^[0-9a-fA-F]{6}$/.test(s)) {
+    throw new Error(`cvdContrast: expected a 6-digit hex colour, got "${hex}"`)
+  }
+  return [0, 2, 4].map(i => parseInt(s.slice(i, i + 2), 16) / 255) as Vec3
+}
+
+const srgbToLinear = (c: number) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4))
+
+/** Linear-RGB as the given viewer's cones report it. */
+function simulate(hex: string, vision: VisionType): Vec3 {
+  const linear = hexToRgb(hex).map(srgbToLinear) as Vec3
+  if (vision === 'normal') return linear
+  const lms = multiply(RGB_TO_LMS, linear)
+  const projected = multiply(DICHROMAT_PROJECTION[vision], lms)
+  return multiply(LMS_TO_RGB, projected)
+}
+
+function linearRgbToLab(linear: Vec3): Vec3 {
+  const xyz = multiply(LINEAR_RGB_TO_XYZ, linear.map(clamp01) as Vec3)
+  const f = (t: number) => (t > 216 / 24389 ? Math.cbrt(t) : (841 / 108) * t + 4 / 29)
+  const [fx, fy, fz] = [f(xyz[0] / WHITE[0]), f(xyz[1] / WHITE[1]), f(xyz[2] / WHITE[2])]
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)]
+}
+
+/** CIELAB for a colour as the given viewer perceives it. */
+export function toLab(hex: string, vision: VisionType = 'normal'): Vec3 {
+  return linearRgbToLab(simulate(hex, vision))
+}
+
+/** CIELAB lightness (L*) — the channel dichromats lean on most. */
+export function lightness(hex: string, vision: VisionType = 'normal'): number {
+  return toLab(hex, vision)[0]
+}
+
+/** CIE76 ΔE: plain Euclidean distance in Lab. Superseded, but it is what the #282 figures used. */
+export function deltaE76(a: string, b: string, vision: VisionType = 'normal'): number {
+  const [l1, a1, b1] = toLab(a, vision)
+  const [l2, a2, b2] = toLab(b, vision)
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2)
+}
+
+/** CIEDE2000 ΔE: the current standard, perceptually weighted. */
+export function deltaE2000(a: string, b: string, vision: VisionType = 'normal'): number {
+  const [L1, a1, b1] = toLab(a, vision)
+  const [L2, a2, b2] = toLab(b, vision)
+  const RAD = Math.PI / 180
+  const DEG = 180 / Math.PI
+
+  const C1 = Math.hypot(a1, b1)
+  const C2 = Math.hypot(a2, b2)
+  const cBar = (C1 + C2) / 2
+  const cBar7 = Math.pow(cBar, 7)
+  const G = 0.5 * (1 - Math.sqrt(cBar7 / (cBar7 + Math.pow(25, 7))))
+
+  const ap1 = (1 + G) * a1
+  const ap2 = (1 + G) * a2
+  const Cp1 = Math.hypot(ap1, b1)
+  const Cp2 = Math.hypot(ap2, b2)
+
+  const hue = (b: number, ap: number) => {
+    if (b === 0 && ap === 0) return 0
+    const h = Math.atan2(b, ap) * DEG
+    return h < 0 ? h + 360 : h
+  }
+  const hp1 = hue(b1, ap1)
+  const hp2 = hue(b2, ap2)
+
+  const dLp = L2 - L1
+  const dCp = Cp2 - Cp1
+  let dhp = 0
+  if (Cp1 * Cp2 !== 0) {
+    dhp = hp2 - hp1
+    if (dhp > 180) dhp -= 360
+    else if (dhp < -180) dhp += 360
+  }
+  const dHp = 2 * Math.sqrt(Cp1 * Cp2) * Math.sin((dhp * RAD) / 2)
+
+  const LBar = (L1 + L2) / 2
+  const CBar = (Cp1 + Cp2) / 2
+  let hBar = hp1 + hp2
+  if (Cp1 * Cp2 !== 0) {
+    if (Math.abs(hp1 - hp2) > 180) hBar = hp1 + hp2 < 360 ? hBar + 360 : hBar - 360
+    hBar /= 2
+  }
+
+  const T =
+    1 -
+    0.17 * Math.cos((hBar - 30) * RAD) +
+    0.24 * Math.cos(2 * hBar * RAD) +
+    0.32 * Math.cos((3 * hBar + 6) * RAD) -
+    0.2 * Math.cos((4 * hBar - 63) * RAD)
+
+  const dTheta = 30 * Math.exp(-Math.pow((hBar - 275) / 25, 2))
+  const CBar7 = Math.pow(CBar, 7)
+  const Rc = 2 * Math.sqrt(CBar7 / (CBar7 + Math.pow(25, 7)))
+  const Sl = 1 + (0.015 * Math.pow(LBar - 50, 2)) / Math.sqrt(20 + Math.pow(LBar - 50, 2))
+  const Sc = 1 + 0.045 * CBar
+  const Sh = 1 + 0.015 * CBar * T
+  const Rt = -Math.sin(2 * dTheta * RAD) * Rc
+
+  return Math.sqrt(
+    Math.pow(dLp / Sl, 2) +
+      Math.pow(dCp / Sc, 2) +
+      Math.pow(dHp / Sh, 2) +
+      Rt * (dCp / Sc) * (dHp / Sh),
+  )
+}
+
+/** Worst-case separation across both red-green deficiencies (the ones that hit polarity). */
+export function worstCaseRedGreenSeparation(a: string, b: string): number {
+  return Math.min(deltaE2000(a, b, 'protan'), deltaE2000(a, b, 'deutan'))
+}

--- a/src/canvas/edges/cvdContrast.ts
+++ b/src/canvas/edges/cvdContrast.ts
@@ -10,7 +10,10 @@
  * Method (the standard one, no dependencies):
  *  1. sRGB → linear RGB
  *  2. linear RGB → LMS cone response (Viénot, Brettel & Mollon 1999)
- *  3. project onto the dichromat's surviving plane (protan/deutan/tritan)
+ *  3. project onto the dichromat's surviving plane (protan/deutan ONLY —
+ *     the Viénot 1999 single-plane reduction is derived for the two
+ *     red-green dichromacies; tritanopia needs the two-plane method of
+ *     Brettel, Viénot & Mollon 1997 and is NOT simulated here, see below)
  *  4. back to linear RGB → CIEXYZ (D65) → CIELAB
  *  5. ΔE between the two simulated Labs — CIEDE2000 by default, CIE76 available
  *     because that is what the earlier figures were computed with.
@@ -20,6 +23,14 @@
  * the meaning. That is precisely why the DS forbids colour as the only cue.
  */
 
+/**
+ * 'tritan' is accepted by the type so callers can name it, but every public
+ * function THROWS for it — see the guard in simulate(). An earlier cut of
+ * this file carried a single-plane "tritan" matrix and returned
+ * authoritative-looking ΔE figures from it; that construction is only valid
+ * for protan/deutan, so the numbers were garbage. Unsupported is the honest
+ * answer until a Brettel-1997 two-plane implementation exists.
+ */
 export type VisionType = 'normal' | 'protan' | 'deutan' | 'tritan'
 
 type Vec3 = [number, number, number]
@@ -51,11 +62,16 @@ export const LMS_TO_RGB: Mat3 = [
   [-0.000365, -0.0041216, 0.693513],
 ]
 
-/** Each dichromat loses one cone; the surviving two reconstruct the lost signal. */
-const DICHROMAT_PROJECTION: Record<Exclude<VisionType, 'normal'>, Mat3> = {
+/**
+ * Each dichromat loses one cone; the surviving two reconstruct the lost
+ * signal. Viénot 1999's single-plane reduction covers exactly these two
+ * deficiencies. There is deliberately NO tritan row: the single-plane tritan
+ * matrix that circulates alongside these is not from that paper and is not
+ * methodologically valid (S-cone loss needs Brettel 1997's two half-planes).
+ */
+const DICHROMAT_PROJECTION: Record<'protan' | 'deutan', Mat3> = {
   protan: [[0, 2.02344, -2.52581], [0, 1, 0], [0, 0, 1]],
   deutan: [[1, 0, 0], [0.494207, 0, 1.24827], [0, 0, 1]],
-  tritan: [[1, 0, 0], [0, 1, 0], [-0.395913, 0.801109, 0]],
 }
 
 const LINEAR_RGB_TO_XYZ: Mat3 = [
@@ -87,6 +103,16 @@ const srgbToLinear = (c: number) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.
 
 /** Linear-RGB as the given viewer's cones report it. */
 function simulate(hex: string, vision: VisionType): Vec3 {
+  if (vision === 'tritan') {
+    throw new Error(
+      'cvdContrast: tritan simulation is not supported. The Viénot/Brettel/' +
+        'Mollon (1999) single-plane projection this module implements is ' +
+        'derived for protanopia and deuteranopia only; tritanopia requires ' +
+        'the two-plane method of Brettel, Viénot & Mollon (1997). A single-' +
+        'plane "tritan" matrix produces authoritative-looking but invalid ΔE ' +
+        'figures, so this module refuses rather than mislead.',
+    )
+  }
   const linear = hexToRgb(hex).map(srgbToLinear) as Vec3
   if (vision === 'normal') return linear
   const lms = multiply(RGB_TO_LMS, linear)

--- a/src/canvas/edges/directionStroke.ts
+++ b/src/canvas/edges/directionStroke.ts
@@ -22,9 +22,9 @@
  * "CVD-aware" when it shipped, but no deficiency was ever simulated; the
  * later measurement (cvdContrast.ts, polarityContrast.spec) found the pair
  * separates WORSE for a dichromat than the green/red it replaced — ΔE2000
- * 12.2 under deuteranopia versus the old pair's 29.6. The cause is lightness,
+ * 11.7 under deuteranopia versus the old pair's 28.3. The cause is lightness,
  * not hue: the old green sat at L* 90.3, this one at L* 66.9. Paul's amber
- * would have been no better (14.5 under protanopia). The hues stand — they
+ * would have been no better (13.8 under protanopia). The hues stand — they
  * are Paul's ruling — but the +/− glyph, not the colour, is what carries
  * polarity for a red-green dichromat here. Do not remove it, and do not let
  * a future change lean on these hues alone.

--- a/src/canvas/edges/directionStroke.ts
+++ b/src/canvas/edges/directionStroke.ts
@@ -5,19 +5,33 @@
  * spec previously kept a hand-copied duplicate that had to be edited in
  * lockstep).
  *
- * E1 (graph-visuals 2026-07-11) — CVD-aware polarity palette. The +/− glyph is
- * the second cue; these hues are the primary. Positive → the #62B290 green
- * Paul selected. Negative → rose #D6336C, chosen over the pack's amber #FFA656
- * (Paul's C2 ruling reserves amber for the warning/fragility family). ΔE-
- * validated: rose sits ΔE 99.7 from the positive green, 66.9 from the amber
- * warning family, and 48.4 from the risk-node border (#EA7B4B) — the old
- * #ef4444 negative was only ΔE 27.6 from that border, the collision this
- * fixes. Dark negative is likewise distinct from the dark risk border.
+ * E1 (graph-visuals 2026-07-11) — polarity palette. The +/− glyph is the
+ * second cue; these hues are the primary. Positive → the #62B290 green Paul
+ * selected. Negative → rose #D6336C, chosen over the pack's amber #FFA656
+ * (Paul's C2 ruling reserves amber for the warning/fragility family).
  * The hue VALUES live in brand.css (--edge-positive/--edge-negative/
- * --edge-neutral + -dark variants) with the full ΔE rationale — this module
- * owns the RULE, the token file owns the colours. Yellow (var(--goal)) stays reserved for truly uninitialised
- * edges (no direction AND no weight); grey for weight-set-but-no-direction and
- * for the neutral weight === 0 choice.
+ * --edge-neutral + -dark variants) — this module owns the RULE, the token
+ * file owns the colours.
+ *
+ * Separation in NORMAL vision (CIE76): rose sits ΔE 99.7 from the positive
+ * green, 66.9 from the amber warning family, and 48.4 from the risk-node
+ * border (#EA7B4B) — the old #ef4444 negative was only ΔE 27.6 from that
+ * border, the collision this fixes.
+ *
+ * Those figures are normal-vision only. This palette was described as
+ * "CVD-aware" when it shipped, but no deficiency was ever simulated; the
+ * later measurement (cvdContrast.ts, polarityContrast.spec) found the pair
+ * separates WORSE for a dichromat than the green/red it replaced — ΔE2000
+ * 12.2 under deuteranopia versus the old pair's 29.6. The cause is lightness,
+ * not hue: the old green sat at L* 90.3, this one at L* 66.9. Paul's amber
+ * would have been no better (14.5 under protanopia). The hues stand — they
+ * are Paul's ruling — but the +/− glyph, not the colour, is what carries
+ * polarity for a red-green dichromat here. Do not remove it, and do not let
+ * a future change lean on these hues alone.
+ *
+ * Yellow (var(--goal)) stays reserved for truly uninitialised edges (no
+ * direction AND no weight); grey for weight-set-but-no-direction and for the
+ * neutral weight === 0 choice.
  */
 export function computeDirectionStroke(
   direction: 'positive' | 'negative' | undefined,

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -97,14 +97,18 @@
      ============================================ */
 
   /* Goal (Yellow) - Primary actions */
-  /* Causal-edge polarity (E1, 2026-07-11 — Paul-selected, CVD-aware).
+  /* Causal-edge polarity (E1, 2026-07-11 — Paul-selected).
      Rose over amber for negative: amber is reserved for the warning/fragility
-     family (C2 ruling). ΔE-validated: rose sits 99.7 from the positive green,
-     66.9 from amber, 48.4 from the risk border #EA7B4B — the old #ef4444
-     negative sat at 27.6, the collision E1 fixed. Dark negative clears the
-     dark risk border #FF6B6B. Yellow (--goal) stays reserved for truly
-     uninitialised edges; neutral grey for weight-set-but-no-direction and
-     the deliberate weight=0 choice. */
+     family (C2 ruling). ΔE-validated in NORMAL vision (CIE76): rose sits 99.7
+     from the positive green, 66.9 from amber, 48.4 from the risk border
+     #EA7B4B — the old #ef4444 negative sat at 27.6, the collision E1 fixed.
+     Dark negative clears the dark risk border #FF6B6B. NOT CVD-validated:
+     the later measurement (cvdContrast.ts, polarityContrast.spec) found this
+     pair separates WORSE for a red-green dichromat than the green/red it
+     replaced (ΔE2000 11.7 vs 28.3 worst-case) — the +/− glyph, not the hue,
+     carries polarity for those viewers. Yellow (--goal) stays reserved for
+     truly uninitialised edges; neutral grey for weight-set-but-no-direction
+     and the deliberate weight=0 choice. */
   --edge-positive: #62B290;
   --edge-negative: #D6336C;
   --edge-neutral: #D4D4D8;


### PR DESCRIPTION
## Review fold (16 Jul) — what changed since first review

Adversarial review of this PR found one real defect in the validator itself, and it is disclosed here rather than buried: **the first cut's `LMS_TO_RGB` was not the true inverse of `RGB_TO_LMS`** — element [1][0] was mistranscribed as `-0.011248` (true value `-0.0102485335`, 9.75% off), which biased every CVD ΔE this PR originally quoted by ~0.5–1.3. Proof was the round-trip: RGB→LMS→RGB carried ~4.9e-2 of error in linear G; with the true inverse it is float noise. Fixed in `f1e25b92` with the spec re-pinned to the corrected figures **in the same commit** (the old pins encoded the buggy matrix's outputs), plus a permanent inverse-identity pin so the matrix can never silently drift again. Mutation-checked: restoring the old coefficient sends the identity pin and all four figure pins RED.

**Every corrected figure is below. Ranking and the headline conclusion are unchanged** (shipped < amber < old; the ~17 ΔE gap dwarfs the ~1.3 correction).

Also from the review:

- **Tritan simulation now refuses loudly** (`f4724249`). The Viénot/Brettel/Mollon (1999) single-plane projection is derived for protanopia/deuteranopia only; the "tritan" matrix the first cut carried is not from that paper and is not methodologically valid (S-cone loss needs Brettel 1997's two half-planes) — yet it returned an authoritative-looking ΔE (66.8) that no method stood behind. All four public entry points now throw for `'tritan'` (the codebase's unsupported-path idiom), pinned by test, and the misattribution comment is corrected.
- **Rebased onto staging** `bf921314` (was 17 commits behind; `directionStroke.ts` had a real conflict with #348's token migration — resolved keeping #348's `--edge-*` token code AND this branch's comment correction). `git merge-tree` against current `origin/staging` is clean.
- brand.css:100's edge-token comment (added by #348 from the pre-correction prose) still said "CVD-aware"; corrected to record the normal-vision scope of the CIE76 figures and the measured CVD numbers. Comments only — **no token value changes anywhere in this PR**.
- The DS drift gate (enforced since #348) correctly flagged the module's `POLARITY_*` hex constants as net-new production-hex duplicates of the brand.css tokens; moved into the spec, their only consumer (`9ac9143e`). `validate-prepush.sh`: ALL CHECKS PASSED.

## Re-verification first: all three items were already shipped

The G3 brief's grounding was from 10 Jul. Re-verified every line against `origin/staging` before writing code. **All three items are merged.** No feature code was duplicated.

| Item | Status on staging | Merged as |
|---|---|---|
| E1 polarity recolour | **Shipped** (with a deviation, see below) | `c2eb4bcc` (#282) |
| E2 key labels in default view | **Shipped, and correct** | `d25e340e` (#276) |
| E4 fragility on canvas | **Shipped, and fails closed correctly** | `a2255511` (#277) |

Verification detail:

- **E2** — `edgeLabelVisibility.ts` implements exactly the briefed rule: `isTopStrengthEdge` short-circuits to `true` in **either** view once results exist; interaction triggers stay Detailed-only; no results or structural connection returns `false`. The brief's perf concern (are E2's labels exactly the resolver's gated set?) **is satisfied**: `StyledEdge.tsx` gates the collision resolver on `isTopStrengthEdge` and feeds the same flag into `shouldShowEdgeLabel`. Same set, one flag. No gate extension needed.
- **E4** — `fragileEdgeMatch.ts` / `StyledEdge.tsx`. Both absence pins from #326 hold: `report.robustness.fragile_edges || []` means an **absent** field yields `[]` yields no badge (fails closed), and a computed `[]` also renders nothing. `!report?.robustness` returns `false` earlier still. Badge copy is producer-backed, using the recorded `switch_probability`, no invented threshold.

## E1 shipped a different colour than the brief specified, and the reason is sound

The brief carried Paul's ruling that negative goes to amber `#FFA656`. **Staging ships rose `#D6336C`.** This is not drift: #282 cites Paul's later **C2 ruling**, which reserves amber for the warning/fragility family. That is exactly the orange-collision risk the brief asked me to check, and a predecessor resolved it upstream by avoiding the collision entirely.

**Orange-collision verdict: moot, and correctly so.** Negative connections are rose, so the "orange means negative *and* edited *and* fragile" three-way collision never arises. Amber now carries one meaning. No on-canvas check was needed to clear it.

## The CVD validation: E1 claimed it, but it never happened

The brief asked me to find the palette validator and run Paul's pair through the same method. **There is no validator in the repo.** The only `protan`/`ΔE`/CVD strings on staging were prose comments. #282's figures had no tooling and no test behind them.

They are also **not CVD figures**. I reproduced all four of them **exactly** as **CIE76 in normal vision** (99.7, 66.9, 48.4, 27.6). The commit titled itself "CVD-aware" and no deficiency was ever simulated. Exact reproduction also cross-validates the Lab pipeline.

So I built the validator (`cvdContrast.ts`: Viénot/Brettel/Mollon 1999 cone projection for protan/deutan, CIEDE2000 + CIE76, CIELAB D65, no dependencies) and measured. Sanity-checked against textbook expectations before trusting it: red goes dark olive under protan and brighter yellow under deutan, green goes yellow under both, blue is untouched, grey stays neutral.

### The numbers (CIEDE2000, corrected matrix; worst case is the lower of protan/deutan)

| Pair | normal | protan | deutan | **worst case** |
|---|---|---|---|---|
| **Shipped** green `#62B290` vs rose `#D6336C` | 67.1 | 37.1 | **11.7** | **11.7** |
| **Paul's** green `#62B290` vs amber `#FFA656` | 42.3 | **13.8** | 22.6 | **13.8** |
| **Old** green `#a7f3d0` vs red `#ef4444` | 65.0 | 38.2 | **28.3** | **28.3** |

### What this means

1. **The brief's premise is false.** Green-vs-orange does **not** separate better than the old green-vs-red. It is worse: 13.8 against 28.3.
2. **The shipped palette is the weakest of the three** under the most common deficiency: **ΔE2000 11.7 under deuteranopia**, against the old pair's 28.3. The recolour **cost** CVD polarity separation.
3. **The hue swap is not the cause. Lightness is.** The old green sat at **L\* 90.3**; `#62B290` sits at **L\* 66.9**. Dichromats lean on lightness and 23 L\* points of it were spent. Under protanopia Paul's amber lands **ΔL\* 1.8** from the green: two muddy tans (`#abab90` vs `#b3b357`).
4. **Both candidate negatives fail**, so this was never a rose-vs-amber question. Rose was picked for a real reason (the C2 amber reservation) and is marginally worse than amber on worst case but better on protan. The choice between them is close to noise next to the green.
5. **The `+`/`−` glyph is load-bearing, not a nicety.** At ΔE2000 11.7 it is the cue actually carrying polarity for a red-green dichromat. It is retained, and both the code comment and a test now say so. **Anything that drops it regresses accessibility outright.**

## For Paul's ruling: this is a TWO-axis trade, not a one-axis regression

The CVD numbers above are one axis. Judged alone they read "revert toward the old lighter green". **Do not rule on that axis alone** — the old green fails a different, decisive test:

**Axis 1 — CVD polarity separation** (green vs negative, worst-case ΔE2000): old pair **28.3**, shipped pair **11.7**. The old, lighter green wins this axis.

**Axis 2 — visibility against the canvas itself** (the canvas is `#F4F0EA`, brand.css — not white). WCAG 1.4.11 asks 3:1 for non-text graphics:

| Stroke | vs canvas `#F4F0EA` (normal) | (protan-simulated) |
|---|---|---|
| Old green `#a7f3d0` | **1.13:1 — effectively invisible, hard 1.4.11 fail** | 1.05:1 |
| Shipped green `#62B290` | **2.23:1** (below 3:1, but clearly visible) | 2.05:1 |
| Old red `#ef4444` | 3.31:1 | — |
| Shipped rose `#D6336C` | 4.07:1 | — |

The shipped darker green wins this axis, by a wider margin than it loses axis 1: **reverting to the L\* 90 green would restore a stroke a normal-vision user can barely see at all**, to recover polarity separation that the +/− glyph already mitigates.

**The lever, if CVD legibility should be recovered, is the green's lightness — somewhere lighter than the current L\* 66.9 but nowhere near the old L\* 90.** Raising L\* buys polarity ΔE and costs canvas contrast; the two tables above are the exchange rate, and `cvdContrast.ts` + `worstCaseRedGreenSeparation()` can score any candidate token in one call. That is a DS palette decision and needs Paul's ruling plus a token; **no colour is invented or changed in this PR** (hues are Paul's ruling and the DS rule is never to invent a colour).

## Tests

RED-first: `polarityContrast.spec.ts` written first, confirmed failing on the missing module, then implemented to green.

- `src/canvas/edges/__tests__/polarityContrast.spec.ts` — **12 tests**. Pins #282's normal-vision figures (so the prose is reproducible), pins the corrected CVD numbers for the shipped pair, Paul's pair and the old pair (11.7 / 13.8 / 28.3), pins the worst-case ranking, pins that colour alone is insufficient, pins `LMS_TO_RGB · RGB_TO_LMS ≈ I` (the inverse-identity guard, tolerance 1e-4: 7x above the 6-s.f. quotation noise of the published coefficients, 400x below the transcription bug), pins the tritan refusal on all four public entry points, plus validator sanity and symmetry.
- Mutation checks: (a) old buggy coefficient restored → identity pin + all 4 figure pins RED (5 failed / 6 passed figure-side), restored → green; (b) tritan guard removed + invalid matrix restored → exactly the guard pin RED (1 failed / 11 passed), restored → 12/12.
- Full `src/canvas/edges` suite at head `9ac9143e`: **153 passed across 11 files; 12/12 in polarityContrast**. The only failures are wall-clock budget tests in `EdgeEditPopover.perf.spec.tsx` (3–4 per run, varies with machine load) — **pre-existing flake, reproduced failing (4 tests) on a clean detached worktree at base `bf921314`**; this branch does not touch that component.

## Gates (measured post-rebase, base = staging `bf921314`)

- `pnpm typecheck` (narrow `tsconfig.ci.json`): **clean, exit 0.**
- `tsc -p tsconfig.app.json --noEmit` (wide), branch vs base measured in **matched separate worktrees**: **2316 errors on base, 2316 on branch, error multisets identical (diff empty). New errors: 0, silently-fixed: 0.**

## Adjacent findings (reported, not fixed)

- **E4's alternative winner is hover-only.** The default-view badge gives the switch probability but does not name the alternative winner; that label appears on hover/selection. Honest as shipped, just less informative than intended at a glance. Out of scope here.
- **The dark palette has the same problem.** Dark green `#bbf7d0` vs dark rose `#F06595` is ΔE2000 18.6 under deuteranopia (corrected matrix). Better than light, still under "clearly distinct".
- `#282`'s claim to have matched "the DS validator that scored its pair 27.9" cannot be checked: no such validator is in this repo. If it lives in a DS repo, its method should be reconciled with `cvdContrast.ts`, because normal-vision CIE76 and CVD-simulated CIEDE2000 are not comparable numbers.

## Note on the title

The brief specified a `feat(canvas)` title for the three items. They were already shipped, so that title would have described work this PR does not do. Retitled to what it actually lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
