### PR TITLE
fix(results): guard the bands-less hydrated report crash (#353) + honest What-changed placeholder (F15)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1128,7 +1128,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   }, [nodes, edges, applyAutoFixChanges])
 
   const canonicalBands = report?.run?.bands ?? null
-  const mostLikelyValue = canonicalBands ? canonicalBands.p50 : report?.results.likely ?? null
+  // #353: `.results` must be optional-chained too — a Supabase-hydrated
+  // report can lack the bands block entirely (the hydration invariant checks
+  // only `status === 'complete' && report`), and the unguarded read
+  // hard-crashed the whole canvas. Fail closed to null (verdict below
+  // already treats null as "no value"); never fabricate a number.
+  const mostLikelyValue = canonicalBands ? canonicalBands.p50 : report?.results?.likely ?? null
   // Lane 3 (SF2): the retained report keeps RENDERING through every status —
   // resultsStart/resultsAnalysing/resultsError/resultsCancelled all preserve
   // `results.report` by contract ("so UI doesn't flash empty"), but the old

--- a/src/canvas/components/__tests__/OutputsDock.bandslessReport.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.bandslessReport.spec.tsx
@@ -1,0 +1,193 @@
+/**
+ * Issue #353 — a bands-less hydrated report must not hard-crash the canvas.
+ *
+ * Live repro (2026-07-15, PR #352 browser acceptance): a Supabase-hydrated
+ * report carrying only `option_comparison`/`option_probabilities` — no
+ * `results` bands block, no `run.bands` — threw
+ * `Cannot read properties of undefined (reading 'likely')` at
+ * OutputsDock.tsx:1131 (`report?.results.likely` guards `report` but not
+ * `.results`) and took the whole canvas down to the error-boundary screen.
+ *
+ * The hydration invariant (`resultsHydrateFromSupabase`) checks ONLY
+ * `status === 'complete' && report` — nothing upstream guarantees the bands
+ * block, so the dock must fail closed at the read: `mostLikelyValue`
+ * becomes null (the same honest absent treatment the neighbouring
+ * `verdict = mostLikelyValue !== null ? … : null` already takes), never a
+ * fabricated value, never a throw.
+ *
+ * Harness mirrors OutputsDock.rerunContinuity.spec.tsx (proven to mount
+ * OutputsDockBody, where line 1131 executes unconditionally). ResultsBody is
+ * stub-mocked so this spec pins exactly the dock-owned read, not descendant
+ * readers (which were verified guarded — see PR body).
+ */
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { act } from 'react'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+
+const { mockUseV2Run, mockShowToast } = vi.hoisted(() => ({
+  mockUseV2Run: vi.fn(() => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() })),
+  mockShowToast: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => true,
+    isJourneyTabEnabled: vi.fn(() => false),
+    isV5CanonicalAnalysisEnabled: vi.fn(() => false),
+  }
+})
+
+vi.mock('../../hooks/useV2Run', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useV2Run')>()
+  return { ...actual, useV2Run: () => mockUseV2Run() }
+})
+
+vi.mock('../../ToastContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../ToastContext')>()
+  return {
+    ...actual,
+    useShowToast: () => mockShowToast,
+    useShowToastSafe: () => mockShowToast,
+  }
+})
+
+vi.mock('../pre-analysis/hooks/usePreAnalysisData', () => ({
+  usePreAnalysisData: () => ({}),
+}))
+
+vi.mock('../../hooks/useGraphReadiness', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useGraphReadiness')>()
+  return {
+    ...actual,
+    useGraphReadiness: () => ({ readiness: null, loading: false, error: null, refresh: vi.fn() }),
+  }
+})
+
+vi.mock('../pre-analysis', () => ({
+  PreAnalysisPanel: () => <div data-testid="pre-analysis-stub" />,
+}))
+
+vi.mock('../../../components/results/ResultsBody', () => ({
+  ResultsBody: () => <div data-testid="mock-results-body" />,
+}))
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+/**
+ * The exact defect shape from #353: a real hydrated report with NO `results`
+ * block and NO `run.bands` — only the option-level blocks the live repro
+ * carried. Do not "complete" this fixture: its incompleteness IS the pin.
+ */
+const bandslessHydratedReport: Record<string, unknown> = {
+  schema: 'report.v1',
+  meta: { seed: null, response_id: 'resp-353', elapsed_ms: 1200 },
+  model_card: { response_hash: 'hash-353', response_hash_algo: 'sha256', normalized: true },
+  option_probabilities: {
+    'opt-a': { goal_probability: 0.62, confidence: 0.8, win_probability: 0.7 },
+    'opt-b': { goal_probability: 0.41, confidence: 0.75, win_probability: 0.3 },
+  },
+  option_comparison: [
+    { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.7 },
+    { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.3 },
+  ],
+}
+
+function seedGraph() {
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+      { id: 'factor-1', type: 'factor', data: { label: 'Factor', kind: 'factor' }, position: { x: 100, y: 0 } },
+    ],
+    edges: [{ id: 'e1', source: 'factor-1', target: 'goal-1', data: { weight: 0.7, direction: 'positive' } }],
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    ceeAnalysisReady: { goal_node_id: 'goal-1', options: [{ id: 'opt-a', label: 'A', interventions: {} }] },
+    showDraftChat: false,
+  } as never)
+}
+
+function renderDock() {
+  return render(
+    <ConversationProvider>
+      <OutputsDock />
+    </ConversationProvider>,
+  )
+}
+
+describe('OutputsDock bands-less hydrated report (#353)', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    vi.clearAllMocks()
+    mockUseV2Run.mockReturnValue({ runV2Analysis: vi.fn(), cancelRun: vi.fn() })
+    seedGraph()
+  })
+
+  afterEach(() => {
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 },
+      hasCompletedFirstRun: false,
+    } as never)
+  })
+
+  it('POSITIVE CONTROL: the hydration invariant ADMITS the bands-less report (nothing upstream guarantees the bands block)', () => {
+    act(() => {
+      useCanvasStore.getState().resultsHydrateFromSupabase({
+        results: { status: 'complete', progress: 100, report: bandslessHydratedReport },
+        runMeta: {},
+      } as never)
+    })
+
+    const { results } = useCanvasStore.getState()
+    expect(results.status).toBe('complete')
+    expect(results.report).toBe(bandslessHydratedReport)
+    // The defect precondition, asserted so this spec fails loud if a future
+    // upstream guarantee makes the render-side pin vacuous.
+    expect((results.report as Record<string, unknown>).results).toBeUndefined()
+    expect((results.report as Record<string, unknown>).run).toBeUndefined()
+  })
+
+  it('renders the dock WITHOUT throwing on the bands-less report, keeping the results body mounted (fail closed, no fabricated value)', () => {
+    act(() => {
+      useCanvasStore.getState().resultsHydrateFromSupabase({
+        results: { status: 'complete', progress: 100, report: bandslessHydratedReport },
+        runMeta: {},
+      } as never)
+    })
+
+    // Pre-fix this throws `Cannot read properties of undefined (reading
+    // 'likely')` from OutputsDock.tsx:1131 — the whole-canvas crash of #353.
+    expect(() => renderDock()).not.toThrow()
+
+    // The honest treatment: the body stays mounted (retained-report
+    // contract), it does not blank or fall back to the pre-analysis panel.
+    expect(screen.getByTestId('results-body-stale-wrapper')).toBeInTheDocument()
+    expect(screen.queryByTestId('pre-analysis-stub')).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.bandslessReport.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.bandslessReport.spec.tsx
@@ -169,8 +169,8 @@ describe('OutputsDock bands-less hydrated report (#353)', () => {
     expect(results.report).toBe(bandslessHydratedReport)
     // The defect precondition, asserted so this spec fails loud if a future
     // upstream guarantee makes the render-side pin vacuous.
-    expect((results.report as Record<string, unknown>).results).toBeUndefined()
-    expect((results.report as Record<string, unknown>).run).toBeUndefined()
+    expect((results.report as unknown as Record<string, unknown>).results).toBeUndefined()
+    expect((results.report as unknown as Record<string, unknown>).run).toBeUndefined()
   })
 
   it('renders the dock WITHOUT throwing on the bands-less report, keeping the results body mounted (fail closed, no fabricated value)', () => {

--- a/src/components/results/analysis-hero/__tests__/content.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/content.spec.tsx
@@ -462,8 +462,12 @@ describe('AnalysisHeroPanel — content', () => {
     expect(screen.queryByTestId('hero-option-row-1')).toBeNull()
     expect(screen.queryByTestId('hero-caption')).toBeNull()
     fireEvent.click(screen.getByTestId('hero-lens-tab-whatChanged'))
+    // F15: the placeholder must name the real dependency (producer-versioned
+    // run comparisons, PLoT #212) in the ratified honest-unavailable
+    // register, and must never read as a session-local unlock or promise a
+    // local approximation.
     expect(screen.getByTestId('hero-lens-unavailable')).toHaveTextContent(
-      'This view compares runs. It unlocks when the analysis can report what changed between runs.',
+      'Run comparison is not available yet. This unlocks with versioned run comparisons. Olumi will not approximate it locally.',
     )
   })
 

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -53,8 +53,14 @@ export const HERO_COPY = {
     outcome: 'Likely outcome is not available for this run.',
     stability:
       'This view needs per-option stability data, which the analysis does not provide yet.',
+    /**
+     * F15: names the real dependency (producer-versioned run comparisons,
+     * PLoT #212) in the ratified honest-unavailable register. Must never
+     * read as a session-local unlock, and must state that Olumi will not
+     * approximate the comparison locally (no client-side run diffing).
+     */
     whatChanged:
-      'This view compares runs. It unlocks when the analysis can report what changed between runs.',
+      'Run comparison is not available yet. This unlocks with versioned run comparisons. Olumi will not approximate it locally.',
   } as const,
 
   headline: {


### PR DESCRIPTION
Two tiny, disjoint, user-visible fixes. One clearly-labelled commit per fix (plus one typecheck-parity follow-up to the #353 spec). DO NOT MERGE without adversarial review.

## Fix 1 — #353: bands-less hydrated report hard-crashed the canvas

`OutputsDock.tsx:1131` read `report?.results.likely` — `report` guarded, `.results` not. A Supabase-hydrated report lacking the bands block threw `Cannot read properties of undefined (reading 'likely')` and took the whole canvas to the error-boundary screen (reproduced live during PR #352 browser acceptance). The hydration invariant (`resultsHydrateFromSupabase`) checks only `status === 'complete' && report`, so nothing upstream guarantees the bands block.

**Fix:** optional-chain `.results`, failing closed to `null` — the adjacent `verdict = mostLikelyValue !== null ? … : null` already carries the honest absent treatment. No value is fabricated.

**Crash repro shape** (the exact fixture in the regression spec — a real hydrated report carrying only the option-level blocks):

```ts
{
  schema: 'report.v1',
  meta: { seed: null, response_id: 'resp-353', elapsed_ms: 1200 },
  model_card: { response_hash: 'hash-353', response_hash_algo: 'sha256', normalized: true },
  option_probabilities: { 'opt-a': { goal_probability: 0.62, confidence: 0.8, win_probability: 0.7 }, … },
  option_comparison: [ { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.7 }, … ],
  // NO `results` block, NO `run.bands`
}
```

**Sibling sweep** (the issue's other named readers, checked at bf921314): all already guarded —
- `DecisionSummary.tsx:231` — guarded by `if (!report?.results) return null` at line 229
- `RecommendationCard/index.tsx:184` — fully optional-chained (`results?.report?.results?.likely`)
- `CompareView.tsx:197` — inside a `report?.summary ?` ternary at line 192 (different field class anyway: `summary`, stored-run shape)

`OutputsDock.tsx:1131` was the ONLY unguarded member of the class; a repo-wide grep of `report?.results.` / `report.results.` in `src/canvas/components/OutputsDock.tsx` finds no other occurrence. Nothing bigger found in the same render path.

## Fix 2 — F15 first half: honest What-changed placeholder

The hero What-changed lens is structurally impossible live (`buildHeroModel.ts:360-362` never pushes it — no producer run-delta contract, PLoT #212), but the placeholder read as a session-local unlock. Reworded to the ratified honest-unavailable register:

> Run comparison is not available yet. This unlocks with versioned run comparisons. Olumi will not approximate it locally.

**Scope walls held:** `WhatChangedChip` NOT retired (D-AC ruling pending); its seed gate untouched (`runHistory.ts` doctrine — "fixing" it deepens the violation). Only `lensUnavailable.whatChanged` changed.

## Tests (all RED-first, all mutation-checked in a throwaway worktree at bf921314)

- **New:** `src/canvas/components/__tests__/OutputsDock.bandslessReport.spec.tsx` — pushes the exact bands-less shape through the REAL `resultsHydrateFromSupabase` (positive control pins that the invariant ADMITS it), then renders the dock. Pre-fix: throws the exact live error (RED verified). Post-fix: green. Mutation check: spec + defect restored → red with `Cannot read properties of undefined (reading 'likely')`.
- **Updated:** `analysis-hero/__tests__/content.spec.tsx` — the placeholder pin was moved to the new copy FIRST and ran red against the old string; `heroCopy.ts` then turned it green. Mutation check: new pin + old copy restored → red.
- Full analysis-hero suite: 14 files, 268 tests, all green (includes copyHygiene: glossary banned terms, trust vocabulary, no-em-dash scans over the new copy).
- All 8 OutputsDock spec files: 7 green; `OutputsDock.conversationSingleton.spec.tsx` fails identically on the PRISTINE base tip (verified in a clean bf921314 worktree) — pre-existing flake, untouched by this diff.

## Typechecks

- `pnpm typecheck` (= `tsc -p tsconfig.ci.json --noEmit`, the small file-allowlist gate): exit 0. Named per trap 2; NOT treated as evidence.
- `tsc -p tsconfig.app.json --noEmit`, error-header multiset vs pristine base (bf921314): **identical — 0 added, 0 removed** (2316 pre-existing errors on both sides; an interim revision of the new spec added 2 TS2352 errors, fixed in the third commit before this PR was opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)