### PR TITLE
refactor(conversation): one type scale — census-enforced (F3)

### DIFF
--- a/scripts/conversation-type-census.mjs
+++ b/scripts/conversation-type-census.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * Conversation-panel type census (lane F3 — one type scale).
+ *
+ * Enumerates every distinct font-size / font-weight / line-height that reaches
+ * the conversation panel and the V5 block renderers, across every mechanism:
+ *
+ *   1. tailwind — text-* / font-* / leading-* utility classes in source
+ *   2. token    — typography.X / typo('X') references, RESOLVED by parsing
+ *                 src/styles/typography.ts at run time (derived, never mirrored)
+ *   3. css      — raw declarations in Conversation.module.css (and any other
+ *                 .css file in scope), with var(--conv-type-*) indirection
+ *                 resolved against the definitions in the same file
+ *   4. inline   — fontSize / fontWeight / lineHeight in JSX style objects
+ *
+ * Output: one line per (value, mechanism, file:line) hit, then the distinct
+ * size / weight / line-height sets. `--json` emits a machine-readable summary
+ * consumed by tests/ci-guards/conversation-type-census.spec.ts.
+ *
+ * FAIL-LOUD RULES (trap-12: a silent gap in a census is worse than no census):
+ *   - unknown named text-* size class            → error
+ *   - `font:` shorthand in CSS                   → error
+ *   - rem/em/calc/clamp font-size                → error (add handling first)
+ *   - template-interpolated `text-${...}`        → error
+ *   - typography token name not found            → error
+ *   - non-literal inline fontSize/fontWeight     → error
+ *   - var(--conv-type-*) used but never defined  → error
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const SCOPE_DIRS = ['src/canvas/conversation', 'src/v5/blocks']
+const TYPOGRAPHY_TS = 'src/styles/typography.ts'
+const EXCLUDE_DIR_NAMES = new Set(['__tests__', 'tests', '__fixtures__'])
+
+// Tailwind v3 default theme (version-pinned; unknown names fail loud below).
+const TW_SIZE_PX = {
+  xs: 12, sm: 14, base: 16, lg: 18, xl: 20,
+  '2xl': 24, '3xl': 30, '4xl': 36, '5xl': 48, '6xl': 60,
+}
+const TW_WEIGHT = {
+  thin: 100, extralight: 200, light: 300, normal: 400, medium: 500,
+  semibold: 600, bold: 700, extrabold: 800, black: 900,
+}
+const TW_LEADING = {
+  none: 1, tight: 1.25, snug: 1.375, normal: 1.5, relaxed: 1.625, loose: 2,
+}
+
+const errors = []
+const hits = [] // { kind: 'size'|'weight'|'lineHeight', value, mechanism, file, line }
+
+function walk(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) {
+      if (!EXCLUDE_DIR_NAMES.has(entry)) out.push(...walk(full))
+    } else if (/\.(tsx?|css)$/.test(entry) && !/\.(test|spec)\./.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function lineOf(src, index) {
+  return src.slice(0, index).split('\n').length
+}
+
+function record(kind, value, mechanism, file, line) {
+  hits.push({ kind, value, mechanism, file: path.relative(ROOT, file), line })
+}
+
+// ---------------------------------------------------------------------------
+// Token table: parse src/styles/typography.ts (derive, don't mirror).
+// ---------------------------------------------------------------------------
+function parseTypographyTokens() {
+  const src = readFileSync(path.join(ROOT, TYPOGRAPHY_TS), 'utf8')
+  const tokens = {}
+  const re = /^\s{2}(\w+):\s*'([^']*)'/gm
+  let m
+  while ((m = re.exec(src)) !== null) {
+    tokens[m[1]] = classesToTraits(m[2], `${TYPOGRAPHY_TS} token "${m[1]}"`)
+  }
+  if (Object.keys(tokens).length === 0) {
+    errors.push(`No tokens parsed from ${TYPOGRAPHY_TS} — parser drift, fix the census`)
+  }
+  return tokens
+}
+
+function classesToTraits(classString, context) {
+  const traits = { size: null, weight: null, lineHeight: null }
+  for (const cls of classString.split(/\s+/)) {
+    let m
+    if ((m = cls.match(/^text-\[(\d+(?:\.\d+)?)px\]$/))) {
+      traits.size = Number(m[1])
+    } else if ((m = cls.match(/^text-\[/))) {
+      errors.push(`${context}: unsupported arbitrary text class "${cls}" (only [Npx] handled)`)
+    } else if ((m = cls.match(/^text-(xs|sm|base|lg|xl|\dxl)$/))) {
+      if (!(m[1] in TW_SIZE_PX)) errors.push(`${context}: unknown text size "${cls}"`)
+      else traits.size = TW_SIZE_PX[m[1]]
+    } else if ((m = cls.match(/^font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)$/))) {
+      traits.weight = TW_WEIGHT[m[1]]
+    } else if ((m = cls.match(/^leading-(none|tight|snug|normal|relaxed|loose)$/))) {
+      traits.lineHeight = TW_LEADING[m[1]]
+    } else if ((m = cls.match(/^leading-\[(\d+(?:\.\d+)?)\]$/))) {
+      traits.lineHeight = Number(m[1])
+    } else if (/^(leading-|text-\d)/.test(cls)) {
+      errors.push(`${context}: unhandled typographic class "${cls}"`)
+    }
+    // everything else (colour, family, tracking, sr-only, …) is not type-scale
+  }
+  return traits
+}
+
+// ---------------------------------------------------------------------------
+// Mechanism 1 + 2 + 4: TS/TSX files
+// ---------------------------------------------------------------------------
+function scanTsx(file, tokens) {
+  const src = readFileSync(file, 'utf8')
+
+  // Fail loud on dynamically-composed size classes.
+  for (const m of src.matchAll(/text-\$\{/g)) {
+    errors.push(`${file}:${lineOf(src, m.index)}: template-interpolated text-\${…} class — census cannot see it`)
+  }
+
+  // 1. Raw tailwind utilities (named + arbitrary sizes, weights, leadings).
+  for (const m of src.matchAll(/\btext-(xs|sm|base|lg|xl|\dxl)\b/g)) {
+    record('size', TW_SIZE_PX[m[1]], 'tailwind', file, lineOf(src, m.index))
+  }
+  for (const m of src.matchAll(/\btext-\[(\d+(?:\.\d+)?)(px|rem)\]/g)) {
+    const px = m[2] === 'rem' ? Number(m[1]) * 16 : Number(m[1])
+    record('size', px, 'tailwind', file, lineOf(src, m.index))
+  }
+  for (const m of src.matchAll(/\bfont-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)\b/g)) {
+    record('weight', TW_WEIGHT[m[1]], 'tailwind', file, lineOf(src, m.index))
+  }
+  for (const m of src.matchAll(/\bleading-(none|tight|snug|normal|relaxed|loose)\b/g)) {
+    record('lineHeight', TW_LEADING[m[1]], 'tailwind', file, lineOf(src, m.index))
+  }
+
+  // 2. typography tokens: typography.X and typo('X')
+  for (const m of src.matchAll(/\btypography\.(\w+)/g)) {
+    resolveToken(m[1], file, lineOf(src, m.index), tokens)
+  }
+  for (const m of src.matchAll(/\btypo\(\s*['"](\w+)['"]/g)) {
+    resolveToken(m[1], file, lineOf(src, m.index), tokens)
+  }
+
+  // 4. Inline style objects.
+  for (const m of src.matchAll(/\bfontSize:\s*([^,}\n]+)/g)) {
+    const raw = m[1].trim()
+    const line = lineOf(src, m.index)
+    let n
+    if (/^\d+(\.\d+)?$/.test(raw)) n = Number(raw)
+    else if ((n = raw.match(/^['"](\d+(?:\.\d+)?)px['"]$/))) n = Number(n[1])
+    else {
+      errors.push(`${file}:${line}: non-literal inline fontSize "${raw}" — census cannot resolve it`)
+      continue
+    }
+    record('size', n, 'inline', file, line)
+  }
+  for (const m of src.matchAll(/\bfontWeight:\s*([^,}\n]+)/g)) {
+    const raw = m[1].trim()
+    const line = lineOf(src, m.index)
+    if (/^\d+$/.test(raw)) record('weight', Number(raw), 'inline', file, line)
+    else if (/^['"](normal|bold)['"]$/.test(raw)) record('weight', raw.includes('bold') ? 700 : 400, 'inline', file, line)
+    else errors.push(`${file}:${line}: non-literal inline fontWeight "${raw}"`)
+  }
+  for (const m of src.matchAll(/\blineHeight:\s*([^,}\n]+)/g)) {
+    const raw = m[1].trim()
+    const line = lineOf(src, m.index)
+    if (/^\d+(\.\d+)?$/.test(raw)) record('lineHeight', Number(raw), 'inline', file, line)
+    else errors.push(`${file}:${line}: non-literal inline lineHeight "${raw}"`)
+  }
+}
+
+function resolveToken(name, file, line, tokens) {
+  if (name === 'screenReaderOnly') return
+  const t = tokens[name]
+  if (!t) {
+    errors.push(`${path.relative(ROOT, file)}:${line}: typography token "${name}" not found in ${TYPOGRAPHY_TS}`)
+    return
+  }
+  if (t.size !== null) record('size', t.size, `token(${name})`, file, line)
+  if (t.weight !== null) record('weight', t.weight, `token(${name})`, file, line)
+  if (t.lineHeight !== null) record('lineHeight', t.lineHeight, `token(${name})`, file, line)
+}
+
+// ---------------------------------------------------------------------------
+// Mechanism 3: CSS files (raw declarations + --conv-type-* var indirection)
+// ---------------------------------------------------------------------------
+function scanCss(file) {
+  const src = readFileSync(file, 'utf8')
+
+  // Collect --conv-type-* definitions first so usages resolve.
+  const varDefs = {}
+  for (const m of src.matchAll(/(--conv-type-[\w-]+):\s*([^;]+);/g)) {
+    varDefs[m[1]] = { raw: m[2].trim(), line: lineOf(src, m.index) }
+  }
+
+  if (/(^|[^-\w])font:\s/m.test(src)) {
+    errors.push(`${file}: CSS \`font:\` shorthand found — census cannot decompose it, replace with longhand`)
+  }
+
+  const parseSize = (raw, line, mechanism) => {
+    let m
+    if (raw === 'inherit') return
+    if ((m = raw.match(/^(\d+(?:\.\d+)?)px$/))) {
+      record('size', Number(m[1]), mechanism, file, line)
+    } else if ((m = raw.match(/^var\((--conv-type-[\w-]+)\)$/))) {
+      const def = varDefs[m[1]]
+      if (!def) errors.push(`${file}:${line}: ${m[1]} used but never defined`)
+      else parseSize(def.raw, line, `cssvar(${m[1]})`)
+    } else {
+      errors.push(`${file}:${line}: unhandled font-size value "${raw}"`)
+    }
+  }
+  const parseWeight = (raw, line, mechanism) => {
+    let m
+    if (raw === 'inherit') return
+    if (/^\d+$/.test(raw)) record('weight', Number(raw), mechanism, file, line)
+    else if ((m = raw.match(/^var\((--conv-type-[\w-]+)\)$/))) {
+      const def = varDefs[m[1]]
+      if (!def) errors.push(`${file}:${line}: ${m[1]} used but never defined`)
+      else parseWeight(def.raw, line, `cssvar(${m[1]})`)
+    } else errors.push(`${file}:${line}: unhandled font-weight value "${raw}"`)
+  }
+  const parseLine = (raw, line, mechanism) => {
+    let m
+    if (raw === 'inherit' || raw === 'normal') return
+    if (/^\d+(\.\d+)?$/.test(raw)) record('lineHeight', Number(raw), mechanism, file, line)
+    else if ((m = raw.match(/^var\((--conv-type-[\w-]+)\)$/))) {
+      const def = varDefs[m[1]]
+      if (!def) errors.push(`${file}:${line}: ${m[1]} used but never defined`)
+      else parseLine(def.raw, line, `cssvar(${m[1]})`)
+    } else if (/^\d+(\.\d+)?px$/.test(raw)) {
+      record('lineHeight', raw, mechanism, file, line)
+    } else errors.push(`${file}:${line}: unhandled line-height value "${raw}"`)
+  }
+
+  for (const m of src.matchAll(/font-size:\s*([^;]+);/g)) {
+    parseSize(m[1].trim().replace(/\s*\/\*.*$/, ''), lineOf(src, m.index), 'css')
+  }
+  for (const m of src.matchAll(/font-weight:\s*([^;]+);/g)) {
+    parseWeight(m[1].trim(), lineOf(src, m.index), 'css')
+  }
+  for (const m of src.matchAll(/line-height:\s*([^;]+);/g)) {
+    parseLine(m[1].trim(), lineOf(src, m.index), 'css')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+const tokens = parseTypographyTokens()
+const files = SCOPE_DIRS.flatMap((d) => walk(path.join(ROOT, d)))
+for (const f of files) {
+  if (f.endsWith('.css')) scanCss(f)
+  else scanTsx(f, tokens)
+}
+
+// Var DEFINITIONS whose values fall outside the census would otherwise hide:
+// definitions are only counted when used, and every use resolves through
+// parseSize/parseWeight/parseLine above — an unused definition is dead weight,
+// flag it so it cannot lie in wait.
+for (const f of files.filter((f) => f.endsWith('.css'))) {
+  const src = readFileSync(f, 'utf8')
+  for (const m of src.matchAll(/(--conv-type-[\w-]+):/g)) {
+    const name = m[1]
+    const uses = [...src.matchAll(new RegExp(`var\\(${name}\\)`, 'g'))].length
+    if (uses === 0) errors.push(`${f}: ${name} defined but never used — remove it`)
+  }
+}
+
+const distinct = (kind) => {
+  const map = new Map()
+  for (const h of hits.filter((h) => h.kind === kind)) {
+    const k = String(h.value)
+    if (!map.has(k)) map.set(k, [])
+    map.get(k).push(h)
+  }
+  return map
+}
+
+const sizes = distinct('size')
+const weights = distinct('weight')
+const lineHeights = distinct('lineHeight')
+
+const summary = {
+  errors,
+  files: files.length,
+  sizes: [...sizes.keys()].map(Number).sort((a, b) => a - b),
+  weights: [...weights.keys()].map(Number).sort((a, b) => a - b),
+  lineHeights: [...lineHeights.keys()].sort(),
+  counts: { sizes: sizes.size, weights: weights.size, lineHeights: lineHeights.size },
+  rawMechanismHits: {
+    // raw = not token-/var-mediated; the sweep drives these to the pinned floor
+    tailwindSize: hits.filter((h) => h.kind === 'size' && h.mechanism === 'tailwind').length,
+    inlineSize: hits.filter((h) => h.kind === 'size' && h.mechanism === 'inline').length,
+    inlineWeight: hits.filter((h) => h.kind === 'weight' && h.mechanism === 'inline').length,
+    cssRawSize: hits.filter((h) => h.kind === 'size' && h.mechanism === 'css').length,
+    cssRawWeight: hits.filter((h) => h.kind === 'weight' && h.mechanism === 'css').length,
+  },
+}
+
+if (process.argv.includes('--json')) {
+  console.log(JSON.stringify({ ...summary, hits }, null, 2))
+} else {
+  console.log(`Conversation-panel type census — ${files.length} files in scope\n`)
+  for (const [label, map] of [['FONT SIZES (px)', sizes], ['FONT WEIGHTS', weights], ['LINE HEIGHTS', lineHeights]]) {
+    console.log(`${label}: ${map.size} distinct`)
+    for (const [value, list] of [...map.entries()].sort((a, b) => Number(a[0]) - Number(b[0]))) {
+      const mechs = [...new Set(list.map((h) => h.mechanism))].join(', ')
+      console.log(`  ${value}  (${list.length} hits via ${mechs})`)
+      for (const h of list) console.log(`      ${h.file}:${h.line}  [${h.mechanism}]`)
+    }
+    console.log()
+  }
+  console.log('Raw (non-token) size hits:', JSON.stringify(summary.rawMechanismHits))
+  if (errors.length) {
+    console.error(`\nCENSUS ERRORS (${errors.length}):`)
+    for (const e of errors) console.error(`  ${e}`)
+  }
+}
+
+if (errors.length) process.exit(2)

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -1,6 +1,29 @@
 /* A.5+ Conversation Panel — CSS Module with Design System v2.1 tokens */
 
 /* ---------------------------------------------------------------------------
+ * § 0 — ONE type scale (lane F3, register 1.69(a))
+ *
+ * Every font-size / font-weight / line-height in this module MUST go through
+ * these tokens. They mirror the panel steps in src/styles/typography.ts
+ * (panelHeader 14/600 · chatProse 14/400 · panelBody 12 · panelMeta 11);
+ * the mirror cannot drift silently — scripts/conversation-type-census.mjs
+ * + tests/ci-guards/conversation-type-census.spec.ts pin both sides and a
+ * raw px declaration outside this block turns the suite red.
+ * ---------------------------------------------------------------------------*/
+
+:root {
+  --conv-type-size-prominent: 14px; /* panelHeader (w/ semibold) · chatProse / bodySmall (regular) */
+  --conv-type-size-body: 12px;      /* panelBody */
+  --conv-type-size-meta: 11px;      /* panelMeta */
+  --conv-type-weight-regular: 400;
+  --conv-type-weight-medium: 500;
+  --conv-type-weight-semibold: 600;
+  --conv-type-line-snug: 1.375;
+  --conv-type-line-normal: 1.5;
+  --conv-type-line-relaxed: 1.625;
+}
+
+/* ---------------------------------------------------------------------------
  * § 1 — Message list container
  * ---------------------------------------------------------------------------*/
 
@@ -28,14 +51,14 @@
 /* Markdown content inside message bubbles */
 .markdownContent {
   white-space: normal;
-  line-height: 1.65;
+  line-height: var(--conv-type-line-relaxed); /* F3 snap: 1.65 → 1.625 */
 }
 /* Compact variant for AI panel v2 — DS v5 panelBody (12px) typography
    plus normalised line-height so the same prose renders identically
    across Compact / Conversation / Focus modes. Focus reveals more
    content via WIDTH, not by changing leading. */
 .markdownContentCompact {
-  line-height: 1.5;
+  line-height: var(--conv-type-line-normal);
 }
 .markdownContent p {
   margin: 0 0 14px;
@@ -72,7 +95,7 @@
   background: var(--bg-panel-hover, #FEF9F3);
   padding: 1px 5px;
   border-radius: 4px;
-  font-size: 12px; /* code token */
+  font-size: var(--conv-type-size-body);
   font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Segoe UI Mono', Menlo, monospace;
 }
 .markdownContent pre {
@@ -82,7 +105,7 @@
   padding: 10px 12px;
   margin: 6px 0;
   overflow-x: auto;
-  font-size: 12px; /* code token */
+  font-size: var(--conv-type-size-body);
 }
 .markdownContent pre code {
   background: none;
@@ -96,11 +119,11 @@
   color: var(--text-light, #908D8D);
 }
 .markdownContent strong {
-  font-weight: 600;
+  font-weight: var(--conv-type-weight-semibold);
 }
 .markdownContent h1, .markdownContent h2, .markdownContent h3,
 .markdownContent h4, .markdownContent h5, .markdownContent h6 {
-  font-weight: 600;
+  font-weight: var(--conv-type-weight-semibold);
   margin: 8px 0 4px;
 }
 .markdownContent h1 { font-size: inherit; }
@@ -150,7 +173,7 @@
 
 /* § 2b — V2 assistant text rhythm (ORCHESTRATOR_RENDERING_V2) */
 .v2AssistantText {
-  line-height: 1.65;
+  line-height: var(--conv-type-line-relaxed); /* F3 snap: 1.65 → 1.625 */
 }
 .v2AssistantText li {
   /* List items sit closer than the 12px inter-block gap (md-gap / ul margins)
@@ -177,8 +200,8 @@
 }
 
 .showMoreTextToggle {
-  font-size: 14px; /* bodySmall */
-  font-weight: 500;
+  font-size: var(--conv-type-size-prominent);
+  font-weight: var(--conv-type-weight-medium);
   color: var(--info, #52A3C8);
   background: none;
   border: none;
@@ -242,7 +265,7 @@
 }
 
 .longRunningHint {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--text-light, #908D8D);
   margin-top: 4px;
 }
@@ -312,7 +335,7 @@
 }
 
 .reviewCardTitle {
-  font-weight: 600;
+  font-weight: var(--conv-type-weight-semibold);
   margin-bottom: 4px;
 }
 
@@ -328,30 +351,30 @@
 }
 
 .factValue {
-  font-weight: 600;
-  font-size: 18px; /* one-off display value */
+  font-weight: var(--conv-type-weight-semibold);
+  font-size: var(--conv-type-size-prominent); /* F3 snap: 18px → 14px */
   color: var(--text-header, #262626);
 }
 
 .factLabel {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--text-light, #908D8D);
 }
 
 .factSource {
-  font-size: 11px; /* panelMeta */
+  font-size: var(--conv-type-size-meta);
   color: var(--text-light, #908D8D);
   font-style: italic;
 }
 
 .showMoreToggle {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--info, #52A3C8);
   background: none;
   border: none;
   cursor: pointer;
   padding: 4px 0;
-  font-weight: 500;
+  font-weight: var(--conv-type-weight-medium);
 }
 
 .showMoreToggle:hover {
@@ -397,28 +420,28 @@
   /* DS v5 §21.2: block type signalled by the goal/30 border + dot. Eyebrow
      uses muted secondary text — no second status colour. */
   color: var(--text-secondary, #6B6B6A);
-  font-weight: 600;
+  font-weight: var(--conv-type-weight-semibold);
 }
 
 .graphPatchReceiptEyebrow {
   color: var(--text-secondary, #6B6B6A);
-  font-weight: 600;
+  font-weight: var(--conv-type-weight-semibold);
 }
 
 .graphPatchSummary {
-  font-weight: 500;
+  font-weight: var(--conv-type-weight-medium);
   color: var(--text-body, #404040);
 }
 
 /* Entity names in summaries render as label token (DS v5: 14px, semibold) */
 .graphPatchSummary strong {
-  font-weight: 600;
-  font-size: 14px;
+  font-weight: var(--conv-type-weight-semibold);
+  font-size: var(--conv-type-size-prominent);
   color: var(--text-header, #262626);
 }
 
 .graphPatchMeta {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--text-light, #908D8D);
 }
 
@@ -458,7 +481,7 @@
   flex-shrink: 0;
   padding: 0;
   color: var(--text-light, #908D8D);
-  font-weight: 400;
+  font-weight: var(--conv-type-weight-regular);
 }
 
 .graphPatchActions {
@@ -476,8 +499,8 @@
   min-height: 44px;
   border-radius: 999px;
   border: none;
-  font-size: 14px; /* panelHeader */
-  font-weight: 500;
+  font-size: var(--conv-type-size-prominent);
+  font-weight: var(--conv-type-weight-medium);
   cursor: pointer;
   background: var(--primary, #52A3C8);
   color: var(--text-on-color, #FFFFFF);
@@ -503,8 +526,8 @@
   min-height: 44px;
   border-radius: 999px;
   border: 1px solid var(--border-default, #EEE6D8);
-  font-size: 14px; /* panelHeader */
-  font-weight: 500;
+  font-size: var(--conv-type-size-prominent);
+  font-weight: var(--conv-type-weight-medium);
   cursor: pointer;
   background: transparent;
   color: var(--text-body, #3F3F3E);
@@ -521,8 +544,8 @@
 }
 
 .graphPatchStatus {
-  font-size: 12px; /* panelBody */
-  font-weight: 500;
+  font-size: var(--conv-type-size-body);
+  font-weight: var(--conv-type-weight-medium);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -544,7 +567,7 @@
 }
 
 .graphPatchError {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--danger, #EA7B4B);
   margin-top: 4px;
 }
@@ -557,7 +580,7 @@
   border: 1px solid var(--danger, #EA7B4B);
   background: none;
   color: var(--danger, #EA7B4B);
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   cursor: pointer;
   margin-top: 4px;
 }
@@ -567,13 +590,13 @@
 }
 
 .graphPatchViolations {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--text-body, #3F3F3E);
   margin-top: 4px;
 }
 
 .graphPatchShowDetails {
-  font-size: 14px; /* bodySmall */
+  font-size: var(--conv-type-size-prominent);
   color: var(--info, #52A3C8);
   background: none;
   border: none;
@@ -593,9 +616,9 @@
    Spec: DS v5 §21.3 — 11px panelMeta, info-blue, no underline on hover. */
 .inlineDisclosureToggle {
   font-family: inherit;
-  font-size: 11px; /* typography.panelMeta */
-  line-height: 1.4;
-  font-weight: 400;
+  font-size: var(--conv-type-size-meta);
+  line-height: var(--conv-type-line-snug); /* F3 snap: 1.4 → 1.375 */
+  font-weight: var(--conv-type-weight-regular);
   color: var(--info, #52A3C8);
   background: none;
   border: none;
@@ -628,15 +651,15 @@
   border-radius: 6px;
 }
 .reasoningPanelHeading {
-  font-size: 11px; /* typography.panelMeta */
-  font-weight: 600;
+  font-size: var(--conv-type-size-meta);
+  font-weight: var(--conv-type-weight-semibold);
   color: var(--text-light, #908D8D);
   margin: 0 0 6px 0;
   text-transform: none;
 }
 .reasoningPanelBody {
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--conv-type-size-prominent); /* F3 snap: 13px → 14px */
+  line-height: var(--conv-type-line-normal);
   color: var(--text-body, #4A4642);
   white-space: pre-wrap;
   word-break: break-word;
@@ -659,8 +682,8 @@
 }
 
 .framingGoal {
-  font-weight: 600;
-  font-size: 14px; /* panelHeader */
+  font-weight: var(--conv-type-weight-semibold);
+  font-size: var(--conv-type-size-prominent);
   color: var(--text-header, #262626);
 }
 
@@ -675,8 +698,8 @@
   border-radius: 999px;
   background: transparent;
   color: var(--text-body, #3F3F3E);
-  font-size: 12px; /* panelBody */
-  font-weight: 500;
+  font-size: var(--conv-type-size-body);
+  font-weight: var(--conv-type-weight-medium);
   border: 1px solid color-mix(in srgb, var(--info, #52A3C8) 30%, transparent);
 }
 
@@ -687,14 +710,14 @@
 }
 
 .framingSectionLabel {
-  font-size: 11px; /* panelMeta */
-  font-weight: 600;
+  font-size: var(--conv-type-size-meta);
+  font-weight: var(--conv-type-weight-semibold);
   color: var(--text-light, #908D8D);
   letter-spacing: 0.04em;
 }
 
 .framingItem {
-  font-size: 13px; /* between panelBody 12px and panelHeader 14px — intentional */
+  font-size: var(--conv-type-size-prominent); /* F3 snap: 13px → 14px */
   color: var(--text-body, #3F3F3E);
   padding-left: 8px;
   border-left: none;
@@ -716,7 +739,7 @@
 }
 
 .briefTitle {
-  font-weight: 600;
+  font-weight: var(--conv-type-weight-semibold);
   margin-bottom: 2px;
 }
 
@@ -739,7 +762,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--info, #52A3C8);
   background: none;
   border: none;
@@ -756,7 +779,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--info, #52A3C8);
   text-decoration: none;
 }
@@ -795,14 +818,14 @@
 }
 
 .factBarLabel {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--text-body, #3F3F3E);
   min-width: 80px;
   flex-shrink: 0;
 }
 
 .factBarValue {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--text-light, #908D8D);
   flex-shrink: 0;
   min-width: 36px;
@@ -828,8 +851,8 @@
 }
 
 .factConstraintBadgePass {
-  font-size: 11px; /* panelMeta */
-  font-weight: 600;
+  font-size: var(--conv-type-size-meta);
+  font-weight: var(--conv-type-weight-semibold);
   padding: 2px 6px;
   border-radius: 4px;
   background: transparent;
@@ -840,8 +863,8 @@
 }
 
 .factConstraintBadgeFail {
-  font-size: 11px; /* panelMeta */
-  font-weight: 600;
+  font-size: var(--conv-type-size-meta);
+  font-weight: var(--conv-type-weight-semibold);
   padding: 2px 6px;
   border-radius: 4px;
   background: transparent;
@@ -852,7 +875,7 @@
 }
 
 .factLineage {
-  font-size: 11px; /* panelMeta */
+  font-size: var(--conv-type-size-meta);
   color: var(--text-light, #908D8D);
   font-style: italic;
   margin-top: 4px;
@@ -863,8 +886,8 @@
  * ---------------------------------------------------------------------------*/
 
 .priorityBadge {
-  font-size: 10px; /* one-off badge */
-  font-weight: 700;
+  font-size: var(--conv-type-size-meta); /* F3 snap: 10px → 11px */
+  font-weight: var(--conv-type-weight-semibold); /* F3 snap: 700 → 600 */
   padding: 1px 6px;
   border-radius: 3px;
   color: var(--text-on-color, #FFFFFF);
@@ -904,7 +927,7 @@
  * ---------------------------------------------------------------------------*/
 
 .citationLegend {
-  font-size: 11px; /* panelMeta */
+  font-size: var(--conv-type-size-meta);
   color: var(--text-light, #908D8D);
   margin-top: 6px;
   border-top: 1px solid var(--border-default, #EEE6D8);
@@ -925,7 +948,7 @@
 }
 
 .citationIndex {
-  font-weight: 600;
+  font-weight: var(--conv-type-weight-semibold);
   color: var(--info, #52A3C8);
   flex-shrink: 0;
 }
@@ -992,9 +1015,9 @@
   align-items: center;
   gap: 2px;
   flex-shrink: 0;
-  font-size: 11px; /* panelMeta */
+  font-size: var(--conv-type-size-meta);
   color: var(--info, #52A3C8);
-  font-weight: 500;
+  font-weight: var(--conv-type-weight-medium);
 }
 
 /* Expanded content: DS v5 §19 pattern — mt-2 pl-3 border-l-2 border-panel-border */
@@ -1066,7 +1089,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 11px; /* panelMeta */
+  font-size: var(--conv-type-size-meta);
   color: var(--info, #52A3C8);
   text-decoration: none;
 }
@@ -1098,8 +1121,8 @@
   min-height: 44px;
   border-radius: 999px;
   border: 1px solid var(--danger, #EA7B4B);
-  font-size: 14px; /* panelHeader */
-  font-weight: 500;
+  font-size: var(--conv-type-size-prominent);
+  font-weight: var(--conv-type-weight-medium);
   cursor: pointer;
   background: none;
   color: var(--danger, #EA7B4B);
@@ -1135,8 +1158,8 @@
   border-radius: 999px;
   border-width: 1px;
   border-style: solid;
-  font-size: 12px; /* panelBody token */
-  font-weight: 500;
+  font-size: var(--conv-type-size-body);
+  font-weight: var(--conv-type-weight-medium);
   cursor: pointer;
   min-height: 44px;
   transition: background 150ms, color 150ms;
@@ -1320,8 +1343,8 @@
   gap: 3px;
   padding: 2px 7px;
   border-radius: 999px;
-  font-size: 11px; /* panelMeta */
-  font-weight: 500;
+  font-size: var(--conv-type-size-meta);
+  font-weight: var(--conv-type-weight-medium);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -1358,7 +1381,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-body, #3F3F3E);
-  font-size: 12px; /* panelBody token */
+  font-size: var(--conv-type-size-body);
   min-width: 0;
 }
 
@@ -1371,8 +1394,8 @@
   border: 1px solid var(--info, #52A3C8);
   background: transparent;
   color: var(--info, #52A3C8);
-  font-size: 12px; /* panelBody */
-  font-weight: 500;
+  font-size: var(--conv-type-size-body);
+  font-weight: var(--conv-type-weight-medium);
   cursor: pointer;
   transition: background 150ms;
   white-space: nowrap;
@@ -1440,8 +1463,8 @@
   background: var(--bg-panel, #FEFEFE);
   color: var(--text-body, #3F3F3E);
   font-family: 'Inter', sans-serif;
-  font-size: 16px; /* input field — intentionally larger */
-  line-height: 1.5;
+  font-size: var(--conv-type-size-prominent); /* F3 snap: 16px → 14px — parity with the live ChatComposer textarea */
+  line-height: var(--conv-type-line-normal);
   resize: none;
   outline: none;
   overflow: hidden;
@@ -1518,8 +1541,8 @@
   border-radius: 999px;
   background: var(--info, #52A3C8);
   color: var(--text-on-color, #FFFFFF);
-  font-size: 12px; /* panelBody */
-  font-weight: 500;
+  font-size: var(--conv-type-size-body);
+  font-weight: var(--conv-type-weight-medium);
   border: none;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
@@ -1572,12 +1595,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-body, #3F3F3E);
-  font-size: 12px; /* panelBody token */
+  font-size: var(--conv-type-size-body);
   min-width: 0;
 }
 
 .actionStripCount {
-  font-size: 11px; /* panelMeta token */
+  font-size: var(--conv-type-size-meta);
   color: var(--text-light, #908D8D);
   white-space: nowrap;
   flex-shrink: 0;
@@ -1590,8 +1613,8 @@
   border: 1px solid var(--border-default, #EEE6D8);
   background: var(--bg-panel, #FEFEFE);
   color: var(--text-body, #3F3F3E);
-  font-size: 12px; /* panelBody */
-  font-weight: 500;
+  font-size: var(--conv-type-size-body);
+  font-weight: var(--conv-type-weight-medium);
   cursor: pointer;
   white-space: nowrap;
   transition: background 150ms;
@@ -1602,8 +1625,8 @@
 }
 
 .actionStripBadge {
-  font-size: 11px; /* panelMeta */
-  font-weight: 500;
+  font-size: var(--conv-type-size-meta);
+  font-weight: var(--conv-type-weight-medium);
   padding: 2px 7px;
   border-radius: 999px;
   white-space: nowrap;
@@ -1630,7 +1653,7 @@
 
 /* Patch staleness warning */
 .patchStalenessWarning {
-  font-size: 12px; /* panelBody */
+  font-size: var(--conv-type-size-body);
   color: var(--warning, #FFA656);
   margin-top: 4px;
   padding: 6px 8px;
@@ -1686,7 +1709,7 @@
   align-items: center;
   gap: 6px;
   padding: 4px 0;
-  font-size: 14px; /* bodySmall token */
+  font-size: var(--conv-type-size-prominent);
   color: var(--text-light, #908D8D);
 }
 
@@ -1836,8 +1859,8 @@
   border: 1px solid color-mix(in srgb, var(--info, #52A3C8) 30%, transparent);
   color: var(--text-body, #3F3F3E);
   background: transparent;
-  font-size: 11px;
-  font-weight: 500;
+  font-size: var(--conv-type-size-meta);
+  font-weight: var(--conv-type-weight-medium);
   white-space: nowrap;
 }
 
@@ -1950,8 +1973,8 @@
   align-items: center;
   gap: 6px;
   align-self: flex-start;
-  font-size: 12px; /* panelBody */
-  font-weight: 500;
+  font-size: var(--conv-type-size-body);
+  font-weight: var(--conv-type-weight-medium);
   color: var(--text-body, #262626);
   background: transparent;
   border: 1px solid var(--border-default, #E4E2E0);
@@ -1975,7 +1998,7 @@
   align-items: center;
   gap: 4px;
   align-self: flex-start;
-  font-size: 11px; /* panelMeta */
+  font-size: var(--conv-type-size-meta);
   color: var(--text-light, #908D8D);
   background: none;
   border: none;

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -1054,7 +1054,7 @@ function FlipAnalysisBlockRenderer({ block }: { block: FlipAnalysisBlockType }) 
       )}
       {block.flip_conditions.map((fc, i) => (
         <div key={`${fc.assumption}-${i}`} style={{ padding: '6px 0', borderBottom: i < block.flip_conditions.length - 1 ? '1px solid var(--border-default)' : 'none' }}>
-          <span className={typography.panelBody} style={{ fontWeight: 600 }}>{fc.assumption}</span>
+          <span className={`${typography.panelBody} font-semibold`}>{fc.assumption}</span>
           <div className={typography.panelMeta} style={{ color: 'var(--text-light)', marginTop: 2 }}>
             {fc.current_value && `Currently ${fc.current_value} · `}{fc.direction} past {fc.flip_threshold}
             {fc.alternative_winner && ` → ${fc.alternative_winner}`}

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -248,7 +248,7 @@ export const MessageBubble = memo(function MessageBubble({
       data-testid={`message-${message.role}`}
     >
       <div
-        className={`${compact ? typography.panelBody : typography.body} ${styles.markdownContent} ${
+        className={`${compact ? typography.panelBody : typography.chatProse} ${styles.markdownContent} ${
           compact ? styles.markdownContentCompact : ''
         } ${isProvisional ? styles.provisionalText : ''} ${
           !isUser && isOrchestratorRenderingV2Enabled() ? styles.v2AssistantText : ''

--- a/src/canvas/conversation/ReadinessPill.tsx
+++ b/src/canvas/conversation/ReadinessPill.tsx
@@ -13,6 +13,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { CheckCircle, Info } from 'lucide-react'
 import type { RealtimeSignals } from '../../signals/realtime-signals'
+import { typography } from '../../styles/typography'
 import {
   extractAlternativeSnippet,
   extractOutcomeSnippet,
@@ -121,7 +122,7 @@ export function ReadinessPill({ signals, briefText }: ReadinessPillProps) {
         onClick={toggle}
         className={`
           inline-flex items-center rounded-full font-medium
-          px-2 py-0.5 text-xs
+          px-2 py-0.5 ${typography.caption}
           bg-panel ${textClass}
           transition-opacity duration-200
           hover:opacity-80
@@ -148,7 +149,7 @@ export function ReadinessPill({ signals, briefText }: ReadinessPillProps) {
               ) : (
                 <Info className="w-3.5 h-3.5 text-text-light flex-shrink-0 mt-0.5" aria-hidden="true" />
               )}
-              <span className={`text-xs ${row.detected ? 'text-text-body' : 'text-text-light'}`}>
+              <span className={`${typography.caption} ${row.detected ? 'text-text-body' : 'text-text-light'}`}>
                 {row.detected ? row.presentLabel : row.missingLabel}
               </span>
             </div>

--- a/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
+++ b/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
@@ -10,6 +10,7 @@ import { ChevronDown } from 'lucide-react'
 import { NodeShape } from '../primitives/NodeShape'
 import type { NodeType } from '../../domain/nodes'
 import { FlipDropdown } from '../../../components/ui/FlipDropdown'
+import { typography } from '../../../styles/typography'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mode definitions
@@ -48,7 +49,7 @@ export function ThinkingModeChip({ selectedMode, onClick }: ThinkingModeChipProp
       type="button"
       onClick={onClick}
       aria-haspopup="true"
-      className="top-bar-chip cursor-pointer"
+      className={`top-bar-chip cursor-pointer ${typography.panelBody} font-medium`} /* F3 snap: 13px/500 → panelBody 12px + medium */
       style={{
         display: 'inline-flex',
         alignItems: 'center',
@@ -59,8 +60,6 @@ export function ThinkingModeChip({ selectedMode, onClick }: ThinkingModeChipProp
         background: 'transparent',
         border: '1px solid var(--border-default, #EEE6D8)',
         color: 'var(--text-body, #3F3F3E)',
-        fontSize: 13,
-        fontWeight: 500,
         whiteSpace: 'nowrap' as const,
         transition: 'all 100ms',
       }}
@@ -107,15 +106,16 @@ export function ThinkingModeDropdown({
     >
       {/* Header */}
       <div className="flex items-center" style={{ gap: 8, marginBottom: 12 }}>
-        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-header, #262626)' }}>Thinking mode</span>
+        {/* F3 snap: 13px/600 → panelHeader 14px/600 */}
+        <span className={typography.panelHeader} style={{ color: 'var(--text-header, #262626)' }}>Thinking mode</span>
+        {/* F3 snap: 10px badge → panelMeta 11px */}
         <span
+          className={typography.panelMeta}
           style={{
-            fontSize: 10,
             color: 'var(--text-light, #908D8D)',
             padding: '2px 8px',
             borderRadius: 999,
             border: '1px solid var(--border-default, #EEE6D8)',
-            lineHeight: 1.4,
           }}
         >
           Coming soon
@@ -163,15 +163,15 @@ export function ThinkingModeDropdown({
               <NodeShape kind={mode.shapeKind} size={14} />
             </div>
             <div>
-              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-header, #262626)' }}>{mode.label}</div>
-              <div style={{ fontSize: 11, color: 'var(--text-light, #908D8D)', marginTop: 1, lineHeight: 1.35 }}>{mode.description}</div>
+              <div className={`${typography.panelBody} font-semibold`} style={{ color: 'var(--text-header, #262626)' }}>{mode.label}</div>
+              <div className={typography.panelMeta} style={{ color: 'var(--text-light, #908D8D)', marginTop: 1 }}>{mode.description}</div>
             </div>
           </button>
         )
       })}
 
       {/* Footer */}
-      <p style={{ fontSize: 11, color: 'var(--text-light, #908D8D)', marginTop: 8, lineHeight: 1.45 }}>
+      <p className={typography.panelMeta} style={{ color: 'var(--text-light, #908D8D)', marginTop: 8 }}>
         Select the depth of reasoning for your analysis. Available in an upcoming release.
       </p>
 

--- a/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
+++ b/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
@@ -10,6 +10,7 @@
 import { NodeShape } from '../primitives/NodeShape'
 import type { BriefElement } from '../hooks/useBriefSignals'
 import type { BriefElementKind } from '../primitives/NodeShape'
+import { typography } from '../../../styles/typography'
 
 /** Map brief element kinds to their DS v4 entity border colours. */
 const ENTITY_BORDERS: Record<BriefElementKind, string> = {
@@ -46,6 +47,7 @@ export function BriefGuidanceStrip({ elements, onElementClick }: BriefGuidanceSt
             transition-all duration-200
             focus-visible:ring-2 focus-visible:ring-info focus-visible:outline-none
             hover:bg-panel-hover
+            ${typography.panelMeta} font-medium
           `}
           style={{
             gap: 4,
@@ -56,8 +58,6 @@ export function BriefGuidanceStrip({ elements, onElementClick }: BriefGuidanceSt
               ? `1px solid ${ENTITY_BORDERS[el.kind]}`
               : '1px solid var(--border-default, #EEE6D8)',
             opacity: el.detected ? 1 : 0.5,
-            fontSize: 11,
-            fontWeight: 500,
             color: el.detected
               ? 'var(--text-body, #3F3F3E)'
               : 'var(--text-light, #908D8D)',

--- a/src/canvas/conversation/zones/BriefReadinessPill.tsx
+++ b/src/canvas/conversation/zones/BriefReadinessPill.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { BriefReadiness } from '../hooks/useBriefSignals'
+import { typography } from '../../../styles/typography'
 
 const READINESS_CONFIG: Record<BriefReadiness, { label: string; dotColor: string; borderColor: string }> = {
   low:    { label: 'Low readiness',    dotColor: 'var(--factor, #B0A899)', borderColor: 'var(--factor-light, rgba(176,168,153,0.3))' },
@@ -34,6 +35,7 @@ export function BriefReadinessPill({ readiness, expanded, onToggle }: BriefReadi
         hover:bg-panel-hover transition-all duration-200
         focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-info
         focus-visible:outline-none
+        ${typography.panelMeta} font-medium
       `}
       style={{
         gap: 5,
@@ -41,8 +43,6 @@ export function BriefReadinessPill({ readiness, expanded, onToggle }: BriefReadi
         padding: '0 9px',
         borderRadius: 999,
         border: `1px solid ${config.borderColor}`,
-        fontSize: 11,
-        fontWeight: 500,
       }}
       data-testid="brief-readiness-pill"
     >

--- a/src/canvas/conversation/zones/ChatComposer.tsx
+++ b/src/canvas/conversation/zones/ChatComposer.tsx
@@ -29,6 +29,7 @@ import { recordUiSurfaceState } from '../../../lib/debug-state'
 import type { BriefElementKind } from '../primitives/NodeShape'
 import type { BriefReadiness } from '../hooks/useBriefSignals'
 import type { UseConversationReturn } from '../useConversation'
+import { typography } from '../../../styles/typography'
 import type { ScenarioStage } from '../../../types/scenario'
 
 // ChatTopBar is removed (Tranche 1 item 30); GenerateState now lives here.
@@ -233,8 +234,8 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
         {/* 3b. BIL summary line (flag-gated, soft guidance only) */}
         {bilSummaryLine && (
           <p
-            className="text-text-light"
-            style={{ fontSize: 11, lineHeight: 1.4, margin: 0, padding: '0 2px' }}
+            className={`text-text-light ${typography.panelMeta}`}
+            style={{ margin: 0, padding: '0 2px' }}
             role="status"
             aria-live="polite"
             data-testid="bil-summary"
@@ -246,8 +247,8 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
         {/* 3c. Causal framing coaching tip (weak framing + sufficient text) */}
         {bilResult?.causal_framing_score === 'weak' && debouncedValue.length > 50 && (
           <p
-            className="text-text-light"
-            style={{ fontSize: 11, lineHeight: 1.4, margin: 0, padding: '0 2px', fontStyle: 'italic' }}
+            className={`text-text-light ${typography.panelMeta}`}
+            style={{ margin: 0, padding: '0 2px', fontStyle: 'italic' }}
             data-testid="bil-causal-tip"
           >
             Tip: describe how factors cause outcomes, not just list them.
@@ -347,10 +348,8 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
             disabled={isThinking}
             rows={1}
             aria-label="Message input"
-            className="flex-1 bg-transparent border-none outline-none resize-none text-text-body placeholder:text-text-light"
+            className={`flex-1 bg-transparent border-none outline-none resize-none text-text-body placeholder:text-text-light ${typography.bodySmall}`}
             style={{
-              fontSize: 14,
-              lineHeight: 1.5,
               fontFamily: 'inherit',
               padding: '12px 4px',
               minHeight: 88,
@@ -466,7 +465,7 @@ function InlineGenerateButton({ state, onClick }: { state: GenerateState; onClic
       onClick={onClick}
       data-active={isActive || undefined}
       data-loading={isLoading || undefined}
-      className="inline-gen-btn flex-shrink-0"
+      className={`inline-gen-btn flex-shrink-0 ${typography.panelMeta} font-semibold`}
       style={{
         display: 'inline-flex',
         alignItems: 'center',
@@ -475,8 +474,6 @@ function InlineGenerateButton({ state, onClick }: { state: GenerateState; onClic
         padding: '0 10px',
         borderRadius: 999,
         marginLeft: 'auto',
-        fontSize: 11,
-        fontWeight: 600,
         whiteSpace: 'nowrap' as const,
         transition: 'all 200ms cubic-bezier(0.4, 0, 0.2, 1)',
         background: (isActive || isLoading) ? 'var(--primary, #2B7FA2)' : 'transparent',

--- a/src/canvas/conversation/zones/CoachingTip.tsx
+++ b/src/canvas/conversation/zones/CoachingTip.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Sparkles } from 'lucide-react'
+import { typography } from '../../../styles/typography'
 
 interface CoachingTipProps {
   tip: string
@@ -26,7 +27,7 @@ export function CoachingTip({ tip, onDismiss }: CoachingTipProps) {
       data-testid="coaching-tip"
     >
       <Sparkles className="w-3.5 h-3.5 text-info flex-shrink-0 mt-0.5" aria-hidden="true" />
-      <p className="text-text-body flex-1" style={{ fontSize: 12, lineHeight: 1.5 }}>{tip}</p>
+      <p className={`text-text-body flex-1 ${typography.panelBody}`}>{tip}</p>
       <button
         type="button"
         onClick={onDismiss}

--- a/src/canvas/conversation/zones/ComposerTools.tsx
+++ b/src/canvas/conversation/zones/ComposerTools.tsx
@@ -262,14 +262,13 @@ export function ComposerTools({
                         padding: '1px 8px',
                         border: '1px solid var(--border-default, #EEE6D8)',
                         borderRadius: 999,
-                        lineHeight: 1.4,
                       }}
                     >
                       Coming soon
                     </span>
                   )}
                 </div>
-                <div className={`${typography.panelMeta} text-text-light`} style={{ lineHeight: 1.4, marginTop: 2 }}>
+                <div className={`${typography.panelMeta} text-text-light`} style={{ marginTop: 2 }}>
                   {mode.description}
                 </div>
               </div>

--- a/src/canvas/conversation/zones/EmptyState.tsx
+++ b/src/canvas/conversation/zones/EmptyState.tsx
@@ -78,8 +78,8 @@ export function EmptyState({ animate = false, statusLabel, streamingText }: Empt
       {/* Heading: welcome text when idle, status label when active */}
       {!isActive ? (
         <h2
-          className="text-text-body text-center"
-          style={{ fontSize: 24, fontWeight: 600, margin: 0 }}
+          className={`text-text-body text-center ${typography.welcomeHeading}`}
+          style={{ margin: 0 }}
         >
           What&rsquo;s on your mind?
         </h2>
@@ -128,8 +128,8 @@ export function EmptyState({ animate = false, statusLabel, streamingText }: Empt
       {/* Streaming text — shown below shapes as LLM text arrives */}
       {streamingText && (
         <p
-          className="text-text-body text-center"
-          style={{ fontSize: 14, lineHeight: 1.5, margin: 0, maxWidth: 480, whiteSpace: 'pre-wrap' }}
+          className={`text-text-body text-center ${typography.bodySmall}`}
+          style={{ margin: 0, maxWidth: 480, whiteSpace: 'pre-wrap' }}
           data-testid="empty-state-streaming"
         >
           {streamingText}

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -53,10 +53,20 @@ export const typography = {
   panelBody: 'text-xs font-sans leading-relaxed',                 // 12px — body text, descriptions, bullets, card content
   panelMeta: 'text-[11px] font-sans leading-snug',                // 11px — badges, pills, axis labels, tertiary metadata
 
+  // Conversation panel — ONE type scale (lane F3, register 1.69(a)).
+  // The panel renders exactly three sizes — 14 (panelHeader / chatProse /
+  // bodySmall), 12 (panelBody), 11 (panelMeta) — plus the named 24px
+  // first-use hero (welcomeHeading below). chatProse is the message-prose
+  // step: same 14px as panelHeader but regular weight with relaxed rhythm
+  // for multi-line reading. Census-enforced: scripts/conversation-type-census.mjs
+  // + tests/ci-guards/conversation-type-census.spec.ts fail on any new size.
+  chatProse: 'text-sm font-sans leading-relaxed',                // 14px — chat message prose
+
   // AI Panel v2 first-use hero heading. Inter, 24px, semibold, calm rhythm.
-  // Used exclusively by the FirstUseComposer welcome surface so the hero
-  // reads as a prominent invitation without breaking the strict panel-text
-  // hierarchy used elsewhere. Neutral letter spacing — display tightening
+  // Used exclusively by first-use welcome surfaces (FirstUseComposer, the
+  // conversation EmptyState hero) so the hero reads as a prominent
+  // invitation without breaking the strict panel-text hierarchy used
+  // elsewhere. Neutral letter spacing — display tightening
   // (tracking-tight) felt off on this hero scale.
   welcomeHeading: 'text-[24px] font-semibold font-sans leading-snug', // 24px — AI Panel v2 hero only
 

--- a/tests/ci-guards/conversation-type-census.spec.ts
+++ b/tests/ci-guards/conversation-type-census.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Conversation-panel type-scale census guard (lane F3).
+ *
+ * Runs scripts/conversation-type-census.mjs — which DERIVES every distinct
+ * font-size / font-weight / line-height reaching the conversation panel and
+ * the V5 block renderers (Tailwind utilities, typography.ts tokens, raw CSS
+ * in Conversation.module.css, inline styles) — and pins the result to the
+ * ONE type scale ruled by Paul (register 1.69(a), 12-Jul + 16-Jul):
+ *
+ *   sizes    11 / 12 / 14 px  + the named 24px first-use hero (welcomeHeading)
+ *   weights  400 / 500 / 600
+ *   leading  1.375 / 1.5 / 1.625
+ *
+ * Any future raw text-size utility, inline fontSize, or raw px font-size in
+ * the CSS module (outside the --conv-type-* token block) turns this spec red.
+ * The census script itself fails loud (exit 2) on any mechanism it cannot
+ * resolve, so a hit can hide from this pin only by breaking the build.
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/conversation-type-census.mjs')
+
+interface CensusSummary {
+  errors: string[]
+  files: number
+  sizes: number[]
+  weights: number[]
+  lineHeights: string[]
+  counts: { sizes: number; weights: number; lineHeights: number }
+  rawMechanismHits: {
+    tailwindSize: number
+    inlineSize: number
+    inlineWeight: number
+    cssRawSize: number
+    cssRawWeight: number
+  }
+}
+
+function runCensus(): CensusSummary {
+  const out = execFileSync('node', [SCRIPT, '--json'], { encoding: 'utf8' })
+  return JSON.parse(out) as CensusSummary
+}
+
+describe('conversation-panel type-scale census (F3)', () => {
+  const census = runCensus()
+
+  it('census resolves every mechanism (no fail-loud errors)', () => {
+    expect(census.errors).toEqual([])
+    // Positive control: an empty scan would pass every absence assertion
+    // below while testing nothing (trap-13). Prove the census SEES type.
+    expect(census.files).toBeGreaterThan(50)
+    expect(census.counts.sizes).toBeGreaterThan(0)
+    expect(census.counts.weights).toBeGreaterThan(0)
+  })
+
+  it('font sizes collapse to the scale: 11 / 12 / 14 (+ named 24px hero)', () => {
+    expect(census.sizes).toEqual([11, 12, 14, 24])
+    expect(census.counts.sizes).toBeLessThanOrEqual(4)
+  })
+
+  it('font weights collapse to 400 / 500 / 600', () => {
+    expect(census.weights).toEqual([400, 500, 600])
+  })
+
+  it('line-heights collapse to 1.375 / 1.5 / 1.625', () => {
+    for (const lh of census.lineHeights) {
+      expect(['1.375', '1.5', '1.625']).toContain(lh)
+    }
+  })
+
+  it('no raw (token-bypassing) size or weight mechanisms remain', () => {
+    expect(census.rawMechanismHits).toEqual({
+      tailwindSize: 0,
+      inlineSize: 0,
+      inlineWeight: 0,
+      cssRawSize: 0,
+      cssRawWeight: 0,
+    })
+  })
+})


### PR DESCRIPTION
Lane F3 — ONE type scale for the conversation panel (Paul, 12-Jul + 16-Jul; register 1.69(a)). Audit-first: the census is committed as a derived script + spec, so the count can never drift silently.

## Before census (commit `f281ec87`, base `1ece3edc`, post-F16 tree)

`node scripts/conversation-type-census.mjs` over `src/canvas/conversation/**` + `src/v5/blocks/**` + `Conversation.module.css` (75 files; mechanisms: Tailwind utilities, typography.ts tokens resolved at run time, raw CSS, inline JSX styles; fail-loud on anything unresolvable):

| Axis | Before | Distinct values |
|---|---|---|
| font-size | **8** | 10 (2 hits) · 11 (86) · 12 (67) · 13 (4) · 14 (51) · 16 (2) · 18 (1) · 24 (1) |
| font-weight | **4** | 400 · 500 · 600 · 700 |
| line-height | **7** | 1.35 · 1.375 · 1.4 · 1.45 · 1.5 · 1.625 · 1.65 |

Raw (token-bypassing) hits: 2 Tailwind sizes, 15 inline sizes, 8 inline weights, 51 raw CSS sizes, 34 raw CSS weights.

## The scale (census-derived: 11/12/14 dominate at 86/67/51 hits)

| Step | Token | Size / weight / leading |
|---|---|---|
| Header | `typography.panelHeader` (existing) | 14 / 600 / 1.375 |
| Prose | `typography.chatProse` (**new**) · `bodySmall` (existing) | 14 / 400 / 1.625 · 1.5 |
| Body | `typography.panelBody` (existing) | 12 / 400 / 1.625 |
| Meta | `typography.panelMeta` (existing) | 11 / 400 / 1.375 |
| Named exception | `typography.welcomeHeading` (existing, first-use hero only) | 24 / 600 / 1.375 |

Weights collapse to **400 / 500 / 600**; line-heights to **1.375 / 1.5 / 1.625**. The CSS module routes every declaration through a `--conv-type-*` token block (§ 0); the census spec pins both sides so the token block cannot drift from typography.ts unnoticed.

## Every snap (off-scale → nearest step)

| File | Old → New | Note |
|---|---|---|
| Conversation.module.css `.priorityBadge` | 10px/700 → 11px/600 | one-off badge |
| ThinkingModeDropdown badge | 10px → 11px (panelMeta) | "Coming soon" badge |
| Conversation.module.css `.reasoningPanelBody` | 13px → 14px | prose-like → prose step |
| Conversation.module.css `.framingItem` | 13px → 14px | prose-like (was "intentional between") |
| ThinkingModeDropdown trigger chip | 13px/500 → 12px/500 (panelBody + medium) | chip family is 12 |
| ThinkingModeDropdown title | 13px/600 → 14px/600 (panelHeader) | section header |
| MessageBubble non-compact prose | `typography.body` 16px → `chatProse` 14px | the lane's core ask |
| Conversation.module.css `.growingInput` | 16px → 14px | **GrowingInput has zero importers (dead code)**; the live ChatComposer textarea is 14px — parity. Flag for veto if the 16px iOS-zoom guard was intentional |
| Conversation.module.css `.factValue` | 18px/600 → 14px/600 | one-off display value |
| EmptyState hero | inline 24/600 → `typography.welcomeHeading` | same rendered size, now named |
| ReadinessPill raw `text-xs` ×2 | → `typography.caption` | 12px preserved; leading 1.33→1.5 |
| CoachingTip | inline 12/1.5 → panelBody | leading 1.5→1.625 |
| Leadings | 1.35/1.4 → 1.375 · 1.45/1.65 → 1.5/1.625 | sub-pixel at panel sizes |

Zero copy changes, zero meaning changes, zero layout restructuring (cockpit untouched — typography only).

## After census (commit `5b425bed`) — spec GREEN 5/5

sizes **[11, 12, 14, 24]** · weights **[400, 500, 600]** · line-heights **[1.375, 1.5, 1.625]** · raw hits **all 0**. Spec: `tests/ci-guards/conversation-type-census.spec.ts` (outside `src/v5/**`); any future raw text-size utility, inline fontSize, or raw px in the CSS module turns the suite red. Positive control included (empty-scan guard, trap-13).

## Real-browser computed-style census

Lane dev server + stubbed CEE `/orchestrate/v2/turn` returning a schema-VALID response (validated against `@talchain/schemas/boundary` 0.15.0) with draft_graph + explanation, analysis_result, comparison, flip_analysis, graph_patch, review_card, coaching, evidence, exercise, held_proposal blocks + 3 suggested chips. Swept `getComputedStyle` over every visible text-bearing element in the conversation surface (own-text filter, sr-only excluded):

- **3 distinct font sizes: 11px / 12px / 14px** (≤ 4-step scale; 24px hero surface not mounted in this flow, pinned statically)
- **3 weights: 400 / 500 / 600**
- **Leading ratios: 1.375 / 1.5 / 1.625**
- 9 distinct (size/weight/leading) tuples across prose, all rendered block kinds, chips, entity pills, legend toggle, composer
- Positive control: the same sweep detected the 16px `sr-only` element before exclusion — it can see off-scale presences

## Mutation checks (throwaway worktree, then removed)

1. Revert `.factValue` var back to raw `font-size: 18px` → spec RED (2 tests: size-scale + raw-mechanism)
2. Revert MessageBubble `chatProse` → `typography.body` → spec RED (1 test: size-scale sees 16)

## Gates

- `pnpm run typecheck` clean
- `npx vitest run --changed origin/staging`: **409 files / 5,318 tests passed** (2 skipped files, 37 skipped tests)
- `pnpm run lint`: **0 errors** (1,100 pre-existing warnings)
- Wide tsc multiset (`tsc -p tsconfig.app.json` in fresh-installed lane + matched-base worktrees, sorted + N-more-normalised): **identical, 4,025 lines both — zero new errors**
- Pre-push fast gate passed on push; full suite runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
