### PR TITLE
docs(canvas): correct stale coaching-successor comments (GuidancePanel is dead)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -74,7 +74,11 @@ import { handleLayoutWithRecovery } from './layout/handleLayoutWithRecovery'
 const IssuesPanel = lazy(() => import(/* webpackChunkName: "issues-panel" */ './panels/IssuesPanel').then(m => ({ default: m.IssuesPanel })))
 const AIClarifierChat = lazy(() => import(/* webpackChunkName: "ai-clarifier" */ './panels/AIClarifierChat').then(m => ({ default: m.AIClarifierChat })))
 // NeedleMoversOverlay removed - consolidated into DriversSignal (OutputsDock)
-// CoachingNudge and useCEECoaching removed - coaching now in GuidancePanel (OutputsDock)
+// CoachingNudge and useCEECoaching removed from this file. Coaching is now driven by
+// guidanceStore (./stores/guidanceStore.ts) and rendered by several surfaces: on-canvas via
+// CoachingCard in ./nodes/FactorNode.tsx, in-conversation via ./conversation/GuidanceStrip.tsx
+// and ./conversation/InlineBlocks.tsx, and in the dock via ./components/OlumiTabBody.tsx.
+// Not GuidancePanel.tsx — that component has no importers.
 import { DocumentsManager } from './components/DocumentsManager'
 import { ProvenanceHubTab } from './components/ProvenanceHubTab'
 import { ConnectPrompt } from './components/ConnectPrompt'
@@ -356,7 +360,8 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     return [...nodes, ghostNode]
   }, [nodes, resultsStatus, viewMode])
 
-  // Week 3: AI Coaching moved to GuidancePanel in OutputsDock
+  // AI coaching is rendered by the guidanceStore consumers, not here — see
+  // ./nodes/FactorNode.tsx (on-canvas CoachingCard) and ./conversation/GuidanceStrip.tsx.
 
   const { getViewport, fitView, zoomIn, zoomOut, zoomTo, screenToFlowPosition } = useReactFlow()
 
@@ -2187,7 +2192,8 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
         currentEdges={edges.length}
       />
 
-      {/* Week 3: AI Coaching nudges moved to GuidancePanel in OutputsDock */}
+      {/* Coaching nudges render on the nodes themselves
+          (./nodes/FactorNode.tsx → ./components/CoachingCard.tsx), not as a canvas overlay */}
 
       {/* Reset Canvas Confirmation */}
       <BottomSheet isOpen={showResetConfirm} onClose={() => setShowResetConfirm(false)} title="Start fresh?">


### PR DESCRIPTION
Comment-only. Three comments in `src/canvas/ReactFlowGraph.tsx` named a **dead** component as the live successor of removed coaching code — repo verification trap #14 ("an honest label can be OVERWRITTEN by a false one"). The next reader would have trusted it.

## 1. Corrected manifest — the brief I was given was wrong

I was told "a case-insensitive grep for `GuidancePanel` across `src/` returns exactly two hits." **It returns 11.** The brief's count was wrong in both directions — it missed the three stale comments (which themselves contain the string) and it conflated `GuidancePanel` with the substring-matching, genuinely-live `DraftGuidancePanel`.

Complete manifest, `/usr/bin/grep -rin "guidancepanel" src/` (11 hits):

| # | Location | Class | Which component |
|---|---|---|---|
| 1 | `ReactFlowGraph.tsx:77` | comment | GuidancePanel |
| 2 | `ReactFlowGraph.tsx:359` | comment | GuidancePanel |
| 3 | `ReactFlowGraph.tsx:2190` | comment | GuidancePanel |
| 4 | `DraftChat.tsx:12` | **import** | **Draft**GuidancePanel |
| 5 | `DraftChat.tsx:1179` | **JSX usage** | **Draft**GuidancePanel |
| 6 | `DraftGuidancePanel.tsx:6` | own file (props type) | **Draft**GuidancePanel |
| 7 | `DraftGuidancePanel.tsx:11` | own file (definition) | **Draft**GuidancePanel |
| 8 | `GuidancePanel.tsx:2` | own file (docblock) | GuidancePanel |
| 9 | `GuidancePanel.tsx:52` | own file (definition) | GuidancePanel |
| 10 | `GuidancePanel.tsx:150` | own file (string literal in `console.warn`) | GuidancePanel |
| 11 | `src/lib/nextSteps.ts:9` | comment (docblock bullet) | GuidancePanel |

