### PR TITLE
docs(design): commit the v6 Analysis-tab build authority so it survives this laptop

### DIFF
--- a/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/ANALYSIS-TAB-BUILD-BRIEF.md
+++ b/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/ANALYSIS-TAB-BUILD-BRIEF.md
@@ -1,0 +1,1256 @@
+# Olumi Analysis Tab Build Brief
+
+> Provenance: supplied verbatim by Paul to A2 on 2026-07-15 ("the brief the previous Workstream was working from"). Companion to analysis-tab-prototype-build-ready-v6.html (sha 080b4a04) in this directory. The brief is the authority on intent, boundaries and acceptance; the prototype is the interaction/layout reference only.
+
+## Status and purpose
+
+This is the implementation and experience brief for the next major Analysis tab build in `DecisionGuideAI`.
+
+It explains not only what to build, but why the experience is structured this way, how each surface should behave, how the pieces should connect to the decision graph and the AI, and where the architectural boundaries sit.
+
+Use `analysis-tab-prototype-build-ready-v6.html` as the interaction and layout reference. It is not production code and it is not a new design-system source of truth. Rebuild the experience from existing Olumi components, selectors, contracts and interaction seams.
+
+The goal is not a pixel-for-pixel port. The goal is a production-quality Olumi-native implementation that preserves the prototype's product logic, improves its usability and accessibility, follows Design System v5 exactly, and integrates the Analysis tab deeply with the graph and AI.
+
+---
+
+# 1. Product intent
+
+Olumi is not a winner-picking dashboard and it is not an AI that outsources thinking.
+
+It is a thinking environment that helps individuals and teams:
+
+- frame the right problem;
+- generate stronger possibilities;
+- challenge assumptions and blind spots;
+- understand causal drivers and uncertainty;
+- compare routes fairly;
+- identify what is worth learning next;
+- reach a defensible provisional decision;
+- preserve ownership of the final judgement.
+
+The Analysis tab should therefore do four jobs:
+
+1. **Orient**
+   Make the current decision, framing quality and decision posture immediately legible.
+
+2. **Explain**
+   Show what the current analysis suggests, why, how uncertain it is and what could change it.
+
+3. **Coach**
+   Identify the single most valuable intervention now, whether that is clarifying, broadening, challenging, evaluating or committing.
+
+4. **Connect**
+   Make the graph, Analysis tab and AI feel like one system rather than three adjacent products.
+
+The experience must remain adaptive and non-linear. Do not expose a visible Frame, Ideate, Evaluate, Decide or Optimise stage switcher in the PoC. Those concepts remain useful internally, but users should simply receive the right guidance for the current state.
+
+---
+
+# 2. Core experience principles
+
+## 2.1 One stable tab, adaptive coaching
+
+The overall Analysis tab structure remains stable. The user should not have to learn a different layout for each stage of reasoning.
+
+What changes is:
+
+- the framing status;
+- the current read;
+- the single highest-priority recommendation;
+- which supporting evidence is available;
+- which methods are relevant.
+
+## 2.2 One question per surface
+
+Each major surface owns one user question:
+
+| Surface | Question it owns |
+|---|---|
+| Decision overview | What decision are we addressing, how is it framed, and how should we treat it? |
+| Freshness | Does this analysis still reflect the current model? |
+| Analysis | What does the current model suggest, why, and what could change it? |
+| Strengthen your model | What is the most valuable thing to improve next? |
+| Advanced | What technical detail, limitations or provenance may an expert need? |
+
+Do not repeat the same target prompt, next action, freshness warning or conclusion across several surfaces.
+
+## 2.3 Answer first, coach second
+
+When analysis exists, lead with the current finding. Coaching follows, unless the framing is contradictory or critically incomplete.
+
+If the brief is contradictory, pause reliance on the read and make resolving the contradiction the primary action.
+
+If information is missing but the model is still useful for exploration, qualify the read rather than blocking everything.
+
+## 2.4 Progressive disclosure
+
+The first viewport should be calm and useful:
+
+- compact decision overview;
+- one freshness status;
+- analysis headline and current lens;
+- one recommendation.
+
+Detailed framing, evidence lists, trade-offs, receipts and secondary recommendations remain one click away.
+
+## 2.5 No false precision
+
+- Do not show a composite trust score.
+- Do not show ambiguous percentages without a clear denominator and meaning.
+- Do not expose normalised values, coefficients, elasticity or internal engine language.
+- Prefer calibrated words such as `tentative`, `close`, `stable` or `needs evidence` when that is the contract-backed representation.
+- Keep win probability, outcome change, evidence quality, influence and flip likelihood visibly distinct.
+
+## 2.6 Human ownership
+
+Olumi can challenge, recommend and propose. It does not silently decide or silently mutate the model.
+
+Any action that changes the graph or model must use the existing proposal, confirmation and canonical apply path.
+
+---
+
+# 3. Canonical Analysis tab hierarchy
+
+Implement the tab in this order:
+
+1. Decision overview
+2. Freshness strip
+3. Merged Analysis panel
+4. Strengthen your model
+5. Advanced and receipts
+
+There is no separate `Understand the result` panel. Its content is now progressively disclosed inside the Analysis panel.
+
+---
+
+# 4. Decision overview
+
+## 4.1 Purpose
+
+This is the orientation and framing surface. It is deliberately separate from analysis results.
+
+It should tell the user:
+
+- what decision or challenge Olumi believes it is helping with;
+- whether the framing has the basics;
+- which parts of the brief need attention;
+- how consequential, urgent or reversible the decision is;
+- what framing question matters most now;
+- which global methods and actions are available.
+
+It should not show option rankings, analysis outcomes, drivers or detailed model-strength recommendations.
+
+## 4.2 Collapsed ready state
+
+When the brief has the basics, keep this surface compact.
+
+Show:
+
+- decision title;
+- decision classification pills;
+- a quiet framing state;
+- the persistent `Actions` control.
+
+Recommended copy:
+
+- `Framing has the basics`
+- supporting line: `Goal, context, constraints and options`
+
+Do not say `good framing`, `good enough` or imply that the brief is objectively correct.
+
+## 4.3 Decision classification
+
+The prototype currently shows:
+
+- High stakes
+- Reversible
+- 12-month horizon
+- Risk cautious
+
+These are useful only if they change behaviour.
+
+They should inform:
+
+- coaching depth;
+- how much challenge Olumi applies;
+- how strongly evidence gaps are prioritised;
+- whether a fast provisional choice is reasonable;
+- how prominently revisit conditions are suggested.
+
+Rules:
+
+- low-stakes and reversible decisions may receive a faster, lighter process;
+- high-stakes or hard-to-reverse decisions should trigger stronger framing, challenge and evidence checks;
+- risk posture may shape how trade-offs are discussed, but must not silently alter the mathematical result;
+- if a classification is inferred rather than user-confirmed, say so and allow correction;
+- if a classification is not consumed anywhere, do not imply that it is active.
+
+Clicking a classification pill should open a small review interaction. It may support direct edit or open a contextual AI conversation.
+
+## 4.4 Canonical brief dimensions
+
+Use one canonical set everywhere:
+
+- Goal
+- Context
+- Constraints
+- Options
+
+The success measure sits within Goal. The problem or challenge is part of Context.
+
+Do not introduce alternative sets such as Frame, Evidence and Estimates.
+
+## 4.5 Brief quality states
+
+### Ready
+
+- collapsed by default;
+- neutral, quiet presentation;
+- no long checklist in the first viewport;
+- user may expand to inspect and edit the brief.
+
+### Thin or incomplete
+
+- expand automatically;
+- qualify the analysis;
+- identify the most important missing information;
+- ask two or three focused questions at most;
+- allow the user to answer directly or work through them with Olumi.
+
+### Contradictory
+
+- expand automatically;
+- pause reliance on the read;
+- show the two conflicting claims in plain language;
+- provide the fastest route to resolve them;
+- do not silently select one interpretation.
+
+### Possible factual inaccuracy
+
+- distinguish between missing information and an unverified claim;
+- do not assert that the claim is false unless evidence supports that;
+- label it as unverified and request a source, correction or confirmation.
+
+## 4.6 The framing question
+
+The overview may show one adversarial framing question, for example:
+
+> What would make bringing on a co-founder clearly better than hiring a senior technical lead?
+
+This is not a generic checklist item. It is the highest-value framing challenge derived from the current brief and model.
+
+Routes:
+
+- `Answer directly`
+- `Work through with Olumi`
+- optional `Focus on canvas` when there is a corresponding goal, constraint or option set
+
+## 4.7 Persistent Actions menu
+
+Keep one persistent Actions menu in the top-right of the Decision overview.
+
+It is not a duplicate of Strengthen your model.
+
+### Strengthen your model owns
+
+- Olumi's single prioritised recommendation;
+- why it matters now;
+- its status and progress;
+- the fastest action.
+
+### Actions owns
+
+- user-invoked science-grounded methods;
+- global utilities;
+- methods the user may deliberately choose even when they are not the current top recommendation.
+
+Recommended catalogue:
+
+**Methods**
+
+- Reframe the problem
+- Generate a materially different option
+- Consider the opposite
+- Apply the outside view
+- Run a pre-mortem
+- Explore trade-offs
+- Review a possible bias
+
+**Global actions**
+
+- Edit decision brief
+- Review all inputs
+- Rerun analysis
+
+Requirements:
+
+- maintain one stable menu rather than separate pre-analysis and post-analysis menus;
+- order or highlight methods contextually, but keep the catalogue recognisable;
+- each method should explain why it could help now;
+- methods open a contextual AI session rather than a generic blank conversation;
+- do not bury the current best next move in the menu;
+- do not show dead or unavailable methods as if they work.
+
+---
+
+# 5. Freshness strip
+
+## 5.1 Purpose
+
+This is the sole owner of current versus stale analysis state.
+
+It should answer:
+
+- does this analysis reflect the current model?
+- if not, why not?
+- what is the recovery action?
+
+## 5.2 Behaviour
+
+Fresh:
+
+- quiet, compact status;
+- no repeated green banners elsewhere.
+
+Stale:
+
+- clear explanation that the model changed after the run;
+- one rerun action;
+- Analysis content may dim or lock as already established, but the recovery action remains crisp.
+
+## 5.3 Ownership
+
+Consume the existing canonical freshness signal.
+
+Do not:
+
+- compute freshness locally from ad hoc UI state;
+- create another graph hash;
+- compare arbitrary client snapshots;
+- show a second stale banner inside Strengthen your model.
+
+---
+
+# 6. Merged Analysis panel
+
+## 6.1 Purpose
+
+This panel combines the current analysis and the evidence needed to understand it.
+
+It answers:
+
+- what currently leads or whether there is no clear leader;
+- what the likely outcomes are;
+- how the options compare against the goal;
+- how stable the recommendation is;
+- why the result looks this way;
+- what is most likely to change it;
+- what practical trade-offs sit behind the leading routes.
+
+The top remains answer-first. Evidence is progressively disclosed.
+
+## 6.2 Analysis headline
+
+The headline must be contract-backed and calibrated.
+
+Examples:
+
+- `Bring On Technical Co-Founder is slightly ahead.`
+- `The top options are close.`
+- `No option is clearly ahead yet.`
+
+Never use `winner`.
+
+Do not make a strong leader claim merely because one option is ranked first.
+
+When the brief is contradictory, replace reliance on the headline with the contradiction state and its resolution action.
+
+## 6.3 Lenses
+
+Current lens set:
+
+- Goal fit
+- Likely outcome
+- Stability
+- What changed
+
+### Goal fit
+
+Available only when a valid measurable success definition exists.
+
+It should not unlock because a stray constraint or joint-goal field happens to be present.
+
+### Likely outcome
+
+Shows option outcome distributions and a clear comparison basis.
+
+Use stable option numbers matching the graph and all other views.
+
+Values need explicit meaning, for example:
+
+- expected change versus the current approach;
+- probability of reaching the success measure;
+- outcome in the user's actual unit.
+
+Never show a percentage if the quantity is not genuinely a percentage.
+
+### Stability
+
+Show only producer-backed per-option stability.
+
+If it is not available, keep the honest unavailable state.
+
+Do not derive or approximate it in the UI.
+
+### What changed
+
+Keep gated until versioned comparison and provenance exist.
+
+Do not recreate it from local browser history or cached run diffs.
+
+## 6.4 Option rows
+
+Requirements:
+
+- stable numbering across graph, Analysis, AI references and other panels;
+- long labels wrap to two lines or provide full text on hover;
+- option order uses the approved shared selector;
+- the active lens must not silently reorder rows unless that behaviour is explicitly designed and labelled;
+- ranges must not exaggerate tiny differences;
+- target markers appear only when units match;
+- identical rendered values must not produce a strongest-outcome claim.
+
+## 6.5 Quick evidence links
+
+The summary may show two compact links:
+
+- Main driver
+- Top flip risk
+
+These must remain semantically distinct:
+
+- **Main driver** means strongest effect on the analysed outcome.
+- **Top flip risk** means most likely to change which option leads.
+
+Clicking either should focus the relevant factor or connection on the canvas.
+
+Do not imply the main driver is necessarily the factor most likely to change the decision.
+
+## 6.6 Expandable evidence section
+
+Use one disclosure:
+
+`Why and what could change it`
+
+Inside it, provide three views:
+
+### Drivers
+
+- rank factors by producer-backed effect on the analysed outcome;
+- show evidence quality separately;
+- make each row clickable to focus the factor on the canvas;
+- avoid internal terms such as elasticity;
+- provide `See all factors` and `Show fewer`.
+
+### Flip risks
+
+- rank producer-backed fragile relationships by leader-switch likelihood;
+- state the consequence in plain language;
+- use user-facing labels and user units where available;
+- do not expose normalised thresholds;
+- only enable drag or direct manipulation if it genuinely previews or reruns the model.
+
+Example:
+
+> If salary cost rises above £X, option 2 becomes the likely leader.
+
+Where an exact threshold is not available, use honest probability-based wording.
+
+### Trade-offs
+
+For each leading option, show:
+
+- You gain
+- You give up
+- Depends on
+- Watch
+
+Trade-offs should come from a grounded producer or reviewed narrative. The UI must not invent them from labels alone.
+
+The section should help users confront the reality of the choice, not only inspect charts.
+
+## 6.7 Route to the next recommendation
+
+The Analysis panel may show a compact line such as:
+
+`Next recommendation: Define a measurable success measure`
+
+It should open or scroll to Strengthen your model.
+
+It must not duplicate the full coaching content or own recommendation status.
+
+---
+
+# 7. Success-measure flow
+
+## 7.1 Why it exists
+
+A qualitative goal can remain qualitative, but Goal fit requires a measurable test.
+
+The existing experience repeated `set a target` in too many places without helping users construct the right target.
+
+Replace those repeated prompts with one canonical `Define success` flow.
+
+## 7.2 Required fields
+
+Capture:
+
+- metric or outcome;
+- direction;
+- numeric threshold;
+- unit;
+- timeframe;
+- optional baseline, evidence or source.
+
+Examples:
+
+- increase delivery capacity by at least 20% within 12 months;
+- reach at least 50 active customers within 6 months;
+- keep implementation cost below £120,000.
+
+## 7.3 Validation
+
+- threshold must be finite;
+- unit is required;
+- timeframe is required;
+- metric must map to a valid outcome or goal representation;
+- show the assembled sentence before commit;
+- protect against percentage scaling and unit mismatch;
+- do not fabricate a number when the user only has a qualitative aspiration.
+
+## 7.4 Write path
+
+This is analysis-affecting and rerun-only.
+
+It must:
+
+- use the existing success-target setter and canonical run path;
+- cause exactly one rerun;
+- mark analysis stale or running using the existing freshness flow;
+- not mutate graph topology;
+- not create local CAS, graph identity or version truth;
+- not silently create a new goal node.
+
+If the user needs help defining the measure, open a contextual AI dialogue before committing a number.
+
+---
+
+# 8. Strengthen your model
+
+## 8.1 Purpose
+
+This is Olumi's adaptive reasoning plan.
+
+It is not a static checklist and it is not a generic task manager.
+
+It should help the user improve the quality of the reasoning by identifying the single highest-value intervention now.
+
+## 8.2 Adaptive help types
+
+Internally, recommendations fall into five help types:
+
+- Clarify
+- Broaden
+- Challenge
+- Evaluate
+- Commit
+
+Do not show these as visible stages or navigation.
+
+## 8.3 Default presentation
+
+Show:
+
+- one expanded recommendation;
+- the remaining recommendations collapsed and hidden behind `Show more`;
+- `Expand all` and `Collapse all`;
+- a compact summary such as `2 addressed · 3 worth checking`;
+- addressed and dismissed history behind disclosure.
+
+Only one recommendation is primary by default.
+
+## 8.4 Recommendation content
+
+Each recommendation needs:
+
+- title;
+- short signal or reason it appeared;
+- why it matters now;
+- one practical `Try this` instruction;
+- named grounding source;
+- one primary action;
+- `Focus on canvas` where a target exists;
+- `Work through with Olumi`;
+- `Not relevant`.
+
+Example:
+
+**Give Engineering Capacity a realistic range**
+
+- Signal: high influence, low evidence.
+- Why: a single figure hides uncertainty in an important input.
+- Try this: use a plausible low and high based on past delivery.
+- Source: sensitivity and evidence-quality signals.
+
+## 8.5 Recommendation lifecycle
+
+Use stable recommendation identities.
+
+Statuses:
+
+- Recommended
+- In progress
+- Addressed
+- Dismissed
+- Reopened
+
+Behaviour:
+
+- addressed recommendations move into history;
+- dismissed means `not relevant`, not silently deleted;
+- a later graph or brief change may reopen an item;
+- explain why a reopened recommendation returned;
+- reprioritise after edits and reruns;
+- do not reset all progress because a new analysis response arrived.
+
+Durable persistence may be limited in the PoC. Keep the internal contract ready for later persistence without claiming it already exists.
+
+## 8.6 Recommendation grounding
+
+Every recommendation must have a named deterministic or producer-backed trigger.
+
+Examples:
+
+- missing measurable success definition;
+- narrow or homogeneous option-set signal;
+- highest Value of Information;
+- low-evidence high-influence factor;
+- highest recorded flip risk;
+- missing counterargument critique;
+- readiness signal supporting provisional commitment.
+
+Do not derive option similarity, trust, trade-offs or bias from superficial UI heuristics.
+
+The UI may adapt presentation, not invent semantic truth.
+
+## 8.7 Backward coaching
+
+This is essential to prevent winner-picker drift.
+
+The system must be able to recommend:
+
+- clarify the goal;
+- reframe the decision;
+- broaden the option set;
+- add a missing outcome;
+- seek a different perspective;
+- challenge the leading option;
+- improve evidence before relying on the ranking.
+
+For example:
+
+> Three of four options use the same mechanism. Generate one materially different route before relying on this comparison.
+
+This must use a producer-owned similarity or coverage signal, not a local text comparison in the UI.
+
+## 8.8 Primary action routing
+
+Use the right route for each recommendation:
+
+- direct inline edit for a threshold, range or known parameter;
+- canvas focus for a factor, option or connection;
+- AI dialogue for framing, ideation, bias checks and science-grounded methods;
+- proposal and confirmation flow for structural model changes;
+- rerun through the canonical run path after analysis-affecting edits.
+
+Close a recommendation only after the action genuinely succeeds.
+
+## 8.9 Addressed history
+
+The history provides continuity and ownership.
+
+It should answer:
+
+- what did the user already address?
+- what changed because of it?
+- why did an issue reopen?
+
+Do not turn it into a performance score or 100% completion target.
+
+---
+
+# 9. Lightweight decision record
+
+## 9.1 Purpose
+
+When `Commit` is genuinely the most valuable next move, offer a light record:
+
+- chosen option;
+- confidence;
+- concise rationale;
+- key assumption to watch;
+- revisit trigger or date.
+
+This preserves agency and enables later learning.
+
+## 9.2 PoC status
+
+Design and prototype it now.
+
+Durable saving depends on required identity, persistence and Model Management decisions.
+
+Until those dependencies land:
+
+- label it honestly;
+- do not imply cross-session durability;
+- do not create a local substitute for canonical decision-record storage;
+- do not expand it into task management, project delivery or ownership workflows.
+
+---
+
+# 10. Advanced and receipts
+
+## 10.1 Purpose
+
+Provide expert depth without burdening the default experience.
+
+Potential content:
+
+- simulation count and seed;
+- provenance and build identifiers;
+- model limitations and warnings;
+- identifiability status;
+- technical diagnostics;
+- unavailable-feature explanations.
+
+## 10.2 Risk profile
+
+The user's decision risk posture belongs in the Decision overview if it actively changes coaching.
+
+Technical or model risk diagnostics belong in Advanced.
+
+Do not conflate:
+
+- user risk preference;
+- decision stakes;
+- model robustness;
+- evidence quality;
+- uncertainty in the outcome.
+
+---
+
+# 11. Cross-surface integration
+
+The Analysis tab should feel physically connected to the graph and AI.
+
+## 11.1 Analysis tab to graph
+
+Use the existing focus and highlight infrastructure.
+
+Expected behaviours:
+
+- clicking an option focuses and selects its option representation;
+- clicking a driver focuses the factor;
+- clicking a flip risk focuses the causal connection;
+- hovering an entity-linked item may highlight it without moving the viewport;
+- explicit click may pan, select and open the appropriate inspector;
+- all interactions respect reduced motion.
+
+Reuse existing `focusByTarget`, `EntityLink`, graph selection and highlight-pulse seams where appropriate.
+
+Do not create a second focus system.
+
+## 11.2 Graph to Analysis tab
+
+Improve the reciprocal direction:
+
+- selecting an option can highlight or reveal its Analysis row;
+- selecting a factor can open Drivers and identify its rank and evidence quality;
+- selecting a fragile connection can open Flip risks;
+- selecting the goal can expose Goal fit or the success-measure action;
+- selecting an element should not unexpectedly replace the whole Analysis narrative.
+
+Treat this as contextual focus, not a permanent filter unless the user explicitly chooses one.
+
+## 11.3 Analysis tab to AI
+
+Every `Work through with Olumi` action should open a contextual working session with:
+
+- recommendation or method identity;
+- relevant entity references;
+- grounding signal;
+- current brief quality;
+- current analysis state;
+- intended outcome of the dialogue.
+
+Examples:
+
+- clarify a missing constraint;
+- generate a non-hiring option;
+- review the strongest case against the leader;
+- plan an evidence check for a fragile assumption;
+- translate a qualitative goal into a measurable success definition.
+
+The user should not need to restate context.
+
+## 11.4 AI to graph
+
+Where the current response contract supports target references:
+
+- render them as clickable entity links;
+- clicking focuses the graph;
+- accepted graph edits should auto-pulse changed elements;
+- proposals should show their target clearly;
+- unknown block kinds should render an honest fallback rather than disappear.
+
+Do not create a new outbound directive contract in this UI brief. If a richer highlight, open-inspector or panel-navigation directive is needed, route it through the orchestrator and shared-schema process.
+
+## 11.5 AI to Analysis tab
+
+Useful future integrations:
+
+- AI can open the relevant recommendation or evidence view after a dialogue;
+- completing a coaching dialogue can mark a recommendation `in progress`;
+- accepting a proposed model change can mark it `addressed` only after the canonical write succeeds;
+- rerun completion should refresh the priority order;
+- the AI can explain why a recommendation appeared, disappeared or reopened.
+
+Use existing system events and typed actions where available. Do not use fragile DOM coupling.
+
+## 11.6 Canvas edits and visibility
+
+When the user or AI changes the model:
+
+- visibly pulse changed elements;
+- mark analysis stale through the sole freshness owner;
+- keep the next recommendation grounded in the latest completed analysis until rerun, clearly labelled;
+- after rerun, update the Analysis read and recommendation plan coherently.
+
+---
+
+# 12. Data and semantic ownership
+
+## 12.1 UI responsibility
+
+The UI:
+
+- displays contract-backed values;
+- adapts layout and progressive disclosure;
+- routes user intent;
+- focuses graph elements;
+- opens contextual AI sessions;
+- submits approved edits through existing action paths.
+
+The UI does not:
+
+- compute model truth;
+- derive option similarity;
+- invent trust bands;
+- calculate graph hashes;
+- create local version history;
+- approximate What changed;
+- synthesise ungrounded trade-offs;
+- rank next actions using new local semantics.
+
+## 12.2 CEE responsibility
+
+CEE or the approved coaching layer owns:
+
+- brief critique and framing questions;
+- science-grounded coaching narratives;
+- grounded bias prompts;
+- option-set coverage or homogeneity interpretation where contracted;
+- structured recommended actions and target references;
+- explanatory narrative around deterministic analysis.
+
+## 12.3 PLoT and ISL responsibility
+
+PLoT and ISL own:
+
+- analysis request validation;
+- outcome distributions;
+- Goal fit probabilities;
+- drivers and sensitivity;
+- robustness and fragile relationships;
+- Value of Information;
+- canonical semantic transforms and repairs.
+
+## 12.4 Shared selector layer
+
+Use one approved adapter or selector layer so that:
+
+- Hero;
+- option rows;
+- graph option labels;
+- WinGauge or equivalent;
+- evidence views;
+- AI references
+
+show the same values, order and labels.
+
+Do not allow each component to independently interpret the raw response.
+
+---
+
+# 13. Design System v5 requirements
+
+The implementation must feel native to Olumi.
+
+## 13.1 Typography
+
+- Inter only.
+- Side-panel components use only:
+  - `panelHeader`: 14px, semibold
+  - `panelBody`: 12px, regular
+  - `panelMeta`: 11px, regular
+- Use semantic typography tokens.
+- Do not use raw font-size or font-weight utility classes.
+
+## 13.2 Colour
+
+- Use exact semantic, entity and data tokens.
+- Do not invent colours.
+- Neutral backgrounds for cards, banners, accordions and pills.
+- Main shades for text, icons and borders.
+- Entity light shades only for canvas fills and entity-linked hover states.
+- Primary action uses the approved info-blue to success-green interaction.
+
+## 13.3 Borders and surfaces
+
+- Full borders only.
+- No left-only accent borders.
+- No coloured card backgrounds.
+- Use shared panel surface, radius and shadow patterns.
+- Avoid nested cards unless the hierarchy genuinely requires them.
+
+## 13.4 Icons and language
+
+- Lucide icons only.
+- Sentence case.
+- British English.
+- Use `and`, not `&`.
+- No em dashes.
+- User-facing language says factors, connections, assumptions, goal, outcomes and risks.
+- Do not expose node, edge, coefficient, elasticity, normalised or graph hash.
+- Prefer `leading option`, not `winner`.
+- Prefer `check` or `review`, not `validate`.
+
+## 13.5 Accessibility
+
+- Accordion headers and rows are buttons, not clickable divs.
+- Correct `aria-expanded`, tab roles and focus order.
+- Keyboard operation for menus, tabs, accordions and modals.
+- Focus must return to the invoking control.
+- Do not rely on colour alone.
+- Honour reduced-motion preferences.
+- Do not place essential information only in 11px metadata.
+
+---
+
+# 14. Refinement authority
+
+You are encouraged to improve the prototype where this brings it closer to the design system and improves function.
+
+You may refine:
+
+- spacing;
+- content density;
+- typography token use;
+- component reuse;
+- responsive behaviour;
+- accessibility;
+- labels and helper copy;
+- progressive disclosure;
+- loading, empty, stale and unavailable states;
+- animation restraint;
+- graph focus and AI hand-off interactions;
+- duplication removal.
+
+You may not independently change:
+
+- semantic meaning of analysis fields;
+- ranking logic;
+- trust calculations;
+- graph mutation contracts;
+- version or freshness authority;
+- schema shapes;
+- producer responsibilities;
+- prompt content;
+- persistence architecture.
+
+If a useful improvement requires one of those changes, document the proposal and stop that part rather than implementing a local workaround.
+
+---
+
+# 15. Implementation approach
+
+Do not ship this as one uncontrolled rewrite.
+
+## Wave 0: read-only audit and plan
+
+Before changing code:
+
+1. Read:
+   - `CLAUDE.md`
+   - current HANDOVER and ROADMAP rows for Analysis
+   - Design System v5
+   - current Analysis Hero and Focus panel code
+   - selector and freshness code
+   - graph focus helpers
+   - current Actions menus
+   - current feature flags
+2. Produce a component map:
+   - current component;
+   - current data source;
+   - current flag;
+   - target component;
+   - keep, merge, retire or defer;
+   - integration seams to reuse.
+3. Identify exactly which prototype elements already exist and which are fixture-only.
+4. Propose the PR sequence and touched files.
+5. Do not implement until the plan is reviewed.
+
+## Wave 1: Decision overview and action ownership
+
+- build the compact overview;
+- consolidate the Actions menus;
+- implement ready, thin and contradictory framing states;
+- connect direct edit and AI hand-off;
+- preserve one freshness owner.
+
+## Wave 2: Merged Analysis panel
+
+- preserve current live Hero behaviours;
+- merge Drivers, Flip risks and Trade-offs under evidence disclosure;
+- reuse the shared selector;
+- keep unavailable states honest;
+- preserve rollback behind the existing transition flag until acceptance.
+
+## Wave 3: Strengthen your model
+
+- implement one primary recommendation;
+- restore Show more, Show fewer, Expand all and Collapse all;
+- add lifecycle and addressed history;
+- route actions to direct edit, canvas focus or AI;
+- use producer-backed recommendation sources only.
+
+## Wave 4: cross-surface integration and polish
+
+- graph focus and hover links;
+- contextual AI hand-offs;
+- applied-edit pulse;
+- accessibility;
+- responsive behaviour;
+- Design System v5 audit.
+
+## Wave 5: gated additions
+
+Only when dependencies exist:
+
+- durable decision records;
+- live option-similarity signal;
+- version-backed What changed;
+- per-option Stability;
+- richer AI directives;
+- collaboration and outcome learning.
+
+One lane at a time. Each wave should be independently testable and reviewable.
+
+---
+
+# 16. Required states and fixtures
+
+Create or reuse representative fixtures for:
+
+1. Ready brief, no target
+2. Ready brief, valid target
+3. Thin brief
+4. Contradictory brief
+5. Fresh analysis
+6. Stale analysis
+7. Close call
+8. Clear leader
+9. Identical rendered outcome values
+10. Stability unavailable
+11. What changed unavailable
+12. Narrow or homogeneous option set
+13. High-influence, low-evidence factor
+14. Fragile relationship with alternative leader
+15. Commit is the top recommendation
+16. No current recommendations
+17. Long option labels
+18. Missing units
+19. Partial analysis response
+20. Unknown AI block fallback
+
+Fixtures must be explicitly labelled as fixtures and must never masquerade as live analysis.
+
+---
+
+# 17. Behavioural acceptance criteria
+
+## Decision overview
+
+- ready state is compact and collapsed;
+- thin and contradictory states expand automatically;
+- contradictory framing pauses reliance on the read;
+- exactly one framing question is promoted;
+- Actions is persistent and not duplicated elsewhere;
+- decision classification can be reviewed or corrected.
+
+## Freshness
+
+- one freshness owner;
+- stale state identifies the recovery action;
+- no local freshness derivation.
+
+## Analysis
+
+- headline, ordering and values reconcile with the approved selector;
+- Goal fit only appears with a valid success measure;
+- Stability and What changed remain honest when unavailable;
+- main driver and top flip risk are distinct;
+- evidence rows focus the correct graph entities;
+- long option labels remain legible;
+- no copy overstates a tie.
+
+## Strengthen your model
+
+- one recommendation is expanded by default;
+- recommendations are producer-backed;
+- Show more and Expand all have distinct functions;
+- addressed and dismissed states persist for the current session;
+- failed actions do not mark items addressed;
+- new analysis reprioritises without resetting all history;
+- broaden does not appear without a valid similarity signal.
+
+## Success measure
+
+- validates metric, finite threshold, unit and timeframe;
+- uses user units;
+- causes one canonical rerun;
+- does not mutate graph topology.
+
+## Decision record
+
+- clearly labelled prototype-only until persistence lands;
+- captures the five agreed fields;
+- does not imply task-management functionality.
+
+## Cross-surface
+
+- entity links focus the graph;
+- AI sessions receive the relevant context;
+- accepted edits visibly pulse;
+- stale state updates coherently;
+- unknown blocks do not disappear silently.
+
+## Design and accessibility
+
+- no raw colour or typography utilities;
+- full borders only;
+- neutral card backgrounds;
+- Lucide icons;
+- keyboard-complete interactions;
+- reduced-motion support;
+- British English and sentence case.
+
+---
+
+# 18. Testing expectations
+
+Follow the repository's RED-first and review discipline.
+
+Minimum tests:
+
+- selector reconciliation;
+- brief-state behaviour;
+- success-measure validation and single rerun;
+- unavailable lens honesty;
+- recommendation grounding and ordering;
+- recommendation lifecycle;
+- narrow-option gating;
+- driver and flip-risk focus routing;
+- Actions ownership;
+- stale/fresh behaviour;
+- unknown-block fallback;
+- feature-flag ON and OFF liveness;
+- accessibility checks for tabs, accordions, menus and modals.
+
+Tests should assert behavioural truth and user-visible meaning, not merely component shape.
+
+Use real captured boundary fixtures where possible.
+
+---
+
+# 19. Explicit do not
+
+Do not:
+
+- create visible stage navigation;
+- add another permanent panel;
+- restore a separate Understand the result panel;
+- duplicate `Define success`;
+- duplicate freshness;
+- duplicate the next recommendation in Actions;
+- invent trust or option-similarity signals;
+- approximate What changed locally;
+- implement local graph mutation, CAS, hashing or version truth;
+- hardcode prompt content;
+- expose internal analytical terminology;
+- ship fixture data as live;
+- silently drop unknown AI blocks;
+- retire the current Hero without a rollback path and staging acceptance;
+- expand the PoC into collaboration, task management or outcome-learning infrastructure.
+
+---
+
+# 20. Required return pack
+
+On completion of each wave, report:
+
+- what changed;
+- screenshots of all key states;
+- components and existing seams reused;
+- new files and touched files;
+- tests run and results;
+- Design System v5 audit;
+- accessibility audit;
+- data source for every displayed semantic claim;
+- any fixture-only or unavailable behaviour;
+- cross-surface integration demonstrated;
+- deviations from this brief;
+- open product or architecture decisions;
+- recommended next wave.
+
+Before merge, perform an independent self-adversarial review of the full diff.
+
+---
+
+# 21. Final product test
+
+The completed Analysis tab should let a user answer, with minimal effort:
+
+1. What decision is Olumi helping me think through?
+2. Has it been framed well enough to rely on?
+3. How consequential and reversible is it?
+4. What does the current model suggest?
+5. Why?
+6. What could change the result?
+7. What should I improve next?
+8. Can I act on that directly, inspect it on the graph or work through it with Olumi?
+9. What have I already addressed?
+10. Am I ready to make a provisional decision and record what would change my mind?
+
+If those answers require the user to decode multiple duplicated panels, search through menus or restate context to the AI, the experience is not finished.

