### PR TITLE
feat(receipts): V6 B1 — display-safe stability verdict, honest simulations row, freshness receipt (both D1 branches)

### DIFF
--- a/src/adapters/plot/types.ts
+++ b/src/adapters/plot/types.ts
@@ -26,6 +26,16 @@ export interface ReportV1 {
   model_card: {
     response_hash: string
     response_hash_algo: 'sha256'
+    /**
+     * Provenance of `response_hash`. `'producer'` = the engine's own hash
+     * (V2/PLoT path, carried verbatim). `'local'` = a device-derived content
+     * hash the UI computed because the producer sent none (V5 conversational
+     * path — a non-crypto digest, NOT an engine identity). Receipts label the
+     * local case explicitly so the hash is never read as a producer identity.
+     * Absent on older reports → treated as producer (never mislabels a real
+     * engine hash as local).
+     */
+    response_hash_source?: 'producer' | 'local'
     normalized: true
     // P0 Engine Features (optional - may not be present in all responses)
     // identifiability_tag can be enum OR string (from top-level identifiability field)

--- a/src/components/results/AdvancedSection.tsx
+++ b/src/components/results/AdvancedSection.tsx
@@ -16,14 +16,78 @@ import { evaluativeVar } from '../../styles/evaluative'
 import { Accordion } from './Accordion'
 import { selectHumanisedInferenceWarnings } from './utils/humaniseInferenceWarning'
 import { useRiskProfile, RISK_PRESETS } from '../../canvas/hooks/useRiskProfile'
+import { derivePostFooterStatus } from '../../canvas/components/utils/postAnalysisFooter'
+import type { RobustnessDisplayVerdict } from './types'
 
 type RiskPresetKey = keyof typeof RISK_PRESETS
 
 export type RiskAppetite = 'conservative' | 'neutral' | 'aggressive'
 
+// ── D1 (ask #16): freshness_reason-as-receipt doctrine — UNRULED ────────────
+// The freshness reason code (e.g. 'graph_hash_match') is doctrine-marked
+// "debug only, never user copy". v6's receipt row would promote it. Both
+// branches are built here so the ruling picks one with a ONE-LINE change and
+// NO rebuild — and with NO runtime flag (per no-dark-launches):
+//   'omit'      → the Freshness receipt row is never rendered (fail-closed
+//                 interim default per the D1 ruling).
+//   'translate' → the row renders a curated en-GB phrase for known reason
+//                 codes only; unknown codes fail closed to omit.
+// Flip THIS constant to 'translate' to activate branch (b). The compile-time
+// union keeps both branches type-live and unit-testable (translateFreshness-
+// Reason is exercised directly) without either becoming unreachable code.
+export const FRESHNESS_RECEIPT_D1_MODE: 'omit' | 'translate' = 'omit'
+
+// Curated code → en-GB copy. Unknown/absent codes fail closed to null (row
+// omitted) — the raw wire string is NEVER surfaced (reason codes are
+// debug-only per doctrine, analysisFreshness.ts:33).
+const FRESHNESS_REASON_COPY: Readonly<Record<string, string>> = {
+  graph_hash_match: 'Graph hash match',
+  graph_hash_mismatch: 'Model changed since this analysis',
+  no_prior_analysis: 'No prior analysis',
+}
+
+/**
+ * Branch (b) translator for the D1 freshness receipt. Returns the curated
+ * phrase for a known reason code, or null for any unknown/absent code (row
+ * omitted). Never echoes the raw wire string. Exported for direct unit tests
+ * so the un-mounted branch stays covered.
+ */
+export function translateFreshnessReason(
+  reason: string | null | undefined,
+): string | null {
+  if (typeof reason !== 'string') return null
+  return FRESHNESS_REASON_COPY[reason] ?? null
+}
+
 export interface AdvancedSectionProps {
-  /** Recommendation stability (0-1) */
+  /**
+   * @deprecated Do NOT render. `recommendation_stability` is DEPRECATED and no
+   * longer emitted by the producer (vendored 0.15.0 enrichment.js:250-262 — it
+   * was byte-identical to the leader's win_probability). The receipts
+   * "Result stability" row keys on the display-safe `robustnessVerdict`
+   * instead. This prop is accepted-but-ignored solely so the negative pin can
+   * prove no recommendation_stability-sourced value is rendered.
+   */
   stability?: number | null
+  /**
+   * Display-safe robustness verdict (producer `robustness.display_verdict`,
+   * normalised fail-closed upstream). Drives the "Result stability" receipt
+   * row via `derivePostFooterStatus` — the SAME verdict contract as the
+   * (retired) post-analysis footer. Absent/undefined → "Robustness unknown".
+   */
+  robustnessVerdict?: RobustnessDisplayVerdict | null
+  /**
+   * Freshness reason code from the analysis-freshness slice (e.g.
+   * 'graph_hash_match'). Consumed only by the D1 'translate' branch of the
+   * Freshness receipt row; ignored while FRESHNESS_RECEIPT_D1_MODE is 'omit'.
+   */
+  freshnessReason?: string | null
+  /**
+   * True when `responseHash` is a device-derived local content hash (V5 path)
+   * rather than a producer/engine hash. Labels the hash row so a local hash is
+   * never read as an engine identity.
+   */
+  responseHashIsLocal?: boolean
   /** Number of simulations */
   nSamples?: number | null
   /** Seed used for reproducibility */
@@ -69,7 +133,12 @@ export interface AdvancedSectionProps {
 const PRESET_ORDER: RiskPresetKey[] = ['risk_averse', 'neutral', 'risk_seeking']
 
 export function AdvancedSection({
-  stability,
+  // `stability` (recommendation_stability) is intentionally NOT destructured —
+  // it is accepted but never rendered (see the prop's @deprecated note). The
+  // "Result stability" row uses `robustnessVerdict` below.
+  robustnessVerdict,
+  freshnessReason,
+  responseHashIsLocal,
   nSamples,
   seedUsed,
   fragileEdgeCount,
@@ -119,7 +188,14 @@ export function AdvancedSection({
     }
   }, [responseHash])
 
-  const stabilityPct = stability != null ? Math.round(stability * 100) : null
+  // Result-stability verdict for the receipts row — the display-safe
+  // `robustnessVerdict` mapped through the shared verdict contract
+  // (`derivePostFooterStatus`). NEVER the deprecated recommendation_stability.
+  const resultStabilityLabel = derivePostFooterStatus(robustnessVerdict).label
+
+  // D1 branch (b) copy — resolved once, consumed only when the mode is
+  // 'translate'. Unknown/absent reason codes → null (row omitted).
+  const freshnessReceiptCopy = translateFreshnessReason(freshnessReason)
 
   // Format identifiability for display
   const identifiabilityLabel = identifiability
@@ -325,17 +401,31 @@ export function AdvancedSection({
             Analysis details
           </h4>
           <dl className={`grid grid-cols-2 gap-x-4 gap-y-1.5 ${typography.panelMeta}`}>
-            {stabilityPct != null && (
-              <>
-                <dt className="text-text-light">Stability</dt>
-                <dd className="text-text-header">{stabilityPct}%</dd>
-              </>
-            )}
+            {/* Result stability — display-safe verdict only (never the
+                deprecated recommendation_stability %). */}
+            <div className="contents" data-testid="receipt-result-stability">
+              <dt className="text-text-light">Result stability</dt>
+              <dd className="text-text-header">{resultStabilityLabel}</dd>
+            </div>
+            {/* Simulations — path-conditional honesty: the count renders ONLY
+                when the current run actually carries it (V2 path). On a pure
+                V5 turn `meta` is stripped upstream so nSamples is null and the
+                row is omitted — never a per-option or stale-prior-run number. */}
             {nSamples != null && (
               <>
                 <dt className="text-text-light">Simulation quality</dt>
                 <dd className="text-text-header">{nSamples.toLocaleString()} simulations</dd>
               </>
+            )}
+            {/* Freshness receipt — D1 (ask #16), UNRULED. Mounted branch is
+                selected by FRESHNESS_RECEIPT_D1_MODE; default 'omit' renders
+                nothing. 'translate' renders a curated phrase for known reason
+                codes only. */}
+            {FRESHNESS_RECEIPT_D1_MODE === 'translate' && freshnessReceiptCopy && (
+              <div className="contents" data-testid="receipt-freshness">
+                <dt className="text-text-light">Freshness</dt>
+                <dd className="text-text-header">{freshnessReceiptCopy}</dd>
+              </div>
             )}
             {fragileEdgeCount != null && (
               <>
@@ -373,9 +463,15 @@ export function AdvancedSection({
             )}
             {responseHash && (
               <div className="contents" data-testid="advanced-hash-row">
-                <dt className="text-text-light">Hash</dt>
+                {/* Local (V5-derived) hashes are labelled so they are never
+                    read as a producer/engine identity (a local hash is a
+                    non-crypto content digest, not an engine receipt). */}
+                <dt className="text-text-light">{responseHashIsLocal ? 'Hash (local)' : 'Hash'}</dt>
                 <dd className="text-text-header flex items-center gap-1">
-                  <span className="font-mono truncate" title={responseHash}>
+                  <span
+                    className="font-mono truncate"
+                    title={responseHashIsLocal ? `${responseHash} (locally derived — not an engine hash)` : responseHash}
+                  >
                     {responseHash.slice(0, 12)}…
                   </span>
                   <button

--- a/src/components/results/AdvancedSection.tsx
+++ b/src/components/results/AdvancedSection.tsx
@@ -402,11 +402,17 @@ export function AdvancedSection({
           </h4>
           <dl className={`grid grid-cols-2 gap-x-4 gap-y-1.5 ${typography.panelMeta}`}>
             {/* Result stability — display-safe verdict only (never the
-                deprecated recommendation_stability %). */}
-            <div className="contents" data-testid="receipt-result-stability">
-              <dt className="text-text-light">Result stability</dt>
-              <dd className="text-text-header">{resultStabilityLabel}</dd>
-            </div>
+                deprecated recommendation_stability %). Fail-closed: a real
+                producer verdict ('robust'|'moderate'|'fragile'|'not_assessed')
+                renders its mapped label; an ABSENT verdict renders NO row —
+                never a "Robustness unknown" placeholder row (no row beats an
+                empty-value row, per the receipts fail-closed doctrine). */}
+            {robustnessVerdict != null && (
+              <div className="contents" data-testid="receipt-result-stability">
+                <dt className="text-text-light">Result stability</dt>
+                <dd className="text-text-header">{resultStabilityLabel}</dd>
+              </div>
+            )}
             {/* Simulations — path-conditional honesty: the count renders ONLY
                 when the current run actually carries it (V2 path). On a pure
                 V5 turn `meta` is stripped upstream so nSamples is null and the

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -166,6 +166,15 @@ export const ResultsBody = memo(function ResultsBody({
   // positional ranks) and ONLY inside the rebuild flag: flag-off cards are
   // byte-identical to today.
   const optionNumbering = useCanvasStore(s => s.optionNumbering)
+
+  // B1 receipts: freshness reason (D1 'translate' branch input, unused while
+  // the mode is 'omit') + local-hash provenance. Read directly from the store
+  // here (same pattern as engineDegradedCritique / optionNumbering above) so
+  // the receipts wiring needs no OutputsDock prop-plumbing (V2 cluster).
+  const freshnessReason = useCanvasStore(s => s.analysisFreshness?.freshnessReason)
+  const responseHashIsLocal = useCanvasStore(
+    s => s.results?.report?.model_card?.response_hash_source === 'local',
+  )
   const stableNumbersForCards = useMemo(() => {
     if (!isAnalysisHeroPanelEnabled()) return undefined
     const all = resultsSectionData.recommendation.allOptions
@@ -530,7 +539,9 @@ export const ResultsBody = memo(function ResultsBody({
       <SectionErrorBoundary section="Advanced">
       <div>
         <AdvancedSection
-          stability={resultsSectionData.recommendation.recommendationStability}
+          robustnessVerdict={resultsSectionData.recommendation.robustnessVerdict}
+          freshnessReason={freshnessReason}
+          responseHashIsLocal={responseHashIsLocal}
           nSamples={nSamples}
           seedUsed={seedUsed}
           fragileEdgeCount={fragileEdgeCount}

--- a/src/components/results/__tests__/AdvancedSection.spec.tsx
+++ b/src/components/results/__tests__/AdvancedSection.spec.tsx
@@ -86,10 +86,14 @@ describe('AdvancedSection', () => {
     expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Robustness not assessed')
   })
 
-  it('falls closed to "Robustness unknown" when the verdict is missing', () => {
+  // Fail-closed doctrine: an ABSENT verdict renders NO row (never a
+  // "Robustness unknown" placeholder row — no row beats an empty-value row).
+  it('renders NO Result-stability row when the verdict is missing (fail-closed)', () => {
     render(<AdvancedSection />)
     fireEvent.click(screen.getByText('Advanced and receipts'))
-    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Robustness unknown')
+    expect(screen.queryByTestId('receipt-result-stability')).not.toBeInTheDocument()
+    expect(screen.queryByText('Result stability')).not.toBeInTheDocument()
+    expect(screen.queryByText('Robustness unknown')).not.toBeInTheDocument()
   })
 
   // NEGATIVE PIN (premise 1): AdvancedSection renders NO

--- a/src/components/results/__tests__/AdvancedSection.spec.tsx
+++ b/src/components/results/__tests__/AdvancedSection.spec.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { AdvancedSection } from '../AdvancedSection'
+import {
+  AdvancedSection,
+  translateFreshnessReason,
+  FRESHNESS_RECEIPT_D1_MODE,
+} from '../AdvancedSection'
 
 // Mock useRiskProfile hook
 vi.mock('../../../canvas/hooks/useRiskProfile', () => ({
@@ -57,12 +61,52 @@ describe('AdvancedSection', () => {
     )
   })
 
-  it('renders stability percentage when provided', () => {
-    render(<AdvancedSection stability={0.85} expertMode />)
+  // ── B1 receipts: Result-stability row keyed on the display-safe verdict ──
+  // (premise 1) — NEVER the deprecated recommendation_stability. The mapping
+  // is the shared ROBUSTNESS-VERDICT-CONTRACT (derivePostFooterStatus).
+  it('renders "Stable result" for a robust display verdict', () => {
+    render(<AdvancedSection robustnessVerdict="robust" />)
     fireEvent.click(screen.getByText('Advanced and receipts'))
+    const row = screen.getByTestId('receipt-result-stability')
+    expect(row).toHaveTextContent('Result stability')
+    expect(row).toHaveTextContent('Stable result')
+  })
 
-    expect(screen.getByText('Stability')).toBeInTheDocument()
-    expect(screen.getByText('85%')).toBeInTheDocument()
+  it('renders "Sensitive to assumptions" for moderate and fragile verdicts', () => {
+    const { rerender } = render(<AdvancedSection robustnessVerdict="moderate" />)
+    fireEvent.click(screen.getByText('Advanced and receipts'))
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Sensitive to assumptions')
+    rerender(<AdvancedSection robustnessVerdict="fragile" />)
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Sensitive to assumptions')
+  })
+
+  it('renders "Robustness not assessed" for the producer not_assessed verdict', () => {
+    render(<AdvancedSection robustnessVerdict="not_assessed" />)
+    fireEvent.click(screen.getByText('Advanced and receipts'))
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Robustness not assessed')
+  })
+
+  it('falls closed to "Robustness unknown" when the verdict is missing', () => {
+    render(<AdvancedSection />)
+    fireEvent.click(screen.getByText('Advanced and receipts'))
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Robustness unknown')
+  })
+
+  // NEGATIVE PIN (premise 1): AdvancedSection renders NO
+  // recommendation_stability-sourced value. The fixture's 0.4375 (== the
+  // leader's win probability, the deprecated stability's exact value) must
+  // never surface as a percentage. Mutation: re-add the old Stability % row →
+  // this goes RED.
+  it('renders NO recommendation_stability-sourced value (negative pin)', () => {
+    render(<AdvancedSection stability={0.4375} robustnessVerdict="robust" nSamples={1000} />)
+    fireEvent.click(screen.getByText('Advanced and receipts'))
+    // The deprecated stability % (44% / 43%) must not appear anywhere.
+    expect(screen.queryByText('44%')).not.toBeInTheDocument()
+    expect(screen.queryByText('43%')).not.toBeInTheDocument()
+    // Nor the old "Stability" dt label.
+    expect(screen.queryByText('Stability')).not.toBeInTheDocument()
+    // The honest verdict row is what shows instead.
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Stable result')
   })
 
   it('renders convergence sample count', () => {
@@ -201,18 +245,18 @@ describe('AdvancedSection', () => {
   })
 
   it('renders analysis details in default (non-expert) mode — receipts are for everyone', () => {
-    render(<AdvancedSection stability={0.85} nSamples={5000} />)
+    render(<AdvancedSection robustnessVerdict="robust" nSamples={5000} />)
     fireEvent.click(screen.getByText('Advanced and receipts'))
 
     expect(screen.getByText('Analysis details')).toBeInTheDocument()
-    expect(screen.getByText('Stability')).toBeInTheDocument()
-    expect(screen.getByText('85%')).toBeInTheDocument()
+    expect(screen.getByText('Result stability')).toBeInTheDocument()
+    expect(screen.getByText('5,000 simulations')).toBeInTheDocument()
   })
 
   it('renders all analysis details together', () => {
     render(
       <AdvancedSection
-        stability={0.72}
+        robustnessVerdict="robust"
         nSamples={5000}
         fragileEdgeCount={2}
         robustEdgeCount={8}
@@ -226,7 +270,7 @@ describe('AdvancedSection', () => {
     )
     fireEvent.click(screen.getByText('Advanced and receipts'))
 
-    expect(screen.getByText('72%')).toBeInTheDocument()
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Stable result')
     expect(screen.getByText('5,000 simulations')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
     expect(screen.getByText('8')).toBeInTheDocument()
@@ -234,5 +278,73 @@ describe('AdvancedSection', () => {
     expect(screen.getByText('Identifiable')).toBeInTheDocument()
     expect(screen.getByText('99')).toBeInTheDocument()
     expect(screen.getByText('hash12345678…')).toBeInTheDocument()
+  })
+
+  // ── B1 receipts: Simulations row path-conditional honesty (premise 2) ────
+  describe('Simulations row — path-conditional honesty', () => {
+    it('omits the Simulations row when nSamples is null (V5-path fail-closed)', () => {
+      // On a pure V5 turn `meta` is stripped upstream so nSamples is null.
+      render(<AdvancedSection nSamples={null} robustnessVerdict="robust" />)
+      fireEvent.click(screen.getByText('Advanced and receipts'))
+      expect(screen.queryByText('Simulation quality')).not.toBeInTheDocument()
+      expect(screen.queryByText(/simulations$/)).not.toBeInTheDocument()
+    })
+
+    it('shows the count only when the run carries it (V2 path)', () => {
+      render(<AdvancedSection nSamples={1000} robustnessVerdict="robust" />)
+      fireEvent.click(screen.getByText('Advanced and receipts'))
+      expect(screen.getByText('Simulation quality')).toBeInTheDocument()
+      expect(screen.getByText('1,000 simulations')).toBeInTheDocument()
+    })
+  })
+
+  // ── B1 receipts: Freshness receipt row — D1 both branches (premise 3) ────
+  describe('Freshness receipt row (D1 ask #16)', () => {
+    it('translates ONLY known reason codes; unknown/absent fail closed to null', () => {
+      expect(translateFreshnessReason('graph_hash_match')).toBe('Graph hash match')
+      expect(translateFreshnessReason('graph_hash_mismatch')).toBe('Model changed since this analysis')
+      // Unknown wire strings are NEVER echoed — they fail closed.
+      expect(translateFreshnessReason('some_unmapped_internal_code')).toBeNull()
+      expect(translateFreshnessReason(undefined)).toBeNull()
+      expect(translateFreshnessReason(null)).toBeNull()
+      expect(translateFreshnessReason('')).toBeNull()
+    })
+
+    it('mounted branch is the fail-closed default: the row is omitted even with a known reason', () => {
+      // The un-ruled D1 default: FRESHNESS_RECEIPT_D1_MODE === 'omit'. Flipping
+      // that single constant to 'translate' activates the row (no rebuild, no
+      // runtime flag) — asserted here so a drift of the default is caught.
+      expect(FRESHNESS_RECEIPT_D1_MODE).toBe('omit')
+      render(<AdvancedSection freshnessReason="graph_hash_match" robustnessVerdict="robust" />)
+      fireEvent.click(screen.getByText('Advanced and receipts'))
+      expect(screen.queryByTestId('receipt-freshness')).not.toBeInTheDocument()
+      expect(screen.queryByText('Graph hash match')).not.toBeInTheDocument()
+    })
+  })
+
+  // ── B1 receipts: local hash labelled local (premise 4) ───────────────────
+  describe('Result hash provenance labelling', () => {
+    it('labels a producer hash "Hash" (no local suffix)', () => {
+      render(<AdvancedSection responseHash="abc123def456ghi789" responseHashIsLocal={false} />)
+      fireEvent.click(screen.getByText('Advanced and receipts'))
+      const row = screen.getByTestId('advanced-hash-row')
+      expect(row).toHaveTextContent('Hash')
+      expect(row).not.toHaveTextContent('local')
+    })
+
+    it('labels a device-derived hash "Hash (local)" so it is not read as engine identity', () => {
+      render(<AdvancedSection responseHash="abc123def456ghi789" responseHashIsLocal />)
+      fireEvent.click(screen.getByText('Advanced and receipts'))
+      expect(screen.getByText('Hash (local)')).toBeInTheDocument()
+    })
+  })
+
+  // ── B1 receipts: Seed row stays absent when there is no real seed ────────
+  // (premise 5, assert-only). T2 (#326) fails the V5 path closed to null; this
+  // pins the fail-closed absence at the display layer.
+  it('omits the Seed row when seedUsed is null (fail-closed, no fabricated 0)', () => {
+    render(<AdvancedSection seedUsed={null} robustnessVerdict="robust" />)
+    fireEvent.click(screen.getByText('Advanced and receipts'))
+    expect(screen.queryByText('Seed')).not.toBeInTheDocument()
   })
 })

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -708,6 +708,12 @@ export function mapV5AnalysisToReport(
     model_card: {
       response_hash: responseHash,
       response_hash_algo: 'sha256',
+      // Provenance for the receipts hash row: when the caller supplied a
+      // producer hash it is 'producer'; otherwise `responseHash` is the
+      // locally-derived `deriveBlockHash` digest (the V5 contract carries no
+      // engine hash) and must be labelled 'local' so the UI never presents it
+      // as an engine identity.
+      response_hash_source: options.responseHash ? 'producer' : 'local',
       normalized: true,
     },
     // Type lies (number, not number | null) — V4 does the same. Downstream


### PR DESCRIPTION
**Lane B1 of the V6 build train** (receipts upgrade; ex-"V3", re-specced build-once). No flags — lands ON, revert = rollback. **DO NOT MERGE** until strategic review.

## Premise verdicts (verified at the bytes, branch tip `9914e9d2`)

| # | Premise | Verdict |
|---|---------|---------|
| 1 | Result-stability row keys on `robustness.display_verdict` via `derivePostFooterStatus`; stop the receipts display-read of `recommendation_stability` | **Valid** — implemented. Was reading `recommendation_stability` (ResultsBody `stability=` feed, deprecated & == leader win-prob). Now keys on the fail-closed `robustnessVerdict` already exposed by `useResultsSectionData`. |
| 2 | Simulations row path-conditional honesty | **Already honest, now pinned** — `nSamples` is null-gated; the V5 report's `summary` is a string and `meta` carries no `n_samples`, so V5 turns render honest-absent. No fabricated constant existed. Added RED pins both directions. |
| 3 | Freshness receipt — build BOTH D1 branches, ruling picks, no flag | **Valid** — implemented behind a compile-time `FRESHNESS_RECEIPT_D1_MODE: 'omit' \| 'translate'` (default `'omit'` mounted). `translateFreshnessReason` (curated en-GB map, unknown→null, never raw wire strings) is the exported, unit-tested `'translate'` branch. One-line flip activates it; no runtime flag. |
| 4 | Local hash labelled local | **Valid (was stale)** — added optional `model_card.response_hash_source` (`'producer' \| 'local'`); `mapV5` tags its device-derived `deriveBlockHash` digest `'local'`; the row renders **"Hash (local)"**. On the live V5 conversational path the hash is *always* locally derived (`applyV5State` passes no producer hash) so this was mislabelled today. |
| 5 | Seed row stays absent | **Partly stale — adapted** — DATA-MATRIX claim "`?? 0` fabrication still live" is STALE: `mapV5` already lands `seed = options.seed ?? null` (T2 #326). So V5-path seed is fail-closed absent. The V2-path seed row (real producer seed) is left intact (removing it = a retirement, out of B1). Added an assert-only absence pin. |

## Per-row evidence
- **Result stability:** new `receipt-result-stability` row → `derivePostFooterStatus(robustnessVerdict).label` (robust→"Stable result", moderate/fragile→"Sensitive to assumptions", not_assessed→"Robustness not assessed", missing→"Robustness unknown"). The deprecated `stability` prop is accepted-but-ignored (not destructured) purely for the negative pin; ResultsBody no longer feeds it.
- **Simulations:** unchanged render, null-gated; new pins assert absent-on-null / "N simulations" on count.
- **Freshness:** `omit` mounted; `translate` built + tested; curated map `{graph_hash_match, graph_hash_mismatch, no_prior_analysis}`.
- **Hash:** `responseHashIsLocal` sourced in ResultsBody from `results.report.model_card.response_hash_source === 'local'` (store read, **no OutputsDock edit** — V2 cluster untouched).

## Ownership / scope respected
No ResultsBody composition changes (prop-lines + 2 store reads only), no OutputsDock edits (V2 cluster), no flags, no retirements. Additive optional report field. Did NOT touch vendor/package.json/buildPayload.ts, stripSourceComments, inspector-v2/GoalPanel, strengthen/**, decision-overview/**.

## Gates
- Repo typecheck (`tsc -p tsconfig.ci.json`): **clean**.
- Touched suites: AdvancedSection (30) + mapV5 (67) + ResultsBody suites (45) = **142 passing**.
- Lint (touched files): 0 errors (1 pre-existing `expertMode`-unused warning, dead at HEAD).
- **Wide tsc** (`tsconfig.app.json`) multiset delta: **net zero new errors** — 2319→2319; the 10/10 comm-diff is the same pre-existing errors (8 `determinism.test.ts` `.seed`/`.confidence` accesses whose printed model_card type merely grew by the optional field; 2 pre-existing errors shifted by line).

## Mutation results (throwaway worktree, never the working tree)
All 7 pins bite (revert-the-fix → RED):
- A negative pin: re-add a separate `recommendation_stability` % row → **RED** ✓
- B verdict mapping → constant → **RED** (5 tests) ✓
- C flip D1 mode `omit`→`translate` → **RED** (omit-default pin) ✓
- D translator echoes raw unknown code → **RED** ✓
- E drop the `(local)` label → **RED** ✓
- F fabricate simulations count when null → **RED** ✓
- G render Seed row when null → **RED** ✓

## UI-SEM ledger
No new client-side derivation/classification introduced — the stability row consumes the producer's display-safe verdict via the existing contract (no new threshold). `translateFreshnessReason` is a curated vocabulary lookup (display copy), not a value transform. No new UI-SEM row required.

## Not done (out of B1)
Real-browser staging acceptance pass (per re-spec §2) — flagged for the reviewer; the D1 mounted branch is `omit` so the freshness row is not yet visible by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)