### PR TITLE
chore(guidance): delete invented signal_code/category defaults — producer now supplies truth

### DIFF
--- a/src/canvas/conversation/ActionStrip.tsx
+++ b/src/canvas/conversation/ActionStrip.tsx
@@ -140,9 +140,11 @@ export function ActionStrip({ messages, patchBlockStates, onNavigate }: ActionSt
       >
         {topGuidanceItem && (
           <>
-            <span className={CATEGORY_STYLES[topGuidanceItem.category] ?? styles.guidanceBadgeInfo}>
-              {topGuidanceItem.category.replace('_', ' ')}
-            </span>
+            {topGuidanceItem.category && (
+              <span className={CATEGORY_STYLES[topGuidanceItem.category] ?? styles.guidanceBadgeInfo}>
+                {topGuidanceItem.category.replace('_', ' ')}
+              </span>
+            )}
             <span className={styles.actionStripTitle}>
               {topGuidanceItem.title}
             </span>

--- a/src/canvas/conversation/GuidanceStrip.tsx
+++ b/src/canvas/conversation/GuidanceStrip.tsx
@@ -23,7 +23,9 @@ const FOCUS_DEBOUNCE_MS = 150
 // Category badge helpers
 // ---------------------------------------------------------------------------
 
-function categoryLabel(cat: GuidanceItem['category']): string {
+// Render helpers take a DEFINED category — the badge that calls them is
+// suppressed when the producer sent none (absent field = absent, visually too).
+function categoryLabel(cat: NonNullable<GuidanceItem['category']>): string {
   switch (cat) {
     case 'must_fix': return 'Must fix'
     case 'should_fix': return 'Should fix'
@@ -32,7 +34,7 @@ function categoryLabel(cat: GuidanceItem['category']): string {
   }
 }
 
-function categoryBadgeClass(cat: GuidanceItem['category']): string {
+function categoryBadgeClass(cat: NonNullable<GuidanceItem['category']>): string {
   switch (cat) {
     case 'must_fix': return styles.guidanceBadgeDanger
     case 'should_fix': return styles.guidanceBadgeInfo
@@ -78,6 +80,11 @@ function coachingItemType(cat: GuidanceItem['category']): GuidanceEventPayload['
     case 'could_fix':
     case 'technique':
       return 'technique_rec'
+    // Category absent (producer sent none): neutral telemetry bucket — a
+    // required enum with no "unknown" member, so this is a classification
+    // fallback for the event stream only, never user-facing copy.
+    default:
+      return 'bias_alert'
   }
 }
 
@@ -275,11 +282,13 @@ export const GuidanceStrip = memo(function GuidanceStrip({
       data-item-id={topItem.item_id}
       data-severity={topItem.category}
     >
-      {/* Category badge */}
-      <span className={`${styles.guidanceBadge} ${categoryBadgeClass(topItem.category)}`}>
-        {categoryIcon(topItem.category)}
-        <span>{categoryLabel(topItem.category)}</span>
-      </span>
+      {/* Category badge — suppressed when the producer sent no category */}
+      {topItem.category && (
+        <span className={`${styles.guidanceBadge} ${categoryBadgeClass(topItem.category)}`}>
+          {categoryIcon(topItem.category)}
+          <span>{categoryLabel(topItem.category)}</span>
+        </span>
+      )}
 
       {/* Title — truncated */}
       <span className={`${styles.guidanceStripTitle} ${typography.bodySmall}`}>

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -3422,8 +3422,10 @@ export function useConversation(): UseConversationReturn {
             if (phase3.guidanceItems.length > 0) {
               const guidance: GuidanceItem[] = phase3.guidanceItems.map((g) => ({
                 item_id: g.item_id,
-                signal_code: g.signal_code,
-                category: g.category,
+                // signal_code / category are producer-owned passthrough: carry
+                // them only when the producer supplied them, never invented.
+                ...(g.signal_code ? { signal_code: g.signal_code } : {}),
+                ...(g.category ? { category: g.category } : {}),
                 source: g.source,
                 title: g.title,
                 ...(g.detail ? { detail: g.detail } : {}),

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -29,8 +29,20 @@ export type GuidanceAction =
 
 export interface GuidanceItem {
   item_id: string
-  signal_code: string
-  category: GuidanceCategory
+  /**
+   * Producer `signal_code` VERBATIM when supplied — an OPEN, producer-owned
+   * SCREAMING_SNAKE vocabulary (never allowlisted, never rendered as user copy;
+   * data-* only). Absent when the producer sent none: the V5 derivation never
+   * invents one from the block type. V4-envelope guidance always carries it.
+   */
+  signal_code?: string
+  /**
+   * Producer four-value `category` VERBATIM when supplied; absent otherwise —
+   * the V5 derivation never defaults it. Rendering surfaces fall back to a
+   * neutral display treatment (or suppress the category badge), never a
+   * synthesised data value. V4-envelope guidance always carries it.
+   */
+  category?: GuidanceCategory
   source: GuidanceSource
   title: string
   detail?: string

--- a/src/canvas/ui/inspector/InspectorGuidanceSection.tsx
+++ b/src/canvas/ui/inspector/InspectorGuidanceSection.tsx
@@ -45,6 +45,9 @@ function cardBorderClass(category: GuidanceItem['category']): string {
     case 'could_fix':
     case 'technique':
       return 'border-l-info'
+    // Category absent (producer sent none): neutral low-urgency styling.
+    default:
+      return 'border-l-info'
   }
 }
 
@@ -55,6 +58,8 @@ function cardBgClass(category: GuidanceItem['category']): string {
       return 'bg-panel'
     case 'could_fix':
     case 'technique':
+      return 'bg-panel'
+    default:
       return 'bg-panel'
   }
 }

--- a/src/components/results/GuidanceActionItemRow.tsx
+++ b/src/components/results/GuidanceActionItemRow.tsx
@@ -47,7 +47,9 @@ const CATEGORY_CONFIG: Record<GuidanceCategory, {
 }
 
 export function GuidanceActionItemRow({ item, onActivate }: GuidanceActionItemRowProps) {
-  const config = CATEGORY_CONFIG[item.category] ?? CATEGORY_CONFIG.should_fix
+  // Category absent (producer sent none) → neutral display styling. This is a
+  // visual fallback (icon/colours), never a synthesised category value.
+  const config = (item.category ? CATEGORY_CONFIG[item.category] : undefined) ?? CATEGORY_CONFIG.should_fix
   const { icon: Icon, textColor, bgColor, borderColor } = config
 
   return (

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
@@ -513,9 +513,10 @@ describe('DecisionOverviewCard — framing-slot honesty (production leak)', () =
   it('a max-priority rerun nudge (non-interrogative detail, discuss action) never renders the framing card', () => {
     useGuidanceStore.setState({
       guidanceItems: [
-        // signal_code 'review_card' is the real derived value: extractPhase3
-        // stamps signal_code = block.type when the block carries none.
-        { item_id: 'g-rerun', signal_code: 'review_card', category: 'should_fix', source: 'analysis', title: 'Analysis may be out of date', detail: LEAKED_RERUN_SENTENCE, primary_action: { type: 'discuss', prompt: LEAKED_RERUN_SENTENCE }, priority: 99 },
+        // A guidance item derived from a block with no producer signal_code:
+        // extractPhase3 now leaves signal_code ABSENT (it never invents one
+        // from block.type). The card does not branch on signal_code.
+        { item_id: 'g-rerun', category: 'should_fix', source: 'analysis', title: 'Analysis may be out of date', detail: LEAKED_RERUN_SENTENCE, primary_action: { type: 'discuss', prompt: LEAKED_RERUN_SENTENCE }, priority: 99 },
       ],
     } as never)
     render(<DecisionOverviewCard title="t" />)
@@ -528,8 +529,8 @@ describe('DecisionOverviewCard — framing-slot honesty (production leak)', () =
   it('a genuine interrogative item wins the slot even when a rerun nudge carries higher priority', () => {
     useGuidanceStore.setState({
       guidanceItems: [
-        { item_id: 'g-rerun', signal_code: 'coaching', category: 'should_fix', source: 'analysis', title: 'Analysis may be out of date', detail: LEAKED_RERUN_SENTENCE, primary_action: { type: 'discuss', prompt: LEAKED_RERUN_SENTENCE }, priority: 99 },
-        { item_id: 'g-question', signal_code: 'review_card', category: 'should_fix', source: 'analysis', title: 'What would make option B clearly better?', primary_action: { type: 'discuss', prompt: 'p' }, priority: 40 },
+        { item_id: 'g-rerun', category: 'should_fix', source: 'analysis', title: 'Analysis may be out of date', detail: LEAKED_RERUN_SENTENCE, primary_action: { type: 'discuss', prompt: LEAKED_RERUN_SENTENCE }, priority: 99 },
+        { item_id: 'g-question', category: 'should_fix', source: 'analysis', title: 'What would make option B clearly better?', primary_action: { type: 'discuss', prompt: 'p' }, priority: 40 },
       ],
     } as never)
     render(<DecisionOverviewCard title="t" />)
@@ -543,7 +544,7 @@ describe('DecisionOverviewCard — framing-slot honesty (production leak)', () =
   it('a framing-scoped imperative item qualifies and keeps the composed question', () => {
     useGuidanceStore.setState({
       guidanceItems: [
-        { item_id: 'g-framing', signal_code: 'coaching', category: 'should_fix', source: 'analysis', title: 'Broaden the option set', primary_action: { type: 'discuss', prompt: 'p' }, priority: 50, target_object: { type: 'framing' } },
+        { item_id: 'g-framing', category: 'should_fix', source: 'analysis', title: 'Broaden the option set', primary_action: { type: 'discuss', prompt: 'p' }, priority: 50, target_object: { type: 'framing' } },
       ],
     } as never)
     render(<DecisionOverviewCard title="t" />)

--- a/src/components/results/strengthen/__tests__/producerGuidancePriority.spec.ts
+++ b/src/components/results/strengthen/__tests__/producerGuidancePriority.spec.ts
@@ -140,16 +140,36 @@ describe('deriveGuidance — consumes 0.19.0 producer fields on their own terms'
     expect(item.priorityRank).toBe(101)
   })
 
-  it('consumes producer `category` for all four canonical values; fail-closed default only on genuine absence', () => {
+  it('surfaces producer `category` verbatim for all four canonical values; absent stays absent (never invented)', () => {
     const res = extract([
       coachingBlock({ block_id: 'c-1', title: 'A', category: 'technique', priority: 30 }),
       coachingBlock({ block_id: 'c-2', title: 'B', category: 'could_fix', priority: 50 }),
-      coachingBlock({ block_id: 'c-3', title: 'C' }), // pre-0.19.0 block
+      coachingBlock({ block_id: 'c-3', title: 'C' }), // producer omitted category
     ])
+    // Passthrough: an omitted `category` stays undefined — the producer owns
+    // this field now, so the UI never invents a value. This pin doubles as the
+    // mutation guard: re-adding the old `?? 'should_fix'` default reddens it.
     expect(res.guidanceItems.map((g) => g.category)).toEqual([
       'technique',
       'could_fix',
-      'should_fix', // fail-closed default, rare path
+      undefined,
+    ])
+  })
+
+  it('surfaces producer `signal_code` verbatim; absent stays absent — NEVER the block type', () => {
+    const res = extract([
+      coachingBlock({ block_id: 'c-1', title: 'Coded', signal_code: 'MISSING_BASE_RATE' }),
+      coachingBlock({ block_id: 'c-2', title: 'Uncoded coaching' }), // producer omitted signal_code
+      { type: 'review_card', block_id: 'rc-1', title: 'Uncoded review' }, // no signal_code either
+    ])
+    // Passthrough: a block WITH a producer code surfaces it verbatim (open,
+    // SCREAMING_SNAKE, producer-owned vocabulary); a block WITHOUT one yields
+    // undefined — NOT the old `block.type` invention ('coaching'/'review_card'
+    // were never real codes). Mutation guard: re-adding `?? block.type` reddens.
+    expect(res.guidanceItems.map((g) => g.signal_code)).toEqual([
+      'MISSING_BASE_RATE',
+      undefined,
+      undefined,
     ])
   })
 

--- a/src/v5/extractPhase3FromV5Response.ts
+++ b/src/v5/extractPhase3FromV5Response.ts
@@ -70,8 +70,21 @@ export interface Phase3RawBlock {
  * need the full fidelity. */
 export interface DerivedGuidanceItem {
   item_id: string
-  signal_code: string
-  category: 'must_fix' | 'should_fix' | 'could_fix' | 'technique'
+  /**
+   * The producer's `signal_code` VERBATIM when emitted — an OPEN,
+   * producer-owned SCREAMING_SNAKE vocabulary (MISSING_BASE_RATE,
+   * PRE_MORTEM, …). Never allowlisted, never rendered as user copy (data-*
+   * only). Absent when the producer sent none: the UI does NOT invent a code
+   * from the block type ('coaching'/'review_card' are block classes, not
+   * codes).
+   */
+  signal_code?: string
+  /**
+   * The producer's four-value `category` VERBATIM when emitted; absent when
+   * the producer sent none. Passthrough — never defaulted to 'should_fix',
+   * never synthesised from `severity`.
+   */
+  category?: 'must_fix' | 'should_fix' | 'could_fix' | 'technique'
   source: 'analysis' | 'structural' | 'prompt'
   title: string
   detail?: string
@@ -295,15 +308,19 @@ function guidanceTargetType(
  *     every rank >= 100 clamped to 0 and the whole coaching band collapsed
  *     into one tie broken by wire array order (the UI-SEM-085 defect,
  *     confirmed by an external Codex review).
- *   - `category` ← wire `category` when canonical — the NORMAL path since
- *     0.19.0 — else the legacy severity match, else 'should_fix' fail-closed.
+ *   - `category` ← wire `category` when canonical, else ABSENT. Passthrough:
+ *     the producer owns this field (real on every 0.19.0 guidance block); a
+ *     non-canonical or omitted value stays undefined — never synthesised from
+ *     `severity`, never defaulted to 'should_fix'.
+ *   - `signal_code` ← wire `signal_code` VERBATIM, else ABSENT. Passthrough:
+ *     an OPEN, producer-owned SCREAMING_SNAKE vocabulary. The UI never invents
+ *     one from `block.type` ('coaching'/'review_card' are block classes, not
+ *     codes — they never matched real codes like MISSING_BASE_RATE), never
+ *     allowlists the set, and never renders codes as user copy.
  *
- * Still UI-authored (the residual UI-SEM-085 inventions):
- * `signal_code`→`block.type` (schemas-blocked: `signal_code` verified absent
- * from the published 0.19.0 tarball; on the orchestrator's queue),
- * `source`→`'analysis'`, and the fail-closed defaults above when a producer
- * field is genuinely absent. Copy is never fabricated (title-less blocks
- * return null below).
+ * Residual UI-authored fields: `source`→`'analysis'` and the `priority` 50
+ * fail-closed default (disclosed by `priorityIsProducerSupplied`). Copy is
+ * never fabricated (title-less blocks return null below).
  */
 function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
   const r = block.raw
@@ -315,16 +332,21 @@ function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
   if (!title) return null
   const detail = safeString(r.detail) ?? safeString(r.body) ?? safeString(r.message)
 
-  // Category — the producer's code-keyed four-value class VERBATIM (the
-  // NORMAL path since 0.19.0). Legacy fallbacks for genuine absence only:
-  // `severity` if it happens to be canonical (it never is on 0.19.0 wires —
-  // severity is info/warning/critical), else should_fix fail-closed.
-  const rawCategory = safeString(r.category) ?? safeString(r.severity)
-  const category: DerivedGuidanceItem['category'] =
+  // Category — the producer's code-keyed four-value class VERBATIM. Passthrough:
+  // an absent or non-canonical `category` stays undefined. The producer owns
+  // this field (real on every 0.19.0 guidance block); the UI never synthesises
+  // it from `severity` nor falls closed to a 'should_fix' default.
+  const rawCategory = safeString(r.category)
+  const category: DerivedGuidanceItem['category'] | undefined =
     rawCategory === 'must_fix' || rawCategory === 'should_fix' ||
     rawCategory === 'could_fix' || rawCategory === 'technique'
       ? rawCategory
-      : 'should_fix'
+      : undefined
+
+  // signal_code — the producer's OPEN, SCREAMING_SNAKE code VERBATIM when
+  // emitted; absent otherwise. Passthrough: the UI never invents one from
+  // `block.type` (block classes are not codes), never allowlists the set.
+  const signal_code = safeString(r.signal_code)
 
   // Source — analysis when emitted as part of a run_analysis turn,
   // structural for graph-shaped advice. Fall back to analysis.
@@ -418,8 +440,10 @@ function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
 
   return {
     item_id: block.id,
-    signal_code: safeString(r.signal_code) ?? block.type,
-    category,
+    // signal_code / category: producer-owned passthrough — included only when
+    // the producer supplied them; absent stays absent, never invented.
+    ...(signal_code ? { signal_code } : {}),
+    ...(category ? { category } : {}),
     source,
     title,
     ...(detail ? { detail } : {}),


### PR DESCRIPTION
## What

CEE emits real `signal_code` and `category` on every guidance-bearing block since 0.19.0 (build 86fca6f, 12-code SCREAMING_SNAKE vocabulary). This deletes the UI's compensating inventions in `deriveGuidance` so the honest passthrough posture holds: **producer-supplied field surfaces verbatim; absent field stays absent, never invented.**

## Deletions (`src/v5/extractPhase3FromV5Response.ts`, `deriveGuidance`)

- `signal_code: safeString(r.signal_code) ?? block.type` → the `?? block.type` fallback stamped `'coaching'`/`'review_card'` (block *classes*, not codes) as pseudo-codes. Deleted.
- `category`: the `?? safeString(r.severity)` synthesis and the `: 'should_fix'` fail-closed default. Deleted.
- The UI-SEM-085 comments that admitted these two inventions.

`signal_code` and `category` are now optional (passthrough) on `DerivedGuidanceItem` and the store `GuidanceItem`. The V5→store mapping (`useConversation.ts`) carries them only when present.

## Dead-consumer finding

No UI logic ever branched on the invented pseudo-codes — `signal_code` was write-only. Making it optional introduced **zero** net-new type errors and the codebase has no `signal_code === …` / switch / allowlist anywhere. The `'coaching'`/`'review_card'` literals elsewhere are all legitimate `block.type` handling, unrelated to the pseudo-codes.

## Rendering

Category badges are **suppressed** when the producer sent no category (no fake severity copy); card/row styling falls back to a neutral display treatment — a visual choice, never a synthesised data value. Codes are treated as an OPEN producer-owned set: never allowlisted, never rendered as user copy.

## Tests (RED→GREEN)

- New passthrough pins in `producerGuidancePriority.spec.ts`: a block WITH producer `signal_code`/`category` surfaces them verbatim; a block WITHOUT yields `undefined` — **not** `block.type`/`'should_fix'`. These FAILED before the deletion (proving the invention) and pass after; they double as mutation guards (re-adding either default reddens them).
- Corrected `DecisionOverviewCard.spec.tsx` fixtures + comment that had encoded the invention as "the real derived value."

## Gates

- Narrow CI typecheck (`tsc -p tsconfig.ci.json`): clean.
- Wide `tsc -p tsconfig.app.json`: 2322 → 2322 (zero net-new).
- Guidance-panel + touched suites: 285 + green; useConversation suites green (CI-style Supabase env).

**DO NOT MERGE** — orchestrator merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)