### PR TITLE
fix(ci): heal the base-red — bg-info/4 emits nothing + brittle --info regex

### DIFF
--- a/src/canvas/ui/inspector-v2/__tests__/InspectorCoaching.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InspectorCoaching.spec.tsx
@@ -155,11 +155,40 @@ describe('InspectorCoaching', () => {
     // And the token it points at must really be declared — `var(--typo)` renders
     // NO border at all, which the assertions above cannot distinguish. Read the
     // source of truth rather than trusting the name (trap 12: derive, don't mirror).
+    //
+    // Assert the RESOLVED VALUE, not the file's current spelling. This used to
+    // regex for `--info: #RRGGBB`, which broke the moment the channel split
+    // (#379) restated the token as `--info-rgb: 39 122 157; --info:
+    // rgb(var(--info-rgb))`, a change that left the colour bit-for-bit
+    // identical. Pinning the prose format made a correct refactor look like a
+    // regression, so follow the `var()` chain instead: any spelling that bottoms
+    // out in a real colour passes, and only a token that is missing or dangling
+    // fails. That is the property this assertion was always about.
     const brandCss = readFileSync(
       join(__dirname, '../../../../styles/brand.css'),
       'utf-8',
     )
-    expect(brandCss).toMatch(/^\s*--info:\s*#[0-9A-Fa-f]{6}\s*;/m)
+    // Comments in brand.css illustrate the token shape; they are not declarations.
+    const declared = new Map<string, string>()
+    for (const m of Array.from(
+      brandCss.replace(/\/\*[\s\S]*?\*\//g, '').matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g),
+    )) {
+      declared.set(m[1], m[2].trim())
+    }
+
+    const resolve = (value: string, depth = 0): string =>
+      depth > 10
+        ? value
+        : value.replace(/var\(\s*(--[\w-]+)\s*\)/g, (whole, name: string) => {
+            const next = declared.get(name)
+            return next === undefined ? whole : resolve(next, depth + 1)
+          })
+
+    expect(declared.has('--info'), '--info is not declared in brand.css').toBe(true)
+    expect(
+      resolve(declared.get('--info')!),
+      '--info must resolve to a real colour, not a dangling var()',
+    ).toMatch(/^(#[0-9A-Fa-f]{3,8}|rgba?\([\d\s,./%]+\))$/)
   })
 
   // ── related_elements matching ──────────────────────────────────────

--- a/src/components/results/ExpertBlock.tsx
+++ b/src/components/results/ExpertBlock.tsx
@@ -3,16 +3,20 @@
  *
  * DS v5 §4.3: panelBody (12px), info-tinted background, proper spacing.
  *
- * Inline style rather than `bg-info/4`, per DS v5 §3.15. That note used to read
- * "opacity modifiers on CSS vars MAY fail silently"; it is now measured, and it
- * is not a maybe. tailwind.config.js declares `info.DEFAULT: 'var(--info)'`
- * with no `<alpha-value>` placeholder, so Tailwind 3.4 cannot inject alpha and
- * DROPS the utility entirely — `bg-info/15` and `border-info/30` emit NO CSS
- * (positive control: `bg-red-500/50` emits `rgb(239 68 68 / 0.5)`).
+ * Inline style rather than `bg-info/5`, per DS v5 §3.15. The tint is 4%, and 4
+ * is not a step on Tailwind's opacity scale (0/5/10/…), so no bare utility
+ * expresses it exactly: `/5` is the nearest legal step, and the exact 4% comes
+ * from the color-mix below. An illegal step is not a near-miss that renders
+ * slightly wrong: it emits NO CSS AT ALL, so the tint would vanish silently.
  *
- * The tint is therefore expressed with color-mix, DERIVED from the token. It
- * previously restated #63ADCF — a pre-D1 blue — as a channel triple, which no
- * hex-based sweep could see, so it had silently orphaned from --info.
+ * Since #379 the semantic colours are declared as
+ * `rgb(var(--info-rgb) / <alpha-value>)`, so LEGAL steps such as `bg-info/15`
+ * and `border-info/30` now emit. Before it they were bare `var(--info)`, which
+ * gave Tailwind 3.4 nowhere to inject alpha and dropped every modified utility.
+ *
+ * The tint is expressed with color-mix, DERIVED from the token. It previously
+ * restated #63ADCF — a pre-D1 blue — as a channel triple, which no hex-based
+ * sweep could see, so it had silently orphaned from --info.
  */
 
 import type { ReactNode } from 'react'


### PR DESCRIPTION
## Why

`origin/staging` is itself red at `dc8c3662`. The last DS merges raced each other's CI, so two specs that each passed on their own branch fail together on the merged base. That base-red blocks four open PRs, so this heals it forward. Neither guard is relaxed.

Both failures reproduce on pristine `origin/staging`, and both are green at head.

## Fix 1: `bg-info/4` emitted NO RULE

`tests/ci-guards/semantic-colour-alpha.spec.ts` (from #379) is correct and stays untouched. It scans `src/` for opacity-modified utilities and compiles each one with the real Tailwind. It found `bg-info/4` and proved Tailwind emits nothing for it.

That verdict is right. `tailwind.config.js` does **not** customise the opacity scale, so Tailwind's default steps apply (0/5/10/15/20/...) and `4` is not among them. An illegal step is not a near miss that renders slightly wrong: it drops the declaration entirely, which is exactly the silent defect class this guard exists to catch.

### The alpha choice

The occurrence is the illustrative token in `ExpertBlock.tsx`'s header comment, not an applied `className`. The guard scans file text, so an anti-pattern quoted in prose is picked up like any other usage.

**No rendered pixel changes.** The tint comes from `color-mix(in srgb, var(--info) 4%, transparent)` and still resolves to exactly 4%. Only the comment's quoted token moves, to `bg-info/5`:

- `/5` is the nearest scale-legal step to the intended 4%, and at this strength the two are visually indistinguishable.
- It matches the sibling call sites: `NodeChip`, `CoachingCard` and `WorthInvestigating` all use `bg-info/5` for the faint info tint.
- The scale is **not** extended. The config never customised it, so `4` was never a legal step to intend. Extending it to legalise a token that appears only inside a comment would widen the DS surface to serve prose.

The same comment also asserted, in the present tense, that the config declares `info.DEFAULT: 'var(--info)'`. #379 made that false. It is corrected in place, because a reader acting on it would reintroduce the defect the guard just caught.

## Fix 2: brittle `--info` regex

`InspectorCoaching.spec.tsx` asserted `/^\s*--info:\s*#[0-9A-Fa-f]{6}\s*;/m` against `brand.css`. #379 split the token into channels:

```css
--info-rgb: 39 122 157;
--info: rgb(var(--info-rgb));
```

The colour is bit-for-bit identical; only the spelling stopped being a hex literal. A correct refactor therefore read as a regression, which is the failure mode where a guard gets deleted rather than fixed.

The assertion's intent survives intact. It exists because the CoachingCard border must point at a token that is really declared: `var(--typo)` renders no border at all, and the surrounding assertions cannot tell that apart from success. Only its brittle textual assumption changes.

It now parses the resolved value rather than regexing the file's current spelling: strip comments, collect the custom-property declarations, follow the `var()` chain, and assert it bottoms out in a real colour. Any future re-spelling that still resolves passes; a missing or dangling token still fails.

### Mutation-checked both ways

| Mutation to `brand.css` | Expected | Result |
| --- | --- | --- |
| `--info: var(--typo-does-not-exist)` | fail | fails with "must resolve to a real colour, not a dangling var()" |
| `--info: #277A9D` (pre-#379 spelling) | pass | passes |

So the rewrite is genuinely less format-brittle without going vacuous.

## Evidence

**RED at base `dc8c3662`**

- guard: `expected [ 'bg-info/4' ] to deeply equal []`
- coaching: `expect(brandCss).toMatch(/^\s*--info:\s*#[0-9A-Fa-f]{6}\s*;/m)` at `:162`

**GREEN at head**

- Both target specs: 17 passed.
- Shard-local suites for all three touched directories (`tests/ci-guards/`, `src/canvas/ui/inspector-v2/`, `src/components/results/`): **181 files, 3470 tests, all passed.**
- `pnpm typecheck` (`tsconfig.ci.json`, the authoritative gate): clean, exit 0.
- `tsconfig.app.json` is not a gate: it fails at pristine base with 2317 pre-existing errors. Neither file touched here contributes any of them.

**`scripts/validate-prepush.sh`**

Checks 1 to 7 pass, with Check 3 linting both changed files. Check 8 fails on a **known pre-existing** net-new violation:

```
production-hex:
  src/components/chat/artefactIframeTemplate.ts  #6E6B6B  --text-light: #6E6B6B;
```

That file is untouched here and is being fixed in a separate lane, so it is deliberately left alone. The DS ratchet otherwise moved the right way (`legacy-tailwind-token` 2159 vs baseline 2165, `production-hex` 303 vs baseline 311).

## Scope

Two files, comment and test only. No component behaviour, no rendered output, and no change to the guard or to the DS scale.

Draft, and not to be merged without review.
