### PR TITLE
fix(auth): restore real sign-in on staging — the front door

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -83,6 +83,24 @@
   # to production by adding to [build.environment] ONLY after sign-off.
   VITE_FEATURE_STRENGTHEN_PANEL = "1"
 
+  # Front door (real sign-in) — keep the REAL Supabase SDK in the staging
+  # bundle. Without this, vite.config.ts aliases @supabase/supabase-js to
+  # src/stubs/supabase-stub.mjs on every guest build, and that stub does not
+  # implement signInWithOtp/signInWithOAuth at all — so sign-in cannot work
+  # no matter what the requireLogin flag says (the runbook in src/flags.ts
+  # `requireLogin` documents exactly this trap).
+  #
+  # This does NOT turn guest mode off: VITE_AUTH_MODE stays "guest", so
+  # unauthenticated visitors still land on the guest canvas exactly as today
+  # and the other workstreams' staging QA is unaffected. It only makes real
+  # sign-in POSSIBLE for anyone who opts in per-browser with
+  # `localStorage.setItem('feature.requireLogin', '1')`.
+  #
+  # Staging-scoped deliberately — production (main) inherits only from
+  # [build.environment] and keeps the stub. Promote to [build.environment]
+  # ONLY after sign-off.
+  VITE_STUB_SUPABASE = "0"
+
   # Hero fixture gallery — internal-only /dev/hero-gallery route rendering
   # prototype hero states from typed fixtures (visible internal-preview
   # banner on every instance). Staging-only for design review; never add to

