### PR TITLE
feat(guidance): Stage 2 severity-major ordering, honest category badges, action_label + signal passthrough

### DIFF
--- a/src/canvas/stores/__tests__/guidanceStore.spec.ts
+++ b/src/canvas/stores/__tests__/guidanceStore.spec.ts
@@ -17,6 +17,7 @@ import {
   selectItemsForTarget,
   selectTopItem,
   selectActiveItem,
+  compareGuidanceDisplayOrder,
   type GuidanceItem,
 } from '../guidanceStore'
 
@@ -188,6 +189,57 @@ describe('guidanceStore — selectTopItem', () => {
   it('returns null when items array is empty', () => {
     const top = selectTopItem(useGuidanceStore.getState())
     expect(top).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// compareGuidanceDisplayOrder — Stage 2 severity-major doctrine
+// ---------------------------------------------------------------------------
+
+describe('guidanceStore — compareGuidanceDisplayOrder (Stage 2 severity-major)', () => {
+  it('orders by category first: must_fix beats should_fix even with a HIGHER rank', () => {
+    // rank favours should_fix (12 < 101); only category-major puts must_fix
+    // first. Mutation: drop the category comparator → should_fix first → RED.
+    const mustFix = makeItem({ item_id: 'mf', category: 'must_fix', priorityRank: 101 })
+    const shouldFix = makeItem({ item_id: 'sf', category: 'should_fix', priorityRank: 12 })
+    const sorted = [shouldFix, mustFix].sort(compareGuidanceDisplayOrder)
+    expect(sorted.map((i) => i.item_id)).toEqual(['mf', 'sf'])
+    const top = selectTopItem({ ...useGuidanceStore.getState(), guidanceItems: [shouldFix, mustFix] })
+    expect(top?.item_id).toBe('mf')
+  })
+
+  it('sorts the full four-value ladder must_fix, should_fix, could_fix, technique', () => {
+    const items = [
+      makeItem({ item_id: 'tech', category: 'technique', priorityRank: 1 }),
+      makeItem({ item_id: 'cf', category: 'could_fix', priorityRank: 1 }),
+      makeItem({ item_id: 'mf', category: 'must_fix', priorityRank: 1 }),
+      makeItem({ item_id: 'sf', category: 'should_fix', priorityRank: 1 }),
+    ]
+    expect([...items].sort(compareGuidanceDisplayOrder).map((i) => i.item_id)).toEqual([
+      'mf',
+      'sf',
+      'cf',
+      'tech',
+    ])
+  })
+
+  it('within a category, ascending priorityRank still decides (verbatim, stable)', () => {
+    const a = makeItem({ item_id: 'a', category: 'must_fix', priorityRank: 150 })
+    const b = makeItem({ item_id: 'b', category: 'must_fix', priorityRank: 101 })
+    expect([a, b].sort(compareGuidanceDisplayOrder).map((i) => i.item_id)).toEqual(['b', 'a'])
+  })
+
+  it('an absent category sorts into ONE trailing bucket, its order otherwise unchanged', () => {
+    // A categorised item leads; the two uncategorised items keep their own
+    // rank order among themselves (never reordered by a severity they lack).
+    const cat = makeItem({ item_id: 'cat', category: 'could_fix', priorityRank: 200 })
+    const un1 = makeItem({ item_id: 'un1', category: undefined, priorityRank: 5 })
+    const un2 = makeItem({ item_id: 'un2', category: undefined, priorityRank: 9 })
+    expect([un2, cat, un1].sort(compareGuidanceDisplayOrder).map((i) => i.item_id)).toEqual([
+      'cat',
+      'un1',
+      'un2',
+    ])
   })
 })
 

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -46,6 +46,19 @@ export interface GuidanceItem {
   source: GuidanceSource
   title: string
   detail?: string
+  /**
+   * Producer `action_label` VERBATIM when supplied; absent otherwise. The CTA
+   * label the producer authored for this item — the UI renders it verbatim and
+   * never invents its own. V4-envelope guidance always carries it.
+   */
+  actionLabel?: string
+  /**
+   * Producer `signal` display line VERBATIM when supplied; absent otherwise.
+   * User-facing producer copy (distinct from `signal_code`, which is a data-*
+   * code and never rendered) — carried today only on the deterministic
+   * stale-rerun nudge. Rendered verbatim where present, never synthesised.
+   */
+  signal?: string
   primary_action: GuidanceAction
   target_object?: GuidanceTargetObject
   /**
@@ -62,10 +75,10 @@ export interface GuidanceItem {
    * COARSE 0-100 urgency, higher = more urgent (the producer's 0.19.0
    * `priority` verbatim when supplied — band-granular, ties normal — else
    * the UI's 50 fail-closed default). Budget/filter/style on it. It is NOT
-   * a display order: the contract says to order by `priorityRank` ascending.
-   * Every ordering consumer must go through `compareGuidanceDisplayOrder`
-   * below — never hand-roll a priority sort (that is how the UI-SEM-085
-   * `100 - rank` inversion happened).
+   * a display order: the display order is severity-major (`category`) then
+   * ascending `priorityRank` (Stage 2). Every ordering consumer must go
+   * through `compareGuidanceDisplayOrder` below — never hand-roll a priority
+   * sort (that is how the UI-SEM-085 `100 - rank` inversion happened).
    */
   priority: number
   /**
@@ -339,10 +352,35 @@ export function selectItemsForTarget(state: GuidanceState, targetId: string): Gu
 }
 
 /**
+ * Severity rank for the four-value producer `category` (Stage 2). Lower =
+ * shown first: must_fix, then should_fix, could_fix, technique. An ABSENT
+ * category sorts into ONE trailing bucket — the producer owns this field, so
+ * the UI never invents a severity for items it did not categorise; those keep
+ * their existing rank/urgency order among themselves.
+ */
+export function guidanceCategoryRank(cat: GuidanceItem['category']): number {
+  switch (cat) {
+    case 'must_fix': return 0
+    case 'should_fix': return 1
+    case 'could_fix': return 2
+    case 'technique': return 3
+    default: return 4 // absent — honest, never invented
+  }
+}
+
+/**
  * THE display-order doctrine for guidance items, in one place (0.19.0
- * contract; UI-SEM-085 narrowed). Producer-ranked items come first, in
- * ASCENDING `priorityRank` order (lower = shown first — verbatim wire
- * semantics, never inverted). Equal ranks are producer-order ties:
+ * contract; UI-SEM-085 narrowed; Stage 2 severity-major).
+ *
+ * PRIMARY: the producer's `category` severity (must_fix → should_fix →
+ * could_fix → technique). This is the user-facing hierarchy — a must_fix
+ * finding outranks a should_fix one whatever their ranks. Items the producer
+ * did not categorise fall into one trailing bucket (honest absence, never a
+ * synthesised severity).
+ *
+ * WITHIN a category (and among uncategorised items): producer-ranked items
+ * come first, in ASCENDING `priorityRank` order (lower = shown first — verbatim
+ * wire semantics, never inverted). Equal ranks are producer-order ties:
  * `Array.prototype.sort` is stable, so wire arrival order holds, which is
  * exactly what the contract prescribes. Unranked items follow, ordered by
  * descending coarse `priority` (the legacy urgency fallback — the contract
@@ -354,6 +392,8 @@ export function selectItemsForTarget(state: GuidanceState, targetId: string): Gu
  * collapsed.
  */
 export function compareGuidanceDisplayOrder(a: GuidanceItem, b: GuidanceItem): number {
+  const catDelta = guidanceCategoryRank(a.category) - guidanceCategoryRank(b.category)
+  if (catDelta !== 0) return catDelta
   const aRank = typeof a.priorityRank === 'number' ? a.priorityRank : undefined
   const bRank = typeof b.priorityRank === 'number' ? b.priorityRank : undefined
   if (aRank !== undefined && bRank !== undefined) return aRank - bRank
@@ -364,8 +404,9 @@ export function compareGuidanceDisplayOrder(a: GuidanceItem, b: GuidanceItem): n
 
 /**
  * Returns the single item the display-order doctrine puts FIRST (or null if
- * empty): lowest producer `priorityRank` when any item carries one, else the
- * highest coarse `priority`. Full ties keep the earliest-arrival item.
+ * empty): the highest-severity `category` (must_fix first), then the lowest
+ * producer `priorityRank`, then the highest coarse `priority`. Full ties keep
+ * the earliest-arrival item.
  */
 export function selectTopItem(state: GuidanceState): GuidanceItem | null {
   if (state.guidanceItems.length === 0) return null

--- a/src/components/results/strengthen/StrengthenPanel.tsx
+++ b/src/components/results/strengthen/StrengthenPanel.tsx
@@ -35,6 +35,17 @@ import {
 import { typography } from '../../../styles/typography'
 import { STRENGTHEN_COPY as COPY } from './strengthenCopy'
 import type { RecRecord } from '../../../canvas/stores/strengthenStore'
+import type { GuidanceCategory } from '../../../canvas/stores/guidanceStore'
+
+/** Stage 2 — severity badge treatment per producer `category`. Sensible
+ * visual hierarchy (danger → warning → info → muted); the badge itself is
+ * rendered ONLY when the producer sent a category (absent = no badge). */
+const SEVERITY_BADGE_CLASS: Record<GuidanceCategory, string> = {
+  must_fix: 'border-danger/40 text-danger',
+  should_fix: 'border-warning/40 text-warning',
+  could_fix: 'border-info/40 text-info',
+  technique: 'border-panel-border text-text-light',
+}
 
 export interface StrengthenPanelProps {
   active: RecRecord[]
@@ -125,6 +136,19 @@ function RecRow({
         <span className="min-w-0">
           <span className={`${typography.panelBody} block font-semibold text-text-header`}>
             {rec.title}
+            {/* Stage 2 — honest severity badge: rendered ONLY when the producer
+                categorised this finding (phase-3 recs). Absent category = no
+                badge (the PR-427 honest-absent posture); the UI's own triggers
+                are uncategorised and stay badge-free. */}
+            {rec.category && (
+              <span
+                data-testid="strengthen-rec-severity"
+                data-category={rec.category}
+                className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border bg-transparent px-1.5 font-normal align-middle ${SEVERITY_BADGE_CLASS[rec.category]}`}
+              >
+                {COPY.severityLabel[rec.category]}
+              </span>
+            )}
             {record.status === 'in_progress' && (
               <span
                 className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border border-info/30 bg-transparent px-1.5 font-normal text-text-body align-middle`}

--- a/src/components/results/strengthen/__tests__/StrengthenContainer.spec.tsx
+++ b/src/components/results/strengthen/__tests__/StrengthenContainer.spec.tsx
@@ -354,3 +354,16 @@ describe('StrengthenContainer — producer priority_rank rides through VERBATIM 
     ])
   })
 })
+
+describe('StrengthenContainer — guidance surface is absent before any analysis (standing rule)', () => {
+  it('with no completed analysis and no producer guidance, no phase-3 rows or severity badges surface', () => {
+    // Guidance blocks arrive with/after a run; pre-run the guidance store is
+    // empty (cleared in beforeEach), so no producer coaching promotes and the
+    // Stage 2 severity badge never appears. The MOUNT itself is separately
+    // gated `!isPreRun && resultsSectionData` in OutputsDock.
+    render(<StrengthenContainer data={makeData({ goalThreshold: 62, analysisStatus: 'unavailable' })} />)
+    const ids = selectActive(useStrengthenStore.getState()).map((r) => r.id)
+    expect(ids.some((id) => id.startsWith('strengthen:phase3:'))).toBe(false)
+    expect(screen.queryByTestId('strengthen-rec-severity')).toBeNull()
+  })
+})

--- a/src/components/results/strengthen/__tests__/StrengthenPanel.spec.tsx
+++ b/src/components/results/strengthen/__tests__/StrengthenPanel.spec.tsx
@@ -331,3 +331,35 @@ describe('StrengthenPanel — §8.9 history', () => {
     expect(container.textContent).not.toMatch(/\d+\s*%|\d+\s*\/\s*\d+ complete/i)
   })
 })
+
+describe('StrengthenPanel — Stage 2 honest severity badge from producer category', () => {
+  it('renders a severity badge for a categorised rec (sentence-case label + data-category)', () => {
+    render(<StrengthenPanel {...baseProps} active={[record('mf', {}, { category: 'must_fix' })]} />)
+    const badge = screen.getByTestId('strengthen-rec-severity')
+    expect(badge).toHaveTextContent('Must fix')
+    expect(badge).toHaveAttribute('data-category', 'must_fix')
+  })
+
+  it('uses the right sentence-case label for each canonical category', () => {
+    const cases = [
+      ['must_fix', 'Must fix'],
+      ['should_fix', 'Should fix'],
+      ['could_fix', 'Could fix'],
+      ['technique', 'Technique'],
+    ] as const
+    for (const [category, label] of cases) {
+      const { unmount } = render(
+        <StrengthenPanel {...baseProps} active={[record('x', {}, { category })]} />,
+      )
+      const badge = screen.getByTestId('strengthen-rec-severity')
+      expect(badge).toHaveTextContent(label)
+      expect(badge).toHaveAttribute('data-category', category)
+      unmount()
+    }
+  })
+
+  it('renders NO badge when the producer sent no category (keeps the PR-427 honest-absent posture)', () => {
+    render(<StrengthenPanel {...baseProps} active={[record('none')]} />)
+    expect(screen.queryByTestId('strengthen-rec-severity')).toBeNull()
+  })
+})

--- a/src/components/results/strengthen/__tests__/guidanceStage2.spec.ts
+++ b/src/components/results/strengthen/__tests__/guidanceStage2.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * Stage 2 — the guidance surface consumes the producer signals that went live
+ * on the 0.19.0+ wire: the four-value `category`, the producer `action_label`,
+ * and the `signal` display line (carried only on the deterministic stale-rerun
+ * nudge today, honestly absent elsewhere).
+ *
+ * RED-first, REAL-path: every fixture is a raw V5 response fed through the live
+ * sidecar path (the ADDITIVE_EXTENSIONS_KEY the V5 writer uses) →
+ * extractPhase3FromV5Response → toStrengthenPhase3Item → buildRecommendations,
+ * so a pin can never pass by hand-shaping an intermediate the real derivation
+ * would never produce (this repo's dominant defect class).
+ *
+ * Stage 1 already carried priority_rank/category/signal_code verbatim on the
+ * DERIVED guidance item (see producerGuidancePriority.spec.ts). Stage 2 adds:
+ *  - `action_label` + the producer `signal` line ride through the derived item
+ *    AND the strengthen mapper — Stage 1 dropped action_label at
+ *    toStrengthenPhase3Item (`actionLabel: undefined`) and never read `signal`;
+ *  - the engine orders promoted phase-3 guidance SEVERITY-major: `category`
+ *    dominates `priority_rank`, stable within a category by ascending rank.
+ *
+ * Location: OUTSIDE src/v5/** (the CI-tsc widening trap), matching the sibling
+ * UI-SEM-085 specs, though it exercises the v5 extractor.
+ */
+import { describe, expect, it } from 'vitest'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+import {
+  ADDITIVE_EXTENSIONS_KEY,
+  type OlumiResponseWithExtensions,
+} from '../../../../v5/responseParser'
+import { extractPhase3FromV5Response } from '../../../../v5/extractPhase3FromV5Response'
+import { buildRecommendations, toStrengthenPhase3Item } from '../buildRecommendations'
+import type { StrengthenInputs } from '../strengthenTypes'
+
+const extract = (blocks: Array<Record<string, unknown>>) => {
+  const response = {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+  } as unknown as OlumiResponse
+  Object.defineProperty(response, ADDITIVE_EXTENSIONS_KEY, {
+    value: Object.freeze({ phase3_blocks: blocks }),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  })
+  return extractPhase3FromV5Response(response as OlumiResponseWithExtensions)
+}
+
+const coachingBlock = (over: Record<string, unknown>): Record<string, unknown> => ({
+  type: 'coaching',
+  ...over,
+})
+
+const baseInputs: StrengthenInputs = {
+  goalThreshold: 62,
+  analysisComplete: true,
+  fragileEdges: [],
+  factors: [],
+  robustness: { status: null, level: null },
+  biasFindingTypes: [],
+  phase3Items: [],
+}
+
+const wireToInputs = (blocks: Array<Record<string, unknown>>): StrengthenInputs => ({
+  ...baseInputs,
+  phase3Items: extract(blocks).guidanceItems.map(toStrengthenPhase3Item),
+})
+
+const phase3Ids = (input: StrengthenInputs): string[] =>
+  buildRecommendations(input)
+    .filter((r) => r.id.startsWith('strengthen:phase3:'))
+    .sort((a, b) => a.priority - b.priority)
+    .map((r) => r.id)
+
+// ─── action_label passthrough (was dropped at the strengthen seam) ──────────
+
+describe('Stage 2 — producer action_label rides through, verbatim', () => {
+  it('deriveGuidance surfaces action_label; an omitted one stays absent', () => {
+    const items = extract([
+      coachingBlock({ block_id: 'c-1', title: 'Confirm the assumption', action_label: 'Confirm this assumption' }),
+      coachingBlock({ block_id: 'c-2', title: 'No label' }),
+    ]).guidanceItems
+    expect(items[0].actionLabel).toBe('Confirm this assumption')
+    expect(items[1].actionLabel).toBeUndefined()
+  })
+
+  it('the strengthen mapper carries action_label (Stage 1 hardcoded it undefined)', () => {
+    const item = extract([
+      coachingBlock({ block_id: 'c-1', title: 'Confirm', action_label: 'Confirm this assumption' }),
+    ]).guidanceItems.map(toStrengthenPhase3Item)[0]
+    expect(item.actionLabel).toBe('Confirm this assumption')
+  })
+
+  it('the promoted rec renders the producer action_label as its CTA and its tip', () => {
+    const rec = buildRecommendations(
+      wireToInputs([
+        coachingBlock({ block_id: 'c-1', title: 'Confirm', action_label: 'Confirm this assumption', priority_rank: 101 }),
+      ]),
+    ).find((r) => r.id === 'strengthen:phase3:c-1')!
+    expect(rec.action.label).toBe('Confirm this assumption')
+    expect(rec.tryThis).toBe('Confirm this assumption')
+  })
+
+  it('with no action_label the rec keeps its honest boilerplate CTA', () => {
+    const rec = buildRecommendations(
+      wireToInputs([coachingBlock({ block_id: 'c-1', title: 'Unlabelled', priority_rank: 101 })]),
+    ).find((r) => r.id === 'strengthen:phase3:c-1')!
+    expect(rec.action.label).toBe('Work through with Olumi')
+  })
+})
+
+// ─── signal display line passthrough (deterministic stale-rerun nudge) ──────
+
+describe('Stage 2 — producer `signal` display line renders verbatim where present', () => {
+  it('deriveGuidance surfaces the producer signal line; an omitted one stays absent', () => {
+    const items = extract([
+      coachingBlock({ block_id: 'c-1', title: 'Refresh', signal: 'Re-run the analysis to refresh the insights.' }),
+      coachingBlock({ block_id: 'c-2', title: 'No signal' }),
+    ]).guidanceItems
+    expect(items[0].signal).toBe('Re-run the analysis to refresh the insights.')
+    expect(items[1].signal).toBeUndefined()
+  })
+
+  it('the promoted rec shows the producer signal verbatim, preferred over the body', () => {
+    const rec = buildRecommendations(
+      wireToInputs([
+        coachingBlock({
+          block_id: 'c-1',
+          title: 'Stale',
+          signal: 'Re-run the analysis to refresh the insights.',
+          body: 'Some longer supporting body.',
+          priority_rank: 101,
+        }),
+      ]),
+    ).find((r) => r.id === 'strengthen:phase3:c-1')!
+    expect(rec.signal).toBe('Re-run the analysis to refresh the insights.')
+  })
+
+  it('falls back to the body when the producer sent no signal line (Stage 1 behaviour intact)', () => {
+    const rec = buildRecommendations(
+      wireToInputs([
+        coachingBlock({ block_id: 'c-1', title: 'Body only', body: 'Only a body here.', priority_rank: 101 }),
+      ]),
+    ).find((r) => r.id === 'strengthen:phase3:c-1')!
+    expect(rec.signal).toBe('Only a body here.')
+  })
+})
+
+// ─── severity-major ordering (category dominates priority_rank) ─────────────
+
+describe('Stage 2 — guidance orders SEVERITY-major (category dominates rank)', () => {
+  it('must_fix precedes should_fix even when must_fix carries a HIGHER (later) rank', () => {
+    // Both wire order and ascending rank favour should_fix; only category-major
+    // ordering puts must_fix first. Mutation: drop the category comparator →
+    // reverts to ascending rank → should_fix first → RED.
+    const ids = phase3Ids(
+      wireToInputs([
+        coachingBlock({ block_id: 'sf', title: 'Should fix', category: 'should_fix', priority_rank: 71 }),
+        coachingBlock({ block_id: 'mf', title: 'Must fix', category: 'must_fix', priority_rank: 150 }),
+      ]),
+    )
+    expect(ids).toEqual(['strengthen:phase3:mf', 'strengthen:phase3:sf'])
+  })
+
+  it('the full four-value ladder orders must_fix, should_fix, could_fix, technique', () => {
+    // Ranks deliberately CONTRADICT the intended order — only category wins.
+    const ids = phase3Ids(
+      wireToInputs([
+        coachingBlock({ block_id: 'tech', title: 'T', category: 'technique', priority_rank: 12 }),
+        coachingBlock({ block_id: 'cf', title: 'C', category: 'could_fix', priority_rank: 13 }),
+        coachingBlock({ block_id: 'mf', title: 'M', category: 'must_fix', priority_rank: 14 }),
+        coachingBlock({ block_id: 'sf', title: 'S', category: 'should_fix', priority_rank: 15 }),
+      ]),
+    )
+    expect(ids).toEqual([
+      'strengthen:phase3:mf',
+      'strengthen:phase3:sf',
+      'strengthen:phase3:cf',
+      'strengthen:phase3:tech',
+    ])
+  })
+
+  it('within one category, ascending producer rank still decides (stable, verbatim)', () => {
+    const ids = phase3Ids(
+      wireToInputs([
+        coachingBlock({ block_id: 'a', title: 'A', category: 'must_fix', priority_rank: 150 }),
+        coachingBlock({ block_id: 'b', title: 'B', category: 'must_fix', priority_rank: 101 }),
+      ]),
+    )
+    expect(ids).toEqual(['strengthen:phase3:b', 'strengthen:phase3:a'])
+  })
+})

--- a/src/components/results/strengthen/buildRecommendations.ts
+++ b/src/components/results/strengthen/buildRecommendations.ts
@@ -25,18 +25,23 @@
  * priority (inputs.adaptivePriority), matching-helpType recs float above
  * the rest while preserving relative order within each group.
  */
-import type { GuidanceItem } from '../../../canvas/stores/guidanceStore'
+import { guidanceCategoryRank, type GuidanceItem } from '../../../canvas/stores/guidanceStore'
 import type { Recommendation, StrengthenInputs, StrengthenPhase3Item } from './strengthenTypes'
 
 /**
  * GuidanceItem → StrengthenPhase3Item, the ONE store→engine mapping
- * (UI-SEM-085 narrowed). `priorityRank` rides through VERBATIM — ascending,
- * lower = first, unbounded, presence = producer-ranked. Nothing is inverted
- * and nothing is defaulted here: the historic `100 - priority` re-inversion
- * at this seam is what collapsed the coaching band (every rank >= 100 had
- * already clamped to priority 0 upstream, so 101 and 201 became one tie
- * broken by wire array order). Exported so specs can pin the live seam
- * instead of re-implementing it.
+ * (UI-SEM-085 narrowed; Stage 2). `priorityRank` rides through VERBATIM —
+ * ascending, lower = first, unbounded, presence = producer-ranked. Nothing is
+ * inverted and nothing is defaulted here: the historic `100 - priority`
+ * re-inversion at this seam is what collapsed the coaching band (every rank
+ * >= 100 had already clamped to priority 0 upstream, so 101 and 201 became one
+ * tie broken by wire array order).
+ *
+ * Stage 2: `category`, `actionLabel` and `signal` now ride through VERBATIM
+ * too. Stage 1 hardcoded `actionLabel: undefined` here, silently dropping the
+ * producer's CTA label for every phase-3 row; `category` and `signal` were
+ * never carried. Exported so specs can pin the live seam instead of
+ * re-implementing it.
  */
 export function toStrengthenPhase3Item(item: GuidanceItem): StrengthenPhase3Item {
   return {
@@ -44,7 +49,9 @@ export function toStrengthenPhase3Item(item: GuidanceItem): StrengthenPhase3Item
     title: item.title,
     body: item.detail,
     actionIntent: item.primary_action.type === 'discuss' ? 'discuss' : item.primary_action.type,
-    actionLabel: undefined,
+    actionLabel: item.actionLabel,
+    ...(item.category ? { category: item.category } : {}),
+    ...(item.signal ? { signal: item.signal } : {}),
     targetIds: item.target_object?.id ? [item.target_object.id] : [],
     ...(typeof item.priorityRank === 'number' ? { priorityRank: item.priorityRank } : {}),
   }
@@ -170,9 +177,22 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
   const seenPhase3Keys = new Set<string>()
   const promotedPhase3 = [...inputs.phase3Items]
     .sort((a, b) => {
+      // Stage 2 — SEVERITY-major: the producer's `category` is the primary
+      // display order (must_fix → should_fix → could_fix → technique). It is
+      // the user-facing hierarchy, so a must_fix finding outranks a should_fix
+      // one whatever their ranks. Items the producer did NOT categorise fall
+      // into one trailing bucket (honest absence — never a synthesised
+      // severity), preserving their existing ranked/arrival order among
+      // themselves (guidanceRankHonesty pins that category-less rows are never
+      // silently reordered).
+      const catDelta = guidanceCategoryRank(a.category) - guidanceCategoryRank(b.category)
+      if (catDelta !== 0) return catDelta
+      // Within a category: producer-ranked before unranked (UI-SEM-085 — rank
+      // PRESENCE is the "producer ordered this" fact; the ranked/unranked band
+      // split below then keeps unranked rows demoted + disclosed).
       const rankedDelta = Number(isProducerRanked(b)) - Number(isProducerRanked(a))
       if (rankedDelta !== 0) return rankedDelta
-      // Ascending producer rank — lower = first, verbatim wire semantics
+      // Then ascending producer rank — lower = first, verbatim wire semantics
       // (unbounded; the bands are disjoint numeric ranges, so plain numeric
       // order respects them — no cross-band re-ranking). Equal ranks are
       // producer-order ties: sort() is stable, arrival order holds, which is
@@ -205,7 +225,11 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
       //   degraded every phase-3 drawer ask to boilerplate (round 2).
       // Boilerplate is the no-body fallback only. The PANEL dedupes display:
       // an open row renders the body once, in full, never clamp + full copy.
-      signal: item.body ?? 'Olumi flagged this while reviewing your model.',
+      // Stage 2: a producer `signal` display line (carried today only on the
+      // deterministic stale-rerun nudge) is preferred VERBATIM over the body —
+      // it is the producer's own subtitle. Body is the fallback; boilerplate
+      // the no-copy floor.
+      signal: item.signal ?? item.body ?? 'Olumi flagged this while reviewing your model.',
       whyNow: item.body ?? 'Resolving it improves what the analysis can tell you.',
       tryThis: item.actionLabel ?? 'Work through it with Olumi.',
       // UI-SEM-085: the label IS the band marker — an unranked row states that
@@ -229,6 +253,10 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
       priority:
         (isProducerRanked(item) ? PRIORITY.phase3Base : PRIORITY.phase3Unranked) +
         promotedIndex++,
+      // Stage 2: the producer's severity, VERBATIM — drives the row badge.
+      // Only phase-3 recs carry it (the UI's own triggers are uncategorised,
+      // so they show no badge — honest absence).
+      ...(item.category ? { category: item.category } : {}),
     })
   }
 

--- a/src/components/results/strengthen/strengthenCopy.ts
+++ b/src/components/results/strengthen/strengthenCopy.ts
@@ -25,6 +25,15 @@ export const STRENGTHEN_COPY = {
   markAddressed: 'Mark as addressed',
   inProgressPill: 'In progress', // (spec — rec-state pill)
   reopenedPill: 'Reopened',
+  // Stage 2 — honest severity badge labels (en-GB, sentence case). Rendered
+  // ONLY from the producer's four-value `category`; absent = no badge. The
+  // labels match the guidance-strip vocabulary so the surfaces read as one.
+  severityLabel: {
+    must_fix: 'Must fix',
+    should_fix: 'Should fix',
+    could_fix: 'Could fix',
+    technique: 'Technique',
+  } as const,
   reopenedPrefix: 'Reopened:',
   tryThisLead: 'Try this', // (spec — bold info lead-in, followed by a space + tip)
   dismissedNotice: 'Recommendation dismissed', // (spec — toast copy)

--- a/src/components/results/strengthen/strengthenTypes.ts
+++ b/src/components/results/strengthen/strengthenTypes.ts
@@ -7,6 +7,8 @@
  * ResultsSectionDataReturn shape.
  */
 
+import type { GuidanceCategory } from '../../../canvas/stores/guidanceStore'
+
 /** §8.2 adaptive help types — internal only, never shown as stages. */
 export type HelpType = 'clarify' | 'broaden' | 'challenge' | 'evaluate' | 'commit'
 
@@ -51,6 +53,13 @@ export interface Recommendation {
   targetId: string | null
   /** Engine priority (ascending = more important). Reprioritises, never resets. */
   priority: number
+  /**
+   * The producer's four-value `category` VERBATIM (Stage 2) — set only on
+   * phase-3 guidance recs, the only recs the producer categorises. Drives the
+   * honest severity badge; absent = no badge (never synthesised for the UI's
+   * own deterministic triggers, which the producer never categorised).
+   */
+  category?: GuidanceCategory
 }
 
 // ── Engine inputs (narrow, fixture-friendly) ─────────────────────────────────
@@ -87,6 +96,19 @@ export interface StrengthenPhase3Item {
   body?: string
   actionIntent?: string
   actionLabel?: string
+  /**
+   * The producer's four-value `category` VERBATIM (Stage 2). Primary display
+   * order in the engine (severity-major); drives the row's severity badge.
+   * Absent = uncategorised (honest absence; never synthesised).
+   */
+  category?: GuidanceCategory
+  /**
+   * The producer's `signal` display line VERBATIM (Stage 2) — user-facing
+   * producer copy carried today only on the deterministic stale-rerun nudge.
+   * When present it is the row's subtitle, preferred over the body; absent
+   * everywhere else.
+   */
+  signal?: string
   targetIds: string[]
   /**
    * The producer's 0.19.0 `priority_rank` VERBATIM (ascending display

--- a/src/v5/extractPhase3FromV5Response.ts
+++ b/src/v5/extractPhase3FromV5Response.ts
@@ -88,6 +88,20 @@ export interface DerivedGuidanceItem {
   source: 'analysis' | 'structural' | 'prompt'
   title: string
   detail?: string
+  /**
+   * The producer's `action_label` VERBATIM when supplied; absent otherwise.
+   * Passthrough — the UI never authors a CTA label of its own from it. Stage 1
+   * carried the raw block but this derived field was missing, so every
+   * downstream consumer (the Strengthen mapper) fell back to boilerplate.
+   */
+  actionLabel?: string
+  /**
+   * The producer's `signal` display line VERBATIM when supplied; absent
+   * otherwise. Distinct from `signal_code` (a data-* code, never copy): this
+   * IS user-facing producer copy, carried today only on the deterministic
+   * stale-rerun nudge. Rendered verbatim where present, never synthesised.
+   */
+  signal?: string
   primary_action: { type: 'discuss'; prompt: string }
   target_object?: { type: 'node' | 'edge' | 'option' | 'graph' | 'framing'; id?: string; label?: string }
   related_elements?: Array<{ id?: string; type?: string; label?: string }>
@@ -348,6 +362,18 @@ function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
   // `block.type` (block classes are not codes), never allowlists the set.
   const signal_code = safeString(r.signal_code)
 
+  // action_label — the producer's CTA label VERBATIM when supplied; absent
+  // otherwise. Passthrough only (never UI-authored). Stage 1 preserved it on
+  // the raw block but dropped it from this derived shape, so the Strengthen
+  // mapper always fell back to boilerplate.
+  const actionLabel = safeString(r.action_label)
+
+  // signal — the producer's user-facing display line VERBATIM when supplied;
+  // absent otherwise. NOT `signal_code` (that is a data-* code, never copy):
+  // this is producer copy, carried today only on the deterministic stale-rerun
+  // nudge. Rendered verbatim where present, never synthesised.
+  const signal = safeString(r.signal)
+
   // Source — analysis when emitted as part of a run_analysis turn,
   // structural for graph-shaped advice. Fall back to analysis.
   const rawSource = safeString(r.source)
@@ -447,6 +473,10 @@ function deriveGuidance(block: Phase3RawBlock): DerivedGuidanceItem | null {
     source,
     title,
     ...(detail ? { detail } : {}),
+    // action_label / signal: producer-owned passthrough — included only when
+    // the producer supplied them; absent stays absent, never invented.
+    ...(actionLabel ? { actionLabel } : {}),
+    ...(signal ? { signal } : {}),
     primary_action: { type: 'discuss', prompt: intentPrompt },
     ...(target_object ? { target_object } : {}),
     ...(related_elements ? { related_elements } : {}),


### PR DESCRIPTION
## Build guidance Stage 2 — real, prioritised, honest coaching

Upgrades the post-analysis guidance surface (the **Strengthen** panel) from generic prompts to real coaching, consuming the producer signals now live on the wire (both repos on schemas **0.21.0**): the four-value `category`, the producer `action_label`, and the `signal` display line. Ships **ON, no flag** (the panel is already behind `VITE_FEATURE_STRENGTHEN_PANEL`; no new gate). One coherent surface pass, no new panels, no redesign.

### Diagnosis (verified at the bytes on staging `5a32fc6c`)

**Current chain:** `deriveGuidance` (src/v5/extractPhase3FromV5Response.ts) → `guidanceStore` → `StrengthenContainer` → `toStrengthenPhase3Item` → `buildRecommendations` → `StrengthenPanel`. The single ordering doctrine is `compareGuidanceDisplayOrder` (used by GuidanceStrip, InspectorGuidanceSection, DecisionOverviewCard, InspectorCoaching).

**Wire semantics verdict (the priority-banding answer):** the 0.19.0+ contract (vendored `boundary/blocks` JSDoc, pinned by `producerGuidancePriority.spec.ts`) states `priority_rank` is an **ASCENDING** ordinal — lower = shown first, positive integers, **unbounded**; bands (1-9 lifecycle, 10-99 review cards, 100-199 coaching, 200+ prompts) encode **block class, not severity**; equal ranks are producer-order ties. `priority` is a coarse 0-100 urgency (higher = more urgent, derived 1:1 from category, **not** a display order). The historic **19c** `100 - rank` inversion (which collapsed the whole coaching band to a tie) **was already removed** by PR #427. So Stage 2 does **not** guess an inversion — it layers the user-facing `category` severity on top, with `priority_rank` as the within-category tiebreak.

**What Stage 1 lacked / this fixes (the asks-ledger `:139`/`:143` defects, current locations):**
- `toStrengthenPhase3Item` hardcoded `actionLabel: undefined` — silently dropping the producer CTA label for **every** phase-3 row (the `:139` defect, still live). The derived `GuidanceItem` carried neither `action_label` nor a producer `signal` line at all.
- Ordering was `priority_rank`-ascending only (category-blind); the Strengthen panel rendered **no** severity badge (GuidanceStrip/ActionStrip already had category badges; the Strengthen panel was the gap).
- The `:143` rank>100 clamp is already gone (PR #427-era); `priority_rank` rides through verbatim.

### What changed

- **`deriveGuidance` + `GuidanceItem`**: carry `action_label` and the producer `signal` line VERBATIM (honest-absent otherwise). `signal` is producer copy (distinct from `signal_code`, which stays data-* only, never rendered).
- **`compareGuidanceDisplayOrder`** (the one doctrine): **severity-major**. `category` is primary (must_fix → should_fix → could_fix → technique); within a category the existing UI-SEM-085 order holds (producer-ranked first, then ascending `priority_rank` verbatim, then coarse `priority`). An **absent** category sorts into one trailing bucket — never a synthesised severity. Backward-compatible: category-less items keep their existing order.
- **`buildRecommendations`**: phase-3 promotion sorts severity-major; the rec carries `category` (badge source), renders the producer `signal` verbatim (preferred over the body), and passes `action_label` through to the CTA label + tip. UI-SEM-085 unranked demotion + disclosure preserved.
- **`StrengthenPanel`**: honest severity **badge** from `category` only — absent = **no badge** (keeps the #427 honest-absent posture). Sensible visual hierarchy: danger → warning → info → muted. Labels (`Must fix`/`Should fix`/`Could fix`/`Technique`) match the guidance-strip vocabulary; the raw code goes to `data-category` only, never copy.
- No internal vocabulary exposed (codes stay data-*); en-GB, sentence case, no em dashes in user copy.

### Tests — RED-first, mutation-checked, real-path

New `guidanceStage2.spec.ts` drives every fixture through the **real** derivation (raw V5 response → `extractPhase3FromV5Response` → `toStrengthenPhase3Item` → `buildRecommendations`), never hand-shaping an intermediate.

- **Ordering pin:** mixed-category fixture renders must_fix before should_fix even when must_fix carries a higher `priority_rank`; full four-value ladder. **Mutation-checked** — neutralising the category comparator reds exactly the two ordering pins.
- **action_label passthrough** (RED against the Stage 1 dropper) — derivation, mapper, and rendered CTA + tip.
- **signal display line** rendered verbatim where present, body fallback otherwise.
- **Badge honesty:** category present → badge; absent → no badge (the #427 pins stay green).
- **Pre-run:** guidance surface absent before any analysis (the mount stays gated `!isPreRun && resultsSectionData` in OutputsDock).
- Store-level `compareGuidanceDisplayOrder` category-major pins added (mutation-covers the doctrine change).

### Gates

- Touched + consumer suites: **309 passed** (Strengthen, extractPhase3, guidanceStore, GuidanceStrip, ActionStrip, InspectorGuidanceSection, InspectorCoaching, DecisionOverviewCard, Brief3Panels) under CI-style Supabase env.
- Narrow CI typecheck (`tsc -p tsconfig.ci.json`): **clean**.
- Wide tsc (`tsconfig.app.json`): **zero net new** (2322 = baseline; all additive optional fields).
- DS-compliance guard: **no net-new**; eslint on touched files: **clean**.

Draft — do not merge.
