### PR TITLE
test(v5): canonical wire stages — retire the vacuous ideate/evaluate fixtures

### DIFF
--- a/src/lib/__tests__/analysisProducingCeeTurn.spec.ts
+++ b/src/lib/__tests__/analysisProducingCeeTurn.spec.ts
@@ -501,7 +501,11 @@ describe('findLatestAnalysisProducingCeeTurn — round-2 P0 + round-3 P0: hash m
         ...(contextHash !== undefined ? { context_hash: contextHash } : {}),
         dsk_version_hash: null,
       },
-      stage_indicator: { stage: 'ideate' },
+      // Canonical wire stage for an analysis-producing turn (frame|analyse|decide|
+      // review). The selector reads lineage.response_hash, never the stage, so this
+      // is decoration — but it now matches the canonical vocabulary the comment above
+      // claims. Was 'ideate' (retired UI/DB vocab, off the canonical enum).
+      stage_indicator: { stage: 'analyse' },
     }
   }
 

--- a/src/v5/__tests__/applyV5State.debug.test.ts
+++ b/src/v5/__tests__/applyV5State.debug.test.ts
@@ -90,12 +90,16 @@ describe('applyV5State [v5-state] debug logging', () => {
 
   it('reports skip_reason when a step is a no-op', () => {
     vi.stubEnv('VITE_V5_STATE_DEBUG', 'true')
-    // Conversational turn with no analysis_ready → step 4 skips with reason
+    // Conversational turn with no analysis_ready → step 4 skips with reason.
+    // Canonical non-analyse wire stage (was 'ideate' — retired UI/DB vocab that
+    // normaliseStage rejects). The skip_reason assertion below is load-bearing on
+    // the turn being NON-analyse; 'frame' and the old 'ideate' both satisfy that,
+    // but 'frame' is the recognised canonical value rather than a rejected one.
     const conversational = {
       turn_id: 't2',
       assistant_text: 'hi',
       blocks: [],
-      stage_indicator: { stage: 'ideate', confidence: 'high', source: 'inferred' },
+      stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
     } as unknown as OlumiResponse
     applyV5State(conversational, makeStore())
     const step4 = (infoSpy.mock.calls as unknown[][])

--- a/src/v5/__tests__/applyV5State.hardening.test.ts
+++ b/src/v5/__tests__/applyV5State.hardening.test.ts
@@ -59,7 +59,11 @@ describe('applyV5State — analyse-turn with missing analysis_ready', () => {
       blocks: [
         { type: 'analysis_result', block_id: 'b1', enrichment: {} } as unknown as OlumiResponse['blocks'][number],
       ],
-      stage_indicator: { stage: 'ideate', confidence: 'high', source: 'inferred' },
+      // Non-analyse stage (canonical wire vocab: frame|analyse|decide|review) — a
+      // deliberate distractor. This test proves the analysis_result BLOCK drives the
+      // clear, independent of stage. (Was 'ideate' — retired UI/DB vocab that
+      // normaliseStage rejects, so it silently exercised the unrecognised-stage path.)
+      stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
     } as unknown as OlumiResponse
 
     applyV5State(response, store)
@@ -68,17 +72,25 @@ describe('applyV5State — analyse-turn with missing analysis_ready', () => {
 })
 
 describe('applyV5State — conversational turn preserves ceeAnalysisReady', () => {
-  it('does not call setCeeAnalysisReady when analysis_ready is absent on an ideate-stage conversational turn', () => {
+  it('does not call setCeeAnalysisReady when analysis_ready is absent on a frame-stage conversational turn', () => {
     const store = makeStore()
     const response = {
       turn_id: 't',
       assistant_text: 'hi',
       blocks: [],
-      stage_indicator: { stage: 'ideate', confidence: 'high', source: 'inferred' },
+      // Canonical non-analyse wire stage. Was 'ideate' (retired UI/DB vocab):
+      // normaliseStage rejected it, so the turn was treated as an *unrecognised*
+      // stage rather than a *recognised conversational* one — the intended path
+      // was never exercised.
+      stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
     } as unknown as OlumiResponse
 
     applyV5State(response, store)
     expect(store.setCeeAnalysisReady).not.toHaveBeenCalled()
+    // The stage is now genuinely recognised and applied — this is what the
+    // fixture always intended. Reverting to 'ideate' makes normaliseStage return
+    // null, this assertion fails, and the vacuous unrecognised-stage path returns.
+    expect(store.setCurrentStage).toHaveBeenCalledWith('frame')
   })
 })
 
@@ -308,11 +320,16 @@ describe('applyV5State — hydration regression', () => {
         turn_id: 'turn_conv',
         assistant_text: 'thinking through it',
         blocks: [],
-        stage_indicator: { stage: 'ideate', confidence: 'high', source: 'inferred' },
+        // Canonical non-analyse wire stage (was 'ideate' — retired UI/DB vocab
+        // that normaliseStage rejects, silently exercising the unrecognised path).
+        stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
       } as unknown as OlumiResponse,
       store,
     )
     expect(setCeeAnalysisReady).not.toHaveBeenCalled()
+    // The conversational stage is recognised and applied. Reverting to 'ideate'
+    // drops this write and re-introduces the vacuous unrecognised-stage path.
+    expect(store.setCurrentStage).toHaveBeenCalledWith('frame')
 
     // 2. Analyse-shaped turn with no analysis_ready → explicit clear.
     applyV5State(

--- a/tests/contracts/response-envelope-contract.test.ts
+++ b/tests/contracts/response-envelope-contract.test.ts
@@ -9,6 +9,13 @@ import { describe, test, expect, vi } from 'vitest'
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 
+// The canonical wire stage vocabulary — single source of truth. Exactly
+// frame | analyse | decide | review (British `analyse`). The committed CEE
+// JSON-schema mirror below diverges from this (see the "KNOWN DEFECT" tests
+// at the end of the response-envelope block); assert stage VALUES against
+// this enum, not against the drifted mirror.
+import { Stage } from '@talchain/schemas/boundary'
+
 import responseSchema from '../../contracts/cee/orchestrator-response-v2.schema.json'
 import streamEventSchema from '../../contracts/cee/stream-event.schema.json'
 
@@ -72,7 +79,10 @@ const successEnvelope = {
       priority: 70,
     },
   ],
-  stage_indicator: { stage: 'ideate', confidence: 'high', source: 'inferred' },
+  // Canonical wire stage (was 'ideate' — retired UI/DB vocab). 'frame' is the only
+  // value in the canonical enum that the drifted committed mirror also accepts, so
+  // it keeps the schema-shape assertions green without ratifying the wrong vocabulary.
+  stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
   client_turn_id: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
 }
 
@@ -97,7 +107,12 @@ const analysisEnvelope = {
     critiques: [],
     response_hash: 'hash-abc123',
   },
-  stage_indicator: 'evaluate',
+  // stage_indicator omitted deliberately. This envelope represents a completed
+  // analysis, whose canonical wire stage is 'analyse' — but the committed CEE
+  // mirror (enum [frame, ideate, evaluate]) REJECTS 'analyse', so a canonically
+  // correct value cannot be asserted valid here. Rather than tag an analysis turn
+  // with a wrong stage, drop the field (it is optional and this test exercises
+  // option_comparison, not stage). See the KNOWN DEFECT tests / cross-repo ask.
 }
 
 /** Error: analysis failed */
@@ -129,7 +144,8 @@ const graphOnlyEnvelope = {
 /** System event ack: stage update only */
 const ackEnvelope = {
   assistant_text: 'Noted. I\'ve updated the model.',
-  stage_indicator: { stage: 'ideate', confidence: 'medium', source: 'event' },
+  // Canonical wire stage (was 'ideate'). See successEnvelope note on 'frame'.
+  stage_indicator: { stage: 'frame', confidence: 'medium', source: 'event' },
   client_turn_id: 'deadbeef-1234-5678-abcd-ef0123456789',
 }
 
@@ -222,21 +238,52 @@ describe('Response envelope contract', () => {
     expect(valid).toBe(true)
   })
 
-  test('string stage_indicator validates', () => {
-    const envelope = { assistant_text: 'Hello', stage_indicator: 'evaluate' }
+  test('canonical string stage_indicator validates', () => {
+    // 'frame' is a canonical wire member AND accepted by the committed mirror.
+    // The stage VALUE is asserted canonical against Stage (source of truth);
+    // reverting to 'evaluate' makes this Stage assertion fail (evaluate is not a
+    // canonical wire stage — it is retired UI/DB vocab).
+    const envelope = { assistant_text: 'Hello', stage_indicator: 'frame' }
+    expect(Stage.safeParse(envelope.stage_indicator).success).toBe(true)
     const valid = validateResponseSchema(envelope)
     if (!valid) console.error('Validation errors:', validateResponseSchema.errors)
     expect(valid).toBe(true)
   })
 
-  test('object stage_indicator validates', () => {
+  test('canonical object stage_indicator validates', () => {
     const envelope = {
       assistant_text: 'Hello',
-      stage_indicator: { stage: 'ideate', confidence: 'high', source: 'inferred' },
+      stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
     }
+    expect(Stage.safeParse(envelope.stage_indicator.stage).success).toBe(true)
     const valid = validateResponseSchema(envelope)
     if (!valid) console.error('Validation errors:', validateResponseSchema.errors)
     expect(valid).toBe(true)
+  })
+
+  // ── KNOWN DEFECT tripwires — cross-repo ask (see PR body) ────────────────
+  // These PIN the current divergence between the canonical wire vocabulary
+  // (@talchain/schemas Stage) and the committed CEE JSON-schema mirror. They are
+  // GREEN today and FAIL LOUD the moment the mirror is corrected to canonical
+  // (re-synced from a fixed CEE export). Do not "fix" them by editing values —
+  // they are the tripwire; when they go red, the mirror has been made canonical
+  // and the fixtures above should switch to the real values (analyse/decide/review).
+
+  test('KNOWN DEFECT: committed response mirror is mis-typed — rejects canonical wire values, accepts retired UI vocab', () => {
+    // The response mirror is NOT permissive — it is an enum of the WRONG set:
+    // [frame, ideate, evaluate]. It rejects canonical 'analyse' and accepts
+    // retired 'ideate'. Positive control (nonsense) confirms it is enum-typed,
+    // not a bare string.
+    const canonicalButRejected = { assistant_text: 'x', stage_indicator: 'analyse' }
+    expect(validateResponseSchema(canonicalButRejected)).toBe(false) // WRONG: 'analyse' is canonical
+    expect(Stage.safeParse('analyse').success).toBe(true)
+
+    const retiredButAccepted = { assistant_text: 'x', stage_indicator: 'ideate' }
+    expect(validateResponseSchema(retiredButAccepted)).toBe(true) // WRONG: 'ideate' is retired
+    expect(Stage.safeParse('ideate').success).toBe(false)
+
+    const nonsense = { assistant_text: 'x', stage_indicator: 'not_a_stage_xyz' }
+    expect(validateResponseSchema(nonsense)).toBe(false) // proves the field IS enum-typed
   })
 })
 
@@ -246,10 +293,23 @@ describe('Response envelope contract', () => {
 
 describe('Stream event contract', () => {
   test('turn_start event validates', () => {
-    const event = { type: 'turn_start', seq: 1, turn_id: 't-1', routing: 'llm', stage: 'ideate' }
+    // Canonical wire stage (was 'ideate'). NB the stream mirror types `stage` as a
+    // bare string (no enum) — see the KNOWN GAP tripwire below — so any value would
+    // validate; 'frame' is used to keep the fixture canonical regardless.
+    const event = { type: 'turn_start', seq: 1, turn_id: 't-1', routing: 'llm', stage: 'frame' }
     const valid = validateStreamEvent(event)
     if (!valid) console.error('Validation errors:', validateStreamEvent.errors)
     expect(valid).toBe(true)
+  })
+
+  test('KNOWN GAP: stream turn_start.stage is an untyped bare string — nonsense validates', () => {
+    // The stream-event mirror types `stage` as { type: 'string' } with no enum, so
+    // it cannot catch a wrong stage value at all. Positive control proves it: an
+    // absurd value validates. Tripwire — fails loud if `stage` is ever tightened to
+    // the canonical Stage enum. See PR body / cross-repo ask.
+    const nonsense = { type: 'turn_start', seq: 1, turn_id: 't-1', routing: 'llm', stage: 'not_a_stage_xyz' }
+    expect(validateStreamEvent(nonsense)).toBe(true) // permissive — zero protection
+    expect(Stage.safeParse('not_a_stage_xyz').success).toBe(false)
   })
 
   test('text_delta event validates', () => {


### PR DESCRIPTION
## What & why

Ten test fixtures sent the retired **UI/DB `ScenarioStage`** vocabulary (`ideate`, `evaluate`) as if it were canonical **wire** vocab. The canonical wire enum is `@talchain/schemas` **`Stage` = `frame | analyse | decide | review`** (British `analyse`). They passed because `normaliseStage()` (`src/v5/applyV5State.ts`) *rejects* non-canonical values — so each fixture silently exercised the "unrecognised stage / stage not applied" path while appearing to test a valid stage. Vacuous coverage. This retires them, choosing per test between a valid canonical value and an explicit distractor.

## 🔴 Headline finding — the contract test ratified the wrong vocabulary, and the "cross-service" gate is dead

`tests/contracts/response-envelope-contract.test.ts` validates envelopes against the committed CEE JSON-schema mirror in `contracts/cee/`. That mirror is **not permissive — it enumerates the WRONG set.**

**Positive control** (ajv, against the committed `contracts/cee/orchestrator-response-v2.schema.json`):

| `stage_indicator` value | committed response mirror | canonical `Stage` |
|---|---|---|
| `frame` | ✅ VALID | ✅ member |
| `ideate` | ✅ VALID | ❌ not a member |
| `evaluate` | ✅ VALID | ❌ not a member |
| `analyse` (canonical) | ❌ **REJECTED** | ✅ member |
| `decide` / `review` (canonical) | ❌ **REJECTED** | ✅ members |
| `not_a_stage_xyz` | ❌ REJECTED | ❌ |

So the response mirror **rejects the canonical wire values and accepts retired UI vocabulary.** `not_a_stage_xyz` being rejected proves it *is* enum-typed — just the wrong enum. A contract test built on it cannot catch a wrong stage; it ratifies one.

The **stream** mirror is worse — `turn_start.stage` is typed `{ "type": "string" }` with **no enum**, so `not_a_stage_xyz` and `""` both validate. Zero protection.

### Three-way divergence (all describe the same wire field)
- `@talchain/schemas` **Stage** (single source of truth): `frame | analyse | decide | review`
- CEE's exported JSON schema (`Talchain/olumi-assistants-service@staging`): `frame | ideate | evaluate | decide | optimise` — a **third** vocabulary (`optimise` exists nowhere else; object-only, no bare-string form)
- DGAI committed mirror (`contracts/cee/…`): `frame | ideate | evaluate`

### The gate that should have caught this is dead
`.github/workflows/contract-validation.yml:51` checks out `repository: Olumi/olumi-assistants-service` — **that org 404s** (the real repo is `Talchain/…`, and it's public). The step is `continue-on-error: true`, so the sync silently falls back to the committed copies. CI log (run `29726389697`, staging, SUCCESS):
```
##[error]Not Found - .../rest/repos/repos#get-a-repository
CEE repo not available — using committed reference schemas
All 6 reference schemas present.
```
The "cross-service contract validation" has **never** validated against the other service — it validates the UI against its own drifted mirror and counts 6 files. Classic hand-maintained-mirror drift.

### Corroboration — a captured live wire value
`src/test/fixtures/golden-path-staging-2026-04-05.json` (captured from real staging bundle `olumi-debug-f0045fec-20260405`) has `cee_response.stage_indicator === "evaluate"`. CEE **really emits** the retired vocab on the wire, and `normaliseStage()` would **reject** it → live "no stage signal" for real responses. Latent runtime bug, not just test hygiene. (That fixture + its assertion are a faithful capture — left untouched.)

## ⚠️ Cross-repo ask (do NOT fix here — cascades / not ours)
The `contracts/cee/*.schema.json` files are **CEE-owned** (fetched via `scripts/fetch-cee-contracts.sh`), so tightening them is not ours to do unilaterally. Precise asks:

1. **`@talchain/schemas` ↔ CEE export reconciliation** — CEE's exported `orchestrator-response-v2.schema.json` `stage_indicator.stage` enum is `[frame, ideate, evaluate, decide, optimise]`; the canonical `Stage` is `[frame, analyse, decide, review]`. Either CEE's export must adopt the canonical enum, or the discrepancy is a genuine wire contract that `@talchain/schemas` doesn't model. Field: `stage_indicator.stage`. Proposed: canonical `Stage` enum. Newly rejects: `ideate`, `evaluate`, `optimise`. Newly accepts: `analyse`, `review`.
2. **Stream `turn_start.stage`** — currently `{type:string}` (CEE adds `minLength:1`); tighten to the canonical enum. Newly rejects: any non-canonical string.
3. **Dead CI gate** — fix `.github/workflows/contract-validation.yml:51` `Olumi/` → `Talchain/`. ⚠️ Not done here on purpose: re-syncing CEE's *real* schema would also start enforcing required fields (`turn_id`, `blocks`, `suggested_actions`) that the current DGAI envelope fixtures omit, cascading failures well beyond these 10 fixtures. Needs its own PR.

## Per-fixture outcomes (all mutation-checked in a throwaway copy)

| Fixture | Intent | Decision | Asserts something real? | Revert → |
|---|---|---|---|---|
| hardening.test.ts:62 | block-driven clear; stage is a distractor | canonical `frame` distractor | Yes — clear is **block-driven**, stage not load-bearing | 🟢 GREEN (expected) |
| hardening.test.ts:77 | conversational turn *preserves* ready | canonical `frame` + **new** `setCurrentStage('frame')` assertion | Yes — now pins the recognised-stage path | 🔴 RED |
| hardening.test.ts:311 | hydration: conversational preserves | canonical `frame` + **new** stage-applied assertion | Yes | 🔴 RED |
| debug.test.ts:98 | step-4 `skip_reason` on conversational turn | canonical `frame` | Yes — `skip_reason` is the subject (needs non-analyse) | 🟢 GREEN (expected) |
| analysisProducingCeeTurn.spec.ts:504 | canonical CEE shape for hash-match selector | canonical `analyse` | Yes — selector reads `lineage.response_hash`; stage is decoration | 🟢 GREEN (expected) |
| response-envelope-contract.test.ts:75 (successEnvelope) | graph-patch envelope validates | canonical `frame` | Yes — tests graph patch/guidance; stage incidental | 🟢 GREEN (expected) |
| …:100 (analysisEnvelope) | option_comparison validates | **dropped** stage (canonical `analyse` is rejected by the mirror — won't mislabel) | Yes — tests option_comparison | 🟢 GREEN (expected) |
| …:132 (ackEnvelope) | ack validates | canonical `frame` | Yes — tests assistant_text | 🟢 GREEN (expected) |
| …:226 (string stage test) | string-form stage validates | canonical `frame` + **assert against `Stage`** | Yes — now pins canonical value | 🔴 RED |
| …:235 (object stage test) | object-form stage validates | canonical `frame` + **assert against `Stage`** | Yes | 🔴 RED |
| …:249 (stream turn_start, bonus 11th) | turn_start validates | canonical `frame` | Yes — but stream `stage` is untyped, so doubly-permissive | 🟢 GREEN (expected) |

**New tests added** (fail-loud tripwires, green today): a KNOWN-DEFECT test pinning the response-mirror divergence (rejects `analyse`, accepts `ideate`, rejects nonsense) and a KNOWN-GAP test pinning the stream-mirror permissiveness. Both go red the moment the mirror is corrected.

### On the GREEN-on-revert fixtures
Seven stayed green when reverted to `ideate`/`evaluate` — as predicted. For those the stage value is genuinely **not** what the test pins (the clear is block-driven; the selector reads the hash; the mirror accepts both vocabularies; the stream schema accepts anything). They were canonicalised for honesty and their real assertions are intact; they are not dead weight. The four RED-on-revert fixtures are the ones where the stage value now carries real weight.

## Gates
- `pnpm run typecheck` — clean
- `pnpm run lint` (touched files) — 0 errors (1 pre-existing unused-directive warning at debug.test.ts:42, not on a touched line)
- `npx vitest run --changed origin/staging` — 4 files, 167 passed
- `npx vitest run tests/ci-guards` — 7 files, 50 passed

**Draft — do not merge.**
