### PR TITLE
refactor(canvas): one home each for the run-gate predicates + atomic staleness action

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -47,7 +47,7 @@ import {
   trackAutoFixSuccess,
   trackAutoFixFailed,
 } from '../utils/sandboxTelemetry'
-import { isJourneyTabEnabled, isCompareTabEnabled, isAiPanelV2Enabled, isV5CanonicalAnalysisEnabled, isPreAnalysisV3Enabled } from '../../flags'
+import { isJourneyTabEnabled, isCompareTabEnabled, isAiPanelV2Enabled, isPreAnalysisV3Enabled } from '../../flags'
 import { OlumiTabBody } from './OlumiTabBody'
 import { PersistentInputStrip } from './PersistentInputStrip'
 import { SelectionPill } from './SelectionPill'
@@ -57,7 +57,7 @@ import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
 import { dockHostsOlumi } from './olumiSurface'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { focusFloating } from '../hooks/useFloatingFocus'
-import { isV5Eligible } from '../../v5/eligibility'
+import { isV5CanonicalRunPath } from '../../v5/eligibility'
 import { countFactorsToVerify, deriveFactorInfluenceMap } from './model-tab/utils'
 import { getGoalDirection } from '../utils/getObjectiveText'
 import { deriveVerdict } from '../utils/interpretOutcome'
@@ -72,7 +72,7 @@ import {
 // Lazy: flag-off users never pay the v3 bundle cost.
 const PreAnalysisPanelV3 = lazy(() => import('./pre-analysis-v3'))
 import { useConversation } from '../conversation/useConversation'
-import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip } from '../utils/canRunAnalysis'
+import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip, computeCeeCannotSeeModel } from '../utils/canRunAnalysis'
 import { WarningBanner } from './WarningBanner'
 import { DegradedStateBanner } from './DegradedStateBanner'
 import { mapConfidenceToReadiness } from '../utils/mapConfidenceToReadiness'
@@ -771,22 +771,13 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     s.graphHealth?.issues?.some((i: { severity: string }) => i.severity === 'error' || i.severity === 'blocker') ?? false
   )
 
-  // #343 honest stopgap: a template-inserted graph exists only client-side
-  // (insertBlueprint stamps data.templateId; no CEE draft path ever does).
-  // On the V5-canonical run path — the SAME condition runCanonicalAnalysis
-  // branches on — the run dispatches to CEE, which has no scenario state for
-  // it and refuses. The gate must say so up front, not claim availability.
-  const hasTemplateProvenance = nodes.some((n) => (n.data as { templateId?: unknown } | undefined)?.templateId != null)
-  const runRoutesThroughCee =
-    isV5CanonicalAnalysisEnabled() &&
-    isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible
   const runGateResult = canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
     hasBlockers: hasValidationBlockers,
     nodeCount: nodes.length,
     isRunning,
-    ceeCannotSeeModel: hasTemplateProvenance && runRoutesThroughCee,
+    ceeCannotSeeModel: computeCeeCannotSeeModel(nodes),
   })
   const canRunAnalysis = runGateResult.allowed
   const runBlockedTooltip = getRunButtonTooltip(runGateResult)
@@ -843,8 +834,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
 
     // Canonical V5 chip-action path. Mirrors what suggested chips do for
     // action_type:'run_analysis' — same chip metadata, same dispatcher.
