### PR TITLE
fix(canvas): confirmed chat edits must dirty the freshness overlay (false 'Analysis reflects the current model')

### DIFF
--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -309,4 +309,44 @@ describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, st
     expect(useCanvasStore.getState().graphEditedSinceLastRun).toBe(true)
     expect(useCanvasStore.getState().analysisStateReady).toBe(false)
   })
+
+  it('marks the freshness overlay dirty on a structural add — the banner must never keep claiming currency', () => {
+    // Reproduced live on staging (2026-07-16): a chat edit confirmed via
+    // "yes" merged a new risk node through THIS path while the analysis
+    // banner kept showing "Analysis reflects the current model" — because the
+    // merge set only the legacy graphEditedSinceLastRun flag, which no
+    // freshness surface reads. The surfaces read the CEE verdict + the
+    // analysisFreshnessDirty overlay, so the merge must mark the overlay like
+    // every other mutation path does (applyDraftResult, edit chokepoints,
+    // commitValidatedMutation).
+    // MUTATION-CHECK: remove the markAnalysisFreshnessDirty call from
+    // mergeAppliedGraphAdditive's commit block and this test goes RED.
+    useCanvasStore.setState({ analysisFreshnessDirty: false } as any)
+
+    mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'risk-new', kind: 'risk', label: 'Key engineer quits' },
+      ],
+      edges: [],
+    } as any)
+
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+  })
+
+  it('does NOT dirty the freshness overlay on a nothing-new receipt (strict no-op stays a no-op)', () => {
+    useCanvasStore.setState({ analysisFreshnessDirty: false } as any)
+
+    const result = mergeAppliedGraphAdditive({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+      ],
+      edges: [],
+    } as any)
+
+    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+  })
 })

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -188,6 +188,16 @@ export function mergeAppliedGraphAdditive(
     analysisStateReady: false,
   })
 
+  // The freshness surfaces (AnalysisFreshnessNotice + useAnalysisDisplayState)
+  // read the CEE verdict + the analysisFreshnessDirty overlay — NOT
+  // graphEditedSinceLastRun above. Without this mark, a confirmed
+  // conversational edit lands nodes on the canvas while the banner keeps
+  // claiming "Analysis reflects the current model" — a false currency claim
+  // sitting next to CEE's own "run the analysis again" (reproduced live on
+  // staging, 2026-07-16). Every other mutation path (applyDraftResult, the
+  // edit chokepoints, commitValidatedMutation) already marks this.
+  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+
   // Warning-only schema validation on the added nodes (mirrors applyDraftResult).
   validateNodesBatch(addedNodes)
 


### PR DESCRIPTION
## The defect, reproduced live

Investigating Paul's manual-test bundle (`4605a72b`): draft a model → run analysis → *"Analysis reflects the current model"* → ask Olumi to add a risk → reply **"yes"** to the held proposal. The node lands on the canvas (11 → 12), CEE itself says *"Run the analysis again when you are ready"* — **and the banner keeps saying "Analysis reflects the current model."** A false currency claim on the trust surface, contradicting the assistant text beside it.

## Root cause

`mergeAppliedGraphAdditive` — the applied-edit receipt path a confirmed conversational edit lands through — sets only the **legacy** staleness flag (`graphEditedSinceLastRun`), which no freshness surface reads any more, and never marks `analysisFreshnessDirty`, the overlay `AnalysisFreshnessNotice` and `useAnalysisDisplayState` actually read. Every other mutation path already marks it (`applyDraftResult`, the edit chokepoints, `commitValidatedMutation`). Two parallel staleness systems; the newest mutation path updated only the dead one — the hand-maintained-mirror drift again.

## The fix

One call in the merge's commit block — **after** the strict-no-op early return, so a nothing-new receipt stays a true no-op. Two pins:

| Pin | Mutation check |
|---|---|
| structural add → overlay dirty | removing the call turns exactly this pin RED (throwaway worktree) |
| nothing-new receipt → overlay untouched | guards against over-marking |

## Cleared suspects (recorded so nobody re-chases them)

During the same live investigation: **edge selection**, **node drag**, and a **plain chat question** all leave the verdict fresh — correctly. The dirty overlay's trigger set is genuinely edit-only; the gap was solely this path.

## Follow-up (product call, not folded in)

The same `fresh+dirty` state renders **two different copies** on two surfaces by design: "Results may be outdated" (`classifyFreshnessForDisplay` → banner) vs "Cannot confirm whether this analysis is current" (`resolveDisplayedFreshness` → notice). One state, two claims. Unifying the copy needs a wording decision — flagged for Paul rather than changed unilaterally.

## Gates

`tsc -p tsconfig.app.json` 2355 == 2355 base (zero new) · lint clean · **1242/1242** tests across the utils + conversation-receipt suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
