### PR TITLE
fix(contracts): re-sync CEE mirror from derived schema + revive the cross-service gate

### DIFF
--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -4,9 +4,20 @@
 # the CEE orchestrator's boundary schemas. Catches shape mismatches at
 # CI-time instead of staging.
 #
-# Schema source: CEE repo exports JSON Schema files. This workflow checks
-# out the CEE repo's contracts/ directory and copies them locally before
-# running the contract test suite.
+# Schema source: CEE repo (Talchain/olumi-assistants-service, public) exports
+# JSON Schema files in contracts/. This workflow checks out CEE's STAGING tip
+# (the integration branch — CEE's default branch `main` is stale and has no
+# contracts/ directory), strict-syncs the schemas over contracts/cee/, and runs
+# the contract suite against the REAL schemas.
+#
+# FAILURE POSTURE (deliberate — 2026-07-20): the checkout and sync steps FAIL
+# THE JOB on any error. The previous version checked out a non-existent org
+# (Olumi/…, 404) under continue-on-error and silently fell back to the
+# committed mirror for the gate's entire life — a cross-service gate that never
+# saw the other service. No silent fallback path remains. Mirror drift against
+# the fetched tip is reported as a loud warning annotation (not a failure:
+# CEE moving first is the normal cross-repo flow, and breaking drift already
+# fails via the tests, which run against the fetched schemas).
 
 name: Contract Validation
 
@@ -42,18 +53,20 @@ jobs:
       - name: Checkout UI repo
         uses: actions/checkout@v4
 
-      # Attempt to fetch CEE contracts from the CEE repo.
-      # If the CEE repo isn't accessible (private repo, no token), fall back
-      # to the reference copies committed in contracts/cee/.
-      - name: Checkout CEE contracts (optional)
+      # Fetch CEE contracts from the real CEE repo (public — no token needed).
+      # ref: staging is required: CEE's default branch is stale and carries no
+      # contracts/ directory, so an unpinned checkout would "succeed" and then
+      # silently exercise nothing. No continue-on-error: a failed checkout
+      # fails the gate.
+      - name: Checkout CEE contracts (Talchain/olumi-assistants-service@staging)
         uses: actions/checkout@v4
         with:
-          repository: Olumi/olumi-assistants-service
+          repository: Talchain/olumi-assistants-service
+          ref: staging
           path: cee-repo
           sparse-checkout: |
             contracts/
             schemas/
-        continue-on-error: true
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -81,19 +94,27 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
 
-      - name: Sync CEE contracts (strict when CEE repo available)
+      # Strict, always: every expected schema must be present in the CEE
+      # checkout or the job fails. The old "using committed reference schemas"
+      # fallback is deliberately GONE — it was the silent path that masked the
+      # dead checkout.
+      - name: Sync CEE contracts (strict — no fallback)
         run: |
-          if [ -d "cee-repo/contracts" ] || [ -d "cee-repo/schemas" ]; then
-            CEE_REPO_PATH=./cee-repo STRICT_CONTRACTS=1 bash scripts/fetch-cee-contracts.sh
+          echo "CEE source: $(git -C cee-repo rev-parse HEAD)"
+          CEE_REPO_PATH=./cee-repo STRICT_CONTRACTS=1 bash scripts/fetch-cee-contracts.sh
+
+      # The tests below run against the FETCHED schemas (the sync overwrote
+      # contracts/cee/). If the committed mirror has drifted from CEE's staging
+      # tip, local runs and CI are validating different bytes — surface that
+      # loudly on the run/PR, but do not fail: breaking drift already fails via
+      # the tests; benign drift needs a visible prompt to re-sync the mirror.
+      - name: Report committed-mirror drift (loud, non-blocking)
+        run: |
+          if git diff --quiet -- contracts/cee/; then
+            echo "Committed mirror matches CEE staging tip."
           else