**Imports of `GuidancePanel`: zero. JSX usages: zero. Test files: zero.** Every non-self reference is a comment.

Outside `src/`, two build artefacts mention only `DraftGuidancePanel` (`scripts/isolation-results/external-files.txt:167`, `tools/ci-guards/ds-compliance-baseline.json`). `GuidancePanel` appears in neither.

### Why the zero is sound, not just un-found
A string grep misses imports that never spell the name. Both bypasses were checked and ruled out:
- `import.meta.glob` / `require.context` in `src/`: the only hit is `src/adapters/plot/mockAdapter.ts:100`, globbing **JSON template fixtures**, not components.
- Barrel re-export: `src/canvas/components/` has **no `index.*`**, and nothing anywhere imports from the components directory as a barrel.

With no glob and no barrel, the only route to importing `GuidancePanel` is a literal containing its name — so the manifest is complete **by construction**.

### Positive control (mandatory — an absence assertion needs a proven presence)
Identical search shape run against four known-live components. All four found their importers:

| Component | Importer found | Files referencing |
|---|---|---|
| `DraftGuidancePanel` | `DraftChat.tsx:12` | 2 |
| `OutputsDock` | `FloatingOlumiPanel.tsx:25` | 97 |
| `DraftChat` | `ReactFlowGraph.tsx:86` | 62 |
| `ValidationPanel` | `OutputsDock.tsx:68` | 7 |

Against `GuidancePanel` the same shape returns one apparent "import" hit — `import.meta.env` on line 150 **of its own file**, a substring false positive, not an import of the component.

## 2. Where coaching actually surfaces

Traced to rendered surfaces, not filenames. The hub is **`src/canvas/stores/guidanceStore.ts`** (~38 non-test consumers). Live render paths:

| Surface | Trace |
|---|---|
| **On-canvas node cards** | `guidanceStore` → `src/canvas/nodes/FactorNode.tsx:25` → renders `CoachingCard` at `:841`. Sibling nodes (Decision/Goal/Outcome/Risk) consume the store too. |
| **Conversation composer** | `src/canvas/conversation/GuidanceStrip.tsx` → `zones/ChatComposer.tsx:23` |
| **Conversation messages** | `src/canvas/conversation/InlineBlocks.tsx` → `MessageBubble.tsx:22` |
| **Dock — Olumi tab** | `src/canvas/components/OlumiTabBody.tsx` → `OutputsDock.tsx:53` |
| **Dock — Analysis tab** | `OutputsDock.tsx:422` reads `guidanceItems`, passes to `ResultsBody` at `:2334` |

There is genuinely **more than one** live surface, so the corrected comment says so rather than picking one. The **direct successor of what `CoachingNudge` did** (inline nudges on the canvas) is `CoachingCard` on the nodes — that is what the `:2190` overlay-site comment now points at.

The old comment's "OutputsDock" was half-right by accident: guidance *does* reach the dock — but via `OlumiTabBody`/`ResultsBody`, never via `GuidancePanel`.

### The other half of the claim, verified
"CoachingNudge and useCEECoaching removed" — **removed from this file only**. Both still exist in the repo (`src/components/coaching/CoachingNudge.tsx`, `src/canvas/hooks/useCEECoaching.ts`). The comment now says "removed from this file" so it cannot be misread as repo-wide deletion.

Also worth recording: **`useCEECoaching` is not CEE-powered.** Despite the name and its "Week 3: CEE-Powered Coaching" docblock, it makes no CEE call — it is a local `setInterval` heuristic over `useCanvasStore` (disconnected nodes, single option, missing risks, uniform weights). Reported, not fixed.

## 3. The three corrections

**`:77`**
```diff
-// CoachingNudge and useCEECoaching removed - coaching now in GuidancePanel (OutputsDock)
+// CoachingNudge and useCEECoaching removed from this file. Coaching is now driven by
+// guidanceStore (./stores/guidanceStore.ts) and rendered by several surfaces: on-canvas via
+// CoachingCard in ./nodes/FactorNode.tsx, in-conversation via ./conversation/GuidanceStrip.tsx
+// and ./conversation/InlineBlocks.tsx, and in the dock via ./components/OlumiTabBody.tsx.
+// Not GuidancePanel.tsx — that component has no importers.
```

