### PR TITLE
fix(guards): strip CSS comments before reading token values (two silent wrong-value footguns)

### DIFF
--- a/src/styles/__tests__/brand-tokens.spec.ts
+++ b/src/styles/__tests__/brand-tokens.spec.ts
@@ -44,8 +44,19 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { resolveTokenHex } from '../channelTriple.mjs'
+import { stripComments } from '../../../tests/helpers/stripSourceComments'
 
 const css = readFileSync(join(__dirname, '../brand.css'), 'utf-8')
+
+/**
+ * brand.css with block comments blanked (newline-preserving). `token()` and the
+ * "no superseded hex in declarations" pin both scan this, not the raw text: a
+ * multiline `^--x:` regex over raw text takes the FIRST match, so a superseded
+ * value quoted at line-start inside a design-note comment ABOVE the live
+ * declaration would be read as the live value (the silent-wrong-read footgun the
+ * shared stripper exists to close). resolveTokenHex already strips internally.
+ */
+const cssNoComments = stripComments(css, 'brand.css')
 
 /**
  * The RAW declared text of a `--token` in brand.css — not resolved.
@@ -55,7 +66,7 @@ const css = readFileSync(join(__dirname, '../brand.css'), 'utf-8')
  * semantic tokens and would be measured as a malformed colour.
  */
 function token(name: string): string {
-  const m = css.match(new RegExp(`^\\s*--${name}:\\s*([^;]+);`, 'm'))
+  const m = cssNoComments.match(new RegExp(`^\\s*--${name}:\\s*([^;]+);`, 'm'))
   if (!m) throw new Error(`brand.css: --${name} not found`)
   return m[1].trim()
 }
