### PR TITLE
fix(guards): comment-aware scanning per the #386 ruling — audit + shared tokeniser

### DIFF
--- a/src/canvas/__tests__/british-english.spec.ts
+++ b/src/canvas/__tests__/british-english.spec.ts
@@ -7,11 +7,19 @@
  * - colour (not color)
  * - behaviour (not behavior)
  * - optimise (not optimize)
+ *
+ * SCOPE: user-facing copy only. Comments and JSDoc are stripped before scanning
+ * (shared literal-aware tokeniser, tests/helpers/stripSourceComments), so a
+ * design-note that merely mentions an American spelling does not redden the guard
+ * — the #386 comment-scanning-footgun fix, applied here. See the
+ * "comment-aware scanning" describe block for the both-directions mutation proof.
  */
 
-import { describe, it, expect } from 'vitest'
-import { readFileSync, readdirSync } from 'fs'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { readFileSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
+import { tmpdir } from 'os'
+import { stripComments } from '../../../tests/helpers/stripSourceComments'
 
 describe('S4-COPY: British English Verification', () => {
   // American spellings that should be British
@@ -89,7 +97,19 @@ describe('S4-COPY: British English Verification', () => {
    * Find American spellings in user-facing strings
    */
   function findAmericanSpellings(filePath: string): Array<{ line: number; text: string; american: string; british: string }> {
-    const content = readFileSync(filePath, 'utf-8')
+    const raw = readFileSync(filePath, 'utf-8')
+    // Comments are NOT user-facing copy. Strip them (literal-aware, comment chars
+    // → spaces so line numbers stay accurate) BEFORE the scan, so a design-note or
+    // JSDoc that merely MENTIONS an American spelling — e.g. the wire field name
+    // `analyze_sentiment` documented in ceeRecovery.ts — can never redden this
+    // guard. This is the same footgun PR #386 fixed in the alpha-emission guard;
+    // both now share tests/helpers/stripSourceComments. String, template and JSX
+    // literals survive stripping, so genuinely rendered copy is still scanned.
+    // Markdown/README files carry no code comments and are user-facing prose end
+    // to end, so they are scanned whole.
+    const content = /\.(tsx?|jsx?|css)$/.test(filePath)
+      ? stripComments(raw, filePath)
+      : raw
     const lines = content.split('\n')
     const violations: Array<{ line: number; text: string; american: string; british: string }> = []
 
@@ -397,6 +417,66 @@ describe('S4-COPY: British English Verification', () => {
       }
 
       expect(violations.length).toBe(0)
+    })
+  })
+
+  /**
+   * MUTATION PROOF (both directions), the #386 discipline applied to this guard.
+   *
+   * The guard's INPUT is now comment-stripped, so two things must hold at once:
+   *   (i)  a real American spelling in RENDERED copy (a string literal / JSX text
+   *        that reaches the UI) is still caught — the positive control, without
+   *        which every "no violations" assertion above is vacuous; and
+   *   (ii) a bare American spelling that lives ONLY inside a comment / JSDoc no
+   *        longer trips it (the footgun that forced ceeRecovery.ts to spell its
+   *        example `analyze_sentiment` to dodge the guard).
+   *
+   * These call the real `findAmericanSpellings` against tiny on-disk files, so
+   * they exercise the exact read → strip → scan path the guard uses in CI.
+   */
+  describe('comment-aware scanning (footgun parity with #386)', () => {
+    let dir: string
+    beforeAll(() => {
+      dir = mkdtempSync(join(tmpdir(), 'british-english-guard-'))
+    })
+    afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+    const scan = (name: string, source: string) => {
+      const p = join(dir, name)
+      writeFileSync(p, source)
+      return findAmericanSpellings(p)
+    }
+
+    it('POSITIVE CONTROL: an American spelling in a user-facing STRING LITERAL is caught', () => {
+      const v = scan('violation.tsx', "export const label = 'Analyze results'\n")
+      expect(v.map((x) => x.american)).toContain('analyze')
+    })
+
+    it('a bare "analyze" that lives ONLY in a // line comment does not trip', () => {
+      const v = scan(
+        'line-comment.tsx',
+        '// we deliberately analyze producer prose upstream\nexport const A = 1\n',
+      )
+      expect(v).toEqual([])
+    })
+
+    it('a bare "analyze" in a /* */ block comment / JSDoc does not trip', () => {
+      const v = scan(
+        'block-comment.tsx',
+        '/**\n * We do not analyze producer prose here — see the note below.\n' +
+          ' * A wire field name like `analyze_sentiment` stays verbatim.\n */\n' +
+          'export const B = 2\n',
+      )
+      expect(v).toEqual([])
+    })
+
+    it('a genuine violation SURVIVES when a comment on the same line is stripped', () => {
+      // The string literal is user-facing (RED); the trailing comment that also
+      // says "optimize" is stripped (not counted). Proves stripping is surgical.
+      const v = scan('mixed.tsx', "export const t = 'Customize your view' // optimize later\n")
+      const words = v.map((x) => x.american)
+      expect(words).toContain('customize')
+      expect(words).not.toContain('optimize')
     })
   })
 })

--- a/src/canvas/conversation/ceeRecovery.ts
+++ b/src/canvas/conversation/ceeRecovery.ts
@@ -312,11 +312,17 @@ export function formatRecoveryHints(hints: string[] | undefined): string {
  *
  * We deliberately do NOT rewrite producer prose — no en-dash substitution, no
  * -ize/-ise mapping, no case fixing. Any such rewrite is lossy on inputs it
- * cannot distinguish: an em dash inside a quoted user brief, a wire field name
- * like `analyze_sentiment` or a quoted identifier, a proper noun that must stay
- * capitalised. Corrupting a correct suggestion is worse than passing through
- * a stylistically off one, because the suggestion is the *only* specific
- * guidance the user gets on a non-retryable failure.
+ * cannot distinguish: an em dash inside a quoted user brief, an American spelling
+ * the producer deliberately chose (it may write `analyze`, not `analyse`), a wire
+ * field name or quoted identifier, a proper noun that must stay capitalised.
+ * Corrupting a correct suggestion is worse than passing through a stylistically
+ * off one, because the suggestion is the *only* specific guidance the user gets
+ * on a non-retryable failure.
+ *
+ * (This natural wording — a bare `analyze` — was previously mangled to
+ * `analyze_sentiment` in commit 49e8c53e purely to dodge the British-English CI
+ * guard, which then scanned comments. That guard is now comment-aware, so the
+ * example reads plainly again and stands as the living proof of the fix.)
  *
  * Reject-only guards are safe because rejection degrades to the caller's own
  * generic copy. Rewriting has no such safe fallback. If house style needs

--- a/tests/ci-guards/semantic-colour-alpha.spec.ts
+++ b/tests/ci-guards/semantic-colour-alpha.spec.ts
@@ -50,6 +50,7 @@ import { tmpdir } from 'node:os'
 import postcss from 'postcss'
 import tailwind from 'tailwindcss'
 import config from '../../tailwind.config.js'
+import { stripComments } from '../helpers/stripSourceComments'
 
 const SRC = resolvePath(__dirname, '../../src')
 
@@ -74,159 +75,11 @@ function walk(dir: string, out: string[] = []): string[] {
   return out
 }
 
-/**
- * Remove comments from a file's text BEFORE the utility scan runs, so a Tailwind
- * token quoted in a comment is never mistaken for a shipped class.
- *
- * WHY. This guard catches opacity-modified utilities that reach the browser and
- * silently emit no CSS. A token inside a comment renders nothing, so it is a
- * non-defect; worse, scanning comments punishes authors for documenting the very
- * anti-pattern this guard teaches (`bg-info/4` in ExpertBlock's header comment
- * reddened staging exactly this way, #385). Only the INPUT TEXT is pre-processed
- * here: every surviving match still compiles against the real Tailwind and every
- * emission assertion is untouched.
- *
- * Comment characters are replaced with spaces (newlines kept) so any line/column
- * the scan reports stays accurate and offsets do not shift; the file is never
- * collapsed.
- *
- * A `//`, a comment-open or a comment-close inside a string, template literal or
- * regex literal is NOT a comment: `content-['//']`, a URL in a string and a
- * regex of slashes all keep their code. Template `${...}` interpolations are real
- * code, so a class inside `${cond ? 'bg-info/30' : ''}` survives.
- *
- * This is a small hand-written state machine rather than a dependency: the repo
- * ships no comment-stripper (strip-comments / strip-json-comments are absent from
- * package.json and node_modules), and a general JS parser (acorn/espree) is not a
- * dependency either, so pulling one in for a CI guard's input pre-pass would be a
- * heavier, less transparent addition than the tokeniser below.
- */
-function stripComments(text: string, file: string): string {
-  return /\.css$/.test(file) ? stripCssComments(text) : stripJsComments(text)
-}
-
-/** May a `/` here begin a regex literal, given the previous significant char? */
-function regexCanStart(prev: string): boolean {
-  // After a value (identifier, number, `)`, `]`, `}`, `.`, or a string/template
-  // close) a `/` is division. Everywhere else (operators, `(`, `,`, `=`, `:`,
-  // `[`, `{`, `;`, `!`, `&`, `|`, `?`, `+`, `-`, `*`, `%`, `<`, `>`, `^`, `~`) or
-  // at the start of the file, a `/` opens a regex.
-  return prev === '' || !/[A-Za-z0-9_$)\].}'"`]/.test(prev)
-}
-
-/**
- * Strip `//` line and block comments from JS/TS/JSX/TSX, treating string,
- * template and regex literals (and `${...}` interpolations) as code.
- */
-function stripJsComments(src: string): string {
-  const a = src.split('')
-  const n = a.length
-  const blank = (i: number): void => {
-    if (a[i] !== '\n' && a[i] !== '\r') a[i] = ' '
-  }
-
-  type State = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex'
-  let state: State = 'code'
-  let prev = '' // previous significant code char, for regex detection
-  let regexClass = false // inside a regex `[...]` char class, where `/` is literal
-  let interp = 0 // brace depth inside the current `${...}`; 0 = not in one
-  const interpStack: number[] = [] // suspended depths, for templates nested in `${...}`
-
-  let i = 0
-  while (i < n) {
-    const c = a[i]
-    const d = i + 1 < n ? a[i + 1] : ''
-
-    if (state === 'code') {
-      if (c === '/' && d === '/') { blank(i); blank(i + 1); state = 'line'; i += 2; continue }
-      if (c === '/' && d === '*') { blank(i); blank(i + 1); state = 'block'; i += 2; continue }
-      if (c === "'") { state = 'single'; prev = c; i++; continue }
-      if (c === '"') { state = 'double'; prev = c; i++; continue }
-      if (c === '`') { state = 'template'; prev = c; i++; continue }
-      if (c === '/' && regexCanStart(prev)) { state = 'regex'; regexClass = false; prev = c; i++; continue }
-      if (interp > 0) {
-        if (c === '{') interp++
-        else if (c === '}') {
-          interp--
-          if (interp === 0) { state = 'template'; interp = interpStack.pop() ?? 0; prev = c; i++; continue }
-        }
-      }
-      if (!/\s/.test(c)) prev = c
-      i++
-      continue
-    }
-    if (state === 'line') {
-      if (c === '\n') { state = 'code'; i++; continue }
-      blank(i); i++; continue
-    }
-    if (state === 'block') {
-      if (c === '*' && d === '/') { blank(i); blank(i + 1); state = 'code'; i += 2; continue }
-      blank(i); i++; continue
-    }
-    if (state === 'single') {
-      if (c === '\\') { i += 2; continue }
-      if (c === "'") { state = 'code'; prev = c; i++; continue }
-      i++; continue
-    }
-    if (state === 'double') {
-      if (c === '\\') { i += 2; continue }
-      if (c === '"') { state = 'code'; prev = c; i++; continue }
-      i++; continue
-    }
-    if (state === 'template') {
-      if (c === '\\') { i += 2; continue }
-      if (c === '`') { state = 'code'; prev = c; i++; continue }
-      if (c === '$' && d === '{') { interpStack.push(interp); interp = 1; state = 'code'; prev = '{'; i += 2; continue }
-      i++; continue
-    }
-    // state === 'regex'
-    if (c === '\\') { i += 2; continue }
-    if (c === '[') { regexClass = true; i++; continue }
-    if (c === ']') { regexClass = false; i++; continue }
-    if (c === '/' && !regexClass) { state = 'code'; prev = c; i++; continue }
-    i++
-  }
-  return a.join('')
-}
-
-/** Strip only block comments from CSS (no line comments), treating strings as code. */
-function stripCssComments(src: string): string {
-  const a = src.split('')
-  const n = a.length
-  const blank = (i: number): void => {
-    if (a[i] !== '\n' && a[i] !== '\r') a[i] = ' '
-  }
-
-  type State = 'code' | 'block' | 'single' | 'double'
-  let state: State = 'code'
-
-  let i = 0
-  while (i < n) {
-    const c = a[i]
-    const d = i + 1 < n ? a[i + 1] : ''
-
-    if (state === 'code') {
-      if (c === '/' && d === '*') { blank(i); blank(i + 1); state = 'block'; i += 2; continue }
-      if (c === "'") { state = 'single'; i++; continue }
-      if (c === '"') { state = 'double'; i++; continue }
-      i++; continue
-    }
-    if (state === 'block') {
-      if (c === '*' && d === '/') { blank(i); blank(i + 1); state = 'code'; i += 2; continue }
-      blank(i); i++; continue
-    }
-    if (state === 'single') {
-      if (c === '\\') { i += 2; continue }
-      if (c === "'") { state = 'code'; i++; continue }
-      i++; continue
-    }
-    // state === 'double'
-    if (c === '\\') { i += 2; continue }
-    if (c === '"') { state = 'code'; i++; continue }
-    i++
-  }
-  return a.join('')
-}
+// The literal-aware comment stripper wired into `usedClasses` below now lives in
+// the shared tests/helpers/stripSourceComments module, so this guard and the
+// British-English copy guard cannot drift apart (see #386 and that module's
+// header for the full rationale). Its behaviour is pinned by the two describe
+// blocks at the foot of this file plus the shared module's own spec.
 
 /** The config's colour key paths, flattened the way Tailwind names them. */
 function colourKeys(): string[] {

--- a/tests/helpers/stripSourceComments.ts
+++ b/tests/helpers/stripSourceComments.ts
@@ -1,0 +1,161 @@
+/**
+ * Literal-aware comment stripper for source-scanning CI guards.
+ *
+ * WHY THIS EXISTS. Several guards read raw source text and regex-scan it for a
+ * pattern — an opacity-modified Tailwind utility, an American spelling in copy,
+ * a banned API. When the pattern also appears inside a COMMENT the scan pulls it
+ * in and reddens CI over text that renders nothing and ships nothing. `bg-info/4`
+ * quoted in ExpertBlock's header comment reddened staging exactly this way (#385),
+ * and an `analyze` in a ceeRecovery.ts design-note JSDoc had to be reworded to
+ * dodge the British-English guard. Both are the same footgun: the guard's intent
+ * is about RENDERED / SHIPPED text, but it scans comments.
+ *
+ * The fix (PR #386, the alpha-emission guard) is to strip comments from the INPUT
+ * TEXT before the scan runs. Comment characters are replaced with spaces (newlines
+ * kept) so every line/column the scan reports stays accurate and offsets never
+ * shift — the file is never collapsed. String, template and regex literals are
+ * treated as CODE, so a `//` in a URL string, a `/*` inside a quoted example, a
+ * regex full of slashes, and a class inside a `${...}` interpolation all survive.
+ *
+ * This is EXTRACTED here (rather than copied into each guard) so the two-plus
+ * guards that need it share ONE implementation and cannot drift apart — the
+ * hand-maintained-mirror is the dominant defect class in this codebase, so a
+ * second hand-kept copy of a state machine is exactly what we do not want.
+ *
+ * It is a small hand-written state machine rather than a dependency: the repo
+ * ships no comment-stripper (strip-comments / strip-json-comments are absent from
+ * package.json and node_modules), and a general JS parser (acorn/espree) is not a
+ * dependency either, so pulling one in for a CI guard's input pre-pass would be a
+ * heavier, less transparent addition than the tokeniser below.
+ */
+
+/**
+ * Remove comments from a file's text, dispatching on extension: `.css` files get
+ * block-comment stripping only; everything else is treated as JS/TS/JSX/TSX.
+ */
+export function stripComments(text: string, file: string): string {
+  return /\.css$/.test(file) ? stripCssComments(text) : stripJsComments(text)
+}
+
+/** May a `/` here begin a regex literal, given the previous significant char? */
+export function regexCanStart(prev: string): boolean {
+  // After a value (identifier, number, `)`, `]`, `}`, `.`, or a string/template
+  // close) a `/` is division. Everywhere else (operators, `(`, `,`, `=`, `:`,
+  // `[`, `{`, `;`, `!`, `&`, `|`, `?`, `+`, `-`, `*`, `%`, `<`, `>`, `^`, `~`) or
+  // at the start of the file, a `/` opens a regex.
+  return prev === '' || !/[A-Za-z0-9_$)\].}'"`]/.test(prev)
+}
+
+/**
+ * Strip `//` line and block comments from JS/TS/JSX/TSX, treating string,
+ * template and regex literals (and `${...}` interpolations) as code.
+ */
+export function stripJsComments(src: string): string {
+  const a = src.split('')
+  const n = a.length
+  const blank = (i: number): void => {
+    if (a[i] !== '\n' && a[i] !== '\r') a[i] = ' '
+  }
+
+  type State = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex'
+  let state: State = 'code'
+  let prev = '' // previous significant code char, for regex detection
+  let regexClass = false // inside a regex `[...]` char class, where `/` is literal
+  let interp = 0 // brace depth inside the current `${...}`; 0 = not in one
+  const interpStack: number[] = [] // suspended depths, for templates nested in `${...}`
+
+  let i = 0
+  while (i < n) {
+    const c = a[i]
+    const d = i + 1 < n ? a[i + 1] : ''
+
+    if (state === 'code') {
+      if (c === '/' && d === '/') { blank(i); blank(i + 1); state = 'line'; i += 2; continue }
+      if (c === '/' && d === '*') { blank(i); blank(i + 1); state = 'block'; i += 2; continue }
+      if (c === "'") { state = 'single'; prev = c; i++; continue }
+      if (c === '"') { state = 'double'; prev = c; i++; continue }
+      if (c === '`') { state = 'template'; prev = c; i++; continue }
+      if (c === '/' && regexCanStart(prev)) { state = 'regex'; regexClass = false; prev = c; i++; continue }
+      if (interp > 0) {
+        if (c === '{') interp++
+        else if (c === '}') {
+          interp--
+          if (interp === 0) { state = 'template'; interp = interpStack.pop() ?? 0; prev = c; i++; continue }
+        }
+      }
+      if (!/\s/.test(c)) prev = c
+      i++
+      continue
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; i++; continue }
+      blank(i); i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { blank(i); blank(i + 1); state = 'code'; i += 2; continue }
+      blank(i); i++; continue
+    }
+    if (state === 'single') {
+      if (c === '\\') { i += 2; continue }
+      if (c === "'") { state = 'code'; prev = c; i++; continue }
+      i++; continue
+    }
+    if (state === 'double') {
+      if (c === '\\') { i += 2; continue }
+      if (c === '"') { state = 'code'; prev = c; i++; continue }
+      i++; continue
+    }
+    if (state === 'template') {
+      if (c === '\\') { i += 2; continue }
+      if (c === '`') { state = 'code'; prev = c; i++; continue }
+      if (c === '$' && d === '{') { interpStack.push(interp); interp = 1; state = 'code'; prev = '{'; i += 2; continue }
+      i++; continue
+    }
+    // state === 'regex'
+    if (c === '\\') { i += 2; continue }
+    if (c === '[') { regexClass = true; i++; continue }
+    if (c === ']') { regexClass = false; i++; continue }
+    if (c === '/' && !regexClass) { state = 'code'; prev = c; i++; continue }
+    i++
+  }
+  return a.join('')
+}
+
+/** Strip only block comments from CSS (no line comments), treating strings as code. */
+export function stripCssComments(src: string): string {
+  const a = src.split('')
+  const n = a.length
+  const blank = (i: number): void => {
+    if (a[i] !== '\n' && a[i] !== '\r') a[i] = ' '
+  }
+
+  type State = 'code' | 'block' | 'single' | 'double'
+  let state: State = 'code'
+
+  let i = 0
+  while (i < n) {
+    const c = a[i]
+    const d = i + 1 < n ? a[i + 1] : ''
+
+    if (state === 'code') {
+      if (c === '/' && d === '*') { blank(i); blank(i + 1); state = 'block'; i += 2; continue }
+      if (c === "'") { state = 'single'; i++; continue }
+      if (c === '"') { state = 'double'; i++; continue }
+      i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { blank(i); blank(i + 1); state = 'code'; i += 2; continue }
+      blank(i); i++; continue
+    }
+    if (state === 'single') {
+      if (c === '\\') { i += 2; continue }
+      if (c === "'") { state = 'code'; i++; continue }
+      i++; continue
+    }
+    // state === 'double'
+    if (c === '\\') { i += 2; continue }
+    if (c === '"') { state = 'code'; i++; continue }
+    i++
+  }
+  return a.join('')
+}


