### PR TITLE
fix(persistence): the analysis answer survives reload (journey step 8)

### DIFF
--- a/src/canvas/conversation/__tests__/envelopeAnalysisPersistence.spec.ts
+++ b/src/canvas/conversation/__tests__/envelopeAnalysisPersistence.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Reload persistence — the analysis answer survives reload (journey step 8).
+ *
+ * The RED this pins: a conversation-driven analysis is DISPLAYED in-session
+ * (store.resultsComplete) but was never written to the scenario row's analysis
+ * columns, so on the next page load loadScenario found analysis_status !==
+ * 'ready' and the user's answer was gone — while the graph (autosaved on its
+ * own subscription) survived. The standalone Run path already persisted via
+ * persistAnalysisSuccess → storeAnalysis; the conversation path (the actual
+ * journey) did not.
+ *
+ * These tests exercise handleEnvelope through the real useConversation hook and
+ * assert the WRITE half of the roundtrip: a successful conversation analysis
+ * persists the same V2RunResponse through the same store_analysis_and_log RPC
+ * the Run path uses (scenarioService.storeAnalysis). The READ half — that
+ * hydrateAnalysisFromV2Response reads it back with honest seed provenance and
+ * 'unknown' freshness — is pinned by receipts-persistence-roundtrip.spec.tsx
+ * and analysisFreshness restore tests; together they close the loop.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+
+// ---------------------------------------------------------------------------
+// Mocks (mirror envelopeAnalysisWiring.spec.ts so the two suites move together)
+// ---------------------------------------------------------------------------
+
+const mockCallTurn = vi.fn()
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+vi.mock('../../../flags', () => ({
+  isOrchestratorV2Enabled: () => true,
+  isOrchestratorStreamingEnabled: () => false,
+}))
+
+vi.mock('../../../adapters/plot/v2', () => ({
+  isSuccessfulAnalysis: (r: unknown) => {
+    const res = r as Record<string, unknown>
+    return res.analysis_status === 'computed' || res.analysis_status === 'partial'
+  },
+  isBlockedResponse: (r: unknown) => (r as any).analysis_status === 'blocked',
+  isFailedAnalysis: (r: unknown) => (r as any).analysis_status === 'failed',
+  validateV2RunResponseFull: () => ({ softWarnings: [] }),
+  sanitizeV2RunResponse: (r: unknown) => r, // identity pass-through
+  reconcileOptionsWithCanvasNodes: (analysisReady: any) =>
+    Array.isArray(analysisReady?.options) ? analysisReady.options : [],
+}))
+
+vi.mock('../../../adapters/plot/v2/responseMapper', () => ({
+  mapV2ResponseToReportV1: vi.fn(() => ({ id: 'mock-report', graph_quality: null })),
+  createEnrichmentFromV2Response: () => null,
+  synthesizeCeeReviewFromV2: () => null,
+  synthesizeCeeTraceFromV2: () => null,
+}))
+
+// The unit under test: the conversation analysis path must persist through the
+// SAME service call the Run path uses. Spy on it; identity for loadScenario so
+// unrelated imports stay intact.
+const { mockStoreAnalysis } = vi.hoisted(() => ({
+  mockStoreAnalysis: vi.fn(async () => undefined),
+}))
+vi.mock('../../../services/scenarioService', () => ({
+  storeAnalysis: (...args: unknown[]) => mockStoreAnalysis(...args),
+  loadScenario: vi.fn(async () => null),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeV2Response(
+  hash = 'hash-abc',
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [],
+    critiques: [],
+    response_hash: hash,
+    ...extra,
+  }
+}
+
+const SCENARIO_ID = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockCallTurn.mockReset()
+  mockStoreAnalysis.mockClear()
+
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [],
+    edges: [],
+    results: { status: 'idle', hash: undefined } as any,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    resultsComplete: vi.fn(),
+    resultsError: vi.fn(),
+  } as any)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('reload persistence — conversation analysis is written to the scenario row', () => {
+  it('persists the analysis via storeAnalysis when the envelope carries a fresh analysis_response', async () => {
+    const v2Response = makeV2Response('hash-journey', { meta: { seed_used: '1337' } })
+    mockCallTurn.mockResolvedValue({
+      client_turn_id: 'turn-42',
+      assistant_text: 'Here is your answer.',
+      analysis_response: v2Response,
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Which option should I pick?')
+    })
+
+    // WRITE half of the roundtrip: without this the answer is gone on reload.
+    expect(mockStoreAnalysis).toHaveBeenCalledTimes(1)
+    const [scenarioId, analysis, , seedUsed, responseHash] = mockStoreAnalysis.mock.calls[0]
+    expect(scenarioId).toBe(SCENARIO_ID)
+    expect((analysis as { response_hash?: string }).response_hash).toBe('hash-journey')
+    expect(responseHash).toBe('hash-journey')
+    // Honest seed provenance — the engine echo, parsed null-safe (never 0).
+    expect(seedUsed).toBe(1337)
+  })
+
+  it('passes an HONEST null seed (never a fabricated 0) when the engine echoes no seed', async () => {
+    mockCallTurn.mockResolvedValue({
+      assistant_text: 'Answer.',
+      analysis_response: makeV2Response('hash-no-seed'), // no meta.seed_used
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('run it')
+    })
+
+    expect(mockStoreAnalysis).toHaveBeenCalledTimes(1)
+    const seedUsed = mockStoreAnalysis.mock.calls[0][3]
+    expect(seedUsed).toBeNull()
+    expect(seedUsed).not.toBe(0)
+  })
+
+  it('does NOT persist on a non-analysis turn (no analysis_response)', async () => {
+    mockCallTurn.mockResolvedValue({ assistant_text: 'Sure, updating the graph.' })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Add a risk node')
+    })
+
+    expect(mockStoreAnalysis).not.toHaveBeenCalled()
+  })
+
+  it('does NOT persist a duplicate (response_hash already in the store)', async () => {
+    useCanvasStore.setState({ results: { status: 'complete', hash: 'hash-dup' } as any })
+    mockCallTurn.mockResolvedValue({
+      assistant_text: 'Same answer.',
+      analysis_response: makeV2Response('hash-dup'),
+    })
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('run again')
+    })
+
+    expect(mockStoreAnalysis).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -87,7 +87,7 @@ import type {
 import { MAX_CHIPS_PER_TURN, MAX_SUGGESTED_ACTIONS } from './types'
 import { applyAutoApplyPatch, synthesiseCeeAnalysisReady } from './utils/applyPatch'
 import { applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
-import { loadScenario as loadScenarioFromDb } from '../../services/scenarioService'
+import { loadScenario as loadScenarioFromDb, storeAnalysis } from '../../services/scenarioService'
 import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
 import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
@@ -2312,6 +2312,51 @@ export function useConversation(): UseConversationReturn {
                 source: 'conversation',
               },
             })
