### PR TITLE
feat(conversation): suggested-chips cap 2→3 per ruled doctrine D-K (F6 UI half)

### DIFF
--- a/src/canvas/conversation/__tests__/SuggestedChips.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.spec.tsx
@@ -2,7 +2,8 @@
  * Tests for SuggestedChips.
  *
  * Verifies:
- * - Chip count: 0, 1, 2 (max); 0 chips renders no container
+ * - Chip count: 0-3 (ruled doctrine D-K, closed 15 Jul); 0 chips renders no
+ *   container (never a fabricated filler chip); 4+ offered still caps at 3
  * - Chips without message field are not rendered
  * - Click dispatches chip.message (not chip.label) — verified via onChipClick call arg
  * - Click failure shows inline error that auto-dismisses after 5s
@@ -57,7 +58,7 @@ describe('SuggestedChips — 0 chips', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Chip count: 1, 2, 3, 4
+// Chip count: 0-3 (ruled doctrine D-K)
 // ---------------------------------------------------------------------------
 
 describe('SuggestedChips — chip count', () => {
@@ -66,19 +67,38 @@ describe('SuggestedChips — chip count', () => {
     expect(screen.getAllByRole('button')).toHaveLength(1)
   })
 
-  it('renders 2 chips', () => {
+  it('renders 2 chips (existing 2-chip behaviour unchanged)', () => {
     const chips = [chip({ id: 'c1' }), chip({ id: 'c2' })]
     render(<SuggestedChips chips={chips} onChipClick={vi.fn().mockResolvedValue(undefined)} />)
     expect(screen.getAllByRole('button')).toHaveLength(2)
   })
 
-  it('caps at 2 chips even when more are supplied (DS v5 §21.4)', () => {
+  it('renders 3 chips when 3 are offered, in offered order (ruled doctrine D-K)', () => {
+    const chips = [
+      chip({ id: 'c1', label: 'First' }),
+      chip({ id: 'c2', label: 'Second' }),
+      chip({ id: 'c3', label: 'Third' }),
+    ]
+    render(<SuggestedChips chips={chips} onChipClick={vi.fn().mockResolvedValue(undefined)} />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(3)
+    // Order preserved: DOM order matches offered order
+    expect(buttons.map(b => b.getAttribute('data-testid'))).toEqual([
+      'suggested-chip-c1',
+      'suggested-chip-c2',
+      'suggested-chip-c3',
+    ])
+  })
+
+  it('caps at 3 chips when 4+ are supplied (ruled doctrine D-K: 0-3)', () => {
     const chips = [
       chip({ id: 'c1' }), chip({ id: 'c2' }), chip({ id: 'c3' }),
       chip({ id: 'c4' }), chip({ id: 'c5' }),
     ]
     render(<SuggestedChips chips={chips} onChipClick={vi.fn().mockResolvedValue(undefined)} />)
-    expect(screen.getAllByRole('button')).toHaveLength(2)
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+    expect(screen.queryByTestId('suggested-chip-c4')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('suggested-chip-c5')).not.toBeInTheDocument()
   })
 
   it('does not render chips without a message field', () => {

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -3434,7 +3434,8 @@ export function useConversation(): UseConversationReturn {
             ]
 
             // V5 suggested_actions → ActionChip. CEE caps count server-side;
-            // UI additionally caps rendering per DS v5 §21.4 in SuggestedChips.
+            // UI additionally caps rendering at 3 in SuggestedChips (ruled
+            // doctrine D-K, closed 15 Jul: 0-3 chips, no fabricated filler).
             // action_type when present drives deterministic routing on next click.
             const actionChips: ActionChip[] = target.response.suggested_actions.map((a) => ({
               id: a.id,

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -2,7 +2,9 @@
  * SuggestedChips — stagger-animated action chips after AI messages.
  *
  * Each chip fades in + slides up with 70ms delay between.
- * Up to 2 chips (DS v5 §21.4 cap). Chip base: bg-panel, border
+ * 0-3 chips (ruled doctrine D-K, closed 15 Jul: render up to 3 when CEE
+ * offers 3; render none when CEE offers none — never fabricate a filler
+ * chip; labels render verbatim as sent by CEE). Chip base: bg-panel, border
  * border-panel-border, hover:bg-panel-hover. Role metadata preserved via
  * data-chip-role and aria-label for styling/accessibility.
  *
@@ -253,8 +255,10 @@ export function SuggestedChips({
         )
     : supported
 
-  // DS v5 §21.4: max 2 suggested action chips
-  const visible = polished.filter(c => !!(c.message || c.prompt)).slice(0, 2)
+  // Ruled doctrine D-K (closed 15 Jul): 0-3 suggested action chips — render
+  // up to 3 when offered, none when none offered (no filler). Supersedes the
+  // DS v5 §21.4 "max 2" cap; the DS doc amendment is owned by the DS-1 lane.
+  const visible = polished.filter(c => !!(c.message || c.prompt)).slice(0, 3)
   if (visible.length === 0) return null
 
   const disabled = isThinking || isHistorical


### PR DESCRIPTION
## What

Lifts the suggested-chips render cap in `SuggestedChips.tsx` from `slice(0, 2)` to `slice(0, 3)` per **ruled doctrine D-K (closed 15 Jul): 0–3 chips** — render up to 3 when CEE offers 3; render none when CEE offers none (never fabricate a filler chip). Labels render verbatim as sent by CEE; the label-content half of F6 is CEE work.

## Changes

- `src/canvas/conversation/zones/SuggestedChips.tsx` — cap 2→3; header + cap-site comments now cite D-K (the stale DS v5 §21.4 "max 2" citation superseded)
- `src/canvas/conversation/useConversation.ts:3437` — stale §21.4 comment at the V5 chip-mapping site updated to cite D-K (comment only, no behaviour)
- `src/canvas/conversation/__tests__/SuggestedChips.spec.tsx` — new pins (see below)

## Cap-site sweep (`/usr/bin/grep -rn "slice(0, *2)|§21.4|max 2|two chips" src/`)

| Site | Disposition |
|---|---|
| `SuggestedChips.tsx:257` `slice(0, 2)` | **Fixed** — the only site truncating suggested chips to 2 |
| `useConversation.ts` `enforceChipBudget` / `MAX_SUGGESTED_ACTIONS` (types.ts:621) | Already 3 — doctrine-compliant, untouched |
| `useConversation.ts:3437` §21.4 comment | Comment updated to D-K |
| `Conversation.module.css:1844`, `EvidenceBlock.spec`, `ActionChipRow.spec` §21.4 refs | Left — §21.4 *styling/aria* contract (outlined pill, classes), not the count cap |
| `NodeBadge`, `RiskNode`, `FactorNode.spec`, `render-matrix.spec` "max 2 chips per node" | Left — canvas *node* chip audit table, a different documented cap |
| `InspectorGuidanceSection`, `InsightsPanel`, `ConditionalGuidance`, `guided.ts`, `useScienceIcons`, `PreAnalysisPanel` | Left — different features, documented separately |
| `lib/nextSteps.ts:161`, `useResultsPanelData.ts:540` | Left — results-panel recommendations, not the chip surface; no live importer outside tests |

**DS doc amendment needed (DS-1 lane owns it):** `docs/design/Olumi_Design_System_v4.md` §21.4 still says "max 2 suggested action chips" — needs amending to the D-K 0–3 doctrine. Not edited here.

## Evidence

- **RED commit** `84e71316` — new pins fail on the old cap (3 offered → 2 rendered; 5 offered → 2 rendered): `Tests 2 failed | 27 passed (29)`
- **GREEN commit** `e4103074` — 29/29 pass. Pins: 3 offered → 3 rendered in offered order; 4+ offered → 3 (cap still bites); 0 offered → no container, no filler (pre-existing pin); 2 offered → 2 (unchanged)
- **Mutation check** (throwaway worktree at `e4103074`, cap reverted to `slice(0, 2)`): exactly the two D-K pins go RED — "renders 3 chips when 3 are offered, in offered order" and "caps at 3 chips when 4+ are supplied". Worktree removed after.

## Gates

- `pnpm run typecheck` (tsconfig.ci.json) — clean
- `npx vitest run --changed origin/staging` — 76 files passed | 1 skipped; 1087 tests passed | 31 skipped, 0 failed
- `pnpm run lint` — 0 errors (1100 pre-existing warnings)
- Wide tsc multiset diff (`tsc -p tsconfig.app.json --noEmit`, lane vs fresh matched base worktree at `3e971f0b`, sorted + count-normalised): 4025 lines both sides; raw diff shows only line-number shifts of identical pre-existing errors caused by added comment lines; position-normalised multiset diff is EMPTY — **zero new errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)