### PR TITLE
feat(v7-l6): guidance with categories/priority + held-proposal single-confirm card + bias section

### DIFF
--- a/src/components/results/AdvancedSection.tsx
+++ b/src/components/results/AdvancedSection.tsx
@@ -419,7 +419,8 @@ export function AdvancedSection({
                 row is omitted — never a per-option or stale-prior-run number. */}
             {nSamples != null && (
               <>
-                <dt className="text-text-light">Simulation quality</dt>
+                {/* Row 12: label carries the real wire field name (`meta.n_samples`). */}
+                <dt className="text-text-light" title="meta.n_samples">Simulation quality</dt>
                 <dd className="text-text-header">{nSamples.toLocaleString()} simulations</dd>
               </>
             )}
@@ -463,7 +464,8 @@ export function AdvancedSection({
             )}
             {seedUsed != null && (
               <>
-                <dt className="text-text-light">Seed</dt>
+                {/* Row 12: label carries the real wire field name (`meta.seed`). */}
+                <dt className="text-text-light" title="meta.seed">Seed</dt>
                 <dd className="text-text-header font-mono">{seedUsed}</dd>
               </>
             )}

--- a/src/components/results/__tests__/AdvancedSection.spec.tsx
+++ b/src/components/results/__tests__/AdvancedSection.spec.tsx
@@ -351,4 +351,12 @@ describe('AdvancedSection', () => {
     fireEvent.click(screen.getByText('Advanced and receipts'))
     expect(screen.queryByText('Seed')).not.toBeInTheDocument()
   })
+
+  // ── V7 L6 row 12: receipt labels name the real wire meta field ──────────
+  it('names the real wire fields on the Seed and Simulation rows (row 12)', () => {
+    render(<AdvancedSection nSamples={1000} seedUsed={42} />)
+    fireEvent.click(screen.getByText('Advanced and receipts'))
+    expect(screen.getByText('Seed')).toHaveAttribute('title', 'meta.seed')
+    expect(screen.getByText('Simulation quality')).toHaveAttribute('title', 'meta.n_samples')
+  })
 })

--- a/src/components/results/coaching/AskOlumiDrawer.tsx
+++ b/src/components/results/coaching/AskOlumiDrawer.tsx
@@ -27,6 +27,7 @@ import { X } from 'lucide-react'
 
 import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
 import { focusModelTarget } from '../../../canvas/utils/focusHelpers'
+import { V7_MODEL_LIMIT_CAVEAT } from '../v7/v7GuidanceCopy'
 import { useAskOlumiStore } from './askOlumiStore'
 
 const TOAST_MS = 1800
@@ -144,6 +145,14 @@ export function AskOlumiDrawer() {
                 {context}
               </p>
             )}
+            {/* Row 15: the drawer ALWAYS carries the model-limit caveat, so a
+                work-through never reads as a real-world forecast. Copy only. */}
+            <p
+              data-testid="ask-olumi-model-limit"
+              className="mb-2 text-[11px] leading-snug text-text-light"
+            >
+              {V7_MODEL_LIMIT_CAVEAT}
+            </p>
             <textarea
               ref={textareaRef}
               data-testid="ask-olumi-draft"

--- a/src/components/results/coaching/__tests__/AskOlumiDrawer.spec.tsx
+++ b/src/components/results/coaching/__tests__/AskOlumiDrawer.spec.tsx
@@ -115,4 +115,13 @@ describe('AskOlumiDrawer', () => {
     act(() => openAskOlumi(payload))
     expect(screen.queryByRole('button', { name: 'Focus on canvas' })).not.toBeInTheDocument()
   })
+
+  // ── V7 L6 row 15: the drawer ALWAYS carries the model-limit caveat ──────
+  it('always shows the model-limit caveat, even with no context line', () => {
+    render(<AskOlumiDrawer />)
+    act(() => openAskOlumi({ ...payload, context: '' }))
+    const caveat = screen.getByTestId('ask-olumi-model-limit')
+    expect(caveat).toBeInTheDocument()
+    expect(caveat).toHaveTextContent(/not guarantee the real world/i)
+  })
 })

