### PR TITLE
fix(conversation): recovery suggestions render on the LIVE V5 path, server retryability authoritative

### DIFF
--- a/src/canvas/conversation/__tests__/ceeRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/ceeRecovery.spec.ts
@@ -16,7 +16,7 @@
  *   - retryable marker absent → undefined → caller keeps retry
  */
 import { describe, it, expect } from 'vitest'
-import { extractCeeRecovery, buildFailureRender } from '../ceeRecovery'
+import { extractCeeRecovery, buildFailureRender, formatRecoveryHints, isDisplaySafeReason } from '../ceeRecovery'
 
 describe('extractCeeRecovery — retryable marker', () => {
   it('reads a flat 0.18.0 CeeTypedError { retryable:false }', () => {
@@ -213,5 +213,98 @@ describe('buildFailureRender — surface (a) recovery + (b) honest retry', () =>
     seen.length = 0
     buildFailureRender(spy, { body: { retryable: true } })
     expect(seen).toEqual([true])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 0.19.0 nested recovery shape ({ recovery: { hints, suggestion, example? } })
+// — the shape the LIVE V5 wire carries at BoundaryError.details.recovery.
+// ---------------------------------------------------------------------------
+
+describe('extractCeeRecovery — 0.19.0 nested recovery object', () => {
+  const NESTED = {
+    hints: ['Name the decision', 'List two options'],
+    suggestion: 'Add more detail to your brief, then draft again.',
+    example: 'Should we expand to Berlin or Munich next year?',
+  }
+
+  it('reads suggestion + hints from a BoundaryError-shaped details.recovery', () => {
+    const boundaryError = {
+      error: 'INTERNAL_ERROR',
+      boundary: 'B1',
+      direction: 'egress',
+      validator: 'draft_graph_pipeline',
+      details: { retryable: false, reason: 'draft_graph_cee_llm_validation_failed', recovery: NESTED },
+      request_id: 'req_1',
+      retryable: false,
+    }
+    const out = extractCeeRecovery(boundaryError)
+    expect(out.retryable).toBe(false)
+    expect(out.suggestion).toBe(NESTED.suggestion)
+    expect(out.hints).toEqual(NESTED.hints)
+  })
+
+  it('flat recovery_suggestion has priority over the nested suggestion in the same container', () => {
+    const out = extractCeeRecovery({
+      body: {
+        retryable: true,
+        recovery_suggestion: 'Flat wins.',
+        recovery: { hints: ['a hint here'], suggestion: 'Nested loses.' },
+      },
+    })
+    expect(out.suggestion).toBe('Flat wins.')
+    expect(out.hints).toEqual(['a hint here'])
+  })
+
+  it('rejects code-like nested suggestions and hints (reject-only guard)', () => {
+    const out = extractCeeRecovery({
+      body: {
+        recovery: {
+          hints: ['CEE_LLM_TIMEOUT', '  ', 'keep this real hint'],
+          suggestion: 'UPSTREAM_TIMEOUT',
+        },
+      },
+    })
+    expect(out.suggestion).toBeUndefined()
+    expect(out.hints).toEqual(['keep this real hint'])
+  })
+
+  it('non-object recovery values fall back to the legacy string reading', () => {
+    const out = extractCeeRecovery({ body: { recovery: 'Just try a shorter brief.' } })
+    expect(out.suggestion).toBe('Just try a shorter brief.')
+    expect(out.hints).toBeUndefined()
+  })
+})
+
+describe('isDisplaySafeReason — machine reasons never render, prose does', () => {
+  it.each([
+    ['draft_graph_cee_llm_validation_failed', false],
+    ['draft_graph_cee_timeout', false],
+    ['CEE_LLM_TIMEOUT', false],
+    ['', false],
+    ['   ', false],
+    ['turn_id must be a UUID v4', true],
+    ['The upstream model returned an empty response', true],
+  ])('%s → %s', (value, expected) => {
+    expect(isDisplaySafeReason(value)).toBe(expected)
+  })
+})
+
+describe('formatRecoveryHints + buildFailureRender hint layering', () => {
+  it('renders hints as bullet lines', () => {
+    expect(formatRecoveryHints(['one', 'two'])).toBe('• one\n• two')
+    expect(formatRecoveryHints([])).toBe('')
+    expect(formatRecoveryHints(undefined)).toBe('')
+  })
+
+  it('buildFailureRender appends suggestion then hints beneath the base copy', () => {
+    const out = buildFailureRender(() => 'Base copy.', {
+      body: {
+        retryable: false,
+        recovery: { hints: ['hint one', 'hint two'], suggestion: 'Do the specific thing.' },
+      },
+    })
+    expect(out.showRetry).toBe(false)
+    expect(out.content).toBe('Base copy.\n\nDo the specific thing.\n\n• hint one\n• hint two')
   })
 })

--- a/src/canvas/conversation/__tests__/useConversation.v5ErrorRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.v5ErrorRecovery.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * LIVE-CHAIN V5 error-recovery tests (Codex F6 — recovery renders on the
+ * LIVE path, server retryability authoritative).
+ *
+ * These tests drive an ACTUAL non-2xx CEE body through the LIVE V5 branch:
+ * a stubbed global fetch returns the real wire shape, then the REAL
+ * `callV5Turn` → REAL `parseV5Response` (real `BoundaryErrorSchema`) → REAL
+ * `routeV5Response` → useConversation's V5 typed_error branch run
+ * unmocked. The only seams stubbed are eligibility (flag on), auth/session,
+ * telemetry, the DB service, and the network itself.
+ *
+ * Why this shape is load-bearing: #383 shipped its recovery rendering with
+ * a renderer unit test fed a hand-built object — and was wired to the DEAD
+ * V4 `handleEnvelope` path (the V5 branch `return`s before it). A grepped
+ * symbol proves presence-in-repo, never presence-on-the-live-wire; only a
+ * wire-in test proves the live chain. These specs FAIL on the pre-fix code.
+ *
+ * Wire provenance (verified at CEE staging cbb619a3, src/orchestrator/
+ * route-v2.ts): every non-2xx `/orchestrate/v2/turn` body is a strict
+ * BoundaryError; recovery rides NESTED at `details.recovery` ({ hints,
+ * suggestion, example? }); `details.reason` carries MACHINE codes
+ * (draft_graph_cee_timeout) that must never render to users. The flat
+ * `recovery_suggestion` (0.19.0 `CeeTypedErrorSchema`, root export) rides
+ * CEEErrorResponseV1-shaped envelopes, which are not BoundaryErrors.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+
+// ---------------------------------------------------------------------------
+// Mocks — seams only; the V5 adapter/parser/router chain stays REAL.
+// ---------------------------------------------------------------------------
+
+// V4 transport must never be touched by these tests.
+const mockCallTurn = vi.fn()
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: async () => null,
+  storeAnalysis: async () => undefined,
+}))
+
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: () => undefined,
+}))
+
+// Eligibility ON so sendMessage enters the V5 exclusive branch regardless of
+// the developer's env (same pattern as useConversation.hook.spec.ts).
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true }),
+    isV5CanonicalRunPath: () => false,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Wire fixtures + fetch stub
+// ---------------------------------------------------------------------------
+
+const RECOVERY_SUGGESTION = 'Add more detail about your options, then draft again.'
+const RECOVERY_HINTS = [
+  'Name the decision you are weighing',
+  'List at least two options you are choosing between',
+]
+const MACHINE_REASON = 'draft_graph_cee_llm_validation_failed'
+
+/** The LIVE wire shape: strict BoundaryError, recovery NESTED in details. */
+function liveBoundaryErrorBody(overrides: {
+  retryable: boolean
+  reason?: string
+  recovery?: { hints: string[]; suggestion: string; example?: string }
+}): Record<string, unknown> {
+  return {
+    error: 'INTERNAL_ERROR',
+    boundary: 'B1',
+    direction: 'egress',
+    validator: 'draft_graph_pipeline',
+    details: {
+      retryable: overrides.retryable,
+      ...(overrides.reason !== undefined ? { reason: overrides.reason } : {}),
+      ...(overrides.recovery !== undefined ? { recovery: overrides.recovery } : {}),
+      pipeline_error_code: 'CEE_LLM_VALIDATION_FAILED',
+      stage: 'frame',
+    },
+    request_id: 'req_live_1',
+    retryable: overrides.retryable,
+  }
+}
+
+function stubFetchWith(status: number, body: unknown) {
+  const fetchStub = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response))
+  vi.stubGlobal('fetch', fetchStub)
+  return fetchStub
+}
+
+async function sendAndGetLastMessage() {
+  const { result } = renderHook(() => useConversation())
+  await act(async () => {
+    await result.current.sendMessage('draft my decision')
+  })
+  const messages = result.current.messages
+  const last = messages[messages.length - 1]
+  expect(last).toBeDefined()
+  expect(last.role).toBe('assistant')
+  return { last, result }
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' } as never,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('V5 live-chain error recovery — non-2xx BoundaryError through the real adapter/parser/router', () => {
+  it('envelope WITH nested recovery + server retryable:false → suggestion and hints render, machine reason does not, no retry affordance despite client-retryable INTERNAL_ERROR', async () => {
+    const fetchStub = stubFetchWith(500, liveBoundaryErrorBody({
+      retryable: false,
+      reason: MACHINE_REASON,
+      recovery: { hints: RECOVERY_HINTS, suggestion: RECOVERY_SUGGESTION },
+    }))
+
+    const { last, result } = await sendAndGetLastMessage()
+    expect(fetchStub).toHaveBeenCalledTimes(1)
+
+    // The user sees the specific recovery suggestion…
+    expect(last.content).toContain(RECOVERY_SUGGESTION)
+    // …and the hints, as bullets…
+    expect(last.content).toContain(`• ${RECOVERY_HINTS[0]}`)
+    expect(last.content).toContain(`• ${RECOVERY_HINTS[1]}`)
+    // …and NEVER the raw machine reason code.
+    expect(last.content).not.toContain(MACHINE_REASON)
+
+    // Server said non-retryable — no retry affordance, even though the
+    // client table classifies INTERNAL_ERROR as retryable.
+    expect(last.actionChips ?? []).toHaveLength(0)
+    // And the copy must not instruct a retry the UI does not offer.
+    expect(last.content).not.toMatch(/please retry|try again/i)
+    // Non-retryable failures do not arm the retry-input restore.
+    expect(result.current.lastFailedInput).toBeNull()
+  })
+
+  it('envelope WITHOUT recovery + server retryable:true → canonical copy with retry affordance, machine reason still never leaks', async () => {
+    stubFetchWith(500, liveBoundaryErrorBody({
+      retryable: true,
+      reason: 'draft_graph_cee_timeout',
+    }))
+
+    const { last } = await sendAndGetLastMessage()
+
+    // Safe fallback: the canonical taxonomy copy.
+    expect(last.content).toContain('Something went wrong on our side. Please retry.')
+    // The machine reason code must not leak to the user.
+    expect(last.content).not.toContain('draft_graph_cee_timeout')
+    // Server says retryable — the affordance is offered.
+    expect(last.actionChips).toEqual([
+      { id: 'retry', label: 'Try again', intent: 'primary' },
+    ])
+  })
+
+  it('server retryable:false WITHOUT recovery → no retry affordance and no retry instruction in the copy', async () => {
+    stubFetchWith(500, liveBoundaryErrorBody({
+      retryable: false,
+      reason: 'draft_graph_cee_graph_invalid',
+    }))
+
+    const { last } = await sendAndGetLastMessage()
+
+    expect(last.content).toContain('Something went wrong on our side.')
+    expect(last.content).not.toMatch(/please retry/i)
+    expect(last.actionChips ?? []).toHaveLength(0)
+  })
+
+  it('prose details.reason (no recovery) renders — the display gate rejects codes, not sentences', async () => {
+    stubFetchWith(500, liveBoundaryErrorBody({
+      retryable: true,
+      reason: 'The upstream model returned an empty response',
+    }))
+
+    const { last } = await sendAndGetLastMessage()
+
+    expect(last.content).toContain('The upstream model returned an empty response')
+  })
+
+  it('flat CeeTypedError-shaped non-2xx body (0.19.0 recovery_suggestion, not a BoundaryError) → suggestion renders and server retryable:false is honoured through the rawBody passthrough', async () => {
+    stubFetchWith(500, {
+      error: 'CEE_LLM_VALIDATION_FAILED',
+      message: 'Draft failed validation.',
+      retryable: false,
+      request_id: 'req_flat_1',
+      recovery_suggestion: RECOVERY_SUGGESTION,
+      recovery: { hints: RECOVERY_HINTS, suggestion: RECOVERY_SUGGESTION },
+    })
+
+    const { last } = await sendAndGetLastMessage()
+
+    expect(last.content).toContain(RECOVERY_SUGGESTION)
+    expect(last.content).toContain(`• ${RECOVERY_HINTS[0]}`)
+    expect(last.actionChips ?? []).toHaveLength(0)
+    expect(last.content).not.toMatch(/please retry|try again/i)
+  })
+
+  it('no envelope at all (200 with a severity-error block) → client table resolves retryability safely', async () => {
+    stubFetchWith(200, {
+      response_version: 2,
+      assistant_text: '',
+      blocks: [{ type: 'error', error_code: 'TURN_BUDGET_EXCEEDED', severity: 'error' }],
+      suggested_actions: [],
+      insights: [],
+      stage_indicator: 'frame',
+    })
+
+    const { last } = await sendAndGetLastMessage()
+
+    // Client-table fallback: TURN_BUDGET_EXCEEDED is non-retryable.
+    expect(last.actionChips ?? []).toHaveLength(0)
+    // Copy agrees with the withheld affordance and the guidance names the way forward.
+    expect(last.content).toContain('That took longer than we allow for a single turn.')
+    expect(last.content).not.toMatch(/please retry/i)
+    expect(last.content).toContain('start a new decision')
+  })
+})

