### PR TITLE
fix(adapters): body-stall timeout — three sibling sites (limits, isl, cee)

### DIFF
--- a/src/adapters/cee/__tests__/client.bodyStall.spec.ts
+++ b/src/adapters/cee/__tests__/client.bodyStall.spec.ts
@@ -137,8 +137,14 @@ describe('CEEClient — a stalled response body must not wedge the request forev
     await done
   })
 
-  it('rejects with CEEError 408 when an HTTP-error body stalls', async () => {
+  it('settles rather than hanging when an HTTP-error body stalls', async () => {
     // The !ok branch reads the body too — it must be protected identically.
+    // Its error semantics differ from the success branch and are preserved
+    // as-is: `response.json().catch(() => ({}))` deliberately tolerates an
+    // unreadable error body, so the mid-body AbortError is swallowed there and
+    // the client reports the REAL HTTP status rather than 408. That is correct
+    // — the server did return 500; only its explanatory body was unreadable.
+    // What this pin asserts is the defect being fixed: it SETTLES.
     globalThis.fetch = stallingBodyFetch(500) as unknown as typeof globalThis.fetch
 
     const client = new CEEClient()
@@ -147,8 +153,8 @@ describe('CEEClient — a stalled response body must not wedge the request forev
     await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 1)
     expect(state.settled).toBe('rejected')
     expect(state.error).toBeInstanceOf(CEEError)
-    expect((state.error as CEEError).status).toBe(408)
-    expect((state.error as CEEError).message).toBe('Request timeout')
+    expect((state.error as CEEError).status).toBe(500)
+    expect((state.error as CEEError).message).toBe('Request failed: 500')
     await done
   })
 

--- a/src/adapters/cee/__tests__/client.bodyStall.spec.ts
+++ b/src/adapters/cee/__tests__/client.bodyStall.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * CEEClient body-stall timeout — the abort timer must stay armed until the
+ * response BODY has been read, not just until the headers arrive.
+ *
+ * Sibling of the runV2 defect fixed in #367. `await fetch(...)` resolves as
+ * soon as the HEADERS land, but fetchWithBase cleared the abort timer at
+ * exactly that point, leaving both body reads below unprotected:
+ *   - `await response.json().catch(...)` on the !ok branch, and
+ *   - `await response.json()` on the success branch.
+ *
+ * A headers-then-body stall (the Netlify-edge hang class this project has hit
+ * before) left the returned promise pending FOREVER. Every draft/coaching
+ * surface awaits this client, so the canvas showed a pending state with no
+ * escape control — the exact failure the F-67 headers-phase timeout was added
+ * to prevent, reachable one phase later.
+ *
+ * Error semantics preserved: a timeout surfaces as
+ * `CEEError('Request timeout', 408)` with the request's correlationId — the
+ * exact shape the existing F-67 spec (client.timeout.spec.ts) already pins for
+ * a headers-phase timeout.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CEEClient, CEEError } from '../client'
+
+// Default CEE timeout (DEFAULT_CEE_TIMEOUT); /bias-check is not in ENDPOINT_TIMEOUTS.
+const TIMEOUT_MS = 150_000
+
+// Avoid crypto.subtle requirement in the test env; mirrors client.timeout.spec.ts.
+vi.mock('../../../lib/observability-headers', () => ({
+  withObservabilityHeaders: vi.fn(async (_url: string, _method: string, _body: unknown, headers: Record<string, string>) => ({
+    headers,
+    startTime: Date.now(),
+  })),
+  recordBffResponse: vi.fn(),
+  recordBffError: vi.fn(),
+  recordBffResponsePayload: vi.fn(),
+}))
+
+vi.mock('../../../lib/gate-state', () => ({
+  useGateStore: { getState: () => ({ setGate: vi.fn() }) },
+}))
+
+vi.mock('../../../lib/api-schemas', () => ({
+  CEEDraftResponseSchema: {},
+  warnOnInvalidApiResponse: vi.fn(),
+}))
+
+// Passthrough: this spec pins fetchWithBase's timer, not the retry policy.
+vi.mock('../../../lib/fetchWithRetry', () => ({
+  withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}))
+
+/**
+ * A fetch that resolves HEADERS immediately but whose body read never settles
+ * on its own — it settles only if the caller's AbortSignal fires, exactly as a
+ * real fetch behaves when the connection stalls mid-body.
+ */
+function stallingBodyFetch(status = 200) {
+  return vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal
+    const stalledBody = new Promise<never>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => {
+        const err = new Error('The operation was aborted.')
+        err.name = 'AbortError'
+        reject(err)
+      })
+    })
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: () => stalledBody,
+      text: () => stalledBody,
+    })
+  })
+}
+
+/** Track settlement without awaiting, so a genuine hang fails loudly instead of timing the runner out. */
+function track<T>(p: Promise<T>) {
+  const state = {
+    settled: 'pending' as 'pending' | 'resolved' | 'rejected',
+    value: undefined as unknown,
+    error: undefined as unknown,
+  }
+  const done = p.then(
+    (v) => { state.settled = 'resolved'; state.value = v },
+    (e) => { state.settled = 'rejected'; state.error = e },
+  )
+  return { state, done }
+}
+
+const graph = { nodes: [{ id: 'a', label: 'A', type: 'factor' }], edges: [] }
+
+let originalFetch: typeof globalThis.fetch
+const originalListeners: ((...args: never[]) => void)[] = []
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  vi.useFakeTimers()
+  // Suppress unhandled-rejection noise from the abort listener firing after the
+  // test body completes; mirrors the existing F-67 timeout spec.
+  originalListeners.push(...(process.listeners('unhandledRejection') as never[]))
+  process.removeAllListeners('unhandledRejection')
+  process.on('unhandledRejection', () => {})
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+  process.removeAllListeners('unhandledRejection')
+  originalListeners.forEach((l) => process.on('unhandledRejection', l as never))
+  originalListeners.length = 0
+})
+
+describe('CEEClient — a stalled response body must not wedge the request forever', () => {
+  it('rejects with CEEError 408 when headers arrive but the body never settles', async () => {
+    globalThis.fetch = stallingBodyFetch(200) as unknown as typeof globalThis.fetch
+
+    const client = new CEEClient()
+    const { state, done } = track(client.biasCheck(graph))
+
+    // Nothing should have settled before the timeout elapses.
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS - 1)
+    expect(state.settled).toBe('pending')
+
+    // Once the timeout fires, the armed abort must tear the body read down and
+    // the existing catch must map it to the client's typed timeout error.
+    // Asserted BEFORE awaiting `done` so an unprotected body read fails here
+    // deterministically instead of hanging until the runner's own timeout.
+    await vi.advanceTimersByTimeAsync(2)
+    expect(state.settled).toBe('rejected')
+    expect(state.error).toBeInstanceOf(CEEError)
+    expect((state.error as CEEError).status).toBe(408)
+    expect((state.error as CEEError).message).toBe('Request timeout')
+    await done
+  })
+
+  it('rejects with CEEError 408 when an HTTP-error body stalls', async () => {
+    // The !ok branch reads the body too — it must be protected identically.
+    globalThis.fetch = stallingBodyFetch(500) as unknown as typeof globalThis.fetch
+
+    const client = new CEEClient()
+    const { state, done } = track(client.biasCheck(graph))
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 1)
+    expect(state.settled).toBe('rejected')
+    expect(state.error).toBeInstanceOf(CEEError)
+    expect((state.error as CEEError).status).toBe(408)
+    expect((state.error as CEEError).message).toBe('Request timeout')
+    await done
+  })
+
+  it('a normal request still resolves and does not leave the abort timer pending', async () => {
+    const payload = { biases: [] }
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        json: () => Promise.resolve(payload),
+      }),
+    ) as unknown as typeof globalThis.fetch
+
+    const client = new CEEClient()
+    const { state, done } = track(client.biasCheck(graph))
+    await vi.advanceTimersByTimeAsync(0)
+    await done
+
+    expect(state.settled).toBe('resolved')
+    expect(state.value).toEqual(payload)
+    // The timer was cleared on the success path — nothing left to fire.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/adapters/cee/client.ts
+++ b/src/adapters/cee/client.ts
@@ -556,9 +556,15 @@ export class CEEClient {
         headers,
       })
 
