### PR TITLE
fix(v5): entity refs focus the canvas — the inert-pill remainder (F4)

### DIFF
--- a/src/canvas/conversation/components/TargetRefPill.tsx
+++ b/src/canvas/conversation/components/TargetRefPill.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback } from 'react'
+import type { Edge, Node } from '@xyflow/react'
 import { useCanvasStore } from '../../store'
 import { focusByTarget } from '../../utils/focusHelpers'
 
@@ -6,11 +7,26 @@ import { focusByTarget } from '../../utils/focusHelpers'
 // change targets) that pans + highlights its canvas element on click.
 //
 // Fail-closed contract (UI-SEAMLESSNESS-REVIEW R1/R3): the pill is clickable
-// ONLY while the referenced element exists on the canvas — checked against
-// the canvas store at render time, scoped by kind (edge ids never resolve
-// against nodes and vice versa). When the target is stale/unknown the pill
-// renders as the same inert <span> it was before this component existed, so
-// a dead reference never advertises an affordance it can't honour.
+// ONLY while the referenced element resolves to exactly one canvas element,
+// checked against the canvas store at render time and scoped by kind (edge
+// refs never resolve against nodes and vice versa). When the target is
+// stale, unknown, or ambiguous the pill renders as the same inert <span> it
+// was before this component existed, so a dead reference never advertises an
+// affordance it can't honour.
+//
+// Resolution (F4, 16-Jul feedback item 2) follows the ratified string-target
+// rule the R3 proposal badges already use:
+//   - non-edge kinds: exact canvas node id, else a UNIQUE exact trimmed
+//     case-sensitive node-label match, else inert.
+//   - edge kind: exact canvas edge id, else a UNIQUE producer edge id
+//     stashed on edge.data (edge_id / plot_edge_id / plot_id, the
+//     focusModelTarget and idMapping conventions; canvas edge ids are
+//     locally generated and rarely match producer ids), else inert. Edge
+//     labels are derived weight/belief text, not identity, so labels never
+//     resolve edges.
+// Resolution is render-time, not ingest-time: the store subscription means
+// labels that drift while a block sits on screen re-resolve, and a pill
+// never points at a guess. Ambiguity always fails closed.
 //
 // When the target exists but ReactFlow is not mounted (no focus handler
 // registered), a click warns and no-ops inside focusHelpers — identical to
