### PR TITLE
fix(ci): make the staging→main promotion path green — zustand guard

### DIFF
--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -117,6 +117,13 @@ jobs:
       - name: Type check
         run: pnpm run typecheck
 
+      # Runs the SAME React #185 (Zustand selector) guard as ci.yml's main-only
+      # `tsc` job. Without this, the guard first fires at staging→main promotion,
+      # i.e. the alarm goes off at the worst possible moment. Enforcing here (it
+      # is green) so a regression is caught on the staging path before promotion.
+      - name: React 185 guard (Zustand selectors)
+        run: pnpm run ci:guard:zustand
+
   # ── Full test suite (sharded 4-way) ───────────────────────────────────
   vitest:
     name: Full Test Suite (shard ${{ matrix.shard }}/${{ strategy.job-total }})

--- a/src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts
+++ b/src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts
@@ -17,7 +17,6 @@
 
 import { useMemo } from 'react'
 import { useCanvasStore } from '../../../store'
-import { useShallow } from 'zustand/shallow'
 import { CURRENCY_SYMBOLS, classifyUnit, unwrapInterventionValue } from '../../../utils/labelUtils'
 import type { Node, Edge } from '@xyflow/react'
 import type { BiasType } from '../primitives/BiasIcon'
@@ -594,9 +593,12 @@ function hasNegativeStrength(edge: Edge): boolean {
  */
 export function usePreAnalysisData(_coaching?: CoachingPayload): PreAnalysisData {
   // M2 merge point: _coaching parameter will be used when CEE CoachingPayload is available
-  // Store selectors
-  const nodes = useCanvasStore(useShallow(s => s.nodes))
-  const edges = useCanvasStore(useShallow(s => s.edges))
+  // Store selectors — individual field selectors (React #185 guard): the store
+  // only replaces the nodes/edges array when a node/edge object actually changes
+  // (applyNodeChanges/applyEdgeChanges), so the reference is stable between real
+  // changes and the default Object.is equality is sufficient — no useShallow needed.
+  const nodes = useCanvasStore(s => s.nodes)
+  const edges = useCanvasStore(s => s.edges)
   const ceeAnalysisReady = useCanvasStore(s => s.ceeAnalysisReady)
   const m1ReviewAssumptions = useCanvasStore(s => s.runMeta?.m1ReviewAssumptions)
   const m1AssumptionsLedger = useCanvasStore(s => s.runMeta?.m1Coaching?.assumptions_ledger as Array<{ severity: string; message: string }> | undefined)

--- a/src/canvas/hooks/usePreAnalysisData.ts
+++ b/src/canvas/hooks/usePreAnalysisData.ts
@@ -12,7 +12,6 @@
 
 import { useMemo } from 'react'
 import { useCanvasStore } from '../store'
-import { useShallow } from 'zustand/shallow'
 import { usePreRunValidation, type ValidationBlocker } from './usePreRunValidation'
 import { useGraphReadiness } from './useGraphReadiness'
 import type { Node, Edge } from '@xyflow/react'
@@ -504,9 +503,12 @@ export interface PreAnalysisData {
  * Hook that provides normalised pre-analysis data
  */
 export function usePreAnalysisData(): PreAnalysisData {
-  // Store data
-  const nodes = useCanvasStore(useShallow(s => s.nodes))
-  const edges = useCanvasStore(useShallow(s => s.edges))
+  // Store data — individual field selectors (React #185 guard): the store only
+  // replaces the nodes/edges array when a node/edge object actually changes
+  // (applyNodeChanges/applyEdgeChanges), so the reference is stable between real
+  // changes and the default Object.is equality is sufficient — no useShallow needed.
+  const nodes = useCanvasStore(s => s.nodes)
+  const edges = useCanvasStore(s => s.edges)
   const ceeAnalysisReady = useCanvasStore(s => s.ceeAnalysisReady)
   const ceeQuality = useCanvasStore(s => s.ceeQuality)
   const ceeExtendedWarnings = useCanvasStore(s => s.ceeExtendedWarnings)

--- a/src/canvas/hooks/usePreRunValidation.ts
+++ b/src/canvas/hooks/usePreRunValidation.ts
@@ -14,7 +14,6 @@
 
 import { useMemo, useEffect, useRef } from 'react'
 import { useCanvasStore } from '../store'
-import { useShallow } from 'zustand/shallow'
 import type { Node, Edge } from '@xyflow/react'
 import type { UIOption } from '../../types/options'
 import { normaliseOptionFromLegacyNode, type LegacyOptionNode } from '../../types/options'
@@ -779,13 +778,16 @@ function createValidationFingerprint(
  * When ceeAnalysisReady is present in the store, its options take priority
  * over canvas node options for validation (CEE has resolved interventions).
  *
- * Uses shallow selectors and fingerprinting to prevent unnecessary re-renders.
+ * Uses individual field selectors and fingerprinting to prevent unnecessary re-renders.
  */
 export function usePreRunValidation(): ValidationResult {
   const outcomeNodeId = useCanvasStore((s) => s.outcomeNodeId)
-  // Use shallow comparison to prevent re-renders when array content is the same
-  const nodes = useCanvasStore(useShallow((s) => s.nodes))
-  const edges = useCanvasStore(useShallow((s) => s.edges))
+  // Individual field selectors (React #185 guard): the store only replaces the
+  // nodes/edges array when a node/edge object actually changes (applyNodeChanges/
+  // applyEdgeChanges), so the reference is stable between real changes and the
+  // default Object.is equality is sufficient — no useShallow needed.
+  const nodes = useCanvasStore((s) => s.nodes)
+  const edges = useCanvasStore((s) => s.edges)
   const ceeAnalysisReady = useCanvasStore((s) => s.ceeAnalysisReady)
   const setOutcomeNode = useCanvasStore((s) => s.setOutcomeNode)
 

--- a/tools/ci-guards/check-zustand-selectors.mjs
+++ b/tools/ci-guards/check-zustand-selectors.mjs
@@ -10,18 +10,59 @@ async function* walk(dir) {
   }
 }
 
+// Detect real imports of zustand/shallow (ignore comments, require an import
+// statement on a single line). Use [^;\n]* to prevent matching across lines
+// (which would catch comments on later lines).
+const importShallowRegex = /(^|\n)\s*import\s+[^;\n]*['"]zustand\/shallow['"]/m
+
+// React #185 landmine = a BARE object selector passed straight to useCanvasStore:
+//   useCanvasStore(s => ({ ... }))            // fresh object every render → #185
+// The arrow must be the DIRECT first argument — an optional (params) or a single
+// identifier, then `=>`, then `({`.
+//
+// A useShallow wrapper is the SAFE pattern and MUST NOT be flagged:
+//   useCanvasStore(useShallow(s => ({ ... })))
+// useShallow shallow-compares the returned object, so a fresh reference each
+// render does not churn (this is the canonical Zustand v5 multi-field pattern,
+// e.g. StyledEdge's audited 2-subscription consolidation). It does not match
+// here because after `useCanvasStore(` comes the identifier `useShallow`
+// followed by `(`, never `=>`. Bare object selectors are still caught
+// regardless of import path — that is the actual React #185 protection.
+//
+// Known, pre-existing gap (out of scope for this guard, unchanged): a block-body
+// selector `useCanvasStore(s => { return { ... } })` is not detected — matching
+// it would false-flag block bodies that return primitives.
+const bareObjectSelectorRegex = /useCanvasStore\s*\(\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*\(\s*\{/m
+
+// Positive control (repo memory: "an absence assertion is vacuous without a
+// presence proof"). If the detection ever stops catching the dangerous shape, or
+// starts catching the safe useShallow shape, fail LOUD rather than pass silently
+// on a scan that proves nothing.
+function selfTest() {
+  const mustFlag = 'const x = useCanvasStore(s => ({ a: s.a, b: s.b }))'
+  const mustFlagParen = 'const x = useCanvasStore((s) => ({ a: s.a }))'
+  const mustPass = 'const x = useCanvasStore(useShallow(s => ({ a: s.a })))'
+  const mustPassMultiline = 'useCanvasStore(\n  useShallow(s => ({\n    a: s.a,\n  })),\n)'
+  const errs = []
+  if (!bareObjectSelectorRegex.test(mustFlag)) errs.push('bare object selector no longer flagged')
+  if (!bareObjectSelectorRegex.test(mustFlagParen)) errs.push('bare (parenthesised) object selector no longer flagged')
+  if (bareObjectSelectorRegex.test(mustPass)) errs.push('useShallow-wrapped selector wrongly flagged')
+  if (bareObjectSelectorRegex.test(mustPassMultiline)) errs.push('multiline useShallow-wrapped selector wrongly flagged')
+  if (errs.length) {
+    console.error('React-185 guard SELF-TEST FAILED — its detection is broken, refusing to run:')
+    for (const e of errs) console.error(' -', e)
+    process.exit(2)
+  }
+}
+
 async function main() {
+  selfTest()
+
   const root = process.cwd()
   const srcCanvasDir = path.join(root, 'src', 'canvas')
 
   const shallowOffenders = []
   const selectorOffenders = []
-
-  // Detect real imports of zustand/shallow (ignore comments, require an import statement on a single line)
-  // Use [^;\n]* to prevent matching across lines (which would catch comments on later lines)
-  const importShallowRegex = /(^|\n)\s*import\s+[^;\n]*['"]zustand\/shallow['"]/m
-  // Detect useCanvasStore(s => ({ ... })) object selectors
-  const selectorRegex = /useCanvasStore\s*\([^)]*=>\s*\(\s*\{/m
 
   try {
     for await (const p of walk(srcCanvasDir)) {
@@ -35,7 +76,7 @@ async function main() {
         shallowOffenders.push(path.relative(root, p))
       }
 
-      if (txt.includes('useCanvasStore(') && selectorRegex.test(txt)) {
+      if (txt.includes('useCanvasStore(') && bareObjectSelectorRegex.test(txt)) {
         selectorOffenders.push(path.relative(root, p))
       }
     }
@@ -55,15 +96,15 @@ async function main() {
     }
 
     if (selectorOffenders.length) {
-      console.error('\nFiles using useCanvasStore with an object selector + shallow-style pattern:')
+      console.error('\nFiles passing a BARE object selector to useCanvasStore (fresh object every render → React #185):')
       for (const p of selectorOffenders) console.error(' -', p)
-      console.error('\nHint: replace object selectors with individual field selectors, or use getState() helpers.')
+      console.error('\nHint: wrap the selector in useShallow(...) or split it into individual field selectors.')
     }
 
     process.exit(1)
   }
 
-  console.log('React-185 guard PASS: no unsafe Zustand shallow imports or object selectors in src/canvas')
+  console.log('React-185 guard PASS: no unsafe Zustand shallow imports or bare object selectors in src/canvas')
 }
 
 main()


### PR DESCRIPTION
## Problem

`ci:guard:zustand` (the React #185 / Zustand-selector guard, `tools/ci-guards/check-zustand-selectors.mjs`) is wired **only** into `ci.yml`'s `tsc` job, which triggers on `push`/`pull_request` to **main**. The staging workflow (`staging-full-tests.yml`) runs lint + typecheck but **never** any `ci:guard:*`. The duplicate policy in `.eslintrc.cjs` is **dead** — ESLint v9 uses flat config (`eslint.config.js`), which ignores `.eslintrc.cjs` and carries none of these rules. So the standalone guard is the only live enforcement, it was **red on 4 pre-existing canvas files**, and it would first fire — invisibly — at the next **staging→main promotion**.

## Premise verification

Confirmed. Guard is main-only; staging path never runs it; guard was red on exactly 4 files. One refinement to the premise: the four files are **not** the actual React #185 landmine — every one uses `useShallow` *correctly* (the pattern that *prevents* #185). They are false positives of a guard whose heuristics are cruder than its intent (which is to catch **bare** inline-object selectors).

## The 4 files — violation / decision / why

| File | What the guard flagged | Decision | Why |
|---|---|---|---|
| `src/canvas/hooks/usePreRunValidation.ts` | imports `zustand/shallow`; `useShallow(s => s.nodes/edges)` | **Real fix** — drop `useShallow`, use plain individual selectors | Single-field array selectors. The store only replaces the `nodes`/`edges` array when a node/edge object actually changes (`applyNodeChanges`/`applyEdgeChanges`), so the reference is stable between real changes and default `Object.is` suffices. #185-safe (returns an existing ref, never a fresh one) and behaviour-neutral — this is the guard's own preferred pattern. |
| `src/canvas/hooks/usePreAnalysisData.ts` | same | **Real fix** — same | same |
| `src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts` | same | **Real fix** — same | same |
| `src/canvas/edges/StyledEdge.tsx` | object selector `useShallow(s => ({...}))` (2×) | **Fix the guard's detection** (file untouched) | These are a deliberate, documented **13→2-subscription** consolidation in the hot per-edge render path — the same audited-`useShallow` class as the whitelisted `OutputsDock`. Un-consolidating into ~13 individual selectors would **regress** a perf optimization, and Group 2's per-field conditional lens logic doesn't decompose cleanly. `useShallow`-wrapped object selectors are the canonical **safe** Zustand v5 multi-field pattern; the guard's regex just couldn't tell them from bare ones. |

## Guard change (precise, not a blanket allowlist)

`tools/ci-guards/check-zustand-selectors.mjs`:
- Object-selector detection narrowed so it flags a selector **only when the arrow is the direct first argument** of `useCanvasStore` (`useCanvasStore(s => ({...}))` — the real #185 landmine). A `useShallow(...)` wrapper no longer false-matches (after `useCanvasStore(` comes the identifier `useShallow` followed by `(`, never `=>`). **Bare object selectors still fail regardless of import path** — protection is unchanged, verified below.
- Added a **positive-control self-test** (repo doctrine: an absence assertion is vacuous without a presence proof): the guard asserts its regex matches known-bad shapes and rejects the safe `useShallow` shape, and **exits 2 (fail loud)** if detection ever silently breaks — so it can never pass on a vacuous scan.
- The `zustand/shallow` **import ban is left as-is** (now dormant after the 3 real fixes; still guards future misuse). The `OutputsDock` whitelist is untouched.

## Trigger-scope decision

**Fixed here (enforcing):** added a `React 185 guard (Zustand selectors)` step to `staging-full-tests.yml`'s `tsc` job, so the alarm now fires on the **staging path** before promotion instead of only at main-merge. It's green, so it runs enforcing. (Follow-up, not done here: `ci:guard:duplicates` and `ci:guard:ds` are also main-only and share this same "fires at the worst moment" shape — worth the same treatment once each is confirmed green on staging.)

## Gate evidence

- `pnpm run ci:guard:zustand` → **PASS (exit 0)**.
- **RED-first / positive control:** reintroducing a bare `useCanvasStore(s => ({...}))` in `src/canvas/` → guard **FAIL (exit 1)**; removing it → PASS. Self-test mutation (break the regex) → **exit 2, "SELF-TEST FAILED"**.
- `pnpm run typecheck` (`tsconfig.ci.json`) → **exit 0**. Broader `tsconfig.app.json` error set for the 3 edited files is **byte-identical to clean staging HEAD** (zero new type errors; the baseline has pre-existing errors unrelated to this change).
- `npx vitest run --changed --bail=1` → **exit 0**, 645 passed / 13 skipped across 37 files, 0 failed.
- ESLint on the 3 edited files → 0 errors (12 pre-existing warnings, none from these edits).

**DO NOT MERGE** — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)