### PR TITLE
fix(goal): constraints carry real ids and stop deleting the success target

### DIFF
--- a/src/adapters/cee/types.ts
+++ b/src/adapters/cee/types.ts
@@ -284,7 +284,19 @@ export interface CEEGoalConstraint {
    * read — `c.label.toLowerCase()` throws on a perfectly valid constraint.
    */
   label?: string
-  operator: '>=' | '<=' | '>' | '<' | '='
+  /**
+   * SCHEMA-AUTHORITATIVE (@talchain/schemas 0.19.0 `DraftGoalConstraintSchema`):
+   * `z.enum(['>=', '<='])`, documented "ASCII only — CEE normalises away '<',
+   * '>' and the Unicode forms". PLoT's own preflight agrees: any other operator
+   * is a CONSTRAINT_INVALID_OPERATOR blocker (`validation/preflight-v2.ts`).
+   *
+   * This union previously also admitted '>' | '<' | '=', which let the GoalPanel
+   * offer an '=' the producer cannot accept. Narrowed to match the contract.
+   * Runtime drift is still gated, not assumed away — see UI-SEM-086
+   * (`prepareGoalConstraintsForRequest`), which re-checks the operator at the
+   * wire boundary rather than trusting this type.
+   */
+  operator: '>=' | '<='
   value: number
   probability?: number | null
 

--- a/src/adapters/plot/v2/__tests__/adapter.spec.ts
+++ b/src/adapters/plot/v2/__tests__/adapter.spec.ts
@@ -1158,7 +1158,14 @@ describe('buildV2RequestFromAnalysisReady — display metadata exclusion', () =>
 
     const { request } = buildV2RequestFromAnalysisReady(
       nodes, edges, analysisReady, [], undefined,
-      { brief: 'test brief', goalConstraints: [{ node_id: 'f1', operator: '>=', value: 40 }] }
+      {
+        brief: 'test brief',
+        // Must be a VALID constraint, or the UI-SEM-086 gate drops it and this
+        // spec silently stops covering the goal_constraints key at all.
+        goalConstraints: [
+          { constraint_id: 'c1', node_id: 'f1', operator: '>=' as const, value: 40 },
+        ],
+      }
     )
 
     // Every key on the request must be in the allowlist
@@ -1203,10 +1210,25 @@ describe('buildV2RequestFromAnalysisReady — display metadata exclusion', () =>
 })
 
 // =============================================================================
-// XOR: goal_threshold vs goal_constraints
+// goal_threshold ALONGSIDE goal_constraints (formerly an XOR)
+//
+// These three specs previously asserted that the adapter DELETES the user's
+// goal_threshold whenever any constraint exists, and they did so using a
+// hand-written constraint the UI never produces and PLoT rejects:
+//     { id: 'c1', label: 'Revenue >= 500', operator: '>=', value: 500 }
+// — no constraint_id, no node_id. That is why five defects survived here: the
+// spec blessed an invalid shape and an incorrect behaviour together.
+//
+// PLoT accepts both fields and applies the precedence itself
+// (plot-lite-service `src/routes/v2/run.ts`, Phase 1e "Precedence Routing",
+// which pushes an explicit repair entry recording that goal_threshold was
+// ignored). Deleting it client-side destroyed the user's success target before
+// the producer could route on it or report it.
+//
+// Constraints below are now the shape PLoT actually validates.
 // =============================================================================
 
-describe('XOR: goal_threshold vs goal_constraints', () => {
+describe('goal_threshold alongside goal_constraints', () => {
   const xorNodes: Node[] = [
     makeNode('f1', { label: 'Factor', kind: 'factor', value: 50 }),
     makeNode('goal', { label: 'Goal', kind: 'goal' }),
@@ -1225,14 +1247,24 @@ describe('XOR: goal_threshold vs goal_constraints', () => {
     goal_threshold: 0.8,
   }
 
-  it('removes goal_threshold when goal_constraints are present (non-empty array)', () => {
+  /** A constraint in the shape PLoT's preflight actually accepts. */
+  const validConstraint = {
+    constraint_id: 'c1',
+    node_id: 'f1',
+    label: 'Revenue floor',
+    operator: '>=' as const,
+    value: 500,
+  }
+
+  it('KEEPS goal_threshold when goal_constraints are present (non-empty array)', () => {
     const { request } = buildV2RequestFromAnalysisReady(
       xorNodes, xorEdges, xorAnalysisReady, [], undefined,
-      { goalConstraints: [{ id: 'c1', label: 'Revenue >= 500', operator: '>=', value: 500 }] }
+      { goalConstraints: [validConstraint] }
     )
 
     expect(request.goal_constraints).toHaveLength(1)
-    expect(request).not.toHaveProperty('goal_threshold')
+    // The user's success target survives. PLoT decides precedence, not the UI.
+    expect(request.goal_threshold).toBe(0.8)
   })
 
   it('preserves goal_threshold when goal_constraints is empty array', () => {
@@ -1261,35 +1293,88 @@ describe('XOR: goal_threshold vs goal_constraints', () => {
     }
     const { request } = buildV2RequestFromAnalysisReady(
       xorNodes, xorEdges, noThreshold, [], undefined,
-      { goalConstraints: [{ id: 'c1', label: 'Revenue >= 500', operator: '>=', value: 500 }] }
+      { goalConstraints: [validConstraint] }
     )
 
     expect(request.goal_constraints).toHaveLength(1)
+    // Nothing to keep — analysisReady carried no threshold.
     expect(request).not.toHaveProperty('goal_threshold')
   })
 
-  it('execute path: goal_threshold re-injected via parameter is removed when goal_constraints exist', () => {
-    // Regression test for executeV2RunWithAnalysisReady (adapter.ts:1186-1196).
-    // The builder XOR removes goal_threshold, but the execute path can re-inject
-    // it via the goalThreshold parameter. The second XOR must catch this.
+  it('drops a constraint whose node_id is absent rather than 422ing the run', () => {
+    // UI-SEM-086. This is the exact object the pre-fix GoalPanel wrote, and what
+    // sits in already-poisoned persisted graphs. Forwarding it makes PLoT emit a
+    // CONSTRAINT_TARGET_NOT_FOUND blocker on node "undefined", which 422s the
+    // WHOLE analysis — so the constraint is dropped and the run survives.
     const { request } = buildV2RequestFromAnalysisReady(
       xorNodes, xorEdges, xorAnalysisReady, [], undefined,
       { goalConstraints: [{ id: 'c1', label: 'Revenue >= 500', operator: '>=', value: 500 }] }
     )
 
-    // Builder XOR already removed goal_threshold
-    expect(request).not.toHaveProperty('goal_threshold')
+    expect(request).not.toHaveProperty('goal_constraints')
+    expect(request.goal_threshold).toBe(0.8)
+  })
 
-    // Simulate execute path: goalThreshold parameter re-injects after builder
-    request.goal_threshold = 0.8
+  it('drops a constraint whose operator PLoT rejects', () => {
+    const { request } = buildV2RequestFromAnalysisReady(
+      xorNodes, xorEdges, xorAnalysisReady, [], undefined,
+      {
+        goalConstraints: [
+          // '=' is a CONSTRAINT_INVALID_OPERATOR blocker in PLoT preflight.
+          { ...validConstraint, operator: '=' as never },
+        ],
+      }
+    )
 
-    // Apply the same XOR pattern as executeV2RunWithAnalysisReady (adapter.ts:1194-1196)
-    if (Array.isArray(request.goal_constraints) && request.goal_constraints.length > 0) {
-      delete request.goal_threshold
-    }
+    expect(request).not.toHaveProperty('goal_constraints')
+  })
 
-    expect(request).not.toHaveProperty('goal_threshold')
+  it('rewrites the Unicode operator forms to the ASCII spelling PLoT accepts', () => {
+    const { request } = buildV2RequestFromAnalysisReady(
+      xorNodes, xorEdges, xorAnalysisReady, [], undefined,
+      {
+        goalConstraints: [
+          // The envelope has historically carried these (see
+          // goalConstraintsEnvelope.regression.spec.ts). '≥' and '>=' are the
+          // same relation, so this is an encoding fix, not a semantic one —
+          // dropping the constraint over its spelling would lose real user
+          // intent.
+          { ...validConstraint, operator: '≥' as never },
+        ],
+      }
+    )
+
     expect(request.goal_constraints).toHaveLength(1)
+    expect(request.goal_constraints![0].operator).toBe('>=')
+  })
+
+  it('does NOT coerce strict/equality operators into the accepted pair', () => {
+    // '>' is not '>=' — rewriting it would silently change the user's
+    // constraint. These are dropped and reported, never guessed at.
+    for (const operator of ['>', '<', '=']) {
+      const { request } = buildV2RequestFromAnalysisReady(
+        xorNodes, xorEdges, xorAnalysisReady, [], undefined,
+        { goalConstraints: [{ ...validConstraint, operator: operator as never }] }
+      )
+      expect(request).not.toHaveProperty('goal_constraints')
+    }
+  })
+
+  it('drops the duplicate when two constraints share a constraint_id', () => {
+    const { request } = buildV2RequestFromAnalysisReady(
+      xorNodes, xorEdges, xorAnalysisReady, [], undefined,
+      {
+        goalConstraints: [
+          validConstraint,
+          // CONSTRAINT_DUPLICATE_ID in PLoT preflight — exactly what the old
+          // positional `c${base.length + 1}` id regenerated after a delete.
+          { ...validConstraint, value: 900 },
+        ],
+      }
+    )
+
+    expect(request.goal_constraints).toHaveLength(1)
+    expect(request.goal_constraints![0].value).toBe(500)
   })
 })
 

--- a/src/adapters/plot/v2/__tests__/ceeV3ContractBridge.spec.ts
+++ b/src/adapters/plot/v2/__tests__/ceeV3ContractBridge.spec.ts
@@ -1037,10 +1037,14 @@ describe('goal_constraints pass-through via buildV2RequestFromAnalysisReady', ()
       options: [makeCEEOptionV3('opt1', 'ready', { factor_price: { value: 100 } })],
       goal_node_id: 'outcome_revenue',
     }
+    // Each constraint names a node that EXISTS in the graph above. The previous
+    // fixture ('MRR', 'Churn rate', 'NPS') carried labels and no node_id at all,
+    // so it asserted pass-through of a shape PLoT rejects with
+    // CONSTRAINT_TARGET_NOT_FOUND — the defect this spec was meant to guard.
     const goalConstraints = [
-      { id: 'c1', label: 'MRR', operator: '>=' as const, value: 50000 },
-      { id: 'c2', label: 'Churn rate', operator: '<=' as const, value: 0.05 },
-      { id: 'c3', label: 'NPS', operator: '>=' as const, value: 40 },
+      { constraint_id: 'c1', node_id: 'factor_price', label: 'MRR', operator: '>=' as const, value: 50000 },
+      { constraint_id: 'c2', node_id: 'outcome_revenue', label: 'Churn rate', operator: '<=' as const, value: 0.05 },
+      { constraint_id: 'c3', node_id: 'factor_price', label: 'NPS', operator: '>=' as const, value: 40 },
     ]
 
     const { request } = buildV2RequestFromAnalysisReady(
@@ -1051,12 +1055,13 @@ describe('goal_constraints pass-through via buildV2RequestFromAnalysisReady', ()
     expect(request.goal_constraints).toBeDefined()
     expect(request.goal_constraints).toHaveLength(3)
     expect(request.goal_constraints![0]).toEqual({
-      id: 'c1',
+      constraint_id: 'c1',
+      node_id: 'factor_price',
       label: 'MRR',
       operator: '>=',
       value: 50000,
     })
-    expect(request.goal_constraints![2].id).toBe('c3')
+    expect(request.goal_constraints![2].constraint_id).toBe('c3')
   })
 
   it('omits goal_constraints from request when not provided in options', () => {

--- a/src/adapters/plot/v2/adapter.ts
+++ b/src/adapters/plot/v2/adapter.ts
@@ -1156,6 +1156,103 @@ export interface BuildV2RequestOptions {
   scenarioId?: string | null
 }
 
+/** Operators PLoT's constraint preflight accepts. Anything else is a blocker. */
+const PLOT_CONSTRAINT_OPERATORS = new Set(['>=', '<='])
+
+/**
+ * Unicode forms of the two accepted operators, mapped to their ASCII spelling.
+ *
+ * MEANING-PRESERVING ONLY. '≥' and '>=' are the same relation written two ways,
+ * so rewriting one to the other is an encoding fix, not a semantic transform.
+ * '>' / '<' / '=' are deliberately ABSENT: mapping a strict inequality onto a
+ * non-strict one (or an equality onto either) would silently change what the
+ * user asked for, so those are dropped and reported instead of guessed at.
+ *
+ * @talchain/schemas documents CEE as already normalising these away, but the
+ * envelope has historically carried the Unicode forms (see
+ * goalConstraintsEnvelope.regression.spec.ts), and dropping a valid constraint
+ * over its spelling would be worse than accepting it.
+ */
+const UNICODE_OPERATOR_ALIASES: Record<string, '>=' | '<='> = {
+  '≥': '>=', // ≥
+  '≤': '<=', // ≤
+}
+
+/**
+ * UI-SEM-086 — goal-constraint request gate.
+ *
+ * Normalises each constraint's `node_id` through the SAME idMap every other ID
+ * in the request goes through, then DROPS any constraint PLoT's preflight would
+ * reject as a blocker. Dropping is deliberate: a single malformed constraint
+ * 422s the ENTIRE run (`validateGoalConstraints` emits blockers), taking every
+ * other constraint, the goal threshold and the whole analysis down with it. A
+ * user whose persisted graph already carries a constraint minted before this fix
+ * would otherwise be permanently unable to run anything.
+ *
+ * No value is transformed — this is a validity gate plus the ID normalisation
+ * the constraints were previously skipping. Drops are logged loudly and
+ * reported to the caller so they can be surfaced rather than swallowed.
+ *
+ * Mirrors PLoT `src/validation/preflight-v2.ts` validateGoalConstraints:
+ *  - CONSTRAINT_TARGET_NOT_FOUND  — node_id absent, or not a node in the graph
+ *  - CONSTRAINT_INVALID_OPERATOR  — operator outside {'>=', '<='}
+ *  - CONSTRAINT_DUPLICATE_ID      — two constraints sharing a constraint_id
+ */
+export function prepareGoalConstraintsForRequest(
+  goalConstraints: CEEGoalConstraint[] | null | undefined,
+  idMap: Map<string, string>,
+  graphNodeIds: Set<string>,
+): { constraints: CEEGoalConstraint[]; dropped: Array<{ constraint: CEEGoalConstraint; reason: string }> } {
+  const constraints: CEEGoalConstraint[] = []
+  const dropped: Array<{ constraint: CEEGoalConstraint; reason: string }> = []
+  const seenIds = new Set<string>()
+
+  for (const c of goalConstraints ?? []) {
+    // Identity: constraint_id is the wire field PLoT reads. Fall back to the
+    // legacy `id` so pre-fix persisted constraints that DO carry a usable
+    // target are not thrown away for want of a rename.
+    const constraintId = c.constraint_id ?? c.id
+    if (!constraintId) {
+      dropped.push({ constraint: c, reason: 'CONSTRAINT_MISSING_ID' })
+      continue
+    }
+    if (seenIds.has(constraintId)) {
+      dropped.push({ constraint: c, reason: 'CONSTRAINT_DUPLICATE_ID' })
+      continue
+    }
+
+    if (!c.node_id) {
+      dropped.push({ constraint: c, reason: 'CONSTRAINT_TARGET_NOT_FOUND' })
+      continue
+    }
+    // Route node_id through the idMap exactly as node IDs, edge from/to, option
+    // IDs and the goal node ID are. Without this an imported/normalised graph
+    // renames its nodes and the constraint points at an ID that no longer
+    // exists — a false 422 on a perfectly valid constraint.
+    const normalisedNodeId = idMap.get(c.node_id) ?? c.node_id
+    if (!graphNodeIds.has(normalisedNodeId)) {
+      dropped.push({ constraint: c, reason: 'CONSTRAINT_TARGET_NOT_FOUND' })
+      continue
+    }
+
+    const operator = UNICODE_OPERATOR_ALIASES[c.operator as string] ?? c.operator
+    if (!PLOT_CONSTRAINT_OPERATORS.has(operator)) {
+      dropped.push({ constraint: c, reason: 'CONSTRAINT_INVALID_OPERATOR' })
+      continue
+    }
+
+    if (typeof c.value !== 'number' || !Number.isFinite(c.value)) {
+      dropped.push({ constraint: c, reason: 'CONSTRAINT_VALUE_NOT_FINITE' })
+      continue
+    }
+
+    seenIds.add(constraintId)
+    constraints.push({ ...c, constraint_id: constraintId, node_id: normalisedNodeId, operator })
+  }
+
+  return { constraints, dropped }
+}
+
 /**
  * Build V2RunRequest preferring CEE analysis_ready when available.
  *
@@ -1259,6 +1356,14 @@ export function buildV2RequestFromAnalysisReady(
     })
   }
 
+  // Step 5b: Goal constraints get the SAME idMap treatment as every other ID,
+  // and are gated against PLoT's constraint preflight before they go out.
+  const preparedConstraints = prepareGoalConstraintsForRequest(
+    goalConstraints,
+    normalised.idMap,
+    new Set(normalised.graph.nodes.map((n) => n.id)),
+  )
+
   // Step 6: Build final request
   // ALLOWLIST: Only PLoT-accepted top-level fields may appear here.
   // PLoT uses extra='forbid' — unknown fields cause 400.
@@ -1277,27 +1382,41 @@ export function buildV2RequestFromAnalysisReady(
     ...(brief && { brief }),
     // Goal threshold (normalised 0-1) — accepted by PLoT. Only present when analysisReady provided it.
     ...(analysisReady?.goal_threshold != null && { goal_threshold: analysisReady.goal_threshold }),
-    // Goal constraints for multi-constraint analysis (from CEE response root, not analysis_ready)
-    ...(goalConstraints?.length && { goal_constraints: goalConstraints }),
+    // Goal constraints for multi-constraint analysis (from CEE response root, not analysis_ready).
+    // UI-SEM-086: node_id normalised through the same idMap as every other ID,
+    // and PLoT-blocker-shaped constraints dropped rather than 422ing the run.
+    ...(preparedConstraints.constraints.length && { goal_constraints: preparedConstraints.constraints }),
   }
 
-  // XOR: goal_constraints take precedence over goal_threshold (PLoT contract §3.3.5).
-  // When constraints are present, ISL uses probability_of_joint_goal instead of probability_of_goal.
-  // delete is safe here: V2RunRequest marks goal_threshold as optional, so removing it
-  // produces a valid request object.
-  if (Array.isArray(request.goal_constraints) && request.goal_constraints.length > 0) {
-    if (request.goal_threshold != null && import.meta.env.DEV) {
-      console.debug('[V2Adapter] XOR: removed goal_threshold (%.2f) — goal_constraints present (%d)', request.goal_threshold, request.goal_constraints.length)
-    }
-    delete request.goal_threshold
-  }
+  // NO XOR. goal_threshold and goal_constraints are BOTH sent when both exist.
+  //
+  // The removed code deleted a valid, user-authored goal_threshold whenever any
+  // constraint was present, citing "PLoT contract §3.3.5". PLoT does not require
+  // that: `src/routes/v2/run.ts` Phase 1e (Precedence Routing) accepts both and
+  // applies the precedence ITSELF, recording an explicit repair entry
+  // ("goal_constraints present. goal_threshold=... ignored") and, where the
+  // constraint on the goal node conflicts, naming the conflicting constraint.
+  // Deleting the threshold client-side destroyed the user's success target
+  // before PLoT could see it, so that decision — and its audit trail — was lost,
+  // and the target silently vanished from the run the moment a constraint was
+  // added. Send both; let the producer route and report.
 
   const requestConstraintCount = request.goal_constraints?.length ?? 0
+  if (preparedConstraints.dropped.length > 0) {
+    console.error('[V2Adapter] Dropped goal constraints PLoT would reject as blockers', {
+      dropped: preparedConstraints.dropped.map((d) => ({
+        reason: d.reason,
+        constraint_id: d.constraint.constraint_id ?? d.constraint.id,
+        node_id: d.constraint.node_id,
+        operator: d.constraint.operator,
+      })),
+    })
+  }
   console.info('[constraint-trace] plot-request', {
     source: 'adapter.buildRunRequest',
     goal_constraints_count: requestConstraintCount,
+    goal_constraints_dropped: preparedConstraints.dropped.length,
     goal_threshold_present: 'goal_threshold' in request,
-    xor_applied: requestConstraintCount > 0 && !('goal_threshold' in request),
   })
 
   return { request, reverseIdMap: normalised.reverseIdMap }
@@ -1639,16 +1758,14 @@ export async function executeV2RunWithAnalysisReady(
     request.goal_threshold = goalThreshold
   }
 
-  // XOR: goal_constraints take precedence over goal_threshold (PLoT contract §3.3.5).
-  // This catches the case where goalThreshold is injected via the function parameter
-  // after the builder already set goal_constraints.
-  // delete is safe: V2RunRequest marks goal_threshold as optional.
-  if (Array.isArray(request.goal_constraints) && request.goal_constraints.length > 0) {
-    if (request.goal_threshold != null && import.meta.env.DEV) {
-      console.debug('[V2Adapter] XOR (execute path): removed goal_threshold (%.2f) — goal_constraints present (%d)', request.goal_threshold, request.goal_constraints.length)
-    }
-    delete request.goal_threshold
-  }
+  // NO XOR on the execute path either.
+  //
+  // This is the SECOND deletion site, and the one that actually bites in
+  // production: useV2Run calls executeV2RunWithAnalysisReady and re-injects the
+  // user's threshold through the `goalThreshold` parameter immediately above,
+  // so removing only the builder's XOR would have left the live wire unchanged.
+  // Both sites now send goal_threshold and goal_constraints together and let
+  // PLoT's Phase 1e precedence routing decide, as it already does.
 
   if (import.meta.env.DEV) {
     console.warn('[V2Adapter] Sending request (via analysisReady path):', {

--- a/src/canvas/conversation/__tests__/goalConstraintsEnvelope.regression.spec.ts
+++ b/src/canvas/conversation/__tests__/goalConstraintsEnvelope.regression.spec.ts
@@ -18,9 +18,16 @@ describe('Issue 2 regression: goal_constraints extraction', () => {
       data: {
         operations: [],
         auto_apply: true,
+        // OFF-CONTRACT ON PURPOSE. CEEGoalConstraint.operator is now
+        // '>=' | '<=' (schema-authoritative: @talchain/schemas
+        // DraftGoalConstraintSchema is z.enum(['>=', '<='])), but the envelope
+        // has historically carried the Unicode forms, which is exactly what
+        // this passthrough regression is here to keep working. The V2 adapter
+        // rewrites '≥'/'≤' to ASCII at the wire boundary (UI-SEM-086); this
+        // block only asserts adaptCEEBlock does not lose the constraints.
         goal_constraints: [
-          { id: 'c1', label: 'Revenue ≥ $1M', operator: '≥', value: 1000000 },
-          { id: 'c2', label: 'Time ≤ 6 months', operator: '≤', value: 6 },
+          { id: 'c1', label: 'Revenue ≥ $1M', operator: '≥' as never, value: 1000000 },
+          { id: 'c2', label: 'Time ≤ 6 months', operator: '≤' as never, value: 6 },
         ],
       },
     }
@@ -44,14 +51,22 @@ describe('Issue 2 regression: goal_constraints extraction', () => {
   })
 
   it('envelope root goal_constraints type matches CEEGoalConstraint shape', () => {
-    // Verify the constraint shape is compatible
+    // Verify the constraint shape is compatible.
+    //
+    // The operator is ASCII: CEEGoalConstraint.operator is now '>=' | '<=',
+    // matching @talchain/schemas DraftGoalConstraintSchema (z.enum(['>=','<=']))
+    // and PLoT's preflight, which treats anything else as a
+    // CONSTRAINT_INVALID_OPERATOR blocker. This spec previously declared '≥'
+    // here, which no longer type-checks — and would not have reached PLoT.
     const constraint: CEEGoalConstraint = {
-      id: 'c1',
+      constraint_id: 'c1',
+      node_id: 'fac_revenue',
       label: 'Revenue',
-      operator: '≥',
+      operator: '>=',
       value: 1000000,
     }
-    expect(constraint.id).toBe('c1')
+    expect(constraint.constraint_id).toBe('c1')
+    expect(constraint.node_id).toBe('fac_revenue')
     expect(constraint.label).toBe('Revenue')
   })
 })

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.constraintJourney.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.constraintJourney.spec.tsx
@@ -1,0 +1,391 @@
+/**
+ * GOAL-CONSTRAINT JOURNEY FIXTURE — the one test that reproduces the live
+ * staging P1: "Add constraint" poisoned every subsequent analysis run with a
+ * PLoT 422 (CONSTRAINT_TARGET_NOT_FOUND on node "undefined").
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * Five separate defects survived in this path because the existing adapter spec
+ * asserted a HAND-WRITTEN constraint object rather than one the UI had actually
+ * produced. It blessed the invalid shape:
+ *
+ *     { id: 'c1', label: 'Revenue >= 500', operator: '>=', value: 500 }
+ *
+ * — no `constraint_id`, no `node_id`. Every assertion passed. The wire 422'd.
+ *
+ * So this fixture drives the REAL journey end to end and never hand-writes the
+ * constraint:
+ *
+ *     render GoalPanel → click "Add constraint" → pick a factor from the real
+ *     dropdown → set operator + value → click Add → read the REAL store →
+ *     feed it to the REAL adapter → assert on the REAL request bytes
+ *
+ * The constraint under test is whatever the UI actually minted. Nothing here
+ * can pass by describing a shape the product does not build.
+ *
+ * THE ORACLE IS DERIVED, NOT MIRRORED
+ * -----------------------------------
+ * Shape conformance is checked against `DraftGoalConstraintSchema` imported
+ * from @talchain/schemas — the contract itself, not a local restatement of it.
+ * If the contract tightens, this test fails rather than silently passing
+ * against a stale copy (CLAUDE.md verification trap #12).
+ *
+ * Target resolution is checked against the request's OWN `graph.nodes`, which
+ * is precisely what PLoT's `validateGoalConstraints` does
+ * (plot-lite-service `src/validation/preflight-v2.ts`): `nodeMap.get(node_id)`
+ * miss => CONSTRAINT_TARGET_NOT_FOUND blocker => 422. Deriving the check from
+ * the emitted request means it cannot drift from what we actually send.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DraftGoalConstraintSchema } from '@talchain/schemas/boundary'
+import { GoalPanel } from '../panels/GoalPanel'
+import { useCanvasStore } from '../../../store'
+import {
+  buildV2RequestFromAnalysisReady,
+  executeV2RunWithAnalysisReady,
+} from '../../../../adapters/plot/v2/adapter'
+import type { CEEAnalysisReady } from '../../../../adapters/cee/types'
+
+// A factor whose ID is deliberately NOTHING like its label. If the panel
+// captures the label instead of the ID, `node_id` cannot accidentally resolve.
+const FACTOR_ID = 'fac_first_year_cost'
+const FACTOR_LABEL = 'First-year cost'
+
+const GOAL_ID = 'goal_margin'
+
+const nodes = [
+  {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: FACTOR_LABEL, kind: 'factor', value: 40000 },
+  },
+  {
+    id: GOAL_ID,
+    type: 'goal',
+    position: { x: 200, y: 0 },
+    data: { label: 'Margin', kind: 'goal' },
+  },
+]
+
+const edges = [
+  {
+    id: 'e1',
+    source: FACTOR_ID,
+    target: GOAL_ID,
+    data: { weight: 0.5, direction: 'positive', beliefExists: 0.8 },
+  },
+]
+
+const analysisReady: CEEAnalysisReady = {
+  options: [
+    {
+      id: 'opt1',
+      label: 'Option A',
+      status: 'ready',
+      interventions: { [FACTOR_ID]: { value: 30000, source: 'brief_extraction' } },
+    },
+  ],
+  goal_node_id: GOAL_ID,
+  // The user's success target. Defect 5 deleted this the moment a constraint
+  // existed, silently dropping the target from every run.
+  goal_threshold: 0.6,
+}
+
+function seedStore(overrides: Record<string, unknown> = {}) {
+  useCanvasStore.setState(
+    {
+      ...useCanvasStore.getState(),
+      nodes,
+      edges,
+      goalConstraints: null,
+      goalThreshold: 0.6,
+      results: { status: 'idle', report: null },
+      ...overrides,
+    } as never,
+    true,
+  )
+}
+
+/**
+ * Drive the real UI: open the form, pick the factor, type the value, submit.
+ * Returns whatever the panel wrote to the store — never a hand-built object.
+ */
+function addConstraintViaUI({ operatorValue = '<=', value = '50000' } = {}) {
+  render(<GoalPanel nodeId={GOAL_ID} techMode={false} onClose={() => {}} onNavigate={() => {}} />)
+
+  fireEvent.click(screen.getByTestId('add-constraint-button'))
+
+  const factorSelect = screen.getByLabelText('Constraint target factor')
+  const optionValues = Array.from(
+    (factorSelect as HTMLSelectElement).querySelectorAll('option'),
+  ).map((o) => (o as HTMLOptionElement).value)
+
+  fireEvent.change(factorSelect, { target: { value: FACTOR_ID } })
+  fireEvent.change(screen.getByLabelText('Constraint operator'), {
+    target: { value: operatorValue },
+  })
+  fireEvent.change(screen.getByLabelText('Constraint target value'), {
+    target: { value },
+  })
+  fireEvent.click(screen.getByTestId('confirm-add-constraint'))
+
+  return {
+    constraints: useCanvasStore.getState().goalConstraints,
+    optionValues,
+  }
+}
+
+/** Build the outbound PLoT request from whatever the UI put in the store. */
+function buildRequestFromStore() {
+  const { goalConstraints } = useCanvasStore.getState()
+  const { request } = buildV2RequestFromAnalysisReady(
+    useCanvasStore.getState().nodes as never,
+    useCanvasStore.getState().edges as never,
+    analysisReady,
+    [],
+    undefined,
+    { goalConstraints },
+  )
+  return request
+}
+
+describe('GOAL-CONSTRAINT JOURNEY — UI "Add constraint" to PLoT request bytes', () => {
+  beforeEach(() => {
+    seedStore()
+  })
+
+  // ── Defect 2: the panel captured the label, not the node ID ──────────────
+  it('the factor dropdown carries NODE IDs, so a selection can name a real node', () => {
+    seedStore()
+    const { optionValues } = addConstraintViaUI()
+
+    // The label must not be usable as an option value — that is the whole bug.
+    expect(optionValues).toContain(FACTOR_ID)
+    expect(optionValues).not.toContain(FACTOR_LABEL)
+  })
+
+  // POSITIVE CONTROL for the oracle. A conformance assertion is worthless if
+  // the validator cannot fail (CLAUDE.md trap #13) — and the schema resolving
+  // to `undefined` off a wrong import path is a live hazard here, since it is
+  // exported from '@talchain/schemas/boundary', not the package root. Prove the
+  // oracle both LOADS and REJECTS the exact shape that shipped the P1.
+  it('CONTROL: the schema oracle is loaded and rejects the pre-fix constraint', () => {
+    expect(DraftGoalConstraintSchema).toBeDefined()
+
+    const preFixShape = { id: 'c1', label: FACTOR_LABEL, operator: '>=', value: 500 }
+    const rejected = DraftGoalConstraintSchema.safeParse(preFixShape)
+    expect(rejected.success).toBe(false)
+
+    const missingKeys = rejected.success
+      ? []
+      : rejected.error.issues.map((i) => i.path.join('.'))
+    expect(missingKeys).toContain('constraint_id')
+    expect(missingKeys).toContain('node_id')
+  })
+
+  // ── Defects 1 + 2: the emitted constraint must satisfy the CONTRACT ──────
+  it('the constraint the UI mints conforms to DraftGoalConstraintSchema', () => {
+    seedStore()
+    const { constraints } = addConstraintViaUI()
+
+    expect(constraints).toHaveLength(1)
+
+    // The contract itself is the oracle. constraint_id and node_id are both
+    // required min(1) — the pre-fix object had neither.
+    const parsed = DraftGoalConstraintSchema.safeParse(constraints![0])
+    expect(parsed.success).toBe(true)
+
+    expect(constraints![0].node_id).toBe(FACTOR_ID)
+    expect(constraints![0].constraint_id).toBeTruthy()
+    // A user-typed constraint is explicit, not inferred from the brief.
+    expect(constraints![0].provenance).toBe('explicit')
+  })
+
+  // ── THE LIVE 422, REPRODUCED: node_id must resolve in the request graph ──
+  it('the outbound request resolves every constraint target against graph.nodes', () => {
+    seedStore()
+    addConstraintViaUI()
+    const request = buildRequestFromStore()
+
+    expect(request.goal_constraints).toHaveLength(1)
+
+    // This is PLoT's preflight, derived from the request we actually send:
+    // a nodeMap miss is CONSTRAINT_TARGET_NOT_FOUND, which 422s the run.
+    const graphNodeIds = new Set(request.graph.nodes.map((n) => n.id))
+    for (const c of request.goal_constraints!) {
+      expect(c.node_id).toBeDefined()
+      expect(String(c.node_id)).not.toBe('undefined')
+      expect(graphNodeIds.has(c.node_id!)).toBe(true)
+    }
+  })
+
+  // ── Defect 5: adding a constraint must not delete the success target ─────
+  it('goal_threshold SURVIVES alongside goal_constraints', () => {
+    seedStore()
+    addConstraintViaUI()
+    const request = buildRequestFromStore()
+
+    expect(request.goal_constraints).toHaveLength(1)
+    // PLoT Phase 1e applies constraint-over-threshold precedence itself and
+    // records the repair. Deleting it client-side destroyed the user's target
+    // before the producer could route or report on it.
+    expect(request.goal_threshold).toBe(0.6)
+  })
+
+  // ── Defect 4: '=' is a PLoT CONSTRAINT_INVALID_OPERATOR blocker ──────────
+  it('the operator dropdown offers only the operators PLoT accepts', () => {
+    seedStore()
+    render(<GoalPanel nodeId={GOAL_ID} techMode={false} onClose={() => {}} onNavigate={() => {}} />)
+    fireEvent.click(screen.getByTestId('add-constraint-button'))
+
+    const operators = Array.from(
+      screen.getByLabelText('Constraint operator').querySelectorAll('option'),
+    ).map((o) => (o as HTMLOptionElement).value)
+
+    expect(operators).toEqual(['>=', '<='])
+    expect(operators).not.toContain('=')
+  })
+
+  // ── Defect 3: positional ids collide after delete-then-add ──────────────
+  it('constraint ids stay unique across a delete-then-add cycle', () => {
+    seedStore()
+    addConstraintViaUI({ value: '50000' })
+    const first = useCanvasStore.getState().goalConstraints![0]
+
+    // Simulate the collision path: the user removes a constraint and adds
+    // another. `c${base.length + 1}` regenerates an id that is already in use,
+    // which PLoT rejects with CONSTRAINT_DUPLICATE_ID.
+    const second = { ...first, constraint_id: crypto.randomUUID() }
+    useCanvasStore.getState().setGoalConstraints([first, second])
+
+    const request = buildRequestFromStore()
+    const ids = request.goal_constraints!.map((c) => c.constraint_id ?? c.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(first.constraint_id).not.toBe(second.constraint_id)
+  })
+})
+
+describe('GOAL-CONSTRAINT JOURNEY — legacy/poisoned constraints do not brick the run', () => {
+  beforeEach(() => {
+    seedStore()
+  })
+
+  // ── Defect 6: node_id must ride the same idMap as every other ID ────────
+  it('normalises constraint node_id through the graph idMap', () => {
+    // An imported graph whose IDs PLoT will not accept verbatim. Every other
+    // ID is normalised; node_id used to skip it and then fail to resolve.
+    const importedId = 'Factor With Spaces!'
+    useCanvasStore.setState(
+      {
+        ...useCanvasStore.getState(),
+        nodes: [
+          { ...nodes[0], id: importedId, data: { ...nodes[0].data } },
+          nodes[1],
+        ],
+        edges: [{ ...edges[0], source: importedId }],
+        goalConstraints: [
+          {
+            constraint_id: 'c-imported',
+            node_id: importedId,
+            operator: '<=' as const,
+            value: 50000,
+          },
+        ],
+      } as never,
+      true,
+    )
+
+    const { request } = buildV2RequestFromAnalysisReady(
+      useCanvasStore.getState().nodes as never,
+      useCanvasStore.getState().edges as never,
+      {
+        ...analysisReady,
+        options: [
+          {
+            id: 'opt1',
+            label: 'Option A',
+            status: 'ready',
+            interventions: { [importedId]: { value: 30000, source: 'brief_extraction' } },
+          },
+        ],
+      },
+      [],
+      undefined,
+      { goalConstraints: useCanvasStore.getState().goalConstraints },
+    )
+
+    expect(request.goal_constraints).toHaveLength(1)
+    const graphNodeIds = new Set(request.graph.nodes.map((n) => n.id))
+    // The constraint must point at the NORMALISED id, and that id must exist.
+    expect(graphNodeIds.has(request.goal_constraints![0].node_id!)).toBe(true)
+  })
+
+  /**
+   * THE LIVE PATH. useV2Run does NOT call the builder directly — it calls
+   * executeV2RunWithAnalysisReady, which re-injects the user's threshold via its
+   * `goalThreshold` parameter and, before this fix, deleted it again in a SECOND
+   * XOR the brief never named. A fixture that only exercised the builder would
+   * have gone green while the deployed wire was unchanged (CLAUDE.md trap #16:
+   * trace the live call chain, not a symbol).
+   */
+  it('LIVE PATH: executeV2RunWithAnalysisReady sends both threshold and constraints', async () => {
+    seedStore()
+    addConstraintViaUI()
+
+    // Capture the ACTUAL wire bytes: stub global fetch, which is what runV2 uses.
+    let captured: Record<string, unknown> | undefined
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async (_url: unknown, init?: { body?: string }) => {
+      captured = JSON.parse(String(init?.body ?? '{}'))
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({ request_id: 'r1', analysis_status: 'complete' }),
+        text: async () => '',
+      }
+    }) as never
+
+    try {
+      await executeV2RunWithAnalysisReady(
+        { baseUrl: 'http://plot.test' } as never,
+        useCanvasStore.getState().nodes as never,
+        useCanvasStore.getState().edges as never,
+        analysisReady,
+        GOAL_ID,
+        'req-1',
+        // The user's normalised threshold, re-injected exactly as useV2Run does.
+        0.6,
+        undefined,
+        undefined,
+        useCanvasStore.getState().goalConstraints,
+      )
+    } finally {
+      globalThis.fetch = realFetch
+    }
+
+    expect(captured).toBeDefined()
+    expect(captured!.goal_constraints).toHaveLength(1)
+    // The success target must reach the wire.
+    expect(captured!.goal_threshold).toBe(0.6)
+  })
+
+  it('drops a pre-fix constraint that names no node, keeping the rest of the run alive', () => {
+    seedStore({
+      // Exactly what the old handleAddConstraint wrote, and what is sitting in
+      // real users' persisted graphs right now.
+      goalConstraints: [
+        { id: 'c1', label: FACTOR_LABEL, operator: '>=' as const, value: 500 },
+      ],
+    })
+
+    const request = buildRequestFromStore()
+
+    // Dropped rather than forwarded: forwarding it 422s the ENTIRE analysis.
+    expect(request.goal_constraints).toBeUndefined()
+    // And the user's success target is still there to run against.
+    expect(request.goal_threshold).toBe(0.6)
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.constraintJourney.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.constraintJourney.spec.tsx
@@ -250,20 +250,67 @@ describe('GOAL-CONSTRAINT JOURNEY — UI "Add constraint" to PLoT request bytes'
 
   // ── Defect 3: positional ids collide after delete-then-add ──────────────
   it('constraint ids stay unique across a delete-then-add cycle', () => {
-    seedStore()
-    addConstraintViaUI({ value: '50000' })
-    const first = useCanvasStore.getState().goalConstraints![0]
+    // The collision is only reachable by DRIVING THE UI through the real
+    // sequence. An earlier version of this test minted the second id itself and
+    // therefore passed with the positional scheme restored — it proved nothing.
+    // `c${base.length + 1}` reissues an id that is already in use:
+    //   add A -> base [] -> "c1"
+    //   add B -> base [A] -> "c2"
+    //   delete A -> base [B("c2")]
+    //   add C -> base [B] -> "c2"  <-- collides with B
+    // PLoT rejects that with CONSTRAINT_DUPLICATE_ID.
+    seedStore({
+      nodes: [
+        ...nodes,
+        {
+          id: 'fac_headcount',
+          type: 'factor',
+          position: { x: 0, y: 120 },
+          data: { label: 'Headcount', kind: 'factor', value: 10 },
+        },
+        {
+          id: 'fac_runway',
+          type: 'factor',
+          position: { x: 0, y: 240 },
+          data: { label: 'Runway', kind: 'factor', value: 12 },
+        },
+      ],
+    })
 
-    // Simulate the collision path: the user removes a constraint and adds
-    // another. `c${base.length + 1}` regenerates an id that is already in use,
-    // which PLoT rejects with CONSTRAINT_DUPLICATE_ID.
-    const second = { ...first, constraint_id: crypto.randomUUID() }
-    useCanvasStore.getState().setGoalConstraints([first, second])
+    const addFor = (factorId: string, value: string) => {
+      const view = render(
+        <GoalPanel nodeId={GOAL_ID} techMode={false} onClose={() => {}} onNavigate={() => {}} />,
+      )
+      fireEvent.click(view.getByTestId('add-constraint-button'))
+      fireEvent.change(view.getByLabelText('Constraint target factor'), {
+        target: { value: factorId },
+      })
+      fireEvent.change(view.getByLabelText('Constraint target value'), { target: { value } })
+      fireEvent.click(view.getByTestId('confirm-add-constraint'))
+      view.unmount()
+    }
 
-    const request = buildRequestFromStore()
-    const ids = request.goal_constraints!.map((c) => c.constraint_id ?? c.id)
+    addFor(FACTOR_ID, '50000')
+    addFor('fac_headcount', '10')
+
+    // The user deletes the FIRST constraint.
+    const afterTwo = useCanvasStore.getState().goalConstraints!
+    expect(afterTwo).toHaveLength(2)
+    useCanvasStore.getState().setGoalConstraints([afterTwo[1]])
+
+    // ...and adds another. This is the reissue point.
+    addFor('fac_runway', '12')
+
+    const finalConstraints = useCanvasStore.getState().goalConstraints!
+    expect(finalConstraints).toHaveLength(2)
+
+    const ids = finalConstraints.map((c) => c.constraint_id ?? c.id)
     expect(new Set(ids).size).toBe(ids.length)
-    expect(first.constraint_id).not.toBe(second.constraint_id)
+
+    // And the request must carry both — the UI-SEM-086 gate drops duplicates,
+    // so a collision here silently costs the user a constraint.
+    const request = buildRequestFromStore()
+    expect(request.goal_constraints).toHaveLength(2)
   })
 })
 

--- a/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
@@ -70,10 +70,16 @@ export const GoalPanel = memo(function GoalPanel({
   const [description, setDescription] = useState(String(node?.data?.description ?? ''))
   const [isEditingDescription, setIsEditingDescription] = useState(false)
 
-  // B.5: Add constraint form state
+  // B.5: Add constraint form state.
+  // The dropdown carries the factor's NODE ID, not its label: PLoT's constraint
+  // preflight resolves `node_id` against graph.nodes, so a label here produces
+  // CONSTRAINT_TARGET_NOT_FOUND and 422s the whole run.
   const [showAddConstraint, setShowAddConstraint] = useState(false)
-  const [newConstraintLabel, setNewConstraintLabel] = useState('')
-  const [newConstraintOperator, setNewConstraintOperator] = useState<'>=' | '<=' | '='>('>=')
+  const [newConstraintNodeId, setNewConstraintNodeId] = useState('')
+  // Operator is restricted to the two ASCII forms PLoT accepts. '=' is NOT a
+  // valid constraint operator (preflight-v2 CONSTRAINT_INVALID_OPERATOR), and
+  // @talchain/schemas DraftGoalConstraintSchema declares z.enum(['>=', '<=']).
+  const [newConstraintOperator, setNewConstraintOperator] = useState<'>=' | '<='>('>=')
   const [newConstraintValue, setNewConstraintValue] = useState('')
   const [constraintError, setConstraintError] = useState('')
 
@@ -85,24 +91,37 @@ export const GoalPanel = memo(function GoalPanel({
     })),
   [nodes])
 
-  // Already-constrained factor labels (case-insensitive)
-  const constrainedLabels = useMemo(() => {
-    if (!goalConstraints?.length) return new Set<string>()
-    // `label` is optional on the wire (CEE's producer schema and the
-    // @talchain/schemas draft contract both declare it optional), so an
-    // unguarded `.toLowerCase()` throws on a perfectly valid constraint.
-    // Unlabelled constraints simply cannot match a factor label — drop them
-    // rather than crash the panel.
-    return new Set(
-      goalConstraints
-        .map(c => c.label?.toLowerCase().trim())
-        .filter((l): l is string => !!l),
-    )
+  // Already-constrained factors, keyed by node ID where the constraint carries
+  // one and by lower-cased label otherwise. Constraints minted before this panel
+  // captured node IDs (and any legacy persisted graph) carry only a label, so
+  // the label leg has to stay for the "(already constrained)" hint to keep
+  // working on those — but node ID is the identity that actually matters.
+  //
+  // `label` is optional on the wire (CEE's producer schema and the
+  // @talchain/schemas draft contract both declare it optional), so an
+  // unguarded `.toLowerCase()` throws on a perfectly valid constraint.
+  const constrainedTargets = useMemo(() => {
+    const byNodeId = new Set<string>()
+    const byLabel = new Set<string>()
+    for (const c of goalConstraints ?? []) {
+      if (c.node_id) byNodeId.add(c.node_id)
+      const l = c.label?.toLowerCase().trim()
+      if (l) byLabel.add(l)
+    }
+    return { byNodeId, byLabel }
   }, [goalConstraints])
 
   const handleAddConstraint = useCallback(() => {
     const value = parseFloat(newConstraintValue)
-    if (!newConstraintLabel) {
+    if (!newConstraintNodeId) {
+      setConstraintError(GOAL_CONSTRAINT_COPY.errorSelectFactor)
+      return
+    }
+    // The dropdown only ever offers factor node IDs, but resolve rather than
+    // trust: a stale selection whose node has since been deleted must not mint
+    // a constraint pointing at a node that is no longer in the graph.
+    const targetNode = factorNodes.find(f => f.id === newConstraintNodeId)
+    if (!targetNode) {
       setConstraintError(GOAL_CONSTRAINT_COPY.errorSelectFactor)
       return
     }
@@ -111,19 +130,31 @@ export const GoalPanel = memo(function GoalPanel({
       return
     }
     const base = preAnalysisConstraints ?? []
+    // Conforms to @talchain/schemas DraftGoalConstraintSchema (0.19.0):
+    // constraint_id and node_id are both REQUIRED and min(1); operator is
+    // z.enum(['>=', '<=']). PLoT's own preflight (validateGoalConstraints)
+    // reads exactly these fields, so anything less 422s the run.
+    //
+    // constraint_id is a UUID rather than a positional `c${n}`: the positional
+    // scheme regenerates an existing id after a delete-then-add, which PLoT
+    // rejects with CONSTRAINT_DUPLICATE_ID.
     const newConstraint: CEEGoalConstraint = {
-      id: `c${base.length + 1}`,
-      label: newConstraintLabel,
+      constraint_id: crypto.randomUUID(),
+      node_id: targetNode.id,
       operator: newConstraintOperator,
       value,
+      label: targetNode.label,
+      // The user typed this constraint into the panel themselves — it is not
+      // inferred from the brief and not a proxy for something else.
+      provenance: 'explicit',
     }
     setGoalConstraints([...base, newConstraint])
     setShowAddConstraint(false)
-    setNewConstraintLabel('')
+    setNewConstraintNodeId('')
     setNewConstraintOperator('>=')
     setNewConstraintValue('')
     setConstraintError('')
-  }, [newConstraintLabel, newConstraintOperator, newConstraintValue, preAnalysisConstraints, setGoalConstraints])
+  }, [factorNodes, newConstraintNodeId, newConstraintOperator, newConstraintValue, preAnalysisConstraints, setGoalConstraints])
 
   // Inbound connections (outcomes/risks → goal)
   const inboundConnections = useMemo(() => {
@@ -234,7 +265,7 @@ export const GoalPanel = memo(function GoalPanel({
                     ? 'border-info/30'
                     : prob >= 0.7 ? 'border-success/30' : prob >= 0.4 ? 'border-warning/30' : 'border-danger/30'
                   return (
-                    <div key={c.id ?? i} className={`px-2.5 py-1.5 bg-panel border ${colourClass} rounded-lg`}>
+                    <div key={c.constraint_id ?? c.id ?? i} className={`px-2.5 py-1.5 bg-panel border ${colourClass} rounded-lg`}>
                       <div className="flex items-center justify-between gap-2">
                         <span className={`${typography.panelBody} text-text-body truncate`}>{c.label ?? `Constraint ${i + 1}`}</span>
                         {prob !== null && (
@@ -279,8 +310,15 @@ export const GoalPanel = memo(function GoalPanel({
                               const parsed = parseFloat(e.target.value)
                               if (Number.isNaN(parsed) || parsed === c.value) return
                               const base = preAnalysisConstraints ?? []
+                              // Identity is `constraint_id ?? id` — panel-minted
+                              // constraints carry only constraint_id, so keying
+                              // on `id` alone silently fell through to index
+                              // matching (wrong row after any reorder/delete).
+                              const identity = c.constraint_id ?? c.id
                               const updated = base.map((pc, idx) =>
-                                (c.id !== undefined ? pc.id === c.id : idx === i)
+                                (identity !== undefined
+                                  ? (pc.constraint_id ?? pc.id) === identity
+                                  : idx === i)
                                   ? { ...pc, value: parsed }
                                   : pc
                               )
@@ -318,16 +356,18 @@ export const GoalPanel = memo(function GoalPanel({
             <div className="mt-2 p-2.5 bg-panel border border-panel-border rounded-lg space-y-2" data-testid="add-constraint-form">
               {/* Factor dropdown */}
               <select
-                value={newConstraintLabel}
-                onChange={e => { setNewConstraintLabel(e.target.value); setConstraintError('') }}
+                value={newConstraintNodeId}
+                onChange={e => { setNewConstraintNodeId(e.target.value); setConstraintError('') }}
                 className={`${typography.panelBody} w-full border border-panel-border rounded-lg px-2.5 py-1.5 bg-panel text-text-body`}
                 aria-label={GOAL_CONSTRAINT_COPY.factorLabel}
               >
                 <option value="">{GOAL_CONSTRAINT_COPY.selectFactor}</option>
                 {factorNodes.map(f => {
-                  const alreadyConstrained = constrainedLabels.has(f.label.toLowerCase().trim())
+                  const alreadyConstrained =
+                    constrainedTargets.byNodeId.has(f.id)
+                    || constrainedTargets.byLabel.has(f.label.toLowerCase().trim())
                   return (
-                    <option key={f.id} value={f.label} disabled={alreadyConstrained}>
+                    <option key={f.id} value={f.id} disabled={alreadyConstrained}>
                       {f.label}{alreadyConstrained ? ` ${GOAL_CONSTRAINT_COPY.alreadyConstrained}` : ''}
                     </option>
                   )
@@ -337,13 +377,13 @@ export const GoalPanel = memo(function GoalPanel({
               <div className="flex items-center gap-1.5">
                 <select
                   value={newConstraintOperator}
-                  onChange={e => setNewConstraintOperator(e.target.value as '>=' | '<=' | '=')}
+                  onChange={e => setNewConstraintOperator(e.target.value as '>=' | '<=')}
                   className={`${typography.panelMeta} w-16 border border-panel-border rounded-lg px-1.5 py-1.5 bg-panel text-text-body`}
                   aria-label={GOAL_CONSTRAINT_COPY.operatorLabel}
                 >
+                  {/* No '=' option: PLoT accepts >= and <= only. */}
                   <option value=">=">{'\u2265'}</option>
                   <option value="<=">{'\u2264'}</option>
-                  <option value="=">=</option>
                 </select>
                 <input
                   type="number"


### PR DESCRIPTION
## The bug

On staging, using **"Add constraint"** in the GoalPanel made every subsequent analysis run **422 at PLoT Phase 1d** — `CONSTRAINT_TARGET_NOT_FOUND` on node `"undefined"`. The constraint persisted, so the poisoning was permanent: the user could not run anything again.

**Seven defects on one path** (the brief named six; #6 below was found while tracing the live call chain).

All seven are confirmed against the consumer's own bytes in `plot-lite-service`:
`src/validation/preflight-v2.ts` (`validateGoalConstraints`) and `src/types/engine-v3.ts` (`GoalConstraint`), which require `constraint_id` + `node_id` and accept `>=` / `<=` only.

| # | Defect | Before | After |
|---|--------|--------|-------|
| 1 | No `constraint_id` | `id: \`c${base.length + 1}\`` only | `constraint_id: crypto.randomUUID()` |
| 2 | `node_id` was the factor's **label** | `label: newConstraintLabel` (a string) | dropdown carries **node IDs**; `node_id: targetNode.id` |
| 3 | Positional id collides | `c${base.length + 1}` reissues an id after delete-then-add → `CONSTRAINT_DUPLICATE_ID` | UUID |
| 4 | `=` operator offered | `<option value="=">` | `>=` / `<=` only |
| 5 | Adapter **deleted** `goal_threshold` | XOR at `adapter.ts` builder | both sent |
| 6 | **Second** XOR on the **live** path | `executeV2RunWithAnalysisReady` deleted it again | both sent |
| 7 | `node_id` skipped idMap normalisation | used verbatim → imported IDs 422 falsely | routed through the same idMap |

### On #2 — this is a capture fix, not a UX change
The node ID was **already in scope** at selection time (`factorNodes` is built from `nodes.filter(...)`) and was being thrown away. No node picker was added.

### On #5 / #6 — the XOR was never required by PLoT
The deleted code cited "PLoT contract §3.3.5". PLoT does not require it: `routes/v2/run.ts` **Phase 1e (Precedence Routing)** accepts both fields, applies constraint-over-threshold precedence itself, and pushes an explicit repair entry (`"goal_constraints present. goal_threshold=… ignored"`), naming the conflicting constraint where one exists. Deleting it client-side destroyed the user's success target *before the producer could route on it or report it*.

**#6 is the one that actually bit in production.** `useV2Run` calls `executeV2RunWithAnalysisReady`, not the builder — fixing only the builder XOR would have left the deployed wire unchanged. (CLAUDE.md trap #16: trace the live call chain, not a symbol.)

## Schema conformance

`DraftGoalConstraintSchema` (`@talchain/schemas` **0.19.0**, `/boundary`) is used directly rather than hand-rolled. Two things it forced:

- **`CEEGoalConstraint.operator` narrowed `'>=' | '<=' | '>' | '<' | '=' ` → `'>=' | '<='`.** The schema is `z.enum(['>=','<='])` and documents "ASCII only"; PLoT agrees. The old union is what let the panel offer an `=` the producer cannot accept.
- **`provenance: 'explicit'`** is set on panel-authored constraints (user-stated, not inferred from the brief).

Narrowing surfaced real off-contract data: `goalConstraintsEnvelope.regression.spec.ts` shows the envelope has carried Unicode `≥` / `≤`. Rather than drop those, the wire boundary **rewrites `≥`→`>=` and `≤`→`<=`** — meaning-preserving. `>` / `<` / `=` are **deliberately not coerced**: mapping a strict inequality onto a non-strict one would silently change what the user asked for, so those are dropped and reported.

## UI-SEM-086 — `prepareGoalConstraintsForRequest`

New exported gate in `adapter.ts`. Normalises `node_id` through the idMap, then drops constraints PLoT would treat as blockers (missing/unresolvable `node_id`, invalid operator, duplicate `constraint_id`, non-finite value), logging each via `console.error`.

**Dropping is deliberate.** A single malformed constraint 422s the *entire* analysis — every other constraint, the goal threshold and the whole run go down with it. Users whose persisted graphs already carry a pre-fix constraint would otherwise be bricked permanently. Nothing is transformed; this is a validity gate plus the ID normalisation the constraints were skipping.

## The journey fixture

`src/canvas/ui/inspector-v2/__tests__/GoalPanel.constraintJourney.spec.tsx` (10 tests).

Codex's finding was that *the existing adapter spec blessed the invalid shape* — it asserted a hand-written object the UI never produces:

```js
{ id: 'c1', label: 'Revenue >= 500', operator: '>=', value: 500 }   // no constraint_id, no node_id
```

Every assertion passed; the wire 422'd. **Two** specs were doing this (`adapter.spec.ts` and `ceeV3ContractBridge.spec.ts`); both are corrected here.

The fixture never hand-writes a constraint. It drives the real journey:

> render GoalPanel → click "Add constraint" → pick a factor from the **real dropdown** → set operator + value → click Add → read the **real store** → feed the **real adapter** → assert on the **real request bytes**

Its oracles are **derived, not mirrored** (CLAUDE.md trap #12):
- shape → `DraftGoalConstraintSchema` imported from the contract itself
- target resolution → checked against the emitted request's **own** `graph.nodes`, which is exactly what PLoT's `nodeMap.get(node_id)` does
- the live path → stubs global `fetch` and asserts the **actual serialised body** out of `executeV2RunWithAnalysisReady`

It carries a **positive control** (trap #13): a test proving the schema oracle both loads and *rejects* the pre-fix shape. This is not hypothetical — `DraftGoalConstraintSchema` is exported from `@talchain/schemas/boundary`, not the package root, and importing from the root silently yields `undefined`.

**RED-first:** run against pristine `origin/staging` in a separate clone, **8 of 9 failed**; the one that passed was the control, which is meant to pass on both.

## Mutation evidence

Each fix reverted **individually** in a throwaway tree (trap #9), against a **107-green** baseline:

| Mutation | Reverted fix | Result | First failing assertion |
|---|---|---|---|
| M1 | `constraint_id` minting | **5 failed** | `expected false to be true` (schema parse) |
| M2 | node ID capture (store label again) | **5 failed** | `expected 'First-year cost' to be 'fac_first_year_cost'` |
| M3 | UUID → positional `c${n}` | **1 failed** | `expected 1 to be 2` (duplicate dropped) |
| M4 | re-add `=` operator | **1 failed** | `expected ['>=','<=','='] to deeply equal ['>=','<=']` |
| M5 | re-add builder XOR | **2 failed** | `expected undefined to be 0.8` |
| M6 | re-add **execute-path** XOR | **1 failed** | `expected undefined to be 0.6` |
| M7 | skip idMap normalisation | **1 failed** | target not found in `graph.nodes` |

**M3 initially stayed GREEN.** The delete-then-add test minted the second id itself, so it passed with the positional scheme restored — it proved nothing about the fix it was meant to pin. It was rewritten to drive the real UI through the reissue sequence (add A, add B, delete A, add C) and now bites. Commit `0fc4de83` is that correction; without the mutation check it would have shipped as theatre.

## Gates

| Gate | Result |
|---|---|
| `pnpm run typecheck` | clean |
| `pnpm run lint` (touched files) | **0 errors**, 15 warnings — all pre-existing; net **−2** vs base |
| `npx vitest run --changed origin/staging` | **2630 passed**, 44 skipped, 0 failed |
| `npx vitest run tests/ci-guards` | **42 passed** |
| Wide `tsc -p tsconfig.app.json` | base **2324** → **2323**; **0 new set-wise** (one pre-existing error fixed) |

Wide typecheck compared against a matched base clone at `b36b6db8` with its own real `node_modules` (traps #1/#2). Set-wise diff, `grep -c "error TS"`.

## Not verified here

No live PLoT run was made from this branch — the fix is verified against PLoT's source at the local checkout of `plot-lite-service`, not against deployed `6ab94427`. **A staging run exercising "Add constraint" should confirm the 422 is gone before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
