### PR TITLE
fix(results): exploratory analysis CTAs prefill the Ask-Olumi drawer, never auto-send [DO NOT MERGE]

### DIFF
--- a/src/components/results/ChallengeSection.tsx
+++ b/src/components/results/ChallengeSection.tsx
@@ -25,6 +25,7 @@ import { HelpCircle, AlertTriangle, Info } from 'lucide-react'
 import { stripEncodingNotation, stripStatusQuoSuffixForDisplay } from './utils/cleanFactorLabel'
 import type { EvidenceGapItem, DriverItem } from './types'
 import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWithAiButton'
+import { openAskOlumi } from './coaching/askOlumiStore'
 import { ExpertBlock } from './ExpertBlock'
 
 /** E-value entry for an edge */
@@ -135,7 +136,7 @@ function ChallengeCard({
             <DiscussWithAiButton
               variant="secondary"
               element={{ kind: 'missing' }}
-              onSend={() => onSendMessage(ctaPrompt)}
+              onSend={() => openAskOlumi({ context: cleanTitle, draft: ctaPrompt, label: 'Explore this' })}
             />
           </div>
         )}
@@ -182,7 +183,7 @@ function ChallengeCard({
             <DiscussWithAiButton
               variant="secondary"
               element={{ kind: 'missing' }}
-              onSend={() => onSendMessage(ctaPrompt)}
+              onSend={() => openAskOlumi({ context: cleanTitle, draft: ctaPrompt, label: 'Explore this' })}
             />
           </div>
         )}
@@ -286,13 +287,15 @@ export function FragileEdgeGroupCard({
           <DiscussWithAiButton
             variant="secondary"
             element={{ kind: 'missing' }}
-            onSend={() => onSendMessage(
-              altWinnerLabel && multiple
+            onSend={() => openAskOlumi({
+              context: 'Fragile relationships',
+              draft: altWinnerLabel && multiple
                 ? `Are these ${edges.length} relationships that could flip the result to ${altWinnerLabel} reliable?`
                 : altWinnerLabel
                   ? `Is the relationship between ${stripEncodingNotation(edges[0].from_label)} and ${stripEncodingNotation(edges[0].to_label)} reliable?`
-                  : `Are these ${edges.length} fragile relationships in my model reliable?`
-            )}
+                  : `Are these ${edges.length} fragile relationships in my model reliable?`,
+              label: 'Discuss fragile relationships',
+            })}
           />
         </div>
       )}
@@ -322,7 +325,7 @@ function IdentifiabilityCard({ onSendMessage }: { onSendMessage?: (text: string)
           <DiscussWithAiButton
             variant="secondary"
             element={{ kind: 'goal', label: 'success target' }}
-            onSend={() => onSendMessage('What baseline should I use for the success target? The current one is a default.')}
+            onSend={() => openAskOlumi({ context: 'The success target relies on a default baseline', draft: 'What baseline should I use for the success target? The current one is a default.', label: 'Discuss the baseline' })}
           />
         </div>
       )}

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -44,6 +44,7 @@ import {
 } from './influenceScaleCopy'
 import { ExpandableCoachingText } from '../../components/shared/ExpandableCoachingText'
 import { isExpertField } from './utils/isExpertField'
