### PR TITLE
feat(auth): optional staging Bearer on PLoT-direct calls (flip precondition)

### DIFF
--- a/src/adapters/cee/__tests__/client.plotBearer.spec.ts
+++ b/src/adapters/cee/__tests__/client.plotBearer.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * CEEClient PLoT Bearer seam — the optional env-injected Authorization header
+ * must ride the outgoing PLoT-direct request assembled in `fetchWithBase`.
+ *
+ * This is one of two seams the browser uses to reach PLoT's /v1/cee/* family
+ * (the other is the readiness store's graph-readiness fetch). Every CEE client
+ * call — draft-graph (PLoT-direct via CEE_DRAFT_ENGINE_BASE), bias-check,
+ * sensitivity-coach — flows through `fetchWithBase`, so injecting the header
+ * there covers the whole family with one merge.
+ *
+ * Assertion is on the headers that reach the real `fetch` after the real
+ * `fetchWithBase` merge (observability is a passthrough that returns exactly
+ * the headers it was handed) — not a hand-built object. Removing
+ * `...plotAuthHeaders()` from `fetchWithBase` turns the presence pin red.
+ *
+ * Observability is mocked to avoid the crypto.subtle requirement in jsdom,
+ * mirroring client.timeout.spec.ts / client.bodyStall.spec.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CEEClient } from '../client'
+
+vi.mock('../../../lib/observability-headers', () => ({
+  withObservabilityHeaders: vi.fn(
+    async (_url: string, _method: string, _body: unknown, headers: Record<string, string>) => ({
+      headers,
+      startTime: Date.now(),
+    }),
+  ),
+  recordBffResponse: vi.fn(),
+  recordBffError: vi.fn(),
+  recordBffResponsePayload: vi.fn(),
+}))
+
+vi.mock('../../../lib/gate-state', () => ({
+  useGateStore: { getState: () => ({ setGate: vi.fn() }) },
+}))
+
+vi.mock('../../../lib/api-schemas', () => ({
+  CEEDraftResponseSchema: {},
+  warnOnInvalidApiResponse: vi.fn(),
+}))
+
+vi.mock('../../../lib/fetchWithRetry', () => ({
+  withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}))
+
+const graph = { nodes: [{ id: 'a', label: 'A', type: 'factor' }], edges: [] }
+
+function okResponse() {
+  return new Response(JSON.stringify({ biases: [] }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn().mockResolvedValue(okResponse())
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+function headersOfFirstFetch(): Record<string, string> {
+  const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+  return (init?.headers ?? {}) as Record<string, string>
+}
+
+describe('CEEClient PLoT Bearer seam (fetchWithBase header merge)', () => {
+  it('attaches Authorization: Bearer <token> to the outgoing request when VITE_PLOT_BEARER is set', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-xyz')
+
+    await new CEEClient().biasCheck(graph)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch().Authorization).toBe('Bearer staging-token-xyz')
+  })
+
+  it('attaches NO Authorization header when VITE_PLOT_BEARER is unset (fail-safe)', async () => {
+    await new CEEClient().biasCheck(graph)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch()).not.toHaveProperty('Authorization')
+  })
+})

--- a/src/adapters/cee/client.ts
+++ b/src/adapters/cee/client.ts
@@ -14,6 +14,7 @@ import { useGateStore } from '../../lib/gate-state'
 import { CEEDraftResponseSchema, warnOnInvalidApiResponse } from '../../lib/api-schemas'
 import { withRetry } from '../../lib/fetchWithRetry'
 import { devWarn } from '../../utils/debugLog'
+import { plotAuthHeaders } from '../../lib/plotAuthHeaders'
 
 const CEE_BASE_URL = (import.meta as any).env?.VITE_CEE_BFF_BASE || '/bff/cee'
 // CEE Draft Engine base URL
