### PR TITLE
fix(conversation,plot): citation scope + body-stall timeout — two filed review defects

### DIFF
--- a/src/adapters/plot/v2/__tests__/adapter.bodyStall.spec.ts
+++ b/src/adapters/plot/v2/__tests__/adapter.bodyStall.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * runV2 body-stall timeout — the abort timer must stay armed until the
+ * response BODY has been read, not just until the headers arrive.
+ *
+ * The adapter used to `clearTimeout(timeoutId)` immediately after `await
+ * fetch(...)` resolved — i.e. as soon as headers landed. The subsequent
+ * `await response.json()` was therefore unprotected, so a headers-then-body
+ * stall (the Netlify-edge hang class this project has hit before) left the
+ * returned promise pending FOREVER: useV2Run's catch/finally never ran,
+ * `results.status` stayed 'preparing'/'connecting', and the Compare tab and
+ * coaching panel showed a run cover indefinitely with no escape control.
+ *
+ * clearTimeout now lives in a `finally`, so the timer survives the body read
+ * and a stalled body surfaces as the same 'V2 run request timed out' error
+ * that a headers-phase timeout already produced.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { runV2 } from '../adapter'
+import type { V2AdapterConfig } from '../adapter'
+import type { V2RunRequest } from '../types'
+
+const TIMEOUT_MS = 5000
+
+const config: V2AdapterConfig = { baseUrl: 'http://plot.test', timeout: TIMEOUT_MS }
+
+const request = {
+  request_id: 'req-body-stall',
+  nodes: [],
+  edges: [],
+  options: [],
+} as unknown as V2RunRequest
+
+/**
+ * A fetch that resolves HEADERS immediately but whose body read never
+ * settles on its own — it settles only if the caller's AbortSignal fires,
+ * exactly as a real fetch behaves when the connection stalls mid-body.
+ */
+function stallingBodyFetch(status = 200) {
+  return vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal
+    const stalledBody = new Promise<never>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => {
+        const err = new Error('The operation was aborted.')
+        err.name = 'AbortError'
+        reject(err)
+      })
+    })
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'OK',
+      headers: new Headers(),
+      clone: () => ({ text: () => stalledBody }),
+      json: () => stalledBody,
+      text: () => stalledBody,
+    })
+  })
+}
+
+/** Track settlement without awaiting, so a genuine hang fails loudly instead of timing the runner out. */
+function track<T>(p: Promise<T>) {
+  const state = { settled: 'pending' as 'pending' | 'resolved' | 'rejected', error: undefined as unknown }
+  const done = p.then(
+    () => { state.settled = 'resolved' },
+    (e) => { state.settled = 'rejected'; state.error = e },
+  )
+  return { state, done }
+}
+
+let originalFetch: typeof globalThis.fetch
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+describe('runV2 — a stalled response body must not wedge the run forever', () => {
+  it('rejects with the timeout error when headers arrive but the body never settles', async () => {
+    globalThis.fetch = stallingBodyFetch(200) as unknown as typeof globalThis.fetch
+
+    const { state, done } = track(runV2(config, request))
+
+    // Nothing should have settled before the timeout elapses.
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS - 1)
+    expect(state.settled).toBe('pending')
+
+    // Once the timeout fires, the armed abort must tear the body read down.
+    // Asserted BEFORE awaiting `done` so an unprotected body read fails here
+    // deterministically instead of hanging until the runner's own timeout.
+    await vi.advanceTimersByTimeAsync(2)
+    expect(state.settled).toBe('rejected')
+    expect((state.error as Error).message).toBe('V2 run request timed out')
+    await done
+  })
+
+  it('rejects with the timeout error when a 422 error body stalls', async () => {
+    // The 422 branch reads the body too — it must be protected identically.
+    globalThis.fetch = stallingBodyFetch(422) as unknown as typeof globalThis.fetch
+
+    const { state, done } = track(runV2(config, request))
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 1)
+    expect(state.settled).toBe('rejected')
+    expect((state.error as Error).message).toBe('V2 run request timed out')
+    await done
+  })
+
+  it('a normal run still resolves and does not leave the abort timer pending', async () => {
+    const payload = { status: 'ok', results: [] }
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        clone: () => ({ text: () => Promise.resolve('') }),
+        json: () => Promise.resolve(payload),
+      }),
+    ) as unknown as typeof globalThis.fetch
+
+    const { state, done } = track(runV2(config, request))
+    await vi.advanceTimersByTimeAsync(0)
+    await done
+
+    expect(state.settled).toBe('resolved')
+    // The timer was cleared on the success path — nothing left to fire.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/adapters/plot/v2/adapter.ts
+++ b/src/adapters/plot/v2/adapter.ts
@@ -1408,7 +1408,14 @@ export async function runV2(
       signal: controller.signal,
     })
 
