### PR TITLE
fix(ci+nodes+guard): staging gate green — stale scan entry, corner-stack edited dot, derived editor-field manifest

### DIFF
--- a/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
+++ b/src/canvas/domain/__tests__/analyticalNodeFields.registry.spec.ts
@@ -41,6 +41,7 @@ import {
 } from '../analyticalNodeFields'
 import { ANALYTICAL_NODE_DATA_FIELDS, ANALYTICAL_EDGE_FIELDS, hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from '../analyticalChange'
 import { computeGraphHash } from '../../hooks/useAutosave'
+import { EDITOR_WRITTEN_FIELDS } from '../../ui/inspector-v2/useInspectorMutations'
 
 // ---------------------------------------------------------------------------
 // The behavioural CONTRACT — the field sets the two bugs (#453/#457), task #23,
@@ -67,15 +68,31 @@ const EXPECTED_STALE_EDGE = [
 // Fields a LIVE user editor writes as persistent state. None may ever appear on the
 // ephemeral denylist — a denylisted persistent field is silently dropped on reload
 // (the exact #457 loss class). See "deny-direction safety" below.
+//
+// The inspector-hook portion is DERIVED from EDITOR_WRITTEN_FIELDS (declared beside
+// the setters in useInspectorMutations.ts, behaviourally pinned by
+// useInspectorMutations.writtenFields.spec.tsx) — NOT re-typed here. The old
+// hand-list silently OMITTED edge `label`, so denylisting `label` left this guard
+// green (Codex P2); deriving from the setters closes that.
+//
+// Fields written by editors OUTSIDE the inspector hook stay as a small residual
+// list, each annotated with its write site. (Follow-up: centralise these editors
+// behind the same manifest so this residual can go too.)
+const NON_INSPECTOR_PERSIST_NODE_FIELDS = [
+  'is_baseline',        // OutputsDock baseline toggle, useAddBaseline, applyDraftResult
+  'success_threshold',  // store.ts setGoalThreshold action, model-tab GoalSection
+  'threshold_source',   // store.ts setGoalThreshold action, model-tab GoalSection
+]
+const NON_INSPECTOR_PERSIST_EDGE_FIELDS = [
+  'confidence',         // useModelActionApply (model-action apply path)
+]
 const KNOWN_EDITOR_PERSIST_NODE_FIELDS = [
-  'observedState', 'interventions', 'is_baseline', 'success_threshold',
-  'goal_threshold_raw', 'goal_threshold_cap', 'goal_threshold_unit', 'threshold_source',
-  'prior', 'probability', 'impact',
-  'description', 'category', 'extractionType', 'factor_type', 'state_space',
-  'uncertainty_drivers', 'label',
+  ...EDITOR_WRITTEN_FIELDS.node,
+  ...NON_INSPECTOR_PERSIST_NODE_FIELDS,
 ]
 const KNOWN_EDITOR_PERSIST_EDGE_FIELDS = [
-  'weight', 'direction', 'strengthStd', 'confidence', 'beliefExists',
+  ...EDITOR_WRITTEN_FIELDS.edge,
+  ...NON_INSPECTOR_PERSIST_EDGE_FIELDS,
 ]
 
 /** Symmetric difference reported as named fields — the guard's failure message. */
@@ -247,6 +264,18 @@ describe('analyticalNodeFields registry — positive controls (guard catches dri
     const drifted = [...EPHEMERAL_NODE_FIELDS, 'success_threshold']
     const wronglyDenied = KNOWN_EDITOR_PERSIST_NODE_FIELDS.filter((f) => drifted.includes(f))
     expect(wronglyDenied).toEqual(['success_threshold'])
+    expect(wronglyDenied).not.toEqual([])
+  })
+
+  it('the deny-direction safety catches edge `label` wrongly denylisted (Codex P2 probe)', () => {
+    // setLabel (useInspectorMutations) writes edge.data.label — a persistent editor
+    // field. Denylisting it would silently drop relabels on reload. Pre-fix the edge
+    // persist list omitted `label`, so this exact probe stayed GREEN; now that the
+    // list DERIVES from EDITOR_WRITTEN_FIELDS.edge (which includes `label`), it bites.
+    expect(KNOWN_EDITOR_PERSIST_EDGE_FIELDS).toContain('label')
+    const drifted = [...EPHEMERAL_EDGE_FIELDS, 'label']
+    const wronglyDenied = KNOWN_EDITOR_PERSIST_EDGE_FIELDS.filter((f) => drifted.includes(f))
+    expect(wronglyDenied).toEqual(['label'])
     expect(wronglyDenied).not.toEqual([])
   })
 

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -274,19 +274,6 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         minHeight: isExpanded ? '120px' : undefined,
       }}
     >
