### PR TITLE
fix(intake): sparks and node chips ship explicit action_type intent metadata

### DIFF
--- a/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
+++ b/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
@@ -102,7 +102,7 @@ function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason }: PreAnalysi
           }))
           break
         case 'send_prompt':
-          sendPrompt(action.label, action.prompt)
+          sendPrompt(action.spark)
           break
         case 'run_analysis':
           runOrExplain()

--- a/src/canvas/components/pre-analysis-v3/__tests__/sparkIntentContract.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/__tests__/sparkIntentContract.spec.ts
@@ -219,6 +219,28 @@ describe('spark click → outgoing wire payload (real send funnel)', () => {
       ).toBe(false)
     }
   })
+
+  it('publication gate: analysis_readiness is DECLARED pending and currently WITHHELD (the gate is holding something back, not vacuously empty)', () => {
+    // Signed off 2026-07-20 for schemas 0.20.0: "assess/coach readiness
+    // for analysis". This test flips RED on the 0.20.0 re-vendor (the
+    // value joins the enum) — at that point remove it from
+    // PENDING_WIRE_ACTION_TYPES; the mapped sparks then SEND it with no
+    // further change (the per-spark wire tests' published arm takes over).
+    expect(PENDING_SET.has('analysis_readiness')).toBe(true)
+    expect(SCHEMA_ACTION_TYPES.has('analysis_readiness')).toBe(false)
+  })
+
+  it('publication gate: at least one registry spark maps to a pending value (the withhold arm is exercised by REAL registry data)', () => {
+    // Without this, the withhold arm would be proven only by the synthetic
+    // control above — a registry regression to all-null would silently
+    // stop exercising it. prepare_first_analysis (the defect spark) and
+    // calibrate_estimates carry analysis_readiness today.
+    const pendingMapped = ALL_SPARKS.filter(
+      (s) => s.action_type !== null && PENDING_SET.has(s.action_type),
+    )
+    expect(pendingMapped.length).toBeGreaterThanOrEqual(1)
+    expect(pendingMapped.map((s) => s.id)).toContain('prepare_first_analysis')
+  })
 })
 
 describe('free-typed text is NEVER stamped with product intent', () => {

--- a/src/canvas/components/pre-analysis-v3/__tests__/sparkIntentContract.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/__tests__/sparkIntentContract.spec.ts
@@ -1,0 +1,246 @@
+/**
+ * Spark intent contract (A1 meta-decision diagnosis, 2026-07-20).
+ *
+ * The defect: product-authored spark prompts travelled to CEE as anonymous
+ * text (`source='chip'`, no metadata), bypassing CEE's deterministic chip
+ * branch; the draft-shape regex then misread "What should I check before
+ * running the first analysis?" as a decision BRIEF on an empty canvas and
+ * the drafter faithfully modelled a meta-decision. EVERY spark in the
+ * registry would misroute the same way.
+ *
+ * The contract pinned here:
+ *  1. Every registry spark ships EXPLICIT intent metadata — an `action_type`
+ *     decision (a schema-enum value, a declared pending value, or a
+ *     deliberate null) plus a stable id. The vocabulary is DERIVED from
+ *     @talchain/schemas ActionType.options, never a hand-kept list (trap
+ *     12: hand-maintained mirrors drift green).
+ *  2. The spark click path carries that metadata to the outgoing wire
+ *     payload (chip.parameters.spark_id always; chip.action_type when the
+ *     registry declares one) — asserted at the built-payload JSON, through
+ *     the REAL production seams (useConversationActions → ActionChip →
+ *     buildChipMeta → buildV5Payload).
+ *  3. THE PUBLICATION GATE: CEE ingress validates action_type FAIL-CLOSED
+ *     against ITS vendored enum, so an unpublished value would 422 the
+ *     whole turn. A mapped value present in OUR vendored enum is sent (and
+ *     promotes source to chip_click); a mapped-but-unpublished value
+ *     (PENDING_WIRE_ACTION_TYPES) is withheld ENTIRELY — no action_type
+ *     key, no chip_click promotion, identity parameters still travel — so
+ *     the turn is no worse than today until a schema re-vendor lights the
+ *     value up with zero code change.
+ *  4. Free-typed user text is NEVER stamped with product intent — the
+ *     composer payload carries no chip object at all (the same honesty
+ *     requirement in reverse).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { ActionType } from '@talchain/schemas/boundary'
+
+import { ACTIONS_MENU, SPARK_PROMPTS } from '../constants'
+import type { SparkPrompt } from '../types'
+import { buildChipMeta, PENDING_WIRE_ACTION_TYPES } from '../../../conversation/chipMeta'
+import { buildV5Payload } from '../../../../v5/buildPayload'
+import type { ActionChip } from '../../../conversation/types'
+
+// ---------------------------------------------------------------------------
+// Hook collaborators — replaced wholesale so the spec exercises the hook's
+// real logic without mounting the conversation stack.
+// ---------------------------------------------------------------------------
+const { sendChipSpy } = vi.hoisted(() => ({
+  sendChipSpy: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('../../../conversation/ConversationContext', () => ({
+  useOptionalConversationContext: () => ({ sendChip: sendChipSpy }),
+}))
+vi.mock('../../../ToastContext', () => ({
+  useShowToast: () => vi.fn(),
+}))
+vi.mock('../../../conversation/revealOlumi', () => ({
+  revealOlumiSurface: vi.fn(),
+}))
+
+import { useConversationActions } from '../hooks/useConversationActions'
+
+/** The complete spark registry — DERIVED by iterating both collections. */
+const ALL_SPARKS: ReadonlyArray<SparkPrompt> = [
+  ...ACTIONS_MENU,
+  ...Object.values(SPARK_PROMPTS),
+]
+
+const SCHEMA_ACTION_TYPES: ReadonlySet<string> = new Set(ActionType.options)
+const PENDING_SET: ReadonlySet<string> = new Set<string>(PENDING_WIRE_ACTION_TYPES)
+
+/** Gate verdict for a mapped value: published values send; pending withhold. */
+function isPublished(actionType: string): boolean {
+  return SCHEMA_ACTION_TYPES.has(actionType)
+}
+
+beforeEach(() => {
+  sendChipSpy.mockClear()
+})
+
+describe('spark registry — every spark ships explicit intent metadata', () => {
+  it('registry is non-empty (positive control for the iteration)', () => {
+    expect(ALL_SPARKS.length).toBeGreaterThanOrEqual(15)
+  })
+
+  it.each(ALL_SPARKS.map(s => [s.id, s] as const))(
+    'spark %s declares action_type explicitly (enum value or deliberate null) and a stable id',
+    (_id, spark) => {
+      // Own-property check: a spark added WITHOUT the field fails here even
+      // if the type system were bypassed (spread, any-cast, JSON import).
+      expect(
+        Object.prototype.hasOwnProperty.call(spark, 'action_type'),
+        `spark "${spark.label}" ships no action_type decision — every product-authored prompt must declare its intent (null is a valid, deliberate declaration)`,
+      ).toBe(true)
+      expect(spark.action_type, 'action_type must be null or an enum member, never undefined').not.toBeUndefined()
+      if (spark.action_type !== null) {
+        expect(
+          SCHEMA_ACTION_TYPES.has(spark.action_type) || PENDING_SET.has(spark.action_type),
+          `action_type "${spark.action_type}" is neither a published @talchain/schemas ActionType member nor a declared PENDING_WIRE_ACTION_TYPES entry — an undeclared value would 422 CEE ingress`,
+        ).toBe(true)
+      }
+      expect(spark.id).toBeTruthy()
+      expect(spark.prompt.trim().length).toBeGreaterThan(0)
+    },
+  )
+
+  it('ids are unique within each collection', () => {
+    const menuIds = ACTIONS_MENU.map(s => s.id)
+    expect(new Set(menuIds).size).toBe(menuIds.length)
+    const sparkIds = Object.values(SPARK_PROMPTS).map(s => s.id)
+    expect(new Set(sparkIds).size).toBe(sparkIds.length)
+  })
+})
+
+describe('spark click → outgoing wire payload (real send funnel)', () => {
+  it.each(ALL_SPARKS.map(s => [s.id, s] as const))(
+    'spark %s ships spark_id (and any action_type) on the built payload',
+    (_id, spark) => {
+      const { result } = renderHook(() => useConversationActions())
+      const accepted = result.current.sendPrompt(spark)
+      expect(accepted).toBe(true)
+      expect(sendChipSpy).toHaveBeenCalledTimes(1)
+
+      const chip = (sendChipSpy.mock.calls[0] as unknown[])[0] as ActionChip
+      expect(chip.message).toBe(spark.prompt)
+      expect(chip.parameters).toEqual({ spark_id: spark.id })
+      if (spark.action_type === null) {
+        // A null decision must not leak as a key CEE could misread.
+        expect('action_type' in chip).toBe(false)
+      } else {
+        expect(chip.action_type).toBe(spark.action_type)
+      }
+
+      // sendChip → dispatchAction is a 1:1 field passthrough
+      // (useConversation.sendChip: action_type/parameters from the chip);
+      // from there the REAL production modules build the wire payload.
+      const chipMeta = buildChipMeta({
+        action_type: chip.action_type,
+        parameters: chip.parameters,
+      })
+      const built = buildV5Payload({
+        turnId: '00000000-0000-4000-8000-000000000001',
+        scenarioId: '00000000-0000-4000-8000-000000000002',
+        stage: 'frame',
+        turnClass: 'frame',
+        mode: 'user',
+        message: chip.message ?? '',
+        source: 'chip',
+        chipMeta,
+      })
+      if (!built.ok) throw new Error('payload build failed: ' + JSON.stringify(built))
+      const payload = built.payload as {
+        source: string
+        message: string
+        chip?: { action_type?: string; parameters?: Record<string, unknown> }
+      }
+
+      // The wire carries the product intent explicitly — through the
+      // publication gate: published values send (and promote the source to
+      // CEE's deterministic chip branch); pending values are withheld
+      // entirely; null-intent sparks ship identity only.
+      expect(payload.message).toBe(spark.prompt)
+      expect(payload.chip).toBeDefined()
+      expect(payload.chip?.parameters).toEqual({ spark_id: spark.id })
+      if (spark.action_type !== null && isPublished(spark.action_type)) {
+        expect(payload.source).toBe('chip_click')
+        expect(payload.chip?.action_type).toBe(spark.action_type)
+      } else {
+        expect(payload.source).toBe('chip')
+        expect(payload.chip && 'action_type' in payload.chip).toBe(false)
+      }
+    },
+  )
+
+  it('publication gate: a mapped-but-unpublished value is withheld entirely (positive control for the withhold arm)', () => {
+    // The pending set is empty today, so no registry spark exercises the
+    // withhold arm — this synthetic value proves the gate BITES: without it
+    // every "pending values are withheld" claim above would be vacuously
+    // green (trap 13: an absence assertion needs a positive control).
+    const syntheticPending = 'coach_readiness_value_pending_0_20_0'
+    expect(SCHEMA_ACTION_TYPES.has(syntheticPending)).toBe(false)
+
+    const chipMeta = buildChipMeta({
+      action_type: syntheticPending,
+      parameters: { spark_id: 'prepare_first_analysis' },
+    })
+    const built = buildV5Payload({
+      turnId: '00000000-0000-4000-8000-000000000005',
+      scenarioId: '00000000-0000-4000-8000-000000000006',
+      stage: 'frame',
+      turnClass: 'frame',
+      mode: 'user',
+      message: 'What should I check before running the first analysis?',
+      source: 'chip',
+      chipMeta,
+    })
+    if (!built.ok) throw new Error('payload build failed')
+    const payload = built.payload as {
+      source: string
+      chip?: { action_type?: string; parameters?: Record<string, unknown> }
+    }
+
+    // Withheld ENTIRELY: no action_type key, no chip_click promotion —
+    // exactly today's identity-only chip, never a 422 risk.
+    expect(payload.source).toBe('chip')
+    expect(payload.chip).toBeDefined()
+    expect(payload.chip && 'action_type' in payload.chip).toBe(false)
+    expect(payload.chip?.parameters).toEqual({ spark_id: 'prepare_first_analysis' })
+  })
+
+  it('publication gate: every declared pending value is genuinely unpublished (list hygiene)', () => {
+    // A pending entry that already exists in the vendored enum is a stale
+    // declaration — the re-vendor landed; remove it from the list.
+    for (const pending of PENDING_SET) {
+      expect(
+        SCHEMA_ACTION_TYPES.has(pending),
+        `PENDING_WIRE_ACTION_TYPES entry "${pending}" is now published in the vendored enum — remove it from the pending list`,
+      ).toBe(false)
+    }
+  })
+})
+
+describe('free-typed text is NEVER stamped with product intent', () => {
+  it('a composer message builds with no chip object at all', () => {
+    // The defect text itself, typed by a user: it must reach CEE as the
+    // user's own words with no product-intent metadata attached.
+    const built = buildV5Payload({
+      turnId: '00000000-0000-4000-8000-000000000003',
+      scenarioId: '00000000-0000-4000-8000-000000000004',
+      stage: 'frame',
+      turnClass: 'frame',
+      mode: 'user',
+      message: 'Run the analysis now',
+      source: 'composer',
+    })
+    if (!built.ok) throw new Error('payload build failed')
+    const payload = built.payload as Record<string, unknown>
+    expect(payload.source).toBe('composer')
+    expect('chip' in payload).toBe(false)
+  })
+
+  it('buildChipMeta yields nothing when neither intent field is present', () => {
+    expect(buildChipMeta({})).toBeUndefined()
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -8,7 +8,9 @@
  * signals/__tests__/registry.spec.ts.
  */
 
-import type { BarKey, BarState } from './types'
+import type { BarKey, BarState, SparkPrompt } from './types'
+
+export type { SparkPrompt } from './types'
 
 /**
  * Bar labels — single constants object by design. The alternative set
@@ -248,87 +250,144 @@ export const HERO_COPY = {
 } as const
 
 /**
- * Actions overflow menu — named methods, every item resolves to a prefilled
- * conversation prompt (sent immediately via the existing chip convention).
- * No contract intents are attached: routing happens from the message text,
- * so none of the dead-end intents can be emitted.
+ * Actions overflow menu — named methods, every item a SparkPrompt with
+ * EXPLICIT wire intent.
+ *
+ * History: this registry previously attached NO intent ("routing happens
+ * from the message text") — a deliberate choice to avoid emitting dead-end
+ * intents. That choice was reversed on A1's meta-decision diagnosis
+ * (2026-07-20): CEE re-infers anonymous text with a draft-shape regex, and
+ * on an empty canvas EVERY spark here matched it — the "Prepare first
+ * analysis" spark was captured as a decision BRIEF and the drafter modelled
+ * the meta-decision ("should we run the analysis?") instead of coaching.
+ * The product knows the intent at authoring time; discarding it and
+ * re-inferring by regex IS the defect mechanism.
+ *
+ * `action_type` is the wire intent, constrained to the @talchain/schemas
+ * 0.19.0 ActionType enum (a strict enum at CEE ingress — out-of-enum values
+ * 422). `null` means: this spark is a coaching/readiness intent and the
+ * current vocabulary has NO honest entry for it — we do NOT force a wrong
+ * one. Every spark still ships its identity as `chip.parameters.spark_id`,
+ * the deterministic hook CEE's routing half keys on. When the schema gains
+ * a coaching/readiness action_type, flip the nulls — the contract test in
+ * __tests__/sparkIntentContract.spec.ts validates values against the enum
+ * itself (derived, never a hand-kept list).
  */
-export interface ActionsMenuItem {
-  id: string
-  label: string
-  prompt: string
-}
+export type ActionsMenuItem = SparkPrompt
 
 export const ACTIONS_MENU: ReadonlyArray<ActionsMenuItem> = [
   {
     id: 'pressure_test_frame',
     label: 'Pressure-test the frame',
     prompt: 'Is this the right question to be asking, and does it fit my wider goals?',
+    // Frame-challenge coaching. explain_from_structure EXPLAINS the model;
+    // this spark challenges it — no honest vocabulary entry.
+    action_type: null,
   },
   {
     id: 'widen_options',
     label: 'Widen the options',
     prompt: 'Suggest materially different options that work through a different mechanism from the ones I already have.',
+    // Option-elicitation coaching; the boundary enum has no add_option.
+    action_type: null,
   },
   {
     id: 'outside_view',
     label: 'Take the outside view',
     prompt: 'Take the outside view on this decision: what do similar decisions and base rates suggest?',
+    // Base-rate coaching — no vocabulary entry.
+    action_type: null,
   },
   {
     id: 'pre_mortem',
     label: 'Run a pre-mortem',
     prompt: 'Run a pre-mortem with me: imagine this choice failed a year from now. What went wrong?',
+    // Failure-imagination coaching — no vocabulary entry.
+    action_type: null,
   },
   {
     id: 'risks_upside',
     label: 'Find risks and upside',
     prompt: 'What risks and best-case upsides are missing from my model?',
+    // Gap-elicitation coaching (what is MISSING) — explain_* describes what
+    // is present; no honest entry.
+    action_type: null,
   },
   {
     id: 'calibrate_estimates',
     label: 'Check estimates',
     prompt: 'Help me check the estimates that matter most to the analysis.',
+    // Pre-analysis calibration coaching. what_would_flip is post-analysis
+    // sensitivity and its deterministic chip handler demands prior analysis
+    // facts — stamping it would turn this spark into "run analysis first".
+    action_type: null,
   },
   {
     id: 'compare_view',
     label: 'Compare my view with Olumi',
     prompt: 'Compare my view of this decision with yours. Where do we differ, and why?',
+    // compare_options compares DECISION OPTIONS, not the user's view vs the
+    // model's — stamping it would misdeclare the intent.
+    action_type: null,
   },
   {
     id: 'prepare_first_analysis',
     label: 'Prepare first analysis',
     prompt: 'What should I check before running the first analysis?',
+    // Readiness coaching (the spark in A1's defect reproduction).
+    // run_analysis would RUN the analysis the user is asking how to prepare
+    // for — the exact wrongness class this metadata exists to kill.
+    action_type: null,
   },
 ]
 
+// Every entry is a coaching intent: action_type stays null until the schema
+// vocabulary gains a coaching/readiness entry (see SparkPrompt doc). Ids
+// shared with ACTIONS_MENU where the prompt is identical — same product
+// intent, same wire identity.
 export const SPARK_PROMPTS = {
   widenOptions: {
+    id: 'widen_options',
     label: 'Widen the options',
     prompt: 'Suggest materially different options that work through a different mechanism from the ones I already have.',
+    action_type: null,
   },
   preMortem: {
+    id: 'pre_mortem',
     label: 'Run a pre-mortem',
     prompt: 'Run a pre-mortem with me: imagine this choice failed a year from now. What went wrong?',
+    action_type: null,
   },
   calibrate: {
+    id: 'calibrate_estimates',
     label: 'Check estimates',
     prompt: 'Help me check the estimates that matter most to the analysis.',
+    action_type: null,
   },
   pressureTestFrame: {
+    id: 'pressure_test_frame',
     label: 'Pressure-test the frame',
     prompt: 'Is this the right question to be asking, and does it fit my wider goals?',
+    action_type: null,
   },
   defineSuccess: {
+    id: 'define_success',
     label: 'Define success with Olumi',
     prompt: 'Help me define a measurable success target for this goal.',
+    // Goal-target coaching; set_factor_value is a validated mutation, not
+    // a conversation — no honest entry.
+    action_type: null,
   },
   findRisks: {
+    id: 'risks_upside',
     label: 'Find risks and upside',
     prompt: 'What risks and best-case upsides are missing from my model?',
+    action_type: null,
   },
   reflectBias: {
+    id: 'reflect_bias',
     label: 'Talk it through with Olumi',
     prompt: 'You flagged a possible blind spot in how my model leans. Help me think it through.',
+    action_type: null,
   },
-} as const
+} as const satisfies Record<string, SparkPrompt>

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -263,15 +263,21 @@ export const HERO_COPY = {
  * The product knows the intent at authoring time; discarding it and
  * re-inferring by regex IS the defect mechanism.
  *
- * `action_type` is the wire intent, constrained to the @talchain/schemas
- * 0.19.0 ActionType enum (a strict enum at CEE ingress — out-of-enum values
- * 422). `null` means: this spark is a coaching/readiness intent and the
- * current vocabulary has NO honest entry for it — we do NOT force a wrong
- * one. Every spark still ships its identity as `chip.parameters.spark_id`,
- * the deterministic hook CEE's routing half keys on. When the schema gains
- * a coaching/readiness action_type, flip the nulls — the contract test in
+ * `action_type` is the wire intent: a @talchain/schemas ActionType enum
+ * value (strict at CEE ingress — out-of-enum values 422), a declared
+ * pending value (PENDING_WIRE_ACTION_TYPES in conversation/chipMeta.ts —
+ * mapped now, WITHHELD from the wire by buildV5Payload's schema-derived
+ * gate until the re-vendor publishes it), or `null` when no honest entry
+ * exists — we do NOT force a wrong one. Every spark still ships its
+ * identity as `chip.parameters.spark_id`, the deterministic hook CEE's
+ * routing half keys on. The contract test in
  * __tests__/sparkIntentContract.spec.ts validates values against the enum
  * itself (derived, never a hand-kept list).
+ *
+ * `analysis_readiness` (signed off for 0.20.0) means "assess/coach
+ * readiness for analysis". Mapped ONLY where that is the spark's honest
+ * intent — elicitation/reflection sparks whose readiness link is incidental
+ * stay null rather than being recast as analysis-gate conversations.
  */
 export type ActionsMenuItem = SparkPrompt
 
@@ -317,10 +323,12 @@ export const ACTIONS_MENU: ReadonlyArray<ActionsMenuItem> = [
     id: 'calibrate_estimates',
     label: 'Check estimates',
     prompt: 'Help me check the estimates that matter most to the analysis.',
-    // Pre-analysis calibration coaching. what_would_flip is post-analysis
-    // sensitivity and its deterministic chip handler demands prior analysis
-    // facts — stamping it would turn this spark into "run analysis first".
-    action_type: null,
+    // Analysis-preparation coaching: "the estimates that matter most to
+    // the ANALYSIS" is readiness-directed — the readiness capability's
+    // estimate-gap signals are the honest answer. NOT what_would_flip
+    // (post-analysis sensitivity; its deterministic handler demands prior
+    // analysis facts). Pending: withheld until the 0.20.0 re-vendor.
+    action_type: 'analysis_readiness',
   },
   {
     id: 'compare_view',
@@ -334,17 +342,19 @@ export const ACTIONS_MENU: ReadonlyArray<ActionsMenuItem> = [
     id: 'prepare_first_analysis',
     label: 'Prepare first analysis',
     prompt: 'What should I check before running the first analysis?',
-    // Readiness coaching (the spark in A1's defect reproduction).
-    // run_analysis would RUN the analysis the user is asking how to prepare
-    // for — the exact wrongness class this metadata exists to kill.
-    action_type: null,
+    // THE readiness spark (A1's defect reproduction) — the verbatim intent
+    // analysis_readiness was coined for. NOT run_analysis, which would RUN
+    // the analysis the user is asking how to prepare for — the exact
+    // wrongness class this metadata exists to kill. Pending: withheld
+    // until the 0.20.0 re-vendor.
+    action_type: 'analysis_readiness',
   },
 ]
 
-// Every entry is a coaching intent: action_type stays null until the schema
-// vocabulary gains a coaching/readiness entry (see SparkPrompt doc). Ids
-// shared with ACTIONS_MENU where the prompt is identical — same product
-// intent, same wire identity.
+// Ids shared with ACTIONS_MENU where the prompt is identical — same product
+// intent, same wire identity, same action_type adjudication (calibrate maps
+// to the pending analysis_readiness; the rest are elicitation/reflection
+// intents with no honest entry — see the ACTIONS_MENU doc).
 export const SPARK_PROMPTS = {
   widenOptions: {
     id: 'widen_options',
@@ -362,7 +372,9 @@ export const SPARK_PROMPTS = {
     id: 'calibrate_estimates',
     label: 'Check estimates',
     prompt: 'Help me check the estimates that matter most to the analysis.',
-    action_type: null,
+    // Same id + adjudication as the ACTIONS_MENU entry: readiness-directed
+    // calibration coaching. Pending: withheld until the 0.20.0 re-vendor.
+    action_type: 'analysis_readiness',
   },
   pressureTestFrame: {
     id: 'pressure_test_frame',

--- a/src/canvas/components/pre-analysis-v3/header/ActionsMenu.tsx
+++ b/src/canvas/components/pre-analysis-v3/header/ActionsMenu.tsx
@@ -13,9 +13,10 @@ import { memo, useEffect, useId, useRef, useState } from 'react'
 import { ChevronDown, Sparkles } from 'lucide-react'
 import { typography } from '../../../../styles/typography'
 import { ACTIONS_MENU } from '../constants'
+import type { SparkPrompt } from '../types'
 
 interface ActionsMenuProps {
-  onAction: (label: string, prompt: string) => void
+  onAction: (spark: SparkPrompt) => void
 }
 
 export const ActionsMenu = memo(function ActionsMenu({ onAction }: ActionsMenuProps) {
@@ -113,7 +114,7 @@ export const ActionsMenu = memo(function ActionsMenu({ onAction }: ActionsMenuPr
               tabIndex={-1}
               onClick={() => {
                 close(true)
-                onAction(item.label, item.prompt)
+                onAction(item)
               }}
               className={`${typography.panelBody} flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-text-body outline-none transition-colors hover:bg-panel-hover focus:bg-panel-hover`}
             >

--- a/src/canvas/components/pre-analysis-v3/header/PanelHeader.tsx
+++ b/src/canvas/components/pre-analysis-v3/header/PanelHeader.tsx
@@ -10,10 +10,11 @@ import { memo } from 'react'
 import { ActionsMenu } from './ActionsMenu'
 import { HealthBars } from './HealthBars'
 import type { BarsModel } from '../selectors/computeBars'
+import type { SparkPrompt } from '../types'
 
 interface PanelHeaderProps {
   bars: BarsModel
-  onAction: (label: string, prompt: string) => void
+  onAction: (spark: SparkPrompt) => void
 }
 
 export const PanelHeader = memo(function PanelHeader({ bars, onAction }: PanelHeaderProps) {

--- a/src/canvas/components/pre-analysis-v3/hero/HeroSection.tsx
+++ b/src/canvas/components/pre-analysis-v3/hero/HeroSection.tsx
@@ -24,7 +24,7 @@ import { BestNextStep } from './BestNextStep'
 import { CoachingSlot } from './CoachingSlot'
 import { InlineField } from './InlineField'
 import type { PreAnalysisModel } from '../hooks/usePreAnalysisModel'
-import type { LadderStep } from '../types'
+import type { LadderStep, SparkPrompt } from '../types'
 
 export const GOAL_INPUT_ID = 'pre-analysis-v3-goal'
 export const SUCCESS_INPUT_ID = 'pre-analysis-v3-success'
@@ -32,7 +32,7 @@ export const SUCCESS_INPUT_ID = 'pre-analysis-v3-success'
 interface HeroSectionProps {
   hero: PreAnalysisModel['hero']
   ladder: LadderStep
-  onSendPrompt: (label: string, prompt: string) => void
+  onSendPrompt: (spark: SparkPrompt) => void
   onLadderAct: (step: LadderStep) => void
 }
 
@@ -158,9 +158,7 @@ export const HeroSection = memo(function HeroSection({
           <PanelIconButton
             variant="ai"
             aria-label="Pressure-test the frame with Olumi"
-            onClick={() =>
-              onSendPrompt(SPARK_PROMPTS.pressureTestFrame.label, SPARK_PROMPTS.pressureTestFrame.prompt)
-            }
+            onClick={() => onSendPrompt(SPARK_PROMPTS.pressureTestFrame)}
           >
             <Sparkles className="h-3.5 w-3.5" aria-hidden />
           </PanelIconButton>
@@ -181,12 +179,7 @@ export const HeroSection = memo(function HeroSection({
               <PanelIconButton
                 variant="ai"
                 aria-label="Pressure-test the goal with Olumi"
-                onClick={() =>
-                  onSendPrompt(
-                    SPARK_PROMPTS.pressureTestFrame.label,
-                    SPARK_PROMPTS.pressureTestFrame.prompt,
-                  )
-                }
+                onClick={() => onSendPrompt(SPARK_PROMPTS.pressureTestFrame)}
               >
                 <Sparkles className="h-3.5 w-3.5" aria-hidden />
               </PanelIconButton>
@@ -208,9 +201,7 @@ export const HeroSection = memo(function HeroSection({
                 <PanelIconButton
                   variant="ai"
                   aria-label="Define success with Olumi"
-                  onClick={() =>
-                    onSendPrompt(SPARK_PROMPTS.defineSuccess.label, SPARK_PROMPTS.defineSuccess.prompt)
-                  }
+                  onClick={() => onSendPrompt(SPARK_PROMPTS.defineSuccess)}
                 >
                   <Sparkles className="h-3.5 w-3.5" aria-hidden />
                 </PanelIconButton>

--- a/src/canvas/components/pre-analysis-v3/hooks/useConversationActions.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/useConversationActions.ts
@@ -9,6 +9,15 @@
  * OlumiTabBody's register effect does not re-run) — the root cause of the
  * "spark does nothing" bug found in local testing.
  *
+ * Intent metadata (A1 meta-decision diagnosis, 2026-07-20): every spark is
+ * product-authored, so its intent is KNOWN at authoring time and must ship
+ * on the wire — `chip.action_type` when the schema vocabulary has an honest
+ * value, and always `chip.parameters.spark_id` (the registry identity CEE's
+ * routing half keys on). Anonymous spark text let CEE's draft-shape regex
+ * misread "What should I check before running the first analysis?" as a
+ * decision brief and draft a meta-decision graph. Free-typed user text is
+ * NEVER stamped — only registry sparks travel through this hook.
+ *
  * After a successful send the Olumi surface is revealed (focus the floating
  * panel if open, else activate the docked Olumi tab) so the user sees the
  * message land. If no delivery path exists at all, a toast says so — never
@@ -21,10 +30,11 @@ import { useGuidanceStore } from '../../../stores/guidanceStore'
 import { useShowToast } from '../../../ToastContext'
 import { revealOlumiSurface } from '../../../conversation/revealOlumi'
 import { FIELD_FEEDBACK_COPY } from '../constants'
+import type { SparkPrompt } from '../types'
 
 export interface ConversationActions {
-  /** Send a prefilled prompt now. Returns false when no surface accepted it. */
-  sendPrompt: (label: string, prompt: string) => boolean
+  /** Send a registry spark now. Returns false when no surface accepted it. */
+  sendPrompt: (spark: SparkPrompt) => boolean
 }
 
 export function useConversationActions(): ConversationActions {
@@ -32,17 +42,40 @@ export function useConversationActions(): ConversationActions {
   const conversation = useOptionalConversationContext()
 
   const sendPrompt = useCallback(
-    (label: string, prompt: string): boolean => {
+    (spark: SparkPrompt): boolean => {
+      const { id, label, prompt, action_type } = spark
       // 1. Live conversation context — no registration race possible.
       if (conversation) {
         conversation
-          .sendChip({ id: `pre-analysis-v3-${Date.now()}`, label, message: prompt, intent: 'primary' })
+          .sendChip({
+            id: `pre-analysis-v3-${Date.now()}`,
+            label,
+            message: prompt,
+            intent: 'primary',
+            ...(action_type ? { action_type } : {}),
+            parameters: { spark_id: id },
+          })
           .catch(() => showToast(FIELD_FEEDBACK_COPY.olumiUnavailable, 'error'))
         revealOlumiSurface()
         return true
       }
-      // 2. Guidance-store bridge (host without the provider).
+      // 2. Guidance-store bridge (host without the provider). Prefer the
+      // unified dispatcher — the only bridge callback that carries chip
+      // metadata to the wire.
       const callbacks = useGuidanceStore.getState()
+      if (callbacks._dispatchAction) {
+        callbacks._dispatchAction({
+          ...(action_type ? { action_type } : {}),
+          parameters: { spark_id: id },
+          label,
+          message: prompt,
+          source: 'chip',
+        })
+        revealOlumiSurface()
+        return true
+      }
+      // Legacy bridges — intent metadata cannot travel these; the message
+      // still lands rather than dead-ending the click.
       if (callbacks._sendChip) {
         callbacks._sendChip(label, prompt)
         revealOlumiSurface()

--- a/src/canvas/components/pre-analysis-v3/model/YourDecisionSection.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/YourDecisionSection.tsx
@@ -28,10 +28,11 @@ import { EstimateRow } from './EstimateRow'
 import { SUCCESS_INPUT_ID } from '../hero/HeroSection'
 import type { NodeType } from '../../../domain/nodes'
 import type { PreAnalysisModel } from '../hooks/usePreAnalysisModel'
+import type { SparkPrompt } from '../types'
 
 interface YourDecisionSectionProps {
   model: PreAnalysisModel
-  onSendPrompt: (label: string, prompt: string) => void
+  onSendPrompt: (spark: SparkPrompt) => void
   /** Bumped by the ladder to open and reveal a specific estimate row. */
   estimateFocus: { nodeId: string; seq: number } | null
 }
@@ -119,9 +120,9 @@ const AddRow = memo(function AddRow({
   placeholder: string
   /** Distinct accessible name for the + button (the input owns the placeholder name). */
   addLabel: string
-  spark: { label: string; prompt: string }
+  spark: SparkPrompt
   onAdd: (label: string) => boolean
-  onSendPrompt: (label: string, prompt: string) => void
+  onSendPrompt: (spark: SparkPrompt) => void
   testId: string
 }) {
   const [draft, setDraft] = useState('')
@@ -162,7 +163,7 @@ const AddRow = memo(function AddRow({
         <PanelIconButton
           variant="ai"
           aria-label={spark.label}
-          onClick={() => onSendPrompt(spark.label, spark.prompt)}
+          onClick={() => onSendPrompt(spark)}
         >
           <Sparkles className="h-3.5 w-3.5" aria-hidden />
         </PanelIconButton>

--- a/src/canvas/components/pre-analysis-v3/sharpen/SharpenSection.tsx
+++ b/src/canvas/components/pre-analysis-v3/sharpen/SharpenSection.tsx
@@ -10,11 +10,11 @@ import { memo, useState } from 'react'
 import { typography, typo } from '../../../../styles/typography'
 import { PANEL_COPY, SHARPEN_DEFAULT_VISIBLE } from '../constants'
 import { SignalRow } from './SignalRow'
-import type { SignalView } from '../types'
+import type { SignalView, SparkPrompt } from '../types'
 
 interface SharpenSectionProps {
   signals: SignalView[]
-  onSendPrompt: (label: string, prompt: string) => void
+  onSendPrompt: (spark: SparkPrompt) => void
   onAction: (view: SignalView) => void
 }
 

--- a/src/canvas/components/pre-analysis-v3/sharpen/SignalRow.tsx
+++ b/src/canvas/components/pre-analysis-v3/sharpen/SignalRow.tsx
@@ -17,11 +17,11 @@ import { NodeShapeIndicator } from '../../../nodes/NodeShapeIndicator'
 import { ATTRIBUTION_COPY } from '../constants'
 import { PanelIconButton } from '../ui/PanelIconButton'
 import type { NodeType } from '../../../domain/nodes'
-import type { SignalView } from '../types'
+import type { SignalView, SparkPrompt } from '../types'
 
 interface SignalRowProps {
   view: SignalView
-  onSendPrompt: (label: string, prompt: string) => void
+  onSendPrompt: (spark: SparkPrompt) => void
   onAction: (view: SignalView) => void
 }
 
@@ -85,7 +85,7 @@ export const SignalRow = memo(function SignalRow({ view, onSendPrompt, onAction 
                 aria-label={detection.spark.label}
                 onClick={() =>
                   detection.action?.type === 'send_prompt'
-                    ? onSendPrompt(detection.spark!.label, detection.spark!.prompt)
+                    ? onSendPrompt(detection.spark!)
                     : onAction(view)
                 }
               >

--- a/src/canvas/components/pre-analysis-v3/signals/registry.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/registry.ts
@@ -105,11 +105,7 @@ export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
           : undefined,
         rationale: SIGNAL_COPY.optionRationale,
         entityKind: 'option',
-        action: {
-          type: 'send_prompt',
-          label: SPARK_PROMPTS.widenOptions.label,
-          prompt: SPARK_PROMPTS.widenOptions.prompt,
-        },
+        action: { type: 'send_prompt', spark: SPARK_PROMPTS.widenOptions },
         spark: SPARK_PROMPTS.widenOptions,
       }
     },
@@ -130,11 +126,7 @@ export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
         copy: { lead: copy.lead, emphasis: copy.emphasis },
         rationale: SIGNAL_COPY.riskRationale,
         entityKind: 'risk',
-        action: {
-          type: 'send_prompt',
-          label: SPARK_PROMPTS.preMortem.label,
-          prompt: SPARK_PROMPTS.preMortem.prompt,
-        },
+        action: { type: 'send_prompt', spark: SPARK_PROMPTS.preMortem },
         spark: SPARK_PROMPTS.preMortem,
       }
     },
@@ -171,11 +163,7 @@ export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
         ceeOverride: { text: input.biasFindingExplanation, attribution: { kind: 'olumi' } },
         rationale: SIGNAL_COPY.ceeBiasRationale,
         entityKind: 'decision',
-        action: {
-          type: 'send_prompt',
-          label: SPARK_PROMPTS.reflectBias.label,
-          prompt: SPARK_PROMPTS.reflectBias.prompt,
-        },
+        action: { type: 'send_prompt', spark: SPARK_PROMPTS.reflectBias },
         spark: SPARK_PROMPTS.reflectBias,
       }
     },

--- a/src/canvas/components/pre-analysis-v3/types.ts
+++ b/src/canvas/components/pre-analysis-v3/types.ts
@@ -7,6 +7,29 @@
  * See docs/pre-analysis-panel-solution-design-v1.md.
  */
 
+import type { ActionTypeLiteral } from '@talchain/schemas/boundary'
+import type { PendingWireActionType } from '../../conversation/chipMeta'
+
+/**
+ * A product-authored spark: a prefilled prompt the product sends on the
+ * user's behalf, carrying EXPLICIT intent metadata on the wire. See the
+ * registry doc in constants.ts (SparkPrompt history + A1 meta-decision
+ * diagnosis, 2026-07-20) for why intent is mandatory.
+ */
+export interface SparkPrompt {
+  /** Stable registry id — ships on the wire as chip.parameters.spark_id. */
+  id: string
+  label: string
+  prompt: string
+  /**
+   * Wire intent decision: a published schema ActionType value (sent), a
+   * signed-off pending value (mapped but withheld by the schema-derived
+   * wire gate until re-vendor — see PendingWireActionType), or null when no
+   * honest value exists (coaching/readiness sparks).
+   */
+  action_type: ActionTypeLiteral | PendingWireActionType | null
+}
+
 /**
  * Collaboration-ready source attribution: a named person or Olumi, never a
  * you-versus-AI binary. Single user today; personId arrives with collaboration.
@@ -114,14 +137,14 @@ export interface SignalDetection {
   /** Primary action target — absent on resolved confirmations. */
   action?: PanelAction
   /** Optional ask-Olumi spark (prefilled prompt, sent immediately). */
-  spark?: { label: string; prompt: string }
+  spark?: SparkPrompt
 }
 
 export type PanelAction =
   | { type: 'focus_success_field' }
   | { type: 'focus_goal_field' }
   | { type: 'open_estimates'; nodeId?: string }
-  | { type: 'send_prompt'; label: string; prompt: string }
+  | { type: 'send_prompt'; spark: SparkPrompt }
   | { type: 'run_analysis' }
 
 export type SignalStatus = 'live' | 'resolved'

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -2570,6 +2570,35 @@ describe('dispatchAction — chip parameters ride the real V5 payload', () => {
     expect(payload.chip).toBeDefined()
     expect(payload.chip).not.toHaveProperty('parameters')
   })
+
+  it('an identity-only dispatch (parameters, no action_type) still ships chip.parameters — the null-intent spark/chip case (A1 meta-decision diagnosis, 2026-07-20)', async () => {
+    // Before buildChipMeta, dispatchAction gated chip metadata on
+    // action_type presence, silently stripping identity-only chips: the
+    // product-authored spark then travelled as anonymous text and CEE's
+    // draft-shape regex misread it as a decision brief. This pin exercises
+    // the REAL dispatchAction → REAL buildV5Payload chain (only the network
+    // runner is mocked), so reverting the construction goes RED here.
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.dispatchAction({
+        parameters: { spark_id: 'prepare_first_analysis' },
+        label: 'Prepare first analysis',
+        message: 'What should I check before running the first analysis?',
+        source: 'chip' as const,
+      })
+    })
+
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    const payload = mockCallV5Turn.mock.calls[0][0] as {
+      source?: string
+      chip?: { action_type?: string; parameters?: Record<string, unknown> }
+    }
+    expect(payload.source).toBe('chip')
+    expect(payload.chip).toBeDefined()
+    expect(payload.chip?.parameters).toEqual({ spark_id: 'prepare_first_analysis' })
+    // No action_type fabricated for a null-intent chip.
+    expect(payload.chip && 'action_type' in payload.chip).toBe(false)
+  })
 })
 
 describe('1.16i — rerun UX integrity', () => {

--- a/src/canvas/conversation/chipMeta.ts
+++ b/src/canvas/conversation/chipMeta.ts
@@ -1,0 +1,76 @@
+/**
+ * buildChipMeta — the single construction point for the chip metadata that
+ * dispatchAction forwards to sendTurn → buildV5Payload → the wire.
+ *
+ * Chip metadata travels whenever EITHER field is present: product-authored
+ * chips without an honest `action_type` still declare their identity via
+ * `parameters` (chip_id / spark_id) so CEE can route on explicit intent
+ * instead of re-inferring it from message text (A1 meta-decision diagnosis,
+ * 2026-07-20 — anonymous spark text was regex-misread as a decision brief).
+ * Before that fix, parameters-only chips were silently stripped
+ * (chipMeta = undefined).
+ *
+ * Pure leaf module so the spark/node-chip intent contract specs can
+ * exercise the REAL production seam without importing the useConversation
+ * hook graph.
+ */
+
+export interface ChipMetaInput {
+  /** Deterministic action type for CEE routing. */
+  action_type?: string
+  /** Structured parameters for action execution / chip identity. */
+  parameters?: Record<string, unknown>
+}
+
+export interface ChipMeta {
+  action_type?: string
+  parameters?: Record<string, unknown>
+}
+
+export function buildChipMeta(opts: ChipMetaInput): ChipMeta | undefined {
+  return opts.action_type || opts.parameters
+    ? {
+        ...(opts.action_type ? { action_type: opts.action_type } : {}),
+        ...(opts.parameters ? { parameters: opts.parameters } : {}),
+      }
+    : undefined
+}
+
+/**
+ * The V4/legacy turn-request wire requires `action_type` on chip_metadata
+ * (turn-request-builder.ts ChipMetadata). Identity-only meta (parameters
+ * without an action_type — the null-intent sparks/chips) is a V5-only
+ * concept and must NOT be coerced onto the V4 wire; it is dropped here,
+ * matching V4's pre-existing behaviour exactly.
+ */
+export function toLegacyChipMetadata(
+  meta: ChipMeta | undefined,
+): { action_type: string; parameters?: Record<string, unknown> } | undefined {
+  return meta?.action_type
+    ? {
+        action_type: meta.action_type,
+        ...(meta.parameters ? { parameters: meta.parameters } : {}),
+      }
+    : undefined
+}
+
+/**
+ * Wire intents whose NAME is signed off for a FUTURE @talchain/schemas
+ * version but which are not yet present in the vendored enum. Registries
+ * (spark registry, NodeChip call sites) may map these immediately; the
+ * schema-derived wire gate in buildV5Payload (sanitiseActionType →
+ * KNOWN_ACTION_TYPES → ActionType.options) withholds them from the wire —
+ * no `action_type` key, no chip_click promotion — until a re-vendor
+ * publishes the value, at which point the send lights up with zero further
+ * code change. CEE ingress validates action_type FAIL-CLOSED, so sending
+ * early would 422 the whole turn.
+ *
+ * Currently empty: the 0.20.0 chip-intent value name is pending sign-off.
+ * Add the literal to the ARRAY when the name lands (the type derives from
+ * it); remove it once the schema re-vendor makes it part of
+ * ActionTypeLiteral. The spark intent contract spec consults this list, so
+ * an entry here is a tested declaration, not a comment.
+ */
+export const PENDING_WIRE_ACTION_TYPES = [] as const
+
+export type PendingWireActionType = (typeof PENDING_WIRE_ACTION_TYPES)[number]

--- a/src/canvas/conversation/chipMeta.ts
+++ b/src/canvas/conversation/chipMeta.ts
@@ -65,12 +65,16 @@ export function toLegacyChipMetadata(
  * code change. CEE ingress validates action_type FAIL-CLOSED, so sending
  * early would 422 the whole turn.
  *
- * Currently empty: the 0.20.0 chip-intent value name is pending sign-off.
- * Add the literal to the ARRAY when the name lands (the type derives from
- * it); remove it once the schema re-vendor makes it part of
- * ActionTypeLiteral. The spark intent contract spec consults this list, so
- * an entry here is a tested declaration, not a comment.
+ * Members are added to the ARRAY on name sign-off (the type derives from
+ * it) and removed once the schema re-vendor makes them part of
+ * ActionTypeLiteral — the contract spec's list-hygiene test goes RED at
+ * that moment, forcing the removal. An entry here is a tested declaration,
+ * not a comment.
+ *
+ * - `analysis_readiness` (signed off 2026-07-20, lands in 0.20.0):
+ *   assess/coach readiness for analysis — the intent behind the
+ *   "Prepare first analysis" defect spark. Intent-shaped, not a command.
  */
-export const PENDING_WIRE_ACTION_TYPES = [] as const
+export const PENDING_WIRE_ACTION_TYPES = ['analysis_readiness'] as const
 
 export type PendingWireActionType = (typeof PENDING_WIRE_ACTION_TYPES)[number]

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -48,6 +48,7 @@ import {
 // surface (malformed / no renderer / legacy suppression). Counting only —
 // recordDroppedContent never throws and never changes composition output.
 import { recordDroppedContent } from '../../lib/droppedContentCounter'
+import { buildChipMeta, toLegacyChipMetadata, type ChipMeta } from './chipMeta'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled, isReasoningDisclosureEnabled } from '../../flags'
 import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
 // Leg 3 blocker fix: the wire->camelCase coaching mapper lives in the CEE
@@ -1880,7 +1881,7 @@ export function useConversation(): UseConversationReturn {
       clientTurnId?: string
       turnType: TurnType
       systemEventWire?: WireSystemEvent
-      chipMeta?: { action_type: string; parameters?: Record<string, unknown> }
+      chipMeta?: ChipMeta
     }): TurnRequestPayload => {
       const store = useCanvasStore.getState()
       const { nodeIds, edgeIds } = store.selection
@@ -2158,7 +2159,9 @@ export function useConversation(): UseConversationReturn {
             graph_state: graphState,
             selected_elements: selectedElements,
             analysis_state: analysisState,
-            chip_metadata: opts.chipMeta,
+            // V4 wire requires action_type on chip_metadata; identity-only
+            // meta (parameters without action_type) is V5-only.
+            chip_metadata: toLegacyChipMetadata(opts.chipMeta),
             client_turn_id: opts.clientTurnId,
           })
         }
@@ -2211,7 +2214,9 @@ export function useConversation(): UseConversationReturn {
         graph_state: graphState,
         selected_elements: selectedElements,
         analysis_state: analysisState,
-        chip_metadata: opts.chipMeta,
+        // V4 wire requires action_type on chip_metadata; identity-only
+        // meta (parameters without action_type) is V5-only.
+        chip_metadata: toLegacyChipMetadata(opts.chipMeta),
         client_turn_id: opts.clientTurnId,
       })
     },
@@ -2902,7 +2907,7 @@ export function useConversation(): UseConversationReturn {
       rightPanelAccidentallySubmittedComposerContent?: boolean
       turnType?: Exclude<TurnType, 'system_event'>
       /** Deterministic chip metadata forwarded for CEE action routing */
-      chipMeta?: { action_type: string; parameters?: Record<string, unknown> }
+      chipMeta?: ChipMeta
       /** When true, render the user bubble as a compact action indicator */
       chipInitiated?: boolean
     }) => {
@@ -4256,9 +4261,12 @@ export function useConversation(): UseConversationReturn {
         payloadSummary: { label: opts.label, source: opts.source, action_type: opts.action_type },
       })
 
-      const chipMeta = opts.action_type
-        ? { action_type: opts.action_type, ...(opts.parameters ? { parameters: opts.parameters } : {}) }
-        : undefined
+      // Chip metadata construction lives in the pure chipMeta module (the
+      // seam the spark/node-chip intent contract specs exercise). It travels
+      // whenever EITHER field is present — see buildChipMeta's doc: identity
+      // parameters (chip_id / spark_id) must reach the wire even when no
+      // honest action_type exists (A1 meta-decision diagnosis, 2026-07-20).
+      const chipMeta = buildChipMeta(opts)
 
       // Resolve turn type: deterministic map first, then keyword heuristic for legacy chips
       let turnType: Exclude<TurnType, 'system_event'> = 'conversation'

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -1016,8 +1016,8 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
               )}
               {/* Coaching chips */}
               <div className="flex flex-col gap-1 mt-2 pt-1.5 border-t border-panel-border">
-                <NodeChip label="What evidence supports this?" message={`What evidence supports the ${dirLabel.toLowerCase()} relationship between ${srcTitle} and ${tgtTitle}?`} />
-                <NodeChip label="Adjust strength" message={`I want to adjust the strength of the relationship between ${srcTitle} and ${tgtTitle}. Current strength is ${strengthPct}%.`} />
+                <NodeChip chipId="edge_evidence_supports" actionType={null} label="What evidence supports this?" message={`What evidence supports the ${dirLabel.toLowerCase()} relationship between ${srcTitle} and ${tgtTitle}?`} />
+                <NodeChip chipId="edge_adjust_strength" actionType="adjust_edge_strength" label="Adjust strength" message={`I want to adjust the strength of the relationship between ${srcTitle} and ${tgtTitle}. Current strength is ${strengthPct}%.`} />
               </div>
             </div>
           </EdgeLabelRenderer>

--- a/src/canvas/nodes/DecisionNode.tsx
+++ b/src/canvas/nodes/DecisionNode.tsx
@@ -250,17 +250,17 @@ export const DecisionNode = memo(({ id, data, selected }: NodeProps<DecisionNode
   // ready, because that's a primary action button rather than coaching.
   const preAnalysisCoachingChips = useMemo(() => (
     <div className="flex items-center gap-1 flex-wrap mt-1.5">
-      <NodeChip label="Explore more options" message="Suggest a third option I haven't considered for this decision" />
+      <NodeChip chipId="decision_explore_more_options" actionType={null} label="Explore more options" message="Suggest a third option I haven't considered for this decision" />
       {!showRunAnalysis && (
-        <NodeChip label="What could go wrong?" message="What could go wrong with this decision?" />
+        <NodeChip chipId="decision_what_could_go_wrong" actionType={null} label="What could go wrong?" message="What could go wrong with this decision?" />
       )}
     </div>
   ), [showRunAnalysis])
 
   const postAnalysisCoachingChips = useMemo(() => (
     <div className="flex gap-1 flex-wrap mt-1.5">
-      <NodeChip label="Challenge this result" message="What assumptions would need to change for a different option to win?" />
-      <NodeChip label="Compare options" message="Compare the options side by side" />
+      <NodeChip chipId="decision_challenge_result" actionType="what_would_flip" label="Challenge this result" message="What assumptions would need to change for a different option to win?" />
+      <NodeChip chipId="decision_compare_options" actionType="compare_options" label="Compare options" message="Compare the options side by side" />
     </div>
   ), [])
 
@@ -352,7 +352,7 @@ export const DecisionNode = memo(({ id, data, selected }: NodeProps<DecisionNode
                 live in the popover below — see preAnalysisCoachingChips. */}
             {showRunAnalysis && (
               <div className="flex items-center gap-1 flex-wrap mt-1.5">
-                <NodeChip label="Run analysis" message="Run the analysis now" />
+                <NodeChip chipId="decision_run_analysis" actionType="run_analysis" label="Run analysis" message="Run the analysis now" />
               </div>
             )}
           </>

--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -472,6 +472,8 @@ export const FactorNode = memo((props: NodeProps) => {
       chips.push(
         <NodeChip
           key="estimate"
+          chipId="factor_help_estimate"
+          actionType={null}
           label="Help me estimate this"
           message={`Help me estimate a reasonable value for ${cleanedLabel}`}
         />
@@ -480,6 +482,8 @@ export const FactorNode = memo((props: NodeProps) => {
       chips.push(
         <NodeChip
           key="external-change"
+          chipId="factor_what_if_changes"
+          actionType={null}
           label="What if this changes?"
           message={`What if ${cleanedLabel} changes? How should I plan for that?`}
         />
@@ -488,6 +492,8 @@ export const FactorNode = memo((props: NodeProps) => {
       chips.push(
         <NodeChip
           key="evidence"
+          chipId="factor_evidence_supports"
+          actionType={null}
           label="What evidence supports this?"
           message={`What evidence supports my assumption about ${cleanedLabel}?`}
         />

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -210,9 +210,9 @@ export const GoalNode = memo((props: NodeProps) => {
       {hasThreshold && (
         <div className="flex gap-1 flex-wrap mt-1.5">
           {displayMetadata.achievementProbability !== null && displayMetadata.achievementProbability < 0.10 && (
-            <NodeChip label="Why is this so low?" message="Why is the probability of reaching my goal target so low? What are the main drivers?" />
+            <NodeChip chipId="goal_why_so_low" actionType="explain_results" label="Why is this so low?" message="Why is the probability of reaching my goal target so low? What are the main drivers?" />
           )}
-          <NodeChip label="Is my target realistic?" message="Is my current goal target realistic given the factors in my model? What would be a more achievable target?" />
+          <NodeChip chipId="goal_target_realistic" actionType={null} label="Is my target realistic?" message="Is my current goal target realistic given the factors in my model? What would be a more achievable target?" />
         </div>
       )}
     </>
@@ -249,7 +249,7 @@ export const GoalNode = memo((props: NodeProps) => {
                 : 'Analysis finished. Set a target and check the graph for incomplete inputs.'}
             </p>
             <div className="mt-1.5">
-              <NodeChip label="Help me set a target" message="Help me define what success looks like for this goal. What metrics or thresholds should I aim for?" />
+              <NodeChip chipId="goal_help_set_target" actionType={null} label="Help me set a target" message="Help me define what success looks like for this goal. What metrics or thresholds should I aim for?" />
             </div>
           </>
         )}
@@ -264,7 +264,7 @@ export const GoalNode = memo((props: NodeProps) => {
               Add a measurable success target, e.g. metric, threshold or deadline
             </p>
             <div className="mt-1.5">
-              <NodeChip label="Help me set a target" message="Help me define what success looks like for this goal. What metrics or thresholds should I aim for?" />
+              <NodeChip chipId="goal_help_set_target" actionType={null} label="Help me set a target" message="Help me define what success looks like for this goal. What metrics or thresholds should I aim for?" />
             </div>
           </>
         )}
@@ -370,7 +370,7 @@ export const GoalNode = memo((props: NodeProps) => {
             first-time users. */}
         {hasThreshold && !isPostAnalysis && (
           <div className="mt-1.5">
-            <NodeChip label="Run analysis" message="Run the analysis now" />
+            <NodeChip chipId="goal_run_analysis" actionType="run_analysis" label="Run analysis" message="Run the analysis now" />
           </div>
         )}
 

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -842,16 +842,16 @@ export const OptionNode = memo((props: NodeProps) => {
         // Baseline chips already pre-existed inside layer2Content; keep them.
         return (
           <div className="flex gap-1 flex-wrap mt-1.5">
-            <NodeChip label="Why does this win/lose?" message={`Why does the status quo (${optionLabel}) win or lose compared to other options?`} />
-            <NodeChip label="Risks of inaction" message="What are the risks of choosing to do nothing?" />
+            <NodeChip chipId="option_why_win_lose" actionType="explain_results" label="Why does this win/lose?" message={`Why does the status quo (${optionLabel}) win or lose compared to other options?`} />
+            <NodeChip chipId="option_risks_of_inaction" actionType={null} label="Risks of inaction" message="What are the risks of choosing to do nothing?" />
           </div>
         )
       }
       if (isRecommended) {
         return (
           <div className="flex gap-1 flex-wrap mt-1.5">
-            <NodeChip label="What would change this?" message={`What would need to change for ${optionLabel} to no longer be the best choice?`} />
-            <NodeChip label="Why does this lead?" message={`Why does ${optionLabel} lead over the other options?`} />
+            <NodeChip chipId="option_what_would_change" actionType="what_would_flip" label="What would change this?" message={`What would need to change for ${optionLabel} to no longer be the best choice?`} />
+            <NodeChip chipId="option_why_lead" actionType="explain_results" label="Why does this lead?" message={`Why does ${optionLabel} lead over the other options?`} />
           </div>
         )
       }
@@ -861,11 +861,13 @@ export const OptionNode = memo((props: NodeProps) => {
           <div className="flex gap-1 flex-wrap mt-1.5">
             {closeCallGapPp != null && (
               <NodeChip
+                chipId="option_what_would_change_close_call"
+                actionType="what_would_flip"
                 label="What would change this?"
                 message={`What would need to change for ${optionLabel} to become the leader?`}
               />
             )}
-            <NodeChip label="What would make this lead?" message={`What would need to change for ${optionLabel} to lead?`} />
+            <NodeChip chipId="option_what_would_make_lead" actionType="what_would_flip" label="What would make this lead?" message={`What would need to change for ${optionLabel} to lead?`} />
           </div>
         )
       }
@@ -875,7 +877,7 @@ export const OptionNode = memo((props: NodeProps) => {
     if (!isBaselineOption) {
       return (
         <div className="flex gap-1 flex-wrap mt-1.5">
-          <NodeChip label="What could go wrong?" message={`What could go wrong if we choose ${optionLabel}?`} />
+          <NodeChip chipId="option_what_could_go_wrong" actionType={null} label="What could go wrong?" message={`What could go wrong if we choose ${optionLabel}?`} />
         </div>
       )
     }

--- a/src/canvas/nodes/OutcomeNode.tsx
+++ b/src/canvas/nodes/OutcomeNode.tsx
@@ -146,6 +146,8 @@ export const OutcomeNode = memo((props: NodeProps) => {
     return (
       <div className="flex gap-1 flex-wrap mt-1.5">
         <NodeChip
+          chipId="outcome_what_strengthens"
+          actionType={null}
           label="What strengthens this?"
           message={`What upstream factors strengthen ${(props.data?.label as string) ?? 'this outcome'}?`}
         />

--- a/src/canvas/nodes/RiskNode.tsx
+++ b/src/canvas/nodes/RiskNode.tsx
@@ -80,8 +80,8 @@ export const RiskNode = memo((props: NodeProps) => {
   // directly; they live in popovers (Standard) or inline in Detailed view.
   const riskChips = useMemo(() => (
     <div className="flex gap-1 flex-wrap mt-1.5">
-      <NodeChip label="What reduces this?" message={`What factors or actions could reduce ${cleanedLabel || 'this risk'}?`} />
-      <NodeChip label="Add mitigation" message={`Suggest a mitigation strategy for ${cleanedLabel || 'this risk'}`} />
+      <NodeChip chipId="risk_what_reduces" actionType={null} label="What reduces this?" message={`What factors or actions could reduce ${cleanedLabel || 'this risk'}?`} />
+      <NodeChip chipId="risk_add_mitigation" actionType={null} label="Add mitigation" message={`Suggest a mitigation strategy for ${cleanedLabel || 'this risk'}`} />
     </div>
   ), [cleanedLabel])
 

--- a/src/canvas/nodes/shared/NodeChip.tsx
+++ b/src/canvas/nodes/shared/NodeChip.tsx
@@ -1,22 +1,59 @@
 /**
  * NodeChip — outlined AI coaching chip for canvas nodes.
- * Triggers _sendMessage via guidanceStore on click.
+ *
+ * Intent metadata is MANDATORY (A1 meta-decision diagnosis, 2026-07-20):
+ * these chips are product-authored prompts, so their intent is known at
+ * authoring time and must ship on the wire instead of being re-inferred
+ * from message text by CEE's heuristics (the "Run the analysis now" chip
+ * was folded into a clarify round as a brief "answer" because it arrived
+ * as anonymous text).
+ *
+ * - `chipId`: stable identity, ships as `chip.parameters.chip_id`.
+ * - `actionType`: wire intent from the @talchain/schemas ActionType enum
+ *   (strict at CEE ingress), or null when the vocabulary has no honest
+ *   value for a coaching chip — never force a wrong one.
+ *
+ * Send path: prefer the unified dispatcher (`_dispatchAction`, the only
+ * bridge that carries chip metadata); fall back to `_sendMessage` so the
+ * click still lands on hosts that registered only the legacy bridge.
  */
 import { useCallback } from 'react'
+import type { ActionTypeLiteral } from '@talchain/schemas/boundary'
+import type { PendingWireActionType } from '../../conversation/chipMeta'
 import { useGuidanceStore } from '../../stores/guidanceStore'
 import { typography } from '../../../styles/typography'
 
 interface NodeChipProps {
   label: string
   message: string
+  /** Stable chip identity — ships as chip.parameters.chip_id. */
+  chipId: string
+  /**
+   * Wire intent: a published ActionType value (sent), a signed-off pending
+   * value (withheld by buildV5Payload's schema-derived gate until the
+   * schema re-vendor), or null when no honest value exists.
+   */
+  actionType: ActionTypeLiteral | PendingWireActionType | null
 }
 
-export function NodeChip({ label, message }: NodeChipProps) {
+export function NodeChip({ label, message, chipId, actionType }: NodeChipProps) {
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
-    const send = useGuidanceStore.getState()._sendMessage
+    const callbacks = useGuidanceStore.getState()
+    if (callbacks._dispatchAction) {
+      callbacks._dispatchAction({
+        ...(actionType ? { action_type: actionType } : {}),
+        parameters: { chip_id: chipId },
+        label,
+        message,
+        source: 'chip',
+      })
+      return
+    }
+    // Legacy bridge — metadata cannot travel; the message still lands.
+    const send = callbacks._sendMessage
     if (send) send(message)
-  }, [message])
+  }, [message, label, chipId, actionType])
 
   return (
     <button

--- a/src/canvas/nodes/shared/__tests__/NodeChip.intent.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/NodeChip.intent.spec.tsx
@@ -1,0 +1,163 @@
+/**
+ * NodeChip intent contract (A1 meta-decision diagnosis, 2026-07-20).
+ *
+ * Node chips are product-authored prompts. Before this contract they were
+ * sent as anonymous text via `_sendMessage` — CEE's heuristics re-inferred
+ * their intent from the words, which is how the product's own "Run the
+ * analysis now" chip got folded into a clarify round as a brief "answer"
+ * instead of running the analysis.
+ *
+ * Pinned here, through the REAL production seams (NodeChip → guidance
+ * bridge → buildChipMeta → buildV5Payload):
+ *  - a chip with a bound action ships `chip.action_type` + its chip_id and
+ *    promotes the wire source to `chip_click` (CEE's deterministic branch);
+ *  - a coaching chip with a deliberate null still ships its chip_id
+ *    (explicit product identity) with NO action_type key;
+ *  - hosts that registered only the legacy `_sendMessage` bridge still get
+ *    the message (no dead clicks).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { ReactElement } from 'react'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+
+import { NodeChip } from '../NodeChip'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import { buildChipMeta } from '../../../conversation/chipMeta'
+import { buildV5Payload } from '../../../../v5/buildPayload'
+
+type DispatchOpts = {
+  action_type?: string
+  parameters?: Record<string, unknown>
+  label: string
+  message: string
+  hidden?: boolean
+  source: string
+}
+
+let unregister: (() => void) | null = null
+
+function registerBridge(withDispatch: boolean) {
+  const sendMessage = vi.fn()
+  const dispatchAction = vi.fn()
+  unregister = useGuidanceStore
+    .getState()
+    .registerConversationCallbacks(
+      sendMessage,
+      vi.fn(),
+      undefined,
+      undefined,
+      undefined,
+      withDispatch ? dispatchAction : undefined,
+    )
+  return { sendMessage, dispatchAction }
+}
+
+afterEach(() => {
+  unregister?.()
+  unregister = null
+  cleanup()
+})
+
+function clickChip(ui: ReactElement, label: string) {
+  const { getByRole } = render(ui)
+  fireEvent.click(getByRole('button', { name: label }))
+}
+
+/** Feed the captured dispatch opts through the real wire modules. */
+function buildWire(opts: DispatchOpts) {
+  const chipMeta = buildChipMeta({
+    action_type: opts.action_type,
+    parameters: opts.parameters,
+  })
+  const built = buildV5Payload({
+    turnId: '00000000-0000-4000-8000-000000000011',
+    scenarioId: '00000000-0000-4000-8000-000000000012',
+    stage: 'frame',
+    turnClass: 'frame',
+    mode: 'user',
+    message: opts.message,
+    source: 'chip',
+    chipMeta,
+  })
+  if (!built.ok) throw new Error('payload build failed: ' + JSON.stringify(built))
+  return built.payload as {
+    source: string
+    message: string
+    chip?: { action_type?: string; parameters?: Record<string, unknown> }
+  }
+}
+
+describe('NodeChip — bound action ships explicit intent to the wire', () => {
+  it('run_analysis chip dispatches action_type + chip_id and builds a chip_click payload', () => {
+    const { dispatchAction, sendMessage } = registerBridge(true)
+    clickChip(
+      <NodeChip
+        chipId="decision_run_analysis"
+        actionType="run_analysis"
+        label="Run analysis"
+        message="Run the analysis now"
+      />,
+      'Run analysis',
+    )
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(dispatchAction).toHaveBeenCalledTimes(1)
+    const opts = dispatchAction.mock.calls[0][0] as DispatchOpts
+    expect(opts.action_type).toBe('run_analysis')
+    expect(opts.parameters).toEqual({ chip_id: 'decision_run_analysis' })
+    expect(opts.message).toBe('Run the analysis now')
+    expect(opts.source).toBe('chip')
+
+    const payload = buildWire(opts)
+    // Bound action promotes the source to CEE's deterministic chip branch.
+    expect(payload.source).toBe('chip_click')
+    expect(payload.chip?.action_type).toBe('run_analysis')
+    expect(payload.chip?.parameters).toEqual({ chip_id: 'decision_run_analysis' })
+    expect(payload.message).toBe('Run the analysis now')
+  })
+})
+
+describe('NodeChip — coaching chip (deliberate null) still ships its identity', () => {
+  it('null actionType dispatches chip_id only and never fabricates an action_type', () => {
+    const { dispatchAction } = registerBridge(true)
+    clickChip(
+      <NodeChip
+        chipId="risk_add_mitigation"
+        actionType={null}
+        label="Add mitigation"
+        message="Suggest a mitigation strategy for this risk"
+      />,
+      'Add mitigation',
+    )
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1)
+    const opts = dispatchAction.mock.calls[0][0] as DispatchOpts
+    // A null decision must not leak as a key CEE could misread.
+    expect('action_type' in opts).toBe(false)
+    expect(opts.parameters).toEqual({ chip_id: 'risk_add_mitigation' })
+
+    const payload = buildWire(opts)
+    expect(payload.source).toBe('chip')
+    expect(payload.chip).toBeDefined()
+    expect(payload.chip && 'action_type' in payload.chip).toBe(false)
+    expect(payload.chip?.parameters).toEqual({ chip_id: 'risk_add_mitigation' })
+  })
+})
+
+describe('NodeChip — legacy bridge fallback', () => {
+  it('falls back to _sendMessage when no dispatcher is registered (no dead clicks)', () => {
+    const { sendMessage } = registerBridge(false)
+    clickChip(
+      <NodeChip
+        chipId="risk_what_reduces"
+        actionType={null}
+        label="What reduces this?"
+        message="What factors or actions could reduce this risk?"
+      />,
+      'What reduces this?',
+    )
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith('What factors or actions could reduce this risk?')
+  })
+})

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -28,6 +28,7 @@ import type {
   TurnSourceLiteral,
   ActionTypeLiteral,
 } from '@talchain/schemas/boundary'
+import { ActionType } from '@talchain/schemas/boundary'
 
 import type { SystemEvent } from '../canvas/conversation/types'
 
@@ -81,14 +82,24 @@ export function buildV5Payload(input: BuildV5PayloadInput): BuildV5PayloadResult
     return { ok: false, reason: 'missing_message' }
   }
 
-  // Derive source: chipMeta presence with an action_type signals a bound
-  // chip click regardless of what the caller labelled it. Keeps downstream
-  // CEE routing accurate when the UI's sendChip path currently passes
-  // source='chip' uniformly (see useConversation.dispatchAction). Retry is
-  // always honoured over chip-derivation so retryLast() still hits the
-  // retry branch on the CEE side.
+  // Publication gate (schema-derived, sanitise BEFORE source derivation):
+  // CEE ingress validates action_type FAIL-CLOSED against ITS vendored enum,
+  // so an unpublished value on the wire would 422 the whole turn. The gate
+  // is derived from OUR vendored enum (sanitiseActionType → KNOWN_ACTION_TYPES
+  // → ActionType.options): a mapped-but-unpublished value is withheld
+  // entirely — no action_type key AND no chip_click promotion — so the turn
+  // behaves exactly like today's identity-only chip until a schema re-vendor
+  // lights the value up with zero code change here.
+  const wireActionType = sanitiseActionType(input.chipMeta?.action_type)
+
+  // Derive source: chipMeta presence with a PUBLISHED action_type signals a
+  // bound chip click regardless of what the caller labelled it. Keeps
+  // downstream CEE routing accurate when the UI's sendChip path currently
+  // passes source='chip' uniformly (see useConversation.dispatchAction).
+  // Retry is always honoured over chip-derivation so retryLast() still hits
+  // the retry branch on the CEE side.
   const rawSource = input.source
-  const hasBoundAction = Boolean(input.chipMeta?.action_type)
+  const hasBoundAction = Boolean(wireActionType) || rawSource === 'chip_click'
   const effectiveSource =
     rawSource === 'retry'
       ? 'retry'
@@ -109,12 +120,12 @@ export function buildV5Payload(input: BuildV5PayloadInput): BuildV5PayloadResult
     source,
   }
 
-  // Chip sub-object — only on chip / chip_click sources.
+  // Chip sub-object — only on chip / chip_click sources. Carries only the
+  // gate-passed (published) action_type; identity parameters always travel.
   if ((source === 'chip' || source === 'chip_click') && input.chipMeta) {
-    const action_type = sanitiseActionType(input.chipMeta.action_type)
     const parameters = input.chipMeta.parameters
     base.chip = {
-      ...(action_type ? { action_type } : {}),
+      ...(wireActionType ? { action_type: wireActionType } : {}),
       ...(parameters ? { parameters } : {}),
     }
   }
@@ -239,22 +250,15 @@ function stringField(src: Record<string, unknown> | undefined, key: string): str
 // action_type, we'd fail ingress; drop it to let CEE's classifier dispatch
 // from message text alone.
 //
-// V-P0-2 fold: this set MUST equal the vendored @talchain/schemas ActionType
-// enum exactly — a hand-copied subset silently strips schema-valid values at
-// the wire (it was 2 generations stale: 7 members vs the 0.15 enum's 9,
-// missing explain_results + explain_from_structure). Parity is pinned by
-// explainChips.vocabulary.spec.ts, which imports the enum and fails on drift.
-export const KNOWN_ACTION_TYPES: ReadonlySet<ActionTypeLiteral> = new Set<ActionTypeLiteral>([
-  'run_analysis',
-  'set_factor_value',
-  'add_constraint',
-  'adjust_edge_strength',
-  'explain_result',
-  'explain_results',
-  'explain_from_structure',
-  'compare_options',
-  'what_would_flip',
-])
+// V-P0-2 fold, completed 2026-07-20: DERIVED from the vendored
+// @talchain/schemas ActionType enum — the hand-copied list this replaced
+// went 2 generations stale (7 members vs the enum's 9, silently stripping
+// explain_results + explain_from_structure at the wire). The parity spec in
+// explainChips.vocabulary.spec.ts stays as the guard against anyone
+// reverting to a hand list.
+export const KNOWN_ACTION_TYPES: ReadonlySet<ActionTypeLiteral> = new Set<ActionTypeLiteral>(
+  ActionType.options,
+)
 
 function sanitiseActionType(raw: string | undefined): ActionTypeLiteral | undefined {
   if (!raw) return undefined


### PR DESCRIPTION
# Sparks and node chips ship explicit `action_type` intent metadata

**Root cause** (A1's meta-decision diagnosis, `parallel-briefs/META-DECISION-DIAGNOSIS-2026-07-20.md` §5): every product-authored spark travelled to CEE as anonymous text (`source='chip'`, no metadata), bypassing CEE's deterministic chip branch. CEE's draft-shape regex (`should`/trailing-`?`, ≥30 chars) then misread the product's own "Prepare first analysis" spark as a decision BRIEF on an empty canvas → CEE drafted a meta-decision graph ("should we run the analysis?") → blank hero. **Every spark in the registry matched the regex and would misroute the same way.** The product knows the intent at authoring time; discarding it and re-inferring by regex IS the defect mechanism. This PR carries the intent explicitly.

## LANDING SEQUENCE (per orchestrator ruling, 2026-07-20)

CEE's B1 ingress validates `action_type` **fail-closed** against its vendored enum — an unpublished value 422s the whole turn. Therefore:

- **Activates NOW (this PR):** the five node-chip values below (`run_analysis`, `what_would_flip`, `compare_options`, `explain_results`, `adjust_edge_strength`). All five are published in the vendored **0.19.0** enum — and were already present in the **0.15** enum (the enum has been 9-membered since ≤0.15), so CEE-pin skew cannot 422 them. They are the same values existing chip surfaces already send through `dispatchAction` today.
- **Activates on the 0.20.0 re-vendor (zero code change): `analysis_readiness`** — SIGNED OFF 2026-07-20 ("assess/coach readiness for analysis", intent-shaped) and STAGED in this PR. Mechanism: `PENDING_WIRE_ACTION_TYPES` (`src/canvas/conversation/chipMeta.ts`) — a runtime const the type derives from (derive-don't-mirror), now containing `analysis_readiness`. Two sparks map to it today (see table); the **publication gate** in `buildV5Payload` (`sanitiseActionType` → `KNOWN_ACTION_TYPES` → `ActionType.options`, sanitising **before** source derivation) withholds it from the wire — no `action_type` key, no `chip_click` promotion, identity parameters still travel — until the re-vendor publishes it, at which point the send lights up with **zero further code change**. Contract tests assert the gate logic itself (mapped+published ⇒ sent; mapped+pending ⇒ withheld — exercised by the REAL mapped sparks AND a synthetic control so the withhold arm is never vacuously green), that `analysis_readiness` is declared pending AND currently unpublished (this test flips RED at the re-vendor, forcing the pending-list removal while the mapped sparks start sending automatically), and list hygiene.
- **Never sends dark values:** `analysis_readiness` is mapped but withheld (proven at the built payload); every other null-mapped spark ships **identity only** (`chip.parameters.spark_id`) — the deterministic hook A1's CEE routing half keys on, and strictly better than today's anonymous text, never worse.

## Per-spark table (registry: `pre-analysis-v3/constants.ts`)

Vocabulary derived from the vendored `@talchain/schemas` 0.19.0 `ActionType` enum (9 members: `run_analysis, set_factor_value, add_constraint, adjust_edge_strength, explain_result, explain_results, explain_from_structure, compare_options, what_would_flip`) — never a hand list.

| Spark (id) | `action_type` | Reasoning |
|---|---|---|
| `pressure_test_frame` | `null` | Frame-challenge coaching. `explain_from_structure` EXPLAINS the model; this spark CHALLENGES it — stamping it would misdeclare. |
| `widen_options` | `null` | Option-elicitation; the enum has no `add_option`. |
| `outside_view` | `null` | Base-rate coaching — no vocabulary entry. |
| `pre_mortem` | `null` | Failure-imagination coaching — no entry. |
| `risks_upside` | `null` | Gap-elicitation (what's MISSING); `explain_*` describes what's present. |
| `calibrate_estimates` | **`analysis_readiness` (pending — withheld until 0.20.0)** | "Help me check the estimates that matter most to the ANALYSIS" — readiness-directed calibration; the readiness capability's estimate-gap signals are the honest answer. NOT `what_would_flip` (post-analysis sensitivity whose deterministic handler demands prior analysis facts). |
| `compare_view` | `null` | `compare_options` compares DECISION OPTIONS, not the user's view vs the model's. |
| `prepare_first_analysis` | **`analysis_readiness` (pending — withheld until 0.20.0)** | **The defect spark — the verbatim intent the value was coined for.** NOT `run_analysis`, which would RUN the analysis the user is asking how to PREPARE for — the exact wrongness class this metadata exists to kill. |
| `define_success` | `null` | Goal-target coaching; `set_factor_value` is a validated mutation, not a conversation. |
| `reflect_bias` | `null` | Bias-reflection coaching — no entry. |

(`SPARK_PROMPTS` shares ids with `ACTIONS_MENU` where the prompt is identical — same product intent, same wire identity. 15 registry entries total across both collections.)

**Pending-mapping adjudication (per the `analysis_readiness` sign-off):** mapped ONLY where "assess/coach readiness for analysis" is the spark's honest intent — `prepare_first_analysis` and `calibrate_estimates` (both collections; shared id). The other 8 stay `null` deliberately: their readiness link is incidental (`define_success`/`goal_help_set_target` RESOLVE a readiness blocker but their intent is goal elicitation, not readiness assessment; `risks_upside` elicits missing content rather than assessing run-readiness) — recasting them would gate elicitation conversations behind analysis framing. None was force-mapped; the stayed-null sparks still await honest vocabulary entries of their own.

## Node chips (all 25 call sites — `chipId` + `actionType` are now REQUIRED props)

Node chips did NOT previously carry `action_type` (proven: `NodeChip` sent bare text via `_sendMessage`; the diagnosis shows even "Run the analysis now" was folded into a clarify round as an anonymous "answer").

| Chip (chipId) | `actionType` | Reasoning |
|---|---|---|
| `decision_run_analysis`, `goal_run_analysis` | `run_analysis` | Literally "Run the analysis now" — the deterministic handler exists. |
| `decision_challenge_result` | `what_would_flip` | "What assumptions would need to change…" — post-analysis sensitivity, shown post-analysis. |
| `option_what_would_change`, `option_what_would_change_close_call`, `option_what_would_make_lead` | `what_would_flip` | Same class: what flips the leader. |
| `decision_compare_options` | `compare_options` | "Compare the options side by side" — exact match. |
| `option_why_win_lose`, `option_why_lead`, `goal_why_so_low` | `explain_results` | Post-analysis "why" questions about computed results. |
| `edge_adjust_strength` | `adjust_edge_strength` | "I want to adjust the strength of the relationship…" — exact match. |
| 14 coaching chips (estimate help, what-could-go-wrong, mitigation, evidence, set-a-target, etc.) | `null` | Coaching intents with no honest entry; ship `chip_id` identity only. |

**`analysis_readiness` adjudication for node chips: ZERO join.** None of the 14 null chips is readiness-shaped — they are elicitation (options/risks/evidence), mitigation, scenario-planning, single-factor estimation help (`factor_help_estimate` coaches ONE estimate; a readiness handler assesses the whole run), or target definition (`goal_help_set_target` — same reasoning as `define_success`). Mapping any of them would be the blanket-mapping dishonesty the adjudication exists to prevent.

## Wire evidence (asserted at the built payload JSON, not the component)

- `sparkIntentContract.spec.ts` — for each of the 15 registry sparks: click through the REAL `useConversationActions` hook → `sendChip` → `buildChipMeta` → `buildV5Payload`, asserting the outgoing payload: `chip.parameters == {spark_id}` always; published `action_type` sent + `source='chip_click'`; null/pending ⇒ no `action_type` key + `source='chip'`.
- `NodeChip.intent.spec.tsx` — real component click → guidance bridge → real wire modules: bound chip promotes to `chip_click`; null chip ships `chip_id` only; legacy `_sendMessage` host still gets the message (no dead clicks).
- `useConversation.hook.spec.ts` (new pin in the existing "Lane 1 seam pin" block) — the REAL `dispatchAction` → REAL `buildV5Payload` (only the network runner mocked): an identity-only dispatch ships `chip.parameters` with no fabricated `action_type`. **This pin exists because the hand-apply initially missed the `dispatchAction` wiring and only the wide-tsc gate caught it — the seam now has direct test coverage.**
- **Reverse guard:** free-typed composer text builds with NO `chip` object at all — user text is never stamped with product intent (the same honesty requirement reversed).

## RED-first + mutations (throwaway worktree, per trap 9)

- **RED-first:** both new specs run against pristine `origin/staging` (2e5abdb1): **34/39 FAIL** — the contract is decisively red today.
- **M1** revert `dispatchAction` to inline action_type-gated construction → identity-only hook pin RED.
- **M2** strip `parameters:{spark_id}` from the spark send path → 15/15 wire tests RED.
- **M3** delete one spark's `action_type` declaration → own-property registry test RED (esbuild strips types, so the runtime check is the guard, not tsc).
- **M4** revert NodeChip to `_sendMessage`-only → 2/3 NodeChip tests RED (legacy-fallback rightly stays green).
- **M5** revert the publication gate to raw-value promotion → synthetic-pending withhold test RED.
- **M6** empty `PENDING_WIRE_ACTION_TYPES` → RED at 3 registry entries ("neither published nor declared pending — would 422 CEE ingress") + both new gate tests.
- **M6b** revert `prepare_first_analysis` to `null` → real-data withhold-arm pin RED (`expected [ 'calibrate_estimates', … ] to include 'prepare_first_analysis'`).

Honest limitation: node-chip `actionType` VALUES live at call sites (no registry to iterate); the component makes the *declaration* mandatory via required props (a new chip without a decision is a wide-tsc error), but a wrong value choice at a call site is adjudicated by review, not tests.

## Gates

- `pnpm run typecheck` (tsconfig.ci.json): clean.
- Wide `tsc -p tsconfig.app.json` vs matched base worktree at 2e5abdb1 with real node_modules: **2323 = 2323**, normalised multiset diff EMPTY (zero new errors set-wise).
- `npx vitest run --changed origin/staging`: **1780 passed | 31 skipped**, 0 failed.
- Lint touched files: **0 errors** (25 warnings, all pre-existing patterns on untouched lines).
- ci-guards (exact commands: `pnpm run ci:guard:{sandbox,flags,zustand,duplicates,ds}` = `node tools/ci-guards/check-{gotosandbox,flags-drift,zustand-selectors,duplicates,ds-compliance}.mjs`, run in this tree AND in a pristine worktree at base 2e5abdb1): duplicates PASS, ds PASS (Δ+0 vs baseline), flags WARN (pre-existing missing-from-UI list, unrelated). **sandbox + zustand FAIL byte-identically on the pristine base — pre-existing, not introduced here. Precision on where those reds live:**
  - `ci:guard:zustand` ("React 185 guard") **IS an enforced step in `.github/workflows/ci.yml`** — but `ci.yml` triggers on push/PR to **`main` only**. Staging pushes/PRs run `staging-full-tests.yml` + `contract-validation.yml`, neither of which runs any guard. So this is **not a live CI red on staging today, but a landmine on the staging→main promotion path**: the next main-bound run will fail on it. Offending files (all pre-dating this branch): `src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts`, `src/canvas/hooks/usePreAnalysisData.ts`, `src/canvas/hooks/usePreRunValidation.ts` (zustand/shallow imports), `src/canvas/edges/StyledEdge.tsx` (object selector + shallow pattern). **Filed as a broken-alarm finding — needs its own fix lane before any staging→main promotion.**
  - `ci:guard:sandbox` (check-gotosandbox.mjs) is referenced in **no workflow** — a local-only extra (part of the local `ci:all` aggregate). Red on: `e2e/sandbox.spec.ts`, `e2e/scenarios-sharelink.spec.ts`, `e2e/smoke/route-transitions.spec.ts`. Lower urgency, but a guard that is red-by-default trains people to ignore it (broken-alarm class) — fix or retire.

## Salvage record

Carried forward from the killed `claude-ui/spark-intent-metadata` lane (verified line-by-line, not trusted): the registry/type redesign (`SparkPrompt`), all spark call-site rewires, all 25 NodeChip call sites, `buildChipMeta`, `KNOWN_ACTION_TYPES` derivation, and both contract specs. **Completed in this session:** rebase onto 2e5abdb1 (predecessor base 8007d03d; hand-applied around #391's `useConversation.ts` changes), the `dispatchAction` wiring itself (missing in the salvage — caught by wide tsc, now test-pinned), `toLegacyChipMetadata` (V4 wire requires `action_type`; identity-only meta is V5-only), the publication gate (sanitise-before-promotion) + `PENDING_WIRE_ACTION_TYPES` staging mechanism per the orchestrator's sequencing ruling, gate contract tests, the hook seam pin, RED-first + all five mutation checks, and all gates.

Coordination: A1's CEE half (round-1 process-meta guard + chip-intent routing) lands independently; this PR is safe with or without it. `useConversation.ts` changes here avoid the V5 error region another lane is editing (rebased over #391/#392 cleanly).

**Draft — do not merge** (per lane instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
