### PR TITLE
fix(results): receipts stay honest through the persistence roundtrip (T2b)

### DIFF
--- a/src/canvas/compare-tab/HealthIndicators.tsx
+++ b/src/canvas/compare-tab/HealthIndicators.tsx
@@ -7,7 +7,14 @@ interface HealthIndicatorsProps {
   latest: AnalysisSnapshot
 }
 
-function stabilityImproving(from: string, to: string): boolean {
+/**
+ * T2b: an unknown stability cannot be "improving". When either end of the
+ * comparison was never assessed there is no trend to claim, so this reports
+ * false rather than letting `indexOf(null)` (-1) manufacture a rise out of
+ * missing data.
+ */
+function stabilityImproving(from: string | null, to: string | null): boolean {
+  if (from == null || to == null) return false
   const order = ['fragile', 'mostly stable', 'stable']
   return order.indexOf(to) > order.indexOf(from)
 }
@@ -23,8 +30,10 @@ export function HealthIndicators({ first, latest }: HealthIndicatorsProps) {
   const indicators = [
     {
       label: 'Result stability',
-      from: first.stabilityLabel,
-      to: latest.stabilityLabel,
+      // T2b: a null label means the producer sent no robustness data. Say so,
+      // rather than rendering an empty gap that reads as a missing UI.
+      from: first.stabilityLabel ?? 'Not assessed',
+      to: latest.stabilityLabel ?? 'Not assessed',
       up: stabilityImproving(first.stabilityLabel, latest.stabilityLabel),
     },
     {

--- a/src/canvas/compare-tab/Hero.tsx
+++ b/src/canvas/compare-tab/Hero.tsx
@@ -21,7 +21,12 @@ function getHeroCopy(
     case 'improving':
       return {
         line1: `Run ${latest.runNumber} · ${latest.winnerLabel} leads at ${latest.winnerProbability}% (was ${first.winnerProbability}% at run 1)`,
-        line2: `Confidence improving · Model ${latest.stabilityLabel}`,
+        // T2b: drop the "Model X" clause entirely when robustness was never
+        // assessed. A template literal would coerce null to the string "null"
+        // ("Model null") and TypeScript cannot catch that.
+        line2: latest.stabilityLabel != null
+          ? `Confidence improving · Model ${latest.stabilityLabel}`
+          : 'Confidence improving',
         actionPrefix: 'Calibrate ',
         actionLink: latest.topEvpiFactor,
         actionNodeId: latest.topEvpiFactorId,
@@ -117,7 +122,13 @@ export function Hero({ state, snapshots, showExpert }: HeroProps) {
       {/* Expert methodology line */}
       {showExpert && (
         <div className={`${typography.panelMeta} mt-1.5`}>
-          1,000 Monte Carlo simulations · Bootstrap stability · Seed: {latest.seedUsed} · Hash: {latest.responseHash}
+          {/* T2b: the Seed segment fails closed. React renders a null child as
+              nothing, which would leave a bare "Seed: ·" claiming a receipt
+              that does not exist. This mirrors AdvancedSection, which hides
+              its Seed row on the same fact. */}
+          1,000 Monte Carlo simulations · Bootstrap stability
+          {latest.seedUsed != null && <> · Seed: {latest.seedUsed}</>}
+          {' · '}Hash: {latest.responseHash}
         </div>
       )}
     </div>

--- a/src/canvas/compare-tab/TrajectorySection.tsx
+++ b/src/canvas/compare-tab/TrajectorySection.tsx
@@ -13,6 +13,17 @@ interface TrajectorySectionProps {
   showExpert: boolean
 }
 
+/**
+ * T2b: absence renders as "Not assessed", never as 0.
+ *
+ * The snapshot fields are absence-preserving (null = the producer sent no
+ * robustness data / the engine echoed no seed). Rendering a null as 0 would
+ * put "0 fragile" in this table while AdvancedSection honestly hid the same
+ * fact for the same run — the cross-surface incoherence #322 was merged to
+ * prevent. An honest producer-sent 0 still shows as 0.
+ */
+const NOT_ASSESSED = 'Not assessed'
+
 function ExpertTable({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
   return (
     <div className="mt-2">
@@ -34,12 +45,14 @@ function ExpertTable({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
             <tr key={s.runId}>
               {[
                 s.runNumber,
-                `${Math.round(s.recommendationStability * 100)}%`,
+                s.recommendationStability != null
+                  ? `${Math.round(s.recommendationStability * 100)}%`
+                  : NOT_ASSESSED,
                 s.evidenceCoverage,
                 `${s.influenceConcentration}%`,
                 s.rankFlipRate.toFixed(2),
-                s.fragileEdgeCount,
-                s.seedUsed,
+                s.fragileEdgeCount ?? NOT_ASSESSED,
+                s.seedUsed ?? NOT_ASSESSED,
               ].map((val, i) => (
                 <td key={i} className={`${typography.panelMeta} tabular-nums px-0.5 py-0.5`}>
                   {val}

--- a/src/canvas/compare-tab/__tests__/TrajectorySection.absence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/TrajectorySection.absence.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * Compare tab renders absence honestly (T2b) — the cross-surface half.
+ *
+ * PR #326 made the mapper's fragile_edges / robust_edges absence-preserving so
+ * AdvancedSection honestly HIDES the "Stable edges" row when the producer sent
+ * nothing. The snapshot factory then re-fabricated a 0, which surfaced here.
+ * The result: same run, same fact, two surfaces — AdvancedSection said
+ * "unknown", the compare tab said "0 fragile". That cross-surface incoherence
+ * is exactly what #322 was merged to prevent.
+ *
+ * These pins hold the compare tab to the same standard as AdvancedSection:
+ * absence renders as "Not assessed"; an honest producer-sent 0 still shows 0.
+ *
+ * Sibling: src/components/results/__tests__/receipts-fail-closed.spec.tsx
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TrajectorySection } from '../TrajectorySection'
+import type { AnalysisSnapshot } from '../types'
+
+function snapshot(overrides: Partial<AnalysisSnapshot> = {}): AnalysisSnapshot {
+  return {
+    runId: 'run-1',
+    runNumber: 1,
+    timestamp: '2026-02-20T10:00:00Z',
+    graphHash: 'hash-1',
+    nodeCount: 2,
+    edgeCount: 1,
+    winnerId: 'opt-1',
+    winnerLabel: 'Option A',
+    winnerProbability: 60,
+    runnerUpId: null,
+    runnerUpLabel: null,
+    runnerUpProbability: null,
+    recommendationStability: 0.8,
+    stabilityLabel: 'stable',
+    fragileEdgeCount: 2,
+    evidenceCoverage: '3/5',
+    topFactors: [],
+    influenceConcentration: 40,
+    topEvpiFactor: '',
+    topEvpiFactorId: '',
+    topEvpiValue: 0,
+    topElasticity: 0,
+    rankFlipRate: 0,
+    goalProbability: null,
+    jointGoalProbability: null,
+    edgeEValues: [],
+    seedUsed: 42,
+    responseHash: 'resp-1',
+    editSummary: '',
+    ...overrides,
+  } as AnalysisSnapshot
+}
+
+describe('TrajectorySection expert table — absence is not zero (T2b)', () => {
+  it('fragileEdgeCount null → "Not assessed", never "0 fragile"', () => {
+    render(<TrajectorySection snapshots={[snapshot({ fragileEdgeCount: null })]} showExpert />)
+
+    // The honest statement is present...
+    expect(screen.getAllByText('Not assessed').length).toBeGreaterThan(0)
+    // ...and the fabricated zero is absent from the Fragile column.
+    const cells = screen.getAllByRole('cell').map(c => c.textContent)
+    expect(cells).toContain('Not assessed')
+    expect(cells).not.toContain('0')
+  })
+
+  it('fragileEdgeCount 0 is an HONEST zero → still shows 0', () => {
+    // The producer measured and found none. That is a real fact and must show.
+    render(<TrajectorySection snapshots={[snapshot({ fragileEdgeCount: 0 })]} showExpert />)
+
+    const cells = screen.getAllByRole('cell').map(c => c.textContent)
+    expect(cells).toContain('0')
+  })
+
+  it('recommendationStability null → "Not assessed", not "0%"', () => {
+    render(
+      <TrajectorySection
+        snapshots={[snapshot({ recommendationStability: null, stabilityLabel: null })]}
+        showExpert
+      />,
+    )
+
+    const cells = screen.getAllByRole('cell').map(c => c.textContent)
+    expect(cells).toContain('Not assessed')
+    expect(cells).not.toContain('0%')
+  })
+
+  it('an honest 0 stability still shows 0%', () => {
+    render(
+      <TrajectorySection
+        snapshots={[snapshot({ recommendationStability: 0, stabilityLabel: 'fragile' })]}
+        showExpert
+      />,
+    )
+
+    const cells = screen.getAllByRole('cell').map(c => c.textContent)
+    expect(cells).toContain('0%')
+  })
+
+  it('seedUsed null → "Not assessed", never "Seed 0"', () => {
+    render(<TrajectorySection snapshots={[snapshot({ seedUsed: null })]} showExpert />)
+
+    const cells = screen.getAllByRole('cell').map(c => c.textContent)
+    expect(cells).toContain('Not assessed')
+    expect(cells).not.toContain('0')
+  })
+
+  it('a real engine seed of 0 still shows 0', () => {
+    render(<TrajectorySection snapshots={[snapshot({ seedUsed: 0 })]} showExpert />)
+
+    const cells = screen.getAllByRole('cell').map(c => c.textContent)
+    expect(cells).toContain('0')
+  })
+
+  it('all robustness present → no "Not assessed" anywhere', () => {
+    render(<TrajectorySection snapshots={[snapshot()]} showExpert />)
+
+    expect(screen.queryByText('Not assessed')).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
@@ -59,6 +59,45 @@ function makeSnapshot(overrides: Partial<AnalysisSnapshot> & { runNumber: number
 // ---------------------------------------------------------------------------
 
 describe('deriveTransitions', () => {
+  // ── T2b: a robustness CHANGE requires BOTH ends to have been assessed ──
+  //
+  // Added because this lane's own headline finding is "the fix was unpinned",
+  // and an adversarial review caught it shipping a SECOND unpinned fix: the
+  // null-guard below could be reverted with this file staying 27/27 green.
+  //
+  // What the guard prevents: TransitionCard renders
+  //   {tr.robustnessChanged && (Result stability: {tr.robustnessFrom} → {tr.robustnessTo})}
+  // and JSX renders null as nothing — so an unguarded null→'stable' pair
+  // reports "Result stability:  → stable": a change claimed from MISSING data.
+  // That is precisely the fabrication class T2b exists to remove.
+  //
+  // MUTATION-CHECKED: dropping either `!= null` clause turns test (a) RED.
+  describe('T2b — robustness change needs both ends assessed', () => {
+    it('(a) does NOT claim a change when the earlier run had no robustness data', () => {
+      const [tr] = deriveTransitions([
+        makeSnapshot({ runNumber: 1, stabilityLabel: null }),
+        makeSnapshot({ runNumber: 2, stabilityLabel: 'stable' }),
+      ])
+      expect(tr.robustnessChanged).toBe(false)
+    })
+
+    it('(b) does NOT claim a change when the later run has no robustness data', () => {
+      const [tr] = deriveTransitions([
+        makeSnapshot({ runNumber: 1, stabilityLabel: 'stable' }),
+        makeSnapshot({ runNumber: 2, stabilityLabel: null }),
+      ])
+      expect(tr.robustnessChanged).toBe(false)
+    })
+
+    it('(c) DOES claim a change when both ends are assessed and differ', () => {
+      const [tr] = deriveTransitions([
+        makeSnapshot({ runNumber: 1, stabilityLabel: 'fragile' }),
+        makeSnapshot({ runNumber: 2, stabilityLabel: 'stable' }),
+      ])
+      expect(tr.robustnessChanged).toBe(true)
+    })
+  })
+
   it('returns empty for fewer than 2 snapshots', () => {
     expect(deriveTransitions([])).toEqual([])
     expect(deriveTransitions([makeSnapshot({ runNumber: 1 })])).toEqual([])

--- a/src/canvas/compare-tab/deriveTransitions.ts
+++ b/src/canvas/compare-tab/deriveTransitions.ts
@@ -183,7 +183,12 @@ function buildTransition(from: AnalysisSnapshot, to: AnalysisSnapshot): Transiti
     magnitude: classifyMagnitude(delta),
     edits: to.editSummary ? [to.editSummary] : [],
     winnerProbDelta: delta,
-    robustnessChanged: from.stabilityLabel !== to.stabilityLabel,
+    // T2b: a robustness CHANGE can only be claimed when both ends were
+    // actually assessed. Comparing a null against a real label would report
+    // "robustness changed" purely because one run had no robustness data.
+    robustnessChanged: from.stabilityLabel != null
+      && to.stabilityLabel != null
+      && from.stabilityLabel !== to.stabilityLabel,
     robustnessFrom: from.stabilityLabel,
     robustnessTo: to.stabilityLabel,
     goalProbDelta,

--- a/src/canvas/compare-tab/types.ts
+++ b/src/canvas/compare-tab/types.ts
@@ -44,11 +44,16 @@ export interface AnalysisSnapshot {
   runnerUpProbability: number | null
 
   // Robustness
-  /** Raw 0-1 */
-  recommendationStability: number
-  /** "fragile" | "mostly stable" | "stable" */
-  stabilityLabel: string
-  fragileEdgeCount: number
+  //
+  // T2b: these are absence-preserving. null means the producer sent no
+  // robustness data — NOT "zero". Rendering a fabricated 0 here contradicted
+  // AdvancedSection, which honestly hides the same fact when it is absent.
+  /** Raw 0-1; null when the producer sent no recommendation_stability. */
+  recommendationStability: number | null
+  /** "fragile" | "mostly stable" | "stable"; null when stability is unknown. */
+  stabilityLabel: string | null
+  /** null when the producer sent no fragile_edges array. `[]` is an honest 0. */
+  fragileEdgeCount: number | null
 
   // Evidence
   /** "3/5" format */
@@ -87,7 +92,8 @@ export interface AnalysisSnapshot {
   }>
 
   // Meta
-  seedUsed: number
+  /** T2b: null when the engine did not echo a usable seed — never a fabricated 0. */
+  seedUsed: number | null
   responseHash: string
   /** Derived from events, max 60 chars */
   editSummary: string
@@ -116,9 +122,11 @@ export interface Transition {
   magnitude: 'major' | 'refinement' | 'minor'
   edits: string[]
   winnerProbDelta: number
+  /** T2b: false when either end was never assessed — absence is not a change. */
   robustnessChanged: boolean
-  robustnessFrom: string
-  robustnessTo: string
+  /** T2b: null when the producer sent no robustness data for that run. */
+  robustnessFrom: string | null
+  robustnessTo: string | null
   goalProbDelta: number | null
   /** Node IDs of affected factors */
   affectedFactorIds: string[]

--- a/src/canvas/hooks/__tests__/useV2Run.seedPersistCallSite.spec.ts
+++ b/src/canvas/hooks/__tests__/useV2Run.seedPersistCallSite.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * T2b — the WRITE-PATH CALL SITE pin. This file exists because the lane's
+ * other specs did not pin the thing the lane exists to fix.
+ *
+ * WHY THIS FILE EXISTS (read before deleting or weakening it):
+ * PR #326 shipped as "receipts fail closed — no fabricated Seed values" and
+ * was TRUE of the read path and FALSE on reload, because the write path still
+ * fabricated. Its tests passed anyway. T2b then fixed the write path — and
+ * repeated the same mistake: `useV2Run.seedPersistence.spec.ts` imports
+ * `resolveSeedUsed` and exercises it as a PURE FUNCTION, while
+ * `receipts-persistence-roundtrip.spec.tsx` RE-IMPLEMENTS the write leg by
+ * hand. Neither invokes `useV2Run`. An adversarial audit proved the
+ * consequence: re-introducing the exact fabricated `0` at the call site left
+ * **595/595 tests green**.
+ *
+ * A fix whose own tests pass when you re-break it is not fixed — it is
+ * unpinned. So these pins do the one thing the others don't: they MOUNT THE
+ * REAL HOOK, drive a real successful run, and assert on what
+ * `persistAnalysisSuccess` actually receives.
+ *
+ * MUTATION-CHECKED (the bar this lane is held to): reverting
+ * `useV2Run.ts`'s call site to the pre-fix expression
+ *
+ *   const seedUsed = successResult.meta?.seed_used
+ *     ? (parseInt(successResult.meta.seed_used, 10) || 0)
+ *     : (seed ?? 0)
+ *
+ * turns tests 1, 2 and 3 below RED. Verify that before trusting them.
+ *
+ * The two sinks answer DIFFERENT questions and are pinned separately:
+ *  - `seedUsed`   = the RECEIPT ("what did the engine say it used?") — must be
+ *                   null when unknown; a real engine 0 must stay 0.
+ *  - `seedForHash`= a RUN IDENTITY for the graph hash — falls back to the seed
+ *                   we actually SENT. Ruled KEEP+LEDGER by the orchestrator on
+ *                   the evidence that the persisted hash has ZERO readers, so
+ *                   this leg is inert today; it is pinned so it stays
+ *                   deliberate rather than becoming accidental.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useV2Run, type V2RunPersistence } from '../useV2Run'
+import { useCanvasStore } from '../../store'
+import { useDraftStore } from '../../stores/draftStore'
+import { useResultsStore } from '../../stores/resultsStore'
+
+vi.mock('../../../adapters/plot/v2', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../adapters/plot/v2')>()
+  return { ...actual, executeV2RunWithAnalysisReady: vi.fn() }
+})
+vi.mock('../../../lib/resultsInstrumentation', () => ({
+  trackRunCompleted: vi.fn(),
+  trackRunFailed: vi.fn(),
+  trackEmptyComputedResults: vi.fn(),
+}))
+vi.mock('../../../lib/telemetry', () => ({ trackTypedError: vi.fn() }))
+vi.mock('../../../lib/gate-state', () => ({
+  useGateStore: { getState: () => ({ setGate: vi.fn() }) },
+  updateRobustnessGate: vi.fn(),
+  updateRobustnessGateFromV2: vi.fn(),
+}))
+
+import { executeV2RunWithAnalysisReady } from '../../../adapters/plot/v2'
+const mockExecute = executeV2RunWithAnalysisReady as Mock
+
+/** A successful V2 run. `meta` is caller-controlled: that is the whole point. */
+function successResponse(meta?: Record<string, unknown>) {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    option_comparison: [],
+    response_hash: 'resp-hash-t2b',
+    request_id: 'req-t2b',
+    outcome: { mean: 100, p10: 80, p50: 100, p90: 120 },
+    ...(meta ? { meta } : {}),
+  }
+}
+
+function seedCanvas() {
+  const baseResults = useCanvasStore.getState().results
+  const nodes: any[] = [
+    { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+    { id: 'fac-1', type: 'factor', data: { label: 'Factor', kind: 'factor' }, position: { x: 100, y: 0 } },
+    { id: 'opt-1', type: 'option', data: { label: 'Option A', kind: 'option', interventions: { 'fac-1': 0.5 } }, position: { x: 200, y: 0 } },
+  ]
+  useCanvasStore.setState({
+    nodes,
+    edges: [{ id: 'e1', source: 'goal-1', target: 'fac-1' }],
+    outcomeNodeId: 'goal-1',
+    ceeAnalysisReady: {
+      goal_node_id: 'goal-1',
+      status: 'ready',
+      options: [{ id: 'opt-1', label: 'Option A', status: 'ready', interventions: { 'fac-1': 0.5 } }],
+    },
+    ceeAnalysisReadyNodeIds: nodes.map((n) => n.id),
+    goalConstraints: null,
+    goalThreshold: null,
+    currentScenarioFraming: null,
+    results: { ...baseResults, status: 'idle' },
+  } as any)
+  useDraftStore.getState().setLastDraftDescription('')
+}
+
+/**
+ * A COMPLETE V2RunPersistence double. Deliberately typed as the real
+ * interface (not `as unknown as`) so that if the interface grows a required
+ * member, this file fails to COMPILE rather than silently taking the hook's
+ * error path and rendering these pins vacuous — which is precisely how the
+ * defect this lane exists to fix stayed invisible.
+ */
+function makePersistence() {
+  const persistAnalysisSuccess = vi.fn().mockResolvedValue(undefined)
+  const persistence: V2RunPersistence = {
+    setAnalysisRunning: vi.fn().mockResolvedValue(undefined),
+    persistAnalysisSuccess,
+    persistAnalysisFailure: vi.fn().mockResolvedValue(undefined),
+    resetAnalysisStatus: vi.fn().mockResolvedValue(undefined),
+  }
+  return { persistence, persistAnalysisSuccess }
+}
+
+/** The seed argument as the REAL call site passed it (3rd positional arg). */
+async function seedPersistedFor(meta?: Record<string, unknown>) {
+  const { persistence, persistAnalysisSuccess } = makePersistence()
+  mockExecute.mockResolvedValueOnce(successResponse(meta))
+  const { result } = renderHook(() => useV2Run(persistence))
+  await act(async () => {
+    await result.current.runV2Analysis()
+  })
+  expect(persistAnalysisSuccess, 'the run must reach the persist call site').toHaveBeenCalledTimes(1)
+  const [, graphHash, seedUsed] = persistAnalysisSuccess.mock.calls[0]
+  return { seedUsed, graphHash }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useResultsStore.setState({ analysisSummary: null })
+  seedCanvas()
+})
+
+describe('T2b — useV2Run persists an HONEST seed receipt (real call site)', () => {
+  it('1. engine echoes NO seed → persists null, never a fabricated 0', async () => {
+    // Pre-fix this took the `: (seed ?? 0)` branch and persisted a number the
+    // engine never confirmed — which hydrateAnalysis then PREFERS, resurrecting
+    // "Seed 0" on reload: #326's claim, false on its own target surface.
+    const { seedUsed } = await seedPersistedFor(undefined)
+    expect(seedUsed).toBeNull()
+  })
+
+  it('2. engine echoes a MALFORMED seed → persists null, never a fabricated 0', async () => {
+    // Pre-fix: parseInt('abc', 10) → NaN → `|| 0` → 0. A lie with no author.
+    const { seedUsed } = await seedPersistedFor({ seed_used: 'abc' })
+    expect(seedUsed).toBeNull()
+  })
+
+  it('3. engine echoes a REAL 0 → persists 0, distinguishable from unknown', async () => {
+    // The other half of the honesty claim, and the one a naive "just use ??"
+    // fix breaks: pre-fix, the truthiness gate made a numeric 0 fall through to
+    // the REQUESTED seed. 0 is a legitimate seed; unknown is not 0.
+    const { seedUsed } = await seedPersistedFor({ seed_used: 0 })
+    expect(seedUsed).toBe(0)
+  })
+
+  it('4. engine echoes a real seed → persists it verbatim', async () => {
+    const { seedUsed } = await seedPersistedFor({ seed_used: '424242' })
+    expect(seedUsed).toBe(424242)
+  })
+
+  it('5. the graph hash is still computed and persisted when the seed is unknown', async () => {
+    // seedForHash falls back to the requested seed, so a hash is always
+    // produced. Pinned as an identity (a non-empty string), NOT as a value:
+    // asserting the digits would freeze a hash whose input this lane
+    // deliberately changed, and which the orchestrator ruled KEEP+LEDGER
+    // precisely because nothing reads it.
+    const { graphHash, seedUsed } = await seedPersistedFor(undefined)
+    expect(seedUsed).toBeNull()
+    expect(typeof graphHash).toBe('string')
+    expect(graphHash.length).toBeGreaterThan(0)
+  })
+
+  it('6. receipt and hash are INDEPENDENT — an unknown receipt does not suppress the hash', async () => {
+    // The two sinks answer different questions; a regression that collapsed
+    // them (e.g. persisting the hash's fallback seed as the receipt) would
+    // reintroduce exactly the fabrication this lane removes.
+    const unknown = await seedPersistedFor(undefined)
+    const known = await seedPersistedFor({ seed_used: '424242' })
+    expect(unknown.seedUsed).toBeNull()
+    expect(known.seedUsed).toBe(424242)
+    expect(typeof unknown.graphHash).toBe('string')
+    expect(unknown.graphHash.length).toBeGreaterThan(0)
+  })
+})

--- a/src/canvas/hooks/__tests__/useV2Run.seedPersistCallSite.spec.ts
+++ b/src/canvas/hooks/__tests__/useV2Run.seedPersistCallSite.spec.ts
@@ -41,7 +41,6 @@ import { renderHook, act } from '@testing-library/react'
 import { useV2Run, type V2RunPersistence } from '../useV2Run'
 import { useCanvasStore } from '../../store'
 import { useDraftStore } from '../../stores/draftStore'
-import { useResultsStore } from '../../stores/resultsStore'
 
 vi.mock('../../../adapters/plot/v2', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../adapters/plot/v2')>()
@@ -102,11 +101,19 @@ function seedCanvas() {
 }
 
 /**
- * A COMPLETE V2RunPersistence double. Deliberately typed as the real
- * interface (not `as unknown as`) so that if the interface grows a required
- * member, this file fails to COMPILE rather than silently taking the hook's
- * error path and rendering these pins vacuous — which is precisely how the
- * defect this lane exists to fix stayed invisible.
+ * A COMPLETE V2RunPersistence double, typed as the real interface rather
+ * than cast through `unknown`.
+ *
+ * What that buys, stated honestly: a missing required member surfaces under
+ * `tsc -p tsconfig.app.json` and in an editor. It does NOT fail the CI gate —
+ * `pnpm typecheck` uses tsconfig.ci.json, whose include list does not cover
+ * src/canvas/hooks at all. So the type is a helpful tripwire, not a guarantee.
+ *
+ * The REAL protection is the runtime guard inside seedPersistedFor: every test
+ * routes through it, and it asserts persistAnalysisSuccess was actually called.
+ * An incomplete double sends the hook down its error path => zero calls => the
+ * guard fails loudly. That matters because it already happened: this double's
+ * first draft omitted setAnalysisRunning and every pin passed vacuously.
  */
 function makePersistence() {
   const persistAnalysisSuccess = vi.fn().mockResolvedValue(undefined)
@@ -134,7 +141,6 @@ async function seedPersistedFor(meta?: Record<string, unknown>) {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  useResultsStore.setState({ analysisSummary: null })
   seedCanvas()
 })
 

--- a/src/canvas/hooks/__tests__/useV2Run.seedPersistence.spec.ts
+++ b/src/canvas/hooks/__tests__/useV2Run.seedPersistence.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Seed persistence honesty (T2b) — the PERSISTED half of the #326 doctrine.
+ *
+ * PR #326 removed the `parseInt(...) || 0` fabrication from the READ path
+ * (hydrateAnalysis.ts) and shipped as "receipts fail closed — no fabricated
+ * Seed/Stable-edges values". But the WRITE path kept the exact same pattern:
+ *
+ *   const seedUsed = successResult.meta?.seed_used
+ *     ? (parseInt(successResult.meta.seed_used, 10) || 0)
+ *     : (seed ?? 0)
+ *
+ * That value has TWO sinks — the Supabase provenance record and the graph
+ * hash. Because hydrateAnalysis PREFERS provenance (`provenance?.seed_used ??
+ * ...`), a fabricated 0 written here comes back as a real-looking "Seed 0"
+ * receipt after a reload, defeating #326 on its own target surface.
+ *
+ * `resolveSeedUsed` is the receipt: what seed did the ENGINE say it used?
+ * Absence and malformed echoes are UNKNOWN (null), never 0. It mirrors
+ * hydrateAnalysis.ts:111-115 (Number.parseInt + Number.isFinite) so the write
+ * path and the read path agree about the same fact.
+ *
+ * Sibling pins:
+ * - src/hooks/__tests__/hydrateAnalysis.spec.ts (the read path, #326)
+ * - src/components/results/__tests__/receipts-fail-closed.spec.tsx (#326)
+ * - src/components/results/__tests__/receipts-persistence-roundtrip.spec.tsx
+ *   (the end-to-end reload pin this lane adds)
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveSeedUsed } from '../useV2Run'
+
+describe('resolveSeedUsed — the engine seed receipt (T2b)', () => {
+  it('a well-formed echo is the receipt', () => {
+    expect(resolveSeedUsed('42')).toBe(42)
+    expect(resolveSeedUsed('1337')).toBe(1337)
+  })
+
+  it('a REAL engine seed of 0 is an honest value — preserved, not confused with unknown', () => {
+    // The whole point of failing closed: 0 must stay distinguishable from
+    // "unknown". A string '0' is the conforming wire shape (V2Meta.seed_used
+    // is declared `string`).
+    expect(resolveSeedUsed('0')).toBe(0)
+  })
+
+  it('a real engine seed of 0 sent as a NUMBER is still preserved', () => {
+    // The old code gated on truthiness, so a numeric 0 was FALSY and silently
+    // fell through to the requested seed — reporting a seed the engine never
+    // confirmed.
+    expect(resolveSeedUsed(0)).toBe(0)
+  })
+
+  it('a MALFORMED echo is unknown → null, never a fabricated 0', () => {
+    // This is the exact `parseInt('abc', 10) || 0` → 0 bug #326 removed from
+    // the read path. NaN must become null, not 0.
+    expect(resolveSeedUsed('abc')).toBeNull()
+    expect(resolveSeedUsed('')).toBeNull()
+    expect(resolveSeedUsed('   ')).toBeNull()
+    expect(resolveSeedUsed({})).toBeNull()
+  })
+
+  it('NO echo is unknown → null, never a fabricated 0', () => {
+    expect(resolveSeedUsed(undefined)).toBeNull()
+    expect(resolveSeedUsed(null)).toBeNull()
+  })
+
+  it('never returns NaN — NaN would survive a `!= null` guard and render as "Seed NaN"', () => {
+    for (const bad of ['abc', '', null, undefined, {}, []]) {
+      const out = resolveSeedUsed(bad)
+      expect(Number.isNaN(out as number)).toBe(false)
+    }
+  })
+
+  it('does NOT fall back to the requested seed — an unconfirmed seed is not a receipt', () => {
+    // useV2Run always has a requested seed in hand (it derives one at
+    // useV2Run.ts:424-441, ending in a timestamp fallback), so the old
+    // `: (seed ?? 0)` branch quietly recorded "the engine used X" whenever the
+    // engine said nothing at all. The receipt must only ever report what the
+    // engine actually echoed; the requested seed is a separate fact.
+    expect(resolveSeedUsed(undefined)).toBeNull()
+  })
+})

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -64,6 +64,33 @@ function deriveNumericSeedFromString(input: string): number {
 }
 
 /**
+ * T2b: resolve the seed the ENGINE reports it used — the receipt.
+ *
+ * Receipts fail closed (T2): no real value → null, never a fabricated 0. This
+ * is the WRITE-path twin of hydrateAnalysis.ts:111-115 and must stay in step
+ * with it, because that function PREFERS the value this one persists
+ * (`provenance?.seed_used ?? ...`). Any fabrication here is laundered into a
+ * real-looking receipt on the next page load.
+ *
+ * The pattern this replaces fabricated a 0 three ways:
+ *   const seedUsed = successResult.meta?.seed_used
+ *     ? (parseInt(successResult.meta.seed_used, 10) || 0)   // 'abc' → NaN → 0
+ *     : (seed ?? 0)                                          // no echo → unconfirmed
+ * plus a truthiness gate that made a numeric engine seed of 0 fall through to
+ * the requested seed.
+ *
+ * Note this deliberately does NOT fall back to the seed we REQUESTED. The
+ * requested seed is a different fact ("what we asked for"); reporting it as
+ * seed_used claims the engine confirmed something it never said. Callers that
+ * need a run identity (e.g. the graph hash) use the requested seed explicitly.
+ */
+export function resolveSeedUsed(metaSeedUsed: unknown): number | null {
+  if (metaSeedUsed == null) return null
+  const parsed = Number.parseInt(String(metaSeedUsed), 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
  * UI-SEM-058: raw → normalised goal-threshold conversion for the PLoT request.
  *
  * store.goalThreshold holds USER UNITS by default (raw), but since Lane 5 its
@@ -329,7 +356,8 @@ export interface V2RunPersistence {
   persistAnalysisSuccess: (
     analysis: unknown,
     graphHash: string,
-    seedUsed: number,
+    /** T2b: null when the engine did not echo a usable seed — never a fabricated 0. */
+    seedUsed: number | null,
     responseHash: string,
     details?: Record<string, unknown>,
   ) => Promise<void>
@@ -936,10 +964,34 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
 
         // C.1b: Persist analysis results to Supabase (non-blocking)
         if (persistence) {
-          const seedUsed = successResult.meta?.seed_used
-            ? (parseInt(successResult.meta.seed_used, 10) || 0)
-            : (seed ?? 0)
-          const graphHash = generateGraphHash(nodes, edges, seedUsed)
+          // T2b: the seed has TWO sinks here, and they answer DIFFERENT questions.
+          //
+          // 1. `seedUsed` is the RECEIPT: "what seed did the engine say it used?"
+          //    Unknown must stay unknown (null) — see resolveSeedUsed. This is
+          //    what lands in Supabase provenance and is read back by
+          //    hydrateAnalysis on reload, so a fabricated 0 here becomes a
+          //    real-looking "Seed 0" row (the exact bug PR #326 removed from
+          //    the read path).
+          //
+          // 2. `seedForHash` is a RUN IDENTITY for the graph hash, not a claim
+          //    about the engine. When the engine did not echo a usable seed we
+          //    fall back to the seed we actually SENT (`seed` is always a real
+          //    number by this point — it is derived at :424-441 above), because
+          //    that is the seed a replay would resend. Falling back to the
+          //    requested seed here is strictly more honest than the old code,
+          //    which hashed a fabricated 0 whenever the echo was malformed.
+          //
+          // The hash's seed component cannot itself distinguish a real 0 from
+          // "unknown" — computeClientHash (adapters/plot/v1/mapper.ts:256) does
+          // `seed: seed || 0`, collapsing null/undefined/NaN/0 to the same
+          // canonical value. Fixing that means changing hash semantics for the
+          // replay gate (pinned by adapters/__tests__/wave2-replay-gate.spec.ts)
+          // and for two out-of-lane call sites (store.ts:2904,
+          // ReactFlowGraph.tsx:1532/1611), so it is deliberately left alone and
+          // ledgered rather than changed casually here.
+          const seedUsed = resolveSeedUsed(successResult.meta?.seed_used)
+          const seedForHash = seedUsed ?? seed
+          const graphHash = generateGraphHash(nodes, edges, seedForHash)
           persistence.persistAnalysisSuccess(
             successResult,
             graphHash,

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -976,7 +976,9 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
           // 2. `seedForHash` is a RUN IDENTITY for the graph hash, not a claim
           //    about the engine. When the engine did not echo a usable seed we
           //    fall back to the seed we actually SENT (`seed` is always a real
-          //    number by this point — it is derived at :424-441 above), because
+          //    number by this point — derived from framing.seed, else hashed
+          //    from scenario_id, else a timestamp fallback; see deriveSeed
+          //    just below the goal validation), because
           //    that is the seed a replay would resend. Falling back to the
           //    requested seed here is strictly more honest than the old code,
           //    which hashed a fabricated 0 whenever the echo was malformed.

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.absence.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.absence.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * analysisSnapshotFactory — absence preservation (T2b).
+ *
+ * The snapshot is a PERSISTENCE surface (it feeds the compare tab across
+ * runs), so a fabrication here has the same reload-resurrection property as
+ * the Supabase provenance leg: the false value outlives the run that produced
+ * it.
+ *
+ * Three `?? 0` fabrications lived here, all of the T2 class — a default that
+ * makes a fail-closed guard pass:
+ *
+ *   :239  robustness?.recommendation_stability ?? 0
+ *   :271  fragileEdgeCount: robustness?.fragile_edges?.length ?? 0
+ *   :250  seed_used != null ? Number(...) : 0
+ *
+ * The fragile_edges one is the sharpest: PR #326 made the mapper's
+ * fragile_edges/robust_edges ABSENCE-PRESERVING so AdvancedSection honestly
+ * HIDES the row when the producer sent nothing — but this factory re-fabricated
+ * a 0 into the snapshot. Same run, same fact, two surfaces: AdvancedSection
+ * said "unknown", the compare tab said "0 fragile". That cross-surface
+ * incoherence is exactly what #322 was merged to prevent.
+ *
+ * The stability one fabricated a VERDICT, not just a number:
+ * deriveStabilityLabel(0) returns 'fragile', so a producer that sent no
+ * robustness data at all made the compare tab assert "Model fragile".
+ */
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+const nodes: Node[] = [
+  { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } },
+]
+const edges: Edge[] = []
+
+function build(rawOverrides: Record<string, unknown>) {
+  return buildAnalysisSnapshot({
+    rawV2Response: {
+      analysis_status: 'computed',
+      option_comparison_status: 'computed',
+      robustness_status: 'unavailable',
+      drivers_status: 'unavailable',
+      option_comparison: [
+        {
+          option_id: 'opt-1',
+          option_label: 'Option A',
+          win_probability: 0.6,
+          confidence_interval: [0.3, 0.7],
+          expected_outcome: 0.5,
+        },
+      ],
+      critiques: [],
+      response_hash: 'resp-1',
+      ...rawOverrides,
+    } as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges,
+    runNumber: 1,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+}
+
+describe('buildAnalysisSnapshot — recommendation_stability absence', () => {
+  it('robustness absent → stability is null, NOT 0', () => {
+    const snap = build({})
+    expect(snap.recommendationStability).toBeNull()
+    expect(snap.recommendationStability).not.toBe(0)
+  })
+
+  it('robustness absent → no fabricated "fragile" verdict', () => {
+    // deriveStabilityLabel(0) === 'fragile'. A missing producer field must not
+    // become an assertion that the model is fragile.
+    const snap = build({})
+    expect(snap.stabilityLabel).toBeNull()
+    expect(snap.stabilityLabel).not.toBe('fragile')
+  })
+
+  it('recommendation_stability present but null → still null, not 0', () => {
+    const snap = build({ robustness: { recommendation_stability: null } })
+    expect(snap.recommendationStability).toBeNull()
+  })
+
+  it('an honest 0 stability is preserved and still labelled', () => {
+    const snap = build({ robustness: { recommendation_stability: 0 } })
+    expect(snap.recommendationStability).toBe(0)
+    expect(snap.stabilityLabel).toBe('fragile')
+  })
+
+  it('a real stability value maps through', () => {
+    const snap = build({ robustness: { recommendation_stability: 0.85 } })
+    expect(snap.recommendationStability).toBe(0.85)
+    expect(snap.stabilityLabel).toBe('stable')
+  })
+})
+
+describe('buildAnalysisSnapshot — fragile_edges absence (cross-surface coherence with #326)', () => {
+  it('fragile_edges absent → fragileEdgeCount is null, NOT 0', () => {
+    const snap = build({ robustness: { recommendation_stability: 0.5 } })
+    expect(snap.fragileEdgeCount).toBeNull()
+    expect(snap.fragileEdgeCount).not.toBe(0)
+  })
+
+  it('robustness entirely absent → fragileEdgeCount is null', () => {
+    const snap = build({})
+    expect(snap.fragileEdgeCount).toBeNull()
+  })
+
+  it('fragile_edges: [] is an honest 0 → preserved as 0, not null', () => {
+    // The producer measured and found none. That is a real fact and must show.
+    const snap = build({ robustness: { recommendation_stability: 0.5, fragile_edges: [] } })
+    expect(snap.fragileEdgeCount).toBe(0)
+  })
+
+  it('fragile_edges with entries → counted', () => {
+    const snap = build({
+      robustness: { recommendation_stability: 0.5, fragile_edges: ['e1', 'e2'] },
+    })
+    expect(snap.fragileEdgeCount).toBe(2)
+  })
+})
+
+describe('buildAnalysisSnapshot — seed absence', () => {
+  it('no meta → seedUsed is null, NOT 0', () => {
+    const snap = build({})
+    expect(snap.seedUsed).toBeNull()
+    expect(snap.seedUsed).not.toBe(0)
+  })
+
+  it('malformed echo → seedUsed is null, and never NaN', () => {
+    // The old code used Number('abc') → NaN, which survives a `!= null` guard
+    // and renders as "Seed NaN".
+    const snap = build({ meta: { seed_used: 'abc' } })
+    expect(snap.seedUsed).toBeNull()
+    expect(Number.isNaN(snap.seedUsed as number)).toBe(false)
+  })
+
+  it('a real engine seed of 0 is preserved', () => {
+    const snap = build({ meta: { seed_used: '0' } })
+    expect(snap.seedUsed).toBe(0)
+  })
+
+  it('a real seed maps through', () => {
+    const snap = build({ meta: { seed_used: '4242' } })
+    expect(snap.seedUsed).toBe(4242)
+  })
+})

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -235,8 +235,18 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     .sort((a, b) => (b.evpi_percentage_points ?? 0) - (a.evpi_percentage_points ?? 0))[0]
 
   // Robustness
+  //
+  // T2b: absence-preserving. `?? 0` here was a T2-class fabrication — a
+  // default that makes a fail-closed guard pass — on a PERSISTENCE surface,
+  // so the false value outlived the run that produced it. It also fabricated
+  // a VERDICT, not just a number: deriveStabilityLabel(0) === 'fragile', so a
+  // producer that sent no robustness data at all made the compare tab assert
+  // "Model fragile". An honest producer-sent 0 still flows through.
   const robustness = rawV2Response.robustness
-  const stability = robustness?.recommendation_stability ?? 0
+  const stability = typeof robustness?.recommendation_stability === 'number'
+    && Number.isFinite(robustness.recommendation_stability)
+    ? robustness.recommendation_stability
+    : null
 
   // Goal probability (from winner)
   const goalProbability = winner?.probability_of_goal != null
@@ -247,9 +257,14 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     : null
 
   // Seed
-  const seedUsed = rawV2Response.meta?.seed_used != null
-    ? Number(rawV2Response.meta.seed_used)
-    : 0
+  //
+  // T2b: absence-preserving, and NaN-safe. The old `Number(...)` turned a
+  // malformed echo into NaN, which survives every `!= null` guard downstream
+  // and renders as "Seed NaN"; the `: 0` arm fabricated a seed outright.
+  // Mirrors resolveSeedUsed (useV2Run) and hydrateAnalysis.ts:111-115.
+  const rawSeed = rawV2Response.meta?.seed_used
+  const parsedSeed = rawSeed != null ? Number.parseInt(String(rawSeed), 10) : Number.NaN
+  const seedUsed: number | null = Number.isFinite(parsedSeed) ? parsedSeed : null
 
   return {
     runId: crypto.randomUUID(),
@@ -267,8 +282,17 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     runnerUpProbability: runnerUp ? Math.round((runnerUp.win_probability ?? 0) * 100) : null,
 
     recommendationStability: stability,
-    stabilityLabel: deriveStabilityLabel(stability),
-    fragileEdgeCount: robustness?.fragile_edges?.length ?? 0,
+    stabilityLabel: stability != null ? deriveStabilityLabel(stability) : null,
+    // T2b: absence-preserving. PR #326 made the mapper's fragile_edges /
+    // robust_edges absence-preserving so AdvancedSection honestly HIDES the
+    // row when the producer sent nothing — but this line re-fabricated a 0
+    // into the snapshot, so the same run reported "unknown" on one surface and
+    // "0 fragile" on another (compare-tab). That cross-surface incoherence is
+    // what #322 was merged to prevent. An honest `fragile_edges: []` (the
+    // producer measured and found none) still reports 0.
+    fragileEdgeCount: robustness?.fragile_edges != null
+      ? robustness.fragile_edges.length
+      : null,
 
     evidenceCoverage: computeEvidenceCoverage(nodes),
 

--- a/src/components/results/__tests__/receipts-persistence-roundtrip.spec.tsx
+++ b/src/components/results/__tests__/receipts-persistence-roundtrip.spec.tsx
@@ -1,0 +1,139 @@
+/**
+ * Receipts stay honest through the PERSISTENCE ROUNDTRIP (T2b) — the headline pin.
+ *
+ * PR #326 made the Seed receipt fail closed on the live path and shipped as
+ * "no fabricated Seed/Stable-edges values". This spec pins the property that
+ * #326 did NOT actually deliver: that it survives a save + reload.
+ *
+ * The roundtrip, composed from the real production units (no mocks of the
+ * units under test):
+ *
+ *   engine response  →  resolveSeedUsed()            [useV2Run WRITE path]
+ *                    →  AnalysisProvenance.seed_used [what Supabase stores]
+ *                    →  hydrateAnalysisFromV2Response() [READ path on reload]
+ *                    →  AdvancedSection seedUsed prop [the receipt surface]
+ *
+ * Before this lane the write path fabricated a 0 (`parseInt(x,10) || 0`), and
+ * because hydrateAnalysis PREFERS provenance (`provenance?.seed_used ?? ...`),
+ * that 0 came back as a real-looking "Seed 0" row after reload — the exact
+ * false receipt #326 was merged to kill, resurrected on the next page load.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { resolveSeedUsed } from '../../../canvas/hooks/useV2Run'
+import { hydrateAnalysisFromV2Response } from '../../../hooks/hydrateAnalysis'
+import { AdvancedSection } from '../AdvancedSection'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { AnalysisProvenance } from '../../../types/scenario'
+
+vi.mock('../../../canvas/hooks/useRiskProfile', () => ({
+  useRiskProfile: () => ({ profile: null, loading: false, selectPreset: vi.fn() }),
+  RISK_PRESETS: {
+    risk_averse: { label: 'Risk Averse', description: 'Prefer certainty', icon: '', score: 0.2 },
+    neutral: { label: 'Neutral', description: 'Balance risk', icon: '', score: 0.5 },
+    risk_seeking: { label: 'Risk Seeking', description: 'Accept higher risk', icon: '', score: 0.8 },
+  },
+}))
+
+function makeV2Response(meta?: Record<string, unknown>): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'unavailable',
+    drivers_status: 'unavailable',
+    option_comparison: [
+      {
+        option_id: 'opt-1',
+        option_label: 'Option A',
+        confidence_interval: [0.3, 0.7],
+        expected_outcome: 0.5,
+      },
+    ],
+    critiques: [],
+    response_hash: 'abc123',
+    ...(meta ? { meta } : {}),
+  } as unknown as V2RunResponse
+}
+
+/**
+ * Replays a full save→reload cycle and returns the seed the receipt surface
+ * would be handed. `requestedSeed` is what useV2Run sent to the engine — it is
+ * ALWAYS a real number in production (derived at useV2Run.ts:424-441), which
+ * is why the old `: (seed ?? 0)` fallback silently recorded an unconfirmed
+ * seed as if the engine had confirmed it.
+ */
+function roundtrip(engineMeta?: Record<string, unknown>) {
+  const response = makeV2Response(engineMeta)
+
+  // --- WRITE: what useV2Run persists as provenance.seed_used
+  const persistedSeed = resolveSeedUsed((response as { meta?: { seed_used?: unknown } }).meta?.seed_used)
+
+  const provenance: AnalysisProvenance = {
+    graph_hash: 'graph-hash-1',
+    seed_used: persistedSeed,
+    response_hash: 'abc123',
+    analysed_at: '2026-02-20T10:00:00Z',
+  }
+
+  // --- READ: what hydrateAnalysis derives on the next page load
+  const hydrated = hydrateAnalysisFromV2Response(response, provenance)
+
+  return { persistedSeed, hydratedSeed: hydrated?.results.report?.meta.seed ?? null }
+}
+
+function expand() {
+  fireEvent.click(screen.getByText('Advanced and receipts'))
+}
+
+describe('Seed receipt survives the persistence roundtrip (T2b)', () => {
+  it('NO echo → persists null → reload HIDES the Seed row (the #326 property, now surviving a save)', () => {
+    const { persistedSeed, hydratedSeed } = roundtrip(undefined)
+
+    // The write path must not invent a seed...
+    expect(persistedSeed).toBeNull()
+    // ...so nothing real-looking comes back on reload...
+    expect(hydratedSeed).toBeNull()
+
+    // ...and the receipt surface stays honest and hides the row.
+    render(<AdvancedSection seedUsed={hydratedSeed} expertMode />)
+    expand()
+    expect(screen.queryByText('Seed')).not.toBeInTheDocument()
+  })
+
+  it('MALFORMED echo ("abc") → persists null → reload HIDES the Seed row (no "Seed 0")', () => {
+    const { persistedSeed, hydratedSeed } = roundtrip({ seed_used: 'abc' })
+
+    expect(persistedSeed).toBeNull()
+    expect(persistedSeed).not.toBe(0)
+    expect(hydratedSeed).toBeNull()
+
+    render(<AdvancedSection seedUsed={hydratedSeed} expertMode />)
+    expand()
+    expect(screen.queryByText('Seed')).not.toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+  })
+
+  it('a REAL engine seed of 0 → persists 0 → reload SHOWS "Seed 0" (0 stays distinguishable from unknown)', () => {
+    const { persistedSeed, hydratedSeed } = roundtrip({ seed_used: '0' })
+
+    expect(persistedSeed).toBe(0)
+    expect(hydratedSeed).toBe(0)
+
+    render(<AdvancedSection seedUsed={hydratedSeed} expertMode />)
+    expand()
+    expect(screen.getByText('Seed')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('a normal seed → persists and reloads unchanged', () => {
+    const { persistedSeed, hydratedSeed } = roundtrip({ seed_used: '1337' })
+
+    expect(persistedSeed).toBe(1337)
+    expect(hydratedSeed).toBe(1337)
+
+    render(<AdvancedSection seedUsed={hydratedSeed} expertMode />)
+    expand()
+    expect(screen.getByText('Seed')).toBeInTheDocument()
+    expect(screen.getByText('1337')).toBeInTheDocument()
+  })
+})

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -47,7 +47,8 @@ export interface UseScenarioReturn {
   persistAnalysisSuccess: (
     analysis: unknown,
     graphHash: string,
-    seedUsed: number,
+    /** T2b: null when the engine did not echo a usable seed — never a fabricated 0. */
+    seedUsed: number | null,
     responseHash: string,
     details?: Record<string, unknown>,
     turnId?: string,
@@ -556,7 +557,7 @@ export function useScenario(): UseScenarioReturn {
     async (
       analysis: unknown,
       graphHash: string,
-      seedUsed: number,
+      seedUsed: number | null,
       responseHash: string,
       details?: Record<string, unknown>,
       turnId?: string,

--- a/src/services/scenarioService.ts
+++ b/src/services/scenarioService.ts
@@ -261,7 +261,13 @@ export async function storeAnalysis(
   scenarioId: string,
   analysis: unknown,
   graphHash: string,
-  seedUsed: number,
+  /**
+   * T2b: null when the engine did not echo a usable seed. The RPC param
+   * `p_seed_used INTEGER` has no NOT NULL and no default, and
+   * `analysis_provenance` is JSONB, so a null lands as JSON `null` — an
+   * honest "unknown" that hydrateAnalysis reads back as null.
+   */
+  seedUsed: number | null,
   responseHash: string,
   eventId: string,
   details?: Record<string, unknown>,

--- a/src/types/scenario.ts
+++ b/src/types/scenario.ts
@@ -71,7 +71,16 @@ export type AnalysisStatus =
 
 export interface AnalysisProvenance {
   graph_hash: string        // Canonical graph hash at time of analysis
-  seed_used: number         // Actual seed from PLoT
+  /**
+   * Actual seed echoed by PLoT, or null when it echoed nothing usable (T2b).
+   *
+   * Receipts fail closed: this is a claim about what the engine did, so
+   * "unknown" must be representable. It was typed `number` while the writer
+   * fabricated a 0 to satisfy that type — the type was enforcing the lie.
+   * The column is JSONB (`scenarios.analysis_provenance`), which has no
+   * NOT NULL on this key, so null is a real wire value.
+   */
+  seed_used: number | null
   response_hash: string     // PLoT response hash
   analysed_at: string       // ISO-8601, server-assigned via to_jsonb(now())
 }


### PR DESCRIPTION
## What

Closes the seed leg PR #326 left open. **#326 shipped as "receipts fail closed — no fabricated Seed values" and that claim is false on reload**, on #326's own target surface: it fixed the READ path (`hydrateAnalysis.ts`) while the WRITE path kept the identical `parseInt(...) || 0` / `seed ?? 0` fabrication. `hydrateAnalysis` *prefers* persisted provenance, so the fabricated `0` was laundered back as a real-looking **"Seed 0"** receipt on the next page load.

- **`resolveSeedUsed(meta.seed_used) → number | null`** — the RECEIPT. Absent/malformed ⇒ `null`, never `0`. A **real engine seed of 0 stays 0** and stays distinguishable from unknown (the old truthiness gate silently sent a numeric `0` to the requested-seed branch).
- **The two sinks are split.** The receipt is nullable; the graph hash uses `seedForHash = seedUsed ?? seed` — a run identity, not an engine claim.
- Widens the persist chain to `number | null` through `types/scenario.ts` → `scenarioService.ts` → `useScenario.ts`, plus the compare-tab absence legs.

## The finding that mattered: **the fix was unpinned**

An adversarial audit (35 agents, 12 findings survived / 19 refuted) found this lane **had reproduced the exact defect it exists to fix**: re-introducing the fabricated `0` at the call site left **595/595 tests green**.

- `useV2Run.seedPersistence.spec.ts` exercised `resolveSeedUsed` as a **pure function** — reverting the call site leaves the helper untouched.
- `receipts-persistence-roundtrip.spec.tsx` **re-implements** the write leg by hand — it failed pre-fix only on symbol existence.
- **Neither invoked `useV2Run`.**

This PR adds `useV2Run.seedPersistCallSite.spec.ts`, which mounts the **real hook**, drives a real successful run, and asserts what `persistAnalysisSuccess` actually receives.

**Mutation-checked in an ISOLATED throwaway worktree** — reverting the call site to the pre-fix expression:

| Spec | vs reverted fix |
|---|---|
| **this PR's call-site pin** | **5 failed / 1 passed → BITES** |
| the lane's existing specs | **11 passed → provably vacuous** |

(The 1 passing test pins the real-seed path, identical pre- and post-fix by design.)

## Blast radius — the hash half of this lane's premise was FALSE

The brief claimed *"the fabricated seed POISONS THE GRAPH HASH, and freshness is hash-based ⇒ wrong freshness verdicts + already-persisted poisoned hashes."* **Verified false at `1d6d84cd` by complete reader manifest.** The orchestrator has accepted the refutation and ruled the `seedForHash` split **KEEP + LEDGER**.

- **`analysis_provenance.graph_hash` has ZERO readers.** `hydrateAnalysis` consumes `seed_used`/`response_hash`/`analysed_at`; `useScenario.ts:453-458` consumes `analysed_at`/`seed_used`. **`hydrateThread.ts:148` is a DOCSTRING that claims stale-detection reads this column and is simply WRONG** — the real caller (`useConversation.ts:2148`) passes the **seedless** hash and says so.
- CEE derives `graph_hash_at_run`/`current_graph_hash` **itself**; the UI's column is never an input to freshness.
- The one real comparator (`ReactFlowGraph.tsx:1532/1611`) is **immune by construction**: it recomputes with `run.seed` stored **alongside** `run.graphHash` in the same `StoredRun`, so poisoning corrupts both sides identically and they still match — and a seed can never mask a graph change. **`store.ts:2904` writes it from `results.seed`, which this diff never touches** (`git diff origin/staging...HEAD | grep -E "results\.seed|resultsSuccess"` → empty).

⇒ **Blast radius = zero scenarios.** A fork needs a comparator; there is none.

## 🔻 LEDGERED (orchestrator conditions on the KEEP ruling)

1. **LATENT HASH DIVERGENCE — first reader beware.** The hash **input** changed on two edge paths (malformed echo: `0` → requested seed; numeric-0 echo: requested seed → `0`). Unobservable today **only because nothing reads the column**. **If you add the first reader of `analysis_provenance.graph_hash`, values written before and after this PR were computed under different rules.** Ledgered at the call site in `useV2Run.ts`, where that reader will look.
2. **OPEN QUESTION, deliberately not closed here: if this column has zero readers, why is it written at all?** A write-only column is dead weight *and* a trap. Out of scope (migration-adjacent, and a future reader may want it). The honest end-state is "written truthfully" or "not written"; this PR buys the first cheaply.
3. **🔴 TWO `generateGraphHash` FUNCTIONS, SAME NAME, CONFLATED REPO-WIDE** — `store/runHistory.ts:48` (3-arg, **seed-bearing**) vs `utils/graphHash.ts:19` (2-arg, **seedless**). **This is the direct cause of the false premise above** and it already produced one wrong docstring. Filed as its own row: name-disambiguate them.
4. **LATENT TRAP — `shared_briefs.seed_used INTEGER NOT NULL`.** Two audit lenses called an honest `null` a BLOCKER here; a third refuted it and **I verified the kill myself**: `create_shared_brief` raises `'No brief to share'` first, and `scenarios.brief`'s only writer (`persistBrief`) has **zero product call sites** — the INSERT is dead code. **Wire `persistBrief` and that NOT NULL goes live: relax the column FIRST.**

## Gates

typecheck clean · **30/30** across the 4 T2b suites · schemas resolves **0.15.0** verified in-worktree (the repo-root `node_modules` trap has already voided three agents' baselines) · mutation-check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
