### PR TITLE
feat(graph-edits): adapt batch direct_graph_edit events to the 0.22 wire (F6)

### DIFF
--- a/src/canvas/conversation/__tests__/graphEditBatchAdapter.spec.ts
+++ b/src/canvas/conversation/__tests__/graphEditBatchAdapter.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * F6 — batch direct_graph_edit -> 0.22 wire adapter.
+ *
+ * These tests START FROM THE REAL EMITTER SHAPE: they drive the real
+ * `useGraphEditEvents` hook against the real canvas store and capture EXACTLY
+ * what it emits (never a hand-built fixture), then cross the REAL
+ * `buildV5Payload` boundary and validate the result against the vendored
+ * `OrchestratorTurnPayloadSchema` (parse MUST succeed).
+ *
+ * RED baseline (pre-fix): the emitter emits a BATCH payload with no singular
+ * `target_id`/`operation`, so the old `buildV5Payload` returned no event and
+ * the edit was silently discarded.
+ * GREEN (this adapter): a wire event with a representative singular pair PLUS
+ * the additive batch fields, which the schema accepts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { OrchestratorTurnPayloadSchema } from '@talchain/schemas/boundary'
+import { useGraphEditEvents } from '../useGraphEditEvents'
+import { useCanvasStore } from '../../store'
+import { buildV5Payload } from '../../../v5/buildPayload'
+import type { WireSystemEvent } from '../types'
+
+vi.mock('../../../flags', () => ({
+  isOrchestratorV2Enabled: () => true,
+  isJourneyTabEnabled: () => false,
+}))
+
+const TURN_ID = '11111111-1111-4111-8111-111111111111'
+const SCENARIO_ID = '22222222-2222-4222-8222-222222222222'
+
+function setStore(overrides: Record<string, unknown>): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' } as any,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    ...overrides,
+  })
+}
+
+/**
+ * Render the REAL emitter, apply `mutate`, flush the debounce, and return the
+ * exact payload the emitter handed to sendSystemEvent. `initial` (if given) is
+ * applied BEFORE mount so it lands in the emitter's baseline snapshot (needed
+ * to exercise the `update` op, which diffs against the mount snapshot).
+ */
+function captureEmittedEvent(mutate: () => void, initial?: Record<string, unknown>): WireSystemEvent {
+  if (initial) setStore(initial)
+  const send = vi.fn().mockResolvedValue(undefined)
+  const { unmount } = renderHook(() => useGraphEditEvents(send))
+  act(() => {
+    mutate()
+  })
+  act(() => {
+    vi.advanceTimersByTime(1500)
+  })
+  unmount()
+  expect(send).toHaveBeenCalledTimes(1)
+  return send.mock.calls[0][0] as WireSystemEvent
+}
+
+function buildFromEvent(event: WireSystemEvent): ReturnType<typeof buildV5Payload> {
+  return buildV5Payload({
+    turnId: TURN_ID,
+    scenarioId: SCENARIO_ID,
+    stage: 'frame',
+    turnClass: 'frame',
+    mode: 'system',
+    systemEvent: event,
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  setStore({})
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('F6 batch direct_graph_edit adapter', () => {
+  it('the real emitter emits a BATCH payload with NO singular target_id/operation (RED premise)', () => {
+    const event = captureEmittedEvent(() => {
+      useCanvasStore.setState({
+        nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'A' } }] as any,
+      })
+    })
+
+    expect(event.type).toBe('direct_graph_edit')
+    expect(event.payload).toMatchObject({ changed_node_ids: ['n1'], operations: ['add'] })
+    // The batch shape carries NO singular pair — this is exactly why the
+    // singular-only builder discarded it before F6.
+    expect(event.payload?.target_id).toBeUndefined()
+    expect(event.payload?.operation).toBeUndefined()
+  })
+
+  it('GREEN: adapts a real batch edit to a schema-valid wire event with a representative pair + batch fields', () => {
+    const event = captureEmittedEvent(
+      () => {
+        // Update n1's label (populates fields_changed) and remove e1.
+        useCanvasStore.setState({
+          nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Updated' } }] as any,
+          edges: [] as any,
+        })
+      },
+      {
+        nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'A' } }],
+        edges: [{ id: 'e1', source: 'n1', target: 'n2', data: { weight: 1 } }],
+      },
+    )
+
+    const result = buildFromEvent(event)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const payload = result.payload as Extract<typeof result.payload, { kind: 'system_event' }>
+    expect(payload.kind).toBe('system_event')
+    const wireEvent = payload.event as Record<string, unknown>
+
+    // Representative singular pair present and non-empty (schema-required).
+    expect(wireEvent.kind).toBe('direct_graph_edit')
+    expect(wireEvent.target_id).toBe('n1') // first changed node in stable order
+    expect(typeof wireEvent.operation).toBe('string')
+    expect((wireEvent.operation as string).length).toBeGreaterThan(0)
+
+    // Additive batch fields retained.
+    expect(wireEvent.changed_node_ids).toEqual(['n1'])
+    expect(wireEvent.changed_edge_ids).toEqual(['e1'])
+    expect(wireEvent.operations).toEqual(['remove', 'update'])
+    // fields_changed converted map -> string[].
+    expect(wireEvent.fields_changed).toEqual(['label'])
+    expect(typeof wireEvent.summary).toBe('string')
+
+    // The whole point: the vendored 0.22 schema parses the adapter output.
+    expect(() => OrchestratorTurnPayloadSchema.parse(payload)).not.toThrow()
+  })
+
+  it('BATCH-FIELDS PIN: the additive batch fields survive the adapter unchanged', () => {
+    const event = captureEmittedEvent(
+      () => {
+        useCanvasStore.setState({
+          nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Updated' } }] as any,
+        })
+      },
+      { nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'A' } }] },
+    )
+
+    const result = buildFromEvent(event)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const wireEvent = (result.payload as any).event as Record<string, unknown>
+
+    expect(wireEvent.changed_node_ids).toEqual(['n1'])
+    expect(wireEvent.operations).toEqual(['update'])
+    expect(wireEvent.fields_changed).toEqual(['label'])
+    expect(wireEvent.summary).toBe('1 node changed')
+  })
+
+  it('converts the fields_changed MAP to a sorted, de-duplicated UNION of field names', () => {
+    const event = captureEmittedEvent(
+      () => {
+        // n1 label changes; n2 note changes -> map { n1: ['label'], n2: ['note'] }.
+        useCanvasStore.setState({
+          nodes: [
+            { id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'B', note: 'x' } },
+            { id: 'n2', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'M', note: 'b' } },
+          ] as any,
+        })
+      },
+      {
+        nodes: [
+          { id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'A', note: 'x' } },
+          { id: 'n2', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'M', note: 'a' } },
+        ],
+      },
+    )
+
+    // Emitter really did produce a MAP (id -> field names).
+    expect(event.payload?.fields_changed).toEqual({ n1: ['label'], n2: ['note'] })
+
+    const result = buildFromEvent(event)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const wireEvent = (result.payload as any).event as Record<string, unknown>
+    // Union across elements, de-duplicated, sorted ascending.
+    expect(wireEvent.fields_changed).toEqual(['label', 'note'])
+    expect(() => OrchestratorTurnPayloadSchema.parse(result.payload)).not.toThrow()
+  })
+
+  it('RETRYABLE-ERROR PIN: an unencodable batch (empty ids) fails retryably, never a silent drop', () => {
+    // The real emitter never fires with empty id lists (it only fires on real
+    // changes), so this pathological input is constructed directly at the
+    // buildV5Payload boundary — the seam that must not fabricate a target.
+    const result = buildV5Payload({
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'frame',
+      turnClass: 'frame',
+      mode: 'system',
+      systemEvent: {
+        type: 'direct_graph_edit',
+        payload: { changed_node_ids: [], changed_edge_ids: [], operations: [], fields_changed: {}, summary: '' },
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('unencodable_graph_edit')
+    expect(result.retryable).toBe(true)
+  })
+
+  it('preserves back-compat: an explicit singular pair still builds a bare wire event', () => {
+    const result = buildV5Payload({
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'frame',
+      turnClass: 'frame',
+      mode: 'system',
+      systemEvent: { type: 'direct_graph_edit', payload: { target_id: 'node-1', operation: 'set_factor_value' } },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect((result.payload as any).event).toEqual({
+      kind: 'direct_graph_edit',
+      target_id: 'node-1',
+      operation: 'set_factor_value',
+    })
+    expect(() => OrchestratorTurnPayloadSchema.parse(result.payload)).not.toThrow()
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -3165,23 +3165,35 @@ export function useConversation(): UseConversationReturn {
         })
 
         if (!build.ok) {
-          // buildV5Payload refused — missing message or unsupported system
-          // event. Surface a typed error rather than a malformed request.
+          // buildV5Payload refused. Surface a typed error rather than a
+          // malformed request.
           //
           // ⚠ The `mode === 'user'` branch below is currently UNREACHABLE, and
           // a 2026-07-20 review that mapped this as "the exit that sets no
-          // failure notice" missed why. buildV5Payload can only fail two ways:
+          // failure notice" missed why. buildV5Payload can fail three ways:
           //   · 'missing_message'          — mode 'user' only, and the guard at
           //     the top of this block (`if (mode === 'user' && !message.trim())`)
           //     already returned, so it never gets here;
           //   · 'unsupported_system_event' — reachable only via
           //     buildSystemEventPayload, i.e. mode === 'system', which fails
-          //     this very `mode === 'user'` test.
+          //     this very `mode === 'user'` test;
+          //   · 'unencodable_graph_edit'   — F6, mode === 'system' only (see the
+          //     retryable branch immediately below).
           // So for a user send this is dead, and adding a failure notice here
           // would be dead code. Left in place as a defensive backstop; if a
           // third refusal reason is ever added for user mode, it MUST raise a
           // SendFailureNotice — the hero has no transcript to show the
           // synthetic bubble below.
+          //
+          // F6: a batch direct_graph_edit whose ids yield no encodable
+          // representative target is a RETRYABLE failure (mode === 'system').
+          // Route it through the failed-event path (setLastSendFailure) so it is
+          // NOT a silent drop and the DEV-only warning below is no longer its
+          // only trace. `kind: 'transport'` — nothing reached CEE; `inputText`
+          // stays '' (a system event has no composer text to restore).
+          if (build.reason === 'unencodable_graph_edit') {
+            setLastSendFailure({ kind: 'transport', retryable: true, inputText: '' })
+          }
           if (mode === 'user' && !hidden) {
             // Nothing was dispatched — the bubble must not read as sent.
             if (userBubbleIdForTurn) {

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -63,7 +63,19 @@ export interface BuildV5PayloadInput {
 
 export type BuildV5PayloadResult =
   | { ok: true; payload: OrchestratorTurnPayload }
-  | { ok: false; reason: 'missing_message' | 'unsupported_system_event'; detail?: string }
+  | {
+      ok: false
+      /**
+       * `unencodable_graph_edit` (F6): a batch `direct_graph_edit` event whose
+       * ids yield no encodable representative target. Distinct from
+       * `unsupported_system_event` because it is RETRYABLE — the caller should
+       * route it through the failed-event path, never drop it silently.
+       */
+      reason: 'missing_message' | 'unsupported_system_event' | 'unencodable_graph_edit'
+      /** True when re-issuing the same action could succeed (F6 retryable path). */
+      retryable?: boolean
+      detail?: string
+    }
 
 /**
  * Convert a sendTurn invocation into the v0.7.0 wire payload.
@@ -165,6 +177,19 @@ function buildSystemEventPayload(input: BuildV5PayloadInput): BuildV5PayloadResu
     if (systemEvent.type === 'direct_analysis_run') {
       return buildDirectAnalysisRunMessage(input)
     }
+    if (systemEvent.type === 'direct_graph_edit') {
+      // F6: the direct_graph_edit adapter (systemEventToPayload, below) returns
+      // null ONLY when a batch has no encodable representative target (e.g. all
+      // changed-id lists empty). That is NOT "unsupported" — it is a RETRYABLE
+      // failure. Surface it so the send leg routes it through the failed-event
+      // path rather than dropping it silently or fabricating a target.
+      return {
+        ok: false,
+        reason: 'unencodable_graph_edit',
+        retryable: true,
+        detail: 'direct_graph_edit batch had no encodable representative target (empty changed ids)',
+      }
+    }
     return {
       ok: false,
       reason: 'unsupported_system_event',
@@ -197,10 +222,9 @@ function systemEventToPayload(args: {
       return { ...base, event: { kind: 'patch_dismissed', patch_id } }
     }
     case 'direct_graph_edit': {
-      const target_id = stringField(eventPayload, 'target_id')
-      const operation = stringField(eventPayload, 'operation')
-      if (!target_id || !operation) return null
-      return { ...base, event: { kind: 'direct_graph_edit', target_id, operation } }
+      const event = adaptDirectGraphEdit(eventPayload)
+      if (event === null) return null
+      return { ...base, event }
     }
     // V5 schema includes chip_click, undo, redo — not currently emitted by
     // the UI as SystemEvent.type (no WireSystemEventType entries). Kept
@@ -248,6 +272,103 @@ function stringField(src: Record<string, unknown> | undefined, key: string): str
   if (!src) return ''
   const val = src[key]
   return typeof val === 'string' && val.length > 0 ? val : ''
+}
+
+// Narrow an optional unknown field to an array of non-empty strings.
+function stringArrayField(src: Record<string, unknown> | undefined, key: string): string[] {
+  if (!src) return []
+  const val = src[key]
+  if (!Array.isArray(val)) return []
+  return val.filter((v): v is string => typeof v === 'string' && v.length > 0)
+}
+
+// The wire `direct_graph_edit` event (0.22), derived from the vendored schema
+// so the shape here can never drift from what `OrchestratorTurnPayloadSchema`
+// will accept.
+type DirectGraphEditWireEvent = Extract<
+  SystemEventTurnPayload['event'],
+  { kind: 'direct_graph_edit' }
+>
+
+// `fields_changed` arrives from the real emitter (useGraphEditEvents.ts) as a
+// MAP (element id → touched field names). The 0.22 wire types `fields_changed`
+// as a flat string[] that "names the touched fields" — no id association.
+// Flatten DETERMINISTICALLY: the sorted, de-duplicated UNION of every element's
+// field names. Non-map / malformed input yields [].
+function flattenFieldsChangedToNames(src: Record<string, unknown> | undefined): string[] {
+  if (!src) return []
+  const raw = src['fields_changed']
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return []
+  const names = new Set<string>()
+  for (const value of Object.values(raw as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue
+    for (const field of value) {
+      if (typeof field === 'string' && field.length > 0) names.add(field)
+    }
+  }
+  return [...names].sort()
+}
+
+/**
+ * F6 — batch `direct_graph_edit` → 0.22 wire adapter.
+ *
+ * The UI's REAL debounced emitter (src/canvas/conversation/useGraphEditEvents.ts,
+ * the `sendSystemEvent({ type: 'direct_graph_edit', payload })` call) emits a
+ * BATCH payload — `{ changed_node_ids, changed_edge_ids, operations,
+ * fields_changed (a MAP), summary }` — and NO singular `target_id` / `operation`.
+ * The vendored 0.22 `DirectGraphEditEvent` STILL REQUIRES the singular
+ * `{ target_id, operation }` pair (back-compat for consumers on an older pin)
+ * and accepts the batch fields ADDITIVELY, typing `fields_changed` as string[]
+ * (not a map). Before this adapter the singular-only read returned null, the
+ * turn was never built, and real batch edits were silently discarded.
+ *
+ * This adapter (a) derives a DETERMINISTIC representative singular pair and
+ * (b) carries the additive batch fields, converting `fields_changed` map →
+ * string[]. It returns null ONLY when no representative target is encodable
+ * (empty ids); the caller turns that into a RETRYABLE failure. It NEVER
+ * fabricates a target.
+ *
+ * Representative-choice rule (documented here because it cannot be read off the
+ * wire shape alone, and MUST be deterministic):
+ *   • target_id = an explicit `target_id` if the caller supplied one (a direct
+ *     singular caller / back-compat), else the FIRST changed id in stable
+ *     order — `changed_node_ids` (sorted ascending) take precedence over
+ *     `changed_edge_ids` (sorted ascending). In words: "first changed node,
+ *     else first changed edge".
+ *   • operation = an explicit `operation` if supplied, else `operations[0]`
+ *     (sorted ascending) — the batch's first operation verb. The wire batch
+ *     carries only the SET of operations (no per-id map), so this describes the
+ *     batch, not necessarily `target_id`'s own op. It is a stable representative.
+ *
+ * Ids and the `operations` array are sorted defensively so the wire output is a
+ * pure function of the input SET, independent of the caller's array order.
+ */
+function adaptDirectGraphEdit(
+  eventPayload: Record<string, unknown> | undefined,
+): DirectGraphEditWireEvent | null {
+  const changedNodeIds = [...stringArrayField(eventPayload, 'changed_node_ids')].sort()
+  const changedEdgeIds = [...stringArrayField(eventPayload, 'changed_edge_ids')].sort()
+  const operations = [...stringArrayField(eventPayload, 'operations')].sort()
+  const fieldsChanged = flattenFieldsChangedToNames(eventPayload)
+  const summary = stringField(eventPayload, 'summary')
+
+  const explicitTarget = stringField(eventPayload, 'target_id')
+  const explicitOperation = stringField(eventPayload, 'operation')
+
+  const target_id = explicitTarget || changedNodeIds[0] || changedEdgeIds[0] || ''
+  const operation = explicitOperation || operations[0] || ''
+
+  // Unencodable: no representative target/operation (e.g. empty ids). Signal
+  // null so the caller raises a RETRYABLE failure. NEVER fabricate a target.
+  if (!target_id || !operation) return null
+
+  const event: DirectGraphEditWireEvent = { kind: 'direct_graph_edit', target_id, operation }
+  if (changedNodeIds.length > 0) event.changed_node_ids = changedNodeIds
+  if (changedEdgeIds.length > 0) event.changed_edge_ids = changedEdgeIds
+  if (operations.length > 0) event.operations = operations
+  if (fieldsChanged.length > 0) event.fields_changed = fieldsChanged
+  if (summary) event.summary = summary
+  return event
 }
 
 // ActionType is a strict enum on the wire. If the UI passes an unknown


### PR DESCRIPTION
## F6 — batch `direct_graph_edit` → 0.22 wire adapter

### Defect
The UI's real debounced emitter (`src/canvas/conversation/useGraphEditEvents.ts:269-278`) sends a **BATCH** `direct_graph_edit` — `{ changed_node_ids, changed_edge_ids, operations, fields_changed (a MAP), summary }` — with **no** singular `target_id`/`operation`. The vendored 0.22 `DirectGraphEditEvent` still **requires** the singular `{ target_id, operation }` pair (back-compat) and accepts the batch fields additively (`fields_changed` typed as `string[]`). `src/v5/buildPayload.ts` read only the singular pair, so a batch event → `null` → the turn was never built and real batch edits were **silently discarded** (dev-only warning at `useConversation.ts`).

Confined to the **V5 path** (`buildV5Payload` → `callV5Turn`, gated by `VITE_ENABLE_V5_ORCHESTRATOR`); the V4 `serializeSystemEvent` path already carried batch payloads and is untouched.

### Fix (build against the schema as it is)
- **`adaptDirectGraphEdit()`** in the `buildPayload` seam derives a **deterministic representative singular pair** and carries the additive batch fields:
  - `target_id` = explicit `target_id`, else first changed **node** (sorted asc), else first changed **edge** (sorted asc).
  - `operation` = explicit `operation`, else `operations[0]` (sorted asc) — the batch's first op verb (the wire batch carries only the op **set**, no per-id map).
  - `fields_changed` map → **sorted, de-duplicated union** of field names (schema types it as flat `string[]`).
  - ids/operations sorted defensively → output is a pure function of the input set.
- **Unencodable** (empty ids) → returns a **RETRYABLE** `BuildV5PayloadResult` (`reason: 'unencodable_graph_edit'`, `retryable: true`), routed through the existing failed-event path (`setLastSendFailure`) in `useConversation` so it is no longer a silent drop nor only a dev-only warning. **Never fabricates a target.**

### Tests (`graphEditBatchAdapter.spec.ts`)
Start from the **REAL emitter shape** (drive `useGraphEditEvents`, capture what it emits — no hand-built fixture), cross the **REAL** `buildV5Payload`, and validate against the vendored `OrchestratorTurnPayloadSchema` (parse must succeed).

- **RED-first:** pre-fix, batch event → no wire event (4/6 fail).
- **GREEN:** wire event with representative pair + batch fields, schema parses.
- **Mutations:** drop representative pair → schema `parse` REDs; drop batch fields → batch-fields pin REDs; remove error path → retryable-error pin REDs.

### Scope guardrails
No emitter changes; schema package (`@talchain/schemas`) untouched; no new wire event kinds.

### Gates
- `pnpm run typecheck` — exit 0, zero net-new errors.
- Affected suites green (v5 + conversation + contracts: 165 files, 2358 passed / 22 skipped).
- eslint clean on touched files (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)