### PR TITLE
feat(ui): the DS bricks — Button, Pill, Skeleton + Modal promotion + one toast system

### DIFF
--- a/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
@@ -9,6 +9,7 @@
  */
 
 import { memo } from 'react'
+import { Button } from '../../../../components/ui'
 import { typography, typo } from '../../../../styles/typography'
 import { FOOTER_COPY } from '../constants'
 import { guardCeeText } from '../signals/ceeTextGuard'
@@ -73,19 +74,16 @@ export const PanelFooter = memo(function PanelFooter({
         <p className={typo('panelBody', 'text-text-header')}>{display.headline}</p>
         <p className={`${typography.panelMeta} text-text-light`}>{display.subline}</p>
       </div>
-      <button
-        type="button"
+      <Button
+        size="sm"
+        className="flex-none"
         onClick={onAnalyse}
         disabled={disabled}
         title={!isAnalysing && !canRun ? safeBlockedReason || FOOTER_COPY.notReadySubFallback : undefined}
-        className={typo(
-          'buttonSmall',
-          'flex-none whitespace-nowrap rounded-full bg-primary px-4 py-2 text-text-on-color transition-colors hover:bg-primary-hover focus-visible:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/40 disabled:cursor-not-allowed disabled:opacity-40',
-        )}
         data-testid="pre-analysis-v3-analyse"
       >
         {isAnalysing ? 'Analysing…' : FOOTER_COPY.analyse}
-      </button>
+      </Button>
     </div>
   )
 })

--- a/src/canvas/panels/TemplatesPanel.tsx
+++ b/src/canvas/panels/TemplatesPanel.tsx
@@ -16,6 +16,7 @@ import { PlotHealthPill } from '../../adapters/plot/v1/components/PlotHealthPill
 import { AdapterStatusBanner } from './AdapterStatusBanner'
 import { PanelShell } from './_shared/PanelShell'
 import { coerceNodes, type BackendNode } from '../adapters/backendKinds'
+import { useShowToastSafe } from '../ToastContext'
 import { PanelSection } from './_shared/PanelSection'
 import { useCanvasStore } from '../store'
 import { loadTemplateBlueprint, confirmReplaceCanvas, fetchTemplateList, TEMPLATE_LOAD_FAILED_MESSAGE } from '../blueprints/loadTemplateBlueprint'
@@ -43,7 +44,7 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
   const [templateVersion, setTemplateVersion] = useState<string | undefined>(undefined)
   const [showDevControls, setShowDevControls] = useState(false)
   const [seed, setSeed] = useState<string>('1337')
-  const [toastMessage, setToastMessage] = useState<string | null>(null)
+
   const panelRef = useRef<HTMLDivElement>(null)
 
   const { loading, progress, canCancel, result, error, run, cancel, clearError } = useTemplatesRun()
@@ -109,10 +110,11 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
   }, [isOpen])
 
   // Toast notification helper (must be declared before handleInsert/handleMerge)
-  const showToast = useCallback((msg: string) => {
-    setToastMessage(msg)
-    setTimeout(() => setToastMessage(null), 3000)
-  }, [])
+  // One toast system (DS: Canonical State Copy / severity owns persistence).
+  // This panel ran its own 3s-fixed local toast for years — the second
+  // dialect the ToastContext consolidation retires. Safe variant: no-ops
+  // if a mount ever lacks the provider rather than crashing the panel.
+  const showToast = useShowToastSafe()
 
   // Retry loading templates after failure
   const retryLoadTemplates = useCallback(() => {
@@ -172,7 +174,7 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
       if (import.meta.env.DEV) {
         console.error('Failed to load template:', err)
       }
-      showToast(TEMPLATE_LOAD_FAILED_MESSAGE)
+      showToast(TEMPLATE_LOAD_FAILED_MESSAGE, 'error')
     }
   }, [onInsertBlueprint])
 
@@ -268,7 +270,7 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
       if (import.meta.env.DEV) {
         console.error('Failed to merge template:', err)
       }
-      showToast('Failed to merge template.')
+      showToast('Failed to merge template.', 'error')
     }
   }, [showToast])
 
@@ -276,7 +278,7 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
     if (!selectedBlueprintId) return
     let seedNum = parseInt(seed, 10)
     if (isNaN(seedNum) || seedNum < 1) {
-      showToast('Please enter a valid seed (≥1)')
+      showToast('Please enter a valid seed (≥1)', 'warning')
       trackRunAttempt({ canRun: false, reason: 'validation', message: '' })
       return
     }
