### PR TITLE
fix(persist): analysis-affecting edits survive reload — close the registry's flagged gaps

### DIFF
--- a/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
+++ b/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
@@ -42,6 +42,10 @@ import { computeGraphHash } from '../../hooks/useAutosave'
 const EXPECTED_PERSIST_NODE = [
   'observedState', 'interventions', 'is_baseline', 'success_threshold',
   'goal_threshold_raw', 'goal_threshold_unit', 'goal_threshold_cap', 'threshold_source',
+  // Task #23: analysis-affecting node fields that are user-editable in isolation on
+  // the live path (probability/impact via RiskPanel, prior via FactorExternalPanel)
+  // were flipped INTO persist so an edit touching only them survives reload (#457 class).
+  'prior', 'probability', 'impact',
 ]
 const EXPECTED_STALE_NODE = [
   'observedState', 'interventions', 'is_baseline', 'success_threshold',

--- a/src/canvas/domain/analyticalNodeFields.ts
+++ b/src/canvas/domain/analyticalNodeFields.ts
@@ -42,14 +42,23 @@
  * are handled inline by each consumer and are deliberately NOT in this registry —
  * it enumerates `data.*` fields only.
  *
- * ── ⚠ KNOWN persist/stale ASYMMETRIES (behaviour preserved; NOT fixed here) ─────
- * Some analysis-affecting fields are NOT in the persist gate today — the SAME
- * class of gap as #457 (an edit to ONLY that field would not flip the autosave
- * dirty hash). They are flagged `stale`-only below with a "KNOWN GAP" note and
- * left as-is so this refactor preserves both behaviours exactly. Candidates for a
- * follow-up: node `probability`, `impact`, `prior`; edge `beliefStrength`,
- * `belief`, `exists_probability`. Making the registry surface these openly is the
- * point of the exercise.
+ * ── persist/stale ASYMMETRIES — adjudicated in task #23 (was ⚠ KNOWN GAP) ───────
+ * Six analysis-affecting fields were flagged `stale`-only with a "KNOWN GAP" note:
+ * an edit touching ONLY that field would not flip the autosave dirty hash — the
+ * SAME class of bug as #457. Task #23 adjudicated each PER FIELD on the LIVE path
+ * (honest verification, not a blanket flip):
+ *
+ *   • node `probability`, `impact` (RiskPanel setters, live since #453) and
+ *     `prior` (FactorExternalPanel setPriorRange) are genuinely user-editable IN
+ *     ISOLATION and analysis-affecting → FLIPPED into `persist`. computeGraphHash
+ *     derives PERSIST_NODE_FIELDS from this registry, so the flip reaches it
+ *     automatically (that is the point of #461). Round-trip pinned in
+ *     useAutosave.analysisFieldPersist.spec.ts.
+ *   • edge `beliefStrength`, `belief`, `exists_probability` have NO live editor
+ *     that writes them in isolation (creation-time defaults / the DEAD v1 edge
+ *     inspector / CEE-ingestion that always co-writes the persisted `beliefExists`
+ *     in the same edge rebuild). An uneditable field cannot be lost by an isolated
+ *     edit → deliberately LEFT `stale`-only. See each field's note for the trace.
  */
 
 export type AnalyticalFieldPurpose = 'persist' | 'stale'
@@ -110,8 +119,8 @@ export const NODE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
   },
   {
     field: 'prior',
-    purposes: ['stale'],
-    note: "A factor's prior belief — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today (a prior-only edit would not trigger an autosave — same class as #457). Behaviour preserved; follow-up candidate. Consumers: staleness.",
+    purposes: ['persist', 'stale'],
+    note: "A factor's prior belief range — analysis-affecting AND user-editable in isolation on the live path (External-factor inspector: FactorExternalPanel/FactorExternalEditor setPriorRange → updateNode(data.prior), routed live via InspectorRouter 'factor-external'; also read by the V1 mapper → PLoT). Task #23: FLIPPED into persist — a prior-only edit must survive reload (was the same class as #457). Consumers: staleness, autosave, V1 mapper.",
   },
   {
     field: 'kind',
@@ -130,13 +139,13 @@ export const NODE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
   },
   {
     field: 'probability',
-    purposes: ['stale'],
-    note: "A risk's likelihood [0,1] — passes through to PLoT (V2 adapter) and drives calculateRiskSeverity. #453 root cause when missing from staleness. ⚠ KNOWN GAP: not in the persist dirty-gate today (top-level node.data field, not nested in observedState — a probability-only edit would not trigger an autosave, same class as #457). Behaviour preserved; follow-up candidate. Consumers: staleness, RiskPanel, V2 adapter.",
+    purposes: ['persist', 'stale'],
+    note: "A risk's likelihood [0,1] — user-editable in isolation via RiskPanel (setProbability → updateNode(data.probability), live since #453) and analysis-affecting (drives calculateRiskSeverity; passes to PLoT). It is a top-level node.data field, not nested in observedState. #453 root cause when missing from staleness. Task #23: FLIPPED into persist — a probability-only edit must survive reload (was the same class as #457). Consumers: staleness, autosave, RiskPanel, V2 adapter.",
   },
   {
     field: 'impact',
-    purposes: ['stale'],
-    note: "A risk's impact enum (low..critical); with probability drives severity. #453. ⚠ KNOWN GAP: same persist gap as probability. Behaviour preserved; follow-up candidate. Consumers: staleness, RiskPanel.",
+    purposes: ['persist', 'stale'],
+    note: "A risk's impact enum (low..critical); with probability drives severity. User-editable in isolation via RiskPanel (setImpact → updateNode(data.impact)). #453. Task #23: FLIPPED into persist — an impact-only edit must survive reload (same class as #457). Consumers: staleness, autosave, RiskPanel.",
   },
 ] as const
 