--- a/src/canvas/conversation/ceeRecovery.ts
+++ b/src/canvas/conversation/ceeRecovery.ts
@@ -7,20 +7,26 @@
  *   2. a *specific recovery suggestion* — plain-language guidance on what to
  *      do instead of, or alongside, retrying.
  *
- * Wire provenance / schema ask
- * ----------------------------
- * As of @talchain/schemas 0.18.0 the `CeeTypedErrorSchema` is `.passthrough()`
- * and types only { error, message, retryable, elapsed_ms?, request_id? }. The
- * `retryable` boolean IS typed (also `retriable` is the canonical PLoT run.v1
- * spelling — see src/types/cee.ts CeeError). The recovery suggestion is NOT
- * typed on the schema, and is absent from CEE Spec v04's CEEErrorResponseV1
- * ({ error: { code, message, details?, retryable } }). It rides on the wire as
- * an untyped passthrough sibling. Until the schema pins it, we read it
- * defensively from a small set of de-facto field names and fail closed.
+ * Wire provenance (RESOLVED — @talchain/schemas 0.19.0, wave-2 ask 7)
+ * -------------------------------------------------------------------
+ * The 0.18.0 SCHEMA ASK that used to live here has been answered. 0.19.0's
+ * `CeeTypedErrorSchema` (a ROOT export — not under `/boundary`; placement
+ * confirmed by design) types BOTH recovery shapes on the CEE error envelope:
+ *   - flat  `recovery_suggestion?: string` — the pinned mirror of
+ *     `recovery.suggestion`, present exactly when the structured object is
+ *     (see CEE `buildCeeErrorResponse`, src/cee/validation/pipeline.ts);
+ *   - nested `recovery?: { hints: string[]; suggestion: string;
+ *     example?: string }` (`CeeErrorRecoverySchema`) — "hints are short
+ *     actionable bullets, suggestion is the one display-safe sentence a UI
+ *     surfaces next to the failure".
  *
