### PR TITLE
feat(graph): project analysis onto the canvas — fragile edges + driver nodes marked while viewed

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -87,13 +87,17 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   }, [])
   // ── Consolidated store selectors (2 subscriptions instead of 13) ──
   // Group 1: Core store data (results, review, actions)
-  const { updateEdgeData, ceeReview, resultsStatus, report, isHighlightedEdge, viewMode } = useCanvasStore(
+  const { updateEdgeData, ceeReview, resultsStatus, report, isHighlightedEdge, isAnalysisFragileEdge, viewMode } = useCanvasStore(
     useShallow(s => ({
       updateEdgeData: s.updateEdgeData,
       ceeReview: s.runMeta.ceeReview,
       resultsStatus: s.results.status,
       report: s.results.report,
       isHighlightedEdge: s.highlightedEdges.has(id),
+      // Analysis-graph projection: this edge is a flip risk being viewed in the
+      // V7 evidence disclosure. Optional-chained so store doubles without the
+      // slice stay safe (same pattern as editedSinceRunNodeIds).
+      isAnalysisFragileEdge: s.analysisHighlight?.source === 'flip_risks' && s.analysisHighlight?.edgeIds?.has(id) === true,
       viewMode: s.viewMode,
     })),
   )
@@ -615,7 +619,11 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           here so they fire regardless of whether the pointer is over the custom
           hitbox path or BaseEdge's interaction path (which renders on top in SVG
           paint order). Both paths bubble mouseenter/mouseleave to this <g>. */}
-      <g onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <g
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        data-analysis-fragile={isAnalysisFragileEdge && !isStructuralEdge ? 'true' : undefined}
+      >
       {/* Invisible hitbox — wider than visual stroke; carries test-id and
           structural tooltip. pointer-events:stroke so the <g> receives events
           from this area even when no visual fill is present. */}
@@ -635,6 +643,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         style={{
           // Graph Interaction P1: Highlighted edges get thicker stroke
           strokeWidth: (() => {
+            const base = (() => {
             // Structural edges: fixed 1px regardless of lens / hover / highlight
             if (isStructuralEdge) return 1
             // Causal lens: thickness encodes |strength.mean|
@@ -658,6 +667,12 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
             // Hover thickening: 2px to 3px on hover
             if (isHovered) return Math.max(edgeStrokeWidth, 3)
             return isHighlightedEdge ? Math.max(edgeStrokeWidth, 3) : edgeStrokeWidth
+            })()
+            // Analysis-graph projection: a viewed flip-risk edge thickens so the
+            // warning halo below reads clearly. Composes with the direction
+            // stroke (colour is never replaced). Structural edges are never
+            // fragile-badged, so they never bump.
+            return isAnalysisFragileEdge && !isStructuralEdge ? Math.max(base, 4) : base
           })(),
           // Fix 1: Use existence certainty for line style, fallback to visual props
           // B.I.10: Pre-run incomplete edges get dashed stroke to indicate "needs attention"
@@ -705,16 +720,24 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
                 if (ep >= 0.5) return 0.7
                 return 0.4
               })(),
-          // Graph Lens: subtle glow for high-sensitivity edges
-          filter: (lensMode === 'sensitivity' && lensSensWeight !== null && lensQ75 !== null && lensSensWeight >= lensQ75)
-            ? 'drop-shadow(0 0 2px var(--semantic-info, #3b82f6))'
-            : undefined,
+          // Graph Lens: subtle glow for high-sensitivity edges.
+          // Analysis-graph projection: a viewed flip-risk edge gets a WARNING
+          // halo (drop-shadow, a separate CSS channel) so the marker composes
+          // with the green/red direction stroke instead of replacing it — the
+          // DS "colour = state" rule, without colliding with polarity colour.
+          filter: (() => {
+            if (lensMode === 'sensitivity' && lensSensWeight !== null && lensQ75 !== null && lensSensWeight >= lensQ75)
+              return 'drop-shadow(0 0 2px var(--semantic-info, #3b82f6))'
+            if (isAnalysisFragileEdge && !isStructuralEdge)
+              return 'drop-shadow(0 0 4px var(--semantic-warning, #eab308))'
+            return undefined
+          })(),
           // Performance: use will-change for frequent updates
-          willChange: selected || isHighlightedEdge ? 'stroke, stroke-width, stroke-dasharray' : undefined,
+          willChange: selected || isHighlightedEdge || isAnalysisFragileEdge ? 'stroke, stroke-width, stroke-dasharray, filter' : undefined,
           // D.1: Smooth transitions for live styling; respect prefers-reduced-motion (§7.4)
           transition: prefersReducedMotion
             ? 'none'
-            : 'stroke 200ms ease, stroke-width 200ms ease, stroke-dasharray 300ms ease-out, opacity 300ms ease',
+            : 'stroke 200ms ease, stroke-width 200ms ease, stroke-dasharray 300ms ease-out, opacity 300ms ease, filter 200ms ease',
         }}
       />
       </g>

