### PR TITLE
fix(conversation): failed sends look failed — transcript honesty on 504

### DIFF
--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -1,7 +1,9 @@
 import { memo, useCallback, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import { AlertCircle } from 'lucide-react'
 import { useCanvasStore } from '../store'
 import { useConversationContext } from '../conversation/ConversationContext'
+import type { SendFailureNotice } from '../conversation/useConversation'
 import { useFloatingPanelState, canAutoDock } from '../hooks/useFloatingPanelState'
 import { useUIStore } from '../../stores/uiStore'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
@@ -42,6 +44,29 @@ interface FirstUseComposerProps {
 const PANEL_WIDTH = 960
 const PANEL_MARGIN = 16
 
+/**
+ * Point-of-failure copy for the hero (dress-rehearsal trust item #3,
+ * paired defect). The hero is the ONE Olumi surface with no visible
+ * transcript — before this notice, a failed draft send reset the composer
+ * to pristine while the only error copy rendered inside the collapsed
+ * outputs dock, so the user's text appeared to vanish into silence.
+ * Transport failures (the rehearsal's 4/4 proxy 504s) get transport-honest
+ * copy — never the false "server processing" claim, never an invented
+ * recovery suggestion.
+ */
+function heroFailureCopy(failure: SendFailureNotice): string {
+  switch (failure.kind) {
+    case 'transport':
+      return "That didn't get through. The server didn't respond, so no model was drafted. Your text wasn't lost. It's back in the box above; send it again when you're ready."
+    case 'timeout':
+      return "That took too long, so we stopped waiting. No model was drafted. Your text wasn't lost. It's back in the box above; send it again when you're ready."
+    case 'server':
+      return failure.retryable
+        ? "Something went wrong on our side and your brief couldn't be processed. Your text wasn't lost. It's back in the box above; try rephrasing or send it again."
+        : "Something went wrong on our side and your brief couldn't be processed. Your text wasn't lost. It's back in the box above."
+  }
+}
+
 /** Reposition margin when post-graph auto-anchoring the floating panel. */
 const REPOSITION_EDGE_MARGIN = 16
 
@@ -68,7 +93,7 @@ const REPOSITION_EDGE_MARGIN = 16
  */
 export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick, blueprintEventBus }: FirstUseComposerProps) {
   const nodeCount = useCanvasStore((s) => s.nodes.length)
-  const { messages, isThinking } = useConversationContext()
+  const { messages, isThinking, lastSendFailure, draft, setDraft } = useConversationContext()
   const realMessageCount = messages.filter((m) => !m.synthetic).length
   // Round-12: during the first-use generating window (user submitted a
   // brief, no graph yet) the composer freezes, its placeholder swaps to
@@ -80,6 +105,27 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick, blu
   // indicator unmounts as soon as the first graph appears (nodeCount > 0
   // → hero unmounts entirely).
   const isGenerating = isThinking && nodeCount === 0
+
+  // Trust item #3 (paired defect): when the send fails while the hero is
+  // the active surface, the failure must be visible HERE — not only in the
+  // collapsed dock's transcript. Notice below the composer + the user's
+  // text restored into it, so nothing reads as vanished.
+  const showSendFailure = lastSendFailure !== null && !isGenerating
+
+  // Restore the failed text into the composer once per failure instance —
+  // never clobber text the user has already retyped.
+  const restoredForFailureRef = useRef<SendFailureNotice | null>(null)
+  useEffect(() => {
+    if (!lastSendFailure) {
+      restoredForFailureRef.current = null
+      return
+    }
+    if (restoredForFailureRef.current === lastSendFailure) return
+    restoredForFailureRef.current = lastSendFailure
+    if (draft.trim() === '' && lastSendFailure.inputText) {
+      setDraft(lastSendFailure.inputText)
+    }
+  }, [lastSendFailure, draft, setDraft])
 
   const isOpen = useFloatingPanelState((s) => s.isOpen)
   const source = useFloatingPanelState((s) => s.source)
@@ -287,6 +333,20 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick, blu
           </div>
         ) : null}
       </div>
