### PR TITLE
feat(coaching): render grounded bias signals on drafts (leg 3, cards capped at 2)

### DIFF
--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -47,6 +47,7 @@ import { V5ComparisonBlock } from '../../v5/blocks/V5ComparisonBlock'
 import { V5FlipAnalysisBlock } from '../../v5/blocks/V5FlipAnalysisBlock'
 import { V5ReviewCardBlock } from '../../v5/blocks/V5ReviewCardBlock'
 import { V5CoachingBlock } from '../../v5/blocks/V5CoachingBlock'
+import { BiasSignalCoachingCard } from '../../v5/blocks/BiasSignalCoachingCard'
 import { V5EvidenceBlock } from '../../v5/blocks/V5EvidenceBlock'
 import { V5ExerciseBlock } from '../../v5/blocks/V5ExerciseBlock'
 import { V5UnsupportedBlock } from '../../v5/blocks/V5UnsupportedBlock'
@@ -307,6 +308,12 @@ function BlockRenderer({
       return <V5ReviewCardBlock block={block} />
 
     case 'v5_coaching':
+      // Leg 3 (bias coaching): bias-signal coaching renders through the
+      // DS-recipe card (neutral bg + coloured left border); every other
+      // coaching_kind keeps the existing V5CoachingBlock renderer.
+      if (block.coaching_kind === 'bias_signal') {
+        return <BiasSignalCoachingCard block={block} />
+      }
       return <V5CoachingBlock block={block} />
 
     // Track C slice 2 (Lane UI-W4 C): 0.13.1-typed evidence + exercise.

--- a/src/canvas/conversation/__tests__/BiasSignalCoachingCard.spec.tsx
+++ b/src/canvas/conversation/__tests__/BiasSignalCoachingCard.spec.tsx
@@ -25,10 +25,11 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
-import { BiasSignalCoachingCard } from '../BiasSignalCoachingCard'
-import { InlineBlocks } from '../../../canvas/conversation/InlineBlocks'
-import { buildDraftBiasSignalBlocks } from '../../../canvas/conversation/draftBiasSignalBlocks'
-import type { V5CoachingBlock as V5CoachingBlockType } from '../../../canvas/conversation/types'
+import { BiasSignalCoachingCard } from '../../../v5/blocks/BiasSignalCoachingCard'
+import { InlineBlocks } from '../InlineBlocks'
+import { buildDraftBiasSignalBlocks } from '../draftBiasSignalBlocks'
+import type { V5CoachingBlock as V5CoachingBlockType } from '../types'
+import type { CEEDraftCoaching } from '../../../adapters/cee/types'
 
 const BIAS_BLOCK: V5CoachingBlockType = {
   type: 'v5_coaching',
@@ -139,12 +140,16 @@ describe('builder → InlineBlocks end-to-end (fixture wire shape)', () => {
   ]
 
   function buildFromWire(signals: typeof WIRE_SIGNALS) {
+    // Post-adapter shape, as the canvas store holds it (CEEDraftCoaching).
+    const draftCoaching: CEEDraftCoaching = {
+      summary: null,
+      strengthenItems: [],
+      wideningLog: [],
+      biasSignals: signals,
+    }
     return buildDraftBiasSignalBlocks({
       isDraftTurn: true,
-      store: {
-        draftCoaching: { summary: null, strengthenItems: [], wideningLog: [], biasSignals: signals },
-        nodes: NODES,
-      },
+      store: { draftCoaching, nodes: NODES },
       existingBlocks: [],
     })
   }

--- a/src/canvas/conversation/__tests__/draftBiasSignalBlocks.seam.spec.ts
+++ b/src/canvas/conversation/__tests__/draftBiasSignalBlocks.seam.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Leg 3 (bias-coaching rendering slice) — SEAM pins for the draft-turn
+ * bias-signal bridge. Unlike the builder pins (draftBiasSignalBlocks.spec.ts,
+ * which inject the store slice by hand), this suite drives the REAL V5
+ * inline-draft seam end to end, exactly as useConversation.ts sendTurn
+ * wires it:
+ *
+ *   wire body → parseV5Response → attachAnalysisReadyToInlineDraftGraph
+ *             → applyDraftResult (real canvas store)
+ *             → buildDraftBiasSignalBlocks
+ *
+ * Why this pin exists (PR #356 adversarial review, confirmed blocker):
+ * at the pinned boundary schema (0.15.0) the strict OlumiResponseSchema
+ * declares NO root `coaching` key, so the parser demotes it to the
+ * non-enumerable `__additive__` sidecar. Nothing on the V5 conversation
+ * path mapped it into the store — applyDraftResult committed
+ * `draftCoaching: null` three statements before the bridge read it, so
+ * the feature was dead on arrival in production while every builder spec
+ * stayed green. This suite is the pin that seam lacked.
+ *
+ * Fixture provenance: shape mirrors the live-verified draft response on
+ * CEE staging (build 57959b2c3, 16 Jul 2026) — root `coaching.bias_signals`
+ * as a SIBLING of `draft_graph`, signals grounded on real node ids.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  parseV5Response,
+  ADDITIVE_EXTENSIONS_KEY,
+  type OlumiResponseWithExtensions,
+} from '../../../v5/responseParser'
+import { attachAnalysisReadyToInlineDraftGraph } from '../useConversation'
+import { applyDraftResult } from '../../utils/applyDraftResult'
+import { useCanvasStore } from '../../store'
+import { buildDraftBiasSignalBlocks } from '../draftBiasSignalBlocks'
+
+// ─── Wire fixture (CEE staging shape) ────────────────────────────────────
+
+const WIRE_NODES = [
+  { id: 'dec_supplier', kind: 'decision', label: 'Choose supplier strategy' },
+  { id: 'opt_switch', kind: 'option', label: 'Switch supplier' },
+  {
+    id: 'fac_current_supplier',
+    kind: 'factor',
+    label: 'Current supplier terms',
+    observed_state: { value: 0.5, baseline: 0.5 },
+  },
+  {
+    id: 'fac_initial_quote',
+    kind: 'factor',
+    label: 'Initial quote',
+    observed_state: { value: 0.5, baseline: 0.5 },
+  },
+  { id: 'goal_cost', kind: 'goal', label: 'Minimise total cost' },
+]
+
+const WIRE_EDGES = [
+  { id: 'e1', from: 'dec_supplier', to: 'opt_switch', weight: 0.5, belief: 0.8 },
+  { id: 'e2', from: 'opt_switch', to: 'fac_current_supplier', weight: 0.5, belief: 0.7 },
+  { id: 'e3', from: 'opt_switch', to: 'fac_initial_quote', weight: 0.5, belief: 0.7 },
+  { id: 'e4', from: 'fac_current_supplier', to: 'goal_cost', weight: 0.5, belief: 0.7 },
+  { id: 'e5', from: 'fac_initial_quote', to: 'goal_cost', weight: 0.5, belief: 0.7 },
+]
+
+const WIRE_COACHING = {
+  summary: 'The draft leans on the current arrangement and the first quote.',
+  bias_signals: [
+    {
+      type: 'status_quo_bias',
+      detail:
+        'The model leans on keeping the current supplier without weighing the switch on equal terms.',
+      target: 'fac_current_supplier',
+    },
+    {
+      type: 'anchoring',
+      detail:
+        'Estimates cluster tightly around the initial quote rather than an independent range.',
+      target: 'fac_initial_quote',
+    },
+  ],
+}
+
+/** A schema-valid 0.15.0 V5 turn body carrying an inline draft graph. */
+function wireBody(opts: { coaching?: unknown } = {}): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: 'I have drafted a starting model of your decision.',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+    draft_graph: {
+      nodes: WIRE_NODES,
+      edges: WIRE_EDGES,
+      node_count: WIRE_NODES.length,
+      edge_count: WIRE_EDGES.length,
+    },
+    analysis_ready: {
+      status: 'ready',
+      options: [
+        { id: 'opt_switch', label: 'Switch supplier', interventions: {}, is_baseline: false },
+      ],
+      goal_node_id: 'goal_cost',
+    },
+    ...('coaching' in opts ? { coaching: opts.coaching } : {}),
+  }
+}
+
+function makeResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Drive the seam exactly as useConversation.ts sendTurn does on the
+ * inline-draft turn (the ONLY production caller of the bridge): parse the
+ * wire body, attach the response-root fields onto the inline graph, apply
+ * it through the real store, then run the bridge against the real store
+ * state. Mirrors useConversation.ts — if the production wiring changes,
+ * update BOTH places.
+ */
+async function driveSeam(body: Record<string, unknown>) {
+  const result = await parseV5Response(makeResponse(body))
+  if (result.kind !== 'response') {
+    throw new Error(`expected a parsed response, got ${result.kind}`)
+  }
+  const response = result.response
+  const inlineGraph = attachAnalysisReadyToInlineDraftGraph(
+    response.draft_graph,
+    (response as { analysis_ready?: unknown }).analysis_ready,
+    (response as { goal_constraints?: unknown }).goal_constraints,
+    // Full parsed response: at the pinned 0.15.0 schema the root `coaching`
+    // key rides the non-enumerable __additive__ sidecar, so the helper needs
+    // the response object itself, not a destructured (and therefore absent)
+    // property.
+    response,
+  )
+  expect(inlineGraph).toBeTruthy()
+  applyDraftResult(inlineGraph as never)
+  return buildDraftBiasSignalBlocks({
+    isDraftTurn: true,
+    store: useCanvasStore.getState(),
+    existingBlocks: [],
+  })
+}
+
+// ─── Pins ────────────────────────────────────────────────────────────────
+
+describe('draft bias-signal bridge — REAL applyDraftResult seam', () => {
+  beforeEach(() => {
+    useCanvasStore.getState().resetCanvas()
+  })
+
+  it('root coaching.bias_signals reaches the store and renders exactly 2 grounded cards', async () => {
+    const blocks = await driveSeam(wireBody({ coaching: WIRE_COACHING }))
+
+    // The commit link: applyDraftResult must have put the mapped coaching
+    // into the store BEFORE the bridge read it.
+    const committed = useCanvasStore.getState().draftCoaching
+    expect(committed).not.toBeNull()
+    expect(committed?.biasSignals).toHaveLength(2)
+
+    // The rendered cards.
+    expect(blocks).toHaveLength(2)
+    expect(blocks.map((b) => b.title)).toEqual(['Status quo bias', 'Anchoring'])
+    expect(blocks.map((b) => b.body)).toEqual([
+      WIRE_COACHING.bias_signals[0].detail,
+      WIRE_COACHING.bias_signals[1].detail,
+    ])
+    expect(blocks[0].target_refs).toEqual([
+      { id: 'fac_current_supplier', label: 'Current supplier terms', kind: 'factor' },
+    ])
+    expect(blocks[1].target_refs).toEqual([
+      { id: 'fac_initial_quote', label: 'Initial quote', kind: 'factor' },
+    ])
+    for (const b of blocks) {
+      expect(b.type).toBe('v5_coaching')
+      expect(b.coaching_kind).toBe('bias_signal')
+    }
+  })
+
+  it('a draft with no root coaching clears stale draftCoaching — no ghost cards from a prior draft', async () => {
+    // Stale coaching keyed to a previous draft's node ids must not survive
+    // a fresh draft (applyDraftResult's existing clear semantics).
+    useCanvasStore.getState().setDraftCoaching({
+      summary: null,
+      strengthenItems: [],
+      wideningLog: [],
+      biasSignals: [
+        { type: 'anchoring', detail: 'Stale signal from a prior draft.', target: 'old_node' },
+      ],
+    })
+
+    const blocks = await driveSeam(wireBody())
+
+    expect(useCanvasStore.getState().draftCoaching).toBeNull()
+    expect(blocks).toEqual([])
+  })
+
+  it('at the pinned 0.15.0 schema, root coaching lands in the __additive__ sidecar, not the strict surface', async () => {
+    // Documents WHY the seam read needs the sidecar: OlumiResponseSchema is
+    // .strict() and declares no `coaching` root key, so adding `coaching` to
+    // KNOWN_OLUMI_TOP_LEVEL_KEYS would route it into strict validation and
+    // fail the whole parse. Until @talchain/schemas formalises the key, the
+    // sidecar IS where a root coaching object lands.
+    const result = await parseV5Response(makeResponse(wireBody({ coaching: WIRE_COACHING })))
+    if (result.kind !== 'response') {
+      throw new Error(`expected a parsed response, got ${result.kind}`)
+    }
+    expect((result.response as { coaching?: unknown }).coaching).toBeUndefined()
+    const sidecar = (result.response as OlumiResponseWithExtensions)[ADDITIVE_EXTENSIONS_KEY]
+    expect(sidecar?.['coaching']).toEqual(WIRE_COACHING)
+  })
+})

--- a/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
+++ b/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Leg 3 (bias-coaching rendering slice) — builder pins for
+ * buildDraftBiasSignalBlocks: draft-turn `coaching.bias_signals` →
+ * typed `v5_coaching` conversation blocks with
+ * `coaching_kind: 'bias_signal'` (the 0.15.0 boundary enum value).
+ *
+ * Fixture provenance: shape mirrors the live-verified draft response on
+ * CEE staging (build 57959b2c3, 16 Jul 2026) — a 15-node draft whose
+ * `coaching.bias_signals` carried `status_quo_bias` + `anchoring`, both
+ * grounded (target set to a real node id). Labels and ids here are
+ * synthetic; the wire shape ({ type, detail, target? }) is the verified
+ * one (CEEDraftCoachingWire.bias_signals, src/adapters/cee/types.ts).
+ *
+ * Pinned behaviour (ratified: cards capped at 2):
+ *   1. Two grounded signals → two typed blocks, humanised titles.
+ *   2. Three or more grounded signals → exactly two (wire order).
+ *   3. Not a draft turn → nothing.
+ *   4. Absent coaching / empty array → nothing.
+ *   5. Unknown bias code → that signal renders nothing (others unaffected).
+ *   6. Malformed entry (blank detail / blank type / wrong types) → nothing
+ *      for that entry, never a crash.
+ *   7. Ungrounded (missing / unresolvable target) → nothing for that entry.
+ *   8. No raw code string ever becomes visible copy (sweep across the
+ *      known-code allowlist).
+ *   9. Producer-typed bias coaching already on the turn → builder yields
+ *      nothing (producer blocks win; no doubled cards).
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  BIAS_SIGNAL_TITLES,
+  DRAFT_BIAS_SIGNAL_CARD_CAP,
+  buildDraftBiasSignalBlocks,
+} from '../draftBiasSignalBlocks'
+import type { ConversationBlock, V5CoachingBlock } from '../types'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────
+
+/** Canvas nodes the grounded targets resolve against. */
+const NODES = [
+  { id: 'fac_current_supplier', type: 'factor', data: { label: 'Current supplier terms' } },
+  { id: 'fac_initial_quote', type: 'factor', data: { label: 'Initial quote' } },
+  { id: 'opt_switch', type: 'option', data: { label: 'Switch supplier' } },
+  { id: 'fac_blank_label', type: 'factor', data: { label: '   ' } },
+]
+
+/** Wire-shaped signals, post-adapter (CEEDraftCoaching.biasSignals). */
+const SIGNAL_STATUS_QUO = {
+  type: 'status_quo_bias',
+  detail: 'The model leans on keeping the current supplier without weighing the switch on equal terms.',
+  target: 'fac_current_supplier',
+}
+const SIGNAL_ANCHORING = {
+  type: 'anchoring',
+  detail: 'Estimates cluster tightly around the initial quote rather than an independent range.',
+  target: 'fac_initial_quote',
+}
+const SIGNAL_SUNK_COST = {
+  type: 'sunk_cost',
+  detail: 'Past spend on the current contract is treated as a reason to continue.',
+  target: 'opt_switch',
+}
+
+function makeStore(
+  biasSignals: Array<{ type: string; detail: string; target?: string }> | null,
+) {
+  return {
+    draftCoaching:
+      biasSignals === null
+        ? null
+        : { summary: null, strengthenItems: [], wideningLog: [], biasSignals },
+    nodes: NODES,
+  }
+}
+
+function build(
+  biasSignals: Array<{ type: string; detail: string; target?: string }> | null,
+  overrides: Partial<{ isDraftTurn: boolean; existingBlocks: readonly ConversationBlock[] }> = {},
+): V5CoachingBlock[] {
+  return buildDraftBiasSignalBlocks({
+    isDraftTurn: overrides.isDraftTurn ?? true,
+    store: makeStore(biasSignals),
+    existingBlocks: overrides.existingBlocks ?? [],
+  })
+}
+
+// ─── Pins ────────────────────────────────────────────────────────────────
+
+describe('buildDraftBiasSignalBlocks — happy path', () => {
+  it('two grounded signals → two typed v5_coaching blocks with coaching_kind bias_signal', () => {
+    const blocks = build([SIGNAL_STATUS_QUO, SIGNAL_ANCHORING])
+    expect(blocks).toHaveLength(2)
+    for (const b of blocks) {
+      expect(b.type).toBe('v5_coaching')
+      expect(b.coaching_kind).toBe('bias_signal')
+      expect(b.source).toBe('draft_graph')
+    }
+  })
+
+  it('humanises the bias code into the title and keeps the detail verbatim as the body', () => {
+    const blocks = build([SIGNAL_STATUS_QUO, SIGNAL_ANCHORING])
+    expect(blocks[0].title).toBe('Status quo bias')
+    expect(blocks[0].body).toBe(SIGNAL_STATUS_QUO.detail)
+    expect(blocks[1].title).toBe('Anchoring')
+    expect(blocks[1].body).toBe(SIGNAL_ANCHORING.detail)
+  })
+
+  it('carries the grounded reference as a target ref resolved against the graph', () => {
+    const blocks = build([SIGNAL_STATUS_QUO])
+    expect(blocks[0].target_refs).toEqual([
+      { id: 'fac_current_supplier', label: 'Current supplier terms', kind: 'factor' },
+    ])
+  })
+
+  it('assigns stable block ids and 1-based priority ranks in wire order', () => {
+    const blocks = build([SIGNAL_STATUS_QUO, SIGNAL_ANCHORING])
+    expect(blocks[0].block_id).not.toBe(blocks[1].block_id)
+    expect(blocks[0].priority_rank).toBe(1)
+    expect(blocks[1].priority_rank).toBe(2)
+  })
+})
+
+describe('buildDraftBiasSignalBlocks — the ratified cap (≤2 cards)', () => {
+  it('pins the cap constant at 2', () => {
+    expect(DRAFT_BIAS_SIGNAL_CARD_CAP).toBe(2)
+  })
+
+  it('three grounded signals → exactly two blocks, first two in wire order', () => {
+    const blocks = build([SIGNAL_STATUS_QUO, SIGNAL_ANCHORING, SIGNAL_SUNK_COST])
+    expect(blocks).toHaveLength(2)
+    expect(blocks.map((b) => b.title)).toEqual(['Status quo bias', 'Anchoring'])
+  })
+
+  it('the cap counts rendered cards, not raw entries — dropped entries do not consume slots', () => {
+    const blocks = build([
+      { ...SIGNAL_STATUS_QUO, target: 'missing_node' }, // ungrounded → dropped
+      SIGNAL_ANCHORING,
+      SIGNAL_SUNK_COST,
+    ])
+    expect(blocks).toHaveLength(2)
+    expect(blocks.map((b) => b.title)).toEqual(['Anchoring', 'Sunk cost'])
+  })
+})
+
+describe('buildDraftBiasSignalBlocks — fail closed', () => {
+  it('not a draft turn → nothing', () => {
+    expect(build([SIGNAL_STATUS_QUO], { isDraftTurn: false })).toEqual([])
+  })
+
+  it('absent coaching (null) → nothing', () => {
+    expect(build(null)).toEqual([])
+  })
+
+  it('empty bias_signals array → nothing', () => {
+    expect(build([])).toEqual([])
+  })
+
+  it('unknown bias code → nothing for that signal; known ones still render', () => {
+    const blocks = build([
+      { type: 'made_up_bias', detail: 'Some plausible prose.', target: 'fac_initial_quote' },
+      SIGNAL_ANCHORING,
+    ])
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].title).toBe('Anchoring')
+  })
+
+  it('entity-id-shaped code → nothing for that signal (never sentence-cased into copy)', () => {
+    const blocks = build([
+      { type: 'fac_current_supplier', detail: 'Prose.', target: 'fac_initial_quote' },
+    ])
+    expect(blocks).toEqual([])
+  })
+
+  it('malformed entries → nothing for each, never a crash', () => {
+    const malformed = [
+      { type: 'anchoring', detail: '   ', target: 'fac_initial_quote' }, // blank detail
+      { type: '', detail: 'Prose.', target: 'fac_initial_quote' }, // blank type
+      { type: 42, detail: 'Prose.', target: 'fac_initial_quote' }, // wrong type type
+      { type: 'anchoring', detail: 7, target: 'fac_initial_quote' }, // wrong detail type
+      null, // not an object
+      'anchoring', // not an object
+    ] as unknown as Array<{ type: string; detail: string; target?: string }>
+    expect(build(malformed)).toEqual([])
+  })
+
+  it('ungrounded signals → nothing: missing target, unresolvable target, blank-label target', () => {
+    const blocks = build([
+      { type: 'anchoring', detail: 'No target at all.' },
+      { type: 'anchoring', detail: 'Target not on the canvas.', target: 'fac_ghost' },
+      { type: 'anchoring', detail: 'Target label is blank.', target: 'fac_blank_label' },
+      { type: 'anchoring', detail: 'Whitespace target.', target: '   ' },
+    ])
+    expect(blocks).toEqual([])
+  })
+
+  it('producer-typed bias coaching already on the turn → builder yields nothing', () => {
+    const producerBlock: ConversationBlock = {
+      type: 'v5_coaching',
+      block_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c02',
+      title: 'Possible anchoring on the first option',
+      body: 'You have only explored variations of Option A so far.',
+      coaching_kind: 'bias_signal',
+      source: 'draft_graph',
+      target_refs: [],
+      priority_rank: 1,
+      freshness: 'fresh',
+    }
+    expect(build([SIGNAL_STATUS_QUO], { existingBlocks: [producerBlock] })).toEqual([])
+    // A non-bias coaching block does NOT suppress the bridge.
+    const otherKind: ConversationBlock = {
+      ...producerBlock,
+      block_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c03',
+      coaching_kind: 'strengthen',
+    }
+    expect(build([SIGNAL_STATUS_QUO], { existingBlocks: [otherKind] })).toHaveLength(1)
+  })
+})
+
+describe('buildDraftBiasSignalBlocks — no raw code string in visible copy (sweep)', () => {
+  it('every allowlisted code humanises to a title that is not the raw code and carries no snake_case', () => {
+    const codes = Object.keys(BIAS_SIGNAL_TITLES)
+    expect(codes.length).toBeGreaterThan(0)
+    for (const code of codes) {
+      const blocks = build([
+        { type: code, detail: 'Grounded prose for the sweep.', target: 'fac_initial_quote' },
+      ])
+      expect(blocks, `code ${code} should render`).toHaveLength(1)
+      const title = blocks[0].title
+      expect(title, `title for ${code}`).not.toBe(code)
+      expect(title, `title for ${code} must not contain underscores`).not.toMatch(/_/)
+      // Humanised copy starts with a capital letter and is not SHOUTED.
+      expect(title).toMatch(/^[A-Z]/)
+      expect(title).not.toMatch(/^[A-Z_]+$/)
+    }
+  })
+
+  it('uppercase code variants humanise through the same allowlist (case-insensitive)', () => {
+    const blocks = build([
+      { type: 'STATUS_QUO_BIAS', detail: 'Uppercase wire convention.', target: 'fac_initial_quote' },
+    ])
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].title).toBe('Status quo bias')
+  })
+})