-      {/* N3 (graph-visuals): amber corner dot — this node was edited since
-          the last analysis run (device-local diff vs the run snapshot; the
-          freshness strip stays the single freshness owner, this is WHERE).
-          Amber = the warning family per Paul's C2 hue ruling. */}
-      {isEditedSinceRun && (
-        <span
-          data-testid={`edited-since-run-${id}`}
-          role="img"
-          aria-label="Edited since the last analysis"
-          title="Edited since the last analysis"
-          className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-warning border border-canvas"
-        />
-      )}
       {/* Context menu: Assumption flag badge (Hard rule 3 — UI-only annotation) */}
       {Boolean(data?.flagged_as_assumption) && (
         <div
@@ -338,16 +325,22 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
       )}
 
       {/* Top-right corner STACK — a single absolutely-positioned flex row that
-          OWNS this corner so the sensitivity-rank badge and the coaching marker
-          never collide. Both previously rendered at `absolute -top-2 -right-2
-          z-10`, identical z, so the rank obscured the coaching marker (Codex
-          P1-5, browser-confirmed). They are now static siblings here: rank
-          FIRST (reads "key driver #N"), coaching beside it. The row is anchored
-          by its right edge and grows leftward, keeping both inside the top band
-          (no title overlap) and off the node's right side; siblings never
-          overlap, so both stay visible and the coaching button stays clickable.
-          Each child self-gates, so the container is empty (0×0, inert) when
-          neither applies. */}
+          OWNS this corner so the sensitivity-rank badge, the edited-since-run
+          dot and the coaching marker never collide. All three previously
+          rendered independently in this same corner (rank + coaching at
+          `-top-2 -right-2 z-10`; the edited dot at `-top-1 -right-1`, default
+          z), so the coaching marker fully covered the edited dot when both were
+          present (Codex P2, browser-confirmed) — the same class of same-corner
+          overlap the P1-5 rank/coaching fix addressed. They are now static flex
+          siblings here, ordered smallest-in-the-middle for legibility: rank
+          FIRST (reads "key driver #N"), then the small 10px edited-since-run
+          freshness dot, then the interactive coaching marker anchored at the
+          corner (rightmost — the easiest click target). The row is anchored by
+          its right edge and grows leftward, keeping all three inside the top
+          band (no title overlap) and off the node's right side; siblings never
+          overlap, so each stays visible and the coaching button stays
+          clickable. Each child self-gates, so the container is empty (0×0,
+          inert) when none applies. */}
       <div
         data-testid={`node-corner-stack-${id}`}
         className="absolute -top-2 -right-2 z-10 flex items-center gap-1"
@@ -362,6 +355,22 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
           >
             #{displayMetadata.sensitivityRank}
           </span>
