### PR TITLE
fix(persist): hash-by-default with ephemeral denylist + cap staleness + exact-seed no-op editor (Codex P1-1/2/4)

### DIFF
--- a/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
+++ b/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
@@ -5,17 +5,27 @@
  * the same week: the autosave dirty-gate missed success_threshold/threshold_source
  * (#457, targets not persisted) and the staleness gate missed probability/impact
  * (#453, risk edits didn't stale the analysis). Both now derive from ONE registry
- * (analyticalNodeFields.ts). This guard proves:
+ * (analyticalNodeFields.ts).
  *
- *   1. The registry is well-formed (no dupes, every field noted + purposed).
- *   2. The derived subsets equal the behavioural CONTRACT the two bugs established
- *      — reported as a NAMED-FIELD symmetric diff, never a bare boolean.
- *   3. The two real consumers (hasAnalyticalNodeChange / hasAnalyticalEdgeChange for
- *      'stale'; computeGraphHash for 'persist') actually HONOUR the registry — a
- *      field flagged for a purpose whose consumer ignores it fails RED.
- *   4. POSITIVE CONTROL: the same diff + behavioural machinery goes RED on a
- *      synthetic drift (a dropped field / a cosmetic field), so the green in (2)/(3)
- *      is load-bearing, not vacuous (traps #11, #13).
+ * Codex P1-1 inverted the autosave dirty-gate from an ALLOWLIST (`persist`) to a
+ * hash-by-default + EPHEMERAL DENYLIST. This guard is updated to the new shape and
+ * proves:
+ *
+ *   1. The registry is well-formed (no dupes, every field noted + purposed, only
+ *      the known purposes 'ephemeral'/'stale').
+ *   2. The derived subsets equal the behavioural CONTRACT — reported as a
+ *      NAMED-FIELD symmetric diff, never a bare boolean. Now includes the ephemeral
+ *      denylist (deny direction).
+ *   3. The two real consumers HONOUR the registry:
+ *        • 'stale'     → hasAnalyticalNodeChange / hasAnalyticalEdgeChange flag every
+ *                        stale field.
+ *        • 'ephemeral' → computeGraphHash does NOT flip for any ephemeral field,
+ *                        AND flips for a non-ephemeral field (hash-by-default).
+ *      Plus the DENY-DIRECTION SAFETY assertion: no field a live editor writes as
+ *      persistent state may appear on the ephemeral denylist (a wrongly-denylisted
+ *      persistent field = silent reload loss — this fails the guard RED).
+ *   4. POSITIVE CONTROLS: the diff + behavioural machinery goes RED on a synthetic
+ *      drift, so the green in (2)/(3) is load-bearing, not vacuous (traps #11, #13).
  */
 import { describe, it, expect } from 'vitest'
 import type { Edge, Node } from '@xyflow/react'
@@ -23,9 +33,9 @@ import {
   NODE_FIELD_REGISTRY,
   EDGE_FIELD_REGISTRY,
   deriveFields,
-  PERSIST_NODE_FIELDS,
+  EPHEMERAL_NODE_FIELDS,
   STALE_NODE_FIELDS,
-  PERSIST_EDGE_FIELDS,
+  EPHEMERAL_EDGE_FIELDS,
   STALE_EDGE_FIELDS,
   type AnalyticalFieldSpec,
 } from '../analyticalNodeFields'
@@ -33,29 +43,39 @@ import { ANALYTICAL_NODE_DATA_FIELDS, ANALYTICAL_EDGE_FIELDS, hasAnalyticalNodeC
 import { computeGraphHash } from '../../hooks/useAutosave'
 
 // ---------------------------------------------------------------------------
-// The behavioural CONTRACT — the field sets the two bugs (#453/#457) and the
-// current shipped behaviour require. Kept as an EXACT bidirectional lock: a field
-// added to or removed from the registry MUST be mirrored here deliberately, which
-// is exactly the drift-detection this guard exists to force.
+// The behavioural CONTRACT — the field sets the two bugs (#453/#457), task #23,
+// and Codex P1-1/P1-2 require. Kept as an EXACT bidirectional lock: a field added
+// to or removed from the registry MUST be mirrored here deliberately, which is
+// exactly the drift-detection this guard exists to force.
 // ---------------------------------------------------------------------------
 
-const EXPECTED_PERSIST_NODE = [
-  'observedState', 'interventions', 'is_baseline', 'success_threshold',
-  'goal_threshold_raw', 'goal_threshold_unit', 'goal_threshold_cap', 'threshold_source',
-  // Task #23: analysis-affecting node fields that are user-editable in isolation on
-  // the live path (probability/impact via RiskPanel, prior via FactorExternalPanel)
-  // were flipped INTO persist so an edit touching only them survives reload (#457 class).
-  'prior', 'probability', 'impact',
-]
+// EPHEMERAL = the autosave-hash DENYLIST. Everything else on node/edge data is
+// persisted by default (hash-by-default), so this list is intentionally tiny.
+const EXPECTED_EPHEMERAL_NODE = ['goalThreshold', 'goal_threshold', '_baseline_snapshot']
+const EXPECTED_EPHEMERAL_EDGE: string[] = []
+
 const EXPECTED_STALE_NODE = [
   'observedState', 'interventions', 'is_baseline', 'success_threshold',
-  'goal_threshold_raw', 'prior', 'kind', 'goalThreshold', 'goal_threshold',
-  'probability', 'impact',
+  'goal_threshold_raw', 'goal_threshold_cap', 'prior', 'kind', 'goalThreshold',
+  'goal_threshold', 'probability', 'impact',
 ]
-const EXPECTED_PERSIST_EDGE = ['weight', 'direction', 'strengthStd', 'confidence', 'beliefExists']
 const EXPECTED_STALE_EDGE = [
   'weight', 'direction', 'strengthStd', 'confidence', 'beliefExists',
   'beliefStrength', 'belief', 'exists_probability',
+]
+
+// Fields a LIVE user editor writes as persistent state. None may ever appear on the
+// ephemeral denylist — a denylisted persistent field is silently dropped on reload
+// (the exact #457 loss class). See "deny-direction safety" below.
+const KNOWN_EDITOR_PERSIST_NODE_FIELDS = [
+  'observedState', 'interventions', 'is_baseline', 'success_threshold',
+  'goal_threshold_raw', 'goal_threshold_cap', 'goal_threshold_unit', 'threshold_source',
+  'prior', 'probability', 'impact',
+  'description', 'category', 'extractionType', 'factor_type', 'state_space',
+  'uncertainty_drivers', 'label',
+]
+const KNOWN_EDITOR_PERSIST_EDGE_FIELDS = [
+  'weight', 'direction', 'strengthStd', 'confidence', 'beliefExists',
 ]
 
 /** Symmetric difference reported as named fields — the guard's failure message. */
@@ -90,7 +110,7 @@ describe('analyticalNodeFields registry — well-formed', () => {
       }
     })
     it(`${name}: purposes are the known set only`, () => {
-      const known = new Set(['persist', 'stale'])
+      const known = new Set(['ephemeral', 'stale'])
       for (const spec of registry) {
         for (const p of spec.purposes) expect(known.has(p), `${spec.field}: unknown purpose ${p}`).toBe(true)
       }
@@ -103,14 +123,14 @@ describe('analyticalNodeFields registry — well-formed', () => {
 // ---------------------------------------------------------------------------
 
 describe('analyticalNodeFields registry — derived subsets match the contract', () => {
-  it('node persist subset', () => {
-    expect(fieldDiff(EXPECTED_PERSIST_NODE, PERSIST_NODE_FIELDS)).toEqual(NO_DIFF)
+  it('node ephemeral denylist', () => {
+    expect(fieldDiff(EXPECTED_EPHEMERAL_NODE, EPHEMERAL_NODE_FIELDS)).toEqual(NO_DIFF)
   })
   it('node stale subset', () => {
     expect(fieldDiff(EXPECTED_STALE_NODE, STALE_NODE_FIELDS)).toEqual(NO_DIFF)
   })
-  it('edge persist subset', () => {
-    expect(fieldDiff(EXPECTED_PERSIST_EDGE, PERSIST_EDGE_FIELDS)).toEqual(NO_DIFF)
+  it('edge ephemeral denylist (empty today)', () => {
+    expect(fieldDiff(EXPECTED_EPHEMERAL_EDGE, EPHEMERAL_EDGE_FIELDS)).toEqual(NO_DIFF)
   })
   it('edge stale subset', () => {
     expect(fieldDiff(EXPECTED_STALE_EDGE, STALE_EDGE_FIELDS)).toEqual(NO_DIFF)
@@ -148,32 +168,55 @@ describe('analyticalNodeFields registry — staleness consumer honours every sta
       expect(changed, `stale edge field '${field}' not seen by hasAnalyticalEdgeChange`).toBe(true)
     }
   })
-  it('does NOT flag a cosmetic field (proves the probe discriminates — trap #13)', () => {
-    // If this were true, the loop above would pass vacuously.
+  it('does NOT flag a cosmetic field for staleness (proves the probe discriminates — trap #13)', () => {
+    // description/body are persisted (hash-by-default) but are NOT analysis-affecting,
+    // so they must not stale. If they did, the loop above could pass vacuously.
     expect(hasAnalyticalNodeChange(nodeWith({}), { data: { description: 'new copy' } })).toBe(false)
     expect(hasAnalyticalNodeChange(nodeWith({}), { data: { body: 'x' } })).toBe(false)
   })
 })
 
-describe('analyticalNodeFields registry — persist consumer honours every persist field', () => {
-  it('computeGraphHash flips for a change to each persist node field', () => {
-    for (const field of PERSIST_NODE_FIELDS) {
+describe('analyticalNodeFields registry — autosave hash honours the ephemeral denylist (hash-by-default)', () => {
+  it('computeGraphHash does NOT flip for a change to any ephemeral node field', () => {
+    for (const field of EPHEMERAL_NODE_FIELDS) {
       const before = computeGraphHash([nodeWith({})], [])
       const after = computeGraphHash([nodeWith({ [field]: SENTINEL })], [])
-      expect(after, `persist node field '${field}' does not flip computeGraphHash`).not.toBe(before)
+      expect(after, `ephemeral node field '${field}' wrongly flips computeGraphHash`).toBe(before)
     }
   })
-  it('computeGraphHash flips for a change to each persist edge field', () => {
-    for (const field of PERSIST_EDGE_FIELDS) {
+  it('computeGraphHash does NOT flip for a change to any ephemeral edge field', () => {
+    for (const field of EPHEMERAL_EDGE_FIELDS) {
       const before = computeGraphHash([], [edgeWith({})])
       const after = computeGraphHash([], [edgeWith({ [field]: SENTINEL })])
-      expect(after, `persist edge field '${field}' does not flip computeGraphHash`).not.toBe(before)
+      expect(after, `ephemeral edge field '${field}' wrongly flips computeGraphHash`).toBe(before)
     }
   })
-  it('computeGraphHash does NOT flip for a cosmetic node field (proves the probe discriminates)', () => {
+  it('computeGraphHash FLIPS for a non-ephemeral node data field (hash-by-default)', () => {
+    // description is NOT on the denylist → it is persisted, so it MUST flip the hash.
+    // This is the exact behaviour the old persist-allowlist suppressed (the defect).
     const before = computeGraphHash([nodeWith({})], [])
     const after = computeGraphHash([nodeWith({ description: 'new copy' })], [])
-    expect(after).toBe(before)
+    expect(after).not.toBe(before)
+  })
+  it('computeGraphHash FLIPS for every stale node field (they are all persisted too)', () => {
+    for (const field of STALE_NODE_FIELDS) {
+      if (EPHEMERAL_NODE_FIELDS.includes(field)) continue // stale+ephemeral derived caches
+      const before = computeGraphHash([nodeWith({})], [])
+      const after = computeGraphHash([nodeWith({ [field]: SENTINEL })], [])
+      expect(after, `stale node field '${field}' does not flip computeGraphHash`).not.toBe(before)
+    }
+  })
+
+  // DENY-DIRECTION SAFETY (Codex P1-1): a field a live editor writes as persistent
+  // state must NEVER be on the ephemeral denylist. If it were, an edit touching only
+  // that field would be silently lost on reload — the #457 class this fix removes.
+  it('no live-editor persistent NODE field is denylisted', () => {
+    const wronglyDenied = KNOWN_EDITOR_PERSIST_NODE_FIELDS.filter((f) => EPHEMERAL_NODE_FIELDS.includes(f))
+    expect(wronglyDenied, `persistent editor field(s) wrongly on the ephemeral denylist: ${wronglyDenied.join(', ')}`).toEqual([])
+  })
+  it('no live-editor persistent EDGE field is denylisted', () => {
+    const wronglyDenied = KNOWN_EDITOR_PERSIST_EDGE_FIELDS.filter((f) => EPHEMERAL_EDGE_FIELDS.includes(f))
+    expect(wronglyDenied, `persistent editor field(s) wrongly on the ephemeral denylist: ${wronglyDenied.join(', ')}`).toEqual([])
   })
 })
 
@@ -189,34 +232,40 @@ describe('analyticalNodeFields registry — positive controls (guard catches dri
     const diff = fieldDiff(EXPECTED_STALE_NODE, drifted)
     expect(diff.missing).toEqual(['probability'])
     expect(diff.extra).toEqual([])
-    // And it is NOT equal to NO_DIFF — the assertion in (2) would fail RED.
     expect(diff).not.toEqual(NO_DIFF)
   })
 
-  it('fieldDiff names a field ADDED to the registry but not to the contract', () => {
-    const drifted = [...STALE_NODE_FIELDS, 'newlyAddedField']
-    const diff = fieldDiff(EXPECTED_STALE_NODE, drifted)
-    expect(diff.extra).toEqual(['newlyAddedField'])
+  it('fieldDiff names a field ADDED to the ephemeral denylist but not to the contract', () => {
+    const drifted = [...EPHEMERAL_NODE_FIELDS, 'newlyDeniedField']
+    const diff = fieldDiff(EXPECTED_EPHEMERAL_NODE, drifted)
+    expect(diff.extra).toEqual(['newlyDeniedField'])
     expect(diff).not.toEqual(NO_DIFF)
   })
 
-  it('the behavioural tie catches a stale field NO consumer handles', () => {
-    // Simulate a registry field flagged 'stale' that the consumer ignores. The
-    // loop in (3) does exactly this check; here we prove that check can fail: a
-    // synthetic field absent from ANALYTICAL_NODE_DATA_FIELDS is NOT seen by
-    // hasAnalyticalNodeChange, so it would trip the guard RED.
-    const synthetic: AnalyticalFieldSpec = { field: 'ghostField', purposes: ['stale'], note: 'x' }
-    expect(synthetic.purposes).toContain('stale')
-    expect(hasAnalyticalNodeChange(nodeWith({}), { data: { ghostField: SENTINEL } })).toBe(false)
+  it('the deny-direction safety catches a persistent field wrongly denylisted', () => {
+    // Simulate someone denylisting success_threshold (a user target — the #457 field).
+    const drifted = [...EPHEMERAL_NODE_FIELDS, 'success_threshold']
+    const wronglyDenied = KNOWN_EDITOR_PERSIST_NODE_FIELDS.filter((f) => drifted.includes(f))
+    expect(wronglyDenied).toEqual(['success_threshold'])
+    expect(wronglyDenied).not.toEqual([])
+  })
+
+  it('the hash behavioural tie catches an ephemeral field computeGraphHash still hashes', () => {
+    // If a "denylisted" field were NOT actually excluded by serializableData, its
+    // change would flip the hash. Proves the tie in (3) can fail: a NON-denylisted
+    // field flips, so if an ephemeral field flipped it would trip the guard RED.
+    const before = computeGraphHash([nodeWith({})], [])
+    const after = computeGraphHash([nodeWith({ notDenylisted: SENTINEL })], [])
+    expect(after).not.toBe(before)
   })
 
   it('deriveFields partitions by purpose (sanity of the derivation itself)', () => {
     const reg: readonly AnalyticalFieldSpec[] = [
-      { field: 'both', purposes: ['persist', 'stale'], note: 'n' },
-      { field: 'p', purposes: ['persist'], note: 'n' },
+      { field: 'both', purposes: ['ephemeral', 'stale'], note: 'n' },
+      { field: 'e', purposes: ['ephemeral'], note: 'n' },
       { field: 's', purposes: ['stale'], note: 'n' },
     ]
-    expect(deriveFields(reg, 'persist')).toEqual(['both', 'p'])
+    expect(deriveFields(reg, 'ephemeral')).toEqual(['both', 'e'])
     expect(deriveFields(reg, 'stale')).toEqual(['both', 's'])
   })
 })

--- a/src/canvas/domain/analyticalNodeFields.ts
+++ b/src/canvas/domain/analyticalNodeFields.ts
@@ -1,7 +1,7 @@
 /**
- * analyticalNodeFields — the ONE registry of node/edge `data.*` fields that carry
- * user-meaningful analytical state, with a per-field record of WHICH PURPOSES
- * consume each field.
+ * analyticalNodeFields — the ONE registry of node/edge `data.*` fields with a
+ * per-field record of which cross-cutting behaviours a change of that field
+ * participates in.
  *
  * ── Why this file exists (trap-12 closure) ─────────────────────────────────────
  * Two hand-maintained field lists had silently drifted apart, and BOTH shipped a
@@ -22,51 +22,68 @@
  * DERIVE their subset from it (`deriveFields`), and `analyticalNodeFields.registry.spec.ts`
  * is the fail-loud drift guard that verifies the real consumers honour it.
  *
- * ── The two purposes are OVERLAPPING, not identical ────────────────────────────
- * They share a large core (observedState, interventions, is_baseline,
- * success_threshold, goal_threshold_raw; edge weight/direction/…) but each has
- * legitimately-exclusive members, so the registry records purposes PER FIELD
- * rather than forcing a single list:
+ * ── ALLOWLIST vs DENYLIST — the two purposes are NOT symmetric (Codex P1-1) ─────
+ * The two behaviours the registry drives are deliberately opposite shapes:
  *
- *   • 'persist'  — a change MUST survive a reload (autosave dirty-gate,
- *                  computeGraphHash). Includes display/provenance metadata
- *                  (goal_threshold_unit/cap, threshold_source) that is not an
- *                  analysis input but is still user state that must not be lost.
- *   • 'stale'    — a change invalidates the current analysis (readiness /
- *                  freshness overlay: hasAnalyticalNodeChange / hasAnalyticalEdgeChange,
- *                  and the raw patch-apply path in applyPatch.ts). Excludes
- *                  cosmetic fields (label, body, description, position, colour),
- *                  and excludes derived values that are re-computed on restore.
+ *   • 'stale'      — ALLOWLIST. A change invalidates the current analysis
+ *                    (readiness / freshness overlay: hasAnalyticalNodeChange /
+ *                    hasAnalyticalEdgeChange, and the raw patch-apply path in
+ *                    applyPatch.ts). Narrow-is-correct here: only genuinely
+ *                    analysis-affecting fields belong. Cosmetic fields (label,
+ *                    body, description, position, colour) and derived caches that
+ *                    are re-computed on restore are deliberately EXCLUDED.
+ *
+ *   • 'ephemeral'  — DENYLIST. computeGraphHash now hashes ALL serialized node /
+ *                    edge `data.*` BY DEFAULT (so any user-editable field a live
+ *                    editor writes survives reload without anyone remembering to
+ *                    allowlist it — the #457/description/category/… class of loss).
+ *                    'ephemeral' is the small, explicit EXCLUSION list: fields
+ *                    whose change must NOT trigger an autosave because they are
+ *                    transient UI/session state or a derived cache re-computed on
+ *                    load. Persist is the default; you only ever add to this list,
+ *                    with a one-line WHY, when a field would otherwise churn or
+ *                    resurrect stale derived state.
+ *
+ * Why this asymmetry (Codex P1-1, adjudicated): the OLD 'persist' purpose was an
+ * allowlist-guarding-an-allowlist. computeGraphHash only hashed fields on the
+ * persist allowlist, so six user-editable fields never on it (`description`,
+ * `category`, `extractionType`, `factor_type`, `state_space`,
+ * `uncertainty_drivers`) were silently dropped on reload — the same defect class
+ * as #457, one allowlist-omission at a time. Inverting to hash-by-default makes
+ * the SAFE direction the default: a new ephemeral field NOT denylisted merely
+ * causes an extra (debounced) save — harmless; a field that a live editor writes
+ * as persistent state can never be silently lost by omission. The only failure
+ * this leaves is the opposite: a genuinely-persistent field wrongly denylisted —
+ * which the drift guard catches (named-field diff + the editor-field disjointness
+ * assertion in analyticalNodeFields.registry.spec.ts).
+ *
+ * FIELDS NEEDING NO ENTRY: everything that is neither analysis-affecting nor
+ * ephemeral is persisted by default and does not appear here — e.g. `description`,
+ * `category`, `extractionType`, `factor_type`, `state_space`,
+ * `uncertainty_drivers`, `goal_threshold_unit`, `threshold_source`. They persist
+ * because the hash defaults to persisting; they do not stale because they are not
+ * analysis inputs (unit/provenance are display/provenance only). Their round-trip
+ * is pinned in useAutosave.hashByDefault.spec.ts.
  *
  * Structural signals (node id / RF `type` / label / position; edge source/target)
  * are handled inline by each consumer and are deliberately NOT in this registry —
  * it enumerates `data.*` fields only.
  *
- * ── persist/stale ASYMMETRIES — adjudicated in task #23 (was ⚠ KNOWN GAP) ───────
- * Six analysis-affecting fields were flagged `stale`-only with a "KNOWN GAP" note:
- * an edit touching ONLY that field would not flip the autosave dirty hash — the
- * SAME class of bug as #457. Task #23 adjudicated each PER FIELD on the LIVE path
- * (honest verification, not a blanket flip):
- *
- *   • node `probability`, `impact` (RiskPanel setters, live since #453) and
- *     `prior` (FactorExternalPanel setPriorRange) are genuinely user-editable IN
- *     ISOLATION and analysis-affecting → FLIPPED into `persist`. computeGraphHash
- *     derives PERSIST_NODE_FIELDS from this registry, so the flip reaches it
- *     automatically (that is the point of #461). Round-trip pinned in
- *     useAutosave.analysisFieldPersist.spec.ts.
- *   • edge `beliefStrength`, `belief`, `exists_probability` have NO live editor
- *     that writes them in isolation (creation-time defaults / the DEAD v1 edge
- *     inspector / CEE-ingestion that always co-writes the persisted `beliefExists`
- *     in the same edge rebuild). An uneditable field cannot be lost by an isolated
- *     edit → deliberately LEFT `stale`-only. See each field's note for the trace.
+ * ── stale/ephemeral notes carried over from task #23 ───────────────────────────
+ * node `probability`, `impact`, `prior` are genuinely user-editable IN ISOLATION
+ * on the live path and analysis-affecting → `stale` (and persisted by default).
+ * edge `beliefStrength`, `belief`, `exists_probability` have NO live editor that
+ * writes them in isolation (creation-time defaults / the DEAD v1 edge inspector /
+ * CEE-ingestion that always co-writes the persisted `beliefExists`) → `stale`
+ * only; they persist by default. See each field's note for the trace.
  */
 
-export type AnalyticalFieldPurpose = 'persist' | 'stale'
+export type AnalyticalFieldPurpose = 'ephemeral' | 'stale'
 
 export interface AnalyticalFieldSpec {
   /** The `data.*` key on the node or edge. */
   readonly field: string
-  /** Which consumers must react to a change of this field. At least one. */
+  /** Which behaviours a change of this field participates in. At least one. */
   readonly purposes: readonly AnalyticalFieldPurpose[]
   /** WHY this field matters + which consumers read it. Required, non-empty. */
   readonly note: string
@@ -74,125 +91,131 @@ export interface AnalyticalFieldSpec {
 
 // ---------------------------------------------------------------------------
 // Node data fields
+//
+// Only 'stale' (analysis-affecting) and 'ephemeral' (excluded from the autosave
+// hash) fields need an entry. Persist is the DEFAULT — a user-editable field that
+// is not analysis-affecting (description, category, extractionType, factor_type,
+// state_space, uncertainty_drivers, goal_threshold_unit, threshold_source) is
+// persisted by hash-by-default and correctly needs no row here.
 // ---------------------------------------------------------------------------
 
 export const NODE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
   {
     field: 'observedState',
-    purposes: ['persist', 'stale'],
-    note: "A factor/outcome's observed value+baseline+std — the core analysis input. CEE set_factor_value merges here. Consumers: staleness (hasAnalyticalNodeChange), autosave dirty-gate (computeGraphHash), V2 adapter extractObservedState → PLoT.",
+    purposes: ['stale'],
+    note: "A factor/outcome's observed value+baseline+std — the core analysis input. CEE set_factor_value merges here. Consumers: staleness (hasAnalyticalNodeChange), V2 adapter extractObservedState → PLoT. Persisted by hash-by-default.",
   },
   {
     field: 'interventions',
-    purposes: ['persist', 'stale'],
-    note: "An option's per-factor intervention values — define what the option does. Consumers: staleness, autosave, V2 adapter.",
+    purposes: ['stale'],
+    note: "An option's per-factor intervention values — define what the option does. Consumers: staleness, V2 adapter. Persisted by hash-by-default.",
   },
   {
     field: 'is_baseline',
-    purposes: ['persist', 'stale'],
-    note: 'Marks the baseline option; flips the analysis framing. Consumers: staleness, autosave.',
+    purposes: ['stale'],
+    note: 'Marks the baseline option; flips the analysis framing. Consumers: staleness. Persisted by hash-by-default.',
   },
   {
     field: 'success_threshold',
-    purposes: ['persist', 'stale'],
-    note: "The user's success target on the goal node (written with threshold_source='user'). #457 root cause when it was missing from persist. Consumers: staleness, autosave, V2 adapter goal_threshold derivation, goal lens.",
+    purposes: ['stale'],
+    note: "The user's success target on the goal node (written with threshold_source='user'). #457 root cause when the old persist allowlist omitted it. Consumers: staleness, V2 adapter goal_threshold derivation, goal lens. Persisted by hash-by-default.",
   },
   {
     field: 'goal_threshold_raw',
-    purposes: ['persist', 'stale'],
-    note: 'User-edited raw goal target; the V2 adapter derives the PLoT goal_threshold from it, so a change is analysis-affecting AND must survive reload. Consumers: staleness, autosave, V2 adapter.',
-  },
-  {
-    field: 'goal_threshold_unit',
-    purposes: ['persist'],
-    note: 'Display/format metadata for the goal target. Must survive reload so the restored target renders identically, but a unit change alone (without a raw change) is not treated as analysis-affecting today. Consumers: autosave.',
+    purposes: ['stale'],
+    note: 'User-edited raw goal target; the V2 adapter derives the PLoT goal_threshold from it (raw/cap), so a change is analysis-affecting AND must survive reload. A raw-only edit already reaches staleness via this entry (Codex P1-2 audit: NOT gapped). Consumers: staleness, V2 adapter. Persisted by hash-by-default.',
   },
   {
     field: 'goal_threshold_cap',
-    purposes: ['persist'],
-    note: 'Cap used to normalise goal_threshold_raw into [0,1] for PLoT; persisted so the raw target re-normalises identically on reload. Not in the staleness set today (a cap change without a raw change is not currently treated as analysis-affecting). Consumers: autosave, V2 adapter normalisation.',
-  },
-  {
-    field: 'threshold_source',
-    purposes: ['persist'],
-    note: "Provenance only ('user' vs auto-synthesised). Pure provenance, not an analysis input — but MUST survive reload (#457: without it a restored user target reads as 'auto'). Consumers: autosave, goal lens / nudge gate.",
+    purposes: ['stale'],
+    note: 'Cap used to normalise goal_threshold_raw into [0,1] for PLoT (resolveGoalThresholdCap → resolveChipGoalThreshold, UI-SEM-058). A cap edit changes the normalised threshold the request carries (cap 25→100 flips implied 0.8→0.2) so it IS analysis-affecting — Codex P1-2 gave it the `stale` purpose (was persist-only, so GoalAdvancedEditor cap edits left freshness clean while changing the math). Consumers: staleness, V2 adapter normalisation. Persisted by hash-by-default.',
   },
   {
     field: 'prior',
-    purposes: ['persist', 'stale'],
-    note: "A factor's prior belief range — analysis-affecting AND user-editable in isolation on the live path (External-factor inspector: FactorExternalPanel/FactorExternalEditor setPriorRange → updateNode(data.prior), routed live via InspectorRouter 'factor-external'; also read by the V1 mapper → PLoT). Task #23: FLIPPED into persist — a prior-only edit must survive reload (was the same class as #457). Consumers: staleness, autosave, V1 mapper.",
+    purposes: ['stale'],
+    note: "A factor's prior belief range — analysis-affecting AND user-editable in isolation on the live path (External-factor inspector: FactorExternalPanel/FactorExternalEditor setPriorRange → updateNode(data.prior), routed live via InspectorRouter 'factor-external'; also read by the V1 mapper → PLoT). Consumers: staleness, V1 mapper. Persisted by hash-by-default.",
   },
   {
     field: 'kind',
     purposes: ['stale'],
-    note: 'A data-level node kind reclassification. The primary kind signal is the RF `type` field, which both consumers handle structurally; this catches a data.kind-only change for staleness. Persist covers kind via n.type. Consumers: staleness.',
+    note: 'A data-level node kind reclassification. The primary kind signal is the RF `type` field, which both consumers handle structurally; this catches a data.kind-only change for staleness. Persisted by hash-by-default (also caught structurally via n.type in computeGraphHash). Consumers: staleness.',
   },
   {
     field: 'goalThreshold',
-    purposes: ['stale'],
-    note: 'camelCase derived goal-threshold cache on the node; analysis-affecting when present, but a derived value that is re-computed on restore, so deliberately not persisted. Consumers: staleness.',
+    purposes: ['stale', 'ephemeral'],
+    note: 'camelCase derived goal-threshold cache on the node; analysis-affecting (staleness) but a DERIVED value re-computed on restore from success_threshold/goal_threshold_raw — EPHEMERAL so it never triggers a persist-save on its own (its inputs are persisted and re-derive it). Consumers: staleness; excluded from computeGraphHash.',
   },
   {
     field: 'goal_threshold',
-    purposes: ['stale'],
-    note: 'snake_case derived/normalised goal threshold; analysis-affecting. Derived and re-computed on restore, so deliberately not persisted. Consumers: staleness, V2 adapter output.',
+    purposes: ['stale', 'ephemeral'],
+    note: 'snake_case derived/normalised goal threshold; analysis-affecting (staleness) but DERIVED and re-computed on restore, so EPHEMERAL — excluded from the autosave hash (a recompute must not churn the dirty-gate; the raw inputs are persisted). Consumers: staleness, V2 adapter output; excluded from computeGraphHash.',
   },
   {
     field: 'probability',
-    purposes: ['persist', 'stale'],
-    note: "A risk's likelihood [0,1] — user-editable in isolation via RiskPanel (setProbability → updateNode(data.probability), live since #453) and analysis-affecting (drives calculateRiskSeverity; passes to PLoT). It is a top-level node.data field, not nested in observedState. #453 root cause when missing from staleness. Task #23: FLIPPED into persist — a probability-only edit must survive reload (was the same class as #457). Consumers: staleness, autosave, RiskPanel, V2 adapter.",
+    purposes: ['stale'],
+    note: "A risk's likelihood [0,1] — user-editable in isolation via RiskPanel (setProbability → updateNode(data.probability), live since #453) and analysis-affecting (drives calculateRiskSeverity; passes to PLoT). Top-level node.data, not nested in observedState. #453 root cause when missing from staleness. Consumers: staleness, RiskPanel, V2 adapter. Persisted by hash-by-default.",
   },
   {
     field: 'impact',
-    purposes: ['persist', 'stale'],
-    note: "A risk's impact enum (low..critical); with probability drives severity. User-editable in isolation via RiskPanel (setImpact → updateNode(data.impact)). #453. Task #23: FLIPPED into persist — an impact-only edit must survive reload (same class as #457). Consumers: staleness, autosave, RiskPanel.",
+    purposes: ['stale'],
+    note: "A risk's impact enum (low..critical); with probability drives severity. User-editable in isolation via RiskPanel (setImpact → updateNode(data.impact)). #453. Consumers: staleness, RiskPanel. Persisted by hash-by-default.",
+  },
+  {
+    field: '_baseline_snapshot',
+    purposes: ['ephemeral'],
+    note: 'Transient session state (labelled as such at store.ts saveScenario / contextMenu/actions.ts): the pre-modification observed value captured by the Set-value best/worst-case actions so "reset to baseline" can restore it. Cleared on scenario save. Never written in isolation — ensureBaselineSnapshot always co-writes observedState (a persisted field) in the same action, so denylisting it changes no save-trigger; it is EPHEMERAL to document intent and stop a future isolated write from falsely dirtying the autosave. Not analysis-affecting (bypasses PLoT). Excluded from computeGraphHash.',
   },
 ] as const
 
 // ---------------------------------------------------------------------------
 // Edge data fields
+//
+// No edge `data.*` field is ephemeral today — path-highlight / dim / selection
+// live in SEPARATE store state (highlightedEdgeIds / dimmedNodeIds), never on
+// edge.data, so nothing on the edge churns per-render. Every field below is
+// analysis-affecting ('stale') and persisted by hash-by-default.
 // ---------------------------------------------------------------------------
 
 export const EDGE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
   {
     field: 'weight',
-    purposes: ['persist', 'stale'],
-    note: 'Magnitude of the edge influence. Consumers: staleness (hasAnalyticalEdgeChange), autosave.',
+    purposes: ['stale'],
+    note: 'Magnitude of the edge influence. Consumers: staleness (hasAnalyticalEdgeChange). Persisted by hash-by-default.',
   },
   {
     field: 'direction',
-    purposes: ['persist', 'stale'],
-    note: 'Sign of the edge influence; CEE adjust_edge_strength writes it via updateEdgeData without touching endpoints. Consumers: staleness, autosave.',
+    purposes: ['stale'],
+    note: 'Sign of the edge influence; CEE adjust_edge_strength writes it via updateEdgeData without touching endpoints. Consumers: staleness. Persisted by hash-by-default.',
   },
   {
     field: 'strengthStd',
-    purposes: ['persist', 'stale'],
-    note: 'Uncertainty (std) on the edge weight. Consumers: staleness, autosave.',
+    purposes: ['stale'],
+    note: 'Uncertainty (std) on the edge weight. Consumers: staleness. Persisted by hash-by-default.',
   },
   {
     field: 'confidence',
-    purposes: ['persist', 'stale'],
-    note: 'Edge confidence; also the legacy dirty-gate key (computeGraphHash previously keyed on confidence ?? weight). Consumers: staleness, autosave.',
+    purposes: ['stale'],
+    note: 'Edge confidence; also the legacy dirty-gate composite (computeGraphHash keeps `confidence ?? weight` inline for exact backward compat). Consumers: staleness. Persisted by hash-by-default.',
   },
   {
     field: 'beliefExists',
-    purposes: ['persist', 'stale'],
-    note: 'Probability the edge relationship exists. Consumers: staleness, autosave.',
+    purposes: ['stale'],
+    note: 'Probability the edge relationship exists. Consumers: staleness. Persisted by hash-by-default.',
   },
   {
     field: 'beliefStrength',
     purposes: ['stale'],
-    note: "Belief magnitude on the edge — analysis-affecting. Task #23 adjudication: deliberately NOT persisted — NO live editor writes edge.data.beliefStrength in isolation. It is set only at edge CREATION (DEFAULT_EDGE_DATA default 0.5) and by CEE normalisation in edges.ts; the live edge inspector (EdgePanel → useEdgeMutations) writes weight/direction/strengthStd/beliefExists, never beliefStrength. An uneditable field can't be lost by an isolated edit. Consumers: staleness.",
+    note: "Belief magnitude on the edge — analysis-affecting. Task #23 trace: NO live editor writes edge.data.beliefStrength in isolation (set only at edge CREATION via DEFAULT_EDGE_DATA and by CEE normalisation in edges.ts; the live edge inspector writes weight/direction/strengthStd/beliefExists). Consumers: staleness. Persisted by hash-by-default.",
   },
   {
     field: 'belief',
     purposes: ['stale'],
-    note: "Legacy belief scalar — analysis-affecting. Task #23 adjudication: deliberately NOT persisted — the only editor that writes edge.data.belief is the DEAD v1 edge inspector (EdgeInspector/InspectorPanel; InspectorModal hardcodes USE_INSPECTOR_V2=true so the live path is EdgePanel, which writes beliefExists, not belief). No live user editor → no isolated edit to lose. Consumers: staleness.",
+    note: "Legacy belief scalar — analysis-affecting. Task #23 trace: the only writer is the DEAD v1 edge inspector (live path is EdgePanel, which writes beliefExists). Consumers: staleness. Persisted by hash-by-default.",
   },
   {
     field: 'exists_probability',
     purposes: ['stale'],
-    note: "snake_case existence probability — analysis-affecting. Task #23 adjudication: deliberately NOT persisted — no isolated user editor. It is written ONLY by the CEE ingestion paths (applyPatch/applyDraftResult buildEdge), each of which co-writes beliefExists (a persist field) in the same edge rebuild, so any change already flips the autosave dirty hash; the live user editor (EdgePanel setExistsProbability) writes beliefExists. Consumers: staleness.",
+    note: "snake_case existence probability — analysis-affecting. Task #23 trace: written ONLY by CEE ingestion (applyPatch/applyDraftResult buildEdge), each co-writing beliefExists; the live editor (EdgePanel setExistsProbability) writes beliefExists. Consumers: staleness. Persisted by hash-by-default.",
   },
 ] as const
 
@@ -213,11 +236,15 @@ export function deriveFields(
   return registry.filter((f) => f.purposes.includes(purpose)).map((f) => f.field)
 }
 
-/** Node `data.*` fields whose change must survive a reload (autosave dirty-gate). */
-export const PERSIST_NODE_FIELDS = deriveFields(NODE_FIELD_REGISTRY, 'persist')
+/**
+ * Node `data.*` fields EXCLUDED from the autosave hash (computeGraphHash) —
+ * transient/derived state whose change must NOT trigger a save. Everything else
+ * on node.data is hashed by default.
+ */
+export const EPHEMERAL_NODE_FIELDS = deriveFields(NODE_FIELD_REGISTRY, 'ephemeral')
 /** Node `data.*` fields whose change invalidates the analysis (staleness). */
 export const STALE_NODE_FIELDS = deriveFields(NODE_FIELD_REGISTRY, 'stale')
-/** Edge `data.*` fields whose change must survive a reload (autosave dirty-gate). */
-export const PERSIST_EDGE_FIELDS = deriveFields(EDGE_FIELD_REGISTRY, 'persist')
+/** Edge `data.*` fields EXCLUDED from the autosave hash (empty today). */
+export const EPHEMERAL_EDGE_FIELDS = deriveFields(EDGE_FIELD_REGISTRY, 'ephemeral')
 /** Edge `data.*` fields whose change invalidates the analysis (staleness). */
 export const STALE_EDGE_FIELDS = deriveFields(EDGE_FIELD_REGISTRY, 'stale')

--- a/src/canvas/hooks/__tests__/useAutosave.analysisFieldPersist.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.analysisFieldPersist.spec.ts
@@ -12,20 +12,19 @@
  *   • impact      — RiskPanel → setImpact      → updateNode(data.impact)
  *   • prior       — FactorExternalPanel → setPriorRange → updateNode(data.prior)
  *
- * Task #23 flips them INTO the persist subset. These are the RED-first round-trip
- * pins, one per field: edit ONLY that field through the real store edit seam
- * (updateNode, the chokepoint every panel setter routes through) →
+ * These are the round-trip pins, one per field: edit ONLY that field through the
+ * real store edit seam (updateNode, the chokepoint every panel setter routes
+ * through) →
  *   (1) computeGraphHash flips,
  *   (2) the next autosave interval FIRES saveAutosave (spy) and the serialized
  *       node carries the new value,
  *   (3) a real saveAutosave → loadAutosave round-trip hydrates it back.
  *
- * RED before the flip: PERSIST_NODE_FIELDS excludes these fields, so
- * computeGraphHash ignores them, the save is skipped, and (1)/(2) fail.
- *
- * Mutation-check: un-flip any one field in the registry (and its EXPECTED_PERSIST_NODE
- * mirror) → EXACTLY that field's pins here go RED; the #461 drift guard stays green
- * (its consumer-tie derives from the registry). See analyticalNodeFields.registry.spec.ts.
+ * Codex P1-1 note: the dirty-gate is now hash-by-default with an ephemeral
+ * denylist, so these analysis-affecting fields are persisted automatically. The
+ * historical defect these pins guard against was the OLD persist-allowlist
+ * excluding them; the discriminator control below edits an EPHEMERAL field and
+ * asserts NO save, so the pins are not passing because "any edit saves".
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -147,8 +146,9 @@ describe('task #23 — analysis-affecting node fields survive reload (persist ro
           [{ id: 'n1', type: c.nodeId === RISK_ID ? 'risk' : 'factor', position: { x: 0, y: 0 }, data: { [c.field]: c.value } }],
           [],
         )
-        // RED before the flip: PERSIST_NODE_FIELDS excludes this field, so the
-        // hash object omits it and the two hashes are identical.
+        // These fields are analysis-affecting AND now persisted by hash-by-default
+        // (Codex P1-1); under the old persist-allowlist they were excluded and the
+        // two hashes were identical (the #457 loss class).
         expect(after, `${c.field} does not flip computeGraphHash`).not.toBe(before)
       })
 
@@ -162,8 +162,8 @@ describe('task #23 — analysis-affecting node fields survive reload (persist ro
         editOnlyField(c.nodeId, c.field, c.value)
         advanceOneAutosaveCycle()
 
-        // RED before the flip: the hash ignores this field, the save is skipped,
-        // and localStorage keeps the pre-edit value (the reload revert).
+        // The hash now covers this field, so the edit triggers a re-save; before
+        // the fix the save was skipped and localStorage kept the pre-edit value.
         expect(mockSaveAutosave, `${c.field}-only edit did not trigger a re-save`).toHaveBeenCalledTimes(2)
 
         const saved = mockSaveAutosave.mock.calls.at(-1)?.[0] as AutosaveData
@@ -192,15 +192,33 @@ describe('task #23 — analysis-affecting node fields survive reload (persist ro
     })
   }
 
-  it('control: a cosmetic-only node edit still does NOT re-save (dirty-hash guard intact)', () => {
+  it('FLIPPED DEFECT PIN (Codex P1-1): a description-only edit now DOES re-save', () => {
+    // This test previously pinned the DEFECT — it asserted a `description` edit did
+    // NOT re-save (description was excluded from the old PERSIST_NODE_FIELDS
+    // allowlist), so a user's description edit was silently lost on reload. Under
+    // hash-by-default `description` is persisted, so the edit must now trigger a save.
     renderHook(() => useAutosave())
     advanceOneAutosaveCycle()
     expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
 
-    // `description` is cosmetic — excluded from PERSIST_NODE_FIELDS. Proves the
-    // pins above discriminate (they are not passing because ANY edit saves).
     editOnlyField(RISK_ID, 'description', 'new copy')
     advanceOneAutosaveCycle()
+    expect(mockSaveAutosave, 'description edit did not persist — hash-by-default regressed').toHaveBeenCalledTimes(2)
+    const saved = mockSaveAutosave.mock.calls.at(-1)?.[0] as AutosaveData
+    expect((saved.nodes.find((n) => n.id === RISK_ID)?.data as any)?.description).toBe('new copy')
+  })
+
+  it('control: an EPHEMERAL-only node edit still does NOT re-save (denylist discriminates)', () => {
+    // The new discriminator under hash-by-default: an edit touching ONLY a
+    // denylisted ephemeral field (goal_threshold — a derived cache re-computed on
+    // restore) must NOT trigger a save. Proves the pins above are not passing
+    // vacuously because "any edit saves".
+    renderHook(() => useAutosave())
+    advanceOneAutosaveCycle()
     expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+
+    editOnlyField(RISK_ID, 'goal_threshold', 0.42)
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave, 'ephemeral goal_threshold edit wrongly triggered a save').toHaveBeenCalledTimes(1)
   })
 })

--- a/src/canvas/hooks/__tests__/useAutosave.hashByDefault.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.hashByDefault.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Codex P1-1 — hash-by-default: previously-lost user-editable fields survive reload.
+ *
+ * The autosave dirty-gate (computeGraphHash) used to hash only a hand-curated
+ * PERSIST allowlist. Six user-editable node fields were never on it, so an edit
+ * touching ONLY one of them never flipped the dirty hash → the 30s autosave
+ * skipped → localStorage kept the pre-edit value → the edit was silently lost on
+ * reload (the same loss class as #457, one allowlist-omission at a time):
+ *
+ *   • description         — RiskPanel/EmptyDescriptionPrompt → setDescription
+ *   • category            — classification editor → setCategory
+ *   • extractionType      — calibration editor → setExtractionType
+ *   • factor_type         — factor editor → setFactorType
+ *   • state_space         — normalisation range editor → setStateSpaceRange
+ *   • uncertainty_drivers — uncertainty editor → setUncertaintyDrivers
+ *
+ * All six are written at the TOP LEVEL of node.data by their inspector mutations,
+ * all of which route through the store `updateNode` chokepoint. Under hash-by-default
+ * they are persisted automatically (none is on the ephemeral denylist).
+ *
+ * Each pin: edit ONLY that field via updateNode →
+ *   (1) computeGraphHash flips,
+ *   (2) a real saveAutosave → loadAutosave round-trip hydrates the value back.
+ *
+ * RED before the fix (old persist-allowlist): computeGraphHash omitted these
+ * fields, so (1) failed (identical hashes).
+ *
+ * Mutation-check: add any one of these fields to the ephemeral denylist in
+ * analyticalNodeFields.ts → EXACTLY that field's (1) goes RED here, and the
+ * deny-direction safety assertion in analyticalNodeFields.registry.spec.ts also
+ * fires (it is a known-editor-persist field).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { computeGraphHash } from '../useAutosave'
+import { projectAutosaveData } from '../../store/autosaveProjection'
+import { saveAutosave, loadAutosave, clearAutosave } from '../../store/scenarios'
+
+const FACTOR_ID = 'factor-1'
+
+function baseNode() {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 40, y: 200 },
+    data: { kind: 'factor', label: 'Market rate' } as Record<string, unknown>,
+  }
+}
+
+interface FieldCase {
+  field: string
+  value: unknown
+  editor: string
+}
+
+const CASES: FieldCase[] = [
+  { field: 'description', value: 'Refined analyst note', editor: 'setDescription' },
+  { field: 'category', value: 'external', editor: 'setCategory' },
+  { field: 'extractionType', value: 'explicit', editor: 'setExtractionType' },
+  { field: 'factor_type', value: 'continuous', editor: 'setFactorType' },
+  { field: 'state_space', value: { range: { min: 0, max: 100 } }, editor: 'setStateSpaceRange' },
+  { field: 'uncertainty_drivers', value: ['fx rate', 'demand'], editor: 'setUncertaintyDrivers' },
+]
+
+beforeEach(() => {
+  clearAutosave()
+})
+
+describe('Codex P1-1 — hash-by-default persists previously-lost user fields', () => {
+  for (const c of CASES) {
+    describe(`${c.field} (${c.editor})`, () => {
+      it('computeGraphHash flips when ONLY this field changes', () => {
+        const before = computeGraphHash([baseNode()], [])
+        const edited = baseNode()
+        edited.data = { ...edited.data, [c.field]: c.value }
+        const after = computeGraphHash([edited], [])
+        // RED under the old persist-allowlist: the field was omitted from the hash,
+        // so before === after and the edit was invisible to autosave.
+        expect(after, `${c.field} does not flip computeGraphHash`).not.toBe(before)
+      })
+
+      it('serialize → hydrate round-trip restores the value', () => {
+        const edited = baseNode()
+        edited.data = { ...edited.data, [c.field]: c.value }
+
+        const payload = projectAutosaveData({
+          nodes: [edited] as any,
+          edges: [],
+          scenarioId: undefined,
+          ceeAnalysisReady: undefined,
+          selectedGoalNode: null,
+        })
+        clearAutosave()
+        saveAutosave(payload)
+        const hydrated = loadAutosave()
+
+        const restored = hydrated?.nodes.find((n) => n.id === FACTOR_ID)
+        expect((restored?.data as any)?.[c.field]).toEqual(c.value)
+      })
+    })
+  }
+
+  it('control: an ephemeral field (goal_threshold) does NOT flip the hash (denylist honoured)', () => {
+    const before = computeGraphHash([baseNode()], [])
+    const edited = baseNode()
+    edited.data = { ...edited.data, goal_threshold: 0.42 }
+    const after = computeGraphHash([edited], [])
+    // Proves the pins above discriminate — a denylisted derived cache is excluded.
+    expect(after).toBe(before)
+  })
+})

--- a/src/canvas/hooks/__tests__/useV2Run.goalCapStaleness.spec.ts
+++ b/src/canvas/hooks/__tests__/useV2Run.goalCapStaleness.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Codex P1-2 — a goal-scale-cap edit must stale the analysis.
+ *
+ * `goal_threshold_cap` participates in the normalised threshold the run request
+ * carries (resolveGoalThresholdCap → resolveChipGoalThreshold, UI-SEM-058:
+ * normalised = raw / cap). But the registry marked it persist-only, so a
+ * GoalAdvancedEditor "Scale cap" edit (setGoalCap → updateNode(goal_threshold_cap))
+ * left analysisFreshnessDirty=false WHILE CHANGING THE MATH — the UI kept saying
+ * "fresh" over a stale result. Repro: raw 20, cap 25→100 flips the implied
+ * threshold 0.8→0.2.
+ *
+ * Codex P1-2 gives `goal_threshold_cap` the `stale` purpose so the edit routes
+ * through hasAnalyticalNodeChange → invalidateAnalysisReady → markAnalysisFreshnessDirty.
+ *
+ * RED before the fix: goal_threshold_cap ∉ STALE_NODE_FIELDS, so the cap-only
+ * updateNode is a no-op for staleness and analysisFreshnessDirty stays false.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { resolveChipGoalThreshold } from '../useV2Run'
+
+const GOAL_ID = 'goal-1'
+
+function seedGoalWithCap(cap: number) {
+  useCanvasStore.getState().reset()
+  useCanvasStore.setState({
+    outcomeNodeId: GOAL_ID,
+    analysisFreshnessDirty: false,
+    nodes: [
+      {
+        id: GOAL_ID,
+        type: 'goal',
+        position: { x: 0, y: 0 },
+        data: {
+          kind: 'goal',
+          label: 'Revenue',
+          goal_threshold_raw: 20,
+          goal_threshold_cap: cap,
+        },
+      },
+    ] as any,
+    edges: [] as any,
+  })
+}
+
+describe('Codex P1-2 — goal_threshold_cap edit stales the analysis', () => {
+  beforeEach(() => {
+    seedGoalWithCap(25)
+  })
+
+  it('a cap-only edit flips analysisFreshnessDirty', () => {
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+
+    // Exactly what GoalAdvancedEditor → setGoalCap performs.
+    useCanvasStore.getState().updateNode(GOAL_ID, {
+      data: { ...useCanvasStore.getState().nodes[0].data, goal_threshold_cap: 100 },
+    } as any)
+
+    // RED before the fix: goal_threshold_cap was persist-only, so this stayed false.
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+  })
+
+  it('the new cap changes the normalised threshold the next run would carry (0.8 → 0.2)', () => {
+    const nodesBefore = useCanvasStore.getState().nodes
+    const before = resolveChipGoalThreshold(20, {
+      analysisReady: null,
+      nodes: nodesBefore,
+      goalNodeId: GOAL_ID,
+      representation: 'raw',
+    })
+    expect(before).toBeCloseTo(0.8, 5) // 20 / 25
+
+    useCanvasStore.getState().updateNode(GOAL_ID, {
+      data: { ...useCanvasStore.getState().nodes[0].data, goal_threshold_cap: 100 },
+    } as any)
+
+    const after = resolveChipGoalThreshold(20, {
+      analysisReady: null,
+      nodes: useCanvasStore.getState().nodes,
+      goalNodeId: GOAL_ID,
+      representation: 'raw',
+    })
+    expect(after).toBeCloseTo(0.2, 5) // 20 / 100
+  })
+})

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -21,77 +21,111 @@ import { useCanvasStore } from '../store'
 import { saveAutosave, loadAutosave } from '../store/scenarios'
 import { projectAutosaveData } from '../store/autosaveProjection'
 import type { AutosaveProjectionSource } from '../store/autosaveProjection'
-import { PERSIST_NODE_FIELDS, PERSIST_EDGE_FIELDS } from '../domain/analyticalNodeFields'
+import { EPHEMERAL_NODE_FIELDS, EPHEMERAL_EDGE_FIELDS } from '../domain/analyticalNodeFields'
+
+// The autosave hash now covers node/edge `data.*` BY DEFAULT (Codex P1-1) and
+// EXCLUDES only the small ephemeral denylist below (transient UI/session state +
+// derived caches re-computed on restore). Sets for O(1) membership.
+const EPHEMERAL_NODE_SET: ReadonlySet<string> = new Set(EPHEMERAL_NODE_FIELDS)
+const EPHEMERAL_EDGE_SET: ReadonlySet<string> = new Set(EPHEMERAL_EDGE_FIELDS)
+
+/**
+ * Deterministic JSON with object keys sorted at every depth. Key-order-insensitive
+ * so re-serialising the same content in a different insertion order (a field
+ * deleted+re-added, a re-normalised object) produces the SAME hash and never
+ * fabricates a spurious save. Used only for the in-memory dirty comparison.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null'
+  if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']'
+  const obj = value as Record<string, unknown>
+  return (
+    '{' +
+    Object.keys(obj)
+      .sort()
+      .map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k]))
+      .join(',') +
+    '}'
+  )
+}
+
+/** Copy `data` minus the ephemeral denylist keys (shallow — denylist is top-level). */
+function serializableData(
+  data: Record<string, unknown>,
+  ephemeral: ReadonlySet<string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(data)) {
+    if (ephemeral.has(key)) continue
+    out[key] = data[key]
+  }
+  return out
+}
 
 const AUTOSAVE_INTERVAL_MS = 30 * 1000 // 30 seconds
 const DEBOUNCE_MS = 500 // Debounce writes to reduce localStorage contention
 
 /**
- * P1 Fix: Compute a canonical hash of graph state for dirty detection.
- * Includes node kind, label, position and edge source/target/weight.
- * Sorted to ensure consistent ordering.
+ * Compute a canonical hash of graph state for autosave dirty-detection.
  *
- * Lane A fix (edit-journey display closure, 2026-07-11): the hash must also
- * cover VALUE-BEARING data. Conversational edits (V5 graph_patch
- * set_factor_value → node.data.observedState merge; adjust_edge_strength →
- * edge.data weight/direction write; intervention / goal-threshold backfill)
- * change none of id/kind/label/position or edge endpoints, so the legacy
- * hash never flipped, the autosave skipped, and localStorage kept the
- * PRE-EDIT values — on reload the recovery path could hydrate the stale
- * graph while the server copy was correct (the "reload visual revert").
- * Extra fields here can only cause an extra save, never a missed one.
+ * HASH-BY-DEFAULT with an ephemeral denylist (Codex P1-1). The hash covers the
+ * structural signals (id / kind via RF `type` / label / position; edge endpoints
+ * + the legacy `confidence ?? weight` composite) PLUS every `data.*` field EXCEPT
+ * the small ephemeral denylist (EPHEMERAL_NODE_FIELDS / EPHEMERAL_EDGE_FIELDS from
+ * the analyticalNodeFields registry).
  *
- * The value-bearing `data.*` fields covered here now DERIVE from the single
- * analyticalNodeFields registry (PERSIST_NODE_FIELDS / PERSIST_EDGE_FIELDS) — the
- * same source the analysis-staleness gate derives from. This closes the drift that
- * caused #457 (success_threshold/threshold_source missing here) and is verified by
- * analyticalNodeFields.registry.spec.ts. Structural signals (id / kind via RF type
- * / label / position; edge endpoints + the legacy confidence??weight composite)
- * stay inline — the registry enumerates value-bearing data fields only. The hash is
- * compared only against itself in-memory (lastSavedHashRef), so the object key names
- * are immaterial; only the SET of fields covered affects dirty-detection.
+ * WHY inverted from an allowlist (adjudicated, do not re-litigate): the previous
+ * version hashed only a hand-curated PERSIST allowlist, so user-editable fields
+ * never on it (`description`, `category`, `extractionType`, `factor_type`,
+ * `state_space`, `uncertainty_drivers`) never flipped the dirty hash → the 30s
+ * autosave skipped → the edit was lost on reload. That is the #457 loss class, one
+ * allowlist-omission at a time. Hashing by default makes the safe direction the
+ * default: a new field that is NOT denylisted merely causes an extra (debounced)
+ * save — harmless; a user-editable field can no longer be silently dropped by
+ * omission. The denylist only excludes transient UI/session state and derived
+ * caches re-computed on restore, so it cannot churn per-render (the debounce
+ * further bounds writes).
  *
- * Exported for the drift guard's behavioural cross-check (registry persist fields
- * must each flip this hash).
+ * `data.*` is serialised with STABLE KEY ORDER at every depth (stableStringify),
+ * so a re-normalised object with identical content does not fabricate a save. The
+ * hash is compared only against itself in-memory (lastSavedHashRef), so object key
+ * names are immaterial; only the SET of fields and their VALUES matter.
+ *
+ * Exported for the drift guard's behavioural cross-check: an ephemeral field must
+ * NOT flip this hash; any non-ephemeral data field MUST.
  */
 export function computeGraphHash(nodes: any[], edges: any[]): string {
   const canonical = {
     nodes: nodes
       .map(n => {
         const data = (n.data ?? {}) as Record<string, unknown>
-        const analytical: Record<string, unknown> = {}
-        // Value-bearing node data — derived from the persist registry subset.
-        for (const field of PERSIST_NODE_FIELDS) analytical[field] = data[field] ?? null
         return {
           id: n.id,
           kind: n.type ?? n.data?.kind,
           label: n.data?.label ?? '',
           x: Math.round(n.position?.x ?? 0),
           y: Math.round(n.position?.y ?? 0),
-          ...analytical,
+          // All node data by default, minus the ephemeral denylist.
+          data: serializableData(data, EPHEMERAL_NODE_SET),
         }
       })
       .sort((a, b) => a.id.localeCompare(b.id)),
     edges: edges
       .map(e => {
         const data = (e.data ?? {}) as Record<string, unknown>
-        const analytical: Record<string, unknown> = {}
-        // Value-bearing edge data — adjust_edge_strength writes these via
-        // updateEdgeData without touching the endpoints. Derived from the persist
-        // registry subset.
-        for (const field of PERSIST_EDGE_FIELDS) analytical[field] = data[field] ?? null
         return {
           from: e.source,
           to: e.target,
-          // Legacy composite (redundant with weight/confidence above, kept to
-          // preserve the exact dirty-detection behaviour).
+          // Legacy composite kept inline to preserve exact dirty-detection for the
+          // old callers; redundant with `data.confidence`/`data.weight` below.
           weight: e.data?.confidence ?? e.data?.weight ?? '',
-          ...analytical,
+          // All edge data by default, minus the ephemeral denylist (empty today).
+          data: serializableData(data, EPHEMERAL_EDGE_SET),
         }
       })
       .sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to)),
   }
-  return JSON.stringify(canonical)
+  return stableStringify(canonical)
 }
 
 export function useAutosave() {

--- a/src/canvas/ui/inspector-v2/__tests__/InlineNumberEditor.precision.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InlineNumberEditor.precision.spec.tsx
@@ -1,0 +1,180 @@
+/**
+ * Codex P1-4 — InlineNumberEditor exact-seed + unchanged-blur no-op.
+ *
+ * The shared editor used to seed from the ROUNDED display (Math.round(p*100)) and
+ * call onSave on EVERY valid blur. So opening a 0.376 probability (shown "38%") and
+ * tabbing out committed 0.38 — a passthrough violation that destroyed producer
+ * precision and falsely dirtied the graph.
+ *
+ * Fix (shared component): (a) seed the draft from the EXACT value, (b) skip onSave
+ * when the parsed draft equals the seeded exact value, (c) permit fractional input.
+ *
+ * Verified on BOTH consumers: RiskPanel (×100 percent scale, the precision case)
+ * and FactorObservablePanel (raw scale, the unchanged-blur no-op).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { RiskPanel } from '../panels/RiskPanel'
+import { FactorObservablePanel } from '../panels/FactorObservablePanel'
+import { InlineNumberEditor } from '../shared/InlineNumberEditor'
+import { useCanvasStore } from '../../../store'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+
+const panelProps = (nodeId: string) => ({ nodeId, techMode: false, onClose: vi.fn(), onNavigate: vi.fn() })
+
+beforeEach(() => {
+  cleanup()
+  useGuidanceStore.setState({ guidanceItems: [], _prefillChat: null, _sendMessage: null })
+})
+
+// ---------------------------------------------------------------------------
+// Component-level unit tests
+// ---------------------------------------------------------------------------
+
+describe('InlineNumberEditor — exact seed + no-op blur (component)', () => {
+  it('seeds the input from the EXACT value, not a rounded readout', () => {
+    render(
+      <InlineNumberEditor
+        readout="38%"
+        placeholder="none"
+        value={37.6}
+        onSave={vi.fn()}
+        displayTestId="d"
+        inputTestId="i"
+      />,
+    )
+    fireEvent.click(screen.getByTestId('d'))
+    expect((screen.getByTestId('i') as HTMLInputElement).value).toBe('37.6')
+  })
+
+  it('does NOT call onSave when the value is blurred unchanged', () => {
+    const onSave = vi.fn()
+    render(
+      <InlineNumberEditor readout="38%" placeholder="none" value={37.6} onSave={onSave} displayTestId="d" inputTestId="i" />,
+    )
+    fireEvent.click(screen.getByTestId('d'))
+    fireEvent.blur(screen.getByTestId('i'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('calls onSave with the parsed value on a real change', () => {
+    const onSave = vi.fn()
+    render(
+      <InlineNumberEditor readout="38%" placeholder="none" value={37.6} onSave={onSave} displayTestId="d" inputTestId="i" />,
+    )
+    fireEvent.click(screen.getByTestId('d'))
+    fireEvent.change(screen.getByTestId('i'), { target: { value: '40' } })
+    fireEvent.blur(screen.getByTestId('i'))
+    expect(onSave).toHaveBeenCalledWith(40)
+  })
+
+  it('permits fractional input (step defaults to "any")', () => {
+    render(
+      <InlineNumberEditor readout="38%" placeholder="none" value={37.6} onSave={vi.fn()} displayTestId="d" inputTestId="i" />,
+    )
+    fireEvent.click(screen.getByTestId('d'))
+    expect((screen.getByTestId('i') as HTMLInputElement).getAttribute('step')).toBe('any')
+  })
+
+  it('discards a non-numeric commit', () => {
+    const onSave = vi.fn()
+    render(
+      <InlineNumberEditor readout="38%" placeholder="none" value={37.6} onSave={onSave} displayTestId="d" inputTestId="i" />,
+    )
+    fireEvent.click(screen.getByTestId('d'))
+    fireEvent.change(screen.getByTestId('i'), { target: { value: 'abc' } })
+    fireEvent.blur(screen.getByTestId('i'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RiskPanel (×100 percent scale) — the precision case
+// ---------------------------------------------------------------------------
+
+function seedRisk(probability: number) {
+  useCanvasStore.setState(useCanvasStore.getState(), true)
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'risk1', type: 'risk', position: { x: 0, y: 0 }, data: { label: 'Churn risk', description: 'x', probability, impact: 'medium' } },
+    ],
+    edges: [],
+    results: { status: 'none', report: null },
+    analysisFreshnessDirty: false,
+  } as any)
+}
+
+describe('RiskPanel — opening + blurring a 0.376 probability preserves precision', () => {
+  it('unchanged blur commits nothing (0.376 stays 0.376, not 0.38) and does not dirty', () => {
+    seedRisk(0.376)
+    const updateSpy = vi.spyOn(useCanvasStore.getState(), 'updateNode')
+    render(<RiskPanel {...panelProps('risk1')} />)
+
+    // Display shows the rounded "38%"; the editor seeds the exact 37.6.
+    expect(screen.getByTestId('risk-probability-display').textContent).toMatch(/38%/)
+    fireEvent.click(screen.getByTestId('risk-probability-display'))
+    expect((screen.getByTestId('risk-probability-input') as HTMLInputElement).value).toBe('37.6')
+    fireEvent.blur(screen.getByTestId('risk-probability-input'))
+
+    const prob = (useCanvasStore.getState().nodes.find(n => n.id === 'risk1')!.data as any).probability
+    expect(prob).toBeCloseTo(0.376, 6) // NOT 0.38 — precision preserved
+    expect(updateSpy).not.toHaveBeenCalled() // zero store writes
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+    updateSpy.mockRestore()
+  })
+
+  it('a real edit still saves (40 → 0.40)', () => {
+    seedRisk(0.376)
+    render(<RiskPanel {...panelProps('risk1')} />)
+    fireEvent.click(screen.getByTestId('risk-probability-display'))
+    fireEvent.change(screen.getByTestId('risk-probability-input'), { target: { value: '40' } })
+    fireEvent.blur(screen.getByTestId('risk-probability-input'))
+    const prob = (useCanvasStore.getState().nodes.find(n => n.id === 'risk1')!.data as any).probability
+    expect(prob).toBeCloseTo(0.4, 6)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FactorObservablePanel (raw scale) — the unchanged-blur no-op
+// ---------------------------------------------------------------------------
+
+function seedFactor(value: number) {
+  useCanvasStore.setState(useCanvasStore.getState(), true)
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'factor-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Market rate', category: 'observable', observedState: { value } } },
+    ],
+    edges: [],
+    results: { status: 'none', report: null },
+    analysisFreshnessDirty: false,
+  } as any)
+}
+
+describe('FactorObservablePanel — unchanged blur is a no-op', () => {
+  it('opening + blurring an unchanged value commits nothing', () => {
+    seedFactor(0.376)
+    const updateSpy = vi.spyOn(useCanvasStore.getState(), 'updateNode')
+    render(<FactorObservablePanel {...panelProps('factor-1')} />)
+
+    fireEvent.click(screen.getByTestId('observable-value-display'))
+    expect((screen.getByTestId('observable-value-input') as HTMLInputElement).value).toBe('0.376')
+    fireEvent.blur(screen.getByTestId('observable-value-input'))
+
+    const val = (useCanvasStore.getState().nodes.find(n => n.id === 'factor-1')!.data as any).observedState.value
+    expect(val).toBeCloseTo(0.376, 6)
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+    updateSpy.mockRestore()
+  })
+
+  it('a real edit still saves', () => {
+    seedFactor(0.376)
+    render(<FactorObservablePanel {...panelProps('factor-1')} />)
+    fireEvent.click(screen.getByTestId('observable-value-display'))
+    fireEvent.change(screen.getByTestId('observable-value-input'), { target: { value: '0.5' } })
+    fireEvent.blur(screen.getByTestId('observable-value-input'))
+    const val = (useCanvasStore.getState().nodes.find(n => n.id === 'factor-1')!.data as any).observedState.value
+    expect(val).toBeCloseTo(0.5, 6)
+  })
+})

--- a/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
@@ -203,7 +203,8 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
           <InlineNumberEditor
             readout={displayValue != null ? formatValue(displayValue) : null}
             placeholder="No value set. Click to enter."
-            editSeed={String(displayValue ?? '')}
+            // Exact raw value (no scale conversion here) → unchanged-blur is a no-op (P1-4).
+            value={displayValue ?? null}
             onSave={handleValueSave}
             displayTestId="observable-value-display"
             inputTestId="observable-value-input"

--- a/src/canvas/ui/inspector-v2/panels/RiskPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/RiskPanel.tsx
@@ -122,14 +122,15 @@ export const RiskPanel = memo(function RiskPanel({
             <InlineNumberEditor
               readout={probabilityPct != null ? `${probabilityPct}%` : null}
               placeholder={INLINE_LABELS.riskNotSet}
-              editSeed={probabilityPct != null ? String(probabilityPct) : ''}
+              // Exact percent (unrounded) so opening + blurring a 0.376 (shown
+              // "38%") is a no-op and preserves the producer's precision (P1-4).
+              value={probability != null ? probability * 100 : null}
               onSave={handleProbabilitySave}
               displayTestId="risk-probability-display"
               inputTestId="risk-probability-input"
               title="Click to set likelihood"
               min={0}
               max={100}
-              step={1}
               ariaLabel="Likelihood percentage"
             />
           </div>

--- a/src/canvas/ui/inspector-v2/shared/InlineNumberEditor.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InlineNumberEditor.tsx
@@ -7,14 +7,18 @@
  * `readout` string, or the italic `placeholder` when there is no value. Click
  * enters edit mode.
  *
- * Edit mode: a number input seeded with `editSeed`; blur OR Enter commits.
- * On a commit that parses to a number the parsed value is handed to `onSave`
- * (the CALLER owns any scale conversion — e.g. percent → 0-1 — and the edit
- * confirmation, so semantic transforms stay tagged at their panel); a
- * non-numeric entry is discarded. Either outcome returns to display mode.
+ * Edit mode: a number input seeded with the EXACT current `value` (Codex P1-4);
+ * blur OR Enter commits. On commit the parsed number is handed to `onSave` (the
+ * CALLER owns any scale conversion — e.g. percent → 0-1 — and the edit
+ * confirmation, so semantic transforms stay tagged at their panel).
  *
- * Rendering is byte-identical to the two original inline editors — the panels'
- * existing specs pin the testids/markup and stay green.
+ * PRECISION / NO-OP (Codex P1-4): the draft is seeded from the UNROUNDED `value`,
+ * never from a rounded display string, and a commit whose parsed draft EQUALS the
+ * seeded exact `value` is a NO-OP (onSave is not called). This fixes a passthrough
+ * violation where opening a 0.376 probability (displayed "38%") and tabbing out
+ * committed 0.38 — destroying producer precision and falsely marking the graph
+ * dirty. Display formatting stays separate: `readout` may still be rounded.
+ * Fractional input is permitted (step defaults to "any").
  */
 import { useState, useCallback } from 'react'
 import { typography } from '../../../../styles/typography'
@@ -24,11 +28,17 @@ interface InlineNumberEditorProps {
   readout: string | null
   /** Italic copy shown when `readout` is null (e.g. "No value set. Click to enter."). */
   placeholder: string
-  /** Seeds the input's editable string when entering edit mode. */
-  editSeed: string
   /**
-   * Called with the parsed number on a valid commit. The caller applies any
-   * scale conversion and edit confirmation (keeping UI-SEM tags at the panel).
+   * The EXACT current value in the editor's own scale (percent for RiskPanel, raw
+   * for FactorObservablePanel). Seeds the input unrounded and is the no-op
+   * baseline: a commit that parses to this exact value does not call `onSave`.
+   * `null` means "no current value" — the input seeds empty.
+   */
+  value: number | null
+  /**
+   * Called with the parsed number on a valid commit that DIFFERS from `value`.
+   * The caller applies any scale conversion and edit confirmation (keeping
+   * UI-SEM tags at the panel).
    */
   onSave: (parsed: number) => void
   /** data-testid for the display button. */
@@ -40,14 +50,15 @@ interface InlineNumberEditorProps {
   /** Optional numeric input constraints + aria-label (e.g. risk's 0–100 %). */
   min?: number
   max?: number
-  step?: number
+  /** Input step. Defaults to "any" so fractional producer values are editable. */
+  step?: number | 'any'
   ariaLabel?: string
 }
 
 export function InlineNumberEditor({
   readout,
   placeholder,
-  editSeed,
+  value,
   onSave,
   displayTestId,
   inputTestId,
@@ -61,10 +72,16 @@ export function InlineNumberEditor({
   const [draft, setDraft] = useState<string>('')
 
   const handleSave = useCallback(() => {
-    const parsed = parseFloat(draft)
-    if (!isNaN(parsed)) onSave(parsed)
     setIsEditing(false)
-  }, [draft, onSave])
+    const parsed = parseFloat(draft)
+    // Non-numeric entry is discarded.
+    if (isNaN(parsed)) return
+    // No-op blur (Codex P1-4): the parsed draft equals the seeded exact value, so
+    // nothing changed — do NOT call onSave (which would round-trip through the
+    // caller's scale conversion, corrupting precision and falsely dirtying).
+    if (value != null && parsed === value) return
+    onSave(parsed)
+  }, [draft, onSave, value])
 
   if (!isEditing) {
     return (
@@ -73,7 +90,8 @@ export function InlineNumberEditor({
         data-testid={displayTestId}
         className={`${typography.panelHeader} text-xl text-left w-full cursor-text hover:bg-panel-hover rounded px-0.5 -mx-0.5 transition-colors`}
         onClick={() => {
-          setDraft(editSeed)
+          // Seed from the EXACT value, never a rounded display string.
+          setDraft(value != null ? String(value) : '')
           setIsEditing(true)
         }}
         title={title}
@@ -91,7 +109,7 @@ export function InlineNumberEditor({
       type="number"
       min={min}
       max={max}
-      step={step}
+      step={step ?? 'any'}
       data-testid={inputTestId}
       value={draft}
       autoFocus


### PR DESCRIPTION
Draft — Codex-review persistence + data-precision group (P1-1, P1-2, P1-4). Does **not** merge itself.

## P1-1 — INVERT the autosave-hash default (adjudicated design decision)
`computeGraphHash` (src/canvas/hooks/useAutosave.ts) used to hash only a hand-curated **persist allowlist** derived from `analyticalNodeFields.ts`. Six user-editable fields were never on it, so an edit touching only them never flipped the 30s dirty hash → the autosave skipped → the edit was lost on reload (the #457 loss class, one allowlist-omission at a time).

**Fix:** hash **all** serialized node/edge `data.*` **by default** (stable key order via a deep `stableStringify`), minus a small explicit **ephemeral denylist**. The registry keeps `stale` as an allowlist (narrower is correct for staleness); the old `persist` purpose is renamed to `ephemeral` (a denylist) and the #461 drift guard is reshaped to the deny direction.

**Ephemeral denylist (each with a WHY in the registry):**
| field | scope | why ephemeral |
|-------|-------|---------------|
| `goalThreshold` | node | camelCase derived goal-threshold cache, re-computed on restore from `success_threshold`/`goal_threshold_raw`; persisting it would let a recompute churn the dirty-gate. Still `stale`. |
| `goal_threshold` | node | snake_case derived/normalised goal threshold; derived + re-computed on restore. Still `stale`. |
| `_baseline_snapshot` | node | transient session state (labelled as such at store.ts / contextMenu/actions.ts); the pre-modification value for "reset to baseline", cleared on save, never written in isolation (always co-writes `observedState`). Not analysis-affecting. |
| _(edges)_ | — | **none** — path-highlight/dim/selection live in separate store state, never on `edge.data`, so nothing on an edge churns per-render. |

Everything else on `data.*` (incl. `description`, `category`, `extractionType`, `factor_type`, `state_space`, `uncertainty_drivers`, `goal_threshold_unit`, `threshold_source`) now persists by default and needs no registry row.

The guard now: named-field diff on the ephemeral denylist **and** a **deny-direction safety assertion** — no field a live editor writes as persistent state may appear on the denylist (a wrongly-denylisted persistent field = silent reload loss, fails RED).

**Flipped defect pin (named):** the old control asserting *"a description-only edit does NOT re-save"* pinned the defect — it is flipped to assert description now persists. A new discriminator control edits an ephemeral field and asserts **no** save (so the persist pins aren't passing because "any edit saves").

## P1-2 — goal cap must stale the analysis
`goal_threshold_cap` participates in the normalised threshold (`raw/cap`, UI-SEM-058; `resolveGoalThresholdCap` reads the goal node's `goal_threshold_cap`) but was persist-only, so a GoalAdvancedEditor cap edit (`setGoalCap` → `updateNode`) left `analysisFreshnessDirty=false` while changing the math (cap 25→100 flips implied 0.8→0.2). **Fix:** gave `goal_threshold_cap` the `stale` purpose.

**Raw-only audit (adjudicated at the bytes):** `goal_threshold_raw` is already `stale` (in `STALE_NODE_FIELDS`) — a raw-only edit already reaches staleness. **Not gapped.** `goal_threshold_unit` is display-only — left out of `stale` (persisted by default).

## P1-4 — InlineNumberEditor precision + unchanged-blur no-op (shared component)
The shared editor seeded from the **rounded** display (`Math.round(p*100)`) and saved on **every** valid blur → opening + tabbing out of a 0.376 probability committed 0.38 (passthrough violation, destroyed producer precision, falsely dirtied). **Fix in the shared component:** (a) seed the draft from the **exact** unrounded value (display formatting stays separate), (b) **skip `onSave`** when the parsed draft equals the seeded exact value, (c) permit fractional input (`step` defaults to `"any"`). Verified on **both** consumers — RiskPanel (×100 percent scale) and FactorObservablePanel (raw scale).

## Gates
- `pnpm run typecheck` — clean (`tsc -p tsconfig.ci.json`).
- Targeted vitest — 138 tests green across the touched + existing panel/persistence specs.
- `eslint` on changed files — 0 errors (4 pre-existing warnings: a DEV `console.log` and FactorObservablePanel's unused `onClose`/`cap`).

## Mutation results (each fix's pins go RED when reverted)
- **P1-1:** add `description` to the ephemeral denylist → the description-persist pins go RED **and** the deny-direction safety assertion fires. Reverted.
- **P1-2:** drop `stale` from `goal_threshold_cap` → the cap-staleness pin goes RED (the normalised-threshold math pin stays green — correctly independent). Reverted.
- **P1-4:** remove the no-op skip → exactly the 3 unchanged-blur pins go RED (exact-seed / fractional / real-edit / non-numeric stay green). Reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)