### PR TITLE
feat(lane-u): typed chip/intent producers — chip.id + intent + typed mutation parameters (S2+S3 Lane U)

### DIFF
--- a/src/canvas/conversation/chipMeta.ts
+++ b/src/canvas/conversation/chipMeta.ts
@@ -16,24 +16,62 @@
  */
 
 export interface ChipMetaInput {
-  /** Deterministic action type for CEE routing. */
+  /**
+   * First-class chip identity (@talchain/schemas 0.22.0 `chip.id`). When
+   * omitted, buildChipMeta LIFTS it from the identity already carried inside
+   * `parameters` (`chip_id` / `spark_id`) — the promotion the S2 design asks
+   * for ("populate chip.id from the existing chip_id/spark_id the UI already
+   * sends inside parameters"). An explicit `id` always wins over the lift.
+   */
+  id?: string
+  /** Deterministic action type for CEE routing (11-member `ActionType`). */
   action_type?: string
+  /**
+   * Typed authored intent (@talchain/schemas 0.22.0 `chip.intent`, an 11-member
+   * `Intent` set incl. `add_option`). Decoupled from `action_type`: an intent
+   * names WHAT the user wants; the send gate in buildV5Payload
+   * (sanitiseIntent → CEE_ACCEPTED_INTENTS) decides whether it reaches the wire.
+   */
+  intent?: string
   /** Structured parameters for action execution / chip identity. */
   parameters?: Record<string, unknown>
 }
 
 export interface ChipMeta {
+  id?: string
   action_type?: string
+  intent?: string
   parameters?: Record<string, unknown>
 }
 