+        )}
+
+        {/* N3 (graph-visuals): amber corner dot — this node was edited since the
+            last analysis run (device-local diff vs the run snapshot; the
+            freshness strip stays the single freshness owner, this is WHERE).
+            Amber = the warning family per Paul's C2 hue ruling. A static flex
+            child here (no absolute/offset of its own) so it sits beside — never
+            under — the coaching marker. `shrink-0` keeps the 10px dot round. */}
+        {isEditedSinceRun && (
+          <span
+            data-testid={`edited-since-run-${id}`}
+            role="img"
+            aria-label="Edited since the last analysis"
+            title="Edited since the last analysis"
+            className="shrink-0 h-2.5 w-2.5 rounded-full bg-warning border border-canvas"
+          />
         )}
 
         {/* On-canvas coaching marker — renders ONLY when a live guidance item

--- a/src/canvas/nodes/__tests__/BaseNode.cornerStack.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.cornerStack.spec.tsx
@@ -9,14 +9,23 @@
  * two render as static flex siblings, so they can no longer occupy the same
  * point.
  *
+ * The edited-since-run dot (Codex P2) was a third, independently-positioned
+ * element in this same corner (`-top-1 -right-1`, default z) — the coaching
+ * marker at `-top-2 -right-2 z-10` drew fully OVER it. It is now folded into the
+ * same stack as a static middle child (rank · edited-dot · coaching), so the
+ * same non-overlap guarantee covers all three.
+ *
  * These pins assert STRUCTURE (jsdom cannot measure pixels — see the honesty
  * note on the non-overlap test):
  *   - both present  → both rendered, inside the shared stack, rank first, and
  *                     neither child carries its own absolute/offset classes
  *                     (the layout-relevant signal that they can't self-collide)
+ *   - all three     → rank · edited-dot · coaching, three distinct siblings in
+ *                     order, the dot carrying no absolute/offset of its own
  *   - each alone    → renders in its place inside the stack
  *   - click-through → the coaching button's onClick still fires with the rank
- *                     badge present (it is a sibling, never covered)
+ *                     badge (and with the edited dot) present — it is a sibling,
+ *                     never covered
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -30,9 +39,12 @@ vi.mock('@xyflow/react', async () => {
 })
 
 // Hoisted so the vi.mock factory (also hoisted) can close over these spies.
-const { selectNodeWithoutHistory, setShowInspectorPanel } = vi.hoisted(() => ({
+// `editedNodeIds` is a mutable set the store mock reads for isEditedSinceRun; a
+// test opts a node in via editedNodeIds.add(id) and beforeEach clears it.
+const { selectNodeWithoutHistory, setShowInspectorPanel, editedNodeIds } = vi.hoisted(() => ({
   selectNodeWithoutHistory: vi.fn(),
   setShowInspectorPanel: vi.fn(),
+  editedNodeIds: new Set<string>(),
 }))
 
 vi.mock('../../store', () => {
@@ -42,7 +54,7 @@ vi.mock('../../store', () => {
     results: { status: 'complete', report: null },
     highlightedNodes: new Set(),
     dimmedNodeIds: new Set(),
-    editedSinceRunNodeIds: new Set(),
+    editedSinceRunNodeIds: editedNodeIds,
     analysisHighlight: { source: null, edgeIds: new Set(), nodeIds: new Set() },
     lens: { _dimmedNodeIds: new Set(), _hiddenNodeIds: new Set(), active: 'full' },
     goalThreshold: null,
@@ -112,6 +124,7 @@ const renderNode = () =>
 beforeEach(() => {
   vi.clearAllMocks()
   sensitivityRank = null
+  editedNodeIds.clear()
   useGuidanceStore.getState().clearGuidanceItems()
 })
 
@@ -147,6 +160,55 @@ describe('BaseNode — top-right corner stack (rank + coaching)', () => {
     expect(rank.className).not.toContain('absolute')
     expect(coaching.className).not.toContain('absolute')
     expect(coaching.className).not.toContain('-right-2')
+  })
+
+  it('ALL THREE present: rank, edited-dot and coaching are distinct siblings in order, none absolute', () => {
+    sensitivityRank = 1
+    editedNodeIds.add('node-a')
+    useGuidanceStore.getState().setGuidanceItems([makeItem()])
+    renderNode()
+
+    const stack = screen.getByTestId('node-corner-stack-node-a')
+    const rank = screen.getByTestId('sensitivity-rank-node-a')
+    const edited = screen.getByTestId('edited-since-run-node-a')
+    const coaching = screen.getByTestId('node-coaching-marker-node-a')
+
+    // Three distinct children, all inside the single positioned stack.
+    expect(stack).toContainElement(rank)
+    expect(stack).toContainElement(edited)
+    expect(stack).toContainElement(coaching)
+
+    // Deterministic order: rank · edited-dot · coaching (smallest in the middle).
+    const kids = Array.from(stack.children)
+    expect(kids).toHaveLength(3)
+    expect(kids[0]).toBe(rank)
+    expect(kids[1]).toBe(edited)
+    expect(kids[2]).toBe(coaching)
+
+    // The edited dot is a static flex child — no absolute/offset of its own, so
+    // it can no longer be drawn under the coaching marker (the P2 defect).
+    expect(edited.className).not.toContain('absolute')
+    expect(edited.className).not.toContain('-right-1')
+    expect(edited.className).not.toContain('-top-1')
+  })
+
+  it('EDITED alone: the edited-since-run dot renders in the stack, no rank or coaching', () => {
+    editedNodeIds.add('node-a')
+    renderNode()
+    const stack = screen.getByTestId('node-corner-stack-node-a')
+    expect(stack).toContainElement(screen.getByTestId('edited-since-run-node-a'))
+    expect(screen.queryByTestId('sensitivity-rank-node-a')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('node-coaching-marker-node-a')).not.toBeInTheDocument()
+  })
+
+  it('CLICK-THROUGH with edited dot present: coaching onClick still fires', () => {
+    editedNodeIds.add('node-a')
+    useGuidanceStore.getState().setGuidanceItems([makeItem({ item_id: 'edit-item' })])
+    renderNode()
+
+    expect(screen.getByTestId('edited-since-run-node-a')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('node-coaching-marker-node-a'))
+    expect(useGuidanceStore.getState().activeGuidanceItemId).toBe('edit-item')
   })
 
   it('RANK alone: rank badge renders in the stack, no coaching marker', () => {

--- a/src/canvas/ui/inspector-v2/__tests__/useInspectorMutations.writtenFields.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/useInspectorMutations.writtenFields.spec.tsx
@@ -1,0 +1,141 @@
+/**
+ * useInspectorMutations — EDITOR_WRITTEN_FIELDS drift guard (Codex P2 root fix).
+ *
+ * The deny-direction guard in analyticalNodeFields.registry.spec.ts used to
+ * hand-list "fields live editors write". That mirror drifted and OMITTED edge
+ * `label` (setLabel writes edge.data.label), so `label` could be added to the
+ * ephemeral denylist with the deny-direction guard staying GREEN — a silent
+ * reload-loss class. The manifest now lives beside the setters
+ * (NODE_SETTER_FIELDS / EDGE_SETTER_FIELDS → EDITOR_WRITTEN_FIELDS) and the guard
+ * imports it. This spec is what makes the manifest UNABLE to drift from the code:
+ *
+ *   1. The setter names the hook returns EQUAL the manifest keys — a setter added
+ *      or removed without updating the manifest fails RED.
+ *   2. Each setter, when driven, writes EXACTLY the top-level `data` field(s) the
+ *      manifest declares for it — a setter that starts writing a new/renamed field
+ *      fails RED. This is a behavioural capture (the setters are executed), not a
+ *      second hand-list.
+ *   3. POSITIVE CONTROLS prove the capture can SEE a field (trap #13) and that
+ *      edge `label` is genuinely captured (the omitted field).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useNodeMutations,
+  useEdgeMutations,
+  NODE_SETTER_FIELDS,
+  EDGE_SETTER_FIELDS,
+  EDITOR_WRITTEN_FIELDS,
+} from '../useInspectorMutations'
+import { useCanvasStore } from '../../../store'
+
+// Spies swapped into the real store so getNode/getEdge still resolve while we
+// capture exactly what each setter writes.
+const updateNode = vi.fn()
+const updateEdge = vi.fn()
+
+const NODE = { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: {} }
+const EDGE = { id: 'e1', source: 'a', target: 'b', data: {} }
+
+beforeEach(() => {
+  updateNode.mockClear()
+  updateEdge.mockClear()
+  useCanvasStore.setState(
+    { nodes: [NODE], edges: [EDGE], updateNode, updateEdge } as never,
+    false,
+  )
+})
+
+/** Valid sample args for each node setter (enough to make the setter write). */
+const NODE_SETTER_ARGS: Record<string, unknown[]> = {
+  setLabel: ['A new label'],
+  setDescription: ['A new description'],
+  setThreshold: [42, 'percent'],
+  setObservedValue: [1],
+  setIntervention: ['factor-x', 1],
+  removeIntervention: ['factor-x'],
+  setPriorRange: [0, 1],
+  setObservedRawValue: [1],
+  setObservedUnit: ['kg'],
+  setObservedCap: [1],
+  setObservedBaseline: [1],
+  setObservedStd: [1],
+  setObservedSource: ['user'],
+  setCategory: ['external'],
+  setExtractionType: ['explicit'],
+  setFactorType: ['lever'],
+  setStateSpaceRange: [0, 1],
+  setUncertaintyDrivers: [['driver-a']],
+  setGoalCap: [1],
+  setProbability: [0.5],
+  setImpact: ['high'],
+}
+
+const EDGE_SETTER_ARGS: Record<string, unknown[]> = {
+  setStrength: [0.5],
+  setStd: [0.1],
+  setExistsProbability: [0.8],
+  setLabel: ['edge label'],
+  setDirection: ['positive'],
+}
+
+/** Drive one setter and return the top-level data keys it wrote. */
+function keysWrittenBy(fn: (...a: unknown[]) => void, args: unknown[], spy: typeof updateNode): string[] {
+  spy.mockClear()
+  act(() => {
+    fn(...args)
+  })
+  const written = new Set<string>()
+  for (const call of spy.mock.calls) {
+    const data = (call[1] as { data?: Record<string, unknown> })?.data
+    if (data) for (const k of Object.keys(data)) written.add(k)
+  }
+  return [...written]
+}
+
+describe('useInspectorMutations — EDITOR_WRITTEN_FIELDS cannot drift from the setters', () => {
+  it('NODE: the setter names the hook returns equal the manifest keys', () => {
+    const { result } = renderHook(() => useNodeMutations('n1'))
+    const returned = Object.keys(result.current).sort()
+    const declared = Object.keys(NODE_SETTER_FIELDS).sort()
+    expect(returned).toEqual(declared)
+  })
+
+  it('EDGE: the setter names the hook returns equal the manifest keys', () => {
+    const { result } = renderHook(() => useEdgeMutations('e1'))
+    const returned = Object.keys(result.current).sort()
+    const declared = Object.keys(EDGE_SETTER_FIELDS).sort()
+    expect(returned).toEqual(declared)
+  })
+
+  it('NODE: each setter writes exactly the data field(s) the manifest declares', () => {
+    const { result } = renderHook(() => useNodeMutations('n1'))
+    const setters = result.current as unknown as Record<string, (...a: unknown[]) => void>
+    for (const [name, expected] of Object.entries(NODE_SETTER_FIELDS)) {
+      const written = keysWrittenBy(setters[name], NODE_SETTER_ARGS[name], updateNode).sort()
+      expect(written, `setter '${name}' wrote unexpected data fields`).toEqual([...expected].sort())
+    }
+  })
+
+  it('EDGE: each setter writes exactly the data field(s) the manifest declares', () => {
+    const { result } = renderHook(() => useEdgeMutations('e1'))
+    const setters = result.current as unknown as Record<string, (...a: unknown[]) => void>
+    for (const [name, expected] of Object.entries(EDGE_SETTER_FIELDS)) {
+      const written = keysWrittenBy(setters[name], EDGE_SETTER_ARGS[name], updateEdge).sort()
+      expect(written, `setter '${name}' wrote unexpected data fields`).toEqual([...expected].sort())
+    }
+  })
+
+  it('EDITOR_WRITTEN_FIELDS is the flattened union of the per-setter maps (incl. edge `label`)', () => {
+    expect(EDITOR_WRITTEN_FIELDS.node).toEqual([...new Set(Object.values(NODE_SETTER_FIELDS).flat())])
+    expect(EDITOR_WRITTEN_FIELDS.edge).toEqual([...new Set(Object.values(EDGE_SETTER_FIELDS).flat())])
+    // The field the old hand-list omitted must be present now.
+    expect(EDITOR_WRITTEN_FIELDS.edge).toContain('label')
+  })
+
+  it('POSITIVE CONTROL: the capture can SEE edge `label` when setLabel runs (not a vacuous pass)', () => {
+    const { result } = renderHook(() => useEdgeMutations('e1'))
+    const written = keysWrittenBy(result.current.setLabel as (...a: unknown[]) => void, ['proves visibility'], updateEdge)
+    expect(written).toEqual(['label'])
+  })
+})

--- a/src/canvas/ui/inspector-v2/useInspectorMutations.ts
+++ b/src/canvas/ui/inspector-v2/useInspectorMutations.ts
@@ -9,6 +9,71 @@ import { useCallback } from 'react'
 import { useCanvasStore } from '../../store'
 import type { RiskImpact } from '../../domain/nodes'
 
+// ─── Editor-written-field manifest (single source of truth) ────────────
+//
+// Every setter below writes one or more top-level `data` fields. Which fields
+// each setter writes is declared ONCE here, co-located with the setters, rather
+// than re-typed into a hand-list inside a distant guard spec (that mirror
+// silently drifted and OMITTED edge `label`, so `label` could be denylisted with
+// the deny-direction guard staying green — Codex P2).
+//
+// This map CANNOT drift from the setters: the co-located behavioural spec
+// (__tests__/useInspectorMutations.writtenFields.spec.tsx) renders the hooks,
+// asserts the returned setter names EQUAL these keys (a new/removed setter fails
+// RED), and DRIVES every setter to assert the data-field keys it actually writes
+// EQUAL the value here (a setter that starts writing a new/renamed field fails
+// RED). `analyticalNodeFields.registry.spec.ts` imports EDITOR_WRITTEN_FIELDS as
+// its deny-direction persist set (no persistent editor field may be denylisted),
+// so the manifest, the setters and the guard can no longer disagree.
+//
+// Fields written by editors OUTSIDE this hook (e.g. the goal-threshold store
+// action, the baseline toggle, the model-action apply path) are NOT listed here
+// — they are named in the registry guard's residual list with their write sites.
+
+/** node setter name → the top-level `data` field(s) that setter writes. */
+export const NODE_SETTER_FIELDS = {
+  setLabel: ['label'],
+  setDescription: ['description'],
+  setThreshold: ['goal_threshold_raw', 'goal_threshold_unit'],
+  setObservedValue: ['observedState'],
+  setIntervention: ['interventions'],
+  removeIntervention: ['interventions'],
+  setPriorRange: ['prior'],
+  setObservedRawValue: ['observedState'],
+  setObservedUnit: ['observedState'],
+  setObservedCap: ['observedState'],
+  setObservedBaseline: ['observedState'],
+  setObservedStd: ['observedState'],
+  setObservedSource: ['observedState'],
+  setCategory: ['category'],
+  setExtractionType: ['extractionType'],
+  setFactorType: ['factor_type'],
+  setStateSpaceRange: ['state_space'],
+  setUncertaintyDrivers: ['uncertainty_drivers'],
+  setGoalCap: ['goal_threshold_cap'],
+  setProbability: ['probability'],
+  setImpact: ['impact'],
+} as const satisfies Record<string, readonly string[]>
+
+/** edge setter name → the top-level `data` field(s) that setter writes. */
+export const EDGE_SETTER_FIELDS = {
+  setStrength: ['weight', 'direction'],
+  setStd: ['strengthStd'],
+  setExistsProbability: ['beliefExists'],
+  setLabel: ['label'],
+  setDirection: ['direction'],
+} as const satisfies Record<string, readonly string[]>
+
+/**
+ * The flattened, de-duplicated set of node/edge `data` fields the inspector
+ * setters write. Derived from the per-setter maps above so it cannot disagree
+ * with them. This is the export the deny-direction registry guard consumes.
+ */
+export const EDITOR_WRITTEN_FIELDS = {
+  node: [...new Set(Object.values(NODE_SETTER_FIELDS).flat())],
+  edge: [...new Set(Object.values(EDGE_SETTER_FIELDS).flat())],
+} as const
+
 // ─── Node mutations ────────────────────────────────────────────────
 export function useNodeMutations(nodeId: string) {
   const updateNode = useCanvasStore(s => s.updateNode)

--- a/tests/ci-guards/complete-borders.spec.ts
+++ b/tests/ci-guards/complete-borders.spec.ts
@@ -58,7 +58,7 @@
  *     comment must NOT be flagged (the #385/#386 footgun).
  */
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { resolve as resolvePath } from 'node:path'
 import { stripComments } from '../helpers/stripSourceComments'
 
@@ -77,7 +77,6 @@ const CONTENT_CARD_FILES = [
   'canvas/components/GuidanceCard.tsx',
   'canvas/components/ActionsSignal.tsx',
   'canvas/components/ValidationPanel.tsx',
-  'canvas/components/InsightsTab.tsx',
   'canvas/components/ProvenanceHubTab.tsx',
   'canvas/components/GraphTextView.tsx',
   'canvas/components/EdgeFunctionTypeSelector.tsx',
@@ -124,6 +123,18 @@ interface Violation {
   snippet: string
 }
 
+/**
+ * Fail-loud on scan-list drift: a listed file that no longer exists is list-drift,
+ * NOT a silent pass and NOT a raw `readFileSync` ENOENT (which reads as an infra
+ * crash, not "remove the entry"). Repo doctrine: a hand-maintained list must FAIL
+ * LOUD on drift. This is exactly the #455 footgun — `InsightsTab.tsx` was deleted
+ * but left in the scan set, so the unconditional read threw ENOENT and reddened the
+ * staging gate as if the harness had broken, obscuring the one-line cause.
+ */
+function findMissingScanFiles(files: string[]): string[] {
+  return files.filter((rel) => !existsSync(resolvePath(SRC, rel)))
+}
+
 /** Scan already-comment-stripped text for one-sided border accents. */
 function findAccentViolations(stripped: string, file: string): Violation[] {
   const out: Violation[] = []
@@ -143,10 +154,26 @@ function findAccentViolations(stripped: string, file: string): Violation[] {
 }
 
 describe('complete-borders guard: analysis-surface content cards carry complete borders only', () => {
+  it('every scan-list file exists (fail loud on list drift, never a raw ENOENT)', () => {
+    const missing = findMissingScanFiles(CONTENT_CARD_FILES)
+    if (missing.length) {
+      const report = missing
+        .map((rel) => `  scan-list entry "${rel}" no longer exists at src/${rel} — remove it or fix the path`)
+        .join('\n')
+      throw new Error(
+        `complete-borders scan-list drift — ${missing.length} listed file(s) no longer exist:\n${report}`,
+      )
+    }
+    expect(missing).toHaveLength(0)
+  })
+
   it('has no one-sided coloured border accent in any swept content-card file', () => {
     const violations: Violation[] = []
     for (const rel of CONTENT_CARD_FILES) {
       const abs = resolvePath(SRC, rel)
+      // A missing file is list-drift, asserted by the dedicated test above with a
+      // named message; skip it here so this scan never masks that as a raw ENOENT.
+      if (!existsSync(abs)) continue
       const text = readFileSync(abs, 'utf8')
       const stripped = stripComments(text, abs)
       violations.push(...findAccentViolations(stripped, rel))
@@ -184,6 +211,13 @@ describe('complete-borders guard: analysis-surface content cards carry complete 
     ].join('\n')
     const found = findAccentViolations(stripComments(negative, 'control.tsx'), 'control.tsx')
     expect(found).toHaveLength(0)
+  })
+
+  it('DRIFT control: findMissingScanFiles flags a non-existent path (detector is not blind)', () => {
+    const bogus = 'canvas/components/__ThisFileDoesNotExist__.tsx'
+    expect(findMissingScanFiles([bogus])).toEqual([bogus])
+    // And a real, present file is NOT reported as missing.
+    expect(findMissingScanFiles(['canvas/components/ValidationPanel.tsx'])).toHaveLength(0)
   })
 
   it('COMMENT control: a border-l-[3px] living only in a comment is not flagged', () => {


### PR DESCRIPTION
**DRAFT** — remediation-review residuals from the Codex pass: the RED staging gate (P1) + two P2s, fixed at root cause. Not for merge by me.

## P1 — complete-borders CI guard reddened the staging gate

`tests/ci-guards/complete-borders.spec.ts:80` still listed `canvas/components/InsightsTab.tsx`, deleted in #455 (`ecc2a9c0`). The spec `readFileSync`s the scan list unconditionally → ENOENT → **staging-full-tests.yml shard 2/4 RED** at tip `1e830dec`.

- **(a)** Removed the stale entry.
- **(b)** The scan list is itself a hand-list, so a missing file now **fails loud as list-drift** with a named assertion — `scan-list entry "X" no longer exists at src/X — remove it or fix the path` — instead of a raw ENOENT that reads as an infra crash. Added a DRIFT positive-control so the detector can't go blind, and guarded the accent loop so it never re-ENOENTs.
- **(d)** Positive-controlled the whole 28-entry list: **InsightsTab was the only stale entry**. All 10 `tests/ci-guards/` specs stay green (65 tests) — the whole-dir green pass is itself the control that no other guard ENOENTs on a stale path.

### (c) PR-vs-staging scope diagnosis — the premise was wrong; corrected at the bytes
The review brief hypothesised the PR suite "does NOT run tests/ci-guards/ (or shards differently)." Verified against the live Actions history, that is **not** what happened:

- `staging-full-tests.yml` is the **only** `pull_request → staging` workflow; it runs the **same** 4-shard full `vitest run` as the push trigger. vitest `include` is `tests/**`, so **both already run ci-guards** — scope is identical, there is no gap to close.
- The PR runs **did** go red: PRs **#455, #460, #466** each show `Full Test Suite (shard 2/4): FAILURE` **and** `Staging Gate: FAILURE` on the PR itself, pre-merge. They merged anyway.
- Root cause of the mask: **`staging` is not a protected branch** (`GET .../branches/staging/protection` → `404 Branch not protected`), so "Staging Gate" is not a required check and merges never block on it. Rapid merges additionally cancelled in-flight **push** runs via the concurrency group (`fa5be570`/`be02447e` = `cancelled`), so the red push runs were easy to miss too.

Because the alignment is already correct and the remaining gap is **governance, not a bounded yml change**, I did **(a)+(b)+(d)** only. **Follow-up (admin):** make "Staging Gate" a required status check on `staging` (branch protection) so a red guard blocks the merge instead of only being visible after it.

## P2 — edited-since-run dot joins the corner stack
`src/canvas/nodes/BaseNode.tsx` rendered the amber edited-since-run dot independently at `-top-1 -right-1` (default z) in the same corner as the #464 stack (rank + coaching at `-top-2 -right-2 z-10`) — the coaching marker drew fully over it (Codex screenshot). Folded it into the shared stack as a **static middle child**: order **rank · edited-dot · coaching** (smallest badge in the middle so the 10px dot isn't crowded against either ~20px neighbour; the interactive coaching marker stays at the corner as the click target). Pins added: all three present → three distinct ordered siblings with the dot carrying no absolute/offset; edited-alone renders; click-through preserved.

## P2 — derived editor-written-field manifest
The deny-direction guard's "fields live editors write" list in `analyticalNodeFields.registry.spec.ts` was hand-maintained and **omitted edge `label`** (`setLabel` writes `edge.data.label`), so denylisting `label` left the guard green (Codex).

- **Root fix (derive, don't mirror):** `useInspectorMutations.ts` now declares `NODE_SETTER_FIELDS` / `EDGE_SETTER_FIELDS` (per-setter → written data-fields) → flattened `EDITOR_WRITTEN_FIELDS`, **co-located with the setters**. A new behavioural spec renders the hooks, asserts the returned setter names equal the manifest keys, and **drives every setter** to assert the captured written-field keys equal the manifest — so the map **cannot drift** from the code.
- The registry guard now **imports `EDITOR_WRITTEN_FIELDS`** instead of its hand-list. Fields written by editors outside the hook (`is_baseline`, `success_threshold`, `threshold_source`, edge `confidence`) stay as a small **annotated residual** (each with its write site) so the guard's strength (and its existing positive controls) is preserved.
- Setter audit: the **node** list was already complete; **only edge `label`** was missing. Now included.
- **Mutation-verified both ways** (then reverted): dropping `label` from the manifest → behavioural spec + deny-direction probe RED; physically denylisting edge `label` in the real `EDGE_FIELD_REGISTRY` → the `no live-editor persistent EDGE field is denylisted` deny-direction test RED (the exact Codex probe now bites).

## Gates
- `pnpm run typecheck` — clean.
- Lint (changed files) — 0 errors (one pre-existing unrelated `viewMode` warning).
- `complete-borders.spec.ts` — green (6/6, proven explicitly).
- Full `tests/ci-guards/` + all touched node/inspector specs — 184 pass (16 files).
- `vitest run --changed --bail=1` — 605 pass (32 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)