@@ -546,6 +547,9 @@ export class CEEClient {
           'Content-Type': 'application/json',
           'x-correlation-id': correlationId,
           ...(options.headers as Record<string, string>),
+          // Optional env-injected Bearer for PLoT-direct calls. Empty {} until
+          // VITE_PLOT_BEARER is provisioned → today's behaviour, byte-for-byte.
+          ...plotAuthHeaders(),
         },
         correlationId
       )

--- a/src/canvas/hooks/useGraphReadiness.ts
+++ b/src/canvas/hooks/useGraphReadiness.ts
@@ -58,6 +58,7 @@ function deduplicatedFetch(
   url: string,
   payloadJson: string,
   correlationId: string,
+  extraHeaders: Record<string, string> = {},
 ): { promise: Promise<DeduplicatedResponse>; entry: InflightEntry; isReused: boolean } {
   const cacheKey = `${url}:${payloadJson}`
   const existing = inflightCache.get(cacheKey)
@@ -78,6 +79,7 @@ function deduplicatedFetch(
       headers: {
         'Content-Type': 'application/json',
         'X-Request-ID': correlationId,
+        ...extraHeaders,
       },
       body: payloadJson,
       signal: controller.signal,

--- a/src/canvas/stores/__tests__/readinessStore.plotBearer.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.plotBearer.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Readiness store PLoT Bearer seam — the optional env-injected Authorization
+ * header must ride the graph-readiness request the store fires.
+ *
+ * This is the second of the two browser→PLoT seams (the other is the CEE
+ * client's `fetchWithBase`). The store's outgoing request is assembled by
+ * `deduplicatedFetch`; the store passes `plotAuthHeaders()` into it, so the
+ * header is present only when VITE_PLOT_BEARER is set.
+ *
+ * The pin drives the REAL store path (`__test__.fetchReadiness`) and asserts on
+ * the headers that reach the real `fetch` — not a hand-built object. Removing
+ * the `plotAuthHeaders()` argument in readinessStore.ts turns the presence pin
+ * red (proving this wiring is load-bearing, independently of the CEE seam).
+ *
+ * The canvas store is mocked to supply a one-node graph so `fetchReadiness`
+ * proceeds to the network (it early-returns without fetching on an empty graph).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../../store', () => ({
+  useCanvasStore: {
+    getState: () => ({
+      nodes: [{ id: 'n1', type: 'factor', data: { label: 'A' } }],
+      edges: [],
+      graphHealth: null,
+      ceeAnalysisReady: null,
+      currentBriefText: null,
+    }),
+  },
+}))
+
+import { __test__ as storeTest, useReadinessStore } from '../readinessStore'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+function okReadiness() {
+  return new Response(
+    JSON.stringify({
+      readiness_score: 75,
+      readiness_level: 'strong',
+      can_run_analysis: true,
+      confidence_explanation: 'Good',
+      improvements: [],
+    }),
+    { status: 200 },
+  )
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  storeTest.resetModuleState()
+  clearInflightCache()
+  fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(okReadiness()))
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+  storeTest.resetModuleState()
+  clearInflightCache()
+  useReadinessStore.setState({ readiness: null, loading: false, error: null })
+})
+
+function headersOfFirstFetch(): Record<string, string> {
+  const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+  return (init?.headers ?? {}) as Record<string, string>
+}
+
+describe('readinessStore PLoT Bearer seam (graph-readiness fetch)', () => {
+  it('attaches Authorization: Bearer <token> to the graph-readiness request when VITE_PLOT_BEARER is set', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-abc')
+
+    await storeTest.fetchReadiness()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch().Authorization).toBe('Bearer staging-token-abc')
+  })
+
+  it('attaches NO Authorization header when VITE_PLOT_BEARER is unset (fail-safe)', async () => {
+    await storeTest.fetchReadiness()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch()).not.toHaveProperty('Authorization')
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -21,6 +21,7 @@ import type {
 import {
   __test__ as dedupUtils,
 } from '../hooks/useGraphReadiness'
+import { plotAuthHeaders } from '../../lib/plotAuthHeaders'
 
 // Re-export types consumers need
 export type { GraphReadiness, GraphImprovement }
@@ -285,6 +286,10 @@ async function fetchReadiness(): Promise<void> {
           `${CEE_BASE_URL}/graph-readiness`,
           payloadJson,
           correlationId,
+          // Optional env-injected Bearer for the PLoT-direct graph-readiness
+          // call. Empty {} until VITE_PLOT_BEARER is provisioned → today's
+          // behaviour, byte-for-byte.
+          plotAuthHeaders(),
         )
         currentInflightEntry = entry
         response = await promise

--- a/src/lib/__tests__/plotAuthHeaders.spec.ts
+++ b/src/lib/__tests__/plotAuthHeaders.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * plotAuthHeaders — unit pins for the optional env-injected PLoT Bearer helper.
+ *
+ * The helper is the single source of the Authorization header wired into both
+ * PLoT-direct seams (CEE client + readiness store). These pins fix its
+ * contract: a Bearer header when the env var is a non-empty string, and the
+ * fail-safe empty object otherwise (today's behaviour before provisioning).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { plotAuthHeaders } from '../plotAuthHeaders'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('plotAuthHeaders', () => {
+  it('returns a Bearer Authorization header when VITE_PLOT_BEARER is a non-empty string', () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+    expect(plotAuthHeaders()).toEqual({ Authorization: 'Bearer staging-token-123' })
+  })
+
+  it('returns {} when VITE_PLOT_BEARER is unset (fail-safe: no header, today\'s behaviour)', () => {
+    // Intentionally not stubbed — the default import.meta.env has no
+    // VITE_PLOT_BEARER (stubEnv(undefined) would inject the string "undefined").
+    expect(plotAuthHeaders()).toEqual({})
+  })
+
+  it('returns {} for an empty-string token (never emits a bare "Bearer ")', () => {
+    vi.stubEnv('VITE_PLOT_BEARER', '')
+    expect(plotAuthHeaders()).toEqual({})
+  })
+})

