### PR TITLE
fix(guards): finish the #386/#403 remediation — blankNonCode convergence + remaining footguns

### DIFF
--- a/src/__tests__/indexHtmlHealthProbe.spec.ts
+++ b/src/__tests__/indexHtmlHealthProbe.spec.ts
@@ -19,29 +19,77 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { stripHtmlComments } from '../../tests/helpers/stripSourceComments'
 
 function indexHtml(): string {
   return readFileSync(resolve(process.cwd(), 'index.html'), 'utf8')
+}
+
+/**
+ * index.html with HTML comments (`<!-- -->`) and the JS comments inside the
+ * inline `<script>` blanked, so a commented-out `onrender.com` host — whether
+ * `<!-- … -->` or `// …` in the safe-screen script — no longer false-reds
+ * (the #386/#403 footgun; neither the JS nor the CSS stripper covers HTML, so
+ * this uses the shared stripHtmlComments). String literals in the script (a
+ * real `fetch('https://…onrender.com')`) are KEPT as code and still caught.
+ */
+function scannableIndexHtml(): string {
+  return stripHtmlComments(indexHtml())
 }
 
 describe('index.html safe-screen health probe', () => {
   it('still probes engine health via the same-origin proxy (positive control)', () => {
     // Proves this spec is reading the real document and the probe exists —
     // without this, the absence assertions below could pass vacuously
-    // against an empty or relocated file.
-    const html = indexHtml()
+    // against an empty or relocated file. Read the STRIPPED text to also prove
+    // the strip leaves the live probe (code + strings) intact.
+    const html = scannableIndexHtml()
     expect(html).toContain("var edge = '/engine'")
     expect(html).toContain("fetch(edge + '/health')")
   })
 
   it('never fetches the production PLoT host', () => {
-    expect(indexHtml()).not.toMatch(/plot-lite-service\.onrender\.com/)
+    expect(scannableIndexHtml()).not.toMatch(/plot-lite-service\.onrender\.com/)
   })
 
   it('contains no cross-origin onrender.com URL at all', () => {
     // The probe must be same-origin only; _redirects decides the backend
     // per environment. Any onrender.com literal here is a cross-environment
     // leak waiting for a CSP block.
-    expect(indexHtml()).not.toMatch(/https:\/\/[a-z0-9-]+\.onrender\.com/i)
+    expect(scannableIndexHtml()).not.toMatch(/https:\/\/[a-z0-9-]+\.onrender\.com/i)
+  })
+})
+
+/**
+ * Both-directions mutation proof for the HTML/script comment strip (#386/#403).
+ */
+describe('index.html probe — stripHtmlComments detector contract', () => {
+  const onrender = /https:\/\/[a-z0-9-]+\.onrender\.com/i
+
+  it('STILL catches a live cross-origin fetch in the script (string literal kept)', () => {
+    const html = "<script>fetch('https://plot-lite-service.onrender.com/health')</script>"
+    expect(onrender.test(stripHtmlComments(html))).toBe(true)
+  })
+
+  it('does NOT catch a host inside an <!-- HTML comment -->', () => {
+    const html = '<!-- old: https://plot-lite-service.onrender.com/health --><script>var x=1</script>'
+    expect(onrender.test(stripHtmlComments(html))).toBe(false)
+  })
+
+  it('does NOT catch a host inside a // comment in the script', () => {
+    const html = "<script>\n  // fallback was https://plot-lite-service.onrender.com/health\n  var x=1\n</script>"
+    expect(onrender.test(stripHtmlComments(html))).toBe(false)
+  })
+
+  it('does NOT catch a host inside a /* block comment */ in the script', () => {
+    const html = '<script>/* https://x.onrender.com */ var y = 2</script>'
+    expect(onrender.test(stripHtmlComments(html))).toBe(false)
+  })
+
+  it('does not mangle an https:// URL that sits in HTML text (no false line-comment)', () => {
+    // A bare `//` in HTML text must NOT be treated as a JS line comment — only
+    // script bodies get JS-comment stripping.
+    const html = '<a href="https://ok.example.com/health">x</a><script>var z=3</script>'
+    expect(stripHtmlComments(html)).toContain('https://ok.example.com/health')
   })
 })

--- a/src/__tests__/wave2-replay-gate.spec.ts
+++ b/src/__tests__/wave2-replay-gate.spec.ts
@@ -16,6 +16,7 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 import { formatTargetValue } from '../components/results/utils/formatTargetValue'
 import { formatPercent } from '../utils/formatPercent'
+import { blankNonCode } from '../../tests/helpers/stripSourceComments'
 
 // =============================================================================
 // 1. Formatter behaviour contracts
