### PR TITLE
feat(feedback): wire feedback_submitted to the typed 0.22 feedback event (F7)

### DIFF
--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -383,12 +383,15 @@ export const ConversationPanel = memo(function ConversationPanel({
   )
 
   const handleFeedback = useCallback(
-    (turnId: string, rating: 'up' | 'down') => {
+    // Return the send promise so FeedbackRow can revert its optimistic vote if
+    // the feedback turn fails to reach the server (the thumbs re-enable for
+    // retry — no new surface). The typed 0.22 mapping lives in buildV5Payload
+    // (feedback_submitted -> feedback wire event); this is the emitter half.
+    (turnId: string, rating: 'up' | 'down') =>
       sendSystemEvent({
         type: 'feedback_submitted',
         payload: { turn_id: turnId, rating },
-      })
-    },
+      }),
     [sendSystemEvent],
   )
 

--- a/src/canvas/conversation/FeedbackRow.tsx
+++ b/src/canvas/conversation/FeedbackRow.tsx
@@ -17,7 +17,7 @@ const feedbackBtnFocusClass = 'feedback-btn'
 interface FeedbackRowProps {
   /** clientTurnId echoed from orchestrator envelope; undefined for synthetic messages */
   turnId: string | undefined
-  onFeedback: (turnId: string, rating: 'up' | 'down') => void
+  onFeedback: (turnId: string, rating: 'up' | 'down') => void | Promise<void>
 }
 
 export const FeedbackRow = memo(function FeedbackRow({ turnId, onFeedback }: FeedbackRowProps) {
@@ -26,10 +26,18 @@ export const FeedbackRow = memo(function FeedbackRow({ turnId, onFeedback }: Fee
   // Don't render for synthetic messages (no canonical turn ID to send)
   if (turnId === undefined) return null
 
-  const handleVote = (rating: 'up' | 'down') => {
+  const handleVote = async (rating: 'up' | 'down') => {
     if (voted !== null) return // Already voted
-    setVoted(rating)
-    onFeedback(turnId, rating)
+    setVoted(rating) // Optimistic: disable the buttons immediately.
+    try {
+      await onFeedback(turnId, rating)
+    } catch {
+      // The feedback turn failed to reach the server. Revert the optimistic
+      // vote so the thumbs re-enable — the user's action must not vanish
+      // silently; they can rate again. No new surface (mirrors the panel's
+      // existing failed-send handling, e.g. handlePatchAccept's retry path).
+      setVoted(null)
+    }
   }
 
   return (

--- a/src/canvas/conversation/__tests__/FeedbackRow.spec.tsx
+++ b/src/canvas/conversation/__tests__/FeedbackRow.spec.tsx
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { FeedbackRow } from '../FeedbackRow'
 
 describe('FeedbackRow', () => {
@@ -67,5 +67,23 @@ describe('FeedbackRow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Helpful' }))
 
     expect(onFeedback).toHaveBeenCalledTimes(1)
+  })
+
+  it('reverts the vote and re-enables the buttons when onFeedback rejects', async () => {
+    // The feedback turn failed to reach the server — the user's thumbs action
+    // must not vanish silently, so the optimistic vote is rolled back and the
+    // buttons re-enable for a retry.
+    const onFeedback = vi.fn().mockRejectedValue(new Error('send failed'))
+    render(<FeedbackRow turnId="turn-1" onFeedback={onFeedback} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Helpful' }))
+    // Optimistic disable happens synchronously on click.
+    expect(screen.getByRole('button', { name: 'Helpful' })).toBeDisabled()
+
+    // After the rejected send settles, both buttons become clickable again.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Helpful' })).not.toBeDisabled()
+    })
+    expect(screen.getByRole('button', { name: 'Not helpful' })).not.toBeDisabled()
   })
 })

--- a/src/v5/__tests__/buildPayload.test.ts
+++ b/src/v5/__tests__/buildPayload.test.ts
@@ -345,7 +345,49 @@ describe('buildV5Payload — system_event payloads', () => {
     if (!r.ok) expect(r.reason).toBe('unsupported_system_event')
   })
 
-  it('feedback_submitted is unsupported (CEE has no V5 handler)', () => {
+  // F7 (feedback thumbs = wire). Seam test driven from the REAL emitter shape:
+  // ConversationPanel.handleFeedback dispatches
+  //   { type: 'feedback_submitted', payload: { turn_id, rating } }
+  // for a whole-turn thumbs rating. These pin that exact object through the
+  // builder to the vendored 0.22 boundary schema (was pinned as a silent drop).
+  it('feedback_submitted (thumbs up) → typed feedback wire event', () => {
+    const r = assertOk(
+      buildV5Payload({
+        turnId: TURN_ID,
+        scenarioId: SCENARIO_ID,
+        stage: 'frame',
+        turnClass: 'frame',
+        mode: 'system',
+        systemEvent: { type: 'feedback_submitted', payload: { turn_id: TURN_ID, rating: 'up' } },
+      }),
+    )
+    expect(r.payload).toMatchObject({
+      kind: 'system_event',
+      event: { kind: 'feedback', rating: 'up', target: { id: TURN_ID, kind: 'turn' } },
+    })
+    // Real boundary: the vendored 0.22 Zod schema must accept the output.
+    expect(() => OrchestratorTurnPayloadSchema.parse(r.payload)).not.toThrow()
+  })
+
+  it('feedback_submitted (thumbs down) → rating carried through unchanged', () => {
+    const r = assertOk(
+      buildV5Payload({
+        turnId: TURN_ID,
+        scenarioId: SCENARIO_ID,
+        stage: 'frame',
+        turnClass: 'frame',
+        mode: 'system',
+        systemEvent: { type: 'feedback_submitted', payload: { turn_id: TURN_ID, rating: 'down' } },
+      }),
+    )
+    expect(r.payload).toMatchObject({
+      kind: 'system_event',
+      event: { kind: 'feedback', rating: 'down', target: { id: TURN_ID, kind: 'turn' } },
+    })
+    expect(() => OrchestratorTurnPayloadSchema.parse(r.payload)).not.toThrow()
+  })
+
+  it('feedback_submitted with an invalid rating → unsupported (fail closed)', () => {
     const r = buildV5Payload({
       turnId: TURN_ID,
       scenarioId: SCENARIO_ID,

--- a/src/v5/__tests__/systemEventParity.test.ts
+++ b/src/v5/__tests__/systemEventParity.test.ts
@@ -74,14 +74,15 @@ const UI_COVERAGE: Record<
     kind: 'message_via_chip',
     chipActionType: 'run_analysis',
   },
-  // feedback_submitted: `feedback` joined SystemEventKind in 0.22.0, but the UI
-  // still has NO emission path for it (buildV5Payload has no case → null →
-  // unsupported), and emission is HELD under the ingress-mirror rule until
-  // CEE >=0.22.0 is deploy-verified. Builder returns
-  // { ok: false, reason: 'unsupported_system_event' }.
+  // feedback_submitted: F7 (feedback thumbs = wire). `feedback` joined
+  // SystemEventKind in 0.22.0 and CEE >=0.22.0 is deploy-verified, so the
+  // ingress-mirror hold is LIFTED. buildV5Payload maps the emitter's
+  // { turn_id, rating } shape onto the typed `feedback` system event (a
+  // whole-turn thumbs rating → target.kind 'turn').
   feedback_submitted: {
-    kind: 'unsupported',
-    reason: 'UI emission held pending CEE 0.22 deploy (ingress-mirror rule)',
+    kind: 'system_event',
+    eventKind: 'feedback',
+    payload: { turn_id: TURN_ID, rating: 'up' },
   },
 }
 
@@ -158,9 +159,10 @@ describe('UI ↔ V5 system event parity', () => {
     )
 
     // Schema kinds NOT in the emitted set are deferred UI work — chip_click,
-    // undo, redo. They're valid on the wire (CEE handles them per the
-    // turn-shape matrix) but the UI has no emission site yet. This is the
-    // parity boundary the reviewer's P0 #3 flagged; the test locks it.
+    // undo, redo, selection_change. They're valid on the wire (CEE handles them
+    // per the turn-shape matrix) but the UI has no emission site yet. This is
+    // the parity boundary the reviewer's P0 #3 flagged; the test locks it.
+    // (0.22.0 `feedback` left this set in F7 — it is now UI-emitted, see above.)
     const knownDeferred: ReadonlySet<(typeof V5_EVENT_KINDS)[number]> = new Set([
       'chip_click',
       'undo',
@@ -169,12 +171,6 @@ describe('UI ↔ V5 system event parity', () => {
       // path (debounced selection_change on canvas selection) is the R5 UI
       // half — a scheduled Experience lane; CEE consumes it already.
       'selection_change',
-      // 0.22.0: feedback joined the wire union (typed feedback event). UI
-      // emission is HELD under the ingress-mirror rule — CEE >=0.22.0 is not
-      // yet deploy-verified, so the UI must not start sending feedback events
-      // in the schemas-0.22 absorption lane. buildV5Payload still refuses
-      // feedback_submitted (unsupported_system_event); this is the deferral.
-      'feedback',
     ])
 
     for (const kind of V5_EVENT_KINDS) {
@@ -188,16 +184,17 @@ describe('UI ↔ V5 system event parity', () => {
     }
   })
 
-  it('locks UI emission count at 3 of 8 V5 SystemEventKind values', () => {
+  it('locks UI emission count at 4 of 8 V5 SystemEventKind values', () => {
     // Explicit canary: if someone adds a new UI emission (extending the
     // system_event branch of UI_COVERAGE) without updating this test, the
     // count will drift and flag for docs reconciliation.
-    // 0.22.0 grew the wire union to 8 (added `feedback`); UI emission count is
-    // unchanged at 3 — feedback is held (see knownDeferred rationale above).
+    // 0.22.0 grew the wire union to 8 (added `feedback`); F7 wired feedback
+    // emission, so UI emission count is now 4 (patch_accepted, patch_dismissed,
+    // direct_graph_edit, feedback).
     const uiEmittedCount = Object.values(UI_COVERAGE).filter(
       (c) => c.kind === 'system_event',
     ).length
-    expect(uiEmittedCount).toBe(3)
+    expect(uiEmittedCount).toBe(4)
     expect(V5_EVENT_KINDS).toHaveLength(8)
   })
 })

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -12,8 +12,8 @@
  *   3. `retry_of` is present ONLY when `source === 'retry'`.
  *   4. `direct_analysis_run` SystemEvent from the UI (not in V5 SystemEventKind)
  *      is mapped to a `kind: 'message'` payload with `chip.action_type: 'run_analysis'`.
- *      Other UI system events that V5 rejects (feedback_submitted) return null
- *      so callers can pre-filter.
+ *      UI system events with no wire member still return null so callers can
+ *      pre-filter (unsupported_system_event).
  *
  * CEE contract: @talchain/schemas. The authoritative UI pin is the
  * `@talchain/schemas` dependency in package.json; CEE pins its own copy and
@@ -160,8 +160,8 @@ function buildSystemEventPayload(input: BuildV5PayloadInput): BuildV5PayloadResu
 
   if (payload === null) {
     // Some UI SystemEvent types map to kind='message' (direct_analysis_run)
-    // or are unsupported (feedback_submitted). Handle the analysis case here;
-    // return unsupported for anything else.
+    // rather than a system_event, or have no wire member at all. Handle the
+    // analysis case here; return unsupported for anything else.
     if (systemEvent.type === 'direct_analysis_run') {
       return buildDirectAnalysisRunMessage(input)
     }
@@ -201,6 +201,21 @@ function systemEventToPayload(args: {
       const operation = stringField(eventPayload, 'operation')
       if (!target_id || !operation) return null
       return { ...base, event: { kind: 'direct_graph_edit', target_id, operation } }
+    }
+    case 'feedback_submitted': {
+      // F7 (feedback thumbs = wire): map the UI's optimistic thumbs event onto
+      // the typed 0.22 `feedback` system event. The emitter
+      // (ConversationPanel.handleFeedback) sends { turn_id, rating } for a
+      // whole-turn rating, so target.kind is 'turn' and target.id is the turn
+      // id. rating is fail-closed to the schema enum: anything but 'up'/'down',
+      // or a missing turn id, returns null -> unsupported, never a wire 422.
+      const rating = stringField(eventPayload, 'rating')
+      const target_id = stringField(eventPayload, 'turn_id')
+      if ((rating !== 'up' && rating !== 'down') || !target_id) return null
+      return {
+        ...base,
+        event: { kind: 'feedback', rating, target: { id: target_id, kind: 'turn' } },
+      }
     }
     // V5 schema includes chip_click, undo, redo — not currently emitted by
     // the UI as SystemEvent.type (no WireSystemEventType entries). Kept


### PR DESCRIPTION
## What

Wires the UI's thumbs up/down feedback onto the typed 0.22 `feedback` wire event, completing the Paul-ruled decision **feedback thumbs = wire (F7)**.

## The defect

- `ConversationPanel.handleFeedback` dispatches a `feedback_submitted` system event `{ turn_id, rating }` on thumbs click.
- `buildV5Payload` (`systemEventToPayload`) had **no case** for it, so it fell through to `unsupported_system_event` and **every submission was silently dropped**.
- The UI's own tests pinned that drop (`buildPayload.test.ts`, `systemEventParity.test.ts`).

## The fix

- **`src/v5/buildPayload.ts`** — map `feedback_submitted` -> `{ kind:'feedback', rating:'up'|'down', target:{ id:<turnId>, kind:'turn' } }` per the vendored `@talchain/schemas` 0.22 boundary schema (`FeedbackRating` = up|down, `FeedbackTargetKind` includes `turn`). A whole-turn thumbs rating maps `turn_id` -> `target.id`, `kind:'turn'`. `rating` is **fail-closed** to the enum: an invalid rating or missing turn id returns `null` -> unsupported, never a wire 422. Removed `feedback` from the parity known-deferred set (ingress-mirror hold lifted; CEE >=0.22.0 deploy-verified accepts schema-valid system events).
- **`FeedbackRow.tsx` / `ConversationPanel.tsx`** — the failed-send surface: `handleFeedback` returns the send promise; `FeedbackRow` reverts its optimistic vote if the turn rejects, so the thumbs re-enable for retry instead of vanishing silently. No new UI surface (mirrors the panel's existing failed-send handling).
- **Tests** — the two pinned-drop tests are rewritten to pin the new mapping (seam test driven from the real emitter shape, validated against the vendored Zod schema); parity UI-emission count 3 -> 4.

## Evidence

- RED-first: with the mapping absent, the seam test fails `expected ok; got unsupported_system_event type=feedback_submitted` (drop proven). GREEN with the mapping.
- Mutation: reverting the mapping REDs the seam test; a rating-flip mis-map REDs the up/down tests.
- Gates: `tsc -p tsconfig.ci.json --noEmit` exit 0 (zero net-new); affected suites green (buildPayload 22, systemEventParity 8, FeedbackRow 7, systemEvents 9, MessageBubble/ChatThread 17); eslint 0 errors on touched files.

**Draft — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)