--- a/src/lib/plotAuthHeaders.ts
+++ b/src/lib/plotAuthHeaders.ts
@@ -1,0 +1,38 @@
+/**
+ * plotAuthHeaders — optional, env-injected Bearer for the browser's
+ * PLoT-direct calls (the /v1/cee/* family: graph-readiness, bias-check,
+ * sensitivity-coach, draft-graph).
+ *
+ * Returns `{ Authorization: 'Bearer <token>' }` when `VITE_PLOT_BEARER` is a
+ * non-empty string, and `{}` otherwise.
+ *
+ * FAIL-SAFE: an absent/empty token reproduces today's behaviour EXACTLY — no
+ * Authorization header is attached — so nothing breaks before the token is
+ * provisioned. This is the precondition for PLoT's auth flip (zero silent
+ * breakage): the header only appears once the env var is set.
+ *
+ * The token is DELIBERATELY bundle-visible: this is option (a) of a ratified
+ * POC choice (a staging-scoped, rotatable Bearer shipped in the client
+ * bundle). Option (b) — a same-origin proxy that keeps the secret
+ * server-side, mirroring the ISL BFF (`netlify/edge-functions/isl-proxy.ts`)
+ * — is a recorded production-hardening row and is intentionally NOT built
+ * here.
+ *
+ * Env access mirrors the repo's `flagFactory.ts` pattern: read via a LITERAL
+ * `import.meta.env` reference (spread). A `(import.meta as any).env` cast
+ * strips Vite's env proxy (documented in flagFactory.ts) and would make the
+ * value unreadable under test — so it is deliberately avoided here. The
+ * `VITE_` naming convention mirrors the ISL/CEE adapters.
+ */
+export function plotAuthHeaders(): Record<string, string> {
+  let env: Record<string, unknown> = {}
+  try {
+    env = { ...import.meta.env }
+  } catch {
+    // SSR/test environment where import.meta.env is unavailable.
+  }
+  const token = env.VITE_PLOT_BEARER
+  return typeof token === 'string' && token.length > 0
+    ? { Authorization: `Bearer ${token}` }
+    : {}
+}