@@ -199,8 +210,9 @@ describe('D1 — canonical info blue', () => {
 
   it('no superseded info-blue hex survives in brand.css declarations', () => {
     // Comments may reference the old values as history; declarations may not.
-    const declarations = css
-      .replace(/\/\*[\s\S]*?\*\//g, '')
+    // Scan the shared-stripper output so this pin and `token()` agree on what
+    // counts as a comment, instead of carrying a second local strip regex.
+    const declarations = cssNoComments
       .split('\n')
       .filter(l => l.includes('--'))
       .join('\n')

--- a/src/styles/channelTriple.mjs
+++ b/src/styles/channelTriple.mjs
@@ -102,15 +102,75 @@ function resolveTripleProperty(name, lookup, depth = 0) {
 }
 
 /**
+ * Strip CSS block comments from a source string, replacing comment characters
+ * with spaces so newlines and column offsets are preserved. Literal-aware: a
+ * comment-open sequence that appears inside a single- or double-quoted CSS
+ * string (e.g. `content: "..."`) stays code and is not treated as a comment.
+ *
+ * WHY declaredValue NEEDS THIS. The declaration regex uses a multiline `^` and
+ * takes the FIRST match, so a superseded value quoted at line-start inside a
+ * design-note comment ABOVE the live declaration was returned INSTEAD of the
+ * live value — a silent wrong read (a comment holding old `--text-light:
+ * #908D8D` shadowed the live `#6E6B6B`). Stripping comments first makes the
+ * first match the live declaration.
+ *
+ * This mirrors `stripCssComments` in tests/helpers/stripSourceComments.ts. It is
+ * re-implemented here rather than imported because this module is `.mjs`,
+ * consumed by the plain node script scripts/css-var-census.mjs which cannot
+ * import a TypeScript helper — the same constraint that already forces this
+ * module to be `.mjs` (see the header). CSS has no `//` line comments, so only
+ * the block-comment form is handled.
+ *
+ * @param {string} css
+ * @returns {string}
+ */
+function stripCssComments(css) {
+  const a = String(css).split('')
+  const n = a.length
+  const blank = (i) => {
+    if (a[i] !== '\n' && a[i] !== '\r') a[i] = ' '
+  }
+  /** @type {'code' | 'block' | 'single' | 'double'} */
+  let state = 'code'
+  let i = 0
+  while (i < n) {
+    const c = a[i]
+    const d = i + 1 < n ? a[i + 1] : ''
+    if (state === 'code') {
+      if (c === '/' && d === '*') { blank(i); blank(i + 1); state = 'block'; i += 2; continue }
+      if (c === "'") { state = 'single'; i++; continue }
+      if (c === '"') { state = 'double'; i++; continue }
+      i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { blank(i); blank(i + 1); state = 'code'; i += 2; continue }
+      blank(i); i++; continue
+    }
+    if (state === 'single') {
+      if (c === '\\') { i += 2; continue }
+      if (c === "'") { state = 'code'; i++; continue }
+      i++; continue
+    }
+    // state === 'double'
+    if (c === '\\') { i += 2; continue }
+    if (c === '"') { state = 'code'; i++; continue }
+    i++
+  }
+  return a.join('')
+}
+
+/**
  * Read a `--token`'s declared value straight out of a brand.css source string.
- * Shared so the callers do not each carry their own declaration regex.
+ * Shared so the callers do not each carry their own declaration regex. Comments
+ * are stripped first (see `stripCssComments`) so a declaration quoted inside a
+ * comment cannot be mistaken for the live one.
  *
  * @param {string} css
  * @param {string} token  including the leading `--`
  * @returns {string | null}
  */
 export function declaredValue(css, token) {
-  const m = css.match(new RegExp(`^\\s*${token}:\\s*([^;]+);`, 'm'))
+  const m = stripCssComments(css).match(new RegExp(`^\\s*${token}:\\s*([^;]+);`, 'm'))
   return m ? m[1].trim() : null
 }
 

--- a/tests/helpers/__tests__/stripSourceComments.spec.ts
+++ b/tests/helpers/__tests__/stripSourceComments.spec.ts
@@ -11,7 +11,7 @@
  * could quietly weaken every guard at once. This is that missing direct pin.
  *
  * The properties asserted are exactly the ones the guards depend on:
- *   - JS `//` line and `/* … *​/` block comments are removed;
+ *   - JS `//` line and `/*` block comments are removed;
  *   - string, template and regex literals are KEPT as code (their contents, incl.
  *     comment-like sequences, survive) — so a real call site is still seen;
  *   - CSS gets block-comment stripping only (no `//` line comments);

--- a/tests/helpers/__tests__/stripSourceComments.spec.ts
+++ b/tests/helpers/__tests__/stripSourceComments.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit contract for the shared literal-aware comment stripper.
+ *
+ * WHY THIS EXISTS. `tests/helpers/stripSourceComments.ts` is imported by a growing
+ * set of source-scanning CI guards (semantic-colour-alpha, plot-fetch-all-seams,
+ * british-english, the analysis-hero hygiene/inertness family, the freshness and
+ * templates routing guards, …) and by the brand-token colour pins via
+ * channelTriple.mjs' sibling strip. Each guard carries its own positive control,
+ * but none pins the stripper's OWN literal-awareness directly — so a regression in
+ * the state machine (a mangled regex literal, a `//` swallowed inside a URL string)
+ * could quietly weaken every guard at once. This is that missing direct pin.
+ *
+ * The properties asserted are exactly the ones the guards depend on:
+ *   - JS `//` line and `/* … *​/` block comments are removed;
+ *   - string, template and regex literals are KEPT as code (their contents, incl.
+ *     comment-like sequences, survive) — so a real call site is still seen;
+ *   - CSS gets block-comment stripping only (no `//` line comments);
+ *   - every stripper is byte-length- and newline-preserving, so a guard's reported
+ *     line/column never shifts.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  stripComments,
+  stripJsComments,
+  stripCssComments,
+  stripHtmlComments,
+  blankNonCode,
+  regexCanStart,
+} from '../stripSourceComments'
+
+/** Byte-length and every newline offset are preserved by a stripper. */
+function preservesLayout(strip: (s: string) => string, input: string): void {
+  const out = strip(input)
+  expect(out.length).toBe(input.length)
+  const nl = (s: string) => [...s].map((c, i) => (c === '\n' ? i : -1)).filter(i => i >= 0)
+  expect(nl(out)).toEqual(nl(input))
+}
+
+describe('stripJsComments — comments go, literals stay', () => {
+  it('blanks a `//` line comment but keeps the code before it', () => {
+    const out = stripJsComments('const x = 1 // secretword')
+    expect(out).toContain('const x = 1')
+    expect(out).not.toContain('secretword')
+  })
+
+  it('blanks a `/* … */` block comment, including multi-line', () => {
+    const out = stripJsComments('a /* one\n two secretword */ b')
+    expect(out).toContain('a')
+    expect(out).toContain('b')
+    expect(out).not.toContain('secretword')
+  })
+
+  it('keeps `//` inside a string literal (a URL is not a comment)', () => {
+    const out = stripJsComments('const u = "http://example.com/x" // real comment')
+    expect(out).toContain('http://example.com/x')
+    expect(out).not.toContain('real comment')
+  })
+
+  it('keeps `/* */` inside a string literal', () => {
+    const out = stripJsComments('const s = "/* not a comment */ keepme"')
+    expect(out).toContain('/* not a comment */ keepme')
+  })
+
+  it('keeps a regex literal whole (its slashes are not comment starts)', () => {
+    const out = stripJsComments('const re = /a\\/b\\/c/g // trailing')
+    expect(out).toContain('/a\\/b\\/c/g')
+    expect(out).not.toContain('trailing')
+  })
+
+  it('treats `/` after a value as division, and still strips the line comment', () => {
+    const out = stripJsComments('const y = a / b // gone')
+    expect(out).toContain('a / b')
+    expect(out).not.toContain('gone')
+  })
+
+  it('keeps comment-like sequences inside a template literal', () => {
+    const out = stripJsComments('const t = `pre // still /* here */ post`')
+    expect(out).toContain('pre // still /* here */ post')
+  })
+
+  it('keeps code inside `${…}` interpolation while stripping a real trailing comment', () => {
+    const out = stripJsComments('const t = `x ${weight / 2} y` // dropme')
+    expect(out).toContain('${weight / 2}')
+    expect(out).not.toContain('dropme')
+  })
+
+  it('is byte-length- and newline-preserving', () => {
+    preservesLayout(stripJsComments, 'line1 // c\nline2 /* b\nb */ line3\n')
+  })
+})
+
+describe('stripComments — dispatches on file extension', () => {
+  it('.ts input is treated as JS (line comments stripped)', () => {
+    expect(stripComments('a // b', 'x.ts')).not.toContain('b')
+  })
+
+  it('.css input is treated as CSS (no `//` line comments — they survive)', () => {
+    // In CSS `//` is NOT a comment; the JS path would wrongly blank it.
+    expect(stripComments('a // b', 'x.css')).toContain('// b')
+  })
+})
+
+describe('stripCssComments — block comments only, literal-aware', () => {
+  it('blanks a `/* … */` block, keeping the live declaration as the survivor', () => {
+    const out = stripCssComments(':root {\n/* --x: 2; */\n  --x: 1;\n}')
+    expect(out).toContain('--x: 1;')
+    expect(out).not.toContain('--x: 2;')
+  })
+
+  it('does NOT treat `//` as a comment (CSS has no line comments)', () => {
+    expect(stripCssComments('--url: "//cdn.example.com";')).toContain('//cdn.example.com')
+  })
+
+  it('keeps `/*` that lives inside a CSS string literal', () => {
+    expect(stripCssComments('content: "/* literal */";')).toContain('"/* literal */"')
+  })
+
+  it('is byte-length- and newline-preserving', () => {
+    preservesLayout(stripCssComments, ':root {\n  /* a\n  b */\n  --x: 1;\n}\n')
+  })
+})
+
+describe('blankNonCode — comments AND string bodies blanked, quote kept', () => {
+  it('blanks a string body but keeps the opening quote and surrounding code', () => {
+    const out = blankNonCode('const s = "secretword" // note')
+    expect(out).toContain('const s =')
+    expect(out).toContain('"') // opening quote kept so the token still parses
+    expect(out).not.toContain('secretword')
+    expect(out).not.toContain('note')
+  })
+
+  it('is byte-length- and newline-preserving', () => {
+    preservesLayout(blankNonCode, 'const s = "a\\nb" /* c */\nconst t = 1\n')
+  })
+})
+
+describe('stripHtmlComments — HTML markers and script-body JS comments', () => {
+  it('blanks `<!-- -->` and JS comments in <script>, keeping a URL string', () => {
+    const out = stripHtmlComments(
+      '<!-- htmlsecret --><script>const u = "http://y.example"// jssecret\n</script>',
+    )
+    expect(out).not.toContain('htmlsecret')
+    expect(out).not.toContain('jssecret')
+    expect(out).toContain('http://y.example')
+  })
+})
+
+describe('regexCanStart — the value-vs-regex discriminator', () => {
+  it('a `/` after a value char is division, not a regex open', () => {
+    for (const prev of ['a', '1', ')', ']', '}', '.', "'", '"', '`']) {
+      expect(regexCanStart(prev)).toBe(false)
+    }
+  })
+
+  it('a `/` at file start or after an operator/opener opens a regex', () => {
+    for (const prev of ['', '=', '(', ',', '[', '{', ';', ':', '!', '&', '|', '?', '+', '-', '*', '<', '>']) {
+      expect(regexCanStart(prev)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## What & why

Fixes the **two silent wrong-value footguns** the guard-comment audit (`GUARD-COMMENT-FOOTGUN-AUDIT-2026-07-19.md`) singled out as *worse than a red CI*, plus adds the missing direct unit spec for the shared comment stripper.

> **The two findings that are worse than red CI.** Most of this class costs a spurious CI failure. **These two make a guard read the WRONG VALUE, silently:**
> 1. `src/styles/channelTriple.mjs` — `declaredValue()` … multiline `^`, **first match wins, no comment awareness**. A superseded token value left in a comment *above* the real declaration is returned **instead of** the real one.
> 2. `src/styles/__tests__/brand-tokens.spec.ts` — same mechanism against `brand.css`.
>
> **Why that matters more:** a red CI is loud and gets fixed. A guard silently asserting against a *commented-out historical value* is a broken alarm that passes — it will happily certify the wrong colour.

Both mechanisms are one regex: `css.match(new RegExp('^\\s*' + token + ':\\s*([^;]+);', 'm'))` — multiline `^`, first-match-wins, no comment awareness. `declaredValue()` is also the read path behind `resolveTokenHex()`, which four colour-token guards consume.

## Re-verified at staging tip `80ec4382` (the audit's Verify phase, run)

Injecting each audit poison case into a scratch copy of the live `brand.css` and calling the functions both ways:

```
                                          OLD (tip 80ec4382)     NEW (this PR)
CASE A  declaredValue(--text-light)   =   "#908D8D"          ->  "rgb(var(--text-light-rgb))"
        resolveTokenHex(--text-light) =   "#908D8D"          ->  "#6E6B6B"          (live)
CASE B  declaredValue(--info)         =   "#52A3C8"          ->  "rgb(var(--info-rgb))"
        resolveTokenHex(--info)       =   "#52A3C8"          ->  "#277A9D"          (live)
CASE C  token()==declaredValue(--chart-5) = "#E8833A" (comment) -> "var(--warning)" (live)
```

CASE A/B are the audit's two proven cases (`--text-light: #908D8D` shadowing live `#6E6B6B`; `/* Superseded — DO NOT RESTORE: --info: #52A3C8; */` above the live block). CASE C is the spec-local `token()` path (identical regex).

### The false-pass, demonstrated (why this is the highest-value slice)

Poison `brand.css` so the **live** `--info` is regressed to the failing `#52A3C8` **but a design-note comment quotes the canonical channels `39 122 157` at line-start** above it, then run only `brand-tokens.spec.ts › --info is the single canonical value`:

- **OLD `channelTriple` (fix reverted) + poison → GREEN.** The guard reads the *commented* canonical value and certifies `#277A9D` while the app ships `#52A3C8`. A broken alarm that passes.
- **NEW `channelTriple` + poison → RED:** `expected '#52A3C8' to be '#277A9D'`. The guard now reads the live value and catches the regression.

### The fix still bites a real regression

Regress the **live** `--info-rgb` to `82 163 200` with **no** comment trick → the full `brand-tokens.spec.ts` reds with 9 failures, including `expected '82 163 200' to be '39 122 157'` (token path), `expected '#52A3C8' to be '#277A9D'` (resolve path) and the AA-contrast pins (`2.83 < 4.5`). The fixes did not neuter the guard.

## Changes

- **`src/styles/channelTriple.mjs`** — private literal-aware, newline-preserving CSS block-comment stripper; `declaredValue()` strips before matching. Re-implemented in-module rather than importing the shared TS helper because this `.mjs` is consumed by the plain node script `scripts/css-var-census.mjs`, which cannot import TypeScript — the same constraint that already forces the module to be `.mjs`. Public API unchanged; `resolveTokenHex` / `resolveChannelTriple` and all four consumers keep working.
- **`src/styles/__tests__/brand-tokens.spec.ts`** — `token()` and the "no superseded hex in declarations" pin now scan the shared literal-aware stripper (`tests/helpers/stripSourceComments`) applied to the `.css` file (→ `stripCssComments`), replacing a local naive strip regex.
- **`tests/helpers/__tests__/stripSourceComments.spec.ts`** (new) — the shared stripper had **no direct unit spec**; each consumer only carried its own positive control. This pins the stripper's own contract: literal-awareness (string / template / regex kept as code, incl. `//` in URLs and `/* */` inside strings), JS line + block comments, CSS block-only (no `//`), byte-length- and newline-preserving, the `regexCanStart` value-vs-regex discriminator, and `blankNonCode` / `stripHtmlComments`.

## Scope held

Per the audit's remediation guidance, this PR is the **proven-dangerous pair + the missing helper spec only** — not a blanket strip of the other flagged specs (per-guard judgement deferred).

The shared helper extraction the audit called for already landed via an earlier lane (`tests/helpers/stripSourceComments.ts`, imported by ~15 guards); this PR reuses it rather than duplicating.

### ⚠️ Follow-up flagged (not fixed here): shared `stripJsComments` desyncs on JSX

While attempting to migrate the last two local strippers (`TemplatesPanel.mergeFreshness.spec.ts`, `analysisFreshnessDirty.spec.ts`) onto the shared helper, `stripJsComments` was found to **mis-tokenise JSX**: a closing tag (`</div>`, `</>`) leaves `regexCanStart` seeing `prev === '<'`, so `/` is read as a regex open and the tokeniser runs to EOF in `regex` state. Minimal repro: `const x = (<div>hi</div>)\n// SENTINEL` leaves `SENTINEL` un-blanked; in `TemplatesPanel.tsx`, 15 comment lines after the first `</button>` survived stripping. Both stragglers scan `.tsx` files, so migrating them would **break their comment-immunity control** — the migrations were therefore reverted and left on their local strippers. This affects every JSX-scanning guard already on the shared helper and wants its own scoped fix + mutation sweep.

## Gates

- `pnpm run typecheck` (`tsc -p tsconfig.ci.json`) → exit 0
- affected + reverted specs green: `brand-tokens` (17), new `stripSourceComments` spec (20), `text-light-contrast` (7), `artefact-template-token-mirror` (3), `GhostOptionNode.contrast` (6), `TemplatesPanel.mergeFreshness` (3), `analysisFreshnessDirty` (25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