@@ -325,7 +327,7 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
     // User cancelled or entered empty name
     if (!name || !name.trim()) {
       if (name === '') {
-        showToast('Scenario name cannot be empty.')
+        showToast('Scenario name cannot be empty.', 'warning')
       }
       return
     }
@@ -339,7 +341,7 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
     if (duplicate) {
       const overwrite = window.confirm(`A scenario named "${trimmedName}" already exists. Overwrite it?`)
       if (!overwrite) {
-        showToast('Scenario save cancelled.')
+        showToast('Scenario save cancelled.', 'warning')
         return
       }
       // Remove the duplicate before saving new one
@@ -777,16 +779,7 @@ export function TemplatesPanel({ isOpen, onClose, onInsertBlueprint, onPinToCanv
             </div>
           )}
 
-            {/* Toast */}
-            {toastMessage && (
-              <div
-                role="status"
-                aria-live="polite"
-                className={`absolute bottom-4 left-0 right-0 mx-4 bg-gray-900 text-white px-4 py-3 rounded-lg shadow-panel ${typography.panelBody}`}
-              >
-                {toastMessage}
-              </div>
-            )}
+
           </div>
         </PanelShell>
       </div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,59 @@
+/**
+ * Button — the DS's one button, as a component instead of a utility recipe.
+ *
+ * Extracted from the pre-analysis-v3 footer button (PanelFooter.tsx), the
+ * cleanest live instance: token typography, pill radius, focus ring,
+ * disabled opacity. The DS specifies exactly one primary treatment
+ * (bg-primary + text-text-on-color); before this component every surface
+ * hand-assembled it from utilities, which is how variants drift.
+ *
+ * Variants:
+ *  - primary   — the single filled treatment (one per view, usually)
+ *  - secondary — outlined neutral
+ *  - ghost     — borderless text action (info-deep text)
+ *  - danger    — outlined danger (never filled; destructive confirm lives in
+ *                the dialog, not the button colour)
+ */
+import { forwardRef, type ButtonHTMLAttributes } from 'react'
+import { typo } from '../../styles/typography'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+export type ButtonSize = 'md' | 'sm'
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+}
+
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary:
+    'bg-primary text-text-on-color hover:bg-primary-hover focus-visible:bg-primary-hover border border-transparent',
+  secondary:
+    'bg-transparent text-text-body border border-panel-border hover:bg-panel-hover',
+  ghost: 'bg-transparent text-info-hover border border-transparent hover:bg-panel-hover',
+  danger: 'bg-transparent text-danger-hover border border-danger/40 hover:bg-panel-hover',
+}
+
+const SIZE_CLASSES: Record<ButtonSize, { typo: 'button' | 'buttonSmall'; pad: string }> = {
+  // Extraction-first: `sm` is PanelFooter's exact geometry (buttonSmall + px-4 py-2).
+  md: { typo: 'button', pad: 'px-5 py-2.5' },
+  sm: { typo: 'buttonSmall', pad: 'px-4 py-2' },
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', size = 'md', className = '', type = 'button', ...rest },
+  ref,
+) {
+  const s = SIZE_CLASSES[size]
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={typo(
+        s.typo,
+        `whitespace-nowrap rounded-full ${s.pad} transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/40 disabled:cursor-not-allowed disabled:opacity-40 ${VARIANT_CLASSES[variant]} ${className}`,
+      )}
+      {...rest}
+    />
+  )
+})

