### PR TITLE
fix(canvas,scenario): B2 atomic reconcile of authoritative CEE graph + B3 goal_constraints persistence

### DIFF
--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -89,7 +89,7 @@ import { applyAutoApplyPatch, synthesiseCeeAnalysisReady } from './utils/applyPa
 import { applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
 import { loadScenario as loadScenarioFromDb } from '../../services/scenarioService'
 import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
-import { mergeAppliedGraphAdditive } from '../utils/mergeAppliedGraph'
+import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
 import { trackEvent } from '../../lib/posthog'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
@@ -3313,18 +3313,37 @@ export function useConversation(): UseConversationReturn {
               // keeps a fresh-draft draft_graph away from a non-empty canvas
               // is CEE's continuation guard (route-v2 isDraftGraphShape
               // requires no prior committed turns on the scenario) — plus the
-              // client-side zero-overlap guard inside mergeAppliedGraphAdditive
+              // client-side zero-overlap guard inside reconcileAppliedGraph
               // for the residual misfire (fresh scenario_id + populated canvas
-              // + first brief-shaped message). Merge ADDITIVELY so a confirmed
-              // added factor/edge appears without a reload. Existing elements
-              // are never repositioned or rewritten; a receipt with nothing
-              // new is a strict no-op (see mergeAppliedGraphAdditive).
+              // + first brief-shaped message).
+              //
+              // B2 (Codex deep review, 2026-07-18): this reconcile is ATOMIC —
+              // adds, UPDATES and deletions. It used to be additive-only, on
+              // the stated belief that "value updates arrive separately as
+              // graph_patch blocks". That belief was FALSE for the edit_graph
+              // path: a successful edit returns `blocks: []`
+              // (edit-graph-dispatch.ts:832-833) and the receipt's draft_graph
+              // is the entire committed post-state. So a confirmed "set Spend
+              // to 250" left the canvas on 100, and the debounced autosave
+              // then wrote that 100 back over CEE's committed 250. Layout
+              // stays canvas-owned throughout — CEE's node schema has no
+              // position field. See reconcileAppliedGraph's header.
               if (useCanvasStore.getState().currentScenarioId === scenarioIdAtDispatch) {
-                const merged = mergeAppliedGraphAdditive(inlineGraph as any)
-                if (import.meta.env.DEV && (merged.addedNodeCount > 0 || merged.addedEdgeCount > 0)) {
+                const merged = reconcileAppliedGraph(inlineGraph as any)
+                if (
+                  import.meta.env.DEV &&
+                  (merged.addedNodeCount > 0 ||
+                    merged.addedEdgeCount > 0 ||
+                    merged.updatedNodeCount > 0 ||
+                    merged.updatedEdgeCount > 0 ||
+                    merged.removedNodeCount > 0 ||
+                    merged.removedEdgeCount > 0)
+                ) {
                   console.log(
-                    '[sendTurn V5] applied-edit receipt merged into canvas:',
-                    merged.addedNodeCount, 'nodes,', merged.addedEdgeCount, 'edges',
+                    '[sendTurn V5] applied-edit receipt reconciled into canvas:',
+                    `+${merged.addedNodeCount}n/+${merged.addedEdgeCount}e`,
+                    `~${merged.updatedNodeCount}n/~${merged.updatedEdgeCount}e`,
+                    `-${merged.removedNodeCount}n/-${merged.removedEdgeCount}e`,
                   )
                 }
               }

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -39,6 +39,7 @@ import type {
 import type { LimitsV1 } from '../adapters/plot/types'
 import type { ScenarioStage, ScenarioEvent } from '../types/scenario'
 import type { CeeDebugHeaders } from './utils/ceeDebugHeaders'
+import { identityFromCanvasGraph } from './utils/graphIdentity'
 import { isCompareTabEnabled } from '../flags'
 import { useAnalysisSnapshotStore } from './stores/analysisSnapshotStore'
 import { buildAnalysisSnapshot } from './stores/analysisSnapshotFactory'
@@ -422,6 +423,26 @@ interface CanvasState {
   ceeAnalysisReadyNodeIds: string[] | null
   // CEE goal constraints from draft-graph response root (for PLoT multi-constraint analysis)
   goalConstraints: CEEGoalConstraint[] | null
+  /**
+   * B2 (Codex deep review, 2026-07-18): the element identities of the most
+   * recent AUTHORITATIVE graph the UI has seen from CEE — a fresh draft, an
+   * applied-edit receipt, or a graph loaded from the DB (which is CEE's own
+   * view of the scenario).
+   *
+   * This exists to make DELETION safe. An applied-edit receipt is a complete
+   * post-state, so "absent from the receipt" means "deleted" — but CEE builds
+   * that post-state from the PERSISTED graph, and the UI's save is debounced
+   * 1500ms. A node the user added moments ago is therefore legitimately absent
+   * from the receipt without having been deleted. Reconciling absence to
+   * deletion unconditionally would trade B2's value-loss for a worse
+   * node-loss. So the reconciler only removes an element that CEE has
+   * previously ACKNOWLEDGED (present in this set) and that the new receipt
+   * omits; anything CEE has never seen is local work and survives untouched.
+   *
+   * Null means "no authoritative graph seen yet" — the fail-safe state, in
+   * which the reconciler removes nothing.
+   */
+  lastAuthoritativeGraph: { nodeIds: string[]; edgePairs: string[] } | null
   // CEE Pipeline trace from last draft-graph response (for debug panel)
   ceePipelineTrace: CeePipelineTrace | null
   // CEE V3: Per-node LLM reasoning (node ID → why text) for rationale tooltips
@@ -720,6 +741,10 @@ interface CanvasState {
   clearAnalysisFreshnessDirty: () => void
   setDraftCoaching: (coaching: CEEDraftCoaching | null) => void
   setGoalConstraints: (constraints: CEEGoalConstraint[] | null) => void
+  /** B2: record the identities of an authoritative CEE graph (see the field). */
+  setLastAuthoritativeGraph: (
+    graph: { nodeIds: string[]; edgePairs: string[] } | null,
+  ) => void
   setCeePipelineTrace: (trace: CeePipelineTrace | null) => void
   setCeeQuality: (quality: CeeQualityDimensions | null) => void
   // Phase 1b actions
@@ -800,7 +825,17 @@ interface CanvasState {
   ) => void
   exitComparisonMode: () => void
   // P2: Hydration hygiene
-  hydrateGraphSlice: (loaded: { nodes?: Node[]; edges?: Edge<EdgeData>[]; currentScenarioId?: string | null }) => void
+  hydrateGraphSlice: (loaded: {
+    nodes?: Node[]
+    edges?: Edge<EdgeData>[]
+    currentScenarioId?: string | null
+    /**
+     * B3: the loaded scenario's persisted hard constraints. MUST be passed on
+     * every full-context load — `undefined` and `null` both resolve to null so
+     * an absent value CLEARS rather than inheriting the previous scenario's.
+     */
+    goalConstraints?: CEEGoalConstraint[] | null
+  }) => void
   // A.7: External mutation suppression — prevents direct_graph_edit events firing
   // during patch-apply, envelope-applied changes, scenario hydration, etc.
   /** Reference count: >0 while a non-user graph mutation is in progress */
@@ -1053,6 +1088,19 @@ const DECISION_CONTEXT_CLEAR = {
   ceeAnalysisReady: null,
   ceeAnalysisReadyNodeIds: null,
   outcomeNodeId: null,
+  // B3 (Codex deep review, 2026-07-18): goalConstraints was the ONE member of
+  // the goal context missing from this set, so it was the one that leaked.
+  // A scenario's hard constraint ("stay under £50k") is per-decision state in
+  // exactly the same sense as goalThreshold — READINESS_CLEAR_FIELDS and
+  // resetCanvas both already cleared it; only the PRODUCTION scenario-load
+  // path (useScenario.loadScenario → hydrateGraphSlice) did not. Switching
+  // A→B therefore left A's cap in place and B's first run could ship it.
+  // hydrateGraphSlice re-assigns the LOADED value (or null) immediately after
+  // applying this set — see the `goalConstraints` handling there.
+  goalConstraints: null,
+  // B2: element identities are graph-specific. A previous scenario's set would
+  // authorise deleting same-id nodes in the newly loaded graph.
+  lastAuthoritativeGraph: null,
 } as const
 
 /**
@@ -1388,6 +1436,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   draftCoaching: null,
   // CEE goal constraints from draft-graph response root
   goalConstraints: null,
+  // B2: no authoritative graph seen yet — reconciler removes nothing.
+  lastAuthoritativeGraph: null,
   // CEE Pipeline trace from last draft
   ceePipelineTrace: null,
   // CEE V3: Per-node LLM reasoning for rationale tooltips
@@ -2507,16 +2557,18 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       touchedNodeIds: new Set(),
       nextNodeId: 1,
       nextEdgeId: 1,
-      // Clear CEE analysis_ready payload, pipeline trace, quality, and
-      // constraints. (ceeAnalysisReady + ceeAnalysisReadyNodeIds are cleared
-      // via DECISION_CONTEXT_CLEAR below — Lane 5.)
+      // Clear CEE analysis_ready payload, pipeline trace and quality.
+      // (ceeAnalysisReady, ceeAnalysisReadyNodeIds, goalConstraints and
+      // lastAuthoritativeGraph are all cleared via DECISION_CONTEXT_CLEAR
+      // below — Lane 5, extended by B2/B3. They are deliberately NOT repeated
+      // here: the duplicate keys this file used to carry were dead weight
+      // that only agreed with the spread by coincidence.)
       analysisFreshness: null,
       analysisFreshnessDirty: false,
       // V5 canonical analysis fact — clear on scenario reset (the fact does
       // not survive a graph reset; rerun analysis to mint a fresh one).
       v5AnalysisFact: null,
       draftCoaching: null,
-      goalConstraints: null,
       ceePipelineTrace: null,
       nodeRationales: {},
       ceeQuality: null,
@@ -3811,6 +3863,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     set({ goalConstraints: constraints })
   },
 
+  setLastAuthoritativeGraph: (graph) => {
+    set({ lastAuthoritativeGraph: graph })
+  },
+
   setCeePipelineTrace: (trace: CeePipelineTrace | null) => {
     if (import.meta.env.DEV && trace) {
       console.warn('[Canvas] setCeePipelineTrace:', {
@@ -4683,6 +4739,20 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // empties the goal selector, nor left stale).
       Object.assign(updates, DECISION_CONTEXT_CLEAR)
       updates.outcomeNodeId = firstGoalNodeId(loaded.nodes)
+      // B3: assign the LOADED constraints or null — never leave the previous
+      // scenario's in place. DECISION_CONTEXT_CLEAR above already nulled the
+      // field; this line is what makes a cold load RESTORE it. The `?? null`
+      // is load-bearing: an absent key must clear, not inherit.
+      updates.goalConstraints = loaded.goalConstraints ?? null
+      // B2: the persisted graph IS CEE's view of this scenario, so everything
+      // in it is an element CEE has acknowledged. Seeding the identity set
+      // here is what lets the FIRST applied-edit receipt after a cold load
+      // reconcile a deletion; without it the reconciler would fail safe and
+      // never remove anything until a second receipt arrived.
+      updates.lastAuthoritativeGraph = identityFromCanvasGraph(
+        loaded.nodes,
+        loaded.edges,
+      )
     }
 
     // Apply updates without clobbering panels/results/other slices

--- a/src/canvas/utils/__tests__/appliedEditDurability.e2e.spec.ts
+++ b/src/canvas/utils/__tests__/appliedEditDurability.e2e.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * B2 (Codex deep review, 2026-07-18) — END-TO-END durability of a CEE edit.
+ *
+ * THE FAILURE THIS PINS
+ * ---------------------
+ * The user confirms "set Spend from 100 to 250 and add Risk". CEE re-referees,
+ * canonicalises, commits BOTH operations, and returns the authoritative
+ * post-commit graph as top-level `draft_graph` (a successful edit carries no
+ * blocks — `edit-graph-dispatch.ts:832-833`).
+ *
+ * The UI's ingestion was ADDITIVE: it added Risk but deliberately did not
+ * update Spend. That alone would be a display bug. What made it data LOSS is
+ * the second half: adding Risk changed store state, which woke the 1500ms
+ * autosave, which then wrote the whole graph — including the stale Spend=100 —
+ * over the 250 CEE had already committed. The server was right, the user was
+ * told it worked, and 1.5 seconds later it was silently undone.
+ *
+ * WHY THIS TEST IS SHAPED THIS WAY
+ * --------------------------------
+ * Asserting on the store alone would have passed the moment the reconcile was
+ * fixed while leaving the write-back live — the defect is a RACE between two
+ * layers, so the test has to cross both. It therefore drives the REAL
+ * reconcile, the REAL useScenario autosave, and the REAL scenarioService
+ * against a mocked supabase, and checks all four stations the review named:
+ *
+ *      immediate UI  →  past the debounce  →  the DB payload  →  reload
+ *
+ * Nothing here can pass on "no error was thrown": every assertion names the
+ * value 250 at a specific station.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// --- supabase (the "database") ---------------------------------------------
+const mockRpc = vi.fn()
+let mockRowsById: Record<string, Record<string, unknown>> = {}
+const mockSingle = vi.fn()
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: (_col: string, id: string) => ({ single: () => mockSingle(id) }),
+      }),
+      update: () => ({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+    }),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  },
+}))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '550e8400-e29b-41d4-a716-446655440000' },
+    authenticated: true,
+  }),
+}))
+
+import { useScenario } from '../../../hooks/useScenario'
+import { useCanvasStore } from '../../store'
+import { reconcileAppliedGraph } from '../mergeAppliedGraph'
+
+const SCENARIO_ID = 'scenario-e2e'
+
+/** The canvas as it stands before the turn: Spend = 100. */
+const NODES_BEFORE = [
+  { id: 'goal-1', type: 'goal', position: { x: 400, y: 0 }, data: { kind: 'goal', label: 'Revenue' } },
+  {
+    id: 'factor-1',
+    type: 'factor',
+    position: { x: 40, y: 200 },
+    data: { kind: 'factor', label: 'Spend', observedState: { value: 100 } },
+  },
+]
+const EDGES_BEFORE = [
+  {
+    id: 'e-0',
+    source: 'factor-1',
+    target: 'goal-1',
+    type: 'styled',
+    data: { weight: 0.7, direction: 'positive' },
+  },
+]
+
+/**
+ * The authoritative post-commit receipt for "set Spend to 250 and add Risk".
+ * Note the shape: the FULL graph in CEE's analytical spelling, with no
+ * position fields anywhere — CEE's NodeV3 has none.
+ */
+const RECEIPT = {
+  nodes: [
+    { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 250 } },
+    { id: 'risk-1', kind: 'risk', label: 'Risk' },
+  ],
+  edges: [
+    { id: 'factor-1::goal-1::0', from: 'factor-1', to: 'goal-1', weight: 0.7 },
+    { id: 'risk-1::goal-1::0', from: 'risk-1', to: 'goal-1', weight: -0.4 },
+  ],
+}
+
+function scenarioRow(graph: unknown): Record<string, unknown> {
+  return {
+    id: SCENARIO_ID,
+    graph,
+    framing: null,
+    stage: 'analyse',
+    updated_at: new Date().toISOString(),
+    analysis_status: 'none',
+    analysis: null,
+    analysis_provenance: null,
+    analysis_error: null,
+    thread: null,
+    events: null,
+  }
+}
+
+/** The `p_graph` of the most recent gated write — i.e. what the DB now holds. */
+function persistedGraph(): Record<string, unknown> | null {
+  const calls = mockRpc.mock.calls.filter((c) => c[0] === 'apply_patch_and_log')
+  if (calls.length === 0) return null
+  return (calls[calls.length - 1][1] as Record<string, unknown>).p_graph as Record<string, unknown>
+}
+
+function spendValueOf(nodes: unknown): unknown {
+  const n = (nodes as Array<Record<string, any>>).find((x) => x.id === 'factor-1')
+  return n?.data?.observedState?.value
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRowsById = { [SCENARIO_ID]: scenarioRow({ nodes: NODES_BEFORE, edges: EDGES_BEFORE }) }
+  mockSingle.mockImplementation(async (id: string) =>
+    mockRowsById[id] ? { data: mockRowsById[id], error: null } : { data: null, error: { code: 'PGRST116' } },
+  )
+  mockRpc.mockResolvedValue({ data: {}, error: null })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('B2 — a confirmed CEE edit is durable through UI, autosave, DB and reload', () => {
+  it('mixed edit (update Spend 100→250 + add Risk) survives all four stations', async () => {
+    vi.useFakeTimers()
+    const { result, unmount } = renderHook(() => useScenario())
+
+    // Cold-load the pre-edit scenario.
+    await act(async () => {
+      await result.current.loadScenario(SCENARIO_ID)
+    })
+    expect(spendValueOf(useCanvasStore.getState().nodes)).toBe(100)
+
+    // --- The turn: CEE's authoritative receipt is ingested -----------------
+    await act(async () => {
+      reconcileAppliedGraph(RECEIPT as never)
+    })
+
+    // STATION 1 — IMMEDIATE UI. The user sees 250 without a reload, and Risk
+    // is on the canvas. (Additive merge: Risk yes, 250 no.)
+    expect(spendValueOf(useCanvasStore.getState().nodes)).toBe(250)
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toContain('risk-1')
+
+    // The user's layout for the pre-existing node is untouched — CEE cannot
+    // return positions, so a wholesale replace would have reset this to 0,0.
+    const spendNode = useCanvasStore.getState().nodes.find((n) => n.id === 'factor-1') as any
+    expect(spendNode.position).toEqual({ x: 40, y: 200 })
+
+    // STATION 2 — PAST THE DEBOUNCE. This is the write that used to carry
+    // the stale 100 back over CEE's 250.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600)
+    })
+    const written = persistedGraph()
+    expect(written).not.toBeNull()
+
+    // STATION 3 — THE DATABASE. The persisted graph holds 250, not 100.
+    expect(spendValueOf(written!.nodes)).toBe(250)
+    expect((written!.nodes as Array<{ id: string }>).map((n) => n.id)).toContain('risk-1')
+    // And the layout the DB would otherwise have lost is in the payload —
+    // CEE's own commit overwrites `nodes` with position-free GraphV3, so this
+    // write is what restores it. (This is why the echo save is NOT suppressed.)
+    expect(
+      (written!.nodes as Array<Record<string, any>>).find((n) => n.id === 'factor-1')!.position,
+    ).toEqual({ x: 40, y: 200 })
+
+    unmount()
+
+    // STATION 4 — RELOAD. Feed back exactly the persisted bytes into a fresh
+    // load and confirm the user still sees 250.
+    vi.useRealTimers()
+    useCanvasStore.setState({ nodes: [], edges: [] } as never)
+    mockRowsById[SCENARIO_ID] = scenarioRow(written)
+
+    const reloaded = renderHook(() => useScenario())
+    await act(async () => {
+      await reloaded.result.current.loadScenario(SCENARIO_ID)
+    })
+
+    expect(spendValueOf(useCanvasStore.getState().nodes)).toBe(250)
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toContain('risk-1')
+  })
+
+  it('a receipt that only DELETES an element is durable too', async () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useScenario())
+
+    await act(async () => {
+      await result.current.loadScenario(SCENARIO_ID)
+    })
+    // Hydration seeds the acknowledgement set from the DB — which IS CEE's
+    // view — so the very first receipt after a cold load can delete.
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).not.toBeNull()
+
+    await act(async () => {
+      reconcileAppliedGraph({
+        nodes: [{ id: 'goal-1', kind: 'goal', label: 'Revenue' }],
+        edges: [],
+      } as never)
+    })
+
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toEqual(['goal-1'])
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600)
+    })
+
+    const written = persistedGraph()
+    expect(written).not.toBeNull()
+    expect((written!.nodes as Array<{ id: string }>).map((n) => n.id)).toEqual(['goal-1'])
+    expect(written!.edges).toHaveLength(0)
+  })
+})