+/**
+ * Derive the first-class chip id: an explicit `id` wins, else the identity the
+ * UI already ships inside `parameters` (`chip_id`, then `spark_id`). This is a
+ * pure identity LIFT (same value, promoted to a typed field) — not a meaning
+ * transform. `parameters` keeps carrying the id too, for back-compat with the
+ * presence-based routing until CEE reads `chip.id`.
+ */
+function deriveChipId(opts: ChipMetaInput): string | undefined {
+  if (typeof opts.id === 'string' && opts.id.length > 0) return opts.id
+  const p = opts.parameters
+  if (!p) return undefined
+  const chipId = p['chip_id']
+  if (typeof chipId === 'string' && chipId.length > 0) return chipId
+  const sparkId = p['spark_id']
+  if (typeof sparkId === 'string' && sparkId.length > 0) return sparkId
+  return undefined
+}
+
 export function buildChipMeta(opts: ChipMetaInput): ChipMeta | undefined {
-  return opts.action_type || opts.parameters
-    ? {
-        ...(opts.action_type ? { action_type: opts.action_type } : {}),
-        ...(opts.parameters ? { parameters: opts.parameters } : {}),
-      }
-    : undefined
+  const id = deriveChipId(opts)
+  const hasAny = id || opts.action_type || opts.intent || opts.parameters
+  if (!hasAny) return undefined
+  return {
+    ...(id ? { id } : {}),
+    ...(opts.action_type ? { action_type: opts.action_type } : {}),
+    ...(opts.intent ? { intent: opts.intent } : {}),
+    ...(opts.parameters ? { parameters: opts.parameters } : {}),
+  }
 }
 
 /**
@@ -41,7 +79,9 @@ export function buildChipMeta(opts: ChipMetaInput): ChipMeta | undefined {
  * (turn-request-builder.ts ChipMetadata). Identity-only meta (parameters
  * without an action_type — the null-intent sparks/chips) is a V5-only
  * concept and must NOT be coerced onto the V4 wire; it is dropped here,
- * matching V4's pre-existing behaviour exactly.
+ * matching V4's pre-existing behaviour exactly. The 0.22 `id` and `intent`
+ * fields are likewise V5-only and intentionally absent from the V4 shape —
+ * they are simply not read here.
  */
 export function toLegacyChipMetadata(
   meta: ChipMeta | undefined,

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -1549,8 +1549,18 @@ export type ActionSource = 'chip' | 'insight' | 'canvas_coaching' | 'pre_analysi
 
 /** Options for the unified action dispatch function */
 export interface DispatchActionOpts {
-  /** Deterministic action type for CEE routing */
+  /**
+   * First-class chip identity (0.22 `chip.id`). Optional — when omitted,
+   * buildChipMeta lifts it from `parameters.chip_id` / `parameters.spark_id`.
+   */
+  id?: string
+  /** Deterministic action type for CEE routing (11-member `ActionType`) */
   action_type?: string
+  /**
+   * Typed authored intent (0.22 `chip.intent`, incl. `add_option`). Withheld
+   * from the wire unless CEE accepts it (buildV5Payload's CEE_ACCEPTED_INTENTS).
+   */
+  intent?: string
   /** Structured parameters for action execution */
   parameters?: Record<string, unknown>
   /** Display label for the action indicator and aria */
@@ -4518,8 +4528,12 @@ export function useConversation(): UseConversationReturn {
 
       const messageToSend = chip.message || chip.prompt
       if (messageToSend) {
-        // Delegate to dispatchAction for unified metadata handling
+        // Delegate to dispatchAction for unified metadata handling.
+        // Thread the chip's first-class identity (`chip.id` on the 0.22 wire) —
+        // NOT `chip.intent`, which is the UI *styling* intent ('primary' |
+        // 'secondary' | 'undo'), a different concept from the wire `Intent` set.
         await dispatchAction({
+          id: chip.id,
           action_type: chip.action_type,
           parameters: chip.parameters,
           label: chip.label,

--- a/src/v5/__tests__/chipParameters.spec.ts
+++ b/src/v5/__tests__/chipParameters.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * Typed chip-parameter builders — unit pins.
+ *
+ * The producer's half of the S2 typed-mutation contract: these builders MUST
+ * emit the exact `chip.parameters` shape CEE's readers accept (field names +
+ * genuinely-typed finite numbers), and MUST refuse (never coerce/default) a bad
+ * value. Field names are matched against the CEE-side shape authorities at
+ * staging tip `e7f312d`:
+ *   set_factor_value / adjust_edge_strength / add_constraint
+ *     → routing/typed-chip-mutation-proposal.ts
+ *   add_option → routing/add-option-transaction.ts
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildSetFactorValueParameters,
+  buildAdjustEdgeStrengthParameters,
+  buildAddConstraintParameters,
+  buildAddOptionParameters,
+  MAX_ADD_OPTION_INTERVENTIONS,
+  ADD_OPTION_INTENT,
+  type ChipParametersResult,
+} from '../chipParameters'
+
+/** Narrow the result union to its failure reason (or a sentinel on ok). */
+function reasonOf(r: ChipParametersResult<unknown>): string {
+  return r.ok ? '<<ok>>' : r.reason
+}
+
+describe('buildSetFactorValueParameters', () => {
+  it('emits the CEE field names with a genuine finite number', () => {
+    const r = buildSetFactorValueParameters({ targetId: 'factor_price', value: 140 })
+    expect(r).toEqual({ ok: true, parameters: { target_id: 'factor_price', value: 140 } })
+    // The value is a real number on the emitted object — never a string.
+    if (r.ok) expect(typeof r.parameters.value).toBe('number')
+  })
+
+  it('carries unit + operator only when provided', () => {
+    const r = buildSetFactorValueParameters({
+      targetId: 'factor_price',
+      value: 12.5,
+      unit: '£',
+      operator: 'increase',
+    })
+    expect(r).toEqual({
+      ok: true,
+      parameters: { target_id: 'factor_price', value: 12.5, unit: '£', operator: 'increase' },
+    })
+  })
+
+  it('refuses NaN / Infinity (never a silent commit)', () => {
+    expect(reasonOf(buildSetFactorValueParameters({ targetId: 'f', value: NaN }))).toBe(
+      'value_not_finite',
+    )
+    expect(reasonOf(buildSetFactorValueParameters({ targetId: 'f', value: Infinity }))).toBe(
+      'value_not_finite',
+    )
+    expect(buildSetFactorValueParameters({ targetId: 'f', value: -Infinity })).toEqual({
+      ok: false,
+      reason: 'value_not_finite',
+    })
+  })
+
+  it('refuses an empty target id and an unknown operator', () => {
+    expect(reasonOf(buildSetFactorValueParameters({ targetId: '', value: 1 }))).toBe(
+      'target_id_required',
+    )
+    expect(
+      reasonOf(
+        // @ts-expect-error — an off-vocabulary operator must not typecheck OR pass
+        buildSetFactorValueParameters({ targetId: 'f', value: 1, operator: 'toggle' }),
+      ),
+    ).toBe('operator_invalid')
+  })
+})
+
+describe('buildAdjustEdgeStrengthParameters', () => {
+  it('accepts a composed edge id and a finite strength in range', () => {
+    const r = buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: 0.4 })
+    expect(r).toEqual({ ok: true, parameters: { target_id: 'a→b', value: 0.4 } })
+  })
+
+  it('accepts an explicit endpoint pair and never emits both target_id and from/to', () => {
+    const r = buildAdjustEdgeStrengthParameters({ from: 'a', to: 'b', value: -0.2, std: 0.1 })
+    expect(r).toEqual({ ok: true, parameters: { from: 'a', to: 'b', value: -0.2, std: 0.1 } })
+    if (r.ok) expect('target_id' in r.parameters).toBe(false)
+  })
+
+  it('refuses when no target is identified', () => {
+    expect(reasonOf(buildAdjustEdgeStrengthParameters({ value: 0.5 }))).toBe('edge_target_required')
+    expect(reasonOf(buildAdjustEdgeStrengthParameters({ from: 'a', value: 0.5 }))).toBe(
+      'edge_target_required',
+    )
+  })
+
+  it('enforces the CEE ranges: value ∈ [-1,1], std ∈ (0,0.5]', () => {
+    expect(reasonOf(buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: 1.5 }))).toBe(
+      'value_out_of_range',
+    )
+    expect(
+      reasonOf(buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: 0.5, std: 0 })),
+    ).toBe('std_out_of_range')
+    expect(
+      reasonOf(buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: 0.5, std: 0.6 })),
+    ).toBe('std_out_of_range')
+    // Boundaries: value ±1 allowed, std 0.5 allowed.
+    expect(buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: 1, std: 0.5 }).ok).toBe(true)
+    expect(buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: -1 }).ok).toBe(true)
+  })
+
+  it('refuses non-finite value / std', () => {
+    expect(reasonOf(buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: NaN }))).toBe(
+      'value_not_finite',
+    )
+    expect(
+      reasonOf(buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: 0.5, std: Infinity })),
+    ).toBe('std_not_finite')
+  })
+})
+
+describe('buildAddConstraintParameters', () => {
+  it('emits target_id + constraint_type + finite value', () => {
+    const r = buildAddConstraintParameters({
+      targetId: 'goal_1',
+      constraintType: 'at_least',
+      value: 0.15,
+    })
+    expect(r).toEqual({
+      ok: true,
+      parameters: { target_id: 'goal_1', constraint_type: 'at_least', value: 0.15 },
+    })
+  })
+
+  it('carries label + unit only when provided', () => {
+    const r = buildAddConstraintParameters({
+      targetId: 'goal_1',
+      constraintType: 'at_most',
+      value: 100000,
+      label: 'Budget ceiling',
+      unit: '£',
+    })
+    expect(r).toEqual({
+      ok: true,
+      parameters: {
+        target_id: 'goal_1',
+        constraint_type: 'at_most',
+        value: 100000,
+        label: 'Budget ceiling',
+        unit: '£',
+      },
+    })
+  })
+
+  it('refuses non-finite value and an invalid direction', () => {
+    expect(
+      reasonOf(buildAddConstraintParameters({ targetId: 'g', constraintType: 'at_least', value: NaN })),
+    ).toBe('value_not_finite')
+    expect(
+      reasonOf(
+        buildAddConstraintParameters({
+          targetId: 'g',
+          // @ts-expect-error — only at_least / at_most are valid
+          constraintType: 'exactly',
+          value: 1,
+        }),
+      ),
+    ).toBe('constraint_type_invalid')
+  })
+})
+
+describe('buildAddOptionParameters', () => {
+  it('emits parent + label + typed interventions with CEE field names', () => {
+    const r = buildAddOptionParameters({
+      parentDecisionId: 'decision_1',
+      label: 'Hybrid plan',
+      interventions: [
+        { factorId: 'factor_price', value: 49 },
+        { factorId: 'factor_support', value: 2, unit: 'FTE', rawValue: 'two' },
+      ],
+    })
+    expect(r).toEqual({
+      ok: true,
+      parameters: {
+        parent_decision_id: 'decision_1',
+        label: 'Hybrid plan',
+        interventions: [
+          { factor_id: 'factor_price', value: 49 },
+          { factor_id: 'factor_support', value: 2, unit: 'FTE', raw_value: 'two' },
+        ],
+      },
+    })
+  })
+
+  it('rides intent add_option (not an action_type)', () => {
+    expect(ADD_OPTION_INTENT).toBe('add_option')
+  })
+
+  it('carries option_id only when provided and defaults interventions to empty', () => {
+    const r = buildAddOptionParameters({
+      parentDecisionId: 'decision_1',
+      label: 'Bare option',
+      optionId: 'opt_bare',
+      interventions: [],
+    })
+    expect(r).toEqual({
+      ok: true,
+      parameters: {
+        parent_decision_id: 'decision_1',
+        label: 'Bare option',
+        option_id: 'opt_bare',
+        interventions: [],
+      },
+    })
+  })
+
+  it('caps at 6 interventions (PROPOSAL_CAP=8, ops = N+2)', () => {
+    const iv = (i: number) => ({ factorId: `f${i}`, value: i })
+    const ok6 = buildAddOptionParameters({
+      parentDecisionId: 'd',
+      label: 'L',
+      interventions: [0, 1, 2, 3, 4, 5].map(iv),
+    })
+    expect(ok6.ok).toBe(true)
+    expect(MAX_ADD_OPTION_INTERVENTIONS).toBe(6)
+    const over = buildAddOptionParameters({
+      parentDecisionId: 'd',
+      label: 'L',
+      interventions: [0, 1, 2, 3, 4, 5, 6].map(iv),
+    })
+    expect(over).toEqual({ ok: false, reason: 'too_many_interventions' })
+  })
+
+  it('refuses a duplicate factor and a non-finite intervention value', () => {
+    expect(
+      reasonOf(
+        buildAddOptionParameters({
+          parentDecisionId: 'd',
+          label: 'L',
+          interventions: [
+            { factorId: 'f1', value: 1 },
+            { factorId: 'f1', value: 2 },
+          ],
+        }),
+      ),
+    ).toBe('duplicate_factor')
+    expect(
+      reasonOf(
+        buildAddOptionParameters({
+          parentDecisionId: 'd',
+          label: 'L',
+          interventions: [{ factorId: 'f1', value: NaN }],
+        }),
+      ),
+    ).toBe('value_not_finite')
+  })
+})

