### PR TITLE
test(edges): correct flags-mock depth in three sibling specs (env-independence)

### DIFF
--- a/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
@@ -77,7 +77,7 @@ vi.mock('../../hooks/usePrefersReducedMotion', () => ({
   usePrefersReducedMotion: () => false,
 }))
 
-vi.mock('../../flags', () => ({
+vi.mock('../../../flags', () => ({
   isGraphLensEnabled: () => false,
 }))
 

--- a/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
@@ -71,7 +71,7 @@ vi.mock('../../hooks/usePrefersReducedMotion', () => ({
   usePrefersReducedMotion: () => false,
 }))
 
-vi.mock('../../flags', () => ({
+vi.mock('../../../flags', () => ({
   isGraphLensEnabled: () => false,
 }))
 

--- a/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
@@ -60,7 +60,7 @@ vi.mock('../../store/edgeLabelMode', () => ({ useEdgeLabelMode: (s: any) => s({ 
 vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
 vi.mock('../../hooks/useFirstTimeHints', () => ({ useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }) }))
 vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
-vi.mock('../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => false }))
 vi.mock('../../utils/fragileEdgeMatch', () => ({
   isEdgeFragile: () => false,
   getFragileEdgeSwitchProbability: () => null,


### PR DESCRIPTION
## What

Three edge specs mocked the graph-lens flag at the wrong depth:

- `src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx`
- `src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx`
- `src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx`

Each did `vi.mock('../../flags', () => ({ isGraphLensEnabled: () => false }))`. From the test dir `src/canvas/edges/__tests__/`, `'../../flags'` resolves to the **non-existent** `src/canvas/flags`, so the mock **silently no-opped** and the real `src/flags` module loaded. `StyledEdge` imports `isGraphLensEnabled` from `'../../../flags'` (== `src/flags`); the correct mock target from the test dir is `'../../../flags'`.

Fix: `'../../flags'` → `'../../../flags'` in all three (one line each).

## Why it's behaviour-preserving

All three mock `isGraphLensEnabled: () => false`, which equals the flag's **current default**. So the pre-existing no-op was harmless, and correcting the path changes no assertion outcome. What it removes is the **latent env-dependence**: with the mock now actually intercepting, the specs no longer read `import.meta.env.VITE_FEATURE_GRAPH_LENS` at all.

## Proof of env-independence (per file, both directions)

Post-fix, each file is green under **both** `VITE_FEATURE_GRAPH_LENS=true` and `env -u VITE_FEATURE_GRAPH_LENS`:

| Spec | `=true` | unset |
|------|---------|-------|
| contested | 9/9 ✅ | 9/9 ✅ |
| hover | 2/2 ✅ | 2/2 ✅ |
| projection | 4/4 ✅ | 4/4 ✅ |

### Pre-fix no-op proof (RED → GREEN)

A focused probe under `VITE_FEATURE_GRAPH_LENS=true` (throwaway, not committed):
- Mocking `'../../flags'` (wrong path) does **not** intercept the real `'../../../flags'` import → `isGraphLensEnabled()` returns `true` → **RED**.
- Mocking `'../../../flags'` (correct path) **does** intercept → returns `false` → **GREEN**.

(The three real specs themselves pass pre-fix under `=true` too, because their store mocks pin `lens.active: 'full'` with empty sets, which makes StyledEdge's lens-enabled code path inert — so the no-op was latent, not observable in these files. The probe isolates the no-op directly.)

## Gates

- `pnpm run typecheck` — clean
- Targeted vitest — three files green under both env conditions; full `src/canvas/edges` dir 169/171
- `eslint` on the three changed files — clean

## Out of scope (pre-existing, not this PR)

`src/canvas/edges/__tests__/StyledEdge.filterCompose.spec.tsx` fails 2/3 on `origin/staging` (reproduced with this change stashed). It has the same wrong-path mock but forces `() => true`, so its no-op **does** bite (real flag off → lens-filter tests fail). That file is fixed by the unmerged **#464** (Codex P2-1); no overlap with this PR.

Co-authored per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)