### PR TITLE
feat(add-option): a reachable, honest UI producer for the add_option transaction

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -14,6 +14,15 @@ import { typo } from '../../styles/typography'
 import { useCanvasStore } from '../store'
 import { useConversationContext } from '../conversation/ConversationContext'
 import { useStageAwarePlaceholder } from '../hooks/useStageAwarePlaceholder'
+import { AddOptionPanel } from '../conversation/AddOptionPanel'
+import {
+  buildAddOptionDispatch,
+  describeAddOptionRefusal,
+  detectAddOptionRequest,
+  resolveAddOptionTargets,
+  type AddOptionCanvasTargets,
+  type AddOptionChange,
+} from '../conversation/addOptionRequest'
 import { messageForElapsed } from './DraftLoadingAnimation'
 
 export type AIInputBarVariant = 'strip' | 'docked-tab' | 'floating' | 'first-use' | 'welcome'
@@ -123,7 +132,8 @@ export const AIInputBar = memo(
     },
     ref,
   ) {
-    const { draft, setDraft, clearDraft, sendMessage, isThinking } = useConversationContext()
+    const { draft, setDraft, clearDraft, sendMessage, dispatchAction, isThinking } =
+      useConversationContext()
     const stagePlaceholder = useStageAwarePlaceholder()
     const textareaRef = useRef<HTMLTextAreaElement | null>(null)
     // Empty canvas → the user's send should DRAFT a model (not chat).
@@ -199,6 +209,29 @@ export const AIInputBar = memo(
       el.style.height = `${Math.min(Math.max(el.scrollHeight, minHeightPx), maxHeightPx)}px`
     }, [draft, minHeightPx, maxHeightPx])
 
+    // --- add-option interception ------------------------------------------
+    // A typed "add an option called X" is routed into CEE's zero-LLM
+    // add_option transaction instead of the free-text edit lane, via a short
+    // configuration step that resolves the ids locally (see addOptionRequest.ts
+    // for why prose-derived ids silently degrade to a 20s LLM path). Holding
+    // the ORIGINAL text means nothing the user typed is ever lost: cancel keeps
+    // it in the composer, "send as a message instead" sends it verbatim.
+    const [addOption, setAddOption] = useState<{
+      label: string
+      text: string
+      targets: AddOptionCanvasTargets
+    } | null>(null)
+    const [addOptionRefusal, setAddOptionRefusal] = useState<string | null>(null)
+
+    const sendPlainMessage = useCallback(
+      (text: string) => {
+        sendMessage(text)
+        clearDraft()
+        onAfterSend?.(text)
+      },
+      [sendMessage, clearDraft, onAfterSend],
+    )
+
     const handleSend = useCallback(() => {
       const text = draft.trim()
       if (!text || disabled || isThinking) return
@@ -209,12 +242,68 @@ export const AIInputBar = memo(
           debugSource: 'generate_model',
           debugSourceSurface: 'ai_panel',
         })
-      } else {
-        sendMessage(text)
+        clearDraft()
+        onAfterSend?.(text)
+        return
       }
-      clearDraft()
-      onAfterSend?.(text)
-    }, [draft, disabled, isThinking, nodeCount, sendMessage, clearDraft, onAfterSend])
+      const detected = detectAddOptionRequest(text)
+      if (detected) {
+        // Read the graph imperatively: the composer must not re-render on every
+        // node change just to be ready for a request it usually never sees.
+        const targets = resolveAddOptionTargets(useCanvasStore.getState().nodes)
+        if (targets.decisionId) {
+          setAddOptionRefusal(null)
+          setAddOption({ label: detected.label, text, targets })
+          return
+        }
+        // No decision node — there is nothing to hang an option off, so fall
+        // through to the ordinary lane rather than open a form that must refuse.
+      }
+      sendPlainMessage(text)
+    }, [
+      draft,
+      disabled,
+      isThinking,
+      nodeCount,
+      sendMessage,
+      clearDraft,
+      onAfterSend,
+      sendPlainMessage,
+    ])
+
+    const closeAddOption = useCallback(() => {
+      setAddOption(null)
+      setAddOptionRefusal(null)
+    }, [])
+
+    const handleAddOptionSendAsMessage = useCallback(() => {
+      const text = addOption?.text ?? ''
+      closeAddOption()
+      if (text) sendPlainMessage(text)
+    }, [addOption, closeAddOption, sendPlainMessage])
+
+    const handleAddOptionSubmit = useCallback(
+      (label: string, changes: readonly AddOptionChange[]) => {
+        // Re-resolve against the LIVE canvas, not the snapshot the panel opened
+        // with: a node deleted while the panel was open must refuse here rather
+        // than ship an id CEE cannot find.
+        const built = buildAddOptionDispatch({
+          label,
+          changes,
+          nodes: useCanvasStore.getState().nodes,
+        })
+        if (!built.ok) {
+          setAddOptionRefusal(describeAddOptionRefusal(built.refusal))
+          return
+        }
+        const originalText = addOption?.text ?? ''
+        closeAddOption()
+        void dispatchAction({ ...built.dispatch, source: 'chip' })
+        clearDraft()
+        onAfterSend?.(originalText)
+      },
+      [addOption, closeAddOption, dispatchAction, clearDraft, onAfterSend],
+    )
 
     const handleKeyDown = useCallback(
       (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -281,6 +370,19 @@ export const AIInputBar = memo(
     const textareaRightPad = isWelcome ? 'pr-12' : isStrip ? 'pr-14' : 'pr-12'
 
     return (
+      <>
+      {addOption && (
+        <AddOptionPanel
+          initialLabel={addOption.label}
+          decisionLabel={addOption.targets.decisionLabel}
+          factors={addOption.targets.factors}
+          refusal={addOptionRefusal}
+          busy={isThinking}
+          onSubmit={handleAddOptionSubmit}
+          onSendAsMessage={handleAddOptionSendAsMessage}
+          onCancel={closeAddOption}
+        />
+      )}
       <div className={containerClasses} data-testid={testId ?? `ai-input-bar-${variant}`}>
         <div className="relative flex-1 bg-panel border border-panel-border rounded-lg transition-colors focus-within:border-info">
           <textarea
@@ -363,6 +465,7 @@ export const AIInputBar = memo(
           </button>
         ) : null}
       </div>
+      </>
     )
   }),
 )

