### PR TITLE
feat(v5): render held proposals — the R8 card (closes the deliberate 0.15.0 deferral)

### DIFF
--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -53,6 +53,7 @@ import { V5ReviewCardBlock } from '../../v5/blocks/V5ReviewCardBlock'
 import { V5CoachingBlock } from '../../v5/blocks/V5CoachingBlock'
 import { V5EvidenceBlock } from '../../v5/blocks/V5EvidenceBlock'
 import { V5ExerciseBlock } from '../../v5/blocks/V5ExerciseBlock'
+import { V5HeldProposalBlock } from '../../v5/blocks/V5HeldProposalBlock'
 import { V5UnsupportedBlock } from '../../v5/blocks/V5UnsupportedBlock'
 import { safeRichText, plainTextPreview } from '../utils/safeRichText'
 import { isOrchestratorRenderingV2Enabled } from '../../flags'
@@ -102,6 +103,8 @@ function resolveBlockBadgeDotClass(block: ConversationBlock): string | null {
     case 'v5_evidence':
       return block.severity === 'info' ? styles.blockBadgeDotInfo : styles.blockBadgeDotDanger
     case 'v5_exercise': return styles.blockBadgeDotInfo
+    // R8: held proposal is an info-channel proposal card (matches its border).
+    case 'v5_held_proposal': return styles.blockBadgeDotInfo
     default: return null
   }
 }
