### PR TITLE
fix(dock): visible response signal when an assistant turn lands while the dock is collapsed

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -56,6 +56,10 @@ import { CogPopover } from './CogPopover'
 import { useConversationContext, useOptionalConversationContext } from '../conversation/ConversationContext'
 import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
 import { dockHostsOlumi } from './olumiSurface'
+import {
+  shouldAutoExpandDockForResponse,
+  latestRealMessageIsAssistantReply,
+} from './collapsedResponseSignal'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { focusFloating } from '../hooks/useFloatingFocus'
 import { isV5CanonicalRunPath } from '../../v5/eligibility'
@@ -507,6 +511,63 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     }
   }, [hasGraphContent, state.activeTab, effectiveIsOpen])
   const openFloatingByUser = useFloatingPanelState((s) => s.open)
+
+  // First-touch response signal (collapsed-dock defect). On the empty-canvas
+  // first-use journey the dock is the collapsed rail and the floating hero
+  // (FirstUseComposer) — which has NO transcript — is the entry point. When the
+  // user sends a brief and CEE replies with a clarify_v2 question + chips (a
+  // conversational turn that drafts no graph), that response renders ONLY in the
+  // collapsed Olumi tab: the user typed, the spinner ended, and nothing visibly
+  // happened. A DRAFT turn masks the same gap (canvas populates + the 0→N
+  // reposition force-activates Analysis); a clarify turn adds no nodes, so
+  // neither fires. Surface it by docking the Olumi tab — the same rail-override
+  // drop + tab-dock the user's own chevron-expand performs (toggleOpen).
+  //
+  // The decision + the "genuine assistant reply" scan are pure/tested helpers
+  // (collapsedResponseSignal.ts); this effect only gathers inputs and, on the
+  // true→false isThinking EDGE of a live send, acts. The edge is the reliable
+  // "user's own composer send" discriminator — hydration/session-resume set
+  // isThinking=false without a preceding true, so a page load never trips it.
+  const conversationIsThinking = conversationCtxForFirstUse?.isThinking ?? false
+  const prevConversationThinkingRef = useRef(conversationIsThinking)
+  const conversationMessagesRef = useRef(conversationCtxForFirstUse?.messages)
+  conversationMessagesRef.current = conversationCtxForFirstUse?.messages
+  const floatingPanelIsOpen = useFloatingPanelState((s) => s.isOpen)
+  const floatingPanelSource = useFloatingPanelState((s) => s.source)
+  const floatingPanelMinimised = useFloatingPanelState((s) => s.isMinimised)
+  useEffect(() => {
+    const wasThinking = prevConversationThinkingRef.current
+    prevConversationThinkingRef.current = conversationIsThinking
+    const thinkingSettled = wasThinking && !conversationIsThinking
+    // A floating panel showing its own transcript already displays the reply —
+    // the transcript-less first-use hero (source 'system-first-use') does not.
+    const floatingTranscriptVisible =
+      floatingPanelIsOpen && !floatingPanelMinimised && floatingPanelSource !== 'system-first-use'
+    const surface = shouldAutoExpandDockForResponse({
+      aiPanelV2On,
+      thinkingSettled,
+      dockCollapsed: !effectiveIsOpen,
+      hasGraphContent,
+      floatingTranscriptVisible,
+      hasAssistantReply: latestRealMessageIsAssistantReply(conversationMessagesRef.current),
+    })
+    if (!surface) return
+    // Same override the user's explicit rail-expand uses: drop the first-use
+    // rail lock for the session and dock the Olumi tab. The close-effect above
+    // then retires the first-use hero, leaving exactly one Olumi surface.
+    userExplicitlyOpenedRailRef.current = true
+    setState((prev) => ({ ...prev, isOpen: true, activeTab: 'olumi' }))
+    useUIStore.getState().setActiveOutputTab('olumi' as OutputTab)
+  }, [
+    conversationIsThinking,
+    aiPanelV2On,
+    effectiveIsOpen,
+    hasGraphContent,
+    floatingPanelIsOpen,
+    floatingPanelSource,
+    floatingPanelMinimised,
+    setState,
+  ])
 
   // Round-14: coordinates a user-initiated float-out from ANY trigger
   // (the OlumiTabBody float-out icon, the persistent strip's chevron, the

