### PR TITLE
fix(honesty): stop speaking UI defaults as measurements — edge belief/strength + factor confidence

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -8,6 +8,7 @@ import '@xyflow/react/dist/style.css'
 import { useCanvasStore } from './store'
 import { useComparisonStore } from './stores/comparisonStore'
 import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS } from './domain/edges'
+import { edgeValueSourcePatch } from './domain/edgeValueProvenance'
 import { parseRunHash } from './utils/shareLink'
 import { useInitialLayoutGuard } from './hooks/useInitialLayoutGuard'
 import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
@@ -1177,6 +1178,13 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
           confidence: edge.probability,
           belief: edge.belief ?? edge.probability,      // v1.2: prefer belief, fallback to probability
           provenance: edge.provenance ?? 'template',    // v1.2: default to template source
+          // Set-vs-defaulted markers (domain/edgeValueProvenance.ts). A blueprint
+          // weight was authored by a template author — a real value, not a UI
+          // fallthrough — so it is 'template', NOT 'cee': it is not an estimate
+          // of THIS user's decision. Matches useBlueprintInsert.
+          ...edgeValueSourcePatch({
+            weight: edge.weight != null ? 'template' : undefined,
+          }),
           templateId: blueprint.id
         }
       }

--- a/src/canvas/components/DraftChat.tsx
+++ b/src/canvas/components/DraftChat.tsx
@@ -13,6 +13,7 @@ import { DraftGuidancePanel } from './DraftGuidancePanel'
 import { RateLimitNotice } from './RateLimitNotice'
 import { ThinkingModePopover } from './ThinkingModePopover'
 import { DEFAULT_EDGE_DATA, trimProvenance } from '../domain/edges'
+import { edgeValueSourcePatch } from '../domain/edgeValueProvenance'
 import { saveAutosave } from '../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
 import { hasAnalysisReady, isCeePipelineTrace } from '../../adapters/cee/types'
