### PR TITLE
fix(goal): success target survives refresh + nudge re-renders post-restore

### DIFF
--- a/src/canvas/hooks/__tests__/useAutosave.staleValueHash.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.staleValueHash.spec.ts
@@ -214,6 +214,51 @@ describe('useAutosave — value-bearing data changes must flip the dirty hash', 
     expect(savedEdge?.data?.direction).toBe('negative')
   })
 
+  it('saves again after a success-target set (setGoalThresholdAndUpdateNode path)', () => {
+    renderHook(() => useAutosave())
+
+    // Baseline save with no target.
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+    // The exact node write GoalThresholdEditor → setGoalThresholdAndUpdateNode
+    // performs when the user sets a success target (no unit): success_threshold +
+    // threshold_source='user' on the goal node. Position, label, kind, id and
+    // goal_threshold_unit all stay identical — none of the fields the legacy hash
+    // covered.
+    act(() => {
+      const s = useCanvasStore.getState()
+      useCanvasStore.setState({
+        nodes: s.nodes.map((n: any) =>
+          n.id === 'goal-1'
+            ? {
+                ...n,
+                data: {
+                  ...n.data,
+                  success_threshold: 20,
+                  threshold_source: 'user',
+                  threshold_confirmed: false,
+                },
+              }
+            : n,
+        ) as any,
+      })
+    })
+
+    advanceOneAutosaveCycle()
+
+    // RED before the fix: the hash ignored success_threshold/threshold_source, the
+    // save was skipped, and localStorage never received the target — on reload the
+    // goal node carries no threshold (live defect, 2026-07-23).
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(2)
+    const lastCall = mockSaveAutosave.mock.calls.at(-1)?.[0] as {
+      nodes: Array<{ id: string; data?: { success_threshold?: number; threshold_source?: string } }>
+    }
+    const savedGoal = lastCall.nodes.find((n) => n.id === 'goal-1')
+    expect(savedGoal?.data?.success_threshold).toBe(20)
+    expect(savedGoal?.data?.threshold_source).toBe('user')
+  })
+
   it('does NOT re-save when nothing changed (dirty-hash guard intact)', () => {
     renderHook(() => useAutosave())
 

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -56,6 +56,13 @@ function computeGraphHash(nodes: any[], edges: any[]): string {
         gtRaw: n.data?.goal_threshold_raw ?? null,
         gtUnit: n.data?.goal_threshold_unit ?? null,
         gtCap: n.data?.goal_threshold_cap ?? null,
+        // The user's own success target (setGoalThresholdAndUpdateNode writes
+        // success_threshold + threshold_source='user'). GoalThresholdEditor passes
+        // no unit, so a target-set changes NONE of the fields above — without
+        // these two the dirty hash never flipped, the autosave was skipped, and
+        // the target never reached localStorage (lost on reload, 2026-07-23).
+        st: n.data?.success_threshold ?? null,
+        ts: n.data?.threshold_source ?? null,
       }))
       .sort((a, b) => a.id.localeCompare(b.id)),
     edges: edges

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -3394,6 +3394,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // Reseed IDs to avoid conflicts
     get().reseedIds(nodes, edges)
 