--- a/src/canvas/components/__tests__/collapsedResponseSignal.spec.ts
+++ b/src/canvas/components/__tests__/collapsedResponseSignal.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * RED-first pin for the collapsed-dock response-signal defect.
+ *
+ * Reproduces the live-verified first-touch gap (staging build 0d41f5dc): a guest
+ * on an empty canvas sends a brief from the floating composer, CEE replies with a
+ * clarify_v2 question + chips (no graph drafted), and the response lands ONLY in
+ * the dock's Olumi tab while the dock is collapsed — zero visible signal.
+ *
+ * `shouldAutoExpandDockForResponse` must return TRUE for exactly that scenario and
+ * FALSE for every case where auto-expanding would be wrong or redundant.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ConversationMessage } from '../../conversation/types'
+import {
+  latestRealMessageIsAssistantReply,
+  shouldAutoExpandDockForResponse,
+  type CollapsedResponseSignalInput,
+} from '../collapsedResponseSignal'
+
+function msg(partial: Partial<ConversationMessage>): ConversationMessage {
+  return {
+    id: partial.id ?? 'm',
+    role: partial.role ?? 'assistant',
+    content: partial.content ?? '',
+    timestamp: new Date(0),
+    ...partial,
+  }
+}
+
+// The clarify-turn-while-collapsed scenario: all gates satisfied.
+const CLARIFY_COLLAPSED: CollapsedResponseSignalInput = {
+  aiPanelV2On: true,
+  thinkingSettled: true,
+  dockCollapsed: true,
+  hasGraphContent: false,
+  floatingTranscriptVisible: false,
+  hasAssistantReply: true,
+}
+
+describe('latestRealMessageIsAssistantReply', () => {
+  it('true when the latest real message is an assistant reply with prose', () => {
+    expect(
+      latestRealMessageIsAssistantReply([
+        msg({ id: 'u1', role: 'user', content: 'should I switch jobs?' }),
+        msg({ id: 'a1', role: 'assistant', content: "What's your timeframe?" }),
+      ]),
+    ).toBe(true)
+  })
+
+  it('true when the assistant reply carries chips but no prose', () => {
+    expect(
+      latestRealMessageIsAssistantReply([
+        msg({ id: 'u1', role: 'user', content: 'help' }),
+        msg({
+          id: 'a1',
+          role: 'assistant',
+          content: '',
+          actionChips: [{ id: 'c1', label: 'Use sensible defaults', intent: 'primary' }],
+        }),
+      ]),
+    ).toBe(true)
+  })
+
+  it('false when the latest real message is the user (no assistant reply landed)', () => {
+    expect(
+      latestRealMessageIsAssistantReply([
+        msg({ id: 'u1', role: 'user', content: 'help' }),
+      ]),
+    ).toBe(false)
+  })
+
+  it('skips a trailing synthetic error bubble (send failure → no signal)', () => {
+    expect(
+      latestRealMessageIsAssistantReply([
+        msg({ id: 'u1', role: 'user', content: 'help' }),
+        msg({ id: 'err', role: 'assistant', content: 'Something went wrong', synthetic: true }),
+      ]),
+    ).toBe(false)
+  })
+
+  it('false for an empty / missing transcript', () => {
+    expect(latestRealMessageIsAssistantReply([])).toBe(false)
+    expect(latestRealMessageIsAssistantReply(undefined)).toBe(false)
+    expect(latestRealMessageIsAssistantReply(null)).toBe(false)
+  })
+
+  it('false when the assistant reply has neither prose nor chips', () => {
+    expect(
+      latestRealMessageIsAssistantReply([
+        msg({ id: 'a1', role: 'assistant', content: '   ' }),
+      ]),
+    ).toBe(false)
+  })
+})
+
+describe('shouldAutoExpandDockForResponse', () => {
+  it('THE DEFECT: clarify turn settles while the dock is collapsed → auto-expand', () => {
+    // Before the fix nothing surfaced this: the user typed, the spinner ended,
+    // and the clarify question + chips stayed invisible in the collapsed dock.
+    expect(shouldAutoExpandDockForResponse(CLARIFY_COLLAPSED)).toBe(true)
+  })
+
+  it('stands down when aiPanelV2 is off (legacy DraftChat path)', () => {
+    expect(shouldAutoExpandDockForResponse({ ...CLARIFY_COLLAPSED, aiPanelV2On: false })).toBe(false)
+  })
+
+  it('stands down when no live turn settled (page load / hydration — no isThinking edge)', () => {
+    expect(shouldAutoExpandDockForResponse({ ...CLARIFY_COLLAPSED, thinkingSettled: false })).toBe(false)
+  })
+
+  it('stands down when the dock is already visibly expanded', () => {
+    expect(shouldAutoExpandDockForResponse({ ...CLARIFY_COLLAPSED, dockCollapsed: false })).toBe(false)
+  })
+
+  it('stands down for a DRAFT turn (graph populated — the draft path owns that case)', () => {
+    expect(shouldAutoExpandDockForResponse({ ...CLARIFY_COLLAPSED, hasGraphContent: true })).toBe(false)
+  })
+
+  it('stands down when the conversation is already visible in a floating transcript', () => {
+    expect(
+      shouldAutoExpandDockForResponse({ ...CLARIFY_COLLAPSED, floatingTranscriptVisible: true }),
+    ).toBe(false)
+  })
+
+  it('stands down when the settled turn produced no genuine assistant reply (send failure)', () => {
+    expect(shouldAutoExpandDockForResponse({ ...CLARIFY_COLLAPSED, hasAssistantReply: false })).toBe(false)
+  })
+})