-      clearTimeout(timeoutId)
-
-      // Record response for observability
+      // NOTE: the abort timer is deliberately NOT cleared here. `fetch` resolves
+      // as soon as the HEADERS arrive, so clearing it at this point left both
+      // `response.json()` reads below unprotected: a headers-then-body stall
+      // (the Netlify-edge hang class this project has hit before) left this
+      // promise pending forever, so the draft and coaching surfaces awaiting
+      // this client sat in a pending state with no escape control — the exact
+      // failure the F-67 headers-phase timeout was added to prevent, reachable
+      // one phase later. The timer is cleared in the `finally` instead, once the
+      // body read has completed or thrown. Mirrors the runV2 fix in #367.
       recordBffResponse(correlationId, url, response, startTime)
 
       if (!response.ok) {
@@ -585,8 +591,6 @@ export class CEEClient {
       recordBffResponsePayload(correlationId, response, body, startTime)
       return body
     } catch (error) {
-      clearTimeout(timeoutId)
-
       // Record error for observability
       recordBffError(correlationId, url, startTime, error)
 
@@ -594,6 +598,13 @@ export class CEEClient {
         throw new CEEError('Request timeout', 408, undefined, correlationId)
       }
       throw error
+    } finally {
+      // Cleared here, and only here — after the body read has settled on every
+      // path (success, HTTP error, abort). An abort raised mid-body rejects the
+      // body read with an AbortError, which the catch above maps to the same
+      // CEEError('Request timeout', 408) a headers-phase timeout already
+      // produced — no new error shape.
+      clearTimeout(timeoutId)
     }
   }
 

