### PR TITLE
fix(conversation): surface CEE recovery suggestions + honest retry on failures

### DIFF
--- a/src/canvas/conversation/__tests__/buildErrorMessage.spec.ts
+++ b/src/canvas/conversation/__tests__/buildErrorMessage.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { buildErrorMessage } from '../useConversation'
+import { buildFailureRender } from '../ceeRecovery'
 import { OrchestratorError } from '../turnService'
 
 // Vitest runs with import.meta.env.DEV = true by default.
@@ -91,5 +92,181 @@ describe('buildErrorMessage', () => {
       const msg = buildErrorMessage(err)
       expect(msg).not.toMatch(/\(\d+\)/)
     }
+  })
+})
+
+/**
+ * Non-retry-directive copy variants (A1 brief item 2 follow-up).
+ *
+ * When the CEE envelope marks a failure `retryable: false` the retry chip is
+ * hidden. The copy must then not instruct the user to retry — there is no
+ * control to do it with. `canRetry: false` selects the counterpart copy for
+ * every retry-directive base.
+ *
+ * Complete manifest of buildErrorMessage's six return sites:
+ *
+ *   | case          | canRetry: true (unchanged)                        | canRetry: false                                              |
+ *   |---------------|---------------------------------------------------|--------------------------------------------------------------|
+ *   | non-Orch      | Something went wrong. Try again or rephrase …     | Something went wrong. Rephrasing your message may help.      |
+ *   | 401           | Authentication error. Please refresh and try again| Authentication error. Please refresh the page to continue.   |
+ *   | 429           | Too many requests. … wait a moment and try again. | Too many requests. … wait a moment before sending another …  |
+ *   | 400           | Request error. Try rephrasing your message.       | (same — no retry directive to remove)                        |
+ *   | >= 500        | Service temporarily unavailable. … try again …    | Service temporarily unavailable. … wait a moment before …    |
+ *   | default       | Something went wrong. Try again or rephrase …     | Something went wrong. Rephrasing your message may help.      |
+ */
+describe('buildErrorMessage — non-retry-directive variants (canRetry: false)', () => {
+  const NO_RETRY = { canRetry: false } as const
+
+  it('no return site directs a retry when canRetry is false (whole manifest)', () => {
+    const cases: unknown[] = [
+      new Error('boom'), // non-OrchestratorError
+      'string error',
+      null,
+      new OrchestratorError('Unauthorized', 401, {}),
+      new OrchestratorError('Too many', 429, {}),
+      new OrchestratorError('Bad request', 400, {}),
+      new OrchestratorError('Internal', 500, {}),
+      new OrchestratorError('Bad gateway', 502, {}),
+      new OrchestratorError('Teapot', 418, {}), // default branch
+      new OrchestratorError('No status', undefined as unknown as number, {}),
+    ]
+    for (const err of cases) {
+      expect(buildErrorMessage(err, NO_RETRY)).not.toMatch(/try again/i)
+    }
+  })
+
+  it('non-OrchestratorError values name an action the user can still take', () => {
+    for (const err of [new Error('boom'), 'string error', null]) {
+      expect(buildErrorMessage(err, NO_RETRY)).toBe(
+        'Something went wrong. Rephrasing your message may help.',
+      )
+    }
+  })
+
+  it('401 asks for a refresh rather than a retry', () => {
+    const msg = buildErrorMessage(new OrchestratorError('Unauthorized', 401, {}), NO_RETRY)
+    expect(msg).toBe('Authentication error. Please refresh the page to continue.')
+  })
+
+  it('429 asks the user to wait rather than to retry', () => {
+    const msg = buildErrorMessage(new OrchestratorError('Too many', 429, {}), NO_RETRY)
+    expect(msg).toBe('Too many requests. Please wait a moment before sending another message.')
+  })
+
+  it('400 copy is unchanged (rephrasing needs no retry control)', () => {
+    const err = new OrchestratorError('Bad request', 400, {})
+    expect(buildErrorMessage(err, NO_RETRY)).toBe(buildErrorMessage(err))
+    expect(buildErrorMessage(err, NO_RETRY)).toBe('Request error. Try rephrasing your message.')
+  })
+
+  it('5xx states the outage and names waiting rather than retrying', () => {
+    for (const status of [500, 502, 503]) {
+      expect(buildErrorMessage(new OrchestratorError('x', status, {}), NO_RETRY)).toBe(
+        'Service temporarily unavailable. Please wait a moment before continuing.',
+      )
+    }
+  })
+
+  it('default branch (unknown status) drops the retry directive', () => {
+    expect(buildErrorMessage(new OrchestratorError('Teapot', 418, {}), NO_RETRY)).toBe(
+      'Something went wrong. Rephrasing your message may help.',
+    )
+  })
+
+  it('keeps the DEV ref suffix and never leaks a raw status code', () => {
+    const err = new OrchestratorError('fail', 500, {}, 'req-abc')
+    const msg = buildErrorMessage(err, NO_RETRY)
+    expect(msg).toContain('[ref: req-abc]')
+    expect(msg).not.toMatch(/\(\d+\)/)
+  })
+
+  it('house style: sentence case, no em dashes, no upper-snake codes', () => {
+    const cases: unknown[] = [
+      new Error('boom'),
+      new OrchestratorError('', 401, {}),
+      new OrchestratorError('', 429, {}),
+      new OrchestratorError('', 400, {}),
+      new OrchestratorError('', 500, {}),
+      new OrchestratorError('', 418, {}),
+    ]
+    for (const err of cases) {
+      for (const msg of [buildErrorMessage(err), buildErrorMessage(err, NO_RETRY)]) {
+        expect(msg).not.toContain('—')
+        expect(msg).not.toMatch(/\b[A-Z][A-Z0-9]*_[A-Z0-9_]+\b/)
+      }
+    }
+  })
+
+  it('fail open: omitting opts, or canRetry:true, returns today\'s copy exactly', () => {
+    const cases: unknown[] = [
+      new Error('boom'),
+      new OrchestratorError('', 401, {}),
+      new OrchestratorError('', 429, {}),
+      new OrchestratorError('', 400, {}),
+      new OrchestratorError('', 500, {}),
+      new OrchestratorError('', 418, {}),
+    ]
+    for (const err of cases) {
+      expect(buildErrorMessage(err, { canRetry: true })).toBe(buildErrorMessage(err))
+      expect(buildErrorMessage(err, {})).toBe(buildErrorMessage(err))
+    }
+    expect(buildErrorMessage(new OrchestratorError('', 500, {}))).toBe(
+      'Service temporarily unavailable. Please try again shortly.',
+    )
+  })
+})
+
+/**
+ * End-to-end pins for the exact contradiction the adversarial review found:
+ * the chip is correctly hidden but the message still tells the user to retry.
+ */
+describe('buildFailureRender + buildErrorMessage — hidden chip implies no retry directive', () => {
+  const render = (err: unknown) =>
+    buildFailureRender((canRetry) => buildErrorMessage(err, { canRetry }), err)
+
+  it('5xx marked non-retryable: chip hidden AND copy does not say try again', () => {
+    const err = new OrchestratorError('Bad gateway', 502, {
+      error: 'CEE_LLM_VALIDATION_FAILED',
+      retryable: false,
+      recovery_suggestion: 'Add one clear goal and two options.',
+    })
+    const out = render(err)
+    expect(out.showRetry).toBe(false)
+    expect(out.content).not.toMatch(/try again/i)
+    expect(out.content).toContain('Service temporarily unavailable.')
+    expect(out.content).toContain('Add one clear goal and two options.')
+  })
+
+  it('generic status marked non-retryable: chip hidden AND copy does not say try again', () => {
+    const err = new OrchestratorError('Teapot', 418, { retryable: false })
+    const out = render(err)
+    expect(out.showRetry).toBe(false)
+    expect(out.content).not.toMatch(/try again/i)
+    expect(out.content).toBe('Something went wrong. Rephrasing your message may help.')
+  })
+
+  it('every status marked non-retryable yields retry-directive-free copy', () => {
+    for (const status of [401, 429, 400, 500, 503, 418]) {
+      const err = new OrchestratorError('x', status, { retryable: false })
+      const out = render(err)
+      expect(out.showRetry).toBe(false)
+      expect(out.content).not.toMatch(/try again/i)
+    }
+  })
+
+  it('fail open unchanged: no marker → chip shown and copy byte-identical to today', () => {
+    for (const status of [401, 429, 400, 500, 418]) {
+      const err = new OrchestratorError('x', status, {})
+      const out = render(err)
+      expect(out.showRetry).toBe(true)
+      expect(out.content).toBe(buildErrorMessage(err))
+    }
+  })
+
+  it('retryable:true keeps the retry chip and the retry-directive copy', () => {
+    const err = new OrchestratorError('Timeout', 504, { retryable: true })
+    const out = render(err)
+    expect(out.showRetry).toBe(true)
+    expect(out.content).toBe('Service temporarily unavailable. Please try again shortly.')
   })
 })

