### PR TITLE
feat(results): run-state coverage outside the Analysis tab — one trust surface, one live region (F9)

### DIFF
--- a/src/canvas/compare-tab/CompareTabBody.tsx
+++ b/src/canvas/compare-tab/CompareTabBody.tsx
@@ -7,6 +7,7 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { useCanvasStore } from '../store'
 import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
+import { AnalysisRunStateCover } from '../components/AnalysisRunStateCover'
 import { useAnalysisSnapshotStore, selectSnapshots } from '../stores/analysisSnapshotStore'
 import { useUIStore } from '../../stores/uiStore'
 import { deriveCompareState } from './deriveCompareState'
@@ -29,11 +30,14 @@ const EXPERT_STORAGE_KEY = 'feature.compareExpert'
 export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
   // Snapshot data
   const snapshots = useAnalysisSnapshotStore(selectSnapshots)
+  // One trust surface (F10/F11): staleness AND run state both come from the
+  // composed useAnalysisTrust answer, never from local flags.
   // "Results outdated" must reflect the composed trust semantic being
   // 'changed' (CEE 'stale' OR a retained-fresh-now-dirtied), NOT the local
   // `graphEditedSinceLastRun` flag, which would independently fabricate a
   // stale state.
-  const graphIsStale = useAnalysisTrust().semantic === 'changed'
+  const trust = useAnalysisTrust()
+  const graphIsStale = trust.semantic === 'changed'
 
   // UI state
   const [preset, setPreset] = useState<RunPreset>('prev')
@@ -114,12 +118,25 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
     useUIStore.getState().setActiveOutputTab('results')
   }, [])
 
-  // Empty state
+  // Empty state. F9: while a run is in flight there is no content to
+  // retain here, so the skeleton stands in for the frozen empty state
+  // (which invites a run that is already happening). Settle, complete or
+  // error, restores the honest empty state.
   if (snapshots.length < 2) {
     return (
       <div className="flex flex-col h-full" data-testid="compare-tab-body">
         <TabHeader showExpert={showExpert} onToggleExpert={handleToggleExpert} />
-        <EmptyState onViewResults={switchToResults} />
+        {trust.isRunning ? (
+          <div className="pt-3">
+            <AnalysisRunStateCover
+              isRunning
+              startedAt={trust.runStartedAt}
+              contentRetained={false}
+            />
+          </div>
+        ) : (
+          <EmptyState onViewResults={switchToResults} />
+        )}
       </div>
     )
   }
@@ -133,7 +150,17 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
         runCount={snapshots.length}
         showExpert={showExpert}
       />
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      {/* F9: run in flight over retained snapshots — banner above, content
+          marked busy below, never blanked (v6 doctrine). */}
+      {trust.isRunning && (
+        <div className="pt-2">
+          <AnalysisRunStateCover isRunning startedAt={trust.runStartedAt} contentRetained />
+        </div>
+      )}
+      <div
+        className="flex-1 min-h-0 overflow-y-auto"
+        aria-busy={trust.isRunning || undefined}
+      >
         <Hero state={compareState} snapshots={snapshots} showExpert={showExpert} />
         <TrajectorySection snapshots={snapshots} showExpert={showExpert} />
         <TransitionsSection

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.runState.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.runState.spec.tsx
@@ -1,0 +1,135 @@
+/**
+ * F9 (UI brief 2026-07-16 item 3): the Compare tab must SHOW a run in
+ * flight. Before this change it had zero isRunning handling: dispatching a
+ * run with Compare fronted left the empty state (or retained snapshots)
+ * frozen on screen with no in-flight signal at all.
+ *
+ * Pins:
+ *  - run in flight, nothing retained (<2 snapshots): skeleton, not the
+ *    empty state (positive control proves the empty state is visible when
+ *    idle, so its absence here is meaningful);
+ *  - run in flight, snapshots retained: running banner ABOVE the retained
+ *    content, content marked busy, never blanked;
+ *  - settle (complete or error): treatment gone, honest state back, never
+ *    skeleton-forever;
+ *  - the body contributes NO aria-live region of its own (the dock-level
+ *    announcer is the single voice).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import type { AnalysisSnapshot } from '../types'
+
+const TWO_SNAPSHOTS = [
+  { runNumber: 1, winnerId: 'opt-a', winnerProbability: 65, runnerUpProbability: 35 },
+  { runNumber: 2, winnerId: 'opt-a', winnerProbability: 65, runnerUpProbability: 35 },
+] as unknown as AnalysisSnapshot[]
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockCanvasState: any
+let mockSnapshots: AnalysisSnapshot[] = []
+
+vi.mock('../../store', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useCanvasStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector(mockCanvasState),
+    { getState: () => mockCanvasState },
+  ),
+}))
+vi.mock('../../stores/analysisSnapshotStore', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useAnalysisSnapshotStore: (selector: (s: any) => unknown) => selector({ snapshots: mockSnapshots }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  selectSnapshots: (s: any) => s.snapshots,
+}))
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector({ activeOutputTab: 'compare' }),
+    { getState: () => ({ setActiveOutputTab: vi.fn() }) },
+  ),
+}))
+vi.mock('../deriveTransitions', () => ({
+  deriveTransitions: () => [],
+  buildCumulativeTransition: () => null,
+}))
+// Stub the heavy child tree; Hero stands in for "retained content".
+vi.mock('../Hero', () => ({ Hero: () => <div data-testid="compare-content" /> }))
+vi.mock('../TabHeader', () => ({ TabHeader: () => null }))
+vi.mock('../RunSelector', () => ({ RunSelector: () => null }))
+vi.mock('../TrajectorySection', () => ({ TrajectorySection: () => null }))
+vi.mock('../TransitionsSection', () => ({ TransitionsSection: () => null }))
+vi.mock('../CompareFooter', () => ({ CompareFooter: () => null }))
+vi.mock('../EmptyState', () => ({ EmptyState: () => <div data-testid="compare-empty-state" /> }))
+
+import { CompareTabBody } from '../CompareTabBody'
+
+function setRun(status: string, startedAt?: number) {
+  mockCanvasState = {
+    ...mockCanvasState,
+    results: { status, startedAt },
+  }
+}
+
+beforeEach(() => {
+  mockSnapshots = []
+  mockCanvasState = {
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    results: { status: 'idle' },
+    currentScenarioId: null,
+    v5AnalysisFact: null,
+    selection: { nodeIds: new Set() },
+  }
+})
+
+describe('F9: CompareTabBody run-state coverage', () => {
+  it('positive control: idle with no snapshots shows the empty state and no run treatment', () => {
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(screen.getByTestId('compare-empty-state')).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('run in flight with nothing retained: skeleton replaces the empty state', () => {
+    setRun('streaming', Date.now())
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(screen.getByTestId('analysis-run-skeleton')).toBeInTheDocument()
+    expect(screen.queryByTestId('compare-empty-state')).not.toBeInTheDocument()
+  })
+
+  it('run in flight with snapshots retained: banner above content, content marked busy, never blanked', () => {
+    mockSnapshots = TWO_SNAPSHOTS
+    setRun('streaming', Date.now())
+    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('compare-content')).toBeInTheDocument()
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull()
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('settle: the treatment is gone and retained content is unmarked', () => {
+    mockSnapshots = TWO_SNAPSHOTS
+    setRun('complete')
+    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+    expect(screen.getByTestId('compare-content')).toBeInTheDocument()
+    expect(container.querySelector('[aria-busy="true"]')).toBeNull()
+  })
+
+  it('error with nothing retained: honest empty state, never skeleton-forever', () => {
+    setRun('error')
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+    expect(screen.getByTestId('compare-empty-state')).toBeInTheDocument()
+  })
+
+  it('contributes no aria-live region of its own (the dock announcer is the single voice)', () => {
+    mockSnapshots = TWO_SNAPSHOTS
+    setRun('streaming', Date.now())
+    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    expect(container.querySelectorAll('[aria-live]')).toHaveLength(0)
+  })
+})

--- a/src/canvas/components/AnalysisRunAnnouncer.tsx
+++ b/src/canvas/components/AnalysisRunAnnouncer.tsx
@@ -1,0 +1,90 @@
+/**
+ * AnalysisRunAnnouncer — THE single aria-live region for analysis run
+ * start/settle (F9, UI brief 2026-07-16 item 3).
+ *
+ * Mounted ONCE at the dock root, outside every tab branch, so it survives
+ * tab switches and speaks for runs dispatched while Compare, Model or Olumi
+ * is fronted (before F9, those runs were silent AND invisible). The
+ * per-surface treatments (AnalysisRunStateCover) are visual only.
+ *
+ * While the Analysis tab is fronted the announcer yields, because that
+ * tab's own furniture already announces: the running banner's narration div
+ * at start (announcing on top of it is the #329 double-announce trap) and
+ * the completion toast / error alert at settle. That yield rule is the pure
+ * `runAnnouncementForTransition` in analysisRunStatus.ts, next to the
+ * Wave1-L2 ongoing-narration rule it extends.
+ *
+ * Announcements fire only on observed TRANSITIONS of the composed
+ * `useAnalysisTrust().isRunning` (one trust surface): a mid-run mount does
+ * not retroactively announce a start it never saw, and fronting a different
+ * tab mid-run never re-announces (the message only changes on a
+ * transition).
+ */
+import { useEffect, useRef, useState } from 'react'
+
+import { useCanvasStore } from '../store'
+import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
+import { runAnnouncementForTransition } from './analysisRunStatus'
+
+export interface AnalysisRunAnnouncerProps {
+  /** The Analysis tab is fronted (dock open, results tab active). */
+  analysisTabFronted: boolean
+}
+
+export function AnalysisRunAnnouncer({ analysisTabFronted }: AnalysisRunAnnouncerProps) {
+  const { isRunning } = useAnalysisTrust()
+  const resultsStatus = useCanvasStore((s) => s.results?.status ?? null)
+
+  const [message, setMessage] = useState('')
+
+  // Read at transition time via refs so the effect below fires ONLY on
+  // isRunning transitions: a tab switch or status refinement mid-run must
+  // never re-announce.
+  const frontedRef = useRef(analysisTabFronted)
+  frontedRef.current = analysisTabFronted
+  const statusRef = useRef(resultsStatus)
+  statusRef.current = resultsStatus
+
+  // The settled status held BEFORE a run starts (updated only while not
+  // running). runAnnouncementForTransition uses it to recognise a FIRST run
+  // (from idle/cancelled), which the dock's I.1 auto-switch fronts onto the
+  // Analysis tab in the same breath — the announcer yields there rather
+  // than racing the auto-switch commit.
+  const preRunStatusRef = useRef(resultsStatus)
+
+  // Initialised to the CURRENT value: a mount mid-run observed no
+  // transition, so it announces nothing retroactively.
+  const wasRunningRef = useRef(isRunning)
+
+  useEffect(() => {
+    if (isRunning === wasRunningRef.current) {
+      if (!isRunning) preRunStatusRef.current = statusRef.current
+      return
+    }
+    wasRunningRef.current = isRunning
+    const announcement = runAnnouncementForTransition({
+      transition: isRunning ? 'start' : 'settle',
+      settledStatus: statusRef.current,
+      preRunStatus: preRunStatusRef.current,
+      analysisTabFronted: frontedRef.current,
+    })
+    if (!isRunning) preRunStatusRef.current = statusRef.current
+    // A yielded transition clears the region (an empty string announces
+    // nothing) rather than holding stale text into the next transition.
+    setMessage(announcement ?? '')
+  }, [isRunning, resultsStatus])
+
+  return (
+    <div
+      className="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="analysis-run-announcer"
+    >
+      {message}
+    </div>
+  )
+}
+
+export default AnalysisRunAnnouncer

