### PR TITLE
refactor(focus-areas): /simplify cleanups — memoize sanitiser, dedup className + plural, one will-scaffold selector

### DIFF
--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -96,6 +96,13 @@ export const PANEL_COPY = {
   bestNextStep: 'Best next step',
 } as const
 
+/**
+ * Singularise the "option(s)" noun for the two scaffold-copy sites
+ * (LADDER_COPY.run_scaffold and FOOTER_COPY.scaffoldSub). One helper so the
+ * two identical `n === 1 ? 'option' : 'options'` ternaries can never drift.
+ */
+const pluralOptions = (n: number): string => (n === 1 ? 'option' : 'options')
+
 export const LADDER_COPY = {
   set_goal: 'Set the goal this decision serves, so every option can be judged against it.',
   set_success: 'Define what success means here, so the analysis can judge the options.',
@@ -108,7 +115,7 @@ export const LADDER_COPY = {
    * draft the remaining options on run, so the offer to run is honest.
    */
   run_scaffold: (n: number) =>
-    `Run your first analysis. Olumi will draft the remaining ${n} ${n === 1 ? 'option' : 'options'}.`,
+    `Run your first analysis. Olumi will draft the remaining ${n} ${pluralOptions(n)}.`,
   run_scaffold_nocount: 'Run your first analysis. Olumi will draft the remaining options.',
 } as const
 
@@ -215,7 +222,7 @@ export const FOOTER_COPY = {
    * not-ready copy so the footer never contradicts the enabled run button.
    */
   scaffoldSub: (n: number) =>
-    `Olumi will draft the remaining ${n} ${n === 1 ? 'option' : 'options'}`,
+    `Olumi will draft the remaining ${n} ${pluralOptions(n)}`,
   scaffoldSubNoCount: 'Olumi will draft the remaining options',
   running: 'Analysis running',
   runningSub: 'Hold on while the first pass completes',

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -10,6 +10,7 @@
 import { useEffect, useMemo } from 'react'
 import { useCanvasStore } from '../../../store'
 import { useGraphReadiness } from '../../../hooks/useGraphReadiness'
+import { readinessWillScaffold } from '../../../utils/canRunAnalysis'
 import { isReviewedByUser } from '../../pre-analysis/utils/isReviewedByUser'
 import { computeBars, type BarsModel } from '../selectors/computeBars'
 import { computeEstimateRanking } from '../selectors/computeEstimateRanking'
@@ -156,7 +157,7 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   // the readiness response; when it will draft the remaining options the graph
   // is runnable despite can_run_analysis being false. Both the footer and the
   // ladder disclose it instead of showing the not-ready copy.
-  const willScaffoldOptions = readiness?.scaffold_plan?.will_scaffold_options === true
+  const willScaffoldOptions = readinessWillScaffold(readiness)
   const scaffoldOptionCount = readiness?.scaffold_plan?.option_count
 
   const ladder = useMemo(

--- a/src/canvas/conversation/AnswerBody.tsx
+++ b/src/canvas/conversation/AnswerBody.tsx
@@ -17,7 +17,7 @@
  * panelBody 12/400) and the shared .inlineDisclosureToggle (11px) — no new
  * font sizes, so the conversation type-scale census (11/12/14) is unaffected.
  */
-import { memo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { safeRichText } from '../utils/safeRichText'
@@ -44,7 +44,15 @@ interface AnswerBodyProps {
 
 export const AnswerBody = memo(function AnswerBody({ answer, compact = false }: AnswerBodyProps) {
   const [expanded, setExpanded] = useState(false)
-  const bullets = answer.bullets.slice(0, MAX_BULLETS) // UI-SEM-090
+  // Memoise the XSS-safe sanitiser output: `answer` is a stable prop and this
+  // component is memo'd, so `expanded` is the only re-render trigger. Without
+  // these memos every Show more/less toggle would re-sanitise the unchanged
+  // headline, bullets and detail. Pure perf — identical output.
+  const headlineHtml = useMemo(() => safeRichText(answer.headline), [answer.headline])
+  // UI-SEM-090: clamp the producer's bullet list to at most MAX_BULLETS at the
+  // display boundary (see MAX_BULLETS above) before sanitising each.
+  const bulletHtml = useMemo(() => answer.bullets.slice(0, MAX_BULLETS).map(safeRichText), [answer.bullets])
+  const detailHtml = useMemo(() => (answer.detail ? safeRichText(answer.detail) : ''), [answer.detail])
   const bodyType = compact ? typography.panelBody : typography.chatProse
 
   return (
@@ -53,15 +61,15 @@ export const AnswerBody = memo(function AnswerBody({ answer, compact = false }: 
         className={`${typography.panelHeader} ${styles.answerHeadline}`}
         data-testid="answer-headline"
         // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText (allowlist: strong, br, ul, li, span)
-        dangerouslySetInnerHTML={{ __html: safeRichText(answer.headline) }}
+        dangerouslySetInnerHTML={{ __html: headlineHtml }}
       />
-      {bullets.length > 0 && (
+      {bulletHtml.length > 0 && (
         <ul className={`${bodyType} ${styles.answerBullets}`} data-testid="answer-bullets">
-          {bullets.map((b, i) => (
+          {bulletHtml.map((html, i) => (
             <li
               key={i}
               // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText
-              dangerouslySetInnerHTML={{ __html: safeRichText(b) }}
+              dangerouslySetInnerHTML={{ __html: html }}
             />
           ))}
         </ul>
@@ -91,7 +99,7 @@ export const AnswerBody = memo(function AnswerBody({ answer, compact = false }: 
               className={`${bodyType} ${styles.answerDetail}`}
               data-testid="answer-detail"
               // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText
-              dangerouslySetInnerHTML={{ __html: safeRichText(answer.detail) }}
+              dangerouslySetInnerHTML={{ __html: detailHtml }}
             />
           )}
         </>

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -284,6 +284,15 @@ export const MessageBubble = memo(function MessageBubble({
     )
   }
 
+  // Body text className — identical in the structured-answer branch and the
+  // free-text branch below. Hoisted to one const so the two render paths can
+  // never drift; rebuilding it verbatim in both was pure duplication.
+  const bodyClassName = `${compact ? typography.panelBody : typography.chatProse} ${styles.markdownContent} ${
+    compact ? styles.markdownContentCompact : ''
+  } ${isProvisional ? styles.provisionalText : ''} ${
+    !isUser && isOrchestratorRenderingV2Enabled() ? styles.v2AssistantText : ''
+  }`
+
   return (
     <>
     {stalenessFreshness && <StalenessPill freshness={stalenessFreshness} />}
@@ -298,22 +307,14 @@ export const MessageBubble = memo(function MessageBubble({
     >
       {showStructuredAnswer && message.answerShape ? (
         <div
-          className={`${compact ? typography.panelBody : typography.chatProse} ${styles.markdownContent} ${
-            compact ? styles.markdownContentCompact : ''
-          } ${isProvisional ? styles.provisionalText : ''} ${
-            !isUser && isOrchestratorRenderingV2Enabled() ? styles.v2AssistantText : ''
-          }`}
+          className={bodyClassName}
           data-testid="message-answer-structured"
         >
           <AnswerBody answer={message.answerShape} compact={compact} />
         </div>
       ) : (
         <div
-          className={`${compact ? typography.panelBody : typography.chatProse} ${styles.markdownContent} ${
-            compact ? styles.markdownContentCompact : ''
-          } ${isProvisional ? styles.provisionalText : ''} ${
-            !isUser && isOrchestratorRenderingV2Enabled() ? styles.v2AssistantText : ''
-          }`}
+          className={bodyClassName}
           data-streaming={isStreaming || undefined}
           // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText (allowlist: strong, br, ul, li; br.md-gap for rule degradation)
           dangerouslySetInnerHTML={{

--- a/src/canvas/conversation/answerShape.ts
+++ b/src/canvas/conversation/answerShape.ts
@@ -28,8 +28,12 @@
  * response — EXACTLY as it does the `_reasoning` sidecar. There is no retained
  * pre-parse raw body on the success path (V5ParseResult carries only the parsed
  * `response`), so `response[ADDITIVE_EXTENSIONS_KEY]._answer_shape` IS the wire
- * value. We read it there, and ALSO probe a formal top-level field so a future
- * schema promotion (as 0.15.0 did for `reasoning`) lights up without an edit.
+ * value. We read it there, and ALSO probe the SAME `_answer_shape` key at the
+ * top level as a defensive fallback (guards a future parser change that leaves
+ * the underscore key un-demoted). NOTE: this fallback does NOT catch a formal
+ * schema promotion — a real promotion (as 0.15.0 did for `reasoning`) drops the
+ * underscore, exposing `answer_shape`, which NEITHER probe reads. Lighting that
+ * up would require an explicit edit here (a new field name), not just this read.
  *
  * FAIL-SAFE: parseAnswerShape returns null on anything malformed, so before
  * CEE's unconditional emit lands (the CEE lane deleting the flag + pinning the
@@ -47,6 +51,13 @@ export interface AnswerShape {
   /** The full supporting explanation, revealed behind "Show more". Non-blank per the contract. */
   detail: string
 }
+
+/**
+ * A string trimmed to its content, or '' for a non-string or blank value.
+ * Shared by the three field reads in parseAnswerShape so "is this a usable
+ * string?" is expressed once rather than hand-rolled per field.
+ */
+const nonBlank = (v: unknown): string => (typeof v === 'string' && v.trim().length > 0 ? v.trim() : '')
 
 /**
  * Defensive validation of the confirmed shape { headline, bullets, detail }.
@@ -69,16 +80,14 @@ export function parseAnswerShape(raw: unknown): AnswerShape | null {
   if (!raw || typeof raw !== 'object') return null
   const o = raw as Record<string, unknown>
 
-  const headline = typeof o.headline === 'string' ? o.headline.trim() : ''
+  const headline = nonBlank(o.headline)
   if (headline.length === 0) return null
 
-  const detail = typeof o.detail === 'string' ? o.detail.trim() : ''
+  const detail = nonBlank(o.detail)
   if (detail.length === 0) return null
 
   const bullets = Array.isArray(o.bullets)
-    ? o.bullets
-        .filter((b): b is string => typeof b === 'string' && b.trim().length > 0)
-        .map((b) => b.trim())
+    ? o.bullets.map(nonBlank).filter((b) => b.length > 0)
     : []
 
   return { headline, bullets, detail }
@@ -86,17 +95,21 @@ export function parseAnswerShape(raw: unknown): AnswerShape | null {
 
 /**
  * Confirmed wire field name (2026-07-21). We read it from the additive-
- * extensions sidecar (where the parser demotes it today) AND from a formal
- * top-level field (future schema promotion), in that precedence.
+ * extensions sidecar (where the parser demotes it today) AND, as a defensive
+ * fallback, from the SAME `_answer_shape` key at the top level. That fallback
+ * does NOT catch a formal schema promotion — a real promotion drops the
+ * underscore (→ `answer_shape`), which this constant does not name.
  */
 const ANSWER_SHAPE_FIELD = '_answer_shape' as const
 
 /**
  * Wire binding. Reads the answer-shape sidecar off a live CEE turn response.
  * Mirrors extractReasoningSidecar: reads the additive-extensions sidecar the
- * parser demotes unknown keys into, and also a formal top-level field. Fail-
- * closed through parseAnswerShape — any absent/malformed shape yields null, and
- * the caller then renders the free-text body unchanged.
+ * parser demotes unknown keys into, and also the same `_answer_shape` key at
+ * the top level as a defensive fallback (NOT a schema-promotion catch — see
+ * ANSWER_SHAPE_FIELD). Fail-closed through parseAnswerShape — any absent/
+ * malformed shape yields null, and the caller then renders the free-text body
+ * unchanged.
  */
 export function extractAnswerShapeSidecar(response: unknown): AnswerShape | null {
   if (!response || typeof response !== 'object') return null

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -98,6 +98,23 @@ export interface CanRunAnalysisParams {
 }
 
 /**
+ * readinessWillScaffold — the single strict-boolean reader of the scaffold
+ * intent (UI-SEM-091). CEE (#612) rides `scaffold_plan.will_scaffold_options`
+ * on the readiness response, and two surfaces consume it with OPPOSITE polarity:
+ * the run GATE here (fail-closed — block unless strictly true) and the
+ * pre-analysis DISPLAY in usePreAnalysisModel (fail-safe — disclose only when
+ * strictly true). They previously read the raw field independently with `!==
+ * true` vs `=== true`, agreeing only because readinessStore normalises the
+ * field. Extracting the one `=== true` strict test guarantees the two reads
+ * can never drift: an absent/undefined scaffold_plan is uniformly false
+ * (fail-closed for the gate via `!readinessWillScaffold`, no-disclosure for the
+ * display).
+ */
+export function readinessWillScaffold(readiness: GraphReadiness | null | undefined): boolean {
+  return readiness?.scaffold_plan?.will_scaffold_options === true
+}
+
+/**
  * Determine if analysis can run based on current state
  *
  * @param params - State from store and hooks
@@ -168,7 +185,7 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   if (
     readiness &&
     !readiness.can_run_analysis &&
-    readiness.scaffold_plan?.will_scaffold_options !== true
+    !readinessWillScaffold(readiness)
   ) {
     if (!blockingReasons.includes(readiness.confidence_explanation)) {
       blockingReasons.push(readiness.confidence_explanation || 'Graph not ready for analysis')


### PR DESCRIPTION
**DO NOT MERGE** pending review. Behavior-preserving cleanups from a `/simplify` review of merged PRs #418 / #419 / #420. **No behavior change, no correctness hunting** — the proof is that all touched suites stay green **unchanged** and the wide-tsc error multiset is identical before/after.

## Fixes

**FIX 1 (efficiency) — `AnswerBody.tsx`**
The component is `memo`'d and its `answer` prop is stable, so its only re-render trigger is the `expanded` toggle — yet `safeRichText(headline)` and `bullets.slice(0,MAX_BULLETS).map(safeRichText)` (and `detail`) ran inline in JSX, re-sanitising the unchanged content on every toggle. Wrapped each in `useMemo` keyed on the respective `answer.*` field. `safeRichText(markdown: string)` uses only its first arg, so `.map(safeRichText)` is byte-identical to `.map(b => safeRichText(b))`. Pure perf, identical output.

**FIX 2 (simplification) — `MessageBubble.tsx`**
The ~5-term body `className` was rebuilt **verbatim** in the structured-answer branch and the free-text branch. Hoisted to one `const bodyClassName` above the return; both branches now use it. Removes the copy + drift risk. (Placed after the two early returns, which don't use it.)

**FIX 3 (altitude — kills a hand-mirror drift) — `canRunAnalysis.ts` + `usePreAnalysisModel.ts`**
`will_scaffold_options` was read independently in two modules with **opposite** operators — the run gate (`!== true`, fail-closed) and the pre-analysis display (`=== true`, fail-safe) — agreeing only because `readinessStore` normalises the field. Extracted one shared strict-boolean selector `readinessWillScaffold(readiness)` (`=== true`). The gate now uses `!readinessWillScaffold(readiness)` — note `!(x === true)` ≡ `x !== true`, **byte-identical**. Home chosen as `canRunAnalysis.ts` (the prompt's first option): it keeps the pure util pure — placing the selector in `useGraphReadiness.ts` would have forced `canRunAnalysis` to convert its erased type-only import into a runtime import pulling react+zustand (wrong coupling direction). Verified no import cycle: `usePreAnalysisModel → canRunAnalysis → v5/eligibility → flags` (leaf); `usePreAnalysisModel` already value-imports the util's sibling.

**FIX 4 (simplification) — `pre-analysis-v3/constants.ts`**
Extracted `pluralOptions(n)` from the duplicated `n === 1 ? 'option' : 'options'` ternary in the two scaffold-copy sites (`LADDER_COPY.run_scaffold`, `FOOTER_COPY.scaffoldSub`). Identical strings.

**FIX 5 (altitude/reuse) — `answerShape.ts`**
(a) Corrected the misleading top-level-probe comment: it claimed the `?? parseAnswerShape(r[ANSWER_SHAPE_FIELD])` probe lets a "future schema promotion light up without an edit," but a real promotion would drop the underscore (`answer_shape`), which the underscore-prefixed probe can **never** catch. The probe is **kept** (harmless defensive read, test-covered); the comment now states it is a defensive fallback only and would NOT catch a schema promotion.
(b) Added a small in-file `nonBlank()` helper for the 3 hand-rolled non-blank-trimmed-string reads (headline, detail, bullets filter). Verified behavior-identical: same null decision, same ordered array of trimmed non-blank bullets.

## Explicitly skipped (per scope)
- Did **not** delete the top-level `_answer_shape` probe (kept as defensive fallback; corrected its comment instead).
- No shared `getAdditiveExtension` accessor or shared disclosure-toggle component (out-of-scope abstractions).
- No repo-wide `nonEmptyString` export (out-of-scope refactor).
- The `nonBlank` double-trim micro-nit left as-is (out of scope).

## Verification
- `pnpm run typecheck` (tsconfig.ci.json): clean (exit 0).
- **Wide tsc** (`tsc -p tsconfig.app.json --noEmit`): 2322 errors before, 2322 after; position-stripped error **multiset IDENTICAL (zero delta)**. The one raw-diff line is a pre-existing `MessageBubble` `TS2345` in `InsightsStrip` (untouched code) shifted 502→503 by FIX 2's net +1 line.
- ESLint on the 6 touched files: clean.
- **Touched suites: 181/181 green** (AnswerBody, answerShape, canRunAnalysis, computeLadder, PreAnalysisPanelV3, readinessStore, all MessageBubble.* specs).
- **FIX 3 before/after proof** — scaffold suites (`canRunAnalysis` 36 + `PreAnalysisPanelV3` 41 + `computeLadder` 12) = **89/89 green BEFORE (original staging) and 89/89 green AFTER**, identical. No spec files edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)