@@ -173,17 +182,17 @@ export const EDGE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
   {
     field: 'beliefStrength',
     purposes: ['stale'],
-    note: 'Belief magnitude on the edge — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today. Behaviour preserved; follow-up candidate. Consumers: staleness.',
+    note: "Belief magnitude on the edge — analysis-affecting. Task #23 adjudication: deliberately NOT persisted — NO live editor writes edge.data.beliefStrength in isolation. It is set only at edge CREATION (DEFAULT_EDGE_DATA default 0.5) and by CEE normalisation in edges.ts; the live edge inspector (EdgePanel → useEdgeMutations) writes weight/direction/strengthStd/beliefExists, never beliefStrength. An uneditable field can't be lost by an isolated edit. Consumers: staleness.",
   },
   {
     field: 'belief',
     purposes: ['stale'],
-    note: 'Legacy belief scalar — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today. Behaviour preserved; follow-up candidate. Consumers: staleness.',
+    note: "Legacy belief scalar — analysis-affecting. Task #23 adjudication: deliberately NOT persisted — the only editor that writes edge.data.belief is the DEAD v1 edge inspector (EdgeInspector/InspectorPanel; InspectorModal hardcodes USE_INSPECTOR_V2=true so the live path is EdgePanel, which writes beliefExists, not belief). No live user editor → no isolated edit to lose. Consumers: staleness.",
   },
   {
     field: 'exists_probability',
     purposes: ['stale'],
-    note: 'snake_case existence probability — analysis-affecting. ⚠ KNOWN GAP: not in the persist dirty-gate today. Behaviour preserved; follow-up candidate. Consumers: staleness.',
+    note: "snake_case existence probability — analysis-affecting. Task #23 adjudication: deliberately NOT persisted — no isolated user editor. It is written ONLY by the CEE ingestion paths (applyPatch/applyDraftResult buildEdge), each of which co-writes beliefExists (a persist field) in the same edge rebuild, so any change already flips the autosave dirty hash; the live user editor (EdgePanel setExistsProbability) writes beliefExists. Consumers: staleness.",
   },
 ] as const
 

