### PR TITLE
fix(persistence): reload reconnects to the same scenario — work survives the error boundary

### DIFF
--- a/src/canvas/ErrorBoundary.tsx
+++ b/src/canvas/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, ReactNode } from 'react'
 import { XCircle, AlertTriangle, ChevronRight } from 'lucide-react'
 import { captureError } from '../lib/monitoring'
+import { flushWorkToAutosave } from './persist/crashFlush'
 
 interface Props {
   children: ReactNode
@@ -21,6 +22,47 @@ const GITHUB_ISSUES_URL = 'https://github.com/Talchain/DecisionGuideAI/issues/ne
 // If more than this many errors in the time window, consider it a recurring error
 const RECURRING_ERROR_THRESHOLD = 3
 const RECURRING_ERROR_WINDOW_MS = 5000
+
+// Stale-chunk auto-recovery: a failed dynamic import after a mid-session deploy
+// is fixed by exactly one reload (the new index.html references the new chunks).
+// One automatic reload, rate-limited via sessionStorage so a genuinely broken
+// deploy cannot produce a reload loop — within the window the user gets the
+// normal error panel with the manual "Reload editor" button instead.
+const CHUNK_RELOAD_GUARD_KEY = 'olumi-chunk-reload-at'
+const CHUNK_RELOAD_GUARD_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * Detect a failed-lazy-chunk error (deploy race / stale index.html). Message
+ * shapes across browsers: Chrome "Failed to fetch dynamically imported module",
+ * Firefox "error loading dynamically imported module", Safari "Importing a
+ * module script failed", plus webpack-era "Loading chunk N failed" kept for
+ * safety.
+ */
+export function isChunkLoadError(error: Error | null): boolean {
+  if (!error) return false
+  const message = `${error.name ?? ''} ${error.message ?? ''}`
+  return /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|Failed to load module script|Loading chunk [\w-]+ failed|ChunkLoadError/i.test(
+    message
+  )
+}
+
+/**
+ * HashRouter guard: reload must land back on the SAME route. location.reload()
+ * preserves the hash, but the recorded replaceState-desync gotcha means the
+ * visible hash can have been dropped by earlier history writes — and a guest
+ * reloading WITHOUT a route hash lands on the sign-in gate, which reads as
+ * total data loss. If the hash is not a route, pin it to the canvas before
+ * reloading.
+ */
+function ensureRouteHash(): void {
+  try {
+    if (!window.location.hash || !window.location.hash.startsWith('#/')) {
+      window.location.hash = '#/canvas'
+    }
+  } catch {
+    // Fail-soft: reloading with the current URL is still better than nothing.
+  }
+}
 
 export class CanvasErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
@@ -48,6 +90,37 @@ export class CanvasErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: any) {
     console.error('[CANVAS ERROR]:', error, errorInfo)
+
+    // Crash-moment flush: persist the CURRENT in-memory graph into the
+    // autosave slot the boot path restores from, BEFORE any reload can happen.
+    // The periodic 30s autosave leaves the newest work unpersisted exactly
+    // when a crash strikes; this is what makes the panel's "Your work is
+    // auto-saved" promise true at the moment it is shown. Fail-soft: an empty
+    // or unreadable store flushes nothing and never clobbers a good autosave.
+    const flushed = flushWorkToAutosave()
+
+    // Stale-chunk auto-recovery: one reload fixes a deploy race. Rate-limited
+    // so a broken deploy shows the error panel instead of reload-looping.
+    if (isChunkLoadError(error) && typeof window !== 'undefined') {
+      let lastAttempt = 0
+      try {
+        lastAttempt = Number(sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)) || 0
+      } catch {
+        // sessionStorage unavailable → treat as recently attempted (no auto
+        // reload) rather than risking an unguarded loop.
+        lastAttempt = Date.now()
+      }
+      if (Date.now() - lastAttempt > CHUNK_RELOAD_GUARD_WINDOW_MS) {
+        try {
+          sessionStorage.setItem(CHUNK_RELOAD_GUARD_KEY, String(Date.now()))
+          ensureRouteHash()
+          // Defer past the commit phase — never reload mid-render.
+          setTimeout(() => window.location.reload(), 0)
+        } catch {
+          // Fall through to the normal error panel.
+        }
+      }
+    }
 
     // Track error count for recurring error detection
     const now = Date.now()
