### PR TITLE
fix(persistence): F1 pre-run save flush barrier + F4 single-owner autosave [DO NOT MERGE]

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -581,6 +581,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     persistAnalysisSuccess,
     persistAnalysisFailure,
     isPersistenceActive: _isPersistenceActive,
+    flushPendingSaves,
   } = useScenario()
 
   // Results-surface staleness is driven by the CEE freshness slice (the single
@@ -811,6 +812,22 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     if (!canRunAnalysis) {
       return { status: 'blocked', reason: runBlockedTooltip || 'Analysis is not available right now.' }
     }
+    // F1 barrier: an authenticated user who edits then presses Analyse within
+    // the 1500ms autosave debounce would otherwise dispatch a canonical V5 run
+    // (scenario_id only, no graph on the wire) that CEE resolves against the
+    // PREVIOUS persisted graph. Flush any pending/dirty save and AWAIT it before
+    // dispatch. No-op for guests/inactive persistence (their runs carry the
+    // graph and are gated elsewhere). A failed flush must NOT proceed to a run
+    // of a stale persisted graph — abort with a surfaced reason.
+    try {
+      await flushPendingSaves()
+    } catch (err) {
+      console.error('[OutputsDock] pre-run save flush failed; aborting run:', err)
+      return {
+        status: 'blocked',
+        reason: 'Could not save your latest changes. Check your connection and try again.',
+      }
+    }
     // Capture pre-analysis review progress for transition bridge
     const storeState = useCanvasStore.getState()
     const { verifiedCount, influenceCoverage } = computeInfluenceCoverage(
@@ -904,7 +921,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     }
     await runV2Analysis()
     return { status: 'v2' }
-  }, [canRunAnalysis, runBlockedTooltip, isRunning, runV2Analysis, framing])
+  }, [canRunAnalysis, runBlockedTooltip, isRunning, runV2Analysis, framing, flushPendingSaves])
 
   // Expose the canonical runner to other surfaces (canvas shortcut, palette).
   useEffect(() => registerCanonicalRunner(runCanonicalAnalysis), [runCanonicalAnalysis])

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OutputsDock } from '../OutputsDock'
 import { useCanvasStore } from '../../store'
@@ -197,7 +197,7 @@ describe('OutputsDock analyse convergence', () => {
     useSuccessMeasureStore.getState()._reset()
   })
 
