### PR TITLE
fix(ds): semantic colours support <alpha-value> — the documented pill recipe now emits

### DIFF
--- a/scripts/css-var-census.mjs
+++ b/scripts/css-var-census.mjs
@@ -74,6 +74,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import ts from 'typescript'
+import { resolveChannelTriple } from '../src/styles/channelTriple.mjs'
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const SRC = path.join(REPO_ROOT, 'src')
@@ -174,10 +175,34 @@ function collectDefinitions(cssFiles, scriptFiles, markupFiles) {
 }
 
 /**
+ * Read a token's first statically-known declared value out of the defs map.
+ * The lookup `resolveChannelTriple` needs to follow `--x-rgb` (and the one
+ * alias hop `--primary-rgb: var(--info-rgb)`).
+ */
+const tripleLookup = (defs) => (n) => (defs.get(n) ?? []).find((e) => e.value)?.value ?? null
+
+/**
+ * If `value` is the channel-triple colour form — `rgb(var(--info-rgb))`, with
+ * `--info-rgb: 39 122 157` — return the literal hex it resolves to.
+ *
+ * WHY THIS BRANCH EXISTS. Semantic colours are declared as their CHANNELS so
+ * that Tailwind can emit opacity-modified utilities (`border-info/30`), which
+ * previously emitted no rule at all. Without this the census would classify
+ * every one of them as "a compound var() expression" and report each hardcoded
+ * fallback against them as UNCOMPARABLE — which would quietly retire the
+ * fallback-drift pin on exactly the tokens most likely to be retinted. Shared
+ * with the four spec-side parsers so all five agree by construction.
+ */
+function channelTripleValue(value, defs) {
+  return resolveChannelTriple(value, tripleLookup(defs))
+}
+
+/**
  * The concrete value(s) a token resolves to, following at most ONE level of
- * `var()` indirection (`--text-primary: var(--text-header)`). Returns a list
- * of `{kind:'value'|'uncomparable'}` — a token declared twice (a theme
- * override) legitimately has more than one.
+ * `var()` indirection (`--text-primary: var(--text-header)`) plus the
+ * channel-triple form at either end of that hop. Returns a list of
+ * `{kind:'value'|'uncomparable'}` — a token declared twice (a theme override)
+ * legitimately has more than one.
  */
 function definitionValues(name, defs) {
   const out = []
@@ -194,12 +219,24 @@ function definitionValues(name, defs) {
         continue
       }
       for (const ie of inner) {
-        if (ie.value == null || ie.value === '' || /var\(/.test(ie.value)) {
+        // `--sky-500: var(--info)` where `--info: rgb(var(--info-rgb))` — the
+        // triple sits one hop away, so try it before giving up on the chain.
+        const viaTriple = ie.value ? channelTripleValue(ie.value, defs) : null
+        if (viaTriple) {
+          out.push({ kind: 'value', value: viaTriple, via: `${name} → ${indirect[1]} (${ie.at})` })
+        } else if (ie.value == null || ie.value === '' || /var\(/.test(ie.value)) {
           out.push({ kind: 'uncomparable', reason: `${name} → ${indirect[1]} needs more than one level of indirection` })
         } else {
           out.push({ kind: 'value', value: ie.value, via: `${name} → ${indirect[1]} (${ie.at})` })
         }
       }
+      continue
+    }
+    // `--info: rgb(var(--info-rgb))` — a compound var() expression that IS
+    // statically resolvable, so it must not be written off as one that is not.
+    const triple = channelTripleValue(entry.value, defs)
+    if (triple) {
+      out.push({ kind: 'value', value: triple, via: `${name} (${entry.at})` })
       continue
     }
     if (/var\(/.test(entry.value)) {

--- a/src/canvas/ToastContext.tsx
+++ b/src/canvas/ToastContext.tsx
@@ -139,10 +139,10 @@ const TOAST_ICON_CLASS: Record<Toast['type'], string> = {
 }
 
 const TOAST_ACTION_CLASS: Record<Toast['type'], string> = {
-  success: 'text-success hover:text-success/80',
-  error:   'text-danger hover:text-danger/80',
-  info:    'text-info hover:text-info/80',
-  warning: 'text-warning hover:text-warning/80',
+  success: 'text-success',
+  error:   'text-danger',
+  info:    'text-info hover:text-info',
+  warning: 'text-warning',
 }
 
 function ToastContainer({ toasts, onRemove }: { toasts: Toast[]; onRemove: (id: string) => void }) {

--- a/src/canvas/components/ComparisonTable.tsx
+++ b/src/canvas/components/ComparisonTable.tsx
@@ -35,7 +35,7 @@ export function ComparisonTableSection() {
   if (nodes.length === 0) {
     return (
       <div className="p-4">
-        <p className={`${typography.body} text-ink-900/50 text-center py-8`}>
+        <p className={`${typography.body} text-ink-900 text-center py-8`}>
           Add nodes to your graph to enable scenario comparison
         </p>
       </div>

--- a/src/canvas/components/ConformalPrediction.tsx
+++ b/src/canvas/components/ConformalPrediction.tsx
@@ -42,7 +42,7 @@ export function ConformalPredictionSection() {
   if (nodes.length === 0) {
     return (
       <div className="p-4">
-        <p className={`${typography.body} text-ink-900/50 text-center py-8`}>
+        <p className={`${typography.body} text-ink-900 text-center py-8`}>
           Add nodes to your graph to enable conformal prediction
         </p>
       </div>
@@ -103,7 +103,7 @@ export function ConformalPredictionSection() {
 
       {!enabled && (
         <div className="p-3 bg-paper-50 border border-sand-200 rounded-lg">
-          <p className={`${typography.body} text-ink-900/70`}>
+          <p className={`${typography.body} text-ink-900`}>
             Enable to see 95% confidence intervals for outcome predictions
           </p>
         </div>

--- a/src/canvas/components/ContextBar.tsx
+++ b/src/canvas/components/ContextBar.tsx
@@ -47,19 +47,19 @@ export function ContextBar() {
       aria-label="Graph context"
     >
       <div className={`flex items-center justify-between ${typography.caption} text-ink-900`}>
-        <span className="font-medium text-ink-900/80">Graph</span>
+        <span className="font-medium text-ink-900">Graph</span>
         <span className="tabular-nums text-ink-900">
           {nodesCount} nodes • {edgesCount} edges
         </span>
       </div>
 
-      <div className={`flex flex-wrap items-start gap-x-6 gap-y-1 ${typography.caption} text-ink-900/80`}>
+      <div className={`flex flex-wrap items-start gap-x-6 gap-y-1 ${typography.caption} text-ink-900`}>
         <div className="flex-1 min-w-[10rem]">
           <div className="font-medium text-ink-900">Limits</div>
           <div className="text-ink-900" aria-live="polite">
             {limitsView.label}
           </div>
-          <div className="text-ink-900/70" aria-live="polite">
+          <div className="text-ink-900" aria-live="polite">
             {limitsView.message}
           </div>
         </div>
@@ -69,7 +69,7 @@ export function ContextBar() {
           <div className="text-ink-900" aria-live="polite">
             {healthView.label}
           </div>
-          <div className="text-ink-900/70" aria-live="polite">
+          <div className="text-ink-900" aria-live="polite">
             {healthView.detail}
           </div>
         </div>

--- a/src/canvas/components/DecisionReadinessBadge.tsx
+++ b/src/canvas/components/DecisionReadinessBadge.tsx
@@ -166,7 +166,7 @@ export function DecisionReadinessBadge({
 
           {/* Expand/collapse chevron */}
           {hasDetails && (
-            <span className="text-ink-900/40">
+            <span className="text-ink-900">
               {isExpanded ? (
                 <ChevronUp className="w-4 h-4" aria-hidden="true" />
               ) : (
@@ -180,7 +180,7 @@ export function DecisionReadinessBadge({
       {/* Composed badges row */}
       {(identifiability || evidenceCoverage) && (
         <div className="flex items-center gap-2 px-3 pb-2 border-t border-current/10">
-          <span className={`${typography.caption} text-ink-900/50 pt-2`}>
+          <span className={`${typography.caption} text-ink-900 pt-2`}>
             Model checks:
           </span>
           <div className="flex items-center gap-2 pt-2">

--- a/src/canvas/components/DegradedBanner.tsx
+++ b/src/canvas/components/DegradedBanner.tsx
@@ -82,7 +82,7 @@ export function DegradedBanner() {
               ? 'Engine currently unavailable; try again shortly.'
               : 'Engine running in degraded mode; performance reduced.'}
           </p>
-          <p className={`mt-1 ${typography.caption} text-warning/80`}>
+          <p className={`mt-1 ${typography.caption}`}>
             {isDown
               ? 'Runs may fail until the engine recovers. You can still explore your graph and past results.'
               : 'Some runs may be slower or limited while the engine is in degraded mode.'}

--- a/src/canvas/components/DeltaInterpretation.tsx
+++ b/src/canvas/components/DeltaInterpretation.tsx
@@ -34,7 +34,7 @@ export function DeltaInterpretation({
   const colorMap = {
     better: 'text-success-700',
     worse: 'text-danger-700',
-    similar: 'text-ink-900/70',
+    similar: 'text-ink-900',
   }
 
   const directionText = {
@@ -62,7 +62,7 @@ export function DeltaInterpretation({
           {objectiveText}.
         </p>
         {delta.direction !== 'similar' && (
-          <p className={`${typography.bodySmall} text-ink-900/70 mt-1`}>
+          <p className={`${typography.bodySmall} text-ink-900 mt-1`}>
             Expected outcome moved from {formatValue(fromValue)} to {formatValue(toValue)}
             {delta.deltaPercent !== null && (
               <>

--- a/src/canvas/components/DocumentsManager.tsx
+++ b/src/canvas/components/DocumentsManager.tsx
@@ -109,7 +109,7 @@ export function DocumentsManager({ onUpload, onDownload, onDelete }: DocumentsMa
       {/* Header */}
       <div className="px-4 py-3 border-b border-sand-200 bg-paper-50">
         <h3 className={`${typography.body} font-semibold text-ink-900`}>Documents</h3>
-        <p className={`${typography.caption} text-ink-900/70 mt-1`}>
+        <p className={`${typography.caption} text-ink-900 mt-1`}>
           {documents.length} document{documents.length !== 1 ? 's' : ''}
           {searchQuery && filteredAndSorted.length !== documents.length && (
             <span> ({filteredAndSorted.length} filtered)</span>
@@ -181,8 +181,8 @@ export function DocumentsManager({ onUpload, onDownload, onDelete }: DocumentsMa
         onDragLeave={() => setIsDragging(false)}
         onDrop={handleDrop}
       >
-        <Upload className="w-8 h-8 mx-auto mb-2 text-ink-900/50" aria-hidden="true" />
-        <p className={`${typography.body} text-ink-900/80 mb-2`}>
+        <Upload className="w-8 h-8 mx-auto mb-2 text-ink-900" aria-hidden="true" />
+        <p className={`${typography.body} text-ink-900 mb-2`}>
           Drag and drop files here, or click to browse
         </p>
         <label className={`inline-block px-4 py-2 bg-info-500 text-text-on-color rounded-md cursor-pointer hover:bg-info-600 ${typography.button}`}>
@@ -196,7 +196,7 @@ export function DocumentsManager({ onUpload, onDownload, onDelete }: DocumentsMa
             data-testid="documents-file-input"
           />
         </label>
-        <p className={`${typography.caption} text-ink-900/60 mt-2`}>
+        <p className={`${typography.caption} text-ink-900 mt-2`}>
           Supports: PDF, TXT, MD, CSV (max 1MB each, 25K chars total)
         </p>
       </div>
@@ -204,22 +204,22 @@ export function DocumentsManager({ onUpload, onDownload, onDelete }: DocumentsMa
       {/* Documents list */}
       <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-2">
         {documents.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-10 text-center text-ink-900/70">
+          <div className="flex flex-col items-center justify-center py-10 text-center text-ink-900">
             <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-sky-50">
               <FileText className="w-6 h-6 text-sky-600" aria-hidden="true" />
             </div>
             <p className={`${typography.body} font-medium`}>No documents yet</p>
-            <p className={`mt-1 ${typography.caption} text-ink-900/60`}>
+            <p className={`mt-1 ${typography.caption} text-ink-900`}>
               Attach research, specs, or data Olumi should consider.
             </p>
           </div>
         ) : filteredAndSorted.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-10 text-center text-ink-900/70">
+          <div className="flex flex-col items-center justify-center py-10 text-center text-ink-900">
             <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-sand-50">
-              <Search className="w-6 h-6 text-ink-900/50" aria-hidden="true" />
+              <Search className="w-6 h-6 text-ink-900" aria-hidden="true" />
             </div>
             <p className={`${typography.body} font-medium`}>No documents match '{searchQuery}'</p>
-            <p className={`mt-1 ${typography.caption} text-ink-900/60`}>Try a different search term</p>
+            <p className={`mt-1 ${typography.caption} text-ink-900`}>Try a different search term</p>
           </div>
         ) : (
           filteredAndSorted.map((doc) => (

--- a/src/canvas/components/DraftPreview.tsx
+++ b/src/canvas/components/DraftPreview.tsx
@@ -76,12 +76,12 @@ export function DraftPreview({
     return (
       <div className="space-y-4 p-4 bg-white rounded-lg border border-sand-200 shadow-panel" data-testid="draft-preview-empty">
         <div className="flex items-center gap-3 p-3 rounded-lg border bg-paper-50 border-sand-200">
-          <CloudOff className="w-5 h-5 text-ink-900/50" />
+          <CloudOff className="w-5 h-5 text-ink-900" />
           <div className="flex-1">
             <p className={`${typography.label} text-ink-900`}>
               No draft available
             </p>
-            <p className={`${typography.caption} text-ink-900/60`}>
+            <p className={`${typography.caption} text-ink-900`}>
               The AI assistant couldn't generate a draft. Try describing your decision differently or check your connection.
             </p>
           </div>
@@ -114,7 +114,7 @@ export function DraftPreview({
               className="max-w-full max-h-[180px] mx-auto"
             />
           ) : (
-            <p className={`${typography.caption} text-ink-900/50 text-center py-8`}>
+            <p className={`${typography.caption} text-ink-900 text-center py-8`}>
               Graph preview will appear on canvas
             </p>
           )}

--- a/src/canvas/components/EvidenceCoverage.tsx
+++ b/src/canvas/components/EvidenceCoverage.tsx
@@ -133,7 +133,7 @@ export function EvidenceCoverage({
         </div>
 
         {/* Count label */}
-        <div className={`${typography.caption} text-ink-900/60`}>
+        <div className={`${typography.caption} text-ink-900`}>
           {evidencedCount} of {totalCount} edges documented
         </div>
       </div>

--- a/src/canvas/components/FocusModeChip.tsx
+++ b/src/canvas/components/FocusModeChip.tsx
@@ -71,7 +71,7 @@ export const FocusModeChip = memo(function FocusModeChip({ className = '' }: Foc
       aria-live="polite"
       data-testid="focus-mode-chip"
     >
-      <span className="text-sm text-ink-900/70">
+      <span className="text-sm text-ink-900">
         Showing paths from{' '}
         <strong className="font-medium" title={nodeTitle ?? undefined}>
           {displayTitle}

--- a/src/canvas/components/GoalModePanel.tsx
+++ b/src/canvas/components/GoalModePanel.tsx
@@ -63,7 +63,7 @@ export function GoalModePanel({ onClose }: GoalModePanelProps) {
           </div>
           <button
             onClick={onClose}
-            className="text-ink-900/60 hover:text-ink-900 transition-colors"
+            className="text-ink-900 transition-colors"
             aria-label="Close"
           >
             <X className="w-5 h-5" />
@@ -179,7 +179,7 @@ export function GoalModePanel({ onClose }: GoalModePanelProps) {
                   </div>
 
                   <div className="flex items-center gap-2 mb-2">
-                    <span className={`${typography.body} text-ink-900/70`}>
+                    <span className={`${typography.body} text-ink-900`}>
                       {step.currentValue} → {step.targetValue}
                     </span>
                     <TrendingUp className="w-4 h-4 text-mint-600" />
@@ -190,7 +190,7 @@ export function GoalModePanel({ onClose }: GoalModePanelProps) {
                   </div>
 
                   {step.impact.sideEffects.length > 0 && (
-                    <div className={`${typography.caption} text-ink-900/60`}>
+                    <div className={`${typography.caption} text-ink-900`}>
                       Side effects: {step.impact.sideEffects[0].nodeLabel}
                       {step.impact.sideEffects[0].expectedChange > 0 ? ' +' : ' '}
                       {step.impact.sideEffects[0].expectedChange.toFixed(1)}

--- a/src/canvas/components/InsightsPanel.tsx
+++ b/src/canvas/components/InsightsPanel.tsx
@@ -401,7 +401,7 @@ export function InsightsPanel({
                 Key Insight
               </span>
               {hasDetails && (
-                <span className="text-ink-900/40">
+                <span className="text-ink-900">
                   {isExpanded ? (
                     <ChevronUp className="w-4 h-4" aria-hidden="true" />
                   ) : (
@@ -452,7 +452,7 @@ export function InsightsPanel({
                   return (
                     <li
                       key={key}
-                      className={`${typography.bodySmall} text-ink-900/80 list-disc`}
+                      className={`${typography.bodySmall} text-ink-900 list-disc`}
                     >
                       {risk}
                     </li>
@@ -483,7 +483,7 @@ export function InsightsPanel({
                 {caveats.map((caveat) => (
                   <li
                     key={caveat.id}
-                    className={`${typography.bodySmall} text-ink-900/80 list-disc`}
+                    className={`${typography.bodySmall} text-ink-900 list-disc`}
                   >
                     {caveat.content}
                   </li>
@@ -537,7 +537,7 @@ export function InsightsPanel({
                       <button
                         type="button"
                         onClick={isInteractive ? handleClick : undefined}
-                        className={`${typography.bodySmall} text-ink-900/80 text-left ${
+                        className={`${typography.bodySmall} text-ink-900 text-left ${
                           isInteractive ? 'underline decoration-dotted hover:text-success' : ''
                         }`}
                         disabled={!isInteractive}

--- a/src/canvas/components/InsightsTab.tsx
+++ b/src/canvas/components/InsightsTab.tsx
@@ -62,7 +62,7 @@ export function InsightsTabBody() {
   if (nodes.length === 0) {
     return (
       <div className="p-4">
-        <p className={`${typography.body} text-ink-900/50 text-center py-8`}>
+        <p className={`${typography.body} text-ink-900 text-center py-8`}>
           Add nodes to your graph to see insights
         </p>
       </div>
@@ -94,10 +94,10 @@ export function InsightsTabBody() {
             </div>
 
             <div className={`flex items-center gap-4 ${typography.body}`}>
-              <span className={`${typography.bodySmall} text-ink-900/70`}>
+              <span className={`${typography.bodySmall} text-ink-900`}>
                 {data.bias_findings.filter(b => b.severity === 'high').length} high-priority biases
               </span>
-              <span className={`${typography.bodySmall} text-ink-900/70`}>
+              <span className={`${typography.bodySmall} text-ink-900`}>
                 {data.structural_health.warnings.length} structural warnings
               </span>
             </div>
@@ -293,7 +293,7 @@ function BiasCard({ bias, checked, expanded, onToggle, onExpand }: BiasCardProps
             <span className={`${typography.label} text-carrot-700`}>
               {bias.severity === 'high' ? '[High]' : '[Medium]'} {bias.type}
             </span>
-            <p className={`${typography.bodySmall} text-ink-900/70 mt-1`}>
+            <p className={`${typography.bodySmall} text-ink-900 mt-1`}>
               {bias.description}
             </p>
           </div>
@@ -326,11 +326,11 @@ function BiasCard({ bias, checked, expanded, onToggle, onExpand }: BiasCardProps
 
           {expanded && bias.mechanism && (
             <div className="p-2 bg-paper-50 rounded border-l-2 border-sky-500">
-              <p className={`${typography.bodySmall} text-ink-900/70`}>
+              <p className={`${typography.bodySmall} text-ink-900`}>
                 {bias.mechanism}
               </p>
               {bias.citation && (
-                <p className={`${typography.caption} text-ink-900/50 mt-1`}>
+                <p className={`${typography.caption} text-ink-900 mt-1`}>
                   {bias.citation}
                 </p>
               )}

--- a/src/canvas/components/LimitsPanel.tsx
+++ b/src/canvas/components/LimitsPanel.tsx
@@ -85,10 +85,10 @@ export function LimitsPanel({ isOpen, onClose, currentNodes, currentEdges }: Lim
         <div className="py-6 text-center">
           <AlertTriangle className="w-12 h-12 mx-auto mb-4 text-danger-500" />
           <h3 className={`${typography.h4} text-ink-900 mb-2`}>Limits Unavailable</h3>
-          <p className={`${typography.body} text-ink-900/70 mb-4`}>
+          <p className={`${typography.body} text-ink-900 mb-4`}>
             {error.message}
           </p>
-          <p className={`${typography.caption} text-ink-900/60 mb-4`}>
+          <p className={`${typography.caption} text-ink-900 mb-4`}>
             Last attempt: {timestamp}
           </p>
           <button
@@ -106,7 +106,7 @@ export function LimitsPanel({ isOpen, onClose, currentNodes, currentEdges }: Lim
       return (
         <div className="py-12 text-center">
           <div className="w-8 h-8 mx-auto mb-4 border-4 border-info/30 border-t-info rounded-full animate-spin" />
-          <p className={`${typography.body} text-ink-900/70`}>Loading limits...</p>
+          <p className={`${typography.body} text-ink-900`}>Loading limits...</p>
         </div>
       )
     }
@@ -119,12 +119,12 @@ export function LimitsPanel({ isOpen, onClose, currentNodes, currentEdges }: Lim
         {/* Source Info */}
         <div className="flex items-center justify-between p-3 rounded-lg bg-paper-50 border border-sand-200">
           <div className={`flex items-center gap-2 ${typography.body}`}>
-            <Database className="w-4 h-4 text-ink-900/70" />
-            <span className="text-ink-900/80">
+            <Database className="w-4 h-4 text-ink-900" />
+            <span className="text-ink-900">
               Source: <span className="font-medium text-ink-900">{source === 'live' ? 'Live' : 'Fallback'}</span>
             </span>
           </div>
-          <div className={`${typography.caption} text-ink-900/60`}>
+          <div className={`${typography.caption} text-ink-900`}>
             Fetched: {timestamp}
           </div>
         </div>
@@ -148,10 +148,10 @@ export function LimitsPanel({ isOpen, onClose, currentNodes, currentEdges }: Lim
             <div className="flex items-center justify-between">
               <span className={`${typography.label} text-ink-900`}>{limitsStatus.zoneLabel}</span>
             </div>
-            <p className={`mt-1 ${typography.caption} text-ink-900/70`}>
+            <p className={`mt-1 ${typography.caption} text-ink-900`}>
               {limitsStatus.message}
             </p>
-            <p className={`mt-1 ${typography.caption} text-ink-900/60`} style={{ fontSize: '11px' }}>
+            <p className={`mt-1 ${typography.caption} text-ink-900`} style={{ fontSize: '11px' }}>
               Current limits: up to {limits.nodes.max} nodes and {limits.edges.max} edges per run.
             </p>
           </div>
@@ -179,14 +179,14 @@ export function LimitsPanel({ isOpen, onClose, currentNodes, currentEdges }: Lim
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <Clock className="w-5 h-5 text-ink-900/70" />
+                <Clock className="w-5 h-5 text-ink-900" />
                 <span className={`${typography.label} text-ink-900`}>Engine p95 Budget</span>
               </div>
               <div className={`${typography.body} tabular-nums`}>
                 <span className="font-semibold text-info-600">{limits.engine_p95_ms_budget}ms</span>
               </div>
             </div>
-            <p className={`${typography.caption} text-ink-900/70`}>
+            <p className={`${typography.caption} text-ink-900`}>
               Maximum expected execution time (95th percentile)
             </p>
           </div>

--- a/src/canvas/components/ModelQualityScore.tsx
+++ b/src/canvas/components/ModelQualityScore.tsx
@@ -91,7 +91,7 @@ function MetricRow({ label, value, tooltip }: MetricRowProps) {
   return (
     <Tooltip content={tooltip} position="right">
       <div className="flex items-center justify-between gap-3 py-1">
-        <span className={`${typography.bodySmall} text-ink-900/70`}>
+        <span className={`${typography.bodySmall} text-ink-900`}>
           {label}
         </span>
         <div className="flex items-center gap-2">
@@ -224,7 +224,7 @@ export function ModelQualityScore({
             )}
 
             {/* Expand/collapse chevron */}
-            <span className="text-ink-900/40">
+            <span className="text-ink-900">
               {isExpanded ? (
                 <ChevronUp className="w-4 h-4" aria-hidden="true" />
               ) : (
@@ -259,7 +259,7 @@ export function ModelQualityScore({
             />
             {/* Show local evidence count detail when available */}
             {localEvidenceCounts && localEvidenceCounts.total > 0 && (
-              <div className={`flex items-center justify-between py-0.5 pl-4 ${typography.caption} text-ink-900/60`}>
+              <div className={`flex items-center justify-between py-0.5 pl-4 ${typography.caption} text-ink-900`}>
                 <span>{localEvidenceCounts.evidenced}/{localEvidenceCounts.total} edges documented</span>
                 {localEvidencePercent !== null && Math.abs(localEvidencePercent - evidence_coverage) > 0.05 && (
                   <span className="text-warning" title="Local count differs from engine assessment">
@@ -286,7 +286,7 @@ export function ModelQualityScore({
                   className="w-4 h-4 text-warning flex-shrink-0 mt-0.5"
                   aria-hidden="true"
                 />
-                <span className={`${typography.bodySmall} text-ink-900/80`}>
+                <span className={`${typography.bodySmall} text-ink-900`}>
                   {recommendation}
                 </span>
               </div>

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1719,7 +1719,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             <button
               type="button"
               onClick={toggleOpen}
-              className={`inline-flex items-center justify-center w-6 h-6 rounded border border-panel-border ${typography.caption} text-text-header/70 hover:bg-panel`}
+              className={`inline-flex items-center justify-center w-6 h-6 rounded border border-panel-border ${typography.caption} text-text-header hover:bg-panel`}
               aria-label={effectiveIsOpen ? 'Collapse outputs dock' : 'Expand outputs dock'}
             >
               {effectiveIsOpen ? '>' : '<'}
@@ -1747,7 +1747,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   className={`flex-1 px-2 py-1 rounded ${typography.caption} font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1 ${
                     effectiveActiveTab === tab.id
                       ? 'text-info border-b-2 border-info'
-                      : 'text-text-header/70 hover:bg-panel hover:text-text-header border-b-2 border-transparent'
+                      : 'text-text-header hover:bg-panel border-b-2 border-transparent'
                   }`}
                   style={
                     effectiveActiveTab === tab.id
@@ -1803,7 +1803,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             <button
               type="button"
               onClick={toggleOpen}
-              className={`inline-flex items-center justify-center w-6 h-6 rounded border border-panel-border ${typography.caption} text-text-header/70 hover:bg-panel`}
+              className={`inline-flex items-center justify-center w-6 h-6 rounded border border-panel-border ${typography.caption} text-text-header hover:bg-panel`}
               aria-label={effectiveIsOpen ? 'Collapse outputs dock' : 'Expand outputs dock'}
             >
               {effectiveIsOpen ? '>' : '<'}
@@ -1836,7 +1836,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 className={`flex items-center justify-center w-7 h-7 rounded-full border ${typography.caption} focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1 ${
                   effectiveActiveTab === tab.id
                     ? 'text-info border-info'
-                    : 'text-text-header/70 bg-panel border-panel-border hover:bg-panel hover:text-text-header'
+                    : 'text-text-header bg-panel border-panel-border hover:bg-panel'
                 }`}
                 style={effectiveActiveTab === tab.id ? { backgroundColor: 'rgba(82,163,200,0.15)' } : undefined}
                 aria-label={tab.label}
@@ -1850,7 +1850,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       )}
 
       {effectiveIsOpen && (
-        <div className={`flex-1 min-h-0 ${typography.caption} text-text-header/70 ${effectiveActiveTab === 'results' || effectiveActiveTab === 'olumi' ? 'flex flex-col overflow-hidden' : 'olumi-scrollbar px-3 py-3 space-y-4 overflow-y-auto'}`} data-testid="outputs-dock-body">
+        <div className={`flex-1 min-h-0 ${typography.caption} text-text-header ${effectiveActiveTab === 'results' || effectiveActiveTab === 'olumi' ? 'flex flex-col overflow-hidden' : 'olumi-scrollbar px-3 py-3 space-y-4 overflow-y-auto'}`} data-testid="outputs-dock-body">
             {effectiveActiveTab === 'results' && (
               <div className="flex-1 min-h-0 flex flex-col">
                 {aiPanelV2On && transitionReceipt === 'model-drafted' ? (
@@ -2007,7 +2007,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                       }`}>
                         {friendlyError.headline}
                       </div>
-                      <div className={`${typography.caption} text-text-header/80`}>
+                      <div className={`${typography.caption} text-text-header`}>
                         {friendlyError.explanation}
                       </div>
                       <div className="flex flex-col gap-2 mt-1">
@@ -2061,7 +2061,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                           )}
                         </div>
                         {/* Task P.3.5: Coaching text for repeated failures */}
-                        <p className={`${typography.caption} text-text-header/70`}>
+                        <p className={`${typography.caption} text-text-header`}>
                           If analysis keeps failing, try simplifying to 8-10 of the most important factors.
                         </p>
                       </div>

--- a/src/canvas/components/RangeChips.tsx
+++ b/src/canvas/components/RangeChips.tsx
@@ -145,7 +145,7 @@ function RangeChip({ label, technicalLabel, value, variant, units, unitSymbol }:
       <div className="text-lg font-semibold mb-1">
         {formattedValue}
       </div>
-      <div className={`${typography.caption} font-medium text-ink-900/70`}>
+      <div className={`${typography.caption} font-medium text-ink-900`}>
         {label}
       </div>
     </div>

--- a/src/canvas/components/RangeDisplay.tsx
+++ b/src/canvas/components/RangeDisplay.tsx
@@ -140,7 +140,7 @@ export function RangeDisplay({
 
   if (!hasAnyValue) {
     return (
-      <div className={`${typography.caption} text-ink-900/70`} data-testid="range-display">
+      <div className={`${typography.caption} text-ink-900`} data-testid="range-display">
         Range is not available for this run.
       </div>
     )

--- a/src/canvas/components/RangeLabels.tsx
+++ b/src/canvas/components/RangeLabels.tsx
@@ -38,7 +38,7 @@ export function RangeLabels({
     return (
       <div className="flex flex-col items-center gap-1 relative">
         <div className="flex items-center gap-1">
-          <span className={`${typography.code} font-medium text-ink-900/70`}>
+          <span className={`${typography.code} font-medium text-ink-900`}>
             {config.userLabel}
           </span>
           {showTooltips && (
@@ -46,7 +46,7 @@ export function RangeLabels({
               type="button"
               onMouseEnter={() => setHoveredRange(rangeKey)}
               onMouseLeave={() => setHoveredRange(null)}
-              className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full text-ink-900/50 hover:text-ink-900/80 hover:bg-sand-100"
+              className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full text-ink-900 hover:bg-sand-100"
               aria-label={`Show details for ${config.userLabel}`}
             >
               <Info className="w-2.5 h-2.5" aria-hidden="true" />
@@ -66,7 +66,7 @@ export function RangeLabels({
             <div className={`${typography.caption} font-medium mb-1`}>
               {config.technicalTerm}
             </div>
-            <div className={`${typography.caption} text-paper-50/90`}>
+            <div className={`${typography.caption}`}>
               {config.description}
             </div>
             {/* Arrow */}

--- a/src/canvas/components/StructuralHealth.tsx
+++ b/src/canvas/components/StructuralHealth.tsx
@@ -81,7 +81,7 @@ function WarningCard({ icon: Icon, title, description, action }: WarningCardProp
       <Icon className="w-4 h-4 flex-shrink-0 text-warning" aria-hidden="true" />
       <div className="flex-1">
         <p className={`${typography.label} text-sun-800`}>{title}</p>
-        <p className={`${typography.bodySmall} text-ink-900/70`}>{description}</p>
+        <p className={`${typography.bodySmall} text-ink-900`}>{description}</p>
         <button className={`${typography.caption} text-sky-600 underline hover:text-sky-700 mt-1`}>
           {action}
         </button>

--- a/src/canvas/components/UnifiedStatusBadge.tsx
+++ b/src/canvas/components/UnifiedStatusBadge.tsx
@@ -194,7 +194,7 @@ export function UnifiedStatusBadge({
 
           {/* Expand/collapse chevron */}
           {hasDetails && (
-            <span className="text-ink-900/40">
+            <span className="text-ink-900">
               {isExpanded ? (
                 <ChevronUp className="w-4 h-4" aria-hidden="true" />
               ) : (

--- a/src/canvas/components/ValidationBanner.tsx
+++ b/src/canvas/components/ValidationBanner.tsx
@@ -65,12 +65,17 @@ export function ValidationBanner({ errors, violations, onDismiss, onFixNow, clas
           >
             {firstError.message}
           </p>
+          {/* The count line carries NO colour class, deliberately. It used to
+              name the warning/danger tokens at 80% opacity, which never emitted
+              a rule (a bare var() colour cannot take an opacity modifier), so
+              it has always rendered in the inherited body colour. Those tokens
+              fall below WCAG AA as text even at FULL strength, so making them
+              solid would have introduced a contrast failure that does not
+              exist today; the dead classes were removed rather than revived.
+              A compliant colour here needs a design ruling — see the
+              channel-triple note in src/styles/brand.css. */}
           {hasMultiple && (
-            <p
-              className={`${typography.caption} mt-1 ${
-                isWarning ? 'text-warning/80' : 'text-danger/80'
-              }`}
-            >
+            <p className={`${typography.caption} mt-1`}>
               +{errors.length - 1} more {errors.length === 2 ? 'issue' : 'issues'}
             </p>
           )}
@@ -79,8 +84,8 @@ export function ValidationBanner({ errors, violations, onDismiss, onFixNow, clas
               onClick={() => onFixNow(firstError)}
               className={`mt-2 ${typography.caption} font-medium underline ${
                 isWarning
-                  ? 'text-warning hover:text-warning/80'
-                  : 'text-danger hover:text-danger/80'
+                  ? 'text-warning'
+                  : 'text-danger'
               }`}
               type="button"
             >
@@ -126,12 +131,12 @@ export function ValidationBanner({ errors, violations, onDismiss, onFixNow, clas
             {firstViolation.message}
           </p>
           {firstViolation.suggestion && (
-            <p className={`${typography.caption} mt-1 text-info/80`}>
+            <p className={`${typography.caption} mt-1 text-info`}>
               Suggestion: {firstViolation.suggestion}
             </p>
           )}
           {hasMultiple && (
-            <p className={`${typography.caption} mt-1 text-info/80`}>
+            <p className={`${typography.caption} mt-1 text-info`}>
               +{violations.length - 1} more {violations.length === 2 ? 'suggestion' : 'suggestions'}
             </p>
           )}
@@ -141,7 +146,7 @@ export function ValidationBanner({ errors, violations, onDismiss, onFixNow, clas
           {onFixNow && (firstViolation.node_id || firstViolation.edge_id) && (
             <button
               onClick={() => onFixNow(firstViolation)}
-              className={`mt-2 ${typography.caption} font-medium underline text-info hover:text-info/80`}
+              className={`mt-2 ${typography.caption} font-medium underline text-info hover:text-info`}
               type="button"
             >
               View in canvas

--- a/src/canvas/components/ValidationSuggestions.tsx
+++ b/src/canvas/components/ValidationSuggestions.tsx
@@ -84,7 +84,7 @@ export function ValidationSuggestionsSection() {
   if (nodes.length === 0) {
     return (
       <div className="p-4">
-        <p className={`${typography.body} text-ink-900/50 text-center py-8`}>
+        <p className={`${typography.body} text-ink-900 text-center py-8`}>
           Add nodes to your graph to see validation suggestions
         </p>
       </div>

--- a/src/canvas/components/WarningBanner.tsx
+++ b/src/canvas/components/WarningBanner.tsx
@@ -67,7 +67,7 @@ export function WarningBanner({ warnings, onDismiss, onViewAffected }: WarningBa
           <button
             type="button"
             onClick={() => setIsExpanded(!isExpanded)}
-            className={`${typography.caption} mt-1 text-warning flex items-center gap-1 hover:text-warning/80`}
+            className={`${typography.caption} mt-1 text-warning flex items-center gap-1`}
           >
             {isExpanded ? (
               <ChevronDown className="w-3 h-3" />
@@ -93,7 +93,7 @@ export function WarningBanner({ warnings, onDismiss, onViewAffected }: WarningBa
           <button
             type="button"
             onClick={() => onViewAffected(firstWarning.affected_ids!)}
-            className={`mt-2 ${typography.caption} font-medium underline text-warning hover:text-warning/80`}
+            className={`mt-2 ${typography.caption} font-medium underline text-warning`}
           >
             View {firstWarning.affected_ids.length} affected{' '}
             {firstWarning.affected_ids.length === 1 ? 'item' : 'items'}

--- a/src/canvas/components/pre-analysis/BlockersSection.tsx
+++ b/src/canvas/components/pre-analysis/BlockersSection.tsx
@@ -188,7 +188,7 @@ export function BlockersSection({
                       <ul className="mt-1 space-y-0.5">
                         {display.suggestedActions.map((action) => (
                           <li key={action} className={`${typography.panelMeta} text-text-light flex items-center gap-1`}>
-                            <span className="text-text-light/50">&bull;</span>
+                            <span className="text-text-light">&bull;</span>
                             {action}
                           </li>
                         ))}
@@ -353,7 +353,7 @@ function ConstraintGroupCard({ items }: { items: EnrichedBlocker[] }) {
             <ul className="mt-1 space-y-0.5" data-testid="constraint-group-list">
               {constraintLabels.map((label, idx) => (
                 <li key={idx} className={`${typography.panelMeta} text-text-light flex items-center gap-1`}>
-                  <span className="text-text-light/50">&bull;</span>
+                  <span className="text-text-light">&bull;</span>
                   {label}
                 </li>
               ))}

--- a/src/canvas/components/pre-analysis/primitives/IconBtn.tsx
+++ b/src/canvas/components/pre-analysis/primitives/IconBtn.tsx
@@ -40,27 +40,27 @@ interface IconBtnProps {
 const variantStyles: Record<IconBtnVariant, { enabled: string; disabled: string }> = {
   default: {
     enabled: 'text-text-light hover:text-text-body hover:bg-panel-hover',
-    disabled: 'text-text-light/50 cursor-not-allowed',
+    disabled: 'text-text-light cursor-not-allowed',
   },
   confirm: {
     enabled: 'text-success hover:bg-panel-hover',
-    disabled: 'text-text-light/50 cursor-not-allowed',
+    disabled: 'text-text-light cursor-not-allowed',
   },
   edit: {
     enabled: 'text-info hover:bg-panel-hover',
-    disabled: 'text-text-light/50 cursor-not-allowed',
+    disabled: 'text-text-light cursor-not-allowed',
   },
   assume: {
     enabled: 'text-warning hover:bg-panel-hover',
-    disabled: 'text-text-light/50 cursor-not-allowed',
+    disabled: 'text-text-light cursor-not-allowed',
   },
   primary: {
     enabled: 'text-info hover:bg-panel-hover',
-    disabled: 'text-text-light/50 cursor-not-allowed',
+    disabled: 'text-text-light cursor-not-allowed',
   },
   ghost: {
     enabled: 'text-text-light hover:text-text-body',
-    disabled: 'text-text-light/50 cursor-not-allowed',
+    disabled: 'text-text-light cursor-not-allowed',
   },
 }
 

--- a/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
+++ b/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
@@ -603,7 +603,7 @@ export function GraphPatchBlockRenderer({
             return (
               <span key={`${id}-${i}`} className="inline-flex items-center">
                 <EntityLink id={id} label={label} kind={kind} />
-                {i < relatedElements.length - 1 && <span className="text-text-light/60" aria-hidden="true">,</span>}
+                {i < relatedElements.length - 1 && <span className="text-text-light" aria-hidden="true">,</span>}
               </span>
             )
           })}

--- a/src/canvas/help/HelpMenu.tsx
+++ b/src/canvas/help/HelpMenu.tsx
@@ -93,7 +93,7 @@ export function HelpMenu({ onShowOnboarding, onShowKeyboardLegend, onShowInfluen
           aria-label="Canvas help"
           className="absolute right-0 mt-2 w-72 bg-panel rounded-lg shadow-panel border border-panel-border py-2 z-[1100]"
         >
-          <p className={`px-4 pb-2 ${typography.caption} uppercase tracking-wide text-ink-900/70`}>Need a refresher?</p>
+          <p className={`px-4 pb-2 ${typography.caption} uppercase tracking-wide text-ink-900`}>Need a refresher?</p>
           <div className="flex flex-col">
             {menuItems.map(item => (
               <button
@@ -103,7 +103,7 @@ export function HelpMenu({ onShowOnboarding, onShowKeyboardLegend, onShowInfluen
                 className="text-left px-4 py-3 hover:bg-paper-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info"
               >
                 <span className={`block ${typography.label} text-ink-900`}>{item.label}</span>
-                <span className={`block ${typography.caption} text-ink-900/70`}>{item.description}</span>
+                <span className={`block ${typography.caption} text-ink-900`}>{item.description}</span>
               </button>
             ))}
           </div>

--- a/src/canvas/highlight/HighlightLayer.tsx
+++ b/src/canvas/highlight/HighlightLayer.tsx
@@ -56,7 +56,7 @@ export function HighlightLayer({ isResultsOpen }: HighlightLayerProps): JSX.Elem
               className={`absolute pointer-events-none transition-all duration-300 rounded-lg ${
                 isHovered
                   ? 'border-4 border-info shadow-3 shadow-info/60 bg-info/15'
-                  : 'border-2 border-info/40 shadow-2 shadow-info/30 bg-info/8'
+                  : 'border-2 border-info/40 shadow-2 shadow-info/30 bg-info/[0.08]'
               }`}
               style={{
                 left: node.position.x,

--- a/src/canvas/nodes/__tests__/GhostOptionNode.contrast.spec.ts
+++ b/src/canvas/nodes/__tests__/GhostOptionNode.contrast.spec.ts
@@ -33,6 +33,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { resolveTokenHex } from '../../../styles/channelTriple.mjs'
 
 const WCAG_NON_TEXT_MIN = 3
 
@@ -55,11 +56,20 @@ function contrast(a: string, b: string): number {
   return (hi + 0.05) / (lo + 0.05)
 }
 
-/** Declared value of a `--token` at :root in brand.css. */
+/**
+ * Declared colour of a `--token` at :root in brand.css.
+ *
+ * Delegated to the shared resolver so this guard reads brand.css identically
+ * to the other four parsers. It understands the channel-triple form
+ * (`--bg-panel-rgb: 254 254 254; --bg-panel: rgb(var(--bg-panel-rgb))`), which
+ * is what allows Tailwind to emit opacity-modified utilities; a literal-hex-only
+ * regex went red the moment that landed. Still throws on anything it cannot
+ * resolve, so no assertion below can go vacuous.
+ */
 function declared(token: string): string {
-  const m = brandCss.match(new RegExp(`^\\s*${token}:\\s*(#[0-9A-Fa-f]{3,8})\\s*;`, 'm'))
-  if (!m) throw new Error(`${token} is not declared with a literal hex in brand.css`)
-  return m[1]
+  const hex = resolveTokenHex(brandCss, token)
+  if (!hex) throw new Error(`${token} does not resolve to a literal colour in brand.css`)
+  return hex
 }
 
 /** The outline's `var(--token, #fallback)`, parsed out of the component. */

--- a/src/canvas/onboarding/EmptyState.tsx
+++ b/src/canvas/onboarding/EmptyState.tsx
@@ -155,7 +155,7 @@ export function EmptyState({
           <h1 className={`${typography.h1} text-ink-900 mb-2`}>
             Start your decision canvas
           </h1>
-          <p className={`${typography.body} text-ink-900/70`}>
+          <p className={`${typography.body} text-ink-900`}>
             Pick a starting template that fits your situation, or start from scratch to build your own model.
           </p>
         </div>
@@ -199,7 +199,7 @@ export function EmptyState({
               </h2>
 
               {/* Description */}
-              <p className={`${typography.body} text-ink-900/70 mb-3`}>
+              <p className={`${typography.body} text-ink-900 mb-3`}>
                 {sanitizeLabel(template.description)}
               </p>
 
@@ -209,7 +209,7 @@ export function EmptyState({
                   {template.tags.map(tag => (
                     <span
                       key={tag}
-                      className={`px-2 py-0.5 ${typography.caption} rounded bg-sand-100 text-ink-900/70`}
+                      className={`px-2 py-0.5 ${typography.caption} rounded bg-sand-100 text-ink-900`}
                     >
                       {sanitizeLabel(tag)}
                     </span>
@@ -237,7 +237,7 @@ export function EmptyState({
             <div className="flex flex-col items-center justify-center h-full text-center">
               <div className="w-16 h-16 mb-4 rounded-full bg-sky-50 flex items-center justify-center">
                 <svg
-                  className="w-8 h-8 text-ink-900/40"
+                  className="w-8 h-8 text-ink-900"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -254,7 +254,7 @@ export function EmptyState({
               <h2 className={`${typography.h4} text-ink-900 mb-2`}>
                 Start from Scratch
               </h2>
-              <p className={`${typography.body} text-ink-900/70`}>
+              <p className={`${typography.body} text-ink-900`}>
                 Build your own decision graph
               </p>
             </div>
@@ -262,7 +262,7 @@ export function EmptyState({
         </div>
 
         {/* Keyboard hints */}
-        <div className={`text-center ${typography.body} text-ink-900/60`}>
+        <div className={`text-center ${typography.body} text-ink-900`}>
           <kbd className="px-2 py-1 bg-sand-100 rounded mr-1">←</kbd>
           <kbd className="px-2 py-1 bg-sand-100 rounded mr-2">→</kbd>
           to navigate
@@ -278,7 +278,7 @@ export function EmptyState({
         <div className="text-center mt-6">
           <button
             onClick={handleDismiss}
-            className={`${typography.body} text-ink-900/60 hover:text-ink-900 underline`}
+            className={`${typography.body} text-ink-900 underline`}
           >
             Don't show this again
           </button>

--- a/src/canvas/panels/InspectorPanel.tsx
+++ b/src/canvas/panels/InspectorPanel.tsx
@@ -244,21 +244,21 @@ export function InspectorPanel({ isOpen, onClose }: InspectorPanelProps): JSX.El
         >
           {/* Empty state or multi-selection message */}
           {!selectedEdge && (
-            <div className="flex flex-col items-center justify-center py-12 text-center text-text-header/70">
+            <div className="flex flex-col items-center justify-center py-12 text-center text-text-header">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-panel">
-                <Settings className="w-6 h-6 text-text-header/50" aria-hidden="true" />
+                <Settings className="w-6 h-6 text-text-header" aria-hidden="true" />
               </div>
               {hasMultipleEdges ? (
                 <>
                   <p className={typography.panelHeader}>Multiple edges selected</p>
-                  <p className={`mt-1 ${typography.panelMeta} text-text-header/60`}>
+                  <p className={`mt-1 ${typography.panelMeta} text-text-header`}>
                     Inspector only supports editing one edge at a time. Select a single edge to continue.
                   </p>
                 </>
               ) : (
                 <>
                   <p className={typography.panelHeader}>Select an edge to inspect</p>
-                  <p className={`mt-1 ${typography.panelMeta} text-text-header/60`}>
+                  <p className={`mt-1 ${typography.panelMeta} text-text-header`}>
                     Click an edge on the canvas to view and edit its metadata.
                   </p>
                 </>

--- a/src/canvas/panels/_shared/PanelShell.tsx
+++ b/src/canvas/panels/_shared/PanelShell.tsx
@@ -91,7 +91,7 @@ export function PanelShell({
       {/* Header */}
       <header className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-panel-border bg-panel rounded-tl-2xl">
         <div className="flex items-center gap-2">
-          {icon && <span className="text-text-header/70">{icon}</span>}
+          {icon && <span className="text-text-header">{icon}</span>}
           <h3 className={`${typography.panelHeader} text-text-header`}>{title}</h3>
           {chips}
         </div>

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -38,12 +38,12 @@ export function Collapsible({
             {title}
           </div>
           {description && (
-            <div className={`${typography.code} text-ink-900/70`}>
+            <div className={`${typography.code} text-ink-900`}>
               {description}
             </div>
           )}
         </div>
-        <Icon className="w-4 h-4 text-ink-900/70 flex-shrink-0" aria-hidden="true" />
+        <Icon className="w-4 h-4 text-ink-900 flex-shrink-0" aria-hidden="true" />
       </button>
       {isOpen && (
         <div

--- a/src/components/EngineAuditPanel.tsx
+++ b/src/components/EngineAuditPanel.tsx
@@ -53,24 +53,24 @@ export default function EngineAuditPanel() {
       </div>
       <div className="grid grid-cols-2 gap-2">
         <div>
-          <div className="text-[11px] text-ink-900/70">Last status</div>
+          <div className="text-[11px] text-ink-900">Last status</div>
           <div data-testid="audit-last-status" className="text-sm">{info.lastStatus ?? '—'}</div>
         </div>
         <div>
-          <div className="text-[11px] text-ink-900/70">Cached ETag</div>
+          <div className="text-[11px] text-ink-900">Cached ETag</div>
           <div data-testid="audit-cached-etag" className="text-sm">{info.cachedEtag ?? '—'}</div>
         </div>
         <div>
-          <div className="text-[11px] text-ink-900/70">Last data hash</div>
+          <div className="text-[11px] text-ink-900">Last data hash</div>
           <div data-testid="audit-data-hash" className="text-sm">{dataHash ?? '—'}</div>
         </div>
         <div className="col-span-2 mt-2">
-          <div className="text-[11px] text-ink-900/70 mb-1">Headers (last /draft-flows)</div>
+          <div className="text-[11px] text-ink-900 mb-1">Headers (last /draft-flows)</div>
           <div className="grid grid-cols-2 gap-2 text-xs">
-            <div><span className="text-ink-900/70">ETag:</span> <span data-testid="audit-header-etag">{etag ?? '—'}</span></div>
-            <div><span className="text-ink-900/70">Content-Length:</span> <span data-testid="audit-header-content-length">{contentLength ?? '—'}</span></div>
-            <div><span className="text-ink-900/70">Cache-Control:</span> <span data-testid="audit-header-cache-control">{cacheControl ?? '—'}</span></div>
-            <div><span className="text-ink-900/70">Vary:</span> <span data-testid="audit-header-vary">{vary ?? '—'}</span></div>
+            <div><span className="text-ink-900">ETag:</span> <span data-testid="audit-header-etag">{etag ?? '—'}</span></div>
+            <div><span className="text-ink-900">Content-Length:</span> <span data-testid="audit-header-content-length">{contentLength ?? '—'}</span></div>
+            <div><span className="text-ink-900">Cache-Control:</span> <span data-testid="audit-header-cache-control">{cacheControl ?? '—'}</span></div>
+            <div><span className="text-ink-900">Vary:</span> <span data-testid="audit-header-vary">{vary ?? '—'}</span></div>
           </div>
         </div>
       </div>

--- a/src/components/HelpTooltip.tsx
+++ b/src/components/HelpTooltip.tsx
@@ -29,7 +29,7 @@ export function HelpTooltip({ term, explanation, citation, learnMoreUrl }: HelpT
         {term}
       </button>
       <Info
-        className="w-3 h-3 text-ink-900/40 group-hover:text-sky-600 group-focus-within:text-sky-600 transition-colors"
+        className="w-3 h-3 text-ink-900 group-hover:text-sky-600 group-focus-within:text-sky-600 transition-colors"
         aria-hidden="true"
       />
 
@@ -52,7 +52,7 @@ export function HelpTooltip({ term, explanation, citation, learnMoreUrl }: HelpT
         </p>
 
         {citation && (
-          <p className={`${typography.caption} text-ink-900/60 mt-2`}>
+          <p className={`${typography.caption} text-ink-900 mt-2`}>
             {citation}
           </p>
         )}

--- a/src/components/JobsProgressPanel.tsx
+++ b/src/components/JobsProgressPanel.tsx
@@ -66,15 +66,15 @@ export default function JobsProgressPanel() {
           const isActive = j.status === 'queued' || j.status === 'running'
           return (
             <li key={j.id} data-testid="job-item" className="flex items-center gap-2">
-              <span data-testid="job-status" className="text-xs px-2 py-0.5 rounded-full border border-sand-200 bg-paper-50 text-ink-900/80">
+              <span data-testid="job-status" className="text-xs px-2 py-0.5 rounded-full border border-sand-200 bg-paper-50 text-ink-900">
                 {j.status === 'queued' && 'Queued'}
                 {j.status === 'running' && 'Running'}
                 {j.status === 'done' && 'Done'}
                 {j.status === 'failed' && 'Failed'}
                 {j.status === 'cancelled' && 'Cancelled'}
               </span>
-              <span className="text-xs text-ink-900/80">{j.id}</span>
-              <time data-testid="job-time" className="text-[11px] text-ink-900/50 ml-1">just now</time>
+              <span className="text-xs text-ink-900">{j.id}</span>
+              <time data-testid="job-time" className="text-[11px] text-ink-900 ml-1">just now</time>
               <div className="ml-auto flex items-center gap-2">
                 {typeof j.progress === 'number' && (
                   <div className="w-24 bg-sand-200 rounded h-2" aria-hidden="true">
@@ -87,7 +87,7 @@ export default function JobsProgressPanel() {
                     data-testid="job-cancel-btn"
                     aria-label={`Cancel job ${j.id}`}
                     title="Cancel job"
-                    className="px-2 py-0.5 rounded border border-sand-200 text-xs text-ink-900/80 hover:bg-paper-50"
+                    className="px-2 py-0.5 rounded border border-sand-200 text-xs text-ink-900 hover:bg-paper-50"
                     onClick={() => cancel(j.id)}
                     ref={cancelBtnRef}
                     disabled={cancelling}

--- a/src/components/ScenarioDrawer.tsx
+++ b/src/components/ScenarioDrawer.tsx
@@ -89,15 +89,15 @@ export default function ScenarioDrawer({ open, onClose, restoreFocusRef, seed, b
         <h2 className="font-semibold text-base mb-2 text-ink-900">Scenarios</h2>
 
         <div className="space-y-2">
-          <label className="text-sm text-ink-900/80 flex flex-col gap-1">
+          <label className="text-sm text-ink-900 flex flex-col gap-1">
             <span>Name</span>
             <input ref={firstRef} data-testid="scenario-name" type="text" className="px-2 py-1 border rounded" value={name} onChange={(e) => setName(e.target.value)} />
           </label>
-          <label className="text-sm text-ink-900/80 flex flex-col gap-1">
+          <label className="text-sm text-ink-900 flex flex-col gap-1">
             <span>Description (optional)</span>
             <textarea data-testid="scenario-desc" className="px-2 py-1 border rounded" rows={2} value={desc} onChange={(e) => setDesc(e.target.value)} />
           </label>
-          <label className="flex items-center gap-2 text-sm text-ink-900/80">
+          <label className="flex items-center gap-2 text-sm text-ink-900">
             <input type="checkbox" data-testid="scenario-remember" checked={remember} onChange={(e) => { setRememberState(e.target.checked); try { setRemember(e.target.checked) } catch {} }} />
             <span>Remember last template</span>
           </label>

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -27,7 +27,7 @@ export function Spinner({ size = 'md', label, className = '' }: SpinnerProps) {
         aria-hidden="true"
       />
       {label && (
-        <span className={`${typography.caption} text-ink-900/70`}>
+        <span className={`${typography.caption} text-ink-900`}>
           {label}
         </span>
       )}

--- a/src/components/assistants/DraftStreamPanel.tsx
+++ b/src/components/assistants/DraftStreamPanel.tsx
@@ -79,20 +79,20 @@ export function DraftStreamPanel({
         <div className="flex items-center gap-4 text-sm">
           <div className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full bg-sky-500" />
-            <span className="text-ink-900/70">
+            <span className="text-ink-900">
               <strong>{nodeCount}</strong> nodes
             </span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full bg-sun-500" />
-            <span className="text-ink-900/70">
+            <span className="text-ink-900">
               <strong>{edgeCount}</strong> edges
             </span>
           </div>
         </div>
 
         {/* Recent events */}
-        <div className="max-h-32 overflow-y-auto space-y-1 text-xs text-ink-900/70">
+        <div className="max-h-32 overflow-y-auto space-y-1 text-xs text-ink-900">
           {events.slice(-5).map((event, i) => (
             <div key={i} className="py-1">
               {event.type === 'node' && `+ Node: ${event.data.label}`}

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -603,7 +603,7 @@ export function DevBuildMarker({
 }) {
   if (!isDev || !expertMode) return null
   return (
-    <div className={`${typography.panelMeta} text-text-light/40 text-center py-1`} data-testid="dev-build-marker">
+    <div className={`${typography.panelMeta} text-text-light text-center py-1`} data-testid="dev-build-marker">
       {sha}
     </div>
   )

--- a/src/components/results/analysis-hero/__tests__/chartClassesCompile.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/chartClassesCompile.spec.ts
@@ -31,8 +31,31 @@ const CHART_CLASS_EXPECTATIONS: ReadonlyArray<{ cls: string; property: string }>
   { cls: HERO_TOKEN_BORDER, property: 'border-color' },
 ]
 
-/** Known-broken modifier forms, pinned so the workaround is revisited if the theme ever becomes alpha-capable. */
-const KNOWN_NON_COMPILING = ['bg-option/40', 'bg-primary/50', 'border-option/40']
+/**
+ * The three modifier forms this chart originally used, and which silently
+ * compiled to NOTHING — the cause of the invisible-range-bars defect.
+ *
+ * They COMPILE NOW. The theme moved to alpha-capable
+ * `rgb(var(--x-rgb) / <alpha-value>)` colours, which is the exact condition
+ * the previous version of this pin named as its trigger:
+ *
+ *     "If this ever starts failing (the classes begin to compile — e.g. the
+ *      theme moves to alpha-capable rgb(var(--x) / <alpha-value>) colours),
+ *      the solid light-token workaround can be revisited"
+ *
+ * That tripwire fired exactly as designed, and this is it being answered. The
+ * assertion is INVERTED rather than deleted, so it stays bidirectional: if the
+ * theme ever regresses to bare `var(--x)`, these go red again instead of the
+ * defect returning unnoticed.
+ *
+ * THE WORKAROUND IS DELIBERATELY LEFT IN PLACE. `HERO_BAR_FILL` still uses
+ * solid `-light` tokens (with two `brand-tokens/no-bare-light-bg` eslint
+ * exceptions, issue 222). Reverting it to `/40` and `/50` would visibly change
+ * this chart's fills, which is a design ruling and not this change's to make —
+ * this change only removes the technical obstacle that forced the workaround.
+ * Revisiting it is now unblocked.
+ */
+const PREVIOUSLY_NON_COMPILING = ['bg-option/40', 'bg-primary/50', 'border-option/40']
 
 /**
  * Boundary-anchored selector matcher: `.cls` not followed by a word char or
@@ -59,7 +82,7 @@ beforeAll(async () => {
         {
           raw: `<div class="${[
             ...CHART_CLASS_EXPECTATIONS.map((e) => e.cls),
-            ...KNOWN_NON_COMPILING,
+            ...PREVIOUSLY_NON_COMPILING,
           ].join(' ')}"></div>`,
           extension: 'html',
         },
@@ -86,16 +109,28 @@ describe('hero chart classes compile against the real Tailwind config', () => {
     }
   })
 
-  it('documents the defect class: opacity modifiers on these theme colours do NOT compile', () => {
-    // If this ever starts failing (the classes begin to compile — e.g. the
-    // theme moves to alpha-capable `rgb(var(--x) / <alpha-value>)` colours),
-    // the solid light-token workaround can be revisited — until then, any
-    // `/NN` modifier on option/primary is an invisible no-op, not a style.
-    for (const cls of KNOWN_NON_COMPILING) {
+  it('opacity modifiers on these theme colours now compile (the defect that caused invisible bars)', () => {
+    // The inversion of the original pin. These three classes emitted no rule
+    // at all, so the bar had geometry and animation but no background. They
+    // must now emit, AND carry a real alpha — a rule that compiled but ignored
+    // the modifier would render identically to the broken behaviour.
+    for (const cls of PREVIOUSLY_NON_COMPILING) {
+      const match = css.match(selectorPattern(cls))
       expect(
-        css.match(selectorPattern(cls)),
-        `"${cls}" unexpectedly compiled — the alpha-capability assumption changed`,
-      ).toBeNull()
+        match,
+        `"${cls}" compiled to nothing — the theme has regressed to a colour form that ` +
+          `cannot take an opacity modifier, which is the invisible-styling defect class ` +
+          `this suite exists for.`,
+      ).not.toBeNull()
+
+      const start = match!.index!
+      const body = css.slice(start, css.indexOf('}', start))
+      const alpha = cls.split('/')[1]
+      expect(
+        body,
+        `"${cls}" emitted a rule but without its ${alpha}% alpha — it would look ` +
+          `identical to the un-emitted case on screen.`,
+      ).toMatch(/\/\s*0?\.\d+\)/)
     }
   })
 })

--- a/src/components/ui/FieldLabel.tsx
+++ b/src/components/ui/FieldLabel.tsx
@@ -58,7 +58,7 @@ export function FieldLabel({
             onClick={() => setShowTooltip(!showTooltip)}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
-            className="inline-flex items-center justify-center w-4 h-4 rounded-full text-ink-900/50 hover:text-ink-900/80 hover:bg-sand-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-info-500"
+            className="inline-flex items-center justify-center w-4 h-4 rounded-full text-ink-900 hover:bg-sand-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-info-500"
             aria-label="Show technical details"
             data-testid="field-label-info-button"
           >
@@ -73,8 +73,13 @@ export function FieldLabel({
               {technicalTerm && (
                 <div className="font-medium mb-1">{technicalTerm}</div>
               )}
+              {/* No colour class, deliberately: this named the near-white
+                  panel token at 90% opacity, which never emitted a rule (see
+                  the channel-triple note in src/styles/brand.css), and at full
+                  strength that token is invisible on this ground. Inherited
+                  colour, exactly as it has always rendered. */}
               {technicalDescription && (
-                <div className="text-paper-50/90">{technicalDescription}</div>
+                <div>{technicalDescription}</div>
               )}
               {/* Tooltip arrow */}
               <div

--- a/src/styles/__tests__/brand-tokens.spec.ts
+++ b/src/styles/__tests__/brand-tokens.spec.ts
@@ -43,21 +43,38 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { resolveTokenHex } from '../channelTriple.mjs'
 
 const css = readFileSync(join(__dirname, '../brand.css'), 'utf-8')
 
-/** Read a `--token: value;` declaration out of brand.css. */
+/**
+ * The RAW declared text of a `--token` in brand.css — not resolved.
+ * Used only where the assertion is about the DECLARATION itself (chart-5/6
+ * must be literal hexes, aliasing nothing). Every colour READ goes through
+ * `resolve()`, because a raw read now returns `rgb(var(--x-rgb))` for most
+ * semantic tokens and would be measured as a malformed colour.
+ */
 function token(name: string): string {
   const m = css.match(new RegExp(`^\\s*--${name}:\\s*([^;]+);`, 'm'))
   if (!m) throw new Error(`brand.css: --${name} not found`)
   return m[1].trim()
 }
 
-/** Resolve one level of `var(--x)` indirection so aliases compare by value. */
+/**
+ * The literal colour a token resolves to, across all three declaration forms
+ * brand.css uses: a literal hex, a `var()` alias (`--primary: var(--info)`),
+ * and the channel-triple form (`--info-rgb: 39 122 157; --info:
+ * rgb(var(--info-rgb))`) that lets Tailwind emit opacity-modified utilities.
+ *
+ * Delegated to the shared resolver so all five brand.css parsers read the file
+ * identically rather than each carrying its own regex — which is how they
+ * would come to disagree. Throws rather than defaulting, so no ratio below can
+ * be computed against a silently-wrong colour.
+ */
 function resolve(name: string): string {
-  const raw = token(name)
-  const alias = raw.match(/^var\(--([a-z0-9-]+)\)$/i)
-  return alias ? resolve(alias[1]) : raw
+  const hex = resolveTokenHex(css, `--${name}`)
+  if (!hex) throw new Error(`brand.css: --${name} does not resolve to a literal colour`)
+  return hex
 }
 
 const hexToRgb = (hex: string): [number, number, number] => {
@@ -108,9 +125,9 @@ const over = (fg: string, alpha: number, bg: string): string => {
  */
 const TEXT_GROUNDS = (): Array<[string, string]> => [
   ['#FFFFFF (legacy white cards)', WHITE],
-  ['--bg-panel (dominant text ground)', token('bg-panel')],
-  ['bg-panel/95 over canvas (dock, edge labels)', over(token('bg-panel'), 0.95, token('bg-canvas'))],
-  ['--bg-panel-hover (the binding ground)', token('bg-panel-hover')],
+  ['--bg-panel (dominant text ground)', resolve('bg-panel')],
+  ['bg-panel/95 over canvas (dock, edge labels)', over(resolve('bg-panel'), 0.95, resolve('bg-canvas'))],
+  ['--bg-panel-hover (the binding ground)', resolve('bg-panel-hover')],
 ]
 
 describe('D1 — canonical info blue', () => {
@@ -123,7 +140,19 @@ describe('D1 — canonical info blue', () => {
   })
 
   it('--info is the single canonical value', () => {
-    expect(token('info').toUpperCase()).toBe(CANONICAL_INFO)
+    expect(resolve('info')).toBe(CANONICAL_INFO)
+  })
+
+  it('--info carries its channels as the source of truth, and they agree with the hex', () => {
+    // `--info` is no longer a literal hex: it is derived from `--info-rgb` so
+    // Tailwind can emit `border-info/30` and friends, which previously emitted
+    // NO RULE AT ALL. The channels are now the single source of truth, so the
+    // thing that must not drift is the channels-to-hex agreement — assert the
+    // DECLARATION FORM as well as the resolved value, or a future edit could
+    // reinstate a literal hex and silently un-emit every opacity utility again.
+    expect(token('info')).toBe('rgb(var(--info-rgb))')
+    expect(token('info-rgb')).toBe('39 122 157')
+    expect(resolve('info')).toBe(CANONICAL_INFO)
   })
 
   it('--primary resolves to the same canonical value (one value, not a copy)', () => {
@@ -134,7 +163,7 @@ describe('D1 — canonical info blue', () => {
   // a value through that failed on --bg-panel by 0.03. Each ground is read from
   // brand.css, so a retint of ANY of them re-measures rather than going stale.
   it.each(TEXT_GROUNDS())('clears WCAG AA text 4.5:1 on %s — computed from brand.css, not hardcoded', (_label, ground) => {
-    expect(contrastRatio(token('info'), ground)).toBeGreaterThanOrEqual(AA_TEXT)
+    expect(contrastRatio(resolve('info'), ground)).toBeGreaterThanOrEqual(AA_TEXT)
   })
 
   it('POSITIVE CONTROL: the TEXT_GROUNDS assertion can actually FAIL', () => {
@@ -146,26 +175,26 @@ describe('D1 — canonical info blue', () => {
     }
     // ...and so must the value this decision corrected, on the panel grounds
     // it actually missed. This is the regression pin for THIS defect.
-    expect(contrastRatio('#2B7FA2', token('bg-panel'))).toBeLessThan(AA_TEXT)
-    expect(contrastRatio('#2B7FA2', token('bg-panel-hover'))).toBeLessThan(AA_TEXT)
+    expect(contrastRatio('#2B7FA2', resolve('bg-panel'))).toBeLessThan(AA_TEXT)
+    expect(contrastRatio('#2B7FA2', resolve('bg-panel-hover'))).toBeLessThan(AA_TEXT)
   })
 
   it('clears the 3:1 SC 1.4.11 bar on --bg-canvas, where info blue is glyphs only', () => {
     // Deliberately 3:1, not 4.5:1 — see the file header for why.
-    expect(contrastRatio(token('info'), token('bg-canvas'))).toBeGreaterThanOrEqual(AA_UI)
+    expect(contrastRatio(resolve('info'), resolve('bg-canvas'))).toBeGreaterThanOrEqual(AA_UI)
   })
 
   it('white text ON an --info fill still clears AA (the primary button)', () => {
     // --info is also a BACKGROUND (bg-primary/bg-info) with --text-on-color on
     // it. Darkening the token helps here, but the pairing must stay pinned so a
     // future LIGHTENING cannot silently break the most-used button in the app.
-    expect(contrastRatio(resolve('text-on-color'), token('info'))).toBeGreaterThanOrEqual(AA_TEXT)
+    expect(contrastRatio(resolve('text-on-color'), resolve('info'))).toBeGreaterThanOrEqual(AA_TEXT)
   })
 
   it('keeps the hover/active progression darker than the base', () => {
-    const base = contrastRatio(token('info'), WHITE)
-    expect(contrastRatio(token('info-hover'), WHITE)).toBeGreaterThan(base)
-    expect(contrastRatio(token('info-active'), WHITE)).toBeGreaterThan(base)
+    const base = contrastRatio(resolve('info'), WHITE)
+    expect(contrastRatio(resolve('info-hover'), WHITE)).toBeGreaterThan(base)
+    expect(contrastRatio(resolve('info-active'), WHITE)).toBeGreaterThan(base)
   })
 
   it('no superseded info-blue hex survives in brand.css declarations', () => {
@@ -202,9 +231,9 @@ describe('D3 — chart series are ordinal, not semantic aliases', () => {
   })
 
   it('series 5 and 6 clear 3:1 against both the canvas and panel grounds', () => {
-    for (const c of [token('chart-5'), token('chart-6')]) {
-      expect(contrastRatio(c, token('bg-canvas'))).toBeGreaterThanOrEqual(AA_UI)
-      expect(contrastRatio(c, token('bg-panel'))).toBeGreaterThanOrEqual(AA_UI)
+    for (const c of [resolve('chart-5'), resolve('chart-6')]) {
+      expect(contrastRatio(c, resolve('bg-canvas'))).toBeGreaterThanOrEqual(AA_UI)
+      expect(contrastRatio(c, resolve('bg-panel'))).toBeGreaterThanOrEqual(AA_UI)
     }
   })
 })

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -11,7 +11,48 @@
  * Usage:
  * - Always use CSS variables, never raw hex values
  * - Use semantic tokens in components
- * - Borders: Use rgba() with main color at 0.3 opacity
+ * - Borders: `border-{colour}/30` (see THE CHANNEL-TRIPLE FORM below)
+ *
+ * ============================================================
+ * THE CHANNEL-TRIPLE FORM — read before editing any colour
+ * ============================================================
+ *
+ * Semantic colours are declared as their CHANNELS, with the colour derived
+ * from them:
+ *
+ *     --info-rgb: 39 122 157;
+ *     --info: rgb(var(--info-rgb));
+ *
+ * The TRIPLE is the single source of truth. The hex form is derived, so the
+ * two can never disagree — do not "helpfully" restore a literal hex and leave
+ * the triple behind, and never state the same colour in both places.
+ *
+ * WHY. Tailwind can only apply an opacity modifier to a colour it can
+ * decompose into channels. Against a bare `var(--info)`, Tailwind 3.4 emits
+ * NO RULE AT ALL for `border-info/30` — no warning, no error, no fallback
+ * declaration. The element silently keeps whatever colour it would otherwise
+ * have had, which for a border is preflight's `#e5e7eb`. That is exactly what
+ * happened: the outlined-pill recipe this design system documents as canonical
+ * had never emitted a single rule for any semantic colour, so the colour
+ * channel that carries "how it's doing" was dropped product-wide.
+ *
+ * The triple lets tailwind.config.js hand Tailwind
+ * `rgb(var(--info-rgb) / <alpha-value>)`, which emits. Every existing
+ * `var(--info)` reference is unaffected — it resolves to the same colour.
+ *
+ * WHAT ENFORCES IT. tests/ci-guards/semantic-colour-alpha.spec.ts compiles the
+ * REAL Tailwind config and fails if any opacity-modified utility used in src/
+ * emits nothing; it carries its own negative control, so reverting a colour to
+ * the bare `var()` form turns it red. A colour that is NOT used with a modifier
+ * anywhere may stay a plain literal — the guard derives the list from usage,
+ * so the day it is used with a modifier, it fails loud rather than silently
+ * rendering nothing.
+ *
+ * READERS OF THIS FILE. Five parsers recover token values from this file (the
+ * artefact-template mirror, the --text-light contrast pin, the brand-token AA
+ * suite, the ghost-outline pin and the css-var census). They all resolve the
+ * triple form through ONE shared implementation, src/styles/channelTriple.mjs
+ * — extend that, never a local regex, or they will come to disagree.
  */
 
 :root {
@@ -20,7 +61,8 @@
      ============================================ */
 
   /* Text Colors */
-  --text-header: #262626;
+  --text-header-rgb: 38 38 38;
+  --text-header: rgb(var(--text-header-rgb));
   --text-body: #3F3F3E;
   /* Muted / meta text.
      A11y: this was #908D8D, which was NOT a legal text colour at any size —
@@ -40,7 +82,8 @@
      tests/ci-guards/text-light-contrast.spec.ts DERIVES both sides from this
      file and pins the MARGIN, not just the bar, so it goes red if either
      moves. Do not hand-edit this value without re-running that guard. */
-  --text-light: #6E6B6B;
+  --text-light-rgb: 110 107 107;
+  --text-light: rgb(var(--text-light-rgb));
   --text-on-color: #FFFFFF;
 
   /* Legacy aliases (for gradual migration) */
@@ -54,9 +97,12 @@
      ============================================ */
 
   --bg-canvas: #F4F0EA;
-  --bg-panel: #FEFEFE;
-  --bg-panel-hover: #FEF9F3;
-  --border-default: #EEE6D8;
+  --bg-panel-rgb: 254 254 254;
+  --bg-panel: rgb(var(--bg-panel-rgb));
+  --bg-panel-hover-rgb: 254 249 243;
+  --bg-panel-hover: rgb(var(--bg-panel-hover-rgb));
+  --border-default-rgb: 238 230 216;
+  --border-default: rgb(var(--border-default-rgb));
 
   /* Legacy aliases */
   --canvas-25: var(--bg-canvas);
@@ -81,13 +127,17 @@
      ============================================ */
 
   /* Danger / Risk / Critical (Red) */
-  --danger: #EA7B4B;
-  --danger-light: #FFB393;
+  --danger-rgb: 234 123 75;
+  --danger: rgb(var(--danger-rgb));
+  --danger-light-rgb: 255 179 147;
+  --danger-light: rgb(var(--danger-light-rgb));
   /* Border: rgba(234, 123, 75, 0.3) */
 
   /* Success / Outcome / Positive (Green) */
-  --success: #67C89E;
-  --success-light: #B8E2D0;
+  --success-rgb: 103 200 158;
+  --success: rgb(var(--success-rgb));
+  --success-light-rgb: 184 226 208;
+  --success-light: rgb(var(--success-light-rgb));
   /* Border: rgba(103, 200, 158, 0.3) */
 
   /* Info / Decision / Navigation (Blue)
@@ -123,17 +173,22 @@
      hardcoded, in src/styles/__tests__/brand-tokens.spec.ts — that test fails
      if this value, or any of those ground tokens, moves below AA.
      Light shade kept for canvas node fills and selection backgrounds. */
-  --info: #277A9D;
-  --info-light: #BAD7E4;
+  --info-rgb: 39 122 157;
+  --info: rgb(var(--info-rgb));
+  --info-light-rgb: 186 215 228;
+  --info-light: rgb(var(--info-light-rgb));
   /* Border: rgba(39, 122, 157, 0.3) */
 
   /* Warning (Orange) - Separate from Danger */
-  --warning: #FFA656;
-  --warning-light: #FCC798;
+  --warning-rgb: 255 166 86;
+  --warning: rgb(var(--warning-rgb));
+  --warning-light-rgb: 252 199 152;
+  --warning-light: rgb(var(--warning-light-rgb));
   /* Border: rgba(255, 166, 86, 0.3) */
 
   /* Border emphasis (stronger than --border-default) */
-  --border-emphasis: #DDD4C4;
+  --border-emphasis-rgb: 221 212 196;
+  --border-emphasis: rgb(var(--border-emphasis-rgb));
 
   /* Neutral track fill (for empty progress-bar tracks and similar
      "outline of a container" surfaces). Reads as clearly neutral
@@ -165,18 +220,25 @@
   --edge-negative-dark: #F06595;
   --edge-neutral-dark: #A1A1AA;
 
-  --goal: #F5C433;
-  --goal-light: #F4DB92;
+  --goal-rgb: 245 196 51;
+
+  --goal: rgb(var(--goal-rgb));
+  --goal-light-rgb: 244 219 146;
+  --goal-light: rgb(var(--goal-light-rgb));
   /* Border: rgba(245, 196, 51, 0.3) */
 
   /* Option (Purple) */
-  --option: #AAA7E4;
-  --option-light: #DDDCF5;
+  --option-rgb: 170 167 228;
+  --option: rgb(var(--option-rgb));
+  --option-light-rgb: 221 220 245;
+  --option-light: rgb(var(--option-light-rgb));
   /* Border: rgba(170, 167, 228, 0.3) */
 
   /* Factor (Stone) */
-  --factor: #B0A899;
-  --factor-light: #EEE6D8;
+  --factor-rgb: 176 168 153;
+  --factor: rgb(var(--factor-rgb));
+  --factor-light-rgb: 238 230 216;
+  --factor-light: rgb(var(--factor-light-rgb));
   /* Border: rgba(176, 168, 153, 0.3) */
 
   /* ============================================
@@ -205,15 +267,16 @@
   /* Primary (Info Blue — v5 §3.10: hover shifts to success green "ready to act")
      --primary is the canonical info blue; --primary-hover/-active are the
      DELIBERATE green shift documented in v5 §3.10 and are left unchanged. */
-  --primary: var(--info);
+  --primary-rgb: var(--info-rgb);
+  --primary: rgb(var(--primary-rgb));
   --primary-hover: #67C89E;
   --primary-active: #5AA88A;
-  --primary-disabled: rgba(39, 122, 157, 0.4);
+  --primary-disabled: rgb(var(--info-rgb) / 0.4);
 
   /* Danger */
   --danger-hover: #D96A3A;
   --danger-active: #C85A2A;
-  --danger-disabled: rgba(234, 123, 75, 0.4);
+  --danger-disabled: rgb(var(--danger-rgb) / 0.4);
 
   /* Info — hover/active for the canonical --info (#277A9D). Both stay darker
      than the base (5.69:1 and 6.75:1 on white, vs the base's 4.82:1) so the
@@ -224,17 +287,17 @@
      was, so these two values are deliberately left unchanged. */
   --info-hover: #236E8E;
   --info-active: #1D6280;
-  --info-disabled: rgba(39, 122, 157, 0.4);
+  --info-disabled: rgb(var(--info-rgb) / 0.4);
 
   /* Success */
   --success-hover: #5AB88D;
   --success-active: #4DA87C;
-  --success-disabled: rgba(103, 200, 158, 0.4);
+  --success-disabled: rgb(var(--success-rgb) / 0.4);
 
   /* Warning */
   --warning-hover: #E89545;
   --warning-active: #D18534;
-  --warning-disabled: rgba(255, 166, 86, 0.4);
+  --warning-disabled: rgb(var(--warning-rgb) / 0.4);
 
   /* ============================================
      FOCUS & ACCESSIBILITY

--- a/src/styles/channelTriple.d.mts
+++ b/src/styles/channelTriple.d.mts
@@ -1,0 +1,28 @@
+/**
+ * Types for `channelTriple.mjs`. Follows the `src/generated/validators.js` +
+ * `validators.d.ts` pattern already used in this repo for a JS module that a
+ * plain node script and TypeScript both have to consume.
+ */
+
+/** A colour declared as `rgb(var(--x-rgb))`, capturing the channel property. */
+export declare const CHANNEL_TRIPLE_FORM: RegExp
+
+/** `'39 122 157'` -> `'#277A9D'`; null if not three in-range channels. */
+export declare function tripleToHex(triple: string): string | null
+
+/** Resolve `rgb(var(--x-rgb))` to a hex via `lookup`; null if not that form. */
+export declare function resolveChannelTriple(
+  value: string,
+  lookup: (name: string) => string | null | undefined,
+  depth?: number,
+): string | null
+
+/** A `--token`'s raw declared value in a brand.css source string. */
+export declare function declaredValue(css: string, token: string): string | null
+
+/**
+ * The literal hex a `--token` resolves to across all three declaration forms
+ * brand.css uses (literal hex, `var()` alias, channel triple). Null when it
+ * does not resolve to a literal colour.
+ */
+export declare function resolveTokenHex(css: string, token: string, depth?: number): string | null

--- a/src/styles/channelTriple.mjs
+++ b/src/styles/channelTriple.mjs
@@ -1,0 +1,151 @@
+/**
+ * The channel-triple colour form, and how to read it back.
+ *
+ * WHY THIS FORM EXISTS. Tailwind can only apply an opacity modifier
+ * (`border-info/30`) to a colour it can decompose into channels. A colour
+ * declared as a bare `var(--info)` cannot be decomposed, so Tailwind 3.4
+ * emits NOTHING AT ALL for the modified utility — no rule, no warning, no
+ * error. The element silently keeps whatever colour it would otherwise have
+ * had (for borders, preflight's `#e5e7eb`). The design system's own
+ * documented pill recipe — `bg-transparent border-{colour}/30` — had never
+ * emitted a single rule for any semantic colour.
+ *
+ * So each semantic colour declares its CHANNELS as the source of truth and
+ * derives the colour from them:
+ *
+ *     --info-rgb: 39 122 157;
+ *     --info: rgb(var(--info-rgb));
+ *
+ * `--info` still resolves to exactly the same colour, so every existing
+ * `var(--info)` reference is untouched, and `rgb(var(--info-rgb) / <alpha-value>)`
+ * in tailwind.config.js now gives Tailwind the channels it needs.
+ *
+ * WHY THIS MODULE EXISTS. Five separate places parse brand.css to recover a
+ * token's literal value — the artefact-template mirror, the --text-light
+ * contrast pin, the brand-token AA suite, the ghost-option contrast pin and
+ * the css-var census. Each had its own `#[0-9A-Fa-f]{3,8}` regex. Teaching
+ * the new form to five copies would be five chances to teach it differently,
+ * which is this repo's dominant defect class (trap 12). They now share this
+ * one implementation.
+ *
+ * It is `.mjs` (with a `.d.mts` sibling, the pattern already used by
+ * `src/generated/validators.js`) because `scripts/css-var-census.mjs` is a
+ * plain node script that cannot import TypeScript, and a resolver the census
+ * could not use would be a resolver with a sixth copy.
+ *
+ * Every function here is TOTAL and fail-quiet-to-null: a caller that gets
+ * null must report the value as uncomparable rather than assume it is fine.
+ * Each of the five callers already does exactly that.
+ */
+
+/**
+ * A colour declared as `rgb(var(--x-rgb))` — the channel-triple form.
+ * Captures the channel property name.
+ */
+export const CHANNEL_TRIPLE_FORM = /^rgb\(\s*var\(\s*(--[A-Za-z0-9_-]+)\s*\)\s*\)$/
+
+/** A bare `var(--x)` alias, used to follow `--primary-rgb: var(--info-rgb)`. */
+const VAR_ALIAS = /^var\(\s*(--[A-Za-z0-9_-]+)\s*\)$/
+
+/** Three space- or comma-separated 0-255 channels: `39 122 157`. */
+const TRIPLE = /^(\d{1,3})[\s,]+(\d{1,3})[\s,]+(\d{1,3})$/
+
+/**
+ * `'39 122 157'` -> `'#277A9D'`. Returns null if the value is not three
+ * in-range channels, so a malformed triple is reported rather than silently
+ * rendered as some other colour.
+ *
+ * @param {string} triple
+ * @returns {string | null}
+ */
+export function tripleToHex(triple) {
+  const m = String(triple).trim().match(TRIPLE)
+  if (!m) return null
+  const ch = [m[1], m[2], m[3]].map(Number)
+  if (ch.some((c) => c > 255)) return null
+  return '#' + ch.map((c) => c.toString(16).padStart(2, '0')).join('').toUpperCase()
+}
+
+/**
+ * If `value` is the channel-triple form, resolve it to a literal hex using
+ * `lookup` to read the channel property (and to follow one alias hop, so
+ * `--primary-rgb: var(--info-rgb)` resolves). Returns null for anything that
+ * is not the triple form, or whose channels cannot be found or parsed.
+ *
+ * @param {string} value           the token's declared value
+ * @param {(name: string) => string | null | undefined} lookup
+ * @param {number} [depth]
+ * @returns {string | null}
+ */
+export function resolveChannelTriple(value, lookup, depth = 0) {
+  if (depth > 8) return null
+  const m = String(value).trim().match(CHANNEL_TRIPLE_FORM)
+  if (!m) return null
+  return resolveTripleProperty(m[1], lookup, depth)
+}
+
+/**
+ * Resolve a `--x-rgb` channel property to a hex, following alias hops.
+ *
+ * @param {string} name
+ * @param {(name: string) => string | null | undefined} lookup
+ * @param {number} [depth]
+ * @returns {string | null}
+ */
+function resolveTripleProperty(name, lookup, depth = 0) {
+  if (depth > 8) return null
+  const raw = lookup(name)
+  if (raw == null || raw === '') return null
+  const alias = String(raw).trim().match(VAR_ALIAS)
+  if (alias) return resolveTripleProperty(alias[1], lookup, depth + 1)
+  return tripleToHex(raw)
+}
+
+/**
+ * Read a `--token`'s declared value straight out of a brand.css source string.
+ * Shared so the callers do not each carry their own declaration regex.
+ *
+ * @param {string} css
+ * @param {string} token  including the leading `--`
+ * @returns {string | null}
+ */
+export function declaredValue(css, token) {
+  const m = css.match(new RegExp(`^\\s*${token}:\\s*([^;]+);`, 'm'))
+  return m ? m[1].trim() : null
+}
+
+/**
+ * The literal hex a `--token` in `css` ultimately resolves to, understanding
+ * all three declaration forms brand.css uses: a literal hex, a `var()` alias
+ * (`--primary: var(--info)`), and the channel-triple form. Returns null when
+ * the token does not resolve to a literal colour — callers MUST surface that
+ * as uncomparable rather than skipping it.
+ *
+ * @param {string} css
+ * @param {string} token  including the leading `--`
+ * @param {number} [depth]
+ * @returns {string | null}
+ */
+export function resolveTokenHex(css, token, depth = 0) {
+  if (depth > 8) return null
+  const raw = declaredValue(css, token)
+  if (raw == null) return null
+
+  const literal = raw.match(/^(#[0-9A-Fa-f]{3,8})$/)
+  if (literal) return expandHex(literal[1])
+
+  const triple = resolveChannelTriple(raw, (n) => declaredValue(css, n))
+  if (triple) return triple
+
+  const alias = raw.match(VAR_ALIAS)
+  if (alias) return resolveTokenHex(css, alias[1], depth + 1)
+
+  return null
+}
+
+/** `#abc` -> `#AABBCC`; already-long hexes are just upper-cased. */
+function expandHex(hex) {
+  const h = hex.slice(1)
+  if (h.length === 3) return '#' + [...h].map((c) => c + c).join('').toUpperCase()
+  return hex.toUpperCase()
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,9 +30,9 @@ export default {
         // TEXT COLORS
         // ============================================
         text: {
-          header: 'var(--text-header)',
+          header: 'rgb(var(--text-header-rgb) / <alpha-value>)',
           body: 'var(--text-body)',
-          light: 'var(--text-light)',
+          light: 'rgb(var(--text-light-rgb) / <alpha-value>)',
           'on-color': 'var(--text-on-color)',
         },
 
@@ -43,14 +43,14 @@ export default {
           DEFAULT: 'var(--bg-canvas)',
         },
         panel: {
-          DEFAULT: 'var(--bg-panel)',
-          hover: 'var(--bg-panel-hover)',
-          border: 'var(--border-default)',
+          DEFAULT: 'rgb(var(--bg-panel-rgb) / <alpha-value>)',
+          hover: 'rgb(var(--bg-panel-hover-rgb) / <alpha-value>)',
+          border: 'rgb(var(--border-default-rgb) / <alpha-value>)',
         },
 
         // Border emphasis
         border: {
-          emphasis: 'var(--border-emphasis)',
+          emphasis: 'rgb(var(--border-emphasis-rgb) / <alpha-value>)',
         },
 
         // Neutral track fill (empty progress bars, container outlines)
@@ -60,13 +60,13 @@ export default {
 
         // Legacy neutral (for gradual migration)
         ink: {
-          900: 'var(--text-header)',
+          900: 'rgb(var(--text-header-rgb) / <alpha-value>)',
         },
         paper: {
-          50: 'var(--bg-panel)',
+          50: 'rgb(var(--bg-panel-rgb) / <alpha-value>)',
         },
         sand: {
-          200: 'var(--border-default)',
+          200: 'rgb(var(--border-default-rgb) / <alpha-value>)',
         },
 
         // ============================================
@@ -75,60 +75,60 @@ export default {
 
         // Danger / Risk / Critical (Red)
         danger: {
-          DEFAULT: 'var(--danger)',
-          light: 'var(--danger-light)',
+          DEFAULT: 'rgb(var(--danger-rgb) / <alpha-value>)',
+          light: 'rgb(var(--danger-light-rgb) / <alpha-value>)',
           hover: 'var(--danger-hover)',
           active: 'var(--danger-active)',
           disabled: 'var(--danger-disabled)',
           // Legacy numeric aliases for backward compatibility
-          100: 'var(--danger-light)',
-          200: 'var(--danger-light)',
-          500: 'var(--danger)',
+          100: 'rgb(var(--danger-light-rgb) / <alpha-value>)',
+          200: 'rgb(var(--danger-light-rgb) / <alpha-value>)',
+          500: 'rgb(var(--danger-rgb) / <alpha-value>)',
           600: 'var(--danger-hover)',
           700: 'var(--danger-active)',
         },
 
         // Success / Outcome / Positive (Green)
         success: {
-          DEFAULT: 'var(--success)',
-          light: 'var(--success-light)',
+          DEFAULT: 'rgb(var(--success-rgb) / <alpha-value>)',
+          light: 'rgb(var(--success-light-rgb) / <alpha-value>)',
           hover: 'var(--success-hover)',
           active: 'var(--success-active)',
           disabled: 'var(--success-disabled)',
           // Legacy numeric aliases for backward compatibility
-          100: 'var(--success-light)',
-          200: 'var(--success-light)',
-          500: 'var(--success)',
+          100: 'rgb(var(--success-light-rgb) / <alpha-value>)',
+          200: 'rgb(var(--success-light-rgb) / <alpha-value>)',
+          500: 'rgb(var(--success-rgb) / <alpha-value>)',
           600: 'var(--success-hover)',
           700: 'var(--success-active)',
         },
 
         // Info / Decision / Navigation (Blue)
         info: {
-          DEFAULT: 'var(--info)',
-          light: 'var(--info-light)',
+          DEFAULT: 'rgb(var(--info-rgb) / <alpha-value>)',
+          light: 'rgb(var(--info-light-rgb) / <alpha-value>)',
           hover: 'var(--info-hover)',
           active: 'var(--info-active)',
           disabled: 'var(--info-disabled)',
           // Legacy numeric aliases for backward compatibility
-          100: 'var(--info-light)',
-          200: 'var(--info-light)',
-          500: 'var(--info)',
+          100: 'rgb(var(--info-light-rgb) / <alpha-value>)',
+          200: 'rgb(var(--info-light-rgb) / <alpha-value>)',
+          500: 'rgb(var(--info-rgb) / <alpha-value>)',
           600: 'var(--info-hover)',
           700: 'var(--info-active)',
         },
 
         // Warning (Orange) - Separate from Danger
         warning: {
-          DEFAULT: 'var(--warning)',
-          light: 'var(--warning-light)',
+          DEFAULT: 'rgb(var(--warning-rgb) / <alpha-value>)',
+          light: 'rgb(var(--warning-light-rgb) / <alpha-value>)',
           hover: 'var(--warning-hover)',
           active: 'var(--warning-active)',
           disabled: 'var(--warning-disabled)',
           // Legacy numeric aliases for backward compatibility
-          100: 'var(--warning-light)',
-          200: 'var(--warning-light)',
-          500: 'var(--warning)',
+          100: 'rgb(var(--warning-light-rgb) / <alpha-value>)',
+          200: 'rgb(var(--warning-light-rgb) / <alpha-value>)',
+          500: 'rgb(var(--warning-rgb) / <alpha-value>)',
           600: 'var(--warning-hover)',
           700: 'var(--warning-active)',
         },
@@ -139,38 +139,38 @@ export default {
 
         // Goal (Yellow) - Entity colour only (v4: decoupled from primary)
         goal: {
-          DEFAULT: 'var(--goal)',
-          light: 'var(--goal-light)',
+          DEFAULT: 'rgb(var(--goal-rgb) / <alpha-value>)',
+          light: 'rgb(var(--goal-light-rgb) / <alpha-value>)',
           hover: '#E5B523',  // Goal-specific hover (10% darker yellow)
           // Legacy numeric aliases
-          50: 'var(--goal-light)',
-          500: 'var(--goal)',
+          50: 'rgb(var(--goal-light-rgb) / <alpha-value>)',
+          500: 'rgb(var(--goal-rgb) / <alpha-value>)',
         },
 
         // Option (Purple)
         option: {
-          DEFAULT: 'var(--option)',
-          light: 'var(--option-light)',
+          DEFAULT: 'rgb(var(--option-rgb) / <alpha-value>)',
+          light: 'rgb(var(--option-light-rgb) / <alpha-value>)',
           // Legacy numeric aliases
-          50: 'var(--option-light)',
-          400: 'var(--option)',
-          500: 'var(--option)',
+          50: 'rgb(var(--option-light-rgb) / <alpha-value>)',
+          400: 'rgb(var(--option-rgb) / <alpha-value>)',
+          500: 'rgb(var(--option-rgb) / <alpha-value>)',
         },
 
         // Factor (Stone)
         factor: {
-          DEFAULT: 'var(--factor)',
-          light: 'var(--factor-light)',
+          DEFAULT: 'rgb(var(--factor-rgb) / <alpha-value>)',
+          light: 'rgb(var(--factor-light-rgb) / <alpha-value>)',
           // Legacy numeric aliases
-          50: 'var(--factor-light)',
-          500: 'var(--factor)',
+          50: 'rgb(var(--factor-light-rgb) / <alpha-value>)',
+          500: 'rgb(var(--factor-rgb) / <alpha-value>)',
         },
 
         // ============================================
         // PRIMARY (Maps to Info Blue — v5 §3.10)
         // ============================================
         primary: {
-          DEFAULT: 'var(--primary)',
+          DEFAULT: 'rgb(var(--primary-rgb) / <alpha-value>)',
           hover: 'var(--primary-hover)',
           active: 'var(--primary-active)',
           disabled: 'var(--primary-disabled)',
@@ -197,22 +197,22 @@ export default {
         // (For backward compatibility during migration)
         // ============================================
         sun: {
-          500: 'var(--goal)',
+          500: 'rgb(var(--goal-rgb) / <alpha-value>)',
         },
         mint: {
-          400: 'var(--success)',
-          500: 'var(--success)',
+          400: 'rgb(var(--success-rgb) / <alpha-value>)',
+          500: 'rgb(var(--success-rgb) / <alpha-value>)',
         },
         sky: {
-          200: 'var(--info-light)',
-          500: 'var(--info)',
+          200: 'rgb(var(--info-light-rgb) / <alpha-value>)',
+          500: 'rgb(var(--info-rgb) / <alpha-value>)',
           600: 'var(--info-hover)',
         },
         carrot: {
-          500: 'var(--danger)',
+          500: 'rgb(var(--danger-rgb) / <alpha-value>)',
         },
         lilac: {
-          400: 'var(--option)',
+          400: 'rgb(var(--option-rgb) / <alpha-value>)',
         },
       },
 

--- a/tests/ci-guards/artefact-template-token-mirror.spec.ts
+++ b/tests/ci-guards/artefact-template-token-mirror.spec.ts
@@ -31,6 +31,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { resolveTokenHex } from '../../src/styles/channelTriple.mjs'
 
 const BRAND_CSS_PATH = join(__dirname, '../../src/styles/brand.css')
 const TEMPLATE_PATH = join(__dirname, '../../src/components/chat/artefactIframeTemplate.ts')
@@ -53,15 +54,18 @@ function templateTokens(): Array<[string, string]> {
  * some tokens as ALIASES rather than copies — `--primary: var(--info)` is the
  * whole point of D1 ("one value that cannot drift"). Comparing only literal
  * hexes would report every alias as UNCOMPARABLE, which is how this guard
- * would go blind on exactly the tokens that were made safe. Depth-limited so a
- * malformed cycle cannot hang the suite.
+ * would go blind on exactly the tokens that were made safe.
+ *
+ * It ALSO resolves the channel-triple form — `--danger-rgb: 234 123 75;
+ * --danger: rgb(var(--danger-rgb))` — which is what lets Tailwind emit
+ * opacity-modified utilities. Twelve of the fifteen tokens this template
+ * restates are declared that way now, so without this the guard would report
+ * all twelve as uncomparable and go blind on the exact drift it exists to
+ * catch. Resolution is delegated to the shared resolver rather than restated
+ * here, so all five brand.css parsers agree by construction.
  */
-function declared(token: string, depth = 0): string | null {
-  if (depth > 8) return null
-  const literal = brandCss.match(new RegExp(`^\\s*${token}:\\s*(#[0-9A-Fa-f]{3,8})\\s*;`, 'm'))
-  if (literal) return literal[1].toUpperCase()
-  const alias = brandCss.match(new RegExp(`^\\s*${token}:\\s*var\\((--[a-z0-9-]+)\\)\\s*;`, 'm'))
-  return alias ? declared(alias[1], depth + 1) : null
+function declared(token: string): string | null {
+  return resolveTokenHex(brandCss, token)
 }
 
 /**
@@ -103,6 +107,19 @@ describe('artefact iframe template mirrors brand.css', () => {
     // And it must be able to detect a divergence at all — assert against a
     // value brand.css definitely does not hold.
     expect(declared('--text-light')).not.toBe('#DEADBE')
+
+    // It must resolve the CHANNEL-TRIPLE form specifically, and to the right
+    // colour. Twelve of the fifteen tokens below are declared that way; a
+    // resolver that mis-assembled the channels would compare the template
+    // against a wrong-but-plausible hex and report drift that is not there —
+    // or worse, miss drift that is. Pinned to concrete values, and to the
+    // declaration form itself, so this cannot pass by resolving nothing.
+    expect(brandCss).toMatch(/--danger:\s*rgb\(var\(--danger-rgb\)\)/)
+    expect(declared('--danger')).toBe('#EA7B4B')
+    // `--primary: rgb(var(--primary-rgb))` where `--primary-rgb: var(--info-rgb)`
+    // — the triple form THROUGH an alias hop, which is the deepest chain here.
+    expect(declared('--primary')).toBe(declared('--info'))
+    expect(declared('--primary')).toBe('#277A9D')
   })
 
   it('every token the template restates matches brand.css', () => {
@@ -125,7 +142,8 @@ describe('artefact iframe template mirrors brand.css', () => {
     expect(
       unknownInBrand,
       `the template restates ${unknownInBrand.length} token(s) that brand.css does not ` +
-        `declare as a literal hex, so they cannot be compared:\n  ${unknownInBrand.join('\n  ')}`,
+        `resolve to a literal colour (literal hex, var() alias, or channel triple), ` +
+        `so they cannot be compared:\n  ${unknownInBrand.join('\n  ')}`,
     ).toEqual([])
 
     const added = found.filter((f) => !KNOWN_TEMPLATE_TOKEN_DRIFT.includes(f))

--- a/tests/ci-guards/semantic-colour-alpha.spec.ts
+++ b/tests/ci-guards/semantic-colour-alpha.spec.ts
@@ -168,8 +168,15 @@ describe('semantic colours emit CSS when used with an opacity modifier', () => {
     // The scan must actually be finding the code it asserts about. Floors sit
     // ~10% under the observed figure so a partial blinding is visible rather
     // than merely "still above a number".
-    expect(used.length, `${used.length} distinct modified classes found (was 118 when set)`)
-      .toBeGreaterThanOrEqual(100)
+    // Floor sits ~10% under the observed figure so a partial blinding is
+    // visible, rather than one count under it. RE-BASELINED 118 -> 96 in this
+    // change: the 132 `text-*/NN` call sites were swept to solid tokens (or
+    // removed, where the token fails AA at full strength), which retired 22
+    // distinct TEXT classes from the scan. The floor moved because the tree
+    // moved, NOT to accommodate a failure — every remaining class still has to
+    // emit, and the mutation control below still has to bite.
+    expect(used.length, `${used.length} distinct modified classes found (was 96 when set)`)
+      .toBeGreaterThanOrEqual(86)
     expect(used, 'the documented outlined-pill recipe must be in the scanned set')
       .toContain('border-info/30')
 

--- a/tests/ci-guards/semantic-colour-alpha.spec.ts
+++ b/tests/ci-guards/semantic-colour-alpha.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * Opacity-modifier EMISSION guard.
+ *
+ * THE DEFECT: in Tailwind 3.4, an opacity modifier applied to a colour that is
+ * declared as a bare `var(--x)` produces NO CSS AT ALL. Not a warning, not a
+ * fallback rule — the utility simply does not exist in the stylesheet. Every
+ * semantic colour in this design system was declared that way, so
+ * `border-info/30` — the outlined-pill recipe CLAUDE.md documents as canonical
+ * ("Pills: outlined only (`bg-transparent border-{colour}/30 text-text-body`)",
+ * "Borders via opacity (`border-danger/30`), never extra shade tokens") — had
+ * never emitted a single rule for any semantic colour, across ~353 files. Those
+ * elements fell through to preflight's `border-color: #e5e7eb`, so the colour
+ * channel that the three-channel system says carries "how it's doing" was
+ * silently dropped product-wide.
+ *
+ * Verified at the DEPLOYED bytes before the fix (staging--olumi.netlify.app,
+ * /assets/index-WhyMS66U.css):
+ *     .bg-gray-400\/10{background-color:#9ca3af1a   <- positive control: emits
+ *     .border-info\/30                              <- NO RULE
+ * The fix is to declare each colour's CHANNELS as the source of truth
+ * (`--info-rgb: 39 122 157; --info: rgb(var(--info-rgb))`) and hand Tailwind
+ * `rgb(var(--info-rgb) / <alpha-value>)`.
+ *
+ * WHY THIS GUARD TESTS EMISSION RATHER THAN CONFIG SHAPE. A regex over
+ * tailwind.config.js asserting "the value contains `<alpha-value>`" would be a
+ * hand-maintained restatement of Tailwind's rules — the exact mirror class that
+ * produced this defect (trap 12), and it would not have caught the original bug
+ * either, because the original config was perfectly valid CSS. So this runs the
+ * REAL Tailwind over the REAL config and asserts a rule comes out.
+ *
+ * BOTH controls are mandatory and both are here:
+ *   · POSITIVE — a stock-palette utility (`bg-gray-400/10`) must emit, proving
+ *     the harness can see a rule at all. Without it, "every class emitted"
+ *     could mean "the compiler produced nothing and we compared empty sets"
+ *     (trap 13).
+ *   · NEGATIVE — the same colour re-declared in the OLD bare `var()` form must
+ *     NOT emit. This is the guard's own mutation check, run on every CI pass
+ *     rather than once by hand: if someone reverts brand.css and the config to
+ *     the pre-fix shape, `emitsFor` provably goes empty for it.
+ *
+ * The class list is DERIVED by scanning src/ for opacity-modified utilities and
+ * resolving each against the config's own colour tree. It is never a hand list,
+ * so a colour used with a modifier tomorrow is covered tomorrow — including
+ * sub-shades (`bg-warning-light/70`) and legacy aliases (`bg-carrot-500/10`).
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve as resolvePath } from 'node:path'
+import postcss from 'postcss'
+import tailwind from 'tailwindcss'
+import config from '../../tailwind.config.js'
+
+const SRC = resolvePath(__dirname, '../../src')
+
+/** Utility prefixes that accept a colour + opacity modifier. */
+const UTILITIES = [
+  'bg', 'text', 'border', 'ring', 'ring-offset', 'fill', 'stroke', 'from', 'via', 'to',
+  'divide', 'outline', 'shadow', 'accent', 'caret', 'decoration', 'placeholder',
+]
+
+/** `border-info/30`, `bg-info/[0.06]` — utility, colour path, alpha. */
+const MODIFIED = new RegExp(
+  `\\b(${UTILITIES.join('|')})-([a-zA-Z0-9-]+)\\/(\\[[^\\]]*\\]|\\d+)`,
+  'g',
+)
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) walk(p, out)
+    else if (/\.(ts|tsx|js|jsx|css)$/.test(p)) out.push(p)
+  }
+  return out
+}
+
+/** The config's colour key paths, flattened the way Tailwind names them. */
+function colourKeys(): string[] {
+  const colours = (config as { theme: { extend: { colors: Record<string, unknown> } } }).theme.extend.colors
+  const keys: string[] = []
+  for (const [k, v] of Object.entries(colours)) {
+    if (typeof v === 'string') keys.push(k)
+    else for (const sub of Object.keys(v as Record<string, unknown>)) {
+      keys.push(sub === 'DEFAULT' ? k : `${k}-${sub}`)
+    }
+  }
+  // Longest first, so `info-light` wins over `info` for `border-info-light/30`.
+  return keys.sort((a, b) => b.length - a.length)
+}
+
+/**
+ * Every opacity-modified utility in src/ whose colour resolves to a key this
+ * config DECLARES. Classes naming a colour the config does not define (a
+ * separate, pre-existing defect — `bg-banana-200/50` and friends) are out of
+ * scope here: this guard is about declaration FORM, and a colour that does not
+ * exist has no form to get wrong.
+ */
+function usedClasses(): string[] {
+  const keys = new Set(colourKeys())
+  const found = new Set<string>()
+  for (const file of walk(SRC)) {
+    const text = readFileSync(file, 'utf8')
+    for (const m of text.matchAll(MODIFIED)) {
+      const [whole, , colour] = m
+      if (keys.has(colour)) found.add(whole)
+    }
+  }
+  return [...found].sort()
+}
+
+/** Compile a set of classes with Tailwind and return the selectors it emitted. */
+async function emitsFor(classes: string[], colourOverride?: Record<string, unknown>): Promise<Set<string>> {
+  const theme = colourOverride
+    ? { ...config.theme, extend: { ...config.theme.extend, colors: { ...config.theme.extend.colors, ...colourOverride } } }
+    : config.theme
+  const result = await postcss([
+    tailwind({
+      ...config,
+      theme,
+      content: [{ raw: classes.join(' '), extension: 'html' }],
+      corePlugins: { preflight: false },
+    }),
+  ]).process('@tailwind utilities;', { from: undefined })
+
+  const selectors = new Set<string>()
+  result.root.walkRules((rule) => {
+    for (const sel of rule.selector.split(',')) selectors.add(sel.trim())
+  })
+  return selectors
+}
+
+/** The CSS selector Tailwind generates for a class (`/` and `.` are escaped). */
+const selectorFor = (cls: string) => '.' + cls.replace(/[/.[\]]/g, (c) => '\\' + c)
+
+/**
+ * Did Tailwind emit a rule for this class?
+ *
+ * Not every utility produces a BARE class selector: `divide-*` emits
+ * `.divide-x\/70 > :not([hidden]) ~ :not([hidden])`. An exact-match check
+ * reported `divide-panel-border/70` as missing when it emits perfectly well —
+ * a guard that cries wolf gets relaxed, so the match is prefix-based, bounded
+ * by a combinator or whitespace so `.border-info\/3` cannot satisfy
+ * `.border-info\/30`.
+ */
+const wasEmitted = (emitted: Set<string>, cls: string): boolean => {
+  const sel = selectorFor(cls)
+  for (const s of emitted) {
+    if (s === sel) return true
+    if (s.startsWith(sel) && /^[\s>+~:]/.test(s.slice(sel.length))) return true
+  }
+  return false
+}
+
+describe('semantic colours emit CSS when used with an opacity modifier', () => {
+  let used: string[]
+  let emitted: Set<string>
+
+  beforeAll(async () => {
+    used = usedClasses()
+    emitted = await emitsFor([...used, 'bg-gray-400/10'])
+  }, 60_000)
+
+  it('the harness can SEE an emitted rule, and can see one go MISSING (both controls)', async () => {
+    // POSITIVE. A stock-palette colour with a modifier must emit. This is the
+    // exact utility whose presence in the deployed stylesheet proved the
+    // semantic ones were absent for a reason specific to THEM.
+    expect(emitted).toContain(selectorFor('bg-gray-400/10'))
+
+    // The scan must actually be finding the code it asserts about. Floors sit
+    // ~10% under the observed figure so a partial blinding is visible rather
+    // than merely "still above a number".
+    expect(used.length, `${used.length} distinct modified classes found (was 118 when set)`)
+      .toBeGreaterThanOrEqual(100)
+    expect(used, 'the documented outlined-pill recipe must be in the scanned set')
+      .toContain('border-info/30')
+
+    // NEGATIVE — this guard's own mutation check, run every time rather than
+    // once by hand. Re-declare `info` in the pre-fix bare-var() form and the
+    // rule must VANISH. If this ever passes with the modifier still emitting,
+    // the harness has stopped measuring emission and every assertion below is
+    // vacuous.
+    const reverted = await emitsFor(['border-info/30', 'bg-gray-400/10'], {
+      info: { DEFAULT: 'var(--info)' },
+    })
+    expect(reverted, 'positive control must still emit under the reverted config')
+      .toContain(selectorFor('bg-gray-400/10'))
+    expect(
+      reverted,
+      'REVERTING the config to `var(--info)` must un-emit `border-info/30`. It did not, ' +
+        'so this guard is no longer measuring what it claims to measure.',
+    ).not.toContain(selectorFor('border-info/30'))
+  }, 60_000)
+
+  it('every opacity-modified semantic utility in src/ emits a rule', () => {
+    const missing = used.filter((cls) => !wasEmitted(emitted, cls))
+    expect(
+      missing,
+      `these utilities are used in src/ but Tailwind emits NO RULE for them, so the ` +
+        `element silently keeps its inherited or preflight colour:\n` +
+        missing.map((c) => `  ${c}`).join('\n') +
+        `\n\nA colour can only take an opacity modifier if tailwind.config.js gives it ` +
+        `channels — \`rgb(var(--x-rgb) / <alpha-value>)\` — backed by a \`--x-rgb\` triple ` +
+        `in src/styles/brand.css. A bare \`var(--x)\` emits nothing at all.`,
+    ).toEqual([])
+  })
+
+  it('the emitted rule actually carries the requested alpha, not a silent 1', async () => {
+    // A rule that EXISTS but ignores the modifier would satisfy the test above
+    // while rendering identically to the broken behaviour on screen. Assert the
+    // alpha reaches the declaration, and that it is the channel form that made
+    // it possible.
+    const css = await postcss([
+      tailwind({
+        ...config,
+        content: [{ raw: 'border-info/30 bg-danger/20', extension: 'html' }],
+        corePlugins: { preflight: false },
+      }),
+    ]).process('@tailwind utilities;', { from: undefined })
+
+    expect(css.css).toMatch(/border-color:\s*rgb\(var\(--info-rgb\)\s*\/\s*0?\.3\)/)
+    expect(css.css).toMatch(/background-color:\s*rgb\(var\(--danger-rgb\)\s*\/\s*0?\.2\)/)
+  }, 60_000)
+})

--- a/tests/ci-guards/text-light-contrast.spec.ts
+++ b/tests/ci-guards/text-light-contrast.spec.ts
@@ -40,6 +40,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { resolveTokenHex } from '../../src/styles/channelTriple.mjs'
 
 /** SC 1.4.3 — normal-size text. Large text (>=24px / >=18.66px bold) may use 3:1. */
 const WCAG_TEXT_MIN = 4.5
@@ -75,11 +76,23 @@ function contrast(a: string, b: string): number {
   return (hi + 0.05) / (lo + 0.05)
 }
 
-/** Declared value of a `--token` at :root in brand.css. Throws rather than defaulting. */
+/**
+ * Declared colour of a `--token` at :root in brand.css. Throws rather than
+ * defaulting.
+ *
+ * Resolution is delegated to the SHARED resolver so this guard understands
+ * exactly the same declaration forms as the other four brand.css parsers —
+ * literal hex, `var()` alias, and the channel-triple form
+ * (`--text-light-rgb: 110 107 107; --text-light: rgb(var(--text-light-rgb))`)
+ * that lets Tailwind emit opacity-modified utilities. This guard previously
+ * matched a literal hex only, so it went red the moment the triple landed:
+ * fail-loud, exactly as designed. Teaching it the form does NOT relax it —
+ * an unresolvable token still throws, and the ratios are still computed.
+ */
 function declared(token: string): string {
-  const m = brandCss.match(new RegExp(`^\\s*${token}:\\s*(#[0-9A-Fa-f]{3,8})\\s*;`, 'm'))
-  if (!m) throw new Error(`${token} is not declared with a literal hex in src/styles/brand.css`)
-  return m[1]
+  const hex = resolveTokenHex(brandCss, token)
+  if (!hex) throw new Error(`${token} does not resolve to a literal colour in src/styles/brand.css`)
+  return hex
 }
 
 /** Every ground `--text-light` is painted on as TEXT, worst case included. */
@@ -104,6 +117,15 @@ describe('--text-light is a legal text colour (WCAG SC 1.4.3)', () => {
     // 3. The parser must actually be reading brand.css, not silently
     //    defaulting: an undeclared token throws rather than returning a value.
     expect(() => declared('--token-that-does-not-exist')).toThrow()
+
+    // 4. The channel-triple form must resolve to the SAME colour the literal
+    //    hex used to declare. `--text-light` is declared as
+    //    `rgb(var(--text-light-rgb))` now; if the resolver mis-assembled the
+    //    channels, every ratio below would be measured against the wrong
+    //    colour and would still look like a pass. This is the one assertion
+    //    that pins the new declaration form to a concrete value.
+    expect(declared('--text-light')).toBe('#6E6B6B')
+    expect(brandCss).toMatch(/--text-light:\s*rgb\(var\(--text-light-rgb\)\)/)
   })
 
   it.each(GROUNDS)('clears 4.5:1 on %s', (ground) => {


### PR DESCRIPTION
> 🚫 **DRAFT — DO NOT MERGE, DO NOT MARK READY.** Self-contained and net-safe, but the design-system finding at the bottom needs an owner decision.

## The defect, proven at the deployed bytes

In Tailwind 3.4 an opacity modifier on a colour declared as a bare `var(--x)` emits **no CSS at all** — no rule, no warning, no fallback. `tailwind.config.js` declared every semantic colour that way, with zero uses of `<alpha-value>`.

From the **live deployed stylesheet** (`staging--olumi.netlify.app`, `/assets/index-WhyMS66U.css`):

```
.bg-gray-400\/10{background-color:#9ca3af1a     ← POSITIVE CONTROL: normal colours DO emit
.border-info\/30                                 ← NO RULE
.(bg|border)-(info|danger|success|warning)\/NN   ← NO RULE, none of them
```

`CLAUDE.md` documents this exact recipe as canonical — *"Pills: outlined only (`bg-transparent border-{colour}/30 text-text-body`)"* and *"Borders via opacity (`border-danger/30`), never extra shade tokens."* **The design system's own documented pattern has never worked**, across ~353 files.

## What those borders actually render as today

**Not "invisible".** Preflight sets `*,:before,:after{ … border-color:#e5e7eb }`, so they paint a **cool grey `#e5e7eb`** at 1px. Confirmed in a live browser: with the new rules deleted from the CSSOM, all 12 on-screen `border-{colour}/30` elements computed to `rgb(229, 231, 235)`.

The honest before/after is **grey → semantic tint**, not nothing → something.

## The fix — derive, don't mirror

```css
--info-rgb: 39 122 157;
--info: rgb(var(--info-rgb));
```

`tailwind.config.js` then uses `rgb(var(--info-rgb) / <alpha-value>)`. Every existing `var(--info)` reference resolves to the same colour and is untouched. The triple is authored once and the hex derived from it — **no token declared in two places**. The five `*-disabled` tokens that hand-copied the same channels as literal `rgba()` now derive from the triple too.

Scope **derived by scanning `src/`**, never hand-listed: 20 config colour keys → 21 tokens given triples → 50 config entries converted.

## Net effect: borders gain their tint, text is untouched

| | count |
|---|---|
| Rules before / after | 2,060 → 2,169 |
| **New opacity-modifier rules** (previously emitted nothing) | **111** |
| — of which TEXT rules | **0** |
| Existing utilities re-emitted in channel form (identical colour) | 163 |
| Net rule delta | **+109** |

Largest groups: `bg-info/*` 8 · `border-info/*` 6 · `border-warning/*` 6 · `border-option/*` 4 · `border-success/*` 4 · `bg-warning/*` 4.

```
.border-danger\/30{border-color:rgb(var(--danger-rgb) / .3)}
.border-info\/30  {border-color:rgb(var(--info-rgb) / .3)}
.border-success\/30{border-color:rgb(var(--success-rgb) / .3)}
.border-warning\/30{border-color:rgb(var(--warning-rgb) / .3)}
```

---

## 🔴 THE DEEPER FINDING — the documented `/30` recipe is structurally non-compliant

**This PR makes the mechanism work. It does not make the recipe compliant, and no alpha value can.**

Against `--bg-canvas`, most semantic tokens fail SC 1.4.11's 3:1 **at full opacity**, so no opacity modifier can rescue them:

```
info        #277A9D  needs alpha >= 79%       text-light  #6E6B6B  needs >= 77%
text-header #262626  needs alpha >= 51%
warning · success · danger · option · factor · goal  —  IMPOSSIBLE AT ANY ALPHA
```

**Zero of the 93 token × alpha × ground border combinations clear 3:1.** The `#e5e7eb` they render as today doesn't either (1.23:1 on `--bg-panel`, 1.09:1 on `--bg-canvas`), so borders are **net-neutral** — and two get marginally *worse*:

| `/30` on `--bg-panel` | today | after | Δ |
|---|---|---|---|
| `border-info/30` | 1.23:1 | **1.50:1** | +0.27 |
| `border-text-light/30` | 1.23:1 | **1.50:1** | +0.27 |
| `border-danger/30` | 1.23:1 | **1.34:1** | +0.11 |
| `border-factor/30` | 1.23:1 | 1.26:1 | +0.03 |
| `border-option/30` | 1.23:1 | 1.24:1 | +0.01 |
| `border-success/30` | 1.23:1 | 1.22:1 | −0.00 |
| `border-warning/30` | 1.23:1 | 1.21:1 | **−0.02** |
| `border-goal/30` | 1.23:1 | 1.16:1 | **−0.07** |

**The recipe itself needs an owner decision** — a materially higher alpha, or a dedicated border token per family. The numbers above are deliberately left as they fall: the recipe was **not** quietly changed to make them look better, because the honest result is the useful one.

---

## Text: 26 AA regressions found, then eliminated

Text utilities with a modifier render **at full token strength today** because the rule doesn't emit. Letting them emit lightened text sharply — **26 combinations fell from passing AA to failing it** (`text-ink-900/40` 15.01:1 → **2.36:1**; `text-text-light/50` 5.23:1 → **2.03:1**, measured live at 2.04:1). So the call-site pre-work is done **in this PR**.

### Verified per site, not assumed — and the premise did not fully hold

A three-state CSSOM comparison (today / with-modifier / with-solid) on every reachable element confirmed *solid == today* on all 11 measured. But it is **not** universally true, and one case actively breaks it:

- A bare element inherits **`#262626` at body level** but **`#3F3F3E` inside a panel** — so solid conversion is a no-op only where the site already inherits the token it names.
- 🔴 **`warning`, `danger`, `success` and `paper-50` fail AA as text at FULL strength** (1.92:1, 2.80:1, 2.02:1, 1.00:1). Converting those to solid would have introduced a **new** contrast failure that does not exist today.

So the sweep is split by that measurement rather than applied uniformly:

| | sites | treatment |
|---|---|---|
| AA-safe tokens (`ink-900`, `text-header`, `text-light`, `info`) | **120** | modifier dropped, token kept — preserves design intent |
| AA-unsafe tokens (`warning`, `danger`, `success`, `paper-50`) | **12** | dead class **removed** — provably a no-op (a class matching no rule cannot affect any computed style) and preserves today's passing, inherited rendering |

The 12 removals each need a design ruling; the three non-obvious ones carry an inline comment explaining why the class is absent.

### Proof of net-zero

```
LIVE text-*/NN class uses remaining (comments stripped): 0     [was 132]
AA REGRESSIONS (passed before, fail after):             0     [was 26]
POSITIVE CONTROL — a reinstated text-ink-900/50 reads 15.01 -> 3.09 = DETECTED ✓
```

Comments are stripped before counting, because **three class mentions appeared in comments this change itself added** — counting prose as usage would have understated the result. (Tailwind's scanner is naive in the same way: those comments generated three real `text-*/NN` rules until the wording was changed. Caught by rebuilding and re-checking the emitted CSS.)

Runtime confirmation: dock labels measure `rgb(38, 38, 38)` both on staging and here; **0 surviving modifier classes and 0 translucent text** anywhere in the DOM.

## HERO_BAR_FILL — untouched, and verified unmoved

Left exactly as it is, eslint exceptions included. Verified rather than assumed — resolved live:

```
bg-info-light      -> rgb(186, 215, 228)   == --info-light
bg-option-light    -> rgb(221, 220, 245)   == --option-light
border-option-light-> rgb(221, 220, 245)   == --option-light
bg-primary         -> rgb(39, 122, 157)    == --primary
```

**Nothing moved.** Unwinding the workaround is now unblocked, but remains a design ruling and is not this PR's business.

## `chartClassesCompile.spec.ts` — the tripwire worked as designed

This suite **already pinned this defect as expected behaviour**, and its own comment named this exact fix as its trigger:

> *"If this ever starts failing (the classes begin to compile — e.g. the theme moves to alpha-capable `rgb(var(--x) / <alpha-value>)` colours), the solid light-token workaround can be revisited"*

It fired the moment the triples landed. The assertion is **inverted, not deleted**, so it stays bidirectional — a regression to bare `var()` turns it red again. It also now asserts the emitted rule carries a real alpha, since a rule that compiled but ignored the modifier would look identical to the broken behaviour on screen.

## Visual verification

Dev server booted with `node_modules/.vite` cleared; **served CSS diffed against disk before any screenshot** (served `brand.css` carries `--info-rgb: 39 122 157`; served bundle emits `.border-info\/30{border-color: rgb(var(--info-rgb) / 0.3)}`; served component modules contain **0** of the removed modifier classes). No stale-build risk.

A/B done by deleting the new rules from the live CSSOM and restoring them — **same DOM, same data**.

| Surface | Verdict |
|---|---|
| OutputsDock tabs + Analysis panel | ✅ Tinted borders read as intended; tab labels unchanged at `rgb(38,38,38)` |
| Validation / critique banners | ✅ Warning border now warm (`#FEE4CC`) vs grey |
| Coaching cards ("Strengthen this model") | ✅ Info borders now blue (`#93BCCE`, 2.02:1) — clearest improvement |
| Results pills ("Needs value", "Weak/Moderate/Strong") | ✅ Correct semantic tint, no layout shift |
| Canvas node chrome ("Needs input") | ✅ Warning border emits; dashed outlines unchanged |
| Model tab | ✅ Renders cleanly |
| **inspector-v2 (single-click node)** | ✅ **Gap closed.** 0 surviving modifier classes, 0 translucent text. All text compliant except a pre-existing solid `text-option` type label at 2.23:1 (unrelated to this change) |

## Separate, reviewable on their own merits

Two real defects found by the new guard on its first run, unrelated to the alpha mechanism:

1. **`bg-info/8`** (`HighlightLayer.tsx`) emitted nothing at *any* colour form — `8` is not in Tailwind's opacity scale. Fixed to `bg-info/[0.08]`.
2. **Seven dead colour classes**, verified as emitting nothing in the built CSS: `bg-banana-200/…`, `bg-banana-300/…`, `bg-charcoal-900/…`, `bg-sand-50/…`, `bg-sand-100/…`, `stroke-info-400/…`, `border-neutral/…` — colour keys the config does not define. **Reported only, not fixed** (each needs a colour decision).

## Every guard edit, and why

| Guard | Edit | Why |
|---|---|---|
| `text-light-contrast.spec.ts` | `declared()` → shared resolver | Matched a literal hex only; went red when `--text-light` became a triple. **Not relaxed** — still throws on anything unresolvable, and gains an explicit pin on the value *and* the declaration form. |
| `artefact-template-token-mirror.spec.ts` | same | 12 of 15 restated tokens are triples now; without this it would report all 12 uncomparable and go blind. Control extended to pin `--danger` and the `--primary → --info-rgb` alias hop. |
| `GhostOptionNode.contrast.spec.ts` | same | Reads `--bg-panel` / `--bg-canvas`. |
| `brand-tokens.spec.ts` | `resolve()` → shared resolver; colour reads moved off the raw reader | Raw reads now return `rgb(var(--x-rgb))`. `token()` kept for the two assertions genuinely about the *declaration*. New test pins channels ⇄ hex agreement. |
| `css-var-census.mjs` | `definitionValues()` resolves the triple at both ends of an alias hop | Would otherwise classify every semantic colour as "a compound var() expression" and quietly retire the fallback-drift pin on the most-retinted tokens. |
| `semantic-colour-alpha.spec.ts` | floor re-baselined **118 → 96** distinct classes | The sweep retired 22 TEXT classes from the scan. The floor moved **because the tree moved**, not to accommodate a failure — every remaining class must still emit, and the mutation control still bites. |
| `chartClassesCompile.spec.ts` | assertion **inverted**, not deleted | See above. |
| `ds-compliance-baseline.json` | **UNCHANGED** | Output matches pristine `origin/staging` byte for byte, and the ratchet moved **down** (`legacy-tailwind-token` −6, `production-hex` −8). The net-new `artefactIframeTemplate.ts #6E6B6B` it reports is **pre-existing** — verified by running the guard on a clean worktree. |

**Five parsers, one resolver.** All five previously carried their own `#[0-9A-Fa-f]{3,8}` regex. They now share `src/styles/channelTriple.mjs` (`.mjs` + `.d.mts`, the pattern already used by `src/generated/validators.js`, because the census is a plain node script that cannot import TypeScript).

## The new guard, and its mutation checks

`semantic-colour-alpha.spec.ts` compiles the **real** Tailwind config over the class list **derived** from `src/` and asserts a rule comes out. It tests *emission*, not config shape — a regex asserting "contains `<alpha-value>`" would restate Tailwind's rules and would not have caught the original bug, whose config was perfectly valid CSS.

- **Positive control**: `bg-gray-400/10` must emit.
- **Negative control (mutation check, every CI pass)**: re-declaring `info` as `var(--info)` must make `border-info/30` vanish.
- Asserts the emitted rule carries the **actual alpha**.

External mutation checks, in throwaway copies:

| Mutation | Result |
|---|---|
| Revert all 50 config entries to bare `var(--x)` | 🔴 **RED** — emitted CSS is literally `""` |
| Same, after the floor re-baseline | 🔴 **RED** — still bites |
| Delete the 21 triples, keep the config | Emission guard passes (Tailwind cannot see an undefined var) — a named blind spot — but 🔴 **RED** in `css-var-resolution` and `brand-tokens` |

## Two self-inflicted errors, caught and reverted rather than shipped

1. A `\b`-bounded dedup regex fused `text-info-600 hover:text-info-700` into **`text-info-600-700`** in 5 files. Caught by grepping for malformed tokens; fully reverted and rewritten with a `(?![\w/-])` boundary.
2. A first dedup pass stripped **pre-existing** redundancy in ~30 unrelated files — unrelated edits bundled into the diff. Reverted; the dedup now runs only over files this branch touched and only removes redundancy **it created** (6 removals; 2 pre-existing pairs deliberately left alone).

A third was caught by the browser: a JSX comment placed inside `{cond && (…)}` broke two components. Fixed before commit.

## Gates

| Gate | Result |
|---|---|
| `pnpm run typecheck` | ✅ 0 errors |
| eslint (all touched files) | ✅ **0 errors** (15 warnings, all pre-existing) |
| `npx vitest run tests/ci-guards` | ✅ 33/33 |
| `npx vitest run --changed origin/staging` | ✅ **1,749 passed**, 23 skipped (168 files) |
| `pnpm run build` | ✅ exit 0 |
| `check-ds-compliance.mjs` | ✅ matches pristine staging; ratchet down |
| Wide `tsc -p tsconfig.app.json` vs matched base clone (own `node_modules`), `grep -c "error TS"` | ✅ **2317 → 2317; set-wise 0 new, 0 removed** |

## Follow-ups (not in this PR)

1. 🔴 **The `/30` recipe cannot satisfy SC 1.4.11** — needs a higher alpha or a dedicated border token per family.
2. The 12 removed AA-unsafe text classes need a compliant colour choice.
3. `HERO_BAR_FILL`'s workaround + eslint exceptions (issue 222) — now unblocked.
4. Seven dead colour classes (above).
5. Stale `ds-compliance-baseline.json` entry for `artefactIframeTemplate.ts #6E6B6B` (pre-existing).
6. `pnpm run build` rewrites tracked `src/generated/validators.js` with a fresh timestamp, dirtying the tree on every build.
7. Pre-existing solid `text-option` type label at 2.23:1 in inspector-v2.

---

🚫 **DO NOT MERGE. DO NOT MARK READY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
