### PR TITLE
test(conversation): deterministic V5-flag isolation for the remaining flaky specs

### DIFF
--- a/src/canvas/conversation/__tests__/analysisInputsReconciliation.spec.ts
+++ b/src/canvas/conversation/__tests__/analysisInputsReconciliation.spec.ts
@@ -109,6 +109,20 @@ const factorNodes = [
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  // Pin the V5-orchestrator flag OFF for this spec (see envelopeAnalysisWiring
+  // .spec.ts / PR #460 for the full rationale). These tests exercise the legacy
+  // V4 turn path (`callOrchestratorTurn`, mocked above) to assert that
+  // `buildRequest` calls `reconcileOptionsWithCanvasNodes` when assembling
+  // `analysis_inputs`. `sendTurn` branches FIRST on
+  // `isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR })`: when the
+  // flag is 'true' every turn routes to the V5 exclusive path (`callV5Turn`)
+  // which this spec does NOT mock — the real fetch throws, the turn is classed a
+  // transport failure, and `callOrchestratorTurn` never fires (mock.calls[0] is
+  // undefined). CI leaves the flag undefined (→ V4 → green); a fresh-clone lane
+  // that copies `.env.local` (which sets VITE_ENABLE_V5_ORCHESTRATOR=true) gets
+  // the V5 path → red. Pinning it here makes the intended V4 path deterministic;
+  // afterEach restores via unstubAllEnvs so nothing leaks to siblings.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
   mockCallTurn.mockResolvedValue({ assistant_text: 'ok', client_turn_id: 'r1' })
@@ -127,6 +141,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/__tests__/analysisInputsWiring.spec.ts
+++ b/src/canvas/conversation/__tests__/analysisInputsWiring.spec.ts
@@ -75,6 +75,14 @@ const mockCeeAnalysisReady: CEEAnalysisReady = {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  // Pin V5-orchestrator flag OFF — same root cause as PR #460 and the three
+  // named specs in this sweep. This spec mocks the legacy V4 turn path
+  // (`callOrchestratorTurn`) but does NOT mock V5; with the fresh-clone
+  // `.env.local` setting VITE_ENABLE_V5_ORCHESTRATOR=true, sendTurn routes every
+  // turn to the unmocked V5 path (`callV5Turn`) → real fetch throws → the V4
+  // spy never fires. Pinning the flag makes the intended V4 path deterministic;
+  // afterEach restores via unstubAllEnvs so nothing leaks to siblings.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
 
@@ -91,6 +99,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/__tests__/envelopeAnalysisPersistence.spec.ts
+++ b/src/canvas/conversation/__tests__/envelopeAnalysisPersistence.spec.ts
@@ -105,6 +105,21 @@ const SCENARIO_ID = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  // Pin the V5-orchestrator flag OFF for this spec (see envelopeAnalysisWiring
+  // .spec.ts / PR #460 for the full rationale). These tests exercise
+  // `handleEnvelope` on the legacy V4 turn path (`callOrchestratorTurn`, mocked
+  // above) to assert the analysis is persisted via `scenarioService.storeAnalysis`.
+  // `sendTurn` branches FIRST on
+  // `isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR })`: when the
+  // flag is 'true' every turn routes to the V5 exclusive path (`callV5Turn`)
+  // which this spec does NOT mock — the real fetch throws, the turn is classed a
+  // transport failure, and handleEnvelope never runs (storeAnalysis sees 0
+  // calls, and the negative-assertion tests pass for the WRONG reason). CI
+  // leaves the flag undefined (→ V4 → green); a fresh-clone lane that copies
+  // `.env.local` (which sets VITE_ENABLE_V5_ORCHESTRATOR=true) gets the V5 path →
+  // red. Pinning it here makes the intended V4 path deterministic; afterEach
+  // restores via unstubAllEnvs so nothing leaks to siblings.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
   mockStoreAnalysis.mockClear()
@@ -123,6 +138,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/__tests__/generateDispatch.spec.ts
+++ b/src/canvas/conversation/__tests__/generateDispatch.spec.ts
@@ -47,6 +47,14 @@ const EMPTY_ENVELOPE = {
 }
 
 beforeEach(() => {
+  // Pin V5-orchestrator flag OFF — same root cause as PR #460 and the three
+  // named specs in this sweep. This spec mocks the legacy V4 turn path
+  // (`callOrchestratorTurn`) but does NOT mock V5; with the fresh-clone
+  // `.env.local` setting VITE_ENABLE_V5_ORCHESTRATOR=true, sendTurn routes every
+  // turn to the unmocked V5 path (`callV5Turn`) → real fetch throws → the V4
+  // spy never fires. Pinning the flag makes the intended V4 path deterministic;
+  // afterEach restores via unstubAllEnvs so nothing leaks to siblings.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
 
@@ -62,6 +70,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/__tests__/handleEnvelopeArbitration.spec.ts
+++ b/src/canvas/conversation/__tests__/handleEnvelopeArbitration.spec.ts
@@ -76,6 +76,14 @@ vi.mock('../utils/applyPatch', () => ({
 const mockSetCeeAnalysisReady = vi.fn()
 
 beforeEach(() => {
+  // Pin V5-orchestrator flag OFF — same root cause as PR #460 and the three
+  // named specs in this sweep. This spec mocks the legacy V4 turn path
+  // (`callOrchestratorTurn`) but does NOT mock V5; with the fresh-clone
+  // `.env.local` setting VITE_ENABLE_V5_ORCHESTRATOR=true, sendTurn routes every
+  // turn to the unmocked V5 path (`callV5Turn`) → real fetch throws → the V4
+  // spy never fires. Pinning the flag makes the intended V4 path deterministic;
+  // afterEach restores via unstubAllEnvs so nothing leaks to siblings.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
   mockSynthesise.mockReset()
@@ -108,6 +116,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/__tests__/streamingLifecycle.spec.ts
+++ b/src/canvas/conversation/__tests__/streamingLifecycle.spec.ts
@@ -62,6 +62,18 @@ async function* fakeStream(events: OrchestratorStreamEvent[]): AsyncGenerator<Or
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  // Pin the V5-orchestrator flag OFF for this spec (see envelopeAnalysisWiring
+  // .spec.ts / PR #460 for the full rationale). These tests exercise the legacy
+  // V4 STREAMING path (`streamOrchestratorTurn`, mocked above). `sendTurn`
+  // branches FIRST on `isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR })`:
+  // when the flag is 'true' every turn routes to the V5 exclusive path
+  // (`callV5Turn`) which this spec does NOT mock — the real fetch throws, the
+  // turn is classed a transport failure, and `streamOrchestratorTurn` never
+  // fires. CI leaves the flag undefined (→ V4 → green); a fresh-clone lane that
+  // copies `.env.local` (which sets VITE_ENABLE_V5_ORCHESTRATOR=true) gets the
+  // V5 path → red. Pinning it here makes the intended V4 streaming path
+  // deterministic; afterEach restores via unstubAllEnvs so nothing leaks.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
   mockStreamTurn.mockReset()
@@ -80,6 +92,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/conversation/__tests__/useConversation.systemEvents.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.systemEvents.spec.ts
@@ -44,6 +44,14 @@ vi.mock('../../../flags', () => ({
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  // Pin V5-orchestrator flag OFF — same root cause as PR #460 and the three
+  // named specs in this sweep. This spec mocks the legacy V4 turn path
+  // (`callOrchestratorTurn`) but does NOT mock V5; with the fresh-clone
+  // `.env.local` setting VITE_ENABLE_V5_ORCHESTRATOR=true, sendTurn routes every
+  // turn to the unmocked V5 path (`callV5Turn`) → real fetch throws → the V4
+  // spy never fires. Pinning the flag makes the intended V4 path deterministic;
+  // afterEach restores via unstubAllEnvs so nothing leaks to siblings.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')
   vi.useFakeTimers()
   mockCallTurn.mockReset()
   flagValue = true
@@ -60,6 +68,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllEnvs()
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Applies the proven **PR #460** diagnosis+fix pattern to the conversation specs that fail in a **fresh clone** (task #24). Test-only; **no product code changes**.

## Root cause (identical to #460)

The fresh-clone repro copies `~/Documents/GitHub/DecisionGuideAI/.env.local`, which bakes `VITE_ENABLE_V5_ORCHESTRATOR=true`. `sendTurn` in `useConversation.ts` branches on `isV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR })` **first** (`useConversation.ts:3097`): when the flag is `'true'`, **every** turn routes to the V5 exclusive path (`callV5Turn` in `src/v5/v5Adapter`). These specs mock the **legacy V4 path** (`callOrchestratorTurn` / `streamOrchestratorTurn`) but **do not mock V5** — so the real fetch throws, the turn is classed a transport failure, and the mocked V4 spies never fire.

CI leaves the flag undefined (→ V4 path → green), so these reds only surface in a local fresh-clone lane that copies `.env.local` (needed for Supabase env).

## Fix

`vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'false')` in `beforeEach` + `vi.unstubAllEnvs()` in `afterEach`. Purely additive (80 insertions, 0 deletions).

## Per-spec verdict

Each spec was adjudicated individually (not blanket-applied). All exercise the legacy V4/V2 orchestrator path and **do not test V5 behaviour**, so the flag stub (not a `v5Adapter` mock) is the correct fix. Each was mutation-proven: **flipping the stub back to `'true'` reproduces the exact pristine failure count**.

| Spec | Isolated baseline | After fix | Mutation (`'true'`) |
|------|-------------------|-----------|---------------------|
| `streamingLifecycle.spec.ts` | 7 fail / 3 pass | 10 pass | 7 fail / 3 pass ✓ |
| `analysisInputsReconciliation.spec.ts` | 5 fail | 5 pass | 5 fail ✓ |
| `envelopeAnalysisPersistence.spec.ts` | 2 fail / 2 pass | 4 pass | 2 fail / 2 pass ✓ |
| `analysisInputsWiring.spec.ts` | 7 fail | 7 pass | 7 fail ✓ |
| `generateDispatch.spec.ts` | 4 fail / 1 pass | 5 pass | 4 fail / 1 pass ✓ |
| `handleEnvelopeArbitration.spec.ts` | 4 fail | 4 pass | 4 fail ✓ |
| `useConversation.systemEvents.spec.ts` | 7 fail / 4 pass | 11 pass | 7 fail / 4 pass ✓ |

The **three named specs** in the task (streamingLifecycle, analysisInputsReconciliation, envelopeAnalysisPersistence) plus **four additional specs** found by the survey below that were **trivially the same pattern**.

## Survey — other conversation specs mocking the V4 path

Grepped `src/canvas/conversation/__tests__/` for specs mocking `turnService` (`callOrchestratorTurn` / `streamOrchestratorTurn`) without a V5-flag stub, then ran each in isolation in a fresh clone:

- **Fixed here (same pattern, red in fresh clone):** `analysisInputsWiring`, `generateDispatch`, `handleEnvelopeArbitration`, `useConversation.systemEvents`.
- **Already stub the flag (no change):** `conversation-flow`, `useConversation.hook`, `useConversation.reasoning`, plus the #460 reference `envelopeAnalysisWiring`.
- **Mock `turnService` but pass in a fresh clone (NOT the same cause — left untouched):** `buildErrorMessage`, `streamEventParsing`, `useConversation.biasSeamCallSite`, `useConversation.systemEventFailure`, `useConversation.transcriptHonesty504`, `useConversation.v5ErrorRecovery` (this last one properly mocks/tests the V5 path — deliberately excluded, as blanket-applying the flag stub would be wrong).

## Out of scope — one unrelated pre-existing red remains

`aiPanelTranche1.spec.tsx > Item 14 … chip button className includes focus-visible:ring-offset-2` fails in a fresh clone. It is a **SuggestedChips focus-ring CSS-class assertion** — it does not mock `turnService`, is unrelated to the V5 flag, and is a pre-existing known-broken test. **Named, not fixed** (different cause).

## Gates (fresh clone, base `origin/staging` @ `93e5f051`)

- `pnpm run typecheck` — clean
- `npx vitest run --changed --bail=1` — **7 files, 46 tests, all pass**
- `eslint` (7 changed files) — clean
- Full conversation dir: `1679 passed | 1 failed` (the one remaining fail is the unrelated `aiPanelTranche1` above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