@@ -82,6 +155,8 @@ export class CanvasErrorBoundary extends Component<Props, State> {
               componentStack: errorInfo?.componentStack?.slice(0, 600),
               errorCount: newErrorCount,
               isRecurring,
+              flushedWorkToAutosave: flushed,
+              isChunkLoadError: isChunkLoadError(error),
             },
           })
         }
@@ -101,18 +176,6 @@ export class CanvasErrorBoundary extends Component<Props, State> {
 
   handleReload = () => {
     window.location.reload()
-  }
-
-  handleCopyState = async () => {
-    try {
-      const state = localStorage.getItem('canvas-state-v1')
-      if (state) {
-        await navigator.clipboard.writeText(state)
-        this.showToast('Canvas state copied to clipboard.')
-      }
-    } catch (e) {
-      console.error('Failed to copy state:', e)
-    }
   }
 
   handleReportIssue = () => {
@@ -145,7 +208,9 @@ export class CanvasErrorBoundary extends Component<Props, State> {
         url: window.location.href,
         userAgent: navigator.userAgent,
         timestamp: new Date().toISOString(),
-        canvasState: localStorage.getItem('canvas-state-v1'),
+        // The autosave slot the boot path restores from — the live persistence
+        // mechanism (the old 'canvas-state-v1' key had no reader or writer).
+        canvasAutosave: localStorage.getItem('olumi-canvas-autosave'),
       }
       await navigator.clipboard.writeText(JSON.stringify(debugInfo, null, 2))
       this.showToast('Debug info copied to clipboard.')
@@ -177,26 +242,21 @@ export class CanvasErrorBoundary extends Component<Props, State> {
   }
 
   handleRecover = () => {
-    // Try to recover from last snapshot
-    try {
-      const snapshots = Object.keys(localStorage)
-        .filter(k => k.startsWith('canvas-snapshot-'))
-        .sort()
-        .reverse()
+    // Flush the current in-memory graph into the autosave slot that the
+    // production boot path actually restores from (olumi-canvas-autosave →
+    // ReactFlowGraph's init effect). The previous implementation here copied
+    // `canvas-snapshot-*` (written only by the manual ⌘S snapshot feature)
+    // into `canvas-state-v1` (read by NOTHING on boot) — a restore promise
+    // wired to two dead keys, which is how the 2026-07-20 rehearsal lost a
+    // whole session to a reassuring "Reload editor" button. The store is a
+    // module singleton and still holds the graph while this panel is shown,
+    // so the flush captures work right up to the crash.
+    flushWorkToAutosave()
 
-      if (snapshots.length > 0) {
-        const lastSnapshot = localStorage.getItem(snapshots[0])
-        if (lastSnapshot) {
-          localStorage.setItem('canvas-state-v1', lastSnapshot)
-          window.location.reload()
-          return
-        }
-      }
-    } catch (e) {
-      console.error('Recovery failed:', e)
-    }
-
-    // Fallback: just reload
+    // Reload must reconnect to the SAME route (and thereby the same scenario:
+    // identity is persisted in olumi-canvas-current-scenario-id and the graph
+    // in the autosave slot keyed alongside it).
+    ensureRouteHash()
     this.handleReload()
   }
 
@@ -334,7 +394,7 @@ export class CanvasErrorBoundary extends Component<Props, State> {
             </div>
 
             <p className="text-xs text-text-light text-center mt-6">
-              Your work is auto-saved. Reloading will restore the last snapshot.
+              Your work is auto-saved. Reloading will restore your latest work.
             </p>
           </div>
         </div>

--- a/src/canvas/__tests__/ErrorBoundary.recovery.spec.tsx
+++ b/src/canvas/__tests__/ErrorBoundary.recovery.spec.tsx
@@ -1,0 +1,234 @@
+/**
+ * Canvas error boundary — crash-moment persistence + reload recovery.
+ *
+ * WHY THIS FILE EXISTS: the 2026-07-20 dress rehearsal hit a mid-session
+ * deploy, the Analysis tab's lazy chunk 404'd, the boundary rendered
+ * "Reload editor — Your work is auto-saved. Reloading will restore the last
+ * snapshot", and the reload came back to an EMPTY canvas. The promise was
+ * wired to two dead localStorage keys: `canvas-snapshot-*` (written only by
+ * the manual ⌘S snapshot feature) copied into `canvas-state-v1` (read by
+ * nothing on boot). The real restore mechanism — `olumi-canvas-autosave`,
+ * which ReactFlowGraph's production init effect hydrates — was only written
+ * by a 30-second interval that a crash outraces.
+ *
+ * These tests pin the fix:
+ *  1. componentDidCatch flushes the CURRENT store graph into the autosave
+ *     slot the boot path reads (crash-moment flush, no interval race);
+ *  2. the "Reload editor" click flushes again and pins the route hash so the
+ *     reload reconnects to the same scenario;
+ *  3. an EMPTY store never clobbers an existing good autosave;
+ *  4. a stale-chunk error triggers ONE guarded automatic reload;
+ *  5. isChunkLoadError recognises the browser message shapes.
+ *
+ * What jsdom proves here: the flush/guard logic and the localStorage writes.
+ * What it CANNOT prove: that a real browser reload then rehydrates the graph
+ * — that is ReactFlowGraph's PROD-only init effect, verified by the real
+ * browser check recorded in the PR (production build via vite preview).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import * as ErrorBoundaryModule from '../ErrorBoundary'
+import { useCanvasStore } from '../store'
+
+const { CanvasErrorBoundary } = ErrorBoundaryModule
+// Namespace access (not a named import) so the RED run against the pre-fix
+// module resolves to undefined instead of failing collection outright.
+const isChunkLoadError = (ErrorBoundaryModule as any).isChunkLoadError as
+  | ((e: Error | null) => boolean)
+  | undefined
+
+const AUTOSAVE_KEY = 'olumi-canvas-autosave'
+const CHUNK_GUARD_KEY = 'olumi-chunk-reload-at'
+
+function Bomb({ message }: { message: string }): never {
+  throw new Error(message)
+}
+
+function nodesFixture() {
+  return [
+    { id: 'n1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+    { id: 'n2', type: 'option', position: { x: 100, y: 0 }, data: { label: 'Option A' } },
+  ] as any[]
+}
+
+function edgesFixture() {
+  return [{ id: 'e1', source: 'n2', target: 'n1', data: { weight: 0.5 } }] as any[]
+}
+
+describe('CanvasErrorBoundary — crash recovery persistence', () => {
+  const reloadSpy = vi.fn()
+  let originalLocation: Location
+  let consoleErrorSpy: { mockRestore: () => void }
+
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    reloadSpy.mockClear()
+
+    // jsdom's location.reload logs "Not implemented" — replace the whole
+    // location object (canonical jsdom workaround) and restore after.
+    originalLocation = window.location
+    // @ts-expect-error jsdom allows deleting the window accessor
+    delete window.location
+    ;(window as any).location = {
+      ...originalLocation,
+      hash: '#/canvas',
+      reload: reloadSpy,
+      assign: vi.fn(),
+      replace: vi.fn(),
+    }
+
+    // Throwing children spam console.error via React — keep output readable.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    useCanvasStore.setState({
+      nodes: nodesFixture(),
+      edges: edgesFixture(),
+      currentScenarioId: '0985abff-d168-4309-83a5-ce5042000001',
+    } as any)
+  })
+
+  afterEach(() => {
+    cleanup()
+    ;(window as any).location = originalLocation
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('1. crash flushes the current graph into the autosave slot the boot path reads (componentDidCatch)', () => {
+    expect(localStorage.getItem(AUTOSAVE_KEY)).toBeNull()
+
+    render(
+      <CanvasErrorBoundary>
+        <Bomb message="Cannot read properties of undefined (reading 'label')" />
+      </CanvasErrorBoundary>
+    )
+
+    const raw = localStorage.getItem(AUTOSAVE_KEY)
+    expect(raw).not.toBeNull()
+    const autosave = JSON.parse(raw!)
+    expect(autosave.nodes).toHaveLength(2)
+    expect(autosave.edges).toHaveLength(1)
+    expect(autosave.nodes.map((n: any) => n.id)).toEqual(['n1', 'n2'])
+    expect(autosave.scenarioId).toBe('0985abff-d168-4309-83a5-ce5042000001')
+    expect(typeof autosave.timestamp).toBe('number')
+  })
+
+  it('2. "Reload editor" flushes work and reloads on the same route', () => {
+    render(
+      <CanvasErrorBoundary>
+        <Bomb message="plain render crash" />
+      </CanvasErrorBoundary>
+    )
+
+    // Simulate post-crash state divergence: the user's newest work exists only
+    // in the store. The click must persist THAT, not a stale interval write.
+    localStorage.removeItem(AUTOSAVE_KEY)
+    // Simulate the recorded HashRouter replaceState-desync: hash lost.
+    ;(window as any).location.hash = ''
+
+    fireEvent.click(screen.getByRole('button', { name: /reload editor/i }))
+
+    const raw = localStorage.getItem(AUTOSAVE_KEY)
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw!).nodes).toHaveLength(2)
+    expect((window as any).location.hash).toBe('#/canvas')
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('3. an EMPTY store never clobbers an existing good autosave', () => {
+    const goodAutosave = JSON.stringify({
+      timestamp: Date.now() - 60_000,
+      nodes: nodesFixture(),
+      edges: edgesFixture(),
+      scenarioId: 'keep-me',
+    })
+    localStorage.setItem(AUTOSAVE_KEY, goodAutosave)
+    useCanvasStore.setState({ nodes: [], edges: [] } as any)
+
+    render(
+      <CanvasErrorBoundary>
+        <Bomb message="crash with an already-emptied store" />
+      </CanvasErrorBoundary>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /reload editor/i }))
+
+    expect(localStorage.getItem(AUTOSAVE_KEY)).toBe(goodAutosave)
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('4a. stale-chunk error → ONE automatic guarded reload, work flushed first', async () => {
+    render(
+      <CanvasErrorBoundary>
+        <Bomb message="Failed to fetch dynamically imported module: https://staging--olumi.netlify.app/assets/index-Dwqco2rO.js" />
+      </CanvasErrorBoundary>
+    )
+
+    // Flush happened at catch even before the deferred reload fires.
+    expect(localStorage.getItem(AUTOSAVE_KEY)).not.toBeNull()
+    // Guard stamped so a broken deploy cannot loop.
+    expect(sessionStorage.getItem(CHUNK_GUARD_KEY)).not.toBeNull()
+
+    // The reload is deferred past the commit phase.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('4b. a second chunk error inside the guard window does NOT auto-reload — the panel shows instead', async () => {
+    sessionStorage.setItem(CHUNK_GUARD_KEY, String(Date.now()))
+
+    render(
+      <CanvasErrorBoundary>
+        <Bomb message="Failed to fetch dynamically imported module: https://staging--olumi.netlify.app/assets/index-Dwqco2rO.js" />
+      </CanvasErrorBoundary>
+    )
+
+    await new Promise((r) => setTimeout(r, 20))
+    expect(reloadSpy).not.toHaveBeenCalled()
+    // Manual recovery stays available.
+    expect(screen.getByRole('button', { name: /reload editor/i })).toBeTruthy()
+  })
+
+  it('6. a structurally broken node is dropped from the flush; valid work and non-dangling edges survive', () => {
+    // A malformed node is the classic cause of a render crash — persisting it
+    // verbatim would rehydrate the poison and crash-loop on every reload.
+    useCanvasStore.setState({
+      nodes: [...nodesFixture(), { id: 'poison' } as any],
+      edges: [
+        ...edgesFixture(),
+        { id: 'e-dangling', source: 'poison', target: 'n1', data: {} } as any,
+      ],
+    } as any)
+
+    render(
+      <CanvasErrorBoundary>
+        <Bomb message="Cannot read properties of undefined (reading 'x')" />
+      </CanvasErrorBoundary>
+    )
+
+    const raw = localStorage.getItem(AUTOSAVE_KEY)
+    expect(raw).not.toBeNull()
+    const autosave = JSON.parse(raw!)
+    expect(autosave.nodes.map((n: any) => n.id)).toEqual(['n1', 'n2'])
+    expect(autosave.edges.map((e: any) => e.id)).toEqual(['e1'])
+  })
+
+  it('5. isChunkLoadError recognises real browser message shapes and rejects ordinary errors', () => {
+    expect(isChunkLoadError).toBeTypeOf('function')
+    const yes = [
+      'Failed to fetch dynamically imported module: https://x/assets/index-abc.js',
+      'error loading dynamically imported module',
+      'Importing a module script failed.',
+      'Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".',
+      'Loading chunk 42 failed',
+    ]
+    const no = [
+      "Cannot read properties of undefined (reading 'label')",
+      'Maximum update depth exceeded',
+      'Network request failed',
+    ]
+    for (const m of yes) expect(isChunkLoadError!(new Error(m)), m).toBe(true)
+    for (const m of no) expect(isChunkLoadError!(new Error(m)), m).toBe(false)
+    expect(isChunkLoadError!(null)).toBe(false)
+  })
+})

--- a/src/canvas/persist/crashFlush.ts
+++ b/src/canvas/persist/crashFlush.ts
@@ -1,0 +1,121 @@
+/**
+ * Crash-moment autosave flush.
+ *
+ * The periodic autosave (useAutosave, 30s interval) leaves a window where the
+ * newest work exists only in the in-memory store. The canvas error boundary's
+ * "Reload editor" promises "Your work is auto-saved. Reloading will restore
+ * the last snapshot" — for that promise to hold AT THE MOMENT IT IS MADE, the
+ * boundary must be able to flush the current store state into the SAME
+ * mechanism the production boot path actually reads (`olumi-canvas-autosave`
+ * via scenarios.loadAutosave → ReactFlowGraph's init effect). The 2026-07-20
+ * dress rehearsal showed the old boundary restoring from `canvas-snapshot-*`
+ * into `canvas-state-v1` — two keys with no writer and no reader respectively —
+ * so the "restore" was theatre and a reload wiped the session.
+ *
+ * Dependency shape: the error boundary lives in the app entry chunk and must
+ * NOT import the canvas store (it would drag the whole canvas dependency tree
+ * into the entry bundle). Instead the store registers a snapshot provider at
+ * module init (see store.ts, next to the window.useCanvasStore exposure), and
+ * the boundary calls flushWorkToAutosave() through this tiny module.
+ */
+
+import { saveAutosave, getCurrentScenarioId } from '../store/scenarios'
+import type { AutosaveData } from '../store/scenarios'
+
+export interface CrashSnapshot {
+  nodes: unknown[]
+  edges: unknown[]
+  scenarioId?: string | null
+  /**
+   * Passed through opaquely: the store's CEEAnalysisReady is a wider union
+   * than AutosaveData's inline shape, and the restore path
+   * (restoreCeeAnalysisReady → validateCeeAnalysisReady) validates before use
+   * — a boundary cast at the write is safe by construction.
+   */
+  ceeAnalysisReady?: unknown
+}
+
+export type CrashSnapshotProvider = () => CrashSnapshot | null
+
+// Module singleton. Deliberately NOT cleared on canvas unmount: the error
+// boundary replaces the canvas subtree BEFORE it runs its own recovery UI, and
+// the store singleton keeps the graph after unmount — a provider that reads
+// getState() stays correct for the whole page lifetime. Re-registration
+// overwrites (idempotent).
+let provider: CrashSnapshotProvider | null = null
+
+export function registerCrashSnapshotProvider(p: CrashSnapshotProvider): void {
+  provider = p
+}
+
+/** Test hook only — restores the unregistered state between specs. */
+export function __resetCrashSnapshotProviderForTests(): void {
+  provider = null
+}
+
+/**
+ * Structural plausibility gates. The flush runs DURING a crash — if the crash
+ * was caused by a malformed node/edge in the store, persisting it verbatim
+ * would rehydrate the poison on reload and crash-loop deterministically.
+ * Dropping only the structurally broken entries keeps the user's valid work
+ * (the rehearsal-shaped outcome) without preserving the crash trigger.
+ * Deliberately minimal — shape checks only, no semantic validation.
+ */
+function isPlausibleNode(n: unknown): boolean {
+  if (!n || typeof n !== 'object') return false
+  const node = n as Record<string, unknown>
+  if (typeof node.id !== 'string' || node.id.length === 0) return false
+  const pos = node.position as Record<string, unknown> | undefined
+  if (!pos || typeof pos !== 'object') return false
+  if (!Number.isFinite(pos.x) || !Number.isFinite(pos.y)) return false
+  if (node.data != null && typeof node.data !== 'object') return false
+  return true
+}
+
+function isPlausibleEdge(e: unknown, keptNodeIds: Set<string>): boolean {
+  if (!e || typeof e !== 'object') return false
+  const edge = e as Record<string, unknown>
+  if (typeof edge.id !== 'string' || edge.id.length === 0) return false
+  if (typeof edge.source !== 'string' || typeof edge.target !== 'string') return false
+  // An edge whose endpoint was dropped as implausible would dangle on reload.
+  return keptNodeIds.has(edge.source) && keptNodeIds.has(edge.target)
+}
+
+/**
+ * Flush the current in-memory graph into the autosave slot the boot path
+ * reads. Returns true when a flush was written.
+ *
+ * Fail-soft by design (this runs while the app is already crashing):
+ * - no provider registered (crash before the canvas store ever loaded) → false;
+ * - provider throws or returns malformed data → false;
+ * - structurally broken nodes/edges are DROPPED, not persisted (see gates);
+ * - EMPTY graph (after filtering) → false WITHOUT writing: an empty store must
+ *   never clobber the last good autosave (the crash may have emptied the
+ *   store — the stale autosave is then strictly better than the "fresh"
+ *   nothing).
+ */
+export function flushWorkToAutosave(): boolean {
+  try {
+    if (!provider) return false
+    const snapshot = provider()
+    if (!snapshot) return false
+    if (!Array.isArray(snapshot.nodes) || !Array.isArray(snapshot.edges)) return false
+
+    const nodes = snapshot.nodes.filter(isPlausibleNode)
+    const keptNodeIds = new Set(nodes.map((n) => (n as { id: string }).id))
+    const edges = snapshot.edges.filter((e) => isPlausibleEdge(e, keptNodeIds))
+    if (nodes.length === 0 && edges.length === 0) return false
+
+    saveAutosave({
+      timestamp: Date.now(),
+      scenarioId: snapshot.scenarioId ?? getCurrentScenarioId() ?? undefined,
+      nodes: nodes as AutosaveData['nodes'],
+      edges: edges as AutosaveData['edges'],
+      // Boundary cast — see CrashSnapshot doc: restore validates before use.
+      ceeAnalysisReady: (snapshot.ceeAnalysisReady ?? undefined) as AutosaveData['ceeAnalysisReady'],
+    })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -19,6 +19,7 @@ import { addRun, generateGraphHash, loadRuns, type StoredRun } from './store/run
 import { RUN_COMPLETED_WITHOUT_VERDICT, deriveAnalysisFreshnessUpdate, type AnalysisFreshnessState } from './store/analysisFreshness'
 import * as scenarios from './store/scenarios'
 import type { ScenarioFraming } from './store/scenarios'
+import { registerCrashSnapshotProvider } from './persist/crashFlush'
 import type { GraphHealth, ValidationIssue, NeedleMover } from './validation/types'
 import type { Document, Citation } from './share/types'
 import type { ComparisonResult } from './snapshots/types'
@@ -4820,6 +4821,21 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 if (typeof window !== 'undefined') {
   ;(window as any).useCanvasStore = useCanvasStore
 }
+
+// Crash-moment autosave flush: give the canvas error boundary (entry chunk,
+// must not import this module) a way to snapshot the CURRENT graph into the
+// autosave slot the production boot path restores from. Registered at module
+// init so it covers every surface that mounts the store, with no mount-order
+// or unmount-timing dependency. See persist/crashFlush.ts.
+registerCrashSnapshotProvider(() => {
+  const s = useCanvasStore.getState()
+  return {
+    nodes: s.nodes,
+    edges: s.edges,
+    scenarioId: s.currentScenarioId,
+    ceeAnalysisReady: s.ceeAnalysisReady ?? undefined,
+  }
+})
 
 // F3 (graph-visuals): the focus dim must never survive its focused node.
 // Nodes can be removed by MANY paths (delete action, AI patch, undo, full


### PR DESCRIPTION
## The defect (dress rehearsal 2026-07-20, Step 8 — worst trust event)

Mid-session deploy → Analysis tab's lazy chunk 404'd → error boundary promised *"Your work is auto-saved. Reloading will restore the last snapshot"* → reload returned an **empty canvas**. Entire session gone. Scenario `0985abff…` survived server-side — a clue that the graph, not the identity, was lost.

## Mechanism (verified at tip `2e5abdb1`, production build, real browser)

| Claim | Finding |
|---|---|
| "Reload editor" restores a snapshot | **Theatre.** `handleRecover` read `canvas-snapshot-*` (written **only** by the manual ⌘S snapshot feature) and wrote `canvas-state-v1` — a key with **zero readers** on any boot path (`/usr/bin/grep` sweep: only the ErrorBoundary itself references it). |
| Autosave protects the work | **Racy.** The real mechanism (`olumi-canvas-autosave` → ReactFlowGraph's PROD init effect) is written by a 30 s interval (`useAutosave`) that a crash outraces — everything since the last tick is unpersisted at exactly the moment the promise is shown. Nothing flushes at crash time. |
| Identity is lost on reload (prior suspect) | **Already fixed upstream of this PR.** `olumi-canvas-current-scenario-id` is persisted by both V4/V5 turn paths; the rehearsal id survived its reloads. The graph was what vanished. |
| Deployed build differed from tip | No — `git log 68a9879e..HEAD` and `8007d03d..HEAD` touch **none** of the persistence files. The defect is live at HEAD. |

## Fix (minimal — no new persistence layer)

1. **`src/canvas/persist/crashFlush.ts`** (new): `flushWorkToAutosave()` writes the *current* store graph into the autosave slot the boot path actually reads. The store registers a snapshot provider at module init (the boundary lives in the entry chunk and must not import the store). Structurally broken nodes/edges are **dropped** (persisting a malformed node would rehydrate the crash and loop); an **empty** graph never clobbers a good autosave.
2. **`ErrorBoundary.tsx`**: flush at `componentDidCatch` (crash-moment) **and** on "Reload editor"; dead-key restore deleted; route-hash guard pins `#/canvas` if the HashRouter hash was desynced (a guest reloading without a hash lands on the sign-in gate); **stale-chunk errors get one automatic reload**, rate-limited (5 min, sessionStorage) so a broken deploy shows the panel instead of looping.
3. Guests: all localStorage — works signed-out. Signed-in Supabase persistence (`useScenario`) untouched.

## Evidence

- **RED-first / mutation-check** (throwaway worktree at pre-fix HEAD, spec copied in): tests 1, 2, 4a, 5 **fail** pre-fix; 3 & 4b are invariant guards that hold on both sides (declared before running). 7/7 green with the fix.
- **jsdom proves** the flush/guard/filter logic and localStorage writes. It **cannot** prove a real reload rehydrates — that is the PROD-only boot effect, so:
- **Real-browser check** (production build, `vite preview`): fresh guest → graph + scenario id injected → **no autosave yet** (inside the 30 s window the old code loses) → genuine render crash → boundary → autosave present with the 4 valid nodes (poison filtered, `flushedWorkToAutosave: true` in SAFE_DEBUG) → "Reload editor" → **all 4 nodes, both edges, same scenario id, same route restored**. Chunk-crash path (chunk deleted, `#/dev/hero-gallery`): exactly one auto-reload (boot marker gone), second failure loop-guarded → panel, autosave intact throughout, work still on `#/canvas` after.

## Gates

- `pnpm run typecheck` clean · eslint **0 errors** on touched files (9 pre-existing warnings on untouched store.ts lines)
- `vitest --changed origin/staging`: **6172 passed** (471 files, 0 failed)
- ci-guards: `duplicates` + `ds` pass; `sandbox` + `zustand` red **byte-identical to pre-fix baseline** (pre-existing)
- Wide `tsc -p tsconfig.app.json`: set-wise identical vs pre-fix baseline (**2323 = 2323**, 0 new, 0 removed)

Draft — do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)