### PR TITLE
fix(config): staging probes staging — same-origin health-probe fallback in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,14 @@
           fetch(edge + '/health').then(function(r){ return r.json(); }).then(function(d){
             healthEl.textContent = 'OK via proxy\n' + JSON.stringify(d, null, 2);
           }).catch(function(){
-            fetch('https://plot-lite-service.onrender.com/health').then(function(r){ return r.json(); }).then(function(d){
-              healthEl.textContent = 'OK via direct\n' + JSON.stringify(d, null, 2);
+            // Same-origin retry only — never a cross-origin service host from
+            // this inline script. The per-environment _redirects/netlify.toml
+            // decide which backend /bff/engine/* reaches, so staging probes
+            // staging and production probes production. (The previous
+            // hardcoded production host was CSP-blocked console noise on
+            // every staging load — rehearsal 2026-07-20.)
+            fetch('/bff/engine/health').then(function(r){ return r.json(); }).then(function(d){
+              healthEl.textContent = 'OK via bff\n' + JSON.stringify(d, null, 2);
             }).catch(function(e2){
               healthEl.textContent = 'FAIL\n' + String(e2);
             });

--- a/src/__tests__/indexHtmlHealthProbe.spec.ts
+++ b/src/__tests__/indexHtmlHealthProbe.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Rehearsal-triage Item B (2026-07-20) — the safe-screen health probe in
+ * index.html must never fetch a cross-origin service host.
+ *
+ * index.html's inline safe-screen script probes PLoT health on EVERY page
+ * load (the safe screen is hidden pre-React, but the fetch has already been
+ * dispatched). Its failure fallback was a hardcoded
+ * `https://plot-lite-service.onrender.com/health` — the PRODUCTION host —
+ * which staging's CSP (connect-src pins the staging host only) blocks with
+ * two console errors precisely when the proxied probe is already failing
+ * (dress-rehearsal console.log 09:58:36Z). The e2e helpers even allowlist
+ * that exact error (e2e/helpers/canvas.ts) — a tolerated broken alarm.
+ *
+ * The rule this spec pins: the inline probe stays SAME-ORIGIN only
+ * (`/engine/*` and `/bff/engine/*`), because the per-environment
+ * `_redirects`/netlify.toml own which backend those paths reach — staging
+ * probes staging, production probes production, and CSP never fires.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function indexHtml(): string {
+  return readFileSync(resolve(process.cwd(), 'index.html'), 'utf8')
+}
+
+describe('index.html safe-screen health probe', () => {
+  it('still probes engine health via the same-origin proxy (positive control)', () => {
+    // Proves this spec is reading the real document and the probe exists —
+    // without this, the absence assertions below could pass vacuously
+    // against an empty or relocated file.
+    const html = indexHtml()
+    expect(html).toContain("var edge = '/engine'")
+    expect(html).toContain("fetch(edge + '/health')")
+  })
+
+  it('never fetches the production PLoT host', () => {
+    expect(indexHtml()).not.toMatch(/plot-lite-service\.onrender\.com/)
+  })
+
+  it('contains no cross-origin onrender.com URL at all', () => {
+    // The probe must be same-origin only; _redirects decides the backend
+    // per environment. Any onrender.com literal here is a cross-environment
+    // leak waiting for a CSP block.
+    expect(indexHtml()).not.toMatch(/https:\/\/[a-z0-9-]+\.onrender\.com/i)
+  })
+})


### PR DESCRIPTION
## Rehearsal-triage Item B (dress rehearsal 2026-07-20)

**Defect.** The safe-screen inline script in `index.html` probes PLoT health on **every page load** (the safe screen is hidden pre-React, but the fetch is already dispatched). Its failure fallback was a hardcoded `https://plot-lite-service.onrender.com/health` — the **production** host — which staging's CSP (connect-src pins `plot-lite-service-staging` only) blocks with two console errors, exactly when the proxied probe is already failing (rehearsal `console.log` 09:58:36Z, mid-Render-deploy window). `e2e/helpers/canvas.ts:60-61` even allowlists that exact error — a tolerated broken alarm. The hardcoded host predates all recent work (index.html untouched since the earliest commits); the deployed staging HTML at `2e5abdb1` still serves it (verified at the bytes; the deployed main JS chunk has 0 references — the document inline script is the only live prober).

**Fix.** The fallback becomes a same-origin `/bff/engine/health` retry. The per-environment `_redirects`/`netlify.toml` own which backend that path reaches, so **staging probes staging, production probes production**, and CSP can never fire. The primary `/engine/health` probe is unchanged (also same-origin; verified live: 200 JSON via the `_redirects` proxy).

**Pin.** New spec `src/__tests__/indexHtmlHealthProbe.spec.ts`: index.html contains **no cross-origin onrender.com URL at all**, with a positive control (`var edge = '/engine'` + `fetch(edge + '/health')`) proving the probe still exists so the absence assertions can't pass vacuously.

**Evidence discipline.** RED-first (2 assertions fail against the unfixed file) · mutation-checked (stash-revert → RED 2/3, restore → GREEN 3/3).

**Gates.** `pnpm run typecheck` clean · eslint 0 errors on the new spec · `npx vitest run --changed origin/staging` 3/3 green.

**Same class, deliberately not touched (follow-ups):**
- `public/poc.html` "direct" diagnostic button still targets the production host — click-gated (no auto-run noise) and CSP-blocked in every environment; needs a decision on whether a "direct" check has any legitimate form under the pinned CSP.
- `e2e/helpers/canvas.ts:60-61` console-error allowlist entries for this exact error are now dead and should be removed so the alarm works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)