### PR TITLE
test(convflow): make conversation-flow.spec env-independent (V5-flag coupling) — DO NOT MERGE pending review

### DIFF
--- a/src/canvas/conversation/__tests__/conversation-flow.spec.ts
+++ b/src/canvas/conversation/__tests__/conversation-flow.spec.ts
@@ -46,6 +46,16 @@ vi.mock('../../../flags', async () => {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  // This spec exercises the V4 non-streaming path (it mocks turnService's
+  // callOrchestratorTurn and forces isOrchestratorStreamingEnabled=false).
+  // Routing to V4 is gated on VITE_ENABLE_V5_ORCHESTRATOR !== 'true' (read via
+  // import.meta.env in useConversation.sendTurn, NOT via the flags module the
+  // mock above replaces). CI leaves the var unset so the V4 path runs and the
+  // mock is hit; a local .env.local that sets it to 'true' routes every turn to
+  // the unmocked V5 dispatch instead, which fails with "message didn't reach the
+  // server" (12/12 red locally, green in CI). Pin it off so the path under test
+  // is env-independent.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
   mockTrackEvent.mockReset()
@@ -61,6 +71,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.unstubAllEnvs()
   vi.useRealTimers()
 })
 


### PR DESCRIPTION
## Adjudication: why conversation-flow.spec.ts fails 12/12 locally while CI stays green

**Not a dark test.** CI genuinely runs it and it passes — verified in shard 4/4 of the latest green `staging-full-tests.yml` run (29768359738): all scenarios show `✓`. The spec is inside vitest's include globs and absent from the exclude list.

### Root cause — a silent env coupling
`conversation-flow.spec.ts` exercises the **V4 non-streaming** path: it `vi.mock`s `turnService.callOrchestratorTurn` and forces `isOrchestratorStreamingEnabled() => false` so the mock is hit.

But V4-vs-V5 routing is gated on `import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR !== 'true'` inside `useConversation.sendTurn` (via `isV5Eligible`, `src/v5/eligibility.ts`) — read **directly from `import.meta.env`**, NOT from the `flags` module the spec's mock replaces.

| Env | `VITE_ENABLE_V5_ORCHESTRATOR` | Path taken | Result |
|-----|------------------------------|------------|--------|
| CI (`staging-full-tests.yml` env block) | unset | V4 → `callOrchestratorTurn` mock hit | 12/12 green |
| Local `.env.local` (staging config) | `true` | V5 dispatch (unmocked) | 12/12 red — "message didn't reach the server" |

### Fix
Pin `VITE_ENABLE_V5_ORCHESTRATOR='false'` in `beforeEach` (unstub in `afterEach`) so the path under test is deterministic regardless of ambient env. CI behaviour is unchanged (`'false'` is still `!== 'true'` → V4 path). Same house pattern as `tests/setup/msw-env.ts` pinning `VITE_PLOT_PROXY_BASE`.

Verified: 12/12 green locally **with** `.env.local` present after the fix; was 12/12 red before (mutation-check inherent — the `stubEnv` line is the only routing-affecting change).

### Broader blast radius (out of this lane's scope — follow-up)
The same coupling makes **9 more conversation specs** red locally / green-in-CI (58 tests total): `envelopeAnalysisWiring`, `streamingLifecycle`, `analysisInputsReconciliation`, `handleEnvelopeArbitration`, `useConversation.systemEvents`, `analysisInputsWiring`, `envelopeAnalysisPersistence`, `generateDispatch`, `aiPanelTranche1`. All mock the V4 `turnService` without pinning the V5 flag. Deeper concern worth a decision: per repo memory the **live deployed path is V5=true**, so this whole family currently asserts against the V4 rollback path — green CI does not cover the live conversation flow. Recommend a dedicated lane to either (a) apply the same pin across all 9, or (b) migrate them to assert the V5 path.

**DO NOT MERGE** pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)