--- a/src/canvas/components/collapsedResponseSignal.ts
+++ b/src/canvas/components/collapsedResponseSignal.ts
@@ -1,0 +1,111 @@
+/**
+ * collapsedResponseSignal — decides whether a just-settled assistant turn
+ * must auto-expand the collapsed outputs dock to its Olumi tab.
+ *
+ * ## The defect this fixes
+ * On the aiPanelV2 first-touch journey the canvas is empty, so the outputs
+ * dock is forced to its collapsed 40px rail (`isFirstUse` overrides
+ * `state.isOpen`) and the floating hero (FirstUseComposer) is the entry
+ * point. The hero renders a composer only — it has NO transcript. When the
+ * user sends a brief and CEE replies with a `clarify_v2` question + suggested
+ * chips (a CONVERSATIONAL turn that drafts no graph), that response renders
+ * ONLY inside the dock's Olumi tab — which is collapsed. From the user's
+ * seat: they typed, the thinking indicator ended, and nothing visibly
+ * happened. The question and its chips are invisible until they happen to
+ * expand the dock.
+ *
+ * A DRAFT turn masks this same gap: the graph populates the canvas and
+ * FirstUseComposer's 0→N reposition effect force-activates the Analysis tab,
+ * so the dock visibly opens. A clarify turn adds no nodes, so neither the
+ * graph nor the reposition fires — nothing surfaces the response.
+ *
+ * ## Why a pure helper
+ * OutputsDock cannot be mounted in the unit suite (its supabase / threadService
+ * dependency chain throws at import in the test env — see aiPanelV2.parity.spec
+ * and OutputsDock.testability.spec). Following the same convention as the other
+ * dock decision helpers (`dockHostsOlumi` in olumiSurface.ts, `deriveNextDockIsOpen`,
+ * `runStatusRegion`), the surfacing decision is a pure function so it is directly
+ * and mutation-checkably testable; OutputsDock's effect is a thin caller that
+ * only gathers the inputs and, on a true verdict, performs the same rail-override
+ * drop + tab-dock that the user's own chevron-expand (`toggleOpen`) performs.
+ */
+
+import type { ConversationMessage } from '../conversation/types'
+
+/**
+ * True when the latest REAL (non-synthetic) message is an assistant reply
+ * that carries something visible — prose or chips. This is the "a genuine
+ * conversational response arrived" test.
+ *
+ * Deliberately skips synthetic messages: a send FAILURE (transport / timeout /
+ * typed error) leaves a synthetic assistant error bubble or no assistant reply
+ * at all, so this returns false and the dock is NOT auto-expanded — the
+ * FirstUseComposer shows its own point-of-failure notice instead. A blank CEE
+ * response (guarded to a synthetic bubble) likewise yields false.
+ */
+export function latestRealMessageIsAssistantReply(
+  messages: readonly ConversationMessage[] | undefined | null,
+): boolean {
+  if (!messages || messages.length === 0) return false
+  let latestReal: ConversationMessage | undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (!messages[i].synthetic) {
+      latestReal = messages[i]
+      break
+    }
+  }
+  if (!latestReal || latestReal.role !== 'assistant') return false
+  const hasProse = (latestReal.content?.trim().length ?? 0) > 0
+  const hasChips = (latestReal.actionChips?.length ?? 0) > 0
+  return hasProse || hasChips
+}
+
+export interface CollapsedResponseSignalInput {
+  /** aiPanelV2 floating-first UX is active. The whole signal is FF-gated. */
+  aiPanelV2On: boolean
+  /**
+   * A live turn just settled: `isThinking` transitioned true→false. This EDGE
+   * is the reliable "user's own composer send" discriminator — hydration and
+   * session-resume set isThinking=false WITHOUT a preceding true
+   * (useConversation.ts), so a page load never trips it. Only a composer send
+   * produces the edge, and on the empty first-touch canvas a composer send is
+   * the only thing that can.
+   */
+  thinkingSettled: boolean
+  /** The dock is visually collapsed right now (effectiveIsOpen === false). */
+  dockCollapsed: boolean
+  /**
+   * A graph exists on the canvas. The DRAFT path already surfaces the dock in
+   * this case (canvas populates + Analysis force-activates), so the clarify
+   * signal must stand down — this cleanly separates a clarify turn (no nodes)
+   * from a draft turn (nodes added before the turn settles).
+   */
+  hasGraphContent: boolean
+  /**
+   * The conversation is already visible in an OPEN floating panel showing its
+   * transcript (source !== 'system-first-use', not minimised). Never move a
+   * conversation the user can already see — that would be surprise motion.
+   * The transcript-less first-use hero does NOT count as visible.
+   */
+  floatingTranscriptVisible: boolean
+  /** The just-settled turn produced a genuine assistant reply (prose or chips). */
+  hasAssistantReply: boolean
+}
+
+/**
+ * Whether a just-settled assistant turn must auto-expand the collapsed dock to
+ * its Olumi tab so the response is visible. All gates must hold; any one false
+ * stands the signal down (no surprise motion, no fighting the draft path).
+ */
+export function shouldAutoExpandDockForResponse(
+  input: CollapsedResponseSignalInput,
+): boolean {
+  return (
+    input.aiPanelV2On &&
+    input.thinkingSettled &&
+    input.dockCollapsed &&
+    !input.hasGraphContent &&
+    !input.floatingTranscriptVisible &&
+    input.hasAssistantReply
+  )
+}