@@ -72,7 +73,13 @@ describe('formatPercent — contract', () => {
 // =============================================================================
 describe('Trust boundary — cast budget', () => {
   const filePath = join(process.cwd(), 'src/components/results/useResultsSectionData.ts')
-  const content = readFileSync(filePath, 'utf-8')
+  const rawContent = readFileSync(filePath, 'utf-8')
+  // blankNonCode blanks comments AND string bodies (offsets preserved) so a
+  // comment- or string-borne `as any` mention can no longer inflate the cast
+  // count (the #386/#403 footgun). Real casts are executable code and survive;
+  // the boundary-field tokens the second test checks are dot-access code and
+  // survive too (verified: no bracket-string field access on any cast line).
+  const content = blankNonCode(rawContent)
 
   it('useResultsSectionData.ts has ≤ 16 "as any" casts (debug-only window access + PLoT-adapter boundary reads)', () => {
     // Packet A (2026-04-19): raised from 6 to 14 with documented rationale.
@@ -214,5 +221,28 @@ describe('No technical-string leakage', () => {
     expect(formatPercent(0)).toBe('0%')
     expect(formatPercent(100)).toBe('100%')
     expect(formatPercent(0.5, { fromDecimal: true })).toBe('50%')
+  })
+})
+
+// =============================================================================
+// 6. Cast-budget strip — both-directions detector contract (#386/#403)
+// =============================================================================
+describe('cast budget — comment/string mentions do not count', () => {
+  const countCasts = (src: string): number => (blankNonCode(src).match(/as any/g) || []).length
+
+  it('STILL counts a real cast', () => {
+    expect(countCasts('const x = (report as any).conditional_winners')).toBe(1)
+  })
+
+  it('does NOT count `as any` in a // comment', () => {
+    expect(countCasts('// removed the (foo as any) cast here')).toBe(0)
+  })
+
+  it('does NOT count `as any` inside a string literal', () => {
+    expect(countCasts('const note = "was cast as any previously"')).toBe(0)
+  })
+
+  it('boundary-field token on a real cast line survives (dot-access is code)', () => {
+    expect(blankNonCode('const r = (report as any).conditional_winners')).toContain('conditional_winners')
   })
 })

--- a/src/canvas/__tests__/cameraMotion.sourceScan.spec.ts
+++ b/src/canvas/__tests__/cameraMotion.sourceScan.spec.ts
@@ -25,6 +25,7 @@ import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { blankNonCode } from '../../../tests/helpers/stripSourceComments'
 
 const CANVAS_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -49,45 +50,11 @@ function sourceFiles(dir: string): string[] {
   return out
 }
 
-/**
- * Blank out comments and string/template bodies, preserving offsets and
- * newlines. Prose about camera moves (this file's own docstring, the contract
- * note in useFitViewOnLayoutVersion) must not read as a call site.
- */
-export function blankNonCode(src: string): string {
-  const out = src.split('')
-  let i = 0
-  const blankTo = (end: number) => {
-    for (let k = i; k < end && k < src.length; k++) if (out[k] !== '\n') out[k] = ' '
-  }
-  while (i < src.length) {
-    const two = src.slice(i, i + 2)
-    if (two === '//') {
-      let end = src.indexOf('\n', i)
-      if (end === -1) end = src.length
-      blankTo(end)
-      i = end
-    } else if (two === '/*') {
-      let end = src.indexOf('*/', i + 2)
-      end = end === -1 ? src.length : end + 2
-      blankTo(end)
-      i = end
-    } else if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
-      const quote = src[i]
-      let j = i + 1
-      while (j < src.length && src[j] !== quote) {
-        if (src[j] === '\\') j++
-        j++
-      }
-      i++ // keep the opening quote so the token still parses as a value
-      blankTo(j)
-      i = Math.min(j + 1, src.length)
-    } else {
-      i++
-    }
-  }
-  return out.join('')
-}
+// `blankNonCode` (blanks comments + string/template bodies, offset-preserving)
+// is the shared helper in tests/helpers/stripSourceComments.ts — the detector
+// contract below still pins its behaviour for this guard. Prose about camera
+// moves (this file's own docstring, the contract note in
+// useFitViewOnLayoutVersion) must not read as a call site.
 
 /** Extract the balanced `(...)` argument text starting at `openIdx`. */
 function argsAt(src: string, openIdx: number): string {

--- a/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
+++ b/src/canvas/components/coaching-panel/focus-now/__tests__/inertness.spec.ts
@@ -21,6 +21,7 @@
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { dirname, join, resolve, sep } from 'node:path'
+import { stripComments } from '../../../../../../tests/helpers/stripSourceComments'
 
 const SRC = resolve(process.cwd(), 'src')
 const MODULE_DIR = join(SRC, 'canvas', 'components', 'coaching-panel', 'focus-now')
@@ -57,7 +58,13 @@ function isUnderModule(p: string): boolean {
 /** Offending specifiers in `content` that resolve into (or path-match) the module. */
 export function findFocusNowImports(content: string, importerFile: string): string[] {
   const offenders: string[] = []
-  for (const m of content.matchAll(SPEC_RE)) {
+  // stripComments blanks comments but KEEPS string literals as code, so a
+  // commented-out `import … from './focus-now'` no longer false-reds
+  // (the #386/#403 footgun) while a real import specifier — which IS a string
+  // literal — is still captured. blankNonCode would blank the specifier body
+  // and make the guard blind to every relative import, so it is the wrong tool
+  // here (reclassified from the #403 manifest's "blankNonCode class").
+  for (const m of stripComments(content, importerFile).matchAll(SPEC_RE)) {
     const spec = m[1]
     const resolved = resolveSpec(spec, importerFile)
     if ((resolved && isUnderModule(resolved)) || PATH_RE.test(spec)) offenders.push(spec)
@@ -142,6 +149,11 @@ describe('Focus Now inertness', () => {
     ['similarly-named relative sibling', PARENT, "import x from './focus-now-helpers'"],
     ['similarly-named aliased sibling', PARENT, "import x from '@/canvas/components/coaching-panel/focus-now-helpers'"],
     ['unrelated relative path elsewhere', join(SRC, 'foo', 'bar.ts'), "import './focus-now'"],
+    // #386/#403 comment-strip: commented-out imports of the module no longer
+    // false-red. The live forms above ('FLAGS …') still fire — both directions.
+    ['//-commented module import', PARENT, "// import { FocusNowPanel } from './focus-now'"],
+    ['block-commented module import', PARENT, "/* import { FocusRow } from './focus-now/FocusRowCard' */"],
+    ['//-commented aliased module import', PARENT, "// import x from '@/canvas/components/coaching-panel/focus-now'"],
   ])('does NOT flag: %s', (_label, importer, code) => {
     expect(findFocusNowImports(code, importer)).toEqual([])
   })

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
+import { stripComments } from '../../../../../../tests/helpers/stripSourceComments'
 import { SIGNAL_REGISTRY, type SignalDetectionInput } from '../registry'
 import {
   ACTIONS_MENU,
@@ -122,7 +123,13 @@ describe('boundary rules — static source assertions over the v3 directory', ()
       if (entry.isDirectory()) {
         if (entry.name !== '__tests__') collect(full)
       } else if (/\.(ts|tsx)$/.test(entry.name)) {
-        sources.push(fs.readFileSync(full, 'utf8'))
+        // stripComments blanks comments but KEEPS strings as code, so a comment
+        // mentioning a dead-end intent no longer false-reds (the #386/#403
+        // footgun) while a real `intent: 'confirm_factor'` string literal or a
+        // `x['readiness_level']` bracket-key read is still caught. blankNonCode
+        // would blank those strings and go blind to a real intent reference, so
+        // it is the wrong tool (reclassified from the "blankNonCode class").
+        sources.push(stripComments(fs.readFileSync(full, 'utf8'), entry.name))
       }
     }
   }
@@ -141,6 +148,16 @@ describe('boundary rules — static source assertions over the v3 directory', ()
 
   it('never uses dangerouslySetInnerHTML', () => {
     expect(blob.includes('dangerouslySetInnerHTML')).toBe(false)
+  })
+
+  it('comment-strip both directions: comment mentions ignored, string/bracket-key still caught', () => {
+    const strip = (s: string) => stripComments(s, 'x.ts')
+    // A comment mentioning a dead-end intent is blanked → not scanned:
+    expect(strip('// never add confirm_factor here').includes('confirm_factor')).toBe(false)
+    // A real intent STRING literal is kept and still caught:
+    expect(strip("const intent = 'confirm_factor'").includes('confirm_factor')).toBe(true)
+    // A bracket-key read of the banned enum survives (why we keep strings):
+    expect(strip("const r = data['readiness_level']").includes('readiness_level')).toBe(true)
   })
 })
 

--- a/src/components/results/__tests__/TornadoChart.dormancy.spec.ts
+++ b/src/components/results/__tests__/TornadoChart.dormancy.spec.ts
@@ -20,12 +20,17 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { blankNonCode } from '../../../../tests/helpers/stripSourceComments'
 
 const RESULTS_BODY = resolve(__dirname, '../ResultsBody.tsx')
 
 describe('Brief 5 P1-3 — TornadoChart apply-rerun dormancy', () => {
   it('ResultsBody does NOT currently pass onApplyAndRerun to TornadoChart (dormant pending PLoT bounds)', () => {
-    const src = readFileSync(RESULTS_BODY, 'utf-8')
+    // blankNonCode blanks comments AND string bodies (offsets preserved): a
+    // commented-out `onApplyAndRerun=` prop inside the tag can no longer
+    // false-red (the #386/#403 footgun), and blanking string prop values also
+    // hardens the opening-tag extraction against a stray `>` inside a string.
+    const src = blankNonCode(readFileSync(RESULTS_BODY, 'utf-8'))
 
     // Find the TornadoChart JSX block. Supports both self-closing
     // (`<TornadoChart ... />`) and open/close (`<TornadoChart ...>...` followed
@@ -49,6 +54,36 @@ describe('Brief 5 P1-3 — TornadoChart apply-rerun dormancy', () => {
         'If bounds are now in place, update this test to assert the wired shape.',
         'If not, this regression needs investigation.',
       ].join(' '),
+    ).toBe(false)
+  })
+})
+
+/**
+ * Both-directions mutation proof for the blankNonCode strip (#386/#403).
+ * A live prop in the tag is still seen; a commented-out one is not.
+ */
+describe('TornadoChart dormancy — detector contract', () => {
+  const tagHasProp = (src: string, prop: string): boolean => {
+    const b = blankNonCode(src)
+    const openIdx = b.indexOf('<TornadoChart')
+    if (openIdx < 0) return false
+    const opener = b.slice(openIdx).match(/<TornadoChart[\s\S]*?\/?>/)
+    return !!opener && opener[0].includes(prop)
+  }
+
+  it('STILL sees a live onApplyAndRerun prop in the tag', () => {
+    expect(tagHasProp('<TornadoChart data={d} onApplyAndRerun={rerun} />', 'onApplyAndRerun=')).toBe(true)
+  })
+
+  it('does NOT see a prop commented out inside a JSX {/* … */}', () => {
+    expect(
+      tagHasProp('<TornadoChart data={d} {/* onApplyAndRerun={rerun} */} />', 'onApplyAndRerun='),
+    ).toBe(false)
+  })
+
+  it('does NOT see a prop on a //-commented line inside the tag', () => {
+    expect(
+      tagHasProp('<TornadoChart\n  data={d}\n  // onApplyAndRerun={rerun}\n/>', 'onApplyAndRerun='),
     ).toBe(false)
   })
 })

--- a/src/components/results/__tests__/no-message-render.spec.ts
+++ b/src/components/results/__tests__/no-message-render.spec.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, readdirSync, statSync } from 'fs'
 import { join, relative } from 'path'
+import { stripComments } from '../../../../tests/helpers/stripSourceComments'
 
 const RESULTS_DIR = join(__dirname, '..')
 
@@ -103,6 +104,19 @@ const SAFE_PATTERNS = [
 ]
 
 /**
+ * Unsafe `.message` renders in `content`, comments stripped first so a
+ * commented-out `{item.message}` or a JSX block comment mentioning `.message`
+ * can no longer false-red (the #386/#403 footgun). String and TEMPLATE literals are
+ * KEPT as code — a real `{`${w.message}`}` interpolation still trips, so this
+ * uses stripComments, not the string-blanking blankNonCode. filePath only
+ * steers .css vs .js dispatch (scanned files are .tsx).
+ */
+function findMessageRenders(content: string, filePath: string): string[] {
+  const matches = stripComments(content, filePath).match(JSX_MESSAGE_RENDER) || []
+  return matches.filter((match) => !SAFE_PATTERNS.some((safe) => safe.test(match)))
+}
+
+/**
  * V14.3b: Files that render .message BUT have runtime defence-in-depth filtering.
  * Map of basename → regex that MUST be present in the file source for the exemption
  * to hold. If someone removes the runtime filter, this test starts failing — keeping
@@ -155,12 +169,10 @@ describe('V14.3: No .message renders in results components', () => {
 
     it(`${fileName} does not render critique .message in JSX`, () => {
       const content = readFileSync(filePath, 'utf-8')
-      const matches = content.match(JSX_MESSAGE_RENDER) || []
-
-      // Filter out known safe patterns
-      const unsafe = matches.filter(match =>
-        !SAFE_PATTERNS.some(safe => safe.test(match)),
-      )
+      // Scan with comments stripped; attestations below still read RAW content
+      // (a defence-in-depth filter's literal predicate can legitimately live in
+      // a string, which stripComments keeps — but raw is unambiguous).
+      const unsafe = findMessageRenders(content, filePath)
 
       if (unsafe.length > 0) {
         // V14.3b: Files with runtime defence-in-depth get a conditional pass —
@@ -187,4 +199,42 @@ describe('V14.3: No .message renders in results components', () => {
       }
     })
   }
+})
+
+/**
+ * Both-directions mutation proof for the comment-strip (#386/#403 remediation).
+ * Real renders still trip; comment-borne mentions no longer do. Mutation-checked
+ * (2026-07-20): removing the strip turns the commented-out cases RED while every
+ * "STILL catches" case stays green.
+ */
+describe('V14.3 — detector contract (RED power preserved)', () => {
+  it('STILL catches a live {item.message} render', () => {
+    expect(findMessageRenders('<span>{item.message}</span>', 'x.tsx').length).toBeGreaterThan(0)
+  })
+
+  it('STILL catches a renamed variable {firstWarning.message}', () => {
+    expect(findMessageRenders('<p>{firstWarning.message}</p>', 'x.tsx').length).toBeGreaterThan(0)
+  })
+
+  it('STILL catches a template-literal render {`${w.message}`} (blankNonCode would miss this)', () => {
+    // Keeping template literals as code is why this guard uses stripComments.
+    expect(findMessageRenders('<p>{`prefix ${w.message}`}</p>', 'x.tsx').length).toBeGreaterThan(0)
+  })
+
+  it('does NOT flag the SAFE patterns (error.message / .test / console)', () => {
+    expect(findMessageRenders('<p>{error.message}</p>', 'x.tsx')).toEqual([])
+    expect(findMessageRenders('{INTERNAL.test(w.message)}', 'x.tsx')).toEqual([])
+  })
+
+  it('does NOT trip on a `//`-commented render', () => {
+    expect(findMessageRenders('// <span>{item.message}</span>', 'x.tsx')).toEqual([])
+  })
+
+  it('does NOT trip on a render inside a JSX {/* … */} comment', () => {
+    expect(findMessageRenders('<div>{/* was {item.message} */}</div>', 'x.tsx')).toEqual([])
+  })
+
+  it('does NOT trip on a render inside a /* block comment */', () => {
+    expect(findMessageRenders('/* <span>{w.message}</span> */', 'x.tsx')).toEqual([])
+  })
 })

--- a/src/components/results/__tests__/no-raw-influence-read.spec.ts
+++ b/src/components/results/__tests__/no-raw-influence-read.spec.ts
@@ -31,6 +31,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, readdirSync, statSync } from 'fs'
 import { join, relative } from 'path'
+import { stripComments } from '../../../../tests/helpers/stripSourceComments'
 
 const REPO_SRC = join(__dirname, '..', '..', '..')
 const SCAN_ROOTS = [
@@ -106,6 +107,31 @@ function isSanctionedChain(lines: string[], i: number, matchIndex: number): bool
   return /displayInfluence[^]*\?\?\s*$/.test(prev.trimEnd())
 }
 
+/**
+ * Raw-metric reads in `content`, comments stripped first (a commented-out
+ * `// return d.influenceScore` must not false-red — the #386/#403 footgun).
+ * String and TEMPLATE literals are KEPT as code, so a real `${d.influenceScore}`
+ * interpolation still trips: this is a policy tripwire, and blanking string
+ * bodies (the `blankNonCode` class) would make it blind to a template-literal
+ * read — strictly weaker detection. filePath only steers .css vs .js dispatch.
+ */
+function findRawInfluenceReads(content: string, filePath: string): string[] {
+  const lines = stripComments(content, filePath).split('\n')
+  const violations: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const member = RAW_MEMBER_READ.exec(line)
+    if (member && !isSanctionedChain(lines, i, member.index)) {
+      violations.push(`  L${i + 1}: ${line.trim()}`)
+      continue
+    }
+    if (RAW_DESTRUCTURE.test(line)) {
+      violations.push(`  L${i + 1}: ${line.trim()} (destructured raw key)`)
+    }
+  }
+  return violations
+}
+
 describe('driver-display policy: no raw influence reads outside the policy', () => {
   const sourceFiles = SCAN_ROOTS.flatMap((root) => getSourceFiles(root))
   expect(sourceFiles.length).toBeGreaterThan(50) // scan actually ran
@@ -130,19 +156,7 @@ describe('driver-display policy: no raw influence reads outside the policy', () 
         return
       }
 
-      const lines = content.split('\n')
-      const violations: string[] = []
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i]
-        const member = RAW_MEMBER_READ.exec(line)
-        if (member && !isSanctionedChain(lines, i, member.index)) {
-          violations.push(`  L${i + 1}: ${line.trim()}`)
-          continue
-        }
-        if (RAW_DESTRUCTURE.test(line)) {
-          violations.push(`  L${i + 1}: ${line.trim()} (destructured raw key)`)
-        }
-      }
+      const violations = findRawInfluenceReads(content, filePath)
 
       if (violations.length > 0) {
         throw new Error(
@@ -155,4 +169,68 @@ describe('driver-display policy: no raw influence reads outside the policy', () 
       }
     })
   }
+})
+
+/**
+ * Both-directions mutation proof for the comment-strip (#386/#403 remediation).
+ *
+ * The RED-detection power of this POLICY tripwire must be provably UNCHANGED by
+ * the strip: every real code read still trips, only comment-borne mentions stop
+ * tripping. The first block re-runs the documented FOUR-bypass RED history (the
+ * July-13 audit) verbatim as live code and asserts each is STILL caught.
+ * (Mutation-verified 2026-07-20: disabling the strip turns exactly the
+ * commented-out cases RED while every "STILL catches" case stays green.)
+ */
+describe('driver-display policy — detector contract (RED power preserved)', () => {
+  // The four live bypasses the audit found, expressed as source lines. Each is
+  // a raw read NOT preceded by displayInfluence — the exact shape the guard
+  // exists to catch.
+  const FOUR_BYPASS_RED_HISTORY: Array<[string, string]> = [
+    ['tornado ordering', 'rows.sort((a, b) => (b.influenceScore ?? b.normalisedInfluence) - (a.influenceScore ?? a.normalisedInfluence))'],
+    ['TriageActionCards nudge', 'const nudge = factor.influenceScore ?? 0'],
+    ['strengthen LEHI ranking', 'const lehi = lever.normalisedInfluence ?? lever.influenceScore'],
+    ['model-tab factor map', 'return { ...f, weight: f.influenceScore }'],
+  ]
+
+  it.each(FOUR_BYPASS_RED_HISTORY)('STILL catches the live bypass: %s', (_label, line) => {
+    expect(findRawInfluenceReads(line, 'x.ts').length).toBeGreaterThan(0)
+  })
+
+  it('STILL catches a destructured raw key in live code', () => {
+    expect(findRawInfluenceReads('const { influenceScore } = driver', 'x.ts').length).toBeGreaterThan(0)
+  })
+
+  it('STILL catches a raw read inside a template literal (blankNonCode would miss this)', () => {
+    // A `${d.influenceScore}` read is a real policy violation; keeping string
+    // literals as code is why this guard uses stripComments, not blankNonCode.
+    expect(findRawInfluenceReads('const s = `infl=${d.influenceScore}`', 'x.ts').length).toBeGreaterThan(0)
+  })
+
+  it('STILL honours the sanctioned displayInfluence-first chain (no false RED)', () => {
+    expect(
+      findRawInfluenceReads('const v = d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence', 'x.ts'),
+    ).toEqual([])
+  })
+
+  it('STILL flags the WRONG-ORDERED chain (influenceScore before displayInfluence)', () => {
+    expect(
+      findRawInfluenceReads('const v = d.influenceScore ?? d.displayInfluence', 'x.ts').length,
+    ).toBeGreaterThan(0)
+  })
+
+  // The OTHER direction: the same bypasses, now commented out, must NOT trip.
+  it.each(FOUR_BYPASS_RED_HISTORY)('does NOT trip on a `//`-commented bypass: %s', (_label, line) => {
+    expect(findRawInfluenceReads(`// ${line}`, 'x.ts')).toEqual([])
+  })
+
+  it('does NOT trip on a bypass inside a /* block comment */ or JSDoc', () => {
+    expect(findRawInfluenceReads('/* was: return d.influenceScore */', 'x.ts')).toEqual([])
+    expect(
+      findRawInfluenceReads('/**\n * @example const x = d.normalisedInfluence\n */', 'x.ts'),
+    ).toEqual([])
+  })
+
+  it('does NOT trip on a commented-out destructure', () => {
+    expect(findRawInfluenceReads('// const { normalisedInfluence } = row', 'x.ts')).toEqual([])
+  })
 })

--- a/src/components/results/analysis-hero/__tests__/fixtureIsolation.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/fixtureIsolation.spec.tsx
@@ -16,6 +16,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, resolve, sep } from 'node:path'
+import { stripComments } from '../../../../../tests/helpers/stripSourceComments'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
@@ -140,7 +141,11 @@ describe('fixture isolation — import boundary (machine-enforced, fails CI)', (
       if (file.startsWith(join(MODULE_DIR, '__tests__') + sep)) continue
       if (file.startsWith(join(MODULE_DIR, 'fixtures') + sep)) continue
       if (file === GALLERY_ROUTE) continue
-      const content = readFileSync(file, 'utf8')
+      // stripComments blanks comments but KEEPS the import string, so a comment
+      // that mentions `analysis-hero/fixtures` no longer false-reds (the
+      // residual #386/#403 footgun on the un-anchored path check) while a real
+      // fixture import string is still caught.
+      const content = stripComments(readFileSync(file, 'utf8'), file)
       // Aliased/absolute form (any importer) plus the relative forms only
       // module-internal files could use — both are offences.
       const internal = file.startsWith(MODULE_DIR + sep)
@@ -166,6 +171,18 @@ describe('fixture isolation — import boundary (machine-enforced, fails CI)', (
 
   it('positive control: the gallery route itself does import the fixtures', () => {
     expect(/analysis-hero\/fixtures/.test(readFileSync(GALLERY_ROUTE, 'utf8'))).toBe(true)
+  })
+
+  it('comment-strip both directions: a commented fixtures path is not an offender; a real import is', () => {
+    const strip = (s: string) => stripComments(s, 'x.tsx')
+    // A prose comment mentioning the path is blanked → not flagged:
+    expect(/analysis-hero\/fixtures/.test(strip('// see analysis-hero/fixtures for examples'))).toBe(false)
+    // A real fixture import string is kept → flagged:
+    expect(
+      /analysis-hero\/fixtures/.test(
+        strip("import { GALLERY_ENTRIES } from '@/components/results/analysis-hero/fixtures/galleryModels'"),
+      ),
+    ).toBe(true)
   })
 })
 

--- a/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
@@ -16,6 +16,7 @@
 import { describe, expect, it } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { stripComments } from '../../../../../tests/helpers/stripSourceComments'
 
 const MODULE_DIR = resolve(process.cwd(), 'src', 'components', 'results', 'analysis-hero')
 
@@ -26,7 +27,14 @@ function productionSources(dir: string, acc: { file: string; content: string }[]
     if (statSync(full).isDirectory()) {
       productionSources(full, acc)
     } else if (/\.(ts|tsx)$/.test(name)) {
-      acc.push({ file: name, content: readFileSync(full, 'utf8') })
+      // stripComments blanks comments but KEEPS strings/templates as code, so a
+      // design-note comment that mentions `fetch(`/`robustnessVerdict`/a
+      // threshold no longer false-reds (the #386/#403 footgun) while a real
+      // bracket-key read (`data['robustnessVerdict']`) or a live
+      // `coaching-panel/focus-now` import string is still caught. blankNonCode
+      // would blank those strings and weaken detection, so it is the wrong tool
+      // (reclassified from the #403 manifest's "blankNonCode class").
+      acc.push({ file: name, content: stripComments(readFileSync(full, 'utf8'), name) })
     }
   }
   return acc
@@ -72,5 +80,25 @@ describe('Analysis hero source hygiene', () => {
     // assertion; the source bytes just no longer spell out that shape.
     const focusNowSpecifier = ['@/canvas/components/coaching-panel', 'focus-now'].join('/')
     expect(/coaching-panel\/focus-now/.test(`import x from '${focusNowSpecifier}'`)).toBe(true)
+  })
+
+  it('comment-strip both directions: comment mentions vanish, code (incl. bracket-key) still trips', () => {
+    const fetchRe = /\bfetch\s*\(|\baxios\b|XMLHttpRequest|EventSource|WebSocket/
+    const verdictRe = /robustnessLevel|robustnessLabel|robustnessVerdict|recommendationStability/
+    // Comment-borne mentions are blanked → not scanned (the #386/#403 footgun):
+    expect(fetchRe.test(stripComments('// must never introduce a second fetch(', 'x.ts'))).toBe(false)
+    expect(verdictRe.test(stripComments('/* must not read robustnessVerdict */', 'x.ts'))).toBe(false)
+    // Real code still trips, INCLUDING a bracket-string read (why we keep
+    // strings — blankNonCode would have blanked this and missed it):
+    expect(fetchRe.test(stripComments('const r = await fetch(url)', 'x.ts'))).toBe(true)
+    expect(verdictRe.test(stripComments("const v = data['robustnessVerdict']", 'x.ts'))).toBe(true)
+    // A live focus-now import string is kept and caught. Assemble the
+    // specifier (do NOT spell out an import-shaped focus-now literal in source)
+    // — the sibling focus-now inertness guard regex-scans this file; same
+    // .join technique as the positive control above.
+    const fnSpecifier = ['./coaching-panel', 'focus-now'].join('/')
+    expect(
+      /coaching-panel\/focus-now/.test(stripComments(`import x from '${fnSpecifier}'`, 'x.ts')),
+    ).toBe(true)
   })
 })

--- a/src/components/results/analysis-hero/__tests__/inertness.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/inertness.spec.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { dirname, join, resolve, sep } from 'node:path'
+import { stripComments } from '../../../../../tests/helpers/stripSourceComments'
 
 const SRC = resolve(process.cwd(), 'src')
 const MODULE_DIR = join(SRC, 'components', 'results', 'analysis-hero')
@@ -51,7 +52,13 @@ function isUnderModule(p: string): boolean {
 
 export function findAnalysisHeroImports(content: string, importerFile: string): string[] {
   const offenders: string[] = []
-  for (const m of content.matchAll(SPEC_RE)) {
+  // stripComments blanks comments but KEEPS string literals as code, so a
+  // commented-out `import … from './analysis-hero'` no longer false-reds
+  // (the #386/#403 footgun) while a real import specifier — which IS a string
+  // literal — is still captured. blankNonCode would blank the specifier body
+  // and make the guard blind to every relative import, so it is the wrong tool
+  // here (reclassified from the #403 manifest's "blankNonCode class").
+  for (const m of stripComments(content, importerFile).matchAll(SPEC_RE)) {
     const spec = m[1]
     const resolved = resolveSpec(spec, importerFile)
     if ((resolved && isUnderModule(resolved)) || PATH_RE.test(spec)) offenders.push(spec)
@@ -120,6 +127,11 @@ describe('Analysis hero inertness', () => {
     ['similarly-named relative sibling', PARENT, "import x from './analysis-hero-helpers'"],
     ['similarly-named aliased sibling', PARENT, "import x from '@/components/results/analysis-hero-helpers'"],
     ['unrelated relative path elsewhere', join(SRC, 'foo', 'bar.ts'), "import './not-analysis-hero'"],
+    // #386/#403 comment-strip: commented-out imports of the module no longer
+    // false-red. The live forms above ('FLAGS …') still fire — both directions.
+    ['//-commented module import', PARENT, "// import { AnalysisHeroContainer } from './analysis-hero'"],
+    ['block-commented module import', PARENT, "/* import { HeroModel } from './analysis-hero/heroTypes' */"],
+    ['//-commented aliased module import', PARENT, "// import x from '@/components/results/analysis-hero'"],
   ])('does NOT flag: %s', (_label, importer, code) => {
     expect(findAnalysisHeroImports(code, importer)).toEqual([])
   })

--- a/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/glossaryCompliance.spec.tsx
@@ -16,6 +16,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
 import { render } from '@testing-library/react'
+import { stripComments } from '../../../../../tests/helpers/stripSourceComments'
 import {
   findBannedTerm,
   GLOSSARY_BANNED_TERMS,
@@ -352,10 +353,14 @@ describe('AnalysisHeroV17 — glossary compliance (source files)', () => {
    */
   function extractCandidateStrings(source: string): string[] {
     const out: string[] = []
-    // Remove single-line and block comments first.
-    const noComments = source
-      .replace(/\/\*[\s\S]*?\*\//g, ' ')
-      .replace(/\/\/.*$/gm, ' ')
+    // Remove comments first. CONVERGED (#386/#403) onto the shared literal-aware
+    // stripComments: the previous naive `/\/\*…\*\//` + `/\/\/.*$/` pair
+    // mishandled literals — a `//` inside a `'http://…'` string, or a `/*`
+    // inside a quoted example, corrupted real copy and could HIDE a banned term
+    // that followed it. stripComments keeps string/template/regex literals as
+    // code (so their contents are still extracted below) and only blanks true
+    // comments, preserving offsets.
+    const noComments = stripComments(source, '.tsx')
     // Pull out double-quoted, single-quoted, and template-literal contents.
     const literalRe = /'([^'\\]*(?:\\.[^'\\]*)*)'|"([^"\\]*(?:\\.[^"\\]*)*)"|`([^`\\]*(?:\\.[^`\\]*)*)`/g
     let m: RegExpExecArray | null
@@ -382,6 +387,19 @@ describe('AnalysisHeroV17 — glossary compliance (source files)', () => {
   function isAllowedLiteral(literal: string): boolean {
     return HARD_CODED_SOURCE_ALLOWLIST.some(re => re.test(literal))
   }
+
+  it('convergence both directions: strip keeps a banned term after a // inside a string; ignores comment-only terms', () => {
+    // The naive `/\/\/.*$/` strip used to truncate a URL string at the `//`,
+    // dropping (and hiding) anything after it. The shared literal-aware strip
+    // keeps the whole string, so a banned term following an in-string `//`
+    // is still extracted and would be caught:
+    const kept = extractCandidateStrings(`const s = 'see http://x then the winner is here'`)
+    expect(kept.some((x) => x.includes('winner'))).toBe(true)
+    // The other direction: a banned term that lives ONLY in a comment is not
+    // a user-facing string and is not extracted:
+    const commentOnly = extractCandidateStrings('// the winner note\nconst ok = "fine"')
+    expect(commentOnly.some((x) => x.includes('winner'))).toBe(false)
+  })
 
   it('no hard-coded user-facing string in v17 hero source files contains a banned term', () => {
     const heroDir = join(__dirname, '..')

--- a/src/services/__tests__/graphWriteSourceGuard.spec.ts
+++ b/src/services/__tests__/graphWriteSourceGuard.spec.ts
@@ -25,17 +25,19 @@
  * reach here; the RPC-shape assertions in scenarioService.spec and the
  * behavioural pins in useScenario.spec are the complementary cover.
  *
- * NOTE: `blankNonCode`/`argsAt` intentionally mirror the proven helpers in
- * canvas/__tests__/cameraMotion.sourceScan.spec.ts. They are pure text utils,
- * and each copy is independently pinned by its own detector-contract block
- * below — a drifted copy fails its own positive controls rather than silently
- * returning a wrong verdict. (Deduping the two onto a shared test helper is a
- * tidy-up, deliberately not bundled into this fix.)
+ * NOTE: `blankNonCode` is now the SHARED helper in
+ * tests/helpers/stripSourceComments.ts (converged 2026-07-20 — the two
+ * hand-duplicated copies here and in cameraMotion.sourceScan.spec.ts were
+ * folded into one). `argsAt` remains a small local text util. The
+ * detector-contract block below still independently pins the shared
+ * `blankNonCode` — a drift fails these positive controls rather than silently
+ * returning a wrong verdict.
  */
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { blankNonCode } from '../../../tests/helpers/stripSourceComments'
 
 const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
@@ -61,44 +63,10 @@ function sourceFiles(dir: string): string[] {
   return out
 }
 
-/**
- * Blank out comments and string/template bodies, preserving offsets and
- * newlines, so documentation of the rule is never mistaken for a violation.
- */
-function blankNonCode(src: string): string {
-  const out = src.split('')
-  let i = 0
-  const blankTo = (end: number) => {
-    for (let k = i; k < end && k < src.length; k++) if (out[k] !== '\n') out[k] = ' '
-  }
-  while (i < src.length) {
-    const two = src.slice(i, i + 2)
-    if (two === '//') {
-      let end = src.indexOf('\n', i)
-      if (end === -1) end = src.length
-      blankTo(end)
-      i = end
-    } else if (two === '/*') {
-      let end = src.indexOf('*/', i + 2)
-      end = end === -1 ? src.length : end + 2
-      blankTo(end)
-      i = end
-    } else if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
-      const quote = src[i]
-      let j = i + 1
-      while (j < src.length && src[j] !== quote) {
-        if (src[j] === '\\') j++
-        j++
-      }
-      i++ // keep the opening quote so the token still parses as a value
-      blankTo(j)
-      i = Math.min(j + 1, src.length)
-    } else {
-      i++
-    }
-  }
-  return out.join('')
-}
+// `blankNonCode` (blanks comments + string/template bodies, offset-preserving)
+// is now the shared helper in tests/helpers/stripSourceComments.ts — the
+// detector contract below still pins its behaviour so documentation of the
+// rule is never mistaken for a violation.
 
 /** Extract the balanced `(...)` argument text starting at `openIdx`. */
 function argsAt(src: string, openIdx: number): string {

--- a/tests/ci-guards/autosave-projection-single-source.spec.ts
+++ b/tests/ci-guards/autosave-projection-single-source.spec.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative } from 'node:path'
+import { blankNonCode } from '../helpers/stripSourceComments'
 
 const SRC = join(process.cwd(), 'src')
 
@@ -52,7 +53,12 @@ function findCallSites(): CallSite[] {
   for (const file of walk(SRC)) {
     const rel = relative(SRC, file).split('\\').join('/')
     if (DEFINITION_FILES.includes(rel)) continue
-    const lines = readFileSync(file, 'utf8').split('\n')
+    // blankNonCode blanks comments AND string bodies (offsets preserved), so a
+    // `saveAutosave(` named inside a comment OR a string literal is no longer a
+    // false call site — the #386/#403 footgun. A real call is executable code
+    // and survives. (This subsumes the line-level comment/import skips below,
+    // which are kept as a cheap belt-and-braces.)
+    const lines = blankNonCode(readFileSync(file, 'utf8')).split('\n')
     lines.forEach((text, i) => {
       const m = /(?:^|[^.\w])(?:scenarios\.)?saveAutosave\(/.exec(text)
       if (!m) return
@@ -91,5 +97,26 @@ describe('autosave payload has a single constructor', () => {
     // `nodes:` in the same object passed to saveAutosave.
     const handBuilt = sites.filter(s => /^\{|timestamp\s*:/.test(s.argument))
     expect(handBuilt.map(o => `${o.file}:${o.line}`)).toEqual([])
+  })
+})
+
+/**
+ * Both-directions mutation proof for the blankNonCode strip (#386/#403).
+ * A real call still counts; a comment- or string-borne mention no longer does.
+ */
+describe('autosave guard — detector contract (comment/string mentions ignored)', () => {
+  const hasCall = (src: string): boolean =>
+    /(?:^|[^.\w])(?:scenarios\.)?saveAutosave\(/.test(blankNonCode(src))
+
+  it('STILL sees a live call', () => {
+    expect(hasCall('  scenarios.saveAutosave(projectAutosaveData(s))')).toBe(true)
+  })
+
+  it('does NOT see a call named in a // comment', () => {
+    expect(hasCall('// replaces scenarios.saveAutosave(payload)')).toBe(false)
+  })
+
+  it('does NOT see a call named in a string literal', () => {
+    expect(hasCall('throw new Error("saveAutosave(x) failed")')).toBe(false)
   })
 })

--- a/tests/helpers/stripSourceComments.ts
+++ b/tests/helpers/stripSourceComments.ts
@@ -121,6 +121,102 @@ export function stripJsComments(src: string): string {
   return a.join('')
 }
 
+/**
+ * Blank comments AND string/template bodies, preserving byte offsets and
+ * newlines. This is the `blankNonCode` CLASS of stripper (distinct from
+ * `stripComments` above): where `stripComments` keeps string/template/regex
+ * literals as CODE, `blankNonCode` also erases the INSIDE of every quoted
+ * string — the opening quote is kept so the remaining token still parses as a
+ * value. Use it for CODE-PATTERN guards where the forbidden thing (a raw
+ * `.update({ graph })`, an `as any` cast, a camera-move `duration:`) is only
+ * ever real when it appears as executable code, never inside a string; there,
+ * a mention of the pattern quoted in a doc string must not read as a call site.
+ *
+ * Do NOT use it for guards whose forbidden pattern legitimately lives in a
+ * string literal — an import specifier (`from './x'`), a route string
+ * (`'#/sandbox'`), a bracket-key read (`x['field']`) — blanking the string
+ * body there would make the guard blind to real violations. Those want
+ * `stripComments` (comments only).
+ *
+ * CONVERGED (2026-07-20): this is the single implementation of the state
+ * machine that was hand-duplicated in cameraMotion.sourceScan.spec.ts and
+ * graphWriteSourceGuard.spec.ts. Both now import it; each still carries its own
+ * detector-contract block (incl. "ignores … comments and strings") that pins
+ * this function, so a drift would fail those positive controls loudly rather
+ * than returning a wrong verdict.
+ */
+export function blankNonCode(src: string): string {
+  const out = src.split('')
+  let i = 0
+  const blankTo = (end: number): void => {
+    for (let k = i; k < end && k < src.length; k++) if (out[k] !== '\n') out[k] = ' '
+  }
+  while (i < src.length) {
+    const two = src.slice(i, i + 2)
+    if (two === '//') {
+      let end = src.indexOf('\n', i)
+      if (end === -1) end = src.length
+      blankTo(end)
+      i = end
+    } else if (two === '/*') {
+      let end = src.indexOf('*/', i + 2)
+      end = end === -1 ? src.length : end + 2
+      blankTo(end)
+      i = end
+    } else if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
+      const quote = src[i]
+      let j = i + 1
+      while (j < src.length && src[j] !== quote) {
+        if (src[j] === '\\') j++
+        j++
+      }
+      i++ // keep the opening quote so the token still parses as a value
+      blankTo(j)
+      i = Math.min(j + 1, src.length)
+    } else {
+      i++
+    }
+  }
+  return out.join('')
+}
+
+/**
+ * Blank HTML comments (`<!-- … -->`) AND the JS comments inside every
+ * `<script>…</script>` block, preserving byte offsets and newlines so a
+ * source-scanning guard's positions stay accurate.
+ *
+ * A hand-written HTML document (index.html) is neither pure JS nor pure CSS:
+ * `stripJsComments` cannot be applied to the whole file because a bare `//`
+ * in an `https://…` URL that sits in HTML text (not inside a JS string) would
+ * be misread as the start of a line comment. So this handles the two comment
+ * grammars that actually occur: HTML `<!-- -->` markers anywhere, and JS line
+ * and block comments inside `<script>` bodies (delegated to `stripJsComments`,
+ * which keeps string/regex literals — so a quoted URL in a `fetch()` argument
+ * survives while a `//`-commented copy of it does not).
+ */
+export function stripHtmlComments(html: string): string {
+  const a = html.split('')
+  let i = 0
+  while (i < a.length) {
+    if (html.startsWith('<!--', i)) {
+      let end = html.indexOf('-->', i + 4)
+      end = end === -1 ? html.length : end + 3
+      for (let k = i; k < end; k++) if (a[k] !== '\n' && a[k] !== '\r') a[k] = ' '
+      i = end
+    } else {
+      i++
+    }
+  }
+  // stripJsComments preserves length exactly, so replacing each script body
+  // in place never shifts any offset outside the block.
+  return a
+    .join('')
+    .replace(
+      /(<script\b[^>]*>)([\s\S]*?)(<\/script>)/gi,
+      (_m, open: string, body: string, close: string) => open + stripJsComments(body) + close,
+    )
+}
+
 /** Strip only block comments from CSS (no line comments), treating strings as code. */
 export function stripCssComments(src: string): string {
   const a = src.split('')


### PR DESCRIPTION
## Why

Follow-up to #403 (merged, staging tip). #403 established the shared literal-aware stripper `tests/helpers/stripSourceComments.ts` and fixed the first copy-footgun; it deferred ~12 category-(a) source-scanning guards that need a `blankNonCode`-class stripper, an HTML variant, and the two `blankNonCode` duplicates converged. This PR finishes that.

**Core principle honoured throughout:** one implementation per stripper (derive-don't-mirror), and every guard gets a **both-directions** mutation proof (a real violation still trips; a comment/string-borne mention no longer does).

## Shared module (`tests/helpers/stripSourceComments.ts`)

- **Converged `blankNonCode`** (blanks comments **and** string bodies, offset-preserving). The two hand-duplicated copies in `cameraMotion.sourceScan.spec.ts` and `graphWriteSourceGuard.spec.ts` now import the shared one; each file keeps its own detector-contract block (incl. "ignores … comments and strings"), which still pins the shared function loudly.
- **Added `stripHtmlComments`** — blanks `<!-- -->` **and** JS comments inside `<script>` bodies (neither existing stripper covers HTML; a bare `//` in an `https://` URL sitting in HTML text must not be misread as a line comment).

## The two strippers are NOT interchangeable — a key reclassification

The #403 manifest tagged most deferred guards "blankNonCode class". Verifying at the bytes, **several of them must use `stripComments` (comments only), not `blankNonCode`** — because their forbidden pattern legitimately lives in a **string literal** (an import specifier, an intent string, a bracket-key read, an extracted user-facing literal). Blanking string bodies there would make the guard **blind to real violations** — strictly weaker detection. Reclassified with evidence below.

## Per-guard table

| Guard | Stripper | Both-directions proof |
|---|---|---|
| `no-raw-influence-read.spec.ts` **(load-bearing policy)** | **stripComments** (reclassified — keeps `${d.influenceScore}` template reads detectable) | 4-bypass RED history still trips; template + wrong-ordered chain still trip; commented/JSDoc versions do not. **Mutation-verified live** (disabling strip → exactly the commented cases RED, all "STILL catches" green). |
| `no-message-render.spec.ts` **(load-bearing policy)** | **stripComments** (reclassified — keeps `{\`${w.message}\`}` template renders detectable) | live `{item.message}` / renamed / template render still trip; SAFE patterns clean; `//`, JSX `{/* */}`, block comment do not. **Mutation-verified live.** |
| `autosave-projection-single-source.spec.ts` | blankNonCode | live `saveAutosave(projectAutosaveData(…))` counts; `//`- and string-borne mentions do not. |
| `TornadoChart.dormancy.spec.ts` | blankNonCode (also hardens tag extraction vs `>` in a string prop) | live `onApplyAndRerun=` prop seen; JSX `{/* */}` and `//`-commented prop not. |
| `wave2-replay-gate.spec.ts` | blankNonCode | real cast counted; comment/string `as any` not; boundary-field token (dot-access) survives on cast lines (verified: no bracket-string field access). |
| `analysis-hero/__tests__/inertness.spec.ts` | **stripComments** (reclassified — the import specifier IS a string) | live import forms still flag; commented-out module imports do not. |
| `focus-now/__tests__/inertness.spec.ts` | **stripComments** (reclassified — same) | same. |
| `analysis-hero/__tests__/hygiene.spec.ts` | **stripComments** (reclassified — keeps bracket-key reads + the focus-now import string catchable) | comment mentions of `fetch(`/`robustnessVerdict` ignored; real code incl. `data['robustnessVerdict']` still trips. |
| `pre-analysis-v3/signals/__tests__/registry.spec.ts` | **stripComments** (reclassified — intent strings + bracket-key enum reads are strings) | comment mention of a dead-end intent ignored; real `'confirm_factor'` string + `data['readiness_level']` still caught. |
| `analysis-hero/__tests__/fixtureIsolation.spec.tsx` | **stripComments** (residual un-anchored path check) | commented `analysis-hero/fixtures` ignored; real fixture import string flagged. |
| `analysisHeroV17/__tests__/glossaryCompliance.spec.tsx` | **stripComments** (converged naive inline strip) | strip keeps a banned term after an in-string `//` (naive strip truncated + hid it); comment-only terms not extracted. |
| `indexHtmlHealthProbe.spec.ts` | **stripHtmlComments** (new) | live cross-origin `fetch('…onrender.com')` caught; host inside `<!-- -->`, `//`, or `/* */` in the script not; HTML-text `https://` URL not mangled. |
| `cameraMotion.sourceScan.spec.ts` / `graphWriteSourceGuard.spec.ts` | converged onto shared `blankNonCode` | existing detector-contract blocks unchanged and green (21 tests). |

## Reclassified as NOT-a-comment-footgun (unchanged, with evidence)

**`tools/ci-guards/check-gotosandbox.mjs` — left unchanged.** Verified at the bytes: it is **dormant** (its `ci:guard:sandbox` npm script is wired into no CI workflow, `ci:all`, pre-push script, or hook) **and already red on live code** — 3 e2e specs reach `#/sandbox` via a raw `page.goto` with no `gotoSandbox()` helper (`e2e/sandbox.spec.ts` ×9, `e2e/scenarios-sharelink.spec.ts`, and `e2e/smoke/route-transitions.spec.ts` only via the `#/sandbox-v1` **substring**). A comment strip alone therefore cannot green it, and converting it to a CI-run vitest spec would **inject 3 real failures** into the gate. The semantics decision — are those 3 raw navigations violations or sanctioned exceptions? (and the `#/sandbox-v1` substring is a separate bug) — belongs to the guard's owner, not a comment-strip lane. The `.ts`/`.mjs` boundary is moot until that decision is made.

## Gates

- `pnpm run typecheck` (tsc -p tsconfig.ci.json) — **clean (exit 0)**.
- All 14 touched guard suites — **green (1312 tests)**; #403 consumers (`british-english`, `semantic-colour-alpha`) still green (25).
- `npx vitest run --changed --bail=1` — **16 files / 1337 tests green**.
- Wide `tsc -p tsconfig.app.json --noEmit` in the same clone — **2318 errors with these changes vs 2319 on the clean staging tree** (0 new; −1 from removing the duplicate `blankNonCode`).
- ESLint on all changed files — clean.

## Note for the package.json-owning lane

None of this touches `package.json`. If `check-gotosandbox` is ever revived, its footgun and the `#/sandbox-v1` substring bug should be addressed together with the "are the 3 raw-goto specs sanctioned?" call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)