### PR TITLE
test(envelope): fix envelopeAnalysisWiring isolation (or honest quarantine)

### DIFF
--- a/src/canvas/conversation/__tests__/envelopeAnalysisWiring.spec.ts
+++ b/src/canvas/conversation/__tests__/envelopeAnalysisWiring.spec.ts
@@ -105,6 +105,25 @@ const mockResultsComplete = vi.fn()
 const mockResultsError = vi.fn()
 
 beforeEach(() => {
+  // Pin the V5-orchestrator flag OFF for this spec.
+  //
+  // These tests exercise `handleEnvelope` — the results-store wiring on the
+  // legacy V4/V2 orchestrator path (`callOrchestratorTurn`, which the spec
+  // mocks above). `sendTurn` in useConversation.ts branches FIRST on
+  // `isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR })`:
+  // when that flag is 'true', every turn routes to the V5 exclusive path
+  // (`callV5Turn` in ../../v5/v5Adapter) which this spec does NOT mock —
+  // so the real fetch throws, the turn is classed a transport failure, and
+  // handleEnvelope never runs (all envelope-path spies see 0 calls).
+  //
+  // The flag's value is environment-dependent, which is what made this spec
+  // order/env-dependent: CI sets Supabase env but NOT this flag (undefined →
+  // V4 path → green), while a local fresh-clone lane copies `.env.local`
+  // (needed for Supabase env) which ALSO sets VITE_ENABLE_V5_ORCHESTRATOR=true
+  // → V5 path → red. Pinning the flag here makes the intended V4 path
+  // deterministic regardless of ambient env or sibling env-stub leakage.
+  // afterEach restores via unstubAllEnvs so we never leak 'false' to siblings.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
   mockMapV2ResponseToReportV1.mockClear()
@@ -126,6 +145,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`src/canvas/conversation/__tests__/envelopeAnalysisWiring.spec.ts` fails **10/13 in isolation** (6/13 in some suite orders) in fresh clones on pristine `origin/staging`, yet **passes in CI**. Three independent fresh-clone lanes re-proved the failure this week — pure onboarding tax.

## Root cause (env/flag skew, not a product bug)

The spec exercises `handleEnvelope` — the results-store wiring on the legacy **V4/V2 orchestrator path** (`callOrchestratorTurn`, which it mocks, along with `../../adapters/plot/v2` and `isOrchestratorV2Enabled: () => true`).

But `sendTurn` in `useConversation.ts` branches **FIRST** on:

```ts
const v5Eligibility = isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR })
if (v5Eligibility.eligible) { /* callV5Turn — the exclusive V5 path */ }
```

When `VITE_ENABLE_V5_ORCHESTRATOR === 'true'`, every turn routes to `callV5Turn` (`../../v5/v5Adapter`), which this spec does **not** mock. The real `fetch` throws in the test env, the turn is classified a **transport failure** (`buildTransportFailureCopy`, `network: true` — the visible symptom is the assistant message "Your message didn't reach the server…"), and `handleEnvelope` never runs. So every envelope-path spy (`resultsComplete`, `resultsError`, `mapV2ResponseToReportV1`) registers **0 calls** → the 10 failures.

**Why CI is green but local is red:**
- **CI** (`staging-full-tests.yml`) sets `VITE_SUPABASE_URL/ANON_KEY` but leaves `VITE_ENABLE_V5_ORCHESTRATOR` **undefined** → `isV5Eligible` false → mocked V4 path → green.
- **Local fresh-clone lane** copies the user's `.env.local` (required — without Supabase env the spec can't even collect: `src/lib/supabase.ts` hits `isE2EEnabled()`, absent from the spec's `flags` mock). That same `.env.local` sets `VITE_ENABLE_V5_ORCHESTRATOR=true` → unmocked V5 path → red.
- **Order-dependence (6 vs 10):** sibling specs `vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', …)` and `vi.unstubAllEnvs()` on the same flag; `unstubEnvs` is not set in `vitest.config.ts`, so whichever stub is in effect when the envelope spec runs shifts how many of its tests take the mocked path.

## Fix (real fix, not quarantine)

Pin the flag OFF for this spec so the intended V4 path is deterministic regardless of ambient env or sibling env-stub leakage:

- `beforeEach`: `vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')`
- `afterEach`: `vi.unstubAllEnvs()` (good citizen — never leaks `'false'` to siblings)

No product code changes; the spec keeps testing exactly what it was written to test (`handleEnvelope` on the V4/rollback path).

## Positive control / verification

- **Isolation:** 13/13 pass (was 10 fail / 3 pass).
- **In-suite:** 13/13 with flag-stubbing siblings (`conversation-flow`, `buildErrorMessage`) in both orders.
- **Mutation control:** flipping the stub to `'true'` reproduces the **exact** pristine failure (10 fail / 3 pass), isolating the stub line as load-bearing.
- **Gates:** `pnpm run typecheck` clean · `eslint` clean · `vitest run --changed --bail=1` → 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)