@@ -615,6 +616,14 @@ export function DraftChat() {
           confidence,
           // P0 Fix: Use belief_exists (structural certainty) for beliefExists, fallback to belief (confidence)
           beliefExists: beliefExistsValue ?? confidence,
+          // Set-vs-defaulted markers (canvas/domain/edgeValueProvenance.ts).
+          // `weightSource` here is the LOCAL string above, which records which
+          // wire probe won — 'default' means the UI filled it in, so that case
+          // is deliberately NOT stamped.
+          ...edgeValueSourcePatch({
+            beliefExists: (beliefExistsValue ?? confidence) !== undefined ? 'cee' : undefined,
+            weight: weightSource !== 'default' ? 'cee' : undefined,
+          }),
           provenance: provenanceText,
           // Brief v2.2: New edge properties
           ...(direction ? { direction } : {}),

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -44,6 +44,7 @@ import { StreamingDiagnostics } from './model-tab/StreamingDiagnostics'
 import { buildSynthesisedPriorMap } from './model-tab/synthesisedPriorHelpers'
 import { countFactorsToVerify } from './model-tab/utils'
 import { ModelAdjustments } from './model-tab/ModelAdjustments'
+import { resolveRawFactorConfidenceDisplay } from '../../components/results/driverConfidenceDisplayPolicy'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -236,8 +237,17 @@ export const ModelTabBody = memo(function ModelTabBody({
       // Rank flip rate
       if (typeof f?.rank_flip_rate === 'number') flipRate.set(id, f.rank_flip_rate)
 
-      // Confidence (0-1)
-      if (typeof f?.confidence === 'number') confidence.set(id, f.confidence)
+      // Confidence (0-1) — resolved through THE shared display policy
+      // (components/results/driverConfidenceDisplayPolicy), never read raw.
+      //
+      // ⛔ This map fed "Confidence NN%" in the factor detail rows off the same
+      // `factor_sensitivity[].confidence` the Drivers panel refuses to render.
+      // In both real staging captures that value is a defaulted 0.25. The
+      // resolver reads the confidence fields off the RAW row here (this surface
+      // never touches the normalised driver feed), so there is still only one
+      // implementation of the rule.
+      const confidenceDisplay = resolveRawFactorConfidenceDisplay(f)
+      if (confidenceDisplay.show) confidence.set(id, confidenceDisplay.value)
     }
 
     return { evpiMap: evpi, attributionStabilityMap: stability, elasticityMap: elasticity, rankFlipRateMap: flipRate, factorConfidenceMap: confidence }
@@ -523,6 +533,9 @@ export const ModelTabBody = memo(function ModelTabBody({
       const patch: DataPatch = {
         weight: Math.abs(mean),
         direction: mean >= 0 ? 'positive' : 'negative',
+        // The accepted value is the producer's pass-2 strength, so the edge
+        // now carries a real estimate rather than the UI default.
+        weightSource: 'cee',
         validation: updatedValidation,
       }
       updateEdge(edgeId, { data: patch as EdgeData })
@@ -533,6 +546,8 @@ export const ModelTabBody = memo(function ModelTabBody({
       const patch: DataPatch = {
         weight: Math.abs(customMean),
         direction: customMean >= 0 ? 'positive' : 'negative',
+        // The user overrode the producer with their own number.
+        weightSource: 'user',
         validation: { ...updatedValidation, resolved_value: { strength_mean: customMean } },
       }
       updateEdge(edgeId, { data: patch as EdgeData })

--- a/src/canvas/components/model-tab/RelationshipsSection.tsx
+++ b/src/canvas/components/model-tab/RelationshipsSection.tsx
@@ -178,7 +178,10 @@ function EdgeCard({
   const handleWeightSave = useCallback((val: string) => {
     const n = parseFloat(val)
     if (isNaN(n) || n < 0 || n > 2) return
-    updateEdge(edgeId, { data: { ...data, weight: n } })
+    // The user typed this number, so it stops being a default (see
+    // canvas/domain/edgeValueProvenance.ts) — stamped in the same update as the
+    // value so the marker can never lag the number it describes.
+    updateEdge(edgeId, { data: { ...data, weight: n, weightSource: 'user' } })
   }, [edgeId, data, updateEdge])
 
   const handleDirectionToggle = useCallback((dir: 'positive' | 'negative') => {
@@ -188,7 +191,7 @@ function EdgeCard({
   const handleLikelihoodSave = useCallback((val: string) => {
     const pct = parseFloat(val)
     if (isNaN(pct) || pct < 0 || pct > 100) return
-    updateEdge(edgeId, { data: { ...data, beliefExists: pct / 100 } })
+    updateEdge(edgeId, { data: { ...data, beliefExists: pct / 100, beliefExistsSource: 'user' } })
   }, [edgeId, data, updateEdge])
 
   return (

--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -8,6 +8,7 @@
 
 import { useCanvasStore } from '../../store'
 import { DEFAULT_EDGE_DATA } from '../../domain/edges'
+import { edgeValueSourcePatch } from '../../domain/edgeValueProvenance'
 import { saveAutosave } from '../../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../../store/autosaveProjection'
 import { pulseAppliedTargets } from '../../utils/appliedEditPulse'
@@ -96,6 +97,12 @@ function buildEdge(op: PatchOperation) {
 
   // Weight priority: strength.mean > strength_mean > weight > default
   const strength = d.strength as Record<string, unknown> | undefined
+  // Derived from the SAME three probes the priority chain below uses, so it
+  // cannot drift: true exactly when the UI-default branch was NOT taken.
+  const wireSuppliedStrength =
+    typeof strength?.mean === 'number'
+    || typeof d.strength_mean === 'number'
+    || typeof d.weight === 'number'
   const rawWeight: number =
     typeof strength?.mean === 'number'
       ? strength.mean
@@ -155,6 +162,14 @@ function buildEdge(op: PatchOperation) {
       ...(edgeType !== undefined ? { edge_type: edgeType } : {}),
       ...(provenanceSource !== undefined ? { provenance_source: provenanceSource } : {}),
       ...(existsProbability !== undefined ? { exists_probability: existsProbability } : {}),
+      // Set-vs-defaulted markers — see domain/edgeValueProvenance.ts. Omitted
+      // when the patch carried no value, so an operation that supplies neither
+      // leaves the edge honestly marked as unset rather than claiming a
+      // producer estimate.
+      ...edgeValueSourcePatch({
+        beliefExists: beliefExists !== undefined ? 'cee' : undefined,
+        weight: wireSuppliedStrength ? 'cee' : undefined,
+      }),
     },
   }
 }

--- a/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
+++ b/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Edge value provenance — the set-vs-defaulted invariant.
+ *
+ * The whole point of this marker is that ABSENT MEANS DEFAULTED. Every test
+ * here is paired: an absence assertion is worthless unless the same shape with
+ * a stamp demonstrably reads as SET, so each "not set" case sits next to the
+ * positive control that proves the reader can see a presence at all.
+ */
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS, EdgeDataSchema } from '../edges'
+import {
+  edgeValueSource,
+  isEdgeValueSet,
+  edgeValueSourcePatch,
+  EDGE_PROVENANCED_FIELDS,
+} from '../edgeValueProvenance'
+
+describe('edgeValueProvenance — the UI defaults are NOT a source', () => {
+  it.each(EDGE_PROVENANCED_FIELDS)(
+    'DEFAULT_EDGE_DATA carries a number for %s but no source, so it reads as NOT SET',
+    (field) => {
+      // The number IS there — this is exactly the trap: the value is present
+      // and plausible, which is why presence could never have been the test.
+      expect(typeof (DEFAULT_EDGE_DATA as Record<string, unknown>)[field]).toBe('number')
+      expect(edgeValueSource(DEFAULT_EDGE_DATA as Record<string, unknown>, field)).toBeNull()
+      expect(isEdgeValueSet(DEFAULT_EDGE_DATA as Record<string, unknown>, field)).toBe(false)
+    },
+  )
+
+  it.each(EDGE_PROVENANCED_FIELDS)(
+    'USER_EDGE_DEFAULTS carries a number for %s but no source, so it reads as NOT SET',
+    (field) => {
+      expect(typeof (USER_EDGE_DEFAULTS as Record<string, unknown>)[field]).toBe('number')
+      expect(isEdgeValueSet(USER_EDGE_DEFAULTS as Record<string, unknown>, field)).toBe(false)
+    },
+  )
+
+  // POSITIVE CONTROL for both blocks above: without this, `isEdgeValueSet`
+  // could be `() => false` and every assertion so far would still pass.
+  it('reads a stamped edge as SET (positive control)', () => {
+    const stamped = { ...USER_EDGE_DEFAULTS, beliefExistsSource: 'user', weightSource: 'user' }
+    expect(edgeValueSource(stamped, 'beliefExists')).toBe('user')
+    expect(edgeValueSource(stamped, 'weight')).toBe('user')
+    expect(isEdgeValueSet(stamped, 'beliefExists')).toBe(true)
+    expect(isEdgeValueSet(stamped, 'weight')).toBe(true)
+  })
+})
+
+describe('edgeValueProvenance — back-compat evidence from producer-only fields', () => {
+  it('treats exists_probability as CEE evidence for beliefExists', () => {
+    expect(edgeValueSource({ beliefExists: 0.65, exists_probability: 0.65 }, 'beliefExists')).toBe('cee')
+  })
+
+  it('treats strength_mean as CEE evidence for weight', () => {
+    expect(edgeValueSource({ weight: 0.4, strength_mean: -0.4 }, 'weight')).toBe('cee')
+  })
+
+  // Discriminating case: the back-compat fallbacks must be FIELD-SPECIFIC.
+  // exists_probability says nothing about weight, and vice versa — if it did,
+  // every CEE edge would claim a set weight it never received.
+  it('does not let one field’s producer evidence vouch for the other', () => {
+    expect(edgeValueSource({ exists_probability: 0.65, weight: 0.5 }, 'weight')).toBeNull()
+    expect(edgeValueSource({ strength_mean: 0.4, beliefExists: 0.8 }, 'beliefExists')).toBeNull()
+  })
+
+  it('does NOT accept a bare beliefExists/weight number as evidence', () => {
+    // These are precisely the fields the defaults fabricate.
+    expect(edgeValueSource({ beliefExists: 0.8 }, 'beliefExists')).toBeNull()
+    expect(edgeValueSource({ weight: 0.5 }, 'weight')).toBeNull()
+  })
+})
+
+describe('edgeValueProvenance — fail closed on a bad marker', () => {
+  it('rejects an unrecognised source value rather than trusting it', () => {
+    expect(edgeValueSource({ beliefExistsSource: 'guessed' }, 'beliefExists')).toBeNull()
+    expect(edgeValueSource({ weightSource: true }, 'weight')).toBeNull()
+    expect(edgeValueSource({ weightSource: '' }, 'weight')).toBeNull()
+  })
+
+  it('handles a missing data bag', () => {
+    expect(edgeValueSource(undefined, 'weight')).toBeNull()
+    expect(edgeValueSource(null, 'beliefExists')).toBeNull()
+  })
+})
+
+describe('edgeValueSourcePatch — omits, never writes undefined', () => {
+  it('produces an empty patch when nothing was supplied', () => {
+    expect(edgeValueSourcePatch({})).toEqual({})
+  })
+
+  it('omits the unsupplied key so spreading cannot erase an existing stamp', () => {
+    const patch = edgeValueSourcePatch({ beliefExists: 'cee' })
+    expect(Object.prototype.hasOwnProperty.call(patch, 'weightSource')).toBe(false)
+    // The real hazard, demonstrated: an explicit `undefined` DOES override a
+    // spread, so a patch that wrote `weightSource: undefined` would silently
+    // wipe a user's stamp on every CEE turn.
+    const merged = { weightSource: 'user', ...patch }
+    expect(merged.weightSource).toBe('user')
+    expect(merged.beliefExistsSource).toBe('cee')
+  })
+})
+
+describe('EdgeDataSchema — the markers survive a parse', () => {
+  it('round-trips both source fields', () => {
+    const parsed = EdgeDataSchema.parse({
+      ...USER_EDGE_DEFAULTS,
+      beliefExistsSource: 'cee',
+      weightSource: 'template',
+    })
+    expect(parsed.beliefExistsSource).toBe('cee')
+    expect(parsed.weightSource).toBe('template')
+  })
+
+  it('parses an unstamped edge without inventing a source', () => {
+    const parsed = EdgeDataSchema.parse({ ...USER_EDGE_DEFAULTS })
+    expect(parsed.beliefExistsSource).toBeUndefined()
+    expect(parsed.weightSource).toBeUndefined()
+  })
+})

--- a/src/canvas/domain/edgeValueProvenance.ts
+++ b/src/canvas/domain/edgeValueProvenance.ts
@@ -1,0 +1,128 @@
+/**
+ * Edge value provenance — "was this number SET, or did it fall through to a UI default?"
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `DEFAULT_EDGE_DATA` / `USER_EDGE_DEFAULTS` pin `beliefExists: 0.8` and
+ * `weight: 0.5 / 0.3`. Those constants were rendered to the user as
+ * `"80% conf."` (ConnRow) and `"50% link strength"` (EdgePills) — a hardcoded
+ * constant SPOKEN AS A MEASUREMENT. `EdgeData` carried no way to tell a value
+ * somebody actually chose from a value nobody ever supplied, so the renderers
+ * could not tell them apart even in principle.
+ *
+ * THE INVARIANT — ABSENT MEANS DEFAULTED
+ * --------------------------------------
+ * A marker that silently defaults to "set" would be WORSE than no marker at
+ * all: it would launder every fallthrough into a claim. So the fields below
+ * are OPTIONAL and are stamped ONLY where the value demonstrably came from a
+ * named source. A construction site that does nothing therefore produces the
+ * HONEST state with no work — and the failure mode of forgetting to stamp is
+ * under-disclosure ("not set" on a value that was in fact set), never an
+ * over-claim.
+ *
+ * WHY FLAT KEYS AND NOT A NESTED `valueProvenance` OBJECT
+ * ------------------------------------------------------
+ * `mergeAppliedGraph.overlayEdge` overlays a wire edge onto an existing canvas
+ * edge KEY BY KEY, applying only keys whose mapped value differs from the
+ * mapper's derived default baseline. Flat keys ride that merge for free: a
+ * wire edge carrying a belief but no weight applies `beliefExistsSource` and
+ * leaves a local `weightSource: 'user'` untouched. A nested object would be
+ * replaced wholesale and would silently drop the user's weight stamp.
+ *
+ * BACK-COMPAT READS (derive, don't assume)
+ * ----------------------------------------
+ * Graphs saved before this marker existed carry no stamps. Rather than let
+ * every historical edge regress to "not set", the readers below also accept
+ * producer-only raw fields as evidence of a real source:
+ *   · `exists_probability` — written ONLY by CEE ingestion
+ *     (`applyDraftResult` / `applyPatch` buildEdge; see the field trace in
+ *     `analyticalNodeFields.ts`), so its presence proves a producer value.
+ *   · `strength_mean` — CEE's pre-signed strength.
+ * There is deliberately NO such fallback for a bare `weight` or `beliefExists`
+ * number: those are exactly the fields the defaults fabricate.
+ */
+
+import { z } from 'zod'
+
+/**
+ * Where a set edge value came from.
+ * - `user`     — the person editing this decision typed/dragged it
+ * - `cee`      — a producer estimated it (CEE draft, graph_patch, starter capture)
+ * - `template` — a blueprint/template author authored it for this template
+ *
+ * `template` is deliberately DISTINCT from `cee`: a template weight is a real
+ * authored value (so it is not a fallthrough default) but it is not an estimate
+ * of THIS user's decision. Surfaces may choose to qualify it; none may treat an
+ * ABSENT marker as any of these.
+ */
+export const EdgeValueSourceEnum = z.enum(['user', 'cee', 'template'])
+export type EdgeValueSource = z.infer<typeof EdgeValueSourceEnum>
+
+/** The edge fields that carry a set-vs-defaulted marker. */
+export const EDGE_PROVENANCED_FIELDS = ['beliefExists', 'weight'] as const
+export type EdgeProvenancedField = (typeof EDGE_PROVENANCED_FIELDS)[number]
+
+/** Marker key for a provenanced field, e.g. `beliefExists` → `beliefExistsSource`. */
+export function edgeSourceKey(field: EdgeProvenancedField): 'beliefExistsSource' | 'weightSource' {
+  return field === 'beliefExists' ? 'beliefExistsSource' : 'weightSource'
+}
+
+function asSource(value: unknown): EdgeValueSource | null {
+  const parsed = EdgeValueSourceEnum.safeParse(value)
+  return parsed.success ? parsed.data : null
+}
+
+/**
+ * Resolve where an edge field's value came from.
+ *
+ * Returns `null` when nothing proves the value was set — which is the state
+ * every UI default lands in. Callers MUST treat `null` as "we do not know this
+ * number" and never render it as a measurement.
+ */
+export function edgeValueSource(
+  data: Record<string, unknown> | undefined | null,
+  field: EdgeProvenancedField,
+): EdgeValueSource | null {
+  if (!data) return null
+
+  const explicit = asSource(data[edgeSourceKey(field)])
+  if (explicit) return explicit
+
+  // Producer-only raw fields — back-compat evidence for graphs saved before
+  // the marker existed. See the module header for why these two specifically.
+  if (field === 'beliefExists' && typeof data.exists_probability === 'number') return 'cee'
+  if (field === 'weight' && typeof data.strength_mean === 'number') return 'cee'
+
+  return null
+}
+
+/** True when the field's value was set by someone rather than defaulted. */
+export function isEdgeValueSet(
+  data: Record<string, unknown> | undefined | null,
+  field: EdgeProvenancedField,
+): boolean {
+  return edgeValueSource(data, field) !== null
+}
+
+/**
+ * Build the marker patch for a construction site.
+ *
+ * Pass `undefined` for a field the wire/user did NOT supply — the key is then
+ * OMITTED entirely rather than written as `undefined`, so spreading this patch
+ * over an existing edge cannot erase a stamp that is already there.
+ *
+ * ```ts
+ * data: { ...DEFAULT_EDGE_DATA, weight, beliefExists,
+ *         ...edgeValueSourcePatch({ beliefExists: wireHadBelief ? 'cee' : undefined,
+ *                                   weight: wireHadStrength ? 'cee' : undefined }) }
+ * ```
+ */
+export function edgeValueSourcePatch(sources: {
+  beliefExists?: EdgeValueSource
+  weight?: EdgeValueSource
+}): { beliefExistsSource?: EdgeValueSource; weightSource?: EdgeValueSource } {
+  const patch: { beliefExistsSource?: EdgeValueSource; weightSource?: EdgeValueSource } = {}
+  if (sources.beliefExists) patch.beliefExistsSource = sources.beliefExists
+  if (sources.weight) patch.weightSource = sources.weight
+  return patch
+}

--- a/src/canvas/domain/edges.ts
+++ b/src/canvas/domain/edges.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod'
 import type { ValidationMetadata } from './validation'
+import { EdgeValueSourceEnum } from './edgeValueProvenance'
 
 /**
  * Edge style options for visualisation
@@ -227,6 +228,17 @@ export const EdgeDataSchema = z.object({
   /** Raw exists probability from CEE V3 (preserved alongside beliefExists) */
   exists_probability: z.number().min(0).max(1).optional(),
 
+  // Set-vs-defaulted markers. ABSENT MEANS DEFAULTED — see
+  // ./edgeValueProvenance.ts for the full rationale. Stamped only where the
+  // value demonstrably came from a named source, so a construction site that
+  // does nothing is correct by default and forgetting to stamp can only
+  // under-disclose, never over-claim. Do NOT add these to DEFAULT_EDGE_DATA or
+  // USER_EDGE_DEFAULTS.
+  /** Where `beliefExists` came from. Absent ⇒ nobody set it (UI default). */
+  beliefExistsSource: EdgeValueSourceEnum.optional(),
+  /** Where `weight` came from. Absent ⇒ nobody set it (UI default). */
+  weightSource: EdgeValueSourceEnum.optional(),
+
   // Phase 3: Non-linear edge functions
   functionType: EdgeFunctionTypeEnum.default('linear'),   // How input transforms to output
   functionParams: EdgeFunctionParamsSchema.optional(),    // Parameters for non-linear functions
@@ -277,6 +289,12 @@ export type EdgeData = z.infer<typeof EdgeDataSchema> & {
 /**
  * Default edge data for new edges (used by adapters, CEE, PLoT as fallback).
  * Keep weight at 0.5 for backward compatibility with downstream services.
+ *
+ * ⛔ These numbers are ASSUMPTIONS, not measurements. Deliberately carries NO
+ * `beliefExistsSource` / `weightSource`: an edge built from these defaults has
+ * had nothing set, and every display surface must be able to see that (see
+ * ./edgeValueProvenance.ts). Adding a source stamp here would launder every
+ * fallthrough into a claim.
  */
 export const DEFAULT_EDGE_DATA: EdgeData = {
   weight: 0.5,
@@ -295,6 +313,11 @@ export const DEFAULT_EDGE_DATA: EdgeData = {
  * Graph Editing Experience Task 6a: Defaults for user-created edges only.
  * More conservative starting point that encourages calibration.
  * Not used by adapters/CEE/PLoT (those keep DEFAULT_EDGE_DATA for compatibility).
+ *
+ * ⛔ Same rule as DEFAULT_EDGE_DATA: NO source stamps. Drawing an edge is not
+ * the same as estimating its strength or its likelihood of existing — until the
+ * user actually sets those, the surfaces must say so rather than report 0.8/0.3
+ * as if the user had chosen them.
  */
 export const USER_EDGE_DEFAULTS: EdgeData = {
   weight: 0.3,            // Moderate starting strength (encourages calibration)

--- a/src/canvas/hooks/__tests__/useNodeConnections.provenance.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeConnections.provenance.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * useNodeConnections — the ConnRow confidence provenance gate.
+ *
+ * ConnRow renders `{confidencePct}% conf.` with aria "N% confidence the link
+ * exists". Because `DEFAULT_EDGE_DATA`/`USER_EDGE_DEFAULTS` pin
+ * `beliefExists: 0.8`, EVERY edge used to produce a confidence — so the canvas
+ * told the user "80% confidence the link exists" about a hardcoded constant.
+ *
+ * ESCAPE THIS TEST MUST NOT MAKE: asserting only `confidencePct === null` would
+ * also pass if the hook returned NO ROWS AT ALL (wrong node id, wrong direction,
+ * results not complete). Every absence case below therefore asserts the ROW
+ * exists and is correctly resolved first, so the null is a null IN A REAL ROW.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useNodeConnections } from '../useNodeConnections'
+import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS } from '../../domain/edges'
+
+let mockState: {
+  edges: unknown[]
+  nodes: unknown[]
+  results: { status: string }
+}
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: (s: typeof mockState) => unknown) => selector(mockState)),
+}))
+
+import { useCanvasStore } from '../../store'
+
+const NODES = [
+  { id: 'fac_price', type: 'factor', data: { label: 'Price' } },
+  { id: 'out_revenue', type: 'outcome', data: { label: 'Revenue' } },
+]
+
+function setup(edgeData: Record<string, unknown>) {
+  mockState = {
+    nodes: NODES,
+    edges: [{ id: 'e1', source: 'fac_price', target: 'out_revenue', data: edgeData }],
+    results: { status: 'complete' },
+  }
+  vi.mocked(useCanvasStore).mockImplementation((selector: any) => selector(mockState))
+  return renderHook(() => useNodeConnections('fac_price', 'outbound')).result.current
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useNodeConnections — a UI default is not a confidence', () => {
+  it('reports NO confidence for a user-drawn edge (USER_EDGE_DEFAULTS, beliefExists 0.8)', () => {
+    const rows = setup({ ...USER_EDGE_DEFAULTS })
+
+    // The row IS resolved — this is what stops the null below being vacuous.
+    expect(rows).toHaveLength(1)
+    expect(rows[0].connectedNodeLabel).toBe('Revenue')
+    expect(rows[0].edgeId).toBe('e1')
+
+    // …and the fabricated 0.8 does not reach the renderer.
+    expect(USER_EDGE_DEFAULTS.beliefExists).toBe(0.8)
+    expect(rows[0].confidencePct).toBeNull()
+  })
+
+  it('reports NO confidence for an adapter-default edge (DEFAULT_EDGE_DATA)', () => {
+    const rows = setup({ ...DEFAULT_EDGE_DATA })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].connectedNodeLabel).toBe('Revenue')
+    expect(rows[0].confidencePct).toBeNull()
+  })
+})
+
+describe('useNodeConnections — a real producer/user value IS reported (positive control)', () => {
+  // Without these, the gate could be `confidencePct = null` unconditionally and
+  // every assertion above would still pass.
+  it('reports a CEE-stamped belief', () => {
+    const rows = setup({ ...DEFAULT_EDGE_DATA, beliefExists: 0.65, beliefExistsSource: 'cee' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].confidencePct).toBe(65)
+  })
+
+  it('reports a user-set belief', () => {
+    const rows = setup({ ...USER_EDGE_DEFAULTS, beliefExists: 0.42, beliefExistsSource: 'user' })
+    expect(rows[0].confidencePct).toBe(42)
+  })
+
+  it('reports a legacy CEE edge via exists_probability, with no stamp', () => {
+    // Back-compat: graphs saved before the marker existed must not all regress.
+    const rows = setup({ ...DEFAULT_EDGE_DATA, beliefExists: 0.68, exists_probability: 0.68 })
+    expect(rows[0].confidencePct).toBe(68)
+  })
+
+  it('prefers exists_probability over beliefExists when both are present', () => {
+    // Guards the pre-existing precedence rule while the gate is layered on top.
+    const rows = setup({
+      ...DEFAULT_EDGE_DATA,
+      beliefExists: 0.5,
+      exists_probability: 0.9,
+      beliefExistsSource: 'cee',
+    })
+    expect(rows[0].confidencePct).toBe(90)
+  })
+})

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.confidencePolicy.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.confidencePolicy.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * useNodeDisplayMetadata — the canvas confidence gate, on REAL captured bytes.
+ *
+ * FIND-1: `DriversSection` pinned `DISPLAY_SAFE_DRIVER_CONFIDENCE = false`
+ * ("no display-safe driver-confidence source exists today, so we never render
+ * raw/defaulted confidence") while this hook read the SAME
+ * `factor_sensitivity[].confidence` off the SAME `results.report` with no gate,
+ * feeding three canvas surfaces AND a spoken coaching line.
+ *
+ * ESCAPE THIS TEST IS WRITTEN TO CATCH: asserting `confidence === null` alone
+ * would ALSO pass if the hook had bailed out entirely — wrong node id, report
+ * shape unrecognised, `isResultsMode` false, feed empty. Every case below
+ * therefore asserts, in the same call, that the hook DID resolve this factor:
+ * `inSensitivityAnalysis` true and a finite `influence`. The confidence null is
+ * then a null in a row the hook genuinely processed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useNodeDisplayMetadata } from '../useNodeDisplayMetadata'
+import bundle from '../../../components/debug/__tests__/fixtures/staging-bundles/olumi-debug-50b336a6-20260510.pre-fix.json'
+
+const plotRows = (bundle as any).payloads.plot_response.factor_sensitivity as Record<string, unknown>[]
+const FACTOR_ID = plotRows[0].factor_id as string
+
+let mockState: { results: { status: string; report: unknown } }
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: (s: typeof mockState) => unknown) => selector(mockState)),
+}))
+
+import { useCanvasStore } from '../../store'
+
+function withReport(factorSensitivity: unknown[]) {
+  mockState = {
+    results: {
+      status: 'complete',
+      // Captured producer rows, verbatim — nothing edited.
+      report: { factor_sensitivity: factorSensitivity },
+    },
+  }
+  vi.mocked(useCanvasStore).mockImplementation((selector: any) => selector(mockState))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('the captured rows are what we think they are', () => {
+  it('the PLoT capture carries a defaulted confidence of 0.25', () => {
+    expect(plotRows.length).toBeGreaterThan(0)
+    expect(FACTOR_ID).toBe('fac_marketing_expertise')
+    expect(plotRows[0].confidence).toBe(0.25)
+    expect((plotRows[0].confidence_components as any).sampling_stability).toBe(0)
+  })
+})
+
+describe('useNodeDisplayMetadata — confidence obeys the shared display policy', () => {
+  it('does not surface the defaulted 0.25 the results panel refuses to show', () => {
+    withReport(plotRows)
+    const { result } = renderHook(() => useNodeDisplayMetadata(FACTOR_ID, 'factor'))
+
+    // ── the anti-vacuity guard: this factor WAS resolved ──────────────────
+    expect(result.current.isResultsMode).toBe(true)
+    expect(result.current.inSensitivityAnalysis).toBe(true)
+    expect(typeof result.current.influence).toBe('number')
+    expect(result.current.influence).toBeGreaterThan(0)
+
+    // ── the actual claim ─────────────────────────────────────────────────
+    expect(result.current.confidence).toBeNull()
+  })
+
+  it('also withholds a NON-defaulted confidence — the ruling is about the source', () => {
+    // ISL's own computed 0.3756 from the same bundle. Under the ruled policy
+    // this is still not display-safe, so the canvas must not print it either;
+    // otherwise the canvas would keep showing a number the panel does not.
+    const islRows = (bundle as any).payloads.isl_response.factor_sensitivity as Record<string, unknown>[]
+    withReport(islRows)
+    const nodeId = islRows[0].node_id as string
+    const { result } = renderHook(() => useNodeDisplayMetadata(nodeId, 'factor'))
+
+    expect(result.current.inSensitivityAnalysis).toBe(true)
+    expect(islRows[0].confidence).toBe(0.3756)
+    expect(result.current.confidence).toBeNull()
+  })
+
+  it('reports no disclosure flags while nothing is shown', () => {
+    withReport(plotRows)
+    const { result } = renderHook(() => useNodeDisplayMetadata(FACTOR_ID, 'factor'))
+    expect(result.current.confidenceIsDefaulted).toBe(false)
+    expect(result.current.confidenceIsProvisional).toBe(false)
+  })
+
+  it('leaves every other producer figure untouched (this lane gates ONE field)', () => {
+    withReport(plotRows)
+    const { result } = renderHook(() => useNodeDisplayMetadata(FACTOR_ID, 'factor'))
+    // influence_rank 1 in the capture → top-ranked driver on the canvas.
+    expect(result.current.sensitivityRank).toBe(1)
+    expect(result.current.influence).toBe(1)
+  })
+})

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.spec.ts
@@ -430,7 +430,14 @@ describe('useNodeDisplayMetadata — unified row feed (C4 fix 2)', () => {
     }
     const { result } = renderHook(() => useNodeDisplayMetadata('B', 'factor'))
     expect(result.current.inSensitivityAnalysis).toBe(true)
-    expect(result.current.confidence).toBeCloseTo(0.7)
+    // ⚠ Was `toBeCloseTo(0.7)`. The subject of this case is that a METRIC-LESS
+    // ROW SURVIVES the merge — proven by the three assertions around this one,
+    // which are untouched. The confidence readback was incidental, and it now
+    // goes through the shared display policy
+    // (components/results/driverConfidenceDisplayPolicy): there is no
+    // display-safe driver-confidence source today, so the canvas withholds the
+    // figure exactly as the Drivers panel does. Row B is still IN the set.
+    expect(result.current.confidence).toBeNull()
     expect(result.current.influence).toBe(0)
     expect(result.current.influenceProvenance).toBe('normalised_elasticity')
   })

--- a/src/canvas/hooks/resolveSeedUsed.ts
+++ b/src/canvas/hooks/resolveSeedUsed.ts
@@ -1,0 +1,36 @@
+/**
+ * T2b: resolve the seed the ENGINE reports it used — the receipt.
+ *
+ * Receipts fail closed (T2): no real value → null, never a fabricated 0. This
+ * is the WRITE-path twin of hydrateAnalysis.ts:111-115 and must stay in step
+ * with it, because that function PREFERS the value this one persists
+ * (`provenance?.seed_used ?? ...`). Any fabrication here is laundered into a
+ * real-looking receipt on the next page load.
+ *
+ * The pattern this replaces fabricated a 0 three ways:
+ *   const seedUsed = successResult.meta?.seed_used
+ *     ? (parseInt(successResult.meta.seed_used, 10) || 0)   // 'abc' → NaN → 0
+ *     : (seed ?? 0)                                          // no echo → unconfirmed
+ * plus a truthiness gate that made a numeric engine seed of 0 fall through to
+ * the requested seed.
+ *
+ * Note this deliberately does NOT fall back to the seed we REQUESTED. The
+ * requested seed is a different fact ("what we asked for"); reporting it as
+ * seed_used claims the engine confirmed something it never said. Callers that
+ * need a run identity (e.g. the graph hash) use the requested seed explicitly.
+ *
+ * WHY ITS OWN MODULE (2026-07-25): it lived inside `useV2Run.ts`, a large hook
+ * module that a dozen specs replace wholesale with a hand-listed `vi.mock`
+ * factory. The moment a second caller (`buildMethodCard`) imported this
+ * function from there, every one of those mocks threw at render — the
+ * hand-maintained-mirror defect, arriving on schedule. A pure leaf module is
+ * importable from anywhere, drags no store/adapter graph into the importer's
+ * chunk, and cannot be blanked by someone else's mock of a different module.
+ * `useV2Run` re-exports it, so existing importers are untouched and there is
+ * still exactly ONE implementation.
+ */
+export function resolveSeedUsed(metaSeedUsed: unknown): number | null {
+  if (metaSeedUsed == null) return null
+  const parsed = Number.parseInt(String(metaSeedUsed), 10)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/src/canvas/hooks/useBlueprintInsert.ts
+++ b/src/canvas/hooks/useBlueprintInsert.ts
@@ -13,6 +13,7 @@ import { useReactFlow } from '@xyflow/react'
 import type { Blueprint } from '../../templates/blueprints/types'
 import { useCanvasStore } from '../store'
 import { DEFAULT_EDGE_DATA } from '../domain/edges'
+import { edgeValueSourcePatch } from '../domain/edgeValueProvenance'
 import { checkLimits, formatLimitError } from '../utils/limitGuard'
 import { useEngineLimits } from './useEngineLimits'
 
@@ -99,6 +100,15 @@ export function useBlueprintInsert() {
           label,
           confidence: edge.probability,
           belief: edge.belief ?? edge.probability,  // v1.2: prefer belief, fallback to probability for legacy
+          // Set-vs-defaulted markers (canvas/domain/edgeValueProvenance.ts).
+          // A blueprint weight was authored by a template author — a real
+          // value, not a UI fallthrough — so it is stamped 'template' rather
+          // than 'cee': it is not an estimate of THIS user's decision. When the
+          // blueprint omits the field the stamp is omitted with it, and the
+          // 0.5/0.8 defaults stay visibly unset.
+          ...edgeValueSourcePatch({
+            weight: edge.weight != null ? 'template' : undefined,
+          }),
           provenance: edge.provenance,              // v1.2: source tracking
           templateId: blueprint.id
         }

--- a/src/canvas/hooks/useModelActionApply.ts
+++ b/src/canvas/hooks/useModelActionApply.ts
@@ -351,7 +351,12 @@ export function useModelActionApply(): UseModelActionApplyReturn {
               ...existingEdge?.data,
               ...(action.payload.label !== undefined && { label: action.payload.label }),
               ...(action.payload.confidence !== undefined && { confidence: action.payload.confidence }),
-              ...(action.payload.weight !== undefined && { weight: action.payload.weight }),
+              // A producer-proposed weight is a real estimate, so stamp it as
+              // such alongside the value (canvas/domain/edgeValueProvenance.ts).
+              ...(action.payload.weight !== undefined && {
+                weight: action.payload.weight,
+                weightSource: 'cee' as const,
+              }),
               ...(action.payload.kind !== undefined && { kind: action.payload.kind }),
             }
           }

--- a/src/canvas/hooks/useNodeConnections.ts
+++ b/src/canvas/hooks/useNodeConnections.ts
@@ -5,11 +5,14 @@
  * Outcome/Risk nodes use direction='inbound' for "Depends on:" section.
  *
  * Gate: returns [] pre-analysis (resultsStatus !== 'complete').
- * Confidence: exists_probability ?? beliefExists, scaled to 0-100. Null when missing.
+ * Confidence: exists_probability ?? beliefExists, scaled to 0-100. Null when
+ * missing OR when nothing set it — a UI default is not a measurement, so it is
+ * reported as unknown rather than rendered (see the gate below).
  */
 import { useMemo } from 'react'
 import { useCanvasStore } from '../store'
 import type { NodeType } from '../domain/nodes'
+import { isEdgeValueSet } from '../domain/edgeValueProvenance'
 
 export interface ConnRowData {
   edgeId: string
@@ -45,10 +48,18 @@ export function useNodeConnections(
       const label = (connectedNode.data?.label as string) ?? 'Untitled'
       const data = edge.data as Record<string, unknown> | undefined
 
-      // Confidence: prefer exists_probability, fall back to beliefExists
+      // Confidence: prefer exists_probability, fall back to beliefExists.
+      //
+      // ⛔ Provenance gate. `DEFAULT_EDGE_DATA`/`USER_EDGE_DEFAULTS` pin
+      // beliefExists = 0.8, so before this gate EVERY edge reported a
+      // confidence and ConnRow rendered a hardcoded constant as
+      // "80% conf." with aria "80% confidence the link exists" — a UI default
+      // spoken as a measurement. We now emit a number ONLY when something
+      // actually set it (canvas/domain/edgeValueProvenance.ts); otherwise
+      // `confidencePct` stays null and ConnRow renders no figure at all.
       const existsProb = typeof data?.exists_probability === 'number' ? data.exists_probability : null
       const beliefExists = typeof data?.beliefExists === 'number' ? data.beliefExists : null
-      const raw = existsProb ?? beliefExists
+      const raw = isEdgeValueSet(data, 'beliefExists') ? (existsProb ?? beliefExists) : null
 
       rows.push({
         edgeId: edge.id,

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -14,6 +14,7 @@ import type { NodeType } from '../domain/nodes'
 import { compareByDisplayModel } from '../../components/results/driverDisplayModel'
 import type { DriverDisplayProvenance } from '../../components/results/driverDisplayModel'
 import { selectDriverPolicyFeed } from '../../components/results/useResultsSectionData'
+import { resolveFactorConfidenceDisplay } from '../../components/results/driverConfidenceDisplayPolicy'
 import type { ResultsReport } from '../../components/results/types'
 
 interface NodeDisplayMetadata {
@@ -30,8 +31,29 @@ interface NodeDisplayMetadata {
    * the Drivers panel. Null whenever `influence` is null.
    */
   influenceProvenance: DriverDisplayProvenance | null
-  /** Factor confidence score (0-1) - Task 3 */
+  /**
+   * Factor confidence score (0-1), ALREADY GATED by the shared display policy
+   * (`components/results/driverConfidenceDisplayPolicy`). Null when the
+   * producer sent none OR when the ruled policy says the figure is not fit to
+   * show — consumers must not second-guess it or read the raw field.
+   *
+   * Until this lane, this returned the raw `factor_sensitivity[].confidence`
+   * ungated while `DriversSection` refused to render the very same number: in
+   * both real staging captures that value is a defaulted `0.25` (ISL's own
+   * computed figure in the same bundle was 0.3756), and the canvas printed it
+   * bare on the node pill, the Detailed-view bar, and — worse — turned it into
+   * the spoken line "Low confidence."
+   */
   confidence: number | null
+  /**
+   * True when the gated `confidence` above is a producer placeholder. Only
+   * meaningful when `confidence` is non-null; surfaces MUST render the
+   * "Default estimate" disclosure alongside the number when this is true, so
+   * that flipping the policy gate can never re-introduce a bare figure.
+   */
+  confidenceIsDefaulted: boolean
+  /** True when PLoT marked the confidence calibration provisional. */
+  confidenceIsProvisional: boolean
   /** Whether this factor was found in the sensitivity analysis (false for root nodes like "Value") */
   inSensitivityAnalysis: boolean
   /** Outcome/Goal achievement probability (0-1) */
@@ -89,6 +111,8 @@ export function useNodeDisplayMetadata(
         influence: null,
         influenceProvenance: null,
         confidence: null,
+        confidenceIsDefaulted: false,
+        confidenceIsProvisional: false,
         inSensitivityAnalysis: false,
         achievementProbability: null,
         achievementProbabilityIsModelledBasis: false,
@@ -106,6 +130,8 @@ export function useNodeDisplayMetadata(
     let influence: number | null = null
     let influenceProvenance: DriverDisplayProvenance | null = null
     let confidence: number | null = null
+    let confidenceIsDefaulted = false
+    let confidenceIsProvisional = false
     let inSensitivityAnalysis = false
     let valueOfInformation: number | null = null
     let voiRank: number | null = null
@@ -175,13 +201,23 @@ export function useNodeDisplayMetadata(
           influenceProvenance = modelEntry.provenance
         }
 
-        // Confidence: Direct extraction (already 0-1)
-        // Note: Intentionally NOT using value_of_information as fallback - VOI is semantically
-        // different from confidence (it measures value of learning more, not certainty)
-        const rawConfidence = factorRow.confidence
-
-        if (typeof rawConfidence === 'number' && rawConfidence >= 0 && rawConfidence <= 1) {
-          confidence = rawConfidence
+        // Confidence: resolved through THE shared display policy, never read
+        // raw. Note: intentionally NOT using value_of_information as a fallback
+        // — VoI is semantically different from confidence (it measures the
+        // value of learning more, not certainty).
+        //
+        // The policy is the same binding `DriversSection` gates on, and the
+        // defaulted verdict comes off the same shared feed row, so the canvas
+        // and the panel cannot disagree about this number for one report.
+        const confidenceDisplay = resolveFactorConfidenceDisplay({
+          confidence: factorRow.confidence,
+          isDefaulted: factorRow.confidenceIsDefaulted,
+          confidenceProvenance: factorRow.confidenceProvenance,
+        })
+        if (confidenceDisplay.show) {
+          confidence = confidenceDisplay.value
+          confidenceIsDefaulted = confidenceDisplay.isDefaulted
+          confidenceIsProvisional = confidenceDisplay.isProvisional
         }
       }
     }
@@ -259,6 +295,8 @@ export function useNodeDisplayMetadata(
       influence,
       influenceProvenance,
       confidence,
+      confidenceIsDefaulted,
+      confidenceIsProvisional,
       inSensitivityAnalysis,
       achievementProbability,
       achievementProbabilityIsModelledBasis,

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -64,31 +64,15 @@ function deriveNumericSeedFromString(input: string): number {
 }
 
 /**
- * T2b: resolve the seed the ENGINE reports it used — the receipt.
- *
- * Receipts fail closed (T2): no real value → null, never a fabricated 0. This
- * is the WRITE-path twin of hydrateAnalysis.ts:111-115 and must stay in step
- * with it, because that function PREFERS the value this one persists
- * (`provenance?.seed_used ?? ...`). Any fabrication here is laundered into a
- * real-looking receipt on the next page load.
- *
- * The pattern this replaces fabricated a 0 three ways:
- *   const seedUsed = successResult.meta?.seed_used
- *     ? (parseInt(successResult.meta.seed_used, 10) || 0)   // 'abc' → NaN → 0
- *     : (seed ?? 0)                                          // no echo → unconfirmed
- * plus a truthiness gate that made a numeric engine seed of 0 fall through to
- * the requested seed.
- *
- * Note this deliberately does NOT fall back to the seed we REQUESTED. The
- * requested seed is a different fact ("what we asked for"); reporting it as
- * seed_used claims the engine confirmed something it never said. Callers that
- * need a run identity (e.g. the graph hash) use the requested seed explicitly.
+ * Re-exported from './resolveSeedUsed'. It was moved to a pure leaf module so a
+ * second caller could import it without being blanked by the hand-listed
+ * `vi.mock` factories that replace THIS module wholesale in a dozen specs (and
+ * without dragging the whole hook's dependency graph into their chunk). One
+ * implementation, unchanged behaviour.
  */
-export function resolveSeedUsed(metaSeedUsed: unknown): number | null {
-  if (metaSeedUsed == null) return null
-  const parsed = Number.parseInt(String(metaSeedUsed), 10)
-  return Number.isFinite(parsed) ? parsed : null
-}
+import { resolveSeedUsed } from './resolveSeedUsed'
+export { resolveSeedUsed }
+
 
 /**
  * UI-SEM-058: raw → normalised goal-threshold conversion for the PLoT request.

--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -432,11 +432,27 @@ export const FactorNode = memo((props: NodeProps) => {
   }, [props.id, observedState])
 
   const influencePct = displayMetadata.influence != null ? Math.round(displayMetadata.influence * 100) : null
+  // Already gated by the shared display policy — see useNodeDisplayMetadata.
+  // Null whenever the ruled policy says the figure is not display-safe, which
+  // is why every confidence surface on this node (pill, bar, AND the
+  // synthesised coaching line below) goes quiet together.
   const confidencePct = displayMetadata.confidence != null ? Math.round(displayMetadata.confidence * 100) : null
+  const confidenceDisclosure = [
+    displayMetadata.confidenceIsDefaulted ? 'Default estimate — not yet validated with evidence' : null,
+    displayMetadata.confidenceIsProvisional ? 'Calibration is provisional' : null,
+  ].filter((q): q is string => q !== null).join('. ') || null
 
   // Graph v1.1 Task 3: synthesised one-line coaching for Standard view post-analysis
   // top-ranked factors. This replaces standalone coaching text (BiasNote etc.) on
   // the same node so there's a single source of guidance.
+  //
+  // ⛔ EVERY branch below is a CLAIM ABOUT CONFIDENCE spoken in prose — "High
+  // influence, low confidence.", "Low confidence." Fed by the ungated raw
+  // field, this node was telling the user their factor had "low confidence" on
+  // the strength of a defaulted 0.25 the Drivers panel refuses to print. The
+  // `confidencePct == null` guard was already here; what changed is that
+  // `confidencePct` is now null whenever the confidence is not display-safe, so
+  // the prose falls silent with the numbers instead of outliving them.
   const synthesisedCoaching = useMemo<{ prefix: string } | null>(() => {
     if (!isPostAnalysis || !isHighPriority) return null
     if (influencePct == null || confidencePct == null) return null
@@ -626,13 +642,35 @@ export const FactorNode = memo((props: NodeProps) => {
               <span className={`${typography.edgeLabel} text-text-light w-7 text-right shrink-0`}>{influencePct}%</span>
             </div>
           )}
+          {/* Confidence — gated upstream by the shared display policy
+              (components/results/driverConfidenceDisplayPolicy): `confidencePct`
+              is null whenever the ruled policy says the figure is not fit to
+              show, so this bar simply does not render. When the policy is
+              flipped the disclosure below travels WITH the number — the bar can
+              never appear bare. */}
           {confidencePct != null && confidencePct > 0 && (
-            <div className="flex items-center gap-1.5">
+            <div
+              className="flex items-center gap-1.5"
+              title={confidenceDisclosure ?? undefined}
+            >
               <span className={`${typography.edgeLabel} text-text-light w-14 shrink-0`}>Confidence</span>
               <div className="flex-1 min-w-0">
-                <DataBar value={confidencePct / 100} label="Confidence" colour="info" />
+                <DataBar
+                  value={confidencePct / 100}
+                  label={confidenceDisclosure ? `Confidence. ${confidenceDisclosure}` : 'Confidence'}
+                  colour="info"
+                />
               </div>
               <span className={`${typography.edgeLabel} text-text-light w-7 text-right shrink-0`}>{confidencePct}%</span>
+              {displayMetadata.confidenceIsDefaulted && (
+                <span
+                  className={`${typography.edgeLabel} text-text-light shrink-0`}
+                  aria-hidden="true"
+                  data-testid="factor-node-confidence-default-estimate"
+                >
+                  *
+                </span>
+              )}
             </div>
           )}
         </div>
@@ -840,6 +878,8 @@ export const FactorNode = memo((props: NodeProps) => {
             influencePct={influencePct}
             influenceProvenance={displayMetadata.influenceProvenance}
             confidencePct={confidencePct}
+            confidenceIsDefaulted={displayMetadata.confidenceIsDefaulted}
+            confidenceIsProvisional={displayMetadata.confidenceIsProvisional}
           />
         )}
 

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -706,6 +706,8 @@ describe('FactorNode', () => {
       influence: 1,
       influenceProvenance: 'normalised_elasticity',
       confidence: null,
+      confidenceIsDefaulted: false,
+      confidenceIsProvisional: false,
       inSensitivityAnalysis: true,
       achievementProbability: null,
       achievementProbabilityIsModelledBasis: false,
@@ -748,7 +750,8 @@ describe('FactorNode', () => {
       )
       vi.mocked(useNodeDisplayMetadata).mockReturnValue({
         sensitivityRank: 1, influence: 0.8, influenceProvenance: 'influence_score',
-        confidence: 0.45, inSensitivityAnalysis: true,
+        confidence: 0.45, confidenceIsDefaulted: false, confidenceIsProvisional: false,
+        inSensitivityAnalysis: true,
         achievementProbability: null, achievementProbabilityIsModelledBasis: false,
         stabilityPercentage: null, winRate: null, isResultsMode: true,
         predictedOutcome: null, valueOfInformation: null, voiRank: null,

--- a/src/canvas/nodes/shared/EdgePills.tsx
+++ b/src/canvas/nodes/shared/EdgePills.tsx
@@ -9,6 +9,12 @@
  * no decode path (brief scope 1); a missing label degrades gracefully to an
  * omitted pill rather than throwing (A2). Capped at 4.
  *
+ * The same rule now applies to the NUMBER: a strength is shown only when
+ * something actually set it. An edge the user simply drew carries
+ * `USER_EDGE_DEFAULTS.weight` (0.3) and `direction: 'positive'` — a UI default
+ * and an assumed direction — which this pill used to announce as "30%" and
+ * "Raises". Unset edges now read "Not set" with no arrow.
+ *
  * Per spec Section 14: 0.5px border, default colour, 10px font, border-radius 10px.
  */
 import { useMemo } from 'react'
@@ -16,6 +22,7 @@ import { ArrowUp, ArrowDown } from 'lucide-react'
 import { useCanvasStore } from '../../store'
 import { NodeShapeIndicator } from '../NodeShapeIndicator'
 import { computeSignedMean } from '../../domain/edges'
+import { isEdgeValueSet } from '../../domain/edgeValueProvenance'
 import type { NodeType } from '../../domain/nodes'
 
 interface EdgePillsProps {
@@ -40,8 +47,21 @@ export function EdgePills({ nodeId }: EdgePillsProps) {
         const rawLabel = targetNode.data?.label
         const label = typeof rawLabel === 'string' ? rawLabel.trim() : ''
         if (!label) return null
+        // ⛔ Provenance gate (canvas/domain/edgeValueProvenance.ts).
+        // `computeSignedMean` falls back to the edge's `weight`, which
+        // `USER_EDGE_DEFAULTS`/`DEFAULT_EDGE_DATA` pin at 0.3/0.5 — so before
+        // this gate a freshly drawn edge announced "30% link strength" and a
+        // "Raises" direction that came from `USER_EDGE_DEFAULTS.direction`,
+        // neither of which anyone had chosen. When nothing set the strength we
+        // keep the pill (the shape and the target label ARE real — the user
+        // drew this connection) and say so, rather than reporting a default as
+        // a measurement or silently hiding the relationship.
+        const edgeData = e.data as Record<string, unknown> | undefined
+        if (!isEdgeValueSet(edgeData, 'weight')) {
+          return { id: e.id, kind, label, direction: null, pct: null }
+        }
         // Retain the sign so the pill can show direction (raises / lowers).
-        const signed = computeSignedMean(e.data as Record<string, unknown> | undefined)
+        const signed = computeSignedMean(edgeData)
         const strength = Math.abs(signed)
         if (strength === 0) return null
         return {
@@ -53,7 +73,9 @@ export function EdgePills({ nodeId }: EdgePillsProps) {
         }
       })
       .filter((p): p is NonNullable<typeof p> => p !== null)
-      .sort((a, b) => b.pct - a.pct)
+      // Unset pills sort last (-1): a known strength outranks "not set", and
+      // the cap of 4 should spend its slots on the numbers we actually have.
+      .sort((a, b) => (b.pct ?? -1) - (a.pct ?? -1))
       .slice(0, 4)
   }, [edges, nodes, nodeId])
 
@@ -69,18 +91,38 @@ export function EdgePills({ nodeId }: EdgePillsProps) {
           {/* Direction for screen readers — the arrow glyph below is aria-hidden,
               so without this the pill would announce only the % and label.
               Uses the approved "Raises"/"Lowers" vocabulary. `sr-only` is out of
-              flow, so the visible pill layout is unchanged. */}
-          <span className="sr-only">{p.direction === 'up' ? 'Raises' : 'Lowers'}</span>
+              flow, so the visible pill layout is unchanged. Omitted entirely
+              when the strength is unset: the direction would come from
+              `USER_EDGE_DEFAULTS.direction`, which nobody chose. */}
+          {p.direction !== null && (
+            <span className="sr-only">{p.direction === 'up' ? 'Raises' : 'Lowers'}</span>
+          )}
           <NodeShapeIndicator nodeKind={p.kind} size={9} />
-          {p.direction === 'up' ? (
+          {p.direction === 'up' && (
             <ArrowUp size={9} className="text-success shrink-0" aria-hidden="true" />
-          ) : (
+          )}
+          {p.direction === 'down' && (
             <ArrowDown size={9} className="text-danger shrink-0" aria-hidden="true" />
           )}
           {/* Audit §8 P0-4: this percentage is link STRENGTH (edge weight),
               not confidence — labelled so it can't be read as the same number
-              family as ConnRow's "N% conf." (beliefExists). */}
-          <span title="Link strength" aria-label={`${p.pct}% link strength`}>{p.pct}%</span>
+              family as ConnRow's "N% conf." (beliefExists).
+              P1-10: when nothing set the strength we say "Not set" instead of
+              reporting the UI default. `role="img"` + aria-label so assistive
+              tech announces the disclosure rather than a bare fragment. */}
+          {p.pct !== null ? (
+            <span title="Link strength" aria-label={`${p.pct}% link strength`}>{p.pct}%</span>
+          ) : (
+            <span
+              className="italic"
+              role="img"
+              title="Link strength not set — open this connection to estimate it"
+              aria-label="Link strength not set"
+              data-testid={`edge-pill-strength-unset-${p.id}`}
+            >
+              Not set
+            </span>
+          )}
           <span>{p.label}</span>
         </span>
       ))}

--- a/src/canvas/nodes/shared/MetricPills.tsx
+++ b/src/canvas/nodes/shared/MetricPills.tsx
@@ -26,10 +26,25 @@ interface MetricPillsProps {
   influencePct?: number | null
   /** Which basis produced influencePct (see driverDisplayModel). Absent → generic copy. */
   influenceProvenance?: DriverDisplayProvenance | null
+  /**
+   * Already gated by the shared display policy
+   * (`components/results/driverConfidenceDisplayPolicy`) — this component must
+   * never resolve the raw field itself. Null ⇒ render no confidence pill.
+   */
   confidencePct?: number | null
+  /** True ⇒ the figure is a producer placeholder; disclosed, never bare. */
+  confidenceIsDefaulted?: boolean
+  /** True ⇒ PLoT marked the calibration provisional; disclosed, never bare. */
+  confidenceIsProvisional?: boolean
 }
 
-export function MetricPills({ influencePct, influenceProvenance, confidencePct }: MetricPillsProps) {
+export function MetricPills({
+  influencePct,
+  influenceProvenance,
+  confidencePct,
+  confidenceIsDefaulted = false,
+  confidenceIsProvisional = false,
+}: MetricPillsProps) {
   const hasInfluence = influencePct != null && influencePct > 0
   const hasConfidence = confidencePct != null && confidencePct > 0
 
@@ -37,6 +52,18 @@ export function MetricPills({ influencePct, influenceProvenance, confidencePct }
 
   const influenceTitle = influenceExplanation(influenceProvenance)
   const influenceAria = influencePillAriaLabel(influencePct ?? 0, influenceProvenance)
+
+  // Confidence disclosure — composed from the two flags the shared policy
+  // returns, so the pill states exactly what it was told and never claims a
+  // quality it was not given.
+  const confidenceQualifiers = [
+    confidenceIsDefaulted ? 'Default estimate — not yet validated with evidence' : null,
+    confidenceIsProvisional ? 'Calibration is provisional' : null,
+  ].filter((q): q is string => q !== null)
+  const confidenceTitle = confidenceQualifiers.length > 0
+    ? confidenceQualifiers.join('. ')
+    : 'Confidence in this factor’s influence'
+  const confidenceAria = `Confidence ${confidencePct ?? 0}%. ${confidenceTitle}`
 
   return (
     <div className="flex gap-[3px] mt-1.5 items-center flex-wrap">
@@ -57,8 +84,23 @@ export function MetricPills({ influencePct, influenceProvenance, confidencePct }
         </span>
       )}
       {hasConfidence && (
-        <span className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-factor/60 text-text-body">
+        <span
+          className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-factor/60 text-text-body inline-flex items-center gap-0.5"
+          // Disclosure travels WITH the number, in the same element, so the
+          // figure cannot be rendered bare. Same vocabulary the Drivers panel
+          // ships ("Default estimate — not yet validated with evidence" /
+          // provisional calibration), not a second pattern.
+          role="img"
+          title={confidenceTitle}
+          aria-label={confidenceAria}
+          data-testid="metric-pill-confidence"
+        >
           Confidence {confidencePct}%
+          {confidenceIsDefaulted && (
+            <span aria-hidden="true" data-testid="metric-pill-confidence-default-estimate">
+              *
+            </span>
+          )}
         </span>
       )}
     </div>

--- a/src/canvas/nodes/shared/__tests__/EdgePills.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/EdgePills.spec.tsx
@@ -2,10 +2,17 @@
  * EdgePills — brief scope 1: always-on factor-card pills now carry direction +
  * the target's label (verbatim) alongside the strength %, with graceful
  * omission (never a throw, never a bare "%") when a label is absent.
+ *
+ * ⚠ Every fixture below now carries `weightSource: 'cee'`. These cases are
+ * about rendering a KNOWN strength, and a known strength is exactly what a
+ * source stamp means. The unstamped case is no longer "the same but quieter" —
+ * it is a different, disclosed state, covered in its own describe block at the
+ * bottom of this file.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { EdgePills } from '../EdgePills'
+import { USER_EDGE_DEFAULTS } from '../../../domain/edges'
 
 type AnyState = Record<string, unknown>
 const makeState = (over: AnyState = {}): AnyState => ({ edges: [], nodes: [], ...over })
@@ -24,7 +31,7 @@ describe('EdgePills', () => {
 
   it('renders direction + percentage + the verbatim target label (decode path)', () => {
     mockStore(makeState({
-      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.45, direction: 'positive' } }],
+      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.45, direction: 'positive', weightSource: 'cee' } }],
       nodes: [{ id: 'o1', type: 'outcome', data: { label: 'Market position' } }],
     }))
     const { container } = render(<EdgePills nodeId="f1" />)
@@ -36,7 +43,7 @@ describe('EdgePills', () => {
 
   it('uses a danger (lowers) arrow for negative edges', () => {
     mockStore(makeState({
-      edges: [{ id: 'e1', source: 'f1', target: 'r1', data: { weight: 0.65, direction: 'negative' } }],
+      edges: [{ id: 'e1', source: 'f1', target: 'r1', data: { weight: 0.65, direction: 'negative', weightSource: 'cee' } }],
       nodes: [{ id: 'r1', type: 'risk', data: { label: 'Burn rate' } }],
     }))
     const { container } = render(<EdgePills nodeId="f1" />)
@@ -47,7 +54,7 @@ describe('EdgePills', () => {
 
   it('omits the pill (no bare value, no throw) when the target label is absent', () => {
     mockStore(makeState({
-      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.65, direction: 'negative' } }],
+      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.65, direction: 'negative', weightSource: 'cee' } }],
       nodes: [{ id: 'o1', type: 'risk', data: {} }], // no label
     }))
     const { container } = render(<EdgePills nodeId="f1" />)
@@ -57,7 +64,7 @@ describe('EdgePills', () => {
 
   it('caps visible pills at 4 (top by strength)', () => {
     const edges = Array.from({ length: 6 }, (_, i) => ({
-      id: `e${i}`, source: 'f1', target: `o${i}`, data: { weight: 0.9 - i * 0.1, direction: 'positive' },
+      id: `e${i}`, source: 'f1', target: `o${i}`, data: { weight: 0.9 - i * 0.1, direction: 'positive', weightSource: 'cee' },
     }))
     const nodes = Array.from({ length: 6 }, (_, i) => ({
       id: `o${i}`, type: 'outcome', data: { label: `Outcome ${i}` },
@@ -69,7 +76,7 @@ describe('EdgePills', () => {
 
   it('only pills outcome/risk targets (skips other kinds)', () => {
     mockStore(makeState({
-      edges: [{ id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive' } }],
+      edges: [{ id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive', weightSource: 'cee' } }],
       nodes: [{ id: 'g1', type: 'goal', data: { label: 'My goal' } }],
     }))
     const { container } = render(<EdgePills nodeId="f1" />)
@@ -81,7 +88,7 @@ describe('EdgePills', () => {
   it('renders a long target label verbatim (no truncation)', () => {
     const longLabel = 'Founder Equity Dilution Across Multiple Funding Rounds'
     mockStore(makeState({
-      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.45, direction: 'positive' } }],
+      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.45, direction: 'positive', weightSource: 'cee' } }],
       nodes: [{ id: 'o1', type: 'risk', data: { label: longLabel } }],
     }))
     render(<EdgePills nodeId="f1" />)
@@ -94,8 +101,8 @@ describe('EdgePills', () => {
   it('exposes direction to screen readers as "Raises"/"Lowers"', () => {
     mockStore(makeState({
       edges: [
-        { id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.45, direction: 'positive' } },
-        { id: 'e2', source: 'f1', target: 'r1', data: { weight: 0.65, direction: 'negative' } },
+        { id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.45, direction: 'positive', weightSource: 'cee' } },
+        { id: 'e2', source: 'f1', target: 'r1', data: { weight: 0.65, direction: 'negative', weightSource: 'cee' } },
       ],
       nodes: [
         { id: 'o1', type: 'outcome', data: { label: 'Revenue Growth' } },
@@ -118,12 +125,109 @@ describe('EdgePills — strength labelling (audit §8 P0-4)', () => {
 
   it('exposes the strength title and aria label on the percentage', () => {
     mockStore(makeState({
-      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.3, direction: 'positive' } }],
+      edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { weight: 0.3, direction: 'positive', weightSource: 'cee' } }],
       nodes: [{ id: 'o1', type: 'outcome', data: { label: 'Shipping speed' } }],
     }))
     render(<EdgePills nodeId="f1" />)
     const pct = screen.getByText('30%')
     expect(pct.getAttribute('title')).toBe('Link strength')
     expect(pct.getAttribute('aria-label')).toBe('30% link strength')
+  })
+})
+
+/**
+ * P1-10 — a UI default is not a link strength.
+ *
+ * `computeSignedMean` falls back to `weight`, which `USER_EDGE_DEFAULTS` pins
+ * at 0.3 and `DEFAULT_EDGE_DATA` at 0.5. A freshly drawn edge therefore
+ * announced "30% link strength" and a "Raises" direction that came from
+ * `USER_EDGE_DEFAULTS.direction` — two claims nobody had made.
+ *
+ * ESCAPES THESE TESTS ARE WRITTEN TO CATCH:
+ *  1. `container.textContent` WELDS adjacent text nodes ("Not set" + label →
+ *     "Not setRevenue"), so a `getByText('Not set')` on the whole container can
+ *     silently fail-or-pass for the wrong reason. Every assertion below targets
+ *     the specific element by testid or exact-node matcher.
+ *  2. Asserting only "30% is absent" would also pass if the pill vanished
+ *     entirely — which is a DIFFERENT, worse outcome (the user's own connection
+ *     disappears). Each case asserts the label IS still rendered.
+ */
+describe('EdgePills — unset strength is disclosed, not reported', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  const unsetState = makeState({
+    edges: [{ id: 'e1', source: 'f1', target: 'o1', data: { ...USER_EDGE_DEFAULTS } }],
+    nodes: [{ id: 'o1', type: 'outcome', data: { label: 'Revenue' } }],
+  })
+
+  it('does not report the USER_EDGE_DEFAULTS weight as a measured strength', () => {
+    mockStore(unsetState)
+    render(<EdgePills nodeId="f1" />)
+    // The default IS 0.3 — the number exists, which is why presence was never
+    // a usable test.
+    expect(USER_EDGE_DEFAULTS.weight).toBe(0.3)
+    expect(screen.queryByText('30%')).toBeNull()
+    expect(screen.queryByLabelText('30% link strength')).toBeNull()
+  })
+
+  it('keeps the pill and its verbatim label — the connection is real even when the number is not', () => {
+    mockStore(unsetState)
+    render(<EdgePills nodeId="f1" />)
+    expect(screen.getByText('Revenue')).toBeDefined()
+  })
+
+  it('says "Not set" on the specific element, with an announceable label', () => {
+    mockStore(unsetState)
+    render(<EdgePills nodeId="f1" />)
+    const marker = screen.getByTestId('edge-pill-strength-unset-e1')
+    expect(marker.textContent).toBe('Not set')
+    expect(marker.getAttribute('aria-label')).toBe('Link strength not set')
+    expect(marker.getAttribute('title')).toContain('not set')
+  })
+
+  it('omits the direction arrow AND the "Raises"/"Lowers" text — direction is defaulted too', () => {
+    mockStore(unsetState)
+    const { container } = render(<EdgePills nodeId="f1" />)
+    // USER_EDGE_DEFAULTS.direction is 'positive'; without this gate the pill
+    // asserted "Raises" about a link the user never characterised.
+    expect(USER_EDGE_DEFAULTS.direction).toBe('positive')
+    expect(screen.queryByText('Raises')).toBeNull()
+    expect(screen.queryByText('Lowers')).toBeNull()
+    expect(container.querySelector('.text-success')).toBeNull()
+    expect(container.querySelector('.text-danger')).toBeNull()
+  })
+
+  // POSITIVE CONTROL — without it, every assertion above would pass against a
+  // component that rendered "Not set" for absolutely everything.
+  it('still reports a stamped strength normally (positive control)', () => {
+    mockStore(makeState({
+      edges: [{
+        id: 'e1', source: 'f1', target: 'o1',
+        data: { ...USER_EDGE_DEFAULTS, weight: 0.55, weightSource: 'user' },
+      }],
+      nodes: [{ id: 'o1', type: 'outcome', data: { label: 'Revenue' } }],
+    }))
+    render(<EdgePills nodeId="f1" />)
+    expect(screen.getByText('55%')).toBeDefined()
+    expect(screen.queryByTestId('edge-pill-strength-unset-e1')).toBeNull()
+    expect(screen.getByText('Raises')).toBeDefined()
+  })
+
+  it('sorts unset pills after known strengths so the cap of 4 spends its slots on real numbers', () => {
+    mockStore(makeState({
+      edges: [
+        { id: 'unset', source: 'f1', target: 'o0', data: { ...USER_EDGE_DEFAULTS } },
+        { id: 'known', source: 'f1', target: 'o1', data: { weight: 0.1, direction: 'positive', weightSource: 'cee' } },
+      ],
+      nodes: [
+        { id: 'o0', type: 'outcome', data: { label: 'Unset target' } },
+        { id: 'o1', type: 'outcome', data: { label: 'Known target' } },
+      ],
+    }))
+    const { container } = render(<EdgePills nodeId="f1" />)
+    const labels = Array.from(container.querySelectorAll('span'))
+      .map(el => el.textContent)
+      .filter(t => t === 'Unset target' || t === 'Known target')
+    expect(labels).toEqual(['Known target', 'Unset target'])
   })
 })

--- a/src/canvas/nodes/shared/__tests__/MetricPills.confidenceDisclosure.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/MetricPills.confidenceDisclosure.spec.tsx
@@ -1,0 +1,62 @@
+/**
+ * MetricPills — the confidence figure can never render BARE.
+ *
+ * The number itself is gated upstream (useNodeDisplayMetadata → the shared
+ * display policy), so today this pill shows no confidence at all. These tests
+ * cover the contract for the day the policy is flipped: whatever disclosure
+ * flags the policy hands down MUST travel with the number, in the same element.
+ *
+ * ESCAPE THIS TEST IS WRITTEN TO CATCH: `container.textContent` welds adjacent
+ * text nodes, so "Confidence 25%" + "*" reads as "Confidence 25%*" and a
+ * whole-document `toContain` assertion cannot tell WHICH element carries what —
+ * a disclosure rendered somewhere else entirely (or nowhere near the number)
+ * would still pass. Every assertion below resolves the pill by testid and reads
+ * that element's own attributes.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MetricPills } from '../MetricPills'
+
+describe('MetricPills — confidence disclosure travels with the number', () => {
+  it('marks a defaulted figure on the SAME element as the number', () => {
+    render(<MetricPills confidencePct={25} confidenceIsDefaulted confidenceIsProvisional />)
+    const pill = screen.getByTestId('metric-pill-confidence')
+
+    // The number and the disclosure are one element — not two siblings that a
+    // layout change could separate.
+    expect(pill.textContent).toContain('25%')
+    expect(pill.getAttribute('aria-label')).toContain('Default estimate')
+    expect(pill.getAttribute('aria-label')).toContain('Calibration is provisional')
+    expect(pill.getAttribute('title')).toContain('Default estimate')
+    expect(screen.getByTestId('metric-pill-confidence-default-estimate')).toBeDefined()
+  })
+
+  it('does NOT claim a default estimate when the policy did not say so', () => {
+    render(<MetricPills confidencePct={45} />)
+    const pill = screen.getByTestId('metric-pill-confidence')
+
+    // Anti-vacuity: the pill IS rendered and DOES carry the number…
+    expect(pill.textContent).toContain('45%')
+    // …and only then is the absence of the marker meaningful.
+    expect(screen.queryByTestId('metric-pill-confidence-default-estimate')).toBeNull()
+    expect(pill.getAttribute('aria-label')).not.toContain('Default estimate')
+    expect(pill.getAttribute('aria-label')).not.toContain('provisional')
+  })
+
+  it('discloses provisional calibration independently of defaulting', () => {
+    render(<MetricPills confidencePct={70} confidenceIsProvisional />)
+    const pill = screen.getByTestId('metric-pill-confidence')
+    expect(pill.getAttribute('aria-label')).toContain('Calibration is provisional')
+    expect(pill.getAttribute('aria-label')).not.toContain('Default estimate')
+    expect(screen.queryByTestId('metric-pill-confidence-default-estimate')).toBeNull()
+  })
+
+  it('renders no confidence pill at all when the policy withheld the number', () => {
+    // The live state today. Note the influence pill is still asked for, so a
+    // pass here cannot come from the component rendering nothing.
+    render(<MetricPills influencePct={80} confidencePct={null} confidenceIsDefaulted />)
+    expect(screen.getByText('Influence 80%')).toBeDefined()
+    expect(screen.queryByTestId('metric-pill-confidence')).toBeNull()
+    expect(screen.queryByTestId('metric-pill-confidence-default-estimate')).toBeNull()
+  })
+})

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -5,6 +5,7 @@ import { saveSnapshot as persistSnapshot, importCanvas as persistImport, exportC
 import { setsEqual, mapsEqual } from './store/utils'
 import { assignStableOptionNumbers } from './store/stableOptionNumbers'
 import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS, type EdgeData } from './domain/edges'
+import { edgeValueSourcePatch } from './domain/edgeValueProvenance'
 import { NODE_REGISTRY, type NodeType, type NodeData } from './domain/nodes'
 import { hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from './domain/analyticalChange'
 import { applyLayout, applyLayoutWithPolicy } from './layout'
@@ -4699,6 +4700,12 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
             weight: e.weight ?? 0.5,
             belief: e.belief ?? confidence,
             confidence,
+            // Set-vs-defaulted markers (domain/edgeValueProvenance.ts). Stamped
+            // only when the clarifier actually sent the value; the `?? 0.5`
+            // fallthrough above is a UI default and stays unstamped.
+            ...edgeValueSourcePatch({
+              weight: e.weight != null ? 'cee' : undefined,
+            }),
             isPreview: true,
           },
           style: {
@@ -4786,6 +4793,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
             weight: e.weight ?? 0.5,
             belief: e.belief ?? confidence,
             confidence,
+            // As in the preview path above: stamp only what the clarifier sent.
+            ...edgeValueSourcePatch({
+              weight: e.weight != null ? 'cee' : undefined,
+            }),
             provenance: e.provenance || 'AI-drafted',
           },
         }

--- a/src/canvas/ui/inspector-v2/useInspectorMutations.ts
+++ b/src/canvas/ui/inspector-v2/useInspectorMutations.ts
@@ -57,9 +57,13 @@ export const NODE_SETTER_FIELDS = {
 
 /** edge setter name → the top-level `data` field(s) that setter writes. */
 export const EDGE_SETTER_FIELDS = {
-  setStrength: ['weight', 'direction'],
+  // The `*Source` markers ride along with the value each setter writes: a
+  // user moving the slider is the ONLY thing that turns a defaulted number
+  // into a set one, so the stamp is written in the same update as the value
+  // and can never lag behind it.
+  setStrength: ['weight', 'direction', 'weightSource'],
   setStd: ['strengthStd'],
-  setExistsProbability: ['beliefExists'],
+  setExistsProbability: ['beliefExists', 'beliefExistsSource'],
   setLabel: ['label'],
   setDirection: ['direction'],
 } as const satisfies Record<string, readonly string[]>
@@ -273,7 +277,9 @@ export function useEdgeMutations(edgeId: string) {
     if (!edge) return
     const absWeight = Math.abs(mean)
     const direction = mean >= 0 ? 'positive' : 'negative'
-    updateEdge(edgeId, { data: { ...edge.data, weight: absWeight, direction } })
+    updateEdge(edgeId, {
+      data: { ...edge.data, weight: absWeight, direction, weightSource: 'user' },
+    })
   }, [edgeId, updateEdge, getEdge])
 
   const setStd = useCallback((std: number) => {
@@ -285,7 +291,9 @@ export function useEdgeMutations(edgeId: string) {
   const setExistsProbability = useCallback((ep: number) => {
     const edge = getEdge()
     if (!edge) return
-    updateEdge(edgeId, { data: { ...edge.data, beliefExists: ep } })
+    updateEdge(edgeId, {
+      data: { ...edge.data, beliefExists: ep, beliefExistsSource: 'user' },
+    })
   }, [edgeId, updateEdge, getEdge])
 
   const setLabel = useCallback((value: string) => {

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -601,6 +601,35 @@ describe('reconcileAppliedGraph — edge value provenance', () => {
     expect(edge.data.weightSource).toBeUndefined() // …and is not credited to CEE
   })
 
+  it('drops an ORPHAN stamp even when the receipt DOES write (the escape-catcher)', () => {
+    // ⚠ THE MUTATION THAT ESCAPED FIRST TIME. The sibling case above passes
+    // even with the coupling rule deleted, because the no-op guard catches it
+    // instead — an assertion passing for the wrong reason. Here the receipt
+    // genuinely changes beliefExists, so the overlay DOES write; the no-op
+    // guard cannot mask anything. Weight is sent as 0.5 (== the mapper
+    // default) so it is NOT applied, and its orphan stamp must be dropped —
+    // otherwise 'CEE set this' lands on the user's own 0.7.
+    reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+      ],
+      edges: [{
+        id: 'e-0', from: 'factor-1', to: 'goal-1',
+        weight: 0.5, belief_exists: 0.9,
+      }],
+    } as any)
+
+    const edge = useCanvasStore.getState().edges.find((e) => e.id === 'e-0') as any
+    // Proof the overlay really did write — without this the assertion below
+    // could pass simply because nothing happened at all.
+    expect(edge.data.beliefExists).toBe(0.9)
+    expect(edge.data.beliefExistsSource).toBe('cee')
+    // …and the orphan is gone.
+    expect(edge.data.weight).toBe(0.7)
+    expect(edge.data.weightSource).toBeUndefined()
+  })
+
   it('is still a strict no-op when only the stamp would change', () => {
     const historyBefore = (useCanvasStore.getState() as any).history?.past?.length
     const edgesBefore = useCanvasStore.getState().edges

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -568,3 +568,74 @@ describe('reconcileAppliedGraph — review fixups (edge-pair self-dedupe, stalen
     expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
   })
 })
+
+/**
+ * Edge value provenance (`beliefExistsSource` / `weightSource`) through the
+ * overlay. Two invariants, both discovered by this suite going red:
+ *
+ *  1. A stamp must never be applied WITHOUT the value it describes. The overlay
+ *     deliberately under-applies a wire value that equals the mapper default —
+ *     but a stamp differs from the baseline whenever the wire supplied
+ *     anything, so without coupling, a receipt carrying weight 0.5 would stamp
+ *     "CEE set this" onto an edge still showing the user's own 0.7. That is the
+ *     exact defect class the marker exists to close.
+ *  2. A stamp ALONE must not trigger a store write. `reconcileAppliedGraph`
+ *     guarantees a matching receipt is a strict no-op; metadata about an
+ *     unchanged number does not earn an exception.
+ */
+describe('reconcileAppliedGraph — edge value provenance', () => {
+  it('does NOT stamp a CEE source when the wire value was not applied (equals the mapper default)', () => {
+    // Local edge is the user's 0.7. The wire sends 0.5 — DEFAULT_EDGE_DATA.weight
+    // — which the baseline filter treats as unsupplied, so the displayed number
+    // stays 0.7. The stamp must not travel without it.
+    reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: 0.5 }],
+    } as any)
+
+    const edge = useCanvasStore.getState().edges.find((e) => e.id === 'e-0') as any
+    expect(edge.data.weight).toBe(0.7)          // the user's value survived…
+    expect(edge.data.weightSource).toBeUndefined() // …and is not credited to CEE
+  })
+
+  it('is still a strict no-op when only the stamp would change', () => {
+    const historyBefore = (useCanvasStore.getState() as any).history?.past?.length
+    const edgesBefore = useCanvasStore.getState().edges
+
+    const result = reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', observed_state: { value: 100 } },
+      ],
+      edges: [{ id: 'e-0', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+    } as any)
+
+    expect(result).toEqual(counts())
+    expect(useCanvasStore.getState().edges).toBe(edgesBefore)
+    expect((useCanvasStore.getState() as any).history?.past?.length).toBe(historyBefore)
+  })
+
+  // POSITIVE CONTROL — without this, both assertions above would pass against
+  // an overlay that had simply stopped writing provenance at all.
+  it('DOES stamp the source when the wire genuinely changes the value', () => {
+    reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+      ],
+      edges: [{
+        id: 'e-0', from: 'factor-1', to: 'goal-1',
+        weight: 0.42, belief_exists: 0.9,
+      }],
+    } as any)
+
+    const edge = useCanvasStore.getState().edges.find((e) => e.id === 'e-0') as any
+    expect(edge.data.weight).toBe(0.42)
+    expect(edge.data.weightSource).toBe('cee')
+    expect(edge.data.beliefExists).toBe(0.9)
+    expect(edge.data.beliefExistsSource).toBe('cee')
+  })
+})

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -13,6 +13,7 @@
 
 import { useCanvasStore } from '../store'
 import { DEFAULT_EDGE_DATA } from '../domain/edges'
+import { edgeValueSourcePatch } from '../domain/edgeValueProvenance'
 import { saveAutosave } from '../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
 import { hasAnalysisReady } from '../../adapters/cee/types'
@@ -66,6 +67,15 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
     typeof e.id === 'string' && e.id.trim().length > 0 ? e.id : `e-${i}`
 
   // Weight priority: strength.mean > strength_mean > weight > default
+  //
+  // `wireSuppliedStrength` is derived from the SAME three probes the priority
+  // chain uses (not a hand-kept copy of them), so it cannot drift from the
+  // value it describes: true exactly when the last branch — the UI default —
+  // was NOT taken.
+  const wireSuppliedStrength =
+    typeof e.strength?.mean === 'number'
+    || typeof e.strength_mean === 'number'
+    || typeof e.weight === 'number'
   const rawWeight: number =
     typeof e.strength?.mean === 'number'
       ? e.strength.mean
@@ -126,6 +136,15 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
       ...(edgeType !== undefined ? { edge_type: edgeType } : {}),
       ...(provenanceSource !== undefined ? { provenance_source: provenanceSource } : {}),
       ...(existsProbability !== undefined ? { exists_probability: existsProbability } : {}),
+      // Set-vs-defaulted markers. Derived from the resolved values themselves,
+      // never from "we are in the CEE mapper so it must be CEE": when the wire
+      // carried no belief at all, `beliefExists` is `undefined` here and the
+      // stamp is omitted, so the edge reads as NOT SET rather than claiming a
+      // producer estimate that was never sent.
+      ...edgeValueSourcePatch({
+        beliefExists: beliefExists !== undefined ? 'cee' : undefined,
+        weight: wireSuppliedStrength ? 'cee' : undefined,
+      }),
       // CEE display provenance (snake_case → camelCase). Distinct from `provenance_source`.
       ...edgeProvenanceDisplayPatch(e),
     },

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -127,6 +127,10 @@ import { saveAutosave } from '../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
 import { pulseAppliedTargets } from './appliedEditPulse'
 import { canvasEdgePairKey, wireEdgePairKey } from './graphIdentity'
+import { EDGE_PROVENANCED_FIELDS, edgeSourceKey } from '../domain/edgeValueProvenance'
+
+/** Derived from EDGE_PROVENANCED_FIELDS — never a hand-listed set. */
+const EDGE_SOURCE_KEYS: ReadonlySet<string> = new Set(EDGE_PROVENANCED_FIELDS.map(edgeSourceKey))
 import {
   backfillInterventionsOntoOptionNodes,
   mapDraftEdgeToCanvas,
@@ -248,7 +252,37 @@ function overlayEdge(existing: any, wireEdge: any): any {
   for (const [k, v] of Object.entries(mappedData)) {
     if (!sameValue(v, defaults[k])) supplied[k] = v
   }
+
+  // A provenance stamp must never outlive or precede the value it describes.
+  //
+  // The filter above deliberately UNDER-applies: a wire value that happens to
+  // equal the mapper default is treated as unsupplied and does not overwrite
+  // local state. A `*Source` stamp, though, differs from the baseline whenever
+  // the wire supplied ANYTHING — so without this coupling a receipt carrying
+  // weight 0.5 (== DEFAULT_EDGE_DATA.weight, therefore not applied) would still
+  // stamp `weightSource: 'cee'` onto an edge still showing the user's own 0.7.
+  // That is the exact defect class this marker exists to close: a claim about
+  // where a number came from, attached to a different number. Derived from
+  // EDGE_PROVENANCED_FIELDS, never a hand-kept pair list.
+  for (const field of EDGE_PROVENANCED_FIELDS) {
+    const sourceKey = edgeSourceKey(field)
+    if (sourceKey in supplied && !(field in supplied)) delete supplied[sourceKey]
+  }
+
   if (Object.keys(supplied).length === 0) return existing
+
+  // …and a stamp alone must not trigger a write. A receipt that genuinely
+  // matches the canvas is a STRICT no-op here — no history entry, no store
+  // write — and metadata about an unchanged number does not earn an exception:
+  // it would churn every user's history on their first turn after this ships,
+  // for a display outcome identical either way. So the no-op test is made
+  // against the data WITHOUT the stamps; when a real value does change, the
+  // stamps ride along with it.
+  const nextDataWithoutStamps = { ...(existing.data ?? {}) }
+  for (const [k, v] of Object.entries(supplied)) {
+    if (!EDGE_SOURCE_KEYS.has(k)) nextDataWithoutStamps[k] = v
+  }
+  if (sameValue(existing.data, nextDataWithoutStamps)) return existing
 
   const nextData = { ...(existing.data ?? {}), ...supplied }
   if (sameValue(existing.data, nextData)) return existing

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -44,6 +44,7 @@ import {
 } from './influenceScaleCopy'
 import { ExpandableCoachingText } from '../../components/shared/ExpandableCoachingText'
 import { isExpertField } from './utils/isExpertField'
+import { DISPLAY_SAFE_DRIVER_CONFIDENCE } from './driverConfidenceDisplayPolicy'
 import { openAskOlumi } from './coaching/askOlumiStore'
 
 interface DriversSectionProps {
@@ -88,7 +89,12 @@ const BAR_COLORS = {
 // certified display-safe driver-confidence source exists; the gated Confidence
 // column + glyph + tooltip signals below then light up, and the grid widens to
 // match via gridCols().
-const DISPLAY_SAFE_DRIVER_CONFIDENCE = false
+//
+// ⚠ The constant now lives in ./driverConfidenceDisplayPolicy and is IMPORTED,
+// not re-declared. It used to be private to this file while three canvas
+// surfaces + the Model tab read the identical `factor_sensitivity[].confidence`
+// with no gate at all — this panel refused to print a number the canvas printed
+// bare, from the same report. One binding makes that fork unrepresentable.
 
 // Fragility ("could change the result") belongs in the fragile-factors section,
 // NOT the driver section. Acceptance: driver section = "this matters most";

--- a/src/components/results/__tests__/driverConfidenceDisplayPolicy.spec.ts
+++ b/src/components/results/__tests__/driverConfidenceDisplayPolicy.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * The shared factor-confidence display policy, anchored to REAL captured bytes.
+ *
+ * Both arms come from ONE real staging bundle, chosen because the two layers
+ * inside it DISAGREE:
+ *   · `payloads.plot_response.factor_sensitivity[]` — confidence 0.25,
+ *     confidence_source 'plot_unified_from_isl_bootstrap',
+ *     confidence_components.sampling_stability 0  → DEFAULTED
+ *   · `payloads.isl_response.factor_sensitivity[]` — confidence 0.3756,
+ *     confidence_source 'bootstrap_sampling'      → NOT defaulted
+ *
+ * That disagreement is the whole finding: the canvas was rendering PLoT's
+ * defaulted 0.25 as a measurement while ISL's own computed 0.3756 sat in the
+ * same file. No invented literals are used for either arm.
+ *
+ * POSITIVE CONTROL (trap 13): every "it is hidden" assertion is paired with the
+ * same row resolved under `displaySafe: true`. Without that pairing the
+ * resolver could return `{show:false}` unconditionally — for a missing field,
+ * a typo'd fixture path, anything — and every hidden-assertion would pass while
+ * testing nothing.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  DISPLAY_SAFE_DRIVER_CONFIDENCE,
+  isDefaultedConfidenceFromRaw,
+  resolveFactorConfidenceDisplay,
+  resolveRawFactorConfidenceDisplay,
+} from '../driverConfidenceDisplayPolicy'
+import bundle from '../../debug/__tests__/fixtures/staging-bundles/olumi-debug-50b336a6-20260510.pre-fix.json'
+
+const plotRows = (bundle as any).payloads.plot_response.factor_sensitivity as Record<string, unknown>[]
+const islRows = (bundle as any).payloads.isl_response.factor_sensitivity as Record<string, unknown>[]
+
+describe('captured bytes — the fixture really does carry the disagreement', () => {
+  // Guards every test below: if the bundle shape ever changes, these fail
+  // LOUDLY rather than letting the suite pass against empty arrays.
+  it('PLoT rows carry a defaulted 0.25', () => {
+    expect(plotRows.length).toBeGreaterThan(0)
+    expect(plotRows[0].confidence).toBe(0.25)
+    expect(plotRows[0].confidence_source).toBe('plot_unified_from_isl_bootstrap')
+    expect((plotRows[0].confidence_components as any).sampling_stability).toBe(0)
+    expect((plotRows[0].confidence_provenance as any).is_provisional).toBe(true)
+  })
+
+  it('ISL rows in the SAME bundle carry a computed 0.3756', () => {
+    expect(islRows.length).toBeGreaterThan(0)
+    expect(islRows[0].confidence).toBe(0.3756)
+    expect(islRows[0].confidence_source).toBe('bootstrap_sampling')
+  })
+})
+
+describe('the ruled policy is unchanged by this lane', () => {
+  it('DISPLAY_SAFE_DRIVER_CONFIDENCE is still false — no doctrine flip here', () => {
+    expect(DISPLAY_SAFE_DRIVER_CONFIDENCE).toBe(false)
+  })
+})
+
+describe('isDefaultedConfidenceFromRaw — discriminates on real bytes', () => {
+  it('calls the PLoT row defaulted', () => {
+    expect(isDefaultedConfidenceFromRaw({
+      confidenceSource: plotRows[0].confidence_source as string,
+      samplingStability: (plotRows[0].confidence_components as any).sampling_stability,
+    })).toBe(true)
+  })
+
+  it('does NOT call the ISL row defaulted', () => {
+    expect(isDefaultedConfidenceFromRaw({
+      confidenceSource: islRows[0].confidence_source as string,
+      samplingStability: undefined,
+    })).toBe(false)
+  })
+})
+
+describe('resolveRawFactorConfidenceDisplay — under the ruled policy, nothing shows', () => {
+  it('hides the defaulted PLoT 0.25 as not-display-safe', () => {
+    const out = resolveRawFactorConfidenceDisplay(plotRows[0])
+    expect(out.show).toBe(false)
+    expect(out).toEqual({ show: false, hiddenReason: 'no_display_safe_source' })
+  })
+
+  it('hides the ISL 0.3756 too — the ruled reason is the SOURCE, not the value', () => {
+    // Important discrimination: this lane implements "no display-safe source
+    // exists", the panel's actual ruling. It is NOT "hide only the defaulted
+    // ones", which would leave un-disclosed numbers on the canvas that the
+    // panel still refuses to print.
+    const out = resolveRawFactorConfidenceDisplay(islRows[0])
+    expect(out).toEqual({ show: false, hiddenReason: 'no_display_safe_source' })
+  })
+
+  it('reports an ABSENT confidence as a different reason from a suppressed one', () => {
+    // Two hidden states that must never be conflated: "the producer sent
+    // nothing" and "the producer sent something we will not print".
+    const { confidence: _dropped, ...noConfidence } = plotRows[0]
+    expect(resolveRawFactorConfidenceDisplay(noConfidence)).toEqual({
+      show: false,
+      hiddenReason: 'absent',
+    })
+  })
+})
+
+describe('POSITIVE CONTROL — with the gate open, the real values do come through', () => {
+  it('shows the PLoT row WITH its defaulted + provisional disclosure, never bare', () => {
+    const out = resolveRawFactorConfidenceDisplay(plotRows[0], true)
+    expect(out).toEqual({
+      show: true,
+      value: 0.25,
+      isDefaulted: true,
+      isProvisional: true,
+    })
+  })
+
+  it('shows the ISL row as NOT defaulted — proving isDefaulted is derived, not hardcoded', () => {
+    const out = resolveRawFactorConfidenceDisplay(islRows[0], true)
+    expect(out).toEqual({
+      show: true,
+      value: 0.3756,
+      isDefaulted: false,
+      isProvisional: false,
+    })
+  })
+})
+
+describe('resolveFactorConfidenceDisplay — rejects values it cannot trust', () => {
+  it.each([null, undefined, NaN, Infinity, -0.1, 1.1, '0.5' as unknown as number])(
+    'reports %p as absent rather than coercing it',
+    (confidence) => {
+      expect(resolveFactorConfidenceDisplay({ confidence: confidence as number }, true)).toEqual({
+        show: false,
+        hiddenReason: 'absent',
+      })
+    },
+  )
+
+  it('never infers a disclosure flag that was not supplied', () => {
+    const out = resolveFactorConfidenceDisplay({ confidence: 0.5 }, true)
+    expect(out).toEqual({ show: true, value: 0.5, isDefaulted: false, isProvisional: false })
+  })
+})

--- a/src/components/results/driverConfidenceDisplayPolicy.ts
+++ b/src/components/results/driverConfidenceDisplayPolicy.ts
@@ -1,0 +1,173 @@
+/**
+ * THE single display policy for factor/driver confidence.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * The Drivers panel had already ruled that `factor_sensitivity[].confidence`
+ * has no display-safe source today and must never be rendered raw or defaulted
+ * (`DISPLAY_SAFE_DRIVER_CONFIDENCE`, formerly a private const in
+ * `DriversSection.tsx`). Three canvas surfaces + the Model tab read THE SAME
+ * field off THE SAME `results.report` with no gate at all, so the product
+ * simultaneously refused to show a number in one panel and printed it, bare, on
+ * four others:
+ *
+ *   · `canvas/nodes/shared/MetricPills.tsx`   "Confidence 25%"
+ *   · `canvas/nodes/FactorNode.tsx`           bar + % in Detailed view
+ *   · `canvas/nodes/FactorNode.tsx`           SPOKEN PROSE — "Low confidence."
+ *   · `canvas/components/model-tab/FactorsSection.tsx`  "Confidence 25%"
+ *   · `canvas/ui/NodeInspector.tsx`           bar + % (dead at runtime today)
+ *
+ * In both real staging captures that number is `0.25` with
+ * `confidence_components.sampling_stability: 0` — the exact condition
+ * `isDefaultedConfidenceFromRaw` classifies as DEFAULTED — while ISL's own
+ * computed figure in the same bundle was `0.3756`.
+ *
+ * A gate that lives in one component and is re-decided in the next is the
+ * hand-maintained-mirror defect class. So the constant lives HERE and every
+ * surface resolves through `resolveFactorConfidenceDisplay`. Adding a surface
+ * that renders confidence without calling this function is the only way to
+ * re-open the fork, and that is now a visible, reviewable act.
+ *
+ * WHAT THIS MODULE DOES NOT DO
+ * ----------------------------
+ * It does NOT flip the doctrine. `DISPLAY_SAFE_DRIVER_CONFIDENCE` keeps its
+ * ruled value of `false`; this change only makes the surfaces that were
+ * ignoring it obey it. Flipping it — i.e. ADDING a number to the product — is a
+ * display-safety doctrine call for the science lane / Paul.
+ *
+ * When it IS flipped, every surface gets `isDefaulted` and `isProvisional`
+ * alongside the value, so nothing renders bare: the same disclosure vocabulary
+ * the Drivers panel already ships (the "Default estimate — not yet validated
+ * with evidence" marker and the provisional-calibration note) applies
+ * everywhere at once.
+ */
+
+/**
+ * Single-source rule (see ROBUSTNESS-VERDICT-CONTRACT): there is no
+ * display-safe source for driver/factor confidence today, so the signal stays
+ * HIDDEN everywhere — no raw %, no bar, no dash, no confidence-derived prose.
+ *
+ * Flip this true ONLY when a certified display-safe confidence source exists.
+ * Everything gated on it lights up together, WITH disclosure.
+ */
+export const DISPLAY_SAFE_DRIVER_CONFIDENCE = false
+
+/** PLoT's confidence disclosure object, as parsed off the wire. */
+export interface ConfidenceProvenanceLike {
+  isProvisional?: boolean
+}
+
+/**
+ * Derive `isDefaultedConfidence` from a normalised factor sensitivity row.
+ *
+ * Tracks ISL-side bootstrap degeneracy (sampling_stability detected as 0,
+ * indicating ISL emitted a placeholder) — NOT PLoT-side `fallback_degenerate`,
+ * which is a different concept. Audit A1-PRIMARY: the source-name list accepts
+ * BOTH legacy values ('isl', 'isl_default') AND the new honest enum
+ * ('plot_unified_from_isl_bootstrap') so the derivation survives both deploy
+ * directions (old PLoT + new UI, and new PLoT + old UI).
+ *
+ * Lives here rather than in `useResultsSectionData` (which re-exports it for
+ * its existing consumers) so that the rule and the gate that consumes it are
+ * one small module, importable by canvas code without dragging a hook file in.
+ */
+export function isDefaultedConfidenceFromRaw(raw: {
+  confidenceSource?: string
+  samplingStability?: number | null
+}): boolean {
+  return (
+    raw.confidenceSource === 'isl'
+    || raw.confidenceSource === 'isl_default'
+    || raw.confidenceSource === 'plot_unified_from_isl_bootstrap'
+  )
+    && raw.samplingStability === 0
+}
+
+/** What a surface should render for one factor's confidence. */
+export type FactorConfidenceDisplay =
+  | {
+      show: false
+      /**
+       * `absent`   — the producer sent no confidence for this factor.
+       * `no_display_safe_source` — a value exists but the ruled policy says it
+       *   is not fit to show. NOT the same thing, and surfaces that want to
+       *   explain themselves need to tell them apart.
+       */
+      hiddenReason: 'absent' | 'no_display_safe_source'
+    }
+  | {
+      show: true
+      /** 0-1. */
+      value: number
+      /** True ⇒ render the "Default estimate" marker; never render bare. */
+      isDefaulted: boolean
+      /** True ⇒ render the provisional-calibration note; never render bare. */
+      isProvisional: boolean
+    }
+
+/**
+ * Resolve one factor's confidence for display.
+ *
+ * @param displaySafe test seam ONLY. Production callers pass nothing, so they
+ * all bind to the single module constant and cannot fork. Tests pass `true` to
+ * exercise the shown branch — which is what makes the "it is hidden" assertions
+ * non-vacuous: without a demonstrated PRESENCE the absence proves nothing.
+ */
+export function resolveFactorConfidenceDisplay(
+  input: {
+    confidence: number | null | undefined
+    isDefaulted?: boolean
+    confidenceProvenance?: ConfidenceProvenanceLike
+  },
+  displaySafe: boolean = DISPLAY_SAFE_DRIVER_CONFIDENCE,
+): FactorConfidenceDisplay {
+  const value = input.confidence
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    return { show: false, hiddenReason: 'absent' }
+  }
+  if (!displaySafe) {
+    return { show: false, hiddenReason: 'no_display_safe_source' }
+  }
+  return {
+    show: true,
+    value,
+    isDefaulted: input.isDefaulted === true,
+    isProvisional: input.confidenceProvenance?.isProvisional === true,
+  }
+}
+
+/**
+ * Read the confidence fields off a RAW `factor_sensitivity` row and resolve the
+ * display in one step.
+ *
+ * Exists because `ModelTabBody` builds its confidence map straight from the raw
+ * wire arrays (including `rawV2Response` fallbacks) and never touches the
+ * normalised driver feed. Rather than let it re-implement the field probes —
+ * a mirror that would drift the moment PLoT renames a field — it calls this.
+ */
+export function resolveRawFactorConfidenceDisplay(
+  raw: unknown,
+  displaySafe: boolean = DISPLAY_SAFE_DRIVER_CONFIDENCE,
+): FactorConfidenceDisplay {
+  if (raw == null || typeof raw !== 'object') return { show: false, hiddenReason: 'absent' }
+  const row = raw as Record<string, unknown>
+  const components = row.confidence_components as Record<string, unknown> | undefined
+  const provenance = row.confidence_provenance as Record<string, unknown> | undefined
+  return resolveFactorConfidenceDisplay(
+    {
+      confidence: typeof row.confidence === 'number' ? row.confidence : null,
+      isDefaulted: isDefaultedConfidenceFromRaw({
+        confidenceSource: typeof row.confidence_source === 'string' ? row.confidence_source : undefined,
+        samplingStability:
+          typeof components?.sampling_stability === 'number'
+            ? (components.sampling_stability as number)
+            : undefined,
+      }),
+      confidenceProvenance:
+        typeof provenance?.is_provisional === 'boolean'
+          ? { isProvisional: provenance.is_provisional as boolean }
+          : undefined,
+    },
+    displaySafe,
+  )
+}

--- a/src/components/results/modals/__tests__/buildMethodCard.spec.ts
+++ b/src/components/results/modals/__tests__/buildMethodCard.spec.ts
@@ -132,10 +132,30 @@ describe('buildMethodCard — fabrication guards', () => {
   it('treats confidence as provisional when ANY factor is provisional', () => {
     // Conservative direction — matches the policy DriversSection already
     // ships (`drivers.some(d => d.confidenceProvenance?.isProvisional)`).
+    //
+    // ⚠ Both payloads below are now FULLY FORMED. They used to be two-key
+    // stubs, and they passed — because this module hand-rolled the read and
+    // accepted any object under the key. See the rejection test below.
     const model = buildMethodCard({
       factor_sensitivity: [
-        { confidence_provenance: { is_provisional: false, calibration_status: 'calibrated' } },
-        { confidence_provenance: { is_provisional: true, calibration_status: 'provisional' } },
+        {
+          confidence_provenance: {
+            computation_source: 'plot_unified_from_graph',
+            formula_version: 'plot_unified_v2',
+            is_provisional: false,
+            calibration_status: 'calibrated',
+            input_quality: 'standard',
+          },
+        },
+        {
+          confidence_provenance: {
+            computation_source: 'plot_unified_from_isl_bootstrap',
+            formula_version: 'plot_unified_v2',
+            is_provisional: true,
+            calibration_status: 'provisional',
+            input_quality: 'standard',
+          },
+        },
       ],
     })
     expect(model.confidenceCalibration).toEqual({
@@ -144,8 +164,73 @@ describe('buildMethodCard — fabrication guards', () => {
     })
   })
 
+  it('REJECTS a malformed confidence_provenance instead of reducing it into a claim', () => {
+    // The pre-2026-07-25 read was `asRecord(f.confidence_provenance) !== null`,
+    // so a half-populated object became a calibration statement on the one card
+    // whose purpose is honest provenance. It now runs through the SAME
+    // `isValidConfidenceProvenance` gate the Drivers panel's disclosure uses.
+    const model = buildMethodCard({
+      factor_sensitivity: [
+        { confidence_provenance: { is_provisional: true, calibration_status: 'provisional' } },
+        { confidence_provenance: { computation_source: 'made_up', formula_version: 'v9' } },
+      ],
+    })
+    expect(model.confidenceCalibration.known).toBe(false)
+  })
+
   it('refuses a non-boolean stability provisional flag rather than coercing truthiness', () => {
     expect(buildMethodCard({ stability_thresholds: { provisional: 'true' } }).stabilityThresholds.known).toBe(false)
     expect(buildMethodCard({ stability_thresholds: {} }).stabilityThresholds.known).toBe(false)
+  })
+})
+
+/**
+ * 🔴 The auto-noise fabrication — reported by the reuse review, 2026-07-25.
+ *
+ * `autoNoiseApplied` inferred from the PRESENCE of `auto_noise_provenance`
+ * rather than reading its `applied` flag through the shared normaliser. A
+ * payload explicitly stating `{ applied: false }` therefore rendered as
+ * "Applied" ON THE PROVENANCE CARD — while `ModelTabBody`, which uses
+ * `normalizeAutoNoiseProvenance`, showed the opposite for the same bytes.
+ *
+ * The shape below is the one the existing autoNoise integration suite uses
+ * (`useResultsSectionData.autoNoise.spec.ts:47-56`) — the same fields PLoT
+ * sends — with only `applied` varied between the two arms.
+ */
+describe('buildMethodCard — auto-noise reads the FLAG, never the presence', () => {
+  const validProvenance = {
+    applied: true,
+    effect: 'widens_outcome_and_risk_uncertainty',
+    formula_version: 'plot_auto_v1',
+    multiplier: 1.0,
+    noise_distribution: 'normal_zero_mean_outcome_std',
+    filter_scope: 'outcome_and_risk_nodes',
+    is_provisional: true,
+    calibration_status: 'provisional_pending_pilot_calibration',
+  }
+
+  it('reports applied=false as FALSE — the defect: this used to render "Applied"', () => {
+    const model = buildMethodCard({
+      auto_noise_provenance: { ...validProvenance, applied: false },
+    })
+    expect(model.autoNoiseApplied).toEqual({ known: true, value: false })
+  })
+
+  // POSITIVE CONTROL: without this the assertion above would pass against a
+  // function that always reported false.
+  it('reports applied=true as TRUE', () => {
+    const model = buildMethodCard({ auto_noise_provenance: validProvenance })
+    expect(model.autoNoiseApplied).toEqual({ known: true, value: true })
+  })
+
+  it('reports a MALFORMED provenance as unknown rather than as applied', () => {
+    // Presence-inference read this as "Applied"; the normaliser rejects it.
+    const { multiplier: _dropped, ...missingMultiplier } = validProvenance
+    expect(buildMethodCard({ auto_noise_provenance: missingMultiplier }).autoNoiseApplied.known).toBe(false)
+    expect(buildMethodCard({ auto_noise_provenance: { applied: true } }).autoNoiseApplied.known).toBe(false)
+  })
+
+  it('still reports an ABSENT provenance as unknown, never as "not applied"', () => {
+    expect(buildMethodCard({}).autoNoiseApplied.known).toBe(false)
   })
 })

--- a/src/components/results/modals/buildMethodCard.ts
+++ b/src/components/results/modals/buildMethodCard.ts
@@ -26,7 +26,25 @@
  *
  * Read directly off `rawV2Response` (canvas store) because every field below
  * is a straight wire passthrough with no display policy attached.
+ *
+ * ⚠ CORRECTED 2026-07-25. The sentence above was true of the SOURCE but was
+ * taken as licence to hand-roll the PARSES, and three of them were wrong or
+ * duplicated — on the one card whose entire purpose is honest provenance:
+ *   · `auto_noise_provenance` was read for PRESENCE, so a payload explicitly
+ *     saying `{ applied: false }` rendered as "Applied" — the exact opposite of
+ *     what `ModelTabBody` showed for the same bytes, via the shared normaliser.
+ *   · `confidence_provenance` was reduced without `isValidConfidenceProvenance`,
+ *     so a malformed object counted as a calibration statement.
+ *   · `meta.seed_used` was a FOURTH independent parse of a field whose
+ *     canonical resolver (`resolveSeedUsed`) exists precisely because earlier
+ *     hand-rolls fabricated a 0 three different ways.
+ * Every one of those is now delegated. A passthrough field still needs THE
+ * shared reader — "no display policy" is not "no parsing rule".
  */
+
+import { normalizeAutoNoiseProvenance } from '../types'
+import { isValidConfidenceProvenance } from '../useResultsSectionData'
+import { resolveSeedUsed } from '../../../canvas/hooks/useV2Run'
 
 /** Either this run reported the fact, or it did not. No defaults, no third state. */
 export type Provenanced<T> = { known: true; value: T } | { known: false }
@@ -87,14 +105,15 @@ function finiteNumber(v: unknown): Provenanced<number> {
 }
 
 /**
- * A non-empty string, or unknown. `seed_used` arrives as a string in real
- * captures ("485977") but is number-typed in some contract revisions, so both
- * are accepted — and anything else is unknown rather than String()-coerced.
+ * Seed, via THE canonical resolver. `seed_used` arrives as a string in real
+ * captures ("485977") but is number-typed in some contract revisions;
+ * `resolveSeedUsed` already owns both cases AND the hard-won rule that an
+ * unparseable value stays unknown rather than becoming 0. This function only
+ * adapts its `number | null` to the card's `Provenanced<string>`.
  */
-function idString(v: unknown): Provenanced<string> {
-  if (typeof v === 'string' && v.trim() !== '') return known(v)
-  if (typeof v === 'number' && Number.isFinite(v)) return known(String(v))
-  return UNKNOWN
+function seedString(v: unknown): Provenanced<string> {
+  const resolved = resolveSeedUsed(v)
+  return resolved === null ? UNKNOWN : known(String(resolved))
 }
 
 /**
@@ -119,22 +138,22 @@ export function buildMethodCard(rawV2Response: unknown): MethodCardModel {
     : []
 
   // ── Confidence calibration ────────────────────────────────────────────
-  // Only factors that actually carry a confidence_provenance object count.
-  // Zero carriers = unknown (the 2026-04-05 capture is exactly this case);
-  // it must NOT read as "calibrated".
+  // Only factors carrying a VALID confidence_provenance object count, gated by
+  // the same `isValidConfidenceProvenance` the Drivers panel's disclosure runs
+  // through. Before this, any object under that key counted — a half-populated
+  // payload could be reduced into a confident-sounding calibration statement on
+  // the provenance card itself. Zero valid carriers = unknown (the 2026-04-05
+  // capture is exactly this case); it must NOT read as "calibrated".
   const provenances = factors
-    .map((f) => asRecord(f.confidence_provenance))
-    .filter((p): p is Record<string, unknown> => p !== null)
+    .map((f) => f.confidence_provenance)
+    .filter(isValidConfidenceProvenance)
 
   const confidenceCalibration: Provenanced<ConfidenceCalibration> =
     provenances.length === 0
       ? UNKNOWN
       : known({
           isProvisional: provenances.some((p) => p.is_provisional === true),
-          status:
-            typeof provenances[0].calibration_status === 'string'
-              ? (provenances[0].calibration_status as string)
-              : null,
+          status: provenances[0].calibration_status,
         })
 
   // ── Stability thresholds ──────────────────────────────────────────────
@@ -148,14 +167,18 @@ export function buildMethodCard(rawV2Response: unknown): MethodCardModel {
         })
 
   // ── Auto-noise ────────────────────────────────────────────────────────
-  // Presence of the provenance object IS the signal that the adjustment ran.
-  // Absence is unknown, never "no adjustment was applied".
+  // ⛔ Read the `applied` FLAG through the shared normaliser — never infer from
+  // presence. Presence-inference rendered "Applied" for a payload that
+  // explicitly said `{ applied: false }`, while `ModelTabBody` (which uses the
+  // normaliser) showed the opposite for the same bytes. A malformed or absent
+  // object normalises to null ⇒ unknown, never "no adjustment was applied".
+  const autoNoise = normalizeAutoNoiseProvenance(root?.auto_noise_provenance)
   const autoNoiseApplied: Provenanced<boolean> =
-    asRecord(root?.auto_noise_provenance) !== null ? known(true) : UNKNOWN
+    autoNoise === null ? UNKNOWN : known(autoNoise.applied)
 
   return {
     nSamples: finiteNumber(meta?.n_samples),
-    seed: idString(meta?.seed_used),
+    seed: seedString(meta?.seed_used),
     evpiMethod: unanimousString(factors, 'evpi_method'),
     confidenceCalibration,
     stabilityThresholds,

--- a/src/components/results/modals/buildMethodCard.ts
+++ b/src/components/results/modals/buildMethodCard.ts
@@ -44,7 +44,7 @@
 
 import { normalizeAutoNoiseProvenance } from '../types'
 import { isValidConfidenceProvenance } from '../useResultsSectionData'
-import { resolveSeedUsed } from '../../../canvas/hooks/useV2Run'
+import { resolveSeedUsed } from '../../../canvas/hooks/resolveSeedUsed'
 
 /** Either this run reported the fact, or it did not. No defaults, no third state. */
 export type Provenanced<T> = { known: true; value: T } | { known: false }

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -18,6 +18,7 @@ import { useCanvasStore } from '../../canvas/store'
 import { THRESHOLDS, LIMITS } from '../../lib/mappers/constants'
 import { useShallow } from 'zustand/react/shallow'
 import { findNodeMatches, type Driver } from '../../canvas/utils/driverMatching'
+import { isDefaultedConfidenceFromRaw } from './driverConfidenceDisplayPolicy'
 import type { Node } from '@xyflow/react'
 import type {
   DecisionResultData,
@@ -48,6 +49,7 @@ import type {
   ConfidenceFormulaVersion,
   ConfidenceCalibrationStatus,
   ConfidenceInputQuality,
+  ConfidenceProvenance,
 } from './types'
 import { normalizeAutoNoiseProvenance, normalizeHeadlineBanded } from './types'
 import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
@@ -299,28 +301,13 @@ export function isValidConfidenceProvenance(value: unknown): value is {
 }
 
 /**
- * Derive `isDefaultedConfidence` from a normalised factor sensitivity row.
- *
- * Tracks ISL-side bootstrap degeneracy (sampling_stability detected as 0,
- * indicating ISL emitted a placeholder) — NOT PLoT-side `fallback_degenerate`,
- * which is a different concept. Audit A1-PRIMARY: the source-name list accepts
- * BOTH legacy values ('isl', 'isl_default') AND the new honest enum
- * ('plot_unified_from_isl_bootstrap') so the derivation survives both deploy
- * directions (old PLoT + new UI, and new PLoT + old UI).
- *
- * Exported for direct unit testing of cross-version compat behaviour.
+ * Re-exported from `driverConfidenceDisplayPolicy`, where the rule now lives
+ * alongside the display gate that consumes it (one small module the canvas can
+ * import without pulling in this hook file). Kept exported here so existing
+ * importers and the cross-version compat unit tests are unaffected — there is
+ * exactly ONE implementation, not two.
  */
-export function isDefaultedConfidenceFromRaw(raw: {
-  confidenceSource?: string
-  samplingStability?: number | null
-}): boolean {
-  return (
-    raw.confidenceSource === 'isl'
-    || raw.confidenceSource === 'isl_default'
-    || raw.confidenceSource === 'plot_unified_from_isl_bootstrap'
-  )
-    && raw.samplingStability === 0
-}
+export { isDefaultedConfidenceFromRaw }
 
 export function normalizeFactorSensitivity(raw: unknown, nodeLabelMap: Map<string, string>): UiFactorSensitivity {
   if (raw == null || typeof raw !== 'object') return { factorId: '', label: 'Unknown factor', elasticity: 0, direction: 'positive' as const, confidence: null, importanceRank: 0 }
@@ -474,6 +461,17 @@ export interface DriverPolicyRow {
   rawElasticity: number
   /** Factor confidence (0-1) when the wire carried one. */
   confidence: number | null
+  /**
+   * True when `confidence` above is a producer PLACEHOLDER rather than a
+   * computed figure (`isDefaultedConfidenceFromRaw`). Carried on the shared
+   * feed so the canvas surfaces resolve the SAME verdict as the Drivers panel
+   * for the same report — previously the panel derived it and the canvas hook
+   * could not see it at all, which is how the canvas ended up printing a
+   * defaulted 0.25 the panel refuses to show.
+   */
+  confidenceIsDefaulted: boolean
+  /** PLoT's confidence disclosure object, when the wire carried a valid one. */
+  confidenceProvenance: ConfidenceProvenance | undefined
   /** value_of_information (snake or camel wire field) when present. */
   valueOfInformation: number | undefined
 }
@@ -634,6 +632,13 @@ export function selectDriverPolicyFeed(
       // disclose it read the signed wire row from `rawFactors`.
       rawElasticity: Math.abs(getRawElasticity(norm)),
       confidence: norm.confidence,
+      // Derived from the SAME normalised row the confidence itself came from,
+      // by the SAME function the panel uses — not a second reading of the wire.
+      confidenceIsDefaulted: isDefaultedConfidenceFromRaw({
+        confidenceSource: norm.confidenceSource,
+        samplingStability: norm.samplingStability,
+      }),
+      confidenceProvenance: norm.confidenceProvenance,
       valueOfInformation: norm.valueOfInformation,
     }
   })


### PR DESCRIPTION
Two live user-facing defects of the **same class**: a fabricated or defaulted number rendered to the user as if it had been measured. Both fixed here because they share the disclosure infrastructure and touch adjacent files.

Full context: `parallel-briefs/P1-9-PROVENANCE-2026-07-25.md` FIND-1 / FIND-2. Lane log: `parallel-briefs/CONFIDENCE-HONESTY-LANE-2026-07-25.md`.

---

## DEFECT A (P1) — a hardcoded constant spoken as a measurement

`DEFAULT_EDGE_DATA` pins `beliefExists: 0.8` / `weight: 0.5`; `USER_EDGE_DEFAULTS` pins `0.8` / `0.3` / `direction: 'positive'`. `ConnRow` rendered that as **`80% conf.`** with `aria-label="80% confidence the link exists"`; `EdgePills` rendered the weight as **`30%` "link strength"** with a **"Raises"** arrow. `EdgeData` carried no way to tell a value somebody SET from one that fell through, so the renderers could not tell them apart even in principle.

**Fix — `beliefExistsSource` / `weightSource` on `EdgeData`. ABSENT MEANS DEFAULTED.** Optional fields, stamped only where the value demonstrably came from a named source (`user` | `cee` | `template`). A construction site that does nothing produces the honest state with **no work**, and forgetting to stamp can only under-disclose, never over-claim.

Flat keys rather than a nested object because `mergeAppliedGraph.overlayEdge` merges wire onto local **key by key** against a derived baseline — a nested object would be replaced wholesale and would drop a local `weight: 'user'` stamp whenever the wire carried only a belief.

**Surfaces now:** ConnRow renders no figure for an unset edge (its existing null path). EdgePills keeps the pill — the shape and the target label are real, the user drew this connection — and shows *"Not set"* in place of the number, with no direction arrow.

⚠ **Correction to the brief's root cause:** the CEE mappers do NOT fabricate the 0.8. `mapDraftEdgeToCanvas`/`buildEdge` list `beliefExists` explicitly after the spread, and an explicit `undefined` overrides a spread — so a CEE edge with no belief lands `undefined`, which is why drafted edges show real values and the fabrication bites on user-created/template/store-side edges.

⚠ **Rejected the smaller diff** (deleting 0.8/0.5 from the defaults): it changes what reaches the ISL/PLoT adapters, the StyledEdge line-style derivation, the science-icon weak-edge detector, and the persisted/hashed edge payload. This lane's mandate is display honesty, not numeric behaviour.

## DEFECT B (P0) — the canvas showed a number the results panel refuses to

`DriversSection.tsx:91` pinned `DISPLAY_SAFE_DRIVER_CONFIDENCE = false` — *"no display-safe driver-confidence source exists today, so we never render raw/defaulted confidence"* — while `useNodeDisplayMetadata` read **the same** `factor_sensitivity[].confidence` off **the same** `results.report` **ungated**, and `ModelTabBody` read it a third time.

In both real staging captures the value is `0.25` with `confidence_components.sampling_stability: 0` — exactly what `isDefaultedConfidenceFromRaw` calls defaulted. In `olumi-debug-50b336a6-20260510.pre-fix.json`, **ISL's own computed figure in the same bundle is `0.3756`**.

⚠ **The brief under-counted the surfaces. There are five, and one is SPOKEN PROSE:** `FactorNode`'s `synthesisedCoaching` turned the defaulted 0.25 into the line **"Low confidence."** That now falls silent with the number. (Fifth: `NodeInspector` — dead at runtime behind `USE_INSPECTOR_V2 = true`, live in the bundle.)

**The doctrine constant is NOT flipped.** Flipping it *adds* a number and is Paul's call. What changes is that the surfaces ignoring it now obey it: the constant **moves** into `driverConfidenceDisplayPolicy.ts` and every read site resolves through it, so the fork is unrepresentable. The disclosure is wired **now** (`isDefaulted` / `isProvisional` travel with the value, in the same element), so if the gate is ever opened nothing renders bare.

## Folded in from the reuse review (same honesty class)

`buildMethodCard.ts` — three hand-rolled parses **on the provenance card itself**:
1. 🔴 `auto_noise_provenance` read for **PRESENCE**, so a payload explicitly saying `{applied: false}` rendered as **"Applied"** — the opposite of what `ModelTabBody` showed for the same bytes. Now reads the flag through `normalizeAutoNoiseProvenance`.
2. `confidence_provenance` reduced without `isValidConfidenceProvenance` — a malformed object became a calibration statement. Now gated.
3. `meta.seed_used` — a fourth independent parse; now delegates to `resolveSeedUsed`.

---

## Verification

**Tests — 60 new, both arms anchored to REAL captured bytes.** Both arms come from ONE bundle that disagrees with itself: PLoT's defaulted `0.25` vs ISL's computed `0.3756`. No invented literals for either arm. Every absence assertion is paired with a positive control proving the reader can see a presence.

**Written against the two escapes that have bitten UI lanes here:**
- a `confidence === null` that would *also* pass if the row had never resolved → every such case asserts `inSensitivityAnalysis` + a finite `influence` in the same call;
- `textContent` welding adjacent nodes ("Not set" + label → "Not setRevenue") → every assertion resolves its element by testid.

**Mutation check — throwaway worktree, 10/10 BITE.** Baseline restored and re-verified green after every revert. Each mutation's write is asserted to have landed on disk in the same pass that applies it (a `grep -F` landed-check gave a false "did not land" on a multi-line anchor — the harness is not exempt from the verification it performs).

| # | Mutation | Result |
|---|---|---|
| M1 | remove the ConnRow provenance gate | RED — 2 |
| M2 | marker defaults to "set" when absent | RED — 13 |
| M3 | remove the EdgePills strength gate | RED — 4 |
| M4 | canvas reads confidence raw again | RED — 3 |
| M5 | `isDefaulted` hardcoded false | RED — 1 |
| M6 | auto-noise presence-inference restored | RED — 2 |
| M7 | confidence-provenance validity gate removed | RED — 1 |
| M8 | draft mapper stamps CEE unconditionally | RED — 1 |
| M9 | orphan-stamp coupling removed | **ESCAPED first, then RED — 1** |
| M10 | stamp-alone triggers a write | RED — 6 |

**M9 escaped on the first run and that is the most useful thing in this PR.** The test I had written passed with the coupling deleted — because a *different* rule (the no-op guard) caught the case. Exactly the escape pattern the brief names. The replacement test makes the receipt genuinely write, so the no-op guard cannot mask anything; the orphan stamp then lands and the test goes red.

**Two invariants found by the suite going red, not by inspection** (`mergeAppliedGraph`): a stamp must never be applied without the value it describes (else a receipt carrying `weight: 0.5` — equal to the default, therefore *not* applied — would stamp "CEE set this" onto the user's own 0.7), and a stamp alone must not trigger a store write (a matching receipt is a strict no-op; churning every user's history for an identical display outcome earns no exception).

**`resolveSeedUsed` moved to a pure leaf module.** Importing it from `useV2Run` broke 60 tests across three OutputsDock suites at *render*: `[vitest] No "resolveSeedUsed" export is defined on the "../../hooks/useV2Run" mock`. A `vi.mock` factory replaces the module, so a hand-listed export set silently omits everything added since. Fixed at the cause rather than by extending twelve mock factories.

**Gates**
- `pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) — **PASSED**, coverage 2995/3013, ratchet **666 files / 2663 errors: baseline UNCHANGED, not raised.** (Two new errors appeared first, both `FactorNode.spec.tsx` mocks missing the new hook fields; fixed at source.)
- Full `vitest run` and `build:ci` (incl. bundle budget) — results appended below.

Base `staging`, never `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)