### PR TITLE
feat(entry): guests can enter the product from the front door

### DIFF
--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -352,7 +352,11 @@ export default function ScenarioListPage() {
     }
   }
 
-  // Guest mode — redirect to login
+  // Guest mode — offer sign-in (primary) and a guest path into the canvas
+  // (secondary). Guest mode is the POC's primary flow and #/canvas works fully
+  // as guest, so this branch must never be a dead end. The guest copy
+  // deliberately promises nothing about persistence — the sign-in copy above
+  // it already frames signing in as the way to save.
   if (!isPersistenceActive) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-canvas p-8">
@@ -361,12 +365,20 @@ export default function ScenarioListPage() {
           <p className={`${typography.body} text-text-body mt-4`}>
             Sign in to save and manage your decisions.
           </p>
-          <button
-            onClick={() => navigate('/login')}
-            className={`${typography.button} mt-6 px-6 py-3 rounded-pill bg-primary text-text-on-color shadow-1 hover:bg-primary-hover transition-all duration-fast`}
-          >
-            Sign in
-          </button>
+          <div className="mt-6 flex flex-col items-center gap-3">
+            <button
+              onClick={() => navigate('/login')}
+              className={`${typography.button} px-6 py-3 rounded-pill bg-primary text-text-on-color shadow-1 hover:bg-primary-hover transition-all duration-fast`}
+            >
+              Sign in
+            </button>
+            <button
+              onClick={() => navigate('/canvas')}
+              className={`${typography.button} px-6 py-3 rounded-pill border border-[rgba(38,38,38,0.16)] text-text-body hover:bg-panel-hover transition-colors duration-fast`}
+            >
+              Continue without an account
+            </button>
+          </div>
         </div>
       </div>
     )

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -304,4 +304,37 @@ describe('ScenarioListPage', () => {
     renderPage()
     expect(screen.getByText('Sign in')).toBeTruthy()
   })
+
+  // -------------------------------------------------------------------------
+  // Front-door guest path. A fresh guest landing at root must have a way INTO
+  // the product: guest mode is the POC's primary flow and #/canvas works fully
+  // as guest, but this branch used to render only a Sign in button — a dead
+  // end. The CTA is the secondary affordance (sign-in stays primary) and its
+  // copy must not promise persistence a guest doesn't get.
+  // -------------------------------------------------------------------------
+
+  it('offers guests a path into the canvas with an accessible name', () => {
+    mockAuthValue = { user: { id: 'guest' }, authenticated: true }
+    renderPage()
+
+    const guestCta = screen.getByRole('button', { name: /continue without an account/i })
+    expect(guestCta).toBeTruthy()
+
+    fireEvent.click(guestCta)
+    expect(mockNavigate).toHaveBeenCalledWith('/canvas')
+  })
+
+  it('keeps Sign in as the primary affordance alongside the guest path', () => {
+    mockAuthValue = { user: { id: 'guest' }, authenticated: true }
+    renderPage()
+
+    const signIn = screen.getByRole('button', { name: /^sign in$/i })
+    expect(signIn.className).toContain('bg-primary')
+
+    const guestCta = screen.getByRole('button', { name: /continue without an account/i })
+    expect(guestCta.className).not.toContain('bg-primary')
+
+    fireEvent.click(signIn)
+    expect(mockNavigate).toHaveBeenCalledWith('/login')
+  })
 })


### PR DESCRIPTION
## What a fresh guest sees

**Before:** Root `/` routes to `ScenarioListPage`; a guest (persistence inactive) gets only:

> **Decisions**
> Sign in to save and manage your decisions.
> [Sign in]

— a dead end. Guest mode is the POC's primary flow and `#/canvas` works fully as guest, but nothing at root pointed there. Byte-verified pre-existing since 2026-03-06 (not a #387 regression).

**After:** Same branch, same copy, same primary Sign in button — plus a secondary affordance directly beneath it:

> [Sign in]  ← primary, `bg-primary text-text-on-color`, unchanged
> [Continue without an account]  ← secondary, outlined pill, navigates to `#/canvas`

## Copy rationale

"Continue without an account" states exactly what the guest gets and promises nothing about persistence — the sign-in copy above it ("Sign in to **save and manage** your decisions") already owns the persistence framing, so the pair reads honestly: sign in to save, or continue without saving to an account. Sign-in stays the primary affordance (signing in is what the product wants long-term; guests are the POC reality).

## Implementation

- `src/pages/ScenarioListPage.tsx` — unauthenticated branch only: secondary button using the page's existing `useNavigate` pattern (`navigate('/canvas')`; HashRouter renders `#/canvas`). Outlined-pill styling follows the secondary-button pattern already in this file (DeleteConfirmDialog Cancel). Native `<button>` — keyboard-reachable, accessible name from its label. No Lucide icon needed; no emoji.
- **Scope:** this branch of this page only. No auth changes, no routing-table changes, no flag.

## Tests + gates

- **RED-first:** both new specs (`ScenarioListPage.spec.tsx`) failed before the implementation — guest CTA present with accessible name + targets `/canvas`; Sign in remains primary.
- **Mutation check:** implementation reverted with tests kept → exactly the 2 new tests RED; restored.
- `pnpm run typecheck` (tsconfig.ci.json) clean.
- Lint: 0 errors on touched files (2 pre-existing warnings, both present at base).
- `npx vitest run --changed origin/staging`: 2 files, 19 tests green.
- ci-guards: duplicates/ds/flags pass; `ci:guard:sandbox` + `ci:guard:zustand` fail **identically at pristine origin/staging** (pre-existing: three e2e specs / `StyledEdge.tsx`) — zero delta from this change.
- Wide `tsc -p tsconfig.app.json` via `grep -c "error TS"`, set-wise vs matched base with real node_modules: 2323 → 2323, **0 new**.

## Governance

Flagged to Paul as **decided-unless-vetoed**: copy ("Continue without an account"), secondary placement, and the `navigate('/canvas')` target are the proposed defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)