### PR TITLE
style(v7-l1): complete borders only — retire one-sided accents

### DIFF
--- a/src/canvas/components/ActionsSignal.tsx
+++ b/src/canvas/components/ActionsSignal.tsx
@@ -81,28 +81,28 @@ const priorityConfig: Record<ActionPriority, {
     icon: AlertTriangle,
     iconColor: 'text-carrot-600',
     badgeColor: 'bg-carrot-100 text-carrot-700',
-    borderColor: 'border-l-carrot-500',
+    borderColor: 'border-danger',
     label: 'Critical',
   },
   high: {
     icon: AlertCircle,
     iconColor: 'text-banana-600',
     badgeColor: 'bg-banana-100 text-banana-700',
-    borderColor: 'border-l-banana-500',
+    borderColor: 'border-warning',
     label: 'High',
   },
   medium: {
     icon: Info,
     iconColor: 'text-sky-600',
     badgeColor: 'bg-sky-100 text-sky-700',
-    borderColor: 'border-l-sky-500',
+    borderColor: 'border-info',
     label: 'Medium',
   },
   low: {
     icon: Info,
     iconColor: 'text-ink-400',
     badgeColor: 'bg-sand-100 text-ink-600',
-    borderColor: 'border-l-sand-300',
+    borderColor: 'border-panel-border',
     label: 'Low',
   },
 }
