### PR TITLE
feat(v7-l5): lens group (Likely outcome / Goal fit / Stability / What changed) + evidence disclosure

### DIFF
--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -1,0 +1,256 @@
+/**
+ * V7EvidenceDisclosure — one expandable evidence section with three views
+ * (V7 Lane L5, spec row 7).
+ *
+ * A single disclosure ("Why, and what could change it") hosting three tabs:
+ *   · Drivers — producer rank order (drivers.drivers, already ranked upstream),
+ *     top 3 with "Show N more" expansion; a +/- direction sign (producer
+ *     direction, omitted when absent) and an "est." tag when the factor value
+ *     or its confidence was defaulted (a direct producer boolean read, never a
+ *     threshold). Rows focus the factor on canvas when a target exists.
+ *   · Flip risks — challengeFragileEdges (the SAME fragile-edge slice the
+ *     signal row + stress test consume): "{from} → {to}" with the producer
+ *     switch probability as row meta.
+ *   · Trade-offs — conditional_winners narrated verbatim from producer values
+ *     (factor label, split value/unit, winner labels); nothing invented.
+ *
+ * Each tab renders its live rows or an honest gate — never a fabricated list.
+ * Tabs use aria-pressed toggle buttons (not role=tab): the disclosure body is
+ * not a full WAI-ARIA tablist and must not promise roving-tabindex it does not
+ * implement (same rationale as the live HeroEvidenceDisclosure).
+ *
+ * PASSTHROUGH only, reads existing store fields, invents no numbers, ships
+ * flagless. COMPLETE borders only (L1 guard).
+ */
+
+import { useState } from 'react'
+import { ChevronDown, AlertTriangle, Crosshair, GitBranch } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { formatPercent } from '@/utils/formatPercent'
+import { formatRangeValue } from '../utils/formatRangeValue'
+import type { V7EvidenceModel } from './buildV7Lenses'
+import { V7_LENS_COPY } from './v7LensCopy'
+
+const E = V7_LENS_COPY.evidence
+const VISIBLE_DRIVERS = 3
+
+type EvidenceView = 'drivers' | 'flipRisks' | 'tradeOffs'
+
+export interface V7EvidenceDisclosureProps {
+  evidence: V7EvidenceModel
+  onFocusNode?: (nodeId: string) => void
+}
+
+export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclosureProps) {
+  const [open, setOpen] = useState(false)
+  const [view, setView] = useState<EvidenceView>('drivers')
+  const [showAllDrivers, setShowAllDrivers] = useState(false)
+
+  const hasDrivers = evidence.drivers.length > 0
+  const hasFlipRisks = evidence.flipRisks.length > 0
+  const hasTradeOffs = evidence.tradeOffs.length > 0
+
+  // Nothing to disclose at all → render nothing (never an empty shell).
+  if (!hasDrivers && !hasFlipRisks && !hasTradeOffs) return null
+
+  const views: Array<{ key: EvidenceView; label: string }> = [
+    { key: 'drivers', label: E.driversTab },
+    { key: 'flipRisks', label: E.flipRisksTab },
+    { key: 'tradeOffs', label: E.tradeOffsTab },
+  ]
+
+  const visibleDrivers = showAllDrivers ? evidence.drivers : evidence.drivers.slice(0, VISIBLE_DRIVERS)
+  const moreCount = evidence.drivers.length - VISIBLE_DRIVERS
+
+  return (
+    <section
+      data-testid="v7-evidence-disclosure"
+      className="rounded-lg border border-panel-border bg-panel px-3 py-1.5"
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 rounded py-1.5 text-left transition-colors hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info"
+      >
+        <span className="min-w-0 flex-1">
+          <span className={`${typography.panelHeader} block text-text-header`}>{E.heading}</span>
+          <span className={`${typography.panelMeta} block text-text-light`}>{E.subtitle}</span>
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`h-3.5 w-3.5 flex-none text-text-light transition-transform motion-reduce:transition-none ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="mt-1 space-y-2 pb-2">
+          <div className="flex flex-wrap gap-1" role="group" aria-label="Evidence view">
+            {views.map((v) => (
+              <button
+                key={v.key}
+                type="button"
+                aria-pressed={view === v.key}
+                onClick={() => setView(v.key)}
+                data-testid={`v7-evidence-tab-${v.key}`}
+                className={`px-2 py-0.5 rounded-full ${typography.panelMeta} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info ${
+                  view === v.key
+                    ? 'bg-primary text-text-on-color'
+                    : 'border border-panel-border bg-transparent text-text-light hover:border-info hover:text-text-body'
+                }`}
+              >
+                {v.label}
+              </button>
+            ))}
+          </div>
+
+          {view === 'drivers' && (
+            <div className="space-y-1.5" data-testid="v7-evidence-drivers">
+              {hasDrivers ? (
+                <>
+                  <p className={`${typography.panelMeta} text-text-light`}>{E.driversNote}</p>
+                  {visibleDrivers.map((d, i) => {
+                    const canFocus = Boolean(d.focusId && onFocusNode)
+                    const body = (
+                      <span className={`${typography.panelBody} flex min-w-0 items-center gap-1.5 text-left text-text-body`}>
+                        {canFocus && <Crosshair aria-hidden="true" className="h-3 w-3 flex-none text-info" />}
+                        {d.direction && (
+                          <span
+                            aria-hidden="true"
+                            data-testid="v7-driver-sign"
+                            className={`font-semibold ${d.direction === 'positive' ? 'text-success' : 'text-danger'}`}
+                          >
+                            {d.direction === 'positive' ? '+' : '-'}
+                          </span>
+                        )}
+                        <span className="min-w-0 truncate">{d.label}</span>
+                        {d.direction && (
+                          <span className="sr-only">
+                            ({d.direction === 'positive' ? 'increases the outcome' : 'decreases the outcome'})
+                          </span>
+                        )}
+                        {d.isEstimate && (
+                          <span
+                            data-testid="v7-driver-est"
+                            aria-label={E.estimateTagAria}
+                            className={`${typography.panelMeta} flex-none rounded-full border border-panel-border bg-transparent px-1.5 py-0 text-text-light`}
+                          >
+                            {E.estimateTag}
+                          </span>
+                        )}
+                      </span>
+                    )
+                    return canFocus ? (
+                      <button
+                        key={`${d.factorKey}-${i}`}
+                        type="button"
+                        onClick={() => onFocusNode?.(d.focusId as string)}
+                        className="flex w-full rounded py-0.5 transition-colors hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info"
+                      >
+                        {body}
+                      </button>
+                    ) : (
+                      <div key={`${d.factorKey}-${i}`} className="py-0.5">
+                        {body}
+                      </div>
+                    )
+                  })}
+                  {moreCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowAllDrivers((s) => !s)}
+                      data-testid="v7-drivers-toggle"
+                      className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                    >
+                      {showAllDrivers ? E.showFewer : E.seeMore(moreCount)}
+                    </button>
+                  )}
+                </>
+              ) : (
+                <p className={`${typography.panelBody} text-text-light`} data-testid="v7-evidence-drivers-gate">
+                  {E.driversGate}
+                </p>
+              )}
+            </div>
+          )}
+
+          {view === 'flipRisks' && (
+            <div className="space-y-1.5" data-testid="v7-evidence-flip-risks">
+              {hasFlipRisks ? (
+                <>
+                  <p className={`${typography.panelMeta} text-text-light`}>{E.flipRisksNote}</p>
+                  {evidence.flipRisks.map((r, i) => {
+                    const canFocus = Boolean(r.fromId && onFocusNode)
+                    const body = (
+                      <>
+                        <span className={`${typography.panelBody} flex min-w-0 items-center gap-1.5 text-left text-text-body`}>
+                          <AlertTriangle aria-hidden="true" className="h-3 w-3 flex-none text-warning" />
+                          <span className="min-w-0 truncate">
+                            {r.fromLabel} → {r.toLabel}
+                          </span>
+                        </span>
+                        {r.switchProbability != null && (
+                          <span className={`${typography.panelMeta} whitespace-nowrap text-right text-text-light`}>
+                            {E.flipSwitchMeta(formatPercent(r.switchProbability, { fromDecimal: true }))}
+                          </span>
+                        )}
+                      </>
+                    )
+                    const grid = 'grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-2'
+                    return canFocus ? (
+                      <button
+                        key={i}
+                        type="button"
+                        onClick={() => onFocusNode?.(r.fromId as string)}
+                        className={`${grid} rounded py-0.5 text-left transition-colors hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                      >
+                        {body}
+                      </button>
+                    ) : (
+                      <div key={i} className={`${grid} py-0.5`}>
+                        {body}
+                      </div>
+                    )
+                  })}
+                </>
+              ) : (
+                <p className={`${typography.panelBody} text-text-light`} data-testid="v7-evidence-flip-risks-gate">
+                  {E.flipRisksGate}
+                </p>
+              )}
+            </div>
+          )}
+
+          {view === 'tradeOffs' && (
+            <div className="space-y-1.5" data-testid="v7-evidence-trade-offs">
+              {hasTradeOffs ? (
+                <>
+                  <p className={`${typography.panelMeta} text-text-light`}>{E.tradeOffsNote}</p>
+                  {evidence.tradeOffs.map((t, i) => (
+                    <div key={`${t.factorId}-${i}`} className="flex items-start gap-1.5">
+                      <GitBranch aria-hidden="true" className="mt-0.5 h-3 w-3 flex-none text-info" />
+                      <p className={`${typography.panelBody} text-text-body`}>
+                        {E.tradeOffSplit(
+                          t.factorLabel,
+                          `${formatRangeValue(t.splitValue)}${t.splitUnit ? ` ${t.splitUnit}` : ''}`,
+                          t.highWinnerLabel,
+                          t.lowWinnerLabel,
+                        )}
+                      </p>
+                    </div>
+                  ))}
+                </>
+              ) : (
+                <p className={`${typography.panelBody} text-text-light`} data-testid="v7-evidence-trade-offs-gate">
+                  {E.tradeOffsGate}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default V7EvidenceDisclosure

--- a/src/components/results/v7/V7LensGroup.tsx
+++ b/src/components/results/v7/V7LensGroup.tsx
@@ -1,0 +1,349 @@
+/**
+ * V7LensGroup — the single lens control + four lens bodies (V7 Lane L5,
+ * spec rows 6/6a/6b/6c/6d).
+ *
+ * ONE control switches four lenses over the SAME resultsSectionData the live
+ * panel below consumes:
+ *   · Likely outcome — p10/p50/p90 range bars + win probability per option,
+ *     from recommendation.allOptions (the fields OptionCards consumes), on the
+ *     shared OptionCards scale.
+ *   · Goal fit — per-option goal probability, gated exactly like OptionCards'
+ *     "Hits target"; the honest gate distinguishes no-target from producer-gap.
+ *   · Stability — the honest gap (not produced; Olumi will not infer it).
+ *   · What changed in the result — run-over-run comparison from local run
+ *     history (read-only; see V7WhatChangedLens), else the honest empty state.
+ *
+ * WAI-ARIA tabs: role=tablist with roving tabindex (Left/Right + Home/End),
+ * only the active tab in the tab order. All four tabs always render and stay
+ * selectable; a lens without data is muted (with a screen-reader cue) and its
+ * body renders the honest gate — never a dead tab, never a fabricated chart.
+ * Lens switching is pure local render state (no fetch, no rerun).
+ *
+ * ADDITIVE + PASSTHROUGH: reads existing store data, returns null when there
+ * are no analysed options, invents no numbers, ships flagless. COMPLETE
+ * borders only (L1 guard) — the tab strip and card carry full borders, the
+ * selected tab uses the bg-primary treatment (no one-sided underline accent).
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { typography } from '@/styles/typography'
+import { formatPercent, formatProbabilityWithResolution } from '@/utils/formatPercent'
+import { formatRangeValue } from '../utils/formatRangeValue'
+import { loadRuns, type StoredRun } from '@/canvas/store/runHistory'
+import * as runsBus from '@/canvas/store/runsBus'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { OptionResult } from '../types'
+import { buildV7Lenses } from './buildV7Lenses'
+import { V7_LENS_COPY } from './v7LensCopy'
+import { SUB_ONE_PERCENT_FLOOR } from '../utils/displayFloors'
+import { V7WhatChangedLens } from './V7WhatChangedLens'
+
+export type V7Lens = 'outcome' | 'goal' | 'stability' | 'whatChanged'
+
+const ALL_LENSES: readonly V7Lens[] = ['outcome', 'goal', 'stability', 'whatChanged']
+
+export interface V7LensGroupProps {
+  resultsSectionData: ResultsSectionDataReturn
+}
+
+/** Thin p10-to-p90 range bar with a median dot — replicates OptionCards'
+ * inline OptionRangeBar (layout only), sharing formatRangeValue so the
+ * numbers cannot drift from the cards below. */
+function V7RangeBar({
+  p10,
+  p50,
+  p90,
+  globalMin,
+  globalMax,
+}: {
+  p10: number
+  p50?: number
+  p90: number
+  globalMin: number
+  globalMax: number
+}) {
+  const span = globalMax - globalMin
+  if (span <= 0) return null
+  const leftPct = ((p10 - globalMin) / span) * 100
+  const widthPct = ((p90 - p10) / span) * 100
+  const dotPct = p50 != null ? ((p50 - globalMin) / span) * 100 : undefined
+  return (
+    <div data-testid="v7-range-bar">
+      <div className="relative" style={{ height: 4, background: 'var(--border-default)', borderRadius: 2 }}>
+        <div
+          className="absolute top-0 h-full rounded-sm"
+          style={{
+            left: `${leftPct}%`,
+            width: `${Math.max(2, widthPct)}%`,
+            background: 'color-mix(in srgb, var(--info) 30%, transparent)',
+          }}
+        />
+        {dotPct != null && (
+          <div
+            className="absolute top-1/2 rounded-full"
+            style={{
+              left: `${dotPct}%`,
+              width: 8,
+              height: 8,
+              background: 'var(--info)',
+              border: '1.5px solid var(--bg-panel)',
+              transform: 'translate(-50%, -50%)',
+            }}
+          />
+        )}
+      </div>
+      <div className={`flex justify-between mt-0.5 ${typography.panelMeta}`}>
+        <span className="text-text-light">{formatRangeValue(p10)}</span>
+        {p50 != null && <span className="text-text-header">{formatRangeValue(p50)}</span>}
+        <span className="text-text-light">{formatRangeValue(p90)}</span>
+      </div>
+    </div>
+  )
+}
+
+/** Likely-outcome option row: label + win readout, then the range bar. */
+function OutcomeRow({
+  option,
+  isWinner,
+  globalMin,
+  globalMax,
+}: {
+  option: OptionResult
+  isWinner: boolean
+  globalMin: number
+  globalMax: number
+}) {
+  const win =
+    typeof option.winProbability === 'number' && Number.isFinite(option.winProbability)
+      ? formatProbabilityWithResolution(option.winProbability, option.nValidSamples)
+      : null
+  const p10 = option.outcome?.p10
+  const p90 = option.outcome?.p90
+  const hasRange = typeof p10 === 'number' && typeof p90 === 'number'
+  return (
+    <div className="space-y-1" data-testid="v7-outcome-row" data-option-id={option.id}>
+      <div className="flex items-baseline justify-between gap-2">
+        <span
+          className={`${typography.panelBody} min-w-0 truncate ${isWinner ? 'text-text-header font-semibold' : 'text-text-body'}`}
+          title={option.label}
+        >
+          {option.label}
+        </span>
+        {win && (
+          <span className={`${typography.panelMeta} whitespace-nowrap ${isWinner ? 'text-text-header' : 'text-text-light'}`}>
+            {V7_LENS_COPY.outcome.winReadout(win)}
+          </span>
+        )}
+      </div>
+      {hasRange && (
+        <V7RangeBar
+          p10={p10 as number}
+          p50={option.outcome?.p50 ?? option.outcome?.mean ?? undefined}
+          p90={p90 as number}
+          globalMin={globalMin}
+          globalMax={globalMax}
+        />
+      )}
+    </div>
+  )
+}
+
+/** Goal-fit probability bar (mirrors OptionCards' "Hits target" StatBar). */
+function GoalRow({
+  label,
+  probability,
+  isWinner,
+}: {
+  label: string
+  probability: number
+  isWinner: boolean
+}) {
+  const readout =
+    probability < SUB_ONE_PERCENT_FLOOR
+      ? V7_LENS_COPY.goal.subOnePercent
+      : formatPercent(probability, { fromDecimal: true })
+  const widthPct = Math.max(2, Math.min(100, Math.round(probability * 100)))
+  return (
+    <div className="space-y-1" data-testid="v7-goal-row">
+      <div className="flex items-baseline justify-between gap-2">
+        <span
+          className={`${typography.panelBody} min-w-0 truncate ${isWinner ? 'text-text-header font-semibold' : 'text-text-body'}`}
+          title={label}
+        >
+          {label}
+        </span>
+        <span className={`${typography.panelMeta} whitespace-nowrap ${isWinner ? 'text-text-header' : 'text-text-light'}`}>
+          {V7_LENS_COPY.goal.hitReadout(readout)}
+        </span>
+      </div>
+      <div className="w-full rounded-full overflow-hidden" style={{ height: 5, background: 'var(--border-default)' }}>
+        <div className="h-full rounded-full bg-info" style={{ width: `${widthPct}%` }} />
+      </div>
+    </div>
+  )
+}
+
+function GateLine({ testId, children }: { testId: string; children: React.ReactNode }) {
+  return (
+    <p className={`${typography.panelBody} text-text-light`} data-testid={testId}>
+      {children}
+    </p>
+  )
+}
+
+export function V7LensGroup({ resultsSectionData }: V7LensGroupProps) {
+  const [active, setActive] = useState<V7Lens>('outcome')
+  const tabRefs = useRef<Partial<Record<V7Lens, HTMLButtonElement | null>>>({})
+
+  // Live run history (read-only) — powers the What-changed lens body and its
+  // tab availability. One read here; V7WhatChangedLens is a pure leaf.
+  const [runs, setRuns] = useState<StoredRun[]>(() => loadRuns())
+  useEffect(() => {
+    const unsub = runsBus.on(() => setRuns(loadRuns()))
+    return unsub
+  }, [])
+
+  const model = buildV7Lenses(resultsSectionData)
+  const options = resultsSectionData.recommendation.allOptions ?? []
+
+  // Analysis-presence guard (belt-and-suspenders — V7TopMatter already gates).
+  if (options.length === 0) return null
+
+  const available: Record<V7Lens, boolean> = {
+    outcome: model.outcome.available,
+    goal: model.goal.available,
+    stability: false, // per-option stability is never on the wire (honest gap)
+    whatChanged: runs.length >= 2,
+  }
+
+  const moveTo = (index: number) => {
+    const count = ALL_LENSES.length
+    const next = ALL_LENSES[(index + count) % count]
+    setActive(next)
+    tabRefs.current[next]?.focus()
+  }
+  const onKeyDown = (e: React.KeyboardEvent, index: number) => {
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault()
+        moveTo(index + 1)
+        break
+      case 'ArrowLeft':
+        e.preventDefault()
+        moveTo(index - 1)
+        break
+      case 'Home':
+        e.preventDefault()
+        moveTo(0)
+        break
+      case 'End':
+        e.preventDefault()
+        moveTo(ALL_LENSES.length - 1)
+        break
+    }
+  }
+
+  const panelId = 'v7-lens-panel'
+
+  return (
+    <section
+      aria-label="Results lens"
+      data-testid="v7-lens-group"
+      className="rounded-lg border border-panel-border bg-panel px-3 py-3"
+    >
+      <div
+        role="tablist"
+        aria-label={V7_LENS_COPY.tablistAria}
+        className="flex gap-0.5 rounded-full border border-panel-border p-0.5"
+      >
+        {ALL_LENSES.map((lens, index) => {
+          const selected = lens === active
+          const isAvailable = available[lens]
+          return (
+            <button
+              key={lens}
+              ref={(el) => {
+                tabRefs.current[lens] = el
+              }}
+              type="button"
+              role="tab"
+              id={`${panelId}-tab-${lens}`}
+              aria-selected={selected}
+              aria-controls={panelId}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => setActive(lens)}
+              onKeyDown={(e) => onKeyDown(e, index)}
+              data-testid={`v7-lens-tab-${lens}`}
+              data-available={isAvailable ? 'true' : 'false'}
+              className={`${typography.panelMeta} flex-1 whitespace-nowrap rounded-full px-2 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info ${
+                selected
+                  ? 'bg-primary text-text-on-color'
+                  : isAvailable
+                    ? 'bg-transparent text-text-light hover:bg-panel-hover hover:text-text-body'
+                    : 'bg-transparent text-text-light opacity-60 hover:bg-panel-hover'
+              }`}
+            >
+              {V7_LENS_COPY.lensLabel[lens]}
+              {!isAvailable && <span className="sr-only"> ({V7_LENS_COPY.srLensUnavailable})</span>}
+            </button>
+          )
+        })}
+      </div>
+
+      <div id={panelId} role="tabpanel" aria-labelledby={`${panelId}-tab-${active}`} className="mt-3">
+        {active === 'outcome' &&
+          (model.outcome.available ? (
+            <div className="space-y-2.5" data-testid="v7-lens-outcome">
+              {model.outcome.options.map((o) => (
+                <OutcomeRow
+                  key={o.id}
+                  option={o}
+                  isWinner={o.id === model.outcome.winnerId}
+                  globalMin={model.outcome.globalMin}
+                  globalMax={model.outcome.globalMax}
+                />
+              ))}
+              {model.outcome.hasRange && (
+                <p className={`${typography.panelMeta} text-text-light`}>{V7_LENS_COPY.outcome.caption}</p>
+              )}
+            </div>
+          ) : (
+            <GateLine testId="v7-lens-outcome-gate">{V7_LENS_COPY.outcome.gate}</GateLine>
+          ))}
+
+        {active === 'goal' &&
+          (model.goal.available ? (
+            <div className="space-y-2.5" data-testid="v7-lens-goal">
+              {model.goal.options.map((o) => (
+                <GoalRow key={o.id} label={o.label} probability={o.goalProbability} isWinner={o.isWinner} />
+              ))}
+              <p className={`${typography.panelMeta} text-text-light`}>{V7_LENS_COPY.goal.caption}</p>
+            </div>
+          ) : (
+            <GateLine testId="v7-lens-goal-gate">
+              {model.goal.gate === 'no_target'
+                ? V7_LENS_COPY.goal.gateNoTarget
+                : V7_LENS_COPY.goal.gateProducerGap}
+            </GateLine>
+          ))}
+
+        {active === 'stability' && (
+          <div data-testid="v7-lens-stability">
+            <p className={`${typography.panelBody} text-text-header font-semibold`}>
+              {V7_LENS_COPY.stability.heading}
+            </p>
+            <GateLine testId="v7-lens-stability-gate">{V7_LENS_COPY.stability.gate}</GateLine>
+          </div>
+        )}
+
+        {active === 'whatChanged' && (
+          <div data-testid="v7-lens-what-changed">
+            <V7WhatChangedLens runs={runs} />
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default V7LensGroup

--- a/src/components/results/v7/V7TopMatter.tsx
+++ b/src/components/results/v7/V7TopMatter.tsx
@@ -19,6 +19,9 @@ import type { DecisionState } from '../types'
 import { V7FreshnessStrip } from './V7FreshnessStrip'
 import { V7SharpenLine, type V7SharpenInput } from './V7SharpenLine'
 import { V7Hero } from './V7Hero'
+import { V7LensGroup } from './V7LensGroup'
+import { V7EvidenceDisclosure } from './V7EvidenceDisclosure'
+import { buildV7Lenses } from './buildV7Lenses'
 
 export interface V7TopMatterProps {
   resultsSectionData: ResultsSectionDataReturn
@@ -48,6 +51,12 @@ export function V7TopMatter({
   }))
   const briefWording = recommendation.goalText ?? resultsSectionData.goalLabel ?? null
 
+  // L5 lens group + evidence disclosure — passthrough over the SAME
+  // resultsSectionData the live panel consumes. The evidence model is built
+  // once here and handed to the disclosure; the lens group reads live fields
+  // (and local run history for the What-changed lens) itself.
+  const { evidence } = buildV7Lenses(resultsSectionData)
+
   return (
     <div className="flex flex-col gap-4" data-testid="v7-top-matter">
       <V7FreshnessStrip />
@@ -60,6 +69,8 @@ export function V7TopMatter({
         onFocusNode={onFocusNode}
         onSendMessage={onSendMessage}
       />
+      <V7LensGroup resultsSectionData={resultsSectionData} />
+      <V7EvidenceDisclosure evidence={evidence} onFocusNode={onFocusNode} />
     </div>
   )
 }

--- a/src/components/results/v7/V7WhatChangedLens.tsx
+++ b/src/components/results/v7/V7WhatChangedLens.tsx
@@ -1,0 +1,111 @@
+/**
+ * V7WhatChangedLens — the "What changed in the result" lens body (V7 Lane L5,
+ * spec row 6d + Paul-question P4).
+ *
+ * Reads LOCAL run history READ-ONLY and renders a run-over-run summary — the
+ * p50 median (with delta), the model-edges-changed line, and the drivers
+ * added/removed — from the two most recent stored runs, or the honest empty
+ * state "Snapshot unavailable — rerun to compare." when fewer than two runs
+ * exist. That empty state is the COMMON CASE on the live V5 path: run
+ * history's only writer is Run-button-gated on results.seed, so it is usually
+ * empty (verified live, PR #426 saga).
+ *
+ * ⚠ DELIBERATE, FLAGGED DEVIATION (see PR body): src/canvas/store/runHistory.ts
+ * carries a "must NEVER back a 'What changed' surface … Do not wire this in"
+ * header. V6-RESPEC-2026-07-23 row 6d + the L5 brief explicitly override that
+ * for READ-ONLY consumption on this new lens (Paul-ruled, dated). This
+ * component adds NO new writers to run history — it only reads the existing
+ * compareRuns / computeRunSummary exports — and never fabricates a comparison.
+ *
+ * Presentational leaf: the live run array is passed in (owned by V7LensGroup),
+ * so this component is a pure function of its props. COMPLETE borders only.
+ */
+
+import { typography } from '@/styles/typography'
+import { compareRuns, computeRunSummary, type StoredRun } from '@/canvas/store/runHistory'
+import { V7_LENS_COPY } from './v7LensCopy'
+
+const C = V7_LENS_COPY.whatChanged
+
+export interface V7WhatChangedLensProps {
+  /** The live run array (latest first), read once in V7LensGroup. */
+  runs: StoredRun[]
+}
+
+function driverLabel(d: { id?: string; label?: string }): string {
+  return d.label ?? d.id ?? 'Unknown driver'
+}
+
+export function V7WhatChangedLens({ runs }: V7WhatChangedLensProps) {
+  const latest = runs[0]
+  const prior = runs[1]
+
+  // Honest empty state — the common case. Fewer than two runs means there is
+  // nothing to compare; never fabricate a delta.
+  if (!latest || !prior) {
+    return (
+      <div data-testid="v7-what-changed-empty">
+        <p className={`${typography.panelBody} text-text-header font-semibold`}>{C.heading}</p>
+        <p className={`${typography.panelBody} text-text-body mt-1`}>{C.empty}</p>
+        <p className={`${typography.panelMeta} text-text-light mt-1`}>{C.emptyDetail}</p>
+      </div>
+    )
+  }
+
+  const summary = computeRunSummary(latest, prior)
+  // compareRuns(A, B): driversAdded = in B not A. Pass prior as A and latest
+  // as B so "added" reads as new-in-the-latest-run and "removed" as gone-since.
+  const comparison = compareRuns(prior.id, latest.id)
+  const added = comparison?.driversAdded ?? []
+  const removed = comparison?.driversRemoved ?? []
+
+  return (
+    <div className="space-y-2" data-testid="v7-what-changed">
+      <p className={`${typography.panelBody} text-text-header font-semibold`}>{C.heading}</p>
+
+      <dl className="space-y-1.5">
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className={`${typography.panelMeta} text-text-light`}>{C.p50Label}</dt>
+          <dd className={`${typography.panelBody} text-text-body text-right`}>
+            {summary.p50Text}
+            {summary.deltaText && (
+              <span className="text-text-light" data-testid="v7-what-changed-delta">
+                {' '}
+                {summary.deltaText}
+              </span>
+            )}
+          </dd>
+        </div>
+        {summary.edgesChangedText && (
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className={`${typography.panelMeta} text-text-light`}>{C.edgesLabel}</dt>
+            <dd className={`${typography.panelBody} text-text-body text-right`} data-testid="v7-what-changed-edges">
+              {summary.edgesChangedText}
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      {added.length === 0 && removed.length === 0 ? (
+        <p className={`${typography.panelMeta} text-text-light`}>{C.noDriverChange}</p>
+      ) : (
+        <div className="space-y-1">
+          {added.length > 0 && (
+            <p className={`${typography.panelMeta} text-text-body`} data-testid="v7-what-changed-drivers-added">
+              <span className="text-text-header">{C.driversAddedLabel}:</span>{' '}
+              {added.map(driverLabel).join(', ')}
+            </p>
+          )}
+          {removed.length > 0 && (
+            <p className={`${typography.panelMeta} text-text-body`} data-testid="v7-what-changed-drivers-removed">
+              <span className="text-text-header">{C.driversRemovedLabel}:</span>{' '}
+              {removed.map(driverLabel).join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default V7WhatChangedLens

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
@@ -1,0 +1,95 @@
+/**
+ * V7EvidenceDisclosure — V7 Lane L5 pins for the three-tab evidence disclosure
+ * (spec row 7).
+ *
+ * Pins: the disclosure expands; Drivers clamp to three with a "Show N more"
+ * expansion; the "est." tag renders on a defaulted driver; the Flip risks and
+ * Trade-offs tabs render their live rows; the whole disclosure renders nothing
+ * when there is nothing to disclose.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
+import type { V7EvidenceModel } from '../buildV7Lenses'
+
+function model(partial: Partial<V7EvidenceModel>): V7EvidenceModel {
+  return {
+    drivers: partial.drivers ?? [],
+    flipRisks: partial.flipRisks ?? [],
+    tradeOffs: partial.tradeOffs ?? [],
+  }
+}
+
+const FIVE_DRIVERS: V7EvidenceModel['drivers'] = [
+  { factorKey: 'f1', label: 'Price', direction: 'negative', isEstimate: true },
+  { factorKey: 'f2', label: 'Demand', direction: 'positive', isEstimate: false },
+  { factorKey: 'f3', label: 'Cost', direction: 'negative', isEstimate: false },
+  { factorKey: 'f4', label: 'Speed', direction: 'positive', isEstimate: false },
+  { factorKey: 'f5', label: 'Risk', direction: null, isEstimate: false },
+]
+
+describe('V7EvidenceDisclosure (V7 L5)', () => {
+  it('renders nothing when there is nothing to disclose', () => {
+    const { container } = render(<V7EvidenceDisclosure evidence={model({})} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('expands to the Drivers view, clamps to three, and shows "Show N more"', () => {
+    render(<V7EvidenceDisclosure evidence={model({ drivers: FIVE_DRIVERS })} />)
+    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+    expect(screen.getByTestId('v7-evidence-drivers')).toBeInTheDocument()
+    expect(screen.getByText('Price')).toBeInTheDocument()
+    expect(screen.getByText('Cost')).toBeInTheDocument()
+    // Fourth+ drivers are clamped until expanded.
+    expect(screen.queryByText('Speed')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('v7-drivers-toggle'))
+    expect(screen.getByText('Speed')).toBeInTheDocument()
+    expect(screen.getByText('Risk')).toBeInTheDocument()
+  })
+
+  it('shows the "est." tag on a defaulted (low-confidence) driver', () => {
+    render(<V7EvidenceDisclosure evidence={model({ drivers: FIVE_DRIVERS })} />)
+    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+    const est = screen.getAllByTestId('v7-driver-est')
+    expect(est).toHaveLength(1)
+    expect(est[0]).toHaveTextContent('est.')
+  })
+
+  it('renders the Flip risks view from challengeFragileEdges values', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          flipRisks: [{ fromId: 'n1', fromLabel: 'Price', toLabel: 'Profit', switchProbability: 0.48 }],
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+    expect(screen.getByTestId('v7-evidence-flip-risks')).toBeInTheDocument()
+    expect(screen.getByText(/Price → Profit/)).toBeInTheDocument()
+    expect(screen.getByText(/48% switch/)).toBeInTheDocument()
+  })
+
+  it('renders the Trade-offs view narrated from conditional_winners values', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          tradeOffs: [
+            {
+              factorLabel: 'Interest rate',
+              factorId: 'n7',
+              splitValue: 5,
+              splitUnit: '%',
+              highWinnerLabel: 'Rent',
+              lowWinnerLabel: 'Buy',
+            },
+          ],
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+    fireEvent.click(screen.getByTestId('v7-evidence-tab-tradeOffs'))
+    expect(screen.getByTestId('v7-evidence-trade-offs')).toBeInTheDocument()
+    expect(screen.getByText(/If Interest rate is above 5 %, Rent leads; below it, Buy leads\./)).toBeInTheDocument()
+  })
+})

--- a/src/components/results/v7/__tests__/V7LensGroup.spec.tsx
+++ b/src/components/results/v7/__tests__/V7LensGroup.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * V7LensGroup — V7 Lane L5 pins for the single lens control + four lens bodies
+ * (spec rows 6/6a/6b/6c/6d).
+ *
+ * Pins: all four tabs render; each lens body renders its live data OR its
+ * honest gate on switch; the goal lens gates (no-target) vs shows bars; the
+ * stability lens is ALWAYS the honest gap; the What-changed lens shows the
+ * honest empty state on empty run history; the group renders nothing with no
+ * analysed options.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { V7LensGroup } from '../V7LensGroup'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import type { OptionResult } from '../../types'
+
+function opt(
+  id: string,
+  label: string,
+  o: Partial<{ win: number; p10: number; p50: number; p90: number; goalProb: number | null }> = {},
+): OptionResult {
+  return {
+    id,
+    label,
+    expected: null,
+    outcome: { mean: null, p10: o.p10 ?? null, p50: o.p50 ?? null, p90: o.p90 ?? null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    winProbability: o.win,
+    goalProbability: o.goalProb ?? null,
+  } as unknown as OptionResult
+}
+
+function data(partial: {
+  allOptions: OptionResult[]
+  recommendedId?: string
+  goalThreshold?: number | null
+}): ResultsSectionDataReturn {
+  const recommendedOption = partial.allOptions.find((o) => o.id === partial.recommendedId) ?? null
+  return {
+    recommendation: {
+      allOptions: partial.allOptions,
+      recommendedOption,
+      goalThreshold: partial.goalThreshold ?? null,
+      outcomeUnit: 'count',
+    },
+    drivers: { drivers: [] },
+    confidence: { challengeFragileEdges: [], conditionalWinners: [] },
+  } as unknown as ResultsSectionDataReturn
+}
+
+const WITH_RANGE = data({
+  allOptions: [
+    opt('a', 'Option A', { win: 0.7, p10: 10, p50: 20, p90: 30 }),
+    opt('b', 'Option B', { win: 0.3, p10: 5, p50: 12, p90: 25 }),
+  ],
+  recommendedId: 'a',
+})
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('V7LensGroup (V7 L5)', () => {
+  it('renders all four lens tabs', () => {
+    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    expect(screen.getByTestId('v7-lens-tab-outcome')).toBeInTheDocument()
+    expect(screen.getByTestId('v7-lens-tab-goal')).toBeInTheDocument()
+    expect(screen.getByTestId('v7-lens-tab-stability')).toBeInTheDocument()
+    expect(screen.getByTestId('v7-lens-tab-whatChanged')).toBeInTheDocument()
+  })
+
+  it('defaults to the Likely outcome lens with range bars and win readouts', () => {
+    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    expect(screen.getByTestId('v7-lens-outcome')).toBeInTheDocument()
+    expect(screen.getAllByTestId('v7-range-bar').length).toBe(2)
+    expect(screen.getByText(/Leads 70%/)).toBeInTheDocument()
+  })
+
+  it('shows the no-target gate on the Goal fit lens when no success target is set', () => {
+    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    fireEvent.click(screen.getByTestId('v7-lens-tab-goal'))
+    expect(screen.getByTestId('v7-lens-goal-gate')).toHaveTextContent('Set a success target to unlock Goal fit.')
+  })
+
+  it('shows per-option goal bars on the Goal fit lens when a target and probabilities exist', () => {
+    const withGoal = data({
+      allOptions: [
+        opt('a', 'Option A', { win: 0.7, goalProb: 0.6 }),
+        opt('b', 'Option B', { win: 0.3, goalProb: 0.2 }),
+      ],
+      recommendedId: 'a',
+      goalThreshold: 80,
+    })
+    render(<V7LensGroup resultsSectionData={withGoal} />)
+    fireEvent.click(screen.getByTestId('v7-lens-tab-goal'))
+    expect(screen.getByTestId('v7-lens-goal')).toBeInTheDocument()
+    expect(screen.getAllByTestId('v7-goal-row').length).toBe(2)
+    expect(screen.getByText(/60% hit target/)).toBeInTheDocument()
+  })
+
+  it('always shows the honest gap on the Stability lens', () => {
+    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    fireEvent.click(screen.getByTestId('v7-lens-tab-stability'))
+    expect(screen.getByTestId('v7-lens-stability-gate')).toHaveTextContent('will not infer it')
+  })
+
+  it('shows the honest empty state on the What-changed lens with empty run history', () => {
+    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    fireEvent.click(screen.getByTestId('v7-lens-tab-whatChanged'))
+    expect(screen.getByTestId('v7-what-changed-empty')).toBeInTheDocument()
+    expect(screen.getByText('Snapshot unavailable — rerun to compare.')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no analysed options (pre-analysis)', () => {
+    const { container } = render(<V7LensGroup resultsSectionData={data({ allOptions: [] })} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/components/results/v7/__tests__/V7WhatChangedLens.spec.tsx
+++ b/src/components/results/v7/__tests__/V7WhatChangedLens.spec.tsx
@@ -1,0 +1,70 @@
+/**
+ * V7WhatChangedLens — V7 Lane L5 pins for the "What changed in the result"
+ * lens body (spec row 6d).
+ *
+ * Two honest paths: the empty state (the COMMON case — run history is usually
+ * empty on the live path) and a real run-over-run delta from the existing
+ * runHistory exports. The lens reads run history READ-ONLY and never fabricates
+ * a comparison.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { V7WhatChangedLens } from '../V7WhatChangedLens'
+import { STORAGE_KEY, type StoredRun } from '../../../../canvas/store/runHistory'
+
+function run(
+  id: string,
+  ts: number,
+  p50: number,
+  edgeWeight: number,
+  drivers: Array<{ kind: 'node' | 'edge'; id?: string; label?: string }>,
+): StoredRun {
+  return {
+    id,
+    ts,
+    seed: 1,
+    adapter: 'httpv1',
+    summary: `run ${id}`,
+    graphHash: `hash-${id}`,
+    report: { run: { bands: { p50 } } },
+    drivers,
+    graph: { nodes: [], edges: [{ id: 'e1', data: { weight: edgeWeight } }] },
+  } as unknown as StoredRun
+}
+
+const PRIOR = run('prior', 1000, 0.6, 0.5, [
+  { kind: 'node', id: 'd1', label: 'Price' },
+  { kind: 'node', id: 'd2', label: 'Demand' },
+])
+const LATEST = run('latest', 2000, 0.66, 0.8, [
+  { kind: 'node', id: 'd2', label: 'Demand' },
+  { kind: 'node', id: 'd3', label: 'Rates' },
+])
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('V7WhatChangedLens (V7 L5)', () => {
+  it('renders the honest empty state when fewer than two runs exist', () => {
+    render(<V7WhatChangedLens runs={[LATEST]} />)
+    expect(screen.getByTestId('v7-what-changed-empty')).toBeInTheDocument()
+    expect(screen.getByText('Snapshot unavailable — rerun to compare.')).toBeInTheDocument()
+  })
+
+  it('renders a real run-over-run delta (p50, edges, drivers added/removed) from two runs', () => {
+    // compareRuns reads localStorage by id, so seed it (latest first).
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([LATEST, PRIOR]))
+    render(<V7WhatChangedLens runs={[LATEST, PRIOR]} />)
+
+    expect(screen.getByTestId('v7-what-changed')).toBeInTheDocument()
+    // p50 of the latest run, with the signed delta vs prior.
+    expect(screen.getByText(/p50 0\.66/)).toBeInTheDocument()
+    expect(screen.getByTestId('v7-what-changed-delta')).toHaveTextContent('+0.06')
+    // one edge weight changed (0.5 -> 0.8).
+    expect(screen.getByTestId('v7-what-changed-edges')).toHaveTextContent('1 edge changed')
+    // Rates is new in the latest run; Price is gone since prior.
+    expect(screen.getByTestId('v7-what-changed-drivers-added')).toHaveTextContent('Rates')
+    expect(screen.getByTestId('v7-what-changed-drivers-removed')).toHaveTextContent('Price')
+  })
+})

--- a/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * buildV7Lenses — V7 Lane L5 pins for the passthrough lens/evidence builder.
+ *
+ * Every value is composed from existing resultsSectionData fields; these pins
+ * lock the honest gates (goal no-target vs producer-gap, outcome availability),
+ * the OptionCards-identical outcome scale, and the evidence model (est. flag,
+ * flip-risk + trade-off passthrough) so no branch can silently start inventing.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildV7Lenses } from '../buildV7Lenses'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import type { OptionResult } from '../../types'
+
+function opt(
+  id: string,
+  label: string,
+  o: Partial<{
+    win: number
+    p10: number
+    p50: number
+    p90: number
+    mean: number
+    goalProb: number | null
+  }> = {},
+): OptionResult {
+  return {
+    id,
+    label,
+    expected: o.mean ?? null,
+    outcome: { mean: o.mean ?? null, p10: o.p10 ?? null, p50: o.p50 ?? null, p90: o.p90 ?? null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    winProbability: o.win,
+    goalProbability: o.goalProb ?? null,
+  } as unknown as OptionResult
+}
+
+function data(partial: {
+  allOptions: OptionResult[]
+  recommendedId?: string
+  goalThreshold?: number | null
+  drivers?: unknown[]
+  challengeFragileEdges?: unknown[]
+  conditionalWinners?: unknown[]
+}): ResultsSectionDataReturn {
+  const recommendedOption = partial.allOptions.find((o) => o.id === partial.recommendedId) ?? null
+  return {
+    recommendation: {
+      allOptions: partial.allOptions,
+      recommendedOption,
+      goalThreshold: partial.goalThreshold ?? null,
+      outcomeUnit: 'count',
+      outcomeUnitSymbol: undefined,
+    },
+    drivers: { drivers: partial.drivers ?? [] },
+    confidence: {
+      challengeFragileEdges: partial.challengeFragileEdges ?? [],
+      conditionalWinners: partial.conditionalWinners ?? [],
+    },
+  } as unknown as ResultsSectionDataReturn
+}
+
+describe('buildV7Lenses — passthrough lens + evidence model (V7 L5)', () => {
+  describe('Likely outcome lens', () => {
+    it('is available when options carry win probabilities', () => {
+      const m = buildV7Lenses(data({ allOptions: [opt('a', 'A', { win: 0.7 }), opt('b', 'B', { win: 0.3 })] }))
+      expect(m.outcome.available).toBe(true)
+      expect(m.outcome.hasRange).toBe(false)
+    })
+
+    it('computes the shared scale exactly like OptionCards (p10/p90 with mean fallback)', () => {
+      const m = buildV7Lenses(
+        data({
+          allOptions: [opt('a', 'A', { p10: 10, p50: 20, p90: 30 }), opt('b', 'B', { p10: 5, p50: 12, p90: 25 })],
+        }),
+      )
+      expect(m.outcome.hasRange).toBe(true)
+      expect(m.outcome.globalMin).toBe(5)
+      expect(m.outcome.globalMax).toBe(30)
+    })
+
+    it('is unavailable when no option carries a win probability or a range', () => {
+      const m = buildV7Lenses(data({ allOptions: [opt('a', 'A'), opt('b', 'B')] }))
+      expect(m.outcome.available).toBe(false)
+    })
+  })
+
+  describe('Goal fit lens honest gates', () => {
+    it('gates as no_target when no success target is set', () => {
+      const m = buildV7Lenses(
+        data({ allOptions: [opt('a', 'A', { goalProb: 0.6 })], goalThreshold: null }),
+      )
+      expect(m.goal.available).toBe(false)
+      expect(m.goal.gate).toBe('no_target')
+    })
+
+    it('gates as producer_gap when a target is set but not every option has a goal probability', () => {
+      const m = buildV7Lenses(
+        data({
+          allOptions: [opt('a', 'A', { goalProb: 0.6 }), opt('b', 'B', { goalProb: null })],
+          goalThreshold: 80,
+        }),
+      )
+      expect(m.goal.available).toBe(false)
+      expect(m.goal.gate).toBe('producer_gap')
+    })
+
+    it('is available with per-option probabilities when a target is set and every option has one', () => {
+      const m = buildV7Lenses(
+        data({
+          allOptions: [opt('a', 'A', { goalProb: 0.6 }), opt('b', 'B', { goalProb: 0.2 })],
+          recommendedId: 'a',
+          goalThreshold: 80,
+        }),
+      )
+      expect(m.goal.available).toBe(true)
+      expect(m.goal.gate).toBe('none')
+      expect(m.goal.options).toEqual([
+        { id: 'a', label: 'A', goalProbability: 0.6, isWinner: true },
+        { id: 'b', label: 'B', goalProbability: 0.2, isWinner: false },
+      ])
+    })
+  })
+
+  describe('Evidence model', () => {
+    it('tags a driver "est." from a defaulted value or confidence (producer boolean, not a threshold)', () => {
+      const m = buildV7Lenses(
+        data({
+          allOptions: [opt('a', 'A', { win: 0.6 })],
+          drivers: [
+            { factorKey: 'f1', factorLabel: 'Price', direction: 'negative', isDefaultedConfidence: true, canFocus: false },
+            { factorKey: 'f2', factorLabel: 'Demand', direction: 'positive', valueDefaulted: false, canFocus: true, matchedNodeId: 'n2' },
+          ],
+        }),
+      )
+      expect(m.evidence.drivers[0]).toMatchObject({ label: 'Price', direction: 'negative', isEstimate: true, focusId: undefined })
+      expect(m.evidence.drivers[1]).toMatchObject({ label: 'Demand', direction: 'positive', isEstimate: false, focusId: 'n2' })
+    })
+
+    it('passes flip risks through from challengeFragileEdges unchanged', () => {
+      const m = buildV7Lenses(
+        data({
+          allOptions: [opt('a', 'A', { win: 0.6 })],
+          challengeFragileEdges: [{ from_id: 'n1', from_label: 'Price', to_label: 'Profit', switch_probability: 0.48 }],
+        }),
+      )
+      expect(m.evidence.flipRisks).toEqual([
+        { fromId: 'n1', fromLabel: 'Price', toLabel: 'Profit', switchProbability: 0.48 },
+      ])
+    })
+
+    it('narrates trade-offs from conditional_winners producer values (nothing invented)', () => {
+      const m = buildV7Lenses(
+        data({
+          allOptions: [opt('a', 'A', { win: 0.6 })],
+          conditionalWinners: [
+            {
+              factor_label: 'Interest rate',
+              factor_id: 'n7',
+              split_value: 5,
+              split_unit: '%',
+              high_bucket: { winner_label: 'Rent', win_probability: 0.6 },
+              low_bucket: { winner_label: 'Buy', win_probability: 0.7 },
+            },
+          ],
+        }),
+      )
+      expect(m.evidence.tradeOffs).toEqual([
+        { factorLabel: 'Interest rate', factorId: 'n7', splitValue: 5, splitUnit: '%', highWinnerLabel: 'Rent', lowWinnerLabel: 'Buy' },
+      ])
+    })
+
+    it('yields empty evidence collections when the backing fields are absent', () => {
+      const m = buildV7Lenses(data({ allOptions: [opt('a', 'A', { win: 0.6 })] }))
+      expect(m.evidence.drivers).toEqual([])
+      expect(m.evidence.flipRisks).toEqual([])
+      expect(m.evidence.tradeOffs).toEqual([])
+    })
+  })
+})

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -1,0 +1,198 @@
+/**
+ * buildV7Lenses — pure passthrough builder for the V7 lens group + evidence
+ * disclosure (V7 Lane L5).
+ *
+ * Composes lens availability, honest-gate selection, and the evidence model
+ * from EXISTING resultsSectionData fields only — never a fabricated number, a
+ * threshold, or an inferred claim (V6-RESPEC-2026-07-23 §5, passthrough
+ * doctrine). Every gate here renders the honest "not produced yet / unlocks
+ * when the engine returns…" line instead of inventing the missing value.
+ *
+ *   · Likely outcome ← recommendation.allOptions (the SAME options + win
+ *     probabilities OptionCards consumes); the shared [globalMin, globalMax]
+ *     scale is computed identically to OptionCards (p10/p90 with mean
+ *     fallback) so the V7 range bars and the cards below cannot drift.
+ *   · Goal fit ← per-option goalProbability vs goalThreshold, gated exactly
+ *     like OptionCards' "Hits target" (threshold present AND every option
+ *     carries a probability); the gate distinguishes the user-actionable
+ *     no-target case from the producer gap.
+ *   · Stability → always the honest gap (no per-option stability on the wire).
+ *   · Evidence: drivers (producer rank order, "est." from a defaulted-value/
+ *     confidence read), flip risks (challengeFragileEdges — the SAME slice the
+ *     signal row + stress test consume), trade-offs (conditional_winners —
+ *     producer factor-split narration, verbatim values).
+ *
+ * The What-changed lens reads local run history at render (V7WhatChangedLens)
+ * and is deliberately NOT modelled here — its data is store-backed, not part
+ * of resultsSectionData.
+ */
+
+import type { OptionResult, OutcomeUnitType, DriverItem, ConditionalWinner } from '../types'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+
+/** One flip-risk row — the challengeFragileEdges slice, unchanged. */
+export interface V7FlipRisk {
+  fromId?: string
+  fromLabel: string
+  toLabel: string
+  /** Producer switch probability in [0,1], or null when non-finite. */
+  switchProbability: number | null
+}
+
+/** One driver row for the evidence disclosure — pure passthrough. */
+export interface V7EvidenceDriver {
+  factorKey: string
+  label: string
+  /** Producer-normalised effect direction; null when the producer sent none. */
+  direction: 'positive' | 'negative' | null
+  /** True when the factor value OR its confidence was defaulted (an estimate)
+   * — a direct producer boolean read, never a threshold. */
+  isEstimate: boolean
+  /** Canvas focus target when the factor maps to a node. */
+  focusId?: string
+}
+
+/** One trade-off row — a producer conditional-winner split, narrated verbatim. */
+export interface V7TradeOff {
+  factorLabel: string
+  factorId: string
+  splitValue: number
+  splitUnit?: string
+  highWinnerLabel: string
+  lowWinnerLabel: string
+}
+
+export interface V7OutcomeLens {
+  /** True when at least one option carries a win probability or a p10/p90 range. */
+  available: boolean
+  /** Options to render (recommendation.allOptions), unchanged. */
+  options: OptionResult[]
+  /** Shared display scale — computed exactly as OptionCards (UI-SEM-free). */
+  globalMin: number
+  globalMax: number
+  /** True when any option carries a full p10/p90 range (gates the caption). */
+  hasRange: boolean
+  winnerId?: string
+  outcomeUnit?: OutcomeUnitType
+  outcomeUnitSymbol?: string
+}
+
+export interface V7GoalLens {
+  available: boolean
+  /** Which honest gate to render when unavailable. */
+  gate: 'none' | 'no_target' | 'producer_gap'
+  goalThreshold: number | null
+  options: Array<{ id: string; label: string; goalProbability: number; isWinner: boolean }>
+}
+
+export interface V7EvidenceModel {
+  drivers: V7EvidenceDriver[]
+  flipRisks: V7FlipRisk[]
+  tradeOffs: V7TradeOff[]
+}
+
+export interface V7LensesModel {
+  outcome: V7OutcomeLens
+  goal: V7GoalLens
+  evidence: V7EvidenceModel
+}
+
+function driverDirection(d: DriverItem): 'positive' | 'negative' | null {
+  return d.direction === 'positive' || d.direction === 'negative' ? d.direction : null
+}
+
+export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
+  const { recommendation, drivers, confidence } = data
+  const options = recommendation.allOptions ?? []
+  const winnerId = recommendation.recommendedOption?.id
+
+  // ── Likely outcome ─────────────────────────────────────────────────────
+  const hasRange = options.some(
+    (o) => typeof o.outcome?.p10 === 'number' && typeof o.outcome?.p90 === 'number',
+  )
+  const hasWin = options.some(
+    (o) => typeof o.winProbability === 'number' && Number.isFinite(o.winProbability),
+  )
+  // Shared [globalMin, globalMax] scale — identical to OptionCards (p10/p90
+  // with mean fallback), so the V7 bars and the cards below share one scale.
+  const globalMin = options.length
+    ? Math.min(...options.map((o) => o.outcome?.p10 ?? o.outcome?.mean ?? 0))
+    : 0
+  const globalMax = options.length
+    ? Math.max(...options.map((o) => o.outcome?.p90 ?? o.outcome?.mean ?? 0))
+    : 1
+
+  const outcome: V7OutcomeLens = {
+    available: options.length > 0 && (hasRange || hasWin),
+    options,
+    globalMin,
+    globalMax,
+    hasRange,
+    winnerId,
+    outcomeUnit: recommendation.outcomeUnit,
+    outcomeUnitSymbol: recommendation.outcomeUnitSymbol,
+  }
+
+  // ── Goal fit ───────────────────────────────────────────────────────────
+  // Gate exactly like OptionCards' "Hits target": a user threshold is present
+  // AND every option carries a finite goal probability. Otherwise the honest
+  // gate, distinguishing the no-target case (user-actionable) from the
+  // producer gap (a target is set but the engine returned no probabilities).
+  const goalThreshold =
+    typeof recommendation.goalThreshold === 'number' && Number.isFinite(recommendation.goalThreshold)
+      ? recommendation.goalThreshold
+      : null
+  const everyGoalProb =
+    options.length > 0 &&
+    options.every((o) => typeof o.goalProbability === 'number' && Number.isFinite(o.goalProbability))
+  const goalAvailable = goalThreshold != null && everyGoalProb
+  const goal: V7GoalLens = {
+    available: goalAvailable,
+    gate: goalAvailable ? 'none' : goalThreshold == null ? 'no_target' : 'producer_gap',
+    goalThreshold,
+    options: goalAvailable
+      ? options.map((o) => ({
+          id: o.id,
+          label: o.label,
+          goalProbability: o.goalProbability as number,
+          isWinner: o.id === winnerId,
+        }))
+      : [],
+  }
+
+  // ── Evidence: drivers / flip risks / trade-offs ────────────────────────
+  const evidenceDrivers: V7EvidenceDriver[] = (drivers.drivers ?? []).map((d) => ({
+    factorKey: d.factorKey,
+    label: d.factorLabel,
+    direction: driverDirection(d),
+    isEstimate: d.isDefaultedConfidence === true || d.valueDefaulted === true,
+    focusId: d.canFocus ? (d.matchedNodeId ?? d.factorKey) : undefined,
+  }))
+
+  const flipRisks: V7FlipRisk[] = (confidence.challengeFragileEdges ?? []).map((e) => ({
+    fromId: e.from_id,
+    fromLabel: e.from_label,
+    toLabel: e.to_label,
+    switchProbability:
+      typeof e.switch_probability === 'number' && Number.isFinite(e.switch_probability)
+        ? e.switch_probability
+        : null,
+  }))
+
+  const tradeOffs: V7TradeOff[] = (confidence.conditionalWinners ?? []).map(
+    (c: ConditionalWinner) => ({
+      factorLabel: c.factor_label,
+      factorId: c.factor_id,
+      splitValue: c.split_value,
+      splitUnit: c.split_unit,
+      highWinnerLabel: c.high_bucket.winner_label,
+      lowWinnerLabel: c.low_bucket.winner_label,
+    }),
+  )
+
+  return {
+    outcome,
+    goal,
+    evidence: { drivers: evidenceDrivers, flipRisks, tradeOffs },
+  }
+}

--- a/src/components/results/v7/v7LensCopy.ts
+++ b/src/components/results/v7/v7LensCopy.ts
@@ -1,0 +1,96 @@
+/**
+ * v7LensCopy — all UI-authored copy for the V7 lens group + evidence
+ * disclosure (V7 Lane L5).
+ *
+ * British English, sentence case, no all-caps, no em dashes in prose (the
+ * '—' in the What-changed empty state is the spec-ratified wording, mirrored
+ * verbatim from V6-RESPEC-2026-07-23 row 6d). Honest-gate strings state WHY a
+ * lens is empty and what unlocks it — never a fabricated chart, never an
+ * inferred number. The gate wording deliberately echoes the live analysis
+ * hero's honest-unavailable register (heroCopy.lensUnavailable) so the two
+ * surfaces can never disagree about what "not produced yet" means.
+ */
+
+export const V7_LENS_COPY = {
+  /** Accessible name for the lens tablist. */
+  tablistAria: 'Results lens',
+
+  /** Lens tab labels. "What changed" is the SHORT tab label; the panel
+   * heading disambiguates it as "in the result" (Paul-question P4 — distinct
+   * from the pushed-down WhatChangedChip's "in the model" graph diff). */
+  lensLabel: {
+    outcome: 'Likely outcome',
+    goal: 'Goal fit',
+    /** Lens NAME only — naming a view, not a claim about this run. */
+    stability: 'Stability',
+    whatChanged: 'What changed',
+  } as const,
+
+  /** Screen-reader suffix for a lens whose data is unavailable this run. */
+  srLensUnavailable: 'not available for this run',
+
+  outcome: {
+    caption: 'Dots show the median. Bars show the realistic range (10th to 90th percentile).',
+    /** Shown when no option carries a distribution or a win probability. */
+    gate: 'Likely outcome is not available for this run.',
+    winReadout: (formatted: string) => `Leads ${formatted}`,
+  },
+
+  goal: {
+    caption: 'Each value is the chance that option reaches your success target.',
+    /** No user target set — user-actionable, distinct from the producer gap. */
+    gateNoTarget: 'Set a success target to unlock Goal fit.',
+    /** A target is set but the engine returned no per-option goal probabilities. */
+    gateProducerGap: 'Goal fit unlocks when the engine returns per-option goal probabilities for this run.',
+    hitReadout: (formatted: string) => `${formatted} hit target`,
+    /** Mirrors OptionCards' sub-1% display-honesty affordance (UI-SEM-057). */
+    subOnePercent: '< 1%',
+  },
+
+  stability: {
+    /** Honest gap — per-option stability is not on the wire, and Olumi will
+     * not infer it (V6-RESPEC row 6c). */
+    heading: 'Stability',
+    gate: 'Per-option stability is not produced yet, and Olumi will not infer it. The overall stability verdict lives in the footer below.',
+  },
+
+  whatChanged: {
+    /** Panel heading — P4 distinctness ("in the result", not "in the model"). */
+    heading: 'What changed in the result',
+    /** Honest empty state — the common case on the live path, where run
+     * history is usually empty (its writer is Run-button-gated on results.seed).
+     * Wording ratified in V6-RESPEC row 6d. */
+    empty: 'Snapshot unavailable — rerun to compare.',
+    emptyDetail: 'This compares your two most recent runs. Run the analysis again to build a comparison.',
+    p50Label: 'Median outcome',
+    edgesLabel: 'Model edges',
+    driversAddedLabel: 'Drivers added',
+    driversRemovedLabel: 'Drivers removed',
+    noDriverChange: 'No change in the drivers.',
+  },
+
+  evidence: {
+    heading: 'Why, and what could change it',
+    subtitle: 'Drivers, flip risks and trade-offs',
+    driversTab: 'Drivers',
+    flipRisksTab: 'Flip risks',
+    tradeOffsTab: 'Trade-offs',
+    driversNote: 'Ranked by effect on the analysed outcome.',
+    /** Low-confidence tag — the factor value or its confidence was defaulted
+     * (an estimate), a direct producer read (never a threshold). */
+    estimateTag: 'est.',
+    estimateTagAria: 'estimated value',
+    seeMore: (n: number) => `Show ${n} more`,
+    showFewer: 'Show fewer',
+    driversGate: 'No drivers to show for this run.',
+    flipRisksNote: 'Relationships whose plausible range can change the leading option.',
+    flipSwitchMeta: (pct: string) => `${pct} switch`,
+    flipRisksGate: 'No flip risks to show for this run.',
+    tradeOffsNote: 'Where the leading option depends on an assumption.',
+    tradeOffsGate: 'No trade-offs to show for this run.',
+    /** Conditional-winner narration — all values are producer-supplied
+     * (factor label, split value/unit, winner labels); nothing invented. */
+    tradeOffSplit: (factor: string, value: string, high: string, low: string) =>
+      `If ${factor} is above ${value}, ${high} leads; below it, ${low} leads.`,
+  },
+} as const

--- a/tests/ci-guards/complete-borders.spec.ts
+++ b/tests/ci-guards/complete-borders.spec.ts
@@ -90,6 +90,10 @@ const CONTENT_CARD_FILES = [
   'components/results/v7/V7SuggestedChips.tsx',
   'components/results/v7/V7SharpenLine.tsx',
   'components/results/v7/V7FreshnessStrip.tsx',
+  // V7 Lane L5 — lens group + evidence disclosure (complete borders only).
+  'components/results/v7/V7LensGroup.tsx',
+  'components/results/v7/V7EvidenceDisclosure.tsx',
+  'components/results/v7/V7WhatChangedLens.tsx',
   // V7 L2 — the final two one-sided accents, now converted to complete borders.
   'v5/blocks/V5CoachingBlock.tsx',
   'canvas/ToastContext.tsx',


### PR DESCRIPTION
## V7 Lane L5 — Lens group + evidence disclosure

Ports the V7 lens control and evidence disclosure onto the live `ResultsBody`
composition (V6-RESPEC-2026-07-23 §5 lane L5, rows 6/6a–6d/7). **Additive,
flagless, passthrough** over the same `resultsSectionData` + `vm` the live panel
below consumes. Mounts inside the L4 `V7TopMatter` group above the "Current
view" divider; **nothing below the divider changes** — `OptionCards`,
`DriversSection`, `TornadoChart`, `WhatChangedChip` are untouched.

### Scope
- **Lens group** (`V7LensGroup`) — one WAI-ARIA tab control switching four lenses:
  - **Likely outcome** — p10/p50/p90 range bars + win probability per option, from
    `recommendation.allOptions` (the fields `OptionCards` consumes), on the shared
    `[globalMin, globalMax]` scale computed identically to `OptionCards`.
  - **Goal fit** — per-option goal probability, gated exactly like `OptionCards`'
    "Hits target" (threshold present AND every option carries a probability).
  - **Stability** — the honest gap, always.
  - **What changed in the result** — run-over-run delta from local run history
    (read-only) or the honest empty state (P4: labelled "in the result", distinct
    from the pushed-down `WhatChangedChip`'s "in the model").
- **Evidence disclosure** (`V7EvidenceDisclosure`) — one disclosure, three tabs:
  Drivers (top 3 + "Show N more", `est.` tag on defaulted factors) / Flip risks /
  Trade-offs.
- **`buildV7Lenses`** — pure passthrough builder for lens availability, honest-gate
  selection, and the evidence model (mirrors the tested `buildV7Headline` pattern).

### Honest-gate inventory (which lens gates on what)
| Lens | Renders data when… | Honest gate otherwise |
|------|--------------------|-----------------------|
| Likely outcome | any option has a win probability OR a p10/p90 range | "Likely outcome is not available for this run." |
| Goal fit | `goalThreshold != null` **and** every option has a finite `goalProbability` | no target → "Set a success target to unlock Goal fit."; target set but engine returned no probabilities → "Goal fit unlocks when the engine returns per-option goal probabilities for this run." |
| Stability | **never** (not on the wire) | "Per-option stability is not produced yet, and Olumi will not infer it. …" |
| What changed | ≥2 stored runs | "Snapshot unavailable — rerun to compare." (the common case on the live path) |
| Evidence · Drivers | `drivers.drivers` non-empty | "No drivers to show for this run." |
| Evidence · Flip risks | `challengeFragileEdges` non-empty | "No flip risks to show for this run." |
| Evidence · Trade-offs | `conditionalWinners` non-empty | "No trade-offs to show for this run." |

No new UI-SEM transforms. Bar widths are layout-only clamps mirroring `OptionCards`'
existing (untagged) win-bar clamp; the displayed data is always the formatted
readout, never the bar geometry. Where a value would need thresholding/deriving,
the honest gate renders instead.

### Tests (24 new specs)
- `buildV7Lenses.spec.ts` (10): outcome availability + OptionCards-identical scale;
  goal gate no_target / producer_gap / available; evidence est.-flag, flip-risk and
  trade-off passthrough; empty collections.
- `V7LensGroup.spec.tsx` (7): four tabs render; default outcome lens (range bars +
  win readouts); goal no-target gate vs per-option bars; stability gate always;
  what-changed empty state; renders nothing pre-analysis.
- `V7WhatChangedLens.spec.tsx` (2): honest empty state; real p50/edges/drivers delta.
- `V7EvidenceDisclosure.spec.tsx` (5): renders-nothing empty; drivers clamp-to-3 +
  Show-more; est. tag; flip-risks view; trade-offs narration.

### Mutation matrix (7 pins mutation-checked in-place, reverted, re-verified green)
| # | Pin | Mutation | Result |
|---|-----|----------|--------|
| M1 | goal no-target vs producer-gap | force gate → `producer_gap` | RED (builder + V7LensGroup) |
| M2 | stability gate always renders | replace gate copy | RED |
| M3 | what-changed honest empty state | disable `<2 runs` guard | RED |
| M4 | drivers added/removed direction | swap `compareRuns` arg order | RED (confirms `(prior, latest)` is correct) |
| M5 | drivers clamp to 3 | `VISIBLE_DRIVERS 3→5` | RED |
| M6 | est. tag from defaulted read | force `isEstimate:false` | RED (builder) |
| M7 | pre-analysis renders nothing | disable `options.length===0` guard | RED |

All mutants reverted; final `v7 + borders` run: **35 passed**. No mutant remnants.

### Borders-guard registration
`V7LensGroup.tsx`, `V7EvidenceDisclosure.tsx`, `V7WhatChangedLens.tsx` added to the
`CONTENT_CARD_FILES` scan set in `tests/ci-guards/complete-borders.spec.ts`
(complete borders only — no one-sided accents; selected tabs use the ratified
`bg-primary` treatment, not an underline). Guard green.

### Gate outputs
- `pnpm run typecheck` — clean.
- `npx eslint <changed files>` — clean (exit 0).
- `npx vitest run --changed` — 34 files / 302 tests passed (incl. ResultsBody consumers).
- complete-borders guard — 4/4 passed.

### Deviations (flagged for veto)
1. **`runHistory` do-not-wire header (deliberate, read-only override).**
   `src/canvas/store/runHistory.ts` carries a "must NEVER back a 'What changed'
   surface … Do not wire this in" header. V6-RESPEC row 6d + the L5 brief explicitly
   override that **for read-only consumption** on this new lens (Paul-ruled, dated
   2026-07-23). `V7WhatChangedLens` adds **no new writers** — it only reads the
   existing `compareRuns` / `computeRunSummary` / `loadRuns` exports — and never
   fabricates a comparison. The existing live `WhatChangedChip` already backs a
   What-changed surface from run history; P4 keeps both, labelled distinctly.
2. **Trade-offs sourced from `conditional_winners`.** The live analysis-hero renders
   trade-offs as fixture-only (producer gap, issue 217). This lane narrates trade-offs
   from `conditional_winners` (factor label, split value/unit, winner labels — all
   producer values, rendered verbatim), which **is** on the wire, so the tab shows
   real data when present and an honest gate otherwise.
3. **What-changed empty-state em dash.** "Snapshot unavailable — rerun to compare."
   uses the spec-ratified em dash (row 6d); `computeRunSummary`'s own en-dash string
   is rendered verbatim for the snapshot-missing edges line.

Draft — do not merge. Assessment-mode build (V6-RESPEC §1); the Current-view group
retires on Paul's sign-off (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