--- a/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
+++ b/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
@@ -31,6 +31,7 @@ import {
   BIAS_SIGNAL_TITLES,
   DRAFT_BIAS_SIGNAL_CARD_CAP,
   buildDraftBiasSignalBlocks,
+  humaniseBiasSignalCode,
 } from '../draftBiasSignalBlocks'
 import type { ConversationBlock, V5CoachingBlock } from '../types'
 
@@ -213,6 +214,31 @@ describe('buildDraftBiasSignalBlocks — fail closed', () => {
       coaching_kind: 'strengthen',
     }
     expect(build([SIGNAL_STATUS_QUO], { existingBlocks: [otherKind] })).toHaveLength(1)
+  })
+})
+
+describe('humaniseBiasSignalCode — prototype-chain escapes (hostile wire codes)', () => {
+  // A bare object-literal index walks the prototype chain: '__proto__'
+  // yields Object.prototype (a truthy object — React throws "Objects are
+  // not valid as a React child", crashing the assistant-message subtree)
+  // and 'constructor' yields the Object function (blank title + console
+  // error). Both must fail closed like any other unknown code. Only these
+  // two survive the toLowerCase() normalisation; 'toString' / 'valueOf' /
+  // 'hasOwnProperty' miss the camelCase prototype properties already.
+  it("'__proto__' fails closed — Object.prototype must never become a card title", () => {
+    expect(humaniseBiasSignalCode('__proto__')).toBeNull()
+  })
+
+  it("'constructor' fails closed — a Function must never become a card title", () => {
+    expect(humaniseBiasSignalCode('constructor')).toBeNull()
+  })
+
+  it('grounded signals carrying hostile codes render no cards (case-insensitive path included)', () => {
+    const blocks = build([
+      { type: '__proto__', detail: 'Hostile wire code.', target: 'fac_initial_quote' },
+      { type: 'CONSTRUCTOR', detail: 'Hostile wire code.', target: 'fac_initial_quote' },
+    ])
+    expect(blocks).toEqual([])
   })
 })
 

