### PR TITLE
fix(dock): surface failed turns too when the dock is collapsed (extends #446)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -59,6 +59,7 @@ import { dockHostsOlumi } from './olumiSurface'
 import {
   shouldAutoExpandDockForResponse,
   latestRealMessageIsAssistantReply,
+  latestRealMessageIsFailedTurn,
 } from './collapsedResponseSignal'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { focusFloating } from '../hooks/useFloatingFocus'
@@ -523,11 +524,19 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // neither fires. Surface it by docking the Olumi tab — the same rail-override
   // drop + tab-dock the user's own chevron-expand performs (toggleOpen).
   //
-  // The decision + the "genuine assistant reply" scan are pure/tested helpers
+  // The same gap swallows a FAILED turn: when the send times out / errors, the
+  // "Not delivered" marker + Retry + recovery guidance render only inside the
+  // collapsed dock (the user typed, waited, and saw nothing). An invisible error
+  // is worse than an invisible question, so a failed turn surfaces the same way
+  // (latestRealMessageIsFailedTurn) — a distinct predicate, never a loosening of
+  // the assistant-reply scan.
+  //
+  // The decision + both message scans are pure/tested helpers
   // (collapsedResponseSignal.ts); this effect only gathers inputs and, on the
   // true→false isThinking EDGE of a live send, acts. The edge is the reliable
   // "user's own composer send" discriminator — hydration/session-resume set
-  // isThinking=false without a preceding true, so a page load never trips it.
+  // isThinking=false without a preceding true, so a page load never trips it,
+  // and a background/system failure (which adds no user bubble) surfaces nothing.
   const conversationIsThinking = conversationCtxForFirstUse?.isThinking ?? false
   const prevConversationThinkingRef = useRef(conversationIsThinking)
   const conversationMessagesRef = useRef(conversationCtxForFirstUse?.messages)
@@ -550,6 +559,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       hasGraphContent,
       floatingTranscriptVisible,
       hasAssistantReply: latestRealMessageIsAssistantReply(conversationMessagesRef.current),
+      hasFailedTurn: latestRealMessageIsFailedTurn(conversationMessagesRef.current),
     })
     if (!surface) return
     // Same override the user's explicit rail-expand uses: drop the first-use

--- a/src/canvas/components/__tests__/collapsedResponseSignal.spec.ts
+++ b/src/canvas/components/__tests__/collapsedResponseSignal.spec.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from 'vitest'
 import type { ConversationMessage } from '../../conversation/types'
 import {
   latestRealMessageIsAssistantReply,
+  latestRealMessageIsFailedTurn,
   shouldAutoExpandDockForResponse,
   type CollapsedResponseSignalInput,
 } from '../collapsedResponseSignal'
@@ -36,6 +37,21 @@ const CLARIFY_COLLAPSED: CollapsedResponseSignalInput = {
   hasGraphContent: false,
   floatingTranscriptVisible: false,
   hasAssistantReply: true,
+  hasFailedTurn: false,
+}
+
+// The failed-turn-while-collapsed scenario: all context gates satisfied, but the
+// turn produced NO assistant reply — its send failed (deliveryState 'failed')
+// and the "Not delivered" + Retry + recovery guidance are stranded in the
+// collapsed dock.
+const FAILED_COLLAPSED: CollapsedResponseSignalInput = {
+  aiPanelV2On: true,
+  thinkingSettled: true,
+  dockCollapsed: true,
+  hasGraphContent: false,
+  floatingTranscriptVisible: false,
+  hasAssistantReply: false,
+  hasFailedTurn: true,
 }
 
 describe('latestRealMessageIsAssistantReply', () => {
@@ -94,6 +110,76 @@ describe('latestRealMessageIsAssistantReply', () => {
   })
 })
 