--- a/src/adapters/isl/__tests__/client.bodyStall.spec.ts
+++ b/src/adapters/isl/__tests__/client.bodyStall.spec.ts
@@ -129,8 +129,14 @@ describe('ISLClient — a stalled response body must not wedge the request forev
     await done
   })
 
-  it('rejects with ISLError 408 when an HTTP-error body stalls', async () => {
+  it('settles rather than hanging when an HTTP-error body stalls', async () => {
     // The !ok branch reads the body too — it must be protected identically.
+    // Its error semantics differ from the success branch and are preserved
+    // as-is: `response.json().catch(() => ({}))` deliberately tolerates an
+    // unreadable error body, so the mid-body AbortError is swallowed there and
+    // the client reports the REAL HTTP status rather than 408. That is correct
+    // — the server did return 500; only its explanatory body was unreadable.
+    // What this pin asserts is the defect being fixed: it SETTLES.
     globalThis.fetch = stallingBodyFetch(500) as unknown as typeof globalThis.fetch
 
     const client = new ISLClient({ timeout: TIMEOUT_MS })
@@ -139,8 +145,8 @@ describe('ISLClient — a stalled response body must not wedge the request forev
     await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 1)
     expect(state.settled).toBe('rejected')
     expect(state.error).toBeInstanceOf(ISLError)
-    expect((state.error as ISLError).status).toBe(408)
-    expect((state.error as ISLError).message).toBe('Request timeout')
+    expect((state.error as ISLError).status).toBe(500)
+    expect((state.error as ISLError).message).toBe('Request failed: 500')
     await done
   })
 

--- a/src/adapters/isl/__tests__/client.bodyStall.spec.ts
+++ b/src/adapters/isl/__tests__/client.bodyStall.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * ISLClient body-stall timeout — the abort timer must stay armed until the
+ * response BODY has been read, not just until the headers arrive.
+ *
+ * Sibling of the runV2 defect fixed in #367. `await fetch(...)` resolves as
+ * soon as the HEADERS land, but fetchOnce cleared the abort timer at exactly
+ * that point, leaving the body reads below unprotected:
+ *   - `await response.json().catch(...)` on the !ok branch, and
+ *   - `return response.json()` on the success branch.
+ *
+ * The success branch is the worse of the two: it returned the body promise
+ * WITHOUT awaiting it, so the try/catch had already exited by the time the body
+ * settled. A headers-then-body stall therefore left the returned promise
+ * pending FOREVER, and even a body-phase abort could not be mapped to the
+ * client's typed error because nothing was watching it.
+ *
+ * Error semantics preserved: a timeout surfaces as
+ * `ISLError('Request timeout', 408)` with the request's correlationId — the
+ * exact shape a headers-phase timeout already produces.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ISLClient, ISLError } from '../client'
+
+const TIMEOUT_MS = 5000
+
+// Avoid crypto.subtle requirement in the test env; mirrors the CEE timeout spec.
+vi.mock('../../../lib/observability-headers', () => ({
+  withObservabilityHeaders: vi.fn(async (_url: string, _method: string, _body: unknown, headers: Record<string, string>) => ({
+    headers,
+    startTime: Date.now(),
+  })),
+  recordBffResponse: vi.fn(),
+  recordBffError: vi.fn(),
+}))
+
+vi.mock('../../../lib/gate-state', () => ({
+  useGateStore: { getState: () => ({ setGate: vi.fn() }) },
+}))
+
+// Passthrough: this spec pins fetchOnce's timer, not the retry policy.
+vi.mock('../../../lib/fetchWithRetry', () => ({
+  withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}))
+
+/**
+ * A fetch that resolves HEADERS immediately but whose body read never settles
+ * on its own — it settles only if the caller's AbortSignal fires, exactly as a
+ * real fetch behaves when the connection stalls mid-body.
+ */
+function stallingBodyFetch(status = 200) {
+  return vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal
+    const stalledBody = new Promise<never>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => {
+        const err = new Error('The operation was aborted.')
+        err.name = 'AbortError'
+        reject(err)
+      })
+    })
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: () => stalledBody,
+      text: () => stalledBody,
+    })
+  })
+}
+
+/** Track settlement without awaiting, so a genuine hang fails loudly instead of timing the runner out. */
+function track<T>(p: Promise<T>) {
+  const state = {
+    settled: 'pending' as 'pending' | 'resolved' | 'rejected',
+    value: undefined as unknown,
+    error: undefined as unknown,
+  }
+  const done = p.then(
+    (v) => { state.settled = 'resolved'; state.value = v },
+    (e) => { state.settled = 'rejected'; state.error = e },
+  )
+  return { state, done }
+}
+
+const request = { nodes: [], edges: [] } as never
+
+let originalFetch: typeof globalThis.fetch
+const originalListeners: ((...args: never[]) => void)[] = []
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  vi.useFakeTimers()
+  // Suppress unhandled-rejection noise from the abort listener firing after the
+  // test body completes; mirrors the existing CEE timeout spec.
+  originalListeners.push(...(process.listeners('unhandledRejection') as never[]))
+  process.removeAllListeners('unhandledRejection')
+  process.on('unhandledRejection', () => {})
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+  process.removeAllListeners('unhandledRejection')
+  originalListeners.forEach((l) => process.on('unhandledRejection', l as never))
+  originalListeners.length = 0
+})
+
+describe('ISLClient — a stalled response body must not wedge the request forever', () => {
+  it('rejects with ISLError 408 when headers arrive but the body never settles', async () => {
+    globalThis.fetch = stallingBodyFetch(200) as unknown as typeof globalThis.fetch
+
+    const client = new ISLClient({ timeout: TIMEOUT_MS })
+    const { state, done } = track(client.validate(request))
+
+    // Nothing should have settled before the timeout elapses.
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS - 1)
+    expect(state.settled).toBe('pending')
+
+    // Once the timeout fires, the armed abort must tear the body read down and
+    // the existing catch must map it to the client's typed timeout error.
+    // Asserted BEFORE awaiting `done` so an unprotected body read fails here
+    // deterministically instead of hanging until the runner's own timeout.
+    await vi.advanceTimersByTimeAsync(2)
+    expect(state.settled).toBe('rejected')
+    expect(state.error).toBeInstanceOf(ISLError)
+    expect((state.error as ISLError).status).toBe(408)
+    expect((state.error as ISLError).message).toBe('Request timeout')
+    await done
+  })
+
+  it('rejects with ISLError 408 when an HTTP-error body stalls', async () => {
+    // The !ok branch reads the body too — it must be protected identically.
+    globalThis.fetch = stallingBodyFetch(500) as unknown as typeof globalThis.fetch
+
+    const client = new ISLClient({ timeout: TIMEOUT_MS })
+    const { state, done } = track(client.validate(request))
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 1)
+    expect(state.settled).toBe('rejected')
+    expect(state.error).toBeInstanceOf(ISLError)
+    expect((state.error as ISLError).status).toBe(408)
+    expect((state.error as ISLError).message).toBe('Request timeout')
+    await done
+  })
+
+  it('a normal request still resolves and does not leave the abort timer pending', async () => {
+    const payload = { valid: true, suggestions: [] }
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        json: () => Promise.resolve(payload),
+      }),
+    ) as unknown as typeof globalThis.fetch
+
+    const client = new ISLClient({ timeout: TIMEOUT_MS })
+    const { state, done } = track(client.validate(request))
+    await vi.advanceTimersByTimeAsync(0)
+    await done
+
+    expect(state.settled).toBe('resolved')
+    expect(state.value).toEqual(payload)
+    // The timer was cleared on the success path — nothing left to fire.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/adapters/isl/client.ts
+++ b/src/adapters/isl/client.ts
@@ -107,9 +107,13 @@ export class ISLClient {
         headers,
       })
 