### PR DESCRIPTION
## The defect (live-verified 23 Jul, staging build `0d41f5dc`)

A guest on an empty canvas types a decision brief into the floating composer and sends. CEE replies with a `clarify_v2` question + suggested chips (e.g. "Use sensible defaults" / timeframe options). That response renders **only** inside the outputs dock's Olumi tab — and on first touch the dock is **collapsed** to its 40px rail. From the user's seat: they typed, hit send, the spinner ended… and nothing visibly happened. The question and its chips are invisible until they happen to expand the dock. This kills the first-touch journey.

## Trace (producer → surface, file:line)

- **Entry point is transcript-less.** On an empty canvas the dock is forced to its collapsed rail — `isFirstUse = aiPanelV2On && !hasGraphContent && !userExplicitlyOpenedRailRef.current` drives `effectiveIsOpen = isFirstUse ? false : state.isOpen` (`src/canvas/components/OutputsDock.tsx:452,461`). The floating hero (`FirstUseComposer`) is the composer, and it renders a composer + thinking indicator + starter cards only — **no conversation transcript** (`src/canvas/components/FirstUseComposer.tsx:258-360`).
- **The only signal that fires today is graph-shaped.** `FirstUseComposer`'s auto-reposition effect fires **only** on a `0 → N+` node transition (a drafted graph): it calls `forceActivateOutputTab('results')` + shows the "Model drafted" receipt + repositions the floating panel (`src/canvas/components/FirstUseComposer.tsx:191-239`). A DRAFT turn therefore visibly opens the dock — the graph populating the canvas **masks the gap**.
- **A clarify turn fires none of it.** A `clarify_v2` turn adds no nodes, so `nodeCount` stays 0, `isFirstUse` stays true, and the dock stays the collapsed rail. `isGenerating = isThinking && nodeCount === 0` clears when the turn settles, so even the thinking indicator disappears (`FirstUseComposer.tsx:107`). The response lands only in the docked Olumi tab (`OutputsDock.tsx:2413` → `OlumiTabBody` → `ConversationPanel`, `src/canvas/components/OlumiTabBody.tsx:102-114`), which is collapsed.
- **The collapsed rail has no unread affordance.** The rail renders plain tab icons with no badge/pulse/unread state on the Olumi control (`OutputsDock.tsx:1814-1849`). No existing mechanism signals "a response arrived" on the collapsed surface.

**Answer to "does the drafted graph mask the same gap for DRAFT responses?"** — Yes. The `0→N` reposition force-opens Analysis and the graph appears on canvas, so a draft turn is visibly acknowledged. Only the no-graph conversational turn (clarify/coach) is stranded.

## Mechanism picked — fix (b): auto-expand the dock to the Olumi tab

Preference (a) does not apply: **no** existing signal mechanism is "simply not firing" for clarify turns — the only signal (`forceActivateOutputTab('results')`) is graph-gated and points at the wrong tab (Analysis, not Olumi) for a conversational turn. So this is fix **(b)** from the brief.

