### PR TITLE
feat(v7-l3): assessment-mode scaffold — current components grouped below divider

### DIFF
--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -246,6 +246,37 @@ export const ResultsBody = memo(function ResultsBody({
   return (
     <div className="flex flex-col gap-4" data-testid="outputs-results-redesign">
 
+      {/* ══ V7 ASSESSMENT-MODE SCAFFOLD (V7 Lane L3) ═══════════════════════
+          Paul's ruling (V6-RESPEC-2026-07-23 §1, "Option A GO — additive,
+          never replace"): the panel renders in two stacked groups so Paul can
+          assess new V7 components against today's live panel in one scroll.
+          L3 is re-parenting + a divider ONLY — no component deleted, no logic
+          changed, no flag. The Current-view group retires once Paul signs off
+          (V6-RESPEC Paul-question P2). */}
+
+      {/* ▛ V7 (new) top group ▟ — the L4–L6 mount point. Empty today (those
+          components do not exist yet); `empty:hidden` keeps it out of layout
+          until a lane fills it, so the scaffold is invisible-but-present. */}
+      <div className="flex flex-col gap-4 empty:hidden" data-testid="v7-top-group" />
+
+      {/* ── "Current view" divider ─────────────────────────────────────────
+          Plain SectionHeader-style separator (sentence case, muted, no accent
+          fill). COMPLETE border only — the four-sided neutral border obeys the
+          L1 rule (complete-borders guard); never a one-sided accent edge.
+          Everything beneath is the shipped panel, re-parented, zero logic
+          change. */}
+      <div
+        data-testid="assessment-current-view-divider"
+        className="flex items-center rounded-lg border border-panel-border bg-panel px-3 py-1.5"
+      >
+        <h3 className={`${typography.panelMeta} text-text-light`}>Current view</h3>
+      </div>
+
+      {/* ── Current view group — today's components, UNCHANGED, pushed down ──
+          Same order, same props, same stores as before L3. This wrapper only
+          re-parents them beneath the divider; the inner `gap-4` preserves the
+          exact inter-component spacing the outer container gave them. */}
+      <div className="flex flex-col gap-4" data-testid="assessment-current-view-group">
 
       {/* Freshness/staleness — CEE analysis_ready.freshness verdict. Renders
           nothing until a verdict exists; never asserts a state we don't hold. */}
@@ -592,6 +623,8 @@ export const ResultsBody = memo(function ResultsBody({
           extracted into `DevBuildMarker` so the production-vs-expert
           combination is unit-testable. */}
       <DevBuildMarker isDev={import.meta.env.DEV} expertMode={!!expertMode} sha={typeof __GIT_SHA__ !== 'undefined' ? __GIT_SHA__ : 'dev'} />
+      {/* ── end Current view group (V7 L3 assessment-mode scaffold) ── */}
+      </div>
     </div>
   )
 })

--- a/src/components/results/__tests__/ResultsBody.assessmentScaffold.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.assessmentScaffold.spec.tsx
@@ -1,0 +1,205 @@
+/**
+ * ResultsBody — V7 Lane L3: assessment-mode scaffold.
+ *
+ * Paul's ruling (V6-RESPEC-2026-07-23 §1): the Analysis panel renders in TWO
+ * stacked groups for the assessment window — a V7 (new) top group above a
+ * "Current view" divider, with today's shipped components re-parented UNCHANGED
+ * beneath it. L3 is re-parenting + a divider only: no component deleted, no
+ * logic changed, no flag.
+ *
+ * These pins lock the additive shape:
+ *   (a) render-parity — every pushed-down component still mounts exactly ONCE,
+ *       and BELOW the "Current view" divider;
+ *   (b) the divider renders;
+ *   (c) count-pin — no current component is lost in the re-parent;
+ *   (d) the empty V7 top group mounts ABOVE the divider (the L4–L6 slot).
+ *
+ * RED-first: with the scaffold absent the divider/group testids do not exist,
+ * so every pin below fails until the scaffold lands.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isStrengthenPanelEnabled: vi.fn(() => false),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }
+})
+
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.4,
+    outcome: { mean: 0.4, p10: 0.2, p50: 0.38, p90: 0.6 },
+    p10: 0.2,
+    p50: 0.38,
+    p90: 0.6,
+    isRecommended: false,
+    winProbability: 0.3,
+    goalProbability: 0.3,
+  } as unknown as OptionResult
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    goalThreshold: 0.6,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody() {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+const before = (a: HTMLElement, b: HTMLElement) =>
+  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+// The current (pushed-down) components' stable anchors — each must survive the
+// re-parent, render exactly once, and sit BELOW the "Current view" divider.
+const PUSHED_DOWN_ANCHORS = [
+  'decision-confidence-panel', // #3 hero (DecisionConfidencePanel, flag-off)
+  'focus-now-panel', // Strengthen / Focus panel
+  'section-header-options', // #2 options section (WinGauge + RiskAppetiteFilter + OptionCards)
+  'option-cards',
+  'accordion-drivers', // #7 DriversSection
+  'accordion-stress-test', // #8 StressTestSection
+  'accordion-advanced', // #12 AdvancedSection (KEEP, single instance)
+] as const
+
+describe('ResultsBody — V7 L3 assessment-mode scaffold', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+  })
+
+  it('(b) renders the "Current view" divider', () => {
+    renderBody()
+    const divider = screen.getByTestId('assessment-current-view-divider')
+    expect(divider).toBeInTheDocument()
+    expect(divider).toHaveTextContent('Current view')
+  })
+
+  it('(d) mounts the empty V7 top group ABOVE the divider', () => {
+    renderBody()
+    const topGroup = screen.getByTestId('v7-top-group')
+    const divider = screen.getByTestId('assessment-current-view-divider')
+    expect(topGroup).toBeInTheDocument()
+    expect(before(topGroup, divider), 'V7 top group precedes the divider').toBe(true)
+  })
+
+  it('(a) every pushed-down component renders exactly ONCE and BELOW the divider', () => {
+    renderBody()
+    const divider = screen.getByTestId('assessment-current-view-divider')
+    for (const anchor of PUSHED_DOWN_ANCHORS) {
+      const matches = screen.getAllByTestId(anchor)
+      expect(matches, `${anchor} renders exactly once`).toHaveLength(1)
+      expect(before(divider, matches[0]), `${anchor} sits below the divider`).toBe(true)
+    }
+  })
+
+  it('(c) count-pin: the current components are all present (nothing lost in the re-parent)', () => {
+    renderBody()
+    for (const anchor of PUSHED_DOWN_ANCHORS) {
+      expect(screen.queryByTestId(anchor), `${anchor} present`).toBeInTheDocument()
+    }
+  })
+
+  it('re-parented components keep their existing document order (byte-identical composition)', () => {
+    renderBody()
+    const hero = screen.getByTestId('decision-confidence-panel')
+    const focus = screen.getByTestId('focus-now-panel')
+    const options = screen.getByTestId('section-header-options')
+    const drivers = screen.getByTestId('accordion-drivers')
+    const advanced = screen.getByTestId('accordion-advanced')
+    expect(before(hero, focus)).toBe(true)
+    expect(before(focus, options)).toBe(true)
+    expect(before(options, drivers)).toBe(true)
+    expect(before(drivers, advanced)).toBe(true)
+  })
+})


### PR DESCRIPTION
## V7 Lane L3 — Assessment-mode scaffold

Implements the additive assessment-mode layout from **V6-RESPEC-2026-07-23 §1** (Paul's "Option A GO — additive, never replace" ruling). This lane is **re-parenting + a divider only**: no component deleted, no logic changed, no flag. Ships ON.

### What changed
`src/components/results/ResultsBody.tsx` — the current composition is wrapped in a **"Current view" group** beneath a muted, complete-bordered divider, and an **empty V7 top group** (`empty:hidden`) is added above it as the L4–L6 mount point.

- Pushed-down components render **byte-identical** (same props, same stores, same document order).
- The divider carries a **four-sided neutral border** (no one-sided accent) — obeys the L1 complete-borders rule.
- `AnalysisFooter` (sticky verdict) and the coaching drawer are untouched single instances — they live in `OutputsDock`, outside `ResultsBody` (V6-RESPEC P1).
- Panel length roughly doubles by design during assessment (V6-RESPEC P2) — temporary until Paul signs off; the Current-view group retires then.

### Pins (RED-first) — `ResultsBody.assessmentScaffold.spec.tsx`
- (b) the "Current view" divider renders
- (d) empty V7 top group mounts **above** the divider
- (a) every pushed-down component renders **exactly once** and **below** the divider
- (c) count-pin: nothing lost in the re-parent
- existing document order preserved

### Gates
- `pnpm run typecheck` → exit 0 (zero net-new)
- Results-panel + OutputsDock suites → **103 files / 2220 tests pass** (no existing spec needed editing; document order + testids preserved)
- complete-borders guard → green
- eslint (changed files) → clean
- `pnpm build` → exit 0

### Spec-table discrepancies (verified against live panel code)
- **`SharpenYourThinking`** is **not** in `ResultsBody` — it lives in `canvas/components/pre-analysis/` (PreAnalysisPanel). Out of L3's reach.
- **`GraphPatchBlockRenderer` / `V5GraphPatchBlock`** are **not** in `ResultsBody` — they are conversation inline blocks (`canvas/conversation/blocks/`, `v5/blocks/`). Out of L3's reach.
- The remaining 6 of the 8 pushed-down components (hero, OptionCards+WinGauge+RiskAppetiteFilter, DriversSection, TornadoChart, StressTestSection, WhatChangedChip) are in-panel and re-parented as specified. Several additional live components (InferenceWarningStrip, the flag-gated AnalysisHeroContainer/StrengthenContainer, AdvancedSection, strengthCorrections, DevBuildMarker) also move down with the group.

**Do not merge** — draft for Paul's assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)