--- a/scripts/supabase-stub-decision.mjs
+++ b/scripts/supabase-stub-decision.mjs
@@ -1,0 +1,45 @@
+// Front-door fix: the single source of truth for "should this build stub the
+// Supabase SDK?".
+//
+// Extracted from vite.config.ts so it can be unit-tested without importing the
+// whole Vite config (which pulls in esbuild and cannot load under jsdom).
+// vite.config.ts imports this module — there is no second copy of the rule.
+//
+// Background: `isPoc` historically did three jobs at once — mint a guest user
+// (src/lib/poc.ts `isGuestAuth`), stub @tanstack/react-query, AND alias the
+// real Supabase SDK out of the bundle. Staging pins VITE_AUTH_MODE="guest" in
+// netlify.toml, so the real auth client was never deployed, and the stub in
+// src/stubs/supabase-stub.mjs does not implement signInWithOtp /
+// signInWithOAuth — the only two methods src/contexts/AuthContext.tsx calls.
+// Sign-in therefore could not work on staging regardless of the requireLogin
+// flag. See the FLIP RUNBOOK note on `requireLogin` in src/flags.ts.
+
+/**
+ * Is this a PoC / guest-mode build?
+ * @param {Record<string, string | undefined>} env
+ * @returns {boolean}
+ */
+export function isPocBuild(env) {
+  return env.VITE_POC_ONLY === '1' || env.VITE_AUTH_MODE === 'guest'
+}
+
+/**
+ * Should the Supabase SDK (`@supabase/supabase-js` AND its internal
+ * `@supabase/gotrue-js`) be aliased to the local stubs?
+ *
+ * Default preserves the historical behaviour exactly: stub on any PoC/guest
+ * build. `VITE_STUB_SUPABASE=0` opts out, keeping the REAL client in the
+ * bundle so magic-link sign-in works — WITHOUT turning guest mode off, so
+ * unauthenticated visitors still get the guest canvas.
+ *
+ * The two Supabase aliases are always decided together: aliasing gotrue-js to
+ * `export default {}` while leaving the real supabase-js in place would break
+ * the client, which imports GoTrueClient from it.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {boolean}
+ */
+export function shouldStubSupabase(env) {
+  if (env.VITE_STUB_SUPABASE === '0') return false
+  return isPocBuild(env)
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,6 +19,13 @@ interface ImportMetaEnv {
   readonly VITE_BUILD_ID?: string
   readonly VITE_POC_ONLY?: string
   readonly VITE_AUTH_MODE?: string
+  /**
+   * Build-time only. "0" keeps the REAL @supabase/supabase-js in the bundle
+   * on a PoC/guest build (see vite.config.ts `stubSupabase`). Unset/any other
+   * value preserves the historical behaviour: stub whenever PoC/guest.
+   * Not read at runtime — the alias decision happens in vite.config.ts.
+   */
+  readonly VITE_STUB_SUPABASE?: string
   readonly VITE_STORAGE_KEY?: string
   readonly VITE_RELEASE_VERSION?: string
   readonly VITE_SESSION_ID?: string

--- a/tests/ci-guards/vite.supabase-stub-decoupling.spec.ts
+++ b/tests/ci-guards/vite.supabase-stub-decoupling.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Front-door guard — the Supabase SDK stub must stay DECOUPLED from PoC mode.
+ *
+ * Why this test exists
+ * --------------------
+ * `vite.config.ts` used to alias `@supabase/supabase-js` (and its internal
+ * `@supabase/gotrue-js`) to `src/stubs/*.mjs` whenever the build was a
+ * PoC/guest build. Staging pins `VITE_AUTH_MODE = "guest"` in `netlify.toml`,
+ * so the REAL auth SDK was never in the deployed bundle — and the stub does
+ * not implement `signInWithOtp` / `signInWithOAuth`, which are the only two
+ * methods `src/contexts/AuthContext.tsx` ever calls. Sign-in could not work,
+ * regardless of the `requireLogin` flag. (Verified at the bytes against the
+ * live staging bundle at commit 9d839524: zero occurrences of `AuthApiError`,
+ * `code_verifier`, `gotrue-js`, `AuthRetryableFetchError`.)
+ *
+ * `VITE_STUB_SUPABASE=0` keeps the real client in the bundle while leaving
+ * guest mode as the default.
+ *
+ * This imports the SAME module `vite.config.ts` imports — there is no
+ * hand-copied second list of the rule to drift out of sync.
+ *
+ * Mutation check: change `shouldStubSupabase` in
+ * scripts/supabase-stub-decision.mjs back to `return isPocBuild(env)` and the
+ * opt-out cases below fail.
+ */
+import { describe, it, expect } from 'vitest'
+import { shouldStubSupabase, isPocBuild } from '../../scripts/supabase-stub-decision.mjs'
+
+describe('shouldStubSupabase — front-door decoupling', () => {
+  it('guest build, VITE_STUB_SUPABASE unset: stubs — historical behaviour pinned', () => {
+    expect(shouldStubSupabase({ VITE_AUTH_MODE: 'guest' })).toBe(true)
+  })
+
+  it('VITE_POC_ONLY=1, VITE_STUB_SUPABASE unset: stubs', () => {
+    expect(shouldStubSupabase({ VITE_POC_ONLY: '1' })).toBe(true)
+  })
+
+  it('guest build + VITE_STUB_SUPABASE=0: does NOT stub — the fix', () => {
+    expect(shouldStubSupabase({ VITE_AUTH_MODE: 'guest', VITE_STUB_SUPABASE: '0' })).toBe(false)
+  })
+
+  it('VITE_POC_ONLY=1 + VITE_STUB_SUPABASE=0: does NOT stub', () => {
+    expect(shouldStubSupabase({ VITE_POC_ONLY: '1', VITE_STUB_SUPABASE: '0' })).toBe(false)
+  })
+
+  it('non-PoC build: does not stub regardless', () => {
+    expect(shouldStubSupabase({ VITE_AUTH_MODE: 'real', VITE_POC_ONLY: '0' })).toBe(false)
+    expect(shouldStubSupabase({})).toBe(false)
+  })
+
+  it('only the exact string "0" opts out — no truthiness surprises', () => {
+    for (const v of ['1', 'true', 'false', '', 'no', '00']) {
+      expect(shouldStubSupabase({ VITE_AUTH_MODE: 'guest', VITE_STUB_SUPABASE: v })).toBe(true)
+    }
+  })
+
+  it('the opt-out does NOT change guest-mode detection itself', () => {
+    // The whole point: guest mode stays on, so unauthenticated visitors keep
+    // the guest canvas and the other workstreams' staging QA is unaffected.
+    expect(isPocBuild({ VITE_AUTH_MODE: 'guest', VITE_STUB_SUPABASE: '0' })).toBe(true)
+    expect(isPocBuild({ VITE_POC_ONLY: '1', VITE_STUB_SUPABASE: '0' })).toBe(true)
+  })
+})
+
+describe('vite.config wiring — the alias list actually uses the decision', () => {
+  it('vite.config.ts imports the shared module and gates BOTH Supabase aliases on it', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    // `import.meta.url` is an http:// URL under jsdom, so resolve from cwd
+    // (vitest runs at the repo root) rather than from the module URL.
+    const src = readFileSync(resolve(process.cwd(), 'vite.config.ts'), 'utf-8')
+
+    expect(src).toContain("from './scripts/supabase-stub-decision.mjs'")
+    expect(src).toContain('shouldStubSupabase(env)')
+
+    // The two Supabase aliases must sit inside the `stubSupabase` block, and
+    // react-query must NOT (it stays on the isPoc gate).
+    const stubBlock = src.slice(src.indexOf('...(stubSupabase ?'), src.indexOf('...(isPoc ?'))
+    expect(stubBlock).toContain('@supabase/supabase-js')
+    expect(stubBlock).toContain('@supabase/gotrue-js')
+    expect(stubBlock).not.toContain('@tanstack/react-query')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+// Single source of truth for the Supabase-stub decision (unit-tested in
+// tests/ci-guards/vite.supabase-stub-decoupling.spec.ts).
+import { shouldStubSupabase } from './scripts/supabase-stub-decision.mjs';
 
 // ⚠️  CRITICAL: DO NOT ADD use-sync-external-store shim aliases!
 // The custom shim causes React #185 infinite loops because useCallback dependencies
@@ -17,6 +20,27 @@ export default defineConfig(({ mode, command }) => {
   const isPoc =
     env.VITE_POC_ONLY === '1' ||
     env.VITE_AUTH_MODE === 'guest';
+
+  // Front-door fix: the Supabase SDK stub is DECOUPLED from PoC mode.
+  //
+  // Historically `isPoc` did three jobs at once: mint a guest user
+  // (src/lib/poc.ts `isGuestAuth`), stub `@tanstack/react-query`, AND alias
+  // the real Supabase SDK out of the bundle. That last one made real sign-in
+  // impossible on any guest build — the stub in src/stubs/supabase-stub.mjs
+  // does not even implement `signInWithOtp` / `signInWithOAuth`, which are
+  // the only two methods src/contexts/AuthContext.tsx actually calls.
+  //
+  // `VITE_STUB_SUPABASE=0` keeps the REAL client in the bundle while leaving
+  // guest mode as the default, so:
+  //   • unauthenticated visitors still get the guest canvas (no regression),
+  //   • anyone opting in via `localStorage feature.requireLogin = 1` gets a
+  //     working magic-link sign-in instead of a silent no-op.
+  //
+  // Default (unset) preserves today's behaviour exactly: stub whenever isPoc.
+  // The two Supabase aliases move TOGETHER — aliasing `@supabase/gotrue-js`
+  // to `export default {}` while leaving the real supabase-js in place would
+  // break the real client, which imports GoTrueClient from it.
+  const stubSupabase = shouldStubSupabase(env);
 
   // Proxy config only applies to serve/preview, not build
   const isServing = command === 'serve';
@@ -66,10 +90,15 @@ export default defineConfig(({ mode, command }) => {
     alias: [
       // @ → src/ path alias (used by 60+ files)
       { find: /^@\//, replacement: path.resolve(__dirname, 'src') + '/' },
-      // POC/test stubs for guest mode
-      ...(isPoc ? [
+      // POC/test stubs for guest mode.
+      // Supabase pair is gated on `stubSupabase` (see above) so real sign-in
+      // can be restored without un-stubbing anything else; react-query stays
+      // on `isPoc` and is unaffected by the front-door fix.
+      ...(stubSupabase ? [
         { find: '@supabase/supabase-js', replacement: path.resolve(__dirname, 'src/stubs/supabase-stub.mjs') },
         { find: '@supabase/gotrue-js',   replacement: path.resolve(__dirname, 'src/stubs/gotrue-stub.mjs') },
+      ] : []),
+      ...(isPoc ? [
         { find: '@tanstack/react-query', replacement: path.resolve(__dirname, 'src/stubs/react-query-stub.mjs') },
       ] : []),
       // ⚠️  NO use-sync-external-store aliases - use real package with dedupe only!


### PR DESCRIPTION
**Draft — do not merge without reading "What still needs Paul" at the bottom.**

Paul cannot sign in to staging. This is why, and the smallest change that fixes it without disturbing the other two workstreams.

---

## The diagnosis, confirmed at the bytes

Staging pins `VITE_AUTH_MODE = "guest"` in `netlify.toml`. `vite.config.ts` read that single variable to do **three unrelated jobs**:

1. mint a guest user (`src/lib/poc.ts` → `isGuestAuth`),
2. stub `@tanstack/react-query`,
3. alias the **real Supabase SDK** out of the bundle.

Job 3 is the bug. `src/stubs/supabase-stub.mjs` implements only `signInWithPassword`, `signOut`, `getSession`, `onAuthStateChange`. It **does not implement `signInWithOtp` or `signInWithOAuth`** — the only two methods `src/contexts/AuthContext.tsx` ever calls. So sign-in could never work on staging, whatever the `requireLogin` flag said.

The `requireLogin` FLIP RUNBOOK comment in `src/flags.ts` predicted this precisely. It was right.

**Live-probed the deployed staging bundle** (commit `9d839524`, `assets/AppPoC-DdrFFakU.js`):

| marker | live staging | with this fix |
|---|---|---|
| `AuthApiError` | 0 | 1 |
| `AuthSessionMissingError` | 0 | 1 |
| `gotrue-js` | 0 | 1 |
| `code_verifier` | 0 | 1 |
| `AuthRetryableFetchError` | 0 | 1 |
| `signInWithOtp` *(positive control)* | 1 | 1 |

The positive control matters: my first attempt used `signInWithOtp` as the discriminator and it was **wrong** — that string is the `AuthContext` call site and is present either way. The five markers above were verified to discriminate (guest build = 0, real build = 1) before being trusted.

## Investigation answers

**1. What do the stubs provide?** `supabase-stub` — 4 methods, none of them the ones actually used; `signInWithPassword` returns `{data: null, error: null}`, a silent fake success. `gotrue-stub` — `export default {}`. `react-query-stub` — `QueryClient`/`QueryClientProvider`/`useQuery`/`useMutation`. All three real packages are declared deps, so nothing is missing from `package.json`.

**Can the aliases be decoupled? Yes — and that is this PR.** But the two *Supabase* aliases must move **together**: aliasing `@supabase/gotrue-js` to `export default {}` while restoring the real `supabase-js` would break the client, which imports `GoTrueClient` from it. `react-query` is genuinely independent and **stays stubbed**.

**2. Are real Supabase credentials configured? YES — verified, not assumed.** The Netlify API masks these (`is_secret: true`), so presence there proves nothing about validity. But `VITE_*` vars are inlined into the client bundle at build time, and `src/lib/supabase.ts` is *not* stubbed — so the real values are already sitting in the deployed staging bundle. Extracted and checked: real project ref, `role=anon`, `iss=supabase`, expiry 2035. `GET /auth/v1/settings` with that key returns **HTTP 200**. The credentials work. (No secret values printed here or in the commit.)

**3. What is the auth method?** Magic link (`signInWithOtp`, `shouldCreateUser: false`) and Google OAuth. Two findings:
- **Google OAuth is not enabled on the Supabase project.** `/auth/v1/settings` reports `external: {email: true}` only. The "Continue with Google" button on `LoginPage` **cannot work** until someone enables the provider.
- **Magic link is invite-only.** Confirmed with a safe negative control (fake address, `create_user: false` — sends no email, creates nothing): `422 otp_disabled`, *"Signups not allowed for otp"*. So the email must already exist in `auth.users`.

**4. Any other guard?** No. `AuthGuard` is already mounted and correct. `isGuestAuth` has exactly **one** runtime consumer (`AuthContext.tsx:60`). `isPoC()` from `pocFlags.ts` has **zero** call sites, so nothing else keys off PoC mode. CSP already allows `https://*.supabase.co` and `wss://*.supabase.co` — no header change needed. Worth noting: only 6 routes sit behind `AuthGuard`; `/login`, `/brief/:slug`, `/plot`, `/plc`, `/test` and the `*` catch-all stay public by design.

**5. What is guest mode for?** It makes the PoC usable with no backend. Killing it would put a login wall in front of all three workstreams' staging QA — and since Google is dead and magic link is invite-only, anyone not already in `auth.users` would be locked out entirely. **So this PR does not kill it.**

## The change

One new build-time variable, `VITE_STUB_SUPABASE`, promoted to `"0"` for the **staging context only**:

- **Guest mode stays on.** `VITE_AUTH_MODE` remains `"guest"`; unauthenticated visitors get the guest canvas exactly as today. Other workstreams unaffected.
- **Real sign-in becomes possible**, opt-in per browser via `localStorage.setItem('feature.requireLogin', '1')`.
- **Production untouched** — `main` inherits only from `[build.environment]` and keeps the stub.
- **Unset default is byte-identical to today.**

The rule lives in one place (`scripts/supabase-stub-decision.mjs`) that `vite.config.ts` imports, so the guard test asserts against the real source rather than a hand-copied mirror.

## Blast radius

| | effect |
|---|---|
| Production (`main`) | **none** — staging-scoped |
| Staging, logged-out visitor | **none** — still the guest canvas |
| Staging, opt-in visitor | gets a working login page instead of a dead one |
| Entry bundle | 46.73 KB gz vs 50 KB budget — **unchanged** (Supabase lands in the lazy `AppPoC` chunk, +94 KB raw there) |
| Tests | `poc.requireLogin.spec.ts` **unmodified**, 9/9 green |

**Residual risks I could not close:**
- The real client now runs `navigator.locks` (the original reason for the gotrue stub) and PKCE on staging.
- **Most likely remaining failure point:** the magic-link callback under `HashRouter` + PKCE. `emailRedirectTo` is `${origin}/#/auth/callback`, which puts `?code=` inside the hash where `detectSessionInUrl` may not find it. Cannot be verified without completing a real sign-in.
- The Supabase **Redirect URL allowlist** must include `https://staging--olumi.netlify.app/**`. Not checkable without dashboard access.

## Rollback

One commit: `git revert 829ceb32`. Staging returns to the stubbed guest build. Nothing else depends on the new variable.

## Gates

`typecheck` clean · `lint` **0 errors** on touched files (4 warnings all pre-existing, in proxy callbacks) · `build` succeeds · `vitest --changed origin/staging` 10/10 · new guard spec 8/8 · `poc.requireLogin.spec.ts` 9/9 unmodified.

**Mutation-checked both ways** (throwaway clone): reverting `shouldStubSupabase` to `return isPocBuild(env)` fails 2 tests; re-coupling the aliases to `isPoc` in `vite.config.ts` fails the wiring test.

## ⚠️ Why there is no deploy-preview evidence

The brief asked for verification on a Netlify deploy preview. **That surface does not exist on this site.** Netlify reports `skip_prs: true` (deploy previews disabled) and `allowed_branches: ['main', 'staging']` — so no preview is built for this PR, and Netlify will not build this branch either. Enabling previews is a site-settings change affecting all workstreams, so I have not touched it.

I verified everything reachable without it: the broken baseline on the live deployed bundle, the fixed behaviour in a local production build byte-compared against that baseline, the credentials against the live Supabase endpoint, and the change logic under mutation. **The deployed behaviour of this specific change is unproven** — that gap is real and is why this is a draft.

## What still needs Paul

1. **Decide how to verify.** Either enable deploy previews / allow this branch on Netlify, or accept merging to staging as the test (rollback is one commit).
2. **Confirm `paulsleepm@gmail.com` exists in `auth.users`.** ⚠️ **Decisive.** Magic link runs `shouldCreateUser: false`, so if the account does not exist, sign-in fails with `otp_disabled` even after this merge. I could not check — the Supabase token in the keychain is a go-keyring blob, not a usable PAT — and I must not create accounts.
3. **After merge:** open staging, run `localStorage.setItem('feature.requireLogin', '1')` in the console, reload, land on `/login`, enter your email, click the link in the email. I did not submit the form — that would send mail on your behalf.
4. **Enable the Google provider in Supabase** if you want that button to work, or accept that it is dead.
5. **Check the Supabase Redirect URL allowlist** covers `https://staging--olumi.netlify.app/**`.

## 🔴 Unrelated security finding — please rotate

While enumerating Netlify env vars I found **`NODE_AUTH_TOKEN`, a GitHub PAT (`ghp_…`), stored unencrypted** (`is_secret: false`, scoped to builds/functions/post_processing/runtime, context `all`). It was printed in plaintext by my enumeration before I could mask it, so it is now in this session's logs. **Treat it as compromised and rotate it.** Separately, it should be marked secret rather than plaintext. Not addressed in this PR.