--- a/src/canvas/conversation/draftBiasSignalBlocks.ts
+++ b/src/canvas/conversation/draftBiasSignalBlocks.ts
@@ -1,0 +1,150 @@
+/**
+ * draftBiasSignalBlocks — leg 3 of the bias-coaching design
+ * (BIAS-COACHING-PROPOSAL-2026-07-16 §2, FRAME beat): bridge the draft
+ * response's `coaching.bias_signals` into typed `v5_coaching` conversation
+ * blocks with `coaching_kind: 'bias_signal'` — the value the 0.15.0
+ * boundary schema already types on its coaching-block enum
+ * (@talchain/schemas boundary/blocks CoachingBlockSchema). Building on
+ * that typed path means that when CEE starts emitting real boundary
+ * coaching blocks for bias signals, the same conversation block type and
+ * the same renderer carry them with no UI change — and this bridge steps
+ * aside (see the producer-wins rule below).
+ *
+ * Gate shape mirrors maybeBuildModelReceiptBlock (modelCardAdapter §8):
+ * pure, store-reading, called on the V5 turn that applied a fresh draft
+ * graph, after applyDraftResult has committed `draftCoaching` to the
+ * canvas store synchronously.
+ *
+ * Fail-closed, per entry (ratified cards-cap 2):
+ *   - not a draft turn / absent coaching / empty array → []
+ *   - malformed entry (non-object, blank/non-string type or detail) → skipped
+ *   - unknown bias code (not on the allowlist) → skipped — the code is
+ *     wire vocabulary, never visible copy, so an unmapped code has no
+ *     honest rendering (mirrors, and tightens, the PreAnalysisPanel
+ *     convention: no safeBiasTitle sentence-casing here)
+ *   - ungrounded (missing / unresolvable / blank-label target) → skipped —
+ *     same resolvable-target rule as PreAnalysisPanel Brief 5.8A D2
+ *   - producer-typed bias coaching already on the turn → [] (producer wins)
+ *
+ * Copy: title is the humanised bias name (same canonical names as the
+ * pre-analysis surface, one bias one name everywhere); body is the
+ * producer's `detail` verbatim; the grounded reference rides as a
+ * target_ref resolved against the live graph.
+ */
+import type { CEEDraftCoaching } from '../../adapters/cee/types'
+import type { ConversationBlock, V5CoachingBlock } from './types'
+
+/** Ratified cap: at most two bias-signal cards per draft turn. */
+export const DRAFT_BIAS_SIGNAL_CARD_CAP = 2
+
+/**
+ * Humanised titles for the known CEE bias codes — the same canonical names
+ * the pre-analysis surface uses (PreAnalysisPanel BIAS_TYPE_ICON), so one
+ * bias renders one name on every surface. Keys are lowercase; lookup is
+ * case-insensitive to cover both wire conventions (lowercase `type`,
+ * uppercase `code`). Unknown codes are NOT sentence-cased — they fail
+ * closed (no card), so a raw wire token can never leak into copy.
+ */
+export const BIAS_SIGNAL_TITLES: Record<string, string> = {
+  framing: 'Narrow framing',
+  framing_bias: 'Narrow framing',
+  narrow_framing: 'Narrow framing',
+  anchoring: 'Anchoring',
+  anchoring_bias: 'Anchoring',
+  confidence: 'Overconfidence',
+  overconfidence: 'Overconfidence',
+  optimism_bias: 'Optimism bias',
+  blind_spots: 'Blind spots',
+  status_quo_bias: 'Status quo bias',
+  confirmation: 'Confirmation bias',
+  confirmation_bias: 'Confirmation bias',
+  authority_bias: 'Authority bias',
+  availability_bias: 'Availability bias',
+  sunk_cost: 'Sunk cost',
+}
+
+/** Allowlist lookup. Returns null for unknown / non-string codes (fail closed). */
+export function humaniseBiasSignalCode(code: unknown): string | null {
+  if (typeof code !== 'string') return null
+  const trimmed = code.trim()
+  if (!trimmed) return null
+  return BIAS_SIGNAL_TITLES[trimmed.toLowerCase()] ?? null
+}
+
+/** The minimal canvas-store surface the builder reads. */
+export interface DraftBiasSignalStoreSlice {
+  draftCoaching: Pick<CEEDraftCoaching, 'biasSignals'> | null
+  nodes: Array<{ id: string; type?: string; data?: unknown }>
+}
+
+/** Resolve a node id to a non-blank label, or null (fail closed). */
+function resolveNodeForTarget(
+  target: unknown,
+  nodes: DraftBiasSignalStoreSlice['nodes'],
+): { id: string; label: string; kind: string } | null {
+  if (typeof target !== 'string') return null
+  const id = target.trim()
+  if (!id) return null
+  const node = nodes.find((n) => n.id === id)
+  if (!node) return null
+  const label = (node.data as Record<string, unknown> | undefined)?.label
+  if (typeof label !== 'string' || !label.trim()) return null
+  const kind = typeof node.type === 'string' && node.type.trim() ? node.type : 'node'
+  return { id, label: label.trim(), kind }
+}
+
+/**
+ * Build ≤2 typed bias-signal coaching blocks for the post-draft assistant
+ * message, or [] when there is nothing honest to show.
+ */
+export function buildDraftBiasSignalBlocks(args: {
+  /** True only on the turn that applied a fresh draft graph. */
+  isDraftTurn: boolean
+  store: DraftBiasSignalStoreSlice
+  /**
+   * Blocks already composed for this turn. When the producer sent real
+   * typed bias coaching (v5_coaching with coaching_kind 'bias_signal'),
+   * this bridge yields nothing — producer blocks win, never doubled cards.
+   */
+  existingBlocks?: readonly ConversationBlock[]
+}): V5CoachingBlock[] {
+  const { isDraftTurn, store, existingBlocks = [] } = args
+  if (!isDraftTurn) return []
+
+  const producerHasBiasCoaching = existingBlocks.some(
+    (b) => b.type === 'v5_coaching' && b.coaching_kind === 'bias_signal',
+  )
+  if (producerHasBiasCoaching) return []
+
+  const signals = store.draftCoaching?.biasSignals
+  if (!Array.isArray(signals) || signals.length === 0) return []
+
+  const out: V5CoachingBlock[] = []
+  for (let i = 0; i < signals.length && out.length < DRAFT_BIAS_SIGNAL_CARD_CAP; i++) {
+    const signal = signals[i] as unknown
+    if (!signal || typeof signal !== 'object') continue
+    const s = signal as Record<string, unknown>
+
+    const title = humaniseBiasSignalCode(s.type)
+    if (!title) continue
+
+    const detail = typeof s.detail === 'string' ? s.detail.trim() : ''
+    if (!detail) continue
+
+    const ref = resolveNodeForTarget(s.target, store.nodes)
+    if (!ref) continue
+
+    out.push({
+      type: 'v5_coaching',
+      block_id: `draft_bias_signal_${i}`,
+      title,
+      body: detail,
+      coaching_kind: 'bias_signal',
+      source: 'draft_graph',
+      target_refs: [ref],
+      priority_rank: out.length + 1,
+      freshness: 'fresh',
+    })
+  }
+  return out
+}

