### PR TITLE
perf(cleanup): drop the duplicate health probe, restore the persistence early-return, derive the retry-suffix guard

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,23 +59,28 @@
         // Add data-testid for E2E tests
         if (safeEl) safeEl.setAttribute('data-testid', 'safe-screen');
         
-        // Health check (only if safe screen is visible)
+        // Health check. This inline script runs during parse, so the safe
+        // screen is still on screen here; `healthEl` is static markup and is
+        // always present.
+        //
+        // NO FALLBACK PROBE. There used to be a `/bff/engine/health` retry in
+        // the .catch(). It was a provable duplicate: public/_redirects sends
+        // BOTH `/engine/*` (line 7) and `/bff/engine/*` (line 4) to the same
+        // host, and netlify.toml's only engine rule (line 154) sends
+        // `/bff/engine/*` there too — so the retry re-issued the byte-identical
+        // request that had just failed, costing a second round-trip (worst
+        // case, a second Render cold-start wait) on every page load, for a
+        // <pre> the app hides milliseconds later. Any per-environment redirect
+        // swap applies to both prefixes equally, so they cannot diverge.
+        // (The pre-#395 fallback was a hardcoded cross-origin host — CSP-blocked,
+        // so it was rejected at zero network cost. Making it same-origin made it
+        // real. Deleted 2026-07-20.)
         var healthEl = document.getElementById('poc-health');
         if (healthEl) {
           fetch(edge + '/health').then(function(r){ return r.json(); }).then(function(d){
             healthEl.textContent = 'OK via proxy\n' + JSON.stringify(d, null, 2);
-          }).catch(function(){
-            // Same-origin retry only — never a cross-origin service host from
-            // this inline script. The per-environment _redirects/netlify.toml
-            // decide which backend /bff/engine/* reaches, so staging probes
-            // staging and production probes production. (The previous
-            // hardcoded production host was CSP-blocked console noise on
-            // every staging load — rehearsal 2026-07-20.)
-            fetch('/bff/engine/health').then(function(r){ return r.json(); }).then(function(d){
-              healthEl.textContent = 'OK via bff\n' + JSON.stringify(d, null, 2);
-            }).catch(function(e2){
-              healthEl.textContent = 'FAIL\n' + String(e2);
-            });
+          }).catch(function(e){
+            healthEl.textContent = 'FAIL\n' + String(e);
           });
         }
       })();

