### PR TITLE
fix(a11y): retint --text-light to clear WCAG 4.5:1 for text

### DIFF
--- a/src/canvas/components/LensDropdown.tsx
+++ b/src/canvas/components/LensDropdown.tsx
@@ -38,7 +38,7 @@ function LensChip({ isActive, onClick, chipRef }: LensChipProps) {
         gap: 4,
         height: 30,
         padding: '0 8px',
-        color: isActive ? 'var(--info)' : 'var(--text-light, #706D6D)',
+        color: isActive ? 'var(--info)' : 'var(--text-light, #6E6B6B)',
         fontSize: 13,
         fontWeight: 500,
         whiteSpace: 'nowrap' as const,
@@ -330,7 +330,7 @@ function LensMenuItem({ label, description, isActive, onClick, dotColor, disable
         fontSize: 12,
         fontWeight: isActive ? 500 : 400,
         color: disabled
-          ? 'var(--text-light, #706D6D)'
+          ? 'var(--text-light, #6E6B6B)'
           : isActive ? 'var(--info)' : 'var(--text-body, #3F3F3E)',
         textAlign: 'left',
         transition: 'background 100ms ease',
@@ -362,7 +362,7 @@ function LensMenuItem({ label, description, isActive, onClick, dotColor, disable
               fontWeight: 400,
               // Disabled dimming comes from the parent button's opacity: 0.6,
               // so both states share the muted text token.
-              color: 'var(--text-light, #706D6D)',
+              color: 'var(--text-light, #6E6B6B)',
               marginTop: 1,
             }}
           >

--- a/src/canvas/components/LensDropdown.tsx
+++ b/src/canvas/components/LensDropdown.tsx
@@ -38,7 +38,7 @@ function LensChip({ isActive, onClick, chipRef }: LensChipProps) {
         gap: 4,
         height: 30,
         padding: '0 8px',
-        color: isActive ? 'var(--info)' : 'var(--text-light, #908D8D)',
+        color: isActive ? 'var(--info)' : 'var(--text-light, #706D6D)',
         fontSize: 13,
         fontWeight: 500,
         whiteSpace: 'nowrap' as const,
@@ -330,7 +330,7 @@ function LensMenuItem({ label, description, isActive, onClick, dotColor, disable
         fontSize: 12,
         fontWeight: isActive ? 500 : 400,
         color: disabled
-          ? 'var(--text-light, #908D8D)'
+          ? 'var(--text-light, #706D6D)'
           : isActive ? 'var(--info)' : 'var(--text-body, #3F3F3E)',
         textAlign: 'left',
         transition: 'background 100ms ease',
@@ -362,7 +362,7 @@ function LensMenuItem({ label, description, isActive, onClick, dotColor, disable
               fontWeight: 400,
               // Disabled dimming comes from the parent button's opacity: 0.6,
               // so both states share the muted text token.
-              color: 'var(--text-light, #908D8D)',
+              color: 'var(--text-light, #706D6D)',
               marginTop: 1,
             }}
           >

--- a/src/canvas/components/LensInfoPanel.tsx
+++ b/src/canvas/components/LensInfoPanel.tsx
@@ -46,7 +46,7 @@ function CausalPanel() {
       <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 4 }}>
         Causal model
       </div>
-      <div style={{ fontSize: 11, color: 'var(--text-light, #908D8D)', lineHeight: 1.5 }}>
+      <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', lineHeight: 1.5 }}>
         Showing the causal model used for inference.{' '}
         {variableCount} variable{variableCount !== 1 ? 's' : ''},{' '}
         {causalEdgeCount} causal edge{causalEdgeCount !== 1 ? 's' : ''}.{' '}
@@ -68,7 +68,7 @@ function CausalPanel() {
         <div className="mt-2 max-h-[200px] overflow-y-auto" style={{ fontSize: 11, fontFamily: 'ui-monospace, monospace' }}>
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
-              <tr style={{ color: 'var(--text-light, #908D8D)', textAlign: 'left' }}>
+              <tr style={{ color: 'var(--text-light, #706D6D)', textAlign: 'left' }}>
                 <th style={{ padding: '2px 4px' }}>From</th>
                 <th style={{ padding: '2px 4px' }}>To</th>
                 <th style={{ padding: '2px 4px' }}>Mean</th>
@@ -82,8 +82,8 @@ function CausalPanel() {
                   <td style={{ padding: '2px 4px', maxWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.from}>{r.from}</td>
                   <td style={{ padding: '2px 4px', maxWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.to}>{r.to}</td>
                   <td style={{ padding: '2px 4px' }}>{r.mean >= 0 ? '+' : ''}{r.mean.toFixed(2)}</td>
-                  <td style={{ padding: '2px 4px', color: r.std === null ? 'var(--text-light, #908D8D)' : undefined }}>{r.std !== null ? r.std.toFixed(2) : '\u2014'}</td>
-                  <td style={{ padding: '2px 4px', color: r.existsProb === null ? 'var(--text-light, #908D8D)' : undefined }}>{r.existsProb !== null ? `${Math.round(r.existsProb * 100)}%` : '\u2014'}</td>
+                  <td style={{ padding: '2px 4px', color: r.std === null ? 'var(--text-light, #706D6D)' : undefined }}>{r.std !== null ? r.std.toFixed(2) : '\u2014'}</td>
+                  <td style={{ padding: '2px 4px', color: r.existsProb === null ? 'var(--text-light, #706D6D)' : undefined }}>{r.existsProb !== null ? `${Math.round(r.existsProb * 100)}%` : '\u2014'}</td>
                 </tr>
               ))}
             </tbody>
@@ -124,7 +124,7 @@ function EvidencePanel() {
       <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 4 }}>
         Evidence quality
       </div>
-      <div style={{ fontSize: 11, color: 'var(--text-light, #908D8D)', lineHeight: 1.5 }}>
+      <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', lineHeight: 1.5 }}>
         {nodeCounts.grounded} of {nodeCounts.total} factor{nodeCounts.total !== 1 ? 's' : ''} have evidence.{' '}
         {assumedEdgeCount} edge{assumedEdgeCount !== 1 ? 's are' : ' is'} model-assumed.
       </div>
@@ -191,7 +191,7 @@ function RobustnessPanel() {
       <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 4 }}>
         Robustness
       </div>
-      <div style={{ fontSize: 11, color: 'var(--text-light, #908D8D)', lineHeight: 1.5 }}>
+      <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', lineHeight: 1.5 }}>
         {stability !== null && (
           <>Recommendation stability: {stability}%. </>
         )}

--- a/src/canvas/components/LensInfoPanel.tsx
+++ b/src/canvas/components/LensInfoPanel.tsx
@@ -46,7 +46,7 @@ function CausalPanel() {
       <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 4 }}>
         Causal model
       </div>
-      <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', lineHeight: 1.5 }}>
+      <div style={{ fontSize: 11, color: 'var(--text-light, #6E6B6B)', lineHeight: 1.5 }}>
         Showing the causal model used for inference.{' '}
         {variableCount} variable{variableCount !== 1 ? 's' : ''},{' '}
         {causalEdgeCount} causal edge{causalEdgeCount !== 1 ? 's' : ''}.{' '}
@@ -68,7 +68,7 @@ function CausalPanel() {
         <div className="mt-2 max-h-[200px] overflow-y-auto" style={{ fontSize: 11, fontFamily: 'ui-monospace, monospace' }}>
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
-              <tr style={{ color: 'var(--text-light, #706D6D)', textAlign: 'left' }}>
+              <tr style={{ color: 'var(--text-light, #6E6B6B)', textAlign: 'left' }}>
                 <th style={{ padding: '2px 4px' }}>From</th>
                 <th style={{ padding: '2px 4px' }}>To</th>
                 <th style={{ padding: '2px 4px' }}>Mean</th>
@@ -82,8 +82,8 @@ function CausalPanel() {
                   <td style={{ padding: '2px 4px', maxWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.from}>{r.from}</td>
                   <td style={{ padding: '2px 4px', maxWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.to}>{r.to}</td>
                   <td style={{ padding: '2px 4px' }}>{r.mean >= 0 ? '+' : ''}{r.mean.toFixed(2)}</td>
-                  <td style={{ padding: '2px 4px', color: r.std === null ? 'var(--text-light, #706D6D)' : undefined }}>{r.std !== null ? r.std.toFixed(2) : '\u2014'}</td>
-                  <td style={{ padding: '2px 4px', color: r.existsProb === null ? 'var(--text-light, #706D6D)' : undefined }}>{r.existsProb !== null ? `${Math.round(r.existsProb * 100)}%` : '\u2014'}</td>
+                  <td style={{ padding: '2px 4px', color: r.std === null ? 'var(--text-light, #6E6B6B)' : undefined }}>{r.std !== null ? r.std.toFixed(2) : '\u2014'}</td>
+                  <td style={{ padding: '2px 4px', color: r.existsProb === null ? 'var(--text-light, #6E6B6B)' : undefined }}>{r.existsProb !== null ? `${Math.round(r.existsProb * 100)}%` : '\u2014'}</td>
                 </tr>
               ))}
             </tbody>
@@ -124,7 +124,7 @@ function EvidencePanel() {
       <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 4 }}>
         Evidence quality
       </div>
-      <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', lineHeight: 1.5 }}>
+      <div style={{ fontSize: 11, color: 'var(--text-light, #6E6B6B)', lineHeight: 1.5 }}>
         {nodeCounts.grounded} of {nodeCounts.total} factor{nodeCounts.total !== 1 ? 's' : ''} have evidence.{' '}
         {assumedEdgeCount} edge{assumedEdgeCount !== 1 ? 's are' : ' is'} model-assumed.
       </div>
@@ -191,7 +191,7 @@ function RobustnessPanel() {
       <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 4 }}>
         Robustness
       </div>
-      <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', lineHeight: 1.5 }}>
+      <div style={{ fontSize: 11, color: 'var(--text-light, #6E6B6B)', lineHeight: 1.5 }}>
         {stability !== null && (
           <>Recommendation stability: {stability}%. </>
         )}

--- a/src/canvas/components/ModelHealthSection.tsx
+++ b/src/canvas/components/ModelHealthSection.tsx
@@ -74,7 +74,7 @@ function IssueRow({ issue }: { issue: HealthIssue }) {
         <div style={{ fontWeight: 500, color: 'var(--text-body, #3F3F3E)' }}>
           {issue.title}
         </div>
-        <div style={{ color: 'var(--text-light, #706D6D)', marginTop: 1 }}>
+        <div style={{ color: 'var(--text-light, #6E6B6B)', marginTop: 1 }}>
           {issue.description}
         </div>
       </div>
@@ -145,7 +145,7 @@ export function ModelHealthSection() {
       )}
 
       {isExpanded && !hasIssues && (
-        <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', marginTop: 4 }}>
+        <div style={{ fontSize: 11, color: 'var(--text-light, #6E6B6B)', marginTop: 4 }}>
           All structural checks pass. The model is ready for analysis.
         </div>
       )}

--- a/src/canvas/components/ModelHealthSection.tsx
+++ b/src/canvas/components/ModelHealthSection.tsx
@@ -74,7 +74,7 @@ function IssueRow({ issue }: { issue: HealthIssue }) {
         <div style={{ fontWeight: 500, color: 'var(--text-body, #3F3F3E)' }}>
           {issue.title}
         </div>
-        <div style={{ color: 'var(--text-light, #908D8D)', marginTop: 1 }}>
+        <div style={{ color: 'var(--text-light, #706D6D)', marginTop: 1 }}>
           {issue.description}
         </div>
       </div>
@@ -145,7 +145,7 @@ export function ModelHealthSection() {
       )}
 
       {isExpanded && !hasIssues && (
-        <div style={{ fontSize: 11, color: 'var(--text-light, #908D8D)', marginTop: 4 }}>
+        <div style={{ fontSize: 11, color: 'var(--text-light, #706D6D)', marginTop: 4 }}>
           All structural checks pass. The model is ready for analysis.
         </div>
       )}

--- a/src/canvas/components/pre-analysis/primitives/BiasIcon.tsx
+++ b/src/canvas/components/pre-analysis/primitives/BiasIcon.tsx
@@ -7,7 +7,7 @@
  * - Confidence (Gauge icon): AI-estimated value (source === 'cee_inference')
  * - Blind spots (EyeOff icon): No constraints, no risks, or no negative edges
  *
- * Always rendered in #908D8D (text-light).
+ * Always rendered in #706D6D (text-light).
  * Tooltip on hover: "{plain-English why} · {Bias category name}"
  */
 

--- a/src/canvas/components/pre-analysis/primitives/BiasIcon.tsx
+++ b/src/canvas/components/pre-analysis/primitives/BiasIcon.tsx
@@ -7,7 +7,7 @@
  * - Confidence (Gauge icon): AI-estimated value (source === 'cee_inference')
  * - Blind spots (EyeOff icon): No constraints, no risks, or no negative edges
  *
- * Always rendered in #706D6D (text-light).
+ * Always rendered in #6E6B6B (text-light).
  * Tooltip on hover: "{plain-English why} · {Bias category name}"
  */
 

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -116,7 +116,7 @@
   border-left: none;
   margin: 6px 0;
   padding: 4px 12px;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 .markdownContent strong {
   font-weight: var(--conv-type-weight-semibold);
@@ -154,7 +154,7 @@
   display: inline-flex;
   align-items: center;
   background: var(--bg-panel-hover, #FEF9F3);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   border-radius: var(--radius-pill, 999px);
   padding: var(--space-1, 4px) var(--space-2, 8px);
   max-width: 85%;
@@ -243,7 +243,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--text-light, #706D6D);
+  background: var(--text-light, #6E6B6B);
   animation: typingBounce 1.4s ease-in-out infinite;
 }
 
@@ -266,7 +266,7 @@
 
 .longRunningHint {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   margin-top: 4px;
 }
 
@@ -283,7 +283,7 @@
 
 .commentaryBlock {
   /* DS v5 §21.2 — Commentary is inline: no border, muted text, slight indent. */
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   padding-left: 12px;
 }
 
@@ -358,12 +358,12 @@
 
 .factLabel {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .factSource {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   font-style: italic;
 }
 
@@ -442,7 +442,7 @@
 
 .graphPatchMeta {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .graphPatchProposalList {
@@ -474,13 +474,13 @@
 }
 
 .graphPatchProposalLabel {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .graphPatchProposalBadge {
   flex-shrink: 0;
   padding: 0;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   font-weight: var(--conv-type-weight-regular);
 }
 
@@ -513,7 +513,7 @@
 
 .graphPatchAccept:disabled {
   background: var(--border-default, #EEE6D8);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   cursor: not-allowed;
 }
 
@@ -539,7 +539,7 @@
 }
 
 .graphPatchDismiss:disabled {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   cursor: not-allowed;
 }
 
@@ -563,7 +563,7 @@
 
 .graphPatchStatusDismissed {
   composes: graphPatchStatus;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .graphPatchError {
@@ -653,7 +653,7 @@
 .reasoningPanelHeading {
   font-size: var(--conv-type-size-meta);
   font-weight: var(--conv-type-weight-semibold);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   margin: 0 0 6px 0;
   text-transform: none;
 }
@@ -712,7 +712,7 @@
 .framingSectionLabel {
   font-size: var(--conv-type-size-meta);
   font-weight: var(--conv-type-weight-semibold);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   letter-spacing: 0.04em;
 }
 
@@ -826,7 +826,7 @@
 
 .factBarValue {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   flex-shrink: 0;
   min-width: 36px;
   text-align: right;
@@ -876,7 +876,7 @@
 
 .factLineage {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   font-style: italic;
   margin-top: 4px;
 }
@@ -912,7 +912,7 @@
 
 .priorityBadgeLow {
   composes: priorityBadge;
-  background: var(--text-light, #706D6D);
+  background: var(--text-light, #6E6B6B);
 }
 
 .reviewCardBadgeRow {
@@ -928,7 +928,7 @@
 
 .citationLegend {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   margin-top: 6px;
   border-top: 1px solid var(--border-default, #EEE6D8);
   padding-top: 4px;
@@ -1099,11 +1099,11 @@
 }
 
 .evidenceConfidence {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .evidenceQuery {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   font-style: italic;
   margin-top: 4px;
 }
@@ -1134,7 +1134,7 @@
 }
 
 .graphPatchDanger:disabled {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   border-color: var(--border-default, #EEE6D8);
   cursor: not-allowed;
 }
@@ -1230,7 +1230,7 @@
 }
 
 .baseRateLabel {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .baseRateRow {
@@ -1422,7 +1422,7 @@
   border-radius: 6px;
   border: none;
   background: transparent;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   cursor: pointer;
   transition: color 150ms;
 }
@@ -1473,7 +1473,7 @@
 }
 
 .growingInput::placeholder {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .sendButton {
@@ -1498,7 +1498,7 @@
 .sendButtonDisabled {
   composes: sendButton;
   background: var(--border-default, #EEE6D8);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   cursor: not-allowed;
 }
 
@@ -1603,7 +1603,7 @@
 
 .actionStripCount {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -1712,7 +1712,7 @@
   gap: 6px;
   padding: 4px 0;
   font-size: var(--conv-type-size-prominent);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .toolLoadingDot {
@@ -1988,7 +1988,7 @@
   gap: 4px;
   align-self: flex-start;
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   background: none;
   border: none;
   padding: 2px 0;
@@ -2023,7 +2023,7 @@
 
 .vocabularyLegendDefinition {
   margin: 0;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 /* Focus-visible for these toggles lives in the shared "Toggles and

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -116,7 +116,7 @@
   border-left: none;
   margin: 6px 0;
   padding: 4px 12px;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 .markdownContent strong {
   font-weight: var(--conv-type-weight-semibold);
@@ -154,7 +154,7 @@
   display: inline-flex;
   align-items: center;
   background: var(--bg-panel-hover, #FEF9F3);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   border-radius: var(--radius-pill, 999px);
   padding: var(--space-1, 4px) var(--space-2, 8px);
   max-width: 85%;
@@ -243,7 +243,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--text-light, #908D8D);
+  background: var(--text-light, #706D6D);
   animation: typingBounce 1.4s ease-in-out infinite;
 }
 
@@ -266,7 +266,7 @@
 
 .longRunningHint {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   margin-top: 4px;
 }
 
@@ -283,7 +283,7 @@
 
 .commentaryBlock {
   /* DS v5 §21.2 — Commentary is inline: no border, muted text, slight indent. */
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   padding-left: 12px;
 }
 
@@ -358,12 +358,12 @@
 
 .factLabel {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .factSource {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   font-style: italic;
 }
 
@@ -442,7 +442,7 @@
 
 .graphPatchMeta {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .graphPatchProposalList {
@@ -474,13 +474,13 @@
 }
 
 .graphPatchProposalLabel {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .graphPatchProposalBadge {
   flex-shrink: 0;
   padding: 0;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   font-weight: var(--conv-type-weight-regular);
 }
 
@@ -513,7 +513,7 @@
 
 .graphPatchAccept:disabled {
   background: var(--border-default, #EEE6D8);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   cursor: not-allowed;
 }
 
@@ -539,7 +539,7 @@
 }
 
 .graphPatchDismiss:disabled {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   cursor: not-allowed;
 }
 
@@ -563,7 +563,7 @@
 
 .graphPatchStatusDismissed {
   composes: graphPatchStatus;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .graphPatchError {
@@ -653,7 +653,7 @@
 .reasoningPanelHeading {
   font-size: var(--conv-type-size-meta);
   font-weight: var(--conv-type-weight-semibold);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   margin: 0 0 6px 0;
   text-transform: none;
 }
@@ -712,7 +712,7 @@
 .framingSectionLabel {
   font-size: var(--conv-type-size-meta);
   font-weight: var(--conv-type-weight-semibold);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   letter-spacing: 0.04em;
 }
 
@@ -826,7 +826,7 @@
 
 .factBarValue {
   font-size: var(--conv-type-size-body);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   flex-shrink: 0;
   min-width: 36px;
   text-align: right;
@@ -876,7 +876,7 @@
 
 .factLineage {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   font-style: italic;
   margin-top: 4px;
 }
@@ -912,7 +912,7 @@
 
 .priorityBadgeLow {
   composes: priorityBadge;
-  background: var(--text-light, #908D8D);
+  background: var(--text-light, #706D6D);
 }
 
 .reviewCardBadgeRow {
@@ -928,7 +928,7 @@
 
 .citationLegend {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   margin-top: 6px;
   border-top: 1px solid var(--border-default, #EEE6D8);
   padding-top: 4px;
@@ -1099,11 +1099,11 @@
 }
 
 .evidenceConfidence {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .evidenceQuery {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   font-style: italic;
   margin-top: 4px;
 }
@@ -1134,7 +1134,7 @@
 }
 
 .graphPatchDanger:disabled {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   border-color: var(--border-default, #EEE6D8);
   cursor: not-allowed;
 }
@@ -1230,7 +1230,7 @@
 }
 
 .baseRateLabel {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .baseRateRow {
@@ -1422,7 +1422,7 @@
   border-radius: 6px;
   border: none;
   background: transparent;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   cursor: pointer;
   transition: color 150ms;
 }
@@ -1473,7 +1473,7 @@
 }
 
 .growingInput::placeholder {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .sendButton {
@@ -1498,7 +1498,7 @@
 .sendButtonDisabled {
   composes: sendButton;
   background: var(--border-default, #EEE6D8);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   cursor: not-allowed;
 }
 
@@ -1603,7 +1603,7 @@
 
 .actionStripCount {
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -1712,7 +1712,7 @@
   gap: 6px;
   padding: 4px 0;
   font-size: var(--conv-type-size-prominent);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .toolLoadingDot {
@@ -1988,7 +1988,7 @@
   gap: 4px;
   align-self: flex-start;
   font-size: var(--conv-type-size-meta);
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   background: none;
   border: none;
   padding: 2px 0;
@@ -2023,7 +2023,7 @@
 
 .vocabularyLegendDefinition {
   margin: 0;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 /* Focus-visible for these toggles lives in the shared "Toggles and

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -614,7 +614,7 @@ export const ConversationPanel = memo(function ConversationPanel({
             width: 28, height: 28,
             background: 'transparent',
             border: 'none',
-            color: 'var(--text-light, #706D6D)',
+            color: 'var(--text-light, #6E6B6B)',
             cursor: 'pointer',
             transition: 'all 150ms',
           }}

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -614,7 +614,7 @@ export const ConversationPanel = memo(function ConversationPanel({
             width: 28, height: 28,
             background: 'transparent',
             border: 'none',
-            color: 'var(--text-light, #908D8D)',
+            color: 'var(--text-light, #706D6D)',
             cursor: 'pointer',
             transition: 'all 150ms',
           }}

--- a/src/canvas/conversation/FeedbackRow.tsx
+++ b/src/canvas/conversation/FeedbackRow.tsx
@@ -60,7 +60,7 @@ export const FeedbackRow = memo(function FeedbackRow({ turnId, onFeedback }: Fee
           borderRadius: '6px',
           cursor: voted !== null ? 'default' : 'pointer',
           opacity: voted !== null && voted !== 'up' ? 0.3 : 1,
-          color: voted === 'up' ? 'var(--success, #67C89E)' : 'var(--text-light, #706D6D)',
+          color: voted === 'up' ? 'var(--success, #67C89E)' : 'var(--text-light, #6E6B6B)',
           transition: 'none',
         }}
       >
@@ -87,7 +87,7 @@ export const FeedbackRow = memo(function FeedbackRow({ turnId, onFeedback }: Fee
           borderRadius: '6px',
           cursor: voted !== null ? 'default' : 'pointer',
           opacity: voted !== null && voted !== 'down' ? 0.3 : 1,
-          color: voted === 'down' ? 'var(--danger, #EA7B4B)' : 'var(--text-light, #706D6D)',
+          color: voted === 'down' ? 'var(--danger, #EA7B4B)' : 'var(--text-light, #6E6B6B)',
           transition: 'none',
         }}
       >

--- a/src/canvas/conversation/FeedbackRow.tsx
+++ b/src/canvas/conversation/FeedbackRow.tsx
@@ -60,7 +60,7 @@ export const FeedbackRow = memo(function FeedbackRow({ turnId, onFeedback }: Fee
           borderRadius: '6px',
           cursor: voted !== null ? 'default' : 'pointer',
           opacity: voted !== null && voted !== 'up' ? 0.3 : 1,
-          color: voted === 'up' ? 'var(--success, #67C89E)' : 'var(--text-light, #908D8D)',
+          color: voted === 'up' ? 'var(--success, #67C89E)' : 'var(--text-light, #706D6D)',
           transition: 'none',
         }}
       >
@@ -87,7 +87,7 @@ export const FeedbackRow = memo(function FeedbackRow({ turnId, onFeedback }: Fee
           borderRadius: '6px',
           cursor: voted !== null ? 'default' : 'pointer',
           opacity: voted !== null && voted !== 'down' ? 0.3 : 1,
-          color: voted === 'down' ? 'var(--danger, #EA7B4B)' : 'var(--text-light, #908D8D)',
+          color: voted === 'down' ? 'var(--danger, #EA7B4B)' : 'var(--text-light, #706D6D)',
           transition: 'none',
         }}
       >

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -272,7 +272,7 @@ export const MessageBubble = memo(function MessageBubble({
       {message.stoppedByUser && (
         <div
           className={typography.panelMeta}
-          style={{ color: 'var(--text-light, #706D6D)', marginTop: 4 }}
+          style={{ color: 'var(--text-light, #6E6B6B)', marginTop: 4 }}
           data-testid="response-stopped-indicator"
         >
           Response stopped.

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -272,7 +272,7 @@ export const MessageBubble = memo(function MessageBubble({
       {message.stoppedByUser && (
         <div
           className={typography.panelMeta}
-          style={{ color: 'var(--text-light, #908D8D)', marginTop: 4 }}
+          style={{ color: 'var(--text-light, #706D6D)', marginTop: 4 }}
           data-testid="response-stopped-indicator"
         >
           Response stopped.

--- a/src/canvas/conversation/__tests__/conversationCss.spec.ts
+++ b/src/canvas/conversation/__tests__/conversationCss.spec.ts
@@ -155,7 +155,7 @@ describe('index.css — olumi scrollbar utility', () => {
     expect(css).toContain('width: 4px')
     expect(css).toContain('height: 4px')
     expect(css).toContain('var(--border-default, #EEE6D8)')
-    expect(css).toContain('var(--text-light, #706D6D)')
+    expect(css).toContain('var(--text-light, #6E6B6B)')
   })
 
   it('is applied to the AI thread and right-hand panel sources', () => {

--- a/src/canvas/conversation/__tests__/conversationCss.spec.ts
+++ b/src/canvas/conversation/__tests__/conversationCss.spec.ts
@@ -155,7 +155,7 @@ describe('index.css — olumi scrollbar utility', () => {
     expect(css).toContain('width: 4px')
     expect(css).toContain('height: 4px')
     expect(css).toContain('var(--border-default, #EEE6D8)')
-    expect(css).toContain('var(--text-light, #908D8D)')
+    expect(css).toContain('var(--text-light, #706D6D)')
   })
 
   it('is applied to the AI thread and right-hand panel sources', () => {

--- a/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
+++ b/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
@@ -112,7 +112,7 @@ export function ThinkingModeDropdown({
         <span
           className={typography.panelMeta}
           style={{
-            color: 'var(--text-light, #706D6D)',
+            color: 'var(--text-light, #6E6B6B)',
             padding: '2px 8px',
             borderRadius: 999,
             border: '1px solid var(--border-default, #EEE6D8)',
@@ -164,14 +164,14 @@ export function ThinkingModeDropdown({
             </div>
             <div>
               <div className={`${typography.panelBody} font-semibold`} style={{ color: 'var(--text-header, #262626)' }}>{mode.label}</div>
-              <div className={typography.panelMeta} style={{ color: 'var(--text-light, #706D6D)', marginTop: 1 }}>{mode.description}</div>
+              <div className={typography.panelMeta} style={{ color: 'var(--text-light, #6E6B6B)', marginTop: 1 }}>{mode.description}</div>
             </div>
           </button>
         )
       })}
 
       {/* Footer */}
-      <p className={typography.panelMeta} style={{ color: 'var(--text-light, #706D6D)', marginTop: 8 }}>
+      <p className={typography.panelMeta} style={{ color: 'var(--text-light, #6E6B6B)', marginTop: 8 }}>
         Select the depth of reasoning for your analysis. Available in an upcoming release.
       </p>
 

--- a/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
+++ b/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
@@ -112,7 +112,7 @@ export function ThinkingModeDropdown({
         <span
           className={typography.panelMeta}
           style={{
-            color: 'var(--text-light, #908D8D)',
+            color: 'var(--text-light, #706D6D)',
             padding: '2px 8px',
             borderRadius: 999,
             border: '1px solid var(--border-default, #EEE6D8)',
@@ -164,14 +164,14 @@ export function ThinkingModeDropdown({
             </div>
             <div>
               <div className={`${typography.panelBody} font-semibold`} style={{ color: 'var(--text-header, #262626)' }}>{mode.label}</div>
-              <div className={typography.panelMeta} style={{ color: 'var(--text-light, #908D8D)', marginTop: 1 }}>{mode.description}</div>
+              <div className={typography.panelMeta} style={{ color: 'var(--text-light, #706D6D)', marginTop: 1 }}>{mode.description}</div>
             </div>
           </button>
         )
       })}
 
       {/* Footer */}
-      <p className={typography.panelMeta} style={{ color: 'var(--text-light, #908D8D)', marginTop: 8 }}>
+      <p className={typography.panelMeta} style={{ color: 'var(--text-light, #706D6D)', marginTop: 8 }}>
         Select the depth of reasoning for your analysis. Available in an upcoming release.
       </p>
 

--- a/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
+++ b/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
@@ -60,7 +60,7 @@ export function BriefGuidanceStrip({ elements, onElementClick }: BriefGuidanceSt
             opacity: el.detected ? 1 : 0.5,
             color: el.detected
               ? 'var(--text-body, #3F3F3E)'
-              : 'var(--text-light, #706D6D)',
+              : 'var(--text-light, #6E6B6B)',
           }}
           title={el.coachingTip}
           aria-label={`${el.label}: ${el.detected ? 'detected' : 'not detected'}`}
@@ -71,7 +71,7 @@ export function BriefGuidanceStrip({ elements, onElementClick }: BriefGuidanceSt
               <NodeShape kind={el.kind} size={10} />
             </span>
           ) : (
-            <span className="flex-shrink-0" style={{ width: 7, height: 7, borderRadius: 999, border: '1.5px solid var(--text-light, #706D6D)' }} />
+            <span className="flex-shrink-0" style={{ width: 7, height: 7, borderRadius: 999, border: '1.5px solid var(--text-light, #6E6B6B)' }} />
           )}
           <span>{el.label}</span>
         </button>

--- a/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
+++ b/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
@@ -60,7 +60,7 @@ export function BriefGuidanceStrip({ elements, onElementClick }: BriefGuidanceSt
             opacity: el.detected ? 1 : 0.5,
             color: el.detected
               ? 'var(--text-body, #3F3F3E)'
-              : 'var(--text-light, #908D8D)',
+              : 'var(--text-light, #706D6D)',
           }}
           title={el.coachingTip}
           aria-label={`${el.label}: ${el.detected ? 'detected' : 'not detected'}`}
@@ -71,7 +71,7 @@ export function BriefGuidanceStrip({ elements, onElementClick }: BriefGuidanceSt
               <NodeShape kind={el.kind} size={10} />
             </span>
           ) : (
-            <span className="flex-shrink-0" style={{ width: 7, height: 7, borderRadius: 999, border: '1.5px solid var(--text-light, #908D8D)' }} />
+            <span className="flex-shrink-0" style={{ width: 7, height: 7, borderRadius: 999, border: '1.5px solid var(--text-light, #706D6D)' }} />
           )}
           <span>{el.label}</span>
         </button>

--- a/src/canvas/conversation/zones/BriefReadinessPill.tsx
+++ b/src/canvas/conversation/zones/BriefReadinessPill.tsx
@@ -56,7 +56,7 @@ export function BriefReadinessPill({ readiness, expanded, onToggle }: BriefReadi
         width="10" height="10" viewBox="0 0 24 24" fill="none"
         aria-hidden="true"
         className="flex-shrink-0"
-        style={{ stroke: 'var(--text-light, #908D8D)', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }}
+        style={{ stroke: 'var(--text-light, #706D6D)', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }}
       >
         {expanded
           ? <path d="M18 15l-6-6-6 6" />

--- a/src/canvas/conversation/zones/BriefReadinessPill.tsx
+++ b/src/canvas/conversation/zones/BriefReadinessPill.tsx
@@ -56,7 +56,7 @@ export function BriefReadinessPill({ readiness, expanded, onToggle }: BriefReadi
         width="10" height="10" viewBox="0 0 24 24" fill="none"
         aria-hidden="true"
         className="flex-shrink-0"
-        style={{ stroke: 'var(--text-light, #706D6D)', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }}
+        style={{ stroke: 'var(--text-light, #6E6B6B)', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }}
       >
         {expanded
           ? <path d="M18 15l-6-6-6 6" />

--- a/src/canvas/conversation/zones/ChatComposer.tsx
+++ b/src/canvas/conversation/zones/ChatComposer.tsx
@@ -290,7 +290,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
             style={{
               width: 34, height: 34, borderRadius: '50%',
               marginBottom: 2, background: 'transparent',
-              border: 'none', color: 'var(--text-light, #908D8D)', cursor: 'pointer',
+              border: 'none', color: 'var(--text-light, #706D6D)', cursor: 'pointer',
               transition: 'all 150ms',
             }}
             data-testid="composer-attach-button"
@@ -306,7 +306,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
             style={{
               width: 34, height: 34, borderRadius: '50%',
               marginBottom: 2, background: 'transparent',
-              border: 'none', color: 'var(--text-light, #908D8D)',
+              border: 'none', color: 'var(--text-light, #706D6D)',
               cursor: 'not-allowed', opacity: 0.5, transition: 'all 150ms',
             }}
             data-testid="composer-voice-button"
@@ -328,7 +328,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
                 marginBottom: 2,
                 background: 'transparent',
                 border: 'none',
-                color: 'var(--text-light, #908D8D)',
+                color: 'var(--text-light, #706D6D)',
                 cursor: runDisabled ? 'not-allowed' : 'pointer',
                 opacity: runDisabled ? 0.5 : 1,
                 transition: 'all 150ms',
@@ -418,7 +418,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
               <ArrowUp
                 className="w-[15px] h-[15px]"
                 strokeWidth={2.2}
-                style={{ stroke: composer.canSend ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #908D8D)' }}
+                style={{ stroke: composer.canSend ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #706D6D)' }}
                 aria-hidden="true"
               />
             </button>
@@ -478,7 +478,7 @@ function InlineGenerateButton({ state, onClick }: { state: GenerateState; onClic
         transition: 'all 200ms cubic-bezier(0.4, 0, 0.2, 1)',
         background: (isActive || isLoading) ? 'var(--primary, #2B7FA2)' : 'transparent',
         border: (isActive || isLoading) ? 'none' : '1px solid rgba(176,168,153,0.3)',
-        color: (isActive || isLoading) ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #908D8D)',
+        color: (isActive || isLoading) ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #706D6D)',
         boxShadow: (isActive || isLoading) ? '0 1px 2px rgba(38,38,38,0.06)' : 'none',
         opacity: (isActive || isLoading) ? 1 : 0.55,
         cursor: isActive ? 'pointer' : isLoading ? 'wait' : 'default',
@@ -495,7 +495,7 @@ function InlineGenerateButton({ state, onClick }: { state: GenerateState; onClic
         <Play
           className="w-[11px] h-[11px] flex-shrink-0"
           strokeWidth={2}
-          style={{ stroke: isActive ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #908D8D)' }}
+          style={{ stroke: isActive ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #706D6D)' }}
           aria-hidden="true"
         />
       )}

--- a/src/canvas/conversation/zones/ChatComposer.tsx
+++ b/src/canvas/conversation/zones/ChatComposer.tsx
@@ -290,7 +290,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
             style={{
               width: 34, height: 34, borderRadius: '50%',
               marginBottom: 2, background: 'transparent',
-              border: 'none', color: 'var(--text-light, #706D6D)', cursor: 'pointer',
+              border: 'none', color: 'var(--text-light, #6E6B6B)', cursor: 'pointer',
               transition: 'all 150ms',
             }}
             data-testid="composer-attach-button"
@@ -306,7 +306,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
             style={{
               width: 34, height: 34, borderRadius: '50%',
               marginBottom: 2, background: 'transparent',
-              border: 'none', color: 'var(--text-light, #706D6D)',
+              border: 'none', color: 'var(--text-light, #6E6B6B)',
               cursor: 'not-allowed', opacity: 0.5, transition: 'all 150ms',
             }}
             data-testid="composer-voice-button"
@@ -328,7 +328,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
                 marginBottom: 2,
                 background: 'transparent',
                 border: 'none',
-                color: 'var(--text-light, #706D6D)',
+                color: 'var(--text-light, #6E6B6B)',
                 cursor: runDisabled ? 'not-allowed' : 'pointer',
                 opacity: runDisabled ? 0.5 : 1,
                 transition: 'all 150ms',
@@ -418,7 +418,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
               <ArrowUp
                 className="w-[15px] h-[15px]"
                 strokeWidth={2.2}
-                style={{ stroke: composer.canSend ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #706D6D)' }}
+                style={{ stroke: composer.canSend ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #6E6B6B)' }}
                 aria-hidden="true"
               />
             </button>
@@ -478,7 +478,7 @@ function InlineGenerateButton({ state, onClick }: { state: GenerateState; onClic
         transition: 'all 200ms cubic-bezier(0.4, 0, 0.2, 1)',
         background: (isActive || isLoading) ? 'var(--primary, #2B7FA2)' : 'transparent',
         border: (isActive || isLoading) ? 'none' : '1px solid rgba(176,168,153,0.3)',
-        color: (isActive || isLoading) ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #706D6D)',
+        color: (isActive || isLoading) ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #6E6B6B)',
         boxShadow: (isActive || isLoading) ? '0 1px 2px rgba(38,38,38,0.06)' : 'none',
         opacity: (isActive || isLoading) ? 1 : 0.55,
         cursor: isActive ? 'pointer' : isLoading ? 'wait' : 'default',
@@ -495,7 +495,7 @@ function InlineGenerateButton({ state, onClick }: { state: GenerateState; onClic
         <Play
           className="w-[11px] h-[11px] flex-shrink-0"
           strokeWidth={2}
-          style={{ stroke: isActive ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #706D6D)' }}
+          style={{ stroke: isActive ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #6E6B6B)' }}
           aria-hidden="true"
         />
       )}

--- a/src/canvas/conversation/zones/ComposerTools.tsx
+++ b/src/canvas/conversation/zones/ComposerTools.tsx
@@ -118,7 +118,7 @@ export function ComposerTools({
           marginBottom: 2,
           background: 'transparent',
           border: '1px solid var(--border-default, #EEE6D8)',
-          color: 'var(--text-light, #908D8D)',
+          color: 'var(--text-light, #706D6D)',
           cursor: 'pointer',
           transition: 'all 150ms',
         }}

--- a/src/canvas/conversation/zones/ComposerTools.tsx
+++ b/src/canvas/conversation/zones/ComposerTools.tsx
@@ -118,7 +118,7 @@ export function ComposerTools({
           marginBottom: 2,
           background: 'transparent',
           border: '1px solid var(--border-default, #EEE6D8)',
-          color: 'var(--text-light, #706D6D)',
+          color: 'var(--text-light, #6E6B6B)',
           cursor: 'pointer',
           transition: 'all 150ms',
         }}

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -740,7 +740,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           >
             {causalEdgeParams.mean >= 0 ? '+' : ''}{causalEdgeParams.mean.toFixed(2)}
             {causalEdgeParams.existsProb !== null && (
-              <span style={{ color: 'var(--text-light, #908D8D)' }}>
+              <span style={{ color: 'var(--text-light, #706D6D)' }}>
                 {' '}({Math.round(causalEdgeParams.existsProb * 100)}%)
               </span>
             )}

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -740,7 +740,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           >
             {causalEdgeParams.mean >= 0 ? '+' : ''}{causalEdgeParams.mean.toFixed(2)}
             {causalEdgeParams.existsProb !== null && (
-              <span style={{ color: 'var(--text-light, #706D6D)' }}>
+              <span style={{ color: 'var(--text-light, #6E6B6B)' }}>
                 {' '}({Math.round(causalEdgeParams.existsProb * 100)}%)
               </span>
             )}

--- a/src/canvas/nodes/GhostOptionNode.tsx
+++ b/src/canvas/nodes/GhostOptionNode.tsx
@@ -32,14 +32,25 @@ export const GhostOptionNode = memo((_props: NodeProps) => {
         // first opaque ancestor, with accumulated opacity 1.0 through the whole
         // react-flow chain. --text-body clears 3:1 on both (10.45:1 / 9.29:1).
         //
-        // It is louder than a ghost ideally wants. Every quieter token either
-        // fails 3:1 (--text-light #908D8D is 3.26 on the fill but 2.90 on the
-        // canvas) or collides with a neighbouring canvas state: --danger-hover
-        // sits ΔE2000 5.3 from the --danger risk border, --info-hover 19.5 from
-        // the --info focus/AI-highlight ring. A NEUTRAL is also the correct
-        // three-channel choice — every semantic token would make a health claim
-        // this placeholder cannot support. The palette has no quiet neutral
-        // between #908D8D and #3F3F3E; closing that gap is a brand.css decision.
+        // It is louder than a ghost ideally wants. The quieter tokens either
+        // collide with a neighbouring canvas state — --danger-hover sits ΔE2000
+        // 5.3 from the --danger risk border, --info-hover 19.5 from the --info
+        // focus/AI-highlight ring — or, historically, failed 3:1. A NEUTRAL is
+        // also the correct three-channel choice: every semantic token would
+        // make a health claim this placeholder cannot support.
+        //
+        // ⚠ THE CONSTRAINT THAT PICKED --text-body HAS SINCE BEEN LIFTED, and
+        // this comment used to assert it as still-true. --text-light was
+        // rejected here because at #908D8D it measured 3.26 on the fill and
+        // 2.90 on the canvas — a 3:1 failure. It was retinted to #706D6D on
+        // WCAG 1.4.3 grounds (it was not a legal TEXT colour at any size), and
+        // now measures 5.08 / 4.51 — it clears 3:1 on both adjacent colours
+        // with room to spare, and is exactly the "quiet neutral" this comment
+        // says the palette lacks. Quieting this outline to --text-light is
+        // therefore now AVAILABLE. It is deliberately NOT taken in the retint
+        // PR: that change alters this affordance's appearance and wants its
+        // own review, not a free ride on a token edit. Whoever takes it must
+        // re-measure both grounds here rather than trusting this note.
         //
         // Quietness is carried by the dashed 1.5px stroke, not by hue. Note the
         // incomplete-node border is ALSO dashed (2px --warning #FFA656), so hue

--- a/src/canvas/nodes/GhostOptionNode.tsx
+++ b/src/canvas/nodes/GhostOptionNode.tsx
@@ -42,9 +42,9 @@ export const GhostOptionNode = memo((_props: NodeProps) => {
         // ⚠ THE CONSTRAINT THAT PICKED --text-body HAS SINCE BEEN LIFTED, and
         // this comment used to assert it as still-true. --text-light was
         // rejected here because at #908D8D it measured 3.26 on the fill and
-        // 2.90 on the canvas — a 3:1 failure. It was retinted to #706D6D on
+        // 2.90 on the canvas — a 3:1 failure. It was retinted to #6E6B6B on
         // WCAG 1.4.3 grounds (it was not a legal TEXT colour at any size), and
-        // now measures 5.08 / 4.51 — it clears 3:1 on both adjacent colours
+        // now measures 5.23 / 4.65 — it clears 3:1 on both adjacent colours
         // with room to spare, and is exactly the "quiet neutral" this comment
         // says the palette lacks. Quieting this outline to --text-light is
         // therefore now AVAILABLE. It is deliberately NOT taken in the retint

--- a/src/components/chat/Artefact.module.css
+++ b/src/components/chat/Artefact.module.css
@@ -40,7 +40,7 @@
 }
 
 .headerCollapseIcon {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   flex-shrink: 0;
 }
 
@@ -60,7 +60,7 @@
 
 .headerDescription {
   font-size: 12px;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -74,7 +74,7 @@
   width: 28px;
   height: 28px;
   border-radius: 6px;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   cursor: pointer;
   flex-shrink: 0;
   transition: background 150ms, color 150ms;
@@ -194,7 +194,7 @@
   width: 32px;
   height: 32px;
   border-radius: 6px;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   cursor: pointer;
   transition: background 150ms, color 150ms;
 }

--- a/src/components/chat/Artefact.module.css
+++ b/src/components/chat/Artefact.module.css
@@ -40,7 +40,7 @@
 }
 
 .headerCollapseIcon {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   flex-shrink: 0;
 }
 
@@ -60,7 +60,7 @@
 
 .headerDescription {
   font-size: 12px;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -74,7 +74,7 @@
   width: 28px;
   height: 28px;
   border-radius: 6px;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   cursor: pointer;
   flex-shrink: 0;
   transition: background 150ms, color 150ms;
@@ -194,7 +194,7 @@
   width: 32px;
   height: 32px;
   border-radius: 6px;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   cursor: pointer;
   transition: background 150ms, color 150ms;
 }

--- a/src/components/chat/artefactIframeTemplate.ts
+++ b/src/components/chat/artefactIframeTemplate.ts
@@ -20,7 +20,7 @@ const TEMPLATE_PREFIX = `<!DOCTYPE html>
       --border-default: #EEE6D8;
       --text-header: #262626;
       --text-body: #3F3F3E;
-      --text-light: #706D6D;
+      --text-light: #6E6B6B;
       --primary: #2B7FA2;
       --primary-hover: #67C89E;
       --danger: #EA7B4B;

--- a/src/components/chat/artefactIframeTemplate.ts
+++ b/src/components/chat/artefactIframeTemplate.ts
@@ -20,7 +20,7 @@ const TEMPLATE_PREFIX = `<!DOCTYPE html>
       --border-default: #EEE6D8;
       --text-header: #262626;
       --text-body: #3F3F3E;
-      --text-light: #908D8D;
+      --text-light: #706D6D;
       --primary: #2B7FA2;
       --primary-hover: #67C89E;
       --danger: #EA7B4B;

--- a/src/components/layout/TopBar.module.css
+++ b/src/components/layout/TopBar.module.css
@@ -81,7 +81,7 @@
 }
 
 .chevronIcon {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   transition: transform 150ms;
 }
 
@@ -274,7 +274,7 @@
 }
 
 .dropdownMenuButton svg {
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
   flex-shrink: 0;
 }
 
@@ -288,7 +288,7 @@
   padding: 8px 10px 4px;
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 /* Canvas settings (flattened in kebab menu) */
@@ -336,7 +336,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 10px;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 /* A.15: Stage lifecycle pill — true pill shape (999px radius, 2px border) */
@@ -387,7 +387,7 @@
   flex-shrink: 0;
   width: 14px;
   height: 14px;
-  color: var(--text-light, #908D8D);
+  color: var(--text-light, #706D6D);
 }
 
 .metadataLabel {

--- a/src/components/layout/TopBar.module.css
+++ b/src/components/layout/TopBar.module.css
@@ -81,7 +81,7 @@
 }
 
 .chevronIcon {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   transition: transform 150ms;
 }
 
@@ -274,7 +274,7 @@
 }
 
 .dropdownMenuButton svg {
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
   flex-shrink: 0;
 }
 
@@ -288,7 +288,7 @@
   padding: 8px 10px 4px;
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 /* Canvas settings (flattened in kebab menu) */
@@ -336,7 +336,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 10px;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 /* A.15: Stage lifecycle pill — true pill shape (999px radius, 2px border) */
@@ -387,7 +387,7 @@
   flex-shrink: 0;
   width: 14px;
   height: 14px;
-  color: var(--text-light, #706D6D);
+  color: var(--text-light, #6E6B6B);
 }
 
 .metadataLabel {

--- a/src/index.css
+++ b/src/index.css
@@ -96,7 +96,7 @@
   }
 
   .olumi-scrollbar::-webkit-scrollbar-thumb:hover {
-    background: var(--text-light, #706D6D);
+    background: var(--text-light, #6E6B6B);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -96,7 +96,7 @@
   }
 
   .olumi-scrollbar::-webkit-scrollbar-thumb:hover {
-    background: var(--text-light, #908D8D);
+    background: var(--text-light, #706D6D);
   }
 }
 

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -22,7 +22,20 @@
   /* Text Colors */
   --text-header: #262626;
   --text-body: #3F3F3E;
-  --text-light: #908D8D;
+  /* Muted / meta text.
+     A11y: this was #908D8D, which was NOT a legal text colour at any size —
+     3.26:1 on --bg-panel and 2.90:1 on --bg-canvas against SC 1.4.3's 4.5:1,
+     with zero of its ~785 live sites qualifying for the large-text exemption
+     (that needs >=24px, or >=18.66px bold; the largest muted site is 20px).
+     Retinted to #706D6D: 5.08:1 on --bg-panel, 4.51:1 on --bg-canvas — the
+     LIGHTEST value preserving this token's warm cast (R = G+3, B = G) that
+     clears 4.5:1 on both real grounds, so it stays as muted as the law allows.
+     The canvas margin is thin by construction (4.51 vs 4.50). Darkening
+     --bg-canvas, or lightening this token, breaks SC 1.4.3 — and
+     tests/ci-guards/text-light-contrast.spec.ts DERIVES both sides from this
+     file and will go red if either moves. Do not hand-edit this value without
+     re-running that guard. */
+  --text-light: #706D6D;
   --text-on-color: #FFFFFF;
 
   /* Legacy aliases (for gradual migration) */

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -27,15 +27,20 @@
      3.26:1 on --bg-panel and 2.90:1 on --bg-canvas against SC 1.4.3's 4.5:1,
      with zero of its ~785 live sites qualifying for the large-text exemption
      (that needs >=24px, or >=18.66px bold; the largest muted site is 20px).
-     Retinted to #706D6D: 5.08:1 on --bg-panel, 4.51:1 on --bg-canvas — the
-     LIGHTEST value preserving this token's warm cast (R = G+3, B = G) that
-     clears 4.5:1 on both real grounds, so it stays as muted as the law allows.
-     The canvas margin is thin by construction (4.51 vs 4.50). Darkening
-     --bg-canvas, or lightening this token, breaks SC 1.4.3 — and
+     Retinted to #6E6B6B: 5.23:1 on --bg-panel, 4.65:1 on --bg-canvas, both
+     preserving this token's warm cast (R = G+3, B = G).
+     WHY NOT LIGHTER. #706D6D is the lightest value that clears 4.5:1 on both
+     grounds (5.08 / 4.51), and it was rejected DELIBERATELY: 4.51 clears the
+     bar by 0.33%, which is close enough that a third-party checker rounding
+     differently, or a one-step tweak to --bg-canvas, would flip a compliance
+     CLAIM. #6E6B6B clears by 3.33% — 10x the headroom — and the two extra
+     steps cost ΔE2000 0.77, below the ~1.0 just-noticeable difference, so
+     nothing is lost in quietness. --bg-canvas is the binding ground; darken
+     it, or lighten this token far, and SC 1.4.3 breaks.
      tests/ci-guards/text-light-contrast.spec.ts DERIVES both sides from this
-     file and will go red if either moves. Do not hand-edit this value without
-     re-running that guard. */
-  --text-light: #706D6D;
+     file and pins the MARGIN, not just the bar, so it goes red if either
+     moves. Do not hand-edit this value without re-running that guard. */
+  --text-light: #6E6B6B;
   --text-on-color: #FFFFFF;
 
   /* Legacy aliases (for gradual migration) */

--- a/tests/ci-guards/artefact-template-token-mirror.spec.ts
+++ b/tests/ci-guards/artefact-template-token-mirror.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * `artefactIframeTemplate.ts` ⇄ `brand.css` token-mirror guard.
+ *
+ * THE DEFECT THIS EXISTS FOR: `--text-light` is declared TWICE in this repo.
+ * Once in `src/styles/brand.css`, and once — easy to miss — inlined into the
+ * `:root` of the artefact iframe template. The retint that made `--text-light`
+ * WCAG-legal had to touch both; had it touched only `brand.css`, artefact
+ * content would have kept rendering the failing colour and the two copies
+ * would have disagreed silently, because NOTHING compared them.
+ *
+ * WHY THE COPY CANNOT SIMPLY BE DELETED. The artefact iframe is a separate
+ * document served under `default-src 'none'; style-src 'unsafe-inline'`. CSS
+ * custom properties do not cross a document boundary, so the iframe cannot
+ * inherit `:root` from the parent — the tokens genuinely have to be restated
+ * inside the template. Deriving them at runtime would mean turning a static
+ * string constant into a DOM-dependent function that yields empty strings
+ * wherever there is no live document (tests, SSR, pre-paint), which trades a
+ * visible drift for an invisible one.
+ *
+ * So the copy stays, and THIS is what makes it safe: the mirror is checked
+ * rather than trusted. Both sides are PARSED — the template's `:root` block
+ * and `brand.css`'s declarations — so nothing here is a hand-typed expectation
+ * that can rot alongside the thing it describes (trap 12: the hand-maintained
+ * mirror is this repo's dominant defect class, and a second copy of the
+ * palette is precisely that shape).
+ *
+ * The pin is EXACT and BIDIRECTIONAL: a NEW divergence fails, and repairing a
+ * pinned one fails too, so the list cannot quietly outlive the drift it
+ * records.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BRAND_CSS_PATH = join(__dirname, '../../src/styles/brand.css')
+const TEMPLATE_PATH = join(__dirname, '../../src/components/chat/artefactIframeTemplate.ts')
+
+const brandCss = readFileSync(BRAND_CSS_PATH, 'utf-8')
+const template = readFileSync(TEMPLATE_PATH, 'utf-8')
+
+/** The literal hex tokens the iframe template inlines into its own :root. */
+function templateTokens(): Array<[string, string]> {
+  const block = template.match(/:root\s*\{([\s\S]*?)\}/)
+  if (!block) throw new Error('could not find the :root block in artefactIframeTemplate.ts')
+  return [...block[1].matchAll(/(--[a-z0-9-]+):\s*(#[0-9A-Fa-f]{3,8})\s*;/g)].map((m) => [m[1], m[2]])
+}
+
+/** Declared value of a `--token` at :root in brand.css, or null if not a literal hex. */
+function declared(token: string): string | null {
+  const m = brandCss.match(new RegExp(`^\\s*${token}:\\s*(#[0-9A-Fa-f]{3,8})\\s*;`, 'm'))
+  return m ? m[1].toUpperCase() : null
+}
+
+/**
+ * Tokens whose iframe value ALREADY disagreed with brand.css before this guard
+ * existed. Pinned, not fixed — each is a colour decision, not a typo, and this
+ * guard's job is to surface them, not to rule on them.
+ *
+ * `--primary` — the template says #2B7FA2, brand.css says #52A3C8. So artefact
+ * buttons render in a different blue from every other button in the product.
+ * #2B7FA2 is the replacement value proposed for `--info`/`--primary` under
+ * ROADMAP 1.51 (PR #369), so the template appears to have been moved to the
+ * NEW value ahead of brand.css — note the sweep in `a8c42590`
+ * ("#63ADCF → #52A3C8") did not touch this file. Worth knowing before #369
+ * lands: #2B7FA2 measures 4.47:1 on `--bg-panel` #FEFEFE, so it does NOT clear
+ * SC 1.4.3's 4.5:1 on the surface it is actually painted on — it only clears
+ * against pure #FFFFFF (4.51:1). Resolving this belongs to that colour
+ * decision, NOT to the --text-light retint that added this guard.
+ *
+ * Format: `--token|#IFRAME_VALUE`.
+ */
+const KNOWN_TEMPLATE_TOKEN_DRIFT = ['--primary|#2B7FA2'].sort()
+
+describe('artefact iframe template mirrors brand.css', () => {
+  it('the parser can SEE the tokens it is asserting about (positive control)', () => {
+    // Without this, "no divergence" could mean "parsed nothing" (trap 13: an
+    // absence assertion must first prove it can see a presence).
+    const tokens = templateTokens()
+    expect(tokens.length, `parsed ${tokens.length} tokens from the template :root (was 15)`)
+      .toBeGreaterThanOrEqual(12)
+
+    // It must find the token this guard was born for, on BOTH sides.
+    const names = tokens.map(([n]) => n)
+    expect(names).toContain('--text-light')
+    expect(declared('--text-light')).not.toBeNull()
+
+    // And it must be able to detect a divergence at all — assert against a
+    // value brand.css definitely does not hold.
+    expect(declared('--text-light')).not.toBe('#DEADBE')
+  })
+
+  it('every token the template restates matches brand.css', () => {
+    const found: string[] = []
+    const unknownInBrand: string[] = []
+
+    for (const [token, value] of templateTokens()) {
+      const brandValue = declared(token)
+      if (brandValue === null) {
+        unknownInBrand.push(`${token} (template: ${value})`)
+        continue
+      }
+      if (brandValue !== value.toUpperCase()) found.push(`${token}|${value.toUpperCase()}`)
+    }
+    found.sort()
+
+    // A token the template invents, or one brand.css stopped declaring as a
+    // literal, is reported rather than silently skipped — a skipped comparison
+    // is how a mirror goes blind.
+    expect(
+      unknownInBrand,
+      `the template restates ${unknownInBrand.length} token(s) that brand.css does not ` +
+        `declare as a literal hex, so they cannot be compared:\n  ${unknownInBrand.join('\n  ')}`,
+    ).toEqual([])
+
+    const added = found.filter((f) => !KNOWN_TEMPLATE_TOKEN_DRIFT.includes(f))
+    const fixed = KNOWN_TEMPLATE_TOKEN_DRIFT.filter((k) => !found.includes(k))
+    expect(
+      found,
+      added.length
+        ? `NEW token drift between artefactIframeTemplate.ts and brand.css: ${added.join(', ')} — ` +
+            `the iframe cannot inherit :root across a document boundary, so this copy is ` +
+            `load-bearing. Update the template to match brand.css.`
+        : `${fixed.join(', ')} no longer diverge — remove them from ` +
+            'KNOWN_TEMPLATE_TOKEN_DRIFT so the pin keeps matching reality.',
+    ).toEqual(KNOWN_TEMPLATE_TOKEN_DRIFT)
+  })
+
+  it('--text-light specifically agrees across both declarations', () => {
+    // Called out on its own, above and beyond the sweep above, because this is
+    // the token whose divergence would silently reintroduce a WCAG failure
+    // into artefact content — a text-legibility defect, not a brand nit.
+    const [, templateValue] = templateTokens().find(([n]) => n === '--text-light')!
+    expect(
+      templateValue.toUpperCase(),
+      'the artefact iframe inlines its own --text-light. If it drifts from brand.css, ' +
+        'artefact body copy silently renders in a colour that may fail SC 1.4.3 while ' +
+        'the rest of the product is compliant.',
+    ).toBe(declared('--text-light'))
+  })
+})

--- a/tests/ci-guards/text-light-contrast.spec.ts
+++ b/tests/ci-guards/text-light-contrast.spec.ts
@@ -33,7 +33,7 @@
  *
  * WHAT THIS DELIBERATELY DOES NOT COVER: sites where an ancestor `opacity`
  * suppresses the text (11 known live sites at opacity-50/60/70 measure
- * 1.9-2.8:1 even after the retint). A colour token cannot fix those — they
+ * 1.9-2.9:1 even after the retint). A colour token cannot fix those — they
  * need the opacity removed — and pretending this guard covers them would be
  * the more dangerous failure. See the retint PR body for the list.
  */
@@ -43,6 +43,14 @@ import { join } from 'node:path'
 
 /** SC 1.4.3 — normal-size text. Large text (>=24px / >=18.66px bold) may use 3:1. */
 const WCAG_TEXT_MIN = 4.5
+
+/**
+ * The bar this palette actually holds itself to. Compliance is a CLAIM someone
+ * else may re-check with a different tool, so clearing 4.5 by a hairline is not
+ * good enough — see the margin test below for the reasoning and the rejected
+ * alternative.
+ */
+const WCAG_TEXT_MARGIN = 4.6
 
 const BRAND_CSS_PATH = join(__dirname, '../../src/styles/brand.css')
 const brandCss = readFileSync(BRAND_CSS_PATH, 'utf-8')
@@ -111,22 +119,29 @@ describe('--text-light is a legal text colour (WCAG SC 1.4.3)', () => {
     ).toBeGreaterThanOrEqual(WCAG_TEXT_MIN)
   })
 
-  it('stays the LIGHTEST compliant value — it must not be over-darkened either', () => {
-    // The token's job is to read as muted. Compliance was bought with the
-    // smallest darkening that clears the bar, and this records that intent so
-    // a later "make it safer" nudge is a deliberate decision, not a drift.
-    // --bg-canvas is the binding ground; one step lighter must FAIL there.
+  it('clears the bar by a MARGIN, not by a hairline', () => {
+    // A compliance CLAIM needs more than arithmetic that scrapes over the line.
+    // #706D6D is the lightest value clearing 4.5:1 on both grounds, at 4.5149
+    // on --bg-canvas — 0.33% over. It was rejected deliberately: a third-party
+    // checker rounding differently, or a single step of drift in --bg-canvas,
+    // flips "we pass" to "we fail" without anyone touching this token. The
+    // shipped #6E6B6B clears by 3.33%, and the two extra steps cost ΔE2000
+    // 0.77 — below the ~1.0 just-noticeable difference — so the headroom is
+    // bought for nothing perceptible.
+    //
+    // This is the ONE-SIDED half of the intent. The opposite risk, darkening
+    // until muted stops reading as muted, is pinned by the separation test
+    // below; together they bracket the token from both directions.
     const fg = declared('--text-light')
     const canvas = declared('--bg-canvas')
-    const [r, g, b] = [0, 2, 4].map((i) => parseInt(fg.replace('#', '').slice(i, i + 2), 16))
-    const oneStepLighter = `#${[r + 1, g + 1, b + 1]
-      .map((n) => Math.min(255, n).toString(16).padStart(2, '0'))
-      .join('')}`
+    const ratio = contrast(fg, canvas)
     expect(
-      contrast(oneStepLighter, canvas),
-      `--text-light ${fg} is darker than it needs to be: ${oneStepLighter} also clears ` +
-        `4.5:1 on --bg-canvas. Use the lighter value — this token is meant to be quiet.`,
-    ).toBeLessThan(WCAG_TEXT_MIN)
+      ratio,
+      `--text-light ${fg} measures ${ratio.toFixed(4)}:1 on --bg-canvas ${canvas} — over ` +
+        `SC 1.4.3's ${WCAG_TEXT_MIN}:1, but by less than the ${(WCAG_TEXT_MARGIN - WCAG_TEXT_MIN).toFixed(2)} ` +
+        `headroom this palette requires. A margin that thin makes the compliance claim ` +
+        `fragile to rounding and to any tweak of --bg-canvas. Darken --text-light slightly.`,
+    ).toBeGreaterThanOrEqual(WCAG_TEXT_MARGIN)
   })
 
   it('white text on a --text-light FILL also clears 4.5:1 (.priorityBadgeLow)', () => {

--- a/tests/ci-guards/text-light-contrast.spec.ts
+++ b/tests/ci-guards/text-light-contrast.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * `--text-light` WCAG 1.4.3 text-contrast pin.
+ *
+ * THE DEFECT THIS EXISTS FOR: `--text-light` shipped as #908D8D, which is
+ * not a legal TEXT colour at any size — 3.26:1 on `--bg-panel` and 2.90:1 on
+ * `--bg-canvas`, against SC 1.4.3's 4.5:1 bar. It was used at ~785 live,
+ * user-visible sites across ~190 files, and NONE qualified for the large-text
+ * exemption (>=24px, or >=18.66px bold — the largest muted site in the tree
+ * is 20px and not bold), so font size could not rescue a single one of them.
+ * Nothing in the suite could see it: the css-var guard asks whether a token
+ * is DEFINED and whether its hardcoded fallbacks AGREE, never what the value
+ * MEASURES. A token can be perfectly self-consistent and still illegal.
+ *
+ * So this asserts the MEASUREMENT, not the spelling. Both sides are DERIVED
+ * from brand.css — the foreground and both grounds are parsed out of the same
+ * file the product renders from — because a hardcoded copy of the new hex
+ * would pass forever regardless of what the token actually says, which is this
+ * repo's dominant defect class (trap 12: the hand-maintained mirror). Retint
+ * `--text-light` lighter, or darken `--bg-canvas`, and this goes red with the
+ * actual figure.
+ *
+ * GROUNDS. Two, and both are real surfaces this token is painted on:
+ *   · `--bg-panel`  #FEFEFE — panels, cards, inspector, results, node fills.
+ *   · `--bg-canvas` #F4F0EA — the <body> behind the react-flow canvas.
+ *     Established in a live browser by the GhostOptionNode lane, not assumed:
+ *     every ancestor from `.react-flow__node` up through `__viewport`,
+ *     `__pane` and `.react-flow` is rgba(0,0,0,0) (xyflow sets
+ *     `--xy-background-color-default: transparent`), so the first opaque
+ *     ancestor is <body>. Accumulated opacity through that chain is 1.0 and
+ *     every filter is `none`, so raw contrast IS effective contrast.
+ *   · `--bg-panel-hover` #FEF9F3 is asserted too — it replaces the panel
+ *     ground on hover, so muted text has to survive it as a third surface.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT COVER: sites where an ancestor `opacity`
+ * suppresses the text (11 known live sites at opacity-50/60/70 measure
+ * 1.9-2.8:1 even after the retint). A colour token cannot fix those — they
+ * need the opacity removed — and pretending this guard covers them would be
+ * the more dangerous failure. See the retint PR body for the list.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** SC 1.4.3 — normal-size text. Large text (>=24px / >=18.66px bold) may use 3:1. */
+const WCAG_TEXT_MIN = 4.5
+
+const BRAND_CSS_PATH = join(__dirname, '../../src/styles/brand.css')
+const brandCss = readFileSync(BRAND_CSS_PATH, 'utf-8')
+
+/**
+ * WCAG 2.x relative luminance + contrast ratio.
+ * Lifted verbatim from src/canvas/nodes/__tests__/GhostOptionNode.contrast.spec.ts
+ * so both a11y guards measure with ONE implementation, not two that can drift.
+ */
+function luminance(hex: string): number {
+  const h = hex.replace('#', '')
+  const full = h.length === 3 ? h.split('').map((c) => c + c).join('') : h
+  const [r, g, b] = [0, 2, 4].map((i) => {
+    const v = parseInt(full.slice(i, i + 2), 16) / 255
+    return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+  })
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** Declared value of a `--token` at :root in brand.css. Throws rather than defaulting. */
+function declared(token: string): string {
+  const m = brandCss.match(new RegExp(`^\\s*${token}:\\s*(#[0-9A-Fa-f]{3,8})\\s*;`, 'm'))
+  if (!m) throw new Error(`${token} is not declared with a literal hex in src/styles/brand.css`)
+  return m[1]
+}
+
+/** Every ground `--text-light` is painted on as TEXT, worst case included. */
+const GROUNDS = ['--bg-panel', '--bg-canvas', '--bg-panel-hover'] as const
+
+describe('--text-light is a legal text colour (WCAG SC 1.4.3)', () => {
+  it('the maths can SEE a failure it is asserting the absence of (positive control)', () => {
+    // Without this, every assertion below could be passing because the
+    // implementation is broken rather than because the token is compliant
+    // (trap 13: an absence assertion must first prove it can see a presence).
+
+    // 1. The KNOWN-BAD historical value must FAIL on both real grounds.
+    //    These are the figures committed in GhostOptionNode.tsx's own comment.
+    expect(contrast('#908D8D', declared('--bg-panel'))).toBeCloseTo(3.26, 2)
+    expect(contrast('#908D8D', declared('--bg-canvas'))).toBeCloseTo(2.9, 2)
+    expect(contrast('#908D8D', declared('--bg-panel'))).toBeLessThan(WCAG_TEXT_MIN)
+
+    // 2. A known-good pairing must PASS — proves the function is not simply
+    //    returning something small for everything.
+    expect(contrast(declared('--text-body'), declared('--bg-panel'))).toBeCloseTo(10.45, 2)
+
+    // 3. The parser must actually be reading brand.css, not silently
+    //    defaulting: an undeclared token throws rather than returning a value.
+    expect(() => declared('--token-that-does-not-exist')).toThrow()
+  })
+
+  it.each(GROUNDS)('clears 4.5:1 on %s', (ground) => {
+    const fg = declared('--text-light')
+    const bg = declared(ground)
+    const ratio = contrast(fg, bg)
+    expect(
+      ratio,
+      `--text-light ${fg} on ${ground} ${bg} measures ${ratio.toFixed(2)}:1, ` +
+        `below SC 1.4.3's ${WCAG_TEXT_MIN}:1 for normal-size text. None of this token's ` +
+        `live sites qualify for the large-text exemption (>=24px, or >=18.66px bold), ` +
+        `so there is no size at which this is legal. Darken --text-light, or lighten ${ground}.`,
+    ).toBeGreaterThanOrEqual(WCAG_TEXT_MIN)
+  })
+
+  it('stays the LIGHTEST compliant value — it must not be over-darkened either', () => {
+    // The token's job is to read as muted. Compliance was bought with the
+    // smallest darkening that clears the bar, and this records that intent so
+    // a later "make it safer" nudge is a deliberate decision, not a drift.
+    // --bg-canvas is the binding ground; one step lighter must FAIL there.
+    const fg = declared('--text-light')
+    const canvas = declared('--bg-canvas')
+    const [r, g, b] = [0, 2, 4].map((i) => parseInt(fg.replace('#', '').slice(i, i + 2), 16))
+    const oneStepLighter = `#${[r + 1, g + 1, b + 1]
+      .map((n) => Math.min(255, n).toString(16).padStart(2, '0'))
+      .join('')}`
+    expect(
+      contrast(oneStepLighter, canvas),
+      `--text-light ${fg} is darker than it needs to be: ${oneStepLighter} also clears ` +
+        `4.5:1 on --bg-canvas. Use the lighter value — this token is meant to be quiet.`,
+    ).toBeLessThan(WCAG_TEXT_MIN)
+  })
+
+  it('white text on a --text-light FILL also clears 4.5:1 (.priorityBadgeLow)', () => {
+    // The token is used as a BACKGROUND in 18 places. Exactly one carries
+    // text: .priorityBadgeLow in Conversation.module.css, which composes
+    // .priorityBadge's `color: var(--text-on-color)`. Darkening the fill can
+    // only help white text — but "can only help" is an argument, not a
+    // measurement, and this pairing was failing (3.29:1) before the retint
+    // with nobody watching it.
+    const ratio = contrast(declared('--text-on-color'), declared('--text-light'))
+    expect(
+      ratio,
+      `--text-on-color on a --text-light fill measures ${ratio.toFixed(2)}:1 — ` +
+        `.priorityBadgeLow renders white text on this token.`,
+    ).toBeGreaterThanOrEqual(WCAG_TEXT_MIN)
+  })
+
+  it('stays visually distinct from --text-body, or the hierarchy collapses', () => {
+    // Compliance is bought by darkening muted text TOWARDS body text, so the
+    // cost of this fix is the muted/body distinction. Guarded so a future
+    // "just darken it a bit more" cannot quietly erase the hierarchy.
+    // Threshold is luminance-ratio based (a proxy, deliberately loose) —
+    // the ΔE2000 figure is in the PR body; this only catches collapse.
+    const light = luminance(declared('--text-light'))
+    const body = luminance(declared('--text-body'))
+    expect(
+      light / body,
+      `--text-light and --text-body are now within 1.5x luminance of each other — ` +
+        `muted text has stopped reading as muted. Reach for a lighter --text-light, ` +
+        `or accept that the palette needs a third rung.`,
+    ).toBeGreaterThan(1.5)
+  })
+})


### PR DESCRIPTION
## The defect

`--text-light` `#908D8D` is **not a legal text colour at any size**. It measures
**3.26:1** on `--bg-panel` `#FEFEFE` — the *lightest* surface in the palette — and
**2.90:1** on `--bg-canvas` `#F4F0EA`, against SC 1.4.3's **4.5:1**. There is no
ground anywhere in `brand.css` on which it passes.

Font size is almost irrelevant, because **zero** of its ~785 live sites qualify for
the large-text exemption (WCAG large text = **≥24px, or ≥18.66px bold**). Confirmed
in a live browser, not just statically: one canvas view rendered **24 muted text
nodes, every one at 10–12px, weight 400**.

## Chosen value: `#6E6B6B` — 5.23 / 4.65

| candidate | `--bg-panel` | `--bg-canvas` | canvas margin | verdict |
|---|---:|---:|---:|---|
| `#908D8D` *(current)* | 3.26 | 2.90 | — | fails both |
| `#706D6D` | 5.08 | 4.5149 | +0.33% | clears — **rejected, too thin** |
| `#6F6C6C` | 5.16 | 4.5818 | +1.82% | clears |
| **`#6E6B6B`** | **5.23** | **4.6498** | **+3.33%** | **shipped** |
| `#6D6A6A` | 5.31 | 4.7191 | +4.87% | clears, darker than needed |
| `#6D6B6B` *(original audit proposal)* | 5.25 | 4.67 | +3.7% | clears, but `R = G+2` — breaks the hue |

`#706D6D` is the *lightest* value clearing both grounds and was **rejected
deliberately**: 0.33% over the bar is close enough that a third-party checker
rounding differently, or one step of drift in `--bg-canvas`, flips a compliance
*claim* without anyone touching the token. `#6E6B6B` clears by **3.33% — 10× the
headroom** — and the two extra steps cost **ΔE2000 0.77**, below the ~1.0
just-noticeable difference, so nothing perceptible is spent buying it.

`#6E6B6B` also preserves the original's warm cast **exactly** (`R = G+3, B = G`);
the audit's `#6D6B6B` is `R = G+2` and slightly cooler.

## Complete usage-role audit — re-measured at `#6E6B6B`

Nothing carried over from the earlier value; the positive control was re-run
against the repo's own committed figures first.

| role | sites | before | after | bar | margin |
|---|---:|---:|---:|---:|---:|
| **text** on `--bg-panel` | ~1000 | 3.263 ✗ | **5.234 ✓** | 4.5 | +0.734 |
| **text** on `--bg-canvas` | canvas nodes, edge labels | 2.899 ✗ | **4.650 ✓** | 4.5 | +0.150 |
| **text** on `--bg-panel-hover` | hover states | 3.144 ✗ | **5.042 ✓** | 4.5 | +0.542 |
| **text** on `bg-black/5` over panel | 2 | 2.914 ✗ | **4.673 ✓** | 4.5 | +0.173 |
| **background, text-bearing** — `.priorityBadgeLow` | 1 | **3.291 ✗** | **5.279 ✓** | 4.5 | +0.779 |
| **background, non-text** — dots, bar fills, dividers | 18 | 2.899–3.263 | **4.650–5.234 ✓** | 3.0 | +1.65…+2.23 |
| **border** | 11 | 2.899–3.263 | **4.650–5.234 ✓** | 3.0 | +1.65…+2.23 |
| **stroke / fill** | 4 | 2.899–3.263 | **4.650–5.234 ✓** | 3.0 | +1.65…+2.23 |

**No pairing regresses**, and that is structural rather than lucky: darkening a
colour on a light ground can only raise contrast, and this token *only ever* sits on
light grounds — there is **no dark theme** (0 hits for `prefers-color-scheme` / `.dark`
/ `[data-theme` across `brand.css` + `index.css`), and **no muted text on the tinted
`-light` surfaces** (0 hits, positive-controlled: 58 `bg-*-light` sites exist and
same-line co-occurrence detection works — a thin control at one instance, reported at
that strength). The only text painted *on* the token is white.

## ΔE separation

| pair | before | after |
|---|---:|---:|
| muted vs `--text-body` #3F3F3E | 29.6 | **15.9** |
| muted vs `--text-header` #262626 | 37.0 | **23.6** |
| muted vs `--bg-panel` (legibility) | 28.5 | **40.7** ↑ |

Well above the ~10 at which `cvdContrast` calls two colours "more similar than
different".

## Visual verdict

Compared the **same** rendered view with the token toggled live, so content is
identical between shots.

⚠ **A stale-bundle trap was caught mid-check.** The dev server was serving
`#908D8D` while disk said `#6E6B6B` — a Vite transform cache surviving two edits,
compounded by browser caching. Had it gone unnoticed, the "visual verification"
would have been of the *old* colour. Fixed by killing the server, clearing
`node_modules/.vite`, and cache-busting the document; the served CSS was then
diffed against disk **before** any screenshot was believed.

**Surfaces verified:** pre-analysis / Analysis panel · Model tab
(`FactorsSection`, model card, search) · conversation panel + composer · canvas
nodes incl. the `GhostOptionNode` label on the canvas ground · **inspector-v2
`OptionPanel`**.

**Verdict: it looks right — recommend proceeding.** Muted still reads as muted. In
an interleaved check (bold heading, 12px body sentence, then a muted meta line) the
retinted line is unmistakably quieter than the body copy above it. What changes is
that 10–11px meta text stops being *washed out*: "Map option effects to factors",
"+ Explore another option", the gauge labels, and inspector-v2's "Context" /
"No connections yet." go from strained to comfortable. The hierarchy is visibly
**flatter** — the real cost, and a design judgement — but not collapsed.

## Inspector-v2 — now verified

Previously reported as unverified. The code answers it: `ReactFlowGraph.tsx:2043` —
*"single-click now opens full inspector directly"*. The earlier attempt failed
because it drove a **store action** (`selectNodeWithoutHistory`), which bypasses the
click handler that sets `showFullInspector`; a real single-click on the node opens it.
Verified directly, not inferred: **6 muted text nodes in the panel compute
`rgb(110, 107, 107)` = `#6E6B6B`** at 11–12px ("Context", "What would choosing this
option actually mean in practice?", "What this option changes", "This option doesn't
change any factors yet", "Connections", "No connections yet.").

## The duplicate declaration — fixed and guarded

`--text-light` is declared **twice**: `brand.css:43` and, easily missed,
`components/chat/artefactIframeTemplate.ts:23`, which inlines its own `:root` copy of
the palette. Both updated.

**Why the copy cannot just be deleted:** the artefact iframe is a separate document
served under `default-src 'none'; style-src 'unsafe-inline'`. CSS custom properties do
not cross a document boundary, so the iframe cannot inherit `:root` from the parent —
the tokens genuinely have to be restated. **Deriving at runtime was considered and
rejected**: it would turn a static string constant into a DOM-dependent function that
yields empty strings wherever there is no live document (tests, SSR, pre-paint),
trading a *visible* drift for an *invisible* one.

So the mirror is **checked instead of trusted**. New guard
`tests/ci-guards/artefact-template-token-mirror.spec.ts` parses the template's `:root`
block and `brand.css` and asserts every restated token agrees — both sides derived,
nothing hand-typed, exact and bidirectional.

### It immediately found a pre-existing divergence

`--primary` is **`#2B7FA2`** in the template but **`#52A3C8`** in `brand.css`, so
**artefact buttons render a different blue from every other button in the product**.
The `#63ADCF → #52A3C8` sweep in `a8c42590` did not touch this file. It is **pinned,
not silently changed** — that is a colour decision belonging to ROADMAP 1.51 / PR #369,
not to a `--text-light` retint.

⚠ Worth knowing before #369 lands: **`#2B7FA2` measures 4.47:1 on `--bg-panel`
#FEFEFE — it does NOT clear 4.5:1** on the surface it is painted on. It only clears
against pure `#FFFFFF` (4.51:1). A reviewer checking against white would not see this.

## The fallback pin

`KNOWN_FALLBACK_DRIFT` needs **no edit** and does **not shrink**:

- The pin lists fallbacks that *disagree* with `brand.css`. `--text-light|#908D8D` was
  **deliberately absent** (documented at lines 170–174) precisely because it *matched*.
- This PR moves the token **and all its hardcoded fallbacks together**, so it still
  matches — nothing added.
- Nothing removed either: no pinned entry equals `#6E6B6B`. The one indirectly-affected
  entry, `--text-muted|#9ca3af` (`--text-muted: var(--text-light)`), disagreed before and
  disagrees now.

The pin was **not weakened to additions-only**. Verified by mutation **at the new
value** rather than carried over: retinting `brand.css` while leaving fallbacks stale
fails with `var(--text-light, #908D8D) but --text-light is #6E6B6B`.

## The guards

`tests/ci-guards/text-light-contrast.spec.ts` asserts the **measurement, not the
spelling** — foreground *and* both grounds parsed out of `brand.css`, so it keeps
biting after future retints (trap 12). It carries a positive control proving it can
*see* a failure before asserting the absence of one (trap 13).

The earlier **"stays the LIGHTEST compliant value"** test encoded the superseded
instruction and would have gone red at `#6E6B6B`. It is replaced by a **margin floor**
(4.6 on the binding ground) that pins the actual decision. The separation test brackets
the opposite direction, so the token is bounded from **both** sides.

Mutation-checked afresh in a **throwaway** tree (trap 9):

| mutation | result |
|---|---|
| restore `#908D8D` | **5 contrast tests RED** |
| set `#706D6D` (the thin-margin value) | **margin test RED**, naming the 4.5149 figure |
| retint token, leave fallbacks stale | **css-var pin RED** at the new value |
| diverge the artefact template | **mirror guard RED** (2 tests) |
| *repair* the pinned `--primary` | **mirror guard RED** — pin is bidirectional |

## What this does NOT fix — 11 opacity-suppressed sites

| opacity | on panel (before → after) | on canvas (before → after) |
|---|---|---|
| 0.7 | 2.164 → **2.881** | 2.011 → **2.689** |
| 0.6 | 1.915 → **2.402** | 1.798 → **2.284** |
| 0.5 | 1.690 → **2.028** | 1.612 → **1.945** |

**A retint cannot rescue these** — even `--text-body` (10.45:1 raw) drops to ~3.2:1 at
`opacity-50`. They need the *opacity* removed and a separate ruling. Where the low
opacity marks a **disabled** control, WCAG exempts it. A further 45 files pair muted
text with an `opacity-*` somewhere, so 11 is a floor, not a total — full ancestry
resolution needs a browser.

Also untouched: ~46 `aria-hidden` + 17 disabled sites (legitimately exempt), and the
larger semantic-colour cluster (`--info` et al., ~1,070 text-like sites at 1.92–2.80:1)
owned by ROADMAP 1.51 / PR #369.

## Gates

| gate | result |
|---|---|
| `pnpm run typecheck` | **clean** |
| `pnpm run lint` | **0 errors** (1099 warnings, all pre-existing) |
| `npx vitest run tests/ci-guards` | **30/30 pass** (5 files) |
| `npx vitest run --changed origin/staging` | **1213 pass**, 0 fail, 22 skipped (101 files) |
| wide `tsc -p tsconfig.app.json --noEmit` | **2317 → 2317**, set-wise: **0 new, 0 fixed** |

Baseline taken in this same clone with the tree at exactly `origin/staging` before any
edit, so `node_modules` are matched by construction (no symlink, no second install).
Counted with `grep -c "error TS"`, diffed as sorted sets so a one-in/one-out swap could
not hide.

⚠ **The pre-push hook did not run** — git does not clone `.git/hooks`, so a fresh clone
has none. Its checks were run manually (above). CI is the real gate.

## Scope

Branch cut from `origin/staging` @ `303a8a0a`. `--info` is still `#52A3C8` here, so
**PR #369 has not landed**; both edit `:root`, so rebase rather than merge blindly.

`GhostOptionNode.tsx`'s comment is updated because this change **falsified** it: it
rejected `--text-light` for failing 3:1, which is no longer true (5.23 / 4.65). The
outline itself is deliberately **not** changed — that alters an affordance's appearance
and wants its own review, not a free ride on a token edit.

---

**DRAFT — do not merge until the owner rules.**
