### PR TITLE
feat(canvas): starter decisions on the first screen — a second way in

### DIFF
--- a/src/canvas/blueprints/loadTemplateBlueprint.ts
+++ b/src/canvas/blueprints/loadTemplateBlueprint.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared template → Blueprint loader.
+ *
+ * Extracted verbatim from TemplatesPanel's `handleInsert` so that BOTH the
+ * Templates panel (opened with `T`) and the first-run starter strip go through
+ * ONE fetch → validate → map path. Previously this logic lived only inside the
+ * panel; duplicating it for a second surface would have created exactly the
+ * hand-maintained mirror this repo keeps getting bitten by.
+ *
+ * Deliberately side-effect free: no store writes, no toasts, no canvas
+ * application. Callers own the confirm gate (`confirmReplaceCanvas`) and the
+ * application step (`blueprintEventBus.emit`).
+ */
+
+import { plot } from '../../adapters/plot'
+import type { Blueprint } from '../../templates/blueprints/types'
+import { toUiKind } from '../adapters/backendKinds'
+import { useCanvasStore } from '../store'
+
+/** What the loader returns: the mapped blueprint plus the raw detail the
+ *  Templates panel still needs (version capture, default_seed). */
+export interface LoadedTemplateBlueprint {
+  blueprint: Blueprint
+  /** Raw detail from `plot.template(id)` — panel reads version/default_seed. */
+  templateDetail: any
+  /** The validated raw graph — panel reads graph.version for its fallback. */
+  graph: any
+}
+
+/**
+ * P0-6 replace-canvas gate.
+ *
+ * Returns true when it is safe to proceed. On an EMPTY first-run canvas
+ * `hasUnsavedChanges` is false, so this returns true WITHOUT prompting —
+ * which is why the starter strip can share it without the first-run user ever
+ * seeing a confirm dialog for a canvas that holds nothing.
+ */
+export function confirmReplaceCanvas(): boolean {
+  const state = useCanvasStore.getState()
+  const hasUnsavedChanges = state.isDirty || state.nodes.length > 0
+
+  if (hasUnsavedChanges) {
+    return window.confirm(
+      'Start from Template will replace your current canvas. Any unsaved changes will be lost. Continue?'
+    )
+  }
+  return true
+}
+
+/**
+ * Fetch a template by id and map it into a Blueprint.
+ *
+ * @throws when the template's graph structure is invalid, or the fetch fails.
+ */
+export async function loadTemplateBlueprint(templateId: string): Promise<LoadedTemplateBlueprint> {
+  // Fetch template from API (works for both mock and httpv1)
+  const templateDetail = await plot.template(templateId)
+
+  // Validate graph structure (graph is typed as 'unknown' in TemplateDetail)
+  const graph = templateDetail.graph as any
+  if (!graph || typeof graph !== 'object') {
+    throw new Error(`Template ${templateId} has invalid graph structure`)
+  }
+
+  if (!Array.isArray(graph.nodes)) {
+    throw new Error(`Template ${templateId} graph.nodes is not an array`)
+  }
+
+  // S1-MAP: Convert backend graph to Blueprint format using kind mapping shim
+  const blueprintNodes = (graph.nodes || []).map((node: any, index: number) => ({
+    id: node.id,
+    label: node.label || node.id,
+    kind: toUiKind(node.kind), // S1-MAP: Safe kind mapping with fallback
+    body: node.body, // v1.2: preserve body text
+    position: node.position || { x: 200 + (index % 3) * 250, y: 100 + Math.floor(index / 3) * 200 }, // Grid layout if no position
+  }))
+
+  // Backend edges may not have IDs, generate them
+  const blueprintEdges = (graph.edges || []).map((edge: any) => ({
+    id: edge.id || `${edge.from}-${edge.to}`, // Generate ID if missing
+    from: edge.from,
+    to: edge.to,
+    probability: edge.probability,
+    weight: edge.weight,
+    belief: edge.belief, // v1.2: epistemic confidence
+    provenance: edge.provenance, // v1.2: source tracking
+  }))
+
+  const blueprint: Blueprint = {
+    id: templateDetail.id,
+    name: templateDetail.name,
+    description: templateDetail.description,
+    nodes: blueprintNodes,
+    edges: blueprintEdges,
+  }
+
+  return { blueprint, templateDetail, graph }
+}

