### PR TITLE
fix(freshness): constraint edits dirty freshness (F2a) + GoalNode rerun copy from freshness (F5a) [DO NOT MERGE]

### DIFF
--- a/src/canvas/__tests__/store.spec.ts
+++ b/src/canvas/__tests__/store.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { useCanvasStore } from '../store'
 import { __resetTelemetryCounters, __getTelemetryCounters } from '../../lib/telemetry'
+import { classifyFreshnessForDisplay } from '../store/analysisFreshness'
 
 function seedDemoGraph() {
   useCanvasStore.setState({
@@ -909,6 +910,75 @@ describe('Canvas Store', () => {
 
       // goalConstraints was never set — must still be null
       expect(useCanvasStore.getState().goalConstraints).toBeNull()
+    })
+  })
+
+  // F2a (Codex review): a USER constraint edit is analysis-affecting (constraints
+  // are sent to PLoT, same class as the goal threshold), so it must dirty the
+  // freshness overlay every trust surface reads — otherwise the results keep
+  // claiming "Analysis reflects the current model" after a hard constraint change.
+  describe('F2a: constraint edits dirty analysis freshness', () => {
+    const FRESH = { freshness: 'fresh' as const, freshnessReason: 'graph_hash_match' }
+
+    beforeEach(() => {
+      useCanvasStore.getState().reset()
+      // reset() deliberately does NOT clear goalConstraints (F8) — normalise it
+      // here so each case starts from a known baseline.
+      // A retained CEE 'fresh' verdict with a clean overlay renders as 'current'.
+      useCanvasStore.setState({
+        goalConstraints: null,
+        analysisFreshness: FRESH,
+        analysisFreshnessDirty: false,
+      })
+    })
+
+    it('a user constraint edit dirties freshness → display downgrades fresh→changed', () => {
+      // Precondition (positive control): fresh + not-dirty reads as 'current'.
+      let s = useCanvasStore.getState()
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('current')
+
+      // User edit via the GoalPanel path (no fromProducerSync opt-out).
+      useCanvasStore.getState().setGoalConstraints([
+        { id: 'c1', operator: '<=', value: 4 },
+      ] as any)
+
+      s = useCanvasStore.getState()
+      expect(s.analysisFreshnessDirty).toBe(true)
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('changed')
+    })
+
+    it('a no-op set (identical content) does NOT dirty freshness', () => {
+      const constraints = [{ id: 'c1', operator: '<=', value: 4 }] as any
+      useCanvasStore.setState({ goalConstraints: constraints })
+      // Re-set with a byte-identical (but new-reference) array.
+      useCanvasStore.getState().setGoalConstraints([{ id: 'c1', operator: '<=', value: 4 }] as any)
+
+      const s = useCanvasStore.getState()
+      expect(s.analysisFreshnessDirty).toBe(false)
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('current')
+    })
+
+    it('null→null is a no-op and does NOT dirty freshness', () => {
+      useCanvasStore.getState().setGoalConstraints(null)
+      expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+    })
+
+    it('a producer-sync write ({ fromProducerSync: true }) does NOT dirty freshness', () => {
+      useCanvasStore.getState().setGoalConstraints(
+        [{ id: 'c1', operator: '<=', value: 4 }] as any,
+        { fromProducerSync: true },
+      )
+      const s = useCanvasStore.getState()
+      expect(s.analysisFreshnessDirty).toBe(false)
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('current')
+    })
+
+    it('clearing a real constraint (array→null) dirties freshness', () => {
+      useCanvasStore.setState({ goalConstraints: [{ id: 'c1', operator: '<=', value: 4 }] as any })
+      useCanvasStore.getState().setGoalConstraints(null)
+      const s = useCanvasStore.getState()
+      expect(s.analysisFreshnessDirty).toBe(true)
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('changed')
     })
   })
 

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -530,9 +530,10 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
               reason: staleCheck.reason,
             })
           }
-          // Clear stale analysis_ready and goal_constraints from store
+          // Clear stale analysis_ready and goal_constraints from store.
+          // System run-prep cleanup, not a user edit → do not self-dirty freshness.
           setCeeAnalysisReady(null)
