### PR TITLE
fix(canvas): analysis gate must not claim availability CEE will refuse (#343 stopgap)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -771,12 +771,22 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     s.graphHealth?.issues?.some((i: { severity: string }) => i.severity === 'error' || i.severity === 'blocker') ?? false
   )
 
+  // #343 honest stopgap: a template-inserted graph exists only client-side
+  // (insertBlueprint stamps data.templateId; no CEE draft path ever does).
+  // On the V5-canonical run path — the SAME condition runCanonicalAnalysis
+  // branches on — the run dispatches to CEE, which has no scenario state for
+  // it and refuses. The gate must say so up front, not claim availability.
+  const hasTemplateProvenance = nodes.some((n) => (n.data as { templateId?: unknown } | undefined)?.templateId != null)
+  const runRoutesThroughCee =
+    isV5CanonicalAnalysisEnabled() &&
+    isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible
   const runGateResult = canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
     hasBlockers: hasValidationBlockers,
     nodeCount: nodes.length,
     isRunning,
+    ceeCannotSeeModel: hasTemplateProvenance && runRoutesThroughCee,
   })
   const canRunAnalysis = runGateResult.allowed
   const runBlockedTooltip = getRunButtonTooltip(runGateResult)

--- a/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
@@ -320,3 +320,34 @@ describe('getRunButtonAriaLabel', () => {
     expect(label).toBe('Run analysis')
   })
 })
+
+describe('canRunAnalysis — #343 honest stopgap (model invisible to CEE)', () => {
+  const base = {
+    graphHealth: null,
+    readiness: null,
+    hasBlockers: false,
+    nodeCount: 5,
+  }
+
+  it('blocks with CEE\'s own refusal sentence when the model cannot be seen by CEE', () => {
+    // Reproduced live (2026-07-16, build f5a22c1e): starter-template model →
+    // panel said "Analysis available — Analyse first pass" → CEE replied
+    // "Draft or save a model first, then run analysis." The panel must never
+    // contradict the engine on a new user's likeliest first click.
+    // MUTATION-CHECK: remove the ceeCannotSeeModel branch and this goes RED.
+    const result = canRunAnalysis({ ...base, ceeCannotSeeModel: true })
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe('Draft or save a model first, then run analysis.')
+  })
+
+  it('does not block when the model is CEE-visible (flag false/omitted)', () => {
+    expect(canRunAnalysis({ ...base, ceeCannotSeeModel: false }).allowed).toBe(true)
+    expect(canRunAnalysis({ ...base }).allowed).toBe(true)
+  })
+
+  it('empty canvas still wins over the CEE-visibility blocker (more fundamental reason first)', () => {
+    const result = canRunAnalysis({ ...base, nodeCount: 0, ceeCannotSeeModel: true })
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe('Add some nodes to get started')
+  })
+})

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -69,6 +69,17 @@ export interface CanRunAnalysisParams {
   nodeCount: number
   /** Whether analysis is currently running */
   isRunning?: boolean
+  /**
+   * True when the canvas model exists ONLY client-side and the run would
+   * route through CEE (the V5-canonical path), which analyses its own
+   * scenario state — not the canvas. Today that is a template-inserted
+   * graph: the insert never touches CEE, so CEE answers "Draft or save a
+   * model first" while this gate used to say "Analysis available" (#343,
+   * reproduced live 2026-07-16). The honest gate blocks with CEE's OWN
+   * sentence so panel and chat speak one dialect instead of contradicting
+   * each other on a new user's likeliest first click.
+   */
+  ceeCannotSeeModel?: boolean
 }
 
 /**
@@ -78,7 +89,7 @@ export interface CanRunAnalysisParams {
  * @returns CanRunAnalysisResult with allowed status and reason
  */
 export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResult {
-  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false } = params
+  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false } = params
 
   const blockingReasons: string[] = []
 
@@ -97,6 +108,16 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
       allowed: false,
       reason: 'Add some nodes to get started',
       blockingReasons: ['No nodes in graph'],
+    }
+  }
+
+  // 2.5 Model invisible to the analysis engine (see CanRunAnalysisParams doc).
+  // The copy is deliberately CEE's own refusal sentence, verbatim.
+  if (ceeCannotSeeModel) {
+    return {
+      allowed: false,
+      reason: 'Draft or save a model first, then run analysis.',
+      blockingReasons: ['Model not in Olumi scenario state (template insert)'],
     }
   }
 


### PR DESCRIPTION
## The contradiction (#343, reproduced live)

Click a starter on the first-run screen → 14-node model → panel footer: **"Analysis available — Analyse first pass."** Click it → CEE: **"Draft or save a model first, then run analysis."** The panel contradicts the engine on a new user's likeliest first click.

Root cause (cross-repo diagnosis, `acceptance-evidence/starter-sync-343`): a template insert only does `setState({nodes,edges})` — no scenario row, no CEE turn — and CEE's `run_analysis` deliberately reads only persisted `scenarios.graph`. The client-computed gate had no notion of CEE visibility.

## The stopgap (ruled to ship first, independent of the sync fix)

- `canRunAnalysis` gains `ceeCannotSeeModel`: blocks with **CEE's own refusal sentence verbatim**, so panel and chat speak one dialect.
- `OutputsDock` computes it as *template provenance* (`data.templateId` — only `insertBlueprint` stamps it; no CEE draft path does) **AND** *the run routes through CEE* (the same canonical-path condition `runCanonicalAnalysis` branches on — a V2-direct run can analyse canvas graphs and stays open).

Footer now reads "Not ready for analysis yet / Draft or save a model first, then run analysis." with the CTA disabled.

The real fix lands separately per the ruling: owned-scenario creation on template insert (UI half, next lane), CEE-side guest handling (held for a doctrine call).

## Evidence

- Pins: exact-sentence block (**mutation-checked**: removing the blocker branch → RED in a throwaway) · CEE-visible stays open · empty canvas wins as the more fundamental reason.
- `tsc` 2355 == 2355 base (zero new) · OutputsDock lint identical to base · **401/401** across canRunAnalysis + OutputsDock.dom + pre-analysis-v3 suites (the 7 initial collection failures were the known missing-worktree-`.env.local` gap — proven environmental by re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
