### PR TITLE
fix(trust-spine): board #2 — single gated mutation path; kill the saveGraph raw-write bypass

### DIFF
--- a/src/canvas/journey/__tests__/renderTimeline.spec.ts
+++ b/src/canvas/journey/__tests__/renderTimeline.spec.ts
@@ -203,6 +203,35 @@ describe('Fixture 4 — Single stage', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Fixture 4b — graph_saved autosave markers are hidden from the timeline
+//   (positive control: a real user event in the SAME list still renders)
+// ---------------------------------------------------------------------------
+
+describe('Fixture 4b — graph_saved filter', () => {
+  it('excludes graph_saved autosave markers but keeps user events', () => {
+    const events = [
+      makeEvent('direct_edit', { change_type: 'update_node', target_label: 'Revenue' }),
+      makeEvent('graph_saved', {}, { hashes: { graph_hash: 'abc123' } }),
+      makeEvent('graph_saved', {}, { hashes: { graph_hash: 'def456' } }),
+    ]
+    const entries = renderTimeline(events)
+    // Positive control: the direct_edit renders...
+    expect(entries).toHaveLength(1)
+    expect(entries[0].headline).toBe('You updated Revenue')
+    // ...and NO entry came from a graph_saved event.
+    expect(entries.some(e => e.headline.toLowerCase().includes('graph saved'))).toBe(false)
+  })
+
+  it('renders nothing for a timeline of only graph_saved markers', () => {
+    const events = [
+      makeEvent('graph_saved', {}, { hashes: { graph_hash: 'a' } }),
+      makeEvent('graph_saved', {}, { hashes: { graph_hash: 'b' } }),
+    ]
+    expect(renderTimeline(events)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Fixture 5 — direct_edit with target_label / fallback to target_id
 // ---------------------------------------------------------------------------
 

--- a/src/canvas/journey/renderTimeline.ts
+++ b/src/canvas/journey/renderTimeline.ts
@@ -170,6 +170,15 @@ const HEADLINE_BUILDERS: Partial<Record<ScenarioEventType, HeadlineBuilder>> = {
 // ---------------------------------------------------------------------------
 
 /**
+ * Event types that are persistence/system machinery, not user-facing
+ * milestones. Rendered nowhere in the Journey timeline. `graph_saved` is the
+ * gated autosave marker: one is appended on every debounced graph write, so
+ * surfacing it would bury the meaningful entries under save noise. The richer,
+ * per-element `direct_edit` events remain the user-visible edit trail.
+ */
+const TIMELINE_HIDDEN_TYPES = new Set<string>(['graph_saved'])
+
+/**
  * Transform raw scenario events into renderable timeline entries.
  *
  * - Sorts by `seq` ascending
@@ -190,6 +199,11 @@ export function renderTimeline(events: ScenarioEvent[]): TimelineEntry[] {
       const to = str(event.details, 'to') as ScenarioStage
       if (to) currentStage = to
     }
+
+    // Skip system persistence markers (graph_saved autosave events).
+    // Placed AFTER the stage-tracking update so a hidden event still cannot
+    // desync the running stage (defensive — graph_saved never carries a stage).
+    if (TIMELINE_HIDDEN_TYPES.has(event.event_type)) continue
 
     const meta = EVENT_META[event.event_type] ?? DEFAULT_META
     const buildHeadline = HEADLINE_BUILDERS[event.event_type]

--- a/src/canvas/journey/renderTimeline.ts
+++ b/src/canvas/journey/renderTimeline.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ScenarioEvent, ScenarioEventType, ScenarioStage } from '../../types/scenario'
+import { SYSTEM_MARKER_EVENT_TYPES } from '../../types/scenario'
 import type { TimelineEntry, TimelineIconKey, TimelineColourClass } from './types'
 
 // ---------------------------------------------------------------------------
@@ -170,15 +171,6 @@ const HEADLINE_BUILDERS: Partial<Record<ScenarioEventType, HeadlineBuilder>> = {
 // ---------------------------------------------------------------------------
 
 /**
- * Event types that are persistence/system machinery, not user-facing
- * milestones. Rendered nowhere in the Journey timeline. `graph_saved` is the
- * gated autosave marker: one is appended on every debounced graph write, so
- * surfacing it would bury the meaningful entries under save noise. The richer,
- * per-element `direct_edit` events remain the user-visible edit trail.
- */
-const TIMELINE_HIDDEN_TYPES = new Set<string>(['graph_saved'])
-
-/**
  * Transform raw scenario events into renderable timeline entries.
  *
  * - Sorts by `seq` ascending
@@ -200,10 +192,11 @@ export function renderTimeline(events: ScenarioEvent[]): TimelineEntry[] {
       if (to) currentStage = to
     }
 
-    // Skip system persistence markers (graph_saved autosave events).
+    // Skip system persistence markers (e.g. graph_saved autosave events),
+    // derived from the shared source of truth in types/scenario.
     // Placed AFTER the stage-tracking update so a hidden event still cannot
-    // desync the running stage (defensive — graph_saved never carries a stage).
-    if (TIMELINE_HIDDEN_TYPES.has(event.event_type)) continue
+    // desync the running stage (defensive — markers never carry a stage).
+    if (SYSTEM_MARKER_EVENT_TYPES.has(event.event_type)) continue
 
     const meta = EVENT_META[event.event_type] ?? DEFAULT_META
     const buildHeadline = HEADLINE_BUILDERS[event.event_type]

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.editSummary.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.editSummary.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * analysisSnapshotFactory — edit summary vs. system persistence markers.
+ *
+ * Trust-spine board #2 consequence: the gated autosave appends a `graph_saved`
+ * event on EVERY debounced graph write, so between two analysis runs the event
+ * log is dominated by markers. If the edit-summary derivation ever counted
+ * them, the Compare tab would report edits that never happened ("Edited 7
+ * factors" for a rerun with no user change).
+ *
+ * `EDIT_EVENT_TYPES` is derived by filtering out
+ * `SYSTEM_MARKER_EVENT_TYPES` (types/scenario, the single source of truth)
+ * rather than relying on a human keeping two lists disjoint. These are the
+ * behavioural pins on that derivation.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import { SYSTEM_MARKER_EVENT_TYPES } from '../../../types/scenario'
+import type { ScenarioEvent } from '../../../types/scenario'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+const nodes: Node[] = [{ id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } }]
+const edges: Edge[] = []
+
+const PREV = '2026-03-08T10:00:00Z'
+const AFTER = '2026-03-08T10:05:00Z'
+
+function ev(type: string, seq: number, details: Record<string, unknown> = {}): ScenarioEvent {
+  return {
+    event_id: `e${seq}`,
+    seq,
+    event_type: type as ScenarioEvent['event_type'],
+    timestamp: AFTER,
+    details,
+  }
+}
+
+/** runNumber 2 so deriveEditSummary actually inspects events (run 1 short-circuits). */
+function summaryFor(events: ScenarioEvent[]): string {
+  return buildAnalysisSnapshot({
+    rawV2Response: {
+      analysis_status: 'computed',
+      option_comparison_status: 'computed',
+      robustness_status: 'unavailable',
+      drivers_status: 'unavailable',
+      option_comparison: [
+        {
+          option_id: 'opt-1',
+          option_label: 'Option A',
+          win_probability: 0.6,
+          confidence_interval: [0.3, 0.7],
+          expected_outcome: 0.5,
+        },
+      ],
+      critiques: [],
+      response_hash: 'resp-1',
+    } as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges,
+    runNumber: 2,
+    events,
+    previousSnapshotTimestamp: PREV,
+  }).editSummary
+}
+
+describe('deriveEditSummary — system markers never count as edits', () => {
+  it('a rerun whose only intervening events are graph_saved reads as "no edits"', () => {
+    const summary = summaryFor([ev('graph_saved', 1), ev('graph_saved', 2), ev('graph_saved', 3)])
+    expect(summary).toBe('Rerun (no edits)')
+  })
+
+  it('markers do not inflate the count alongside a real edit', () => {
+    // One real edit + three autosave markers must read as ONE edit, not four.
+    const withMarkers = summaryFor([
+      ev('direct_edit', 1, { change_type: 'update_node', target_id: 'n1' }),
+      ev('graph_saved', 2),
+      ev('graph_saved', 3),
+      ev('graph_saved', 4),
+    ])
+    const withoutMarkers = summaryFor([
+      ev('direct_edit', 1, { change_type: 'update_node', target_id: 'n1' }),
+    ])
+    // Positive control: the real edit IS seen (not a vacuous "no edits" pass).
+    expect(withoutMarkers).not.toBe('Rerun (no edits)')
+    expect(withMarkers).toBe(withoutMarkers)
+  })
+
+  it('multi-edit counts ignore markers entirely', () => {
+    const summary = summaryFor([
+      ev('direct_edit', 1, { target_id: 'n1' }),
+      ev('graph_saved', 2),
+      ev('direct_edit', 3, { target_id: 'n2' }),
+      ev('graph_saved', 4),
+    ])
+    expect(summary).toContain('Edited 2 factors')
+  })
+})
+
+describe('SYSTEM_MARKER_EVENT_TYPES — shared source of truth', () => {
+  it('is non-empty (a silently emptied set would make every consumer vacuous)', () => {
+    expect(SYSTEM_MARKER_EVENT_TYPES.size).toBeGreaterThan(0)
+  })
+
+  it('classifies graph_saved as a system marker', () => {
+    expect(SYSTEM_MARKER_EVENT_TYPES.has('graph_saved')).toBe(true)
+  })
+
+  it('does NOT classify real user activity as a marker', () => {
+    for (const t of ['direct_edit', 'patch_accepted', 'graph_drafted', 'analysis_run'] as const) {
+      expect(SYSTEM_MARKER_EVENT_TYPES.has(t)).toBe(false)
+    }
+  })
+})

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -8,7 +8,8 @@
 import type { Node, Edge } from '@xyflow/react'
 import type { V2RunResponse, V2FactorSensitivity, V2OptionComparison } from '../../adapters/plot/v2/types'
 import type { ReportV1 } from '../../adapters/plot/types'
-import type { ScenarioEvent } from '../../types/scenario'
+import type { ScenarioEvent, ScenarioEventType } from '../../types/scenario'
+import { SYSTEM_MARKER_EVENT_TYPES } from '../../types/scenario'
 import type { AnalysisSnapshot, FactorSensitivitySummary } from '../compare-tab/types'
 import { generateGraphHash } from '../utils/graphHash'
 import { hasObservedData } from '../utils/observedStateHelpers'
@@ -159,12 +160,15 @@ function extractInferenceWarnings(
 // Edit summary derivation
 // ---------------------------------------------------------------------------
 
-const EDIT_EVENT_TYPES = new Set([
-  'direct_edit',
-  'patch_accepted',
-  'graph_drafted',
-  'stage_changed',
-])
+// Events that count as a user edit for the Compare-tab summary.
+// Derived, not hand-kept-disjoint: any type classified as a system persistence
+// marker (types/scenario SYSTEM_MARKER_EVENT_TYPES) is structurally removed
+// here, so a future marker can never start inflating the edit count just
+// because someone forgot this list existed.
+const EDIT_EVENT_TYPES: ReadonlySet<ScenarioEventType> = new Set(
+  (['direct_edit', 'patch_accepted', 'graph_drafted', 'stage_changed'] as ScenarioEventType[])
+    .filter((t) => !SYSTEM_MARKER_EVENT_TYPES.has(t)),
+)
 
 function deriveEditSummary(
   events: ScenarioEvent[],

--- a/src/hooks/__tests__/useScenario.gatedWrite.integration.spec.ts
+++ b/src/hooks/__tests__/useScenario.gatedWrite.integration.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Trust-spine board #2 — behavioural pins for EVERY autosave write path.
+ *
+ * WHY THIS FILE EXISTS (review finding): useScenario.spec.ts mocks
+ * scenarioService wholesale, so mutating the retry / unmount-flush call sites
+ * went RED only via a mock-shape artifact ("No `saveGraph` export defined on
+ * the mock") rather than a real assertion about what got persisted. A raw
+ * `supabase.from('scenarios').update({ graph })` introduced in the hook would
+ * have satisfied that mock-shaped test and shipped.
+ *
+ * So this spec deliberately does NOT mock scenarioService. It wires the REAL
+ * service to a mocked `lib/supabase` and asserts, for all three write paths
+ * (debounced save, retry-after-failure, unmount flush), that the actual
+ * `apply_patch_and_log` RPC was invoked with the gated payload — a
+ * `graph_saved` event carrying a derived `graph_hash`. Nothing here can pass
+ * on "no error was thrown".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// --- supabase (the real boundary we assert on) ------------------------------
+const mockRpc = vi.fn()
+const mockUpdate = vi.fn((..._args: unknown[]) => ({
+  eq: vi.fn().mockResolvedValue({ error: null }),
+}))
+const mockFrom = vi.fn((..._args: unknown[]) => ({
+  update: mockUpdate,
+  upsert: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+  insert: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn() })) })),
+  select: vi.fn(() => ({ eq: vi.fn(), order: vi.fn() })),
+  delete: vi.fn(() => ({ eq: vi.fn() })),
+}))
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  },
+}))
+
+// --- router / auth ----------------------------------------------------------
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+
+const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+let mockAuthValue: { user: { id: string } | null; authenticated: boolean } = {
+  user: { id: REAL_USER_ID },
+  authenticated: true,
+}
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => mockAuthValue }))
+
+// --- canvas store (capture the autosave subscription) -----------------------
+type StoreSubscriber = (state: Record<string, unknown>, prev: Record<string, unknown>) => void
+const mockSubscribeCallbacks: StoreSubscriber[] = []
+let storeState: Record<string, unknown> = {}
+
+vi.mock('../../canvas/store', () => ({
+  useCanvasStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+    {
+      getState: () => ({
+        markClean: vi.fn(),
+        hydrateGraphSlice: vi.fn(),
+        resultsHydrateFromSupabase: vi.fn(),
+        ...storeState,
+      }),
+      setState: (partial: Record<string, unknown>) => {
+        storeState = { ...storeState, ...partial }
+      },
+      subscribe: (cb: StoreSubscriber) => {
+        mockSubscribeCallbacks.push(cb)
+        return () => {}
+      },
+    },
+  ),
+}))
+
+vi.mock('../../canvas/domain/edges', () => ({
+  DEFAULT_EDGE_DATA: { weight: 0.5, style: 'solid', curvature: 0.15 },
+}))
+
+import { useScenario } from '../useScenario'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SCENARIO_ID = 'scenario-1'
+const NODES_BEFORE = [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'A' } }]
+const NODES_AFTER = [
+  ...NODES_BEFORE,
+  { id: 'n2', type: 'option', position: { x: 1, y: 1 }, data: { label: 'B' } },
+]
+
+/** Every apply_patch_and_log invocation seen so far. */
+function gatedCalls() {
+  return mockRpc.mock.calls.filter((c) => c[0] === 'apply_patch_and_log')
+}
+
+/** Assert one gated write happened with the full event payload. */
+function expectGatedPayload(params: Record<string, unknown>) {
+  expect(params.p_scenario_id).toBe(SCENARIO_ID)
+  expect(params.p_event_type).toBe('graph_saved')
+  expect(typeof params.p_event_id).toBe('string')
+  expect((params.p_event_id as string).length).toBeGreaterThan(0)
+  const hashes = params.p_hashes as { graph_hash?: string }
+  expect(typeof hashes?.graph_hash).toBe('string')
+  expect(hashes.graph_hash!.length).toBeGreaterThan(0)
+  const graph = params.p_graph as { nodes: unknown[]; edges: unknown[] }
+  expect(graph.nodes).toHaveLength(NODES_AFTER.length)
+}
+
+/** Drive a nodes change through the captured autosave subscription. */
+function triggerGraphChange() {
+  storeState = { ...storeState, nodes: NODES_AFTER, edges: [] }
+  const graphSub = mockSubscribeCallbacks[0]
+  graphSub(
+    { nodes: NODES_AFTER, edges: [], results: { status: 'idle' } },
+    { nodes: NODES_BEFORE, edges: [], results: { status: 'idle' } },
+  )
+}
+
+describe('useScenario — every graph write path goes through apply_patch_and_log', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSubscribeCallbacks.length = 0
+    mockAuthValue = { user: { id: REAL_USER_ID }, authenticated: true }
+    storeState = {
+      currentScenarioId: SCENARIO_ID,
+      nodes: NODES_BEFORE,
+      edges: [],
+      currentScenarioFraming: null,
+      isDirty: false,
+      lastSavedAt: null,
+      results: { status: 'idle' },
+    }
+    mockRpc.mockResolvedValue({ data: {}, error: null })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // -------------------------------------------------------------------------
+  // Path 1 — the debounced save
+  // -------------------------------------------------------------------------
+
+  it('debounced autosave calls apply_patch_and_log with a graph_saved event + hash', async () => {
+    renderHook(() => useScenario())
+
+    await act(async () => {
+      triggerGraphChange()
+      await vi.advanceTimersByTimeAsync(1600)
+    })
+
+    const calls = gatedCalls()
+    expect(calls).toHaveLength(1)
+    expectGatedPayload(calls[0][1] as Record<string, unknown>)
+    // And crucially: no raw column write.
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // Path 2 — the retry after a failed save (useScenario.ts retry branch)
+  // -------------------------------------------------------------------------
+
+  it('RETRY after a failed save re-persists through the gated RPC', async () => {
+    // First gated write fails; the retry (3s later) succeeds.
+    mockRpc
+      .mockResolvedValueOnce({ data: null, error: { message: 'network blip' } })
+      .mockResolvedValue({ data: {}, error: null })
+
+    renderHook(() => useScenario())
+
+    await act(async () => {
+      triggerGraphChange()
+      await vi.advanceTimersByTimeAsync(1600) // debounce → attempt 1 (fails)
+    })
+    expect(gatedCalls()).toHaveLength(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3200) // RETRY_DELAY_MS → attempt 2
+    })
+
+    const calls = gatedCalls()
+    expect(calls).toHaveLength(2)
+    // The retry is a real gated write with its own event id, not a raw update.
+    expectGatedPayload(calls[1][1] as Record<string, unknown>)
+    expect(calls[1][1].p_event_id).not.toBe(calls[0][1].p_event_id)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // Path 3 — the unmount flush (pending debounce fired on cleanup)
+  // -------------------------------------------------------------------------
+
+  it('UNMOUNT FLUSH of a pending save persists through the gated RPC', async () => {
+    const { unmount } = renderHook(() => useScenario())
+
+    // Schedule a debounced save but do NOT let it fire...
+    await act(async () => {
+      triggerGraphChange()
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    expect(gatedCalls()).toHaveLength(0)
+
+    // ...then unmount: the cleanup must flush it through the gated path.
+    await act(async () => {
+      unmount()
+      await Promise.resolve()
+    })
+
+    const calls = gatedCalls()
+    expect(calls).toHaveLength(1)
+    expectGatedPayload(calls[0][1] as Record<string, unknown>)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // Guest mode — zero RPC, zero raw write
+  // -------------------------------------------------------------------------
+
+  it('guest mode performs NO graph write at all (no RPC, no raw update)', async () => {
+    mockAuthValue = { user: { id: 'guest' }, authenticated: true }
+    const { unmount } = renderHook(() => useScenario())
+
+    await act(async () => {
+      triggerGraphChange()
+      await vi.advanceTimersByTimeAsync(1600)
+    })
+    await act(async () => {
+      unmount()
+      await Promise.resolve()
+    })
+
+    expect(gatedCalls()).toHaveLength(0)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/__tests__/useScenario.spec.ts
+++ b/src/hooks/__tests__/useScenario.spec.ts
@@ -40,7 +40,7 @@ vi.mock('../../contexts/AuthContext', () => ({
 const mockCreateScenario = vi.fn()
 const mockLoadScenario = vi.fn()
 const mockDeleteScenario = vi.fn()
-const mockSaveGraph = vi.fn()
+const mockSaveGraphViaGatedPath = vi.fn()
 const mockSaveFraming = vi.fn()
 const mockStoreAnalysis = vi.fn()
 const mockStoreAnalysisFailure = vi.fn()
@@ -55,7 +55,7 @@ vi.mock('../../services/scenarioService', () => ({
   createScenario: (...args: unknown[]) => mockCreateScenario(...args),
   loadScenario: (...args: unknown[]) => mockLoadScenario(...args),
   deleteScenario: (...args: unknown[]) => mockDeleteScenario(...args),
-  saveGraph: (...args: unknown[]) => mockSaveGraph(...args),
+  saveGraphViaGatedPath: (...args: unknown[]) => mockSaveGraphViaGatedPath(...args),
   saveFraming: (...args: unknown[]) => mockSaveFraming(...args),
   storeAnalysis: (...args: unknown[]) => mockStoreAnalysis(...args),
   storeAnalysisFailure: (...args: unknown[]) => mockStoreAnalysisFailure(...args),
@@ -88,6 +88,11 @@ const mockSetState = vi.fn((partial: Record<string, unknown>) => {
   storeState = { ...storeState, ...partial }
 })
 
+// Capture every subscribe callback so a test can drive the debounced autosave
+// subscription directly (the graph-autosave effect subscribes first).
+type StoreSubscriber = (state: Record<string, unknown>, prev: Record<string, unknown>) => void
+const mockSubscribeCallbacks: StoreSubscriber[] = []
+
 vi.mock('../../canvas/store', () => ({
   useCanvasStore: Object.assign(
     // The hook-style call: useCanvasStore(selector)
@@ -95,8 +100,11 @@ vi.mock('../../canvas/store', () => ({
     {
       getState: () => mockGetState(),
       setState: (partial: Record<string, unknown>) => mockSetState(partial),
-      // subscribe mock — returns an unsubscribe function (no-op for tests)
-      subscribe: vi.fn(() => vi.fn()),
+      // subscribe mock — records the callback and returns an unsubscribe no-op
+      subscribe: (cb: StoreSubscriber) => {
+        mockSubscribeCallbacks.push(cb)
+        return () => {}
+      },
     },
   ),
 }))
@@ -137,6 +145,7 @@ function renderUseScenario() {
 describe('useScenario', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSubscribeCallbacks.length = 0
     storeState = {
       currentScenarioId: null,
       nodes: [],
@@ -148,7 +157,7 @@ describe('useScenario', () => {
     }
     setAuth(null, false)
     // Default mock returns — flush-on-unmount calls .catch() on these
-    mockSaveGraph.mockResolvedValue(undefined)
+    mockSaveGraphViaGatedPath.mockResolvedValue(undefined)
     mockSaveFraming.mockResolvedValue(undefined)
     mockSaveTitle.mockResolvedValue(undefined)
     vi.useFakeTimers()
@@ -321,9 +330,79 @@ describe('useScenario', () => {
         await result.current.loadScenario('scenario-2')
       })
 
-      // Should have called resetAnalysisStatus (not saveGraph) to reset the interrupted analysis
+      // Should have called resetAnalysisStatus (not a graph write) to reset the interrupted analysis
       expect(mockResetAnalysisStatus).toHaveBeenCalledWith('scenario-2')
-      expect(mockSaveGraph).not.toHaveBeenCalled()
+      expect(mockSaveGraphViaGatedPath).not.toHaveBeenCalled()
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Graph autosave routing (trust-spine board #2)
+  //
+  // The debounced autosave MUST persist through the single gated path
+  // (saveGraphViaGatedPath → apply_patch_and_log, event + hash), never a raw
+  // write. Reverting the hook back to a raw `saveGraph` call flips this RED.
+  // -----------------------------------------------------------------------
+
+  describe('graph autosave routing', () => {
+    it('routes the debounced autosave through saveGraphViaGatedPath', async () => {
+      setAuth(REAL_USER_ID, true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        nodes: [{ id: 'n1' }],
+        edges: [],
+        results: { status: 'idle' },
+      })
+
+      renderUseScenario()
+
+      // The graph-autosave effect subscribes first.
+      expect(mockSubscribeCallbacks.length).toBeGreaterThan(0)
+      const graphSub = mockSubscribeCallbacks[0]
+
+      const prev = { nodes: [{ id: 'n1' }], edges: [], results: { status: 'idle' } }
+      const nextNodes = [{ id: 'n1' }, { id: 'n2' }]
+      const next = { nodes: nextNodes, edges: [], results: { status: 'idle' } }
+      // getState() (read inside the debounce timer) must reflect the change too.
+      setStoreState({ nodes: nextNodes, edges: [] })
+
+      await act(async () => {
+        graphSub(next, prev)
+        await vi.advanceTimersByTimeAsync(1600)
+      })
+
+      expect(mockSaveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+      const [sid, graph, eventId] = mockSaveGraphViaGatedPath.mock.calls[0]
+      expect(sid).toBe('scenario-1')
+      expect(graph).toEqual({ nodes: nextNodes, edges: [] })
+      expect(typeof eventId).toBe('string')
+      expect(eventId.length).toBeGreaterThan(0)
+    })
+
+    it('does not autosave in guest mode (persistence inactive)', async () => {
+      setAuth('guest', true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        nodes: [{ id: 'n1' }],
+        edges: [],
+        results: { status: 'idle' },
+      })
+
+      renderUseScenario()
+
+      // Subscription still registers, but the callback must no-op for guests.
+      const graphSub = mockSubscribeCallbacks[0]
+      if (graphSub) {
+        await act(async () => {
+          graphSub(
+            { nodes: [{ id: 'n1' }, { id: 'n2' }], edges: [], results: { status: 'idle' } },
+            { nodes: [{ id: 'n1' }], edges: [], results: { status: 'idle' } },
+          )
+          await vi.advanceTimersByTimeAsync(1600)
+        })
+      }
+
+      expect(mockSaveGraphViaGatedPath).not.toHaveBeenCalled()
     })
   })
 

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -151,7 +151,11 @@ export function useScenario(): UseScenarioReturn {
 
         try {
           const currentState = useCanvasStore.getState()
-          await scenarioService.saveGraph(saveSid, { nodes: currentState.nodes, edges: currentState.edges })
+          await scenarioService.saveGraphViaGatedPath(
+            saveSid,
+            { nodes: currentState.nodes, edges: currentState.edges },
+            crypto.randomUUID(),
+          )
           lastSavedGraphRef.current = JSON.stringify({ nodes: currentState.nodes, edges: currentState.edges })
           if (mountedRef.current) {
             const now = Date.now()
@@ -172,7 +176,11 @@ export function useScenario(): UseScenarioReturn {
             if (!retrySid || !mountedRef.current) return
             try {
               const retryState = useCanvasStore.getState()
-              await scenarioService.saveGraph(retrySid, { nodes: retryState.nodes, edges: retryState.edges })
+              await scenarioService.saveGraphViaGatedPath(
+                retrySid,
+                { nodes: retryState.nodes, edges: retryState.edges },
+                crypto.randomUUID(),
+              )
               lastSavedGraphRef.current = JSON.stringify({ nodes: retryState.nodes, edges: retryState.edges })
               if (mountedRef.current) {
                 const now = Date.now()
@@ -253,7 +261,7 @@ export function useScenario(): UseScenarioReturn {
         const sid = scenarioIdRef.current
         if (sid) {
           const { nodes: n, edges: e } = useCanvasStore.getState()
-          scenarioService.saveGraph(sid, { nodes: n, edges: e }).catch((err) => {
+          scenarioService.saveGraphViaGatedPath(sid, { nodes: n, edges: e }, crypto.randomUUID()).catch((err) => {
             console.error('[useScenario] Unmount graph flush failed:', err)
           })
         }

--- a/src/lib/__tests__/loginDraftImport.spec.ts
+++ b/src/lib/__tests__/loginDraftImport.spec.ts
@@ -4,16 +4,16 @@
  * The UI's localStorage half of guest-claim (the server half is CEE's
  * claim_guest_scenario RPC — service_role-only; the browser NEVER calls it).
  * Routes through the EXISTING authenticated create/persist path
- * (scenarioService.createScenario + saveGraph), no new persistence machinery.
+ * (scenarioService.createScenario + saveGraphViaGatedPath), no new persistence machinery.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 const createScenario = vi.fn()
-const saveGraph = vi.fn()
+const saveGraphViaGatedPath = vi.fn()
 
 vi.mock('../../services/scenarioService', () => ({
   createScenario: (...args: unknown[]) => createScenario(...args),
-  saveGraph: (...args: unknown[]) => saveGraph(...args),
+  saveGraphViaGatedPath: (...args: unknown[]) => saveGraphViaGatedPath(...args),
 }))
 
 import {
@@ -40,7 +40,7 @@ function flagOn() {
 beforeEach(() => {
   localStorage.clear()
   createScenario.mockReset()
-  saveGraph.mockReset()
+  saveGraphViaGatedPath.mockReset()
 })
 
 afterEach(() => {
@@ -104,7 +104,7 @@ describe('importGuestDraft', () => {
   it('creates a scenario via the existing path, saves the draft graph, marks imported, returns the id', async () => {
     seedDraft()
     createScenario.mockResolvedValue({ id: 'scn-1' })
-    saveGraph.mockResolvedValue(undefined)
+    saveGraphViaGatedPath.mockResolvedValue(undefined)
 
     const id = await importGuestDraft(REAL_USER.id)
 
@@ -116,8 +116,8 @@ describe('importGuestDraft', () => {
     expect(eventId).toMatch(/^[0-9a-f-]{36}$/)
     // The draft graph is persisted into the new row BEFORE any navigation,
     // so the /scenario/:id server-hydration loads the draft, not an empty graph.
-    expect(saveGraph).toHaveBeenCalledTimes(1)
-    const [scenarioId, graph] = saveGraph.mock.calls[0]
+    expect(saveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+    const [scenarioId, graph] = saveGraphViaGatedPath.mock.calls[0]
     expect(scenarioId).toBe('scn-1')
     expect((graph as { nodes: unknown[] }).nodes).toHaveLength(1)
     expect(localStorage.getItem(DRAFT_IMPORT_MARKER_KEY)).toBe('imported')
@@ -126,7 +126,7 @@ describe('importGuestDraft', () => {
   it('keeps the localStorage draft after import (never deletes user data)', async () => {
     seedDraft()
     createScenario.mockResolvedValue({ id: 'scn-1' })
-    saveGraph.mockResolvedValue(undefined)
+    saveGraphViaGatedPath.mockResolvedValue(undefined)
     await importGuestDraft(REAL_USER.id)
     expect(localStorage.getItem('canvas-storage')).not.toBeNull()
   })
@@ -140,7 +140,7 @@ describe('importGuestDraft', () => {
   it('does NOT mark imported when persistence fails (offer can retry)', async () => {
     seedDraft()
     createScenario.mockResolvedValue({ id: 'scn-1' })
-    saveGraph.mockRejectedValue(new Error('save failed'))
+    saveGraphViaGatedPath.mockRejectedValue(new Error('save failed'))
     await expect(importGuestDraft(REAL_USER.id)).rejects.toThrow('save failed')
     expect(localStorage.getItem(DRAFT_IMPORT_MARKER_KEY)).toBeNull()
   })

--- a/src/lib/loginDraftImport.ts
+++ b/src/lib/loginDraftImport.ts
@@ -8,8 +8,8 @@
  * browser owns is the draft that only exists locally: the `canvas-storage`
  * graph a guest built before signing in. This module offers a one-time
  * import of that draft through the EXISTING authenticated create/persist
- * path (scenarioService.createScenario + saveGraph) — no new persistence
- * machinery, real user_id stamped by the existing seam.
+ * path (scenarioService.createScenario + saveGraphViaGatedPath) — no new
+ * persistence machinery, real user_id stamped by the existing seam.
  *
  * Order matters: the draft graph is saved into the new scenario row BEFORE
  * any navigation, because /scenario/:id hydrates the canvas store from the
@@ -88,7 +88,11 @@ export async function importGuestDraft(userId: string): Promise<string> {
   }
   const eventId = crypto.randomUUID()
   const row = await scenarioService.createScenario(userId, eventId, 'Imported draft')
-  await scenarioService.saveGraph(row.id, { nodes: draft.nodes, edges: draft.edges })
+  await scenarioService.saveGraphViaGatedPath(
+    row.id,
+    { nodes: draft.nodes, edges: draft.edges },
+    crypto.randomUUID(),
+  )
   setMarker('imported')
   return row.id
 }

--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -17,6 +17,7 @@ import { GuestDraftImportBanner } from '../components/auth/GuestDraftImportBanne
 import { useScenario } from '../hooks/useScenario'
 import * as scenarioService from '../services/scenarioService'
 import type { ScenarioListItem, ScenarioStage, AnalysisStatus, ScenarioEvent } from '../types/scenario'
+import { SYSTEM_MARKER_EVENT_TYPES } from '../types/scenario'
 import { Skeleton } from '../components/Skeleton'
 import { formatRelativeTime } from '../utils/formatRelativeTime'
 import { UserAvatarMenu } from '../components/layout/UserAvatarMenu'
@@ -74,7 +75,24 @@ function formatLastActivity(events: ScenarioEvent[] | null | undefined, updatedA
   if (!events || events.length === 0) {
     return `Created ${formatRelativeTime(updatedAt)}`
   }
-  const lastEvent = events[events.length - 1]
+  // Walk back past system persistence markers to the last event that represents
+  // real user activity. The gated autosave appends a `graph_saved` marker after
+  // EVERY graph write, so it is almost always the trailing event — reading
+  // events[length-1] blindly would collapse every card to the generic
+  // "Updated X ago" and silently lose "Model drafted…" / "Model updated…".
+  // The skip-set is derived from the shared source of truth, never hand-listed.
+  let lastEvent: ScenarioEvent | undefined
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (!SYSTEM_MARKER_EVENT_TYPES.has(events[i].event_type)) {
+      lastEvent = events[i]
+      break
+    }
+  }
+  // Only markers (e.g. a freshly-autosaved scenario with no other activity):
+  // fall back to the relative time of the newest marker.
+  if (!lastEvent) {
+    return `Updated ${formatRelativeTime(events[events.length - 1].timestamp ?? updatedAt)}`
+  }
   const details = lastEvent.details ?? {}
 
   switch (lastEvent.event_type) {

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -198,6 +198,107 @@ describe('ScenarioListPage', () => {
     })
   })
 
+  // -------------------------------------------------------------------------
+  // Trust-spine board #2 regression guard.
+  //
+  // The gated autosave appends a `graph_saved` marker after EVERY graph write,
+  // so it is almost always the TRAILING event. Reading events[length-1] blindly
+  // collapses every card to the generic "Updated X ago" and silently loses the
+  // meaningful label. These pin that system markers are skipped.
+  // -------------------------------------------------------------------------
+
+  it('keeps the drafted label when a graph_saved marker trails graph_drafted', async () => {
+    const now = new Date().toISOString()
+    mockListScenarios.mockResolvedValue([
+      {
+        id: 's1',
+        title: 'Test',
+        stage: 'ideate',
+        analysis_status: 'none',
+        updated_at: now,
+        events: [
+          {
+            event_id: 'e1',
+            seq: 1,
+            event_type: 'graph_drafted',
+            timestamp: now,
+            details: { node_count: 6, edge_count: 8 },
+          },
+          // Autosave marker lands last — must NOT mask the drafted label.
+          {
+            event_id: 'e2',
+            seq: 2,
+            event_type: 'graph_saved',
+            timestamp: now,
+            details: {},
+            hashes: { graph_hash: 'abc123' },
+          },
+        ],
+      },
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Model drafted with 6 factors/)).toBeTruthy()
+    })
+    expect(screen.queryByText(/^Updated /)).toBeNull()
+  })
+
+  it('keeps the patch_accepted label behind several trailing graph_saved markers', async () => {
+    const now = new Date().toISOString()
+    mockListScenarios.mockResolvedValue([
+      {
+        id: 's1',
+        title: 'Test',
+        stage: 'ideate',
+        analysis_status: 'none',
+        updated_at: now,
+        events: [
+          {
+            event_id: 'e1',
+            seq: 1,
+            event_type: 'patch_accepted',
+            timestamp: now,
+            details: { summary: 'Added regulatory risk' },
+          },
+          { event_id: 'e2', seq: 2, event_type: 'graph_saved', timestamp: now, details: {} },
+          { event_id: 'e3', seq: 3, event_type: 'graph_saved', timestamp: now, details: {} },
+        ],
+      },
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Model updated — Added regulatory risk/)).toBeTruthy()
+    })
+  })
+
+  it('falls back to the relative-time label when ONLY markers exist', async () => {
+    const now = new Date().toISOString()
+    mockListScenarios.mockResolvedValue([
+      {
+        id: 's1',
+        title: 'Test',
+        stage: 'frame',
+        analysis_status: 'none',
+        updated_at: now,
+        events: [
+          { event_id: 'e1', seq: 1, event_type: 'graph_saved', timestamp: now, details: {} },
+        ],
+      },
+    ])
+
+    renderPage()
+
+    // No meaningful event to describe — the generic label is correct here,
+    // and it must not crash on an all-markers event list.
+    await waitFor(() => {
+      expect(screen.getByText(/Updated /)).toBeTruthy()
+    })
+  })
+
   it('shows sign-in message for guest users', () => {
     mockAuthValue = { user: { id: 'guest' }, authenticated: true }
     renderPage()

--- a/src/services/__tests__/graphWriteSourceGuard.spec.ts
+++ b/src/services/__tests__/graphWriteSourceGuard.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * Trust-spine board #2 — "one authoritative graph-mutation path" enforced
+ * structurally, across the WHOLE source tree.
+ *
+ * THE RULE: nothing in src/ may write the `scenarios.graph` column through a
+ * raw PostgREST `.update(...)` / `.upsert(...)`. The only sanctioned writer is
+ * the gated `apply_patch_and_log` RPC (wrapped by
+ * `scenarioService.saveGraphViaGatedPath`), which atomically writes the graph
+ * AND appends an event carrying the graph hash. A raw write persists graph
+ * state with no event and no hash — invisible to the audit trail.
+ *
+ * WHY REPO-WIDE, not one file: the first version of this guard read only
+ * `scenarioService.ts`. A raw write introduced in `useScenario.ts` (or any
+ * component reaching for `supabase` directly) would have evaded it completely.
+ * The bypass this PR removed lived in the service, but nothing structurally
+ * confines the next one there.
+ *
+ * Scope: all non-test .ts/.tsx under src/, comments and string bodies blanked
+ * so prose about the rule (this docstring included) cannot read as a call site.
+ *
+ * KNOWN LIMIT (stated, not papered over): the scan resolves inline object
+ * literals — `.update({ graph })` / `.update({ graph: g })` — which is the
+ * shape the real bypass used. A write assembled indirectly
+ * (`.update(payload)` where `payload.graph` is set elsewhere) is beyond static
+ * reach here; the RPC-shape assertions in scenarioService.spec and the
+ * behavioural pins in useScenario.spec are the complementary cover.
+ *
+ * NOTE: `blankNonCode`/`argsAt` intentionally mirror the proven helpers in
+ * canvas/__tests__/cameraMotion.sourceScan.spec.ts. They are pure text utils,
+ * and each copy is independently pinned by its own detector-contract block
+ * below — a drifted copy fails its own positive controls rather than silently
+ * returning a wrong verdict. (Deduping the two onto a shared test helper is a
+ * tidy-up, deliberately not bundled into this fix.)
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+const EXCLUDED_DIR_NAMES = new Set(['__tests__', '__fixtures__', '__helpers__', '__mocks__'])
+
+/** PostgREST mutation builders that can write a column directly. */
+const RAW_WRITERS = ['update', 'upsert']
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stats = statSync(full)
+    if (stats.isDirectory()) {
+      if (!EXCLUDED_DIR_NAMES.has(entry)) out.push(...sourceFiles(full))
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue
+    if (/\.(spec|test)\.(ts|tsx)$/.test(entry)) continue
+    if (/\.d\.ts$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+/**
+ * Blank out comments and string/template bodies, preserving offsets and
+ * newlines, so documentation of the rule is never mistaken for a violation.
+ */
+function blankNonCode(src: string): string {
+  const out = src.split('')
+  let i = 0
+  const blankTo = (end: number) => {
+    for (let k = i; k < end && k < src.length; k++) if (out[k] !== '\n') out[k] = ' '
+  }
+  while (i < src.length) {
+    const two = src.slice(i, i + 2)
+    if (two === '//') {
+      let end = src.indexOf('\n', i)
+      if (end === -1) end = src.length
+      blankTo(end)
+      i = end
+    } else if (two === '/*') {
+      let end = src.indexOf('*/', i + 2)
+      end = end === -1 ? src.length : end + 2
+      blankTo(end)
+      i = end
+    } else if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
+      const quote = src[i]
+      let j = i + 1
+      while (j < src.length && src[j] !== quote) {
+        if (src[j] === '\\') j++
+        j++
+      }
+      i++ // keep the opening quote so the token still parses as a value
+      blankTo(j)
+      i = Math.min(j + 1, src.length)
+    } else {
+      i++
+    }
+  }
+  return out.join('')
+}
+
+/** Extract the balanced `(...)` argument text starting at `openIdx`. */
+function argsAt(src: string, openIdx: number): string {
+  let depth = 0
+  for (let i = openIdx; i < src.length; i++) {
+    if (src[i] === '(') depth++
+    else if (src[i] === ')') {
+      depth--
+      if (depth === 0) return src.slice(openIdx + 1, i)
+    }
+  }
+  return src.slice(openIdx + 1)
+}
+
+/**
+ * True when the argument text contains `graph` in KEY position of an object
+ * literal — `{ graph }`, `{ graph: x }`, `{ a: 1, graph: b }`.
+ *
+ * Deliberately anchored on a preceding `{` or `,` so that `graph` appearing as
+ * a VALUE (`{ framing: graph }`) is not a false positive.
+ */
+function writesGraphKey(args: string): boolean {
+  return /[{,]\s*graph\s*[:,}]/.test(args)
+}
+
+/**
+ * Every raw `.update(...)`/`.upsert(...)` in `src` whose inline object literal
+ * writes a `graph` column. Exported shape: `.update({ … graph … })`.
+ */
+export function findRawGraphWrites(src: string): string[] {
+  const code = blankNonCode(src)
+  const violations: string[] = []
+  for (const writer of RAW_WRITERS) {
+    const re = new RegExp(`\\.${writer}\\s*\\(`, 'g')
+    let m: RegExpExecArray | null
+    while ((m = re.exec(code)) !== null) {
+      const openIdx = code.indexOf('(', m.index)
+      if (openIdx === -1) continue
+      const args = argsAt(code, openIdx)
+      if (writesGraphKey(args)) violations.push(`.${writer}({ … graph … })`)
+    }
+  }
+  return violations
+}
+
+// ---------------------------------------------------------------------------
+// Positive control: the scan must be able to SEE a violation.
+// An absence assertion whose detector cannot detect is vacuous.
+// ---------------------------------------------------------------------------
+
+describe('board #2 — the scan itself bites (detector contract)', () => {
+  it('catches the exact bypass shape this PR removed', () => {
+    expect(
+      findRawGraphWrites("await supabase.from('scenarios').update({ graph }).eq('id', id)"),
+    ).toEqual(['.update({ … graph … })'])
+  })
+
+  it('catches an explicit graph value', () => {
+    expect(findRawGraphWrites(".from('scenarios').update({ graph: nextGraph })")).toEqual([
+      '.update({ … graph … })',
+    ])
+  })
+
+  it('catches graph alongside other columns', () => {
+    expect(findRawGraphWrites('.update({ title: t, graph: g, stage: s })')).toEqual([
+      '.update({ … graph … })',
+    ])
+  })
+
+  it('catches a multi-line update payload', () => {
+    const src = ["supabase.from('scenarios').update({", '  graph: currentGraph,', '})'].join('\n')
+    expect(findRawGraphWrites(src)).toEqual(['.update({ … graph … })'])
+  })
+
+  it('catches an upsert that carries a graph column', () => {
+    expect(findRawGraphWrites('.upsert({ id, graph: g }, { onConflict: "id" })')).toEqual([
+      '.upsert({ … graph … })',
+    ])
+  })
+
+  it('catches a raw write no matter WHICH file it lives in (shape-directed, not path-directed)', () => {
+    // The evasion the one-file guard allowed: a raw write inside a hook.
+    const hookish = [
+      'export function useThing() {',
+      "  void supabase.from('scenarios').update({ graph: g }).eq('id', sid)",
+      '}',
+    ].join('\n')
+    expect(findRawGraphWrites(hookish)).toHaveLength(1)
+  })
+
+  // -- and must NOT fire on the sanctioned path or unrelated writes ----------
+
+  it('allows the gated RPC (p_graph is an RPC param, not a column write)', () => {
+    const gated = [
+      "await supabase.rpc('apply_patch_and_log', {",
+      '  p_scenario_id: scenarioId,',
+      '  p_graph: graph,',
+      "  p_event_type: 'graph_saved',",
+      '})',
+    ].join('\n')
+    expect(findRawGraphWrites(gated)).toEqual([])
+  })
+
+  it('allows updates to other columns', () => {
+    expect(findRawGraphWrites(".from('scenarios').update({ framing }).eq('id', id)")).toEqual([])
+    expect(findRawGraphWrites(".from('scenarios').update({ title: t }).eq('id', id)")).toEqual([])
+    expect(
+      findRawGraphWrites(".update({ analysis_status: 'none', analysis_error: null })"),
+    ).toEqual([])
+  })
+
+  it('does not treat `graph` in VALUE position as a graph-column write', () => {
+    expect(findRawGraphWrites('.update({ framing: graph })')).toEqual([])
+  })
+
+  it('ignores raw writes written in comments and strings', () => {
+    expect(findRawGraphWrites('// legacy: .update({ graph })')).toEqual([])
+    expect(findRawGraphWrites('/* .update({ graph: g }) */')).toEqual([])
+    expect(findRawGraphWrites('const doc = ".update({ graph })"')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The actual guard.
+// ---------------------------------------------------------------------------
+
+describe('board #2 — no raw scenarios.graph writer anywhere in src/', () => {
+  it('every graph write routes through the gated RPC (violations must be [])', () => {
+    const violations: string[] = []
+    for (const file of sourceFiles(SRC_ROOT)) {
+      for (const v of findRawGraphWrites(readFileSync(file, 'utf8'))) {
+        violations.push(`${relative(SRC_ROOT, file)} → ${v}`)
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('scans a non-trivial number of files (the walk is not silently empty)', () => {
+    // Guards the guard: a broken walk would make the assertion above vacuous.
+    expect(sourceFiles(SRC_ROOT).length).toBeGreaterThan(200)
+  })
+})

--- a/src/services/__tests__/scenarioService.spec.ts
+++ b/src/services/__tests__/scenarioService.spec.ts
@@ -9,6 +9,8 @@
  * - listScenarios selects only list columns, orders by updated_at DESC
  */
 
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ScenarioPersistenceError } from '../../types/scenario'
 
@@ -209,29 +211,106 @@ describe('scenarioService', () => {
   })
 
   // -----------------------------------------------------------------------
-  // saveGraph / saveFraming / saveTitle (direct UPDATE, no RPC)
+  // saveGraphViaGatedPath (apply_patch_and_log RPC — the ONE gated graph write)
+  //
+  // Trust-spine board #2: the former `saveGraph` raw-UPDATE bypass is gone.
+  // Every scenarios.graph write is now the gated RPC that records an event + a
+  // derived graph hash. These tests pin: (a) the RPC is called (never a raw
+  // UPDATE), (b) event_type is 'graph_saved', (c) the graph_hash is present and
+  // derived from the graph being written, (d) the old export no longer exists.
   // -----------------------------------------------------------------------
 
-  describe('saveGraph', () => {
-    it('calls UPDATE on scenarios table', async () => {
-      const eqFn = vi.fn().mockResolvedValue({ error: null })
-      const updateFn = vi.fn().mockReturnValue({ eq: eqFn })
-      mockFrom.mockReturnValue({ update: updateFn, select: vi.fn(), insert: mockInsert, delete: mockDelete })
+  describe('saveGraphViaGatedPath', () => {
+    const GRAPH = {
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'A' } }],
+      edges: [{ id: 'e1', source: 'n1', target: 'n1', data: { weight: 0.5 } }],
+    } as unknown as Parameters<typeof service.saveGraphViaGatedPath>[1]
 
-      await service.saveGraph('scenario-1', { nodes: [], edges: [] })
+    it('calls apply_patch_and_log with a graph_saved event and a derived graph_hash', async () => {
+      mockRpc.mockResolvedValue({ data: {}, error: null })
 
-      expect(mockFrom).toHaveBeenCalledWith('scenarios')
-      expect(updateFn).toHaveBeenCalledWith({ graph: { nodes: [], edges: [] } })
-      expect(eqFn).toHaveBeenCalledWith('id', 'scenario-1')
+      await service.saveGraphViaGatedPath('scenario-1', GRAPH, VALID_EVENT_ID)
+
+      expect(mockRpc).toHaveBeenCalledTimes(1)
+      const [rpcName, params] = mockRpc.mock.calls[0] as [string, Record<string, unknown>]
+      expect(rpcName).toBe('apply_patch_and_log')
+      expect(params.p_scenario_id).toBe('scenario-1')
+      expect(params.p_graph).toBe(GRAPH)
+      expect(params.p_event_id).toBe(VALID_EVENT_ID)
+      expect(params.p_event_type).toBe('graph_saved')
+      expect(params.p_turn_id).toBeNull()
+      // Hash is recorded and non-empty (records WHAT graph state was persisted)
+      const hashes = params.p_hashes as { graph_hash?: string }
+      expect(typeof hashes.graph_hash).toBe('string')
+      expect(hashes.graph_hash.length).toBeGreaterThan(0)
     })
 
-    it('does not call any RPC', async () => {
-      const eqFn = vi.fn().mockResolvedValue({ error: null })
-      const updateFn = vi.fn().mockReturnValue({ eq: eqFn })
-      mockFrom.mockReturnValue({ update: updateFn, select: vi.fn(), insert: mockInsert, delete: mockDelete })
+    it('records a hash derived from the graph being written (changes with the graph)', async () => {
+      mockRpc.mockResolvedValue({ data: {}, error: null })
 
-      await service.saveGraph('scenario-1', {})
-      expect(mockRpc).not.toHaveBeenCalled()
+      await service.saveGraphViaGatedPath('scenario-1', GRAPH, VALID_EVENT_ID)
+      const hashA = (mockRpc.mock.calls[0][1] as { p_hashes: { graph_hash: string } }).p_hashes.graph_hash
+
+      mockRpc.mockClear()
+      const GRAPH2 = {
+        nodes: [
+          ...(GRAPH as { nodes: unknown[] }).nodes,
+          { id: 'n2', type: 'option', position: { x: 1, y: 1 }, data: { label: 'B' } },
+        ],
+        edges: (GRAPH as { edges: unknown[] }).edges,
+      } as unknown as Parameters<typeof service.saveGraphViaGatedPath>[1]
+      await service.saveGraphViaGatedPath('scenario-1', GRAPH2, VALID_EVENT_ID)
+      const hashB = (mockRpc.mock.calls[0][1] as { p_hashes: { graph_hash: string } }).p_hashes.graph_hash
+
+      expect(hashB).not.toBe(hashA)
+    })
+
+    it('does NOT perform a raw scenarios UPDATE (no bypass writer)', async () => {
+      const updateFn = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) })
+      mockFrom.mockReturnValue({ update: updateFn, select: vi.fn(), insert: mockInsert, delete: mockDelete })
+      mockRpc.mockResolvedValue({ data: {}, error: null })
+
+      await service.saveGraphViaGatedPath('scenario-1', GRAPH, VALID_EVENT_ID)
+
+      expect(updateFn).not.toHaveBeenCalled()
+    })
+
+    it('throws ScenarioPersistenceError on RPC failure', async () => {
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'DB error' } })
+
+      await expect(
+        service.saveGraphViaGatedPath('scenario-1', GRAPH, VALID_EVENT_ID),
+      ).rejects.toMatchObject({ code: 'SAVE_GRAPH_FAILED' })
+    })
+
+    it('the raw-write bypass export `saveGraph` no longer exists', () => {
+      expect((service as Record<string, unknown>).saveGraph).toBeUndefined()
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Source guard — no raw scenarios.graph writer may be re-introduced
+  //
+  // Fail-loud on drift (rule: derive/enforce from the source of truth, never
+  // trust a hand-maintained memory that a bypass "won't come back"). If a
+  // future edit adds `.update({ graph ... })` on the scenarios table, this
+  // trips immediately rather than silently reopening the trust-spine hole.
+  // -----------------------------------------------------------------------
+
+  describe('source guard: no raw graph writer', () => {
+    // Resolve from the repo root (vitest cwd) — robust across transforms.
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/services/scenarioService.ts'),
+      'utf8',
+    )
+
+    it('contains no raw `.update({ graph ... })` on the scenarios table', () => {
+      // Matches update payloads whose first key is `graph` (the bypass shape).
+      expect(/\.update\(\s*\{\s*graph\b/.test(source)).toBe(false)
+    })
+
+    it('writes scenarios.graph only through the apply_patch_and_log RPC', () => {
+      expect(source.includes("supabase.rpc('apply_patch_and_log'")).toBe(true)
     })
   })
 

--- a/src/services/__tests__/scenarioService.spec.ts
+++ b/src/services/__tests__/scenarioService.spec.ts
@@ -9,8 +9,6 @@
  * - listScenarios selects only list columns, orders by updated_at DESC
  */
 
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ScenarioPersistenceError } from '../../types/scenario'
 
@@ -288,31 +286,12 @@ describe('scenarioService', () => {
     })
   })
 
-  // -----------------------------------------------------------------------
-  // Source guard — no raw scenarios.graph writer may be re-introduced
-  //
-  // Fail-loud on drift (rule: derive/enforce from the source of truth, never
-  // trust a hand-maintained memory that a bypass "won't come back"). If a
-  // future edit adds `.update({ graph ... })` on the scenarios table, this
-  // trips immediately rather than silently reopening the trust-spine hole.
-  // -----------------------------------------------------------------------
-
-  describe('source guard: no raw graph writer', () => {
-    // Resolve from the repo root (vitest cwd) — robust across transforms.
-    const source = readFileSync(
-      resolve(process.cwd(), 'src/services/scenarioService.ts'),
-      'utf8',
-    )
-
-    it('contains no raw `.update({ graph ... })` on the scenarios table', () => {
-      // Matches update payloads whose first key is `graph` (the bypass shape).
-      expect(/\.update\(\s*\{\s*graph\b/.test(source)).toBe(false)
-    })
-
-    it('writes scenarios.graph only through the apply_patch_and_log RPC', () => {
-      expect(source.includes("supabase.rpc('apply_patch_and_log'")).toBe(true)
-    })
-  })
+  // NOTE: the source-level "no raw graph writer" guard formerly lived here and
+  // read ONLY this file — so a raw write introduced in useScenario.ts (or any
+  // component reaching for supabase directly) evaded it. It has been replaced
+  // by the repo-wide, shape-directed scan in
+  // services/__tests__/graphWriteSourceGuard.spec.ts, which carries its own
+  // detector-bites positive controls.
 
   describe('saveFraming', () => {
     it('calls UPDATE with framing payload', async () => {

--- a/src/services/scenarioService.ts
+++ b/src/services/scenarioService.ts
@@ -13,8 +13,15 @@
  * idempotency control with the caller.
  */
 
+import type { Node, Edge } from '@xyflow/react'
 import { supabase } from '../lib/supabase'
 import { clearSuppressedScenarioId } from './threadService'
+// Seedless structural+data graph hash. Deliberately the seedless twin
+// (`canvas/utils/graphHash`), NOT the seed-bearing analysis hash in
+// `canvas/store/runHistory`: a persisted-graph event records WHAT graph state
+// was written, independent of any run/seed. Both are pure (type-only imports +
+// a pure edge-key fn), so importing here introduces no React/store dependency.
+import { generateGraphHash } from '../canvas/utils/graphHash'
 import type {
   ScenarioRow,
   ScenarioListItem,
@@ -146,17 +153,35 @@ export async function loadScenario(
 }
 
 // ---------------------------------------------------------------------------
-// 4. saveGraph (direct UPDATE, no event — §6.1)
+// 4. saveGraphViaGatedPath (apply_patch_and_log RPC — the ONE gated graph write)
+//
+// Trust-spine board #2: this REPLACES the former `saveGraph`, which wrote
+// `scenarios.graph` via a RAW `UPDATE` with no event and no hash — a second,
+// unaudited mutation path. Every Supabase write to `scenarios.graph` now goes
+// through the single gated RPC that atomically (a) writes the graph and
+// (b) appends a `graph_saved` event carrying the graph hash. There is no
+// second writer: `apply_patch_and_log` is the sole client-side graph writer.
+//
+// The event hash is DERIVED here from the exact graph being written (never
+// mirrored from a caller-supplied value), so the recorded hash always
+// describes the persisted bytes.
 // ---------------------------------------------------------------------------
 
-export async function saveGraph(
+export async function saveGraphViaGatedPath(
   scenarioId: string,
-  graph: unknown,
+  graph: { nodes: Node[]; edges: Edge[] },
+  eventId: string,
+  turnId?: string,
 ): Promise<void> {
-  const { error } = await supabase
-    .from('scenarios')
-    .update({ graph })
-    .eq('id', scenarioId)
+  const { error } = await supabase.rpc('apply_patch_and_log', {
+    p_scenario_id: scenarioId,
+    p_graph: graph,
+    p_event_id: eventId,
+    p_event_type: 'graph_saved',
+    p_details: {},
+    p_hashes: { graph_hash: generateGraphHash(graph.nodes, graph.edges) },
+    p_turn_id: turnId ?? null,
+  })
 
   if (error) {
     throw new ScenarioPersistenceError(

--- a/src/types/scenario.ts
+++ b/src/types/scenario.ts
@@ -131,6 +131,30 @@ export type ScenarioEventType =
   | 'changed_thinking'
   | 'feedback_submitted'
 
+/**
+ * SINGLE SOURCE OF TRUTH for "this event is machine persistence noise, not a
+ * user-facing activity".
+ *
+ * Events listed here are appended by the persistence layer itself (not by a
+ * user action) and would otherwise drown the surfaces that summarise activity:
+ * the gated autosave appends one `graph_saved` per debounced write, so it is
+ * ALWAYS the trailing event after any meaningful one.
+ *
+ * Every surface that summarises or renders scenario activity MUST consume this
+ * set rather than hand-listing members — a hand-maintained mirror of this list
+ * is exactly the drift class that has bitten this codebase before. Current
+ * consumers:
+ *   - canvas/journey/renderTimeline.ts   (hides them from the Journey timeline)
+ *   - pages/ScenarioListPage.tsx         (skips them when labelling last activity)
+ *   - canvas/stores/analysisSnapshotFactory.ts (excluded from the edit set)
+ *
+ * Typed as ReadonlySet<ScenarioEventType>, so a member that is not a real
+ * event type is a COMPILE error — the union above stays the source of truth.
+ */
+export const SYSTEM_MARKER_EVENT_TYPES: ReadonlySet<ScenarioEventType> = new Set<ScenarioEventType>([
+  'graph_saved',
+])
+
 // ---------------------------------------------------------------------------
 // § 2.3 — shared_briefs (public-access shape returned by get_shared_brief_by_slug)
 // ---------------------------------------------------------------------------

--- a/src/types/scenario.ts
+++ b/src/types/scenario.ts
@@ -114,6 +114,10 @@ export type ScenarioEventType =
   | 'patch_dismissed'
   | 'patch_rejected'
   | 'direct_edit'
+  // Persistence marker — appended by the gated autosave write
+  // (saveGraphViaGatedPath). System-level: hidden from the Journey timeline and
+  // excluded from the edit-count summary; carries the persisted graph_hash.
+  | 'graph_saved'
   // Analysis
   | 'analysis_run'
   | 'analysis_failed'


### PR DESCRIPTION
## Trust-spine board #2 — one authoritative graph-mutation path

**Defect.** The canvas autosave persisted `scenarios.graph` via a RAW
`UPDATE` (`scenarioService.saveGraph`) that recorded **no event and no hash** —
a second, unaudited graph-write path running parallel to the gated
`apply_patch_and_log` RPC. Any graph state written this way was invisible to
the event log and hash trail.

**Fix.** `saveGraph` is replaced by `saveGraphViaGatedPath`, which writes the
graph through the single gated `apply_patch_and_log` RPC — atomically writing
the graph **and** appending a `graph_saved` event whose `graph_hash` is
**derived from the exact graph being written** (never a caller-mirrored value).
All autosave writers route through it: `useScenario` (debounced save, retry,
unmount flush) and `loginDraftImport` (guest-draft claim). No raw
`scenarios.graph` writer remains.

### Complete graph-writer manifest (verified at the bytes, staging `a85b73c2`)
| Writer | Target | Verdict |
|---|---|---|
| `saveGraph` (raw `UPDATE {graph}`) | `scenarios.graph` | **KILLED** → replaced by `saveGraphViaGatedPath` |
| `apply_patch_and_log` RPC (gated) | `scenarios.graph` | The ONE path; now the sole client-side graph writer |
| `duplicate_scenario` RPC | `scenarios.graph` (server-side `INSERT…SELECT`) | Left — SECURITY DEFINER server copy, not a canvas write path |
| `create_snapshot` RPC | `shared_snapshots`/`scenario_snapshots.graph` | Left — separate immutable snapshot table, not the live graph |
| `store_analysis_and_log` | `scenarios.analysis` | Not a graph writer |

`saveFraming`/`saveTitle`/pin/archive/analysis-status raw updates touch other
columns, not `graph` — untouched.

### `graph_saved` event type
Added to `ScenarioEventType`. It is a **system persistence marker**: filtered
out of the Journey timeline (one is appended per debounced save; surfacing them
would bury real milestones) and excluded from the edit-count summary. The
richer per-element `direct_edit` stream (emitted separately by
`useGraphEditEvents`) is untouched, so edits are **not** double-counted.

### Guest mode
Unchanged. Persistence stays gated on a signed-in user (`user.id !== 'guest'`);
the localStorage canvas path is byte-identical.

### Tests (RED-first; mutation-checked — reverting each fix turns the pin RED)
- **scenarioService**: gated path calls `apply_patch_and_log` with a
  `graph_saved` event + derived `graph_hash`; performs no raw `UPDATE`;
  source-guard forbids re-introducing `.update({ graph })`; the old `saveGraph`
  export is gone.
- **useScenario**: the debounced autosave routes through
  `saveGraphViaGatedPath`; guest mode writes nothing.
- **renderTimeline**: `graph_saved` markers are filtered (positive control — a
  real user event in the same list still renders).

### Gates
- `pnpm build` (real compile gate): **pass** (built in 3m 23s).
- `pnpm typecheck` (`tsconfig.ci.json`): **pass** — but weak (covers ~a dozen
  named files; none of the changed files are in its include list).
- Full-app `tsc -p tsconfig.app.json`: 2323 **pre-existing** errors; **zero** in
  the changed product files (one unrelated pre-existing `AnalysisStatus`
  unused-import warning in `useScenario.ts:23`, present on base).
- `pnpm test`: 17015 pass / 2 fail / 60 files fail — the 2 failing tests and 60
  failing files are **pre-existing** (proven: the identical set fails on base
  `staging` with my change stashed; cause = the documented flags-mock drift +
  MSW/Supabase-env infra, unrelated to this change).
- `eslint` (changed files): 0 errors, 3 pre-existing warnings.

Do **not** merge — draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 2 — both items closed (`7db25c43`)

### P1 (regression this PR introduced) — activity labels restored
Because the gated autosave appends a `graph_saved` marker after EVERY graph
write, that marker is almost always the **trailing** event.
`ScenarioListPage.formatLastActivity` read `events[events.length-1]` and fell
through to `default:`, so scenario cards silently lost
"Model drafted with N factors" / "Model updated — …" and collapsed to a generic
"Updated X ago".

**Shared constant — created, not hand-listed.** No suitable one existed
(`EDIT_EVENT_TYPES` is an inclusion allowlist, semantically the inverse), so
`SYSTEM_MARKER_EVENT_TYPES` now lives in `types/scenario.ts` beside the
`ScenarioEventType` union, typed `ReadonlySet<ScenarioEventType>` so a bogus
member is a **compile** error. All three surfaces consume it:

| Surface | Before | Now |
|---|---|---|
| `journey/renderTimeline.ts` | local `TIMELINE_HIDDEN_TYPES` | consumes shared |
| `pages/ScenarioListPage.tsx` | (no skip — the bug) | walks back past markers |
| `stores/analysisSnapshotFactory.ts` | hand-kept disjoint | `EDIT_EVENT_TYPES` filters markers out structurally |

Honest nuance: the snapshot factory is an **allowlist**, so it was already
immune — its filter is a forward-looking safety net, and its edit-count tests
stay green under the "empty the constant" mutation by construction. The
renderTimeline and ScenarioListPage consumers do bite (see below).

### P2 — every write path behaviourally pinned; guard broadened
- **`useScenario.gatedWrite.integration.spec.ts` (new)** deliberately does NOT
  mock `scenarioService`. It wires the **real** service to a mocked `supabase`
  and asserts that the debounced save, the **retry**, and the **unmount flush**
  each invoke `apply_patch_and_log` with a `graph_saved` event and a derived
  `graph_hash` — and that `mockUpdate` is never called. Guest mode asserts zero
  RPC and zero raw write. Nothing here can pass on "no error was thrown".
- **`graphWriteSourceGuard.spec.ts` (new)** replaces the one-file guard with a
  repo-wide, shape-directed scan of all non-test `src/`, comments and strings
  blanked, carrying its own **detector-bites** positive controls (it must prove
  it can SEE a violation before its absence assertion means anything). The
  gated RPC needs no allowlist — `p_graph` is an RPC param, not a column write,
  so it does not match by construction. Stated limit: it resolves inline object
  literals (the shape the real bypass used); an indirectly-assembled payload is
  beyond static reach, which is what the behavioural pins above cover.

### Mutation outputs (each fix reverted → RED)
| Mutation | Result |
|---|---|
| `formatLastActivity` → blind `events[length-1]` | **RED** — both label tests ("Unable to find *Model drafted with 6 factors*") |
| `SYSTEM_MARKER_EVENT_TYPES` → empty set | **RED** — renderTimeline (2) + ScenarioListPage (2) + constant guards (2) |
| raw `.update({ graph })` in **retry** path | **RED** — retry pin, **and** guard: `hooks/useScenario.ts → .update({ … graph … })` |
| raw `.update({ graph })` in **unmount flush** | **RED** — unmount pin **and** guard |

The guard naming `hooks/useScenario.ts` is the precise evasion the previous
one-file guard permitted.

### Gates (round 2)
- `pnpm build`: **pass** (35s).
- `pnpm typecheck`: **pass** (still weak — none of the changed files are in
  `tsconfig.ci.json`'s include list).
- Full-app `tsc -p tsconfig.app.json`: caught **one new error of mine** (a
  spread-arg type in the new integration spec) — **fixed**; changed files now
  add zero new errors. Remaining hits in touched files (`AnalysisStatus`,
  `authenticated`, `deleting`) are pre-existing on untouched lines.
- `pnpm test`: 17038 pass / 2 fail / 60 files fail — the failing set is
  **byte-identical** (`diff` empty) to the set already proven pre-existing by
  running it on base with this change stashed. My 3 new spec files add +23
  passing tests.

---

## Known residual — NOT addressed here (routed to architecture assessment)

**`scenarios.events` JSONB array growth is O(n²) and unbounded.** Evidence:
- `scenarios.events JSONB NOT NULL DEFAULT '[]'` — migration
  `20260226000000_scenario_schema_v2.sql:22`.
- `append_scenario_event` appends via
  `SET events = events || jsonb_build_array(v_event)` (:139) — PostgreSQL
  rewrites the **entire** array on every append, so N appends cost O(N²) bytes
  written.
- `listScenarios` selects the whole column for every row
  (`scenarioService.ts:113`), so the hub list drags every event of every
  scenario over the wire.

**This PR amplifies the append rate** (one `graph_saved` per debounced save)
even though the underlying design is pre-existing. Deliberately out of scope
for this fix; flagged so it is not lost.