--- a/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/README.md
+++ b/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/README.md
@@ -1,0 +1,29 @@
+# Analysis Tab — Build Guide v6 (2026-07-15)
+
+**Why this directory is in the repo:** these six files are the governing design authority for the v6 Analysis-tab build. Until 2026-07-15 they existed **only on one laptop** at `~/Documents/GitHub/docs-designs/` — a path that is not a git repository and has no remote. The code was safe on GitHub; the design authority governing the next build was one disk failure from gone, and no other workstream or machine could reach it. They are committed here so any workstream, on any machine, can read them at a pinned SHA:
+
+```bash
+gh api "repos/Talchain/DecisionGuideAI/contents/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/ANALYSIS-TAB-BUILD-BRIEF.md?ref=staging" --jq .content | base64 -d
+# or, in a checkout:
+git show origin/staging:docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/ANALYSIS-TAB-BUILD-BRIEF.md
+```
+
+## What each file is — and which one wins
+
+| File | Status |
+|---|---|
+| **`ANALYSIS-TAB-BUILD-BRIEF.md`** | ⭐ **THE AUTHORITY.** Paul's brief, saved verbatim. It governs intent, boundaries, and acceptance. **Where anything below disagrees with it, it wins.** |
+| `analysis-tab-prototype-build-ready-v6.html` | **Layout reference ONLY — not a spec.** Supplied by Paul (this copy is byte-identical to the one he re-issued on 2026-07-15; git blob `8cee7e65…`). It *simulates* producer-owned states the wire does not yet supply — do not read simulated data as a contract. Brief §13.4 explicitly overrides its receipt copy (never expose "graph hash"). |
+| `V6-BUILD-SPEC.md` | Derived component/behaviour spec. |
+| `V6-STAGING-MAP.md` | Prototype → shipped-component map. |
+| `V6-DATA-MATRIX.md` | Field-level wire availability per surface. |
+| `V6-BUILD-PLAN.md` | Six-lane plan (V1–V6). ⚠️ **Reviewed → APPROVED-WITH-AMENDMENTS (11 amendments).** The plan is **not** safe to execute as written — the amendments are recorded in `parallel-briefs/HANDOVER-EXPERIENCE.md`; reconcile before dispatching any V-lane. |
+
+## Before you build from this — read these first
+
+1. **Paul-gated, not engineering calls.** The build is blocked on his rulings for **Options-section retirement** (WinGauge / OptionCards / RiskAppetiteFilter — *deliberately reinstated 2026-05-27; rationale verbatim at `ResultsBody.tsx:330-336`*) and **WhatChangedChip retirement**. Do not start those without his word.
+2. **The prototype's own sha citation is unreliable.** `HANDOVER-EXPERIENCE.md` cites the prototype as "sha 080b4a04"; that value matches **none** of this file's git-blob / sha256 / md5. The bytes are what count — all copies found on the machine are identical to Paul's re-issued file.
+3. **Re-verify every code reference against `origin/staging` before using it.** These docs were written against an earlier tip and much of Waves 1–3 was pre-merged (#284–#300). Lane briefs derived from them have already been wrong twice on this basis.
+4. Cross-workstream state, decisions, and the current lane queue live in `parallel-briefs/HANDOVER-EXPERIENCE.md` (UI/Experience) and the orchestrator-owned boards.
+
+**Provenance:** committed by the UI/Experience workstream on 2026-07-15 at Paul's instruction ("save it somewhere any other Workstream can access"). Content copied verbatim; nothing edited. The `docs-designs/` tree at the GitHub root remains the working copy — **this is the durable one.**

--- a/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-BUILD-PLAN.md
+++ b/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-BUILD-PLAN.md
@@ -1,0 +1,370 @@
+# V6 BUILD PLAN — Analysis-tab v6 lane slicing, flag strategy, tests, decisions, risks
+
+**Inputs:** `ANALYSIS-TAB-BUILD-BRIEF.md` (intent authority), `V6-BUILD-SPEC.md` (prototype contract),
+`V6-STAGING-MAP.md` (component verdicts), `V6-DATA-MATRIX.md` (wire verdicts) — all in this directory.
+**Baseline:** the three analyst docs are cited against `origin/staging @ dbd6be9d`; head verified
+**`f7a52a0c`** at planning time (2026-07-15) — **T1 (#322), T2 (#326) and C3 (#320) have already
+squash-merged**, so their outcomes are baseline facts, not preconditions. Every lane branches from
+the **live** origin/staging head at branch time, in a **fresh worktree**, after its remaining
+precondition lanes have merged. Line anchors drift with each merge (at f7a52a0c the ResultsBody
+mounts sit at: hero :277, strengthen :317, "Your options" :342, Drivers :423, Tornado :472) —
+anchors below cite dbd6be9d unless marked otherwise; re-derive at branch time.
+
+**Central planning fact (from the staging map):** v6 is not greenfield. Waves 1–3a already shipped the
+v6 stack (DecisionOverviewCard + ActionsMenu, AnalysisFreshnessNotice, analysis-hero merged panel with
+lenses/evidence disclosure/next-route, Strengthen stack + lifecycle store, DefineSuccess/DecisionRecord
+modals, AskOlumiDrawer) and staging's flag config already runs it. The v6 build is therefore:
+**(a) composition** — retire the legacy surfaces that still co-mount; **(b) receipts adaptation**;
+**(c) small fidelity fixes** (Strengthen container defects, drawer titling); **(d) fixtures + QA + flip**.
+Producer-gap elements (trade-offs, per-option stability, versioned what-changed, option-similarity,
+evidence-quality meta, classification pills, direct brief edit) ship as the already-implemented
+fail-closed honest placeholders — no lane below builds them.
+
+---
+
+## 0. Preconditions — in-flight lanes merge FIRST
+
+The v6 lanes rebase on these; where a v6 lane touches the same file cluster it is sequenced after the
+conflicting lane and must compose with its outcome, not fight it. Status verified against
+origin/staging `f7a52a0c` + `gh pr list` on 2026-07-15:
+
+| In-flight lane | Status @ f7a52a0c | File cluster | Conflicts with v6 lane |
+|---|---|---|---|
+| T1 rank-badge | **MERGED** (#322) | `useResultsSectionData.ts` numbering + display-order pin | none direct (V3 reads its outputs via props) |
+| T2 receipts | **MERGED** (#326) | `mapV5AnalysisToReport.ts` (seed fail-closed null, robust_edges absent-vs-empty), hydration, envelope wiring | **V3 semantic dependency — satisfied.** V3 asserts fail-closed seed, never re-fabricates |
+| T3 guidance | **OPEN draft PR #321** | `DecisionOverviewCard.tsx`, `StrengthenPanel.tsx`, `buildRecommendations.ts` (verified file list; does NOT touch StrengthenContainer) | **V4, V5** — both rebase after T3 |
+| C1 rerun-single-owner | **UNSTARTED** (no PR) | `AnalysisHeroPanel.tsx`, `OutputsDock.tsx` | **V2** — rebases after C1; if C1 is descoped, V2 proceeds off head with extra care at the rerun call sites |
+| C2 StyledEdge labels | OPEN draft PR #324 | `StyledEdge.tsx` + `edgeLabelCollision.ts` (canvas only) | none |
+| C3 FactorNode units | **MERGED** (#320) | `FactorNode.tsx` prior-range rendering | none |
+| C4 DriversSection/MetricPills disclosure | **OPEN draft PR #325** | `DriversSection.tsx`, `MetricPills.tsx`, `FactorNode.tsx`, `useNodeDisplayMetadata.ts` | **V1** — the retirement gate lands after C4 merges (flag-off keeps DriversSection live, so C4's work is not wasted; the canvas MetricPills half of C4 is untouched by v6 anyway) |
+
+Discipline per repo convention: each lane = fresh worktree off origin/staging, RED-first, DRAFT PR,
+adversarial review, CI shard logs, squash-merge, `git ls-remote` confirmation of the remote head.
+
+---
+
+## 1. Lane slicing (6 lanes, dependency-ordered)
+
+### Lane V1 — `analysisTabV6` flag + ResultsBody composition (retirements behind the flag)
+
+**After:** C4 (#325) merged (T1 already landed). **First v6 lane** — it introduces the flag every
+later lane gates on.
+
+**Files:**
+- `src/flags.ts` — add `analysisTabV6` entry (§2 below) + resolved gate helper.
+- `src/components/results/ResultsBody.tsx` — gate behind `!isAnalysisTabV6Enabled()`:
+  - Options-comparison section (`SectionHeader "Your options"` + RiskAppetiteFilter + WinGauge + OptionCards, :337–409)
+  - Drivers accordion + `DriversSection` mount (:412–437) — **`driverDisplayModel.ts` untouched** (shared SSOT for hero evidence + canvas badge)
+  - Tornado accordion + `TornadoChart` (:440–484)
+  - `StressTestSection` (:488–538)
+  - `WhatChangedChip` (:268) — contradicts the no-local-approximation doctrine
+  - Adjustments-made `<details>` (:569–585) — per ruling D5 (fold into receipts later or gate now)
+- New `src/components/results/__tests__/resultsBody.v6Composition.spec.tsx`.
+
+**Adapts/replaces:** replaces the standalone DriversSection surface with the (already-shipped) hero
+evidence Drivers tab; retires four legacy sections *behind the flag only*. Flag-off is byte-identical
+(repo convention: pinned by test).
+
+**Explicitly untouched:** AnalysisOrphanBanner (:253) and InferenceWarningStrip (:263) stay mounted
+(honesty surfaces, confirm in D6); AnalysisHeroContainer, StrengthenContainer, AdvancedSection stay.
+
+### Lane V2 — OutputsDock composition: post-run footer retirement + chrome cleanup
+
+**After:** C1 and V1 merged. Single OutputsDock lane — nothing else may touch this 2,400-line hotspot.
+
+**Files:**
+- `src/canvas/components/OutputsDock.tsx`:
+  - Gate the post-run `AnalysisFooter` mount (:2277–2292) behind `!isAnalysisTabV6Enabled()`; the
+    `suppressAnalysisFooterForOrphanBanner` interlock (:720–725) stays intact for flag-off.
+    `AnalysisFooter` the component is NOT retired — the pre-run `StickyFooter` still uses it.
+    `derivePostFooterStatus` (postAnalysisFooter.ts) is NOT retired — V3 reuses it as the receipt mapping.
+  - Chrome retire-candidates, each per its D-ruling (D5): `ai-panel-transition-receipt` (:1787–1796),
+    `stale-results-banner` (:2160–2171 — freshness strip owns staleness), `conv-results-indicator`
+    (:2178–2191), `IdentifiabilityBadge` (:2083–2092 — already a receipt row). `WarningBanner` vs
+    `InferenceWarningStrip` overlap and `DegradedStateBanner` need rulings before touching; default is KEEP.
+  - If D4 rules the overview mounts pre-run/conflict states: the `!isPreRun && hasInlineSummary`
+    gate change at :2203 lands **here**, not in V5, so OutputsDock has exactly one lane.
+
+**Adapts/replaces:** freshness strip + Actions menu become the only Rerun surfaces post-run (both exist);
+robustness verdict moves from sticky footer to receipts (V3).
+
+### Lane V3 — Advanced receipts adaptation
+
+**After:** V1 merged (ResultsBody prop seam). T2's seed/robust_edges semantics already landed
+(#326 verified at f7a52a0c: V5 path `meta.seed` fails closed to null, robust/fragile edge keys
+absent when the producer sent none, honest 0 preserved).
+
+**Files:**
+- `src/components/results/AdvancedSection.tsx` — the ADAPT verdict:
+  - **Result stability row:** key on producer `robustness.display_verdict` via the
+    ROBUSTNESS-VERDICT-CONTRACT mapping (`derivePostFooterStatus`, postAnalysisFooter.ts:8–37 —
+    robust → "Stable result", moderate/fragile → "Sensitive to assumptions", not_assessed →
+    "Robustness not assessed", missing → "Robustness unknown"). The calibrated "Tentative" tier
+    (`calibrateUncertaintyCopy`) may render as neutral meta beside a determinate verdict, never alone.
+  - **Stop sourcing `recommendation_stability`** — DEPRECATED, no longer emitted (vendored 0.15.0
+    enrichment.js:250–262). At f7a52a0c ResultsBody feeds it TWICE: `stability=` into AdvancedSection
+    (~:547 — removed here) and `recommendationStability=` into OptionCards (:403 — that surface is
+    gated off by V1's Options-section retirement, archived in Phase 3). The complete consumer grep
+    recorded in the PR must list both; keep inbound tolerance in mappers.
+  - **Simulations row path-conditional honesty:** root `meta.n_samples` is V2-path-only (the CEE→UI
+    keep-list deep-strips `meta`); on a pure V5 turn render honest-absent — never promote per-option
+    `outcome.n_samples`, never show a stale prior-run number.
+  - **Freshness receipt row** ("Graph hash match"): implementation follows the D1 ruling (ask #16).
+    Build both branches ready: (a) row omitted; (b) translated vocabulary — a small code→copy map,
+    unknown codes fail closed to omit, never raw wire strings.
+  - **Seed row:** stays absent (v6 dropped it; T2's #326 made the V5 path fail-closed — landed).
+    Assert-only.
+  - **Result hash:** producer `response_hash` verbatim truncated; a V5 locally-derived hash must be
+    labelled local, not producer.
+  - **Risk slider:** per D7 ruling — it loses its Options-section sibling when V1 gates that section.
+- `src/components/results/ResultsBody.tsx` — prop-line changes only (sequenced after V1; same file, later lane).
+
+### Lane V4 — Strengthen fidelity + commit path
+
+**After:** T3 merged (open draft PR #321 at planning time; its verified file list is
+DecisionOverviewCard + StrengthenPanel + buildRecommendations — it does NOT touch
+StrengthenContainer, so V4's container fixes cannot collide, but the buildRecommendations
+gating edit rebases on #321's dedupe/subtitle outcome).
+
+**Files:**
+- `src/components/results/strengthen/StrengthenContainer.tsx` — the two ledgered container defects
+  (both re-verified present at f7a52a0c):
+  - :139 stops dropping producer `action_label` (phase-3 rows currently get `actionLabel: undefined`);
+  - :143 rank inversion `100 − priority` clamps producer ranks > 100 (fixture ranks 101–104/201–202
+    collapse to one band) — preserve producer ordering for arbitrary ranks.
+- `src/components/results/strengthen/buildRecommendations.ts` — commit-rec gating per D3 ruling.
+  Interim default (recommended): keep the robustness `computed ∧ high` gate; the stage-indicator
+  bridge stays **ordering-only, never a gate** (UI-SEM-076); `'analyse'` (outside the ScenarioStage
+  union) keeps mapping to null with the ladder untouched.
+- Broaden gate: no code change — producer-bias-finding-only stays; the fixture `confirmation_bias`
+  enum drift means there is no evidenced live trigger (documented, fail-closed).
+- `src/canvas/stores/strengthenStore.ts` — untouched unless rec identity changes force a
+  `strengthen.lifecycle.v1` version bump (see risk R2).
+
+**Anti-regression (prototype defects D1/D3 from the spec):** commit rec must open DecisionRecordModal
+via `openDecisionRecord()` (already correct on staging — pin it); progress summary, next-route text and
+"Show N more" are already derived live (pin with tests; never reintroduce static seeds).
+
+### Lane V5 — Decision overview polish + drawer titling
+
+**After:** T3 merged (#321 edits DecisionOverviewCard's framing filter — V5's copy-parity sweep
+targets the post-#321 text). Files strictly under `decision-overview/` + `coaching/` (no OutputsDock
+edits — any mount-gate change belongs to V2).
+
+**Files:**
+- `src/components/results/decision-overview/DecisionOverviewCard.tsx` / `ActionsMenu.tsx` — copy/behaviour
+  parity sweep against V6-BUILD-SPEC §1 (verbatim en-GB, brief auto-expand on thin/conflict, chip dot
+  semantics, goal-chip note from the saved measure sentence).
+- Drawer titling (prototype defect D2): every `openAskOlumi` call titles the drawer after the actual
+  task (the framing question's "Work through with Olumi" must not inherit an unrelated title) —
+  audit all call sites in `decision-overview/*` + `strengthen/*` + hero.
+- Classification pills: keep the shipped UI-SEM-077 fail-closed "not set" states + horizon from the
+  decision-node brief timeframe; pill click opens the review drawer. **No fabrication** — stakes/
+  reversibility/risk have no wire home (data matrix §10).
+- "Answer directly": stays the drawer-draft honest interim ("My answer: " prefix) — the direct
+  brief-edit write path is a producer gap (asks #14/#15 cluster).
+
+### Lane V6 — Required-state fixtures, browser QA, staging flip
+
+**After:** V1–V5 merged. Last lane; carries the netlify staging promotion.
+
+**Files:**
+- Hero fixture gallery + typed fixtures covering the brief §16 matrix (20 states: ready/thin/
+  contradictory brief, fresh/stale/unknown, close call, clear leader, identical readouts, unavailable
+  lenses, narrow option set, LEHI factor, fragile relationship with alternative leader, commit-top,
+  no recommendations, long labels, missing units, partial response, unknown-block fallback).
+  `fixtureIsolation.spec` stays pinned: fixtures never reach product routes.
+- `netlify.toml` — `VITE_FEATURE_ANALYSIS_TAB_V6 = "1"` under `[context.staging.environment]`
+  with the standard promotion comment (production promotion only by adding to `[build.environment]`
+  after sign-off).
+- Browser QA checklist doc (per brief §20 return pack: screenshots of all key states, DS v5 audit,
+  a11y audit, data source for every displayed semantic claim).
+
+**Note on a11y scope:** re-verified at f7a52a0c — `modals/ModalShell.tsx` implements Escape-close,
+backdrop-click close, Tab trap, focus-into-dialog on open and focus-restore on close, with
+`role="dialog"` + `aria-modal` + `aria-labelledby` (header doc :12–17 states this explicitly as
+"BEYOND the prototype"); `ActionsMenu.tsx` :44–74 implements the full menu keyboard model (Escape
+with focus restore, Arrow/Home/End roving focus, `aria-haspopup="menu"`/`aria-expanded`);
+`HeroLensTabs.tsx` :5, :79–97 implements the WAI-ARIA tabs pattern (`role="tablist"`,
+`aria-selected`, `aria-controls`, roving tabindex, Left/Right). The evidence-disclosure tabs are
+deliberately plain toggle buttons (documented decision). The prototype's D5 gaps are therefore
+**already fixed in the app**; no standalone a11y lane — each lane's acceptance includes the brief
+§13.5 checks for the surfaces it touches.
+
+### Dependency graph
+
+```
+[landed: T1 T2 C3 · open drafts: T3(#321) C2(#324) C4(#325) · unstarted: C1]
+        │
+        V1 (flag + ResultsBody)          ← after C4 (T1, T2 already in baseline)
+       ┌┴─────────────┐
+       V2 (OutputsDock) V3 (receipts)    ← V2 after C1+V1; V3 after V1. V2 ∥ V3: disjoint files
+       │               │                    (OutputsDock vs AdvancedSection + ResultsBody prop lines)
+       V4 (strengthen) V5 (overview)     ← both after T3; parallel with V2/V3 (disjoint clusters)
+       └───────┬───────┘
+               V6 (fixtures + QA + staging flip)
+```
+
+Strict file-cluster ownership: ResultsBody.tsx edits only in V1 then V3 (sequential); OutputsDock.tsx
+only in V2; strengthen/* only in V4; decision-overview/* only in V5. V4 and V5 can run in parallel with
+V2 and V3.
+
+---
+
+## 2. Flag strategy + retirement sequence
+
+### The flag
+
+Following `src/flags.ts` conventions, verified at f7a52a0c: a `FLAGS_CONFIG` entry (camelCase key,
+`VITE_FEATURE_*` envKey, `feature.*` storageKey, optional `defaultValue` — omitted here, so default
+off), a `makeFlag(FLAGS_CONFIG.analysisTabV6)` registration in the `flags` export (:507–509 pattern),
+and an `isAnalysisTabV6Enabled` export (:512–525 naming pattern), with the comment block stating
+rollout + local enable:
+
+```ts
+// Analysis-tab rebuild v6 (BUILD-GUIDE-2026-07-15): the v6 COMPOSITION delta —
+// retires the legacy co-mounted surfaces (Options comparison, Drivers accordion,
+// Tornado, StressTest, WhatChangedChip, post-run AnalysisFooter, retired chrome)
+// and adapts AdvancedSection receipts. Gates ONLY the delta: the surfaces it
+// reveals are the already-accepted Wave 1–3a stack. Default OFF; staging-on by
+// netlify.toml promotion after browser QA (Lane V6); flag-off is byte-identical
+// (pinned). Enable locally: localStorage.setItem('feature.analysisTabV6', '1')
+analysisTabV6: {
+  envKey: 'VITE_FEATURE_ANALYSIS_TAB_V6',
+  storageKey: 'feature.analysisTabV6',
+},
+```
+
+**Composition rule (fail-closed):** a resolved helper
+`isAnalysisTabV6Enabled() = flag('analysisTabV6') && decisionOverview && analysisHeroPanel && strengthenPanel`.
+The v6 layout only makes sense on top of the Wave 1–3a stack; if any stack flag is off, the helper
+returns false and the layout is exactly today's — never a half-v6 hybrid (e.g. Options section retired
+but no hero option table to replace it). Each combination is unit-tested.
+
+**Dark-landing:** the flags.ts entry ships in V1 with default off and **no** netlify promotion.
+Lanes V1–V5 land dark; QA runs via localStorage. The staging promotion is the last change (Lane V6).
+Production promotion is a separate config-only PR, Paul-gated after staging sign-off.
+
+### Retirement sequence (after the flag proves out)
+
+Nothing is deleted while the flag exists — retirement is gate-then-archive:
+
+1. **Phase 0 (during build):** everything gated, flag-off byte-identical. Rollback = flip the flag.
+2. **Phase 1 (staging flip, Lane V6):** browser QA against the §16 state matrix + brief §17 acceptance.
+3. **Phase 2 (soak):** staging soak (D8 rules the duration; suggest ≥1 week of active dogfooding with
+   zero flag-off rollbacks), then production promotion (config-only PR).
+4. **Phase 3 (archive PR 1 — v6-gated surfaces):** delete the `!v6` branches and archive:
+   OptionCards/WinGauge (+ unused CompactOptionSpread), RiskAppetiteFilter (per D7 — relocate or
+   archive), DriversSection.tsx (KEEP `driverDisplayModel.ts`), TornadoChart + accordion,
+   StressTestSection, WhatChangedChip, post-run AnalysisFooter wiring in OutputsDock (KEEP
+   `AnalysisFooter.tsx` for pre-run StickyFooter; KEEP `derivePostFooterStatus` for the receipt row),
+   retired chrome blocks. Note the 2026-05-27 Options-section revert comment (ResultsBody:330–336):
+   cite the v6 acceptance in the PR to pre-empt a second revert.
+5. **Phase 4 (archive PR 2 — pre-v6 fallbacks now unreachable):** DecisionConfidencePanel +
+   `analysisHeroV17/` module + `analysisHeroCompare` flag (analysisHeroPanel acceptance);
+   FocusNowContainer + `focusNowPanel` flag ("kill switch retires at 3a acceptance" — now due);
+   dead files ChallengeSection.tsx, ResultsFooter.tsx.
+6. **Phase 5 (flag fold):** once production runs v6 for a release, fold
+   `decisionOverview`/`analysisHeroPanel`/`strengthenPanel`/`analysisTabV6` into permanent code in one
+   cleanup PR, keeping `analysisTabV6` alone as the kill switch for one further release, then delete it.
+
+---
+
+## 3. Per-lane RED-test focus
+
+**V1 — composition:**
+- RED: flag-off mount inventory is byte-identical to pre-lane staging (pinned snapshot of section
+  testids in order).
+- RED: flag-on inventory — NO option-cards/win-gauge/risk-filter/drivers-accordion/tornado/stress-test/
+  what-changed-chip testids; hero, strengthen, advanced, orphan banner, inference strip all present.
+- RED: flag helper combinatorics — `analysisTabV6` on with any stack flag off → today's layout.
+
+**V2 — OutputsDock:**
+- RED: flag-on → `results-analysis-footer` absent post-run; freshness strip + Actions menu both offer
+  Rerun; orphan banner behaviour unchanged (the footer-suppression interlock has nothing to suppress —
+  assert no crash and banner still renders).
+- RED: chrome blocks absent flag-on per D5 rulings; present flag-off.
+- RED: AnalysisFreshnessNotice remains the sole freshness owner in both flag states ('unknown' never
+  rendered as stale — reuse CompareTabBody.freshness.spec pattern).
+- RED (if D4 rules pre-run overview): overview mounts pre-run without resultsSectionData and fails
+  closed on missing fields.
+
+**V3 — receipts:**
+- RED: display_verdict → copy mapping incl. missing → "Robustness unknown"; raw stability % only as
+  neutral meta beside a determinate verdict.
+- RED: no code path reads `recommendation_stability` for display (complete-manifest grep recorded in
+  the PR; inbound tolerance preserved).
+- RED: V5-path turn (meta stripped) → Simulations row honest-absent; V2-path → "N simulations".
+- RED: freshness receipt — unknown reason code → row omitted; known code → translated copy only
+  (or row omitted entirely, per D1 ruling).
+- RED: no seed row in either path; local-derived hash labelled local.
+
+**V4 — strengthen:**
+- RED: producer `action_label` reaches the rendered primary button for phase-3 rows.
+- RED: producer ranks 101–104/201–202 preserve relative order (no clamp collapse).
+- RED: commit rec primary opens DecisionRecordModal; modal save marks commit addressed (D1
+  anti-regression); modal option list binds to the live analysed set (D7 anti-regression).
+- RED: lifecycle — new analysis hash reconciles by id: statuses survive, reopen fires only on
+  genuine hash change; `markAllStale` labels visible-but-stale without resetting history.
+- RED: `stage_indicator: 'analyse'` → bridge null → deterministic ladder order unchanged.
+- RED: broaden absent without a producer narrow-framing finding (never local option counting).
+
+**V5 — overview:**
+- RED: drawer title per invoking task for every `openAskOlumi` call site (framing question ≠
+  "Resolve the brief conflict").
+- RED: brief bar auto-expands + `aria-expanded=true` on thin/conflict, collapses on ready; chip dot
+  semantics (warn only under thin, conflict only under conflict).
+- RED: pills fail closed to "not set"; horizon renders the brief timeframe verbatim; no fabricated
+  stakes/reversibility/risk.
+- RED: goal chip note = saved measure sentence "{metric}: {threshold}{unit}, {timeframe}" after
+  Define-success save; single canonical rerun (one `executeCanonicalRun`, source pinned).
+
+**V6 — fixtures/QA:**
+- RED: every §16 state has a rendering assertion (live-derivable states in component specs;
+  producer-gap states gallery-only with the internal-preview banner).
+- RED: fixture isolation — no product route imports fixture models; netlify flag matrix pinned
+  (staging-on, production + deploy previews off).
+
+---
+
+## 4. Decisions needed (Paul / orchestrator rulings)
+
+| # | Decision | Options / recommendation |
+|---|---|---|
+| D1 | **freshness_reason-as-receipt doctrine (ask #16).** The field is AVAILABLE (`freshness_reason: 'graph_hash_match'`) but doctrine-marked "debug only, never user copy"; v6's receipt row promotes it. | (a) omit the row; (b) **recommended:** translated vocabulary — curated code→en-GB copy map, unknown codes fail closed to omit, never raw wire strings; (c) verbatim (violates doctrine). V3 builds branch-ready for (a)/(b). |
+| D2 | **Success-measure wire structure (ask #14).** Today only the numeric threshold reaches the wire; metric/direction/unit/timeframe/baseline live in sessionStorage. Does the rich measure become a wire/brief-persisted structure? | Affects Goal-fit lens hardening + goal-chip note provenance + reopen semantics. No v6 lane blocks on it (the shipped honesty note covers the interim), but the ruling must land before Goal-fit copy hardens further. |
+| D3 | **Commit-rec gating.** v6 wants "commit shows only when the producer says so"; staging gates on robustness `computed ∧ high`; the canonical strengthen-priority signal is ask #8 and staging fixtures emit `'analyse'` outside the ScenarioStage union (needs CEE vocabulary confirmation). | **Recommended interim:** keep the robustness gate, stage bridge stays ordering-only. Revisit when ask #8 ships. |
+| D4 | **Overview mounting scope.** v6 mounts the overview card in all states incl. pre-run/conflict; staging gates `!isPreRun && hasInlineSummary`. | If yes → gate change lands in Lane V2 (OutputsDock). Pre-run overview needs fail-closed rendering without `resultsSectionData`. |
+| D5 | **OutputsDock chrome retire-candidates.** Per-item ruling: transition receipt, stale-results banner, conv-results indicator, IdentifiabilityBadge (retire-candidates); WarningBanner-vs-InferenceWarningStrip overlap, DegradedStateBanner, adjustments-made details (keep/fold decisions). | Default in V2 is retire the four candidates behind the flag, KEEP the honesty banners. Rulings before V2 starts. |
+| D6 | **Orphan banner + InferenceWarningStrip retention.** Not in the v6 prototype; both are honesty surfaces. | Staging map says keep — confirm so V1 pins them in the flag-on inventory. |
+| D7 | **Risk slider home.** RiskAppetiteFilter's section retires in V1; AdvancedSection also hosts a risk-tolerance slider; brief §10.2 says user risk posture belongs in the overview only if it actively changes coaching (the CEE→ISL preference flow is a stub). | (a) keep slider in AdvancedSection unchanged; (b) retire the filter with its section and defer posture to the classification-pills producer ask. Rulings before V1/V3. |
+| D8 | **Soak duration + promotion authority.** How long staging soaks before Phase 3 archive PRs; production promotion sign-off (Paul per repo convention). | Suggest ≥1 week active dogfooding, zero flag-off rollbacks. |
+| D9 | **Flag fold timing (Phase 5).** When the three wave flags + `analysisTabV6` collapse into permanent code. | Suggest one production release after promotion. |
+
+---
+
+## 5. Risks and mitigations
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | **OutputsDock churn.** 2,400-line hotspot; C1 touches it in-flight; historically conflict-prone. | Exactly one v6 lane (V2) owns the file; rebases after C1; edits are gate-expressions only (no restructuring); flag-off byte-identical pinned; mount-order inventory test. |
+| R2 | **strengthenStore lifecycle compatibility.** V4's container fixes change rec ordering inputs; `strengthen.lifecycle.v1` sessionStorage reconciles by id — if ids or reconciliation semantics shift, user history resets or stale reopens fire. | Rec ids stay stable (`success`, `flip:*`, phase-3 item_ids); RED test: new payload with changed ranks/labels does not reset statuses; reopen only on genuine analysis-hash change; bump the storage version key only if the record shape changes, with a migration or documented reset. |
+| R3 | **Goal-threshold representation interplay.** #309/#317 just stabilised raw-vs-normalised (`goalThresholdRepresentation`, `resolveChipGoalThreshold` short-circuit at useV2Run.ts:226). Any v6 edit near the threshold path could re-break double-normalisation. | No v6 lane touches `useV2Run.ts`, `store.ts` threshold slices, or DefineSuccessModal's commit path. V5's goal-chip work reads the measure store only. Regression spec runs in V3/V5 CI shards regardless. |
+| R4 | **Deprecated `recommendation_stability` removal breaks a hidden consumer.** | Complete-manifest grep (scope: `src/`, claim type: no display-read) recorded in the V3 PR; mappers keep inbound tolerance; only display sourcing removed. |
+| R5 | **V5-path receipts dishonesty.** Keep-list strips `meta`; a V5 turn after a V2 run could show the stale V2 seed/n_samples as if current. | Receipts derive from the current report's provenance, not last-known values; RED tests per path; T2's #326 already landed the fail-closed seed + no-stale-attribution pins (envelopeAnalysisWiring), so V3 asserts and extends rather than re-implements. |
+| R6 | **Flag combinatorics hybrid.** `analysisTabV6` on where stack flags are off (e.g. production localStorage) would retire sections with no replacement mounted. | The resolved AND-helper (§2); combination unit tests; netlify promotion only carries the one new var. |
+| R7 | **Retiring Tornado/StressTest loses data surfaces.** Their inputs (`flip_thresholds`, `fragile_edges`) must remain fully represented in the hero evidence tabs. | Pre-retirement parity check: top flip risks rendered by the evidence tab match StressTest's merged cards on the golden fixture; code archived only in Phase 3, not deleted at gating time. |
+| R8 | **In-flight lane drift.** T3/C1/C2/C4 outcomes may differ from their briefs (T1/T2/C3 verified merged at f7a52a0c and folded into this plan); analyst docs were baselined at dbd6be9d. | Each v6 lane re-reads its file cluster at branch time from the live head (fresh worktree); verify remote head via ls-remote; re-derive any dependent claim if a precursor lane's verdict flipped (global working practice). |
+| R9 | **Copy drift / double edits.** T3 edits DecisionOverviewCard + buildRecommendations copy in-flight while V4/V5 assert "(spec) verbatim" strings. | V4/V5 sequence strictly after T3; verbatim-copy assertions target the spec doc strings, updated once against T3's merged reality. |
+| R10 | **Prototype defects leaking in (D1–D7 of the spec).** | All seven are app-avoided today; V4/V5/V3 add anti-regression pins (commit→modal, derived progress strings, live option list in the record modal, measure-sentence word order via `measureSentence.ts` authored shape). |
+| R11 | **Revert history repeats.** The Options-comparison section was reverted back in on 2026-05-27; retiring it again may surprise stakeholders. | Retirement is flag-gated (instant restore), cited to this build guide + brief §3 in the V1 PR; archive only post-soak with Paul's sign-off (D8). |
+| R12 | **`headline_banded` has zero fixture evidence.** The producer band is contract-typed but unseen on the wire; the shipped fallback thresholds carry the headline. | No v6 lane changes headline logic (out of refinement authority — brief §14). V6 fixtures include a `headline_banded` case so the adoption path is at least gallery-proven. |
+
+---
+
+## 6. Return-pack hooks (per lane)
+
+Each lane's DRAFT PR carries the brief §20 pack: what changed, flag state matrix, screenshots
+(V6 gallery states for producer-gap surfaces), tests run with CI shard logs, DS v5 + a11y audit for
+touched surfaces, data source for every displayed semantic claim (cite V6-DATA-MATRIX row), deviations,
+and open decisions blocking the next lane.

--- a/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-BUILD-SPEC.md
+++ b/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-BUILD-SPEC.md
@@ -1,0 +1,311 @@
+# V6 BUILD SPEC — Olumi Analysis tab (ratified design contract)
+
+Source of truth: `analysis-tab-prototype-build-ready-v6.html` in this directory (590 lines; `<html lang="en-GB">`, proto:3).
+All `proto:NNN` references are line numbers in that file. All `src/…:NNN` references are `origin/staging` of
+`/Users/paulslee/Documents/GitHub/DecisionGuideAI` (working tree is dirty/behind — do not trust it).
+
+Conventions: every copy string below is VERBATIM (British English). "Producer-owned state" = the simulated
+control-panel states in the prototype (proto:190–206) that stand in for real backend/CEE signals — they are
+**not** product-visible controls (proto:192 "These simulate producer-owned states. They are not visible controls in the product.").
+
+---
+
+## 0. Producer-owned simulated states (the drive matrix)
+
+| Control | Values (default first) | Mock mechanism | What it drives |
+|---|---|---|---|
+| `quality` | `ready` / `thin` / `conflict` (labels "Ready" / "Thin" / "Contradictory", proto:193) | class `quality-{value}` on `#mock` (proto:548–549) | brief-bar icon colour + state copy, brief auto-expand, brief-dot colours, conflict pause-read, hiding of analysis body/evidence/next-route |
+| `fresh` | `current` / `stale` (labels "Current" / "Model edited", proto:194) | class `stale` toggled on `#mock` (proto:570) | freshness strip icon + copy line swap |
+| `measure` | `missing` / `set` (proto:195) | classes `measure-missing`/`measure-set` on `#mock` (proto:207, 515, 570 — note: **no CSS selector references these classes**; they are pure state markers) | Goal-fit lens content, Goal brief-chip note, `success` recommendation status |
+| `priority` | `clarify` / `broaden` / `challenge` / `evaluate` / `commit` (proto:196) | JS var `priority` (proto:416, 570) | recommendation sort order (matching `job` first), gating of `commit` rec, resets `visibleCount=1` |
+| `diversity` | `diverse` / `narrow` (proto:200–205) | JS var `optionSetNarrow` (proto:417, 571–581) | gating of `broaden` rec, Options brief-chip note text |
+
+Design boundary (proto:197, verbatim): "**Design boundary:** the Analysis tab owns framing quality, the current read, one next move and supporting evidence. Deeper dialogue opens in Olumi. Collaboration and outcome learning remain separate workstreams."
+
+Workspace dock (proto:208): `<nav aria-label="Workspace tabs">` with buttons "Olumi", "Analysis" (`.active`), "Compare", "Model".
+
+---
+
+## 1. Decision overview card (`section.card.decision-overview#decisionOverview`, proto:210–249)
+
+### 1a. DOM / behaviour
+- Head row (`.decision-overview-head`, proto:211): meta label + `<h2>` + classification pills on the left, Actions menu (`.method-wrap.decision-actions`) on the right.
+- Classification pills: `<div aria-label="Decision classification" class="decision-pills">` (proto:215) containing four `<button class="decision-pill" data-overview="…">`. Click → `openDrawer("Review ${data-overview}", "Help me check whether this decision classification is right and how it should affect the process.")` (proto:489–491). NB drawer title uses the raw data value, e.g. "Review stakes".
+- **Actions menu**: `#methodToggle` ghost-button, `aria-expanded="false|true"` (proto:223, 461); `#methodMenu` `aria-label="Methods and global actions"` (proto:224), positioned *below* the trigger in this placement (`.decision-actions .method-menu{top:34px;bottom:auto;right:0}`, proto:146). When expanded the trigger gets info border + header text colour (proto:147). Menu items are `.method-button` (strong title + span description), with `.method-heading` group labels and rendered in source order (proto:456–460). On item click: menu closes, `aria-expanded` reset (proto:462). Routing (proto:463–465):
+  - "Rerun analysis" → clears `stale`, sets fresh control to `current`, toast "Analysis rerun completed with the current model".
+  - "Edit decision brief" → `openDrawer('Review my decision brief','Challenge the framing across Goal, Context, Constraints and Options.')`.
+  - Every other item → `openDrawer(title, description)`.
+  - ⚠ No outside-click/Escape dismissal is implemented — the real app must add it.
+- **Brief bar**: `#briefToggle` full-width button with `aria-expanded` (proto:227–231): status dot `●` (`.brief-status-icon`, `aria-hidden`), `.brief-state` + `.brief-state-note` stacked, chevron `⌄` rotating 180° when `#decisionOverview` has `.brief-open` (proto:85). Click toggles `.brief-open` + `aria-expanded` (proto:467). Boot forces collapsed (proto:583–584). Quality `thin`/`conflict` auto-expands and sets `aria-expanded="true"`; `ready` collapses (proto:555–568).
+- **Brief details** (`.brief-details`, hidden unless `.brief-open`, proto:86): 2×2 `.brief-grid` of `.brief-chip` buttons (`data-brief="Goal|Context|Constraints|Options"`). Each chip: `.brief-dot` (7px circle, border `--success` by default; `.warn` → `--warning` only under `.quality-thin`; `.conflict` → `--danger` only under `.quality-conflict`, proto:89) + `<strong>` name + note span. Chip click → `openDrawer("Review ${brief}", "Help me strengthen the ${brief.toLowerCase()} in my decision brief.")` (proto:468).
+- Brief actions row (proto:239): text-button `data-open-brief` → same drawer as "Edit decision brief" (proto:469).
+- **Framing question** (`.framing-question`, inside brief-details, proto:240–248): meta label, question `<p>`, then two actions:
+  - `ghost-button data-direct-edit="Goal"` "Answer directly" → `openDrawer('Edit Goal','Update this part of the persisted decision brief directly.')` (proto:492–494).
+  - `text-button data-ask="Work through the framing question"` "Work through with Olumi" → ⚠ the shared `[data-ask]` handler (proto:542) titles the drawer **'Resolve the brief conflict'** with the `data-ask` value as context — a prototype quirk; the real app should title it after the actual task.
+- Status icon colours: ready `--success`, thin `--warning`, conflict `--danger` (proto:84, reinforced scoped at proto:152–153).
+
+### 1b. Copy (verbatim)
+- Meta: "Decision overview" (proto:213). Title: "Technical Co-Founder" (proto:214).
+- Pills: "High stakes" · "Reversible" · "12-month horizon" · "Risk cautious" (proto:216–219). Trigger: "Actions ⌄" (proto:223).
+- Brief state by quality (proto:552–568):
+  - ready: "Framing has the basics" / "Goal, context, constraints and options"
+  - thin: "Framing needs one clarification" / "The goal is broad or important context is missing"
+  - conflict: "The brief contains a conflict" / "Resolve it before relying on the read"
+- Chips (proto:234–237): Goal → note `.goal-note` "Success measure missing" (becomes "`${metric}: ${threshold}${unit}, ${timeframe}`" after save, e.g. "Productivity: 20%, within 6 months", proto:515); Context → "Challenge is clear"; Constraints → "Key limits captured"; Options → note `.options-note` "Four distinct routes" (diversity narrow → "Three of four use the same mechanism", proto:574).
+- Brief actions: "Review your decision brief" · "Olumi challenges one issue at a time." (proto:239).
+- Framing question: "Olumi's framing question" / "What would make bringing on a co-founder clearly better than hiring a senior technical lead?" / "Answer directly" / "Work through with Olumi" (proto:242–247).
+- Actions menu items (proto:445–454), `title` / `description`:
+  - **Methods**: "Reframe the problem" / "Check whether the current question is too narrow." · "Generate a materially different option" / "Use divergent thinking before narrowing." · "Consider the opposite" / "Build the strongest case against the current leader." · "Apply the outside view" / "Compare with a relevant reference class." · "Run a pre-mortem" / "Imagine failure and capture plausible causes." · "Explore trade-offs" / "Make gains and sacrifices explicit." · "Review a possible bias" / "Use only biases grounded in this brief or model."
+  - **Global actions**: "Edit decision brief" / "Review Goal, Context, Constraints and Options." · "Review all inputs" / "Inspect the current model inputs without changing them." · "Rerun analysis" / "Run the analysis against the current model."
+  - Group headings: "Methods", "Global actions".
+
+### 1c. Driving state
+`quality` (icon colour, state copy, auto-expand, dot colours); `measure` (goal-note text); `diversity` (options-note text); `fresh` (reset via "Rerun analysis" item).
+
+### 1d. Tokens
+`--panel-header` (card h2 14px), `--panel-body` (12px), `--panel-meta` (11px labels/notes), `--text-header/--text-body/--text-light`, `--border-default` (chip/pill/menu borders, dividers), `--bg-panel-hover` (hovers), `--success/--warning/--danger` (status icon + dots), `--info` (expanded trigger border, text-buttons), `--shadow-2` (menu), radii: pills 999px, chips 9px, menu 12px, menu buttons 8px.
+
+---
+
+## 2. Freshness strip (`section.status-strip`, proto:249–255)
+
+### 2a. DOM / behaviour
+`aria-label="Analysis freshness"`. Layout: `●` `.status-icon` (aria-hidden) + one visible copy line + spacer + `ghost-button.rerun` "Rerun". `.status-current` shown by default; `.mock.stale` swaps to `.status-stale` and turns the icon `--warning` (proto:70–71). Rerun click: remove `stale`, reset control, toast "Analysis rerun completed with the current model" (proto:505).
+
+### 2b. Copy
+- current: "Analysis reflects the current model."
+- stale: "The model changed after this analysis."
+- Button: "Rerun".
+
+### 2c. Driving state
+`fresh` (`current`/`stale`). Cleared by either Rerun surface (strip button or Actions-menu "Rerun analysis").
+
+### 2d. Tokens
+`--success` (current icon), `--warning` (stale icon), `--text-header` (stale copy weight of colour, proto:70), `--panel-body`, `--border-default`, `--bg-panel`, `--shadow-1`, radius 12px.
+
+### Real-app deviation (freshness)
+The prototype models only current/stale. The app contract is four-valued: `freshness?: 'fresh' | 'stale' | 'unknown' | 'none'` (`src/adapters/cee/types.ts:410`), where `'unknown': CEE could not determine freshness` (`src/adapters/cee/types.ts:406`) and absent/invalid values coerce to `'unknown'` (`src/adapters/cee/types.ts:409` "Absent on legacy responses; treated as 'unknown' by the UI."; contract tests `src/__contracts__/__tests__/analysisReadyContract.spec.ts:266–277`). Hydrated/historical results must display the cannot-confirm state (`src/canvas/__tests__/store.spec.ts:474,496`), CEE `fresh` + locally dirty graph degrades to `unknown` (`src/canvas/blueprints/__tests__/commitTemplateGraph.spec.ts:50`), and `unknown` must NEVER be rendered as "stale" (no fabrication — `src/canvas/compare-tab/__tests__/CompareTabBody.freshness.spec.tsx:75–76`). **The strip therefore needs a third visual state (cannot-confirm) with its own copy; do not reuse the stale line.**
+
+---
+
+## 3. Merged analysis panel (`section.card.hero#hero`, `data-component="merged-analysis-panel"`, `aria-label="Analysis"`, proto:256–313)
+
+### 3a. Headline / subline
+`h2.hero-headline` "Bring On Technical Co-Founder is slightly ahead." + `p.hero-subline` "It also has the strongest expected outcome, but the top two remain close." (proto:258). Hidden (with lenses, lens-body, summary) under `.quality-conflict` (proto:103).
+
+### 3b. Lenses (4-tab segmented control)
+`div.lenses[role=tablist][aria-label="Analysis lenses"]` (proto:259–264) with `button.lens[role=tab]`: "Goal fit" (`data-lens="goal"`), "Likely outcome" (`data-lens="outcome"`, default `.active`), "Stability" (`data-lens="stability"`), "What changed" (`data-lens="changed"`). Click swaps `.active` on lens + matching `.lens-view[data-view]` (proto:471). ⚠ Prototype sets no `aria-selected`/`aria-controls` and no arrow-key nav — real app must implement full tab semantics. Active lens = `--primary` fill + `--text-on-colour`.
+
+- **Goal fit — measure missing** (proto:266, re-rendered by `renderGoalView(false)` proto:507): `.unavailable` row — `ⓘ` (aria-hidden) + "Goal fit needs a measurable success definition. " + text-button `.open-success` "Define success" (opens the Define-success modal).
+- **Goal fit — measure set** (`renderGoalView(true)`, proto:507): option-table without range tracks — rows 1–4 with values "72%", "64%", "31%", "27%" (row 1 `.leading`), footer meta "Probability of meeting the success measure."
+- **Likely outcome** (proto:267–275): `div.option-table[aria-label="Expected outcome by option"]`; each `.option-row` is a grid `24px minmax(0,1fr) 43px` (proto:97): `.option-number` (stable 1–4; bordered `--option`; leading row: `--info` background + `--text-on-colour`, proto:98), `.option-name` (2-line clamp), `.option-value` right-aligned, then full-width `.range-track` (grid-column 2/4, 7px) with `.range-fill` (option tint, leading = info tint) + `.range-dot` (10px, 2px `--bg-panel` border). Values/geometry:
+  1. "Bring On Technical Co-Founder" "+26%" fill left 18% width 64%, dot 58% (leading)
+  2. "Hire Senior Technical Lead" "+20%" fill 14%/60%, dot 51%
+  3. "Continue Without Technical Lead" "0%" fill 7%/18%, dot 15%
+  4. "Outsource Technical Leadership" "-7%" fill 2%/22%, dot 11%
+  Footer meta: "Expected change versus the current approach. Ranges show plausible outcomes."
+- **Stability — honest unavailable** (proto:276): "Per-option stability is not produced yet. Olumi will not infer it in the UI."
+- **What changed — honest unavailable** (proto:277): "This unlocks with versioned run comparisons. Olumi will not approximate it locally."
+
+### 3c. Summary chips
+`.hero-summary` (proto:279): `button.summary-link[data-focus]` — "Main driver: Market Timing Pressure" (`data-focus="Market Timing Pressure"`) and "Top flip risk: Technical Leadership Capacity" (`data-focus="Technical Leadership Capacity"`). Click → toast `Focused ${data-focus} on the canvas` (proto:472).
+
+### 3d. Conflict pause-read
+`.pause-read` shown ONLY under `.quality-conflict` (proto:104), which also hides headline/subline/lenses/lens-body/summary (proto:103) AND the evidence toggle, evidence body and next-route (proto:171–173). Content (proto:281): `<strong>`"Resolve the conflicting brief before relying on this read."`</strong>` + card-copy "The brief says speed is the priority but also says delivery date does not matter. Olumi needs one clarification." + primary-button `data-ask="Resolve the conflict in my decision brief"` "Resolve with Olumi" → drawer titled "Resolve the brief conflict" with that context (proto:542).
+
+### 3e. Collapsed evidence toggle + Drivers / Flip risks / Trade-offs
+- Toggle `#analysisEvidenceToggle` (`aria-expanded`, proto:282–288): strong "Why and what could change it" + sub-span "Drivers, flip risks and trade-offs" + chevron `⌄` (rotates when `#hero` gains `.analysis-evidence-open`, proto:163). Click toggles `.analysis-evidence-open` and `aria-expanded` (proto:475–478). Body `#analysisEvidence` hidden unless open (proto:164–165).
+- Tabs (`role=tablist`, proto:289): `.tab-button` "Drivers" (active) / "Flip risks" / "Trade-offs" (`data-evidence="drivers|flips|tradeoffs"`), same active-swap pattern (proto:496–501); same missing aria-selected caveat.
+- **Drivers** (proto:289–296): note "Ranked by effect on the analysed outcome. Evidence quality is separate." Rows `.evidence-row[data-focus]` (grid `minmax(0,1fr) 80px 58px`, clickable → toast `Focused ${data-focus} on the canvas`, proto:502): sign `+`/`-` (`.sign.pos` `--success` / `.sign.neg` `--danger`) + name, `.evidence-bar` (6px, `--info` fill `<i>`), `.evidence-meta` right:
+  - "+ Market Timing Pressure" 100% "Low evidence"
+  - "- Founder Equity Dilution" 87% "Low evidence"
+  - "+ Engineering Capacity" 66% "Low evidence"
+  - hidden `.extra-evidence`: "- Ongoing Salary Cost" 58% "Low evidence" (`style="display:none"`, proto:294)
+  - Footer text-button `.see-all-evidence` "See all factors" ↔ toggles the extra row (display `grid`) and relabels to "Show fewer" (proto:503).
+- **Flip risks** (proto:296–301): note "Chance the leading option changes when a relationship is varied within its plausible range." Rows (name uses `→` glyph; `data-focus` uses "… to …" wording):
+  - "Technical Leadership Capacity → Technical Quality" bar 96%, "48% switch"
+  - "Founder Equity Dilution → Retention" 72%, "36% switch"
+  - "Ongoing Salary Cost → Runway" 62%, "31% switch"
+  - Footer meta: "If the top relationship under-delivers, option 2 becomes the likely leader."
+- **Trade-offs** (proto:302–305): note "What the two leading routes gain, give up and depend on." Two `.trade-row`s, each `.trade-title` (option-number + name) + 2×2 `.trade-grid` of `.trade-cell` (strong label + span):
+  - 1 "Bring On Technical Co-Founder": You gain / "Long-term technical ownership" · You give up / "Equity and hiring time" · Depends on / "Finding the right partner" · Watch / "Runway and role clarity"
+  - 2 "Hire Senior Technical Lead": You gain / "Faster execution capacity" · You give up / "Ongoing salary cost" · Depends on / "Delegated authority" · Watch / "Founder bottlenecks"
+
+### 3f. Next-recommendation route
+`.analysis-next-route` (proto:306–313): icon `◎` (`.analysis-next-icon`, `--info`, aria-hidden) + meta "Next recommendation" + strong "Define a measurable success measure" + ghost-button `#openRecommendation` "Open". Click (proto:479–488): smooth-scrolls `#strengthCard` into view (`block:'start'`) and force-opens the first `.recommendation` (adds `.open`, sets its head `aria-expanded="true"`). ⚠ The strong text is **static** in the prototype — the real app must derive it from the current top recommendation.
+
+### 3g. Driving state
+`quality` (conflict collapses the whole panel to pause-read); `measure` (Goal-fit lens content + which rec the route targets); producer analysis payload supplies headline, options, ranges, drivers, flip risks, trade-offs (all copy above is fixture data for the "Technical Co-Founder" decision).
+
+### 3h. Tokens
+`--primary` (active lens/tab fill — value equals `--info` #63ADCF), `--text-on-colour`, `--option` #AAA7E4 (option numbers, range fill/dot; non-token tint `rgba(170,167,228,.38)` proto:100), `--info` (leading fills; non-token tint `rgba(99,173,207,.38)`), `--success`/`--danger` (driver signs), `--border-default` (tracks, bars, dividers), `--text-header/-body/-light`, `--panel-header/-body/-meta`, `--bg-panel-hover` (row hover). ⚠ The two `rgba()` tints and the `→`/`◎`/`ⓘ`/`⌄` glyphs are hard-coded, not tokenised.
+
+---
+
+## 4. Strengthen card (`section.card#strengthCard`, proto:314–323)
+
+### 4a. Adaptive recommendation model (THE schema)
+Array `recommendations` (proto:408–415). Fields per item:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | string | stable key (`success`, `broaden`, `assumption`, `range`, `bias`, `commit`) |
+| `job` | enum `clarify\|broaden\|challenge\|evaluate\|commit` | matched against producer `priority` for ordering/gating |
+| `icon` | enum `target\|grid\|shield\|scale\|check\|clock\|range` | inline 24×24 stroke SVG, 17px render (proto:397–406; `clock` defined but unused) |
+| `title` | string | head line |
+| `signal` | string | one-line evidence signal under the title |
+| `why` | string | body paragraph |
+| `tip` | string | rendered as "**Try this** {tip}" (`.try-line`, "Try this" in `--info`, proto:113) |
+| `source` | string | provenance line (`.source-line`, meta size/colour) |
+| `action` | string | primary button label |
+| `actionType` | enum `success\|broaden\|ask` (+ `commit` branch exists in handler, proto:437) | routes the primary action |
+
+Per-item runtime state `recState`: `status: 'recommended' | 'progressing' | 'addressed' | 'dismissed'` (proto:418).
+
+### 4b. The six recommendations (verbatim, proto:409–414)
+1. `success` · clarify · target — "Define what success looks like" · "Goal fit is unavailable" · "Your goal is understandable, but Olumi cannot test whether an option succeeds until the outcome has a measurable threshold and timeframe." · tip "Keep the goal in plain language. Add a metric, direction, threshold, unit and timeframe." · source "Triggered because the goal has no valid success measure." · action "Define success" (`success`).
+2. `broaden` · broaden · grid — "Find a route that is not hiring" · "Three of four options use the same mechanism" · "The current set may be converging too early. A materially different route is more useful than another hiring variation." · tip "Explore a partnership, specialist studio, scope reduction or internal capability route." · source "Uses the producer-owned option-similarity signal." · action "Generate a different option" (`broaden`).
+3. `assumption` · challenge · shield — "Test the assumption most likely to change the leader" · "48% chance of switching the leader" · "Technical Leadership Capacity to Technical Quality is not the largest driver, but it is the relationship most likely to change the recommendation." · tip "Look for evidence that leadership capacity reliably improves technical quality in comparable teams." · source "Prioritised from recorded flip risk, not influence." · action "Plan an evidence check" (`ask`).
+4. `range` · evaluate · range — "Give Engineering Capacity a realistic range" · "High influence, low evidence" · "A single figure hides uncertainty in one of the most important inputs." · tip "Use a plausible low and high estimate based on past delivery, not an optimistic point estimate." · source "Triggered by sensitivity and low evidence quality." · action "Set a range" (`ask`).
+5. `bias` · challenge · scale — "Consider the strongest case against option 1" · "No counter-argument captured" · "The model contains the case for the current leader, but not the strongest opposing explanation." · tip "Use a consider-the-opposite dialogue, then add any surviving concern to the model." · source "Grounded in the missing-counterargument critique." · action "Challenge the leader" (`ask`).
+6. `commit` · commit · check — "Record the decision and what would trigger a rethink" · "The model is ready for a provisional choice" · "A lightweight record preserves ownership and makes later review possible without turning Olumi into project management." · tip "Capture the choice, confidence, rationale, assumption to watch and revisit trigger." · source "Shown only when commitment is the highest-value move." · action "Create a decision record" (`ask` — ⚠ see defect D1).
+
+### 4c. Ordering / gating (proto:419–425)
+`orderedRecommendations()`: drop `addressed`/`dismissed`; drop `broaden` unless `optionSetNarrow`; drop `commit` unless `priority==='commit'`; sort recs whose `job === priority` first, otherwise original array order. `visibleCount` starts at 1 (only the top rec visible; the rest get `.hidden-rec`); index 0 (or all when `allExpanded`) renders `.open` with head `aria-expanded="true"` (proto:426).
+
+### 4d. Row DOM + interactions (proto:426, 431–438)
+`article.recommendation[data-rec]` → `button.recommendation-head` (grid `22px minmax(0,1fr) 18px`; icon / title+signal / chevron `›` rotating 90° when open, proto:110–111) + `.rec-body` (visible when `.open`): why ¶, try-line ¶, source-line ¶, `.rec-actions`: `primary-button.rec-primary[data-action-type]` {action} · `ghost-button.rec-focus` "Focus on canvas" · `text-button.rec-dismiss` "Not relevant" · `icon-button.rec-ask` "✦" with `title`/`aria-label` "Work through this with Olumi" (right-aligned via `margin-left:auto`, proto:114).
+- Head click: toggle `.open` + `aria-expanded`.
+- `.rec-focus`: toast `Focused ${rec.title} on the canvas`.
+- `.rec-ask`: `openDrawer(rec.title, rec.why)`.
+- `.rec-dismiss`: status `dismissed`, re-render, toast "Recommendation dismissed".
+- Primary by `actionType` (proto:437): `success` → open Define-success modal; `commit` → open Record-decision modal; `broaden` → status `addressed`, re-render, toast "Added option 5: Partner with a specialist product studio"; anything else (`ask`) → status `progressing`, re-render, `openDrawer(rec.title, rec.tip)`.
+- `progressing` renders an inline pill `<span class="rec-state progressing">In progress</span>` after the title (proto:426; `--info` border/colour, proto:112).
+
+### 4e. Header / footer / addressed panel
+- Header (proto:315): title "Strengthen your model"; `#progressText` static seed "0 addressed · 5 worth checking" — immediately re-rendered at boot to the computed `` `${addressed} addressed · ${worth} worth checking` `` (proto:427); with defaults (clarify/diverse/missing) worth = 4, so users see "0 addressed · 4 worth checking". `icon-button#addressedToggle` "✓" `aria-label`+`title` "Show addressed recommendations" toggles `#addressedPanel.open` (proto:442).
+- Empty list state (proto:427): "No recommendations need attention right now."
+- Footer (proto:318–322): `#showMore` — hidden unless worth > 1; label `` `Show ${worth-visibleCount} more` `` when collapsed, else "Show fewer"; click flips `visibleCount` between full count and 1 (proto:440). `#expandAll` — "Expand all" ↔ "Collapse all", toggles `allExpanded` (proto:441). (Static HTML seed "Show 3 more".)
+- Addressed panel (proto:317, 428): meta "Addressed or dismissed"; items = check icon + title for every `addressed`/`dismissed` rec; empty state "Nothing addressed yet."
+
+### 4f. Driving state
+`priority` (ordering + commit gating + visibleCount reset), `diversity` (broaden gating + prototype toast "Prototype: producer-owned option-similarity signal is active.", proto:577), `measure` (success rec toggles addressed↔recommended, proto:515, 570).
+
+### 4g. Tokens
+`--factor` #B0A899 (rec icons, proto:111), `--info` ("Try this", In-progress pill, ✦ icon-button colour, text-buttons), `--success` (addressed pill CSS + receipt border — dead in v6, see D6), `--primary/-hover/-active` (primary buttons), `--border-default`, `--text-header/-body/-light`, `--panel-body/-meta`, `--bg-panel-hover`.
+
+---
+
+## 5. Advanced receipts (`<details>`, proto:324)
+
+Collapsed by default (no `open` attr). Summary: "Advanced and receipts" + trailing `›` (inline-styled `margin-left:auto;color:var(--text-light)`). Body `dl.receipt-grid` (2-col `auto 1fr`, meta size, proto:129): "Simulations" → "4,000" · "Freshness" → "Graph hash match" · "Result stability" → "Tentative" · "Result hash" → "8ce04678…". No JS. Tokens: `--panel-header` (summary), `--panel-meta` (grid), `--text-light` (dt), `--bg-panel`, `--border-default`, `--shadow-1`, radius 12px.
+
+---
+
+## 6. Define-success modal (`#successModal`, proto:329–344)
+
+### 6a. DOM / behaviour
+`div.overlay[role=dialog][aria-modal=true][aria-labelledby=successTitle]`; `.open` class displays it (flex-centred, scrim `rgba(38,38,38,.28)` — not tokenised, proto:132). Card `min(430px,100%)`, max-height 90vh. Close: `.close-success` icon-button `aria-label="Close"` ("×") and "Cancel" ghost. Open via any `.open-success` (Goal-fit lens link, success rec primary) — `openSuccess()` focuses `#threshold` (proto:510).
+- Fields (proto:333–338): `#metric` input, label "What outcome should improve?", default value "Productivity" (full-width) · `#direction` select "Direction" — options "Increase by at least" / "Reach at least" / "Keep below" · `#threshold` input "Threshold", `inputmode="decimal"`, placeholder "20" · `#unit` select "Unit" — options "%", "projects", "weeks", "£" · `#timeframe` input "Timeframe", placeholder "Within 6 months" · `#baseline` input "Baseline or evidence, optional", placeholder "Current productivity or source" (full-width).
+- Live preview `#measurePreview` (goal-yellow border `--goal`, proto:132): static seed "Success means: increase Productivity by at least [number]% within [timeframe]." but `updatePreview()` (proto:514, run at boot proto:586) composes `` `Success means: ${direction.toLowerCase()} ${metric||'[outcome]'} ${threshold||'[number]'}${unit} ${(timeframe||'[timeframe]').toLowerCase()}.` `` — ⚠ word order differs from the seed (see D4).
+- Write-semantics note (proto:340): "This updates the analysis success measure and reruns the analysis. It does not change the graph structure."
+- Validation (proto:515): metric, threshold, unit, timeframe all required (trimmed) AND `Number(threshold)` finite; failure shows `#measureError` "Add a number and timeframe so Olumi can evaluate Goal fit." Baseline optional; direction always valid.
+- **Save and rerun** (`#saveSuccess`, proto:515) on success: hide error → mock `measure-missing`→`measure-set` → Goal chip note becomes "`${metric}: ${threshold}${unit}, ${timeframe}`" → `success` rec `addressed` → re-render recs → close modal → sync measure control → toast "Success measure updated. Analysis rerun without changing graph structure." → `renderGoalView(true)` → programmatically activates the Goal-fit lens.
+
+### 6b. Copy
+Title "Define success"; intro "Keep the goal in plain language, then give Olumi a measurable test for Goal fit."; buttons "Cancel" / "Save and rerun". (Field labels/options/placeholders/error/note as above, all verbatim.)
+
+### 6c/6d
+Driven by `measure`; on save flips it to `set`. Tokens: `--goal` #F5C433 (preview border), `--danger` (error), `--info` (field focus border; non-token focus ring `rgba(99,173,207,.25)` on modal textareas proto:179), `--border-default`, `--bg-panel`, `--panel-meta` (labels), `--panel-body` (inputs), field radius 9px, card radius 12px, `--shadow-1` (modal-card base style, proto:63).
+
+---
+
+## 7. Record-decision modal (`#decisionModal`, proto:345–388)
+
+### 7a. DOM / behaviour
+Same overlay/dialog pattern; `aria-labelledby="decisionRecordTitle"`. `openDecision()` focuses `#decisionConfidence` (proto:519). Close: `.close-decision` ("×" aria-label "Close", "Cancel").
+- Prototype note (`.prototype-note`, proto:354): "Prototype only. Durable saving depends on identity and Model Management."
+- Fields (proto:355–381): `#chosenOption` select "Chosen option" — options "1. Bring On Technical Co-Founder" / "2. Hire Senior Technical Lead" / "3. Continue Without Technical Lead" / "4. Outsource Technical Leadership" (full) · `#decisionConfidence` "Confidence, 0–100", `inputmode="numeric"`, placeholder "e.g. 70" · `#revisitDate` "Revisit trigger or date", placeholder "e.g. runway falls below 9 months" · `#decisionRationale` textarea "Concise rationale", placeholder "Why this is the best current choice", rows 3 (full) · `#assumptionWatch` "Key assumption to watch", placeholder "The assumption most likely to change the choice" (full).
+- Validation (proto:522–532): confidence must be a finite number in [0,100]; rationale, assumption and revisit all non-empty; else show `#decisionError` "Add confidence, rationale, an assumption to watch and a revisit trigger."
+- Save (`#saveDecision` "Capture prototype record", proto:534–537): `commit` rec → `addressed`, re-render, close, toast "Prototype decision record captured in this session."
+
+### 7b. Copy
+Title "Record the decision"; intro "Capture the choice and what would justify revisiting it."; buttons "Cancel" / "Capture prototype record"; note + labels + placeholders + error verbatim above.
+
+### 7c/7d
+Intended trigger: commit rec primary when `priority==='commit'` (see defect D1 — currently unreachable). Tokens: same modal set as §6 minus `--goal`.
+
+---
+
+## 8. Olumi drawer (`#olumiDrawer`, proto:388–391)
+
+`div.drawer[aria-label="Olumi coaching session"]`, fixed right 18px bottom 18px, width `min(370px, calc(100vw - 36px))`, z-index 25, `.open` displays (proto:133). Head strong "Work through it with Olumi" + `#closeDrawer` "×" (`aria-label="Close"`). Body: `#drawerContext` (info-bordered box; default "Context will appear here.") + `#drawerMessage` textarea `aria-label="Message to Olumi"` + actions `#focusFromDrawer` ghost "Focus on canvas" / `#sendDrawer` primary "Send".
+- `openDrawer(title, context)` (proto:541): context box gets `<strong>{title}</strong><br>{context}`; textarea prefilled `` `Help me work through: ${title}` ``.
+- Send → toast "Sent to Olumi with the relevant model context", closes drawer (proto:544). Focus → toast "Focused the relevant model elements on the canvas" (does not close).
+- Every "deeper dialogue" surface routes here: brief chips, review-brief links, framing-question buttons, classification pills, method menu items, rec ✦ / ask-type primaries, pause-read "Resolve with Olumi".
+Tokens: `--info` (context border), `--shadow-2`, `--border-default`, `--bg-panel`, `--panel-header` (head), radii 12px/9px.
+
+---
+
+## 9. Toast (`#toast`, proto:392, 395–396)
+
+`role="status"`, fixed bottom-centre pill, background `--text-header`, colour `--text-on-colour`, `max-width:min(90vw,430px)`, radius 999px, opacity transition .2s (shown at .96), auto-hide after **1800 ms**, single-instance (re-trigger resets timer). Honour `prefers-reduced-motion` (global kill at proto:135). Complete toast catalogue (all verbatim):
+- `Focused ${name} on the canvas` (summary chips, evidence rows, rec "Focus on canvas")
+- "Analysis rerun completed with the current model"
+- "Recommendation dismissed"
+- "Added option 5: Partner with a specialist product studio"
+- "Success measure updated. Analysis rerun without changing graph structure."
+- "Prototype decision record captured in this session."
+- "Sent to Olumi with the relevant model context"
+- "Focused the relevant model elements on the canvas"
+- "Prototype: producer-owned option-similarity signal is active." (control-panel only; not product copy)
+
+---
+
+## 10. Design tokens — `:root` values (proto:9–33)
+
+| Token | Value | Principal uses |
+|---|---|---|
+| `--bg-canvas` | `#F4F0EA` | page + mock background |
+| `--bg-panel` | `#FEFEFE` | cards, strip, modals, drawer, menus, inputs, range-dot border |
+| `--bg-panel-hover` | `#FEF9F3` | all button/row hovers |
+| `--border-default` | `#EEE6D8` | every default border, dividers, tracks/bars |
+| `--text-header` | `#262626` | headings, values, toast bg, overlay scrim base |
+| `--text-body` | `#3F3F3E` | body copy |
+| `--text-light` | `#908D8D` | meta, labels, chevrons, inactive lens/tab |
+| `--text-on-colour` | `#FFFFFF` | text on primary/info fills, toast text |
+| `--danger` | `#EA7B4B` | conflict icon/dot, negative sign, errors |
+| `--success` | `#67C89E` | ready/current icons, default brief-dots, positive sign, addressed accents |
+| `--info` | `#63ADCF` | text-buttons, icon-buttons, active-segment border, field focus, drawer context, "Try this", In-progress, flip bars, next-route icon |
+| `--warning` | `#FFA656` | thin icon/dot, stale icon |
+| `--goal` | `#F5C433` | measure-preview border only |
+| `--option` | `#AAA7E4` | option numbers, range fill/dot |
+| `--factor` | `#B0A899` | recommendation icons |
+| `--primary` | `#63ADCF` | primary buttons, active lens/tab fill (== `--info` by value) |
+| `--primary-hover` | `#67C89E` | primary hover (== `--success` by value) |
+| `--primary-active` | `#5AA88A` | primary active |
+| `--panel-header` | `14px` | card titles, modal/drawer heads, summary, next-icon |
+| `--panel-body` | `12px` | body, buttons, inputs, rows |
+| `--panel-meta` | `11px` | meta, labels, chips, signals, receipts |
+| `--shadow-1` | `0 1px 2px rgba(38,38,38,.06)` | cards/strip/controls |
+| `--shadow-2` | `0 4px 12px rgba(38,38,38,.10)` | mock, menus, drawer |
+
+**Non-tokenised literals the app must map to its DS:** option range tint `rgba(170,167,228,.38)` and info tint `rgba(99,173,207,.38)` (proto:100); overlay scrim `rgba(38,38,38,.28)` (proto:132); textarea focus ring `rgba(99,173,207,.25)` (proto:179); toast opacity `.96`; Inter font stack (proto:35); disabled opacities `.4` (primary) / `.55` (lens); glyph characters `● ⌄ › ✓ ✦ × ◎ ⓘ →`.
+
+---
+
+## 11. Deviations the real app must handle (prototype omissions)
+
+1. **Freshness `unknown` (cannot-confirm) + `none`.** Prototype: binary current/stale. App: `'fresh' | 'stale' | 'unknown' | 'none'` (`src/adapters/cee/types.ts:410`; coercion tests `src/__contracts__/__tests__/analysisReadyContract.spec.ts:266–277`; hydrate/historical → unknown `src/canvas/__tests__/store.spec.ts:474,496`; fresh+dirty → unknown `src/canvas/blueprints/__tests__/commitTemplateGraph.spec.ts:50`; unknown must not render as stale `src/canvas/compare-tab/__tests__/CompareTabBody.freshness.spec.tsx:75`). The strip needs distinct cannot-confirm copy and icon treatment.
+2. **No orphan banner.** The app surfaces `showOrphanBanner` from `useAnalysisStateSource` (`src/canvas/hooks/useAnalysisStateSource.ts:38`, true at `:102` for orphaned plot results; gate spec `src/canvas/hooks/__tests__/useAnalysisDisplayState.orphanGate.spec.ts:37`) and suppresses the analysis footer while it shows (`src/canvas/components/OutputsDock.tsx:724–725`, `:2277`). The v6 layout must reserve this banner slot above the merged panel.
+3. **No sticky robustness footer.** The app renders `AnalysisFooter` (`src/canvas/components/OutputsDock.tsx:114`, `:2278`; pre-analysis wrapper `src/canvas/components/pre-analysis/StickyFooter.tsx:133`) whose verdict obeys ROBUSTNESS-VERDICT-CONTRACT (`src/canvas/components/utils/postAnalysisFooter.ts:8–37`): only the display-safe `robustnessVerdict` may produce a verdict — `robust` → "Stable result", `moderate|fragile` → "Sensitive to assumptions", `not_assessed` → "Robustness not assessed", missing → "Robustness unknown"; raw stability % appears only as neutral meta beside a determinate verdict. The prototype's only stability surface is the "Result stability — Tentative" receipt (proto:324); building v6 must not drop the certified footer lane.
+4. **"Rerun analysis" is a real async run**, not an instant class flip (proto:463/505 fake it): needs pending/error states and must be the sole primary action per the footer contract (`src/canvas/components/OutputsDock.tsx:1224`).
+
+### Prototype defects/quirks to correct (do NOT replicate)
+- **D1 — commit rec never opens the Record-decision modal**: `commit` has `actionType:'ask'` (proto:414) while the handler's `openDecision()` branch requires `actionType==='commit'` (proto:437). Intended wiring is `commit` → modal (the modal's save marks the `commit` rec addressed, proto:534).
+- **D2 — `[data-ask]` drawer title is hard-coded** to 'Resolve the brief conflict' (proto:542), mis-titling "Work through with Olumi" on the framing question.
+- **D3 — static strings that must become derived**: next-route "Define a measurable success measure" (proto:310), progress seed "0 addressed · 5 worth checking" (real boot value is 4, proto:315 vs 427), footer seed "Show 3 more" (proto:319).
+- **D4 — preview word order**: `updatePreview()` yields "increase by at least Productivity 20% within 6 months" (proto:514); ship the seed's order "increase Productivity by at least 20% within 6 months" (proto:340).
+- **D5 — accessibility gaps**: tablists without `aria-selected`/`aria-controls`/arrow keys (proto:259, 289); no focus trap, Escape or overlay-click close on modals/drawer/menu; focus not restored on close.
+- **D6 — dead code**: `.rec-receipt` + `.rec-state.addressed` CSS (proto:112, 115) never rendered by `recMarkup` (addressed recs are filtered out entirely); `icons.clock` unused (proto:403); `measure-missing`/`measure-set` classes unreferenced by CSS; `.quality-thin #decisionOverview{scroll-margin-top:10px}` (proto:182) has no scroll trigger.
+- **D7 — decision modal option list is a static copy** of the four options (proto:359–362); must bind to the live option set (including any generated "option 5").

--- a/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-DATA-MATRIX.md
+++ b/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-DATA-MATRIX.md
@@ -1,0 +1,208 @@
+# V6 Data Availability Matrix
+
+**Scope.** Every data element the v6 build guide (`analysis-tab-prototype-build-ready-v6.html`, this directory) renders, with a verdict:
+
+- **AVAILABLE** — the field exists on the wire today (vendored `@talchain/schemas` 0.15.0 type and/or mapper + fixture evidence).
+- **DERIVABLE** — the UI can compute it honestly from existing fields (the derivation is stated).
+- **PRODUCER-GAP** — no honest source exists; ships as a fail-closed placeholder. Cross-referenced to asks-ledger items 8–16 in `parallel-briefs/UI-CROSS-REPO-ASKS-2026-07-15.md`.
+
+**Evidence base.** All code citations are against `origin/staging` @ `dbd6be9d` of `DecisionGuideAI` (the working tree is dirty/behind and was not used). Wire-shape evidence comes from the vendored contract (`vendor/talchain-schemas-0.15.0.tgz`, pinned by `src/lib/talchainSchemasVersion.ts:14` — `TALCHAIN_SCHEMAS_VENDORED_VERSION = '0.15.0'`; schema line numbers below are the tarball's compact `package/dist/*.js` sources), the golden fixture `src/test/fixtures/golden-path-staging-2026-04-05.json` (real staging bundle, v2.6), and the CEE V5 fixture `src/v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json`.
+
+A significant portion of v6 is **already implemented on staging** (DecisionOverviewCard, analysis-hero, Strengthen panel, Define-success / Decision-record modals) — where that is true the matrix cites the shipped honest-interim behaviour rather than speculating.
+
+**Path-conditionality (applies to every AVAILABLE verdict below).** Analysis data reaches the UI on two wire paths:
+
+1. **V2 run path** — a full PLoT `/v2/run` response, either direct (`rawV2Response`) or embedded on a CEE turn as `envelope.analysis_response` (`src/canvas/conversation/types.ts:752-758`; hydrated `useConversation.ts:2222+`). Carries `meta` (seed / n_samples / hashes / request-id chain), `decision_brief`, top-level `flip_thresholds`.
+2. **V5 conversational path** — the CEE `analysis_result` block's `enrichment`, reduced to the CEE→UI keep-list: `option_comparison, factor_sensitivity, results, robustness, decision_review, option_comparison_status, conditional_probabilities, edge_e_values, inference_warnings, confidence_tier, flip_thresholds` (`CEE_UI_ENRICHMENT_KEEP_LIST`, vendored `dist/boundary/enrichment.js:534-546`). **`meta` and `m1_coaching` are deliberately deep-stripped on this path** ("internal carriers (`_meta`, `meta`, `downstream_calls`, graph hashes, ...) deep-stripped" — `enrichment.js:51-57`). Anything sourced from `meta` (seed, n_samples) or `m1_coaching` (story headlines, readiness) is therefore **V2-path-only**; the V5 path must fail closed for those fields.
+
+---
+
+## Summary table
+
+| # | v6 element | Verdict |
+|---|---|---|
+| 1 | Calibrated headline + subline | **AVAILABLE** (producer band, newer PLoT) with **DERIVABLE** fallback (shipped) |
+| 2 | Expected-change % per option + plausible ranges | **AVAILABLE** (ranges/centres); delta-vs-current-approach **DERIVABLE only when a baseline is flagged** |
+| 3 | Goal-fit % per option + success-measure gating | **AVAILABLE** (probabilities) + **DERIVABLE** gate (shipped); rich measure structure is ask #14 |
+| 4 | Flip risks (relationship + switch % + "option 2 leads" line) | **AVAILABLE** |
+| 5 | Drivers — signed direction, ranked magnitude | **AVAILABLE** |
+| 5b | Drivers — per-factor evidence quality | **PRODUCER-GAP** (ask #10; raw `confidence` exists but is ruled not display-safe) |
+| 6 | Trade-offs content | **PRODUCER-GAP** (ask #11) |
+| 7 | Adaptive priority | **DERIVABLE** interim (stage_indicator bridge, shipped) + **PRODUCER-GAP** for the canonical signal (ask #8) |
+| 8 | Option-similarity ("diversity") | **PRODUCER-GAP** (ask #9); narrow-framing bias-signal channel exists as the only honest gate |
+| 9 | Brief quality ready/thin/conflict + chips + framing question | **DERIVABLE** (partial, shipped) + **PRODUCER-GAP** for conflict/unverified and explicit `framing_question` (ask #1) |
+| 10 | Decision classification pills (stakes/reversibility/horizon/risk) | **PRODUCER-GAP** (3 of 4); horizon **DERIVABLE** from the decision-node brief timeframe |
+| 11 | Freshness verdict + reason string | **AVAILABLE** (both); reason-as-receipt needs the ask #16 doctrine ruling |
+| 12 | Receipts: simulations / result stability / result hash | **AVAILABLE** (all three, V2 path; V5 path strips `meta`); stability must key on `level`/`display_verdict`, NOT the deprecated `recommendation_stability`; seed row correctly dropped by v6 (ask #5; `?? 0` fabrication still live at `mapV5AnalysisToReport.ts:319`) |
+| 13 | Strengthen recommendation fields | **AVAILABLE/DERIVABLE** per-trigger (shipped); producer one-line `signal` is ask #12 |
+| 14 | Option stable numbers | **DERIVABLE** (shipped, UI-local identity-anchored ordinals) |
+| 15 | "Answer directly" direct-brief-edit path | **PRODUCER-GAP** — no brief-edit write path exists (asks #14/#15 adjacent) |
+| — | Stability lens / What-changed lens (v6 ships honest-unavailable) | **PRODUCER-GAP** (ask #13; producer gaps 211/212) — v6 agrees |
+
+---
+
+## 1. Calibrated headline + subline ("slightly ahead", "the top two remain close")
+
+**Verdict: AVAILABLE (producer band) with a shipped DERIVABLE fallback.**
+
+- **Producer path (preferred):** PLoT `decision_brief.headline_banded` carries a closed set of band tokens `'very_close' | 'slightly_ahead' | 'clearly_ahead'` plus `leader_option_id` and `robustness_gated` — `src/components/results/types.ts:459` ("PLoT #200"), type at `types.ts:461-472`, fail-closed normaliser `normalizeHeadlineBanded` at `types.ts:488-500` (unknown token / missing leader id → `null`, never guessed into copy). Band → copy mapping in `buildHeroModel.ts:437-440`: `clearly_ahead → 'strong'`, `slightly_ahead → 'ahead'` ("is slightly ahead", `heroCopy.ts:86`), `very_close → 'none'` ("No option is clearly ahead.", `heroCopy.ts:88`). The band applies **only when it names the same leader the hero headlines** (`buildHeroModel.ts:444-448`).
+- **Caveat:** the golden fixture's `plot_response` (2026-04-05 build `0d93364`) has **no** `decision_brief` key — the band exists only on newer PLoT builds. The UI therefore keeps the fallback below.
+- **Fallback thresholds (UI-SEM-060 residual, exactly answering "what thresholds derive this honestly"):** `buildHeroModel.ts:456-470` — leader's own `win_probability` ≥ `WIN_STRONG_LEADER = 0.65` → "most likely to be strongest overall"; ≥ `WIN_MAJORITY = 0.5` → "slightly ahead"; below majority, "ahead" only if `leadWinP − rivalWinP ≥ GAP_THRESHOLD` (`0.10`, shared with the panel's indeterminate state — `buildResultsVM.ts:31`); otherwise "No option is clearly ahead." `win_probability` per option is on the wire: golden fixture `plot_response.option_comparison[0].win_probability = 0.4375`.
+- **Subline ("top two remain close"):** the runner-up is named only when the top-two expected-outcome **centres** differ by ≤ `OUTCOME_CLOSE_RATIO = 0.15` of the larger magnitude (`buildHeroModel.ts:140`, applied at `:491-500`; copy `closeOnOutcome` `heroCopy.ts:119`). A readout-tie (identical rendered readouts) switches to the neutral plural "The top options are close on expected outcome." (UI-SEM-070, `buildHeroModel.ts:503-514`; copy `heroCopy.ts:126`). Range overlap alone never produces a "close" claim — it only appends the overlap advisory (`heroCopy.ts:131`-region, gate at `buildHeroModel.ts:481-489`). The aligned-leader subline "also has the strongest expected outcome" is `heroCopy.ts:112`.
+- PLoT `robustness.near_tie` (`{is_tie, top_option_id, second_option_id, gap, threshold}`) is also on the wire (golden fixture; mapper `src/lib/mappers/mapRobustness.ts:124-155`) but the hero's closeness claims deliberately key off win-prob/centres, not near_tie.
+
+## 2. Expected-change % per option + plausible ranges (lo/hi)
+
+**Verdict: AVAILABLE for centres and ranges; the "+26% versus the current approach" DELTA framing is DERIVABLE only when a baseline option is flagged.**
+
+- **Wire:** every `option_comparison[i].outcome` carries `mean, std, p10, p50, p90, n_samples, n_valid_samples, validity_ratio` — golden fixture `plot_response.option_comparison[0].outcome` (`mean 0.3599…, p10 0.0378…, p90 0.6536…`). (`FactorSensitivity`/`FragileEdge` are the only response schemas in vendored 0.15.0 `dist/responses.js`; option outcomes flow through the passthrough report mappers — `useResultsSectionData.ts` fallback chain at `:1226` "expected_outcome > expected > outcome.mean > bands > goal_probability".)
+- **Ranges:** hero row lo/hi = `getPessimistic(o) ?? o.p10` / `getOptimistic(o) ?? o.p90` (`buildHeroModel.ts:95-100`); centre = `getExpectedValue ?? getMedian ?? p50` (`:92-94`). Rendered as the range bar + dot (v6 `.range-track`) — AVAILABLE.
+- **Delta vs "current approach":** `deltaFromBaseline = optionOutcome − baselineOutcome` is computed at `useResultsSectionData.ts:1352-1360`, but **only** when `resolveBaselineId` (`:138-159`) finds a baseline: precedence is PLoT `is_baseline: true` on an option node > user selection; the label heuristic was **removed in v7.5** (`:155-156` comment) so no baseline is ever guessed. The wire does carry the flag: `cee-response-b82c89dd-trimmed.json` → `analysis_ready.options[0].is_baseline` (boolean). Without a flagged baseline the honest rendering is the absolute expected value (which is what the shipped hero does — readout at `buildHeroModel.ts:341-344`), **not** a fabricated "+X% vs current".
+- Note: fixture outcome values are normalised model scores (0–1); `isNormalised` (`types.ts:315-319`) forces "Relative score" labelling — v6's "%" framing must respect this flag.
+
+## 3. Goal-fit % per option + gating on success measure
+
+**Verdict: AVAILABLE (probabilities) + DERIVABLE gate (shipped). Rich success-measure structure = ask #14.**
+
+- **Wire:** per option `win_probability` (0.4375), `probability_of_joint_goal` (0.028), `constraint_probabilities` keyed by constraint id (`auto_goal_threshold: 0.028`) — golden fixture `option_comparison[0]`. Goal threshold rides the graph node: `NodeV3Schema.goal_threshold` (vendored `dist/graph.js:36`); CEE echoes `goal_threshold`, `goal_threshold_raw`, `goal_threshold_unit`, `goal_threshold_cap` on `analysis_ready` (`src/adapters/cee/types.ts:346-352`).
+- **Selection:** `goalProbability` = `probability_of_joint_goal` when the option carries constraints, else `goal_probability` (`useResultsSectionData.ts:1258-1268`, via `selectGoalProbability`).
+- **Gate (exactly v6's "Goal fit needs a measurable success definition"):** `hasUserTarget = goalThreshold != null` (`buildHeroModel.ts:254`); every row's goal value is nulled without it (`:283`) and the lens is withheld (`goalAvailable = hasUserTarget && …`, `:356`) — UI-SEM-071. The sub-1% floor withholds the crown when no option is meaningfully on track (`:517-…`, UI-SEM-057).
+- **Success-measure structure (metric/direction/threshold/unit/timeframe/baseline):** shipped as the Define-success modal + `successMeasureStore`, whose honesty contract (`src/components/results/modals/successMeasureStore.ts:4-14`) states: **only the numeric `threshold` flows into the analysis** (via `setGoalThreshold → executeCanonicalRun`); the richer fields are display/record only, sessionStorage-persisted per scenario. That is ask #14 (wire extension vs brief-persisted rich fields) — needs the orchestrator/Paul ruling before the Goal-fit lens build hardens.
+
+## 4. Flip risks (relationship label + switch % + "if under-delivers, option 2 leads")
+
+**Verdict: AVAILABLE.**
+
+- **Wire:** `FragileEdgeSchema` (vendored `dist/responses.js:29-36`) is passthrough with `edge_id, from_id, to_id, current_strength, threshold, impact_on_outcome`; the live wire adds (golden fixture `robustness.fragile_edges[0]`): `switch_probability: 0.484`, `marginal_switch_probability: 0.35`, `from_label`, `to_label`, `alternative_winner_id`, `alternative_winner_label` ("Build Dedicated Mid-Market Product Tier"). `robust_edges[]` also present (absence-vs-empty semantics = ask #6; mapper keeps whatever arrives, `mapRobustness.ts:229-231`).
+- **Relationship label "X → Y":** `from_label` + `to_label` — direct.
+- **Switch %:** `switch_probability` / `marginal_switch_probability` — the shipped Strengthen flip trigger reads `marginal_switch_probability ?? switch_probability` (`StrengthenContainer.tsx:100-107`) and formats "NN% chance the result flips to {alt}" (`buildRecommendations.ts:139-143`). The hero's flip rows show "48% switch" meta via a node-id join to the same values (`buildHeroModel.ts:806-816, 855-866`).
+- **"If the top relationship under-delivers, option 2 becomes the likely leader":** DERIVABLE composition of `alternative_winner_label`/`alternative_winner_id` on the top-ranked fragile edge + the stable option number map (element 14). No fabrication needed. (Ask #7 — flip-risk single-sourcing — still applies: keep one formatter.)
+- The hero also renders threshold-style flip rows from `recommendation.flipThresholds` (`flip_value`/`current_value`/`unit`/`alternative_winner_label`, UI-SEM-074 direction rules, `buildHeroModel.ts:817-870`) — a second, also-available producer source; v6's relationship-styled rows map more naturally to `fragile_edges`.
+
+## 5. Drivers (signed direction, ranked magnitude, per-factor evidence quality)
+
+**Verdict: direction + magnitude AVAILABLE; per-factor evidence quality PRODUCER-GAP (ask #10).**
+
+- **Signed direction:** `FactorSensitivitySchema.direction` ∈ `['positive','negative']` (vendored `dist/responses.js:5,15`); fixture `factor_sensitivity[0].direction = "positive"`. Hero passes it through, omitting the glyph when absent (`buildHeroModel.ts:794-796`) — never guessed.
+- **Ranked magnitude:** `importance_score`, `sensitivity_score`, `elasticity`, `importance_rank` in the schema (`dist/responses.js:12-16`); the live wire adds `influence_score`, `influence_rank`, `value_of_information`, `evpi_percentage_points` (golden fixture `factor_sensitivity[0]`). Display uses the complete-metric-set-resolved `displayInfluence` (`types.ts:512-…`, Codex R3-B1; hero at `buildHeroModel.ts:786-788`).
+- **Per-factor evidence quality ("Low evidence" column):** the wire DOES carry raw ingredients — schema-optional `confidence` (0–1) + `confidence_components {structural_certainty, sampling_stability}` (`dist/responses.js:17-21`; fixture `confidence: 0.25`, `confidence_source: "isl"`; plus `m1_coaching.evidence_gaps[].confidence_display`). But the UI has **ruled these not display-safe as an "evidence" claim**: "Evidence-quality wording is deliberately ABSENT live: an evidence claim derived from raw confidence fields is forbidden (same class as the hidden DriversSection quality hint / trust line, issues 219/221)" — `buildHeroModel.ts:773-776`; same in `HeroEvidenceDisclosure.tsx:13-18`. So the v6 meta column is **PRODUCER-GAP per ask #10** ("check what 0.15 already carries before adding" — answer: `confidence` exists; what's missing is a display-safe evidence-quality contract or a doctrine ruling that `confidence` may be banded into "Low/Med/High evidence"). Interim: omit the column (matches ask #10). Note the raw `confidence` IS already consumed non-verbally: the LEHI Strengthen trigger gates on `confidence < 0.4 && influence > 0.5`, producer-confidence-only (`buildRecommendations.ts:29-31,160-176`).
+
+## 6. Trade-offs content (You gain / You give up / Depends on / Watch)
+
+**Verdict: PRODUCER-GAP (ask #11).**
+
+- The shipped evidence model hard-nulls the slot: "Trade-offs require a grounded producer or reviewed narrative — the live adapter has none (producer gap) … The UI must not invent trade-offs from labels" (`buildHeroModel.ts:906-910`, `evidence: { …, tradeOffs: null }`). `HeroEvidenceDisclosure.tsx:23-27`: the tab "renders ONLY when the model carries a producer/reviewed narrative … fixture-gallery-only today".
+- Nothing on the 0.15.0 wire carries this. (The legacy `Tradeoff` interface at `src/canvas/components/RecommendationCard/types.ts:83-92` belongs to an older CEE recommendation contract, not the current analysis envelope; `robustness.pareto.tradeoff_narrative` in `islRobustnessAdapter.ts:88` is a different, multi-goal surface.) Ships as hidden/honest-unavailable tab until CEE emits a typed block (additive schema ask).
+
+## 7. Adaptive priority (clarify | broaden | challenge | evaluate | commit)
+
+**Verdict: DERIVABLE interim (shipped) + PRODUCER-GAP for the canonical signal (ask #8).**
+
+- **What exists on the wire:** the CEE envelope's `stage_indicator` — golden fixture `cee_response.stage_indicator = "evaluate"`; b82c89dd fixture `"analyse"`; parsed at `useConversation.ts:243-245` / `turnService.ts:264`.
+- **Shipped bridge (UI-SEM-076):** `adaptivePriorityFromStage` maps `frame→clarify, ideate→broaden, evaluate→evaluate, decide→commit`, `optimise→null` (`StrengthenContainer.tsx:63-71`); it is **ordering only, never a gate** — matching recs float via `ADAPTIVE_MATCH_BOOST` (`buildRecommendations.ts:45-47, 303-310`), and null leaves the deterministic ladder untouched. Note: no stage maps to `challenge`, and the **commit recommendation is NOT gated on the producer priority** — it fires only on `robustness.status === 'computed' && level === 'high'` (`buildRecommendations.ts:276-280`), which diverges from v6's "commit shows only when the producer says so".
+- **Gap:** ask #8 stands — a canonical strengthen-priority/phase signal (the code's own comment: "Remove when CEE ships a canonical strengthen-priority signal on the wire", `StrengthenContainer.tsx:60-62`).
+- **Wire-vocabulary drift caveat:** `ScenarioStage = 'frame'|'ideate'|'evaluate'|'decide'|'optimise'` (`src/types/scenario.ts:55-60`), yet staging fixtures emit `stage_indicator: 'analyse'` (b82c89dd; also both 2026-05-10 debug bundles) — a value outside the union. It maps to `null` in the bridge (fail-closed, ladder untouched), which means adaptive priority silently never fires on those turns. Worth a CEE vocabulary confirmation alongside ask #8.
+
+## 8. Option-similarity ("diversity") signal
+
+**Verdict: PRODUCER-GAP (ask #9).**
+
+- `DecisionOverviewCard.tsx:263-264`: "No diversity/quality claims — the producer option-similarity signal does not exist yet."
+- The only honest producer channel today is the draft-coaching **bias signal**: vendored `CoachingSchema.bias_signals` with `BiasType ∈ ['anchoring','narrow_framing','status_quo_bias','overconfidence']` (`dist/coaching.js:2-11,31-36`); adapter `src/adapters/cee/types.ts:459` / `client.ts:136-141`; fixture proof `tests/fixtures/cee-responses/draft-graph.success.partial…/with-coaching-and-provenance.json` → `coaching.bias_signals[0].type = "confirmation_bias"`. The shipped broaden rec fires **only** from a producer `narrow_framing`-class finding — "never local option counting" (`buildRecommendations.ts:251-256`, NARROW_TYPES). **Drift note:** the fixture's `'confirmation_bias'` sits OUTSIDE the 0.15.0 `BiasType` enum (and its `widening_log` is a list where the schema declares a strict object) — so CEE is already emitting beyond the strict contract, and no `narrow_framing` emission is fixture-evidenced. The broaden gate has a wired channel but zero evidence of a live trigger.
+- v6's "Three of four options use the same mechanism" chip note and the gated "Find a route that is not hiring" rec therefore ship absent until CEE/ISL emit the signal. Interim = recommendation absent (matches ask #9).
+
+## 9. Brief quality (ready/thin/conflict) + per-chip states + framing question
+
+**Verdict: DERIVABLE (partial, shipped); conflict/unverified and the explicit framing question are PRODUCER-GAPs (ask #1).**
+
+- **Quality states (UI-SEM-079, `DecisionOverviewCard.tsx:195-215`):** `ready`/`needs_input` come from the wire (`analysis_ready.status` ∈ `ready | needs_encoding | needs_user_mapping | needs_user_input`, `adapters/cee/types.ts:330`; vendored `AnalysisReadyV3Schema.status`, `dist/analysis.js`); `blocked` derives from a blocker-severity engine critique; `thin` derives from `goalThreshold == null`; no assessment → quiet `unassessed`. v6's **"Contradictory/conflict"** state (and `unverified`) render **only via fixture `stateOverride`** (`DecisionOverviewCard.tsx:17-19,146`) — no producer framing-quality/conflict signal exists ("Remove when CEE/PLoT provide a producer framing_quality signal", `:203-204`).
+- **Per-chip states (`DecisionOverviewCard.tsx:259-291`):** Goal = saved success measure (scenario-keyed store) → committed `goalThreshold` → "Success measure missing"; Context = brief text presence (`currentBriefText`); Constraints = structured `goalConstraints` count; Options = canvas option count. All store-derived, fail-closed — DERIVABLE.
+- **Framing question (UI-SEM-078, `DecisionOverviewCard.tsx:124-140`):** derived from the top `'discuss'`-actionable guidance item (`primary_action.type === 'discuss'`, priority max — `:188-193`), preferring interrogative title/detail, else mechanically composing "What would it take to …?". This is exactly ask #1's hardened interim (T3); the explicit `framing_question` field remains a CEE ask (additive, 0.16.x). Guidance items themselves are AVAILABLE with `item_id, signal_code, category, source, title, detail, primary_action, target_object, priority, valid_while{analysis_hash}` (`guidanceStore.ts:30-53`; golden fixture `cee_response.guidance_items[0]`, `signal_code: "CTA_LITE"`).
+- `analysis_ready.user_questions` (`adapters/cee/types.ts:334`) additionally feeds the needs-input questions list (`DecisionOverviewCard.tsx:222,375-383`).
+
+## 10. Decision classification pills (stakes / reversibility / horizon / risk)
+
+**Verdict: PRODUCER-GAP for stakes, reversibility, risk; horizon DERIVABLE. No post-#309 wire home exists.**
+
+- **Where they live today: nowhere on the analysis wire.** UI-SEM-077 (`DecisionOverviewCard.tsx:231-247`): "No producer classification contract exists; the only honest client-side input today is the decision node's brief timeframe (→ horizon). Stakes, reversibility and risk appetite have NO live signal, so those pills fail closed to an explicit 'not set' state — values are NEVER fabricated. Remove when CEE provides decision_classification."
+- **Horizon:** derived verbatim from the decision node's brief block `timeframe` field (`DecisionOverviewCard.tsx:160-174`) — the same field DecisionPanel displays.
+- **Risk:** a risk-tolerance *input* exists UI-side (`useRiskProfile` presets driving re-weight, `AdvancedSection.tsx:74-…`; suggestion heuristics in `useRiskToleranceSuggestion.ts:173-178` keyed on a local `context.stakes`), but nothing producer-owned classifies the decision. The CEE→ISL preference flow (incl. `risk_tolerance`) is an explicitly NOT-IMPLEMENTED stub (`src/canvas/adapters/preferenceAdapter.ts:1-10,59`).
+- **Legacy note:** the pre-canvas app captured `importance`/`reversibility` in route state and Supabase decision metadata (`src/components/Analysis.tsx:19,105,419`; `ReversibilitySelector.tsx`), but that flow is not connected to the canvas/analysis-tab wire. If #309's decision-context/brief work is to carry these, it needs a new contract — this is a **new producer ask beyond items 8–16** (adjacent to ask #14's brief-persistence question).
+- **"Post-#309" disambiguation:** #309's "decision context" (`fix(goal-threshold): Lane 5 — representation tagging + decision-context isolation`, commit `7856b80d`) is the goal-target trio `goalThreshold / ceeAnalysisReady / outcomeNodeId` cleared atomically on scenario replacement (`DECISION_CONTEXT_CLEAR`) — it is NOT a classification store. Separately, the vendored orchestrator contract's `DecisionContextSchema` (`dist/orchestrator/decision-context.js:12-24`) is a **domain-anchors placeholder** (`monetary_figures / timeline / named_entities / goal_translation`, `status: 'not_populated'` in all current tranches, reserved for E-series coaching) — it carries no stakes/reversibility/risk fields either. Conclusion stands: no wire home exists for the classification pills.
+
+## 11. Freshness verdict + reason string
+
+**Verdict: AVAILABLE (both fields); rendering the reason as a receipt requires the ask #16 ruling.**
+
+- **Wire:** `analysis_ready.freshness ∈ 'fresh'|'stale'|'unknown'|'none'` + `freshness_reason` (`adapters/cee/types.ts:410-412`); fixture proof: b82c89dd `analysis_ready.freshness = "fresh"`, `freshness_reason = "graph_hash_match"`, plus `graph_hash_at_run` / `current_graph_hash` / `computed_at`.
+- **Verdict rendering (shipped):** `analysisFreshness.ts` store holds CEE's verdict verbatim with retain / never-absence→fresh / order-by-computed_at rules (`src/canvas/store/analysisFreshness.ts:7-17,62-80`); copy `FRESHNESS_COPY` — "Analysis reflects the current model." / "Model changed since this analysis. Re-run to update." (`AnalysisFreshnessNotice.tsx:28-31`).
+- **Reason string:** carried but doctrine-marked "Technical reason code from CEE (e.g. 'graph_hash_match') — debug only, never user copy" (`analysisFreshness.ts:23`). v6's receipt row "Freshness: Graph hash match" **promotes** it to user copy — that is exactly ask #16 (A1/Paul ruling needed). Data-wise: AVAILABLE; doctrinally: blocked until ruled. Fail-closed interim: omit the receipt row, keep the verdict strip.
+
+## 12. Receipts (simulations count, result stability verdict, result hash)
+
+**Verdict: AVAILABLE (all three v6 rows) — with two receipt-integrity caveats.**
+
+- **Simulations:** `meta.n_samples` (golden fixture `1000`; read at `useResultsSectionData.ts:975`; rendered "N simulations" `AdvancedSection.tsx:334-338`; sourced `OutputsDock.tsx:2243` `report.summary.n_samples_used ?? report.meta.n_samples`). Per-option `outcome.n_samples`/`n_valid_samples` also exist (those DO survive the V5 keep-list inside `option_comparison`). **Caveat:** the root `meta` count is **V2-path-only** (keep-list strips `meta`) — on a pure V5 turn the receipt must render honest-absent, not a stale or per-option-promoted number.
+- **Result stability ("Tentative"):** the robustness verdict is on the wire — `robustness.level` (`'very_low'` in fixture), `is_robust`, plus the ADDITIVE display-safe pair `display_verdict` (`'robust'|'moderate'|'fragile'|'not_assessed'`) and `display_verdict_reason` ("a producer-owned claim-safe phrase the UI renders verbatim") — vendored `dist/boundary/enrichment.js:244-276` (PLoT lane W5, PR #202). The calibrated verbal tier already exists: `calibrateUncertaintyCopy` maps level/label → `'confident'|'moderate'|'tentative'` with "This result is tentative…" for low/very_low (`utils/uncertaintyCalibration.ts:31,41,86-88`), honest-render (no signal → null, never invented). v6's one-word "Tentative" receipt is a re-labelling of this AVAILABLE tier. **Caveat — do NOT source this receipt from `recommendation_stability`:** the vendored 0.15.0 contract marks it "**DEPRECATED and no longer emitted** (PLoT lane H item B, 2026-07-07): it was byte-identical to the leader's win_probability. Kept optional for inbound tolerance of old payloads only — consumers must use the absence path" (`enrichment.js:250-262`; the golden fixture's 0.4375 is an old-build value and equals the leader's win probability exactly). `ResultsBody.tsx:548` still passes `recommendationStability` into `AdvancedSection` — the v6 receipts build should key on `level`/`display_verdict` instead.
+- **Result hash:** `response_hash` — `ResponseMetaSchema.response_hash` (optional; vendored `dist/analysis` — `response_hash` at the meta level) and top-level `plot_response.response_hash = "ee93f3a42afc11e1"` in the golden fixture; rendered truncated-with-copy at `AdvancedSection.tsx:376-398`. On the V5 path `mapV5AnalysisToReport` derives a deterministic **local** hash when the producer sent none (`mapV5AnalysisToReport.ts:296-303,841`) — if surfaced as a receipt it must be labelled local, not producer.
+- **Seed (v6 drops the row — correct):** `meta.seed_used` + `seed_source` exist on the V2/PLoT path (`ResponseMetaSchema`, `dist/analysis.d.ts:132-133`; fixture `"485977"`/`client_generated`; consumed at `analysisSnapshotFactory.ts:250-251`), but the V5 conversational contract carries **no seed** (ask #5) — so dropping the receipt row aligns with T2 fail-closed. **Status at this commit:** the T2 fix has NOT landed on origin/staging — `mapV5AnalysisToReport.ts:319` still fabricates `const seed = options.seed ?? 0` ("Defaults to 0 when caller has none", `:294`). The v6 build must not re-surface a seed receipt until that lane lands.
+- Freshness receipt row: see element 11 / ask #16.
+
+## 13. Strengthen recommendation fields (title / signal / why / tip / source-provenance line)
+
+**Verdict: AVAILABLE/DERIVABLE per named trigger (shipped engine); producer one-line `signal` = ask #12.**
+
+Every shipped recommendation has a named deterministic or producer-backed trigger (`buildRecommendations.ts:1-24`), with all five v6 fields populated:
+
+| Trigger | Signal source | Citation |
+|---|---|---|
+| Define success (clarify) | deterministic: `goalThreshold == null` | `buildRecommendations.ts:71-95` |
+| Phase-3 promotion | verbatim producer coaching/review blocks (title/body/`action_intent`/`action_label`/`priority_rank`/`target_refs` — b82c89dd blocks[5]) capped to producer top-4, deduped (UI-SEM-075) | `:97-129` |
+| Flip risk (evaluate) | `fragile_edges` switch prob + `alternative_winner_label` | `:131-158` |
+| LEHI range (clarify) | producer per-factor `confidence` < 0.4 ∧ influence > 0.5 — producer-confidence ONLY, never the beliefExists fallback | `:160-186` |
+| VOI (evaluate) | producer `worth_investigating` flag, else honestly-labelled UI EVPI floor ("engine flag not available") | `:188-225` |
+| Challenge leader | `robustness.level ∈ low/very_low` | `:227-249` |
+| Broaden | producer bias finding only (§19) | `:251-273` |
+| Commit | `robustness.status computed ∧ level high` | `:275-300` |
+
+- **Source-provenance line:** each rec carries an explicit `sourceLine` naming its basis (e.g. "Source: robustness analysis (fragile relationships)." `:144`; the VOI line distinguishes producer-backed vs UI-threshold `:211-214`) — v6's "Triggered because…" line is this field.
+- **Signal one-liner:** live signals are UI-composed from producer numbers ("48% chance the result flips to X…"); phase-3 promoted rows get a generic "Olumi flagged this while reviewing your model." (`:112`) because guidance blocks have no short `signal` field — that is **ask #12** (interim: T3 derives from body). The 0.15.0 block contracts confirm the field set: `ReviewCardBlockSchema`/`CoachingBlockSchema` carry `title` (≤80) / `body` (≤300) / `severity` / required `priority_rank` / structured `target_refs[]` / optional `action_intent` + `action_label` (≤40) / `coaching_kind` — but no `signal` (`dist/boundary/blocks.js:197-255`).
+- **Known container defects at this commit (already on the A2 ledger queue):** `StrengthenContainer.tsx:139` drops the producer `action_label` (`actionLabel: undefined` for every phase-3 item) and `:143` inverts priority as `100 − priority`, clamping producer ranks >100 (b82c89dd ranks 71–74 survive, but fixture ranks 101–104/201–202 collapse to one band). Fold into the Wave-3 Strengthen build.
+- Lifecycle (addressed/dismissed/in-progress, "0 addressed · 5 worth checking") is UI-local (`strengthenStore`, reconcile-by-id — `StrengthenContainer.tsx:12-15`): DERIVABLE.
+
+## 14. Option stable numbers
+
+**Verdict: DERIVABLE (shipped, UI-local).**
+
+- `selectDisplayOptions` emits `displayIndex` (re-ranks each run) and `stableNumber` — "identity-anchored ordinal: assigned once per option id in first-appearance order, stable across rerun rank flips, never reused" (`src/components/results/selectors/analysisDisplaySelector.ts:7-11,36-46`), backed by the store's `optionNumbering` map (`assignStableOptionNumbers`, `canvas/store/stableOptionNumbers`). Unregistered ids get `null`, never a colliding fallback (`:29-31`). Rendered in the hero (`HeroOptionRow.tsx:220` — `row.stableNumber ?? row.index`) and OptionCards (`OptionCards.tsx:381-386`); captured into decision records (`decisionRecordStore.ts:26-27`). No producer field needed; option identity (`option_id`/`id`, `label`) is AVAILABLE (vendored `OptionForAnalysisSchema`, `dist/analysis.d.ts:7-13`).
+
+## 15. "Answer directly" — direct brief-edit write path
+
+**Verdict: PRODUCER-GAP — no brief-edit write path exists today.**
+
+- The shipped card is explicit: "No direct brief editor exists yet — Answer directly primes the drawer draft for a straight answer instead (honest interim; see the lane report)" — `DecisionOverviewCard.tsx:408-410`; the button opens the Ask-Olumi drawer with draft prefix "My answer: " (`:411-419`, `OVERVIEW_COPY.answerDraftPrefix` `:65`).
+- What writable state exists: the brief is `currentBriefText` in the canvas store (read-only presence check at `DecisionOverviewCard.tsx:155`); the only analysis-affecting direct write is `setGoalThreshold → executeCanonicalRun` (success-measure path, `successMeasureStore.ts:5-8`); the rich measure and the decision record persist to **sessionStorage only** (`successMeasureStore.ts:16-19`, `decisionRecordStore.ts:5-9` — "NO backend persistence exists — durable saving is blocked on identity + Model Management"). v6's `data-direct-edit` ("Update this part of the persisted decision brief directly") presumes a **persisted, field-addressable brief** — that is the asks #14/#15 cluster plus the CEE brief-persistence question; no ledger item yet covers a brief-section write API, so this is an addition for the orchestrator.
+- **Decision-record wire contract already exists but is unwired (ask #15 status):** vendored 0.15.0 ships `DecisionRecordSchema` (`dist/boundary/decision-record.js` — `record_id / scenario_id / decision{chosen_option_id, chosen_option_label, graph_hash, analysis_summary} / prediction{statement, confidence} / review_date / outcome{result: better|as_expected|worse|abandoned, brier_component}`), with the explicit pin "**NOT wired into OlumiResponse (or any other producer schema) yet** ... Persistence lives in Supabase ... a Supabase migration is being authored in parallel (this sprint's Account 3 lane); FIELD NAMES MUST MATCH THIS SCHEMA EXACTLY." The v6 modal's fields should be shaped to this schema now so the sessionStorage interim migrates without translation.
+
+## Stability lens / What-changed lens (v6 ships honest-unavailable — confirming ask #13)
+
+- `buildHeroModel.ts:888-892`: "Stability / What-changed carry no live data (producer gaps 211/212) — no leader can exist on a lens with nothing to lead"; leaders hard-null. `factor_stability[]` + `stability_thresholds` exist on the wire for *factors* (golden fixture: `elasticity_std`, `attribution_stability`, `rank_flip_rate`, `stability_method: bootstrap_20`), but **per-option** stability and versioned run comparison do not — v6's honest-unavailable copy is the correct shipped state (ask #13).
+
+---
+
+## Producer-gap roll-up (maps to asks 8–16)
+
+| Ask | v6 element(s) | Fail-closed interim shipping now |
+|---|---|---|
+| #8 adaptive priority | Strengthen ordering, commit gating | stage_indicator bridge (ordering only); commit gated on robustness `high`, not producer phase |
+| #9 option-similarity | broaden rec, Options chip note | rec absent unless producer bias finding; chip note counts only |
+| #10 per-factor evidence quality | Drivers meta column | column omitted (raw `confidence` exists on wire but ruled not display-safe — needs contract or ruling) |
+| #11 trade-offs | Trade-offs tab | `tradeOffs: null`; tab fixture-gallery-only |
+| #12 guidance `signal` line | Strengthen phase-3 rows | generic signal / body-derived (T3) |
+| #13 per-option stability + run comparison | Stability & What-changed lenses | honest-unavailable copy, null leaders (gaps 211/212) |
+| #14 success-measure structure | Define-success modal, Goal chip | threshold-only on wire; rich fields sessionStorage display/record; ruling pending |
+| #15 decision-record persistence | Record-the-decision modal | sessionStorage-only record with analysisHash snapshot |
+| #16 freshness_reason promotion | "Freshness: Graph hash match" receipt | field AVAILABLE but debug-only per doctrine; receipt row withheld pending ruling |
+| *(new)* decision classification | stakes/reversibility/risk pills | "not set" pills (UI-SEM-077); horizon from brief timeframe |
+| *(new)* framing_quality conflict signal | "Contradictory" brief state + pause-read | fixture-override only; live derives ready/needs_input/thin/blocked |
+| *(new)* brief-section write path | "Answer directly" direct edit | drawer draft prefill ("My answer: ") |

--- a/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-STAGING-MAP.md
+++ b/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/V6-STAGING-MAP.md
@@ -1,0 +1,206 @@
+# V6 Staging Component Map
+
+**Baseline:** `origin/staging @ dbd6be9d` (2026-07-14, "perf(canvas): P1 round 2 … (#318)").
+All file:line references are against that commit (`git show origin/staging:<path>`), NOT the dirty working tree.
+**Prototype:** `analysis-tab-prototype-build-ready-v6.html` (this folder, 590 lines).
+
+**Headline finding:** the v6 prototype is not a greenfield build. Waves 1–3a of the Analysis-tab rebuild already landed on staging *built against this prototype family* — `DecisionOverviewCard` cites "prototype decision-overview v6", `DefineSuccessModal`/`DecisionRecordModal`/`AskOlumiDrawer` cite "build-ready v6", and the analysis-hero module implements the merged panel including the `HeroEvidenceDisclosure` ("Why and what could change it") and the next-recommendation route. The v6 build is therefore mostly (a) flag-consolidation + copy parity, (b) **retiring** the legacy surfaces that still co-mount (Options comparison, Drivers accordion, Tornado, StressTest, AnalysisFooter), and (c) a small set of producer-blocked NEW items (trade-offs narrative, per-option stability, versioned what-changed, option-similarity signal).
+
+Verdict vocabulary: **REUSE** (ship as-is), **ADAPT** (exists, needs targeted change), **REPLACE** (surface exists but v6 supersedes it with a different component), **NEW** (nothing usable exists), **RETIRE** (mounted today, absent from v6).
+
+---
+
+## 0. Feature-flag matrix (src/flags.ts)
+
+| Flag | flags.ts | Default | Staging (netlify.toml) | Gates |
+|---|---|---|---|---|
+| `decisionOverview` | src/flags.ts:423 | off | **ON** — netlify.toml:78 | DecisionOverviewCard mount (OutputsDock.tsx:2203) |
+| `strengthenPanel` | src/flags.ts:431 | off | **ON** — netlify.toml:84 | StrengthenContainer vs FocusNow (ResultsBody.tsx:315) |
+| `analysisHeroPanel` | src/flags.ts:339 | off | **ON** — netlify.toml:71 | AnalysisHeroContainer mount + DecisionConfidencePanel suppression (ResultsBody.tsx:275, 292) |
+| `analysisHeroV17` | src/flags.ts:305 | off | off | Legacy v17 hero substitution (ResultsBody.tsx:205, 301) — only relevant when `analysisHeroPanel` is OFF |
+| `analysisHeroCompare` | src/flags.ts:325 | off | off | v17+legacy side-by-side comparison (ResultsBody.tsx:295) |
+| `focusNowPanel` | src/flags.ts:315 | **on** (defaultValue: true) | on | FocusNowContainer fallback when `strengthenPanel` OFF (ResultsBody.tsx:320); "kill switch retires at 3a acceptance" |
+| `aiPanelV2` | src/flags.ts:372 | **on** (defaultValue: true) | ON — netlify.toml:50 | Olumi tab (OutputsDock.tsx:237), FloatingOlumiPanel (ReactFlowGraph.tsx:2250), results-tab freshness icon (resultsTabFreshness.ts:31) |
+| `v5CanonicalAnalysis` | src/flags.ts:391 | off | off | Canonical run routing + AnalysisOrphanBanner condition (via useAnalysisStateSource) |
+| `heroFixtureGallery` | src/flags.ts:356 | off | ON — netlify.toml:90 | Internal /#/dev/hero-gallery only; fixture models blocked from product routes |
+| `compareTab` / `journeyTab` | src/flags.ts (compareTab, journeyTab entries) | off | off | Compare/Journey dock tabs (OutputsDock.tsx:239, 241) |
+
+So on staging today the v6 stack (`decisionOverview` + `analysisHeroPanel` + `strengthenPanel` + `aiPanelV2`) is **already the live configuration**.
+
+---
+
+## 1. DecisionOverviewCard (+ ActionsMenu / actionsCatalogue, framing question) — **REUSE**
+
+v6: `#decisionOverview` card — title, classification pills, Actions menu, collapsible brief bar, four brief chips, "Review your decision brief" row, Olumi's framing question (prototype lines 210–248).
+
+- `src/components/results/decision-overview/DecisionOverviewCard.tsx` (451 lines). Header doc:1–22 explicitly: "Wave 1 + parity O — Decision overview card (brief §4, prototype decision-overview v6)". Copy deck `OVERVIEW_COPY` :40–75 matches v6 verbatim ("Framing has the basics", "Olumi's framing question", "Answer directly", "Work through with Olumi").
+  - Card root `data-testid="decision-overview"` :303; classification pills :328 (`decision-pill-${dim}`, stakes/reversibility/horizon/risk per :102); **ActionsMenu mounted inside the card** :326; brief bar :331; brief-dimension chips :355–366 (`brief-dim-*`); needs-input questions list :376; brief-actions row :385; framing question block :401–442 (both buttons route to the Ask-Olumi drawer via `openAskOlumi`, :414 and :429).
+  - Framing-question derivation `deriveFramingQuestion` :131 (UI-SEM-078 — interrogative from top `discuss` guidance item, selected :190); brief-state machine :195–225 (UI-SEM-079: ready/needs_input/unassessed live, thin/blocked live-derived, contradictory/unverified fixture-only via `stateOverride`).
+- `src/components/results/decision-overview/ActionsMenu.tsx` (192 lines): methods open the drawer with prefilled editable draft (:90–101, `parameters: { method_id }`); `rerun_analysis` is a DIRECT canonical run (:107–113); `edit_brief` reuses `REVIEW_BRIEF_ASK` (:127).
+- `src/components/results/decision-overview/actionsCatalogue.ts` (111 lines): `METHOD_CATALOGUE` :49–92 and `GLOBAL_ACTIONS` :94–111 are byte-for-byte the v6 `methods` array (prototype lines 444–455): 7 methods + Edit decision brief / Review all inputs / Rerun analysis. `REVIEW_BRIEF_ASK` :31, `RERUN_TOASTS` :43 (honest "started" vs prototype "completed").
+- Mount: OutputsDock.tsx:2203–2205, gated `isDecisionOverviewEnabled() && !isPreRun && hasInlineSummary && resultsSectionData`; title from `overviewTitle` memo (OutputsDock.tsx:633).
+- **Flag:** `decisionOverview` (staging-on).
+- **Delta vs v6:** v6's "Answer directly" claims to "Update this part of the persisted decision brief directly" (prototype :492–494); staging routes it to the drawer with an `answerDraftPrefix` ("My answer: ", :62) — a deliberate approximation until a direct brief-edit path exists. v6 mounts the card in ALL states including pre-run conflict; staging gates on `!isPreRun && hasInlineSummary` (post-run only).
+
+## 2. AnalysisFreshnessNotice + resolveDisplayedFreshness + results-tab icon — **REUSE**
+
+v6: `.status-strip` — colour dot, current/stale line, Rerun ghost button (prototype :249–255).
+
+- `src/components/results/AnalysisFreshnessNotice.tsx` (155 lines). `FRESHNESS_COPY` :28–33 (fresh/stale/unknown/none); prototype-v6 colour-only dot vocabulary :35–43; renders nothing without a verdict :88; Rerun offered in every state except `none` (:98–101, "Parity audit: the prototype offers Rerun in the FRESH state too") and routes through `executeCanonicalRun({ source: 'freshness-strip' })` :138 with honest blocked/unavailable toasts :139–141; rerun-completed toast on running→complete :63–85 (with the settled-without-new-report honesty branch :78).
+- `resolveDisplayedFreshness` — `src/canvas/store/analysisFreshness.ts:119` (values type :19). Rule: CEE verdict is source of truth; local dirty overlay may only downgrade retained `fresh` → `unknown`, never fabricate `stale`.
+- Mount: OutputsDock.tsx:2209–2211 — deliberately ABOVE the stale wrapper "the recovery control must never sit inside an aria-disabled region" (:2206–2208). It is **the sole freshness owner**: the old top-level stale banner is retired (:2172–2176) and the results body is marked, not dimmed (:2212–2229, `data-freshness-confirmed`, `aria-busy`).
+- Results-tab icon states: `deriveResultsTabFreshness` — `src/canvas/components/resultsTabFreshness.ts:27–35` (genuine `stale` → warning glyph; overlay `unknown` → NEUTRAL glyph, "never fabricate stale"; gated on `aiPanelV2`). Consumed OutputsDock.tsx:1585–1586 (from `displayedFreshness` at :601), rendered on the Analysis tab label :1689–1692.
+- **Flag:** none for the strip itself; the tab icon is gated by `aiPanelV2`.
+
+## 3. Merged analysis panel (AnalysisHero*) — **REUSE core / ADAPT at the edges**
+
+v6: `#hero` `data-component="merged-analysis-panel"` — headline + subline, 4-lens strip, option table with range bars, quick-link pills, conflict pause-read, evidence disclosure, next-recommendation route (prototype :256–313).
+
+- `src/components/results/analysis-hero/AnalysisHeroContainer.tsx` (67 lines) — "the ONE authorised mount" (doc :2–7, enforced by `__tests__/inertness.spec.ts`), mounted exclusively at ResultsBody.tsx:275–284 behind `analysisHeroPanel`, inside a SectionErrorBoundary; fail-closed empty model :51. Focus routed through `focusModelTarget` :48–50.
+- `src/components/results/analysis-hero/useAnalysisHero.ts` — builds the model (:66 `buildHeroModel(data, optionNumbering, canvasNodeIds)`); **next recommendation read live from strengthenStore** (:26, :79–83, gated on `isStrengthenPanelEnabled()` :70); rerun via `executeCanonicalRun({ source: 'analysis-hero' })` :89; `focusPanelSelector` targets `[data-testid="strengthen-panel"]` :46.
+- `src/components/results/analysis-hero/AnalysisHeroPanel.tsx` (690 lines, store-free): paused/blocked status variants (`hero-status-${variant}`, `hero-paused-resolve`) :105–120 — the v6 quality-conflict "pause read"; headline :309 / subline :324; lens strip :336; honest unavailable-lens body + inline "Define success" CTA :355–366; option rows :400–403; quick-link pills (`hero-quicklink-driver` / `-flip` / `-combined`) :432–461; `HeroEvidenceDisclosure` :476; rerun :510; focus-target editor + apply-threshold :530–618; **next-step route row** (`hero-next-rec`, "prototype §5 .analysis-next-route: mirrors the TOP active Strengthen entry; Open scrolls to the panel") :651–667.
+- `src/components/results/analysis-hero/HeroLensTabs.tsx` (121 lines) + `heroTypes.ts` — `HeroLens = 'goal' | 'outcome' | 'stability' | 'whatChanged'` :19, fixed order :22. **The four v6 lenses exist here** (Goal fit / Likely outcome / Stability / What changed — `heroCopy.ts:28–38`), Goal fit + Likely outcome live, Stability + What changed honest-unavailable (`heroCopy.ts:47–53`; heroTypes doc :11–16 "Olumi will not infer it in the UI" semantics).
+- `src/components/results/analysis-hero/buildHeroModel.ts` — flip-threshold filtering :272; evidence flip-risk sentences from producer `flipThresholds` :817–826.
+- `src/components/results/analysis-hero/HeroOptionRow.tsx` (454 lines) — stable option numbers + range tracks (numbering via `selectors/optionNumberingStore`).
+- `src/components/results/analysis-hero/heroCopy.ts` — headline banding (`slightlyAhead` :86, `noClearLeader` :88, producer `decision_brief.headline_banded` adoption :74–75); sublines :105–130.
+- **Flag:** `analysisHeroPanel` (staging-on, production-off). When ON it also **suppresses** `DecisionConfidencePanel`/v17 (ResultsBody.tsx:286–304 "Wave 2 flag-scoped retirement").
+- **ADAPT for v6:** v6 makes this panel the *only* driver/flip surface (see §5) and the only headline surface; the remaining work is retiring the parallel legacy sections below it, not changing the panel. v6's `.analysis-evidence-toggle` copy ("Why and what could change it" / "Drivers, flip risks and trade-offs") already matches HeroEvidenceDisclosure doc :2–7.
+
+## 4. Lens/tab structures — **REUSE** (they exist inside the hero, nowhere else)
+
+- Goal fit / Likely outcome / Stability / What changed live at `analysis-hero/HeroLensTabs.tsx` + `heroTypes.ts:19–22` + `heroCopy.ts:28–38` (see §3). No other Analysis-tab component implements the lens strip.
+- Goal-fit unlock: null-target suppression + "Set a success target to unlock Goal fit" (`heroCopy.ts:48`) with the Define-success CTA (AnalysisHeroPanel.tsx:366).
+- Note: `WhatChangedChip` (ResultsBody.tsx:268, `src/canvas/components/WhatChangedChip.tsx`) is a *client-side* run-over-run diff chip — it is NOT the "What changed" lens and contradicts the v6 doctrine that the UI "will not approximate it locally" (prototype :277). Retirement candidate (§13).
+
+## 5. DriversSection + driverDisplayModel — **REPLACE surface, REUSE policy module**
+
+- `src/components/results/DriversSection.tsx` (1005 lines) mounts as its own accordion "What's driving this" at ResultsBody.tsx:412–437. **v6 has no standalone drivers accordion** — drivers are the first evidence tab inside the merged panel (prototype :289–295), already implemented by `HeroEvidenceDisclosure` (top-3 + "See all factors", +/- producer direction sign, influence magnitude bar — doc :10–17, `VISIBLE_DRIVERS = 3` :36).
+- Verdict: **RETIRE the ResultsBody accordion mount** in the v6 layout; **REUSE `src/components/results/driverDisplayModel.ts`** — it is the declared single source of truth for "which number a driver displays and how it is ranked", shared by the Drivers panel, the analysis hero, and the canvas badge (doc :1–21; `DriverDisplayProvenance` :23; `computeNormalisedInfluences` :39). The evidence tab already consumes the same displayed metric ("UI-SEM-080 layout mapping", HeroEvidenceDisclosure.tsx:13).
+- Caveat: HeroEvidenceDisclosure deliberately omits the v6 "Low evidence" per-row wording ("no display-safe producer contract", doc :14–17) — the evidence-quality meta column is **NEW/producer-blocked**.
+
+## 6. Flip-risk data consumers (`robustness.fragile_edges`) — inventory
+
+Producers/mappers:
+- `src/adapters/plot/v2/responseMapper.ts` — fragile/robust extraction :521–539, confidence proxy :738–743, display payload :1150–1212.
+- `src/adapters/plot/enrichment.ts` — `fragile_edges` on sensitivity :92, :427–484, count :519.
+
+UI consumers on the Analysis tab:
+- `useResultsSectionData` → `confidence.challengeFragileEdges` → `StressTestSection` (props :53, :189, merged cards :227; mounted ResultsBody.tsx:520–532) — **RETIRE from tab** (not in v6; its "sensitive assumptions" content is covered by the evidence Flip risks tab + Strengthen's flip rec).
+- `ChallengeSection.tsx` (:36 "Fragile edge from robustness.fragile_edges") — already superseded by StressTestSection (ResultsBody.tsx:490–494 comment); file is legacy. **RETIRE**.
+- `analysis-hero/buildHeroModel.ts:817–826` — evidence Flip risks tab (switch-probability meta, named alternative winner). **REUSE — this is the v6 renderer.**
+- `strengthen/buildRecommendations.ts:129–131` — top flip risk → the "Test the assumption most likely to change the leader" rec (inputs mapped from `challengeFragileEdges` at StrengthenContainer.tsx:94–98). **REUSE.**
+- `AdvancedSection` receives `fragileEdgeCount`/`robustEdgeCount` (OutputsDock.tsx:2245–2246 → ResultsBody.tsx:551–552). **REUSE (receipts).**
+- Off-tab (unaffected): `ModelTabBody.tsx:400–402` (Model tab), `LensInfoPanel.tsx:158` (canvas graph lens), `TornadoChart` flip markers via `flipThresholds` (retiring with Tornado, §13).
+
+## 7. StrengthenPanel / StrengthenContainer / buildRecommendations / strengthenCopy / strengthenStore — **REUSE**
+
+v6: `#strengthCard` — "Strengthen your model", "N addressed · M worth checking", one-open-by-default list, Try-this lead, Focus on canvas / Not relevant / ask icon, Show more / Expand all, addressed history (prototype :314–323, 408–441).
+
+- `src/components/results/strengthen/StrengthenPanel.tsx` — store-free panel; `data-testid="strengthen-panel"` :271; progress summary :277; exactly-one-open discipline :224–247; per-rec status pills (In progress / Reopened) :123–134; stale label :140; Try-this :158; actions row :177–200.
+- `src/components/results/strengthen/StrengthenContainer.tsx` — the ONE store-aware mount (doc :1–33): maps producer inputs (worth_investigating, CEE bias signals, stage), reconciles the lifecycle store per completed analysis, credits the success rec directly on goal-threshold set, labels visible-but-stale, routes primary actions vs the prefilled drawer. `adaptivePriorityFromStage` :63–70 (frame→clarify, ideate→broaden, evaluate→evaluate, decide→commit — the v6 "Adaptive priority" control's live equivalent).
+- `src/components/results/strengthen/buildRecommendations.ts` — deterministic trigger ladder (PRIORITY :47–56; success-measure deterministic; flip :129; LEHI path-conditional; VOI honesty; **broaden fires ONLY from a producer bias finding** :251–269; commit producer-gated :280–297; flood control `MAX_PHASE3_PROMOTED = 4` :41; adaptive boost :45).
+- `src/components/results/strengthen/strengthenCopy.ts` :6–34 — strings marked "(spec) verbatim from the build-ready v6 prototype copy deck".
+- `src/canvas/stores/strengthenStore.ts` (254 lines) — the lifecycle: reconcile-by-id never wholesale replace, reopen-on-new-hash, auto-address, visible-but-stale via `markAllStale`, `restoreDismissed` undo; sessionStorage `strengthen.lifecycle.v1` :66 (doc :1–25; `RecRecord` :36–47).
+- Mount: ResultsBody.tsx:315–318 behind `strengthenPanel` (staging-on); flag-off fallback `FocusNowContainer` :320–324 (retires at 3a acceptance).
+- **Delta vs v6:** v6's broaden rec uses a "producer-owned option-similarity signal" (prototype :410, diversity control :200–205); staging has no such signal — broaden keys off producer bias findings only. NEW producer dependency if v6's diversity trigger is wanted.
+
+## 8. AdvancedSection receipts — **ADAPT**
+
+v6: one collapsed `<details>` "Advanced and receipts" with a 4-row grid: Simulations / Freshness ("Graph hash match") / Result stability ("Tentative") / Result hash (prototype :324).
+
+- `src/components/results/AdvancedSection.tsx` — accordion titled "Advanced and receipts" :138; receipts grid `data-testid="analysis-receipts"` :319–390 (stability %, simulations, edges, graph size, identifiability, seed, copyable hash :375–386; "the prototype's receipts are for EVERYONE — the expert-mode gate hid…" :320–322). Also still hosts the risk-tolerance slider (doc :4–8) and inference-warning surfacing (:17, :563).
+- Mounted ResultsBody.tsx:545–566.
+- **ADAPT:** (a) fold the robustness display verdict (today rendered by the footer, §9) into the receipts as v6's "Result stability" row, reusing `derivePostFooterStatus`'s fail-closed mapping; (b) add the "Freshness: graph hash match" receipt row (source: the freshness slice's reason field, already on `data-freshness-reason` — AnalysisFreshnessNotice.tsx:112); (c) decide whether the risk slider stays (v6's receipt block has no slider; RiskAppetiteFilter currently renders in the Options section, ResultsBody.tsx:350, which v6 retires).
+
+## 9. AnalysisFooter + postAnalysisFooter — **RETIRE** (v6 removes the sticky footer)
+
+- `src/canvas/shared/AnalysisFooter.tsx:35–112`, mounted at OutputsDock.tsx:2277–2292 with `derivePostFooterStatus`/`derivePostFooterMeta` from `src/canvas/components/utils/postAnalysisFooter.ts` (imports OutputsDock.tsx:114–115; status derivation :1131). The helper's contract doc (postAnalysisFooter.ts:1–40) is the ROBUSTNESS-VERDICT-CONTRACT: verdict only from producer `robustness.display_verdict`, raw stability only as neutral meta beside a determinate verdict.
+- v6 has no post-run footer; its robustness statement becomes a receipt row (§8) and Rerun already exists in TWO v6-sanctioned places staging has: the freshness strip (AnalysisFreshnessNotice.tsx:131–149) and the Actions menu (`rerun_analysis`, ActionsMenu.tsx:107).
+- **Keep the pure helper** (`derivePostFooterStatus`) as the verdict→copy mapping for the receipt row; retire the mount. Note the existing V17-only suppression interlock (OutputsDock.tsx:720–725, `suppressAnalysisFooterForOrphanBanner`) goes with it. `AnalysisFooter` itself remains used by the pre-run `StickyFooter` (src/canvas/components/pre-analysis/StickyFooter.tsx:133) — retire the *post-run mount*, not the shared component.
+- Related already-dead code: `ResultsFooter.tsx` still exists but is unmounted (deletion note ResultsBody.tsx:587–591).
+
+## 10. DefineSuccessModal / goal-threshold commit path — **REUSE**
+
+v6: `#successModal` — metric/direction/threshold/unit/timeframe/baseline, live sentence preview, "Save and rerun", write-note (prototype :329–343, 507–515).
+
+- `src/components/results/modals/DefineSuccessModal.tsx` — header doc :1–23: "prototype #successModal, build-ready v6 … ONE setter + ONE rerun … never a second rerun pipeline". Copy deck :52–70 matches v6 verbatim incl. the write-note; adds the honesty note "Only the target number affects the analysis today" :67. Commit path: `setGoalThresholdAndUpdateNode(goalNodeId, parsedThreshold)` :203 (fallback bare `setGoalThreshold` :205) then `executeCanonicalRun({ source: 'define-success-modal', … })` :223–224 — the same convention as OutputsDock's `handleApplyThreshold` (OutputsDock.tsx:940–989, node+global write :944–945).
+- `src/components/results/modals/successMeasureStore.ts` — structured measure per scenario, sessionStorage, version-keyed (doc :1–18); **honesty contract:** only `threshold` reaches the wire (`SuccessMeasure` :28–42). `measureSentence.ts` builds the preview; `scenarioKey.ts` resolves the key.
+- **Current (post-#309/#317-era) representation model:** `store.goalThreshold` holds RAW user units with representation carried explicitly in `store.goalThresholdRepresentation: 'raw' | 'normalised' | null` (store.ts:331; set at :2714 and :2721; node-derived thresholds always 'raw' :1077–1090). Request-side normalisation is UI-SEM-058: `resolveChipGoalThreshold` (useV2Run.ts:192–230) divides by the resolved cap (`resolveGoalThresholdCap` :134–151: analysis_ready first, then goal-node data, then measure-unit cap) and **short-circuits when representation is already 'normalised'** (:226) so a CEE bare-synced 0–1 value is never re-divided (doc :69–78). The V5 chip build applies the same normalisation + representation short-circuit (:598–640). The Strengthen success rec is credited directly on threshold set (StrengthenContainer doc :15–18) so a failed rerun never leaves a stale rec.
+- `DecisionRecordModal` (v6 `#decisionModal`) also exists and is REUSE: `src/components/results/modals/DecisionRecordModal.tsx` doc :1–23 — options populated read-only from the live analysed set (never the prototype fixtures), confidence validation closes the prototype's `Number('')===0` hole, sessionStorage `decisionRecordStore.ts`, opened via `openDecisionRecord()` (the spec explicitly flags the prototype's 'ask' routing for the commit rec as "a critical wiring bug not to copy").
+- Mounts: `AskOlumiDrawer` / `DefineSuccessModal` / `DecisionRecordModal` mounted once at OutputsDock.tsx:1632–1636 (outside the tab switch — always available).
+
+## 11. FloatingOlumiPanel / AskOlumiDrawer (v6 drawer analogue) — **REUSE**
+
+v6's `#olumiDrawer` ("Work through it with Olumi": fixed bottom-right, context box, prefilled editable textarea, Focus on canvas + Send) maps to **AskOlumiDrawer**, not FloatingOlumiPanel:
+
+- `src/components/results/coaching/AskOlumiDrawer.tsx` — header doc :1–24: "Parity P1 — 'Work through it with Olumi' drawer (prototype #olumiDrawer, build-ready v6)". Anatomy per spec; Send dispatches conversation-typed turn via guidance-store degrade chain (`_dispatchAction → _sendMessage`, :45–47) with an honest disabled state; focus via `focusModelTarget`; self-contained toast. Opened everywhere via `openAskOlumi` (`askOlumiStore.ts`). **REUSE — every v6 "drawer" interaction already routes here** (overview pills/chips, methods, strengthen ask-buttons, framing question).
+- `src/canvas/components/FloatingOlumiPanel.tsx` (1,048 lines) — the aiPanelV2 draggable/resizable floating conversation panel (portal), hosting `ConversationPanel` + `AIInputBar`; mounted via `FloatingOlumiPanelHost` at ReactFlowGraph.tsx:2250/2341 behind `aiPanelV2` (default ON). This is v6's "deeper dialogue opens in Olumi" destination. **REUSE unchanged** — v6 does not alter it.
+
+## 12. AnalysisOrphanBanner / InferenceWarningStrip — **REUSE (keep; not in v6 — confirm)**
+
+- `src/components/results/AnalysisOrphanBanner.tsx` — renders only when `useAnalysisStateSource().showOrphanBanner` (source === 'orphaned_plot_result' under the `v5CanonicalAnalysis` flag; doc :1–17); Run analysis fires the V5 chip path :28–36; mounted ResultsBody.tsx:253. Honesty surface, no v6 equivalent; keep unless Paul rules otherwise.
+- `src/components/results/InferenceWarningStrip.tsx` — warning-severity producer `inference_warnings` only, humanised, fail-closed (doc :1–23; selector :36–41); mounted ResultsBody.tsx:263 directly below the freshness area. Same class of honest caveat; keep.
+
+## 13. OutputsDock results-tab mount order (full sweep) + retirement candidates
+
+`src/canvas/components/OutputsDock.tsx` (2,406 lines), `effectiveActiveTab === 'results'` block :1785–2294. Order as mounted:
+
+| # | Component / block | Lines | In v6? | Verdict for v6 |
+|---|---|---|---|---|
+| 1 | `ai-panel-transition-receipt` ("Model drafted. Review readiness.") | 1787–1796 | no | RETIRE-candidate (transitional chrome) |
+| 2 | Error display: coached intervention-recovery branch + generic `outputs-error-banner` | 1799–2012 | no (v6 has no error state) | KEEP (error path, orthogonal to v6) |
+| 3 | Pre-run: `PreAnalysisPanelV3` (flag `preAnalysisV3`, lazy) / legacy `PreAnalysisPanel` | 2015–2044 | no (v6 is post-run only) | KEEP (pre-run surface, separate workstream) |
+| 4 | `slow-run-message` strip | 2046–2056 | no | KEEP (run feedback) |
+| 5 | `AnalysisRunningBanner` (running + report) | 2060 | no | KEEP |
+| 6 | Cancel button (`isV2RunInFlight`) | 2065–2077 | no | KEEP |
+| 7 | `ResultsPanelSkeleton` (running, no report) | 2079–2081 | no | KEEP |
+| 8 | `IdentifiabilityBadge` | 2083–2092 | no | RETIRE-candidate (identifiability already a receipt row in AdvancedSection) |
+| 9 | `ValidationPanel` (blocker engine critique, freshness-gated) | 2104–2111 | partially (v6 conflict pause-read) | KEEP for now; hero 'paused' status is the v6 conflict surface |
+| 10 | `WarningBanner` (response warnings) | 2113–2124 | no | RETIRE-candidate (overlaps InferenceWarningStrip) — decision |
+| 11 | `DegradedStateBanner` (CEE degraded / partial ISL) | 2126–2157 | no | KEEP (honesty) — decision |
+| 12 | `stale-results-banner` (error + retained report) | 2160–2171 | no | RETIRE-candidate (freshness strip owns staleness) |
+| 13 | `conv-results-indicator` ("Updated from conversation") | 2178–2191 | no | RETIRE-candidate |
+| 14 | **DecisionOverviewCard** | 2203–2205 | yes | REUSE (§1) |
+| 15 | **AnalysisFreshnessNotice** | 2209–2211 | yes (status-strip) | REUSE (§2) |
+| 16 | Stale wrapper + **ResultsBody** | 2212–2271 | — | see below |
+| 17 | **AnalysisFooter** (post-run) | 2277–2292 | **no** | RETIRE (§9) |
+
+Inside `ResultsBody` (`src/components/results/ResultsBody.tsx`, render :247–599), order:
+
+| # | Component | Lines | In v6? | Verdict |
+|---|---|---|---|---|
+| a | `AnalysisOrphanBanner` | 253 | no | REUSE/keep (§12) |
+| b | `InferenceWarningStrip` | 263 | no | REUSE/keep (§12) |
+| c | `WhatChangedChip` (client-side run diff) | 268 | **no** (v6: What-changed lens is producer-blocked, "will not approximate locally") | RETIRE-candidate — decision |
+| d | **AnalysisHeroContainer** (flag `analysisHeroPanel`) | 275–284 | yes (merged panel) | REUSE (§3) |
+| e | `DecisionConfidencePanel` / `AnalysisHeroV17` (+compare) — only when `analysisHeroPanel` OFF | 292–304 | no | RETIRE once `analysisHeroPanel` is accepted (Wave 2 flag-scoped retirement already written, :286–291); then archive `DecisionConfidencePanel.tsx` + `analysisHeroV17/` module |
+| f | **StrengthenContainer** (flag `strengthenPanel`) / `FocusNowContainer` fallback | 315–325 | yes | REUSE (§7); retire FocusNow + `focusNowPanel` at 3a acceptance |
+| g | Options comparison: `SectionHeader` "Your options" + `RiskAppetiteFilter` + `WinGauge` + `OptionCards` | 337–409 | **no** (v6's option table lives inside the hero's outcome lens) | RETIRE from tab — decision (note the 2026-05-27 revert comment :330–336 that reinstated it; `CompactOptionSpread` kept-in-repo unused) |
+| h | Drivers accordion "What's driving this" + `DriversSection` | 412–437 | **no** (evidence tab) | RETIRE (§5) |
+| i | Tornado accordion "What could change the result" + `TornadoChart` + flip-thresholds status notes | 440–484 | **no** | RETIRE — flip risks move to the evidence tab |
+| j | `StressTestSection` ("Stress-test your decision") | 488–538 | **no** | RETIRE — content covered by evidence Flip risks + Strengthen challenge recs; methods menu carries pre-mortem/consider-the-opposite |
+| k | **AdvancedSection** | 545–566 | yes (receipts) | ADAPT (§8) |
+| l | Adjustments-made details (strength corrections) | 569–585 | no | RETIRE-candidate (fold into receipts) — decision |
+| m | `DevBuildMarker` (dev+expert only) | 598, 610–625 | no | KEEP (dev-only) |
+
+Dock chrome: tab strip `getOutputTabsForParity` OutputsDock.tsx:232–243 — Olumi | Analysis | Compare(flag) | Model | Journey(flag) — matches the v6 dock (Olumi / Analysis / Compare / Model) except Compare is behind `compareTab` (default off).
+
+## 14. NEW items (nothing usable on staging)
+
+1. **Trade-offs live data** — HeroEvidenceDisclosure renders the Trade-offs view only from a producer/reviewed narrative, "null live — the UI must not invent trade-offs" (doc :23–26). Needs a producer contract.
+2. **Per-option Stability lens** — heroTypes.ts:122 requires the per-option producer field; honest-unavailable until then.
+3. **What changed lens** — requires versioned run comparisons (producer); local `WhatChangedChip` is explicitly not this.
+4. **Option-similarity / diversity signal** for the broaden rec (v6 prototype control) — staging's broaden trigger is producer-bias-only (buildRecommendations.ts:251–269).
+5. **Evidence-quality meta** ("Low evidence") on driver rows — no display-safe producer contract yet (HeroEvidenceDisclosure.tsx:14–17).
+6. **Direct brief edit** ("Answer directly" writing to a persisted brief) — currently a drawer draft (§1 delta).
+7. **Durable decision-record persistence** — sessionStorage only; blocked on identity + Model Management (DecisionRecordModal doc :16–18; v6 prototype-note says the same).
+
+---
+
+### Verdict summary
+
+REUSE: DecisionOverviewCard + ActionsMenu/actionsCatalogue, AnalysisFreshnessNotice + resolveDisplayedFreshness + tab icon, analysis-hero module (panel/container/hook/model/rows/copy/lens tabs/evidence disclosure/next-route), Strengthen stack + strengthenStore, DefineSuccessModal + successMeasureStore + canonical threshold commit, DecisionRecordModal, AskOlumiDrawer, FloatingOlumiPanel, AnalysisOrphanBanner, InferenceWarningStrip, driverDisplayModel.
+ADAPT: AdvancedSection (receipt rows: result-stability verdict + freshness receipt; slider decision), DecisionOverviewCard pre-run gating if v6 wants the overview in conflict/pre-run states.
+REPLACE: standalone DriversSection accordion → hero evidence Drivers tab.
+RETIRE: AnalysisFooter post-run mount (+postAnalysisFooter mount wiring), Options-comparison section (WinGauge/OptionCards/RiskAppetiteFilter placement), Tornado accordion, StressTestSection, DecisionConfidencePanel + analysisHeroV17 module (flag-off fallbacks), FocusNowContainer + focusNowPanel flag, WhatChangedChip, ChallengeSection + ResultsFooter (already dead), stale-results banner, conv indicator, IdentifiabilityBadge, transition receipt.
+NEW: producer-blocked items in §14.

--- a/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/analysis-tab-prototype-build-ready-v6.html
+++ b/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/analysis-tab-prototype-build-ready-v6.html
@@ -1,0 +1,589 @@
+<!DOCTYPE html>
+
+<html lang="en-GB">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1" name="viewport"/>
+<title>Olumi Analysis tab, build-ready prototype v6</title>
+<style>
+:root {
+  --bg-canvas:#F4F0EA;
+  --bg-panel:#FEFEFE;
+  --bg-panel-hover:#FEF9F3;
+  --border-default:#EEE6D8;
+  --text-header:#262626;
+  --text-body:#3F3F3E;
+  --text-light:#908D8D;
+  --text-on-colour:#FFFFFF;
+  --danger:#EA7B4B;
+  --success:#67C89E;
+  --info:#63ADCF;
+  --warning:#FFA656;
+  --goal:#F5C433;
+  --option:#AAA7E4;
+  --factor:#B0A899;
+  --primary:#63ADCF;
+  --primary-hover:#67C89E;
+  --primary-active:#5AA88A;
+  --panel-header:14px;
+  --panel-body:12px;
+  --panel-meta:11px;
+  --shadow-1:0 1px 2px rgba(38,38,38,.06);
+  --shadow-2:0 4px 12px rgba(38,38,38,.10);
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg-canvas);color:var(--text-body);font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;font-size:var(--panel-body);line-height:1.5}
+button,input,select,textarea{font:inherit}
+button{color:inherit}
+svg{display:block}
+.page{width:min(1160px,100%);margin:0 auto;padding:22px 18px 70px}
+.page-title{margin:0;color:var(--text-header);font-size:var(--panel-header);font-weight:600}
+.page-sub{margin:4px 0 16px;color:var(--text-light);font-size:var(--panel-body)}
+.layout{display:grid;grid-template-columns:minmax(270px,1fr) 430px;gap:24px;align-items:start}
+@media(max-width:860px){.layout{grid-template-columns:1fr}.controls{position:static!important}}
+.controls{position:sticky;top:16px;background:var(--bg-panel);border:1px solid var(--border-default);border-radius:12px;box-shadow:var(--shadow-1);padding:14px}
+.controls h2,.controls h3{margin:0;color:var(--text-header);font-size:var(--panel-header);font-weight:600}
+.controls h3{margin-top:14px}
+.controls p,.controls li{font-size:var(--panel-body)}
+.controls p{margin:4px 0 0}.controls ul{margin:6px 0 0;padding-left:18px}.controls li+li{margin-top:4px}
+.control{margin-top:11px}.control-label{display:block;margin-bottom:5px;color:var(--text-light);font-size:var(--panel-meta)}
+.segment{display:flex;flex-wrap:wrap;gap:5px}
+.segment button,.ghost-button,.text-button,.icon-button,.tab-button,.row-action,.brief-chip,.method-button,.recommendation-head{background:transparent;border:1px solid var(--border-default);cursor:pointer}
+.segment button{padding:5px 9px;border-radius:999px;font-size:var(--panel-body)}
+.segment button[aria-pressed="true"]{border-color:var(--info);color:var(--text-header)}
+.segment button:hover,.ghost-button:hover,.text-button:hover,.icon-button:hover,.tab-button:hover,.row-action:hover,.brief-chip:hover,.method-button:hover,.recommendation-head:hover{background:var(--bg-panel-hover)}
+.note{margin-top:12px;padding:9px 10px;border:1px solid var(--info);border-radius:12px;background:var(--bg-panel);font-size:var(--panel-body)}
+.note strong{color:var(--text-header);font-weight:600}
+
+.mock{width:100%;max-width:430px;background:var(--bg-canvas);border:1px solid var(--border-default);border-radius:18px;box-shadow:var(--shadow-2);overflow:hidden}
+.dock{display:flex;gap:4px;padding:8px 10px;background:var(--bg-panel);border-bottom:1px solid var(--border-default)}
+.dock button{padding:6px 9px;border:1px solid transparent;border-radius:999px;background:transparent;color:var(--text-light);cursor:pointer;font-size:var(--panel-body)}
+.dock button.active{border-color:var(--info);color:var(--text-header)}
+.content{display:flex;flex-direction:column;gap:9px;padding:11px 12px 14px}
+.card,.status-strip,.modal-card,.drawer{background:var(--bg-panel);border:1px solid var(--border-default);border-radius:12px;box-shadow:var(--shadow-1)}
+.card{overflow:hidden}
+.card-pad{padding:11px 12px}
+.card-title{margin:0;color:var(--text-header);font-size:var(--panel-header);font-weight:600}
+.card-copy{margin:3px 0 0;color:var(--text-body);font-size:var(--panel-body)}
+.meta{color:var(--text-light);font-size:var(--panel-meta)}
+.status-strip{display:flex;align-items:center;gap:8px;padding:8px 10px}
+.status-strip .grow{flex:1}.status-current{display:inline}.status-stale{display:none}.mock.stale .status-current{display:none}.mock.stale .status-stale{display:inline;color:var(--text-header)}
+.status-icon{color:var(--success)}.mock.stale .status-icon{color:var(--warning)}
+.primary-button{display:inline-flex;align-items:center;justify-content:center;gap:5px;padding:7px 11px;border:1px solid var(--primary);border-radius:999px;background:var(--primary);color:var(--text-on-colour);cursor:pointer;font-size:var(--panel-body);font-weight:600}
+.primary-button:hover{border-color:var(--primary-hover);background:var(--primary-hover)}.primary-button:active{border-color:var(--primary-active);background:var(--primary-active)}
+.primary-button:disabled{opacity:.4;cursor:not-allowed}
+.ghost-button{display:inline-flex;align-items:center;gap:5px;padding:6px 10px;border-radius:999px;font-size:var(--panel-body)}
+.text-button{padding:2px 0;border:0;color:var(--info);font-size:var(--panel-body)}
+.icon-button{width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;border-radius:8px;color:var(--info)}
+
+/* Hero */
+.hero{padding:0}
+.brief-bar{display:flex;align-items:center;gap:8px;padding:9px 11px;border:0;border-bottom:1px solid var(--border-default);background:transparent;width:100%;text-align:left;cursor:pointer}
+.brief-bar:hover{background:var(--bg-panel-hover)}
+.brief-state{color:var(--text-header);font-size:var(--panel-body);font-weight:600}.brief-state-note{color:var(--text-light);font-size:var(--panel-meta)}
+.brief-status-icon{color:var(--success)}.quality-thin .brief-status-icon{color:var(--warning)}.quality-conflict .brief-status-icon{color:var(--danger)}
+.brief-bar>span:nth-child(2){display:flex;flex-direction:column;min-width:0}.brief-bar .grow{flex:1}.brief-chevron{color:var(--text-light);transition:transform .2s}.brief-open .brief-chevron{transform:rotate(180deg)}
+.brief-details{display:none;padding:10px 11px;border-bottom:1px solid var(--border-default)}.brief-open .brief-details{display:block}
+.brief-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px}.brief-chip{display:flex;align-items:center;gap:6px;padding:7px 8px;border-radius:9px;text-align:left;min-width:0}
+.brief-chip strong{display:block;color:var(--text-header);font-size:var(--panel-body);font-weight:600}.brief-chip span{display:block;color:var(--text-light);font-size:var(--panel-meta);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.brief-dot{width:7px;height:7px;border-radius:50%;border:1px solid var(--success);flex:none}.quality-thin .brief-dot.warn{border-color:var(--warning)}.quality-conflict .brief-dot.conflict{border-color:var(--danger)}
+.brief-actions{display:flex;align-items:center;gap:8px;margin-top:8px}
+.hero-main{padding:11px 12px 10px}.hero-topline{display:flex;flex-direction:column;align-items:flex-start;gap:5px}.hero-topline .grow{width:100%}.hero-topline .decision-chip{align-self:flex-start}.decision-chip{display:inline-flex;align-items:center;padding:2px 7px;border:1px solid var(--border-default);border-radius:999px;color:var(--text-light);font-size:var(--panel-meta);white-space:nowrap}
+.hero-headline{margin:0;color:var(--text-header);font-size:var(--panel-header);font-weight:600;line-height:1.35}.hero-subline{margin:3px 0 0;color:var(--text-light);font-size:var(--panel-body)}
+.lenses{display:grid;grid-template-columns:repeat(4,1fr);gap:3px;margin-top:10px;padding:3px;border:1px solid var(--border-default);border-radius:999px}
+.lens{padding:6px 4px;border:0;border-radius:999px;background:transparent;color:var(--text-light);cursor:pointer;font-size:var(--panel-body);white-space:nowrap}.lens.active{background:var(--primary);color:var(--text-on-colour)}.lens:disabled{opacity:.55;cursor:pointer}
+.lens-body{padding:10px 0 0}.lens-view{display:none}.lens-view.active{display:block}
+.unavailable{display:flex;align-items:flex-start;gap:7px;color:var(--text-light);font-size:var(--panel-body)}.unavailable button{margin-left:2px}
+.option-table{display:flex;flex-direction:column;gap:7px}.option-row{display:grid;grid-template-columns:24px minmax(0,1fr) 43px;gap:7px;align-items:center}
+.option-number{width:24px;height:24px;display:flex;align-items:center;justify-content:center;border:1px solid var(--option);border-radius:7px;color:var(--text-header);font-size:var(--panel-body)}.option-row.leading .option-number{border-color:var(--info);background:var(--info);color:var(--text-on-colour)}
+.option-name{color:var(--text-header);font-size:var(--panel-body);line-height:1.3;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}.option-value{text-align:right;color:var(--text-header);font-size:var(--panel-body);font-weight:600}
+.range-track{grid-column:2/4;height:7px;border-radius:999px;background:var(--border-default);position:relative}.range-fill{position:absolute;top:0;bottom:0;border:1px solid var(--option);border-radius:999px;background:rgba(170,167,228,.38)}.leading .range-fill{border-color:var(--info);background:rgba(99,173,207,.38)}.range-dot{position:absolute;top:50%;width:10px;height:10px;transform:translate(-50%,-50%);border:2px solid var(--bg-panel);border-radius:50%;background:var(--option)}.leading .range-dot{background:var(--info)}
+.hero-summary{display:flex;flex-wrap:wrap;gap:6px;margin-top:9px;padding-top:9px;border-top:1px solid var(--border-default)}
+.summary-link{display:inline-flex;align-items:center;gap:4px;padding:3px 7px;border:1px solid var(--border-default);border-radius:999px;background:transparent;color:var(--text-body);cursor:pointer;font-size:var(--panel-meta)}.summary-link:hover{background:var(--bg-panel-hover)}
+.quality-conflict .hero-main .hero-headline,.quality-conflict .hero-main .hero-subline,.quality-conflict .lenses,.quality-conflict .lens-body,.quality-conflict .hero-summary{display:none}
+.pause-read{display:none;padding:12px;color:var(--text-body);font-size:var(--panel-body)}.quality-conflict .pause-read{display:block}
+
+/* Strengthen */
+.strength-head{display:flex;align-items:flex-start;gap:8px;padding:11px 12px 8px}.strength-head .grow{flex:1}.progress{color:var(--text-light);font-size:var(--panel-meta)}
+.recommendation-list{border-top:1px solid var(--border-default)}
+.recommendation{border-bottom:1px solid var(--border-default)}.recommendation:last-child{border-bottom:0}.recommendation.hidden-rec{display:none}
+.recommendation-head{width:100%;display:grid;grid-template-columns:22px minmax(0,1fr) 18px;gap:8px;align-items:start;padding:9px 12px;border:0;border-radius:0;text-align:left}
+.rec-icon{color:var(--factor);margin-top:1px}.recommendation-head>span:nth-child(2){min-width:0}.rec-title,.rec-signal{display:block}.rec-title{color:var(--text-header);font-size:var(--panel-body);font-weight:600;line-height:1.35}.rec-signal{margin-top:2px;color:var(--text-light);font-size:var(--panel-meta);line-height:1.35}.rec-chevron{color:var(--text-light);transition:transform .2s}.recommendation.open .rec-chevron{transform:rotate(90deg)}
+.rec-state{display:inline-flex;margin-left:5px;padding:1px 5px;border:1px solid var(--border-default);border-radius:999px;color:var(--text-light);font-size:var(--panel-meta);font-weight:400}.rec-state.addressed{border-color:var(--success);color:var(--success)}.rec-state.progressing{border-color:var(--info);color:var(--info)}
+.rec-body{display:none;padding:0 12px 11px 42px}.recommendation.open .rec-body{display:block}.rec-body p{margin:0 0 7px;font-size:var(--panel-body)}.try-line{color:var(--text-header)}.try-line strong{color:var(--info);font-weight:600}.source-line{color:var(--text-light);font-size:var(--panel-meta)!important}
+.rec-actions{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-top:9px}.rec-actions .icon-button{margin-left:auto}
+.rec-receipt{display:none;margin-top:8px;padding:8px 9px;border:1px solid var(--success);border-radius:9px;color:var(--text-body);font-size:var(--panel-body)}.recommendation.addressed .rec-receipt{display:block}.recommendation.addressed .rec-actions,.recommendation.addressed .try-line{display:none}
+.strength-footer{display:flex;align-items:center;gap:10px;padding:9px 12px;border-top:1px solid var(--border-default)}.strength-footer .grow{flex:1}
+.method-wrap{position:relative}.method-menu{display:none;position:absolute;right:0;bottom:34px;width:260px;padding:7px;background:var(--bg-panel);border:1px solid var(--border-default);border-radius:12px;box-shadow:var(--shadow-2);z-index:8}.method-menu.open{display:block}.method-button{width:100%;display:block;padding:7px 8px;border:0;border-radius:8px;text-align:left}.method-button strong{display:block;color:var(--text-header);font-size:var(--panel-body);font-weight:600}.method-button span{display:block;color:var(--text-light);font-size:var(--panel-meta)}
+.addressed-panel{display:none;border-top:1px solid var(--border-default);padding:9px 12px}.addressed-panel.open{display:block}.addressed-item{display:flex;align-items:center;gap:7px;padding:4px 0;color:var(--text-light);font-size:var(--panel-body)}
+
+/* Evidence */
+.evidence-head{display:flex;align-items:center;gap:8px;padding:11px 12px 8px}.evidence-head .grow{flex:1}.evidence-tabs{display:grid;grid-template-columns:repeat(3,1fr);gap:3px;margin:0 12px 8px;padding:3px;border:1px solid var(--border-default);border-radius:999px}.tab-button{padding:5px 4px;border:0;border-radius:999px;color:var(--text-light);font-size:var(--panel-body)}.tab-button.active{background:var(--primary);color:var(--text-on-colour)}
+.evidence-view{display:none;padding:0 12px 11px}.evidence-view.active{display:block}.evidence-note{margin:0 0 7px;color:var(--text-light);font-size:var(--panel-meta)}
+.evidence-row{display:grid;grid-template-columns:minmax(0,1fr) 80px 58px;gap:8px;align-items:center;padding:7px 0;border-top:1px solid var(--border-default);cursor:pointer}.evidence-row:first-of-type{border-top:0}.evidence-row:hover{background:var(--bg-panel-hover)}
+.evidence-name{color:var(--text-header);font-size:var(--panel-body);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.evidence-name .sign{font-weight:600;margin-right:4px}.sign.pos{color:var(--success)}.sign.neg{color:var(--danger)}.evidence-bar{height:6px;border-radius:999px;background:var(--border-default);overflow:hidden}.evidence-bar i{display:block;height:100%;border-radius:999px;background:var(--info)}.evidence-meta{text-align:right;color:var(--text-light);font-size:var(--panel-meta)}
+.trade-row{padding:8px 0;border-top:1px solid var(--border-default)}.trade-row:first-of-type{border-top:0}.trade-title{display:flex;gap:7px;align-items:center;color:var(--text-header);font-size:var(--panel-body);font-weight:600}.trade-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:6px}.trade-cell{padding:7px;border:1px solid var(--border-default);border-radius:9px}.trade-cell strong{display:block;color:var(--text-light);font-size:var(--panel-meta);font-weight:400}.trade-cell span{display:block;margin-top:2px;color:var(--text-body);font-size:var(--panel-body)}
+.evidence-footer{display:flex;justify-content:flex-end;margin-top:7px}
+
+/* Advanced */
+details{background:var(--bg-panel);border:1px solid var(--border-default);border-radius:12px;box-shadow:var(--shadow-1)}details summary{display:flex;align-items:center;gap:8px;padding:10px 12px;cursor:pointer;color:var(--text-header);font-size:var(--panel-header);font-weight:600;list-style:none}details summary::-webkit-details-marker{display:none}.details-body{padding:0 12px 11px}.receipt-grid{display:grid;grid-template-columns:auto 1fr;gap:4px 10px;margin:0;font-size:var(--panel-meta)}.receipt-grid dt{color:var(--text-light)}.receipt-grid dd{margin:0}
+
+/* Modal and drawer */
+.overlay{display:none;position:fixed;inset:0;background:rgba(38,38,38,.28);z-index:30;align-items:center;justify-content:center;padding:18px}.overlay.open{display:flex}.modal-card{width:min(430px,100%);max-height:90vh;overflow:auto;padding:13px}.modal-head{display:flex;align-items:flex-start;gap:8px}.modal-head .grow{flex:1}.modal-card h2{margin:0;color:var(--text-header);font-size:var(--panel-header);font-weight:600}.modal-card p{margin:3px 0 0;font-size:var(--panel-body)}.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:11px}.field{display:flex;flex-direction:column;gap:4px}.field.full{grid-column:1/-1}.field label{color:var(--text-light);font-size:var(--panel-meta)}.field input,.field select,.field textarea{width:100%;padding:7px 8px;border:1px solid var(--border-default);border-radius:9px;background:var(--bg-panel);color:var(--text-header);font-size:var(--panel-body);outline:none}.field textarea{min-height:58px;resize:vertical}.field input:focus,.field select:focus,.field textarea:focus{border-color:var(--info)}.measure-preview{margin-top:9px;padding:8px 9px;border:1px solid var(--goal);border-radius:9px;color:var(--text-body);font-size:var(--panel-body)}.error{display:none;margin-top:7px;color:var(--danger);font-size:var(--panel-meta)}.error.show{display:block}.modal-actions{display:flex;justify-content:flex-end;gap:7px;margin-top:11px}
+.drawer{display:none;position:fixed;right:18px;bottom:18px;width:min(370px,calc(100vw - 36px));z-index:25;box-shadow:var(--shadow-2);overflow:hidden}.drawer.open{display:block}.drawer-head{display:flex;align-items:center;gap:8px;padding:10px 11px;border-bottom:1px solid var(--border-default)}.drawer-head strong{color:var(--text-header);font-size:var(--panel-header);font-weight:600}.drawer-body{padding:10px 11px}.drawer-context{padding:8px 9px;border:1px solid var(--info);border-radius:9px;font-size:var(--panel-body)}.drawer textarea{width:100%;min-height:64px;margin-top:8px;padding:8px;border:1px solid var(--border-default);border-radius:9px;resize:vertical;color:var(--text-header)}.drawer-actions{display:flex;justify-content:flex-end;gap:7px;margin-top:8px}
+.toast{position:fixed;left:50%;bottom:18px;z-index:60;max-width:min(90vw,430px);padding:8px 13px;transform:translateX(-50%);border-radius:999px;background:var(--text-header);color:var(--text-on-colour);opacity:0;pointer-events:none;transition:opacity .2s;font-size:var(--panel-body)}.toast.show{opacity:.96}
+@media(prefers-reduced-motion:reduce){*{transition:none!important}}
+
+
+/* Decision overview */
+.decision-overview-head{display:flex;align-items:flex-start;gap:10px;padding:11px 12px}
+.decision-overview-title{min-width:0;flex:1}
+.decision-overview-title h2{margin:1px 0 6px;color:var(--text-header);font-size:var(--panel-header);font-weight:600}
+.decision-pills{display:flex;flex-wrap:wrap;gap:5px}
+.decision-pill{padding:3px 7px;border:1px solid var(--border-default);border-radius:999px;background:transparent;color:var(--text-body);cursor:pointer;font-size:var(--panel-meta)}
+.decision-pill:hover{background:var(--bg-panel-hover)}
+.decision-actions{flex:none}
+.decision-actions .method-menu{top:34px;bottom:auto;right:0}
+.decision-actions #methodToggle[aria-expanded="true"]{border-color:var(--info);color:var(--text-header)}
+.framing-question{display:flex;align-items:flex-start;gap:9px;margin-top:9px;padding-top:9px;border-top:1px solid var(--border-default)}
+.framing-question>div:first-child{min-width:0;flex:1}
+.framing-question p{margin:2px 0 0;color:var(--text-header);font-size:var(--panel-body)}
+.framing-question-actions{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+.quality-thin .decision-overview .brief-status-icon{color:var(--warning)}
+.quality-conflict .decision-overview .brief-status-icon{color:var(--danger)}
+
+/* Merged Analysis panel */
+.hero-topline{display:block}
+.analysis-evidence-toggle{width:100%;display:flex;align-items:center;gap:8px;padding:10px 12px;border:0;border-top:1px solid var(--border-default);background:transparent;text-align:left;cursor:pointer}
+.analysis-evidence-toggle:hover{background:var(--bg-panel-hover)}
+.analysis-evidence-toggle strong{display:block;color:var(--text-header);font-size:var(--panel-header);font-weight:600}
+.analysis-evidence-toggle span span{display:block;color:var(--text-light);font-size:var(--panel-meta)}
+.analysis-evidence-toggle .grow{flex:1}
+.analysis-evidence-chevron{color:var(--text-light);transition:transform .2s}
+.hero.analysis-evidence-open .analysis-evidence-chevron{transform:rotate(180deg)}
+.analysis-evidence{display:none;border-top:1px solid var(--border-default);padding-top:9px}
+.hero.analysis-evidence-open .analysis-evidence{display:block}
+.analysis-evidence .evidence-tabs{margin-top:0}
+.analysis-next-route{display:flex;align-items:center;gap:8px;padding:9px 12px;border-top:1px solid var(--border-default)}
+.analysis-next-route .grow{min-width:0;flex:1}
+.analysis-next-route strong{display:block;color:var(--text-header);font-size:var(--panel-body);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.analysis-next-icon{color:var(--info);font-size:var(--panel-header)}
+.quality-conflict .analysis-evidence-toggle,
+.quality-conflict .analysis-evidence,
+.quality-conflict .analysis-next-route{display:none}
+
+
+.measure-write-note{margin:7px 0 0;color:var(--text-light);font-size:var(--panel-meta)}
+.prototype-note{margin:0 0 10px;padding:8px 9px;border:1px solid var(--border-default);border-radius:9px;background:var(--bg-panel);color:var(--text-light);font-size:var(--panel-meta)}
+.modal-card textarea{width:100%;min-height:72px;resize:vertical;border:1px solid var(--border-default);border-radius:9px;background:var(--bg-panel);padding:8px 9px;color:var(--text-header);font:inherit}
+.modal-card textarea:focus{outline:2px solid rgba(99,173,207,.25);border-color:var(--info)}
+.method-heading{padding:7px 10px 4px;color:var(--text-light);font-size:var(--panel-meta)}
+.method-divider{height:1px;margin:4px 0;background:var(--border-default)}
+.quality-thin #decisionOverview,.quality-conflict #decisionOverview{scroll-margin-top:10px}
+</style>
+</head>
+<body>
+<div class="page">
+<h1 class="page-title">Olumi Analysis tab, build-ready prototype v6</h1>
+<p class="page-sub">Decision overview, merged analysis and one adaptive recommendation, with clear action ownership.</p>
+<div class="layout">
+<aside class="controls">
+<h2>Prototype controls</h2>
+<p>These simulate producer-owned states. They are not visible controls in the product.</p>
+<div class="control"><span class="control-label">Brief quality</span><div class="segment" data-control="quality"><button aria-pressed="true" data-value="ready">Ready</button><button aria-pressed="false" data-value="thin">Thin</button><button aria-pressed="false" data-value="conflict">Contradictory</button></div></div>
+<div class="control"><span class="control-label">Freshness</span><div class="segment" data-control="fresh"><button aria-pressed="true" data-value="current">Current</button><button aria-pressed="false" data-value="stale">Model edited</button></div></div>
+<div class="control"><span class="control-label">Success measure</span><div class="segment" data-control="measure"><button aria-pressed="true" data-value="missing">Missing</button><button aria-pressed="false" data-value="set">Set</button></div></div>
+<div class="control"><span class="control-label">Adaptive priority</span><div class="segment" data-control="priority"><button aria-pressed="true" data-value="clarify">Clarify</button><button aria-pressed="false" data-value="broaden">Broaden</button><button aria-pressed="false" data-value="challenge">Challenge</button><button aria-pressed="false" data-value="evaluate">Evaluate</button><button aria-pressed="false" data-value="commit">Commit</button></div></div>
+<div class="note"><strong>Design boundary:</strong> the Analysis tab owns framing quality, the current read, one next move and supporting evidence. Deeper dialogue opens in Olumi. Collaboration and outcome learning remain separate workstreams.</div>
+<h3>Included improvements</h3>
+<ul><li>A compact decision overview owns framing quality, decision classification and the persistent Actions menu.</li><li>Current analysis and supporting evidence are merged into one progressively disclosed panel.</li><li>One success-measure flow, with metric, threshold, unit and timeframe.</li><li>One adaptive recommendation, with progress and addressed history.</li><li>Stable option numbers, explicit driver and flip-risk meanings, and contextual trade-offs.</li><li>Advanced receipts remain collapsed and deeper dialogue opens in Olumi.</li></ul>
+<div class="control">
+<span class="control-label">Option diversity signal</span>
+<div class="segment" data-control="diversity">
+<button aria-pressed="true" data-value="diverse">Diverse</button>
+<button aria-pressed="false" data-value="narrow">Narrow</button>
+</div>
+</div></aside>
+<main class="mock quality-ready measure-missing" id="mock">
+<nav aria-label="Workspace tabs" class="dock"><button>Olumi</button><button class="active">Analysis</button><button>Compare</button><button>Model</button></nav>
+<div class="content">
+<section class="card decision-overview" id="decisionOverview">
+<div class="decision-overview-head">
+<div class="decision-overview-title">
+<span class="meta">Decision overview</span>
+<h2>Technical Co-Founder</h2>
+<div aria-label="Decision classification" class="decision-pills">
+<button class="decision-pill" data-overview="stakes" type="button">High stakes</button>
+<button class="decision-pill" data-overview="reversibility" type="button">Reversible</button>
+<button class="decision-pill" data-overview="horizon" type="button">12-month horizon</button>
+<button class="decision-pill" data-overview="risk" type="button">Risk cautious</button>
+</div>
+</div>
+<div class="method-wrap decision-actions">
+<button aria-expanded="false" class="ghost-button" id="methodToggle" type="button">Actions <span aria-hidden="true">⌄</span></button>
+<div aria-label="Methods and global actions" class="method-menu" id="methodMenu"></div>
+</div>
+</div>
+<button aria-expanded="false" class="brief-bar" id="briefToggle" type="button">
+<span aria-hidden="true" class="brief-status-icon">●</span>
+<span><span class="brief-state">Framing has the basics</span><span class="brief-state-note">Goal, context, constraints and options</span></span>
+<span class="grow"></span>
+<span class="brief-chevron">⌄</span>
+</button><div class="brief-details">
+<div class="brief-grid">
+<button class="brief-chip" data-brief="Goal"><span class="brief-dot warn"></span><span><strong>Goal</strong><span class="goal-note">Success measure missing</span></span></button>
+<button class="brief-chip" data-brief="Context"><span class="brief-dot"></span><span><strong>Context</strong><span>Challenge is clear</span></span></button>
+<button class="brief-chip" data-brief="Constraints"><span class="brief-dot"></span><span><strong>Constraints</strong><span>Key limits captured</span></span></button>
+<button class="brief-chip" data-brief="Options"><span class="brief-dot conflict"></span><span><strong>Options</strong><span class="options-note">Four distinct routes</span></span></button>
+</div>
+<div class="brief-actions"><button class="text-button" data-open-brief="">Review your decision brief</button><span class="meta">Olumi challenges one issue at a time.</span></div>
+<div class="framing-question">
+<div>
+<span class="meta">Olumi's framing question</span>
+<p>What would make bringing on a co-founder clearly better than hiring a senior technical lead?</p>
+</div>
+<div class="framing-question-actions">
+<button class="ghost-button" data-direct-edit="Goal" type="button">Answer directly</button>
+<button class="text-button" data-ask="Work through the framing question" type="button">Work through with Olumi</button>
+</div>
+</div></div></section><section aria-label="Analysis freshness" class="status-strip">
+<span aria-hidden="true" class="status-icon">●</span>
+<span class="status-current">Analysis reflects the current model.</span>
+<span class="status-stale">The model changed after this analysis.</span>
+<span class="grow"></span>
+<button class="ghost-button rerun" type="button">Rerun</button>
+</section>
+<section aria-label="Analysis" class="card hero" data-component="merged-analysis-panel" id="hero">
+<div class="hero-main">
+<div class="hero-topline"><div class="grow"><h2 class="hero-headline">Bring On Technical Co-Founder is slightly ahead.</h2><p class="hero-subline">It also has the strongest expected outcome, but the top two remain close.</p></div></div>
+<div aria-label="Analysis lenses" class="lenses" role="tablist">
+<button class="lens" data-lens="goal" role="tab">Goal fit</button>
+<button class="lens active" data-lens="outcome" role="tab">Likely outcome</button>
+<button class="lens" data-lens="stability" role="tab">Stability</button>
+<button class="lens" data-lens="changed" role="tab">What changed</button>
+</div>
+<div class="lens-body">
+<div class="lens-view" data-view="goal"><div class="unavailable"><span aria-hidden="true">ⓘ</span><span>Goal fit needs a measurable success definition. <button class="text-button open-success" type="button">Define success</button></span></div></div>
+<div class="lens-view active" data-view="outcome">
+<div aria-label="Expected outcome by option" class="option-table">
+<div class="option-row leading"><span class="option-number">1</span><span class="option-name">Bring On Technical Co-Founder</span><span class="option-value">+26%</span><span class="range-track"><span class="range-fill" style="left:18%;width:64%"></span><span class="range-dot" style="left:58%"></span></span></div>
+<div class="option-row"><span class="option-number">2</span><span class="option-name">Hire Senior Technical Lead</span><span class="option-value">+20%</span><span class="range-track"><span class="range-fill" style="left:14%;width:60%"></span><span class="range-dot" style="left:51%"></span></span></div>
+<div class="option-row"><span class="option-number">3</span><span class="option-name">Continue Without Technical Lead</span><span class="option-value">0%</span><span class="range-track"><span class="range-fill" style="left:7%;width:18%"></span><span class="range-dot" style="left:15%"></span></span></div>
+<div class="option-row"><span class="option-number">4</span><span class="option-name">Outsource Technical Leadership</span><span class="option-value">-7%</span><span class="range-track"><span class="range-fill" style="left:2%;width:22%"></span><span class="range-dot" style="left:11%"></span></span></div>
+</div>
+<p class="meta" style="margin:8px 0 0">Expected change versus the current approach. Ranges show plausible outcomes.</p>
+</div>
+<div class="lens-view" data-view="stability"><div class="unavailable"><span aria-hidden="true">ⓘ</span><span>Per-option stability is not produced yet. Olumi will not infer it in the UI.</span></div></div>
+<div class="lens-view" data-view="changed"><div class="unavailable"><span aria-hidden="true">ⓘ</span><span>This unlocks with versioned run comparisons. Olumi will not approximate it locally.</span></div></div>
+</div>
+<div class="hero-summary"><button class="summary-link" data-focus="Market Timing Pressure">Main driver: Market Timing Pressure</button><button class="summary-link" data-focus="Technical Leadership Capacity">Top flip risk: Technical Leadership Capacity</button></div>
+</div>
+<div class="pause-read"><strong>Resolve the conflicting brief before relying on this read.</strong><p class="card-copy">The brief says speed is the priority but also says delivery date does not matter. Olumi needs one clarification.</p><button class="primary-button" data-ask="Resolve the conflict in my decision brief" type="button">Resolve with Olumi</button></div>
+<button aria-expanded="false" class="analysis-evidence-toggle" id="analysisEvidenceToggle" type="button">
+<span>
+<strong>Why and what could change it</strong>
+<span>Drivers, flip risks and trade-offs</span>
+</span>
+<span class="grow"></span>
+<span aria-hidden="true" class="analysis-evidence-chevron">⌄</span>
+</button><div class="analysis-evidence" id="analysisEvidence"><div class="evidence-tabs" role="tablist"><button class="tab-button active" data-evidence="drivers">Drivers</button><button class="tab-button" data-evidence="flips">Flip risks</button><button class="tab-button" data-evidence="tradeoffs">Trade-offs</button></div><div class="evidence-view active" data-evidence-view="drivers">
+<p class="evidence-note">Ranked by effect on the analysed outcome. Evidence quality is separate.</p>
+<div class="evidence-row" data-focus="Market Timing Pressure"><span class="evidence-name"><span class="sign pos">+</span>Market Timing Pressure</span><span class="evidence-bar"><i style="width:100%"></i></span><span class="evidence-meta">Low evidence</span></div>
+<div class="evidence-row" data-focus="Founder Equity Dilution"><span class="evidence-name"><span class="sign neg">-</span>Founder Equity Dilution</span><span class="evidence-bar"><i style="width:87%"></i></span><span class="evidence-meta">Low evidence</span></div>
+<div class="evidence-row" data-focus="Engineering Capacity"><span class="evidence-name"><span class="sign pos">+</span>Engineering Capacity</span><span class="evidence-bar"><i style="width:66%"></i></span><span class="evidence-meta">Low evidence</span></div>
+<div class="evidence-row extra-evidence" data-focus="Ongoing Salary Cost" style="display:none"><span class="evidence-name"><span class="sign neg">-</span>Ongoing Salary Cost</span><span class="evidence-bar"><i style="width:58%"></i></span><span class="evidence-meta">Low evidence</span></div>
+<div class="evidence-footer"><button class="text-button see-all-evidence" type="button">See all factors</button></div>
+</div><div class="evidence-view" data-evidence-view="flips">
+<p class="evidence-note">Chance the leading option changes when a relationship is varied within its plausible range.</p>
+<div class="evidence-row" data-focus="Technical Leadership Capacity to Technical Quality"><span class="evidence-name">Technical Leadership Capacity → Technical Quality</span><span class="evidence-bar"><i style="width:96%"></i></span><span class="evidence-meta">48% switch</span></div>
+<div class="evidence-row" data-focus="Founder Equity Dilution to Retention"><span class="evidence-name">Founder Equity Dilution → Retention</span><span class="evidence-bar"><i style="width:72%"></i></span><span class="evidence-meta">36% switch</span></div>
+<div class="evidence-row" data-focus="Ongoing Salary Cost to Runway"><span class="evidence-name">Ongoing Salary Cost → Runway</span><span class="evidence-bar"><i style="width:62%"></i></span><span class="evidence-meta">31% switch</span></div>
+<p class="meta" style="margin:7px 0 0">If the top relationship under-delivers, option 2 becomes the likely leader.</p>
+</div><div class="evidence-view" data-evidence-view="tradeoffs">
+<p class="evidence-note">What the two leading routes gain, give up and depend on.</p>
+<div class="trade-row"><div class="trade-title"><span class="option-number">1</span>Bring On Technical Co-Founder</div><div class="trade-grid"><div class="trade-cell"><strong>You gain</strong><span>Long-term technical ownership</span></div><div class="trade-cell"><strong>You give up</strong><span>Equity and hiring time</span></div><div class="trade-cell"><strong>Depends on</strong><span>Finding the right partner</span></div><div class="trade-cell"><strong>Watch</strong><span>Runway and role clarity</span></div></div></div>
+<div class="trade-row"><div class="trade-title"><span class="option-number">2</span>Hire Senior Technical Lead</div><div class="trade-grid"><div class="trade-cell"><strong>You gain</strong><span>Faster execution capacity</span></div><div class="trade-cell"><strong>You give up</strong><span>Ongoing salary cost</span></div><div class="trade-cell"><strong>Depends on</strong><span>Delegated authority</span></div><div class="trade-cell"><strong>Watch</strong><span>Founder bottlenecks</span></div></div></div>
+</div></div><div class="analysis-next-route">
+<span aria-hidden="true" class="analysis-next-icon">◎</span>
+<div class="grow">
+<span class="meta">Next recommendation</span>
+<strong>Define a measurable success measure</strong>
+</div>
+<button class="ghost-button" id="openRecommendation" type="button">Open</button>
+</div></section>
+<section class="card" id="strengthCard">
+<div class="strength-head"><div class="grow"><h2 class="card-title">Strengthen your model</h2><p class="progress" id="progressText">0 addressed · 5 worth checking</p></div><button aria-label="Show addressed recommendations" class="icon-button" id="addressedToggle" title="Show addressed recommendations">✓</button></div>
+<div class="recommendation-list" id="recommendationList"></div>
+<div class="addressed-panel" id="addressedPanel"><p class="meta" style="margin:0 0 4px">Addressed or dismissed</p><div id="addressedItems"></div></div>
+<div class="strength-footer">
+<button class="text-button" id="showMore" type="button">Show 3 more</button>
+<button class="text-button" id="expandAll" type="button">Expand all</button>
+<span class="grow"></span>
+</div>
+</section>
+<details><summary>Advanced and receipts <span style="margin-left:auto;color:var(--text-light)">›</span></summary><div class="details-body"><dl class="receipt-grid"><dt>Simulations</dt><dd>4,000</dd><dt>Freshness</dt><dd>Graph hash match</dd><dt>Result stability</dt><dd>Tentative</dd><dt>Result hash</dt><dd>8ce04678…</dd></dl></div></details>
+</div>
+</main>
+</div>
+</div>
+<div aria-labelledby="successTitle" aria-modal="true" class="overlay" id="successModal" role="dialog">
+<div class="modal-card">
+<div class="modal-head"><div class="grow"><h2 id="successTitle">Define success</h2><p>Keep the goal in plain language, then give Olumi a measurable test for Goal fit.</p></div><button aria-label="Close" class="icon-button close-success">×</button></div>
+<div class="form-grid">
+<div class="field full"><label for="metric">What outcome should improve?</label><input id="metric" value="Productivity"/></div>
+<div class="field"><label for="direction">Direction</label><select id="direction"><option>Increase by at least</option><option>Reach at least</option><option>Keep below</option></select></div>
+<div class="field"><label for="threshold">Threshold</label><input id="threshold" inputmode="decimal" placeholder="20"/></div>
+<div class="field"><label for="unit">Unit</label><select id="unit"><option value="%">%</option><option value="projects">projects</option><option value="weeks">weeks</option><option value="£">£</option></select></div>
+<div class="field"><label for="timeframe">Timeframe</label><input id="timeframe" placeholder="Within 6 months"/></div>
+<div class="field full"><label for="baseline">Baseline or evidence, optional</label><input id="baseline" placeholder="Current productivity or source"/></div>
+</div>
+<div class="measure-preview" id="measurePreview">Success means: increase Productivity by at least [number]% within [timeframe].</div><p class="measure-write-note">This updates the analysis success measure and reruns the analysis. It does not change the graph structure.</p>
+<div class="error" id="measureError">Add a number and timeframe so Olumi can evaluate Goal fit.</div>
+<div class="modal-actions"><button class="ghost-button close-success" type="button">Cancel</button><button class="primary-button" id="saveSuccess" type="button">Save and rerun</button></div>
+</div>
+</div>
+<div aria-labelledby="decisionRecordTitle" aria-modal="true" class="overlay" id="decisionModal" role="dialog">
+<div class="modal-card">
+<div class="modal-head">
+<div class="grow">
+<h2 id="decisionRecordTitle">Record the decision</h2>
+<p>Capture the choice and what would justify revisiting it.</p>
+</div>
+<button aria-label="Close" class="icon-button close-decision" type="button">×</button>
+</div>
+<div class="prototype-note">Prototype only. Durable saving depends on identity and Model Management.</div>
+<div class="form-grid">
+<div class="field full">
+<label for="chosenOption">Chosen option</label>
+<select id="chosenOption">
+<option>1. Bring On Technical Co-Founder</option>
+<option>2. Hire Senior Technical Lead</option>
+<option>3. Continue Without Technical Lead</option>
+<option>4. Outsource Technical Leadership</option>
+</select>
+</div>
+<div class="field">
+<label for="decisionConfidence">Confidence, 0–100</label>
+<input id="decisionConfidence" inputmode="numeric" placeholder="e.g. 70"/>
+</div>
+<div class="field">
+<label for="revisitDate">Revisit trigger or date</label>
+<input id="revisitDate" placeholder="e.g. runway falls below 9 months"/>
+</div>
+<div class="field full">
+<label for="decisionRationale">Concise rationale</label>
+<textarea id="decisionRationale" placeholder="Why this is the best current choice" rows="3"></textarea>
+</div>
+<div class="field full">
+<label for="assumptionWatch">Key assumption to watch</label>
+<input id="assumptionWatch" placeholder="The assumption most likely to change the choice"/>
+</div>
+</div>
+<div class="error" id="decisionError">Add confidence, rationale, an assumption to watch and a revisit trigger.</div>
+<div class="modal-actions">
+<button class="ghost-button close-decision" type="button">Cancel</button>
+<button class="primary-button" id="saveDecision" type="button">Capture prototype record</button>
+</div>
+</div>
+</div><div aria-label="Olumi coaching session" class="drawer" id="olumiDrawer">
+<div class="drawer-head"><strong>Work through it with Olumi</strong><span style="flex:1"></span><button aria-label="Close" class="icon-button" id="closeDrawer">×</button></div>
+<div class="drawer-body"><div class="drawer-context" id="drawerContext">Context will appear here.</div><textarea aria-label="Message to Olumi" id="drawerMessage"></textarea><div class="drawer-actions"><button class="ghost-button" id="focusFromDrawer" type="button">Focus on canvas</button><button class="primary-button" id="sendDrawer" type="button">Send</button></div></div>
+</div>
+<div class="toast" id="toast" role="status"></div>
+<script>
+const mock=document.getElementById('mock');
+const toastEl=document.getElementById('toast');let toastTimer;
+function toast(message){toastEl.textContent=message;toastEl.classList.add('show');clearTimeout(toastTimer);toastTimer=setTimeout(()=>toastEl.classList.remove('show'),1800)}
+const icons={
+ target:'<circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="5"/><circle cx="12" cy="12" r="1.5"/>',
+ grid:'<rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/>',
+ shield:'<path d="M20 13c0 5-3.5 7.5-7.7 9C7.5 20.5 4 18 4 13V6c2.6 0 5.5-1.4 8-3.5C14.5 4.6 17.4 6 20 6z"/><path d="M12 8v4M12 16h.01"/>',
+ scale:'<path d="M12 3v18M5 7h14M3 7l-2 5h4L3 7zm18 0-2 5h4l-2-5zM7 21h10"/>',
+ check:'<path d="m5 12 4 4L19 6"/>',
+ clock:'<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>',
+ range:'<path d="M4 12h16M8 8l-4 4 4 4M16 8l4 4-4 4"/>'
+};
+function svg(name){return `<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">${icons[name]||icons.check}</svg>`}
+
+const recommendations=[
+ {id:'success',job:'clarify',icon:'target',title:'Define what success looks like',signal:'Goal fit is unavailable',why:'Your goal is understandable, but Olumi cannot test whether an option succeeds until the outcome has a measurable threshold and timeframe.',tip:'Keep the goal in plain language. Add a metric, direction, threshold, unit and timeframe.',source:'Triggered because the goal has no valid success measure.',action:'Define success',actionType:'success'},
+ {id:'broaden',job:'broaden',icon:'grid',title:"Find a route that is not hiring",signal:'Three of four options use the same mechanism',why:'The current set may be converging too early. A materially different route is more useful than another hiring variation.',tip:'Explore a partnership, specialist studio, scope reduction or internal capability route.',source:'Uses the producer-owned option-similarity signal.',action:'Generate a different option',actionType:'broaden'},
+ {id:'assumption',job:'challenge',icon:'shield',title:'Test the assumption most likely to change the leader',signal:'48% chance of switching the leader',why:'Technical Leadership Capacity to Technical Quality is not the largest driver, but it is the relationship most likely to change the recommendation.',tip:'Look for evidence that leadership capacity reliably improves technical quality in comparable teams.',source:'Prioritised from recorded flip risk, not influence.',action:'Plan an evidence check',actionType:'ask'},
+ {id:'range',job:'evaluate',icon:'range',title:'Give Engineering Capacity a realistic range',signal:'High influence, low evidence',why:'A single figure hides uncertainty in one of the most important inputs.',tip:'Use a plausible low and high estimate based on past delivery, not an optimistic point estimate.',source:'Triggered by sensitivity and low evidence quality.',action:'Set a range',actionType:'ask'},
+ {id:'bias',job:'challenge',icon:'scale',title:'Consider the strongest case against option 1',signal:'No counter-argument captured',why:'The model contains the case for the current leader, but not the strongest opposing explanation.',tip:'Use a consider-the-opposite dialogue, then add any surviving concern to the model.',source:'Grounded in the missing-counterargument critique.',action:'Challenge the leader',actionType:'ask'},
+ {id:'commit',job:'commit',icon:'check',title:'Record the decision and what would trigger a rethink',signal:'The model is ready for a provisional choice',why:'A lightweight record preserves ownership and makes later review possible without turning Olumi into project management.',tip:'Capture the choice, confidence, rationale, assumption to watch and revisit trigger.',source:'Shown only when commitment is the highest-value move.',action:'Create a decision record',actionType:'ask'}
+];
+let priority='clarify',visibleCount=1,allExpanded=false;
+let optionSetNarrow=false;
+const recState=new Map(recommendations.map(r=>[r.id,{status:'recommended'}]));
+function orderedRecommendations(){return recommendations.filter(r=>{
+  const status=recState.get(r.id).status;
+  if(status==='addressed'||status==='dismissed')return false;
+  if(r.id==='broaden'&&!optionSetNarrow)return false;
+  if(r.id==='commit'&&priority!=='commit')return false;
+  return true;
+}).sort((a,b)=>{if(a.job===priority&&b.job!==priority)return -1;if(b.job===priority&&a.job!==priority)return 1;return recommendations.indexOf(a)-recommendations.indexOf(b)})}
+function recMarkup(r,index){const st=recState.get(r.id);const stateLabel=st.status==='progressing'?'<span class="rec-state progressing">In progress</span>':'';return `<article class="recommendation ${index===0||allExpanded?'open':''} ${index>=visibleCount?'hidden-rec':''}" data-rec="${r.id}"><button class="recommendation-head" type="button" aria-expanded="${index===0||allExpanded}"><span class="rec-icon">${svg(r.icon)}</span><span><span class="rec-title">${r.title}${stateLabel}</span><span class="rec-signal">${r.signal}</span></span><span class="rec-chevron">›</span></button><div class="rec-body"><p>${r.why}</p><p class="try-line"><strong>Try this</strong> ${r.tip}</p><p class="source-line">${r.source}</p><div class="rec-actions"><button class="primary-button rec-primary" data-action-type="${r.actionType}" type="button">${r.action}</button><button class="ghost-button rec-focus" type="button">Focus on canvas</button><button class="text-button rec-dismiss" type="button">Not relevant</button><button class="icon-button rec-ask" title="Work through this with Olumi" aria-label="Work through this with Olumi">✦</button></div></div></article>`}
+function renderRecommendations(){const ordered=orderedRecommendations();document.getElementById('recommendationList').innerHTML=ordered.length?ordered.map(recMarkup).join(''):'<div class="card-pad"><p class="card-copy">No recommendations need attention right now.</p></div>';const addressed=[...recState.values()].filter(s=>s.status==='addressed').length;const worth=ordered.length;document.getElementById('progressText').textContent=`${addressed} addressed · ${worth} worth checking`;document.getElementById('showMore').style.display=worth>1?'inline':'none';document.getElementById('showMore').textContent=visibleCount<worth?`Show ${worth-visibleCount} more`:'Show fewer';document.getElementById('expandAll').style.display=worth>1?'inline':'none';document.getElementById('expandAll').textContent=allExpanded?'Collapse all':'Expand all';renderAddressed()}
+function renderAddressed(){const items=recommendations.filter(r=>{const s=recState.get(r.id).status;return s==='addressed'||s==='dismissed'});document.getElementById('addressedItems').innerHTML=items.length?items.map(r=>`<div class="addressed-item">${svg('check')}<span>${r.title}</span></div>`).join(''):'<div class="meta">Nothing addressed yet.</div>'}
+renderRecommendations();
+
+document.getElementById('recommendationList').addEventListener('click',e=>{
+ const article=e.target.closest('.recommendation');if(!article)return;const id=article.dataset.rec;const rec=recommendations.find(r=>r.id===id);
+ if(e.target.closest('.recommendation-head')){article.classList.toggle('open');article.querySelector('.recommendation-head').setAttribute('aria-expanded',article.classList.contains('open'));return}
+ if(e.target.closest('.rec-focus')){toast(`Focused ${rec.title} on the canvas`);return}
+ if(e.target.closest('.rec-ask')){openDrawer(rec.title,rec.why);return}
+ if(e.target.closest('.rec-dismiss')){recState.set(id,{status:'dismissed'});renderRecommendations();toast('Recommendation dismissed');return}
+ const primary=e.target.closest('.rec-primary');if(primary){const type=primary.dataset.actionType;if(type==='success'){openSuccess()}else if(type==='commit'){openDecision()}else if(type==='broaden'){recState.set(id,{status:'addressed'});renderRecommendations();toast('Added option 5: Partner with a specialist product studio')}else{recState.set(id,{status:'progressing'});renderRecommendations();openDrawer(rec.title,rec.tip)} }
+});
+
+document.getElementById('showMore').addEventListener('click',()=>{const active=orderedRecommendations().length;visibleCount=visibleCount<active?active:1;renderRecommendations()});
+document.getElementById('expandAll').addEventListener('click',()=>{allExpanded=!allExpanded;renderRecommendations()});
+document.getElementById('addressedToggle').addEventListener('click',()=>document.getElementById('addressedPanel').classList.toggle('open'));
+
+const methods=[
+ {group:'Methods',title:'Reframe the problem',description:'Check whether the current question is too narrow.'},
+ {group:'Methods',title:'Generate a materially different option',description:'Use divergent thinking before narrowing.'},
+ {group:'Methods',title:'Consider the opposite',description:'Build the strongest case against the current leader.'},
+ {group:'Methods',title:'Apply the outside view',description:'Compare with a relevant reference class.'},
+ {group:'Methods',title:'Run a pre-mortem',description:'Imagine failure and capture plausible causes.'},
+ {group:'Methods',title:'Explore trade-offs',description:'Make gains and sacrifices explicit.'},
+ {group:'Methods',title:'Review a possible bias',description:'Use only biases grounded in this brief or model.'},
+ {group:'Global actions',title:'Edit decision brief',description:'Review Goal, Context, Constraints and Options.'},
+ {group:'Global actions',title:'Review all inputs',description:'Inspect the current model inputs without changing them.'},
+ {group:'Global actions',title:'Rerun analysis',description:'Run the analysis against the current model.'}
+];
+document.getElementById('methodMenu').innerHTML=methods.map((m,i)=>{
+  const previous=i?methods[i-1].group:null;
+  const heading=m.group!==previous?`<div class="method-heading">${m.group}</div>`:'';
+  return `${heading}<button class="method-button" type="button" data-method="${m.title}"><strong>${m.title}</strong><span>${m.description}</span></button>`;
+}).join('');
+document.getElementById('methodToggle').addEventListener('click',()=>{const menu=document.getElementById('methodMenu');const open=menu.classList.toggle('open');document.getElementById('methodToggle').setAttribute('aria-expanded',String(open))});
+document.getElementById('methodMenu').addEventListener('click',e=>{const b=e.target.closest('[data-method]');if(!b)return;document.getElementById('methodMenu').classList.remove('open');document.getElementById('methodToggle').setAttribute('aria-expanded','false');const method=methods.find(m=>m.title===b.dataset.method);
+if(method.title==='Rerun analysis'){mock.classList.remove('stale');setPressed('fresh','current');toast('Analysis rerun completed with the current model')}
+else if(method.title==='Edit decision brief'){openDrawer('Review my decision brief','Challenge the framing across Goal, Context, Constraints and Options.')}
+else{openDrawer(method.title,method.description)}});
+
+document.getElementById('briefToggle').addEventListener('click',()=>{const open=document.getElementById('decisionOverview').classList.toggle('brief-open');document.getElementById('briefToggle').setAttribute('aria-expanded',String(open))});
+document.querySelectorAll('[data-brief]').forEach(b=>b.addEventListener('click',()=>openDrawer(`Review ${b.dataset.brief}`,`Help me strengthen the ${b.dataset.brief.toLowerCase()} in my decision brief.`)));
+document.querySelector('[data-open-brief]').addEventListener('click',()=>openDrawer('Review my decision brief','Challenge the framing across Goal, Context, Constraints and Options.'));
+
+document.querySelectorAll('.lens').forEach(b=>b.addEventListener('click',()=>{document.querySelectorAll('.lens').forEach(x=>x.classList.remove('active'));document.querySelectorAll('.lens-view').forEach(x=>x.classList.remove('active'));b.classList.add('active');document.querySelector(`[data-view="${b.dataset.lens}"]`).classList.add('active')}));
+document.querySelectorAll('[data-focus]').forEach(b=>b.addEventListener('click',()=>toast(`Focused ${b.dataset.focus} on the canvas`)));
+
+
+document.getElementById('analysisEvidenceToggle').addEventListener('click',()=>{
+  const open=document.getElementById('hero').classList.toggle('analysis-evidence-open');
+  document.getElementById('analysisEvidenceToggle').setAttribute('aria-expanded',String(open));
+});
+document.getElementById('openRecommendation').addEventListener('click',()=>{
+  const card=document.getElementById('strengthCard');
+  card.scrollIntoView({behavior:'smooth',block:'start'});
+  const first=card.querySelector('.recommendation');
+  if(first&&!first.classList.contains('open')){
+    first.classList.add('open');
+    const button=first.querySelector('.recommendation-head');
+    if(button)button.setAttribute('aria-expanded','true');
+  }
+});
+document.querySelectorAll('[data-overview]').forEach(button=>button.addEventListener('click',()=>{
+  openDrawer(`Review ${button.dataset.overview}`,`Help me check whether this decision classification is right and how it should affect the process.`);
+}));
+document.querySelectorAll('[data-direct-edit]').forEach(button=>button.addEventListener('click',()=>{
+  openDrawer(`Edit ${button.dataset.directEdit}`,`Update this part of the persisted decision brief directly.`);
+}));
+
+document.querySelectorAll('.tab-button').forEach(b=>b.addEventListener('click',()=>{
+  document.querySelectorAll('.tab-button').forEach(x=>x.classList.remove('active'));
+  document.querySelectorAll('.evidence-view').forEach(x=>x.classList.remove('active'));
+  b.classList.add('active');
+  document.querySelector(`[data-evidence-view="${b.dataset.evidence}"]`).classList.add('active');
+}));
+document.querySelectorAll('.evidence-row').forEach(r=>r.addEventListener('click',()=>toast(`Focused ${r.dataset.focus} on the canvas`)));
+document.querySelector('.see-all-evidence').addEventListener('click',e=>{const extra=document.querySelector('.extra-evidence');const show=extra.style.display==='none';extra.style.display=show?'grid':'none';e.target.textContent=show?'Show fewer':'See all factors'});
+
+document.querySelector('.rerun').addEventListener('click',()=>{mock.classList.remove('stale');setPressed('fresh','current');toast('Analysis rerun completed with the current model')});
+
+function renderGoalView(isSet){const view=document.querySelector('[data-view="goal"]');if(!isSet){view.innerHTML='<div class="unavailable"><span aria-hidden="true">ⓘ</span><span>Goal fit needs a measurable success definition. <button class="text-button open-success" type="button">Define success</button></span></div>';view.querySelector('.open-success').addEventListener('click',openSuccess);return}view.innerHTML='<div class="option-table"><div class="option-row leading"><span class="option-number">1</span><span class="option-name">Bring On Technical Co-Founder</span><span class="option-value">72%</span></div><div class="option-row"><span class="option-number">2</span><span class="option-name">Hire Senior Technical Lead</span><span class="option-value">64%</span></div><div class="option-row"><span class="option-number">3</span><span class="option-name">Continue Without Technical Lead</span><span class="option-value">31%</span></div><div class="option-row"><span class="option-number">4</span><span class="option-name">Outsource Technical Leadership</span><span class="option-value">27%</span></div></div><p class="meta" style="margin:8px 0 0">Probability of meeting the success measure.</p>'}
+
+const modal=document.getElementById('successModal');
+function openSuccess(){modal.classList.add('open');document.getElementById('threshold').focus()}
+function closeSuccess(){modal.classList.remove('open')}
+document.querySelectorAll('.open-success').forEach(b=>b.addEventListener('click',openSuccess));document.querySelectorAll('.close-success').forEach(b=>b.addEventListener('click',closeSuccess));
+['metric','direction','threshold','unit','timeframe'].forEach(id=>document.getElementById(id).addEventListener('input',updatePreview));
+function updatePreview(){const metric=document.getElementById('metric').value||'[outcome]';const direction=document.getElementById('direction').value.toLowerCase();const threshold=document.getElementById('threshold').value||'[number]';const unit=document.getElementById('unit').value;const timeframe=document.getElementById('timeframe').value||'[timeframe]';document.getElementById('measurePreview').textContent=`Success means: ${direction} ${metric} ${threshold}${unit} ${timeframe.toLowerCase()}.`}
+document.getElementById('saveSuccess').addEventListener('click',()=>{const metric=document.getElementById('metric').value.trim(),t=document.getElementById('threshold').value.trim(),unit=document.getElementById('unit').value.trim(),f=document.getElementById('timeframe').value.trim();if(!metric||!t||!unit||!f||!Number.isFinite(Number(t))){document.getElementById('measureError').classList.add('show');return}document.getElementById('measureError').classList.remove('show');mock.classList.remove('measure-missing');mock.classList.add('measure-set');document.querySelector('.goal-note').textContent=`${document.getElementById('metric').value}: ${t}${document.getElementById('unit').value}, ${f}`;recState.set('success',{status:'addressed'});renderRecommendations();closeSuccess();setPressed('measure','set');toast('Success measure updated. Analysis rerun without changing graph structure.');renderGoalView(true);document.querySelector('[data-lens="goal"]').click()});
+
+
+const decisionModal=document.getElementById('decisionModal');
+function openDecision(){decisionModal.classList.add('open');document.getElementById('decisionConfidence').focus()}
+function closeDecision(){decisionModal.classList.remove('open')}
+document.querySelectorAll('.close-decision').forEach(button=>button.addEventListener('click',closeDecision));
+document.getElementById('saveDecision').addEventListener('click',()=>{
+  const confidence=document.getElementById('decisionConfidence').value.trim();
+  const rationale=document.getElementById('decisionRationale').value.trim();
+  const assumption=document.getElementById('assumptionWatch').value.trim();
+  const revisit=document.getElementById('revisitDate').value.trim();
+  const error=document.getElementById('decisionError');
+  const confidenceNumber=Number(confidence);
+  if(!Number.isFinite(confidenceNumber)||confidenceNumber<0||confidenceNumber>100||!rationale||!assumption||!revisit){
+    error.classList.add('show');
+    return;
+  }
+  error.classList.remove('show');
+  recState.set('commit',{status:'addressed'});
+  renderRecommendations();
+  closeDecision();
+  toast('Prototype decision record captured in this session.');
+});
+
+const drawer=document.getElementById('olumiDrawer');
+function openDrawer(title,context){document.getElementById('drawerContext').innerHTML=`<strong style="color:var(--text-header);font-weight:600">${title}</strong><br>${context}`;document.getElementById('drawerMessage').value=`Help me work through: ${title}`;drawer.classList.add('open')}
+document.querySelectorAll('[data-ask]').forEach(b=>b.addEventListener('click',()=>openDrawer('Resolve the brief conflict',b.dataset.ask)));
+document.getElementById('closeDrawer').addEventListener('click',()=>drawer.classList.remove('open'));
+document.getElementById('sendDrawer').addEventListener('click',()=>{toast('Sent to Olumi with the relevant model context');drawer.classList.remove('open')});document.getElementById('focusFromDrawer').addEventListener('click',()=>toast('Focused the relevant model elements on the canvas'));
+
+function setPressed(group,value){document.querySelectorAll(`[data-control="${group}"] button`).forEach(b=>b.setAttribute('aria-pressed',String(b.dataset.value===value)))}
+document.querySelectorAll('[data-control] button').forEach(b=>b.addEventListener('click',()=>{const group=b.closest('[data-control]').dataset.control,value=b.dataset.value;setPressed(group,value);if(group==='quality'){
+  mock.classList.remove('quality-ready','quality-thin','quality-conflict');
+  mock.classList.add(`quality-${value}`);
+  const state=document.querySelector('.brief-state'),note=document.querySelector('.brief-state-note');
+  const overview=document.getElementById('decisionOverview'),toggle=document.getElementById('briefToggle');
+  if(value==='ready'){
+    state.textContent='Framing has the basics';
+    note.textContent='Goal, context, constraints and options';
+    overview.classList.remove('brief-open');
+    toggle.setAttribute('aria-expanded','false');
+  }
+  if(value==='thin'){
+    state.textContent='Framing needs one clarification';
+    note.textContent='The goal is broad or important context is missing';
+    overview.classList.add('brief-open');
+    toggle.setAttribute('aria-expanded','true');
+  }
+  if(value==='conflict'){
+    state.textContent='The brief contains a conflict';
+    note.textContent='Resolve it before relying on the read';
+    overview.classList.add('brief-open');
+    toggle.setAttribute('aria-expanded','true');
+  }
+}if(group==='fresh'){mock.classList.toggle('stale',value==='stale')}if(group==='measure'){if(value==='set'){document.getElementById('threshold').value='20';document.getElementById('timeframe').value='within 6 months';document.getElementById('saveSuccess').click()}else{mock.classList.add('measure-missing');mock.classList.remove('measure-set');document.querySelector('.goal-note').textContent='Success measure missing';renderGoalView(false);recState.set('success',{status:'recommended'});renderRecommendations()}}if(group==='priority'){priority=value;visibleCount=1;renderRecommendations()}
+if(group==='diversity'){
+  optionSetNarrow=value==='narrow';
+  const optionsNote=document.querySelector('.options-note');
+  if(optionsNote)optionsNote.textContent=optionSetNarrow?'Three of four use the same mechanism':'Four distinct routes';
+  if(optionSetNarrow){
+    recState.set('broaden',{status:'recommended'});
+    toast('Prototype: producer-owned option-similarity signal is active.');
+  }
+  visibleCount=1;
+  renderRecommendations();
+}}));
+
+document.getElementById('decisionOverview').classList.remove('brief-open');
+document.getElementById('briefToggle').setAttribute('aria-expanded','false');
+renderGoalView(false);
+updatePreview();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Why

Paul asked for the v6 prototype to be saved "somewhere any other Workstream can access going forward". Checking where it already lived surfaced the actual problem.

**These six files existed only on one laptop.** `~/Documents/GitHub/docs-designs/` is **not a git repository** and has **no remote** (`git rev-parse --is-inside-work-tree` → `fatal: not a git repository`). Among them is `ANALYSIS-TAB-BUILD-BRIEF.md` — which the kickoff calls **the authority** on intent, boundaries and acceptance for the entire v6 build. The code was safe on GitHub; **the design governing the next build was one disk failure from gone**, and no other machine or workstream could read it.

Copying it to another folder on the same disk would not have answered the ask. This does:
```bash
gh api "repos/Talchain/DecisionGuideAI/contents/docs-designs/ANALYSIS-TAB-BUILD-GUIDE-V6-2026-07-15/ANALYSIS-TAB-BUILD-BRIEF.md?ref=staging" --jq .content | base64 -d
```

## What

Six files committed **verbatim** (nothing edited) + a README.

**Integrity:** the prototype is **byte-identical** to the copy Paul re-issued today and to both copies already on disk — all three hash to git blob `8cee7e65`. No version ambiguity. (Note: `HANDOVER-EXPERIENCE.md` cites this prototype as "sha 080b4a04"; that matches **none** of the file's git-blob/sha256/md5. The bytes are what count, and they agree.)

The README records what a future reader needs and cannot infer from the files:
- **`ANALYSIS-TAB-BUILD-BRIEF.md` wins** where anything else disagrees with it.
- The prototype is **layout reference only** — it *simulates* producer-owned states the wire does not supply, and brief §13.4 explicitly overrides its receipt copy.
- **`V6-BUILD-PLAN.md` is APPROVED-WITH-AMENDMENTS (11) and is NOT safe to execute as written.**
- The build is **Paul-gated** on Options-section retirement + WhatChangedChip retirement.
- Re-verify every code reference against `origin/staging` first — lane briefs derived from these docs have already been wrong twice on that basis.

## Scope

**Docs only.** No source, no tests, no config. Staged by explicit path.

## Related — programme-level risk, routed to the orchestrator, not fixed here

The same check shows **~157 briefs in `parallel-briefs/`, ~281 files in `docs-designs/`, and 16 root boards** (`CLAUDE.md`, `ROADMAP.md`, `PROGRAM-BOARD.md`, `HANDOVER.md`) are **all machine-local with no remote**. That is every handover and the whole coordination layer. The boards are orchestrator-owned, so this PR deliberately rescues **only** the UI/Experience design authority in my own repo rather than unilaterally importing someone else's files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)