--- a/src/canvas/hooks/__tests__/useAutosave.analysisFieldPersist.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.analysisFieldPersist.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * Task #23 — analysis-affecting node edits must survive reload.
+ *
+ * The analyticalNodeFields registry (#461) flagged node `probability`, `impact`
+ * and `prior` as `stale`-only (analysis-affecting) but NOT `persist`: an edit
+ * touching ONLY one of those fields never flipped the autosave dirty hash
+ * (computeGraphHash), so the 30s autosave skipped and localStorage kept the
+ * pre-edit value — the exact class of the #457 lost-target bug. All three are
+ * genuinely user-editable in isolation on the LIVE path:
+ *
+ *   • probability — RiskPanel → setProbability → updateNode(data.probability)
+ *   • impact      — RiskPanel → setImpact      → updateNode(data.impact)
+ *   • prior       — FactorExternalPanel → setPriorRange → updateNode(data.prior)
+ *
+ * Task #23 flips them INTO the persist subset. These are the RED-first round-trip
+ * pins, one per field: edit ONLY that field through the real store edit seam
+ * (updateNode, the chokepoint every panel setter routes through) →
+ *   (1) computeGraphHash flips,
+ *   (2) the next autosave interval FIRES saveAutosave (spy) and the serialized
+ *       node carries the new value,
+ *   (3) a real saveAutosave → loadAutosave round-trip hydrates it back.
+ *
+ * RED before the flip: PERSIST_NODE_FIELDS excludes these fields, so
+ * computeGraphHash ignores them, the save is skipped, and (1)/(2) fail.
+ *
+ * Mutation-check: un-flip any one field in the registry (and its EXPECTED_PERSIST_NODE
+ * mirror) → EXACTLY that field's pins here go RED; the #461 drift guard stays green
+ * (its consumer-tie derives from the registry). See analyticalNodeFields.registry.spec.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { computeGraphHash, useAutosave } from '../useAutosave'
+import { useCanvasStore } from '../../store'
+import type { AutosaveData } from '../../store/scenarios'
+
+// ---------------------------------------------------------------------------
+// Mocks — intercept the localStorage persistence boundary only (same pattern as
+// useAutosave.staleValueHash.spec.ts). The REAL save/load are pulled via
+// importOriginal for the hydrate round-trip.
+// ---------------------------------------------------------------------------
+
+const mockSaveAutosave = vi.fn()
+const mockLoadAutosave = vi.fn()
+
+vi.mock('../../store/scenarios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../store/scenarios')>()
+  return {
+    ...actual,
+    saveAutosave: (...args: unknown[]) => mockSaveAutosave(...args),
+    loadAutosave: (...args: unknown[]) => mockLoadAutosave(...args),
+  }
+})
+
+// The un-mocked persistence functions, for the real hydrate round-trip.
+const realScenarios =
+  await vi.importActual<typeof import('../../store/scenarios')>('../../store/scenarios')
+
+const SCENARIO_ID = 'b1b1b1b1-c2c2-4d3d-8e4e-f5f5f5f5f5f5'
+const AUTOSAVE_INTERVAL_MS = 30 * 1000
+const DEBOUNCE_MS = 500
+
+const RISK_ID = 'risk-1'
+const FACTOR_EXT_ID = 'factor-ext-1'
+
+function seedCanvas() {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      { id: 'goal-1', type: 'goal', position: { x: 400, y: 40 }, data: { kind: 'goal', label: 'Revenue' } },
+      {
+        id: RISK_ID,
+        type: 'risk',
+        position: { x: 40, y: 200 },
+        // Risk node with a settled likelihood/impact — the RiskPanel edit target.
+        data: { kind: 'risk', label: 'Supplier delay', probability: 0.3, impact: 'medium' },
+      },
+      {
+        id: FACTOR_EXT_ID,
+        type: 'factor',
+        position: { x: 40, y: 400 },
+        // External factor with a prior range — the FactorExternalPanel edit target.
+        data: { kind: 'factor', label: 'Market rate', prior: { range_min: 0.4, range_max: 0.8 } },
+      },
+    ] as any,
+    edges: [] as any,
+  })
+}
+
+/** Run one full autosave cycle: interval tick + debounce flush. */
+function advanceOneAutosaveCycle() {
+  act(() => {
+    vi.advanceTimersByTime(AUTOSAVE_INTERVAL_MS)
+  })
+  act(() => {
+    vi.advanceTimersByTime(DEBOUNCE_MS)
+  })
+}
+
+/** Edit ONLY the named field on a node via the real store chokepoint. */
+function editOnlyField(nodeId: string, field: string, value: unknown) {
+  act(() => {
+    useCanvasStore.getState().updateNode(nodeId, { data: { [field]: value } } as any)
+  })
+}
+
+interface FieldCase {
+  field: string
+  nodeId: string
+  value: unknown
+  editor: string
+}
+
+const CASES: FieldCase[] = [
+  { field: 'probability', nodeId: RISK_ID, value: 0.42, editor: 'RiskPanel → setProbability' },
+  { field: 'impact', nodeId: RISK_ID, value: 'high', editor: 'RiskPanel → setImpact' },
+  {
+    field: 'prior',
+    nodeId: FACTOR_EXT_ID,
+    value: { range_min: 0.2, range_max: 0.6 },
+    editor: 'FactorExternalPanel → setPriorRange',
+  },
+]
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockSaveAutosave.mockReset()
+  mockLoadAutosave.mockReset()
+  // No competing tab — the multi-tab guard must not block the write.
+  mockLoadAutosave.mockReturnValue(null)
+  seedCanvas()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('task #23 — analysis-affecting node fields survive reload (persist round-trip)', () => {
+  for (const c of CASES) {
+    describe(`${c.field} (${c.editor})`, () => {
+      it('computeGraphHash flips when ONLY this field changes', () => {
+        const before = computeGraphHash(
+          [{ id: 'n1', type: c.nodeId === RISK_ID ? 'risk' : 'factor', position: { x: 0, y: 0 }, data: {} }],
+          [],
+        )
+        const after = computeGraphHash(
+          [{ id: 'n1', type: c.nodeId === RISK_ID ? 'risk' : 'factor', position: { x: 0, y: 0 }, data: { [c.field]: c.value } }],
+          [],
+        )
+        // RED before the flip: PERSIST_NODE_FIELDS excludes this field, so the
+        // hash object omits it and the two hashes are identical.
+        expect(after, `${c.field} does not flip computeGraphHash`).not.toBe(before)
+      })
+
+      it('the next autosave FIRES and the serialized node carries the new value', () => {
+        renderHook(() => useAutosave())
+
+        // Baseline save with the pre-edit value.
+        advanceOneAutosaveCycle()
+        expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+        editOnlyField(c.nodeId, c.field, c.value)
+        advanceOneAutosaveCycle()
+
+        // RED before the flip: the hash ignores this field, the save is skipped,
+        // and localStorage keeps the pre-edit value (the reload revert).
+        expect(mockSaveAutosave, `${c.field}-only edit did not trigger a re-save`).toHaveBeenCalledTimes(2)
+
+        const saved = mockSaveAutosave.mock.calls.at(-1)?.[0] as AutosaveData
+        const savedNode = saved.nodes.find((n) => n.id === c.nodeId)
+        expect((savedNode?.data as any)?.[c.field]).toEqual(c.value)
+      })
+
+      it('a real saveAutosave → loadAutosave round-trip hydrates the value back', () => {
+        renderHook(() => useAutosave())
+        advanceOneAutosaveCycle()
+        editOnlyField(c.nodeId, c.field, c.value)
+        advanceOneAutosaveCycle()
+
+        // The exact payload the mocked spy captured is what the store would
+        // persist. Push it through the REAL localStorage seam and read it back.
+        const payload = mockSaveAutosave.mock.calls.at(-1)?.[0] as AutosaveData
+        expect(payload, `${c.field}: no autosave payload was produced`).toBeDefined()
+
+        realScenarios.clearAutosave()
+        realScenarios.saveAutosave(payload)
+        const hydrated = realScenarios.loadAutosave()
+
+        const restored = hydrated?.nodes.find((n) => n.id === c.nodeId)
+        expect((restored?.data as any)?.[c.field]).toEqual(c.value)
+      })
+    })
+  }
+
+  it('control: a cosmetic-only node edit still does NOT re-save (dirty-hash guard intact)', () => {
+    renderHook(() => useAutosave())
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+    // `description` is cosmetic — excluded from PERSIST_NODE_FIELDS. Proves the
+    // pins above discriminate (they are not passing because ANY edit saves).
+    editOnlyField(RISK_ID, 'description', 'new copy')
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What

Closes the persist-gate gaps the #461 analytical-fields registry flagged with `⚠ KNOWN GAP`. Six analysis-affecting node/edge fields were `stale`-only but not in the `persist` subset, so an edit touching **only** one of them never flipped the autosave dirty hash (`computeGraphHash`) → the 30s autosave skipped → the change was lost on reload (the exact class of the #457 lost-target bug; risk probability/impact are live-editable via RiskPanel since #453).

## Per-field adjudication (verified at the bytes on the LIVE path)

**FLIPPED into `persist`** — genuinely user-editable in isolation + analysis-affecting:

| Field | Live editor | Analysis |
|-------|-------------|----------|
| node `probability` | RiskPanel → `setProbability` → `updateNode(data.probability)` (live since #453) | `calculateRiskSeverity`, PLoT |
| node `impact` | RiskPanel → `setImpact` → `updateNode(data.impact)` | risk severity |
| node `prior` | FactorExternalPanel → `setPriorRange` → `updateNode(data.prior)` (InspectorRouter `factor-external`) | staleness + V1 mapper → PLoT |

**LEFT `stale`-only, re-justified** — no live editor writes them in isolation, so an uneditable field can't be lost:

| Field | Why not persisted |
|-------|-------------------|
| edge `beliefStrength` | set only at edge **creation** (`DEFAULT_EDGE_DATA` default) / CEE normalisation; the live `EdgePanel` writes weight/direction/strengthStd/beliefExists, never beliefStrength |
| edge `belief` | the only writer is the **dead** v1 `EdgeInspector`/`InspectorPanel` (`InspectorModal` hardcodes `USE_INSPECTOR_V2=true` → live path is `EdgePanel`, which writes `beliefExists`) |
| edge `exists_probability` | written only by CEE ingestion (`applyPatch`/`applyDraftResult` buildEdge), always **co-writing** the persisted `beliefExists` in the same edge rebuild, so any change already flips the hash |

`computeGraphHash` derives `PERSIST_NODE_FIELDS` from the registry, so the flip reaches the autosave gate automatically (the point of #461). The `#461` drift guard's `EXPECTED_PERSIST_NODE` mirror is updated in lockstep (deliberate membership lock).

## Tests

New `useAutosave.analysisFieldPersist.spec.ts` — RED-first round-trip pins, one per flipped field: edit only that field via the real `updateNode` seam → `computeGraphHash` flips → autosave **fires** (spy) → serialized node carries it → real `saveAutosave`→`loadAutosave` hydrates it back. Plus a cosmetic-only control that must NOT re-save.

**Mutation-checked**: un-flipping any one field (registry flag + its contract mirror) turns **exactly** that field's 3 pins RED (`3 failed | 7 passed`) while the #461 drift guard stays 21/21 GREEN.

## Gates

- `pnpm run typecheck` — clean
- `pnpm run lint` (changed files) — clean
- `vitest --changed --bail=1` — 3681 passed; 1 pre-existing failure (`streamingLifecycle.spec.ts`, unrelated to persist — confirmed identical on clean `origin/staging`)
- new pins + #461 guard + `useAutosave.staleValueHash` + domain/autosave-projection specs — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)