### PR TITLE
fix(anchor): run-analysis control shows where a robustness verdict was occupying its slot

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -38,7 +38,6 @@ import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectR
 import { resolveDisplayedFreshness } from '../store/analysisFreshness'
 import { getScenario } from '../store/scenarios'
 import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
-import { useAnalysisStateSource } from '../hooks/useAnalysisStateSource'
 import { DecisionOverviewCard } from '../../components/results/decision-overview/DecisionOverviewCard'
 import { isDecisionOverviewEnabled } from '../../flags'
 import { deriveResultsTabFreshness } from './resultsTabFreshness'
@@ -596,27 +595,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const freshnessDirty = useCanvasStore(s => s.analysisFreshnessDirty)
   const displayedFreshness = resolveDisplayedFreshness(ceeFreshness, freshnessDirty)
   const analysisNotConfirmedFresh = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
-  // C1 (one Rerun owner per viewport, brief §5 / §2.2): AnalysisFreshnessNotice
-  // mounts under the SAME post-run condition as the AnalysisFooter below and
-  // renders its Rerun whenever a verdict is held ('fresh'/'stale'/'unknown' —
-  // only 'none'/unset draw no action). While the strip owns that recovery
-  // action, the footer is STATUS-ONLY (robustness verdict + producer meta
-  // stay); when the strip shows no action the footer keeps its Rerun so the
-  // tab never loses its only recovery affordance.
-  // F11 fold: the strip ALSO renders (with the one Rerun) for an ORPHANED
-  // result — the ownership predicate must match the strip's OFFERS-RERUN
-  // condition (not merely its render condition) or the tab is left with
-  // either two Rerun owners or none (C1). The strip's precedence rule
-  // (resolveTrustEffectiveState) makes an orphaned result ALWAYS offer the
-  // Rerun: a held fresh/stale/unknown verdict wins (left disjunct), and a
-  // null or 'none' verdict synthesises the cannot-confirm variant with the
-  // Rerun (right disjunct). Only a NON-orphaned 'none'/unset verdict draws
-  // no strip control, and there the footer keeps its action. Same source the
-  // strip itself uses; never a hand-mirror of its old condition.
-  const { source: analysisStateSource } = useAnalysisStateSource()
-  const orphanedResult = analysisStateSource === 'orphaned_plot_result'
-  const freshnessStripOwnsRerun =
-    (displayedFreshness != null && displayedFreshness !== 'none') || orphanedResult
+  // Anchor-run-control (Paul, 21-Jul): the sticky bottom AnalysisFooter is the
+  // SOLE Rerun owner in every post-run state — it carries the robustness
+  // verdict AND the Rerun action together, and being OUTSIDE the scroller it is
+  // the tab's most reliable always-visible recovery affordance. The freshness
+  // strip (AnalysisFreshnessNotice) still states fresh/stale/unknown but no
+  // longer renders a Rerun, so there is exactly one Rerun and no duplicate.
   // Within the not-fresh window, distinguish a model that definitely CHANGED since
   // the run (CEE 'stale' or a local edit that downgraded a retained 'fresh') from a
   // CANNOT-CONFIRM state where CEE could not determine freshness — so the stale
@@ -755,19 +739,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // banner's "Refresh analysis · Coaching may be out of date".
   //
   // The suppression's only REAL effect was CTA dedupe against the banner's
-  // own "Run analysis" — and post-C1 that is already handled, better, by
-  // `freshnessStripOwnsRerun`: when a verdict is held the footer renders no
-  // action at all, so suppressing the whole footer deleted nothing but the
-  // robustness verdict + producer meta that C1 says must STAY. (The cited
-  // "4-CTA corner case" cannot arise post-C1: the max is 2.)
+  // own "Run analysis" — and the footer already carries its own robustness
+  // verdict + producer meta (never freshness copy), so suppressing the whole
+  // footer would have deleted the verdict + the anchor's Rerun, which the
+  // anchor-run-control fix says must STAY.
   //
   // It must not come back as an action-level gate either. AnalysisOrphanBanner
   // (deleted in the F11 fold) mounted inside ResultsBody — INSIDE the
   // scroller — so it scrolled away. Letting a scrolling surface suppress the
   // footer's action would recreate the exact zero-affordance blocker this
-  // lane fixed, in the state where the strip holds no verdict and the footer
-  // is the tab's only always-visible owner. The footer yields its action
-  // ONLY to the strip, which is pinned.
+  // lane fixed: the footer is the tab's only always-visible Rerun owner (it
+  // sits outside the scroller) and must never yield its action.
   //
   // Net: banner + footer can coexist — which is precisely what the base
   // already did on the legacy path, deliberately ("the legacy
@@ -2292,9 +2274,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 {isDecisionOverviewEnabled() && !isPreRun && hasInlineSummary && resultsSectionData && (
                   <DecisionOverviewCard title={overviewTitle} />
                 )}
-                {/* Wave F-B review (a): the sole freshness strip + its Rerun
-                    mount ABOVE the dim wrapper at full opacity — the recovery
-                    control must never sit inside an aria-disabled region. */}
+                {/* The freshness strip states fresh/stale/unknown (informational
+                    only — the anchor footer below owns the Rerun). It mounts
+                    ABOVE the dim wrapper at full opacity so the freshness signal
+                    never sits inside an aria-disabled region. */}
                 {!isPreRun && hasInlineSummary && resultsSectionData && (
                   <AnalysisFreshnessNotice />
                 )}
@@ -2359,15 +2342,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 )}
                 </div>
                 {/* Brief 5.4 Phase 11: "Create decision brief" placeholder removed.
-                    C1 (one Rerun owner per viewport): while the freshness strip
-                    above owns the one Rerun, this footer is STATUS-ONLY — the
-                    robustness verdict + producer meta stay, the action goes.
-                    The action renders only when the strip shows none (no
-                    freshness verdict held, or a 'none' verdict), preserving the
-                    tab's recovery — the footer is then the only ALWAYS-VISIBLE
-                    owner (it sits outside the scroller, unlike the strip which
-                    needs `sticky` to qualify). See the orphan-banner note above
-                    for why nothing else may suppress this footer. */}
+                    Anchor-run-control (Paul, 21-Jul): the sticky bottom anchor
+                    is the SOLE Rerun owner. It shows the robustness verdict AND
+                    the Rerun action ALONGSIDE each other — never the verdict in
+                    place of the run control (Paul's finding: "the bottom anchor
+                    shows the verdict in the slot where the run-analysis control
+                    should be"). The footer is the tab's most reliable
+                    always-visible owner — it sits OUTSIDE the scroller, so it
+                    can never scroll away. The freshness strip above keeps
+                    stating fresh/stale/unknown but no longer carries a Rerun, so
+                    there is exactly one Rerun and no duplicate. See the
+                    orphan-banner note above for why nothing else may suppress
+                    this footer. */}
                 {!isPreRun && hasInlineSummary && resultsSectionData && (
                   <AnalysisFooter
                     statusIcon={postRunFooter.icon}
@@ -2375,17 +2361,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     statusText={postRunFooter.label}
                     metaText={postRunMetaText}
                     metaPlacement="stacked"
-                    {...(freshnessStripOwnsRerun
-                      ? {}
-                      : {
-                          actionLabel: isRunning ? 'Running analysis…' : 'Rerun',
-                          actionVariant: 'secondary' as const,
-                          onAction: handleRunAnalysis,
-                          actionDisabled: isRunning || !canRunAnalysis,
-                          actionLoading: isRunning,
-                          actionTitle:
-                            !canRunAnalysis && !isRunning ? runBlockedTooltip : undefined,
-                        })}
+                    actionLabel={isRunning ? 'Running analysis…' : 'Rerun'}
+                    actionVariant="secondary"
+                    onAction={handleRunAnalysis}
+                    actionDisabled={isRunning || !canRunAnalysis}
+                    actionLoading={isRunning}
+                    actionTitle={!canRunAnalysis && !isRunning ? runBlockedTooltip : undefined}
                     testId="results-analysis-footer"
                   />
                 )}