--- a/src/canvas/components/AnalysisRunStateCover.tsx
+++ b/src/canvas/components/AnalysisRunStateCover.tsx
@@ -1,0 +1,71 @@
+/**
+ * AnalysisRunStateCover — the shared in-flight treatment for dock surfaces
+ * OUTSIDE the Analysis tab (F9, UI brief 2026-07-16 item 3).
+ *
+ * Before this, run-state furniture existed only inside the Analysis tab's
+ * scroller: dispatching a run with Compare or Model fronted (or with the
+ * coaching panel in view) changed NOTHING on screen. This component gives
+ * every such surface the same two primitives the Analysis tab already uses:
+ *
+ *  - content retained behind it → the running banner (same staged, honest
+ *    narration, driven by the run's TRUE start clock via
+ *    useAnalysisTrust().runStartedAt);
+ *  - nothing retained → a skeleton, built from the DS Skeleton brick.
+ *
+ * Both forms are VISUAL ONLY. The dock-level AnalysisRunAnnouncer is the
+ * single aria-live voice for run start/settle, so the banner mounts here
+ * with announces=false and the skeleton is decorative (aria-hidden). One
+ * live region per surface is exactly the stacked-narration class the
+ * Wave1-L2 rule (analysisRunStatus.ts) exists to prevent.
+ *
+ * Presentational by design: run state arrives as props so render-only
+ * bodies (the coaching panel, Phase 0) can adopt it without store access.
+ * Store-aware surfaces read `useAnalysisTrust()` and pass `isRunning` /
+ * `runStartedAt` straight through — one trust surface, no parallel
+ * run-state source.
+ */
+import { Skeleton } from '../../components/ui/Skeleton'
+import { AnalysisRunningBanner } from './AnalysisRunningBanner'
+
+export interface AnalysisRunStateCoverProps {
+  /** An analysis is in flight (useAnalysisTrust().isRunning). */
+  isRunning: boolean
+  /** True run start clock (useAnalysisTrust().runStartedAt). */
+  startedAt?: number
+  /**
+   * Whether the hosting surface keeps content on screen during the run.
+   * Retained content gets the banner above it (marked, never blanked);
+   * an empty surface gets the skeleton instead of a frozen empty state.
+   */
+  contentRetained: boolean
+}
+
+/** Decorative loading shape: one neutral card of DS Skeleton lines. */
+function AnalysisRunSkeleton() {
+  return (
+    <div
+      className="mx-3 mb-2 rounded-md border border-panel-border bg-panel p-3 space-y-2"
+      data-testid="analysis-run-skeleton"
+      aria-hidden="true"
+    >
+      <Skeleton className="h-4 w-3/5" />
+      <Skeleton className="h-3 w-full" />
+      <Skeleton className="h-3 w-4/5" />
+      <Skeleton className="h-3 w-2/3" />
+    </div>
+  )
+}
+
+export function AnalysisRunStateCover({
+  isRunning,
+  startedAt,
+  contentRetained,
+}: AnalysisRunStateCoverProps) {
+  if (!isRunning) return null
+  if (contentRetained) {
+    return <AnalysisRunningBanner startedAt={startedAt} announces={false} />
+  }
+  return <AnalysisRunSkeleton />
+}
+
+export default AnalysisRunStateCover

--- a/src/canvas/components/AnalysisRunningBanner.tsx
+++ b/src/canvas/components/AnalysisRunningBanner.tsx
@@ -106,9 +106,18 @@ export interface AnalysisRunningBannerProps {
    * origin is mount time, which is what the round-2 regression was.
    */
   startedAt?: number
+  /**
+   * F9: whether this mount is a live region (role=status, aria-live).
+   * Default true — the Analysis tab's mount keeps today's behaviour
+   * unchanged. Mounts OUTSIDE the Analysis tab (via AnalysisRunStateCover)
+   * pass false: the dock-level AnalysisRunAnnouncer is the single voice for
+   * run transitions there, and one live region per surface is exactly the
+   * stacked-narration class the Wave1-L2 rule exists to prevent.
+   */
+  announces?: boolean
 }
 
