### PR TITLE
fix(edges): theme-aware polarity-glyph chip (kills the cream hex)

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -779,7 +779,12 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
               fontSize: '16px',
               fontWeight: 700,
               color: direction === 'positive' ? '#059669' : '#dc2626',
-              backgroundColor: '#F4F0EA',
+              // Chip surface = the panel token, matching the sibling edge-label
+              // chips (bg-panel) so it no longer glares on a dark canvas. Inline
+              // CSS-var idiom mirrors the other token refs in this file
+              // (e.g. the leader line's var(--border-default, #d4d4d8)); the
+              // hex is only a var() fallback, not a live literal.
+              backgroundColor: 'var(--bg-panel, #FEFEFE)',
               padding: '0 3px',
               borderRadius: '2px',
             }}


### PR DESCRIPTION
## What

The edge polarity `+`/`−` glyph in `src/canvas/edges/StyledEdge.tsx` carried a pre-existing hardcoded cream chip background (`#F4F0EA`). Since #456 the glyph renders in far more contexts — **Standard view + pre-run**, not just Expert+results — including the **dark canvas**, where the fixed cream chip glares.

This swaps the literal for the panel-surface token the sibling edge-label chips already use, so the glyph chip follows the design-token system instead of a frozen hex.

## The change (one line)

```diff
-              backgroundColor: '#F4F0EA',
+              backgroundColor: 'var(--bg-panel, #FEFEFE)',
```

- **Token chosen:** `--bg-panel` — the canonical canvas panel surface (`tailwind.config.js`: `panel.DEFAULT → rgb(var(--bg-panel-rgb) / <alpha-value>)`; `brand.css`: `--bg-panel-rgb: 254 254 254`). This is exactly what the neighbouring causal/evidence/fragile edge-label chips reference via `bg-panel`, and `brand.css` names "edge labels" as a `bg-panel/95` consumer.
- **Idiom cite:** written in this file's inline CSS-var form `var(--token, #truevalue)`, matching the sibling token refs — the SVG leader line's `stroke="var(--border-default, #d4d4d8)"` (line ~855) and `var(--text-body, #3F3F3E)` / `var(--text-light, #6E6B6B)`. The `#FEFEFE` is the token's true value used only as a var() fallback, not a live literal.
- **Out of scope, untouched:** the direction green/red `color` (`#059669` / `#dc2626`) is documented as a pre-existing direction hex in the file docblock and is not part of this brief.

## Gates

- `pnpm run typecheck` — clean.
- Targeted vitest (`StyledEdge.encoding`, `polarityContrast`, `directionColour`, `StyledEdge.hover`, `StyledEdge.structural`) — 37/37 pass. `vitest run --changed --bail=1` — 56/56 pass. No spec asserts on the glyph background, so the swap is behaviour-neutral.
- `eslint src/canvas/edges/StyledEdge.tsx` — 0 errors (6 pre-existing warnings, none from this line).
- **DS-compliance guard** (`ci:guard:ds`): `production-hex` for `StyledEdge.tsx` **falls 4→3** — the cream literal becomes a `var()` fallback, which the guard excludes (scoping decision #1). **Zero net-new production-hex.** (The guard's only net-new entries are pre-existing `panel-typography-scoped` items in `src/components/results/v7/*`, untouched by this PR.) No separate borders guard exists; the borders rule lives in the same DS guard and the glyph has no border.

Tiny follow-up from #456 (task #16). Draft — not for merge by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)