-      clearTimeout(timeoutId)
-
-      // Record response for observability
+      // NOTE: the abort timer is deliberately NOT cleared here. `fetch` resolves
+      // as soon as the HEADERS arrive, so clearing it at this point left both
+      // `response.json()` reads below unprotected: a headers-then-body stall
+      // (the Netlify-edge hang class this project has hit before) left this
+      // promise pending forever, so callers never reached their catch/finally.
+      // The timer is cleared in the `finally` instead, once the body read has
+      // completed or thrown. Mirrors the runV2 fix in #367.
       recordBffResponse(correlationId, url, response, startTime)
 
       if (!response.ok) {
@@ -122,10 +126,12 @@ export class ISLClient {
         )
       }
 
-      return response.json()
+      // `await`, not a bare `return` of the promise: without it the try block
+      // exits before the body has been read, so the body read would escape both
+      // the catch (no AbortError → ISLError mapping, no recordBffError) and the
+      // finally's timer (cleared while the read was still in flight).
+      return await response.json()
     } catch (error) {
-      clearTimeout(timeoutId)
-
       // Record error for observability
       recordBffError(correlationId, url, startTime, error)
 
@@ -133,6 +139,13 @@ export class ISLClient {
         throw new ISLError('Request timeout', 408, undefined, correlationId)
       }
       throw error
+    } finally {
+      // Cleared here, and only here — after the body read has settled on every
+      // path (success, HTTP error, abort). An abort raised mid-body rejects the
+      // body read with an AbortError, which the catch above maps to the same
+      // ISLError('Request timeout', 408) a headers-phase timeout already
+      // produced — no new error shape.
+      clearTimeout(timeoutId)
     }
   }
 