### PR DESCRIPTION
## What

Adds an **optional, env-injected Bearer** (`VITE_PLOT_BEARER`) to the browser's two PLoT-direct seams, ahead of PLoT's auth flip. This is a **flip precondition**, not the flip itself.

## Zero-breakage story (no-op until provisioned)

The header is attached **only when `VITE_PLOT_BEARER` is a non-empty string**. Absent or empty ⇒ no `Authorization` header ⇒ **today's behaviour, byte-for-byte**. Nothing changes for any environment until the token is provisioned, so this can merge safely before PLoT enforces auth (satisfies the "zero silent breakage" condition on the flip).

One shared helper is the single source of the header:

- `src/lib/plotAuthHeaders.ts` → `{ Authorization: 'Bearer <token>' }` when set, `{}` otherwise (fail-safe).

Wired into **both** browser→PLoT seams (the only two paths that reach the `/v1/cee/*` family — graph-readiness, bias-check, sensitivity-coach, draft-graph):

| Seam | File:line | How |
|------|-----------|-----|
| CEE client | `src/adapters/cee/client.ts:550` | `...plotAuthHeaders()` merged into `fetchWithBase`'s header assembly (covers draft-graph PLoT-direct via `CEE_DRAFT_ENGINE_BASE`, bias-check, sensitivity-coach) |
| Readiness store | `src/canvas/stores/readinessStore.ts:290` | `plotAuthHeaders()` passed into the graph-readiness fetch (`deduplicatedFetch` gains an optional `extraHeaders` arg in `src/canvas/hooks/useGraphReadiness.ts`) |

Untouched by design: ISL client, the `/proxy/v5/turn` path, and Supabase auth.

## Deliberate bundle-visibility + rotation

The token is **deliberately bundle-visible** for the POC — this is **option (a)** of a ratified choice: a **staging-scoped, rotatable** Bearer shipped in the client bundle. Rotate by updating `VITE_PLOT_BEARER` in the staging build env and redeploying; because the value is read at request time from `import.meta.env`, no code change is needed to rotate or to revoke (unset ⇒ header disappears ⇒ fail-safe).

**Option (b)** — a same-origin proxy that keeps the secret server-side (mirroring the ISL BFF, `netlify/edge-functions/isl-proxy.ts`) — is the recorded **production-hardening row**. It is intentionally **NOT built here**; this PR is the POC-scoped option (a).

## Flip sequence

1. **A3 guard-reconcile** — A3's PLoT auth-flip guard/plan lands first.
2. **This PR + env provision** — merge this (no-op on its own), then provision `VITE_PLOT_BEARER` in the staging build env.
3. **Joint flip + smoke** — PLoT flips auth ON; joint smoke over the `/v1/cee/*` family confirms the browser's PLoT-direct calls now authenticate on both seams.

This PR is **HELD**: merge is sequenced by A3's flip plan — do not merge ahead of it.

## Tests (RED-first, mutation-checked, real header-assembly path)

- `src/lib/__tests__/plotAuthHeaders.spec.ts` — helper unit pins (set ⇒ Bearer; unset/empty ⇒ `{}`).
- `src/adapters/cee/__tests__/client.plotBearer.spec.ts` — asserts the header on the real `fetch` after `fetchWithBase`'s merge; env-unset ⇒ absent.
- `src/canvas/stores/__tests__/readinessStore.plotBearer.spec.ts` — drives the real `fetchReadiness` path; env-set ⇒ header on the outgoing graph-readiness request; env-unset ⇒ absent.
- **Mutation-verified**: removing the wiring from either seam turns *that* seam's presence pin red while the other stays green (both wirings are independently load-bearing).

Gates: touched suites green (97/97 incl. existing CEE client / dedup / OutputsDock); narrow CI typecheck (`tsconfig.ci.json`) 0 errors; wide `tsc` (`tsconfig.app.json`) zero net-new (2322 = baseline, line-agnostic diff empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