**`:359`**
```diff
-  // Week 3: AI Coaching moved to GuidancePanel in OutputsDock
+  // AI coaching is rendered by the guidanceStore consumers, not here — see
+  // ./nodes/FactorNode.tsx (on-canvas CoachingCard) and ./conversation/GuidanceStrip.tsx.
```

**`:2190`**
```diff
-      {/* Week 3: AI Coaching nudges moved to GuidancePanel in OutputsDock */}
+      {/* Coaching nudges render on the nodes themselves
+          (./nodes/FactorNode.tsx → ./components/CoachingCard.tsx), not as a canvas overlay */}
```

"Week 3:" was dropped as an unverifiable historical marker on lines being rewritten anyway. Flagging it explicitly in case a reviewer wants it kept.

`src/lib/nextSteps.ts:9` also names `GuidancePanel` in a docblock bullet. **Left untouched** — it is a design-intent note in a different subsystem, not a successor claim, and out of scope for this branch.

## 4. Owner ruling requested — `GuidancePanel.tsx` archive recommendation

**Recommendation: archive. Reported, not acted on** — matching how #372 handled `AIClarifierChat` and the Provenance Hub: evidence recorded, code untouched, owner decides.

It is not one stranded file but a **stranded cluster of six**, ~1,620 lines:

| File | Lines | Why dead |
|---|---|---|
| `src/canvas/components/GuidancePanel.tsx` | 323 | zero importers (manifest above) |
| `src/canvas/components/PreAnalysisGuidance.tsx` | 728 | zero importers — see below |
| `src/canvas/components/GuidanceCard.tsx` | 281 | imported **only** by the two dead files above |
| `src/canvas/hooks/useCEECoaching.ts` | 187 | imported **only** by the two dead files above |
| `src/components/coaching/CoachingNudge.tsx` | 101 | only reference is a **type-only** import (`NudgeData`) from dead `useCEECoaching`; **zero `<CoachingNudge` JSX usages repo-wide** |
| `src/components/coaching/CoachingNudge.module.css` | — | consumed only by the above |

**`PreAnalysisGuidance` is the `StabilityGauge` pattern, and worse.** Its only reference is `__tests__/PreAnalysisGuidance.gaps.spec.ts` — and that spec **does not import it**. Its only import is `vitest`; it *replicates* the logic, self-describing as `// ----- Extracted/replicated gapItems logic (mirrors PreAnalysisGuidance.tsx) -----`. So 728 lines of product code are covered by a test that would stay green if the file were deleted. `GuidancePanel` itself has **no test at all**.

Second dead export: `useGuidanceCount()` (`GuidancePanel.tsx:288`) — zero importers.

**Would it still work if mounted?** Probably yes — this is rot-by-obsolescence, not rot-by-breakage. Every store slice it reads is still live (`graphHealth` 45 refs, `runMeta` 40, `setHighlightedNodes` 4, plus `hasCompletedFirstRun`/`currentScenarioFraming` via the hook), `GuidanceCard` still exists, and typecheck is clean. **But it would render the wrong thing:** it predates `guidanceStore` entirely and reads none of it, so it would show legacy `graphHealth`/`runMeta.ceeReview` data while every live surface reads the store — two divergent guidance models on screen at once.

**What would be lost by archiving:** the only consolidated severity-ranked guidance view (blockers → warnings → info across coaching, validation, weight suggestions and bias findings), its keyboard-navigation implementation, and `GuidanceCard`'s auto-fix affordance (`AutoFixStatus`, used only by dead `PreAnalysisGuidance`). Today's live surfaces are context-local — none aggregates. If a consolidated panel is on the roadmap, `GuidanceCard` is the reusable part; if not, the whole cluster goes.

## Gates
- `pnpm run typecheck` — clean
- `pnpm run lint` (`eslint src/canvas/ReactFlowGraph.tsx`) — **0 errors**, 17 pre-existing warnings, none in the changed lines
- No new tests: comment-only change

Verified in a fresh blobless clone off `origin/staging` @ `1237c441`, not a local working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
