### PR TITLE
feat(v7-l4): V7 top matter — hero, signal row, sharpen line, chips, freshness strip

### DIFF
--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -31,6 +31,7 @@ import { StrengthenContainer } from './strengthen/StrengthenContainer'
 import { InferenceWarningStrip } from './InferenceWarningStrip'
 import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
 import { AnalysisHeroContainer } from './analysis-hero'
+import { V7TopMatter } from './v7/V7TopMatter'
 import { openDefineSuccess } from './modals'
 import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled, isAnalysisHeroPanelEnabled, isStrengthenPanelEnabled } from '@/flags'
 
@@ -254,10 +255,22 @@ export const ResultsBody = memo(function ResultsBody({
           changed, no flag. The Current-view group retires once Paul signs off
           (V6-RESPEC Paul-question P2). */}
 
-      {/* ▛ V7 (new) top group ▟ — the L4–L6 mount point. Empty today (those
-          components do not exist yet); `empty:hidden` keeps it out of layout
-          until a lane fills it, so the scaffold is invisible-but-present. */}
-      <div className="flex flex-col gap-4 empty:hidden" data-testid="v7-top-group" />
+      {/* ▛ V7 (new) top group ▟ — the L4–L6 mount point. `empty:hidden` keeps
+          it out of layout until a lane fills it. L4 (V7 top matter — freshness
+          strip, sharpen line, V7 hero + signal row + max-2 chips) mounts here;
+          V7TopMatter returns null pre-analysis, so the group stays hidden until
+          analysis data exists. Reads the SAME resultsSectionData + vm the live
+          panel below consumes — additive, passthrough, no flag. */}
+      <div className="flex flex-col gap-4 empty:hidden" data-testid="v7-top-group">
+        <SectionErrorBoundary section="V7 top matter">
+          <V7TopMatter
+            resultsSectionData={resultsSectionData}
+            decisionState={vm.decisionState}
+            onFocusNode={onFocusNode}
+            onSendMessage={onSendMessage}
+          />
+        </SectionErrorBoundary>
+      </div>
 
       {/* ── "Current view" divider ─────────────────────────────────────────
           Plain SectionHeader-style separator (sentence case, muted, no accent

--- a/src/components/results/__tests__/ResultsBody.v7TopMatter.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.v7TopMatter.spec.tsx
@@ -1,0 +1,236 @@
+/**
+ * ResultsBody — V7 Lane L4: V7 top matter.
+ *
+ * Pins the additive top-group content that mounts in the `v7-top-group` slot,
+ * ABOVE the "Current view" divider:
+ *   (a) present  — freshness strip + hero (+headline +signal row) render, and
+ *       ALL sit ABOVE the divider;
+ *   (b) absent   — with no analysis, the top matter renders NOTHING (the group
+ *       stays empty → hidden), and the pushed-down panel is untouched;
+ *   (c) max-2    — with 3 guidance items only 2 chips render;
+ *   (d) fresh    — the freshness strip reflects the store's fresh/stale verdict;
+ *   (e) honest   — the hero headline is composed ONLY from the fixture winner
+ *       label (no invented content).
+ *
+ * RED-first: against the L3 ResultsBody (no L4 mount) the `v7-top-matter`
+ * / `v7-hero` testids do not exist, so (a),(c),(d),(e) fail until L4 lands.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  DriverItem,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isStrengthenPanelEnabled: vi.fn(() => false),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }
+})
+
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+import { useGuidanceStore, type GuidanceItem } from '@/canvas/stores/guidanceStore'
+import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
+
+const WINNER_LABEL = 'Bring In 6-Month Contractor'
+
+function driver(): DriverItem {
+  return {
+    factorKey: 'n_lead',
+    factorLabel: 'Tech lead hired',
+    rawElasticity: 1,
+    normalisedInfluence: 1,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: true,
+    matchedNodeId: 'n_lead',
+  } as DriverItem
+}
+
+function makeData(overrides?: { empty?: boolean }): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: WINNER_LABEL,
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.71,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Hire Permanent Senior Tech Lead',
+    isRecommended: false,
+    winProbability: 0.31,
+  } as unknown as OptionResult
+
+  const recommendation = overrides?.empty
+    ? ({ recommendedOption: undefined, allOptions: [], isSingleOption: false } as unknown as DecisionResultData)
+    : ({
+        recommendedOption: winner,
+        allOptions: [winner, runnerUp],
+        goalLabel: 'Maximise success',
+        goalText: 'Ship the Q4 migration without blowing the budget',
+        goalThreshold: 0.6,
+        isSingleOption: false,
+        analysisStatus: 'computed',
+        recommendationStability: 0.92,
+        robustnessLevel: 'high',
+        isNormalised: false,
+      } as unknown as DecisionResultData)
+
+  const drivers: DriversSectionData = overrides?.empty
+    ? { drivers: [], topDrivers: [], driversStatus: 'computed', totalCount: 0, hasMagnitudeData: false }
+    : { drivers: [driver()], topDrivers: [driver()], driversStatus: 'computed', totalCount: 1, hasMagnitudeData: true }
+
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: overrides?.empty
+      ? []
+      : [
+          { factorId: 'n_pipeline', factorLabel: 'Hiring Pipeline Duration', confidence: 40, voi: 0.6, suggestion: 'Confirm the pipeline estimate', targetNodeId: 'n_pipeline' },
+          { factorId: 'n_salary', factorLabel: 'Salary Budget Utilisation', confidence: 45, voi: 0.5, suggestion: 'Confirm the budget estimate', targetNodeId: 'n_salary' },
+        ],
+    nextActions: [],
+    topNextActions: [],
+    challengeFragileEdges: overrides?.empty
+      ? []
+      : [{ edge_id: 'e1', from_id: 'n_lead', from_label: 'Tech lead hired', to_label: 'Outsource', switch_probability: 0.22 }],
+  } as unknown as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = { improvements: [], count: 0, hasHighPriority: false } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function guidanceItem(id: string, priority: number): GuidanceItem {
+  return {
+    item_id: id,
+    source: 'analysis',
+    title: `Guidance ${id}`,
+    actionLabel: `Do ${id}`,
+    primary_action: { type: 'discuss', prompt: `Discuss ${id}` },
+    priority,
+  } as GuidanceItem
+}
+
+function renderBody(overrides?: { empty?: boolean }) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(overrides)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      onFocusNode={() => {}}
+    />,
+  )
+}
+
+const before = (a: HTMLElement, b: HTMLElement) =>
+  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+
+const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-07-23T00:00:00Z' }
+const STALE: AnalysisFreshnessState = { freshness: 'stale', computedAt: '2026-07-23T00:00:00Z' }
+
+describe('ResultsBody — V7 L4 top matter', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useGuidanceStore.setState({ guidanceItems: [] })
+  })
+
+  it('(a) renders the hero + signal row + freshness strip, ALL above the divider', () => {
+    renderBody()
+    const divider = screen.getByTestId('assessment-current-view-divider')
+    const topMatter = screen.getByTestId('v7-top-matter')
+    const hero = screen.getByTestId('v7-hero')
+    const signalRow = screen.getByTestId('v7-signal-row')
+    const strip = screen.getByTestId('v7-freshness-strip')
+    for (const el of [topMatter, hero, signalRow, strip]) {
+      expect(el).toBeInTheDocument()
+      expect(before(el, divider), 'top matter precedes the divider').toBe(true)
+    }
+    // Live hero below the divider is untouched (parity).
+    const liveHero = screen.getByTestId('decision-confidence-panel')
+    expect(before(divider, liveHero)).toBe(true)
+  })
+
+  it('(b) renders NOTHING pre-analysis (top group stays empty), pushed-down panel intact', () => {
+    renderBody({ empty: true })
+    expect(screen.queryByTestId('v7-top-matter')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('v7-hero')).not.toBeInTheDocument()
+    const group = screen.getByTestId('v7-top-group')
+    expect(group).toBeEmptyDOMElement()
+    // The divider + live panel still render (nothing below the divider changed).
+    expect(screen.getByTestId('assessment-current-view-divider')).toBeInTheDocument()
+    expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
+  })
+
+  it('(c) max-2 chips: 3 guidance items → exactly 2 chips', () => {
+    useGuidanceStore.setState({
+      guidanceItems: [guidanceItem('one', 90), guidanceItem('two', 80), guidanceItem('three', 70)],
+    })
+    renderBody()
+    expect(screen.getAllByTestId('v7-suggested-chip')).toHaveLength(2)
+  })
+
+  it('(d) freshness strip reflects the store verdict (fresh vs stale)', () => {
+    const { unmount } = renderBody()
+    expect(screen.getByTestId('v7-freshness-strip')).toHaveAttribute('data-freshness-semantic', 'current')
+    expect(screen.getByTestId('v7-freshness-strip')).toHaveTextContent('Analysis reflects the current model.')
+    unmount()
+
+    useCanvasStore.setState({ analysisFreshness: STALE, analysisFreshnessDirty: false })
+    renderBody()
+    expect(screen.getByTestId('v7-freshness-strip')).toHaveAttribute('data-freshness-semantic', 'changed')
+  })
+
+  it('(e) no invented content: hero headline is composed only from the fixture winner', () => {
+    renderBody()
+    // Robust fixture (stability 0.92, clear gap) → the "performs best" form.
+    expect(screen.getByTestId('v7-hero-headline')).toHaveTextContent(`${WINNER_LABEL} performs best`)
+    // Signal chips echo the fixture's fragile edge + top driver, verbatim.
+    expect(screen.getByTestId('v7-signal-flip-risk')).toHaveTextContent('22% flip risk · Tech lead hired')
+    expect(screen.getByTestId('v7-signal-main-driver')).toHaveTextContent('Main driver · Tech lead hired')
+    // Sharpen line quotes Paul's own brief wording.
+    expect(screen.getByTestId('v7-sharpen-quote')).toHaveTextContent('Ship the Q4 migration without blowing the budget')
+  })
+})

--- a/src/components/results/v7/V7FreshnessStrip.tsx
+++ b/src/components/results/v7/V7FreshnessStrip.tsx
@@ -1,0 +1,83 @@
+/**
+ * V7FreshnessStrip — slim freshness strip for the V7 top group (V7 Lane L4).
+ *
+ * Spec row 14 (V6-RESPEC-2026-07-23): a NEW slim strip that states, honestly,
+ * whether the analysis reflects the current model. It reuses the single-source
+ * freshness classifier (`classifyFreshnessForDisplay`) and the canonical copy
+ * table (`FRESHNESS_COPY`) that the live `AnalysisFreshnessNotice` uses — the
+ * two strips can never disagree because they read the same slice through the
+ * same reducer.
+ *
+ * NO RERUN HERE (deliberate deviation from the prototype's "+ Rerun"): the
+ * codebase enforces a single-Rerun owner — the sticky bottom `AnalysisFooter`
+ * in OutputsDock (AnalysisFreshnessNotice header: "there is exactly one Rerun
+ * and no duplicate"). Adding a second Rerun would break that invariant, the
+ * same way the hero must not duplicate the footer's verdict (spec P1). This
+ * strip is informational only.
+ *
+ * Honest absence: when there is no verdict to show (semantic 'none') it renders
+ * nothing — it never asserts a freshness state the store does not hold.
+ * COMPLETE borders only (L1 guard): the changed state colours all four sides
+ * (`border-warning/30`), never a one-sided accent.
+ */
+
+import { useCanvasStore } from '@/canvas/store'
+import { typography } from '@/styles/typography'
+import {
+  classifyFreshnessForDisplay,
+  type AnalysisFreshnessState,
+} from '@/canvas/store/analysisFreshness'
+import { FRESHNESS_COPY } from '../AnalysisFreshnessNotice'
+
+export interface V7FreshnessStripProps {
+  /** Override the store slice (tests / Storybook). `undefined` → read the store. */
+  state?: AnalysisFreshnessState | null
+  /** Override the local dirty overlay (tests / Storybook). `undefined` → read the store. */
+  dirty?: boolean
+}
+
+export function V7FreshnessStrip({ state: stateProp, dirty: dirtyProp }: V7FreshnessStripProps = {}) {
+  const storeState = useCanvasStore(s => s.analysisFreshness)
+  const storeDirty = useCanvasStore(s => s.analysisFreshnessDirty)
+  const state = stateProp !== undefined ? stateProp : storeState
+  const dirty = dirtyProp !== undefined ? dirtyProp : storeDirty
+
+  const semantic = classifyFreshnessForDisplay(state, dirty)
+
+  // Honest absence — no verdict to show.
+  if (semantic === 'none') return null
+
+  // Map the display semantic to the canonical copy + dot colour. 'changed'
+  // reuses the 'stale' copy line; 'cannot_confirm' the 'unknown' line.
+  const copy =
+    semantic === 'current'
+      ? FRESHNESS_COPY.fresh
+      : semantic === 'changed'
+        ? FRESHNESS_COPY.stale
+        : FRESHNESS_COPY.unknown
+  const dotColour =
+    semantic === 'current' ? 'bg-success' : semantic === 'changed' ? 'bg-warning' : 'bg-text-light'
+  const borderColour = semantic === 'changed' ? 'border-warning/30' : 'border-panel-border'
+
+  return (
+    <div
+      data-testid="v7-freshness-strip"
+      data-freshness-semantic={semantic}
+      className={`flex items-center gap-2 rounded-md border ${borderColour} bg-panel px-3 py-1.5`}
+    >
+      <span
+        className={`flex-none w-2 h-2 rounded-full ${dotColour}`}
+        aria-hidden="true"
+        data-testid="v7-freshness-dot"
+      />
+      <span
+        role="status"
+        className={`${typography.panelMeta} ${semantic === 'changed' ? 'text-text-header' : 'text-text-body'} min-w-0 flex-1 truncate`}
+      >
+        {copy}
+      </span>
+    </div>
+  )
+}
+
+export default V7FreshnessStrip

--- a/src/components/results/v7/V7Hero.tsx
+++ b/src/components/results/v7/V7Hero.tsx
@@ -1,0 +1,111 @@
+/**
+ * V7Hero — the new top-of-panel hero (V7 Lane L4, spec row 3).
+ *
+ * A win gauge reading the live winner win probability + a headline composed
+ * VERBATIM from production headline templates (see buildV7Headline) + an
+ * optional subline, with the two honest signal chips (V7SignalRow) and the
+ * max-2 suggested chips (V7SuggestedChips) beneath it.
+ *
+ * This hero does NOT own the robustness verdict — that stays the single
+ * responsibility of the sticky `AnalysisFooter` in OutputsDock (spec P1). The
+ * hero speaks only to WHO leads and BY HOW MUCH, from live results.
+ *
+ * Honest absence: no winner → empty headline → the hero renders nothing (the
+ * gauge only renders when a finite win probability exists). COMPLETE borders.
+ */
+
+import { typography } from '@/styles/typography'
+import { formatPercent } from '@/utils/formatPercent'
+import type { DecisionResultData, DecisionState, DriverItem } from '../types'
+import { buildV7Headline } from './buildV7Headline'
+import { V7SignalRow } from './V7SignalRow'
+import { V7SuggestedChips } from './V7SuggestedChips'
+
+type FragileEdge = {
+  edge_id?: string
+  from_id?: string
+  from_label: string
+  to_label: string
+  switch_probability: number
+}
+
+export interface V7HeroProps {
+  recommendation: DecisionResultData
+  decisionState: DecisionState
+  topDrivers?: DriverItem[]
+  fragileEdges?: FragileEdge[]
+  onFocusNode?: (nodeId: string) => void
+  onSendMessage?: (text: string) => void
+}
+
+/** Gauge geometry — r=22 donut, circumference ≈ 138.23. */
+const GAUGE_R = 22
+const GAUGE_CIRCUMFERENCE = 2 * Math.PI * GAUGE_R
+
+export function V7Hero({
+  recommendation,
+  decisionState,
+  topDrivers,
+  fragileEdges,
+  onFocusNode,
+  onSendMessage,
+}: V7HeroProps) {
+  const model = buildV7Headline(recommendation, decisionState)
+
+  // Honest absence — nothing to headline means no hero.
+  if (!model.headline) return null
+
+  const winPct = model.winProbability
+  const dash = winPct != null ? `${Math.max(0, Math.min(1, winPct)) * GAUGE_CIRCUMFERENCE} ${GAUGE_CIRCUMFERENCE}` : null
+
+  return (
+    <section
+      aria-label="Analysis"
+      data-testid="v7-hero"
+      className="rounded-lg border border-panel-border bg-panel px-3 py-3"
+    >
+      <div className="flex items-start gap-3">
+        {winPct != null && dash && (
+          <div className="relative h-[52px] w-[52px] flex-none" data-testid="v7-hero-gauge">
+            <svg viewBox="0 0 52 52" className="h-[52px] w-[52px]">
+              <circle cx="26" cy="26" r={GAUGE_R} fill="none" stroke="currentColor" strokeWidth="5" className="text-panel-border" />
+              <circle
+                cx="26"
+                cy="26"
+                r={GAUGE_R}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="5"
+                strokeLinecap="round"
+                strokeDasharray={dash}
+                transform="rotate(-90 26 26)"
+                className="text-info"
+              />
+            </svg>
+            <div className="absolute inset-0 flex flex-col items-center justify-center leading-none">
+              <span className={`${typography.panelHeader} text-text-header`}>
+                {formatPercent(winPct, { fromDecimal: true })}
+              </span>
+              <span className="text-[8.5px] text-text-light">wins</span>
+            </div>
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <h2 className={`${typography.panelHeader} text-text-header`} data-testid="v7-hero-headline">
+            {model.headline}
+          </h2>
+          {model.subline && (
+            <p className={`${typography.panelBody} text-text-light mt-0.5`} data-testid="v7-hero-subline">
+              {model.subline}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <V7SignalRow topDrivers={topDrivers} fragileEdges={fragileEdges} onFocusNode={onFocusNode} />
+      <V7SuggestedChips onSendMessage={onSendMessage} />
+    </section>
+  )
+}
+
+export default V7Hero

--- a/src/components/results/v7/V7SharpenLine.tsx
+++ b/src/components/results/v7/V7SharpenLine.tsx
@@ -1,0 +1,106 @@
+/**
+ * V7SharpenLine — the "a few inputs would sharpen these results" line
+ * (V7 Lane L4, spec row 2).
+ *
+ * Passthrough only. Two honest, store-backed parts:
+ *   · The brief quote ← the user's own framing goal
+ *     (`recommendation.goalText`, else `goalLabel`) — Paul's own wording,
+ *     rendered verbatim in quotes.
+ *   · The inputs to review (≤3 + "and N more") ← `confidence.topEvidenceGaps`
+ *     (each carries `factorLabel` + a canvas focus target), the factors whose
+ *     evidence is thin enough to be worth confirming.
+ * Plus a static, honest model-limit caveat (not a data claim).
+ *
+ * SKIPPED (honest absence, reported): the prototype also renders a
+ * conversation-aware *reframed question* ("Olumi reframed that as: …"). That
+ * reinterpretation is model output with no results-store selector, so it is
+ * NOT rendered — inventing it would breach the passthrough rule.
+ *
+ * Gate: the line renders only when there ARE inputs to sharpen
+ * (`inputs.length > 0`) — otherwise the "a few inputs would sharpen…" claim
+ * would be false, so it renders nothing. COMPLETE borders only (L1 guard).
+ */
+
+import { AlertTriangle } from 'lucide-react'
+import { typography } from '@/styles/typography'
+
+export interface V7SharpenInput {
+  /** Display label — an evidence-gap factor label. */
+  label: string
+  /** Canvas focus target, when the gap maps to a node. */
+  nodeId?: string
+}
+
+export interface V7SharpenLineProps {
+  /** The user's own framing goal — `recommendation.goalText ?? goalLabel`. */
+  briefWording?: string | null
+  /** Inputs worth confirming — derived from `confidence.topEvidenceGaps`. */
+  inputs: V7SharpenInput[]
+  /** Focus the matching canvas element for an input. */
+  onFocusNode?: (nodeId: string) => void
+}
+
+/** How many inputs show before collapsing into "and N more". */
+const VISIBLE_INPUTS = 3
+
+export function V7SharpenLine({ briefWording, inputs, onFocusNode }: V7SharpenLineProps) {
+  // Honest absence — nothing to sharpen, so make no claim.
+  if (inputs.length === 0) return null
+
+  const shown = inputs.slice(0, VISIBLE_INPUTS)
+  const moreCount = inputs.length - shown.length
+  const quote = briefWording?.trim()
+
+  return (
+    <section
+      data-testid="v7-sharpen-line"
+      className="rounded-lg border border-panel-border bg-panel px-3 py-2.5"
+    >
+      <p className={`${typography.panelBody} text-text-header font-semibold`}>
+        A few inputs would sharpen these results
+      </p>
+      {quote && (
+        <p className={`${typography.panelBody} text-text-body mt-1`} data-testid="v7-sharpen-quote">
+          You wrote: &ldquo;{quote}&rdquo;
+        </p>
+      )}
+      <p className={`${typography.panelMeta} text-text-light mt-1`}>
+        Olumi can point to what the model implies, but not guarantee the real world behaves the same.
+        Confirm these before you lean on the result.
+      </p>
+      <ul className="mt-2 space-y-0.5">
+        {shown.map((input, i) => {
+          const canFocus = Boolean(input.nodeId && onFocusNode)
+          const content = (
+            <span className="inline-flex items-start gap-1.5">
+              <AlertTriangle className="mt-[1px] h-3 w-3 flex-none text-warning" aria-hidden />
+              <span>{input.label}</span>
+            </span>
+          )
+          return (
+            <li key={`${input.label}-${i}`} className={`${typography.panelMeta} text-text-body`}>
+              {canFocus ? (
+                <button
+                  type="button"
+                  onClick={() => onFocusNode?.(input.nodeId as string)}
+                  className="text-left hover:text-text-header"
+                >
+                  {content}
+                </button>
+              ) : (
+                content
+              )}
+            </li>
+          )
+        })}
+      </ul>
+      {moreCount > 0 && (
+        <p className={`${typography.panelMeta} text-text-light mt-1`} data-testid="v7-sharpen-more">
+          and {moreCount} more
+        </p>
+      )}
+    </section>
+  )
+}
+
+export default V7SharpenLine

--- a/src/components/results/v7/V7SignalRow.tsx
+++ b/src/components/results/v7/V7SignalRow.tsx
@@ -1,0 +1,101 @@
+/**
+ * V7SignalRow — the two honest signal chips under the V7 hero (V7 Lane L4).
+ *
+ * Spec row 4 (V6-RESPEC-2026-07-23): a flip-risk chip + a main-driver chip on
+ * one line, composed from `fragile_edges[0]` + `factor_sensitivity[0]`.
+ * Passthrough only:
+ *   · Flip-risk chip ← `confidence.challengeFragileEdges[0]` (switch_probability
+ *     + from_label) — the SAME fragile-edge slice StressTestSection consumes.
+ *   · Main-driver chip ← `drivers.topDrivers[0]` (factorLabel) — the top row of
+ *     the drivers table, already ranked upstream.
+ *
+ * Honest absence: a signal with no backing data renders nothing — no
+ * placeholder chip. When neither signal exists the row itself is empty.
+ * COMPLETE borders only (L1 guard): chips carry a full `border` on all sides.
+ */
+
+import { AlertTriangle, Zap } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { formatPercent } from '@/utils/formatPercent'
+import type { DriverItem } from '../types'
+
+type FragileEdge = {
+  edge_id?: string
+  from_id?: string
+  from_label: string
+  to_label: string
+  switch_probability: number
+}
+
+export interface V7SignalRowProps {
+  /** Ranked drivers — `resultsSectionData.drivers.topDrivers`. */
+  topDrivers?: DriverItem[]
+  /** Fragile edges — `resultsSectionData.confidence.challengeFragileEdges`. */
+  fragileEdges?: FragileEdge[]
+  /** Focus the matching canvas element when a chip is clicked. */
+  onFocusNode?: (nodeId: string) => void
+}
+
+export function V7SignalRow({ topDrivers, fragileEdges, onFocusNode }: V7SignalRowProps) {
+  const flip = fragileEdges?.[0]
+  const flipPct =
+    flip && typeof flip.switch_probability === 'number' && Number.isFinite(flip.switch_probability)
+      ? flip.switch_probability
+      : null
+  const mainDriver = topDrivers?.[0]
+
+  const chips: React.ReactNode[] = []
+
+  // Flip-risk chip — only when a fragile edge with a finite switch probability exists.
+  if (flip && flipPct != null) {
+    const focusId = flip.from_id
+    chips.push(
+      <button
+        key="flip"
+        type="button"
+        data-testid="v7-signal-flip-risk"
+        disabled={!focusId || !onFocusNode}
+        onClick={focusId && onFocusNode ? () => onFocusNode(focusId) : undefined}
+        className={`inline-flex items-center gap-1.5 rounded-full border border-panel-border bg-transparent px-2 py-0.5 ${typography.panelMeta} text-text-body enabled:hover:bg-panel-hover disabled:cursor-default`}
+      >
+        <AlertTriangle className="h-3 w-3 flex-none text-warning" aria-hidden />
+        <span>
+          <span className="font-semibold text-text-header">
+            {formatPercent(flipPct, { fromDecimal: true })}
+          </span>{' '}
+          flip risk · {flip.from_label}
+        </span>
+      </button>,
+    )
+  }
+
+  // Main-driver chip — only when a top driver exists.
+  if (mainDriver) {
+    const focusId = mainDriver.canFocus ? (mainDriver.matchedNodeId ?? mainDriver.factorKey) : undefined
+    chips.push(
+      <button
+        key="driver"
+        type="button"
+        data-testid="v7-signal-main-driver"
+        disabled={!focusId || !onFocusNode}
+        onClick={focusId && onFocusNode ? () => onFocusNode(focusId) : undefined}
+        className={`inline-flex items-center gap-1.5 rounded-full border border-panel-border bg-transparent px-2 py-0.5 ${typography.panelMeta} text-text-body enabled:hover:bg-panel-hover disabled:cursor-default`}
+      >
+        <Zap className="h-3 w-3 flex-none text-info" aria-hidden />
+        <span>
+          <span className="font-semibold text-text-header">Main driver</span> · {mainDriver.factorLabel}
+        </span>
+      </button>,
+    )
+  }
+
+  if (chips.length === 0) return null
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5" data-testid="v7-signal-row">
+      {chips}
+    </div>
+  )
+}
+
+export default V7SignalRow

--- a/src/components/results/v7/V7SuggestedChips.tsx
+++ b/src/components/results/v7/V7SuggestedChips.tsx
@@ -1,0 +1,69 @@
+/**
+ * V7SuggestedChips — the max-2 suggested-action chips (V7 Lane L4).
+ *
+ * Spec row 5 (V6-RESPEC-2026-07-23): at most TWO chips, reusing the existing
+ * chip dispatch path — no new chip plumbing. The chips are the top ≤2 live
+ * guidance items (`guidanceStore.guidanceItems`), ordered by the single
+ * canonical comparator (`compareGuidanceDisplayOrder` — the same doctrine the
+ * strip/inspector use), and each chip hands its question to the REAL
+ * conversation via the `onSendMessage` path ResultsBody already threads to
+ * DriversSection / StressTestSection. This is the honest fix for the F2
+ * finding ("pill answers are canned"): the chip sends a real turn to the
+ * conversation engine instead of rendering a fabricated answer.
+ *
+ * Honest absence: no guidance items, or no `onSendMessage` sink, → nothing
+ * renders. The MAX-2 cap is enforced here (slice(0, 2)).
+ * COMPLETE borders only (L1 guard): chips carry a full `border`.
+ */
+
+import { MessageCircle } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { useGuidanceStore, compareGuidanceDisplayOrder, type GuidanceItem } from '@/canvas/stores/guidanceStore'
+
+/** Max chips the top matter ever shows (spec row 5). */
+export const MAX_SUGGESTED_CHIPS = 2
+
+export interface V7SuggestedChipsProps {
+  /** Existing conversation dispatch path (threaded through ResultsBody). */
+  onSendMessage?: (text: string) => void
+  /** Test/story override for the guidance items; `undefined` → read the store. */
+  items?: GuidanceItem[]
+}
+
+/** The message a chip sends — a discuss prompt where present, else the item detail/title. */
+function chipMessage(item: GuidanceItem): string {
+  if (item.primary_action?.type === 'discuss' && item.primary_action.prompt) {
+    return item.primary_action.prompt
+  }
+  return item.detail ?? item.title
+}
+
+export function V7SuggestedChips({ onSendMessage, items: itemsProp }: V7SuggestedChipsProps) {
+  const storeItems = useGuidanceStore(s => s.guidanceItems)
+  const source = itemsProp !== undefined ? itemsProp : storeItems
+
+  // Honest absence — no conversation sink, or nothing to suggest.
+  if (!onSendMessage || source.length === 0) return null
+
+  const chips = [...source].sort(compareGuidanceDisplayOrder).slice(0, MAX_SUGGESTED_CHIPS)
+  if (chips.length === 0) return null
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5" data-testid="v7-suggested-chips" aria-label="Suggested next questions">
+      {chips.map(item => (
+        <button
+          key={item.item_id}
+          type="button"
+          data-testid="v7-suggested-chip"
+          onClick={() => onSendMessage(chipMessage(item))}
+          className={`inline-flex items-center gap-1.5 rounded-full border border-panel-border bg-transparent px-2.5 py-1 ${typography.panelMeta} text-text-header hover:border-info hover:bg-panel-hover`}
+        >
+          <MessageCircle className="h-3 w-3 flex-none text-info" aria-hidden />
+          <span className="truncate">{item.actionLabel ?? item.title}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default V7SuggestedChips

--- a/src/components/results/v7/V7TopMatter.tsx
+++ b/src/components/results/v7/V7TopMatter.tsx
@@ -1,0 +1,67 @@
+/**
+ * V7TopMatter — the V7 (new) top group's L4 content (V7 Lane L4).
+ *
+ * Mounts inside the `v7-top-group` slot in ResultsBody, ABOVE the
+ * "Current view" divider (the L3 scaffold). Composes the L4 components:
+ *   1. V7FreshnessStrip — current / changed / cannot-confirm, honest
+ *   2. V7SharpenLine    — brief quote + inputs to confirm + model-limit caveat
+ *   3. V7Hero           — gauge + live headline + subline + signal row + chips
+ *
+ * ADDITIVE and PASSTHROUGH: every part reads existing store data and renders
+ * nothing when its backing data is absent. The whole group is gated on
+ * analysis presence — pre-analysis it returns null, so `v7-top-group`'s
+ * `empty:hidden` keeps it out of layout entirely (spec: renders NOTHING
+ * pre-analysis; nothing below the divider changes).
+ */
+
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { DecisionState } from '../types'
+import { V7FreshnessStrip } from './V7FreshnessStrip'
+import { V7SharpenLine, type V7SharpenInput } from './V7SharpenLine'
+import { V7Hero } from './V7Hero'
+
+export interface V7TopMatterProps {
+  resultsSectionData: ResultsSectionDataReturn
+  /** `buildResultsVM(...).decisionState` — the SAME tri-state the live hero uses. */
+  decisionState: DecisionState
+  onFocusNode?: (nodeId: string) => void
+  onSendMessage?: (text: string) => void
+}
+
+export function V7TopMatter({
+  resultsSectionData,
+  decisionState,
+  onFocusNode,
+  onSendMessage,
+}: V7TopMatterProps) {
+  const { recommendation, drivers, confidence, isLoading, isError } = resultsSectionData
+
+  // Analysis-presence gate — mirror the live hero: there is analysis to show
+  // once options with results exist and the panel is neither loading nor errored.
+  const hasAnalysis = !isLoading && !isError && (recommendation.allOptions?.length ?? 0) > 0
+  if (!hasAnalysis) return null
+
+  // Sharpen inputs — the evidence gaps worth confirming (honest, store-backed).
+  const sharpenInputs: V7SharpenInput[] = (confidence.topEvidenceGaps ?? []).map(gap => ({
+    label: gap.factorLabel,
+    nodeId: gap.targetNodeId,
+  }))
+  const briefWording = recommendation.goalText ?? resultsSectionData.goalLabel ?? null
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="v7-top-matter">
+      <V7FreshnessStrip />
+      <V7SharpenLine briefWording={briefWording} inputs={sharpenInputs} onFocusNode={onFocusNode} />
+      <V7Hero
+        recommendation={recommendation}
+        decisionState={decisionState}
+        topDrivers={drivers.topDrivers}
+        fragileEdges={confidence.challengeFragileEdges}
+        onFocusNode={onFocusNode}
+        onSendMessage={onSendMessage}
+      />
+    </div>
+  )
+}
+
+export default V7TopMatter

--- a/src/components/results/v7/__tests__/buildV7Headline.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Headline.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * buildV7Headline — V7 Lane L4 pins for the passthrough hero headline.
+ *
+ * The hero copy must be composed ONLY from store values (no invented number or
+ * claim), and must use the production template forms verbatim. These pins lock
+ * each branch to its exact string and prove the gauge value is the winner's own
+ * win probability.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildV7Headline } from '../buildV7Headline'
+import type { DecisionResultData, OptionResult } from '../../types'
+
+function opt(id: string, label: string, winProbability: number, isRecommended = false): OptionResult {
+  return { id, label, winProbability, isRecommended } as unknown as OptionResult
+}
+
+function rec(partial: Partial<DecisionResultData>): DecisionResultData {
+  return partial as DecisionResultData
+}
+
+describe('buildV7Headline — passthrough hero copy (V7 L4)', () => {
+  it('clear winner → "{winner} performs best", gauge = winner win probability', () => {
+    const winner = opt('a', 'Option A', 0.71, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.3)] }),
+      'robust',
+    )
+    expect(model.headline).toBe('Option A performs best')
+    expect(model.winProbability).toBe(0.71)
+    expect(model.winnerLabel).toBe('Option A')
+  })
+
+  it('clear winner subline names the lead in points from the real runner-up gap', () => {
+    const winner = opt('a', 'Option A', 0.7, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.3)] }),
+      'robust',
+    )
+    // 0.70 − 0.30 = 40 points — derived, never fabricated.
+    expect(model.subline).toBe('Leads by 40 points')
+  })
+
+  it('near-tie → "Too close to call" (from recommendation.nearTie)', () => {
+    const winner = opt('a', 'Option A', 0.52, true)
+    const model = buildV7Headline(
+      rec({
+        recommendedOption: winner,
+        allOptions: [winner, opt('b', 'Option B', 0.48)],
+        nearTie: { isTie: true, topOptionId: 'a', secondOptionId: 'b', tiedOptionIds: ['a', 'b'], gap: 0.04, threshold: 0.1 },
+      }),
+      'sensitive',
+    )
+    expect(model.headline).toBe('Too close to call')
+    expect(model.subline).toBe('Option A leads slightly more often')
+  })
+
+  it('indeterminate decision state → "No clear leading option"', () => {
+    const winner = opt('a', 'Option A', 0.34, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.33)] }),
+      'indeterminate',
+    )
+    expect(model.headline).toBe('No clear leading option')
+  })
+
+  it('single option → "{winner} is your only option"', () => {
+    const winner = opt('a', 'Option A', 0.9, true)
+    const model = buildV7Headline(rec({ recommendedOption: winner, allOptions: [winner] }), 'robust')
+    expect(model.headline).toBe('Option A is your only option')
+  })
+
+  it('no winner → empty headline (honest absence, hero renders nothing)', () => {
+    const model = buildV7Headline(rec({ recommendedOption: null, allOptions: [] }), 'indeterminate')
+    expect(model.headline).toBe('')
+    expect(model.winnerLabel).toBeNull()
+  })
+
+  it('winner without a win probability → null gauge value, no fabricated number', () => {
+    const winner = { id: 'a', label: 'Option A', isRecommended: true } as unknown as OptionResult
+    const model = buildV7Headline(rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.3)] }), 'robust')
+    expect(model.winProbability).toBeNull()
+    expect(model.headline).toBe('Option A performs best')
+    // No runner-up gap is claimed when the winner carries no probability.
+    expect(model.subline).toBeNull()
+  })
+})

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -1,0 +1,114 @@
+/**
+ * buildV7Headline — pure passthrough for the V7 hero headline (V7 Lane L4).
+ *
+ * Composes the hero headline + subline from EXISTING results-store data only —
+ * never invents a number or a claim (V6-RESPEC-2026-07-23 §L4: "UI IS A
+ * PASSTHROUGH"). Every string form below is sourced VERBATIM from a live
+ * production headline surface, so "Headline copy matches production strings"
+ * (spec row 3 done-when) holds:
+ *
+ *   · "{winner} performs best"        — M1 winner headline
+ *     (src/components/debug/utils/exportBundle.ts `deriveHeroHeadline`;
+ *      src/canvas/components/ResultsPanel/OptionComparisonReveal.tsx)
+ *   · "{winner} is your only option"  — single-option form
+ *     (src/components/results/utils/certaintyCopy.ts rule 3)
+ *   · "No clear leading option"       — indeterminate / GAP form
+ *     (certaintyCopy.ts rule 1: "no clear leading option, …")
+ *   · "Too close to call"             — near-tie form (recommendation.nearTie)
+ *   · "{winner} leads slightly more often" / " by N points" sublines
+ *     (certaintyCopy.ts rules 1 and 4)
+ *
+ * Honest absence: with no recommended option the headline is empty and the
+ * hero renders nothing (the caller gates the whole top group on analysis
+ * presence). The gauge value is the winner's live win probability, or null.
+ */
+
+import type { DecisionResultData, DecisionState } from '../types'
+
+export interface V7HeadlineModel {
+  /** Main headline. Empty string when there is no winner to headline. */
+  headline: string
+  /** One-line subhead, or null when no honest subline applies. */
+  subline: string | null
+  /** Winner win probability in [0,1] for the gauge, or null when absent. */
+  winProbability: number | null
+  /** Winner display label, or null. */
+  winnerLabel: string | null
+}
+
+/**
+ * @param recommendation `resultsSectionData.recommendation` (DecisionResultData)
+ * @param decisionState  `buildResultsVM(...).decisionState` — the SAME tri-state
+ *   the live hero uses ('robust' | 'sensitive' | 'indeterminate').
+ */
+export function buildV7Headline(
+  recommendation: DecisionResultData,
+  decisionState: DecisionState,
+): V7HeadlineModel {
+  const winner = recommendation.recommendedOption ?? null
+  const allOptions = recommendation.allOptions ?? []
+  const optionCount = allOptions.length
+  const winnerLabel = winner?.label ?? null
+  const winProbability =
+    typeof winner?.winProbability === 'number' && Number.isFinite(winner.winProbability)
+      ? winner.winProbability
+      : null
+
+  // No winner → nothing to headline (honest absence; caller renders nothing).
+  if (!winnerLabel) {
+    return { headline: '', subline: null, winProbability, winnerLabel: null }
+  }
+
+  // Single option — the honest "only option" form.
+  if (optionCount === 1) {
+    return {
+      headline: `${winnerLabel} is your only option`,
+      subline: null,
+      winProbability,
+      winnerLabel,
+    }
+  }
+
+  // Near-tie — the producer's near-tie detection (recommendation.nearTie).
+  if (recommendation.nearTie?.isTie === true) {
+    return {
+      headline: 'Too close to call',
+      subline: `${winnerLabel} leads slightly more often`,
+      winProbability,
+      winnerLabel,
+    }
+  }
+
+  // Indeterminate (GAP) — no clear leader.
+  if (decisionState === 'indeterminate') {
+    return {
+      headline: 'No clear leading option',
+      subline: `${winnerLabel} leads slightly more often`,
+      winProbability,
+      winnerLabel,
+    }
+  }
+
+  // Clear winner — "performs best". Subline names the lead in points when the
+  // runner-up carries a win probability we can difference against (store-derived,
+  // never fabricated).
+  const runnerUp = allOptions
+    .filter(o => o.id !== winner?.id)
+    .filter((o): o is typeof o & { winProbability: number } => typeof o.winProbability === 'number')
+    .sort((a, b) => b.winProbability - a.winProbability)[0]
+  const gapPoints =
+    winProbability != null && runnerUp
+      ? Math.round((winProbability - runnerUp.winProbability) * 100)
+      : null
+  const subline =
+    gapPoints != null && gapPoints > 0
+      ? `Leads by ${gapPoints} point${gapPoints === 1 ? '' : 's'}`
+      : null
+
+  return {
+    headline: `${winnerLabel} performs best`,
+    subline,
+    winProbability,
+    winnerLabel,
+  }
+}