-  it('dispatches direct V2 run instead of the shared conversation callback', () => {
+  it('dispatches direct V2 run instead of the shared conversation callback', async () => {
     const runViaConversation = vi.fn()
     const runV2Analysis = vi.fn()
 
@@ -208,11 +208,13 @@ describe('OutputsDock analyse convergence', () => {
 
     fireEvent.click(screen.getByTestId('outputs-run-button'))
 
-    expect(runV2Analysis).toHaveBeenCalledTimes(1)
+    // The run now awaits the pre-dispatch save flush (F1 barrier) before
+    // reaching the V2/dispatch path, so the spy resolves on a later microtask.
+    await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
     expect(runViaConversation).not.toHaveBeenCalled()
   })
 
-  it('runs directly without opening the AI panel or warning toast when no conversation callback is registered', () => {
+  it('runs directly without opening the AI panel or warning toast when no conversation callback is registered', async () => {
     const runV2Analysis = vi.fn()
     mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
 
@@ -220,7 +222,7 @@ describe('OutputsDock analyse convergence', () => {
 
     fireEvent.click(screen.getByTestId('outputs-run-button'))
 
-    expect(runV2Analysis).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
     expect(mockShowToast).not.toHaveBeenCalled()
     expect(useCanvasStore.getState().showDraftChat).toBe(false)
     expect(
@@ -236,7 +238,7 @@ describe('OutputsDock analyse convergence', () => {
   })
 
   describe('v5 canonical analysis routing (v5-canonical-analysis brief)', () => {
-    it('fires chip-shaped dispatchAction with action_type=run_analysis when canonical flag is on AND V5 eligible', () => {
+    it('fires chip-shaped dispatchAction with action_type=run_analysis when canonical flag is on AND V5 eligible', async () => {
       const dispatchAction = vi.fn()
       const runV2Analysis = vi.fn()
       mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
@@ -250,7 +252,7 @@ describe('OutputsDock analyse convergence', () => {
 
       // Correction 8: exact chip/action payload shape — action_type
       // 'run_analysis', source 'chip', no free-text LLM route.
-      expect(dispatchAction).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(dispatchAction).toHaveBeenCalledTimes(1))
       const call = dispatchAction.mock.calls[0][0]
       expect(call.action_type).toBe('run_analysis')
       expect(call.source).toBe('chip')
@@ -264,7 +266,7 @@ describe('OutputsDock analyse convergence', () => {
       expect(runV2Analysis).not.toHaveBeenCalled()
     })
 
-    it('falls back to direct V2 when canonical flag is off (control case)', () => {
+    it('falls back to direct V2 when canonical flag is off (control case)', async () => {
       const dispatchAction = vi.fn()
       const runV2Analysis = vi.fn()
       mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
@@ -276,11 +278,11 @@ describe('OutputsDock analyse convergence', () => {
       renderOutputsDock()
       fireEvent.click(screen.getByTestId('outputs-run-button'))
 
-      expect(runV2Analysis).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
       expect(dispatchAction).not.toHaveBeenCalled()
     })
 
-    it('falls back to direct V2 when canonical flag is on but V5 is not eligible', () => {
+    it('falls back to direct V2 when canonical flag is on but V5 is not eligible', async () => {
       const dispatchAction = vi.fn()
       const runV2Analysis = vi.fn()
       mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
@@ -292,11 +294,11 @@ describe('OutputsDock analyse convergence', () => {
       renderOutputsDock()
       fireEvent.click(screen.getByTestId('outputs-run-button'))
 
-      expect(runV2Analysis).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
       expect(dispatchAction).not.toHaveBeenCalled()
     })
 
-    it('falls back to direct V2 when canonical flag is on but no _dispatchAction is registered', () => {
+    it('falls back to direct V2 when canonical flag is on but no _dispatchAction is registered', async () => {
       const runV2Analysis = vi.fn()
       mockUseV2Run.mockReturnValue({ runV2Analysis, cancelRun: vi.fn() })
       mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
@@ -309,7 +311,7 @@ describe('OutputsDock analyse convergence', () => {
       renderOutputsDock()
       fireEvent.click(screen.getByTestId('outputs-run-button'))
 
-      expect(runV2Analysis).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
     })
   })
 

--- a/src/hooks/__tests__/useScenario.persistenceFlushSingleOwner.spec.ts
+++ b/src/hooks/__tests__/useScenario.persistenceFlushSingleOwner.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * useScenario — persistence flush barrier (F1) + single-owner autosave (F4)
+ *
+ * Codex review findings, both CONFIRMED at the bytes:
+ *
+ * F1 RACE — an authenticated user who edits then presses Analyse within the
+ * 1500ms autosave debounce dispatches a canonical V5 run (scenario_id only, no
+ * graph on the wire) that CEE resolves against the PREVIOUS persisted graph.
+ * The fix is `flushPendingSaves`: an awaitable barrier that persists any
+ * pending/dirty graph and resolves only once the write lands (reject on
+ * failure), a no-op for guests / inactive persistence.
+ *
+ * F4 DOUBLE PIPELINE — useScenario() mounts in BOTH CanvasMVP and OutputsDock.
+ * Two instances each installed their own store subscriptions + debounce timers,
+ * so ONE edit scheduled TWO independent saves and a slower stale save could
+ * overwrite newer work. The fix is a module-level ownership registry: only the
+ * head owner persists, so two mounts + one edit ⇒ exactly one save.
+ *
+ * MUTATION CHECKS (proved in a throwaway tree, see PR body):
+ * - Remove the `if (!isAutosaveOwner(...)) return` guard from the graph
+ *   subscription ⇒ "two mounts, one edit ⇒ exactly one save" flips to 2 saves.
+ * - Make `flushPendingSaves` resolve without awaiting the write ⇒ the
+ *   "waits for the slow save" test flips (spy not yet called at assert time).
+ * - Swallow the save rejection in the flush ⇒ the failure-path test flips
+ *   (promise resolves instead of rejecting).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks (mirror useScenario.spec.ts harness)
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => mockNavigate }))
+
+let mockAuthValue = {
+  user: null as { id: string; email?: string } | null,
+  authenticated: false,
+}
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => mockAuthValue }))
+
+const mockSaveGraphViaGatedPath = vi.fn()
+const mockSaveFraming = vi.fn()
+const mockSaveTitle = vi.fn()
+
+vi.mock('../../services/scenarioService', () => ({
+  createScenario: vi.fn(),
+  loadScenario: vi.fn(),
+  deleteScenario: vi.fn(),
+  saveGraphViaGatedPath: (...args: unknown[]) => mockSaveGraphViaGatedPath(...args),
+  saveFraming: (...args: unknown[]) => mockSaveFraming(...args),
+  storeAnalysis: vi.fn(),
+  storeAnalysisFailure: vi.fn(),
+  storeBrief: vi.fn(),
+  setStage: vi.fn(),
+  createSharedBrief: vi.fn(),
+  resetAnalysisStatus: vi.fn(),
+  setAnalysisRunning: vi.fn(),
+  saveTitle: (...args: unknown[]) => mockSaveTitle(...args),
+}))
+
+const mockMarkClean = vi.fn()
+let storeState: Record<string, unknown> = {}
+
+const mockGetState = vi.fn(() => ({
+  markClean: mockMarkClean,
+  hydrateGraphSlice: vi.fn(),
+  ...storeState,
+}))
+const mockSetState = vi.fn((partial: Record<string, unknown>) => {
+  storeState = { ...storeState, ...partial }
+})
+
+// Records every subscribe callback so a test can drive the debounced autosave
+// directly. The graph-autosave effect subscribes FIRST per mount.
+type StoreSubscriber = (state: Record<string, unknown>, prev: Record<string, unknown>) => void
+const mockSubscribeCallbacks: StoreSubscriber[] = []
+
+vi.mock('../../canvas/store', () => ({
+  useCanvasStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) => selector(storeState),
+    {
+      getState: () => mockGetState(),
+      setState: (partial: Record<string, unknown>) => mockSetState(partial),
+      subscribe: (cb: StoreSubscriber) => {
+        mockSubscribeCallbacks.push(cb)
+        return () => {}
+      },
+    },
+  ),
+}))
+
+vi.mock('../../canvas/domain/edges', () => ({
+  DEFAULT_EDGE_DATA: { weight: 0.5, style: 'solid', curvature: 0.15 },
+}))
+
+import { useScenario } from '../useScenario'
+
+const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+function setAuth(userId: string | null, authenticated: boolean) {
+  mockAuthValue = {
+    user: userId ? { id: userId, email: `${userId}@test.com` } : null,
+    authenticated,
+  }
+}
+
+// A deferred promise the test resolves/rejects manually.
+function deferred<T = void>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSubscribeCallbacks.length = 0
+  storeState = {
+    currentScenarioId: null,
+    nodes: [],
+    edges: [],
+    goalConstraints: null,
+    currentScenarioFraming: null,
+    isDirty: false,
+    results: { status: 'idle' },
+  }
+  setAuth(null, false)
+  mockSaveGraphViaGatedPath.mockResolvedValue(undefined)
+  mockSaveFraming.mockResolvedValue(undefined)
+  mockSaveTitle.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  // RTL auto-cleanup (tests/setup/rtl.ts) unmounts every render, which empties
+  // the ownership registry and resets the shared save key between tests.
+})
+
+// ---------------------------------------------------------------------------
+// F1 — flush barrier
+// ---------------------------------------------------------------------------
+
+describe('F1: flushPendingSaves barrier', () => {
+  it('is a no-op for guests / inactive persistence (no write, resolves)', async () => {
+    setAuth('guest', true)
+    storeState = { ...storeState, currentScenarioId: 'sc-1', nodes: [{ id: 'a' }] }
+    const { result } = renderHook(() => useScenario())
+
+    await act(async () => {
+      await result.current.flushPendingSaves()
+    })
+
+    expect(mockSaveGraphViaGatedPath).not.toHaveBeenCalled()
+  })
+
+  it('persists a dirty graph and resolves only after the write lands', async () => {
+    setAuth(REAL_USER_ID, true)
+    storeState = { ...storeState, currentScenarioId: 'sc-1', nodes: [{ id: 'a' }] }
+    const { result } = renderHook(() => useScenario())
+
+    const d = deferred()
+    mockSaveGraphViaGatedPath.mockReturnValueOnce(d.promise)
+
+    let settled = false
+    let flushPromise!: Promise<void>
+    act(() => {
+      flushPromise = result.current.flushPendingSaves().then(() => {
+        settled = true
+      })
+    })
+
+    // The write is in flight but not yet resolved — the barrier MUST still be
+    // pending (this is the whole point: dispatch must wait for the save).
+    await Promise.resolve()
+    expect(mockSaveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+    expect(settled).toBe(false)
+
+    await act(async () => {
+      d.resolve()
+      await flushPromise
+    })
+    expect(settled).toBe(true)
+  })
+
+  it('rejects when the save fails — dispatch must NOT silently proceed', async () => {
+    setAuth(REAL_USER_ID, true)
+    storeState = { ...storeState, currentScenarioId: 'sc-1', nodes: [{ id: 'a' }] }
+    const { result } = renderHook(() => useScenario())
+
+    mockSaveGraphViaGatedPath.mockRejectedValueOnce(new Error('network down'))
+
+    await act(async () => {
+      await expect(result.current.flushPendingSaves()).rejects.toThrow('network down')
+    })
+  })
+
+  it('resolves immediately without a second write when the graph is already clean', async () => {
+    setAuth(REAL_USER_ID, true)
+    storeState = { ...storeState, currentScenarioId: 'sc-1', nodes: [{ id: 'a' }] }
+    const { result } = renderHook(() => useScenario())
+
+    // First flush persists and records the "already saved" key.
+    await act(async () => {
+      await result.current.flushPendingSaves()
+    })
+    expect(mockSaveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+
+    // Graph unchanged → second flush is a no-op.
+    await act(async () => {
+      await result.current.flushPendingSaves()
+    })
+    expect(mockSaveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F4 — single-owner autosave
+// ---------------------------------------------------------------------------
+
+describe('F4: single-owner autosave (two mounts, one writer)', () => {
+  it('schedules exactly ONE debounced save when two mounts observe the same edit', () => {
+    vi.useFakeTimers()
+    try {
+      setAuth(REAL_USER_ID, true)
+      storeState = { ...storeState, currentScenarioId: 'sc-1', nodes: [] }
+
+      // Two independent mounts of useScenario — CanvasMVP + OutputsDock.
+      renderHook(() => useScenario())
+      renderHook(() => useScenario())
+
+      // Each mount's graph-autosave effect subscribes first, so callbacks
+      // 0 and 3 are the two graph subscribers.
+      const graphSubs = [mockSubscribeCallbacks[0], mockSubscribeCallbacks[3]]
+      expect(graphSubs.every((cb) => typeof cb === 'function')).toBe(true)
+
+      // The store notifies BOTH subscribers of the same edit.
+      const prev = { ...storeState }
+      storeState = { ...storeState, nodes: [{ id: 'n1' }] }
+      act(() => {
+        graphSubs.forEach((cb) => cb(storeState, prev))
+        vi.advanceTimersByTime(1600)
+      })
+
+      // F4: only the owner writes — exactly one save, not two.
+      expect(mockSaveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -66,6 +66,11 @@ export interface UseScenarioReturn {
   // Graph staleness — true when graph has been edited after the last analysis
   analysisStale: boolean
   clearAnalysisStale: () => void
+
+  // F1: awaitable barrier — flush any pending/dirty debounced graph save so a
+  // run dispatched immediately after an edit analyses the CURRENT graph. No-op
+  // for guests/inactive persistence; rejects on save failure (caller aborts).
+  flushPendingSaves: () => Promise<void>
 }
 
 const GRAPH_DEBOUNCE_MS = 1500
@@ -92,6 +97,104 @@ function graphSaveKey(s: {
     edges: s.edges,
     goalConstraints: s.goalConstraints ?? null,
   })
+}
+
+// ---------------------------------------------------------------------------
+// Single-owner autosave coordination (Codex findings F1 + F4)
+//
+// F4 — DOUBLE PIPELINE: useScenario() mounts in BOTH CanvasMVP and OutputsDock.
+// Two instances each installed their own store subscriptions and debounce
+// timers, so a single edit scheduled TWO independent saves; the DB write has no
+// revision check, so a slower stale save could overwrite newer work. The fix is
+// ONE writer: a module-level ownership registry. Every mount installs passive
+// subscriptions, but only the mount at the head of `activeAutosaveOwners`
+// actually persists. Ownership is checked at call time (not install time), so it
+// transfers to a surviving mount the instant the owner unmounts — no gap.
+//
+// F1 — RACE: an authenticated user who edits then presses Analyse within the
+// 1500ms debounce window gets analysis of the PREVIOUS graph (a canonical V5 run
+// sends only scenario_id; CEE reads its persisted scenario graph). The fix is a
+// single awaitable barrier — `flushPendingGraphSave` — awaited before run
+// dispatch. It shares the "already persisted" key and the in-flight save promise
+// below with the debounced autosave so the two never disagree on cleanliness or
+// double-write.
+const activeAutosaveOwners: string[] = []
+function isAutosaveOwner(id: string): boolean {
+  return activeAutosaveOwners.length > 0 && activeAutosaveOwners[0] === id
+}
+
+// Shared across every mount AND the flush barrier: the key of the graph payload
+// already persisted, and the in-flight graph save (if any). Module-level so the
+// pre-analysis flush and the debounced autosave agree on "clean" and never
+// double-write. Reset when the last mount unmounts (see the ownership effect).
+let sharedLastSavedGraphKey = ''
+let inFlightGraphSave: Promise<void> | null = null
+
+// Record the in-flight save so the flush barrier can await it, and self-clear
+// when it settles. The housekeeping `.finally` chain swallows its own rejection
+// (`.catch`) so it never surfaces as an unhandled rejection — the ACTUAL result
+// is always awaited by the caller (the autosave try/catch, or the flush
+// barrier), which is where a real failure is handled.
+function trackInFlightGraphSave(p: Promise<void>): void {
+  inFlightGraphSave = p
+  void p
+    .finally(() => {
+      if (inFlightGraphSave === p) inFlightGraphSave = null
+    })
+    .catch(() => {})
+}
+
+/**
+ * Persist the current canvas graph immediately via the gated write path.
+ * Shared by the debounced autosave, its retry, and the flush barrier so there is
+ * ONE write code path. Updates the shared "already persisted" key and marks the
+ * store clean on success. Rejects (propagates) on failure — callers decide.
+ */
+async function persistGraphNow(sid: string): Promise<void> {
+  const state = useCanvasStore.getState()
+  const key = graphSaveKey(state)
+  await scenarioService.saveGraphViaGatedPath(
+    sid,
+    { nodes: state.nodes, edges: state.edges },
+    crypto.randomUUID(),
+    undefined,
+    state.goalConstraints,
+  )
+  sharedLastSavedGraphKey = key
+  const now = Date.now()
+  useCanvasStore.getState().markClean()
+  useCanvasStore.setState({ lastSavedAt: now })
+}
+
+/**
+ * F1 barrier: flush any pending/dirty debounced graph save and await it, so a
+ * run dispatched right after an edit analyses the CURRENT graph.
+ *
+ * Contract:
+ * - Persistence inactive (guests / signed-out) → no-op, resolves immediately.
+ *   Their runs carry the graph on the wire and are gated elsewhere.
+ * - No active scenario id → no-op resolve.
+ * - Graph already persisted (clean) → resolves immediately.
+ * - Dirty → saves now, awaits, and REJECTS on failure. A failed flush must NOT
+ *   silently proceed to dispatch; the caller aborts the run.
+ */
+export async function flushPendingGraphSave(isPersistenceActive: boolean): Promise<void> {
+  if (!isPersistenceActive) return
+  const sid = useCanvasStore.getState().currentScenarioId
+  if (!sid) return
+  // Await any autosave already mid-flight so we settle on top of it.
+  if (inFlightGraphSave) {
+    try {
+      await inFlightGraphSave
+    } catch {
+      // A failed in-flight autosave is re-evaluated below: if still dirty we
+      // retry the save here and surface its outcome to the caller.
+    }
+  }
+  if (graphSaveKey(useCanvasStore.getState()) === sharedLastSavedGraphKey) return
+  const p = persistGraphNow(sid)
+  trackInFlightGraphSave(p)
+  await p
 }
 
 export function useScenario(): UseScenarioReturn {
@@ -130,9 +233,35 @@ export function useScenario(): UseScenarioReturn {
     return () => { mountedRef.current = false }
   }, [])
 
-  // Track the last saved graph to skip redundant saves.
-  // Uses a serialised snapshot (JSON string) for deep comparison.
-  const lastSavedGraphRef = useRef<string>('')
+  // F4: register this mount in the module-level autosave ownership registry.
+  // First-in wins; only the head owner drives the debounced writers. On unmount
+  // the id is removed and a surviving mount silently becomes owner. When the
+  // last mount unmounts, reset the shared save state so a future canvas session
+  // (or a test) starts clean.
+  const instanceIdRef = useRef<string>('')
+  if (!instanceIdRef.current) {
+    instanceIdRef.current =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `own_${Math.random().toString(36).slice(2)}`
+  }
+  useEffect(() => {
+    const id = instanceIdRef.current
+    activeAutosaveOwners.push(id)
+    return () => {
+      const i = activeAutosaveOwners.indexOf(id)
+      if (i >= 0) activeAutosaveOwners.splice(i, 1)
+      if (activeAutosaveOwners.length === 0) {
+        sharedLastSavedGraphKey = ''
+        inFlightGraphSave = null
+      }
+    }
+  }, [])
+
+  // Track the last saved framing to skip redundant saves (per-instance; only
+  // the owner writes framing, so no cross-mount coordination is needed here).
+  // The graph "already persisted" key is module-level (sharedLastSavedGraphKey)
+  // because the flush barrier must agree with the autosave on cleanliness.
   const lastSavedFramingRef = useRef<string>('')
 
   // Stable reference to the current scenario ID for use inside timers
@@ -164,9 +293,11 @@ export function useScenario(): UseScenarioReturn {
       const sid = scenarioIdRef.current
       if (!isPersistenceActiveRef.current || !sid) return
       if (!mountedRef.current) return
+      // F4: only the owning mount schedules writes.
+      if (!isAutosaveOwner(instanceIdRef.current)) return
 
       const graphSnapshot = graphSaveKey(state)
-      if (graphSnapshot === lastSavedGraphRef.current) return
+      if (graphSnapshot === sharedLastSavedGraphKey) return
 
       // Mark results as stale when graph changes after a completed analysis
       if (state.results.status === 'complete') {
@@ -178,26 +309,21 @@ export function useScenario(): UseScenarioReturn {
       graphSaveTimerRef.current = setTimeout(async () => {
         const saveSid = scenarioIdRef.current
         if (!saveSid || !mountedRef.current) return
+        // Re-check ownership + cleanliness at fire time: a flush barrier or the
+        // other mount may have persisted this exact graph in the meantime.
+        if (!isAutosaveOwner(instanceIdRef.current)) return
+        if (graphSaveKey(useCanvasStore.getState()) === sharedLastSavedGraphKey) return
 
         if (mountedRef.current) setSaveStatus('saving')
 
         try {
-          const currentState = useCanvasStore.getState()
-          await scenarioService.saveGraphViaGatedPath(
-            saveSid,
-            { nodes: currentState.nodes, edges: currentState.edges },
-            crypto.randomUUID(),
-            undefined,
-            currentState.goalConstraints,
-          )
-          lastSavedGraphRef.current = graphSaveKey(currentState)
+          const p = persistGraphNow(saveSid)
+          trackInFlightGraphSave(p)
+          await p
           if (mountedRef.current) {
-            const now = Date.now()
             setSaveStatus('saved')
-            setLastSavedAt(now)
+            setLastSavedAt(Date.now())
             setSaveError(null)
-            useCanvasStore.getState().markClean()
-            useCanvasStore.setState({ lastSavedAt: now })
           }
         } catch (err) {
           if (mountedRef.current) {
@@ -209,22 +335,13 @@ export function useScenario(): UseScenarioReturn {
             const retrySid = scenarioIdRef.current
             if (!retrySid || !mountedRef.current) return
             try {
-              const retryState = useCanvasStore.getState()
-              await scenarioService.saveGraphViaGatedPath(
-                retrySid,
-                { nodes: retryState.nodes, edges: retryState.edges },
-                crypto.randomUUID(),
-                undefined,
-                retryState.goalConstraints,
-              )
-              lastSavedGraphRef.current = graphSaveKey(retryState)
+              const rp = persistGraphNow(retrySid)
+              trackInFlightGraphSave(rp)
+              await rp
               if (mountedRef.current) {
-                const now = Date.now()
                 setSaveStatus('saved')
-                setLastSavedAt(now)
+                setLastSavedAt(Date.now())
                 setSaveError(null)
-                useCanvasStore.getState().markClean()
-                useCanvasStore.setState({ lastSavedAt: now })
               }
             } catch (retryErr) {
               console.error('[useScenario] save retry failed:', retryErr)
@@ -252,6 +369,8 @@ export function useScenario(): UseScenarioReturn {
       const sid = scenarioIdRef.current
       if (!isPersistenceActiveRef.current || !sid) return
       if (!mountedRef.current) return
+      // F4: only the owning mount schedules writes.
+      if (!isAutosaveOwner(instanceIdRef.current)) return
 
       const framing = state.currentScenarioFraming
       if (!framing) return
@@ -331,6 +450,8 @@ export function useScenario(): UseScenarioReturn {
     const tryAutoTitle = () => {
       const sid = scenarioIdRef.current
       if (!isPersistenceActiveRef.current || !sid) return
+      // F4: only the owning mount writes the auto-title.
+      if (!isAutosaveOwner(instanceIdRef.current)) return
       if (titleAutoSetForScenarioRef.current === sid) return
 
       const framingObj = useCanvasStore.getState().currentScenarioFraming as Record<string, unknown> | null
@@ -445,7 +566,7 @@ export function useScenario(): UseScenarioReturn {
       // include the constraints for the same reason it includes the graph:
       // priming it with a different value than the store is about to hold
       // would schedule an immediate no-op save on every scenario open.
-      lastSavedGraphRef.current = graphSaveKey({
+      sharedLastSavedGraphKey = graphSaveKey({
         nodes: graphNodes,
         edges: graphEdges,
         goalConstraints: loadedGoalConstraints,
@@ -611,6 +732,12 @@ export function useScenario(): UseScenarioReturn {
     setAnalysisStale(false)
   }, [])
 
+  // F1: awaitable flush barrier bound to this session's persistence state.
+  const flushPendingSaves = useCallback(
+    () => flushPendingGraphSave(isPersistenceActive),
+    [isPersistenceActive],
+  )
+
   const persistAnalysisSuccess = useCallback(
     async (
       analysis: unknown,
@@ -704,6 +831,7 @@ export function useScenario(): UseScenarioReturn {
       createSharedBrief,
       analysisStale,
       clearAnalysisStale,
+      flushPendingSaves,
     }),
     [
       createScenario,
@@ -722,6 +850,7 @@ export function useScenario(): UseScenarioReturn {
       createSharedBrief,
       analysisStale,
       clearAnalysisStale,
+      flushPendingSaves,
     ],
   )
 }


### PR DESCRIPTION
## Codex review findings 1 + 4 — both CONFIRMED at the bytes

### Premise verdicts
- **F1 (RACE) — CONFIRMED.** Autosave debounces 1500ms (`useScenario.ts`); the canonical V5 run dispatches `action_type:'run_analysis'` with only `scenario_id` (no graph on the wire), so CEE analyses its persisted scenario graph. `runCanonicalAnalysis` had no persistence barrier before dispatch → a run fired inside the debounce window analyses the PREVIOUS graph.
- **F4 (DOUBLE PIPELINE) — CONFIRMED.** `useScenario()` mounts in both `CanvasMVP.tsx` and `OutputsDock.tsx`. Each instance installed its own `useCanvasStore.subscribe` graph/framing/title autosave subscriptions and debounce/retry timers → one edit scheduled two independent saves; the DB write has no revision check, so a slower stale save could overwrite newer work.

### Design chosen
Single module-level **ownership registry** in `useScenario.ts` (the "module-level singleton the second mount attaches to" option). Every mount still installs its subscriptions, but the graph/framing/title write bodies early-return unless the instance is `activeAutosaveOwners[0]`. Ownership is evaluated at **call time**, so it transfers to a surviving mount the instant the owner unmounts — no autosave gap, no per-mount teardown coordination.

The graph "already-persisted" key (`sharedLastSavedGraphKey`) and the in-flight save promise (`inFlightGraphSave`) are hoisted to module scope, giving:
- **F4:** one writer per edit (owner guard) plus content de-dup as defence-in-depth.
- **F1:** `flushPendingGraphSave(isPersistenceActive)` — exported, exposed via the hook as `flushPendingSaves` — awaited at the top of `runCanonicalAnalysis` before ANY dispatch (canonical V5 chip **and** V2 fallback). Contract: no-op for guests/inactive persistence; resolve immediately when clean; on dirty, persist-now + await; **reject on failure** → the run aborts with a surfaced reason instead of analysing a stale persisted graph. One shared write path (`persistGraphNow`) for autosave, retry, and flush.

Server-side CAS / revision check is explicitly **out of scope** (single-graph 0.21.0 work).

### Mutation evidence (proven in a throwaway; source restored to green after each)
- **F4** — remove the owner guard from the graph timer body → `two mounts, one edit ⇒ exactly one save` flips to **2 saves**.
- **F1 barrier** — make `flushPendingGraphSave` resolve without `await p` → `resolves only after the write lands` flips (`settled` true while the write is still pending).
- **F1 failure** — swallow the save rejection (`await p.catch(()=>{})`) → `rejects when the save fails` flips (promise resolves instead of rejecting).

### Gates
- `pnpm run typecheck` (tsconfig.ci.json): clean.
- Wide `tsc -p tsconfig.app.json`: no NEW errors in touched files (the one `AnalysisStatus` unused-import warning is pre-existing on clean staging).
- Lint touched files: 0 errors (2 pre-existing warnings).
- Suites: new spec 5/5; `useScenario.spec` + `.gatedWrite` + `.goalConstraints.lifecycle` 49/49 (fixed an orphaned-rejection leak in the in-flight tracker); `OutputsDock.analysis-run` 20/20 (6 sync assertions updated to `await waitFor` now that the run awaits the barrier); `OutputsDock.dom` + `.conversationSingleton` 50/50; `ReactFlowGraph.layoutLifecycle` + `appliedEditDurability` 6/6. (The 2 conversationSingleton failures seen in one parallel run are pre-existing flakes, green on re-run and on clean base.)

### Scope discipline
OutputsDock hunks touch only the `useScenario` mount (~581) + the run dispatch (~812) — disjoint from the ~2329 sendMessage/prefill region owned by another lane. None of the DO NOT TOUCH files are modified.

**DO NOT MERGE** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)