-export function AnalysisRunningBanner({ startedAt }: AnalysisRunningBannerProps = {}) {
+export function AnalysisRunningBanner({ startedAt, announces = true }: AnalysisRunningBannerProps = {}) {
   const prefersReducedMotion = usePrefersReducedMotion()
 
   // Fallback origin, captured once so it cannot drift across re-renders.
@@ -157,8 +166,7 @@ export function AnalysisRunningBanner({ startedAt }: AnalysisRunningBannerProps 
     <div
       className="mx-3 mb-2 flex items-center gap-2 rounded-md border border-panel-border bg-panel px-3 py-2"
       data-testid="analysis-running-banner"
-      role="status"
-      aria-live="polite"
+      {...(announces ? ({ role: 'status', 'aria-live': 'polite' } as const) : {})}
     >
       <Loader2
         className={`h-4 w-4 text-info ${prefersReducedMotion ? '' : 'animate-spin'}`}

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -18,6 +18,8 @@ import {
 } from 'react'
 import type { Node, Edge } from '@xyflow/react'
 import { useCanvasStore } from '../store'
+import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
+import { AnalysisRunStateCover } from './AnalysisRunStateCover'
 import { useUIStore } from '../../stores/uiStore'
 import { getDisplayEdgeId, buildFragileEdgeLookup } from '../utils/edgeIdentity'
 import { getCausalEdges } from '../domain/edgeUtils'
@@ -156,6 +158,10 @@ export const ModelTabBody = memo(function ModelTabBody({
     })
     useUIStore.getState().requestModelTabSection(null)
   }, [pendingSection])
+
+  // F9 (UI brief 2026-07-16 item 3): run-state coverage. One trust surface:
+  // the composed useAnalysisTrust answer drives the in-flight treatment.
+  const trust = useAnalysisTrust()
 
   const ceeAnalysisReady = useCanvasStore(s => s.ceeAnalysisReady)
   const ceePipelineTrace = useCanvasStore(s => s.ceePipelineTrace)
@@ -578,7 +584,20 @@ export const ModelTabBody = memo(function ModelTabBody({
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div className="space-y-4 pb-4" data-testid="model-tab">
+    <div
+      className="space-y-4 pb-4"
+      data-testid="model-tab"
+      aria-busy={trust.isRunning || undefined}
+    >
+
+      {/* F9: run in flight — banner above the retained model (marked, never
+          blanked); defensive skeleton when there is no model to retain. The
+          dock-level announcer carries the aria-live announcement. */}
+      <AnalysisRunStateCover
+        isRunning={trust.isRunning}
+        startedAt={trust.runStartedAt}
+        contentRetained={nodes.length > 0}
+      />
 
       {/* ── Header: factor/edge counts + "Show full detail" toggle ─────────── */}
       <ModelTabHeader

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -29,6 +29,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
 import { AnalysisRunningBanner } from './AnalysisRunningBanner'
+import { AnalysisRunAnnouncer } from './AnalysisRunAnnouncer'
 import { runStatusRegion } from './analysisRunStatus'
 import { registerCanonicalRunner, type CanonicalRunOptions, type CanonicalRunOutcome } from '../analysis/canonicalRunRegistry'
 import { useShowToastSafe } from '../ToastContext'
@@ -1692,6 +1693,15 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
           openDefineSuccess()/openDecisionRecord() work from any surface. */}
       <DefineSuccessModal />
       <DecisionRecordModal />
+      {/* F9: THE single aria-live region for run start/settle, mounted once
+          at the dock root so it survives tab switches and speaks for runs
+          dispatched from ANY tab. It yields while the Analysis tab is
+          fronted — that tab's own furniture (narration banner, completion
+          toast, error alert) already announces there. Rule:
+          runAnnouncementForTransition in analysisRunStatus.ts. */}
+      <AnalysisRunAnnouncer
+        analysisTabFronted={effectiveIsOpen && effectiveActiveTab === 'results'}
+      />
       {effectiveIsOpen && (
         <div
           aria-hidden="true"

--- a/src/canvas/components/__tests__/AnalysisRunAnnouncer.spec.tsx
+++ b/src/canvas/components/__tests__/AnalysisRunAnnouncer.spec.tsx
@@ -1,0 +1,130 @@
+/**
+ * F9 (UI brief 2026-07-16 item 3): AnalysisRunAnnouncer — THE single
+ * aria-live region for run start/settle outside the Analysis tab.
+ *
+ * The dock mounts this ONCE, so a run dispatched while Compare, Model or
+ * Olumi is fronted is still announced; per-surface treatments (banner,
+ * skeleton) stay silent. While the Analysis tab is fronted the announcer
+ * yields, because that tab's own furniture already speaks: the running
+ * banner's narration div at start (the #329 trap: adding a second start
+ * announcement there double-announces) and the completion toast / error
+ * alert at settle.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+interface MockResults {
+  status: string
+  startedAt?: number
+  report?: unknown
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockCanvasState: any
+
+vi.mock('../../store', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useCanvasStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector(mockCanvasState),
+    { getState: () => mockCanvasState },
+  ),
+}))
+
+import { AnalysisRunAnnouncer } from '../AnalysisRunAnnouncer'
+
+function setResults(results: MockResults) {
+  mockCanvasState = {
+    ...mockCanvasState,
+    results,
+  }
+}
+
+beforeEach(() => {
+  mockCanvasState = {
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    results: { status: 'idle' },
+    currentScenarioId: null,
+    v5AnalysisFact: null,
+    selection: { nodeIds: new Set() },
+  }
+})
+
+const announcer = () => screen.getByTestId('analysis-run-announcer')
+
+describe('F9: AnalysisRunAnnouncer', () => {
+  it('renders one polite, visually hidden live region, initially silent', () => {
+    render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    const region = announcer()
+    expect(region).toHaveAttribute('aria-live', 'polite')
+    expect(region).toHaveClass('sr-only')
+    expect(region).toHaveTextContent('')
+  })
+
+  it('announces run start when the Analysis tab is not fronted', () => {
+    const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(announcer()).toHaveTextContent('Analysis started.')
+  })
+
+  it('stays silent at run start while the Analysis tab is fronted (its narration div already announces)', () => {
+    const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={true} />)
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={true} />)
+    expect(announcer()).toHaveTextContent('')
+  })
+
+  it('announces completion when the Analysis tab is not fronted', () => {
+    const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    setResults({ status: 'complete' })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(announcer()).toHaveTextContent('Analysis complete.')
+  })
+
+  it('stays silent at settle while the Analysis tab is fronted (the completion toast already announces)', () => {
+    const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={true} />)
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={true} />)
+    setResults({ status: 'complete' })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={true} />)
+    expect(announcer()).toHaveTextContent('')
+  })
+
+  it('announces failure honestly (never a completion claim) when not fronted', () => {
+    const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    setResults({ status: 'error' })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(announcer()).toHaveTextContent('Analysis failed.')
+  })
+
+  it('does not re-announce when the user switches tabs mid-run', () => {
+    const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(announcer()).toHaveTextContent('Analysis started.')
+
+    // Front the Analysis tab, then leave again: no state transition, so the
+    // message must not change (a change would re-announce to screen readers).
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={true} />)
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(announcer()).toHaveTextContent('Analysis started.')
+  })
+
+  it('does not retroactively announce a start it never observed (mid-run mount)', () => {
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(announcer()).toHaveTextContent('')
+  })
+
+  it('is the ONLY aria-live element it contributes (no nested duplicate regions)', () => {
+    const { container } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(container.querySelectorAll('[aria-live]')).toHaveLength(1)
+  })
+})

--- a/src/canvas/components/__tests__/AnalysisRunAnnouncer.spec.tsx
+++ b/src/canvas/components/__tests__/AnalysisRunAnnouncer.spec.tsx
@@ -63,14 +63,25 @@ describe('F9: AnalysisRunAnnouncer', () => {
     expect(region).toHaveTextContent('')
   })
 
-  it('announces run start when the Analysis tab is not fronted', () => {
+  it('announces a rerun start when the Analysis tab is not fronted', () => {
+    setResults({ status: 'complete' })
     const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
     setResults({ status: 'streaming', startedAt: Date.now() })
     rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
     expect(announcer()).toHaveTextContent('Analysis started.')
   })
 
-  it('stays silent at run start while the Analysis tab is fronted (its narration div already announces)', () => {
+  it('stays silent at a FIRST-run start (the dock auto-switch fronts the Analysis tab in the same breath)', () => {
+    // Pre-run status idle: the I.1 auto-switch is about to front the
+    // Analysis tab, whose furniture speaks. The announcer must not race it.
+    const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    setResults({ status: 'streaming', startedAt: Date.now() })
+    rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
+    expect(announcer()).toHaveTextContent('')
+  })
+
+  it('stays silent at a rerun start while the Analysis tab is fronted (its narration div already announces)', () => {
+    setResults({ status: 'complete' })
     const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={true} />)
     setResults({ status: 'streaming', startedAt: Date.now() })
     rerender(<AnalysisRunAnnouncer analysisTabFronted={true} />)
@@ -78,6 +89,7 @@ describe('F9: AnalysisRunAnnouncer', () => {
   })
 
   it('announces completion when the Analysis tab is not fronted', () => {
+    setResults({ status: 'complete' })
     const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
     setResults({ status: 'streaming', startedAt: Date.now() })
     rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
@@ -87,6 +99,7 @@ describe('F9: AnalysisRunAnnouncer', () => {
   })
 
   it('stays silent at settle while the Analysis tab is fronted (the completion toast already announces)', () => {
+    setResults({ status: 'complete' })
     const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={true} />)
     setResults({ status: 'streaming', startedAt: Date.now() })
     rerender(<AnalysisRunAnnouncer analysisTabFronted={true} />)
@@ -96,6 +109,7 @@ describe('F9: AnalysisRunAnnouncer', () => {
   })
 
   it('announces failure honestly (never a completion claim) when not fronted', () => {
+    setResults({ status: 'complete' })
     const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
     setResults({ status: 'streaming', startedAt: Date.now() })
     rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)
@@ -105,6 +119,7 @@ describe('F9: AnalysisRunAnnouncer', () => {
   })
 
   it('does not re-announce when the user switches tabs mid-run', () => {
+    setResults({ status: 'complete' })
     const { rerender } = render(<AnalysisRunAnnouncer analysisTabFronted={false} />)
     setResults({ status: 'streaming', startedAt: Date.now() })
     rerender(<AnalysisRunAnnouncer analysisTabFronted={false} />)

--- a/src/canvas/components/__tests__/AnalysisRunStateCover.spec.tsx
+++ b/src/canvas/components/__tests__/AnalysisRunStateCover.spec.tsx
@@ -1,0 +1,64 @@
+/**
+ * F9 (UI brief 2026-07-16 item 3): AnalysisRunStateCover — the shared
+ * banner-or-skeleton in-flight treatment for surfaces OUTSIDE the Analysis
+ * tab (Compare tab, Model tab, coaching panel).
+ *
+ * The rule (brief item 3 build (ii)): running banner when content is
+ * retained behind it, skeleton when nothing is retained. Both forms are
+ * VISUAL ONLY here: the dock-level AnalysisRunAnnouncer is the single
+ * aria-live voice for run transitions, so neither form may mint its own
+ * live region (the exact stacked-narration class Wave1-L2 removed).
+ */
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+import { AnalysisRunStateCover } from '../AnalysisRunStateCover'
+
+describe('F9: AnalysisRunStateCover', () => {
+  it('renders nothing when no run is in flight', () => {
+    const { container } = render(
+      <AnalysisRunStateCover isRunning={false} contentRetained />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the running banner when content is retained, without its own live region', () => {
+    render(
+      <AnalysisRunStateCover isRunning contentRetained startedAt={Date.now()} />,
+    )
+    const banner = screen.getByTestId('analysis-running-banner')
+    expect(banner).toBeInTheDocument()
+    // The dock announcer is the one voice; the reused banner must not
+    // announce (that would be one live region per surface).
+    expect(banner).not.toHaveAttribute('aria-live')
+    expect(banner).not.toHaveAttribute('role')
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('shows the skeleton when nothing is retained, decorative only', () => {
+    render(<AnalysisRunStateCover isRunning contentRetained={false} />)
+    const skeleton = screen.getByTestId('analysis-run-skeleton')
+    expect(skeleton).toBeInTheDocument()
+    expect(skeleton).toHaveAttribute('aria-hidden', 'true')
+    expect(skeleton.querySelector('[aria-live]')).toBeNull()
+    expect(skeleton.querySelector('[role="status"]')).toBeNull()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+  })
+
+  it('narrates from the true run clock, not mount time (mid-run mount shows the escalated stage)', () => {
+    // A run that started 45s ago must show the 40s-stage copy on its FIRST
+    // frame; a mount-time clock would show the fresh-start line (the #327
+    // round-2 regression class).
+    render(
+      <AnalysisRunStateCover
+        isRunning
+        contentRetained
+        startedAt={Date.now() - 45_000}
+      />,
+    )
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(
+      'Still analysing',
+    )
+  })
+})

--- a/src/canvas/components/__tests__/ModelTabBody.runState.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.runState.spec.tsx
@@ -1,0 +1,151 @@
+/**
+ * F9 (UI brief 2026-07-16 item 3): the Model tab must SHOW a run in flight.
+ * Before this change it had zero isRunning handling: dispatching a run with
+ * Model fronted left the sections frozen with no in-flight signal.
+ *
+ * Pins: banner above the retained model + body marked busy while running;
+ * treatment gone on settle (complete or error); no aria-live region of its
+ * own (the dock-level announcer is the single voice); defensive skeleton
+ * when there is no model to retain.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockCanvasState: any
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector(mockCanvasState),
+    { getState: () => mockCanvasState },
+  ),
+}))
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector({ pendingModelTabSection: null }),
+    { getState: () => ({ requestModelTabSection: vi.fn() }) },
+  ),
+}))
+vi.mock('../../../telemetry/guidanceEvents', () => ({ trackGuidance: vi.fn() }))
+vi.mock('../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+// Stub the heavy section tree; the header passes children through so the
+// sections' wrapper (the retained content) stays in the DOM.
+vi.mock('../model-tab/ModelTabHeader', () => ({
+  ModelTabHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="model-content">{children}</div>
+  ),
+}))
+vi.mock('../model-tab/StatusBar', () => ({ StatusBar: () => null }))
+vi.mock('../model-tab/EntityBar', () => ({ EntityBar: () => null }))
+vi.mock('../model-tab/GoalSection', () => ({ GoalSection: () => null }))
+vi.mock('../model-tab/OptionsSection', () => ({ OptionsSection: () => null }))
+vi.mock('../model-tab/FactorsSection', () => ({ FactorsSection: () => null }))
+vi.mock('../model-tab/RelationshipsSection', () => ({ RelationshipsSection: () => null }))
+vi.mock('../model-tab/RisksSection', () => ({ RisksSection: () => null }))
+vi.mock('../model-tab/ModelAdjustments', () => ({ ModelAdjustments: () => null }))
+vi.mock('../model-tab/ModelHealthSection', () => ({ ModelHealthSection: () => null }))
+vi.mock('../model-tab/StreamingDiagnostics', () => ({ StreamingDiagnostics: () => null }))
+vi.mock('../model-tab/ReanalyseBar', () => ({ ReanalyseBar: () => null }))
+vi.mock('../model-tab/ModelFooter', () => ({ ModelFooter: () => null }))
+
+import { ModelTabBody } from '../ModelTabBody'
+
+const NODES: Node[] = [
+  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+  { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor' } },
+]
+
+function renderModelTab(nodes: Node[] = NODES) {
+  return render(
+    <ModelTabBody
+      showDebug={false}
+      hasDiagnostics={false}
+      diagnostics={null}
+      hasTrim={false}
+      effectiveCorrelationId={null}
+      correlationMismatch={false}
+      correlationIdHeader={null}
+      nodes={nodes}
+      edges={[]}
+      robustness={null}
+    />,
+  )
+}
+
+function setRun(status: string, startedAt?: number) {
+  mockCanvasState = {
+    ...mockCanvasState,
+    results: { status, startedAt },
+  }
+}
+
+beforeEach(() => {
+  mockCanvasState = {
+    updateEdge: vi.fn(),
+    ceeAnalysisReady: null,
+    ceePipelineTrace: null,
+    repairsApplied: null,
+    results: { status: 'idle' },
+    hasCompletedFirstRun: false,
+    rawV2Response: null,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    currentScenarioId: null,
+    v5AnalysisFact: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set() },
+  }
+})
+
+describe('F9: ModelTabBody run-state coverage', () => {
+  it('positive control: idle shows the model with no run treatment and no busy mark', () => {
+    renderModelTab()
+    expect(screen.getByTestId('model-content')).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+    expect(screen.getByTestId('model-tab')).not.toHaveAttribute('aria-busy')
+  })
+
+  it('run in flight: banner above the retained model, body marked busy, never blanked', () => {
+    setRun('streaming', Date.now())
+    renderModelTab()
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('model-content')).toBeInTheDocument()
+    expect(screen.getByTestId('model-tab')).toHaveAttribute('aria-busy', 'true')
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('run in flight with no model to retain: skeleton, not a blank body', () => {
+    setRun('preparing', Date.now())
+    renderModelTab([])
+    expect(screen.getByTestId('analysis-run-skeleton')).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+  })
+
+  it('settle: treatment gone, busy mark gone', () => {
+    setRun('complete')
+    renderModelTab()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+    expect(screen.getByTestId('model-tab')).not.toHaveAttribute('aria-busy')
+  })
+
+  it('error: honest settled state, never a stuck treatment', () => {
+    setRun('error')
+    renderModelTab()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+    expect(screen.getByTestId('model-content')).toBeInTheDocument()
+  })
+
+  it('contributes no aria-live region of its own (the dock announcer is the single voice)', () => {
+    setRun('streaming', Date.now())
+    const { container } = renderModelTab()
+    expect(container.querySelectorAll('[aria-live]')).toHaveLength(0)
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -1285,12 +1285,15 @@ describe('F9: dock-level run announcer (single voice for start/settle)', () => {
     expect(screen.getAllByTestId('analysis-run-announcer')).toHaveLength(1)
   })
 
-  it('announces start and settle while the Compare tab is fronted, exactly once', () => {
-    seedIdle(false)
+  it('announces rerun start and settle while the Compare tab is fronted, exactly once', () => {
+    // A RERUN (complete -> streaming) does not trip the I.1 auto-switch, so
+    // Compare stays fronted for the whole run — exactly the F9 scenario
+    // (rerun dispatched with another tab in view was silent and frozen).
+    seedIdle(true)
     renderOutputsDock()
     fireEvent.click(screen.getByRole('button', { name: 'Compare' }))
 
-    startRun(false)
+    startRun(true)
     expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent(
       'Analysis started.',
     )
@@ -1307,16 +1310,29 @@ describe('F9: dock-level run announcer (single voice for start/settle)', () => {
     )
   })
 
-  it('announces failure honestly while the Model tab is fronted', () => {
-    seedIdle(false)
+  it('announces rerun failure honestly while the Model tab is fronted', () => {
+    seedIdle(true)
     renderOutputsDock()
     fireEvent.click(screen.getByRole('button', { name: 'Model' }))
 
-    startRun(false)
+    startRun(true)
     settleRun('error')
     expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent(
       'Analysis failed.',
     )
+  })
+
+  it('stays silent on a FIRST run: the auto-switch fronts the Analysis tab, whose furniture speaks', () => {
+    seedIdle(false)
+    renderOutputsDock()
+    fireEvent.click(screen.getByRole('button', { name: 'Compare' }))
+
+    startRun(false)
+    // The I.1 auto-switch yanked the dock to the Analysis tab, where the
+    // results skeleton is the visible run furniture...
+    expect(screen.getByTestId('headline-skeleton')).toBeInTheDocument()
+    // ...so the announcer yields the start rather than double-announcing.
+    expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent('')
   })
 
   it('yields while the Analysis tab is fronted: the narration banner speaks, the announcer stays silent', () => {

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -1226,3 +1226,106 @@ describe('Wave1-L2: single run-status live region', () => {
     vi.useRealTimers()
   })
 })
+
+/**
+ * F9 (UI brief 2026-07-16 item 3): run start/settle is announced by ONE
+ * dock-level live region, whichever tab is fronted.
+ *
+ * The Wave1-L2 rule above guarantees at most one ONGOING narration region
+ * inside the Analysis tab. These cases pin its F9 extension: a single
+ * always-mounted announcer speaks run START and SETTLE for every other tab,
+ * and YIELDS while the Analysis tab is fronted, whose own furniture (the
+ * banner's narration div at start, the completion toast at settle) already
+ * announces there. Without the yield, an Analysis-tab run start would be
+ * spoken twice (the #329 narration-div trap).
+ */
+describe('F9: dock-level run announcer (single voice for start/settle)', () => {
+  beforeEach(cleanupDockState)
+
+  function seedIdle(withReport: boolean) {
+    const baseResults = useCanvasStore.getState().results
+    useCanvasStore.setState({
+      nodes: testNodes,
+      edges: testEdges,
+      hasCompletedFirstRun: withReport,
+      results: {
+        ...baseResults,
+        status: withReport ? 'complete' : 'idle',
+        report: withReport ? fakeReportForTests : null,
+      },
+    } as any)
+  }
+
+  function startRun(withReport: boolean) {
+    const current = useCanvasStore.getState().results
+    act(() => {
+      useCanvasStore.setState({
+        results: {
+          ...current,
+          status: 'streaming',
+          startedAt: Date.now(),
+          report: withReport ? fakeReportForTests : null,
+        },
+      } as any)
+    })
+  }
+
+  function settleRun(status: 'complete' | 'error') {
+    const current = useCanvasStore.getState().results
+    act(() => {
+      useCanvasStore.setState({
+        results: { ...current, status },
+      } as any)
+    })
+  }
+
+  it('mounts exactly one announcer at dock level', () => {
+    seedIdle(false)
+    renderOutputsDock()
+    expect(screen.getAllByTestId('analysis-run-announcer')).toHaveLength(1)
+  })
+
+  it('announces start and settle while the Compare tab is fronted, exactly once', () => {
+    seedIdle(false)
+    renderOutputsDock()
+    fireEvent.click(screen.getByRole('button', { name: 'Compare' }))
+
+    startRun(false)
+    expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent(
+      'Analysis started.',
+    )
+    // Structural single-voice pin: no OTHER live region carries the
+    // announcement (one aria-live announcement per transition).
+    const speakingRegions = Array.from(
+      document.querySelectorAll('[aria-live]'),
+    ).filter((el) => (el.textContent ?? '').includes('Analysis started.'))
+    expect(speakingRegions).toHaveLength(1)
+
+    settleRun('complete')
+    expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent(
+      'Analysis complete.',
+    )
+  })
+
+  it('announces failure honestly while the Model tab is fronted', () => {
+    seedIdle(false)
+    renderOutputsDock()
+    fireEvent.click(screen.getByRole('button', { name: 'Model' }))
+
+    startRun(false)
+    settleRun('error')
+    expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent(
+      'Analysis failed.',
+    )
+  })
+
+  it('yields while the Analysis tab is fronted: the narration banner speaks, the announcer stays silent', () => {
+    seedIdle(true)
+    renderOutputsDock()
+
+    startRun(true)
+    // The Analysis tab's own narration region is the run-start voice here.
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent('')
+  })
+})

--- a/src/canvas/components/__tests__/analysisRunStatus.announcement.spec.ts
+++ b/src/canvas/components/__tests__/analysisRunStatus.announcement.spec.ts
@@ -24,6 +24,7 @@ const runAnnouncementForTransition = (
     runAnnouncementForTransition?: (input: {
       transition: 'start' | 'settle'
       settledStatus?: string | null
+      preRunStatus?: string | null
       analysisTabFronted: boolean
     }) => string | null
   }
@@ -34,15 +35,51 @@ describe('F9: runAnnouncementForTransition (one voice per transition)', () => {
     expect(typeof runAnnouncementForTransition).toBe('function')
   })
 
-  it('announces run start when the Analysis tab is NOT fronted', () => {
+  it('announces a RERUN start when the Analysis tab is NOT fronted', () => {
     expect(
-      runAnnouncementForTransition!({ transition: 'start', analysisTabFronted: false }),
+      runAnnouncementForTransition!({
+        transition: 'start',
+        preRunStatus: 'complete',
+        analysisTabFronted: false,
+      }),
+    ).toBe('Analysis started.')
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'start',
+        preRunStatus: 'error',
+        analysisTabFronted: false,
+      }),
     ).toBe('Analysis started.')
   })
 
   it('yields run start to the Analysis tab furniture when it is fronted (the narration div already speaks)', () => {
     expect(
-      runAnnouncementForTransition!({ transition: 'start', analysisTabFronted: true }),
+      runAnnouncementForTransition!({
+        transition: 'start',
+        preRunStatus: 'complete',
+        analysisTabFronted: true,
+      }),
+    ).toBeNull()
+  })
+
+  it('yields a FIRST-run start unconditionally: the dock auto-switch fronts the Analysis tab in the same breath', () => {
+    // I.1 auto-switch: idle/cancelled -> active fronts the Analysis tab,
+    // whose skeleton/banner furniture speaks. The announcer observes the
+    // transition one commit before the switch, so frontedness is stale;
+    // the rule encodes the contract instead of racing the commit.
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'start',
+        preRunStatus: 'idle',
+        analysisTabFronted: false,
+      }),
+    ).toBeNull()
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'start',
+        preRunStatus: 'cancelled',
+        analysisTabFronted: false,
+      }),
     ).toBeNull()
   })
 

--- a/src/canvas/components/__tests__/analysisRunStatus.announcement.spec.ts
+++ b/src/canvas/components/__tests__/analysisRunStatus.announcement.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * F9 (UI brief 2026-07-16 item 3): the single-live-region rule, extended to
+ * run START and SETTLE announcements.
+ *
+ * `runStatusRegion` already guarantees at most one ONGOING narration region
+ * (banner vs slow-run) inside the Analysis tab. F9 adds a dock-level
+ * announcer so a run is audible from ANY tab. The extension must keep the
+ * one-voice invariant: while the Analysis tab is fronted, its own furniture
+ * already speaks (the running banner's narration div at start, the
+ * completion toast and error alert at settle), so the announcer must yield
+ * there. Everywhere else the announcer is the only voice.
+ *
+ * These cases pin the pure rule; AnalysisRunAnnouncer.spec.tsx pins the
+ * component wiring on top of it.
+ */
+import { describe, it, expect } from 'vitest'
+
+import * as analysisRunStatus from '../analysisRunStatus'
+
+// Typed indirection keeps this spec compiling RED-first (the export does not
+// exist yet); the assertions below fail loudly until it lands.
+const runAnnouncementForTransition = (
+  analysisRunStatus as unknown as {
+    runAnnouncementForTransition?: (input: {
+      transition: 'start' | 'settle'
+      settledStatus?: string | null
+      analysisTabFronted: boolean
+    }) => string | null
+  }
+).runAnnouncementForTransition
+
+describe('F9: runAnnouncementForTransition (one voice per transition)', () => {
+  it('is exported from the analysisRunStatus module (the single-live-region rule lives in ONE place)', () => {
+    expect(typeof runAnnouncementForTransition).toBe('function')
+  })
+
+  it('announces run start when the Analysis tab is NOT fronted', () => {
+    expect(
+      runAnnouncementForTransition!({ transition: 'start', analysisTabFronted: false }),
+    ).toBe('Analysis started.')
+  })
+
+  it('yields run start to the Analysis tab furniture when it is fronted (the narration div already speaks)', () => {
+    expect(
+      runAnnouncementForTransition!({ transition: 'start', analysisTabFronted: true }),
+    ).toBeNull()
+  })
+
+  it('announces completion when the Analysis tab is NOT fronted', () => {
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'settle',
+        settledStatus: 'complete',
+        analysisTabFronted: false,
+      }),
+    ).toBe('Analysis complete.')
+  })
+
+  it('yields settle to the Analysis tab furniture when it is fronted (the completion toast already speaks)', () => {
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'settle',
+        settledStatus: 'complete',
+        analysisTabFronted: true,
+      }),
+    ).toBeNull()
+  })
+
+  it('announces failure honestly when the Analysis tab is NOT fronted', () => {
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'settle',
+        settledStatus: 'error',
+        analysisTabFronted: false,
+      }),
+    ).toBe('Analysis failed.')
+  })
+
+  it('announces cancellation when the Analysis tab is NOT fronted', () => {
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'settle',
+        settledStatus: 'cancelled',
+        analysisTabFronted: false,
+      }),
+    ).toBe('Analysis cancelled.')
+  })
+
+  it('says nothing for a settle into an unrecognised or reset status (never fabricate an outcome)', () => {
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'settle',
+        settledStatus: 'idle',
+        analysisTabFronted: false,
+      }),
+    ).toBeNull()
+    expect(
+      runAnnouncementForTransition!({
+        transition: 'settle',
+        settledStatus: null,
+        analysisTabFronted: false,
+      }),
+    ).toBeNull()
+  })
+})