--- a/src/canvas/components/__tests__/OutputsDock.anchorRunControl.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.anchorRunControl.spec.tsx
@@ -1,0 +1,215 @@
+/**
+ * OutputsDock — the bottom anchor keeps the run-analysis control (Paul, 21-Jul).
+ *
+ * Paul's finding: opening the canvas onto a completed analysis, "the bottom
+ * anchor panel shows the robustness verdict ('Sensitive to assumptions…') in
+ * the slot where the RUN-ANALYSIS control should be — instead of the
+ * functionality to run the analysis."
+ *
+ * Root cause: the post-run AnalysisFooter (the sticky bottom anchor) dropped
+ * its Rerun action in every held-verdict state (`freshnessStripOwnsRerun`),
+ * yielding the recovery affordance to the top freshness strip and leaving the
+ * anchor showing ONLY the robustness verdict.
+ *
+ * Fix (ownership relocated to the anchor): the always-visible bottom footer is
+ * the SOLE Rerun owner in every post-run state — it renders the robustness
+ * verdict AND the Rerun action, ALONGSIDE each other, never verdict-in-place-
+ * of-control. The freshness strip stays (it still states fresh/stale/unknown)
+ * but no longer carries a Rerun button, so there is never a duplicate.
+ *
+ * This is the anti-regression pin for the anchor-run-control fix. The broader
+ * one-owner matrix lives in OutputsDock.rerunSingleOwner.spec.tsx.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { collectRerunControls } from '../../../../tests/helpers/rerunControls'
+
+const { mockIsV5CanonicalAnalysisEnabled, mockIsAnalysisHeroV17Enabled, mockIsAnalysisHeroPanelEnabled } =
+  vi.hoisted(() => ({
+    mockIsV5CanonicalAnalysisEnabled: vi.fn(() => false),
+    mockIsAnalysisHeroV17Enabled: vi.fn(() => false),
+    mockIsAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isCompareEnabled: () => true,
+    isOrchestratorV2Enabled: () => true,
+    isLegacyDirectRunEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isAiPanelV2Enabled: () => false,
+    isV5CanonicalAnalysisEnabled: mockIsV5CanonicalAnalysisEnabled,
+    isAnalysisHeroV17Enabled: mockIsAnalysisHeroV17Enabled,
+    isAnalysisHeroPanelEnabled: mockIsAnalysisHeroPanelEnabled,
+  }
+})
+
+vi.mock('../../hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() }),
+}))
+
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../pre-analysis', () => ({ PreAnalysisPanel: () => null }))
+vi.mock('../../hooks/useGraphReadiness', () => ({
+  useGraphReadiness: () => ({ readiness: { state: 'ready' } }),
+}))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+// robustness.recommendation_stability 0.42 → a display-safe 'fragile'/'moderate'
+// verdict → the "Sensitive to assumptions" footer label Paul reported. The exact
+// verdict token is derived upstream; the point of THIS pin is that whatever the
+// verdict, the anchor also carries the run control.
+const fakeReport: Record<string, unknown> = {
+  results: { conservative: 10, likely: 20, optimistic: 30, units: 'percent', unitSymbol: '%' },
+  run: { bands: { p10: 10, p50: 20, p90: 30 } },
+  robustness: { recommendation_stability: 0.42 },
+}
+
+function seedPostRun(overrides: Record<string, unknown> = {}) {
+  useCanvasStore.setState({
+    currentScenarioFraming: null,
+    currentScenarioLastResultHash: null,
+    hasCompletedFirstRun: true,
+    nodes: [
+      { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+      { id: 'opt-a', type: 'option', data: { label: 'Option A', kind: 'option' }, position: { x: 50, y: 0 } },
+      { id: 'factor-1', type: 'factor', data: { label: 'Factor', kind: 'factor' }, position: { x: 100, y: 0 } },
+    ],
+    edges: [{ id: 'e1', source: 'factor-1', target: 'goal-1', data: { weight: 0.7, direction: 'positive' } }],
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    results: { status: 'complete', report: fakeReport },
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    v5AnalysisFact: null,
+    showDraftChat: false,
+    ...overrides,
+  } as never)
+}
+
+const SCROLLER_RE = /overflow-y-auto|overflow-y-scroll|(^|\s)overflow-auto(\s|$)/
+const classOf = (el: Element) => el.getAttribute('class') ?? ''
+
+/** Walk up to the nearest scrolling ancestor (null when outside every scroller). */
+function nearestScroller(control: Element): Element | null {
+  let node: Element | null = control.parentElement
+  while (node && node !== document.body) {
+    if (SCROLLER_RE.test(classOf(node))) return node
+    node = node.parentElement
+  }
+  return null
+}
+
+describe('OutputsDock — the bottom anchor keeps the run-analysis control (anchor-run-control)', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    try {
+      sessionStorage.clear()
+    } catch {
+      /* jsdom quirk */
+    }
+    mockIsV5CanonicalAnalysisEnabled.mockReturnValue(false)
+    mockIsAnalysisHeroV17Enabled.mockReturnValue(false)
+    mockIsAnalysisHeroPanelEnabled.mockReturnValue(false)
+  })
+
+  // The exact state Paul hit: a completed run, freshness confirmed 'fresh'. The
+  // old code made THIS the state where the footer showed the verdict and NO
+  // action (freshnessStripOwnsRerun === true for a held 'fresh' verdict).
+  it("fresh post-run (Paul's repro): the anchor shows the verdict AND a Rerun control", () => {
+    seedPostRun({
+      analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: 1 },
+    })
+    render(<OutputsDock />)
+
+    const footer = screen.getByTestId('results-analysis-footer')
+    // The robustness verdict still lives in the anchor (never removed)…
+    expect(footer).toHaveTextContent(/Sensitive to assumptions|Stable result|Robustness/)
+    // …ALONGSIDE the run control, not in place of it.
+    const action = screen.getByTestId('results-analysis-footer-action')
+    expect(action).toBeInTheDocument()
+    expect(action).toHaveTextContent('Rerun')
+
+    // The freshness strip no longer carries its own Rerun — no duplicate.
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+
+    // Exactly ONE rerun control in the whole tab, and it is the anchor's.
+    expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([action])
+
+    // The anchor sits OUTSIDE the scroller — always visible without a pin.
+    expect(nearestScroller(action)).toBeNull()
+  })
+
+  it.each(['stale', 'unknown'] as const)(
+    '%s post-run: the anchor still owns the one Rerun (verdict + control together)',
+    (freshness) => {
+      seedPostRun({ analysisFreshness: { freshness, computedAt: '2026-07-15T00:00:00.000Z' } })
+      render(<OutputsDock />)
+
+      const action = screen.getByTestId('results-analysis-footer-action')
+      expect(action).toBeInTheDocument()
+      expect(action).toHaveTextContent('Rerun')
+      expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+      expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([action])
+    },
+  )
+
+  it('orphaned result (canonical flag on, no v5 fact): the anchor owns the one Rerun', () => {
+    mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
+    seedPostRun({ analysisFreshness: { freshness: 'stale', computedAt: 1 }, v5AnalysisFact: null })
+    render(<OutputsDock />)
+
+    const action = screen.getByTestId('results-analysis-footer-action')
+    expect(action).toBeInTheDocument()
+    // The strip still communicates freshness, but carries no Rerun.
+    expect(screen.getByTestId('analysis-freshness-notice')).toBeInTheDocument()
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+    expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([action])
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.rerunSingleOwner.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.rerunSingleOwner.spec.tsx
@@ -1,34 +1,28 @@
 /**
- * OutputsDock — ONE Rerun owner per viewport (lane C1).
+ * OutputsDock — ONE Rerun owner per viewport, owned by the bottom anchor
+ * (anchor-run-control, Paul 21-Jul).
  *
- * Doctrine (Wave F-B, brief §5 / §2.2): AnalysisFreshnessNotice is the sole
- * freshness owner and carries THE one Rerun; the same action is never
- * repeated across surfaces in one viewport. This spec pins the post-run
- * Analysis-tab matrix:
+ * Doctrine: the sticky bottom AnalysisFooter is the SOLE Rerun owner in every
+ * post-run state — it renders the robustness verdict AND the Rerun action
+ * ALONGSIDE each other (never the verdict in place of the run control, which
+ * was Paul's finding). AnalysisFreshnessNotice still states fresh/stale/unknown
+ * but carries NO Rerun, so the action is never duplicated across surfaces. This
+ * spec pins the post-run Analysis-tab matrix:
  *
- *   - stale / unknown / fresh verdict → the strip renders its Rerun and the
- *     sticky AnalysisFooter is STATUS-ONLY (robustness verdict + producer
- *     meta stay; no `results-analysis-footer-action`), and no hero-side
- *     rerun exists anywhere in the tab tree;
- *   - no freshness verdict held (strip renders nothing) → the footer KEEPS
- *     its Rerun action, so the tab never loses its only recovery affordance;
- *   - no rerun offered by the strip (NON-orphan 'none' verdict) → the footer
- *     KEEPS its Rerun, pinning the `!== 'none'` clause of
- *     `freshnessStripOwnsRerun`;
- *   - orphaned result (V5 canonical flag on, no V5 fact) → the strip ALWAYS
- *     offers the one Rerun: a held fresh/stale/unknown verdict wins, and a
- *     null or 'none' verdict synthesises the cannot-confirm variant
- *     (resolveTrustEffectiveState) — the footer stays status-only, keeping
- *     its robustness status.
+ *   - stale / unknown / fresh verdict → the footer carries the verdict + the
+ *     one Rerun (`results-analysis-footer-action`); the strip renders no
+ *     Rerun; no hero-side rerun exists anywhere in the tab tree;
+ *   - local dirty overlay (fresh downgraded to unknown) → footer still owns;
+ *   - NON-orphan 'none' verdict, and no freshness verdict held → footer owns;
+ *   - orphaned result (V5 canonical flag on, no V5 fact) → footer owns; the
+ *     strip renders (informational) but carries no Rerun.
  *
  * VISIBILITY IS A STRUCTURAL PROXY HERE. jsdom has no layout engine, so no
  * assertion in this file can prove the sole owner is on SCREEN:
  * `getAllByRole`/`getByTestId` prove DOM PRESENCE only, and mount-parity is
- * NOT visibility-parity. (An earlier revision of this spec asserted
- * `toHaveLength(1)` under an "always-visible" comment while the sole owner
- * scrolled away — presence held, visibility did not.) The invariant that
- * makes visibility true is pinned instead by
- * `expectRerunOwnerCannotScrollAway` below.
+ * NOT visibility-parity. The invariant that makes visibility true is pinned
+ * instead by `expectRerunOwnerCannotScrollAway` below — and the footer is the
+ * strongest case: it sits OUTSIDE the scroller, so it needs no pin at all.
  *
  * Scaffolding mirrors OutputsDock.testability.spec.tsx (real ResultsBody,
  * stable useConversation stub, aiPanelV2 OFF).
@@ -220,7 +214,7 @@ function expectRerunOwnerCannotScrollAway(control: Element, opts: { insideScroll
   expect(rerunOwnerCannotScrollAway(control)).toBe(true)
 }
 
-describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
+describe('OutputsDock — one Rerun owner, owned by the bottom anchor (anchor-run-control)', () => {
   beforeEach(() => {
     ensureMatchMedia()
     try {
@@ -233,8 +227,8 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
     mockIsAnalysisHeroPanelEnabled.mockReturnValue(false)
   })
 
-  it.each(['stale', 'unknown'] as const)(
-    'CEE %s verdict: the strip Rerun is the ONLY rerun control — footer is status-only, no hero rerun',
+  it.each(['stale', 'unknown', 'fresh'] as const)(
+    'CEE %s verdict: the anchor footer carries the verdict AND the one Rerun; strip has no Rerun; no hero rerun',
     (freshness) => {
       mockIsAnalysisHeroPanelEnabled.mockReturnValue(true)
       seedPostRun({
@@ -242,48 +236,33 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
       })
       render(<OutputsDock />)
 
-      // The strip owns recovery — its Rerun renders.
+      // The strip still states the freshness verdict, but carries no Rerun.
       expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute('data-freshness', freshness)
-      const stripRerun = screen.getByTestId('freshness-strip-rerun')
-      expect(stripRerun).toBeInTheDocument()
+      expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
 
       // No hero-side rerun (v6: the hero has no stale affordance of its own).
-      // Re-anchored: this previously queried `hero-rerun`, a testid that
-      // exists NOWHERE in source, so it asserted the absence of something
-      // that could never be present and could never fail. Anchor to the
-      // hero's REAL root (getByTestId throws if the hero stops rendering, so
-      // the pin cannot go vacuous again) and sweep its whole subtree.
       const hero = screen.getByTestId('analysis-hero-panel')
       expect(collectRerunControls(hero).size).toBe(0)
 
-      // The footer keeps its robustness STATUS but drops its Rerun action.
-      expect(screen.getByTestId('results-analysis-footer')).toBeInTheDocument()
-      expect(screen.getByTestId('results-analysis-footer')).toHaveTextContent('Robustness unknown')
-      expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
+      // The footer carries the robustness STATUS *and* the one Rerun action —
+      // alongside, never verdict-in-place-of-control (Paul's finding).
+      const footer = screen.getByTestId('results-analysis-footer')
+      expect(footer).toHaveTextContent('Robustness unknown')
+      const action = screen.getByTestId('results-analysis-footer-action')
+      expect(action).toHaveTextContent('Rerun')
 
       // Exactly ONE rerun control in the whole tab tree — matched by name OR
       // testid, so a control reintroduced under any other spelling is caught.
-      const controls = collectRerunControls(document.body as HTMLElement)
-      expect([...controls]).toEqual([stripRerun])
+      expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([action])
 
-      // ...and that sole owner cannot scroll out of the viewport.
-      expectRerunOwnerCannotScrollAway(stripRerun, { insideScroller: true })
+      // ...and that sole owner cannot scroll out of the viewport — the footer
+      // sits OUTSIDE the scroller, so it needs no pin at all.
+      expectRerunOwnerCannotScrollAway(action, { insideScroller: false })
+      expect(nearestScroller(action)).toBeNull()
     },
   )
 
-  it('fresh verdict: strip Rerun (parity: rerun is always legitimate) + status-only footer', () => {
-    seedPostRun({
-      analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: 1 },
-    })
-    render(<OutputsDock />)
-
-    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute('data-freshness', 'fresh')
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
-    expect(screen.getByTestId('results-analysis-footer')).toBeInTheDocument()
-    expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
-  })
-
-  it('local dirty overlay (fresh downgraded to unknown): still one owner — footer stays status-only', () => {
+  it('local dirty overlay (fresh downgraded to unknown): still one owner — the anchor footer', () => {
     seedPostRun({
       analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: 1 },
       analysisFreshnessDirty: true,
@@ -291,36 +270,23 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
     render(<OutputsDock />)
 
     expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute('data-freshness', 'unknown')
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
-    expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+    expect(screen.getByTestId('results-analysis-footer-action')).toBeInTheDocument()
   })
 
-  it('the sole Rerun owner is pinned against scrolling away (structural proxy — jsdom cannot see)', () => {
+  it('the sole Rerun owner cannot scroll away (structural proxy — jsdom cannot see): the anchor footer is OUTSIDE the scroller', () => {
     mockIsAnalysisHeroPanelEnabled.mockReturnValue(true)
     seedPostRun({ analysisFreshness: { freshness: 'stale', computedAt: 1 } })
     render(<OutputsDock />)
 
-    const strip = screen.getByTestId('analysis-freshness-notice')
-    const stripRerun = screen.getByTestId('freshness-strip-rerun')
+    // The strip is informational (no Rerun); the footer owns the one Rerun.
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+    const action = screen.getByTestId('results-analysis-footer-action')
 
-    // The footer has yielded its action, so the strip is the ONLY owner...
-    expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
-
-    // ...and the strip really does live inside the tab's one scroller, above
-    // the whole ResultsBody. Without a pin it would scroll away on the first
-    // scroll and take the tab's only recovery action off screen with it.
-    expect(nearestScroller(stripRerun)).not.toBeNull()
-
-    // The pin itself: `sticky top-0` on the strip root (load-bearing — see
-    // the always-visibility contract in AnalysisFreshnessNotice's header).
-    expect(classOf(strip)).toMatch(/(^|\s)sticky(\s|$)/)
-    expect(classOf(strip)).toMatch(/(^|\s)top-0(\s|$)/)
-    // `bg-panel` is what makes the pinned strip opaque to the body scrolling
-    // behind it; `z-10` is what keeps it above.
-    expect(classOf(strip)).toMatch(/(^|\s)z-10(\s|$)/)
-    expect(classOf(strip)).toMatch(/(^|\s)bg-panel(\s|$)/)
-
-    expectRerunOwnerCannotScrollAway(stripRerun, { insideScroller: true })
+    // The footer sits OUTSIDE the tab's one scroller — always visible without
+    // needing a sticky pin (the strongest form of the always-visible invariant).
+    expect(nearestScroller(action)).toBeNull()
+    expectRerunOwnerCannotScrollAway(action, { insideScroller: false })
   })
 
   it('structural proxy self-check: the helper FAILS an unpinned control inside a scroller', () => {
@@ -353,11 +319,7 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
     host.remove()
   })
 
-  it("CEE 'none' verdict: strip holds a verdict but offers NO rerun, so the footer keeps its action", () => {
-    // Pins the `!== 'none'` clause of `freshnessStripOwnsRerun`. A verdict IS
-    // held (so a `!= null`-only gate would wrongly strip the footer's action),
-    // but 'none' means there is nothing to rerun and the strip draws no
-    // control — the footer must therefore remain the tab's recovery owner.
+  it("CEE 'none' verdict: strip holds a verdict but offers NO rerun; the anchor footer owns the one Rerun", () => {
     seedPostRun({ analysisFreshness: { freshness: 'none', computedAt: 1 } })
     render(<OutputsDock />)
 
@@ -368,8 +330,7 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
     expect(action).toBeInTheDocument()
     expect(action).toHaveTextContent('Rerun')
 
-    // Still exactly one owner — ownership moved to the footer, it did not
-    // vanish and it did not double up.
+    // Exactly one owner — the footer.
     expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([action])
 
     // The footer is a sibling OUTSIDE the scroller, so it is always visible
@@ -378,7 +339,7 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
     expect(nearestScroller(action)).toBeNull()
   })
 
-  it('NO freshness verdict held: the strip renders nothing and the footer KEEPS its Rerun (no affordance loss)', () => {
+  it('NO freshness verdict held: the strip renders nothing and the anchor footer owns the Rerun (no affordance loss)', () => {
     seedPostRun({ analysisFreshness: null })
     render(<OutputsDock />)
 
@@ -393,17 +354,17 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
   })
 
   // ── Orphan state (F11 fold: the orphan BANNER is deleted; orphan renders
-  // as the freshness strip's no-verdict variant, sticky, with THE one Rerun) ─
-  // One underlying state must never render two banners — Paul's 16-Jul
-  // session had "Results may be outdated" stacked on "Refresh analysis" for
-  // a single stale verdict. MUTATION-CHECK: restore the AnalysisOrphanBanner
-  // mount in ResultsBody and these tests go RED on the second banner.
+  // as the freshness strip's no-verdict variant). One underlying state must
+  // never render two banners — Paul's 16-Jul session had "Results may be
+  // outdated" stacked on "Refresh analysis" for a single stale verdict.
+  // MUTATION-CHECK: restore the AnalysisOrphanBanner mount in ResultsBody and
+  // these tests go RED on the second banner.
   it.each([
     ['analysisHeroPanel', 'panel'],
     ['V17', 'v17'],
     ['both hero flags off (legacy path)', 'legacy'],
   ] as const)(
-    'orphan state + %s: ONE banner (the strip), footer KEEPS its robustness status',
+    'orphan state + %s: ONE banner (the strip), the anchor footer owns verdict + Rerun',
     (_label, mode) => {
       // V5 canonical flag on with a report but NO v5 fact → orphaned result.
       mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
@@ -419,24 +380,16 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
       expect(screen.queryByTestId('analysis-orphan-banner')).not.toBeInTheDocument()
       expect(screen.getByTestId('analysis-freshness-notice')).toBeInTheDocument()
 
-      // The footer still states the robustness verdict (C1 finding 2).
-      expect(screen.getByTestId('results-analysis-footer')).toBeInTheDocument()
+      // The footer states the robustness verdict AND owns the one Rerun.
       expect(screen.getByTestId('results-analysis-footer')).toHaveTextContent('Robustness unknown')
+      expect(screen.getByTestId('results-analysis-footer-action')).toBeInTheDocument()
 
-      // A verdict is held, so the strip owns the one Rerun and the footer is
-      // status-only — the dedupe C1 actually needs, done by the right gate.
-      expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
-      expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
+      // The strip carries no Rerun — no duplicate owner.
+      expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
     },
   )
 
-  it('orphan state with NO verdict: the strip renders the cannot-confirm variant with the ONE Rerun (F11 fold upgrade)', () => {
-    // Pre-fold, this state rendered the orphan banner INSIDE the scroller
-    // (its CTA scrolled away) while the strip rendered nothing. Post-fold the
-    // strip itself carries the orphan state — and the strip is sticky
-    // (structural proxy asserted below; jsdom cannot prove pinning visually —
-    // the real-browser acceptance run remains the pre-merge gate for the
-    // visibility claim).
+  it('orphan state with NO verdict: the strip renders the cannot-confirm variant (no Rerun); the anchor footer owns the one Rerun', () => {
     mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
     mockIsAnalysisHeroPanelEnabled.mockReturnValue(true)
     seedPostRun({ analysisFreshness: null, v5AnalysisFact: null })
@@ -446,30 +399,23 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
     const strip = screen.getByTestId('analysis-freshness-notice')
     expect(strip).toHaveAttribute('data-orphaned', 'true')
     expect(strip).toHaveAttribute('data-freshness', 'unknown')
-    const stripRerun = screen.getByTestId('freshness-strip-rerun')
-    expect(stripRerun).toBeInTheDocument()
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
 
-    // With the strip holding a state, the footer is status-only (C1: one owner).
-    expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
+    const action = screen.getByTestId('results-analysis-footer-action')
+    expect(action).toBeInTheDocument()
 
-    // Whole-tree sweep: exactly ONE rerun control under any spelling — this
-    // is the one genuinely NEW ownership state the fold created, so it gets
-    // the same sweep + cannot-scroll-away rigour as the verdict states.
-    expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([stripRerun])
-    expectRerunOwnerCannotScrollAway(stripRerun, { insideScroller: true })
+    // Whole-tree sweep: exactly ONE rerun control under any spelling.
+    expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([action])
+    expectRerunOwnerCannotScrollAway(action, { insideScroller: false })
   })
 
-  it("orphan state with a 'none' verdict: the strip PREFERS the cannot-confirm variant and keeps the ONE Rerun (no zero-affordance hole)", () => {
+  it("orphan state with a 'none' verdict: the strip PREFERS the cannot-confirm copy (no Rerun); the anchor footer owns the one Rerun (no zero-affordance hole)", () => {
     // The C1 blocker cell: canonical flag ON, results present, no V5 fact
-    // (orphaned — reachable because a 'none' turn also CLEARS the fact),
-    // and a held {freshness:'none'} verdict. Pre-fix the strip rendered
-    // "No analysis yet." (no Rerun — offersRerun is freshness !== 'none')
-    // above a full results body while `freshnessStripOwnsRerun`'s orphan
-    // term stripped the footer action too: ZERO recovery controls in the
-    // tab, and incoherent copy. The precedence rule
-    // (resolveTrustEffectiveState) now prefers the orphan cannot-confirm
-    // variant over a 'none' verdict when results exist, so the strip owns
-    // the one Rerun and the copy is honest.
+    // (orphaned — reachable because a 'none' turn also CLEARS the fact), and a
+    // held {freshness:'none'} verdict. The precedence rule
+    // (resolveTrustEffectiveState) prefers the orphan cannot-confirm variant
+    // over a 'none' verdict when results exist, so the strip's copy is honest;
+    // recovery is always available via the anchor footer.
     mockIsV5CanonicalAnalysisEnabled.mockReturnValue(true)
     mockIsAnalysisHeroPanelEnabled.mockReturnValue(true)
     seedPostRun({
@@ -483,14 +429,13 @@ describe('OutputsDock — one Rerun owner per viewport (C1)', () => {
     expect(strip).toHaveAttribute('data-freshness', 'unknown')
     expect(strip).toHaveTextContent('Cannot confirm whether this analysis is current.')
     expect(strip).not.toHaveTextContent('No analysis yet.')
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
 
-    const stripRerun = screen.getByTestId('freshness-strip-rerun')
-    expect(stripRerun).toBeInTheDocument()
-    expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
+    const action = screen.getByTestId('results-analysis-footer-action')
+    expect(action).toBeInTheDocument()
 
-    // ≥1 recovery affordance ALWAYS (the C1 invariant this cell violated):
-    // exactly one, and it cannot scroll away.
-    expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([stripRerun])
-    expectRerunOwnerCannotScrollAway(stripRerun, { insideScroller: true })
+    // ≥1 recovery affordance ALWAYS: exactly one, and it cannot scroll away.
+    expect([...collectRerunControls(document.body as HTMLElement)]).toEqual([action])
+    expectRerunOwnerCannotScrollAway(action, { insideScroller: false })
   })
 })

--- a/src/canvas/components/__tests__/OutputsDock.testability.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.testability.spec.tsx
@@ -3,12 +3,10 @@
  *
  * Pins the stable selectors the Playwright acceptance harness needs on the
  * Analysis (Results) tab:
- *   - freshness strip:     data-testid="analysis-freshness-notice" (sole stale owner)
- *   - its Rerun button:    data-testid="freshness-strip-rerun"     (Wave F-B)
+ *   - freshness strip:     data-testid="analysis-freshness-notice" (informational)
  *   - footer Rerun action: data-testid="results-analysis-footer-action"
- *     (AnalysisFooter stamps `${testId}-action` on its action button —
- *     C1: rendered only while the freshness strip shows no Rerun of its
- *     own, i.e. when no freshness verdict is held)
+ *     (AnalysisFooter stamps `${testId}-action` on its action button — the
+ *     bottom anchor is the sole Rerun owner; the strip carries no Rerun)
  *
  * Test-support attributes only — zero behaviour change. Scaffolding mirrors
  * OutputsDock.conversationSingleton.spec.tsx (stable useConversation stub;
@@ -147,30 +145,26 @@ describe('OutputsDock testability selectors (Analysis tab)', () => {
     } as never)
   })
 
-  it('the freshness strip and its Rerun are the ONE stale surface (Wave F-B)', () => {
+  it('the freshness strip states stale but carries NO Rerun (anchor-run-control)', () => {
     render(<OutputsDock />)
 
-    // The old top-level banner is retired — the strip owns stale + Rerun.
+    // The old top-level banner is retired; the strip is informational only.
     expect(screen.queryByTestId('graph-stale-banner')).not.toBeInTheDocument()
     const strip = screen.getByTestId('analysis-freshness-notice')
     expect(strip).toHaveAttribute('data-freshness', 'stale')
-    const rerun = screen.getByTestId('freshness-strip-rerun')
-    expect(rerun).toBeInTheDocument()
-    expect(rerun).toHaveTextContent('Rerun')
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
   })
 
-  it('stale: the footer is STATUS-ONLY (C1 — the strip above owns the one Rerun)', () => {
-    // RETIRED PIN: this test formerly asserted the footer action rendered
-    // alongside the stale strip — two always-visible Reruns in one viewport.
+  it('stale: the bottom anchor footer carries the verdict AND the one Rerun', () => {
     render(<OutputsDock />)
 
     expect(screen.getByTestId('results-analysis-footer')).toBeInTheDocument()
-    expect(screen.queryByTestId('results-analysis-footer-action')).not.toBeInTheDocument()
+    const action = screen.getByTestId('results-analysis-footer-action')
+    expect(action).toBeInTheDocument()
+    expect(action).toHaveTextContent('Rerun')
   })
 
-  it('AnalysisFooter action button derives `${testId}-action` (no freshness verdict → footer keeps its Rerun)', () => {
-    // With no verdict held the strip renders nothing, so the footer is the
-    // tab's only recovery affordance and keeps its action.
+  it('AnalysisFooter action button derives `${testId}-action` (no freshness verdict → footer still owns its Rerun)', () => {
     useCanvasStore.setState({ analysisFreshness: null } as never)
     render(<OutputsDock />)
 

--- a/src/components/results/AnalysisFreshnessNotice.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.tsx
@@ -13,34 +13,18 @@
  * or any local graph-hash computation, and it never shows the technical
  * reason/hash fields as copy (they ride on data-*).
  *
- * ALWAYS-VISIBILITY CONTRACT (C1 — one Rerun owner per viewport)
- * -------------------------------------------------------------
- * This strip is the SOLE owner of the Rerun action: while it offers one, the
- * AnalysisFooter deliberately renders NO action (OutputsDock). Sole ownership
- * only holds if the strip is always visible — so `sticky top-0 z-10` on the
- * root is LOAD-BEARING and must not be dropped.
+ * RERUN OWNERSHIP (anchor-run-control, Paul 21-Jul)
+ * -------------------------------------------------
+ * This strip is INFORMATIONAL: it states fresh/stale/unknown but carries NO
+ * Rerun. The one Rerun lives in the sticky bottom AnalysisFooter (OutputsDock),
+ * ALONGSIDE the robustness verdict — the always-visible anchor Paul expects the
+ * run control to occupy. The footer sits OUTSIDE the tab's one scroller, so it
+ * can never scroll away; there is exactly one Rerun and no duplicate.
  *
- * Why: the strip's only mount site (OutputsDock) is INSIDE the Analysis tab's
- * one scroller, above the entire ResultsBody (hero, options, drivers,
- * Strengthen). Unstuck, it scrolls off on the first scroll — and because the
- * footer yields its action to the strip, the viewport would then carry ZERO
- * rerun affordance exactly when a stale verdict says one is needed. Its
- * structural counterpart is AnalysisFooter's `sticky bottom-0 z-10`.
- *
- * `bg-panel` on the root is what makes `z-10` opaque to the scrolling body.
- *
- * Known cosmetic nuance: the scroller's own `py-3` insets the pinned strip by
- * 12px, because a sticky box is clamped to its containing block (the
- * scroller's CONTENT box) while overflow clips at the PADDING box. A 12px
- * sliver of body content therefore passes above the strip. The strip itself
- * stays fully visible and clickable, so the recovery affordance holds.
- *
- * jsdom cannot prove visual visibility (no layout engine), so the guarantee is
- * pinned STRUCTURALLY instead — see OutputsDock.rerunSingleOwner.spec.tsx
- * ('rerun owner is always-visible (structural proxy)').
+ * `sticky top-0 z-10 bg-panel` is kept so the freshness line stays legible over
+ * the scrolling body (not to pin a control) — see OutputsDock.rerunSingleOwner.
  */
 import { useEffect, useRef } from 'react'
-import { RefreshCw } from 'lucide-react'
 import { useCanvasStore } from '@/canvas/store'
 import { useAnalysisStateSource } from '@/canvas/hooks/useAnalysisStateSource'
 import { typography } from '@/styles/typography'
@@ -51,7 +35,6 @@ import {
   type AnalysisFreshnessValue,
 } from '@/canvas/store/analysisFreshness'
 import { resolveTrustEffectiveState } from '@/canvas/hooks/useAnalysisTrust'
-import { executeCanonicalRun } from '@/canvas/analysis/canonicalRunRegistry'
 import { useShowToastSafe } from '@/canvas/ToastContext'
 import { RUN_ENDED_WITHOUT_NEW_RESULTS_COPY } from '@/canvas/components/analysisRunStatus'
 
@@ -153,14 +136,6 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
   // downgrade a retained 'fresh' to cannot-confirm (never fabricate 'stale').
   const freshness = resolveDisplayedFreshness(effectiveState, dirty) as AnalysisFreshnessValue
   const isStale = freshness === 'stale'
-  // Recovery applies to BOTH not-confirmably-fresh states: a stale verdict
-  // and a cannot-confirm 'unknown' (e.g. recovered session, local edit
-  // downgrade). The old top-level banner offered Rerun for both — the strip
-  // must not drop that affordance. 'none' has nothing to rerun.
-  // Parity audit: the prototype offers Rerun in the FRESH state too (rerun
-  // against the current model is always a legitimate action); only 'none'
-  // (nothing analysed yet) has nothing to rerun.
-  const offersRerun = freshness !== 'none'
   // Mark when the displayed verdict differs from CEE's because of a local edit —
   // technical signal for tests/debug only, not user copy.
   const downgraded = effectiveState.freshness === 'fresh' && freshness === 'unknown'
@@ -173,8 +148,8 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
       data-freshness-dirty={downgraded ? 'true' : undefined}
       data-orphaned={orphanSynthesised ? 'true' : undefined}
       data-freshness-reason={effectiveState.freshnessReason}
-      // C1: `sticky top-0 z-10` is load-bearing, not decoration — see the
-      // always-visibility contract in the file header. Do not remove.
+      // `sticky top-0 z-10 bg-panel` keeps the freshness line legible over the
+      // scrolling body; the Rerun lives in the bottom anchor (see header).
       className={`sticky top-0 z-10 flex items-center gap-2 rounded-md border px-3 py-2 bg-panel ${isStale ? 'border-warning/30' : 'border-panel-border'} ${className}`.trim()}
     >
       <span
@@ -182,37 +157,12 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
         aria-hidden="true"
         data-testid="freshness-dot"
       />
-      {/* Live region on the copy only (review c) — never around the button.
-          Stale message renders in header colour per the prototype's heavier
-          emphasis; a run in flight states so honestly. */}
+      {/* Live region on the freshness copy. Stale message renders in header
+          colour per the prototype's heavier emphasis; a run in flight states
+          so honestly. Recovery (Rerun) lives in the bottom anchor footer. */}
       <span role="status" className={`${typography.panelBody} ${isStale ? 'text-text-header' : 'text-text-body'} flex-1`}>
         {isRunning ? 'Rerunning the analysis with the current model…' : FRESHNESS_COPY[freshness]}
       </span>
-      {offersRerun && (
-        // Wave F-B (brief §5.2): the strip is the sole stale owner and carries
-        // THE recovery action — canonical-runner routed, never a private
-        // pipeline. Disabled while any run is analysing ('preparing' from V2
-        // resultsStart or V5 resultsAnalysing, plus the SSE states).
-        <button
-          type="button"
-          data-testid="freshness-strip-rerun"
-          onClick={() => {
-            // Honest recovery (brief §5.2 'the recovery action remains
-            // crisp'): a blocked or unavailable run says WHY instead of
-            // silently doing nothing.
-            void executeCanonicalRun({ source: 'freshness-strip' }).then((outcome) => {
-              if (outcome.status === 'blocked' || outcome.status === 'unavailable') {
-                showToast(outcome.reason)
-              }
-            })
-          }}
-          disabled={isRunning}
-          className={`${typography.panelBody} inline-flex items-center gap-1 px-3 py-1 rounded-pill border border-panel-border text-text-body hover:bg-panel-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-fast`}
-        >
-          <RefreshCw size={12} aria-hidden="true" />
-          Rerun
-        </button>
-      )}
     </div>
   )
 }

