### PR TITLE
fix(ci): setup-node cache post-step hard-fails when install is skipped — staging reds since the 0.20.0 lockfile change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: https://npm.pkg.github.com
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache node_modules
         id: cache-nm
@@ -105,8 +103,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -135,8 +131,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -238,8 +232,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -285,8 +277,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -320,8 +310,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -367,8 +355,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -426,8 +412,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -459,8 +443,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -491,8 +473,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
@@ -546,8 +526,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -78,8 +78,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: https://npm.pkg.github.com
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache node_modules
         id: cache-nm

--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -68,8 +68,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: https://npm.pkg.github.com
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache node_modules
         id: cache-nm
@@ -102,8 +100,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -146,8 +142,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -382,8 +376,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Restore node_modules cache
         uses: actions/cache@v4

--- a/.github/workflows/unified-evidence.yml
+++ b/.github/workflows/unified-evidence.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install unzip
         run: sudo apt-get update && sudo apt-get install -y unzip


### PR DESCRIPTION
## Symptom

Every push to \`staging\` has been fully red since **#405** changed \`pnpm-lock.yaml\` (0.20.0), with **no test ever running**. Step-level evidence (run 29772131204 job *Install & Cache*, run 29772131213 *CEE Contract Validation* — identical): Checkout ✓, Set up pnpm ✓, Use Node.js from .nvmrc ✓, Cache node_modules ✓ (HIT → *Install dependencies* SKIPPED), then:

```
Post Use Node.js from .nvmrc  — FAILS
Path Validation Error: Path(s) specified in the action for caching do(es) not exist
```

→ Install job fails → all dependent jobs skip → Summary + Staging Gate red.

## Root cause (verified at the workflow bytes)

\`actions/setup-node@v4\` was configured with \`cache: 'pnpm'\`. Its **post-step SAVES the pnpm content-addressable store**, keyed on \`hashFiles('pnpm-lock.yaml')\`. But these jobs carry a **separate node_modules cache** and skip \`pnpm install\` on a node_modules cache **HIT** — so on a hit the pnpm store directory is never created.

While the lockfile was stable, the store cache key already existed, so the post-step no-op'd on a cache hit. The #405 lockfile change minted a **new** store key → post-step tried to **save a path that does not exist** → hard failure. Latent since the workflows were written; unmasked by the first lockfile change whose node_modules cache got populated cross-run.

## Fix — the class, not the instance

Removed \`cache: 'pnpm'\` + \`cache-dependency-path\` from setup-node in **every job that already has a node_modules cache**. The store cache is redundant there: on a node_modules hit install is skipped; on a miss \`pnpm install --frozen-lockfile\` repopulates node_modules directly.

**Miss-path cost, honestly:** both caches key on the *same* \`hashFiles('pnpm-lock.yaml')\`, so they invalidate in lockstep. The one path where a pnpm-store cache could help (a lockfile change) is exactly the path where the store cache *also* misses — so removal costs no measurable miss-path time. The PREFERRED option in the brief, and the evidence supports it.

Also removed from \`unified-evidence.yml\`, which had \`cache: 'pnpm'\` with **no install and no node_modules cache** — same landmine, store never populated.

**Not** papered over with \`continue-on-error\` on the post-step (that silences a broken alarm rather than fixing it).

### Deliberately untouched

\`codeql\` · \`main\` · \`poc-pr\` · \`poc-sweep\` · \`ui-evidence-selftest\` run \`pnpm install --frozen-lockfile\` **unconditionally** with no node_modules cache → the pnpm store IS populated → the post-step saves fine. \`cache: 'pnpm'\` is a legitimate install speed-up there, not the bug. \`windsurf-direct-apply.yml\` has no pnpm cache at all. The #404 zustand-guard step in \`staging-full-tests.yml\` is untouched.

## Per-workflow / per-job manifest

| Workflow | Job | Has node_modules cache? | Install runs? | Was broken on lockfile change? | Action |
|---|---|---|---|---|---|
| staging-full-tests.yml | Install & Cache | ✅ | skipped on hit | **yes** (the reported red) | removed cache:pnpm |
| staging-full-tests.yml | TypeScript + Lint | ✅ (restore) | no (relies on nm cache) | **yes** | removed cache:pnpm |
| staging-full-tests.yml | Full Test Suite (×4 shards) | ✅ (restore) | no | **yes** | removed cache:pnpm |
| staging-full-tests.yml | Production Build | ✅ (restore) | no | **yes** | removed cache:pnpm |
| contract-validation.yml | CEE Contract Validation | ✅ | skipped on hit | **yes** (the reported red) | removed cache:pnpm |
| ci.yml | install + 10 downstream (audit, tsc, tests, backend-contract, build, 4×e2e, evidence, prod-safe) | ✅ | skipped/none | **yes** (latent; PR/main-triggered) | removed cache:pnpm (11 blocks) |
| unified-evidence.yml | unified-evidence | ❌ | no install at all | **yes** (store never populated) | removed cache:pnpm |
| codeql.yml | analyze | ❌ | \`pnpm install\` unconditional | no (store populated) | **kept** |
| main.yml | (dispatch) | ❌ | \`pnpm install\` unconditional | no | **kept** |
| poc-pr.yml | (PR main) | ❌ | \`pnpm install\` unconditional | no | **kept** |
| poc-sweep.yml | (push feat/…) | ❌ | \`pnpm install\` unconditional | no | **kept** |
| ui-evidence-selftest.yml | (dispatch) | ❌ | \`pnpm install\` unconditional | no | **kept** |
| windsurf-direct-apply.yml | — | ❌ | — | no (no pnpm cache) | **n/a** |

Net diff: **34 deletions, 0 insertions** across 4 files (17 setup-node blocks × 2 lines).

## Proof

- **actionlint 1.7.12** clean (exit 0) on all four edited workflows.
- All 9 pnpm workflows parse as valid YAML.
- **This PR's own run** (targets \`staging\` → triggers staging-full-tests.yml + contract-validation.yml, the two reported-red workflows) is the live adjudicator. Local vitest cannot prove CI config; the Install & Cache and CEE Contract Validation jobs going green here — including the cache-hit path once caches are populated — is the demonstration.

## ⚠️ Do not merge

Report-only per the lane brief. Merge + the next staging push are the final adjudication, to be done by the maintainer.

---

## ✅ This PR's own run — step-level evidence (run 29772765403 / 29772765667)

Both previously-red jobs pass, **on the cache-HIT path** (the exact condition that fired the bug):

**Install & Cache** (was red):
```
4 Use Node.js from .nvmrc      — success
5 Cache node_modules           — success
6 Install dependencies         — skipped   ← node_modules cache HIT (the bug's trigger condition)
10 Post Use Node.js from .nvmrc — success   ← the exact step that failed "Path Validation Error"
13 Complete job                — success
```

**CEE Contract Validation** (was red):
```
6 Cache node_modules           — success
7 Install dependencies         — skipped   ← cache HIT
10 Run contract tests           — success
17 Post Use Node.js from .nvmrc — success   ← previously failing step, now green
21 Complete job                — success
```

Because the node_modules cache was already populated for this lockfile hash, run 1 **already exercised the "install skipped" cache-hit path** — no second run needed to reach the failing condition. The previously-**skipped** dependent jobs (TypeScript + Lint, Full Test Suite ×4, Production Build) now **run** instead of being blocked by the failed Install job.