@@ -300,7 +300,7 @@ function ActionItem({ action, fixStatus, onFocus, onAutoFix, nodes }: ActionItem
 
   return (
     <div
-      className={`px-4 py-3 border-l-4 ${config.borderColor} ${hasAffectedElements ? 'cursor-pointer hover:bg-sand-50' : ''} transition-colors`}
+      className={`px-4 py-3 border ${config.borderColor} ${hasAffectedElements ? 'cursor-pointer hover:bg-sand-50' : ''} transition-colors`}
       onClick={hasAffectedElements ? onFocus : undefined}
       role={hasAffectedElements ? 'button' : undefined}
       tabIndex={hasAffectedElements ? 0 : undefined}

--- a/src/canvas/components/EdgeFunctionTypeSelector.tsx
+++ b/src/canvas/components/EdgeFunctionTypeSelector.tsx
@@ -201,7 +201,7 @@ export const EdgeFunctionTypeSelector = memo(function EdgeFunctionTypeSelector({
 
       {/* Function parameters (for non-linear types) */}
       {value !== 'linear' && showParams && (
-        <div className="pl-2 pt-2 border-l-2 border-sand-200 space-y-3">
+        <div className="p-2 border border-sand-200 rounded space-y-3">
           {value === 'threshold' && (
             <SliderWithLabel
               id="func-threshold"

--- a/src/canvas/components/GraphTextView.tsx
+++ b/src/canvas/components/GraphTextView.tsx
@@ -506,7 +506,7 @@ export function GraphTextView({
               {isExpanded && (
                 <div
                   id={`graph-section-${type}`}
-                  className="ml-6 mt-1 border-l-2 border-sand-200 pl-4"
+                  className="ml-6 mt-1 border border-sand-200 rounded py-1 pl-4 pr-2"
                 >
                   {nodeList.map(node => {
                     const label = getNodeLabel(node)

--- a/src/canvas/components/GuidanceCard.tsx
+++ b/src/canvas/components/GuidanceCard.tsx
@@ -62,11 +62,11 @@ interface GuidanceCardProps {
   autoFixStatus?: AutoFixStatus
 }
 
-// Severity styles with left border for visual hierarchy
+// Severity styles with complete border for visual hierarchy (V7 L1: complete borders only)
 const severityStyles: Record<GuidanceSeverity, string> = {
-  blocker: 'border-l-4 border-l-carrot-500 border border-carrot-200 bg-paper-50',
-  warning: 'border-l-4 border-l-banana-500 border border-banana-200 bg-paper-50',
-  info: 'border-l-4 border-l-sky-500 border border-sky-200 bg-sky-50',
+  blocker: 'border border-carrot-200 bg-paper-50',
+  warning: 'border border-banana-200 bg-paper-50',
+  info: 'border border-sky-200 bg-sky-50',
 }
 
 const typeIcons: Record<GuidanceType, typeof Lightbulb> = {

--- a/src/canvas/components/InsightsTab.tsx
+++ b/src/canvas/components/InsightsTab.tsx
@@ -325,7 +325,7 @@ function BiasCard({ bias, checked, expanded, onToggle, onExpand }: BiasCardProps
           </div>
 
           {expanded && bias.mechanism && (
-            <div className="p-2 bg-paper-50 rounded border-l-2 border-sky-500">
+            <div className="p-2 bg-paper-50 rounded border border-sky-500">
               <p className={`${typography.bodySmall} text-ink-900`}>
                 {bias.mechanism}
               </p>

--- a/src/canvas/components/ProvenanceHubTab.tsx
+++ b/src/canvas/components/ProvenanceHubTab.tsx
@@ -197,7 +197,7 @@ function CitationCard({
       </button>
 
       {/* Snippet */}
-      <div className={`${typography.body} text-gray-700 italic border-l-2 border-option/30 pl-3 mb-2`}>
+      <div className={`${typography.body} text-gray-700 italic border border-option/30 rounded px-3 py-1.5 mb-2`}>
         "{snippet}"
       </div>
 

--- a/src/canvas/components/ValidationPanel.tsx
+++ b/src/canvas/components/ValidationPanel.tsx
@@ -334,7 +334,7 @@ function CritiqueItemRow({
 
   return (
     <div
-      className={`rounded-lg border-l-4 ${borderColorClass} bg-white p-3 shadow-sm transition-all duration-300 ${
+      className={`rounded-lg border ${borderColorClass} bg-white p-3 shadow-sm transition-all duration-300 ${
         isFixed ? 'opacity-60' : ''
       }`}
       data-testid={`critique-item-${item.code || 'unknown'}`}

--- a/src/canvas/components/model-tab/ModelTabHeader.tsx
+++ b/src/canvas/components/model-tab/ModelTabHeader.tsx
@@ -43,7 +43,7 @@ export function ModelTabHeader({
           </span>
         )}
       </div>
-      <div className={showDetail ? 'border-t-2 border-info/40 pt-3' : ''}>
+      <div className={showDetail ? 'mt-2 border border-info/40 rounded p-3' : ''}>
         {children}
       </div>
     </DetailToggleContext.Provider>

--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -805,7 +805,7 @@ const T1DecisionReadinessCard = memo(function T1DecisionReadinessCard({
             return (
               <div
                 key={entry.card.key}
-                className={emphasised ? 'rounded-[10px] border border-info/50 border-l-[3px] border-l-info bg-info/[0.02]' : ''}
+                className={emphasised ? 'rounded-[10px] border border-info/50 bg-info/[0.02]' : ''}
                 data-testid={emphasised ? 't1-triage-emphasised' : undefined}
               >
                 <TriageCard
@@ -2001,7 +2001,7 @@ export function PreAnalysisPanel({
             detail and is hidden from non-expert users. */}
         {isFailed && lastDraftError && (
           <div
-            className="rounded-md bg-panel border border-panel-border border-t-[3px] border-t-danger px-4 py-2.5"
+            className="rounded-md bg-panel border border-danger px-4 py-2.5"
             data-testid="draft-error-card"
           >
             <p className={`${typography.panelHeader} text-danger`}>Draft failed</p>

--- a/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.spec.tsx
@@ -546,10 +546,11 @@ describe('PreAnalysisPanel', () => {
       const emphasised = screen.getByTestId('t1-triage-emphasised')
       expect(emphasised).toBeInTheDocument()
       // Matches the post-analysis emphasis treatment (DecisionConfidencePanel
-      // unified-triage-emphasised) — border-info/50 + 3px left accent.
+      // unified-triage-emphasised). V7 L1: complete border-info/50 only; the
+      // one-sided left accent is retired (state colour rides the complete border).
       expect(emphasised.className).toContain('border-info/50')
-      expect(emphasised.className).toContain('border-l-[3px]')
-      expect(emphasised.className).toContain('border-l-info')
+      expect(emphasised.className).not.toContain('border-l-[3px]')
+      expect(emphasised.className).not.toContain('border-l-info')
     })
   })
 

--- a/src/canvas/ui/inspector/InspectorGuidanceSection.tsx
+++ b/src/canvas/ui/inspector/InspectorGuidanceSection.tsx
@@ -38,16 +38,18 @@ function actionLabel(action: GuidanceAction): string {
 }
 
 function cardBorderClass(category: GuidanceItem['category']): string {
+  // V7 L1: complete borders only — the state colour rides all four sides, never
+  // a one-sided left accent.
   switch (category) {
     case 'must_fix':
     case 'should_fix':
-      return 'border-l-danger'
+      return 'border-danger'
     case 'could_fix':
     case 'technique':
-      return 'border-l-info'
+      return 'border-info'
     // Category absent (producer sent none): neutral low-urgency styling.
     default:
-      return 'border-l-info'
+      return 'border-info'
   }
 }
 
@@ -133,9 +135,9 @@ const GuidanceCard = memo(function GuidanceCard({
     <div
       ref={cardRef}
       className={`
-        flex items-start gap-2 p-2 rounded border-l-4
+        flex items-start gap-2 p-2 rounded border
         ${cardBorderClass(item.category)}
-        ${isActive ? `${cardBgClass(item.category)} ring-1 ring-info/40` : 'bg-panel border border-panel-border border-l-4'}
+        ${isActive ? `${cardBgClass(item.category)} ring-1 ring-info/40` : 'bg-panel'}
         transition-colors
       `}
       onMouseEnter={handleMouseEnter}

--- a/src/components/assistants/ProvenanceChip.tsx
+++ b/src/components/assistants/ProvenanceChip.tsx
@@ -97,7 +97,7 @@ export function ProvenanceChip({ documents, redacted = true, onToggleRedaction }
 
           <div className="space-y-2">
             {displayDocuments.map((doc) => (
-              <div key={doc.id} className="border-l-2 border-option/30 pl-2">
+              <div key={doc.id} className="border border-option/30 rounded px-2 py-1">
                 <div className="font-medium text-xs text-gray-900">{doc.name}</div>
                 {doc.snippet && (
                   <div className="text-xs text-gray-600 mt-0.5 italic">

--- a/src/components/results/ConfidenceSection.tsx
+++ b/src/components/results/ConfidenceSection.tsx
@@ -516,7 +516,7 @@ export function ConfidenceSection({
       {decisionState && hinge && (
         <div
           id="mvs-card"
-          className="bg-panel p-4 border border-success/30 border-l-[3px] border-l-success rounded-lg shadow-1" /* §6.4 coaching accent card — p-4 intentional (border-l-[3px]) */
+          className="bg-panel p-4 border border-success/30 rounded-lg shadow-1" /* §6.4 coaching accent card — p-4 intentional; complete border, one-sided accent retired (V7 L1) */
           data-testid="voi-promoted-block"
         >
           <div className="flex items-start gap-2 mb-1">

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -747,7 +747,7 @@ export const TriageActionCardsBody = memo(function TriageActionCardsBody({
                 return (
                   <div
                     key={item.key}
-                    className={emphasised ? 'rounded-[10px] border border-info/50 border-l-[3px] border-l-info bg-info/[0.02]' : ''}
+                    className={emphasised ? 'rounded-[10px] border border-info/50 bg-info/[0.02]' : ''}
                     data-testid={emphasised ? 'unified-triage-emphasised' : undefined}
                   >
                     <TriageCard

--- a/src/components/results/__tests__/DecisionConfidencePanel.unifiedQueueD2b.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.unifiedQueueD2b.spec.tsx
@@ -4,8 +4,9 @@
  * The post-analysis T1 card now ranks evidence-gap and next-action items into
  * a single EVPI-sorted stack:
  *   - Top 3 → unified queue with the first card visually emphasised
- *     (`border-info/50 bg-info/[0.02]` plus a `border-l-[3px] border-l-info`
- *     left accent per DS v5 §6.4, mirroring the pre-analysis `.ac.em`).
+ *     (a complete `border-info/50` + `bg-info/[0.02]`, mirroring the
+ *     pre-analysis `.ac.em`; V7 L1 retired the one-sided `border-l-[3px]`
+ *     left accent — the state colour now rides the complete border).
  *   - Items 4-6 → `AlsoConsiderDisclosure` (compact rows, collapsed by default).
  *   - Stability narrative renders above the queue when there is at least one
  *     item; suppressed otherwise.
@@ -150,10 +151,11 @@ describe('DecisionConfidencePanel — Brief 5.8B D2b unified triage queue', () =
     expect(screen.getByTestId('unified-triage-queue')).toBeInTheDocument()
     const emphasised = screen.getByTestId('unified-triage-emphasised')
     expect(emphasised).toBeInTheDocument()
-    // 5.8B hotfix Fix 10 — strengthened emphasis: border-info/50 + 3px left accent.
+    // 5.8B hotfix Fix 10 — strengthened emphasis. V7 L1: complete border only;
+    // the one-sided left accent is retired (state colour rides the complete border).
     expect(emphasised.className).toContain('border-info/50')
-    expect(emphasised.className).toContain('border-l-[3px]')
-    expect(emphasised.className).toContain('border-l-info')
+    expect(emphasised.className).not.toContain('border-l-[3px]')
+    expect(emphasised.className).not.toContain('border-l-info')
   })
 
   it('removes the legacy split sub-headers (D2b unified them into one queue)', () => {

--- a/tests/ci-guards/complete-borders.spec.ts
+++ b/tests/ci-guards/complete-borders.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * complete-borders guard — the one-sided-accent preventer (V7 Lane L1).
+ *
+ * THE RULE (Paul, ruled repeatedly; re-ruled 23 Jul 2026 with a screenshot of the
+ * draft-error card): analysis-surface cards/rows/panels carry COMPLETE borders
+ * only — never a one-sided coloured accent edge. A card that wants to signal
+ * state does it through the border COLOUR (state-colour on all four sides) or a
+ * badge/tint, never through a lone `border-l-[3px]` / `border-t-2` / `border-l-info`
+ * stripe. This guard reads the source of the analysis-surface content-card files
+ * swept in L1 and fails if any single-side border accent is reintroduced.
+ *
+ * WHY A SOURCE SCAN, AND WHY COMMENT-STRIPPED. The rule is a design convention, so
+ * it is enforced by reading the source. Comments are stripped FIRST via the shared
+ * literal-aware `stripComments` (tests/helpers/stripSourceComments) — the JSX-aware
+ * stripper the alpha-emission and plotFetch guards use — because this repo's
+ * dominant guard footgun (#385/#386) is a source scan reddening CI over a class
+ * that lives only in a comment or a documentation example. A `border-l-[3px]`
+ * written in a JSDoc block ships nothing and must not fail CI; the COMMENT control
+ * at the foot of this file pins that.
+ *
+ * WHAT IT FLAGS (on comment-stripped source):
+ *   · `border-{l,r,t,b}-[<arbitrary>]`  e.g. border-l-[3px], border-t-[3px]
+ *   · `border-{l,r,t,b}-<width≥1>`      e.g. border-l-4, border-t-2, border-b-2
+ *   · `border-{l,r,t,b}-<colour>`       e.g. border-l-info, border-t-danger,
+ *                                            border-l-carrot-500
+ *   · inline `border{Left,Top,Right,Bottom}: …` (non-transparent)
+ *
+ * WHAT IT DOES NOT FLAG (documented exclusions — none of these is a coloured
+ * accent on a content card, per §3.3 of V6-RESPEC-2026-07-23):
+ *   · Neutral hairline row separators — `border-t` / `border-b` with NO width
+ *     digit (1px) + a neutral colour (`border-panel-border`, `border-sand-200`).
+ *     The width regex requires a digit ≥1, so these never match; the colour regex
+ *     requires the colour to sit directly after the side letter (`border-b-<c>`),
+ *     which a separated `border-b … border-sand-200` never forms.
+ *   · Width-zero resets — `border-{l,r,t,b}-0` (e.g. `last:border-b-0`): the width
+ *     regex is `[1-9]`, so a `-0` reset is ignored.
+ *   · Loading-spinner arcs (`animate-spin … border-b-2`), the RangeLabels CSS
+ *     triangle, the FloatingOlumiPanel resize-handle corner, and the dock
+ *     tab-underline indicators (`border-b-2 border-info`) — none live in the
+ *     content-card set below, so they are out of scope by file selection.
+ *
+ * OUT OF THIS LANE (tracked as Paul-questions, deliberately NOT swept here):
+ *   · §16 conversation coaching blocks (V5CoachingBlock `border-l-[3px] border-info`)
+ *     — pinned by an intentional design-contract test.
+ *   · §17 toast notifications (ToastContext inline `borderLeft`).
+ *   These surfaces are excluded by file selection, not by a colour exception.
+ *
+ * CONTROLS (run every CI pass, not once by hand):
+ *   · POSITIVE — a synthetic `border-l-[3px]` and a `border-t-2` MUST be flagged,
+ *     proving the scanner can see a violation at all.
+ *   · NEGATIVE — a complete `border border-danger`, a neutral `border-b
+ *     border-panel-border` separator, and a `last:border-b-0` reset must NOT be
+ *     flagged, proving the scanner is accent-scoped rather than a blunt
+ *     "no border-b anywhere" rule.
+ *   · COMMENT — a `border-l-[3px]` that exists ONLY inside a `//` and a block
+ *     comment must NOT be flagged (the #385/#386 footgun).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve as resolvePath } from 'node:path'
+import { stripComments } from '../helpers/stripSourceComments'
+
+const SRC = resolvePath(__dirname, '../../src')
+
+/**
+ * The analysis-surface content-card files swept in V7 Lane L1. This is the
+ * scan set: the rule is enforced here, so a reintroduced accent in any of these
+ * files reddens CI. (New analysis-surface cards should be added to this list.)
+ */
+const CONTENT_CARD_FILES = [
+  'canvas/components/pre-analysis/PreAnalysisPanel.tsx',
+  'components/results/TriageActionCardsBody.tsx',
+  'components/results/ConfidenceSection.tsx',
+  'canvas/components/GuidanceCard.tsx',
+  'canvas/components/ActionsSignal.tsx',
+  'canvas/components/ValidationPanel.tsx',
+  'canvas/components/InsightsTab.tsx',
+  'canvas/components/ProvenanceHubTab.tsx',
+  'canvas/components/GraphTextView.tsx',
+  'canvas/components/EdgeFunctionTypeSelector.tsx',
+  'canvas/components/model-tab/ModelTabHeader.tsx',
+  'canvas/ui/inspector/InspectorGuidanceSection.tsx',
+  'components/assistants/ProvenanceChip.tsx',
+]
+
+/** Single-side border width with an arbitrary value: `border-l-[3px]`. */
+const ACCENT_WIDTH_ARBITRARY = /\bborder-[lrtb]-\[/
+/** Single-side border width ≥1: `border-l-4`, `border-t-2` (not `-0` resets). */
+const ACCENT_WIDTH_NUMERIC = /\bborder-[lrtb]-[1-9]/
+/** Single-side border COLOUR: `border-l-info`, `border-t-danger`, `border-l-carrot-500`. */
+const ACCENT_COLOUR_SIDE =
+  /\bborder-[lrtb]-(?:danger|info|success|warning|carrot|banana|sky|sand|option|mint|sun|lilac|ink|paper|slate|gray|grey|zinc|neutral|red|blue|green|amber|yellow|orange|emerald|rose)\b/
+/** Inline single-side border style: `borderLeft:`, `borderTop:` … (non-transparent). */
+const INLINE_SIDE = /\bborder(?:Left|Top|Right|Bottom)\s*:/
+
+interface Violation {
+  file: string
+  line: number
+  token: string
+  snippet: string
+}
+
+/** Scan already-comment-stripped text for one-sided border accents. */
+function findAccentViolations(stripped: string, file: string): Violation[] {
+  const out: Violation[] = []
+  const lines = stripped.split('\n')
+  lines.forEach((line, i) => {
+    for (const re of [ACCENT_WIDTH_ARBITRARY, ACCENT_WIDTH_NUMERIC, ACCENT_COLOUR_SIDE]) {
+      const m = re.exec(line)
+      if (m) out.push({ file, line: i + 1, token: m[0], snippet: line.trim().slice(0, 120) })
+    }
+    // Inline single-side border style, excluding a transparent edge (CSS-triangle idiom).
+    if (INLINE_SIDE.test(line) && !/transparent/.test(line)) {
+      const m = INLINE_SIDE.exec(line)
+      if (m) out.push({ file, line: i + 1, token: m[0], snippet: line.trim().slice(0, 120) })
+    }
+  })
+  return out
+}
+
+describe('complete-borders guard: analysis-surface content cards carry complete borders only', () => {
+  it('has no one-sided coloured border accent in any swept content-card file', () => {
+    const violations: Violation[] = []
+    for (const rel of CONTENT_CARD_FILES) {
+      const abs = resolvePath(SRC, rel)
+      const text = readFileSync(abs, 'utf8')
+      const stripped = stripComments(text, abs)
+      violations.push(...findAccentViolations(stripped, rel))
+    }
+    if (violations.length) {
+      const report = violations
+        .map((v) => `  ${v.file}:${v.line}  ${v.token}  ${v.snippet}`)
+        .join('\n')
+      throw new Error(
+        `One-sided border accent(s) found — convert to a complete border ` +
+          `(carry the state colour on all four sides):\n${report}`,
+      )
+    }
+    expect(violations).toHaveLength(0)
+  })
+
+  // ── Self-test controls (prove the detector is neither blind nor over-eager) ──
+
+  it('POSITIVE control: flags border-l-[3px] and border-t-2 accents', () => {
+    const positive = [
+      `<div className="rounded-md border border-panel-border border-t-[3px] border-t-danger" />`,
+      `<div className="px-4 py-3 border-l-4 border-l-info" />`,
+      `<div className="border-t-2 border-info/40 pt-3" />`,
+    ].join('\n')
+    const found = findAccentViolations(stripComments(positive, 'control.tsx'), 'control.tsx')
+    expect(found.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('NEGATIVE control: does not flag complete borders, neutral separators, or -0 resets', () => {
+    const negative = [
+      `<div className="rounded-md border border-danger px-4 py-2.5" />`,
+      `<div className="border border-info/50 bg-info/[0.02]" />`,
+      `<li className="border-b border-panel-border last:border-b-0" />`,
+      `<div className="py-2 border-t border-sand-200 first:border-t-0" />`,
+    ].join('\n')
+    const found = findAccentViolations(stripComments(negative, 'control.tsx'), 'control.tsx')
+    expect(found).toHaveLength(0)
+  })
+
+  it('COMMENT control: a border-l-[3px] living only in a comment is not flagged', () => {
+    const commented = [
+      `// legacy coaching card used border-l-[3px] border-l-info here`,
+      `/* MVS card: border-l-[3px] border-l-success (retired in V7 L1) */`,
+      `<div className="border border-success/30 rounded-lg" />`,
+    ].join('\n')
+    const found = findAccentViolations(stripComments(commented, 'control.tsx'), 'control.tsx')
+    expect(found).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## V7 Lane L1 — the COMPLETE-BORDERS sweep

Paul's repeated rule, re-ruled 23 Jul with a screenshot of the draft-error card: **only ever complete borders on cards/rows/panels — never one-sided coloured accent edges.** Per `V6-RESPEC-2026-07-23.md` §3. Pure className/CSS; ships ON, no flag.

Each accent becomes a COMPLETE border carrying the same semantic colour (the state colour rides all four sides now, not one edge).

### Converted accents (before → after class)

**§3.1 in-panel (the screenshotted surfaces):**
| File | Before | After |
|---|---|---|
| `pre-analysis/PreAnalysisPanel.tsx` (draft-error card) | `border border-panel-border border-t-[3px] border-t-danger` | `border border-danger` |
| `pre-analysis/PreAnalysisPanel.tsx` (emphasised card) | `border border-info/50 border-l-[3px] border-l-info bg-info/[0.02]` | `border border-info/50 bg-info/[0.02]` |
| `results/TriageActionCardsBody.tsx` (emphasised card) | `border border-info/50 border-l-[3px] border-l-info bg-info/[0.02]` | `border border-info/50 bg-info/[0.02]` |
| `results/ConfidenceSection.tsx` (coaching card) | `border border-success/30 border-l-[3px] border-l-success` | `border border-success/30` |

**§3.2 canvas-adjacent fast-follows:**
| File | Before | After |
|---|---|---|
| `GuidanceCard.tsx` (×3 severities) | `border-l-4 border-l-{carrot,banana,sky}-500 border border-{…}-200` | `border border-{carrot,banana,sky}-200` |
| `ActionsSignal.tsx` (borderColor map + card) | `border-l-4` + `border-l-{carrot-500,banana-500,sky-500,sand-300}` | `border` + `border-{danger,warning,info,panel-border}` |
| `ValidationPanel.tsx` | `rounded-lg border-l-4 ${borderColorClass}` | `rounded-lg border ${borderColorClass}` |
| `InsightsTab.tsx` | `border-l-2 border-sky-500` | `border border-sky-500` |
| `ProvenanceHubTab.tsx` | `border-l-2 border-option/30 pl-3` | `border border-option/30 rounded px-3 py-1.5` |
| `GraphTextView.tsx` | `border-l-2 border-sand-200 pl-4` | `border border-sand-200 rounded py-1 pl-4 pr-2` |
| `EdgeFunctionTypeSelector.tsx` | `pl-2 pt-2 border-l-2 border-sand-200` | `p-2 border border-sand-200 rounded` |
| `model-tab/ModelTabHeader.tsx` | `border-t-2 border-info/40 pt-3` | `mt-2 border border-info/40 rounded p-3` |

**Beyond the spec's list** (found by re-running the sweep; same rule, same canvas analysis surface, no contradicting design contract):
| File | Before | After |
|---|---|---|
| `canvas/ui/inspector/InspectorGuidanceSection.tsx` (guidance card) | `border-l-4` + `cardBorderClass → border-l-{danger,info}` | `border` + `cardBorderClass → border-{danger,info}` |
| `components/assistants/ProvenanceChip.tsx` (doc snippet) | `border-l-2 border-option/30 pl-2` | `border border-option/30 rounded px-2 py-1` |

`ActionsSignal` and `InspectorGuidanceSection` use semantic tokens (`danger`/`info`/`warning`/`panel-border`) which are **exact aliases** of the legacy palette (`carrot-500`, `sky-500`, `sand-200`) per `tailwind.config.js` — pixel-faithful, and keeps the DS-ratchet neutral (no net-new legacy tokens).

### Exclusions honoured (§3.3)
Neutral hairline row separators, loading-spinner arcs, the RangeLabels CSS triangle, the FloatingOlumiPanel resize-handle corner, and the dock **tab-underline** indicators (`border-b-2 border-info`, Paul-question P3) are all left untouched.

### Flagged, NOT swept this lane (Paul-questions)
- **`V5CoachingBlock`** (`src/v5/blocks`) carries a live `border-l-[3px] border-info` accent pinned by an intentional design-contract test (`V5CoachingBlock.biasSignalVariant.spec.tsx`) as the §16 conversation coaching-card recipe. Retiring it means flipping that contract — out of this lane's manifest.
- **`ToastContext.tsx`** toasts use an inline `borderLeft: 3px` (a documented §17 toast affordance, global surface).

Both are recommended as a follow-up ruling rather than swept unilaterally.

### Guard (RED → GREEN)
New `tests/ci-guards/complete-borders.spec.ts` — a JSX-aware source scan (shared `stripSourceComments` helper) over the 13 swept content-card files, with POSITIVE/NEGATIVE/COMMENT self-test controls and the exclusion list documented in-file.
- **RED** on pre-fix code: flagged 30 one-sided accents across the 13 files.
- **GREEN** after the sweep.

The two design-contract pins that encoded the retired `border-l-[3px]` accent (`PreAnalysisPanel.spec.tsx`, `DecisionConfidencePanel.unifiedQueueD2b.spec.tsx`) were flipped to assert the complete border.

### Gates
- `pnpm run typecheck` — exit 0
- Touched-file suites — 333 passed / 1 skipped (14 files), incl. the new guard + updated pins
- eslint (touched files) — 0 errors (only pre-existing unused-var warnings)
- `ci:guard:ds --enforce` — no net-new drift (legacy-token Δ-6, hex Δ-8)
- `pnpm build` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