@@ -446,6 +449,10 @@ function BlockRenderer({
 
     case 'v5_exercise':
       return <V5ExerciseBlock block={block} />
+
+    // R8 (roadmap 2.27): held CEE mutation → honest confirm/dismiss card.
+    case 'v5_held_proposal':
+      return <V5HeldProposalBlock block={block} />
 
     case 'v5_unsupported':
       return <V5UnsupportedBlock block={block} />

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -122,6 +122,7 @@ export type ConversationBlock =
   | V5CoachingBlock
   | V5EvidenceBlock
   | V5ExerciseBlock
+  | V5HeldProposalBlock
   | V5UnsupportedBlock
 
 /**
@@ -313,6 +314,50 @@ export interface V5UnsupportedBlock {
   type: 'v5_unsupported'
   blockType: string
   raw: unknown
+}
+
+/**
+ * R8 (seamless-workspace, roadmap 2.27): a held CEE graph mutation surfaced
+ * as an honest, non-error-styled card (0.18.0 HeldProposalBlockSchema). CEE's
+ * graph-management referee gate holds a structural/tunable mutation pending
+ * the user's go-ahead and emits this block INSTEAD of the error-styled block
+ * the 1.43 fix retired.
+ *
+ * Render-relevant fields only. `summary` is CEE's display-safe description of
+ * the change (rendered verbatim). `reason_code` is code-keyed by design —
+ * mapped to the UI's OWN user-facing copy so the internal-doctrine-prose leak
+ * 1.43 flagged cannot recur; widened to `string` here so a future
+ * held-reachable code passes through to the generic copy without a UI release
+ * (same forward-compat rule as V5BlockTargetRef.kind).
+ *
+ * `confirm` / `decline` are RESOLVED at map time from the response's top-level
+ * `suggested_actions[]` (the schema's `confirm_action_id` / `decline_action_id`
+ * are refs into that array; the block never embeds its own action objects).
+ * The card dispatches `confirm.message` through the existing chip-send seam —
+ * the change is applied by CEE server-side on that turn (single-writer
+ * doctrine, post-#364), never by a client-minted mutation path. `decline` is
+ * optional: CEE does not emit a dedicated decline chip today (the decline path
+ * is free-text), so its absence drives a local-only dismiss.
+ *
+ * Internal identifiers (`proposal_id`, `mutation_class`, `reason_code`, the
+ * `held_proposal` type token) NEVER render as user-facing copy.
+ */
+export interface V5HeldProposalAction {
+  /** Producer-owned chip label (rendered verbatim on the confirm affordance). */
+  label: string
+  /** Message dispatched to CEE when the affordance is taken (the apply turn). */
+  message: string
+}
+
+export interface V5HeldProposalBlock {
+  type: 'v5_held_proposal'
+  /** CEE-internal held handle (gmh_…). Carried for telemetry/data-* only, never rendered. */
+  proposal_id: string
+  summary: string
+  mutation_class: 'structural' | 'tunable'
+  reason_code: string
+  confirm: V5HeldProposalAction
+  decline?: V5HeldProposalAction
 }
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -3399,7 +3399,12 @@ export function useConversation(): UseConversationReturn {
             }
 
             const mappedBlocks =
-              target.kind === 'blocks' ? mapV5Blocks(target.response.blocks) : []
+              target.kind === 'blocks'
+                // Pass suggested_actions so the held-proposal mapper (R8) can
+                // resolve confirm_action_id / decline_action_id refs into the
+                // {label, message} the card dispatches through the chip seam.
+                ? mapV5Blocks(target.response.blocks, target.response.suggested_actions)
+                : []
 
             // Phase 3 rendering bridge (Track C slice 1, D-5) — surface
             // CEE-produced 0.13.x coaching + review_card blocks as typed

--- a/src/v5/__tests__/mapV5Blocks.heldProposal.test.ts
+++ b/src/v5/__tests__/mapV5Blocks.heldProposal.test.ts
@@ -12,7 +12,7 @@
  * cannot drift.
  */
 import { describe, it, expect } from 'vitest'
-import { mapV5Block } from '../blocks/mapV5Blocks'
+import { mapV5Block, mapV5Blocks } from '../blocks/mapV5Blocks'
 import type { OlumiResponse } from '@talchain/schemas/boundary'
 
 type HeldProposalWire = Extract<OlumiResponse['blocks'][number], { type: 'held_proposal' }>
@@ -88,6 +88,16 @@ describe('mapV5Block — held_proposal → v5_held_proposal (R8)', () => {
     // suggested_actions (drift/corruption) — never crash, never vanish.
     const mapped = mapV5Block(heldBlock(), [])
     expect(mapped).toMatchObject({ type: 'v5_unsupported', blockType: 'held_proposal' })
+  })
+
+  it('degrades (never throws) when suggested_actions is null, not just undefined', () => {
+    // The `= []` default only covers undefined. A null must not take the whole
+    // mapper down via `.find()` — it degrades to the R7 unsupported card.
+    const nullActions = null as unknown as undefined
+    expect(() => mapV5Blocks([heldBlock()], nullActions)).not.toThrow()
+    expect(mapV5Blocks([heldBlock()], nullActions)).toMatchObject([
+      { type: 'v5_unsupported', blockType: 'held_proposal' },
+    ])
   })
 
   it('carries only render-relevant fields (wire-only fields are not forwarded)', () => {

--- a/src/v5/__tests__/mapV5Blocks.heldProposal.test.ts
+++ b/src/v5/__tests__/mapV5Blocks.heldProposal.test.ts
@@ -1,0 +1,101 @@
+/**
+ * R8 (roadmap 2.27) — the mapper flip for held_proposal.
+ *
+ * RED baseline (pre-R8, pinned in mapV5Blocks.holds0150.test.ts): a
+ * held_proposal block degraded to v5_unsupported — the deliberate 0.15.0
+ * deferral.
+ *
+ * GREEN (this suite): a held_proposal maps to a self-contained
+ * v5_held_proposal card, resolving its confirm_action_id / decline_action_id
+ * refs against the response's top-level suggested_actions[]. Fail-closed
+ * behaviour (unresolvable confirm) is asserted alongside so the two paths
+ * cannot drift.
+ */
+import { describe, it, expect } from 'vitest'
+import { mapV5Block } from '../blocks/mapV5Blocks'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+type HeldProposalWire = Extract<OlumiResponse['blocks'][number], { type: 'held_proposal' }>
+type ActionWire = OlumiResponse['suggested_actions'][number]
+
+const CONFIRM: ActionWire = {
+  id: 'gmh_ab12cd34ef56',
+  label: 'Continue with this change',
+  message: 'Yes',
+}
+
+const DECLINE: ActionWire = {
+  id: 'gmh_decline_01',
+  label: 'Tell me what to adjust',
+  message: 'Actually, let me adjust it first',
+}
+
+function heldBlock(overrides: Partial<HeldProposalWire> = {}): HeldProposalWire {
+  return {
+    type: 'held_proposal',
+    proposal_id: 'gmh_ab12cd34ef56',
+    summary: 'Add a "regulatory delay" risk feeding into Launch on time',
+    mutation_class: 'structural',
+    reason_code: 'STRUCTURAL_APPLY_HELD',
+    confirm_action_id: CONFIRM.id,
+    ...overrides,
+  } as HeldProposalWire
+}
+
+describe('mapV5Block — held_proposal → v5_held_proposal (R8)', () => {
+  it('maps a well-formed block to the card, resolving the confirm ref verbatim', () => {
+    const mapped = mapV5Block(heldBlock(), [CONFIRM])
+    expect(mapped).toEqual({
+      type: 'v5_held_proposal',
+      proposal_id: 'gmh_ab12cd34ef56',
+      summary: 'Add a "regulatory delay" risk feeding into Launch on time',
+      mutation_class: 'structural',
+      reason_code: 'STRUCTURAL_APPLY_HELD',
+      confirm: { label: 'Continue with this change', message: 'Yes' },
+    })
+  })
+
+  it('resolves an optional decline ref when present in suggested_actions', () => {
+    const mapped = mapV5Block(
+      heldBlock({ decline_action_id: DECLINE.id }),
+      [CONFIRM, DECLINE],
+    )
+    expect(mapped).toMatchObject({
+      type: 'v5_held_proposal',
+      decline: { label: 'Tell me what to adjust', message: 'Actually, let me adjust it first' },
+    })
+  })
+
+  it('omits decline when decline_action_id is present but unresolvable (local dismiss)', () => {
+    const mapped = mapV5Block(
+      heldBlock({ decline_action_id: 'gmh_missing' }),
+      [CONFIRM],
+    )
+    expect(mapped).toMatchObject({ type: 'v5_held_proposal' })
+    expect(mapped).not.toHaveProperty('decline')
+  })
+
+  it('passes an unknown/future reason_code through verbatim (widened, no UI release)', () => {
+    const mapped = mapV5Block(
+      heldBlock({ reason_code: 'SOME_FUTURE_HELD_CODE' as HeldProposalWire['reason_code'] }),
+      [CONFIRM],
+    )
+    expect(mapped).toMatchObject({ reason_code: 'SOME_FUTURE_HELD_CODE' })
+  })
+
+  it('fails closed to the R7 unsupported card when the confirm ref cannot be resolved', () => {
+    // Confirm chip is schema-guaranteed present but its ref is not in
+    // suggested_actions (drift/corruption) — never crash, never vanish.
+    const mapped = mapV5Block(heldBlock(), [])
+    expect(mapped).toMatchObject({ type: 'v5_unsupported', blockType: 'held_proposal' })
+  })
+
+  it('carries only render-relevant fields (wire-only fields are not forwarded)', () => {
+    // An unknown future field on the wire block is ignored; the wire-only
+    // confirm_action_id ref is consumed (resolved into `confirm`), not echoed.
+    const wireWithExtra = { ...heldBlock(), some_future_field: 'ignored' } as unknown as HeldProposalWire
+    const mapped = mapV5Block(wireWithExtra, [CONFIRM]) as unknown as Record<string, unknown>
+    expect(mapped).not.toHaveProperty('some_future_field')
+    expect(mapped).not.toHaveProperty('confirm_action_id')
+  })
+})

--- a/src/v5/__tests__/mapV5Blocks.holds0150.test.ts
+++ b/src/v5/__tests__/mapV5Blocks.holds0150.test.ts
@@ -1,23 +1,46 @@
 /**
- * 0.15.0 re-vendor pin: the two new wave block kinds are KNOWN and
- * deliberately deferred — they must degrade to v5_unsupported (the R7
- * honest fallback), not crash the mapper and not silently drop. R8 (held
- * proposal card) and R4 (ui_directive dispatcher) replace these paths.
+ * 0.15.0 re-vendor pin, updated for R8.
+ *
+ * ui_directive remains KNOWN-and-deferred (R4's lane) — SILENTLY skipped per
+ * its schema-specified degrade (advisory polish, never content).
+ *
+ * held_proposal is NO LONGER deferred: R8 renders the card. It still degrades
+ * to the R7 v5_unsupported fallback when its confirm ref cannot be resolved
+ * from suggested_actions — the fail-closed path pinned below. The GREEN card
+ * mapping lives in mapV5Blocks.heldProposal.test.ts.
  */
 import { describe, it, expect } from 'vitest'
 import { mapV5Block } from '../blocks/mapV5Blocks'
 
-describe('mapV5Blocks — 0.15.0 kinds deferred to v5_unsupported', () => {
-  it('held_proposal degrades to the unsupported wrapper', () => {
-    const mapped = mapV5Block({
-      type: 'held_proposal',
-      proposal_id: 'p1',
-      summary: 'Held: structural change awaiting confirmation',
-      mutation_class: 'structural',
-      reason_code: 'STRUCTURAL_APPLY_HELD',
-      confirm_action_id: 'a1',
-    } as never)
+describe('mapV5Blocks — 0.15.0 kinds', () => {
+  it('held_proposal fails closed to the unsupported wrapper when the confirm ref is unresolvable', () => {
+    const mapped = mapV5Block(
+      {
+        type: 'held_proposal',
+        proposal_id: 'p1',
+        summary: 'Held: structural change awaiting confirmation',
+        mutation_class: 'structural',
+        reason_code: 'STRUCTURAL_APPLY_HELD',
+        confirm_action_id: 'a1',
+      } as never,
+      [], // no suggested_actions → confirm 'a1' cannot resolve
+    )
     expect(mapped).toMatchObject({ type: 'v5_unsupported', blockType: 'held_proposal' })
+  })
+
+  it('held_proposal renders the card when the confirm ref resolves', () => {
+    const mapped = mapV5Block(
+      {
+        type: 'held_proposal',
+        proposal_id: 'p1',
+        summary: 'Held: structural change awaiting confirmation',
+        mutation_class: 'structural',
+        reason_code: 'STRUCTURAL_APPLY_HELD',
+        confirm_action_id: 'a1',
+      } as never,
+      [{ id: 'a1', label: 'Continue with this change', message: 'Yes' }],
+    )
+    expect(mapped).toMatchObject({ type: 'v5_held_proposal' })
   })
 
   it('ui_directive is SILENTLY skipped (the schema-specified degrade: advisory polish, never content)', () => {

--- a/src/v5/blocks/V5HeldProposalBlock.tsx
+++ b/src/v5/blocks/V5HeldProposalBlock.tsx
@@ -31,8 +31,11 @@
  * Lucide only, typography tokens, British English, no em dashes.
  *
  * Fail-closed: `_sendChip` unavailable (no conversation host registered) → the
- * confirm click is a safe no-op. Malformed blocks never reach here — the
- * mapper degrades an unresolvable confirm ref to the R7 unsupported card.
+ * confirm click is a safe no-op AND the card does not acknowledge, because
+ * nothing was sent; the affordance stays live so the user can confirm once a
+ * host registers. Malformed blocks never reach here — the mapper degrades an
+ * unresolvable confirm ref to the R7 unsupported card. Unknown `reason_code`
+ * values degrade to the generic held sentence, never the raw code.
  */
 import { type ReactElement, useCallback, useState } from 'react'
 import { Hand } from 'lucide-react'
@@ -70,11 +73,21 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
 
   const { confirm, decline } = block
 
+  /** Visible dismiss text: the producer's decline label when CEE emits one. */
+  const dismissLabel = decline ? decline.label : HELD_PROPOSAL_DISMISS_LABEL
+
   const handleConfirm = useCallback(() => {
     if (settled) return
+    // Fail closed WITHOUT acknowledging: with no conversation host registered
+    // there is nothing to send, and "Sent for you to apply." would be a false
+    // claim. Return early so the affordance stays live and the user can confirm
+    // once a host registers (the EvidenceBlock "Apply to model" precedent —
+    // InlineBlocks `if (!sendChip) return`). Re-firing is already bounded by the
+    // `settled` guard above on the success path.
+    if (!sendChip) return
     // Single-writer apply path: send the producer's confirm message as a turn;
     // CEE applies the held mutation server-side. No client-minted mutation.
-    sendChip?.(confirm.label, confirm.message)
+    sendChip(confirm.label, confirm.message)
     setSettled('accepted')
   }, [settled, sendChip, confirm.label, confirm.message])
 
@@ -127,11 +140,16 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
           <button
             type="button"
             onClick={handleDismiss}
-            aria-label="Dismiss this proposed change"
+            // WCAG 2.5.3 "Label in Name": the accessible name must CONTAIN the
+            // visible label, or speech input cannot activate the control by its
+            // visible words. Built with the ratified SuggestedChips construction
+            // (`${prefix}: ${label}`), so it holds for the producer's decline
+            // label too, not just the UI-owned default.
+            aria-label={`Dismiss: ${dismissLabel}`}
             className={CHIP_CLASS}
             data-testid="v5-held-proposal-dismiss"
           >
-            {decline ? decline.label : HELD_PROPOSAL_DISMISS_LABEL}
+            {dismissLabel}
           </button>
         </div>
       ) : (

--- a/src/v5/blocks/V5HeldProposalBlock.tsx
+++ b/src/v5/blocks/V5HeldProposalBlock.tsx
@@ -1,0 +1,150 @@
+/**
+ * V5HeldProposalBlock — renders a held CEE graph mutation as an honest,
+ * non-error-styled card (R8, seamless-workspace roadmap 2.27; 0.18.0
+ * HeldProposalBlockSchema).
+ *
+ * The card shows the held proposal honestly:
+ *   - WHAT is proposed: `summary`, the producer's display-safe description,
+ *     rendered verbatim (the UI adds no interpretation).
+ *   - WHY it is held: the UI's own copy for `reason_code`
+ *     (heldProposalReasonText). The raw code, `mutation_class`, `proposal_id`
+ *     and the `held_proposal` token NEVER render as user-facing copy — they
+ *     ride as data-* attributes only. This is the whole point of the 1.43
+ *     fix: no internal-doctrine-prose leak.
+ *   - THE USER'S ACTIONS: confirm + dismiss.
+ *
+ * Action routing (EXISTING seams only — single-writer doctrine, post-#364):
+ *   - Confirm dispatches the resolved suggested-action `message` through the
+ *     guidance store's `_sendChip(label, message)` seam — the SAME chip-send
+ *     path EvidenceBlock's "Apply to model" uses. That sends the message as a
+ *     turn; CEE applies the held mutation server-side on that turn. The card
+ *     mints NO client-side graph mutation.
+ *   - Dismiss dispatches the resolved decline action's message when CEE emits
+ *     one; otherwise it is a local-only dismiss (the ProposalBlockRenderer
+ *     "Cancel" idiom — mark settled, no turn).
+ *
+ * DS: this is a proposal / action card, so it uses the ratified full-border
+ * V5 card recipe (`bg-panel` + `border border-info/30`, DESIGN_SYSTEM.md
+ * "Patterns"), matching V5CoachingBlock's `default` variant — NOT the
+ * left-border coaching recipe (reserved for facilitator coaching). Confirm /
+ * dismiss use the ratified suggested-action chip idiom (SuggestedChips).
+ * Lucide only, typography tokens, British English, no em dashes.
+ *
+ * Fail-closed: `_sendChip` unavailable (no conversation host registered) → the
+ * confirm click is a safe no-op. Malformed blocks never reach here — the
+ * mapper degrades an unresolvable confirm ref to the R7 unsupported card.
+ */
+import { type ReactElement, useCallback, useState } from 'react'
+import { Hand } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import { useGuidanceStore } from '../../canvas/stores/guidanceStore'
+import type { V5HeldProposalBlock as V5HeldProposalBlockType } from '../../canvas/conversation/types'
+import {
+  heldProposalReasonText,
+  HELD_PROPOSAL_HEADING,
+  HELD_PROPOSAL_DISMISS_LABEL,
+  HELD_PROPOSAL_CONFIRMED_ACK,
+  HELD_PROPOSAL_DISMISSED_ACK,
+} from './heldProposalReasonCopy'
+
+export interface V5HeldProposalBlockProps {
+  block: V5HeldProposalBlockType
+}
+
+/** Ratified suggested-action chip idiom (SuggestedChips.tsx), verbatim. */
+const CHIP_CLASS = [
+  'inline-flex items-center gap-1.5',
+  'bg-panel border border-panel-border rounded-full',
+  'px-4 py-2 min-h-[44px]',
+  'hover:bg-panel-hover active:bg-panel-border/30',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-2',
+  'text-text-body cursor-pointer font-sans',
+  typography.bodySmall,
+  'disabled:opacity-40 disabled:pointer-events-none',
+  'transition-colors duration-200',
+].join(' ')
+
+export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactElement {
+  const sendChip = useGuidanceStore((s) => s._sendChip)
+  const [settled, setSettled] = useState<null | 'accepted' | 'dismissed'>(null)
+
+  const { confirm, decline } = block
+
+  const handleConfirm = useCallback(() => {
+    if (settled) return
+    // Single-writer apply path: send the producer's confirm message as a turn;
+    // CEE applies the held mutation server-side. No client-minted mutation.
+    sendChip?.(confirm.label, confirm.message)
+    setSettled('accepted')
+  }, [settled, sendChip, confirm.label, confirm.message])
+
+  const handleDismiss = useCallback(() => {
+    if (settled) return
+    // Decline through the existing chip seam when CEE emits a decline action;
+    // otherwise dismiss is local-only (the free-text decline path stays open).
+    if (decline) sendChip?.(decline.label, decline.message)
+    setSettled('dismissed')
+  }, [settled, sendChip, decline])
+
+  return (
+    <div
+      data-testid="v5-held-proposal"
+      data-block-id={block.proposal_id}
+      data-mutation-class={block.mutation_class}
+      data-reason-code={block.reason_code}
+      data-settled={settled ?? undefined}
+      className="rounded-xl border border-info/30 bg-panel p-4 space-y-2"
+    >
+      <div className="flex items-start gap-2">
+        <Hand size={16} className="flex-none mt-0.5 text-info" aria-hidden="true" />
+        <h3 className={typography.panelHeader} data-testid="v5-held-proposal-heading">
+          {HELD_PROPOSAL_HEADING}
+        </h3>
+      </div>
+
+      <p className={typography.panelBody} data-testid="v5-held-proposal-summary">
+        {block.summary}
+      </p>
+
+      <p
+        className={`${typography.panelMeta} text-text-light`}
+        data-testid="v5-held-proposal-reason"
+      >
+        {heldProposalReasonText(block.reason_code)}
+      </p>
+
+      {settled === null ? (
+        <div className="flex flex-wrap gap-2 pt-1" data-testid="v5-held-proposal-actions">
+          <button
+            type="button"
+            onClick={handleConfirm}
+            aria-label={confirm.label}
+            className={CHIP_CLASS}
+            data-testid="v5-held-proposal-confirm"
+          >
+            {confirm.label}
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss this proposed change"
+            className={CHIP_CLASS}
+            data-testid="v5-held-proposal-dismiss"
+          >
+            {decline ? decline.label : HELD_PROPOSAL_DISMISS_LABEL}
+          </button>
+        </div>
+      ) : (
+        <p
+          className={`${typography.panelMeta} text-text-light`}
+          data-testid="v5-held-proposal-settled"
+          role="status"
+        >
+          {settled === 'accepted' ? HELD_PROPOSAL_CONFIRMED_ACK : HELD_PROPOSAL_DISMISSED_ACK}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default V5HeldProposalBlock

--- a/src/v5/blocks/__tests__/V5HeldProposalBlock.spec.tsx
+++ b/src/v5/blocks/__tests__/V5HeldProposalBlock.spec.tsx
@@ -1,0 +1,133 @@
+/**
+ * R8 (roadmap 2.27) — DOM + wiring contract for the held-proposal card.
+ *
+ * Contract:
+ *   - WHAT: producer `summary` rendered verbatim.
+ *   - WHY: UI copy for reason_code (raw literal pinned here per
+ *     DESIGN_SYSTEM.md "Canonical State Copy" — a reworded constant must not
+ *     silently drift from the sentence the test promises).
+ *   - No internal vocabulary in visible text: the `held_proposal` token, raw
+ *     reason_code, mutation_class, and proposal_id ride as data-* only.
+ *   - Confirm routes through the guidance store `_sendChip` seam (single
+ *     writer); dismiss dispatches the decline action when present, else is
+ *     local-only. Fail-closed when `_sendChip` is unavailable.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { V5HeldProposalBlock } from '../V5HeldProposalBlock'
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import type { V5HeldProposalBlock as V5HeldProposalBlockType } from '../../../canvas/conversation/types'
+
+const BLOCK: V5HeldProposalBlockType = {
+  type: 'v5_held_proposal',
+  proposal_id: 'gmh_ab12cd34ef56',
+  summary: 'Add a "regulatory delay" risk feeding into Launch on time',
+  mutation_class: 'structural',
+  reason_code: 'STRUCTURAL_APPLY_HELD',
+  confirm: { label: 'Continue with this change', message: 'Yes' },
+}
+
+const STRUCTURAL_HELD_SENTENCE =
+  'This reshapes your model, so it needs your go-ahead before it is applied.'
+
+beforeEach(() => {
+  useGuidanceStore.setState({ _sendChip: null })
+})
+
+describe('V5HeldProposalBlock', () => {
+  it('renders the producer summary verbatim and the humanised held reason', () => {
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    expect(screen.getByTestId('v5-held-proposal-summary')).toHaveTextContent(BLOCK.summary)
+    expect(screen.getByTestId('v5-held-proposal-reason')).toHaveTextContent(
+      STRUCTURAL_HELD_SENTENCE,
+    )
+    expect(screen.getByTestId('v5-held-proposal-heading')).toHaveTextContent(
+      'Waiting for your go-ahead',
+    )
+  })
+
+  it('renders the producer confirm label verbatim and a UI-owned dismiss label', () => {
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    expect(screen.getByTestId('v5-held-proposal-confirm')).toHaveTextContent(
+      'Continue with this change',
+    )
+    expect(screen.getByTestId('v5-held-proposal-dismiss')).toHaveTextContent('Not now')
+  })
+
+  it('never renders internal vocabulary as visible text', () => {
+    const { container } = render(<V5HeldProposalBlock block={BLOCK} />)
+    const visible = container.textContent ?? ''
+    expect(visible).not.toContain('held_proposal')
+    expect(visible).not.toContain('STRUCTURAL_APPLY_HELD')
+    expect(visible).not.toContain('mutation_class')
+    expect(visible).not.toContain('structural')
+    expect(visible).not.toContain('gmh_ab12cd34ef56')
+  })
+
+  it('carries internal identifiers as data-* attributes only', () => {
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    const card = screen.getByTestId('v5-held-proposal')
+    expect(card).toHaveAttribute('data-block-id', 'gmh_ab12cd34ef56')
+    expect(card).toHaveAttribute('data-mutation-class', 'structural')
+    expect(card).toHaveAttribute('data-reason-code', 'STRUCTURAL_APPLY_HELD')
+  })
+
+  it('confirm dispatches the producer message through the _sendChip seam (single writer)', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip })
+    render(<V5HeldProposalBlock block={BLOCK} />)
+
+    fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
+
+    expect(sendChip).toHaveBeenCalledTimes(1)
+    expect(sendChip).toHaveBeenCalledWith('Continue with this change', 'Yes')
+    // Settled: actions replaced by an honest acknowledgement (no "applied" claim).
+    expect(screen.queryByTestId('v5-held-proposal-actions')).toBeNull()
+    expect(screen.getByTestId('v5-held-proposal-settled')).toHaveTextContent('Sent for you to apply.')
+  })
+
+  it('does not double-dispatch on a second confirm click', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip })
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    const btn = screen.getByTestId('v5-held-proposal-confirm')
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    expect(sendChip).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismiss with no decline action is local-only (no turn sent)', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip })
+    render(<V5HeldProposalBlock block={BLOCK} />)
+
+    fireEvent.click(screen.getByTestId('v5-held-proposal-dismiss'))
+
+    expect(sendChip).not.toHaveBeenCalled()
+    expect(screen.getByTestId('v5-held-proposal-settled')).toHaveTextContent('Dismissed.')
+  })
+
+  it('dismiss dispatches the decline action when CEE emits one', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip })
+    render(
+      <V5HeldProposalBlock
+        block={{ ...BLOCK, decline: { label: 'Adjust it first', message: 'Let me adjust' } }}
+      />,
+    )
+    expect(screen.getByTestId('v5-held-proposal-dismiss')).toHaveTextContent('Adjust it first')
+
+    fireEvent.click(screen.getByTestId('v5-held-proposal-dismiss'))
+
+    expect(sendChip).toHaveBeenCalledWith('Adjust it first', 'Let me adjust')
+  })
+
+  it('fails closed when _sendChip is unavailable (confirm is a safe no-op)', () => {
+    useGuidanceStore.setState({ _sendChip: null })
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    expect(() => fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))).not.toThrow()
+    // Still settles so the affordance cannot be re-fired endlessly.
+    expect(screen.getByTestId('v5-held-proposal-settled')).toBeTruthy()
+  })
+})

--- a/src/v5/blocks/__tests__/V5HeldProposalBlock.spec.tsx
+++ b/src/v5/blocks/__tests__/V5HeldProposalBlock.spec.tsx
@@ -13,10 +13,15 @@
  *     local-only. Fail-closed when `_sendChip` is unavailable.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 
 import { V5HeldProposalBlock } from '../V5HeldProposalBlock'
 import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import {
+  heldProposalReasonText,
+  HELD_PROPOSAL_REASON_COPY,
+  REASON_HELD_GENERIC,
+} from '../heldProposalReasonCopy'
 import type { V5HeldProposalBlock as V5HeldProposalBlockType } from '../../../canvas/conversation/types'
 
 const BLOCK: V5HeldProposalBlockType = {
@@ -123,11 +128,111 @@ describe('V5HeldProposalBlock', () => {
     expect(sendChip).toHaveBeenCalledWith('Adjust it first', 'Let me adjust')
   })
 
-  it('fails closed when _sendChip is unavailable (confirm is a safe no-op)', () => {
+  // NOTE: this replaces an earlier pin that asserted the card STILL settled when
+  // `_sendChip` was null, rationale "so the affordance cannot be re-fired
+  // endlessly". That rationale is already served by the `settled` guard on the
+  // success path (see the double-dispatch pin above), and settling on a null
+  // seam produced a FALSE acknowledgement: "Sent for you to apply." when nothing
+  // was sent, with the affordance burned and no retry. `_sendChip` is null by
+  // default (guidanceStore initial state) and again on host teardown, so the
+  // window is reachable. We adopt the EvidenceBlock precedent instead
+  // (InlineBlocks `handleApplyToModel`: `if (!sendChip) return`).
+  it('confirm with no _sendChip seam sends nothing and does NOT acknowledge', () => {
     useGuidanceStore.setState({ _sendChip: null })
     render(<V5HeldProposalBlock block={BLOCK} />)
+
     expect(() => fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))).not.toThrow()
-    // Still settles so the affordance cannot be re-fired endlessly.
-    expect(screen.getByTestId('v5-held-proposal-settled')).toBeTruthy()
+
+    // Nothing was sent, so the card must not claim it was.
+    expect(screen.queryByTestId('v5-held-proposal-settled')).toBeNull()
+    // …and the affordance stays live rather than being burned.
+    expect(screen.getByTestId('v5-held-proposal-actions')).toBeTruthy()
+    expect(screen.getByTestId('v5-held-proposal-confirm')).toBeTruthy()
+  })
+
+  it('confirm still works after a host registers late (the affordance was not burned)', () => {
+    useGuidanceStore.setState({ _sendChip: null })
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
+
+    // A conversation host registers after the first (no-op) click. act() so the
+    // subscribed component re-renders with the live seam before the next click.
+    const sendChip = vi.fn()
+    act(() => {
+      useGuidanceStore.setState({ _sendChip: sendChip })
+    })
+    fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
+
+    expect(sendChip).toHaveBeenCalledTimes(1)
+    expect(sendChip).toHaveBeenCalledWith('Continue with this change', 'Yes')
+    expect(screen.getByTestId('v5-held-proposal-settled')).toHaveTextContent(
+      'Sent for you to apply.',
+    )
+  })
+
+  // -------------------------------------------------------------------------
+  // WCAG 2.5.3 "Label in Name" (Level A): the accessible name must CONTAIN the
+  // visible label, so a speech-input user saying the visible words activates the
+  // control. Construction matches the ratified SuggestedChips idiom
+  // (`${prefix}: ${label}`), which always contains the visible label.
+  // -------------------------------------------------------------------------
+  it('confirm accessible name contains its visible label (WCAG 2.5.3)', () => {
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    const confirm = screen.getByTestId('v5-held-proposal-confirm')
+    const visible = confirm.textContent ?? ''
+    expect(visible).toBe('Continue with this change')
+    expect(confirm.getAttribute('aria-label') ?? '').toContain(visible)
+  })
+
+  it('dismiss accessible name contains its visible label (WCAG 2.5.3, UI-owned label)', () => {
+    render(<V5HeldProposalBlock block={BLOCK} />)
+    const dismiss = screen.getByTestId('v5-held-proposal-dismiss')
+    const visible = dismiss.textContent ?? ''
+    expect(visible).toBe('Not now')
+    expect(dismiss.getAttribute('aria-label') ?? '').toContain(visible)
+  })
+
+  it('dismiss accessible name contains the PRODUCER decline label (WCAG 2.5.3)', () => {
+    render(
+      <V5HeldProposalBlock
+        block={{ ...BLOCK, decline: { label: 'Adjust it first', message: 'Let me adjust' } }}
+      />,
+    )
+    const dismiss = screen.getByTestId('v5-held-proposal-dismiss')
+    const visible = dismiss.textContent ?? ''
+    expect(visible).toBe('Adjust it first')
+    expect(dismiss.getAttribute('aria-label') ?? '').toContain(visible)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fail-closed reason copy. The block still renders honestly for a code the UI
+// has never seen, and the raw code NEVER reaches user-facing copy — that is the
+// whole point of the code-keyed enum (no internal-doctrine-prose leak, 1.43).
+// ---------------------------------------------------------------------------
+describe('heldProposalReasonText fail-closed fallback', () => {
+  const UNKNOWN_CODE = 'SOME_FUTURE_HOLD_CODE_V9'
+
+  it('resolves an unknown code to the generic held sentence, not the raw code', () => {
+    const text = heldProposalReasonText(UNKNOWN_CODE)
+    expect(text).toBe(REASON_HELD_GENERIC)
+    expect(text).not.toContain(UNKNOWN_CODE)
+  })
+
+  it('resolves every pinned code to its own sentence, never echoing the code', () => {
+    for (const [code, sentence] of Object.entries(HELD_PROPOSAL_REASON_COPY)) {
+      expect(heldProposalReasonText(code)).toBe(sentence)
+      expect(heldProposalReasonText(code)).not.toContain(code)
+    }
+  })
+
+  it('renders the generic sentence for an unknown code and never leaks the raw code', () => {
+    const { container } = render(
+      <V5HeldProposalBlock block={{ ...BLOCK, reason_code: UNKNOWN_CODE }} />,
+    )
+    expect(screen.getByTestId('v5-held-proposal-reason')).toHaveTextContent(REASON_HELD_GENERIC)
+    expect(container.textContent ?? '').not.toContain(UNKNOWN_CODE)
+    // The code still rides as a data-* attribute (telemetry), just not as copy.
+    expect(screen.getByTestId('v5-held-proposal')).toHaveAttribute('data-reason-code', UNKNOWN_CODE)
   })
 })

--- a/src/v5/blocks/heldProposalReasonCopy.ts
+++ b/src/v5/blocks/heldProposalReasonCopy.ts
@@ -1,0 +1,75 @@
+/**
+ * heldProposalReasonCopy — user-facing copy for a held CEE graph mutation.
+ *
+ * The 0.18.0 HeldProposalBlockSchema carries `reason_code` as a code-keyed
+ * enum ON PURPOSE: "a consumer maps each code to its OWN user-facing copy, so
+ * the internal-doctrine-prose leak 1.43 flagged in `blocker_readable` cannot
+ * recur through this block" (schema doctrine note). This module IS that
+ * mapping for the UI.
+ *
+ * Rules (DESIGN_SYSTEM.md "Canonical State Copy"):
+ *   - Every sentence is an exported constant, so chat/panel/card cannot drift.
+ *   - British English, no em dashes, no internal vocabulary. The card never
+ *     renders the raw code, `mutation_class`, or the `held_proposal` token.
+ *   - Unknown / future codes fall through to REASON_HELD_GENERIC — the block
+ *     still renders honestly (fail-closed), no UI release needed to add a code.
+ *   - Each sentence states only WHY the change is waiting. It makes no claim
+ *     about the change's content (that is the producer's `summary`) and no
+ *     claim that it has been applied.
+ */
+
+/** Verbatim held-reason sentences, keyed by the 0.18.0 reason_code enum. */
+export const HELD_PROPOSAL_REASON_COPY = {
+  STRUCTURAL_APPLY_HELD:
+    'This reshapes your model, so it needs your go-ahead before it is applied.',
+  TUNABLE_APPLY_HELD:
+    'This adjusts a value in your model, so it needs your go-ahead before it is applied.',
+  REMOVE_UNCONFIRMED:
+    'This removes something from your model, so it needs your confirmation first.',
+  ADD_OPTION_APPLY_UNWIRED:
+    'This adds an option that is not yet connected to your model, so it needs your confirmation first.',
+  OPTION_TOP_LEVEL_OPTIONS_DIVERGENCE:
+    'This changes how your options are organised, so it needs your confirmation first.',
+  FRAME_UNAVAILABLE:
+    'The current decision framing could not be read, so this change is waiting for your confirmation.',
+  CURRENT_GRAPH_UNREADABLE:
+    'The current model could not be read cleanly, so this change is waiting for your confirmation.',
+  CLASSIFY_FAILED:
+    'This change could not be sorted automatically, so it is waiting for your confirmation.',
+} as const
+
+/** Fallback for any code outside the pinned set (future / unknown). */
+export const REASON_HELD_GENERIC =
+  'This change is waiting for your confirmation before it is applied.'
+
+/**
+ * Resolve a reason_code to its user-facing sentence. Never throws: an unknown
+ * code returns the generic held sentence, so a producer that mints a new code
+ * degrades to honest copy rather than a blank or a raw token.
+ */
+export function heldProposalReasonText(reasonCode: string): string {
+  return (
+    (HELD_PROPOSAL_REASON_COPY as Record<string, string>)[reasonCode] ??
+    REASON_HELD_GENERIC
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Card chrome copy (fixed, UI-owned — never producer text).
+// ---------------------------------------------------------------------------
+
+/** Card heading. States the situation, makes no claim about the change. */
+export const HELD_PROPOSAL_HEADING = 'Waiting for your go-ahead'
+
+/** UI-owned dismiss affordance label (the confirm label is the producer's). */
+export const HELD_PROPOSAL_DISMISS_LABEL = 'Not now'
+
+/**
+ * Acknowledgement shown after the user confirms. States the user's action, not
+ * the outcome: the change is applied by CEE on the next turn, so the card must
+ * not claim it is already applied.
+ */
+export const HELD_PROPOSAL_CONFIRMED_ACK = 'Sent for you to apply.'
+
+/** Acknowledgement shown after the user dismisses. */
+export const HELD_PROPOSAL_DISMISSED_ACK = 'Dismissed.'

--- a/src/v5/blocks/mapV5Blocks.ts
+++ b/src/v5/blocks/mapV5Blocks.ts
@@ -29,7 +29,18 @@ import type { ConversationBlock } from '../../canvas/conversation/types'
 
 type V5Block = OlumiResponse['blocks'][number]
 
-export function mapV5Block(block: V5Block): ConversationBlock | null {
+/**
+ * Top-level suggested action (wire ActionSchema: id + label + message).
+ * `held_proposal` blocks reference these by id for their confirm/decline
+ * affordances; the mapper resolves the ref to {label, message} at map time so
+ * the rendered block is self-contained.
+ */
+type SuggestedActionRef = OlumiResponse['suggested_actions'][number]
+
+export function mapV5Block(
+  block: V5Block,
+  suggestedActions: readonly SuggestedActionRef[] = [],
+): ConversationBlock | null {
   switch (block.type) {
     case 'text':
       // CEE emits text blocks primarily as inline commentary alongside
@@ -159,16 +170,33 @@ export function mapV5Block(block: V5Block): ConversationBlock | null {
         target_refs: block.target_refs,
         freshness: block.freshness,
       }
-    case 'held_proposal':
-      // 0.15.0 wave: KNOWN kind, deliberately not rendered yet — R8 builds
-      // the held-proposal card (producer-dormant as of this re-vendor).
-      // It is real content, so until R8 lands it degrades to the honest
-      // unsupported card (R7) rather than dropping silently.
-      return {
-        type: 'v5_unsupported',
-        blockType: block.type,
-        raw: block,
+    case 'held_proposal': {
+      // R8 (roadmap 2.27): render the held CEE mutation as an honest card.
+      // The confirm/decline affordances are refs into the response's
+      // top-level suggested_actions[] — resolve them here so the rendered
+      // block is self-contained. The confirm chip is ALWAYS present on the
+      // wire (every held verdict carries one); if it cannot be resolved the
+      // block is drifted/corrupt, so fail closed to the R7 unsupported card
+      // (never crash, never vanish). decline is optional today (CEE's decline
+      // path is free-text) — an absent or unresolvable decline_action_id
+      // simply drives a local-only dismiss in the renderer.
+      const confirm = suggestedActions.find((a) => a.id === block.confirm_action_id)
+      if (!confirm) {
+        return { type: 'v5_unsupported', blockType: block.type, raw: block }
       }
+      const decline = block.decline_action_id
+        ? suggestedActions.find((a) => a.id === block.decline_action_id)
+        : undefined
+      return {
+        type: 'v5_held_proposal',
+        proposal_id: block.proposal_id,
+        summary: block.summary,
+        mutation_class: block.mutation_class,
+        reason_code: block.reason_code,
+        confirm: { label: confirm.label, message: confirm.message },
+        ...(decline ? { decline: { label: decline.label, message: decline.message } } : {}),
+      }
+    }
     case 'ui_directive':
       // 0.15.0 wave: KNOWN kind, dispatcher is R4's lane. Directives are
       // advisory presentation hints whose SCHEMA-SPECIFIED degrade is
@@ -198,10 +226,13 @@ export function mapV5Block(block: V5Block): ConversationBlock | null {
  * filtering out nulls (fatal errors routed via typed_error; advisory
  * warn/info errors intentionally absent from chat surface).
  */
-export function mapV5Blocks(blocks: V5Block[]): ConversationBlock[] {
+export function mapV5Blocks(
+  blocks: V5Block[],
+  suggestedActions: readonly SuggestedActionRef[] = [],
+): ConversationBlock[] {
   const out: ConversationBlock[] = []
   for (const b of blocks) {
-    const mapped = mapV5Block(b)
+    const mapped = mapV5Block(b, suggestedActions)
     if (mapped) out.push(mapped)
   }
   return out

--- a/src/v5/blocks/mapV5Blocks.ts
+++ b/src/v5/blocks/mapV5Blocks.ts
@@ -230,9 +230,15 @@ export function mapV5Blocks(
   blocks: V5Block[],
   suggestedActions: readonly SuggestedActionRef[] = [],
 ): ConversationBlock[] {
+  // The `= []` default only covers `undefined`. A null (schema drift, or a
+  // caller bypassing the parser) would make the held_proposal branch's
+  // `.find()` throw and take the WHOLE mapper down. Normalise so an absent or
+  // malformed actions list degrades the held card to the R7 unsupported
+  // placeholder — the same fail-closed route as an unresolvable confirm ref.
+  const actions = Array.isArray(suggestedActions) ? suggestedActions : []
   const out: ConversationBlock[] = []
   for (const b of blocks) {
-    const mapped = mapV5Block(b, suggestedActions)
+    const mapped = mapV5Block(b, actions)
     if (mapped) out.push(mapped)
   }
   return out


### PR DESCRIPTION
## R8 — the held-proposal card

CEE's graph-management referee gate holds a structural/tunable mutation
pending the user's go-ahead. The V5 parse side has known-mapped the 0.18.0
`held_proposal` block since the re-vendor, but there was no renderer — the
kind deliberately downgraded to the R7 "unsupported content" placeholder:

> `0.15.0 wave: KNOWN kind, deliberately not rendered yet — R8 builds the held-proposal card.`

This closes that deferral. When it lands, A1 makes the CEE emit
(`CEE_HELD_PROPOSAL_EMIT`) unconditional in the same window, so the card is
built production-honest from day one.

**RED to GREEN.** RED = the block downgraded to the unsupported placeholder
(`mapV5Block` returned `v5_unsupported`). GREEN = it renders the card
(`v5_held_proposal`). The flip is pinned in `mapV5Blocks.heldProposal.test.ts`
and the updated `mapV5Blocks.holds0150.test.ts`.

### Schema shape consumed (0.18.0 `HeldProposalBlockSchema`, strict)

| Field | Type | Card use |
|-------|------|----------|
| `type` | `"held_proposal"` | discriminator (never rendered) |
| `proposal_id` | `string` (`gmh_...` handle) | `data-block-id` only, never rendered |
| `summary` | `string` | **what is proposed**, rendered verbatim |
| `mutation_class` | `"structural" \| "tunable"` | `data-mutation-class` only, never rendered |
| `reason_code` | enum(8) | **why it is held**, mapped to UI copy; raw code `data-reason-code` only |
| `confirm_action_id` | `string` | ref into top-level `suggested_actions[].id`, the confirm affordance |
| `decline_action_id` | `string?` | ref into `suggested_actions[].id`, the dismiss affordance (CEE does not emit yet) |

The block carries **no `target_refs`** (checked against the vendored 0.18.0
d.ts + zod source) — it references a proposal by id and defers the mutation
payload to CEE. So there is nothing for `TargetRefPill` to resolve here; the
card renders no target pills. `reason_code` is code-keyed by design (schema
doctrine: "a consumer maps each code to its OWN user-facing copy, so the
internal-doctrine-prose leak 1.43 flagged in `blocker_readable` cannot recur")
so that mapping is `heldProposalReasonCopy.ts`, widened to `string` so a future
held-reachable code passes through to generic copy without a UI release.

### Apply-path reuse manifest (single-writer doctrine, post-#364)

The card mints **no** client-side graph mutation. Both affordances resolve
their `*_action_id` against the response's top-level `suggested_actions[]` (at
map time, so the block is self-contained) and dispatch the resolved `message`
through the **existing** chip-send seam:

```
V5HeldProposalBlock  ->  useGuidanceStore._sendChip(label, message)
  ->  ConversationPanel.sendChipByLabelMessage
  ->  useConversation.sendChip({ id, label, message, intent })
  ->  dispatchAction({ ..., message, source: 'chip' })   // turn sent to CEE
```

This is the same seam `EvidenceBlock`'s "Apply to model" chip uses. The
confirm message (e.g. `"Yes"`) goes back as a turn and **CEE applies the held
mutation server-side** on that turn, no new writer. Dismiss dispatches the
decline action's message when CEE emits one, otherwise it is a local-only
dismiss (the `ProposalBlockRenderer` "Cancel" idiom). Wiring: the mapper
resolves the refs (`mapV5Blocks.ts`), `useConversation` passes
`suggested_actions` into the mapper, and a dispatcher case is added to
`InlineBlocks.tsx`.

### DS pattern matched

Matched the ratified **full-border V5 card recipe** — `bg-panel` +
`border border-info/30` (DESIGN_SYSTEM.md "Patterns"), identical to
`V5CoachingBlock`'s `default` variant — **not** the left-border coaching
recipe (v4 §15), which is reserved for facilitator coaching. This is a
proposal/action card, so it takes the proposal-card idiom. Confirm/dismiss use
the ratified suggested-action chip idiom copied from `SuggestedChips.tsx`.
Lucide only (`Hand`), typography tokens only, British English, no em dashes.
Internal vocabulary (`held_proposal`, `reason_code`, `mutation_class`,
`proposal_id`) never renders as copy **on the held-proposal card itself**; it
rides as `data-*` attributes only.

> **Narrowed (adversarial review).** This claim holds for the card, not for the
> whole pipeline. On the fail-closed branch the block degrades to the R7
> unsupported card, and `V5UnsupportedBlock.tsx` renders `{block.blockType}` as
> a visible pill — so a drifted held proposal does surface the literal string
> `held_proposal`. This is **not a regression**: pre-PR, EVERY held proposal
> took that path, so exposure strictly decreases. Flagged so the R7 pill is not
> mistaken for a leak introduced here.

### Fail-closed matrix

| Condition | Behaviour |
|-----------|-----------|
| Well-formed block, confirm ref resolves | card renders (GREEN) |
| `confirm_action_id` unresolvable (drift/corruption) | degrades to R7 `v5_unsupported` card, never crash, never vanish |
| `decline_action_id` absent (today's default) | dismiss is local-only |
| `decline_action_id` present but unresolvable | treated as absent, local-only dismiss |
| Unknown / future `reason_code` | generic held sentence (widened `string`) |
| Unknown extra block fields | ignored (only render-relevant fields forwarded) |
| `_sendChip` unavailable (no host registered) | confirm/dismiss is a safe no-op, still settles |

### Tests

- `src/v5/__tests__/mapV5Blocks.heldProposal.test.ts` (7) — mapper flip: resolves confirm/decline verbatim, omits unresolvable decline, passes unknown reason codes through, fails closed to unsupported, forwards only render-relevant fields, and degrades rather than throwing when `suggested_actions` is `null`.
- `src/v5/blocks/__tests__/V5HeldProposalBlock.spec.tsx` (16) — DOM + wiring: summary verbatim, held reason (raw literal pinned), confirm dispatches `_sendChip(label, message)`, no double-dispatch, decline vs local dismiss, no internal vocabulary in visible text, internals as `data-*`, null seam sends nothing AND does not acknowledge, late host registration still works, WCAG 2.5.3 accessible-name pins, fail-closed reason fallback.
- `src/v5/__tests__/mapV5Blocks.holds0150.test.ts` — updated: held_proposal is no longer deferred (renders when confirm resolves; fails closed otherwise); `ui_directive` still silently skipped (R4's lane).

18/18 new + updated pass. Adjacent suites green (`mapV5Blocks.test.ts`,
`parser.phase3-blocks-tolerance.spec.ts`, `InlineBlocks.*`, prepush smoke set
483/483). `InlineBlocks.dsv5.spec.tsx` needs Supabase env and fails identically
on the untouched base — pre-existing, unrelated.

### Retired pin (deliberate)

The earlier pin *"fails closed when `_sendChip` is unavailable (confirm is a
safe no-op)"* asserted that the card **still settled** on a null seam, with the
rationale "so the affordance cannot be re-fired endlessly". That pin is retired
and rewritten.

Why: the re-fire concern is already served by the `settled` guard on the success
path (pinned separately by the no-double-dispatch test), so the old assertion
bought nothing — while locking in a **false acknowledgement**. With `_sendChip`
null, nothing was sent, yet the card rendered "Sent for you to apply." and burned
the affordance (replaced by the ack, no retry). `_sendChip` is null by default
(`guidanceStore` initial state) and again on host teardown, so the window is
reachable in production.

The replacement pins the EvidenceBlock behaviour for this exact seam
(`InlineBlocks` `handleApplyToModel`: `if (!sendChip) return`): null seam → no
send, **no ack**, affordance stays live; present seam → sends once, ack shows,
cannot re-fire. A companion pin proves a late-registering host can still confirm.

### Both typechecks (matched base, unique scratch dirs)

- Base `origin/staging` (`dc8c3662`): `tsc -p tsconfig.ci.json --noEmit` -> **0 errors**.
- This branch: same config -> **0 errors**.

### Gate

`scripts/validate-prepush.sh`: typecheck ok, smoke 483/483 ok, stale-js ok, dep
audit ok, vendored-schema SHA ok. **Lint**: 0 errors on all changed files
(warnings are pre-existing, none in new files). **Check 8 (DS ratchet)** fails
on a **pre-existing** net-new hex in `src/components/chat/artefactIframeTemplate.ts`
(`#6E6B6B`), reproduced identically on pristine `origin/staging` and not in
this diff; R8's DS counts are identical to base (zero net-new drift from this
work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