--- a/src/canvas/ErrorBoundary.tsx
+++ b/src/canvas/ErrorBoundary.tsx
@@ -251,6 +251,32 @@ export class CanvasErrorBoundary extends Component<Props, State> {
     // whole session to a reassuring "Reload editor" button. The store is a
     // module singleton and still holds the graph while this panel is shown,
     // so the flush captures work right up to the crash.
+    //
+    // NOT a duplicate of the componentDidCatch flush, though it looks like
+    // one. It re-reads the store (crashFlush pulls useCanvasStore.getState()
+    // fresh on every call — it holds no snapshot), and the store CAN move
+    // between the crash and this click:
+    //   · This boundary is mounted at several depths. The inner mount
+    //     (PreAnalysisPanelV3 → PanelBody) sits BELOW ConversationProvider, so
+    //     a crash there never unmounts useConversation and never runs its
+    //     abort cleanup. An in-flight turn parked on `await callV5Turn` then
+    //     resolves and runs straight into applyDraftResult/reconcileAppliedGraph,
+    //     which setState the whole graph — after componentDidCatch returned.
+    //   · The "Dismiss and continue" branch below re-renders the live canvas
+    //     under a banner and wires its Reload to this same handler, so the user
+    //     may keep editing for an unbounded period before clicking.
+    //   · applyDraftResult's own saveAutosave is partial (omits
+    //     ceeAnalysisReady/selectedGoalNode) and fires before its later
+    //     backfill setStates, which otherwise reach storage only via the 30s
+    //     periodic autosave — and that interval is cleared when an outer crash
+    //     unmounts useAutosave.
+    //   · On an empty graph crashFlush returns without writing at all, so the
+    //     first flush can be a no-op.
+    // handleReload() below is a hard destroy-and-rehydrate: anything in memory
+    // and not in the autosave slot at this instant is gone permanently. This
+    // call is the last-write barrier before that, and is correct as a barrier
+    // even where no mutation happened — the alternative is auditing every
+    // async store writer in the app, forever.
     flushWorkToAutosave()
 
     // Reload must reconnect to the SAME route (and thereby the same scenario:

--- a/src/canvas/conversation/__tests__/ChatThread.chipGroup.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.chipGroup.spec.tsx
@@ -44,9 +44,11 @@ beforeEach(() => {
 // Fixtures
 // ---------------------------------------------------------------------------
 
+let seq = 0
 function makeMsg(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  seq += 1
   return {
-    id: 'msg-1',
+    id: `msg-${seq}`,
     role: 'assistant',
     content: 'Hello',
     timestamp: new Date(),
@@ -115,5 +117,41 @@ describe('ChatThread: chip grouping', () => {
     )
 
     expect(screen.queryByTestId('response-chip-group')).not.toBeInTheDocument()
+  })
+
+  // Pins WHICH assistant message owns the chips. The two fixtures above hold
+  // a single assistant message, so first-of-role and last-of-role are
+  // indistinguishable there — a mutation taking the FIRST assistant message
+  // passed them both. This fixture separates the two.
+  it('takes chips from the LAST assistant message, not the first', () => {
+    const messages = [
+      makeMsg({ content: 'older reply', actionChips: [{ ...chip, id: 'stale', label: 'Stale chip' }] }),
+      makeMsg({ role: 'user', content: 'follow-up question' }),
+      makeMsg({ content: 'newest reply', actionChips: [{ ...chip, id: 'fresh', label: 'Fresh chip' }] }),
+    ]
+    render(
+      <ChatThread
+        messages={messages}
+        isThinking={false}
+        longRunningHint={null}
+        nodeCount={1}
+        patchBlockStates={new Map()}
+        patchRejections={new Map()}
+        onChipClick={noop}
+        onPatchAccept={vi.fn()}
+        onPatchDismiss={vi.fn()}
+        onFeedback={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+
+    const chips = screen.getByTestId('suggested-chips')
+    expect(chips.textContent).toContain('Fresh chip')
+    expect(chips.textContent).not.toContain('Stale chip')
+
+    // ...and the group wraps the NEWEST assistant message, not the older one.
+    const group = screen.getByTestId('response-chip-group')
+    expect(group.textContent).toContain('newest reply')
+    expect(group.textContent).not.toContain('older reply')
   })
 })

--- a/src/canvas/conversation/hooks/useThreadPersistence.ts
+++ b/src/canvas/conversation/hooks/useThreadPersistence.ts
@@ -162,12 +162,43 @@ export function useThreadPersistence(
 
     // Track every currently-pending visible user send — new dispatches AND
     // failed bubbles re-pended by a retry.
-    for (const msg of messages) {
-      if (msg.role !== 'user') continue
+    //
+    // This does NOT need a full-transcript walk. A user message can only
+    // BECOME 'pending' in two places, both in useConversation's dispatch
+    // block (~3120-3136):
+    //   1. a fresh dispatch (`addUserBubble`) — appends a new bubble, so it
+    //      always arrives in `newMessages`;
+    //   2. a retryLast re-pend (`skipUserBubble`) — always targets
+    //      `lastVisibleUserBubbleIdRef`, which is only ever assigned the id of
+    //      a just-added bubble, i.e. the LAST user-role message. (ChatThread
+    //      wires its retry affordance off this same derivation.)
+    // So the candidate set is `newMessages` + that one message. A third case
+    // would have to mutate deliveryState from outside that block; there is
+    // none.
+    const trackIfPending = (msg: ConversationMessage) => {
+      if (msg.role !== 'user') return
       if (msg.deliveryState === 'pending' && !handledMessageIdsRef.current.has(msg.id)) {
         deferredPendingIdsRef.current.add(msg.id)
       }
     }
+    for (const msg of newMessages) trackIfPending(msg)
+    // The retry re-pend target: the last user-role message. Scans back only
+    // over the trailing non-user messages, not the transcript.
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i]
+      if (msg.role === 'user') {
+        trackIfPending(msg)
+        break
+      }
+    }
+
+    // Bail out before the resolution walk when there is provably nothing to
+    // do. With no deferred ids the resolution pass below is a no-op (it is
+    // gated on the same condition) and `resolvedUserMessages` stays empty, so
+    // this returns exactly where the check at the end of this block would —
+    // it just skips a full-transcript walk to get there. Restores the O(1)
+    // early return that the pre-deferral version had as a length compare.
+    if (newMessages.length === 0 && deferredPendingIdsRef.current.size === 0) return
 
     // Resolution pass: deferred messages whose delivery state has settled.
     // 'sent' → persist now; 'failed' → drop for good (never committed —

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -102,12 +102,22 @@ export const ChatThread = memo(function ChatThread({
   // resend — the LAST user message. Older failed attempts keep the
   // "Not delivered" marker without a retry button (clicking retry there
   // would resend different text than the bubble shows).
-  const lastUserMsg = [...messages].reverse().find(m => m.role === 'user')
+  // One backwards pass captures both last-of-role messages. Previously this
+  // was two `[...messages].reverse().find(...)` chains — two full array copies
+  // plus two reverses per render, on a path that runs ~60x/sec once streaming
+  // is enabled.
+  let lastUserMsg: ConversationMessage | undefined
+  let lastAssistantMsg: ConversationMessage | undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (!lastUserMsg && m.role === 'user') lastUserMsg = m
+    if (!lastAssistantMsg && m.role === 'assistant') lastAssistantMsg = m
+    if (lastUserMsg && lastAssistantMsg) break
+  }
   const failedSendRetryId =
     lastUserMsg && lastUserMsg.deliveryState === 'failed' ? lastUserMsg.id : null
 
   // Get suggested chips from last assistant message
-  const lastAssistantMsg = [...messages].reverse().find(m => m.role === 'assistant')
   const suggestedChips = lastAssistantMsg?.actionChips ?? []
   // Only hide inline chips when SuggestedChips will actually render something.
   // SuggestedChips filters out chips without a message field (e.g. retry chips),

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -218,6 +218,15 @@ export const GoalNode = memo((props: NodeProps) => {
     </>
   ) : null
 
+  // Rendered identically by the two no-target branches below (post-analysis
+  // and pre-analysis). They are mutually exclusive on `isPostAnalysis`, so one
+  // element serves both.
+  const helpSetTargetChip = (
+    <div className="mt-1.5">
+      <NodeChip chipId="goal_help_set_target" actionType={null} label="Help me set a target" message="Help me define what success looks like for this goal. What metrics or thresholds should I aim for?" />
+    </div>
+  )
+
   return (
     <div
       ref={nodeElRef as React.Ref<HTMLDivElement>}
@@ -248,9 +257,7 @@ export const GoalNode = memo((props: NodeProps) => {
                 ? 'Analysis complete. Set a target to see your chances.'
                 : 'Analysis finished. Set a target and check the graph for incomplete inputs.'}
             </p>
-            <div className="mt-1.5">
-              <NodeChip chipId="goal_help_set_target" actionType={null} label="Help me set a target" message="Help me define what success looks like for this goal. What metrics or thresholds should I aim for?" />
-            </div>
+            {helpSetTargetChip}
           </>
         )}
 
@@ -263,9 +270,7 @@ export const GoalNode = memo((props: NodeProps) => {
             <p className={`${typography.edgeLabel} text-text-light mt-0.5 m-0`}>
               Add a measurable success target, e.g. metric, threshold or deadline
             </p>
-            <div className="mt-1.5">
-              <NodeChip chipId="goal_help_set_target" actionType={null} label="Help me set a target" message="Help me define what success looks like for this goal. What metrics or thresholds should I aim for?" />
-            </div>
+            {helpSetTargetChip}
           </>
         )}
 

--- a/src/v5/__tests__/failureTypeRetryability.drift.spec.ts
+++ b/src/v5/__tests__/failureTypeRetryability.drift.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * DRIFT SIMULATION — the mutation-check for RETRY_INSTRUCTION_SENTENCE.
+ *
+ * `resolveFailureBaseCopy` strips a trailing "please retry" sentence from
+ * FAILURE_USER_TEXT when the retry affordance is withheld, so the copy never
+ * instructs an action the UI gives the user no way to take.
+ *
+ * That strip used to be three exact-suffix literals (' Please retry.',
+ * ' Please try again.', ' Please retry shortly.') — a hand-kept mirror of
+ * sentence endings inside the vendored @talchain/schemas copy. Today's
+ * vendored table happens to match those literals exactly, which is precisely
+ * why the mirror was invisible: a derived test over the REAL table passes
+ * either way. Only a table that has DRIFTED can tell the two implementations
+ * apart.
+ *
+ * This file supplies that table. Reverting the regex to the three literals
+ * turns these tests RED.
+ *
+ * Lives in its own file because `vi.mock` is hoisted file-wide — mocking the
+ * table inside failureTypeRetryability.test.ts would corrupt that file's
+ * verbatim-copy expectations.
+ *
+ * The mock spreads `importOriginal` rather than replacing the module: a bare
+ * factory REPLACES it, silently dropping every other export (the failure mode
+ * that once killed 51 tests at collection).
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@talchain/schemas/boundary', async importOriginal => {
+  const actual = await importOriginal<typeof import('@talchain/schemas/boundary')>()
+  return {
+    ...actual,
+    FAILURE_USER_TEXT: {
+      ...actual.FAILURE_USER_TEXT,
+      // Phrasings that none of the three old literals ended with. Each is a
+      // plausible re-vendor of the same intent.
+      INTERNAL_ERROR: 'Something went wrong on our side. Please try again in a moment.',
+      UPSTREAM_TIMEOUT: 'An upstream service did not respond in time. Please retry in a few seconds.',
+      LLM_UNAVAILABLE: 'The model is temporarily unavailable. Please try again later.',
+    },
+  }
+})
+
+const { FAILURE_USER_TEXT } = await import('@talchain/schemas/boundary')
+const { resolveFailureBaseCopy } = await import('../failureTypeRetryability')
+type FailureTypeLiteral = keyof typeof FAILURE_USER_TEXT
+
+describe('resolveFailureBaseCopy — survives a re-vendor that rephrases the retry instruction', () => {
+  it('the drifted table really is drifted (positive control)', () => {
+    // If the mock silently failed to apply, every assertion below would be
+    // testing the ORIGINAL copy — which the old literals match — and would
+    // pass while proving nothing.
+    expect(FAILURE_USER_TEXT.INTERNAL_ERROR).toBe(
+      'Something went wrong on our side. Please try again in a moment.',
+    )
+    const OLD_LITERALS = [' Please retry.', ' Please try again.', ' Please retry shortly.']
+    for (const code of ['INTERNAL_ERROR', 'UPSTREAM_TIMEOUT', 'LLM_UNAVAILABLE'] as const) {
+      expect(OLD_LITERALS.some(s => FAILURE_USER_TEXT[code].endsWith(s))).toBe(false)
+    }
+  })
+
+  it('strips drifted retry sentences the old exact-suffix list would have missed', () => {
+    expect(resolveFailureBaseCopy('INTERNAL_ERROR', false)).toBe(
+      'Something went wrong on our side.',
+    )
+    expect(resolveFailureBaseCopy('UPSTREAM_TIMEOUT', false)).toBe(
+      'An upstream service did not respond in time.',
+    )
+    expect(resolveFailureBaseCopy('LLM_UNAVAILABLE', false)).toBe(
+      'The model is temporarily unavailable.',
+    )
+  })
+
+  it('leaves no retry language anywhere in the drifted table', () => {
+    const codes = Object.keys(FAILURE_USER_TEXT) as FailureTypeLiteral[]
+    const survivors = codes.filter(code =>
+      /retry|try\s+again/i.test(resolveFailureBaseCopy(code, false)),
+    )
+    expect(survivors).toEqual([])
+  })
+
+  it('still returns the drifted copy verbatim when retry IS offered', () => {
+    const codes = Object.keys(FAILURE_USER_TEXT) as FailureTypeLiteral[]
+    for (const code of codes) {
+      expect(resolveFailureBaseCopy(code, true)).toBe(FAILURE_USER_TEXT[code])
+    }
+  })
+})

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import type { BoundaryError } from '@talchain/schemas/boundary'
+import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
+import type { BoundaryError, FailureTypeLiteral } from '@talchain/schemas/boundary'
 import {
   isRetryable,
   checkRetryableAgreement,
@@ -166,3 +167,41 @@ describe('resolveFailureBaseCopy — copy agrees with the retry decision', () =>
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// DERIVED guard — the strip must hold for EVERY code in the vendored table,
+// not for a hand-listed three. The strip used to be three exact-suffix
+// literals mirroring sentence endings inside @talchain/schemas; a re-vendor
+// that rephrased a code would silently no-op the strip (fail open) and no
+// test would notice. This derives the expectation from the table itself.
+// ---------------------------------------------------------------------------
+describe('resolveFailureBaseCopy — DERIVED over the whole vendored table', () => {
+  const CODES = Object.keys(FAILURE_USER_TEXT) as FailureTypeLiteral[]
+
+  it('has a non-trivial table to iterate (positive control)', () => {
+    // An empty/absent table would make every assertion below vacuous.
+    expect(CODES.length).toBeGreaterThanOrEqual(8)
+    expect(
+      CODES.filter(c => /retry|try\s+again/i.test(FAILURE_USER_TEXT[c])).length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('leaves NO retry language in any code once the affordance is withheld', () => {
+    const survivors = CODES.filter(code =>
+      /retry|try\s+again/i.test(resolveFailureBaseCopy(code, false)),
+    )
+    expect(survivors).toEqual([])
+  })
+
+  it('never empties the copy, and never alters it when retry IS offered', () => {
+    for (const code of CODES) {
+      expect(resolveFailureBaseCopy(code, false).length).toBeGreaterThan(0)
+      expect(resolveFailureBaseCopy(code, true)).toBe(FAILURE_USER_TEXT[code])
+    }
+  })
+})
+
+// The drift-simulation counterpart (a re-vendor that rephrases the retry
+// instruction) lives in failureTypeRetryability.drift.spec.ts — it needs a
+// module mock, and vi.mock is hoisted file-wide, which would corrupt the
+// verbatim-copy expectations above.

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -56,18 +56,27 @@ export function resolveRetryable(
 }
 
 /**
- * Sentences in FAILURE_USER_TEXT that instruct the user to retry. When the
- * retry affordance is withheld (server said non-retryable), copy telling the
- * user to "please retry" beside a missing Try-again chip instructs an action
- * the UI gives them no way to take — the same honesty rule
- * ceeRecovery.buildFailureRender enforces on the V4 path. Exact-suffix
- * matches only; unmatched copy passes through unchanged (fail open).
+ * Trailing sentence in FAILURE_USER_TEXT that instructs the user to retry.
+ * When the retry affordance is withheld (server said non-retryable), copy
+ * telling the user to "please retry" beside a missing Try-again chip
+ * instructs an action the UI gives them no way to take — the same honesty
+ * rule ceeRecovery.buildFailureRender enforces on the V4 path.
+ *
+ * This was three exact-suffix literals (' Please retry.', ' Please try
+ * again.', ' Please retry shortly.') — a HAND-KEPT MIRROR of sentence endings
+ * inside the vendored @talchain/schemas copy. A re-vendor phrasing a code
+ * differently ("Please try again in a moment.") silently no-opped the strip
+ * and FAILED OPEN, with no test to catch it. The pattern generalises over the
+ * sentence instead: any trailing "Please retry…" / "Please try again…"
+ * sentence, however it continues. `[^.]*` keeps it from crossing a sentence
+ * boundary. Copy with no such sentence passes through unchanged (fail open).
+ *
+ * The derived guard in failureTypeRetryability.test.ts iterates every key of
+ * FAILURE_USER_TEXT and asserts no retry language survives showRetry=false,
+ * so the next re-vendor that drifts the phrasing fails loudly rather than
+ * silently shipping copy that contradicts the UI.
  */
-const RETRY_INSTRUCTION_SUFFIXES = [
-  ' Please retry.',
-  ' Please try again.',
-  ' Please retry shortly.',
-] as const
+const RETRY_INSTRUCTION_SENTENCE = /\s*Please\s+(?:retry|try\s+again)\b[^.]*\.\s*$/i
 
 /**
  * Base failure copy that AGREES with the retry decision. With the retry
@@ -81,12 +90,10 @@ export function resolveFailureBaseCopy(
 ): string {
   const canonical = FAILURE_USER_TEXT[code]
   if (showRetry) return canonical
-  for (const suffix of RETRY_INSTRUCTION_SUFFIXES) {
-    if (canonical.endsWith(suffix)) {
-      return canonical.slice(0, canonical.length - suffix.length)
-    }
-  }
-  return canonical
+  const stripped = canonical.replace(RETRY_INSTRUCTION_SENTENCE, '')
+  // Fail open rather than render nothing: copy that is ONLY a retry
+  // instruction keeps its canonical text.
+  return stripped.length > 0 ? stripped : canonical
 }
 
 /**

--- a/src/v5/responseRouter.ts
+++ b/src/v5/responseRouter.ts
@@ -32,7 +32,6 @@
  */
 import type { OlumiResponse, FailureTypeLiteral, BoundaryError } from '@talchain/schemas/boundary';
 
-import type { ErrorSource, ParseFailureKind } from './responseParser';
 import type { V5CallResult } from './v5Adapter';
 
 /**
@@ -45,13 +44,20 @@ import type { V5CallResult } from './v5Adapter';
  * didn't go through") instead of the false server-fault claim
  * ("Something went wrong on our side").
  */
+/**
+ * Reduced 2026-07-20 to the one field anything actually reads. `httpStatus`,
+ * `source` and `parseFailureKind` were written here and read NOWHERE — a
+ * complete reader sweep across `src` (including co-located `__tests__`) and
+ * `tests` found zero consumers, with the `network` read at
+ * transportFailure.ts:85 as the positive control proving the sweep could see
+ * a reader. The object is never spread, stringified, logged or attached to a
+ * message, so there was no whole-object passthrough keeping them alive
+ * either; useConversation only forwards it, and transportFailure reads
+ * `network` alone. Debug export already reconstructs `parse_failure_kind`
+ * independently from the raw CEE envelope
+ * (components/debug/utils/exportBundle.ts), so diagnostics lose nothing.
+ */
 export interface TypedErrorTransportMeta {
-  /** HTTP status of the failed response. Absent when fetch itself threw. */
-  httpStatus?: number;
-  /** Header/body-derived origin classification from the parser. */
-  source?: ErrorSource;
-  /** Which parse failure fired (non_json / non_ok_non_boundary / ...). */
-  parseFailureKind?: ParseFailureKind;
   /**
    * True when the request never produced a response at all (fetch threw:
    * offline, DNS, CORS preflight). The strongest "didn't reach the server"
@@ -101,11 +107,6 @@ export function routeV5Response(result: V5CallResult): RenderTarget {
       code: 'INTERNAL_ERROR',
       ...(result.raw !== undefined ? { rawBody: result.raw } : {}),
       transportMeta: {
-        ...(result.http_status !== undefined ? { httpStatus: result.http_status } : {}),
-        ...(result.source !== undefined ? { source: result.source } : {}),
-        ...(result.parse_failure_kind !== undefined
-          ? { parseFailureKind: result.parse_failure_kind }
-          : {}),
         // The fetch-threw parse_error (v5Adapter catch) is the only one
         // with no http_status — every parseV5Response branch stamps one.
         network: result.http_status === undefined,


### PR DESCRIPTION
Seven cleanups from a quality review of today's shipped wave. Each was re-verified at the bytes before changing — **two of the seven were overturned by that check** and are reported below as findings rather than fixes.

---

## FIX 1 — `index.html`: delete the fallback health probe 🔴

**The one with a live per-page-load cost.**

#395 replaced a CSP-blocked fallback with `fetch('/bff/engine/health')`. The old target was cross-origin and CSP-blocked — **rejected at zero network cost**. The new one is same-origin and *allowed*, so it became a real request.

Verified both redirect rules myself:

| Rule | File | Target |
|---|---|---|
| `/engine/*` | `public/_redirects:7` | `https://plot-lite-service-staging.onrender.com/:splat` |
| `/bff/engine/*` | `public/_redirects:4` | `https://plot-lite-service-staging.onrender.com/:splat` |
| `/bff/engine/*` | `netlify.toml:154` | `https://plot-lite-service-staging.onrender.com/:splat` |

`netlify.toml` has **no** `/engine/*` rule, and its only `context.*` block is `[context.staging.environment]` (env vars, not redirects). So both prefixes resolve to the same host, and any per-environment swap applies to both equally — they cannot diverge, which retires the comment's stated justification.

- **Before:** primary probe fails → fallback re-issues the **byte-identical** request → a full extra round-trip **on every page load**, worst case a second Render cold-start wait, for a `<pre id="poc-health">` the app hides milliseconds later.
- **After:** primary probe fails → `FAIL` written to the same element. One request.
- **Frequency:** every page load, on the failure path.

I chose deletion over the gating alternative. The comment two lines above promises "only if safe screen is visible" and `if (healthEl)` is indeed always true — but this inline script runs *during parse*, before `__APP_MOUNTED__('pre-react')`, so the safe screen genuinely is visible at that instant. The gate isn't false in effect, and the fallback is a provable duplicate regardless of gating. Comment corrected to say what the code actually does.

---

## FIX 2 — `useThreadPersistence`: hoist the bail-out

Two full-transcript `for` loops ran before the "nothing to do" check, so every `messages` identity change cost 1–2 full walks where it once cost a length compare.

A user message can only *become* `pending` in two places, both in `useConversation`'s dispatch block:

1. **fresh dispatch** (`addUserBubble`, ~:3120) — appends a new bubble, so it always arrives in `newMessages`;
2. **retry re-pend** (`skipUserBubble`, :3134-3136) — always targets `lastVisibleUserBubbleIdRef`, which is only ever assigned a just-added bubble id, i.e. **the last user-role message**. `ChatThread:105` already wires its retry affordance off this same derivation.

Tracking now scans `newMessages` plus that one candidate (a backwards scan bounded by trailing non-user messages, typically 0–2), then returns early when `newMessages` is empty and `deferredPendingIdsRef` is empty. That early return is **exactly equivalent** to the existing end-of-block check — the resolution pass is gated on the same set being non-empty — it just skips a full walk to reach the same outcome.

- **Frequency:** every `messages` identity change (every streaming tick, every block-state update).

### FIX 2b — `deferredPendingIdsRef` KEPT, not derived

The proposed derivation is *semantically* sound on today's code, but I kept the ref for two reasons:

1. **It defeats FIX 2.** `messages.filter(m => m.role === 'user' && m.deliveryState === 'sent' && !handled.has(m.id))` is an O(n) walk over the whole transcript on *every* render — precisely the cost FIX 2 exists to remove. The ref *is* the O(1) early return.
2. **It drops two guards.** The `newMessages` path skips `msg.synthetic` and `_threadMeta.entryId` (hydrated) messages; the filter checks neither. It is safe today only because `hydrateThread.ts` sets `deliveryState` **nowhere** (verified: 0 occurrences) — an unstated cross-file invariant. If hydration ever recorded delivery state (plausible; it *is* transcript-honesty data), every hydrated user turn would be silently re-persisted on every render.

---

## FIX 3 — `ChatThread`: one backwards pass

Replaced two `[...messages].reverse().find(...)` chains with a single backwards loop capturing both last-of-role messages. **Two full array copies + two reverses per render → zero allocations.**

- **Frequency:** every render; latent hot path at ~60×/sec once streaming is enabled.

---

## FIX 4 — `failureTypeRetryability`: derive the guard

Three exact-suffix literals mirrored sentence endings inside vendored `@talchain/schemas` `FAILURE_USER_TEXT`. A re-vendor phrasing a code differently would silently no-op the strip (**fail open** — copy telling the user to retry beside a missing Try-again chip) with no test to catch it.

Replaced with `/\s*Please\s+(?:retry|try\s+again)\b[^.]*\.\s*$/i` (`[^.]*` prevents crossing a sentence boundary), plus a fail-open guard so copy that is *only* a retry instruction keeps its canonical text rather than rendering empty.

Two new test layers:
- **Derived guard** over `Object.keys(FAILURE_USER_TEXT)` asserting no `/retry|try again/i` survives `showRetry === false`, with a positive control that the table is non-empty and *does* contain retry language (otherwise the assertion is vacuous).
- **Drift simulation** (`failureTypeRetryability.drift.spec.ts`) mocking a re-vendored table. Separate file because `vi.mock` is hoisted file-wide and would corrupt the sibling file's verbatim-copy expectations; the mock spreads `importOriginal` rather than replacing the module.

---

## FIX 5 — `ErrorBoundary`: second flush KEPT ⚠️ premise refuted

The review's exception clause fires. The `:254` flush is **not** redundant:

- `crashFlush` re-reads `useCanvasStore.getState()` on every call — it holds **no** snapshot, so the two calls read different points in time.
- The boundary is mounted at several depths. The **inner** mount (`PreAnalysisPanelV3` → `PanelBody`) sits *below* `ConversationProvider`, so a crash there never unmounts `useConversation` and never runs its abort cleanup. An in-flight turn parked on `await callV5Turn` then resolves — its abort guard passes, nothing aborted it — and runs straight into `applyDraftResult`/`reconcileAppliedGraph`, which `setState` the whole graph **after `componentDidCatch` returned**. No awaits in between; it's one synchronous continuation.
- The **"Dismiss and continue"** branch re-renders the *live canvas* under a banner and wires its Reload to this same handler — the user may keep editing for an unbounded period before clicking.
- `applyDraftResult`'s own `saveAutosave` is partial (omits `ceeAnalysisReady`, `selectedGoalNode`) and fires *before* its own later backfill `setState`s.
- On an empty graph `crashFlush` returns **without writing**, so the first flush can be a no-op entirely.
- `handleRecover` ends in `window.location.reload()` — a hard destroy-and-rehydrate. This is the last-write barrier before that, correct as a barrier even where no mutation occurred.

Kept, with a comment stating all of the above — nothing previously did.

---

## FIX 6 — `responseRouter`: reduce `TypedErrorTransportMeta`

`httpStatus`, `source`, `parseFailureKind` reduced away; `network` retained.

Zero-reader claim re-verified with a **positive control**: the same `/usr/bin/grep` sweep that returned nothing for the three fields *did* find the `network` read at `transportFailure.ts:85`, so the method demonstrably sees readers. Scope: all of `src` (including co-located `__tests__`) and `tests`, plus `e2e/`, `scripts/`, `tools/`, `contracts/`, `netlify/`.

Also confirmed **no whole-object passthrough** — no `...meta`, no `JSON.stringify`, never stored on a message or attached to the export bundle. `isTransportFailure` treats the object opaquely (existence check only); `buildTransportFailureCopy` reads `meta.network` alone.

**`transportFailure.ts` was NOT touched** (other lane owns it) — it reads only `network`, so the reduction compiles standalone. Diagnostics lose nothing: `exportBundle.ts` already reconstructs `parse_failure_kind` independently from the raw CEE envelope. Now-unused `ErrorSource` / `ParseFailureKind` type imports removed.

---

## FIX 7 — `GoalNode`: hoist the duplicated chip

`goal_help_set_target` appeared byte-identically at `:252` and `:267`. The two branches are mutually exclusive on `isPostAnalysis`, so one element serves both.

---

## Mutation results

Run in a **throwaway worktree**, never in the working tree.

| Fix | Mutation | Result |
|---|---|---|
| FIX 4 | Revert regex → three literals | 🔴 **RED** — drift spec fails naming exactly `UPSTREAM_TIMEOUT`, `LLM_UNAVAILABLE`, `INTERNAL_ERROR`. The derived test on the real table still passed, confirming why the drift simulation is needed: today's vendored copy matches the literals exactly, so a derived test alone cannot tell the two implementations apart. |
| FIX 2 | Remove retry re-pend candidate scan | 🔴 **RED** — existing `retry journey` case in `useThreadPersistence.deliveryState.spec.ts:189` fails. |
| FIX 3 (user side) | Forward pass, first-of-role | 🔴 **RED** — `ChatThread.sendFailedRetry.spec.tsx` third case fails. |
| FIX 3 (assistant side) | Forward pass, first-of-role | ⚪ **initially GREEN — coverage gap.** Both `chipGroup` fixtures held a *single* assistant message, so first and last are indistinguishable. Added a third fixture pinning that chips come from the newest assistant message; it now goes 🔴 RED under the same inversion (`expected 'Stale chip' to contain 'Fresh chip'`). |

**One honest note on method:** my first FIX 3 mutation appeared not to bite. It was an ineffective mutation, not a coverage gap — I had kept the `break` on both-found, so backwards iteration still yielded last-of-role. Re-run as a genuine forward-pass inversion, it bit. The assistant-side gap above is real and was only found *after* correcting the mutation.

FIX 1, 6, 7 are not behavioural-with-a-test: FIX 1 is a network-path deletion evidenced by the redirect files, FIX 6 a pure deletion evidenced by the positive-control reader sweep, FIX 7 a hoist covered by existing GoalNode rendering tests.

---

## Skipped for file ownership

**Nothing was skipped.** No file on the reserved list was touched — verified against the final diff. FIX 6 was the only fix that risked reaching into `transportFailure.ts`, and it did not need to.

---

## Gates

| Gate | Result |
|---|---|
| `pnpm run typecheck` | ✅ clean |
| `pnpm run lint` (touched files) | ✅ **0 errors** (1 warning: a pre-existing `console.debug` at `ChatThread.tsx:96`, untouched) |
| `npx vitest run --changed origin/staging` | ✅ 94 files passed, 1 skipped — **1379 passed**, 31 skipped |
| `npx vitest run tests/ci-guards` | ✅ 7 files, **50 passed** |
| Wide `tsc -p tsconfig.app.json --noEmit` | ✅ **2323 = 2323**, set-wise **identical** — `comm` empty in *both* directions vs a matched base worktree at `42390d7f` with real `node_modules` |

The first wide-tsc baseline attempt wrote 0 bytes and was discarded as invalid rather than read as "clean"; the number above comes from a re-run against a pristine `git worktree` at the same SHA sharing this clone's `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
