### PR TITLE
fix(ci-guards): scan compiled output not comments — the alpha guard ignores documented anti-patterns

### DIFF
--- a/tests/ci-guards/semantic-colour-alpha.spec.ts
+++ b/tests/ci-guards/semantic-colour-alpha.spec.ts
@@ -78,12 +78,154 @@ function walk(dir: string, out: string[] = []): string[] {
  * Remove comments from a file's text BEFORE the utility scan runs, so a Tailwind
  * token quoted in a comment is never mistaken for a shipped class.
  *
- * STUB (RED checkpoint): returns the text unchanged. The scan therefore still
- * sees comment tokens, so the footgun tests below fail. The real literal-aware
- * strippers replace this body in the follow-up commit.
+ * WHY. This guard catches opacity-modified utilities that reach the browser and
+ * silently emit no CSS. A token inside a comment renders nothing, so it is a
+ * non-defect; worse, scanning comments punishes authors for documenting the very
+ * anti-pattern this guard teaches (`bg-info/4` in ExpertBlock's header comment
+ * reddened staging exactly this way, #385). Only the INPUT TEXT is pre-processed
+ * here: every surviving match still compiles against the real Tailwind and every
+ * emission assertion is untouched.
+ *
+ * Comment characters are replaced with spaces (newlines kept) so any line/column
+ * the scan reports stays accurate and offsets do not shift; the file is never
+ * collapsed.
+ *
+ * A `//`, a comment-open or a comment-close inside a string, template literal or
+ * regex literal is NOT a comment: `content-['//']`, a URL in a string and a
+ * regex of slashes all keep their code. Template `${...}` interpolations are real
+ * code, so a class inside `${cond ? 'bg-info/30' : ''}` survives.
+ *
+ * This is a small hand-written state machine rather than a dependency: the repo
+ * ships no comment-stripper (strip-comments / strip-json-comments are absent from
+ * package.json and node_modules), and a general JS parser (acorn/espree) is not a
+ * dependency either, so pulling one in for a CI guard's input pre-pass would be a
+ * heavier, less transparent addition than the tokeniser below.
  */
-function stripComments(text: string, _file: string): string {
-  return text
+function stripComments(text: string, file: string): string {
+  return /\.css$/.test(file) ? stripCssComments(text) : stripJsComments(text)
+}
+
+/** May a `/` here begin a regex literal, given the previous significant char? */
+function regexCanStart(prev: string): boolean {
+  // After a value (identifier, number, `)`, `]`, `}`, `.`, or a string/template
+  // close) a `/` is division. Everywhere else (operators, `(`, `,`, `=`, `:`,
+  // `[`, `{`, `;`, `!`, `&`, `|`, `?`, `+`, `-`, `*`, `%`, `<`, `>`, `^`, `~`) or
+  // at the start of the file, a `/` opens a regex.
+  return prev === '' || !/[A-Za-z0-9_$)\].}'"`]/.test(prev)
+}
+
+/**
+ * Strip `//` line and block comments from JS/TS/JSX/TSX, treating string,
+ * template and regex literals (and `${...}` interpolations) as code.
+ */
+function stripJsComments(src: string): string {
+  const a = src.split('')
+  const n = a.length
+  const blank = (i: number): void => {
+    if (a[i] !== '\n' && a[i] !== '\r') a[i] = ' '
+  }
+
+  type State = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex'
+  let state: State = 'code'
+  let prev = '' // previous significant code char, for regex detection
+  let regexClass = false // inside a regex `[...]` char class, where `/` is literal
+  let interp = 0 // brace depth inside the current `${...}`; 0 = not in one
+  const interpStack: number[] = [] // suspended depths, for templates nested in `${...}`
+
+  let i = 0
+  while (i < n) {
+    const c = a[i]
+    const d = i + 1 < n ? a[i + 1] : ''
+
+    if (state === 'code') {
+      if (c === '/' && d === '/') { blank(i); blank(i + 1); state = 'line'; i += 2; continue }
+      if (c === '/' && d === '*') { blank(i); blank(i + 1); state = 'block'; i += 2; continue }
+      if (c === "'") { state = 'single'; prev = c; i++; continue }
+      if (c === '"') { state = 'double'; prev = c; i++; continue }
+      if (c === '`') { state = 'template'; prev = c; i++; continue }
+      if (c === '/' && regexCanStart(prev)) { state = 'regex'; regexClass = false; prev = c; i++; continue }
+      if (interp > 0) {
+        if (c === '{') interp++
+        else if (c === '}') {
+          interp--
+          if (interp === 0) { state = 'template'; interp = interpStack.pop() ?? 0; prev = c; i++; continue }
+        }
+      }
+      if (!/\s/.test(c)) prev = c
+      i++
+      continue
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; i++; continue }
+      blank(i); i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { blank(i); blank(i + 1); state = 'code'; i += 2; continue }
+      blank(i); i++; continue
+    }
+    if (state === 'single') {
+      if (c === '\\') { i += 2; continue }
+      if (c === "'") { state = 'code'; prev = c; i++; continue }
+      i++; continue
+    }
+    if (state === 'double') {
+      if (c === '\\') { i += 2; continue }
+      if (c === '"') { state = 'code'; prev = c; i++; continue }
+      i++; continue
+    }
+    if (state === 'template') {
+      if (c === '\\') { i += 2; continue }
+      if (c === '`') { state = 'code'; prev = c; i++; continue }
+      if (c === '$' && d === '{') { interpStack.push(interp); interp = 1; state = 'code'; prev = '{'; i += 2; continue }
+      i++; continue
+    }
+    // state === 'regex'
+    if (c === '\\') { i += 2; continue }
+    if (c === '[') { regexClass = true; i++; continue }
+    if (c === ']') { regexClass = false; i++; continue }
+    if (c === '/' && !regexClass) { state = 'code'; prev = c; i++; continue }
+    i++
+  }
+  return a.join('')
+}
+
+/** Strip only block comments from CSS (no line comments), treating strings as code. */
+function stripCssComments(src: string): string {
+  const a = src.split('')
+  const n = a.length
+  const blank = (i: number): void => {
+    if (a[i] !== '\n' && a[i] !== '\r') a[i] = ' '
+  }
+
+  type State = 'code' | 'block' | 'single' | 'double'
+  let state: State = 'code'
+
+  let i = 0
+  while (i < n) {
+    const c = a[i]
+    const d = i + 1 < n ? a[i + 1] : ''
+
+    if (state === 'code') {
+      if (c === '/' && d === '*') { blank(i); blank(i + 1); state = 'block'; i += 2; continue }
+      if (c === "'") { state = 'single'; i++; continue }
+      if (c === '"') { state = 'double'; i++; continue }
+      i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { blank(i); blank(i + 1); state = 'code'; i += 2; continue }
+      blank(i); i++; continue
+    }
+    if (state === 'single') {
+      if (c === '\\') { i += 2; continue }
+      if (c === "'") { state = 'code'; i++; continue }
+      i++; continue
+    }
+    // state === 'double'
+    if (c === '\\') { i += 2; continue }
+    if (c === '"') { state = 'code'; i++; continue }
+    i++
+  }
+  return a.join('')
 }
 
 /** The config's colour key paths, flattened the way Tailwind names them. */