+    // Re-derive the goal/outcome selection AND the goal-threshold scalar from the
+    // restored graph's own goal node (both computed once). outcomeNodeId is never
+    // persisted; the threshold rides the node's success_threshold
+    // (threshold_source==='user') and must follow it across a refresh, or the V7
+    // goal lens gates 'no_target' post-reload (mirror of the hydrateGraphSlice
+    // fix, live defect 2026-07-23). Returns {null,null} when the goal node carries
+    // no user target — leaving the CEE bare-sync below free to repopulate.
+    const restoredGoalId = firstGoalNodeId(nodes)
+    const restoredGoalThreshold = deriveGoalThresholdFromNode(nodes, restoredGoalId)
+
     // A.7: Suppress direct_graph_edit events during scenario hydration
     set((s) => ({ _externalMutationActive: s._externalMutationActive + 1 }))
     try {
@@ -3431,16 +3441,17 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       draftComposerText: null,
       // Lane 1b/5 review folds: the goal threshold is per-decision — the
       // previous scenario's target must not ride this scenario's runs (the V2
-      // boundary reads it every run; canonical V5 runs default-attach it). The
-      // CEE-sync (bare goal_threshold on analysis_ready ingestion) or a fresh
-      // user commit repopulates the threshold for THIS scenario.
-      goalThreshold: null,
-      goalThresholdRepresentation: null,
+      // boundary reads it every run; canonical V5 runs default-attach it). It is
+      // re-derived (not cleared) from THIS scenario's own goal node below, so a
+      // user's success target survives a refresh; a target-less goal yields
+      // {null,null} and the CEE-sync (bare goal_threshold on analysis_ready
+      // ingestion) or a fresh user commit repopulates it as before.
+      ...restoredGoalThreshold,
       // loadScenario restores ceeAnalysisReady below, but outcomeNodeId is
       // NEITHER persisted NOR restored (review fold: the earlier comment was
       // wrong) — re-derive it to the LOADED graph's goal node so a stale id
       // from the previous scenario cannot collide with a same-id node here.
-      outcomeNodeId: firstGoalNodeId(nodes),
+      outcomeNodeId: restoredGoalId,
     })
 
     // Exit comparison mode when switching scenarios (lives in useComparisonStore as of C3-3)
@@ -4850,6 +4861,15 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // empties the goal selector, nor left stale).
       Object.assign(updates, DECISION_CONTEXT_CLEAR)
       updates.outcomeNodeId = firstGoalNodeId(loaded.nodes)
+      // Re-derive the goal-threshold scalar from the RESTORED goal node so a
+      // user success target survives a refresh. The node's success_threshold
+      // (threshold_source==='user') rides nodes[] and is the durable source of
+      // truth; the scalar is a derived cache. DECISION_CONTEXT_CLEAR above nulled
+      // it — without this re-derive the guest autosave restore path left it null
+      // and the V7 goal lens gated 'no_target' though the node carried a target
+      // (live defect, 2026-07-23). Same helper as undo/redo/delete/reselect;
+      // returns {null,null} when the goal node carries no user target.
+      Object.assign(updates, deriveGoalThresholdFromNode(loaded.nodes, updates.outcomeNodeId))
       // B3: assign the LOADED constraints or null — never leave the previous
       // scenario's in place. DECISION_CONTEXT_CLEAR above already nulled the
       // field; this line is what makes a cold load RESTORE it. The `?? null`

--- a/src/canvas/store/__tests__/goalContextRestore.spec.ts
+++ b/src/canvas/store/__tests__/goalContextRestore.spec.ts
@@ -19,6 +19,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useCanvasStore } from '../../store'
 import { useGoalNodeActions } from '../../components/GoalNodeSelector'