--- a/src/v5/__tests__/intentGate.spec.ts
+++ b/src/v5/__tests__/intentGate.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Intent send-gate — the two-signal discipline (published AND CEE-accepted),
+ * mirroring the action_type gate. Publication alone (or acceptance alone) must
+ * never open the gate; the accept registry is the SECOND, independent signal.
+ */
+import { describe, it, expect } from 'vitest'
+import { Intent } from '@talchain/schemas/boundary'
+import {
+  KNOWN_INTENTS,
+  CEE_ACCEPTED_INTENTS,
+  isSendableIntent,
+} from '../buildPayload'
+
+describe('intent wire allowlist — schema parity (derive-don\'t-mirror)', () => {
+  it('KNOWN_INTENTS equals the @talchain/schemas Intent enum EXACTLY (drift = red)', () => {
+    expect(new Set(KNOWN_INTENTS)).toEqual(new Set(Intent.options))
+  })
+
+  it('every CEE-accepted intent is published in the vendored enum (no inert entries)', () => {
+    for (const v of CEE_ACCEPTED_INTENTS) {
+      expect(KNOWN_INTENTS.has(v)).toBe(true)
+    }
+  })
+
+  it('add_option is the currently-accepted intent; coaching intents are withheld', () => {
+    expect(CEE_ACCEPTED_INTENTS.has('add_option')).toBe(true)
+    // The coaching/elicitation arm is not confirmed deployed — withheld until
+    // the registry-stamping lane adds them with deploy provenance.
+    expect(CEE_ACCEPTED_INTENTS.has('challenge_frame')).toBe(false)
+    expect(CEE_ACCEPTED_INTENTS.has('elicit_options')).toBe(false)
+  })
+})
+
+describe('isSendableIntent — the AND actually bites', () => {
+  const published = new Set(['add_option', 'elicit_options'])
+  const accepted = new Set(['add_option'])
+
+  it('sends only when BOTH signals hold', () => {
+    expect(isSendableIntent('add_option', published, accepted)).toBe(true)
+  })
+
+  it('publication ALONE does not open the gate', () => {
+    // elicit_options is published but not accepted → withheld.
+    expect(isSendableIntent('elicit_options', published, accepted)).toBe(false)
+  })
+
+  it('acceptance ALONE (unpublished) does not open the gate', () => {
+    const acceptedOnly = new Set(['ghost_intent'])
+    expect(isSendableIntent('ghost_intent', new Set<string>(), acceptedOnly)).toBe(false)
+  })
+
+  it('an unknown value is never sendable', () => {
+    expect(isSendableIntent('nonsense', published, accepted)).toBe(false)
+  })
+})