-    const canonical = isV5CanonicalAnalysisEnabled() &&
-      isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible
+    const canonical = isV5CanonicalRunPath()
     if (canonical) {
       const dispatch = useGuidanceStore.getState()._dispatchAction
       if (dispatch) {

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -63,9 +63,21 @@ vi.mock('../../../flags', async (importOriginal) => {
   }
 })
 
-vi.mock('../../../v5/eligibility', () => ({
-  isV5Eligible: mockIsV5Eligible,
-}))
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  // Spread the real module (repo rule: a hand-listed factory silently drops
+  // every export added later — this exact mock shipped that failure once).
+  // isV5CanonicalRunPath re-derives from THIS file's mocked flags + stub so
+  // tests that toggle either mock drive the canonical path like production.
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: mockIsV5Eligible,
+    isV5CanonicalRunPath: () =>
+      flags.isV5CanonicalAnalysisEnabled() &&
+      mockIsV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible,
+  }
+})
 
 vi.mock('../../hooks/useV2Run', async (importOriginal) => {
   // Spread the real module: OutputsDock also imports the pure goal-threshold

--- a/src/canvas/components/__tests__/OutputsDock.rerunContinuity.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.rerunContinuity.spec.tsx
@@ -67,7 +67,17 @@ vi.mock('../../../flags', async (importOriginal) => {
   }
 })
 
-vi.mock('../../../v5/eligibility', () => ({ isV5Eligible: mockIsV5Eligible }))
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: mockIsV5Eligible,
+    isV5CanonicalRunPath: () =>
+      flags.isV5CanonicalAnalysisEnabled() &&
+      mockIsV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible,
+  }
+})
 
 vi.mock('../../hooks/useV2Run', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../hooks/useV2Run')>()

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -26,11 +26,10 @@ import { prefillInto } from './prefillTarget'
 import type { BriefReadiness } from './hooks/useBriefSignals'
 import { useThreadPersistence } from './hooks/useThreadPersistence'
 import { beginInteractionChain, getUiSurfaceState, recordCrossSurfaceEvent, recordInteractionEvent, recordUserAction, type InteractionStateSnapshot } from '../../lib/debug-state'
-import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip } from '../utils/canRunAnalysis'
+import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip, computeCeeCannotSeeModel } from '../utils/canRunAnalysis'
 import { useV2Run } from '../hooks/useV2Run'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
-import { isV5CanonicalAnalysisEnabled } from '../../flags'
-import { isV5Eligible } from '../../v5/eligibility'
+import { isV5CanonicalRunPath } from '../../v5/eligibility'
 
 interface ConversationPanelProps {
   conversation: UseConversationReturn
@@ -425,13 +424,18 @@ export const ConversationPanel = memo(function ConversationPanel({
   })
   const isAnalysisRunning = resultsStatus === 'preparing' || resultsStatus === 'connecting' || resultsStatus === 'streaming'
 
+  // Boolean selector: recomputes on store writes but only re-renders on a
+  // flip. Same honest gate as OutputsDock — without it this surface's run
+  // button re-created the exact panel-vs-engine contradiction #343 fixed.
+  const ceeCannotSeeModel = useCanvasStore((s) => computeCeeCannotSeeModel(s.nodes))
   const runGateResult = useMemo(() => canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
     hasBlockers,
     nodeCount,
     isRunning: isAnalysisRunning,
-  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning])
+    ceeCannotSeeModel,
+  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, ceeCannotSeeModel])
 
   // In-flight takes priority over structural reasons: the composer button
   // is disabled for either cause, but the user-visible tooltip should explain