+import * as scenarios from '../scenarios'
 
 const goalNode = (id: string, extra: Record<string, unknown> = {}) => ({
   id,
@@ -219,6 +220,75 @@ describe('P0-1 round 2: goal reselection strips the previous goal producer targe
     expect(s.ceeAnalysisReady?.goal_threshold ?? null).toBeNull()
     expect(s.ceeAnalysisReady?.goal_threshold_raw ?? null).toBeNull()
     expect(s.ceeAnalysisReady?.goal_threshold_unit ?? null).toBeNull()
+  })
+})
+
+// ─── Refresh persistence (live defect 2026-07-23, 15d60a0c) ────────────────
+//
+// The COMPLEMENT of every case above: there the scalar wrongly OUTLIVED a node
+// that lost its target; here the node KEEPS its user target across a refresh
+// (it rides nodes[] / the persisted scenario graph) but the store scalar was
+// cleared on the previous context and must be RE-DERIVED from the restored
+// node. Before the fix, hydrateGraphSlice and loadScenario cleared goalThreshold
+// (DECISION_CONTEXT_CLEAR) and re-derived only outcomeNodeId — never the scalar
+// — so the V7 goal lens (buildV7Lenses gate: goalThreshold == null → no_target)
+// reported "no target" even though the goal node carried one.
+
+describe('refresh persistence: restore re-derives the goal-threshold scalar from the restored node', () => {
+  beforeEach(() => useCanvasStore.getState().reset())
+
+  it('hydrateGraphSlice (guest autosave restore) adopts a restored user target', () => {
+    useCanvasStore.setState({ goalThreshold: null, goalThresholdRepresentation: null } as never)
+    useCanvasStore.getState().hydrateGraphSlice({
+      nodes: [goalNode('goal_1', { success_threshold: 20, threshold_source: 'user' })] as never,
+      edges: [],
+    })
+    const s = useCanvasStore.getState()
+    // RED before the fix: the scalar stayed null while the node carried 20.
+    expect(s.goalThreshold).toBe(20)
+    expect(s.goalThresholdRepresentation).toBe('raw')
+  })
+
+  it('hydrateGraphSlice with a target-LESS goal node leaves the scalar null', () => {
+    useCanvasStore.getState().hydrateGraphSlice({
+      nodes: [goalNode('goal_1')] as never,
+      edges: [],
+    })
+    const s = useCanvasStore.getState()
+    expect(s.goalThreshold).toBeNull()
+    expect(s.goalThresholdRepresentation).toBeNull()
+  })
+
+  it('hydrateGraphSlice ignores a node-level threshold that is NOT user-set (CEE-only)', () => {
+    // Only a user commit (threshold_source === 'user') is a durable target; a
+    // bare CEE-derived value must not be adopted as the scalar here.
+    useCanvasStore.getState().hydrateGraphSlice({
+      nodes: [goalNode('goal_1', { success_threshold: 20 })] as never,
+      edges: [],
+    })
+    expect(useCanvasStore.getState().goalThreshold).toBeNull()
+  })
+
+  it('loadScenario (logged-in restore) adopts the restored user target', () => {
+    const id = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+    scenarios.saveScenarios([
+      {
+        id,
+        name: 'Refresh scenario',
+        createdAt: 1,
+        updatedAt: 2,
+        graph: {
+          nodes: [goalNode('goal_1', { success_threshold: 20, threshold_source: 'user' })] as never,
+          edges: [],
+        },
+      },
+    ])
+    const ok = useCanvasStore.getState().loadScenario(id)
+    expect(ok).toBe(true)
+    const s = useCanvasStore.getState()
+    // RED before the fix: loadScenario set goalThreshold: null and never re-derived.
+    expect(s.goalThreshold).toBe(20)
+    expect(s.goalThresholdRepresentation).toBe('raw')
   })
 })
 

