### PR TITLE
feat(edges): polarity glyph in standard view + single-channel encodings + factor badge de-noise

### DIFF
--- a/src/canvas/components/CanvasLegendPopover.tsx
+++ b/src/canvas/components/CanvasLegendPopover.tsx
@@ -73,14 +73,16 @@ function ThicknessSwatch({ width }: { width: number }) {
   )
 }
 
-// Thickness = influence. Stroke widths mirror importanceToStrokeWidth() in
-// graphDisplayCalculations.ts (normalised importance [0,1] → [1,8]): Weak ≈ 0.15
-// → 2, Moderate ≈ 0.5 → 4.5, Strong ≈ 1.0 → 8. Folded in from the former
-// standalone EdgeThicknessLegend so the two bottom-left legends are now one key.
+// Thickness = effect strength (weight magnitude), the same meaning in both
+// phases (P2.9 — thickness no longer switches to composite importance after a
+// run). Stroke widths mirror weightMagnitudeToStrokeWidth() in
+// graphDisplayCalculations.ts: |mean| < 0.4 → 1.5, ≥ 0.4 → 2, ≥ 0.7 → 3.
+// Folded in from the former standalone EdgeThicknessLegend so the two
+// bottom-left legends are now one key.
 const THICKNESS_ROWS: LegendRow[] = [
-  { label: 'Weak influence', swatch: <ThicknessSwatch width={2} /> },
-  { label: 'Moderate influence', swatch: <ThicknessSwatch width={4.5} /> },
-  { label: 'Strong influence', swatch: <ThicknessSwatch width={8} /> },
+  { label: 'Weak effect', swatch: <ThicknessSwatch width={1.5} /> },
+  { label: 'Moderate effect', swatch: <ThicknessSwatch width={2} /> },
+  { label: 'Strong effect', swatch: <ThicknessSwatch width={3} /> },
 ]
 
 const DIRECTION_ROWS: LegendRow[] = [

--- a/src/canvas/components/__tests__/CanvasLegendPopover.spec.tsx
+++ b/src/canvas/components/__tests__/CanvasLegendPopover.spec.tsx
@@ -11,7 +11,7 @@ import { CanvasLegendPopover } from '../CanvasLegendPopover'
 const APPROVED = [
   'Decision', 'Option', 'Factor', 'Outcome', 'Risk', 'Goal', 'Outside your control',
   'Raises', 'Lowers', 'Solid connection: established', 'Dashed connection: less certain',
-  'Weak influence', 'Moderate influence', 'Strong influence',
+  'Weak effect', 'Moderate effect', 'Strong effect',
 ]
 
 describe('CanvasLegendPopover', () => {
@@ -71,13 +71,15 @@ describe('CanvasLegendPopover', () => {
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 
-  // The folded-in influence scale renders its three samples (was the standalone
-  // EdgeThicknessLegend; now one consolidated key).
-  it('renders the influence-thickness scale', () => {
+  // The folded-in effect-strength scale renders its three samples (was the
+  // standalone EdgeThicknessLegend; now one consolidated key). P2.9: thickness
+  // means effect strength (weight magnitude) in both phases, so the labels read
+  // "effect" not "influence".
+  it('renders the effect-strength thickness scale', () => {
     render(<CanvasLegendPopover />)
     fireEvent.click(screen.getByRole('button', { name: 'How to read this' }))
-    expect(screen.getByText('Weak influence')).toBeDefined()
-    expect(screen.getByText('Moderate influence')).toBeDefined()
-    expect(screen.getByText('Strong influence')).toBeDefined()
+    expect(screen.getByText('Weak effect')).toBeDefined()
+    expect(screen.getByText('Moderate effect')).toBeDefined()
+    expect(screen.getByText('Strong effect')).toBeDefined()
   })
 })

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -34,7 +34,7 @@ import { EdgeEditPopover } from './EdgeEditPopover'
 import { useCanvasStore } from '../store'
 import { isGraphLensEnabled } from '../../flags'
 import { isEdgeFragile as isEdgeFragileFn, getFragileEdgeSwitchProbability, isTopFragileEdge as isTopFragileEdgeFn } from '../utils/fragileEdgeMatch'
-import { existenceCertaintyToLineStyle, calculateEdgeImportance, importanceToStrokeWidth, weightMagnitudeToStrokeWidth } from '../utils/graphDisplayCalculations'
+import { existenceCertaintyToLineStyle, calculateEdgeImportance, weightMagnitudeToStrokeWidth } from '../utils/graphDisplayCalculations'
 import { typography } from '../../styles/typography'
 import { getStrengthDescription, getProvenanceLabel } from '../ui/inspector-v2/inspectorStrings'
 import { useEdgeEditHint } from '../hooks/useFirstTimeHints'
@@ -222,58 +222,18 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     [weight, style, curvature, selected, isDark]
   )
 
-  // Task A: Edge thickness based on importance (Results) or weight magnitude (Edit)
-  const edgeStrokeWidth = useMemo(() => {
-    if (!isResultsMode || !report) {
-      // D.1: Pre-run mode — stroke width encodes weight magnitude
-      return weightMagnitudeToStrokeWidth(computeSignedMean(edgeData as Record<string, unknown> | undefined))
-    }
-
-    // Get factor_sensitivity data
-    const factorSensitivity = report.enrichment?.sensitivity_analysis?.factors ||
-                             report.factor_sensitivity ||
-                             []
-
-    if (factorSensitivity.length === 0) {
-      return visualProps.strokeWidth // Fallback: no sensitivity data
-    }
-
-    // Find the source node's elasticity (goal_sensitivity)
-    // Fix 4: For edges from non-factor nodes (Outcome/Risk/Goal), use elasticity=1.0 fallback
-    const sourceFactor = factorSensitivity.find((f: any) => {
-      const factorId = f.factor_id || f.factorId || f.node_id || f.nodeId
-      return factorId === source
-    })
-    const goalSensitivity = sourceFactor ?
-      Math.abs(sourceFactor.elasticity ?? sourceFactor.sensitivity_score ?? sourceFactor.importance_score ?? 0) :
-      1.0 // Fallback for non-factor nodes: use 1.0 to provide meaningful variation based on belief×strength
-
-    // Calculate importance for this edge
-    const belief = edgeData?.beliefExists
-    const strength = weight // edge weight represents causal strength
-    const importance = calculateEdgeImportance(belief, strength, goalSensitivity)
-
-    // Get all edges to find max importance
-    const allEdges = getEdges()
-    const importances = allEdges.map(edge => {
-      const edgeSource = edge.source
-      const edgeData = edge.data as EdgeData | undefined
-      const sourceFactor = factorSensitivity.find((f: any) => {
-        const factorId = f.factor_id || f.factorId || f.node_id || f.nodeId
-        return factorId === edgeSource
-      })
-      const goalSens = sourceFactor ?
-        Math.abs(sourceFactor.elasticity ?? sourceFactor.sensitivity_score ?? sourceFactor.importance_score ?? 0) :
-        1.0 // Fix 4: Fallback for non-factor edges
-      const belief = edgeData?.beliefExists
-      const strength = edgeData?.weight ?? 0.5 // Aligned with DEFAULT_EDGE_DATA.weight
-      return calculateEdgeImportance(belief, strength, goalSens)
-    })
-    const maxImportance = Math.max(...importances, 0)
-
-    // Map to stroke width (1-8px range)
-    return importanceToStrokeWidth(importance, maxImportance)
-  }, [isResultsMode, report, source, edgeData?.beliefExists, weight, getEdges, edgeData?.direction])
+  // P2.9: Stroke width encodes WEIGHT MAGNITUDE in BOTH phases. Previously it
+  // switched meaning — |strength.mean| pre-run, composite importance
+  // (belief × strength × goal_sensitivity) post-run — so the one visual a user
+  // learns pre-run silently re-scaled the moment results arrived. Width is now
+  // the stable, learnable channel; post-run importance is already surfaced via
+  // the edge label, the top-3 auto-labels, and the #451 projection halo, so it
+  // no longer needs to hijack thickness. (Deliberate, Paul-approved encoding
+  // change — see PR body.)
+  const edgeStrokeWidth = useMemo(
+    () => weightMagnitudeToStrokeWidth(computeSignedMean(edgeData as Record<string, unknown> | undefined)),
+    [edgeData]
+  )
 
   // F.2 + E1: direction-based stroke colour (see directionStroke.ts for the
   // CVD-aware polarity palette and the ΔE rationale). Applies pre-run and
@@ -706,20 +666,18 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
             }
             return isHighlightedEdge ? 'var(--semantic-info)' : (directionStroke ?? visualProps.stroke)
           })(),
-          // Graph Lens: opacity for dimmed edges
-          // Graph Editing Experience Task 9b: Confidence opacity layered on top
-          // Structural edges always full opacity (no exists_probability gating).
+          // Opacity is a lens-only channel now. exists_probability is a SINGLE
+          // encoding — the dash (existenceCertaintyDash above), which stays
+          // legible at every zoom level and doesn't fight the analysis halo.
+          // The former Task 9b belief→opacity coupling was dropped (P2.9): two
+          // channels for one variable is exactly the encoding overload the
+          // audit flags, and a dimmed edge collided with lens dimming and the
+          // projection halo. Opacity therefore returns to a constant except for
+          // the lens's own dim/sensitivity states. Structural edges: full opacity.
           opacity: isStructuralEdge ? undefined
             : isLensDimmed ? 0.2
             : (lensMode === 'sensitivity' && lensSensWeight !== null && lensQ25 !== null && lensSensWeight <= lensQ25) ? 0.4
-            : (() => {
-                // Task 9b: Encode exists_probability as opacity
-                const ep = beliefExists
-                if (ep === undefined || ep === null) return undefined
-                if (ep >= 0.8) return undefined // full opacity (1.0)
-                if (ep >= 0.5) return 0.7
-                return 0.4
-              })(),
+            : undefined,
           // Graph Lens: subtle glow for high-sensitivity edges.
           // Analysis-graph projection: a viewed flip-risk edge gets a WARNING
           // halo (drop-shadow, a separate CSS channel) so the marker composes
@@ -794,9 +752,17 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         </EdgeLabelRenderer>
       )}
 