--- a/src/canvas/utils/__tests__/applyDraftResult.spec.ts
+++ b/src/canvas/utils/__tests__/applyDraftResult.spec.ts
@@ -20,6 +20,7 @@ const mockSetCeeAnalysisReady = vi.fn()
 const mockSetCeePipelineTrace = vi.fn()
 const mockSetCeeQuality = vi.fn()
 const mockSetGoalConstraints = vi.fn()
+const mockSetLastAuthoritativeGraph = vi.fn()
 const mockSetDraftCoaching = vi.fn()
 const mockSetPreAnalysisSensitivity = vi.fn()
 const mockMarkAnalysisFreshnessDirty = vi.fn()
@@ -46,6 +47,14 @@ vi.mock('../../store', () => ({
         setCeePipelineTrace: mockSetCeePipelineTrace,
         setCeeQuality: mockSetCeeQuality,
         setGoalConstraints: mockSetGoalConstraints,
+        // B2. NOTE: this getState() block is a HAND-MAINTAINED MIRROR of the
+        // store's action surface — a `vi.mock` factory REPLACES the module, so
+        // any action added to the store and called by applyDraftResult throws
+        // here until someone remembers to add it. That is how this line came
+        // to exist. It is left strict (no `?.()` at the call site) on purpose:
+        // a loud throw in one spec is far better than an optional call that
+        // silently no-ops the deletion-authorisation record in production.
+        setLastAuthoritativeGraph: mockSetLastAuthoritativeGraph,
         setDraftCoaching: mockSetDraftCoaching,
         setPreAnalysisSensitivity: mockSetPreAnalysisSensitivity,
         currentScenarioId: null,

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for mergeAppliedGraphAdditive (POC Lane C — applied-edit receipt
+ * Tests for reconcileAppliedGraph (POC Lane C — applied-edit receipt
  * ingestion on a non-empty canvas).
  *
  * Uses the REAL canvas store (mirrors the hook-level fixture in
@@ -17,9 +17,31 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mergeAppliedGraphAdditive } from '../mergeAppliedGraph'
+import { reconcileAppliedGraph, type ReconcileAppliedGraphResult } from '../mergeAppliedGraph'
 import { useCanvasStore } from '../../store'
 import { logger } from '../../../lib/logger'
+// Derived, never hardcoded: the pair separator is a NUL, which is invisible
+// in source and unwritable as a literal without corrupting the file.
+import { edgePairKey } from '../graphIdentity'
+
+/**
+ * Fill the counters a case does not mention with 0, so every assertion checks
+ * ALL SIX exactly. Deliberately not `objectContaining`: an unasserted counter
+ * is how an unintended removal would slip through.
+ */
+function counts(
+  p: Partial<ReconcileAppliedGraphResult> = {},
+): ReconcileAppliedGraphResult {
+  return {
+    addedNodeCount: 0,
+    addedEdgeCount: 0,
+    updatedNodeCount: 0,
+    updatedEdgeCount: 0,
+    removedNodeCount: 0,
+    removedEdgeCount: 0,
+    ...p,
+  }
+}
 
 const EXISTING_NODES = [
   {
@@ -52,6 +74,11 @@ function seedCanvas() {
     nodes: structuredClone(EXISTING_NODES) as any,
     edges: structuredClone(EXISTING_EDGES) as any,
     ceeAnalysisReady: null,
+    // B2: default to "CEE has acknowledged nothing" so the deletion path is
+    // OFF unless a case opts in. Without this reset the field would leak
+    // between cases and a later test could delete the seed graph.
+    lastAuthoritativeGraph: null,
+    history: { past: [], future: [] },
   } as any)
 }
 
@@ -59,9 +86,9 @@ beforeEach(() => {
   seedCanvas()
 })
 
-describe('mergeAppliedGraphAdditive', () => {
+describe('reconcileAppliedGraph', () => {
   it('adds wire nodes/edges missing from the canvas and leaves existing elements untouched', () => {
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
@@ -73,7 +100,7 @@ describe('mergeAppliedGraphAdditive', () => {
       ],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 1 })
+    expect(result).toEqual(counts({ addedNodeCount: 1, addedEdgeCount: 1 }))
 
     const { nodes, edges } = useCanvasStore.getState()
     expect(nodes).toHaveLength(3)
@@ -99,7 +126,7 @@ describe('mergeAppliedGraphAdditive', () => {
   })
 
   it('places added nodes right of the existing bounding box (no re-layout of existing nodes)', () => {
-    mergeAppliedGraphAdditive({
+    reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -121,7 +148,7 @@ describe('mergeAppliedGraphAdditive', () => {
   })
 
   it('does not re-add an existing edge whose local id differs from the wire id (endpoint-pair dedupe)', () => {
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -130,12 +157,12 @@ describe('mergeAppliedGraphAdditive', () => {
       edges: [{ id: 'factor-1::goal-1::0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ addedNodeCount: 0, addedEdgeCount: 0 }))
     expect(useCanvasStore.getState().edges).toHaveLength(1)
   })
 
   it('drops a dangling wire edge fail-closed (endpoint not on canvas and not being added)', () => {
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -144,12 +171,12 @@ describe('mergeAppliedGraphAdditive', () => {
       edges: [{ id: 'ghost-1::goal-1::0', from: 'ghost-1', to: 'goal-1', weight: 0.5 }],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ addedNodeCount: 0, addedEdgeCount: 0 }))
     expect(useCanvasStore.getState().edges).toHaveLength(1)
   })
 
   it('uniquifies the mapper fallback edge id against existing canvas ids', () => {
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -160,7 +187,7 @@ describe('mergeAppliedGraphAdditive', () => {
       edges: [{ from: 'factor-2', to: 'goal-1', weight: 0.3 }],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 1 })
+    expect(result).toEqual(counts({ addedNodeCount: 1, addedEdgeCount: 1 }))
     const { edges } = useCanvasStore.getState()
     expect(edges).toHaveLength(2)
     const ids = edges.map((e) => e.id)
@@ -169,11 +196,25 @@ describe('mergeAppliedGraphAdditive', () => {
     expect(addedEdge.id).not.toBe('e-0')
   })
 
-  it('is a strict no-op (no history entry) when the receipt carries nothing new', () => {
+  // ---------------------------------------------------------------------
+  // B2 (Codex deep review, 2026-07-18) — CORRECTED, NOT DELETED.
+  //
+  // This case used to be titled "is a strict no-op (no history entry) when
+  // the receipt carries nothing new" and fed a receipt in which factor-1's
+  // observed value was 250 while the canvas held 100 — then asserted that
+  // NOTHING happened. That is the defect, written down as an expectation:
+  // the green suite was pinning the data-loss. A receipt carrying a value
+  // the canvas does not have is not "nothing new", it is the whole point of
+  // the edit.
+  //
+  // The genuine no-op case (a receipt that really does carry nothing new)
+  // still exists and is asserted separately, below and at the end of the
+  // file — losing it would have been the opposite mistake.
+  // ---------------------------------------------------------------------
+  it('APPLIES an updated value on an existing node (B2 — this receipt is authoritative)', () => {
     const historyBefore = (useCanvasStore.getState() as any).history?.past?.length ?? 0
-    const nodesBefore = useCanvasStore.getState().nodes
 
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 250 } },
@@ -181,15 +222,46 @@ describe('mergeAppliedGraphAdditive', () => {
       edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ updatedNodeCount: 1 }))
+
+    // The value CEE committed is now what the canvas shows.
+    const factor1 = useCanvasStore.getState().nodes.find((n) => n.id === 'factor-1') as any
+    expect(factor1?.data?.observedState).toEqual({ value: 250 })
+
+    // ...and it is a real, undoable mutation, not a silent overwrite.
+    const historyAfter = (useCanvasStore.getState() as any).history?.past?.length ?? 0
+    expect(historyAfter).toBe(historyBefore + 1)
+
+    // LAYOUT PRESERVED — the whole reason this is an overlay and not a
+    // replace. CEE's node schema has no position field; if the reconcile
+    // took the mapper's node wholesale, this would be {x:0,y:0}.
+    expect(factor1?.position).toEqual({ x: 40, y: 200 })
+  })
+
+  it('is a strict no-op (no history entry, no store write) when the receipt genuinely matches the canvas', () => {
+    const historyBefore = (useCanvasStore.getState() as any).history?.past?.length ?? 0
+    const nodesBefore = useCanvasStore.getState().nodes
+    const edgesBefore = useCanvasStore.getState().edges
+
+    const result = reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        // Same value the canvas already holds.
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+    } as any)
+
+    expect(result).toEqual(counts())
     const historyAfter = (useCanvasStore.getState() as any).history?.past?.length ?? 0
     expect(historyAfter).toBe(historyBefore)
-    // Node identity preserved — no store write at all.
+    // Identity preserved — no store write at all.
     expect(useCanvasStore.getState().nodes).toBe(nodesBefore)
+    expect(useCanvasStore.getState().edges).toBe(edgesBefore)
   })
 
   it('handles the nested graph shape ({ graph: { nodes, edges } })', () => {
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       graph: {
         nodes: [
           { id: 'goal-1', kind: 'goal', label: 'Revenue' },
@@ -200,7 +272,7 @@ describe('mergeAppliedGraphAdditive', () => {
       },
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ addedNodeCount: 1, addedEdgeCount: 0 }))
     expect(useCanvasStore.getState().nodes.map((n) => n.id)).toContain('risk-1')
   })
 })
@@ -209,7 +281,161 @@ describe('mergeAppliedGraphAdditive', () => {
 // Fixup round (adversarial review on PR #266)
 // ---------------------------------------------------------------------------
 
-describe('mergeAppliedGraphAdditive — zero-overlap structural guard', () => {
+// ---------------------------------------------------------------------------
+// B2 — deletions, and the acknowledgement guard that makes them safe
+// ---------------------------------------------------------------------------
+
+describe('reconcileAppliedGraph — deletions', () => {
+  it('REMOVES a node CEE previously acknowledged and now omits (absence == deletion)', () => {
+    // CEE has seen both factor-1 and goal-1 (e.g. from the draft or a prior
+    // receipt), so their absence from this receipt is authoritative.
+    useCanvasStore.getState().setLastAuthoritativeGraph({
+      nodeIds: ['goal-1', 'factor-1'],
+      edgePairs: [edgePairKey('factor-1', 'goal-1')],
+    })
+
+    const result = reconcileAppliedGraph({
+      nodes: [{ id: 'goal-1', kind: 'goal', label: 'Revenue' }],
+      edges: [],
+    } as any)
+
+    // The node AND the edge that hung off it are gone.
+    expect(result).toEqual(counts({ removedNodeCount: 1, removedEdgeCount: 1 }))
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toEqual(['goal-1'])
+    expect(useCanvasStore.getState().edges).toHaveLength(0)
+  })
+
+  it('does NOT remove a local node CEE has never acknowledged (unsaved local work survives)', () => {
+    // The user added factor-99 seconds ago; the 1500ms autosave has not run,
+    // so CEE built its post-state without it. Absence here is ignorance, not
+    // deletion — removing it would be a worse bug than the one B2 fixes.
+    useCanvasStore.setState({
+      nodes: [
+        ...structuredClone(EXISTING_NODES),
+        { id: 'factor-99', type: 'factor', position: { x: 900, y: 900 }, data: { kind: 'factor', label: 'Local only' } },
+      ] as any,
+    })
+    useCanvasStore.getState().setLastAuthoritativeGraph({
+      nodeIds: ['goal-1', 'factor-1'], // factor-99 deliberately absent
+      edgePairs: [edgePairKey('factor-1', 'goal-1')],
+    })
+
+    const result = reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+    } as any)
+
+    expect(result).toEqual(counts())
+    expect(useCanvasStore.getState().nodes.map((n) => n.id)).toContain('factor-99')
+  })
+
+  it('removes NOTHING when no authoritative graph has been recorded yet (fail-safe)', () => {
+    useCanvasStore.getState().setLastAuthoritativeGraph(null)
+
+    const result = reconcileAppliedGraph({
+      nodes: [{ id: 'goal-1', kind: 'goal', label: 'Revenue' }],
+      edges: [],
+    } as any)
+
+    expect(result).toEqual(counts())
+    expect(useCanvasStore.getState().nodes).toHaveLength(2)
+  })
+
+  it('records the receipt as the new authoritative set even on a no-op turn', () => {
+    // Otherwise an idempotent turn would leave the acknowledgement set stale
+    // and a LATER receipt could not delete what this one confirmed.
+    useCanvasStore.getState().setLastAuthoritativeGraph(null)
+
+    reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+    } as any)
+
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toEqual({
+      nodeIds: ['goal-1', 'factor-1'],
+      edgePairs: [edgePairKey('factor-1', 'goal-1')],
+    })
+  })
+})
+
+describe('reconcileAppliedGraph — updates preserve layout and local-only data', () => {
+  it('keeps position/size/selection while overlaying the wire value', () => {
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: 'factor-1',
+          type: 'factor',
+          position: { x: 40, y: 200 },
+          width: 180,
+          height: 90,
+          selected: true,
+          data: { kind: 'factor', label: 'Spend', observedState: { value: 100 }, is_baseline: true },
+        },
+        ...structuredClone(EXISTING_NODES).filter((n) => n.id === 'goal-1'),
+      ] as any,
+    })
+
+    const result = reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 250 } },
+      ],
+      edges: [],
+    } as any)
+
+    expect(result).toEqual(counts({ updatedNodeCount: 1 }))
+    const f = useCanvasStore.getState().nodes.find((n) => n.id === 'factor-1') as any
+    expect(f.data.observedState).toEqual({ value: 250 })
+    // Layout-only React Flow state survives untouched.
+    expect(f.position).toEqual({ x: 40, y: 200 })
+    expect(f.width).toBe(180)
+    expect(f.height).toBe(90)
+    expect(f.selected).toBe(true)
+    // UI-side backfill the wire never mentions is not wiped.
+    expect(f.data.is_baseline).toBe(true)
+  })
+
+  it('does not splat edge-mapper DEFAULTS over a locally-tuned edge', () => {
+    // A wire edge carrying no analytical fields must not overwrite the
+    // canvas edge's weight/direction with DEFAULT_EDGE_DATA — otherwise
+    // every receipt would churn history and reset the user's edges.
+    const edgesBefore = useCanvasStore.getState().edges
+    const result = reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1' }],
+    } as any)
+
+    expect(result).toEqual(counts())
+    expect(useCanvasStore.getState().edges).toBe(edgesBefore)
+    expect((edgesBefore[0] as any).data.weight).toBeCloseTo(0.7)
+  })
+
+  it('APPLIES a changed edge weight from the receipt', () => {
+    const result = reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: -0.9 }],
+    } as any)
+
+    expect(result).toEqual(counts({ updatedEdgeCount: 1 }))
+    const e = useCanvasStore.getState().edges[0] as any
+    expect(e.data.weight).toBeCloseTo(0.9)
+    expect(e.data.direction).toBe('negative')
+  })
+})
+
+describe('reconcileAppliedGraph — zero-overlap structural guard', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
@@ -229,7 +455,7 @@ describe('mergeAppliedGraphAdditive — zero-overlap structural guard', () => {
     const nodesBefore = useCanvasStore.getState().nodes
     const edgesBefore = useCanvasStore.getState().edges
 
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal_1', kind: 'goal', label: 'Unrelated goal' },
         { id: 'opt_1', kind: 'option', label: 'Unrelated option' },
@@ -238,7 +464,7 @@ describe('mergeAppliedGraphAdditive — zero-overlap structural guard', () => {
       edges: [{ id: 'opt_1::out_1::0', from: 'opt_1', to: 'out_1', weight: 0.5 }],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ addedNodeCount: 0, addedEdgeCount: 0 }))
     // Store untouched — identity preserved, nothing grafted.
     expect(useCanvasStore.getState().nodes).toBe(nodesBefore)
     expect(useCanvasStore.getState().edges).toBe(edgesBefore)
@@ -248,7 +474,7 @@ describe('mergeAppliedGraphAdditive — zero-overlap structural guard', () => {
   })
 
   it('still merges the normal superset receipt (overlap present) without warning', () => {
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -257,16 +483,16 @@ describe('mergeAppliedGraphAdditive — zero-overlap structural guard', () => {
       edges: [],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ addedNodeCount: 1, addedEdgeCount: 0 }))
     expect(warnSpy).not.toHaveBeenCalled()
   })
 })
 
-describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, staleness flags)', () => {
+describe('reconcileAppliedGraph — review fixups (edge-pair self-dedupe, staleness flags)', () => {
   it('dedupes two NEW wire edges sharing the same endpoint pair against each other', () => {
     // Direct setState bypasses addEdge's duplicate guard, so the merge must
     // self-dedupe wire edges that share an endpoint pair.
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -278,7 +504,7 @@ describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, st
       ],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 1 })
+    expect(result).toEqual(counts({ addedNodeCount: 1, addedEdgeCount: 1 }))
     const pairs = useCanvasStore
       .getState()
       .edges.filter((e) => e.source === 'factor-2' && e.target === 'goal-1')
@@ -296,7 +522,7 @@ describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, st
       analysisStateReady: true,
     } as any)
 
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -305,17 +531,17 @@ describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, st
       edges: [],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 1, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ addedNodeCount: 1, addedEdgeCount: 0 }))
     expect(useCanvasStore.getState().graphEditedSinceLastRun).toBe(true)
     expect(useCanvasStore.getState().analysisStateReady).toBe(false)
   })
 
   it('marks the freshness overlay dirty on a structural add — the banner must never keep claiming currency', () => {
     // The freshness banners read analysisFreshnessDirty, not the legacy
-    // graphEditedSinceLastRun flag — see mergeAppliedGraphAdditive's commit block.
+    // graphEditedSinceLastRun flag — see reconcileAppliedGraph's commit block.
     useCanvasStore.setState({ analysisFreshnessDirty: false } as any)
 
-    mergeAppliedGraphAdditive({
+    reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -330,7 +556,7 @@ describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, st
   it('does NOT dirty the freshness overlay on a nothing-new receipt (strict no-op stays a no-op)', () => {
     useCanvasStore.setState({ analysisFreshnessDirty: false } as any)
 
-    const result = mergeAppliedGraphAdditive({
+    const result = reconcileAppliedGraph({
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Revenue' },
         { id: 'factor-1', kind: 'factor', label: 'Spend' },
@@ -338,7 +564,7 @@ describe('mergeAppliedGraphAdditive — review fixups (edge-pair self-dedupe, st
       edges: [],
     } as any)
 
-    expect(result).toEqual({ addedNodeCount: 0, addedEdgeCount: 0 })
+    expect(result).toEqual(counts({ addedNodeCount: 0, addedEdgeCount: 0 }))
     expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
   })
 })

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -21,6 +21,7 @@ import { logger } from '../../lib/logger'
 import { validateNodesBatch } from '../domain/nodes'
 import { devLog } from '../../utils/debugLog'
 import { detectBaseline } from './baselineDetection'
+import { identityFromCanvasGraph } from './graphIdentity'
 
 /**
  * Map one CEE wire node → React Flow canvas node.
@@ -173,6 +174,15 @@ export function applyDraftResult(
   // Warning-only schema validation at the mutation boundary. Non-throwing —
   // shape drift is logged via devWarn in DEV builds only.
   validateNodesBatch(nodes)
+
+  // B2: a fresh draft IS an authoritative CEE graph. Recording its element
+  // identities is what lets the NEXT applied-edit receipt reconcile a
+  // deletion — reconcileAppliedGraph only removes elements CEE has
+  // previously acknowledged, so without this the first deletion after a
+  // draft would be silently ignored.
+  useCanvasStore.getState().setLastAuthoritativeGraph(
+    identityFromCanvasGraph(nodes, edges),
+  )
 
   // Draft application replaces the graph via bare setState (bypasses the edit
   // chokepoints), so mark the freshness overlay dirty. If the draft carries an

--- a/src/canvas/utils/graphIdentity.ts
+++ b/src/canvas/utils/graphIdentity.ts
@@ -1,0 +1,75 @@
+/**
+ * graphIdentity — the single definition of "which element is this".
+ *
+ * B2 (Codex deep review, 2026-07-18). The reconciler and the store both need
+ * to record and compare element identities across an authoritative CEE graph
+ * and the local canvas. Node identity is the id. EDGE identity is the
+ * endpoint PAIR, not the id: CEE mints composite ids
+ * (`factor-1::goal-1::0`) while the draft mapper falls back to positional ids
+ * (`e-0`), so the same edge routinely carries different ids on the two sides.
+ * The existing dedupe in the reconciler already relied on the pair; this
+ * module makes that the one definition rather than a format repeated at each
+ * site (a repeated key format is a mirror, and mirrors drift).
+ *
+ * Parallel edges between the same ordered pair are not a supported canvas
+ * shape, so the pair is a safe identity.
+ */
+
+/** NUL separator — cannot occur in an id, so the key is unambiguous. */
+const PAIR_SEPARATOR = '\u0000'
+
+/** Identity key for an edge, from its two endpoints. */
+export function edgePairKey(source: string, target: string): string {
+  return `${source}${PAIR_SEPARATOR}${target}`
+}
+
+/** Endpoint pair of a canvas edge (`source`/`target`). */
+export function canvasEdgePairKey(e: {
+  source?: unknown
+  target?: unknown
+}): string | null {
+  const { source, target } = e
+  if (typeof source !== 'string' || typeof target !== 'string') return null
+  return edgePairKey(source, target)
+}
+
+/**
+ * Endpoint pair of a WIRE edge. CEE emits `from`/`to`; some adapter shapes
+ * carry `source`/`target`. Accept both — the reconciler is fed by more than
+ * one producer.
+ */
+export function wireEdgePairKey(e: {
+  from?: unknown
+  to?: unknown
+  source?: unknown
+  target?: unknown
+}): string | null {
+  const from = e.from ?? e.source
+  const to = e.to ?? e.target
+  if (typeof from !== 'string' || typeof to !== 'string') return null
+  return edgePairKey(from, to)
+}
+
+/** The identity snapshot stored as `lastAuthoritativeGraph`. */
+export interface AuthoritativeGraphIdentity {
+  nodeIds: string[]
+  edgePairs: string[]
+}
+
+/**
+ * Build an identity snapshot from a canvas-shaped graph (`source`/`target`
+ * edges) — used when hydrating from the DB, whose contents are CEE's own view.
+ */
+export function identityFromCanvasGraph(
+  nodes: ReadonlyArray<{ id?: unknown }> | undefined,
+  edges: ReadonlyArray<{ source?: unknown; target?: unknown }> | undefined,
+): AuthoritativeGraphIdentity {
+  return {
+    nodeIds: (nodes ?? [])
+      .map((n) => n?.id)
+      .filter((id): id is string => typeof id === 'string'),
+    edgePairs: (edges ?? [])
+      .map((e) => (e ? canvasEdgePairKey(e) : null))
+      .filter((k): k is string => k !== null),
+  }
+}

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -1,6 +1,7 @@
 /**
- * mergeAppliedGraphAdditive — ingest an applied-edit receipt's graph into a
- * NON-EMPTY canvas (POC Lane C, edit-journey display closure, 2026-07-11).
+ * reconcileAppliedGraph — ingest an applied-edit receipt's authoritative graph
+ * into a NON-EMPTY canvas (POC Lane C, edit-journey display closure,
+ * 2026-07-11; made ATOMIC for defect B2, Codex deep review 2026-07-18).
  *
  * Wire contract: CEE #414/#424 attach the FULL committed post-mutation graph
  * to applied-edit receipts via the EXISTING top-level `draft_graph` field
@@ -11,6 +12,42 @@
  * canvasIsEmpty, so a confirmed structural edit (add factor / add edge) never
  * reached a populated canvas until a full reload.
  *
+ * ---------------------------------------------------------------------------
+ * WHAT THE RECEIPT ACTUALLY IS (verified against CEE staging `10633948`,
+ * 2026-07-18 — this replaces an incorrect claim that used to live here)
+ * ---------------------------------------------------------------------------
+ *
+ * A successful edit's receipt is the COMPLETE post-mutation graph, and it is
+ * the ONLY transport for the result of that edit:
+ *
+ *   - `blocks` is EMPTY on success. `buildBoundaryBlocks`
+ *     (edit-graph-dispatch.ts:832-833) opens with `if (!result.wasRejected)
+ *     return []`. The previous version of this comment asserted that "value
+ *     updates on existing elements arrive separately as graph_patch blocks
+ *     (applyV5State)". That was FALSE for the edit_graph path and it is why
+ *     this merge was additive-only. `graph_patch` reaches the wire only from
+ *     compose.ts:338-345, gated on the three D1 typed-handler facts
+ *     (set_factor_value / add_constraint / adjust_edge_strength) — and those
+ *     turns carry a full `draft_graph` as well. On the LLM-driven edit_graph
+ *     path, a rejected edit is converted to an `error` block
+ *     (edit-graph-dispatch.ts:859-866); a successful one carries nothing but
+ *     the graph. CEE's own docstring (edit-graph-dispatch.ts:809-818) had
+ *     already corrected this myth on the server side.
+ *   - `draft_graph` is the whole graph, not a delta —
+ *     `buildAppliedGraphWireField` (applied-graph-emit.ts:41-48) emits
+ *     `graph.nodes` / `graph.edges` wholesale from a structuredClone that
+ *     `patch-applier.ts` mutated in place.
+ *   - ABSENCE THEREFORE MEANS DELETION. `patch-applier.ts:105-117` splices the
+ *     node out and filters its edges; CEE itself infers option deletion purely
+ *     from absence (edit-graph-dispatch.ts:1148-1153).
+ *   - It carries NO LAYOUT. `NodeV3` (schemas/cee-v3.ts:89-144) is closed and
+ *     declares analytical fields only — no `position`, `width`, `measured`.
+ *     Layout is UI-owned state that CEE never sees and can never return.
+ *
+ * Hence the semantics below: a full three-way reconcile that treats the
+ * receipt as authoritative for ANALYTICAL state while the canvas stays
+ * authoritative for LAYOUT.
+ *
  * Why "draft_graph + non-empty canvas" is treated as an applied-edit receipt:
  * the V5 payload carries NO graph_state (buildPayload.ts — MessageTurnPayload
  * is turn ids/stage/message/source/chip only), so CEE's
@@ -20,37 +57,67 @@
  * `!isContinuationScenario` (loadHasPriorTurns on the scenario), and a
  * non-empty canvas normally belongs to a scenario with prior committed turns.
  * The reachable misfire — a FRESH scenario_id with a populated canvas whose
- * first message is a ≥30-char brief-shaped text — slips past that guard and
+ * first message is a >=30-char brief-shaped text — slips past that guard and
  * returns a misdrafted fresh graph; the zero-overlap guard below drops it
- * client-side (an applied receipt always supersets the committed graph, so
- * zero node-id overlap with the canvas is diagnostic). CEE also COMMITS that
- * misdrafted graph server-side — a pre-existing CEE bug filed as its own
- * follow-up lane (see PR #266 body).
+ * client-side (an applied receipt always overlaps the committed graph, so
+ * zero node-id overlap with the canvas is diagnostic).
  *
- * Semantics — ADDITIVE ONLY:
- *   - Wire nodes/edges missing from the canvas are added, converted with the
- *     SAME mappers as the draft path (mapDraftNodeToCanvas /
- *     mapDraftEdgeToCanvas), then pulsed with the applied-edit highlight.
- *   - Existing canvas elements are never repositioned, rewritten, or removed.
- *     Value updates on existing elements arrive separately as graph_patch
- *     blocks (applyV5State); removals have no ingestion path yet (known
- *     residual, same class as applyV5State's missing delete case).
- *   - No full re-layout: added nodes are placed in a column to the right of
- *     the current graph's bounding box so the user's layout is untouched.
- *   - A receipt whose graph carries nothing new (e.g. a value-only edit) is a
- *     strict no-op — no history entry, no store write, no autosave.
- *   - Zero node-id overlap with a non-empty canvas ⇒ DROP + structured warn
- *     (never graft an unrelated graph).
+ * ---------------------------------------------------------------------------
+ * SEMANTICS — ATOMIC RECONCILE (adds + updates + deletions, one history entry)
+ * ---------------------------------------------------------------------------
+ *   - ADD: wire elements missing from the canvas are converted with the SAME
+ *     mappers as the draft path (mapDraftNodeToCanvas / mapDraftEdgeToCanvas)
+ *     and placed in a column right of the current bounding box — never a full
+ *     re-layout of the user's graph.
+ *   - UPDATE: wire elements already on the canvas have their ANALYTICAL fields
+ *     overlaid onto the existing element. Layout-only state (position, size,
+ *     measurement, selection, drag state) is preserved by construction: the
+ *     existing element is spread first and the mapper's `position` is
+ *     discarded. This is the hunk that fixes B2 — before it, a confirmed
+ *     "set Spend to 250" left the canvas showing 100, and the 1500ms autosave
+ *     then wrote that stale 100 back over CEE's committed 250.
+ *   - REMOVE: elements absent from the receipt are removed — but ONLY if CEE
+ *     had previously acknowledged them (`lastAuthoritativeGraph`). CEE builds
+ *     the post-state from the PERSISTED graph, and the UI's save is debounced,
+ *     so a node the user added moments ago is legitimately absent from the
+ *     receipt without having been deleted. Removing it would trade B2's
+ *     value-loss for a worse node-loss. Unacknowledged local work survives.
+ *   - A receipt that changes nothing is a strict no-op — no history entry, no
+ *     store write, no autosave, no freshness dirtying.
+ *   - Zero node-id overlap with a non-empty canvas => DROP + structured warn.
  *
- * Freshness: deliberately NOT marking the local dirty overlay here. The same
- * response carries CEE's post-apply analysis_ready.freshness verdict (routed
- * through applyV5State step 4 setAnalysisFreshness before this merge runs);
- * that verdict is authoritative for exactly this graph — the overlay exists
- * for local writes CEE has not seen. graphEditedSinceLastRun /
- * analysisStateReady are set EXPLICITLY in the commit below (true / false):
- * pushHistory alone cannot be relied on for them, because pushToHistory
- * early-returns without flipping either flag when the pre-merge state equals
- * the last history snapshot.
+ * ---------------------------------------------------------------------------
+ * WHY THE FOLLOW-UP AUTOSAVE IS LEFT IN PLACE (B2, argued)
+ * ---------------------------------------------------------------------------
+ * The review offered "suppress the receipt-echo autosave OR advance the saved
+ * snapshot". Both were rejected on evidence, because the echo save is NOT the
+ * defect once this reconcile is correct, and it is load-bearing:
+ *
+ *   1. The echo can no longer write stale state. useScenario's debounced save
+ *      re-reads the store AT FIRE TIME (useScenario.ts:153), it does not
+ *      persist a snapshot captured when the timer was scheduled, and
+ *      clearTimeout collapses overlapping edits into one write. So once the
+ *      STORE holds CEE's values, the write carries CEE's values. The staleness
+ *      was never in the save path — it was in this merge refusing to update.
+ *   2. Suppressing it would cause layout loss. CEE's own persistence
+ *      (`mergeAppliedGraphForPersistence`, edit-graph-dispatch.ts:1131-1135)
+ *      overwrites the whole `nodes` array of `scenarios.graph` with the
+ *      GraphV3-parsed applied graph, which has no position fields. So at the
+ *      moment a receipt arrives the DB has already LOST the user's layout, and
+ *      the UI's save is the only thing that restores it. Suppressing the save
+ *      would make every AI edit silently scramble the user's canvas on reload.
+ *
+ * The residual — that this save and a concurrent CEE write can race in the
+ * 1500ms window — is the shared-writer/CAS problem (review C1/A3), not B2, and
+ * is deliberately not addressed here.
+ *
+ * Freshness: deliberately NOT marking the local dirty overlay by hand here.
+ * The same response carries CEE's post-apply analysis_ready.freshness verdict
+ * (routed through applyV5State step 4 setAnalysisFreshness before this
+ * reconcile runs); that verdict is authoritative for exactly this graph.
+ * graphEditedSinceLastRun / analysisStateReady are set EXPLICITLY in the
+ * commit below: pushToHistory early-returns without flipping either flag when
+ * the pre-merge state equals the last history snapshot.
  */
 
 import { useCanvasStore } from '../store'
@@ -58,6 +125,7 @@ import { validateNodesBatch } from '../domain/nodes'
 import { logger } from '../../lib/logger'
 import { saveAutosave } from '../store/scenarios'
 import { pulseAppliedTargets } from './appliedEditPulse'
+import { canvasEdgePairKey, wireEdgePairKey } from './graphIdentity'
 import {
   backfillInterventionsOntoOptionNodes,
   mapDraftEdgeToCanvas,
@@ -70,14 +138,125 @@ const ADDED_COLUMN_X_GAP = 260
 /** Vertical spacing between stacked added nodes. */
 const ADDED_COLUMN_Y_STEP = 140
 
-export interface MergeAppliedGraphResult {
+export interface ReconcileAppliedGraphResult {
   addedNodeCount: number
   addedEdgeCount: number
+  updatedNodeCount: number
+  updatedEdgeCount: number
+  removedNodeCount: number
+  removedEdgeCount: number
 }
 
-export function mergeAppliedGraphAdditive(
+const NO_CHANGE: ReconcileAppliedGraphResult = {
+  addedNodeCount: 0,
+  addedEdgeCount: 0,
+  updatedNodeCount: 0,
+  updatedEdgeCount: 0,
+  removedNodeCount: 0,
+  removedEdgeCount: 0,
+}
+
+/**
+ * The edge `data` the mapper produces for a wire edge carrying NO analytical
+ * fields — i.e. pure mapper defaults (DEFAULT_EDGE_DATA plus derived
+ * fallbacks). DERIVED from the mapper, never hand-listed: a hand-maintained
+ * list of "which fields are defaults" would silently drift the moment
+ * mapDraftEdgeToCanvas gains a field, and would then start overwriting local
+ * edge state with defaults the wire never sent.
+ *
+ * Used to tell "the wire supplied this value" from "the mapper filled this in"
+ * when overlaying onto an EXISTING edge. Accepted, fail-safe under-application:
+ * a wire value that happens to equal the mapper default is treated as
+ * unsupplied and does not overwrite local state.
+ */
+let edgeMapperDefaultsCache: Record<string, unknown> | null = null
+function edgeMapperDefaults(): Record<string, unknown> {
+  // Computed lazily, not at module load: a throw at import time would take
+  // down every consumer of this module rather than one reconcile.
+  if (edgeMapperDefaultsCache === null) {
+    try {
+      edgeMapperDefaultsCache = (mapDraftEdgeToCanvas(
+        { from: '__baseline_src__', to: '__baseline_tgt__' },
+        0,
+      ).data ?? {}) as Record<string, unknown>
+    } catch {
+      // Fail-safe: an empty baseline means "every mapped key counts as
+      // wire-supplied", which over-applies rather than silently dropping the
+      // update. Loud enough to find, safe enough to ship.
+      edgeMapperDefaultsCache = {}
+    }
+  }
+  return edgeMapperDefaultsCache
+}
+
+/** Stable deep-equality for plain JSON-ish canvas data. */
+function sameValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Overlay a wire node's analytical fields onto an existing canvas node.
+ *
+ * Returns the SAME object reference when nothing changed, so callers can use
+ * identity to detect a no-op.
+ *
+ * Layout preservation is structural: `existing` is spread first and only
+ * `type` / `data` are replaced. `mapped.position` (always `{x:0,y:0}`) is
+ * discarded, and every other root-level React Flow field the canvas owns —
+ * position, width, height, measured, selected, dragging, style, zIndex,
+ * parentId — is carried through untouched.
+ *
+ * Field-level rule: the wire WINS on keys it carries, the canvas KEEPS keys
+ * the wire omits. Absence of a key is not treated as "clear it" — CEE's node
+ * schema is closed and omits optional fields it has no value for, and UI-side
+ * backfills (interventions, is_baseline, goal_threshold_*) live in the same
+ * `data` bag. The residual is documented and accepted: a value CEE genuinely
+ * cleared stays on the canvas until the next full draft.
+ */
+function overlayNode(existing: any, wireNode: any): any {
+  const mapped = mapDraftNodeToCanvas(wireNode)
+  const nextData = { ...(existing.data ?? {}), ...(mapped.data ?? {}) }
+  const nextType = mapped.type ?? existing.type
+
+  if (nextType === existing.type && sameValue(existing.data, nextData)) {
+    return existing
+  }
+  return { ...existing, type: nextType, data: nextData }
+}
+
+/**
+ * Overlay a wire edge's analytical fields onto an existing canvas edge.
+ * Returns the SAME reference when nothing changed.
+ *
+ * Only keys whose mapped value DIFFERS from the mapper's default baseline are
+ * applied — see EDGE_MAPPER_DEFAULTS. Without that filter every receipt would
+ * splat DEFAULT_EDGE_DATA over locally-tuned edges and churn history on every
+ * turn.
+ */
+function overlayEdge(existing: any, wireEdge: any): any {
+  const mapped = mapDraftEdgeToCanvas(wireEdge, 0)
+  const mappedData = (mapped.data ?? {}) as Record<string, unknown>
+
+  const defaults = edgeMapperDefaults()
+  const supplied: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(mappedData)) {
+    if (!sameValue(v, defaults[k])) supplied[k] = v
+  }
+  if (Object.keys(supplied).length === 0) return existing
+
+  const nextData = { ...(existing.data ?? {}), ...supplied }
+  if (sameValue(existing.data, nextData)) return existing
+  return { ...existing, data: nextData }
+}
+
+export function reconcileAppliedGraph(
   draftData: CEEDraftResponse | CEEv2Response | CEEv3Response
-): MergeAppliedGraphResult {
+): ReconcileAppliedGraphResult {
   const rawNodes: any[] =
     (draftData as any)?.nodes ?? (draftData as any)?.graph?.nodes ?? []
   const rawEdges: any[] =
@@ -93,6 +272,9 @@ export function mergeAppliedGraphAdditive(
   // misdrafted FRESH graph (fresh scenario_id + populated canvas + first
   // brief-shaped message slips past CEE's continuation guard) — grafting it
   // would union two unrelated graphs. Drop and warn instead.
+  //
+  // This guard is MORE load-bearing now than it was under the additive merge:
+  // an unrelated graph would not merely graft, it would DELETE the real one.
   if (store.nodes.length > 0 && rawNodes.length > 0) {
     const hasOverlap = rawNodes.some(
       (n: any) => n != null && typeof n.id === 'string' && existingNodeIds.has(n.id)
@@ -103,16 +285,74 @@ export function mergeAppliedGraphAdditive(
         canvasNodeCount: store.nodes.length,
         wireNodeCount: rawNodes.length,
       })
-      return { addedNodeCount: 0, addedEdgeCount: 0 }
+      return { ...NO_CHANGE }
     }
   }
-  // Endpoint-pair dedupe: an existing edge whose id was locally rewritten
-  // (fallback `e-${i}` ids from an earlier draft) must not be re-added under
-  // the wire's id. Parallel edges between the same pair are not a supported
-  // canvas shape today, so the pair key is a safe identity fallback.
-  const existingEdgePairs = new Set(
-    store.edges.map((e) => `${e.source}\u0000${e.target}`)
-  )
+
+  // --- Wire indexes ---
+  const wireNodeById = new Map<string, any>()
+  for (const n of rawNodes) {
+    if (n != null && typeof n.id === 'string' && n.id.length > 0) {
+      if (!wireNodeById.has(n.id)) wireNodeById.set(n.id, n)
+    }
+  }
+  const wireEdgeByPair = new Map<string, any>()
+  for (const e of rawEdges) {
+    if (e == null) continue
+    const key = wireEdgePairKey(e)
+    // First wins: parallel edges between one pair are not a canvas shape.
+    if (key && !wireEdgeByPair.has(key)) wireEdgeByPair.set(key, e)
+  }
+
+  // --- Removals (authorised only for elements CEE has acknowledged) ---
+  // `lastAuthoritativeGraph` is null until the UI has seen an authoritative
+  // graph for this scenario (fresh draft, prior receipt, or DB hydration), in
+  // which case nothing is removable — the fail-safe direction.
+  const authoritative = store.lastAuthoritativeGraph
+  const ackNodeIds = new Set(authoritative?.nodeIds ?? [])
+  const ackEdgePairs = new Set(authoritative?.edgePairs ?? [])
+
+  const removedNodeIds = new Set<string>()
+  for (const n of store.nodes) {
+    if (ackNodeIds.has(n.id) && !wireNodeById.has(n.id)) removedNodeIds.add(n.id)
+  }
+
+  const survivingNodes = store.nodes.filter((n) => !removedNodeIds.has(n.id))
+
+  const removedEdgeIds = new Set<string>()
+  for (const e of store.edges) {
+    // An edge whose endpoint was removed cannot survive (matches CEE's own
+    // remove_node semantics: patch-applier.ts filters connected edges).
+    if (removedNodeIds.has(e.source) || removedNodeIds.has(e.target)) {
+      removedEdgeIds.add(e.id)
+      continue
+    }
+    const key = canvasEdgePairKey(e)
+    if (key && ackEdgePairs.has(key) && !wireEdgeByPair.has(key)) {
+      removedEdgeIds.add(e.id)
+    }
+  }
+
+  // --- Updates on surviving elements ---
+  let updatedNodeCount = 0
+  const reconciledNodes = survivingNodes.map((n: any) => {
+    const wireNode = wireNodeById.get(n.id)
+    if (!wireNode) return n
+    const next = overlayNode(n, wireNode)
+    if (next !== n) updatedNodeCount += 1
+    return next
+  })
+
+  let updatedEdgeCount = 0
+  const survivingEdges = store.edges.filter((e) => !removedEdgeIds.has(e.id))
+  const reconciledEdges = survivingEdges.map((e: any) => {
+    const key = canvasEdgePairKey(e)
+    const wireEdge = key ? wireEdgeByPair.get(key) : undefined
+    if (!wireEdge) return e
+    const next = overlayEdge(e, wireEdge)
+    if (next !== e) updatedEdgeCount += 1
+    return next
+  })
 
   // --- Added nodes: on the wire, not on the canvas ---
   const missingRawNodes = rawNodes.filter(
@@ -124,11 +364,11 @@ export function mergeAppliedGraphAdditive(
   )
   const addedNodes = missingRawNodes.map((n: any) => mapDraftNodeToCanvas(n))
 
-  // Deterministic placement: a column to the right of the current bounding
+  // Deterministic placement: a column to the right of the SURVIVING bounding
   // box. Never re-layouts the user's existing nodes.
   if (addedNodes.length > 0) {
-    const xs = store.nodes.map((n) => n.position?.x ?? 0)
-    const ys = store.nodes.map((n) => n.position?.y ?? 0)
+    const xs = reconciledNodes.map((n: any) => n.position?.x ?? 0)
+    const ys = reconciledNodes.map((n: any) => n.position?.y ?? 0)
     const baseX = (xs.length ? Math.max(...xs) : 0) + ADDED_COLUMN_X_GAP
     const baseY = ys.length ? Math.min(...ys) : 0
     addedNodes.forEach((n: any, idx: number) => {
@@ -138,28 +378,34 @@ export function mergeAppliedGraphAdditive(
 
   // --- Added edges: on the wire, not on the canvas, endpoints resolvable ---
   const unionNodeIds = new Set<string>([
-    ...existingNodeIds,
+    ...reconciledNodes.map((n: any) => n.id as string),
     ...addedNodes.map((n: any) => n.id as string),
   ])
-  // Track endpoint pairs already taken — by existing canvas edges AND by
+  // Track endpoint pairs already taken — by surviving canvas edges AND by
   // earlier NEW edges in this same receipt. The commit below writes via a
   // direct setState (bypassing addEdge's duplicate guard), so two wire edges
   // sharing a pair must self-dedupe here (first wins).
-  const seenEdgePairs = new Set(existingEdgePairs)
+  const seenEdgePairs = new Set<string>(
+    reconciledEdges
+      .map((e: any) => canvasEdgePairKey(e))
+      .filter((k): k is string => k !== null)
+  )
+  const survivingEdgeIds = new Set(reconciledEdges.map((e: any) => e.id))
   const missingRawEdges = rawEdges.filter((e: any) => {
     if (e == null) return false
-    const from = e.from ?? e.source
-    const to = e.to ?? e.target
-    if (typeof from !== 'string' || typeof to !== 'string') return false
-    if (typeof e.id === 'string' && existingEdgeIds.has(e.id)) return false
-    if (seenEdgePairs.has(`${from}\u0000${to}`)) return false
+    const key = wireEdgePairKey(e)
+    if (key === null) return false
+    if (typeof e.id === 'string' && survivingEdgeIds.has(e.id)) return false
+    if (seenEdgePairs.has(key)) return false
     // Fail-closed: never add a dangling edge (e.g. wire endpoint the user
     // deleted locally and the receipt re-references).
+    const from = e.from ?? e.source
+    const to = e.to ?? e.target
     if (!unionNodeIds.has(from) || !unionNodeIds.has(to)) return false
-    seenEdgePairs.add(`${from}\u0000${to}`)
+    seenEdgePairs.add(key)
     return true
   })
-  const usedEdgeIds = new Set<string>(existingEdgeIds)
+  const usedEdgeIds = new Set<string>([...existingEdgeIds, ...survivingEdgeIds])
   const addedEdges = missingRawEdges.map((e: any, i: number) => {
     const mapped = mapDraftEdgeToCanvas(e, i)
     // The mapper's fallback id (`e-${i}`) indexes the wire array — make it
@@ -170,16 +416,40 @@ export function mergeAppliedGraphAdditive(
     return { ...mapped, id }
   })
 
-  if (addedNodes.length === 0 && addedEdges.length === 0) {
-    return { addedNodeCount: 0, addedEdgeCount: 0 }
+  const result: ReconcileAppliedGraphResult = {
+    addedNodeCount: addedNodes.length,
+    addedEdgeCount: addedEdges.length,
+    updatedNodeCount,
+    updatedEdgeCount,
+    removedNodeCount: removedNodeIds.size,
+    removedEdgeCount: removedEdgeIds.size,
   }
 
-  // --- Commit: one history entry, additive store write ---
+  const changed =
+    result.addedNodeCount > 0 ||
+    result.addedEdgeCount > 0 ||
+    result.updatedNodeCount > 0 ||
+    result.updatedEdgeCount > 0 ||
+    result.removedNodeCount > 0 ||
+    result.removedEdgeCount > 0
+
+  // Record what CEE has acknowledged even on a no-op: the receipt is proof
+  // that CEE has seen exactly these elements, which is what authorises a
+  // LATER receipt to delete them. Doing this only on a change would leave the
+  // set stale after an idempotent turn.
+  useCanvasStore.getState().setLastAuthoritativeGraph({
+    nodeIds: [...wireNodeById.keys()],
+    edgePairs: [...wireEdgeByPair.keys()],
+  })
+
+  if (!changed) return result
+
+  // --- Commit: one history entry, one atomic store write ---
   const canvas = useCanvasStore.getState()
   canvas.pushHistory()
   useCanvasStore.setState({
-    nodes: [...canvas.nodes, ...addedNodes],
-    edges: [...canvas.edges, ...addedEdges],
+    nodes: [...reconciledNodes, ...addedNodes] as any,
+    edges: [...reconciledEdges, ...addedEdges] as any,
   })
 
   // Staleness flags set EXPLICITLY (not via pushToHistory, which early-returns
@@ -195,14 +465,26 @@ export function mergeAppliedGraphAdditive(
   // Seamlessness R2: acknowledge the AI's applied edit with the SAME
   // coalesced 2s highlight the graph_patch path uses — pulse only, no
   // selection/viewport hijack. Fail-closed downstream against the canvas.
+  // Updated elements pulse too: a changed value the user cannot see change is
+  // the display half of the same defect.
   pulseAppliedTargets({
-    nodeIds: addedNodes.map((n: any) => n.id as string),
-    edgeIds: addedEdges.map((e: any) => e.id as string),
+    nodeIds: [
+      ...addedNodes.map((n: any) => n.id as string),
+      ...reconciledNodes
+        .filter((n: any, i: number) => n !== survivingNodes[i])
+        .map((n: any) => n.id as string),
+    ],
+    edgeIds: [
+      ...addedEdges.map((e: any) => e.id as string),
+      ...reconciledEdges
+        .filter((e: any, i: number) => e !== survivingEdges[i])
+        .map((e: any) => e.id as string),
+    ],
   })
 
   // Newly added option nodes need node.data.interventions mirrored from
   // analysis_ready (OptionNode render, islRequestAdapter fallback readers).
-  // applyV5State step 4 wrote ceeAnalysisReady BEFORE this merge ran, when
+  // applyV5State step 4 wrote ceeAnalysisReady BEFORE this reconcile ran, when
   // the option node did not yet exist — close the loop now. Idempotent.
   const analysisReady = useCanvasStore.getState().ceeAnalysisReady
   if (analysisReady) {
@@ -222,5 +504,5 @@ export function mergeAppliedGraphAdditive(
     // Non-critical — swallow save errors
   }
 
-  return { addedNodeCount: addedNodes.length, addedEdgeCount: addedEdges.length }
+  return result
 }

--- a/src/canvas/utils/persistedGraph.ts
+++ b/src/canvas/utils/persistedGraph.ts
@@ -1,0 +1,109 @@
+/**
+ * persistedGraph — the canonical shape of the `scenarios.graph` JSONB column.
+ *
+ * B3 (Codex deep review, 2026-07-18). Before this module the column was
+ * written as `{ nodes, edges }` and read back as `{ nodes, edges }`, so a
+ * scenario's hard constraints were session-only:
+ *
+ *   - the browser's full-graph save carried only `{ nodes, edges }`, which
+ *     STRIPPED any top-level `goal_constraints` already persisted into that
+ *     column, and
+ *   - `useScenario.loadScenario` reconstructed only `{ nodes, edges }`, so a
+ *     cold load could not restore a constraint even when one was stored.
+ *
+ * The constraint therefore survived only in memory, which is also why it
+ * leaked across a scenario switch (see DECISION_CONTEXT_CLEAR in store.ts).
+ *
+ * WIRE-KEY CHOICE: the persisted key is `goal_constraints` (snake_case),
+ * matching the CEE/@talchain/schemas wire name, NOT the store's camelCase
+ * `goalConstraints`. The column is a cross-boundary artefact — CEE reads and
+ * writes it too — so it keeps the wire spelling; the camelCase name stops at
+ * the store. Both spellings are accepted on READ so a row written by either
+ * side hydrates (fail-open on read, canonical on write).
+ *
+ * The graph HASH is deliberately still computed over `{ nodes, edges }` only
+ * (see scenarioService.saveGraphViaGatedPath): the hash is compared against
+ * CEE's own graph hash, and adding a key to the hashed surface would fork
+ * the two hash definitions. Constraints ride the column, not the hash.
+ */
+
+import type { CEEGoalConstraint } from '../../adapters/cee/types'
+
+/** The persisted `scenarios.graph` payload. */
+export interface PersistedGraph<TNode = unknown, TEdge = unknown> {
+  nodes: TNode[]
+  edges: TEdge[]
+  /** Canonical persisted spelling — matches the CEE wire, not the store. */
+  goal_constraints?: CEEGoalConstraint[] | null
+}
+
+/**
+ * Defensive read of `goal_constraints` out of a `scenarios.graph` JSONB value.
+ *
+ * Returns `null` for every shape that is not a non-empty array of
+ * constraint-like objects. JSONB is untyped at the boundary and this value is
+ * fed straight to the run request, so a malformed row must degrade to "no
+ * constraint" rather than shipping junk to PLoT.
+ *
+ * An EMPTY array also returns null: `[]` and "absent" mean the same thing to
+ * every downstream reader (isGoalDefined, GoalPanel, the run request), and
+ * collapsing them here keeps the round-trip assertion unambiguous.
+ */
+export function readPersistedGoalConstraints(
+  graph: unknown,
+): CEEGoalConstraint[] | null {
+  if (graph == null || typeof graph !== 'object') return null
+
+  const raw =
+    (graph as { goal_constraints?: unknown }).goal_constraints ??
+    // Fail-open: tolerate a row written with the store's camelCase spelling.
+    (graph as { goalConstraints?: unknown }).goalConstraints
+
+  if (!Array.isArray(raw) || raw.length === 0) return null
+
+  const valid = raw.filter(isConstraintLike)
+  return valid.length > 0 ? valid : null
+}
+
+/**
+ * Minimum shape a persisted constraint must have to be usable.
+ *
+ * `operator` and `value` are the only fields every consumer dereferences
+ * unconditionally (`id`/`constraint_id`/`label` are all documented-optional on
+ * CEEGoalConstraint), so they are the only ones required here. Anything
+ * looser would let a `{}` through and re-open the class of bug where a
+ * constraint renders as an empty row.
+ */
+function isConstraintLike(c: unknown): c is CEEGoalConstraint {
+  if (c == null || typeof c !== 'object') return false
+  const { operator, value } = c as { operator?: unknown; value?: unknown }
+  return (
+    (operator === '>=' ||
+      operator === '<=' ||
+      operator === '>' ||
+      operator === '<' ||
+      operator === '=') &&
+    typeof value === 'number' &&
+    Number.isFinite(value)
+  )
+}
+
+/**
+ * Build the canonical persisted payload.
+ *
+ * `goal_constraints` is emitted ONLY when there is something to persist, so a
+ * constraint-free scenario keeps writing the historical `{ nodes, edges }`
+ * bytes exactly — no churn in the saved snapshot, and no new key appearing on
+ * every row in the estate.
+ */
+export function buildPersistedGraph<TNode, TEdge>(
+  nodes: TNode[],
+  edges: TEdge[],
+  goalConstraints: CEEGoalConstraint[] | null | undefined,
+): PersistedGraph<TNode, TEdge> {
+  const base: PersistedGraph<TNode, TEdge> = { nodes, edges }
+  if (Array.isArray(goalConstraints) && goalConstraints.length > 0) {
+    base.goal_constraints = goalConstraints
+  }
+  return base
+}

--- a/src/hooks/__tests__/useScenario.goalConstraints.lifecycle.spec.ts
+++ b/src/hooks/__tests__/useScenario.goalConstraints.lifecycle.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * B3 (Codex deep review, 2026-07-18) — `goal_constraints` lifecycle.
+ *
+ * Before this lane the constraint was SESSION-ONLY, which broke in two
+ * opposite directions:
+ *
+ *   1. LEAK A→B. The production hydration clear-set (DECISION_CONTEXT_CLEAR,
+ *      consumed by hydrateGraphSlice) listed every other member of the goal
+ *      context but not `goalConstraints`. Switching from a scenario with a
+ *      £50k cap to one with none left the cap in place, and B's first run
+ *      could ship A's constraint.
+ *   2. LOST ON COLD LOAD. `useScenario.loadScenario` reconstructed only
+ *      `{ nodes, edges }` from the row, and the autosave WROTE only
+ *      `{ nodes, edges }` — which also stripped any top-level
+ *      `goal_constraints` CEE had persisted into that column.
+ *
+ * The existing positive control for the IMMEDIATE path is
+ * `canvas/conversation/__tests__/draftGoalConstraints.wire.spec.ts`: it proves
+ * real CEE wire bytes reach the store. That half already worked and is
+ * deliberately untouched. This file covers the half that did not: PERSISTENCE
+ * and HYDRATION.
+ *
+ * Both cases below fail on the pre-fix HEAD — case 1 retains A's constraint,
+ * case 2 restores nothing.
+ *
+ * Deliberately NOT mocking scenarioService: the defect lived in the exact
+ * bytes handed to / read back from the gated RPC, so a mocked service would
+ * assert against the wrong surface (the same trap documented at the top of
+ * useScenario.gatedWrite.integration.spec.ts).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// --- supabase (the real boundary) ------------------------------------------
+const mockRpc = vi.fn()
+let mockRowsById: Record<string, Record<string, unknown>> = {}
+
+const mockSingle = vi.fn()
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: (_col: string, id: string) => ({
+          single: () => mockSingle(id),
+        }),
+      }),
+      update: () => ({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+    }),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  },
+}))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+
+const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: REAL_USER_ID }, authenticated: true }),
+}))
+
+import { useScenario } from '../useScenario'
+import { useCanvasStore } from '../../canvas/store'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CAP_50K = [
+  {
+    constraint_id: 'constraint_spend_max',
+    node_id: 'factor-1',
+    operator: '<=' as const,
+    value: 50000,
+    unit: 'GBP',
+  },
+]
+
+const NODES = [
+  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Revenue' } },
+  { id: 'factor-1', type: 'factor', position: { x: 0, y: 100 }, data: { kind: 'factor', label: 'Spend' } },
+]
+
+function scenarioRow(id: string, graph: unknown): Record<string, unknown> {
+  return {
+    id,
+    graph,
+    framing: null,
+    stage: 'analyse',
+    updated_at: new Date().toISOString(),
+    analysis_status: 'none',
+    analysis: null,
+    analysis_provenance: null,
+    analysis_error: null,
+    thread: null,
+    events: null,
+  }
+}
+
+/** The `p_graph` of the most recent gated write. */
+function lastWrittenGraph(): Record<string, unknown> | null {
+  const calls = mockRpc.mock.calls.filter((c) => c[0] === 'apply_patch_and_log')
+  if (calls.length === 0) return null
+  return (calls[calls.length - 1][1] as Record<string, unknown>)
+    .p_graph as Record<string, unknown>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRowsById = {}
+  mockSingle.mockImplementation(async (id: string) =>
+    mockRowsById[id]
+      ? { data: mockRowsById[id], error: null }
+      : { data: null, error: { code: 'PGRST116' } },
+  )
+  mockRpc.mockResolvedValue({ data: {}, error: null })
+  useCanvasStore.getState().setGoalConstraints(null)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+// Case 1 — the LEAK: A (non-empty) → B (absent) must CLEAR
+// ---------------------------------------------------------------------------
+
+describe('B3 — goal_constraints do not leak across a scenario switch', () => {
+  it('switching from a scenario WITH a constraint to one WITHOUT clears it', async () => {
+    mockRowsById['scenario-A'] = scenarioRow('scenario-A', {
+      nodes: NODES,
+      edges: [],
+      goal_constraints: CAP_50K,
+    })
+    // B genuinely has no constraint — the key is absent, as it is for every
+    // scenario created before this lane.
+    mockRowsById['scenario-B'] = scenarioRow('scenario-B', {
+      nodes: NODES,
+      edges: [],
+    })
+
+    const { result } = renderHook(() => useScenario())
+
+    await act(async () => {
+      await result.current.loadScenario('scenario-A')
+    })
+
+    // Precondition — A's constraint really did land. Without this assertion
+    // the clear below could pass against a value that was never there.
+    expect(useCanvasStore.getState().goalConstraints).toHaveLength(1)
+    expect(useCanvasStore.getState().goalConstraints![0].value).toBe(50000)
+
+    await act(async () => {
+      await result.current.loadScenario('scenario-B')
+    })
+
+    // THE DEFECT: this was A's constraint, still sitting on B, ready to be
+    // sent on B's first run.
+    expect(useCanvasStore.getState().goalConstraints).toBeNull()
+  })
+
+  it('switching between two scenarios that BOTH have constraints installs the new one', () => {
+    // Guards against "fixed the leak by always clearing" — a clear-only fix
+    // would pass the case above and still lose every real constraint.
+    mockRowsById['scenario-A'] = scenarioRow('scenario-A', {
+      nodes: NODES,
+      edges: [],
+      goal_constraints: CAP_50K,
+    })
+    mockRowsById['scenario-C'] = scenarioRow('scenario-C', {
+      nodes: NODES,
+      edges: [],
+      goal_constraints: [{ ...CAP_50K[0], constraint_id: 'c_other', value: 120000 }],
+    })
+
+    const { result } = renderHook(() => useScenario())
+
+    return act(async () => {
+      await result.current.loadScenario('scenario-A')
+      expect(useCanvasStore.getState().goalConstraints![0].value).toBe(50000)
+      await result.current.loadScenario('scenario-C')
+      expect(useCanvasStore.getState().goalConstraints).toHaveLength(1)
+      expect(useCanvasStore.getState().goalConstraints![0].value).toBe(120000)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Case 2 — the ROUND TRIP: save → cold load must PRESERVE
+// ---------------------------------------------------------------------------
+
+describe('B3 — goal_constraints survive save → cold load', () => {
+  it('a constraint held in memory is written to the graph column and restored on reload', async () => {
+    vi.useFakeTimers()
+
+    // Cold-load a constraint-free scenario, then have CEE deliver a
+    // constraint into the store (what applyDraftResult does on a real turn).
+    mockRowsById['scenario-A'] = scenarioRow('scenario-A', { nodes: NODES, edges: [] })
+
+    const { result, unmount } = renderHook(() => useScenario())
+
+    await act(async () => {
+      await result.current.loadScenario('scenario-A')
+    })
+    expect(useCanvasStore.getState().goalConstraints).toBeNull()
+
+    // A turn arrives carrying the cap, and the graph changes with it.
+    await act(async () => {
+      useCanvasStore.getState().setGoalConstraints(CAP_50K as never)
+      useCanvasStore.setState({
+        nodes: [...NODES, { id: 'factor-2', type: 'factor', position: { x: 0, y: 200 }, data: { kind: 'factor', label: 'Risk' } }],
+      } as never)
+      await vi.advanceTimersByTimeAsync(1600) // past GRAPH_DEBOUNCE_MS
+    })
+
+    // HALF 1 — the constraint actually reached the persisted payload. Before
+    // this lane `p_graph` was `{ nodes, edges }` and this key did not exist.
+    const written = lastWrittenGraph()
+    expect(written).not.toBeNull()
+    expect(written!.goal_constraints).toBeDefined()
+    expect((written!.goal_constraints as unknown[])).toHaveLength(1)
+    expect((written!.goal_constraints as Array<{ value: number }>)[0].value).toBe(50000)
+
+    // The hash is still derived over nodes+edges only — widening it would
+    // fork this UI's definition from CEE's.
+    const rpcArgs = mockRpc.mock.calls.filter((c) => c[0] === 'apply_patch_and_log').pop()![1] as Record<string, unknown>
+    expect((rpcArgs.p_hashes as { graph_hash?: string }).graph_hash).toBeTruthy()
+
+    unmount()
+
+    // HALF 2 — COLD LOAD. Feed back exactly the bytes that were written,
+    // into a fresh store with the constraint cleared: nothing survives in
+    // memory, so anything present afterwards came out of the column.
+    vi.useRealTimers()
+    useCanvasStore.getState().setGoalConstraints(null)
+    mockRowsById['scenario-A'] = scenarioRow('scenario-A', written)
+
+    const reloaded = renderHook(() => useScenario())
+    await act(async () => {
+      await reloaded.result.current.loadScenario('scenario-A')
+    })
+
+    expect(useCanvasStore.getState().goalConstraints).toHaveLength(1)
+    expect(useCanvasStore.getState().goalConstraints![0].value).toBe(50000)
+    expect(useCanvasStore.getState().goalConstraints![0].operator).toBe('<=')
+  })
+
+  it('a malformed persisted constraint degrades to null rather than reaching a run', async () => {
+    // The column is untyped JSONB and this value feeds the run request.
+    mockRowsById['scenario-junk'] = scenarioRow('scenario-junk', {
+      nodes: NODES,
+      edges: [],
+      goal_constraints: [{ label: 'no operator, no value' }, 'not an object'],
+    })
+
+    const { result } = renderHook(() => useScenario())
+    await act(async () => {
+      await result.current.loadScenario('scenario-junk')
+    })
+
+    expect(useCanvasStore.getState().goalConstraints).toBeNull()
+  })
+})

--- a/src/hooks/__tests__/useScenario.spec.ts
+++ b/src/hooks/__tests__/useScenario.spec.ts
@@ -283,6 +283,11 @@ describe('useScenario', () => {
           },
         ],
         currentScenarioId: 'scenario-1',
+        // B3: every full-context load now assigns the loaded constraints OR
+        // null. This row has none, so null — asserted explicitly, because
+        // "key absent" was exactly the bug (it let the previous scenario's
+        // constraint ride the new one).
+        goalConstraints: null,
       })
 
       // Verify framing and metadata were set

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -24,6 +24,7 @@ import type { ScenarioStage, AnalysisProvenance, AnalysisStatus } from '../types
 import { hydrateAnalysisFromV2Response } from './hydrateAnalysis'
 import type { Edge } from '@xyflow/react'
 import { DEFAULT_EDGE_DATA, type EdgeData } from '../canvas/domain/edges'
+import { readPersistedGoalConstraints } from '../canvas/utils/persistedGraph'
 
 export type SaveStatus = 'saved' | 'saving' | 'error'
 
@@ -69,6 +70,28 @@ export interface UseScenarioReturn {
 const GRAPH_DEBOUNCE_MS = 1500
 const FRAMING_DEBOUNCE_MS = 1500
 const RETRY_DELAY_MS = 3000
+
+/**
+ * The "have I already saved this?" key for the debounced graph autosave.
+ *
+ * ONE definition, used by the subscription, the save, the retry, and the
+ * post-load priming. It previously existed as four hand-written
+ * `JSON.stringify({ nodes, edges })` copies; B3 had to add a third field to
+ * the payload, and a copy missed would have meant either a save storm (key
+ * never matches) or a silently dropped constraint (key matches when the
+ * payload differs).
+ */
+function graphSaveKey(s: {
+  nodes: unknown
+  edges: unknown
+  goalConstraints: unknown
+}): string {
+  return JSON.stringify({
+    nodes: s.nodes,
+    edges: s.edges,
+    goalConstraints: s.goalConstraints ?? null,
+  })
+}
 
 export function useScenario(): UseScenarioReturn {
   const { user, authenticated } = useAuth()
@@ -125,15 +148,21 @@ export function useScenario(): UseScenarioReturn {
 
   useEffect(() => {
     const unsubscribe = useCanvasStore.subscribe((state, prevState) => {
-      // Only react to nodes/edges changes
-      if (state.nodes === prevState.nodes && state.edges === prevState.edges) return
+      // React to nodes/edges changes — and to goalConstraints, which B3 made
+      // part of the persisted graph payload. Without the third check a
+      // constraint arriving on a turn that did not touch the graph would
+      // never reach the database.
+      if (
+        state.nodes === prevState.nodes &&
+        state.edges === prevState.edges &&
+        state.goalConstraints === prevState.goalConstraints
+      ) return
 
       const sid = scenarioIdRef.current
       if (!isPersistenceActiveRef.current || !sid) return
       if (!mountedRef.current) return
 
-      const { nodes, edges } = state
-      const graphSnapshot = JSON.stringify({ nodes, edges })
+      const graphSnapshot = graphSaveKey(state)
       if (graphSnapshot === lastSavedGraphRef.current) return
 
       // Mark results as stale when graph changes after a completed analysis
@@ -155,8 +184,10 @@ export function useScenario(): UseScenarioReturn {
             saveSid,
             { nodes: currentState.nodes, edges: currentState.edges },
             crypto.randomUUID(),
+            undefined,
+            currentState.goalConstraints,
           )
-          lastSavedGraphRef.current = JSON.stringify({ nodes: currentState.nodes, edges: currentState.edges })
+          lastSavedGraphRef.current = graphSaveKey(currentState)
           if (mountedRef.current) {
             const now = Date.now()
             setSaveStatus('saved')
@@ -180,8 +211,10 @@ export function useScenario(): UseScenarioReturn {
                 retrySid,
                 { nodes: retryState.nodes, edges: retryState.edges },
                 crypto.randomUUID(),
+                undefined,
+                retryState.goalConstraints,
               )
-              lastSavedGraphRef.current = JSON.stringify({ nodes: retryState.nodes, edges: retryState.edges })
+              lastSavedGraphRef.current = graphSaveKey(retryState)
               if (mountedRef.current) {
                 const now = Date.now()
                 setSaveStatus('saved')
@@ -260,10 +293,12 @@ export function useScenario(): UseScenarioReturn {
         clearTimeout(graphSaveTimerRef.current)
         const sid = scenarioIdRef.current
         if (sid) {
-          const { nodes: n, edges: e } = useCanvasStore.getState()
-          scenarioService.saveGraphViaGatedPath(sid, { nodes: n, edges: e }, crypto.randomUUID()).catch((err) => {
-            console.error('[useScenario] Unmount graph flush failed:', err)
-          })
+          const { nodes: n, edges: e, goalConstraints: gc } = useCanvasStore.getState()
+          scenarioService
+            .saveGraphViaGatedPath(sid, { nodes: n, edges: e }, crypto.randomUUID(), undefined, gc)
+            .catch((err) => {
+              console.error('[useScenario] Unmount graph flush failed:', err)
+            })
         }
       }
       if (framingSaveTimerRef.current) {
@@ -397,20 +432,32 @@ export function useScenario(): UseScenarioReturn {
         },
       }))
 
+      // B3: the scenario's persisted hard constraints. Read defensively —
+      // this is untyped JSONB and the value feeds the run request.
+      const loadedGoalConstraints = readPersistedGoalConstraints(row.graph)
+
       // Update local refs BEFORE hydrating the store to prevent the
       // subscription callbacks from scheduling a redundant re-save when
-      // hydrateGraphSlice fires synchronous store updates.
-      lastSavedGraphRef.current = JSON.stringify({
+      // hydrateGraphSlice fires synchronous store updates. The key MUST
+      // include the constraints for the same reason it includes the graph:
+      // priming it with a different value than the store is about to hold
+      // would schedule an immediate no-op save on every scenario open.
+      lastSavedGraphRef.current = graphSaveKey({
         nodes: graphNodes,
         edges: graphEdges,
+        goalConstraints: loadedGoalConstraints,
       })
       lastSavedFramingRef.current = JSON.stringify(row.framing ?? null)
 
-      // Hydrate graph slice (resets history, selection, reseeds IDs)
+      // Hydrate graph slice (resets history, selection, reseeds IDs).
+      // B3: goalConstraints is passed on EVERY load — the value or null. It
+      // is not conditional, because "this scenario has no constraint" must
+      // overwrite the previous scenario's, not fall through to it.
       useCanvasStore.getState().hydrateGraphSlice({
         nodes: graphNodes,
         edges: graphEdges,
         currentScenarioId: row.id,
+        goalConstraints: loadedGoalConstraints,
       })
 
       // Hydrate framing + stage.

--- a/src/services/__tests__/scenarioService.spec.ts
+++ b/src/services/__tests__/scenarioService.spec.ts
@@ -233,7 +233,13 @@ describe('scenarioService', () => {
       const [rpcName, params] = mockRpc.mock.calls[0] as [string, Record<string, unknown>]
       expect(rpcName).toBe('apply_patch_and_log')
       expect(params.p_scenario_id).toBe('scenario-1')
-      expect(params.p_graph).toBe(GRAPH)
+      // B3: p_graph is now BUILT (buildPersistedGraph) rather than passed
+      // through by reference, so identity no longer holds. The contract that
+      // matters is the VALUE — and specifically that a constraint-free save
+      // still writes exactly the historical { nodes, edges } bytes, with no
+      // stray goal_constraints key appearing on every row in the estate.
+      expect(params.p_graph).toEqual({ nodes: GRAPH.nodes, edges: GRAPH.edges })
+      expect(params.p_graph).not.toHaveProperty('goal_constraints')
       expect(params.p_event_id).toBe(VALID_EVENT_ID)
       expect(params.p_event_type).toBe('graph_saved')
       expect(params.p_turn_id).toBeNull()

--- a/src/services/scenarioService.ts
+++ b/src/services/scenarioService.ts
@@ -22,6 +22,10 @@ import { clearSuppressedScenarioId } from './threadService'
 // was written, independent of any run/seed. Both are pure (type-only imports +
 // a pure edge-key fn), so importing here introduces no React/store dependency.
 import { generateGraphHash } from '../canvas/utils/graphHash'
+// B3: the canonical `scenarios.graph` payload shape. Pure builder — no store
+// or React dependency, consistent with this module's constraints.
+import { buildPersistedGraph } from '../canvas/utils/persistedGraph'
+import type { CEEGoalConstraint } from '../adapters/cee/types'
 import type {
   ScenarioRow,
   ScenarioListItem,
@@ -172,13 +176,26 @@ export async function saveGraphViaGatedPath(
   graph: { nodes: Node[]; edges: Edge[] },
   eventId: string,
   turnId?: string,
+  /**
+   * B3: the scenario's validated hard constraints, persisted INTO the same
+   * `scenarios.graph` payload. Passed through the SAME single gated RPC — this
+   * adds a key to the payload, it does not add a write path (the
+   * single-gated-mutation-path property from PR #364 is unchanged).
+   *
+   * Omitted/null/empty writes the historical `{ nodes, edges }` bytes exactly.
+   */
+  goalConstraints?: CEEGoalConstraint[] | null,
 ): Promise<void> {
   const { error } = await supabase.rpc('apply_patch_and_log', {
     p_scenario_id: scenarioId,
-    p_graph: graph,
+    p_graph: buildPersistedGraph(graph.nodes, graph.edges, goalConstraints),
     p_event_id: eventId,
     p_event_type: 'graph_saved',
     p_details: {},
+    // Hash stays over { nodes, edges } ONLY. It is compared against CEE's own
+    // graph hash, so widening the hashed surface here would fork the two
+    // definitions and make every scenario read as changed. Constraints ride
+    // the column, not the hash.
     p_hashes: { graph_hash: generateGraphHash(graph.nodes, graph.edges) },
     p_turn_id: turnId ?? null,
   })


### PR DESCRIPTION
Fixes **B2** and **B3** from the Codex deep review. They share `useScenario.ts` and the same root theme — the UI's handling of authoritative server state — which is why they are one lane.

Base: `staging` @ `b4c38a1a`. The brief named `3578e272e`; staging had advanced two commits (`5f782ff6`, `b4c38a1a`), neither related.

---

## B2 — a CEE edit could commit correctly, display stale, then be rolled back

### What the receipt actually contains (verified, not assumed)

The old code carried this comment:

> *"Value updates on existing elements arrive separately as `graph_patch` blocks (applyV5State); removals have no ingestion path yet."*

**That was false**, and it was the reason the merge was additive-only. Verified against CEE `staging@10633948`:

| Claim | Reality |
|---|---|
| updates arrive as `graph_patch` | `buildBoundaryBlocks` opens `if (!result.wasRejected) return []` — a successful edit returns **no blocks at all** (`edit-graph-dispatch.ts:832-833`). `graph_patch` reaches the wire only from `compose.ts:338-345`, gated on the three D1 typed-handler facts — and those turns carry a full `draft_graph` too. On the `edit_graph` path a *rejected* edit becomes an `error` block (`:859-866`); a successful one carries only the graph. |
| receipt is a delta | It is the **entire committed post-state** — `buildAppliedGraphWireField` emits `graph.nodes`/`graph.edges` wholesale (`applied-graph-emit.ts:41-48`). |
| removals have no path | **Absence *is* the deletion signal.** `patch-applier.ts:105-117` splices the node and filters its edges; CEE infers option deletion purely from absence (`edit-graph-dispatch.ts:1148-1153`). |
| — | The receipt carries **no layout**. `NodeV3` (`schemas/cee-v3.ts:89-144`) is closed and analytical-only — no `position`. |

CEE's own docstring (`edit-graph-dispatch.ts:809-818`) had already corrected this myth server-side. **The comment is fixed** and now cites the evidence.

### The failure

"Set Spend from 100 to 250 and add Risk" → CEE commits both → the additive merge adds Risk, leaves Spend on 100 → the store changed, so the 1500ms autosave fires and writes the stale **100 back over CEE's committed 250**. The user is told it worked; 1.5s later it is silently undone.

### The fix

`mergeAppliedGraphAdditive` → **`reconcileAppliedGraph`**: an atomic three-way reconcile in one history entry. Renamed because "Additive" would now be an actively false label.

- **Updates** overlay analytical fields onto the *existing* element, so **layout is preserved by construction** — the existing node is spread first and the mapper's `position` is discarded, keeping position/width/height/measured/selected/dragging. Field rule: the wire wins on keys it carries, the canvas keeps keys the wire omits (so UI-side backfills — `interventions`, `is_baseline`, `goal_threshold_*` — are not wiped).
- **Deletions** are authorised only for elements CEE has previously **acknowledged** (new `lastAuthoritativeGraph`, seeded from DB hydration, a fresh draft, or a prior receipt). CEE builds its post-state from the *persisted* graph and the UI's save is debounced, so absence alone would have deleted unsaved local work — trading B2 for something worse. Default is "acknowledge nothing" ⇒ remove nothing.
- **Edge updates** apply only fields differing from the mapper's own default baseline, **derived from the mapper** rather than hand-listed, so a receipt cannot splat `DEFAULT_EDGE_DATA` over locally-tuned edges.

### On the echo autosave — I did not suppress it, and this is deliberate

The brief offered "suppress the receipt-echo autosave **or** advance the saved revision/snapshot". I did neither, on evidence:

1. **It can no longer write stale state.** `useScenario`'s debounced save re-reads the store **at fire time** (`useScenario.ts:153`) — it does not persist a snapshot captured at schedule time, and `clearTimeout` collapses overlapping edits into one write. The staleness was never in the save path; it was in the merge refusing to update. Fixing the reconcile closes the vector at source.
2. **Suppressing it would cause layout loss.** CEE's `mergeAppliedGraphForPersistence` (`edit-graph-dispatch.ts:1131-1135`) overwrites the whole `nodes` array of `scenarios.graph` with position-free GraphV3. So when a receipt arrives **the DB has already lost the user's layout**, and the UI's save is the only thing that restores it. Suppressing would swap a value-loss bug for a layout-loss bug.

Both options as literally stated would have introduced a new defect, so the reasoning is recorded in the module header rather than applied silently. **Happy to be overruled** — but it should be an informed call.

The residual — this save racing a concurrent CEE write inside the 1500ms window — is the shared-writer/CAS problem (review **C1/A3**), not B2, and is deliberately untouched.

### The corrected test — stated explicitly, as asked

`mergeAppliedGraph.spec.ts:172-188` was titled *"is a strict no-op (no history entry) when the receipt carries nothing new"* and fed a receipt where `factor-1` carried `observed_state: { value: 250 }` while the canvas held `100` — then asserted **nothing happened**. That is the defect written down as an expectation; the green suite was pinning the data loss.

It is **corrected, not deleted** → *"APPLIES an updated value on an existing node (B2 — this receipt is authoritative)"*, now asserting 250 lands, history grows by one, and position survives.

The **genuine** no-op case was not lost: a separate case feeds a receipt that really does match the canvas and asserts strict identity of both `nodes` and `edges`. Deleting the original outright would have dropped that coverage.

### Required end-to-end test

`appliedEditDurability.e2e.spec.ts` drives the real reconcile, the real `useScenario` autosave and the real `scenarioService` against a mocked Supabase, crossing all four stations the brief named: **immediate UI = 250 → past the 1500ms debounce → DB payload = 250 → reload = 250**. Asserting on the store alone would have passed the moment the reconcile was fixed while leaving the write-back live.

---

## B3 — `goal_constraints` was session-only: leaked A→B, lost on cold load

`goalConstraints` was the **one** member of the goal context missing from `DECISION_CONTEXT_CLEAR` — `READINESS_CLEAR_FIELDS` and `resetCanvas` both already cleared it; only the production load path did not. And both ends of persistence handled only `{nodes, edges}`, so the save **stripped** the key and the load could not restore it.

### Persistence contract change

New `canvas/utils/persistedGraph.ts` — one definition of the `scenarios.graph` payload, used by both writer and reader:

- Persisted key is **`goal_constraints`** (snake_case, the CEE wire spelling), because the column is a cross-boundary artefact. The camelCase name stops at the store. Reads accept **both** spellings (fail-open).
- The key is emitted **only when non-empty**, so constraint-free scenarios write byte-identical bytes to today — no churn, no new key across the estate. Pinned by an assertion in `scenarioService.spec`.
- Reads are defensive (untyped JSONB feeding a run request): anything not a well-formed constraint degrades to `null`.
- **The graph hash still covers `{nodes, edges}` only.** Widening it would fork this UI's definition from CEE's and make every scenario read as changed.
- Still the **single gated RPC** — a key added to `p_graph`, not a second write path. The PR #364 single-gated-mutation-path property is unchanged, and the events-array design (B6) is untouched.
- `hydrateGraphSlice` now takes `goalConstraints` and assigns **the loaded value or `null`** on every full-context load.

**Compatibility (checked, not assumed):** CEE's merge is `{ ...base, nodes, edges }`, its documented rule 3 preserves every other top-level key verbatim, and rule 2 states *"Top-level `goal_constraints` is NOT overlaid… the base keeps its own"* (`edit-graph-dispatch.ts:1051-1072`). So a `goal_constraints` the UI writes **survives** CEE's edit commits. Previously the UI's `{nodes, edges}` save destroyed it, leaving CEE's `...base` nothing to preserve. Rollback is inert — old code reads only `graph.nodes`/`graph.edges` and ignores the extra key.

⚠️ **Known seam worth recording:** this field is now written by *both* CEE and the UI, last-writer-wins. Same one-column-two-writers class as **C1**; not closed here.

### The two discriminating tests

`useScenario.goalConstraints.lifecycle.spec.ts` — real store, real service, mocked Supabase (deliberately *not* mocking `scenarioService`; the defect lived in the exact bytes at that boundary):

1. **A(non-empty) → B(absent) clears** — with a precondition assertion that A's constraint really landed first, so the clear cannot pass against a value that was never there. Plus an A→C case where both have constraints, to block a "fix" that just always clears.
2. **save → cold-load round-trips** — asserts the constraint reaches `p_graph`, then feeds *exactly those bytes* back into a fresh load with the store cleared, so anything present afterwards provably came out of the column.

Plus a malformed-JSONB case degrading to `null`. The existing `draftGoalConstraints.wire.spec.ts` positive control (immediate wire→store path) is untouched — that half already worked.

---

## Flag posture — argued per defect

**B2 → ship default-on, no new flag.**
The current behaviour silently destroys user data and there is no defensible "safe" reading of it to preserve; a flag would ship a known data-loss path as the default and create a second control. A9 is *not* a usable gate here — `reconcileAppliedGraph` runs on every applied-edit receipt, not only A9 turns. The one genuinely new capability, **deletion**, is made safe structurally rather than by flag: it can only remove elements CEE has already acknowledged, and defaults to removing nothing.

**B3 → ship default-on, no new flag, on compatibility evidence.**
This is the one the brief flagged for care, and I checked rather than assumed. It is safe because it is *self-limiting in both directions*: the key appears only when a constraint exists, CEE provably preserves it, and rollback is inert. A flag would gate a field absent from most scenarios anyway, while also switching off the leak fix — the half with no persistence risk at all.

---

## Gates

| Gate | Result |
|---|---|
| `pnpm build` (**the real gate**) | ✅ built in 1m 4s |
| `pnpm typecheck` | ✅ clean — **but weak**, see below |
| `npx tsc -p tsconfig.app.json` | 2320 errors at HEAD, **2320 at base**; per-file counts **identical** ⇒ zero introduced |
| eslint (touched files) | ✅ **0 errors** (19 pre-existing warnings) |
| `pnpm test` | 61 failed files / 3 failed tests vs base 60 / 2 — set diff below |

**On `pnpm typecheck` being weak — measured, not repeated:** `tsconfig.ci.json` names ~18 entries, which pull **226** src files transitively. That *does* include `store.ts` — and it caught two real duplicate-key errors (`TS2783`) that `pnpm build` sailed straight past, because Vite/esbuild strips types without checking them. It does **not** cover `useScenario.ts`, `scenarioService.ts`, `mergeAppliedGraph.ts` or `persistedGraph.ts`, so those were checked via the full app config and the per-file diff above.

## RED-first / mutation checks

Every fix was reverted in a **throwaway** tree (never the lane tree) and the corresponding test confirmed RED:

| Mutation | Result |
|---|---|
| **B2-a** `overlayNode` returns `existing` (restore additive-only) | 🔴 3 RED, incl. the end-to-end |
| **B2-b** removals disabled | 🔴 2 RED, incl. the end-to-end delete case |
| **B2-c** delete on absence *unconditionally* (drop the acknowledgement guard) | 🔴 2 RED — proves the safety guard is load-bearing, not decoration |
| **B3-a** `goalConstraints` out of the clear-set + hydration | 🔴 3 RED |
| **B3-b** `buildPersistedGraph` never emits the key | 🔴 1 RED (the round-trip) |

## Test-set diff — the SET, not the counts

Base captured first: **60 failed files / 2 failed tests** of 1172. Extraction validated by count agreement (60 extracted = 60 reported) and a positive control.

**Result: all 60 base failures still fail. No swap. Exactly one new file:**

`src/signals/__tests__/realtime-signals.test.ts > performance > processes 500-word brief in <5ms average`

**This is pre-existing and not mine** — it fails at base `b4c38a1a` in isolation **3 runs out of 3**, it is a wall-clock assertion sensitive to machine load, and this branch touches **zero** files under `src/signals/`. It simply happened to pass during the base full run and fail during mine.

⚠️ **Process note, recorded rather than buried:** a first HEAD run produced a log with no summary and zero `FAIL` lines — my own polling loop's SIGTERM had killed the process group. Had I trusted it, I would have reported a clean set diff from a truncated log. That log was discarded and the numbers above come from a clean re-run. (Related: an early `grep --include` was eaten by zsh globbing and returned three false "0 hits" — every absence claim here was re-run with a positive control.)

### Three specs failed for real and were fixed properly, not weakened

- `scenarioService.spec` — asserted `p_graph` by **reference** (`toBe`); it is now built. Changed to a value assertion, **plus** a new "no stray `goal_constraints` key" check.
- `useScenario.spec` — `hydrateGraphSlice` now receives `goalConstraints`; asserted `null` explicitly, since "key absent" was the defect.
- `applyDraftResult.spec` — its store mock is a **hand-maintained mirror** of the action surface and threw on the new action. Added, hazard documented; the production call is left **strict** (no `?.()`) so future drift fails loud rather than silently no-oping the deletion-authorisation record.


---

## ⚠ CORRECTION appended by A1 at merge (adversarial review, 18 Jul)

**The claim above that this branch introduces "exactly one new failing file" (`realtime-signals.test.ts`) is FALSE — corrected in the safe direction.**

Independent verification found that file **fails at BASE as well as HEAD** under the full suite (base 12.81ms, head 13.46ms), so it is not a new failure. Within the scope actually measured there were **zero newly-failing files**, and one file went the other way — `httpV1Adapter.stream.test.ts` fails at base and passes here (itself a flake: test and source blobs are byte-identical at both SHAs, so no diff-attributable difference is possible).

**Scope caveat:** that comparison covered **~17% of the suite** (199/1172 files at base, 198/1172 at head); the runs did not finish. The lane's "60 failures at base" figure is therefore **neither confirmed nor refuted** — it must not be cited as verified.

**Why the flake exists, for whoever picks this up:** vitest runs single-threaded here (`maxThreads: 1`), so *any* PR that merely **adds test files** raises in-process work before a later file runs and can tip a marginal wall-clock assertion **with no product regression at all**. This PR adds two test files (~500 lines). The defect is the `expect(avgMs).toBeLessThan(5)` assertion at `src/signals/__tests__/realtime-signals.test.ts:454`, not this diff. Tracked as ROADMAP 1.162. **Do not "fix" it with `retry`.**

**Also dissolved at merge:** the review's open P3 — that `overlayNode` setting `label` unconditionally could null a local label — does not apply. `NodeV3.label` is `z.string()` (**required**) at `src/schemas/cee-v3.ts` (positive control: `description`, `observed_state`, `category`, `goal_threshold` in the same object all carry `.optional()`), so a label-less wire node cannot occur.
