### PR TITLE
fix(system-events): propagate send failures — no more silent drops (sendTurn)

### DIFF
--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -166,9 +166,43 @@ export const ConversationPanel = memo(function ConversationPanel({
     [sendMessage],
   )
 
+  // Best-effort system-event dispatch: for background acks (patch_dismissed,
+  // and — via useGraphEditEvents — direct_graph_edit) whose failure has no
+  // user-facing surface. sendSystemEvent now REJECTS on a failed POST
+  // (SystemEventSendError), so we must consume the rejection here to avoid an
+  // unhandled promise rejection. Mirrors the existing best-effort `.catch()`
+  // pattern for background events; not a silent drop for the failures that DO
+  // own a surface (feedback → FeedbackRow revert, patch accept → NETWORK_ERROR).
+  const sendSystemEventBestEffort = useCallback(
+    (event: Parameters<typeof sendSystemEvent>[0]) => {
+      // Promise.resolve() coerces the return so a non-thenable stub can't throw.
+      void Promise.resolve(sendSystemEvent(event)).catch((err) => {
+        if (import.meta.env.DEV) {
+          console.warn('[ConversationPanel] Best-effort system event failed:', event.type, err)
+        }
+      })
+    },
+    [sendSystemEvent],
+  )
+
   // ── Patch handlers (unchanged from previous version) ──────────────────
   const handlePatchAccept = useCallback(
     async (stateKey: string, block: GraphPatchBlock) => {
+      // Notify CEE that the user accepted — AFTER the patch has been applied
+      // optimistically. sendSystemEvent now rejects on a failed POST, so surface
+      // that via the EXISTING NETWORK_ERROR retry affordance (block returns to
+      // 'proposed' so the "Try again" control renders) rather than dropping the
+      // failure silently. No new UI surface — same card as the validate-path
+      // catch below. The applied graph stays applied; retry re-confirms.
+      const notifyPatchAccepted = (payload: Record<string, unknown>) => {
+        void Promise.resolve(sendSystemEvent({ type: 'patch_accepted', payload })).catch(() => {
+          setPatchBlockState(stateKey, 'proposed')
+          setPatchRejection(stateKey, {
+            code: 'NETWORK_ERROR',
+            message: 'Failed to apply — try again',
+          })
+        })
+      }
       const chainId = beginInteractionChain({
         triggerSurface: 'proposal_accept',
         sourceSurface: 'ai_panel',
@@ -211,7 +245,7 @@ export const ConversationPanel = memo(function ConversationPanel({
             code: 'UNSUPPORTED_OPERATION',
             message: `Unsupported operation: ${unknownOps[0].op}`,
           })
-          sendSystemEvent({
+          sendSystemEventBestEffort({
             type: 'patch_dismissed',
             payload: { patch_id: block.patch_id, reason: 'unsupported_operation' },
           })
@@ -271,13 +305,10 @@ export const ConversationPanel = memo(function ConversationPanel({
               useGuidanceStore.getState().clearItemsByTargetIds(allIds)
             }
 
-            sendSystemEvent({
-              type: 'patch_accepted',
-              payload: {
-                patch_id: block.patch_id,
-                operations: block.operations,
-                applied_graph_hash: typeof result.graph_hash === 'string' ? result.graph_hash : undefined,
-              },
+            notifyPatchAccepted({
+              patch_id: block.patch_id,
+              operations: block.operations,
+              applied_graph_hash: typeof result.graph_hash === 'string' ? result.graph_hash : undefined,
             })
 
             // Track 2: persist block state change
@@ -293,7 +324,7 @@ export const ConversationPanel = memo(function ConversationPanel({
               message: result.message ?? 'Patch validation failed',
               violations,
             })
-            sendSystemEvent({
+            sendSystemEventBestEffort({
               type: 'patch_dismissed',
               payload: { patch_id: block.patch_id, reason: 'validation_failed' },
             })
@@ -332,13 +363,10 @@ export const ConversationPanel = memo(function ConversationPanel({
             useGuidanceStore.getState().clearItemsByTargetIds(ids)
           }
 
-          sendSystemEvent({
-            type: 'patch_accepted',
-            payload: {
-              patch_id: block.patch_id,
-              operations: block.operations,
-              applied_graph_hash: undefined,
-            },
+          notifyPatchAccepted({
+            patch_id: block.patch_id,
+            operations: block.operations,
+            applied_graph_hash: undefined,
           })
 
           // Track 2: persist block state change
@@ -352,7 +380,7 @@ export const ConversationPanel = memo(function ConversationPanel({
         })
       }
     },
-    [setPatchBlockState, setPatchRejection, sendSystemEvent, onBlockAction],
+    [setPatchBlockState, setPatchRejection, sendSystemEvent, sendSystemEventBestEffort, onBlockAction],
   )
 
   const handlePatchDismiss = useCallback(
@@ -370,7 +398,7 @@ export const ConversationPanel = memo(function ConversationPanel({
       setPatchBlockState(stateKey, 'dismissed')
       const message = messages.find((candidate) => candidate.id && stateKey.startsWith(`${candidate.id}:`))
       const patchId = message?.id ? stateKey.slice(message.id.length + 1) : stateKey
-      sendSystemEvent({
+      sendSystemEventBestEffort({
         type: 'patch_dismissed',
         payload: { patch_id: patchId },
       })
@@ -379,7 +407,7 @@ export const ConversationPanel = memo(function ConversationPanel({
       const turnId = extractTurnIdFromStateKey(stateKey, patchId)
       void onBlockAction(turnId, patchId, 'dismissed', `Dismissed suggestion`)
     },
-    [messages.length, setPatchBlockState, sendSystemEvent, onBlockAction],
+    [messages.length, setPatchBlockState, sendSystemEventBestEffort, onBlockAction],
   )
 
   const handleFeedback = useCallback(

--- a/src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
+++ b/src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
@@ -1,0 +1,218 @@
+/**
+ * Caller-level surfacing when a system-event send FAILS (F-lane: no silent
+ * drops). The real ConversationPanel is rendered with a mock conversation whose
+ * `sendSystemEvent` REJECTS — which the seam spec
+ * (useConversation.systemEventFailure.spec.ts) proves is exactly what happens
+ * on a real failed POST (network / 4xx / 5xx). Here we lock the two callers'
+ * reactions to that rejection:
+ *
+ *   1. FeedbackRow (PR #435) — the optimistic thumbs vote REVERTS, re-enabling
+ *      the buttons for retry. Pre-fix (sendSystemEvent resolved) this never
+ *      fired; the vote stuck silently on a failed POST.
+ *   2. handlePatchAccept — the failure surfaces via the EXISTING NETWORK_ERROR
+ *      retry affordance (block returns to 'proposed'). Pre-fix the send was
+ *      fire-and-forget, so a failed POST was dropped silently.
+ *
+ * No new UI surface is introduced — both reuse affordances that already exist.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ConversationPanel } from '../ConversationPanel'
+import { useCanvasStore } from '../../store'
+import type { ConversationMessage, GraphPatchBlock } from '../types'
+import type { UseConversationReturn, PatchBlockState, PatchRejectionInfo } from '../useConversation'
+
+// ---------------------------------------------------------------------------
+// Mock: PLoT adapter (patch accept path validates through this)
+// ---------------------------------------------------------------------------
+
+const mockValidatePatch = vi.fn()
+vi.mock('../../../adapters/plot', () => ({
+  plot: {
+    validatePatch: (...args: unknown[]) => mockValidatePatch(...args),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Harness — mirrors patchAcceptLogic.spec.tsx, but sendSystemEvent is
+// injectable so a test can make it REJECT.
+// ---------------------------------------------------------------------------
+
+const INITIAL_NODES = [
+  { id: 'n1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+  { id: 'n2', type: 'option', position: { x: 100, y: 0 }, data: { label: 'Option A' } },
+]
+const INITIAL_EDGES = [
+  { id: 'e1', source: 'n1', target: 'n2', type: 'styled', data: { weight: 1 } },
+]
+
+function makePatchBlock(overrides?: Partial<GraphPatchBlock>): GraphPatchBlock {
+  return {
+    type: 'graph_patch',
+    patch_id: 'patch-1',
+    summary: "Add 'competitor response' as a risk factor",
+    operations: [
+      { op: 'add_node', target_id: 'n-new', data: { type: 'risk', label: 'Competitor response' } },
+    ],
+    target_graph_hash: 'hash-1',
+    ...overrides,
+  }
+}
+
+function makePatchMessage(block: GraphPatchBlock): ConversationMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: 'I suggest adding a risk factor.',
+    blocks: [block],
+    timestamp: new Date(),
+    clientTurnId: 'turn-1',
+  }
+}
+
+function makeFeedbackMessage(): ConversationMessage {
+  // Assistant, non-synthetic, real conversational content + a clientTurnId →
+  // MessageBubble renders FeedbackRow with a defined turnId.
+  return {
+    id: 'msg-fb',
+    role: 'assistant',
+    content: 'Here is my analysis of your decision.',
+    timestamp: new Date(),
+    clientTurnId: 'turn-fb-1',
+  }
+}
+
+function makeMockConversation(
+  messages: ConversationMessage[],
+  sendSystemEvent: ReturnType<typeof vi.fn>,
+): {
+  conversation: UseConversationReturn
+  patchStates: Map<string, PatchBlockState>
+  patchRejections: Map<string, PatchRejectionInfo>
+} {
+  const patchStates = new Map<string, PatchBlockState>()
+  const patchRejections = new Map<string, PatchRejectionInfo>()
+
+  const conversation: UseConversationReturn = {
+    messages,
+    isThinking: false,
+    longRunningHint: null,
+    lastSendFailure: null,
+    dispatchAction: vi.fn().mockResolvedValue(undefined),
+    cancelTurn: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendSystemEvent,
+    sendChip: vi.fn().mockResolvedValue(undefined),
+    clearHistory: vi.fn(),
+    retryLast: vi.fn().mockResolvedValue(undefined),
+    patchBlockStates: patchStates,
+    setPatchBlockState: (key: string, state: PatchBlockState) => {
+      patchStates.set(key, state)
+    },
+    patchRejections,
+    setPatchRejection: (key: string, info: PatchRejectionInfo) => {
+      patchRejections.set(key, info)
+    },
+  }
+
+  return { conversation, patchStates, patchRejections }
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  mockValidatePatch.mockReset()
+  useCanvasStore.setState({
+    nodes: [...INITIAL_NODES],
+    edges: [...INITIAL_EDGES],
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    currentScenarioLastResultHash: 'hash-1',
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    results: { status: 'idle' } as never,
+    _externalMutationActive: 0,
+  } as never)
+})
+
+afterEach(() => {
+  useCanvasStore.setState({ nodes: [], edges: [] } as never)
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// FeedbackRow — reverts the optimistic vote on a failed send
+// ---------------------------------------------------------------------------
+
+describe('FeedbackRow revert on a failed feedback send', () => {
+  it('re-enables the thumbs after the feedback turn rejects (optimistic revert)', async () => {
+    const sendSystemEvent = vi.fn().mockRejectedValue(new Error('send failed'))
+    const { conversation } = makeMockConversation([makeFeedbackMessage()], sendSystemEvent)
+
+    render(<ConversationPanel conversation={conversation} onCollapse={vi.fn()} />)
+
+    const thumbsUp = screen.getByRole('button', { name: 'Helpful' })
+    fireEvent.click(thumbsUp)
+
+    // Optimistic disable is synchronous on click.
+    expect(screen.getByRole('button', { name: 'Helpful' })).toBeDisabled()
+
+    // The feedback POST was dispatched as a system event…
+    expect(sendSystemEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'feedback_submitted',
+        payload: { turn_id: 'turn-fb-1', rating: 'up' },
+      }),
+    )
+
+    // …and once its rejection settles, the buttons re-enable for retry.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Helpful' })).not.toBeDisabled()
+    })
+    expect(screen.getByRole('button', { name: 'Not helpful' })).not.toBeDisabled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePatchAccept — surfaces via the existing NETWORK_ERROR retry affordance
+// ---------------------------------------------------------------------------
+
+describe('handlePatchAccept surfaces a failed patch_accepted send', () => {
+  it('returns the block to proposed + NETWORK_ERROR retry when the send rejects', async () => {
+    mockValidatePatch.mockResolvedValue({
+      valid: true,
+      graph: {
+        nodes: [
+          ...INITIAL_NODES,
+          { id: 'n-new', type: 'risk', position: { x: 200, y: 0 }, data: { label: 'Competitor response' } },
+        ],
+        edges: [...INITIAL_EDGES],
+      },
+    })
+    const sendSystemEvent = vi.fn().mockRejectedValue(new Error('send failed'))
+    const { conversation, patchStates, patchRejections } = makeMockConversation(
+      [makePatchMessage(makePatchBlock())],
+      sendSystemEvent,
+    )
+
+    render(<ConversationPanel conversation={conversation} onCollapse={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('patch-accept'))
+
+    // The patch_accepted notification was attempted…
+    await waitFor(() => {
+      expect(sendSystemEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'patch_accepted' }),
+      )
+    })
+
+    // …and its rejection surfaces via the existing NETWORK_ERROR retry
+    // affordance: the block returns to 'proposed' (so GraphPatchBlockRenderer's
+    // `patch-retry-error` "Try again" card renders) with the NETWORK_ERROR
+    // rejection info — no new UI surface. (Asserted on the state maps, as the
+    // sibling patchAcceptLogic.spec.tsx does — the mock's setters mutate Maps
+    // and do not trigger a parent re-render.)
+    await waitFor(() => {
+      expect(patchRejections.get('msg-1:patch-1')?.code).toBe('NETWORK_ERROR')
+    })
+    expect(patchStates.get('msg-1:patch-1')).toBe('proposed')
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.systemEventFailure.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.systemEventFailure.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * LIVE-CHAIN system-event send-failure propagation (F-lane: no more silent
+ * drops). These tests drive an ACTUAL failed POST through the REAL V5 seam —
+ * stubbed global `fetch` → REAL `callV5Turn` → REAL `parseV5Response` → REAL
+ * `routeV5Response` → useConversation's V5 branch, unmocked — and assert that a
+ * SYSTEM-mode turn (feedback / patch / graph-edit all funnel through
+ * `sendSystemEvent`) now REJECTS instead of resolving void.
+ *
+ * Why this shape is load-bearing: the defect was invisible to callers because
+ * `sendTurn` swallowed the system-mode typed error and returned void, so PR
+ * #435's FeedbackRow optimistic-revert (and handlePatchAccept's affordance)
+ * could never fire on a swallowed 4xx/5xx/network failure. A `sendSystemEvent`
+ * that rejects is the seam that makes silence impossible. These specs FAIL on
+ * the pre-fix code (sendSystemEvent resolves) — that is the RED that proves the
+ * swallow; restoring the swallow re-REDs them (mutation check).
+ *
+ * The user-mode pin at the bottom locks the asymmetry: a user turn on the SAME
+ * failing POST must NOT throw — it keeps its in-transcript synthetic bubble +
+ * setLastSendFailure exactly as before.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation, SystemEventSendError } from '../useConversation'
+import { useCanvasStore } from '../../store'
+
+// ---------------------------------------------------------------------------
+// Mocks — seams only; the V5 adapter/parser/router chain stays REAL.
+// ---------------------------------------------------------------------------
+
+// V4 transport must never be touched by these tests.
+const mockCallTurn = vi.fn()
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: async () => null,
+  storeAnalysis: async () => undefined,
+}))
+
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: () => undefined,
+}))
+
+// sendSystemEvent's own pre-check no-ops unless orchestrator V2 is enabled.
+// Keep every other flag real (importOriginal) — the success path reads several
+// (isPreAnalysisEnrichedEnabled, …) and must not trip an undefined-export throw.
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isOrchestratorV2Enabled: () => true,
+    isOrchestratorStreamingEnabled: () => false,
+  }
+})
+
+// Eligibility ON so every turn enters the V5 exclusive branch regardless of
+// the developer's env (same pattern as useConversation.v5ErrorRecovery.spec.ts).
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true }),
+    isV5CanonicalRunPath: () => false,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Wire fixtures + fetch stubs
+// ---------------------------------------------------------------------------
+
+/** A strict CEE BoundaryError body (the real 4xx/5xx wire shape). */
+function boundaryErrorBody(retryable: boolean): Record<string, unknown> {
+  return {
+    error: 'INTERNAL_ERROR',
+    boundary: 'B1',
+    direction: 'egress',
+    validator: 'system_event_pipeline',
+    details: { retryable, stage: 'frame' },
+    request_id: 'req_sys_1',
+    retryable,
+  }
+}
+
+/** A minimal valid OlumiResponse (200 success) — CEE acknowledged the event. */
+function okResponseBody(assistantText: string): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: assistantText,
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+  }
+}
+
+function stubFetchWith(status: number, body: unknown) {
+  const fetchStub = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response))
+  vi.stubGlobal('fetch', fetchStub)
+  return fetchStub
+}
+
+/** Network reject: fetch itself throws (offline / DNS / CORS preflight). */
+function stubFetchReject() {
+  const fetchStub = vi.fn(async () => {
+    throw new TypeError('Failed to fetch')
+  })
+  vi.stubGlobal('fetch', fetchStub)
+  return fetchStub
+}
+
+const FEEDBACK_EVENT = {
+  type: 'feedback_submitted' as const,
+  payload: { turn_id: 'turn-1', rating: 'up' as const },
+}
+
+/** Run a system event and capture its outcome without an unhandled rejection. */
+async function runSystemEvent(): Promise<unknown | 'resolved'> {
+  const { result } = renderHook(() => useConversation())
+  let outcome: unknown | 'resolved' = 'resolved'
+  await act(async () => {
+    outcome = await result.current
+      .sendSystemEvent(FEEDBACK_EVENT)
+      .then(() => 'resolved', (e) => e)
+  })
+  return outcome
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' } as never,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests — the swallow, proven at the real seam
+// ---------------------------------------------------------------------------
+
+describe('sendSystemEvent — send failures propagate (no silent drop)', () => {
+  it('rejects with SystemEventSendError when the POST is a network reject', async () => {
+    const fetchStub = stubFetchReject()
+
+    const outcome = await runSystemEvent()
+
+    expect(fetchStub).toHaveBeenCalledTimes(1)
+    // RED pre-fix: sendSystemEvent RESOLVES (outcome === 'resolved').
+    expect(outcome).toBeInstanceOf(SystemEventSendError)
+  })
+
+  it('rejects with SystemEventSendError when the POST returns a 500', async () => {
+    const fetchStub = stubFetchWith(500, boundaryErrorBody(false))
+
+    const outcome = await runSystemEvent()
+
+    expect(fetchStub).toHaveBeenCalledTimes(1)
+    expect(outcome).toBeInstanceOf(SystemEventSendError)
+  })
+
+  it('does NOT reject on a 200 success — the event was acknowledged', async () => {
+    // Over-throwing would revert a SUCCESSFUL feedback vote. A successful ack
+    // must resolve so callers keep the optimistic state.
+    stubFetchWith(200, okResponseBody('Thanks for the feedback.'))
+
+    const outcome = await runSystemEvent()
+
+    expect(outcome).toBe('resolved')
+  })
+
+  it('leaves NO synthetic error bubble in the transcript on system failure', async () => {
+    // System turns have no transcript surface — the failure propagates to the
+    // dispatcher, it does not inject an out-of-context chat message.
+    stubFetchWith(500, boundaryErrorBody(true))
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendSystemEvent(FEEDBACK_EVENT).catch(() => undefined)
+    })
+
+    expect(result.current.messages).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression pin — user-mode failure behaviour is UNCHANGED
+// ---------------------------------------------------------------------------
+
+describe('user-mode failure behaviour is pinned unchanged', () => {
+  it('sendMessage on the SAME failing 500 does NOT throw and still surfaces in-transcript', async () => {
+    stubFetchWith(500, boundaryErrorBody(true))
+
+    const { result } = renderHook(() => useConversation())
+    let threw = false
+    await act(async () => {
+      await result.current.sendMessage('draft my decision').catch(() => {
+        threw = true
+      })
+    })
+
+    // User-mode turns NEVER throw — they surface in the transcript.
+    expect(threw).toBe(false)
+
+    const last = result.current.messages[result.current.messages.length - 1]
+    expect(last).toBeDefined()
+    expect(last.role).toBe('assistant')
+    expect(last.synthetic).toBe(true)
+    expect(last.content).toContain('Something went wrong on our side')
+    // The user's text is preserved for restore-into-composer.
+    expect(result.current.lastSendFailure?.inputText).toBe('draft my decision')
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -1601,6 +1601,50 @@ export interface SendFailureNotice {
   inputText: string
 }
 
+/**
+ * SystemEventSendError — the rejection `sendTurn` raises when a SYSTEM-mode
+ * turn (feedback / patch_accepted / patch_dismissed / direct_graph_edit) fails
+ * to reach or complete at the server: a network reject, a 4xx/5xx, a parse
+ * failure, or a thrown dispatch error.
+ *
+ * CONTRACT — system-event send-failure propagation (why this exists):
+ *   System turns have NO transcript surface of their own. They never render a
+ *   user bubble, and (post-fix) they never render a synthetic assistant error
+ *   bubble either — an out-of-context "Something went wrong" in the chat for a
+ *   background feedback/patch/graph-edit turn is noise, and it matches V4's
+ *   established "system failures are silent in the transcript" behaviour. The
+ *   ONLY honest way for such a failure to surface is for its dispatcher to
+ *   react. So `sendSystemEvent` (which `await`s `sendTurn` in system mode)
+ *   rejects with this error, letting each caller reach for its OWN existing
+ *   affordance:
+ *     • FeedbackRow        → revert the optimistic thumbs vote (its `catch`)
+ *     • handlePatchAccept  → the existing NETWORK_ERROR retry card
+ *     • background dispatchers (graph-edit / patch_dismissed) → best-effort log
+ *
+ *   Rethrow (not a returned result) is deliberate: PR #435's FeedbackRow does
+ *   `try { await onFeedback() } catch { revert }`, and `handleFeedback` returns
+ *   the `sendSystemEvent` promise unchanged — a rejection is what reverts the
+ *   vote with ZERO churn to that just-landed code. A resolved `{ ok: false }`
+ *   would silently pass FeedbackRow's `catch`.
+ *
+ *   USER-mode turns NEVER throw: they keep rendering their in-transcript
+ *   synthetic bubble + `setLastSendFailure` exactly as before. This asymmetry
+ *   is the whole point and is pinned by regression tests.
+ */
+export class SystemEventSendError extends Error {
+  /** 'transport': nothing reached the server (network / proxy timeout).
+   *  'server':    the server received the turn and failed it (typed error). */
+  readonly kind: 'transport' | 'server'
+  constructor(kind: 'transport' | 'server', options?: { cause?: unknown }) {
+    super(`System event send failed (${kind})`)
+    this.name = 'SystemEventSendError'
+    this.kind = kind
+    if (options?.cause !== undefined) {
+      ;(this as Error & { cause?: unknown }).cause = options.cause
+    }
+  }
+}
+
 export interface UseConversationReturn {
   messages: ConversationMessage[]
   isThinking: boolean
@@ -3280,6 +3324,14 @@ export function useConversation(): UseConversationReturn {
           setLongRunningHint(null)
         }
 
+        // System-event send-failure carrier. Populated ONLY on a system-mode
+        // failure (typed error / thrown dispatch), then rethrown AFTER the
+        // `finally` settles lifecycle state so `sendSystemEvent` — and through
+        // it FeedbackRow / handlePatchAccept / the graph-edit dispatcher — can
+        // react. See the SystemEventSendError contract above. Never set for
+        // user-mode turns, which surface in-transcript and return void.
+        let systemSendFailure: SystemEventSendError | null = null
+
         try {
           // Resolve session identity once — X-User-Id + Authorization Bearer
           // (login 3.4 UI half) and the post-response graph re-fetch auth
@@ -3758,20 +3810,33 @@ export function useConversation(): UseConversationReturn {
             const retryChips: ActionChip[] = retryable && mode === 'user' && !hidden
               ? [{ id: 'retry', label: 'Try again', intent: 'primary' }]
               : []
-            addMessage({
-              id: crypto.randomUUID(),
-              role: 'assistant',
-              synthetic: true,
-              content,
-              actionChips: retryChips,
-              timestamp: new Date(),
-            })
+            // System turns get NO transcript bubble — the failure propagates to
+            // the dispatcher instead (see SystemEventSendError). Gating here
+            // matches the empty/catch/timeout branches, which already user-gate
+            // their bubbles, and keeps V4 parity ("system failures are silent
+            // in the transcript"). User-mode rendering is unchanged.
+            if (mode === 'user') {
+              addMessage({
+                id: crypto.randomUUID(),
+                role: 'assistant',
+                synthetic: true,
+                content,
+                actionChips: retryChips,
+                timestamp: new Date(),
+              })
+            }
             if (inputForRestore) {
               setLastSendFailure({
                 kind: transportFailure ? 'transport' : 'server',
                 retryable,
                 inputText: inputForRestore,
               })
+            } else if (mode === 'system') {
+              // inputForRestore is null for system turns; record the failure so
+              // it is rethrown after `finally` and the dispatcher can react.
+              systemSendFailure = new SystemEventSendError(
+                transportFailure ? 'transport' : 'server',
+              )
             }
           }
         } catch (err) {
@@ -3797,6 +3862,13 @@ export function useConversation(): UseConversationReturn {
               setLastSendFailure({ kind: 'transport', retryable: true, inputText: inputForRestore })
             }
           }
+          if (!isAbort && mode === 'system') {
+            // A system turn threw before/around the network (e.g. a fetch
+            // reject re-raised by callV5Turn, or an internal error). Propagate
+            // to the dispatcher — an aborted turn (user stop / timeout) is not
+            // a failure and is excluded above.
+            systemSendFailure = new SystemEventSendError('transport', { cause: err })
+          }
           if (import.meta.env.DEV && !isAbort) {
             console.warn('[sendTurn V5] Dispatch error:', err)
           }
@@ -3814,6 +3886,14 @@ export function useConversation(): UseConversationReturn {
             activeRunTurnIdRef.current = null
             useCanvasStore.getState().resultsSettle()
           }
+        }
+        // Rethrow a system-mode send failure AFTER `finally` has settled the
+        // lifecycle. This is the seam that makes silent system-event drops
+        // impossible: sendSystemEvent's `await` now rejects, so its callers
+        // react. The abort-discard `return` inside the try bypasses this (an
+        // aborted turn never sets systemSendFailure). User turns never set it.
+        if (systemSendFailure) {
+          throw systemSendFailure
         }
         return
       }

--- a/src/canvas/conversation/useGraphEditEvents.ts
+++ b/src/canvas/conversation/useGraphEditEvents.ts
@@ -266,15 +266,27 @@ export function useGraphEditEvents(
           if (fields.size > 0) fieldsChangedMap[id] = [...fields].sort()
         }
 
-        sendSystemEvent({
-          type: 'direct_graph_edit',
-          payload: {
-            changed_node_ids: changedNodeIds,
-            changed_edge_ids: changedEdgeIds,
-            operations,
-            fields_changed: fieldsChangedMap,
-            summary: buildSummary(batchAcc),
-          },
+        // Best-effort background sync: sendSystemEvent now REJECTS on a failed
+        // POST (SystemEventSendError). This debounced edit-mirror has no
+        // user-facing surface, so consume the rejection here to avoid an
+        // unhandled promise rejection — same best-effort `.catch()` pattern as
+        // the sibling appendEvent calls below. Promise.resolve() coerces the
+        // injected dispatcher's return so a non-thenable stub can't throw here.
+        void Promise.resolve(
+          sendSystemEvent({
+            type: 'direct_graph_edit',
+            payload: {
+              changed_node_ids: changedNodeIds,
+              changed_edge_ids: changedEdgeIds,
+              operations,
+              fields_changed: fieldsChangedMap,
+              summary: buildSummary(batchAcc),
+            },
+          }),
+        ).catch((err) => {
+          if (import.meta.env.DEV) {
+            console.warn('[useGraphEditEvents] direct_graph_edit sync failed (best-effort):', err)
+          }
         })
 
         // Emit direct_edit scenario events with target_label (Journey tab data).


### PR DESCRIPTION
## Problem

`sendTurn`'s V5 **system-mode** failure paths returned `void`, so every system event — feedback (#435), `patch_accepted`/`patch_dismissed`, `direct_graph_edit` — failed **silently at the network level**. `callV5Turn` converts a network reject / 500 into a `parse_error`/`boundary_error`, `routeV5Response` maps that to `typed_error`, and the typed-error branch rendered nothing for system mode and fell through to `return` (void). The catch is user-gated too. So `sendSystemEvent` **resolved** on a failed POST, and PR #435's FeedbackRow optimistic-revert (which reverts on a rejected promise) never fired on a swallowed 4xx/5xx/network failure.

## The propagation contract

`sendTurn` now **rethrows `SystemEventSendError`** on a system-mode send failure, after `finally` settles the lifecycle. `sendSystemEvent` `await`s it, so its promise rejects and each caller reacts through its **own existing affordance**.

**Rethrow (not a returned result)** is deliberate: #435's `FeedbackRow` already does `try { await onFeedback() } catch { revert }` and `handleFeedback` returns the `sendSystemEvent` promise unchanged — a rejection reverts the vote with **zero churn** to that just-landed code. A resolved `{ ok: false }` would silently pass FeedbackRow's `catch`.

**User-mode is pinned unchanged:** user turns never throw — they keep their in-transcript synthetic bubble + `setLastSendFailure` exactly as before. The system-mode typed-error branch now user-gates its assistant bubble (matching the empty/catch/timeout branches and V4's "system failures are silent in the transcript").

## Callers

- **FeedbackRow** — revert now fires on a failed POST (unchanged file; #435's `catch`).
- **handlePatchAccept** — a failed `patch_accepted` surfaces via the **existing** NETWORK_ERROR retry card (block returns to `proposed`); no new UI surface.
- **Background dispatchers** (`patch_dismissed`, `direct_graph_edit`) — consume the rejection best-effort (no unhandled rejections). `Promise.resolve()` coerces the injected dispatcher's return so a non-thenable test stub can't throw.

## Tests (RED-first at the real seam)

- `useConversation.systemEventFailure.spec.ts` drives a real failed POST (**network reject AND 500**) through the REAL `sendTurn` → `callV5Turn` → parser → router: `sendSystemEvent` **rejects** (RED pre-fix), a 200 ack resolves, no transcript bubble, and user-mode `sendMessage` on the same 500 does **not** throw (pin).
- `conversationPanel.systemEventFailure.spec.tsx`: FeedbackRow reverts + handlePatchAccept surfaces NETWORK_ERROR when `sendSystemEvent` rejects.
- **Mutation** (restore the swallow) re-REDs the seam spec.

## Gates

- `pnpm run typecheck` (tsc -p tsconfig.ci.json): **0 errors**.
- ESLint on touched files: **0 errors**.
- Full `src/canvas/conversation/__tests__` + `buildPayload` + `systemEventParity`: **122 files, 1704 passed / 0 failed**.

Base includes #435 (FeedbackRow optimistic-revert verified present). Do **not** merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