-      {/* Direction sign indicator: Detailed view, post-analysis only.
-          Structural edges have no semantic direction — exclude defensively. */}
-      {viewMode !== 'standard' && isResultsMode && direction && lensMode !== 'causal' && !isStructuralEdge && (
+      {/* Polarity glyph (+/−): rendered whenever a non-structural edge has a
+          direction — in Standard view AND pre-run, not only Expert+results.
+          directionStroke.ts's docblock is explicit that the glyph, not the
+          green/rose colour, is what carries polarity for a red-green dichromat
+          (the palette separates WORSE than green/red under deuteranopia), so
+          colour-alone polarity pre-run/Standard was a legibility gap. Positioned
+          at the target end (targetX/Y − 18), away from the mid-path label, so it
+          collision-avoids labels exactly as before. Causal lens shows its own
+          numeric parameter label instead. Structural edges have no semantic
+          direction — excluded defensively. */}
+      {direction && lensMode !== 'causal' && !isStructuralEdge && (
         <EdgeLabelRenderer>
           <div
             style={{

--- a/src/canvas/edges/__tests__/StyledEdge.encoding.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.encoding.spec.tsx
@@ -1,0 +1,216 @@
+/**
+ * StyledEdge — encoding rationalisation (23-Jul deep-audit P1.8/P2.9).
+ *
+ * Three mechanism pins, one per Paul-approved encoding change:
+ *   1. Polarity glyph (+/−) renders whenever a non-structural edge has a
+ *      direction — in Standard view AND pre-run — not only Expert+results.
+ *      (directionStroke.ts's own docblock: the glyph, not the colour, carries
+ *      polarity for a red-green dichromat; today it only shows Expert+results.)
+ *   2. exists_probability drives a SINGLE channel — the dash — not dash AND
+ *      opacity. Opacity returns to a constant; the belief dash stays.
+ *   3. Stroke width means WEIGHT MAGNITUDE in BOTH phases (stable, learnable),
+ *      never composite importance post-run.
+ *
+ * Harness mirrors StyledEdge.structural.spec.tsx. graphDisplayCalculations is
+ * mocked with DISTINCT width outputs (weightMagnitude=2 ≠ importance=7) so a
+ * width assertion can tell which formula the component chose; the dash mock
+ * reflects the real <0.7 rule so the belief-dash pin is meaningful.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { StyledEdge } from '../StyledEdge'
+import { Position } from '@xyflow/react'
+
+// ── Node kind registry — switched per-test ───────────────────────────────────
+const nodeKinds: Record<string, string> = {}
+
+// ── Mutable store state — overridden per-test ────────────────────────────────
+interface StoreState {
+  viewMode: 'standard' | 'expert'
+  resultsStatus: 'idle' | 'complete'
+  report: unknown
+}
+const storeState: StoreState = { viewMode: 'standard', resultsStatus: 'idle', report: null }
+const setStore = (over: Partial<StoreState>) => Object.assign(storeState, over)
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: ({ style }: any) => <path data-testid="base-edge" style={style} />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) =>
+        nodeKinds[id]
+          ? { id, type: nodeKinds[id], data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 } }
+          : null,
+      getEdges: () => [],
+      getNodes: () =>
+        Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+    }),
+    useStore: (selector: any) =>
+      selector({
+        nodes: Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+      }),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      results: { status: storeState.resultsStatus, report: storeState.report },
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      viewMode: storeState.viewMode,
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+      },
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+// Distinct width outputs so an assertion can tell the two formulas apart;
+// dash reflects the real <0.7 rule so the belief-dash pin is meaningful.
+vi.mock('../../utils/graphDisplayCalculations', () => ({
+  existenceCertaintyToLineStyle: (p: number | undefined) => (p !== undefined && p < 0.7 ? '6,4' : undefined),
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 7,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+vi.mock('../../theme/edges', () => ({ applyEdgeVisualProps: (_: any, props: any) => props }))
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
+  getStrengthDescription: () => 'moderate',
+  getProvenanceLabel: () => '',
+}))
+
+const baseProps = {
+  id: 'e1', source: 'src', target: 'tgt',
+  sourceX: 0, sourceY: 0, targetX: 100, targetY: 100,
+  sourcePosition: Position.Right, targetPosition: Position.Left,
+  selected: false,
+}
+
+const RESULTS_REPORT = {
+  robustness: { fragile_edges: [] },
+  factor_sensitivity: [{ factor_id: 'src', elasticity: 0.5 }],
+}
+
+const styleOf = (container: HTMLElement) =>
+  ((container.querySelector('[data-testid="base-edge"]') as unknown as HTMLElement).style)
+
+describe('StyledEdge — polarity glyph legibility (item 1)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    setStore({ viewMode: 'standard', resultsStatus: 'idle', report: null })
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+  })
+
+  it('renders the + glyph in Standard view, pre-run, for a positive causal edge', () => {
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+    )
+    const glyph = container.querySelector('[aria-label="Effect direction: positive"]')
+    expect(glyph).not.toBeNull()
+    expect(glyph!.textContent).toBe('+')
+  })
+
+  it('renders the − glyph in Standard view, pre-run, for a negative causal edge', () => {
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'negative', beliefExists: 0.8 }} />
+    )
+    const glyph = container.querySelector('[aria-label="Effect direction: negative"]')
+    expect(glyph).not.toBeNull()
+    expect(glyph!.textContent).toBe('−')
+  })
+
+  it('still suppresses the glyph on structural edges (decision→option)', () => {
+    nodeKinds.src = 'decision'
+    nodeKinds.tgt = 'option'
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+    )
+    expect(container.querySelector('[aria-label="Effect direction: positive"]')).toBeNull()
+  })
+})
+
+describe('StyledEdge — belief is a single channel: dash, not opacity (item 2)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    setStore({ viewMode: 'standard', resultsStatus: 'complete', report: RESULTS_REPORT })
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+  })
+
+  it('low exists_probability sets the dash but NEVER dims the edge via opacity', () => {
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.3, confidence: 0.5 }} />
+    )
+    const style = styleOf(container)
+    // Belief still encoded via the dash channel.
+    expect(style.strokeDasharray).toBe('6,4')
+    // Opacity is a constant — never coupled to exists_probability.
+    expect(style.opacity).toBe('')
+  })
+
+  it('high exists_probability also leaves opacity constant (no belief coupling)', () => {
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.9, confidence: 0.5 }} />
+    )
+    expect(styleOf(container).opacity).toBe('')
+  })
+})
+
+describe('StyledEdge — stroke width means weight magnitude in both phases (item 3)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+  })
+
+  it('pre-run: width follows weight magnitude (2), not importance (7)', () => {
+    setStore({ viewMode: 'standard', resultsStatus: 'idle', report: null })
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+    )
+    expect(styleOf(container).strokeWidth).toBe('2')
+  })
+
+  it('post-run: width STILL follows weight magnitude (2), not composite importance (7)', () => {
+    setStore({ viewMode: 'standard', resultsStatus: 'complete', report: RESULTS_REPORT })
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+    )
+    expect(styleOf(container).strokeWidth).toBe('2')
+  })
+})

--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -828,10 +828,14 @@ export const FactorNode = memo((props: NodeProps) => {
           </p>
         )}
 
-        {/* Post-analysis: MetricPills. Lane C4: pass the display model's
-            provenance through so the "I: NN%" pill discloses the basis
-            (set-relative top ≡ 100% vs absolute producer score). */}
-        {isPostAnalysis && (
+        {/* Post-analysis: MetricPills — the Standard-view compact influence/
+            confidence summary. Lane C4: provenance passes through so the pill
+            discloses its basis (set-relative top ≡ 100% vs absolute producer
+            score). P2.9 item 4 (factor-badge de-noise): gated to Standard only —
+            in Detailed the Layer-2 Influence/Confidence bars below carry the same
+            two numbers with more context, so the pills were a duplicate % channel
+            in the densest view. No information is lost; the bars remain. */}
+        {isPostAnalysis && !isDetailed && (
           <MetricPills
             influencePct={influencePct}
             influenceProvenance={displayMetadata.influenceProvenance}

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -730,6 +730,55 @@ describe('FactorNode', () => {
   })
 
   // -------------------------------------------------------------------------
+  // P2.9 item 4 (factor-badge de-noise): the MetricPills influence/confidence
+  // pills are a Standard-view compact summary. In Detailed view the labelled
+  // Influence/Confidence bars (Layer 2) carry the SAME two numbers, so the pills
+  // were a duplicate channel — one of the "three % semantics in identical pill
+  // dress" the audit flagged, doubled in the densest view. They are now gated to
+  // Standard only. "Influence NN%" is a single text node the bar never produces
+  // (the bar renders "Influence" and "NN%" separately), so it uniquely
+  // identifies the pill.
+  // -------------------------------------------------------------------------
+  describe('MetricPills are Standard-only; Detailed shows the bars, not the duplicate pills', () => {
+    const setup = (viewMode: 'standard' | 'expert') => {
+      vi.mocked(useCanvasStore).mockImplementation((selector: any) =>
+        selector({
+          hoveredOptionId: null, nodes: [], edges: [], ceeAnalysisReady: null,
+          results: { status: 'complete', report: null },
+          highlightedNodes: new Set(), dimmedNodeIds: new Set(),
+          goalThreshold: null, goalConstraints: [], viewMode,
+        })
+      )
+      vi.mocked(useNodeDisplayMetadata).mockReturnValue({
+        sensitivityRank: 1, influence: 0.8, influenceProvenance: 'influence_score',
+        confidence: 0.45, inSensitivityAnalysis: true,
+        achievementProbability: null, achievementProbabilityIsModelledBasis: false,
+        stabilityPercentage: null, winRate: null, isResultsMode: true,
+        predictedOutcome: null, valueOfInformation: null, voiRank: null,
+      })
+      renderFactor({ label: 'Salary', type: 'factor', observedState: { value: 0.5 } })
+    }
+
+    it('Standard view: renders the MetricPills influence + confidence pills', () => {
+      setup('standard')
+      expect(screen.getByText('Influence 80%')).toBeDefined()
+      expect(screen.getByText('Confidence 45%')).toBeDefined()
+    })
+
+    it('Detailed view: the duplicate pills are gone; the labelled bars remain', () => {
+      setup('expert')
+      // The pills (single "Influence NN%" / "Confidence NN%" nodes) are suppressed…
+      expect(screen.queryByText('Influence 80%')).toBeNull()
+      expect(screen.queryByText('Confidence 45%')).toBeNull()
+      // …while the Layer-2 bars still carry the numbers (label + value separate).
+      expect(screen.getByText('Influence')).toBeDefined()
+      expect(screen.getByText('Confidence')).toBeDefined()
+      expect(screen.getByText('80%')).toBeDefined()
+      expect(screen.getByText('45%')).toBeDefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Review fix 4: the DETAILED view renders the same display-model number one
   // level up from the pill ('Influence' + DataBar + 'NN%') and had NO basis
   // disclosure at all — the identical misread class the pill fix addressed.


### PR DESCRIPTION
Edge legibility + encoding rationalisation — 23-Jul deep-audit **P1.8 + P2.9**, Paul-approved. Branch cut from `origin/staging` at `c4a3ce11` (the #451 analysis-projection merge); every StyledEdge change composes with its `analysisHighlight` halo. **Not touched:** structural-edge styling, the projection halo/outline (#451), RiskNode.

## What changed (per audit item)

### 1. Polarity glyph (+/−) visible pre-run and in Standard view
Previously the glyph rendered only `viewMode !== 'standard' && isResultsMode`. `directionStroke.ts`'s own docblock is explicit that **the glyph, not the green/rose colour, carries polarity for a red-green dichromat** (the palette measured ΔE2000 11.7 under deuteranopia — *worse* than the green/red it replaced), so pre-run/Standard polarity was colour-only. The gate is now `direction && lensMode !== 'causal' && !isStructuralEdge` — renders in every view and both phases. Same small target-end styling (`targetX/Y − 18`), so it still collision-avoids the mid-path label.

### 2. Belief is a single channel (dash), not dash + opacity
`exists_probability` drove **both** the dash (`existenceCertaintyToLineStyle`) **and** opacity (Task 9b). Kept the **dash** (legible at every zoom, doesn't fight the halo); dropped the opacity coupling — opacity is now a lens-only constant. No spec pinned the old opacity behaviour.

### 3. Stroke width = weight magnitude in BOTH phases  ⚠️ deliberate encoding change
Width was `|strength.mean|` pre-run but **composite importance** (`belief × strength × goal_sensitivity`) post-run — the one visual a user learns pre-run silently re-scaled the moment results arrived. Width now always means **weight magnitude** (`weightMagnitudeToStrokeWidth`, 1.5/2/3px). Post-run importance is already surfaced by the edge label, the top-3 auto-labels, and the #451 projection halo, so it no longer needs to hijack thickness.

**Downstream consumer updated (required for UI honesty):** `CanvasLegendPopover` said "Thickness = influence" with 2/4.5/8px samples — now inaccurate (edges cap at 3px). Relabelled to **"Weak/Moderate/Strong effect"** with **1.5/2/3px** samples matching `weightMagnitudeToStrokeWidth`.

### 4. Factor-badge de-noise
- **(a) three % families already distinguished** — audit §8 P0-4 already made them visibly self-identifying: EdgePills = target **shape-glyph + raise/lower arrow + verbatim label + "link strength"** aria (strength); ConnRow = **"NN% conf."** (belief-exists); MetricPills = spelled **"Influence"/"Confidence"** word (influence/confidence). No per-pill relabel needed.
- **Concrete de-noise:** `MetricPills` gated to **Standard only** (`isPostAnalysis && !isDetailed`). In Detailed the Layer-2 Influence/Confidence **bars** already carry the same two numbers with more context, so the pills were a duplicate % channel in the densest view — removing two of the "three % semantics in identical pill dress" from that view. **No information lost; the bars remain.**
- **(b) no clean low-signal gate — did (a) + de-dup only, and saying so:** the EdgePills row is *deliberately* shown for low-priority factors ("shown for both high- and low-priority factors per wireframe v4 FactorLowPre — the structural cue that conveys relative influence pre-analysis"), and the sensitivity "Key assumption unvalidated" note is already hard-gated at `sensitivityRank <= 2`. Gating either harder would contradict a deliberate design decision.

## No UI-SEM / no flags / no thresholds
Encoding + display only. No new UI-SEM ledger row (introduced no threshold). No feature flags.

## Specs pinning the two deliberately-changed encodings — updated (named)
- `CanvasLegendPopover.spec.tsx` — thickness labels `Weak/Moderate/Strong influence` → `…effect` (item 3).
- `FactorNode.spec.tsx` — **new** describe block pinning MetricPills Standard-only (item 4 de-dup).
- No spec pinned the old belief→opacity or importance-width behaviour (verified by grep across the suite), so nothing else needed updating.

## Verification
- **RED-first pins per mechanism** (new `StyledEdge.encoding.spec.tsx`: glyph-in-Standard/pre-run, opacity-decoupled + dash-retained, width=weight-magnitude post-run; `FactorNode.spec.tsx`: MetricPills Standard-only). Confirmed the 4 pins fail on the original source and pass after, with 3 positive-control tests staying green (structural-suppress, high-belief opacity, pre-run width).
- **Mutation check** in a throwaway `git worktree` off the same base: reverting to original source turns exactly the 4 mechanism pins RED; the positive controls stay green (pins are not vacuous).
- **Typecheck:** CI gate (`tsc -p tsconfig.ci.json`) clean; app-config diff base vs branch = **zero new errors** (2 baseline `ReportV1` errors removed by deleting the importance block).
- **Lint:** 0 errors on changed files.
- **Tests:** 772 passed across the full affected surface (`src/canvas/edges` + `src/canvas/nodes` + legend + `graphDisplayCalculations`).
- **DS/borders guard:** no NET-NEW violations in any changed file (the guard's net-new list is entirely pre-existing `src/components/results/v7/*` drift from the base merge; report-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