-    clearTimeout(timeoutId)
+    // NOTE: the abort timer is deliberately NOT cleared here. `fetch` resolves
+    // as soon as the HEADERS arrive, so clearing it at this point left every
+    // `response.json()` below unprotected: a headers-then-body stall (the
+    // Netlify-edge hang class this project has hit before) left this promise
+    // pending forever, useV2Run's catch/finally never ran, and results.status
+    // stayed 'preparing'/'connecting' with no escape control in the UI. The
+    // timer is cleared in the `finally` instead, once the body read has
+    // completed or thrown.
 
     // Handle 422 - returns V2RunError directly (not wrapped in error.v1)
     if (response.status === 422) {
@@ -1486,8 +1493,6 @@ export async function runV2(
 
     return result
   } catch (error) {
-    clearTimeout(timeoutId)
-
     const errorMessage = error instanceof Error && error.name === 'AbortError'
       ? 'V2 run request timed out'
       : error instanceof Error ? error.message : 'Unknown error'
@@ -1509,6 +1514,12 @@ export async function runV2(
     }
 
     throw error
+  } finally {
+    // Cleared here, and only here — after the body read has settled on every
+    // path (success, HTTP error, 422, abort). An abort raised mid-body still
+    // surfaces through the catch above as the same 'V2 run request timed out'
+    // error a headers-phase timeout already produced.
+    clearTimeout(timeoutId)
   }
 }
 

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -7,7 +7,8 @@
  * always stay visible — budget is enforced upstream in useConversation).
  */
 
-import { useState, useCallback, useMemo, memo } from 'react'
+import { useState, useCallback, useMemo, memo, useRef } from 'react'
+import type { RefObject } from 'react'
 import { flushSync } from 'react-dom'
 import { Lightbulb, AlertTriangle, ChevronDown, ChevronUp, ExternalLink, Wand2 } from 'lucide-react'
 import { typography } from '../../styles/typography'
