### PR TITLE
fix(auth): all PLoT-direct seams send the Bearer via one plotFetch wrapper (flip blocker)

### DIFF
--- a/src/adapters/plot/v1/health.ts
+++ b/src/adapters/plot/v1/health.ts
@@ -4,6 +4,7 @@
  * Probes engine health using HEAD /v1/run
  * Returns 204 = healthy, anything else = unhealthy
  */
+import { plotFetch } from '../../../lib/plotFetch'
 
 const getProxyBase = (): string => {
   return import.meta.env.VITE_PLOT_PROXY_BASE || '/bff/engine'
@@ -21,7 +22,7 @@ export async function probeHealth(): Promise<HealthStatus> {
   const timeoutId = setTimeout(() => controller.abort(), 5000)
 
   try {
-    const response = await fetch(`${base}/v1/run`, {
+    const response = await plotFetch(`${base}/v1/run`, {
       method: 'HEAD',
       signal: controller.signal,
     })

--- a/src/adapters/plot/v1/http.ts
+++ b/src/adapters/plot/v1/http.ts
@@ -35,6 +35,7 @@ import { V1SyncRunResponseSchema, warnOnInvalidApiResponse } from '../../../lib/
 // 438) wrote to the store, which left the entry without `service` /
 // `endpoint` and the bundle silently rejected it.
 import { recordRequestPayload, recordResponsePayload } from '../../../lib/payload-trace-store'
+import { plotFetch } from '../../../lib/plotFetch'
 
 const getProxyBase = (): string => {
   return import.meta.env.VITE_PLOT_PROXY_BASE || '/bff/engine'
@@ -82,7 +83,7 @@ export async function getCapabilities(): Promise<CapabilitiesResponse> {
   const timeoutId = setTimeout(() => controller.abort(), 5000)
 
   try {
-    const response = await fetch(`${base}/version`, {
+    const response = await plotFetch(`${base}/version`, {
       method: 'GET',
       signal: controller.signal,
     })
@@ -303,7 +304,7 @@ export async function health(): Promise<V1HealthResponse> {
   const timeoutId = setTimeout(() => controller.abort(), 5000)
 
   try {
-    const response = await fetch(`${base}/v1/health`, {
+    const response = await plotFetch(`${base}/v1/health`, {
       method: 'GET',
       signal: controller.signal,
     })
@@ -443,7 +444,7 @@ async function runSyncOnce(
       body: requestForBody,
     })
 
-    const response = await fetch(endpoint, {
+    const response = await plotFetch(endpoint, {
       method: 'POST',
       headers,
       body: JSON.stringify(requestForBody),
@@ -703,7 +704,7 @@ export async function cancel(runId: string): Promise<void> {
   const base = getProxyBase()
 
   try {
-    const response = await fetch(`${base}/v1/run/${runId}/cancel`, {
+    const response = await plotFetch(`${base}/v1/run/${runId}/cancel`, {
       method: 'POST',
     })
 
@@ -726,7 +727,7 @@ export async function templates(): Promise<V1TemplateListResponse> {
   const timeoutId = setTimeout(() => controller.abort(), 10000)
 
   try {
-    const response = await fetch(`${base}/v1/templates`, {
+    const response = await plotFetch(`${base}/v1/templates`, {
       method: 'GET',
       signal: controller.signal,
     })
@@ -764,7 +765,7 @@ export async function templateGraph(id: string): Promise<V1TemplateGraphResponse
   const timeoutId = setTimeout(() => controller.abort(), 10000)
 
   try {
-    const response = await fetch(`${base}/v1/templates/${encodeURIComponent(id)}/graph`, {
+    const response = await plotFetch(`${base}/v1/templates/${encodeURIComponent(id)}/graph`, {
       method: 'GET',
       signal: controller.signal,
     })
@@ -823,7 +824,7 @@ export async function validate(request: V1ValidateRequest): Promise<V1ValidateRe
     )
     startTime = obsStartTime
 
-    const response = await fetch(endpoint, {
+    const response = await plotFetch(endpoint, {
       method: 'POST',
       headers,
       body: JSON.stringify(request),
@@ -870,7 +871,7 @@ export async function limits(): Promise<V1LimitsResponse> {
   const timeoutId = setTimeout(() => controller.abort(), 5000)
 
   try {
-    const response = await fetch(`${base}/v1/limits`, {
+    const response = await plotFetch(`${base}/v1/limits`, {
       method: 'GET',
       signal: controller.signal,
     })
@@ -930,7 +931,7 @@ export async function runBundle(request: V1RunBundleRequest): Promise<V1RunBundl
     )
     startTime = obsStartTime
 
-    const response = await fetch(endpoint, {
+    const response = await plotFetch(endpoint, {
       method: 'POST',
       headers,
       body: JSON.stringify(request),

--- a/src/adapters/plot/v1/limits.ts
+++ b/src/adapters/plot/v1/limits.ts
@@ -7,6 +7,7 @@
  */
 
 import type { V1LimitsResponse } from './types'
+import { plotFetch } from '../../../lib/plotFetch'
 
 /**
  * Get proxy base URL, aligned with http.ts pattern
@@ -89,7 +90,7 @@ export async function fetchLimits(): Promise<V1LimitsResponse> {
   const timeoutId = setTimeout(() => controller.abort(), 5000)
 
   try {
-    const response = await fetch(`${base}/v1/limits`, {
+    const response = await plotFetch(`${base}/v1/limits`, {
       method: 'GET',
       signal: controller.signal,
     })

--- a/src/adapters/plot/v1/probe.ts
+++ b/src/adapters/plot/v1/probe.ts
@@ -4,6 +4,7 @@
  * Probes production endpoint to detect v1 route availability.
  * Falls back to mock adapter when v1 routes unavailable.
  */
+import { plotFetch } from '../../../lib/plotFetch'
 
 export const PROBE_CACHE_KEY = 'plot_v1_capability_probe';
 const PROBE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -131,7 +132,7 @@ export async function probeCapability(
 
   try {
     // Step 1: Check health endpoint (primary: /v1/health)
-    const healthResponse = await fetch(`${resolvedBase}/v1/health`, {
+    const healthResponse = await plotFetch(`${resolvedBase}/v1/health`, {
       method: 'GET',
       signal: AbortSignal.timeout(5000),
     });
@@ -151,7 +152,7 @@ export async function probeCapability(
       }
 
       // Try fallback /health (non-versioned)
-      const fallbackResponse = await fetch(`${resolvedBase}/health`, {
+      const fallbackResponse = await plotFetch(`${resolvedBase}/health`, {
         method: 'GET',
         signal: AbortSignal.timeout(5000),
       });

--- a/src/adapters/plot/v1/sseClient.ts
+++ b/src/adapters/plot/v1/sseClient.ts
@@ -13,6 +13,7 @@ import type {
   V1Error,
 } from './types'
 import { TIMEOUTS } from './constants'
+import { plotFetch } from '../../../lib/plotFetch'
 // PR follow-up to #153: record the streaming SSE request + completion
 // into the payload-trace-store so the debug bundle's PLoT selector can
 // find this entry. Gate-checked inside the helpers; closed gate makes
@@ -133,7 +134,7 @@ export function runStream(
     },
   }
 
-  fetch(url, {
+  plotFetch(url, {
     method: 'POST',
     headers,
     body: JSON.stringify(requestForBody),

--- a/src/adapters/plot/v2/__tests__/runV2.plotBearer.spec.ts
+++ b/src/adapters/plot/v2/__tests__/runV2.plotBearer.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * runV2 PLoT Bearer seam — the CRITICAL analysis-run path.
+ *
+ * `runV2` is the fetch that `useV2Run` (and `useScenarioComparison`) drive for
+ * every analysis run — the single most important browser→PLoT call, and the one
+ * PR #428 did NOT cover. It now fetches through `plotFetch`, so the env-injected
+ * Bearer rides the real `POST ${baseUrl}/v2/run` request.
+ *
+ * The pin drives the REAL `runV2` (mirroring adapter.bodyStall.spec.ts) and
+ * asserts on the headers that reach the stubbed global `fetch` — not a
+ * hand-built object. Swapping `plotFetch` back to a bare `fetch` in adapter.ts
+ * turns the presence pin red.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { runV2 } from '../adapter'
+import type { V2AdapterConfig } from '../adapter'
+import type { V2RunRequest } from '../types'
+
+const config: V2AdapterConfig = { baseUrl: 'http://plot.test', timeout: 5000 }
+
+const request = {
+  request_id: 'req-bearer',
+  nodes: [],
+  edges: [],
+  options: [],
+} as unknown as V2RunRequest
+
+let fetchSpy: ReturnType<typeof vi.fn>
+let originalFetch: typeof globalThis.fetch
+
+function okFetch() {
+  return vi.fn((_url: string, _init?: RequestInit) =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      clone: () => ({ text: () => Promise.resolve('') }),
+      json: () => Promise.resolve({ status: 'ok', results: [] }),
+    }),
+  )
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  fetchSpy = okFetch()
+  globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+function headersOfFirstFetch(): Record<string, string> {
+  const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+  return (init?.headers ?? {}) as Record<string, string>
+}
+
+describe('runV2 PLoT Bearer seam (the analysis-run path)', () => {
+  it('attaches Authorization: Bearer <token> to POST /v2/run when VITE_PLOT_BEARER is set', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-run')
+
+    await runV2(config, request)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://plot.test/v2/run')
+    expect(headersOfFirstFetch().Authorization).toBe('Bearer staging-token-run')
+  })
+
+  it('attaches NO Authorization header when VITE_PLOT_BEARER is unset (fail-safe)', async () => {
+    await runV2(config, request)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch()).not.toHaveProperty('Authorization')
+  })
+})

--- a/src/adapters/plot/v2/adapter.ts
+++ b/src/adapters/plot/v2/adapter.ts
@@ -32,6 +32,7 @@ import type { CEEAnalysisReady, CEEGoalConstraint, CEEOptionV3 } from '../../cee
 import { recordRequestPayload, recordResponsePayload } from '../../../lib/payload-trace-store'
 import { STRENGTH_BOUNDS, clampStrength } from '../../../canvas/domain/edges'
 import { logger } from '../../../lib/logger'
+import { plotFetch } from '../../../lib/plotFetch'
 
 // ============================================================================
 // Canvas Data Types (input format)
@@ -1520,7 +1521,7 @@ export async function runV2(
   })
 
   try {
-    const response = await fetch(`${resolvedBaseUrl}/v2/run`, {
+    const response = await plotFetch(`${resolvedBaseUrl}/v2/run`, {
       method: 'POST',
       headers,
       body: JSON.stringify(request),

--- a/src/canvas/components/pre-analysis-v3/hooks/__tests__/useSensitivityRanking.plotBearer.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/hooks/__tests__/useSensitivityRanking.plotBearer.spec.tsx
@@ -1,0 +1,79 @@
+/**
+ * useSensitivityRanking PLoT Bearer seam — the pre-analysis-sensitivity call
+ * that the capture flagged as MISSING the Bearer (readiness had it; this seam
+ * did not). It now fetches through `plotFetch`, so the env-injected Bearer rides
+ * the real `POST ${plotProxyBase}/v1/pre-analysis-sensitivity` request.
+ *
+ * The pin renders the REAL hook (mirroring useSensitivityRanking.spec.tsx) with
+ * a graph that has no matching cached payload, so the debounced effect fetches,
+ * and asserts on the headers that reach the stubbed global `fetch`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { useSensitivityRanking } from '../useSensitivityRanking'
+import { useCanvasStore } from '../../../../store'
+
+function node(id: string, kind: string, label: string): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label } } as Node
+}
+
+type StoreEdge = Parameters<typeof useCanvasStore.setState>[0] extends infer S
+  ? S extends { edges?: Array<infer E> | undefined }
+    ? E
+    : never
+  : never
+
+function edge(id: string, source: string, target: string): StoreEdge {
+  return { id, source, target, data: { weight: 1, direction: 'positive' } } as StoreEdge
+}
+
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ factor_influence: { f1: 1 }, edge_influence: {}, method: 'linear' }),
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  fetchMock.mockClear()
+  vi.stubGlobal('fetch', fetchMock)
+  // No preAnalysisSensitivity → the hook cannot adopt a cached payload and must
+  // fetch for this structure.
+  useCanvasStore.setState({
+    nodes: [node('g1', 'goal', 'Goal'), node('f1', 'factor', 'Factor one'), node('o1', 'option', 'Option')],
+    edges: [edge('e1', 'f1', 'g1')],
+    preAnalysisSensitivity: undefined,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+function headersOfFirstFetch(): Record<string, string> {
+  const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+  return (init?.headers ?? {}) as Record<string, string>
+}
+
+describe('useSensitivityRanking PLoT Bearer seam', () => {
+  it('attaches Authorization: Bearer <token> to the sensitivity request when VITE_PLOT_BEARER is set', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-sens')
+
+    renderHook(() => useSensitivityRanking(true))
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch().Authorization).toBe('Bearer staging-token-sens')
+  })
+
+  it('attaches NO Authorization header when VITE_PLOT_BEARER is unset (fail-safe)', async () => {
+    renderHook(() => useSensitivityRanking(true))
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch()).not.toHaveProperty('Authorization')
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/hooks/useSensitivityRanking.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/useSensitivityRanking.ts
@@ -27,6 +27,7 @@
 import { useEffect, useRef } from 'react'
 import { useCanvasStore } from '../../../store'
 import { plotProxyBase } from '../../../../lib/config'
+import { plotFetch } from '../../../../lib/plotFetch'
 import { buildV2Request } from '../../../../adapters/plot/v2/adapter'
 import type { PreAnalysisSensitivity } from '../../../../adapters/cee/types'
 import { computeGraphFacts, kindOf } from '../selectors/graphFacts'
@@ -105,7 +106,7 @@ export function useSensitivityRanking(enabled: boolean): void {
           [],
           facts.goalNode!.id,
         )
-        const res = await fetch(`${plotProxyBase}/v1/pre-analysis-sensitivity`, {
+        const res = await plotFetch(`${plotProxyBase}/v1/pre-analysis-sensitivity`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
           body: JSON.stringify({ graph: request.graph, goal_node_id: request.goal_node_id }),

--- a/src/canvas/hooks/__tests__/useRecommendation.plotBearer.spec.tsx
+++ b/src/canvas/hooks/__tests__/useRecommendation.plotBearer.spec.tsx
@@ -1,0 +1,65 @@
+/**
+ * useRecommendation PLoT Bearer seam — the CEE recommendation call
+ * (`POST ${BFF_BASE_URL}/v1/recommend/generate`). It now fetches through
+ * `plotFetch`, so the env-injected Bearer rides the real outgoing request.
+ *
+ * The pin renders the REAL hook and drives its `fetch()` with a runId (so it
+ * reaches the network rather than the no-run-id fallback), asserting on the
+ * headers that reach the stubbed global `fetch`. This is the "one recommendation
+ * seam" pin; the sibling recommendation/analysis hooks share the identical
+ * `fetch( → plotFetch(` migration and the repo guard pins that they all do.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useRecommendation } from '../useRecommendation'
+import { useCanvasStore } from '../../store'
+
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ recommendation: { summary: 'ok' } }),
+}))
+
+beforeEach(() => {
+  fetchMock.mockClear()
+  vi.stubGlobal('fetch', fetchMock)
+  useCanvasStore.setState({ nodes: [], edges: [], results: null })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+function headersOfFirstFetch(): Record<string, string> {
+  const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+  return (init?.headers ?? {}) as Record<string, string>
+}
+
+describe('useRecommendation PLoT Bearer seam', () => {
+  it('attaches Authorization: Bearer <token> to the recommend/generate request when VITE_PLOT_BEARER is set', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-rec')
+
+    // Distinct runId per test — the hook keeps a module-level response cache
+    // keyed by runId, so a shared id would let the second test hit the cache
+    // instead of the network.
+    const { result } = renderHook(() => useRecommendation({ runId: 'run-present' }))
+    await act(async () => {
+      await result.current.fetch()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/v1/recommend/generate')
+    expect(headersOfFirstFetch().Authorization).toBe('Bearer staging-token-rec')
+  })
+
+  it('attaches NO Authorization header when VITE_PLOT_BEARER is unset (fail-safe)', async () => {
+    const { result } = renderHook(() => useRecommendation({ runId: 'run-absent' }))
+    await act(async () => {
+      await result.current.fetch()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstFetch()).not.toHaveProperty('Authorization')
+  })
+})

--- a/src/canvas/hooks/useConditionalRecommendations.ts
+++ b/src/canvas/hooks/useConditionalRecommendations.ts
@@ -13,6 +13,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { useCanvasStore } from '../store'
 import { useComparisonStore } from '../stores/comparisonStore'
+import { plotFetch } from '../../lib/plotFetch'
 import type {
   ConditionalRecommendRequest,
   ConditionalRecommendResponse,
@@ -108,7 +109,7 @@ export function useConditionalRecommendations(
     }
 
     try {
-      const response = await fetch(`${BFF_BASE_URL}/v1/analysis/conditional-recommend`, {
+      const response = await plotFetch(`${BFF_BASE_URL}/v1/analysis/conditional-recommend`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -153,7 +154,7 @@ export function useConditionalRecommendations(
     }
 
     try {
-      const response = await fetch(`${BFF_BASE_URL}/v1/narrate/conditions`, {
+      const response = await plotFetch(`${BFF_BASE_URL}/v1/narrate/conditions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/canvas/hooks/useEdgeFunctionSuggestion.ts
+++ b/src/canvas/hooks/useEdgeFunctionSuggestion.ts
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useCanvasStore } from '../store'
+import { plotFetch } from '../../lib/plotFetch'
 import type { EdgeFunctionType, EdgeFunctionParams } from '../domain/edges'
 
 export interface EdgeFunctionSuggestion {
@@ -108,7 +109,7 @@ export function useEdgeFunctionSuggestion({
       }
 
       // Call the suggest endpoint
-      const response = await fetch('/bff/engine/v1/suggest/edge-function', {
+      const response = await plotFetch('/bff/engine/v1/suggest/edge-function', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/canvas/hooks/useRecommendation.ts
+++ b/src/canvas/hooks/useRecommendation.ts
@@ -8,6 +8,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { useCanvasStore } from '../store'
 import { useComparisonStore } from '../stores/comparisonStore'
+import { plotFetch } from '../../lib/plotFetch'
 import type {
   GenerateRecommendationRequest,
   GenerateRecommendationResponse,
@@ -158,7 +159,7 @@ export function useRecommendation(
         narrative_style: narrativeStyle,
       }
 
-      const response = await fetch(`${BFF_BASE_URL}/v1/recommend/generate`, {
+      const response = await plotFetch(`${BFF_BASE_URL}/v1/recommend/generate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/canvas/hooks/useSequentialAnalysis.ts
+++ b/src/canvas/hooks/useSequentialAnalysis.ts
@@ -12,6 +12,7 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useCanvasStore } from '../store'
+import { plotFetch } from '../../lib/plotFetch'
 import type {
   SequentialMetadata,
   SequentialAnalysisRequest,
@@ -198,7 +199,7 @@ export function useSequentialAnalysis(
     }
 
     try {
-      const response = await fetch(`${BFF_BASE_URL}/v1/analysis/sequential`, {
+      const response = await plotFetch(`${BFF_BASE_URL}/v1/analysis/sequential`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -246,7 +247,7 @@ export function useSequentialAnalysis(
     }
 
     try {
-      const response = await fetch(`${BFF_BASE_URL}/v1/explain/policy`, {
+      const response = await plotFetch(`${BFF_BASE_URL}/v1/explain/policy`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/hooks/usePareto.ts
+++ b/src/hooks/usePareto.ts
@@ -12,6 +12,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react'
+import { plotFetch } from '../lib/plotFetch'
 
 const PARETO_ENDPOINT = '/bff/engine/v1/analysis/pareto'
 const REQUEST_TIMEOUT_MS = 10000
@@ -160,7 +161,7 @@ export function usePareto({
 
       const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
 
-      const response = await fetch(PARETO_ENDPOINT, {
+      const response = await plotFetch(PARETO_ENDPOINT, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/lib/__tests__/plotFetch.spec.ts
+++ b/src/lib/__tests__/plotFetch.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * plotFetch — unit pins for the one PLoT-direct fetch wrapper.
+ *
+ * Asserts the two behaviours the flip depends on:
+ *   · PRESENCE — with VITE_PLOT_BEARER set, the outgoing request carries
+ *     `Authorization: Bearer <token>`, merged over the caller's own headers.
+ *   · ABSENCE (fail-safe) — with it unset, the call is forwarded to the global
+ *     `fetch` UNTOUCHED: no Authorization header, and the very `init` reference
+ *     the caller passed reaches `fetch` unchanged (byte-for-byte identical to a
+ *     bare fetch).
+ *
+ * The global `fetch` is stubbed and the assertion is on what actually reached
+ * it — the same technique the two #428 seam specs use.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { plotFetch } from '../plotFetch'
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+function initOfFirstCall(): RequestInit | undefined {
+  return fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+}
+function headersOfFirstCall(): Record<string, string> {
+  return (initOfFirstCall()?.headers ?? {}) as Record<string, string>
+}
+
+describe('plotFetch', () => {
+  it('merges Authorization: Bearer <token> when VITE_PLOT_BEARER is set', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+    await plotFetch('/bff/engine/v1/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstCall()).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer staging-token-123',
+    })
+  })
+
+  it('passes the URL through unchanged regardless of which PLoT base was used', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+    await plotFetch('https://plot-lite-service-staging.onrender.com/v2/run', { method: 'POST' })
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('https://plot-lite-service-staging.onrender.com/v2/run')
+    expect(headersOfFirstCall().Authorization).toBe('Bearer staging-token-123')
+  })
+
+  it('attaches NO Authorization header when VITE_PLOT_BEARER is unset (fail-safe)', async () => {
+    await plotFetch('/bff/engine/v1/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(headersOfFirstCall()).not.toHaveProperty('Authorization')
+  })
+
+  it('forwards the exact same init reference untouched when the token is absent', async () => {
+    const init: RequestInit = { method: 'POST', headers: { 'X-Foo': 'bar' } }
+
+    await plotFetch('/bff/engine/v1/run', init)
+
+    // Byte-for-byte identical to a bare fetch: not cloned, not re-shaped.
+    expect(initOfFirstCall()).toBe(init)
+  })
+
+  it('works with no init at all (token absent → bare forward)', async () => {
+    await plotFetch('/bff/engine/v1/health')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('/bff/engine/v1/health')
+    expect(initOfFirstCall()).toBeUndefined()
+  })
+
+  it('merges the Bearer even when the caller passed no headers (token present)', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+    await plotFetch('/bff/engine/v1/health', { cache: 'no-store' })
+
+    expect(headersOfFirstCall().Authorization).toBe('Bearer staging-token-123')
+    // Non-header init survives the merge.
+    expect(initOfFirstCall()?.cache).toBe('no-store')
+  })
+
+  it('normalises a Headers-instance init and still injects the Bearer (defensive arm)', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+    await plotFetch('/bff/engine/v1/run', {
+      method: 'POST',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+    })
+
+    expect(headersOfFirstCall()).toMatchObject({
+      'content-type': 'application/json',
+      Authorization: 'Bearer staging-token-123',
+    })
+  })
+
+  it('the injected Bearer wins over a stale caller-supplied Authorization', async () => {
+    vi.stubEnv('VITE_PLOT_BEARER', 'fresh-token')
+
+    await plotFetch('/bff/engine/v1/run', {
+      headers: { Authorization: 'Bearer stale' },
+    })
+
+    expect(headersOfFirstCall().Authorization).toBe('Bearer fresh-token')
+  })
+})

--- a/src/lib/plotFetch.ts
+++ b/src/lib/plotFetch.ts
@@ -1,0 +1,84 @@
+/**
+ * plotFetch — the ONE seam through which every browser→PLoT request flows.
+ *
+ * WHY THIS EXISTS. PLoT's staging auth flip turns the plain Netlify pass-through
+ * `/bff/engine/*` (netlify.toml: `/bff/engine/*` → plot-lite-service-staging,
+ * no header injection) from open to Bearer-gated. Any browser `fetch` that hits
+ * a PLoT base WITHOUT the token would start returning 401 the moment the flip
+ * lands. PR #428 attached the Bearer to the two CEE-family seams
+ * (readinessStore's graph-readiness call and the CEE client's `fetchWithBase`),
+ * but ~a-dozen OTHER PLoT-direct seams — the analysis-run path (useV2Run →
+ * v2/adapter), every recommendation/analysis hook, the V1 engine client, the
+ * sensitivity ranker, the SafeMode health probe — still sent no header. Nine
+ * of those would have flipped red.
+ *
+ * Rather than a global monkey-patch of `window.fetch` (invisible, order- and
+ * test-hostile, and it would touch Supabase / CEE-assist / ISL / static-asset
+ * fetches it has no business touching), this is ONE explicit, greppable wrapper
+ * that every PLoT-direct caller routes through. It merges `plotAuthHeaders()`
+ * (from PR #428) into the outgoing request's headers and is otherwise a
+ * pass-through. The header is applied REGARDLESS of which PLoT base the caller
+ * used — callers pass their own fully-formed URLs; this wrapper never inspects
+ * or rewrites them.
+ *
+ * FAIL-SAFE (the precondition for a zero-breakage flip). `plotAuthHeaders()`
+ * returns `{}` until `VITE_PLOT_BEARER` is provisioned. When it is empty this
+ * function forwards `(input, init)` to the global `fetch` UNTOUCHED — same
+ * references, same header object, no clone — so today's behaviour is
+ * byte-for-byte identical everywhere it is installed, and the absence pins stay
+ * green. The header only materialises once the env var is set.
+ *
+ * The signature mirrors `fetch`, so migrating a seam is a mechanical
+ * `fetch(` → `plotFetch(` rename plus this import; no call-site restructuring.
+ *
+ * A repo guard (tests/ci-guards/plot-fetch-all-seams.spec.ts) fails CI if a bare
+ * `fetch(` to a PLoT base is introduced outside this wrapper — the tenth-seam
+ * preventer.
+ */
+import { plotAuthHeaders } from './plotAuthHeaders'
+
+/**
+ * Merge the (already-normalised, plain-object) auth headers over whatever the
+ * caller passed as `init.headers`. Returns a plain `Record<string, string>` so
+ * every PLoT seam ends up with a predictable header shape.
+ *
+ * Only runs on the token-present branch — i.e. once the flip is happening — so a
+ * `Headers`/tuple-array caller (none exist among the PLoT seams today; this arm
+ * is defensive) being normalised to a record here never affects the fail-safe,
+ * byte-identical, token-absent path below.
+ */
+function mergeAuthHeaders(
+  base: HeadersInit | undefined,
+  auth: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (base instanceof Headers) {
+    base.forEach((value, key) => {
+      out[key] = value
+    })
+  } else if (Array.isArray(base)) {
+    for (const [key, value] of base) out[key] = value
+  } else if (base) {
+    Object.assign(out, base)
+  }
+  // Auth wins on collision — the flip's Bearer must not be shadowed by a stale
+  // caller-supplied Authorization.
+  Object.assign(out, auth)
+  return out
+}
+
+/**
+ * `fetch`, with the optional env-injected PLoT Bearer merged in. Drop-in for the
+ * global `fetch` on any browser→PLoT call.
+ */
+export function plotFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const auth = plotAuthHeaders()
+
+  // FAIL-SAFE: no token → forward untouched, byte-for-byte identical to a bare
+  // `fetch`. This is the token-absent path that reproduces today's behaviour.
+  if (Object.keys(auth).length === 0) {
+    return fetch(input, init)
+  }
+
+  return fetch(input, { ...init, headers: mergeAuthHeaders(init?.headers, auth) })
+}

--- a/src/pages/sandbox-guide/hooks/useCompareData.ts
+++ b/src/pages/sandbox-guide/hooks/useCompareData.ts
@@ -11,6 +11,7 @@
 
 import { useState, useEffect } from 'react'
 import { loadRuns, type StoredRun } from '../../../canvas/store/runHistory'
+import { plotFetch } from '../../../lib/plotFetch'
 
 export interface CompareData {
   baseline: StoredRun | null
@@ -123,7 +124,7 @@ export function useCompareData({
       setError(null)
 
       try {
-        const response = await fetch('/bff/engine/v1/diff', {
+        const response = await plotFetch('/bff/engine/v1/diff', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/src/poc/SafeMode.tsx
+++ b/src/poc/SafeMode.tsx
@@ -1,5 +1,6 @@
 // POC: minimal, dependency-light safe UI that can't fail
 import React from 'react'
+import { plotFetch } from '../lib/plotFetch'
 
 export default function SafeMode() {
   const [engine, setEngine] = React.useState<{ ok?: boolean; json?: any; err?: string }>({})
@@ -18,7 +19,7 @@ export default function SafeMode() {
     ;(async () => {
       for (const u of urls) {
         try {
-          const r = await fetch(u, { cache: 'no-store', mode: 'cors' })
+          const r = await plotFetch(u, { cache: 'no-store', mode: 'cors' })
           const j = await r.json()
           setEngine({ ok: true, json: j })
           if (import.meta.env.DEV) {

--- a/tests/ci-guards/plot-fetch-all-seams.spec.ts
+++ b/tests/ci-guards/plot-fetch-all-seams.spec.ts
@@ -1,0 +1,262 @@
+/**
+ * plotFetch SEAM guard — the tenth-seam preventer.
+ *
+ * THE DEFECT CLASS. PLoT's staging auth flip Bearer-gates the plain Netlify
+ * pass-through `/bff/engine/*` (netlify.toml: `/bff/engine/*` →
+ * plot-lite-service-staging, no header injection). Any browser `fetch` that hits
+ * a PLoT base without the token starts 401-ing the instant the flip lands. PR
+ * #428 wired the Bearer into the two CEE-family seams; this change routes every
+ * OTHER PLoT-direct seam through `src/lib/plotFetch.ts`, which merges
+ * `plotAuthHeaders()` for all of them at once. The residual risk is the ELEVENTH
+ * hand: a new hook, copy-pasted from `useRecommendation` / `usePareto` /
+ * `useEdgeFunctionSuggestion`, that writes `fetch('/bff/engine/v1/…')` or
+ * `fetch(\`${BFF_BASE_URL}/…\`)` and silently sends no header again. Nothing in
+ * TypeScript or ESLint objects. This guard does.
+ *
+ * WHAT IT FLAGS. A bare `fetch(` (not `plotFetch(`, not `.fetch(`, not
+ * `deduplicatedFetch(`) in src/ whose FIRST argument — the URL — references a
+ * PLoT base:
+ *   · a literal PLoT path/host  (`/bff/engine`, `plot-lite-service`), or
+ *   · a PLoT base env token      (`VITE_PLOT_PROXY_BASE`, `VITE_BFF_BASE`), or
+ *   · an identifier bound to one of those in the same file (`BFF_BASE_URL`,
+ *     `proxyBase`, `PARETO_ENDPOINT = '/bff/engine/…'`), or the shared
+ *     `plotProxyBase` export from lib/config.
+ * It deliberately does NOT flag other-service seams (`/bff/cee`, `/bff/assist`,
+ * `/bff/isl`, `/bff/orchestrate`), Supabase `/functions/v1/*`, the POC edge
+ * gateway, or static-asset fetches — those are not PLoT and the flip does not
+ * touch them. The URL check is on the FIRST argument only, so a `/bff/engine`
+ * string sitting in a request BODY does not trip it.
+ *
+ * WHY A SOURCE SCAN, AND WHY COMMENT-STRIPPED. The seam is a coding convention
+ * ("reach PLoT only through plotFetch"), and a convention is enforced by reading
+ * the source. Comments are stripped FIRST, via the shared literal-aware
+ * `stripComments` (tests/helpers/stripSourceComments) — the same stripper the
+ * alpha-emission guard uses — because this repo's dominant guard footgun (#385,
+ * #386) is a source-scanning guard reddening CI over a token that lives only in
+ * a comment or a documentation example. A `fetch('/bff/engine/…')` written in a
+ * JSDoc block ships nothing and must not fail CI; the comment-strip control at
+ * the foot of this file pins that, and it is the guard's own mutation check that
+ * the stripper is actually wired in.
+ *
+ * CONTROLS (run every CI pass, not once by hand):
+ *   · POSITIVE — an injected bare `fetch('/bff/engine/…')` and a
+ *     `fetch(\`${BASE}/…\`)` (BASE bound to a PLoT token) in a scratch file MUST
+ *     be flagged, proving the scanner can see a violation at all.
+ *   · NEGATIVE — the SAME calls rewritten as `plotFetch(…)`, a genuinely
+ *     non-PLoT `fetch('/bff/assist/…')`, and a `fetch('/version.json')` must NOT
+ *     be flagged, proving the scanner is PLoT-scoped and plotFetch-aware rather
+ *     than a blunt "no fetch anywhere" rule.
+ *   · COMMENT — a `fetch('/bff/engine/…')` that exists ONLY inside a `//` and a
+ *     `/* *\/` comment must NOT be flagged (the #385/#386 footgun).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { join, resolve as resolvePath } from 'node:path'
+import { tmpdir } from 'node:os'
+import { stripComments } from '../helpers/stripSourceComments'
+
+const SRC = resolvePath(__dirname, '../../src')
+
+/** The one sanctioned bare-`fetch` seam — the wrapper itself. */
+const WRAPPER = resolvePath(SRC, 'lib/plotFetch.ts')
+
+/** Literal PLoT base markers that may appear directly in a fetch URL argument. */
+const PLOT_LITERAL = /\/bff\/engine|plot-lite-service|VITE_PLOT_PROXY_BASE|VITE_BFF_BASE/
+
+/** The shared PLoT base export from lib/config — always a base identifier. */
+const KNOWN_BASE_NAMES = ['plotProxyBase']
+
+/** A bare `fetch(` — not `.fetch(`, `refetch(`, `plotFetch(`, `deduplicatedFetch(`. */
+const BARE_FETCH = /(?<![\w.$])fetch\s*\(/g
+
+/** `const|let|var NAME = <initialiser up to end-of-line>` — for base discovery. */
+const BINDING = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([^\n]*)/g
+
+interface Violation {
+  file: string
+  line: number
+  snippet: string
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      walk(p, out)
+    } else if (/\.(ts|tsx)$/.test(p) && !/\.(spec|test)\.tsx?$/.test(p) && !/\.d\.ts$/.test(p)) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+/**
+ * The first-argument expression of a `fetch(` call, extracted by balancing
+ * `()[]{}` and skipping `'`/`"`/`` ` `` literals (template `${…}` interpolations
+ * are followed so a comma inside one does not end the argument). `open` points at
+ * the `(` immediately after `fetch`.
+ */
+function firstArg(src: string, open: number): string {
+  let i = open + 1
+  const start = i
+  let depth = 1
+  const n = src.length
+  while (i < n) {
+    const c = src[i]
+    if (c === "'" || c === '"') {
+      const quote = c
+      i++
+      while (i < n && src[i] !== quote) {
+        if (src[i] === '\\') i++
+        i++
+      }
+      i++
+      continue
+    }
+    if (c === '`') {
+      i++
+      while (i < n && src[i] !== '`') {
+        if (src[i] === '\\') { i += 2; continue }
+        if (src[i] === '$' && src[i + 1] === '{') {
+          let braces = 1
+          i += 2
+          while (i < n && braces > 0) {
+            if (src[i] === '{') braces++
+            else if (src[i] === '}') braces--
+            i++
+          }
+          continue
+        }
+        i++
+      }
+      i++
+      continue
+    }
+    if (c === '(' || c === '[' || c === '{') { depth++; i++; continue }
+    if (c === ')' || c === ']' || c === '}') {
+      depth--
+      if (depth === 0) return src.slice(start, i)
+      i++
+      continue
+    }
+    if (c === ',' && depth === 1) return src.slice(start, i)
+    i++
+  }
+  return src.slice(start, i)
+}
+
+/** Every PLoT-direct bare `fetch(` in `root` that does NOT go through plotFetch. */
+function plotViolations(root: string = SRC): Violation[] {
+  const violations: Violation[] = []
+  for (const file of walk(root)) {
+    if (resolvePath(file) === WRAPPER) continue
+    const raw = readFileSync(file, 'utf8')
+    const text = stripComments(raw, file)
+
+    // Base identifiers bound to a PLoT token IN THIS FILE, plus the shared export.
+    const bases = new Set<string>(KNOWN_BASE_NAMES)
+    for (const m of text.matchAll(BINDING)) {
+      if (PLOT_LITERAL.test(m[2])) bases.add(m[1])
+    }
+    const basePattern = bases.size
+      ? new RegExp(`\\b(?:${[...bases].map((b) => b.replace(/[$]/g, '\\$&')).join('|')})\\b`)
+      : null
+
+    for (const m of text.matchAll(BARE_FETCH)) {
+      const arg = firstArg(text, m.index! + m[0].length - 1)
+      const hitsLiteral = PLOT_LITERAL.test(arg)
+      const hitsBase = basePattern ? basePattern.test(arg) : false
+      if (hitsLiteral || hitsBase) {
+        const line = text.slice(0, m.index!).split('\n').length
+        violations.push({
+          file: file.slice(root.length + 1),
+          line,
+          snippet: raw.split('\n')[line - 1]?.trim() ?? '',
+        })
+      }
+    }
+  }
+  return violations
+}
+
+describe('every PLoT-direct fetch seam goes through plotFetch', () => {
+  it('src/ contains no bare fetch() to a PLoT base outside the plotFetch wrapper', () => {
+    const violations = plotViolations()
+    expect(
+      violations,
+      violations.length
+        ? `these bare fetch() calls hit a PLoT base (/bff/engine, VITE_PLOT_PROXY_BASE, ` +
+            `VITE_BFF_BASE, plot-lite-service) without the env-injected Bearer, so they will ` +
+            `401 the moment PLoT's auth flip lands. Route each through src/lib/plotFetch.ts ` +
+            `(a mechanical fetch( → plotFetch( rename plus the import):\n` +
+            violations.map((v) => `  ${v.file}:${v.line}  ${v.snippet}`).join('\n')
+        : '',
+    ).toEqual([])
+  })
+
+  it('POSITIVE + NEGATIVE controls: the scanner sees a real violation and clears a migrated one', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plot-fetch-guard-'))
+    try {
+      // POSITIVE — a literal PLoT path and a base-bound template, both un-migrated.
+      writeFileSync(
+        join(dir, 'offender-literal.ts'),
+        `export const go = () => fetch('/bff/engine/v1/analysis/new-thing', { method: 'POST' })\n`,
+      )
+      writeFileSync(
+        join(dir, 'offender-base.ts'),
+        `const BFF_BASE_URL = import.meta.env.VITE_BFF_BASE || '/bff/engine'\n` +
+          `export const go = () => fetch(\`\${BFF_BASE_URL}/v1/x\`, { method: 'POST' })\n`,
+      )
+      writeFileSync(
+        join(dir, 'offender-shared-base.ts'),
+        `import { plotProxyBase } from '../../../lib/config'\n` +
+          `export const go = () => fetch(\`\${plotProxyBase}/v1/x\`)\n`,
+      )
+      // NEGATIVE — migrated (plotFetch), and genuinely non-PLoT fetches.
+      writeFileSync(
+        join(dir, 'migrated.ts'),
+        `import { plotFetch } from '../../../lib/plotFetch'\n` +
+          `export const go = () => plotFetch('/bff/engine/v1/analysis/new-thing', { method: 'POST' })\n`,
+      )
+      writeFileSync(
+        join(dir, 'other-service.ts'),
+        `export const a = () => fetch('/bff/assist/suggest-options', { method: 'POST' })\n` +
+          `export const b = () => fetch('/bff/cee/graph-readiness')\n` +
+          `export const c = () => fetch('/version.json')\n`,
+      )
+
+      const v = plotViolations(dir)
+      const files = v.map((x) => x.file).sort()
+      expect(files, 'the three un-migrated PLoT seams must be flagged').toEqual([
+        'offender-base.ts',
+        'offender-literal.ts',
+        'offender-shared-base.ts',
+      ])
+      // And nothing else — plotFetch and non-PLoT fetches are clean.
+      expect(v.some((x) => x.file === 'migrated.ts')).toBe(false)
+      expect(v.some((x) => x.file === 'other-service.ts')).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('COMMENT control: a PLoT fetch that lives only in a comment is not flagged (#385/#386)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'plot-fetch-guard-cmt-'))
+    try {
+      writeFileSync(
+        join(dir, 'documented.ts'),
+        `// never write fetch('/bff/engine/v1/x') directly — use plotFetch\n` +
+          `/* example of the anti-pattern: fetch('/bff/engine/v1/y') */\n` +
+          `import { plotFetch } from '../../../lib/plotFetch'\n` +
+          `export const go = () => plotFetch('/bff/engine/v1/real')\n`,
+      )
+      expect(
+        plotViolations(dir),
+        'a fetch() quoted only in a comment ships nothing and must not fail CI',
+      ).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Why (capture evidence)

PLoT's staging auth flip Bearer-gates the plain Netlify pass-through `/bff/engine/*` (netlify.toml → `plot-lite-service-staging.onrender.com/:splat`, **no header injection**). PR #428 attached the env-injected Bearer to the two CEE-family seams, but a capture showed the gap: **readiness carried the Bearer; pre-analysis-sensitivity did not.** Every other browser→PLoT fetch — most critically the analysis-run path itself (`useV2Run` → `runV2`) — would start returning 401 the moment the flip lands.

## The fix — one explicit shared seam

`src/lib/plotFetch.ts`: a thin wrapper mirroring `fetch`'s signature that merges `plotAuthHeaders()` (from #428) into the outgoing request, regardless of which PLoT base the caller used. **Fail-safe:** with `VITE_PLOT_BEARER` unset it forwards `(input, init)` to the global `fetch` *untouched* — today's behaviour is byte-for-byte identical everywhere; the header only appears once the env var is set. No global monkey-patch.

## Complete seam manifest (migrated `fetch( → plotFetch(`)

**Feature hooks (the ~9):**
- `canvas/components/pre-analysis-v3/hooks/useSensitivityRanking.ts` (`${plotProxyBase}/v1/pre-analysis-sensitivity`)
- `canvas/hooks/useEdgeFunctionSuggestion.ts` (`/bff/engine/v1/suggest/edge-function`)
- `canvas/hooks/useSequentialAnalysis.ts` ×2 (`/v1/analysis/sequential`, `/v1/explain/policy`)
- `canvas/hooks/useConditionalRecommendations.ts` ×2 (`/v1/analysis/conditional-recommend`, `/v1/narrate/conditions`)
- `canvas/hooks/useRecommendation.ts` (`/v1/recommend/generate`)
- `hooks/usePareto.ts` (`/bff/engine/v1/analysis/pareto`) — found by grep
- `pages/sandbox-guide/hooks/useCompareData.ts` (`/bff/engine/v1/diff`) — found by grep
- `poc/SafeMode.tsx` (`${proxyBase}/v1/health`)

**Analysis-run path (the critical seam #428 missed):**
- `adapters/plot/v2/adapter.ts` `runV2` (`${resolvedBaseUrl}/v2/run`) — the single injection point covering **both** `useV2Run:509` and `useScenarioComparison:405` (they feed this runner's `baseUrl`).

**V1 engine client (live PLoT-direct calls that would also 401):**
- `adapters/plot/v1/http.ts` ×9 (version, run, health, cancel, templates ×2, limits, validate, run_bundle)
- `adapters/plot/v1/health.ts`, `limits.ts`, `probe.ts` ×2, `sseClient.ts`

**Left as-is (already covered by #428, not guard targets):**
- `canvas/stores/readinessStore.ts` — Bearer threaded through `deduplicatedFetch` (not a bare fetch); base is `/bff/cee`.
- `adapters/cee/client.ts` `fetchWithBase` — already spreads `...plotAuthHeaders()`; its fetch URL is a param, so the guard doesn't flag it. Its #428 spec stays green.

## The repo guard (tenth-seam preventer)

`tests/ci-guards/plot-fetch-all-seams.spec.ts` scans `src/` for any bare `fetch(` whose first argument references a PLoT base (`/bff/engine`, `VITE_PLOT_PROXY_BASE`, `VITE_BFF_BASE`, `plot-lite-service`, or a same-file/imported base identifier) outside the wrapper, and fails with a `file:line` message. Comments are stripped first via the shared literal-aware `stripComments` (the #385/#386 comment-scanning footgun). Positive/negative/comment controls mutation-check the scanner every CI pass. Verified empirically: reverting one migrated seam to a bare `fetch(` trips it (`useEdgeFunctionSuggestion.ts:112`); the migrated sites do not.

## Tests / gates
- `plotFetch` unit pins (presence, absence/byte-identical forward, header merge).
- Per-seam presence+absence pins: `runV2` (run path), `useSensitivityRanking`, `useRecommendation`.
- #428 specs stay green.
- Wide `tsc -p tsconfig.ci.json`: zero net-new errors. Plot-adapter suites (530) + migrated-hook suites (51) green.

Do not merge — draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)