### PR TITLE
fix(f2b): what-changed send fires on every click — server owns freshness honesty

### DIFF
--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -21,6 +21,17 @@
  * (useOptionalConversationContext() === null), the send is simply skipped and
  * the chip degrades to today's pulse-only behaviour — never a broken chip.
  *
+ * F2 CHANGE B follow-up (2026-07-22) — the CEE send fires UNCONDITIONALLY, on
+ * every click. #423 wired it inside the click handler, but the handler only
+ * existed when a LOCAL delta was available (both snapshots present AND a
+ * non-empty diff), so identical runs / missing snapshots self-hid the chip and
+ * the send was unreachable — a catch-22, since the SERVER (not this device)
+ * owns freshness/mode honesty (compared / insufficient_runs / stale /
+ * unconfirmed / incomparable). So: the chip renders and sends whenever there is
+ * a previous run to reference; only the canvas pulse stays gated on local-diff
+ * availability, and the resting accessible name is the ACTION ("What changed?"),
+ * never a disability claim.
+ *
  * Click pulses the added+modified elements via pulseAppliedTargets (same
  * 2s ring as applied AI edits). Removed elements no longer exist on the
  * canvas and are excluded — the pulse util would filter them fail-closed
@@ -125,46 +136,71 @@ export function WhatChangedChip() {
   // skipped and only the canvas pulse fires. Hook is read unconditionally
   // (before the early returns below) to keep hook order stable.
   const dispatchAction = useOptionalConversationContext()?.dispatchAction
+  // No PREVIOUS run at all → there is no "last run" to compare and nothing for
+  // the server to compare either; the chip's whole premise is absent. This is
+  // the "no comparison target" boundary, NOT a local-diff-unavailable state.
   if (runs.length < 2) return null
 
   const [latest, previous] = runs // newest-first per loadRuns()'s sort
-  // A run without a graph snapshot (legacy pre-v1.2 entries) is
-  // NON-COMPARABLE, not empty — diffing against [] would fabricate an
-  // "everything added/removed" delta. Same rule as computeRunSummary's
-  // "Snapshot unavailable" precedent: hide instead.
-  if (!latest.graph || !previous.graph) return null
-  const diff = computeGraphDiff(
-    latest.graph.nodes ?? [],
-    latest.graph.edges ?? [],
-    previous.graph.nodes ?? [],
-    previous.graph.edges ?? []
-  )
+  // LOCAL structural diff — only computable when BOTH runs carry an alignable
+  // graph snapshot. A run without one (legacy pre-v1.2 entries) is
+  // NON-COMPARABLE locally, not empty — diffing against [] would fabricate an
+  // "everything added/removed" delta, so we compute NOTHING and treat the
+  // local highlight as unavailable (same rule as computeRunSummary's
+  // "Snapshot unavailable" precedent). The SERVER can still answer the
+  // outcome delta, so the chip stays actionable regardless.
+  const diff =
+    latest.graph && previous.graph
+      ? computeGraphDiff(
+          latest.graph.nodes ?? [],
+          latest.graph.edges ?? [],
+          previous.graph.nodes ?? [],
+          previous.graph.edges ?? []
+        )
+      : null
 
-  const parts = [formatCounts('Nodes', diff.nodes), formatCounts('Edges', diff.edges)].filter(
-    (p): p is string => p !== null
-  )
-  if (parts.length === 0) return null
+  const parts = diff
+    ? [formatCounts('Nodes', diff.nodes), formatCounts('Edges', diff.edges)].filter(
+        (p): p is string => p !== null
+      )
+    : []
+
+  // F2 CHANGE B follow-up (2026-07-22): the LOCAL-diff availability gate no
+  // longer decides whether the chip renders — it only decides whether the
+  // canvas pulse can fire. The pulse needs an alignable local pair AND a
+  // non-empty delta descriptor to highlight anything ("pulse-when-computable").
+  // A zero-delta pair (identical runs) or a missing snapshot yields no local
+  // highlight — but the chip is still actionable and the CEE send still fires.
+  const localHighlightAvailable = diff !== null && parts.length > 0
 
   const handleClick = () => {
-    // (1) STRUCTURAL answer — the canvas pulse STAYS (F2 CHANGE B: augment).
+    // (1) STRUCTURAL answer — the canvas pulse, GATED on local-diff
+    // availability. It needs an alignable local pair to highlight anything, so
+    // it fires only when a delta is computable; a zero-delta / missing-snapshot
+    // click simply skips it (never crashes).
     // F4 (graph-visuals): fit-before-pulse lives at the pulse choke point —
     // appliedEditPulse's flush fits every surviving target into view before
     // the ring fires, for EVERY feeder (applyPatch, applyV5State, this chip).
     // A chip-local fit on top would double the camera move, so the chip
     // delegates. Removed elements are gone from the canvas — only surviving
     // changes can be highlighted (the flush filters fail-closed anyway).
-    pulseAppliedTargets({
-      nodeIds: [...diff.nodes.added, ...diff.nodes.modified],
-      edgeIds: [...diff.edges.added, ...diff.edges.modified],
-    })
+    if (localHighlightAvailable) {
+      pulseAppliedTargets({
+        nodeIds: [...diff.nodes.added, ...diff.nodes.modified],
+        edgeIds: [...diff.edges.added, ...diff.edges.modified],
+      })
+    }
 
-    // (2) OUTCOME answer — ADDITIONALLY dispatch a real CEE turn through the
-    // existing chip dispatch mechanism (dispatchAction → buildChipMeta →
-    // buildV5Payload). The send gate promotes source to 'chip_click' because
-    // 'what_changed' now passes isSendableActionType; the payload is not built
-    // here. The answer renders in the conversation panel via the normal turn
-    // flow (no new render surface). FAIL-SAFE: when dispatchAction is absent
-    // (no conversation hook), the structural pulse above is the whole story.
+    // (2) OUTCOME answer — the CEE send fires on EVERY click, UNCONDITIONALLY.
+    // The SERVER owns freshness/mode honesty: its four-way gate answers
+    // compared / insufficient_runs / stale / unconfirmed / incomparable
+    // honestly (F2B byte-confirm §3). Gating the send on the LOCAL diff would
+    // hide the honest server answer behind a device-side heuristic — the exact
+    // catch-22 this fixes. Dispatch goes through the existing chip mechanism
+    // (dispatchAction → buildChipMeta → buildV5Payload); the send gate promotes
+    // source to 'chip_click' because 'what_changed' passes isSendableActionType
+    // — the payload is not built here. FAIL-SAFE: when dispatchAction is absent
+    // (no conversation hook), the click is a no-op beyond the optional pulse.
     if (dispatchAction) {
       void dispatchAction({
         action_type: 'what_changed',
@@ -172,11 +208,22 @@ export function WhatChangedChip() {
         message: WHAT_CHANGED_CHIP_MESSAGE,
         source: 'chip',
       }).catch(() => {
-        // The pulse has already fired; a failed CEE send must never break the
-        // chip. The conversation panel surfaces its own send-failure notice.
+        // A failed CEE send must never break the chip. The conversation panel
+        // surfaces its own send-failure notice.
       })
     }
   }
+
+  // Label + accessible name. With the send always available the chip is always
+  // actionable, so the resting state names the ACTION ("What changed?"), never
+  // a disability claim. When a local delta IS computable we additionally show
+  // the counts and name the highlight it will pulse.
+  const label = localHighlightAvailable
+    ? `Since your last run: ${parts.join(' • ')}`
+    : 'What changed?'
+  const ariaLabel = localHighlightAvailable
+    ? `Since your last run: ${parts.join(', ')}. Highlight the changes on the canvas.`
+    : 'What changed?'
 
   return (
     <span className="inline-flex flex-col items-start gap-0.5">
@@ -190,12 +237,12 @@ export function WhatChangedChip() {
         'font-medium cursor-pointer hover:border-info/50 hover:underline',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-info',
       ].join(' ')}
-      aria-label={`Since your last run: ${parts.join(', ')}. Highlight the changes on the canvas.`}
+      aria-label={ariaLabel}
       title="Compared with the previous analysis stored on this device"
       data-testid="what-changed-chip"
     >
       <GitCompareArrows size={14} className="text-info flex-none" aria-hidden="true" />
-      <span>Since your last run: {parts.join(' • ')}</span>
+      <span>{label}</span>
     </button>
     {/* Paul's ruling 2026-07-12 (keep + improve): the comparison basis is a
         VISIBLE label, never tooltip-only — this is a device-local diff of

--- a/src/canvas/components/__tests__/WhatChangedChip.sendUnconditional.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.sendUnconditional.spec.tsx
@@ -1,0 +1,208 @@
+/**
+ * WhatChangedChip — F2 CHANGE B follow-up: the CEE send fires on EVERY click,
+ * UNCONDITIONALLY (server owns freshness/mode honesty).
+ *
+ * The catch-22 this fixes: #423 wired the send inside the click handler, but the
+ * click handler only exists when the chip renders its button, and the chip only
+ * rendered when a LOCAL structural diff was available (both runs carry an
+ * alignable graph snapshot AND the delta is non-empty). So in the two live
+ * failure states —
+ *   • two SAME-graph runs  → zero local delta (parts.length === 0), and
+ *   • two runs where a snapshot is missing → non-comparable (!graph),
+ * — the chip self-hid, the button never rendered, and clicking fired NOTHING:
+ * no wire request AND no pulse. Yet the CEE contract is proven live (a typed
+ * what_changed chip_click returns a real compared-mode answer), so the send was
+ * unreachable behind the LOCAL-diff availability gate.
+ *
+ * Ruling (2026-07-22): the SERVER owns freshness/mode honesty (its four-way gate
+ * answers compared / insufficient_runs / stale / unconfirmed / incomparable).
+ * Therefore:
+ *   1. the CEE send fires on every click, unconditionally;
+ *   2. the canvas pulse STAYS gated on local-diff availability (it needs an
+ *      alignable local pair to highlight anything);
+ *   3. the resting accessible name is the ACTION ("What changed?"), never a
+ *      disability claim.
+ *
+ * These specs are RED-first: written to assert the corrected behaviour, run
+ * against the unfixed component (where the dispatch never fires because the chip
+ * self-hides), then GREEN after the gate is lifted off the send.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+
+const { loadRunsMock, pulseMock, ctxMock } = vi.hoisted(() => ({
+  loadRunsMock: vi.fn(),
+  pulseMock: vi.fn(),
+  ctxMock: vi.fn(),
+}))
+vi.mock('../../store/runHistory', () => ({ loadRuns: loadRunsMock }))
+vi.mock('../../utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
+}))
+vi.mock('../../conversation/ConversationContext', () => ({
+  useOptionalConversationContext: ctxMock,
+}))
+
+import { WhatChangedChip, WHAT_CHANGED_CHIP_MESSAGE } from '../WhatChangedChip'
+
+const node = (id: string, label: string): Node =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label } }) as Node
+const edge = (id: string, weight: number): Edge =>
+  ({ id, source: 'a', target: 'b', data: { weight, belief: 0.7 } }) as Edge
+
+let runSeq = 0
+const run = (graph?: { nodes: Node[]; edges: Edge[] }) => ({
+  id: `run-${++runSeq}`,
+  ts: 1000 - runSeq,
+  ...(graph ? { graph } : {}),
+})
+
+/** Two runs whose graphs are IDENTICAL → zero local delta (the live
+ * "two same-graph runs" failure). Local highlight unavailable; server can
+ * still answer. */
+function seedIdenticalRuns() {
+  const g = { nodes: [node('a', 'A')], edges: [edge('e1', 0.5)] }
+  loadRunsMock.mockReturnValue([run(g), run(g)])
+}
+
+/** Two runs where the PREVIOUS one predates graph snapshots → non-comparable
+ * locally (the live "two different-graph runs / no alignable snapshot"
+ * failure). Local highlight unavailable; server can still answer. */
+function seedMissingSnapshot() {
+  loadRunsMock.mockReturnValue([
+    run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }),
+    run(), // legacy run, no graph snapshot
+  ])
+}
+
+/** A real delta (added node + modified edge) → local highlight IS available. */
+function seedRunsWithDelta() {
+  loadRunsMock.mockReturnValue([
+    run({ nodes: [node('a', 'A'), node('c', 'C')], edges: [edge('e1', 0.9)] }),
+    run({ nodes: [node('a', 'A')], edges: [edge('e1', 0.5)] }),
+  ])
+}
+
+const EXPECTED_DISPATCH = {
+  action_type: 'what_changed',
+  label: WHAT_CHANGED_CHIP_MESSAGE,
+  message: 'What changed since the last run?',
+  source: 'chip',
+}
+
+beforeEach(() => {
+  loadRunsMock.mockReset()
+  pulseMock.mockReset()
+  ctxMock.mockReset()
+})
+afterEach(() => cleanup())
+
+describe('WhatChangedChip — the CEE send fires on every click, unconditionally', () => {
+  it('LOCAL DIFF UNAVAILABLE (identical runs): the chip is still actionable and the send fires — pulse does NOT', () => {
+    // RED against the unfixed component: the chip self-hides (parts.length === 0
+    // → return null), so getByTestId throws and the dispatch never fires. This
+    // is exactly the live catch-22: no wire request, no pulse.
+    const dispatchMock = vi.fn().mockResolvedValue(undefined)
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    seedIdenticalRuns()
+
+    render(<WhatChangedChip />)
+    fireEvent.click(screen.getByTestId('what-changed-chip'))
+
+    // The send fired — the server owns the honest answer (compared / stale /
+    // incomparable / insufficient_runs), NOT this local gate.
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(dispatchMock).toHaveBeenCalledWith(EXPECTED_DISPATCH)
+    // The pulse stays gated on local-diff availability: nothing alignable to
+    // highlight, so it must NOT fire (and must not crash).
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('LOCAL DIFF UNAVAILABLE (missing snapshot): the chip is still actionable and the send fires — pulse does NOT', () => {
+    const dispatchMock = vi.fn().mockResolvedValue(undefined)
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    seedMissingSnapshot()
+
+    render(<WhatChangedChip />)
+    fireEvent.click(screen.getByTestId('what-changed-chip'))
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(dispatchMock).toHaveBeenCalledWith(EXPECTED_DISPATCH)
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('LOCAL DIFF AVAILABLE (real delta): BOTH the send AND the pulse fire', () => {
+    const dispatchMock = vi.fn().mockResolvedValue(undefined)
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    seedRunsWithDelta()
+
+    render(<WhatChangedChip />)
+    fireEvent.click(screen.getByTestId('what-changed-chip'))
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(dispatchMock).toHaveBeenCalledWith(EXPECTED_DISPATCH)
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT hand-build a chip_click source in the unavailable state — it passes chip and lets the gate promote', () => {
+    const dispatchMock = vi.fn().mockResolvedValue(undefined)
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    seedIdenticalRuns()
+
+    render(<WhatChangedChip />)
+    fireEvent.click(screen.getByTestId('what-changed-chip'))
+
+    expect(dispatchMock.mock.calls[0][0].source).toBe('chip')
+  })
+})
+
+describe('WhatChangedChip — resting accessible name is the action, not a disability claim', () => {
+  it('names the ACTION "What changed?" when no local highlight is available', () => {
+    ctxMock.mockReturnValue({ dispatchAction: vi.fn().mockResolvedValue(undefined) })
+    seedIdenticalRuns()
+
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    // The accessible name is the action — never "(not available for this run)".
+    expect(chip).toHaveAccessibleName('What changed?')
+    expect(chip.getAttribute('aria-label') ?? '').not.toMatch(/not available/i)
+    expect(chip.textContent).not.toMatch(/not available/i)
+  })
+
+  it('does NOT fabricate a local delta count when a snapshot is missing', () => {
+    ctxMock.mockReturnValue({ dispatchAction: vi.fn().mockResolvedValue(undefined) })
+    seedMissingSnapshot()
+
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    // Anti-fabrication contract from #423 survives: no everything-added "+N".
+    expect(chip.textContent).not.toMatch(/[+~-]\d/)
+    expect(chip.textContent).toMatch(/what changed\?/i)
+  })
+})
+
+describe('WhatChangedChip — FAIL-SAFE holds in the unavailable state too', () => {
+  it('no conversation hook: click does not throw, no dispatch, no pulse', () => {
+    ctxMock.mockReturnValue(null)
+    seedIdenticalRuns()
+
+    render(<WhatChangedChip />)
+    expect(() => fireEvent.click(screen.getByTestId('what-changed-chip'))).not.toThrow()
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('a rejected send in the unavailable state does not break the chip', () => {
+    const dispatchMock = vi.fn().mockRejectedValue(new Error('transport'))
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    seedIdenticalRuns()
+
+    render(<WhatChangedChip />)
+    expect(() => fireEvent.click(screen.getByTestId('what-changed-chip'))).not.toThrow()
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
@@ -16,8 +16,13 @@
  *   every node modified on every run).
  * - Copy is honest about the client-side cached-run basis ("since your last
  *   run") — the engine-backed delta is a later contract (ROADMAP 2.1).
- * - Hidden entirely (<2 runs, or zero delta). Ignores the LIVE canvas —
- *   the delta is between analyses, not live edits.
+ * - Hidden entirely only when there is NO previous run to reference (<2 runs).
+ *   When a previous run exists but the LOCAL diff is unavailable (identical
+ *   runs / a missing snapshot), the chip STAYS actionable (its CEE send fires
+ *   unconditionally — the server owns freshness honesty; see
+ *   WhatChangedChip.sendUnconditional.spec.tsx) and only the canvas pulse is
+ *   gated on local-diff availability. Ignores the LIVE canvas — the delta is
+ *   between analyses, not live edits.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
@@ -67,38 +72,55 @@ describe('WhatChangedChip — visibility', () => {
     expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
   })
 
-  it('renders nothing when the last two runs are identical', () => {
+  it('STAYS actionable when the last two runs are identical — no local delta, so no pulse, but the chip renders', () => {
+    // Pre-fix this self-hid (zero delta → return null), stranding the CEE send
+    // behind the local-diff gate. The send now fires unconditionally, so the
+    // chip must render; only the pulse is gated (nothing to highlight).
     const g = { nodes: [node('a', 'A')], edges: [edge('e1', 0.5)] }
     loadRunsMock.mockReturnValue([run(g), run(g)])
     render(<WhatChangedChip />)
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    fireEvent.click(chip)
+    expect(pulseMock).not.toHaveBeenCalled()
   })
 
-  it('renders nothing when a run lacks a graph snapshot (older stored runs)', () => {
+  it('STAYS actionable when a run lacks a graph snapshot (older stored runs) — no pulse', () => {
     loadRunsMock.mockReturnValue([
       { id: 'r-nograph-1', ts: 2 },
       { id: 'r-nograph-2', ts: 1 },
     ])
     render(<WhatChangedChip />)
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    fireEvent.click(chip)
+    expect(pulseMock).not.toHaveBeenCalled()
   })
 
-  it('hides on a SINGLE-SIDED missing snapshot — never fabricates an everything-added delta', () => {
+  it('a SINGLE-SIDED missing snapshot stays actionable but NEVER fabricates an everything-added delta', () => {
     loadRunsMock.mockReturnValue([
       run({ nodes: [node('a', 'A'), node('b', 'B')], edges: [] }), // latest has a graph
       { id: 'r-legacy', ts: 1 }, // previous predates v1.2 snapshots
     ])
     render(<WhatChangedChip />)
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    const chip = screen.getByTestId('what-changed-chip')
+    // Anti-fabrication contract preserved: no "+2 nodes" conjured from []-diff.
+    expect(chip.textContent).not.toMatch(/[+~-]\d/)
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    fireEvent.click(chip)
+    expect(pulseMock).not.toHaveBeenCalled()
   })
 
-  it('hides when only the LATEST run lacks a snapshot (reverse single-sided case)', () => {
+  it('stays actionable but pulses nothing when only the LATEST run lacks a snapshot (reverse single-sided case)', () => {
     loadRunsMock.mockReturnValue([
       { id: 'r-legacy', ts: 2 },
       run({ nodes: [node('a', 'A')], edges: [] }),
     ])
     render(<WhatChangedChip />)
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).not.toMatch(/[+~-]\d/)
+    fireEvent.click(chip)
+    expect(pulseMock).not.toHaveBeenCalled()
   })
 })
 
@@ -128,13 +150,19 @@ describe('WhatChangedChip — diffs the last two runs (newest-first order)', () 
     expect(screen.getByTestId('what-changed-chip').textContent).toMatch(/Nodes: \+1, -1, ~1/)
   })
 
-  it('position-only moves are NOT counted as modified (layout is not an analytical delta)', () => {
+  it('position-only moves are NOT counted as modified (layout is not an analytical delta) — chip stays actionable, no count, no pulse', () => {
     loadRunsMock.mockReturnValue([
       run({ nodes: [node('a', 'A', 500, 500)], edges: [] }),
       run({ nodes: [node('a', 'A', 0, 0)], edges: [] }),
     ])
     render(<WhatChangedChip />)
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    const chip = screen.getByTestId('what-changed-chip')
+    // A layout-only move yields a zero analytical delta: no count shown, and
+    // no pulse — but the chip is still actionable (the CEE send is unblocked).
+    expect(chip.textContent).not.toMatch(/[+~-]\d/)
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    fireEvent.click(chip)
+    expect(pulseMock).not.toHaveBeenCalled()
   })
 
   it('counts edge weight/belief changes as modified', () => {

--- a/src/components/results/__tests__/ResultsBody.whatChanged.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.whatChanged.spec.tsx
@@ -2,9 +2,13 @@
  * ResultsBody — WhatChangedChip mount (seamlessness R6 / ROADMAP 2.1 slice 1).
  *
  * The run-delta chip mounts in the analysis-tab header stack, after the
- * freshness notice slot and above the hero block. It self-hides (<2 stored
- * runs or zero delta), so mounting it must be a no-op for first runs.
- * Fixture pattern mirrors ResultsBody.heroPlacement.spec.tsx.
+ * freshness notice slot and above the hero block. It self-hides only when
+ * there is no previous run to reference (<2 stored runs); once a previous run
+ * exists it STAYS mounted and actionable even with a zero local delta, because
+ * its CEE send fires unconditionally (the server owns freshness honesty — see
+ * WhatChangedChip.sendUnconditional.spec.tsx). Only the canvas pulse is gated
+ * on local-diff availability. Fixture pattern mirrors
+ * ResultsBody.heroPlacement.spec.tsx.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
@@ -156,10 +160,15 @@ describe('ResultsBody — WhatChangedChip mount (R6)', () => {
     expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
   })
 
-  it('renders no chip when nothing changed between runs', () => {
+  it('KEEPS the chip mounted and actionable when nothing changed between runs (send is unconditional; only the pulse is gated)', () => {
     const same = [nodeFx('a', 'A')]
     loadRunsMock.mockReturnValue([runFx(same, 1), runFx(same, 2)])
     renderBody()
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    // A previous run exists, so the chip stays actionable even at zero local
+    // delta — its resting name is the ACTION, not a "(not available)" claim.
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    const existingHero = screen.getByTestId('decision-confidence-panel')
+    expect(before(chip, existingHero), 'chip must precede the hero block').toBe(true)
   })
 })


### PR DESCRIPTION
## The catch-22 (live evidence)

#423 landed the WhatChangedChip's typed `what_changed` CEE send, but wired it **inside the click handler** — and the click handler only exists when the chip renders its `<button>`. The chip only rendered when a **local** structural diff was available (both runs carry an alignable graph snapshot **and** the delta is non-empty). So the new send sat *behind* the legacy local-diff availability gate:

- **Two same-graph runs** → `parts.length === 0` → `return null` → no button.
- **Two runs with a missing snapshot** → `!latest.graph || !previous.graph` → `return null` → no button.

In both states the chip showed as unavailable and **clicking fired nothing — no wire request and no pulse**. Yet the CEE contract is proven live: a typed `what_changed` `chip_click` (`source:'chip_click'`, `chip.action_type:'what_changed'`) returns a real compared-mode answer in ~2.4s deterministic (req `d63e89a9-15f5-43f5-b793-c093d0f94309`, build `4774d54`: *"Hire Permanent Tech Lead still leads. The size of its lead is essentially unchanged…"*). The send worked; it was simply unreachable.

## The blocking condition

`src/canvas/components/WhatChangedChip.tsx` — the dispatch lives in `handleClick`, reachable only past the early-returns at **line 135** (`if (!latest.graph || !previous.graph) return null`) and **line 146** (`if (parts.length === 0) return null`). Either return kills the button, so both the dispatch and the pulse are unreachable whenever the local diff is unavailable.

## Design ruling (server owns freshness honesty)

The **server** owns freshness/mode honesty — its four-way gate answers `compared / insufficient_runs / stale / unconfirmed / incomparable` honestly (F2B byte-confirm §3, verified live). A device-side local-diff heuristic must not sit in front of it.

1. **The CEE send fires on every click, unconditionally** (given a previous run to reference). The local diff is now computed to `null`/`[]` when unavailable, and the chip stays rendered and actionable.
2. **The canvas pulse stays gated on local-diff availability** — `localHighlightAvailable = diff !== null && parts.length > 0`. It needs an alignable local pair to highlight anything; pulse-when-computable.
3. **The resting accessible name is the action** (`"What changed?"`), never a `"(not available for this run)"` disability claim. When a local delta *is* computable, the counts + highlight affordance render exactly as before. British-English sentence case, no em dashes.

`runs.length < 2` still self-hides — with no previous run there is no "last run" to reference at all (the "no comparison target" boundary, distinct from "local highlight unavailable").

**Untouched** (all landed + proven in #423): `V5_ENABLED_ACTIONS`, `CEE_ACCEPTED_ACTION_TYPES`, the `@talchain/schemas` vendor, and the payload/wire path.

## RED → GREEN

New `WhatChangedChip.sendUnconditional.spec.tsx`, written RED-first.

**RED** (against the unfixed component — the chip self-hides, so the button never renders):

```
❯ WhatChangedChip.sendUnconditional.spec.tsx  (8 tests | 7 failed)
  → LOCAL DIFF UNAVAILABLE (identical runs): the chip is still actionable and the send fires — pulse does NOT
    Unable to find an element by: [data-testid="what-changed-chip"]
    Ignored nodes: comments, script, style
    <body>
      <div />
    </body>
```

The empty `<body><div /></body>` is the catch-22 made visible: no button ⇒ no dispatch, no pulse.

**GREEN** (after lifting the gate off the send):

```
✓ WhatChangedChip.sendUnconditional.spec.tsx  (8 tests)
✓ WhatChangedChip.spec.tsx                     (18 tests)
✓ WhatChangedChip.send.spec.tsx                (4 tests)   ← #423 payload pins
✓ whatChangedSend.spec.ts                      (6 tests)   ← #423 wire/mutation pins
✓ ResultsBody.whatChanged.spec.tsx             (3 tests)
✓ dispatchAction.spec.ts                       (18 tests)
Tests  57 passed
```

**Mutation check** — making the pulse unconditional (`if (localHighlightAvailable || true)`) turns **8** assertions red across the two chip specs (the "pulse does NOT fire when locally unavailable" pins), proving the pulse-gate is load-bearing. Reverted.

## Gates

- Touched + downstream suites green: 57 focused; full `src/components/results` + `src/canvas/components` sweep **6554 passed / 37 skipped / 0 failed**.
- Narrow CI typecheck (`tsconfig.ci.json`): **0** errors.
- Wide app typecheck (`tsconfig.app.json`): **2322 → 2322**, zero net new (position-normalised set diff empty).

**DO NOT MERGE** — draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