--- a/src/canvas/conversation/__tests__/ceeRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/ceeRecovery.spec.ts
@@ -104,6 +104,29 @@ describe('extractCeeRecovery — recovery suggestion', () => {
     expect(extractCeeRecovery({ retryable: false, suggested_action: 'UPSTREAM_TIMEOUT' }).suggestion).toBeUndefined()
   })
 
+  it('rejects multi-token code dumps (no lowercase letter anywhere)', () => {
+    for (const dump of ['UPSTREAM_TIMEOUT: CEE_LLM_TIMEOUT', 'ERR_A, ERR_B', 'CEE_X / CEE_Y', '500 CEE_INTERNAL_ERROR']) {
+      expect(extractCeeRecovery({ recovery_suggestion: dump }).suggestion).toBeUndefined()
+    }
+  })
+
+  it('reject-only: legitimate prose is passed through byte-for-byte, never rewritten', () => {
+    // Prose that a naive normaliser would corrupt: em dash, US spelling,
+    // capitalised proper noun, an embedded upper-snake identifier. All must
+    // survive verbatim — house style on this field is the producer's job.
+    const cases = [
+      'Add one clear goal and two options, then send again.',
+      'Your brief is too long — try naming a single decision.',
+      'Analyze fewer options at once.',
+      'Ask CEE for a shorter draft.',
+      'Set GRAPH_MODE in your brief to a supported value.',
+      'OK, but add a goal.',
+    ]
+    for (const prose of cases) {
+      expect(extractCeeRecovery({ recovery_suggestion: prose }).suggestion).toBe(prose)
+    }
+  })
+
   it('ignores empty / whitespace-only suggestions and trims real ones', () => {
     expect(extractCeeRecovery({ recovery_suggestion: '   ' }).suggestion).toBeUndefined()
     expect(extractCeeRecovery({ recovery_suggestion: '  Add a goal.  ' }).suggestion).toBe('Add a goal.')
@@ -116,34 +139,79 @@ describe('extractCeeRecovery — recovery suggestion', () => {
 })
 
 describe('buildFailureRender — surface (a) recovery + (b) honest retry', () => {
-  const base = 'Service temporarily unavailable. Please try again shortly.'
+  const RETRY_BASE = 'Service temporarily unavailable. Please try again shortly.'
+  const NO_RETRY_BASE = 'Service temporarily unavailable. Please wait a moment before continuing.'
 
-  it('non-retryable: hides retry and appends the specific recovery suggestion', () => {
+  /**
+   * Stand-in for useConversation's buildErrorMessage: retry-directive copy when
+   * a retry chip will exist, non-retry-directive copy when it will not.
+   */
+  const buildBase = (showRetry: boolean): string => (showRetry ? RETRY_BASE : NO_RETRY_BASE)
+
+  /**
+   * RETIRED PIN (deliberate). The previous spec here read:
+   *
+   *   it('non-retryable: hides retry and appends the specific recovery
+   *      suggestion', … expect(out.content).toContain(RETRY_BASE) …)
+   *
+   * with `showRetry` false. That asserted the *retry-directive* base survives
+   * into copy rendered with no retry control — i.e. it pinned the defect as
+   * intended behaviour. It is replaced by the two specs below, which keep the
+   * append behaviour it was really guarding and additionally forbid the retry
+   * directive. See buildErrorMessage.spec.ts for the end-to-end copy pins.
+   */
+  it('non-retryable: hides retry, uses the non-retry-directive base, appends the suggestion', () => {
     const err = { body: { error: 'CEE_LLM_VALIDATION_FAILED', retryable: false, recovery_suggestion: 'Add one clear goal and two options.' } }
-    const out = buildFailureRender(base, err)
+    const out = buildFailureRender(buildBase, err)
     expect(out.showRetry).toBe(false)
-    expect(out.content).toContain(base)
+    expect(out.content).toContain(NO_RETRY_BASE)
     expect(out.content).toContain('Add one clear goal and two options.')
   })
 
-  it('retryable: keeps retry', () => {
+  it('non-retryable: the rendered copy never directs a retry it cannot offer', () => {
+    const err = { body: { retryable: false, recovery_suggestion: 'Add one clear goal.' } }
+    const out = buildFailureRender(buildBase, err)
+    expect(out.showRetry).toBe(false)
+    expect(out.content).not.toContain(RETRY_BASE)
+    expect(out.content).not.toMatch(/try again/i)
+  })
+
+  it('retryable: keeps retry and the retry-directive base', () => {
     const err = { body: { error: 'CEE_LLM_TIMEOUT', retryable: true } }
-    expect(buildFailureRender(base, err).showRetry).toBe(true)
+    const out = buildFailureRender(buildBase, err)
+    expect(out.showRetry).toBe(true)
+    expect(out.content).toContain(RETRY_BASE)
   })
 
-  it('fail closed: absent retryable marker keeps retry (never strand)', () => {
-    expect(buildFailureRender(base, new Error('network')).showRetry).toBe(true)
+  it('fail open: absent retryable marker keeps retry AND today\'s copy (never strand)', () => {
+    const out = buildFailureRender(buildBase, new Error('network'))
+    expect(out.showRetry).toBe(true)
+    expect(out.content).toBe(RETRY_BASE)
   })
 
-  it('fail closed: absent suggestion keeps the generic copy verbatim', () => {
-    const out = buildFailureRender(base, { body: { error: 'CEE_LLM_TIMEOUT', retryable: true } })
-    expect(out.content).toBe(base)
+  it('fail open: absent suggestion keeps the generic copy verbatim', () => {
+    const out = buildFailureRender(buildBase, { body: { error: 'CEE_LLM_TIMEOUT', retryable: true } })
+    expect(out.content).toBe(RETRY_BASE)
   })
 
   it('suggestion is surfaced even when the failure is retryable', () => {
     const err = { body: { retryable: true, recovery_suggestion: 'You can also simplify the brief.' } }
-    const out = buildFailureRender(base, err)
+    const out = buildFailureRender(buildBase, err)
     expect(out.showRetry).toBe(true)
     expect(out.content).toContain('You can also simplify the brief.')
+  })
+
+  it('passes the resolved retry state to the base builder exactly once', () => {
+    const seen: boolean[] = []
+    const spy = (showRetry: boolean): string => {
+      seen.push(showRetry)
+      return 'base'
+    }
+    buildFailureRender(spy, { body: { retryable: false } })
+    expect(seen).toEqual([false])
+
+    seen.length = 0
+    buildFailureRender(spy, { body: { retryable: true } })
+    expect(seen).toEqual([true])
   })
 })

--- a/src/canvas/conversation/__tests__/ceeRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/ceeRecovery.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * CEE failure-recovery reader — unit specs (RED-first).
+ *
+ * A1 brief item 2 (failure recovery on screen): when a draft/turn fails, CEE
+ * puts a *specific recovery suggestion* on the wire and marks the failure
+ * retryable/non-retryable. The live conversation catch path (useConversation
+ * V4) previously ignored both — it showed generic copy plus an unconditional
+ * "Try again" chip even on failures explicitly marked non-retryable.
+ *
+ * These specs pin the pure reader that fixes that:
+ *   (a) surface the specific recovery suggestion alongside the generic copy;
+ *   (b) hide the retry affordance when the wire says retryable === false.
+ *
+ * Fail-closed contract (never strand the user):
+ *   - suggestion absent → undefined → caller keeps today's generic copy
+ *   - retryable marker absent → undefined → caller keeps retry
+ */
+import { describe, it, expect } from 'vitest'
+import { extractCeeRecovery, buildFailureRender } from '../ceeRecovery'
+
+describe('extractCeeRecovery — retryable marker', () => {
+  it('reads a flat 0.18.0 CeeTypedError { retryable:false }', () => {
+    expect(extractCeeRecovery({ error: 'CEE_LLM_VALIDATION_FAILED', message: 'x', retryable: false }).retryable).toBe(false)
+  })
+
+  it('reads a flat CeeTypedError { retryable:true }', () => {
+    expect(extractCeeRecovery({ error: 'CEE_LLM_TIMEOUT', message: 'x', retryable: true }).retryable).toBe(true)
+  })
+
+  it('reads the nested spec-v04 shape { error: { code, retryable } }', () => {
+    expect(extractCeeRecovery({ error: { code: 'CEE_VALIDATION_FAILED', message: 'x', retryable: false } }).retryable).toBe(false)
+  })
+
+  it('reads retryable off an OrchestratorError-like { body }', () => {
+    expect(extractCeeRecovery({ body: { error: 'CEE_LLM_TIMEOUT', retryable: false } }).retryable).toBe(false)
+  })
+
+  it('reads retryable off a CEEError-like { details }', () => {
+    expect(extractCeeRecovery({ details: { retryable: false } }).retryable).toBe(false)
+  })
+
+  it('reads retryable off a BFF-wrapped { cee_response }', () => {
+    expect(extractCeeRecovery({ cee_response: { retryable: true } }).retryable).toBe(true)
+  })
+
+  it('honours the canonical PLoT spelling `retriable`', () => {
+    expect(extractCeeRecovery({ error: 'CEE_INTERNAL_ERROR', retriable: false }).retryable).toBe(false)
+  })
+
+  it('fails closed: absent marker → undefined (caller keeps retry)', () => {
+    expect(extractCeeRecovery({ error: 'CEE_LLM_TIMEOUT', message: 'x' }).retryable).toBeUndefined()
+  })
+
+  it('ignores non-boolean retryable values (never coerces)', () => {
+    expect(extractCeeRecovery({ retryable: 'false' }).retryable).toBeUndefined()
+    expect(extractCeeRecovery({ retryable: 0 }).retryable).toBeUndefined()
+  })
+
+  it('returns empty for non-object inputs', () => {
+    expect(extractCeeRecovery(null).retryable).toBeUndefined()
+    expect(extractCeeRecovery(undefined).retryable).toBeUndefined()
+    expect(extractCeeRecovery('boom').retryable).toBeUndefined()
+    expect(extractCeeRecovery(new Error('boom')).retryable).toBeUndefined()
+  })
+})
+
+describe('extractCeeRecovery — recovery suggestion', () => {
+  it('reads recovery_suggestion (primary wire name)', () => {
+    expect(
+      extractCeeRecovery({ error: 'CEE_LLM_VALIDATION_FAILED', retryable: false, recovery_suggestion: 'Add a clear goal and two options, then re-send.' }).suggestion,
+    ).toBe('Add a clear goal and two options, then re-send.')
+  })
+
+  it('reads suggested_action (matches UI CeeError.suggestedAction normalisation)', () => {
+    expect(
+      extractCeeRecovery({ error: 'CEE_LLM_VALIDATION_FAILED', retryable: false, suggested_action: 'Shorten your brief to the key decision.' }).suggestion,
+    ).toBe('Shorten your brief to the key decision.')
+  })
+
+  it('reads the short `recovery` alias', () => {
+    expect(extractCeeRecovery({ retryable: false, recovery: 'Try a simpler brief.' }).suggestion).toBe('Try a simpler brief.')
+  })
+
+  it('reads the suggestion from a nested spec-v04 error object', () => {
+    expect(
+      extractCeeRecovery({ error: { code: 'CEE_VALIDATION_FAILED', retryable: false, recovery_suggestion: 'Name one goal.' } }).suggestion,
+    ).toBe('Name one goal.')
+  })
+
+  it('reads the suggestion off an OrchestratorError-like { body }', () => {
+    expect(extractCeeRecovery({ body: { retryable: false, recovery_suggestion: 'Do X.' } }).suggestion).toBe('Do X.')
+  })
+
+  it('tolerates camelCase SDK variance (suggestedAction)', () => {
+    expect(extractCeeRecovery({ retryable: false, suggestedAction: 'Do Y.' }).suggestion).toBe('Do Y.')
+  })
+
+  it('fails closed: absent suggestion → undefined (generic copy)', () => {
+    expect(extractCeeRecovery({ error: 'CEE_LLM_TIMEOUT', retryable: true }).suggestion).toBeUndefined()
+  })
+
+  it('never renders a raw error code as a suggestion', () => {
+    expect(extractCeeRecovery({ error: 'CEE_LLM_TIMEOUT', retryable: true, recovery_suggestion: 'CEE_LLM_TIMEOUT' }).suggestion).toBeUndefined()
+    expect(extractCeeRecovery({ retryable: false, suggested_action: 'UPSTREAM_TIMEOUT' }).suggestion).toBeUndefined()
+  })
+
+  it('ignores empty / whitespace-only suggestions and trims real ones', () => {
+    expect(extractCeeRecovery({ recovery_suggestion: '   ' }).suggestion).toBeUndefined()
+    expect(extractCeeRecovery({ recovery_suggestion: '  Add a goal.  ' }).suggestion).toBe('Add a goal.')
+  })
+
+  it('ignores non-string suggestion values', () => {
+    expect(extractCeeRecovery({ recovery_suggestion: 42 }).suggestion).toBeUndefined()
+    expect(extractCeeRecovery({ recovery_suggestion: { text: 'x' } }).suggestion).toBeUndefined()
+  })
+})
+
+describe('buildFailureRender — surface (a) recovery + (b) honest retry', () => {
+  const base = 'Service temporarily unavailable. Please try again shortly.'
+
+  it('non-retryable: hides retry and appends the specific recovery suggestion', () => {
+    const err = { body: { error: 'CEE_LLM_VALIDATION_FAILED', retryable: false, recovery_suggestion: 'Add one clear goal and two options.' } }
+    const out = buildFailureRender(base, err)
+    expect(out.showRetry).toBe(false)
+    expect(out.content).toContain(base)
+    expect(out.content).toContain('Add one clear goal and two options.')
+  })
+
+  it('retryable: keeps retry', () => {
+    const err = { body: { error: 'CEE_LLM_TIMEOUT', retryable: true } }
+    expect(buildFailureRender(base, err).showRetry).toBe(true)
+  })
+
+  it('fail closed: absent retryable marker keeps retry (never strand)', () => {
+    expect(buildFailureRender(base, new Error('network')).showRetry).toBe(true)
+  })
+
+  it('fail closed: absent suggestion keeps the generic copy verbatim', () => {
+    const out = buildFailureRender(base, { body: { error: 'CEE_LLM_TIMEOUT', retryable: true } })
+    expect(out.content).toBe(base)
+  })
+
+  it('suggestion is surfaced even when the failure is retryable', () => {
+    const err = { body: { retryable: true, recovery_suggestion: 'You can also simplify the brief.' } }
+    const out = buildFailureRender(base, err)
+    expect(out.showRetry).toBe(true)
+    expect(out.content).toContain('You can also simplify the brief.')
+  })
+})

--- a/src/canvas/conversation/ceeRecovery.ts
+++ b/src/canvas/conversation/ceeRecovery.ts
@@ -1,0 +1,172 @@
+/**
+ * CEE failure-recovery reader.
+ *
+ * A1 brief item 2 (failure recovery on screen). When a draft/turn fails, CEE
+ * returns an error envelope carrying two pieces the UI must honour:
+ *   1. a `retryable` marker — whether offering "Try again" can actually work;
+ *   2. a *specific recovery suggestion* — plain-language guidance on what to
+ *      do instead of, or alongside, retrying.
+ *
+ * Wire provenance / schema ask
+ * ----------------------------
+ * As of @talchain/schemas 0.18.0 the `CeeTypedErrorSchema` is `.passthrough()`
+ * and types only { error, message, retryable, elapsed_ms?, request_id? }. The
+ * `retryable` boolean IS typed (also `retriable` is the canonical PLoT run.v1
+ * spelling — see src/types/cee.ts CeeError). The recovery suggestion is NOT
+ * typed on the schema, and is absent from CEE Spec v04's CEEErrorResponseV1
+ * ({ error: { code, message, details?, retryable } }). It rides on the wire as
+ * an untyped passthrough sibling. Until the schema pins it, we read it
+ * defensively from a small set of de-facto field names and fail closed.
+ *
+ * SCHEMA ASK: add a typed `recovery_suggestion?: string` (or confirm the real
+ * producer field name) to CeeTypedErrorSchema so the UI can stop
+ * passthrough-sniffing and gain a compile-time contract.
+ *
+ * Fail-closed contract (never strand the user)
+ * --------------------------------------------
+ *   - recovery suggestion absent → `undefined` → caller keeps today's generic copy
+ *   - retryable marker absent     → `undefined` → caller keeps the retry affordance
+ *
+ * This module is a zero-dependency pure leaf on purpose: it operates on
+ * `unknown` (duck-typed OrchestratorError.body / CEEError.details / raw body),
+ * imports nothing, and is covered by the narrow CI typecheck gate.
+ */
+
+/** Field names, in priority order, under which CEE may place the retryable marker. */
+const RETRYABLE_KEYS = ['retryable', 'retriable'] as const
+
+/** Field names, in priority order, under which CEE may place the recovery suggestion. */
+const SUGGESTION_KEYS = [
+  'recovery_suggestion',
+  'suggested_action',
+  'recovery',
+  'suggestedAction',
+  'recoverySuggestion',
+] as const
+
+export interface CeeRecovery {
+  /**
+   * The wire retryable/retriable marker. `true` / `false` only when the wire
+   * carried an actual boolean; `undefined` when absent (fail closed — the
+   * caller keeps the retry affordance rather than guessing).
+   */
+  retryable?: boolean
+  /**
+   * Plain-language recovery suggestion from CEE, trimmed. `undefined` when
+   * absent, empty, or when the value looks like a raw error code (we never
+   * render codes to users). Fail closed → the caller keeps its generic copy.
+   */
+  suggestion?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Collect the candidate record containers to scan, in priority order.
+ *
+ * Draft/turn failures reach the UI as either an OrchestratorError (`.body` =
+ * parsed CEE error body) or a CEEError (`.details` = raw error body), or as the
+ * raw body object itself. Within any of those, the CEE envelope may be flat
+ * (0.18.0 CeeTypedError), nested under `error` (Spec v04 CEEErrorResponseV1),
+ * nested under `details`, or BFF-wrapped under `cee_response`.
+ */
+function collectContainers(err: unknown): Record<string, unknown>[] {
+  const roots: unknown[] = []
+  if (isRecord(err)) {
+    // Prefer the transport-specific payloads over the wrapper object itself.
+    if ('body' in err) roots.push(err.body)
+    if ('details' in err) roots.push(err.details)
+    roots.push(err)
+  }
+
+  const seen = new Set<Record<string, unknown>>()
+  const out: Record<string, unknown>[] = []
+  const push = (value: unknown): void => {
+    if (!isRecord(value) || seen.has(value)) return
+    seen.add(value)
+    out.push(value)
+  }
+
+  for (const root of roots) {
+    if (!isRecord(root)) continue
+    push(root)
+    push(root.error) // nested spec-v04 { error: { ... } }
+    push(root.details) // { details: { ... } }
+    if (isRecord(root.cee_response)) {
+      push(root.cee_response) // BFF wrap
+      push(root.cee_response.error)
+      push(root.cee_response.details)
+    }
+  }
+  return out
+}
+
+/** True when the string looks like an enum/error code rather than prose. */
+function looksLikeCode(value: string): boolean {
+  // e.g. CEE_LLM_TIMEOUT, UPSTREAM_TIMEOUT, INGRESS_CONTRACT_VIOLATION — all
+  // upper-snake, no lowercase, no spaces. Real suggestions are sentences.
+  return /^[A-Z][A-Z0-9_]{2,}$/.test(value.trim())
+}
+
+/**
+ * Read the retryable + recovery-suggestion signals out of a draft/turn failure.
+ * Always returns an object; both fields are optional and absent by design when
+ * the wire did not carry them (fail closed).
+ */
+export function extractCeeRecovery(err: unknown): CeeRecovery {
+  const containers = collectContainers(err)
+  const result: CeeRecovery = {}
+
+  for (const c of containers) {
+    if (result.retryable === undefined) {
+      for (const key of RETRYABLE_KEYS) {
+        if (typeof c[key] === 'boolean') {
+          result.retryable = c[key] as boolean
+          break
+        }
+      }
+    }
+    if (result.suggestion === undefined) {
+      for (const key of SUGGESTION_KEYS) {
+        const raw = c[key]
+        if (typeof raw === 'string') {
+          const trimmed = raw.trim()
+          if (trimmed.length > 0 && !looksLikeCode(trimmed)) {
+            result.suggestion = trimmed
+            break
+          }
+        }
+      }
+    }
+    if (result.retryable !== undefined && result.suggestion !== undefined) break
+  }
+
+  return result
+}
+
+export interface FailureRender {
+  /**
+   * Message body to render: the caller's generic copy, with the specific CEE
+   * recovery suggestion appended when one is present (never replacing it —
+   * layering keeps the honest fallback visible).
+   */
+  content: string
+  /**
+   * Whether to render the "Try again" affordance. Fail closed: `true` unless
+   * the wire explicitly marked the failure `retryable: false`.
+   */
+  showRetry: boolean
+}
+
+/**
+ * Compose the failure render from the caller's generic message plus the CEE
+ * envelope. Pure — the caller owns actually building the chip/button.
+ */
+export function buildFailureRender(baseMessage: string, err: unknown): FailureRender {
+  const { retryable, suggestion } = extractCeeRecovery(err)
+  const content = suggestion ? `${baseMessage}\n\n${suggestion}` : baseMessage
+  const showRetry = retryable !== false
+  return { content, showRetry }
+}

--- a/src/canvas/conversation/ceeRecovery.ts
+++ b/src/canvas/conversation/ceeRecovery.ts
@@ -211,8 +211,8 @@ export function buildFailureRender(buildBase: FailureBaseBuilder, err: unknown):
  *
  * We deliberately do NOT rewrite producer prose — no en-dash substitution, no
  * -ize/-ise mapping, no case fixing. Any such rewrite is lossy on inputs it
- * cannot distinguish: an em dash inside a quoted user brief, "analyze" inside
- * a field name or a quoted identifier, a proper noun that must stay
+ * cannot distinguish: an em dash inside a quoted user brief, a wire field name
+ * like `analyze_sentiment` or a quoted identifier, a proper noun that must stay
  * capitalised. Corrupting a correct suggestion is worse than passing through
  * a stylistically off one, because the suggestion is the *only* specific
  * guidance the user gets on a non-retryable failure.

--- a/src/canvas/conversation/ceeRecovery.ts
+++ b/src/canvas/conversation/ceeRecovery.ts
@@ -103,11 +103,25 @@ function collectContainers(err: unknown): Record<string, unknown>[] {
   return out
 }
 
-/** True when the string looks like an enum/error code rather than prose. */
+/**
+ * True when the string looks like machine output rather than prose.
+ *
+ * Two rejections, both *reject-only* — this module never rewrites producer
+ * copy (see the normalisation note at the bottom of this file):
+ *
+ *   1. a single upper-snake token: CEE_LLM_TIMEOUT, UPSTREAM_TIMEOUT, …
+ *   2. any value with no lowercase letter at all, which catches multi-token
+ *      code dumps the single-token test misses ("UPSTREAM_TIMEOUT:
+ *      CEE_LLM_TIMEOUT", "ERR_A, ERR_B"). English prose always contains a
+ *      lowercase letter, so this cannot reject a legitimate suggestion.
+ *
+ * Rejecting is safe: the caller falls back to its own generic copy, which is
+ * already honest for the retry state.
+ */
 function looksLikeCode(value: string): boolean {
-  // e.g. CEE_LLM_TIMEOUT, UPSTREAM_TIMEOUT, INGRESS_CONTRACT_VIOLATION — all
-  // upper-snake, no lowercase, no spaces. Real suggestions are sentences.
-  return /^[A-Z][A-Z0-9_]{2,}$/.test(value.trim())
+  const trimmed = value.trim()
+  if (/^[A-Z][A-Z0-9_]{2,}$/.test(trimmed)) return true
+  return !/[a-z]/.test(trimmed)
 }
 
 /**
@@ -148,9 +162,9 @@ export function extractCeeRecovery(err: unknown): CeeRecovery {
 
 export interface FailureRender {
   /**
-   * Message body to render: the caller's generic copy, with the specific CEE
-   * recovery suggestion appended when one is present (never replacing it —
-   * layering keeps the honest fallback visible).
+   * Message body to render: the caller's generic copy for this retry state,
+   * with the specific CEE recovery suggestion appended when one is present
+   * (never replacing it — layering keeps the honest fallback visible).
    */
   content: string
   /**
@@ -161,12 +175,50 @@ export interface FailureRender {
 }
 
 /**
- * Compose the failure render from the caller's generic message plus the CEE
- * envelope. Pure — the caller owns actually building the chip/button.
+ * Builds the generic base copy for a given retry state.
+ *
+ * Deliberately a callback rather than a plain string. The retry decision is
+ * made here, from the wire, and the base copy has to agree with it: copy that
+ * says "please try again" beside a hidden retry chip instructs the user to do
+ * something the UI gives them no way to do. Taking a resolver makes it
+ * structurally impossible to compose the base copy without first knowing
+ * whether the retry affordance will exist.
  */
-export function buildFailureRender(baseMessage: string, err: unknown): FailureRender {
+export type FailureBaseBuilder = (showRetry: boolean) => string
+
+/**
+ * Compose the failure render from the CEE envelope plus retry-state-aware base
+ * copy. Pure — the caller owns actually building the chip/button.
+ *
+ * Fail open is unchanged: an absent `retryable` marker yields `showRetry:true`,
+ * so `buildBase(true)` is called and today's copy is returned verbatim.
+ */
+export function buildFailureRender(buildBase: FailureBaseBuilder, err: unknown): FailureRender {
   const { retryable, suggestion } = extractCeeRecovery(err)
-  const content = suggestion ? `${baseMessage}\n\n${suggestion}` : baseMessage
   const showRetry = retryable !== false
+  const baseMessage = buildBase(showRetry)
+  const content = suggestion ? `${baseMessage}\n\n${suggestion}` : baseMessage
   return { content, showRetry }
 }
+
+/**
+ * Normalisation note (deliberate non-decision)
+ * -------------------------------------------
+ * The CEE recovery suggestion is rendered VERBATIM. House copy standards
+ * (British English, no em dashes, no raw codes, sentence case) are therefore
+ * delegated to the producer, guarded here only by the *reject-only* checks in
+ * `looksLikeCode`.
+ *
+ * We deliberately do NOT rewrite producer prose — no en-dash substitution, no
+ * -ize/-ise mapping, no case fixing. Any such rewrite is lossy on inputs it
+ * cannot distinguish: an em dash inside a quoted user brief, "analyze" inside
+ * a field name or a quoted identifier, a proper noun that must stay
+ * capitalised. Corrupting a correct suggestion is worse than passing through
+ * a stylistically off one, because the suggestion is the *only* specific
+ * guidance the user gets on a non-retryable failure.
+ *
+ * Reject-only guards are safe because rejection degrades to the caller's own
+ * generic copy. Rewriting has no such safe fallback. If house style needs
+ * enforcing on this field, it belongs at the producer (see the SCHEMA ASK
+ * above) or in a shared copy linter, not in a defensive UI reader.
+ */

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -381,8 +381,31 @@ export function stripDiagnostics(text: string): string {
   return cleaned.replace(/^\n+/, '').replace(/\n{3,}/g, '\n\n').trimEnd()
 }
 
-/** Build a user-facing error message from a caught error */
-export function buildErrorMessage(err: unknown): string {
+export interface BuildErrorMessageOptions {
+  /**
+   * Whether a "Try again" affordance will actually be rendered alongside this
+   * copy. Defaults to `true` (fail open — today's behaviour and copy).
+   *
+   * When `false` the caller has decided, from the CEE `retryable` marker, that
+   * no retry control will exist. The copy must then NOT instruct the user to
+   * retry: an instruction with no control to carry it out is a dead end. Each
+   * retry-directive base below has a non-retry-directive counterpart that
+   * states what happened and names an action the user can still take without a
+   * retry button (refresh, wait, rephrase and send a new message).
+   */
+  canRetry?: boolean
+}
+
+/**
+ * Build a user-facing error message from a caught error.
+ *
+ * `opts.canRetry === false` selects the non-retry-directive copy variants. See
+ * BuildErrorMessageOptions and ./ceeRecovery — `buildFailureRender` is the
+ * single composition point that decides `canRetry` from the wire and calls
+ * back into this function, so the two can never disagree.
+ */
+export function buildErrorMessage(err: unknown, opts?: BuildErrorMessageOptions): string {
+  const canRetry = opts?.canRetry !== false
   // Always log structured detail for development console output (never rendered).
   if (err instanceof OrchestratorError) {
     if (import.meta.env.DEV) {
@@ -394,21 +417,34 @@ export function buildErrorMessage(err: unknown): string {
     }
   }
   if (!(err instanceof OrchestratorError)) {
-    return 'Something went wrong. Try again or rephrase your message.'
+    return canRetry
+      ? 'Something went wrong. Try again or rephrase your message.'
+      : 'Something went wrong. Rephrasing your message may help.'
   }
   // DEV-only ref suffix to aid debugging; never in production bundles.
   const ref = import.meta.env.DEV && err.requestId ? ` [ref: ${err.requestId}]` : ''
   switch (true) {
     case err.status === 401:
-      return `Authentication error.${ref} Please refresh and try again.`
+      return canRetry
+        ? `Authentication error.${ref} Please refresh and try again.`
+        : `Authentication error.${ref} Please refresh the page to continue.`
     case err.status === 429:
-      return `Too many requests.${ref} Please wait a moment and try again.`
+      return canRetry
+        ? `Too many requests.${ref} Please wait a moment and try again.`
+        : `Too many requests.${ref} Please wait a moment before sending another message.`
     case err.status === 400:
+      // No retry directive in either variant: "rephrase your message" is an
+      // action the user can always take from the composer, with or without a
+      // retry chip. Single copy on purpose.
       return `Request error.${ref} Try rephrasing your message.`
     case err.status !== undefined && err.status >= 500:
-      return `Service temporarily unavailable.${ref} Please try again shortly.`
+      return canRetry
+        ? `Service temporarily unavailable.${ref} Please try again shortly.`
+        : `Service temporarily unavailable.${ref} Please wait a moment before continuing.`
     default:
-      return `Something went wrong.${ref} Try again or rephrase your message.`
+      return canRetry
+        ? `Something went wrong.${ref} Try again or rephrase your message.`
+        : `Something went wrong.${ref} Rephrasing your message may help.`
   }
 }
 
@@ -3947,9 +3983,14 @@ export function useConversation(): UseConversationReturn {
           // suggestion (see ./ceeRecovery for wire provenance + the schema
           // ask) so we (a) surface the suggestion alongside the generic copy
           // and (b) hide "Try again" when the failure is explicitly
-          // non-retryable — a retry that cannot work. Fail closed: absent
-          // suggestion → generic copy; absent marker → keep retry.
-          const { content: errorMessage, showRetry } = buildFailureRender(buildErrorMessage(err), err)
+          // non-retryable — a retry that cannot work. The base copy is built
+          // *from* that same retry decision, so we never tell the user to try
+          // again while withholding the control. Fail open: absent suggestion →
+          // generic copy; absent marker → keep retry + today's copy.
+          const { content: errorMessage, showRetry } = buildFailureRender(
+            (canRetry) => buildErrorMessage(err, { canRetry }),
+            err,
+          )
           const retryChips: ActionChip[] = showRetry
             ? [{ id: 'retry', label: 'Try again', intent: 'primary' as const }]
             : []

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -12,6 +12,7 @@ import { setCurrentScenarioId } from '../store/scenarios'
 import { useDraftStore } from '../stores/draftStore'
 import { generateGraphHash } from '../utils/graphHash'
 import { callOrchestratorTurn, streamOrchestratorTurn, OrchestratorError } from './turnService'
+import { buildFailureRender } from './ceeRecovery'
 import { callV5Turn, getV5Endpoint } from '../../v5/v5Adapter'
 import { routeV5Response } from '../../v5/responseRouter'
 import { getTimeoutMs } from '../../v5/getTimeoutMs'
@@ -3940,7 +3941,18 @@ export function useConversation(): UseConversationReturn {
         if (mode === 'user' && !hidden) {
           setLastFailedInput(message)
 
-          const errorMessage = buildErrorMessage(err)
+          // A1 brief item 2 — failure recovery on screen. A non-2xx CEE turn
+          // throws OrchestratorError carrying the CEE error envelope in
+          // `err.body`. Read its retryable marker + specific recovery
+          // suggestion (see ./ceeRecovery for wire provenance + the schema
+          // ask) so we (a) surface the suggestion alongside the generic copy
+          // and (b) hide "Try again" when the failure is explicitly
+          // non-retryable — a retry that cannot work. Fail closed: absent
+          // suggestion → generic copy; absent marker → keep retry.
+          const { content: errorMessage, showRetry } = buildFailureRender(buildErrorMessage(err), err)
+          const retryChips: ActionChip[] = showRetry
+            ? [{ id: 'retry', label: 'Try again', intent: 'primary' as const }]
+            : []
 
           // If the streaming path pre-created a message, reuse it instead
           // of creating a duplicate.
@@ -3951,7 +3963,7 @@ export function useConversation(): UseConversationReturn {
               isProvisional: false,
               toolLoadingState: null,
               synthetic: true,
-              actionChips: [{ id: 'retry', label: 'Try again', intent: 'primary' as const }],
+              actionChips: retryChips,
             })
             streamingMsgIdRef.current = null
           } else {
@@ -3960,7 +3972,7 @@ export function useConversation(): UseConversationReturn {
               role: 'assistant',
               content: errorMessage,
               synthetic: true,
-              actionChips: [{ id: 'retry', label: 'Try again', intent: 'primary' }],
+              actionChips: retryChips,
               timestamp: new Date(),
             })
           }

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -30,7 +30,12 @@
     // reference.
     "src/canvas/components/pre-analysis/utils/isReviewedByUser.ts",
     "src/canvas/components/pre-analysis/utils/isAiSource.ts",
-    "src/canvas/components/pre-analysis/utils/buildPriorityProgress.ts"
+    "src/canvas/components/pre-analysis/utils/buildPriorityProgress.ts",
+
+    // failure-recovery (A1 brief item 2): the CEE failure-recovery reader is a
+    // zero-import pure leaf (operates on `unknown`), so it typechecks cleanly
+    // under the narrow gate without dragging in the conversation graph.
+    "src/canvas/conversation/ceeRecovery.ts"
   ],
   "exclude": [
     "src/components/teams/**",


### PR DESCRIPTION
## What & why (A1 brief item 2 — failure recovery on screen)

When a CEE draft/turn fails, CEE puts a **specific recovery suggestion** on the error envelope and marks the failure retryable/non-retryable. The live conversation path had **zero readers** for the recovery field, and injected an **unconditional "Try again" chip** — even on failures explicitly marked `retryable: false`, i.e. a button that cannot work.

### Where the defect actually lives (live path)

`netlify.toml` sets `VITE_ENABLE_ORCHESTRATOR_V2 = "true"` for both prod and staging, and `VITE_ENABLE_V5_ORCHESTRATOR` is unset (false). So the live draft/turn path is **`useConversation` V4** (ConversationPanel). A non-2xx CEE turn throws `OrchestratorError(msg, status, body, requestId)` (`turnService.ts`; streaming falls back to non-streaming on a non-2xx pre-stream), which lands in the `sendTurn` catch. That catch built the message from `buildErrorMessage(err)` (generic, status-based) and attached `{ id: 'retry' }` **unconditionally**, never reading `err.body` (the CEE error envelope).

> The legacy `DraftChat` error card (`formatCEEError`) and the V5 typed-error branch are **not** the live surface here — the former is only reached when `!isOrchV2` (dead in deployed builds); the latter already reads `suggested_actions` + gates retry by `retryable`.

## The change

New zero-dependency pure reader **`src/canvas/conversation/ceeRecovery.ts`**:

- `extractCeeRecovery(err)` → `{ retryable?, suggestion? }` — duck-types `OrchestratorError.body` / `CEEError.details` / raw body, across the flat 0.18.0 shape, the nested Spec-v04 `error: {…}` shape, and the BFF `cee_response` wrap.
- `buildFailureRender(baseMessage, err)` → `{ content, showRetry }`.

Wired into the `useConversation` `sendTurn` catch (both the streaming-reuse and `addMessage` branches):

- **(a)** the specific recovery suggestion is appended **alongside** the generic copy (layering keeps the honest fallback visible);
- **(b)** the "Try again" chip is **hidden** when `retryable === false`.

## Wire field names + provenance

| Signal | Wire field(s) read | Provenance |
|---|---|---|
| Retryable marker | `retryable` (primary), `retriable` (canonical PLoT run.v1 spelling) | **Typed** on `CeeTypedErrorSchema` (`@talchain/schemas` 0.18.0, `retryable: z.boolean()`, `.passthrough()`). `retriable` is the canonical spelling per `src/types/cee.ts` `CeeError`. Also read from nested `error.retryable`, `details.retryable`, `cee_response.retryable`. |
| Recovery suggestion | `recovery_suggestion` (primary), `suggested_action` (matches UI `CeeError.suggestedAction`), `recovery`, + camelCase variants | **UNTYPED.** Absent from 0.18.0 `CeeTypedErrorSchema` (rides as a `.passthrough()` sibling) **and** from CEE Spec v04 `CEEErrorResponseV1` (`{ error: { code, message, details?, retryable } }`). Read defensively; a value that looks like a raw code (`^[A-Z][A-Z0-9_]{2,}$`) is rejected (never render codes). |

### 🔧 SCHEMA ASK

`CeeTypedErrorSchema` (0.18.0) does not type a recovery-suggestion field, and the vendored tarball is a Paul-gated pre-release. Please **pin the producer field name and add a typed `recovery_suggestion?: string`** (or confirm the real name) so the UI can stop passthrough-sniffing and gain a compile-time contract. Until then this reader accepts the de-facto candidates above and fails closed.

## Hide vs disable — decision: **HIDE**

Justified by the codebase's own honest-state idiom, not a fresh choice:

- **Chat action chips are ephemeral affordances** — a greyed/disabled chip in a chat thread has no DS idiom and reads as broken. There is no "disabled-with-tooltip" chip pattern to follow.
- The **V5 typed-error branch already hides** (`useConversation.ts` ~L3516: retry chip only when `retryable`, else omit + layer guidance).
- **`PreAnalysisPanel`'s draft-error card already replaces** "Retry Draft" with "Edit brief" on `retryable === false`.

So: hide the button, and let the surfaced recovery suggestion carry the "what to do instead". The user is never left without direction.

## Fail-closed matrix

| `retryable` on wire | recovery suggestion on wire | Retry chip | Message body |
|---|---|---|---|
| `false` | present | **hidden** | generic + suggestion |
| `false` | absent | **hidden** | generic only |
| `true` | present | shown | generic + suggestion |
| `true` | absent | shown | generic only |
| absent | present | **shown** (never strand) | generic + suggestion |
| absent | absent | **shown** (never strand) | generic only (today's behaviour) |

## Wire-enum trap (brief item 4) — verified, no bug

The retry path already sends a wire-legal `source`. Retry chip → `ConversationPanel.handleChipClick` (`chip.id === 'retry'` → `retryLast()`) → `sendTurn({ source: 'retry', … })` (`useConversation.ts` L4201). No internal enum leaks to the boundary; no 422 risk. No change needed.

## Tests

- **New** `src/canvas/conversation/__tests__/ceeRecovery.spec.ts` — 25 specs, RED-first (added before the module; confirmed failing on missing import, then green). Covers: flat/nested/BFF-wrapped envelopes, `retryable`+`retriable`, all suggestion field names + camelCase, raw-code rejection, whitespace/non-string guards, and the full fail-closed matrix via `buildFailureRender`.
- Regression: full `src/canvas/conversation/` suite **122 files / 1710 passed / 0 failed**; existing `buildErrorMessage.spec.ts` green; prepush smoke suite green.

## Both typechecks

- **Narrow** (`tsconfig.ci.json`, the prepush gate): **exit 0**. `ceeRecovery.ts` added to the narrow `include` (zero-import leaf → real gate coverage, confirmed present via `--listFilesOnly`).
- **App-config** (`tsconfig.app.json`, full `src`): coordinate-stripped error **multiset identical to base** (origin/staging @ `dc8c3662`): 2317 == 2317, empty diff → **zero new errors** (the diffs seen without stripping are pure line-shift from the +1 import line). No error references `ceeRecovery.ts`.

## Scope notes / adjacent findings

- The **streaming mid-turn `error` event** path already gates retry by `event.recoverable`, but its event shape (`{ code, message, recoverable }`) does not carry the recovery suggestion — surfacing (a) there needs a small `turnService` forward once the wire field is pinned. Left out of scope.
- **Pre-existing (not this PR):** the DS-compliance ratchet flags a net-new `#6E6B6B` in `src/components/chat/artefactIframeTemplate.ts` — that hex is already on `origin/staging` (line 23); the committed DS baseline is stale. Untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