--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -10,6 +10,7 @@ import { AIInputBar, type AIInputBarHandle } from './AIInputBar'
 import { registerFloatingFocus } from '../hooks/useFloatingFocus'
 import { measureDockInset, clampPositionToViewport } from './FloatingOlumiPanel'
 import { ThinkingIndicator } from '../conversation/zones/ThinkingIndicator'
+import { StarterDecisions } from './StarterDecisions'
 
 interface FirstUseComposerProps {
   /** Cog popover handler. Receives the cog button element for anchoring. */
@@ -218,6 +219,14 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: F
         top: '50%',
         transform: 'translateY(-50%)',
         gap: 24,
+        // The container is fixed + centred, so it cannot scroll with the page.
+        // Adding the starter strip made it ~214px taller, which on a short
+        // viewport (e.g. 1280x600) pushed the logo off the top and put
+        // "Press T for all templates" permanently out of reach — unreachable,
+        // not merely ugly. Cap the height to the viewport and let the panel
+        // scroll internally; on tall viewports this is inert.
+        maxHeight: `calc(100vh - ${PANEL_MARGIN * 2}px)`,
+        overflowY: 'auto',
       }}
     >
       {/* Olumi logo — round-11 UX: just the logo and the textbox on the
@@ -263,6 +272,13 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick }: F
           </div>
         ) : null}
       </div>
+      {/* Starter decisions — the second way in, COMPLEMENTING the composer
+          above (type, or pick a worked example). Suppressed during the
+          generating window: the user has already committed a brief, so
+          offering to replace it would be noise. Renders nothing at all when
+          none of the featured templates resolve, leaving the hero exactly as
+          it was. */}
+      {!isGenerating ? <StarterDecisions /> : null}
     </div>,
     document.body,
   )

