### PR TITLE
feat(goal): coach a success target at draft time — unlocks Goal fit

### DIFF
--- a/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
+++ b/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
@@ -15,6 +15,7 @@ import { guardCeeText } from './signals/ceeTextGuard'
 import { usePreAnalysisModel } from './hooks/usePreAnalysisModel'
 import { useConversationActions } from './hooks/useConversationActions'
 import { useSensitivityRanking } from './hooks/useSensitivityRanking'
+import { GoalTargetNudge } from '../pre-analysis/GoalTargetNudge'
 import { PanelHeader } from './header/PanelHeader'
 import { HeroSection, GOAL_INPUT_ID, SUCCESS_INPUT_ID } from './hero/HeroSection'
 import { SharpenSection } from './sharpen/SharpenSection'
@@ -117,6 +118,24 @@ function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason }: PreAnalysi
       {/* No flex-1: content sits at natural height (footer follows it), and
           shrinks to keep the footer visible only when it overflows. */}
       <div className="min-h-0 overflow-y-auto">
+        {/* Success-target elicitation nudge (also mounted in the legacy
+            PreAnalysisPanel). On the deployed staging build the V3 panel is
+            the LIVE surface (flags baked via the Netlify dashboard env, not
+            netlify.toml), so the nudge must live here too or it is dark. Same
+            gating as the legacy mount — a goal exists AND no success target is
+            set — expressed in V3 model terms (hero.goal / hero.success.isSet).
+            Routes into the V3 panel's OWN setter seam: focus the inline
+            success field by id, the same route handleLadderAct('set_success')
+            and handleSignalAction('focus_success_field') use — no second
+            editor. Unlocks the honestly-gated Goal-fit lens; vanishes the
+            instant a target is set; never blocks analysis. */}
+        <div className="px-4 pt-4">
+          <GoalTargetNudge
+            hasGoalNode={model.hero.goal != null}
+            hasSuccessTarget={model.hero.success.isSet}
+            onSetTarget={() => document.getElementById(SUCCESS_INPUT_ID)?.focus()}
+          />
+        </div>
         <PanelHeader bars={model.bars} onAction={sendPrompt} />
         <HeroSection
           hero={model.hero}

--- a/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
@@ -16,6 +16,7 @@ import '@testing-library/jest-dom/vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import type { Node } from '@xyflow/react'
 import { PreAnalysisPanelV3 } from '../PreAnalysisPanelV3'
+import { SUCCESS_INPUT_ID } from '../hero/HeroSection'
 import { ToastProvider } from '../../../ToastContext'
 import { useCanvasStore } from '../../../store'
 import { useReadinessStore } from '../../../stores/readinessStore'
@@ -751,5 +752,40 @@ describe('assessment-pass regressions', () => {
     const bar = screen.getByTestId('pre-analysis-v3-bar-estimates')
     expect(bar).toHaveAccessibleName('Estimates: No estimates yet')
     expect(bar).not.toHaveTextContent('medium')
+  })
+})
+
+describe('Success-target nudge (V3)', () => {
+  it('renders the nudge when a drafted graph has a goal but no success target', () => {
+    // beforeEach seeds seedGraph(): goal g1 present, no goal_threshold →
+    // success unset. The V3 panel is the LIVE staging surface, so the nudge
+    // must be present here (regression guard for the dark-nudge defect).
+    renderPanel()
+    expect(screen.getByTestId('goal-target-nudge')).toBeInTheDocument()
+  })
+
+  it('hides the nudge once a success target is set', () => {
+    seedGraph({ successSet: true })
+    renderPanel()
+    expect(screen.queryByTestId('goal-target-nudge')).not.toBeInTheDocument()
+  })
+
+  it('does not render the nudge when there is no goal node', () => {
+    useCanvasStore.setState({
+      nodes: useCanvasStore
+        .getState()
+        .nodes.filter(n => (n.data as { kind?: string }).kind !== 'goal'),
+    })
+    renderPanel()
+    expect(screen.queryByTestId('goal-target-nudge')).not.toBeInTheDocument()
+  })
+
+  it('CTA reaches the V3 setter seam (focuses the inline success field)', () => {
+    // Same route handleLadderAct('set_success') / handleSignalAction(
+    // 'focus_success_field') use — focus the inline success field by id. No
+    // second editor.
+    renderPanel()
+    fireEvent.click(screen.getByTestId('goal-target-nudge-cta'))
+    expect(document.getElementById(SUCCESS_INPUT_ID)).toHaveFocus()
   })
 })