--- a/tests/ci-guards/complete-borders.spec.ts
+++ b/tests/ci-guards/complete-borders.spec.ts
@@ -81,6 +81,13 @@ const CONTENT_CARD_FILES = [
   'canvas/components/model-tab/ModelTabHeader.tsx',
   'canvas/ui/inspector/InspectorGuidanceSection.tsx',
   'components/assistants/ProvenanceChip.tsx',
+  // V7 Lane L4 — top-matter content cards (complete borders only).
+  'components/results/v7/V7TopMatter.tsx',
+  'components/results/v7/V7Hero.tsx',
+  'components/results/v7/V7SignalRow.tsx',
+  'components/results/v7/V7SuggestedChips.tsx',
+  'components/results/v7/V7SharpenLine.tsx',
+  'components/results/v7/V7FreshnessStrip.tsx',
 ]
 
 /** Single-side border width with an arbitrary value: `border-l-[3px]`. */


### PR DESCRIPTION
## V7 Lane L4 — V7 top matter (additive, flagless)

Fills the L3 `v7-top-group` slot (above the **Current view** divider) with the V7 top matter. Additive and passthrough per **V6-RESPEC-2026-07-23 §L4**: reads the SAME `resultsSectionData` + `vm` the live panel below consumes, invents no numbers, and nothing below the divider changes. Ships **ON, no flag**.

