### PR TITLE
refactor(fields): one analytical-fields registry + fail-loud drift guard (trap-12 closure)

### DIFF
--- a/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
+++ b/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * analyticalNodeFields — FAIL-LOUD DRIFT GUARD (trap-12 closure).
+ *
+ * Two hand-maintained field lists drifted apart and each shipped a data-loss bug
+ * the same week: the autosave dirty-gate missed success_threshold/threshold_source
+ * (#457, targets not persisted) and the staleness gate missed probability/impact
+ * (#453, risk edits didn't stale the analysis). Both now derive from ONE registry
+ * (analyticalNodeFields.ts). This guard proves:
+ *
+ *   1. The registry is well-formed (no dupes, every field noted + purposed).
+ *   2. The derived subsets equal the behavioural CONTRACT the two bugs established
+ *      — reported as a NAMED-FIELD symmetric diff, never a bare boolean.
+ *   3. The two real consumers (hasAnalyticalNodeChange / hasAnalyticalEdgeChange for
+ *      'stale'; computeGraphHash for 'persist') actually HONOUR the registry — a
+ *      field flagged for a purpose whose consumer ignores it fails RED.
+ *   4. POSITIVE CONTROL: the same diff + behavioural machinery goes RED on a
+ *      synthetic drift (a dropped field / a cosmetic field), so the green in (2)/(3)
+ *      is load-bearing, not vacuous (traps #11, #13).
+ */
+import { describe, it, expect } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import {
+  NODE_FIELD_REGISTRY,
+  EDGE_FIELD_REGISTRY,
+  deriveFields,
+  PERSIST_NODE_FIELDS,
+  STALE_NODE_FIELDS,
+  PERSIST_EDGE_FIELDS,
+  STALE_EDGE_FIELDS,
+  type AnalyticalFieldSpec,
+} from '../analyticalNodeFields'
+import { ANALYTICAL_NODE_DATA_FIELDS, ANALYTICAL_EDGE_FIELDS, hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from '../analyticalChange'
+import { computeGraphHash } from '../../hooks/useAutosave'
+
+// ---------------------------------------------------------------------------
+// The behavioural CONTRACT — the field sets the two bugs (#453/#457) and the
+// current shipped behaviour require. Kept as an EXACT bidirectional lock: a field
+// added to or removed from the registry MUST be mirrored here deliberately, which
+// is exactly the drift-detection this guard exists to force.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_PERSIST_NODE = [
+  'observedState', 'interventions', 'is_baseline', 'success_threshold',
+  'goal_threshold_raw', 'goal_threshold_unit', 'goal_threshold_cap', 'threshold_source',
+]
+const EXPECTED_STALE_NODE = [
+  'observedState', 'interventions', 'is_baseline', 'success_threshold',
+  'goal_threshold_raw', 'prior', 'kind', 'goalThreshold', 'goal_threshold',
+  'probability', 'impact',
+]
+const EXPECTED_PERSIST_EDGE = ['weight', 'direction', 'strengthStd', 'confidence', 'beliefExists']
+const EXPECTED_STALE_EDGE = [
+  'weight', 'direction', 'strengthStd', 'confidence', 'beliefExists',
+  'beliefStrength', 'belief', 'exists_probability',
+]
+
+/** Symmetric difference reported as named fields — the guard's failure message. */
+function fieldDiff(expected: readonly string[], actual: readonly string[]) {
+  const e = new Set(expected)
+  const a = new Set(actual)
+  return {
+    missing: expected.filter((f) => !a.has(f)), // in contract, absent from registry
+    extra: actual.filter((f) => !e.has(f)), // in registry, absent from contract
+  }
+}
+
+const NO_DIFF = { missing: [], extra: [] }
+
+// ---------------------------------------------------------------------------
+// 1. Well-formedness
+// ---------------------------------------------------------------------------
+
+describe('analyticalNodeFields registry — well-formed', () => {
+  for (const [name, registry] of [
+    ['node', NODE_FIELD_REGISTRY],
+    ['edge', EDGE_FIELD_REGISTRY],
+  ] as const) {
+    it(`${name}: no duplicate field names`, () => {
+      const names = registry.map((f) => f.field)
+      expect(names).toHaveLength(new Set(names).size)
+    })
+    it(`${name}: every field has >=1 purpose and a non-empty note`, () => {
+      for (const spec of registry) {
+        expect(spec.purposes.length, `${spec.field} has no purpose`).toBeGreaterThan(0)
+        expect(spec.note.trim().length, `${spec.field} has no note`).toBeGreaterThan(0)
+      }
+    })
+    it(`${name}: purposes are the known set only`, () => {
+      const known = new Set(['persist', 'stale'])
+      for (const spec of registry) {
+        for (const p of spec.purposes) expect(known.has(p), `${spec.field}: unknown purpose ${p}`).toBe(true)
+      }
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// 2. Derived subsets == behavioural contract (named-field diff)
+// ---------------------------------------------------------------------------
+
+describe('analyticalNodeFields registry — derived subsets match the contract', () => {
+  it('node persist subset', () => {
+    expect(fieldDiff(EXPECTED_PERSIST_NODE, PERSIST_NODE_FIELDS)).toEqual(NO_DIFF)
+  })
+  it('node stale subset', () => {
+    expect(fieldDiff(EXPECTED_STALE_NODE, STALE_NODE_FIELDS)).toEqual(NO_DIFF)
+  })
+  it('edge persist subset', () => {
+    expect(fieldDiff(EXPECTED_PERSIST_EDGE, PERSIST_EDGE_FIELDS)).toEqual(NO_DIFF)
+  })
+  it('edge stale subset', () => {
+    expect(fieldDiff(EXPECTED_STALE_EDGE, STALE_EDGE_FIELDS)).toEqual(NO_DIFF)
+  })
+
+  it('analyticalChange re-exports the registry-derived stale subset (no re-hardcoding)', () => {
+    // Proves the staleness call site truly derives from the registry — if someone
+    // pastes a literal array back into analyticalChange.ts, this fails.
+    expect(ANALYTICAL_NODE_DATA_FIELDS).toEqual(STALE_NODE_FIELDS)
+    expect(ANALYTICAL_EDGE_FIELDS).toEqual(STALE_EDGE_FIELDS)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. The real consumers HONOUR the registry (registry ↔ behaviour tie)
+// ---------------------------------------------------------------------------
+
+/** A value guaranteed to differ from `undefined`/absent for any field. */
+const SENTINEL = { __changed__: true }
+const nodeWith = (data: Record<string, unknown>): Node =>
+  ({ id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data } as Node)
+const edgeWith = (data: Record<string, unknown>): Edge =>
+  ({ id: 'e1', source: 'a', target: 'b', data } as Edge)
+
+describe('analyticalNodeFields registry — staleness consumer honours every stale field', () => {
+  it('hasAnalyticalNodeChange flags a change to each stale node field', () => {
+    for (const field of STALE_NODE_FIELDS) {
+      const changed = hasAnalyticalNodeChange(nodeWith({}), { data: { [field]: SENTINEL } })
+      expect(changed, `stale node field '${field}' not seen by hasAnalyticalNodeChange`).toBe(true)
+    }
+  })
+  it('hasAnalyticalEdgeChange flags a change to each stale edge field', () => {
+    for (const field of STALE_EDGE_FIELDS) {
+      const changed = hasAnalyticalEdgeChange(edgeWith({}), { data: { [field]: SENTINEL } })
+      expect(changed, `stale edge field '${field}' not seen by hasAnalyticalEdgeChange`).toBe(true)
+    }
+  })
+  it('does NOT flag a cosmetic field (proves the probe discriminates — trap #13)', () => {
+    // If this were true, the loop above would pass vacuously.
+    expect(hasAnalyticalNodeChange(nodeWith({}), { data: { description: 'new copy' } })).toBe(false)
+    expect(hasAnalyticalNodeChange(nodeWith({}), { data: { body: 'x' } })).toBe(false)
+  })
+})
+
+describe('analyticalNodeFields registry — persist consumer honours every persist field', () => {
+  it('computeGraphHash flips for a change to each persist node field', () => {
+    for (const field of PERSIST_NODE_FIELDS) {
+      const before = computeGraphHash([nodeWith({})], [])
+      const after = computeGraphHash([nodeWith({ [field]: SENTINEL })], [])
+      expect(after, `persist node field '${field}' does not flip computeGraphHash`).not.toBe(before)
+    }
+  })
+  it('computeGraphHash flips for a change to each persist edge field', () => {
+    for (const field of PERSIST_EDGE_FIELDS) {
+      const before = computeGraphHash([], [edgeWith({})])
+      const after = computeGraphHash([], [edgeWith({ [field]: SENTINEL })])
+      expect(after, `persist edge field '${field}' does not flip computeGraphHash`).not.toBe(before)
+    }
+  })
+  it('computeGraphHash does NOT flip for a cosmetic node field (proves the probe discriminates)', () => {
+    const before = computeGraphHash([nodeWith({})], [])
+    const after = computeGraphHash([nodeWith({ description: 'new copy' })], [])
+    expect(after).toBe(before)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. POSITIVE CONTROLS — the guard's machinery goes RED on a synthetic drift.
+//    (Mutation-proofing: proves 2 & 3 are load-bearing, not vacuous.)
+// ---------------------------------------------------------------------------
+
+describe('analyticalNodeFields registry — positive controls (guard catches drift)', () => {
+  it('fieldDiff names a field DROPPED from the registry (the #453 regression)', () => {
+    // Simulate the exact #453 drift: probability removed from the stale set.
+    const drifted = STALE_NODE_FIELDS.filter((f) => f !== 'probability')
+    const diff = fieldDiff(EXPECTED_STALE_NODE, drifted)
+    expect(diff.missing).toEqual(['probability'])
+    expect(diff.extra).toEqual([])
+    // And it is NOT equal to NO_DIFF — the assertion in (2) would fail RED.
+    expect(diff).not.toEqual(NO_DIFF)
+  })
+
+  it('fieldDiff names a field ADDED to the registry but not to the contract', () => {
+    const drifted = [...STALE_NODE_FIELDS, 'newlyAddedField']
+    const diff = fieldDiff(EXPECTED_STALE_NODE, drifted)
+    expect(diff.extra).toEqual(['newlyAddedField'])
+    expect(diff).not.toEqual(NO_DIFF)
+  })
+
+  it('the behavioural tie catches a stale field NO consumer handles', () => {
+    // Simulate a registry field flagged 'stale' that the consumer ignores. The
+    // loop in (3) does exactly this check; here we prove that check can fail: a
+    // synthetic field absent from ANALYTICAL_NODE_DATA_FIELDS is NOT seen by
+    // hasAnalyticalNodeChange, so it would trip the guard RED.
+    const synthetic: AnalyticalFieldSpec = { field: 'ghostField', purposes: ['stale'], note: 'x' }
+    expect(synthetic.purposes).toContain('stale')
+    expect(hasAnalyticalNodeChange(nodeWith({}), { data: { ghostField: SENTINEL } })).toBe(false)
+  })
+
+  it('deriveFields partitions by purpose (sanity of the derivation itself)', () => {
+    const reg: readonly AnalyticalFieldSpec[] = [
+      { field: 'both', purposes: ['persist', 'stale'], note: 'n' },
+      { field: 'p', purposes: ['persist'], note: 'n' },
+      { field: 's', purposes: ['stale'], note: 'n' },
+    ]
+    expect(deriveFields(reg, 'persist')).toEqual(['both', 'p'])
+    expect(deriveFields(reg, 'stale')).toEqual(['both', 's'])
+  })
+})

--- a/src/canvas/domain/analyticalChange.ts
+++ b/src/canvas/domain/analyticalChange.ts
@@ -14,25 +14,17 @@
  */
 
 import type { Edge, Node } from '@xyflow/react'
+import { STALE_NODE_FIELDS, STALE_EDGE_FIELDS } from './analyticalNodeFields'
 
-export const ANALYTICAL_NODE_DATA_FIELDS = [
-  'observedState', 'interventions', 'is_baseline',
-  'prior', 'kind', 'success_threshold', 'goalThreshold',
-  // goal_threshold_raw is the user-edited goal target (GoalSection inline edit +
-  // inspector); the V2 adapter derives the PLoT goal_threshold from it, so a change
-  // IS analysis-affecting.
-  'goal_threshold_raw', 'goal_threshold',
-  // A risk's defining probability × impact pair (P1.7): both pass through to PLoT
-  // (V2 adapter — not blocklisted) and drive calculateRiskSeverity, so a user edit
-  // must stale the analysis exactly like a factor observedState edit.
-  'probability', 'impact',
-] as const
+// The 'stale' (analysis-affecting) subset now DERIVES from the single
+// analyticalNodeFields registry — the same source the autosave persist dirty-gate
+// derives from. Adding a field there with the 'stale' purpose reaches this consumer
+// automatically; analyticalNodeFields.registry.spec.ts fails loud on any drift.
+// The `probability`/`impact` (risk P1.7, #453) and `success_threshold`/
+// `goal_threshold_raw` (#457) inclusions live in the registry's per-field notes.
+export const ANALYTICAL_NODE_DATA_FIELDS = STALE_NODE_FIELDS
 
-export const ANALYTICAL_EDGE_FIELDS = [
-  'weight', 'direction', 'strengthStd',
-  'confidence', 'beliefExists', 'beliefStrength', 'belief',
-  'exists_probability',
-] as const
+export const ANALYTICAL_EDGE_FIELDS = STALE_EDGE_FIELDS
 
 /** Key-order-insensitive deep equality for small JSON-safe analytical values. */
 export function deepEqual(a: unknown, b: unknown): boolean {

--- a/src/canvas/domain/analyticalNodeFields.ts
+++ b/src/canvas/domain/analyticalNodeFields.ts
@@ -1,0 +1,214 @@
+/**
+ * analyticalNodeFields — the ONE registry of node/edge `data.*` fields that carry
+ * user-meaningful analytical state, with a per-field record of WHICH PURPOSES
+ * consume each field.
+ *
+ * ── Why this file exists (trap-12 closure) ─────────────────────────────────────
+ * Two hand-maintained field lists had silently drifted apart, and BOTH shipped a
+ * user-visible data-loss bug in the same week:
+ *
+ *   • `computeGraphHash` (canvas/hooks/useAutosave.ts) — the autosave dirty-gate.
+ *     It hand-listed the node/edge fields whose change should trigger a save. It
+ *     was missing `success_threshold` / `threshold_source`, so a user's success
+ *     target never flipped the dirty hash → the 30s autosave skipped → the target
+ *     was lost on reload (#457).
+ *
+ *   • `ANALYTICAL_NODE_DATA_FIELDS` (canvas/domain/analyticalChange.ts) — the
+ *     "is this edit analysis-affecting?" staleness gate. It was missing
+ *     `probability` / `impact`, so a risk edit never staled the analysis (#453).
+ *
+ * A list a human must remember to keep in sync WILL drift, and the drift always
+ * reads as green. This registry is the single source of truth; both call sites
+ * DERIVE their subset from it (`deriveFields`), and `analyticalNodeFields.registry.spec.ts`
+ * is the fail-loud drift guard that verifies the real consumers honour it.
+ *
+ * ── The two purposes are OVERLAPPING, not identical ────────────────────────────
+ * They share a large core (observedState, interventions, is_baseline,
+ * success_threshold, goal_threshold_raw; edge weight/direction/…) but each has
+ * legitimately-exclusive members, so the registry records purposes PER FIELD
+ * rather than forcing a single list:
+ *
+ *   • 'persist'  — a change MUST survive a reload (autosave dirty-gate,
+ *                  computeGraphHash). Includes display/provenance metadata
+ *                  (goal_threshold_unit/cap, threshold_source) that is not an
+ *                  analysis input but is still user state that must not be lost.
+ *   • 'stale'    — a change invalidates the current analysis (readiness /
+ *                  freshness overlay: hasAnalyticalNodeChange / hasAnalyticalEdgeChange,
+ *                  and the raw patch-apply path in applyPatch.ts). Excludes
+ *                  cosmetic fields (label, body, description, position, colour),
+ *                  and excludes derived values that are re-computed on restore.
+ *
+ * Structural signals (node id / RF `type` / label / position; edge source/target)
+ * are handled inline by each consumer and are deliberately NOT in this registry —
+ * it enumerates `data.*` fields only.
+ *
+ * ── ⚠ KNOWN persist/stale ASYMMETRIES (behaviour preserved; NOT fixed here) ─────
+ * Some analysis-affecting fields are NOT in the persist gate today — the SAME
+ * class of gap as #457 (an edit to ONLY that field would not flip the autosave
+ * dirty hash). They are flagged `stale`-only below with a "KNOWN GAP" note and
+ * left as-is so this refactor preserves both behaviours exactly. Candidates for a
+ * follow-up: node `probability`, `impact`, `prior`; edge `beliefStrength`,
+ * `belief`, `exists_probability`. Making the registry surface these openly is the
+ * point of the exercise.
+ */
+
+export type AnalyticalFieldPurpose = 'persist' | 'stale'
+
+export interface AnalyticalFieldSpec {
+  /** The `data.*` key on the node or edge. */
+  readonly field: string
+  /** Which consumers must react to a change of this field. At least one. */
+  readonly purposes: readonly AnalyticalFieldPurpose[]
+  /** WHY this field matters + which consumers read it. Required, non-empty. */
+  readonly note: string
+}
+
+// ---------------------------------------------------------------------------
+// Node data fields
+// ---------------------------------------------------------------------------
+
+export const NODE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
+  {
+    field: 'observedState',
+    purposes: ['persist', 'stale'],
+    note: "A factor/outcome's observed value+baseline+std — the core analysis input. CEE set_factor_value merges here. Consumers: staleness (hasAnalyticalNodeChange), autosave dirty-gate (computeGraphHash), V2 adapter extractObservedState → PLoT.",
+  },
+  {
+    field: 'interventions',
+    purposes: ['persist', 'stale'],
+    note: "An option's per-factor intervention values — define what the option does. Consumers: staleness, autosave, V2 adapter.",
+  },
+  {
+    field: 'is_baseline',
+    purposes: ['persist', 'stale'],
+    note: 'Marks the baseline option; flips the analysis framing. Consumers: staleness, autosave.',
+  },
+  {
+    field: 'success_threshold',
+    purposes: ['persist', 'stale'],
+    note: "The user's success target on the goal node (written with threshold_source='user'). #457 root cause when it was missing from persist. Consumers: staleness, autosave, V2 adapter goal_threshold derivation, goal lens.",
+  },
+  {
+    field: 'goal_threshold_raw',
+    purposes: ['persist', 'stale'],
+    note: 'User-edited raw goal target; the V2 adapter derives the PLoT goal_threshold from it, so a change is analysis-affecting AND must survive reload. Consumers: staleness, autosave, V2 adapter.',
+  },
+  {
+    field: 'goal_threshold_unit',
+    purposes: ['persist'],
+    note: 'Display/format metadata for the goal target. Must survive reload so the restored target renders identically, but a unit change alone (without a raw change) is not treated as analysis-affecting today. Consumers: autosave.',
+  },
+  {
+    field: 'goal_threshold_cap',
+    purposes: ['persist'],
+    note: 'Cap used to normalise goal_threshold_raw into [0,1] for PLoT; persisted so the raw target re-normalises identically on reload. Not in the staleness set today (a cap change without a raw change is not currently treated as analysis-affecting). Consumers: autosave, V2 adapter normalisation.',
+  },
+  {
+    field: 'threshold_source',
+    purposes: ['persist'],
+    note: "Provenance only ('user' vs auto-synthesised). Pure provenance, not an analysis input — but MUST survive reload (#457: without it a restored user target reads as 'auto'). Consumers: autosave, goal lens / nudge gate.",
+  },
+  {
+    field: 'prior',
+    purposes: ['stale'],
+    note: "A factor's prior belief — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today (a prior-only edit would not trigger an autosave — same class as #457). Behaviour preserved; follow-up candidate. Consumers: staleness.",
+  },
+  {
+    field: 'kind',
+    purposes: ['stale'],
+    note: 'A data-level node kind reclassification. The primary kind signal is the RF `type` field, which both consumers handle structurally; this catches a data.kind-only change for staleness. Persist covers kind via n.type. Consumers: staleness.',
+  },
+  {
+    field: 'goalThreshold',
+    purposes: ['stale'],
+    note: 'camelCase derived goal-threshold cache on the node; analysis-affecting when present, but a derived value that is re-computed on restore, so deliberately not persisted. Consumers: staleness.',
+  },
+  {
+    field: 'goal_threshold',
+    purposes: ['stale'],
+    note: 'snake_case derived/normalised goal threshold; analysis-affecting. Derived and re-computed on restore, so deliberately not persisted. Consumers: staleness, V2 adapter output.',
+  },
+  {
+    field: 'probability',
+    purposes: ['stale'],
+    note: "A risk's likelihood [0,1] — passes through to PLoT (V2 adapter) and drives calculateRiskSeverity. #453 root cause when missing from staleness. ⚠ KNOWN GAP: not in the persist dirty-gate today (top-level node.data field, not nested in observedState — a probability-only edit would not trigger an autosave, same class as #457). Behaviour preserved; follow-up candidate. Consumers: staleness, RiskPanel, V2 adapter.",
+  },
+  {
+    field: 'impact',
+    purposes: ['stale'],
+    note: "A risk's impact enum (low..critical); with probability drives severity. #453. ⚠ KNOWN GAP: same persist gap as probability. Behaviour preserved; follow-up candidate. Consumers: staleness, RiskPanel.",
+  },
+] as const
+
+// ---------------------------------------------------------------------------
+// Edge data fields
+// ---------------------------------------------------------------------------
+
+export const EDGE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
+  {
+    field: 'weight',
+    purposes: ['persist', 'stale'],
+    note: 'Magnitude of the edge influence. Consumers: staleness (hasAnalyticalEdgeChange), autosave.',
+  },
+  {
+    field: 'direction',
+    purposes: ['persist', 'stale'],
+    note: 'Sign of the edge influence; CEE adjust_edge_strength writes it via updateEdgeData without touching endpoints. Consumers: staleness, autosave.',
+  },
+  {
+    field: 'strengthStd',
+    purposes: ['persist', 'stale'],
+    note: 'Uncertainty (std) on the edge weight. Consumers: staleness, autosave.',
+  },
+  {
+    field: 'confidence',
+    purposes: ['persist', 'stale'],
+    note: 'Edge confidence; also the legacy dirty-gate key (computeGraphHash previously keyed on confidence ?? weight). Consumers: staleness, autosave.',
+  },
+  {
+    field: 'beliefExists',
+    purposes: ['persist', 'stale'],
+    note: 'Probability the edge relationship exists. Consumers: staleness, autosave.',
+  },
+  {
+    field: 'beliefStrength',
+    purposes: ['stale'],
+    note: 'Belief magnitude on the edge — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today. Behaviour preserved; follow-up candidate. Consumers: staleness.',
+  },
+  {
+    field: 'belief',
+    purposes: ['stale'],
+    note: 'Legacy belief scalar — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today. Behaviour preserved; follow-up candidate. Consumers: staleness.',
+  },
+  {
+    field: 'exists_probability',
+    purposes: ['stale'],
+    note: 'snake_case existence probability — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today. Behaviour preserved; follow-up candidate. Consumers: staleness.',
+  },
+] as const
+
+// ---------------------------------------------------------------------------
+// Derivation — the ONLY way a consumer should obtain its field list.
+// ---------------------------------------------------------------------------
+
+/**
+ * The `data.*` field names from `registry` that the given `purpose` consumes,
+ * in registry order. This is the single derivation both call sites use — a new
+ * field added to the registry with the right purpose flag reaches every consumer
+ * automatically, and the drift guard fails loud if a consumer stops honouring it.
+ */
+export function deriveFields(
+  registry: readonly AnalyticalFieldSpec[],
+  purpose: AnalyticalFieldPurpose,
+): readonly string[] {
+  return registry.filter((f) => f.purposes.includes(purpose)).map((f) => f.field)
+}
+
+/** Node `data.*` fields whose change must survive a reload (autosave dirty-gate). */
+export const PERSIST_NODE_FIELDS = deriveFields(NODE_FIELD_REGISTRY, 'persist')
+/** Node `data.*` fields whose change invalidates the analysis (staleness). */
+export const STALE_NODE_FIELDS = deriveFields(NODE_FIELD_REGISTRY, 'stale')
+/** Edge `data.*` fields whose change must survive a reload (autosave dirty-gate). */
+export const PERSIST_EDGE_FIELDS = deriveFields(EDGE_FIELD_REGISTRY, 'persist')
+/** Edge `data.*` fields whose change invalidates the analysis (staleness). */
+export const STALE_EDGE_FIELDS = deriveFields(EDGE_FIELD_REGISTRY, 'stale')

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -21,6 +21,7 @@ import { useCanvasStore } from '../store'
 import { saveAutosave, loadAutosave } from '../store/scenarios'
 import { projectAutosaveData } from '../store/autosaveProjection'
 import type { AutosaveProjectionSource } from '../store/autosaveProjection'
+import { PERSIST_NODE_FIELDS, PERSIST_EDGE_FIELDS } from '../domain/analyticalNodeFields'
 
 const AUTOSAVE_INTERVAL_MS = 30 * 1000 // 30 seconds
 const DEBOUNCE_MS = 500 // Debounce writes to reduce localStorage contention
@@ -39,45 +40,55 @@ const DEBOUNCE_MS = 500 // Debounce writes to reduce localStorage contention
  * PRE-EDIT values — on reload the recovery path could hydrate the stale
  * graph while the server copy was correct (the "reload visual revert").
  * Extra fields here can only cause an extra save, never a missed one.
+ *
+ * The value-bearing `data.*` fields covered here now DERIVE from the single
+ * analyticalNodeFields registry (PERSIST_NODE_FIELDS / PERSIST_EDGE_FIELDS) — the
+ * same source the analysis-staleness gate derives from. This closes the drift that
+ * caused #457 (success_threshold/threshold_source missing here) and is verified by
+ * analyticalNodeFields.registry.spec.ts. Structural signals (id / kind via RF type
+ * / label / position; edge endpoints + the legacy confidence??weight composite)
+ * stay inline — the registry enumerates value-bearing data fields only. The hash is
+ * compared only against itself in-memory (lastSavedHashRef), so the object key names
+ * are immaterial; only the SET of fields covered affects dirty-detection.
+ *
+ * Exported for the drift guard's behavioural cross-check (registry persist fields
+ * must each flip this hash).
  */
-function computeGraphHash(nodes: any[], edges: any[]): string {
+export function computeGraphHash(nodes: any[], edges: any[]): string {
   const canonical = {
     nodes: nodes
-      .map(n => ({
-        id: n.id,
-        kind: n.type ?? n.data?.kind,
-        label: n.data?.label ?? '',
-        x: Math.round(n.position?.x ?? 0),
-        y: Math.round(n.position?.y ?? 0),
-        // Value-bearing node data (see doc comment above).
-        os: n.data?.observedState ?? null,
-        iv: n.data?.interventions ?? null,
-        base: n.data?.is_baseline ?? null,
-        gtRaw: n.data?.goal_threshold_raw ?? null,
-        gtUnit: n.data?.goal_threshold_unit ?? null,
-        gtCap: n.data?.goal_threshold_cap ?? null,
-        // The user's own success target (setGoalThresholdAndUpdateNode writes
-        // success_threshold + threshold_source='user'). GoalThresholdEditor passes
-        // no unit, so a target-set changes NONE of the fields above — without
-        // these two the dirty hash never flipped, the autosave was skipped, and
-        // the target never reached localStorage (lost on reload, 2026-07-23).
-        st: n.data?.success_threshold ?? null,
-        ts: n.data?.threshold_source ?? null,
-      }))
+      .map(n => {
+        const data = (n.data ?? {}) as Record<string, unknown>
+        const analytical: Record<string, unknown> = {}
+        // Value-bearing node data — derived from the persist registry subset.
+        for (const field of PERSIST_NODE_FIELDS) analytical[field] = data[field] ?? null
+        return {
+          id: n.id,
+          kind: n.type ?? n.data?.kind,
+          label: n.data?.label ?? '',
+          x: Math.round(n.position?.x ?? 0),
+          y: Math.round(n.position?.y ?? 0),
+          ...analytical,
+        }
+      })
       .sort((a, b) => a.id.localeCompare(b.id)),
     edges: edges
-      .map(e => ({
-        from: e.source,
-        to: e.target,
-        weight: e.data?.confidence ?? e.data?.weight ?? '',
+      .map(e => {
+        const data = (e.data ?? {}) as Record<string, unknown>
+        const analytical: Record<string, unknown> = {}
         // Value-bearing edge data — adjust_edge_strength writes these via
-        // updateEdgeData without touching the endpoints.
-        w: e.data?.weight ?? null,
-        dir: e.data?.direction ?? null,
-        conf: e.data?.confidence ?? null,
-        be: e.data?.beliefExists ?? null,
-        std: e.data?.strengthStd ?? null,
-      }))
+        // updateEdgeData without touching the endpoints. Derived from the persist
+        // registry subset.
+        for (const field of PERSIST_EDGE_FIELDS) analytical[field] = data[field] ?? null
+        return {
+          from: e.source,
+          to: e.target,
+          // Legacy composite (redundant with weight/confidence above, kept to
+          // preserve the exact dirty-detection behaviour).
+          weight: e.data?.confidence ?? e.data?.weight ?? '',
+          ...analytical,
+        }
+      })
       .sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to)),
   }
   return JSON.stringify(canonical)


### PR DESCRIPTION
## Why

Two hand-maintained node/edge field lists had silently drifted apart, and **each shipped a user-visible data-loss bug the same week**:

- **`computeGraphHash`** (`src/canvas/hooks/useAutosave.ts`) — the autosave dirty-gate — was missing `success_threshold`/`threshold_source`, so a user's success target never flipped the dirty hash and was lost on reload (**#457**).
- **`ANALYTICAL_NODE_DATA_FIELDS`** (`src/canvas/domain/analyticalChange.ts`) — the analysis-staleness gate — was missing `probability`/`impact`, so a risk edit never staled the analysis (**#453**).

A list a human must remember to sync WILL drift, and the drift always reads as green (trap-12).

## What

**One registry** — `src/canvas/domain/analyticalNodeFields.ts` — records, per `data.*` field, **which purposes consume it**:
- `persist` — a change must survive a reload (autosave dirty-gate).
- `stale` — a change invalidates the analysis (readiness / freshness overlay).

Both call sites now `deriveFields(...)` their subset from it.

### Same-concept-or-not verdict: **two OVERLAPPING concepts, not one**

They share a large core, but each has legitimately-exclusive members, so the registry keeps **per-field purpose flags** rather than forcing a false single list:
- **persist-only**: `goal_threshold_unit`, `goal_threshold_cap`, `threshold_source` — display/provenance metadata that must survive reload but is not an analysis input.
- **stale-only**: `goalThreshold`, `goal_threshold` — derived caches re-computed on restore, so deliberately not persisted; plus `prior`, `probability`, `impact`, `kind`.

### Behaviour preserved exactly

The derived subsets equal the currently-shipped field sets. The registry additionally **surfaces** several analysis-affecting-but-not-persisted fields as `⚠ KNOWN GAP` (node `probability`/`impact`/`prior`; edge `beliefStrength`/`belief`/`exists_probability`) — the same class as #457. These are **flagged for a follow-up, not changed here** (this PR is a behaviour-preserving refactor).

## The fail-loud drift guard

`src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts`:
1. Registry well-formedness (no dupes; every field has a purpose + a note).
2. Derived subsets vs a **named-field contract** — failures report the exact missing/extra fields, never a bare boolean.
3. **Behavioural tie**: the real consumers (`hasAnalyticalNodeChange`/`hasAnalyticalEdgeChange` for `stale`; `computeGraphHash` for `persist`) must honour **every** registry field; cosmetic-field negative controls prove the probes discriminate (trap-13).
4. Positive controls for the diff + behavioural machinery.

### Mutation-proofed (traps #9/#11)
- Dropping `probability` from the registry reproduces **#453 RED** — `node stale subset` fails with `missing: ['probability']`.
- Skipping a persist field in `computeGraphHash` reproduces **#457 RED** — `persist node field 'success_threshold' does not flip computeGraphHash`. (Notably stricter than the existing `staleValueHash` pin, which stays green because it also mutates `threshold_source`.)
Both reverted; all green restored.

## Third-sibling search

No third hand-list of the **same concept class** exists. Ruled out (different concepts, untouched): `RF_NODE_BLOCKLIST` / `V2_NODE_BLOCKLIST` (wire-passthrough strip lists), `UPDATE_FIELD_PRIORITY` (friendlyOperation display ordering), `graphPayload.ts` extractors (wire read helpers).

## Existing pins — green, unmodified

`analyticalChange.risk.spec` · `useAutosave.staleValueHash.spec` · `successTargetRefreshPersistence.spec` all pass unchanged.

## Gates
- `pnpm run typecheck` (tsconfig.ci.json, authoritative): **pass**.
- Targeted vitest (guard + 3 pins): **33/33**. Other consumers (`applyPatch`, `applyV5State`): **51/51**.
- `vitest --changed`: **3185 passed**, 1 pre-existing failure (`envelopeAnalysisWiring.spec.ts`, confirmed failing identically on clean `origin/staging`, unrelated).
- Lint (touched files): 0 errors (2 pre-existing `console.log` warnings, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)