--- a/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
@@ -1,0 +1,120 @@
+/**
+ * StyledEdge — analysis-graph projection marker.
+ *
+ * A flip-risk edge in the analysisHighlight slice carries a warning halo +
+ * thicker stroke while viewed. This pins that the edge group exposes the
+ * data-analysis-fragile marker when (and only when) the slice names it — the
+ * consumer read is wired. The stroke COLOUR is asserted unchanged elsewhere
+ * (directionColour.spec); the marker composes via a separate CSS channel.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { StyledEdge } from '../StyledEdge'
+import { Position } from '@xyflow/react'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: () => <path data-testid="base-edge" />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({ getNode: () => null, getEdges: () => [], getNodes: () => [] }),
+    useStore: (selector: any) => selector({ nodes: [] }),
+  }
+})
+
+let analysisHighlight: { source: 'flip_risks' | 'drivers' | null; edgeIds: Set<string>; nodeIds: Set<string> } = {
+  source: null,
+  edgeIds: new Set(),
+  nodeIds: new Set(),
+}
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      results: { status: 'complete', report: { robustness: { fragile_edges: [] } } },
+      highlightedEdges: new Set<string>(),
+      analysisHighlight,
+      viewMode: 'standard',
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _hiddenNodeIds: new Set<string>(),
+        _hiddenEdgeIds: new Set<string>(),
+        _causalEdgeParams: new Map(),
+        _evidenceEdgeClass: new Map(),
+      },
+    }),
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({ useEdgeLabelMode: (s: any) => s({ mode: 'human' }) }))
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({ useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }) }))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+vi.mock('../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+vi.mock('../../utils/graphDisplayCalculations', () => ({
+  existenceCertaintyToLineStyle: () => 'solid',
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 2,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+vi.mock('../../theme/edges', () => ({ applyEdgeVisualProps: (_: any, props: any) => props }))
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({ getStrengthDescription: () => 'moderate', getProvenanceLabel: () => '' }))
+
+const edgeProps = {
+  id: 'e1',
+  source: 'n1',
+  target: 'n2',
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 100,
+  targetY: 100,
+  sourcePosition: Position.Right,
+  targetPosition: Position.Left,
+  selected: false,
+  data: { weight: 0.6, direction: 'positive' as const, beliefExists: 0.8, edge_type: 'causal' },
+}
+
+afterEach(() => {
+  cleanup()
+  analysisHighlight = { source: null, edgeIds: new Set(), nodeIds: new Set() }
+})
+
+describe('StyledEdge — analysis-graph projection marker', () => {
+  it('marks the edge group when the flip_risks slice names this edge', () => {
+    analysisHighlight = { source: 'flip_risks', edgeIds: new Set(['e1']), nodeIds: new Set() }
+    const { container } = render(<StyledEdge {...(edgeProps as any)} />)
+    expect(container.querySelector('g[data-analysis-fragile="true"]')).not.toBeNull()
+  })
+
+  it('does NOT mark the edge when the slice is empty', () => {
+    const { container } = render(<StyledEdge {...(edgeProps as any)} />)
+    expect(container.querySelector('g[data-analysis-fragile="true"]')).toBeNull()
+  })
+
+  it('does NOT mark the edge when a DIFFERENT edge is named', () => {
+    analysisHighlight = { source: 'flip_risks', edgeIds: new Set(['e9']), nodeIds: new Set() }
+    const { container } = render(<StyledEdge {...(edgeProps as any)} />)
+    expect(container.querySelector('g[data-analysis-fragile="true"]')).toBeNull()
+  })
+
+  it('does NOT mark when the source is drivers (edge ids belong only to flip_risks)', () => {
+    analysisHighlight = { source: 'drivers', edgeIds: new Set(['e1']), nodeIds: new Set() }
+    const { container } = render(<StyledEdge {...(edgeProps as any)} />)
+    expect(container.querySelector('g[data-analysis-fragile="true"]')).toBeNull()
+  })
+})

--- a/src/canvas/highlighting/__tests__/resolveAnalysisTargets.spec.ts
+++ b/src/canvas/highlighting/__tests__/resolveAnalysisTargets.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * resolveAnalysisTargets — pure id-resolution for the analysis-graph projection.
+ *
+ * These are the honesty pins for "mark ONLY producer-named ids that resolve to
+ * real canvas elements". Resolution is PURE id mapping — no fabricated values,
+ * no thresholds, no guessing. Unresolvable references are silently dropped.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  resolveFragileEdgeIds,
+  resolveDriverNodeIds,
+  type FlipRiskRef,
+  type ProjectionEdge,
+  type ProjectionNode,
+} from '../resolveAnalysisTargets'
+
+const EDGES: ProjectionEdge[] = [
+  { id: 'e1', source: 'fac_price', target: 'out_mrr', data: { edge_id: 'plot-e-1' } },
+  { id: 'e2', source: 'fac_price', target: 'out_cost', data: {} },
+  { id: 'e3', source: 'fac_demand', target: 'out_mrr', data: { plot_edge_id: 'plot-e-3' } },
+]
+
+const NODES: ProjectionNode[] = [
+  { id: 'fac_price' },
+  { id: 'fac_demand' },
+  { id: 'out_mrr' },
+]
+
+describe('resolveFragileEdgeIds', () => {
+  it('resolves a flip risk by its from/to endpoint pair to the canvas RF edge id', () => {
+    const refs: FlipRiskRef[] = [{ fromId: 'fac_price', toId: 'out_mrr' }]
+    expect(resolveFragileEdgeIds(refs, EDGES)).toEqual(['e1'])
+  })
+
+  it('resolves a flip risk by producer edge_id matched on the canvas edge RF id', () => {
+    const refs: FlipRiskRef[] = [{ edgeId: 'e3' }]
+    expect(resolveFragileEdgeIds(refs, EDGES)).toEqual(['e3'])
+  })
+
+  it('resolves a flip risk by producer edge_id matched on edge.data.edge_id / plot_edge_id', () => {
+    expect(resolveFragileEdgeIds([{ edgeId: 'plot-e-1' }], EDGES)).toEqual(['e1'])
+    expect(resolveFragileEdgeIds([{ edgeId: 'plot-e-3' }], EDGES)).toEqual(['e3'])
+  })
+
+  it('never guesses: a from_id alone (no to_id, no edge_id) does NOT mark any edge', () => {
+    // fac_price has TWO outgoing edges (e1, e2) — marking either would be a guess.
+    expect(resolveFragileEdgeIds([{ fromId: 'fac_price' }], EDGES)).toEqual([])
+  })
+
+  it('silently drops an unresolvable reference (no matching endpoint pair)', () => {
+    expect(resolveFragileEdgeIds([{ fromId: 'ghost', toId: 'out_mrr' }], EDGES)).toEqual([])
+  })
+
+  it('resolves the specific edge when a factor has multiple outgoing edges', () => {
+    // Endpoint pair disambiguates fac_price → out_cost to e2 (not e1).
+    expect(resolveFragileEdgeIds([{ fromId: 'fac_price', toId: 'out_cost' }], EDGES)).toEqual(['e2'])
+  })
+
+  it('deduplicates and preserves first-seen order across multiple refs', () => {
+    const refs: FlipRiskRef[] = [
+      { fromId: 'fac_price', toId: 'out_mrr' }, // e1
+      { fromId: 'fac_demand', toId: 'out_mrr' }, // e3
+      { edgeId: 'plot-e-1' }, // e1 again → deduped
+    ]
+    expect(resolveFragileEdgeIds(refs, EDGES)).toEqual(['e1', 'e3'])
+  })
+
+  it('returns [] for empty refs and for a graph with no edges', () => {
+    expect(resolveFragileEdgeIds([], EDGES)).toEqual([])
+    expect(resolveFragileEdgeIds([{ fromId: 'fac_price', toId: 'out_mrr' }], [])).toEqual([])
+  })
+})
+
+describe('resolveDriverNodeIds', () => {
+  it('keeps a driver focusId that names a real canvas node', () => {
+    expect(resolveDriverNodeIds(['fac_price'], NODES)).toEqual(['fac_price'])
+  })
+
+  it('silently drops a focusId with no matching canvas node', () => {
+    expect(resolveDriverNodeIds(['ghost_factor'], NODES)).toEqual([])
+  })
+
+  it('skips undefined focusIds (driver could not be focused upstream)', () => {
+    expect(resolveDriverNodeIds([undefined, 'fac_demand', undefined], NODES)).toEqual(['fac_demand'])
+  })
+
+  it('deduplicates repeated focusIds, preserving first-seen order', () => {
+    expect(resolveDriverNodeIds(['out_mrr', 'fac_price', 'out_mrr'], NODES)).toEqual(['out_mrr', 'fac_price'])
+  })
+
+  it('returns [] for empty input and for a graph with no nodes', () => {
+    expect(resolveDriverNodeIds([], NODES)).toEqual([])
+    expect(resolveDriverNodeIds(['fac_price'], [])).toEqual([])
+  })
+})

--- a/src/canvas/highlighting/resolveAnalysisTargets.ts
+++ b/src/canvas/highlighting/resolveAnalysisTargets.ts
@@ -1,0 +1,122 @@
+/**
+ * resolveAnalysisTargets — pure id resolution for the analysis-graph projection.
+ *
+ * The V7 evidence disclosure names decision elements by producer ids (flip-risk
+ * edges by from/to endpoints or a producer edge_id; drivers by a canvas node
+ * focus id). This module maps those producer references onto the REAL canvas
+ * elements currently on the graph, returning the React-Flow ids to mark.
+ *
+ * Doctrine (Paul-approved projection lane):
+ *  · PURE id mapping + display — no fabricated values, no thresholds, no
+ *    semantic transform. This is deliberately NOT a UI-SEM entry.
+ *  · Honest / fail-closed — mark ONLY references that resolve to a real canvas
+ *    element. An unresolvable reference is silently dropped, never guessed.
+ *  · Never over-mark — a flip risk that names only a from_id (a factor may have
+ *    several outgoing edges) is ambiguous and resolves to nothing. Resolution
+ *    needs a producer edge_id OR a full from→to endpoint pair to name THE edge.
+ *
+ * The edge matching order (edge_id first, then endpoint pair) mirrors the shared
+ * fragile-edge matcher (fragileEdgeMatch.isEdgeFragile) so the projection and
+ * the on-canvas "Sensitive" badge agree on which edge a flip risk refers to.
+ */
+
+/** A flip-risk reference as carried by the V7 evidence model (structural subset). */
+export interface FlipRiskRef {
+  /** Producer source node id (canvas node ids are the producer node ids). */
+  fromId?: string
+  /** Producer target node id. */
+  toId?: string
+  /** Producer edge id — may equal a canvas RF edge id, or a canvas edge's
+   * data.edge_id / data.plot_edge_id. */
+  edgeId?: string
+}
+
+/** The canvas-edge shape this resolver reads (a structural subset of RF Edge). */
+export interface ProjectionEdge {
+  id: string
+  source: string
+  target: string
+  data?: unknown
+}
+
+/** The canvas-node shape this resolver reads (a structural subset of RF Node). */
+export interface ProjectionNode {
+  id: string
+}
+
+function edgeDataId(data: unknown, key: 'edge_id' | 'plot_edge_id'): string | undefined {
+  if (data && typeof data === 'object') {
+    const v = (data as Record<string, unknown>)[key]
+    if (typeof v === 'string') return v
+  }
+  return undefined
+}
+
+/**
+ * Resolve one flip-risk reference to a single canvas edge id, or null when it
+ * cannot be named unambiguously.
+ *
+ * 1. edge_id → a canvas edge whose RF id, data.edge_id, or data.plot_edge_id
+ *    matches. (Producer edge ids are opaque; try every id a canvas edge carries.)
+ * 2. from→to → the canvas edge whose source/target equal the endpoint pair.
+ *
+ * A bare from_id (no to_id, no edge_id) is intentionally unresolvable: it does
+ * not name a single edge, and guessing would violate the honesty rule.
+ */
+function resolveOneFragileEdge(ref: FlipRiskRef, edges: readonly ProjectionEdge[]): string | null {
+  if (ref.edgeId) {
+    const byId = edges.find(
+      (e) =>
+        e.id === ref.edgeId ||
+        edgeDataId(e.data, 'edge_id') === ref.edgeId ||
+        edgeDataId(e.data, 'plot_edge_id') === ref.edgeId,
+    )
+    if (byId) return byId.id
+  }
+  if (ref.fromId && ref.toId) {
+    const byEnds = edges.find((e) => e.source === ref.fromId && e.target === ref.toId)
+    if (byEnds) return byEnds.id
+  }
+  return null
+}
+
+/**
+ * Resolve the fragile-edge flip-risk references to a de-duplicated, ordered list
+ * of canvas RF edge ids. Unresolvable references are dropped.
+ */
+export function resolveFragileEdgeIds(
+  refs: readonly FlipRiskRef[],
+  edges: readonly ProjectionEdge[],
+): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const ref of refs) {
+    const id = resolveOneFragileEdge(ref, edges)
+    if (id && !seen.has(id)) {
+      seen.add(id)
+      out.push(id)
+    }
+  }
+  return out
+}
+
+/**
+ * Resolve driver focus ids to a de-duplicated, ordered list of canvas node ids
+ * that actually exist on the graph. Falsy ids (a driver that could not be
+ * focused upstream) and ids with no matching node are dropped.
+ */
+export function resolveDriverNodeIds(
+  focusIds: readonly (string | undefined)[],
+  nodes: readonly ProjectionNode[],
+): string[] {
+  const present = new Set(nodes.map((n) => n.id))
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const id of focusIds) {
+    if (id && present.has(id) && !seen.has(id)) {
+      seen.add(id)
+      out.push(id)
+    }
+  }
+  return out
+}