--- a/src/adapters/plot/v1/__tests__/limits.bodyStall.spec.ts
+++ b/src/adapters/plot/v1/__tests__/limits.bodyStall.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * fetchLimits body-stall timeout — the abort timer must stay armed until the
+ * response BODY has been read, not just until the headers arrive.
+ *
+ * Sibling of the runV2 defect fixed in #367. `await fetch(...)` resolves as
+ * soon as the HEADERS land, but fetchLimits cleared the abort timer at exactly
+ * that point, leaving the `await response.json()` below unprotected. A
+ * headers-then-body stall (the Netlify-edge hang class this project has hit
+ * before) left the returned promise pending FOREVER — and because every caller
+ * awaits fetchLimits before it can size the graph-capacity guard, that wedges
+ * the caller with no escape.
+ *
+ * Error semantics preserved: fetchLimits NEVER throws. Its documented contract
+ * is "falls back to defaults if fetch fails", so a stalled body must RESOLVE to
+ * the same defaults object a headers-phase timeout already produces — it must
+ * not start rejecting.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchLimits, clearLimitsCache } from '../limits'
+
+const TIMEOUT_MS = 5000
+
+/** The defaults fetchLimits falls back to — its existing timeout semantics. */
+const FALLBACK = {
+  schema: 'limits.v1',
+  max_nodes: 50,
+  max_edges: 100,
+  max_body_kb: 96,
+  rate_limit_rpm: 60,
+  flags: { scm_lite: 1 },
+}
+
+/**
+ * A fetch that resolves HEADERS immediately but whose body read never settles
+ * on its own — it settles only if the caller's AbortSignal fires, exactly as a
+ * real fetch behaves when the connection stalls mid-body.
+ */
+function stallingBodyFetch(status = 200) {
+  return vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal
+    const stalledBody = new Promise<never>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => {
+        const err = new Error('The operation was aborted.')
+        err.name = 'AbortError'
+        reject(err)
+      })
+    })
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: () => stalledBody,
+      text: () => stalledBody,
+    })
+  })
+}
+
+/** Track settlement without awaiting, so a genuine hang fails loudly instead of timing the runner out. */
+function track<T>(p: Promise<T>) {
+  const state = {
+    settled: 'pending' as 'pending' | 'resolved' | 'rejected',
+    value: undefined as unknown,
+    error: undefined as unknown,
+  }
+  const done = p.then(
+    (v) => { state.settled = 'resolved'; state.value = v },
+    (e) => { state.settled = 'rejected'; state.error = e },
+  )
+  return { state, done }
+}
+
+let originalFetch: typeof globalThis.fetch
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  clearLimitsCache()
+  sessionStorage.clear()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+describe('fetchLimits — a stalled response body must not wedge the caller forever', () => {
+  it('falls back to defaults when headers arrive but the body never settles', async () => {
+    globalThis.fetch = stallingBodyFetch(200) as unknown as typeof globalThis.fetch
+
+    const { state, done } = track(fetchLimits())
+
+    // Nothing should have settled before the timeout elapses.
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS - 1)
+    expect(state.settled).toBe('pending')
+
+    // Once the timeout fires, the armed abort must tear the body read down and
+    // the existing catch must return the documented defaults.
+    // Asserted BEFORE awaiting `done` so an unprotected body read fails here
+    // deterministically instead of hanging until the runner's own timeout.
+    await vi.advanceTimersByTimeAsync(2)
+    expect(state.settled).toBe('resolved')
+    expect(state.value).toEqual(FALLBACK)
+    await done
+  })
+
+  it('does not cache the fallback produced by a stalled body', async () => {
+    globalThis.fetch = stallingBodyFetch(200) as unknown as typeof globalThis.fetch
+
+    const { done } = track(fetchLimits())
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 1)
+    await done
+
+    // A timed-out run must not poison the 1-hour cache with defaults.
+    expect(sessionStorage.getItem('plot_limits_cache')).toBeNull()
+  })
+
+  it('a normal fetch still resolves and does not leave the abort timer pending', async () => {
+    const payload = {
+      schema: 'limits.v1',
+      max_nodes: 50,
+      max_edges: 200,
+      max_body_kb: 96,
+      rate_limit_rpm: 60,
+    }
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        json: () => Promise.resolve(payload),
+      }),
+    ) as unknown as typeof globalThis.fetch
+
+    const { state, done } = track(fetchLimits())
+    await vi.advanceTimersByTimeAsync(0)
+    await done
+
+    expect(state.settled).toBe('resolved')
+    expect(state.value).toEqual(payload)
+    // The timer was cleared on the success path — nothing left to fire.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/adapters/plot/v1/limits.ts
+++ b/src/adapters/plot/v1/limits.ts
@@ -94,8 +94,13 @@ export async function fetchLimits(): Promise<V1LimitsResponse> {
       signal: controller.signal,
     })
 
