### PR TITLE
fix: Codex F8 honesty copy · F14 uuid advisory · F5 plotFetch hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-router-dom": "^6.30.3",
     "recharts": "^3.8.1",
     "use-sync-external-store": "^1.2.0",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.1",
     "web-vitals": "^5.1.0",
     "y-websocket": "^3.0.0",
     "yjs": "^13.6.27",
@@ -137,7 +137,6 @@
     "@types/pako": "^2.0.4",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
-    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "8.6.0",
     "@typescript-eslint/parser": "8.6.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -193,8 +192,7 @@
     "ws": "GHSA-96hv-2xvq-fx4p (high) + GHSA-58qx-3vcg-4xpx (moderate) via @supabase/realtime-js. Patched >=8.21.0. Remove when @supabase/realtime-js bumps ws.",
     "dompurify": "GHSA-cmwh-pvxp-8882 + others (moderate/low) via posthog-js. Patched >=3.4.11. Remove when posthog-js bumps dompurify.",
     "react-router": "GHSA-2j2x-hqr9-3h42 (moderate) via react-router-dom. Patched >=6.30.4. Remove when react-router-dom bumps within 6.x.",
-    "@opentelemetry/core": "GHSA-8988-4f7v-96qf (moderate) via posthog-js. Patched >=2.8.0. Remove when posthog-js bumps opentelemetry.",
-    "_deferred_uuid": "GHSA-w5hq-g745-h8pq (moderate) — direct dep uuid is ^9.0.1; the patched range is >=11.1.1, a MAJOR bump that could change runtime behaviour, so it is NOT overridden here. Below the critical+high gate threshold. Follow-up: raise the direct uuid dependency to ^11 with a compat check."
+    "@opentelemetry/core": "GHSA-8988-4f7v-96qf (moderate) via posthog-js. Patched >=2.8.0. Remove when posthog-js bumps opentelemetry."
   },
   "optionalDependencies": {
     "@esbuild/darwin-arm64": "0.21.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^1.2.0
         version: 1.6.0(react@18.3.1)
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.1
+        version: 11.1.1
       web-vitals:
         specifier: ^5.1.0
         version: 5.2.0
@@ -165,9 +165,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.28)
-      '@types/uuid':
-        specifier: ^9.0.8
-        version: 9.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: 8.6.0
         version: 8.6.0(@typescript-eslint/parser@8.6.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
@@ -1559,9 +1556,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -4172,13 +4166,12 @@ packages:
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -5657,8 +5650,6 @@ snapshots:
     optional: true
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -8607,9 +8598,9 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
 
-  uuid@13.0.0: {}
+  uuid@11.1.1: {}
 
-  uuid@9.0.1: {}
+  uuid@13.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/src/adapters/plot/v2/__tests__/runV2.plotBearer.spec.ts
+++ b/src/adapters/plot/v2/__tests__/runV2.plotBearer.spec.ts
@@ -61,6 +61,12 @@ function headersOfFirstFetch(): Record<string, string> {
 describe('runV2 PLoT Bearer seam (the analysis-run path)', () => {
   it('attaches Authorization: Bearer <token> to POST /v2/run when VITE_PLOT_BEARER is set', async () => {
     vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-run')
+    // The real callers (useV2Run / useScenarioComparison) derive this baseUrl
+    // from VITE_PLOT_PROXY_BASE. Declaring it here keeps the fixture faithful to
+    // that wiring and lets plotFetch's F5 origin guard recognise http://plot.test
+    // as the configured PLoT base (rather than a foreign origin the Bearer must
+    // not ride to).
+    vi.stubEnv('VITE_PLOT_PROXY_BASE', 'http://plot.test')
 
     await runV2(config, request)
 

--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -243,20 +243,37 @@ export function WhatChangedChip() {
     ? `Since your last run: ${parts.join(', ')}. Highlight the changes on the canvas.`
     : 'What changed?'
 
+  // F8 (honesty): the click can only DO something when either the pulse is
+  // available (a computable local delta) OR a dispatcher is in scope (the CEE
+  // send). With NEITHER, the button is a dead affordance — clicking is a pure
+  // no-op — so it must present itself as disabled rather than actionable. When a
+  // dispatcher exists it stays enabled and the send fires unconditionally (F2-B),
+  // regardless of local-diff availability.
+  const isNoOp = !localHighlightAvailable && !dispatchAction
+
   return (
     <span className="inline-flex flex-col items-start gap-0.5">
     <button
       type="button"
       onClick={handleClick}
+      disabled={isNoOp}
       className={[
         'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full',
         'bg-transparent border border-info/30 text-text-body',
         typography.caption,
         'font-medium cursor-pointer hover:border-info/50 hover:underline',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-info',
+        'disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:no-underline',
       ].join(' ')}
       aria-label={ariaLabel}
-      title="Compared with the previous analysis stored on this device"
+      // F8 (honesty): the device-local comparison basis is only claimed when a
+      // real local comparison happened (an alignable pair with a computable,
+      // non-empty delta). With no such pair the tooltip must not assert one.
+      title={
+        localHighlightAvailable
+          ? 'Compared with the previous analysis stored on this device'
+          : undefined
+      }
       data-testid="what-changed-chip"
     >
       <GitCompareArrows size={14} className="text-info flex-none" aria-hidden="true" />
@@ -264,10 +281,15 @@ export function WhatChangedChip() {
     </button>
     {/* Paul's ruling 2026-07-12 (keep + improve): the comparison basis is a
         VISIBLE label, never tooltip-only — this is a device-local diff of
-        the last two runs, not producer-versioned comparison. */}
-    <span className={`${typography.panelMeta} text-text-light pl-1`}>
-      Compared with your previous run on this device
-    </span>
+        the last two runs, not producer-versioned comparison.
+        F8 (honesty): shown ONLY when a real local pair was compared
+        (localHighlightAvailable) — never when no pair exists, where the claim
+        would be false. */}
+    {localHighlightAvailable && (
+      <span className={`${typography.panelMeta} text-text-light pl-1`}>
+        Compared with your previous run on this device
+      </span>
+    )}
     </span>
   )
 }

--- a/src/canvas/components/__tests__/WhatChangedChip.honestyGate.spec.tsx
+++ b/src/canvas/components/__tests__/WhatChangedChip.honestyGate.spec.tsx
@@ -1,0 +1,168 @@
+/**
+ * WhatChangedChip — F8 (Codex): honesty of the device-local comparison copy,
+ * and removal of the no-op click affordance.
+ *
+ * Two defects at the tip:
+ *   1. FALSE DEVICE-LOCAL CLAIM. The visible meta line ("Compared with your
+ *      previous run on this device") and the button title render UNCONDITIONALLY
+ *      — even when NO local run pair exists (empty / single / missing-snapshot
+ *      history), where nothing was compared on this device at all. The copy must
+ *      render ONLY when a real local comparison happened (an alignable pair with
+ *      a computable, non-empty delta — i.e. localHighlightAvailable).
+ *   2. NO-OP CLICK. When neither a local diff (no pulse to fire) NOR a dispatcher
+ *      (no CEE send) is available, the button still rendered enabled and
+ *      clickable — a dead affordance. It must be disabled in that state.
+ *
+ * CAUTION pinned here (F2-B must not regress): whenever a dispatcher EXISTS the
+ * button stays enabled and the unconditional send keeps firing — regardless of
+ * local-diff availability. Only the no-dispatcher-AND-no-diff case is disabled,
+ * and only the false-basis copy is gated.
+ *
+ * RED-first: written against the corrected behaviour, run against the unfixed
+ * component (copy present with no pair → fails; button not disabled → fails),
+ * GREEN after the gate + disabled land.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+
+const { loadRunsMock, pulseMock, ctxMock } = vi.hoisted(() => ({
+  loadRunsMock: vi.fn(),
+  pulseMock: vi.fn(),
+  ctxMock: vi.fn(),
+}))
+vi.mock('../../store/runHistory', () => ({ loadRuns: loadRunsMock }))
+vi.mock('../../utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
+}))
+vi.mock('../../conversation/ConversationContext', () => ({
+  useOptionalConversationContext: ctxMock,
+}))
+
+import { WhatChangedChip } from '../WhatChangedChip'
+
+const node = (id: string, label: string): Node =>
+  ({ id, type: 'factor', position: { x: 0, y: 0 }, data: { label } }) as Node
+const edge = (id: string, weight: number): Edge =>
+  ({ id, source: 'a', target: 'b', data: { weight, belief: 0.7 } }) as Edge
+
+let runSeq = 0
+const run = (graph?: { nodes: Node[]; edges: Edge[] }) => ({
+  id: `run-${++runSeq}`,
+  ts: 1000 - runSeq,
+  ...(graph ? { graph } : {}),
+})
+
+/** A real, non-empty local delta → localHighlightAvailable === true. */
+function seedRunsWithDelta() {
+  loadRunsMock.mockReturnValue([
+    run({ nodes: [node('a', 'A'), node('c', 'C')], edges: [edge('e1', 0.9)] }),
+    run({ nodes: [node('a', 'A')], edges: [edge('e1', 0.5)] }),
+  ])
+}
+/** Two identical runs → an alignable pair but a ZERO delta (no highlight). */
+function seedIdenticalRuns() {
+  const g = { nodes: [node('a', 'A')], edges: [edge('e1', 0.5)] }
+  loadRunsMock.mockReturnValue([run(g), run(g)])
+}
+
+const DEVICE_COPY = 'Compared with your previous run on this device'
+
+beforeEach(() => {
+  loadRunsMock.mockReset()
+  pulseMock.mockReset()
+  ctxMock.mockReset()
+})
+afterEach(() => cleanup())
+
+describe('WhatChangedChip — F8: the device-local comparison copy is honest', () => {
+  it('does NOT claim a device-local comparison when NO local pair exists (empty history)', () => {
+    // A dispatcher is present so the chip is enabled — this isolates the COPY
+    // defect from the disabled defect. Nothing was compared on this device, so
+    // the "compared … on this device" basis line must not render.
+    ctxMock.mockReturnValue({ dispatchAction: vi.fn().mockResolvedValue(undefined) })
+    loadRunsMock.mockReturnValue([])
+
+    render(<WhatChangedChip />)
+
+    expect(screen.queryByText(DEVICE_COPY)).toBeNull()
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip.getAttribute('title') ?? '').not.toMatch(/on this device/i)
+  })
+
+  it('does NOT claim a device-local comparison for an identical (zero-delta) pair', () => {
+    ctxMock.mockReturnValue({ dispatchAction: vi.fn().mockResolvedValue(undefined) })
+    seedIdenticalRuns()
+
+    render(<WhatChangedChip />)
+
+    expect(screen.queryByText(DEVICE_COPY)).toBeNull()
+  })
+
+  it('DOES show the device-local basis when a real local delta was computed', () => {
+    // The honest, true case survives: an alignable pair with a non-empty delta.
+    ctxMock.mockReturnValue({ dispatchAction: vi.fn().mockResolvedValue(undefined) })
+    seedRunsWithDelta()
+
+    render(<WhatChangedChip />)
+
+    expect(screen.getByText(DEVICE_COPY)).toBeInTheDocument()
+    expect(screen.getByTestId('what-changed-chip')).toHaveAttribute(
+      'title',
+      expect.stringMatching(/on this device/i),
+    )
+  })
+})
+
+describe('WhatChangedChip — F8: no dead no-op affordance', () => {
+  it('DISABLES the button when neither a local diff nor a dispatcher is available', () => {
+    // No pulse possible AND no CEE send possible → a click does nothing. The
+    // control must not present itself as actionable.
+    ctxMock.mockReturnValue(null)
+    loadRunsMock.mockReturnValue([])
+
+    render(<WhatChangedChip />)
+
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip).toBeDisabled()
+    fireEvent.click(chip)
+    expect(pulseMock).not.toHaveBeenCalled()
+  })
+
+  it('DISABLES for an identical (zero-delta) pair with no dispatcher', () => {
+    ctxMock.mockReturnValue(null)
+    seedIdenticalRuns()
+
+    render(<WhatChangedChip />)
+    expect(screen.getByTestId('what-changed-chip')).toBeDisabled()
+  })
+
+  it('F2-B NOT regressed: with a dispatcher the button stays ENABLED even with no local diff', () => {
+    // The server-owned send must keep firing unconditionally when the dispatcher
+    // exists — so the button must remain actionable regardless of local diff.
+    const dispatchMock = vi.fn().mockResolvedValue(undefined)
+    ctxMock.mockReturnValue({ dispatchAction: dispatchMock })
+    loadRunsMock.mockReturnValue([])
+
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip).toBeEnabled()
+    fireEvent.click(chip)
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays ENABLED with a local diff even when no dispatcher is present (pulse is still useful)', () => {
+    ctxMock.mockReturnValue(null)
+    seedRunsWithDelta()
+
+    render(<WhatChangedChip />)
+    const chip = screen.getByTestId('what-changed-chip')
+    expect(chip).toBeEnabled()
+    fireEvent.click(chip)
+    expect(pulseMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/contexts/__tests__/GuestContext.uuid.smoke.spec.tsx
+++ b/src/contexts/__tests__/GuestContext.uuid.smoke.spec.tsx
@@ -1,0 +1,35 @@
+/**
+ * F14 (Codex): uuid direct dep raised 9.0.1 → 11.1.1 (GHSA-w5hq-g745-h8pq).
+ *
+ * The v9→v11 major bump keeps the v4 named-export API, but ESM/interop of the
+ * `import { v4 as uuidv4 } from 'uuid'` site can regress silently across a major
+ * bundler resolution. This smoke exercises the ONLY import site (GuestContext)
+ * end-to-end: rendering the provider generates a guest id and persists it, so a
+ * broken `v4` import would fail here in the app's real jsdom/vite resolution.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+import { GuestProvider } from '../GuestContext'
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+beforeEach(() => localStorage.clear())
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe('uuid import site (GuestContext) after the 9→11 bump', () => {
+  it('the v4 named import mints a valid RFC-4122 v4 guest id', async () => {
+    render(
+      <GuestProvider>
+        <div />
+      </GuestProvider>,
+    )
+
+    await waitFor(() => {
+      expect(localStorage.getItem('guestId')).toMatch(UUID_V4)
+    })
+  })
+})

--- a/src/lib/__tests__/plotFetch.spec.ts
+++ b/src/lib/__tests__/plotFetch.spec.ts
@@ -120,3 +120,132 @@ describe('plotFetch', () => {
     expect(headersOfFirstCall().Authorization).toBe('Bearer fresh-token')
   })
 })
+
+/**
+ * F5 hardening (defense-in-depth):
+ *   (a) ORIGIN GUARD — with the Bearer present, a request whose resolved origin
+ *       is not same-origin or the configured PLoT base is REJECTED pre-flight
+ *       (thrown before `fetch`), so the token can never ride to a foreign origin.
+ *       When the token is ABSENT (fail-safe) the guard is inert — the request
+ *       forwards untouched, exactly as a bare fetch would.
+ *   (b) REQUEST-OBJECT HEADERS — when the caller passes a Request object, its own
+ *       headers survive the merge alongside the injected Bearer (the pre-fix path
+ *       replaced them with the init.headers object and dropped them).
+ */
+describe('plotFetch — F5 hardening', () => {
+  describe('(a) origin guard: the Bearer never rides to a foreign origin', () => {
+    it('THROWS pre-flight for a foreign origin and never calls fetch (token present)', () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+      expect(() =>
+        plotFetch('https://evil.example.com/steal', { method: 'POST' }),
+      ).toThrow(/origin/i)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('rejects a look-alike host that merely embeds the PLoT marker', () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+      expect(() =>
+        plotFetch('https://plot-lite-service.evil.com/v2/run'),
+      ).toThrow(/origin/i)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('rejects a protocol-relative URL to a foreign host', () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+      expect(() => plotFetch('//evil.example.com/steal')).toThrow(/origin/i)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('ALLOWS a same-origin relative path (token present)', async () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+      await plotFetch('/bff/engine/v1/run', { method: 'POST' })
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(headersOfFirstCall().Authorization).toBe('Bearer staging-token-123')
+    })
+
+    it('ALLOWS the canonical PLoT staging host (token present)', async () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+      await plotFetch('https://plot-lite-service-staging.onrender.com/v2/run')
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(headersOfFirstCall().Authorization).toBe('Bearer staging-token-123')
+    })
+
+    it('ALLOWS an absolute origin that matches the configured PLoT base env', async () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+      vi.stubEnv('VITE_PLOT_PROXY_BASE', 'https://plot.internal.example.test')
+
+      await plotFetch('https://plot.internal.example.test/v1/run', { method: 'POST' })
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(headersOfFirstCall().Authorization).toBe('Bearer staging-token-123')
+    })
+
+    it('does NOT guard the fail-safe path: a foreign origin forwards untouched when the token is absent', async () => {
+      // No Bearer to leak → the request is a bare, byte-identical forward. The
+      // guard must not change today's behaviour before the token is provisioned.
+      const init: RequestInit = { method: 'POST' }
+      await plotFetch('https://evil.example.com/whatever', init)
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe('https://evil.example.com/whatever')
+      expect(initOfFirstCall()).toBe(init)
+      expect(headersOfFirstCall()).not.toHaveProperty('Authorization')
+    })
+  })
+
+  describe('(b) Request-object input: original headers survive alongside the Bearer', () => {
+    it('merges the Request object’s own headers AND the injected Bearer', async () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+      // Absolute same-origin URL: jsdom's Request does not resolve relative URLs.
+      const req = new Request(`${location.origin}/bff/engine/v1/run`, {
+        method: 'POST',
+        headers: { 'X-Trace': 'abc', 'Content-Type': 'application/json' },
+      })
+      await plotFetch(req)
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      const headers = headersOfFirstCall()
+      // Both the Request's own headers AND the Bearer are present (pre-fix the
+      // Request headers were dropped when init.headers was set).
+      expect(headers['x-trace']).toBe('abc')
+      expect(headers['content-type']).toBe('application/json')
+      expect(headers.Authorization).toBe('Bearer staging-token-123')
+    })
+
+    it('init.headers override the Request’s headers, and the Bearer overrides a stale Authorization case-insensitively', async () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'fresh-token')
+
+      // The Request carries a stale, LOWERCASE authorization (jsdom lowercases a
+      // Request's header names). The injected capitalised Authorization must
+      // replace it — not coexist as a second key that fetch would combine.
+      const req = new Request(`${location.origin}/bff/engine/v1/run`, {
+        headers: { 'x-both': 'from-request', 'x-req': 'req', authorization: 'Bearer stale' },
+      })
+      await plotFetch(req, { headers: { 'x-both': 'from-init', 'x-init': 'init' } })
+
+      const headers = headersOfFirstCall()
+      expect(headers['x-req']).toBe('req') // survives from the Request
+      expect(headers['x-init']).toBe('init') // added by init
+      expect(headers['x-both']).toBe('from-init') // init wins over the Request
+      expect(headers.Authorization).toBe('Bearer fresh-token') // Bearer wins over all
+      // The stale lowercase authorization must NOT survive alongside the Bearer.
+      expect(headers.authorization).toBeUndefined()
+    })
+
+    it('a Request object to a foreign origin is rejected pre-flight (token present)', () => {
+      vi.stubEnv('VITE_PLOT_BEARER', 'staging-token-123')
+
+      const req = new Request('https://evil.example.com/steal')
+      expect(() => plotFetch(req)).toThrow(/origin/i)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/plotFetch.ts
+++ b/src/lib/plotFetch.ts
@@ -38,33 +38,122 @@
 import { plotAuthHeaders } from './plotAuthHeaders'
 
 /**
- * Merge the (already-normalised, plain-object) auth headers over whatever the
- * caller passed as `init.headers`. Returns a plain `Record<string, string>` so
- * every PLoT seam ends up with a predictable header shape.
+ * Fold an ordered list of header sources into ONE plain `Record<string,string>`,
+ * later sources winning on collision. `Headers`/tuple-array/record inputs are all
+ * normalised, so every PLoT seam ends up with a predictable header shape.
  *
- * Only runs on the token-present branch — i.e. once the flip is happening — so a
- * `Headers`/tuple-array caller (none exist among the PLoT seams today; this arm
- * is defensive) being normalised to a record here never affects the fail-safe,
- * byte-identical, token-absent path below.
+ * Ordered lowest→highest precedence: a Request object's OWN headers (F5), then
+ * the caller's `init.headers`, then the injected auth. Auth is last so the flip's
+ * Bearer is never shadowed by a stale caller-supplied Authorization.
+ *
+ * Only runs on the token-present branch — i.e. once the flip is happening — so
+ * normalising a `Headers`/tuple-array caller to a record here never affects the
+ * fail-safe, byte-identical, token-absent path below.
  */
-function mergeAuthHeaders(
-  base: HeadersInit | undefined,
-  auth: Record<string, string>,
-): Record<string, string> {
+function mergeHeaders(...sources: (HeadersInit | undefined)[]): Record<string, string> {
   const out: Record<string, string> = {}
-  if (base instanceof Headers) {
-    base.forEach((value, key) => {
-      out[key] = value
-    })
-  } else if (Array.isArray(base)) {
-    for (const [key, value] of base) out[key] = value
-  } else if (base) {
-    Object.assign(out, base)
+  // HTTP header names are case-INSENSITIVE. Dedupe on the lowercased name so a
+  // later source (init, then auth) cleanly REPLACES an earlier one regardless of
+  // casing — critical because a Request object's `.headers` lowercases its keys,
+  // so a stale lowercase `authorization` must not survive alongside the injected
+  // capitalised `Authorization` (which `fetch` would otherwise COMBINE, shadowing
+  // the flip's Bearer). The last writer's own casing is preserved in the output.
+  const keyByLower = new Map<string, string>()
+  const set = (key: string, value: string) => {
+    const lower = key.toLowerCase()
+    const prior = keyByLower.get(lower)
+    if (prior !== undefined && prior !== key) delete out[prior]
+    out[key] = value
+    keyByLower.set(lower, key)
   }
-  // Auth wins on collision — the flip's Bearer must not be shadowed by a stale
-  // caller-supplied Authorization.
-  Object.assign(out, auth)
+  for (const src of sources) {
+    if (!src) continue
+    if (Array.isArray(src)) {
+      for (const [key, value] of src) set(key, value)
+    } else if (typeof (src as Headers).forEach === 'function') {
+      // A Headers or Headers-LIKE object. Feature-detected via `forEach` rather
+      // than `instanceof Headers`: a Request object's own `.headers` is not an
+      // instance of the global Headers in every runtime (jsdom notably), yet it
+      // exposes the same `forEach(value, key)` contract.
+      ;(src as Headers).forEach((value, key) => set(key, value))
+    } else {
+      for (const [key, value] of Object.entries(src)) set(key, value as string)
+    }
+  }
   return out
+}
+
+/** The absolute-or-relative URL string a `fetch` input resolves from. */
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.href
+  // A Request object — its `url` is already an absolute, resolved URL.
+  return input.url
+}
+
+/**
+ * The origins the PLoT Bearer is allowed to ride to: this app's own origin
+ * (relative paths and any same-origin absolute URL — the `/bff/engine/*` Netlify
+ * pass-through and the local dev proxy) plus whatever absolute PLoT base the
+ * deployment configured.
+ */
+function allowedPlotOrigins(): Set<string> {
+  const origins = new Set<string>()
+  if (typeof location !== 'undefined' && location.origin && location.origin !== 'null') {
+    origins.add(location.origin)
+  }
+  let env: Record<string, unknown> = {}
+  try {
+    env = { ...import.meta.env }
+  } catch {
+    // SSR/test env where import.meta.env is unavailable.
+  }
+  // The three env tokens the PLoT-direct seams derive their base from. Only
+  // ABSOLUTE bases contribute an origin; the relative default ('/bff/engine') is
+  // same-origin and is already covered by location.origin above.
+  for (const key of ['VITE_PLOT_PROXY_BASE', 'VITE_BFF_BASE', 'VITE_PLOT_ENGINE_URL']) {
+    const val = env[key]
+    if (typeof val === 'string' && /^https?:\/\//i.test(val)) {
+      try {
+        origins.add(new URL(val).origin)
+      } catch {
+        // Malformed base — ignore; it simply won't be allow-listed.
+      }
+    }
+  }
+  return origins
+}
+
+/** The canonical PLoT deployment host family (plot-lite-service[-env].onrender.com). */
+const PLOT_HOST = /^plot-lite-service(?:-[a-z0-9]+)*\.onrender\.com$/i
+
+/**
+ * F5 (a): REJECT before the Bearer is attached if the request's resolved origin
+ * is neither same-origin, the configured PLoT base, nor the canonical PLoT host.
+ * The Bearer must never ride to a foreign origin. Runs ONLY on the token-present
+ * branch, so the fail-safe (token-absent) path stays byte-for-byte a bare fetch.
+ */
+function assertPlotOrigin(input: RequestInfo | URL): void {
+  const raw = urlOf(input)
+  const base = typeof location !== 'undefined' ? location.href : undefined
+  let origin: string
+  try {
+    origin = new URL(raw, base).origin
+  } catch {
+    // Unresolvable (a relative URL with no base to resolve against). A relative
+    // URL is inherently same-origin and cannot carry the Bearer cross-origin.
+    return
+  }
+  if (allowedPlotOrigins().has(origin)) return
+  try {
+    if (PLOT_HOST.test(new URL(origin).hostname)) return
+  } catch {
+    // fall through to reject
+  }
+  throw new Error(
+    `plotFetch: refusing to attach the PLoT Bearer to a non-PLoT origin (${origin}). ` +
+      `The Bearer may ride only to same-origin or the configured PLoT base.`,
+  )
 }
 
 /**
@@ -80,5 +169,15 @@ export function plotFetch(input: RequestInfo | URL, init?: RequestInit): Promise
     return fetch(input, init)
   }
 
-  return fetch(input, { ...init, headers: mergeAuthHeaders(init?.headers, auth) })
+  // The Bearer is about to ride. Guard the origin FIRST (F5 a) — throw before it
+  // is attached if the destination is foreign.
+  assertPlotOrigin(input)
+
+  // F5 (b): when the input is a Request object, its OWN headers must survive the
+  // merge. Passing `{ ...init, headers }` to `fetch(request, …)` REPLACES the
+  // Request's headers with `headers`, so fold the Request's headers in first.
+  const requestHeaders =
+    typeof Request !== 'undefined' && input instanceof Request ? input.headers : undefined
+
+  return fetch(input, { ...init, headers: mergeHeaders(requestHeaders, init?.headers, auth) })
 }


### PR DESCRIPTION
Three small adjudicated Codex findings, verified at the current `staging` tip then fixed, one commit each. RED-first pins for the behavioural changes; existing pins kept green.

## Commit 1 — F8 (P1): WhatChangedChip honesty
`src/canvas/components/WhatChangedChip.tsx`

- The device-local comparison copy ("Compared with your previous run on this device" + the matching tooltip) rendered **unconditionally** — even with an empty / single / missing-snapshot run history where nothing was compared on this device. It now renders **only** when a real local comparison happened (`localHighlightAvailable`).
- The button was left enabled and clickable when neither a local diff (no pulse) nor a dispatcher (no CEE send) was available — a dead no-op affordance. It is now `disabled` in that state.
- **F2-B preserved:** whenever a dispatcher exists the button stays enabled and the server-owned `what_changed` send keeps firing unconditionally, regardless of local-diff availability.
- RED-first pins added (`WhatChangedChip.honestyGate.spec.tsx`): false-basis-with-no-pair (copy absent) and no-op-click (button disabled), plus the F2-B non-regression.

## Commit 2 — F14 (P2): uuid advisory
`package.json`, `pnpm-lock.yaml`

- Raised the direct `uuid` dep `^9.0.1 → ^11.1.1` (latest 11.x = the patched version for GHSA-w5hq-g745-h8pq).
- Dropped `@types/uuid` (uuid ≥10 ships its own types) and removed the resolved `_deferred_uuid` provenance note.
- API impact: none — the sole import site (`GuestContext.tsx`) uses the `v4` named export, unchanged across the bump. A smoke test exercises that import site end-to-end.
- `pnpm audit` no longer reports the advisory on the direct `uuid` path.

## Commit 3 — F5 (defense-in-depth): plotFetch hardening
`src/lib/plotFetch.ts`

On the token-present branch only (the token-absent fail-safe path stays a byte-identical bare fetch):
- **(a) Origin guard** — before the Bearer is attached, reject any request whose resolved origin is not same-origin, the configured PLoT base (`VITE_PLOT_PROXY_BASE` / `VITE_BFF_BASE` / `VITE_PLOT_ENGINE_URL`), or the canonical PLoT host (`plot-lite-service[-env].onrender.com`). The Bearer can no longer ride to a foreign origin; a look-alike host and a protocol-relative `//evil` URL are both refused pre-flight.
- **(b) Request-object header merge** — a Request object's own headers now survive the merge (the prior `{ ...init, headers }` passed to `fetch(request, …)` replaced them). Folding is case-insensitive so a stale lowercase `authorization` cannot shadow the injected `Authorization`.
- Tests extend `plotFetch.spec.ts`; `runV2.plotBearer.spec.ts` now declares its absolute base via `VITE_PLOT_PROXY_BASE` (the env its real callers use), keeping the fixture faithful and origin-guard-recognised.

## Gates
- `pnpm run typecheck` — exit 0, zero net-new errors.
- Affected suites green: WhatChangedChip (41) + honestyGate (7) + F2-B/send pins, plotFetch (18 incl. 10 new F5 pins) + plotAuthHeaders + seam guard, uuid import-site smoke; broad plot run 980 passed / 3 skipped / 0 failed.
- ESLint clean on all touched files (incl. no-irregular-whitespace).
- `pnpm audit` — direct `uuid` advisory resolved; prod high-gate exit 0.

**Draft — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)