### PR DESCRIPTION
## Why

This repo was bitten twice in one day by one footgun class: **a guard spec that scans raw source text for a pattern — user-facing copy or a forbidden code pattern — but ingests comments/JSDoc, so an innocent design-note reddens CI.** PR #386 established the ruling and the fix for `semantic-colour-alpha.spec.ts` (a literal-aware tokeniser that strips comments before the scan, keeping string/template/regex literals as code).

`british-english.spec.ts` carried the **identical unfixed footgun**: its `isUserFacing` heuristic explicitly treated `//`, `/*` and `*` (JSDoc) lines as user-facing copy and scanned them for American spellings. The cost is on record — `ceeRecovery.ts` had to misspell its own JSDoc example as `analyze_sentiment` (commit `49e8c53e`) purely to dodge the `\banalyze\b` word boundary, rather than the guard being fixed.

## What this PR does (scope: the assigned KNOWN instance + the shared tokeniser)

1. **Extracts #386's tokeniser verbatim into a shared module** — `tests/helpers/stripSourceComments.ts` (`stripComments` / `stripJsComments` / `stripCssComments` / `regexCanStart`). Both `semantic-colour-alpha.spec.ts` (inline copy removed, −159 lines) and `british-english.spec.ts` now import it, so the two cannot drift apart. This is the derive-don't-mirror requirement: one implementation, two consumers.
2. **Fixes `british-english.spec.ts`** — comments are stripped (literal-aware; strings/JSX text survive, so genuinely rendered copy is still scanned) before the scan. Markdown/README is scanned whole (no code comments). A both-directions mutation-proof `describe` block is added.
3. **Restores `ceeRecovery.ts`'s JSDoc** to the natural bare `analyze` (comment-only) as living proof — the guard scans this file and stays green.

