### PR TITLE
fix(ds): follow the --text-light retint into the DS ratchet baseline (unblocks Check 8 on staging)

### DIFF
--- a/src/components/chat/artefactIframeTemplate.ts
+++ b/src/components/chat/artefactIframeTemplate.ts
@@ -20,6 +20,15 @@ const TEMPLATE_PREFIX = `<!DOCTYPE html>
       --border-default: #EEE6D8;
       --text-header: #262626;
       --text-body: #3F3F3E;
+      /* Literal, deliberately: this is the iframe-local DEFINITION of
+         --text-light, not a reference to the parent document's. Custom
+         properties do not cross a document boundary, so a var() here would
+         resolve to nothing and artefact body copy would silently lose its
+         colour. Held equal to brand.css by
+         artefact-template-token-mirror.spec.ts and pinned as WCAG-legal by
+         text-light-contrast.spec.ts, so the raw hex is recorded as a
+         deliberate exception in tools/ci-guards/ds-compliance-baseline.json
+         rather than tokenised. */
       --text-light: #6E6B6B;
       --primary: #277A9D;
       --primary-hover: #67C89E;

--- a/tools/ci-guards/ds-compliance-baseline.json
+++ b/tools/ci-guards/ds-compliance-baseline.json
@@ -5471,11 +5471,11 @@
           "token": "#3F3F3E",
           "sample": "--text-body: #3F3F3E;"
         },
-        "production-hex :: src/components/chat/artefactIframeTemplate.ts :: #908D8D": {
+        "production-hex :: src/components/chat/artefactIframeTemplate.ts :: #6E6B6B": {
           "count": 1,
           "file": "src/components/chat/artefactIframeTemplate.ts",
-          "token": "#908D8D",
-          "sample": "--text-light: #908D8D;"
+          "token": "#6E6B6B",
+          "sample": "--text-light: #6E6B6B;"
         },
         "production-hex :: src/components/chat/artefactIframeTemplate.ts :: #277A9D": {
           "count": 1,


### PR DESCRIPTION
## The problem

`scripts/validate-prepush.sh` **Check 8** (DS v5 drift ratchet) has been failing on **origin/staging itself**. Four independent lanes hit it today. It is a pre-existing blocker, not something any of those lanes introduced.

At base (`dc8c366`, origin/staging) the ratchet reports exactly one net-new signature:

```
NET-NEW violations (would block under --enforce):
  production-hex:
    src/components/chat/artefactIframeTemplate.ts  #6E6B6B  --text-light: #6E6B6B;

DS-compliance ENFORCE: 1 class(es) have net-new violations.   (exit 1)
```

Worth noting how it surfaced: `production-hex` is DOWN overall (303 vs baseline 311). The ratchet still blocked, because it keys on `{class, file, token}` signatures rather than counts, so a new violation cannot be hidden behind reductions elsewhere. Working exactly as designed.

## Diagnosis: baseline staleness, not drift

`#6E6B6B` is the **correct, deliberate, WCAG-legal** value. `--text-light` shipped as `#908D8D`, which measures 3.26:1 on `--bg-panel` and 2.90:1 on `--bg-canvas`, both below SC 1.4.3's 4.5:1, across ~785 live sites. The retint moved it to `#6E6B6B`.

That retint had to touch **two** declarations, because `--text-light` is declared twice: once in `src/styles/brand.css`, and once inlined into the `:root` of the artefact iframe template. It correctly swept both. The one place it did not sweep was `tools/ci-guards/ds-compliance-baseline.json`, which still recorded the old `#908D8D`. So the ratchet sees the new literal as net-new debt when it is in fact the same single occurrence, retinted.

## The fix, and why it is not a token swap

The baseline signature for this file moves from `#908D8D` to `#6E6B6B`, count 1. It is a **swap, not an addition**, so `byFile` (15) and the `production-hex` total (311) are unchanged, and the entry now matches what `--update` would emit for this file. Regenerating the whole baseline was rejected: it would have swept in the unrelated Δ-6 / Δ-8 reductions elsewhere in the tree and produced an unreviewable diff across a 327 KB file.

**I deliberately did not swap the hex for `var(--text-light)`.** The brief asked me to check whether the token can resolve inside the iframe. It cannot, for three independent reasons:

1. **It would resolve to nothing.** The iframe is a separate document under `default-src 'none'; style-src 'unsafe-inline'`. CSS custom properties do not cross a document boundary, so the iframe cannot inherit `:root` from the parent. The template restates the palette by necessity, and the file already documents this as load-bearing.
2. **The line is the definition, not a reference.** Line 23 is where `--text-light` is *defined* inside the iframe's own `:root`. `--text-light: var(--text-light)` is self-referential; the declaration would be dropped and artefact body copy would silently lose its colour. That is precisely the "values that silently resolve to nothing" defect class this repo has just spent a week removing.
3. **It would fail two existing guards.** `artefact-template-token-mirror.spec.ts` parses the `:root` for `--token: #hex;` literals and asserts `--text-light` is present and equal to `brand.css`; `text-light-contrast.spec.ts` pins the resolved value to `#6E6B6B` and measures it against three real grounds. A `var()` there breaks the mirror's positive control.

So the honest fix is a baseline entry with a justification, which is what this PR does.

## The justification comment

Added beside the literal in `artefactIframeTemplate.ts`, where anyone tempted to "tidy" the raw hex into a token will actually look. It records why the literal is load-bearing, names the two guards that hold it equal to `brand.css` and pin it as WCAG-legal, and states that the hex is a deliberate baseline exception rather than un-migrated debt.

The comment is deliberately **hex-free and brace-free**, so it cannot perturb either detector: no `#` means the comment-aware `production-hex` scanner counts nothing from it, and no `}` means the mirror's non-greedy `:root` block match still terminates in the right place. Verified: the mirror still parses 15 tokens with `--text-light: #6E6B6B`.

## Verification

RED first, on a fresh blobless clone of origin/staging:

| Stage | Check 8 | Evidence |
| --- | --- | --- |
| Base `dc8c366` | **FAIL** (exit 1) | 1 net-new signature, `#6E6B6B` |
| Head `bc811dd` | **PASS** (exit 0) | `No net-new ratcheted violations vs baseline` |

- `scripts/validate-prepush.sh` full run at head: **exit 0, ALL CHECKS PASSED** (Checks 1 to 8).
- Guards most affected by the source edit, run explicitly since the prepush smoke set does not include them: `artefact-template-token-mirror.spec.ts` (3), `text-light-contrast.spec.ts` (7), `ArtefactBlock.spec.tsx` (28) = **38 passed**.

## Scope

Two files, +12/-3. No behaviour change: the rendered colour is identical before and after, since `#6E6B6B` was already what the template shipped. This only makes the ratchet agree with reality so the four blocked lanes can push.

Draft, as requested. Not for merge without review of the baselining decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