--- a/src/components/results/v7/V7BiasSection.tsx
+++ b/src/components/results/v7/V7BiasSection.tsx
@@ -1,0 +1,113 @@
+/**
+ * V7BiasSection — "Challenge your assumptions" (V7 Lane L6, spec row 11).
+ *
+ * Bias-coaching cards built from the producer's bias findings (the untyped
+ * `ceeReview(V1).bias_findings` passthrough seam — see buildV7Bias). Each card
+ * shows the producer description plus the `micro_intervention.steps` and
+ * `estimated_minutes` VISIBLE (spec row 11), verbatim.
+ *
+ * COMPLETE borders only. The prototype's `.coach-card` `border-left:3px` is
+ * named a violation in V6-RESPEC §3.1 and is NOT reproduced: the card carries a
+ * complete four-sided `border-panel-border`, and the bias KIND is conveyed by a
+ * badge + icon tint, never an edge accent.
+ *
+ * PASSTHROUGH, additive, flagless. Honest absence: no findings → renders
+ * nothing (never an empty coaching shell). Reads the canvas store with a STABLE
+ * selector (`s.runMeta`); the source pick + mapping run in a memo, never in the
+ * selector (inline-selector landmine).
+ */
+
+import { useMemo } from 'react'
+import { Brain, Clock } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { useCanvasStore } from '../../../canvas/store'
+import { buildV7BiasFindings, pickBiasFindingsSource, type V7BiasFinding } from './buildV7Bias'
+import { V7_GUIDANCE_COPY } from './v7GuidanceCopy'
+
+const B = V7_GUIDANCE_COPY.bias
+
+function BiasCard({ finding }: { finding: V7BiasFinding }) {
+  return (
+    <div
+      data-testid="v7-bias-card"
+      className="rounded-lg border border-panel-border bg-panel p-3 space-y-1.5"
+    >
+      <div className="flex items-center gap-2">
+        <Brain aria-hidden="true" className="h-3.5 w-3.5 flex-none text-info" />
+        {/* Kind badge — outlined, complete border; conveys kind without an edge accent. */}
+        <span
+          data-testid="v7-bias-kind"
+          className={`flex-none rounded-full border border-info/30 bg-transparent px-1.5 py-0 ${typography.panelMeta} text-text-body`}
+        >
+          {finding.kindLabel}
+        </span>
+      </div>
+
+      {finding.description && (
+        <p className={`${typography.panelBody} text-text-body`}>{finding.description}</p>
+      )}
+
+      {finding.steps.length > 0 && (
+        <div className="space-y-1" data-testid="v7-bias-steps">
+          <div className="flex items-center gap-2">
+            <span className={`${typography.panelMeta} font-semibold text-text-header`}>
+              {B.stepsLabel}
+            </span>
+            {finding.estimatedMinutes != null && (
+              <span
+                data-testid="v7-bias-minutes"
+                className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}
+              >
+                <Clock aria-hidden="true" className="h-3 w-3 flex-none" />
+                {B.minutes(finding.estimatedMinutes)}
+              </span>
+            )}
+          </div>
+          <ol className="space-y-0.5">
+            {finding.steps.map((step, i) => (
+              <li key={i} className={`${typography.panelMeta} text-text-body`}>
+                {i + 1}. {step}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {/* Minutes with no steps still surfaces the estimate honestly. */}
+      {finding.steps.length === 0 && finding.estimatedMinutes != null && (
+        <span
+          data-testid="v7-bias-minutes"
+          className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}
+        >
+          <Clock aria-hidden="true" className="h-3 w-3 flex-none" />
+          {B.minutes(finding.estimatedMinutes)}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export function V7BiasSection() {
+  // STABLE selector — the runMeta object reference. Source pick + build run in
+  // the memo, never in the selector.
+  const runMeta = useCanvasStore((s) => s.runMeta)
+  const findings = useMemo(() => buildV7BiasFindings(pickBiasFindingsSource(runMeta)), [runMeta])
+
+  if (findings.length === 0) return null
+
+  return (
+    <section data-testid="v7-bias-section" className="space-y-2">
+      <div>
+        <h3 className={`${typography.panelHeader} text-text-header`}>{B.heading}</h3>
+        <p className={`${typography.panelMeta} text-text-light`}>{B.subtitle}</p>
+      </div>
+      <div className="space-y-2">
+        {findings.map((f) => (
+          <BiasCard key={f.key} finding={f} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default V7BiasSection

--- a/src/components/results/v7/V7GuidanceSection.tsx
+++ b/src/components/results/v7/V7GuidanceSection.tsx
@@ -1,0 +1,236 @@
+/**
+ * V7GuidanceSection — "What to do next" (V7 Lane L6, spec rows 8 + 9).
+ *
+ * Renders the guidance store's items, ordered by the ONE canonical
+ * display-order doctrine (severity `category` major → producer `priorityRank`
+ * → coarse `priority`; see buildV7Guidance / compareGuidanceDisplayOrder). The
+ * top item shows open; the rest are counted behind a "Show N more" toggle
+ * (spec: "one open, rest counted").
+ *
+ * Category is conveyed by an OUTLINED count-style badge (DS v5 §22.3) — a
+ * complete four-sided border whose COLOUR carries severity, never a
+ * `border-l-*` accent, never a filled or `text-{colour}` pill. An ABSENT
+ * producer category suppresses the badge (honest — never a synthesised
+ * severity).
+ *
+ * Each item's `primary_action` maps to its honest affordance (spec row 9):
+ *   · open_inspector → Focus (centres the node on canvas)
+ *   · discuss        → Work through it (opens the Ask-Olumi drawer)
+ *   · run_exercise   → Try a … (sends the exercise command)
+ *   · approve_patch  → promoted to the held-proposal card, never listed here
+ *   · anything else  → NO affordance (fail closed, no guessing)
+ *
+ * PASSTHROUGH only, no flags, additive, COMPLETE borders. Reads the shared
+ * guidance store with STABLE selectors (never an inline object selector — the
+ * Zustand inline-selector landmine); the ordering happens in a memo, never in
+ * the selector.
+ */
+
+import { useMemo, useState } from 'react'
+import { Crosshair, MessageCircle, FlaskConical } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import {
+  useGuidanceStore,
+  selectGuidanceItems,
+  type GuidanceItem,
+  type GuidanceCategory,
+} from '../../../canvas/stores/guidanceStore'
+import { openAskOlumi } from '../coaching/askOlumiStore'
+import { buildV7Guidance, deriveGuidanceAffordance } from './buildV7Guidance'
+import { V7_GUIDANCE_COPY } from './v7GuidanceCopy'
+import { V7HeldProposalCard } from './V7HeldProposalCard'
+
+const C = V7_GUIDANCE_COPY.guidance
+
+export interface V7GuidanceSectionProps {
+  onFocusNode?: (nodeId: string) => void
+  onSendMessage?: (text: string) => void
+}
+
+/** Outlined category badge — colour on ALL four sides (complete border),
+ *  never a one-sided accent, never a filled or text-{colour} pill. */
+function categoryBorderClass(cat: GuidanceCategory): string {
+  switch (cat) {
+    case 'must_fix':
+      return 'border-danger/30'
+    case 'should_fix':
+      return 'border-warning/30'
+    case 'could_fix':
+      return 'border-info/30'
+    case 'technique':
+      return 'border-panel-border'
+  }
+}
+
+function CategoryBadge({ category }: { category?: GuidanceCategory }) {
+  // Absent producer category → no badge (never a synthesised severity).
+  if (!category) return null
+  return (
+    <span
+      data-testid="v7-guidance-badge"
+      data-category={category}
+      className={`flex-none rounded-full border ${categoryBorderClass(category)} bg-transparent px-1.5 py-0 ${typography.panelMeta} text-text-body`}
+    >
+      {C.categoryLabel[category]}
+    </span>
+  )
+}
+
+function GuidanceAffordance({
+  item,
+  onFocusNode,
+  onSendMessage,
+}: {
+  item: GuidanceItem
+  onFocusNode?: (nodeId: string) => void
+  onSendMessage?: (text: string) => void
+}) {
+  const affordance = deriveGuidanceAffordance(item)
+
+  const chipClass = `inline-flex items-center gap-1.5 rounded-full border border-panel-border bg-transparent px-2.5 py-1 ${typography.panelMeta} text-text-body hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`
+
+  switch (affordance.kind) {
+    case 'focus':
+      if (!onFocusNode) return null
+      return (
+        <button
+          type="button"
+          data-testid="v7-guidance-action-focus"
+          onClick={() => onFocusNode(affordance.nodeId)}
+          className={chipClass}
+        >
+          <Crosshair aria-hidden="true" className="h-3 w-3 flex-none text-info" />
+          {C.action.focus}
+        </button>
+      )
+    case 'work_through':
+      return (
+        <button
+          type="button"
+          data-testid="v7-guidance-action-work-through"
+          onClick={() =>
+            openAskOlumi({ context: item.title, draft: affordance.prompt, label: C.action.workThrough })
+          }
+          className={chipClass}
+        >
+          <MessageCircle aria-hidden="true" className="h-3 w-3 flex-none text-info" />
+          {C.action.workThrough}
+        </button>
+      )
+    case 'run_exercise':
+      if (!onSendMessage) return null
+      return (
+        <button
+          type="button"
+          data-testid="v7-guidance-action-run-exercise"
+          onClick={() => onSendMessage(`/exercise ${affordance.exercise}`)}
+          className={chipClass}
+        >
+          <FlaskConical aria-hidden="true" className="h-3 w-3 flex-none text-info" />
+          {C.action.runExercise(affordance.exercise)}
+        </button>
+      )
+    // 'none' — unknown / navigate / promoted approve_patch: render NO
+    // affordance (fail closed). The item still shows its title + category.
+    case 'none':
+      return null
+  }
+}
+
+function GuidanceRow({
+  item,
+  open,
+  onFocusNode,
+  onSendMessage,
+}: {
+  item: GuidanceItem
+  open: boolean
+  onFocusNode?: (nodeId: string) => void
+  onSendMessage?: (text: string) => void
+}) {
+  return (
+    <div className="space-y-1" data-testid="v7-guidance-item" data-item-id={item.item_id}>
+      <div className="flex items-start gap-2">
+        <CategoryBadge category={item.category} />
+        <p className={`${typography.panelBody} min-w-0 flex-1 text-text-body`}>{item.title}</p>
+      </div>
+      {open && item.detail && (
+        <p className={`${typography.panelMeta} text-text-light`}>{item.detail}</p>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        <GuidanceAffordance item={item} onFocusNode={onFocusNode} onSendMessage={onSendMessage} />
+      </div>
+    </div>
+  )
+}
+
+export function V7GuidanceSection({ onFocusNode, onSendMessage }: V7GuidanceSectionProps) {
+  // STABLE selector — the stored array reference. Ordering/splitting happens in
+  // the memo below, NEVER in the selector (inline-selector landmine).
+  const guidanceItems = useGuidanceStore(selectGuidanceItems)
+  const [showAll, setShowAll] = useState(false)
+
+  const { guidance, heldProposals } = useMemo(() => buildV7Guidance(guidanceItems), [guidanceItems])
+
+  // Nothing to guide AND no held proposal → render nothing (never a shell).
+  if (guidance.length === 0 && heldProposals.length === 0) return null
+
+  const top = guidance[0]
+  const rest = guidance.slice(1)
+  const moreCount = rest.length
+
+  return (
+    <section
+      data-testid="v7-guidance-section"
+      className="rounded-lg border border-panel-border bg-panel px-3 py-2.5 space-y-2.5"
+    >
+      {/* Held proposals (approve_patch) — the ONLY L6 surface for a proposal,
+          a display-only pointer to the single live confirm in chat. Rendered
+          above the next-steps list so a pending change reads first. */}
+      {heldProposals.map((item) => (
+        <V7HeldProposalCard key={item.item_id} item={item} />
+      ))}
+
+      {guidance.length > 0 && (
+        <div className="space-y-2">
+          <div>
+            <h3 className={`${typography.panelHeader} text-text-header`}>{C.heading}</h3>
+            <p className={`${typography.panelMeta} text-text-light`}>{C.subtitle}</p>
+          </div>
+
+          {/* Top item — shown open. */}
+          <GuidanceRow item={top} open onFocusNode={onFocusNode} onSendMessage={onSendMessage} />
+
+          {/* The rest — counted, revealed on demand. */}
+          {moreCount > 0 && (
+            <>
+              {showAll && (
+                <div className="space-y-2 border-t border-panel-border pt-2">
+                  {rest.map((item) => (
+                    <GuidanceRow
+                      key={item.item_id}
+                      item={item}
+                      open={false}
+                      onFocusNode={onFocusNode}
+                      onSendMessage={onSendMessage}
+                    />
+                  ))}
+                </div>
+              )}
+              <button
+                type="button"
+                data-testid="v7-guidance-toggle"
+                onClick={() => setShowAll((s) => !s)}
+                className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+              >
+                {showAll ? C.showFewer : C.showMore(moreCount)}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default V7GuidanceSection

--- a/src/components/results/v7/V7HeldProposalCard.tsx
+++ b/src/components/results/v7/V7HeldProposalCard.tsx
@@ -1,0 +1,120 @@
+/**
+ * V7HeldProposalCard — the held-proposal surface in the V7 analysis panel
+ * (V7 Lane L6, spec row 10).
+ *
+ * ⚠️ CONFIRM-OWNERSHIP (the doubled-confirm defect, Paul-hit, UI PR #424).
+ * There must be EXACTLY ONE live confirm affordance per proposal across the
+ * whole panel. The single owner already exists: on a held-proposal turn CEE
+ * single-sources ONE confirm chip (`confirm_action_id`) and the conversation's
+ * V5HeldProposalBlock resolves + renders it (and buildSuggestedActionChips
+ * drops that id from the generic chip row). A guidance `approve_patch` item is,
+ * by the established GuidanceStrip doctrine, a POINTER to that owner — its
+ * handler SCROLLS to the GraphPatchBlock, it never applies.
+ *
+ * So this card is DISPLAY-ONLY. It summarises the proposal (title, detail,
+ * ≤3 change lines) and offers a single "Review in chat" POINTER
+ * (`_scrollToPatch`) to the one live confirm — it mints NO confirm/apply of
+ * its own. Claiming the confirm here would either duplicate the owner or force
+ * a client-minted apply path (which V5HeldProposalBlock explicitly forbids);
+ * both cross the ownership seam, so per the lane brief we ship display-only and
+ * flag the tension. The invariant thus holds by construction: this file
+ * contains no confirm control.
+ *
+ * PASSTHROUGH, additive, flagless, COMPLETE border.
+ */
+
+import { Hand } from 'lucide-react'
+import { typography } from '@/styles/typography'
+import { useGuidanceStore, type GuidanceItem } from '../../../canvas/stores/guidanceStore'
+import { V7_GUIDANCE_COPY } from './v7GuidanceCopy'
+
+const P = V7_GUIDANCE_COPY.proposal
+const MAX_ITEMS = 3
+
+export interface V7HeldProposalCardProps {
+  /** A guidance item whose primary_action is `approve_patch`. */
+  item: GuidanceItem
+}
+
+/** Humanise an operation's `op` verb ("add_edge" → "Add edge"). Returns null
+ *  for anything that is not a plain snake_case verb, so no raw id or opaque
+ *  value is ever rendered (fail closed). */
+function describeOp(op: unknown): string | null {
+  if (!op || typeof op !== 'object') return null
+  const verb = (op as Record<string, unknown>).op ?? (op as Record<string, unknown>).type
+  if (typeof verb !== 'string' || !/^[a-z][a-z0-9_]*$/.test(verb)) return null
+  const words = verb.replace(/_/g, ' ')
+  return words.charAt(0).toUpperCase() + words.slice(1)
+}
+
+export function V7HeldProposalCard({ item }: V7HeldProposalCardProps) {
+  // Stable selector — the registered scroll-to-patch seam (or null).
+  const scrollToPatch = useGuidanceStore((s) => s._scrollToPatch)
+
+  const action = item.primary_action
+  const operations = action.type === 'approve_patch' && Array.isArray(action.operations) ? action.operations : []
+
+  const described = operations.map(describeOp).filter((d): d is string => d != null)
+  const visible = described.slice(0, MAX_ITEMS)
+  const overflow = described.length - visible.length
+
+  // The patch id the pointer scrolls to — first operation's patch_id, else the
+  // guidance item id (mirrors GuidanceStrip's approve_patch resolution).
+  const firstOp = operations[0] as Record<string, unknown> | undefined
+  const patchId =
+    firstOp && typeof firstOp.patch_id === 'string' ? firstOp.patch_id : item.item_id
+
+  return (
+    <div
+      data-testid="v7-held-proposal-card"
+      data-item-id={item.item_id}
+      className="rounded-lg border border-info/30 bg-panel p-3 space-y-1.5"
+    >
+      <div className="flex items-center gap-2">
+        <Hand aria-hidden="true" className="h-3.5 w-3.5 flex-none text-info" />
+        <h3 className={`${typography.panelHeader} text-text-header`}>{P.heading}</h3>
+      </div>
+
+      <p className={`${typography.panelBody} text-text-body`}>{item.title}</p>
+      {item.detail && <p className={`${typography.panelMeta} text-text-light`}>{item.detail}</p>}
+
+      {/* ≤3 change lines from the operations, or an honest count when none of
+          them yield a safe verb. */}
+      {visible.length > 0 ? (
+        <ul className="space-y-0.5" data-testid="v7-held-proposal-items">
+          {visible.map((d, i) => (
+            <li key={i} className={`${typography.panelMeta} text-text-body`}>
+              · {d}
+            </li>
+          ))}
+          {overflow > 0 && (
+            <li className={`${typography.panelMeta} text-text-light`}>{P.changesMore(overflow)}</li>
+          )}
+        </ul>
+      ) : (
+        operations.length > 0 && (
+          <p className={`${typography.panelMeta} text-text-light`} data-testid="v7-held-proposal-count">
+            {P.changeCount(operations.length)}
+          </p>
+        )
+      )}
+
+      {/* Pointer to the SINGLE live confirm (in chat). Never a confirm here. */}
+      <div className="flex flex-col gap-1 pt-0.5">
+        {scrollToPatch && (
+          <button
+            type="button"
+            data-testid="v7-held-proposal-review"
+            onClick={() => scrollToPatch(patchId)}
+            className={`inline-flex w-fit items-center gap-1.5 rounded-full border border-panel-border bg-transparent px-2.5 py-1 ${typography.panelMeta} text-text-body hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+          >
+            {P.reviewLabel}
+          </button>
+        )}
+        <p className={`${typography.panelMeta} text-text-light`}>{P.pointerNote}</p>
+      </div>
+    </div>
+  )
+}
+
+export default V7HeldProposalCard

--- a/src/components/results/v7/V7TopMatter.tsx
+++ b/src/components/results/v7/V7TopMatter.tsx
@@ -21,6 +21,8 @@ import { V7SharpenLine, type V7SharpenInput } from './V7SharpenLine'
 import { V7Hero } from './V7Hero'
 import { V7LensGroup } from './V7LensGroup'
 import { V7EvidenceDisclosure } from './V7EvidenceDisclosure'
+import { V7GuidanceSection } from './V7GuidanceSection'
+import { V7BiasSection } from './V7BiasSection'
 import { buildV7Lenses } from './buildV7Lenses'
 
 export interface V7TopMatterProps {
@@ -71,6 +73,12 @@ export function V7TopMatter({
       />
       <V7LensGroup resultsSectionData={resultsSectionData} />
       <V7EvidenceDisclosure evidence={evidence} onFocusNode={onFocusNode} />
+      {/* L6 — "What to do next" (guidance + held-proposal pointer card) and
+          "Challenge your assumptions" (bias coaching). Both read their own
+          stores (guidance store / canvas ceeReview) and render nothing when
+          their backing data is absent. */}
+      <V7GuidanceSection onFocusNode={onFocusNode} onSendMessage={onSendMessage} />
+      <V7BiasSection />
     </div>
   )
 }

--- a/src/components/results/v7/__tests__/V7BiasSection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7BiasSection.spec.tsx
@@ -1,0 +1,59 @@
+/**
+ * V7BiasSection — V7 Lane L6 pins for "Challenge your assumptions" (spec
+ * row 11).
+ *
+ * Pins: nothing renders without findings (no empty shell); a finding renders
+ * its micro_intervention.steps AND estimated_minutes; the card carries a
+ * COMPLETE border (never a border-left accent — the prototype's .coach-card
+ * violation is not reproduced); the bias kind reads from a humanised badge.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { V7BiasSection } from '../V7BiasSection'
+import { useCanvasStore } from '../../../../canvas/store'
+
+function setBiasFindings(findings: unknown[] | undefined) {
+  useCanvasStore.setState({
+    runMeta: findings ? { ceeReviewV1: { bias_findings: findings } } : {},
+  } as never)
+}
+
+beforeEach(() => {
+  setBiasFindings(undefined)
+})
+
+describe('V7BiasSection (V7 L6)', () => {
+  it('renders nothing when there are no bias findings', () => {
+    const { container } = render(<V7BiasSection />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders steps and estimated minutes for a finding', () => {
+    setBiasFindings([
+      {
+        type: 'ANCHORING_RISK',
+        description: 'Your first estimate may anchor the rest.',
+        micro_intervention: {
+          estimated_minutes: 5,
+          steps: ['Re-estimate from scratch', 'Compare with the anchor'],
+        },
+      },
+    ])
+    render(<V7BiasSection />)
+    expect(screen.getByTestId('v7-bias-section')).toBeInTheDocument()
+    expect(screen.getByTestId('v7-bias-kind')).toHaveTextContent('Anchoring')
+    expect(screen.getByTestId('v7-bias-steps')).toHaveTextContent('Re-estimate from scratch')
+    expect(screen.getByTestId('v7-bias-steps')).toHaveTextContent('Compare with the anchor')
+    expect(screen.getByTestId('v7-bias-minutes')).toHaveTextContent('About 5 min')
+  })
+
+  it('renders the card with a COMPLETE border (never a border-left accent)', () => {
+    setBiasFindings([
+      { type: 'SUNK_COST', description: 'Past spend is pulling the decision.', micro_intervention: { steps: ['List future-only costs'] } },
+    ])
+    render(<V7BiasSection />)
+    const card = screen.getByTestId('v7-bias-card')
+    expect(card.className).toContain('border-panel-border')
+    expect(card.className).not.toMatch(/border-[lrtb]-/)
+  })
+})

--- a/src/components/results/v7/__tests__/V7GuidanceSection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7GuidanceSection.spec.tsx
@@ -1,0 +1,117 @@
+/**
+ * V7GuidanceSection — V7 Lane L6 pins for "What to do next" (spec rows 8 + 9).
+ *
+ * Pins: nothing renders with no items; the category badge is an OUTLINED
+ * complete-border pill (never a border-l accent); one item shows open and the
+ * rest are counted behind a toggle; each action type renders its honest
+ * affordance; an unknown action type renders NO affordance (fail closed);
+ * ordering follows the canonical severity-major doctrine.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { V7GuidanceSection } from '../V7GuidanceSection'
+import { useGuidanceStore, type GuidanceItem } from '../../../../canvas/stores/guidanceStore'
+import { useAskOlumiStore } from '../../coaching/askOlumiStore'
+
+function item(partial: Partial<GuidanceItem> & { item_id: string }): GuidanceItem {
+  return {
+    source: 'analysis',
+    title: partial.item_id,
+    primary_action: { type: 'discuss', prompt: 'Tell me more' },
+    priority: 50,
+    ...partial,
+  } as GuidanceItem
+}
+
+beforeEach(() => {
+  useGuidanceStore.getState().clearGuidanceItems()
+  useAskOlumiStore.getState().close()
+})
+
+describe('V7GuidanceSection (V7 L6)', () => {
+  it('renders nothing when there are no guidance items', () => {
+    const { container } = render(<V7GuidanceSection />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders an OUTLINED category badge, never a one-sided border accent', () => {
+    useGuidanceStore.getState().setGuidanceItems([
+      item({ item_id: 'g1', category: 'must_fix', title: 'Fix the goal' }),
+    ])
+    render(<V7GuidanceSection />)
+    const badge = screen.getByTestId('v7-guidance-badge')
+    expect(badge).toHaveTextContent('Must fix')
+    expect(badge.className).toContain('border-danger/30')
+    expect(badge.className).not.toMatch(/border-[lrtb]-/)
+  })
+
+  it('suppresses the badge when the producer sent no category', () => {
+    useGuidanceStore.getState().setGuidanceItems([item({ item_id: 'g1', title: 'No category' })])
+    render(<V7GuidanceSection />)
+    expect(screen.queryByTestId('v7-guidance-badge')).toBeNull()
+  })
+
+  it('shows one item open and counts the rest behind a toggle', () => {
+    useGuidanceStore.getState().setGuidanceItems([
+      item({ item_id: 'a', category: 'must_fix', title: 'First' }),
+      item({ item_id: 'b', category: 'should_fix', title: 'Second' }),
+      item({ item_id: 'c', category: 'could_fix', title: 'Third' }),
+    ])
+    render(<V7GuidanceSection />)
+    // Top item visible; the other two hidden until the toggle is used.
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.queryByText('Second')).toBeNull()
+    const toggle = screen.getByTestId('v7-guidance-toggle')
+    expect(toggle).toHaveTextContent('Show 2 more')
+    fireEvent.click(toggle)
+    expect(screen.getByText('Second')).toBeInTheDocument()
+    expect(screen.getByText('Third')).toBeInTheDocument()
+  })
+
+  it('orders by severity major (must_fix first) regardless of wire order', () => {
+    useGuidanceStore.getState().setGuidanceItems([
+      item({ item_id: 'tech', category: 'technique', title: 'Technique item' }),
+      item({ item_id: 'must', category: 'must_fix', title: 'Must item' }),
+    ])
+    render(<V7GuidanceSection />)
+    // must_fix is the single open item; the technique item is behind the toggle.
+    expect(screen.getByText('Must item')).toBeInTheDocument()
+    expect(screen.queryByText('Technique item')).toBeNull()
+  })
+
+  it('maps discuss → Work through it (opens the drawer)', () => {
+    useGuidanceStore.getState().setGuidanceItems([
+      item({ item_id: 'g1', primary_action: { type: 'discuss', prompt: 'What if demand drops?' } }),
+    ])
+    render(<V7GuidanceSection />)
+    fireEvent.click(screen.getByTestId('v7-guidance-action-work-through'))
+    const drawer = useAskOlumiStore.getState()
+    expect(drawer.isOpen).toBe(true)
+    expect(drawer.draft).toBe('What if demand drops?')
+  })
+
+  it('maps open_inspector → Focus and run_exercise → Try …', () => {
+    const onFocusNode = vi.fn()
+    const onSendMessage = vi.fn()
+    useGuidanceStore.getState().setGuidanceItems([
+      item({ item_id: 'g1', category: 'must_fix', primary_action: { type: 'open_inspector', node_id: 'node-9' } }),
+      item({ item_id: 'g2', category: 'could_fix', primary_action: { type: 'run_exercise', exercise: 'pre_mortem' } }),
+    ])
+    render(<V7GuidanceSection onFocusNode={onFocusNode} onSendMessage={onSendMessage} />)
+    fireEvent.click(screen.getByTestId('v7-guidance-action-focus'))
+    expect(onFocusNode).toHaveBeenCalledWith('node-9')
+    fireEvent.click(screen.getByTestId('v7-guidance-toggle'))
+    fireEvent.click(screen.getByTestId('v7-guidance-action-run-exercise'))
+    expect(onSendMessage).toHaveBeenCalledWith('/exercise pre_mortem')
+  })
+
+  it('renders NO affordance for an unknown action type (fail closed)', () => {
+    const rogue = { type: 'delete_everything', target: 'x' } as unknown as GuidanceItem['primary_action']
+    useGuidanceStore.getState().setGuidanceItems([item({ item_id: 'g1', title: 'Rogue', primary_action: rogue })])
+    render(<V7GuidanceSection />)
+    expect(screen.getByText('Rogue')).toBeInTheDocument()
+    expect(screen.queryByTestId('v7-guidance-action-focus')).toBeNull()
+    expect(screen.queryByTestId('v7-guidance-action-work-through')).toBeNull()
+    expect(screen.queryByTestId('v7-guidance-action-run-exercise')).toBeNull()
+  })
+})

--- a/src/components/results/v7/__tests__/V7HeldProposalCard.spec.tsx
+++ b/src/components/results/v7/__tests__/V7HeldProposalCard.spec.tsx
@@ -1,0 +1,124 @@
+/**
+ * V7HeldProposalCard — V7 Lane L6 pins for the held-proposal surface (spec
+ * row 10) and the HARD one-confirm invariant (UI PR #424, the doubled-confirm
+ * defect Paul hit).
+ *
+ * Pins: the card shows ≤3 change lines with an overflow count; it offers a
+ * single "Review in chat" POINTER (only when the scroll seam is registered) and
+ * NEVER a confirm/apply control of its own; and — rendered alongside the
+ * conversation's single owner (V5HeldProposalBlock) plus the same-turn
+ * suggested-action chip row — exactly ONE confirm affordance exists across the
+ * whole DOM. Positive control: the owner's confirm IS counted (the query can
+ * see a confirm at all).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { V7HeldProposalCard } from '../V7HeldProposalCard'
+import { V5HeldProposalBlock } from '../../../../v5/blocks/V5HeldProposalBlock'
+import { buildSuggestedActionChips } from '../../../../v5/blocks/suggestedActionChips'
+import { useGuidanceStore, type GuidanceItem } from '../../../../canvas/stores/guidanceStore'
+import type { V5HeldProposalBlock as V5HeldProposalBlockType } from '../../../../canvas/conversation/types'
+
+function patchItem(ops: Array<Record<string, unknown>>): GuidanceItem {
+  return {
+    item_id: 'patch-1',
+    source: 'analysis',
+    title: 'Add the missing competitor edge',
+    detail: 'Your model omits the competitor-price relationship.',
+    primary_action: { type: 'approve_patch', operations: ops },
+    priority: 50,
+  } as GuidanceItem
+}
+
+/** Count confirm affordances in the DOM by accessible name (apply / confirm). */
+function confirmAffordanceCount(): number {
+  return screen
+    .queryAllByRole('button')
+    .filter((b) => /\b(apply|confirm)\b/i.test(b.getAttribute('aria-label') ?? b.textContent ?? ''))
+    .length
+}
+
+beforeEach(() => {
+  useGuidanceStore.setState({ _scrollToPatch: null, _sendChip: null })
+})
+
+describe('V7HeldProposalCard (V7 L6 row 10)', () => {
+  it('shows at most three change lines with an overflow count', () => {
+    render(
+      <V7HeldProposalCard
+        item={patchItem([
+          { op: 'add_edge' },
+          { op: 'update_node' },
+          { op: 'set_value' },
+          { op: 'remove_edge' },
+          { op: 'add_node' },
+        ])}
+      />,
+    )
+    const items = screen.getByTestId('v7-held-proposal-items')
+    expect(items).toHaveTextContent('Add edge')
+    expect(items).toHaveTextContent('Update node')
+    expect(items).toHaveTextContent('Set value')
+    // Fourth/fifth collapse into a "+2 more" count, never rendered as raw ops.
+    expect(items).toHaveTextContent('+2 more')
+    expect(items).not.toHaveTextContent('Remove edge')
+  })
+
+  it('renders the review POINTER only when the scroll seam is registered, and never a confirm', () => {
+    const { rerender } = render(<V7HeldProposalCard item={patchItem([{ op: 'add_edge' }])} />)
+    // No seam → no dead button, but the pointer note still routes the user.
+    expect(screen.queryByTestId('v7-held-proposal-review')).toBeNull()
+    expect(screen.getByText(/confirm or dismiss this in the chat/i)).toBeInTheDocument()
+
+    const scrollToPatch = vi.fn()
+    useGuidanceStore.setState({ _scrollToPatch: scrollToPatch })
+    rerender(<V7HeldProposalCard item={patchItem([{ op: 'add_edge', patch_id: 'p-42' }])} />)
+    const review = screen.getByTestId('v7-held-proposal-review')
+    review.click()
+    expect(scrollToPatch).toHaveBeenCalledWith('p-42')
+
+    // The card itself carries NO confirm affordance.
+    expect(confirmAffordanceCount()).toBe(0)
+  })
+})
+
+describe('one-confirm invariant (UI PR #424, spec row 10 hazard)', () => {
+  const owner: V5HeldProposalBlockType = {
+    type: 'v5_held_proposal',
+    proposal_id: 'gmh_1',
+    summary: 'Olumi wants to add the competitor-price edge.',
+    mutation_class: 'structural',
+    reason_code: 'needs_confirmation',
+    confirm: { label: 'Apply', message: 'apply the held change' },
+    decline: { label: 'Not what I meant', message: 'decline' },
+  }
+
+  it('renders exactly one confirm across the owner card + the V7 pointer card', () => {
+    render(
+      <div>
+        <V5HeldProposalBlock block={owner} />
+        <V7HeldProposalCard item={patchItem([{ op: 'add_edge', patch_id: 'gmh_1' }])} />
+      </div>,
+    )
+    // Positive control: the single owner's confirm IS visible (the query works).
+    expect(screen.getByTestId('v5-held-proposal-confirm')).toBeInTheDocument()
+    // Invariant: exactly ONE confirm affordance in the whole DOM.
+    expect(confirmAffordanceCount()).toBe(1)
+    // The V7 card contributes a display-only card, not a second confirm.
+    expect(screen.getByTestId('v7-held-proposal-card')).toBeInTheDocument()
+  })
+
+  it('the same-turn suggested-action chip row drops the id the owner consumes', () => {
+    // The third potential surface — the generic chip row — stands down for the
+    // exact confirm id the held_proposal block references (single-owner drop).
+    const blocks = [
+      { type: 'held_proposal', confirm_action_id: 'act_confirm', proposal_id: 'gmh_1' },
+    ] as unknown as Parameters<typeof buildSuggestedActionChips>[0]
+    const actions = [
+      { id: 'act_confirm', label: 'Apply', message: 'apply' },
+      { id: 'act_other', label: 'Explain', message: 'explain' },
+    ] as unknown as Parameters<typeof buildSuggestedActionChips>[1]
+    const chips = buildSuggestedActionChips(blocks, actions)
+    expect(chips.map((c) => c.id)).toEqual(['act_other'])
+  })
+})

--- a/src/components/results/v7/__tests__/buildV7Bias.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Bias.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * buildV7Bias — V7 Lane L6 pins for the bias-finding passthrough builder
+ * (spec row 11).
+ *
+ * Pins: producer type/description/steps/estimated_minutes/affected are read
+ * verbatim; steps accept both `string[]` and `{ text }[]` wire shapes;
+ * estimated_minutes is read from the intervention OR the finding root; a finding
+ * with neither description nor step is dropped (honest, no empty shell); the
+ * kind token is humanised (and "_RISK" trimmed); pickBiasFindingsSource prefers
+ * ceeReviewV1 over the legacy ceeReview.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildV7BiasFindings, buildV7BiasFinding, pickBiasFindingsSource } from '../buildV7Bias'
+
+describe('buildV7BiasFindings (V7 L6)', () => {
+  it('maps type, description, string steps, minutes and affected nodes verbatim', () => {
+    const raw = [
+      {
+        type: 'ANCHORING_RISK',
+        description: 'Your estimate may be anchored to the first number.',
+        affected_node_ids: ['n1', 'n2'],
+        micro_intervention: { estimated_minutes: 4, steps: ['Re-estimate independently', 'Compare'] },
+      },
+    ]
+    const out = buildV7BiasFindings(raw)
+    expect(out).toHaveLength(1)
+    expect(out[0].kindLabel).toBe('Anchoring')
+    expect(out[0].description).toContain('anchored')
+    expect(out[0].steps).toEqual(['Re-estimate independently', 'Compare'])
+    expect(out[0].estimatedMinutes).toBe(4)
+    expect(out[0].affectedNodeIds).toEqual(['n1', 'n2'])
+  })
+
+  it('accepts { text } step objects and root-level estimated_minutes', () => {
+    const raw = [
+      {
+        code: 'sunk_cost',
+        message: 'You may be over-weighting past investment.',
+        estimated_minutes: 6,
+        micro_intervention: { steps: [{ text: 'List only future costs' }, { notText: 'x' }] },
+      },
+    ]
+    const out = buildV7BiasFindings(raw)
+    expect(out[0].kindLabel).toBe('Sunk cost')
+    expect(out[0].steps).toEqual(['List only future costs'])
+    expect(out[0].estimatedMinutes).toBe(6)
+  })
+
+  it('drops a finding with neither a description nor a step (no empty shell)', () => {
+    expect(buildV7BiasFinding({ type: 'ANCHORING', micro_intervention: { steps: [] } }, 0)).toBeNull()
+    expect(buildV7BiasFindings([{ type: 'X' }, { junk: true }, null])).toEqual([])
+  })
+
+  it('returns [] for non-array input', () => {
+    expect(buildV7BiasFindings(undefined)).toEqual([])
+    expect(buildV7BiasFindings({})).toEqual([])
+  })
+})
+
+describe('pickBiasFindingsSource (V7 L6)', () => {
+  it('prefers ceeReviewV1 over the legacy ceeReview', () => {
+    const runMeta = {
+      ceeReviewV1: { bias_findings: [{ id: 'v1' }] },
+      ceeReview: { bias_findings: [{ id: 'legacy' }] },
+    }
+    expect(pickBiasFindingsSource(runMeta)).toEqual([{ id: 'v1' }])
+  })
+
+  it('falls back to legacy ceeReview when V1 has none', () => {
+    const runMeta = { ceeReview: { bias_findings: [{ id: 'legacy' }] } }
+    expect(pickBiasFindingsSource(runMeta)).toEqual([{ id: 'legacy' }])
+  })
+
+  it('returns undefined when neither carries findings', () => {
+    expect(pickBiasFindingsSource({})).toBeUndefined()
+    expect(pickBiasFindingsSource(null)).toBeUndefined()
+  })
+})

--- a/src/components/results/v7/__tests__/buildV7Guidance.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Guidance.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * buildV7Guidance — V7 Lane L6 pins for the guidance split/order/affordance
+ * builder (spec rows 8 + 9).
+ *
+ * Pins: approve_patch items are promoted to heldProposals and excluded from the
+ * ordered list; the list is ordered by the canonical display-order doctrine
+ * (category severity major, then priorityRank); the source array is never
+ * mutated; each action type maps to its honest affordance and an unknown /
+ * navigate / defaulted action fails closed to no affordance.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildV7Guidance, deriveGuidanceAffordance } from '../buildV7Guidance'
+import type { GuidanceItem, GuidanceAction } from '../../../../canvas/stores/guidanceStore'
+
+function item(partial: Partial<GuidanceItem> & { item_id: string }): GuidanceItem {
+  return {
+    source: 'analysis',
+    title: partial.item_id,
+    primary_action: { type: 'discuss', prompt: 'Tell me more' },
+    priority: 50,
+    ...partial,
+  } as GuidanceItem
+}
+
+describe('buildV7Guidance (V7 L6)', () => {
+  it('promotes approve_patch items to heldProposals and excludes them from the list', () => {
+    const patch = item({
+      item_id: 'patch-1',
+      primary_action: { type: 'approve_patch', operations: [{ op: 'add_edge' }] },
+    })
+    const discuss = item({ item_id: 'd-1', primary_action: { type: 'discuss', prompt: 'q' } })
+
+    const { heldProposals, guidance } = buildV7Guidance([patch, discuss])
+
+    expect(heldProposals.map((i) => i.item_id)).toEqual(['patch-1'])
+    expect(guidance.map((i) => i.item_id)).toEqual(['d-1'])
+  })
+
+  it('orders the list by category severity, then priorityRank (canonical comparator)', () => {
+    // Deliberately unsorted: technique first, must_fix last on the wire.
+    const items = [
+      item({ item_id: 'tech', category: 'technique', priorityRank: 200 }),
+      item({ item_id: 'could', category: 'could_fix', priorityRank: 20 }),
+      item({ item_id: 'must-b', category: 'must_fix', priorityRank: 5 }),
+      item({ item_id: 'must-a', category: 'must_fix', priorityRank: 2 }),
+    ]
+    const { guidance } = buildV7Guidance(items)
+    // must_fix (by ascending rank) → could_fix → technique.
+    expect(guidance.map((i) => i.item_id)).toEqual(['must-a', 'must-b', 'could', 'tech'])
+  })
+
+  it('does not mutate the source array', () => {
+    const items = [
+      item({ item_id: 'b', category: 'could_fix' }),
+      item({ item_id: 'a', category: 'must_fix' }),
+    ]
+    const before = items.map((i) => i.item_id)
+    buildV7Guidance(items)
+    expect(items.map((i) => i.item_id)).toEqual(before)
+  })
+
+  it('handles an empty / undefined input', () => {
+    expect(buildV7Guidance([])).toEqual({ heldProposals: [], guidance: [] })
+    expect(buildV7Guidance(undefined)).toEqual({ heldProposals: [], guidance: [] })
+  })
+})
+
+describe('deriveGuidanceAffordance (V7 L6 row 9)', () => {
+  const cases: Array<[string, GuidanceAction, string]> = [
+    ['open_inspector → focus', { type: 'open_inspector', node_id: 'n1', field: 'value' }, 'focus'],
+    ['discuss → work_through', { type: 'discuss', prompt: 'q' }, 'work_through'],
+    ['run_exercise → run_exercise', { type: 'run_exercise', exercise: 'pre_mortem' }, 'run_exercise'],
+    ['approve_patch → none (promoted)', { type: 'approve_patch', operations: [] }, 'none'],
+    ['navigate → none', { type: 'navigate', target: '#/x' }, 'none'],
+  ]
+  it.each(cases)('%s', (_label, action, expected) => {
+    expect(deriveGuidanceAffordance(item({ item_id: 'x', primary_action: action })).kind).toBe(expected)
+  })
+
+  it('fails closed on an unknown action type', () => {
+    const rogue = { type: 'delete_everything', target: 'x' } as unknown as GuidanceAction
+    expect(deriveGuidanceAffordance(item({ item_id: 'x', primary_action: rogue })).kind).toBe('none')
+  })
+
+  it('fails closed when a known action is missing its required field', () => {
+    const noNode = { type: 'open_inspector' } as unknown as GuidanceAction
+    expect(deriveGuidanceAffordance(item({ item_id: 'x', primary_action: noNode })).kind).toBe('none')
+    const emptyPrompt = { type: 'discuss', prompt: '   ' } as GuidanceAction
+    expect(deriveGuidanceAffordance(item({ item_id: 'x', primary_action: emptyPrompt })).kind).toBe('none')
+  })
+})

--- a/src/components/results/v7/buildV7Bias.ts
+++ b/src/components/results/v7/buildV7Bias.ts
@@ -1,0 +1,130 @@
+/**
+ * buildV7Bias — pure passthrough builder for the V7 L6 "Challenge your
+ * assumptions" bias section (V6-RESPEC-2026-07-23 row 11).
+ *
+ * The producer's bias findings ride on the CEE review payload UNTYPED (the
+ * `CeeDecisionReviewPayload` type does not declare `bias_findings`; it is a
+ * known-open passthrough seam — the same shape GuidancePanel and
+ * PreAnalysisGuidance already read at runtime). This builder reads it
+ * DEFENSIVELY, field by field, and invents nothing:
+ *   · a bias KIND label from the producer `type`/`code` (humanised only — the
+ *     raw token never renders raw);
+ *   · the producer DESCRIPTION (`description` / `message` / `explanation`);
+ *   · the `micro_intervention.steps` (strings, or `{ text }` step objects — both
+ *     shapes appear on the wire) and `estimated_minutes`, verbatim (spec row 11
+ *     requires steps + minutes VISIBLE);
+ *   · affected node ids, for graph links.
+ *
+ * Honest absence: a finding with neither a description nor a step is dropped
+ * (never an empty coaching shell); no findings at all → `[]`, and the section
+ * renders nothing.
+ */
+
+export interface V7BiasFinding {
+  key: string
+  /** Humanised producer bias type/code (e.g. "Anchoring"). Never the raw token. */
+  kindLabel: string
+  /** Producer-authored description. */
+  description: string
+  /** micro_intervention.steps, verbatim (spec row 11). */
+  steps: string[]
+  /** Producer estimate in minutes, or null when absent/non-finite. */
+  estimatedMinutes: number | null
+  /** Affected canvas node ids, for graph links. */
+  affectedNodeIds: string[]
+}
+
+const asString = (v: unknown): string | null =>
+  typeof v === 'string' && v.trim().length > 0 ? v : null
+
+const asStringArray = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0) : []
+
+/** Humanise a SCREAMING_SNAKE / snake_case bias token into a title-case label. */
+function humaniseKind(raw: string): string {
+  const words = raw
+    .replace(/_/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\brisk\b/g, '') // "ANCHORING_RISK" → "Anchoring", not "Anchoring risk"
+    .trim()
+  if (!words) return 'Cognitive bias'
+  return words.charAt(0).toUpperCase() + words.slice(1)
+}
+
+/** Normalise a step that may be a plain string OR a `{ text }` object. */
+function stepText(step: unknown): string | null {
+  if (typeof step === 'string') return asString(step)
+  if (step && typeof step === 'object' && 'text' in step) return asString((step as { text: unknown }).text)
+  return null
+}
+
+/**
+ * Map one raw finding (untyped) into a clean V7BiasFinding, or null when it
+ * carries no renderable content.
+ */
+export function buildV7BiasFinding(raw: unknown, index: number): V7BiasFinding | null {
+  if (!raw || typeof raw !== 'object') return null
+  const f = raw as Record<string, unknown>
+
+  const typeToken = asString(f.type) ?? asString(f.code)
+  const description =
+    asString(f.description) ?? asString(f.message) ?? asString(f.explanation) ?? ''
+
+  const micro =
+    f.micro_intervention && typeof f.micro_intervention === 'object'
+      ? (f.micro_intervention as Record<string, unknown>)
+      : null
+
+  const steps = (Array.isArray(micro?.steps) ? micro!.steps : [])
+    .map(stepText)
+    .filter((s): s is string => s != null)
+
+  // estimated_minutes may sit on the intervention OR the finding root.
+  const rawMinutes = micro?.estimated_minutes ?? f.estimated_minutes
+  const estimatedMinutes =
+    typeof rawMinutes === 'number' && Number.isFinite(rawMinutes) ? rawMinutes : null
+
+  const affectedNodeIds =
+    asStringArray(f.affected_node_ids).length > 0
+      ? asStringArray(f.affected_node_ids)
+      : asStringArray(f.affected_elements).length > 0
+        ? asStringArray(f.affected_elements)
+        : asStringArray(f.affectedNodes)
+
+  // Honest gate: nothing renderable → drop (never an empty coaching shell).
+  if (!description && steps.length === 0) return null
+
+  const key = asString(f.id) ?? `${typeToken ?? 'bias'}-${index}`
+
+  return {
+    key,
+    kindLabel: typeToken ? humaniseKind(typeToken) : 'Cognitive bias',
+    description,
+    steps,
+    estimatedMinutes,
+    affectedNodeIds,
+  }
+}
+
+export function buildV7BiasFindings(raw: unknown): V7BiasFinding[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map((r, i) => buildV7BiasFinding(r, i))
+    .filter((f): f is V7BiasFinding => f != null)
+}
+
+/**
+ * Pick the bias_findings array off a runMeta-shaped object, preferring the
+ * current `ceeReviewV1` over the legacy `ceeReview` (the order
+ * useResultsSectionData + GuidancePanel already use). Returns the stored array
+ * reference (stable) or undefined — never a fresh array, so callers can key a
+ * memo on it safely.
+ */
+export function pickBiasFindingsSource(runMeta: unknown): unknown {
+  if (!runMeta || typeof runMeta !== 'object') return undefined
+  const m = runMeta as Record<string, unknown>
+  const v1 = m.ceeReviewV1 as Record<string, unknown> | null | undefined
+  const legacy = m.ceeReview as Record<string, unknown> | null | undefined
+  return v1?.bias_findings ?? legacy?.bias_findings
+}

--- a/src/components/results/v7/buildV7Guidance.ts
+++ b/src/components/results/v7/buildV7Guidance.ts
@@ -1,0 +1,91 @@
+/**
+ * buildV7Guidance — pure passthrough builder for the V7 L6 guidance list +
+ * held-proposal card (V6-RESPEC-2026-07-23 rows 8/9/10).
+ *
+ * PASSTHROUGH ONLY. It reads the guidance store's `guidanceItems` and does two
+ * things, both without inventing a value:
+ *
+ *   1. SPLIT. `approve_patch` items are the analysis-panel's held proposals
+ *      (spec row 10). By the established single-owner doctrine (GuidanceStrip's
+ *      approve_patch handler SCROLLS to the conversation GraphPatchBlock — the
+ *      one live confirm — it never applies), an approve_patch guidance item is
+ *      a POINTER to that owner, never a confirm surface. So we promote them to
+ *      the held-proposal card and EXCLUDE them from the guidance list: exactly
+ *      one L6 surface per proposal, and no second confirm anywhere (the hard
+ *      invariant; UI PR #424).
+ *
+ *   2. ORDER. The remaining guidance items are ordered by the store's ONE
+ *      canonical comparator, `compareGuidanceDisplayOrder` (category severity
+ *      major → producer `priorityRank` ascending → coarse `priority`
+ *      descending). We never hand-roll a priority sort — that is exactly how
+ *      the UI-SEM-085 `100 - rank` inversion happened. The source array is
+ *      sliced before sorting so the shared store array is never mutated.
+ *
+ * The per-item affordance (spec row 9) is derived here as a discriminated kind
+ * so the component renders each action type's HONEST affordance and an unknown
+ * action type renders NONE (fail closed, no guessing).
+ */
+
+import {
+  compareGuidanceDisplayOrder,
+  type GuidanceItem,
+} from '../../../canvas/stores/guidanceStore'
+
+/** The affordance a guidance item's `primary_action` maps to (spec row 9). */
+export type V7GuidanceAffordance =
+  /** open_inspector → Focus the target node on canvas. */
+  | { kind: 'focus'; nodeId: string; field?: string }
+  /** discuss → open the work-through drawer with the producer prompt. */
+  | { kind: 'work_through'; prompt: string }
+  /** run_exercise → send the exercise command (pre-mortem etc.). */
+  | { kind: 'run_exercise'; exercise: string }
+  /** Unknown / navigate / approve_patch (promoted) → no affordance. */
+  | { kind: 'none' }
+
+export interface V7GuidanceModel {
+  /** approve_patch items — rendered as held-proposal cards (row 10). */
+  heldProposals: GuidanceItem[]
+  /** Everything else, ordered by the canonical display-order doctrine. */
+  guidance: GuidanceItem[]
+}
+
+const isApprovePatch = (i: GuidanceItem): boolean => i.primary_action?.type === 'approve_patch'
+
+/**
+ * Map a guidance item's `primary_action` to its honest affordance. Only the
+ * four action types the spec names (row 9) render an affordance; `navigate`,
+ * `approve_patch` (promoted to the card), and any UNKNOWN type fall through to
+ * `none` — the fail-closed default, never a guessed control.
+ */
+export function deriveGuidanceAffordance(item: GuidanceItem): V7GuidanceAffordance {
+  const action = item.primary_action
+  if (!action || typeof action.type !== 'string') return { kind: 'none' }
+  switch (action.type) {
+    case 'open_inspector':
+      return typeof action.node_id === 'string' && action.node_id.length > 0
+        ? { kind: 'focus', nodeId: action.node_id, field: action.field }
+        : { kind: 'none' }
+    case 'discuss':
+      return typeof action.prompt === 'string' && action.prompt.trim().length > 0
+        ? { kind: 'work_through', prompt: action.prompt }
+        : { kind: 'none' }
+    case 'run_exercise':
+      return typeof action.exercise === 'string' && action.exercise.length > 0
+        ? { kind: 'run_exercise', exercise: action.exercise }
+        : { kind: 'none' }
+    // 'approve_patch' is promoted to the held-proposal card; 'navigate' and any
+    // unknown/future action type render no affordance (fail closed).
+    default:
+      return { kind: 'none' }
+  }
+}
+
+export function buildV7Guidance(items: readonly GuidanceItem[] = []): V7GuidanceModel {
+  const list = Array.isArray(items) ? items : []
+  const heldProposals = list.filter(isApprovePatch)
+  const guidance = list
+    .filter((i) => !isApprovePatch(i))
+    .slice()
+    .sort(compareGuidanceDisplayOrder)
+  return { heldProposals, guidance }
+}

--- a/src/components/results/v7/v7GuidanceCopy.ts
+++ b/src/components/results/v7/v7GuidanceCopy.ts
@@ -1,0 +1,68 @@
+/**
+ * v7GuidanceCopy — all UI-authored copy for the V7 L6 surfaces: the
+ * "What to do next" guidance list, the held-proposal card, and the
+ * "Challenge your assumptions" bias section (V7 Lane L6).
+ *
+ * British English, sentence case, no all-caps, no em dashes in prose. Category
+ * labels mirror the conversation GuidanceStrip verbatim (Must fix / Should fix
+ * / Could fix / Technique) so the two surfaces cannot disagree about what a
+ * producer `category` means. The model-limit caveat is the SAME sentence
+ * V7SharpenLine ships, kept identical on purpose so the two honest-caveat
+ * surfaces read as one voice.
+ *
+ * Copy only — no thresholds, no data, no inference lives here.
+ */
+
+/** The single model-limit caveat, shared verbatim with V7SharpenLine. */
+export const V7_MODEL_LIMIT_CAVEAT =
+  'Olumi can point to what the model implies, but not guarantee the real world behaves the same.'
+
+export const V7_GUIDANCE_COPY = {
+  guidance: {
+    heading: 'What to do next',
+    subtitle: 'Ordered by how much it matters.',
+    /** Producer four-value category labels — verbatim GuidanceStrip wording. */
+    categoryLabel: {
+      must_fix: 'Must fix',
+      should_fix: 'Should fix',
+      could_fix: 'Could fix',
+      technique: 'Technique',
+    } as const,
+    /** One item is shown open; the rest are counted behind this toggle. */
+    showMore: (n: number) => `Show ${n} more`,
+    showFewer: 'Show fewer',
+    /** Honest action affordances (spec row 9). Each maps to ONE action type;
+     * an unknown action type renders none of these (fail closed). */
+    action: {
+      focus: 'Focus',
+      workThrough: 'Work through it',
+      /** run_exercise — the label names the exercise the producer chose. */
+      runExercise: (exercise: string) => {
+        const name = exercise.replace(/_/g, ' ').trim()
+        return name ? `Try a ${name}` : 'Try it'
+      },
+    },
+  },
+
+  proposal: {
+    heading: 'Proposed change',
+    /** Count of changes bundled in the proposal (≤3 shown, rest counted). */
+    changesMore: (n: number) => `+${n} more`,
+    /** The card is display only: the ONE live confirm lives on the chat card
+     * that proposed the change (single-owner doctrine, UI PR #424). This label
+     * points there — it is a pointer, never a second confirm. */
+    reviewLabel: 'Review in chat',
+    pointerNote: 'Confirm or dismiss this in the chat where it was proposed.',
+    /** Shown when the proposal names an unresolved change count only. */
+    changeCount: (n: number) => `${n} proposed ${n === 1 ? 'change' : 'changes'}`,
+  },
+
+  bias: {
+    heading: 'Challenge your assumptions',
+    subtitle: 'Thinking patterns worth a second look.',
+    /** Micro-intervention effort, from the producer estimate. */
+    minutes: (n: number) => `About ${n} min`,
+    /** Precedes the micro_intervention.steps list. */
+    stepsLabel: 'Try this',
+  },
+} as const

--- a/tests/ci-guards/complete-borders.spec.ts
+++ b/tests/ci-guards/complete-borders.spec.ts
@@ -94,6 +94,10 @@ const CONTENT_CARD_FILES = [
   'components/results/v7/V7LensGroup.tsx',
   'components/results/v7/V7EvidenceDisclosure.tsx',
   'components/results/v7/V7WhatChangedLens.tsx',
+  // V7 Lane L6 — guidance list, held-proposal pointer card, bias coaching.
+  'components/results/v7/V7GuidanceSection.tsx',
+  'components/results/v7/V7HeldProposalCard.tsx',
+  'components/results/v7/V7BiasSection.tsx',
   // V7 L2 — the final two one-sided accents, now converted to complete borders.
   'v5/blocks/V5CoachingBlock.tsx',
   'canvas/ToastContext.tsx',


### PR DESCRIPTION
## V7 Lane L6 — guidance + proposals + bias

Builds V6-RESPEC-2026-07-23 §5 L6 (rows 8/9/10/11) plus fold-ins 12/15, following the merged L4/L5 V7 patterns: additive, passthrough, flagless, ships **ON**, composed into `V7TopMatter` after the L5 lens group + evidence disclosure. Copy lives in a dedicated module (`v7GuidanceCopy.ts`). **Does not merge.**

### Scope delivered
1. **"What to do next" guidance (rows 8/9)** — `buildV7Guidance` splits the guidance store and orders the list by the store's ONE canonical comparator `compareGuidanceDisplayOrder` (category severity major → producer `priorityRank` → coarse `priority`; never a hand-rolled priority sort — that is the UI-SEM-085 `100 - rank` inversion trap). Category badge is an **outlined count-style pill** (complete four-sided border, colour = severity), never a `border-l` accent; an absent producer category **suppresses** the badge (no synthesised severity). One item open, the rest counted behind a toggle. Action mapping: `open_inspector`=Focus · `discuss`=Work through it (opens the Ask-Olumi drawer) · `run_exercise`=Try a … · `approve_patch`=promoted to the held-proposal card · **unknown/`navigate`=NO affordance (fail closed)**. Stable guidance-store selectors only (the Zustand inline-selector landmine — ordering happens in a memo, never the selector).
2. **Held-proposal card (row 10)** — display-only; see confirm-ownership below.
3. **"Challenge your assumptions" bias section (row 11)** — `buildV7Bias` reads the producer bias findings (`ceeReview(V1).bias_findings`, the untyped passthrough seam GuidancePanel already reads) defensively, surfacing `micro_intervention.steps` + `estimated_minutes` **visible**. **COMPLETE borders**; the bias kind is conveyed by a badge + icon tint, never the prototype `.coach-card` `border-left:3px` (§3.1 violation, not reproduced).
4. **Fold-ins** — row 12: Advanced receipts name the real wire fields (`meta.seed`, `meta.n_samples`) via `title` (copy-only). Row 15: the Ask-Olumi drawer **always** carries the model-limit caveat (shared verbatim with `V7SharpenLine`).

### Confirm-ownership design (the doubled-confirm hazard, UI PR #424)

**Traced owners at tip `7c17a6e3`:**
- **The conversation held-proposal card** (`V5HeldProposalBlock`) — the established SINGLE OWNER. On a held turn CEE single-sources one confirm chip (`confirm_action_id`); the card resolves + renders it and mints no client mutation.
- **The suggested-action chip row** (`SuggestedChips`) — already stands down via `buildSuggestedActionChips` / `heldProposalConsumedActionIds` (drops the id the held_proposal consumes, keyed on id).
- **`GraphPatchBlockRenderer`** — a conversation block, not in `ResultsBody`; the guidance-store `approve_patch` action's handler (GuidanceStrip) **scrolls** to it (`onScrollToPatch`) — it never applies. So an `approve_patch` guidance item is, by the existing contract, a **pointer to the owner, not a confirm**.

**Verdict — display-only card, invariant holds by construction.** The V7 held-proposal card sources from `approve_patch` guidance items (the only `ResultsBody`-accessible proposal data), promotes them out of the guidance list (single L6 surface per proposal), and renders a summary + ≤3 change lines + a single **"Review in chat" pointer** (`_scrollToPatch`) — it contains **no confirm/apply control**. Claiming the confirm here would either duplicate the owner or force a client-minted apply path (which `V5HeldProposalBlock` explicitly forbids); both cross the ownership seam, so per the brief's STOP clause I shipped display-only and flag it here. **Total live confirms per proposal across the panel (incl. assessment mode with the legacy renderer below): exactly 1.**

RED-first pin: the invariant test renders the owner (`V5HeldProposalBlock`) **and** the V7 card together and asserts exactly one confirm affordance in the whole DOM, with a positive control that the owner's confirm is counted; a second unit pin asserts `buildSuggestedActionChips` drops the consumed id.

### Honest-gate inventory (passthrough, no fabrication)
- No guidance items **and** no held proposal → section renders nothing.
- Absent producer `category` → badge suppressed (never invented).
- Unknown/`navigate`/malformed action → no affordance.
- No `_scrollToPatch` seam registered → no dead button (the pointer note still routes the user); the pointer is never a confirm.
- No bias findings, or a finding with neither description nor step → bias section / card renders nothing.
- Row 12 leaves `recommendation_stability`/`level`/`is_robust` behind the existing display-safe-verdict deprecation guard (see Deviations).

### No new UI-SEM transforms, no flags. Complete-borders guard updated with the three new JSX files.

### Test list (RED-first)
- `buildV7Guidance.spec.ts` — promotion/exclusion of `approve_patch`; canonical ordering; no source mutation; affordance mapping + fail-closed on unknown/missing-field actions.
- `buildV7Bias.spec.ts` — verbatim mapping; `string[]` and `{ text }[]` steps; root/intervention minutes; drop-when-empty; `ceeReviewV1` preference.
- `V7GuidanceSection.spec.tsx` — nothing-when-empty; outlined badge (asserts no `border-[lrtb]-`); badge suppression; one-open/rest-counted; severity ordering; each affordance; unknown → no affordance.
- `V7HeldProposalCard.spec.tsx` — ≤3 lines + overflow; pointer only when the seam is registered; **no confirm**; the one-confirm invariant + chip-row drop.
- `V7BiasSection.spec.tsx` — steps + minutes render; complete border; honest absence.
- `AdvancedSection.spec.tsx` (row 12) + `AskOlumiDrawer.spec.tsx` (row 15) additions.

### Mutation matrix (7/7 bite, verified in a throwaway copy)
| # | Pin | Mutation | Result |
|---|-----|----------|--------|
| 1 | Guidance ordering | drop `.sort(compareGuidanceDisplayOrder)` | 2 ordering tests RED |
| 2 | Outlined badge | `border-danger/30` → `border-l-danger` | badge test **and** complete-borders guard RED |
| 3 | Unknown fail-closed | default affordance → `work_through` | 4 fail-closed tests RED |
| 4 | One-confirm invariant | add an "Apply" button to the card | invariant + no-confirm tests RED |
| 5 | Bias steps/minutes | `stepText` → always null | 3 bias tests RED |
| 6 | Receipt labels | strip `title="meta.seed"` | row-12 test RED |
| 7 | Drawer caveat | remove the caveat `<p>` | row-15 test RED |

### Borders registration
`tests/ci-guards/complete-borders.spec.ts` now scans `V7GuidanceSection.tsx`, `V7HeldProposalCard.tsx`, `V7BiasSection.tsx`.

### Deviations (flagged for Paul)
- **Row 10 literal "Apply / Not what I meant" on the card was intentionally NOT reproduced as a live confirm** — it would mint a third confirm surface, and claiming the id requires touching `V5HeldProposalBlock`/`buildSuggestedActionChips` (pushed-down conversation components beyond the ownership seam) or a forbidden client apply. Shipped as a display-only pointer to the single owner, per the brief's STOP clause.
- **Row 12 scoped to non-deprecated wire fields.** `recommendation_stability`/`level`/`is_robust` were not surfaced as receipt values: `AdvancedSection` has a deliberate deprecation guard (the "Result stability" row keys on the display-safe verdict, and a test proves no `recommendation_stability`-sourced value renders). Aligning those labels would violate that guard. Only `seed`/`n_samples` (unambiguous, non-deprecated) got wire-name `title`s.
- **Guidance list does not auto-dismiss items on action** (unlike the conversation GuidanceStrip's discuss path) — the list is an additive read surface and must not mutate shared store state other surfaces depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