--- a/src/v5/__tests__/typedChipProducers.seam.spec.ts
+++ b/src/v5/__tests__/typedChipProducers.seam.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Lane U seam pin — typed chip PRODUCER → the ACTUAL HTTP body.
+ *
+ * Composes the REAL production seam the chip-dispatch call site uses —
+ * buildChipMeta (canvas/conversation/chipMeta, the pure leaf dispatchAction
+ * calls) → buildV5Payload → callV5Turn(fetchImpl) — and asserts on
+ * JSON.parse(init.body). The wire is the truth. This is the exact pattern
+ * goalThreshold.chipToWire.spec.ts pins for goal_threshold, extended to the four
+ * S2 producers: first-class `chip.id`, typed `chip.intent`, and genuinely-typed
+ * FINITE `chip.parameters` for set_factor_value / adjust_edge_strength /
+ * add_constraint / add_option.
+ *
+ * Every asserted body is ALSO validated against OrchestratorTurnPayloadSchema
+ * (0.22, `.strict()` on the chip) so a shape drift between producer and wire
+ * schema fails the test.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { OrchestratorTurnPayloadSchema } from '@talchain/schemas/boundary'
+
+import { buildChipMeta, type ChipMetaInput } from '../../canvas/conversation/chipMeta'
+import { buildV5Payload, type BuildV5PayloadInput } from '../buildPayload'
+import { callV5Turn } from '../v5Adapter'
+import {
+  buildSetFactorValueParameters,
+  buildAdjustEdgeStrengthParameters,
+  buildAddConstraintParameters,
+  buildAddOptionParameters,
+  ADD_OPTION_INTENT,
+} from '../chipParameters'
+
+const TURN_ID = '11111111-1111-4111-8111-111111111111'
+const SCENARIO_ID = '22222222-2222-4222-8222-222222222222'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function makeFetchImpl() {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ response_version: 1, assistant_text: 'ok', blocks: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}
+
+interface WireChip {
+  id?: string
+  action_type?: string
+  intent?: string
+  parameters?: Record<string, unknown>
+}
+
+/**
+ * Drive the real seam: a chip's raw dispatch opts → buildChipMeta → buildV5Payload
+ * → callV5Turn(fetchImpl). Returns the parsed HTTP body. Also parses the body
+ * back through the 0.22 schema so any strict-mode drift fails here.
+ */
+async function wireBody(
+  chipInput: ChipMetaInput,
+  source: string,
+): Promise<{ source?: string; chip?: WireChip }> {
+  const chipMeta = buildChipMeta(chipInput)
+  const input: BuildV5PayloadInput = {
+    turnId: TURN_ID,
+    scenarioId: SCENARIO_ID,
+    stage: 'analyse',
+    turnClass: 'frame',
+    mode: 'user',
+    message: 'typed chip click',
+    source,
+    chipMeta,
+  }
+  const build = buildV5Payload(input)
+  if (!build.ok) throw new Error('payload build failed: ' + JSON.stringify(build))
+  // The producer's output must satisfy the 0.22 wire schema before it ships.
+  expect(() => OrchestratorTurnPayloadSchema.parse(build.payload)).not.toThrow()
+  const fetchImpl = makeFetchImpl()
+  await callV5Turn(build.payload, { fetchImpl })
+  expect(fetchImpl).toHaveBeenCalledTimes(1)
+  const init = fetchImpl.mock.calls[0][1] as { body: string }
+  return JSON.parse(init.body) as { source?: string; chip?: WireChip }
+}
+
+describe('typed mutation chips → HTTP body (finite numbers, CEE field names)', () => {
+  it('set_factor_value: typed value reaches the body as a real number, source promoted to chip_click', async () => {
+    const params = buildSetFactorValueParameters({ targetId: 'factor_price', value: 140, unit: '£' })
+    if (!params.ok) throw new Error('builder refused: ' + params.reason)
+    const body = await wireBody(
+      { id: 'chip_price', action_type: 'set_factor_value', parameters: params.parameters },
+      'chip',
+    )
+    // A bound action_type promotes a plain chip to chip_click — required for the
+    // typed-chip reader door (route-v2 isNonReadinessTypedChipClickForExecutor).
+    expect(body.source).toBe('chip_click')
+    expect(body.chip).toEqual({
+      id: 'chip_price',
+      action_type: 'set_factor_value',
+      parameters: { target_id: 'factor_price', value: 140, unit: '£' },
+    })
+    expect(typeof body.chip?.parameters?.value).toBe('number')
+    // The value is NEVER stringified onto the wire.
+    expect(JSON.stringify(body)).toContain('"value":140')
+    expect(JSON.stringify(body)).not.toContain('"value":"140"')
+  })
+
+  it('adjust_edge_strength: composed edge id + finite strength/std reach the body', async () => {
+    const params = buildAdjustEdgeStrengthParameters({ targetId: 'a→b', value: 0.4, std: 0.1 })
+    if (!params.ok) throw new Error('builder refused: ' + params.reason)
+    const body = await wireBody(
+      { action_type: 'adjust_edge_strength', parameters: params.parameters },
+      'chip',
+    )
+    expect(body.source).toBe('chip_click')
+    expect(body.chip).toEqual({
+      action_type: 'adjust_edge_strength',
+      parameters: { target_id: 'a→b', value: 0.4, std: 0.1 },
+    })
+    expect(typeof body.chip?.parameters?.value).toBe('number')
+    expect(typeof body.chip?.parameters?.std).toBe('number')
+  })
+
+  it('add_constraint: target + direction + finite value reach the body', async () => {
+    const params = buildAddConstraintParameters({
+      targetId: 'goal_1',
+      constraintType: 'at_least',
+      value: 0.15,
+    })
+    if (!params.ok) throw new Error('builder refused: ' + params.reason)
+    const body = await wireBody(
+      { action_type: 'add_constraint', parameters: params.parameters },
+      'chip',
+    )
+    expect(body.chip).toEqual({
+      action_type: 'add_constraint',
+      parameters: { target_id: 'goal_1', constraint_type: 'at_least', value: 0.15 },
+    })
+    expect(typeof body.chip?.parameters?.value).toBe('number')
+  })
+})
+
+describe('add_option intent chip → HTTP body (Intent, not action_type)', () => {
+  it('ships chip.intent=add_option with typed interventions and NO action_type', async () => {
+    const params = buildAddOptionParameters({
+      parentDecisionId: 'decision_1',
+      label: 'Hybrid plan',
+      interventions: [
+        { factorId: 'factor_price', value: 49 },
+        { factorId: 'factor_support', value: 2 },
+      ],
+    })
+    if (!params.ok) throw new Error('builder refused: ' + params.reason)
+    const body = await wireBody(
+      { intent: ADD_OPTION_INTENT, parameters: params.parameters },
+      // getInsightAction-class source — CEE accepts source ∈ {chip, chip_click}
+      // for chip.intent==='add_option' (route-v2.ts:2198).
+      'insight',
+    )
+    expect(body.source).toBe('chip')
+    expect(body.chip?.intent).toBe('add_option')
+    expect(body.chip && 'action_type' in body.chip).toBe(false)
+    expect(body.chip?.parameters).toEqual({
+      parent_decision_id: 'decision_1',
+      label: 'Hybrid plan',
+      interventions: [
+        { factor_id: 'factor_price', value: 49 },
+        { factor_id: 'factor_support', value: 2 },
+      ],
+    })
+  })
+})
+
+describe('first-class chip.id lift + intent send gate', () => {
+  it('lifts parameters.chip_id to a first-class chip.id (identity promoted, parameters preserved)', async () => {
+    const body = await wireBody({ parameters: { chip_id: 'decision_run_analysis' } }, 'chip')
+    expect(body.chip?.id).toBe('decision_run_analysis')
+    // Back-compat: the id STILL rides parameters until CEE reads chip.id.
+    expect(body.chip?.parameters).toEqual({ chip_id: 'decision_run_analysis' })
+  })
+
+  it('lifts parameters.spark_id when no chip_id and no explicit id is present', async () => {
+    const body = await wireBody({ parameters: { spark_id: 'prepare_first_analysis' } }, 'chip')
+    expect(body.chip?.id).toBe('prepare_first_analysis')
+  })
+
+  it('an explicit id wins over the parameters lift', async () => {
+    const body = await wireBody({ id: 'explicit', parameters: { chip_id: 'derived' } }, 'chip')
+    expect(body.chip?.id).toBe('explicit')
+  })
+
+  it('WITHHOLDS a not-yet-accepted intent (challenge_frame) — no intent key on the wire', async () => {
+    const body = await wireBody(
+      { intent: 'challenge_frame', parameters: { spark_id: 'frame_1' } },
+      'chip',
+    )
+    // The gate fails closed: the chip behaves like an identity-only chip.
+    expect(body.chip && 'intent' in body.chip).toBe(false)
+    expect(body.chip?.id).toBe('frame_1')
+    expect(body.chip?.parameters).toEqual({ spark_id: 'frame_1' })
+  })
+})

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -29,8 +29,9 @@ import type {
   TurnClassType,
   TurnSourceLiteral,
   ActionTypeLiteral,
+  IntentLiteral,
 } from '@talchain/schemas/boundary'