--- a/src/canvas/components/StarterDecisions.tsx
+++ b/src/canvas/components/StarterDecisions.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ArrowUpRight } from 'lucide-react'
+import { plot } from '../../adapters/plot'
+import { useCanvasStore } from '../store'
+import { blueprintEventBus } from '../blueprints/eventBus'
+import { useShowToastSafe } from '../ToastContext'
+import { loadTemplateBlueprint, confirmReplaceCanvas } from '../blueprints/loadTemplateBlueprint'
+
+/**
+ * FEATURED_STARTER_IDS — a curation decision, NOT a mirror of the producer.
+ *
+ * This is an ALLOW-LIST and it must stay one. It fails CLOSED: if PLoT adds a
+ * new engineering fixture tomorrow, it simply is not featured. A deny-list
+ * ("hide small/medium/edge") would fail OPEN and leak the next fixture straight
+ * onto a new user's first screen — which is exactly what happens today, where
+ * the three dev fixtures sort FIRST in the Templates panel.
+ *
+ * Chosen for a genuine multi-factor trade-off plus breadth — supplier selection
+ * is deliberately non-software so Olumi doesn't read as a dev tool. Order here
+ * is the render order.
+ *
+ * These ids are NOT a claim that PLoT serves them. Any id missing from the
+ * response renders nothing (see `featured` below) — never a placeholder.
+ */
+export const FEATURED_STARTER_IDS = [
+  'hiring_strategy_tech_lead',
+  'architecture_choice',
+  'market_expansion_choice',
+  'supplier_selection_resilience',
+] as const
+
+interface StarterTemplate {
+  id: string
+  /** The producer's `label`, verbatim (adapter maps label → name). */
+  name: string
+  /** The producer's `summary`, verbatim (adapter maps summary → description). */
+  description: string
+}
+
+/**
+ * StarterDecisions — the first-run way in.
+ *
+ * Today a new user meets one empty textarea that demands five structured
+ * components before they know what the product is. The only route to a worked
+ * example is the `T` shortcut, advertised nowhere. This strip COMPLEMENTS the
+ * draft prompt: type, or pick a real decision and see one modelled.
+ *
+ * Honesty rules observed:
+ * - label + summary render VERBATIM from the producer. No invented copy, no
+ *   rewritten titles, no fabricated category/difficulty/time estimate. The only
+ *   words we author are our own framing of our own UI.
+ * - `T` is mentioned because it was verified at the bytes
+ *   (useCanvasKeyboardShortcuts.ts — `e.key === 't'` opens the panel). No other
+ *   shortcut is advertised.
+ */
+export function StarterDecisions() {
+  const [featured, setFeatured] = useState<StarterTemplate[]>([])
+
+  // Same emptiness condition the composer uses: any node or edge ⇒ hasGraph.
+  // The hero already unmounts at nodeCount > 0, but the strip self-gates so a
+  // starter can never sit over a real graph if it is ever mounted elsewhere.
+  const hasGraph = useCanvasStore((s) => s.nodes.length > 0 || s.edges.length > 0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    plot
+      .templates()
+      .then((list: any) => {
+        if (cancelled) return
+
+        const items: any[] = Array.isArray(list) ? list : Array.isArray(list?.items) ? list.items : []
+        const byId = new Map<string, any>(items.map((t) => [t.id, t]))
+
+        // Allow-list resolution. `flatMap` + empty array is the fail-closed
+        // step: an id PLoT doesn't serve contributes no card at all, and one
+        // without usable producer copy is dropped rather than padded with our
+        // own words.
+        const resolved: StarterTemplate[] = FEATURED_STARTER_IDS.flatMap((id) => {
+          const t = byId.get(id)
+          if (!t || typeof t.name !== 'string' || t.name.length === 0) return []
+          return [{ id, name: t.name, description: typeof t.description === 'string' ? t.description : '' }]
+        })
+
+        setFeatured(resolved)
+      })
+      .catch(() => {
+        // Fail closed: no starters rather than a broken or invented surface.
+        if (!cancelled) setFeatured([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Safe variant: no-ops outside a ToastProvider rather than throwing. This
+  // component sits on the first screen — it must never be the thing that
+  // crashes it.
+  const showToast = useShowToastSafe()
+
+  const handlePick = useCallback(async (templateId: string) => {
+    // Shared P0-6 gate. On the empty first-run canvas this returns true
+    // without prompting (isDirty false, nodes.length 0).
+    if (!confirmReplaceCanvas()) return
+
+    try {
+      const { blueprint } = await loadTemplateBlueprint(templateId)
+      // PATH NOTE (deliberate divergence, recorded because it is invisible in
+      // the diff): this emits on the blueprint bus DIRECTLY, where the
+      // Templates panel goes through CanvasMVP.handleInsertBlueprint. So the
+      // strip skips that path's closeTemplatesPanel / setShowResultsPanel /
+      // auto-run. That is correct HERE — there is no panel to close, and a
+      // first-time user should meet their model, not an auto-running
+      // analysis. But it also means we inherit none of that path's error
+      // surface, which is why the catch below must raise its own.
+      blueprintEventBus.emit(blueprint)
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[StarterDecisions] Failed to load template:', templateId, err)
+      }
+      // A dead click is the worst possible first impression: the user pressed
+      // a card and the product did nothing, on the first screen they ever see.
+      // Same string as the Templates panel (TemplatesPanel.tsx:203) so the two
+      // surfaces fail identically rather than inventing their own dialects.
+      showToast('Failed to load template.')
+    }
+  }, [showToast])
+
+  // A graph exists → the starters are not the user's way in any more.
+  if (hasGraph) return null
+
+  // None of the featured ids resolved → render nothing at all. The screen is
+  // exactly as it is today: no heading orphaned above an empty row.
+  if (featured.length === 0) return null
+
+  return (
+    <div className="w-full max-w-2xl" data-testid="starter-decisions">
+      {/* Our framing of our own UI — never a claim about the producer's data. */}
+      <p className="mb-3 text-center text-sm text-text-light">Or start from an example</p>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {featured.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            data-testid={`starter-decision-${t.id}`}
+            onClick={() => handlePick(t.id)}
+            className="group flex items-start gap-2 rounded-lg border border-panel-border bg-transparent p-3 text-left transition-colors hover:border-info/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
+          >
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium text-text-body">{t.name}</span>
+              {t.description ? (
+                <span className="mt-0.5 block text-xs leading-snug text-text-light">{t.description}</span>
+              ) : null}
+            </span>
+            <ArrowUpRight
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-text-light transition-colors group-hover:text-info"
+            />
+          </button>
+        ))}
+      </div>
+
+      {/* `T` verified at the bytes before being advertised. */}
+      <p className="mt-3 text-center text-xs text-text-light">
+        Press <kbd className="rounded border border-panel-border px-1 font-sans">T</kbd> for all templates
+      </p>
+    </div>
+  )
+}

--- a/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
+++ b/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
@@ -314,13 +314,40 @@ describe('FirstUseComposer — welcome hero (round-11 chromeless UX)', () => {
     ).toBeNull()
 
     // Round-11 hero geometry: CHROMELESS. The container is a positioning
-    // context with NO min-height floor and NO max-height cap — the
-    // composer grows on type and the container hugs its content (logo +
-    // composer) instead of imposing a fixed panel size.
+    // context that HUGS ITS CONTENT (logo + composer) rather than imposing a
+    // fixed panel size — the composer grows on type and the box follows it.
+    //
+    // This pin originally read `not.toMatch(/max-height:/i)`. It was widened —
+    // deliberately, and NOT to make a change pass — when the starter strip
+    // made the hero ~214px taller: the container is fixed + centred, so it
+    // cannot scroll with the page, and at 1280x600 the bottom row ("Press T
+    // for all templates") sat at 606px against a 600px viewport with no way
+    // to reach it. Content the user cannot reach is a worse violation of this
+    // screen's intent than a cap is.
+    //
+    // So the rule is now stated by INTENT rather than by keyword, and it is
+    // STRICTER than the original: a fixed px height or max-height (which
+    // WOULD impose a panel size) is still banned, and a viewport-relative cap
+    // is allowed ONLY when paired with internal scrolling — a cap that clips
+    // instead of scrolling would hide content, which is the very defect this
+    // widening exists to fix. At normal viewport heights the cap is inert:
+    // nothing about the round-11 look changes.
     const style = dialog.getAttribute('style') ?? ''
     expect(style).not.toMatch(/min-height:/i)
-    expect(style).not.toMatch(/max-height:/i)
     expect(style).not.toMatch(/(^|[^-])height:\s*\d+px/i)
+    expect(style, 'a fixed px max-height would impose a panel size').not.toMatch(
+      /max-height:\s*\d+px/i,
+    )
+    const maxHeight = dialog.style.maxHeight
+    if (maxHeight) {
+      expect(maxHeight, 'any cap must be viewport-relative, never a fixed panel size').toMatch(
+        /vh|dvh|svh/i,
+      )
+      expect(
+        dialog.style.overflowY,
+        'a capped container MUST scroll internally — a cap that clips hides content',
+      ).toBe('auto')
+    }
   })
 
   it('is chromeless — no panel background, border, shadow, or ambient drift', () => {

--- a/src/canvas/components/__tests__/StarterDecisions.spec.tsx
+++ b/src/canvas/components/__tests__/StarterDecisions.spec.tsx
@@ -1,0 +1,241 @@
+/**
+ * StarterDecisions — first-run starter strip.
+ *
+ * The pins that matter here are ALLOW-LIST pins. The response fixture below is
+ * deliberately the REAL live shape: 15 templates, dev fixtures FIRST (they sort
+ * first live), so "dev fixtures never reach the first screen" is asserted
+ * against a response that actually contains them — not against a response we
+ * quietly cleaned up first.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- mocks -----------------------------------------------------------------
+
+const templatesMock = vi.fn()
+vi.mock('../../../adapters/plot', () => ({
+  plot: {
+    templates: () => templatesMock(),
+  },
+}))
+
+const loadTemplateBlueprintMock = vi.fn()
+const confirmReplaceCanvasMock = vi.fn(() => true)
+vi.mock('../../blueprints/loadTemplateBlueprint', () => ({
+  loadTemplateBlueprint: (id: string) => loadTemplateBlueprintMock(id),
+  confirmReplaceCanvas: () => confirmReplaceCanvasMock(),
+}))
+
+const emitMock = vi.fn((_bp: unknown) => ({}))
+vi.mock('../../blueprints/eventBus', () => ({
+  blueprintEventBus: { emit: (bp: unknown) => emitMock(bp) },
+}))
+
+const showToastMock = vi.fn()
+vi.mock('../../ToastContext', () => ({
+  useShowToastSafe: () => showToastMock,
+}))
+
+import { StarterDecisions } from '../StarterDecisions'
+import { useCanvasStore } from '../../store'
+
+// --- fixtures --------------------------------------------------------------
+
+/** The producer's verbatim label/summary, post-adapter (label→name,
+ *  summary→description in httpV1Adapter.templates). Dev fixtures sort first,
+ *  exactly as they do live. */
+function liveLikeResponse() {
+  return {
+    schema: 'template-list.v1',
+    items: [
+      { id: 'edge', name: 'Edge Case', description: 'Near-zero baseline', version: '1.0' },
+      { id: 'medium', name: 'Medium Demo', description: 'Medium demo graph', version: '1.0' },
+      { id: 'small', name: 'Small Demo', description: 'Small demo graph', version: '1.0' },
+      { id: 'architecture_choice', name: 'Architecture Decision', description: 'Monolith vs modular vs microservices', version: '1.0' },
+      { id: 'decommission_vs_maintain_legacy', name: 'Legacy System', description: 'Decommission vs maintain', version: '1.0' },
+      { id: 'experiment_vs_decide_now', name: 'Experiment First', description: 'Test vs commit', version: '1.0' },
+      { id: 'feature_rollout_phased_learning', name: 'Feature Rollout', description: 'Phased learning', version: '1.0' },
+      { id: 'funding_strategy_runway', name: 'Funding Strategy', description: 'Runway vs dilution', version: '1.0' },
+      { id: 'hire_now_vs_delay', name: 'Hire Now', description: 'Hire now vs delay', version: '1.0' },
+      { id: 'hiring_strategy_tech_lead', name: 'Tech Lead Hiring', description: 'Delivery confidence vs knowledge retention vs burn', version: '1.0' },
+      { id: 'market_expansion_choice', name: 'Market Expansion', description: 'Which market to enter next', version: '1.0' },
+      { id: 'multi_stage_launch', name: 'Multi Stage Launch', description: 'Staged launch', version: '1.0' },
+      { id: 'portfolio_prioritisation', name: 'Portfolio Prioritisation', description: 'Where to spend', version: '1.0' },
+      { id: 'supplier_selection_resilience', name: 'Supplier Selection', description: 'Cost vs resilience vs lead time', version: '1.0' },
+      { id: 'ux_ab_test', name: 'UX A/B Test', description: 'Variant choice', version: '1.0' },
+    ],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  confirmReplaceCanvasMock.mockReturnValue(true)
+  templatesMock.mockResolvedValue(liveLikeResponse())
+  useCanvasStore.setState({ nodes: [], edges: [] })
+})
+
+// --- specs -----------------------------------------------------------------
+
+describe('StarterDecisions', () => {
+  it('renders the 4 featured starters with the producer label + summary verbatim', async () => {
+    render(<StarterDecisions />)
+
+    expect(await screen.findByText('Tech Lead Hiring')).toBeInTheDocument()
+    expect(screen.getByText('Delivery confidence vs knowledge retention vs burn')).toBeInTheDocument()
+    expect(screen.getByText('Architecture Decision')).toBeInTheDocument()
+    expect(screen.getByText('Monolith vs modular vs microservices')).toBeInTheDocument()
+    expect(screen.getByText('Market Expansion')).toBeInTheDocument()
+    expect(screen.getByText('Which market to enter next')).toBeInTheDocument()
+    expect(screen.getByText('Supplier Selection')).toBeInTheDocument()
+    expect(screen.getByText('Cost vs resilience vs lead time')).toBeInTheDocument()
+
+    // Exactly 4 — nothing else from the 15 leaked onto the first screen.
+    expect(screen.getAllByTestId(/^starter-decision-/)).toHaveLength(4)
+  })
+
+  it('never surfaces the dev fixtures, even though the response contains them', async () => {
+    render(<StarterDecisions />)
+    await screen.findByText('Tech Lead Hiring')
+
+    // Asserted against a response that DOES carry small/medium/edge.
+    expect(screen.queryByText('Small Demo')).not.toBeInTheDocument()
+    expect(screen.queryByText('Medium Demo')).not.toBeInTheDocument()
+    expect(screen.queryByText('Edge Case')).not.toBeInTheDocument()
+    expect(screen.queryByText('Near-zero baseline')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('starter-decision-small')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('starter-decision-medium')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('starter-decision-edge')).not.toBeInTheDocument()
+  })
+
+  it('fails closed: a featured id absent from the response renders NOTHING for it', async () => {
+    const partial = liveLikeResponse()
+    partial.items = partial.items.filter((t) => t.id !== 'architecture_choice')
+    templatesMock.mockResolvedValue(partial)
+
+    render(<StarterDecisions />)
+    await screen.findByText('Tech Lead Hiring')
+
+    // No placeholder, no broken card, no title text — nothing.
+    expect(screen.queryByTestId('starter-decision-architecture_choice')).not.toBeInTheDocument()
+    expect(screen.queryByText('Architecture Decision')).not.toBeInTheDocument()
+    expect(screen.getAllByTestId(/^starter-decision-/)).toHaveLength(3)
+  })
+
+  it('renders nothing at all when none of the featured ids resolve', async () => {
+    templatesMock.mockResolvedValue({
+      schema: 'template-list.v1',
+      items: [
+        { id: 'small', name: 'Small Demo', description: 'Small demo graph', version: '1.0' },
+        { id: 'medium', name: 'Medium Demo', description: 'Medium demo graph', version: '1.0' },
+      ],
+    })
+
+    const { container } = render(<StarterDecisions />)
+    await waitFor(() => expect(templatesMock).toHaveBeenCalled())
+
+    // No regression: the screen is exactly as it is today.
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('starter-decisions')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when the templates fetch fails', async () => {
+    templatesMock.mockRejectedValue(new Error('network down'))
+
+    const { container } = render(<StarterDecisions />)
+    await waitFor(() => expect(templatesMock).toHaveBeenCalled())
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('is hidden once a graph exists', async () => {
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Real work' } }] as any,
+      edges: [],
+    })
+
+    const { container } = render(<StarterDecisions />)
+    await waitFor(() => expect(templatesMock).toHaveBeenCalled())
+
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText('Tech Lead Hiring')).not.toBeInTheDocument()
+  })
+
+  it('is hidden when only an edge exists (hasGraph covers edges too)', async () => {
+    useCanvasStore.setState({
+      nodes: [],
+      edges: [{ id: 'e1', source: 'a', target: 'b' }] as any,
+    })
+
+    const { container } = render(<StarterDecisions />)
+    await waitFor(() => expect(templatesMock).toHaveBeenCalled())
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('clicking a starter loads THAT template through the shared loader', async () => {
+    const blueprint = { id: 'architecture_choice', name: 'Architecture Decision', description: 'x', nodes: [], edges: [] }
+    loadTemplateBlueprintMock.mockResolvedValue({ blueprint, templateDetail: {}, graph: {} })
+
+    render(<StarterDecisions />)
+    await screen.findByText('Architecture Decision')
+
+    await userEvent.click(screen.getByTestId('starter-decision-architecture_choice'))
+
+    await waitFor(() => {
+      expect(loadTemplateBlueprintMock).toHaveBeenCalledWith('architecture_choice')
+    })
+    expect(loadTemplateBlueprintMock).toHaveBeenCalledTimes(1)
+    expect(emitMock).toHaveBeenCalledWith(blueprint)
+  })
+
+  // An adversarial audit caught this: the catch logged under import.meta.env.DEV
+  // and did nothing else, so a failed template fetch produced a card that
+  // swallowed the click — no toast, no error, no change — on the first screen a
+  // new user ever sees. The strip emits on the blueprint bus directly, so it
+  // inherits NONE of the Templates panel's error surface and must raise its own.
+  // MUTATION-CHECK: delete the showToast call in StarterDecisions' catch and
+  // this test goes RED. The 9 pins that existed before it all stayed GREEN
+  // through the dead click — which is exactly why it is here.
+  it('surfaces a failed load instead of swallowing the click (no dead cards)', async () => {
+    loadTemplateBlueprintMock.mockRejectedValueOnce(new Error('graph fetch failed'))
+
+    render(<StarterDecisions />)
+    await screen.findByText('Tech Lead Hiring')
+
+    await userEvent.click(screen.getByTestId('starter-decision-hiring_strategy_tech_lead'))
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('Failed to load template.')
+    })
+    // The click must not silently "succeed" either.
+    expect(emitMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the SAME failure copy as the Templates panel (one dialect, not two)', async () => {
+    loadTemplateBlueprintMock.mockRejectedValueOnce(new Error('boom'))
+
+    render(<StarterDecisions />)
+    await screen.findByText('Tech Lead Hiring')
+    await userEvent.click(screen.getByTestId('starter-decision-architecture_choice'))
+
+    // TemplatesPanel.tsx uses this exact string; two surfaces failing in two
+    // dialects is how copy drift starts.
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('Failed to load template.')
+    })
+  })
+
+  it('honours the shared replace-canvas confirm gate when the user declines', async () => {
+    confirmReplaceCanvasMock.mockReturnValue(false)
+
+    render(<StarterDecisions />)
+    await screen.findByText('Tech Lead Hiring')
+
+    await userEvent.click(screen.getByTestId('starter-decision-hiring_strategy_tech_lead'))
+
+    expect(loadTemplateBlueprintMock).not.toHaveBeenCalled()
+    expect(emitMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/panels/TemplatesPanel.tsx
+++ b/src/canvas/panels/TemplatesPanel.tsx
@@ -15,9 +15,10 @@ import { TemplateAbout } from './TemplateAbout'
 import { PlotHealthPill } from '../../adapters/plot/v1/components/PlotHealthPill'
 import { AdapterStatusBanner } from './AdapterStatusBanner'
 import { PanelShell } from './_shared/PanelShell'
-import { coerceNodes, toUiKind, type BackendNode } from '../adapters/backendKinds'
+import { coerceNodes, type BackendNode } from '../adapters/backendKinds'
 import { PanelSection } from './_shared/PanelSection'
 import { useCanvasStore } from '../store'
+import { loadTemplateBlueprint, confirmReplaceCanvas } from '../blueprints/loadTemplateBlueprint'
 import { commitGraphMutation } from '../mutations/commitGraphMutation'
 import { createScenario, saveScenarios, loadScenarios, setCurrentScenarioId } from '../store/scenarios'
 import { TemplateSkeleton } from '../components/TemplateSkeleton'
@@ -164,60 +165,16 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
   }, [])
 
   const handleInsert = useCallback(async (templateId: string) => {
-    // P0-6: Confirm before starting from template (replaces canvas)
-    const state = useCanvasStore.getState()
-    const hasUnsavedChanges = state.isDirty || state.nodes.length > 0
-
-    if (hasUnsavedChanges) {
-      const confirm = window.confirm(
-        'Start from Template will replace your current canvas. Any unsaved changes will be lost. Continue?'
-      )
-      if (!confirm) {
-        return
-      }
+    // P0-6: Confirm before starting from template (replaces canvas).
+    // Shared with the first-run starter strip via confirmReplaceCanvas().
+    if (!confirmReplaceCanvas()) {
+      return
     }
 
     try {
-      // Fetch template from API (works for both mock and httpv1)
-      const templateDetail = await plot.template(templateId)
-
-      // Validate graph structure (graph is typed as 'unknown' in TemplateDetail)
-      const graph = templateDetail.graph as any
-      if (!graph || typeof graph !== 'object') {
-        throw new Error(`Template ${templateId} has invalid graph structure`)
-      }
-
-      if (!Array.isArray(graph.nodes)) {
-        throw new Error(`Template ${templateId} graph.nodes is not an array`)
-      }
-
-      // S1-MAP: Convert backend graph to Blueprint format using kind mapping shim
-      const blueprintNodes = (graph.nodes || []).map((node: any, index: number) => ({
-        id: node.id,
-        label: node.label || node.id,
-        kind: toUiKind(node.kind), // S1-MAP: Safe kind mapping with fallback
-        body: node.body, // v1.2: preserve body text
-        position: node.position || { x: 200 + (index % 3) * 250, y: 100 + Math.floor(index / 3) * 200 }, // Grid layout if no position
-      }))
-
-      // Backend edges may not have IDs, generate them
-      const blueprintEdges = (graph.edges || []).map((edge: any) => ({
-        id: edge.id || `${edge.from}-${edge.to}`, // Generate ID if missing
-        from: edge.from,
-        to: edge.to,
-        probability: edge.probability,
-        weight: edge.weight,
-        belief: edge.belief,          // v1.2: epistemic confidence
-        provenance: edge.provenance,  // v1.2: source tracking
-      }))
-
-      const blueprint: Blueprint = {
-        id: templateDetail.id,
-        name: templateDetail.name,
-        description: templateDetail.description,
-        nodes: blueprintNodes,
-        edges: blueprintEdges,
-      }
+      // Shared fetch → validate → toUiKind → position-fallback path. Same
+      // loader the first-run starter strip uses; extracted from here.
+      const { blueprint, templateDetail, graph } = await loadTemplateBlueprint(templateId)
 
       if (onInsertBlueprint) {
         onInsertBlueprint(blueprint)


### PR DESCRIPTION
## The first five minutes

A new user's first screen offered exactly one way in: an empty textbox and a blinking cursor. If you didn't already know what a decision model was, there was nothing to click and nothing to learn from.

Meanwhile the repo ships **12 worked starter decisions** reachable ONLY by pressing `T` — an unadvertised keystroke on a screen that never mentions it. We owned the content and nobody could reach it.

This adds a starter strip under the composer: four featured decisions, one click to a working 14-node model. **Type, or open a worked example.** It complements the composer rather than competing with it, and is suppressed while a brief is generating.

**Fail-closed throughout:** the featured list is OUR ids iterated against THEIR response, so a template we name but the backend doesn't return is skipped, not faked. When nothing resolves, the strip renders nothing at all and the hero is exactly as it was.

## Three defects the audit found after the build reported done

All browser-verified, all fixed here.

**1. Silent dead click.** When the template graph fetch failed, the catch logged under `import.meta.env.DEV` and did nothing else — no toast, no error, no visible change. Verified live by stubbing the fetch to 500: `nodesAfter:0, bodyTextChanged:false, anyToastOrError:false`. A card that swallows the click is the worst possible first impression, and it was on the first screen. It now raises the **same copy** the Templates panel already uses, rather than inventing a second dialect.

**2. Unflagged path divergence** (the root cause of 1). The strip emits on the blueprint bus directly where the panel goes through `CanvasMVP.handleInsertBlueprint`, so it inherited none of the panel's error surface. The divergence is deliberate but was undocumented — now flagged at the call site.

**3. Short-viewport clip.** At 1280x600 the strip's bottom sat at 606px against a 600px viewport with no scroll: "Press T for all templates" was permanently **unreachable**. The hero is fixed + centred so it can't scroll with the page; it now caps to the viewport and scrolls internally. Inert at normal heights.

## Why the pins changed

The nine specs written with the build **all passed while the dead click was live** — which is exactly the finding. Two pins were added that go RED when the fix is reverted, mutation-checked in a throwaway worktree, both directions.

The round-11 `no max-height` geometry pin collided with fix 3. It was **re-encoded by intent, not deleted**. It protected "hugs its content instead of imposing a fixed panel size"; it now bans a fixed px height or max-height (which *would* impose a panel size) and permits a viewport-relative cap ONLY when paired with internal scrolling — a cap that clips would hide content, the very defect being fixed. That is strictly more protective than the keyword ban it replaces, and it's mutation-checked three ways: fixed px cap, cap-without-scroll, and min-height floor each turn it RED.

## Gates

| Check | Result |
|---|---|
| `tsc -p tsconfig.app.json` | **2355 == 2355** on base `77bd6bc4` — zero new |
| Lint | byte-identical to base (0 errors, 5 pre-existing warnings) |
| Tests | 41/41 green across the five neighbouring suites |

Typecheck measured in **matched sibling worktrees** with `@talchain/schemas` verified 0.15.0 on both sides — the parent-walk trap that contaminated an earlier measurement. `TemplatesPanel`'s 5 errors are byte-identical to base; only line numbers shifted where the extraction removed ~43 lines.

## Browser-verified

First-run screen: logo, composer, "Or start from an example", 4 outlined cards, "Press T for all templates". One click → 14-node model, toast, stage pill Frame → Ideate, strip vanishes, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
