### PR TITLE
refactor(simplify): session-span cleanups — single lens build, shared range bar/scale, gate dedup, dead fields

### DIFF
--- a/src/canvas/components/WhatChangedChip.tsx
+++ b/src/canvas/components/WhatChangedChip.tsx
@@ -216,7 +216,7 @@ export function WhatChangedChip() {
     // hide the honest server answer behind a device-side heuristic — the exact
     // catch-22 this fixes. Dispatch goes through the existing chip mechanism
     // (dispatchAction → buildChipMeta → buildV5Payload); the send gate promotes
-    // source to 'chip_click' because 'what_changed' passes isSendableActionType
+    // source to 'chip_click' because 'what_changed' passes isSendableToken
     // — the payload is not built here. FAIL-SAFE: when dispatchAction is absent
     // (no conversation hook), the click is a no-op beyond the optional pulse.
     if (dispatchAction) {

--- a/src/canvas/components/pre-analysis-v3/__tests__/sparkIntentContract.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/__tests__/sparkIntentContract.spec.ts
@@ -46,7 +46,7 @@ import {
   buildV5Payload,
   KNOWN_ACTION_TYPES,
   CEE_ACCEPTED_ACTION_TYPES,
-  isSendableActionType,
+  isSendableToken,
 } from '../../../../v5/buildPayload'
 import type { ActionChip } from '../../../conversation/types'
 
@@ -87,7 +87,7 @@ const PENDING_SET: ReadonlySet<string> = new Set<string>(PENDING_WIRE_ACTION_TYP
  * tests below, not this helper).
  */
 function isSendable(actionType: string): boolean {
-  return isSendableActionType(actionType, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES)
+  return isSendableToken(actionType, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES)
 }
 
 beforeEach(() => {
@@ -339,7 +339,7 @@ describe('spark click → outgoing wire payload (real send funnel)', () => {
     // send predicate with SYNTHETIC registries so it can model a value that is
     // published-but-unaccepted — a state no real value is in today, precisely
     // because the acceptance registry is the second signal. Under the old
-    // publication-only gate `isSendableActionType` would ignore `accepted` and
+    // publication-only gate `isSendableToken` would ignore `accepted` and
     // this would be RED.
     const synthetic = 'synthetic_published_but_unaccepted_value'
 
@@ -350,13 +350,13 @@ describe('spark click → outgoing wire payload (real send funnel)', () => {
     expect((CEE_ACCEPTED_ACTION_TYPES as ReadonlySet<string>).has(synthetic)).toBe(false)
 
     // The AND bites on the ACCEPTANCE signal: published but unaccepted → withheld.
-    expect(isSendableActionType(synthetic, publishedWithSynthetic, CEE_ACCEPTED_ACTION_TYPES)).toBe(false)
+    expect(isSendableToken(synthetic, publishedWithSynthetic, CEE_ACCEPTED_ACTION_TYPES)).toBe(false)
 
     // Mirror — acceptance WITHOUT publication is also insufficient, so neither
     // signal can open the gate alone.
     const acceptedWithSynthetic = new Set<string>([...CEE_ACCEPTED_ACTION_TYPES, synthetic])
     expect((KNOWN_ACTION_TYPES as ReadonlySet<string>).has(synthetic)).toBe(false)
-    expect(isSendableActionType(synthetic, KNOWN_ACTION_TYPES, acceptedWithSynthetic)).toBe(false)
+    expect(isSendableToken(synthetic, KNOWN_ACTION_TYPES, acceptedWithSynthetic)).toBe(false)
   })
 
   it('CLASS-KILLER (end-to-end): an unrecognised value is withheld by buildV5Payload — identity-only chip, never a 422 (positive control: the send arm above proves the gate CAN pass a value)', () => {

--- a/src/canvas/conversation/chipMeta.ts
+++ b/src/canvas/conversation/chipMeta.ts
@@ -99,7 +99,7 @@ export function toLegacyChipMetadata(
  * yet FULLY LIVE — meaning BOTH published in the vendored @talchain/schemas
  * enum AND accepted by CEE's deployed service. Registries (spark registry,
  * NodeChip call sites) may map these immediately; the send gate in
- * buildV5Payload (sanitiseActionType → isSendableActionType, which requires
+ * buildV5Payload (sanitiseActionType → isSendableToken, which requires
  * membership in KNOWN_ACTION_TYPES AND in CEE_ACCEPTED_ACTION_TYPES) withholds
  * them from the wire — no `action_type` key, no chip_click promotion — until
  * the value is fully live, at which point the send lights up with zero further

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -26,7 +26,7 @@ import {
 import { ExpertBlock } from './ExpertBlock'
 import { formatOptionLabelForCard } from './utils/cleanFactorLabel'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
-import { formatRangeValue } from './utils/formatRangeValue'
+import { OptionRangeBar, computeOptionScale } from './shared/OptionRangeBar'
 import { SUB_ONE_PERCENT_FLOOR } from './utils/displayFloors'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from './utils/goalFitBasisCaveatCopy'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
@@ -211,69 +211,10 @@ function StatBar({
 // (utils/formatRangeValue) — the same rule formatThreshold's user-unit
 // percent branch uses, so card labels and hero readouts share one scale.
 // TODO: PLoT should provide outcome_unit for proper display.
-
-/**
- * OptionRangeBar — thin 4px bar showing p10-to-p90 range with dot at median.
- *
- * All option range bars share the same [globalMin, globalMax] scale
- * for visual comparability between options. The bar fill width
- * represents each option's range within the shared scale.
- */
-function OptionRangeBar({
-  p10,
-  p50,
-  p90,
-  globalMin,
-  globalMax,
-}: {
-  p10: number
-  p50?: number
-  p90: number
-  globalMin: number
-  globalMax: number
-}) {
-  const span = globalMax - globalMin
-  if (span <= 0) return null
-
-  const leftPct = ((p10 - globalMin) / span) * 100
-  const widthPct = ((p90 - p10) / span) * 100
-  const dotPct = p50 != null ? ((p50 - globalMin) / span) * 100 : undefined
-
-  return (
-    <div data-testid="option-range-bar">
-      <div className="relative" style={{ height: 4, background: 'var(--border-default)', borderRadius: 2 }}>
-        <div
-          className="absolute top-0 h-full rounded-sm"
-          style={{
-            left: `${leftPct}%`,
-            width: `${Math.max(2, widthPct)}%`,
-            background: 'color-mix(in srgb, var(--info) 30%, transparent)',
-          }}
-        />
-        {dotPct != null && (
-          <div
-            className="absolute top-1/2 -translate-y-1/2 rounded-full"
-            style={{
-              left: `${dotPct}%`,
-              width: 8,
-              height: 8,
-              background: 'var(--info)',
-              border: '1.5px solid var(--bg-panel)',
-              transform: `translate(-50%, -50%)`,
-            }}
-          />
-        )}
-      </div>
-      <div className={`flex justify-between mt-0.5 ${typography.panelMeta}`}>
-        <span className="text-text-light">{formatRangeValue(p10)}</span>
-        {p50 != null && (
-          <span className="text-text-header">{formatRangeValue(p50)}</span>
-        )}
-        <span className="text-text-light">{formatRangeValue(p90)}</span>
-      </div>
-    </div>
-  )
-}
+//
+// OptionRangeBar + the [globalMin, globalMax] scale now live in the shared
+// ./shared/OptionRangeBar module (consumed here and by the V7 lens group) so
+// the two surfaces cannot drift.
 
 /** Single option card */
 function OptionCard({
@@ -608,13 +549,9 @@ export function OptionCards({
   const sorted = sortOptionsForDisplay(options)
 
   // Range bar global scale: shared [globalMin, globalMax] across all options
-  // so bar widths are visually comparable. Falls back to mean when percentiles absent.
-  const globalMin = Math.min(
-    ...options.map(o => o.outcome?.p10 ?? o.outcome?.mean ?? 0),
-  )
-  const globalMax = Math.max(
-    ...options.map(o => o.outcome?.p90 ?? o.outcome?.mean ?? 0),
-  )
+  // so bar widths are visually comparable. Falls back to mean when percentiles
+  // absent (computeOptionScale — the same formula the V7 lens shares).
+  const { globalMin, globalMax } = computeOptionScale(options)
 
   // Brief 5.8B D3 collapsed the per-rank border palette to a 2-state
   // (winner / non-winner) hierarchy, so `buildSegmentBorderClassMap` /

--- a/src/components/results/shared/OptionRangeBar.tsx
+++ b/src/components/results/shared/OptionRangeBar.tsx
@@ -1,0 +1,101 @@
+/**
+ * OptionRangeBar + computeOptionScale — the shared p10→p90 range bar and its
+ * [globalMin, globalMax] scale, extracted VERBATIM from OptionCards so the V7
+ * lens bars and the option cards below cannot drift.
+ *
+ * OptionRangeBar renders a thin 4px bar showing the p10-to-p90 range with a dot
+ * at the median. All bars sharing one scale (computeOptionScale over the same
+ * option set) makes bar widths visually comparable between options. The bar fill
+ * width represents each option's range within the shared scale.
+ *
+ * `data-testid` defaults to `option-range-bar` (OptionCards' original testid);
+ * the V7 lens passes `v7-range-bar`.
+ */
+
+import { typography } from '../../../styles/typography'
+import { formatRangeValue } from '../utils/formatRangeValue'
+import type { OptionResult } from '../types'
+
+/**
+ * Shared [globalMin, globalMax] display scale — the exact OptionCards formula
+ * (`p10 ?? mean ?? 0` / `p90 ?? mean ?? 0`) with the empty-array guard from
+ * buildV7Lenses so an empty option set yields the neutral [0, 1] span instead
+ * of [Infinity, -Infinity].
+ */
+export function computeOptionScale(options: OptionResult[]): { globalMin: number; globalMax: number } {
+  return {
+    globalMin: options.length
+      ? Math.min(...options.map((o) => o.outcome?.p10 ?? o.outcome?.mean ?? 0))
+      : 0,
+    globalMax: options.length
+      ? Math.max(...options.map((o) => o.outcome?.p90 ?? o.outcome?.mean ?? 0))
+      : 1,
+  }
+}
+
+/**
+ * OptionRangeBar — thin 4px bar showing p10-to-p90 range with dot at median.
+ *
+ * All option range bars share the same [globalMin, globalMax] scale
+ * for visual comparability between options. The bar fill width
+ * represents each option's range within the shared scale.
+ */
+export function OptionRangeBar({
+  p10,
+  p50,
+  p90,
+  globalMin,
+  globalMax,
+  'data-testid': dataTestId = 'option-range-bar',
+}: {
+  p10: number
+  p50?: number
+  p90: number
+  globalMin: number
+  globalMax: number
+  'data-testid'?: string
+}) {
+  const span = globalMax - globalMin
+  if (span <= 0) return null
+
+  const leftPct = ((p10 - globalMin) / span) * 100
+  const widthPct = ((p90 - p10) / span) * 100
+  const dotPct = p50 != null ? ((p50 - globalMin) / span) * 100 : undefined
+
+  return (
+    <div data-testid={dataTestId}>
+      <div className="relative" style={{ height: 4, background: 'var(--border-default)', borderRadius: 2 }}>
+        <div
+          className="absolute top-0 h-full rounded-sm"
+          style={{
+            left: `${leftPct}%`,
+            width: `${Math.max(2, widthPct)}%`,
+            background: 'color-mix(in srgb, var(--info) 30%, transparent)',
+          }}
+        />
+        {dotPct != null && (
+          <div
+            className="absolute top-1/2 -translate-y-1/2 rounded-full"
+            style={{
+              left: `${dotPct}%`,
+              width: 8,
+              height: 8,
+              background: 'var(--info)',
+              border: '1.5px solid var(--bg-panel)',
+              transform: `translate(-50%, -50%)`,
+            }}
+          />
+        )}
+      </div>
+      <div className={`flex justify-between mt-0.5 ${typography.panelMeta}`}>
+        <span className="text-text-light">{formatRangeValue(p10)}</span>
+        {p50 != null && (
+          <span className="text-text-header">{formatRangeValue(p50)}</span>
+        )}
+        <span className="text-text-light">{formatRangeValue(p90)}</span>
+      </div>
+    </div>
+  )
+}
+
+export default OptionRangeBar

--- a/src/components/results/v7/V7BiasSection.tsx
+++ b/src/components/results/v7/V7BiasSection.tsx
@@ -26,6 +26,20 @@ import { V7_GUIDANCE_COPY } from './v7GuidanceCopy'
 
 const B = V7_GUIDANCE_COPY.bias
 
+/** The producer minutes estimate, rendered identically in both slots (with or
+ * without steps). One leaf so the testid + classes cannot drift between them. */
+function MinutesBadge({ minutes }: { minutes: number }) {
+  return (
+    <span
+      data-testid="v7-bias-minutes"
+      className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}
+    >
+      <Clock aria-hidden="true" className="h-3 w-3 flex-none" />
+      {B.minutes(minutes)}
+    </span>
+  )
+}
+
 function BiasCard({ finding }: { finding: V7BiasFinding }) {
   return (
     <div
@@ -54,13 +68,7 @@ function BiasCard({ finding }: { finding: V7BiasFinding }) {
               {B.stepsLabel}
             </span>
             {finding.estimatedMinutes != null && (
-              <span
-                data-testid="v7-bias-minutes"
-                className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}
-              >
-                <Clock aria-hidden="true" className="h-3 w-3 flex-none" />
-                {B.minutes(finding.estimatedMinutes)}
-              </span>
+              <MinutesBadge minutes={finding.estimatedMinutes} />
             )}
           </div>
           <ol className="space-y-0.5">
@@ -75,13 +83,7 @@ function BiasCard({ finding }: { finding: V7BiasFinding }) {
 
       {/* Minutes with no steps still surfaces the estimate honestly. */}
       {finding.steps.length === 0 && finding.estimatedMinutes != null && (
-        <span
-          data-testid="v7-bias-minutes"
-          className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}
-        >
-          <Clock aria-hidden="true" className="h-3 w-3 flex-none" />
-          {B.minutes(finding.estimatedMinutes)}
-        </span>
+        <MinutesBadge minutes={finding.estimatedMinutes} />
       )}
     </div>
   )

--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -41,6 +41,21 @@ export interface V7EvidenceDisclosureProps {
   onFocusNode?: (nodeId: string) => void
 }
 
+/** Honest-gate line — one leaf for the three identical per-view gate copies
+ * (same classes; only the testid + copy differ per view). */
+function EvidenceGate({ testId, children }: { testId: string; children: React.ReactNode }) {
+  return (
+    <p className={`${typography.panelBody} text-text-light`} data-testid={testId}>
+      {children}
+    </p>
+  )
+}
+
+/** The muted lead-in note above a view's rows — three identical copies. */
+function EvidenceNote({ children }: { children: React.ReactNode }) {
+  return <p className={`${typography.panelMeta} text-text-light`}>{children}</p>
+}
+
 export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclosureProps) {
   const [open, setOpen] = useState(false)
   const [view, setView] = useState<EvidenceView>('drivers')
@@ -108,7 +123,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
             <div className="space-y-1.5" data-testid="v7-evidence-drivers">
               {hasDrivers ? (
                 <>
-                  <p className={`${typography.panelMeta} text-text-light`}>{E.driversNote}</p>
+                  <EvidenceNote>{E.driversNote}</EvidenceNote>
                   {visibleDrivers.map((d, i) => {
                     const canFocus = Boolean(d.focusId && onFocusNode)
                     const body = (
@@ -167,9 +182,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
                   )}
                 </>
               ) : (
-                <p className={`${typography.panelBody} text-text-light`} data-testid="v7-evidence-drivers-gate">
-                  {E.driversGate}
-                </p>
+                <EvidenceGate testId="v7-evidence-drivers-gate">{E.driversGate}</EvidenceGate>
               )}
             </div>
           )}
@@ -178,7 +191,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
             <div className="space-y-1.5" data-testid="v7-evidence-flip-risks">
               {hasFlipRisks ? (
                 <>
-                  <p className={`${typography.panelMeta} text-text-light`}>{E.flipRisksNote}</p>
+                  <EvidenceNote>{E.flipRisksNote}</EvidenceNote>
                   {evidence.flipRisks.map((r, i) => {
                     const canFocus = Boolean(r.fromId && onFocusNode)
                     const body = (
@@ -214,9 +227,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
                   })}
                 </>
               ) : (
-                <p className={`${typography.panelBody} text-text-light`} data-testid="v7-evidence-flip-risks-gate">
-                  {E.flipRisksGate}
-                </p>
+                <EvidenceGate testId="v7-evidence-flip-risks-gate">{E.flipRisksGate}</EvidenceGate>
               )}
             </div>
           )}
@@ -225,7 +236,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
             <div className="space-y-1.5" data-testid="v7-evidence-trade-offs">
               {hasTradeOffs ? (
                 <>
-                  <p className={`${typography.panelMeta} text-text-light`}>{E.tradeOffsNote}</p>
+                  <EvidenceNote>{E.tradeOffsNote}</EvidenceNote>
                   {evidence.tradeOffs.map((t, i) => (
                     <div key={`${t.factorId}-${i}`} className="flex items-start gap-1.5">
                       <GitBranch aria-hidden="true" className="mt-0.5 h-3 w-3 flex-none text-info" />
@@ -241,9 +252,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
                   ))}
                 </>
               ) : (
-                <p className={`${typography.panelBody} text-text-light`} data-testid="v7-evidence-trade-offs-gate">
-                  {E.tradeOffsGate}
-                </p>
+                <EvidenceGate testId="v7-evidence-trade-offs-gate">{E.tradeOffsGate}</EvidenceGate>
               )}
             </div>
           )}

--- a/src/components/results/v7/V7LensGroup.tsx
+++ b/src/components/results/v7/V7LensGroup.tsx
@@ -28,77 +28,22 @@
 import { useEffect, useRef, useState } from 'react'
 import { typography } from '@/styles/typography'
 import { formatPercent, formatProbabilityWithResolution } from '@/utils/formatPercent'
-import { formatRangeValue } from '../utils/formatRangeValue'
 import { loadRuns, type StoredRun } from '@/canvas/store/runHistory'
 import * as runsBus from '@/canvas/store/runsBus'
-import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { OptionResult } from '../types'
-import { buildV7Lenses } from './buildV7Lenses'
+import { OptionRangeBar } from '../shared/OptionRangeBar'
+import type { V7LensesModel } from './buildV7Lenses'
 import { V7_LENS_COPY } from './v7LensCopy'
 import { SUB_ONE_PERCENT_FLOOR } from '../utils/displayFloors'
-import { V7WhatChangedLens } from './V7WhatChangedLens'
+import { V7WhatChangedLens, hasComparableRuns } from './V7WhatChangedLens'
 
 export type V7Lens = 'outcome' | 'goal' | 'stability' | 'whatChanged'
 
 const ALL_LENSES: readonly V7Lens[] = ['outcome', 'goal', 'stability', 'whatChanged']
 
 export interface V7LensGroupProps {
-  resultsSectionData: ResultsSectionDataReturn
-}
-
-/** Thin p10-to-p90 range bar with a median dot — replicates OptionCards'
- * inline OptionRangeBar (layout only), sharing formatRangeValue so the
- * numbers cannot drift from the cards below. */
-function V7RangeBar({
-  p10,
-  p50,
-  p90,
-  globalMin,
-  globalMax,
-}: {
-  p10: number
-  p50?: number
-  p90: number
-  globalMin: number
-  globalMax: number
-}) {
-  const span = globalMax - globalMin
-  if (span <= 0) return null
-  const leftPct = ((p10 - globalMin) / span) * 100
-  const widthPct = ((p90 - p10) / span) * 100
-  const dotPct = p50 != null ? ((p50 - globalMin) / span) * 100 : undefined
-  return (
-    <div data-testid="v7-range-bar">
-      <div className="relative" style={{ height: 4, background: 'var(--border-default)', borderRadius: 2 }}>
-        <div
-          className="absolute top-0 h-full rounded-sm"
-          style={{
-            left: `${leftPct}%`,
-            width: `${Math.max(2, widthPct)}%`,
-            background: 'color-mix(in srgb, var(--info) 30%, transparent)',
-          }}
-        />
-        {dotPct != null && (
-          <div
-            className="absolute top-1/2 rounded-full"
-            style={{
-              left: `${dotPct}%`,
-              width: 8,
-              height: 8,
-              background: 'var(--info)',
-              border: '1.5px solid var(--bg-panel)',
-              transform: 'translate(-50%, -50%)',
-            }}
-          />
-        )}
-      </div>
-      <div className={`flex justify-between mt-0.5 ${typography.panelMeta}`}>
-        <span className="text-text-light">{formatRangeValue(p10)}</span>
-        {p50 != null && <span className="text-text-header">{formatRangeValue(p50)}</span>}
-        <span className="text-text-light">{formatRangeValue(p90)}</span>
-      </div>
-    </div>
-  )
+  /** The lens model, built once in V7TopMatter (buildV7Lenses). */
+  model: V7LensesModel
 }
 
 /** Likely-outcome option row: label + win readout, then the range bar. */
@@ -136,12 +81,13 @@ function OutcomeRow({
         )}
       </div>
       {hasRange && (
-        <V7RangeBar
+        <OptionRangeBar
           p10={p10 as number}
           p50={option.outcome?.p50 ?? option.outcome?.mean ?? undefined}
           p90={p90 as number}
           globalMin={globalMin}
           globalMax={globalMax}
+          data-testid="v7-range-bar"
         />
       )}
     </div>
@@ -191,7 +137,7 @@ function GateLine({ testId, children }: { testId: string; children: React.ReactN
   )
 }
 
-export function V7LensGroup({ resultsSectionData }: V7LensGroupProps) {
+export function V7LensGroup({ model }: V7LensGroupProps) {
   const [active, setActive] = useState<V7Lens>('outcome')
   const tabRefs = useRef<Partial<Record<V7Lens, HTMLButtonElement | null>>>({})
 
@@ -203,17 +149,14 @@ export function V7LensGroup({ resultsSectionData }: V7LensGroupProps) {
     return unsub
   }, [])
 
-  const model = buildV7Lenses(resultsSectionData)
-  const options = resultsSectionData.recommendation.allOptions ?? []
-
   // Analysis-presence guard (belt-and-suspenders — V7TopMatter already gates).
-  if (options.length === 0) return null
+  if (model.outcome.options.length === 0) return null
 
   const available: Record<V7Lens, boolean> = {
     outcome: model.outcome.available,
     goal: model.goal.available,
     stability: false, // per-option stability is never on the wire (honest gap)
-    whatChanged: runs.length >= 2,
+    whatChanged: hasComparableRuns(runs),
   }
 
   const moveTo = (index: number) => {

--- a/src/components/results/v7/V7SharpenLine.tsx
+++ b/src/components/results/v7/V7SharpenLine.tsx
@@ -23,6 +23,7 @@
 
 import { AlertTriangle } from 'lucide-react'
 import { typography } from '@/styles/typography'
+import { V7_MODEL_LIMIT_CAVEAT } from './v7GuidanceCopy'
 
 export interface V7SharpenInput {
   /** Display label — an evidence-gap factor label. */
@@ -65,8 +66,7 @@ export function V7SharpenLine({ briefWording, inputs, onFocusNode }: V7SharpenLi
         </p>
       )}
       <p className={`${typography.panelMeta} text-text-light mt-1`}>
-        Olumi can point to what the model implies, but not guarantee the real world behaves the same.
-        Confirm these before you lean on the result.
+        {V7_MODEL_LIMIT_CAVEAT} Confirm these before you lean on the result.
       </p>
       <ul className="mt-2 space-y-0.5">
         {shown.map((input, i) => {

--- a/src/components/results/v7/V7TopMatter.tsx
+++ b/src/components/results/v7/V7TopMatter.tsx
@@ -14,6 +14,7 @@
  * pre-analysis; nothing below the divider changes).
  */
 
+import { useMemo } from 'react'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { DecisionState } from '../types'
 import { V7FreshnessStrip } from './V7FreshnessStrip'
@@ -54,10 +55,11 @@ export function V7TopMatter({
   const briefWording = recommendation.goalText ?? resultsSectionData.goalLabel ?? null
 
   // L5 lens group + evidence disclosure — passthrough over the SAME
-  // resultsSectionData the live panel consumes. The evidence model is built
-  // once here and handed to the disclosure; the lens group reads live fields
-  // (and local run history for the What-changed lens) itself.
-  const { evidence } = buildV7Lenses(resultsSectionData)
+  // resultsSectionData the live panel consumes. The lens model is built ONCE
+  // here (memoised on resultsSectionData) and handed to BOTH the lens group and
+  // the evidence disclosure; the lens group still reads local run history for
+  // the What-changed lens itself.
+  const model = useMemo(() => buildV7Lenses(resultsSectionData), [resultsSectionData])
 
   return (
     <div className="flex flex-col gap-4" data-testid="v7-top-matter">
@@ -71,8 +73,8 @@ export function V7TopMatter({
         onFocusNode={onFocusNode}
         onSendMessage={onSendMessage}
       />
-      <V7LensGroup resultsSectionData={resultsSectionData} />
-      <V7EvidenceDisclosure evidence={evidence} onFocusNode={onFocusNode} />
+      <V7LensGroup model={model} />
+      <V7EvidenceDisclosure evidence={model.evidence} onFocusNode={onFocusNode} />
       {/* L6 — "What to do next" (guidance + held-proposal pointer card) and
           "Challenge your assumptions" (bias coaching). Both read their own
           stores (guidance store / canvas ceeReview) and render nothing when

--- a/src/components/results/v7/V7WhatChangedLens.tsx
+++ b/src/components/results/v7/V7WhatChangedLens.tsx
@@ -21,6 +21,7 @@
  * so this component is a pure function of its props. COMPLETE borders only.
  */
 
+import { useMemo } from 'react'
 import { typography } from '@/styles/typography'
 import { compareRuns, computeRunSummary, type StoredRun } from '@/canvas/store/runHistory'
 import { V7_LENS_COPY } from './v7LensCopy'
@@ -32,6 +33,13 @@ export interface V7WhatChangedLensProps {
   runs: StoredRun[]
 }
 
+/** ≥2 stored runs — the shared predicate for "there is something to compare".
+ * Used by both this lens's empty-state gate and V7LensGroup's tab availability
+ * so the two cannot disagree about when the What-changed lens has data. */
+export function hasComparableRuns(runs: StoredRun[]): boolean {
+  return runs.length >= 2
+}
+
 function driverLabel(d: { id?: string; label?: string }): string {
   return d.label ?? d.id ?? 'Unknown driver'
 }
@@ -40,9 +48,25 @@ export function V7WhatChangedLens({ runs }: V7WhatChangedLensProps) {
   const latest = runs[0]
   const prior = runs[1]
 
+  // Derive the run-over-run summary + driver deltas once, keyed by the two run
+  // ids — stored runs are immutable, so the ids fully determine the result.
+  const derived = useMemo(() => {
+    if (!latest || !prior) return null
+    const summary = computeRunSummary(latest, prior)
+    // compareRuns(A, B): driversAdded = in B not A. Pass prior as A and latest
+    // as B so "added" reads as new-in-the-latest-run and "removed" as gone-since.
+    const comparison = compareRuns(prior.id, latest.id)
+    return {
+      summary,
+      added: comparison?.driversAdded ?? [],
+      removed: comparison?.driversRemoved ?? [],
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the run ids: stored runs are immutable, so the ids fully determine the memo (same pattern as WhatChangedChip's version-keyed read)
+  }, [latest?.id, prior?.id])
+
   // Honest empty state — the common case. Fewer than two runs means there is
   // nothing to compare; never fabricate a delta.
-  if (!latest || !prior) {
+  if (!hasComparableRuns(runs) || !derived) {
     return (
       <div data-testid="v7-what-changed-empty">
         <p className={`${typography.panelBody} text-text-header font-semibold`}>{C.heading}</p>
@@ -52,12 +76,7 @@ export function V7WhatChangedLens({ runs }: V7WhatChangedLensProps) {
     )
   }
 
-  const summary = computeRunSummary(latest, prior)
-  // compareRuns(A, B): driversAdded = in B not A. Pass prior as A and latest
-  // as B so "added" reads as new-in-the-latest-run and "removed" as gone-since.
-  const comparison = compareRuns(prior.id, latest.id)
-  const added = comparison?.driversAdded ?? []
-  const removed = comparison?.driversRemoved ?? []
+  const { summary, added, removed } = derived
 
   return (
     <div className="space-y-2" data-testid="v7-what-changed">

--- a/src/components/results/v7/__tests__/V7LensGroup.spec.tsx
+++ b/src/components/results/v7/__tests__/V7LensGroup.spec.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { V7LensGroup } from '../V7LensGroup'
+import { buildV7Lenses } from '../buildV7Lenses'
 import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
 import type { OptionResult } from '../../types'
 
@@ -65,7 +66,7 @@ beforeEach(() => {
 
 describe('V7LensGroup (V7 L5)', () => {
   it('renders all four lens tabs', () => {
-    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    render(<V7LensGroup model={buildV7Lenses(WITH_RANGE)} />)
     expect(screen.getByTestId('v7-lens-tab-outcome')).toBeInTheDocument()
     expect(screen.getByTestId('v7-lens-tab-goal')).toBeInTheDocument()
     expect(screen.getByTestId('v7-lens-tab-stability')).toBeInTheDocument()
@@ -73,14 +74,14 @@ describe('V7LensGroup (V7 L5)', () => {
   })
 
   it('defaults to the Likely outcome lens with range bars and win readouts', () => {
-    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    render(<V7LensGroup model={buildV7Lenses(WITH_RANGE)} />)
     expect(screen.getByTestId('v7-lens-outcome')).toBeInTheDocument()
     expect(screen.getAllByTestId('v7-range-bar').length).toBe(2)
     expect(screen.getByText(/Leads 70%/)).toBeInTheDocument()
   })
 
   it('shows the no-target gate on the Goal fit lens when no success target is set', () => {
-    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    render(<V7LensGroup model={buildV7Lenses(WITH_RANGE)} />)
     fireEvent.click(screen.getByTestId('v7-lens-tab-goal'))
     expect(screen.getByTestId('v7-lens-goal-gate')).toHaveTextContent('Set a success target to unlock Goal fit.')
   })
@@ -94,7 +95,7 @@ describe('V7LensGroup (V7 L5)', () => {
       recommendedId: 'a',
       goalThreshold: 80,
     })
-    render(<V7LensGroup resultsSectionData={withGoal} />)
+    render(<V7LensGroup model={buildV7Lenses(withGoal)} />)
     fireEvent.click(screen.getByTestId('v7-lens-tab-goal'))
     expect(screen.getByTestId('v7-lens-goal')).toBeInTheDocument()
     expect(screen.getAllByTestId('v7-goal-row').length).toBe(2)
@@ -102,20 +103,20 @@ describe('V7LensGroup (V7 L5)', () => {
   })
 
   it('always shows the honest gap on the Stability lens', () => {
-    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    render(<V7LensGroup model={buildV7Lenses(WITH_RANGE)} />)
     fireEvent.click(screen.getByTestId('v7-lens-tab-stability'))
     expect(screen.getByTestId('v7-lens-stability-gate')).toHaveTextContent('will not infer it')
   })
 
   it('shows the honest empty state on the What-changed lens with empty run history', () => {
-    render(<V7LensGroup resultsSectionData={WITH_RANGE} />)
+    render(<V7LensGroup model={buildV7Lenses(WITH_RANGE)} />)
     fireEvent.click(screen.getByTestId('v7-lens-tab-whatChanged'))
     expect(screen.getByTestId('v7-what-changed-empty')).toBeInTheDocument()
     expect(screen.getByText('Snapshot unavailable — rerun to compare.')).toBeInTheDocument()
   })
 
   it('renders nothing when there are no analysed options (pre-analysis)', () => {
-    const { container } = render(<V7LensGroup resultsSectionData={data({ allOptions: [] })} />)
+    const { container } = render(<V7LensGroup model={buildV7Lenses(data({ allOptions: [] }))} />)
     expect(container.firstChild).toBeNull()
   })
 })

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -27,8 +27,9 @@
  * of resultsSectionData.
  */
 
-import type { OptionResult, OutcomeUnitType, DriverItem, ConditionalWinner } from '../types'
+import type { OptionResult, DriverItem, ConditionalWinner } from '../types'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { computeOptionScale } from '../shared/OptionRangeBar'
 
 /** One flip-risk row — the challengeFragileEdges slice, unchanged. */
 export interface V7FlipRisk {
@@ -73,8 +74,6 @@ export interface V7OutcomeLens {
   /** True when any option carries a full p10/p90 range (gates the caption). */
   hasRange: boolean
   winnerId?: string
-  outcomeUnit?: OutcomeUnitType
-  outcomeUnitSymbol?: string
 }
 
 export interface V7GoalLens {
@@ -113,14 +112,10 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
   const hasWin = options.some(
     (o) => typeof o.winProbability === 'number' && Number.isFinite(o.winProbability),
   )
-  // Shared [globalMin, globalMax] scale — identical to OptionCards (p10/p90
-  // with mean fallback), so the V7 bars and the cards below share one scale.
-  const globalMin = options.length
-    ? Math.min(...options.map((o) => o.outcome?.p10 ?? o.outcome?.mean ?? 0))
-    : 0
-  const globalMax = options.length
-    ? Math.max(...options.map((o) => o.outcome?.p90 ?? o.outcome?.mean ?? 0))
-    : 1
+  // Shared [globalMin, globalMax] scale — computeOptionScale is the exact
+  // OptionCards formula (p10/p90 with mean fallback), so the V7 bars and the
+  // cards below share one scale.
+  const { globalMin, globalMax } = computeOptionScale(options)
 
   const outcome: V7OutcomeLens = {
     available: options.length > 0 && (hasRange || hasWin),
@@ -129,8 +124,6 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
     globalMax,
     hasRange,
     winnerId,
-    outcomeUnit: recommendation.outcomeUnit,
-    outcomeUnitSymbol: recommendation.outcomeUnitSymbol,
   }
 
   // ── Goal fit ───────────────────────────────────────────────────────────

--- a/src/v5/__tests__/intentGate.spec.ts
+++ b/src/v5/__tests__/intentGate.spec.ts
@@ -8,7 +8,7 @@ import { Intent } from '@talchain/schemas/boundary'
 import {
   KNOWN_INTENTS,
   CEE_ACCEPTED_INTENTS,
-  isSendableIntent,
+  isSendableToken,
 } from '../buildPayload'
 
 describe('intent wire allowlist — schema parity (derive-don\'t-mirror)', () => {
@@ -31,25 +31,25 @@ describe('intent wire allowlist — schema parity (derive-don\'t-mirror)', () =>
   })
 })
 
-describe('isSendableIntent — the AND actually bites', () => {
+describe('isSendableToken — the AND actually bites', () => {
   const published = new Set(['add_option', 'elicit_options'])
   const accepted = new Set(['add_option'])
 
   it('sends only when BOTH signals hold', () => {
-    expect(isSendableIntent('add_option', published, accepted)).toBe(true)
+    expect(isSendableToken('add_option', published, accepted)).toBe(true)
   })
 
   it('publication ALONE does not open the gate', () => {
     // elicit_options is published but not accepted → withheld.
-    expect(isSendableIntent('elicit_options', published, accepted)).toBe(false)
+    expect(isSendableToken('elicit_options', published, accepted)).toBe(false)
   })
 
   it('acceptance ALONE (unpublished) does not open the gate', () => {
     const acceptedOnly = new Set(['ghost_intent'])
-    expect(isSendableIntent('ghost_intent', new Set<string>(), acceptedOnly)).toBe(false)
+    expect(isSendableToken('ghost_intent', new Set<string>(), acceptedOnly)).toBe(false)
   })
 
   it('an unknown value is never sendable', () => {
-    expect(isSendableIntent('nonsense', published, accepted)).toBe(false)
+    expect(isSendableToken('nonsense', published, accepted)).toBe(false)
   })
 })

--- a/src/v5/__tests__/whatChangedSend.spec.ts
+++ b/src/v5/__tests__/whatChangedSend.spec.ts
@@ -3,7 +3,7 @@
  *
  * These specs pin the WIRE CONTRACT for the typed `what_changed` chip_click and
  * mutation-check the send gate, both built from the REAL production seams
- * (buildChipMeta + buildV5Payload + the exported isSendableActionType predicate)
+ * (buildChipMeta + buildV5Payload + the exported isSendableToken predicate)
  * — never a hand-built payload object. The bug class this guards against is a
  * green test whose fixture encodes the very assumption under test, so:
  *
@@ -26,7 +26,7 @@ import {
 } from '@talchain/schemas/boundary'
 import {
   buildV5Payload,
-  isSendableActionType,
+  isSendableToken,
   KNOWN_ACTION_TYPES,
   CEE_ACCEPTED_ACTION_TYPES,
 } from '../buildPayload'
@@ -103,12 +103,12 @@ describe('what_changed send gate — the CEE-accept mirror is load-bearing (muta
 
     // Drop: published but NOT accepted → withheld from the wire.
     expect(
-      isSendableActionType('what_changed', KNOWN_ACTION_TYPES, acceptedWithout),
+      isSendableToken('what_changed', KNOWN_ACTION_TYPES, acceptedWithout),
     ).toBe(false)
 
     // Restore (the real registry, post-edit): published AND accepted → sends.
     expect(
-      isSendableActionType('what_changed', KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES),
+      isSendableToken('what_changed', KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES),
     ).toBe(true)
   })
 
@@ -116,9 +116,9 @@ describe('what_changed send gate — the CEE-accept mirror is load-bearing (muta
     const onlyAccepted = new Set(['what_changed'])
     const onlyPublished = new Set(['what_changed'])
     // Accepted but not published (e.g. UI on an older schema pin) → dropped.
-    expect(isSendableActionType('what_changed', new Set(), onlyAccepted)).toBe(false)
+    expect(isSendableToken('what_changed', new Set(), onlyAccepted)).toBe(false)
     // Published but not accepted (CEE has not deployed acceptance) → dropped.
-    expect(isSendableActionType('what_changed', onlyPublished, new Set())).toBe(false)
+    expect(isSendableToken('what_changed', onlyPublished, new Set())).toBe(false)
   })
 
   it('the accepted registry actually contains what_changed after the mirror edit', () => {

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -428,7 +428,7 @@ export const KNOWN_ACTION_TYPES: ReadonlySet<ActionTypeLiteral> = new Set<Action
  * The gate used to key on publication ALONE — but OUR publishing a value says
  * nothing about whether CEE accepts it, so a publication-only gate can only
  * ever be right by luck. The two facts are now DECOUPLED: a value is sent only
- * when BOTH hold (see isSendableActionType). A newly re-vendored value is
+ * when BOTH hold (see isSendableToken). A newly re-vendored value is
  * WITHHELD until it is added here with provenance — publication can never again
  * open the gate on its own.
  *
@@ -493,13 +493,16 @@ export const CEE_ACCEPTED_ACTION_TYPES: ReadonlySet<ActionTypeLiteral> =
   ])
 
 /**
- * The send gate, factored out as a PURE predicate so a test can drive it with
- * SYNTHETIC registries and prove the AND actually bites — that publication
- * alone (or acceptance alone) can never open it. A value is sendable IFF it is
- * BOTH published in the vendored enum AND present in the CEE-acceptance
- * registry.
+ * The send gate, factored out as ONE PURE predicate shared by BOTH the
+ * action_type and intent sanitisers, so a test can drive it with SYNTHETIC
+ * registries and prove the AND actually bites — that publication alone (or
+ * acceptance alone) can never open it. A token is sendable IFF it is BOTH
+ * published in the vendored enum AND present in the matching CEE-acceptance
+ * registry. The two registries (action_type + intent) remain SEPARATE and
+ * hand-maintained per the doctrine above; this predicate is only the generic
+ * AND that each of them applies to its own token.
  */
-export function isSendableActionType(
+export function isSendableToken(
   raw: string,
   published: ReadonlySet<string>,
   accepted: ReadonlySet<string>,
@@ -509,7 +512,7 @@ export function isSendableActionType(
 
 function sanitiseActionType(raw: string | undefined): ActionTypeLiteral | undefined {
   if (!raw) return undefined
-  return isSendableActionType(raw, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES)
+  return isSendableToken(raw, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES)
     ? (raw as ActionTypeLiteral)
     : undefined
 }
@@ -554,23 +557,9 @@ export const CEE_ACCEPTED_INTENTS: ReadonlySet<IntentLiteral> = new Set<IntentLi
   'add_option',
 ])
 
-/**
- * The intent send gate, factored out as a PURE predicate (mirrors
- * isSendableActionType) so a test can drive it with SYNTHETIC registries and
- * prove the AND actually bites — publication alone (or acceptance alone) can
- * never open it.
- */
-export function isSendableIntent(
-  raw: string,
-  published: ReadonlySet<string>,
-  accepted: ReadonlySet<string>,
-): boolean {
-  return published.has(raw) && accepted.has(raw)
-}
-
 function sanitiseIntent(raw: string | undefined): IntentLiteral | undefined {
   if (!raw) return undefined
-  return isSendableIntent(raw, KNOWN_INTENTS, CEE_ACCEPTED_INTENTS)
+  return isSendableToken(raw, KNOWN_INTENTS, CEE_ACCEPTED_INTENTS)
     ? (raw as IntentLiteral)
     : undefined
 }


### PR DESCRIPTION
Adjudicated `/simplify` fix list applied to the V7 top-matter (L4/L5/L6) + V5 send-gate merged tonight. Every item is **behaviour-preserving**; all existing specs pass unmodified except where a fix explicitly moved an import/prop (items 1/3/5/6). Head: `79e9161c`.

## Per-item status

| # | Fix | Status |
|---|-----|--------|
| 1 | **Build the lens model once.** `V7TopMatter` builds `buildV7Lenses` in a `useMemo` and threads `model` to `<V7LensGroup>` and `model.evidence` to the disclosure. `V7LensGroup` prop is now `model: V7LensesModel`; its internal `buildV7Lenses` call is deleted; the analysis-presence guard reads `model.outcome.options.length === 0`. Stale "built once … reads live fields" comment fixed. | ✅ applied |
| 2 | **Shared range bar + scale.** New `src/components/results/shared/OptionRangeBar.tsx` exports `OptionRangeBar` (extracted **verbatim** from OptionCards' private fn; optional `data-testid` defaulting to `option-range-bar`) and `computeOptionScale` (OptionCards' `p10 ?? mean ?? 0` / `p90 ?? mean ?? 0` formula + buildV7Lenses' empty-array guard). OptionCards consumes both (private fn + inline min/max deleted — rendering byte-identical). `V7LensGroup` deletes `V7RangeBar`, uses the shared bar with `data-testid="v7-range-bar"`. `buildV7Lenses` uses `computeOptionScale`. **Not** registered in complete-borders guard: a bare bar carries no one-sided border accent (checked the guard's regexes). | ✅ applied |
| 3 | **Finish the caveat migration.** `V7SharpenLine` now renders `{V7_MODEL_LIMIT_CAVEAT}` (imported from `./v7GuidanceCopy`) + the residual "Confirm these…" sentence. Rendered text byte-identical. No spec pinned the literal. | ✅ applied |
| 4 | **Memoise the what-changed derivation.** `V7WhatChangedLens` wraps `computeRunSummary` + `compareRuns` in `useMemo(…, [latest?.id, prior?.id])` (added `useMemo` import). Intentional id-keying suppressed with a rationale `eslint-disable` comment (same pattern as `WhatChangedChip`). | ✅ applied |
| 5 | **Delete dead fields.** Removed `outcomeUnit` / `outcomeUnitSymbol` from `V7OutcomeLens` + the two assignments in `buildV7Lenses` (and the now-unused `OutcomeUnitType` import). No spec asserted on the lens-level fields, so no spec assertions changed. | ✅ applied |
| 6 | **One send-gate predicate.** `isSendableActionType` + `isSendableIntent` collapsed into one exported generic `isSendableToken(raw, published, accepted)`; both sanitisers call it. The two registries + their doctrine comments are untouched. | ✅ applied |
| 7 | **MinutesBadge dedup.** Extracted the duplicated minutes `<span>` in `V7BiasSection` into one local `MinutesBadge` leaf (same testid/classes), used in both slots. | ✅ applied |
| 8 | **Evidence gate/note dedup.** Extracted local `EvidenceGate({testId, children})` and `EvidenceNote({children})` in `V7EvidenceDisclosure`, replacing the three copies of each. The three view branches are otherwise unchanged. | ✅ applied |
| 9 | **Shared ≥2-runs predicate.** Exported `hasComparableRuns(runs)` from `V7WhatChangedLens`; used for both `V7LensGroup`'s tab-availability map and the lens's own empty-state gate. | ✅ applied |

## Specs moved (item 6 import rename) + why

The predicate rename in item 6 removes both named exports, so **every** importer had to move to `isSendableToken` — a pure call/import rename, no assertion weakened:

- `src/v5/__tests__/intentGate.spec.ts` — named in the brief.
- `src/canvas/components/pre-analysis-v3/__tests__/sparkIntentContract.spec.ts` — named in the brief.
- `src/v5/__tests__/whatChangedSend.spec.ts` — **NOT named in the brief** but also imports `isSendableActionType`; leaving it would break collection, so it was updated too (flagged here, derive-don't-mirror).

`src/components/results/v7/__tests__/V7LensGroup.spec.tsx` (item 1): render calls now pass `model={buildV7Lenses(<fixture>)}` — derived from the same fixtures, not hand-typed.

Comment-only touch-ups to keep function-name references accurate: `src/canvas/conversation/chipMeta.ts`, `src/canvas/components/WhatChangedChip.tsx`, and the `buildPayload.ts` doctrine prose.

## Gate results

- `pnpm run typecheck` — **clean**. Broader `tsc -p tsconfig.app.json --noEmit` filtered to touched files — **no new errors**.
- Full touched-area spec set (v7 dir, all OptionCards specs, buildPayload/intentGate/sparkIntentContract/whatChangedSend/typedChipProducers seam, collapsedResponseSignal, complete-borders guard) — **259 passed / 259**.
- `pnpm lint` on changed files — **0 errors, 0 warnings**.
- `vitest run --changed` surfaced 46 failures in `src/canvas/conversation/__tests__/` (analysisInputs*, envelopeAnalysis*, generateDispatch, streamingLifecycle, handleEnvelopeArbitration, useConversation.systemEvents). **Proven pre-existing**: identical `46 failed | 13 passed` on the clean base tip `a9d022b6` (stash-verified) — unrelated to this diff (a conversation-suite env/mock issue in the standalone clone).

Draft — **do not merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)