-import { ActionType } from '@talchain/schemas/boundary'
+import { ActionType, Intent } from '@talchain/schemas/boundary'
 
 import type { SystemEvent } from '../canvas/conversation/types'
 
@@ -46,7 +47,9 @@ export interface BuildV5PayloadInput {
   /** sendTurn source string. Maps to TurnSource. */
   source?: string | undefined
   /** Chip metadata forwarded by chip click handlers. */
-  chipMeta?: { action_type?: string; parameters?: Record<string, unknown> } | undefined
+  chipMeta?:
+    | { id?: string; action_type?: string; intent?: string; parameters?: Record<string, unknown> }
+    | undefined
   /**
    * Prior client_turn_id being retried. Today's UI reuses the prior
    * client_turn_id as the new turn's `turn_id` for idempotent replay
@@ -106,6 +109,12 @@ export function buildV5Payload(input: BuildV5PayloadInput): BuildV5PayloadResult
   // chip_click promotion — so the turn behaves exactly like today's
   // identity-only chip until the value is BOTH re-vendored and accepted.
   const wireActionType = sanitiseActionType(input.chipMeta?.action_type)
+  // The typed authored intent (0.22 `chip.intent`) rides the SAME two-signal
+  // gate discipline as action_type: published in OUR vendored enum AND accepted
+  // by CEE's deployed service. `add_option` is the only value CEE currently
+  // routes (see CEE_ACCEPTED_INTENTS); every other intent is withheld and the
+  // chip behaves exactly like today's identity-only chip until CEE confirms it.
+  const wireIntent = sanitiseIntent(input.chipMeta?.intent)
 
   // Derive source: chipMeta presence with a PUBLISHED action_type signals a
   // bound chip click regardless of what the caller labelled it. Keeps
@@ -135,13 +144,17 @@ export function buildV5Payload(input: BuildV5PayloadInput): BuildV5PayloadResult
     source,
   }
 
-  // Chip sub-object — only on chip / chip_click sources. Carries only the
-  // gate-passed (published AND CEE-accepted) action_type; identity parameters
-  // always travel.
+  // Chip sub-object — only on chip / chip_click sources. Carries the first-class
+  // chip `id`, the gate-passed (published AND CEE-accepted) `action_type` and
+  // `intent`, and the identity `parameters` (which always travel). Key order
+  // mirrors the 0.22 schema (id, action_type, intent, parameters).
   if ((source === 'chip' || source === 'chip_click') && input.chipMeta) {
     const parameters = input.chipMeta.parameters
+    const id = input.chipMeta.id
     base.chip = {
+      ...(id ? { id } : {}),
       ...(wireActionType ? { action_type: wireActionType } : {}),
+      ...(wireIntent ? { intent: wireIntent } : {}),
       ...(parameters ? { parameters } : {}),
     }
   }
@@ -498,5 +511,66 @@ function sanitiseActionType(raw: string | undefined): ActionTypeLiteral | undefi
   if (!raw) return undefined
   return isSendableActionType(raw, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES)
     ? (raw as ActionTypeLiteral)
+    : undefined
+}
+
+/**
+ * KNOWN_INTENTS — "is this value published in the `Intent` enum WE vendored?"
+ * DERIVED from the vendored @talchain/schemas `Intent` enum (never a hand list),
+ * the exact derive-don't-mirror discipline KNOWN_ACTION_TYPES uses. `Intent` is
+ * the 0.22 authored-intent set (`add_option`, `elicit_options`, coaching
+ * intents…). Necessary but NOT sufficient to send — the send gate also requires
+ * CEE_ACCEPTED_INTENTS.
+ */
+export const KNOWN_INTENTS: ReadonlySet<IntentLiteral> = new Set<IntentLiteral>(Intent.options)
+
+/**
+ * CEE-acceptance registry for typed intents — the SECOND, independent send-gate
+ * signal, answering "does CEE's DEPLOYED service ROUTE this intent?" (not "did
+ * WE publish it?"). Same rationale + hazards as CEE_ACCEPTED_ACTION_TYPES: a
+ * DELIBERATE hand-maintained allowlist that CANNOT be derived from our vendored
+ * enum (deriving it would re-couple publication with CEE acceptance and re-create
+ * the silent-drop bug the gate prevents). It fails CLOSED — an intent absent here
+ * is WITHHELD (the chip behaves like today's identity-only chip, never a wire
+ * 422), so drift over-blocks, never leaks. The element type is IntentLiteral, so
+ * an entry not in the vendored enum is a COMPILE error.
+ *
+ * Provenance per value:
+ * - add_option: C3's atomic add-option transaction, live on CEE staging since
+ *   `03d03e9`+ and present in build `e7f312d` (the edge-chip-door build).
+ *   route-v2.ts fires the add-option pre-route on
+ *   `(source ∈ {chip, chip_click}) && chip.intent === 'add_option'`, building ONE
+ *   atomic held proposal via add-option-transaction.ts; an incomplete/absent
+ *   `chip.parameters` falls through benignly to the coach (never a 422).
+ *
+ * NOT yet listed (deliberately withheld): the coaching / elicitation intents
+ * (`elicit_options`, `challenge_frame`, `challenge_assumption`, `outside_view`,
+ * `pre_mortem`, `elicit_risks`, `estimate_help`, `mitigation_help`,
+ * `define_success`, `discuss`). Their typed CEE routing arm (design §3.1) is not
+ * confirmed on the deployed service; the registry-stamping lane adds them here
+ * WITH deploy provenance, in lockstep with the CEE coaching-arm deploy.
+ */
+export const CEE_ACCEPTED_INTENTS: ReadonlySet<IntentLiteral> = new Set<IntentLiteral>([
+  'add_option',
+])
+
+/**
+ * The intent send gate, factored out as a PURE predicate (mirrors
+ * isSendableActionType) so a test can drive it with SYNTHETIC registries and
+ * prove the AND actually bites — publication alone (or acceptance alone) can
+ * never open it.
+ */
+export function isSendableIntent(
+  raw: string,
+  published: ReadonlySet<string>,
+  accepted: ReadonlySet<string>,
+): boolean {
+  return published.has(raw) && accepted.has(raw)
+}
+
+function sanitiseIntent(raw: string | undefined): IntentLiteral | undefined {
+  if (!raw) return undefined
+  return isSendableIntent(raw, KNOWN_INTENTS, CEE_ACCEPTED_INTENTS)
+    ? (raw as IntentLiteral)
     : undefined
 }

--- a/src/v5/chipParameters.ts
+++ b/src/v5/chipParameters.ts
@@ -1,0 +1,298 @@
+/**
+ * Typed chip-parameter builders — the UI-producer shape authority for the S2
+ * typed-mutation / add-option intents (@talchain/schemas 0.22.0).
+ *
+ * THE GAP THESE CLOSE: today a mutation chip sends free-text and relies on CEE
+ * re-parsing the rendered copy (Sonnet ORIENT / the deterministic value parser).
+ * S2 stops that: when the UI has RESOLVED the edit on the canvas (target id + a
+ * numeric value), it ships that pre-resolved spec in `chip.parameters` and CEE's
+ * typed reader synthesises a zero-LLM proposal. These builders produce EXACTLY
+ * the parameter shape CEE's readers accept — matched byte-for-byte against the
+ * CEE-side shape authorities at staging tip `e7f312d` (edge-chip-door build):
+ *   set_factor_value / adjust_edge_strength / add_constraint
+ *     → src/orchestrator-v5/routing/typed-chip-mutation-proposal.ts
+ *   add_option (an Intent, not an action_type)
+ *     → src/orchestrator-v5/routing/add-option-transaction.ts
+ *
+ * TWO HARD RULES (both enforced here, both proven by tests):
+ *  1. GENUINELY-TYPED FINITE NUMBERS, NEVER STRINGS, NEVER COERCED. Every
+ *     numeric field is emitted as a real `number` and validated `Number.isFinite`
+ *     (NaN / ±Infinity are rejected, not clamped). CEE's readers reject a
+ *     non-finite / non-numeric value and fall through to the LLM (#635); a
+ *     silent commit of a coerced value is the exact failure mode this closes.
+ *  2. NO SILENT DEFAULTING. A builder REFUSES (returns `{ ok: false, reason }`)
+ *     rather than fabricate a value or drop a bad one — the UI-is-a-passthrough
+ *     rule. The caller decides (fall through to free-text, surface an error).
+ *
+ * Chip copy is NOT a fallback channel (CEE no longer re-parses it, #639) — the
+ * value MUST ride these typed parameters or it does not reach CEE at all.
+ */
+
+/** Discriminated result — never throws, never coerces. */
+export type ChipParametersResult<T> =
+  | { readonly ok: true; readonly parameters: T }
+  | { readonly ok: false; readonly reason: ChipParametersFailReason }
+
+export type ChipParametersFailReason =
+  | 'target_id_required'
+  | 'edge_target_required'
+  | 'value_not_finite'
+  | 'value_out_of_range'
+  | 'std_not_finite'
+  | 'std_out_of_range'
+  | 'unit_invalid'
+  | 'operator_invalid'
+  | 'constraint_type_invalid'
+  | 'label_required'
+  | 'parent_decision_id_required'
+  | 'option_id_invalid'
+  | 'factor_id_required'
+  | 'raw_value_not_finite'
+  | 'duplicate_factor'
+  | 'too_many_interventions'
+
+/**
+ * Operator vocabulary — identical to CEE's `OperatorSchema`
+ * (typed-chip-mutation-proposal.ts). CEE defaults a missing operator to 'set';
+ * the UI only emits `operator` when it genuinely means a non-set operation.
+ */
+export const CHIP_PARAM_OPERATORS = ['set', 'increase', 'decrease', 'multiply'] as const
+export type ChipParamOperator = (typeof CHIP_PARAM_OPERATORS)[number]
+
+/** add_constraint direction vocabulary — CEE `constraint_type`. */
+export const CONSTRAINT_TYPES = ['at_least', 'at_most'] as const
+export type ConstraintType = (typeof CONSTRAINT_TYPES)[number]
+
+/**
+ * Max intervention factors on a single add_option chip.
+ *
+ * CEE's held-proposal PROPOSAL_CAP is 8 PatchOperations. An add_option
+ * transaction (add-option-transaction.ts) emits: 1 `add_node` (the option) +
+ * 1 `add_edge` (parent-decision → option) + N `add_edge` (option → factor),
+ * where N = interventions.length. So N + 2 ≤ 8 ⇒ N ≤ 6. A chip proposing more
+ * than 6 configured factors exceeds the cap and CEE classifies it as a
+ * fall-through — never let the UI emit a doomed transaction.
+ */
+export const MAX_ADD_OPTION_INTERVENTIONS = 6
+
+// --- shared guards ----------------------------------------------------------
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0
+}
+
+function isOperator(v: unknown): v is ChipParamOperator {
+  return typeof v === 'string' && (CHIP_PARAM_OPERATORS as readonly string[]).includes(v)
+}
+
+function fail<T>(reason: ChipParametersFailReason): ChipParametersResult<T> {
+  return { ok: false, reason }
+}
+
+// --- set_factor_value -------------------------------------------------------
+
+export type SetFactorValueParameters = {
+  target_id: string
+  value: number
+  unit?: string
+  operator?: ChipParamOperator
+}
+
+export interface SetFactorValueInput {
+  /** Factor node id (CEE requires the target to resolve to a `factor` node). */
+  targetId: string
+  /** The factor value — a genuine finite number. */
+  value: number
+  unit?: string
+  operator?: ChipParamOperator
+}
+
+export function buildSetFactorValueParameters(
+  input: SetFactorValueInput,
+): ChipParametersResult<SetFactorValueParameters> {
+  if (!isNonEmptyString(input.targetId)) return fail('target_id_required')
+  if (!Number.isFinite(input.value)) return fail('value_not_finite')
+  if (input.unit !== undefined && !isNonEmptyString(input.unit)) return fail('unit_invalid')
+  if (input.operator !== undefined && !isOperator(input.operator)) return fail('operator_invalid')
+  return {
+    ok: true,
+    parameters: {
+      target_id: input.targetId,
+      value: input.value,
+      ...(input.unit !== undefined ? { unit: input.unit } : {}),
+      ...(input.operator !== undefined ? { operator: input.operator } : {}),
+    },
+  }
+}
+
+// --- adjust_edge_strength ---------------------------------------------------
+
+export type AdjustEdgeStrengthParameters = {
+  target_id?: string
+  from?: string
+  to?: string
+  /** Edge strength — CEE's chip.parameters field is `value` (the ProposalAction
+   * later names it `strength`). Finite, in [-1, 1]. */
+  value: number
+  std?: number
+  operator?: ChipParamOperator
+}
+
+export interface AdjustEdgeStrengthInput {
+  /** A composed edge id ("from→to" or "from->to"). Provide this OR from+to. */
+  targetId?: string
+  from?: string
+  to?: string
+  /** Edge strength (finite, [-1, 1]). */
+  value: number
+  /** Optional dispersion (finite, (0, 0.5]). */
+  std?: number
+  operator?: ChipParamOperator
+}
+
+export function buildAdjustEdgeStrengthParameters(
+  input: AdjustEdgeStrengthInput,
+): ChipParametersResult<AdjustEdgeStrengthParameters> {
+  const hasComposed = isNonEmptyString(input.targetId)
+  const hasPair = isNonEmptyString(input.from) && isNonEmptyString(input.to)
+  // CEE refine: target_id != null OR (from != null AND to != null).
+  if (!hasComposed && !hasPair) return fail('edge_target_required')
+  if (!Number.isFinite(input.value)) return fail('value_not_finite')
+  if (input.value < -1 || input.value > 1) return fail('value_out_of_range')
+  if (input.std !== undefined) {
+    if (!Number.isFinite(input.std)) return fail('std_not_finite')
+    if (input.std <= 0 || input.std > 0.5) return fail('std_out_of_range')
+  }
+  if (input.operator !== undefined && !isOperator(input.operator)) return fail('operator_invalid')
+  // Prefer the composed id when supplied (CEE parses "from→to"); otherwise the
+  // explicit endpoint pair. Never emit both.
+  const target = hasComposed
+    ? { target_id: input.targetId as string }
+    : { from: input.from as string, to: input.to as string }
+  return {
+    ok: true,
+    parameters: {
+      ...target,
+      value: input.value,
+      ...(input.std !== undefined ? { std: input.std } : {}),
+      ...(input.operator !== undefined ? { operator: input.operator } : {}),
+    },
+  }
+}
+
+// --- add_constraint ---------------------------------------------------------
+
+export type AddConstraintParameters = {
+  target_id: string
+  constraint_type: ConstraintType
+  value: number
+  label?: string
+  unit?: string
+}
+
+export interface AddConstraintInput {
+  /** Goal / node id the constraint attaches to (an option target is refused by CEE). */
+  targetId: string
+  constraintType: ConstraintType
+  value: number
+  label?: string
+  unit?: string
+}
+
+export function buildAddConstraintParameters(
+  input: AddConstraintInput,
+): ChipParametersResult<AddConstraintParameters> {
+  if (!isNonEmptyString(input.targetId)) return fail('target_id_required')
+  if (input.constraintType !== 'at_least' && input.constraintType !== 'at_most') {
+    return fail('constraint_type_invalid')
+  }
+  if (!Number.isFinite(input.value)) return fail('value_not_finite')
+  if (input.label !== undefined && !isNonEmptyString(input.label)) return fail('label_required')
+  if (input.unit !== undefined && !isNonEmptyString(input.unit)) return fail('unit_invalid')
+  return {
+    ok: true,
+    parameters: {
+      target_id: input.targetId,
+      constraint_type: input.constraintType,
+      value: input.value,
+      ...(input.label !== undefined ? { label: input.label } : {}),
+      ...(input.unit !== undefined ? { unit: input.unit } : {}),
+    },
+  }
+}
+
+// --- add_option (Intent) ----------------------------------------------------
+
+export type AddOptionInterventionParameters = {
+  factor_id: string
+  value: number
+  unit?: string
+  raw_value?: number | string | boolean
+}
+
+export type AddOptionParameters = {
+  parent_decision_id: string
+  label: string
+  option_id?: string
+  interventions: AddOptionInterventionParameters[]
+}
+
+export interface AddOptionInterventionInput {
+  factorId: string
+  /** The effect value — a genuine finite number. */
+  value: number
+  unit?: string
+  /** Polymorphic raw value; the NUMBER branch must still be finite. */
+  rawValue?: number | string | boolean
+}
+
+export interface AddOptionInput {
+  parentDecisionId: string
+  label: string
+  optionId?: string
+  interventions: AddOptionInterventionInput[]
+}
+
+export function buildAddOptionParameters(
+  input: AddOptionInput,
+): ChipParametersResult<AddOptionParameters> {
+  if (!isNonEmptyString(input.parentDecisionId)) return fail('parent_decision_id_required')
+  if (!isNonEmptyString(input.label)) return fail('label_required')
+  if (input.optionId !== undefined && !isNonEmptyString(input.optionId)) {
+    return fail('option_id_invalid')
+  }
+  // Guard the PROPOSAL_CAP up front so the UI never emits a doomed transaction.
+  if (input.interventions.length > MAX_ADD_OPTION_INTERVENTIONS) {
+    return fail('too_many_interventions')
+  }
+  const seenFactors = new Set<string>()
+  const interventions: AddOptionInterventionParameters[] = []
+  for (const iv of input.interventions) {
+    if (!isNonEmptyString(iv.factorId)) return fail('factor_id_required')
+    if (seenFactors.has(iv.factorId)) return fail('duplicate_factor')
+    seenFactors.add(iv.factorId)
+    if (!Number.isFinite(iv.value)) return fail('value_not_finite')
+    if (iv.unit !== undefined && !isNonEmptyString(iv.unit)) return fail('unit_invalid')
+    if (typeof iv.rawValue === 'number' && !Number.isFinite(iv.rawValue)) {
+      return fail('raw_value_not_finite')
+    }
+    interventions.push({
+      factor_id: iv.factorId,
+      value: iv.value,
+      ...(iv.unit !== undefined ? { unit: iv.unit } : {}),
+      ...(iv.rawValue !== undefined ? { raw_value: iv.rawValue } : {}),
+    })
+  }
+  return {
+    ok: true,
+    parameters: {
+      parent_decision_id: input.parentDecisionId,
+      label: input.label,
+      ...(input.optionId !== undefined ? { option_id: input.optionId } : {}),
+      interventions,
+    },
+  }
+}
+
+/** The typed intent an add_option chip carries (an `Intent`, not an `ActionType`). */
+export const ADD_OPTION_INTENT = 'add_option' as const


