### PR TITLE
fix(canvas): metric pills speak plain words — 'Influence 38%', not 'I: 38%'

### DIFF
--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -720,7 +720,7 @@ describe('FactorNode', () => {
       voiRank: null,
     })
     renderFactor({ label: 'Technical Leadership Capability', type: 'factor', observedState: { value: 0.5 } })
-    const pill = screen.getByText('I: 100%')
+    const pill = screen.getByText('Influence 100%')
     expect(pill.getAttribute('title')).toBe(
       'Influence: how much this factor affects the outcome, relative to the strongest. The top driver always shows 100%.'
     )

--- a/src/canvas/nodes/shared/MetricPills.tsx
+++ b/src/canvas/nodes/shared/MetricPills.tsx
@@ -1,6 +1,8 @@
 /**
  * MetricPills — compact row of small outlined pills at the bottom of Standard view nodes.
- * Three pill types: Influence (I:%), Confidence (C:%), and optional bias icon.
+ * Three pill types: Influence, Confidence (plain words, not I:/C: — the
+ * first-five-minutes review found the abbreviations unreadable at first
+ * contact; the tooltip/aria still carry the full provenance), and bias icon.
  * Font 10px (edgeLabel). Pill padding 1px 5px. Border-radius 10px. Gap 3px.
  *
  * Lane C4 (influence-scale disclosure): the influence number comes from the
@@ -58,12 +60,12 @@ export function MetricPills({ influencePct, influenceProvenance, confidencePct, 
           role="img"
           aria-label={influenceAria}
         >
-          I: {influencePct}%
+          Influence {influencePct}%
         </span>
       )}
       {hasConfidence && (
         <span className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-factor/60 text-text-body">
-          C: {confidencePct}%
+          Confidence {confidencePct}%
         </span>
       )}
       {hasBias && (

--- a/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/MetricPills.spec.tsx
@@ -36,7 +36,7 @@ describe('MetricPills — influence-scale disclosure (lane C4)', () => {
     const pill = screen.getByRole('img', {
       name: 'Influence 100%, relative to the strongest factor. The top driver always shows 100%',
     })
-    expect(pill.textContent).toBe('I: 100%')
+    expect(pill.textContent).toBe('Influence 100%')
     expect(pill.getAttribute('title')).toBe(RELATIVE_TITLE)
   })
 
@@ -45,7 +45,7 @@ describe('MetricPills — influence-scale disclosure (lane C4)', () => {
     const pill = screen.getByRole('img', {
       name: 'Influence 62%, an absolute causal influence score from the analysis',
     })
-    expect(pill.textContent).toBe('I: 62%')
+    expect(pill.textContent).toBe('Influence 62%')
     expect(pill.getAttribute('title')).toBe(ABSOLUTE_TITLE)
     expect(pill.getAttribute('title')).not.toContain('always shows 100%')
   })
@@ -53,7 +53,7 @@ describe('MetricPills — influence-scale disclosure (lane C4)', () => {
   it('no provenance (fail-closed): generic honest label, no basis claim', () => {
     render(<MetricPills influencePct={80} />)
     const pill = screen.getByRole('img', { name: 'Influence 80%' })
-    expect(pill.textContent).toBe('I: 80%')
+    expect(pill.textContent).toBe('Influence 80%')
     expect(pill.getAttribute('title')).toBe(GENERIC_TITLE)
   })
 
@@ -64,7 +64,7 @@ describe('MetricPills — influence-scale disclosure (lane C4)', () => {
 
   it('unchanged behaviour: confidence pill renders without an influence disclosure', () => {
     render(<MetricPills confidencePct={45} />)
-    expect(screen.getByText('C: 45%')).toBeDefined()
+    expect(screen.getByText('Confidence 45%')).toBeDefined()
     expect(screen.queryByText(/^I: /)).toBeNull()
   })
 })


### PR DESCRIPTION
Graph finding G4 from the DS review: the node pills' abbreviations are unreadable at first contact. Visible labels now say the word; tooltips/provenance/aria unchanged; spec pins updated.

**Scope note — two findings deliberately NOT implemented after byte-checks:** the needs-input amber border (G1) turned out to be **ratified wireframe-v4 law** (dashed = outside your control; amber = needs your judgement — pinned in FactorNode.spec), and the edge labels (G2) are **three owned signals, not one drifting grammar**. Both DS-doc sections in #348 were corrected to codify reality, with the amber/risk ΔE adjacency recorded as an open question for Paul rather than silently re-ruled.

Gates: 108/108 · tsc 2321 == base · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)