+import { openAskOlumi } from './coaching/askOlumiStore'
 
 interface DriversSectionProps {
   data: DriversSectionData
@@ -701,9 +702,13 @@ function DriverRow({
             type="button"
             data-testid={`driver-technique-chip-${driver.factorKey}`}
             onClick={() => {
-              onSendMessage(
-                `${techniqueSuggestion} could help with "${cleanedLabel}". How would you apply it here?`,
-              )
+              // Codex finding 6: exploratory CTA — prefill the Ask-Olumi drawer
+              // (editable draft, user presses Send), never auto-send.
+              openAskOlumi({
+                context: `${techniqueSuggestion} for "${cleanedLabel}"`,
+                draft: `${techniqueSuggestion} could help with "${cleanedLabel}". How would you apply it here?`,
+                label: techniqueSuggestion,
+              })
             }}
             className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2 py-0.5 bg-transparent hover:bg-panel-hover cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1`}
             aria-label={`Discuss ${techniqueSuggestion.replace(/^Try:\s*/i, '')} for ${cleanedLabel}`}

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -40,6 +40,7 @@ import {
 import { buildSegmentColorMap, WIN_GAUGE_COLORS } from './WinGauge'
 import Tooltip from '../Tooltip'
 import { winnerChipLabel, winnerChipPrompt } from './utils/winnerChipCopy'
+import { openAskOlumi } from './coaching/askOlumiStore'
 
 export interface OptionCardsProps {
   options: OptionResult[]
@@ -539,7 +540,14 @@ function OptionCard({
               type="button"
               onClick={(e) => {
                 e.stopPropagation()
-                onSendMessage(winnerChipPrompt(isWinner, option.label))
+                // Codex finding 6: exploratory question-shaped CTA — prefill the
+                // Ask-Olumi drawer (editable draft, user presses Send) instead of
+                // auto-sending into a possibly-hidden conversation.
+                openAskOlumi({
+                  context: `About "${option.label}"`,
+                  draft: winnerChipPrompt(isWinner, option.label),
+                  label: winnerChipLabel(isWinner, confidenceTier, recommendationStability),
+                })
               }}
               className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2.5 py-1 bg-transparent hover:bg-panel-hover cursor-pointer`}
             >
@@ -721,12 +729,16 @@ export function OptionCards({
             </button>
           )}
           {/* Brief 5.8B D3 step 3: "What if I tried a different approach?" link.
-              Routes the prompt through the existing onSendMessage pathway so the
-              conversation panel reuses the same coaching loop the AI chips use. */}
+              Codex finding 6: exploratory CTA — prefills the Ask-Olumi drawer
+              (editable draft, user presses Send) rather than auto-sending. */}
           {onSendMessage && (
             <button
               type="button"
-              onClick={() => onSendMessage('What if I tried a different approach? Suggest one or two alternative options I could compare against the current set.')}
+              onClick={() => openAskOlumi({
+                context: 'Explore a different approach',
+                draft: 'What if I tried a different approach? Suggest one or two alternative options I could compare against the current set.',
+                label: 'A different approach',
+              })}
               className={`self-start ${typography.panelBody} text-info hover:underline cursor-pointer`}
               data-testid="option-cards-different-approach"
             >

--- a/src/components/results/StressTestSection.tsx
+++ b/src/components/results/StressTestSection.tsx
@@ -41,6 +41,7 @@ import {
   buildOutsideViewCard,
 } from './utils/stressTestTemplates'
 import { SensitivityReferenceCaption } from './SensitivityReferenceCaption'
+import { openAskOlumi } from './coaching/askOlumiStore'
 import type { DriverItem } from './types'
 
 const RANK_FLIP_THRESHOLD = 0.15
@@ -138,9 +139,11 @@ function SensitiveAssumptionCard({
         type="button"
         disabled={!onSendMessage}
         onClick={onSendMessage
-          ? () => onSendMessage(
-              `What if ${cleanLabel} changes? Walk me through the impact.`,
-            )
+          ? () => openAskOlumi({
+              context: `${cleanLabel} — a shift could change the result.`,
+              draft: `What if ${cleanLabel} changes? Walk me through the impact.`,
+              label: 'What if this changes?',
+            })
           : undefined}
         className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2.5 py-1 bg-transparent hover:bg-panel-hover cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1 disabled:cursor-default disabled:opacity-50`}
         aria-label={`Explore what happens if ${cleanLabel} changes`}
@@ -174,7 +177,13 @@ function ThinkingPatternCardView({
       <button
         type="button"
         disabled={!onSendMessage}
-        onClick={onSendMessage ? () => onSendMessage(promptBuilder()) : undefined}
+        onClick={onSendMessage
+          ? () => openAskOlumi({
+              context: card.context ? `${card.question} ${card.context}` : card.question,
+              draft: promptBuilder(),
+              label: card.chipLabel,
+            })
+          : undefined}
         className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2.5 py-1 bg-transparent hover:bg-panel-hover cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1 disabled:cursor-default disabled:opacity-50`}
         aria-label={card.chipLabel}
       >

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -36,6 +36,7 @@ import { safeInterpolatedLabel } from './analysisHeroV17/glossaryCheck'
 import { typography } from '@/styles/typography'
 import type { ResultsSectionDataReturn } from './useResultsSectionData'
 import { MissingKnowledgePrompt } from '@/components/shared/MissingKnowledgePrompt'
+import { openAskOlumi } from './coaching/askOlumiStore'
 import { useCanvasStore } from '@/canvas/store'
 import {
   buildStrengthenOverlayMap,
@@ -386,13 +387,19 @@ function T1DominantNudge({
           Validate
         </button>
       )}
-      {/* (Round-5 P1.1) Research chip dispatches `onSendMessage` — auto-send.
-          v17 hero has zero auto-send paths, so the chip is suppressed when
-          useV17Copy is true. Legacy panel still renders it. */}
+      {/* (Round-5 P1.1) Research chip is exploratory/question-shaped. Codex
+          finding 6: prefill the Ask-Olumi drawer (editable draft, user presses
+          Send) instead of auto-sending. Suppressed under v17 copy (which has its
+          own affordances); the legacy panel still renders it. Gated on
+          onSendMessage as the "chat is available" signal. */}
       {!useV17Copy && onSendMessage && (
         <button
           type="button"
-          onClick={() => onSendMessage(`Can you research ${dominantLabel} and suggest a reasonable estimate with sources?`)}
+          onClick={() => openAskOlumi({
+            context: `Research ${dominantLabel}`,
+            draft: `Can you research ${dominantLabel} and suggest a reasonable estimate with sources?`,
+            label: 'Research',
+          })}
           className={`flex-shrink-0 px-2 py-0.5 rounded-full ${typography.panelMeta} text-warning border border-warning/30 bg-transparent hover:bg-panel-hover cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warning`}
           aria-label={`Research ${dominantLabel}`}
         >

--- a/src/components/results/__tests__/OptionCards.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.spec.tsx
@@ -656,7 +656,11 @@ describe('OptionCards', () => {
       expect(screen.getByTestId('option-cards-different-approach')).toBeInTheDocument()
     })
 
-    it('clicking the link routes a prompt through onSendMessage', () => {
+    it('clicking the link prefills the Ask-Olumi drawer instead of auto-sending', async () => {
+      // Codex finding 6: exploratory CTA routes through openAskOlumi (prefilled
+      // editable draft) — it must NOT call the threaded onSendMessage.
+      const { useAskOlumiStore } = await import('../coaching/askOlumiStore')
+      useAskOlumiStore.getState().close()
       const onSendMessage = vi.fn()
       render(
         <OptionCards
@@ -666,8 +670,10 @@ describe('OptionCards', () => {
         />,
       )
       fireEvent.click(screen.getByTestId('option-cards-different-approach'))
-      expect(onSendMessage).toHaveBeenCalledTimes(1)
-      expect(onSendMessage.mock.calls[0][0]).toMatch(/different approach/i)
+      expect(onSendMessage).not.toHaveBeenCalled()
+      const state = useAskOlumiStore.getState()
+      expect(state.isOpen).toBe(true)
+      expect(state.draft).toMatch(/different approach/i)
     })
   })
 })

--- a/src/components/results/__tests__/StressTestSection.spec.tsx
+++ b/src/components/results/__tests__/StressTestSection.spec.tsx
@@ -159,7 +159,11 @@ describe('StressTestSection — Brief 5.8B D4', () => {
       expect(screen.queryByText(/Sensitive assumptions/)).not.toBeInTheDocument()
     })
 
-    it('"What if this changes?" chip routes the prompt through onSendMessage', () => {
+    it('"What if this changes?" chip prefills the Ask-Olumi drawer instead of auto-sending', async () => {
+      // Codex finding 6: exploratory CTA routes through openAskOlumi (prefilled
+      // editable draft) — it must NOT call the threaded onSendMessage.
+      const { useAskOlumiStore } = await import('../coaching/askOlumiStore')
+      useAskOlumiStore.getState().close()
       const onSendMessage = vi.fn()
       render(
         <StressTestSection
@@ -171,8 +175,10 @@ describe('StressTestSection — Brief 5.8B D4', () => {
         />,
       )
       fireEvent.click(screen.getByText('What if this changes?'))
-      expect(onSendMessage).toHaveBeenCalledTimes(1)
-      expect(onSendMessage.mock.calls[0][0]).toMatch(/Customer churn rate/)
+      expect(onSendMessage).not.toHaveBeenCalled()
+      const state = useAskOlumiStore.getState()
+      expect(state.isOpen).toBe(true)
+      expect(state.draft).toMatch(/Customer churn rate/)
     })
   })
 

--- a/src/components/results/__tests__/ctaPrefillNeverAutosend.spec.tsx
+++ b/src/components/results/__tests__/ctaPrefillNeverAutosend.spec.tsx
@@ -1,0 +1,170 @@
+/**
+ * Codex review finding 6 — exploratory "ask Olumi" CTAs in the analysis panel
+ * must NOT auto-send into a possibly-hidden conversation. They route through the
+ * Ask-Olumi drawer (openAskOlumi): a PREFILLED, EDITABLE draft that the user
+ * sends by pressing Send — the openAskOlumi/prefill doctrine.
+ *
+ * These are the RED tests for the fix. Before the fix each CTA called the
+ * threaded onSendMessage directly (auto-send); after the fix it opens the drawer
+ * with the prompt prefilled and the composer focused, dispatching nothing until
+ * the user presses Send.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+
+import { OptionCards } from '../OptionCards'
+import { StressTestSection } from '../StressTestSection'
+import { AskOlumiDrawer } from '../coaching/AskOlumiDrawer'
+import { useAskOlumiStore } from '../coaching/askOlumiStore'
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import type { OptionResult, DriverItem } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+const mockOptions: OptionResult[] = [
+  {
+    id: 'option-1',
+    label: 'Option A',
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended: true,
+    winProbability: 0.65,
+    goalProbability: 0.75,
+    rank: 1,
+  },
+  {
+    id: 'option-2',
+    label: 'Option B',
+    expected: 90,
+    outcome: { mean: 90, p10: 50, p50: 90, p90: 130 },
+    p10: 50,
+    p50: 90,
+    p90: 130,
+    isRecommended: false,
+    winProbability: 0.35,
+    goalProbability: 0.55,
+    rank: 2,
+  },
+]
+
+function makeDriver(overrides: Partial<DriverItem> = {}): DriverItem {
+  return {
+    factorKey: 'fac_top',
+    factorLabel: 'Customer churn rate',
+    rawElasticity: 0.5,
+    normalisedInfluence: 0.5,
+    influenceScore: 0.5,
+    rank: 1,
+    direction: 'positive',
+    semanticLabel: 'biggest',
+    canFocus: true,
+    matchedNodeId: 'node_default',
+    confidence: 0.8,
+    rankFlipRate: 0.32,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  // Reset the singleton stores between tests.
+  useAskOlumiStore.getState().close()
+  useAskOlumiStore.setState({ draft: '', context: '', label: '' })
+  useGuidanceStore.setState({ _sendMessage: null, _dispatchAction: null })
+})
+
+describe('OptionCards winner chip — prefill, never auto-send', () => {
+  it('clicking "What makes this lead?" opens the drawer prefilled and dispatches nothing', () => {
+    const onSendMessage = vi.fn()
+    render(
+      <>
+        <OptionCards options={mockOptions} winnerId="option-1" onSendMessage={onSendMessage} />
+        <AskOlumiDrawer />
+      </>,
+    )
+
+    // The winner chip on Option A.
+    fireEvent.click(screen.getByText('What makes this lead?'))
+
+    // No auto-send: the threaded send path is never touched.
+    expect(onSendMessage).not.toHaveBeenCalled()
+
+    // The drawer is open with the prompt prefilled into the editable composer.
+    const draft = screen.getByTestId('ask-olumi-draft') as HTMLTextAreaElement
+    expect(draft).toBeInTheDocument()
+    expect(draft.value).toMatch(/Option A/)
+    expect(draft.value).toMatch(/leading option|key advantages/i)
+
+    // Composer is focused for immediate editing.
+    expect(document.activeElement).toBe(draft)
+  })
+
+  it('positive control: pressing Send after prefill dispatches exactly once', () => {
+    const send = vi.fn()
+    useGuidanceStore.setState({ _sendMessage: send, _dispatchAction: null })
+
+    render(
+      <>
+        <OptionCards options={mockOptions} winnerId="option-1" onSendMessage={vi.fn()} />
+        <AskOlumiDrawer />
+      </>,
+    )
+
+    fireEvent.click(screen.getByText('What makes this lead?'))
+    expect(send).not.toHaveBeenCalled() // nothing sent on prefill
+
+    const drawer = screen.getByTestId('ask-olumi-drawer')
+    fireEvent.click(within(drawer).getByText('Send'))
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send.mock.calls[0][0]).toMatch(/Option A/)
+  })
+})
+
+describe('OptionCards "different approach" link — prefill, never auto-send', () => {
+  it('clicking the link opens the drawer prefilled and dispatches nothing', () => {
+    const onSendMessage = vi.fn()
+    render(
+      <>
+        <OptionCards options={mockOptions} winnerId="option-1" onSendMessage={onSendMessage} />
+        <AskOlumiDrawer />
+      </>,
+    )
+
+    fireEvent.click(screen.getByTestId('option-cards-different-approach'))
+
+    expect(onSendMessage).not.toHaveBeenCalled()
+    const draft = screen.getByTestId('ask-olumi-draft') as HTMLTextAreaElement
+    expect(draft.value).toMatch(/different approach/i)
+  })
+})
+
+describe('StressTestSection "What if this changes?" — prefill, never auto-send', () => {
+  it('clicking the chip opens the drawer prefilled and dispatches nothing', () => {
+    const onSendMessage = vi.fn()
+    render(
+      <>
+        <StressTestSection
+          drivers={[makeDriver()]}
+          fragileEdges={[]}
+          winnerLabel="Option A"
+          alternativeLabel="Option B"
+          onSendMessage={onSendMessage}
+        />
+        <AskOlumiDrawer />
+      </>,
+    )
+
+    fireEvent.click(screen.getByText('What if this changes?'))
+
+    expect(onSendMessage).not.toHaveBeenCalled()
+    const draft = screen.getByTestId('ask-olumi-draft') as HTMLTextAreaElement
+    expect(draft.value).toMatch(/Customer churn rate/)
+  })
+})


### PR DESCRIPTION
## Codex review finding 6 — exploratory "ask Olumi" CTAs auto-send into a possibly-hidden conversation

**Confirmed live**: clicking OptionCards' winner chip ("What makes this the current leader?") immediately appended a user turn and fired a network request with the composer empty — the CTA called the threaded `onSendMessage` directly. This violates the `openAskOlumi`/prefill doctrine: prefilled EDITABLE draft, user presses Send.

### Fix
Route every exploratory question-shaped CTA in the results/analysis surfaces through the existing **`openAskOlumi`** drawer (`AskOlumiDrawer` is a self-contained fixed overlay mounted unconditionally in OutputsDock; it focuses its textarea on open and dispatches only on Send). No parallel path invented; no new reveal mechanism.

### CTA manifest (site / class / action)

| Site | Prompt | Class | Live on staging? | Action |
|------|--------|-------|------------------|--------|
| `OptionCards.tsx` winner chip | "What makes this…lead / the current leader?" | exploratory | **Yes** | → `openAskOlumi` |
| `OptionCards.tsx` "different approach" link | "What if I tried a different approach?…" | exploratory | **Yes** | → `openAskOlumi` |
| `StressTestSection.tsx` SensitiveAssumptionCard | "What if `<factor>` changes?…" | exploratory | **Yes** | → `openAskOlumi` |
| `StressTestSection.tsx` ThinkingPatternCardView | template chip prompt | exploratory | dormant (`showThinkingPatterns=false` under heroPanel) | → `openAskOlumi` |
| `DriversSection.tsx` technique chip | "`<technique>` could help…" | exploratory | dormant (`DISPLAY_SAFE_DRIVER_CONFIDENCE=false`) | → `openAskOlumi` |
| `ChallengeSection.tsx` ×4 (`DiscussWithAiButton` onSend) | exercise / fragile-edge / baseline prompts | exploratory | dormant (via DecisionConfidencePanel; flag-off) | → `openAskOlumi` |
| `TriageActionCardsBody.tsx` Research chip | "Can you research `<factor>`…?" | exploratory | dormant (legacy DCP; suppressed under v17) | → `openAskOlumi` |
| `analysis-hero/AnalysisHeroPanel.tsx` | paused-state resolution | exploratory | **Yes** | already `openAskOlumi` (no change) |
| `AnalysisHeroV17.tsx` `prefillChat`→`_sendMessage` | hero/row CTAs | exploratory (auto-send, misnamed) | **No** (`VITE_FEATURE_ANALYSIS_HERO_PANEL=1`; superseded by analysis-hero) | **left — follow-up** (touches `run_devils_advocacy` contract zone) |

No genuinely-transactional auto-send CTAs were found in these surfaces; all were question-shaped exploration.

### Reveal
`openAskOlumi` opens the drawer overlay regardless of the active tab and focuses the composer — the "prefill into a hidden composer" failure mode does not apply.

### Tests
- New `ctaPrefillNeverAutosend.spec.tsx`: CTA click → drawer prefilled + composer focused, threaded `onSendMessage` **not** called, nothing dispatched; positive control → drawer **Send** dispatches exactly once. **Mutation-checked**: restoring direct-send on the winner chip turns the spec RED (2 failed), then restored.
- Updated the two existing specs that asserted the old auto-send (OptionCards different-approach, StressTest "What if this changes?").

### Verification
- `pnpm typecheck` (tsconfig.ci.json): green
- `tsc -p tsconfig.app.json --noEmit`: no new errors in touched files
- Touched suites: 105/105 green (OptionCards ×3, StressTestSection ×2, ChallengeSection, DriversSection.techniqueChip, ctaPrefill)

**DO NOT MERGE** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)