### PR TITLE
fix(ds): orphaned rgba channel-triple info blues → token-derived (D1 follow-up)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1761,7 +1761,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   }`}
                   style={
                     effectiveActiveTab === tab.id
-                      ? { backgroundColor: 'rgba(82,163,200,0.15)' }
+                      ? { backgroundColor: 'color-mix(in srgb, var(--info) 15%, transparent)' }
                       : undefined
                   }
                 >
@@ -1848,7 +1848,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     ? 'text-info border-info'
                     : 'text-text-header/70 bg-panel border-panel-border hover:bg-panel hover:text-text-header'
                 }`}
-                style={effectiveActiveTab === tab.id ? { backgroundColor: 'rgba(82,163,200,0.15)' } : undefined}
+                style={effectiveActiveTab === tab.id ? { backgroundColor: 'color-mix(in srgb, var(--info) 15%, transparent)' } : undefined}
                 aria-label={tab.label}
                 title={tab.label}
               >

--- a/src/canvas/components/pre-analysis/AllImprovements.tsx
+++ b/src/canvas/components/pre-analysis/AllImprovements.tsx
@@ -90,7 +90,10 @@ function ConfidenceSpectrum({ items }: { items: ImprovementItem[] }) {
       </div>
       <div
         className="relative h-4 rounded-lg border border-panel-border"
-        style={{ background: 'linear-gradient(to right, rgba(255,166,86,0.12), rgba(82,163,200,0.12), rgba(103,200,158,0.12))' }}
+        // Middle stop derived from --info; the warning/success stops still match
+        // brand.css exactly (#FFA656 / #67C89E) and are left for the follow-up
+        // sweep. Only the blue had orphaned (it held the pre-D1 #52A3C8).
+        style={{ background: 'linear-gradient(to right, rgba(255,166,86,0.12), color-mix(in srgb, var(--info) 12%, transparent), rgba(103,200,158,0.12))' }}
       >
         {dots}
       </div>

--- a/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
+++ b/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
@@ -140,7 +140,7 @@ export function ThinkingModeDropdown({
               padding: '9px 11px',
               borderRadius: 12,
               border: mode.enabled && isSelected
-                ? '1px solid rgba(82,163,200,0.4)'
+                ? '1px solid color-mix(in srgb, var(--info) 40%, transparent)'
                 : '1px solid var(--border-default, #EEE6D8)',
               background: mode.enabled && isSelected ? 'var(--bg-panel-hover, #FEF9F3)' : 'transparent',
               marginBottom: 4,

--- a/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
+++ b/src/canvas/conversation/zones/BriefGuidanceStrip.tsx
@@ -12,12 +12,21 @@ import type { BriefElement } from '../hooks/useBriefSignals'
 import type { BriefElementKind } from '../primitives/NodeShape'
 import { typography } from '../../../styles/typography'
 
-/** Map brief element kinds to their DS v4 entity border colours. */
+/**
+ * Map brief element kinds to their DS v4 entity border colours.
+ *
+ * `constraints` is DERIVED from --info; the other four restate the token's
+ * current hex as a channel triple. Those four still AGREE with brand.css today
+ * (goal #F5C433, options #AAA7E4, metric #67C89E, risks #EA7B4B) — `constraints`
+ * is the one that did not: it held the pre-D1 blue #52A3C8 and had silently
+ * orphaned from --info, which is why only it is converted here. The remaining
+ * four are the same latent shape and are tracked for the follow-up sweep.
+ */
 const ENTITY_BORDERS: Record<BriefElementKind, string> = {
   goal:        'rgba(245,196,51,0.4)',
   options:     'rgba(170,167,228,0.4)',
   metric:      'rgba(103,200,158,0.4)',
-  constraints: 'rgba(82,163,200,0.4)',
+  constraints: 'color-mix(in srgb, var(--info) 40%, transparent)',
   risks:       'rgba(234,123,75,0.4)',
 }
 

--- a/src/canvas/conversation/zones/CoachingTip.tsx
+++ b/src/canvas/conversation/zones/CoachingTip.tsx
@@ -21,7 +21,7 @@ export function CoachingTip({ tip, onDismiss }: CoachingTipProps) {
       style={{
         gap: 8,
         padding: '8px 12px',
-        border: '1px solid rgba(82,163,200,0.12)',
+        border: '1px solid color-mix(in srgb, var(--info) 12%, transparent)',
         boxShadow: '0 1px 2px rgba(38,38,38,0.06)',
       }}
       data-testid="coaching-tip"

--- a/src/canvas/ui/inspector-v2/__tests__/InspectorCoaching.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InspectorCoaching.spec.tsx
@@ -10,6 +10,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { InspectorCoaching } from '../shared/InspectorCoaching'
 import { useGuidanceStore, type GuidanceItem } from '../../../stores/guidanceStore'
@@ -134,9 +136,30 @@ describe('InspectorCoaching', () => {
       _prefillChat: vi.fn(),
     })
     const { container } = render(<InspectorCoaching {...defaultProps} />)
-    // CoachingCard uses inline style with info border
+    // CoachingCard uses inline style with info border.
+    //
+    // This used to assert the raw triple `rgba(82, 163, 200, 0.3)` — the PRE-D1
+    // blue. That literal was invisible to every hex-based DS sweep, so when
+    // `--info` became #277A9D the card silently kept rendering the old colour
+    // and THIS TEST WENT ON PASSING, pinning the drift in place. So assert the
+    // property D1 actually wants (the border DERIVES from the token) instead of
+    // any one value: a future retint of `--info` then cannot break this test,
+    // and — the point — cannot pass while the card drifts away from the token.
     const card = container.firstElementChild as HTMLElement
-    expect(card.style.border).toContain('rgba(82, 163, 200, 0.3)')
+    expect(card.style.border).toBe(
+      '1px solid color-mix(in srgb, var(--info) 30%, transparent)',
+    )
+    // A hardcoded channel triple here is exactly the regression this file once
+    // enshrined; fail loudly if one comes back.
+    expect(card.style.border).not.toMatch(/rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+/)
+    // And the token it points at must really be declared — `var(--typo)` renders
+    // NO border at all, which the assertions above cannot distinguish. Read the
+    // source of truth rather than trusting the name (trap 12: derive, don't mirror).
+    const brandCss = readFileSync(
+      join(__dirname, '../../../../styles/brand.css'),
+      'utf-8',
+    )
+    expect(brandCss).toMatch(/^\s*--info:\s*#[0-9A-Fa-f]{6}\s*;/m)
   })
 
   // ── related_elements matching ──────────────────────────────────────

--- a/src/canvas/ui/inspector-v2/shared/CoachingCard.tsx
+++ b/src/canvas/ui/inspector-v2/shared/CoachingCard.tsx
@@ -1,6 +1,6 @@
 /**
  * CoachingCard — DS v4 §15
- * bg-panel, full thin info border (1px solid rgba(82,163,200,0.30)), rounded-lg
+ * bg-panel, full thin info border (1px solid --info at 30%), rounded-lg
  * Lightbulb icon + panelBody text + dismiss + optional action chip
  * Absent (not rendered) when no coaching data — parent controls visibility
  */
@@ -24,7 +24,7 @@ export function CoachingCard({ text, action }: CoachingCardProps) {
   return (
     <div
       className="mt-3 bg-panel rounded-lg shadow-1"
-      style={{ border: '1px solid rgba(82,163,200,0.30)' }}
+      style={{ border: '1px solid color-mix(in srgb, var(--info) 30%, transparent)' }}
     >
       <div className="p-2.5 pr-2">
         <div className="flex justify-between items-start gap-2">

--- a/src/components/chat/artefactIframeTemplate.ts
+++ b/src/components/chat/artefactIframeTemplate.ts
@@ -67,9 +67,19 @@ const TEMPLATE_PREFIX = `<!DOCTYPE html>
       outline: none;
       transition: border-color 200ms;
     }
+    /* The focus ring DERIVES from --primary, which this template declares in its
+       own :root above (custom properties cannot cross the iframe's document
+       boundary, so the copy is load-bearing — see
+       tests/ci-guards/artefact-template-token-mirror.spec.ts). It previously
+       restated the pre-D1 blue rgba(82,163,200,·) as a channel triple, so the
+       ring disagreed with the border-color on the very same rule. Deriving it
+       puts the ring under that guard's existing pin transitively, without
+       adding a new token to the mirror. color-mix is a CSS function, not a
+       fetched resource, so the default-src 'none' policy does not affect it.
+       (No backticks in this comment: it lives inside a JS template literal.) */
     input:focus, select:focus {
       border-color: var(--primary);
-      box-shadow: 0 0 0 2px rgba(82, 163, 200, 0.15);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 15%, transparent);
     }
 
     table {

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -242,7 +242,7 @@ function ContestedDriverQuickSelect({ driver }: { driver: DriverItem }) {
             padding: '4px 10px',
             borderRadius: '999px',
             border: `1px solid ${selectedIndex === i ? 'var(--info)' : 'var(--border-default)'}`,
-            background: selectedIndex === i ? 'rgba(82,163,200,0.1)' : 'transparent',
+            background: selectedIndex === i ? 'color-mix(in srgb, var(--info) 10%, transparent)' : 'transparent',
             cursor: 'pointer',
           }}
         >

--- a/src/components/results/ExpertBlock.tsx
+++ b/src/components/results/ExpertBlock.tsx
@@ -16,7 +16,7 @@ export function ExpertBlock({ children }: ExpertBlockProps) {
   return (
     <div
       className="rounded-md px-3 py-2 mt-1"
-      style={{ backgroundColor: 'rgba(99, 173, 207, 0.04)' }}
+      style={{ backgroundColor: 'color-mix(in srgb, var(--info) 4%, transparent)' }}
     >
       {children}
     </div>

--- a/src/components/results/ExpertBlock.tsx
+++ b/src/components/results/ExpertBlock.tsx
@@ -2,8 +2,17 @@
  * ExpertBlock — wrapper for expert-mode-only content.
  *
  * DS v5 §4.3: panelBody (12px), info-tinted background, proper spacing.
- * Inline rgba() style per DS v5 §3.15 — Tailwind opacity modifiers on CSS
- * vars may fail silently if the var resolves to hex rather than RGB channels.
+ *
+ * Inline style rather than `bg-info/4`, per DS v5 §3.15. That note used to read
+ * "opacity modifiers on CSS vars MAY fail silently"; it is now measured, and it
+ * is not a maybe. tailwind.config.js declares `info.DEFAULT: 'var(--info)'`
+ * with no `<alpha-value>` placeholder, so Tailwind 3.4 cannot inject alpha and
+ * DROPS the utility entirely — `bg-info/15` and `border-info/30` emit NO CSS
+ * (positive control: `bg-red-500/50` emits `rgb(239 68 68 / 0.5)`).
+ *
+ * The tint is therefore expressed with color-mix, DERIVED from the token. It
+ * previously restated #63ADCF — a pre-D1 blue — as a channel triple, which no
+ * hex-based sweep could see, so it had silently orphaned from --info.
  */
 
 import type { ReactNode } from 'react'

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -246,7 +246,7 @@ function OptionRangeBar({
           style={{
             left: `${leftPct}%`,
             width: `${Math.max(2, widthPct)}%`,
-            background: 'rgba(82,163,200,0.3)',
+            background: 'color-mix(in srgb, var(--info) 30%, transparent)',
           }}
         />
         {dotPct != null && (

--- a/src/components/results/__tests__/DriversSection.expertLeak.spec.tsx
+++ b/src/components/results/__tests__/DriversSection.expertLeak.spec.tsx
@@ -117,13 +117,18 @@ describe('DriversSection: Brief 5.1 Task 1 — expert leak regression', () => {
     expect(labels[2]).toMatch(/^influence:/)
 
     // Structural: the block is wrapped in the info-tinted ExpertBlock.
-    // ExpertBlock uses an inline background-color style rather than a
-    // class we can match directly, so assert the DS rgba string is
-    // present on a parent.
+    // ExpertBlock uses an inline background-color style rather than a class we
+    // can match directly, so assert its tint is present on a parent.
+    //
+    // This used to match the channel triple '99, 173, 207' — the superseded
+    // #63ADCF blue. ExpertBlock's tint now DERIVES from --info via color-mix,
+    // so match the token reference instead: a retint of --info then cannot
+    // break this leak test, and the test can no longer keep passing while the
+    // wrapper silently renders a colour the product has abandoned.
     let cursor: HTMLElement | null = block
     let foundExpertWrapper = false
     while (cursor) {
-      if ((cursor.style.backgroundColor ?? '').includes('99, 173, 207')) {
+      if ((cursor.style.backgroundColor ?? '').includes('var(--info)')) {
         foundExpertWrapper = true
         break
       }

--- a/src/index.css
+++ b/src/index.css
@@ -417,16 +417,28 @@
    keyframe — it must NOT reuse pulse-fade, which powers .animate-pulse on
    15+ skeleton/status components. The Tailwind ring on the node stays
    visible; this only adds the expanding halo. Reduced-motion drops the
-   animation and leaves the static ring, so the highlight is still legible. */
+   animation and leaves the static ring, so the highlight is still legible.
+
+   The opening stop is DERIVED from --info via color-mix rather than restating
+   the hue: this keyframe previously hardcoded rgba(82,163,200,·) — the PRE-D1
+   blue — as a channel triple, so it survived every hex-based sweep and drifted
+   away from the token while this very comment claimed it was #277A9D.
+
+   The fade-out stops are plain `transparent`, not a 0-alpha info. color-mix
+   cannot express "this hue at zero alpha" (mixing 0% of a colour yields
+   transparent BLACK, losing the hue), and it does not need to: CSS Color 4
+   mandates PREMULTIPLIED interpolation for animated colours, so fading to
+   `transparent` is visually identical to fading to rgba(info, 0) — no grey/black
+   halo. Do not "restore" a hue here; it would only re-introduce a literal. */
 @keyframes ai-highlight-pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(82, 163, 200, 0.55);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--info) 55%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 8px rgba(82, 163, 200, 0);
+    box-shadow: 0 0 0 8px transparent;
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(82, 163, 200, 0);
+    box-shadow: 0 0 0 0 transparent;
   }
 }
 


### PR DESCRIPTION
D1 shipped `--info: #277A9D` under the goal **"one value that cannot drift"**. That is not yet true. 14 production sites restated the *pre-D1* blues as **rgba channel triples** — a form no hex-based sweep can see — so they orphaned from the token and render a visibly different blue from the rest of the product.

**Why they survived every sweep:** `production-hex` in `check-ds-compliance.mjs` matches `/#[0-9a-fA-F]{6}\b/`. The `rgba(82,163,200,·)` form contains no `#`, so the guard is **structurally blind to this entire defect class**. `src/index.css` made the drift literal — its comment claimed *"Uses the info/AI colour (--info #277A9D)"* directly above a keyframe painting `#52A3C8`.

## Re-derived site list (I did not trust the brief's counts)

Complete manifest: **43 distinct triples / 204 occurrences** across `src/`, each classified against current + historical `brand.css`.

### In scope — orphaned superseded info blues (14 code sites)

| # | Site | Alpha | Disposition |
|---|------|-------|-------------|
| 1–3 | `src/index.css:423,426,429` (`ai-highlight-pulse`) | .55/0/0 | **color-mix** (opening stop); fade stops → `transparent` — see note |
| 4 | `src/canvas/ui/inspector-v2/shared/CoachingCard.tsx:27` | .30 | **color-mix** |
| 5 | `…/CoachingCard.tsx:3` (doc comment) | — | comment corrected |
| 6 | `src/canvas/components/pre-analysis/AllImprovements.tsx:93` | .12 | **color-mix** (middle gradient stop only) |
| 7–8 | `src/canvas/components/OutputsDock.tsx:1764,1851` | .15 | **color-mix** (*not* `bg-info/15` — see below) |
| 9 | `src/canvas/conversation/zones/BriefGuidanceStrip.tsx:20` | .40 | **color-mix** (`constraints` key only) |
| 10 | `src/canvas/conversation/zones/CoachingTip.tsx:24` | .12 | **color-mix** |
| 11 | `src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx:143` | .40 | **color-mix** |
| 12 | `src/components/chat/artefactIframeTemplate.ts:72` | .15 | **color-mix on `var(--primary)`** — see below |
| 13 | `src/components/results/DriversSection.tsx:245` | .10 | **color-mix** |
| 14 | `src/components/results/OptionCards.tsx:249` | .30 | **color-mix** |
| 15 | `src/components/results/ExpertBlock.tsx:19` (`#63ADCF`) | .04 | **color-mix** |

**Zero literal `rgba(39,122,157,…)` were introduced.** Every site derives. Remaining grep hits for the old triples are explanatory comments only, plus `brand-tokens.spec.ts`, which *deliberately* asserts the superseded values fail WCAG.

`DriversSection.tsx` is the tell: line 244 already used `var(--info)` for the border while line 245 painted the orphaned literal — **two different blues on the same element.**

## ⚠️ Correction: `bg-info/15` does not work in this repo

The brief suggested a Tailwind alpha utility where the element takes a class. **It would have silently removed the tint entirely.**

`tailwind.config.js` declares `info.DEFAULT: 'var(--info)'` with no `<alpha-value>` placeholder, so Tailwind 3.4 cannot inject alpha and **drops the utility**. Measured with an isolated build + positive control:

```
bg-red-500/50  →  rgb(239 68 68 / 0.5)     ← positive control: probe CAN emit alpha
bg-info/15     →  (no CSS emitted)
border-info/30 →  (no CSS emitted)
bg-info        →  background-color: var(--info)
```

So **color-mix is used at every site**, including the two that take classes. `ExpertBlock.tsx` already half-suspected this ("*may* fail silently"); its note is now the measurement rather than a hedge.

> **Filed separately (not fixed here):** this means `border-info/30` — the DS v5 outlined-pill recipe — and every `bg-*/N` on a token colour emit nothing repo-wide. Needs a DS-level decision (add `<alpha-value>` channels, or move the recipe to color-mix).

## The iframe template — guard reacted as designed, no pin relaxed

`artefactIframeTemplate.ts` renders under `default-src 'none'` where custom properties do not cross the document boundary. **But the template declares `--primary: #277A9D` in its own `:root`**, so `color-mix(… var(--primary) …)` resolves there. `--primary` is also what line 71 already uses for `border-color` on the very same rule — the ring had disagreed with its own border.

The edit sits **outside the `:root` block**, so `artefact-template-token-mirror.spec.ts`'s parse is untouched (15 tokens, all still matching). The focus ring is now **transitively pinned** by that guard. `KNOWN_TEMPLATE_TOKEN_DRIFT` stays `[]` — **nothing relaxed to additions-only.** Guard green.

## Test assertions — 2 changed, 0 deleted

The brief named one. **There were two** — the second used the bare string `'99, 173, 207'` with no `rgba(` prefix, so a prefix-anchored regex misses it (my own first sweep did; I re-swept prefix-free).

1. `InspectorCoaching.spec.tsx:139` — was `toContain('rgba(82, 163, 200, 0.3)')`
2. `DriversSection.expertLeak.spec.tsx:126` — was `.includes('99, 173, 207')`

Both now assert the **token-derived** form, per the brief's preference, plus a `not.toMatch(/rgba?\(\d+,\d+,\d+/)` regression guard. `InspectorCoaching` additionally reads `brand.css` to prove `--info` is really declared — `var(--typo)` renders *no* border, which a string assertion alone cannot distinguish.

**These tests were pinning the drift in place**: both passed happily while their components rendered an abandoned colour. That is the failure mode, not a detail.

**Mutation check** (throwaway worktree, per trap 9): reverting both components to the orphaned literals turns **both tests RED**. The pins bite.

## Gates

| Gate | Result |
|---|---|
| `pnpm run typecheck` | clean |
| eslint (12 touched files) | **0 errors**, 7 warnings (all pre-existing: unused vars / hook deps) |
| `npx vitest run tests/ci-guards` | **30/30 green** (incl. artefact token-mirror) |
| `npx vitest run --changed origin/staging` | **1190 passed**, then 2 assertion updates → **47/47** on re-run |
| Wide `tsc -p tsconfig.app.json` | base **2317** / branch **2317** — **0 new, set-wise** |
| Mutation check | both tests RED when reverted ✅ |

Wide typecheck used a **separate base clone at `origin/staging` with its own real `node_modules`** (both on `@talchain/schemas` 0.18.0). Counted with `grep -c "error TS"`. The raw diff showed 9 new / 9 gone — **all pure +3 line-shift** in `AllImprovements.tsx` from an added comment; normalising line numbers gives **0 new / 0 gone**.

## DS compliance — flat, and that is the finding

```
                        BEFORE                    AFTER
production-hex          303 (baseline 311, Δ-8)   303 (baseline 311, Δ-8)   ← identical
legacy-tailwind-token   2165 (Δ+0)                2165 (Δ+0)
uppercase-text          79 (Δ+0)                  79 (Δ+0)
panel-typography-scoped 34 (Δ+0)                  34 (Δ+0)
emoji-icon              28 (Δ+0)                  28 (Δ+0)
```

**`production-hex` did not move, and could not have.** The brief expected a *reduction*; that expectation was wrong, for the reason this PR exists — the guard never counted `rgba()` triples, so removing 14 of them changes nothing. **`ds-compliance-baseline.json` is therefore UNCHANGED** — no edit needed, and `--update` was never run.

The one net-new entry (`artefactIframeTemplate.ts #6E6B6B`) is **pre-existing on `staging`** from #376's `--text-light` retint. Present identically before and after. Not mine, not touched.

> **Filed:** extend `production-hex` to count `rgb()/rgba()` channel triples, or the next retint orphans silently in exactly this way.

## Visual check — real browser, cache-busted

Dev server killed, `node_modules/.vite` removed, restarted, and the **served bytes diffed against disk** before believing anything (per the stale-build trap):

- Served `src/index.css` → `color-mix(in srgb, var(--info) 55%, transparent)` ✅
- Served `OutputsDock.tsx` → both tint sites ✅
- Orphaned-triple hits in served assets: **0** (one match in `index.css` is my own comment)

Live DOM, OutputsDock **Analysis** tab actually mounted:
```
inline   : color-mix(in srgb, var(--info) 15%, transparent)
computed : color(srgb 0.152941 0.478431 0.615686 / 0.15)   = #277A9D @ 15% ✅ resolves, tint painted
text     : rgb(39, 122, 157)
```
Live DOM elements still painting an orphaned triple: **0**.

**Verdict: no visible jump.** At 4%/10%/12%/15% the shift is imperceptible; at 30% (OptionCards range bar) it reads as a marginally deeper, more saturated blue. Every tint still reads as the same soft info-blue family — now matching the rest of the product rather than diverging from it.

## ⚠️ OutputsDock contrast — REPORTED, NOT FIXED (and this PR moves it DOWN)

The active-tab label is `text-info` on an info tint. Reproduced exactly through the real composite chain (`#FEFEFE` → strip `rgba(255,255,255,.95)` → tint @15%):

| | tint | contrast vs `#277A9D` |
|---|---|---|
| Before | `rgb(229,241,247)` | **4.194:1** ← matches the brief's live measurement exactly |
| After | `rgb(223,235,240)` | **3.964:1** |
| **Δ** | | **−0.230** |

**This PR moves that number DOWN by 0.23, and it still fails SC 1.4.3 (4.5:1).**

That is expected and not evidence the change is wrong: the tint was only "better" because it was the *wrong, lighter* blue. Correcting it to the canonical token necessarily darkens the ground under same-coloured text. As the brief notes, **retinting cannot fix this** — both sides are `--info`, so they move together. It needs a DS decision on the documented v5 "Tabs" selected-pill recipe. **Not silently redesigned here.**

## Wider class sweep — 3 more orphaned families found (filed, not fixed)

The blindness is not specific to blue.

**Orphaned (superseded, no longer in `brand.css`) — 9 sites:**
- **`#E8ECF5`** ×6 — `KeyboardMap.module.css:53,71,111,136,137,145` (was `--olumi-text` / `--edge-label-text`)
- **`#E1D8C7`** ×2 — `AllImprovements.tsx:458,498` (was `sand-200`; current `--border-emphasis` is `#DDD4C4`)
- **`#F7C948`** ×1 — `CoachingNudge.module.css:56` (was `--olumi-warning`; **two generations stale** — → `#F5C433` → `#FFA656`)

**Current-value mirrors — agree today, same blindness, will orphan on the next retint:**
`#262626`×42 (`--text-header`) · `#67C89E`×7 (`--success`) · `#FFA656`×6 (`--warning`) · `#EA7B4B`×5 (`--danger`) · `#277A9D`×3 (`--info`) · `#AAA7E4`×3 (`--option`) · `#B0A899`×3 (`--factor`) · `#EEE6D8`×3 (`--border-default`) · `#F5C433`×2 (`--goal`)

Two in-scope edits sit right next to these and were **deliberately left**, with the reasoning in-code:
- `BriefGuidanceStrip` `ENTITY_BORDERS` — only `constraints` was orphaned; the other four still match `brand.css`.
- `AllImprovements` gradient — only the middle stop was orphaned; the warning/success stops are exact.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