--- a/src/canvas/store/__tests__/successTargetRefreshPersistence.spec.ts
+++ b/src/canvas/store/__tests__/successTargetRefreshPersistence.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Success-target refresh-persistence — the live defect found 2026-07-23 on
+ * 15d60a0c. A guest sets a success target then reloads; the target is lost.
+ *
+ * Two independent links dropped the value. `setGoalThresholdAndUpdateNode` writes
+ * BOTH the goal node's data.success_threshold (threshold_source='user') AND the
+ * store's goalThreshold scalar (a derived cache of the node field).
+ *
+ *   Link 1 — the node field never reached localStorage. useAutosave's dirty-gate
+ *   (computeGraphHash) did not cover success_threshold/threshold_source, so a
+ *   target-set (which changes nothing else the hash sees) never flipped the hash;
+ *   the 30s autosave was skipped and the node target was never persisted. Pinned
+ *   in useAutosave.staleValueHash.spec.ts.
+ *
+ *   Link 2 — the scalar was never re-derived on restore. hydrateGraphSlice (guest
+ *   autosave restore) and loadScenario (logged-in restore) clear goalThreshold on
+ *   the previous context and re-derive only outcomeNodeId — never the scalar. So
+ *   the V7 goal lens (buildV7Lenses gate: goalThreshold == null → no_target) read
+ *   "no target" even when the node carried one. Pinned in goalContextRestore.spec.
+ *
+ * This spec exercises the REAL save → serialise → load → hydrate round-trip end to
+ * end, and the nudge's gate input (GoalTargetNudge's hasSuccessTarget comes from
+ * computeSuccessState, which reads the goal node's user target).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Node } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import { projectAutosaveData, autosaveSourceFromStore } from '../autosaveProjection'
+import { computeSuccessState } from '../../components/pre-analysis-v3/selectors/computeSuccessState'
+
+const goalNode = (id: string, extra: Record<string, unknown> = {}): Node =>
+  ({ id, type: 'goal', position: { x: 0, y: 0 }, data: { label: id, ...extra } } as Node)
+
+/**
+ * Simulate the exact localStorage round-trip the autosave path performs:
+ * store → autosaveSourceFromStore → projectAutosaveData → JSON (setItem) →
+ * JSON (getItem). The serialise/parse catches any non-serialisable drift, and
+ * is what loadAutosave hands hydrateGraphSlice.
+ */
+function persistAndReload(): { nodes: Node[]; edges: unknown[] } {
+  const payload = projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState()))
+  return JSON.parse(JSON.stringify(payload)) as { nodes: Node[]; edges: unknown[] }
+}
+
+describe('success target survives a refresh (save → load → hydrate round-trip)', () => {
+  beforeEach(() => useCanvasStore.getState().reset())
+
+  it('persists the node target AND re-derives the goalThreshold scalar', () => {
+    useCanvasStore.setState({ nodes: [goalNode('goal_1')], edges: [], outcomeNodeId: 'goal_1' } as never)
+    // The exact write GoalThresholdEditor performs (no unit).
+    useCanvasStore.getState().setGoalThresholdAndUpdateNode('goal_1', 20)
+
+    const persisted = persistAndReload()
+
+    // Link 1: the node target is in the persisted payload.
+    const savedGoal = persisted.nodes.find((n) => n.id === 'goal_1')
+    expect((savedGoal?.data as Record<string, unknown> | undefined)?.success_threshold).toBe(20)
+    expect((savedGoal?.data as Record<string, unknown> | undefined)?.threshold_source).toBe('user')
+
+    // Fresh page: a new store boots from initialState (null decision context).
+    // reset() clears the graph but deliberately not the scalar, so null it too.
+    useCanvasStore.getState().reset()
+    useCanvasStore.setState({ goalThreshold: null, goalThresholdRepresentation: null } as never)
+    expect(useCanvasStore.getState().goalThreshold).toBeNull()
+
+    useCanvasStore.getState().hydrateGraphSlice({ nodes: persisted.nodes, edges: persisted.edges as never })
+
+    const s = useCanvasStore.getState()
+    const goal = s.nodes.find((n) => n.id === 'goal_1')
+    // node field survived the round-trip
+    expect((goal?.data as Record<string, unknown> | undefined)?.success_threshold).toBe(20)
+    // Link 2: scalar re-derived — this is what the V7 goal lens gates on
+    expect(s.goalThreshold).toBe(20)
+    expect(s.goalThresholdRepresentation).toBe('raw')
+  })
+
+  it('nudge gate reads the restored target as SET → nudge hides (restored-with-target)', () => {
+    useCanvasStore.setState({ nodes: [goalNode('goal_1')], edges: [], outcomeNodeId: 'goal_1' } as never)
+    useCanvasStore.getState().setGoalThresholdAndUpdateNode('goal_1', 20)
+    const persisted = persistAndReload()
+    useCanvasStore.getState().reset()
+    useCanvasStore.setState({ goalThreshold: null, goalThresholdRepresentation: null } as never)
+    useCanvasStore.getState().hydrateGraphSlice({ nodes: persisted.nodes, edges: persisted.edges as never })
+
+    const goal = useCanvasStore.getState().nodes.find((n) => n.id === 'goal_1') ?? null
+    const success = computeSuccessState(goal, null, null)
+    // GoalTargetNudge: !hasGoalNode || hasSuccessTarget → null. isSet===true ⇒ absent.
+    expect(success.isSet).toBe(true)
+    expect(success.rawValue).toBe(20)
+  })
+
+  it('nudge gate reads no restored target as UNSET → nudge renders (restored-no-target)', () => {
+    useCanvasStore.setState({ nodes: [goalNode('goal_1')], edges: [], outcomeNodeId: 'goal_1' } as never)
+    // No target set before the reload.
+    const persisted = persistAndReload()
+    useCanvasStore.getState().reset()
+    useCanvasStore.setState({ goalThreshold: null, goalThresholdRepresentation: null } as never)
+    useCanvasStore.getState().hydrateGraphSlice({ nodes: persisted.nodes, edges: persisted.edges as never })
+
+    const s = useCanvasStore.getState()
+    expect(s.goalThreshold).toBeNull()
+    const goal = s.nodes.find((n) => n.id === 'goal_1') ?? null
+    const success = computeSuccessState(goal, null, null)
+    // hasGoalNode (goal present) && !hasSuccessTarget ⇒ the nudge renders again.
+    expect(success.isSet).toBe(false)
+  })
+})