## Mutation evidence (both directions)

Ran against the real `findAmericanSpellings` (read → strip → scan path) with tiny on-disk files.

**With the strip DISABLED** (`content = raw`), `npx vitest run british-english.spec.ts -t "comment-aware scanning"`:

```
Tests  3 failed | 1 passed
  ✓ POSITIVE CONTROL: American spelling in a string literal is caught   (still RED-capable → guard not vacuous)
  ✗ a bare "analyze" in a // line comment does not trip                 expected [...] to equal []
  ✗ a bare "analyze" in a /* */ block comment / JSDoc does not trip     expected [...] to equal []
  ✗ a genuine violation survives when a same-line comment is stripped   expected ['optimize','customize'] not to include 'optimize'
```

- **(i) still catches real copy:** the positive control — `analyze` in a string literal — passes even with the strip off, so the guard is not measuring nothing (trap 13).
- **(ii) comments no longer trip:** the three comment-only cases go RED only when the strip is removed, proving they depend on it.

**With the strip ENABLED** (as shipped): `british-english.spec.ts` 13/13 green, `semantic-colour-alpha.spec.ts` 12/12 green, incl. the real `ceeRecovery.ts` with its restored bare `analyze` in a comment.

## Gates

- `pnpm run typecheck` (tsc -p tsconfig.ci.json) — clean.
- Touched guard suites — 25/25 green.
- `npx vitest run --changed --bail=1` — the changed graph is green **except** `conversation-flow.spec.ts`, which is a **pre-existing** failure: it fails 12/12 on the pristine `staging` tree with all changes stashed (proven), and my only product change is comment-only. Not introduced here.
- ESLint on all touched files — clean.

