### PR TITLE
fix(test): deflake health.indicator timeout assertion

### DIFF
--- a/src/components/HealthIndicator.tsx
+++ b/src/components/HealthIndicator.tsx
@@ -10,6 +10,11 @@ export default function HealthIndicator({ pause = false }: { pause?: boolean }) 
   const timeoutMs = isE2EEnabled() ? 100 : 1_000
   const backoffRef = useRef<number>(base)
   const lastProbeRef = useRef<number | null>(null)
+  // Guards the async tail of an in-flight tick(): the unmount cleanup below runs
+  // clearTimer() once, so a tick that resolves AFTER unmount would otherwise
+  // re-arm a timer nothing will ever clear — an orphaned poll loop that keeps
+  // fetching (and setting state on an unmounted tree) for the life of the page.
+  const mountedRef = useRef(true)
 
   const clearTimer = () => {
     if (timerRef.current != null) {
@@ -38,19 +43,27 @@ export default function HealthIndicator({ pause = false }: { pause?: boolean }) 
       const t = setTimeout(() => ac.abort(), timeoutMs)
       try {
         const res = await fetch(mkUrl('/health'), { signal: ac.signal })
-        clearTimeout(t)
         if (res.ok) return true
-      } catch {}
+      } catch {
+        // fall through to the /report probe
+      } finally {
+        // `finally`, not the success path only: when fetch REJECTS (abort or
+        // network error) the abort timer would otherwise be left pending.
+        clearTimeout(t)
+      }
+      const ac2 = new AbortController()
+      const t2 = setTimeout(() => ac2.abort(), timeoutMs)
       try {
-        const ac2 = new AbortController()
-        const t2 = setTimeout(() => ac2.abort(), timeoutMs)
         const res2 = await fetch(mkUrl('/report?probe=1'), { signal: ac2.signal })
-        clearTimeout(t2)
         return !!res2?.ok
-      } catch {}
-      return false
+      } catch {
+        return false
+      } finally {
+        clearTimeout(t2)
+      }
     }
     const okNow = await tryProbe()