--- a/src/canvas/components/__tests__/AIInputBar.addOption.spec.tsx
+++ b/src/canvas/components/__tests__/AIInputBar.addOption.spec.tsx
@@ -1,0 +1,264 @@
+/**
+ * AIInputBar — the add-option journey, from typed sentence to dispatched chip.
+ *
+ * This is the reachability proof the capability was missing: it asserts that a
+ * user who TYPES "add an option called X" reaches `dispatchAction` with
+ * `intent: 'add_option'` and a canvas-resolved parameter spec — and that
+ * nothing they typed is ever lost on any exit from the panel.
+ *
+ * jsdom cannot prove layout or the live wire; the live capture in
+ * parallel-briefs/ADD-OPTION-LANE-2026-07-25.md carries those claims.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { AIInputBar } from '../AIInputBar'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { useCanvasStore } from '../../store'
+
+const sendMessage = vi.fn()
+const dispatchAction = vi.fn()
+
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    lastSendFailure: null,
+    sendMessage,
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    dispatchAction,
+    clearHistory: vi.fn(),
+    retryLast: vi.fn(),
+    cancelTurn: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+function n(id: string, kind: string, label: string, observed?: Record<string, unknown>) {
+  return {
+    id,
+    type: kind,
+    position: { x: 0, y: 0 },
+    data: { label, kind, ...(observed ? { observedState: observed } : {}) },
+  }
+}
+
+const NODES = [
+  n('dec_1', 'decision', 'Open a second site'),
+  n('fac_capex', 'factor', 'Capital Investment', { value: 0.65, raw_value: 26000, unit: '£', cap: 40000 }),
+  n('fac_timing', 'factor', 'Speed of Launch', { value: 0.4 }),
+]
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+function renderBar() {
+  return render(
+    <Wrapper>
+      <AIInputBar variant="floating" />
+    </Wrapper>,
+  )
+}
+
+function type(text: string) {
+  const ta = screen.getByTestId('ai-input-bar-floating-textarea')
+  fireEvent.change(ta, { target: { value: text } })
+  return ta
+}
+
+function send(text: string) {
+  const ta = type(text)
+  fireEvent.keyDown(ta, { key: 'Enter' })
+}
+
+describe('AIInputBar — add-option interception', () => {
+  beforeEach(() => {
+    sendMessage.mockClear()
+    dispatchAction.mockClear()
+    act(() => {
+      useCanvasStore.setState({ nodes: NODES as never, edges: [] as never })
+    })
+  })
+
+  it('opens the configuration panel instead of sending the free-text message', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    expect(screen.getByTestId('add-option-panel')).toBeTruthy()
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect((screen.getByTestId('add-option-label-input') as HTMLInputElement).value).toBe(
+      'Hybrid Pilot',
+    )
+  })
+
+  it('lists every factor on the canvas, with its current value', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    const list = screen.getByTestId('add-option-factor-list')
+    expect(list.textContent).toContain('Capital Investment')
+    expect(list.textContent).toContain('Speed of Launch')
+    expect(list.textContent).toContain('£26,000')
+  })
+
+  it('does NOT intercept an ordinary message', () => {
+    renderBar()
+    send('What should I do next?')
+    expect(screen.queryByTestId('add-option-panel')).toBeNull()
+    expect(sendMessage).toHaveBeenCalledWith('What should I do next?')
+  })
+
+  it('does NOT intercept a deliberative question about options', () => {
+    renderBar()
+    send('Should I add an option called Hybrid Pilot?')
+    expect(screen.queryByTestId('add-option-panel')).toBeNull()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT intercept when the canvas has no decision node', () => {
+    act(() => {
+      useCanvasStore.setState({ nodes: [n('fac_a', 'factor', 'A')] as never })
+    })
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    expect(screen.queryByTestId('add-option-panel')).toBeNull()
+    expect(sendMessage).toHaveBeenCalledWith('Add an option called Hybrid Pilot')
+  })
+
+  // ⭐ THE REACHABILITY PROOF
+  it('dispatches the typed add_option chip with canvas-resolved ids', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+
+    fireEvent.click(screen.getByLabelText('New value for Capital Investment', { exact: false }).previousSibling as Element)
+    fireEvent.change(screen.getByTestId('add-option-value-fac_capex'), {
+      target: { value: '20000' },
+    })
+    fireEvent.click(screen.getByTestId('add-option-submit'))
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1)
+    expect(dispatchAction).toHaveBeenCalledWith({
+      id: 'ui_add_option_form',
+      intent: 'add_option',
+      label: 'Add option "Hybrid Pilot"',
+      message: 'Add an option called "Hybrid Pilot" that changes "Capital Investment".',
+      parameters: {
+        parent_decision_id: 'dec_1',
+        label: 'Hybrid Pilot',
+        interventions: [{ factor_id: 'fac_capex', value: 0.5, unit: '£', raw_value: 20000 }],
+      },
+      source: 'chip',
+    })
+    // The chip replaces the free-text send — never both.
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('add-option-panel')).toBeNull()
+  })
+
+  it('dispatches an option with no changes when none are ticked', () => {
+    renderBar()
+    send('Add an option called Status Quo Plus')
+    fireEvent.click(screen.getByTestId('add-option-submit'))
+    expect(dispatchAction).toHaveBeenCalledTimes(1)
+    expect(dispatchAction.mock.calls[0][0].parameters.interventions).toEqual([])
+  })
+
+  it('uses the EDITED label, not the extracted one', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    fireEvent.change(screen.getByTestId('add-option-label-input'), {
+      target: { value: 'Renamed By User' },
+    })
+    fireEvent.click(screen.getByTestId('add-option-submit'))
+    expect(dispatchAction.mock.calls[0][0].parameters.label).toBe('Renamed By User')
+  })
+
+  // --- nothing the user typed is ever lost --------------------------------
+
+  it('"send as a message instead" sends the ORIGINAL text verbatim', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    fireEvent.click(screen.getByTestId('add-option-send-as-message'))
+    expect(sendMessage).toHaveBeenCalledWith('Add an option called Hybrid Pilot')
+    expect(dispatchAction).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('add-option-panel')).toBeNull()
+  })
+
+  it('cancel keeps the text in the composer and sends nothing', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    fireEvent.click(screen.getByTestId('add-option-cancel'))
+    expect(screen.queryByTestId('add-option-panel')).toBeNull()
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(dispatchAction).not.toHaveBeenCalled()
+    expect((screen.getByTestId('ai-input-bar-floating-textarea') as HTMLTextAreaElement).value).toBe(
+      'Add an option called Hybrid Pilot',
+    )
+  })
+
+  it('Escape cancels without losing the text', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByTestId('add-option-panel')).toBeNull()
+    expect((screen.getByTestId('ai-input-bar-floating-textarea') as HTMLTextAreaElement).value).toBe(
+      'Add an option called Hybrid Pilot',
+    )
+  })
+
+  // --- refusals are surfaced, never swallowed ------------------------------
+
+  it('refuses — naming the reason — when a ticked factor leaves the canvas', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    fireEvent.click(screen.getByLabelText('New value for Capital Investment', { exact: false }).previousSibling as Element)
+    fireEvent.change(screen.getByTestId('add-option-value-fac_capex'), { target: { value: '20000' } })
+    // The node disappears while the panel is open (another surface deleted it).
+    act(() => {
+      useCanvasStore.setState({ nodes: [NODES[0], NODES[2]] as never })
+    })
+    fireEvent.click(screen.getByTestId('add-option-submit'))
+    expect(dispatchAction).not.toHaveBeenCalled()
+    expect(screen.getByTestId('add-option-refusal').textContent).toMatch(/no longer on the canvas/i)
+  })
+
+  it('blocks submit — naming the reason — when a ticked factor has no number', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    fireEvent.click(screen.getByLabelText('New value for Speed of Launch', { exact: false }).previousSibling as Element)
+    fireEvent.change(screen.getByTestId('add-option-value-fac_timing'), { target: { value: '' } })
+    expect(screen.getByTestId('add-option-invalid')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('add-option-submit'))
+    expect(dispatchAction).not.toHaveBeenCalled()
+  })
+
+  it('blocks submit when the name is cleared', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    fireEvent.change(screen.getByTestId('add-option-label-input'), { target: { value: '  ' } })
+    fireEvent.click(screen.getByTestId('add-option-submit'))
+    expect(dispatchAction).not.toHaveBeenCalled()
+  })
+
+  // --- the panel is a request, never a receipt ----------------------------
+
+  it('claims no outcome anywhere in the panel', () => {
+    renderBar()
+    send('Add an option called Hybrid Pilot')
+    const text = screen.getByTestId('add-option-panel').textContent!.toLowerCase()
+    for (const banned of ['added', 'created', 'saved', 'applied', 'updated', 'success']) {
+      expect(text).not.toMatch(new RegExp(`\\b${banned}\\b`))
+    }
+    // Positive control: the assertion above can SEE a claim when one is present.
+    expect('option added to your model').toMatch(/\badded\b/)
+  })
+})

--- a/src/canvas/components/__tests__/AIInputBar.addOption.spec.tsx
+++ b/src/canvas/components/__tests__/AIInputBar.addOption.spec.tsx
@@ -16,7 +16,24 @@ import type { ReactNode } from 'react'
 
 import { AIInputBar } from '../AIInputBar'
 import { ConversationProvider } from '../../conversation/ConversationContext'
+import { NO_OUTCOME_CLAIM_VOCABULARY } from '../../conversation/addOptionRequest'
 import { useCanvasStore } from '../../store'
+
+/**
+ * Lower-cased visible text, with text NODES joined by a space.
+ *
+ * `element.textContent` concatenates adjacent nodes with no separator, which
+ * silently welds the end of one string to the start of the next and defeats any
+ * word-boundary assertion across that seam. Every prohibition in this file runs
+ * through here so it cannot be fooled that way.
+ */
+function renderedText(el: Element): string {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+  const parts: string[] = []
+  let node: Node | null
+  while ((node = walker.nextNode()) !== null) parts.push(node.textContent ?? '')
+  return parts.join(' ').toLowerCase()
+}
 
 const sendMessage = vi.fn()
 const dispatchAction = vi.fn()