### PR DESCRIPTION
## The defect (live-verified 2026-07-23 on 15d60a0c)

A guest sets a success target (`goalThreshold` 20 via the #449 nudge → inspector `GoalThresholdEditor` → `setGoalThresholdAndUpdateNode`). On reload, the target is gone: the store scalar is null and the goal node carries no threshold. Only the V7 goal-lens gate communicates the loss.

`setGoalThresholdAndUpdateNode` writes BOTH the goal node's `data.success_threshold` (`threshold_source: 'user'`) AND the `goalThreshold` store scalar. **Two independent links dropped the value.**

## Root cause

**Link 1 — the node target never reached localStorage.** `useAutosave.computeGraphHash` (the 30s autosave dirty-gate) covered value-bearing fields (`observedState`, `interventions`, `goal_threshold_raw/unit/cap`) but **not** `success_threshold`/`threshold_source`. `GoalThresholdEditor` passes no unit, so a target-set flipped **none** of the fields the hash saw → `currentHash === lastSavedHashRef` → the 30s write was skipped → the persisted `nodes[]` never carried the target. (Same class as the 2026-07-11 "reload visual revert" that added the other value-bearing fields but missed the goal target.)

**Link 2 — the scalar was never re-derived on restore.** `hydrateGraphSlice` (guest autosave restore) and `loadScenario` (logged-in restore) both clear `goalThreshold` via `DECISION_CONTEXT_CLEAR` and re-derive only `outcomeNodeId` — but, unlike undo/redo/delete/reselect, **never** re-derived the scalar from the restored goal node. So even when the node field survived, the V7 goal lens (`buildV7Lenses` gate: `goalThreshold == null → 'no_target'`) read "no target".

## The fix

- **`useAutosave.ts`**: add `st: success_threshold` / `ts: threshold_source` to `computeGraphHash` so a target set/clear flips the dirty-gate (extra fields can only cause an extra save, never a missed one).
- **`store.ts` `hydrateGraphSlice` + `loadScenario`**: re-derive `goalThreshold` from the restored goal node via the **existing** `deriveGoalThresholdFromNode(nodes, goalId)` helper — the same one undo/redo/delete/reselect use. Returns `{null, null}` for a target-less or CEE-only node, leaving the CEE bare-sync free to repopulate as before; a restored user target now takes precedence (the CEE sync only writes when `goalThreshold == null`).

The goal **node** is the single source of truth; the scalar is a derived cache — no drift after restore. No new persistence channel, no flags, no defaulting a value in (passthrough), no new UI-SEM (dirty-detection + derived-cache re-hydration, not display transforms). The nudge gate (`computeSuccessState`) already reads the node's user target, so once the node field round-trips it hides with a target and re-renders without one.

## Tests (RED-first, mutation-checked)

- `useAutosave.staleValueHash.spec.ts` — a target-set flips the hash → the autosave fires and persists `success_threshold`.
- `goalContextRestore.spec.ts` — `hydrateGraphSlice` + `loadScenario` re-derive the scalar from a restored user target; target-less / CEE-only nodes leave it null.
- `successTargetRefreshPersistence.spec.ts` (new) — full **save → serialize → load → hydrate** round-trip restores both the node threshold and the scalar; the nudge gate reads SET with a restored target and UNSET without.

Mutation check (throwaway stash of the two fix files): reverting the fix turns exactly the 4 new RED probes red again; restoring turns them green.

## Gates

- `pnpm run typecheck` — clean.
- `pnpm run lint` (changed files) — 0 errors (only pre-existing warnings on lines not touched).
- Targeted vitest — the 3 specs above + 10 regression files (`hydrate.graphSlice`, `decisionContextClear`, `goalThresholdSync`, `goalThreshold.atomic`, `autosave.throttle`, `autosaveProjectionParity`, `computeSuccessState`, `buildV7Lenses`, …) all green.
- `vitest run --changed` — the only failures (47, all in `src/canvas/conversation/__tests__/`) are the **pre-existing** known-broken `useConversation`/`aiPanelTranche1` cluster: **identical count on the untouched baseline** (47 failed | 1743 passed on both), so this change adds **zero** new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)