-    clearTimeout(timeoutId)
-
+    // NOTE: the abort timer is deliberately NOT cleared here. `fetch` resolves
+    // as soon as the HEADERS arrive, so clearing it at this point left the
+    // `response.json()` below unprotected: a headers-then-body stall (the
+    // Netlify-edge hang class this project has hit before) left this promise
+    // pending forever, so every caller awaiting the engine limits hung with no
+    // escape. The timer is cleared in the `finally` instead, once the body read
+    // has completed or thrown. Mirrors the runV2 fix in #367.
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
     }
@@ -119,8 +124,6 @@ export async function fetchLimits(): Promise<V1LimitsResponse> {
 
     return data
   } catch (err) {
-    clearTimeout(timeoutId)
-
     // Return defaults if fetch fails
     const fallback: V1LimitsResponse = {
       schema: 'limits.v1',
@@ -136,6 +139,13 @@ export async function fetchLimits(): Promise<V1LimitsResponse> {
     }
 
     return fallback
+  } finally {
+    // Cleared here, and only here — after the body read has settled on every
+    // path (success, HTTP error, abort). An abort raised mid-body rejects the
+    // body read with an AbortError, which the existing catch already turns into
+    // the same defaults a headers-phase timeout already produced — no new error
+    // shape, and fetchLimits still never throws.
+    clearTimeout(timeoutId)
   }
 }
 


