### PR TITLE
feat(v7-l2): collapsed overview shows values not labels · final accent conversions

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -255,12 +255,19 @@ className="border-danger-200"  // DOESN'T EXIST
 
 ### Coaching Cards (v4 §15)
 
+Complete borders only (V7 L2 — Paul's categorical rule). The neutral `bg-panel`
+plus the semantic border **colour on all four sides** is the coaching signal;
+the retired `border-l-[3px]` one-sided accent must not come back.
+
 ```tsx
-// ✅ Correct — neutral bg, coloured left border
+// ✅ Correct — neutral bg, complete coloured border
+<div className="bg-panel border border-info rounded-lg px-4 py-3">
+
+// ❌ Wrong — one-sided left accent (retired in V7 L2)
 <div className="bg-panel border-l-[3px] border-info rounded-lg px-4 py-3">
 
 // ❌ Wrong — coloured background
-<div className="bg-info-light border-l-[3px] border-info rounded-lg px-4 py-3">
+<div className="bg-info-light border border-info rounded-lg px-4 py-3">
 ```
 
 ### Evaluative Colour Thresholds (v4 §11.6)

--- a/docs/Design/Olumi_Design_System_v5.md
+++ b/docs/Design/Olumi_Design_System_v5.md
@@ -384,7 +384,7 @@ Coloured borders communicate state or type. Neutral borders separate content. Ev
 |-------------|-----------------|---------|
 | **Panel section cards** (options, factors, assumptions, quality, improvements) | Full border, all sides: `border border-{colour}/30 rounded-lg` | `border border-option/30` |
 | **Conversation blocks** (§21.2) | Top 3px accent: `border-t-[3px] border-{colour}` | `border-t-[3px] border-info` |
-| **Coaching cards** (§16) | Left 3px accent: `border-l-[3px] border-info` | Only exception for left-only border |
+| **Coaching cards** (§16) | Complete border: `border border-info` | V7 L2 — one-sided accent retired |
 | **MVS card** (§16.1) | Left 3px accent: `border-l-[3px] border-success` | Elevated coaching |
 | **Alert cards** (§16.2) | Top 3px accent: `border-t-[3px] border-danger` | Blocking issues |
 | **Canvas nodes** | Full border, confidence-based: `border-2 border-{confidence-colour} border-{style}` | Solid green = high confidence |
@@ -394,7 +394,7 @@ Coloured borders communicate state or type. Neutral borders separate content. Ev
 | **Non-winner option cards** (results) | Full border: `border border-panel-border rounded-lg` | Neutral |
 
 **Rules:**
-- Left-only coloured borders are prohibited except for coaching cards (§16) and MVS cards (§16.1).
+- Left-only coloured borders are prohibited. (Coaching cards (§16) were the last exception; V7 L2 converted them to a complete `border border-info`.)
 - Structural borders (dividers, separators) always use `border-panel-border`.
 - Coloured borders always mean something. If a border is decorative, it should be `border-panel-border`.
 
@@ -918,7 +918,7 @@ Use one shared accordion component with smooth CSS height transition (`transitio
 Distinct from error/warning. Feels encouraging, not blocking.
 
 ```tsx
-<div className="bg-panel border-l-[3px] border-info rounded-lg px-4 py-3">
+<div className="bg-panel border border-info rounded-lg px-4 py-3">
   <div className="flex items-center gap-2 mb-1">
     <Lightbulb className="text-info w-4 h-4" />
     <span className={typography.panelHeader + " text-info"}>Strengthen your model</span>
@@ -929,7 +929,9 @@ Distinct from error/warning. Feels encouraging, not blocking.
 </div>
 ```
 
-**Key differences from alerts:** left border (not top), `bg-panel` background, Lucide `Lightbulb` icon, encouraging copy.
+**Key differences from alerts:** complete `border border-info` (V7 L2 retired the
+one-sided `border-l-[3px]` accent under Paul's categorical complete-borders rule),
+`bg-panel` background, Lucide `Lightbulb` icon, encouraging copy.
 
 ### 16.1 Most Valuable Step (MVS) card
 
@@ -945,7 +947,7 @@ Elevated coaching card for the single highest-priority action.
 | Variant | When | Border | Background | Icon | Tone |
 |---------|------|--------|------------|------|------|
 | **Alert** (default) | Risks, critical issues, blocking items | Top 3px `danger` | `bg-panel` | `AlertTriangle` | Direct |
-| **Coaching** | Suggestions, evidence gaps, optional enhancements | Left 3px `info` | `bg-panel` | `Lightbulb` | Encouraging |
+| **Coaching** | Suggestions, evidence gaps, optional enhancements | Complete `border-info` (V7 L2) | `bg-panel` | `Lightbulb` | Encouraging |
 
 ---
 
@@ -973,7 +975,9 @@ background: var(--bg-panel);
 border-radius: 12px;
 padding: 12px 16px;
 box-shadow: var(--shadow-2);
-border-left: 3px solid {severity colour};
+/* V7 L2 — complete border (severity colour on all four sides). The one-sided
+   `border-left: 3px` accent was retired under Paul's categorical rule. */
+border: 1px solid {severity colour};
 max-width: 360px;
 ```
 

--- a/src/canvas/ToastContext.tsx
+++ b/src/canvas/ToastContext.tsx
@@ -123,7 +123,9 @@ const TOAST_ICONS = {
   warning: AlertTriangle,
 } as const
 
-// Maps toast type to the semantic CSS variable for the left border colour
+// Maps toast type to the semantic CSS variable for the complete border colour
+// (V7 L2: a complete border carries the severity colour on all four sides —
+// the one-sided `borderLeft` accent was retired under Paul's categorical rule).
 const TOAST_BORDER_COLOR: Record<Toast['type'], string> = {
   success: 'var(--success)',
   error:   'var(--danger)',
@@ -156,7 +158,7 @@ function ToastContainer({ toasts, onRemove }: { toasts: Toast[]; onRemove: (id: 
           <div
             key={toast.id}
             className="bg-panel rounded-lg shadow-2 flex items-center gap-3 px-4 py-3 max-w-[360px] animate-slideDown"
-            style={{ borderLeft: `3px solid ${TOAST_BORDER_COLOR[toast.type]}` }}
+            style={{ border: `1px solid ${TOAST_BORDER_COLOR[toast.type]}` }}
             role="alert"
           >
             <Icon className={`w-4 h-4 flex-shrink-0 ${TOAST_ICON_CLASS[toast.type]}`} aria-hidden="true" />

--- a/src/canvas/components/pre-analysis/__tests__/design-contracts.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/design-contracts.spec.tsx
@@ -2,8 +2,9 @@
  * Design contract regression tests for pre-analysis components.
  *
  * Guards against reintroduction of:
- * 1. Non-exempt coloured left-border (border-l-*) classes — only coaching/MVS/alert/toast
- *    cards may have left-accent borders per §6.4 / §16–§17 of the design system.
+ * 1. Coloured left-border (border-l-*) classes in pre-analysis content cards.
+ *    Complete borders only — V7 L2 converted the last exceptions (§16 coaching
+ *    cards, §17 toasts) to complete borders, so Paul's rule is categorical now.
  * 2. Em-dash characters (— / \u2014) in user-visible UI strings per the copy style guide.
  */
 
@@ -64,16 +65,17 @@ function getAllClassNames(container: HTMLElement): string {
 }
 
 /**
- * Exempt left-border patterns per §6.4 / §16–§17:
- * - border-l-[3px] border-l-{colour} — coaching card (§16) / MVS card (§16.1)
- * - border-l-2 border-panel-border — neutral indent guides are NOT exempt; all
- *   left borders are banned in analysis-tab content cards after this pass.
+ * Left-border patterns are banned outright in pre-analysis content cards:
+ * - border-l-[3px] border-l-{colour} — the coaching-card accent, converted to a
+ *   complete border in V7 L2 (§16); no coaching card renders here anyway.
+ * - border-l-2 border-panel-border — neutral indent guides are also banned; all
+ *   left borders are prohibited in analysis-tab content cards.
  *
- * This helper returns true if a class string contains a non-exempt coloured left border.
+ * This helper returns true if a class string contains any coloured/structural
+ * left border.
  */
 function hasNonExemptLeftBorder(classString: string): boolean {
-  // Any border-l class is non-exempt in pre-analysis content cards.
-  // (ConfidenceSection MVS card is in results/, not tested here.)
+  // Any border-l class is banned in pre-analysis content cards.
   return /\bborder-l-/.test(classString)
 }
 

--- a/src/canvas/conversation/__tests__/V5CoachingBlock.biasSignalVariant.spec.tsx
+++ b/src/canvas/conversation/__tests__/V5CoachingBlock.biasSignalVariant.spec.tsx
@@ -11,9 +11,12 @@
  * `status_quo_bias` + `anchoring`, both grounded. Copy here is synthetic.
  *
  * Pinned behaviour:
- *   1. DS coaching-card recipe (DESIGN_SYSTEM.md:256-264): bg-panel +
- *      coloured LEFT border (border-l-[3px] border-info) + rounded-lg
- *      px-4 py-3 — NOT the full-border idiom of the default variant.
+ *   1. DS coaching-card recipe (DESIGN_SYSTEM.md §16): bg-panel + a COMPLETE
+ *      coloured border (border border-info) + rounded-lg px-4 py-3. V7 L2
+ *      retired the one-sided `border-l-[3px]` accent — Paul's complete-borders
+ *      rule is categorical. The variant still differs from the default idiom
+ *      by colour strength (full border-info vs default border-info/30) and by
+ *      its rounded-lg px-4 py-3 shape.
  *   2. Humanised title and producer-verbatim body render; the grounded
  *      reference label is visible.
  *   3. coaching_kind / source ride as data-* only — no raw code string
@@ -63,17 +66,19 @@ const OTHER_COACHING_BLOCK: V5CoachingBlockType = {
 }
 
 describe('V5CoachingBlock bias_signal variant — DS coaching-card recipe', () => {
-  it('uses the DS recipe: bg-panel + coloured left border, no full border', () => {
+  it('uses the DS recipe: bg-panel + a COMPLETE coloured border (V7 L2: no one-sided accent)', () => {
     render(<V5CoachingBlock block={BIAS_BLOCK} variant="bias_signal" />)
     const card = screen.getByTestId('bias-signal-card')
     expect(card.classList.contains('bg-panel')).toBe(true)
-    expect(card.classList.contains('border-l-[3px]')).toBe(true)
+    // Complete border in the full-strength semantic colour — the retired
+    // one-sided left accent must not come back (Paul's categorical rule).
+    expect(card.classList.contains('border')).toBe(true)
     expect(card.classList.contains('border-info')).toBe(true)
+    expect(card.classList.contains('border-l-[3px]')).toBe(false)
     expect(card.classList.contains('rounded-lg')).toBe(true)
     expect(card.classList.contains('px-4')).toBe(true)
     expect(card.classList.contains('py-3')).toBe(true)
-    // NOT the full-border idiom (the DS-audit non-compliance we must not propagate).
-    expect(card.classList.contains('border')).toBe(false)
+    // Distinct from the default variant's softer border-info/30.
     expect(card.classList.contains('border-info/30')).toBe(false)
     // Neutral background only — never a coloured card background.
     expect([...card.classList].some((c) => /^bg-(info|warning|danger|success)/.test(c))).toBe(false)
@@ -199,7 +204,9 @@ describe('builder → InlineBlocks end-to-end (fixture wire shape)', () => {
     expect(cards).toHaveLength(2)
     for (const card of cards) {
       expect(card.classList.contains('bg-panel')).toBe(true)
-      expect(card.classList.contains('border-l-[3px]')).toBe(true)
+      expect(card.classList.contains('border')).toBe(true)
+      expect(card.classList.contains('border-info')).toBe(true)
+      expect(card.classList.contains('border-l-[3px]')).toBe(false)
     }
   })
 

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -68,10 +68,10 @@ export const OVERVIEW_COPY = {
   capturedInBrief: 'Captured in brief',
   notCaptured: 'Not captured yet',
   optionsNoteEmpty: 'No options mapped yet',
-  stakesUnset: 'Stakes not set',
-  reversibilityUnset: 'Reversibility not set',
-  horizonUnset: 'Horizon not set',
-  riskUnset: 'Risk approach not set',
+  // V6-RESPEC §4: empty classification fields fold into ONE muted aggregate
+  // chip ("+N to set") — collapsed shows what IS, never a per-field inventory
+  // of what ISN'T. The old per-field "not set" name labels are retired.
+  classificationUnsetSuffix: 'to set',
 } as const
 
 const STATE_COPY: Record<BriefState, { line: string; note: string }> = {
@@ -265,18 +265,24 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
         ? { line: OVERVIEW_COPY.thin, note: OVERVIEW_COPY.thinLiveNote }
         : STATE_COPY[state]
 
-  // UI-SEM-077: decision-classification pill inference. No producer
-  // classification contract exists; the only honest client-side input today
-  // is the decision node's brief timeframe (-> horizon). Stakes,
-  // reversibility and risk appetite have NO live signal, so those pills
-  // fail closed to an explicit "not set" state — values are NEVER
-  // fabricated. Remove when CEE provides decision_classification.
-  const pillLabels: Record<ClassificationDimension, string> = {
-    stakes: OVERVIEW_COPY.stakesUnset,
-    reversibility: OVERVIEW_COPY.reversibilityUnset,
-    horizon: horizonText ? `Horizon: ${horizonText}` : OVERVIEW_COPY.horizonUnset,
-    risk: OVERVIEW_COPY.riskUnset,
+  // UI-SEM-077 (+ V7 L2, values-not-labels): decision-classification pill
+  // inference. No producer classification contract exists; the only honest
+  // client-side input today is the decision node's brief timeframe
+  // (-> horizon). Stakes, reversibility and risk appetite have NO live
+  // signal, so those fields fail closed to EMPTY (value null) — values are
+  // NEVER fabricated. Collapsed doctrine (V6-RESPEC §4): a FILLED field
+  // renders as its value chip; every EMPTY field folds into ONE muted
+  // "+N to set" aggregate — the card shows what IS, never an inventory of
+  // hidden field names. Remove the null fallbacks when CEE provides
+  // decision_classification.
+  const pillValues: Record<ClassificationDimension, string | null> = {
+    stakes: null,
+    reversibility: null,
+    horizon: horizonText ? `Horizon: ${horizonText}` : null,
+    risk: null,
   }
+  const filledDims = CLASSIFICATION_DIMENSIONS.filter((dim) => pillValues[dim] != null)
+  const unsetCount = CLASSIFICATION_DIMENSIONS.length - filledDims.length
 
   const reviewClassification = (dim: ClassificationDimension) =>
     openAskOlumi({
@@ -347,7 +353,7 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
             {title || OVERVIEW_COPY.titleFallback}
           </h2>
           <div aria-label="Decision classification" className="mt-1.5 flex flex-wrap gap-1.5">
-            {CLASSIFICATION_DIMENSIONS.map((dim) => (
+            {filledDims.map((dim) => (
               <button
                 key={dim}
                 type="button"
@@ -355,9 +361,22 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
                 onClick={() => reviewClassification(dim)}
                 className={`${typography.panelMeta} max-w-full truncate rounded-pill border border-panel-border bg-transparent px-2 py-0.5 text-text-body hover:bg-panel-hover`}
               >
-                {pillLabels[dim]}
+                {pillValues[dim]}
               </button>
             ))}
+            {/* One muted aggregate for every empty field (V6-RESPEC §4).
+                Clicking it expands the card — the existing boolean expand
+                behaviour, no new focus plumbing. Complete (dashed) border. */}
+            {unsetCount > 0 && (
+              <button
+                type="button"
+                data-testid="decision-pills-unset"
+                onClick={() => setExpanded(true)}
+                className={`${typography.panelMeta} max-w-full truncate rounded-pill border border-dashed border-panel-border bg-transparent px-2 py-0.5 text-text-light hover:bg-panel-hover`}
+              >
+                +{unsetCount} {OVERVIEW_COPY.classificationUnsetSuffix}
+              </button>
+            )}
           </div>
         </div>
         <ActionsMenu />

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
@@ -121,23 +121,27 @@ describe('DecisionOverviewCard — ready state (live)', () => {
   })
 })
 
-describe('DecisionOverviewCard — classification pills (UI-SEM-077)', () => {
+describe('DecisionOverviewCard — classification pills (UI-SEM-077, L2 values-not-labels)', () => {
   beforeEach(() => {
     flagOn()
     resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
   })
 
-  it('renders all four dimensions fail-closed as "not set" when no signal exists', () => {
+  it('collapsed shows ONE muted "+N to set" aggregate, never per-field "not set" name chips', () => {
     render(<DecisionOverviewCard title="t" />)
-    expect(screen.getByTestId('decision-pill-stakes')).toHaveTextContent(OVERVIEW_COPY.stakesUnset)
-    expect(screen.getByTestId('decision-pill-reversibility')).toHaveTextContent(
-      OVERVIEW_COPY.reversibilityUnset,
-    )
-    expect(screen.getByTestId('decision-pill-horizon')).toHaveTextContent(OVERVIEW_COPY.horizonUnset)
-    expect(screen.getByTestId('decision-pill-risk')).toHaveTextContent(OVERVIEW_COPY.riskUnset)
+    // V6-RESPEC §4: collapsed = what IS. The four classification dimensions
+    // have no live signal → all empty → folded into a single muted chip, never
+    // an inventory of hidden field names.
+    expect(screen.getByTestId('decision-pills-unset')).toHaveTextContent('+4 to set')
+    // The retired "what ISN'T" per-field name chips are gone.
+    expect(screen.queryByTestId('decision-pill-stakes')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('decision-pill-reversibility')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('decision-pill-horizon')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('decision-pill-risk')).not.toBeInTheDocument()
+    expect(screen.queryByText(/not set/i)).not.toBeInTheDocument()
   })
 
-  it('horizon pill shows the decision-node brief timeframe verbatim when present', () => {
+  it('a FILLED field renders as a value chip; only the empty remainder aggregates', () => {
     useCanvasStore.setState({
       nodes: [
         {
@@ -149,17 +153,38 @@ describe('DecisionOverviewCard — classification pills (UI-SEM-077)', () => {
       ],
     } as never)
     render(<DecisionOverviewCard title="t" />)
+    // Horizon is the one dimension with a live signal → its value renders as a
+    // chip (the brief timeframe verbatim); the other three fold into "+3 to set".
     expect(screen.getByTestId('decision-pill-horizon')).toHaveTextContent('Horizon: within 6 months')
+    expect(screen.getByTestId('decision-pills-unset')).toHaveTextContent('+3 to set')
   })
 
-  it('pill click opens the Ask-Olumi drawer with the classification review ask', () => {
+  it('the "+N to set" aggregate expands the card (no new focus plumbing)', () => {
     render(<DecisionOverviewCard title="t" />)
-    fireEvent.click(screen.getByTestId('decision-pill-stakes'))
+    // Ready state is collapsed by default.
+    expect(screen.getByTestId('brief-bar')).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(screen.getByTestId('decision-pills-unset'))
+    expect(screen.getByTestId('brief-bar')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('a filled value chip still opens the Ask-Olumi drawer with the classification review ask', () => {
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: 'd1',
+          type: 'decision',
+          position: { x: 0, y: 0 },
+          data: { label: 'Decide', brief: { timeframe: 'Q3' } },
+        },
+      ],
+    } as never)
+    render(<DecisionOverviewCard title="t" />)
+    fireEvent.click(screen.getByTestId('decision-pill-horizon'))
     const drawer = useAskOlumiStore.getState()
     expect(drawer.isOpen).toBe(true)
-    expect(drawer.label).toBe('Review stakes')
+    expect(drawer.label).toBe('Review horizon')
     expect(drawer.context).toBe(OVERVIEW_COPY.pillContext)
-    expect(drawer.draft).toBe('Help me work through: Review stakes')
+    expect(drawer.draft).toBe('Help me work through: Review horizon')
   })
 })
 

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -23,10 +23,12 @@
  * duplicated this whole structure and silently DROPPED action_label):
  *   - 'default': full border-info/30 card (the existing idiom).
  *   - 'bias_signal': the DS coaching-card recipe (DESIGN_SYSTEM.md
- *     "Coaching Cards (v4 §15)") — neutral bg-panel + coloured LEFT border
- *     (border-l-[3px] border-info), testid prefix `bias-signal-card` (the
- *     #356 specs key on it). ONLY the container class and testid prefix
- *     differ; structure, refs and the action_label pill are identical.
+ *     "Coaching Cards (v4 §15)") — neutral bg-panel + a COMPLETE coloured
+ *     border (border border-info; V7 L2 retired the one-sided
+ *     `border-l-[3px]` accent under Paul's categorical complete-borders
+ *     rule), testid prefix `bias-signal-card` (the #356 specs key on it).
+ *     ONLY the container class and testid prefix differ; structure, refs and
+ *     the action_label pill are identical.
  */
 import { type ReactElement } from 'react'
 import { Lightbulb } from 'lucide-react'
@@ -41,7 +43,7 @@ export interface V5CoachingBlockProps {
 
 const CONTAINER_CLASS: Record<'default' | 'bias_signal', string> = {
   default: 'rounded-xl border border-info/30 bg-panel p-4 space-y-2',
-  bias_signal: 'bg-panel border-l-[3px] border-info rounded-lg px-4 py-3 space-y-2',
+  bias_signal: 'bg-panel border border-info rounded-lg px-4 py-3 space-y-2',
 }
 
 export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockProps): ReactElement {

--- a/tests/ci-guards/complete-borders.spec.ts
+++ b/tests/ci-guards/complete-borders.spec.ts
@@ -39,11 +39,13 @@
  *     tab-underline indicators (`border-b-2 border-info`) — none live in the
  *     content-card set below, so they are out of scope by file selection.
  *
- * OUT OF THIS LANE (tracked as Paul-questions, deliberately NOT swept here):
- *   · §16 conversation coaching blocks (V5CoachingBlock `border-l-[3px] border-info`)
- *     — pinned by an intentional design-contract test.
- *   · §17 toast notifications (ToastContext inline `borderLeft`).
- *   These surfaces are excluded by file selection, not by a colour exception.
+ * SWEPT IN V7 L2 (the last two one-sided accents — Paul's rule is categorical):
+ *   · §16 conversation coaching blocks (V5CoachingBlock `bias_signal` variant):
+ *     `border-l-[3px] border-info` -> complete `border border-info`.
+ *   · §17 toast notifications (ToastContext inline `borderLeft: 3px` ->
+ *     complete `border: 1px`).
+ *   Both files are now in the scan set below and their design-contract specs
+ *   pin the complete-border form. No surface remains behind a colour exception.
  *
  * CONTROLS (run every CI pass, not once by hand):
  *   · POSITIVE — a synthetic `border-l-[3px]` and a `border-t-2` MUST be flagged,
@@ -81,6 +83,9 @@ const CONTENT_CARD_FILES = [
   'canvas/components/model-tab/ModelTabHeader.tsx',
   'canvas/ui/inspector/InspectorGuidanceSection.tsx',
   'components/assistants/ProvenanceChip.tsx',
+  // V7 L2 — the final two one-sided accents, now converted to complete borders.
+  'v5/blocks/V5CoachingBlock.tsx',
+  'canvas/ToastContext.tsx',
 ]
 
 /** Single-side border width with an arbitrary value: `border-l-[3px]`. */


### PR DESCRIPTION
## V7 Lane L2 — collapsed decision-overview redesign + the final two one-sided-accent conversions

Two tight commits, branched from staging tip `419f0a7c` (L1 borders sweep #439).

### Commit 1 — L2: collapsed decision-overview = what IS, not what ISN'T
`src/components/results/decision-overview/DecisionOverviewCard.tsx`

Paul's observed problem: collapsed, the classification row listed every empty dimension by NAME ("Stakes not set", "Reversibility not set", "Risk approach not set") — an inventory of what you can't see. Per **V6-RESPEC §4**:

- **FILLED** fields render as VALUE chips (today only horizon has a live signal: `Horizon: <brief timeframe>`), truncated, still routing to the Ask-Olumi classification-review drawer on click.
- **EMPTY** fields fold into **ONE** muted `+N to set` aggregate chip (complete dashed border) that **expands the card** — the existing boolean expand behaviour, no new focus plumbing.
- Readiness/health line, status dot, and the **entire expanded disclosure are unchanged**. Values are never fabricated: no-signal dimensions stay empty.

Retires the per-field `OVERVIEW_COPY` `*Unset` labels. Pins flipped RED→GREEN: value-chip render, all-empty aggregate (`+4 to set`), filled-remainder aggregate (`+3 to set`), aggregate-expands-card, filled-chip drawer route.

### Commit 2 — final accent conversions (Paul's categorical rule closes out)
- **`src/v5/blocks/V5CoachingBlock.tsx`** `bias_signal` variant (§16 coaching recipe): `border-l-[3px] border-info` → complete `border border-info`.
- **`src/canvas/ToastContext.tsx`** toast affordance (§17): inline `borderLeft: 3px solid` → complete `border: 1px solid`, same severity colour.
- Both files **added to the live `tests/ci-guards/complete-borders.spec.ts` scan set** (previously excluded by file selection); guard note updated to record the sweep.
- Design-contract specs flipped RED→GREEN (`V5CoachingBlock.biasSignalVariant.spec.tsx` recipe + end-to-end assertions; `design-contracts.spec.tsx` exemption prose).
- §16/§17 recipes updated in `DESIGN_SYSTEM.md` and `docs/Design/Olumi_Design_System_v5.md`.

### Gates
- `pnpm run typecheck` — exit 0, zero net-new
- Touched suites green: `DecisionOverviewCard.spec.tsx`, `V5CoachingBlock.biasSignalVariant.spec.tsx`, `complete-borders.spec.ts`, `design-contracts.spec.tsx`, plus related `InlineBlocks.*` / `V5Phase3Blocks` coaching specs
- complete-borders guard green (now scans both converted files)
- eslint clean on all touched code files
- `pnpm build` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)