### PR TITLE
fix(v5+nodes): constraint upsert, corner-badge stack, spec env-independence, dead compat removal (Codex P1-3/P1-5/P2-1/P2-2)

### DIFF
--- a/src/canvas/edges/__tests__/StyledEdge.filterCompose.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.filterCompose.spec.tsx
@@ -74,7 +74,11 @@ vi.mock('../../hooks/useFirstTimeHints', () => ({ useEdgeEditHint: () => ({ show
 vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
 // Lens ENABLED so the sensitivity glow branch can fire (the other StyledEdge
 // specs disable it because they exercise non-lens encodings).
-vi.mock('../../flags', () => ({ isGraphLensEnabled: () => true }))
+// Path is '../../../flags' (src/flags) — the module StyledEdge imports. The
+// spec sits one level deeper (edges/__tests__/), so '../../flags' resolved to
+// the non-existent src/canvas/flags and the mock silently no-op'd, leaving
+// these two tests depending on ambient VITE_FEATURE_GRAPH_LENS (Codex P2-1).
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => true }))
 vi.mock('../../utils/fragileEdgeMatch', () => ({
   isEdgeFragile: () => false,
   getFragileEdgeSwitchProbability: () => null,

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -287,12 +287,6 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
           className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-warning border border-canvas"
         />
       )}
-      {/* On-canvas coaching marker: rendered ONLY when a live guidance item names
-          this node (target_object.id). Replaces the permanently-empty CEE/ISL
-          NodeBadge (23-Jul audit G3). Click opens the same guidance surface the
-          inspector uses. */}
-      <NodeCoachingMarker nodeId={id} />
-
       {/* Context menu: Assumption flag badge (Hard rule 3 — UI-only annotation) */}
       {Boolean(data?.flagged_as_assumption) && (
         <div
@@ -343,16 +337,39 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         </div>
       )}
 
-      {/* Sensitivity rank badge — top-right (Results mode, top 3 factors) */}
-      {typeof displayMetadata.sensitivityRank === 'number' && (
-        <span
-          className={`absolute -top-2 -right-2 z-10 ${typography.nodeLabel} font-semibold text-text-body bg-panel-border rounded-full flex items-center justify-center shadow-sm`}
-          style={{ minWidth: '20px', height: '20px', padding: '0 4px', pointerEvents: 'none' }}
-          title={`Key driver #${displayMetadata.sensitivityRank}: ranked by influence on the outcome`}
-        >
-          #{displayMetadata.sensitivityRank}
-        </span>
-      )}
+      {/* Top-right corner STACK — a single absolutely-positioned flex row that
+          OWNS this corner so the sensitivity-rank badge and the coaching marker
+          never collide. Both previously rendered at `absolute -top-2 -right-2
+          z-10`, identical z, so the rank obscured the coaching marker (Codex
+          P1-5, browser-confirmed). They are now static siblings here: rank
+          FIRST (reads "key driver #N"), coaching beside it. The row is anchored
+          by its right edge and grows leftward, keeping both inside the top band
+          (no title overlap) and off the node's right side; siblings never
+          overlap, so both stay visible and the coaching button stays clickable.
+          Each child self-gates, so the container is empty (0×0, inert) when
+          neither applies. */}
+      <div
+        data-testid={`node-corner-stack-${id}`}
+        className="absolute -top-2 -right-2 z-10 flex items-center gap-1"
+      >
+        {/* Sensitivity rank badge — Results mode, top 3 factors. */}
+        {typeof displayMetadata.sensitivityRank === 'number' && (
+          <span
+            data-testid={`sensitivity-rank-${id}`}
+            className={`${typography.nodeLabel} font-semibold text-text-body bg-panel-border rounded-full flex items-center justify-center shadow-sm`}
+            style={{ minWidth: '20px', height: '20px', padding: '0 4px', pointerEvents: 'none' }}
+            title={`Key driver #${displayMetadata.sensitivityRank}: ranked by influence on the outcome`}
+          >
+            #{displayMetadata.sensitivityRank}
+          </span>
+        )}
+
+        {/* On-canvas coaching marker — renders ONLY when a live guidance item
+            names this node (target_object.id). Replaces the permanently-empty
+            CEE/ISL NodeBadge (23-Jul audit G3). Click opens the same guidance
+            surface the inspector uses. */}
+        <NodeCoachingMarker nodeId={id} />
+      </div>
 
       {/* Node header — shape + title on same row (spec Section 3.2) */}
       {!isCausalLens && (

--- a/src/canvas/nodes/__tests__/BaseNode.cornerStack.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.cornerStack.spec.tsx
@@ -1,0 +1,182 @@
+/**
+ * BaseNode — top-right corner STACK (Codex P1-5).
+ *
+ * The sensitivity-rank badge and the on-canvas coaching marker both used to
+ * render at `absolute -top-2 -right-2 z-10` with identical z, so a ranked node
+ * that also had a coaching item drew the rank OVER the coaching marker (Paul's
+ * screenshot: the "#1" slot obscured the coaching badge). The fix routes both
+ * through ONE absolutely-positioned flex container that owns the corner; the
+ * two render as static flex siblings, so they can no longer occupy the same
+ * point.
+ *
+ * These pins assert STRUCTURE (jsdom cannot measure pixels — see the honesty
+ * note on the non-overlap test):
+ *   - both present  → both rendered, inside the shared stack, rank first, and
+ *                     neither child carries its own absolute/offset classes
+ *                     (the layout-relevant signal that they can't self-collide)
+ *   - each alone    → renders in its place inside the stack
+ *   - click-through → the coaching button's onClick still fires with the rank
+ *                     badge present (it is a sibling, never covered)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { DecisionNode } from '../DecisionNode'
+import { useGuidanceStore, type GuidanceItem } from '../../stores/guidanceStore'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+// Hoisted so the vi.mock factory (also hoisted) can close over these spies.
+const { selectNodeWithoutHistory, setShowInspectorPanel } = vi.hoisted(() => ({
+  selectNodeWithoutHistory: vi.fn(),
+  setShowInspectorPanel: vi.fn(),
+}))
+
+vi.mock('../../store', () => {
+  const state = {
+    edges: [],
+    nodes: [],
+    results: { status: 'complete', report: null },
+    highlightedNodes: new Set(),
+    dimmedNodeIds: new Set(),
+    editedSinceRunNodeIds: new Set(),
+    analysisHighlight: { source: null, edgeIds: new Set(), nodeIds: new Set() },
+    lens: { _dimmedNodeIds: new Set(), _hiddenNodeIds: new Set(), active: 'full' },
+    goalThreshold: null,
+    goalConstraints: [],
+    ceeAnalysisReady: null,
+    lodActive: false,
+    viewMode: 'expert',
+    selectNodeWithoutHistory,
+    setShowInspectorPanel,
+  }
+  const useCanvasStore = vi.fn((selector: (s: unknown) => unknown) => selector(state))
+  ;(useCanvasStore as unknown as { getState: () => unknown }).getState = () => state
+  return { useCanvasStore }
+})
+
+// sensitivityRank drives the rank badge; toggled per test.
+let sensitivityRank: number | null = null
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    stabilityPercentage: null,
+    winRate: null,
+    isResultsMode: false,
+    predictedOutcome: null,
+    valueOfInformation: null,
+    voiRank: null,
+  })),
+}))
+
+const baseProps = {
+  id: 'node-a',
+  type: 'decision',
+  position: { x: 0, y: 0 },
+  selected: false,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+  data: { label: 'Should we hire?', type: 'decision' },
+}
+
+function makeItem(overrides: Partial<GuidanceItem> = {}): GuidanceItem {
+  return {
+    item_id: 'item-1',
+    category: 'should_fix',
+    source: 'structural',
+    title: 'Review this node',
+    priority: 50,
+    primary_action: { type: 'discuss', prompt: 'Let us discuss.' },
+    target_object: { type: 'node', id: 'node-a' },
+    ...overrides,
+  }
+}
+
+const renderNode = () =>
+  render(
+    <ReactFlowProvider>
+      <DecisionNode {...(baseProps as never)} />
+    </ReactFlowProvider>,
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sensitivityRank = null
+  useGuidanceStore.getState().clearGuidanceItems()
+})
+
+describe('BaseNode — top-right corner stack (rank + coaching)', () => {
+  it('BOTH present: rank and coaching render inside ONE stack, rank first, no overlapping offsets', () => {
+    sensitivityRank = 1
+    useGuidanceStore.getState().setGuidanceItems([makeItem()])
+    renderNode()
+
+    const stack = screen.getByTestId('node-corner-stack-node-a')
+    const rank = screen.getByTestId('sensitivity-rank-node-a')
+    const coaching = screen.getByTestId('node-coaching-marker-node-a')
+
+    // Both live inside the single positioned container.
+    expect(stack).toContainElement(rank)
+    expect(stack).toContainElement(coaching)
+
+    // Deterministic order: rank FIRST, coaching beside it.
+    const kids = Array.from(stack.children)
+    expect(kids[0]).toBe(rank)
+    expect(kids[1]).toBe(coaching)
+
+    // The STACK owns the corner + z; children carry NO absolute/offset of their
+    // own, so they cannot independently land on the same point. jsdom cannot
+    // prove pixels — this asserts the layout-relevant class contract that makes
+    // a same-corner overlap structurally impossible (true-pixel spacing is a
+    // browser concern, verified separately).
+    expect(stack.className).toContain('absolute')
+    expect(stack.className).toContain('-top-2')
+    expect(stack.className).toContain('-right-2')
+    expect(stack.className).toContain('z-10')
+    expect(stack.className).toContain('flex')
+    expect(rank.className).not.toContain('absolute')
+    expect(coaching.className).not.toContain('absolute')
+    expect(coaching.className).not.toContain('-right-2')
+  })
+
+  it('RANK alone: rank badge renders in the stack, no coaching marker', () => {
+    sensitivityRank = 2
+    renderNode()
+    const stack = screen.getByTestId('node-corner-stack-node-a')
+    expect(stack).toContainElement(screen.getByTestId('sensitivity-rank-node-a'))
+    expect(screen.queryByTestId('node-coaching-marker-node-a')).not.toBeInTheDocument()
+  })
+
+  it('COACHING alone: coaching marker renders in the stack, no rank badge', () => {
+    sensitivityRank = null
+    useGuidanceStore.getState().setGuidanceItems([makeItem()])
+    renderNode()
+    const stack = screen.getByTestId('node-corner-stack-node-a')
+    expect(stack).toContainElement(screen.getByTestId('node-coaching-marker-node-a'))
+    expect(screen.queryByTestId('sensitivity-rank-node-a')).not.toBeInTheDocument()
+  })
+
+  it('CLICK-THROUGH: coaching onClick still fires with the rank badge present', () => {
+    sensitivityRank = 1
+    useGuidanceStore.getState().setGuidanceItems([makeItem({ item_id: 'the-item' })])
+    renderNode()
+
+    // Rank present alongside — the coaching button must remain clickable.
+    expect(screen.getByTestId('sensitivity-rank-node-a')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('node-coaching-marker-node-a'))
+
+    expect(selectNodeWithoutHistory).toHaveBeenCalledWith('node-a')
+    expect(setShowInspectorPanel).toHaveBeenCalledWith(true)
+    expect(useGuidanceStore.getState().activeGuidanceItemId).toBe('the-item')
+  })
+})

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -473,8 +473,8 @@ describe('FactorNode', () => {
     expect(screen.queryByText('Measurable')).toBeNull()
   })
 
-  // P3: Rank badge in header row
-  it('rank badge renders with absolute positioning (P3)', () => {
+  // P3: Rank badge in the top-right corner stack
+  it('rank badge renders inside the top-right corner stack (P3)', () => {
     vi.mocked(useNodeDisplayMetadata).mockReturnValue({
       sensitivityRank: 1,
       influence: null,
@@ -496,10 +496,15 @@ describe('FactorNode', () => {
     // Badge renders with expected text
     const badge = screen.getByText('#1')
     expect(badge).toBeDefined()
-    // Badge uses absolute positioning (top-right corner of node)
-    expect(badge.className).toContain('absolute')
-    expect(badge.className).toContain('-top-2')
-    expect(badge.className).toContain('-right-2')
+    // Positioning is owned by the shared corner STACK (Codex P1-5), not the
+    // badge itself — that is what stops the rank badge and the coaching marker
+    // colliding in the same corner. The badge is a static flex child.
+    const stack = badge.parentElement!
+    expect(stack.getAttribute('data-testid')).toMatch(/^node-corner-stack-/)
+    expect(stack.className).toContain('absolute')
+    expect(stack.className).toContain('-top-2')
+    expect(stack.className).toContain('-right-2')
+    expect(badge.className).not.toContain('absolute')
     // Category icons removed — science icons replace them
   })
 

--- a/src/canvas/nodes/shared/NodeCoachingMarker.tsx
+++ b/src/canvas/nodes/shared/NodeCoachingMarker.tsx
@@ -95,6 +95,10 @@ export function NodeCoachingMarker({ nodeId }: NodeCoachingMarkerProps) {
       ? `${count} coaching suggestions for this node. Top: ${top.title}`
       : `Coaching suggestion: ${top.title}`
 
+  // Positioning is owned by BaseNode's top-right corner STACK — this marker
+  // renders as a static flex child there (alongside the sensitivity-rank badge)
+  // so the two never collide (Codex P1-5). It carries no `absolute`/offset of
+  // its own; only its intrinsic pill styling.
   return (
     <button
       type="button"
@@ -106,7 +110,7 @@ export function NodeCoachingMarker({ nodeId }: NodeCoachingMarkerProps) {
       title={label}
       aria-label={label}
       className={`
-        nodrag nopan absolute -top-2 -right-2 z-10
+        nodrag nopan
         inline-flex items-center gap-0.5 h-5 min-w-5 px-1
         rounded-full bg-panel border ${borderColour} shadow-1
         cursor-pointer hover:scale-110 transition-transform

--- a/src/v5/__tests__/applyV5State.addConstraint.test.ts
+++ b/src/v5/__tests__/applyV5State.addConstraint.test.ts
@@ -6,10 +6,13 @@
  * Wire shape: a graph_patch block with operation 'add_constraint' carries the
  * constrained node in `target_id` and the constraint payload in `after`
  * (untyped Record on the wire). The applicator maps `after` → CEEGoalConstraint
- * and APPENDS it (deduped) to the existing constraints via setGoalConstraints
- * with { fromProducerSync: true } (a producer sync — the response's own
- * analysis_ready.freshness verdict governs staleness, so the write must not
- * self-dirty the freshness overlay).
+ * and UPSERTS it (by constraint id) into the existing constraints via
+ * setGoalConstraints with { fromProducerSync: true } (a producer sync — the
+ * response's own analysis_ready.freshness verdict governs staleness, so the
+ * write must not self-dirty the freshness overlay). A patch that shares the id
+ * of a stored constraint but changes its value/label/unit REPLACES it in place
+ * (CEE edits constraints in place, keeping the id); only a deep-semantic no-op
+ * (all fields equal) writes nothing (P1-3).
  *
  * Operator vocabulary tolerance: `after.operator` may be the schema form
  * ('>=' / '<=') OR the chip form ('at_least' / 'at_most'); node id may be
@@ -163,7 +166,7 @@ describe('applyV5State — add_constraint graph_patch', () => {
     expect(constraints[0].node_id).toBe('goal-node')
   })
 
-  it('IDEMPOTENT: applying the same response twice does not double-append', () => {
+  it('IDEMPOTENT: re-sending a byte-identical constraint writes nothing', () => {
     const store = makeStore(null)
     const response = baseResponse({
       blocks: [
@@ -172,11 +175,88 @@ describe('applyV5State — add_constraint graph_patch', () => {
     })
     applyV5State(response, store)
     const firstArray = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    // second fire: the store now already holds that constraint
+    // second fire: the store now already holds that exact constraint
     const store2 = makeStore(firstArray)
     const result2 = applyV5State(response, store2)
     expect(store2.setGoalConstraints).not.toHaveBeenCalled()
-    expect(result2.deferred.some((d) => d.reason === 'add_constraint_duplicate_skipped')).toBe(true)
+    expect(result2.deferred.some((d) => d.reason === 'add_constraint_noop_skipped')).toBe(true)
+  })
+
+  it('UPSERT: a same-id patch with a changed value REPLACES the stored constraint in place (not appended)', () => {
+    const existing: CEEGoalConstraint = {
+      constraint_id: 'gc-stable',
+      node_id: 'factor-a',
+      operator: '>=',
+      value: 5,
+    }
+    const store = makeStore([existing])
+    const result = applyV5State(
+      baseResponse({
+        blocks: [
+          constraintPatch({
+            constraint_id: 'gc-stable',
+            node_id: 'factor-a',
+            operator: '>=',
+            value: 10,
+          }),
+        ],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).toHaveBeenCalledTimes(1)
+    const [constraints] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    // Replaced in place — still ONE constraint under this id, now value 10.
+    expect(constraints).toHaveLength(1)
+    expect(constraints[0]).toMatchObject({ constraint_id: 'gc-stable', value: 10 })
+    expect(result.applied).toContain('graph_patch:add_constraint:factor-a')
+  })
+
+  it('UPSERT: a same-id label/unit edit (value unchanged) still writes (identity match is not a no-op)', () => {
+    const existing: CEEGoalConstraint = {
+      constraint_id: 'gc-stable',
+      node_id: 'factor-a',
+      operator: '<=',
+      value: 250,
+      label: 'Budget',
+      unit: '£',
+    }
+    const store = makeStore([existing])
+    applyV5State(
+      baseResponse({
+        blocks: [
+          constraintPatch({
+            constraint_id: 'gc-stable',
+            node_id: 'factor-a',
+            operator: '<=',
+            value: 250,
+            label: 'Budget cap',
+            unit: '£',
+          }),
+        ],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).toHaveBeenCalledTimes(1)
+    const [constraints] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(constraints).toHaveLength(1)
+    expect(constraints[0]).toMatchObject({ constraint_id: 'gc-stable', label: 'Budget cap' })
+  })
+
+  it('COALESCE: multiple same-id patches in one turn settle on the LAST write', () => {
+    const store = makeStore(null)
+    applyV5State(
+      baseResponse({
+        blocks: [
+          constraintPatch({ constraint_id: 'gc-x', node_id: 'factor-a', operator: '>=', value: 5 }),
+          constraintPatch({ constraint_id: 'gc-x', node_id: 'factor-a', operator: '>=', value: 12 }),
+        ],
+      }),
+      store,
+    )
+    expect(store.setGoalConstraints).toHaveBeenCalledTimes(1)
+    const [constraints] = (store.setGoalConstraints as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(constraints).toHaveLength(1)
+    expect(constraints[0].value).toBe(12)
   })
 
   it('coalesces multiple add_constraint patches into ONE setGoalConstraints call', () => {

--- a/src/v5/__tests__/applyV5State.test.ts
+++ b/src/v5/__tests__/applyV5State.test.ts
@@ -712,37 +712,13 @@ describe('applyV5State — goal-threshold quad ingestion (ROADMAP 1.22)', () => 
     expect(backfillGoalThreshold).not.toHaveBeenCalled()
   })
 
-  it('ingests goal_constraints from the response root additively', () => {
-    const { store, setGoalConstraints } = makeStore([goalNode])
-    const constraints = [
-      { constraint_id: 'c1', factor_id: 'f1', label: 'Budget', threshold: 100 },
-    ]
-    applyV5State(
-      responseWith(
-        {
-          status: 'ready',
-          goal_node_id: 'goal-1',
-          options: [readyOption],
-        },
-        { goal_constraints: constraints },
-      ),
-      store,
-    )
-    // Producer sync — passes fromProducerSync so the ingestion write does not self-dirty freshness.
-    expect(setGoalConstraints).toHaveBeenCalledWith(constraints, { fromProducerSync: true })
-  })
-
-  it('does not call setGoalConstraints when the response carries none (additive only — no clearing)', () => {
-    const { store, setGoalConstraints } = makeStore([goalNode])
-    applyV5State(
-      responseWith({
-        status: 'ready',
-        goal_node_id: 'goal-1',
-        options: [readyOption],
-      }),
-      store,
-    )
-    expect(setGoalConstraints).not.toHaveBeenCalled()
-  })
+  // NOTE (Codex P2-2): the former "ingests goal_constraints from the response
+  // ROOT" tests were removed with the dead root-level compat leg. responseParser
+  // demotes every unknown top-level key to the non-enumerable `__additive__`
+  // sidecar, so `response.goal_constraints` is never set on a really-parsed
+  // OlumiResponse — the old positive test only passed by fabricating a typed
+  // response that bypassed the parser. Live constraint ingestion is covered by
+  // applyV5State.addConstraint.test.ts (add_constraint graph_patch) and
+  // applyDraftResult.spec.ts / draftGoalConstraints.wire.spec.ts (draft_graph).
 })
 

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -13,9 +13,13 @@
  *   1. stage_indicator → canvas.currentStage
  *   2. graph_patch (applied) → canvas store mutation for set_factor_value,
  *      adjust_edge_strength, and add_constraint. add_constraint maps `after`
- *      into a CEEGoalConstraint and APPENDS it (deduped) to the canvas
- *      `goalConstraints` slice via setGoalConstraints — the SAME slice
- *      GoalPanel's "Add constraint" flow writes. Also: ui_directive verbs
+ *      into a CEEGoalConstraint and UPSERTS it (by constraint id) into the
+ *      canvas `goalConstraints` slice via setGoalConstraints — the SAME slice
+ *      GoalPanel's "Add constraint" flow writes. A patch that carries the
+ *      constraint_id of one already stored REPLACES it in place (CEE edits a
+ *      constraint's value/label/unit while retaining its id — see
+ *      add-constraint.ts); only a deep-semantic no-op (all fields equal after
+ *      normalisation) writes nothing. Also: ui_directive verbs
  *      (highlight / focus / open_inspector) — the AI's "point at the graph"
  *      gestures, each reusing the seam its user-driven equivalent uses.
  *   3. analysis_result.enrichment.decision_review → runMeta.ceeReviewV1.
@@ -63,23 +67,25 @@ export interface V5ApplicatorStore {
   /** Write (or clear) the CEE analysis_ready payload that gates the run. */
   setCeeAnalysisReady: (analysisReady: CEEAnalysisReady | null) => void
   /**
-   * Optional: write goal_constraints (ROADMAP 1.22). CEE places these at the
-   * response root on the V5 "commit response" path — additive only, this
-   * applicator never clears a prior turn's constraints on this slot (mirrors
-   * the V4 envelope path's ADD semantics but without its clear-on-empty-patch
-   * behaviour, which has no V5 equivalent signal to gate on).
+   * Optional: write goal_constraints (ROADMAP 1.22). On the V5 path this
+   * applicator writes via `add_constraint` graph_patch blocks only, UPSERTING
+   * by constraint id (step 2) — additive/replace, never a clear (a turn with no
+   * constraint patch leaves the slice untouched; there is no V5 clear signal to
+   * gate on). The other live source, CEE's `draft_graph.goal_constraints`, is
+   * owned by applyDraftResult, not here.
    */
   setGoalConstraints?: (
     constraints: CEEGoalConstraint[] | null,
     opts?: { fromProducerSync?: boolean },
   ) => void
   /**
-   * Current goal constraints, read to append an `add_constraint` graph_patch's
-   * constraint without dropping the ones already present. Snapshot-frozen at
-   * apply time (the applicator receives a spread of getState()), so multiple
-   * add_constraint patches in one turn are coalesced into a single
-   * setGoalConstraints write after the block loop — reading this field again
-   * after a mid-loop set would return the stale pre-turn value.
+   * Current goal constraints, read to UPSERT an `add_constraint` graph_patch's
+   * constraint (replace by id, or append when new) without dropping the ones
+   * already present. Snapshot-frozen at apply time (the applicator receives a
+   * spread of getState()), so multiple add_constraint patches in one turn are
+   * coalesced into a single setGoalConstraints write after the block loop —
+   * reading this field again after a mid-loop set would return the stale
+   * pre-turn value.
    */
   goalConstraints?: CEEGoalConstraint[] | null
   /**
@@ -392,6 +398,29 @@ function constraintsSameIdentity(a: CEEGoalConstraint, b: CEEGoalConstraint): bo
   )
 }
 
+/**
+ * Deep-semantic equality for an UPSERT no-op check. Two constraints are equal
+ * only when every content field matches after normalisation (undefined treated
+ * as absent). Identity alone is NOT sufficient: CEE edits a constraint in place
+ * retaining its constraint_id, so a value/label/unit change shares identity but
+ * differs in content and MUST write. This gate lets an exact re-send (byte-
+ * identical echo / double-fire) coalesce to zero writes while a genuine update
+ * still lands.
+ */
+function constraintsDeepEqual(a: CEEGoalConstraint, b: CEEGoalConstraint): boolean {
+  return (
+    (a.constraint_id ?? a.id) === (b.constraint_id ?? b.id) &&
+    a.node_id === b.node_id &&
+    a.operator === b.operator &&
+    a.value === b.value &&
+    (a.label ?? undefined) === (b.label ?? undefined) &&
+    (a.unit ?? undefined) === (b.unit ?? undefined) &&
+    (a.source_quote ?? undefined) === (b.source_quote ?? undefined) &&
+    (a.confidence ?? undefined) === (b.confidence ?? undefined) &&
+    (a.provenance ?? undefined) === (b.provenance ?? undefined)
+  )
+}
+
 type V5Block = OlumiResponse['blocks'][number]
 
 export interface ApplyV5StateResult {
@@ -609,22 +638,38 @@ export function applyV5State(
             })
             break
           }
-          // Idempotency + dedupe: skip when an equal constraint already exists
-          // (store OR queued earlier this turn) so a double-fire / echo never
-          // double-appends. Mirrors the neighbours' keyed-assignment idempotency.
+          // UPSERT by identity (P1-3). CEE updates an existing goal constraint
+          // in place, retaining its constraint_id (add-constraint.ts) — so a
+          // matching id is NOT a duplicate to skip; it is an edit to apply. Look
+          // up the current value for this identity (queued-this-turn wins over
+          // the store snapshot, so coalesced patches settle on the last write).
+          //   - deep-equal existing  → no-op, write nothing (exact re-send / echo)
+          //   - different content    → replace it (value/label/unit update)
+          //   - no existing          → new constraint
           const priorConstraints = store.goalConstraints ?? []
-          const isDuplicate = [...priorConstraints, ...pendingConstraints].some((c) =>
+          const pendingIdx = pendingConstraints.findIndex((c) =>
             constraintsSameIdentity(c, constraint),
           )
-          if (isDuplicate) {
+          const existing =
+            pendingIdx >= 0
+              ? pendingConstraints[pendingIdx]
+              : priorConstraints.find((c) => constraintsSameIdentity(c, constraint))
+          if (existing && constraintsDeepEqual(existing, constraint)) {
+            // Deep-semantic no-op: identical content already present/queued.
             deferred.push({
-              reason: 'add_constraint_duplicate_skipped',
+              reason: 'add_constraint_noop_skipped',
               block,
               detail: constraint.constraint_id ?? constraint.node_id ?? target,
             })
             break
           }
-          pendingConstraints.push(constraint)
+          if (pendingIdx >= 0) {
+            // Coalesce: a later patch for the same identity supersedes the
+            // earlier queued one (last-write-wins within the turn).
+            pendingConstraints[pendingIdx] = constraint
+          } else {
+            pendingConstraints.push(constraint)
+          }
           applied.push(`graph_patch:add_constraint:${constraint.node_id ?? target}`)
           break
         }
@@ -768,14 +813,20 @@ export function applyV5State(
   // Flush any add_constraint patches in ONE setGoalConstraints write (see
   // pendingConstraints declaration). fromProducerSync: true — a CEE-applied
   // constraint is a producer sync, not a user edit; the response's own
-  // analysis_ready.freshness verdict governs staleness (same reasoning as the
-  // response-root goal_constraints path below), so the write must not
-  // self-dirty the freshness overlay. Additive: prior constraints are spread
-  // first (the response-root goal_constraints path, if present, still owns the
-  // authoritative full-set replace at step 4).
+  // analysis_ready.freshness verdict governs staleness, so the write must not
+  // self-dirty the freshness overlay. Upsert semantics (P1-3): each pending
+  // constraint REPLACES a stored one of the same identity in place (preserving
+  // order) or is appended when new — a same-id edit updates rather than
+  // duplicates. No-ops never reach this list, so a pending constraint always
+  // represents a real add or change.
   if (pendingConstraints.length > 0) {
-    const base = store.goalConstraints ?? []
-    store.setGoalConstraints?.([...base, ...pendingConstraints], { fromProducerSync: true })
+    const merged = [...(store.goalConstraints ?? [])]
+    for (const pc of pendingConstraints) {
+      const idx = merged.findIndex((c) => constraintsSameIdentity(c, pc))
+      if (idx >= 0) merged[idx] = pc
+      else merged.push(pc)
+    }
+    store.setGoalConstraints?.(merged, { fromProducerSync: true })
   }
   const blockAppliedCount = applied.length - appliedCountBeforeBlocks
   logV5StateStep({
@@ -846,19 +897,13 @@ export function applyV5State(
   // Independent of ceeAnalysisReady (which clears on analyse-turns-without-analysis_ready).
   store.setAnalysisFreshness?.(rawAnalysisReady)
 
-  // ROADMAP 1.22 — goal_constraints at the response root. CEE places these
-  // outside analysis_ready (mirrors the V4 envelope path at
-  // useConversation.ts:2376+); goal_constraints is an untyped passthrough
-  // field on OlumiResponse (not in @talchain/schemas), so it is read via
-  // duck-typing. Additive only — a turn with no constraints does not clear
-  // a prior turn's, since (unlike the V4 path) this applicator has no
-  // "a new graph patch was applied" signal to gate a clear on.
-  const rawGoalConstraints = (response as { goal_constraints?: unknown }).goal_constraints
-  if (Array.isArray(rawGoalConstraints) && rawGoalConstraints.length > 0) {
-    // Producer sync (V5 state apply) — must not self-dirty the freshness overlay.
-    store.setGoalConstraints?.(rawGoalConstraints as CEEGoalConstraint[], { fromProducerSync: true })
-    applied.push('goal_constraints:set')
-  }
+  // NOTE: there is intentionally no response-ROOT goal_constraints read here.
+  // Constraints reach the store via the two LIVE paths only: CEE's
+  // `draft_graph.goal_constraints` (applyDraftResult) and `add_constraint`
+  // graph_patch blocks (upserted in step 2 above). A former root-level compat
+  // leg was dead — responseParser demotes every unknown top-level key to the
+  // non-enumerable `__additive__` sidecar, so `response.goal_constraints` is
+  // never set on a really-parsed OlumiResponse (Codex P2-2, removed).
   if (rawAnalysisReady !== undefined) {
     const normalised = normaliseV5AnalysisReady(rawAnalysisReady)
     if (normalised) {


### PR DESCRIPTION
Addresses four Codex-review findings in the V5 ingestion + node-chrome group. Draft — do **not** merge; for review.

## Fix 1 — P1-3: constraint UPSERT, not identity-dedupe (`src/v5/applyV5State.ts`)
CEE updates an existing goal constraint **in place**, retaining its `constraint_id` (CEE `add-constraint.ts:358/553`). The #452 ingestion treated a matching id as a duplicate and **skipped**, so a value/label/unit edit (e.g. `5→10` on `gc-stable`) produced **zero** UI writes.

Now the `add_constraint` graph_patch path upserts by identity:
- **deep-equal** existing (all fields equal after normalisation) → no-op, writes nothing (`add_constraint_noop_skipped`);
- **same id, different content** → replaces the stored constraint in place (order preserved);
- **new identity** → appended.

The unmappable-shape fail-closed behaviour is unchanged. Added `constraintsDeepEqual`; the post-loop flush is now an upsert-merge. RED-first pins in `applyV5State.addConstraint.test.ts`: update-in-place applies · label/unit edit writes · coalesced same-id patches settle on the last write · byte-identical re-send writes nothing. Reverting the upsert → **3 tests RED** (verified).

## Fix 2 — P1-5: top-right corner-badge collision (`BaseNode.tsx`, `NodeCoachingMarker.tsx`)
The sensitivity-rank badge and the coaching marker both rendered at `absolute -top-2 -right-2 z-10` (identical z), so the rank obscured the coaching marker (Paul's screenshot). Adjudicated minimal fix (not the full annotation compositor): a single absolutely-positioned flex container in `BaseNode` owns the corner; the rank badge and coaching marker are static flex children.

**Layout choice:** horizontal flex row (`flex items-center gap-1`), **rank first**, coaching beside it. Rationale: reads as "key driver #N, then coaching"; both stay in the top-edge band (no title overlap); the row is right-anchored and grows leftward (never clips the node's right side); siblings can't overlap, so both stay visible and the coaching button stays clickable. `NodeCoachingMarker` dropped its own `absolute`/offset classes (positioning is now the parent's job). DS rules hold (no one-sided borders; `bg-panel`).

New `BaseNode.cornerStack.spec.tsx` pins: both-present render both inside one stack, rank first, children carry no `absolute`/offset of their own (the layout-relevant contract jsdom **can** assert — true-pixel spacing is a browser concern, noted honestly) · each alone renders in place · click-through fires with the rank present. Reverting to base → **4 tests RED** (verified). Updated the one pre-existing `FactorNode` test that asserted the badge's own positioning to assert the stack's instead.

## Fix 3 — P2-1: filterCompose spec mocked the wrong flags path (`StyledEdge.filterCompose.spec.tsx`)
`vi.mock('../../flags', …)` resolved to the non-existent `src/canvas/flags`; `StyledEdge` imports `src/flags` (which from the test dir is `../../../flags`), so the mock silently no-op'd and the two lens-dependent tests depended on ambient `VITE_FEATURE_GRAPH_LENS`. Corrected to `../../../flags`. Proven env-independent: green both with `VITE_FEATURE_GRAPH_LENS=false` and unset; with the **old** path + `=false` → 2 tests RED (verified).

> Note: three sibling specs (`StyledEdge.contested/hover/projection`) share the same wrong-path pattern (they mock lens `false`, matching the current default, so they pass today but are latent). Out of the named P2-1 scope — flagged as a separate follow-up task, not touched here.

## Fix 4 — P2-2: remove the dead root-level `goal_constraints` compat leg (`src/v5/applyV5State.ts`)
`responseParser` demotes every unknown top-level key to the non-enumerable `__additive__` sidecar, so `response.goal_constraints` is never set on a really-parsed `OlumiResponse` — the applicator's direct root read was unreachable, and its positive test only passed by fabricating a typed response that bypassed the parser. Deleted the leg (+ its `goal_constraints:set` token) and both root-leg tests; left a one-line comment naming the live sources (CEE `draft_graph.goal_constraints` via `applyDraftResult`, and `add_constraint` graph_patch). Positive control: the live constraint-path tests stay green (draft_graph wire + `applyDraftResult` + `add_constraint`), grep residue clean.

## Gates
- `pnpm run typecheck` (tsc -p tsconfig.ci.json) — clean.
- Lint (changed files) — clean (one pre-existing `viewMode` unused-var **warning** in `BaseNode.tsx`, present on base, not introduced here).
- Targeted vitest — all touched specs green (183 across 7 files); live constraint-path + full `src/v5` dir green (669/47).
- Mutation checks (throwaway clone): Fix 1 → 3 RED on revert; Fix 2 → 4 RED on revert; Fix 3 → 2 RED under the old path.

Verification note: Fix 2's structural pins are jsdom (presence + order + class contract). Per the adjudication, true-pixel non-overlap is a browser concern and is not asserted here.