---

## Complete audit manifest

Every spec/script that reads source with `readFileSync`/`readdirSync`/glob was classified. **(a)** = footgun (intent conflicts with scanning comments/strings); **(b)** = correct-as-is (genuinely wants comments, or its regex can't false-positive by design); **(c)** = safe (already strips / scans compiled or rendered output / reads fixtures or modules / filenames-only).

| Guard | Class | Action |
|---|---|---|
| `src/canvas/__tests__/british-english.spec.ts` | **(a)** | **FIXED this PR** — shared tokeniser + mutation proof |
| `tests/ci-guards/semantic-colour-alpha.spec.ts` | (c) | **Converged this PR** onto the shared tokeniser (was the #386 origin) |
| `src/components/results/__tests__/no-raw-influence-read.spec.ts` | **(a)** | Deferred — code-pattern; a commented-out `// return d.influenceScore` false-reds. Needs comments+strings blanked (`blankNonCode` class), not the copy tokeniser |
| `src/components/results/__tests__/no-message-render.spec.ts` | **(a)** | Deferred — code-pattern; a commented-out `{item.message}` / JSX comment false-reds. `blankNonCode` class |
| `tests/ci-guards/autosave-projection-single-source.spec.ts` | **(a)** | Deferred — code-pattern; skips leading full-line comments only, inline/string mentions still false-red. `blankNonCode` class |
| `src/components/results/__tests__/TornadoChart.dormancy.spec.ts` | **(a)** | Deferred — dormancy tripwire; a commented-out prop inside the `<TornadoChart>` tag false-reds. `blankNonCode` class |
| `src/components/results/analysis-hero/__tests__/inertness.spec.ts` | **(a)** | Deferred — import-ban; a commented-out `import` matches `SPEC_RE`. `blankNonCode` class |
| `src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts` | **(a)** | Deferred — import-ban; string/comment import false-positive already documented in-repo (`hygiene.spec.ts` L66-74 forced a `.join('/')` workaround). `blankNonCode` class |
| `src/components/results/analysis-hero/__tests__/hygiene.spec.ts` | **(a)** | Deferred — whole-file regex for `robustnessVerdict`/`fetch(`; a design-note comment mentioning them false-reds. `blankNonCode` class |
| `src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts` | **(a)** | Deferred — `.includes()`-scans a whole feature-dir source blob for forbidden identifiers, no strip. `blankNonCode` class |
| `src/__tests__/wave2-replay-gate.spec.ts` | **(a)** | Deferred — cast-budget counts `as any` over raw source; a comment/string mentioning a cast inflates the count. `blankNonCode` class |
| `src/__tests__/indexHtmlHealthProbe.spec.ts` | **(a)** | Deferred — scans raw `index.html` for a `*.onrender.com` URL; a commented-out host (`<!-- -->`) false-reds. Needs an **HTML** comment stripper (neither existing helper covers HTML) |
| `tools/ci-guards/check-gotosandbox.mjs` | **(a)** | Deferred — substring scan of e2e specs for `#/sandbox`; a comment mention false-reds. Wants `stripComments` (keep the route string) but is **`.mjs`** — cannot import the `.ts` helper without a build step |
| `src/components/results/analysis-hero/__tests__/fixtureIsolation.spec.tsx` | **(a)** low | Deferred — mostly specifier-anchored (safe); residual: the un-anchored `/analysis-hero\/fixtures/` offenders alternative could match a comment |
| `src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx` | (c) | Deferred (mirror) — already strips comments, but via a **naive inline regex** (`/\/\*…\*\//` + `/\/\/.*$/`) that mishandles literals. Converge onto the shared tokeniser in the follow-up |
| `src/canvas/components/__tests__/aiPanelV2.typography.spec.ts` | (b) | None — code-pattern (forbidden Tailwind classes); skips full comment lines |
| `src/canvas/conversation/__tests__/conversationCss.spec.ts` | (b) | None — code-pattern (DS token in CSS); minor residual (a `--warning` in a CSS comment) but not the copy footgun |
| `tools/ci-guards/check-ds-compliance.mjs` | (b) | None — code-pattern (DS drift); hex/emoji classes strip, the rest ride a net-new baseline ratchet |
| `src/__tests__/no-shim-regression.spec.ts` | (b) | None — deliberately scans config text and **requires a marker comment to EXIST**; stripping would break it |
| `src/canvas/__tests__/cameraMotion.sourceScan.spec.ts` | (c) | None — uses `blankNonCode` (blanks comments+strings) already |
| `src/services/__tests__/graphWriteSourceGuard.spec.ts` | (c) | None — uses `blankNonCode` already (**duplicate** of cameraMotion's — a mirror; see follow-up) |
| `src/styles/__tests__/brand-tokens.spec.ts` | (c) | None — WCAG ratios from resolved tokens; its hex scan strips `/* */` |
| `src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts` | (c) | None — forbidden-API source scan strips comments first |
| `src/canvas/panels/__tests__/TemplatesPanel.mergeFreshness.spec.ts` | (c) | None — source-routing scan strips comments first |
| `src/__tests__/vitestExcludeRegister.spec.ts` | (c) | None — comment/string-aware bracket parser |
| `src/canvas/nodes/__tests__/GhostOptionNode.contrast.spec.ts` | (c) | None — anchored CSS-in-JS decl + measured colour |
| `tests/ci-guards/text-light-contrast.spec.ts` | (c) | None — computed contrast ratios from tokens |
| `src/canvas/__tests__/layout.semantic.spec.ts` | (c) | None — module/fixture geometry |
| `src/v5/__tests__/explainChips.vocabulary.spec.ts` | (c) | None — JSON fixture + module imports |
| `src/__tests__/netlifyCsp.spec.ts` | (c) | None — extracts the CSP directive value |
| `src/__tests__/orchestratorProxyHeaders.spec.ts` | (c) | None — extracts an allowlist array, presence checks |
| `src/lib/__tests__/talchainSchemasVersion.spec.ts` | (c) | None — version-pin equality (JSON) |
| `tests/ci-guards/vite.supabase-stub-decoupling.spec.ts` | (c) | None — module import + scoped presence checks |
| `src/canvas/components/pre-analysis-v3/__tests__/flagGate.spec.ts` | (c) | None — extracts a small object literal |
| `tests/ci-guards/artefact-template-token-mirror.spec.ts` | (c) | None — structured token value-mirror |
| `tests/brand/vars-present.test.tsx` | (c) | None — `--var` presence only |
| `src/v5/__tests__/phase3TypedBlocks.spec.ts` | (c) | None — fixtures + Zod |
| `src/v5/__tests__/responseParser.actionTypeAlias.spec.ts` | (c) | None — fixture parsing |
| `tools/ci-guards/check-duplicates.mjs` | (c) | None — filenames only, no content read |
| `tools/ci-guards/check-flags-drift.mjs` | (c) | None — diffs two JSON manifests |

### Why the deferred (a) cluster is a follow-up, not this PR (no heroics)

The ~12 remaining footguns are **not the same small fix** and splitting them off keeps this PR to the assigned copy footgun:

- **Most are code-pattern guards** (no live call/import/cast to X) whose correct fix blanks **comments *and* string bodies** — a `blankNonCode` variant, *not* the copy tokeniser (which deliberately keeps strings). The repo already has a proven `blankNonCode`, but **duplicated** across `cameraMotion.sourceScan.spec.ts` and `graphWriteSourceGuard.spec.ts`.
- **A few need yet other strippers:** `check-gotosandbox.mjs` wants `stripComments` but is `.mjs` (can't import a `.ts` helper without a build step); `indexHtmlHealthProbe.spec.ts` needs an **HTML** (`<!-- -->`) stripper neither helper provides.
- Each needs its own both-directions mutation check.

**Recommended follow-up (one coherent change):** extend `tests/helpers/stripSourceComments.ts` with a shared `blankNonCode` (fold in the two existing duplicates), route the code-pattern footguns through it and the string/route ones through `stripComments`, add an HTML variant for the index.html probe, resolve the `.ts`/`.mjs` boundary for the two `.mjs` guards, and converge `glossaryCompliance`'s naive strip. None of these files is in a lane-locked directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