+      {/* Trust item #3: send-failure notice at the point of failure. Plain
+          visible content — deliberately NOT a live region (the
+          conversation's role="log" owner announces; adding aria-live here
+          would violate the single-live-region invariant). Hidden while a
+          new attempt is generating; cleared by the next dispatch. */}
+      {showSendFailure && lastSendFailure ? (
+        <div
+          data-testid="first-use-send-failure"
+          className="w-full max-w-2xl flex items-start gap-2 rounded-lg bg-panel border border-danger/30 px-3 py-2.5"
+        >
+          <AlertCircle className="w-4 h-4 text-danger flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-sm text-text-body m-0">{heroFailureCopy(lastSendFailure)}</p>
+        </div>
+      ) : null}
       {/* Starter decisions — the second way in, COMPLEMENTING the composer
           above (type, or pick a worked example). Suppressed during the
           generating window: the user has already committed a brief, so

--- a/src/canvas/components/__tests__/FirstUseComposer.sendFailure.spec.tsx
+++ b/src/canvas/components/__tests__/FirstUseComposer.sendFailure.spec.tsx
@@ -1,0 +1,182 @@
+/**
+ * FirstUseComposer — point-of-failure feedback (dress-rehearsal trust
+ * item #3, paired defect).
+ *
+ * On a fresh guest's first-use hero, a failed draft send used to reset the
+ * composer to pristine while the only error copy rendered inside the
+ * collapsed-by-default outputs dock — the user's text appeared to vanish
+ * into silence. The hero is the one Olumi surface with no visible
+ * transcript, so failure feedback must appear HERE, where the user is
+ * looking:
+ *  - an honest failure notice below the composer (transport copy for the
+ *    504/network class — no fake "server processing" claim);
+ *  - the user's text restored into the composer so nothing reads as lost.
+ *
+ * Single-live-region invariant: the notice is plain visible content — the
+ * conversation's role="log" owner does the announcing; this surface adds
+ * NO aria-live region for the failure.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }),
+  },
+  isSupabaseAvailable: () => false,
+}))
+
+const canvasMockState: {
+  nodes: Array<{ id: string }>
+  edges: Array<unknown>
+  results: { status: string }
+  _internal: Record<string, unknown>
+  selection: null
+} = { nodes: [], edges: [], results: { status: 'idle' }, _internal: {}, selection: null }
+vi.mock('../../store', () => {
+  const useCanvasStore: any = (selector: (s: any) => any) => selector(canvasMockState)
+  useCanvasStore.getState = () => canvasMockState
+  return {
+    useCanvasStore,
+    selectResultsStatus: (s: any) => s.results?.status,
+    selectReport: (s: any) => s.results?.report,
+    selectError: (s: any) => s.results?.error,
+    selectResultsSource: (s: any) => s.results?.source,
+  }
+})
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+vi.mock('../../hooks/useSelectionContext', () => ({
+  useSelectionContext: () => null,
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => true,
+}))
+vi.mock('../../../adapters/plot', () => ({
+  plot: {
+    templates: () => new Promise(() => {}),
+  },
+}))
+
+// Mutable mocked conversation state the tests reconfigure.
+const messagesMockState: { messages: Array<{ id: string; role: string; synthetic?: boolean }> } = {
+  messages: [],
+}
+const thinkingMockState: { isThinking: boolean } = { isThinking: false }
+const failureMockState: {
+  lastSendFailure: { kind: string; retryable: boolean; inputText: string } | null
+} = { lastSendFailure: null }
+
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      const [sendSystemEvent] = useState(() => vi.fn())
+      const [sendChip] = useState(() => vi.fn())
+      const [retryLast] = useState(() => vi.fn())
+      const [setPatchBlockState] = useState(() => vi.fn())
+      const [setPatchRejection] = useState(() => vi.fn())
+      return {
+        messages: messagesMockState.messages,
+        isThinking: thinkingMockState.isThinking,
+        longRunningHint: null,
+        lastFailedInput: failureMockState.lastSendFailure?.inputText ?? null,
+        lastSendFailure: failureMockState.lastSendFailure,
+        sendMessage,
+        sendSystemEvent,
+        sendChip,
+        retryLast,
+        patchBlockStates: new Map(),
+        setPatchBlockState,
+        patchRejections: new Map(),
+        setPatchRejection,
+      }
+    },
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { FirstUseComposer } from '../FirstUseComposer'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+beforeEach(() => {
+  useFloatingPanelState.getState().reset()
+  useFloatingPanelState.getState().open('system-first-use')
+  canvasMockState.nodes = []
+  messagesMockState.messages = []
+  thinkingMockState.isThinking = false
+  failureMockState.lastSendFailure = null
+})
+
+describe('FirstUseComposer — send-failure notice at the point of failure', () => {
+  it('transport failure: notice renders with honest transport copy and the text restores into the composer', () => {
+    failureMockState.lastSendFailure = {
+      kind: 'transport',
+      retryable: true,
+      inputText: 'my lost coffee brief',
+    }
+    messagesMockState.messages = [{ id: 'u1', role: 'user' }]
+
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+
+    const notice = screen.getByTestId('first-use-send-failure')
+    expect(notice.textContent).toMatch(/didn’t get through|didn't get through/)
+    expect(notice.textContent).toMatch(/wasn’t lost|wasn't lost|not lost/)
+    // No false server-fault claim on the transport class.
+    expect(notice.textContent).not.toContain('Something went wrong on our side')
+
+    // The user's text is back in the composer — nothing reads as vanished.
+    const input = screen.getByTestId('first-use-input-bar-textarea') as HTMLTextAreaElement
+    expect(input.value).toBe('my lost coffee brief')
+  })
+
+  it('no notice when there is no failure', () => {
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(screen.queryByTestId('first-use-send-failure')).toBeNull()
+  })
+
+  it('notice hides while a new attempt is generating', () => {
+    failureMockState.lastSendFailure = {
+      kind: 'transport',
+      retryable: true,
+      inputText: 'retrying brief',
+    }
+    thinkingMockState.isThinking = true
+
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    expect(screen.queryByTestId('first-use-send-failure')).toBeNull()
+  })
+
+  it('single-live-region invariant: the notice carries no aria-live and no alert role', () => {
+    failureMockState.lastSendFailure = {
+      kind: 'transport',
+      retryable: true,
+      inputText: 'brief',
+    }
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const notice = screen.getByTestId('first-use-send-failure')
+    expect(notice.getAttribute('aria-live')).toBeNull()
+    expect(notice.getAttribute('role')).not.toBe('alert')
+    expect(notice.querySelector('[aria-live]')).toBeNull()
+    expect(notice.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('server-class failure still gets a notice (the hero must never fail silently)', () => {
+    failureMockState.lastSendFailure = {
+      kind: 'server',
+      retryable: true,
+      inputText: 'brief that CEE rejected',
+    }
+    render(<FirstUseComposer onCogClick={() => {}} />, { wrapper: Wrapper })
+    const notice = screen.getByTestId('first-use-send-failure')
+    expect(notice.textContent).toMatch(/couldn’t be processed|couldn't be processed/)
+  })
+})

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -139,6 +139,51 @@
 }
 
 /**
+ * Transcript honesty (trust item #3): a user send whose turn failed must
+ * look visibly different from delivered history. Danger-tinted border (DS
+ * rule: borders via opacity, never extra shade tokens) + slightly muted
+ * body so the "Not delivered" marker below reads as the message's status.
+ */
+.messageBubbleUserFailed {
+  border: 1px solid color-mix(in srgb, var(--danger, #EA7B4B) 30%, transparent);
+  opacity: 0.85;
+}
+
+/** Failed-send marker row: icon + "Not delivered" + optional Retry.
+ *  Type scale comes from typography.panelMeta applied in JSX (F3 census). */
+.sendFailedRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-end;
+  margin-top: 4px;
+  color: var(--danger, #EA7B4B);
+}
+
+/** Outlined retry affordance on the failed message itself (DS pill rules).
+ *  Type scale comes from typography.panelMeta applied in JSX (F3 census). */
+.sendFailedRetryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--danger, #EA7B4B) 30%, transparent);
+  border-radius: var(--radius-pill, 999px);
+  color: var(--text-body, #3F3F3E);
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.sendFailedRetryButton:hover {
+  background: var(--bg-panel-hover, #FEF9F3);
+}
+
+.sendFailedRetryButton:focus-visible {
+  outline: 2px solid var(--info, #277A9D);
+  outline-offset: 1px;
+}
+
+/**
  * Compact pill for chip/pill-initiated user turns — no avatar, no timestamp, no copy/retry.
  * Right-aligned to match user bubble position in conversation flow.
  *

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -20,7 +20,7 @@ import { memo, useState, useMemo, useRef } from 'react'
 import { typography } from '../../styles/typography'
 import { safeRichText } from '../utils/safeRichText'
 import { InlineBlocks } from './InlineBlocks'
-import { ChevronDown, ChevronUp, ListPlus, AlignLeft } from 'lucide-react'
+import { AlertCircle, ChevronDown, ChevronUp, ListPlus, AlignLeft, RefreshCw } from 'lucide-react'
 import { BaseRateChipRow } from './BaseRateChipRow'
 import { FeedbackRow } from './FeedbackRow'
 import { StalenessPill, type StalenessFreshness } from './StalenessPill'
@@ -136,6 +136,14 @@ interface MessageBubbleProps {
    * preserve FF-off behaviour.
    */
   compact?: boolean
+  /**
+   * Transcript honesty (trust item #3): retry handler for a FAILED user
+   * message (deliveryState 'failed'). Wired by ChatThread only for the
+   * message retryLast would actually resend (the last user message) —
+   * older failed attempts show the "Not delivered" marker without the
+   * affordance. Ignored for non-failed or assistant messages.
+   */
+  onRetryFailedSend?: () => void
 }
 
 export const MessageBubble = memo(function MessageBubble({
@@ -149,8 +157,33 @@ export const MessageBubble = memo(function MessageBubble({
   onArtefactMessage,
   onProposalConfirm,
   compact = false,
+  onRetryFailedSend,
 }: MessageBubbleProps) {
   const isUser = message.role === 'user'
+  // Transcript honesty (trust item #3): a user send whose turn failed must
+  // LOOK failed — marker + optional retry affordance on the message itself.
+  const sendFailed = isUser && message.deliveryState === 'failed'
+  const sendFailedMarker = sendFailed ? (
+    <div
+      className={`${styles.sendFailedRow} ${typography.panelMeta}`}
+      data-testid="send-failed-indicator"
+    >
+      <AlertCircle size={12} aria-hidden="true" />
+      <span>Not delivered</span>
+      {onRetryFailedSend && (
+        <button
+          type="button"
+          className={`${styles.sendFailedRetryButton} ${typography.panelMeta}`}
+          onClick={onRetryFailedSend}
+          data-testid="send-failed-retry"
+          aria-label="Retry sending this message"
+        >
+          <RefreshCw size={12} aria-hidden="true" />
+          Retry
+        </button>
+      )}
+    </div>
+  ) : null
 
   // Defensive guard: never render the [system] sentinel as a user bubble
   if (isUser && message.content === SYSTEM_MESSAGE_SENTINEL) return null
@@ -164,9 +197,12 @@ export const MessageBubble = memo(function MessageBubble({
   // Chip-initiated user messages render as a compact pill, not a full bubble
   if (isUser && message.chipInitiated) {
     return (
-      <div className={styles.chipActionIndicator} data-testid="chip-action-indicator">
-        <span className={typography.caption}>{message.displayContent ?? message.content}</span>
-      </div>
+      <>
+        <div className={styles.chipActionIndicator} data-testid="chip-action-indicator">
+          <span className={typography.caption}>{message.displayContent ?? message.content}</span>
+        </div>
+        {sendFailedMarker}
+      </>
     )
   }
 
@@ -244,8 +280,13 @@ export const MessageBubble = memo(function MessageBubble({
     <>
     {stalenessFreshness && <StalenessPill freshness={stalenessFreshness} />}
     <div
-      className={isUser ? styles.messageBubbleUser : styles.messageBubbleAssistant}
+      className={
+        isUser
+          ? `${styles.messageBubbleUser}${sendFailed ? ` ${styles.messageBubbleUserFailed}` : ''}`
+          : styles.messageBubbleAssistant
+      }
       data-testid={`message-${message.role}`}
+      data-delivery-state={isUser ? message.deliveryState : undefined}
     >
       <div
         className={`${compact ? typography.panelBody : typography.chatProse} ${styles.markdownContent} ${
@@ -267,6 +308,10 @@ export const MessageBubble = memo(function MessageBubble({
           {message.toolLoadingState}
         </div>
       )}
+      {/* Transcript honesty (trust item #3): failed-send marker + retry
+        * affordance on the message itself. Cleared when a retry delivers
+        * (deliveryState flips back to 'sent'). */}
+      {sendFailedMarker}
       {/* T6: persistent "Response stopped." indicator on user-cancelled turns.
         * Set by useConversation.cancelTurn(); never cleared by late chunks. */}
       {message.stoppedByUser && (

--- a/src/canvas/conversation/__tests__/ChatThread.sendFailedRetry.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.sendFailedRetry.spec.tsx
@@ -1,0 +1,110 @@
+/**
+ * ChatThread: failed-send retry wiring — dress-rehearsal trust item #3.
+ *
+ * The retry affordance on a failed user message must only appear on the
+ * message that retryLast would actually resend (the LAST user message).
+ * Older failed attempts keep the "Not delivered" marker without a retry
+ * button — clicking retry there would resend a DIFFERENT text than the
+ * bubble shows.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ChatThread } from '../zones/ChatThread'
+import type { ConversationMessage } from '../types'
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    (selector: (s: any) => any) => selector({ nodes: [], edges: [] }),
+    { getState: () => ({ nodes: [], edges: [] }), setState: vi.fn(), subscribe: vi.fn() },
+  ),
+}))
+
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign(
+    (selector: (s: any) => any) => selector({}),
+    { getState: () => ({ setActiveOutputTab: vi.fn() }), setState: vi.fn() },
+  ),
+}))
+
+vi.mock('../../stores/guidanceStore', () => ({
+  useGuidanceStore: Object.assign(
+    (selector: (s: any) => any) => selector({ guidanceItems: [], _dispatchAction: vi.fn() }),
+    { getState: () => ({ guidanceItems: [], _dispatchAction: vi.fn(), dismissItem: vi.fn() }) },
+  ),
+}))
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+let seq = 0
+function makeMsg(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  seq += 1
+  return {
+    id: `msg-${seq}`,
+    role: 'user',
+    content: 'text',
+    timestamp: new Date(),
+    ...overrides,
+  } as ConversationMessage
+}
+
+const noop = vi.fn().mockResolvedValue(undefined)
+
+function renderThread(messages: ConversationMessage[], onRetry = vi.fn()) {
+  render(
+    <ChatThread
+      messages={messages}
+      isThinking={false}
+      longRunningHint={null}
+      nodeCount={1}
+      patchBlockStates={new Map()}
+      patchRejections={new Map()}
+      onChipClick={noop}
+      onPatchAccept={vi.fn()}
+      onPatchDismiss={vi.fn()}
+      onFeedback={vi.fn()}
+      onRetry={onRetry}
+    />,
+  )
+  return onRetry
+}
+
+describe('ChatThread: failed-send retry wiring', () => {
+  it('last failed user message gets the retry affordance; clicking fires onRetry', async () => {
+    const onRetry = renderThread([
+      makeMsg({ content: 'failed brief', deliveryState: 'failed' }),
+      makeMsg({ role: 'assistant', content: 'error copy', synthetic: true }),
+    ])
+    const btn = screen.getByTestId('send-failed-retry')
+    await userEvent.click(btn)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('older failed attempts keep the marker but NOT the retry affordance', () => {
+    renderThread([
+      makeMsg({ content: 'first failed', deliveryState: 'failed' }),
+      makeMsg({ role: 'assistant', content: 'error copy', synthetic: true }),
+      makeMsg({ content: 'second failed', deliveryState: 'failed' }),
+      makeMsg({ role: 'assistant', content: 'error copy 2', synthetic: true }),
+    ])
+    const markers = screen.getAllByTestId('send-failed-indicator')
+    expect(markers).toHaveLength(2)
+    // Only ONE retry affordance — on the last user message.
+    const retries = screen.getAllByTestId('send-failed-retry')
+    expect(retries).toHaveLength(1)
+  })
+
+  it('a failed message followed by a newer DELIVERED user message gets no retry affordance', () => {
+    renderThread([
+      makeMsg({ content: 'failed brief', deliveryState: 'failed' }),
+      makeMsg({ role: 'assistant', content: 'error copy', synthetic: true }),
+      makeMsg({ content: 'newer delivered', deliveryState: 'sent' }),
+      makeMsg({ role: 'assistant', content: 'reply' }),
+    ])
+    expect(screen.getByTestId('send-failed-indicator')).toBeTruthy()
+    expect(screen.queryByTestId('send-failed-retry')).toBeNull()
+  })
+})

--- a/src/canvas/conversation/__tests__/MessageBubble.sendFailed.spec.tsx
+++ b/src/canvas/conversation/__tests__/MessageBubble.sendFailed.spec.tsx
@@ -1,0 +1,137 @@
+/**
+ * MessageBubble failed-send marker — dress-rehearsal trust item #3.
+ *
+ * A user message whose turn failed (deliveryState 'failed') must LOOK failed
+ * in the transcript: a visible "Not delivered" marker plus, when the caller
+ * wires it (ChatThread does so only for the message retryLast would actually
+ * resend), a retry affordance ON the message itself. Delivered and pending
+ * messages render no marker — the failed state must never leak onto normal
+ * history.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../Conversation.module.css', () => ({
+  default: {
+    messageBubbleUser: 'messageBubbleUser',
+    messageBubbleUserFailed: 'messageBubbleUserFailed',
+    messageBubbleAssistant: 'messageBubbleAssistant',
+    markdownContent: 'markdownContent',
+    streamingThinking: 'streamingThinking',
+    streamingDot: 'streamingDot',
+    sendFailedRow: 'sendFailedRow',
+    sendFailedRetryButton: 'sendFailedRetryButton',
+    chipActionIndicator: 'chipActionIndicator',
+  },
+}))
+
+vi.mock('../../../styles/typography', () => ({
+  typography: { bodySmall: 'bodySmall', panelMeta: 'panelMeta', caption: 'caption', body: 'body', chatProse: 'chatProse', panelBody: 'panelBody' },
+}))
+
+vi.mock('../InlineBlocks', () => ({
+  InlineBlocks: () => null,
+}))
+
+vi.mock('../FeedbackRow', () => ({
+  FeedbackRow: () => null,
+}))
+
+vi.mock('../useConversation', () => ({
+  SYSTEM_MESSAGE_SENTINEL: '[system]',
+  isNonConversationalContent: () => false,
+  normaliseAnalysisReady: (x: unknown) => x,
+}))
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MessageBubble } from '../MessageBubble'
+import type { ConversationMessage } from '../types'
+
+function makeUserMsg(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'u1',
+    role: 'user',
+    content: 'my brief',
+    timestamp: new Date(),
+    ...overrides,
+  } as ConversationMessage
+}
+
+const noopChip = async () => {}
+
+describe('MessageBubble — failed-send marker', () => {
+  it('renders "Not delivered" marker on a failed user message', () => {
+    render(
+      <MessageBubble
+        message={makeUserMsg({ deliveryState: 'failed' })}
+        onChipClick={noopChip}
+      />,
+    )
+    const marker = screen.getByTestId('send-failed-indicator')
+    expect(marker.textContent).toContain('Not delivered')
+  })
+
+  it('renders a retry affordance on the failed message when wired, and clicking it fires the handler', async () => {
+    const onRetry = vi.fn()
+    render(
+      <MessageBubble
+        message={makeUserMsg({ deliveryState: 'failed' })}
+        onChipClick={noopChip}
+        onRetryFailedSend={onRetry}
+      />,
+    )
+    const btn = screen.getByTestId('send-failed-retry')
+    await userEvent.click(btn)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('no retry affordance when the caller does not wire one (older failed attempts)', () => {
+    render(
+      <MessageBubble
+        message={makeUserMsg({ deliveryState: 'failed' })}
+        onChipClick={noopChip}
+      />,
+    )
+    expect(screen.getByTestId('send-failed-indicator')).toBeTruthy()
+    expect(screen.queryByTestId('send-failed-retry')).toBeNull()
+  })
+
+  it('no marker on delivered, pending, or unmarked user messages', () => {
+    const { rerender } = render(
+      <MessageBubble message={makeUserMsg({ deliveryState: 'sent' })} onChipClick={noopChip} />,
+    )
+    expect(screen.queryByTestId('send-failed-indicator')).toBeNull()
+    rerender(
+      <MessageBubble message={makeUserMsg({ deliveryState: 'pending' })} onChipClick={noopChip} />,
+    )
+    expect(screen.queryByTestId('send-failed-indicator')).toBeNull()
+    rerender(<MessageBubble message={makeUserMsg()} onChipClick={noopChip} />)
+    expect(screen.queryByTestId('send-failed-indicator')).toBeNull()
+  })
+
+  it('no marker on assistant messages regardless of field value', () => {
+    render(
+      <MessageBubble
+        message={{
+          id: 'a1',
+          role: 'assistant',
+          content: 'reply',
+          timestamp: new Date(),
+          deliveryState: 'failed',
+        } as ConversationMessage}
+        onChipClick={noopChip}
+      />,
+    )
+    expect(screen.queryByTestId('send-failed-indicator')).toBeNull()
+  })
+
+  it('failed marker also renders on chip-initiated compact user pills', () => {
+    render(
+      <MessageBubble
+        message={makeUserMsg({ chipInitiated: true, deliveryState: 'failed' })}
+        onChipClick={noopChip}
+      />,
+    )
+    expect(screen.getByTestId('send-failed-indicator')).toBeTruthy()
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.transcriptHonesty504.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.transcriptHonesty504.spec.ts
@@ -1,0 +1,275 @@
+/**
+ * LIVE-CHAIN transcript-honesty tests — dress-rehearsal trust item #3
+ * (2026-07-20): turns lost to a 504 displayed in the transcript as if sent,
+ * so the assistant later appeared to deny visible conversation; the only
+ * error copy lived in the collapsed-by-default dock.
+ *
+ * These tests drive the ACTUAL rehearsal wire shapes (the Netlify proxy's
+ * 504 `PROXY_UPSTREAM_TIMEOUT` JSON body, a thrown network TypeError)
+ * through the LIVE V5 branch: stubbed global fetch → REAL `callV5Turn` →
+ * REAL `parseV5Response` → REAL `routeV5Response` → useConversation's V5
+ * typed_error branch, unmocked (same harness discipline as
+ * useConversation.v5ErrorRecovery.spec.ts — #391).
+ *
+ * What they pin:
+ *  1. a user message whose turn failed carries `deliveryState: 'failed'`
+ *     (the transcript marker MessageBubble renders as "Not delivered");
+ *  2. the failure copy for a transport-class failure (504 proxy timeout /
+ *     network error — no CEE body on the wire) is transport-honest: it says
+ *     the message did not go through and nothing was lost, and does NOT
+ *     claim a server-side processing fault ("Something went wrong on our
+ *     side") or invent a CEE recovery suggestion;
+ *  3. a CEE-class failure (strict BoundaryError body) keeps #391's recovery
+ *     rendering AND now also marks the user message failed;
+ *  4. retry-success turns the failed user message back into a normal sent
+ *     message (`deliveryState: 'sent'`), with no duplicate user bubble —
+ *     the failed marker must not persist as history the assistant would
+ *     then "deny".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+
+// ---------------------------------------------------------------------------
+// Mocks — seams only; the V5 adapter/parser/router chain stays REAL.
+// ---------------------------------------------------------------------------
+
+const mockCallTurn = vi.fn()
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(msg: string, status: number, body: unknown) {
+      super(msg)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: async () => null,
+  storeAnalysis: async () => undefined,
+}))
+
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: () => undefined,
+}))
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true }),
+    isV5CanonicalRunPath: () => false,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Wire fixtures — the rehearsal captures, verbatim shapes
+// ---------------------------------------------------------------------------
+
+/** The Netlify proxy's 504 body from wire/001-504 (dress rehearsal 2026-07-20). */
+const PROXY_504_BODY = {
+  code: 'PROXY_UPSTREAM_TIMEOUT',
+  message:
+    'The model generation service did not respond within 125s. This can happen under heavy load. Please try again.',
+  request_id: '6f30b61f-b596-45c2-ac3e-9f40db7513a9',
+}
+
+/** A strict live-wire BoundaryError (CEE-class failure — reached CEE). */
+const BOUNDARY_ERROR_BODY = {
+  error: 'INTERNAL_ERROR',
+  boundary: 'B1',
+  direction: 'egress',
+  validator: 'draft_graph_pipeline',
+  details: {
+    retryable: true,
+    reason: 'draft_graph_cee_timeout',
+  },
+  request_id: 'req_live_2',
+  retryable: true,
+}
+
+/** Minimal valid OlumiResponse for the retry-success leg. */
+const SUCCESS_BODY = {
+  response_version: 2,
+  assistant_text: 'Here is your draft.',
+  blocks: [],
+  suggested_actions: [],
+  insights: [],
+  stage_indicator: 'frame',
+}
+
+function stubFetchWith(status: number, body: unknown) {
+  const fetchStub = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response))
+  vi.stubGlobal('fetch', fetchStub)
+  return fetchStub
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' } as never,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('transcript honesty on 504 — failed sends look failed (LIVE V5 chain)', () => {
+  it('504 proxy timeout: the user message is marked deliveryState failed', async () => {
+    stubFetchWith(504, PROXY_504_BODY)
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Should we expand our coffee subscription into Germany or the UAE?')
+    })
+
+    const userMsg = result.current.messages.find((m) => m.role === 'user')
+    expect(userMsg).toBeDefined()
+    // The transcript marker: a turn that never got through must not look
+    // identical to a delivered one.
+    expect(userMsg?.deliveryState).toBe('failed')
+  })
+
+  it('504 proxy timeout: failure copy is transport-honest — no false server-fault claim, no invented recovery, retry offered', async () => {
+    stubFetchWith(504, PROXY_504_BODY)
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('coffee subscription brief')
+    })
+
+    const last = result.current.messages[result.current.messages.length - 1]
+    expect(last.role).toBe('assistant')
+    // Transport truth: the message did not go through, and nothing was lost.
+    expect(last.content).toMatch(/didn’t go through|didn't go through|didn’t reach|didn't reach/)
+    expect(last.content).toContain('Nothing you typed was lost')
+    // NOT the generic server-fault claim (that is the CEE-class copy).
+    expect(last.content).not.toContain('Something went wrong on our side')
+    // The proxy's machine code must never render.
+    expect(last.content).not.toContain('PROXY_UPSTREAM_TIMEOUT')
+    // A transport failure is retryable — affordance present.
+    expect(last.actionChips).toEqual([
+      { id: 'retry', label: 'Try again', intent: 'primary' },
+    ])
+    expect(result.current.lastFailedInput).toBe('coffee subscription brief')
+  })
+
+  it('504 proxy timeout: structured lastSendFailure fires with transport class (point-of-failure surfaces consume this)', async () => {
+    stubFetchWith(504, PROXY_504_BODY)
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('the brief text')
+    })
+
+    expect(result.current.lastSendFailure).toEqual(
+      expect.objectContaining({
+        kind: 'transport',
+        retryable: true,
+        inputText: 'the brief text',
+      }),
+    )
+  })
+
+  it('network failure (fetch throws): user message marked failed, transport-honest copy', async () => {
+    const fetchStub = vi.fn(async () => {
+      throw new TypeError('Failed to fetch')
+    })
+    vi.stubGlobal('fetch', fetchStub)
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('offline brief')
+    })
+
+    const userMsg = result.current.messages.find((m) => m.role === 'user')
+    expect(userMsg?.deliveryState).toBe('failed')
+    const last = result.current.messages[result.current.messages.length - 1]
+    expect(last.role).toBe('assistant')
+    expect(last.content).toMatch(/didn’t reach|didn't reach|didn’t go through|didn't go through/)
+    expect(last.content).not.toContain('Something went wrong on our side')
+    expect(result.current.lastSendFailure?.kind).toBe('transport')
+  })
+
+  it('CEE-class BoundaryError: #391 copy preserved AND the user message is now marked failed', async () => {
+    stubFetchWith(500, BOUNDARY_ERROR_BODY)
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('draft my decision')
+    })
+
+    const userMsg = result.current.messages.find((m) => m.role === 'user')
+    expect(userMsg?.deliveryState).toBe('failed')
+    const last = result.current.messages[result.current.messages.length - 1]
+    // CEE-class keeps the canonical taxonomy copy (server fault IS the truth here).
+    expect(last.content).toContain('Something went wrong on our side. Please retry.')
+    // And the class is server, not transport.
+    expect(result.current.lastSendFailure?.kind).toBe('server')
+  })
+
+  it('retry-success: the original failed user message becomes a normal sent message, no duplicate user bubble, no lingering failed marker', async () => {
+    // Leg 1: 504.
+    stubFetchWith(504, PROXY_504_BODY)
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('retry me')
+    })
+    const failedUser = result.current.messages.find((m) => m.role === 'user')
+    expect(failedUser?.deliveryState).toBe('failed')
+
+    // Leg 2: retry succeeds.
+    stubFetchWith(200, SUCCESS_BODY)
+    await act(async () => {
+      await result.current.retryLast()
+    })
+
+    const userMsgs = result.current.messages.filter((m) => m.role === 'user')
+    expect(userMsgs).toHaveLength(1)
+    expect(userMsgs[0].id).toBe(failedUser?.id)
+    expect(userMsgs[0].deliveryState).toBe('sent')
+    // The failure notice state clears on the fresh dispatch.
+    expect(result.current.lastSendFailure).toBeNull()
+    // And the assistant reply landed.
+    const last = result.current.messages[result.current.messages.length - 1]
+    expect(last.role).toBe('assistant')
+    expect(last.content).toContain('Here is your draft.')
+  })
+
+  it('delivered turn: user message ends as sent, never failed, and no failure notice fires', async () => {
+    stubFetchWith(200, SUCCESS_BODY)
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('happy path')
+    })
+
+    const userMsg = result.current.messages.find((m) => m.role === 'user')
+    expect(userMsg?.deliveryState).toBe('sent')
+    expect(result.current.lastSendFailure).toBeNull()
+  })
+})

--- a/src/canvas/conversation/hooks/__tests__/useThreadPersistence.deliveryState.spec.ts
+++ b/src/canvas/conversation/hooks/__tests__/useThreadPersistence.deliveryState.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * useThreadPersistence — delivery-aware commit honesty (dress-rehearsal
+ * trust item #3, persistence half).
+ *
+ * A user turn that never reached the server must NOT be committed to
+ * storage as if it happened. Before this fix, the hook persisted every
+ * visible user message at add-time (entry_status 'complete' + the always-on
+ * insertConversationTurn), ~2s after the bubble appeared — two minutes
+ * before a 504 could even come back. Storage then contradicted the served
+ * history: the assistant would "deny" turns the transcript showed.
+ *
+ * Contract pinned here:
+ *  - deliveryState 'pending'  → deferred: nothing persisted yet;
+ *  - 'pending' → 'sent'       → persisted exactly once, at resolution;
+ *  - 'pending' → 'failed'     → NEVER persisted (matches server truth);
+ *  - deliveryState undefined  → legacy behaviour: persisted at add-time
+ *    (V4 path and hydrated history are unaffected).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+vi.mock('../../../../flags', () => ({
+  isThreadPersistEnabled: vi.fn(() => true),
+}))
+
+const mockAppendThreadEntries = vi.fn()
+const mockUpdateThreadBlockState = vi.fn()
+const mockInsertConversationTurn = vi.fn().mockResolvedValue(null)
+vi.mock('../../../../services/threadService', () => ({
+  appendThreadEntries: (...args: unknown[]) => mockAppendThreadEntries(...args),
+  updateThreadBlockState: (...args: unknown[]) => mockUpdateThreadBlockState(...args),
+  insertConversationTurn: (...args: unknown[]) => mockInsertConversationTurn(...args),
+}))
+
+vi.mock('../../../store', () => ({
+  useCanvasStore: {
+    getState: () => ({ scenarioPersistedToDb: true }),
+  },
+}))
+
+vi.mock('../../../stores/resultsStore', () => ({
+  useResultsStore: {
+    getState: () => ({ results: { lastSnapshotId: null } }),
+  },
+}))
+
+vi.mock('../../../../lib/supabase', () => ({
+  getUserId: vi.fn(async () => 'user-abc-123'),
+}))
+
+import { useThreadPersistence } from '../useThreadPersistence'
+import type { ConversationMessage } from '../../types'
+
+let seq = 0
+function makeUserMessage(
+  text: string,
+  overrides: Partial<ConversationMessage> = {},
+): ConversationMessage {
+  seq += 1
+  return {
+    id: `msg-${seq}`,
+    role: 'user',
+    content: text,
+    timestamp: new Date(),
+    ...overrides,
+  } as ConversationMessage
+}
+
+async function settle() {
+  await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+  await act(async () => { await vi.advanceTimersByTimeAsync(2100) })
+}
+
+/** User texts persisted via the legacy thread-entries path. */
+function legacyUserTexts(): string[] {
+  return mockAppendThreadEntries.mock.calls.flatMap((call) =>
+    (call[1] as Array<{ role: string; user_message?: string }>)
+      .filter((e) => e.role === 'user' && e.user_message !== undefined)
+      .map((e) => e.user_message as string),
+  )
+}
+
+/** User texts persisted via the always-on normalised-turn path. */
+function normalisedUserTexts(): string[] {
+  return mockInsertConversationTurn.mock.calls
+    .map((call) => call[0] as { role: string; content?: string })
+    .filter((a) => a.role === 'user')
+    .map((a) => a.content as string)
+}
+
+/** All persisted user texts across both persistence paths. */
+function persistedUserTexts(): string[] {
+  return [...legacyUserTexts(), ...normalisedUserTexts()]
+}
+
+describe('useThreadPersistence — delivery-aware commit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    mockAppendThreadEntries.mockResolvedValue([])
+    mockUpdateThreadBlockState.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('a pending user message is NOT persisted at add-time', async () => {
+    const pending = makeUserMessage('in flight', { deliveryState: 'pending' })
+    const { rerender } = renderHook(
+      ({ msgs }) => useThreadPersistence('scenario-1', msgs),
+      { initialProps: { msgs: [] as ConversationMessage[] } },
+    )
+    rerender({ msgs: [pending] })
+    await settle()
+
+    expect(persistedUserTexts()).toEqual([])
+  })
+
+  it('a pending message that resolves to sent is persisted exactly once', async () => {
+    const pending = makeUserMessage('deliver me', { deliveryState: 'pending' })
+    const { rerender } = renderHook(
+      ({ msgs }) => useThreadPersistence('scenario-1', msgs),
+      { initialProps: { msgs: [] as ConversationMessage[] } },
+    )
+    rerender({ msgs: [pending] })
+    await settle()
+    expect(persistedUserTexts()).toEqual([])
+
+    // Same message id, resolved (updateMessage shallow-merge produces a new
+    // object with the same id and length-unchanged array). Both persistence
+    // paths fire exactly once each.
+    rerender({ msgs: [{ ...pending, deliveryState: 'sent' as const }] })
+    await settle()
+    expect(legacyUserTexts()).toEqual(['deliver me'])
+    expect(normalisedUserTexts()).toEqual(['deliver me'])
+
+    // Re-render with no change must not double-persist.
+    rerender({ msgs: [{ ...pending, deliveryState: 'sent' as const }] })
+    await settle()
+    expect(legacyUserTexts()).toEqual(['deliver me'])
+    expect(normalisedUserTexts()).toEqual(['deliver me'])
+  })
+
+  it('a pending message that resolves to failed is NEVER persisted', async () => {
+    const pending = makeUserMessage('lost to a 504', { deliveryState: 'pending' })
+    const { rerender } = renderHook(
+      ({ msgs }) => useThreadPersistence('scenario-1', msgs),
+      { initialProps: { msgs: [] as ConversationMessage[] } },
+    )
+    rerender({ msgs: [pending] })
+    await settle()
+    rerender({ msgs: [{ ...pending, deliveryState: 'failed' as const }] })
+    await settle()
+
+    expect(persistedUserTexts()).toEqual([])
+  })
+
+  it('a message observed ALREADY failed (e.g. surface mounted after the failure) is never persisted', async () => {
+    const failed = makeUserMessage('failed before mount', { deliveryState: 'failed' })
+    const { rerender } = renderHook(
+      ({ msgs }) => useThreadPersistence('scenario-1', msgs),
+      { initialProps: { msgs: [] as ConversationMessage[] } },
+    )
+    rerender({ msgs: [failed] })
+    await settle()
+
+    expect(persistedUserTexts()).toEqual([])
+  })
+
+  it('failed-then-retried: the same bubble re-pended and resolved sent persists once', async () => {
+    const msg = makeUserMessage('retry journey', { deliveryState: 'pending' })
+    const { rerender } = renderHook(
+      ({ msgs }) => useThreadPersistence('scenario-1', msgs),
+      { initialProps: { msgs: [] as ConversationMessage[] } },
+    )
+    rerender({ msgs: [msg] })
+    await settle()
+    rerender({ msgs: [{ ...msg, deliveryState: 'failed' as const }] })
+    await settle()
+    expect(persistedUserTexts()).toEqual([])
+
+    // Retry re-pends the SAME bubble, then it lands.
+    rerender({ msgs: [{ ...msg, deliveryState: 'pending' as const }] })
+    await settle()
+    rerender({ msgs: [{ ...msg, deliveryState: 'sent' as const }] })
+    await settle()
+    expect(legacyUserTexts()).toEqual(['retry journey'])
+    expect(normalisedUserTexts()).toEqual(['retry journey'])
+  })
+
+  it('legacy user messages without deliveryState keep add-time persistence (V4 / hydrated back-compat)', async () => {
+    const legacy = makeUserMessage('legacy path')
+    const { rerender } = renderHook(
+      ({ msgs }) => useThreadPersistence('scenario-1', msgs),
+      { initialProps: { msgs: [] as ConversationMessage[] } },
+    )
+    rerender({ msgs: [legacy] })
+    await settle()
+
+    expect(legacyUserTexts()).toEqual(['legacy path'])
+    expect(normalisedUserTexts()).toEqual(['legacy path'])
+  })
+})

--- a/src/canvas/conversation/hooks/useThreadPersistence.ts
+++ b/src/canvas/conversation/hooks/useThreadPersistence.ts
@@ -82,6 +82,18 @@ export function useThreadPersistence(
   const persistedIdsRef = useRef<Set<string>>(new Set())
   const messageToEntryIdRef = useRef<Map<string, string>>(new Map())
   const prevMessageCountRef = useRef(0)
+  // Transcript honesty (trust item #3): user messages observed while
+  // deliveryState === 'pending' are DEFERRED — persisted only if/when they
+  // resolve to 'sent'. A turn the server never served ('failed', or still
+  // pending at teardown) must never be committed to storage as if it
+  // happened: before this, a user turn was written as entry_status
+  // 'complete' ~2s after the bubble appeared, two minutes before a 504
+  // could even come back, so storage contradicted the served history.
+  const deferredPendingIdsRef = useRef<Set<string>>(new Set())
+  // Message ids that have been through user-message persistence already
+  // (dispatch-time or resolution-time) — the resolution pass runs on every
+  // messages change, so it needs its own idempotency guard.
+  const handledMessageIdsRef = useRef<Set<string>>(new Set())
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const consecutiveFailuresRef = useRef(0)
   const cachedUserIdRef = useRef<string | undefined>(undefined)
@@ -137,21 +149,79 @@ export function useThreadPersistence(
     [scheduleFlush],
   )
 
-  // Observe new messages via count diff
+  // Observe messages: new arrivals via count diff, plus a resolution pass
+  // for deferred pending user messages (trust item #3 — a user turn is
+  // committed only once its delivery is known 'sent').
   useEffect(() => {
     if (!scenarioId) return
-    if (messages.length <= prevMessageCountRef.current) {
-      prevMessageCountRef.current = messages.length
-      return
-    }
-
-    const newMessages = messages.slice(prevMessageCountRef.current)
+    const newMessages =
+      messages.length > prevMessageCountRef.current
+        ? messages.slice(prevMessageCountRef.current)
+        : []
     prevMessageCountRef.current = messages.length
 
-    // Process new messages async (need user ID)
+    // Track every currently-pending visible user send — new dispatches AND
+    // failed bubbles re-pended by a retry.
+    for (const msg of messages) {
+      if (msg.role !== 'user') continue
+      if (msg.deliveryState === 'pending' && !handledMessageIdsRef.current.has(msg.id)) {
+        deferredPendingIdsRef.current.add(msg.id)
+      }
+    }
+
+    // Resolution pass: deferred messages whose delivery state has settled.
+    // 'sent' → persist now; 'failed' → drop for good (never committed —
+    // matches the served history, which lacks the failed turn).
+    const resolvedUserMessages: ConversationMessage[] = []
+    if (deferredPendingIdsRef.current.size > 0) {
+      for (const msg of messages) {
+        if (!deferredPendingIdsRef.current.has(msg.id)) continue
+        if (msg.deliveryState === 'pending') continue
+        deferredPendingIdsRef.current.delete(msg.id)
+        if (msg.deliveryState === 'sent') resolvedUserMessages.push(msg)
+      }
+    }
+
+    if (newMessages.length === 0 && resolvedUserMessages.length === 0) return
+
+    // Process async (need user ID)
     void (async () => {
       const userId = await resolveUserId()
       const legacyEnabled = isThreadPersistEnabled()
+
+      const persistUserMessage = (msg: ConversationMessage) => {
+        if (handledMessageIdsRef.current.has(msg.id)) return
+        handledMessageIdsRef.current.add(msg.id)
+        const entryId = crypto.randomUUID()
+        messageToEntryIdRef.current.set(msg.id, entryId)
+
+        // Legacy thread path (flag-gated)
+        if (legacyEnabled) {
+          enqueue({
+            entry_id: entryId,
+            entry_schema_version: 1,
+            role: 'user',
+            origin: 'conversation',
+            actor_user_id: userId,
+            entry_status: 'complete',
+            user_message: msg.content,
+            turn_id: msg.clientTurnId,
+            redaction_state: 'full',
+          })
+        }
+
+        // Normalised turn (always-on, best-effort, fire-and-forget)
+        // Skip if scenario not persisted to Supabase
+        if (useCanvasStore.getState().scenarioPersistedToDb) {
+          void insertConversationTurn({
+            scenarioId,
+            role: 'user',
+            content: msg.content,
+            clientTurnId: msg.clientTurnId,
+            snapshotId: useResultsStore.getState().results.lastSnapshotId ?? undefined,
+          })
+        }
+      }
 
       for (const msg of newMessages) {
         // Skip synthetic messages (welcome, error, undo confirmations)
@@ -166,37 +236,17 @@ export function useThreadPersistence(
           continue
         }
 
-        const entryId = crypto.randomUUID()
-        messageToEntryIdRef.current.set(msg.id, entryId)
-
         if (msg.role === 'user') {
-          // Legacy thread path (flag-gated)
-          if (legacyEnabled) {
-            enqueue({
-              entry_id: entryId,
-              entry_schema_version: 1,
-              role: 'user',
-              origin: 'conversation',
-              actor_user_id: userId,
-              entry_status: 'complete',
-              user_message: msg.content,
-              turn_id: msg.clientTurnId,
-              redaction_state: 'full',
-            })
-          }
-
-          // Normalised turn (always-on, best-effort, fire-and-forget)
-          // Skip if scenario not persisted to Supabase
-          if (useCanvasStore.getState().scenarioPersistedToDb) {
-            void insertConversationTurn({
-              scenarioId,
-              role: 'user',
-              content: msg.content,
-              clientTurnId: msg.clientTurnId,
-              snapshotId: useResultsStore.getState().results.lastSnapshotId ?? undefined,
-            })
-          }
+          // Trust item #3: an unresolved send is deferred (tracked above);
+          // a failed one is never committed. Only known-delivered messages
+          // — 'sent', or legacy/V4 messages with no deliveryState — persist
+          // at observation time.
+          if (msg.deliveryState === 'pending' || msg.deliveryState === 'failed') continue
+          persistUserMessage(msg)
         } else if (msg.role === 'assistant') {
+          const entryId = crypto.randomUUID()
+          messageToEntryIdRef.current.set(msg.id, entryId)
+
           // Legacy thread path (flag-gated)
           if (legacyEnabled) {
             const blocks = msg.blocks?.map(toPersistedBlock)
@@ -240,6 +290,11 @@ export function useThreadPersistence(
           }
         }
       }
+
+      // Deferred user sends whose delivery just resolved 'sent'.
+      for (const msg of resolvedUserMessages) {
+        persistUserMessage(msg)
+      }
     })()
   }, [messages, scenarioId, enqueue, resolveUserId])
 
@@ -266,6 +321,8 @@ export function useThreadPersistence(
   useEffect(() => {
     persistedIdsRef.current.clear()
     messageToEntryIdRef.current.clear()
+    deferredPendingIdsRef.current.clear()
+    handledMessageIdsRef.current.clear()
     prevMessageCountRef.current = 0
     bufferRef.current = []
     consecutiveFailuresRef.current = 0

--- a/src/canvas/conversation/transportFailure.ts
+++ b/src/canvas/conversation/transportFailure.ts
@@ -1,0 +1,92 @@
+/**
+ * Transport-failure classification + copy (dress-rehearsal trust item #3,
+ * 2026-07-20).
+ *
+ * The rehearsal's 4/4 draft failures were HTTP 504s from the Netlify proxy
+ * (`{"code":"PROXY_UPSTREAM_TIMEOUT", ...}`) — no CEE body ever reached the
+ * UI, and the served conversation history legitimately lacks those turns.
+ * The old rendering routed them through the INTERNAL_ERROR taxonomy and
+ * told the user "Something went wrong on our side. Please retry." — a
+ * server-processing-fault claim that is FALSE for this class: the honest
+ * statement is transport-level ("your message didn't go through; nothing
+ * was lost").
+ *
+ * Class split:
+ *   - CEE-class:      a BoundaryError envelope, OR a raw body carrying any
+ *                     typed CEE signal (recovery data, retryable marker, an
+ *                     `error` code field). The server received and failed
+ *                     the turn — #391's recovery rendering owns the copy.
+ *   - transport-class: a parse_error with NO CEE signal at all — proxy
+ *                     timeout JSON, edge-timeout HTML, network throw. The
+ *                     turn never produced a server outcome. Transport copy
+ *                     owns it; we never invent a recovery suggestion here.
+ *
+ * Pure leaf: no imports beyond types, fail-closed duck-typing.
+ */
+
+import type { TypedErrorTransportMeta } from '../../v5/responseRouter'
+import type { CeeRecovery } from './ceeRecovery'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * True when the raw non-2xx body looks like a CEE error envelope rather
+ * than proxy/edge output. The discriminator is the typed `error` code field
+ * every CEE envelope shape carries (BoundaryError, CeeTypedError,
+ * CEEErrorResponseV1's nested `error` object). The rehearsal proxy body
+ * carries `code`, not `error` — proxy output stays transport-class.
+ */
+export function looksLikeCeeEnvelope(rawBody: unknown): boolean {
+  if (!isRecord(rawBody)) return false
+  if (typeof rawBody.error === 'string') return true
+  // Spec-v04 nested shape: { error: { code, ... } }
+  if (isRecord(rawBody.error)) return true
+  return false
+}
+
+/**
+ * Classify a typed_error as transport-class. Fail closed towards the
+ * CEE-class copy: only a parse_error-originated target (transportMeta
+ * present, no BoundaryError) with zero CEE signal anywhere classifies as
+ * transport.
+ */
+export function isTransportFailure(args: {
+  hasBoundaryError: boolean
+  transportMeta: TypedErrorTransportMeta | undefined
+  recovery: CeeRecovery
+  rawBody: unknown
+}): boolean {
+  const { hasBoundaryError, transportMeta, recovery, rawBody } = args
+  if (hasBoundaryError) return false
+  if (transportMeta === undefined) return false
+  if (
+    recovery.retryable !== undefined ||
+    recovery.suggestion !== undefined ||
+    recovery.hints !== undefined
+  ) {
+    return false
+  }
+  if (looksLikeCeeEnvelope(rawBody)) return false
+  return true
+}
+
+/**
+ * Honest copy for a transport-class failure. States what actually happened
+ * (the message did not go through), what was NOT lost, and instructs a
+ * retry only when the retry affordance is actually offered (same
+ * copy-agrees-with-affordance rule as resolveFailureBaseCopy).
+ */
+export function buildTransportFailureCopy(
+  meta: TypedErrorTransportMeta,
+  showRetry: boolean,
+): string {
+  const what = meta.network
+    ? "Your message didn't reach the server."
+    : "The server didn't respond in time, so your message didn't go through."
+  const consequence =
+    "It hasn't been added to the conversation and is marked as not delivered above. Nothing you typed was lost."
+  const action = showRetry ? "Try again when you're ready." : ''
+  return [what, consequence, action].filter((s) => s.length > 0).join(' ')
+}

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -65,6 +65,20 @@ export interface ConversationMessage {
    * Ephemeral: excluded from thread persistence (session-only).
    */
   reasoning?: string
+  /**
+   * Transcript honesty (dress-rehearsal trust item #3, 2026-07-20): delivery
+   * state of a visible user send on the LIVE V5 path.
+   *   - 'pending': dispatched, turn unresolved. Not yet persisted.
+   *   - 'sent':    the turn resolved with a server response — normal history.
+   *   - 'failed':  the turn produced no assistant response (504/network
+   *     transport failure, typed error, browser timeout). Renders the
+   *     "Not delivered" marker + retry affordance and is NEVER persisted —
+   *     a turn the server never served must not be committed as if it
+   *     happened.
+   * `undefined` = legacy/delivered (assistant messages, V4 path, hydrated
+   * history) — treated as sent everywhere.
+   */
+  deliveryState?: 'pending' | 'sent' | 'failed'
 }
 
 /** A set of frequency-framed chips for a single factor's base rate elicitation */

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -18,6 +18,7 @@ import {
   formatRecoveryHints,
   isDisplaySafeReason,
 } from './ceeRecovery'
+import { buildTransportFailureCopy, isTransportFailure } from './transportFailure'
 import { callV5Turn, getV5Endpoint } from '../../v5/v5Adapter'
 import { routeV5Response } from '../../v5/responseRouter'
 import { getTimeoutMs } from '../../v5/getTimeoutMs'
@@ -1591,12 +1592,37 @@ function resolveUserTurnType(
   return 'conversation'
 }
 
+/**
+ * Structured record of the most recent visible user send that failed
+ * (transcript honesty, trust item #3). Unlike `lastFailedInput` (retryable
+ * failures only), this fires for EVERY failed visible user send so
+ * point-of-failure surfaces with no visible transcript (the first-use hero)
+ * can show feedback instead of failing silently. Cleared on the next
+ * visible user dispatch, clearHistory, and scenario switch.
+ */
+export interface SendFailureNotice {
+  /**
+   * 'transport': no CEE body reached the UI (proxy 504, network throw) —
+   *   the turn never produced a server outcome.
+   * 'timeout':   the browser's own timer aborted the wait.
+   * 'server':    the server received the turn and failed it (typed error /
+   *   empty response).
+   */
+  kind: 'transport' | 'timeout' | 'server'
+  /** Whether the retry affordance is being offered for this failure. */
+  retryable: boolean
+  /** The submitted input text, for restore-into-composer affordances. */
+  inputText: string
+}
+
 export interface UseConversationReturn {
   messages: ConversationMessage[]
   isThinking: boolean
   longRunningHint: string | null
   /** The user's last input text, restored on error so they can edit and resend */
   lastFailedInput: string | null
+  /** Most recent visible-user-send failure, all classes. Null when none. */
+  lastSendFailure: SendFailureNotice | null
   sendMessage: (text: string, opts?: {
     hidden?: boolean
     turnType?: Exclude<TurnType, 'system_event'>
@@ -1645,6 +1671,7 @@ export function useConversation(): UseConversationReturn {
   useEffect(() => { isThinkingRef.current = isThinking }, [isThinking])
   const [longRunningHint, setLongRunningHint] = useState<string | null>(null)
   const [lastFailedInput, setLastFailedInput] = useState<string | null>(null)
+  const [lastSendFailure, setLastSendFailure] = useState<SendFailureNotice | null>(null)
   const [patchBlockStates, setPatchBlockStates] = useState<Map<string, PatchBlockState>>(new Map())
   const [patchRejections, setPatchRejectionsMap] = useState<Map<string, PatchRejectionInfo>>(new Map())
 
@@ -1661,6 +1688,11 @@ export function useConversation(): UseConversationReturn {
   const timeoutTimerRef = useRef<ReturnType<typeof setTimeout>>()
   const elapsedIntervalRef = useRef<ReturnType<typeof setInterval>>()
   const lastUserInputRef = useRef<{ message: string; clientTurnId?: string }>({ message: '' })
+  // Transcript honesty (trust item #3): id of the most recent VISIBLE user
+  // bubble. Written when the V5 path adds a user bubble; read by the
+  // retryLast/skipUserBubble path so a retry re-pends and (on the next
+  // outcome) re-marks the ORIGINAL bubble instead of minting a duplicate.
+  const lastVisibleUserBubbleIdRef = useRef<string | null>(null)
   // Tracks the client_turn_id of the most-recently-dispatched V5 turn of ANY
   // kind — visible, hidden, or system. Used by applyV5State's stale-turn
   // guard so that hidden and system responses are NOT falsely treated as
@@ -1762,6 +1794,7 @@ export function useConversation(): UseConversationReturn {
             useDraftStore.getState().setIsGenerating(false)
             setLongRunningHint(null)
             setLastFailedInput(null)
+            setLastSendFailure(null)
 
             // Persist session boundary entry (best-effort)
             if (isThreadPersistEnabled()) {
@@ -1786,6 +1819,7 @@ export function useConversation(): UseConversationReturn {
             useDraftStore.getState().setIsGenerating(false)
             setLongRunningHint(null)
             setLastFailedInput(null)
+            setLastSendFailure(null)
           } finally {
             // Clear from store to prevent re-hydration (even on error)
             useCanvasStore.setState({ _hydratedThread: null })
@@ -1801,6 +1835,7 @@ export function useConversation(): UseConversationReturn {
       useDraftStore.getState().setIsGenerating(false)
       setLongRunningHint(null)
       setLastFailedInput(null)
+      setLastSendFailure(null)
     }
   }, [scenarioId])
 
@@ -3059,6 +3094,7 @@ export function useConversation(): UseConversationReturn {
           })
           lastUserInputRef.current = { message, clientTurnId: turnClientId }
           setLastFailedInput(null)
+          setLastSendFailure(null)
         } else if (hidden && source === 'right_panel_action') {
           recordUserAction({
             actionType: 'clicked run analysis',
@@ -3068,16 +3104,32 @@ export function useConversation(): UseConversationReturn {
 
         // User bubble — HARD RULE: system events never get one, and `hidden`
         // turns skip the bubble too. See docs/v5/ui-outbound-payload-coverage.md.
+        //
+        // Transcript honesty (trust item #3): the bubble starts
+        // deliveryState 'pending' and this turn's outcome resolves it to
+        // 'sent' or 'failed' — a send lost to a 504 must not sit in the
+        // transcript looking identical to a delivered one. A retryLast
+        // re-dispatch (skipUserBubble) re-pends the ORIGINAL bubble so the
+        // failed marker clears for the new attempt without a duplicate.
+        let userBubbleIdForTurn: string | null = null
         if (addUserBubble) {
+          userBubbleIdForTurn = crypto.randomUUID()
+          lastVisibleUserBubbleIdRef.current = userBubbleIdForTurn
           addMessage({
-            id: crypto.randomUUID(),
+            id: userBubbleIdForTurn,
             role: 'user',
             content: displayText ?? message,
             displayContent: displayText,
             submittedPrompt: message,
             timestamp: new Date(),
+            deliveryState: 'pending',
             ...(chipInitiated ? { chipInitiated: true } : {}),
           })
+        } else if (skipUserBubble && mode === 'user' && !hidden) {
+          userBubbleIdForTurn = lastVisibleUserBubbleIdRef.current
+          if (userBubbleIdForTurn) {
+            updateMessage(userBubbleIdForTurn, { deliveryState: 'pending' })
+          }
         }
 
         // Lazy UUID allocation — mirrors V4 buildRequest above.
@@ -3138,6 +3190,10 @@ export function useConversation(): UseConversationReturn {
           // buildV5Payload refused — missing message or unsupported system
           // event. Surface a typed error rather than a malformed request.
           if (mode === 'user' && !hidden) {
+            // Nothing was dispatched — the bubble must not read as sent.
+            if (userBubbleIdForTurn) {
+              updateMessage(userBubbleIdForTurn, { deliveryState: 'failed' })
+            }
             const msg = build.reason === 'missing_message'
               ? 'Please enter a message.'
               : "This action isn't supported yet. Try a different approach."
@@ -3184,10 +3240,18 @@ export function useConversation(): UseConversationReturn {
           setLongRunningHint(null)
           if (inputForRestore) setLastFailedInput(inputForRestore)
           if (mode === 'user' && !hidden) {
+            // Transcript honesty: we stopped waiting — the turn produced no
+            // response, so the bubble must not read as delivered.
+            if (userBubbleIdForTurn) {
+              updateMessage(userBubbleIdForTurn, { deliveryState: 'failed' })
+            }
+            if (inputForRestore) {
+              setLastSendFailure({ kind: 'timeout', retryable: true, inputText: inputForRestore })
+            }
             addMessage({
               id: crypto.randomUUID(),
               role: 'assistant',
-              content: 'This is taking longer than expected. Try again or rephrase your message.',
+              content: 'This is taking longer than expected. We stopped waiting, so your message has not gone through. Nothing you typed was lost. Try again or rephrase your message.',
               synthetic: true,
               actionChips: [{ id: 'retry', label: 'Try again', intent: 'primary' }],
               timestamp: new Date(),
@@ -3246,6 +3310,16 @@ export function useConversation(): UseConversationReturn {
           }
 
           const target = routeV5Response(v5Result)
+
+          // Transcript honesty: resolve this turn's user bubble. Any server
+          // response (including an empty one) means the send was delivered;
+          // only typed_error leaves it failed. Resolved BEFORE rendering so
+          // the marker and the outcome message land in the same commit.
+          if (userBubbleIdForTurn) {
+            updateMessage(userBubbleIdForTurn, {
+              deliveryState: target.kind === 'typed_error' ? 'failed' : 'sent',
+            })
+          }
 
           if (target.kind === 'text_only' || target.kind === 'blocks') {
             // Apply side-effects (stage, graph_patch mutations) BEFORE the
@@ -3601,7 +3675,12 @@ export function useConversation(): UseConversationReturn {
                 : [],
               timestamp: new Date(),
             })
-            if (inputForRestore) setLastFailedInput(inputForRestore)
+            if (inputForRestore) {
+              setLastFailedInput(inputForRestore)
+              // Delivered but produced nothing — the hero must still show
+              // feedback rather than fail silently (server class).
+              setLastSendFailure({ kind: 'server', retryable: true, inputText: inputForRestore })
+            }
           } else {
             // Typed error — the LIVE V5 error surface (Codex F6 fix; #383's
             // recovery rendering was wired only to the dead V4 handleEnvelope
@@ -3622,32 +3701,49 @@ export function useConversation(): UseConversationReturn {
             // retryable marker. Fail closed on every field.
             const recovery = extractCeeRecovery(target.boundaryError ?? target.rawBody)
             const retryable = resolveV5Retryable(target.code, recovery.retryable)
-            // Layered content, each layer display-honest:
-            //   1. canonical taxonomy text, stripped of retry instructions
-            //      when the retry affordance is withheld;
-            //   2. the CEE recovery suggestion (specific what-to-do) when
-            //      present; otherwise the wire reason ONLY when it reads as
-            //      prose — machine reasons (draft_graph_cee_timeout) never
-            //      render to users;
-            //   3. recovery hints as bullets;
-            //   4. generic code-keyed guidance only when no specific
-            //      suggestion filled the what-next slot (non-retryable codes
-            //      only — the Try again chip serves that role otherwise).
-            const baseCopy = resolveFailureBaseCopy(target.code, retryable)
-            const reason = extractV5ErrorReason(target.boundaryError)
-            const reasonLayer =
-              recovery.suggestion === undefined && isDisplaySafeReason(reason) ? reason : ''
-            const guidance =
-              recovery.suggestion === undefined ? resolveV5ErrorGuidance(target.code) : ''
-            const content = [
-              baseCopy,
-              recovery.suggestion ?? '',
-              reasonLayer,
-              formatRecoveryHints(recovery.hints),
-              guidance,
-            ]
-              .filter((s) => s.length > 0)
-              .join('\n\n')
+            // Transcript honesty (trust item #3): the rehearsal's 504s carry
+            // NO CEE body — the proxy timeout JSON is not a server-processing
+            // fault, and "Something went wrong on our side" was a false
+            // claim for that class. A parse_error-originated target with
+            // zero CEE signal renders transport-honest copy instead, and
+            // never invents a recovery suggestion.
+            const transportFailure = isTransportFailure({
+              hasBoundaryError: target.boundaryError !== undefined,
+              transportMeta: target.transportMeta,
+              recovery,
+              rawBody: target.rawBody,
+            })
+            let content: string
+            if (transportFailure && target.transportMeta) {
+              content = buildTransportFailureCopy(target.transportMeta, retryable)
+            } else {
+              // CEE-class — layered content, each layer display-honest:
+              //   1. canonical taxonomy text, stripped of retry instructions
+              //      when the retry affordance is withheld;
+              //   2. the CEE recovery suggestion (specific what-to-do) when
+              //      present; otherwise the wire reason ONLY when it reads as
+              //      prose — machine reasons (draft_graph_cee_timeout) never
+              //      render to users;
+              //   3. recovery hints as bullets;
+              //   4. generic code-keyed guidance only when no specific
+              //      suggestion filled the what-next slot (non-retryable codes
+              //      only — the Try again chip serves that role otherwise).
+              const baseCopy = resolveFailureBaseCopy(target.code, retryable)
+              const reason = extractV5ErrorReason(target.boundaryError)
+              const reasonLayer =
+                recovery.suggestion === undefined && isDisplaySafeReason(reason) ? reason : ''
+              const guidance =
+                recovery.suggestion === undefined ? resolveV5ErrorGuidance(target.code) : ''
+              content = [
+                baseCopy,
+                recovery.suggestion ?? '',
+                reasonLayer,
+                formatRecoveryHints(recovery.hints),
+                guidance,
+              ]
+                .filter((s) => s.length > 0)
+                .join('\n\n')
+            }
             const retryChips: ActionChip[] = retryable && mode === 'user' && !hidden
               ? [{ id: 'retry', label: 'Try again', intent: 'primary' }]
               : []
@@ -3660,6 +3756,13 @@ export function useConversation(): UseConversationReturn {
               timestamp: new Date(),
             })
             if (retryable && inputForRestore) setLastFailedInput(inputForRestore)
+            if (inputForRestore) {
+              setLastSendFailure({
+                kind: transportFailure ? 'transport' : 'server',
+                retryable,
+                inputText: inputForRestore,
+              })
+            }
           }
         } catch (err) {
           clearLifecycleTimers()
@@ -3667,15 +3770,23 @@ export function useConversation(): UseConversationReturn {
           // Timeout-triggered aborts render their own bubble (above). User
           // stops and concurrent cancellations are silent by design.
           if (!isAbort && mode === 'user' && !hidden) {
+            // Transcript honesty: the dispatch itself threw — nothing
+            // reached the server, so the bubble must not read as sent.
+            if (userBubbleIdForTurn) {
+              updateMessage(userBubbleIdForTurn, { deliveryState: 'failed' })
+            }
             addMessage({
               id: crypto.randomUUID(),
               role: 'assistant',
               synthetic: true,
-              content: 'Something went wrong sending your message. Try again.',
+              content: "Your message didn't reach the server, so it has not been added to the conversation. Nothing you typed was lost. Try again.",
               actionChips: [{ id: 'retry', label: 'Try again', intent: 'primary' }],
               timestamp: new Date(),
             })
-            if (inputForRestore) setLastFailedInput(inputForRestore)
+            if (inputForRestore) {
+              setLastFailedInput(inputForRestore)
+              setLastSendFailure({ kind: 'transport', retryable: true, inputText: inputForRestore })
+            }
           }
           if (import.meta.env.DEV && !isAbort) {
             console.warn('[sendTurn V5] Dispatch error:', err)
@@ -3721,6 +3832,7 @@ export function useConversation(): UseConversationReturn {
           })
           lastUserInputRef.current = { message, clientTurnId: turnClientId }
           setLastFailedInput(null)
+          setLastSendFailure(null)
 
           if (!skipUserBubble) {
             addMessage({
@@ -4362,6 +4474,7 @@ export function useConversation(): UseConversationReturn {
     useDraftStore.getState().setIsGenerating(false)
     setLongRunningHint(null)
     setLastFailedInput(null)
+    setLastSendFailure(null)
     setPatchBlockStates(new Map())
     setPatchRejectionsMap(new Map())
     abortRef.current?.abort()
@@ -4434,6 +4547,7 @@ export function useConversation(): UseConversationReturn {
     isThinking,
     longRunningHint,
     lastFailedInput,
+    lastSendFailure,
     sendMessage,
     sendSystemEvent,
     sendChip,

--- a/src/canvas/conversation/zones/ChatMessage.tsx
+++ b/src/canvas/conversation/zones/ChatMessage.tsx
@@ -51,6 +51,12 @@ interface ChatMessageProps {
   onProposalConfirm?: (proposalId: string) => void
   /** AI panel v2 surface — render message body at panelBody (12px). */
   compact?: boolean
+  /**
+   * Transcript honesty (trust item #3): when true, this failed user message
+   * is the one retryLast would resend — wire onRetry as the message's own
+   * retry affordance. ChatThread sets this for at most ONE message.
+   */
+  showFailedSendRetry?: boolean
 }
 
 export const ChatMessage = memo(function ChatMessage({
@@ -68,6 +74,7 @@ export const ChatMessage = memo(function ChatMessage({
   onArtefactMessage,
   onProposalConfirm,
   compact,
+  showFailedSendRetry,
 }: ChatMessageProps) {
   const category = getMessageCategory(message)
   const borderClass = CATEGORY_BORDER[category]
@@ -109,6 +116,7 @@ export const ChatMessage = memo(function ChatMessage({
         onArtefactMessage={onArtefactMessage}
         onProposalConfirm={onProposalConfirm}
         compact={compact}
+        onRetryFailedSend={showFailedSendRetry ? onRetry : undefined}
       />
     </div>
   )

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -97,6 +97,15 @@ export const ChatThread = memo(function ChatThread({
       showEmptyState, isThinking, nodeCount, hasFinalizedAssistant, messages.length, !!streamingText)
   }
 
+  // Transcript honesty (trust item #3): the retry affordance on a failed
+  // user message is wired ONLY for the message retryLast would actually
+  // resend — the LAST user message. Older failed attempts keep the
+  // "Not delivered" marker without a retry button (clicking retry there
+  // would resend different text than the bubble shows).
+  const lastUserMsg = [...messages].reverse().find(m => m.role === 'user')
+  const failedSendRetryId =
+    lastUserMsg && lastUserMsg.deliveryState === 'failed' ? lastUserMsg.id : null
+
   // Get suggested chips from last assistant message
   const lastAssistantMsg = [...messages].reverse().find(m => m.role === 'assistant')
   const suggestedChips = lastAssistantMsg?.actionChips ?? []
@@ -140,6 +149,7 @@ export const ChatThread = memo(function ChatThread({
             historicalChips={!isLastAssistant}
             onChipClick={onChipClick}
             onRetry={onRetry}
+            showFailedSendRetry={msg.id === failedSendRetryId}
             patchBlockStates={patchBlockStates}
             patchRejections={patchRejections}
             onPatchAccept={onPatchAccept}

--- a/src/v5/responseRouter.ts
+++ b/src/v5/responseRouter.ts
@@ -32,7 +32,33 @@
  */
 import type { OlumiResponse, FailureTypeLiteral, BoundaryError } from '@talchain/schemas/boundary';
 
+import type { ErrorSource, ParseFailureKind } from './responseParser';
 import type { V5CallResult } from './v5Adapter';
+
+/**
+ * Parse-failure metadata forwarded on typed_error targets that originated
+ * from a `parse_error` (transcript honesty, trust item #3). A parse_error
+ * means NO typed CEE body reached the UI — the failure may be pure
+ * transport (proxy 504 `PROXY_UPSTREAM_TIMEOUT`, Netlify edge timeout HTML,
+ * a thrown network TypeError). Consumers combine this with the absence of
+ * any CEE recovery signal to render transport-honest copy ("your message
+ * didn't go through") instead of the false server-fault claim
+ * ("Something went wrong on our side").
+ */
+export interface TypedErrorTransportMeta {
+  /** HTTP status of the failed response. Absent when fetch itself threw. */
+  httpStatus?: number;
+  /** Header/body-derived origin classification from the parser. */
+  source?: ErrorSource;
+  /** Which parse failure fired (non_json / non_ok_non_boundary / ...). */
+  parseFailureKind?: ParseFailureKind;
+  /**
+   * True when the request never produced a response at all (fetch threw:
+   * offline, DNS, CORS preflight). The strongest "didn't reach the server"
+   * signal.
+   */
+  network: boolean;
+}
 
 export type RenderTarget =
   | { kind: 'text_only'; response: OlumiResponse }
@@ -53,6 +79,11 @@ export type RenderTarget =
        * defensively via ceeRecovery.extractCeeRecovery (fail closed).
        */
       rawBody?: unknown;
+      /**
+       * Present exactly when this typed_error came from a parse_error (no
+       * BoundaryError envelope on the wire). See TypedErrorTransportMeta.
+       */
+      transportMeta?: TypedErrorTransportMeta;
     };
 
 export function routeV5Response(result: V5CallResult): RenderTarget {
@@ -69,6 +100,16 @@ export function routeV5Response(result: V5CallResult): RenderTarget {
       kind: 'typed_error',
       code: 'INTERNAL_ERROR',
       ...(result.raw !== undefined ? { rawBody: result.raw } : {}),
+      transportMeta: {
+        ...(result.http_status !== undefined ? { httpStatus: result.http_status } : {}),
+        ...(result.source !== undefined ? { source: result.source } : {}),
+        ...(result.parse_failure_kind !== undefined
+          ? { parseFailureKind: result.parse_failure_kind }
+          : {}),
+        // The fetch-threw parse_error (v5Adapter catch) is the only one
+        // with no http_status — every parseV5Response branch stamps one.
+        network: result.http_status === undefined,
+      },
     };
   }
 


### PR DESCRIPTION
## Dress-rehearsal trust item #3 — turns lost to a 504 displayed as if sent

**Evidence** (`acceptance-evidence/dress-rehearsal-2026-07-20/REHEARSAL-LOG.md`): 4/4 draft briefs in the 09:45–10:15 window died as HTTP 504 `PROXY_UPSTREAM_TIMEOUT` at ~125s (wire/001, 002, 004, 005). The transcript showed the user's briefs as ordinary sent messages; the only error copy ("Something went wrong on our side. Please retry.") rendered inside the outputs dock, which is **collapsed by default for a fresh guest and never auto-opens or badges** (03c-dock-expanded.png vs 02b-graph-after-draft.png). Net effect: "my text vanished into silence", and later (Step 5) the assistant appeared to deny £250k-cap messages visible on screen — served history legitimately lacked the failed turns, but the transcript displayed them as delivered.

## What #391 provided vs what this adds

#391 (`c586388f`) landed the LIVE V5 error surface: the typed_error branch, `ceeRecovery` (nested 0.19.0 recovery + flat mirror), server-authoritative retryability, and failure rendering as ordinary assistant messages through ChatThread's `role="log"` owner. This PR builds on those structures and adds what #391 did not cover:

1. **Failed sends look failed** — `ConversationMessage.deliveryState` (`'pending' | 'sent' | 'failed'`). The V5 path stamps the user bubble `'pending'` at dispatch and resolves it from the turn outcome (any server response → `'sent'`; typed error / network throw / browser timeout / build refusal → `'failed'`). A failed user message renders a danger-tinted border + "Not delivered" marker + a Retry affordance **on the message itself** (wired only for the message `retryLast` would actually resend; older failed attempts keep the marker without the button). Retry-success re-pends and resolves the **same** bubble to `'sent'` — no duplicate user bubble, no lingering failed marker for the assistant to "deny".

2. **Transport-vs-CEE failure class split** — a 504 has no CEE body, so it must not claim a server processing fault or invent a recovery suggestion. `routeV5Response` now forwards parse-failure metadata (`transportMeta`: httpStatus / source / parseFailureKind / network) and `transportFailure.ts` classifies fail-closed: transport-class **only** when there is no BoundaryError, no CEE recovery signal (retryable marker / suggestion / hints), and the raw body is not CEE-envelope-shaped (`error` field discriminator — the proxy body carries `code`). Transport copy: *"The server didn't respond in time, so your message didn't go through. It hasn't been added to the conversation and is marked as not delivered above. Nothing you typed was lost. Try again when you're ready."* BoundaryError / CeeTypedError-shaped bodies keep #391's recovery rendering unchanged (its 6-test live-chain spec still passes).

3. **Failure feedback at the point of failure** — the first-use hero (`FirstUseComposer`) is the one Olumi surface with **no visible transcript** (the composer invariant means every other send happens beside a visible thread: docked Olumi tab or floating panel). On failure the hero now shows an honest notice below the composer and restores the failed text into the box (once per failure; never clobbers retyped text). The dock error path stays — it is simply no longer the only signal. Residual (noted, not fixed here): a canvas-launched chip send with every Olumi surface closed would still surface only in the dock; that state is not reachable from the rehearsal journey.

4. **Single-live-region invariant** — the marker, transport copy, and hero notice are plain content; failure announcements still come only from ChatThread's existing `role="log"` `aria-live="polite"` owner. The hero notice explicitly has no `aria-live` / `role="alert"` (asserted in spec).

## Persistence findings (fix item 5)

**The dishonesty did extend to storage, UI-owned, now fixed.** `useThreadPersistence` persisted every visible user message at add-time — `entry_status: 'complete'` thread entries (flag-gated `VITE_FEATURE_THREAD_PERSIST`) **and** the always-on `insertConversationTurn` normalised path (gated on `scenarioPersistedToDb`) — ~2s after the bubble appeared, two minutes before a 504 could come back. A never-delivered turn was committed as if it happened. Now: `'pending'` user messages are deferred, persisted only on resolution to `'sent'`; `'failed'` (and still-pending-at-teardown) turns are **never** committed. Legacy messages without `deliveryState` (V4 path, hydrated history) keep add-time persistence.

**CEE-owned commit semantics need no fix**: the rehearsal's Step-5 memory probe confirms CEE's served history already (correctly) lacks 504-failed turns — the server side was honest; the UI transcript and UI-side storage were not. Note for the rehearsal itself: the guest session had `scenarioPersistedToDb === false` and the thread flags off, so the storage half was likely latent rather than live that day — fixed regardless, as both paths are live for signed-in users with persisted scenarios.

## RED-first + mutations (throwaway worktree)

- Pre-fix on `origin/staging` (2e5abdb1): the 5 new spec files ran **23 failed / 4 passed** (the 4 = negative controls; every positive assertion RED).
- Mutation 1 — revert failed-state marking (4 sites) → `useConversation.transcriptHonesty504` **4/7 RED**.
- Mutation 2 — revert hero notice + draft restore → `FirstUseComposer.sendFailure` **3/5 RED**.
- Mutation 3 — revert persistence deferral gate → `useThreadPersistence.deliveryState` **5/6 RED**.
- Mutation 4 — revert transport classification (always CEE-class) → **3/7 RED**.

## Gates

- `pnpm run typecheck` (tsconfig.ci.json): clean.
- ESLint on all touched files: **0 errors** (10 pre-existing warnings in untouched regions).
- `npx vitest run --changed origin/staging`: **1491 passed | 31 skipped (115 files)** on the final tree.
- `tests/ci-guards`: **50 passed** (the guards caught and I fixed a `--danger` fallback drift + two raw font-size decls — marker type scale now comes from `typography.panelMeta`).
- Wide `tsc -p tsconfig.app.json` via `grep -c "error TS"`: **2323 vs 2323** against a matched base clone (fresh blobless clone of 2e5abdb1, own `pnpm install`). Position-normalised multiset: zero new error sites — the only textual delta is two **pre-existing** TS2739s (`generateModelIntegration.spec.tsx`, `patchAcceptLogic.spec.tsx`, mocks already missing `dispatchAction`/`cancelTurn` on base) whose missing-properties list now also names `lastSendFailure`.

## What the user now sees on a 504

Their message stays in the transcript with a danger-tinted border and "Not delivered · Retry"; the assistant-side copy says the message didn't go through and nothing was lost (with a Try again chip); on the first-use hero, a notice appears right under the composer and their brief is restored into the box. On retry-success everything returns to normal sent history. Storage never records the failed turn, so the assistant can no longer be contradicted by its own transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