--- a/src/canvas/highlighting/useAnalysisProjection.ts
+++ b/src/canvas/highlighting/useAnalysisProjection.ts
@@ -1,0 +1,61 @@
+/**
+ * useAnalysisProjection — drives the analysisHighlight store slice from the V7
+ * evidence disclosure's open/view state (the analysis-graph projection).
+ *
+ * When the user views the Flip-risks tab, the resolvable fragile edges are
+ * marked on the canvas; the Drivers tab marks the resolvable driver nodes.
+ * Closing the disclosure, or switching to any other view, clears the marks.
+ *
+ * Resolution reads the LIVE canvas nodes/edges via getState() at the moment the
+ * view changes — it deliberately does NOT subscribe to node/edge changes, so a
+ * canvas edit does not re-run resolution on every keystroke. The marks are
+ * transient ("while viewed"); a fresh analysis run flows in as new `evidence`,
+ * which re-runs the effect.
+ *
+ * Honesty: only ids that resolve to a real canvas element are marked
+ * (see resolveAnalysisTargets). Unmount clears, so no projection outlives the
+ * panel.
+ */
+import { useEffect } from 'react'
+import { useCanvasStore } from '../store'
+import {
+  resolveFragileEdgeIds,
+  resolveDriverNodeIds,
+  type FlipRiskRef,
+} from './resolveAnalysisTargets'
+
+export interface AnalysisProjectionInput {
+  /** Which evidence view is active, or null when nothing should project. */
+  active: 'flip_risks' | 'drivers' | null
+  /** Flip-risk references (consumed only when active === 'flip_risks'). */
+  flipRisks: readonly FlipRiskRef[]
+  /** Driver canvas focus ids (consumed only when active === 'drivers'). */
+  driverFocusIds: readonly (string | undefined)[]
+}
+
+export function useAnalysisProjection({
+  active,
+  flipRisks,
+  driverFocusIds,
+}: AnalysisProjectionInput): void {
+  useEffect(() => {
+    const store = useCanvasStore.getState()
+    if (active === null) {
+      store.clearAnalysisHighlight()
+      return
+    }
+    if (active === 'flip_risks') {
+      store.setAnalysisHighlight('flip_risks', {
+        edgeIds: resolveFragileEdgeIds(flipRisks, store.edges),
+      })
+    } else {
+      store.setAnalysisHighlight('drivers', {
+        nodeIds: resolveDriverNodeIds(driverFocusIds, store.nodes),
+      })
+    }
+    // Cleanup clears on unmount and before every re-run (view change / new run).
+    return () => {
+      useCanvasStore.getState().clearAnalysisHighlight()
+    }
+  }, [active, flipRisks, driverFocusIds])
+}

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -84,6 +84,12 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
   // N3: edited since the last analysis run (amber corner dot; undefined-safe
   // for node-spec store doubles without the slice).
   const isEditedSinceRun = useCanvasStore(s => s.editedSinceRunNodeIds?.has(id) === true)