- * SCHEMA ASK: add a typed `recovery_suggestion?: string` (or confirm the real
- * producer field name) to CeeTypedErrorSchema so the UI can stop
- * passthrough-sniffing and gain a compile-time contract.
+ * On the LIVE V5 wire (`/orchestrate/v2/turn`), every non-2xx body is a
+ * strict `BoundaryError` whose passthrough `details` carries the NESTED
+ * shape at `details.recovery` (CEE route-v2.ts `postStageExtras.recovery`).
+ * The FLAT mirror rides envelopes built directly from
+ * `buildCeeErrorResponse` (assist/V4 endpoints, CEEErrorResponseV1). This
+ * module therefore reads both, per the contract. The de-facto alias keys
+ * below are retained for pre-0.19.0 producers and fail closed as before.
  *
  * Fail-closed contract (never strand the user)
  * --------------------------------------------
@@ -35,7 +41,14 @@
 /** Field names, in priority order, under which CEE may place the retryable marker. */
 const RETRYABLE_KEYS = ['retryable', 'retriable'] as const
 
-/** Field names, in priority order, under which CEE may place the recovery suggestion. */
+/**
+ * Field names, in priority order, under which CEE may place the recovery
+ * suggestion as a plain string. `recovery_suggestion` is the 0.19.0-pinned
+ * flat mirror; the rest are pre-0.19.0 de-facto aliases. The 0.19.0 NESTED
+ * `recovery` object ({ hints, suggestion, example? }) is read separately in
+ * `extractCeeRecovery` — the legacy `'recovery'` entry here only matches
+ * when the value is itself a string.
+ */
 const SUGGESTION_KEYS = [
   'recovery_suggestion',
   'suggested_action',
@@ -57,6 +70,13 @@ export interface CeeRecovery {
    * render codes to users). Fail closed → the caller keeps its generic copy.
    */
   suggestion?: string
+  /**
+   * Short actionable bullets from the 0.19.0 nested `recovery.hints[]`.
+   * Only display-safe entries survive (trimmed, non-empty, not code-like).
+   * `undefined` when the wire carried none (fail closed — callers render
+   * nothing rather than inventing hints).
+   */
+  hints?: string[]
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -118,10 +138,58 @@ function collectContainers(err: unknown): Record<string, unknown>[] {
  * Rejecting is safe: the caller falls back to its own generic copy, which is
  * already honest for the retry state.
  */
-function looksLikeCode(value: string): boolean {
+export function looksLikeCode(value: string): boolean {
   const trimmed = value.trim()
   if (/^[A-Z][A-Z0-9_]{2,}$/.test(trimmed)) return true
   return !/[a-z]/.test(trimmed)
+}
+
+/**
+ * True when a wire `details.reason` value is safe to show a user as prose.
+ *
+ * Stricter than `looksLikeCode`'s reject-only rules because the reason field
+ * is a DIFFERENT contract: CEE's live V5 wire populates it with typed
+ * machine reasons in lower_snake_case (`draft_graph_cee_timeout`,
+ * `draft_graph_cee_llm_validation_failed` — see CEE route-v2.ts
+ * `mapDraftGraphPipelineReason`), which `looksLikeCode` alone cannot reject
+ * (they contain lowercase letters). Genuine prose reasons ("turn_id must be
+ * a UUID v4") contain whitespace; single-token values never do. Rejecting is
+ * safe — the caller falls back to the canonical failure copy, which is
+ * already honest.
+ */
+export function isDisplaySafeReason(value: string): boolean {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return false
+  if (!/\s/.test(trimmed)) return false
+  return !looksLikeCode(trimmed)
+}
+
+/**
+ * Read the 0.19.0 nested `recovery` object ({ hints, suggestion, example? })
+ * out of a container, applying the same reject-only display guards as the
+ * flat path. Returns only the fields that survived the guards.
+ */
+function readNestedRecovery(container: Record<string, unknown>): {
+  suggestion?: string
+  hints?: string[]
+} {
+  const nested = container.recovery
+  if (!isRecord(nested)) return {}
+  const out: { suggestion?: string; hints?: string[] } = {}
+  if (typeof nested.suggestion === 'string') {
+    const trimmed = nested.suggestion.trim()
+    if (trimmed.length > 0 && !looksLikeCode(trimmed)) {
+      out.suggestion = trimmed
+    }
+  }
+  if (Array.isArray(nested.hints)) {
+    const safe = nested.hints
+      .filter((h): h is string => typeof h === 'string')
+      .map((h) => h.trim())
+      .filter((h) => h.length > 0 && !looksLikeCode(h))
+    if (safe.length > 0) out.hints = safe
+  }
+  return out
 }
 
 /**
@@ -154,7 +222,23 @@ export function extractCeeRecovery(err: unknown): CeeRecovery {
         }
       }
     }
-    if (result.retryable !== undefined && result.suggestion !== undefined) break
+    // 0.19.0 nested shape ({ recovery: { hints, suggestion, example? } }) —
+    // the shape the LIVE V5 wire carries at BoundaryError.details.recovery.
+    // The flat mirror (when both are present they agree by contract) has
+    // priority via the loop above; the nested object fills whatever is
+    // still missing.
+    const nested = readNestedRecovery(c)
+    if (result.suggestion === undefined && nested.suggestion !== undefined) {
+      result.suggestion = nested.suggestion
+    }
+    if (result.hints === undefined && nested.hints !== undefined) {
+      result.hints = nested.hints
+    }
+    if (
+      result.retryable !== undefined &&
+      result.suggestion !== undefined &&
+      result.hints !== undefined
+    ) break
   }
 
   return result
@@ -194,11 +278,24 @@ export type FailureBaseBuilder = (showRetry: boolean) => string
  * so `buildBase(true)` is called and today's copy is returned verbatim.
  */
 export function buildFailureRender(buildBase: FailureBaseBuilder, err: unknown): FailureRender {
-  const { retryable, suggestion } = extractCeeRecovery(err)
+  const { retryable, suggestion, hints } = extractCeeRecovery(err)
   const showRetry = retryable !== false
   const baseMessage = buildBase(showRetry)
-  const content = suggestion ? `${baseMessage}\n\n${suggestion}` : baseMessage
+  const hintsBlock = formatRecoveryHints(hints)
+  const content = [baseMessage, suggestion ?? '', hintsBlock]
+    .filter((s) => s.length > 0)
+    .join('\n\n')
   return { content, showRetry }
+}
+
+/**
+ * Render the 0.19.0 `recovery.hints[]` bullets as display lines. Pure string
+ * assembly — the entries were already display-guarded in extraction. Empty
+ * string when there is nothing to show, so callers can filter it out.
+ */
+export function formatRecoveryHints(hints: string[] | undefined): string {
+  if (!hints || hints.length === 0) return ''
+  return hints.map((h) => `• ${h}`).join('\n')
 }
 
 /**

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -12,17 +12,23 @@ import { setCurrentScenarioId } from '../store/scenarios'
 import { useDraftStore } from '../stores/draftStore'
 import { generateGraphHash } from '../utils/graphHash'
 import { callOrchestratorTurn, streamOrchestratorTurn, OrchestratorError } from './turnService'
-import { buildFailureRender } from './ceeRecovery'
+import {
+  buildFailureRender,
+  extractCeeRecovery,
+  formatRecoveryHints,
+  isDisplaySafeReason,
+} from './ceeRecovery'
 import { callV5Turn, getV5Endpoint } from '../../v5/v5Adapter'
 import { routeV5Response } from '../../v5/responseRouter'
 import { getTimeoutMs } from '../../v5/getTimeoutMs'
 import { isV5Eligible } from '../../v5/eligibility'
 import { buildV5Payload } from '../../v5/buildPayload'
 import {
-  isRetryable as isV5ErrorRetryable,
   checkRetryableAgreement,
   extractReason as extractV5ErrorReason,
   resolveGuidance as resolveV5ErrorGuidance,
+  resolveRetryable as resolveV5Retryable,
+  resolveFailureBaseCopy,
 } from '../../v5/failureTypeRetryability'
 import { mapV5Blocks } from '../../v5/blocks/mapV5Blocks'
 import { deriveV5Stage, v5StageToScenarioStage } from '../../v5/stageMapper'
@@ -42,7 +48,6 @@ import {
 // surface (malformed / no renderer / legacy suppression). Counting only —
 // recordDroppedContent never throws and never changes composition output.
 import { recordDroppedContent } from '../../lib/droppedContentCounter'
-import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled, isReasoningDisclosureEnabled } from '../../flags'
 import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
 // Leg 3 blocker fix: the wire->camelCase coaching mapper lives in the CEE
@@ -3596,20 +3601,49 @@ export function useConversation(): UseConversationReturn {
             })
             if (inputForRestore) setLastFailedInput(inputForRestore)
           } else {
-            // Typed error. Layer server reason beneath the canonical text;
-            // offer Try again chip when the error is retryable (client table
-            // is authoritative; DEV warning fires if server disagrees).
+            // Typed error — the LIVE V5 error surface (Codex F6 fix; #383's
+            // recovery rendering was wired only to the dead V4 handleEnvelope
+            // path, which this branch's `return` makes unreachable).
+            //
+            // Authority order: the server's `retryable` marker on the error
+            // envelope is authoritative (BoundaryError.retryable is typed +
+            // required; CEE computes it per-failure, so INTERNAL_ERROR is NOT
+            // uniformly retryable). The client table covers only its absence
+            // (200-response error blocks / parse errors carry no envelope).
             if (target.boundaryError) {
               checkRetryableAgreement(target.boundaryError)
             }
-            const retryable = isV5ErrorRetryable(target.code)
-            const canonicalText = FAILURE_USER_TEXT[target.code]
+            // extractCeeRecovery reads the typed 0.19.0 recovery shapes:
+            // nested `details.recovery` ({ hints, suggestion }) on the live
+            // BoundaryError wire, flat `recovery_suggestion` on
+            // CeeTypedError-shaped bodies (via rawBody), plus the server
+            // retryable marker. Fail closed on every field.
+            const recovery = extractCeeRecovery(target.boundaryError ?? target.rawBody)
+            const retryable = resolveV5Retryable(target.code, recovery.retryable)
+            // Layered content, each layer display-honest:
+            //   1. canonical taxonomy text, stripped of retry instructions
+            //      when the retry affordance is withheld;
+            //   2. the CEE recovery suggestion (specific what-to-do) when
+            //      present; otherwise the wire reason ONLY when it reads as
+            //      prose — machine reasons (draft_graph_cee_timeout) never
+            //      render to users;
+            //   3. recovery hints as bullets;
+            //   4. generic code-keyed guidance only when no specific
+            //      suggestion filled the what-next slot (non-retryable codes
+            //      only — the Try again chip serves that role otherwise).
+            const baseCopy = resolveFailureBaseCopy(target.code, retryable)
             const reason = extractV5ErrorReason(target.boundaryError)
-            const guidance = resolveV5ErrorGuidance(target.code)
-            // Layer: canonical taxonomy text → server reason (if any) →
-            // code-specific guidance (non-retryable only). Retryable errors
-            // omit guidance because the Try again chip serves that role.
-            const content = [canonicalText, reason, guidance]
+            const reasonLayer =
+              recovery.suggestion === undefined && isDisplaySafeReason(reason) ? reason : ''
+            const guidance =
+              recovery.suggestion === undefined ? resolveV5ErrorGuidance(target.code) : ''
+            const content = [
+              baseCopy,
+              recovery.suggestion ?? '',
+              reasonLayer,
+              formatRecoveryHints(recovery.hints),
+              guidance,
+            ]
               .filter((s) => s.length > 0)
               .join('\n\n')
             const retryChips: ActionChip[] = retryable && mode === 'user' && !hidden

--- a/src/v5/__tests__/end-to-end.test.ts
+++ b/src/v5/__tests__/end-to-end.test.ts
@@ -237,8 +237,14 @@ describe('V5 typed error — layered content assembly', () => {
   });
 
   it('boundary_error with details.reason produces canonical + reason + guidance layers', async () => {
-    // Mirrors the three-layer join in useConversation's typed_error branch:
-    //   FAILURE_USER_TEXT[code] + extractReason(boundaryError) + resolveGuidance(code)
+    // Mirrors the layered join in useConversation's typed_error branch for
+    // the no-recovery-suggestion case:
+    //   resolveFailureBaseCopy(code, retryable) + extractReason(boundaryError)
+    //   [prose only, via isDisplaySafeReason] + resolveGuidance(code)
+    // (Codex F6: server `retryable` is authoritative; recovery suggestions,
+    // when present, replace the reason/guidance slots. The LIVE-chain
+    // rendering coverage is useConversation.v5ErrorRecovery.spec.ts — this
+    // test pins the adapter→router layer inputs only.)
     // A refactor that drops any layer or substitutes a generic string would fail this test.
     const boundaryErr: BoundaryError = {
       error: 'INGRESS_CONTRACT_VIOLATION',

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -5,6 +5,8 @@ import {
   checkRetryableAgreement,
   extractReason,
   resolveGuidance,
+  resolveRetryable,
+  resolveFailureBaseCopy,
 } from '../failureTypeRetryability'
 
 describe('isRetryable — exhaustive over FailureTypeLiteral', () => {
@@ -109,5 +111,58 @@ describe('resolveGuidance — shared guidance resolver', () => {
     const g = resolveGuidance(code)
     expect(g.length).toBeGreaterThan(0)
     expect(g).toMatch(pattern)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Codex F6 — server-authoritative retryability + retry-consistent base copy
+// ---------------------------------------------------------------------------
+
+describe('resolveRetryable — server marker authoritative, table covers absence', () => {
+  it('server false beats a client-retryable code', () => {
+    expect(resolveRetryable('INTERNAL_ERROR', false)).toBe(false)
+    expect(resolveRetryable('UPSTREAM_TIMEOUT', false)).toBe(false)
+  })
+
+  it('server true beats a client-non-retryable code', () => {
+    expect(resolveRetryable('INGRESS_CONTRACT_VIOLATION', true)).toBe(true)
+    expect(resolveRetryable('TURN_BUDGET_EXCEEDED', true)).toBe(true)
+  })
+
+  it('absence falls back to the client table', () => {
+    expect(resolveRetryable('INTERNAL_ERROR', undefined)).toBe(true)
+    expect(resolveRetryable('FEATURE_NOT_ENABLED', undefined)).toBe(false)
+  })
+})
+
+describe('resolveFailureBaseCopy — copy agrees with the retry decision', () => {
+  it('returns the canonical text verbatim when retry is offered', () => {
+    expect(resolveFailureBaseCopy('INTERNAL_ERROR', true)).toBe(
+      'Something went wrong on our side. Please retry.',
+    )
+  })
+
+  it('drops the retry-instruction sentence when the affordance is withheld', () => {
+    expect(resolveFailureBaseCopy('INTERNAL_ERROR', false)).toBe(
+      'Something went wrong on our side.',
+    )
+    expect(resolveFailureBaseCopy('INGRESS_CONTRACT_VIOLATION', false)).toBe(
+      'We could not process that request.',
+    )
+    expect(resolveFailureBaseCopy('LLM_UNAVAILABLE', false)).toBe(
+      'The model is temporarily unavailable.',
+    )
+    expect(resolveFailureBaseCopy('TURN_BUDGET_EXCEEDED', false)).toBe(
+      'That took longer than we allow for a single turn.',
+    )
+  })
+
+  it('copy without a retry instruction passes through unchanged (fail open)', () => {
+    expect(resolveFailureBaseCopy('FEATURE_NOT_ENABLED', false)).toBe(
+      'This feature is not enabled in your environment.',
+    )
+    expect(resolveFailureBaseCopy('UPSTREAM_UNAVAILABLE', false)).toBe(
+      'An upstream service is temporarily unavailable.',
+    )
   })
 })

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -1,11 +1,16 @@
 /**
  * Failure-type retryability classifier.
  *
- * BoundaryError in @talchain/schemas@0.7.0 carries a top-level `retryable:
- * boolean`, but the UI also classifies client-side to stay stable when the
- * server field is absent (e.g. when the router surfaces a synthetic
- * typed_error from a block-level error_code, or a parse_error). The
- * client-side table is the canonical UI-side source.
+ * ⚠ AUTHORITY ORDER (Codex F6 fix): the SERVER's `retryable` marker on the
+ * error envelope is authoritative — `BoundaryError.retryable` is a typed,
+ * REQUIRED boolean on every non-2xx `/orchestrate/v2/turn` body, and CEE
+ * computes it per-failure (e.g. `mapDraftGraphPipelineReason`:
+ * CEE_LLM_VALIDATION_FAILED → false, CEE_TIMEOUT → true — both surface as
+ * `INTERNAL_ERROR` at the envelope level). The client-side table below is
+ * the FALLBACK for the marker's ABSENCE only (synthetic typed_errors from a
+ * 200-response error block, or parse_errors where no envelope exists). It
+ * must never override what the server said — a client-forced retry on a
+ * server-non-retryable failure is a retry that cannot work.
  *
  * Retryable codes — transient, worth offering a retry action:
  *   UPSTREAM_TIMEOUT       — CEE → PLoT/LLM call timed out
@@ -19,10 +24,10 @@
  *   FEATURE_NOT_ENABLED        — flag gated
  *   TURN_BUDGET_EXCEEDED       — session limit hit; new decision required
  *
- * Keep this table in lockstep with CEE's retryable determination at
- * olumi-assistants-service/src/orchestrator/route-v2.ts. If they diverge,
- * checkRetryableAgreement surfaces a DEV warning so ops can reconcile.
+ * checkRetryableAgreement still surfaces a DEV warning when the table and
+ * the server disagree, so drift stays visible in staging telemetry.
  */
+import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
 import type { FailureTypeLiteral, BoundaryError } from '@talchain/schemas/boundary'
 
 const RETRYABLE: ReadonlySet<FailureTypeLiteral> = new Set<FailureTypeLiteral>([
@@ -34,6 +39,54 @@ const RETRYABLE: ReadonlySet<FailureTypeLiteral> = new Set<FailureTypeLiteral>([
 
 export function isRetryable(code: FailureTypeLiteral): boolean {
   return RETRYABLE.has(code)
+}
+
+/**
+ * Resolve the effective retry decision for a typed error: the server's
+ * envelope marker when it exists, the client table otherwise. See the
+ * authority-order note at the top of this file. Absence resolves through
+ * the table, never to a hard-coded default, so an unknown-marker envelope
+ * still degrades to today's behaviour.
+ */
+export function resolveRetryable(
+  code: FailureTypeLiteral,
+  serverRetryable: boolean | undefined,
+): boolean {
+  return typeof serverRetryable === 'boolean' ? serverRetryable : isRetryable(code)
+}
+
+/**
+ * Sentences in FAILURE_USER_TEXT that instruct the user to retry. When the
+ * retry affordance is withheld (server said non-retryable), copy telling the
+ * user to "please retry" beside a missing Try-again chip instructs an action
+ * the UI gives them no way to take — the same honesty rule
+ * ceeRecovery.buildFailureRender enforces on the V4 path. Exact-suffix
+ * matches only; unmatched copy passes through unchanged (fail open).
+ */
+const RETRY_INSTRUCTION_SUFFIXES = [
+  ' Please retry.',
+  ' Please try again.',
+  ' Please retry shortly.',
+] as const
+
+/**
+ * Base failure copy that AGREES with the retry decision. With the retry
+ * affordance shown, this is exactly FAILURE_USER_TEXT[code]. With it
+ * withheld, any trailing retry-instruction sentence is dropped so the copy
+ * never tells the user to do something the UI won't offer.
+ */
+export function resolveFailureBaseCopy(
+  code: FailureTypeLiteral,
+  showRetry: boolean,
+): string {
+  const canonical = FAILURE_USER_TEXT[code]
+  if (showRetry) return canonical
+  for (const suffix of RETRY_INSTRUCTION_SUFFIXES) {
+    if (canonical.endsWith(suffix)) {
+      return canonical.slice(0, canonical.length - suffix.length)
+    }
+  }
+  return canonical
 }
 
 /**

--- a/src/v5/responseRouter.ts
+++ b/src/v5/responseRouter.ts
@@ -43,6 +43,16 @@ export type RenderTarget =
       code: FailureTypeLiteral;
       requestId?: string;
       boundaryError?: BoundaryError;
+      /**
+       * Raw non-2xx JSON body when the parse failed to be a BoundaryError.
+       * 0.19.0 types the CEE error envelope (`CeeTypedErrorSchema`, root
+       * export) with `retryable` + flat `recovery_suggestion` + nested
+       * `recovery` — an envelope of THAT shape is not a BoundaryError, so
+       * without this passthrough its typed recovery data would be dropped
+       * here and the user shown a generic INTERNAL_ERROR. Consumers read it
+       * defensively via ceeRecovery.extractCeeRecovery (fail closed).
+       */
+      rawBody?: unknown;
     };
 
 export function routeV5Response(result: V5CallResult): RenderTarget {
@@ -55,7 +65,11 @@ export function routeV5Response(result: V5CallResult): RenderTarget {
     };
   }
   if (result.kind === 'parse_error') {
-    return { kind: 'typed_error', code: 'INTERNAL_ERROR' };
+    return {
+      kind: 'typed_error',
+      code: 'INTERNAL_ERROR',
+      ...(result.raw !== undefined ? { rawBody: result.raw } : {}),
+    };
   }
 
   // Happy path: an OlumiResponse.


### PR DESCRIPTION
**P2 / Codex F6.** PR #383's error-recovery rendering was wired only to the dead V4 `handleEnvelope` path; the live V5 branch `return`s before it. This wires recovery to the live path and makes the server's retryability marker authoritative. **DRAFT — do not merge.**

## The live-chain trace (where V5 errors actually flow)

Verified at the bytes on CEE staging `cbb619a3` and UI staging `8007d03d`:

**Producer:** `buildCeeErrorResponse` (CEE `src/cee/validation/pipeline.ts`) emits nested `recovery: {hints, suggestion, example?}` **and** the flat `recovery_suggestion` mirror (wave-2 ask 7) → `handleDraftGraph` (`src/orchestrator/tools/draft-graph.ts:243`) attaches `body.recovery` to the throw → `route-v2.ts` `dispatchDraftGraph` catch puts it at **`BoundaryError.details.recovery`** → `reply.code(500).send(wireBoundary)` (every non-2xx send in the `/orchestrate/v2/turn` route is a strict BoundaryError) → browser proxy passes status+body through verbatim.

**Consumer (UI):** `callV5Turn` → `parseV5Response` (`BoundaryErrorSchema.safeParse` on non-2xx) → `routeV5Response` → `useConversation`'s **V5 `typed_error` branch** (the `return` at the end of the V5 block makes the V4 catch — where #383 lived — unreachable when the flag is on, which staging bakes to `true`).

## Wire shapes found, and which are consumed

`@talchain/schemas` 0.19.0 (`CeeTypedErrorSchema` + `CeeErrorRecoverySchema` are **root exports**, not `/boundary` — placement by design) types **both** shapes:

| Shape | Where it rides | Consumed via |
|---|---|---|
| Nested `recovery: {hints: string[], suggestion: string, example?}` | `BoundaryError.details.recovery` — **the live `/orchestrate/v2/turn` shape** | `extractCeeRecovery` container walk (new nested reader) |
| Flat `recovery_suggestion: string` (pinned mirror of `recovery.suggestion`) | `CEEErrorResponseV1`-shaped envelopes (`buildCeeErrorResponse` direct surfaces) — not BoundaryErrors, so previously dropped as `parse_error` | new `typed_error.rawBody` passthrough on the router → same reader |

`example` is typed but not rendered (no display slot asked for it). `BoundaryErrorSchema` is `.strict()` with no top-level recovery fields — only its passthrough `details` carries recovery, which is exactly where CEE puts it.

## Before / after (what the user sees on a CEE failure)

**Before** (e.g. draft failed validation, server says non-retryable):
> Something went wrong on our side. Please retry.
>
> draft_graph_cee_llm_validation_failed
>
> *(+ a Try again chip that cannot work — client table marks every INTERNAL_ERROR retryable)*

**After:**
> Something went wrong on our side.
>
> Add more detail about your options, then draft again.
>
> • Name the decision you are weighing
> • List at least two options you are choosing between
>
> *(no retry chip — the server said the retry cannot work; the copy no longer instructs one either)*

Rules: server `retryable` wins whenever the envelope carries it; the client table resolves only its **absence** (200-response error blocks, parse errors) — never silently dropped. Machine reason codes (`draft_graph_cee_*`) are prose-gated and never render; genuine prose reasons still do. Errors render as ordinary assistant messages through ChatThread's existing `role="log"` live region — no second live region.

## The test that matters

`src/canvas/conversation/__tests__/useConversation.v5ErrorRecovery.spec.ts` drives **actual non-2xx bodies through the REAL adapter → REAL parser (real `BoundaryErrorSchema`) → REAL router → the hook's live V5 branch**; only eligibility, auth, telemetry, and the network fetch are stubbed. (#383 passed with a renderer unit test fed a hand-built object — this spec class cannot.)

## Mutation results (throwaway worktree, per repo discipline)

- **Revert the V5 wiring** (spec on pre-fix `origin/staging` `8007d03d`): **5/6 RED** — first failure shows `+ draft_graph_cee_llm_validation_failed` rendered to the user. (The 1 green is the prose-reason non-regression case, green by design on both.)
- **Restore client-side-always-retryable** (fixed code, `resolveV5Retryable(code, undefined)`): **3/6 RED** — every server-says-non-retryable case.

## Gates

- `pnpm run typecheck` (tsconfig.ci) — clean
- `pnpm run lint` on touched files — **0 errors** (9 pre-existing warnings on untouched lines)
- `npx vitest run --changed origin/staging` — **1201 passed**, 0 failed (83 files)
- `npx vitest run tests/ci-guards` — **50 passed**
- Wide `tsc -p tsconfig.app.json --noEmit`, `grep -c "error TS"`: **2323 vs 2323** against a matched base clone (same SHA, its own real node_modules); position-normalised error multiset **identical** — zero new, set-wise

🤖 Generated with [Claude Code](https://claude.com/claude-code)