+
+            // Journey step 8 — reload persistence. resultsComplete above only
+            // hydrates the IN-SESSION results slice; it does NOT write the
+            // scenario row's analysis columns. The standalone Run path persists
+            // via persistAnalysisSuccess (useV2Run.ts:997 → storeAnalysis), so a
+            // Run-button answer survives a reload — but a conversation-driven
+            // analysis (the actual user journey) never reached that call, so
+            // loadScenario found analysis_status !== 'ready' on reload and the
+            // user's answer was lost while the graph (autosaved on its own
+            // subscription) survived. Persist the same V2RunResponse through the
+            // same store_analysis_and_log RPC the Run path uses, so the existing
+            // hydrateAnalysisFromV2Response → resultsHydrateFromSupabase path
+            // restores it on reload — with the honest 'unknown' freshness that
+            // path already stamps, never a fabricated 'fresh'
+            // (store.resultsHydrateFromSupabase). Seed provenance is the same
+            // T2b null-safe echo used for the mapper above — no fabricated 0.
+            //
+            // Best-effort and fire-and-forget, mirroring the createSnapshot call
+            // below and the "always-on normalised persistence" contract
+            // (threadService header): the write is gated on a scenario id, and a
+            // guest / unauthenticated call fails the RPC's row-level security and
+            // is swallowed here rather than surfacing to the user.
+            if (store.currentScenarioId) {
+              const analysisGraphHash = generateGraphHash(store.nodes, store.edges)
+              void storeAnalysis(
+                store.currentScenarioId,
+                raw,
+                analysisGraphHash,
+                seedUsed,
+                result.response_hash,
+                crypto.randomUUID(),
+                {
+                  option_count: Array.isArray(raw.option_comparison)
+                    ? raw.option_comparison.length
+                    : 0,
+                  analysis_status: raw.analysis_status,
+                  source: 'conversation',
+                },
+                envelope.client_turn_id ?? undefined,
+              ).catch((err) => {
+                if (import.meta.env.DEV) {
+                  console.warn('[handleEnvelope] Supabase analysis persistence failed', err)
+                }
+              })
+            }
 
             // BIL Phase 1: cache assembled analysis summary for subsequent turn requests.
             // Always-on persistence — not gated behind BIL preview flag.


### PR DESCRIPTION
## The defect (journey step 8)

On reload the graph survives but the analysis answer does not — a user who reloads loses their result.

## Why it was lost (diagnosed at the tip, dc8c3662)

The persistence machinery mostly exists and is honest, so the loss is a wiring gap, not a missing subsystem:

- **Graph** is autosaved by its own dedicated subscription in `useScenario` (`saveGraphViaGatedPath`, debounced) and restored on reload via `loadScenario` → `hydrateGraphSlice` (plus a localStorage autosave fallback in `ReactFlowGraph`). So the graph round-trips.
- **Analysis** is persisted by a *separate* call: `persistAnalysisSuccess` → `scenarioService.storeAnalysis` → the `store_analysis_and_log` RPC, which writes the scenario row's `analysis` / `analysis_status='ready'` / `analysis_provenance` columns. That call is made in exactly **one** place — `useV2Run.ts:997`, the standalone **Run** button.
- **The conversation-driven analysis path never made that call.** When the answer arrives through the conversation (the actual journey — CEE returns `envelope.analysis_response` on a propose/decide turn), `handleEnvelope` (`useConversation.ts`) hydrates the **in-session** results slice via `store.resultsComplete(...)` and writes a BIL `createSnapshot`, but never `storeAnalysis`. So the scenario row's analysis columns stay empty.
- On reload, `loadScenario` hydrates analysis only when `row.analysis_status === 'ready' && row.analysis != null`. For a conversation answer that condition is false → `hydrateAnalysisFromV2Response` never runs → the answer is gone, while the separately-autosaved graph remains. Exactly the reported symptom.

This matches the brief's hint: persistence was wired for the Run (V2) path, not for the conversation path.

## What this ships — the analysis-result leg

Wire the **same** `store_analysis_and_log` write into the conversation analysis-completion path in `handleEnvelope`, persisting the same `V2RunResponse` the engine sent. No hydration changes are needed: the existing reload path `loadScenario` → `hydrateAnalysisFromV2Response` → `resultsHydrateFromSupabase` reads it straight back.

- **Freshness honesty (#352):** the fix deliberately reuses `resultsHydrateFromSupabase`, which already stamps `analysisFreshness: { freshness: 'unknown', freshnessReason: 'hydrated_without_capture' }`. Reload restores an **honest** cannot-confirm state — never a fabricated `'fresh'`. No new freshness code.
- **Seed honesty (T2b):** provenance reuses the same null-safe engine echo (`meta.seed_used` parsed, else `null`) already used for the mapper — no fabricated `0`.
- **Best-effort:** the write is fire-and-forget and gated on a scenario id, mirroring the adjacent `createSnapshot` call and the "always-on normalised persistence" contract. A guest / unauthenticated call fails the RPC's RLS and is swallowed, never surfaced.
- The dedup guard (`response_hash === store.results.hash`) already prevents double-writing a hash the Run path persisted.

## What is deliberately NOT in this PR (honest scoping)

- **Conversation-turn persistence.** The machinery exists (`useThreadPersistence` → `appendThreadEntries`; hydrated via `_hydratedThread` → `hydrateMessagesFromThread`) but is gated behind `threadPersist` / `threadHydrate`, which **default off and are not enabled in `netlify.toml`** (neither production `[build.environment]` nor `[context.staging.environment]`). So on the live build conversation turns are neither persisted nor hydrated. Turning them on is a rollout decision — stale-block revalidation against a changed graph, `redaction_state`, session-boundary entries, and the existing 403-suppression story — architecturally bigger than this lane. Options for a follow-up: (a) promote the two flags on staging and soak the existing hydration path; (b) treat the restored analysis result as the reload anchor and reconstruct a minimal conversation header from it; (c) design turn-level redaction/revalidation before enabling. Recommend (a) as the smallest honest next step, gated behind a soak.
- **V5-canonical analysis leg.** `applyV5State` step 5 has the identical in-session-only gap, but its `analysis_result` block maps to a `ReportV1`, not a `V2RunResponse` — persisting it into the `analysis` column would fail `isValidV2RunResponse` on reload. V5 is flag-dark (`VITE_ENABLE_V5_ORCHESTRATOR` / `VITE_V5_CANONICAL_ANALYSIS` unset in `netlify.toml`) and out of the live journey, so it needs its own V2-projection-or-parallel-hydration lane.

## Tests

RED-first. `envelopeAnalysisPersistence.spec.ts` drives `handleEnvelope` through the real `useConversation` hook and asserts the **write** half of the roundtrip: a fresh conversation analysis calls `storeAnalysis` with the analysis + `response_hash` + honest seed; non-analysis and duplicate-hash turns do not.

- Verified RED without the source change (the two "must persist" assertions fail); GREEN with it.
- The **read** half stays pinned by `receipts-persistence-roundtrip.spec.tsx` (unchanged, still green) — together they close the save→reload loop.
- Full `src/canvas/conversation` suite: **1689 passed / 22 skipped**, no regressions. Persistence/hydration set (`hydrateAnalysis`, `useScenario`, `scenarioService`, receipts roundtrip, envelope wiring): **115 passed**.

## Checks

- **Typecheck (branch):** `tsc -p tsconfig.ci.json --noEmit` → exit 0.
- **Typecheck (base origin/staging dc8c3662, separate worktree):** exit 0 — matched clean.
- **validate-prepush.sh:** branch guard, typecheck, lint (changed files), smoke (483 tests), stale-js, dependency audit all pass. The one failing check — Check 8 DS drift, a net-new hex in `src/components/chat/artefactIframeTemplate.ts` — reproduces **identically on the untouched base** and is unrelated to this change (this PR touches no colours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