@@ -37,6 +53,42 @@ export interface TargetRefPillProps {
 const INTERACTIVE_CLASSES =
   'cursor-pointer hover:border-info/50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-info'
 
+/**
+ * Resolve a non-edge ref to a canvas node id: exact id, else UNIQUE exact
+ * trimmed case-sensitive label, else null (inert).
+ */
+function resolveNodeTarget(nodes: Node[], id: string, label: string): string | null {
+  if (nodes.some((n) => n.id === id)) return id
+  const wanted = label.trim()
+  if (!wanted) return null
+  let found: string | null = null
+  for (const n of nodes) {
+    const l = (n.data as Record<string, unknown> | undefined)?.label
+    if (typeof l === 'string' && l.trim() === wanted) {
+      if (found !== null) return null
+      found = n.id
+    }
+  }
+  return found
+}
+
+/**
+ * Resolve an edge ref to a canvas edge id: exact canvas id, else a UNIQUE
+ * producer id stashed on edge.data, else null (inert).
+ */
+function resolveEdgeTarget(edges: Edge[], id: string): string | null {
+  if (edges.some((e) => e.id === id)) return id
+  let found: string | null = null
+  for (const e of edges) {
+    const d = e.data as Record<string, unknown> | undefined
+    if (d && (d.edge_id === id || d.plot_edge_id === id || d.plot_id === id)) {
+      if (found !== null) return null
+      found = e.id
+    }
+  }
+  return found
+}
+
 export const TargetRefPill = memo(function TargetRefPill({
   id,
   label,
@@ -45,17 +97,20 @@ export const TargetRefPill = memo(function TargetRefPill({
   role,
 }: TargetRefPillProps) {
   const isEdge = kind === 'edge'
-  const exists = useCanvasStore((s) =>
-    isEdge ? s.edges.some((e) => e.id === id) : s.nodes.some((n) => n.id === id),
+  // Selector returns a primitive (string | null), so the pill re-renders
+  // only when its own resolution changes, never on unrelated store churn
+  // (node drags update the nodes array identity every frame).
+  const resolvedId = useCanvasStore((s) =>
+    isEdge ? resolveEdgeTarget(s.edges, id) : resolveNodeTarget(s.nodes, id, label),
   )
 
   const handleClick = useCallback(() => {
     // Same kind collapse as EntityLink: all non-edge targets are canvas
     // nodes. Reduced-motion is handled inside the focus helper.
-    focusByTarget(id, isEdge ? 'edge' : 'node')
-  }, [id, isEdge])
+    if (resolvedId) focusByTarget(resolvedId, isEdge ? 'edge' : 'node')
+  }, [resolvedId, isEdge])
 
-  if (!exists) {
+  if (!resolvedId) {
     return (
       <span
         {...(role ? { role } : {})}
@@ -78,6 +133,7 @@ export const TargetRefPill = memo(function TargetRefPill({
         onClick={handleClick}
         data-ref-id={id}
         data-ref-kind={kind}
+        data-resolved-id={resolvedId}
         data-testid={`target-ref-pill-${id}`}
         aria-label={`Highlight ${label} on the canvas`}
         className={[className, INTERACTIVE_CLASSES].filter(Boolean).join(' ')}

--- a/src/canvas/conversation/components/__tests__/TargetRefPill.resolution.spec.tsx
+++ b/src/canvas/conversation/components/__tests__/TargetRefPill.resolution.spec.tsx
@@ -1,0 +1,233 @@
+/**
+ * F4 (16-Jul feedback item 2): the inert-pill remainder.
+ *
+ * PR #256 shipped click-to-focus for target_refs pills, resolving by exact
+ * canvas id only. The ratified string-target rule (exact id, else UNIQUE
+ * exact trimmed case-sensitive label, else inert fail-closed) was applied to
+ * the R3 proposal badges but never to the contract ref pills themselves, and
+ * #256's own report filed "edge-kind refs inert in practice (canvas edge ids
+ * never match producer ids)" as an unshipped follow-up.
+ *
+ * This spec pins the ratified resolution inside TargetRefPill:
+ *   - non-edge kinds: exact node id, else UNIQUE exact trimmed
+ *     case-sensitive node-label match, else inert.
+ *   - edge kind: exact canvas edge id, else UNIQUE producer edge id stashed
+ *     on edge.data (edge_id / plot_edge_id / plot_id, the focusModelTarget
+ *     and idMapping conventions), else inert. Edge labels are derived
+ *     weight/belief text, not identity, so labels never resolve edges.
+ *
+ * Resolution is render-time (store subscription), matching the reviewed R3
+ * rationale: labels drift while blocks sit on screen, and a pill must never
+ * point at a guess. Ambiguity always fails closed.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+const { focusByTargetMock } = vi.hoisted(() => ({ focusByTargetMock: vi.fn() }))
+vi.mock('../../../utils/focusHelpers', () => ({
+  focusByTarget: focusByTargetMock,
+}))
+
+import { TargetRefPill } from '../TargetRefPill'
+import { useCanvasStore } from '../../../store'
+
+const PILL_CLASSES =
+  'inline-flex items-center rounded-full px-2.5 py-0.5 bg-transparent border border-panel-border text-text-body'
+
+function node(id: string, label: string) {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label } } as any
+}
+
+beforeEach(() => {
+  focusByTargetMock.mockReset()
+  useCanvasStore.setState({ nodes: [], edges: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  useCanvasStore.setState({ nodes: [], edges: [] })
+})
+
+describe('TargetRefPill node-label resolution (ratified rule leg 2)', () => {
+  it('positive control: an exact-id ref is clickable and focuses that id', () => {
+    useCanvasStore.setState({ nodes: [node('n1', 'Conversion Rate')], edges: [] })
+    render(
+      <TargetRefPill id="n1" label="Conversion Rate" kind="factor" className={PILL_CLASSES} />,
+    )
+    screen.getByRole('button').click()
+    expect(focusByTargetMock).toHaveBeenCalledWith('n1', 'node')
+  })
+
+  it('resolves an unknown id via a UNIQUE exact label match and focuses the RESOLVED canvas id', () => {
+    useCanvasStore.setState({
+      nodes: [node('n1', 'Conversion Rate'), node('n2', 'Churn')],
+      edges: [],
+    })
+    render(
+      <TargetRefPill
+        id="fac_conversion_rate"
+        label="Conversion Rate"
+        kind="factor"
+        className={PILL_CLASSES}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: /highlight conversion rate on the canvas/i })
+    // Producer identity is preserved for diagnostics; the resolved canvas id
+    // is exposed alongside it.
+    expect(btn).toHaveAttribute('data-ref-id', 'fac_conversion_rate')
+    expect(btn).toHaveAttribute('data-resolved-id', 'n1')
+    btn.click()
+    expect(focusByTargetMock).toHaveBeenCalledWith('n1', 'node')
+  })
+
+  it('label matching is trimmed on both sides', () => {
+    useCanvasStore.setState({ nodes: [node('n1', '  Conversion Rate ')], edges: [] })
+    render(
+      <TargetRefPill
+        id="fac_conversion_rate"
+        label="Conversion Rate  "
+        kind="factor"
+        className={PILL_CLASSES}
+      />,
+    )
+    screen.getByRole('button').click()
+    expect(focusByTargetMock).toHaveBeenCalledWith('n1', 'node')
+  })
+
+  it('an AMBIGUOUS label (two nodes share it) stays inert, fail-closed', () => {
+    useCanvasStore.setState({
+      nodes: [node('n1', 'Conversion Rate'), node('n2', 'Conversion Rate')],
+      edges: [],
+    })
+    render(
+      <TargetRefPill
+        id="fac_conversion_rate"
+        label="Conversion Rate"
+        kind="factor"
+        className={PILL_CLASSES}
+      />,
+    )
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Conversion Rate').tagName).toBe('SPAN')
+    expect(focusByTargetMock).not.toHaveBeenCalled()
+  })
+
+  it('label matching is case-sensitive: a case-differing label stays inert', () => {
+    useCanvasStore.setState({ nodes: [node('n1', 'conversion rate')], edges: [] })
+    render(
+      <TargetRefPill
+        id="fac_conversion_rate"
+        label="Conversion Rate"
+        kind="factor"
+        className={PILL_CLASSES}
+      />,
+    )
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Conversion Rate').tagName).toBe('SPAN')
+  })
+
+  it('an unknown id with no label match stays inert', () => {
+    useCanvasStore.setState({ nodes: [node('n1', 'Churn')], edges: [] })
+    render(
+      <TargetRefPill id="ghost" label="Deleted thing" kind="factor" className={PILL_CLASSES} />,
+    )
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Deleted thing').tagName).toBe('SPAN')
+  })
+
+  it('re-resolves at render time: a label-resolved pill goes inert after the node is renamed', () => {
+    useCanvasStore.setState({ nodes: [node('n1', 'Conversion Rate')], edges: [] })
+    const { rerender } = render(
+      <TargetRefPill
+        id="fac_conversion_rate"
+        label="Conversion Rate"
+        kind="factor"
+        className={PILL_CLASSES}
+      />,
+    )
+    expect(screen.getByRole('button')).toBeInTheDocument()
+    useCanvasStore.setState({ nodes: [node('n1', 'Renamed Factor')], edges: [] })
+    rerender(
+      <TargetRefPill
+        id="fac_conversion_rate"
+        label="Conversion Rate"
+        kind="factor"
+        className={PILL_CLASSES}
+      />,
+    )
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Conversion Rate').tagName).toBe('SPAN')
+  })
+})
+
+describe('TargetRefPill edge producer-id resolution (the #256 filed follow-up)', () => {
+  it('positive control: an exact canvas edge id is clickable', () => {
+    useCanvasStore.setState({
+      nodes: [],
+      edges: [{ id: 'e1', source: 'a', target: 'b' } as any],
+    })
+    render(<TargetRefPill id="e1" label="Influence" kind="edge" className={PILL_CLASSES} />)
+    screen.getByRole('button').click()
+    expect(focusByTargetMock).toHaveBeenCalledWith('e1', 'edge')
+  })
+
+  it.each(['edge_id', 'plot_edge_id', 'plot_id'] as const)(
+    'resolves a producer edge id stashed on edge.data.%s to the canvas edge id',
+    (dataKey) => {
+      useCanvasStore.setState({
+        nodes: [],
+        edges: [
+          { id: 'e-0', source: 'a', target: 'b', data: { [dataKey]: 'price::demand::0' } } as any,
+        ],
+      })
+      render(
+        <TargetRefPill
+          id="price::demand::0"
+          label="Price to Demand"
+          kind="edge"
+          className={PILL_CLASSES}
+        />,
+      )
+      const btn = screen.getByRole('button')
+      expect(btn).toHaveAttribute('data-ref-id', 'price::demand::0')
+      expect(btn).toHaveAttribute('data-resolved-id', 'e-0')
+      btn.click()
+      expect(focusByTargetMock).toHaveBeenCalledWith('e-0', 'edge')
+    },
+  )
+
+  it('an AMBIGUOUS producer edge id (two edges claim it) stays inert, fail-closed', () => {
+    useCanvasStore.setState({
+      nodes: [],
+      edges: [
+        { id: 'e-0', source: 'a', target: 'b', data: { edge_id: 'dup' } } as any,
+        { id: 'e-1', source: 'b', target: 'c', data: { edge_id: 'dup' } } as any,
+      ],
+    })
+    render(<TargetRefPill id="dup" label="Duplicated" kind="edge" className={PILL_CLASSES} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Duplicated').tagName).toBe('SPAN')
+    expect(focusByTargetMock).not.toHaveBeenCalled()
+  })
+
+  it('edge refs never resolve by label (derived weight text is not identity)', () => {
+    useCanvasStore.setState({
+      nodes: [node('n1', 'Influence')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', label: 'Influence' } as any],
+    })
+    render(<TargetRefPill id="ghost" label="Influence" kind="edge" className={PILL_CLASSES} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Influence').tagName).toBe('SPAN')
+  })
+
+  it('kind scoping still holds: a node-kind ref never resolves against edges', () => {
+    useCanvasStore.setState({
+      nodes: [],
+      edges: [{ id: 'shared', source: 'a', target: 'b' } as any],
+    })
+    render(<TargetRefPill id="shared" label="Mislabelled" kind="factor" className={PILL_CLASSES} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Mislabelled').tagName).toBe('SPAN')
+  })
+})


### PR DESCRIPTION
## Re-verification result (mandatory first step — the brief's premise was partially stale)

The brief (16-Jul feedback item 2) says the four V5 block renderers show `target_refs` as inert spans. At `bf921314` that is no longer true:

**Already live before this PR:**
- PR #256 (10 Jul) shipped `TargetRefPill` click-to-focus wired into all four phase-3 renderers (`V5ReviewCardBlock`, `V5CoachingBlock`, `V5EvidenceBlock`, `V5ExerciseBlock`), keyboard-reachable native buttons, fail-closed inert spans for unknown ids, kind-scoped resolution.
- PR #267 (12 Jul) fixed the extractor: `guidanceTargetType` in `extractPhase3FromV5Response.ts` reads contract `kind` first with the full vocabulary (factor|option|edge|goal|risk|constraint|outcome), legacy `type` as fallback only. The 15-Jul ledger note about `target_refs[0].type` is stale at tip — no extractor fix was needed.
- Reduced motion is honoured inside the focus seam (`useFocusCamera`, F1) — untouched here; this PR only changes which id reaches it.

**The genuinely-inert remainder (what this PR ships):**
`TargetRefPill` resolved by exact canvas id only. The ratified string-target rule (exact id, else UNIQUE exact trimmed case-sensitive label, else inert fail-closed) was applied to the R3 proposal badges in #256 but never to the contract ref pills themselves — and #256's own report filed "edge-kind refs inert in practice (canvas edge ids never match producer ids)" as a follow-up that never landed. So:
- a node ref whose producer id (`fac_conversion_rate`) is not a canvas id stayed inert even when its label uniquely named one node;
- edge refs were inert in practice (canvas edge ids are locally generated).

## Change

One file: `src/canvas/conversation/components/TargetRefPill.tsx`.
- Non-edge kinds: exact node id, else UNIQUE exact trimmed case-sensitive node-label match, else inert.
- Edge kind: exact canvas edge id, else UNIQUE producer id stashed on `edge.data` (`edge_id` / `plot_edge_id` / `plot_id` — the `focusModelTarget` and `idMapping` conventions), else inert. Edge labels are derived weight text, never identity, so labels never resolve edges.
- Resolution is render-time (dedupe-at-ingest was considered and rejected: labels drift while a block sits on screen, and a pill must never point at a guess — same reviewed rationale as the R3 resolver). The store selector returns a primitive so pills do not re-render on node drags.
- Ambiguity always fails closed. Producer identity kept on `data-ref-id`; resolved canvas id exposed as `data-resolved-id`.

## Tests (RED-first, mutation-checked)

- `TargetRefPill.resolution.spec.tsx`: 14 pins — positive controls (exact id node/edge), unique-label resolution to the RESOLVED id, trim pin, case-sensitivity pin, ambiguity pins (label ×2 nodes; producer edge id ×2 edges), unknown-ref inert, edge-never-by-label pin, kind-scoping pin, render-time re-resolution (rename → inert).
- RED commit `b69c4b09`: 6 failed / 8 passed before the fix.
- Mutation check (throwaway worktree, fix reverted to origin/staging): exactly the 6 resolution pins go red — the pins bite.
- `npx vitest run --changed origin/staging`: 623 passed, 0 failed (9 pre-existing skips).

## Typechecks (both, per trap 2)

- `pnpm typecheck` (= `tsc -p tsconfig.ci.json --noEmit`): clean. Named caveat: this config covers only a small file set.
- `tsc -p tsconfig.app.json --noEmit`, lane vs matched base worktree at `bf921314`: 4025 error lines each, sorted multisets byte-identical — zero new errors.

## Real-browser proof (lane build, Vite dev server, `/#/canvas`)

Canvas seeded via the sanctioned E2E seam (`window.useCanvasStore`); the REAL `TargetRefPill` module mounted through Vite's dev module graph (same store singleton, same registered focus handlers as the page):
- exact-id pill → button, click selects + pans to the node (path lens engages, inspector context switches);
- producer-id node ref (`fac_conversion_rate`, label "Conversion Rate") → resolved to `n2`, click selects + pans to it; "Selected: Conversion Rate" visible in the dock;
- producer edge id (`conversion::revenue::0` on `edge.data.edge_id`) → resolved to canvas edge `e-0`, click selects it;
- unknown ref and ambiguous label → inert spans, absent from the accessibility tree, no dead affordance.

Honest caveats: (1) the pills were mounted in an overlay, not rendered from a live CEE conversation turn — no CEE backend in the loop; the renderer→pill wiring is pinned by the existing jsdom suites (`V5Phase3Blocks.spec`). (2) Keyboard: the pill is focusable with the correct aria-label and is a native `<button type="button">`; the browser harness's synthetic Enter dispatch reached the focused pill (trusted keydown, not default-prevented) but did not run default activation — a harness limitation, so keyboard activation rests on native button semantics plus the jsdom click pins, not on an observed real-browser Enter.

## Scope walls respected

No changes to conversation/draft coaching-card rendering, OutputsDock chrome, Compare/Model tab bodies, `StyledEdge`/`cvdContrast`, or the R3 proposal-badge resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
