### PR TITLE
fix(f4): held-proposal confirm affordance renders once (single owner)

### DIFF
--- a/src/canvas/conversation/__tests__/heldProposalSingleConfirmOwner.spec.tsx
+++ b/src/canvas/conversation/__tests__/heldProposalSingleConfirmOwner.spec.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+/**
+ * F4 — held-proposal confirm affordance renders ONCE (single owner).
+ *
+ * DIAGNOSIS pinned here: on a held-proposal turn the confirm affordance was
+ * rendered by TWO surfaces at once —
+ *   1. the held-proposal CARD's confirm button (V5HeldProposalBlock, resolved
+ *      from the block's confirm_action_id), and
+ *   2. the generic suggested-action chip row (SuggestedChips), because the
+ *      SAME action was also emitted into the turn's actionChips.
+ * (The legacy diagnostic `type:"error"` / `severity:"warn"` block that rides
+ * the turn is a NON-contributor: mapV5Block returns null for it.)
+ *
+ * OWNERSHIP RULE (mirrors C1 "single Rerun owner"): the CARD owns the confirm /
+ * decline affordance it consumes via confirm_action_id / decline_action_id;
+ * buildSuggestedActionChips drops exactly those ids from the chip row.
+ *
+ * These pins mount BOTH surfaces in one tree — exactly as a real assistant turn
+ * does — and count confirm/decline controls across the whole render (the
+ * collectRerunControls "match by accessible name, whole-tree" style), so a
+ * re-duplication on EITHER surface fails the pin. Fixtures come from the REAL
+ * wire → parseV5Response → mapV5Blocks path, never hand-built blocks.
+ *
+ * RED→GREEN: with the ownership filter reverted the confirm count is 2 (the
+ * documented pre-fix duplicate); with it in place the count is 1.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, within } from '@testing-library/react'
+import type { ReactElement } from 'react'
+
+import { InlineBlocks } from '../InlineBlocks'
+import { SuggestedChips } from '../zones/SuggestedChips'
+import { useGuidanceStore } from '../../stores/guidanceStore'
+import { parseV5Response } from '../../../v5/responseParser'
+import { mapV5Blocks } from '../../../v5/blocks/mapV5Blocks'
+import { buildSuggestedActionChips } from '../../../v5/blocks/suggestedActionChips'
+
+// ── Wire fixtures (real parse path) — probe scenario a9b32212 ───────────
+
+const CONFIRM_ID = 'gmh_7576c3fbaf58'
+const CONFIRM_LABEL = 'Continue with this change'
+const DECLINE_ID = 'gmh_decline_01'
+const DECLINE_LABEL = 'Tell me what to adjust'
+
+function heldTurnBody(opts: { withDecline?: boolean } = {}): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: 'I can add that, but it reshapes your model.',
+    blocks: [
+      {
+        type: 'error',
+        error_code: 'INTERNAL_ERROR',
+        severity: 'warn',
+        details: { source: 'graph_management', verdict: 'held', candidate_id: 'cand_99' },
+      },
+      {
+        type: 'held_proposal',
+        proposal_id: CONFIRM_ID,
+        summary: 'Add a "regulatory delay" risk feeding into Launch on time',
+        mutation_class: 'structural',
+        reason_code: 'STRUCTURAL_APPLY_HELD',
+        confirm_action_id: CONFIRM_ID,
+        ...(opts.withDecline ? { decline_action_id: DECLINE_ID } : {}),
+      },
+    ],
+    suggested_actions: [
+      { id: CONFIRM_ID, label: CONFIRM_LABEL, message: 'Yes' },
+      ...(opts.withDecline
+        ? [{ id: DECLINE_ID, label: DECLINE_LABEL, message: 'Let me adjust it first' }]
+        : []),
+      { id: 'explain_it', label: 'Explain this', message: 'Explain why this is held' },
+    ],
+    insights: [],
+    stage_indicator: 'analyse',
+  }
+}
+
+function noHeldTurnBody(): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: 'Here are some options.',
+    blocks: [{ type: 'text', content: 'Some commentary.' }],
+    suggested_actions: [
+      { id: CONFIRM_ID, label: CONFIRM_LABEL, message: 'Yes' },
+      { id: 'explain_it', label: 'Explain this', message: 'Explain why this is held' },
+    ],
+    insights: [],
+    stage_indicator: 'analyse',
+  }
+}
+
+async function parseTurn(body: unknown) {
+  const result = await parseV5Response(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+  if (result.kind !== 'response') throw new Error(`expected response, got ${result.kind}`)
+  return result.response
+}
+
+/**
+ * Render a full assistant turn exactly as production composes it: the mapped
+ * blocks (the held-proposal card, error dropped) AND the derived chip row,
+ * mounted together in one tree.
+ */
+function renderTurn(response: Awaited<ReturnType<typeof parseTurn>>): ReactElement {
+  const mappedBlocks = mapV5Blocks(response.blocks, response.suggested_actions)
+  const actionChips = buildSuggestedActionChips(response.blocks, response.suggested_actions)
+  return (
+    <>
+      <InlineBlocks blocks={mappedBlocks} />
+      <SuggestedChips chips={actionChips} onChipClick={vi.fn().mockResolvedValue(undefined)} />
+    </>
+  )
+}
+
+/**
+ * Every button in `scope` whose ACCESSIBLE NAME contains `label` — a confirm
+ * affordance whichever surface renders it (the card's confirm button names the
+ * label verbatim; a chip's accessible name is the label; the card's DECLINE
+ * button names "Dismiss: <label>", which still contains it). Whole-tree, so a
+ * re-duplication on either surface is caught. Mirrors collectRerunControls.
+ */
+function collectAffordances(scope: HTMLElement, label: string): HTMLElement[] {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return within(scope).queryAllByRole('button', { name: new RegExp(escaped) })
+}
+
+beforeEach(() => {
+  useGuidanceStore.setState({ _sendChip: vi.fn() })
+})
+
+// ── RED→GREEN: exactly one confirm affordance across both surfaces ─────
+
+describe('F4 — held-proposal confirm affordance renders once (single owner)', () => {
+  it('renders the confirm affordance EXACTLY ONCE across the whole turn — owned by the card', async () => {
+    const response = await parseTurn(heldTurnBody())
+    const { container } = render(renderTurn(response))
+
+    // Whole-tree: exactly one control carries the confirm label. Pre-fix this
+    // was 2 (card button + chip); the ownership filter drops the chip.
+    const confirmControls = collectAffordances(container, CONFIRM_LABEL)
+    expect(confirmControls).toHaveLength(1)
+
+    // The surviving owner is the CARD's confirm button, not a chip.
+    const [owner] = confirmControls
+    expect(owner).toHaveAttribute('data-testid', 'v5-held-proposal-confirm')
+
+    // The generic chip row rendered no chip for the consumed confirm action…
+    expect(container.querySelector(`[data-testid="suggested-chip-${CONFIRM_ID}"]`)).toBeNull()
+    // …but the unrelated conversational chip still renders (fail-safe: only the
+    // consumed id drops, the row is otherwise untouched).
+    expect(container.querySelector('[data-testid="suggested-chip-explain_it"]')).not.toBeNull()
+  })
+
+  it('handles the decline affordance identically — the card owns it, the chip row does not repeat it', async () => {
+    const response = await parseTurn(heldTurnBody({ withDecline: true }))
+    const { container } = render(renderTurn(response))
+
+    // Confirm still single-owned.
+    expect(collectAffordances(container, CONFIRM_LABEL)).toHaveLength(1)
+
+    // Decline label appears on exactly one control — the card's dismiss button.
+    const declineControls = collectAffordances(container, DECLINE_LABEL)
+    expect(declineControls).toHaveLength(1)
+    expect(declineControls[0]).toHaveAttribute('data-testid', 'v5-held-proposal-dismiss')
+
+    // Neither consumed action leaks into the chip row.
+    expect(container.querySelector(`[data-testid="suggested-chip-${CONFIRM_ID}"]`)).toBeNull()
+    expect(container.querySelector(`[data-testid="suggested-chip-${DECLINE_ID}"]`)).toBeNull()
+    expect(container.querySelector('[data-testid="suggested-chip-explain_it"]')).not.toBeNull()
+  })
+
+  it('fail-safe: a turn with the same suggested_actions but NO held_proposal block renders the chip row unchanged', async () => {
+    const response = await parseTurn(noHeldTurnBody())
+    const { container } = render(renderTurn(response))
+
+    // No card is present…
+    expect(container.querySelector('[data-testid="v5-held-proposal"]')).toBeNull()
+    // …so the confirm action renders as a normal chip (zero behaviour change).
+    const confirmControls = collectAffordances(container, CONFIRM_LABEL)
+    expect(confirmControls).toHaveLength(1)
+    expect(confirmControls[0]).toHaveAttribute('data-testid', `suggested-chip-${CONFIRM_ID}`)
+    expect(container.querySelector('[data-testid="suggested-chip-explain_it"]')).not.toBeNull()
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -32,6 +32,7 @@ import {
   resolveFailureBaseCopy,
 } from '../../v5/failureTypeRetryability'
 import { mapV5Blocks } from '../../v5/blocks/mapV5Blocks'
+import { buildSuggestedActionChips } from '../../v5/blocks/suggestedActionChips'
 import { deriveV5Stage, v5StageToScenarioStage } from '../../v5/stageMapper'
 import { applyV5State } from '../../v5/applyV5State'
 import {
@@ -3621,13 +3622,19 @@ export function useConversation(): UseConversationReturn {
             // UI additionally caps rendering at 3 in SuggestedChips (ruled
             // doctrine D-K, closed 15 Jul: 0-3 chips, no fabricated filler).
             // action_type when present drives deterministic routing on next click.
-            const actionChips: ActionChip[] = target.response.suggested_actions.map((a) => ({
-              id: a.id,
-              label: a.label,
-              intent: 'primary',
-              message: a.message,
-              ...(a.action_type ? { action_type: a.action_type } : {}),
-            }))
+            //
+            // F4 (single confirm owner): on a held-proposal turn the held card
+            // (V5HeldProposalBlock, from mappedBlocks above) is the SOLE owner
+            // of the confirm/decline affordance it resolves via
+            // confirm_action_id / decline_action_id. buildSuggestedActionChips
+            // drops exactly those consumed ids from the generic chip row so the
+            // user sees the confirm once — keyed on the block's referenced ids,
+            // never on action_type. Off the held-proposal path the chip row is
+            // unchanged (no held_proposal block ⇒ nothing suppressed).
+            const actionChips: ActionChip[] = buildSuggestedActionChips(
+              target.response.blocks,
+              target.response.suggested_actions,
+            )
             // ROADMAP 1.42 (Show-reasoning progressive disclosure — verbatim,
             // labelled): CEE MAY carry a top-level `_reasoning` string. At the
             // pinned schema (0.13.1) this unknown key is auto-demoted by the

--- a/src/v5/blocks/__tests__/suggestedActionChips.test.ts
+++ b/src/v5/blocks/__tests__/suggestedActionChips.test.ts
@@ -1,0 +1,188 @@
+/**
+ * F4 — the held-proposal confirm affordance has a SINGLE owner (the card),
+ * so the generic suggested-action chip row must NOT re-render the action(s) a
+ * held_proposal block on the same turn consumes.
+ *
+ * These pins build fixtures from the REAL wire → parseV5Response path (NOT
+ * hand-built ConversationBlock objects), so the suppression keys on the same
+ * ids the mapper resolves. Fixture shape mirrors the probe / the schema's own
+ * held-proposal capture (blocks.ts §HeldProposalBlock evidence): ONE
+ * held_proposal block whose confirm_action_id (and optional decline_action_id)
+ * reference top-level suggested_actions, plus the legacy diagnostic
+ * `type:"error"` / `severity:"warn"` block that rides the same turn.
+ *
+ * The whole-render "confirm renders exactly once" pin (both surfaces mounted in
+ * one tree) lives in
+ *   src/canvas/conversation/__tests__/heldProposalSingleConfirmOwner.spec.tsx
+ * — it cannot live here because importing the conversation render graph would
+ * drag ~1000 pre-existing errors into the narrow tsconfig.ci.json typecheck.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { parseV5Response } from '../../responseParser'
+import type { OlumiResponseWithExtensions } from '../../responseParser'
+import { mapV5Block } from '../mapV5Blocks'
+import {
+  heldProposalConsumedActionIds,
+  buildSuggestedActionChips,
+} from '../suggestedActionChips'
+
+// ── Wire fixtures (real parse path) ────────────────────────────────────
+
+const CONFIRM_ID = 'gmh_7576c3fbaf58'
+const DECLINE_ID = 'gmh_decline_01'
+
+/**
+ * A held-proposal turn shaped like the probe (scenario a9b32212, graph hash
+ * gmh_7576c3fbaf58): one held_proposal block referencing the ONE confirm
+ * action, the legacy warn error block riding alongside (carries NO chip), and
+ * an unrelated conversational action that MUST survive into the chip row.
+ */
+function heldTurnBody(opts: { withDecline?: boolean } = {}): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: 'I can add that, but it reshapes your model.',
+    blocks: [
+      // Legacy diagnostic error block that rides the held turn — advisory
+      // (severity 'warn'), carries NO chip. Present to prove it is not a
+      // confirm-affordance source (mapV5Block returns null for it).
+      {
+        type: 'error',
+        error_code: 'INTERNAL_ERROR',
+        severity: 'warn',
+        details: { source: 'graph_management', verdict: 'held', candidate_id: 'cand_99' },
+      },
+      {
+        type: 'held_proposal',
+        proposal_id: CONFIRM_ID,
+        summary: 'Add a "regulatory delay" risk feeding into Launch on time',
+        mutation_class: 'structural',
+        reason_code: 'STRUCTURAL_APPLY_HELD',
+        confirm_action_id: CONFIRM_ID,
+        ...(opts.withDecline ? { decline_action_id: DECLINE_ID } : {}),
+      },
+    ],
+    suggested_actions: [
+      // The ONE confirm chip the held block references (single-sourced).
+      { id: CONFIRM_ID, label: 'Continue with this change', message: 'Yes' },
+      ...(opts.withDecline
+        ? [{ id: DECLINE_ID, label: 'Tell me what to adjust', message: 'Let me adjust it first' }]
+        : []),
+      // An UNRELATED conversational action — never consumed by the held block,
+      // so it MUST survive into the chip row.
+      { id: 'explain_it', label: 'Explain this', message: 'Explain why this is held' },
+    ],
+    insights: [],
+    stage_indicator: 'analyse',
+  }
+}
+
+/** A plain turn with the SAME suggested_actions but NO held_proposal block. */
+function noHeldTurnBody(): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: 'Here are some options.',
+    blocks: [{ type: 'text', content: 'Some commentary.' }],
+    suggested_actions: [
+      { id: CONFIRM_ID, label: 'Continue with this change', message: 'Yes' },
+      { id: 'explain_it', label: 'Explain this', message: 'Explain why this is held' },
+    ],
+    insights: [],
+    stage_indicator: 'analyse',
+  }
+}
+
+function makeResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function parse(body: unknown): Promise<OlumiResponseWithExtensions> {
+  const result = await parseV5Response(makeResponse(body))
+  if (result.kind !== 'response') {
+    throw new Error(`expected a parsed response, got ${result.kind}`)
+  }
+  return result.response as OlumiResponseWithExtensions
+}
+
+// ── heldProposalConsumedActionIds ──────────────────────────────────────
+
+describe('heldProposalConsumedActionIds (real parse path)', () => {
+  it('collects the confirm id a held_proposal block references', async () => {
+    const response = await parse(heldTurnBody())
+    const consumed = heldProposalConsumedActionIds(response.blocks)
+    expect([...consumed]).toEqual([CONFIRM_ID])
+  })
+
+  it('collects both confirm and decline ids when the block references a decline', async () => {
+    const response = await parse(heldTurnBody({ withDecline: true }))
+    const consumed = heldProposalConsumedActionIds(response.blocks)
+    expect(consumed.has(CONFIRM_ID)).toBe(true)
+    expect(consumed.has(DECLINE_ID)).toBe(true)
+    expect(consumed.size).toBe(2)
+  })
+
+  it('is empty for a turn with no held_proposal block (fail-safe)', async () => {
+    const response = await parse(noHeldTurnBody())
+    expect(heldProposalConsumedActionIds(response.blocks).size).toBe(0)
+  })
+
+  it('tolerates undefined / null blocks without throwing', () => {
+    expect(heldProposalConsumedActionIds(undefined).size).toBe(0)
+    expect(heldProposalConsumedActionIds(null as never).size).toBe(0)
+  })
+})
+
+// ── buildSuggestedActionChips ──────────────────────────────────────────
+
+describe('buildSuggestedActionChips (real parse path) — F4 single confirm owner', () => {
+  it('drops the confirm action the held card owns, keeping unrelated chips', async () => {
+    const response = await parse(heldTurnBody())
+
+    // The card genuinely resolves + owns the confirm (mapper renders it).
+    const card = mapV5Block(response.blocks[1], response.suggested_actions)
+    expect(card).toMatchObject({ type: 'v5_held_proposal', confirm: { label: 'Continue with this change' } })
+
+    const chips = buildSuggestedActionChips(response.blocks, response.suggested_actions)
+    const ids = chips.map((c) => c.id)
+    expect(ids).not.toContain(CONFIRM_ID)
+    expect(ids).toEqual(['explain_it'])
+  })
+
+  it('also drops the decline action when the card renders a decline (identical handling)', async () => {
+    const response = await parse(heldTurnBody({ withDecline: true }))
+
+    const card = mapV5Block(response.blocks[1], response.suggested_actions)
+    expect(card).toMatchObject({
+      type: 'v5_held_proposal',
+      confirm: { label: 'Continue with this change' },
+      decline: { label: 'Tell me what to adjust' },
+    })
+
+    const chips = buildSuggestedActionChips(response.blocks, response.suggested_actions)
+    const ids = chips.map((c) => c.id)
+    expect(ids).not.toContain(CONFIRM_ID)
+    expect(ids).not.toContain(DECLINE_ID)
+    expect(ids).toEqual(['explain_it'])
+  })
+
+  it('fail-safe: with NO held_proposal block the chip row is unchanged', async () => {
+    const response = await parse(noHeldTurnBody())
+    const chips = buildSuggestedActionChips(response.blocks, response.suggested_actions)
+    expect(chips.map((c) => c.id)).toEqual([CONFIRM_ID, 'explain_it'])
+  })
+
+  it('maps wire fields verbatim (id/label/message) and omits absent action_type', async () => {
+    const response = await parse(noHeldTurnBody())
+    const chips = buildSuggestedActionChips(response.blocks, response.suggested_actions)
+    expect(chips[0]).toEqual({
+      id: CONFIRM_ID,
+      label: 'Continue with this change',
+      intent: 'primary',
+      message: 'Yes',
+    })
+    expect(chips[0]).not.toHaveProperty('action_type')
+  })
+})

--- a/src/v5/blocks/suggestedActionChips.ts
+++ b/src/v5/blocks/suggestedActionChips.ts
@@ -1,0 +1,85 @@
+/**
+ * suggestedActionChips — build the turn's generic suggested-action chip row
+ * from a V5 response, with the F4 single-confirm-owner rule applied.
+ *
+ * F4 (held-proposal confirm affordance renders once):
+ *   On a held-proposal turn CEE emits EXACTLY ONE confirm chip in
+ *   `suggested_actions`, and the `held_proposal` block references THAT SAME
+ *   chip by id (`confirm_action_id`, and optionally `decline_action_id`) —
+ *   single-sourced on the wire (HeldProposalBlockSchema: "This block never
+ *   embeds its own action object, so the chip is never duplicated on the
+ *   wire."). The held-proposal CARD (V5HeldProposalBlock) resolves those refs
+ *   and renders the confirm / decline buttons — it is the SINGLE OWNER of the
+ *   affordance, because it carries the mutation context the user is confirming
+ *   (mirrors the repo's C1 "single Rerun owner" doctrine).
+ *
+ *   Without this module the SAME action was ALSO emitted into the generic
+ *   `suggested_actions` chip row, so the user saw the confirm twice. We drop
+ *   from the chip row exactly the ids a held_proposal block on the SAME turn
+ *   consumes — keyed on the REFERENCED ids, never on `action_type`: other
+ *   turns legitimately render chips of the same action_type, so only the exact
+ *   ids a held_proposal references may be suppressed.
+ *
+ *   Fail-safe: a turn with no held_proposal block yields an empty consumed set,
+ *   so the chip row is byte-for-byte unchanged everywhere else (zero behaviour
+ *   change off the held-proposal path). An unresolvable confirm/decline ref is
+ *   a no-op here too — the id it names is, by definition, absent from
+ *   `suggested_actions`, so filtering by it removes nothing (the same
+ *   fail-closed alignment mapV5Blocks already has when it degrades an
+ *   unresolvable held_proposal to the R7 unsupported card).
+ *
+ *   The legacy diagnostic error block that rides the held turn
+ *   (`type:"error"`, `severity:"warn"`) is NOT a chip source: mapV5Block
+ *   returns null for it, so it contributes no affordance and needs no
+ *   suppression here.
+ */
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+import type { ActionChip } from '../../canvas/conversation/types'
+
+type V5Block = OlumiResponse['blocks'][number]
+type SuggestedActionRef = OlumiResponse['suggested_actions'][number]
+
+/**
+ * Ids of top-level `suggested_actions` that held_proposal blocks on this turn
+ * consume as their confirm / decline affordance. The held-proposal CARD owns
+ * those affordances, so the generic chip row must not also render them.
+ *
+ * Empty when the turn carries no held_proposal block (the fail-safe path).
+ */
+export function heldProposalConsumedActionIds(
+  blocks: readonly V5Block[] = [],
+): ReadonlySet<string> {
+  const consumed = new Set<string>()
+  const list = Array.isArray(blocks) ? blocks : []
+  for (const block of list) {
+    if (block.type !== 'held_proposal') continue
+    consumed.add(block.confirm_action_id)
+    if (block.decline_action_id) consumed.add(block.decline_action_id)
+  }
+  return consumed
+}
+
+/**
+ * Map a V5 response's top-level `suggested_actions[]` to the UI `ActionChip[]`
+ * that the SuggestedChips row renders, excluding any action a held_proposal
+ * block on the same turn already owns (F4 single confirm owner). SuggestedChips
+ * additionally caps rendering at 3 (ruled doctrine D-K); this function does not
+ * cap — it only maps and applies the ownership filter.
+ */
+export function buildSuggestedActionChips(
+  blocks: readonly V5Block[] = [],
+  suggestedActions: readonly SuggestedActionRef[] = [],
+): ActionChip[] {
+  const consumed = heldProposalConsumedActionIds(blocks)
+  const actions = Array.isArray(suggestedActions) ? suggestedActions : []
+  return actions
+    .filter((a) => !consumed.has(a.id))
+    .map((a) => ({
+      id: a.id,
+      label: a.label,
+      intent: 'primary' as const,
+      message: a.message,
+      ...(a.action_type ? { action_type: a.action_type } : {}),
+    }))
+}


### PR DESCRIPTION
## Diagnosis (which surfaces doubled)

On a held-proposal turn CEE emits **exactly one** confirm chip in `suggested_actions`; the `held_proposal` block references THAT SAME chip via `confirm_action_id` (single-sourced on the wire — `HeldProposalBlockSchema`: "This block never embeds its own action object, so the chip is never duplicated on the wire"). The user-visible doubled confirm was a **UI render duplicate** across two surfaces:

1. **The held-proposal card** — `V5HeldProposalBlock` (`src/v5/blocks/V5HeldProposalBlock.tsx`) renders a confirm button whose `{label, message}` is resolved from `confirm_action_id` by `mapV5Blocks.ts` (`suggestedActions.find(a => a.id === block.confirm_action_id)`). Testid `v5-held-proposal-confirm`.
2. **The generic suggested-action chip row** — `SuggestedChips.tsx`, fed by `useConversation.ts`, which mapped **every** `suggested_actions` entry into `actionChips` — including the one the card already consumes. Testid `suggested-chip-<id>`.

Both surfaces rendered a control carrying the **same** confirm label / same action id on one turn → the doubled affordance.

**Third surface ruled OUT:** the legacy diagnostic `type:"error"` / `severity:"warn"` block that rides the held turn (probe: different `candidate_id`, carries no chip) is a **non-contributor** — `mapV5Block` returns `null` for error blocks, so it renders nothing in the chat surface. No suppression needed there. (`routeV5Response` keeps the turn classified as `blocks` because the error is advisory `warn`, not fatal `error`.)

Probe reference: scenario `a9b32212`, graph hash `gmh_7576c3fbaf58`.

## Ownership rule

The held-proposal **card is the single owner** of the confirm/decline affordance it consumes (it carries the mutation context the user is confirming) — mirroring the repo's C1 "single Rerun owner" doctrine.

New `src/v5/blocks/suggestedActionChips.ts` (`buildSuggestedActionChips`) drops from the chip row exactly the ids a `held_proposal` block on the same turn references via `confirm_action_id` / `decline_action_id`. `useConversation.ts` now builds `actionChips` through it.

- **Keyed on the block's referenced ids, NOT on `action_type`** — other turns legitimately render chips of the same action_type, so only the exact ids a held_proposal consumes are dropped.
- **Decline handled identically** when the card renders one.

## Fail-safe

A turn with **no** `held_proposal` block yields an empty consumed set ⇒ nothing suppressed ⇒ the chip row is byte-identical to today. Zero behaviour change off the held-proposal path. An unresolvable confirm/decline ref is a no-op too: the id it names is (by definition) absent from `suggested_actions`, so filtering by it removes nothing — the same fail-closed alignment `mapV5Blocks` already has.

Out of scope (untouched): confirm label length/truncation (producer-side wave-2 ask); no restyling.

## RED → GREEN evidence

Fixtures are built from the **real** wire → `parseV5Response` → `mapV5Blocks` path (not hand-built blocks). The whole-render pin mounts **both** surfaces in one tree and counts confirm/decline controls tree-wide (the `collectRerunControls` "match by accessible name, whole-tree" style).

**RED** (ownership filter reverted — the documented pre-fix duplicate):
```
× heldProposalSingleConfirmOwner … renders the confirm affordance EXACTLY ONCE …
  → expected [ <button …>, …(1) ] to have a length of 1 but got 2
× heldProposalSingleConfirmOwner … handles the decline affordance identically …
  → expected [ <button …>, …(1) ] to have a length of 1 but got 2
× suggestedActionChips … drops the confirm action the held card owns …
  → expected [ 'gmh_7576c3fbaf58', 'explain_it' ] to not include 'gmh_7576c3fbaf58'
× suggestedActionChips … also drops the decline action …
  → expected [ 'gmh_7576c3fbaf58', …(2) ] to not include 'gmh_7576c3fbaf58'
✓ fail-safe: NO held_proposal block renders the chip row unchanged   (stays green)
```

**GREEN** (fix in place):
```
✓ heldProposalSingleConfirmOwner  (3 tests)   — confirm renders once, owner = card; decline once; fail-safe
✓ suggestedActionChips            (8 tests)   — consumed-id collection, suppression, fail-safe, verbatim mapping
Test Files  2 passed (2)   Tests  11 passed (11)
```

## Gate results

- **Touched + adjacent suites:** 101 passed (new suites + `SuggestedChips` ×3, `V5HeldProposalBlock`, `mapV5Blocks.heldProposal`/`.holds0150`); key `useConversation` suites 94 passed / 22 pre-existing skips; full `src/v5` tree 46 files / 669 tests pass.
- **Narrow CI typecheck** (`tsc -p tsconfig.ci.json`): exit 0, clean.
- **App typecheck** (`tsc -p tsconfig.app.json --noEmit`) new-vs-base: **zero net new** — 2322 errors on base and branch, per-file counts identical; new files contribute 0.

## Files
- `src/v5/blocks/suggestedActionChips.ts` (new — helper: `heldProposalConsumedActionIds`, `buildSuggestedActionChips`)
- `src/canvas/conversation/useConversation.ts` (build `actionChips` via the helper)
- `src/v5/blocks/__tests__/suggestedActionChips.test.ts` (new — unit pins, real parse path)
- `src/canvas/conversation/__tests__/heldProposalSingleConfirmOwner.spec.tsx` (new — whole-render RED→GREEN pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