New pure, tested helper `src/canvas/components/collapsedResponseSignal.ts`:
- `shouldAutoExpandDockForResponse(input)` — all gates must hold: aiPanelV2 on · `isThinking` **true→false edge** of a live send · dock collapsed · **no** graph drafted · conversation **not** already visible in an open floating transcript · a genuine assistant reply landed.
- `latestRealMessageIsAssistantReply(messages)` — the latest non-synthetic message is an assistant reply carrying prose or chips (a send failure leaves a synthetic error / no reply → false → no auto-expand; `FirstUseComposer` shows its own failure notice).

`OutputsDock.tsx` adds a thin effect that gathers those inputs and, on a true verdict, performs the **same** rail-override drop + tab-dock the user's own chevron-expand does (`userExplicitlyOpenedRailRef.current = true`, dock `isOpen:true`/`activeTab:'olumi'`, `setActiveOutputTab('olumi')`). The existing close-effect then retires the first-use hero, leaving exactly one Olumi surface showing the question + chips.

**Why the `isThinking` edge = "the user's own composer send" (the brief's no-surprise-motion rule):** hydration / session-resume set `isThinking=false` **without** a preceding `true` (`src/canvas/conversation/useConversation.ts:1831,1855,1870`), so a page load never produces the edge. On the empty first-touch canvas the only thing that sets `isThinking=true` is a composer send. Background/system events (patch accepted/dismissed, direct graph edit) require a graph and can't occur here.

**Why no draft-path conflict / no flicker:** a full_draft turn adds nodes **before** the turn settles, so at the `isThinking` false edge `hasGraphContent` is already true and the signal stands down — the draft path owns that case. Scoping by `!hasGraphContent` also naturally limits this to the first-touch (empty-canvas) scenario, matching the live defect.

## Alternatives considered (for veto)

1. **Render the transcript inside the floating hero** instead of docking. Rejected: bigger change (the hero is deliberately chromeless/transcript-less), and the brief prefers auto-expand.
2. **Unread badge/pulse on the collapsed Olumi rail icon** (fix (c)). Viable and less motion, but leaves the user one extra click from their answer on the *first* touch — a worse first-run outcome than surfacing it, and auto-expand does **not** fight the existing auto-collapse logic (it reuses the user's own `toggleOpen` override path). Happy to switch to the badge if you'd rather avoid the motion — the decision is isolated in `collapsedResponseSignal.ts`.
3. **Flip the floating `source` from `system-first-use` to `user`** so `FloatingOlumiPanel` (which has a transcript) takes over. Rejected: mutates floating-source semantics that other invariants depend on.

## Tests (`src/canvas/components/__tests__/collapsedResponseSignal.spec.ts`, 13)

- `latestRealMessageIsAssistantReply`: prose reply · chips-only reply · latest-is-user → false · **skips a trailing synthetic error bubble** (send failure) · empty/undefined/null → false · whitespace-only + no chips → false.
- `shouldAutoExpandDockForResponse`: **THE DEFECT** clarify-while-collapsed → true · stands down for FF-off · no isThinking edge (page load/hydration) · already expanded · **DRAFT turn (graph populated)** · floating transcript already visible · send failure (no assistant reply).

## Mutation results (throwaway copy, per verification discipline)

| Mutation | Pin that went RED |
|---|---|
| `shouldAutoExpandDockForResponse` → `return false` (pre-fix behaviour) | "THE DEFECT: clarify turn settles while collapsed → auto-expand" |
| remove the `!hasGraphContent` guard | "stands down for a DRAFT turn (graph populated)" |
| `latestRealMessageIsAssistantReply` stops skipping synthetic messages | "skips a trailing synthetic error bubble (send failure → no signal)" |

Each mutation flipped exactly one distinct pin; reverting restores green.

## Gates

- `pnpm run typecheck` — clean.
- `npx vitest run --changed --bail=1` — 19 files / 224 tests pass (includes all OutputsDock specs + the new spec). *(8 OutputsDock suites fail to **collect** without a local `.env.local` — pre-existing supabase-env requirement, unrelated to this change; green after copying it in.)*
- `pnpm run lint` (changed files) — 0 errors. The one warning (`OutputsDock.tsx:1112` `report` dep on `strengthCorrectionsForRun`) is pre-existing, not in this diff.

## Design compliance

Complete borders only, semantic tokens, Lucide only, sentence case, **no flag** (ships on), **no new UI-SEM transform** — the effect surfaces an existing value, never fabricates or transforms one.

Draft — do not merge.