### PR TITLE
fix(f2b): what-changed chip mounts with the analysis — server owns comparison honesty

### DIFF
--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -32,6 +32,18 @@
  * availability, and the resting accessible name is the ACTION ("What changed?"),
  * never a disability claim.
  *
+ * F2B follow-up (2026-07-22) — MOUNT decoupled from the local run count. The
+ * one surviving mount boundary (#425 kept `runs.length < 2 → return null`) was
+ * still a dead precondition: on the live guest path runHistory stays EMPTY even
+ * after several completed analyses (the resultsComplete writer records a run
+ * only when `results.seed` is set, which the conversation/V5 envelope path never
+ * sets — see store.ts resultsComplete), so the chip never mounted and the send
+ * stayed stranded. Because the SERVER owns comparison honesty, the chip now
+ * mounts and stays actionable whenever its host analysis surface (ResultsBody)
+ * renders — 0, 1, or many stored runs. Clicking always fires the typed send;
+ * CEE answers "only one run so far, nothing to compare yet" honestly when true.
+ * Local runHistory continues to gate ONLY the pulse/highlight extras.
+ *
  * Click pulses the added+modified elements via pulseAppliedTargets (same
  * 2s ring as applied AI edits). Removed elements no longer exist on the
  * canvas and are excluded — the pulse util would filter them fail-closed
@@ -136,12 +148,18 @@ export function WhatChangedChip() {
   // skipped and only the canvas pulse fires. Hook is read unconditionally
   // (before the early returns below) to keep hook order stable.
   const dispatchAction = useOptionalConversationContext()?.dispatchAction
-  // No PREVIOUS run at all → there is no "last run" to compare and nothing for
-  // the server to compare either; the chip's whole premise is absent. This is
-  // the "no comparison target" boundary, NOT a local-diff-unavailable state.
-  if (runs.length < 2) return null
-
-  const [latest, previous] = runs // newest-first per loadRuns()'s sort
+  // F2B (2026-07-22): the chip's MOUNT is decoupled from the local run count.
+  // The old `runs.length < 2 → return null` boundary stranded the CEE send
+  // behind a dead precondition — on the live guest path runHistory stays EMPTY
+  // even after completed analyses (the writer never records there), so the chip
+  // never mounted and the send was unreachable. The SERVER owns comparison
+  // honesty (its what_changed gate answers insufficient_runs / stale /
+  // unconfirmed / incomparable), so the chip renders and stays actionable
+  // whenever its host analysis surface (ResultsBody) renders — regardless of how
+  // many runs are stored locally. Only the pulse/highlight extras below stay
+  // gated on a computable local pair.
+  const latest = runs[0] // newest-first per loadRuns()'s sort; may be undefined
+  const previous = runs[1] // second-newest; undefined with < 2 stored runs
   // LOCAL structural diff — only computable when BOTH runs carry an alignable
   // graph snapshot. A run without one (legacy pre-v1.2 entries) is
   // NON-COMPARABLE locally, not empty — diffing against [] would fabricate an
@@ -150,7 +168,7 @@ export function WhatChangedChip() {
   // "Snapshot unavailable" precedent). The SERVER can still answer the
   // outcome delta, so the chip stays actionable regardless.
   const diff =
-    latest.graph && previous.graph
+    latest?.graph && previous?.graph
       ? computeGraphDiff(
           latest.graph.nodes ?? [],
           latest.graph.edges ?? [],

--- a/src/canvas/components/__tests__/WhatChangedChip.sendUnconditional.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.sendUnconditional.spec.tsx
@@ -161,6 +161,46 @@ describe('WhatChangedChip — the CEE send fires on every click, unconditionally
   })
 })
 
+describe('WhatChangedChip — F2B: mounts and sends with NO comparison pair (empty / single run history)', () => {
+  it('EMPTY run history (the live finding): the chip mounts and the typed what_changed send fires — pulse does NOT', () => {
+    // RED against the pre-F2B component: `runs.length < 2 → return null`, so the
+    // chip never renders, getByTestId throws, and the send is unreachable. This
+    // is the exact live catch-22 — completed analyses, empty runHistory, dead chip.
+    const dispatchMock = vi.fn().mockResolvedValue(undefined)
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    loadRunsMock.mockReturnValue([])
+
+    render(<WhatChangedChip />)
+    fireEvent.click(screen.getByTestId('what-changed-chip'))
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(dispatchMock).toHaveBeenCalledWith(EXPECTED_DISPATCH)
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('SINGLE stored run: the chip mounts and the typed what_changed send fires — pulse does NOT', () => {
+    const dispatchMock = vi.fn().mockResolvedValue(undefined)
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    loadRunsMock.mockReturnValue([run({ nodes: [node('a', 'A')], edges: [edge('e1', 0.5)] })])
+
+    render(<WhatChangedChip />)
+    fireEvent.click(screen.getByTestId('what-changed-chip'))
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(dispatchMock).toHaveBeenCalledWith(EXPECTED_DISPATCH)
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('EMPTY run history, no conversation hook: click is a safe no-op (fail-safe holds)', () => {
+    ctxMock.mockReturnValue(null)
+    loadRunsMock.mockReturnValue([])
+
+    render(<WhatChangedChip />)
+    expect(() => fireEvent.click(screen.getByTestId('what-changed-chip'))).not.toThrow()
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+})
+
 describe('WhatChangedChip — resting accessible name is the action, not a disability claim', () => {
   it('names the ACTION "What changed?" when no local highlight is available', () => {
     ctxMock.mockReturnValue({ dispatchAction: vi.fn().mockResolvedValue(undefined) })

--- a/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.spec.tsx
@@ -16,10 +16,12 @@
  *   every node modified on every run).
  * - Copy is honest about the client-side cached-run basis ("since your last
  *   run") — the engine-backed delta is a later contract (ROADMAP 2.1).
- * - Hidden entirely only when there is NO previous run to reference (<2 runs).
- *   When a previous run exists but the LOCAL diff is unavailable (identical
- *   runs / a missing snapshot), the chip STAYS actionable (its CEE send fires
- *   unconditionally — the server owns freshness honesty; see
+ * - F2B (2026-07-22): the chip's MOUNT is decoupled from the local run count.
+ *   It renders whenever its host analysis surface renders — even with 0 or 1
+ *   stored runs — because the SERVER owns comparison honesty (its gate answers
+ *   insufficient_runs / stale / unconfirmed / incomparable). When the LOCAL diff
+ *   is unavailable (no pair / identical runs / a missing snapshot), the chip
+ *   STAYS actionable (its CEE send fires unconditionally; see
  *   WhatChangedChip.sendUnconditional.spec.tsx) and only the canvas pulse is
  *   gated on local-diff availability. Ignores the LIVE canvas — the delta is
  *   between analyses, not live edits.
@@ -66,10 +68,29 @@ beforeEach(() => {
 afterEach(() => cleanup())
 
 describe('WhatChangedChip — visibility', () => {
-  it('renders nothing with fewer than 2 runs', () => {
+  it('F2B: mounts and stays actionable with a SINGLE stored run (no comparison pair yet — server owns honesty)', () => {
+    // Pre-F2B this self-hid (runs.length < 2 → return null), stranding the CEE
+    // send behind a dead precondition. The server answers "insufficient_runs"
+    // honestly, so the chip must render and be clickable; only the pulse is
+    // gated (no alignable pair to highlight).
     loadRunsMock.mockReturnValue([run({ nodes: [node('a', 'A')], edges: [] })])
     render(<WhatChangedChip />)
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    expect(() => fireEvent.click(chip)).not.toThrow()
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('F2B: mounts and stays actionable with an EMPTY run history (the live finding: analysis present, zero stored runs)', () => {
+    // Reproduces the deployed-build finding: a real guest session completes
+    // analyses but runHistory is EMPTY (the writer never records on the live
+    // path), so the old `runs.length < 2` boundary hid the chip entirely.
+    loadRunsMock.mockReturnValue([])
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    expect(() => fireEvent.click(chip)).not.toThrow()
+    expect(pulseMock).not.toHaveBeenCalled()
   })
 
   it('STAYS actionable when the last two runs are identical — no local delta, so no pulse, but the chip renders', () => {

--- a/src/components/results/__tests__/ResultsBody.whatChanged.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.whatChanged.spec.tsx
@@ -2,12 +2,15 @@
  * ResultsBody — WhatChangedChip mount (seamlessness R6 / ROADMAP 2.1 slice 1).
  *
  * The run-delta chip mounts in the analysis-tab header stack, after the
- * freshness notice slot and above the hero block. It self-hides only when
- * there is no previous run to reference (<2 stored runs); once a previous run
- * exists it STAYS mounted and actionable even with a zero local delta, because
- * its CEE send fires unconditionally (the server owns freshness honesty — see
- * WhatChangedChip.sendUnconditional.spec.tsx). Only the canvas pulse is gated
- * on local-diff availability. Fixture pattern mirrors
+ * freshness notice slot and above the hero block. F2B (2026-07-22): its MOUNT
+ * is decoupled from the local run count — it renders whenever THIS analysis
+ * surface (ResultsBody) renders, even with an EMPTY run history (the live
+ * finding: a real guest session's runHistory stays empty after completed
+ * analyses). It STAYS mounted and actionable because its CEE send fires
+ * unconditionally (the SERVER owns comparison honesty — its gate answers
+ * insufficient_runs / stale / unconfirmed / incomparable; see
+ * WhatChangedChip.sendUnconditional.spec.tsx). Only the canvas pulse/highlight
+ * extras are gated on local-diff availability. Fixture pattern mirrors
  * ResultsBody.heroPlacement.spec.tsx.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -154,10 +157,25 @@ describe('ResultsBody — WhatChangedChip mount (R6)', () => {
     expect(before(chip, existingHero), 'chip must precede the hero block').toBe(true)
   })
 
-  it('renders no chip on a first run (fewer than 2 stored runs)', () => {
+  it('F2B — mounts the chip when runHistory is EMPTY but the analysis surface is present (the live finding)', () => {
+    // The deployed guest build renders ResultsBody after completed analyses, yet
+    // runHistory is EMPTY (no run/history key written on the live path). Under
+    // the old `runs.length < 2` boundary the chip never mounted and the CEE send
+    // was stranded. The chip must now mount and stay actionable — the server
+    // answers "only one run so far, nothing to compare yet" honestly on click.
+    loadRunsMock.mockReturnValue([])
+    renderBody()
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/what changed\?/i)
+    const existingHero = screen.getByTestId('decision-confidence-panel')
+    expect(before(chip, existingHero), 'chip must precede the hero block').toBe(true)
+  })
+
+  it('F2B — mounts the chip on a single stored run (still no comparison pair)', () => {
     loadRunsMock.mockReturnValue([runFx([nodeFx('a', 'A')], 1)])
     renderBody()
-    expect(screen.queryByTestId('what-changed-chip')).not.toBeInTheDocument()
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.textContent).toMatch(/what changed\?/i)
   })
 
   it('KEEPS the chip mounted and actionable when nothing changed between runs (send is unconditional; only the pulse is gated)', () => {


### PR DESCRIPTION
## Problem (live finding)

On the deployed guest build the **What changed?** chip never mounts, even after several completed analyses in one document. The cause is a dead precondition: PR #425 kept **one** surviving mount boundary in `WhatChangedChip` — `runs.length < 2 → return null` — but the local `runHistory` store is **empty** in a real guest session (localStorage has no run/history key at all). So the typed `what_changed` send is stranded behind a boundary that never opens.

## Part 1 — diagnosis (why runHistory is empty): verdict (a) writer effectively dead on the live path

- `runHistory.ts` has exactly **one** writer: `addRun`, called only from the canvas store's `resultsComplete` action (`src/canvas/store.ts:3039`).
- That write is gated: `if (report && results.seed !== undefined)` (`store.ts:3038`). `results.seed` is set **only** by `resultsStart({ seed })` (`store.ts:2861`), whose only live callers are the **Run-button** paths (`useV2Run.ts:488`, `useResultsRun.ts:48`).
- The **live guest journey is conversation/V5-driven**: `useConversation.ts:2372` and `applyV5State.ts:748` call `store.resultsComplete(...)` **directly, without a preceding `resultsStart`**, so `results.seed` stays at its initial `undefined` (`store.ts:1425` initial `results: { status: 'idle', progress: 0 }`). The `addRun` block is skipped → **no run is ever recorded on the conversation/V5 path**. That is exactly the empty-history live finding.
- Not (b) guest-gated: `addRun` is a plain localStorage write with no auth check. Not (c) a fully retired store: `runHistory` is still actively read by RunHistory, Compare, ShareDrawer, palette, decisionBrief, `useEditedSinceRun`.
- **Report-only on the writer (no rewire).** A rewire is not the ratified fix and is not ≤5 lines: (1) the V5 path carries **no seed at all** (`rawV2Response: null`), so backfilling would require a seed-provenance design decision; (2) `runHistory.ts`'s file header (ANALYSIS-TAB BRIEF §19) explicitly forbids wiring this store to back a what-changed / freshness surface (\"Do not wire this in\"). The chip must not depend on the local writer — which is the point of this PR.

## Part 2 — fix (this PR): mount decoupled, server owns honesty

Under the ratified ruling (SERVER owns run-comparison honesty — its `what_changed` gate answers insufficient_runs / stale / unconfirmed / incomparable), drop the last mount boundary. The chip mounts and stays actionable whenever its host analysis surface (ResultsBody) renders — 0, 1, or many stored runs. Clicking always fires the typed `what_changed` send; CEE answers \"only one run so far, nothing to compare yet\" honestly when true. Local `runHistory` continues to gate **only** the pulse/highlight extras.

`WhatChangedChip.tsx`: remove `if (runs.length < 2) return null`; read `runs[0]`/`runs[1]` undefined-safe and guard the local diff with optional chaining. No other behaviour change — the send was already unconditional (#425); the pulse stays gated on a computable local pair.

## Tests (RED-first, mutation-checked, real-path fixtures)

RED reproduces the live finding — chip absent from the DOM with an **empty** `runHistory` while the analysis surface is present — then GREEN after the fix (chip mounts + click dispatches the typed `what_changed`). Verified RED against the unfixed component (7 new assertions failing, 27 prior pins green), GREEN after the fix.

- `ResultsBody.whatChanged.spec.tsx`: chip mounts at the real host surface with empty / single run history.
- `WhatChangedChip.sendUnconditional.spec.tsx`: empty / single run history → chip mounts + typed `what_changed` dispatch fires; fail-safe (no hook) is a safe no-op.
- `WhatChangedChip.spec.tsx`: 0 / 1 run → chip mounts, resting name \"What changed?\", no pulse, no crash.
- #425's send-unconditional / diff-order / pulse / a11y / DS pins stay green.

## Gates

- Touched suites: 44/44 chip + wiring specs green; full `src/components/results` dir 3247/3247 green.
- Narrow CI typecheck (`tsconfig.ci.json`): exit 0, 0 errors.
- Wide tsc (`tsconfig.app.json`): 2322 errors on branch == 2322 on the staging base — **zero net new**; none reference the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)