--- a/src/components/results/__tests__/AnalysisFreshnessNotice.rerun.spec.tsx
+++ b/src/components/results/__tests__/AnalysisFreshnessNotice.rerun.spec.tsx
@@ -1,16 +1,14 @@
 /**
- * Wave F-B — the freshness strip is the SOLE stale owner and carries the
- * ONE Rerun action (brief §5.2), routed through the canonical runner.
+ * Anchor-run-control (Paul, 21-Jul) — the freshness strip is INFORMATIONAL: it
+ * states fresh/stale/unknown but carries NO Rerun. The one Rerun lives in the
+ * bottom anchor AnalysisFooter (see OutputsDock.rerunSingleOwner.spec.tsx).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 
 import { AnalysisFreshnessNotice } from '../AnalysisFreshnessNotice'
 import { useCanvasStore } from '../../../canvas/store'
-import {
-  registerCanonicalRunner,
-  __resetCanonicalRunnerForTests,
-} from '../../../canvas/analysis/canonicalRunRegistry'
+import { __resetCanonicalRunnerForTests } from '../../../canvas/analysis/canonicalRunRegistry'
 
 const showToast = vi.fn()
 vi.mock('../../../canvas/ToastContext', () => ({
@@ -28,54 +26,33 @@ beforeEach(() => {
 })
 afterEach(() => __resetCanonicalRunnerForTests())
 
-describe('AnalysisFreshnessNotice — strip Rerun (Wave F-B)', () => {
-  it('stale verdict → the strip carries THE Rerun action', () => {
+describe('AnalysisFreshnessNotice — informational only (anchor-run-control)', () => {
+  // The strip states freshness; the Rerun moved to the bottom anchor footer.
+  // MUTATION-CHECK: reintroduce the `freshness-strip-rerun` button in
+  // AnalysisFreshnessNotice and these go RED (a second Rerun owner is back).
+  it.each(['stale', 'unknown', 'fresh', 'none'] as const)(
+    '%s verdict → the strip carries NO Rerun button',
+    (freshness) => {
+      render(<AnalysisFreshnessNotice state={{ freshness, freshnessReason: null, computedAt: 1 } as never} dirty={false} />)
+      expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+    },
+  )
+
+  it('renders the freshness copy for a held verdict (still communicates state)', () => {
     render(<AnalysisFreshnessNotice state={STALE as never} dirty={false} />)
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
-  })
-
-  it("unknown (cannot-confirm) also offers Rerun — the old banner covered both not-fresh states", () => {
-    render(<AnalysisFreshnessNotice state={{ freshness: 'unknown', freshnessReason: null, computedAt: 1 } as never} dirty={false} />)
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
-  })
-
-  // Parity rebuild 2026-07-13: the prototype offers Rerun in the FRESH state
-  // too (rerunning against the current model is always legitimate); only
-  // 'none' — nothing analysed yet — has no rerun affordance.
-  it('fresh → Rerun offered; none → no Rerun affordance', () => {
-    const { rerender } = render(<AnalysisFreshnessNotice state={FRESH as never} dirty={false} />)
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
-    rerender(<AnalysisFreshnessNotice state={{ freshness: 'none', freshnessReason: null, computedAt: 1 } as never} dirty={false} />)
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).toHaveAttribute('data-freshness', 'stale')
+    expect(notice).toHaveTextContent('Model changed since this analysis. Re-run to update.')
     expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
   })
 
-  it('click routes through the canonical runner (never a private pipeline)', () => {
-    const runner = vi.fn(async (_opts?: import('../../../canvas/analysis/canonicalRunRegistry').CanonicalRunOptions) => ({ status: 'dispatched' as const }))
-    registerCanonicalRunner(runner)
-    render(<AnalysisFreshnessNotice state={STALE as never} dirty={false} />)
-    fireEvent.click(screen.getByTestId('freshness-strip-rerun'))
-    expect(runner).toHaveBeenCalledTimes(1)
-    expect(runner.mock.calls[0][0]).toMatchObject({ source: 'freshness-strip' })
-  })
-
-  it('a blocked or unavailable run says WHY (no dead control)', async () => {
-    const runner = vi.fn(async (_opts?: import('../../../canvas/analysis/canonicalRunRegistry').CanonicalRunOptions) => ({ status: 'blocked' as const, reason: 'Add a goal first.' }))
-    registerCanonicalRunner(runner)
-    render(<AnalysisFreshnessNotice state={STALE as never} dirty={false} />)
-    fireEvent.click(screen.getByTestId('freshness-strip-rerun'))
-    await vi.waitFor(() => expect(showToast).toHaveBeenCalledWith('Add a goal first.'))
-  })
-
-  it("disables while analysing — identically for V2 resultsStart and V5 resultsAnalysing ('preparing' equivalence pin)", () => {
-    registerCanonicalRunner(vi.fn(async () => ({ status: 'dispatched' as const })))
+  it('never renders a Rerun even while analysing (no dead control, no duplicate owner)', () => {
     useCanvasStore.getState().resultsStart({ seed: 1 })
     const { rerender } = render(<AnalysisFreshnessNotice state={STALE as never} dirty={false} />)
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeDisabled()
-
-    useCanvasStore.getState().resultsReset()
-    useCanvasStore.getState().resultsAnalysing()
-    rerender(<AnalysisFreshnessNotice state={STALE as never} dirty={false} />)
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeDisabled()
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
+    // FRESH still has nothing to click either.
+    rerender(<AnalysisFreshnessNotice state={FRESH as never} dirty={false} />)
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
   })
 })
 

--- a/src/components/results/__tests__/AnalysisFreshnessNotice.spec.tsx
+++ b/src/components/results/__tests__/AnalysisFreshnessNotice.spec.tsx
@@ -142,7 +142,7 @@ describe('AnalysisFreshnessNotice — self-contradictory stale verdict (a16a0e82
     expect(el).toHaveAttribute('data-freshness', 'stale')
   })
 
-  it('the cannot-confirm variant still offers the Rerun recovery action', () => {
+  it('the cannot-confirm variant renders its copy but no Rerun (recovery lives in the anchor footer)', () => {
     render(
       <AnalysisFreshnessNotice
         state={{
@@ -152,7 +152,10 @@ describe('AnalysisFreshnessNotice — self-contradictory stale verdict (a16a0e82
         }}
       />,
     )
-    expect(screen.getByTestId('freshness-strip-rerun')).toBeInTheDocument()
+    // Anchor-run-control: the strip is informational; the Rerun is in the
+    // bottom AnalysisFooter, not here.
+    expect(screen.getByTestId('analysis-freshness-notice')).toBeInTheDocument()
+    expect(screen.queryByTestId('freshness-strip-rerun')).not.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## DO NOT MERGE — awaiting review + post-merge staging browser-verify

### Paul's finding (21-Jul, A2-owned)
Opening the canvas onto a completed analysis, "the bottom anchor panel shows the robustness verdict ('Sensitive to assumptions…') in the slot where the RUN-ANALYSIS control should be — instead of the functionality to run the analysis."

### Root cause (traced at the bytes, staging tip e85c8bb5)
The post-run **AnalysisFooter** (the sticky bottom anchor, `data-testid="results-analysis-footer"`) dropped its Rerun action in every held-verdict state:

```tsx
{...(freshnessStripOwnsRerun ? {} : { actionLabel: 'Rerun', onAction: handleRunAnalysis, ... })}
```

`freshnessStripOwnsRerun = (displayedFreshness != null && displayedFreshness !== 'none') || orphanedResult` (`OutputsDock.tsx:618`, staging). Under the C1 "one Rerun owner per viewport" doctrine the strip (`AnalysisFreshnessNotice`, sticky *top*) owned the Rerun, so the bottom anchor became **status-only**: just the verdict, no run control.

**Repro:** any completed run whose robustness verdict is moderate/fragile → footer label "Sensitive to assumptions", and freshness held (`fresh`/`stale`/`unknown`) or orphaned → footer action suppressed. This is the normal post-run state (right after a run freshness is `fresh` → `freshnessStripOwnsRerun === true`), so it is what Paul hit — not an edge case.

Not a zero-affordance bug: the Rerun did exist, in the *top* strip. But Paul (product owner) has ruled the run control belongs in the bottom anchor, alongside the verdict.

### Fix — relocate Rerun ownership to the anchor
- **OutputsDock**: the bottom `AnalysisFooter` now **always** renders its action → it carries the robustness verdict **and** the Rerun *alongside* each other, never verdict-in-place-of-control. Removed the dead `freshnessStripOwnsRerun` / `orphanedResult` / `useAnalysisStateSource` gating.
- **AnalysisFreshnessNotice**: now **informational only** — it still states fresh/stale/unknown but no longer renders a Rerun button (dropped `RefreshCw` + `executeCanonicalRun`; completion toast unchanged). One Rerun, no duplicate.
- The footer sits **outside** the tab's one scroller, so the sole owner can never scroll away — a stronger always-visible guarantee than the strip's `sticky top-0` pin.
- Verdict is **not** removed from the product; it stays in the anchor, and `handleRunAnalysis` already routes through the canonical runner.

### Evidence
- **RED-first**: new `OutputsDock.anchorRunControl.spec.tsx` — 4/4 fail on unfixed source (`results-analysis-footer-action` absent), pass after fix.
- **Mutation-check** (source reverted, updated specs kept): **22 tests go RED** across all 5 spec files.
- **Touched suites**: 5 updated/added specs → 51 pass; 13 dependent specs (OutputsDock + AnalysisFreshnessNotice importers) → 152 pass; AnalysisFooter-direct + postAnalysisFooter → 40 pass.
- **typecheck** (`tsc -p tsconfig.ci.json`): clean.
- **wide-tsc** (`tsc -p tsconfig.app.json`): multiset **identical** to pristine staging baseline (2322 = 2322, zero errors added/removed).
- **lint** (touched files): 0 errors (one pre-existing `exhaustive-deps` warning on untouched line 1051).

### ⚠ Not yet done
jsdom cannot prove on-screen visibility (repo rule #3). **Post-merge staging browser-verify** of the anchor (verdict + usable Rerun) is the real "done" — deliberately left for the merge/deploy owner. Capture before/after of the bottom anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)