### PR DESCRIPTION
Replicates the canonical `runV2` fix from #367 across the three sibling sites that PR explicitly filed and left untouched. Mechanical, RED-first, one commit per adapter.

## The pattern

```ts
const response = await fetch(url, { signal: controller.signal, ... })
clearTimeout(timeoutId)      // ← cleared once HEADERS arrive
... await response.json()    // ← body read now UNPROTECTED
```

`fetch` resolves as soon as the response **headers** land. Clearing the abort timer there leaves every subsequent `response.json()` with no timeout: a headers-then-body stall — the Netlify-edge hang class this project has already hit — leaves the returned promise **pending forever**, with no timer left to abort it and no catch/finally for the caller to recover through.

The fix is the same in all three: `clearTimeout` moves into a `finally` that runs after the body read has completed or thrown, and the now-redundant catch-side clear is removed. `src/adapters/plot/v1/http.ts` (9 sites) already does exactly this and is the reference.

## The three sites

| Site | Preserved error semantics |
|---|---|
| `src/adapters/plot/v1/limits.ts` (was :97) | **Never throws.** Its documented contract is "falls back to defaults if fetch fails", so a stalled body must *resolve* to the same defaults a headers-phase timeout already produced. Also pinned: a timed-out run must not poison the 1-hour sessionStorage cache. |
| `src/adapters/isl/client.ts` (was :110) | `ISLError('Request timeout', 408)` with the request's correlationId. |
| `src/adapters/cee/client.ts` (was :559) | `CEEError('Request timeout', 408)` with the request's correlationId — the shape `client.timeout.spec.ts` (F-67) already pins for a headers-phase timeout. |

Each adapter keeps its own convention; this lane does **not** unify them.

**Controllers verified per-invocation locals** at all three sites (`limits.ts:88`, `isl/client.ts:74`, `cee/client.ts:519`) — no controller is shared across calls, so there is no cross-request abort risk from keeping the timer armed longer.

### ISL needed one extra change

`return response.json()` returned the body promise **without awaiting it**, so the try block had already exited by the time the body settled. A `finally` alone would have been **inert** there — it would clear the timer while the read was still in flight — and a body-phase abort could never reach the catch to be mapped to `ISLError`. Changed to `return await response.json()`.

