### PR TITLE
docs(canvas): two stranded panels investigated — both RETIRE, neither revived (AI Clarifier, Provenance Hub)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -2100,6 +2100,40 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
       )}
 
       {/* Task C: Unified right-panel orchestrator — only one overlay panel at a time */}
+
+      {/* ⚠ BOTH PANELS BELOW ARE STRANDED — no opener exists for either. Verified at
+        * the bytes across all of src/ (case-insensitive): every `setShowProvenanceHub(…)`
+        * and `setShowAIClarifier(…)` call site passes `false`. Neither flag has a
+        * true-setter. They got here by DIFFERENT routes — one deliberate, one accidental —
+        * but both are superseded today. Do not "fix" this by adding a button; read on:
+        *
+        * Provenance Hub — opener removed DELIBERATELY BY THE REPO OWNER in c80f0fe8
+        *   (29 Mar 2026) "refactor(sidebar): remove Run Analysis, Compare Runs, and
+        *   Evidence & Provenance from left menu". Independently, its data source is dead:
+        *   `addCitation` has zero callers in all of history, so `citations` is always []
+        *   and this panel renders an empty state by construction (see store.ts addCitation).
+        *   Live successor: conversation CitationLegend (InlineBlocks.tsx), V5-fed.
+        *   NOTE: this flag IS persisted + rehydrated (uiPreferences SHOW_PROVENANCE_HUB),
+        *   so a returning user carrying a stale `ui.showProvenanceHub=true` from a pre-
+        *   c80f0fe8 build can still surface the empty panel. Open question for the owner.
+        *
+        * AI Clarifier — stranded BY ACCIDENT, then overtaken by events. Its opener shipped
+        *   in 723be292 (5 Dec 2025, 20:02) and was dropped four minutes later by merge
+        *   commit 4ce7117d (20:06) "chore: resolve merge conflicts with main", which took
+        *   main's side of this file and never mentions the clarifier. (`git log -S` misses
+        *   this: pickaxe skips merge commits. Proven by direct revision scan —
+        *   `setShowAIClarifier(true)` in this file: 723be292=1, 4ce7117d=0, and 0 ever after.)
+        *   So it was not retired on purpose — but the job has since genuinely moved. The
+        *   sidebar AI button outlived the binding and by 13c4c3b8 (31 Jan 2026) read
+        *   `onAiClick={() => setShowDraftChat(true)}` before being removed as redundant;
+        *   DraftChat / FloatingOlumiPanelHost are now mounted unconditionally a few hundred
+        *   lines below (the aiPanelV2 pair). Reviving this panel would duplicate a live
+        *   surface AND SHIP A WORSE DRAFT PATH: applyClarifierGraph keeps only
+        *   {label, body, uncertainty} and drops observed_state, edge weight, direction and
+        *   belief — the fields the V2 adapter needs for PLoT.
+        *
+        * Retained pending the owner's ruling; see PR "stranded panels" for the full case.
+        */}
       {showProvenanceHub && (
         <RightPanel
           width="32rem"

--- a/src/canvas/components/ProvenanceHubTab.tsx
+++ b/src/canvas/components/ProvenanceHubTab.tsx
@@ -1,6 +1,23 @@
 /**
  * M5: Provenance Hub Tab
  * Shows all citations and document connections
+ *
+ * ⚠ STRANDED, AND EMPTY BY CONSTRUCTION. Two independent reasons, either sufficient:
+ *
+ * 1. No opener. Nothing sets `showProvenanceHub` true; the entry point was removed
+ *    deliberately by the repo owner in c80f0fe8 (29 Mar 2026), "remove Run Analysis,
+ *    Compare Runs, and Evidence & Provenance from left menu".
+ * 2. No data. The `citations` prop comes from the canvas store, whose `addCitation`
+ *    action has NEVER been called — zero call sites in src/, zero commits in the repo's
+ *    entire history (`git log --all -S'addCitation('`). The M5 milestone shipped this UI
+ *    and the document-upload half, but never built citation production. So this renders
+ *    "0 citations from N documents" and the empty state, always.
+ *
+ * Do not wire an opener without first wiring a producer — an opener alone ships a button
+ * to an empty box. The live citation surface today is the conversation CitationLegend
+ * (src/canvas/conversation/InlineBlocks.tsx), fed from the V5 stream.
+ *
+ * Retained (not deleted) pending the owner's ruling. See PR "stranded panels".
  */
 
 import { useState } from 'react'

--- a/src/canvas/panels/AIClarifierChat.tsx
+++ b/src/canvas/panels/AIClarifierChat.tsx
@@ -2,6 +2,32 @@
  * AI Clarifier Chat Panel
  * Multi-turn conversational interface for drafting decision models
  * Week 3: AI Integration
+ *
+ * ⚠ STRANDED — UNREACHABLE, AND SUPERSEDED. Nothing sets `showAIClarifier` true
+ * (verified across all of src/, case-insensitive: every setter passes `false`), and
+ * the flag is not in UIPreferences/STORAGE_KEYS, so it cannot rehydrate either.
+ *
+ * How it was stranded — by ACCIDENT, not by decision. The opener shipped in 723be292
+ * (5 Dec 2025, 20:02) and was gone four minutes later, dropped by merge commit 4ce7117d
+ * (20:06) "chore: resolve merge conflicts with main", which took main's side of
+ * ReactFlowGraph.tsx and never mentions the clarifier. This panel has therefore been
+ * unreachable for effectively its entire existence. (`git log -S` will not show you this:
+ * pickaxe skips merge commits. Direct revision scan of `setShowAIClarifier(true)` in
+ * ReactFlowGraph.tsx: 723be292=1, 4ce7117d=0, 0 in every revision since.)
+ *
+ * Why it is nevertheless not worth reviving — the job moved while it was dark. The sidebar
+ * AI button outlived the binding; by its removal in 13c4c3b8 (31 Jan 2026) it read
+ * `onAiClick={() => setShowDraftChat(true)}`, and it went because DraftChat /
+ * FloatingOlumiPanelHost are mounted unconditionally at the canvas root (ReactFlowGraph,
+ * aiPanelV2 pair). Drafting chat is fully served today.
+ *
+ * Reviving this would also regress data fidelity: this panel applies CEE output via
+ * `applyClarifierGraph`, which keeps only {label, body, uncertainty} and drops
+ * observed_state, edge weight, direction and belief — the fields the V2 adapter needs to
+ * build the PLoT request. DraftChat's mapping preserves them. Wiring an opener here would
+ * hand users a second, quieter, worse drafting path.
+ *
+ * Retained (not deleted) pending the owner's ruling. See PR "stranded panels".
  */
 
 import { useState, useEffect, useRef, useCallback, memo } from 'react'

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -4304,6 +4304,21 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     saveSortPreferences(field, direction)
   },
 
+  // ⚠ NO CALLERS. `addCitation` has never been called — not here, not anywhere in
+  // src/, and not once in the repo's entire history (`git log --all -S'addCitation('`
+  // returns zero commits). `citations` is therefore empty by construction: it is
+  // initialised `[]`, only ever FILTERED (on document delete), and the sole push is
+  // the line below, which nothing reaches.
+  //
+  // Consequence: the Provenance Hub (ProvenanceHubTab, rendered from ReactFlowGraph)
+  // can only ever render "0 citations from N documents" / "No citations found". The
+  // M5 Grounding & Provenance milestone shipped its UI and its document-upload half,
+  // but the citation-production half was never built. Do not wire an opener onto that
+  // panel without first wiring a producer here.
+  //
+  // The live citation surface today is the conversation CitationLegend
+  // (src/canvas/conversation/InlineBlocks.tsx), fed from the V5 stream at
+  // useConversation.ts:~1300 — a different, working pipeline. See PR "stranded panels".
   addCitation: (citation) => {
     const id = crypto.randomUUID()
     const newCitation: Citation = {


### PR DESCRIPTION
## Verdict: both panels RETIRE. No opener built for either.

The brief's default was REVIVE ("wire dead controls, don't delete them"). I did not revive either panel, because that rule assumes the affordance is still wanted — and for both of these, the evidence says it isn't. Neither verdict was close. **No code was deleted**; both panels, their store flags, and their gates are exactly where they were. This PR adds explanatory comments only (+91 lines, zero behaviour change) so the next reader doesn't spend a session re-deriving this.

---

## Panel 1 — Provenance Hub (`ProvenanceHubTab`): **RETIRE**

Two independent reasons, either sufficient on its own.

**1. The owner already removed the opener, on purpose.**

`c80f0fe8` (29 Mar 2026, Paul) — *"refactor(sidebar): remove Run Analysis, Compare Runs, and Evidence & Provenance from left menu"*. It deleted `onEvidenceClick={() => setShowProvenanceHub(true)}` and the Layers-icon button. Reviving this would directly reverse an explicit owner decision.

**2. The panel has never had data, and cannot get any.**

`addCitation` — the only code that can ever push into `store.citations` — **has zero callers in `src/`, and zero across the repo's entire history** (`git log --all -S'addCitation('` → no commits). `citations` is initialised `[]`, only ever *filtered* (on document delete), and the sole push is unreachable.

So the M5 Grounding & Provenance milestone shipped this UI and its document-upload half, but the citation-production half was never built. The panel renders `"0 citations from N documents"` and the empty state — **always, by construction**. It would have rendered empty even while the button existed.

This is the brief's own warning case: wiring an opener here ships a button to an empty box.

**Successor (live):** the conversation `CitationLegend` (`src/canvas/conversation/InlineBlocks.tsx:618`, rendered :568/:609), fed from the V5 stream (`useConversation.ts:~1300`) — a *different data path* from `store.citations`, which is exactly why it works while the Hub is empty. Recently hardened by `3578e272` "citation scope". It is keyboard-reachable with per-citation `aria-label`s.

**What would genuinely be lost:** no single live surface shows citations *and* documents together. OutputsDock tabs are `results | compare | diagnostics | journey | olumi` — there is no provenance tab. If the owner wants that combined view back, the work is **building the citation feed**, not wiring a button.

---

## Panel 2 — AI Clarifier (`AIClarifierChat`): **RETIRE**

The interesting one, and the place my first answer was **wrong**.

**How it was stranded: by accident, in four minutes.** The opener shipped in `723be292` (5 Dec 2025, **20:02**) and was gone by `4ce7117d` (**20:06**) — *"chore: resolve merge conflicts with main"*, a merge commit that took main's side of `ReactFlowGraph.tsx`. Its message resolves three named conflicts and **never mentions the clarifier**. The component file survived; only the opener died.

> ⚠️ **`git log -S` does not show this — pickaxe skips merge commits by default.** My first pass concluded the opener was retired deliberately; that was wrong, and it was wrong because I trusted a pickaxe result. Proven instead by direct revision scan of `setShowAIClarifier(true)` in `ReactFlowGraph.tsx`: `723be292`=1, `4ce7117d`=0, other merge parent `e470e32d`=0, and 0 in every revision since. This panel has been unreachable for effectively its entire existence.

So this was **not** a deliberate retirement. It still should not be revived, for two reasons:

**1. The job moved while it was dark.** The sidebar AI button outlived the binding — by its removal in `13c4c3b8` (31 Jan 2026) it read `onAiClick={() => setShowDraftChat(true)}`. It went because the successor is mounted *unconditionally* at the canvas root: `ReactFlowGraph.tsx:2205-2206` renders `<DraftChat />` (aiPanelV2 off) or `<FloatingOlumiPanelHost />` (on). You cannot use the canvas without the successor being present. Reviving would give users two drafting chats.

**2. Reviving it would ship a *worse* draft path.** `applyClarifierGraph` keeps only `{label, body}` (+`uncertainty` on finalize) and **drops `observed_state`, edge `weight`, `direction`, and `belief`** — the fields `transformNodeToV2`/`extractObservedState` need to build the PLoT request (see `CLAUDE.md`, "CEE → UI → PLoT Data Flow"). DraftChat's mapping preserves them. A Clarifier-drafted graph would be analytically degraded relative to what users already get.

Corroborating rot: lint reports `handleApply` and `handleClose` assigned-but-never-used, plus `console.log` calls and a legacy `var(--sky-500)` token (deprecated by the design system) inside `applyClarifierGraph`'s preview styling.

---

## Mutual exclusion

Moot — I revived neither, so the shared gate `{!showProvenanceHub && showAIClarifier}` is unchanged and still unreachable from both sides. Flagged for completeness: had both been revived, that gate silently swallows the Clarifier whenever the Hub is open, with no feedback. Any future revival of *either* needs that gate reworked.

---

## ⚠️ Left for the owner to rule on

**1. The Provenance Hub is still reachable by returning users — and shows an empty panel.**

Unlike `showAIClarifier` (not persisted, genuinely unreachable), `showProvenanceHub` **is** persisted and rehydrated (`saveUIPreference` at `store.ts:4334`; `loadUIPreferences()` spread into store init at `store.ts:1424`; `STORAGE_KEYS.SHOW_PROVENANCE_HUB`). A user carrying a stale `ui.showProvenanceHub=true` in localStorage from a pre-`c80f0fe8` build **still gets the panel today**, rendering empty.

That is a live user-facing defect, not just dead code. The minimal fix is to stop rehydrating that key. **I did not apply it** — it's a behaviour change on a panel whose fate is your call, and if you revive the Hub you'll want persistence back. Your ruling.

**2. Do you want the combined citations+documents view back at all?** If yes, the work is a citation producer (`addCitation`), not an opener. If no, both panels can be archived in a follow-up — I have deliberately not done so.

**3. Out of scope, spotted in passing:** the comments at `ReactFlowGraph.tsx:77/:359/:2217` claiming *"coaching now in GuidancePanel (OutputsDock)"* are **stale** — `GuidancePanel.tsx` has zero importers anywhere in `src/` (the only two "GuidancePanel" hits are `DraftGuidancePanel`, a different component, and a log string inside the file itself; positive control: the same grep finds DraftChat's real importer). The named successor is itself dead. Filed separately.

---

## Gates

| Gate | Result |
|---|---|
| `pnpm run typecheck` | clean |
| `pnpm run lint` (changed files) | **0 errors**, 35 warnings — all pre-existing |
| Wide `tsc -p tsconfig.app.json --noEmit` | **2320 base → 2320 modified — zero new** (via `grep -c "error TS"`) |
| Targeted specs (5 files, 37 tests) | **all passed** — `useEscapePanel`, `RightPanel`, `provenance.hub.navigate`, `store.applyClarifierGraph.layoutFail`, `useCanvasKeyboardShortcuts` |
| `npx vitest run --changed origin/staging` | ⚠️ **not completed locally — deferred to CI** (see below) |

On the `--changed` gate, honestly: because the diff touches `store.ts` and `ReactFlowGraph.tsx` (hub modules), `--changed origin/staging` selects effectively the entire suite. It ran ~25 minutes across 52 workers, streaming passes the whole way, and was then killed by **my own 15-minute tool timeout** (exit 144) — *not* by a test failure. I am not claiming it green, because I did not see it finish. I ran the five directly-relevant specs instead (above, all passing) and am leaving the full suite to CI, which `CLAUDE.md` names as the authoritative gate.

The wide-typecheck base was a throwaway `git worktree` at `origin/staging` with `node_modules` **symlinked to the same directory** as the modified tree — so the two counts cannot differ through dependency drift (the `CLAUDE.md` stale-`node_modules` trap).

**No new tests.** The brief's RED-first requirement was conditional on reviving ("a test that fails because the opener does not exist, then passes once it does"). Nothing was revived, and the diff is comments only, so there is no behaviour to pin and nothing to mutation-check. I did not write a test asserting the panels are unreachable — that would enshrine the current state as intended rather than leave it open for your ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
