### PR TITLE
feat(v5): wire focus/open_inspector directives + apply add_constraint patches

### DIFF
--- a/src/v5/__tests__/applyV5State.addConstraint.test.ts
+++ b/src/v5/__tests__/applyV5State.addConstraint.test.ts
@@ -1,0 +1,253 @@
+/**
+ * add_constraint graph_patch — apply CEE's server-applied constraint patches
+ * into the canvas `goalConstraints` store slice (the SAME slice GoalPanel's
+ * "Add constraint" flow writes via setGoalConstraints).
+ *
+ * Wire shape: a graph_patch block with operation 'add_constraint' carries the
+ * constrained node in `target_id` and the constraint payload in `after`
+ * (untyped Record on the wire). The applicator maps `after` → CEEGoalConstraint
+ * and APPENDS it (deduped) to the existing constraints via setGoalConstraints
+ * with { fromProducerSync: true } (a producer sync — the response's own
+ * analysis_ready.freshness verdict governs staleness, so the write must not
+ * self-dirty the freshness overlay).
+ *
+ * Operator vocabulary tolerance: `after.operator` may be the schema form
+ * ('>=' / '<=') OR the chip form ('at_least' / 'at_most'); node id may be
+ * `after.node_id`, `after.target_id`, or fall back to the patch `target_id`.
+ * Anything that cannot resolve a node id + operator + finite value is DEFERRED
+ * (fail-closed) — the applicator never fabricates a constraint.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+import type { CEEGoalConstraint } from '../../adapters/cee/types'
+
+const { pulseMock } = vi.hoisted(() => ({ pulseMock: vi.fn() }))
+vi.mock('../../canvas/utils/appliedEditPulse', () => ({
+  pulseAppliedTargets: pulseMock,
+  __resetAppliedEditPulseForTests: vi.fn(),
+  PULSE_COALESCE_MS: 100,
+  PULSE_DURATION_MS: 2000,
+}))
+vi.mock('../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+
+function baseResponse(overrides: Partial<OlumiResponse> = {}): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+    ...overrides,
+  }
+}
+
+function makeStore(
+  goalConstraints: CEEGoalConstraint[] | null = null,
+  nodes: V5ApplicatorStore['nodes'] = [],
+): V5ApplicatorStore {
+  return {
+    setCurrentStage: vi.fn(),
+    updateNode: vi.fn(),
+    updateEdgeData: vi.fn(),
+    setRunMeta: vi.fn(),
+    setCeeAnalysisReady: vi.fn(),
+    setGoalConstraints: vi.fn(),
+    backfillGoalThreshold: vi.fn(),
+    selectNodeWithoutHistory: vi.fn(),
+    selectEdgeWithoutHistory: vi.fn(),
+    goalConstraints,
+    nodes,
+    edges: [],
+  }
+}
+
+const constraintPatch = (after: Record<string, unknown> | null, target_id = 'goal-1') =>
+  ({
+    type: 'graph_patch',
+    status: 'applied',
+    operation: 'add_constraint',
+    target_id,
+    before: null,
+    after,
+  }) as never
+
+beforeEach(() => {
+  pulseMock.mockClear()
+})
+
+describe('applyV5State — add_constraint graph_patch', () => {
+  it('appends a constraint (schema operator) to goalConstraints via setGoalConstraints', () => {
+    const store = makeStore(null)
+    const result = applyV5State(
+      baseResponse({
+        blocks: [
+          constraintPatch({
+            constraint_id: 'c_budget',
+            node_id: 'factor-spend',
+            operator: '<=',
+            value: 250,
+            label: 'Budget cap',
+            unit: '£',
+          }),
+        ],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).toHaveBeenCalledTimes(1)
+    const [constraints, opts] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(constraints).toHaveLength(1)
+    expect(constraints[0]).toMatchObject({
+      constraint_id: 'c_budget',
+      node_id: 'factor-spend',
+      operator: '<=',
+      value: 250,
+      label: 'Budget cap',
+      unit: '£',
+    })
+    // producer sync — must NOT self-dirty the freshness overlay
+    expect(opts).toEqual({ fromProducerSync: true })
+    expect(result.applied).toContain('graph_patch:add_constraint:factor-spend')
+  })
+
+  it('preserves existing constraints — the new one is APPENDED, not replaced', () => {
+    const existing: CEEGoalConstraint = {
+      constraint_id: 'c_old',
+      node_id: 'factor-a',
+      operator: '>=',
+      value: 10,
+    }
+    const store = makeStore([existing])
+    applyV5State(
+      baseResponse({
+        blocks: [
+          constraintPatch({ node_id: 'factor-b', operator: '<=', value: 5 }),
+        ],
+      }),
+      store,
+    )
+    const [constraints] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(constraints).toHaveLength(2)
+    expect(constraints[0]).toBe(existing)
+    expect(constraints[1]).toMatchObject({ node_id: 'factor-b', operator: '<=', value: 5 })
+  })
+
+  it('maps the chip operator vocabulary (at_least → >=, at_most → <=)', () => {
+    const store = makeStore(null)
+    applyV5State(
+      baseResponse({
+        blocks: [
+          constraintPatch({ node_id: 'factor-a', constraint_type: 'at_least', value: 3 }),
+        ],
+      }),
+      store,
+    )
+    const [constraints] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(constraints[0].operator).toBe('>=')
+  })
+
+  it('falls back to the patch target_id for node_id when after omits it', () => {
+    const store = makeStore(null)
+    applyV5State(
+      baseResponse({
+        blocks: [constraintPatch({ operator: '>=', value: 7 }, 'goal-node')],
+      }),
+      store,
+    )
+    const [constraints] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(constraints[0].node_id).toBe('goal-node')
+  })
+
+  it('IDEMPOTENT: applying the same response twice does not double-append', () => {
+    const store = makeStore(null)
+    const response = baseResponse({
+      blocks: [
+        constraintPatch({ node_id: 'factor-a', operator: '>=', value: 3 }),
+      ],
+    })
+    applyV5State(response, store)
+    const firstArray = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    // second fire: the store now already holds that constraint
+    const store2 = makeStore(firstArray)
+    const result2 = applyV5State(response, store2)
+    expect(store2.setGoalConstraints).not.toHaveBeenCalled()
+    expect(result2.deferred.some((d) => d.reason === 'add_constraint_duplicate_skipped')).toBe(true)
+  })
+
+  it('coalesces multiple add_constraint patches into ONE setGoalConstraints call', () => {
+    const store = makeStore(null)
+    applyV5State(
+      baseResponse({
+        blocks: [
+          constraintPatch({ node_id: 'factor-a', operator: '>=', value: 3 }),
+          constraintPatch({ node_id: 'factor-b', operator: '<=', value: 9 }),
+        ],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).toHaveBeenCalledTimes(1)
+    const [constraints] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(constraints).toHaveLength(2)
+  })
+
+  it('NEGATIVE CONTROL: a non-applied patch is skipped (no store write)', () => {
+    const store = makeStore(null)
+    applyV5State(
+      baseResponse({
+        blocks: [
+          {
+            type: 'graph_patch',
+            status: 'proposed',
+            operation: 'add_constraint',
+            target_id: 'goal-1',
+            before: null,
+            after: { node_id: 'factor-a', operator: '>=', value: 3 },
+          } as never,
+        ],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).not.toHaveBeenCalled()
+  })
+
+  it('NEGATIVE CONTROL: an unmappable shape (no operator) DEFERS fail-closed, no write', () => {
+    const store = makeStore(null)
+    const result = applyV5State(
+      baseResponse({
+        blocks: [constraintPatch({ node_id: 'factor-a', value: 3 })],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).not.toHaveBeenCalled()
+    expect(result.deferred.some((d) => d.reason === 'add_constraint_unmappable_shape')).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL: a non-finite / non-numeric value DEFERS (never coerced)', () => {
+    const store = makeStore(null)
+    const result = applyV5State(
+      baseResponse({
+        blocks: [constraintPatch({ node_id: 'factor-a', operator: '>=', value: '3' })],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).not.toHaveBeenCalled()
+    expect(result.deferred.some((d) => d.reason === 'add_constraint_unmappable_shape')).toBe(true)
+  })
+
+  it('does not mutate node/edge data (constraints are metadata, not causal structure)', () => {
+    const store = makeStore(null)
+    applyV5State(
+      baseResponse({
+        blocks: [constraintPatch({ node_id: 'factor-a', operator: '>=', value: 3 })],
+      }),
+      store,
+    )
+    expect(store.updateNode).not.toHaveBeenCalled()
+    expect(store.updateEdgeData).not.toHaveBeenCalled()
+  })
+})

--- a/src/v5/__tests__/applyV5State.test.ts
+++ b/src/v5/__tests__/applyV5State.test.ts
@@ -272,8 +272,12 @@ describe('applyV5State — analysis_result: decision_review wiring', () => {
 })
 
 describe('applyV5State — deferred operations', () => {
-  it('add_constraint is explicitly deferred as NEEDS_FIX', () => {
-    const { store } = makeStore()
+  it('add_constraint with an unmappable `after` shape defers fail-closed (never fabricates)', () => {
+    // `after` carries no operator and no numeric value — the applicator must
+    // NOT invent a constraint from it. Full add_constraint wiring (valid
+    // shapes, dedupe, coalescing, operator vocabularies) is pinned in
+    // applyV5State.addConstraint.test.ts.
+    const { store, setGoalConstraints } = makeStore()
     const result = applyV5State(
       baseResponse({
         blocks: [
@@ -289,7 +293,8 @@ describe('applyV5State — deferred operations', () => {
       }),
       store,
     )
-    expect(result.deferred[0]?.reason).toBe('add_constraint_not_wired')
+    expect(result.deferred[0]?.reason).toBe('add_constraint_unmappable_shape')
+    expect(setGoalConstraints).not.toHaveBeenCalled()
   })
 
   it('ignores render-only block kinds (text, explanation, comparison, flip_analysis)', () => {

--- a/src/v5/__tests__/applyV5State.uiDirective.test.ts
+++ b/src/v5/__tests__/applyV5State.uiDirective.test.ts
@@ -1,22 +1,27 @@
 /**
  * R4 UI half — ui_directive dispatcher (surfacing gates 3–5).
  *
- * CEE's first slice (merged dark, CEE PR #408) emits at most ONE directive
- * per fresh run_analysis turn: verb `highlight`, typed target refs, no free
- * text. The UI executes it at applyV5State (the once-per-envelope
- * side-effect site — never render-driven, so re-renders can't re-fire it):
+ * CEE emits at most ONE directive per turn: a typed verb + typed target refs,
+ * no free text. The UI executes it at applyV5State (the once-per-envelope
+ * side-effect site — never render-driven, so re-renders can't re-fire it).
+ * Three verbs are wired, each reusing the SAME seam a user action uses — the
+ * AI can point at the graph, never do something the user cannot:
  *
  * - `highlight` targets join the SAME coalesced pulse the applied-edit path
- *   uses (fail-closed in-graph filter, one 2s ring, no viewport movement —
- *   the AI cannot hijack what the user is doing).
+ *   uses (fail-closed in-graph filter, one 2s ring, no viewport movement).
+ * - `focus` centres the viewport on a single target via the guidance
+ *   click-to-focus seam (focusNodeById / focusEdgeById).
+ * - `open_inspector` selects a single target via the user-selection seam
+ *   (selectNodeWithoutHistory / selectEdgeWithoutHistory) so inspector-v2
+ *   opens/retargets — selection only, no camera move.
+ * - An UNKNOWN verb (a newer producer) DEFERS fail-closed; it must no-op with
+ *   a deferred record, never crash.
  * - Rate limit: exactly ONE directive executed per envelope (the producer
  *   contract); extras are deferred, never silently executed.
- * - `focus` / `open_inspector` are schema-valid but DEFERRED fail-closed in
- *   this slice (viewport/panel-moving verbs need their own rate-limit
- *   design); they must no-op with a deferred record, never crash.
- * - Directives are instructions, not content: the mapper renders nothing
- *   (pinned in mapV5Blocks.holds0150.test.ts); execution must be visible
- *   only as the highlight itself.
+ * - Every verb is fail-closed on the target id: an off-canvas / unknown id is
+ *   recorded not-found and never executed (the negative controls below).
+ * - Directives NEVER mutate graph data (no updateNode / updateEdgeData /
+ *   setGoalConstraints from any verb).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { OlumiResponse } from '@talchain/schemas/boundary'
@@ -27,6 +32,15 @@ vi.mock('../../canvas/utils/appliedEditPulse', () => ({
   __resetAppliedEditPulseForTests: vi.fn(),
   PULSE_COALESCE_MS: 100,
   PULSE_DURATION_MS: 2000,
+}))
+
+const { focusNodeMock, focusEdgeMock } = vi.hoisted(() => ({
+  focusNodeMock: vi.fn(),
+  focusEdgeMock: vi.fn(),
+}))
+vi.mock('../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: focusNodeMock,
+  focusEdgeById: focusEdgeMock,
 }))
 
 import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
@@ -55,16 +69,23 @@ function makeStore(
     setCeeAnalysisReady: vi.fn(),
     setGoalConstraints: vi.fn(),
     backfillGoalThreshold: vi.fn(),
+    selectNodeWithoutHistory: vi.fn(),
+    selectEdgeWithoutHistory: vi.fn(),
+    goalConstraints: null,
     nodes,
     edges,
   }
 }
 
-const directive = (verb: string, targets: Array<{ id: string; label: string; kind: string }>) =>
-  ({ type: 'ui_directive', verb, targets }) as never
+const directive = (
+  verb: string,
+  targets: Array<{ id: string; label: string; kind: string }>,
+) => ({ type: 'ui_directive', verb, targets }) as never
 
 beforeEach(() => {
   pulseMock.mockClear()
+  focusNodeMock.mockClear()
+  focusEdgeMock.mockClear()
 })
 
 describe('applyV5State — ui_directive dispatcher (R4)', () => {
@@ -120,26 +141,120 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
     ).toBe(true)
   })
 
-  it('focus verb is DEFERRED fail-closed (viewport-moving verbs are a later slice)', () => {
+  // ── focus ────────────────────────────────────────────────────────────────
+  it('focus verb centres the viewport on a NODE via focusNodeById (guidance seam)', () => {
     const result = applyV5State(
       baseResponse({
         blocks: [directive('focus', [{ id: 'opt_a', label: 'A', kind: 'option' }])],
       }),
-      makeStore(),
+      makeStore([{ id: 'opt_a', data: {} } as never]),
     )
+    expect(focusNodeMock).toHaveBeenCalledTimes(1)
+    expect(focusNodeMock).toHaveBeenCalledWith('opt_a')
+    expect(focusEdgeMock).not.toHaveBeenCalled()
     expect(pulseMock).not.toHaveBeenCalled()
-    expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
+    expect(result.applied).toContain('ui_directive:focus:opt_a')
   })
 
-  it('open_inspector verb is DEFERRED fail-closed', () => {
+  it('focus verb centres the viewport on an EDGE via focusEdgeById', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('focus', [{ id: 'e1', label: 'Influence', kind: 'edge' }])],
+      }),
+      makeStore([], [{ id: 'e1', source: 'a', target: 'b' } as never]),
+    )
+    expect(focusEdgeMock).toHaveBeenCalledWith('e1')
+    expect(focusNodeMock).not.toHaveBeenCalled()
+    expect(result.applied).toContain('ui_directive:focus:e1')
+  })
+
+  it('focus NEGATIVE CONTROL: an unknown target id no-ops silently (fail-closed)', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('focus', [{ id: 'ghost', label: 'Deleted', kind: 'option' }])],
+      }),
+      makeStore([{ id: 'opt_a', data: {} } as never]),
+    )
+    expect(focusNodeMock).not.toHaveBeenCalled()
+    expect(focusEdgeMock).not.toHaveBeenCalled()
+    expect(result.applied.some((a) => a.startsWith('ui_directive:focus'))).toBe(false)
+    expect(
+      result.deferred.some(
+        (d) => d.reason === 'ui_directive_target_not_found' && d.detail === 'ghost',
+      ),
+    ).toBe(true)
+  })
+
+  it('focus is single-target: acts on the first resolvable target, defers the rest', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [
+          directive('focus', [
+            { id: 'opt_a', label: 'A', kind: 'option' },
+            { id: 'opt_b', label: 'B', kind: 'option' },
+          ]),
+        ],
+      }),
+      makeStore([
+        { id: 'opt_a', data: {} } as never,
+        { id: 'opt_b', data: {} } as never,
+      ]),
+    )
+    expect(focusNodeMock).toHaveBeenCalledTimes(1)
+    expect(focusNodeMock).toHaveBeenCalledWith('opt_a')
+    expect(result.applied).toContain('ui_directive:focus:opt_a')
+    expect(
+      result.deferred.some(
+        (d) => d.reason === 'ui_directive_extra_target_ignored' && d.detail === 'opt_b',
+      ),
+    ).toBe(true)
+  })
+
+  // ── open_inspector ─────────────────────────────────────────────────────────
+  it('open_inspector selects a NODE via selectNodeWithoutHistory (no camera move)', () => {
+    const store = makeStore([{ id: 'opt_a', data: {} } as never])
     const result = applyV5State(
       baseResponse({
         blocks: [directive('open_inspector', [{ id: 'opt_a', label: 'A', kind: 'option' }])],
       }),
-      makeStore(),
+      store,
     )
+    expect(store.selectNodeWithoutHistory).toHaveBeenCalledWith('opt_a')
+    expect(store.selectEdgeWithoutHistory).not.toHaveBeenCalled()
+    expect(focusNodeMock).not.toHaveBeenCalled()
     expect(pulseMock).not.toHaveBeenCalled()
-    expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
+    expect(result.applied).toContain('ui_directive:open_inspector:opt_a')
+  })
+
+  it('open_inspector selects an EDGE via selectEdgeWithoutHistory', () => {
+    const store = makeStore([], [{ id: 'e1', source: 'a', target: 'b' } as never])
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('open_inspector', [{ id: 'e1', label: 'Influence', kind: 'edge' }])],
+      }),
+      store,
+    )
+    expect(store.selectEdgeWithoutHistory).toHaveBeenCalledWith('e1')
+    expect(store.selectNodeWithoutHistory).not.toHaveBeenCalled()
+    expect(result.applied).toContain('ui_directive:open_inspector:e1')
+  })
+
+  it('open_inspector NEGATIVE CONTROL: an unknown target id no-ops silently (fail-closed)', () => {
+    const store = makeStore([{ id: 'opt_a', data: {} } as never])
+    const result = applyV5State(
+      baseResponse({
+        blocks: [directive('open_inspector', [{ id: 'ghost', label: 'Gone', kind: 'option' }])],
+      }),
+      store,
+    )
+    expect(store.selectNodeWithoutHistory).not.toHaveBeenCalled()
+    expect(store.selectEdgeWithoutHistory).not.toHaveBeenCalled()
+    expect(result.applied.some((a) => a.startsWith('ui_directive:open_inspector'))).toBe(false)
+    expect(
+      result.deferred.some(
+        (d) => d.reason === 'ui_directive_target_not_found' && d.detail === 'ghost',
+      ),
+    ).toBe(true)
   })
 
   it('unknown verb (newer producer) defers without crashing', () => {
@@ -150,14 +265,15 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
       makeStore(),
     )
     expect(pulseMock).not.toHaveBeenCalled()
+    expect(focusNodeMock).not.toHaveBeenCalled()
     expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
   })
 
-  it('a DEFERRED first directive does not burn the budget — the next valid one executes', () => {
+  it('a DEFERRED first directive (unknown verb) does not burn the budget — the next valid one executes', () => {
     const result = applyV5State(
       baseResponse({
         blocks: [
-          directive('focus', [{ id: 'opt_a', label: 'A', kind: 'option' }]), // deferred verb
+          directive('start_tour', [{ id: 'opt_a', label: 'A', kind: 'option' }]), // unknown verb
           directive('highlight', [{ id: 'opt_b', label: 'B', kind: 'option' }]),
         ],
       }),
@@ -168,7 +284,25 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
     expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
   })
 
-  it('an off-canvas target is recorded as not-found, never as an execution', () => {
+  it('an EXECUTED focus burns the budget — a following highlight is rate-limited', () => {
+    const result = applyV5State(
+      baseResponse({
+        blocks: [
+          directive('focus', [{ id: 'opt_a', label: 'A', kind: 'option' }]),
+          directive('highlight', [{ id: 'opt_b', label: 'B', kind: 'option' }]),
+        ],
+      }),
+      makeStore([
+        { id: 'opt_a', data: {} } as never,
+        { id: 'opt_b', data: {} } as never,
+      ]),
+    )
+    expect(focusNodeMock).toHaveBeenCalledTimes(1)
+    expect(pulseMock).not.toHaveBeenCalled()
+    expect(result.deferred.some((d) => d.reason === 'ui_directive_rate_limited')).toBe(true)
+  })
+
+  it('an off-canvas target is recorded as not-found, never as an execution (highlight)', () => {
     const result = applyV5State(
       baseResponse({
         blocks: [
@@ -197,6 +331,24 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
     )
     expect(pulseMock).not.toHaveBeenCalled()
     expect(result.deferred.some((d) => d.reason === 'ui_directive_no_targets')).toBe(true)
+  })
+
+  it('directives NEVER mutate graph data (no node/edge/constraint writes from any verb)', () => {
+    for (const verb of ['highlight', 'focus', 'open_inspector']) {
+      const store = makeStore(
+        [{ id: 'opt_a', data: {} } as never],
+        [{ id: 'e1', source: 'a', target: 'b' } as never],
+      )
+      applyV5State(
+        baseResponse({
+          blocks: [directive(verb, [{ id: 'opt_a', label: 'A', kind: 'option' }])],
+        }),
+        store,
+      )
+      expect(store.updateNode).not.toHaveBeenCalled()
+      expect(store.updateEdgeData).not.toHaveBeenCalled()
+      expect(store.setGoalConstraints).not.toHaveBeenCalled()
+    }
   })
 
   it('a directive pulse coalesces with server-applied patch targets (one pulse per envelope)', () => {

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -12,9 +12,12 @@
  * Scope:
  *   1. stage_indicator → canvas.currentStage
  *   2. graph_patch (applied) → canvas store mutation for set_factor_value,
- *      adjust_edge_strength. add_constraint is a NEEDS_FIX marker (no 1:1
- *      UI store target yet; constraints live on node prior fields and
- *      require a canonical source of truth from CEE).
+ *      adjust_edge_strength, and add_constraint. add_constraint maps `after`
+ *      into a CEEGoalConstraint and APPENDS it (deduped) to the canvas
+ *      `goalConstraints` slice via setGoalConstraints — the SAME slice
+ *      GoalPanel's "Add constraint" flow writes. Also: ui_directive verbs
+ *      (highlight / focus / open_inspector) — the AI's "point at the graph"
+ *      gestures, each reusing the seam its user-driven equivalent uses.
  *   3. analysis_result.enrichment.decision_review → runMeta.ceeReviewV1.
  *      Block enrichment is the canonical source. A secondary check on a
  *      non-schema top-level enrichment field (future CEE extension) is
@@ -38,6 +41,7 @@ import type { CeeDecisionReviewPayloadV1 } from '../types/cee'
 import type { ScenarioStage } from '../types/scenario'
 import { logV5StateStep } from './debugLog'
 import { pulseAppliedTargets } from '../canvas/utils/appliedEditPulse'
+import { focusNodeById, focusEdgeById } from '../canvas/utils/focusHelpers'
 import { extractDecisionReview } from './decisionReviewAdapter'
 import { mapV5AnalysisToReport } from './mapV5AnalysisToReport'
 import { v5StageToScenarioStage } from './stageMapper'
@@ -69,6 +73,23 @@ export interface V5ApplicatorStore {
     constraints: CEEGoalConstraint[] | null,
     opts?: { fromProducerSync?: boolean },
   ) => void
+  /**
+   * Current goal constraints, read to append an `add_constraint` graph_patch's
+   * constraint without dropping the ones already present. Snapshot-frozen at
+   * apply time (the applicator receives a spread of getState()), so multiple
+   * add_constraint patches in one turn are coalesced into a single
+   * setGoalConstraints write after the block loop — reading this field again
+   * after a mid-loop set would return the stale pre-turn value.
+   */
+  goalConstraints?: CEEGoalConstraint[] | null
+  /**
+   * Optional: select a node without a history entry — the SAME seam a user
+   * click uses to open/retarget inspector-v2 (store.ts). Wired for the
+   * `open_inspector` ui_directive verb; selection only, no viewport move.
+   */
+  selectNodeWithoutHistory?: (nodeId: string) => void
+  /** Optional: select an edge without a history entry (edge inspector). */
+  selectEdgeWithoutHistory?: (edgeId: string) => void
   /**
    * Optional: backfill goal_threshold_raw/unit/cap onto the goal node's data
    * (ROADMAP 1.22). Wired at the real call site to the shared
@@ -270,6 +291,107 @@ function inlinePathWillOwnAnalysisReadyWrite(
   return wouldPassStrictAttachContract(normalisedAnalysisReady)
 }
 
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0
+}
+
+/**
+ * Resolve an `add_constraint` patch operator, tolerant of both wire
+ * vocabularies: the schema/DraftGoalConstraint form ('>=' / '<=') and the
+ * chip-parameter form ('at_least' / 'at_most', chipParameters.ts). Returns
+ * null when neither maps — the caller then fail-closes the whole patch.
+ */
+function resolveConstraintOperator(
+  operatorRaw: unknown,
+  constraintTypeRaw: unknown,
+): '>=' | '<=' | null {
+  if (operatorRaw === '>=' || operatorRaw === '<=') return operatorRaw
+  if (constraintTypeRaw === 'at_least') return '>='
+  if (constraintTypeRaw === 'at_most') return '<='
+  return null
+}
+
+/**
+ * Map an `add_constraint` graph_patch's `after` record (untyped on the wire)
+ * into a CEEGoalConstraint — the shape the canvas `goalConstraints` slice and
+ * PLoT's preflight both read. UI-is-a-passthrough: never coerce a value, never
+ * fabricate an operator. Returns null (→ deferred, an A1 ask if it recurs)
+ * when a node id, a valid operator, OR a finite numeric value cannot be
+ * resolved.
+ *
+ * node_id resolution order: explicit `after.node_id`, then `after.target_id`,
+ * then the patch's own `target_id` (the constrained node). constraint_id
+ * prefers the wire value; when absent it is derived deterministically as CEE's
+ * own `constraint_<node_id>_<min|max>` scheme so a re-applied identical patch
+ * dedupes by id (idempotency — no crypto/random, which would defeat it).
+ */
+function normaliseAddConstraintPatch(
+  after: Record<string, unknown> | null,
+  patchTargetId: string | undefined,
+): CEEGoalConstraint | null {
+  if (!after || typeof after !== 'object') return null
+
+  const nodeId = isNonEmptyString(after.node_id)
+    ? after.node_id
+    : isNonEmptyString(after.target_id)
+      ? after.target_id
+      : isNonEmptyString(patchTargetId)
+        ? patchTargetId
+        : undefined
+  if (!nodeId) return null
+
+  const operator = resolveConstraintOperator(after.operator, after.constraint_type)
+  if (!operator) return null
+
+  const value = after.value
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+
+  const constraint_id = isNonEmptyString(after.constraint_id)
+    ? after.constraint_id
+    : isNonEmptyString(after.id)
+      ? after.id
+      : `constraint_${nodeId}_${operator === '>=' ? 'min' : 'max'}`
+
+  const constraint: CEEGoalConstraint = {
+    constraint_id,
+    node_id: nodeId,
+    operator,
+    value,
+  }
+  if (isNonEmptyString(after.label)) constraint.label = after.label
+  if (isNonEmptyString(after.unit)) constraint.unit = after.unit
+  if (isNonEmptyString(after.source_quote)) constraint.source_quote = after.source_quote
+  if (typeof after.confidence === 'number' && Number.isFinite(after.confidence)) {
+    constraint.confidence = after.confidence
+  }
+  if (
+    after.provenance === 'explicit' ||
+    after.provenance === 'inferred' ||
+    after.provenance === 'proxy'
+  ) {
+    constraint.provenance = after.provenance
+  }
+  return constraint
+}
+
+/**
+ * Constraint identity for dedupe/idempotency: a shared constraint_id/id, OR the
+ * same (node_id, operator, value) triple. The triple check keeps a re-applied
+ * patch that carries NO constraint_id idempotent even though a fresh derived id
+ * would otherwise differ across fires.
+ */
+function constraintsSameIdentity(a: CEEGoalConstraint, b: CEEGoalConstraint): boolean {
+  const aId = a.constraint_id ?? a.id
+  const bId = b.constraint_id ?? b.id
+  if (aId && bId && aId === bId) return true
+  return (
+    a.node_id != null &&
+    a.node_id === b.node_id &&
+    a.operator === b.operator &&
+    a.value === b.value
+  )
+}
+
 type V5Block = OlumiResponse['blocks'][number]
 
 export interface ApplyV5StateResult {
@@ -398,6 +520,11 @@ export function applyV5State(
   // the targets that actually apply below and pulse once after the loop.
   const pulsedNodeIds: string[] = []
   const pulsedEdgeIds: string[] = []
+  // add_constraint patches are collected here and flushed to
+  // setGoalConstraints ONCE after the loop: the store snapshot's
+  // goalConstraints is frozen at apply time, so a per-patch read-modify-write
+  // would drop every constraint but the last.
+  const pendingConstraints: CEEGoalConstraint[] = []
   // R4 dispatcher rate limit: the producer contract is at most ONE
   // ui_directive per turn — the UI enforces it defensively; extras defer.
   let uiDirectiveExecuted = false
@@ -455,15 +582,50 @@ export function applyV5State(
           break
         }
         case 'add_constraint': {
-          // Not wired yet — constraints live on goal node prior fields.
-          // A translator from CEE's constraint shape → prior.range_min/
-          // range_max / threshold is deferred until CEE + UI agree on the
-          // canonical source of truth.
-          deferred.push({
-            reason: 'add_constraint_not_wired',
-            block,
-            detail: 'Constraint application deferred; see walkthrough NEEDS_FIX.',
-          })
+          // Constraints live in the canvas `goalConstraints` slice (the same
+          // one GoalPanel writes via setGoalConstraints) — NOT on goal-node
+          // prior fields as the old NEEDS_FIX marker assumed. Map `after` →
+          // CEEGoalConstraint and queue it; the loop flushes all queued
+          // constraints in one setGoalConstraints call afterwards.
+          if (typeof store.setGoalConstraints !== 'function') {
+            deferred.push({
+              reason: 'add_constraint_store_lacks_setter',
+              block,
+              detail: 'Applicator store has no setGoalConstraints; constraint not applied.',
+            })
+            break
+          }
+          const constraint = normaliseAddConstraintPatch(
+            block.after as Record<string, unknown> | null,
+            target,
+          )
+          if (!constraint) {
+            // Fail-closed: the `after` record could not resolve a node id, a
+            // valid operator, and a finite value. Never fabricate — surface it.
+            deferred.push({
+              reason: 'add_constraint_unmappable_shape',
+              block,
+              detail: 'after did not resolve to node_id + operator + finite value.',
+            })
+            break
+          }
+          // Idempotency + dedupe: skip when an equal constraint already exists
+          // (store OR queued earlier this turn) so a double-fire / echo never
+          // double-appends. Mirrors the neighbours' keyed-assignment idempotency.
+          const priorConstraints = store.goalConstraints ?? []
+          const isDuplicate = [...priorConstraints, ...pendingConstraints].some((c) =>
+            constraintsSameIdentity(c, constraint),
+          )
+          if (isDuplicate) {
+            deferred.push({
+              reason: 'add_constraint_duplicate_skipped',
+              block,
+              detail: constraint.constraint_id ?? constraint.node_id ?? target,
+            })
+            break
+          }
+          pendingConstraints.push(constraint)
+          applied.push(`graph_patch:add_constraint:${constraint.node_id ?? target}`)
           break
         }
         default: {
@@ -476,22 +638,36 @@ export function applyV5State(
         }
       }
     } else if (block.type === 'ui_directive') {
-      // R4 UI half (surfacing gate 4): execute directives at the
+      // R4 UI half: execute the AI's "point at the graph" directives at the
       // once-per-envelope side-effect site — never render-driven, so
-      // re-renders cannot re-fire them. Slice 1 executes `highlight` only,
-      // by feeding the SAME coalesced pulse the applied-edit path uses
-      // (fail-closed in-graph filter downstream, one 2s static ring, zero
-      // viewport movement — the AI cannot hijack what the user is doing).
-      // `focus`/`open_inspector` move the viewport/panels and get their own
-      // rate-limit design in a later slice; they defer fail-closed, as do
-      // verbs this build doesn't know. duration_ms is a producer hint not
-      // yet honoured (the ring is fixed 2s).
+      // re-renders cannot re-fire them. Three verbs are wired, each reusing
+      // the SAME seam its user-driven equivalent uses (the AI can point at the
+      // graph, never do something the user cannot):
+      //   - highlight      → the coalesced applied-edit pulse (one 2s static
+      //                       ring, fail-closed in-graph filter, no viewport
+      //                       or selection change) — the AI cannot hijack what
+      //                       the user is doing.
+      //   - focus          → focusNodeById / focusEdgeById, the guidance
+      //                       click-to-focus seam (centre viewport + select +
+      //                       brief glow). Single-target.
+      //   - open_inspector → selectNodeWithoutHistory / selectEdgeWithoutHistory,
+      //                       the user-selection seam that opens/retargets
+      //                       inspector-v2. Selection only, no camera move.
+      //                       Single-target.
+      // Unknown verbs (a newer producer) defer fail-closed. duration_ms is a
+      // producer hint not yet honoured (the highlight ring is a fixed 2s).
+      // Every verb is fail-closed on the target id: an off-canvas / unknown id
+      // is recorded not-found and never executed (keeps applied[] truthful and
+      // mirrors the graph_patch path's honesty).
       const targets = Array.isArray(block.targets) ? block.targets : []
-      if (block.verb !== 'highlight') {
+      const verb = block.verb
+      const verbSupported =
+        verb === 'highlight' || verb === 'focus' || verb === 'open_inspector'
+      if (!verbSupported) {
         deferred.push({
           reason: 'ui_directive_verb_deferred',
           block,
-          detail: String(block.verb),
+          detail: String(verb),
         })
       } else if (targets.length === 0) {
         deferred.push({ reason: 'ui_directive_no_targets', block })
@@ -503,11 +679,12 @@ export function applyV5State(
         })
       } else {
         uiDirectiveExecuted = true
+        // focus / open_inspector act on a SINGLE target (the viewport centres
+        // on one element / the inspector opens one element); highlight pulses
+        // every resolvable target.
+        let singleTargetActioned = false
         for (const t of targets) {
           if (!t?.id) continue
-          // Mirror the graph_patch path's honesty: an off-canvas target is
-          // recorded as not-found, never as an execution (the pulse filter
-          // would drop it downstream anyway — this keeps applied[] truthful).
           const isEdge = t.kind === 'edge'
           const exists = isEdge
             ? store.edges.some((e) => e.id === t.id)
@@ -520,12 +697,45 @@ export function applyV5State(
             })
             continue
           }
-          if (isEdge) {
-            pulsedEdgeIds.push(t.id)
-          } else {
-            pulsedNodeIds.push(t.id)
+          if (verb === 'highlight') {
+            if (isEdge) pulsedEdgeIds.push(t.id)
+            else pulsedNodeIds.push(t.id)
+            applied.push(`ui_directive:highlight:${t.id}`)
+            continue
           }
-          applied.push(`ui_directive:highlight:${t.id}`)
+          // focus / open_inspector: act on the first resolvable target only;
+          // later targets are extraneous for a viewport/panel verb — record
+          // them as ignored so applied[] stays truthful.
+          if (singleTargetActioned) {
+            deferred.push({
+              reason: 'ui_directive_extra_target_ignored',
+              block,
+              detail: t.id,
+            })
+            continue
+          }
+          if (verb === 'focus') {
+            if (isEdge) focusEdgeById(t.id)
+            else focusNodeById(t.id)
+            applied.push(`ui_directive:focus:${t.id}`)
+            singleTargetActioned = true
+          } else {
+            // open_inspector
+            const selectFn = isEdge
+              ? store.selectEdgeWithoutHistory
+              : store.selectNodeWithoutHistory
+            if (typeof selectFn === 'function') {
+              selectFn(t.id)
+              applied.push(`ui_directive:open_inspector:${t.id}`)
+              singleTargetActioned = true
+            } else {
+              deferred.push({
+                reason: 'ui_directive_open_inspector_store_lacks_setter',
+                block,
+                detail: t.id,
+              })
+            }
+          }
         }
       }
     } else if (block.type === 'analysis_result') {
@@ -554,6 +764,18 @@ export function applyV5State(
   }
   if (pulsedNodeIds.length > 0 || pulsedEdgeIds.length > 0) {
     pulseAppliedTargets({ nodeIds: pulsedNodeIds, edgeIds: pulsedEdgeIds })
+  }
+  // Flush any add_constraint patches in ONE setGoalConstraints write (see
+  // pendingConstraints declaration). fromProducerSync: true — a CEE-applied
+  // constraint is a producer sync, not a user edit; the response's own
+  // analysis_ready.freshness verdict governs staleness (same reasoning as the
+  // response-root goal_constraints path below), so the write must not
+  // self-dirty the freshness overlay. Additive: prior constraints are spread
+  // first (the response-root goal_constraints path, if present, still owns the
+  // authoritative full-set replace at step 4).
+  if (pendingConstraints.length > 0) {
+    const base = store.goalConstraints ?? []
+    store.setGoalConstraints?.([...base, ...pendingConstraints], { fromProducerSync: true })
   }
   const blockAppliedCount = applied.length - appliedCountBeforeBlocks
   logV5StateStep({


### PR DESCRIPTION
## What

Consumer (UI) half of the AI's "point at the graph" gestures + dropped constraint patches — 23-Jul capability audit **P1.3-UI** (directive verbs) + **P1.6** (add_constraint), Paul-approved. All changes are in `src/v5/applyV5State.ts`; each reuses the exact seam its user-driven equivalent uses, so the AI can point at the graph but never do something the user cannot.

### 1. `ui_directive` verbs — `focus` + `open_inspector` (were deferred fail-closed)
- **`focus`** → `focusNodeById` / `focusEdgeById` from `canvas/utils/focusHelpers` — the *exact* seam the guidance click-to-focus path uses (`GuidancePanel.tsx:75/83`). Centre viewport + select + brief glow. Single-target.
- **`open_inspector`** → `selectNodeWithoutHistory` / `selectEdgeWithoutHistory` (`store.ts:1889/1899`) — the same selection seam `OutputsDock` (`openOptionInInspector`), the context menu, and `PreAnalysisGuidance` use to open/retarget inspector-v2. Selection only, no camera move. Single-target.
- **`highlight`** unchanged (coalesced 2 s pulse). **Unknown verbs** still defer fail-closed. The **one-directive-per-turn** rate limit now spans all three verbs. Off-canvas / unknown target ids **no-op silently** (recorded `ui_directive_target_not_found`), and no verb mutates graph data.
- `zoom` is **not in the schema enum** (`highlight | focus | open_inspector`), so there is nothing to defer — unknown-verb handling covers any future producer verb.

### 2. `add_constraint` graph_patch (was `add_constraint_not_wired`)
- Maps the untyped `after` record → `CEEGoalConstraint` and **APPENDS it (deduped)** to the canvas `goalConstraints` slice via `setGoalConstraints` — the same slice `GoalPanel`'s "Add constraint" flow writes. (The old NEEDS_FIX comment assumed constraints live on goal-node prior fields; they migrated to the store slice.)
- **Tolerant** of both operator vocabularies (`>=`/`<=` and `at_least`/`at_most`) and both node-id fields (`after.node_id` / `after.target_id` / patch `target_id`).
- **Fail-closed**: an `after` that cannot resolve node_id + operator + finite value defers (`add_constraint_unmappable_shape`) rather than fabricate; values are never coerced (UI-is-a-passthrough).
- **Idempotent + coalesced**: multiple patches in a turn flush in ONE `setGoalConstraints` write (the applicator's store snapshot is frozen at apply time); a re-applied identical patch dedupes by id or by (node, operator, value) triple. Written with `fromProducerSync: true` so it doesn't self-dirty the freshness overlay (the response's own `analysis_ready.freshness` governs).

## Safety / hygiene
- No flags. **No new UI-SEM** — directive dispatch + constraint passthrough transform no displayed meaning.
- RED-first pins per verb + per patch op, incl. unknown-id no-op **negative controls**.
- **Mutation-checked** in a throwaway copy: reverting (a) focus/open_inspector verb support, (b) the constraint flush, and (c) the never-fabricate operator each turned the corresponding pins RED.

## Gates
- `pnpm run typecheck` — clean (baseline was clean too).
- ESLint on all changed files — clean (exit 0).
- `vitest` `src/v5/__tests__/` — 622 passed; new/updated pins 65 passed.
- One `--changed` dependent (`envelopeAnalysisWiring.spec.ts`) fails **identically on the clean baseline** (needs network/MSW mocking absent locally) — pre-existing, not a regression.

## Producer note
CEE currently never emits `focus` / `open_inspector` (producer ask filed with A1). The consumer is built ready and pinned with synthetic-response fixtures the way `highlight` is pinned.

## Known limitation (open_inspector)
`selectNodeWithoutHistory` sets `selection` (which inspector-v2 reads) but does not flip the `showFullInspector` local state in `ReactFlowGraph` — that state is only set by a user click. So `open_inspector` retargets an already-open inspector and populates selection, exactly like every existing programmatic caller (`openOptionInInspector`, context menu, `PreAnalysisGuidance`). Forcing the modal chrome open would need new UI plumbing beyond the named seam; flagging rather than adding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)