--- a/src/canvas/components/pre-analysis/GoalTargetNudge.tsx
+++ b/src/canvas/components/pre-analysis/GoalTargetNudge.tsx
@@ -1,0 +1,77 @@
+/**
+ * GoalTargetNudge — post-draft coaching nudge that points the user at the
+ * success-target setter when a drafted graph has a goal but no target yet.
+ *
+ * WHY THIS EXISTS. The Goal-fit lens (each option's probability of reaching the
+ * user's success target) is the highest-value analysis view, but it is honestly
+ * gated on a USER success target: `buildHeroModel` UI-SEM-071/072 and the
+ * results goal lens (`buildV7Lenses` — `gate: goalThreshold == null ?
+ * 'no_target' : …`) both suppress Goal fit when `goalThreshold == null`. Today
+ * the only affordances that point at the target-setter are the T1 "Goal target
+ * not set" checklist row and the collapsed-by-default T2 "Sharpen" framing card
+ * — both gated on a CEE quantitative hint and deficiency-framed, so a plain
+ * draft with no hint gets NO pointer toward the most valuable lens. This nudge
+ * is the single, always-visible, value-framed affordance that fills that gap.
+ *
+ * PRESENCE / ABSENCE ONLY — no new UI-SEM. Nothing is transformed: the nudge
+ * renders purely on existing state (a goal node exists AND no success target is
+ * set) and vanishes the instant a target lands. It never blocks analysis (the
+ * target stays optional) and routes into the EXISTING setter via the same seam
+ * `SharpenYourThinking` uses (`selectNodeWithoutHistory` + `focusNodeById` →
+ * the inspector Goal panel's `GoalThresholdEditor`) — it builds no second
+ * editor of its own.
+ *
+ * Copy aligns with the product's canonical gate line ("Set a success target to
+ * unlock Goal fit." — `v7LensCopy` / `heroCopy`). DS: complete `border`, semantic
+ * tokens, `bg-panel`, sentence case, Lucide icon, no emoji.
+ */
+
+import { Target } from 'lucide-react'
+import { typography } from '@/styles/typography'
+
+interface GoalTargetNudgeProps {
+  /** True when a goal node exists in the drafted graph (something to target). */
+  hasGoalNode: boolean
+  /** True when a success target (goal threshold) is already set. */
+  hasSuccessTarget: boolean
+  /** Opens / focuses the EXISTING target-setting flow (inspector Goal panel). */
+  onSetTarget: () => void
+}
+
+export function GoalTargetNudge({
+  hasGoalNode,
+  hasSuccessTarget,
+  onSetTarget,
+}: GoalTargetNudgeProps) {
+  // Presence gate: a goal exists to target AND no target is set yet. Absent
+  // pre-draft (no goal node) and the moment a target lands. Never nags — a
+  // single quiet card that removes itself once the target exists.
+  if (!hasGoalNode || hasSuccessTarget) return null
+
+  return (
+    <div
+      className="flex items-start gap-3 rounded-lg border border-info/30 bg-panel p-3"
+      role="note"
+      data-testid="goal-target-nudge"
+    >
+      <Target className="w-4 h-4 text-info shrink-0 mt-0.5" aria-hidden="true" />
+      <div className="flex flex-col gap-1 min-w-0">
+        <p className={`${typography.panelHeader} text-text-header`}>Set a success target</p>
+        <p className={`${typography.panelBody} text-text-light`}>
+          Unlock Goal fit — see each option's probability of reaching your target. Optional; analysis runs without one.
+        </p>
+        <button
+          type="button"
+          onClick={onSetTarget}
+          className={`self-start mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 ${typography.panelBody} text-info bg-transparent border border-info/40 rounded-full hover:border-success/40 hover:text-success transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+          data-testid="goal-target-nudge-cta"
+        >
+          <Target className="w-3 h-3 shrink-0" aria-hidden="true" />
+          Set target
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default GoalTargetNudge

--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -22,6 +22,7 @@ import { SuccessTarget } from './SuccessTarget'
 import { BlockersSection } from './BlockersSection'
 import { OptionPreview } from './OptionPreview'
 import { SharpenYourThinking } from './SharpenYourThinking'
+import { GoalTargetNudge } from './GoalTargetNudge'
 import { AnalysisSettings } from './AnalysisSettings'
 import { deriveExpertiseGroups } from './hooks/deriveExpertiseGroups'
 import { StickyFooter } from './StickyFooter'
@@ -2096,6 +2097,21 @@ export function PreAnalysisPanel({
               />
             </SectionErrorBoundary>
           )}
+
+          {/* Success-target elicitation nudge. When a draft has landed with a
+              goal but no success target, this is the single always-visible,
+              value-framed pointer into the EXISTING target-setter (routes via
+              handleSetTargetFocus — the same seam SharpenYourThinking uses).
+              It unlocks the honestly-gated Goal-fit lens (buildHeroModel
+              UI-SEM-071/072; buildV7Lenses goalThreshold==null gate). Presence
+              /absence only — vanishes the instant a target is set, never blocks
+              analysis (target stays optional). Sits above the T1 readiness card
+              so it lands where the eye already is post-draft. */}
+          <GoalTargetNudge
+            hasGoalNode={hasGoalNode}
+            hasSuccessTarget={hasGoalTarget}
+            onSetTarget={handleSetTargetFocus}
+          />
 
           {/* Brief 5.8A D3a: T1 "Decision readiness" card. The .sc wrapper
               hosts the ring + 4 dimension bars (ModelHealthCard compact mode),

--- a/src/canvas/components/pre-analysis/__tests__/GoalTargetNudge.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/GoalTargetNudge.spec.tsx
@@ -1,0 +1,50 @@
+/**
+ * GoalTargetNudge — RED-first pins for the success-target elicitation nudge.
+ *
+ * The nudge is presence/absence on existing state only. These pins lock the
+ * exact render condition (goal node present AND no success target), that it
+ * disappears once a target is set, that it never renders with no goal to
+ * target (the pre-draft / no-goal case), and that its CTA reaches the passed
+ * setter seam. DS: complete border (no one-sided accent) + bg-panel.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { GoalTargetNudge } from '../GoalTargetNudge'
+
+describe('GoalTargetNudge', () => {
+  it('renders when a goal exists and no success target is set (drafted graph, target absent)', () => {
+    render(<GoalTargetNudge hasGoalNode hasSuccessTarget={false} onSetTarget={vi.fn()} />)
+    expect(screen.getByTestId('goal-target-nudge')).toBeInTheDocument()
+    // Honest about the value it unlocks + that it is optional.
+    expect(screen.getByText('Set a success target')).toBeInTheDocument()
+    expect(screen.getByText(/Unlock Goal fit/)).toBeInTheDocument()
+    expect(screen.getByText(/Optional; analysis runs without one\./)).toBeInTheDocument()
+  })
+
+  it('disappears once a success target is set', () => {
+    render(<GoalTargetNudge hasGoalNode hasSuccessTarget onSetTarget={vi.fn()} />)
+    expect(screen.queryByTestId('goal-target-nudge')).not.toBeInTheDocument()
+  })
+
+  it('does not render when there is no goal node (pre-draft / nothing to target)', () => {
+    render(<GoalTargetNudge hasGoalNode={false} hasSuccessTarget={false} onSetTarget={vi.fn()} />)
+    expect(screen.queryByTestId('goal-target-nudge')).not.toBeInTheDocument()
+  })
+
+  it('reaches the setter seam: clicking the CTA calls onSetTarget exactly once', () => {
+    const onSetTarget = vi.fn()
+    render(<GoalTargetNudge hasGoalNode hasSuccessTarget={false} onSetTarget={onSetTarget} />)
+    fireEvent.click(screen.getByTestId('goal-target-nudge-cta'))
+    expect(onSetTarget).toHaveBeenCalledTimes(1)
+  })
+
+  it('is DS-compliant: complete border (no one-sided accent) on bg-panel', () => {
+    render(<GoalTargetNudge hasGoalNode hasSuccessTarget={false} onSetTarget={vi.fn()} />)
+    const card = screen.getByTestId('goal-target-nudge')
+    expect(card.className).toContain('bg-panel')
+    expect(card.className).toContain('border')
+    // No one-sided coloured accent edge (complete-borders rule).
+    expect(card.className).not.toMatch(/border-[lrtb]-/)
+  })
+})

--- a/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.spec.tsx
@@ -233,6 +233,52 @@ describe('PreAnalysisPanel', () => {
     mockLastDraftError = null
   })
 
+  describe('Success-target nudge', () => {
+    it('renders the nudge when a drafted graph has a goal but no success target', () => {
+      // createMockData defaults: 1 goal node, successThreshold null.
+      mockUsePreAnalysisData.mockReturnValue(createMockData())
+      render(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+      expect(screen.getByTestId('goal-target-nudge')).toBeInTheDocument()
+    })
+
+    it('hides the nudge once a success target is set', () => {
+      mockUsePreAnalysisData.mockReturnValue(createMockData({ successThreshold: 60 }))
+      render(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+      expect(screen.queryByTestId('goal-target-nudge')).not.toBeInTheDocument()
+    })
+
+    it('does not render the nudge when there is no goal node', () => {
+      mockUsePreAnalysisData.mockReturnValue(createMockData({
+        nodesByKind: {
+          goal: [],
+          decision: [],
+          option: [
+            { id: 'o1', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option 1' } },
+            { id: 'o2', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option 2' } },
+          ],
+          factor: [],
+          risk: [],
+          outcome: [],
+        },
+        goalNode: null,
+      }))
+      render(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+      expect(screen.queryByTestId('goal-target-nudge')).not.toBeInTheDocument()
+    })
+
+    it('CTA reaches the real setter seam (selectNodeWithoutHistory on the goal)', () => {
+      // Seam test: clicking the nudge CTA routes into the EXISTING target-
+      // setting flow via handleSetTargetFocus → selectNodeWithoutHistory +
+      // focusNodeById on the goal node (opens the inspector Goal panel's
+      // GoalThresholdEditor). Proves the affordance reaches the real setter,
+      // not a second editor.
+      mockUsePreAnalysisData.mockReturnValue(createMockData())
+      render(<PreAnalysisPanel onAnalyse={mockOnAnalyse} />)
+      fireEvent.click(screen.getByTestId('goal-target-nudge-cta'))
+      expect(mockSelectNodeWithoutHistory).toHaveBeenCalledWith('g1')
+    })
+  })
+
   describe('State Transitions', () => {
     it('renders null when canvas is empty', () => {
       mockUsePreAnalysisData.mockReturnValue(createMockData({

--- a/tests/ci-guards/complete-borders.spec.ts
+++ b/tests/ci-guards/complete-borders.spec.ts
@@ -71,6 +71,7 @@ const SRC = resolvePath(__dirname, '../../src')
  */
 const CONTENT_CARD_FILES = [
   'canvas/components/pre-analysis/PreAnalysisPanel.tsx',
+  'canvas/components/pre-analysis/GoalTargetNudge.tsx',
   'components/results/TriageActionCardsBody.tsx',
   'components/results/ConfidenceSection.tsx',
   'canvas/components/GuidanceCard.tsx',


### PR DESCRIPTION
## What

When a draft lands with a goal node but **no success target**, surface a single, always-visible, value-framed nudge that points the user into the **existing** target-setter. This unlocks the Goal-fit lens — the highest-value analysis view — which is honestly gated on a user target.

**Ships ON, no flag.** Presence/absence on existing state only — no new UI-SEM transform.

## Trace (cited)

**How a success target is set today**
- Store: `goalThreshold: number | null` (`src/canvas/store.ts:326`), written by `setGoalThreshold` / `setGoalThresholdAndUpdateNode` (store.ts:2808/2825).
- Panel surface: `SuccessTarget.tsx` renders the editor, but it now lives **inside the collapsed-by-default T3 "Advanced" accordion** (`AnalysisSettings.tsx`, `defaultExpanded={false}`) — so post-draft there is no visible pointer to it.
- Canonical setter seam: `handleSetTargetFocus` (`PreAnalysisPanel.tsx:1024`) → `selectNodeWithoutHistory(goalId)` + `focusNodeById(goalId)` → inspector Goal panel (`inspector-v2/panels/GoalPanel.tsx`) → `GoalThresholdEditor`. This is the same seam `SharpenYourThinking`'s `onSetTarget` already uses.

**How goal-gating consumes it (what "unlocks Goal fit" means)**
- `buildHeroModel.ts` UI-SEM-071/072: the goal-fit bars, readouts, goal lens, goal-fit crown and on-track headline are all gated on `goalThreshold != null`.
- `components/results/v7/buildV7Lenses.ts:144`: goal lens `gate: goalThreshold == null ? 'no_target' : …`.
- Canonical product copy already reads `"Set a success target to unlock Goal fit."` (`v7LensCopy.ts:42`, `heroCopy.ts:48`) — the nudge aligns to it.

**Post-draft moment**
- Live panel is `PreAnalysisPanel` (the V3 panel is behind `preAnalysisV3`, which defaults false and is **not** set in `netlify.toml`). It renders when `isPreRun && nodes.length > 0` (`OutputsDock.tsx:2154/2174`) — so the nudge inherently cannot render pre-draft.

## The gap this closes

The only existing pointers to the setter are the **T1 "Goal target not set" checklist row** and the **collapsed T2 "Sharpen" framing card** — both gated on a CEE quantitative hint (`goal_threshold_unit`/`_cap`) or a user-cleared target (`usePreAnalysisData.ts:1710-1725`), and both deficiency-framed. A plain draft with no hint gets **no** pointer toward the most valuable lens.

## Placement decision

`GoalTargetNudge` renders at the **top of the pre-analysis panel content, above the T1 readiness card** (after any blockers) — where the eye lands post-draft. Gate: `hasGoalNode && !hasGoalTarget` (i.e. `data.successThreshold === null`). It routes via `handleSetTargetFocus` (no second editor), disappears the instant a target is set, and **never blocks analysis** (the target stays optional).

## Gates

- `pnpm run typecheck` — clean.
- Targeted vitest (`GoalTargetNudge.spec`, `PreAnalysisPanel.spec`, `complete-borders` guard) — 83 passed / 1 skipped.
- `vitest run --changed` — 35 files, 449 passed / 13 skipped.
- ESLint (changed files) — 0 errors (1 pre-existing warning on staging: unused `hasGoalTarget` prop on `T1DecisionReadinessCard`, unrelated).
- Complete-borders CI guard — new file added to the scan set; passes.

## RED-first pins (mutation-checked in throwaway)

- Nudge renders iff `hasGoalNode && !hasSuccessTarget`; hidden when target set; hidden with no goal node.
- CTA reaches the real setter: unit asserts `onSetTarget` fires once; panel asserts `selectNodeWithoutHistory('g1')` fires on CTA click.
- **Mutation A** (component always `return null`): the 5 presence/seam pins go RED, the 2 absence pins stay green. **Mutation B** (drop the `hasSuccessTarget` guard): the 2 "disappears once set" pins go RED. Restored to byte-identical original; re-run green.

## DS

Complete `border border-info/30`, `bg-panel`, semantic tokens, sentence case, Lucide `Target` icon, no emoji, outlined action button.

## Deviations / notes for the reviewer

- **Existing narrow `no_target` surfaces left in place.** In the CEE-quantitative-hint subset the new nudge overlaps with the (secondary) T1 checklist row and the (collapsed) T2 framing card. I left them to keep this PR minimal — removing them would churn `usePreAnalysisData`, `SharpenYourThinking`, the T1 card and 3+ test files. If you'd prefer strict single-affordance dedup, removing the T1 `no_target` row is a clean fast-follow.
- Scope respected: **no CEE / clarify-flow changes** (A1's half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)