--- a/src/canvas/conversation/draftBiasSignalBlocks.ts
+++ b/src/canvas/conversation/draftBiasSignalBlocks.ts
@@ -66,9 +66,17 @@ export const BIAS_SIGNAL_TITLES: Record<string, string> = {
 /** Allowlist lookup. Returns null for unknown / non-string codes (fail closed). */
 export function humaniseBiasSignalCode(code: unknown): string | null {
   if (typeof code !== 'string') return null
-  const trimmed = code.trim()
-  if (!trimmed) return null
-  return BIAS_SIGNAL_TITLES[trimmed.toLowerCase()] ?? null
+  const key = code.trim().toLowerCase()
+  if (!key) return null
+  // Own-key guard: a bare object-literal index walks the prototype chain,
+  // so the hostile wire codes '__proto__' (returns Object.prototype, a
+  // truthy object React refuses to render, crashing the assistant-message
+  // subtree) and 'constructor' (returns a Function) would escape both the
+  // `?? null` here and the caller's `if (!title)` check. Only own keys are
+  // titles; everything else fails closed like any other unknown code.
+  return Object.prototype.hasOwnProperty.call(BIAS_SIGNAL_TITLES, key)
+    ? BIAS_SIGNAL_TITLES[key]
+    : null
 }
 
 /** The minimal canvas-store surface the builder reads. */

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -44,6 +44,10 @@ import { recordDroppedContent } from '../../lib/droppedContentCounter'
 import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled, isReasoningDisclosureEnabled } from '../../flags'
 import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