--- a/src/components/ui/Pill.tsx
+++ b/src/components/ui/Pill.tsx
@@ -1,0 +1,44 @@
+/**
+ * Pill — the DS's outlined-only status pill, as a component.
+ *
+ * The DS law this encodes (so it can't drift per-surface): pills are ALWAYS
+ * `bg-transparent`, colour arrives ONLY through the border (main colour at
+ * ~30-40%) and an optional dot; the text stays `text-text-body` so a row of
+ * pills never shouts. Filled pills are a Don't (see DESIGN_SYSTEM.md §Pills).
+ * Extracted from the results-hero status pills — the instance every other
+ * surface was copying by hand.
+ */
+import type { ReactNode } from 'react'
+import { typography } from '../../styles/typography'
+
+export type PillTone = 'success' | 'warning' | 'danger' | 'info' | 'neutral'
+
+const TONE: Record<PillTone, { border: string; dot: string | null }> = {
+  success: { border: 'border-success/40', dot: 'bg-success' },
+  warning: { border: 'border-warning/50', dot: 'bg-warning' },
+  danger: { border: 'border-danger/40', dot: 'bg-danger' },
+  info: { border: 'border-info/40', dot: 'bg-info' },
+  neutral: { border: 'border-panel-border', dot: null },
+}
+
+export interface PillProps {
+  tone?: PillTone
+  /** Show the tone dot (never shown for neutral). */
+  dot?: boolean
+  children: ReactNode
+  className?: string
+  title?: string
+}
+
+export function Pill({ tone = 'neutral', dot = false, children, className = '', title }: PillProps) {
+  const t = TONE[tone]
+  return (
+    <span
+      title={title}
+      className={`${typography.panelMeta} inline-flex items-center gap-1.5 rounded-full border bg-transparent px-2 py-0.5 text-text-body ${t.border} ${className}`}
+    >
+      {dot && t.dot ? <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${t.dot}`} /> : null}
+      {children}
+    </span>
+  )
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,25 @@
+/**
+ * Skeleton — the DS §18 loading shimmer, as a component (none existed; every
+ * loading state hand-rolled its own placeholder or showed nothing).
+ *
+ * Text lines, card blocks, node stubs — one primitive, shaped by className.
+ * The shimmer honours prefers-reduced-motion via Tailwind's motion-safe
+ * gate; the base tone is the canvas-adjacent neutral so it reads as
+ * "content coming", not "content broken".
+ */
+export interface SkeletonProps {
+  className?: string
+  /** Accessible loading hint for the region (defaults to decorative). */
+  label?: string
+}
+
+export function Skeleton({ className = '', label }: SkeletonProps) {
+  return (
+    <span
+      role={label ? 'status' : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+      className={`relative block overflow-hidden rounded-md bg-border-default motion-safe:animate-pulse ${className}`}
+    />
+  )
+}

--- a/src/components/ui/__tests__/bricks.spec.tsx
+++ b/src/components/ui/__tests__/bricks.spec.tsx
@@ -1,0 +1,68 @@
+/**
+ * DS bricks — the laws each component encodes, pinned.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Button } from '../Button'
+import { Pill } from '../Pill'
+import { Skeleton } from '../Skeleton'
+
+describe('Button — the DS single-treatment button', () => {
+  it('primary carries the DS pair: bg-primary + text-text-on-color, pill radius', () => {
+    render(<Button>Analyse first pass</Button>)
+    const b = screen.getByRole('button', { name: 'Analyse first pass' })
+    expect(b.className).toContain('bg-primary')
+    expect(b.className).toContain('text-text-on-color')
+    expect(b.className).toContain('rounded-full')
+  })
+
+  it('defaults type="button" — a Button inside a form must not submit it by accident', () => {
+    render(<Button>Open</Button>)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+  })
+
+  it('danger is OUTLINED, never filled (destructive confirm belongs to the dialog)', () => {
+    render(<Button variant="danger">Remove node</Button>)
+    const b = screen.getByRole('button')
+    expect(b.className).toContain('bg-transparent')
+    expect(b.className).not.toContain('bg-danger')
+  })
+
+  it('disabled keeps the DS opacity treatment and blocks interaction', () => {
+    render(<Button disabled>Analyse</Button>)
+    const b = screen.getByRole('button')
+    expect(b).toBeDisabled()
+    expect(b.className).toContain('disabled:opacity-40')
+  })
+})
+
+describe('Pill — outlined only, ink text (DS law)', () => {
+  it('is always bg-transparent with text-text-body, colour only on the border', () => {
+    render(<Pill tone="success" dot>Stable result</Pill>)
+    const p = screen.getByText('Stable result')
+    expect(p.className).toContain('bg-transparent')
+    expect(p.className).toContain('text-text-body')
+    expect(p.className).toContain('border-success/40')
+    // The law the component exists to encode: no filled tone background.
+    expect(p.className).not.toMatch(/bg-(success|warning|danger|info)\b/)
+  })
+
+  it('neutral never renders a dot even when asked', () => {
+    const { container } = render(<Pill dot>Stakes not set</Pill>)
+    expect(container.querySelectorAll('span span')).toHaveLength(0)
+  })
+})
+
+describe('Skeleton', () => {
+  it('is decorative by default, a labelled status region when named', () => {
+    const { rerender, container } = render(<Skeleton className="h-4 w-40" />)
+    expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'true')
+    rerender(<Skeleton className="h-4 w-40" label="Loading analysis" />)
+    expect(screen.getByRole('status', { name: 'Loading analysis' })).toBeInTheDocument()
+  })
+
+  it('shimmer is motion-safe gated (prefers-reduced-motion honoured by class contract)', () => {
+    const { container } = render(<Skeleton />)
+    expect(container.firstElementChild?.className).toContain('motion-safe:animate-pulse')
+  })
+})

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -20,8 +20,14 @@ export { VerdictCard } from '../../canvas/components/VerdictCard'
 export { DeltaInterpretation } from '../../canvas/components/DeltaInterpretation'
 export { ObjectiveBanner } from '../../canvas/components/ObjectiveBanner'
 
-// Existing UI Components (to be added as they're discovered)
-// export { Button } from './Button'
-// export { Tooltip, TooltipTrigger, TooltipContent } from './Tooltip'
-// export { Spinner } from './Spinner'
-// export { ErrorAlert } from './ErrorAlert'
+// DS bricks (2026-07-16, extraction-first — see DESIGN_SYSTEM.md):
+export { Button } from './Button'
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button'
+export { Pill } from './Pill'
+export type { PillProps, PillTone } from './Pill'
+export { Skeleton } from './Skeleton'
+export type { SkeletonProps } from './Skeleton'
+// Modal: promote the existing token-compliant dialog rather than rebuild.
+export { ConfirmDialog } from '../../canvas/components/ConfirmDialog'
+// Toasts: the brick is ToastContext (severity owns persistence) — import
+// useShowToastSafe from src/canvas/ToastContext; do NOT build local toasts.

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom'
 import ReactFlowGraph from '../canvas/ReactFlowGraph'
 import type { Blueprint } from '../templates/blueprints/types'
 import { blueprintEventBus } from '../canvas/blueprints/eventBus'
+import { ToastProvider } from '../canvas/ToastContext'
 import { useCanvasStore } from '../canvas/store'
 import { useResultsRun } from '../canvas/hooks/useResultsRun'
 import { useDebugShortcut } from '../canvas/hooks/useDebugShortcut'
@@ -235,6 +236,11 @@ export default function CanvasMVP() {
   }, [isPersistenceActive, createSharedBrief])
 
   return (
+    // ToastProvider at route level so surfaces OUTSIDE ReactFlowGraph
+    // (TemplatesPanel above all) share the one toast system. RFG keeps its
+    // own inner provider — nested providers simply scope to their subtree,
+    // so RFG-originated toasts render exactly as before.
+    <ToastProvider>
     <div style={{ height: '100vh', width: '100vw', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
       <TopBar
         scenarioTitle={scenarioTitle}
@@ -280,5 +286,6 @@ export default function CanvasMVP() {
         )}
       </div>
     </div>
+    </ToastProvider>
   )
 }


### PR DESCRIPTION
feat(ui): the DS bricks — Button, Pill, Skeleton + Modal promotion + one toast system

The DS review's core gap: a strong spec with almost no shared code.
This lands the bricks, extraction-first, each encoding a DS law its
tests pin:

- Button (from PanelFooter, the cleanest live instance -- its geometry
  IS the sm size): primary carries the DS pair bg-primary+text-on-color;
  danger is OUTLINED never filled; type defaults to "button".
  PanelFooter now composes it (proves the extraction round-trips;
  361/361 pre-analysis-v3 suite unchanged).
- Pill (from the results-hero pills): ALWAYS bg-transparent, ink text,
  colour only via border/dot -- the filled-pill Don't is now a failing
  test, not a review comment.
- Skeleton (DS spec'd loading patterns, no component existed): motion-safe
  shimmer, decorative by default, labelled status region when named.
- Modal: the existing token-compliant ConfirmDialog is PROMOTED via
  components/ui (rebuild rejected -- it already does focus/Esc/backdrop
  right).
- One toast system: TemplatesPanel ran its own 3s-fixed local toast for
  years (the "two dialects" incident source). CanvasMVP gains a
  route-level ToastProvider; the panel now uses useShowToastSafe with
  explicit severities -- failures are 'error' and PERSIST until
  dismissed (DS: severity owns persistence). Local state, timer and
  render block deleted. RFG keeps its inner provider (nested scoping,
  behaviour unchanged); host consolidation filed as follow-up.

index.ts's own commented-out `export { Button }` placeholder finally
resolves. NodeBadge/NodeMeter + wider adoption filed (#350-class
follow-up) rather than silently dropped.

Gates: 370/370 across panels + pre-analysis-v3 + ui suites; tsc 2321
multiset zero-new; lint 12==12 on the two touched heavy files.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