@@ -468,10 +472,7 @@ export const ConversationPanel = memo(function ConversationPanel({
     // are on, route through the existing chip-action dispatch so CEE
     // persists a run_analysis fact. Mirrors OutputsDock.handleRunAnalysis.
     // Same exact payload shape as suggested chips — never free-text.
-    if (
-      isV5CanonicalAnalysisEnabled() &&
-      isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible
-    ) {
+    if (isV5CanonicalRunPath()) {
       void dispatchAction({
         action_type: 'run_analysis',
         label: 'Run analysis',

--- a/src/canvas/conversation/__tests__/aiPanelTranche1Hotfix.spec.tsx
+++ b/src/canvas/conversation/__tests__/aiPanelTranche1Hotfix.spec.tsx
@@ -64,6 +64,10 @@ vi.mock('../zones/CoachingTip', () => ({
 
 vi.mock('../../../flags', () => ({
   isBilPreviewEnabled: () => false,
+  // The run gate reaches this via computeCeeCannotSeeModel → isV5CanonicalRunPath;
+  // false = canonical dispatch off, preserving this suite's pre-gate behaviour.
+  // (Hand-listed factory debt: vitest fails loud on any OTHER missing export.)
+  isV5CanonicalAnalysisEnabled: () => false,
 }))
 vi.mock('../../brief-intelligence/extract', () => ({
   extractLocalBIL: () => null,

--- a/src/canvas/conversation/__tests__/generateModelIntegration.spec.tsx
+++ b/src/canvas/conversation/__tests__/generateModelIntegration.spec.tsx
@@ -98,6 +98,10 @@ vi.mock('../zones/CoachingTip', () => ({
 
 vi.mock('../../../flags', () => ({
   isBilPreviewEnabled: () => false,
+  // The run gate reaches this via computeCeeCannotSeeModel → isV5CanonicalRunPath;
+  // false = canonical dispatch off, preserving this suite's pre-gate behaviour.
+  // (Hand-listed factory debt: vitest fails loud on any OTHER missing export.)
+  isV5CanonicalAnalysisEnabled: () => false,
   isOrchestratorV2Enabled: () => true,
   isOrchestratorStreamingEnabled: () => false,
 }))

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -78,9 +78,17 @@ vi.mock('../../../v5/v5Adapter', () => ({
 // unaffected; the V5-only blocks below flip it on for their scope.
 const mockIsV5Eligible = vi.fn<[{ flag: string | undefined }], { eligible: boolean; reason?: string }>()
 
-vi.mock('../../../v5/eligibility', () => ({
-  isV5Eligible: (...args: unknown[]) => mockIsV5Eligible(...(args as [{ flag: string | undefined }])),
-}))
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: (...args: unknown[]) => mockIsV5Eligible(...(args as [{ flag: string | undefined }])),
+    isV5CanonicalRunPath: () =>
+      flags.isV5CanonicalAnalysisEnabled() &&
+      mockIsV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible,
+  }
+})
 
 // 1.16i: telemetry sink for the run-click swallow guard.
 const mockTrackEvent = vi.fn()

--- a/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.reasoning.spec.ts
@@ -65,9 +65,15 @@ vi.mock('../../../v5/v5Adapter', () => ({
 // on a clean checkout where the flag is undefined and sendMessage takes the
 // V4 path instead, so mockCallV5Turn is never invoked). Mocking the gate
 // itself makes the suite self-contained.
-vi.mock('../../../v5/eligibility', () => ({
-  isV5Eligible: () => ({ eligible: true as const }),
-}))
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true as const }),
+    isV5CanonicalRunPath: () => flags.isV5CanonicalAnalysisEnabled(),
+  }
+})
 
 const mockGetUserId = vi.fn<[], Promise<string | null>>()
 vi.mock('../../../lib/supabase', () => ({

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -712,6 +712,8 @@ interface CanvasState {
   setAnalysisFreshness: (rawAnalysisReady: unknown) => void
   /** Public dirty-overlay setter for external graph mutators (e.g. accepted CEE graph patches) that bypass the internal edit chokepoints. */
   markAnalysisFreshnessDirty: () => void
+  /** Atomically set all three staleness flags — the entry point for external structural mutators. */
+  markGraphStructurallyEdited: () => void
   /** Clear the dirty overlay when a genuinely new analysis run completes (reliable run identity, e.g. a new analysis_result response_hash). */
   clearAnalysisFreshnessDirty: () => void
   setDraftCoaching: (coaching: CEEDraftCoaching | null) => void
@@ -3764,6 +3766,17 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   // context-menu commit path, and the draft producers. Delegates to the module
   // helper so the idempotent set lives in one place (no drift between the two).
   markAnalysisFreshnessDirty: () => markAnalysisFreshnessDirty(get, set),
+  // The 3-flag staleness invariant for EXTERNAL structural mutators, set
+  // atomically. Two staleness systems exist with disjoint readers: the legacy
+  // pair (graphEditedSinceLastRun/analysisStateReady) and the freshness
+  // overlay the banners actually read (analysisFreshnessDirty). A mutation
+  // path that sets one and misses the other ships a false "analysis reflects
+  // the current model" — that exact miss shipped once (#344). New external
+  // mutators call THIS, not the flags piecemeal.
+  markGraphStructurallyEdited: () => {
+    set(() => ({ graphEditedSinceLastRun: true, analysisStateReady: false }))
+    markAnalysisFreshnessDirty(get, set)
+  },
   clearAnalysisFreshnessDirty: () => {
     if (get().analysisFreshnessDirty) set(() => ({ analysisFreshnessDirty: false }))
   },

--- a/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
@@ -2,13 +2,22 @@
  * canRunAnalysis Utility Tests
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
   canRunAnalysis,
   getRunButtonTooltip,
   getRunButtonAriaLabel,
+  computeCeeCannotSeeModel,
+  CEE_DRAFT_FIRST_REFUSAL,
   type CanRunAnalysisParams,
 } from '../canRunAnalysis'
+
+
+const isV5CanonicalRunPathMock = vi.fn(() => true)
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return { ...actual, isV5CanonicalRunPath: () => isV5CanonicalRunPathMock() }
+})
 
 describe('canRunAnalysis', () => {
   const defaultParams: CanRunAnalysisParams = {
@@ -330,11 +339,9 @@ describe('canRunAnalysis — #343 honest stopgap (model invisible to CEE)', () =
   }
 
   it('blocks with CEE\'s own refusal sentence when the model cannot be seen by CEE', () => {
-    // Reproduced live (2026-07-16, build f5a22c1e): starter-template model →
-    // panel said "Analysis available — Analyse first pass" → CEE replied
-    // "Draft or save a model first, then run analysis." The panel must never
-    // contradict the engine on a new user's likeliest first click.
-    // MUTATION-CHECK: remove the ceeCannotSeeModel branch and this goes RED.
+    // The reason string must be CEE's own refusal sentence so panel and chat
+    // agree (#343). Deliberately the raw literal, NOT the exported constant:
+    // this pin is what catches the constant drifting from CEE's actual copy.
     const result = canRunAnalysis({ ...base, ceeCannotSeeModel: true })
     expect(result.allowed).toBe(false)
     expect(result.reason).toBe('Draft or save a model first, then run analysis.')
@@ -349,5 +356,27 @@ describe('canRunAnalysis — #343 honest stopgap (model invisible to CEE)', () =
     const result = canRunAnalysis({ ...base, nodeCount: 0, ceeCannotSeeModel: true })
     expect(result.allowed).toBe(false)
     expect(result.reason).toBe('Add some nodes to get started')
+  })
+})
+
+describe('computeCeeCannotSeeModel — the ONE home for the honest-gate predicate', () => {
+  const templateNodes = [{ data: { templateId: 'hiring-v1' } }, { data: {} }]
+  const draftedNodes = [{ data: {} }, { data: { label: 'x' } }]
+
+  it('true only for template provenance on the CEE-routed path', () => {
+    isV5CanonicalRunPathMock.mockReturnValue(true)
+    expect(computeCeeCannotSeeModel(templateNodes)).toBe(true)
+    expect(computeCeeCannotSeeModel(draftedNodes)).toBe(false)
+  })
+
+  it('false off the canonical path — a V2-direct run CAN analyse canvas graphs', () => {
+    isV5CanonicalRunPathMock.mockReturnValue(false)
+    expect(computeCeeCannotSeeModel(templateNodes)).toBe(false)
+  })
+
+  it('the exported refusal constant IS the sentence the gate emits (one home, no drift)', () => {
+    isV5CanonicalRunPathMock.mockReturnValue(true)
+    const result = canRunAnalysis({ graphHealth: null, readiness: null, hasBlockers: false, nodeCount: 5, ceeCannotSeeModel: computeCeeCannotSeeModel(templateNodes) })
+    expect(result.reason).toBe(CEE_DRAFT_FIRST_REFUSAL)
   })
 })

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -311,16 +311,8 @@ describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, st
   })
 
   it('marks the freshness overlay dirty on a structural add — the banner must never keep claiming currency', () => {
-    // Reproduced live on staging (2026-07-16): a chat edit confirmed via
-    // "yes" merged a new risk node through THIS path while the analysis
-    // banner kept showing "Analysis reflects the current model" — because the
-    // merge set only the legacy graphEditedSinceLastRun flag, which no
-    // freshness surface reads. The surfaces read the CEE verdict + the
-    // analysisFreshnessDirty overlay, so the merge must mark the overlay like
-    // every other mutation path does (applyDraftResult, edit chokepoints,
-    // commitValidatedMutation).
-    // MUTATION-CHECK: remove the markAnalysisFreshnessDirty call from
-    // mergeAppliedGraphAdditive's commit block and this test goes RED.
+    // The freshness banners read analysisFreshnessDirty, not the legacy
+    // graphEditedSinceLastRun flag — see mergeAppliedGraphAdditive's commit block.
     useCanvasStore.setState({ analysisFreshnessDirty: false } as any)
 
     mergeAppliedGraphAdditive({

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -37,6 +37,29 @@
  */
 
 import type { GraphReadiness } from '../hooks/useGraphReadiness'
+import { isV5CanonicalRunPath } from '../../v5/eligibility'
+
+/**
+ * CEE's refusal sentence, verbatim — the gate must show the engine's own
+ * words so panel and chat never contradict each other. If CEE rewords its
+ * refusal, this constant (and the spec pinning the raw literal) must follow.
+ */
+export const CEE_DRAFT_FIRST_REFUSAL = 'Draft or save a model first, then run analysis.'
+
+/**
+ * True when the canvas model is invisible to the analysis engine: the graph
+ * carries template provenance (only insertBlueprint stamps data.templateId;
+ * no CEE draft path does) AND the run would route through CEE, which analyses
+ * its own scenario state — not the canvas (#343). A V2-direct run can analyse
+ * canvas graphs, so the gate stays open off the canonical path.
+ * ONE home for the predicate: both gate callers (OutputsDock,
+ * ConversationPanel) consume this instead of re-deriving it.
+ */
+export function computeCeeCannotSeeModel(
+  nodes: ReadonlyArray<{ data?: Record<string, unknown> | undefined }>,
+): boolean {
+  return isV5CanonicalRunPath() && nodes.some((n) => n.data?.templateId != null)
+}
 
 export interface CanRunAnalysisResult {
   /** Whether analysis can be run */
@@ -69,16 +92,8 @@ export interface CanRunAnalysisParams {
   nodeCount: number
   /** Whether analysis is currently running */
   isRunning?: boolean
-  /**
-   * True when the canvas model exists ONLY client-side and the run would
-   * route through CEE (the V5-canonical path), which analyses its own
-   * scenario state — not the canvas. Today that is a template-inserted
-   * graph: the insert never touches CEE, so CEE answers "Draft or save a
-   * model first" while this gate used to say "Analysis available" (#343,
-   * reproduced live 2026-07-16). The honest gate blocks with CEE's OWN
-   * sentence so panel and chat speak one dialect instead of contradicting
-   * each other on a new user's likeliest first click.
-   */
+  /** See computeCeeCannotSeeModel — the model exists only client-side and
+   *  the run routes through CEE, so the engine would refuse it (#343). */
   ceeCannotSeeModel?: boolean
 }
 
@@ -111,12 +126,11 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
     }
   }
 
-  // 2.5 Model invisible to the analysis engine (see CanRunAnalysisParams doc).
-  // The copy is deliberately CEE's own refusal sentence, verbatim.
+  // 2.5 Model invisible to the analysis engine (see computeCeeCannotSeeModel).
   if (ceeCannotSeeModel) {
     return {
       allowed: false,
-      reason: 'Draft or save a model first, then run analysis.',
+      reason: CEE_DRAFT_FIRST_REFUSAL,
       blockingReasons: ['Model not in Olumi scenario state (template insert)'],
     }
   }

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -180,23 +180,14 @@ export function mergeAppliedGraphAdditive(
   useCanvasStore.setState({
     nodes: [...canvas.nodes, ...addedNodes],
     edges: [...canvas.edges, ...addedEdges],
-    // Set the staleness flags EXPLICITLY: pushToHistory sets them too, but
-    // early-returns without flipping either when the pre-merge state equals
-    // the last history snapshot (dedupe guard, store.ts) — and a structural
-    // add always makes the last analysis snapshot stale.
-    graphEditedSinceLastRun: true,
-    analysisStateReady: false,
   })
 
-  // The freshness surfaces (AnalysisFreshnessNotice + useAnalysisDisplayState)
-  // read the CEE verdict + the analysisFreshnessDirty overlay — NOT
-  // graphEditedSinceLastRun above. Without this mark, a confirmed
-  // conversational edit lands nodes on the canvas while the banner keeps
-  // claiming "Analysis reflects the current model" — a false currency claim
-  // sitting next to CEE's own "run the analysis again" (reproduced live on
-  // staging, 2026-07-16). Every other mutation path (applyDraftResult, the
-  // edit chokepoints, commitValidatedMutation) already marks this.
-  useCanvasStore.getState().markAnalysisFreshnessDirty?.()
+  // Staleness flags set EXPLICITLY (not via pushToHistory, which early-returns
+  // without flipping them when the pre-merge state equals the last snapshot),
+  // and ATOMICALLY: the freshness banners read the analysisFreshnessDirty
+  // overlay, not the legacy pair, and every other mutation path already marks
+  // all three (applyDraftResult, the edit chokepoints, commitValidatedMutation).
+  useCanvasStore.getState().markGraphStructurallyEdited?.()
 
   // Warning-only schema validation on the added nodes (mirrors applyDraftResult).
   validateNodesBatch(addedNodes)

--- a/src/v5/eligibility.ts
+++ b/src/v5/eligibility.ts
@@ -13,6 +13,8 @@
  * Rollback is a flag flip plus redeploy.
  */
 
+import { isV5CanonicalAnalysisEnabled } from '../flags'
+
 export interface V5EligibilityInput {
   /** VITE_ENABLE_V5_ORCHESTRATOR raw string value. Exact match on 'true'. */
   flag: string | undefined
@@ -29,4 +31,18 @@ export function isV5Eligible(input: V5EligibilityInput): V5EligibilityResult {
     return { eligible: false, reason: 'flag_off' }
   }
   return { eligible: true }
+}
+
+/**
+ * The V5-canonical run path: run affordances dispatch a run_analysis chip to
+ * CEE instead of running V2 PLoT-direct. ONE home for the compound condition
+ * — it previously existed as three hand-maintained copies (OutputsDock x2,
+ * ConversationPanel), and the analysis gate's honesty depends on checking the
+ * SAME condition the runner branches on.
+ */
+export function isV5CanonicalRunPath(): boolean {
+  return (
+    isV5CanonicalAnalysisEnabled() &&
+    isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible
+  )
 }


### PR DESCRIPTION
## /simplify pass over the #344/#345 lanes

Four cleanup angles (reuse / simplification / efficiency / altitude) reviewed `592c30a0^..c6c9c89a`. Efficiency came back clean (everything matched local convention). Three mechanism findings and a comment-discipline sweep survived, all applied:

**1. One home for the V5-canonical-path condition.** `isV5CanonicalAnalysisEnabled() && isV5Eligible(...)` existed as three hand-maintained copies (OutputsDock ×2, ConversationPanel) — and the #345 gate's honesty depends on checking *the same condition the runner branches on*. Now `isV5CanonicalRunPath()` in `v5/eligibility.ts`, consumed at all three sites.

**2. One home for the honest-gate predicate — closing the second door.** The predicate was computed inside one of the util's two callers; **ConversationPanel called the same gate without it and dispatches its own `run_analysis` chip to CEE**, so the chat composer's run button still claimed availability on template models — the exact contradiction #345 fixed, on the untouched surface. Now `computeCeeCannotSeeModel(nodes)` exported from `canRunAnalysis.ts` and passed by both callers. This is a deliberate coverage extension of the ruled stopgap (same intended behaviour, second surface), not a behaviour change. Registry-routed affordances (⌘Enter, palette, freshness strip) already inherited the gate.

**3. Atomic staleness action.** `mergeAppliedGraph` hand-set three staleness flags in sequence — the shape of the exact miss #344 fixed. New store action `markGraphStructurallyEdited()` owns the 3-flag invariant (with the two-reader-populations rationale on it); future external mutators get one documented entry point.

**Also:** CEE's refusal sentence → exported `CEE_DRAFT_FIRST_REFUSAL` (the spec deliberately keeps the raw literal, so the constant can't drift from CEE's copy unnoticed); provenance/date narration trimmed from comments, load-bearing constraints kept in exactly one place each; three new unit pins on the shared predicate.

**Skipped (with reasons):** module-scope memoization of the flag pair (breaks localStorage-override semantics; matches local convention as-is) · shared test-fixture helper (inline is the file's established style at this scale) · promoting template provenance to store state (rejected while the stopgap ruling stands) · migrating the six other `markAnalysisFreshnessDirty?.()` call sites (follow-up scale).

## Gates

tsc error multisets **identical** to base (2355 == 2355 — the one textual delta is a pre-existing tolerated `V5ApplicatorStore` error whose printed member count shifted `238→239` from the added store member; verified same error both sides). Lint identical to base. **948/948** across 61 files including OutputsDock.dom, patchAcceptLogic (ConversationPanel), pre-analysis-v3 and v5 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
