### PR TITLE
feat(f4): send factor observed_state on graph-readiness so scaffold_plan reports runnable

### DIFF
--- a/src/canvas/stores/__tests__/readinessStore.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.spec.ts
@@ -379,3 +379,117 @@ describe('readinessStore', () => {
     })
   })
 })
+
+// ── F4: factor observed_state on the graph-readiness REQUEST ─────────
+//
+// Request-side contract (A1, byte-confirmed against merged CEE schema):
+//   FACTOR nodes emit TOP-LEVEL `observed_state: { value, raw_value? }`
+//   (sibling of `data`, snake_case). `value` REQUIRED (0-1 model scale);
+//   `raw_value` OPTIONAL (display magnitude). NO metadata/unit/source key —
+//   a metadata-shaped key routes CEE to the strict constraint branch → 400.
+//   Non-factor nodes never get observed_state. Lets CEE report
+//   scaffold_plan.will_scaffold_options (fixes "blocked despite scaffold fired").
+
+/** Parse the POSTed graph-readiness request body and return graph.nodes keyed by id. */
+async function captureRequestNodesById(): Promise<Record<string, any>> {
+  const call = [...mockFetch.mock.calls]
+    .reverse()
+    .find((c) => typeof c?.[0] === 'string' && c[0].endsWith('/graph-readiness'))
+  expect(call, 'expected a POST to /graph-readiness').toBeDefined()
+  const body = JSON.parse((call![1] as any).body as string)
+  const byId: Record<string, any> = {}
+  for (const node of body.graph.nodes) byId[node.id] = node
+  return byId
+}
+
+/** Seed a mixed graph exercising every observed_state gate, then fetch & capture. */
+async function seedAndCaptureF4Graph(): Promise<Record<string, any>> {
+  useCanvasStore.setState({
+    nodes: [
+      // factor with numeric value + raw_value; also carries data.value to prove the
+      // observed_state attach is independent of the data:{value} branch.
+      {
+        id: 'fac1',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Team size', kind: 'factor', value: 0.9, observedState: { value: 0.4, raw_value: 200 } },
+      },
+      // factor with value but unit/source and NO raw_value.
+      {
+        id: 'fac2',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Spend', kind: 'factor', observedState: { value: 0.4, unit: '%', source: 'cee_inference' } },
+      },
+      // factor with NO observedState.
+      {
+        id: 'fac3',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Bare factor', kind: 'factor' },
+      },
+      // factor with observedState but non-numeric value.
+      {
+        id: 'fac4',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Nullish factor', kind: 'factor', observedState: { value: null, raw_value: 5 } },
+      },
+      // NON-factor (constraint) carrying a numeric observedState.value.
+      {
+        id: 'con1',
+        type: 'constraint',
+        position: { x: 0, y: 0 },
+        data: { label: 'Budget cap', kind: 'constraint', observedState: { value: 0.7, raw_value: 1000 } },
+      },
+      // NON-factor (goal) carrying a numeric observedState.value.
+      {
+        id: 'goal1',
+        type: 'goal',
+        position: { x: 0, y: 0 },
+        data: { label: 'Goal', kind: 'goal', observedState: { value: 0.6 } },
+      },
+    ] as any,
+    edges: [] as any,
+  })
+
+  useReadinessStore.getState().startListening()
+  await vi.runAllTimersAsync()
+  return captureRequestNodesById()
+}
+
+describe('readinessStore — F4 factor observed_state (request-side)', () => {
+  // (1) factor with value + raw_value → observed_state {value, raw_value}; no leak; data:{value} intact.
+  it('attaches observed_state {value, raw_value} on a factor and leaks no metadata/unit/source', async () => {
+    const nodes = await seedAndCaptureF4Graph()
+    expect(nodes.fac1.observed_state).toEqual({ value: 0.4, raw_value: 200 })
+    expect(nodes.fac1.observed_state).not.toHaveProperty('metadata')
+    expect(nodes.fac1.observed_state).not.toHaveProperty('unit')
+    expect(nodes.fac1.observed_state).not.toHaveProperty('source')
+    // The independent data:{value} branch is unaffected by the restructure.
+    expect(nodes.fac1.data).toEqual({ value: 0.9 })
+  })
+
+  // (2) factor with value + unit/source but no raw_value → observed_state {value} only.
+  it('emits observed_state {value} only when raw_value is absent, never leaking unit/source', async () => {
+    const nodes = await seedAndCaptureF4Graph()
+    expect(nodes.fac2.observed_state).toEqual({ value: 0.4 })
+    expect(nodes.fac2.observed_state).not.toHaveProperty('raw_value')
+    expect(nodes.fac2.observed_state).not.toHaveProperty('unit')
+    expect(nodes.fac2.observed_state).not.toHaveProperty('source')
+  })
+
+  // (3) factor with no observedState / non-numeric value → no observed_state key.
+  it('omits observed_state when the factor has no observedState or a non-numeric value', async () => {
+    const nodes = await seedAndCaptureF4Graph()
+    expect(nodes.fac3).not.toHaveProperty('observed_state')
+    expect(nodes.fac4).not.toHaveProperty('observed_state')
+  })
+
+  // (4) non-factor nodes never get observed_state (kind gate).
+  it('never attaches observed_state to non-factor nodes (constraint, goal)', async () => {
+    const nodes = await seedAndCaptureF4Graph()
+    expect(nodes.con1).not.toHaveProperty('observed_state')
+    expect(nodes.goal1).not.toHaveProperty('observed_state')
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -205,17 +205,34 @@ async function fetchReadiness(): Promise<void> {
       const payload: Record<string, unknown> = {
         graph: {
           nodes: currentNodes.map((n) => {
-            const nodeKind = (n.data as any)?.kind || n.type || 'factor'
-            const baseNode = {
+            const data = n.data as any
+            const nodeKind = data?.kind || n.type || 'factor'
+            const node: Record<string, unknown> = {
               id: n.id,
               type: nodeKind,
               kind: nodeKind,
-              label: (n.data as any)?.label || n.id,
+              label: data?.label || n.id,
             }
-            if (typeof (n.data as any)?.value === 'number') {
-              return { ...baseNode, data: { value: (n.data as any).value } }
+            if (typeof data?.value === 'number') {
+              node.data = { value: data.value }
             }
-            return baseNode
+            // F4 (A1 GO 21 Jul — CEE widen merged + deploy-verified live): send factor
+            // observed_state so /assist/v1/graph-readiness can report
+            // scaffold_plan.will_scaffold_options (fixes "blocked despite scaffold fired").
+            // Built EXPLICITLY (never spread observedState) so unit/source and any
+            // metadata-shaped key are excluded — a metadata key routes CEE to the strict
+            // constraint branch (needs metadata.operator) → HTTP 400. value REQUIRED (0-1
+            // model scale); raw_value OPTIONAL (display magnitude), only when numeric.
+            const observedState = data?.observedState
+            if (nodeKind === 'factor' && typeof observedState?.value === 'number') {
+              node.observed_state = {
+                value: observedState.value,
+                ...(typeof observedState.raw_value === 'number'
+                  ? { raw_value: observedState.raw_value }
+                  : {}),
+              }
+            }
+            return node
           }),
           /**
            * UI-SEM-011: Default belief injection (belief: 0.8).


### PR DESCRIPTION
## Contract (A1 — byte-confirmed against merged CEE schema + a live HTTP 200 probe)

On the `/assist/v1/graph-readiness` request, emit **top-level** `observed_state` on **FACTOR** nodes (sibling of `data`, snake_case) so CEE can report `scaffold_plan.will_scaffold_options`. Fixes Paul's "blocked despite scaffold fired" case. **Request-side only** — the response contract is unchanged (`scaffold_plan` is already forwarded, #420).

- `value` — **REQUIRED**, the 0–1 model scale. Source: `n.data.observedState.value`.
- `raw_value` — **OPTIONAL**, the display magnitude. Source: `n.data.observedState.raw_value` (emitted only when numeric).
- **NO `metadata` / `unit` / `source` key.** The CEE schema distinguishes factor-vs-constraint by the **absence of metadata**; any metadata-shaped key routes it to the strict constraint branch (needs `metadata.operator`) → **HTTP 400**.

### Metadata-leak safeguard — impossible by construction
The `observed_state` object is built **explicitly** (`{ value, ...(raw_value?) }`), **never** by spreading `observedState`. `unit`/`source`/any metadata key on the source `observedState` therefore cannot leak onto the wire. The `nodeKind === 'factor'` gate (checked against `data.kind`, verified against DraftChat ingestion at `DraftChat.tsx` ~L445 which maps `observed_state`→`observedState` preserving inner snake_case) keeps non-factor nodes clean.

## Files
- `src/canvas/stores/readinessStore.ts` — restructured the node map to attach `observed_state` top-level, independent of the existing `data:{value}` branch.
- `src/canvas/stores/__tests__/readinessStore.spec.ts` — 4 RED-first tests.

## RED-first proof (mutation-checked in a throwaway git worktree)
- **Mutation A** — remove the whole `observed_state` attach block → `it1` (value+raw_value) and `it2` (value-only, no leak) go RED (`expected undefined to deeply equal { value: 0.4, raw_value: 200 }` / `{ value: 0.4 }`); `it3`/`it4` stay green.
- **Mutation B** — drop the `nodeKind === 'factor'` gate → `it4` (non-factor) goes RED (`expected { Object } to not have property "observed_state"`); others stay green.
- **Restore** → all 20 in the suite green.

## Gates
- `pnpm run typecheck` (tsconfig.ci.json): **0 errors**.
- readinessStore suite: **20/20 green**; `vitest --changed origin/staging`: **48 files / 700 tests green** (0 failed, 22 skipped).
- Wide-tsc (`tsc -p tsconfig.app.json --noEmit`), position-stripped multiset: **2322 → 2322, ZERO new, byte-identical** (no new errors, no line-shifted entries).
- ESLint on the touched files: **0 errors** (4 pre-existing warnings, none on the added lines).

---

**Landing order satisfied** — A1 CEE widen merged + deploy-verified live (factor `observed_state` → HTTP 200). **DO NOT MERGE** — orchestrator reads verdict + CI, merges separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)