### PR TITLE
feat(conversation): phase-3 card pacing + legend (F16) + #356 call-site pin + title-map parity

### DIFF
--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -28,6 +28,7 @@ import { StickyFooter } from './StickyFooter'
 import { focusNodeById } from '../../utils/focusHelpers'
 import { withObservedStateUpdate } from '../../utils/observedStateHelpers'
 import { useCanvasStore } from '../../store'
+import { BIAS_SIGNAL_TITLES } from '../../shared/biasSignalTitles'
 import { useDraftStore } from '../../stores/draftStore'
 import { useRetryDraft } from '../../hooks/useRetryDraft'
 import { SOFT_BYPASS_STATUSES } from '../../hooks/usePreRunValidation'
@@ -85,31 +86,49 @@ const AI_SOURCES = new Set(['ai', 'cee_inference', 'inferred', 'ai_estimate', 'e
  *      need explicit mapping per the brief.
  *
  * Any unrecognised key falls back to BIAS_FALLBACK (EyeOff) per the brief.
+ *
+ * #356 fast-follow: TITLES derive from the ONE canonical map
+ * (src/canvas/shared/biasSignalTitles.ts) shared with the conversation
+ * bias-signal cards — one bias, one name, every surface. Only the ICON
+ * channel stays panel-local. A key with no canonical title is omitted
+ * (falls through to BIAS_FALLBACK — fail closed, never an invented
+ * title); the parity spec's drift trap fails loud if that ever happens.
+ * Exported for that drift trap (biasSignalTitles.parity.spec.ts).
  */
-const BIAS_TYPE_ICON: Record<string, { icon: typeof Frame; title: string }> = {
+const BIAS_TYPE_ICON_CHANNEL: Record<string, typeof Frame> = {
   // Lowercase type values (existing field convention)
-  framing:           { icon: Frame,  title: 'Narrow framing' },
-  framing_bias:      { icon: Frame,  title: 'Narrow framing' },
-  narrow_framing:    { icon: Frame,  title: 'Narrow framing' },
-  anchoring:         { icon: Anchor, title: 'Anchoring' },
-  anchoring_bias:    { icon: Anchor, title: 'Anchoring' },
-  confidence:        { icon: Gauge,  title: 'Overconfidence' },
-  overconfidence:    { icon: Gauge,  title: 'Overconfidence' },
-  optimism_bias:     { icon: Gauge,  title: 'Optimism bias' },
-  blind_spots:       { icon: EyeOff, title: 'Blind spots' },
-  status_quo_bias:   { icon: EyeOff, title: 'Status quo bias' },
-  confirmation:      { icon: Frame,  title: 'Confirmation bias' },
-  confirmation_bias: { icon: Frame,  title: 'Confirmation bias' },
-  authority_bias:    { icon: Anchor, title: 'Authority bias' },
-  availability_bias: { icon: Frame,  title: 'Availability bias' },
-  sunk_cost:         { icon: Anchor, title: 'Sunk cost' },
+  framing:           Frame,
+  framing_bias:      Frame,
+  narrow_framing:    Frame,
+  anchoring:         Anchor,
+  anchoring_bias:    Anchor,
+  confidence:        Gauge,
+  overconfidence:    Gauge,
+  optimism_bias:     Gauge,
+  blind_spots:       EyeOff,
+  status_quo_bias:   EyeOff,
+  confirmation:      Frame,
+  confirmation_bias: Frame,
+  authority_bias:    Anchor,
+  availability_bias: Frame,
+  sunk_cost:         Anchor,
   // Uppercase code values (newer schema)
-  AUTHORITY_BIAS:    { icon: Anchor, title: 'Authority bias' },
-  CONFIRMATION_BIAS: { icon: Gauge,  title: 'Confirmation bias' },
-  SUNK_COST:         { icon: Anchor, title: 'Sunk cost' },
-  NARROW_FRAMING:    { icon: Frame,  title: 'Narrow framing' },
-  STATUS_QUO_BIAS:   { icon: EyeOff, title: 'Status quo bias' },
+  AUTHORITY_BIAS:    Anchor,
+  CONFIRMATION_BIAS: Gauge,
+  SUNK_COST:         Anchor,
+  NARROW_FRAMING:    Frame,
+  STATUS_QUO_BIAS:   EyeOff,
 }
+
+export const BIAS_TYPE_ICON: Record<string, { icon: typeof Frame; title: string }> =
+  Object.fromEntries(
+    Object.entries(BIAS_TYPE_ICON_CHANNEL).flatMap(([key, icon]) => {
+      const title = Object.prototype.hasOwnProperty.call(BIAS_SIGNAL_TITLES, key.toLowerCase())
+        ? BIAS_SIGNAL_TITLES[key.toLowerCase()]
+        : undefined
+      return title ? [[key, { icon, title }] as const] : []
+    }),
+  )
 
 /**
  * Entity-ID prefixes that must NEVER appear in user-facing copy. If a CEE bug

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -1925,3 +1925,97 @@
   padding: 6px 12px;
   min-height: 32px;
 }
+
+/* ---------------------------------------------------------------------------
+ * § F16 — phase-3 card pacing + graph vocabulary legend
+ * ---------------------------------------------------------------------------*/
+
+/* Visually hidden, screen-reader-only status text. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* The single count affordance for collapsed phase-3 cards — outlined per DS,
+ * never filled. */
+.phase3PacingToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  font-size: 12px; /* panelBody */
+  font-weight: 500;
+  color: var(--text-body, #262626);
+  background: transparent;
+  border: 1px solid var(--border-default, #E4E2E0);
+  border-radius: 9999px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.phase3PacingToggle:hover {
+  background: var(--bg-panel-hover, #FEF9F3);
+}
+
+.vocabularyLegend {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.vocabularyLegendToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  align-self: flex-start;
+  font-size: 11px; /* panelMeta */
+  color: var(--text-light, #908D8D);
+  background: none;
+  border: none;
+  padding: 2px 0;
+  cursor: pointer;
+}
+
+.vocabularyLegendToggle:hover {
+  color: var(--text-body, #262626);
+  text-decoration: underline;
+}
+
+.vocabularyLegendList {
+  margin: 0;
+  padding: 8px 12px;
+  background: var(--bg-panel, #FEFEFE);
+  border: 1px solid var(--border-default, #E4E2E0);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.vocabularyLegendRow {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.vocabularyLegendTerm {
+  min-width: 76px;
+}
+
+.vocabularyLegendDefinition {
+  margin: 0;
+  color: var(--text-light, #908D8D);
+}
+
+.phase3PacingToggle:focus-visible,
+.vocabularyLegendToggle:focus-visible {
+  outline: 2px solid var(--info, #52A3C8);
+  outline-offset: 2px;
+}

--- a/src/canvas/conversation/GraphVocabularyLegend.tsx
+++ b/src/canvas/conversation/GraphVocabularyLegend.tsx
@@ -1,0 +1,61 @@
+/**
+ * GraphVocabularyLegend — F16: the small "What do these terms mean?"
+ * affordance rendered near phase-3 coaching/review cards
+ * (COACHING-REVIEW-UI-BRIEF names the legend affordance; the brief
+ * specifies no legend copy, so this is the minimal legend of the node/edge
+ * vocabulary the cards' target references use).
+ *
+ * Static UI-authored educational copy only — it defines the canvas
+ * vocabulary, never interprets producer data (no values, no thresholds,
+ * no science interpretation), so the UI-passthrough doctrine is not in
+ * play. Collapsed by default; outlined text affordance per DS (no filled
+ * pill, Lucide icon only).
+ */
+import { useState } from 'react'
+import { ChevronDown, ChevronUp, HelpCircle } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import styles from './Conversation.module.css'
+
+/** Minimal node/edge vocabulary used by phase-3 card target references. */
+const LEGEND_TERMS: ReadonlyArray<{ term: string; definition: string }> = [
+  { term: 'Decision', definition: 'The choice you are weighing up.' },
+  { term: 'Option', definition: 'A course of action you could take.' },
+  { term: 'Factor', definition: 'Something that influences how things turn out.' },
+  { term: 'Risk', definition: 'An uncertain event that could work against you.' },
+  { term: 'Goal', definition: 'The outcome you are trying to achieve.' },
+  { term: 'Constraint', definition: 'A limit the decision must respect.' },
+  { term: 'Link', definition: 'An arrow showing one element influencing another.' },
+]
+
+export function GraphVocabularyLegend() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className={styles.vocabularyLegend}>
+      <button
+        type="button"
+        className={styles.vocabularyLegendToggle}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <HelpCircle size={12} aria-hidden="true" />
+        What do these terms mean?
+        {open
+          ? <ChevronUp size={12} aria-hidden="true" />
+          : <ChevronDown size={12} aria-hidden="true" />}
+      </button>
+      {open && (
+        <dl className={styles.vocabularyLegendList} aria-label="Graph vocabulary">
+          {LEGEND_TERMS.map(({ term, definition }) => (
+            <div key={term} className={styles.vocabularyLegendRow}>
+              <dt className={`${typography.panelHeader} ${styles.vocabularyLegendTerm}`}>{term}</dt>
+              <dd className={`${typography.panelMeta} ${styles.vocabularyLegendDefinition}`}>
+                {definition}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  )
+}

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -40,6 +40,8 @@ import { ArtefactBlock as ArtefactBlockComponent } from '../../components/chat/A
 import type { PatchBlockState, PatchRejectionInfo } from './useConversation'
 import { MAX_VISIBLE_BLOCKS_PER_TURN } from './types'
 import { GraphPatchBlockRenderer, ProposalBlockRenderer } from './blocks/GraphPatchBlockRenderer'
+import { computePhase3Pacing, isPhase3CardBlock } from './phase3Pacing'
+import { GraphVocabularyLegend } from './GraphVocabularyLegend'
 import { V5AnalysisResultBlock } from '../../v5/blocks/V5AnalysisResultBlock'
 import { V5GraphPatchBlock } from '../../v5/blocks/V5GraphPatchBlock'
 import { V5ExplanationBlock } from '../../v5/blocks/V5ExplanationBlock'
@@ -134,16 +136,71 @@ export const InlineBlocks = memo(function InlineBlocks({
   assistantTextWordCount = 0,
 }: InlineBlocksProps) {
   const [showAll, setShowAll] = useState(false)
+  // F16: phase-3 card pacing — flood turns default to the top 3 phase-3
+  // cards expanded, the remainder behind ONE count affordance.
+  const [showAllPhase3, setShowAllPhase3] = useState(false)
 
-  const visible = showAll ? blocks : blocks.slice(0, MAX_VISIBLE_BLOCKS_PER_TURN)
-  const hasOverflow = blocks.length > MAX_VISIBLE_BLOCKS_PER_TURN
-  const hiddenCount = blocks.length - MAX_VISIBLE_BLOCKS_PER_TURN
+  const pacing = computePhase3Pacing(blocks)
+
+  // Legacy per-turn budget. When phase-3 pacing is active, the phase-3
+  // cards carry their own budget (the pacing group), so the legacy cap
+  // counts only the non-phase-3 blocks; otherwise behaviour is unchanged
+  // (cap across all blocks, as before F16).
+  const budgetIndices: number[] = []
+  for (let i = 0; i < blocks.length; i++) {
+    if (pacing.pacingActive && isPhase3CardBlock(blocks[i])) continue
+    budgetIndices.push(i)
+  }
+  const hiddenByBudget = new Set(
+    showAll ? [] : budgetIndices.slice(MAX_VISIBLE_BLOCKS_PER_TURN),
+  )
+  const hasOverflow = budgetIndices.length > MAX_VISIBLE_BLOCKS_PER_TURN
+  const hiddenCount = budgetIndices.length - MAX_VISIBLE_BLOCKS_PER_TURN
   // DS v5 §21.2: block type badge dots are always on (no v2 flag gate).
   const showBadgeDots = true
 
+  const phase3Collapsed = pacing.pacingActive && !showAllPhase3
+
   return (
     <div className={styles.blockContainer}>
-      {visible.map((block, i) => {
+      {pacing.pacingActive && (
+        // Collapsed-count announcement for screen readers. The affordance's
+        // accessible name carries the count too; this status region also
+        // announces the change on reveal.
+        <span role="status" className={styles.srOnly}>
+          {phase3Collapsed
+            ? `${pacing.collapsedCount} more coaching and review cards collapsed`
+            : `Showing all ${pacing.phase3Count} coaching and review cards`}
+        </span>
+      )}
+      {blocks.map((block, i) => {
+        // The single phase-3 count affordance sits at the position of the
+        // first collapsed card, so reading order is preserved exactly.
+        const affordance =
+          pacing.pacingActive && i === pacing.affordanceIndex ? (
+            <button
+              type="button"
+              className={styles.phase3PacingToggle}
+              onClick={() => setShowAllPhase3((v) => !v)}
+              aria-expanded={showAllPhase3}
+              aria-label={
+                showAllPhase3
+                  ? 'Show fewer coaching and review cards'
+                  : `Show ${pacing.collapsedCount} more coaching and review card${pacing.collapsedCount !== 1 ? 's' : ''}`
+              }
+            >
+              {showAllPhase3 ? (
+                <><ChevronUp size={12} aria-hidden="true" /> Show less</>
+              ) : (
+                <><ChevronDown size={12} aria-hidden="true" /> Show {pacing.collapsedCount} more</>
+              )}
+            </button>
+          ) : null
+
+        if (hiddenByBudget.has(i) || (phase3Collapsed && pacing.collapsedIndices.has(i))) {
+          return affordance ? <div key={i}>{affordance}</div> : null
+        }
+
         const badgeDotClass = showBadgeDots ? resolveBlockBadgeDotClass(block) : null
         return (
           // data-citation-target is 1-based; CitationRef.index matches this
@@ -154,6 +211,7 @@ export const InlineBlocks = memo(function InlineBlocks({
             className={badgeDotClass ? styles.blockWithBadge : undefined}
             {...(block.type === 'graph_patch' ? { 'data-patch-id': block.patch_id } : {})}
           >
+            {affordance}
             {badgeDotClass && <span className={badgeDotClass} data-testid="block-badge-dot" aria-hidden="true" />}
             <BlockRenderer
               block={block}
@@ -180,6 +238,8 @@ export const InlineBlocks = memo(function InlineBlocks({
           {showAll ? 'Show less' : `Show ${hiddenCount} more`}
         </button>
       )}
+      {/* F16: graph-vocabulary legend affordance near the phase-3 cards. */}
+      {pacing.phase3Count > 0 && <GraphVocabularyLegend />}
     </div>
   )
 })

--- a/src/canvas/conversation/__tests__/InlineBlocks.phase3Pacing.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.phase3Pacing.spec.tsx
@@ -1,0 +1,212 @@
+/**
+ * F16 — phase-3 card pacing + graph-vocabulary legend (COACHING-REVIEW-UI-BRIEF §3
+ * progressive disclosure, ratified renderer target).
+ *
+ * A single run response can land 10–15 phase-3 blocks (observed live:
+ * 5 review_card + 4 coaching + 1 evidence) with no pacing — a card flood.
+ * These pins hold the ratified pacing contract at the RENDER layer
+ * (InlineBlocks): the store/message keeps ALL blocks; the panel defaults to
+ * the top 3 phase-3 cards expanded, the remainder behind exactly ONE count
+ * affordance, order preserved exactly, collapsed count announced to screen
+ * readers. A small "What do these terms mean?" affordance offers the graph
+ * vocabulary legend near the cards.
+ *
+ * Flood pin (mutation check): reverting the grouping renders 4 cards by the
+ * legacy per-turn cap instead of 3 → the default-expanded pin goes RED.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { InlineBlocks } from '../InlineBlocks'
+import type {
+  ConversationBlock,
+  FactBlock,
+  V5CoachingBlock,
+  V5EvidenceBlock,
+  V5ReviewCardBlock,
+} from '../types'
+
+// Minimal canvas store mock — InlineBlocks reads `nodes` for patch target
+// lookup and the V5 target-ref pills read selection actions (same shape as
+// InlineBlocks.dsv5.spec.tsx).
+vi.mock('../../store', () => {
+  const mockState = {
+    nodes: [] as Array<{ id: string }>,
+    selectNodeWithoutHistory: vi.fn(),
+    selectNodes: vi.fn(),
+    setShowInspectorPanel: vi.fn(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+  }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+// ─── Fixture: the observed live flood shape ──────────────────────────────
+// 5 review_card + 4 coaching + 1 evidence = 10 phase-3 blocks in one turn.
+
+function reviewCard(n: number): V5ReviewCardBlock {
+  return {
+    type: 'v5_review_card',
+    block_id: `rc_${n}`,
+    title: `Review card ${n}`,
+    body: `Review body ${n}`,
+    severity: 'info',
+    card_kind: 'narrative',
+    target_refs: [],
+    priority_rank: n,
+    freshness: 'fresh',
+  }
+}
+
+function coaching(n: number): V5CoachingBlock {
+  return {
+    type: 'v5_coaching',
+    block_id: `co_${n}`,
+    title: `Coaching card ${n}`,
+    body: `Coaching body ${n}`,
+    coaching_kind: 'assumption_check',
+    source: 'decision_review',
+    target_refs: [],
+    priority_rank: 10 + n,
+    freshness: 'fresh',
+  }
+}
+
+function evidence(n: number): V5EvidenceBlock {
+  return {
+    type: 'v5_evidence',
+    block_id: `ev_${n}`,
+    factor_label: `Evidence factor ${n}`,
+    target_refs: [],
+    current_confidence: 'low',
+    evidence_gap: `Gap ${n}`,
+    suggested_technique: `Technique ${n}`,
+    impact_if_gathered: `Impact ${n}`,
+    priority_rank: 20 + n,
+    severity: 'info',
+    freshness: 'fresh',
+  }
+}
+
+/** The a16a0e82-shaped flood: 5 review + 4 coaching + 1 evidence, in order. */
+function floodBlocks(): ConversationBlock[] {
+  return [
+    reviewCard(1),
+    reviewCard(2),
+    reviewCard(3),
+    reviewCard(4),
+    reviewCard(5),
+    coaching(1),
+    coaching(2),
+    coaching(3),
+    coaching(4),
+    evidence(1),
+  ]
+}
+
+const factBlock: FactBlock = {
+  type: 'fact',
+  value: '42%',
+  label: 'Conversion lift',
+  fact_type: 'simple',
+}
+
+/** All rendered phase-3 card title texts, in DOM order. */
+function renderedCardTitles(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll(
+      '[data-testid="v5-review-card-title"], [data-testid="v5-coaching-title"], [data-testid="v5-evidence-title"]',
+    ),
+  ).map((el) => el.textContent ?? '')
+}
+
+// ─── Pins ────────────────────────────────────────────────────────────────
+
+describe('InlineBlocks — phase-3 card pacing (F16)', () => {
+  it('FLOOD PIN: a 10-block phase-3 flood defaults to exactly 3 expanded cards', () => {
+    const { container } = render(<InlineBlocks blocks={floodBlocks()} />)
+    expect(renderedCardTitles(container)).toEqual([
+      'Review card 1',
+      'Review card 2',
+      'Review card 3',
+    ])
+  })
+
+  it('the remainder sits behind exactly ONE count affordance announcing the collapsed count', () => {
+    render(<InlineBlocks blocks={floodBlocks()} />)
+    const toggles = screen.getAllByRole('button', { name: /show 7 more/i })
+    expect(toggles).toHaveLength(1)
+    expect(toggles[0]).toHaveAttribute('aria-expanded', 'false')
+    // No competing second overflow affordance for the same turn.
+    expect(screen.getAllByRole('button', { name: /show \d+ more/i })).toHaveLength(1)
+  })
+
+  it('screen reader status announces the collapsed count', () => {
+    render(<InlineBlocks blocks={floodBlocks()} />)
+    expect(screen.getByRole('status')).toHaveTextContent(/7 more/i)
+  })
+
+  it('ONE interaction reveals all 10 cards with order preserved exactly', () => {
+    const { container } = render(<InlineBlocks blocks={floodBlocks()} />)
+    fireEvent.click(screen.getByRole('button', { name: /show 7 more/i }))
+    expect(renderedCardTitles(container)).toEqual([
+      'Review card 1',
+      'Review card 2',
+      'Review card 3',
+      'Review card 4',
+      'Review card 5',
+      'Coaching card 1',
+      'Coaching card 2',
+      'Coaching card 3',
+      'Coaching card 4',
+      'Evidence factor 1',
+    ])
+  })
+
+  it('non-phase-3 blocks in the same turn stay visible and do not consume the card budget', () => {
+    const { container } = render(
+      <InlineBlocks blocks={[factBlock, ...floodBlocks()]} />,
+    )
+    // The fact block renders alongside the 3 default-expanded cards.
+    expect(screen.getByTestId('block-fact')).toBeInTheDocument()
+    expect(renderedCardTitles(container)).toEqual([
+      'Review card 1',
+      'Review card 2',
+      'Review card 3',
+    ])
+    expect(screen.getByRole('button', { name: /show 7 more/i })).toBeInTheDocument()
+  })
+
+  it('no pacing affordance when the turn carries 3 or fewer phase-3 cards', () => {
+    const { container } = render(
+      <InlineBlocks blocks={[reviewCard(1), coaching(1), evidence(1)]} />,
+    )
+    expect(renderedCardTitles(container)).toHaveLength(3)
+    expect(screen.queryByRole('button', { name: /show \d+ more/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('InlineBlocks — graph-vocabulary legend affordance (F16)', () => {
+  it('offers "What do these terms mean?" near phase-3 cards and reveals the legend on demand', () => {
+    render(<InlineBlocks blocks={floodBlocks()} />)
+    const legendToggle = screen.getByRole('button', { name: /what do these terms mean/i })
+    expect(legendToggle).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(legendToggle)
+    expect(legendToggle).toHaveAttribute('aria-expanded', 'true')
+    // Minimal node/edge vocabulary of the cards' target refs.
+    for (const term of ['Factor', 'Option', 'Goal', 'Risk', 'Constraint', 'Link']) {
+      expect(screen.getByText(term)).toBeInTheDocument()
+    }
+  })
+
+  it('renders no legend affordance when the turn has no phase-3 cards', () => {
+    render(<InlineBlocks blocks={[factBlock]} />)
+    expect(
+      screen.queryByRole('button', { name: /what do these terms mean/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/conversation/__tests__/biasSignalTitles.parity.spec.ts
+++ b/src/canvas/conversation/__tests__/biasSignalTitles.parity.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * PR #356 fast-follow 2 — bias-title canonical-map parity.
+ *
+ * BIAS_SIGNAL_TITLES (conversation cards, draftBiasSignalBlocks.ts) was a
+ * hand-maintained mirror of the titles inside BIAS_TYPE_ICON
+ * (PreAnalysisPanel.tsx) — the repo's dominant defect class. The ratified
+ * fix: ONE shared canonical map (src/canvas/shared/biasSignalTitles.ts)
+ * both surfaces import, so one bias renders one name everywhere by
+ * construction. These pins hold that:
+ *   - the conversation map IS the canonical object (identity, not a copy);
+ *   - the pre-analysis surface resolves every canonical code to the
+ *     canonical title, through its real public mappers (both wire
+ *     conventions: lowercase `type` and uppercase `code`);
+ *   - every icon-map key resolves a canonical title (drift in either
+ *     direction fails loud here, never silently).
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+import { BIAS_SIGNAL_TITLES } from '../../shared/biasSignalTitles'
+import {
+  BIAS_SIGNAL_TITLES as CONVERSATION_TITLES,
+  humaniseBiasSignalCode,
+} from '../draftBiasSignalBlocks'
+import {
+  BIAS_TYPE_ICON,
+  mapDraftBiasSignalToTrigger,
+  normaliseCeeBiasFinding,
+} from '../../components/pre-analysis/PreAnalysisPanel'
+
+// PreAnalysisPanel imports the canvas store transitively; keep the module
+// import light and deterministic (the functions under test are pure).
+vi.mock('../../store', () => {
+  const mockState = { nodes: [] as Array<{ id: string }> }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+describe('bias-signal titles — one canonical map (#356 fast-follow 2)', () => {
+  it('the conversation surface uses the canonical map itself, not a copy', () => {
+    expect(CONVERSATION_TITLES).toBe(BIAS_SIGNAL_TITLES)
+  })
+
+  it('canonical keys are lowercase and titles are non-empty sentence-case strings', () => {
+    const entries = Object.entries(BIAS_SIGNAL_TITLES)
+    expect(entries.length).toBeGreaterThanOrEqual(15)
+    for (const [key, title] of entries) {
+      expect(key).toBe(key.toLowerCase())
+      expect(title.trim().length).toBeGreaterThan(0)
+      expect(title[0]).toBe(title[0].toUpperCase())
+    }
+  })
+
+  it('the pre-analysis draft-signal mapper resolves every canonical code to the canonical title', () => {
+    for (const [code, title] of Object.entries(BIAS_SIGNAL_TITLES)) {
+      const trigger = mapDraftBiasSignalToTrigger(
+        { type: code, detail: 'A grounded detail sentence.' },
+        0,
+        () => null,
+      )
+      expect(trigger, `code ${code} produced no trigger`).not.toBeNull()
+      expect(trigger!.title, `title drift for code ${code}`).toBe(title)
+      // Case-insensitive: the uppercase wire convention lands on the same title.
+      const upper = mapDraftBiasSignalToTrigger(
+        { type: code.toUpperCase(), detail: 'A grounded detail sentence.' },
+        0,
+        () => null,
+      )
+      expect(upper!.title, `uppercase title drift for code ${code}`).toBe(title)
+    }
+  })
+
+  it('the conversation resolver agrees with the canonical map, case-insensitively', () => {
+    for (const [code, title] of Object.entries(BIAS_SIGNAL_TITLES)) {
+      expect(humaniseBiasSignalCode(code)).toBe(title)
+      expect(humaniseBiasSignalCode(code.toUpperCase())).toBe(title)
+    }
+  })
+
+  it('the CEE-findings mapper (uppercase `code` convention) resolves canonical titles', () => {
+    for (const code of ['AUTHORITY_BIAS', 'CONFIRMATION_BIAS', 'SUNK_COST', 'NARROW_FRAMING', 'STATUS_QUO_BIAS']) {
+      const trigger = normaliseCeeBiasFinding(
+        { code, explanation: 'A grounded explanation.' },
+        0,
+        () => null,
+      )
+      expect(trigger, `code ${code} produced no trigger`).not.toBeNull()
+      expect(trigger!.title).toBe(BIAS_SIGNAL_TITLES[code.toLowerCase()])
+    }
+  })
+
+  it('DRIFT TRAP: every icon-map key resolves a canonical title', () => {
+    for (const [key, entry] of Object.entries(BIAS_TYPE_ICON)) {
+      const canonical = BIAS_SIGNAL_TITLES[key.toLowerCase()]
+      expect(canonical, `icon key ${key} has no canonical title`).toBeDefined()
+      expect(entry.title, `icon-map title drift for key ${key}`).toBe(canonical)
+    }
+  })
+})

--- a/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
+++ b/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
@@ -268,3 +268,41 @@ describe('buildDraftBiasSignalBlocks — no raw code string in visible copy (swe
     expect(blocks[0].title).toBe('Status quo bias')
   })
 })
+
+// ─── #356 fast-follow: (bias, target) dedupe ahead of the cap ────────────
+
+describe('buildDraftBiasSignalBlocks — duplicate (type,target) dedupe (#356 fast-follow)', () => {
+  it('an identical (type,target) duplicate cannot displace a distinct third signal', () => {
+    const blocks = build([
+      SIGNAL_ANCHORING,
+      { ...SIGNAL_ANCHORING, detail: 'Same anchoring signal, reworded by the producer.' },
+      SIGNAL_STATUS_QUO,
+    ])
+    expect(blocks).toHaveLength(2)
+    expect(blocks.map((b) => b.title)).toEqual(['Anchoring', 'Status quo bias'])
+    // First occurrence wins — its detail is the rendered body.
+    expect(blocks[0].body).toBe(SIGNAL_ANCHORING.detail)
+  })
+
+  it('dedupes on canonical bias identity: alias codes for the same bias on the same target', () => {
+    const blocks = build([
+      SIGNAL_ANCHORING,
+      { ...SIGNAL_ANCHORING, type: 'anchoring_bias' },
+      SIGNAL_SUNK_COST,
+    ])
+    expect(blocks).toHaveLength(2)
+    expect(blocks.map((b) => b.title)).toEqual(['Anchoring', 'Sunk cost'])
+  })
+
+  it('the same bias on DIFFERENT targets is two distinct signals — both render', () => {
+    const blocks = build([
+      SIGNAL_ANCHORING,
+      { ...SIGNAL_ANCHORING, target: 'fac_current_supplier' },
+    ])
+    expect(blocks).toHaveLength(2)
+    expect(blocks.map((b) => b.target_refs[0].id)).toEqual([
+      'fac_initial_quote',
+      'fac_current_supplier',
+    ])
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.biasSeamCallSite.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.biasSeamCallSite.spec.ts
@@ -1,0 +1,331 @@
+/**
+ * PR #356 fast-follow — CALL-SITE pin for the draft bias-signal seam.
+ *
+ * The existing suites pin the pieces, not the wiring:
+ *   - draftBiasSignalBlocks.spec.ts pins the builder with a hand-injected
+ *     store slice;
+ *   - draftBiasSignalBlocks.seam.spec.ts drives a MIRROR of the sendTurn
+ *     wiring (its own driveSeam copy).
+ * The #356 review proved by mutation that dropping any of the real
+ * call-site arguments — `target.response` into
+ * attachAnalysisReadyToInlineDraftGraph (useConversation.ts ~L3293), or
+ * `isDraftTurn` / `existingBlocks` into buildDraftBiasSignalBlocks
+ * (~L3425-3429) — leaves all 23 seam+builder tests GREEN while the feature
+ * dies in production. This suite is the missing pin: it renders the REAL
+ * useConversation hook and drives sendMessage through the REAL V5
+ * success path (routeV5Response → attach → applyDraftResult → bridge →
+ * addMessage), asserting on the message the user would see.
+ *
+ * Mutation map (each verified RED in a throwaway worktree):
+ *   - drop the 4th arg (`target.response`) at the attach call
+ *       → sidecar coaching never reaches the store → 'renders the two
+ *         grounded bias cards' goes RED (0 cards).
+ *   - drop/false `isDraftTurn: draftAppliedThisTurn`
+ *       → bridge gate never opens → same test RED.
+ *   - drop `existingBlocks: finalBlocks`
+ *       → producer-wins suppression dies → 'producer typed bias coaching
+ *         wins' goes RED (bridge doubles the cards).
+ *
+ * Harness mirrors useConversation.reasoning.spec.ts (the established
+ * V5-happy-path hook harness), plus a real draft graph + root coaching
+ * sidecar in the CEE staging wire shape (build 57959b2c3, 16 Jul 2026).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import { useResultsStore } from '../../stores/resultsStore'
+import { ADDITIVE_EXTENSIONS_KEY } from '../../../v5/responseParser'
+import type { V5CoachingBlock } from '../types'
+
+// ---------------------------------------------------------------------------
+// Mocks (same bridge set as useConversation.reasoning.spec.ts)
+// ---------------------------------------------------------------------------
+
+const mockCallTurn = vi.fn()
+const mockStreamTurn = vi.fn()
+
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockStreamTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+const mockCallV5Turn = vi.fn()
+vi.mock('../../../v5/v5Adapter', () => ({
+  callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+  getV5Endpoint: () => 'https://cee.test/orchestrate/v2/turn',
+}))
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true as const }),
+    isV5CanonicalRunPath: () => flags.isV5CanonicalAnalysisEnabled(),
+  }
+})
+
+const mockGetUserId = vi.fn<[], Promise<string | null>>()
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: (...args: unknown[]) => mockGetUserId(...(args as [])),
+  getSessionIdentity: async () => ({
+    userId: (await mockGetUserId()) ?? null,
+    accessToken: null,
+  }),
+}))
+
+const mockLoadScenario = vi.fn<[string], Promise<unknown>>()
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: (...args: unknown[]) => mockLoadScenario(...(args as [string])),
+}))
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isOrchestratorStreamingEnabled: () => true,
+    isOrchestratorV2Enabled: () => true,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Wire fixture (CEE staging shape — same graph as the seam spec)
+// ---------------------------------------------------------------------------
+
+const WIRE_NODES = [
+  { id: 'dec_supplier', kind: 'decision', label: 'Choose supplier strategy' },
+  { id: 'opt_switch', kind: 'option', label: 'Switch supplier' },
+  {
+    id: 'fac_current_supplier',
+    kind: 'factor',
+    label: 'Current supplier terms',
+    observed_state: { value: 0.5, baseline: 0.5 },
+  },
+  {
+    id: 'fac_initial_quote',
+    kind: 'factor',
+    label: 'Initial quote',
+    observed_state: { value: 0.5, baseline: 0.5 },
+  },
+  { id: 'goal_cost', kind: 'goal', label: 'Minimise total cost' },
+]
+
+const WIRE_EDGES = [
+  { id: 'e1', from: 'dec_supplier', to: 'opt_switch', weight: 0.5, belief: 0.8 },
+  { id: 'e2', from: 'opt_switch', to: 'fac_current_supplier', weight: 0.5, belief: 0.7 },
+  { id: 'e3', from: 'opt_switch', to: 'fac_initial_quote', weight: 0.5, belief: 0.7 },
+  { id: 'e4', from: 'fac_current_supplier', to: 'goal_cost', weight: 0.5, belief: 0.7 },
+  { id: 'e5', from: 'fac_initial_quote', to: 'goal_cost', weight: 0.5, belief: 0.7 },
+]
+
+const WIRE_COACHING = {
+  summary: 'The draft leans on the current arrangement and the first quote.',
+  bias_signals: [
+    {
+      type: 'status_quo_bias',
+      detail:
+        'The model leans on keeping the current supplier without weighing the switch on equal terms.',
+      target: 'fac_current_supplier',
+    },
+    {
+      type: 'anchoring',
+      detail:
+        'Estimates cluster tightly around the initial quote rather than an independent range.',
+      target: 'fac_initial_quote',
+    },
+  ],
+}
+
+/** A producer-typed 0.13.x bias coaching block, as it would ride the
+ * parser's phase-3 sidecar (splitBlocksTolerance lifts it out of blocks[]). */
+const PRODUCER_BIAS_BLOCK = {
+  type: 'coaching',
+  block_id: 'producer_bias_1',
+  title: 'Anchoring',
+  body: 'Producer-authored anchoring coaching, verbatim.',
+  coaching_kind: 'bias_signal',
+  source: 'decision_review',
+  target_refs: [],
+  priority_rank: 1,
+  freshness: 'fresh',
+}
+
+/**
+ * A parsed V5 draft-turn result exactly as routeV5Response receives it:
+ * draft_graph + analysis_ready on the strict surface, root `coaching`
+ * demoted to the ADDITIVE_EXTENSIONS_KEY sidecar (the parser's behaviour at
+ * the pinned 0.15.0 schema — pinned by draftBiasSignalBlocks.seam.spec.ts).
+ */
+function makeDraftTurnResult(opts: { coaching?: unknown; phase3Blocks?: unknown[] } = {}) {
+  const response: Record<string, unknown> = {
+    response_version: 2,
+    assistant_text: 'I have drafted a starting model of your decision.',
+    blocks: [] as unknown[],
+    suggested_actions: [] as unknown[],
+    insights: [] as unknown[],
+    stage_indicator: 'analyse',
+    draft_graph: {
+      nodes: WIRE_NODES,
+      edges: WIRE_EDGES,
+      node_count: WIRE_NODES.length,
+      edge_count: WIRE_EDGES.length,
+    },
+    analysis_ready: {
+      status: 'ready',
+      options: [
+        { id: 'opt_switch', label: 'Switch supplier', interventions: {}, is_baseline: false },
+      ],
+      goal_node_id: 'goal_cost',
+    },
+  }
+  const sidecar: Record<string, unknown> = {}
+  if (opts.coaching !== undefined) sidecar.coaching = opts.coaching
+  if (opts.phase3Blocks !== undefined) sidecar.phase3_blocks = opts.phase3Blocks
+  if (Object.keys(sidecar).length > 0) {
+    response[ADDITIVE_EXTENSIONS_KEY] = sidecar
+  }
+  return { kind: 'response' as const, response }
+}
+
+beforeEach(() => {
+  mockCallTurn.mockReset()
+  mockStreamTurn.mockReset()
+  mockCallV5Turn.mockReset()
+  mockGetUserId.mockReset()
+  mockGetUserId.mockResolvedValue(null)
+  mockLoadScenario.mockReset()
+  mockLoadScenario.mockResolvedValue(null)
+
+  useResultsStore.setState({
+    results: {
+      status: 'idle',
+      progress: 0,
+      analysisSummary: undefined,
+      lastSnapshotId: undefined,
+    },
+  } as never)
+
+  useCanvasStore.getState().resetCanvas()
+  useCanvasStore.setState({
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    nodes: [],
+    edges: [],
+  })
+})
+
+function lastAssistantMessage(messages: ReturnType<typeof useConversation>['messages']) {
+  return [...messages].reverse().find((m) => m.role === 'assistant')
+}
+
+function biasSignalBlocksOf(
+  messages: ReturnType<typeof useConversation>['messages'],
+): V5CoachingBlock[] {
+  const msg = lastAssistantMessage(messages)
+  return ((msg?.blocks ?? []) as V5CoachingBlock[]).filter(
+    (b) => b.type === 'v5_coaching' && b.coaching_kind === 'bias_signal',
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pins
+// ---------------------------------------------------------------------------
+
+describe('useConversation — draft bias-signal seam CALL-SITE pin (#356 fast-follow)', () => {
+  it('a real draft turn with root coaching renders the two grounded bias cards on the assistant message', async () => {
+    mockCallV5Turn.mockResolvedValue(makeDraftTurnResult({ coaching: WIRE_COACHING }))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Help me decide on a supplier strategy')
+    })
+
+    // The draft graph actually applied (the isDraftTurn gate's substrate).
+    expect(useCanvasStore.getState().nodes.length).toBe(WIRE_NODES.length)
+    // The response-root coaching reached the store through the attach call's
+    // 4th argument (target.response) — not through any test-side injection.
+    expect(useCanvasStore.getState().draftCoaching?.biasSignals).toHaveLength(2)
+
+    const cards = biasSignalBlocksOf(result.current.messages)
+    expect(cards).toHaveLength(2)
+    expect(cards.map((b) => b.title)).toEqual(['Status quo bias', 'Anchoring'])
+    expect(cards.map((b) => b.body)).toEqual([
+      WIRE_COACHING.bias_signals[0].detail,
+      WIRE_COACHING.bias_signals[1].detail,
+    ])
+    expect(cards[0].target_refs).toEqual([
+      { id: 'fac_current_supplier', label: 'Current supplier terms', kind: 'factor' },
+    ])
+  })
+
+  it('producer typed bias coaching wins — the bridge adds nothing when the turn already carries it', async () => {
+    mockCallV5Turn.mockResolvedValue(
+      makeDraftTurnResult({ coaching: WIRE_COACHING, phase3Blocks: [PRODUCER_BIAS_BLOCK] }),
+    )
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Help me decide on a supplier strategy')
+    })
+
+    // Store still carries the wire coaching (the draft applied normally)…
+    expect(useCanvasStore.getState().draftCoaching?.biasSignals).toHaveLength(2)
+
+    // …but exactly ONE bias card renders: the producer's, never doubled by
+    // the bridge (existingBlocks: finalBlocks at the call site).
+    const cards = biasSignalBlocksOf(result.current.messages)
+    expect(cards).toHaveLength(1)
+    expect(cards[0].block_id).toBe('producer_bias_1')
+    expect(cards[0].body).toBe(PRODUCER_BIAS_BLOCK.body)
+  })
+
+  it('a non-draft turn (no draft_graph) renders no bias cards even with stale store coaching', async () => {
+    // Stale coaching left over in the store from a prior draft…
+    useCanvasStore.getState().setDraftCoaching({
+      summary: null,
+      strengthenItems: [],
+      wideningLog: [],
+      biasSignals: [
+        {
+          type: 'anchoring',
+          detail: 'Stale signal from a prior draft.',
+          target: 'fac_current_supplier',
+        },
+      ],
+    })
+    // …and a populated canvas so no fresh draft can apply this turn.
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: 'fac_current_supplier',
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: { label: 'Current supplier terms' },
+        },
+      ] as never,
+    })
+
+    const turn = makeDraftTurnResult()
+    delete (turn.response as Record<string, unknown>).draft_graph
+    mockCallV5Turn.mockResolvedValue(turn)
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Tell me more about the trade-offs')
+    })
+
+    // The isDraftTurn gate at the call site is load-bearing: stale store
+    // coaching must not leak cards onto a conversational turn.
+    expect(biasSignalBlocksOf(result.current.messages)).toEqual([])
+  })
+})

--- a/src/canvas/conversation/draftBiasSignalBlocks.ts
+++ b/src/canvas/conversation/draftBiasSignalBlocks.ts
@@ -115,6 +115,12 @@ export function buildDraftBiasSignalBlocks(args: {
   if (!Array.isArray(signals) || signals.length === 0) return []
 
   const out: V5CoachingBlock[] = []
+  // #356 fast-follow: dedupe identical (bias, target) signals BEFORE the
+  // cap, so a producer duplicate can never displace a distinct third
+  // signal. Identity is the canonical humanised title (alias codes like
+  // anchoring/anchoring_bias are the same bias — one bias, one name) plus
+  // the resolved target node id. First occurrence wins.
+  const seen = new Set<string>()
   for (let i = 0; i < signals.length && out.length < DRAFT_BIAS_SIGNAL_CARD_CAP; i++) {
     const signal = signals[i] as unknown
     if (!signal || typeof signal !== 'object') continue
@@ -128,6 +134,10 @@ export function buildDraftBiasSignalBlocks(args: {
 
     const ref = resolveNodeForTarget(s.target, store.nodes)
     if (!ref) continue
+
+    const identity = `${title}|${ref.id}`
+    if (seen.has(identity)) continue
+    seen.add(identity)
 
     out.push({
       type: 'v5_coaching',

--- a/src/canvas/conversation/draftBiasSignalBlocks.ts
+++ b/src/canvas/conversation/draftBiasSignalBlocks.ts
@@ -33,35 +33,22 @@
  */
 import type { CEEDraftCoaching } from '../../adapters/cee/types'
 import type { ConversationBlock, V5CoachingBlock } from './types'
+import { BIAS_SIGNAL_TITLES } from '../shared/biasSignalTitles'
 
 /** Ratified cap: at most two bias-signal cards per draft turn. */
 export const DRAFT_BIAS_SIGNAL_CARD_CAP = 2
 
 /**
- * Humanised titles for the known CEE bias codes — the same canonical names
- * the pre-analysis surface uses (PreAnalysisPanel BIAS_TYPE_ICON), so one
- * bias renders one name on every surface. Keys are lowercase; lookup is
- * case-insensitive to cover both wire conventions (lowercase `type`,
- * uppercase `code`). Unknown codes are NOT sentence-cased — they fail
- * closed (no card), so a raw wire token can never leak into copy.
+ * Humanised titles for the known CEE bias codes — re-exported from the ONE
+ * canonical map (src/canvas/shared/biasSignalTitles.ts) that the
+ * pre-analysis surface also derives from, so one bias renders one name on
+ * every surface by construction (#356 fast-follow: was a hand-maintained
+ * mirror of PreAnalysisPanel's BIAS_TYPE_ICON titles). Keys are lowercase;
+ * lookup is case-insensitive to cover both wire conventions (lowercase
+ * `type`, uppercase `code`). Unknown codes are NOT sentence-cased — they
+ * fail closed (no card), so a raw wire token can never leak into copy.
  */
-export const BIAS_SIGNAL_TITLES: Record<string, string> = {
-  framing: 'Narrow framing',
-  framing_bias: 'Narrow framing',
-  narrow_framing: 'Narrow framing',
-  anchoring: 'Anchoring',
-  anchoring_bias: 'Anchoring',
-  confidence: 'Overconfidence',
-  overconfidence: 'Overconfidence',
-  optimism_bias: 'Optimism bias',
-  blind_spots: 'Blind spots',
-  status_quo_bias: 'Status quo bias',
-  confirmation: 'Confirmation bias',
-  confirmation_bias: 'Confirmation bias',
-  authority_bias: 'Authority bias',
-  availability_bias: 'Availability bias',
-  sunk_cost: 'Sunk cost',
-}
+export { BIAS_SIGNAL_TITLES }
 
 /** Allowlist lookup. Returns null for unknown / non-string codes (fail closed). */
 export function humaniseBiasSignalCode(code: unknown): string | null {

--- a/src/canvas/conversation/phase3Pacing.ts
+++ b/src/canvas/conversation/phase3Pacing.ts
@@ -1,0 +1,76 @@
+/**
+ * phase3Pacing — F16: pacing computation for phase-3 coaching/review card
+ * floods in a single conversation turn (COACHING-REVIEW-UI-BRIEF §3
+ * progressive disclosure; ratified renderer target).
+ *
+ * A single run response can land 10–15 phase-3 blocks (observed live:
+ * 5 review_card + 4 coaching + 1 evidence). Pacing lives at the RENDER
+ * layer: the message/store keeps ALL blocks (nothing is mutated at ingest),
+ * and InlineBlocks consults this pure helper to decide which phase-3 cards
+ * default to expanded and which sit behind the single count affordance.
+ *
+ * Rules (ratified):
+ *   - The first PHASE3_DEFAULT_EXPANDED phase-3 cards (producer order —
+ *     composePhase3BridgedBlocks has already applied priority_rank
+ *     ordering) render by default.
+ *   - Every later phase-3 card collapses behind ONE affordance, placed at
+ *     the position of the first collapsed card so reading order is
+ *     preserved exactly on reveal.
+ *   - Non-phase-3 blocks are untouched: when pacing is active they keep
+ *     their own legacy per-turn budget, counted WITHOUT the phase-3 cards
+ *     (the pacing group is the phase-3 budget).
+ */
+import type { ConversationBlock } from './types'
+
+/** The four typed phase-3 conversation block kinds (Track C slices 1+2). */
+export const PHASE3_CARD_TYPES: ReadonlySet<ConversationBlock['type']> = new Set([
+  'v5_review_card',
+  'v5_coaching',
+  'v5_evidence',
+  'v5_exercise',
+] as const)
+
+/** Ratified default-expanded cap: at most 3 phase-3 cards open by default. */
+export const PHASE3_DEFAULT_EXPANDED = 3
+
+export interface Phase3Pacing {
+  /** True when the turn carries more phase-3 cards than the default cap. */
+  pacingActive: boolean
+  /** Total phase-3 cards on the turn. */
+  phase3Count: number
+  /** How many phase-3 cards are behind the affordance when collapsed. */
+  collapsedCount: number
+  /** Block indices (into the original array) collapsed by default. */
+  collapsedIndices: ReadonlySet<number>
+  /** Original index of the first collapsed card — where the affordance renders. */
+  affordanceIndex: number
+}
+
+export function isPhase3CardBlock(block: ConversationBlock): boolean {
+  return PHASE3_CARD_TYPES.has(block.type)
+}
+
+/** Pure pacing computation over a turn's full block list. */
+export function computePhase3Pacing(blocks: readonly ConversationBlock[]): Phase3Pacing {
+  const phase3Indices: number[] = []
+  for (let i = 0; i < blocks.length; i++) {
+    if (isPhase3CardBlock(blocks[i])) phase3Indices.push(i)
+  }
+  if (phase3Indices.length <= PHASE3_DEFAULT_EXPANDED) {
+    return {
+      pacingActive: false,
+      phase3Count: phase3Indices.length,
+      collapsedCount: 0,
+      collapsedIndices: new Set(),
+      affordanceIndex: -1,
+    }
+  }
+  const collapsed = phase3Indices.slice(PHASE3_DEFAULT_EXPANDED)
+  return {
+    pacingActive: true,
+    phase3Count: phase3Indices.length,
+    collapsedCount: collapsed.length,
+    collapsedIndices: new Set(collapsed),
+    affordanceIndex: collapsed[0],
+  }
+}

--- a/src/canvas/shared/biasSignalTitles.ts
+++ b/src/canvas/shared/biasSignalTitles.ts
@@ -1,0 +1,35 @@
+/**
+ * biasSignalTitles — the ONE canonical map from CEE bias codes to the
+ * humanised titles the UI shows (#356 fast-follow: extracted so the
+ * conversation bridge and the pre-analysis panel can never drift — one
+ * bias renders one name on every surface, by construction).
+ *
+ * Importers:
+ *   - src/canvas/conversation/draftBiasSignalBlocks.ts (v5_coaching
+ *     bias-signal card titles; fail-closed allowlist lookup)
+ *   - src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+ *     (BIAS_TYPE_ICON titles — icons stay panel-local; titles derive
+ *     from here)
+ *
+ * Keys are canonical lowercase; lookups must lowercase first (both wire
+ * conventions arrive: lowercase `type` and uppercase `code`). Unknown
+ * codes are the caller's fail-closed concern — this map never invents a
+ * title. Parity + drift traps: biasSignalTitles.parity.spec.ts.
+ */
+export const BIAS_SIGNAL_TITLES: Record<string, string> = {
+  framing: 'Narrow framing',
+  framing_bias: 'Narrow framing',
+  narrow_framing: 'Narrow framing',
+  anchoring: 'Anchoring',
+  anchoring_bias: 'Anchoring',
+  confidence: 'Overconfidence',
+  overconfidence: 'Overconfidence',
+  optimism_bias: 'Optimism bias',
+  blind_spots: 'Blind spots',
+  status_quo_bias: 'Status quo bias',
+  confirmation: 'Confirmation bias',
+  confirmation_bias: 'Confirmation bias',
+  authority_bias: 'Authority bias',
+  availability_bias: 'Availability bias',
+  sunk_cost: 'Sunk cost',
+}


### PR DESCRIPTION
Lane F16 + the two ratified #356 fast-follows. Base `3e971f0b`; RED/GREEN commit order throughout; every pin mutation-checked in a throwaway worktree.

## Part A — phase-3 card pacing + legend (F16)

**Problem:** one run response can land 10–15 phase-3 blocks (observed live: 5 review_card + 4 coaching + 1 evidence) with no pacing and no vocabulary legend.

**Design (where grouping lives):** render layer only — `InlineBlocks` consults the new pure helper `src/canvas/conversation/phase3Pacing.ts`; the store/message keeps ALL blocks (no ingest mutation, per the brief's preference). Top 3 phase-3 cards default-expanded; every later phase-3 card sits behind ONE outlined count affordance placed at the first collapsed card's position, so a single interaction reveals the remainder with order preserved exactly. Collapsed count is announced via the affordance's accessible name plus a visually-hidden `role="status"` region. While pacing is active the legacy 4-block per-turn budget counts only non-phase-3 blocks (the pacing group IS the phase-3 budget) — turns with ≤3 phase-3 cards render byte-identically to before. `GraphVocabularyLegend` adds the brief's "What do these terms mean?" affordance (static vocabulary copy, collapsed by default, Lucide only, outlined per DS).

**Fixture:** `acceptance-evidence/` carries no a16a0e82 replay in this repo, so the spec builds the observed flood shape from typed fixtures: 5 `v5_review_card` + 4 `v5_coaching` + 1 `v5_evidence` (`InlineBlocks.phase3Pacing.spec.tsx`).

**Acceptance evidence (spec pins):** ≤3 default-expanded ✓ · remainder behind exactly one interaction ✓ · order preserved exactly ✓ · SR announces collapsed count ✓ · legend affordance ✓ · non-flood turns unchanged ✓.

**Mutation check (throwaway worktree):** grouping reverted (pacing stubbed inactive) → `InlineBlocks.phase3Pacing.spec.tsx` **5 failed / 3 passed** (flood pin RED); restored → 8/8 GREEN.

**Tone/DS:** no banner language, no danger styling added — severity remains producer-owned; affordances outlined, not filled; British English, sentence case; Lucide only.

## Part B1 — #356 call-site pin

`useConversation.biasSeamCallSite.spec.ts` drives the REAL `useConversation.sendMessage` V5 success path (routeV5Response → attach → applyDraftResult → bridge → addMessage) with a CEE-staging-shaped draft turn (root `coaching` on the additive sidecar) and asserts on the assistant message the user would see.

**Mutation proofs (throwaway worktree, each restored to GREEN 3/3 after):**

| Mutation at the call site | Result |
|---|---|
| drop `target.response` (attach 4th arg, ~L3293) | **RED — 2 failed** |
| `isDraftTurn: false` (~L3426) | **RED — 1 failed** |
| drop `existingBlocks: finalBlocks` (~L3428) | **RED — 1 failed** (producer-wins test catches the doubled cards) |

## Part B2 — title-map parity + dedupe nit

- **Extraction (preferred option):** `src/canvas/shared/biasSignalTitles.ts` is now the ONE canonical code→title map. `draftBiasSignalBlocks.ts` re-exports it (importers unchanged); `PreAnalysisPanel.tsx` keeps only the panel-local ICON channel and derives every `BIAS_TYPE_ICON` title from the canonical map (a key with no canonical title falls through to `BIAS_FALLBACK` — fail closed, never invented). Key sets and lookup semantics unchanged; titles byte-identical.
- **Parity spec** (`biasSignalTitles.parity.spec.ts`, committed RED first — shared module absent): identity pin (conversation map IS the canonical object), functional parity through both surfaces' real public mappers (both wire conventions, case-insensitive), and a drift trap over every icon-map key.
- **Mutation proof:** drifted one panel title locally ('Anchoring' → 'Anchor bias') → **RED — 2 failed**; restored → 6/6 GREEN.
- **Dedupe nit (done):** identical (bias, target) signals dedupe BEFORE the ≤2 cap (identity = canonical title + resolved target id; first occurrence wins; same bias on different targets stays distinct). RED spec committed first (2 failed), fix GREEN.

## Gates

- `pnpm run typecheck` — clean
- `npx vitest run --changed origin/staging` — **1554 passed | 44 skipped (114 files), 0 failed**
- `pnpm run lint` — **0 errors** (1100 pre-existing warnings)
- Wide tsc multiset (`npx tsc -p tsconfig.app.json --noEmit`, lane vs fresh installed base worktree pinned to `3e971f0b`, uniquely-named output files, sort + count-normalised): **4025 lines both sides; zero new errors.** Raw diff showed only line-number drift on 4 pre-existing `PreAnalysisPanel.tsx` errors (+19 lines from the refactor); with positions normalised the multisets are identical.
- New specs live under `src/canvas/conversation/__tests__/` (non-widening path — nothing added under `src/v5/**`).
- Stale-.js sweep: none.

## Deliberately NOT done

- **No panel restructure** — pacing lives entirely within `InlineBlocks` in the existing conversation panel; OutputsDock chrome, Compare/Model bodies, StyledEdge and the Analysis tab untouched (cockpit pick ROADMAP 2.6 stays Paul-gated).
- **No UI-SEM row** for the pacing cap: it is a disclosure/layout budget (same class as the existing un-SEM'd `MAX_VISIBLE_BLOCKS_PER_TURN = 4`), not a semantic transform — no producer value is interpreted, classified or fabricated. Flagging the judgement call for review.
- The uppercase `CONFIRMATION_BIAS → Gauge` vs lowercase `confirmation_bias → Frame` **icon**-channel discrepancy in `BIAS_TYPE_ICON` is preserved as-is — the ratified fast-follow covers titles; changing icon semantics would be scope creep (noting it here as a candidate follow-up).
- `staging` moved to `1ec88729` (#360, suggested-chips cap) after this lane branched; no file overlap with this diff. Branch left on its `3e971f0b` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