+describe('latestRealMessageIsFailedTurn', () => {
+  it('true when the latest real message is a failed user send behind a synthetic error bubble', () => {
+    // The live failure shape: the user bubble is patched deliveryState 'failed'
+    // in place (so it keeps its position) and a SYNTHETIC assistant error bubble
+    // — "Not delivered" copy + Retry chip — is appended after it.
+    expect(
+      latestRealMessageIsFailedTurn([
+        msg({ id: 'u1', role: 'user', content: 'should I switch jobs?', deliveryState: 'failed' }),
+        msg({
+          id: 'err',
+          role: 'assistant',
+          synthetic: true,
+          content: 'This is taking longer than expected. We stopped waiting…',
+          actionChips: [{ id: 'retry', label: 'Try again', intent: 'primary' }],
+        }),
+      ]),
+    ).toBe(true)
+  })
+
+  it('true when the failed user send is the only message', () => {
+    expect(
+      latestRealMessageIsFailedTurn([
+        msg({ id: 'u1', role: 'user', content: 'help', deliveryState: 'failed' }),
+      ]),
+    ).toBe(true)
+  })
+
+  it('false for a delivered send (deliveryState "sent" — e.g. blank-response turn)', () => {
+    // Delivered-but-empty leaves the user bubble 'sent'; that is the #446
+    // blank-response case, not a failure — neither predicate fires for it.
+    expect(
+      latestRealMessageIsFailedTurn([
+        msg({ id: 'u1', role: 'user', content: 'help', deliveryState: 'sent' }),
+        msg({ id: 'blank', role: 'assistant', synthetic: true, content: "I couldn't generate a response." }),
+      ]),
+    ).toBe(false)
+  })
+
+  it('false while the send is still in flight (deliveryState "pending")', () => {
+    expect(
+      latestRealMessageIsFailedTurn([
+        msg({ id: 'u1', role: 'user', content: 'help', deliveryState: 'pending' }),
+      ]),
+    ).toBe(false)
+  })
+
+  it('false for a legacy/hydrated user send with no deliveryState', () => {
+    expect(
+      latestRealMessageIsFailedTurn([
+        msg({ id: 'u1', role: 'user', content: 'help' }),
+      ]),
+    ).toBe(false)
+  })
+
+  it('false when the latest real message is a successful assistant reply (mutually exclusive with the reply scan)', () => {
+    const messages = [
+      msg({ id: 'u1', role: 'user', content: 'help', deliveryState: 'sent' }),
+      msg({ id: 'a1', role: 'assistant', content: "What's your timeframe?" }),
+    ]
+    expect(latestRealMessageIsFailedTurn(messages)).toBe(false)
+    expect(latestRealMessageIsAssistantReply(messages)).toBe(true)
+  })
+
+  it('false for an empty / missing transcript', () => {
+    expect(latestRealMessageIsFailedTurn([])).toBe(false)
+    expect(latestRealMessageIsFailedTurn(undefined)).toBe(false)
+    expect(latestRealMessageIsFailedTurn(null)).toBe(false)
+  })
+})
+
 describe('shouldAutoExpandDockForResponse', () => {
   it('THE DEFECT: clarify turn settles while the dock is collapsed → auto-expand', () => {
     // Before the fix nothing surfaced this: the user typed, the spinner ended,
@@ -123,7 +209,42 @@ describe('shouldAutoExpandDockForResponse', () => {
     ).toBe(false)
   })
 
-  it('stands down when the settled turn produced no genuine assistant reply (send failure)', () => {
-    expect(shouldAutoExpandDockForResponse({ ...CLARIFY_COLLAPSED, hasAssistantReply: false })).toBe(false)
+  it('stands down when the settled turn produced neither a reply nor a failure', () => {
+    expect(
+      shouldAutoExpandDockForResponse({
+        ...CLARIFY_COLLAPSED,
+        hasAssistantReply: false,
+        hasFailedTurn: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('THE ERROR DEFECT: a failed turn settles while the dock is collapsed → auto-expand', () => {
+    // The residual gap #446 left: the user typed, waited ~90s, the send failed,
+    // and the "Not delivered" + Retry + recovery guidance stayed invisible in the
+    // collapsed dock. A failure surfaces the same as a reply — no assistant reply
+    // required (hasAssistantReply is false here).
+    expect(shouldAutoExpandDockForResponse(FAILED_COLLAPSED)).toBe(true)
+  })
+
+  it('failed turn stands down when no live turn settled (background/hydration failure — no isThinking edge)', () => {
+    // The thinking-edge guard must still gate: a failure that surfaces without a
+    // user's own composer send (page load, background/system turn) must NOT move
+    // the dock.
+    expect(
+      shouldAutoExpandDockForResponse({ ...FAILED_COLLAPSED, thinkingSettled: false }),
+    ).toBe(false)
+  })
+
+  it('failed turn stands down when a graph already exists (draft path owns that surface)', () => {
+    expect(
+      shouldAutoExpandDockForResponse({ ...FAILED_COLLAPSED, hasGraphContent: true }),
+    ).toBe(false)
+  })
+
+  it('failed turn stands down when aiPanelV2 is off (legacy DraftChat path)', () => {
+    expect(
+      shouldAutoExpandDockForResponse({ ...FAILED_COLLAPSED, aiPanelV2On: false }),
+    ).toBe(false)
   })
 })

--- a/src/canvas/components/collapsedResponseSignal.ts
+++ b/src/canvas/components/collapsedResponseSignal.ts
@@ -60,6 +60,48 @@ export function latestRealMessageIsAssistantReply(
   return hasProse || hasChips
 }
 
+/**
+ * True when the latest REAL (non-synthetic) message is a user send whose
+ * delivery FAILED (`deliveryState === 'failed'`). This is the honest ERROR
+ * counterpart to `latestRealMessageIsAssistantReply`: an invisible error is
+ * worse than an invisible question, so a failed turn must surface the same way
+ * a clarify reply does.
+ *
+ * Every user-mode failure path in useConversation.ts — buildV5Payload refusal,
+ * the request timeout, a typed_error response, and a thrown dispatch — marks
+ * the user bubble `deliveryState: 'failed'` (useConversation.ts:3254, 3304,
+ * 3386, 3873) and then appends a SYNTHETIC assistant error bubble carrying the
+ * "Not delivered" copy + Retry chip + recovery guidance. `updateMessage`
+ * patches the user bubble in place (useConversation.ts:1888), so it keeps its
+ * original position AHEAD of the appended synthetic bubble. Skipping synthetics
+ * (exactly as the assistant-reply scan does), the latest real message is
+ * therefore that failed user bubble.
+ *
+ * Deliberately narrow — matches a genuinely FAILED user send only:
+ *   - a delivered-but-empty turn leaves the user bubble `deliveryState: 'sent'`
+ *     (useConversation.ts:3386) and matches neither predicate — that's the
+ *     blank-response case #446 already stands down on;
+ *   - a system / background failure adds no user bubble at all (its transcript
+ *     bubble is suppressed), so there is no failed user send to find.
+ * This does NOT loosen `latestRealMessageIsAssistantReply` — the two are
+ * mutually exclusive by construction (the latest real message is one role or
+ * the other).
+ */
+export function latestRealMessageIsFailedTurn(
+  messages: readonly ConversationMessage[] | undefined | null,
+): boolean {
+  if (!messages || messages.length === 0) return false
+  let latestReal: ConversationMessage | undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (!messages[i].synthetic) {
+      latestReal = messages[i]
+      break
+    }
+  }
+  if (!latestReal || latestReal.role !== 'user') return false
+  return latestReal.deliveryState === 'failed'
+}
+
 export interface CollapsedResponseSignalInput {
   /** aiPanelV2 floating-first UX is active. The whole signal is FF-gated. */
   aiPanelV2On: boolean
@@ -90,12 +132,24 @@ export interface CollapsedResponseSignalInput {
   floatingTranscriptVisible: boolean
   /** The just-settled turn produced a genuine assistant reply (prose or chips). */
   hasAssistantReply: boolean
+  /**
+   * The just-settled turn FAILED — its user send is marked
+   * `deliveryState: 'failed'` (timeout / typed error / thrown dispatch) and the
+   * "Not delivered" + Retry + recovery guidance renders only inside the
+   * collapsed dock. Surfaced for the same reason as a reply: an invisible error
+   * is worse than an invisible question.
+   */
+  hasFailedTurn: boolean
 }
 
 /**
- * Whether a just-settled assistant turn must auto-expand the collapsed dock to
- * its Olumi tab so the response is visible. All gates must hold; any one false
- * stands the signal down (no surprise motion, no fighting the draft path).
+ * Whether a just-settled turn must auto-expand the collapsed dock to its Olumi
+ * tab so its outcome is visible. All five context gates must hold, and the turn
+ * must have produced something worth surfacing — a genuine assistant reply OR a
+ * failed send whose recovery affordance is otherwise stranded in the collapsed
+ * dock. Any context gate false stands the signal down (no surprise motion, no
+ * fighting the draft path); a turn that produced neither a reply nor a failure
+ * surfaces nothing.
  */
 export function shouldAutoExpandDockForResponse(
   input: CollapsedResponseSignalInput,
@@ -106,6 +160,6 @@ export function shouldAutoExpandDockForResponse(
     input.dockCollapsed &&
     !input.hasGraphContent &&
     !input.floatingTranscriptVisible &&
-    input.hasAssistantReply
+    (input.hasAssistantReply || input.hasFailedTurn)
   )
 }


### PR DESCRIPTION
## Problem

PR #446 auto-expands the collapsed outputs dock to its Olumi tab when a genuine assistant reply lands on the graphless first-touch journey. But its `latestRealMessageIsAssistantReply` scan **deliberately skips synthetic bubbles**, so when the turn **fails** nothing surfaces.

Live-verified 23 Jul: four consecutive draft failures rendered "Not delivered" + Retry + recovery guidance **only inside the collapsed dock**. The user typed, waited ~90s, and saw nothing. An invisible error is worse than an invisible question.

## Trace — how a failed turn lands in the conversation

Every user-mode (`mode === 'user'`, `!hidden`) failure path in `useConversation.ts` does the same two things: it marks the **user bubble** `deliveryState: 'failed'`, then appends a **synthetic** assistant error bubble (the "Not delivered" copy + Retry chip + recovery guidance):

| Failure site | `src/canvas/conversation/useConversation.ts` | User bubble | Synthetic assistant bubble |
|---|---|---|---|
| `buildV5Payload` refusal | `:3254` → `:3259` | `deliveryState: 'failed'` | yes |
| Request timeout (the live ~90s case) | `:3304` → `:3309` | `deliveryState: 'failed'` | yes (+ Retry) |
| `typed_error` response | `:3386` → `:3841` | `deliveryState: 'failed'` | yes (+ Retry when retryable) |
| Thrown dispatch (catch) | `:3873` → `:3875` | `deliveryState: 'failed'` | yes (+ Retry) |

`updateMessage` patches the user bubble **in place** (`useConversation.ts:1888`, `prev.map(...)`), so it keeps its position **ahead** of the appended synthetic bubble. Skipping synthetics — exactly as `latestRealMessageIsAssistantReply` already does — the **latest real message is that failed user send**. The `deliveryState` field is defined in `src/canvas/conversation/types.ts:91` (`'pending' | 'sent' | 'failed'`).

Delivered-but-empty is **not** a failure: it leaves the user bubble `deliveryState: 'sent'` (`useConversation.ts:3386`, `target.kind === 'empty'`) — the #446 blank-response case, correctly left alone. System/background failures add **no** user bubble (transcript bubble suppressed), so there is nothing to surface.

## Predicate design

New DISTINCT pure predicate in `collapsedResponseSignal.ts`:

```ts
latestRealMessageIsFailedTurn(messages): boolean
// latest non-synthetic message is a USER send with deliveryState === 'failed'
```

It detects **a failed user send behind the synthetic error bubble** — the honest ERROR counterpart to `latestRealMessageIsAssistantReply`, which is **not loosened**. The two are mutually exclusive by construction (the latest real message is one role or the other).

Wired into the same six-guard decision — the pure function stays the single decision point:

```ts
input.aiPanelV2On && input.thinkingSettled && input.dockCollapsed &&
!input.hasGraphContent && !input.floatingTranscriptVisible &&
(input.hasAssistantReply || input.hasFailedTurn)   // ← only this line changed
```

`hasFailedTurn` is a new required field on `CollapsedResponseSignalInput`; the `OutputsDock` effect gathers it via `latestRealMessageIsFailedTurn(conversationMessagesRef.current)` alongside the existing `hasAssistantReply` — no dependency-array change (both read from the same ref). The thinking-edge guard (`thinkingSettled`) still gates, so a background/hydration failure never moves the dock.

## Tests (`collapsedResponseSignal.spec.ts`, 14 → 24)

`latestRealMessageIsFailedTurn` (7 new):
- TRUE: failed user send behind a synthetic error bubble (the live shape)
- TRUE: failed user send is the only message
- FALSE: `deliveryState: 'sent'` (delivered — blank-response case)
- FALSE: `deliveryState: 'pending'` (in flight)
- FALSE: no `deliveryState` (legacy/hydrated)
- FALSE: successful assistant reply (asserts mutual exclusivity with the reply scan)
- FALSE: empty / `undefined` / `null`

`shouldAutoExpandDockForResponse` (3 new + 1 tightened):
- **THE ERROR DEFECT**: a failed turn settles while collapsed → auto-expand (no assistant reply required)
- Stands down when no live turn settled (`thinkingSettled: false` — background/hydration, thinking-edge guard)
- Stands down when a graph already exists (draft path owns that surface)
- Stands down when aiPanelV2 is off
- Existing "no genuine assistant reply" pin re-expressed as "neither reply nor failure → false"

## Mutation results (throwaway, against committed `688650b0`, tree restored + verified clean after each)

- **Mutation A** — revert the decision point (`(hasAssistantReply || hasFailedTurn)` → `hasAssistantReply`): **1 failed / 23 passed** — exactly the `shouldAutoExpandDockForResponse` "THE ERROR DEFECT" pin goes RED; all #446 pins + predicate pins stay green.
- **Mutation B** — break the predicate body (`return false`, ignore `deliveryState`): **2 failed / 22 passed** — exactly the two `latestRealMessageIsFailedTurn` TRUE pins go RED; the `shouldAutoExpand` ERROR pin (input literal, not the predicate) stays green, correctly isolating the predicate.

## Gates

- `pnpm run typecheck` — clean
- `npx vitest run src/canvas/components/__tests__/collapsedResponseSignal.spec.ts` — 24 passed
- `npx eslint` (changed files) — 0 errors (1 pre-existing `useMemo` warning at `OutputsDock.tsx:1122`, unrelated to this change)

No flag, no new UI-SEM transform, no UI surface change (complete-borders/etc. unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
