### PR TITLE
fix(v5): stop stripping value-of-information fields + read edge values from the real wire location (P0 F5/F6)

### DIFF
--- a/src/v5/__tests__/mapV5AnalysisToReport.voi-edge-values.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.voi-edge-values.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * P0 F5/F6 (A3-filed, A1-verified) — the two top user-visible data losses on
+ * the live V5 conversational path. Both are UI-side; PLoT's wire is correct
+ * (A3 → ORCHESTRATOR, 19 Jul 2026; positive control = the checked-in staging
+ * bundle fixture used here).
+ *
+ * F5 — value-of-information / EVPI stripped: `normaliseFactorEntry` narrowed
+ * `enrichment.factor_sensitivity[]` to a closed `NormalisedFactor` that never
+ * read `value_of_information` / `evpi_percentage_points` / `evpi_method` /
+ * `evpi_status`, so every EVPI field was DELETED before the store. The V4
+ * mapper preserves them (`responseMapper.ts:281,336`) and the Model tab renders
+ * them (`ModelTabBody.tsx:209-217` builds the EVPI map from
+ * `evpi_percentage_points` ?? `value_of_information * 100`); the V5 path went
+ * dark. These tests lock the additive passthrough — verbatim, never scaled,
+ * never defaulted.
+ *
+ * F6 — edge E-values read from the wrong nested location: PLoT emits
+ * `edge_e_values` at the TOP LEVEL of enrichment (`enrichment.edge_e_values`);
+ * the legacy nested copy (`enrichment.robustness.edge_e_values`) is no longer
+ * populated on the live V5 wire. Every UI consumer reads
+ * `report.robustness.edge_e_values` (`useAnalysisResults.ts:54`,
+ * `ModelTabBody.tsx:238`, `useResultsSectionData.ts:2491/2958`,
+ * `analysisSnapshotFactory.ts:115`), so E-values rendered empty despite real
+ * data on the wire. These tests lock: `report.robustness.edge_e_values` is
+ * sourced from the real top-level wire location, falls back to the legacy
+ * nested copy, and fails closed when both are genuinely absent.
+ *
+ * REAL WIRE PROVENANCE — every nesting below is pinned to the checked-in
+ * capture `fixtures/v5-analysis-result.bundle-45c9b625.json`
+ * (debug bundle olumi-debug-45c9b625-20260707, payloads.cee_response.blocks[0]):
+ *   - factor VoI/EVPI at  block.enrichment.factor_sensitivity[].value_of_information
+ *                          block.enrichment.factor_sensitivity[].evpi_percentage_points
+ *   - edge E-values at     block.enrichment.edge_e_values   (TOP LEVEL, 6 entries)
+ *   - block.enrichment.robustness carries NO edge_e_values.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+import bundleFixture from './fixtures/v5-analysis-result.bundle-45c9b625.json'
+
+type WidenedReport = ReturnType<typeof mapV5AnalysisToReport> & Record<string, unknown>
+
+interface FactorRow {
+  factor_id: string
+  factor_label: string
+  sensitivity: number
+  direction: 'positive' | 'negative'
+  value_of_information?: number
+  evpi_percentage_points?: number
+  evpi_method?: string
+  evpi_status?: string
+}
+
+function mapBundleBlock(): WidenedReport {
+  const block = bundleFixture.block as unknown as AnalysisResultBlock
+  return mapV5AnalysisToReport(block) as WidenedReport
+}
+
+function factorById(report: WidenedReport, id: string): FactorRow {
+  const rows = report.factor_sensitivity as FactorRow[]
+  const row = rows.find((f) => f.factor_id === id)
+  expect(row, `factor ${id} present in widened.factor_sensitivity`).toBeDefined()
+  return row as FactorRow
+}
+
+describe('mapV5AnalysisToReport — value-of-information / EVPI passthrough (P0 F5)', () => {
+  it('carries per-factor value_of_information verbatim onto factor_sensitivity rows (real staging bundle)', () => {
+    const report = mapBundleBlock()
+    // Every factor in the captured bundle carries value_of_information (0 here —
+    // a below-resolution capture). The defect DELETED the field entirely; the
+    // fix must preserve it, including a real 0 (0 is data, not absence).
+    for (const id of [
+      'fac_marketing_expertise',
+      'fac_market_receptivity',
+      'fac_founder_time',
+      'fac_manager_cost',
+      'fac_ad_spend',
+    ]) {
+      const row = factorById(report, id)
+      expect('value_of_information' in row, `${id} keeps value_of_information`).toBe(true)
+      expect(row.value_of_information).toBe(0)
+    }
+  })
+
+  it('carries evpi_percentage_points where the producer sent it, omits it where absent (no defaults)', () => {
+    const report = mapBundleBlock()
+    // Present (0) on these two entries in the capture.
+    expect(factorById(report, 'fac_market_receptivity').evpi_percentage_points).toBe(0)
+    expect(factorById(report, 'fac_founder_time').evpi_percentage_points).toBe(0)
+    expect(factorById(report, 'fac_market_receptivity').evpi_method).toBe('heuristic')
+    expect(factorById(report, 'fac_founder_time').evpi_method).toBe('heuristic')
+    // Absent on these — must NOT be fabricated to 0 (fail closed).
+    for (const id of ['fac_marketing_expertise', 'fac_manager_cost', 'fac_ad_spend']) {
+      expect('evpi_percentage_points' in factorById(report, id), `${id} has no fabricated evpi_percentage_points`).toBe(false)
+    }
+  })
+
+  it('passes a non-zero value_of_information / evpi through verbatim — never scaled', () => {
+    const block = {
+      type: 'analysis_result',
+      summary: 'non-zero VoI',
+      leading_option_id: null,
+      win_probabilities: { opt_a: 0.6 },
+      enrichment: {
+        factor_sensitivity: [
+          {
+            factor_id: 'fac_x',
+            factor_label: 'X',
+            sensitivity_score: 0.4,
+            direction: 'positive',
+            value_of_information: 0.72,
+            evpi_percentage_points: 21,
+            evpi_method: 'heuristic',
+            evpi_status: 'above_resolution',
+          },
+        ],
+      },
+    } as unknown as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as WidenedReport
+    const row = (report.factor_sensitivity as FactorRow[])[0]
+    expect(row.value_of_information).toBe(0.72) // NOT 72
+    expect(row.evpi_percentage_points).toBe(21)
+    expect(row.evpi_method).toBe('heuristic')
+    expect(row.evpi_status).toBe('above_resolution')
+  })
+
+  it('omits every EVPI field when the producer omits them (no defaults, no derivation)', () => {
+    const block = {
+      type: 'analysis_result',
+      summary: 'legacy shape without EVPI fields',
+      leading_option_id: null,
+      win_probabilities: { opt_a: 0.6 },
+      enrichment: {
+        factor_sensitivity: [
+          { factor_id: 'fac_x', factor_label: 'X', sensitivity_score: 0.4, direction: 'positive' },
+        ],
+      },
+    } as unknown as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as WidenedReport
+    const row = (report.factor_sensitivity as FactorRow[])[0]
+    expect('value_of_information' in row).toBe(false)
+    expect('evpi_percentage_points' in row).toBe(false)
+    expect('evpi_method' in row).toBe(false)
+    expect('evpi_status' in row).toBe(false)
+  })
+})
+
+describe('mapV5AnalysisToReport — edge E-values from the real top-level wire location (P0 F6)', () => {
+  it('populates report.robustness.edge_e_values from the TOP-LEVEL enrichment.edge_e_values (real staging bundle)', () => {
+    const report = mapBundleBlock()
+    const robustness = report.robustness as { edge_e_values?: unknown[] } | undefined
+    expect(robustness, 'report.robustness present for the bundle').toBeDefined()
+    // The live wire carries edge_e_values at the top level; robustness carries
+    // none. Consumers read report.robustness.edge_e_values, so it must be
+    // sourced from the real (top-level) location — byte-for-byte.
+    const wireTopLevel = (bundleFixture.block as { enrichment: { edge_e_values: unknown[] } })
+      .enrichment.edge_e_values
+    expect(robustness!.edge_e_values).toEqual(wireTopLevel)
+    expect(robustness!.edge_e_values).toHaveLength(6)
+    // Spot-check the non-unit E-value survives (would be lost if read empty).
+    const rows = robustness!.edge_e_values as Array<{ edge_id: string; e_value: number }>
+    const founderDistraction = rows.find(
+      (r) => r.edge_id === 'fac_marketing_expertise::risk_founder_distraction',
+    )
+    expect(founderDistraction?.e_value).toBe(2.2528)
+  })
+
+  it('falls back to the legacy nested robustness.edge_e_values when no top-level array is present', () => {
+    const block = {
+      type: 'analysis_result',
+      summary: 'legacy nested edge_e_values',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.7 },
+      enrichment: {
+        robustness: {
+          is_robust: true,
+          level: 'high',
+          edge_e_values: [{ edge_id: 'e_legacy', e_value: 0.4 }],
+        },
+      },
+    } as unknown as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as WidenedReport
+    const robustness = report.robustness as { edge_e_values?: unknown[] } | undefined
+    expect(robustness!.edge_e_values).toEqual([{ edge_id: 'e_legacy', e_value: 0.4 }])
+  })
+
+  it('prefers the top-level wire location over any stale nested copy', () => {
+    const block = {
+      type: 'analysis_result',
+      summary: 'top-level wins',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.7 },
+      enrichment: {
+        edge_e_values: [{ edge_id: 'e_top', e_value: 0.9 }],
+        robustness: {
+          is_robust: true,
+          level: 'high',
+          edge_e_values: [{ edge_id: 'e_stale', e_value: 0.1 }],
+        },
+      },
+    } as unknown as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as WidenedReport
+    const robustness = report.robustness as { edge_e_values?: unknown[] } | undefined
+    expect(robustness!.edge_e_values).toEqual([{ edge_id: 'e_top', e_value: 0.9 }])
+  })
+
+  it('fails closed — no edge_e_values key when neither location carries data', () => {
+    const block = {
+      type: 'analysis_result',
+      summary: 'no edges',
+      leading_option_id: 'opt_a',
+      win_probabilities: { opt_a: 0.7 },
+      enrichment: {
+        robustness: { is_robust: true, level: 'high' },
+      },
+    } as unknown as AnalysisResultBlock
+    const report = mapV5AnalysisToReport(block) as WidenedReport
+    const robustness = report.robustness as Record<string, unknown> | undefined
+    expect(robustness).toBeDefined()
+    expect('edge_e_values' in robustness!).toBe(false)
+  })
+})

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -92,6 +92,20 @@ interface NormalisedFactor {
    * sensitivity-flavoured copy for pinned factors.
    */
   zero_reason?: string
+  /**
+   * EVPI family (value-of-information), producer-owned. P0 F5: the live V5
+   * mapper previously stripped all four before the store, so the EVPI/VoI
+   * surfaces went dark on the conversational path (the V4 mapper preserves
+   * them — responseMapper.ts:281,336 — and ModelTabBody.tsx:209-217 renders
+   * the EVPI map from `evpi_percentage_points` ?? `value_of_information * 100`;
+   * useResultsSectionData.ts:358 reads `value_of_information`). Additive
+   * passthrough only — never derived, never defaulted, never scaled; a real
+   * 0 is data (a below-resolution EVPI), an absent field stays absent.
+   */
+  value_of_information?: number
+  evpi_percentage_points?: number
+  evpi_method?: string
+  evpi_status?: string
 }
 
 /**
@@ -142,6 +156,15 @@ function normaliseFactorEntry(entry: unknown): NormalisedFactor | null {
   const influenceRank = safeFiniteNumber(entry.influence_rank)
   const zeroReason = safeString(entry.zero_reason)
 
+  // P0 F5: EVPI family (value-of-information) carried through verbatim. No
+  // derivation, no defaults, no scaling — safeFiniteNumber(0) === 0 preserves
+  // a real below-resolution EVPI, while an absent field yields undefined so
+  // the conditional spread omits the key (fail closed).
+  const valueOfInformation = safeFiniteNumber(entry.value_of_information)
+  const evpiPercentagePoints = safeFiniteNumber(entry.evpi_percentage_points)
+  const evpiMethod = safeString(entry.evpi_method)
+  const evpiStatus = safeString(entry.evpi_status)
+
   return {
     factor_id: factorId,
     factor_label: factorLabel,
@@ -150,6 +173,10 @@ function normaliseFactorEntry(entry: unknown): NormalisedFactor | null {
     ...(influenceScore !== undefined ? { influence_score: influenceScore } : {}),
     ...(influenceRank !== undefined ? { influence_rank: influenceRank } : {}),
     ...(zeroReason !== undefined ? { zero_reason: zeroReason } : {}),
+    ...(valueOfInformation !== undefined ? { value_of_information: valueOfInformation } : {}),
+    ...(evpiPercentagePoints !== undefined ? { evpi_percentage_points: evpiPercentagePoints } : {}),
+    ...(evpiMethod !== undefined ? { evpi_method: evpiMethod } : {}),
+    ...(evpiStatus !== undefined ? { evpi_status: evpiStatus } : {}),
   }
 }
 
@@ -471,6 +498,27 @@ export function mapV5AnalysisToReport(
   const robustnessRaw = isPlainObject(enrichment?.robustness)
     ? enrichment!.robustness
     : undefined
+
+  // P0 F6: edge E-values. PLoT emits `edge_e_values` at the TOP LEVEL of
+  // enrichment (enrichment.edge_e_values); the legacy nested copy
+  // (enrichment.robustness.edge_e_values) is no longer populated on the live
+  // V5 wire (A3 Codex compute-wave, 19 Jul 2026). Every UI consumer reads
+  // `report.robustness.edge_e_values` (useAnalysisResults.ts:54,
+  // ModelTabBody.tsx:238, useResultsSectionData.ts:2491/2958,
+  // analysisSnapshotFactory.ts:115), so it must be sourced from the REAL wire
+  // location — top-level first (real), the nested copy as a legacy fallback,
+  // and fail closed (omit) when neither carries a non-empty array. An empty
+  // array is treated as "no data" so a stale/empty top-level does not mask a
+  // populated legacy copy.
+  const topLevelEdgeEValuesRaw = enrichment?.edge_e_values
+  const nestedEdgeEValuesRaw = robustnessRaw?.edge_e_values
+  const robustnessEdgeEValues =
+    Array.isArray(topLevelEdgeEValuesRaw) && topLevelEdgeEValuesRaw.length > 0
+      ? topLevelEdgeEValuesRaw
+      : Array.isArray(nestedEdgeEValuesRaw) && nestedEdgeEValuesRaw.length > 0
+        ? nestedEdgeEValuesRaw
+        : undefined
+
   const robustness = robustnessRaw
     ? {
         // Receipts fail closed (T2): preserve ABSENCE. Keys are emitted
@@ -510,8 +558,11 @@ export function mapV5AnalysisToReport(
         ...(Array.isArray(robustnessRaw.flip_thresholds)
           ? { flip_thresholds: robustnessRaw.flip_thresholds }
           : {}),
-        ...(Array.isArray(robustnessRaw.edge_e_values)
-          ? { edge_e_values: robustnessRaw.edge_e_values }
+        // P0 F6: sourced from the real wire location (top-level first, nested
+        // legacy fallback) so report.robustness.edge_e_values — the slot every
+        // edge consumer reads — is populated from PLoT's top-level emit.
+        ...(robustnessEdgeEValues !== undefined
+          ? { edge_e_values: robustnessEdgeEValues }
           : {}),
         ...(Array.isArray(robustnessRaw.conditional_winners)
           ? { conditional_winners: robustnessRaw.conditional_winners }
@@ -689,6 +740,14 @@ export function mapV5AnalysisToReport(
       ...(f.influence_score !== undefined ? { influence_score: f.influence_score } : {}),
       ...(f.influence_rank !== undefined ? { influence_rank: f.influence_rank } : {}),
       ...(f.zero_reason !== undefined ? { zero_reason: f.zero_reason } : {}),
+      // P0 F5: EVPI family reaches the store so ModelTabBody's EVPI map
+      // (evpi_percentage_points ?? value_of_information * 100) and the
+      // useResultsSectionData value_of_information read light up on the V5
+      // path. Omitted when absent (no fabricated 0).
+      ...(f.value_of_information !== undefined ? { value_of_information: f.value_of_information } : {}),
+      ...(f.evpi_percentage_points !== undefined ? { evpi_percentage_points: f.evpi_percentage_points } : {}),
+      ...(f.evpi_method !== undefined ? { evpi_method: f.evpi_method } : {}),
+      ...(f.evpi_status !== undefined ? { evpi_status: f.evpi_status } : {}),
     }))
   }
   if (robustness) widened.robustness = robustness


### PR DESCRIPTION
## What & why

Two P0 data losses on the **live V5 conversational path** (A3-filed F5/F6, verified real by A1). Both are UI-side projection defects in the Seam-A mapper `src/v5/mapV5AnalysisToReport.ts`; **PLoT's wire is correct** (A3 → ORCHESTRATOR, 19 Jul 2026). These are the top user-visible data losses in the product today.

RED-first: commit 1 pins the failing state; commit 2 turns it green. Additive-only mapper change.

## F5 — value-of-information / EVPI stripped before render

`normaliseFactorEntry` narrowed `enrichment.factor_sensitivity[]` to a closed `NormalisedFactor` that read `sensitivity`/`influence_*`/`zero_reason` but **never the EVPI family**, so `value_of_information` / `evpi_percentage_points` / `evpi_method` / `evpi_status` were deleted before the store. No EVPI chips/ranking, and the Model tab EVPI map went dark on the V5 path.

- **Wrong (before):** EVPI fields dropped — never read from the factor entry, never written to the widened `factor_sensitivity` rows.
- **Right (after):** carried through verbatim onto the widened rows — never derived, never scaled, never defaulted; a real `0` is preserved (below-resolution EVPI is data), an absent field stays absent. Mirrors the V4 mapper (`src/adapters/plot/v2/responseMapper.ts:281,336`).

**Real wire shape + provenance** (pinned to `src/v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json`, debug bundle `olumi-debug-45c9b625-20260707`, `payloads.cee_response.blocks[0]`):

```
block.enrichment.factor_sensitivity[].value_of_information   (number; 0 = below-resolution, not absence)
block.enrichment.factor_sensitivity[].evpi_percentage_points (number; absent on 3/5 entries — never fabricated)
block.enrichment.factor_sensitivity[].evpi_method            (string, e.g. "heuristic")
```

**Consumer manifest for (a)** — surfaces that read these fields off `report.factor_sensitivity`, dark on V5 before this fix:

| Consumer | Location | Reads |
|---|---|---|
| Model tab EVPI map (RENDERED) | `src/canvas/components/ModelTabBody.tsx:193,209-217` | `evpi_percentage_points` ?? `value_of_information * 100` → per-node EVPI (UI-SEM-049) |
| Drivers VoI signal (RENDERED) | `src/components/results/useResultsSectionData.ts:358` | `value_of_information` (0-1) |
| Driver-row field set | `src/components/results/useResultsSectionData.ts:1882` | `value_of_information` |
| Pre-analysis guidance | `src/canvas/components/PreAnalysisGuidance.tsx:503` | `value_of_information` |

At least one consumer renders them (ModelTabBody EVPI map / DriversSection VoI) — no new surface invented in this lane.

## F6 — edge E-values read from the wrong nested location

The mapper sourced `report.robustness.edge_e_values` from the **nested** `enrichment.robustness.edge_e_values` — a location PLoT **no longer populates** on the live V5 wire (A3 Codex compute-wave, 19 Jul 2026). PLoT emits `edge_e_values` at the **top level** of enrichment. Every edge consumer reads `report.robustness.edge_e_values`, so E-values rendered empty despite real data on the wire.

- **Wrong (before):** `...(Array.isArray(robustnessRaw.edge_e_values) ? { edge_e_values: robustnessRaw.edge_e_values } : {})` — reads `enrichment.robustness.edge_e_values` (empty on the live wire).
- **Right (after):** source from the real top-level `enrichment.edge_e_values` first, fall back to the legacy nested copy, and **fail closed** (omit) when neither carries a non-empty array. Lands the data where all consumers already read it — single-seam fix.

**Real wire shape + provenance** (same bundle fixture):

```
block.enrichment.edge_e_values           (TOP LEVEL — 6 entries, incl. e_value 2.2528)
block.enrichment.robustness              (present, but carries NO edge_e_values)
```

**Consumers reading `report.robustness.edge_e_values`** (all lit up by the single-seam fix):
`src/canvas/ui/inspector-v2/useAnalysisResults.ts:54` (EdgePanel) · `src/canvas/components/ModelTabBody.tsx:238` · `src/components/results/useResultsSectionData.ts:2491,2958` · `src/canvas/stores/analysisSnapshotFactory.ts:115`

> Note on the older `UI-BOUNDARY-DATA-INVENTORY.md §3.7` ("populated copies live at `robustness.edge_e_values`; the top-level is empty") — that describes the **pre-wave** shape. The authoritative current wire (post A3 Codex compute-wave, per `ORCHESTRATOR-UPDATE-A3-CODEX-WAVE-2026-07-19`) is top-level, matched by the checked-in bundle fixture. The RED test is pinned to the current wire; the legacy nested path is retained as a fallback and covered by an existing test.

## Tests

New: `src/v5/__tests__/mapV5AnalysisToReport.voi-edge-values.spec.ts` (8 tests). RED-first: 5 failed / 3 passed against the unmodified mapper (the 3 passes are the no-defaults, legacy-fallback and fail-closed invariants). All 8 green after the fix. Every pin mutation-checked in a throwaway (scale ×100 → "never scaled" bites; `?? 0` default → "omits when absent" bites; nested-only source → top-level bundle pin bites).

Regression sweep: **4260 passed** across `src/v5`, `src/components/results`, `src/canvas/ui/inspector-v2`, `src/canvas/stores`, `src/canvas/compare-tab`, results-panel-contract. The one failing test (`InspectorCoaching.spec.tsx:162`, a brand-CSS `--info:` regex) is **pre-existing on the untouched base clone** (identical 1 failed / 13 passed at `dc8c3662`), unrelated to this change.

## Typechecks

- **Narrow (gate):** `pnpm typecheck` (`tsc -p tsconfig.ci.json --noEmit`) — clean, exit 0.
- **Full app config:** `tsc -p tsconfig.app.json --noEmit` multiset **identical** to a matched base clone at `dc8c3662` (2317 pre-existing errors both sides; this narrow config is not the gate). Positive control: injecting a deliberate type error into the mapper raised the count and named the file, proving it is in the compile graph.

## Prepush gate

`scripts/validate-prepush.sh`: branch guard, typecheck, lint (changed files), 483 smoke tests all **pass**. The gate's whole-tree Design-System ratchet flags one net-new `#6E6B6B` hex in `src/components/chat/artefactIframeTemplate.ts` — **pre-existing at base `dc8c3662`** and not in this branch's diff (this branch touches only the two V5 files). Not fixed here to keep the P0 change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