@@ -193,8 +194,16 @@ export const InlineBlocks = memo(function InlineBlocks({
   }, [])
   const hasCollapsedContent = phase3Collapsed || hiddenByBudget.size > 0
 
+  // Citation targets are numbered 1-based PER TURN, so in a thread with
+  // several assistant turns on screen every turn carries its own
+  // data-citation-target="1", "2", … A document-wide lookup would resolve to
+  // the FIRST match in document order — the oldest turn's block — and scroll
+  // the user away from the turn they clicked in. The handler resolves inside
+  // this container only, so a citation lands in its own turn or nowhere.
+  const blockContainerRef = useRef<HTMLDivElement>(null)
+
   return (
-    <div className={styles.blockContainer}>
+    <div className={styles.blockContainer} ref={blockContainerRef}>
       {pacing.pacingActive && (
         // Static sr-only summary of the collapsed count. Deliberately NOT
         // a live region (C4): the toggle's accessible name already carries
@@ -258,6 +267,7 @@ export const InlineBlocks = memo(function InlineBlocks({
               onProposalConfirm={onProposalConfirm}
               assistantTextWordCount={assistantTextWordCount}
               onRevealHiddenBlocks={hasCollapsedContent ? revealHiddenBlocks : undefined}
+              blockContainerRef={blockContainerRef}
             />
           </div>
         )
@@ -296,6 +306,8 @@ interface BlockRendererProps {
   assistantTextWordCount?: number
   /** C11: reveal collapsed pacing/budget content (present only while something is collapsed). */
   onRevealHiddenBlocks?: () => void
+  /** Scope for citation-target lookups — the emitting turn's own block container. */
+  blockContainerRef: RefObject<HTMLDivElement | null>
 }
 
 function BlockRenderer({
@@ -309,6 +321,7 @@ function BlockRenderer({
   onProposalConfirm,
   assistantTextWordCount = 0,
   onRevealHiddenBlocks,
+  blockContainerRef,
 }: BlockRendererProps) {
   switch (block.type) {
     case 'commentary':
@@ -317,6 +330,7 @@ function BlockRenderer({
           block={block}
           assistantTextWordCount={assistantTextWordCount}
           onRevealHiddenBlocks={onRevealHiddenBlocks}
+          blockContainerRef={blockContainerRef}
         />
       )
 
@@ -478,18 +492,29 @@ const CommentaryBlockRenderer = memo(function CommentaryBlockRenderer({
   block,
   assistantTextWordCount = 0,
   onRevealHiddenBlocks,
+  blockContainerRef,
 }: {
   block: CommentaryBlockType
   /** Word count of the assistant_text in the same turn — used for default expand logic */
   assistantTextWordCount?: number
   /** C11: reveal collapsed pacing/budget content (present only while something is collapsed). */
   onRevealHiddenBlocks?: () => void
+  /** Scope for citation-target lookups — the emitting turn's own block container. */
+  blockContainerRef: RefObject<HTMLDivElement | null>
 }) {
   const renderingV2 = isOrchestratorRenderingV2Enabled()
 
   const handleCitationClick = useCallback((index: number) => {
-    // Scroll to the referenced block element by citation index
-    const target = document.querySelector(`[data-citation-target="${index}"]`)
+    // CitationRef.index is 1-based WITHIN THE TURN, and every rendered turn
+    // emits its own data-citation-target="1", "2", … A document-wide lookup
+    // resolves to the first match in document order — the OLDEST turn's
+    // block — so a citation clicked in turn 5 scrolled the user to turn 1.
+    // Scoped to the emitting turn's container: a citation lands in its own
+    // turn or nowhere. Fails CLOSED when the container is not mounted — a
+    // document-wide fallback here would silently reinstate the cross-turn bug.
+    const scope = blockContainerRef.current
+    if (!scope) return
+    const target = scope.querySelector(`[data-citation-target="${index}"]`)
     if (target) {
       scrollToCitationTarget(target)
       return
@@ -502,9 +527,9 @@ const CommentaryBlockRenderer = memo(function CommentaryBlockRenderer({
     // target is STILL missing (a genuinely dangling citation).
     if (!onRevealHiddenBlocks) return
     flushSync(onRevealHiddenBlocks)
-    const revealed = document.querySelector(`[data-citation-target="${index}"]`)
+    const revealed = scope.querySelector(`[data-citation-target="${index}"]`)
     if (revealed) scrollToCitationTarget(revealed)
-  }, [onRevealHiddenBlocks])
+  }, [onRevealHiddenBlocks, blockContainerRef])
 
   const toneClass =
     block.tone === 'warning'

--- a/src/canvas/conversation/__tests__/InlineBlocks.citationScope.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.citationScope.spec.tsx
@@ -1,0 +1,160 @@
+/**
+ * Citation scope — a citation click must resolve within its OWN turn.
+ *
+ * `data-citation-target` is emitted 1-based PER TURN (InlineBlocks renders
+ * `data-citation-target={i + 1}` over that turn's own block list), so in a
+ * thread with several assistant turns on screen EVERY turn carries a
+ * `data-citation-target="1"`, a `"2"`, and so on. The click handler used to
+ * resolve the target with an UNSCOPED `document.querySelector(...)`, which
+ * returns the FIRST match in document order — i.e. the OLDEST turn's block.
+ * A citation clicked in turn 5 scrolled the user to turn 1.
+ *
+ * The lookup is now scoped to the emitting InlineBlocks instance's own block
+ * container, so a citation resolves within its turn or not at all.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { InlineBlocks } from '../InlineBlocks'
+import type {
+  BriefBlock,
+  CommentaryBlock,
+  ConversationBlock,
+  FactBlock,
+  FramingBlock,
+} from '../types'
+
+vi.mock('../../store', () => {
+  const mockState = {
+    nodes: [] as Array<{ id: string }>,
+    selectNodeWithoutHistory: vi.fn(),
+    selectNodes: vi.fn(),
+    setShowInspectorPanel: vi.fn(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+  }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+function factBlock(label: string): FactBlock {
+  return { type: 'fact', value: '42%', label, fact_type: 'simple' }
+}
+
+function citing(index: number, text: string): CommentaryBlock {
+  return {
+    type: 'commentary',
+    text: `${text} [${index}]`,
+    citations: [{ index, source: `Source ${index}` }],
+  }
+}
+
+const framing: FramingBlock = { type: 'framing', goal: 'A goal', options: [] }
+const brief: BriefBlock = { type: 'brief', title: 'A brief', summary: 'Summary.' }
+
+/** Elements whose scrollIntoView was invoked, in call order. */
+let scrolled: Element[]
+
+beforeEach(() => {
+  scrolled = []
+  Element.prototype.scrollIntoView = function (this: Element) {
+    scrolled.push(this)
+  } as unknown as typeof Element.prototype.scrollIntoView
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('citation scope — the lookup is scoped to the emitting turn', () => {
+  it('a citation clicked in the SECOND turn scrolls that turn\'s block, not the first turn\'s same-index block', () => {
+    // Both turns emit a block at data-citation-target="2". Pre-fix the
+    // unscoped document query resolved turn one's.
+    const turnOne: ConversationBlock[] = [
+      citing(2, 'Turn one commentary.'),
+      factBlock('Turn one fact'),
+    ]
+    const turnTwo: ConversationBlock[] = [
+      citing(2, 'Turn two commentary.'),
+      factBlock('Turn two fact'),
+    ]
+
+    render(
+      <div>
+        <div data-testid="turn-1"><InlineBlocks blocks={turnOne} turnId="t1" /></div>
+        <div data-testid="turn-2"><InlineBlocks blocks={turnTwo} turnId="t2" /></div>
+      </div>,
+    )
+
+    // Sanity: the ambiguity this test is about genuinely exists in the DOM.
+    expect(document.querySelectorAll('[data-citation-target="2"]')).toHaveLength(2)
+
+    const turn2 = screen.getByTestId('turn-2')
+    fireEvent.click(within(turn2).getByRole('button', { name: /citation 2/i }))
+
+    expect(scrolled).toHaveLength(1)
+    expect(scrolled[0].textContent).toContain('Turn two fact')
+    expect(scrolled[0].textContent).not.toContain('Turn one fact')
+    // And the scrolled node really is inside turn two's subtree.
+    expect(turn2.contains(scrolled[0])).toBe(true)
+  })
+
+  it('a citation whose index exists only in an EARLIER turn is a silent no-op, never a cross-turn scroll', () => {
+    // Turn one has four blocks (target "4" = the brief); turn two has two, so
+    // its citation [4] is dangling WITHIN its own turn. Pre-fix the unscoped
+    // query happily found turn one's brief and scrolled there.
+    const turnOne: ConversationBlock[] = [
+      citing(2, 'Turn one commentary.'),
+      factBlock('Turn one fact'),
+      framing,
+      brief,
+    ]
+    const turnTwo: ConversationBlock[] = [
+      citing(4, 'Turn two commentary.'),
+      factBlock('Turn two fact'),
+    ]
+
+    render(
+      <div>
+        <div data-testid="turn-1"><InlineBlocks blocks={turnOne} turnId="t1" /></div>
+        <div data-testid="turn-2"><InlineBlocks blocks={turnTwo} turnId="t2" /></div>
+      </div>,
+    )
+
+    // The cross-turn target the unscoped query used to reach really is present.
+    expect(document.querySelectorAll('[data-citation-target="4"]')).toHaveLength(1)
+
+    const turn2 = screen.getByTestId('turn-2')
+    fireEvent.click(within(turn2).getByRole('button', { name: /citation 4/i }))
+
+    expect(scrolled).toHaveLength(0)
+  })
+
+  it('a within-turn citation in the FIRST turn still scrolls (scoping does not break the happy path)', () => {
+    const turnOne: ConversationBlock[] = [
+      citing(2, 'Turn one commentary.'),
+      factBlock('Turn one fact'),
+    ]
+    const turnTwo: ConversationBlock[] = [
+      citing(2, 'Turn two commentary.'),
+      factBlock('Turn two fact'),
+    ]
+
+    render(
+      <div>
+        <div data-testid="turn-1"><InlineBlocks blocks={turnOne} turnId="t1" /></div>
+        <div data-testid="turn-2"><InlineBlocks blocks={turnTwo} turnId="t2" /></div>
+      </div>,
+    )
+
+    const turn1 = screen.getByTestId('turn-1')
+    fireEvent.click(within(turn1).getByRole('button', { name: /citation 2/i }))
+
+    expect(scrolled).toHaveLength(1)
+    expect(scrolled[0].textContent).toContain('Turn one fact')
+    expect(turn1.contains(scrolled[0])).toBe(true)
+  })
+})


### PR DESCRIPTION
Two CONFIRMED correctness defects filed during a code review, kept out of the cleanup PRs because each wants its own fix + pin. Small, surgical, RED-first. Base `63961e55` (staging tip). **Draft — do not merge.**

Both mechanisms were re-confirmed at the current tip before fixing (the review descriptions were accurate; line numbers had moved under #363/#366).

---

## Bug 1 — citation clicks scroll to the WRONG turn's block (live V5 path)

**Mechanism (confirmed at tip).** `InlineBlocks` emits `data-citation-target={i + 1}` — 1-based **per turn**. In a thread with several assistant turns rendered, every turn carries its own `data-citation-target="1"`, `"2"`, … The click handler (`CommentaryBlockRenderer.handleCitationClick`, `InlineBlocks.tsx`) resolved the target with an **unscoped** `document.querySelector(...)`, which returns the first match in document order — the **oldest** turn's block. A citation clicked in turn 5 scrolled the user to turn 1. The C11 reveal-then-retry query (post-#366, after `flushSync`) had the same unscoped bug.

**Repro (pin `InlineBlocks.citationScope.spec.tsx`).** Two `InlineBlocks` turns in one tree, each with ≥2 blocks both emitting `data-citation-target="2"`; click the citation in the **second** turn; assert the scrolled element is turn two's block. RED before the fix: *"expected '42%Turn one fact' to contain 'Turn two fact'"*. A second case proves a within-turn-dangling citation no longer cross-scrolls to an earlier turn (expected 0 scrolls, got 1 pre-fix); a third guards the first-turn happy path against over-scoping.

**Fix.** `InlineBlocks` holds a `useRef` on the block container it renders into and threads it (required prop) through `BlockRenderer` → `CommentaryBlockRenderer`; both the initial lookup and the C11 reveal-retry query that container instead of the document. The prop is **required** and the handler **fails closed** (returns) when the container is unmounted — an optional `?? document` fallback would silently reinstate the cross-turn bug the first time a future call site forgot to pass it. Both components are module-local with one call site each, so requiring it costs nothing. Reveal-then-retry and the fail-silent dangling-citation path are unchanged.

## Bug 2 — a stalled response body wedges a run forever (V2 fallback path)

**Mechanism (confirmed at tip).** `runV2` (`src/adapters/plot/v2/adapter.ts`) did `const response = await fetch(...)` then `clearTimeout(timeoutId)` immediately — but `fetch` resolves as soon as **headers** arrive, so the three `await response.json()` reads that follow (success, non-ok error, and the 422 branch) ran with **no timeout protecting them**. A headers-then-body stall (the Netlify-edge hang class this project has hit) left the promise pending forever: `useV2Run`'s catch/finally never ran, `results.status` stayed `'preparing'`/`'connecting'`, and the Compare tab and coaching panel showed a run cover/skeleton indefinitely with no escape control.

**Repro (pin `adapter.bodyStall.spec.ts`).** A fetch mock that resolves headers but returns a body promise that only settles on abort; fake timers. RED before the fix: after the full timeout elapses the run is still `'pending'` (*"expected 'pending' to be 'rejected'"*) — it never settles. Covers both the 200 body-read and the 422 error-body read. A third case guards the normal-response path and asserts no timer is left pending.

**Fix.** `clearTimeout(timeoutId)` moved into a `finally` that runs after the body read settles on **every** path; the redundant clear at the top of the `catch` is removed. An abort raised mid-body rejects the body read with an `AbortError`, which the existing `catch` already maps to the same `'V2 run request timed out'` error the callers handle today — no new error shape.

**Sibling audit.** `runV2` is the only `fetch` in `v2/adapter.ts`. `v1/http.ts` already uses the correct `finally` pattern (the reference this change matches). `v1/health.ts` clears after headers too but issues a HEAD and reads no body — **not affected**. The same defect class DOES exist in three other adapters, left untouched as separate filings: `src/adapters/plot/v1/limits.ts:97`, `src/adapters/isl/client.ts:110`, `src/adapters/cee/client.ts:559`.

---

## Mutation check (throwaway worktree, positive control first)

Positive control: unmutated tree, both pins GREEN (6/6). Then per fix, in a throwaway worktree that was removed after:

- **Bug 1** — revert scope to `document`-wide → citation-scope pin RED (2 failed / 1 passed).
- **Bug 2** — move `clearTimeout` back to post-headers, drop the `finally` → body-stall pin RED (2 failed / 1 passed).

Each RED commit was also confirmed to compile (the RED spec typechecks) so the pins stand as checkout-and-verify artefacts.

## Gates (fresh blobless clone, real `node_modules`, base `63961e55`)

- `pnpm run typecheck` — clean.
- `npx vitest run --changed origin/staging` — **2058 passed**, 44 skipped (147 files).
- `pnpm run lint` — **0 errors** (1100 pre-existing warnings; none on lines this PR touched).
- Wide `tsc -p tsconfig.app.json --noEmit`, multiset-compared against a matched `63961e55` base checkout with its own real `node_modules` (never symlinked) — **0 new, 0 removed** (2320 = 2320). This gate caught a wrong import (`V2AdapterConfig` from `../types` instead of `../adapter`) that the narrow `typecheck` config missed; fixed before push.

## Scope discipline

No refactor of the visibility model, no `scrollAndPulse` generalisation, no spec-harness extraction (separately filed). Both new specs live outside `src/v5/**`. British English; UI-passthrough doctrine preserved (no semantic transforms added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