-            echo "CEE repo not available — using committed reference schemas"
-            echo "Verifying all 6 expected schemas are present..."
-            actual=$(ls contracts/cee/*.json 2>/dev/null | wc -l | tr -d ' ')
-            if [ "$actual" -ne 6 ]; then
-              echo "ERROR: Expected 6 schemas in contracts/cee/, found $actual"
-              exit 1
-            fi
-            echo "All 6 reference schemas present."
+            echo "::warning title=CEE contract mirror drift::contracts/cee/ no longer matches Talchain/olumi-assistants-service@staging ($(git -C cee-repo rev-parse --short HEAD)). Tests in this job run against the FETCHED schemas; local runs use the committed mirror. Re-sync via scripts/fetch-cee-contracts.sh and update contracts/cee/README.md."
+            git --no-pager diff --stat -- contracts/cee/
           fi
 
       - name: Run contract tests

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -27,8 +27,12 @@ CEE_REPO_PATH=../olumi-assistants-service bash scripts/fetch-cee-contracts.sh
 ```
 
 If the CEE repo doesn't yet export a `contracts/` directory, the script
-will look for `schemas/` as a fallback. Missing schemas are skipped —
-the committed reference copies in this directory are used instead.
+will look for `schemas/` as a fallback. In local (permissive) mode, missing
+schemas are skipped with a warning and the committed reference copies in
+`cee/` are used instead; in CI the sync is strict and any missing schema
+fails the job. Provenance of the committed copies (source repo/branch/SHA and
+what each file derives from) is recorded in [`cee/README.md`](cee/README.md) —
+update it whenever you re-sync.
 
 ## Running contract tests
 
@@ -50,7 +54,11 @@ npx vitest run tests/contracts/
 The `Contract Validation` workflow (`.github/workflows/contract-validation.yml`)
 runs on every push/PR to staging and main:
 
-1. Optionally fetches latest CEE contracts from the CEE repo
-2. Falls back to committed reference schemas if CEE repo is unavailable
-3. Runs all contract tests
-4. Fails the build if any payload mismatch is detected
+1. Checks out `Talchain/olumi-assistants-service@staging` — a failed checkout
+   **fails the job** (no silent fallback; the pre-2026-07-20 version silently
+   fell back to the committed mirror for the gate's entire life)
+2. Strict-syncs CEE's exported schemas over `contracts/cee/`
+3. Emits a loud warning annotation if the committed mirror has drifted from
+   CEE's staging tip (non-blocking — breaking drift fails via the tests)
+4. Runs all contract tests against the fetched (real) schemas
+5. Fails the build if any payload mismatch is detected

--- a/contracts/cee/README.md
+++ b/contracts/cee/README.md
@@ -1,0 +1,43 @@
+# CEE contract mirror — provenance
+
+The `*.schema.json` files in this directory are **byte-for-byte copies of CEE's
+exported contract schemas**. Do not hand-edit them — re-sync instead:
+
+```bash
+CEE_REPO_PATH=../olumi-assistants-service bash scripts/fetch-cee-contracts.sh
+```
+
+Keeping them byte-identical to CEE's export matters: the CI gate
+(`.github/workflows/contract-validation.yml`) fetches the live schemas from
+CEE's `staging` tip on every run and reports any drift between that tip and
+these committed copies.
+
+## Current sync
+
+| | |
+|---|---|
+| Source repo | `Talchain/olumi-assistants-service` |
+| Source branch | `staging` |
+| Source commit | `53b817b6dfc9846049250b67c02352b7008dec34` |
+| Synced | 2026-07-20 |
+| Notable | Includes CEE #574 (`6a6e427e`): envelope stage vocabulary now DERIVED from the canonical `@talchain/schemas` `Stage` (`frame · analyse · decide · review`); retired `ideate`/`evaluate`/`optimise` gone from the response schema. |
+
+## Provenance caveats (verified 2026-07-20 at the source commit above)
+
+- CEE generates these files with `scripts/export-schemas.ts` (zod-to-json-schema
+  over the source Zod schemas).
+- **Output schemas** (`orchestrator-response-v2`, `stream-event`) derive from
+  CEE's V2 contract-test surface (`response-envelope-schema.ts`,
+  `stream-events.ts`). The live `/orchestrate/v2/turn` boundary itself validates
+  with `@talchain/schemas/boundary`.
+- **Input schemas** (`turn-request`, `system-event`, `analysis-state`,
+  `graph-state`) derive from `src/orchestrator/route-schemas.ts`, which guards
+  **`POST /orchestrate/v1/turn` — a surface that returns 410 on live deploys**
+  (V4 disabled). They describe the legacy request surface, not the live V5
+  payload shape. CEE's own #574 commit records the same caveat for
+  `turn-request.schema.json` ("still carries the retired vocabulary — it
+  derives from the V1 request schema … behind the /orchestrate/v1/turn 410").
+- `stream-event.schema.json` `turn_start.stage` is still an untyped bare string
+  (`minLength: 1`, no enum) — the KNOWN GAP tripwire in
+  `tests/contracts/response-envelope-contract.test.ts` pins this and fails loud
+  if CEE ever tightens it.

--- a/contracts/cee/analysis-state.schema.json
+++ b/contracts/cee/analysis-state.schema.json
@@ -1,28 +1,32 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://olumi.ai/contracts/cee/analysis-state.v1.json",
-  "title": "CEE Analysis State",
-  "description": "Shape of analysis_state included in post-analysis turn requests. V2 fields (option_comparison, robustness, drivers, etc.) live at top level.",
-  "type": "object",
-  "required": ["analysis_status", "meta"],
-  "properties": {
-    "analysis_status": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Status of the analysis run (e.g. 'complete', 'computed')"
-    },
-    "meta": {
-      "type": "object",
-      "required": ["response_hash"],
-      "properties": {
-        "response_hash": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Hash identifying the analysis run result"
+  "$ref": "#/definitions/AnalysisStateSchema",
+  "definitions": {
+    "AnalysisStateSchema": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "meta": {
+              "type": "object",
+              "properties": {
+                "response_hash": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "response_hash"
+              ],
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "null"
         }
-      },
-      "additionalProperties": true
+      ]
     }
   },
-  "additionalProperties": true
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/contracts/cee/graph-state.schema.json
+++ b/contracts/cee/graph-state.schema.json
@@ -1,74 +1,61 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://olumi.ai/contracts/cee/graph-state.v1.json",
-  "title": "CEE Graph State",
-  "description": "Graph state payload sent with turn requests. Contains V3-format nodes and edges.",
-  "type": "object",
-  "required": ["nodes", "edges"],
-  "properties": {
-    "nodes": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["id", "kind", "label"],
-        "properties": {
-          "id": { "type": "string" },
-          "kind": {
-            "type": "string",
-            "enum": ["goal", "factor", "outcome", "decision", "risk", "action", "option"]
-          },
-          "label": { "type": "string" },
-          "description": { "type": "string" },
-          "observed_state": {
-            "type": "object",
-            "required": ["value"],
-            "properties": {
-              "value": { "type": "number" },
-              "baseline": { "type": "number" },
-              "unit": { "type": "string" },
-              "source": { "type": "string" },
-              "raw_value": { "type": "number" },
-              "cap": { "type": "number" }
+  "$ref": "#/definitions/GraphSchema",
+  "definitions": {
+    "GraphSchema": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "nodes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "kind"
+                ],
+                "additionalProperties": true
+              }
             },
-            "additionalProperties": true
-          },
-          "category": {
-            "type": "string",
-            "enum": ["controllable", "observable", "external"]
-          }
-        },
-        "additionalProperties": true
-      }
-    },
-    "edges": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["from", "to"],
-        "properties": {
-          "from": { "type": "string" },
-          "to": { "type": "string" },
-          "strength": {
-            "type": "object",
-            "required": ["mean"],
-            "properties": {
-              "mean": { "type": "number" },
-              "std": { "type": "number" }
+            "edges": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from",
+                  "to"
+                ],
+                "additionalProperties": true
+              }
             }
           },
-          "exists_probability": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1
-          },
-          "effect_direction": {
-            "type": "string",
-            "enum": ["positive", "negative"]
-          }
+          "required": [
+            "nodes",
+            "edges"
+          ],
+          "additionalProperties": true
         },
-        "additionalProperties": true
-      }
+        {
+          "type": "null"
+        }
+      ]
     }
   },
-  "additionalProperties": false
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/contracts/cee/orchestrator-response-v2.schema.json
+++ b/contracts/cee/orchestrator-response-v2.schema.json
@@ -1,117 +1,524 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://olumi.ai/contracts/cee/orchestrator-response-v2.json",
-  "title": "OrchestratorResponseEnvelopeV2",
-  "description": "Response envelope returned by CEE orchestrator. Consumed by the UI's handleEnvelope().",
-  "type": "object",
-  "required": ["assistant_text"],
-  "properties": {
-    "assistant_text": {
-      "type": ["string", "null"],
-      "description": "Main response text. Null on graph-only responses."
-    },
-    "blocks": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/ConversationBlock" },
-      "description": "Structured blocks (graph patches, commentary, facts, etc.)"
-    },
-    "suggested_actions": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/ActionChip" },
-      "description": "Action chips shown to the user"
-    },
-    "stage_indicator": {
-      "description": "Current scenario stage — plain string or object with stage field",
-      "oneOf": [
-        { "type": "string", "enum": ["frame", "ideate", "evaluate"] },
-        {
+  "$ref": "#/definitions/OrchestratorResponseEnvelopeV2Schema",
+  "definitions": {
+    "OrchestratorResponseEnvelopeV2Schema": {
+      "type": "object",
+      "properties": {
+        "turn_id": {
+          "type": "string"
+        },
+        "assistant_text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assistant_tool_calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "input": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "name",
+              "input"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "blocks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "block_id": {
+                "type": "string"
+              },
+              "block_type": {
+                "type": "string"
+              },
+              "data": {}
+            },
+            "required": [
+              "block_id",
+              "block_type"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "suggested_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "prompt": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "facilitator",
+                  "challenger"
+                ]
+              }
+            },
+            "required": [
+              "label",
+              "prompt",
+              "role"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "proposed_changes": {},
+        "analysis_response": {},
+        "applied_changes": {},
+        "deterministic_answer_tier": {
+          "type": "number",
+          "enum": [
+            1,
+            2,
+            3
+          ]
+        },
+        "lineage": {
           "type": "object",
-          "required": ["stage"],
           "properties": {
-            "stage": { "type": "string", "enum": ["frame", "ideate", "evaluate"] },
-            "confidence": { "type": "string" },
-            "source": { "type": "string" }
+            "context_hash": {
+              "type": "string"
+            },
+            "plan_hash": {
+              "type": "string"
+            },
+            "response_hash": {
+              "type": "string"
+            },
+            "dsk_version_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           },
+          "required": [
+            "context_hash",
+            "dsk_version_hash"
+          ],
+          "additionalProperties": false
+        },
+        "stage_indicator": {
+          "type": "object",
+          "properties": {
+            "stage": {
+              "type": "string",
+              "enum": [
+                "frame",
+                "analyse",
+                "decide",
+                "review"
+              ]
+            },
+            "substate": {
+              "type": "string"
+            },
+            "confidence": {
+              "type": "string",
+              "enum": [
+                "high",
+                "medium",
+                "low"
+              ]
+            },
+            "source": {
+              "type": "string",
+              "enum": [
+                "explicit_event",
+                "inferred"
+              ]
+            },
+            "transition": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "$ref": "#/definitions/OrchestratorResponseEnvelopeV2Schema/properties/stage_indicator/properties/stage"
+                },
+                "to": {
+                  "$ref": "#/definitions/OrchestratorResponseEnvelopeV2Schema/properties/stage_indicator/properties/stage"
+                },
+                "trigger": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "from",
+                "to",
+                "trigger"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "stage",
+            "confidence",
+            "source"
+          ],
+          "additionalProperties": false
+        },
+        "science_ledger": {
+          "type": "object",
+          "properties": {
+            "claims_used": {
+              "type": "array",
+              "items": {}
+            },
+            "techniques_used": {
+              "type": "array",
+              "items": {}
+            },
+            "scope_violations": {
+              "type": "array",
+              "items": {}
+            },
+            "phrasing_violations": {
+              "type": "array",
+              "items": {}
+            },
+            "rewrite_applied": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "claims_used",
+            "techniques_used",
+            "scope_violations",
+            "phrasing_violations",
+            "rewrite_applied"
+          ],
           "additionalProperties": true
+        },
+        "progress_marker": {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "changed_model",
+                "ran_analysis",
+                "added_evidence",
+                "committed",
+                "none"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "additionalProperties": false
+        },
+        "observability": {
+          "type": "object",
+          "properties": {
+            "triggers_fired": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "triggers_suppressed": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "intent_classification": {
+              "type": "string"
+            },
+            "specialist_contributions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "specialist_id": {
+                    "type": "string"
+                  },
+                  "recommendation": {
+                    "type": "string"
+                  },
+                  "confidence": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "specialist_id",
+                  "recommendation",
+                  "confidence"
+                ],
+                "additionalProperties": true
+              }
+            },
+            "specialist_disagreement": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "triggers_fired",
+            "triggers_suppressed",
+            "intent_classification",
+            "specialist_contributions",
+            "specialist_disagreement"
+          ],
+          "additionalProperties": false
+        },
+        "turn_plan": {
+          "type": "object",
+          "properties": {
+            "selected_tool": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "routing": {
+              "type": "string",
+              "enum": [
+                "deterministic",
+                "llm"
+              ]
+            },
+            "long_running": {
+              "type": "boolean"
+            },
+            "tool_latency_ms": {
+              "type": "number"
+            },
+            "executed_tools": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "deferred_tools": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "system_event": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "event_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "event_id"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "selected_tool",
+            "routing",
+            "long_running"
+          ],
+          "additionalProperties": true
+        },
+        "guidance_items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "item_id": {
+                "type": "string"
+              },
+              "signal_code": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              },
+              "primary_action": {
+                "type": "string"
+              },
+              "target_object": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "node",
+                      "edge",
+                      "option",
+                      "graph",
+                      "framing"
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": true
+              },
+              "valid_while": {
+                "type": "object",
+                "properties": {
+                  "stage": {
+                    "type": "string"
+                  },
+                  "max_turns": {
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "item_id",
+              "signal_code",
+              "category",
+              "source",
+              "title",
+              "primary_action"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "analysis_ready": {},
+        "analysis_status": {
+          "type": "string"
+        },
+        "status_reason": {
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "critiques": {
+          "type": "array",
+          "items": {}
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ],
+          "additionalProperties": false
+        },
+        "model_receipt": {
+          "type": "object",
+          "properties": {
+            "node_count": {
+              "type": "number"
+            },
+            "edge_count": {
+              "type": "number"
+            },
+            "option_labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "goal_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "top_insight": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "readiness_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "repairs_applied_count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "node_count",
+            "edge_count",
+            "option_labels",
+            "goal_label",
+            "top_insight",
+            "readiness_status",
+            "repairs_applied_count"
+          ],
+          "additionalProperties": true
+        },
+        "diagnostics": {
+          "type": "string"
+        },
+        "parse_warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
-      ]
-    },
-    "guidance_items": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/GuidanceItem" }
-    },
-    "client_turn_id": {
-      "type": "string",
-      "description": "Echoed client_turn_id for deduplication"
-    },
-    "analysis_response": {
-      "type": "object",
-      "description": "Full V2RunResponse when orchestrator executed run_analysis",
-      "additionalProperties": true
-    },
-    "analysis_error": {
-      "type": "object",
-      "required": ["code", "message"],
-      "properties": {
-        "code": { "type": "string" },
-        "message": { "type": "string" }
       },
-      "additionalProperties": false
-    },
-    "turn_plan": {
-      "description": "Debug/trace field — not displayed to user"
-    },
-    "proposed_changes": {
-      "type": "array"
-    },
-    "_route_metadata": {
-      "type": "object",
-      "properties": {
-        "resolved_model": { "type": ["string", "null"] },
-        "resolved_provider": { "type": ["string", "null"] }
-      },
+      "required": [
+        "turn_id",
+        "assistant_text",
+        "blocks",
+        "suggested_actions",
+        "lineage",
+        "stage_indicator",
+        "science_ledger",
+        "progress_marker",
+        "observability",
+        "turn_plan",
+        "guidance_items"
+      ],
       "additionalProperties": true
     }
   },
-  "additionalProperties": true,
-  "definitions": {
-    "ConversationBlock": {
-      "type": "object",
-      "description": "A structured block in the response. Uses block_type (CEE wire) or type (adapted).",
-      "properties": {
-        "block_type": { "type": "string" },
-        "type": { "type": "string" },
-        "block_id": { "type": "string" },
-        "data": { "type": "object", "additionalProperties": true }
-      },
-      "additionalProperties": true
-    },
-    "ActionChip": {
-      "type": "object",
-      "required": ["id", "label", "intent"],
-      "properties": {
-        "id": { "type": "string" },
-        "label": { "type": "string" },
-        "intent": { "type": "string", "enum": ["primary", "secondary", "undo"] },
-        "message": { "type": "string" }
-      },
-      "additionalProperties": false
-    },
-    "GuidanceItem": {
-      "type": "object",
-      "required": ["item_id", "signal_code", "title", "detail"],
-      "properties": {
-        "item_id": { "type": "string" },
-        "signal_code": { "type": "string" },
-        "category": { "type": "string" },
-        "source": { "type": "string" },
-        "title": { "type": "string" },
-        "detail": { "type": "string" },
-        "primary_action": { "type": "object", "additionalProperties": true },
-        "target_object": { "type": "object", "additionalProperties": true },
-        "priority": { "type": "number" }
-      },
-      "additionalProperties": true
-    }
-  }
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/contracts/cee/stream-event.schema.json
+++ b/contracts/cee/stream-event.schema.json
@@ -1,90 +1,287 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://olumi.ai/contracts/cee/stream-event.v1.json",
-  "title": "OrchestratorStreamEvent",
-  "description": "SSE stream events emitted by CEE orchestrator during turn processing.",
-  "type": "object",
-  "required": ["type", "seq"],
-  "properties": {
-    "type": {
-      "type": "string",
-      "enum": ["turn_start", "text_delta", "tool_start", "block", "tool_result", "turn_complete", "error"]
-    },
-    "seq": {
-      "type": "integer",
-      "minimum": 0
+  "$ref": "#/definitions/OrchestratorStreamEventSchema",
+  "definitions": {
+    "OrchestratorStreamEventSchema": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "turn_start"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "turn_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "routing": {
+              "type": "string",
+              "enum": [
+                "deterministic",
+                "llm"
+              ]
+            },
+            "stage": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "turn_id",
+            "routing",
+            "stage"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "text_delta"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "delta": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "delta"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "tool_start"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "tool_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "long_running": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "tool_name",
+            "long_running"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "progress"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "tool_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "elapsed_ms": {
+              "type": "number",
+              "minimum": 0
+            },
+            "message": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "tool_name",
+            "elapsed_ms",
+            "message"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "block"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "block": {
+              "type": "object",
+              "properties": {
+                "block_type": {
+                  "type": "string"
+                },
+                "data": {}
+              },
+              "required": [
+                "block_type"
+              ],
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "block"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "tool_result"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "tool_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "success": {
+              "type": "boolean"
+            },
+            "duration_ms": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "tool_name",
+            "success"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "turn_complete"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "envelope": {
+              "type": "object",
+              "properties": {
+                "turn_id": {
+                  "type": "string"
+                },
+                "assistant_text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blocks": {
+                  "type": "array",
+                  "items": {}
+                },
+                "lineage": {
+                  "type": "object",
+                  "properties": {
+                    "context_hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "context_hash"
+                  ],
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "turn_id",
+                "assistant_text",
+                "blocks",
+                "lineage"
+              ],
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "envelope"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "error"
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "error": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "code",
+                "message"
+              ],
+              "additionalProperties": false
+            },
+            "recoverable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type",
+            "seq",
+            "error",
+            "recoverable"
+          ],
+          "additionalProperties": false
+        }
+      ]
     }
   },
-  "oneOf": [
-    {
-      "title": "TurnStart",
-      "properties": {
-        "type": { "const": "turn_start" },
-        "turn_id": { "type": "string" },
-        "routing": { "type": "string", "enum": ["deterministic", "llm"] },
-        "stage": { "type": "string" }
-      },
-      "required": ["type", "seq", "turn_id", "routing", "stage"]
-    },
-    {
-      "title": "TextDelta",
-      "properties": {
-        "type": { "const": "text_delta" },
-        "delta": { "type": "string" }
-      },
-      "required": ["type", "seq", "delta"]
-    },
-    {
-      "title": "ToolStart",
-      "properties": {
-        "type": { "const": "tool_start" },
-        "tool_name": { "type": "string" },
-        "long_running": { "type": "boolean" }
-      },
-      "required": ["type", "seq", "tool_name", "long_running"]
-    },
-    {
-      "title": "Block",
-      "properties": {
-        "type": { "const": "block" },
-        "block": { "type": "object", "additionalProperties": true }
-      },
-      "required": ["type", "seq", "block"]
-    },
-    {
-      "title": "ToolResult",
-      "properties": {
-        "type": { "const": "tool_result" },
-        "tool_name": { "type": "string" },
-        "success": { "type": "boolean" },
-        "duration_ms": { "type": "number" }
-      },
-      "required": ["type", "seq", "tool_name", "success"]
-    },
-    {
-      "title": "TurnComplete",
-      "properties": {
-        "type": { "const": "turn_complete" },
-        "envelope": { "type": "object", "additionalProperties": true }
-      },
-      "required": ["type", "seq", "envelope"]
-    },
-    {
-      "title": "Error",
-      "properties": {
-        "type": { "const": "error" },
-        "error": {
-          "type": "object",
-          "required": ["code", "message"],
-          "properties": {
-            "code": { "type": "string" },
-            "message": { "type": "string" }
-          }
-        },
-        "recoverable": { "type": "boolean" }
-      },
-      "required": ["type", "seq", "error", "recoverable"]
-    }
-  ],
-  "additionalProperties": true
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/contracts/cee/system-event.schema.json
+++ b/contracts/cee/system-event.schema.json
@@ -1,27 +1,225 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://olumi.ai/contracts/cee/system-event.v1.json",
-  "title": "CEE System Event",
-  "description": "Wire-safe system event payload sent to CEE to signal UI-side actions.",
-  "type": "object",
-  "required": ["type"],
-  "properties": {
-    "type": {
-      "type": "string",
-      "enum": [
-        "direct_graph_edit",
-        "direct_analysis_run",
-        "patch_accepted",
-        "patch_dismissed",
-        "feedback_submitted"
-      ],
-      "description": "Discriminator for the system event kind"
-    },
-    "payload": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Event-specific payload (e.g. changed_node_ids for direct_graph_edit)"
+  "$ref": "#/definitions/SystemEventSchema",
+  "definitions": {
+    "SystemEventSchema": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "type": "string",
+              "const": "patch_accepted"
+            },
+            "timestamp": {
+              "type": "string"
+            },
+            "event_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "details": {
+              "type": "object",
+              "properties": {
+                "patch_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "block_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "operations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "applied_graph_hash": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "operations"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "event_type",
+            "timestamp",
+            "event_id",
+            "details"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "type": "string",
+              "const": "patch_dismissed"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/timestamp"
+            },
+            "event_id": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/event_id"
+            },
+            "details": {
+              "type": "object",
+              "properties": {
+                "patch_id": {
+                  "type": "string"
+                },
+                "block_id": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "event_type",
+            "timestamp",
+            "event_id",
+            "details"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "type": "string",
+              "const": "direct_graph_edit"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/timestamp"
+            },
+            "event_id": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/event_id"
+            },
+            "details": {
+              "type": "object",
+              "properties": {
+                "changed_node_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "changed_edge_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "operations": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "add",
+                      "update",
+                      "remove"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "changed_node_ids",
+                "changed_edge_ids",
+                "operations"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "event_type",
+            "timestamp",
+            "event_id",
+            "details"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "type": "string",
+              "const": "direct_analysis_run"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/timestamp"
+            },
+            "event_id": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/event_id"
+            },
+            "details": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "event_type",
+            "timestamp",
+            "event_id",
+            "details"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "type": "string",
+              "const": "feedback_submitted"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/timestamp"
+            },
+            "event_id": {
+              "$ref": "#/definitions/SystemEventSchema/anyOf/0/properties/event_id"
+            },
+            "details": {
+              "type": "object",
+              "properties": {
+                "turn_id": {
+                  "type": "string"
+                },
+                "rating": {
+                  "type": "string",
+                  "enum": [
+                    "up",
+                    "down"
+                  ]
+                },
+                "comment": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "turn_id",
+                "rating"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "event_type",
+            "timestamp",
+            "event_id",
+            "details"
+          ],
+          "additionalProperties": false
+        }
+      ]
     }
   },
-  "additionalProperties": false
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/contracts/cee/turn-request.schema.json
+++ b/contracts/cee/turn-request.schema.json
@@ -1,310 +1,726 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://olumi.ai/contracts/cee/turn-request.v1.json",
-  "title": "CEE Turn Request",
-  "description": "Discriminated union of all turn request types sent by the UI to the CEE orchestrator via /bff/orchestrate/v1/turn. Per-turn forbidden-field restrictions enforced via oneOf + not.",
-  "type": "object",
-  "required": ["scenario_id", "client_turn_id", "conversation_history"],
-  "properties": {
-    "scenario_id": {
-      "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-      "description": "UUID identifying the decision scenario"
-    },
-    "client_turn_id": {
-      "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-      "description": "UUID for deduplication and correlation"
-    },
-    "conversation_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["role", "content"],
-        "properties": {
-          "role": { "type": "string" },
-          "content": { "type": "string" }
-        }
-      }
-    },
-    "message": {
-      "type": "string",
-      "description": "User message text. Required for conversation, explain, explicit_generate, system_event, clarification_response turns."
-    },
-    "graph_state": { "$ref": "#/definitions/GraphState" },
-    "selected_elements": { "$ref": "#/definitions/SelectedElements" },
-    "analysis_state": { "$ref": "#/definitions/AnalysisState" },
-    "analysis_inputs": { "$ref": "#/definitions/AnalysisInputs" },
-    "generate_model": {
-      "type": "boolean",
-      "const": true,
-      "description": "Flag for explicit_generate turns"
-    },
-    "system_event": { "$ref": "#/definitions/SystemEvent" }
-  },
-  "additionalProperties": false,
-  "oneOf": [
-    {
-      "title": "ConversationOrExplainTurn",
-      "description": "Standard conversation or explain message. Both have identical wire shapes (message + graph_state, optional selected_elements + analysis_state). Discriminated by intent, not structure.",
-      "required": ["message", "graph_state"],
-      "not": {
-        "anyOf": [
-          { "required": ["generate_model"] },
-          { "required": ["analysis_inputs"] },
-          { "required": ["system_event"] }
-        ]
-      }
-    },
-    {
-      "title": "ExplicitGenerateTurn",
-      "description": "User requests explicit model generation. Routes to CEE's deterministic draft pipeline.",
-      "required": ["message", "graph_state", "generate_model"],
-      "not": {
-        "anyOf": [
-          { "required": ["selected_elements"] },
-          { "required": ["analysis_inputs"] },
-          { "required": ["system_event"] }
-        ]
-      }
-    },
-    {
-      "title": "RunAnalysisTurn",
-      "description": "Run analysis with user-selected options via PLoT.",
-      "required": ["graph_state", "analysis_inputs"],
-      "not": {
-        "anyOf": [
-          { "required": ["message"] },
-          { "required": ["selected_elements"] },
-          { "required": ["analysis_state"] },
-          { "required": ["generate_model"] },
-          { "required": ["system_event"] }
-        ]
-      }
-    },
-    {
-      "title": "SystemEventTurn",
-      "description": "Signal CEE about graph edits, patch accept/dismiss, feedback, or direct analysis runs.",
-      "required": ["message", "graph_state", "system_event"],
-      "not": {
-        "anyOf": [
-          { "required": ["selected_elements"] },
-          { "required": ["analysis_inputs"] },
-          { "required": ["generate_model"] }
-        ]
-      }
-    },
-    {
-      "title": "PatchFollowupTurn",
-      "description": "Follow-up after graph patch applied. Graph state changed but no user message.",
-      "required": ["graph_state"],
-      "not": {
-        "anyOf": [
-          { "required": ["message"] },
-          { "required": ["selected_elements"] },
-          { "required": ["analysis_inputs"] },
-          { "required": ["generate_model"] },
-          { "required": ["system_event"] }
-        ]
-      }
-    },
-    {
-      "title": "ClarificationResponseTurn",
-      "description": "Minimal turn for answering CEE's clarification requests.",
-      "required": ["message"],
-      "not": {
-        "anyOf": [
-          { "required": ["graph_state"] },
-          { "required": ["selected_elements"] },
-          { "required": ["analysis_state"] },
-          { "required": ["analysis_inputs"] },
-          { "required": ["generate_model"] },
-          { "required": ["system_event"] }
-        ]
-      }
-    }
-  ],
+  "$ref": "#/definitions/TurnRequestSchema",
   "definitions": {
-    "GraphState": {
+    "TurnRequestSchema": {
       "type": "object",
-      "required": ["nodes", "edges"],
       "properties": {
-        "nodes": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/GraphNode" }
-        },
-        "edges": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/GraphEdge" }
-        }
-      },
-      "additionalProperties": false
-    },
-    "GraphNode": {
-      "type": "object",
-      "required": ["id", "kind", "label"],
-      "properties": {
-        "id": { "type": "string" },
-        "kind": {
+        "message": {
           "type": "string",
-          "enum": ["goal", "factor", "outcome", "decision", "risk", "action", "option"]
+          "minLength": 0,
+          "maxLength": 10000,
+          "default": ""
         },
-        "label": { "type": "string" },
-        "description": { "type": "string" },
-        "observed_state": { "$ref": "#/definitions/ObservedState" },
-        "category": {
-          "type": "string",
-          "enum": ["controllable", "observable", "external"]
-        },
-        "prior": { "type": "object" },
-        "goal_threshold": { "type": "number" },
-        "goal_threshold_raw": { "type": "number" },
-        "goal_threshold_unit": { "type": "string" },
-        "goal_threshold_cap": { "type": "number" }
-      },
-      "additionalProperties": true
-    },
-    "ObservedState": {
-      "type": "object",
-      "required": ["value"],
-      "properties": {
-        "value": { "type": "number" },
-        "baseline": { "type": "number" },
-        "unit": { "type": "string" },
-        "source": {
-          "type": "string",
-          "enum": ["brief_extraction", "cee_inference"]
-        },
-        "raw_value": { "type": "number" },
-        "cap": { "type": "number" },
-        "extractionType": {
-          "type": "string",
-          "enum": ["explicit", "inferred", "range", "observed"]
-        },
-        "factor_type": {
-          "type": "string",
-          "enum": ["cost", "price", "time", "probability", "revenue", "demand", "quality", "other"]
-        },
-        "uncertainty_drivers": {
-          "type": "array",
-          "items": { "type": "string" },
-          "maxItems": 2
-        }
-      },
-      "additionalProperties": true
-    },
-    "GraphEdge": {
-      "type": "object",
-      "required": ["from", "to"],
-      "properties": {
-        "from": { "type": "string" },
-        "to": { "type": "string" },
-        "strength": {
+        "context": {
           "type": "object",
-          "required": ["mean"],
           "properties": {
-            "mean": { "type": "number" },
-            "std": { "type": "number" }
-          }
-        },
-        "exists_probability": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
-        },
-        "effect_direction": {
-          "type": "string",
-          "enum": ["positive", "negative"]
-        },
-        "origin": { "type": "string" },
-        "edge_type": {
-          "type": "string",
-          "enum": ["directed", "bidirected"]
-        }
-      },
-      "additionalProperties": true
-    },
-    "SelectedElements": {
-      "type": "object",
-      "properties": {
-        "node_ids": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "edge_ids": {
-          "type": "array",
-          "items": { "type": "string" }
-        }
-      },
-      "additionalProperties": false
-    },
-    "AnalysisState": {
-      "type": "object",
-      "required": ["analysis_status", "meta"],
-      "properties": {
-        "analysis_status": {
-          "type": "string",
-          "minLength": 1
-        },
-        "meta": {
-          "type": "object",
-          "required": ["response_hash"],
-          "properties": {
-            "response_hash": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "additionalProperties": true
-        }
-      },
-      "additionalProperties": true
-    },
-    "AnalysisInputs": {
-      "type": "object",
-      "required": ["options", "goal_node_id"],
-      "properties": {
-        "options": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["id", "option_id", "label", "interventions"],
-            "properties": {
-              "id": { "type": "string" },
-              "option_id": { "type": "string" },
-              "label": { "type": "string" },
-              "interventions": {
+            "graph": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "nodes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "kind"
+                        ],
+                        "additionalProperties": true
+                      }
+                    },
+                    "edges": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "from": {
+                            "type": "string"
+                          },
+                          "to": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "from",
+                          "to"
+                        ],
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "nodes",
+                    "edges"
+                  ],
+                  "additionalProperties": true
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "analysis_response": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "analysis_status": {
+                      "type": "string"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "response_hash": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "response_hash"
+                      ],
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "framing": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "stage": {
+                      "type": "string",
+                      "enum": [
+                        "frame",
+                        "ideate",
+                        "evaluate",
+                        "decide",
+                        "optimise"
+                      ]
+                    },
+                    "goal": {
+                      "type": "string"
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 200
+                      },
+                      "maxItems": 20
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 200
+                      },
+                      "maxItems": 20
+                    }
+                  },
+                  "required": [
+                    "stage"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "messages": {
+              "type": "array",
+              "items": {
                 "type": "object",
-                "additionalProperties": true
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "user",
+                      "assistant"
+                    ]
+                  },
+                  "content": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "tool_calls": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "input": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "input"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "assistant_tool_calls": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/TurnRequestSchema/properties/context/properties/messages/items/properties/tool_calls/items"
+                    }
+                  }
+                },
+                "required": [
+                  "role"
+                ],
+                "additionalProperties": false
               }
             },
-            "additionalProperties": true
-          }
+            "event_log_summary": {
+              "type": "string"
+            },
+            "selected_elements": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "node_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "edge_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "scenario_id": {
+              "type": "string"
+            },
+            "analysis_inputs": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "interventions": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "option_id": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "interventions",
+                              "option_id"
+                            ],
+                            "additionalProperties": true
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "$ref": "#/definitions/TurnRequestSchema/properties/context/properties/analysis_inputs/anyOf/0/properties/options/items/anyOf/0/properties/label"
+                              },
+                              "interventions": {
+                                "$ref": "#/definitions/TurnRequestSchema/properties/context/properties/analysis_inputs/anyOf/0/properties/options/items/anyOf/0/properties/interventions"
+                              },
+                              "option_id": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "interventions",
+                              "id"
+                            ],
+                            "additionalProperties": true
+                          }
+                        ]
+                      }
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "seed": {
+                      "type": "number"
+                    },
+                    "n_samples": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "options"
+                  ],
+                  "additionalProperties": true
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "graph",
+            "analysis_response",
+            "framing",
+            "messages",
+            "scenario_id"
+          ],
+          "additionalProperties": false
         },
-        "goal_node_id": { "type": "string" }
-      },
-      "additionalProperties": false
-    },
-    "SystemEvent": {
-      "type": "object",
-      "required": ["type"],
-      "properties": {
-        "type": {
+        "scenario_id": {
           "type": "string",
-          "enum": [
-            "direct_graph_edit",
-            "direct_analysis_run",
-            "patch_accepted",
-            "patch_dismissed",
-            "feedback_submitted"
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "system_event": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "event_type": {
+                  "type": "string",
+                  "const": "patch_accepted"
+                },
+                "timestamp": {
+                  "type": "string"
+                },
+                "event_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "details": {
+                  "type": "object",
+                  "properties": {
+                    "patch_id": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "block_id": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "operations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "applied_graph_hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "operations"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "event_type",
+                "timestamp",
+                "event_id",
+                "details"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "event_type": {
+                  "type": "string",
+                  "const": "patch_dismissed"
+                },
+                "timestamp": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/timestamp"
+                },
+                "event_id": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/event_id"
+                },
+                "details": {
+                  "type": "object",
+                  "properties": {
+                    "patch_id": {
+                      "type": "string"
+                    },
+                    "block_id": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "event_type",
+                "timestamp",
+                "event_id",
+                "details"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "event_type": {
+                  "type": "string",
+                  "const": "direct_graph_edit"
+                },
+                "timestamp": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/timestamp"
+                },
+                "event_id": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/event_id"
+                },
+                "details": {
+                  "type": "object",
+                  "properties": {
+                    "changed_node_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "changed_edge_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "operations": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "add",
+                          "update",
+                          "remove"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "changed_node_ids",
+                    "changed_edge_ids",
+                    "operations"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "event_type",
+                "timestamp",
+                "event_id",
+                "details"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "event_type": {
+                  "type": "string",
+                  "const": "direct_analysis_run"
+                },
+                "timestamp": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/timestamp"
+                },
+                "event_id": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/event_id"
+                },
+                "details": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "event_type",
+                "timestamp",
+                "event_id",
+                "details"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "event_type": {
+                  "type": "string",
+                  "const": "feedback_submitted"
+                },
+                "timestamp": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/timestamp"
+                },
+                "event_id": {
+                  "$ref": "#/definitions/TurnRequestSchema/properties/system_event/anyOf/0/properties/event_id"
+                },
+                "details": {
+                  "type": "object",
+                  "properties": {
+                    "turn_id": {
+                      "type": "string"
+                    },
+                    "rating": {
+                      "type": "string",
+                      "enum": [
+                        "up",
+                        "down"
+                      ]
+                    },
+                    "comment": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "turn_id",
+                    "rating"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "event_type",
+                "timestamp",
+                "event_id",
+                "details"
+              ],
+              "additionalProperties": false
+            }
           ]
         },
-        "payload": {
+        "client_turn_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "turn_nonce": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "graph_state": {
+          "$ref": "#/definitions/TurnRequestSchema/properties/context/properties/graph"
+        },
+        "analysis_state": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "response_hash": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": [
+                    "response_hash"
+                  ],
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "conversation_history": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TurnRequestSchema/properties/context/properties/messages/items"
+          }
+        },
+        "analysis_inputs": {
+          "$ref": "#/definitions/TurnRequestSchema/properties/context/properties/analysis_inputs"
+        },
+        "generate_model": {
+          "type": "boolean",
+          "default": false
+        },
+        "explicit_generate": {
+          "type": "boolean"
+        },
+        "session_state": {
           "type": "object",
-          "additionalProperties": true
+          "properties": {
+            "prediction": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "calibrations_provided": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "plays_fired": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "questions_asked": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "accepted_patches": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "dismissed_patches": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "last_chip_ids_shown": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "chip_ids_shown_prev_turn": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "chip_ids_clicked": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "last_question_turn": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "preferred_option": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "convergence_signal": {
+              "type": "string",
+              "enum": [
+                "exploring",
+                "narrowing",
+                "converging"
+              ]
+            },
+            "analysis_graph_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "analysis_scenario_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "prior_analysis_envelope": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": true
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "chip_metadata": {
+          "type": "object",
+          "properties": {
+            "action_type": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            },
+            "parameters": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          },
+          "required": [
+            "action_type"
+          ],
+          "additionalProperties": false
         }
       },
+      "required": [
+        "scenario_id",
+        "client_turn_id"
+      ],
       "additionalProperties": false
     }
-  }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/tests/contracts/response-envelope-contract.test.ts
+++ b/tests/contracts/response-envelope-contract.test.ts
@@ -10,10 +10,10 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 
 // The canonical wire stage vocabulary — single source of truth. Exactly
-// frame | analyse | decide | review (British `analyse`). The committed CEE
-// JSON-schema mirror below diverges from this (see the "KNOWN DEFECT" tests
-// at the end of the response-envelope block); assert stage VALUES against
-// this enum, not against the drifted mirror.
+// frame | analyse | decide | review (British `analyse`). Since the 2026-07-20
+// re-sync (CEE #574 derives the export from this same Stage) the committed
+// mirror AGREES with it — the "MIRROR CANONICAL" test at the end of the
+// response-envelope block pins that agreement and fails loud on any new drift.
 import { Stage } from '@talchain/schemas/boundary'
 
 import responseSchema from '../../contracts/cee/orchestrator-response-v2.schema.json'
@@ -40,8 +40,44 @@ const validateStreamEvent = ajv.compile(streamEventSchema)
 // Representative response fixtures
 // ---------------------------------------------------------------------------
 
+/**
+ * Producer-required envelope scaffold. The re-synced CEE export (see
+ * contracts/cee/README.md for source SHA/vintage) requires eleven top-level
+ * fields on every envelope: turn_id, assistant_text, blocks, suggested_actions,
+ * lineage, stage_indicator, science_ledger, progress_marker, observability,
+ * turn_plan, guidance_items. Values below mirror CEE's own deterministic
+ * fixture shapes; per-fixture fields override the scaffold.
+ */
+const producerRequiredScaffold = {
+  turn_id: 'turn-contract-001',
+  lineage: {
+    context_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    dsk_version_hash: null,
+  },
+  science_ledger: {
+    claims_used: [],
+    techniques_used: [],
+    scope_violations: [],
+    phrasing_violations: [],
+    rewrite_applied: false,
+  },
+  progress_marker: { kind: 'none' },
+  observability: {
+    triggers_fired: [],
+    triggers_suppressed: [],
+    intent_classification: 'conversation',
+    specialist_contributions: [],
+    specialist_disagreement: null,
+  },
+  turn_plan: { selected_tool: null, routing: 'llm', long_running: false },
+  blocks: [],
+  suggested_actions: [],
+  guidance_items: [],
+}
+
 /** Success: full draft with graph patch, guidance, stage indicator */
 const successEnvelope = {
+  ...producerRequiredScaffold,
   assistant_text: null,
   blocks: [
     {
@@ -58,13 +94,19 @@ const successEnvelope = {
       },
     },
     {
+      // block_id is producer-required on every block (re-synced export)
+      block_id: 'blk_commentary_9c1d4b21',
       block_type: 'commentary',
       data: { text: "I've created an initial model based on your brief." },
     },
   ],
+  // Producer chip shape: { label, prompt, role } (re-synced export; role enum
+  // facilitator|challenger, additionalProperties: false). The UI consumption
+  // maps prompt → message (validateResponse), so these also exercise the
+  // consumption path with the real wire shape.
   suggested_actions: [
-    { id: 'chip-1', label: 'Run Analysis', intent: 'primary', message: 'Run the analysis on this model' },
-    { id: 'chip-2', label: 'Add factors', intent: 'secondary', message: 'Help me add more factors' },
+    { label: 'Run Analysis', prompt: 'Run the analysis on this model', role: 'facilitator' },
+    { label: 'Add factors', prompt: 'Help me add more factors', role: 'facilitator' },
   ],
   guidance_items: [
     {
@@ -74,23 +116,28 @@ const successEnvelope = {
       source: 'structural',
       title: 'Subscription Price has default confidence',
       detail: 'Calibrate it for more accurate results.',
-      primary_action: { type: 'open_inspector', node_id: 'fac_price' },
+      // primary_action is a STRING in the producer schema (z.string()); the
+      // target node lives in target_object.id. The previous object form
+      // ({ type, node_id }) never matched the producer.
+      primary_action: 'open_inspector',
       target_object: { type: 'node', id: 'fac_price', label: 'Subscription Price' },
       priority: 70,
     },
   ],
-  // Canonical wire stage (was 'ideate' — retired UI/DB vocab). 'frame' is the only
-  // value in the canonical enum that the drifted committed mirror also accepts, so
-  // it keeps the schema-shape assertions green without ratifying the wrong vocabulary.
+  progress_marker: { kind: 'changed_model' },
+  turn_plan: { selected_tool: 'draft_graph', routing: 'llm', long_running: false },
+  // Canonical wire stage (was 'ideate' — retired UI/DB vocab).
   stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
   client_turn_id: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
 }
 
 /** Success: analysis response with option_comparison */
 const analysisEnvelope = {
+  ...producerRequiredScaffold,
   assistant_text: 'Analysis complete. Here are your results.',
   blocks: [
     {
+      block_id: 'blk_fact_31f0aa02',
       block_type: 'fact',
       data: { label: 'Best Option', value: 'Keep at £49 (65% win probability)', source: 'analysis' },
     },
@@ -107,28 +154,34 @@ const analysisEnvelope = {
     critiques: [],
     response_hash: 'hash-abc123',
   },
-  // stage_indicator omitted deliberately. This envelope represents a completed
-  // analysis, whose canonical wire stage is 'analyse' — but the committed CEE
-  // mirror (enum [frame, ideate, evaluate]) REJECTS 'analyse', so a canonically
-  // correct value cannot be asserted valid here. Rather than tag an analysis turn
-  // with a wrong stage, drop the field (it is optional and this test exercises
-  // option_comparison, not stage). See the KNOWN DEFECT tests / cross-repo ask.
+  lineage: { ...producerRequiredScaffold.lineage, response_hash: 'hash-abc123' },
+  progress_marker: { kind: 'ran_analysis' },
+  observability: { ...producerRequiredScaffold.observability, intent_classification: 'run_analysis' },
+  turn_plan: { selected_tool: 'run_analysis', routing: 'llm', long_running: true },
+  // INTENT RESTORED (#390 note): this stage was omitted deliberately while the
+  // drifted committed mirror rejected canonical 'analyse'. The re-synced mirror
+  // accepts it, so a completed analysis now carries its true canonical stage.
+  stage_indicator: { stage: 'analyse', confidence: 'high', source: 'explicit_event' },
 }
 
 /** Error: analysis failed */
 const errorEnvelope = {
+  ...producerRequiredScaffold,
   assistant_text: null,
   analysis_error: {
     code: 'ANALYSIS_FAILED',
     message: 'Could not run analysis: graph is incomplete — add at least one factor node',
   },
+  stage_indicator: { stage: 'frame', confidence: 'medium', source: 'inferred' },
 }
 
 /** Minimal: graph-only response (assistant_text null, no chips) */
 const graphOnlyEnvelope = {
+  ...producerRequiredScaffold,
   assistant_text: null,
   blocks: [
     {
+      block_id: 'blk_graph_patch_5a77c3e0',
       block_type: 'graph_patch',
       data: {
         patch_type: 'incremental',
@@ -139,18 +192,24 @@ const graphOnlyEnvelope = {
       },
     },
   ],
+  progress_marker: { kind: 'changed_model' },
+  stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
 }
 
 /** System event ack: stage update only */
 const ackEnvelope = {
+  ...producerRequiredScaffold,
   assistant_text: 'Noted. I\'ve updated the model.',
-  // Canonical wire stage (was 'ideate'). See successEnvelope note on 'frame'.
-  stage_indicator: { stage: 'frame', confidence: 'medium', source: 'event' },
+  // Canonical wire stage (was 'ideate'). Source was 'event' — not a member of the
+  // producer's source enum [explicit_event, inferred]; an ack of a system event
+  // is an explicit_event by definition.
+  stage_indicator: { stage: 'frame', confidence: 'medium', source: 'explicit_event' },
   client_turn_id: 'deadbeef-1234-5678-abcd-ef0123456789',
 }
 
 /** Conversation with route metadata */
 const routeMetadataEnvelope = {
+  ...producerRequiredScaffold,
   assistant_text: 'Here is my analysis of the pricing decision.',
   _route_metadata: {
     resolved_model: 'claude-sonnet-4-20250514',
@@ -162,6 +221,7 @@ const routeMetadataEnvelope = {
     long_running: false,
     tool_latency_ms: 0,
   },
+  stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
 }
 
 // ---------------------------------------------------------------------------
@@ -238,20 +298,20 @@ describe('Response envelope contract', () => {
     expect(valid).toBe(true)
   })
 
-  test('canonical string stage_indicator validates', () => {
-    // 'frame' is a canonical wire member AND accepted by the committed mirror.
-    // The stage VALUE is asserted canonical against Stage (source of truth);
-    // reverting to 'evaluate' makes this Stage assertion fail (evaluate is not a
-    // canonical wire stage — it is retired UI/DB vocab).
-    const envelope = { assistant_text: 'Hello', stage_indicator: 'frame' }
+  test('bare-string stage_indicator is retired — the wire shape is object-only', () => {
+    // The pre-resync mirror allowed stage_indicator as a bare string. The
+    // producer schema (re-synced export, faithful to CEE's zod) types it as an
+    // object { stage, confidence, source } only. Pin the retirement: a
+    // string-form envelope no longer validates, while the value itself remains
+    // canonical per Stage (so this failure is about SHAPE, not vocabulary).
+    const envelope = { ...producerRequiredScaffold, assistant_text: 'Hello', stage_indicator: 'frame' }
     expect(Stage.safeParse(envelope.stage_indicator).success).toBe(true)
-    const valid = validateResponseSchema(envelope)
-    if (!valid) console.error('Validation errors:', validateResponseSchema.errors)
-    expect(valid).toBe(true)
+    expect(validateResponseSchema(envelope)).toBe(false)
   })
 
   test('canonical object stage_indicator validates', () => {
     const envelope = {
+      ...producerRequiredScaffold,
       assistant_text: 'Hello',
       stage_indicator: { stage: 'frame', confidence: 'high', source: 'inferred' },
     }
@@ -261,29 +321,40 @@ describe('Response envelope contract', () => {
     expect(valid).toBe(true)
   })
 
-  // ── KNOWN DEFECT tripwires — cross-repo ask (see PR body) ────────────────
-  // These PIN the current divergence between the canonical wire vocabulary
-  // (@talchain/schemas Stage) and the committed CEE JSON-schema mirror. They are
-  // GREEN today and FAIL LOUD the moment the mirror is corrected to canonical
-  // (re-synced from a fixed CEE export). Do not "fix" them by editing values —
-  // they are the tripwire; when they go red, the mirror has been made canonical
-  // and the fixtures above should switch to the real values (analyse/decide/review).
+  // ── MIRROR CANONICAL — flipped tripwire ──────────────────────────────────
+  // Until the 2026-07-20 re-sync this was the #390 KNOWN DEFECT tripwire: it
+  // PINNED the drifted mirror (accepts retired 'ideate', rejects canonical
+  // 'analyse') and was designed to go RED the moment the mirror was corrected.
+  // It went RED on re-syncing from CEE's derived export (CEE #574, source SHA
+  // in contracts/cee/README.md) — the design working — and is now flipped to
+  // pin the CORRECTED state. If it ever fails again, the mirror has drifted
+  // from the canonical Stage vocabulary: re-sync before touching this test.
 
-  test('KNOWN DEFECT: committed response mirror is mis-typed — rejects canonical wire values, accepts retired UI vocab', () => {
-    // The response mirror is NOT permissive — it is an enum of the WRONG set:
-    // [frame, ideate, evaluate]. It rejects canonical 'analyse' and accepts
-    // retired 'ideate'. Positive control (nonsense) confirms it is enum-typed,
-    // not a bare string.
-    const canonicalButRejected = { assistant_text: 'x', stage_indicator: 'analyse' }
-    expect(validateResponseSchema(canonicalButRejected)).toBe(false) // WRONG: 'analyse' is canonical
-    expect(Stage.safeParse('analyse').success).toBe(true)
+  test('MIRROR CANONICAL: response mirror accepts every canonical stage and rejects every retired one', () => {
+    const envelopeWithStage = (stage: string) => ({
+      ...producerRequiredScaffold,
+      assistant_text: 'x',
+      stage_indicator: { stage, confidence: 'high', source: 'inferred' },
+    })
 
-    const retiredButAccepted = { assistant_text: 'x', stage_indicator: 'ideate' }
-    expect(validateResponseSchema(retiredButAccepted)).toBe(true) // WRONG: 'ideate' is retired
-    expect(Stage.safeParse('ideate').success).toBe(false)
+    // Every canonical member — iterated from Stage.options (derive, don't
+    // hand-list; a re-hardcoded copy that later drifts would fail here).
+    for (const stage of Stage.options) {
+      const valid = validateResponseSchema(envelopeWithStage(stage))
+      if (!valid) console.error(`canonical '${stage}' rejected:`, validateResponseSchema.errors)
+      expect(valid).toBe(true)
+      expect(Stage.safeParse(stage).success).toBe(true)
+    }
 
-    const nonsense = { assistant_text: 'x', stage_indicator: 'not_a_stage_xyz' }
-    expect(validateResponseSchema(nonsense)).toBe(false) // proves the field IS enum-typed
+    // Every retired member (the historical 5-stage vocabulary minus the
+    // canonical survivors) is rejected by mirror AND source of truth.
+    for (const retired of ['ideate', 'evaluate', 'optimise']) {
+      expect(validateResponseSchema(envelopeWithStage(retired))).toBe(false)
+      expect(Stage.safeParse(retired).success).toBe(false)
+    }
+
+    // Positive control: nonsense rejected — the field is enum-typed.
+    expect(validateResponseSchema(envelopeWithStage('not_a_stage_xyz'))).toBe(false)
   })
 })
 
@@ -306,7 +377,10 @@ describe('Stream event contract', () => {
     // The stream-event mirror types `stage` as { type: 'string' } with no enum, so
     // it cannot catch a wrong stage value at all. Positive control proves it: an
     // absurd value validates. Tripwire — fails loud if `stage` is ever tightened to
-    // the canonical Stage enum. See PR body / cross-repo ask.
+    // the canonical Stage enum. RE-VERIFIED at the 2026-07-20 re-sync (source SHA
+    // in contracts/cee/README.md): CEE #574 corrected the response envelope but
+    // did NOT touch the stream schema — turn_start.stage is still z.string()
+    // (minLength 1 only), so this gap tripwire STAYS. See PR body / cross-repo ask.
     const nonsense = { type: 'turn_start', seq: 1, turn_id: 't-1', routing: 'llm', stage: 'not_a_stage_xyz' }
     expect(validateStreamEvent(nonsense)).toBe(true) // permissive — zero protection
     expect(Stage.safeParse('not_a_stage_xyz').success).toBe(false)
@@ -323,8 +397,12 @@ describe('Stream event contract', () => {
   })
 
   test('block event validates', () => {
-    const event = { type: 'block', seq: 4, block: { type: 'commentary', text: 'Insight here' } }
-    expect(validateStreamEvent(event)).toBe(true)
+    // Re-synced stream schema requires block.block_type (block.type was never
+    // the producer's field name); payload lives under data.
+    const event = { type: 'block', seq: 4, block: { block_type: 'commentary', data: { text: 'Insight here' } } }
+    const valid = validateStreamEvent(event)
+    if (!valid) console.error('Validation errors:', validateStreamEvent.errors)
+    expect(valid).toBe(true)
   })
 
   test('tool_result event validates', () => {
@@ -333,8 +411,22 @@ describe('Stream event contract', () => {
   })
 
   test('turn_complete event validates', () => {
-    const event = { type: 'turn_complete', seq: 6, envelope: { assistant_text: 'Done', blocks: [] } }
-    expect(validateStreamEvent(event)).toBe(true)
+    // Re-synced stream schema requires the nested envelope to carry turn_id,
+    // assistant_text, blocks and lineage.context_hash (a subset of the full
+    // envelope contract — the stream variant is looser than the response one).
+    const event = {
+      type: 'turn_complete',
+      seq: 6,
+      envelope: {
+        turn_id: 'turn-stream-001',
+        assistant_text: 'Done',
+        blocks: [],
+        lineage: { context_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' },
+      },
+    }
+    const valid = validateStreamEvent(event)
+    if (!valid) console.error('Validation errors:', validateStreamEvent.errors)
+    expect(valid).toBe(true)
   })
 
   test('error event validates', () => {

--- a/tests/contracts/turn-request-contract.test.ts
+++ b/tests/contracts/turn-request-contract.test.ts
@@ -4,6 +4,18 @@
  * Validates that every turn type the UI can send matches the structural
  * contract CEE expects. Uses the actual builder functions with representative
  * data — not hand-crafted minimal payloads.
+ *
+ * PROVENANCE (2026-07-20 re-sync — see contracts/cee/README.md for source SHA):
+ * CEE exports turn-request/system-event/analysis-state/graph-state from
+ * src/orchestrator/route-schemas.ts, which validates POST /orchestrate/v1/turn —
+ * a surface that returns 410 on live deploys (V4 disabled; live turns go to
+ * /orchestrate/v2/turn, validated by @talchain/schemas/boundary). These tests
+ * therefore pin the LEGACY builder surface (src/services/turn-request-builder)
+ * against CEE's CURRENT export of that same legacy surface; the live V5 payload
+ * path (src/v5/buildPayload.ts) is a different shape and is not covered here.
+ * Where the current export has diverged from what the legacy builders emit,
+ * the divergence is pinned explicitly as KNOWN DIVERGENCE below rather than
+ * papered over — see the PR body / cross-repo ask.
  */
 import { describe, test, expect } from 'vitest'
 import Ajv from 'ajv'
@@ -200,7 +212,13 @@ describe('Turn request contract', () => {
     expect(valid).toBe(true)
   })
 
-  test('conversation turn with selected_elements validates', () => {
+  test('KNOWN DIVERGENCE: builder emits selected_elements — the current CEE export no longer models it', () => {
+    // The pre-resync mirror accepted selected_elements on conversation turns.
+    // CEE's current export has no such property and rejects unknown keys
+    // (additionalProperties: false), so a selection-bearing legacy turn no
+    // longer validates. The builder still emits it (pinned below). Fails loud
+    // if CEE re-adds the field (first expect flips) or if the builder stops
+    // sending it (property assertion fails). See PR body / cross-repo ask.
     const request = wirePayload(buildConversationTurnRequest({
       scenario_id: VALID_UUID,
       conversation_history: [...conversationHistory],
@@ -209,7 +227,13 @@ describe('Turn request contract', () => {
       selected_elements: { node_ids: ['fac_price'], edge_ids: [] },
     }))
 
-    const valid = validateTurnRequest(request)
+    expect(request).toHaveProperty('selected_elements') // producer still emits it
+    expect(validateTurnRequest(request)).toBe(false) // current export rejects it
+
+    // Positive control: the rejection is exactly this field — stripping it validates.
+    const withoutSelection: Record<string, unknown> = { ...(request as Record<string, unknown>) }
+    delete withoutSelection.selected_elements
+    const valid = validateTurnRequest(withoutSelection)
     if (!valid) console.error('Validation errors:', validateTurnRequest.errors)
     expect(valid).toBe(true)
   })
@@ -291,7 +315,16 @@ describe('Turn request contract', () => {
     expect(valid).toBe(true)
   })
 
-  test('system_event turn (patch_accepted) validates against CEE schema', () => {
+  // KNOWN DIVERGENCE (system_event shape): the legacy builder wraps events as
+  // { type, payload }; CEE's current export models system_event as an anyOf of
+  // envelope-bearing variants { event_type, event_id, timestamp, details }
+  // (additionalProperties: false). A legacy-shaped system_event turn therefore
+  // no longer validates. Each test pins BOTH sides: the builder still emits the
+  // legacy shape (rejected), and the same turn with a schema-shaped event
+  // validates (positive control proving the rejection is exactly this field).
+  // Fails loud if either side moves. See PR body / cross-repo ask.
+
+  test('KNOWN DIVERGENCE: system_event turn (patch_accepted) — legacy {type,payload} rejected, schema shape accepted', () => {
     const request = wirePayload(buildSystemEventTurnRequest({
       scenario_id: VALID_UUID,
       conversation_history: [...conversationHistory],
@@ -301,12 +334,23 @@ describe('Turn request contract', () => {
     }))
 
     expect(request).toHaveProperty('system_event')
-    const valid = validateTurnRequest(request)
+    expect(validateTurnRequest(request)).toBe(false) // legacy {type,payload} shape
+
+    const schemaShaped = {
+      ...(request as Record<string, unknown>),
+      system_event: {
+        event_type: 'patch_accepted',
+        event_id: 'evt_patch_1',
+        timestamp: '2026-07-20T12:00:00Z',
+        details: { patch_id: 'blk_graph_patch_7e2a2e78', operations: [] },
+      },
+    }
+    const valid = validateTurnRequest(schemaShaped)
     if (!valid) console.error('Validation errors:', validateTurnRequest.errors)
     expect(valid).toBe(true)
   })
 
-  test('system_event turn (direct_graph_edit) validates', () => {
+  test('KNOWN DIVERGENCE: system_event turn (direct_graph_edit) — legacy {type,payload} rejected, schema shape accepted', () => {
     const request = wirePayload(buildSystemEventTurnRequest({
       scenario_id: VALID_UUID,
       conversation_history: [...conversationHistory],
@@ -315,12 +359,23 @@ describe('Turn request contract', () => {
       system_event: { type: 'direct_graph_edit', payload: { changed_node_ids: ['fac_price'] } },
     }))
 
-    const valid = validateTurnRequest(request)
+    expect(validateTurnRequest(request)).toBe(false) // legacy {type,payload} shape
+
+    const schemaShaped = {
+      ...(request as Record<string, unknown>),
+      system_event: {
+        event_type: 'direct_graph_edit',
+        event_id: 'evt_edit_1',
+        timestamp: '2026-07-20T12:00:00Z',
+        details: { changed_node_ids: ['fac_price'], changed_edge_ids: [], operations: [] },
+      },
+    }
+    const valid = validateTurnRequest(schemaShaped)
     if (!valid) console.error('Validation errors:', validateTurnRequest.errors)
     expect(valid).toBe(true)
   })
 
-  test('R11: system_event turn omits analysis_state', () => {
+  test('R11: system_event turn omits analysis_state (legacy event shape divergence pinned)', () => {
     const request = wirePayload(buildSystemEventTurnRequest({
       scenario_id: VALID_UUID,
       conversation_history: [...conversationHistory],
@@ -329,9 +384,22 @@ describe('Turn request contract', () => {
       system_event: { type: 'feedback_submitted', payload: { rating: 'positive' } },
     }))
 
+    // The R11 pin — builder behaviour, independent of the schema divergence.
     expect(request).toHaveProperty('system_event')
     expect(request).not.toHaveProperty('analysis_state')
-    const valid = validateTurnRequest(request)
+
+    expect(validateTurnRequest(request)).toBe(false) // legacy {type,payload} shape
+
+    const schemaShaped = {
+      ...(request as Record<string, unknown>),
+      system_event: {
+        event_type: 'feedback_submitted',
+        event_id: 'evt_feedback_1',
+        timestamp: '2026-07-20T12:00:00Z',
+        details: { turn_id: 'turn-1', rating: 'up' }, // rating enum: up | down
+      },
+    }
+    const valid = validateTurnRequest(schemaShaped)
     if (!valid) console.error('Validation errors:', validateTurnRequest.errors)
     expect(valid).toBe(true)
   })
@@ -380,7 +448,8 @@ describe('Turn request contract', () => {
     expect(valid).toBe(true)
   })
 
-  test('explain turn with selected_elements validates', () => {
+  test('KNOWN DIVERGENCE: explain turn with selected_elements — current CEE export rejects the field', () => {
+    // Same divergence as the conversation-turn pin above, on the explain path.
     const request = wirePayload(buildExplainTurnRequest({
       scenario_id: VALID_UUID,
       conversation_history: [...conversationHistory],
@@ -390,8 +459,13 @@ describe('Turn request contract', () => {
       analysis_state: analysisState,
     }))
 
-    expect(request).toHaveProperty('selected_elements')
-    const valid = validateTurnRequest(request)
+    expect(request).toHaveProperty('selected_elements') // producer still emits it
+    expect(validateTurnRequest(request)).toBe(false) // current export rejects it
+
+    // Positive control: stripping exactly this field validates.
+    const withoutSelection: Record<string, unknown> = { ...(request as Record<string, unknown>) }
+    delete withoutSelection.selected_elements
+    const valid = validateTurnRequest(withoutSelection)
     if (!valid) console.error('Validation errors:', validateTurnRequest.errors)
     expect(valid).toBe(true)
   })
@@ -467,18 +541,20 @@ describe('Graph state contract', () => {
 // Per-turn oneOf discrimination: forbidden field rejection
 // ---------------------------------------------------------------------------
 
-describe('Turn request schema rejects forbidden fields', () => {
-  // Note: JSON Schema oneOf matches any structurally valid variant.
-  // A payload with message + graph_state + generate_model matches ExplicitGenerateTurn.
-  // A payload with message + graph_state + system_event matches SystemEventTurn.
-  // The oneOf catches STRUCTURALLY IMPOSSIBLE combinations (e.g. a payload matching
-  // NO variant, or matching MULTIPLE variants simultaneously).
-  // Intent-level discrimination (e.g. "this was meant to be conversation but has
-  // generate_model") is enforced by the builder + _turn_type boundary validator.
+describe('Turn request schema discrimination (current export)', () => {
+  // SCHEMA MODEL CHANGE (2026-07-20 re-sync): the pre-resync mirror was a oneOf
+  // of per-turn-type variants with mutual-exclusion rules (run_analysis forbids
+  // message, etc.). CEE's CURRENT export retired the variant model: a single
+  // flat object, required = [scenario_id, client_turn_id], every other field
+  // optional, unknown keys rejected (additionalProperties: false). The
+  // exclusivity pins below are therefore FLIPPED and retitled to state what the
+  // schema now enforces — intent-level turn discrimination lives solely in the
+  // builder + _turn_type boundary validator now. Each flip is deliberate, not
+  // an appeasement: the old expectation pinned mirror-only strictness that the
+  // producer no longer exports.
 
-  test('run_analysis turn with message matches no variant (rejected)', () => {
-    // run_analysis forbids message; other variants that require message also require
-    // fields run_analysis doesn't have. This creates a true multi-variant mismatch.
+  test('VARIANT EXCLUSIVITY RETIRED: run_analysis-shaped payload with message is accepted by the current export', () => {
+    // Pre-resync: message was forbidden on run_analysis (matched no variant).
     const payload = {
       scenario_id: VALID_UUID,
       client_turn_id: VALID_UUID,
@@ -487,17 +563,11 @@ describe('Turn request schema rejects forbidden fields', () => {
       analysis_inputs: analysisInputs,
       message: 'should not be here',
     }
-    // ConversationOrExplainTurn: has analysis_inputs (forbidden)
-    // ExplicitGenerateTurn: has analysis_inputs (forbidden)
-    // RunAnalysisTurn: has message (forbidden)
-    // SystemEventTurn: no system_event (missing required)
-    // PatchFollowupTurn: has message (forbidden)
-    // ClarificationResponseTurn: has graph_state (forbidden)
-    // → matches no variant
-    expect(validateTurnRequest(payload)).toBe(false)
+    expect(validateTurnRequest(payload)).toBe(true)
   })
 
-  test('run_analysis turn with analysis_state is rejected', () => {
+  test('VARIANT EXCLUSIVITY RETIRED: run_analysis-shaped payload with analysis_state is accepted by the current export', () => {
+    // Pre-resync: analysis_state was forbidden alongside analysis_inputs.
     const payload = {
       scenario_id: VALID_UUID,
       client_turn_id: VALID_UUID,
@@ -506,14 +576,12 @@ describe('Turn request schema rejects forbidden fields', () => {
       analysis_inputs: analysisInputs,
       analysis_state: analysisState,
     }
-    // RunAnalysisTurn forbids analysis_state
-    // No other variant requires analysis_inputs
-    expect(validateTurnRequest(payload)).toBe(false)
+    expect(validateTurnRequest(payload)).toBe(true)
   })
 
-  test('clarification_response with graph_state matches ConversationOrExplainTurn (oneOf routes correctly)', () => {
-    // A payload with message + graph_state routes to ConversationOrExplainTurn, not
-    // ClarificationResponseTurn. This is correct oneOf behavior.
+  test('message + graph_state payload validates', () => {
+    // Pre-resync this pinned oneOf routing (ConversationOrExplainTurn); under
+    // the flat model it is simply a valid payload.
     const payload = {
       scenario_id: VALID_UUID,
       client_turn_id: VALID_UUID,
@@ -521,10 +589,14 @@ describe('Turn request schema rejects forbidden fields', () => {
       message: 'answer',
       graph_state: graphState,
     }
-    expect(validateTurnRequest(payload)).toBe(true) // matches ConversationOrExplainTurn
+    expect(validateTurnRequest(payload)).toBe(true)
   })
 
-  test('payload with both analysis_inputs and system_event matches no variant', () => {
+  test('malformed system_event ({type} only) is rejected', () => {
+    // Pre-resync this passed via variant exclusivity ("matches no variant").
+    // It still fails today, but for a different reason: the system_event value
+    // does not match any event variant (legacy {type} shape — see the KNOWN
+    // DIVERGENCE pins above). Kept as a negative pin on the event sub-schema.
     const payload = {
       scenario_id: VALID_UUID,
       client_turn_id: VALID_UUID,
@@ -534,11 +606,10 @@ describe('Turn request schema rejects forbidden fields', () => {
       analysis_inputs: analysisInputs,
       system_event: { type: 'direct_graph_edit' },
     }
-    // Every variant forbids at least one of these
     expect(validateTurnRequest(payload)).toBe(false)
   })
 
-  test('payload with generate_model + system_event matches no variant', () => {
+  test('generate_model with malformed system_event is rejected (event sub-schema, not exclusivity)', () => {
     const payload = {
       scenario_id: VALID_UUID,
       client_turn_id: VALID_UUID,
@@ -573,10 +644,9 @@ describe('Turn request schema rejects forbidden fields', () => {
     expect(validateTurnRequest(payload)).toBe(false)
   })
 
-  test('non-UUID scenario_id is rejected', () => {
+  test('missing client_turn_id is rejected (newly required by the current export)', () => {
     const payload = {
-      scenario_id: 'not-a-uuid',
-      client_turn_id: VALID_UUID,
+      scenario_id: VALID_UUID,
       conversation_history: [...conversationHistory],
       message: 'hello',
       graph_state: graphState,
@@ -584,13 +654,30 @@ describe('Turn request schema rejects forbidden fields', () => {
     expect(validateTurnRequest(payload)).toBe(false)
   })
 
-  test('payload with no message and no graph_state matches no variant', () => {
+  test('UUID FORMAT NOT ENFORCED: non-UUID scenario_id is accepted by the current export (length bounds only)', () => {
+    // Pre-resync the mirror enforced format: uuid and this was a rejection pin.
+    // The current export types scenario_id as a plain string (minLength 1,
+    // maxLength 200) — malformed-id rejection, if any, now happens beyond this
+    // schema. Both bounds pinned so a re-tightening fails loud here.
+    const payload = {
+      scenario_id: 'not-a-uuid',
+      client_turn_id: VALID_UUID,
+      conversation_history: [...conversationHistory],
+      message: 'hello',
+      graph_state: graphState,
+    }
+    expect(validateTurnRequest(payload)).toBe(true)
+    expect(validateTurnRequest({ ...payload, scenario_id: '' })).toBe(false) // minLength 1 still bites
+  })
+
+  test('EXCLUSIVITY RETIRED: payload with neither message nor graph_state is accepted (only scenario_id + client_turn_id required)', () => {
+    // Pre-resync: matched no variant. The flat model has no such floor.
     const payload = {
       scenario_id: VALID_UUID,
       client_turn_id: VALID_UUID,
       conversation_history: [...conversationHistory],
     }
-    expect(validateTurnRequest(payload)).toBe(false)
+    expect(validateTurnRequest(payload)).toBe(true)
   })
 })
 
@@ -768,17 +855,41 @@ describe('RF → CEE node/edge transform contract', () => {
 })
 
 describe('System event contract', () => {
-  test('all wire event types validate', () => {
-    const types = ['direct_graph_edit', 'direct_analysis_run', 'patch_accepted', 'patch_dismissed', 'feedback_submitted'] as const
-    for (const type of types) {
-      const event = { type, payload: {} }
+  // SCHEMA MODEL CHANGE (2026-07-20 re-sync): the standalone SystemEventSchema
+  // export is now an anyOf of five { event_type, event_id, timestamp, details }
+  // variants (additionalProperties: false) — not the legacy { type, payload }
+  // wrapper the UI's legacy builder emits. Minimal valid details per variant
+  // are taken from the export's own required lists.
+
+  test('all wire event types validate (schema-shaped)', () => {
+    const events = [
+      { event_type: 'patch_accepted', details: { operations: [] } },
+      { event_type: 'patch_dismissed', details: {} },
+      { event_type: 'direct_graph_edit', details: { changed_node_ids: [], changed_edge_ids: [], operations: [] } },
+      { event_type: 'direct_analysis_run', details: {} },
+      { event_type: 'feedback_submitted', details: { turn_id: 'turn-1', rating: 'up' } }, // rating enum: up | down
+    ]
+    for (const partial of events) {
+      const event = { event_id: `evt_${partial.event_type}`, timestamp: '2026-07-20T12:00:00Z', ...partial }
       const valid = validateSystemEvent(event)
-      if (!valid) console.error(`${type} failed:`, validateSystemEvent.errors)
+      if (!valid) console.error(`${partial.event_type} failed:`, validateSystemEvent.errors)
       expect(valid).toBe(true)
     }
   })
 
+  test('KNOWN DIVERGENCE: legacy {type,payload} event shape no longer validates', () => {
+    // The legacy builder wraps events as { type, payload } — pinned rejected
+    // against the current export. Goes red if CEE restores the legacy shape.
+    expect(validateSystemEvent({ type: 'patch_accepted', payload: {} })).toBe(false)
+  })
+
   test('unknown event type fails', () => {
-    expect(validateSystemEvent({ type: 'unknown_event' })).toBe(false)
+    const event = {
+      event_type: 'unknown_event',
+      event_id: 'evt_unknown',
+      timestamp: '2026-07-20T12:00:00Z',
+      details: {},
+    }
+    expect(validateSystemEvent(event)).toBe(false)
   })
 })


### PR DESCRIPTION
Sequenced behind CEE #574 (merged + deploy-confirmed): CEE's exported contract JSON now DERIVES its stage vocabulary from canonical `Stage`. This PR does the three-part repair that was deliberately held behind that signal — re-sync the stale mirror, fix the dead cross-service CI gate, uplift the fixtures the real schema enforces. One PR, not three, because re-pointing the gate at the real schema cascades into the fixtures.

## 1 · CEE source — verified at the bytes, not trusted from the message

- **Source: `Talchain/olumi-assistants-service` @ `staging` tip `53b817b6dfc9846049250b67c02352b7008dec34`** (contains #574 merge `6a6e427e785dd421fb2ec60218d622f12734bb8f`; the contract file is unchanged between #574 and tip — verified with `git log 6a6e427e..HEAD -- contracts/orchestrator-response-v2.schema.json` → empty).
- `stage_indicator.stage` enum is exactly `["frame","analyse","decide","review"]`; `transition.from`/`to` `$ref` the same single enum (all three sites derive). `optimise` dropped, retired members gone.
- Absence claim: `/usr/bin/grep -c 'ideate\|evaluate\|optimise' contracts/orchestrator-response-v2.schema.json` → **0** over the whole file at that SHA.
- All six schemas re-synced **byte-for-byte** (the CI drift check depends on byte identity). Provenance + vintage recorded in **`contracts/cee/README.md`**.
- ⚠️ Provenance caveat carried into that README: the four INPUT schemas (`turn-request`, `system-event`, `analysis-state`, `graph-state`) derive from CEE's `route-schemas.ts`, which guards **`POST /orchestrate/v1/turn` — 410 on live deploys** (verified: `route.ts:88-110` returns the 410 before parse; live V2 validates via `@talchain/schemas/boundary` in `validators/b1.ts`). CEE's own #574 commit records the same caveat. The turn-request tests pin the legacy-builder↔legacy-export pairing honestly (below) rather than pretending it is the live wire.

## 2 · Tripwire outcomes — the RED before the flip

Baseline on clean `origin/staging` (`2e5abdb1`): `tests/contracts` **113/113 green**.

After copying the six CEE files (no other change): **21 failed | 92 passed**, including exactly the #390 tripwire:

```
FAIL  Response envelope contract > KNOWN DEFECT: committed response mirror is mis-typed —
      rejects canonical wire values, accepts retired UI vocab
  ❯ response-envelope-contract.test.ts:282  expect(validateResponseSchema(retiredButAccepted)).toBe(true)
```
— the corrected mirror now rejects `ideate`: **the tripwire went RED on correction, exactly as designed.**

- **Tripwire (1) FLIPPED** → `MIRROR CANONICAL`: accepts every member **iterated from `Stage.options`** (derive, don't hand-list), rejects every retired member (`ideate`/`evaluate`/`optimise`), nonsense positive control. Fails loud on any NEW drift.
- **Tripwire (2) STAYS**: re-verified at `53b817b6` — #574 did **not** touch the stream schema; `turn_start.stage` is still `z.string()` (`minLength: 1`, no enum). The KNOWN GAP test remains, comment updated with the re-verification.
- New shape pin: bare-string `stage_indicator` is retired (producer schema is object-only) — pinned as a rejection with the value still canonical per `Stage`, so the failure is provably about shape, not vocabulary.

## 3 · CI failure posture — decision + why

`contract-validation.yml` changes:
- `repository: Olumi/…` → **`Talchain/olumi-assistants-service`** (the 404 that killed the gate).
- **`ref: staging` pinned** — discovered during verification: CEE's default branch `main` is stale (2026-01-20) and has **no `contracts/` directory at all**, so an org-only fix would have "succeeded" into the very same silent fallback.
- **`continue-on-error` REMOVED; the silent committed-fallback branch DELETED.** Posture chosen: **checkout/sync failure fails the job.** The repo is public (verified via unauthenticated API: `private: false`), so no token is needed — no auth caveat applies.
- **Loud, non-blocking drift step**: after the strict sync overwrites `contracts/cee/`, `git diff --quiet` against the committed mirror; drift emits a `::warning::` annotation naming the fetched CEE SHA + diff stat. Deliberately not a failure: CEE moving first is the normal cross-repo flow, and **breaking** drift already fails via the tests (which run against the fetched real schemas). A hard fail on every benign CEE schema change would manufacture a red everyone learns to ignore — the exact broken-alarm class this PR removes.
- Sync step logs the fetched CEE SHA (`git -C cee-repo rev-parse HEAD`) on every run.

Workflow triggers on `pull_request: [staging]`, so **this PR runs the revived gate itself** — I could not observe the run from this session (draft freshly pushed); check the PR's checks tab for `CEE Contract Validation`, which now must fetch the real repo or fail.

## 4 · Fixture changes — each with its intent note (#390's table respected)

**Response envelope** (`response-envelope-contract.test.ts`):
- New `producerRequiredScaffold`: the export now requires eleven top-level fields (`turn_id`, `assistant_text`, `blocks`, `suggested_actions`, `lineage`, `stage_indicator`, `science_ledger`, `progress_marker`, `observability`, `turn_plan`, `guidance_items`) — values mirror CEE's own deterministic fixture; every envelope fixture spreads it.
- `analysisEnvelope`: **intent RESTORED** — #390 dropped `stage_indicator` only because the drifted mirror rejected canonical `analyse`; it now carries `{stage:'analyse', confidence:'high', source:'explicit_event'}`.
- `ackEnvelope`: `source:'event'` → `'explicit_event'` (never a member of the producer enum `[explicit_event, inferred]`).
- Chips → producer shape `{label, prompt, role}` (UI consumption already maps `prompt`→`message`, so `validateResponse` still passes with 0 repairs — the consumption tests now exercise the real wire shape).
- `guidance_items.primary_action` → string (`z.string()` in CEE's zod; the old object form never matched the producer).
- Missing `block_id`s added (producer-required per block).
- Stream: `block` event uses `block.block_type` + `data`; `turn_complete.envelope` carries its required subset (`turn_id`, `assistant_text`, `blocks`, `lineage.context_hash`).

**Turn request** (`turn-request-contract.test.ts`) — pinned honestly, **not padded**:
- `selected_elements` (conversation + explain): builder still emits it; current export rejects unknown keys → **KNOWN DIVERGENCE** pins both sides, with a strip-the-field positive control proving the rejection is exactly that field.
- `system_event` turns (3 tests): legacy builder shape `{type, payload}` vs export's `{event_type, event_id, timestamp, details}` anyOf → KNOWN DIVERGENCE pins (legacy rejected) + schema-shaped positive controls (accepted). R11's omits-analysis_state builder pin preserved.
- Variant-exclusivity tests: the export **retired the oneOf variant model** (single flat object; required = `scenario_id` + `client_turn_id` only) — four expectations flipped **with retitles stating what the schema now enforces** (deliberate, not appeasement: the old pins asserted mirror-only strictness the producer no longer exports). `not_a_stage`-class negatives kept where they still bite (unknown top-level key, malformed `system_event`, empty `scenario_id` via `minLength`).
- New pin: missing `client_turn_id` rejected (newly required).
- UUID format: no longer enforced by the export (plain string, length bounds) — flipped + both bounds pinned so a re-tightening fails loud.
- Standalone system-event suite rewritten to the five-variant shape (incl. `rating` enum `up|down`), plus a KNOWN DIVERGENCE pin that the legacy `{type,payload}` shape no longer validates.

Untouched (already conformant): `cee-response-consumption`, `golden-path-fixture`, `fixtures-schema`, analysis-state/graph-state suites — all green against the new schemas unchanged.

## 5 · Mutation proof (throwaway worktree at `a44b7bf0`, reverted + removed after)

| Mutation | Result |
|---|---|
| A — fixture stage `analyse` → retired `evaluate` | 🔴 1 failed (exactly the analysis-envelope test) |
| B — delete producer-required `turn_id` from the scaffold | 🔴 8 failed |
| C — revert the mirror to the pre-sync drifted schema | 🔴 4 failed, **including `MIRROR CANONICAL`** — reverting the fix turns its own pin red |

## 6 · Gates

- `pnpm run typecheck` — clean
- `npx eslint` on both touched test files — 0 errors, 0 warnings
- `npx vitest run tests/contracts` — **115/115** (was 113; +2 net from restructuring)
- `npx vitest run --changed origin/staging` — 64/64
- `npx vitest run tests/ci-guards` — 50/50
- Wide `npx tsc -p tsconfig.app.json --noEmit` — `grep -c "error TS"`: **2323 = 2323**, set-wise identical vs matched base worktree at `origin/staging` with the same real node_modules (zero new)
- Workflow YAML: parsed + structurally asserted (no `continue-on-error` remains; repo/ref correct). actionlint unavailable locally — **the real proof is this PR's own `CEE Contract Validation` run.**

## Cross-repo asks (unchanged / refreshed)

1. CEE: tighten stream `turn_start.stage` to the canonical `Stage` enum (KNOWN GAP tripwire will fail loud and should then be flipped like this PR flipped #390's).
2. CEE: export the **live V2** request-surface schemas (the current four input exports describe the 410'd V1 route); on that day the KNOWN DIVERGENCE pins here go red and get flipped to live-wire pins.

**Draft — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)