--- a/tests/ci-guards/semantic-colour-alpha.spec.ts
+++ b/tests/ci-guards/semantic-colour-alpha.spec.ts
@@ -43,9 +43,10 @@
  * so a colour used with a modifier tomorrow is covered tomorrow — including
  * sub-shades (`bg-warning-light/70`) and legacy aliases (`bg-carrot-500/10`).
  */
-import { describe, it, expect, beforeAll } from 'vitest'
-import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { readFileSync, readdirSync, statSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { join, resolve as resolvePath } from 'node:path'
+import { tmpdir } from 'node:os'
 import postcss from 'postcss'
 import tailwind from 'tailwindcss'
 import config from '../../tailwind.config.js'
@@ -73,6 +74,18 @@ function walk(dir: string, out: string[] = []): string[] {
   return out
 }
 
+/**
+ * Remove comments from a file's text BEFORE the utility scan runs, so a Tailwind
+ * token quoted in a comment is never mistaken for a shipped class.
+ *
+ * STUB (RED checkpoint): returns the text unchanged. The scan therefore still
+ * sees comment tokens, so the footgun tests below fail. The real literal-aware
+ * strippers replace this body in the follow-up commit.
+ */
+function stripComments(text: string, _file: string): string {
+  return text
+}
+
 /** The config's colour key paths, flattened the way Tailwind names them. */
 function colourKeys(): string[] {
   const colours = (config as { theme: { extend: { colors: Record<string, unknown> } } }).theme.extend.colors
@@ -94,11 +107,11 @@ function colourKeys(): string[] {
  * scope here: this guard is about declaration FORM, and a colour that does not
  * exist has no form to get wrong.
  */
-function usedClasses(): string[] {
+function usedClasses(root: string = SRC): string[] {
   const keys = new Set(colourKeys())
   const found = new Set<string>()
-  for (const file of walk(SRC)) {
-    const text = readFileSync(file, 'utf8')
+  for (const file of walk(root)) {
+    const text = stripComments(readFileSync(file, 'utf8'), file)
     for (const m of text.matchAll(MODIFIED)) {
       const [whole, , colour] = m
       if (keys.has(colour)) found.add(whole)
@@ -226,4 +239,116 @@ describe('semantic colours emit CSS when used with an opacity modifier', () => {
     expect(css.css).toMatch(/border-color:\s*rgb\(var\(--info-rgb\)\s*\/\s*0?\.3\)/)
     expect(css.css).toMatch(/background-color:\s*rgb\(var\(--danger-rgb\)\s*\/\s*0?\.2\)/)
   }, 60_000)
+})
+
+/**
+ * THE FOOTGUN. The scan reads raw file text, so a utility QUOTED IN A COMMENT is
+ * pulled into the required set and compiled like a shipped class. `bg-info/4`
+ * (4 is not a legal opacity step, so it emits NO rule) sat in ExpertBlock's
+ * header comment and reddened origin/staging exactly this way (#385, healed only
+ * by rewording the comment; the footgun itself remained). A token in a comment
+ * renders nothing, so it is a non-defect; scanning comments also punishes authors
+ * for documenting the very anti-pattern this guard teaches. So comments are
+ * stripped from the INPUT TEXT before the scan; nothing else changes: every
+ * surviving match still compiles against the real Tailwind and every emission
+ * assertion above is untouched.
+ */
+describe('the scan ignores tokens that live only in comments (footgun #385)', () => {
+  let dir: string
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'guard-strip-comments-'))
+    // `bg-info/4`, the illegal step that emits nothing, appears ONLY in
+    // comments, in all three forms the guard scans: a `//` line comment, a
+    // `/* */` block comment, and a CSS `/* */` comment. Real, shipped utilities
+    // (`border-info/30` as a className AND as a CSS `@apply`, `bg-info/5` as a
+    // className) sit in genuine code and MUST survive the stripping.
+    writeFileSync(
+      join(dir, 'line.tsx'),
+      '// documented anti-pattern: never ship bg-info/4, it emits no CSS\n' +
+        'export const A = () => <div className="border-info/30" />\n',
+    )
+    writeFileSync(
+      join(dir, 'block.tsx'),
+      '/* the faint info tint bg-info/4 is illegal; the nearest legal step is bg-info/5 */\n' +
+        'export const B = () => <div className="bg-info/5" />\n',
+    )
+    writeFileSync(
+      join(dir, 'style.css'),
+      '/* never author bg-info/4 in a stylesheet, 4 is not a scale step */\n' +
+        '.pill { @apply border-info/30; }\n',
+    )
+  })
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('an illegal utility quoted ONLY in a comment is not scanned (the headline)', () => {
+    // RED before stripping: the passthrough stub leaves `bg-info/4` in the text,
+    // so the scan pulls it from the // , /* */ and CSS /* */ comments and the
+    // required set contains a class that provably emits nothing.
+    expect(
+      usedClasses(dir),
+      'bg-info/4 lives only in comments and renders nothing; the scan must ignore it',
+    ).not.toContain('bg-info/4')
+  })
+
+  it('a REAL utility in genuine code survives stripping (className and CSS @apply)', () => {
+    const used = usedClasses(dir)
+    // The existing mutation control asserts `border-info/30` stays in the scanned
+    // set; prove a real usage is not collateral of comment stripping.
+    expect(used, 'a real border-info/30 (className and @apply) must still be scanned')
+      .toContain('border-info/30')
+    expect(used, 'a real bg-info/5 className must still be scanned')
+      .toContain('bg-info/5')
+  })
+})
+
+/**
+ * LITERAL-SAFETY PINS. A naive line-comment regex strip eats real code: a URL in
+ * a string, a class after content-['//'], a regex full of slashes. These pin the
+ * tokeniser so a comment-opening sequence inside a string, template or regex
+ * literal is treated as code, and a class inside a template interpolation is real
+ * code. Each hostile class has its own case; swapping the tokeniser for the naive
+ * stripper turns these RED (mutation-checked in the PR).
+ */
+describe('literal-aware stripping: comment markers inside string/template/regex are code', () => {
+  const scan = (text: string, file = 'hostile.tsx'): Set<string> =>
+    new Set([...stripComments(text, file).matchAll(MODIFIED)].map((m) => m[0]))
+
+  it('`//` inside a string does not strip a real class later on the same line', () => {
+    const src = "const u = 'https://cdn.example/x'; const c = 'border-info/30'"
+    expect(scan(src)).toContain('border-info/30')
+  })
+
+  it('a class inside a template `${...}` interpolation survives', () => {
+    const src = "const c = `p-2 ${cond ? 'bg-info/30' : ''}`"
+    expect(scan(src)).toContain('bg-info/30')
+  })
+
+  it('`/*` and `*/` inside a string neither open nor close a comment', () => {
+    const src = "const a = '/*'; const c = 'bg-danger/20'; const b = '*/'"
+    expect(scan(src)).toContain('bg-danger/20')
+  })
+
+  it('`//` inside a regex literal is not a comment', () => {
+    const src = "const re = /\\/\\//g; const c = 'text-info/40'"
+    expect(scan(src)).toContain('text-info/40')
+  })
+
+  it("`content-['//']` keeps the class that follows it", () => {
+    const src = '<div className="before:content-[\'//\'] border-info/30" />'
+    expect(scan(src)).toContain('border-info/30')
+  })
+
+  it('a genuine `//` line comment IS still stripped', () => {
+    const found = scan("const c = 'bg-info/5' // ship note: bg-info/4 is illegal")
+    expect(found).toContain('bg-info/5')
+    expect(found).not.toContain('bg-info/4')
+  })
+
+  it('a genuine `/* */` block comment IS still stripped', () => {
+    const found = scan("const c = 'bg-info/5' /* avoid bg-info/4 here */")
+    expect(found).toContain('bg-info/5')
+    expect(found).not.toContain('bg-info/4')
+  })
 })


### PR DESCRIPTION
## The decision

**Strip comments before the guard scans.** `semantic-colour-alpha.spec.ts` reads
each file's raw text and requires every opacity-modified utility it finds to
compile against the real Tailwind and emit a rule — but it scanned comments too.

The guard exists to catch opacity-modified utilities that ship to the browser
and silently emit no CSS. A token inside a comment renders nothing, so it is a
non-defect. Scanning comments therefore both **false-positives on non-defects**
AND **pressures authors to stop documenting the exact anti-pattern class the
guard teaches**. `bg-info/4` quoted in `src/components/results/ExpertBlock.tsx`'s
header comment broke `origin/staging` this way (fixed in #385 by rewording the
quoted token; the footgun itself remained). Only the *input text* is
pre-processed here — the compile-with-real-Tailwind step and every emission
assertion are untouched.

Over the real tree the fix removes exactly **one** comment-only token:
`border-goal/30`, a JSDoc example in `src/canvas/ui/inspector-v2/types.ts:57`
(`/** ... CSS class like 'border-goal/30' */`). The scanned floor moves 93 → 92,
still well above the guard's `>= 86` floor.

## Approach: a small literal-aware tokeniser, not a regex, not a new dependency

`stripComments(text, file)` dispatches on extension and replaces every comment
character with a space (newlines kept), so line/column offsets never shift and
the file is never collapsed.

- **JS/TS/JSX/TSX** — a hand-written state machine over
  in-string / in-template / in-regex / in-line-comment / in-block-comment states.
  A naive `text.replace(/\/\/.*/g, '')` eats real code, so it is deliberately
  avoided.
- **CSS** — strips only block comments (standard CSS has no `//`), string-aware.

**Why a tokeniser, not a dependency.** The repo ships no comment-stripper
(`strip-comments` / `strip-json-comments` absent from `package.json` and
`node_modules`) and no general JS parser dependency (`acorn` / `espree`). Pulling
one in for a CI guard's input pre-pass would be a heavier, less transparent
addition than the ~60-line state machine. **No dependency was added.**

### Literal-safety guarantees (pinned)

A `//`, comment-open or comment-close inside a string, template or regex literal
is treated as code, and a class inside a `${...}` interpolation survives:

- `//` inside a string does not strip a later class on the same line
  (`'https://cdn…'; 'border-info/30'`).
- A class inside a template `${cond ? 'bg-info/30' : ''}` survives.
- Comment-open / comment-close inside a string neither open nor close a comment.
- `//` inside a regex literal (`/\/\//g`) is not a comment.
- `content-['//']` keeps the class that follows it.
- A genuine `//` and a genuine `/* */` comment ARE still stripped.

## RED-first + mutation evidence

- **RED checkpoint** (commit `5c35077`): the seam is wired in with a **passthrough
  stub**. The three comment-dependent tests fail RED (headline + both "genuine
  comment IS stripped" pins); the existing emission controls stay GREEN.
- **GREEN checkpoint** (commit `d3d426a`): the real tokeniser lands. **12/12 pass.**
- **Mutation A (remove the stripping)**: the passthrough stub is exactly this
  mutation — the headline goes RED, proving the test bites.
- **Mutation B (naive regex stripper)**: swapping the tokeniser for
  `text.replace(/\/\/.*/g,'').replace(/\/\*[\s\S]*?\*\//g,'')` turns the four
  literal-safety pins (string `//`, string `/* */`, regex `//`, `content-['//']`)
  RED while the emission controls stay green — proving the tokeniser earns its keep.

**Both original mutation controls still bite** (verified unchanged): the positive
`bg-gray-400/10` control still emits, and reverting `info` to bare `var(--info)`
still un-emits `border-info/30`. A new positive fixture proves a real
`border-info/30` className **and** a real `@apply border-info/30` both survive
stripping.

## Gates

- **Guard spec + all ci-guards siblings**: 6 files, 42 tests pass.
- **Narrow typecheck** (`tsc -p tsconfig.ci.json`, the CI gate): clean.
- **`tsc -p tsconfig.app.json` vs a matched base worktree**: error multisets
  byte-identical (4003 = 4003) — zero new errors. The changed file lives under
  `tests/`, outside both configs' `src`-only include, so it is out of typecheck
  scope by construction.
- **`scripts/validate-prepush.sh`**: Checks 1–7 pass (branch guard, typecheck,
  lint, smoke tests, stale-.js, dep audit, close-out). The only failure is
  **Check 8** flagging `src/components/chat/artefactIframeTemplate.ts` (`#6E6B6B`)
  — pre-existing drift on the base `8308d9e3`, #384's, **untouched by this branch**
  (this branch changes one file only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
