### PR TITLE
refactor(conversation): /simplify folds — one bias predicate, typed registry, structural bias cap

### DIFF
--- a/src/canvas/components/analysisRunStatus.ts
+++ b/src/canvas/components/analysisRunStatus.ts
@@ -141,17 +141,20 @@ export function runAnnouncementForTransition({
   settledWithoutNewReport,
 }: RunAnnouncementInput): string | null {
   const firstRun = preRunStatus === 'idle' || preRunStatus === 'cancelled'
-  if (transition === 'start') {
-    if (analysisTabFronted) return null
-    // First run: the dock's auto-switch is about to front the Analysis tab,
-    // whose own furniture speaks. Announcing here would double up.
-    if (firstRun) return null
-    return 'Analysis started.'
-  }
-  // Settle: yield to the fronted Analysis tab's completion toast / error
-  // alert — EXCEPT on a first run, whose settle nothing else announces
-  // (the asymmetry documented above).
-  if (analysisTabFronted && !firstRun) return null
+  // The C6 asymmetry as ONE expression (/simplify item 8), so the two
+  // transitions' yield rules sit side by side and cannot drift:
+  //  - START yields when the tab is fronted OR the run is a first run (the
+  //    dock's auto-switch is about to front the Analysis tab, whose own
+  //    furniture speaks — announcing here would double up).
+  //  - SETTLE yields only when fronted AND it is NOT a first run: nothing
+  //    else announces a first-run settle (the completion toast mounts
+  //    post-settle with wasRunningRef = false).
+  const yieldsToTabFurniture =
+    transition === 'start' ? analysisTabFronted || firstRun : analysisTabFronted && !firstRun
+  if (yieldsToTabFurniture) return null
+  if (transition === 'start') return 'Analysis started.'
+  // settledStatus is a raw store string — keep the switch. An object lookup
+  // would reintroduce the prototype-chain hazard fix set A just closed.
   switch (settledStatus) {
     case 'complete':
       // C2: a settle that carried no new report must not claim completion.

--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -28,13 +28,15 @@ import { StickyFooter } from './StickyFooter'
 import { focusNodeById } from '../../utils/focusHelpers'
 import { withObservedStateUpdate } from '../../utils/observedStateHelpers'
 import { useCanvasStore } from '../../store'
-import { resolveBiasSignal } from '../../shared/biasSignalTitles'
+import { biasSignal, resolveBiasSignal } from '../../shared/biasSignalTitles'
+import type { KnownBiasCode } from '../../shared/biasSignalTitles'
 import { useDraftStore } from '../../stores/draftStore'
 import { useRetryDraft } from '../../hooks/useRetryDraft'
 import { SOFT_BYPASS_STATUSES } from '../../hooks/usePreRunValidation'
 import { useShowToast } from '../../ToastContext'
 import { copyTextToClipboard } from '../../../utils/clipboard'
-import { RefreshCw, Copy, Pencil, AlertTriangle, Check, X, Frame, ShieldAlert, Gauge, Anchor, EyeOff, Link as LinkIcon } from 'lucide-react'
+import { RefreshCw, Copy, Pencil, AlertTriangle, Check, X, ShieldAlert, EyeOff, Link as LinkIcon } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import { useUIStore } from '@/stores/uiStore'
 import { getCausalEdges } from '../../domain/edgeUtils'
 import type { EdgeData } from '../../domain/edges'
@@ -74,15 +76,6 @@ import { WhatOlumiAddedSection } from './WhatOlumiAddedSection'
 
 /** AI source provenance labels */
 const AI_SOURCES = new Set(['ai', 'cee_inference', 'inferred', 'ai_estimate', 'engine'])
-
-// Icon + title lookup for CEE bias type strings: THE shared bias registry
-// (src/canvas/shared/biasSignalTitles.ts — resolveBiasSignal). One
-// lowercase-keyed map for both wire conventions (lowercase `type`,
-// uppercase `code` — the resolver lowercases), one guarded lookup (own-key
-// check, so hostile prototype-chain codes like 'constructor'/'__proto__'
-// fail closed instead of crashing the panel). Any unrecognised key falls
-// back to safeBiasTitle / BIAS_FALLBACK per the brief. Replaces the
-// panel-local BIAS_TYPE_ICON dual-case mirror (review-folds 2026-07-17).
 
 /**
  * Entity-ID prefixes that must NEVER appear in user-facing copy. If a CEE bug
@@ -134,7 +127,7 @@ export function safeBiasTitle(token: string): string | null {
 }
 
 /** Generic fallback for unrecognised bias codes per the brief. */
-const BIAS_FALLBACK: { icon: typeof Frame; title: string } = {
+const BIAS_FALLBACK: { icon: LucideIcon; title: string } = {
   icon: EyeOff,
   title: 'Bias detected',
 }
@@ -309,7 +302,7 @@ type RawBiasFinding = {
 
 export interface NormalisedBiasTrigger {
   id: string
-  icon: typeof Frame
+  icon: LucideIcon
   title: string
   subtitle: string
   fullExplanation: string
@@ -1418,12 +1411,21 @@ export function PreAnalysisPanel({
     // no target factor — these are graph-level signals that do not anchor to
     // a single node).
 
-    const pushDeterministic = (
-      id: string,
-      icon: typeof Frame,
-      title: string,
-      explanation: string,
-    ) => {
+    /**
+     * A deterministic trigger's identity. `{ code }` derives BOTH channels —
+     * title and icon — from the ONE bias registry, so the two can never
+     * drift apart at a call site (/simplify item 3). The explicit
+     * `{ id, title, icon }` arm is for non-bias graph signals:
+     * `missing_risks` is a graph-signal label, NOT a bias code, and is
+     * deliberately kept out of the registry.
+     */
+    type DeterministicTriggerSpec =
+      | { code: KnownBiasCode }
+      | { id: string; title: string; icon: LucideIcon }
+
+    const pushDeterministic = (spec: DeterministicTriggerSpec, explanation: string) => {
+      const { id, title, icon } =
+        'code' in spec ? { id: spec.code, ...biasSignal(spec.code) } : spec
       triggers.push({
         id,
         icon,
@@ -1440,22 +1442,20 @@ export function PreAnalysisPanel({
     // 1. Narrow framing: fewer than 2 non-baseline options
     const nonBaselineOptions = data.optionPreviews.filter(o => !o.isBaseline)
     if (nonBaselineOptions.length < 2) {
+      // Title AND icon from the one registry; the explanation copy stays
+      // local to this trigger.
       pushDeterministic(
-        'narrow_framing',
-        Frame,
-        // Bias NAME from the one registry (review-folds C15) — the
-        // explanation copy stays local to this trigger.
-        resolveBiasSignal('narrow_framing')!.title,
+        { code: 'narrow_framing' },
         'Consider structurally different approaches. What would a competitor do?',
       )
     }
 
     // 2. Missing risks: 0 or 1 risk nodes
     if (data.nodesByKind.risk.length <= 1) {
+      // Non-bias graph signal — explicit label + icon, deliberately not a
+      // registry entry.
       pushDeterministic(
-        'missing_risks',
-        ShieldAlert,
-        'Missing risks',
+        { id: 'missing_risks', title: 'Missing risks', icon: ShieldAlert },
         'Your model has few risks. Consider what could go wrong with each option.',
       )
     }
@@ -1479,10 +1479,7 @@ export function PreAnalysisPanel({
           if (source && AI_SOURCES.has(source) && (!drivers || drivers.length === 0)) {
             const label = (nd.label as string) ?? topFactorId
             pushDeterministic(
-              'overconfidence',
-              Gauge,
-              // Bias NAME from the one registry (review-folds C15).
-              resolveBiasSignal('overconfidence')!.title,
+              { code: 'overconfidence' },
               `${label} drives most of the outcome but has no supporting evidence. Validate it before relying on it.`,
             )
           }
@@ -1523,9 +1520,7 @@ export function PreAnalysisPanel({
           }
           if (allNarrow && hasValidFactor) {
             pushDeterministic(
-              'anchoring',
-              Anchor,
-              'Anchoring',
+              { code: 'anchoring' },
               'Your options are similar. Try a wider range of approaches.',
             )
           }

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useCallback, useMemo, memo } from 'react'
+import { flushSync } from 'react-dom'
 import { Lightbulb, AlertTriangle, ChevronDown, ChevronUp, ExternalLink, Wand2 } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { useGuidanceStore } from '../stores/guidanceStore'
@@ -145,13 +146,14 @@ export const InlineBlocks = memo(function InlineBlocks({
   // cards carry their own budget (the pacing group), so the legacy cap
   // counts only the non-phase-3 blocks; otherwise behaviour is unchanged
   // (cap across all blocks, as before F16). Bias-signal cards are exempt
-  // UNCONDITIONALLY (review-folds C1): they carry their own ≤2 cap
-  // upstream, so they never join this budget and never hide behind
-  // "Show N more" — the ratified #356 acceptance.
+  // (review-folds C1) — but only the FIRST DRAFT_BIAS_SIGNAL_CARD_CAP of
+  // them (/simplify item 5), from the ONE exempt set computePhase3Pacing
+  // already derived, so this budget and the pacing budget cannot disagree.
+  // Bias cards beyond the cap fall through to the normal budget path.
   const { hiddenByBudget, hasOverflow, hiddenCount } = useMemo(() => {
     const budgetIndices: number[] = []
     for (let i = 0; i < blocks.length; i++) {
-      if (isBiasSignalCoachingBlock(blocks[i])) continue
+      if (pacing.biasSignalExemptIndices.has(i)) continue
       if (pacing.pacingActive && isPhase3CardBlock(blocks[i])) continue
       budgetIndices.push(i)
     }
@@ -168,20 +170,19 @@ export const InlineBlocks = memo(function InlineBlocks({
 
   const phase3Collapsed = pacing.pacingActive && !showAllPhase3
 
+  // THE visibility rule — one predicate, both consumers (/simplify item 4).
+  // The render guard below and the legend gate were De Morgan duals of this
+  // and could drift apart.
+  const isBlockHidden = useCallback(
+    (i: number) => hiddenByBudget.has(i) || (phase3Collapsed && pacing.collapsedIndices.has(i)),
+    [hiddenByBudget, phase3Collapsed, pacing],
+  )
+
   // C13: the graph-vocabulary legend gates on a phase-3 card being
   // CURRENTLY RENDERED — never on mere presence in the turn (a legend for
   // cards hidden behind the pacing collapse or the legacy budget explained
   // vocabulary the user could not see).
-  const phase3Rendered = useMemo(
-    () =>
-      blocks.some(
-        (b, i) =>
-          isPhase3CardBlock(b) &&
-          !hiddenByBudget.has(i) &&
-          !(pacing.pacingActive && !showAllPhase3 && pacing.collapsedIndices.has(i)),
-      ),
-    [blocks, hiddenByBudget, pacing, showAllPhase3],
-  )
+  const phase3Rendered = blocks.some((b, i) => isPhase3CardBlock(b) && !isBlockHidden(i))
 
   // C11: citations can point at collapsed content. Handed to the
   // commentary renderer only while something is actually collapsed, so a
@@ -230,7 +231,7 @@ export const InlineBlocks = memo(function InlineBlocks({
             </button>
           ) : null
 
-        if (hiddenByBudget.has(i) || (phase3Collapsed && pacing.collapsedIndices.has(i))) {
+        if (isBlockHidden(i)) {
           return affordance ? <div key={i}>{affordance}</div> : null
         }
 
@@ -420,7 +421,7 @@ function BlockRenderer({
       return (
         <V5CoachingBlock
           block={block}
-          variant={block.coaching_kind === 'bias_signal' ? 'bias_signal' : 'default'}
+          variant={isBiasSignalCoachingBlock(block) ? 'bias_signal' : 'default'}
         />
       )
 
@@ -495,18 +496,14 @@ const CommentaryBlockRenderer = memo(function CommentaryBlockRenderer({
     }
     // C11: the target may sit behind the phase-3 pacing collapse or the
     // legacy per-turn budget (collapsed blocks render no
-    // data-citation-target node). When collapsed content exists, reveal
-    // it, wait for the commit (double rAF), then retry the lookup and
-    // scroll. Fail silent only when the target is STILL missing (a
-    // genuinely dangling citation).
+    // data-citation-target node). When collapsed content exists, reveal it
+    // and flush the commit synchronously, so the retried lookup sees the
+    // revealed node in this same click handler. Fail silent only when the
+    // target is STILL missing (a genuinely dangling citation).
     if (!onRevealHiddenBlocks) return
-    onRevealHiddenBlocks()
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const revealed = document.querySelector(`[data-citation-target="${index}"]`)
-        if (revealed) scrollToCitationTarget(revealed)
-      })
-    })
+    flushSync(onRevealHiddenBlocks)
+    const revealed = document.querySelector(`[data-citation-target="${index}"]`)
+    if (revealed) scrollToCitationTarget(revealed)
   }, [onRevealHiddenBlocks])
 
   const toneClass =

--- a/src/canvas/conversation/__tests__/InlineBlocks.biasSignalBudget.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.biasSignalBudget.spec.tsx
@@ -70,6 +70,25 @@ function biasCard(n: number): V5CoachingBlock {
   }
 }
 
+/**
+ * A PRODUCER-typed bias card (carries priority_rank + freshness, unlike the
+ * UI bridge's). It matches isBiasSignalCoachingBlock exactly as the bridge's
+ * does — which is precisely why the cap had to become structural.
+ */
+function producerBiasCard(n: number): V5CoachingBlock {
+  return {
+    type: 'v5_coaching',
+    block_id: `producer_bias_${n}`,
+    title: `Producer bias signal ${n}`,
+    body: `Producer-authored bias detail ${n}.`,
+    coaching_kind: 'bias_signal',
+    source: 'engine',
+    target_refs: [],
+    priority_rank: n,
+    freshness: 'fresh',
+  }
+}
+
 const fact: FactBlock = { type: 'fact', value: '42%', label: 'Lift', fact_type: 'simple' }
 const commentary: CommentaryBlock = { type: 'commentary', text: 'Some commentary.' }
 const framing: FramingBlock = { type: 'framing', goal: 'A goal', options: [] }
@@ -123,5 +142,47 @@ describe('C1 regime 2 — BLOCK-RICH turn: >=4 non-phase-3 blocks + 2 bias cards
   it('the legacy overflow toggle does not count the bias cards (4 non-phase-3 blocks = no overflow)', () => {
     render(<InlineBlocks blocks={blocks} />)
     expect(screen.queryByRole('button', { name: /show \d+ more block/i })).not.toBeInTheDocument()
+  })
+})
+
+/**
+ * /simplify item 5 — the ONE deliberate behaviour change.
+ *
+ * The C1 exemption keyed on block KIND, but the ≤2 cap it cited lived only
+ * in the UI bridge (DRAFT_BIAS_SIGNAL_CARD_CAP). The bridge deliberately
+ * stands down when CEE emits real bias coaching — and producer blocks match
+ * the same predicate — so producer bias cards were exempt from BOTH budgets
+ * and capped by NOTHING. Written RED-first: before the fix all 13 rendered
+ * uncollapsed with no affordance at all.
+ *
+ * No behaviour change on today's live path: the bridge already caps at 2, so
+ * a turn never carries more than 2 bias cards in production.
+ */
+describe('/simplify item 5 — the cap is STRUCTURAL: producer bias floods are budgeted', () => {
+  const thirteen: ConversationBlock[] = Array.from({ length: 13 }, (_, i) => producerBiasCard(i + 1))
+
+  it('13 producer bias blocks → only the first 2 are budget-exempt', () => {
+    render(<InlineBlocks blocks={thirteen} />)
+    // 2 exempt + the 3 the phase-3 pacing budget defaults to expanded.
+    expect(visibleBiasCards()).toHaveLength(5)
+  })
+
+  it('the remaining 8 fall through to the normal pacing path, behind ONE affordance', () => {
+    render(<InlineBlocks blocks={thirteen} />)
+    expect(screen.getByRole('button', { name: /show 8 more coaching and review card/i }))
+      .toBeInTheDocument()
+  })
+
+  it('revealing the affordance shows all 13 — nothing is dropped, only paced', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    render(<InlineBlocks blocks={thirteen} />)
+    await userEvent.click(screen.getByRole('button', { name: /show 8 more coaching and review card/i }))
+    expect(visibleBiasCards()).toHaveLength(13)
+  })
+
+  it('the exemption is capped, not disabled: 2 bias cards still always render', () => {
+    render(<InlineBlocks blocks={[producerBiasCard(1), producerBiasCard(2)]} />)
+    expect(visibleBiasCards()).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: /show \d+ more/i })).not.toBeInTheDocument()
   })
 })

--- a/src/canvas/conversation/__tests__/InlineBlocks.citationReveal.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.citationReveal.spec.tsx
@@ -5,8 +5,8 @@
  *
  *   C11: a citation click whose [data-citation-target] sits behind the
  *        pacing/budget collapse used to hit `if (!target) return` — a
- *        silent no-op. Now it reveals the collapsed content, retries after
- *        the commit (double rAF) and scrolls; it fails silent only when
+ *        silent no-op. Now it reveals the collapsed content, flushes the
+ *        commit synchronously and scrolls; it fails silent only when
  *        the target is STILL missing.
  *   C13: the graph-vocabulary legend used to gate on phase3Count > 0 — it
  *        rendered for a turn whose ONLY phase-3 card was hidden behind the
@@ -18,7 +18,7 @@
  *        text stays; the live-region role goes.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { InlineBlocks } from '../InlineBlocks'
 import type {
   BriefBlock,
@@ -84,15 +84,9 @@ let scrollSpy: ReturnType<typeof vi.fn>
 beforeEach(() => {
   scrollSpy = vi.fn()
   Element.prototype.scrollIntoView = scrollSpy as unknown as typeof Element.prototype.scrollIntoView
-  // Deterministic double-rAF: queue callbacks as macrotasks so they run
-  // AFTER React commits the reveal (matching real frame timing), and let
-  // waitFor flush them.
-  vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
-    (cb: FrameRequestCallback) => {
-      setTimeout(() => cb(0), 0)
-      return 0
-    },
-  )
+  // No rAF mock needed: the handler reveals via flushSync and re-queries
+  // synchronously (/simplify item 6), so every assertion below is
+  // synchronous — no waitFor, no macrotask flush.
 })
 
 afterEach(() => {
@@ -100,7 +94,7 @@ afterEach(() => {
 })
 
 describe('C11 — citation to collapsed content reveals and scrolls', () => {
-  it('a citation targeting a pacing-collapsed phase-3 card expands the collapse and scrolls to it', async () => {
+  it('a citation targeting a pacing-collapsed phase-3 card expands the collapse and scrolls to it', () => {
     // blocks[0] commentary with a citation at index 6 → blocks[5] (rc_5),
     // which sits behind the phase-3 pacing collapse (5 phase-3 cards,
     // default-expanded 3).
@@ -125,10 +119,10 @@ describe('C11 — citation to collapsed content reveals and scrolls', () => {
 
     // Revealed and scrolled — not a silent no-op.
     expect(screen.getByText('Review card 5')).toBeInTheDocument()
-    await waitFor(() => expect(scrollSpy).toHaveBeenCalled())
+    expect(scrollSpy).toHaveBeenCalled()
   })
 
-  it('a citation targeting a budget-hidden block expands "Show more" and scrolls to it', async () => {
+  it('a citation targeting a budget-hidden block expands "Show more" and scrolls to it', () => {
     // Pacing inactive (1 phase-3 card); the 5th block (index 4, citation
     // target 5) hides behind the legacy per-turn budget of 4.
     const commentary: CommentaryBlock = {
@@ -143,10 +137,10 @@ describe('C11 — citation to collapsed content reveals and scrolls', () => {
     fireEvent.click(screen.getByRole('button', { name: /citation 5/i }))
 
     expect(screen.getByText('Coaching card 1')).toBeInTheDocument()
-    await waitFor(() => expect(scrollSpy).toHaveBeenCalled())
+    expect(scrollSpy).toHaveBeenCalled()
   })
 
-  it('a citation whose target is genuinely missing stays a silent no-op (no crash, nothing revealed)', async () => {
+  it('a citation whose target is genuinely missing stays a silent no-op (no crash, nothing revealed)', () => {
     const commentary: CommentaryBlock = {
       type: 'commentary',
       text: 'Dangling citation. [9]',
@@ -154,8 +148,8 @@ describe('C11 — citation to collapsed content reveals and scrolls', () => {
     }
     render(<InlineBlocks blocks={[commentary, fact]} />)
     fireEvent.click(screen.getByRole('button', { name: /citation 9/i }))
-    // Flush any queued rAF retries before asserting the negative.
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    // The reveal + retry are synchronous, so the negative is safe to assert
+    // immediately — no macrotask flush to wait on.
     expect(scrollSpy).not.toHaveBeenCalled()
   })
 

--- a/src/canvas/conversation/__tests__/biasSignalTitles.parity.spec.ts
+++ b/src/canvas/conversation/__tests__/biasSignalTitles.parity.spec.ts
@@ -19,9 +19,10 @@
  *     findings path is case-insensitive (C8).
  */
 import { describe, it, expect, vi } from 'vitest'
+import { Anchor, EyeOff, Frame, Gauge } from 'lucide-react'
 
-import { BIAS_SIGNAL_REGISTRY, resolveBiasSignal } from '../../shared/biasSignalTitles'
-import { humaniseBiasSignalCode } from '../draftBiasSignalBlocks'
+import { BIAS_SIGNAL_REGISTRY, biasSignal, resolveBiasSignal } from '../../shared/biasSignalTitles'
+import type { KnownBiasCode } from '../../shared/biasSignalTitles'
 import {
   mapDraftBiasSignalToTrigger,
   normaliseCeeBiasFinding,
@@ -39,20 +40,13 @@ vi.mock('../../store', () => {
   }
 })
 
-/**
- * Every bias code a UI surface composes copy from via
- * resolveBiasSignal('<code>')!. Keep in step with the literal call sites:
- *   - PreAnalysisPanel.tsx pushDeterministic (narrow_framing, overconfidence)
- *   - useScienceIcons.ts / OptionNode.tsx status-quo tooltips
- *   - DecisionNode.tsx bias trigger strings
- * A code missing from the registry would make those sites throw at render —
- * this trap fails first.
- */
-const COMPOSED_TRIGGER_CODES = [
-  'narrow_framing',
-  'overconfidence',
-  'status_quo_bias',
-] as const
+// The composed-trigger allowlist that used to live here is GONE
+// (/simplify item 2). Composed call sites now go through the TOTAL accessor
+// `biasSignal(code: KnownBiasCode)`, whose parameter type is
+// `keyof typeof BIAS_SIGNAL_REGISTRY` — so renaming or removing a registry
+// key is a TYPECHECK error at every site that composes copy from it. The
+// compiler enforces what a hand-maintained list could only mirror
+// (platform trap 12: derive, don't mirror).
 
 describe('bias-signal registry — drift traps over the SOURCE (C9)', () => {
   it('every registry key is lowercase with a non-empty sentence-case title AND an icon', () => {
@@ -67,16 +61,31 @@ describe('bias-signal registry — drift traps over the SOURCE (C9)', () => {
     }
   })
 
-  it('every code the deterministic-trigger literals compose from resolves', () => {
-    for (const code of COMPOSED_TRIGGER_CODES) {
-      const entry = resolveBiasSignal(code)
-      expect(entry, `composed-trigger code ${code} must resolve`).not.toBeNull()
+  it('the total accessor agrees with the guarded wire resolver on every registry code', () => {
+    for (const code of Object.keys(BIAS_SIGNAL_REGISTRY) as KnownBiasCode[]) {
+      expect(biasSignal(code)).toEqual(resolveBiasSignal(code))
     }
   })
 
-  it('pins one composed trigger string byte-identical to the pre-registry literal (C15)', () => {
-    expect(`${resolveBiasSignal('status_quo_bias')!.title}: inaction risks often underestimated.`)
+  it('pins the composed trigger strings byte-identical to the pre-registry literals (C15)', () => {
+    expect(`${biasSignal('status_quo_bias').title}: inaction risks often underestimated.`)
       .toBe('Status quo bias: inaction risks often underestimated.')
+    expect(`${biasSignal('narrow_framing').title}: < 3 options`)
+      .toBe('Narrow framing: < 3 options')
+    expect(`${biasSignal('status_quo_bias').title}: baseline present`)
+      .toBe('Status quo bias: baseline present')
+    expect(`${biasSignal('overconfidence').title}: top factor unvalidated`)
+      .toBe('Overconfidence: top factor unvalidated')
+  })
+
+  it('pins the ICON each composed site now resolves from the registry (/simplify item 3)', () => {
+    // Both channels come from one entry, so these are the icons the
+    // status-quo science icon and the three deterministic panel triggers
+    // render — byte-identical to the pre-migration hardcoded literals.
+    expect(biasSignal('status_quo_bias').icon).toBe(EyeOff)
+    expect(biasSignal('narrow_framing').icon).toBe(Frame)
+    expect(biasSignal('overconfidence').icon).toBe(Gauge)
+    expect(biasSignal('anchoring').icon).toBe(Anchor)
   })
 
   it('CONFIRMATION_BIAS resolves ONE icon for both wire cases (the divergence is dead)', () => {
@@ -112,8 +121,8 @@ describe('bias-signal registry — every surface resolves through it', () => {
 
   it('the conversation resolver agrees with the registry, case-insensitively', () => {
     for (const [code, entry] of Object.entries(BIAS_SIGNAL_REGISTRY)) {
-      expect(humaniseBiasSignalCode(code)).toBe(entry.title)
-      expect(humaniseBiasSignalCode(code.toUpperCase())).toBe(entry.title)
+      expect(resolveBiasSignal(code)?.title).toBe(entry.title)
+      expect(resolveBiasSignal(code.toUpperCase())?.title).toBe(entry.title)
     }
   })
 

--- a/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
+++ b/src/canvas/conversation/__tests__/draftBiasSignalBlocks.spec.ts
@@ -30,7 +30,6 @@ import { describe, it, expect } from 'vitest'
 import {
   DRAFT_BIAS_SIGNAL_CARD_CAP,
   buildDraftBiasSignalBlocks,
-  humaniseBiasSignalCode,
 } from '../draftBiasSignalBlocks'
 import { BIAS_SIGNAL_REGISTRY } from '../../shared/biasSignalTitles'
 import type { ConversationBlock, V5CoachingBlock } from '../types'
@@ -222,22 +221,17 @@ describe('buildDraftBiasSignalBlocks — fail closed', () => {
   })
 })
 
-describe('humaniseBiasSignalCode — prototype-chain escapes (hostile wire codes)', () => {
+describe('bias-signal titles — prototype-chain escapes (hostile wire codes)', () => {
   // A bare object-literal index walks the prototype chain: '__proto__'
   // yields Object.prototype (a truthy object — React throws "Objects are
   // not valid as a React child", crashing the assistant-message subtree)
   // and 'constructor' yields the Object function (blank title + console
-  // error). Both must fail closed like any other unknown code. Only these
-  // two survive the toLowerCase() normalisation; 'toString' / 'valueOf' /
-  // 'hasOwnProperty' miss the camelCase prototype properties already.
-  it("'__proto__' fails closed — Object.prototype must never become a card title", () => {
-    expect(humaniseBiasSignalCode('__proto__')).toBeNull()
-  })
-
-  it("'constructor' fails closed — a Function must never become a card title", () => {
-    expect(humaniseBiasSignalCode('constructor')).toBeNull()
-  })
-
+  // error). Both must fail closed like any other unknown code.
+  //
+  // The direct resolver-level assertions that used to sit here are covered
+  // (with more cases) by biasSignalTitles.parity.spec.ts C7. What this
+  // spec uniquely owns is the INTEGRATION below: hostile codes arriving as
+  // grounded signals must produce no cards.
   it('grounded signals carrying hostile codes render no cards (case-insensitive path included)', () => {
     const blocks = build([
       { type: '__proto__', detail: 'Hostile wire code.', target: 'fac_initial_quote' },

--- a/src/canvas/conversation/draftBiasSignalBlocks.ts
+++ b/src/canvas/conversation/draftBiasSignalBlocks.ts
@@ -33,25 +33,14 @@
  */
 import type { CEEDraftCoaching } from '../../adapters/cee/types'
 import type { ConversationBlock, V5CoachingBlock } from './types'
+import { DRAFT_BIAS_SIGNAL_CARD_CAP } from './types'
+import { isBiasSignalCoachingBlock } from './phase3Pacing'
 import { resolveBiasSignal } from '../shared/biasSignalTitles'
 
-/**
- * UI-SEM-084: ratified cap — at most two bias-signal cards per draft turn
- * (display budget only; drops the third-and-later grounded signals, never
- * transforms any value).
- */
-export const DRAFT_BIAS_SIGNAL_CARD_CAP = 2
-
-/**
- * Allowlist lookup through the ONE bias registry
- * (src/canvas/shared/biasSignalTitles.ts) — the trim/lowercase/own-key
- * guard lives there, shared with every other surface. Returns null for
- * unknown / non-string codes (fail closed): unknown codes are NOT
- * sentence-cased, so a raw wire token can never leak into copy.
- */
-export function humaniseBiasSignalCode(code: unknown): string | null {
-  return resolveBiasSignal(code)?.title ?? null
-}
+// The cap's one definition lives with the other render budgets in ./types
+// (/simplify item 5) — the render layer consumes it too. Re-exported here
+// because this bridge is where it is enforced on the producing side.
+export { DRAFT_BIAS_SIGNAL_CARD_CAP }
 
 /** The minimal canvas-store surface the builder reads. */
 export interface DraftBiasSignalStoreSlice {
@@ -93,10 +82,7 @@ export function buildDraftBiasSignalBlocks(args: {
   const { isDraftTurn, store, existingBlocks = [] } = args
   if (!isDraftTurn) return []
 
-  const producerHasBiasCoaching = existingBlocks.some(
-    (b) => b.type === 'v5_coaching' && b.coaching_kind === 'bias_signal',
-  )
-  if (producerHasBiasCoaching) return []
+  if (existingBlocks.some(isBiasSignalCoachingBlock)) return []
 
   const signals = store.draftCoaching?.biasSignals
   if (!Array.isArray(signals) || signals.length === 0) return []
@@ -117,7 +103,11 @@ export function buildDraftBiasSignalBlocks(args: {
     if (!signal || typeof signal !== 'object') continue
     const s = signal as Record<string, unknown>
 
-    const title = humaniseBiasSignalCode(s.type)
+    // Allowlist lookup through the ONE bias registry — the
+    // trim/lowercase/own-key guard lives there, shared with every other
+    // surface. Unknown / non-string codes fail closed (never
+    // sentence-cased), so a raw wire token can never leak into copy.
+    const title = resolveBiasSignal(s.type)?.title ?? null
     if (!title) continue
 
     const detail = typeof s.detail === 'string' ? s.detail.trim() : ''

--- a/src/canvas/conversation/phase3Pacing.ts
+++ b/src/canvas/conversation/phase3Pacing.ts
@@ -20,6 +20,7 @@
  *     their own legacy per-turn budget, counted WITHOUT the phase-3 cards
  *     (the pacing group is the phase-3 budget).
  */
+import { DRAFT_BIAS_SIGNAL_CARD_CAP } from './types'
 import type { ConversationBlock } from './types'
 
 /** The four typed phase-3 conversation block kinds (Track C slices 1+2). */
@@ -44,6 +45,13 @@ export interface Phase3Pacing {
   collapsedIndices: ReadonlySet<number>
   /** Original index of the first collapsed card — where the affordance renders. */
   affordanceIndex: number
+  /**
+   * Indices of the bias-signal coaching cards that are exempt from BOTH
+   * visibility budgets — the first DRAFT_BIAS_SIGNAL_CARD_CAP only.
+   * Computed once here and read by InlineBlocks' legacy budget too, so the
+   * two budgets cannot disagree about which cards are exempt.
+   */
+  biasSignalExemptIndices: ReadonlySet<number>
 }
 
 export function isPhase3CardBlock(block: ConversationBlock): boolean {
@@ -51,22 +59,45 @@ export function isPhase3CardBlock(block: ConversationBlock): boolean {
 }
 
 /**
- * Review-folds C1: bias-signal coaching cards are exempt from BOTH
- * visibility budgets — they carry their own ≤2 cap
- * (buildDraftBiasSignalBlocks DRAFT_BIAS_SIGNAL_CARD_CAP), so per the
- * ratified #356 acceptance they ALWAYS render by default. They neither
- * count toward the >3 pacing trigger nor collapse (here), and InlineBlocks
- * excludes them from the legacy per-turn budget too.
+ * THE bias-signal-coaching predicate — one definition, every surface
+ * (pacing, the legacy budget, the renderer's card variant, and the draft
+ * bridge's producer-wins check) goes through it (/simplify item 1).
  */
 export function isBiasSignalCoachingBlock(block: ConversationBlock): boolean {
   return block.type === 'v5_coaching' && block.coaching_kind === 'bias_signal'
 }
 
+/**
+ * Review-folds C1: bias-signal coaching cards are exempt from BOTH
+ * visibility budgets, so per the ratified #356 acceptance they render by
+ * default. /simplify item 5 makes the ≤2 cap they cite STRUCTURAL rather
+ * than merely cited: only the FIRST DRAFT_BIAS_SIGNAL_CARD_CAP of them are
+ * exempt, and any beyond that fall through to the normal budget/pacing
+ * path.
+ *
+ * Why that matters: the cap used to live only in the UI draft bridge
+ * (buildDraftBiasSignalBlocks), which deliberately stands down when CEE
+ * emits real bias coaching. Producer blocks match the same predicate, so a
+ * producer turn carrying 12 bias signals was exempt from both budgets and
+ * capped by nothing — 12 uncollapsed cards. No behaviour change on today's
+ * live path, where the bridge already emits at most 2.
+ */
+function computeBiasSignalExemptIndices(
+  blocks: readonly ConversationBlock[],
+): ReadonlySet<number> {
+  const exempt = new Set<number>()
+  for (let i = 0; i < blocks.length && exempt.size < DRAFT_BIAS_SIGNAL_CARD_CAP; i++) {
+    if (isBiasSignalCoachingBlock(blocks[i])) exempt.add(i)
+  }
+  return exempt
+}
+
 /** Pure pacing computation over a turn's full block list. */
 export function computePhase3Pacing(blocks: readonly ConversationBlock[]): Phase3Pacing {
+  const biasSignalExemptIndices = computeBiasSignalExemptIndices(blocks)
   const phase3Indices: number[] = []
   for (let i = 0; i < blocks.length; i++) {
-    if (isPhase3CardBlock(blocks[i]) && !isBiasSignalCoachingBlock(blocks[i])) phase3Indices.push(i)
+    if (isPhase3CardBlock(blocks[i]) && !biasSignalExemptIndices.has(i)) phase3Indices.push(i)
   }
   if (phase3Indices.length <= PHASE3_DEFAULT_EXPANDED) {
     return {
@@ -75,6 +106,7 @@ export function computePhase3Pacing(blocks: readonly ConversationBlock[]): Phase
       collapsedCount: 0,
       collapsedIndices: new Set(),
       affordanceIndex: -1,
+      biasSignalExemptIndices,
     }
   }
   const collapsed = phase3Indices.slice(PHASE3_DEFAULT_EXPANDED)
@@ -84,5 +116,6 @@ export function computePhase3Pacing(blocks: readonly ConversationBlock[]): Phase
     collapsedCount: collapsed.length,
     collapsedIndices: new Set(collapsed),
     affordanceIndex: collapsed[0],
+    biasSignalExemptIndices,
   }
 }

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -631,6 +631,20 @@ export const MAX_SUGGESTED_ACTIONS = 3
 /** Max visible blocks per assistant turn before "Show more" toggle */
 export const MAX_VISIBLE_BLOCKS_PER_TURN = 4
 
+/**
+ * UI-SEM-084: ratified cap — at most two bias-signal coaching cards render
+ * budget-exempt per turn (display budget only; never transforms a value).
+ *
+ * Defined HERE, alongside the other render budgets, because it has two
+ * consumers that must not import each other: the draft bridge
+ * (draftBiasSignalBlocks, which stops emitting past the cap) and the render
+ * layer (phase3Pacing/InlineBlocks, which exempts only the first N from the
+ * visibility budgets). Before /simplify item 5 the cap lived only in the
+ * bridge, so PRODUCER bias blocks — which the bridge stands down for — were
+ * exempt from both budgets and capped by nothing.
+ */
+export const DRAFT_BIAS_SIGNAL_CARD_CAP = 2
+
 // ---------------------------------------------------------------------------
 // § 4 — System events (type-defined now, wired in follow-up PR)
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -1099,12 +1099,7 @@ export function composePhase3BridgedBlocks(
       if (adapted) {
         if (!seenTypedBlockIds.has(adapted.block_id)) {
           seenTypedBlockIds.add(adapted.block_id)
-          // adaptTypedCoachingBlock fails closed without a finite
-          // priority_rank, so the ?? arm is unreachable at runtime — it
-          // exists because the V5CoachingBlock TYPE now allows rank-less
-          // blocks (the UI-side bias bridge), using the same missing-rank
-          // convention as exercises below.
-          typed.push({ block: adapted, rank: adapted.priority_rank ?? Number.POSITIVE_INFINITY, order: order++ })
+          typed.push({ block: adapted, rank: adapted.priority_rank, order: order++ })
         }
         continue
       }

--- a/src/canvas/hooks/useScienceIcons.ts
+++ b/src/canvas/hooks/useScienceIcons.ts
@@ -9,9 +9,9 @@ import { useMemo } from 'react'
 import { useCanvasStore } from '../store'
 import { useNodeDisplayMetadata } from './useNodeDisplayMetadata'
 import {
-  FileQuestion, Sparkles, Unlink, Frame, ShieldAlert, EyeOff, Anchor, Gauge,
+  FileQuestion, Sparkles, Unlink, Frame, ShieldAlert, Anchor, Gauge,
 } from 'lucide-react'
-import { resolveBiasSignal } from '../shared/biasSignalTitles'
+import { biasSignal } from '../shared/biasSignalTitles'
 import type { ComponentType } from 'react'
 import type { NodeType } from '../domain/nodes'
 import { computeSignedMean } from '../domain/edges'
@@ -173,12 +173,15 @@ export function useScienceIcons(nodeId: string, nodeType: NodeType): ScienceIcon
       // 6. Status quo bias
       const isBaseline = (nodeData as any)?.is_baseline === true
       if (isBaseline) {
+        // BOTH channels — name AND icon — from the one registry entry, so
+        // the icon can no longer drift from the title it sits beside
+        // (review-folds C15; /simplify item 3). Rendered output is
+        // byte-identical to the old literals.
+        const statusQuo = biasSignal('status_quo_bias')
         icons.push({
           id: 'status-quo-bias',
-          icon: EyeOff,
-          // Bias NAME composed from the one registry (review-folds C15) —
-          // rendered output byte-identical to the old literal.
-          tooltip: `${resolveBiasSignal('status_quo_bias')!.title}: inaction risks often underestimated.`,
+          icon: statusQuo.icon,
+          tooltip: `${statusQuo.title}: inaction risks often underestimated.`,
           action: 'What could go wrong with doing nothing?',
           colour: 'text-warning',
           priority: 6,

--- a/src/canvas/nodes/DecisionNode.tsx
+++ b/src/canvas/nodes/DecisionNode.tsx
@@ -20,7 +20,7 @@ import { typography } from '../../styles/typography'
 import { NodeChip, NodePopover } from './shared'
 import { isGoalDefined } from '../../utils/isGoalDefined'
 import { cleanFactorLabel } from '../utils/labelUtils'
-import { resolveBiasSignal } from '../shared/biasSignalTitles'
+import { biasSignal } from '../shared/biasSignalTitles'
 
 /** Truncate text at word boundary. */
 function truncateAtWord(text: string, maxLength: number): string {
@@ -83,16 +83,16 @@ function useModelReadiness(decisionId: string): ModelReadiness {
     // literals). 'Missing risks' is a graph-signal label, not a registry
     // bias code, so it stays local.
     const biasTriggers: string[] = []
-    if (optionNodes.length < 3) biasTriggers.push(`${resolveBiasSignal('narrow_framing')!.title}: < 3 options`)
+    if (optionNodes.length < 3) biasTriggers.push(`${biasSignal('narrow_framing').title}: < 3 options`)
     if (riskNodes.length <= 1) biasTriggers.push('Missing risks: \u2264 1 risk identified')
     const hasBaseline = optionNodes.some(n => (n.data as Record<string, unknown> | undefined)?.is_baseline === true)
-    if (hasBaseline) biasTriggers.push(`${resolveBiasSignal('status_quo_bias')!.title}: baseline present`)
+    if (hasBaseline) biasTriggers.push(`${biasSignal('status_quo_bias').title}: baseline present`)
     // Overconfidence: any factor is inferred (unvalidated estimate)
     const hasInferredFactor = factorNodes.some(n => {
       const os = (n.data as Record<string, unknown> | undefined)?.observedState as Record<string, unknown> | undefined
       return os?.extractionType === 'inferred'
     })
-    if (hasInferredFactor) biasTriggers.push(`${resolveBiasSignal('overconfidence')!.title}: top factor unvalidated`)
+    if (hasInferredFactor) biasTriggers.push(`${biasSignal('overconfidence').title}: top factor unvalidated`)
 
     return {
       explicitCount,

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -5,7 +5,7 @@ import { BaseNode } from './BaseNode'
 import { NODE_REGISTRY } from '../domain/nodes'
 import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { useScienceIcons } from '../hooks/useScienceIcons'
-import { resolveBiasSignal } from '../shared/biasSignalTitles'
+import { biasSignal } from '../shared/biasSignalTitles'
 import { useCanvasStore } from '../store'
 import { focusExistingTarget } from '../utils/focusHelpers'
 import { selectDriverDisplayModel, compareByDisplayModel, extractPolicyRow } from '../../components/results/driverDisplayModel'
@@ -1211,7 +1211,7 @@ export const OptionNode = memo((props: NodeProps) => {
           <MetricPills
             biasType="status-quo"
             // Bias NAME composed from the one registry (review-folds C15).
-            biasTip={`${resolveBiasSignal('status_quo_bias')!.title}: inaction risks often underestimated.`}
+            biasTip={`${biasSignal('status_quo_bias').title}: inaction risks often underestimated.`}
             biasLinkLabel="Explore risks of inaction"
             biasLinkMessage="What are the risks of choosing to do nothing?"
           />

--- a/src/canvas/shared/biasSignalTitles.ts
+++ b/src/canvas/shared/biasSignalTitles.ts
@@ -35,7 +35,7 @@ export interface BiasSignalEntry {
   icon: LucideIcon
 }
 
-export const BIAS_SIGNAL_REGISTRY: Record<string, BiasSignalEntry> = {
+export const BIAS_SIGNAL_REGISTRY = {
   framing: { title: 'Narrow framing', icon: Frame },
   framing_bias: { title: 'Narrow framing', icon: Frame },
   narrow_framing: { title: 'Narrow framing', icon: Frame },
@@ -51,12 +51,33 @@ export const BIAS_SIGNAL_REGISTRY: Record<string, BiasSignalEntry> = {
   authority_bias: { title: 'Authority bias', icon: Anchor },
   availability_bias: { title: 'Availability bias', icon: Frame },
   sunk_cost: { title: 'Sunk cost', icon: Anchor },
+} as const satisfies Record<string, BiasSignalEntry>
+
+/**
+ * The registry's own key space, as a literal union. Composed call sites
+ * (`biasSignal('narrow_framing')`) type against THIS, so renaming or
+ * removing a registry key is a compile error at every surface that composes
+ * copy from it — the compiler replaces the hand-maintained
+ * COMPOSED_TRIGGER_CODES allowlist the parity spec used to carry
+ * (review-folds /simplify item 2; platform trap 12 — derive, don't mirror).
+ */
+export type KnownBiasCode = keyof typeof BIAS_SIGNAL_REGISTRY
+
+/**
+ * TOTAL accessor for COMPOSED copy — the code is a compile-time literal the
+ * registry provably holds, so the lookup cannot fail and needs no `!`.
+ * Wire input must go through `resolveBiasSignal` instead: only that path
+ * carries the trim/lowercase/own-key guard.
+ */
+export function biasSignal(code: KnownBiasCode): BiasSignalEntry {
+  return BIAS_SIGNAL_REGISTRY[code]
 }
 
 /**
- * THE guarded registry lookup, shared by every surface (the guard logic
- * lived in draftBiasSignalBlocks.humaniseBiasSignalCode; it now lives here
- * once — that function delegates).
+ * THE guarded registry lookup for WIRE input, shared by every surface. The
+ * guard logic used to live in the draft bridge's humaniseBiasSignalCode
+ * delegate; it lives here once now, and that delegate is gone
+ * (/simplify item 7).
  *
  * - trims + lowercases, so both wire conventions resolve;
  * - own-key guard: a bare object-literal index walks the prototype chain,
@@ -71,6 +92,6 @@ export function resolveBiasSignal(code: unknown): BiasSignalEntry | null {
   const key = code.trim().toLowerCase()
   if (!key) return null
   return Object.prototype.hasOwnProperty.call(BIAS_SIGNAL_REGISTRY, key)
-    ? BIAS_SIGNAL_REGISTRY[key]
+    ? (BIAS_SIGNAL_REGISTRY as Record<string, BiasSignalEntry>)[key]
     : null
 }

--- a/src/components/results/__tests__/AnalysisFreshnessNotice.rerun.spec.tsx
+++ b/src/components/results/__tests__/AnalysisFreshnessNotice.rerun.spec.tsx
@@ -142,3 +142,58 @@ describe('AnalysisFreshnessNotice — completion toast agrees with the strip (ac
     expect(showToast).not.toHaveBeenCalledWith('Analysis rerun completed with the current model')
   })
 })
+
+/**
+ * /simplify item 10 — the C6 whisper contract, pinned on the COUNTERPARTY.
+ *
+ * runAnnouncementForTransition encodes "a FIRST-run settle does NOT yield,
+ * because nothing else announces it". That rule was pinned only on the pure
+ * function's own side, where it passes by construction. The claim it rests
+ * on is about THIS surface: the completion toast mounts post-settle with
+ * wasRunningRef = false, so it stays silent on a first run.
+ *
+ * If this surface ever started toasting a first-run settle, the announcer's
+ * non-yield would become a DOUBLE announcement — and nothing would catch it.
+ */
+describe('C6 counterparty — the completion toast is silent on a FIRST-run settle', () => {
+  const FIRST_RUN_REPORT = { model_card: { response_hash: 'h-first' } } as never
+
+  it('mounting AFTER the settle fires no toast — the first run is this surface’s blind spot', () => {
+    act(() => {
+      useCanvasStore.setState({
+        analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match' },
+        analysisFreshnessDirty: false,
+      })
+    })
+    // The entire run happens before this surface exists — exactly the first-run
+    // case, where the dock's auto-switch fronts the Analysis tab and the notice
+    // mounts onto an already-settled store.
+    act(() => {
+      useCanvasStore.getState().resultsStart({ seed: 1 })
+    })
+    act(() => {
+      useCanvasStore.getState().resultsComplete({ report: FIRST_RUN_REPORT, hash: 'h-first' })
+    })
+
+    render(<AnalysisFreshnessNotice />)
+
+    expect(showToast).not.toHaveBeenCalled()
+  })
+
+  it('positive control: the SAME harness does toast when the notice watched the run', () => {
+    act(() => {
+      useCanvasStore.setState({
+        analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match' },
+        analysisFreshnessDirty: false,
+      })
+    })
+    render(<AnalysisFreshnessNotice />)
+    act(() => {
+      useCanvasStore.getState().resultsStart({ seed: 1 })
+    })
+    act(() => {
+      useCanvasStore.getState().resultsComplete({ report: FIRST_RUN_REPORT, hash: 'h-first' })
+    })
+    expect(showToast).toHaveBeenCalled()
+  })
+})

--- a/src/v5/phase3TypedBlocks.ts
+++ b/src/v5/phase3TypedBlocks.ts
@@ -135,8 +135,16 @@ export function adaptTypedReviewCardBlock(raw: unknown): V5ReviewCardBlock | nul
  * Adapt a verbatim raw payload to a typed v5_coaching block.
  * Returns null when the payload is not a well-formed 0.13.x coaching block
  * (fail-closed; the caller counts + suppresses).
+ *
+ * The return type pins `priority_rank` as PRESENT (/simplify item 9): the
+ * guard below fails closed without a finite rank, so callers no longer need
+ * a defensive missing-rank arm — the compiler now proves it dead. The
+ * V5CoachingBlock TYPE keeps rank optional for the UI-side bias bridge,
+ * which legitimately builds rank-less blocks.
  */
-export function adaptTypedCoachingBlock(raw: unknown): V5CoachingBlock | null {
+export function adaptTypedCoachingBlock(
+  raw: unknown,
+): (V5CoachingBlock & { priority_rank: number }) | null {
   if (!isPlainObject(raw)) return null
   if (raw.type !== 'coaching') return null
 


### PR DESCRIPTION
Quality-only cleanup from a 4-angle `/simplify` review of #363 (merged at `a85b73c2`). Branched off the current staging tip `bcc88c85`.

Behaviour-preserving throughout **except item 5**, called out below.

---

## ⚠️ The ONE behaviour change — item 5: the bias-card cap is now STRUCTURAL

The C1 budget exemption keys on block **KIND**, but the "≤2" cap it cites lived only in the UI draft bridge (`DRAFT_BIAS_SIGNAL_CARD_CAP`). `draftBiasSignalBlocks` deliberately **stands down** when CEE emits real bias coaching — and producer blocks match the same predicate — so producer bias cards were exempt from **BOTH** budgets and capped by **NOTHING**. A producer turn carrying 12 bias signals rendered 12 uncollapsed cards.

**Fix:** `computePhase3Pacing` now derives `biasSignalExemptIndices` — the **first `DRAFT_BIAS_SIGNAL_CARD_CAP`** bias-signal blocks only — and *both* budgets read that one set, so they cannot disagree about which cards are exempt. Bias cards beyond the cap fall through to the normal budget/pacing path. The cap constant moves to `conversation/types.ts` (alongside the other render budgets) because its two consumers must not import each other; the bridge re-exports it.

**No behaviour change on today's live path** — the bridge already caps at 2, so a turn never carries more than 2 bias cards in production. This only bites a producer flood that nothing bounded before.

Pinned RED-first: *"13 producer bias blocks → 2 always-visible, the rest budgeted"*. **Mutation-checked in a throwaway worktree**: reverting the cap turns 3 of the 4 new tests RED while all 5 pre-existing C1 tests stay GREEN.

---

## The rest (behaviour-preserving)

**1. ONE bias-signal predicate** (was 4 copies). `isBiasSignalCoachingBlock` (phase3Pacing) is canonical; the renderer's card-variant fork and the bridge's producer-wins check now call it. No import cycle — both modules depend only on `./types`.

**2. Registry typed as a literal union** — kills every `!` AND a hand-maintained sync list. `BIAS_SIGNAL_REGISTRY` is `as const satisfies Record<string, BiasSignalEntry>`, exporting `KnownBiasCode` and a TOTAL accessor `biasSignal(code: KnownBiasCode)`. Six `resolveBiasSignal('...')!` assertions are gone. `resolveBiasSignal(code: unknown)` is untouched for WIRE input — its trim/lowercase/own-key guard closed a real crash defect. The parity spec's `COMPOSED_TRIGGER_CODES` allowlist and drift test are **deleted**: a renamed key is now a typecheck error at every composing site (platform trap 12 — derive, don't mirror). Every other parity test kept; two new pins added.

**3. Registry migration finished.** The 4th deterministic trigger (`anchoring`) resolved its title from a literal; the **icon channel** was still hardcoded beside registry title lookups in three places. `pushDeterministic` now takes either `{ code }` — deriving *both* channels from one entry — or an explicit `{ id, title, icon }` for non-bias graph signals. `missing_risks` is a graph-signal label, NOT a bias code, and stays out of the registry via that second arm. Rendered output byte-identical for all known codes; new specs pin the composed strings **and** the resolved icons.

**4. ONE visibility predicate in InlineBlocks.** `phase3Rendered` and the render guard were De Morgan duals of the same rule; both now call `isBlockHidden(i)`. `phase3Rendered` drops its `useMemo` (≤15 blocks, already-memo'd component).

**6. Citation reveal: `flushSync` instead of double-rAF.** Click handler on React 18.3.1, so the reveal commits synchronously and the re-query + scroll happen in the same handler: 8 lines → 3. The spec loses its bespoke rAF→setTimeout macrotask mock, both `waitFor`s and the 10ms flush — every assertion is now synchronous. **Abandon condition checked: the suite emits no React warning** (no flushSync/act/lifecycle warning anywhere in the run).

**7. Dead/leftover cleanup.** `humaniseBiasSignalCode` had become a one-line delegate with a stale doc comment and one production caller in its own file — inlined, export deleted, spec imports repointed. Its two `__proto__`/`constructor` tests dropped as redundant (the parity spec covers those plus more); the grounded-signal **integration** test, which nothing else covers, is kept. Also deleted an 8-line comment describing a removed panel-local map that had come to float above an unrelated JSDoc.

**8. Announcer yield rule as one expression.** The C6 asymmetry was split across two guards in different branches; now one `yieldsToTabFurniture` expression. The `switch` on `settledStatus` is **kept** — it is a raw store string, and an object lookup would reintroduce the prototype-chain hazard fix set A closed.

**9. Compiler-enforced fail-closed contract.** `adaptTypedCoachingBlock` narrows to `(V5CoachingBlock & { priority_rank: number }) | null`, so the `?? Number.POSITIVE_INFINITY` arm and its 5-line "unreachable" comment in useConversation are now provably dead and deleted.

**10. The whisper contract, pinned on the counterparty.** C6 says a first-run settle does NOT yield *because nothing else announces it* — previously pinned only on the pure-function side, where it passes by construction. Adds one test on `AnalysisFreshnessNotice` asserting silence when it mounts post-settle, **with a positive control** in the same harness proving the assertion can see a toast when there is one.

---

## Filed, deliberately NOT attempted here

- **Shared spec harnesses/fixtures** (`renderDock`, `seedCompletedRun`, `ensureMatchMedia`, `reviewCard`/`coaching` builders, the `vi.mock('../../store')` factory) — real duplication across 5–10 files, but well outside this diff.
- **Generalise `scrollToField.ts` into a shared `scrollAndPulse`** — 4 variants repo-wide, outside diff.
- **Unscoped `document.querySelector('[data-citation-target=...]')`** — first-in-document match across turns. This is a **pre-existing correctness bug**, not cleanup scope, and wants its own fix + pin.
- A single announcement-decision owner for toast+announcer; the `settledWithoutNewReport` derived selector; attach-helper param typing.

---

## Gates

| Gate | Result |
|---|---|
| `pnpm run typecheck` (tsconfig.ci.json) | ✅ clean |
| `npx vitest run --changed origin/staging` | ✅ 1960 passed, 44 skipped, **0 failures** (127 files) |
| `pnpm run lint` (touched files) | ✅ **0 errors** (19 pre-existing warnings, none from this diff) |
| Wide `tsc -p tsconfig.app.json` multiset vs matched base | ✅ **ZERO new** (2314 vs 2314, identical multiset) |
| Item 5 mutation check | ✅ revert → 3 RED, pre-existing C1 stays GREEN |

Specs are all outside `src/v5/**`. British English throughout.

**Environment note:** the main checkout's object store is unusable — `.git/objects/pack/pack-b489b6a8….pack` is an iCloud dataless placeholder (`ls` reports 5.5 MB, `cat` returns 0 bytes), which hangs `git worktree add`/`git worktree list` and fails `git archive` with *"far too short to be a packfile"*. This branch was built in a fresh blobless clone per CLAUDE.md trap 1. **The main checkout likely needs re-cloning.**

⚠️ Draft — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
