### PR TITLE
fix(guards): make shared comment stripper JSX-aware (phantom regex on `</`)

### DIFF
--- a/src/canvas/panels/__tests__/TemplatesPanel.mergeFreshness.spec.ts
+++ b/src/canvas/panels/__tests__/TemplatesPanel.mergeFreshness.spec.ts
@@ -18,12 +18,16 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { stripComments } from '../../../../tests/helpers/stripSourceComments'
 
-const stripComments = (src: string) =>
-  src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
-
+// TemplatesPanel.tsx is JSX-heavy; the naive regex strip PR #432 had to keep
+// here mis-handled it, and the shared strip's earlier JSX tokeniser bug (a
+// `</tag>` slash mistaken for a regex open) made the migration unsafe until the
+// stripper was made JSX-aware. Now it is, so route through the shared helper —
+// passing the real `.tsx` filename selects the JSX-aware path.
 const source = stripComments(
   readFileSync(join(process.cwd(), 'src/canvas/panels/TemplatesPanel.tsx'), 'utf8'),
+  'TemplatesPanel.tsx',
 )
 
 describe('TemplatesPanel — merge actions dirty the freshness overlay', () => {

--- a/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshnessDirty.spec.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { stripComments } from '../../../../tests/helpers/stripSourceComments'
 import type { Node, Edge } from '@xyflow/react'
 import { useCanvasStore } from '../../store'
 import type { EdgeData } from '../../domain/edges'
@@ -294,10 +295,11 @@ describe('#9 no forbidden freshness paths', () => {
   // The overlay must never depend on v5AnalysisFact.freshness, useStaleGuard,
   // _context_summary, or any client graph hash. Comments legitimately *mention*
   // those names ("deliberately independent of …"), so scan comment-stripped code.
-  const stripComments = (src: string) =>
-    src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
-
-  const read = (rel: string) => stripComments(readFileSync(join(process.cwd(), rel), 'utf8'))
+  // One of the scanned files (AnalysisFreshnessNotice.tsx) is JSX, which the naive
+  // regex here mis-stripped and the shared helper's earlier JSX bug made unsafe to
+  // adopt; now the shared strip is JSX-aware, so pass each file's real extension
+  // and let it pick the correct (JSX/JS/CSS) tokeniser.
+  const read = (rel: string) => stripComments(readFileSync(join(process.cwd(), rel), 'utf8'), rel)
 
   it('the dedicated freshness modules use no forbidden API', () => {
     const freshnessFiles = [

--- a/tests/helpers/__tests__/stripSourceComments.spec.ts
+++ b/tests/helpers/__tests__/stripSourceComments.spec.ts
@@ -98,6 +98,106 @@ describe('stripComments — dispatches on file extension', () => {
     // In CSS `//` is NOT a comment; the JS path would wrongly blank it.
     expect(stripComments('a // b', 'x.css')).toContain('// b')
   })
+
+  it('.tsx / .jsx select the JSX-aware path; other extensions stay plain JS', () => {
+    // A `//` comment after a JSX close tag is only reliably stripped on the JSX
+    // path (see the JSX block below for why). This pins the extension dispatch.
+    for (const ext of ['x.tsx', 'x.jsx']) {
+      expect(stripComments('const x = (<div>hi</div>)\n// gone\n', ext)).not.toContain('gone')
+    }
+    // Plain `.ts` keeps the pre-fix (non-JSX) tokenisation exactly — the `</div>`
+    // slash opens a phantom regex and the trailing comment survives. This is the
+    // deliberately-unchanged legacy behaviour, asserted so a future edit that
+    // silently JSX-ifies `.ts` is caught.
+    expect(stripComments('const x = (<div>hi</div>)\n// kept\n', 'x.ts')).toContain('kept')
+  })
+})
+
+describe('stripJsComments — JSX-aware mode (`.tsx`/`.jsx`)', () => {
+  // REGRESSION PIN (the bug this file's fix closes). Pre-fix, the `/` in a JSX
+  // close tag `</div>` was read as a regex open (its previous significant char is
+  // `<`, which `regexCanStart` treats as an operator), so the tokeniser entered
+  // `regex` state and swallowed every comment after it. The minimal repro:
+  it('MINIMAL REPRO: a `//` after `</div>` is blanked in JSX mode', () => {
+    const out = stripJsComments('const x = (<div>hi</div>)\n// SENTINEL\n', true)
+    expect(out).not.toContain('SENTINEL')
+    expect(out).toContain('const x =') // code before the tag is untouched
+  })
+
+  it('blanks a `//` line comment after a JSX close tag', () => {
+    const out = stripJsComments('return <div>x</div> // trailing note\n', true)
+    expect(out).not.toContain('trailing note')
+  })
+
+  it('blanks a `/* … */` block comment after a JSX close tag', () => {
+    const out = stripJsComments('return <div>x</div> /* block note */\n', true)
+    expect(out).not.toContain('block note')
+  })
+
+  it('blanks a comment after a fragment close `</>`', () => {
+    const line = stripJsComments('return <>x</> // frag note\n', true)
+    expect(line).not.toContain('frag note')
+    const block = stripJsComments('return <>x</> /* frag block */\n', true)
+    expect(block).not.toContain('frag block')
+  })
+
+  it('blanks a comment after a self-closing tag `<Foo />` and `<br/>`', () => {
+    expect(stripJsComments('return <Foo /> // sc note\n', true)).not.toContain('sc note')
+    expect(stripJsComments('return <br/> /* sc block */\n', true)).not.toContain('sc block')
+  })
+
+  it('a real forbidden-looking token in CODE after JSX stays visible', () => {
+    // The whole point of stripping: real call sites must survive so the guard
+    // still bites. A `.update({ graph })`-style token after a close tag is code.
+    const out = stripJsComments("const x = <div/>\nstore.setState({ nodes })\n", true)
+    expect(out).toContain('store.setState({ nodes })')
+  })
+
+  it('keeps string, template and regex literals around JSX', () => {
+    const out = stripJsComments(
+      'const u = "http://x/y"\nreturn <div/>\nconst re = /a\\/b/g\nconst t = `p // q`\n// gone\n',
+      true,
+    )
+    expect(out).toContain('http://x/y') // string with `//` kept
+    expect(out).toContain('/a\\/b/g') // regex literal kept whole
+    expect(out).toContain('p // q') // template body kept
+    expect(out).not.toContain('gone') // the real trailing comment IS stripped
+  })
+
+  it('a genuine regex whose first char is not `>` still opens in JSX mode', () => {
+    // The self-close rule only suppresses a `/` immediately BEFORE a `>` (i.e.
+    // `/>`). A regex like `/x>/` opens on its first `/` (prev `=`, next `x`), so
+    // it is still recognised and the trailing comment after it is stripped.
+    const out = stripJsComments('const re = /x>/g // trailing\n', true)
+    expect(out).toContain('/x>/g')
+    expect(out).not.toContain('trailing')
+  })
+
+  it('DECISION — plain `.ts`/`.js` keeps `a < /re/ … /` as a regex literal (unchanged)', () => {
+    // In plain JS `a < /re/.source.length` is legal: `<` is less-than, `/re/` is a
+    // regex. The non-JSX path (default `jsx=false`) preserves this exactly: the
+    // regex opens after `<` and consumes to its closing `/`, so the trailing
+    // comment is stripped. We keep this behaviour byte-for-byte for `.ts`/`.js`.
+    const plain = stripJsComments('const n = a < /re/.source.length // gone\n')
+    expect(plain).toContain('/re/')
+    expect(plain).not.toContain('gone')
+  })
+
+  it('DECISION — in JSX mode `a < /re/` reads as JSX (JSX context wins), the trade-off', () => {
+    // The rare valid-JS `a < /re/` is ambiguous against a JSX close tag. For
+    // `.tsx`/`.jsx` we let JSX win: the `/` after `<` is treated as tag syntax,
+    // NOT a regex open. Consequence — the `/re/` is plain code, so a real comment
+    // after it is still correctly stripped (the priority we want for JSX files).
+    const jsxOut = stripJsComments('const n = a < /re/.x // gone\n', true)
+    expect(jsxOut).not.toContain('gone')
+  })
+
+  it('is byte-length- and newline-preserving in JSX mode', () => {
+    preservesLayout(
+      (s: string) => stripJsComments(s, true),
+      'return (\n  <div>hi</div> // c\n)\n{/* jsx block\n   note */}\n',
+    )
+  })
 })
 
 describe('stripCssComments — block comments only, literal-aware', () => {

--- a/tests/helpers/stripSourceComments.ts
+++ b/tests/helpers/stripSourceComments.ts
@@ -31,10 +31,15 @@
 
 /**
  * Remove comments from a file's text, dispatching on extension: `.css` files get
- * block-comment stripping only; everything else is treated as JS/TS/JSX/TSX.
+ * block-comment stripping only; `.tsx`/`.jsx` get JSX-aware JS tokenisation (a
+ * JSX close `</` or self-close `/>` slash is never mistaken for a regex open);
+ * every other extension (`.ts`/`.js`/`.mjs`/…) is plain JS/TS, tokenised exactly
+ * as before — the JSX rule is opt-in by extension so it cannot change how a
+ * non-JSX file is read.
  */
 export function stripComments(text: string, file: string): string {
-  return /\.css$/.test(file) ? stripCssComments(text) : stripJsComments(text)
+  if (/\.css$/.test(file)) return stripCssComments(text)
+  return stripJsComments(text, /\.(tsx|jsx)$/.test(file))
 }
 
 /** May a `/` here begin a regex literal, given the previous significant char? */
@@ -49,8 +54,25 @@ export function regexCanStart(prev: string): boolean {
 /**
  * Strip `//` line and block comments from JS/TS/JSX/TSX, treating string,
  * template and regex literals (and `${...}` interpolations) as code.
+ *
+ * JSX AWARENESS (`jsx = true`, set by `stripComments` for `.tsx`/`.jsx`). In JSX,
+ * `<` is a tag opener rather than a less-than operator, so the `/` in a close tag
+ * (`</div>`, `</>`) and the `/` in a self-close (`<Foo />`, `<br/>`) are tag
+ * syntax, not the start of a regex literal. The plain tokeniser (`regexCanStart`)
+ * only inspects the previous significant char, where after `<` a `/` looks like a
+ * regex open — so on `</div>` it enters `regex` state and, finding no closing `/`
+ * before EOF (or latching onto a later stray `/`), swallows every comment past
+ * that point. The guard below suppresses the regex open for exactly the two JSX
+ * shapes: a `/` whose previous significant char is `<` (close tag), and a `/`
+ * whose next char is `>` (self-close). It runs AFTER the `//`/`/*` comment checks,
+ * so a real comment immediately following a tag is still stripped, and only when
+ * `jsx` is set — plain `.ts`/`.js` tokenisation (including the rare, legitimate
+ * `a < /re/ … /` division-then-regex) is left byte-for-byte unchanged. In `.tsx`
+ * that same `a < /re/` reads as JSX by design (JSX context wins), the documented
+ * trade-off; a genuine regex whose FIRST char is not `>` still opens normally
+ * (its opening `/` has neither a `<` before it nor a `>` after it).
  */
-export function stripJsComments(src: string): string {
+export function stripJsComments(src: string, jsx = false): string {
   const a = src.split('')
   const n = a.length
   const blank = (i: number): void => {
@@ -75,6 +97,11 @@ export function stripJsComments(src: string): string {
       if (c === "'") { state = 'single'; prev = c; i++; continue }
       if (c === '"') { state = 'double'; prev = c; i++; continue }
       if (c === '`') { state = 'template'; prev = c; i++; continue }
+      // JSX tag slash (`.tsx`/`.jsx` only): a `/` in a close tag (`</…`, prev is
+      // `<`) or a self-close (`…/>`, next char is `>`) is tag syntax, not a regex
+      // open. Kept as an ordinary code char so tokenisation stays aligned and any
+      // comment after the tag is still seen. Runs before the regex check below.
+      if (c === '/' && jsx && (prev === '<' || d === '>')) { prev = c; i++; continue }
       if (c === '/' && regexCanStart(prev)) { state = 'regex'; regexClass = false; prev = c; i++; continue }
       if (interp > 0) {
         if (c === '{') interp++


### PR DESCRIPTION
## Bug (confirmed, repro verified at tip 80ec4382)

`tests/helpers/stripSourceComments.ts` → `stripJsComments` mis-tokenises JSX. On a JSX closing tag (`</div>`, `</>`) the previous significant char is `<`; `regexCanStart('<')` returns true (`<` is not in its value-char class), so the `/` opens a **phantom regex literal**. The tokeniser then runs forward in `regex` state — with no following `/` it consumes to EOF (or latches onto a later stray `/`), so **every comment after that point survives stripping** and code regions are misclassified.

Concretely:
- Minimal: `stripJsComments('const x = (<div>hi</div>)\n// SENTINEL\n')` leaves `SENTINEL` present (should be blanked).
- Real file: `stripComments(TemplatesPanel.tsx, 'TemplatesPanel.tsx')` leaves **15** `{/* … */}` JSX comments un-stripped, all after the first `</button>` (line 499).

Every source-scanning CI guard that reads a `.tsx`/`.jsx` file through the shared helper therefore false-reddens on a forbidden pattern quoted in a comment **after** any JSX tag — the exact `bg-info/4`-in-a-comment footgun (#385/#386) the helper exists to prevent, re-opened for JSX files.

## Fix

Make the stripper JSX-aware, **opt-in by extension** (the same dispatch shape `stripComments` already uses for CSS):

- `stripComments` routes `.tsx`/`.jsx` through `stripJsComments(text, jsx=true)`; `.css` unchanged; every other extension (`.ts`/`.js`/`.mjs`/…) stays plain JS/TS, **tokenised byte-for-byte as before** (`jsx` defaults `false`).
- In JSX mode a `/` whose previous significant char is `<` (close tag `</…`) or whose next char is `>` (self-close `…/>`) is treated as tag syntax, not a regex open. The guard runs **after** the `//`/`/*` comment checks, so a real comment right after a tag is still stripped.
- Invariants preserved: byte-length- and newline-preserving; string / template / regex literals kept as code.
- **Trade-off (documented in the spec):** the rare valid-JS `a < /re/ … /` reads as JSX in `.tsx`/`.jsx` (JSX context wins); plain `.ts`/`.js` keeps the regex reading exactly. A genuine regex whose first char is not `>` still opens normally in JSX mode.

## Mutation evidence

**RED → GREEN** (stripper level): the minimal repro and the 15-survivor TemplatesPanel repro fail pre-fix, pass post-fix.

**Consumer mutation matrix** — every JSX-scanning guard importing the shared helper (enumerated by grep). Injected a temp `.tsx` (JSX close tag, then the pattern) into each guard's scan tree; commented-after-JSX must stay GREEN, real must go RED:

| Guard | commented-after-JSX | real |
|---|---|---|
| british-english | GREEN | RED |
| coaching-panel/focus-now inertness | GREEN | RED |
| analysis-hero inertness | GREEN | RED |
| analysis-hero hygiene | GREEN | RED |
| analysis-hero fixtureIsolation | GREEN | RED |
| pre-analysis-v3 registry | GREEN | RED |
| no-message-render | GREEN | RED |
| no-raw-influence-read | GREEN | RED |
| plot-fetch-all-seams | GREEN | RED |
| semantic-colour-alpha | GREEN | RED |

Fragment `</>` sanity variant: GREEN / RED. Pre-fix, the commented-after-JSX variants were RED (bug confirmed at guard level). No guard assertions were weakened — #386's emission assertion in `semantic-colour-alpha.spec.ts` is untouched; injections were temp files, reverted after capture.

## Also in this PR

- **Unit spec** (`stripSourceComments.spec.ts`) extended with JSX cases: `//` and `/* */` after `</div>`, fragment `</>`, self-close `<Foo />`/`<br/>`, a real forbidden-looking token after JSX still visible, string/template/regex literals preserved around JSX, the minimal-repro pin, the `.ts` vs `.tsx` `a < /re/` decision, and layout preservation in JSX mode.
- **Migrations unblocked** (the two spec-local naive strippers PR #432 had to revert): `TemplatesPanel.mergeFreshness.spec.ts` and `analysisFreshnessDirty.spec.ts` now use the shared JSX-aware helper.

## Gates

- Helper unit spec (32) + all 10 consumer guard specs + 2 migrated specs: **1284 passing**.
- `pnpm run typecheck` (tsc -p tsconfig.ci.json): **exit 0**, zero net-new errors.
- `eslint` on touched files: **exit 0** (no-irregular-whitespace clean).

Do not merge — draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