### PR DESCRIPTION
## Lane U — UI typed-chip/intent producers (S2+S3)

The UI starts EMITTING the 0.22 typed chip identity on the live wire. CEE's accept side is fully deployed (CEE staging `e7f312d`, incl. the edge-chip door #643); the UI sent only legacy `action_type` + `parameters`. This closes the producer gap.

**Scope: producer plumbing + typed parameter builders + seam pins. No new rendered UI surface; no meaning transforms.**

### 1. Thread `chip.id` + `chip.intent` (retaining legacy `action_type`)
- `src/canvas/conversation/chipMeta.ts` — `ChipMetaInput`/`ChipMeta` gain `id` + `intent`. `buildChipMeta` LIFTS `chip.id` from the identity the UI already ships inside `parameters` (`chip_id`, then `spark_id`) — a pure identity promotion; `parameters` still carries it for back-compat until CEE reads `chip.id`. `toLegacyChipMetadata` still drops `id`/`intent` (V5-only).
- `src/v5/buildPayload.ts` — the wire chip now carries `id` + `intent` (key order mirrors the 0.22 schema). Adds a two-signal **intent send gate** mirroring the action_type gate: `KNOWN_INTENTS` (DERIVED from `Intent.options`) AND `CEE_ACCEPTED_INTENTS` (hand-list, currently `{add_option}` with provenance). Fails closed — an unaccepted intent is withheld, never a 422.
- `src/canvas/conversation/useConversation.ts` — `DispatchActionOpts` gains `id` + `intent`; `sendChip` threads `ActionChip.id`. **Naming collision flagged:** `ActionChip.intent` is the UI *styling* intent (`'primary' | 'secondary' | 'undo'`), NOT the wire `Intent` set — so `sendChip` forwards `chip.id` but not `chip.intent`.