@@ -254,11 +271,25 @@ describe('AIInputBar — add-option interception', () => {
   it('claims no outcome anywhere in the panel', () => {
     renderBar()
     send('Add an option called Hybrid Pilot')
-    const text = screen.getByTestId('add-option-panel').textContent!.toLowerCase()
-    for (const banned of ['added', 'created', 'saved', 'applied', 'updated', 'success']) {
-      expect(text).not.toMatch(new RegExp(`\\b${banned}\\b`))
+    const text = renderedText(screen.getByTestId('add-option-panel'))
+    for (const banned of NO_OUTCOME_CLAIM_VOCABULARY) {
+      expect(text).not.toContain(banned)
     }
-    // Positive control: the assertion above can SEE a claim when one is present.
-    expect('option added to your model').toMatch(/\badded\b/)
+  })
+
+  // ⭐ POSITIVE CONTROL, through the REAL check. Two earlier versions of this
+  // assertion were vacuous: `element.textContent` concatenates adjacent text
+  // nodes with no separator, so a heading mutated to "Option added" rendered as
+  // "Option addedA new option under…" and `\badded\b` did not match — the
+  // mutation escaped 68 green tests. `renderedText` joins text NODES, and the
+  // prohibition is a substring, not a word boundary.
+  it('positive control — renderedText + the vocabulary check SEE a planted claim', () => {
+    const host = document.createElement('div')
+    host.innerHTML = '<h3>Option added</h3><p>A new option under "D".</p>'
+    document.body.appendChild(host)
+    const text = renderedText(host)
+    expect(text).toContain('added')
+    expect(NO_OUTCOME_CLAIM_VOCABULARY.filter((w) => text.includes(w))).toContain('added')
+    host.remove()
   })
 })

--- a/src/canvas/conversation/AddOptionPanel.tsx
+++ b/src/canvas/conversation/AddOptionPanel.tsx
@@ -1,0 +1,278 @@
+/**
+ * AddOptionPanel — the surface that turns "add an option called X" into the
+ * typed `add_option` chip CEE's zero-LLM transaction consumes.
+ *
+ * It is a REQUEST BUILDER, not a receipt. It renders no outcome, no success
+ * state and no post-send confirmation: once the chip is dispatched the panel is
+ * gone and the only account of what happened is CEE's own hold/confirm copy,
+ * which names every operation. `NO_OUTCOME_CLAIM_VOCABULARY` and its spec pin
+ * that rule mechanically.
+ *
+ * The user's typed message is never lost. "Send as a message instead" hands the
+ * original text to the ordinary free-text lane, byte-identical to what would
+ * have happened had this panel not opened.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react'
+
+import { typography } from '../../styles/typography'
+import { formatValueWithUnit } from '../utils/formatValueWithUnit'
+import { MAX_ADD_OPTION_INTERVENTIONS } from '../../v5/chipParameters'
+import type { AddOptionChange, AddOptionFactorTarget } from './addOptionRequest'
+
+export interface AddOptionPanelProps {
+  /** Label extracted from the user's message — a prefill, always editable. */
+  readonly initialLabel: string
+  /** Label of the decision this option will sit under, for orientation. */
+  readonly decisionLabel: string | null
+  readonly factors: readonly AddOptionFactorTarget[]
+  /** Refusal text to show, e.g. from `describeAddOptionRefusal`. */
+  readonly refusal?: string | null
+  readonly busy?: boolean
+  readonly onSubmit: (label: string, changes: readonly AddOptionChange[]) => void
+  /** Send the user's original message down the ordinary free-text lane. */
+  readonly onSendAsMessage: () => void
+  readonly onCancel: () => void
+}
+
+interface RowState {
+  readonly checked: boolean
+  readonly text: string
+}
+
+function initialRowState(factor: AddOptionFactorTarget): RowState {
+  return {
+    checked: false,
+    text: factor.currentRaw != null ? String(factor.currentRaw) : '',
+  }
+}
+
+const INPUT_CLASS =
+  'w-28 rounded-md border border-panel-border bg-panel px-2 py-1 text-text-body outline-none focus:border-info disabled:opacity-50'
+
+export function AddOptionPanel({
+  initialLabel,
+  decisionLabel,
+  factors,
+  refusal,
+  busy = false,
+  onSubmit,
+  onSendAsMessage,
+  onCancel,
+}: AddOptionPanelProps) {
+  const [label, setLabel] = useState(initialLabel)
+  const [rows, setRows] = useState<Record<string, RowState>>(() =>
+    Object.fromEntries(factors.map((f) => [f.id, initialRowState(f)])),
+  )
+  const labelRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    labelRef.current?.focus()
+    labelRef.current?.select()
+  }, [])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onCancel])
+
+  const toggleRow = useCallback((id: string) => {
+    setRows((prev) => ({ ...prev, [id]: { ...prev[id], checked: !prev[id]?.checked } }))
+  }, [])
+
+  const setRowText = useCallback((id: string, text: string) => {
+    setRows((prev) => ({ ...prev, [id]: { ...prev[id], text } }))
+  }, [])
+
+  const checkedIds = useMemo(
+    () => factors.filter((f) => rows[f.id]?.checked).map((f) => f.id),
+    [factors, rows],
+  )
+
+  /**
+   * A ticked factor with an unparseable number is REFUSED here rather than
+   * dropped, defaulted or coerced — the builder's no-silent-defaulting rule,
+   * enforced at the surface so the user sees which row is at fault.
+   */
+  const invalidIds = useMemo(
+    () =>
+      checkedIds.filter((id) => {
+        const parsed = Number.parseFloat(rows[id]?.text ?? '')
+        return !Number.isFinite(parsed)
+      }),
+    [checkedIds, rows],
+  )
+
+  const overCap = checkedIds.length > MAX_ADD_OPTION_INTERVENTIONS
+  const canSubmit = label.trim().length > 0 && invalidIds.length === 0 && !overCap && !busy
+
+  const handleSubmit = useCallback(() => {
+    if (!canSubmit) return
+    const changes: AddOptionChange[] = checkedIds.map((id) => ({
+      factorId: id,
+      rawValue: Number.parseFloat(rows[id]?.text ?? ''),
+    }))
+    onSubmit(label.trim(), changes)
+  }, [canSubmit, checkedIds, rows, label, onSubmit])
+
+  const handleBackdrop = useCallback(
+    (e: ReactMouseEvent) => {
+      if (e.target === e.currentTarget) onCancel()
+    },
+    [onCancel],
+  )
+
+  const handleLabelKey = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        handleSubmit()
+      }
+    },
+    [handleSubmit],
+  )
+
+  return (
+    <div
+      className="fixed inset-0 z-[5000] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={handleBackdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-option-title"
+      data-testid="add-option-panel"
+    >
+      <div className="bg-panel rounded-lg shadow-panel p-6 w-[min(32rem,calc(100vw-2rem))] max-h-[calc(100vh-4rem)] overflow-y-auto">
+        <h3 id="add-option-title" className={`${typography.h4} text-text-header mb-1`}>
+          Add an option
+        </h3>
+        <p className={`${typography.bodySmall} text-text-light mb-4`}>
+          {decisionLabel
+            ? `A new option under "${decisionLabel}". Nothing changes on your canvas yet.`
+            : 'Nothing changes on your canvas yet.'}
+        </p>
+
+        <label className={`${typography.label} text-text-header block mb-1`} htmlFor="add-option-label">
+          Name
+        </label>
+        <input
+          id="add-option-label"
+          ref={labelRef}
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          onKeyDown={handleLabelKey}
+          disabled={busy}
+          data-testid="add-option-label-input"
+          className={`${typography.body} w-full rounded-md border border-panel-border bg-panel px-3 py-2 text-text-body outline-none focus:border-info mb-5`}
+        />
+
+        {factors.length > 0 && (
+          <>
+            <p className={`${typography.label} text-text-header mb-1`}>What this option changes</p>
+            <p className={`${typography.bodySmall} text-text-light mb-3`}>
+              Optional. Tick a factor and give it the value this option would produce — up to{' '}
+              {MAX_ADD_OPTION_INTERVENTIONS}.
+            </p>
+            <ul className="mb-5 space-y-2" data-testid="add-option-factor-list">
+              {factors.map((factor) => {
+                const row = rows[factor.id] ?? { checked: false, text: '' }
+                const invalid = row.checked && invalidIds.includes(factor.id)
+                return (
+                  <li key={factor.id} className="flex items-center gap-3">
+                    <input
+                      type="checkbox"
+                      id={`add-option-factor-${factor.id}`}
+                      checked={row.checked}
+                      onChange={() => toggleRow(factor.id)}
+                      disabled={busy}
+                      className="flex-none"
+                    />
+                    <label
+                      htmlFor={`add-option-factor-${factor.id}`}
+                      className={`${typography.bodySmall} text-text-body flex-1 min-w-0`}
+                    >
+                      <span className="block truncate">{factor.label}</span>
+                      {factor.currentRaw != null && (
+                        <span className={`${typography.panelMeta} text-text-light`}>
+                          now {formatValueWithUnit(factor.currentRaw, factor.unit)}
+                        </span>
+                      )}
+                    </label>
+                    <input
+                      type="number"
+                      step="any"
+                      aria-label={`New value for ${factor.label}`}
+                      value={row.text}
+                      onChange={(e) => setRowText(factor.id, e.target.value)}
+                      disabled={busy || !row.checked}
+                      data-testid={`add-option-value-${factor.id}`}
+                      className={`${typography.bodySmall} ${INPUT_CLASS} ${
+                        invalid ? 'border-danger' : ''
+                      }`}
+                    />
+                    <span className={`${typography.panelMeta} text-text-light w-16 flex-none`}>
+                      {factor.unit ?? (factor.cap ? '' : '0–1')}
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
+          </>
+        )}
+
+        {overCap && (
+          <p className={`${typography.bodySmall} text-danger mb-3`} data-testid="add-option-over-cap">
+            An option can change at most {MAX_ADD_OPTION_INTERVENTIONS} factors in one go. Untick{' '}
+            {checkedIds.length - MAX_ADD_OPTION_INTERVENTIONS} of them.
+          </p>
+        )}
+        {invalidIds.length > 0 && (
+          <p className={`${typography.bodySmall} text-danger mb-3`} data-testid="add-option-invalid">
+            Every factor you tick needs a number.
+          </p>
+        )}
+        {refusal && (
+          <p className={`${typography.bodySmall} text-danger mb-3`} data-testid="add-option-refusal">
+            {refusal}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <button
+            type="button"
+            onClick={onSendAsMessage}
+            disabled={busy}
+            data-testid="add-option-send-as-message"
+            className={`${typography.label} text-text-light underline underline-offset-2 hover:text-text-body disabled:opacity-50`}
+          >
+            Send as a message instead
+          </button>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={busy}
+              data-testid="add-option-cancel"
+              className={`px-4 py-2 ${typography.label} text-text-body bg-panel-hover rounded-lg hover:bg-panel-border disabled:opacity-50`}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              data-testid="add-option-submit"
+              className={`px-4 py-2 ${typography.label} text-text-on-color bg-primary rounded-lg hover:bg-primary/90 disabled:opacity-50`}
+            >
+              Ask Olumi to add it
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/canvas/conversation/AddOptionPanel.tsx
+++ b/src/canvas/conversation/AddOptionPanel.tsx
@@ -146,16 +146,16 @@ export function AddOptionPanel({
       data-testid="add-option-panel"
     >
       <div className="bg-panel rounded-lg shadow-panel p-6 w-[min(32rem,calc(100vw-2rem))] max-h-[calc(100vh-4rem)] overflow-y-auto">
-        <h3 id="add-option-title" className={`${typography.h4} text-text-header mb-1`}>
+        <h3 id="add-option-title" className={`${typography.panelHeader} text-text-header mb-1`}>
           Add an option
         </h3>
-        <p className={`${typography.bodySmall} text-text-light mb-4`}>
+        <p className={`${typography.panelBody} text-text-light mb-4`}>
           {decisionLabel
             ? `A new option under "${decisionLabel}". Nothing changes on your canvas yet.`
             : 'Nothing changes on your canvas yet.'}
         </p>
 
-        <label className={`${typography.label} text-text-header block mb-1`} htmlFor="add-option-label">
+        <label className={`${typography.panelHeader} text-text-header block mb-1`} htmlFor="add-option-label">
           Name
         </label>
         <input
@@ -167,13 +167,13 @@ export function AddOptionPanel({
           onKeyDown={handleLabelKey}
           disabled={busy}
           data-testid="add-option-label-input"
-          className={`${typography.body} w-full rounded-md border border-panel-border bg-panel px-3 py-2 text-text-body outline-none focus:border-info mb-5`}
+          className={`${typography.bodySmall} w-full rounded-md border border-panel-border bg-panel px-3 py-2 text-text-body outline-none focus:border-info mb-5`}
         />
 
         {factors.length > 0 && (
           <>
-            <p className={`${typography.label} text-text-header mb-1`}>What this option changes</p>
-            <p className={`${typography.bodySmall} text-text-light mb-3`}>
+            <p className={`${typography.panelHeader} text-text-header mb-1`}>What this option changes</p>
+            <p className={`${typography.panelBody} text-text-light mb-3`}>
               Optional. Tick a factor and give it the value this option would produce — up to{' '}
               {MAX_ADD_OPTION_INTERVENTIONS}.
             </p>
@@ -193,7 +193,7 @@ export function AddOptionPanel({
                     />
                     <label
                       htmlFor={`add-option-factor-${factor.id}`}
-                      className={`${typography.bodySmall} text-text-body flex-1 min-w-0`}
+                      className={`${typography.panelBody} text-text-body flex-1 min-w-0`}
                     >
                       <span className="block truncate">{factor.label}</span>
                       {factor.currentRaw != null && (
@@ -225,18 +225,18 @@ export function AddOptionPanel({
         )}
 
         {overCap && (
-          <p className={`${typography.bodySmall} text-danger mb-3`} data-testid="add-option-over-cap">
+          <p className={`${typography.panelBody} text-danger mb-3`} data-testid="add-option-over-cap">
             An option can change at most {MAX_ADD_OPTION_INTERVENTIONS} factors in one go. Untick{' '}
             {checkedIds.length - MAX_ADD_OPTION_INTERVENTIONS} of them.
           </p>
         )}
         {invalidIds.length > 0 && (
-          <p className={`${typography.bodySmall} text-danger mb-3`} data-testid="add-option-invalid">
+          <p className={`${typography.panelBody} text-danger mb-3`} data-testid="add-option-invalid">
             Every factor you tick needs a number.
           </p>
         )}
         {refusal && (
-          <p className={`${typography.bodySmall} text-danger mb-3`} data-testid="add-option-refusal">
+          <p className={`${typography.panelBody} text-danger mb-3`} data-testid="add-option-refusal">
             {refusal}
           </p>
         )}
@@ -247,7 +247,7 @@ export function AddOptionPanel({
             onClick={onSendAsMessage}
             disabled={busy}
             data-testid="add-option-send-as-message"
-            className={`${typography.label} text-text-light underline underline-offset-2 hover:text-text-body disabled:opacity-50`}
+            className={`${typography.panelBody} text-text-light underline underline-offset-2 hover:text-text-body disabled:opacity-50`}
           >
             Send as a message instead
           </button>
@@ -257,7 +257,7 @@ export function AddOptionPanel({
               onClick={onCancel}
               disabled={busy}
               data-testid="add-option-cancel"
-              className={`px-4 py-2 ${typography.label} text-text-body bg-panel-hover rounded-lg hover:bg-panel-border disabled:opacity-50`}
+              className={`px-4 py-2 ${typography.bodySmall} text-text-body bg-panel-hover rounded-lg hover:bg-panel-border disabled:opacity-50`}
             >
               Cancel
             </button>
@@ -266,7 +266,7 @@ export function AddOptionPanel({
               onClick={handleSubmit}
               disabled={!canSubmit}
               data-testid="add-option-submit"
-              className={`px-4 py-2 ${typography.label} text-text-on-color bg-primary rounded-lg hover:bg-primary/90 disabled:opacity-50`}
+              className={`px-4 py-2 ${typography.panelHeader} text-text-on-color bg-primary rounded-lg hover:bg-primary/90 disabled:opacity-50`}
             >
               Ask Olumi to add it
             </button>

--- a/src/canvas/conversation/__tests__/addOptionRequest.spec.ts
+++ b/src/canvas/conversation/__tests__/addOptionRequest.spec.ts
@@ -1,0 +1,380 @@
+/**
+ * addOptionRequest — the pure producer seam.
+ *
+ * The load-bearing test in this file is `wire seam`: it drives the builder's
+ * output through the REAL buildChipMeta → buildV5Payload chain and asserts the
+ * final wire payload. Asserting the builder's return value alone would let a
+ * dropped `intent` survive anywhere downstream (chipMeta lift, the send gate,
+ * the chip sub-object) — the exact escape a recent UI lane hit when removing a
+ * provenance stamp left 27 tests green.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Node } from '@xyflow/react'
+
+import {
+  ADD_OPTION_CHIP_ID,
+  buildAddOptionDispatch,
+  describeAddOptionRefusal,
+  detectAddOptionRequest,
+  resolveAddOptionTargets,
+  NO_OUTCOME_CLAIM_VOCABULARY,
+} from '../addOptionRequest'
+import { buildChipMeta } from '../chipMeta'
+import { buildV5Payload } from '../../../v5/buildPayload'
+import { MAX_ADD_OPTION_INTERVENTIONS } from '../../../v5/chipParameters'
+
+// --- fixtures ---------------------------------------------------------------
+
+function node(id: string, kind: string, label: string, observed?: Record<string, unknown>): Node {
+  return {
+    id,
+    type: kind,
+    position: { x: 0, y: 0 },
+    data: { label, kind, ...(observed ? { observedState: observed } : {}) },
+  } as unknown as Node
+}
+
+const GRAPH: Node[] = [
+  node('dec_bakery', 'decision', 'Open Second Bakery Location in Leeds'),
+  node('fac_capex', 'factor', 'Capital Investment', { value: 0.65, raw_value: 26000, unit: '£', cap: 40000 }),
+  node('fac_timing', 'factor', 'Speed of Launch', { value: 0.4 }),
+  node('goal_x', 'goal', 'Profitable Expansion'),
+  node('opt_a', 'option', 'Open Next Quarter'),
+]
+
+// --- 1. detection -----------------------------------------------------------
+
+describe('detectAddOptionRequest', () => {
+  it.each([
+    ['Add an option called Hybrid Pilot', 'Hybrid Pilot'],
+    ['add a new option called Hybrid Pilot', 'Hybrid Pilot'],
+    ['Create an option named Franchise Model', 'Franchise Model'],
+    ['Include another option titled Slow Rollout', 'Slow Rollout'],
+    ['Can you add an option called Hybrid Pilot', 'Hybrid Pilot'],
+    ['Please add an option called Hybrid Pilot', 'Hybrid Pilot'],
+    ["I'd like to add an option called Hybrid Pilot", 'Hybrid Pilot'],
+    ['Add an option "Hybrid Pilot"', 'Hybrid Pilot'],
+    ['Add an option “Hybrid Pilot”', 'Hybrid Pilot'],
+    ['Add an alternative called Hybrid Pilot', 'Hybrid Pilot'],
+    ['Add a choice called Hybrid Pilot', 'Hybrid Pilot'],
+    // A trailing descriptive clause names the option, not the clause.
+    ['Add an option called Hybrid Pilot that cuts cost by 20%', 'Hybrid Pilot'],
+    ['Add an option called Hybrid Pilot.', 'Hybrid Pilot'],
+  ])('matches %j → %j', (text, label) => {
+    expect(detectAddOptionRequest(text)).toEqual({ label })
+  })
+
+  it.each([
+    // Deliberation, not an instruction.
+    ['Should I add an option called Hybrid Pilot?'],
+    ['Do you think we should add an option called Hybrid?'],
+    ['Is it worth adding an option called Hybrid'],
+    ['What if I add an option called Hybrid?'],
+    // Plural = a brainstorm request for the coach, not one resolved option.
+    ['Add more options'],
+    ['Add some alternatives to consider'],
+    ['Create three new options'],
+    // No nameable label — the free-text lane still handles it.
+    ['Add an option'],
+    ['Add an option to the model'],
+    // Not an add-option request at all.
+    ['What are my options?'],
+    ['Remove the option called Hybrid Pilot'],
+    ['Explain the option called Hybrid Pilot'],
+    ['Add a factor called Shipping costs'],
+    ['Add a risk called Supplier failure'],
+    [''],
+    ['   '],
+  ])('does NOT match %j', (text) => {
+    expect(detectAddOptionRequest(text)).toBeNull()
+  })
+
+  it('never throws on non-string input', () => {
+    expect(detectAddOptionRequest(undefined as unknown as string)).toBeNull()
+    expect(detectAddOptionRequest(null as unknown as string)).toBeNull()
+    expect(detectAddOptionRequest(42 as unknown as string)).toBeNull()
+  })
+})
+
+// --- 2. canvas resolution ---------------------------------------------------
+
+describe('resolveAddOptionTargets', () => {
+  it('derives the decision node and every factor, and nothing else', () => {
+    const t = resolveAddOptionTargets(GRAPH)
+    expect(t.decisionId).toBe('dec_bakery')
+    expect(t.decisionLabel).toBe('Open Second Bakery Location in Leeds')
+    expect(t.factors.map((f) => f.id)).toEqual(['fac_capex', 'fac_timing'])
+  })
+
+  it('carries the raw figure, unit and cap when the factor has an honest scale', () => {
+    const capex = resolveAddOptionTargets(GRAPH).factors[0]
+    expect(capex).toMatchObject({ currentRaw: 26000, unit: '£', cap: 40000 })
+  })
+
+  it('falls back to model space when there is no cap', () => {
+    const timing = resolveAddOptionTargets(GRAPH).factors[1]
+    expect(timing).toMatchObject({ currentRaw: 0.4, unit: undefined, cap: undefined })
+  })
+
+  it('resolves kind from data.kind even when the ReactFlow type disagrees', () => {
+    const mislabelled = [
+      { ...node('d1', 'default', 'Decision'), data: { label: 'Decision', kind: 'decision' } },
+    ] as unknown as Node[]
+    expect(resolveAddOptionTargets(mislabelled).decisionId).toBe('d1')
+  })
+
+  it('reports no decision node on an empty canvas', () => {
+    expect(resolveAddOptionTargets([]).decisionId).toBeNull()
+  })
+})
+
+// --- 3. dispatch construction ----------------------------------------------
+
+describe('buildAddOptionDispatch', () => {
+  it('builds the typed add_option chip with canvas-resolved ids', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid Pilot',
+      changes: [{ factorId: 'fac_capex', rawValue: 20000 }],
+      nodes: GRAPH,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.dispatch.id).toBe(ADD_OPTION_CHIP_ID)
+    expect(r.dispatch.intent).toBe('add_option')
+    expect(r.dispatch.parameters).toEqual({
+      parent_decision_id: 'dec_bakery',
+      label: 'Hybrid Pilot',
+      // 20000 / cap 40000 — the same raw→model rule every other value-edit path
+      // in the UI applies, with the raw figure and unit preserved alongside.
+      interventions: [{ factor_id: 'fac_capex', value: 0.5, unit: '£', raw_value: 20000 }],
+    })
+  })
+
+  it('sends the typed number in model space, never the raw figure', () => {
+    const r = buildAddOptionDispatch({
+      label: 'X',
+      changes: [{ factorId: 'fac_capex', rawValue: 40000 }],
+      nodes: GRAPH,
+    })
+    expect(r.ok && r.dispatch.parameters.interventions[0].value).toBe(1)
+  })
+
+  it('treats the typed number AS model space when the factor has no cap', () => {
+    const r = buildAddOptionDispatch({
+      label: 'X',
+      changes: [{ factorId: 'fac_timing', rawValue: 0.8 }],
+      nodes: GRAPH,
+    })
+    expect(r.ok && r.dispatch.parameters.interventions[0]).toEqual({
+      factor_id: 'fac_timing',
+      value: 0.8,
+    })
+  })
+
+  it('accepts an option with no changes at all', () => {
+    const r = buildAddOptionDispatch({ label: 'Status Quo Plus', changes: [], nodes: GRAPH })
+    expect(r.ok).toBe(true)
+    expect(r.ok && r.dispatch.parameters.interventions).toEqual([])
+    expect(r.ok && r.dispatch.message).toBe('Add an option called "Status Quo Plus".')
+  })
+
+  it('names every changed factor in the message, truthfully', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid',
+      changes: [
+        { factorId: 'fac_capex', rawValue: 20000 },
+        { factorId: 'fac_timing', rawValue: 0.9 },
+      ],
+      nodes: GRAPH,
+    })
+    expect(r.ok && r.dispatch.message).toBe(
+      'Add an option called "Hybrid" that changes "Capital Investment" and "Speed of Launch".',
+    )
+  })
+
+  // ⭐ THE GUARD. Proven on the live wire 2026-07-25: an id CEE cannot find does
+  // NOT error — it silently falls through to the LLM edit lane (18–27s,
+  // exit_path 'edit_graph'), same 200, same held_proposal shape. Refusing here
+  // is the only thing standing between a stale id and an invisible degradation.
+  it('REFUSES a factor id that is not on the canvas', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid',
+      changes: [{ factorId: 'fac_deleted', rawValue: 1 }],
+      nodes: GRAPH,
+    })
+    expect(r.ok).toBe(false)
+    expect(!r.ok && r.refusal).toEqual({ kind: 'unknown_factor', factorId: 'fac_deleted' })
+  })
+
+  it('REFUSES an id that exists but is not a factor', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid',
+      changes: [{ factorId: 'opt_a', rawValue: 1 }],
+      nodes: GRAPH,
+    })
+    expect(!r.ok && r.refusal.kind).toBe('unknown_factor')
+  })
+
+  it('REFUSES when the canvas has no decision node', () => {
+    const r = buildAddOptionDispatch({ label: 'Hybrid', changes: [], nodes: [] })
+    expect(!r.ok && r.refusal).toEqual({ kind: 'no_decision_node' })
+  })
+
+  it('REFUSES an empty or whitespace label', () => {
+    expect(buildAddOptionDispatch({ label: '   ', changes: [], nodes: GRAPH })).toEqual({
+      ok: false,
+      refusal: { kind: 'label_required' },
+    })
+  })
+
+  it('REFUSES more changes than CEE can hold in one proposal', () => {
+    const many = Array.from({ length: MAX_ADD_OPTION_INTERVENTIONS + 1 }, (_, i) => ({
+      factorId: `fac_${i}`,
+      rawValue: 1,
+    }))
+    const r = buildAddOptionDispatch({ label: 'Hybrid', changes: many, nodes: GRAPH })
+    expect(!r.ok && r.refusal).toEqual({
+      kind: 'too_many_changes',
+      max: MAX_ADD_OPTION_INTERVENTIONS,
+    })
+  })
+
+  it('REFUSES a non-finite value rather than coercing it', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid',
+      changes: [{ factorId: 'fac_timing', rawValue: Number.NaN }],
+      nodes: GRAPH,
+    })
+    expect(!r.ok && r.refusal).toEqual({ kind: 'parameters', reason: 'value_not_finite' })
+  })
+
+  it('REFUSES the same factor twice', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid',
+      changes: [
+        { factorId: 'fac_timing', rawValue: 0.2 },
+        { factorId: 'fac_timing', rawValue: 0.3 },
+      ],
+      nodes: GRAPH,
+    })
+    expect(!r.ok && r.refusal).toEqual({ kind: 'parameters', reason: 'duplicate_factor' })
+  })
+
+  it('gives every refusal a specific, non-generic explanation', () => {
+    const refusals = [
+      { kind: 'label_required' },
+      { kind: 'no_decision_node' },
+      { kind: 'unknown_factor', factorId: 'x' },
+      { kind: 'too_many_changes', max: 6 },
+      { kind: 'parameters', reason: 'value_not_finite' },
+      { kind: 'parameters', reason: 'duplicate_factor' },
+    ] as const
+    const texts = refusals.map((r) => describeAddOptionRefusal(r))
+    expect(new Set(texts).size).toBe(texts.length)
+    for (const t of texts) {
+      expect(t.length).toBeGreaterThan(10)
+      expect(t).not.toMatch(/something went wrong|unknown error|try again later/i)
+    }
+  })
+})
+
+// --- 4. ⭐ THE WIRE SEAM ----------------------------------------------------
+
+describe('wire seam — builder output through the REAL chipMeta → buildV5Payload chain', () => {
+  function toWire(dispatchLike: { id: string; intent: string; parameters: Record<string, unknown>; message: string }) {
+    const chipMeta = buildChipMeta(dispatchLike)
+    const built = buildV5Payload({
+      turnId: 't-1',
+      scenarioId: 's-1',
+      stage: 'frame',
+      turnClass: 'propose',
+      mode: 'user',
+      message: dispatchLike.message,
+      source: 'chip',
+      chipMeta,
+    })
+    expect(built.ok).toBe(true)
+    return built.ok ? built.payload : null
+  }
+
+  it('puts intent AND the full parameter spec on the wire chip', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid Pilot',
+      changes: [{ factorId: 'fac_capex', rawValue: 20000 }],
+      nodes: GRAPH,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+
+    const payload = toWire(r.dispatch)
+    expect(payload).not.toBeNull()
+    expect(payload!.kind).toBe('message')
+    const chip = (payload as { chip?: Record<string, unknown> }).chip
+    // If `intent` is dropped ANYWHERE — the builder, buildChipMeta, or the
+    // CEE_ACCEPTED_INTENTS send gate — this assertion is the one that goes RED.
+    expect(chip?.intent).toBe('add_option')
+    expect(chip?.id).toBe(ADD_OPTION_CHIP_ID)
+    expect(chip?.parameters).toEqual({
+      parent_decision_id: 'dec_bakery',
+      label: 'Hybrid Pilot',
+      interventions: [{ factor_id: 'fac_capex', value: 0.5, unit: '£', raw_value: 20000 }],
+    })
+  })
+
+  it('emits GENUINE finite numbers on the wire, never strings', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid',
+      changes: [{ factorId: 'fac_capex', rawValue: 20000 }],
+      nodes: GRAPH,
+    })
+    if (!r.ok) throw new Error('expected ok')
+    const chip = (toWire(r.dispatch) as { chip?: { parameters?: { interventions: unknown[] } } }).chip
+    const iv = chip!.parameters!.interventions[0] as Record<string, unknown>
+    expect(typeof iv.value).toBe('number')
+    expect(Number.isFinite(iv.value as number)).toBe(true)
+    expect(typeof iv.raw_value).toBe('number')
+    // Round-trips through JSON as a number, not "0.5".
+    const roundTripped = JSON.parse(JSON.stringify(chip)) as { parameters: { interventions: Record<string, unknown>[] } }
+    expect(typeof roundTripped.parameters.interventions[0].value).toBe('number')
+  })
+
+  it('carries no key CEE does not expect in the add_option spec', () => {
+    const r = buildAddOptionDispatch({ label: 'Hybrid', changes: [], nodes: GRAPH })
+    if (!r.ok) throw new Error('expected ok')
+    // Chip identity rides `chip.id`, NOT the parameter spec: an extra key in
+    // `parameters` is read by CEE's AddOptionParamsSchema, and polluting it is
+    // how a typed chip quietly becomes a free-text one.
+    expect(Object.keys(r.dispatch.parameters).sort()).toEqual([
+      'interventions',
+      'label',
+      'parent_decision_id',
+    ])
+  })
+})
+
+// --- 5. no-outcome-claim vocabulary ----------------------------------------
+
+describe('the producer never claims an outcome', () => {
+  it('keeps outcome verbs out of every string the builder emits', () => {
+    const r = buildAddOptionDispatch({
+      label: 'Hybrid',
+      changes: [{ factorId: 'fac_capex', rawValue: 20000 }],
+      nodes: GRAPH,
+    })
+    if (!r.ok) throw new Error('expected ok')
+    const strings = [r.dispatch.label, r.dispatch.message]
+    for (const s of strings) {
+      for (const banned of NO_OUTCOME_CLAIM_VOCABULARY) {
+        expect(s.toLowerCase()).not.toMatch(new RegExp(`\\b${banned}\\b`))
+      }
+    }
+  })
+
+  it('positive control — the vocabulary check can SEE a violation', () => {
+    const claim = 'Added option "Hybrid"'
+    const hits = NO_OUTCOME_CLAIM_VOCABULARY.filter((w) =>
+      new RegExp(`\\b${w}\\b`).test(claim.toLowerCase()),
+    )
+    expect(hits).toContain('added')
+  })
+})

--- a/src/canvas/conversation/__tests__/addOptionRequest.spec.ts
+++ b/src/canvas/conversation/__tests__/addOptionRequest.spec.ts
@@ -20,6 +20,7 @@ import {
   NO_OUTCOME_CLAIM_VOCABULARY,
 } from '../addOptionRequest'
 import { buildChipMeta } from '../chipMeta'
+import { normaliseRawFactorValue } from '../../utils/observedStateHelpers'
 import { buildV5Payload } from '../../../v5/buildPayload'
 import { MAX_ADD_OPTION_INTERVENTIONS } from '../../../v5/chipParameters'
 
@@ -70,10 +71,24 @@ describe('detectAddOptionRequest', () => {
     ['Do you think we should add an option called Hybrid?'],
     ['Is it worth adding an option called Hybrid'],
     ['What if I add an option called Hybrid?'],
+    // ISOLATES THE QUESTION-MARK RULE. Every case above is also blocked by the
+    // imperative test, so without these the '?' rejection is untested — a
+    // mutation removing it escaped 68 green tests until they were added.
+    ['Can you add an option called Hybrid Pilot?'],
+    ['Please add an option called Hybrid Pilot?'],
+    ['Add an option called Hybrid Pilot?'],
     // Plural = a brainstorm request for the coach, not one resolved option.
     ['Add more options'],
     ['Add some alternatives to consider'],
     ['Create three new options'],
+    // ISOLATES THE SINGULAR RULE. The three above are all blocked by the
+    // quantifier word ("more"/"some"/"three"), not by the plural — so without
+    // these the singular constraint is untested, and a mutation admitting
+    // plurals escaped 68 green tests.
+    ['Add options called Hybrid and Franchise'],
+    ['Add alternatives called Hybrid'],
+    ['Create choices called Hybrid'],
+    ['Add the options called Hybrid'],
     // No nameable label — the free-text lane still handles it.
     ['Add an option'],
     ['Add an option to the model'],
@@ -125,6 +140,54 @@ describe('resolveAddOptionTargets', () => {
 
   it('reports no decision node on an empty canvas', () => {
     expect(resolveAddOptionTargets([]).decisionId).toBeNull()
+  })
+})
+
+// --- 2b. the raw→model-space rule -------------------------------------------
+
+describe('normaliseRawFactorValue', () => {
+  it('divides by a genuine positive cap', () => {
+    expect(normaliseRawFactorValue(20000, 40000)).toBe(0.5)
+  })
+
+  // A cap of 0 divides to Infinity and a negative cap flips the sign — both
+  // would reach CEE as a "genuine finite number" and commit silently. The
+  // guard, not the caller, is what stops them.
+  it.each([
+    ['zero', 0],
+    ['negative', -40000],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('treats a %s cap as no scale and returns the raw figure', (_name, cap) => {
+    expect(normaliseRawFactorValue(20000, cap)).toBe(20000)
+  })
+
+  it('treats a missing cap as no scale', () => {
+    expect(normaliseRawFactorValue(0.8, undefined)).toBe(0.8)
+    expect(normaliseRawFactorValue(0.8, null)).toBe(0.8)
+  })
+
+  it('never invents a value from a non-finite input', () => {
+    expect(normaliseRawFactorValue(Number.NaN, 40000)).toBeNaN()
+  })
+})
+
+describe('a zero cap cannot produce a non-finite intervention', () => {
+  const ZERO_CAP: Node[] = [
+    node('dec_1', 'decision', 'D'),
+    node('fac_zero', 'factor', 'Zero Cap', { value: 0, cap: 0, unit: '£' }),
+  ]
+  it('sends the typed figure, never Infinity', () => {
+    const r = buildAddOptionDispatch({
+      label: 'X',
+      changes: [{ factorId: 'fac_zero', rawValue: 500 }],
+      nodes: ZERO_CAP,
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    const value = r.dispatch.parameters.interventions[0].value
+    expect(Number.isFinite(value)).toBe(true)
+    expect(value).toBe(500)
   })
 })
 
@@ -362,19 +425,18 @@ describe('the producer never claims an outcome', () => {
       nodes: GRAPH,
     })
     if (!r.ok) throw new Error('expected ok')
-    const strings = [r.dispatch.label, r.dispatch.message]
-    for (const s of strings) {
+    // SUBSTRING, not a word-boundary regex. A boundary assertion is the weaker
+    // prohibition (it misses "addedA", "successfully"), and weaker is the wrong
+    // direction for a rule whose whole job is to catch a claim.
+    for (const s of [r.dispatch.label, r.dispatch.message]) {
       for (const banned of NO_OUTCOME_CLAIM_VOCABULARY) {
-        expect(s.toLowerCase()).not.toMatch(new RegExp(`\\b${banned}\\b`))
+        expect(s.toLowerCase()).not.toContain(banned)
       }
     }
   })
 
   it('positive control — the vocabulary check can SEE a violation', () => {
-    const claim = 'Added option "Hybrid"'
-    const hits = NO_OUTCOME_CLAIM_VOCABULARY.filter((w) =>
-      new RegExp(`\\b${w}\\b`).test(claim.toLowerCase()),
-    )
-    expect(hits).toContain('added')
+    const claim = 'Added option "Hybrid"'.toLowerCase()
+    expect(NO_OUTCOME_CLAIM_VOCABULARY.filter((w) => claim.includes(w))).toContain('added')
   })
 })

--- a/src/canvas/conversation/addOptionRequest.ts
+++ b/src/canvas/conversation/addOptionRequest.ts
@@ -1,0 +1,384 @@
+/**
+ * addOptionRequest — the UI PRODUCER seam for the `add_option` intent.
+ *
+ * WHY THIS EXISTS. Everything downstream of an `add_option` chip has been live
+ * and probe-proven on staging for months: CEE's zero-LLM `add_option` transaction
+ * (`orchestrator-v5/routing/add-option-transaction.ts`) atomically holds
+ * add_node(option) + add_edge(decision→option) + N × add_edge(option→factor),
+ * the hold→consent→apply flow works, and the applied receipt carries a
+ * `draft_graph` the canvas reconciles. The UI's wire gate is open
+ * (`CEE_ACCEPTED_INTENTS = {'add_option'}`) and the parameter builder
+ * (`buildAddOptionParameters`) is spec-pinned.
+ *
+ * The ONLY missing piece was a surface that produces the chip. This module is
+ * the pure half of that surface: it decides WHETHER a typed message is an
+ * add-option request, and turns a resolved (label, changes) pair into the exact
+ * `dispatchAction` argument. No React, no store, no I/O — so every rule here is
+ * directly testable and the seam can be exercised end-to-end through the REAL
+ * `buildChipMeta` → `buildV5Payload` chain.
+ *
+ * THREE HARD RULES, each with a mechanism and a test that goes RED without it:
+ *
+ *  1. **IDS COME FROM THE LIVE CANVAS, NEVER FROM PROSE.** Verified on the wire
+ *     2026-07-25: a chip carrying a `parent_decision_id` or `factor_id` that is
+ *     not in the persisted graph does NOT fail — CEE silently falls through to
+ *     the LLM edit lane (`exit_path: 'edit_graph'`, 18–27s, `llm_calls` non-empty)
+ *     and an LLM authors the edit instead. Same 200, same `held_proposal` shape,
+ *     so the degradation is INVISIBLE at the boundary. `buildAddOptionDispatch`
+ *     therefore REFUSES any id it cannot find on the canvas rather than emit a
+ *     chip that will quietly take the slow, non-deterministic path.
+ *
+ *  2. **DETECTION IS HIGH-PRECISION AND NEVER LOSES THE USER'S TEXT.** A false
+ *     positive costs the user a dismissable panel and their message is still
+ *     sent verbatim; a false negative costs nothing (the message goes to the
+ *     existing free-text lane exactly as today). So the rules are tuned for
+ *     precision: an imperative add-verb, a SINGULAR option noun, an extractable
+ *     label, and no question mark. Ambiguous deliberation ("should I add an
+ *     option?", "add more options") is deliberately NOT matched.
+ *
+ *  3. **THE PRODUCER NEVER CLAIMS AN OUTCOME.** This module builds a REQUEST.
+ *     It has no vocabulary for success — the only truthful receipt is CEE's own
+ *     hold/confirm copy, which names every operation. See
+ *     `NO_OUTCOME_CLAIM_VOCABULARY` and the test that pins it.
+ */
+
+import type { Node } from '@xyflow/react'
+
+import {
+  ADD_OPTION_INTENT,
+  MAX_ADD_OPTION_INTERVENTIONS,
+  buildAddOptionParameters,
+  type AddOptionInterventionInput,
+  type AddOptionParameters,
+  type ChipParametersFailReason,
+} from '../../v5/chipParameters'
+import { getObservedState, normaliseRawFactorValue } from '../utils/observedStateHelpers'
+import { computeGraphFacts } from '../components/pre-analysis-v3/selectors/graphFacts'
+
+// ---------------------------------------------------------------------------
+// 1. Natural-language detection
+// ---------------------------------------------------------------------------
+
+export interface AddOptionDetection {
+  /**
+   * The label the user named, verbatim and trimmed. This is a PREFILL, not a
+   * commitment — the panel renders it in an editable field, which is why a
+   * slightly-off extraction is an ergonomics cost and never a correctness one.
+   */
+  readonly label: string
+}
+
+/**
+ * Courtesy / framing prefixes stripped before the imperative test, so
+ * "Can you add an option called X" is treated the same as "Add an option
+ * called X". Deliberately SMALL: every entry widens the match, and the
+ * deliberative openers ("should I", "what if", "do you think", "is it worth")
+ * are absent on purpose — those are questions for the coach, not commands.
+ */
+const COURTESY_PREFIX =
+  /^(?:please\s+|can\s+you\s+|could\s+you\s+|i\s+want\s+to\s+|i'?d\s+like\s+to\s+|i\s+would\s+like\s+to\s+|let'?s\s+)+/i
+
+/**
+ * The imperative core. `option|alternative|choice` is matched with a trailing
+ * `\b` and NO plural alternative, so "add more options" / "add some
+ * alternatives" (brainstorm requests, which belong to the coach) do not match
+ * while "add an option" does.
+ */
+const ADD_OPTION_IMPERATIVE =
+  /^(?:add|create|include)\s+(?:a|an|another|one|the)?\s*(?:new\s+)?(?:option|alternative|choice)\b/i
+
+/** Straight and curly quotes, double and single. Group 2 is the content. */
+const QUOTED_LABEL = /(["'“‘])([^"'“”‘’]{1,120})(["'”’])/
+
+/** `called X` / `named X` / `titled X` — the unquoted naming forms. */
+const NAMED_LABEL = /\b(?:called|named|titled)\s+(.{1,120})$/i
+
+/**
+ * Trailing relative clauses that describe the option rather than name it.
+ * "…called Hybrid that cuts cost" must yield "Hybrid", not the whole tail.
+ */
+const LABEL_TAIL_CLAUSE = /\s+(?:that|which|where|who|so\s+that|in\s+order)\b.*$/i
+
+function trimLabel(raw: string): string {
+  return raw
+    .replace(LABEL_TAIL_CLAUSE, '')
+    .replace(/[\s.,;:!]+$/u, '')
+    .trim()
+}
+
+/**
+ * Decide whether a composer message is an add-option request, and extract the
+ * option's label. Returns `null` for anything that is not an unambiguous
+ * request — the caller then sends the message through the existing free-text
+ * lane, byte-identical to today.
+ *
+ * Pure. Never throws.
+ */
+export function detectAddOptionRequest(text: string): AddOptionDetection | null {
+  if (typeof text !== 'string') return null
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return null
+
+  // A question is deliberation, not an instruction. "Should I add an option
+  // called X?" must reach the coach, not open a form.
+  if (trimmed.endsWith('?')) return null
+
+  const imperative = trimmed.replace(COURTESY_PREFIX, '')
+  if (!ADD_OPTION_IMPERATIVE.test(imperative)) return null
+
+  const quoted = QUOTED_LABEL.exec(imperative)
+  if (quoted) {
+    const label = trimLabel(quoted[2])
+    return label.length > 0 ? { label } : null
+  }
+
+  const named = NAMED_LABEL.exec(imperative)
+  if (named) {
+    const label = trimLabel(named[1])
+    return label.length > 0 ? { label } : null
+  }
+
+  // An add-option request with no nameable label ("add an option") is a real
+  // request but not a resolved one — hand it to the free-text lane rather than
+  // open a form with an empty, unexplained field.
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// 2. Canvas resolution
+// ---------------------------------------------------------------------------
+
+export interface AddOptionFactorTarget {
+  readonly id: string
+  readonly label: string
+  /**
+   * The factor's current value in the SAME terms the panel will ask the user to
+   * type — raw units when the factor carries an honest scale (a positive cap),
+   * model-space otherwise. `null` when the factor has no value yet.
+   */
+  readonly currentRaw: number | null
+  readonly unit: string | undefined
+  /** Positive, finite cap when one exists — the raw→model-space divisor. */
+  readonly cap: number | undefined
+}
+
+export interface AddOptionCanvasTargets {
+  readonly decisionId: string | null
+  readonly decisionLabel: string | null
+  readonly factors: readonly AddOptionFactorTarget[]
+}
+
+function labelOf(node: Node): string {
+  const raw = (node.data as Record<string, unknown> | undefined)?.label
+  return typeof raw === 'string' && raw.length > 0 ? raw : node.id
+}
+
+/**
+ * Derive the add-option targets from the live canvas. DERIVED, never mirrored:
+ * `computeGraphFacts` is the repo's single kind-resolver (it handles the
+ * `data.kind` vs `type` divergence that the ad-hoc `n.type === 'decision'`
+ * filters get wrong), so this cannot drift from how the rest of the UI counts
+ * decisions and factors.
+ */
+export function resolveAddOptionTargets(nodes: ReadonlyArray<Node>): AddOptionCanvasTargets {
+  const facts = computeGraphFacts(nodes)
+  const factors = facts.factorNodes.map((node): AddOptionFactorTarget => {
+    const observed = getObservedState(node.data)
+    const cap = typeof observed.cap === 'number' && Number.isFinite(observed.cap) && observed.cap > 0
+      ? observed.cap
+      : undefined
+    const rawCandidate = typeof observed.raw_value === 'number' ? observed.raw_value : undefined
+    const modelValue = typeof observed.value === 'number' ? observed.value : undefined
+    // Present whatever the user would type: the raw figure when we have one,
+    // else the raw figure implied by the cap, else the model-space value.
+    const currentRaw =
+      rawCandidate !== undefined && Number.isFinite(rawCandidate)
+        ? rawCandidate
+        : cap !== undefined && modelValue !== undefined && Number.isFinite(modelValue)
+          ? modelValue * cap
+          : modelValue !== undefined && Number.isFinite(modelValue)
+            ? modelValue
+            : null
+    return {
+      id: node.id,
+      label: labelOf(node),
+      currentRaw,
+      unit: typeof observed.unit === 'string' && observed.unit.length > 0 ? observed.unit : undefined,
+      cap,
+    }
+  })
+  return {
+    decisionId: facts.decisionNode?.id ?? null,
+    decisionLabel: facts.decisionNode ? labelOf(facts.decisionNode) : null,
+    factors,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Dispatch construction
+// ---------------------------------------------------------------------------
+
+/** One factor the user says this option changes, in the units they typed. */
+export interface AddOptionChange {
+  readonly factorId: string
+  /** The number the user typed, in the factor's own displayed units. */
+  readonly rawValue: number
+}
+
+export type AddOptionRefusal =
+  | { readonly kind: 'label_required' }
+  | { readonly kind: 'no_decision_node' }
+  | { readonly kind: 'unknown_factor'; readonly factorId: string }
+  | { readonly kind: 'too_many_changes'; readonly max: number }
+  | { readonly kind: 'parameters'; readonly reason: ChipParametersFailReason }
+
+/**
+ * The exact `dispatchAction` argument. Structurally a subset of
+ * `DispatchActionOpts` so the compiler pins the two together.
+ */
+export interface AddOptionDispatchRequest {
+  readonly id: string
+  readonly intent: typeof ADD_OPTION_INTENT
+  readonly parameters: AddOptionParameters
+  readonly label: string
+  readonly message: string
+}
+
+export type AddOptionDispatchResult =
+  | { readonly ok: true; readonly dispatch: AddOptionDispatchRequest }
+  | { readonly ok: false; readonly refusal: AddOptionRefusal }
+
+/** Chip identity for the composer-originated add-option request. */
+export const ADD_OPTION_CHIP_ID = 'ui_add_option_form'
+
+function quoteList(labels: readonly string[]): string {
+  if (labels.length === 0) return ''
+  if (labels.length === 1) return `"${labels[0]}"`
+  return `${labels.slice(0, -1).map((l) => `"${l}"`).join(', ')} and "${labels[labels.length - 1]}"`
+}
+
+/**
+ * Build the add-option chip from a label plus the changes the user configured.
+ *
+ * REFUSES rather than degrades. In particular every `factorId` must resolve to
+ * a node the canvas currently classifies as a factor: an id CEE cannot find is
+ * not an error on the wire, it is a silent fall-through to the LLM edit lane
+ * (rule 1 in the module docstring), which is precisely the failure this surface
+ * exists to avoid.
+ */
+export function buildAddOptionDispatch(input: {
+  readonly label: string
+  readonly changes: readonly AddOptionChange[]
+  readonly nodes: ReadonlyArray<Node>
+}): AddOptionDispatchResult {
+  const label = input.label.trim()
+  if (label.length === 0) return { ok: false, refusal: { kind: 'label_required' } }
+
+  const targets = resolveAddOptionTargets(input.nodes)
+  if (!targets.decisionId) return { ok: false, refusal: { kind: 'no_decision_node' } }
+
+  if (input.changes.length > MAX_ADD_OPTION_INTERVENTIONS) {
+    return { ok: false, refusal: { kind: 'too_many_changes', max: MAX_ADD_OPTION_INTERVENTIONS } }
+  }
+
+  const byId = new Map(targets.factors.map((f) => [f.id, f]))
+  const interventions: AddOptionInterventionInput[] = []
+  const changedLabels: string[] = []
+  for (const change of input.changes) {
+    const target = byId.get(change.factorId)
+    if (!target) return { ok: false, refusal: { kind: 'unknown_factor', factorId: change.factorId } }
+    const normalised = normaliseRawFactorValue(change.rawValue, target.cap)
+    interventions.push({
+      factorId: target.id,
+      value: normalised,
+      // Carry the raw figure and its unit alongside the model-space value, the
+      // same pairing every other value-edit path in the UI persists, so the
+      // user's real-world number is never lost to the normalisation.
+      ...(target.cap !== undefined ? { rawValue: change.rawValue } : {}),
+      ...(target.cap !== undefined && target.unit !== undefined ? { unit: target.unit } : {}),
+    })
+    changedLabels.push(target.label)
+  }
+
+  const built = buildAddOptionParameters({
+    parentDecisionId: targets.decisionId,
+    label,
+    interventions,
+  })
+  if (!built.ok) return { ok: false, refusal: { kind: 'parameters', reason: built.reason } }
+
+  const message =
+    changedLabels.length > 0
+      ? `Add an option called "${label}" that changes ${quoteList(changedLabels)}.`
+      : `Add an option called "${label}".`
+
+  return {
+    ok: true,
+    dispatch: {
+      id: ADD_OPTION_CHIP_ID,
+      intent: ADD_OPTION_INTENT,
+      parameters: built.parameters,
+      label: `Add option "${label}"`,
+      message,
+    },
+  }
+}
+
+/**
+ * User-facing text for a refusal. Names WHICH part was refused and WHY, in the
+ * product's own vocabulary — never a code, never a generic "something went
+ * wrong".
+ */
+export function describeAddOptionRefusal(refusal: AddOptionRefusal): string {
+  switch (refusal.kind) {
+    case 'label_required':
+      return 'Give the option a name first.'
+    case 'no_decision_node':
+      return 'This model has no decision node yet, so there is nothing to add an option to.'
+    case 'unknown_factor':
+      return `One of the factors you picked is no longer on the canvas, so it was not included. Close this and try again.`
+    case 'too_many_changes':
+      return `An option can change at most ${refusal.max} factors in one go. Remove some and add the rest afterwards.`
+    case 'parameters':
+      return describeParametersRefusal(refusal.reason)
+  }
+}
+
+function describeParametersRefusal(reason: ChipParametersFailReason): string {
+  switch (reason) {
+    case 'label_required':
+      return 'Give the option a name first.'
+    case 'value_not_finite':
+    case 'raw_value_not_finite':
+      return 'Every factor you tick needs a number.'
+    case 'duplicate_factor':
+      return 'The same factor is listed twice.'
+    case 'too_many_interventions':
+      return `An option can change at most ${MAX_ADD_OPTION_INTERVENTIONS} factors in one go.`
+    case 'parent_decision_id_required':
+      return 'This model has no decision node yet, so there is nothing to add an option to.'
+    default:
+      // Every remaining reason belongs to a different builder (edge/constraint
+      // chips) and is unreachable here; say so honestly rather than invent copy.
+      return `This request could not be built (${reason}).`
+  }
+}
+
+/**
+ * Words this surface must never use about a change it has only REQUESTED.
+ *
+ * The estate has shipped receipts claiming changes that never happened, so the
+ * producer is held to a mechanical rule: it proposes, CEE reports. The panel
+ * spec asserts none of these appear in any string this surface renders, which
+ * is why the list lives here (next to the code it constrains) rather than in
+ * the test file.
+ */
+export const NO_OUTCOME_CLAIM_VOCABULARY: readonly string[] = [
+  'added',
+  'created',
+  'saved',
+  'applied',
+  'updated',
+  'done',
+  'success',
+]

--- a/src/canvas/utils/observedStateHelpers.ts
+++ b/src/canvas/utils/observedStateHelpers.ts
@@ -112,6 +112,29 @@ export function isFactorNeedsInput(nodeData: unknown): boolean {
 }
 
 /**
+ * Convert a raw, real-world factor figure into the normalised model-space
+ * `value` the engine consumes.
+ *
+ * This is the rule every value-edit path in the UI already applies —
+ * PreAnalysisPanel.handleInlineEditValue and CalibrateDrillIn.commitValue both
+ * inline `cap != null && cap > 0 ? rawValue / cap : rawValue`. It is factored
+ * out here (the canonical home for observed-state logic) so new callers derive
+ * the rule instead of re-typing it. The two existing inline copies are
+ * unchanged by this commit and are tracked for convergence.
+ *
+ * A missing, non-finite or non-positive cap means "no honest scale exists", in
+ * which case the typed number IS the model-space value — the same fallback the
+ * existing call sites take. Never throws; a non-finite raw value is returned
+ * unchanged so the caller's own finite-number guard is the single rejection
+ * point rather than a silent coercion here.
+ */
+export function normaliseRawFactorValue(rawValue: number, cap: number | undefined | null): number {
+  if (!Number.isFinite(rawValue)) return rawValue
+  if (typeof cap !== 'number' || !Number.isFinite(cap) || cap <= 0) return rawValue
+  return rawValue / cap
+}
+
+/**
  * Build a node data patch that writes observed_state updates to BOTH keys.
  * Spreads existing state, then overlays the updates.
  *


### PR DESCRIPTION
Closes the **oldest open capability gap in the programme** — "add option" has been broken since June.

## The gap was a missing UI producer, and only that

CEE's zero-LLM `add_option` transaction has been live and probe-proven on staging for months. The UI's wire gate (`CEE_ACCEPTED_INTENTS = {'add_option'}`) has been open. The parameter builder `buildAddOptionParameters` has been spec-pinned with **zero non-test importers**. Nothing produced the chip.

**Re-verified at today's DEPLOYMENT values before building** (2026-07-25) — not repo defaults, which is how a prior design lane concluded the opposite:

| Probe | Result |
|---|---|
| `CEE_GRAPH_MANAGEMENT_MODE` on cee-staging (Render env) | **`live`** |
| add_option intent chip → `/proxy/v5/turn` | **200 / 1.76s / `llm_calls: []` / `exit_path: "add_option_transaction"`** / `held_proposal` + one confirm chip |
| confirm chip replayed | **200 / 2.67s / `llm_calls: []`** / `"Confirmed: add option …"` + `draft_graph` (canvas-refresh channel) |
| persisted `scenarios.graph` | option node + 3 edges + `options[]` entry, `status: 'ready'`, nodes 14→15 |

CEE build `8de3d3d`.

## What this adds

A user types **"add an option called X"**. The UI detects that deterministically, resolves `parent_decision_id` and the factor ids **from the live canvas**, and asks only for the part prose cannot carry — which factors the option changes and to what value. That produces the typed chip, which routes into the **existing tested transaction** and its **existing hold → confirm → apply consent flow**.

No new transaction. No fork of the consent flow. **Zero CEE change, zero schemas change, zero re-vendor, zero LLM on either side.**

Natural language is the **entry**, not the sole route, and the trace is why: a sentence yields the label deterministically but never the changes — turning "cuts cost by 20%" into `{factor_id, value}` is target resolution plus value extraction, a separate programme step. Shipping the label alone would land the user in `needs_encoding`, the exact state they complain about.

## Two mechanisms the wire proved were needed

1. **Canvas-id guard.** A chip carrying an id CEE cannot find does **not** fail — it silently falls through to the LLM edit lane (`exit_path: 'edit_graph'`, **18–27s**, `llm_calls` non-empty) behind the same 200 and the same `held_proposal` shape. The degradation is invisible at the boundary. So `buildAddOptionDispatch` refuses any id not currently on the canvas, and **re-resolves at submit, not at panel-open** — a node deleted mid-panel refuses instead of shipping a stale id.
2. **Nothing typed is ever lost.** Cancel keeps the text in the composer; "Send as a message instead" sends it verbatim down the ordinary lane. A false-positive detection costs a dismissable panel, never a dropped message.

## Honesty

The producer has **no vocabulary for success**. `NO_OUTCOME_CLAIM_VOCABULARY` is asserted against every string the builder emits *and* against the panel's entire rendered text, each with a positive control. The only receipt is CEE's own, which names every operation verbatim.

## Mutation checks — 17/17 bite, and **four ESCAPED first**

Run in a throwaway copy, never the working tree.

| Escape | Why it mattered |
|---|---|
| detector admits **plurals** | Every "plural" non-match case was blocked by the *quantifier word*, not the plural. The rule was unreachable from any test. |
| **`?` rejection** removed | Every "question" case was blocked by the *imperative test*, not the `?`. Same defect. |
| panel **claims an outcome** | `element.textContent` concatenates adjacent text nodes with no separator, so `"Option added"` rendered as `"Option addedA new option…"` and `/\badded\b/` did not match. **The absence assertion was vacuous.** Fixed with a text-node join + a substring prohibition + a positive control that plants a claim in a real DOM fragment. |
| **cap ≤ 0** admitted | A cap of `0` divides to `Infinity`, a negative cap flips the sign; both reach CEE as a "genuine finite number". |

The other 13 (canvas-id guard, `intent` dropped, normalisation skipped, label tail-clause, send-as-message, cancel-clears-draft, double-send, kind resolver, re-resolve-at-submit, refusal swallowed, interception disabled, cap removed, non-finite raw) bit on the first pass.

The load-bearing test is the **wire seam**: the builder's output is driven through the **real** `buildChipMeta` → `buildV5Payload` chain and the final payload's `chip.intent` is asserted — so a dropped intent goes RED *wherever* it is dropped, not only at the builder's return value.

## Gates

- `pnpm run typecheck` (the authoritative gate): **PASS**, coverage 2984/3002, **ratchet baseline UNCHANGED** (666 files / 2663 errors). All four touched files carry **zero** diagnostics. The gate proved itself on the way in — it caught an unused import in a brand-new file, exactly what #470 was for.
- eslint on all six changed files: clean.
- `ci:guard:zustand` PASS · `ci:guard:duplicates` PASS · `ci:guard:ds` exit 0 with **zero** net-new entries naming any file here.
- **84 new tests**, all green.

## Real-browser verification

The panel renders and behaves correctly in the running app (local dev, deployed-staging graph): heading, `"A new option under \"International Expansion Strategy\". Nothing changes on your canvas yet."`, prefilled editable name, all eight factors with their current values and units, tick + value, and the chip dispatches with the builder's exact message. The local dev origin cannot reach `cee-staging`'s browser proxy (`PROXY_ORIGIN_REJECTED` — the allow-list is the Netlify origins), so the **wire + apply + canvas legs are verified on deployed staging after merge**; the wire legs themselves are already proven by the direct probes above.

## Known, disclosed

`normaliseRawFactorValue` is factored into `observedStateHelpers` (its canonical home), but the two pre-existing inline copies in `PreAnalysisPanel.handleInlineEditValue` and `CalibrateDrillIn.commitValue` are **not** converged here — out of scope, rowed separately.

Lane log: `parallel-briefs/ADD-OPTION-LANE-2026-07-25.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)