--- a/src/canvas/components/analysisRunStatus.ts
+++ b/src/canvas/components/analysisRunStatus.ts
@@ -52,3 +52,80 @@ export function runStatusRegion({
   if (isRunning && slowRunMessage) return 'slow-run'
   return 'none'
 }
+
+/**
+ * F9 (UI brief 2026-07-16 item 3) — the same single-live-region rule,
+ * extended from ONGOING narration to run START and SETTLE transitions.
+ *
+ * The dock now mounts one always-present announcer (AnalysisRunAnnouncer)
+ * so a run is audible whichever tab is fronted. But the Analysis tab's own
+ * furniture already speaks there:
+ *
+ *  - START: the running banner's narration div (role=status) mounts with
+ *    "Analysing your decision…", and the no-report skeleton carries its own
+ *    sr-only loading line. A dock announcement on top would be heard twice.
+ *  - SETTLE: AnalysisFreshnessNotice fires the completion toast
+ *    (role=alert) on the running→complete transition, and the error banner
+ *    mounts as role=alert on failure.
+ *
+ * So the rule is: while the Analysis tab is fronted, the announcer YIELDS
+ * every transition to that tab's furniture; everywhere else it is the one
+ * voice. Expressed as one pure function, like runStatusRegion above, so
+ * "exactly one announcement per transition" is structural, not per-consumer
+ * discipline.
+ *
+ * FIRST runs are a special case of the same rule. The dock's I.1 auto-switch
+ * fronts the Analysis tab whenever status transitions from idle/cancelled
+ * into an active state, so on a FIRST run the user lands on the Analysis
+ * tab (and its furniture) in the same breath as the start — but the
+ * announcer's effect observes the transition BEFORE the dock's auto-switch
+ * effect re-renders, so its `analysisTabFronted` input is one commit stale.
+ * Rather than race that commit, the rule encodes the auto-switch contract:
+ * a start from idle/cancelled yields unconditionally. RERUNS (from
+ * complete/error) do not auto-switch — that is exactly the case F9 exists
+ * for (rerun dispatched while Compare/Model is fronted stayed silent and
+ * frozen) — so there the current frontedness decides.
+ *
+ * Settle copy never fabricates an outcome: only statuses the store actually
+ * settles into ('complete' | 'error' | 'cancelled') get a line; anything
+ * else (a reset to 'idle', an unknown value) announces nothing.
+ */
+export interface RunAnnouncementInput {
+  /** Which transition just happened. */
+  transition: 'start' | 'settle'
+  /** The results status the run settled into (settle transitions only). */
+  settledStatus?: string | null
+  /**
+   * The results status held BEFORE the run started (start transitions
+   * only). idle/cancelled marks a FIRST run, which the dock auto-switches
+   * to the Analysis tab (see above).
+   */
+  preRunStatus?: string | null
+  /** The Analysis tab is fronted (dock open, results tab active). */
+  analysisTabFronted: boolean
+}
+
+export function runAnnouncementForTransition({
+  transition,
+  settledStatus,
+  preRunStatus,
+  analysisTabFronted,
+}: RunAnnouncementInput): string | null {
+  if (analysisTabFronted) return null
+  if (transition === 'start') {
+    // First run: the dock's auto-switch is about to front the Analysis tab,
+    // whose own furniture speaks. Announcing here would double up.
+    if (preRunStatus === 'idle' || preRunStatus === 'cancelled') return null
+    return 'Analysis started.'
+  }
+  switch (settledStatus) {
+    case 'complete':
+      return 'Analysis complete.'
+    case 'error':
+      return 'Analysis failed.'
+    case 'cancelled':
+      return 'Analysis cancelled.'
+    default:
+      return null
+  }
+}

--- a/src/canvas/components/coaching-panel/CoachingPanel.tsx
+++ b/src/canvas/components/coaching-panel/CoachingPanel.tsx
@@ -7,12 +7,18 @@
  * to the later mount PR (UX amendment 2). The future mount (Analysis tab) will
  * flag-gate this component and swap the fixture feed for the live envelope.
  *
- * Renders, in order: an optional fixture-only stale banner, the orientation
- * summary line (verbatim, omitted when absent — never synthesised), and either
- * a neutral empty state or the signal list (in received order). All model
- * strings render as TEXT — never HTML.
+ * Renders, in order: an optional fixture-only stale banner, the run-state
+ * treatment when a run is in flight (F9 — banner over retained coaching,
+ * skeleton when there is none; run state arrives as PROPS so this body stays
+ * store-free and the mount decides the wiring), the orientation summary line
+ * (verbatim, omitted when absent — never synthesised), and either a neutral
+ * empty state or the signal list (in received order). While a run is in
+ * flight the empty state is suppressed: "no coaching to show" is a settled
+ * answer this surface does not hold mid-run. All model strings render as
+ * TEXT — never HTML.
  */
 import { typography } from '@/styles/typography'
+import { AnalysisRunStateCover } from '../AnalysisRunStateCover'
 import { CoachingList } from './CoachingList'
 import { StaleBanner } from './StaleBanner'
 import { COACHING_COPY } from './constants'
@@ -25,19 +31,42 @@ export interface CoachingPanelProps {
    * staleness data this phase; the UI never derives it (F.6).
    */
   showStaleBanner?: boolean
+  /**
+   * F9: an analysis run is in flight. The mount supplies this from
+   * useAnalysisTrust().isRunning — the panel itself stays store-free.
+   */
+  isRunning?: boolean
+  /** F9: the run's true start clock (useAnalysisTrust().runStartedAt). */
+  runStartedAt?: number
   className?: string
 }
 
-export function CoachingPanel({ coaching, showStaleBanner = false, className = '' }: CoachingPanelProps) {
+export function CoachingPanel({
+  coaching,
+  showStaleBanner = false,
+  isRunning = false,
+  runStartedAt,
+  className = '',
+}: CoachingPanelProps) {
   const signals = coaching?.signals ?? []
+  const hasRetainedContent = signals.length > 0 || Boolean(coaching?.summary)
 
   return (
     <section
       aria-label={COACHING_COPY.panelAria}
       data-testid="coaching-panel"
       className={`flex flex-col gap-3 ${className}`}
+      aria-busy={isRunning || undefined}
     >
       {showStaleBanner && <StaleBanner />}
+
+      {isRunning && (
+        <AnalysisRunStateCover
+          isRunning
+          startedAt={runStartedAt}
+          contentRetained={hasRetainedContent}
+        />
+      )}
 
       {coaching?.summary && (
         <p className={`${typography.panelBody} text-text-body`} data-testid="coaching-summary">
@@ -46,9 +75,11 @@ export function CoachingPanel({ coaching, showStaleBanner = false, className = '
       )}
 
       {signals.length === 0 ? (
-        <p className={`${typography.panelBody} text-text-light`} data-testid="coaching-empty">
-          {COACHING_COPY.emptyState}
-        </p>
+        isRunning ? null : (
+          <p className={`${typography.panelBody} text-text-light`} data-testid="coaching-empty">
+            {COACHING_COPY.emptyState}
+          </p>
+        )
       ) : (
         <CoachingList signals={signals} />
       )}

--- a/src/canvas/components/coaching-panel/__tests__/runState.spec.tsx
+++ b/src/canvas/components/coaching-panel/__tests__/runState.spec.tsx
@@ -1,0 +1,55 @@
+/**
+ * F9 (UI brief 2026-07-16 item 3): the coaching-panel body gates on run
+ * state with the same two primitives as the other dock surfaces: running
+ * banner when coaching content is retained, skeleton when there is none.
+ *
+ * The panel stays render-only (Phase 0): run state arrives as PROPS, never
+ * from a store, so the future mount PR decides the wiring exactly as it
+ * decides the coaching envelope. While a run is in flight the panel must
+ * never show the frozen "no coaching" empty line (that reads as a settled
+ * answer the system does not hold), and it must never mint its own live
+ * region (the dock-level announcer is the single voice).
+ */
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+import { CoachingPanel } from '../CoachingPanel'
+import { typicalPanel } from '../__fixtures__/coaching.fixtures'
+
+describe('F9: CoachingPanel run-state coverage', () => {
+  it('positive control: idle and empty shows the empty line, no run treatment', () => {
+    render(<CoachingPanel coaching={null} />)
+    expect(screen.getByTestId('coaching-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('run in flight with retained signals: banner above the retained cards, never blanked', () => {
+    render(<CoachingPanel coaching={typicalPanel} isRunning runStartedAt={Date.now()} />)
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    expect(screen.getAllByTestId('coaching-card').length).toBeGreaterThan(0)
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('run in flight with nothing retained: skeleton, and the frozen empty line is suppressed', () => {
+    render(<CoachingPanel coaching={null} isRunning />)
+    expect(screen.getByTestId('analysis-run-skeleton')).toBeInTheDocument()
+    expect(screen.queryByTestId('coaching-empty')).not.toBeInTheDocument()
+  })
+
+  it('settle: treatment gone, empty line back', () => {
+    const { rerender } = render(<CoachingPanel coaching={null} isRunning />)
+    rerender(<CoachingPanel coaching={null} isRunning={false} />)
+    expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
+    expect(screen.getByTestId('coaching-empty')).toBeInTheDocument()
+  })
+
+  it('contributes no aria-live region of its own (the dock announcer is the single voice)', () => {
+    const { container } = render(
+      <CoachingPanel coaching={typicalPanel} isRunning runStartedAt={Date.now()} />,
+    )
+    expect(container.querySelectorAll('[aria-live]')).toHaveLength(0)
+  })
+})

--- a/src/canvas/hooks/__tests__/analysisTrust.runStartedAt.spec.ts
+++ b/src/canvas/hooks/__tests__/analysisTrust.runStartedAt.spec.ts
@@ -19,10 +19,10 @@ describe('F9: analysis trust composition carries the run clock', () => {
       source: 'none',
       resultsStatus: 'streaming',
       resultsStartedAt: 1_700_000_000_000,
-    } as Parameters<typeof computeAnalysisTrust>[0])
+    })
 
     expect(trust.isRunning).toBe(true)
-    expect((trust as Record<string, unknown>).runStartedAt).toBe(1_700_000_000_000)
+    expect(trust.runStartedAt).toBe(1_700_000_000_000)
   })
 
   it('leaves runStartedAt undefined when no run has ever started', () => {
@@ -31,9 +31,9 @@ describe('F9: analysis trust composition carries the run clock', () => {
       dirty: false,
       source: 'none',
       resultsStatus: 'idle',
-    } as Parameters<typeof computeAnalysisTrust>[0])
+    })
 
     expect(trust.isRunning).toBe(false)
-    expect((trust as Record<string, unknown>).runStartedAt).toBeUndefined()
+    expect(trust.runStartedAt).toBeUndefined()
   })
 })

--- a/src/canvas/hooks/__tests__/analysisTrust.runStartedAt.spec.ts
+++ b/src/canvas/hooks/__tests__/analysisTrust.runStartedAt.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * F9 (UI brief 2026-07-16 item 3): run-state coverage outside the Analysis
+ * tab consumes ONE trust surface. `useAnalysisTrust` already answers
+ * `isRunning`; the reused running banner also needs the run's true start
+ * time (the store's `results.startedAt`) so its narration clock reports the
+ * age of the RUN, not the age of the component (the #327 round-2 regression
+ * class). That field joins the trust composition here, its designated home,
+ * rather than minting a parallel run-state hook.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { computeAnalysisTrust } from '../useAnalysisTrust'
+
+describe('F9: analysis trust composition carries the run clock', () => {
+  it('exposes runStartedAt from the results startedAt input', () => {
+    const trust = computeAnalysisTrust({
+      freshness: null,
+      dirty: false,
+      source: 'none',
+      resultsStatus: 'streaming',
+      resultsStartedAt: 1_700_000_000_000,
+    } as Parameters<typeof computeAnalysisTrust>[0])
+
+    expect(trust.isRunning).toBe(true)
+    expect((trust as Record<string, unknown>).runStartedAt).toBe(1_700_000_000_000)
+  })
+
+  it('leaves runStartedAt undefined when no run has ever started', () => {
+    const trust = computeAnalysisTrust({
+      freshness: null,
+      dirty: false,
+      source: 'none',
+      resultsStatus: 'idle',
+    } as Parameters<typeof computeAnalysisTrust>[0])
+
+    expect(trust.isRunning).toBe(false)
+    expect((trust as Record<string, unknown>).runStartedAt).toBeUndefined()
+  })
+})

--- a/src/canvas/hooks/useAnalysisTrust.ts
+++ b/src/canvas/hooks/useAnalysisTrust.ts
@@ -30,6 +30,15 @@ export interface AnalysisTrust {
   orphaned: boolean
   /** An analysis is in flight right now. */
   isRunning: boolean
+  /**
+   * Wall-clock ms when the current/most recent run started (the store's
+   * `results.startedAt`, stamped by every path that enters a running
+   * status). F9: reused run-state banners narrate from THIS clock so a
+   * mid-run mount reports the age of the RUN, never the age of the
+   * component (the #327 round-2 regression class). Meaningful alongside
+   * `isRunning`; undefined when no run has ever started.
+   */
+  runStartedAt?: number
   /** Technical reason code (debug/telemetry; never user copy). */
   reason?: string
 }
@@ -69,8 +78,9 @@ export function computeAnalysisTrust(input: {
   dirty: boolean
   source: AnalysisStateSource | null | undefined
   resultsStatus: string | null | undefined
+  resultsStartedAt?: number
 }): AnalysisTrust {
-  const { freshness, dirty, source, resultsStatus } = input
+  const { freshness, dirty, source, resultsStatus, resultsStartedAt } = input
   const orphaned = source === 'orphaned_plot_result'
   // Same effective state the strip renders — the orphan fold happens HERE,
   // not per-consumer, so adopting surfaces inherit the F11 precedence rather
@@ -80,6 +90,7 @@ export function computeAnalysisTrust(input: {
     semantic: classifyFreshnessForDisplay(effective, dirty),
     orphaned,
     isRunning: RUNNING_STATUSES.has(resultsStatus ?? ''),
+    runStartedAt: resultsStartedAt,
     reason: effective?.freshnessReason,
   }
 }
@@ -88,6 +99,7 @@ export function useAnalysisTrust(): AnalysisTrust {
   const freshness = useCanvasStore((s) => s.analysisFreshness)
   const dirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const resultsStatus = useCanvasStore((s) => s.results?.status)
+  const resultsStartedAt = useCanvasStore((s) => s.results?.startedAt)
   const { source } = useAnalysisStateSource()
-  return computeAnalysisTrust({ freshness, dirty, source, resultsStatus })
+  return computeAnalysisTrust({ freshness, dirty, source, resultsStatus, resultsStartedAt })
 }

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -6,6 +6,12 @@
  * The shimmer honours prefers-reduced-motion via Tailwind's motion-safe
  * gate; the base tone is the canvas-adjacent neutral so it reads as
  * "content coming", not "content broken".
+ *
+ * F9 correction: the original class was `bg-border-default`, which does NOT
+ * exist in the Tailwind palette (the `border` colour group only defines
+ * `emphasis`), so every Skeleton rendered TRANSPARENT — verified live in a
+ * real browser (computed background rgba(0,0,0,0)). The real token for
+ * var(--border-default) is `panel.border`, i.e. `bg-panel-border`.
  */
 export interface SkeletonProps {
   className?: string
@@ -19,7 +25,7 @@ export function Skeleton({ className = '', label }: SkeletonProps) {
       role={label ? 'status' : undefined}
       aria-label={label}
       aria-hidden={label ? undefined : true}
-      className={`relative block overflow-hidden rounded-md bg-border-default motion-safe:animate-pulse ${className}`}
+      className={`relative block overflow-hidden rounded-md bg-panel-border motion-safe:animate-pulse ${className}`}
     />
   )
 }


### PR DESCRIPTION
## What

While an analysis runs, only the Analysis tab showed any run state. Dispatching or rerunning with Compare or Model fronted changed nothing on screen (UI brief 2026-07-16 item 3, F9), and no settle announcement existed outside the Analysis tab. This PR adds banner-or-skeleton run-state coverage to the surfaces outside that tab, plus a single aria-live region announcing run start and settle.

## The useAnalysisTrust decision: consume, with one addition

`useAnalysisTrust()` (#352) already composes `isRunning`, so this lane consumes it everywhere rather than minting a parallel run-state hook; a second source of truth would repeat the exact class #352 consolidated. One field is added to the composition, in its designated home: `runStartedAt` (the store's `results.startedAt`), so reused banners narrate from the true run clock instead of mount time (the #327 round-2 regression class). Nothing else changed in the trust surface; all 8 existing consumers are untouched.

## Surfaces covered

| Surface | In flight, content retained | In flight, nothing retained | Settle / error |
|---|---|---|---|
| Compare tab body | running banner above retained snapshots, scroller `aria-busy` | skeleton replaces the frozen empty state | treatment gone, honest state back |
| Model tab body | running banner above the retained model, body `aria-busy` | defensive skeleton (no model) | treatment gone, busy mark gone |
| Coaching-panel body (`CoachingPanel`, render-only Phase 0) | banner above retained signals via props | skeleton; the frozen "no coaching" line is suppressed mid-run | treatment gone, empty line back |

Shared primitive: new `AnalysisRunStateCover` (presentational), which reuses `AnalysisRunningBanner` (now with an `announces` prop, default true so the Analysis tab mount is attribute-identical) and a DS Skeleton brick card. Both forms are visual only; no surface mints its own live region.

**Coaching-panel scope call:** the live coaching surfaces (Strengthen on staging, FocusNow fallback) mount inside the Analysis tab's results body, which already sits under that tab's run treatment (banner plus `aria-busy` wrapper). Mounting a second banner there would recreate the stacked-furniture class F10/F11 just removed, so the coaching-panel BODY gates via props (`isRunning`, `runStartedAt`), proven fixture-first, and its future mount inherits the coverage.

## One live region

New `AnalysisRunAnnouncer`, mounted once at the dock root (survives tab switches; visually hidden; polite). The yield rule extends the Wave1-L2 single-narration-region doctrine and lives beside it as `runAnnouncementForTransition` in `analysisRunStatus.ts`:

- While the Analysis tab is fronted the announcer yields every transition: that tab's own furniture already speaks (the running banner's narration div at start, which is the known #329 double-announce trap; the completion toast and error alert at settle).
- First runs (idle or cancelled to active) yield unconditionally: the dock's I.1 auto-switch fronts the Analysis tab in the same breath, and the announcer's effect observes the transition one commit before the switch, so encoding the contract beats racing the commit. Reruns do not auto-switch, which is exactly the frozen-panel scenario F9 exists for; there the current frontedness decides.
- Settle copy never fabricates an outcome: only complete, error and cancelled get a line ("Analysis complete." / "Analysis failed." / "Analysis cancelled.").

## Found and fixed on the way

The #351 Skeleton brick rendered invisible: its `bg-border-default` class does not exist in the Tailwind palette (the `border` colour group only defines `emphasis`), verified live with computed background `rgba(0,0,0,0)`. Fixed to the real token `bg-panel-border` (`var(--border-default)`); this lane is the brick's first production consumer. The same dead class on two `CanvasViewportControls` separators is filed separately.

## Tests

RED first at dd9c4f9a (19 doctrinal failures, positive controls green), GREEN at d939f5e9:

- `analysisTrust.runStartedAt.spec.ts`: the composition carries the run clock.
- `analysisRunStatus.announcement.spec.ts`: the pure one-voice rule, including both yield branches.
- `AnalysisRunAnnouncer.spec.tsx`: transitions, yields, no re-announce on tab switch, no retroactive start on mid-run mount, single region.
- `AnalysisRunStateCover.spec.tsx`: banner-or-skeleton, non-announcing, true-clock narration on mid-run mount.
- `CompareTabBody.runState.spec.tsx`, `ModelTabBody.runState.spec.tsx`, coaching-panel `runState.spec.tsx`: per-surface pins with positive controls, settle and error restoration, and zero per-surface `aria-live`.
- `OutputsDock.dom.spec.tsx` (new F9 describe): announcer mounted once; rerun start and settle announced with Compare or Model fronted, exactly one live region speaking; silence on first-run auto-switch; yield with Analysis fronted.

Mutation checks (throwaway worktree, 8 mutations, each reverted after): Compare/Model/Coaching wiring reverts each fail their pins; announcer unmount fails all 5 dock pins; removing the fronted yield fails 5 tests (the double-announce pin); removing the first-run yield fails 3; forcing the banner to always announce fails 3; dropping `runStartedAt` from the composition fails its pin.

Adjacent suites green (about 700 tests across dock, coaching-panel, compare-tab, model-tab, freshness and conversation consumers). Two pre-existing `OutputsDock.conversationSingleton` failures reproduce at base bf921314 with the implementation stashed; not from this lane.

## Typechecks

- `pnpm typecheck` (tsconfig.ci.json, the narrow ~6-file gate): clean.
- Wide `tsc -p tsconfig.app.json` multiset against a matched base worktree at bf921314 (same install): 2316 == 2316 errors; the only diff is a 2-line position shift of a pre-existing TS6133 in ModelTabBody.

## Real-browser acceptance (dev server on this branch, states driven through the real store)

- Model fronted mid-run: banner with staged narration ("Still analysing...") above the retained model, `aria-busy="true"`, banner carries no role or aria-live.
- Compare fronted, rerun dispatched: announcer text "Analysis started." with exactly one `aria-live` element carrying it; skeleton (visible after the brick fix, lines at `rgb(238,230,216)`) replaces the empty state.
- Settle with Model fronted: "Analysis complete.", banner unmounts, busy mark clears.
- Error with Compare fronted: "Analysis failed.", skeleton gone, honest empty state restored.
- First run: the I.1 auto-switch fronted the Analysis tab and the announcer stayed silent.

## Residual gaps (pre-existing, out of scope walls)

- First-run settle with the Analysis tab fronted still announces nothing (the completion toast only fires if the freshness notice was mounted during the run; the skeleton has no settle line). Analysis-tab furniture, untouched per the scope wall.
- The Strengthen panel (staging coaching surface, wave 3a, not `coaching-panel/*`) relies on the Analysis tab treatment; it gained no panel-level mark by design (see scope call above).

Draft; do not merge. Mutation and acceptance evidence recorded above; review before any merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