### Components (each with the store selector it reads)
| Component | Store selectors read |
|---|---|
| **V7Hero** (gauge + headline + subline) | `recommendation.recommendedOption.{label,winProbability}`, `recommendation.allOptions`, `recommendation.nearTie`, `vm.decisionState` |
| **V7SignalRow** (flip-risk + main-driver chips) | `confidence.challengeFragileEdges[0]`, `drivers.topDrivers[0]` |
| **V7SharpenLine** (brief quote + inputs + model-limit caveat) | `recommendation.goalText` (→ `goalLabel`), `confidence.topEvidenceGaps` |
| **V7SuggestedChips** (max 2) | `guidanceStore.guidanceItems` ordered by `compareGuidanceDisplayOrder`; dispatched via the existing `onSendMessage` path |
| **V7FreshnessStrip** | `analysisFreshness` + `analysisFreshnessDirty` → `classifyFreshnessForDisplay`; copy from `FRESHNESS_COPY` |

### Headline — production strings verbatim (`buildV7Headline`)
"{winner} performs best" · "Too close to call" (near-tie) · "No clear leading option" (indeterminate) · "{winner} is your only option" — each sourced from a named live surface (`deriveHeroHeadline` / `OptionComparisonReveal` / `certaintyCopy`). Gauge reads the winner's live win probability.

### Honesty
- **SKIPPED** (no store selector): the sharpen line's conversation-aware *reframed question* is model output not carried on the results store — not rendered (would breach passthrough).
- **No duplicate verdict / Rerun**: the hero does not own the robustness verdict and the freshness strip carries **no Rerun** — `AnalysisFooter` stays the single owner of both (spec P1 + single-Rerun invariant). Deliberate deviation from the prototype's "+ Rerun".
- Every component renders **nothing** when its backing data is absent; `V7TopMatter` returns `null` pre-analysis so `empty:hidden` keeps the group out of layout.

### Tests (RED-first)
- `buildV7Headline.spec.ts` — 7 pins on the template forms + gauge value + honest absence.
- `ResultsBody.v7TopMatter.spec.tsx` — top-group presence above the divider, **renders NOTHING pre-analysis**, **max-2 chips**, freshness verdict, no-invented-content. RED verified: with the mount removed, 4/5 integration pins fail.
- **L3 scaffold pins stay green**; the 6 new files are added to the **complete-borders guard** scan set.

### Gates
`pnpm run typecheck` exit 0 (zero net-new) · results-panel suites **158 files / 3292 tests** green · L3 pins + complete-borders guard green · eslint clean (`no-irregular-whitespace`) · `pnpm build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)