Side effect, disclosed: the added `await` also routes non-abort body errors (e.g. malformed JSON) through the catch, so they are now passed to `recordBffError`. The error object thrown is unchanged; only the observability record is new.

### One assertion I had to correct

My first RED spec predicted `408` on the HTTP-error branch of ISL and CEE. That was wrong, and the fix exposed it: both `!ok` branches read the body via `response.json().catch(() => ({}))`, which **deliberately tolerates an unreadable error body** and therefore swallows the mid-body `AbortError`. A stalled *error* body correctly reports the real HTTP status (500), not 408 — the server did respond; only its explanatory body was unreadable. The specs now pin what this change is actually about on that branch: **it settles instead of hanging**. Re-verified RED with the corrected assertions before keeping the fix.

## RED-first + mutation check

Each spec has 2 stall cases plus a normal-response **positive control** (guards the success path and asserts `vi.getTimerCount() === 0`, so the absence assertions can't pass vacuously). The stall mock resolves headers immediately and returns a body promise that settles *only* on abort; settlement is tracked without awaiting, so a genuine hang fails loudly at the assertion rather than timing the runner out.

RED at `3578e272` — all three specs: 2 failed | 1 passed.

**Mutation-checked individually.** Reverting each source fix on its own turns that adapter's pins RED again:

- limits → `expected 'pending' to be 'resolved'` + a 5000 ms runner timeout (the hang itself)
- isl → `expected 'pending' to be 'rejected'` ×2
- cee → `expected 'pending' to be 'rejected'` ×2

## Gates

| Gate | Result |
|---|---|
| `pnpm run typecheck` | clean |
| `pnpm run lint` | **0 errors** (1100 pre-existing warnings) |
| `npx vitest run --changed origin/staging` | **1955 passed**, 44 skipped, 0 failed (148 files) |
| `tsc -p tsconfig.app.json --noEmit` | **zero new** — 2320 vs 2320, multiset diff empty in *both* directions vs a separate base clone at `3578e272` with its **own real** `node_modules` (both verified real dirs, both `@talchain/schemas` 0.18.0) |

Targeted run across all three adapters' test dirs plus `limits.spec.ts` and the pre-existing F-67 `client.timeout.spec.ts`: 67 passed.

## Fourth-instance sweep

`/usr/bin/grep -rn "clearTimeout" src/adapters src/lib src/v5` — 38 hits, every one checked against the shape. Three more instances of the same defect found; **left unfixed and filed here** rather than expanding a lane whose title names three sites:

- **`src/lib/service-health.ts:148`** — same defect (clears after headers, `await response.json()` unprotected). **Not equally mechanical**: `controller`/`timeoutId` are declared *inside* the `try`, so a `finally` needs them hoisted, and there is an entangled second defect — the fetch passes `signal: options?.signal || controller.signal`, so whenever a caller supplies its own signal the internal timer aborts a controller that isn't wired to the fetch at all and the timeout is **inert**. Fixing the timer placement alone would leave that half broken. Needs its own filing and a design call.
- **`src/lib/runReport.ts:89` and `:137`** — both the same defect and genuinely mechanical (`clearTimeout(timer)` after `await fetch`, then `await res.json()`). Both sit inside `try {} catch {}` blocks that swallow everything and fall back to a deterministic sample — but the swallow never runs on a stall, so the hang is real. Recommend a follow-up lane; they are a clean, ~2-line pair.

Confirmed **not** the defect: `src/lib/prompt-preloader.ts:62,76` (checks `response.ok`/`.status` only, never reads a body) · `src/lib/fetchWithRetry.ts:139` (a backoff-sleep timer, not a fetch) · `src/adapters/plot/v1/health.ts:29,39` (HEAD request, no body) · `src/adapters/plot/v1/http.ts` (already correct `finally`) · `src/adapters/plot/reconnection.ts`, `sseClient.ts`, `PlotHealthPill.tsx` (lifecycle/heartbeat timers, no body read).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