+    if (!mountedRef.current) return
     setOk(okNow)
     lastProbeRef.current = Date.now()
     if (okNow) {
@@ -62,8 +75,9 @@ export default function HealthIndicator({ pause = false }: { pause?: boolean }) 
   }
 
   useEffect(() => {
+    mountedRef.current = true
     void tick() // run immediately on mount
-    return () => clearTimer()
+    return () => { mountedRef.current = false; clearTimer() }
     // REVIEWED: Intentional mount-only effect. tick/clearTimer/schedule use refs for state,
     // not state variables, so including them would cause infinite loops.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/__tests__/health.indicator.test.tsx
+++ b/src/lib/__tests__/health.indicator.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
 import React from 'react'
 
 // Speed up polling by enabling E2E mode in this test only
@@ -9,6 +9,27 @@ vi.mock('../config', () => ({ getGatewayBaseUrl: () => '' }))
 
 import HealthIndicator from '../../components/HealthIndicator'
 
+// Why `waitFor` and not `await new Promise((r) => setTimeout(r, 0))`:
+//
+// HealthIndicator probes /health on mount and calls setOk() from the async tail
+// of that probe. React 18 does not commit that update synchronously — outside
+// act() it hands the render to the Scheduler, which under Node + jsdom schedules
+// via `setImmediate` (scheduler.development.js `localSetImmediate`), i.e. the
+// event loop's CHECK phase. A `setTimeout(…, 0)` barrier resolves in the TIMERS
+// phase.
+//
+// Node gives NO ordering guarantee between a 0ms timer and a setImmediate
+// registered after it: the winner depends on which phase the test body resumed
+// from and on whether the (1ms-clamped) timer has already expired by the time the
+// loop reaches the timers phase. Measured locally: ~0.3% inversions idle and
+// ~1.5% under CPU load when resuming from the check phase. When the timer wins,
+// the assertion reads the DOM before React has committed and sees "Checking…" —
+// which is exactly how this file failed in CI (shard 1/4, run 29662467861).
+//
+// `waitFor` removes the bet: it polls the assertion until it holds, so the test
+// no longer depends on host-callback phase ordering. It is a synchronisation
+// barrier, not a retry — the assertions are byte-for-byte as strict as before,
+// and a genuinely wrong title still fails the run.
 describe('HealthIndicator', () => {
   beforeEach(() => {})
   afterEach(() => {
@@ -19,25 +40,48 @@ describe('HealthIndicator', () => {
   it('success → Connected', async () => {
     const fetchSpy = vi.spyOn(globalThis as any, 'fetch').mockResolvedValue({ ok: true } as any)
     render(<HealthIndicator />)
-    // Runs immediately; flush microtasks
-    await Promise.resolve()
-    await new Promise((r) => setTimeout(r, 0))
-    const dot = screen.getByTestId('health-dot')
-    expect(dot.getAttribute('title') || '').toMatch(/^Connected — checked \d+s ago$/)
+    // First probe runs immediately on mount and succeeds; await the commit.
+    await waitFor(() => {
+      const dot = screen.getByTestId('health-dot')
+      expect(dot.getAttribute('title') || '').toMatch(/^Connected — checked \d+s ago$/)
+    })
     expect(fetchSpy).toHaveBeenCalled()
   })
 
   it('timeout/non-200 → Offline', async () => {
     const seq: Array<{ ok: boolean }> = [{ ok: false }]
-    const fetchSpy = vi.spyOn(globalThis as any, 'fetch').mockImplementation(async () => {
+    vi.spyOn(globalThis as any, 'fetch').mockImplementation(async () => {
       return seq.shift() ?? ({ ok: false } as any)
     })
 
     render(<HealthIndicator />)
-    // First probe runs immediately and fails
-    await Promise.resolve()
-    await new Promise((r) => setTimeout(r, 0))
-    const dot = screen.getByTestId('health-dot')
-    expect(dot.getAttribute('title') || '').toMatch(/^Offline — checked \d+s ago$/)
+    // First probe runs immediately and fails; await the commit.
+    await waitFor(() => {
+      const dot = screen.getByTestId('health-dot')
+      expect(dot.getAttribute('title') || '').toMatch(/^Offline — checked \d+s ago$/)
+    })
+  })
+
+  it('unmount mid-probe does not leave an orphaned poll loop', async () => {
+    // Pins the component fix: tick()'s async tail must not re-arm the timer
+    // after the unmount cleanup has already run clearTimer(). Before the fix the
+    // resolved probe called schedule(), arming a timer nothing would ever clear.
+    let releaseProbe: (v: any) => void = () => {}
+    const fetchSpy = vi.spyOn(globalThis as any, 'fetch').mockImplementation(
+      () => new Promise((resolve) => { releaseProbe = resolve }),
+    )
+
+    const { unmount } = render(<HealthIndicator />)
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+
+    // Unmount while the probe is still in flight, then let it settle.
+    unmount()
+    releaseProbe({ ok: true })
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+
+    // E2E backoff is 200ms; an orphaned timer would fire a second probe well
+    // inside this window.
+    await new Promise((r) => setTimeout(r, 600))
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Root-cause mechanism

`HealthIndicator` probes `/health` on mount and calls `setOk()` from the **async tail** of that probe. React 18 does not commit that update synchronously: outside `act()` it hands the render to the Scheduler, and `scheduler@0.23.2` prefers **`setImmediate`** under Node + jsdom:

```js
// scheduler.development.js:166,551
var localSetImmediate = typeof setImmediate !== 'undefined' ? setImmediate : null; // IE and Node.js + jsdom
if (typeof localSetImmediate === 'function') { … }   // chosen ahead of MessageChannel
```

So React's commit is a **check-phase** task. The test synchronised on:

```js
await new Promise((r) => setTimeout(r, 0))   // ← a TIMERS-phase task
```

registered **before** that `setImmediate`. Node guarantees no ordering between those two queues. When the test body resumes from the check phase, the (1 ms-clamped) timer has already expired by the time the loop reaches the timers phase, so the test's continuation runs **before** React commits — the assertion reads `title="Checking…"` and fails.

Measured at the Node level, mimicking the exact registration order:

| Resume phase | Inversions, idle | Inversions, under CPU load |
|---|---|---|
| sync / timers | 0 / 400 | 0 / 400 |
| **check (`setImmediate`)** | **1 / 400 (0.3%)** | **6 / 400 (1.5%)** |
| poll (I/O) | 0 / 400 | 0 / 400 |

That is the whole flake: a ~1% phase inversion that only shows up when the process is loaded and the test body happens to resume from the check phase — i.e. in a full 4-way-sharded CI run, not in isolation.

## Repro

**Natural (unmodified test, fresh processes, under CPU load):** 3 assertion failures in 110 runs, every one `expected 'Checking…' to match /^Connected — checked \d+s ago$/`.

**Deterministic (forced legal reordering):** a throwaway setup file delays React's scheduler host callback by N macrotasks — a legal alternative interleaving of check vs timers — before `scheduler` captures `setImmediate` at module load:

```ts
const real = globalThis.setImmediate
;(globalThis as any).setImmediate = (fn, ...a) => real(() => real(() => fn(...a)))
```

| Delay | Original test result |
|---|---|
| 0 hops | both pass |
| 1 hop | `success → Connected` fails at **26:45** — `Received: "Checking…"` |
| 3 hops | **both** fail; `timeout/non-200 → Offline` fails at **41:45** — `Received: "Checking…"`, the exact CI failure |
| 25 hops | both fail |

**Note on which assertion fires:** the local natural repro landed on test 1 (26:45); CI reported test 2 (41:45). Both assertions stand on identical footing — proven by the forced-ordering run where both fail with the same `"Checking…"` value. The CI shard's load profile simply lands the inversion in a different window.

**In-process repetition does NOT reproduce it** (400 repeated bodies in one process: 400/400 pass). That is itself confirming evidence: within one process the bodies all resume from the same phase, so the inversion never occurs. The race needs fresh processes with varying phase context — which is exactly why a plain rerun goes green.

## The fix

Both barriers become `waitFor`, which awaits the *condition* rather than betting on host-callback phase ordering. The regexes are byte-for-byte unchanged — this is a synchronisation fix, **not** a strictness reduction, no widened timeout, no retry, no skip, no exclude-list entry.

Also fixes two genuine `HealthIndicator` defects surfaced by the investigation. **Neither is the flake's cause** — stated plainly so the record is honest:

1. **Orphaned poll loop.** `tick()`'s async tail called `schedule()` after the unmount cleanup had already run `clearTimer()`, arming a timer nothing could ever cancel — a self-perpetuating `fetch` loop that outlives the component (it mounts under `SandboxStreamPanel`'s `configFlag`). Guarded with `mountedRef`, pinned by a new test.
2. **Leaked abort timer.** `tryProbe()` cleared its abort timer only on the resolve path; a rejected `fetch` (abort or network error) left it pending. Moved to `finally`.

## Numbers

Interleaved A/B — arms alternate on **every** iteration, so ambient machine load is shared equally. (Load average was ~130–160 throughout from an unrelated concurrent process; an earlier non-interleaved measurement was **voided** for exactly that reason.)

| Arm | N | Assertion failures | Process kills (0-byte log, OOM/SIGKILL under load) |
|---|---|---|---|
| `origin/staging` | 110 | **3** (2.7%) | 1 |
| This branch | 110 | **0** | 1 |

Both arms took exactly one environmental kill — symmetric, as interleaving intends. Those are classified separately and **not** counted as flake instances.

## Mutation checks

1. **Test fix bites.** The fixed test passes at 1, 3, 10 and **50** delay hops — where the original fails at 1. Positive control: the original at 25 hops fails *both* assertions. The fix survives a 50× worse inversion than the one that breaks the original, so it is structurally deterministic, not lucky.
2. **Component fix bites.** In a throwaway worktree, reverting `HealthIndicator.tsx` alone (keeping the new test) turns the new test **red**: `expected "fetch" to be called 1 times, but got 2 times` — the orphaned loop firing a second probe after unmount.

## Siblings — checked, all clear

Complete manifest of every test using a bare `setTimeout(0)` settle barrier (9 files; 6 with assertions that could plausibly depend on a React commit). Each run under the 25-hop forced-reordering harness, **with the original `health.indicator` as a positive control proving the harness can detect the defect**:

| File | 25 hops |
|---|---|
| `health.indicator.test.tsx` (original — **positive control**) | **both tests FAIL** |
| `canvas.send.test.tsx` | pass |
| `canvas.drawer.test.tsx` | pass |
| `config.drawer.test.tsx` | pass |
| `ActionsMenu.spec.tsx` | pass |
| `report.download.test.tsx` | pass |
| `canvas.export.text.test.tsx` | pass |

They are **not** on the same footing, and the reason is structural: in every sibling the barrier is *redundant* — the assertion is already reached through a preceding `await screen.findBy*` (an RTL `waitFor`, phase-independent) or a `fireEvent` (act-wrapped, so React commits synchronously). `health.indicator` was the only case where a bare barrier was the **sole** synchronisation for a state update arriving from an unprompted async probe. No files churned on speculation.

**Separately flagged, not fixed here** (different class — a coverage weakness, not a flake): `ActionsMenu.spec.tsx:179-181` and `canvas.drawer.test.tsx:114` assert *absence* (`toBeNull()`, `.length === 0`) after the barrier. Those pass whether or not React committed, so they are vacuous under the same inversion — repo trap 13 ("a positive control, or the absence assertion is vacuous"). Repairing them means adding a positive control, which changes test intent and belongs in its own PR.

## Stale "known broken" labels — none found

Repo-wide unrestricted grep (all file types, excluding `node_modules`/`.git`/`dist`) for `health.indicator` / `healthindicator` returns a complete manifest of 9 hits: the component, the spec, a Playwright e2e spec, `SandboxStreamPanel`'s call site, a generated file list, and 4 unrelated prose mentions. **There is no known-flake registry entry, doc, comment, or `vitest.config.ts` exclude entry naming this test** — so there is nothing stale to remove. The tolerated red here was a *practice* (one-shot rerun), not a recorded label.

## Gates

- `pnpm run typecheck` — clean (exit 0)
- `pnpm run lint` — **0 errors** (1,099 pre-existing warnings)
- `npx vitest run src/lib/__tests__/health.indicator.test.tsx` — 3 passed
- `npx vitest run --changed origin/staging` — 27 files, 83 tests, all passed
- Wide `tsc -p tsconfig.app.json --noEmit`, `grep -c "error TS"`, vs a matched base clone with its own real `node_modules`: base **2320** → head **2319**. Set-diff (not just the count, which can mask one-in/one-out): **0 new**, 1 removed (`TS6133: 'fetchSpy' is declared but its value is never read` — the unused binding dropped in the rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