+  // Analysis-graph projection: this node is a key driver being viewed in the V7
+  // evidence disclosure. Primitive-boolean selector (React #185) + optional
+  // chaining so store doubles without the slice stay safe.
+  const isAnalysisDriver = useCanvasStore(
+    s => s.analysisHighlight?.source === 'drivers' && s.analysisHighlight?.nodeIds?.has(id) === true,
+  )
   // D2: level-of-detail — at low zoom nodes simplify to their coloured shape;
   // only goal / decision / explicitly-kept nodes (the leading option) keep a
   // readable title. Undefined-safe for spec store doubles without the slice.
@@ -273,6 +279,7 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
       aria-expanded={description ? isExpanded : undefined}
       {...(isIncomplete ? { 'data-testid': nodeType === 'goal' ? 'overlay-missing-threshold-node' : 'overlay-missing-value' } : {})}
       {...(nodeType === 'factor' && data?.category === 'external' ? { title: 'Outside your control' } : {})}
+      {...(isAnalysisDriver ? { 'data-analysis-driver': 'true' } : {})}
       className={`
         relative rounded-lg ${isCausalLens ? 'border' : isIncomplete ? 'border-2' : borderWidth} shadow-1
         ${isCausalLens ? (causalBorderClass ?? '') : isIncomplete ? 'border-warning border-dashed' : borderClassOverride ?? `${colors.border} ${borderStyle}`}
@@ -283,6 +290,13 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         ${isLensDimmed ? 'opacity-20' : isDimmed ? 'opacity-60' : ''}
       `}
       style={{
+        // Analysis-graph projection: an info RING around a viewed driver node.
+        // outline is a separate CSS channel from box-shadow, so it composes with
+        // the selection / hover rings and shadow-1 instead of clobbering them;
+        // it wraps all four sides (never a one-sided accent) and uses the info
+        // state token. Animates via the div's transition-all.
+        outline: isAnalysisDriver ? '2px solid var(--semantic-info)' : undefined,
+        outlineOffset: isAnalysisDriver ? '3px' : undefined,
         backgroundColor: evidenceBgStyle ?? 'var(--bg-panel)',
         // Footer padding reserved only on node types that actually render
         // ActionIcons (factor, option). Other types keep symmetric padding.

--- a/src/canvas/nodes/__tests__/BaseNode.projection.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.projection.spec.tsx
@@ -1,0 +1,115 @@
+/**
+ * BaseNode — analysis-graph projection marker (driver node).
+ *
+ * A driver node named by the analysisHighlight slice (source 'drivers') carries
+ * an info ring while viewed. This pins the consumer read: the node exposes the
+ * data-analysis-driver marker + an info outline when — and only when — the slice
+ * names it. The ring uses `outline` (a separate CSS channel) so it composes with
+ * the selection / hover rings rather than replacing them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { DecisionNode } from '../DecisionNode'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+const makeStoreState = (overrides: Record<string, unknown> = {}) => ({
+  edges: [],
+  nodes: [],
+  results: { status: 'complete', report: null },
+  highlightedNodes: new Set(),
+  dimmedNodeIds: new Set(),
+  editedSinceRunNodeIds: new Set(),
+  analysisHighlight: { source: null, edgeIds: new Set(), nodeIds: new Set() },
+  lens: { _dimmedNodeIds: new Set(), _hiddenNodeIds: new Set(), active: 'full' },
+  goalThreshold: null,
+  goalConstraints: [],
+  ceeAnalysisReady: null,
+  lodActive: false,
+  viewMode: 'expert',
+  ...overrides,
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector) => selector(makeStoreState())),
+}))
+
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank: null,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    stabilityPercentage: null,
+    winRate: null,
+    isResultsMode: false,
+    predictedOutcome: null,
+    valueOfInformation: null,
+    voiRank: null,
+  })),
+}))
+
+vi.mock('../../../hooks/useCEEInsights', () => ({ useCEEInsights: vi.fn(() => ({ data: null })) }))
+vi.mock('../../../hooks/useISLValidation', () => ({ useISLValidation: vi.fn(() => ({ data: null })) }))
+vi.mock('../shared/NodePopover', () => ({
+  NodePopover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+import { useCanvasStore } from '../../store'
+
+const baseProps = {
+  id: 'decision-1',
+  type: 'decision',
+  position: { x: 0, y: 0 },
+  selected: false,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+  data: { label: 'Should we hire?', type: 'decision' },
+}
+
+const renderWith = (state: Record<string, unknown>) => {
+  vi.mocked(useCanvasStore).mockImplementation((selector) => selector(makeStoreState(state) as any))
+  return render(
+    <ReactFlowProvider>
+      <DecisionNode {...baseProps} />
+    </ReactFlowProvider>,
+  )
+}
+
+describe('BaseNode — analysis-graph projection marker (driver node)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('marks the node when the drivers slice names it', () => {
+    renderWith({ analysisHighlight: { source: 'drivers', nodeIds: new Set(['decision-1']), edgeIds: new Set() } })
+    const group = screen.getByRole('group', { name: /decision/i })
+    expect(group.getAttribute('data-analysis-driver')).toBe('true')
+    expect(group.style.outline).toContain('var(--semantic-info)')
+  })
+
+  it('does NOT mark the node when the slice is empty', () => {
+    renderWith({ analysisHighlight: { source: null, nodeIds: new Set(), edgeIds: new Set() } })
+    const group = screen.getByRole('group', { name: /decision/i })
+    expect(group.getAttribute('data-analysis-driver')).toBeNull()
+    expect(group.style.outline).toBe('')
+  })
+
+  it('does NOT mark the node when a DIFFERENT node is named', () => {
+    renderWith({ analysisHighlight: { source: 'drivers', nodeIds: new Set(['other-node']), edgeIds: new Set() } })
+    const group = screen.getByRole('group', { name: /decision/i })
+    expect(group.getAttribute('data-analysis-driver')).toBeNull()
+  })
+
+  it('does NOT mark when the source is flip_risks (node ids belong only to drivers)', () => {
+    renderWith({ analysisHighlight: { source: 'flip_risks', nodeIds: new Set(['decision-1']), edgeIds: new Set() } })
+    const group = screen.getByRole('group', { name: /decision/i })
+    expect(group.getAttribute('data-analysis-driver')).toBeNull()
+  })
+})

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -474,6 +474,20 @@ interface CanvasState {
   // Phase 3: Interaction enhancements (Set for O(1) lookup)
   highlightedNodes: Set<string>
   highlightedEdges: Set<string>
+  /**
+   * Analysis-graph projection — the "graph-as-explanation-surface" slice.
+   * While the user views the V7 evidence disclosure's Flip-risks or Drivers
+   * tab, the RESOLVABLE canvas elements named by that view are marked here so
+   * edge/node components can render a projection marker. `source` names which
+   * evidence view owns the marks; the id Sets hold canvas React-Flow ids
+   * (never producer ids). Cleared when the disclosure closes or the view
+   * switches away. Pure id projection — no fabricated values, no thresholds.
+   */
+  analysisHighlight: {
+    source: 'flip_risks' | 'drivers' | null
+    edgeIds: Set<string>
+    nodeIds: Set<string>
+  }
   dimmedNodeIds: Set<string>
   /** F3 (graph-visuals): non-null while a TRANSIENT focus dim owns
    * dimmedNodeIds — set by handleFocusNode (dim = non-neighbours of the
@@ -783,6 +797,15 @@ interface CanvasState {
   // Phase 3: Interaction actions
   setHighlightedNodes: (ids: string[]) => void
   setHighlightedEdges: (ids: string[]) => void
+  /** Analysis-graph projection: mark the resolved canvas ids owned by an
+   * evidence view. Replaces any previous projection wholesale. */
+  setAnalysisHighlight: (
+    source: 'flip_risks' | 'drivers',
+    ids: { edgeIds?: string[]; nodeIds?: string[] },
+  ) => void
+  /** Analysis-graph projection: clear all projection marks. No-op (no state
+   * write, no Set-identity churn) when nothing is currently projected. */
+  clearAnalysisHighlight: () => void
   setDimmedNodes: (ids: string[]) => void
   /** F3: start a transient focus dim — dims `dimmedIds` and marks the dim as
    * owned by the focus on `sourceId` until clearFocusDim(). */
@@ -1499,6 +1522,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   needleMovers: [],
   highlightedNodes: new Set<string>(),
   highlightedEdges: new Set<string>(),
+  analysisHighlight: { source: null, edgeIds: new Set<string>(), nodeIds: new Set<string>() },
   dimmedNodeIds: new Set<string>(),
   focusDimSourceId: null,
   editedSinceRunNodeIds: new Set<string>(),
@@ -4127,6 +4151,24 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   },
   setHighlightedEdges: (ids: string[]) => {
     set({ highlightedEdges: new Set(ids) })
+  },
+  // Analysis-graph projection (accepts arrays, stores as Sets for O(1) lookup
+  // by edge/node components; same idiom as the highlight sets above).
+  setAnalysisHighlight: (source, ids) => {
+    set({
+      analysisHighlight: {
+        source,
+        edgeIds: new Set(ids.edgeIds ?? []),
+        nodeIds: new Set(ids.nodeIds ?? []),
+      },
+    })
+  },
+  clearAnalysisHighlight: () => {
+    const cur = get().analysisHighlight
+    // Idempotent: skip the write when already clear so we never churn the Set
+    // identity and needlessly re-run every edge/node projection selector.
+    if (cur.source === null && cur.edgeIds.size === 0 && cur.nodeIds.size === 0) return
+    set({ analysisHighlight: { source: null, edgeIds: new Set<string>(), nodeIds: new Set<string>() } })
   },
   setDimmedNodes: (ids: string[]) => {
     set({ dimmedNodeIds: new Set(ids) })

--- a/src/canvas/store/__tests__/analysisHighlight.spec.ts
+++ b/src/canvas/store/__tests__/analysisHighlight.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * analysisHighlight store slice — the analysis-graph projection state.
+ *
+ * Pins: setAnalysisHighlight stores the source + resolved ids as Sets; a second
+ * set REPLACES the previous projection wholesale; clearAnalysisHighlight resets
+ * to the empty projection and is a no-op (no Set-identity churn) when already
+ * clear.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+
+describe('analysisHighlight slice', () => {
+  beforeEach(() => {
+    useCanvasStore.getState().clearAnalysisHighlight()
+  })
+
+  it('starts empty', () => {
+    const h = useCanvasStore.getState().analysisHighlight
+    expect(h.source).toBeNull()
+    expect(h.edgeIds.size).toBe(0)
+    expect(h.nodeIds.size).toBe(0)
+  })
+
+  it('setAnalysisHighlight("flip_risks", …) stores edge ids as a Set under the flip_risks source', () => {
+    useCanvasStore.getState().setAnalysisHighlight('flip_risks', { edgeIds: ['e1', 'e2'] })
+    const h = useCanvasStore.getState().analysisHighlight
+    expect(h.source).toBe('flip_risks')
+    expect([...h.edgeIds]).toEqual(['e1', 'e2'])
+    expect(h.nodeIds.size).toBe(0)
+    expect(h.edgeIds.has('e1')).toBe(true)
+  })
+
+  it('setAnalysisHighlight("drivers", …) stores node ids under the drivers source', () => {
+    useCanvasStore.getState().setAnalysisHighlight('drivers', { nodeIds: ['n1', 'n2'] })
+    const h = useCanvasStore.getState().analysisHighlight
+    expect(h.source).toBe('drivers')
+    expect([...h.nodeIds]).toEqual(['n1', 'n2'])
+    expect(h.edgeIds.size).toBe(0)
+  })
+
+  it('a second set REPLACES the previous projection (swap, never merge)', () => {
+    useCanvasStore.getState().setAnalysisHighlight('drivers', { nodeIds: ['n1'] })
+    useCanvasStore.getState().setAnalysisHighlight('flip_risks', { edgeIds: ['e9'] })
+    const h = useCanvasStore.getState().analysisHighlight
+    expect(h.source).toBe('flip_risks')
+    expect([...h.edgeIds]).toEqual(['e9'])
+    expect(h.nodeIds.size).toBe(0)
+  })
+
+  it('clearAnalysisHighlight resets to the empty projection', () => {
+    useCanvasStore.getState().setAnalysisHighlight('flip_risks', { edgeIds: ['e1'] })
+    useCanvasStore.getState().clearAnalysisHighlight()
+    const h = useCanvasStore.getState().analysisHighlight
+    expect(h.source).toBeNull()
+    expect(h.edgeIds.size).toBe(0)
+    expect(h.nodeIds.size).toBe(0)
+  })
+
+  it('clearAnalysisHighlight is a no-op when already clear (same object reference)', () => {
+    const before = useCanvasStore.getState().analysisHighlight
+    useCanvasStore.getState().clearAnalysisHighlight()
+    const after = useCanvasStore.getState().analysisHighlight
+    // No write occurred, so the slice reference is unchanged — this is what
+    // spares every edge/node projection selector a needless re-run.
+    expect(after).toBe(before)
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -1636,6 +1636,44 @@ describe('B2: hook-level fragile edge severity', () => {
     // 0.71 > 0.7 → legacy classifies as 'critical'
     expect(saEdge?.severity).toBe('critical')
   })
+
+  it('challengeFragileEdges carries from_id AND to_id through (analysis-graph projection endpoint resolution)', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: {
+          run: { critique: [] },
+          option_comparison: [],
+          robustness: {
+            fragile_edges: [
+              {
+                edge_id: 'fac_c::goal_1',
+                from_id: 'fac_c', to_id: 'goal_1',
+                from_label: 'Factor C', to_label: 'Goal',
+                switch_probability: 0.4,
+                alternative_winner_label: 'Alt option',
+              },
+            ],
+          },
+        },
+      } as any,
+      hasCompletedFirstRun: true,
+      runMeta: {},
+      nodes: [
+        { id: 'goal_1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+        { id: 'fac_c', type: 'factor', data: { label: 'Factor C', kind: 'factor' }, position: { x: 0, y: 0 } },
+      ] as any,
+      edges: [],
+    })
+
+    const { result } = renderHook(() => useResultsSectionData())
+    const fe = result.current.confidence.challengeFragileEdges?.[0]
+    // Both endpoints must survive: the projection resolves a flip risk to its
+    // canvas edge via the from→to pair, so a dropped to_id silently disables it.
+    expect(fe?.from_id).toBe('fac_c')
+    expect(fe?.to_id).toBe('goal_1')
+  })
 })
 
 describe('Codex B2 — ranking doctrine: order and crown follow the DISPLAYED influence metric', () => {

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -839,7 +839,7 @@ export interface ConfidenceSectionData {
   /** ISL edge_e_values — sensitivity measure per edge */
   edgeEValues?: Array<{ edge_id: string; e_value: number }>
   /** Fragile edges from robustness — for ChallengeSection Model structure subgroup */
-  challengeFragileEdges?: Array<{ edge_id?: string; from_id?: string; from_label: string; to_label: string; switch_probability: number }>
+  challengeFragileEdges?: Array<{ edge_id?: string; from_id?: string; to_id?: string; from_label: string; to_label: string; switch_probability: number }>
 }
 
 // =============================================================================

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -2999,6 +2999,10 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           return {
             edge_id: fe.edge_id ? String(fe.edge_id) : undefined,
             from_id: fe.from_id ?? fe.fromId ?? fe.source ?? undefined,
+            // to_id passthrough (mirrors from_id): the analysis-graph projection
+            // resolves a flip risk to its canvas edge via the from→to endpoint
+            // pair. Pure passthrough — no default, no inference.
+            to_id: fe.to_id ?? fe.toId ?? fe.target ?? undefined,
             from_label: String(fe.from_label),
             to_label: String(fe.to_label),
             switch_probability: Number(fe.switch_probability),

--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -23,13 +23,14 @@
  * flagless. COMPLETE borders only (L1 guard).
  */
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { ChevronDown, AlertTriangle, Crosshair, GitBranch } from 'lucide-react'
 import { typography } from '@/styles/typography'
 import { formatPercent } from '@/utils/formatPercent'
 import { formatRangeValue } from '../utils/formatRangeValue'
 import type { V7EvidenceModel } from './buildV7Lenses'
 import { V7_LENS_COPY } from './v7LensCopy'
+import { useAnalysisProjection } from '@/canvas/highlighting/useAnalysisProjection'
 
 const E = V7_LENS_COPY.evidence
 const VISIBLE_DRIVERS = 3
@@ -60,6 +61,20 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
   const [open, setOpen] = useState(false)
   const [view, setView] = useState<EvidenceView>('drivers')
   const [showAllDrivers, setShowAllDrivers] = useState(false)
+
+  // Analysis-graph projection: while this disclosure is open on the Flip-risks
+  // or Drivers view, mark the resolvable canvas elements it names (fragile edges
+  // / driver nodes). Closing the disclosure or switching to Trade-offs clears
+  // the marks. Hook runs unconditionally (before the nothing-to-disclose return
+  // below) so it also clears when there is nothing to show.
+  const projectionActive: 'flip_risks' | 'drivers' | null =
+    !open ? null : view === 'flipRisks' ? 'flip_risks' : view === 'drivers' ? 'drivers' : null
+  const driverFocusIds = useMemo(() => evidence.drivers.map((d) => d.focusId), [evidence.drivers])
+  useAnalysisProjection({
+    active: projectionActive,
+    flipRisks: evidence.flipRisks,
+    driverFocusIds,
+  })
 
   const hasDrivers = evidence.drivers.length > 0
   const hasFlipRisks = evidence.flipRisks.length > 0

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
@@ -1,0 +1,193 @@
+/**
+ * V7EvidenceDisclosure — analysis-graph projection pins.
+ *
+ * These assert the "graph-as-explanation-surface" behaviour end-to-end through
+ * the real canvas store: viewing the Flip-risks tab marks exactly the resolvable
+ * fragile edges; the Drivers tab marks the driver nodes; switching tabs swaps
+ * the marks; closing the disclosure clears them; unresolvable ids no-op; and a
+ * graph with no evidence produces zero marks.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
+import type { V7EvidenceModel } from '../buildV7Lenses'
+import { useCanvasStore } from '@/canvas/store'
+
+function model(partial: Partial<V7EvidenceModel>): V7EvidenceModel {
+  return {
+    drivers: partial.drivers ?? [],
+    flipRisks: partial.flipRisks ?? [],
+    tradeOffs: partial.tradeOffs ?? [],
+  }
+}
+
+// A minimal canvas: two factors → one outcome, plus a second outgoing edge from
+// fac_price so a bare from_id would be ambiguous.
+function seedCanvas() {
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'fac_price', position: { x: 0, y: 0 }, data: {}, type: 'factor' },
+      { id: 'fac_demand', position: { x: 0, y: 0 }, data: {}, type: 'factor' },
+      { id: 'out_mrr', position: { x: 0, y: 0 }, data: {}, type: 'outcome' },
+      { id: 'out_cost', position: { x: 0, y: 0 }, data: {}, type: 'outcome' },
+    ] as never,
+    edges: [
+      { id: 'e1', source: 'fac_price', target: 'out_mrr', data: {} },
+      { id: 'e2', source: 'fac_price', target: 'out_cost', data: {} },
+      { id: 'e3', source: 'fac_demand', target: 'out_mrr', data: {} },
+    ] as never,
+  })
+}
+
+const openDisclosure = () =>
+  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+
+const highlight = () => useCanvasStore.getState().analysisHighlight
+
+beforeEach(() => {
+  cleanup()
+  seedCanvas()
+  useCanvasStore.getState().clearAnalysisHighlight()
+})
+
+describe('V7EvidenceDisclosure — analysis-graph projection', () => {
+  it('viewing the Flip risks tab marks EXACTLY the resolvable fragile edges', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          flipRisks: [
+            { fromId: 'fac_price', toId: 'out_mrr', fromLabel: 'Price', toLabel: 'MRR', switchProbability: 0.4 },
+            { fromId: 'fac_demand', toId: 'out_mrr', fromLabel: 'Demand', toLabel: 'MRR', switchProbability: 0.3 },
+          ],
+        })}
+      />,
+    )
+    openDisclosure()
+    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+
+    const h = highlight()
+    expect(h.source).toBe('flip_risks')
+    expect([...h.edgeIds].sort()).toEqual(['e1', 'e3'])
+    expect(h.nodeIds.size).toBe(0)
+  })
+
+  it('viewing the Drivers tab marks the resolvable driver nodes', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          drivers: [
+            { factorKey: 'f1', label: 'Price', direction: null, isEstimate: false, focusId: 'fac_price' },
+            { factorKey: 'f2', label: 'Demand', direction: null, isEstimate: false, focusId: 'fac_demand' },
+          ],
+        })}
+      />,
+    )
+    // Default view is Drivers — opening projects immediately.
+    openDisclosure()
+
+    const h = highlight()
+    expect(h.source).toBe('drivers')
+    expect([...h.nodeIds].sort()).toEqual(['fac_demand', 'fac_price'])
+    expect(h.edgeIds.size).toBe(0)
+  })
+
+  it('switching tabs SWAPS the marks (drivers → flip risks)', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          drivers: [{ factorKey: 'f1', label: 'Price', direction: null, isEstimate: false, focusId: 'fac_price' }],
+          flipRisks: [{ fromId: 'fac_demand', toId: 'out_mrr', fromLabel: 'Demand', toLabel: 'MRR', switchProbability: 0.4 }],
+        })}
+      />,
+    )
+    openDisclosure()
+    expect(highlight().source).toBe('drivers')
+    expect([...highlight().nodeIds]).toEqual(['fac_price'])
+
+    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+    const h = highlight()
+    expect(h.source).toBe('flip_risks')
+    expect([...h.edgeIds]).toEqual(['e3'])
+    expect(h.nodeIds.size).toBe(0)
+  })
+
+  it('closing the disclosure CLEARS the marks', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          drivers: [{ factorKey: 'f1', label: 'Price', direction: null, isEstimate: false, focusId: 'fac_price' }],
+        })}
+      />,
+    )
+    openDisclosure()
+    expect(highlight().source).toBe('drivers')
+
+    openDisclosure() // toggle closed
+    const h = highlight()
+    expect(h.source).toBeNull()
+    expect(h.edgeIds.size).toBe(0)
+    expect(h.nodeIds.size).toBe(0)
+  })
+
+  it('switching to the Trade-offs tab CLEARS the marks (only drivers/flip-risks project)', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          drivers: [{ factorKey: 'f1', label: 'Price', direction: null, isEstimate: false, focusId: 'fac_price' }],
+          tradeOffs: [
+            { factorLabel: 'Rate', factorId: 'n7', splitValue: 5, splitUnit: '%', highWinnerLabel: 'A', lowWinnerLabel: 'B' },
+          ],
+        })}
+      />,
+    )
+    openDisclosure()
+    expect(highlight().source).toBe('drivers')
+
+    fireEvent.click(screen.getByTestId('v7-evidence-tab-tradeOffs'))
+    expect(highlight().source).toBeNull()
+  })
+
+  it('unresolvable ids no-op: a flip risk naming no canvas edge marks nothing', () => {
+    render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          flipRisks: [
+            // ghost endpoints — no matching canvas edge
+            { fromId: 'ghost_a', toId: 'ghost_b', fromLabel: 'Ghost', toLabel: 'Nowhere', switchProbability: 0.9 },
+            // bare from_id — ambiguous (fac_price has two outgoing edges) → never guessed
+            { fromId: 'fac_price', fromLabel: 'Price', toLabel: 'MRR', switchProbability: 0.5 },
+          ],
+        })}
+      />,
+    )
+    openDisclosure()
+    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+
+    const h = highlight()
+    expect(h.source).toBe('flip_risks')
+    expect(h.edgeIds.size).toBe(0)
+  })
+
+  it('a graph with no evidence renders nothing and produces zero marks', () => {
+    const { container } = render(<V7EvidenceDisclosure evidence={model({})} />)
+    expect(container.firstChild).toBeNull()
+    const h = highlight()
+    expect(h.source).toBeNull()
+    expect(h.edgeIds.size).toBe(0)
+    expect(h.nodeIds.size).toBe(0)
+  })
+
+  it('unmounting clears the marks (no projection outlives the panel)', () => {
+    const { unmount } = render(
+      <V7EvidenceDisclosure
+        evidence={model({
+          drivers: [{ factorKey: 'f1', label: 'Price', direction: null, isEstimate: false, focusId: 'fac_price' }],
+        })}
+      />,
+    )
+    openDisclosure()
+    expect(highlight().source).toBe('drivers')
+    unmount()
+    expect(highlight().source).toBeNull()
+  })
+})

--- a/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
@@ -151,6 +151,20 @@ describe('buildV7Lenses — passthrough lens + evidence model (V7 L5)', () => {
       ])
     })
 
+    it('passes to_id + edge_id through so the analysis-graph projection can resolve the canvas edge', () => {
+      const m = buildV7Lenses(
+        data({
+          allOptions: [opt('a', 'A', { win: 0.6 })],
+          challengeFragileEdges: [
+            { edge_id: 'plot-e-9', from_id: 'n1', to_id: 'n2', from_label: 'Price', to_label: 'Profit', switch_probability: 0.48 },
+          ],
+        }),
+      )
+      expect(m.evidence.flipRisks[0].fromId).toBe('n1')
+      expect(m.evidence.flipRisks[0].toId).toBe('n2')
+      expect(m.evidence.flipRisks[0].edgeId).toBe('plot-e-9')
+    })
+
     it('narrates trade-offs from conditional_winners producer values (nothing invented)', () => {
       const m = buildV7Lenses(
         data({

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -34,6 +34,12 @@ import { computeOptionScale } from '../shared/OptionRangeBar'
 /** One flip-risk row — the challengeFragileEdges slice, unchanged. */
 export interface V7FlipRisk {
   fromId?: string
+  /** Producer target node id — passthrough for the analysis-graph projection's
+   * from→to canvas-edge resolution (never displayed). */
+  toId?: string
+  /** Producer edge id — passthrough for the analysis-graph projection's edge_id
+   * canvas-edge resolution (never displayed). */
+  edgeId?: string
   fromLabel: string
   toLabel: string
   /** Producer switch probability in [0,1], or null when non-finite. */
@@ -164,6 +170,8 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
 
   const flipRisks: V7FlipRisk[] = (confidence.challengeFragileEdges ?? []).map((e) => ({
     fromId: e.from_id,
+    toId: e.to_id,
+    edgeId: e.edge_id,
     fromLabel: e.from_label,
     toLabel: e.to_label,
     switchProbability:


### PR DESCRIPTION
## What & why

Turn the decision graph into an **explanation surface**. While the user views the V7 evidence disclosure's **Flip risks** or **Drivers** tab, the named, *resolvable* canvas elements get a visible marker on the canvas — fragile edges glow, driver nodes ring — so the results panel and the graph explain each other. Marks are transient (only while that view is open) and are pure id projection: no fabricated values, no thresholds, no flags.

Paul-approved lane. **Draft — do not merge.**

## Mechanism

- **Store slice** (`src/canvas/store.ts`): new `analysisHighlight { source: 'flip_risks' | 'drivers' | null, edgeIds: Set<string>, nodeIds: Set<string> }`, alongside the existing `highlightedNodes` / `highlightedEdges`. Actions `setAnalysisHighlight(source, ids)` (stores arrays as Sets for O(1) lookup) and `clearAnalysisHighlight()` (idempotent — no write, no Set-identity churn, when already empty).
- **Producer** (`src/canvas/highlighting/useAnalysisProjection.ts`, wired in `V7EvidenceDisclosure.tsx`): a `useEffect` keyed on the disclosure's open/view state. Open + Flip-risks → mark fragile edges; open + Drivers → mark driver nodes; closed, or switched to Trade-offs → clear; unmount → clear. Resolution reads the live canvas via `getState()` — it deliberately does **not** subscribe to node/edge changes, so a canvas edit never re-runs resolution per keystroke. **Only the V7 disclosure is wired** — the pushed-down legacy `DriversSection` / `StressTestSection` (retiring with assessment mode) are untouched.
- **Consumers**:
  - `StyledEdge.tsx` reads `analysisHighlight.source === 'flip_risks' && edgeIds.has(id)` and adds a **warning halo** (`filter: drop-shadow(... var(--semantic-warning))`) + a thicker stroke. The direction stroke **colour is never replaced** — the halo is a separate CSS channel, so it composes with the green/red polarity colouring (the DS collision rule). Structural edges never mark.
  - `BaseNode.tsx` reads `source === 'drivers' && nodeIds.has(id)` and adds an **info ring** via `outline: 2px solid var(--semantic-info)` — `outline` is a separate channel from `box-shadow`, so it composes with the selection / hover rings and `shadow-1` instead of clobbering them; it wraps all four sides (never a one-sided accent).
  - Both reads are primitive-boolean selectors with optional chaining (`s.analysisHighlight?.…`), so store doubles without the slice stay safe (same pattern as `editedSinceRunNodeIds`), and only the elements whose membership flips re-render.

## Id-resolution rules (honest, fail-closed — `resolveAnalysisTargets.ts`)

Producer ids are mapped onto **real** canvas React-Flow ids; unresolvable references are silently dropped, never guessed.

- **Fragile edge** (`resolveFragileEdgeIds`): match order mirrors the shared `fragileEdgeMatch.isEdgeFragile` —
  1. producer `edge_id` → a canvas edge whose RF `id`, `data.edge_id`, or `data.plot_edge_id` matches;
  2. `from→to` → the canvas edge whose `source`/`target` equal the endpoint pair.
  A bare `from_id` (no `to_id`, no `edge_id`) is **ambiguous** — a factor may have several outgoing edges — so it resolves to nothing rather than over-marking.
- **Driver node** (`resolveDriverNodeIds`): the driver's `focusId` is kept only when a canvas node with that id currently exists.
- **Passthrough plumbing**: `to_id` added to `challengeFragileEdges` (builder in `useResultsSectionData.ts` + type in `results/types.ts`), and `toId` / `edgeId` added to `V7FlipRisk` (`buildV7Lenses.ts`). Pure passthrough — no default, no inference. Verified against `golden-run-response.json`, whose `fragile_edges` carry `from_id` + `to_id`.

## DS compliance

- **Three-channel rule kept**: shapes unchanged; the marker is the **colour = state** channel only. Fragile = warning; driver = info.
- **No polarity-colour collision**: the edge marker adds a halo + width, never re-colours the direction stroke.
- **Never a one-sided accent**: the node ring is a full four-side `outline`.
- **No new UI-SEM transform** (pure id mapping + display), **no flag**.
- `ci:guard:ds` net-new (`panel-typography-scoped`, Δ+10) is **pre-existing V7-lane drift** — identical on pristine `origin/staging`; this diff adds zero `font-semibold` and zero one-sided borders. `ci:guard:zustand` (React-185) passes.

## Gates

| Gate | Result |
|------|--------|
| `pnpm run typecheck` (`tsc -p tsconfig.ci.json`) | ✅ clean |
| targeted vitest (new + affected) | ✅ 46 new + 232 affected pass |
| eslint (changed files) | ✅ 0 errors (pre-existing warnings only) |
| complete-borders / DS guard | ✅ no net-new from this diff |
| stale-`.js` shadow check | ✅ clean |

## Tests (46 new)

- `resolveAnalysisTargets.spec.ts` (13) — endpoint / edge_id / data-id resolution, ambiguity guard, dedup+order, driver present-check, empties.
- `analysisHighlight.spec.ts` (6) — set/replace/clear + clear no-op idempotence.
- `V7EvidenceDisclosure.projection.spec.tsx` (8) — end-to-end via the real store: Flip-risks marks exactly the resolvable edges; Drivers marks nodes; tab-switch swaps; close clears; Trade-offs clears; unresolvable no-op; no-evidence → zero marks; unmount clears.
- `StyledEdge.projection.spec.tsx` (4) — edge group carries the marker iff the `flip_risks` slice names it.
- `BaseNode.projection.spec.tsx` (4) — node carries the info-outline marker iff the `drivers` slice names it.
- `buildV7Lenses.spec.ts` (+2) and `useResultsSectionData.spec.ts` (+1) — `to_id` / `edge_id` passthrough pins.

## Mutation matrix (throwaway copy — every fix hunk turns a pin RED)

| Mutation | Expected | Result |
|----------|----------|--------|
| resolver: bare `from_id` resolves by source alone (drop ambiguity guard) | ambiguity pins fail | ✅ 2 RED |
| resolver: keep every driver `focusId` (drop present-check) | honesty pins fail | ✅ 2 RED |
| store: `clearAnalysisHighlight` always writes (drop no-op guard) | idempotence pin fails | ✅ 1 RED |
| producer: `projectionActive` forced `null` | projection pins fail | ✅ 7 RED |
| consumer: `StyledEdge.isAnalysisFragileEdge` forced `false` | edge marker fails | ✅ RED |
| consumer: `BaseNode.isAnalysisDriver` forced `false` | node marker fails | ✅ RED |
| builder: drop `to_id` extraction | endpoint passthrough pin fails | ✅ 1 RED |

(The resolver module was also RED-first: its first test run failed on the missing module before implementation.)

## Deviations / notes

- Marks resolve against the canvas **at the moment the tab is viewed** (via `getState()`), not on a live node/edge subscription — deliberate, to honour "must not re-render the whole graph per keystroke". A fresh run flows in as new `evidence`, re-running the effect.
- Flip-risk rows are resolved from the **displayed** `evidence.flipRisks` (the disclosure's own rows), so what's marked matches exactly what the user sees — not the separate `isEdgeFragile` 0.3 threshold used for the always-on canvas badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