### 2. Typed mutation parameters — `src/v5/chipParameters.ts` (new)
Pure builders producing genuinely-typed FINITE numbers (`value`, edge strength, `std`), never strings, never coerced/clamped. They REFUSE (`{ok:false, reason}`) rather than default — the UI-is-a-passthrough rule; a non-finite value would otherwise fall through to CEE's LLM path (#635), never a silent commit. Field names matched byte-for-byte against the CEE-side shape authorities (see below).

### 3. `add_option` is an Intent (not an action_type)
`buildAddOptionParameters` emits `parent_decision_id` + `label` + typed `interventions[]`, and is capped at **6 interventions** (`MAX_ADD_OPTION_INTERVENTIONS`): CEE PROPOSAL_CAP=8, ops = 1 node + 1 parent edge + N factor edges = N+2 ≤ 8 ⇒ N ≤ 6. `ADD_OPTION_INTENT` rides `chip.intent`; CEE (`route-v2.ts:2198`) fires on `(source ∈ {chip, chip_click}) && chip.intent === 'add_option'`.

### CEE reader field names verified (read, not guessed)
Fetched at CEE **staging tip `e7f312d198b07059cf447ce233b4a54fab46a1c2`** (`gh api .../contents/<path>?ref=staging`):

`src/orchestrator-v5/routing/typed-chip-mutation-proposal.ts`:
- `set_factor_value`: `{ target_id, value:number FINITE, unit?, operator?:'set'|'increase'|'decrease'|'multiply' }`
- `adjust_edge_strength`: `{ target_id:"from→to" | (from,to), value:number FINITE ∈ [-1,1], std?:number FINITE ∈ (0,0.5], operator? }` — wire field is `value` (the ProposalAction later names it `strength`)
- `add_constraint`: `{ target_id, constraint_type:'at_least'|'at_most', value:number FINITE, label?, unit? }`