+// Leg 3 blocker fix: the wire->camelCase coaching mapper lives in the CEE
+// client adapter (DraftChat/useRetryDraft path); the V5 inline-draft seam
+// reuses it so one mapper owns the coaching wire shape.
+import { mapDraftCoachingFromResponse } from '../../adapters/cee/client'
 import { maybeBuildModelReceiptBlock } from '../adapters/modelCardAdapter'
 import { buildDraftBiasSignalBlocks } from './draftBiasSignalBlocks'
 import { assembleAnalysisInputsSummary } from '../analysis/assembleAnalysisInputsSummary'
@@ -652,6 +656,25 @@ export function attachAnalysisReadyToInlineDraftGraph(
   // exactly how analysis_ready is attached below — so applyDraftResult's
   // existing read sees it.
   responseGoalConstraints?: unknown,
+  // Leg 3 blocker fix (PR #356 review): CEE places `coaching` at the V5
+  // response ROOT, as a SIBLING of `draft_graph` — same class as the
+  // goal_constraints residual above. At the pinned boundary schema
+  // (0.15.0) the strict OlumiResponseSchema declares NO `coaching` key,
+  // so the parser demotes it to the non-enumerable `__additive__` sidecar
+  // (it must NOT be added to KNOWN_OLUMI_TOP_LEVEL_KEYS — the schema is
+  // .strict(), so routing an undeclared key into strict validation would
+  // fail the whole parse; formalising `coaching` at the root is a
+  // @talchain/schemas ask, tracked in the PR record). That means the read
+  // needs the full parsed response object — a destructured `coaching`
+  // property is always absent — so this parameter takes the response
+  // itself, reads the sidecar (formal root key first, should the schema
+  // ever declare it), maps the wire shape through
+  // mapDraftCoachingFromResponse, and attaches the post-adapter
+  // `draftCoaching` field that applyDraftResult already reads and
+  // commits to the store. Absent/malformed coaching attaches nothing, so
+  // applyDraftResult's existing "new draft clears stale coaching"
+  // semantics are preserved unchanged.
+  parsedResponse?: unknown,
 ): Record<string, unknown> | undefined {
   if (draftGraph == null || typeof draftGraph !== 'object') return undefined
 
@@ -672,13 +695,30 @@ export function attachAnalysisReadyToInlineDraftGraph(
     ? { ...graph, goal_constraints: rootGoalConstraints }
     : graph
 
-  if (graphWithConstraints.analysis_ready != null) return graphWithConstraints
+  // Root coaching → post-adapter draftCoaching (see the parameter note
+  // above). Attach only when the inline object doesn't already carry its
+  // own and the mapping yields a real payload (mapDraftCoachingFromResponse
+  // is fail-closed: null for absent/non-object input).
+  const rootCoaching =
+    (parsedResponse as { coaching?: unknown } | null | undefined)?.coaching ??
+    (parsedResponse as OlumiResponseWithExtensions | null | undefined)?.[
+      ADDITIVE_EXTENSIONS_KEY
+    ]?.['coaching']
+  const mappedCoaching =
+    graphWithConstraints.draftCoaching == null
+      ? mapDraftCoachingFromResponse(rootCoaching)
+      : null
+  const graphWithCoaching = mappedCoaching
+    ? { ...graphWithConstraints, draftCoaching: mappedCoaching }
+    : graphWithConstraints
+
+  if (graphWithCoaching.analysis_ready != null) return graphWithCoaching
 
   const normalised = normaliseAnalysisReady(responseAnalysisReady)
-  if (!normalised) return graphWithConstraints
+  if (!normalised) return graphWithCoaching
 
   return {
-    ...graphWithConstraints,
+    ...graphWithCoaching,
     analysis_ready: normalised,
   }
 }
@@ -3243,6 +3283,14 @@ export function useConversation(): UseConversationReturn {
               // see it as absent and clear the store on every inline-draft
               // turn.
               (target.response as { goal_constraints?: unknown }).goal_constraints,
+              // Leg 3 blocker fix: pass the full parsed response — root
+              // `coaching` rides the __additive__ sidecar at the pinned
+              // 0.15.0 schema (a destructured property would always be
+              // absent). The helper maps it to the post-adapter
+              // `draftCoaching` field applyDraftResult commits to the store.
+              // Seam pinned by draftBiasSignalBlocks.seam.spec.ts — keep the
+              // spec's driveSeam wiring in step with this call.
+              target.response,
             )
             const inlineNodeCount = (inlineGraph?.nodes as unknown[] | undefined)?.length ?? 0
 
@@ -3360,13 +3408,20 @@ export function useConversation(): UseConversationReturn {
 
             // Leg 3 (bias coaching, BIAS-COACHING-PROPOSAL-2026-07-16 §2
             // FRAME beat): bridge the draft response's coaching.bias_signals
-            // (committed to the store by applyDraftResult synchronously
-            // above) into ≤2 typed v5_coaching blocks with coaching_kind
-            // 'bias_signal'. Same gate pattern as the model receipt: fires
-            // only on the turn that applied a fresh draft graph. Fail-closed
-            // throughout (absent/empty/unknown/malformed/ungrounded entries
-            // render nothing); producer-typed bias coaching in finalBlocks
-            // suppresses the bridge entirely.
+            // into ≤2 typed v5_coaching blocks with coaching_kind
+            // 'bias_signal'. The coaching arrives at the response ROOT
+            // (demoted to the __additive__ sidecar at the pinned 0.15.0
+            // schema); attachAnalysisReadyToInlineDraftGraph maps it onto
+            // the inline graph as `draftCoaching`, and applyDraftResult
+            // committed it to the store synchronously above — on any other
+            // path (no fresh draft applied) the store slice is stale, which
+            // is why the isDraftTurn gate below is load-bearing. Same gate
+            // pattern as the model receipt: fires only on the turn that
+            // applied a fresh draft graph. Fail-closed throughout
+            // (absent/empty/unknown/malformed/ungrounded entries render
+            // nothing); producer-typed bias coaching in finalBlocks
+            // suppresses the bridge entirely. Seam pinned end to end by
+            // draftBiasSignalBlocks.seam.spec.ts.
             const biasSignalBlocks = buildDraftBiasSignalBlocks({
               isDraftTurn: draftAppliedThisTurn,
               store: useCanvasStore.getState(),

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -45,6 +45,7 @@ import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled, isReasoningDisclosureEnabled } from '../../flags'
 import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
 import { maybeBuildModelReceiptBlock } from '../adapters/modelCardAdapter'
+import { buildDraftBiasSignalBlocks } from './draftBiasSignalBlocks'
 import { assembleAnalysisInputsSummary } from '../analysis/assembleAnalysisInputsSummary'
 import { useResultsStore } from '../stores/resultsStore'
 import { hydrateMessagesFromThread, formatSessionBoundary } from './utils/hydrateThread'
@@ -3356,7 +3357,26 @@ export function useConversation(): UseConversationReturn {
               isDraftTurn: draftAppliedThisTurn,
               store: useCanvasStore.getState(),
             })
-            const renderBlocks = receipt ? [...finalBlocks, receipt] : finalBlocks
+
+            // Leg 3 (bias coaching, BIAS-COACHING-PROPOSAL-2026-07-16 §2
+            // FRAME beat): bridge the draft response's coaching.bias_signals
+            // (committed to the store by applyDraftResult synchronously
+            // above) into ≤2 typed v5_coaching blocks with coaching_kind
+            // 'bias_signal'. Same gate pattern as the model receipt: fires
+            // only on the turn that applied a fresh draft graph. Fail-closed
+            // throughout (absent/empty/unknown/malformed/ungrounded entries
+            // render nothing); producer-typed bias coaching in finalBlocks
+            // suppresses the bridge entirely.
+            const biasSignalBlocks = buildDraftBiasSignalBlocks({
+              isDraftTurn: draftAppliedThisTurn,
+              store: useCanvasStore.getState(),
+              existingBlocks: finalBlocks,
+            })
+            const renderBlocks = [
+              ...finalBlocks,
+              ...(receipt ? [receipt] : []),
+              ...biasSignalBlocks,
+            ]
 
             // V5 suggested_actions → ActionChip. CEE caps count server-side;
             // UI additionally caps rendering per DS v5 §21.4 in SuggestedChips.

--- a/src/v5/blocks/BiasSignalCoachingCard.tsx
+++ b/src/v5/blocks/BiasSignalCoachingCard.tsx
@@ -1,0 +1,81 @@
+/**
+ * BiasSignalCoachingCard — renders a `v5_coaching` block whose
+ * coaching_kind is 'bias_signal' (leg 3 of the bias-coaching design,
+ * BIAS-COACHING-PROPOSAL-2026-07-16 §2 FRAME beat; ratified cap ≤2 cards,
+ * enforced upstream in buildDraftBiasSignalBlocks).
+ *
+ * Structure reuses the V5CoachingBlock idiom (header icon + title, body,
+ * TargetRefPill refs, enum tokens as data-* only) but the styling follows
+ * the DS coaching-card recipe (DESIGN_SYSTEM.md "Coaching Cards (v4 §15)"):
+ * neutral bg-panel + coloured LEFT border (border-l-[3px] border-info),
+ * NOT the full-border idiom — the DS audit found all three live
+ * CoachingCard implementations (and V5CoachingBlock itself) contradict the
+ * recipe, and this card must not propagate that.
+ *
+ * Copy contract:
+ *   - title is the humanised bias name (allowlist-mapped upstream — a raw
+ *     wire code like `status_quo_bias` can never reach this component);
+ *   - body is the producer's detail verbatim;
+ *   - the grounded reference renders as a click-to-focus TargetRefPill
+ *     (fail-closed: inert when the node has left the canvas);
+ *   - coaching_kind / source / freshness / block_id ride as data-* only;
+ *   - info visual channel (coaching is facilitator-voice; never danger,
+ *     no "bias detected" banner language — est. #23 card doctrine).
+ */
+import { type ReactElement } from 'react'
+import { Lightbulb } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
+import type { V5CoachingBlock as V5CoachingBlockType } from '../../canvas/conversation/types'
+
+export interface BiasSignalCoachingCardProps {
+  block: V5CoachingBlockType
+}
+
+export function BiasSignalCoachingCard({ block }: BiasSignalCoachingCardProps): ReactElement {
+  return (
+    <div
+      data-testid="bias-signal-card"
+      data-block-id={block.block_id}
+      data-coaching-kind={block.coaching_kind}
+      data-coaching-source={block.source}
+      data-freshness={block.freshness}
+      className="bg-panel border-l-[3px] border-info rounded-lg px-4 py-3 space-y-2"
+    >
+      <div className="flex items-start gap-2">
+        <Lightbulb size={16} className="flex-none mt-0.5 text-info" aria-hidden="true" />
+        <h3 className={typography.panelHeader} data-testid="bias-signal-card-title">
+          {block.title}
+        </h3>
+      </div>
+      <p className={typography.panelBody} data-testid="bias-signal-card-body">
+        {block.body}
+      </p>
+      {block.target_refs.length > 0 && (
+        <div
+          className="flex flex-wrap gap-2"
+          role="list"
+          aria-label="Referenced elements"
+          data-testid="bias-signal-card-refs"
+        >
+          {block.target_refs.map((ref) => (
+            <TargetRefPill
+              key={ref.id}
+              role="listitem"
+              id={ref.id}
+              label={ref.label}
+              kind={ref.kind}
+              className={[
+                'inline-flex items-center rounded-full px-2.5 py-0.5',
+                'bg-transparent border border-panel-border text-text-body',
+                typography.panelMeta,
+              ].join(' ')}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default BiasSignalCoachingCard

--- a/src/v5/blocks/__tests__/BiasSignalCoachingCard.spec.tsx
+++ b/src/v5/blocks/__tests__/BiasSignalCoachingCard.spec.tsx
@@ -1,0 +1,172 @@
+/**
+ * Leg 3 (bias-coaching rendering slice) — DOM contract for
+ * BiasSignalCoachingCard and its InlineBlocks routing.
+ *
+ * Fixture provenance: block shapes mirror what buildDraftBiasSignalBlocks
+ * produces from the live-verified draft response on CEE staging (build
+ * 57959b2c3, 16 Jul 2026): `coaching.bias_signals` carrying
+ * `status_quo_bias` + `anchoring`, both grounded. Copy here is synthetic.
+ *
+ * Pinned behaviour:
+ *   1. DS coaching-card recipe (DESIGN_SYSTEM.md:256-264): bg-panel +
+ *      coloured LEFT border (border-l-[3px] border-info) + rounded-lg
+ *      px-4 py-3 — NOT the full-border idiom the three live CoachingCard
+ *      implementations use.
+ *   2. Humanised title and producer-verbatim body render; the grounded
+ *      reference label is visible.
+ *   3. coaching_kind / source / freshness ride as data-* only — no raw
+ *      code string (snake_case token) anywhere in visible text (sweep).
+ *   4. InlineBlocks routes coaching_kind 'bias_signal' to this card and
+ *      every other coaching_kind to the existing V5CoachingBlock
+ *      (structure reuse pinned in both directions).
+ *   5. Two blocks → two cards; the builder cap means never more than two
+ *      reach this renderer, pinned end-to-end via builder + InlineBlocks.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { BiasSignalCoachingCard } from '../BiasSignalCoachingCard'
+import { InlineBlocks } from '../../../canvas/conversation/InlineBlocks'
+import { buildDraftBiasSignalBlocks } from '../../../canvas/conversation/draftBiasSignalBlocks'
+import type { V5CoachingBlock as V5CoachingBlockType } from '../../../canvas/conversation/types'
+
+const BIAS_BLOCK: V5CoachingBlockType = {
+  type: 'v5_coaching',
+  block_id: 'draft_bias_signal_0',
+  title: 'Status quo bias',
+  body: 'The model leans on keeping the current supplier without weighing the switch on equal terms.',
+  coaching_kind: 'bias_signal',
+  source: 'draft_graph',
+  target_refs: [
+    { id: 'fac_current_supplier', label: 'Current supplier terms', kind: 'factor' },
+  ],
+  priority_rank: 1,
+  freshness: 'fresh',
+}
+
+const OTHER_COACHING_BLOCK: V5CoachingBlockType = {
+  type: 'v5_coaching',
+  block_id: '7e0855c7-d79d-5d16-9fee-19e68ece297d',
+  title: 'An assumption to check',
+  body: 'The relationship between supplier terms and cost remains stable.',
+  coaching_kind: 'assumption_check',
+  source: 'decision_review',
+  target_refs: [],
+  priority_rank: 2,
+  freshness: 'fresh',
+}
+
+describe('BiasSignalCoachingCard — DS coaching-card recipe', () => {
+  it('uses the DS recipe: bg-panel + coloured left border, no full border', () => {
+    render(<BiasSignalCoachingCard block={BIAS_BLOCK} />)
+    const card = screen.getByTestId('bias-signal-card')
+    expect(card.classList.contains('bg-panel')).toBe(true)
+    expect(card.classList.contains('border-l-[3px]')).toBe(true)
+    expect(card.classList.contains('border-info')).toBe(true)
+    expect(card.classList.contains('rounded-lg')).toBe(true)
+    expect(card.classList.contains('px-4')).toBe(true)
+    expect(card.classList.contains('py-3')).toBe(true)
+    // NOT the full-border idiom (the DS-audit non-compliance we must not propagate).
+    expect(card.classList.contains('border')).toBe(false)
+    expect(card.classList.contains('border-info/30')).toBe(false)
+    // Neutral background only — never a coloured card background.
+    expect([...card.classList].some((c) => /^bg-(info|warning|danger|success)/.test(c))).toBe(false)
+  })
+})
+
+describe('BiasSignalCoachingCard — copy contract', () => {
+  it('renders the humanised title, the producer body verbatim, and the grounded reference', () => {
+    render(<BiasSignalCoachingCard block={BIAS_BLOCK} />)
+    expect(screen.getByTestId('bias-signal-card-title')).toHaveTextContent('Status quo bias')
+    expect(screen.getByTestId('bias-signal-card-body')).toHaveTextContent(BIAS_BLOCK.body)
+    expect(screen.getByTestId('bias-signal-card-refs')).toHaveTextContent('Current supplier terms')
+  })
+
+  it('exposes coaching_kind / source / freshness as data-* only — never as visible copy', () => {
+    render(<BiasSignalCoachingCard block={BIAS_BLOCK} />)
+    const card = screen.getByTestId('bias-signal-card')
+    expect(card).toHaveAttribute('data-coaching-kind', 'bias_signal')
+    expect(card).toHaveAttribute('data-coaching-source', 'draft_graph')
+    expect(card).toHaveAttribute('data-freshness', 'fresh')
+    expect(card).toHaveAttribute('data-block-id', 'draft_bias_signal_0')
+    expect(card.textContent).not.toMatch(/bias_signal|draft_graph|\bfresh\b/)
+  })
+
+  it('sweep: no snake_case token ever appears in the visible text', () => {
+    render(<BiasSignalCoachingCard block={BIAS_BLOCK} />)
+    const card = screen.getByTestId('bias-signal-card')
+    expect(card.textContent).not.toMatch(/\b[a-z]+(?:_[a-z]+)+\b/)
+  })
+
+  it('renders no refs list when target_refs is empty (renders nothing invented)', () => {
+    render(<BiasSignalCoachingCard block={{ ...BIAS_BLOCK, target_refs: [] }} />)
+    expect(screen.queryByTestId('bias-signal-card-refs')).not.toBeInTheDocument()
+  })
+})
+
+describe('InlineBlocks routing — structure reuse pinned in both directions', () => {
+  it("routes coaching_kind 'bias_signal' to BiasSignalCoachingCard and other kinds to V5CoachingBlock", () => {
+    render(<InlineBlocks blocks={[BIAS_BLOCK, OTHER_COACHING_BLOCK]} />)
+    expect(screen.getAllByTestId('bias-signal-card')).toHaveLength(1)
+    expect(screen.getAllByTestId('v5-coaching')).toHaveLength(1)
+    // The non-bias coaching block still renders its own producer copy.
+    expect(screen.getByTestId('v5-coaching-title')).toHaveTextContent('An assumption to check')
+  })
+})
+
+describe('builder → InlineBlocks end-to-end (fixture wire shape)', () => {
+  const NODES = [
+    { id: 'fac_current_supplier', type: 'factor', data: { label: 'Current supplier terms' } },
+    { id: 'fac_initial_quote', type: 'factor', data: { label: 'Initial quote' } },
+    { id: 'opt_switch', type: 'option', data: { label: 'Switch supplier' } },
+  ]
+  const WIRE_SIGNALS = [
+    {
+      type: 'status_quo_bias',
+      detail: 'The model leans on keeping the current supplier without weighing the switch on equal terms.',
+      target: 'fac_current_supplier',
+    },
+    {
+      type: 'anchoring',
+      detail: 'Estimates cluster tightly around the initial quote rather than an independent range.',
+      target: 'fac_initial_quote',
+    },
+    {
+      type: 'sunk_cost',
+      detail: 'Past spend on the current contract is treated as a reason to continue.',
+      target: 'opt_switch',
+    },
+  ]
+
+  function buildFromWire(signals: typeof WIRE_SIGNALS) {
+    return buildDraftBiasSignalBlocks({
+      isDraftTurn: true,
+      store: {
+        draftCoaching: { summary: null, strengthenItems: [], wideningLog: [], biasSignals: signals },
+        nodes: NODES,
+      },
+      existingBlocks: [],
+    })
+  }
+
+  it('two signals → two DS-recipe cards', () => {
+    render(<InlineBlocks blocks={buildFromWire(WIRE_SIGNALS.slice(0, 2))} />)
+    const cards = screen.getAllByTestId('bias-signal-card')
+    expect(cards).toHaveLength(2)
+    for (const card of cards) {
+      expect(card.classList.contains('bg-panel')).toBe(true)
+      expect(card.classList.contains('border-l-[3px]')).toBe(true)
+    }
+  })
+
+  it('three signals → exactly two cards', () => {
+    render(<InlineBlocks blocks={buildFromWire(WIRE_SIGNALS)} />)
+    expect(screen.getAllByTestId('bias-signal-card')).toHaveLength(2)
+  })
+
+  it('sweep: raw wire codes never reach the rendered DOM', () => {
+    const { container } = render(<InlineBlocks blocks={buildFromWire(WIRE_SIGNALS)} />)
+    expect(container.textContent).not.toMatch(/status_quo_bias|anchoring_bias|sunk_cost|bias_signal/)
+    expect(container.textContent).not.toMatch(/\b[a-z]+(?:_[a-z]+)+\b/)
+  })
+})


### PR DESCRIPTION
Leg 3 of BIAS-COACHING-PROPOSAL-2026-07-16 (§2 FRAME beat): grounded bias signals from DRAFT responses now render as coaching cards on the conversation/draft surface, capped at 2 (ratified).

## Wire shape + fixture provenance

- Wire fact: draft responses carry `coaching.bias_signals: [{ type, detail, target? }]` at the response root (CEE build a555cf7b+; `CEEDraftCoachingWire`, `src/adapters/cee/types.ts`). Live-verified on CEE staging `57959b2c3` (16 Jul 2026): a 15-node draft carried `status_quo_bias` + `anchoring`, both grounded.
- Fixtures mirror that verified shape (codes + grounded targets); labels/ids/prose are synthetic. Provenance is noted in both spec headers. No wire test was run for this PR — fixtures are sufficient per the lane brief.
- Typed path, not a sidecar: the 0.15.0 boundary schema already types the coaching block with `coaching_kind: 'bias_signal'` in its enum (`@talchain/schemas` boundary blocks). The bridge emits standard `v5_coaching` conversation blocks with that kind, so when CEE starts emitting real boundary coaching blocks for bias signals the same block type and renderer carry them — and the bridge stands down (producer-wins rule below).

## How it works

`buildDraftBiasSignalBlocks` (new, pure) runs at the same seam as the model receipt (`maybeBuildModelReceiptBlock` precedent) on the V5 turn that applied a fresh draft graph, after `applyDraftResult` has committed `draftCoaching` to the store synchronously. It emits ≤2 typed `v5_coaching` blocks: humanised title from a known-code allowlist, producer `detail` verbatim as the body, grounded reference resolved against the live graph and rendered as a click-to-focus `TargetRefPill`. `InlineBlocks` routes `coaching_kind === 'bias_signal'` to the new `BiasSignalCoachingCard`; every other coaching kind renders through the existing `V5CoachingBlock`, unchanged.

## Fail-closed matrix (each row pinned + mutation-checked)

| Input | Rendered |
|---|---|
| 2 grounded signals | 2 DS-recipe cards |
| 3+ grounded signals | exactly 2 (wire order; dropped entries do not consume slots) |
| Not a draft turn | nothing |
| `coaching` absent / `bias_signals` empty | nothing |
| Unknown bias code (not on the allowlist) | nothing for that signal (never sentence-cased into copy) |
| Entity-id-shaped code (`fac_*` etc.) | nothing for that signal |
| Malformed entry (non-object, blank/non-string type or detail) | nothing for that entry, no crash |
| Ungrounded (missing / unresolvable / blank-label target) | nothing for that entry |
| Producer-typed `v5_coaching` with kind `bias_signal` already on the turn | bridge yields nothing (producer wins, never doubled cards) |
| Raw code strings (`status_quo_bias`, …) | never visible — sweep pin across the full allowlist + rendered DOM |

Mutation checks: 11 mutations (cap 2→3, raw-code title, sentence-case unknown codes, drop detail guard, fabricate ungrounded ref, remove draft-turn gate, fabricate fallback card on empty, remove producer-wins, full-border restyle, remove InlineBlocks routing, leak enum into copy) — every one turned the suite RED (1–8 failures each), then restored to GREEN.

## DS-recipe compliance note

- Built on the STRUCTURE of `V5CoachingBlock` (header icon + title, verbatim body, `TargetRefPill` refs, enum tokens as `data-*` only).
- Styled per the DS coaching-card recipe (DESIGN_SYSTEM.md:256-264): `bg-panel border-l-[3px] border-info rounded-lg px-4 py-3` — neutral background, coloured LEFT border. Pinned (including the absence of the full-border idiom).
- Discrepancy flagged, not fixed: the three live `CoachingCard` implementations all contradict the recipe — `src/canvas/components/CoachingCard.tsx` (full `border border-{colour}/30`), `src/canvas/components/model-tab/CoachingCard.tsx` (`bg-panel-hover`, no coloured border), `src/canvas/ui/inspector-v2/shared/CoachingCard.tsx` (inline full 1px border). `V5CoachingBlock` itself also uses the full-border idiom. None were changed here; this card does not propagate the non-compliance.

## Row-21 answer (estate table)

This slice references NONE of: `ceeDataAdapter.extractInsights`, the `bias_check` placeholder path, `BiasAlertIcon`, `InsightsTab`/`GuidancePanel`. Verified by sweep over the full branch diff (zero matches). CEE's deletion PR on those items is unblocked by this lane.

## Tests

- `src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts` — 17 tests (builder pins).
- `src/canvas/conversation/__tests__/BiasSignalCoachingCard.spec.tsx` — 9 tests (DOM contract, DS recipe, routing, builder→InlineBlocks end-to-end, sweeps).
- RED-first: pushed failing at `ed13a789`, green at `58f5392c`.
- Adjacent suites green: InlineBlocks.dsv5, V5Phase3Blocks, phase3 bridge specs (typed + legacy + live fixture), ModelReceiptBlock, modelCardAdapter, MixedBlocks integration, BlockFallback, blockSchemaAlignment — 118 tests in the final combined run.

## Typechecks (both, matched worktrees)

- `pnpm typecheck` (`tsc -p tsconfig.ci.json --noEmit`): exit 0 on this branch AND on a matched base worktree at `bf921314` (own `pnpm install`, no root node_modules symlink).
- `tsc -p tsconfig.app.json --noEmit`: base 2316 errors, branch 2316 errors; position-normalised error multisets IDENTICAL (raw diff shows only line-number drift inside `useConversation.ts` from the two insertions). All four new files are inside the app program (verified via `--listFilesOnly`) and contribute zero errors.
- Found and fixed in-flight: the card spec originally lived under `src/v5/blocks/__tests__/`, which `tsconfig.ci.json` includes via `src/v5/**` — importing `InlineBlocks` from there widened the CI gate's program and surfaced ~100 pre-existing errors the gate normally excludes. Moved the spec next to the other InlineBlocks specs (outside the gate); the component itself mirrors `V5CoachingBlock`'s import surface and adds nothing new to the gate.

## Scope

No changes to OutputsDock, AnalysisFreshnessNotice, useAnalysisTrust/useAnalysisStateSource, or results/*. decision_review v15 copy was not used to calibrate any pin (fixtures are draft-wire-shaped, not review copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