-          setGoalConstraints(null)
+          setGoalConstraints(null, { fromProducerSync: true })
           effectiveAnalysisReady = null
           effectiveGoalConstraints = null
         }

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -32,6 +32,7 @@ import { useScienceIcons } from '../hooks/useScienceIcons'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { usePopoverHover } from '../hooks/usePopoverHover'
 import { useHasAnyRealProbability } from '../ui/inspector-v2/useAnalysisResults'
+import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
 import type { CEEGoalConstraint } from '../../adapters/cee/types'
 
 export const GoalNode = memo((props: NodeProps) => {
@@ -47,6 +48,13 @@ export const GoalNode = memo((props: NodeProps) => {
   // per-option win_probability means the engine finished but produced no
   // probability. We must not render "Analysis complete" copy in that case.
   const hasAnyProbability = useHasAnyRealProbability()
+  // F5a (Codex review): the rerun prompt must be driven by the ACTUAL freshness
+  // state — the same composed trust surface AnalysisFreshnessNotice reads — never
+  // by value absence. A completed CURRENT run can legitimately carry no goal
+  // probability (producer returned none), and demanding a rerun then contradicts
+  // the panel's "Analysis reflects the current model". Only a genuinely
+  // changed/stale model ('changed' semantic) warrants "Rerun the analysis".
+  const analysisChanged = useAnalysisTrust().semantic === 'changed'
   // Audit §8 P1: canvas result decorations mirror the panels' freshness
   // verdict (opacity + title only — no layout shift).
 
@@ -285,10 +293,17 @@ export const GoalNode = memo((props: NodeProps) => {
             probability for it (target set after the run, or the run produced
             none). The old branches ignored this quadrant, leaving a card
             that showed a target with no path to a probability. No new CTA —
-            the edit affordance and Run flows already exist elsewhere. */}
+            the edit affordance and Run flows already exist elsewhere.
+            F5a (Codex review): the copy is driven by the freshness/dirty state,
+            not by value absence — a CURRENT run that simply produced no goal
+            probability shows the honest absent-state copy (never a rerun demand
+            that would contradict the panel's "reflects the current model"); only
+            a genuinely changed model prompts a rerun. */}
         {hasThreshold && isPostAnalysis && displayMetadata.achievementProbability === null && (
           <p className={`${typography.nodeLabel} text-text-body mt-1 m-0`}>
-            Target set. Rerun the analysis to update your results.
+            {analysisChanged
+              ? 'Target set. Rerun the analysis to update your results.'
+              : 'Target set. This run did not produce a goal probability.'}
           </p>
         )}
 

--- a/src/canvas/nodes/__tests__/GoalNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/GoalNode.spec.tsx
@@ -723,17 +723,41 @@ describe('GoalNode — goal-state copy matrix (audit §8 P1)', () => {
     expect(screen.queryByText(/Rerun the analysis/)).toBeNull()
   })
 
-  it('target SET + no probability (post-analysis): says rerun, no set-a-target chip', () => {
+  // F5a (Codex review): a CURRENT run (no genuine 'changed'/'stale' freshness)
+  // that simply produced no goal probability must NOT demand a rerun — that
+  // contradicted the panel's "Analysis reflects the current model". It shows the
+  // honest absent-state copy instead.
+  it('target SET + no probability + CURRENT run: honest absent-state copy, NOT a rerun demand', () => {
     vi.mocked(useCanvasStore).mockImplementation((selector) =>
       selector(makeStoreState({
         results: { status: 'complete', report: {} },
+        // No genuine change signal: freshness fresh, overlay clean → 'current'.
+        analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match' },
+        analysisFreshnessDirty: false,
+      }) as any)
+    )
+    renderGoal({ goal_threshold_raw: '100', goal_threshold_unit: '%' })
+    expect(screen.getByText('Target set. This run did not produce a goal probability.')).toBeDefined()
+    expect(screen.queryByText(/Rerun the analysis/)).toBeNull()
+    // The live bug: card said "Analysis complete. Set a target to see your
+    // chances." while a target was set. Must never render here.
+    expect(screen.queryByText(/Set a target to see your chances/)).toBeNull()
+    expect(screen.queryByText('Help me set a target')).toBeNull()
+  })
+
+  // Positive control: a GENUINELY stale/changed model (freshness 'stale' →
+  // 'changed' semantic) DOES warrant the rerun prompt.
+  it('target SET + no probability + CHANGED model: shows the rerun demand', () => {
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeStoreState({
+        results: { status: 'complete', report: {} },
+        analysisFreshness: { freshness: 'stale', freshnessReason: 'graph_changed' },
+        analysisFreshnessDirty: true,
       }) as any)
     )
     renderGoal({ goal_threshold_raw: '100', goal_threshold_unit: '%' })
     expect(screen.getByText('Target set. Rerun the analysis to update your results.')).toBeDefined()
-    // The live bug: card said "Analysis complete. Set a target to see your
-    // chances." while a target was set. Must never render here.
-    expect(screen.queryByText(/Set a target to see your chances/)).toBeNull()
+    expect(screen.queryByText(/This run did not produce a goal probability/)).toBeNull()
     expect(screen.queryByText('Help me set a target')).toBeNull()
   })
 

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -40,7 +40,12 @@ vi.mock('../../layoutStore', () => ({
     selector({ layoutNodeWidth: null })
   ),
 }))
-vi.mock('../../../flags', () => ({
+// Spread the real flags module so newly-added flags (e.g. any flag GoalNode
+// transitively reads through useAnalysisTrust → useAnalysisStateSource) never go
+// silently absent and throw at render — see CLAUDE.md #12 (derive, don't mirror).
+// Only the three flags this suite deliberately pins are overridden to false.
+vi.mock('../../../flags', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../flags')>()),
   isGraphBadgesEnabled: vi.fn(() => false),
   isCrossHighlightEnabled: vi.fn(() => false),
   isGraphLensEnabled: vi.fn(() => false),

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -747,7 +747,18 @@ interface CanvasState {
   /** Clear the dirty overlay when a genuinely new analysis run completes (reliable run identity, e.g. a new analysis_result response_hash). */
   clearAnalysisFreshnessDirty: () => void
   setDraftCoaching: (coaching: CEEDraftCoaching | null) => void
-  setGoalConstraints: (constraints: CEEGoalConstraint[] | null) => void
+  /**
+   * Set the goal constraints. A USER edit (GoalPanel add/remove/change) is
+   * analysis-affecting — the constraints are sent to PLoT (same class as the
+   * goal threshold) — so a genuine content change dirties the freshness overlay
+   * that every trust surface reads. Producer/reset paths (draft ingestion, V5
+   * state apply, run reset) pass `{ fromProducerSync: true }` so an ingestion
+   * write does NOT self-dirty (mirrors setGoalThreshold's `fromCeeSync`).
+   */
+  setGoalConstraints: (
+    constraints: CEEGoalConstraint[] | null,
+    opts?: { fromProducerSync?: boolean },
+  ) => void
   /** B2: record the identities of an authoritative CEE graph (see the field). */
   setLastAuthoritativeGraph: (
     graph: { nodeIds: string[]; edgePairs: string[] } | null,
@@ -1198,6 +1209,24 @@ function markAnalysisFreshnessDirty(
   if (!get().analysisFreshnessDirty) {
     set(() => ({ analysisFreshnessDirty: true }))
   }
+}
+
+/**
+ * By-value equality for the goal-constraints array — used by setGoalConstraints
+ * to honour the no-op discipline (a set whose content matches the current value
+ * must not dirty freshness). Conservative: ANY structural content difference
+ * (identity, operator, value, node binding, unit, probability, provenance)
+ * counts as a change; one-null-one-array counts as a change. A null↔null or
+ * same-reference set is a no-op.
+ */
+function goalConstraintsEqual(
+  a: CEEGoalConstraint[] | null,
+  b: CEEGoalConstraint[] | null,
+): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return false
+  if (a.length !== b.length) return false
+  return JSON.stringify(a) === JSON.stringify(b)
 }
 
 function invalidateAnalysisReady(
@@ -3872,8 +3901,20 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     if (get().analysisFreshnessDirty) set(() => ({ analysisFreshnessDirty: false }))
   },
 
-  setGoalConstraints: (constraints: CEEGoalConstraint[] | null) => {
+  setGoalConstraints: (constraints, opts) => {
+    // The goal constraints are sent to PLoT, so a USER change is
+    // analysis-affecting → dirty the freshness overlay on a real content
+    // change. Same class as setGoalThreshold (analysis-affecting-but-not-
+    // structural): it uses markAnalysisFreshnessDirty ONLY, never the legacy
+    // structural pair — the graph hash is constraint-blind (single-graph
+    // 0.21.0, Paul-gated), and the banners that claimed a false "analysis
+    // reflects the current model" read the freshness overlay. Producer/reset
+    // callers (draft ingestion, V5 apply, run reset) pass fromProducerSync so
+    // their ingestion write does not self-dirty. No-op discipline: a set whose
+    // content equals the current value must NOT dirty.
+    const changed = !goalConstraintsEqual(get().goalConstraints, constraints)
     set({ goalConstraints: constraints })
+    if (changed && !opts?.fromProducerSync) markAnalysisFreshnessDirty(get, set)
   },
 
   setLastAuthoritativeGraph: (graph) => {

--- a/src/canvas/utils/__tests__/applyDraftResult.spec.ts
+++ b/src/canvas/utils/__tests__/applyDraftResult.spec.ts
@@ -607,7 +607,8 @@ describe('applyDraftResult', () => {
 
     applyDraftResult(draftData)
 
-    expect(mockSetGoalConstraints).toHaveBeenCalledWith(constraints)
+    // Producer sync — passes fromProducerSync so the ingestion write does not self-dirty freshness.
+    expect(mockSetGoalConstraints).toHaveBeenCalledWith(constraints, { fromProducerSync: true })
   })
 
   it('clears stale goal_constraints when V3 response has none (no-constraint draft after constrained draft)', () => {
@@ -629,7 +630,7 @@ describe('applyDraftResult', () => {
 
     applyDraftResult(draftData)
 
-    expect(mockSetGoalConstraints).toHaveBeenCalledWith(null)
+    expect(mockSetGoalConstraints).toHaveBeenCalledWith(null, { fromProducerSync: true })
   })
 
   it('clears stale is_baseline when baseline option changes', () => {

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -298,14 +298,15 @@ export function applyDraftResult(
   const rawGoalConstraints = (draftData as { goal_constraints?: unknown }).goal_constraints
   if (Array.isArray(rawGoalConstraints) && rawGoalConstraints.length > 0) {
     const constraints = rawGoalConstraints as CEEGoalConstraint[]
-    useCanvasStore.getState().setGoalConstraints(constraints)
+    // Producer sync (draft ingestion) — must not self-dirty the freshness overlay.
+    useCanvasStore.getState().setGoalConstraints(constraints, { fromProducerSync: true })
     logger.info('[constraint-trace] store-write', {
       source: 'applyDraftResult',
       count: constraints.length,
       constraint_ids: constraints.map((c) => c.constraint_id),
     })
   } else {
-    useCanvasStore.getState().setGoalConstraints(null)
+    useCanvasStore.getState().setGoalConstraints(null, { fromProducerSync: true })
     logger.info('[constraint-trace] store-write', {
       source: 'applyDraftResult',
       count: 0,

--- a/src/v5/__tests__/applyV5State.test.ts
+++ b/src/v5/__tests__/applyV5State.test.ts
@@ -723,7 +723,8 @@ describe('applyV5State — goal-threshold quad ingestion (ROADMAP 1.22)', () => 
       ),
       store,
     )
-    expect(setGoalConstraints).toHaveBeenCalledWith(constraints)
+    // Producer sync — passes fromProducerSync so the ingestion write does not self-dirty freshness.
+    expect(setGoalConstraints).toHaveBeenCalledWith(constraints, { fromProducerSync: true })
   })
 
   it('does not call setGoalConstraints when the response carries none (additive only — no clearing)', () => {

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -65,7 +65,10 @@ export interface V5ApplicatorStore {
    * the V4 envelope path's ADD semantics but without its clear-on-empty-patch
    * behaviour, which has no V5 equivalent signal to gate on).
    */
-  setGoalConstraints?: (constraints: CEEGoalConstraint[] | null) => void
+  setGoalConstraints?: (
+    constraints: CEEGoalConstraint[] | null,
+    opts?: { fromProducerSync?: boolean },
+  ) => void
   /**
    * Optional: backfill goal_threshold_raw/unit/cap onto the goal node's data
    * (ROADMAP 1.22). Wired at the real call site to the shared
@@ -630,7 +633,8 @@ export function applyV5State(
   // "a new graph patch was applied" signal to gate a clear on.
   const rawGoalConstraints = (response as { goal_constraints?: unknown }).goal_constraints
   if (Array.isArray(rawGoalConstraints) && rawGoalConstraints.length > 0) {
-    store.setGoalConstraints?.(rawGoalConstraints as CEEGoalConstraint[])
+    // Producer sync (V5 state apply) — must not self-dirty the freshness overlay.
+    store.setGoalConstraints?.(rawGoalConstraints as CEEGoalConstraint[], { fromProducerSync: true })
     applied.push('goal_constraints:set')
   }
   if (rawAnalysisReady !== undefined) {


### PR DESCRIPTION
**DO NOT MERGE** — Codex review findings 2a + 5a. Verified premises at the bytes; both confirmed.

## Premise verdicts
- **F2a — CONFIRMED.** `setGoalConstraints` (store.ts) wrote `goalConstraints` with **no** freshness marking, bypassing both staleness systems. After a hard-constraint edit the trust surfaces kept classifying `current` ("Analysis reflects the current model").
- **F5a — CONFIRMED.** `GoalNode.tsx` showed "Rerun the analysis…" whenever `achievementProbability === null`, even on a completed CURRENT run that simply carried no goal probability — the live self-contradiction with the panel.

## Fixes
### F2a (scoped)
Constraints are analysis-affecting-**but-not-structural** (sent to PLoT, same class as the goal threshold), so the fix mirrors `setGoalThreshold`'s established precedent: `markAnalysisFreshnessDirty` **only** (never the legacy structural pair), on a genuine content change, with a by-value no-op guard (`goalConstraintsEqual`). The structural pair / graph hash is deliberately untouched — the hash is constraint-blind (single-graph 0.21.0, Paul-gated, out of scope).

Producer/reset callers pass `{ fromProducerSync: true }` so ingestion writes do not self-dirty: `applyDraftResult`, `applyV5State`, `useV2Run` run-prep reset. User edits (GoalPanel) do not, so they dirty.

### Bypass sweep
| Analysis-input mutation | Routes through overlay? |
|---|---|
| Goal constraints (`setGoalConstraints`) | **FIXED here** (was the sole bypass) |
| Node edits, interventions, observed values (`updateNode`→`hasAnalyticalNodeChange`→`invalidateAnalysisReady`) | ✅ already |
| Edge edits incl. direction (`updateEdge`→`hasAnalyticalEdgeChange`) | ✅ already |
| Goal threshold (`setGoalThreshold`, `setGoalThresholdAndUpdateNode`) | ✅ already |
| Outcome/goal-node selection (`setOutcomeNode`) | ✅ already |
| `batchUpdateNodes` | producer-only by design (must NOT dirty) |

### F5a
The rerun prompt is now driven by the composed trust surface (`useAnalysisTrust().semantic`), never by value absence: only a genuinely changed/stale model (`'changed'`) prompts "Rerun the analysis…"; a current-but-valueless run shows honest absent-state copy ("Target set. This run did not produce a goal probability.").

## Evidence
- **RED-first + mutation-checked in a throwaway:** reverting the F2a dirty-mark → 2 store pins red; reverting the F5a gate → 2 GoalNode pins red. Both restored, green.
- New/updated pins: `store.spec.ts` F2a (user-edit dirties fresh→changed; no-op no-dirty; null↔null no-op; producer-sync no-dirty; array→null dirties); `GoalNode.spec.tsx` (current run → honest copy; **positive control** changed model → rerun demand).
- ci `pnpm run typecheck` clean; wide `tsc -p tsconfig.app.json` shows **zero new** errors referencing the changed symbols (baseline unchanged). Lint 0 errors on changed lines.
- Touched suites green incl. the #352 echo-guard `analysisFreshness` specs (verdict semantics preserved) and `analysisTrust` specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)