`src/orchestrator-v5/routing/add-option-transaction.ts`:
- `add_option` (intent): `{ parent_decision_id, label, option_id?, interventions:[{ factor_id, value:number FINITE, unit?, raw_value?:number FINITE|string|boolean }] }`

### Tests
- `src/v5/__tests__/chipParameters.spec.ts` (17) — field names, finite enforcement, ranges, ≤6 cap, edge target modes, duplicate-factor refusal.
- `src/v5/__tests__/typedChipProducers.seam.spec.ts` (8) — **producer→wire seam**: `buildChipMeta → buildV5Payload → callV5Turn(fetchImpl) → JSON.parse(body)` for all four producers + `chip.id` lift + intent-gate withholding, each round-tripped through `OrchestratorTurnPayloadSchema` (0.22 `.strict()`).
- `src/v5/__tests__/intentGate.spec.ts` (7) — `KNOWN_INTENTS === Intent.options`, accepted ⊆ published, and `isSendableIntent` AND-bites proof.

### Mutation-check matrix (throwaway copy, reverted after)
| # | Reverted mechanism | Tests that went RED |
|---|---|---|
| 1 | wire chip `id`/`intent` threading (buildPayload) | 6 seam tests (set_factor_value id, add_option intent, chip_id/spark_id lift, explicit-id-wins, withhold-id) |
| 2 | `CEE_ACCEPTED_INTENTS` → empty | intentGate (add_option accepted) + seam (ships intent=add_option) |
| 3 | `deriveChipId` parameters lift (chipMeta) | 3 seam tests (chip_id lift, spark_id lift, withhold-id) |
| 4 | `set_factor_value` finite guard | chipParameters (refuses NaN/Infinity) |
| 5 | `add_option` cap guard | chipParameters (caps at 6) |

### Gates
- `pnpm run typecheck` (tsconfig.ci): **clean** (covers `src/v5/**` incl. the new module + tests; transitively pulls `chipMeta.ts`).
- `npx eslint` on changed files: **0 errors** (9 pre-existing warnings in `useConversation.ts`, all outside the edited lines).
- Targeted vitest: **121 passed** across the new + affected existing specs (NodeChip.intent, sparkIntentContract, buildPayload, goalThreshold.chipToWire, dispatchAction.dom, useConversation.hook, whatChangedSend, explainChips.vocabulary).

### Honest deferrals
- **Coaching/elicitation intents** (`elicit_options`, `challenge_frame`, `challenge_assumption`, …) are withheld by `CEE_ACCEPTED_INTENTS` — their typed CEE routing arm (design §3.1) is not confirmed on the deployed service. Adding them (with deploy provenance) + stamping the four UI registries is the broader Lane U1 registry-stamping task.
- **`getInsightAction`'s mislabeled `add_option`/`challenge_assumption`** (`MessageBubble.tsx`, currently invalid `action_type`s silently stripped) are NOT retagged here: "Explore more options" is semantically `elicit_options`, not `add_option` — the elicit-vs-add decision is a product-semantic call for the registry-stamping lane. Behaviour is unchanged (still stripped).
- No live rendered typed-mutation/add_option chip surface exists to emit these yet; the producer capability is proven by the seam tests. The brief's live-browser acceptance probe is downstream once such a surface is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
