### PR TITLE
fix(honesty): one read-side accessor for edge values; converge four duplicated rules; five verified deletions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,43 @@ jobs:
       - name: Design System v5 drift (report-only soak)
         run: pnpm run ci:guard:ds
 
+  # ── Typecheck gate self-test (positive control) ──────────────────────
+  # PARITY WITH staging-full-tests.yml. The `tsc` job above asserts an ABSENCE
+  # ("no new type errors, no invisible files"). That assertion is worth nothing
+  # unless the gate can be shown to detect a PRESENCE — the gate it replaced was
+  # green for months while loading 9% of src, and nobody had ever watched it go
+  # red. #470 wired this self-test into the Staging Gate but not into ci.yml, so
+  # the `TypeScript` check required on `main` was running an unproven gate.
+  # Its own job so it runs in parallel and costs no serial time.
+  typecheck-selftest:
+    name: Typecheck Gate Self-Test
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      # The self-test derives the source set with `git ls-files`, so it needs a
+      # real checkout (actions/checkout gives one) and a clean working tree.
+      - name: Prove the typecheck gate actually bites
+        run: pnpm run typecheck:selftest
+
   # ── Unit tests + coverage (merged — was two separate jobs running tests twice) ──
   vitest:
     name: Tests + Coverage

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -90,7 +90,7 @@ import {
 import { resolveScenarioKey } from '../../components/results/modals/scenarioKey'
 import { useScenario } from '../../hooks/useScenario'
 import { focusExistingTarget } from '../utils/focusHelpers'
-import { withObservedStateUpdate } from '../utils/observedStateHelpers'
+import { normaliseRawFactorValue, withObservedStateUpdate } from '../utils/observedStateHelpers'
 import { ModelTabBody } from './ModelTabBody'
 import { JourneyTabBody } from '../journey/JourneyTabBody'
 import { CompareTabBody as CompareTabBodyV2 } from '../compare-tab/CompareTabBody'
@@ -1289,7 +1289,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     const nd = node.data as Record<string, unknown>
     const existing = (nd?.observedState ?? nd?.observed_state ?? {}) as Record<string, unknown>
     const cap = (existing.cap as number | null) ?? null
-    const normalised = cap != null && cap > 0 ? rawValue / cap : rawValue
+    const normalised = normaliseRawFactorValue(rawValue, cap)
     updateNode(nodeId, {
       data: withObservedStateUpdate(node.data, {
         raw_value: rawValue,

--- a/src/canvas/components/StarterProvenanceBanner.tsx
+++ b/src/canvas/components/StarterProvenanceBanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { BookmarkCheck, X } from 'lucide-react'
 import { useCanvasStore } from '../store'
@@ -31,7 +31,6 @@ import { typography } from '../../styles/typography'
  */
 export function StarterProvenanceBanner() {
   const [dismissed, setDismissed] = useState(false)
-  const redraftInFlight = useRef(false)
   const { sendMessage } = useConversationContext()
 
   // `resolveStarterId` is the single shape for this question, shared with the
@@ -39,7 +38,7 @@ export function StarterProvenanceBanner() {
   const starterId = useCanvasStore((s) => resolveStarterId(s.nodes))
 
   const handleRedraft = useCallback(() => {
-    if (redraftInFlight.current || !starterId) return
+    if (!starterId) return
     const starter = getStarter(starterId)
     if (!starter) return
 
@@ -56,8 +55,13 @@ export function StarterProvenanceBanner() {
     )
     if (!confirmed) return
 
-    redraftInFlight.current = true
-    try {
+    // NOTE: no re-entrancy guard here, deliberately. There was one; it set a
+    // ref true and cleared it in a `finally` within the SAME synchronous span
+    // (`sendMessage` is async and was never awaited), so the read could never
+    // observe `true`. The double-send it appeared to prevent is prevented
+    // structurally instead: `resetCanvas` empties the graph, `starterId` goes
+    // null, and the early return below unmounts the banner and its button.
+    {
       // Reset FIRST so the canvas is genuinely empty: the composer treats an
       // empty canvas as "draft a model" rather than "chat about this one", and
       // the first-use hero re-engages to show thinking state and — on failure —
@@ -72,8 +76,6 @@ export function StarterProvenanceBanner() {
         debugSource: 'generate_model',
         debugSourceSurface: 'starter_redraft',
       })
-    } finally {
-      redraftInFlight.current = false
     }
   }, [starterId, sendMessage])
 

--- a/src/canvas/components/StarterProvenanceBanner.tsx
+++ b/src/canvas/components/StarterProvenanceBanner.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { BookmarkCheck, X } from 'lucide-react'
 import { useCanvasStore } from '../store'
 import { useConversationContext } from '../conversation/ConversationContext'
-import { getStarter } from '../starters/loadStarter'
+import { getStarter, resolveStarterId } from '../starters/loadStarter'
 import { typography } from '../../styles/typography'
 
 /**
@@ -34,14 +34,9 @@ export function StarterProvenanceBanner() {
   const redraftInFlight = useRef(false)
   const { sendMessage } = useConversationContext()
 
-  // Derive from the graph itself, never from a separate "which starter is
-  // loaded" store slot — a second source of truth would drift the moment the
-  // user drafts over the starter. The stamp lives on the nodes, so it
-  // disappears exactly when the starter graph does.
-  const starterId = useCanvasStore((s) => {
-    const first = s.nodes[0]?.data?.starterId
-    return typeof first === 'string' ? first : null
-  })
+  // `resolveStarterId` is the single shape for this question, shared with the
+  // run gate — see its docstring for why reading nodes[0] alone was wrong.
+  const starterId = useCanvasStore((s) => resolveStarterId(s.nodes))
 
   const handleRedraft = useCallback(() => {
     if (redraftInFlight.current || !starterId) return

--- a/src/canvas/components/__tests__/ModelTabBody.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.spec.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ModelTabBody } from '../ModelTabBody'
 import type { Node, Edge } from '@xyflow/react'
+import { edgeValueSourcePatch } from '../../domain/edgeValueProvenance'
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -101,6 +102,10 @@ function makeEdge(
       strengthStd: opts.strengthStd ?? 0.125,
       provenance: opts.provenance ?? 'assumption',
       direction: opts.direction ?? 'positive',
+      // A characterised edge is a STAMPED edge — the RelationshipsSection card
+      // is provenance-gated, so an unstamped fixture renders "Not set" no
+      // matter what numbers it carries.
+      ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }),
     },
   }
 }
@@ -336,11 +341,11 @@ describe('Golden UI test — headline numbers regression guard', () => {
   // Causal edges (between factors + goal)
   const e1: Edge = {
     id: 'e1', source: 'f1', target: 'g1',
-    data: { weight: 0.8, strengthStd: 0.1, provenance: 'user_study', direction: 'positive', beliefExists: 0.85 },
+    data: { weight: 0.8, strengthStd: 0.1, provenance: 'user_study', direction: 'positive', beliefExists: 0.85, ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }) },
   }
   const e2: Edge = {
     id: 'e2', source: 'f2', target: 'g1',
-    data: { weight: 0.6, strengthStd: 0.15, provenance: 'assumption', direction: 'negative', beliefExists: 0.90 },
+    data: { weight: 0.6, strengthStd: 0.15, provenance: 'assumption', direction: 'negative', beliefExists: 0.90, ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }) },
   }
   // Organisational edges (to/from decision+options — excluded from causal)
   const e3: Edge = { id: 'e3', source: 'd1', target: 'opt_a', data: {} }
@@ -372,7 +377,7 @@ describe('Golden UI test — headline numbers regression guard', () => {
     // Canvas store canonical name — CEE ingestion normalises to beliefExists
     const edgeWithExistsProb: Edge = {
       id: 'e-ep', source: 'f1', target: 'g1',
-      data: { weight: 0.7, strengthStd: 0.1, provenance: 'assumption', direction: 'positive', beliefExists: 0.73 },
+      data: { weight: 0.7, strengthStd: 0.1, provenance: 'assumption', direction: 'positive', beliefExists: 0.73, ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }) },
     }
     render(
       <ModelTabBody
@@ -519,7 +524,7 @@ describe('DS-4: Likelihood bars use evaluative threshold colours', () => {
     const nodes = [makeFactorNode('f1', 'A'), makeFactorNode('f2', 'B')]
     const edges: import('@xyflow/react').Edge[] = [{
       id: 'e1', source: 'f1', target: 'f2',
-      data: { weight: 0.5, strengthStd: 0.1, direction: 'positive', beliefExists: 0.3 },
+      data: { weight: 0.5, strengthStd: 0.1, direction: 'positive', beliefExists: 0.3, ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }) },
     }]
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={nodes} edges={edges} />)
     // Edge cards are collapsed by default — click to expand

--- a/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
+++ b/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
@@ -70,6 +70,42 @@ describe('StarterProvenanceBanner', () => {
       expect(screen.getByTestId('starter-provenance-banner')).toHaveTextContent(/analysis is held/i)
     })
 
+    // ── the two-shapes defect ────────────────────────────────────────────
+    //
+    // `computeCeeCannotSeeModel` (canRunAnalysis.ts) refuses the run when ANY
+    // node carries starter provenance — `nodes.some(...)`. This banner used to
+    // read `nodes[0]?.data?.starterId`, i.e. the FIRST node only. Two shapes
+    // for one question, and they disagree exactly when an unstamped node sits
+    // at index 0: the gate still refuses to analyse, and the banner that
+    // exists to explain the refusal is gone. That is the precise failure this
+    // component's own docstring says it exists to prevent — "a user who does
+    // not know why will read it as the product being broken".
+    it('discloses provenance when a LATER node carries the stamp, matching the run gate', () => {
+      useCanvasStore.setState({
+        nodes: [
+          // A node added after the starter loaded — no stamp.
+          { id: 'n_user', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'My own factor' } },
+          {
+            id: 'n_starter',
+            type: 'factor',
+            position: { x: 0, y: 0 },
+            data: { label: 'From the starter', starterId: 'market-entry', starterTitle: MARKET.title },
+          },
+        ] as never,
+        edges: [] as never,
+      })
+      render(<StarterProvenanceBanner />)
+      expect(screen.getByTestId('starter-provenance-banner')).toHaveTextContent(/saved example/i)
+    })
+
+    it('renders nothing when NO node carries starter provenance', () => {
+      // Positive control for the assertion above: the same query that found the
+      // banner must be able to NOT find it, or "it renders" proves nothing.
+      setNodes({})
+      render(<StarterProvenanceBanner />)
+      expect(screen.queryByTestId('starter-provenance-banner')).toBeNull()
+    })
+
     it('does NOT promise that saving re-enables analysis — the stamp rides a save', () => {
       // An earlier draft of this copy said "drafted or saved into your own
       // decision". Saving does not strip `starterId`, so the gate still

--- a/src/canvas/components/model-tab/RelationshipsSection.tsx
+++ b/src/canvas/components/model-tab/RelationshipsSection.tsx
@@ -38,6 +38,10 @@ import { StrengthBar } from '../../ui/inspector/StrengthBar'
 import { ContestedEdgeCard } from './ContestedEdgeCard'
 import { CoachingCard } from './CoachingCard'
 import type { ValidationMetadata, UserAction } from '../../domain/validation'
+import {
+  resolveEdgeValueDisplay,
+  resolveEdgeSignedStrengthDisplay,
+} from '../../domain/edgeValueProvenance'
 
 /** Repair display entry for edge detail */
 export interface EdgeRepairDisplay {
@@ -135,22 +139,33 @@ function EdgeCard({
   const fromLabel = String((sourceNode?.data as Record<string, unknown>)?.label ?? edge.source)
   const toLabel = String((targetNode?.data as Record<string, unknown>)?.label ?? edge.target)
 
-  // Read raw values — treat absent fields as truly unset (no silent defaults)
-  const rawWeight = data?.weight as number | undefined
+  // PROVENANCE-GATED READ, not a presence check.
+  //
+  // This block used to read `rawWeight !== undefined`. `DEFAULT_EDGE_DATA` and
+  // `USER_EDGE_DEFAULTS` ALWAYS define `weight` and `beliefExists`, so that
+  // test was true for every edge that exists in the product and the "Not set"
+  // branches below were statically unreachable — while the comment here
+  // claimed the opposite. A drawn edge rendered `+0.30`, `Moderate positive`,
+  // `p0.80` and a GREEN 80% "Likelihood" bar, all UI defaults, under a tooltip
+  // attributing the confidence to the user.
+  //
+  // `resolveEdgeValueDisplay` cannot hand back a number without a source, so
+  // the fabrication is no longer expressible here.
+  const strengthDisplay = resolveEdgeSignedStrengthDisplay(data)
+  const likelihoodDisplay = resolveEdgeValueDisplay(data, 'beliefExists')
+
   const rawDirection = data?.direction as string | undefined
   const safeDirection: 'positive' | 'negative' =
     rawDirection === 'negative' ? 'negative' : rawDirection === 'positive' ? 'positive' : 'positive'
   const strengthStd = data?.strengthStd ?? data?.strength_std
 
-  const hasStrength = rawWeight !== undefined
-  const signedMean = hasStrength ? (safeDirection === 'negative' ? -rawWeight! : rawWeight!) : undefined
+  const hasStrength = strengthDisplay.show
+  const rawWeight = strengthDisplay.show ? Math.abs(strengthDisplay.value) : undefined
+  const signedMean = strengthDisplay.show ? strengthDisplay.value : undefined
 
-  // Likelihood — absent means unset, not 70%
-  // Canvas store canonical name — CEE ingestion normalises to beliefExists
-  const rawBelief = data?.beliefExists ?? data?.confidence ?? data?.belief
-  const hasLikelihood = rawBelief !== undefined
-  const beliefExists = hasLikelihood ? (rawBelief as number) : undefined
-  const likelihoodPct = hasLikelihood ? Math.round(beliefExists! * 100) : undefined
+  const hasLikelihood = likelihoodDisplay.show
+  const beliefExists = likelihoodDisplay.show ? likelihoodDisplay.value : undefined
+  const likelihoodPct = likelihoodDisplay.show ? Math.round(likelihoodDisplay.value * 100) : undefined
 
   const likelihoodColour = likelihoodPct === undefined
     ? 'bg-panel-border'

--- a/src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx
@@ -6,6 +6,8 @@ import { describe, it, expect, vi, beforeAll } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { RelationshipsSection } from '../RelationshipsSection'
 import type { Edge, Node } from '@xyflow/react'
+import { USER_EDGE_DEFAULTS } from '../../../domain/edges'
+import { edgeValueSourcePatch } from '../../../domain/edgeValueProvenance'
 
 // jsdom does not implement scrollIntoView
 beforeAll(() => {
@@ -57,6 +59,19 @@ function makeNode(id: string, label: string): Node {
   return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label } }
 }
 
+/**
+ * An edge whose strength and likelihood were actually CHARACTERISED.
+ *
+ * The stamps are not decoration — they are what makes this fixture a model of
+ * a real edge. The card is provenance-gated, so an unstamped edge renders
+ * "Not set" no matter what numbers `data` carries. Before the F1 fix these
+ * tests passed WITHOUT the stamps, which is precisely the bug: the component
+ * could not tell a value somebody set from one that fell through a default,
+ * and the tests inherited that blindness.
+ *
+ * For the unstamped case — a freshly drawn edge — see the
+ * `USER_EDGE_DEFAULTS` describe block below.
+ */
 function makeEdge(id: string, source: string, target: string, opts: {
   weight?: number
   direction?: string
@@ -72,6 +87,7 @@ function makeEdge(id: string, source: string, target: string, opts: {
       direction: opts.direction ?? 'positive',
       beliefExists: opts.beliefExists ?? 0.7,
       provenance: opts.provenance ?? 'assumption',
+      ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }),
     },
   }
 }
@@ -142,6 +158,67 @@ describe('RelationshipsSection', () => {
     expect(screen.getByTestId('edge-e-ul-likelihood-notset')).toHaveTextContent('Not set')
     // No actionable button — no default injection
     expect(screen.queryByTestId('edge-e-ul-likelihood-unset')).not.toBeInTheDocument()
+  })
+
+  // ── F1: the gate that could not fire ──────────────────────────────────
+  //
+  // The two "Not set" tests above build `data` with the field literally
+  // absent. That state does not exist in the product: every edge is
+  // constructed by spreading DEFAULT_EDGE_DATA or USER_EDGE_DEFAULTS, both of
+  // which ALWAYS define `weight` and `beliefExists`. So the old read gate
+  // (`rawWeight !== undefined`) was true for every real edge and the "Not set"
+  // branches were statically unreachable on the canvas — while the comment
+  // above them claimed "treat absent fields as truly unset (no silent
+  // defaults)".
+  //
+  // These tests use the SHAPE THE PRODUCT ACTUALLY BUILDS.
+  describe('a freshly drawn edge (USER_EDGE_DEFAULTS) — nothing was characterised', () => {
+    function drawnEdge(id = 'e-drawn'): Edge {
+      return { id, source: 'f1', target: 'f2', data: { ...USER_EDGE_DEFAULTS } }
+    }
+
+    it('does NOT speak the defaulted strength', () => {
+      render(<RelationshipsSection edges={[drawnEdge()]} nodes={nodes} />)
+      fireEvent.click(screen.getByTestId('edge-card-e-drawn'))
+      expect(screen.getByTestId('edge-e-drawn-strength-notset')).toHaveTextContent('Not set')
+    })
+
+    it('does NOT speak the defaulted likelihood, nor draw the reassuring green bar', () => {
+      render(<RelationshipsSection edges={[drawnEdge()]} nodes={nodes} />)
+      fireEvent.click(screen.getByTestId('edge-card-e-drawn'))
+      expect(screen.getByTestId('edge-e-drawn-likelihood-notset')).toHaveTextContent('Not set')
+      // 0.8 lands in the >= 70 band, so the old code rendered `bg-success`:
+      // a reassuring signal about a relationship nobody has characterised.
+      expect(document.querySelector('.bg-success')).toBeNull()
+    })
+
+    it('does not render a percentage anywhere on the card', () => {
+      render(<RelationshipsSection edges={[drawnEdge()]} nodes={nodes} />)
+      fireEvent.click(screen.getByTestId('edge-card-e-drawn'))
+      expect(screen.getByTestId('edge-card-e-drawn').textContent ?? '').not.toMatch(/\d+%/)
+    })
+
+    it('POSITIVE CONTROL: the same card DOES speak the values once they are stamped', () => {
+      // Without this the assertions above would pass on a component that
+      // rendered "Not set" unconditionally.
+      const stamped: Edge = {
+        id: 'e-stamped',
+        source: 'f1',
+        target: 'f2',
+        data: {
+          ...USER_EDGE_DEFAULTS,
+          weight: 0.8,
+          beliefExists: 0.9,
+          direction: 'positive',
+          ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }),
+        },
+      }
+      render(<RelationshipsSection edges={[stamped]} nodes={nodes} />)
+      fireEvent.click(screen.getByTestId('edge-card-e-stamped'))
+      expect(screen.queryByTestId('edge-e-stamped-strength-notset')).toBeNull()
+      expect(screen.queryByTestId('edge-e-stamped-likelihood-notset')).toBeNull()
+      expect(screen.getByTestId('edge-card-e-stamped').textContent ?? '').toMatch(/90%/)
+    })
   })
 
   it('does not write defaults when rendering missing values', () => {
@@ -215,7 +292,10 @@ describe('RelationshipsSection', () => {
   it('reads beliefExists (canonical store name)', () => {
     const edgeWithBelief: Edge = {
       id: 'e-ep', source: 'f1', target: 'f2',
-      data: { weight: 0.7, direction: 'positive', beliefExists: 0.73, provenance: 'assumption' },
+      data: {
+        weight: 0.7, direction: 'positive', beliefExists: 0.73, provenance: 'assumption',
+        ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }),
+      },
     }
     render(<RelationshipsSection edges={[edgeWithBelief]} nodes={nodes} />)
     // Click to expand card (progressive disclosure)
@@ -252,7 +332,10 @@ describe('RelationshipsSection — expert inline data', () => {
   it('shows σ and p on compact row when expert mode ON', () => {
     const edgeWithStd: Edge = {
       id: 'e1', source: 'f1', target: 'f2',
-      data: { weight: 0.5, direction: 'positive', beliefExists: 0.8, strengthStd: 0.15, provenance: 'assumption' },
+      data: {
+        weight: 0.5, direction: 'positive', beliefExists: 0.8, strengthStd: 0.15, provenance: 'assumption',
+        ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }),
+      },
     }
     render(
       <DetailToggleContext.Provider value={{ showDetail: true }}>
@@ -266,7 +349,10 @@ describe('RelationshipsSection — expert inline data', () => {
   it('hides σ and p on compact row when expert mode OFF', () => {
     const edgeWithStd: Edge = {
       id: 'e1', source: 'f1', target: 'f2',
-      data: { weight: 0.5, direction: 'positive', beliefExists: 0.8, strengthStd: 0.15, provenance: 'assumption' },
+      data: {
+        weight: 0.5, direction: 'positive', beliefExists: 0.8, strengthStd: 0.15, provenance: 'assumption',
+        ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }),
+      },
     }
     render(
       <DetailToggleContext.Provider value={{ showDetail: false }}>

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -17,7 +17,7 @@ import Tooltip from '../../../../components/Tooltip'
 import { typography, typo } from '../../../../styles/typography'
 import { FIELD_FEEDBACK_COPY } from '../constants'
 import { useCanvasStore } from '../../../store'
-import { withObservedStateUpdate } from '../../../utils/observedStateHelpers'
+import { normaliseRawFactorValue, withObservedStateUpdate } from '../../../utils/observedStateHelpers'
 import { PanelIconButton } from '../ui/PanelIconButton'
 import { parseSuccessTarget } from '../hero/parseSuccessTarget'
 import type { EstimateRowModel } from '../types'
@@ -31,7 +31,7 @@ function commitValue(nodeId: string, rawValue: number, cap: number | null): void
   const { nodes, updateNode } = useCanvasStore.getState()
   const node = nodes.find(n => n.id === nodeId)
   if (!node) return
-  const normalised = cap != null && cap > 0 ? rawValue / cap : rawValue
+  const normalised = normaliseRawFactorValue(rawValue, cap)
   updateNode(nodeId, {
     data: withObservedStateUpdate(node.data, {
       raw_value: rawValue,

--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -27,7 +27,7 @@ import { AnalysisSettings } from './AnalysisSettings'
 import { deriveExpertiseGroups } from './hooks/deriveExpertiseGroups'
 import { StickyFooter } from './StickyFooter'
 import { focusNodeById } from '../../utils/focusHelpers'
-import { withObservedStateUpdate } from '../../utils/observedStateHelpers'
+import { normaliseRawFactorValue, withObservedStateUpdate } from '../../utils/observedStateHelpers'
 import { useCanvasStore } from '../../store'
 import { biasSignal, resolveBiasSignal } from '../../shared/biasSignalTitles'
 import type { KnownBiasCode } from '../../shared/biasSignalTitles'
@@ -1185,7 +1185,7 @@ export function PreAnalysisPanel({
     const node = nodes.find(n => n.id === nodeId)
     if (!node) return
 
-    const normalised = cap != null && cap > 0 ? rawValue / cap : rawValue
+    const normalised = normaliseRawFactorValue(rawValue, cap)
     updateNode(nodeId, {
       data: withObservedStateUpdate(node.data, {
         raw_value: rawValue,

--- a/src/canvas/conversation/AddOptionPanel.tsx
+++ b/src/canvas/conversation/AddOptionPanel.tsx
@@ -19,6 +19,7 @@ import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent
 import { typography } from '../../styles/typography'
 import { formatValueWithUnit } from '../utils/formatValueWithUnit'
 import { MAX_ADD_OPTION_INTERVENTIONS } from '../../v5/chipParameters'
+import { ADD_OPTION_REFUSAL_COPY } from './addOptionRequest'
 import type { AddOptionChange, AddOptionFactorTarget } from './addOptionRequest'
 
 export interface AddOptionPanelProps {
@@ -226,13 +227,13 @@ export function AddOptionPanel({
 
         {overCap && (
           <p className={`${typography.panelBody} text-danger mb-3`} data-testid="add-option-over-cap">
-            An option can change at most {MAX_ADD_OPTION_INTERVENTIONS} factors in one go. Untick{' '}
+            {ADD_OPTION_REFUSAL_COPY.overCap(MAX_ADD_OPTION_INTERVENTIONS)} Untick{' '}
             {checkedIds.length - MAX_ADD_OPTION_INTERVENTIONS} of them.
           </p>
         )}
         {invalidIds.length > 0 && (
           <p className={`${typography.panelBody} text-danger mb-3`} data-testid="add-option-invalid">
-            Every factor you tick needs a number.
+            {ADD_OPTION_REFUSAL_COPY.factorNeedsNumber}
           </p>
         )}
         {refusal && (

--- a/src/canvas/conversation/__tests__/addOptionRequest.spec.ts
+++ b/src/canvas/conversation/__tests__/addOptionRequest.spec.ts
@@ -141,6 +141,63 @@ describe('resolveAddOptionTargets', () => {
   it('reports no decision node on an empty canvas', () => {
     expect(resolveAddOptionTargets([]).decisionId).toBeNull()
   })
+
+  // ── the string-typed raw_value defect ────────────────────────────────────
+  //
+  // `ObservedStateData.raw_value` is typed `number | string | null`
+  // (observedStateHelpers.ts:22) and a string genuinely arrives on the wire —
+  // `denormaliseInterventionValue` takes `string | number | null` for exactly
+  // that reason. This builder used to probe it with a bare
+  // `typeof observed.raw_value === 'number'`, so a string raw figure was
+  // discarded and the prefill fell through to `value * cap`.
+  //
+  // For the £70k-cap factor below that is 0.69 × 70000 = 48300 — the user is
+  // shown "48.3" where they typed "49". Rounding error presented as their own
+  // stated figure, in the field they are about to edit.
+  it('honours a STRING raw_value instead of recomputing it from the cap', () => {
+    const graph = [
+      node('dec_x', 'decision', 'Fund the platform rebuild'),
+      node('fac_budget', 'factor', 'Engineering Budget', {
+        value: 0.69,
+        raw_value: '49000',
+        unit: '£',
+        cap: 70000,
+      }),
+    ] as Node[]
+    const budget = resolveAddOptionTargets(graph).factors[0]
+    // 49000, NOT 0.69 × 70000 = 48300.
+    expect(budget.currentRaw).toBe(49000)
+  })
+
+  it('still derives the raw figure from the cap when no raw_value exists at all', () => {
+    const graph = [
+      node('dec_x', 'decision', 'Fund the platform rebuild'),
+      node('fac_budget', 'factor', 'Engineering Budget', { value: 0.69, unit: '£', cap: 70000 }),
+    ] as Node[]
+    expect(resolveAddOptionTargets(graph).factors[0].currentRaw).toBeCloseTo(48300)
+  })
+
+  it('ignores an unparseable raw_value rather than surfacing NaN', () => {
+    const graph = [
+      node('dec_x', 'decision', 'Fund the platform rebuild'),
+      node('fac_budget', 'factor', 'Engineering Budget', {
+        value: 0.69,
+        raw_value: 'about fifty grand',
+        cap: 70000,
+      }),
+    ] as Node[]
+    const currentRaw = resolveAddOptionTargets(graph).factors[0].currentRaw
+    expect(currentRaw).not.toBeNaN()
+    expect(currentRaw).toBeCloseTo(48300)
+  })
+
+  it('carries a string raw_value through even when the factor has no model value', () => {
+    const graph = [
+      node('dec_x', 'decision', 'Fund the platform rebuild'),
+      node('fac_budget', 'factor', 'Engineering Budget', { raw_value: '49000', unit: '£' }),
+    ] as Node[]
+    expect(resolveAddOptionTargets(graph).factors[0].currentRaw).toBe(49000)
+  })
 })
 
 // --- 2b. the raw→model-space rule -------------------------------------------

--- a/src/canvas/conversation/addOptionRequest.ts
+++ b/src/canvas/conversation/addOptionRequest.ts
@@ -53,6 +53,7 @@ import {
   type ChipParametersFailReason,
 } from '../../v5/chipParameters'
 import { getObservedState, normaliseRawFactorValue } from '../utils/observedStateHelpers'
+import { denormaliseInterventionValue, toFiniteNumber } from '../utils/labelUtils'
 import { computeGraphFacts } from '../components/pre-analysis-v3/selectors/graphFacts'
 
 // ---------------------------------------------------------------------------
@@ -174,6 +175,24 @@ function labelOf(node: Node): string {
 }
 
 /**
+ * The raw, real-world figure to prefill for one factor — i.e. what the user
+ * would recognise as the number they typed.
+ *
+ * Flat, not nested: each branch is a complete answer on its own.
+ */
+function resolveCurrentRawFigure(
+  observed: { value?: unknown; raw_value?: unknown },
+  cap: number | undefined,
+): number | null {
+  const modelValue =
+    typeof observed.value === 'number' && Number.isFinite(observed.value) ? observed.value : null
+  // No model-space value to anchor the mapping on: the wire's raw figure is
+  // all there is (and `null` when that is unusable too).
+  if (modelValue === null) return toFiniteNumber(observed.raw_value)
+  return denormaliseInterventionValue(modelValue, cap ?? null, modelValue, toFiniteNumber(observed.raw_value))
+}
+
+/**
  * Derive the add-option targets from the live canvas. DERIVED, never mirrored:
  * `computeGraphFacts` is the repo's single kind-resolver (it handles the
  * `data.kind` vs `type` divergence that the ad-hoc `n.type === 'decision'`
@@ -187,18 +206,15 @@ export function resolveAddOptionTargets(nodes: ReadonlyArray<Node>): AddOptionCa
     const cap = typeof observed.cap === 'number' && Number.isFinite(observed.cap) && observed.cap > 0
       ? observed.cap
       : undefined
-    const rawCandidate = typeof observed.raw_value === 'number' ? observed.raw_value : undefined
-    const modelValue = typeof observed.value === 'number' ? observed.value : undefined
-    // Present whatever the user would type: the raw figure when we have one,
-    // else the raw figure implied by the cap, else the model-space value.
-    const currentRaw =
-      rawCandidate !== undefined && Number.isFinite(rawCandidate)
-        ? rawCandidate
-        : cap !== undefined && modelValue !== undefined && Number.isFinite(modelValue)
-          ? modelValue * cap
-          : modelValue !== undefined && Number.isFinite(modelValue)
-            ? modelValue
-            : null
+    // Present whatever the user would type. `denormaliseInterventionValue` is
+    // the repo's single normalised→raw mapping; anchoring it on the factor's
+    // OWN baseline makes it return the user's stated raw figure verbatim when
+    // one exists and fall back to the cap scale when it does not. Re-deriving
+    // that here as `modelValue * cap` is what made a £70k-cap factor prefill
+    // 48.3 where the user had typed 49: a string-typed `raw_value` (the field
+    // is `number | string | null`) failed a bare `typeof === 'number'` probe
+    // and the honest figure was thrown away for a rounded recomputation.
+    const currentRaw = resolveCurrentRawFigure(observed, cap)
     return {
       id: node.id,
       label: labelOf(node),
@@ -325,6 +341,34 @@ export function buildAddOptionDispatch(input: {
 }
 
 /**
+ * THE single home for add-option refusal copy.
+ *
+ * The same sentences are spoken from two places — this module (refusals raised
+ * while BUILDING the dispatch) and `AddOptionPanel` (the live validation hints
+ * shown while the user is still ticking boxes). They were written out
+ * independently in both files, so the user could be told "Every factor you tick
+ * needs a number." in two subtly different wordings depending on which check
+ * fired first, and a copy edit in one file silently left the other behind.
+ *
+ * Both surfaces now read these constants. There is no third wording to keep in
+ * step, because there is no third copy.
+ */
+export const ADD_OPTION_REFUSAL_COPY = {
+  labelRequired: 'Give the option a name first.',
+  noDecisionNode: 'This model has no decision node yet, so there is nothing to add an option to.',
+  factorNeedsNumber: 'Every factor you tick needs a number.',
+  duplicateFactor: 'The same factor is listed twice.',
+  unknownFactor:
+    'One of the factors you picked is no longer on the canvas, so it was not included. Close this and try again.',
+  /**
+   * The cap sentence takes its max as an argument: the builder reports the cap
+   * the REFUSAL carried, the panel reports the compile-time constant. One
+   * wording, two callers, no drift.
+   */
+  overCap: (max: number) => `An option can change at most ${max} factors in one go.`,
+} as const
+
+/**
  * User-facing text for a refusal. Names WHICH part was refused and WHY, in the
  * product's own vocabulary — never a code, never a generic "something went
  * wrong".
@@ -332,13 +376,13 @@ export function buildAddOptionDispatch(input: {
 export function describeAddOptionRefusal(refusal: AddOptionRefusal): string {
   switch (refusal.kind) {
     case 'label_required':
-      return 'Give the option a name first.'
+      return ADD_OPTION_REFUSAL_COPY.labelRequired
     case 'no_decision_node':
-      return 'This model has no decision node yet, so there is nothing to add an option to.'
+      return ADD_OPTION_REFUSAL_COPY.noDecisionNode
     case 'unknown_factor':
-      return `One of the factors you picked is no longer on the canvas, so it was not included. Close this and try again.`
+      return ADD_OPTION_REFUSAL_COPY.unknownFactor
     case 'too_many_changes':
-      return `An option can change at most ${refusal.max} factors in one go. Remove some and add the rest afterwards.`
+      return `${ADD_OPTION_REFUSAL_COPY.overCap(refusal.max)} Remove some and add the rest afterwards.`
     case 'parameters':
       return describeParametersRefusal(refusal.reason)
   }
@@ -347,16 +391,16 @@ export function describeAddOptionRefusal(refusal: AddOptionRefusal): string {
 function describeParametersRefusal(reason: ChipParametersFailReason): string {
   switch (reason) {
     case 'label_required':
-      return 'Give the option a name first.'
+      return ADD_OPTION_REFUSAL_COPY.labelRequired
     case 'value_not_finite':
     case 'raw_value_not_finite':
-      return 'Every factor you tick needs a number.'
+      return ADD_OPTION_REFUSAL_COPY.factorNeedsNumber
     case 'duplicate_factor':
-      return 'The same factor is listed twice.'
+      return ADD_OPTION_REFUSAL_COPY.duplicateFactor
     case 'too_many_interventions':
-      return `An option can change at most ${MAX_ADD_OPTION_INTERVENTIONS} factors in one go.`
+      return ADD_OPTION_REFUSAL_COPY.overCap(MAX_ADD_OPTION_INTERVENTIONS)
     case 'parent_decision_id_required':
-      return 'This model has no decision node yet, so there is nothing to add an option to.'
+      return ADD_OPTION_REFUSAL_COPY.noDecisionNode
     default:
       // Every remaining reason belongs to a different builder (edge/constraint
       // chips) and is unreachable here; say so honestly rather than invent copy.

--- a/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
+++ b/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
@@ -12,6 +12,8 @@ import {
   edgeValueSource,
   isEdgeValueSet,
   edgeValueSourcePatch,
+  resolveEdgeValueDisplay,
+  resolveEdgeSignedStrengthDisplay,
   EDGE_PROVENANCED_FIELDS,
 } from '../edgeValueProvenance'
 
@@ -115,5 +117,103 @@ describe('EdgeDataSchema — the markers survive a parse', () => {
     const parsed = EdgeDataSchema.parse({ ...USER_EDGE_DEFAULTS })
     expect(parsed.beliefExistsSource).toBeUndefined()
     expect(parsed.weightSource).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveEdgeValueDisplay — the read-side gate
+// ---------------------------------------------------------------------------
+//
+// Paired throughout: every "hidden" assertion sits next to the stamped twin
+// that proves the resolver CAN show a value. Without the positive control the
+// hidden assertions would pass on a resolver that returned `show: false`
+// unconditionally.
+describe('resolveEdgeValueDisplay', () => {
+  it.each(EDGE_PROVENANCED_FIELDS)(
+    'hides %s on a freshly drawn edge — the number is there, the source is not',
+    (field) => {
+      const drawn = { ...USER_EDGE_DEFAULTS } as Record<string, unknown>
+      expect(typeof drawn[field]).toBe('number')
+      expect(resolveEdgeValueDisplay(drawn, field)).toEqual({ show: false, reason: 'not_set' })
+    },
+  )
+
+  it.each(EDGE_PROVENANCED_FIELDS)('POSITIVE CONTROL: shows %s once stamped', (field) => {
+    const stamped = {
+      ...USER_EDGE_DEFAULTS,
+      ...edgeValueSourcePatch({ [field]: 'user' } as never),
+    } as Record<string, unknown>
+    const got = resolveEdgeValueDisplay(stamped, field)
+    expect(got.show).toBe(true)
+    expect(got).toMatchObject({ source: 'user', value: (USER_EDGE_DEFAULTS as Record<string, number>)[field] })
+  })
+
+  it('distinguishes "not set" from "absent" — they are different sentences', () => {
+    expect(resolveEdgeValueDisplay({ weight: 0.3 }, 'weight')).toEqual({ show: false, reason: 'not_set' })
+    expect(resolveEdgeValueDisplay({}, 'weight')).toEqual({ show: false, reason: 'absent' })
+    expect(resolveEdgeValueDisplay(undefined, 'weight')).toEqual({ show: false, reason: 'absent' })
+  })
+
+  it('honours the legacy `belief` field, and back-compat producer evidence', () => {
+    // exists_probability is written ONLY by CEE ingestion, so it proves a producer value
+    // on graphs saved before the marker existed.
+    expect(resolveEdgeValueDisplay({ belief: 0.42, exists_probability: 0.42 }, 'beliefExists')).toEqual({
+      show: true,
+      value: 0.42,
+      source: 'cee',
+    })
+    // ...but a bare legacy number with no evidence stays hidden.
+    expect(resolveEdgeValueDisplay({ belief: 0.42 }, 'beliefExists')).toEqual({
+      show: false,
+      reason: 'not_set',
+    })
+  })
+
+  it('never returns a value without a source (the type-level guarantee, checked at runtime)', () => {
+    const samples: Array<Record<string, unknown>> = [
+      { ...DEFAULT_EDGE_DATA },
+      { ...USER_EDGE_DEFAULTS },
+      { weight: 0.9, direction: 'negative' },
+      { beliefExists: 0.8 },
+      {},
+    ]
+    for (const sample of samples) {
+      for (const field of EDGE_PROVENANCED_FIELDS) {
+        const got = resolveEdgeValueDisplay(sample, field)
+        if (got.show) expect(got.source).toBeTruthy()
+      }
+    }
+  })
+})
+
+describe('resolveEdgeSignedStrengthDisplay', () => {
+  it('hides the signed strength of a freshly drawn edge — the DIRECTION is defaulted too', () => {
+    // USER_EDGE_DEFAULTS pins direction 'positive'. Rendering "Raises" for an
+    // edge nobody characterised is the same fabrication as rendering "30%".
+    expect(resolveEdgeSignedStrengthDisplay({ ...USER_EDGE_DEFAULTS })).toEqual({
+      show: false,
+      reason: 'not_set',
+    })
+  })
+
+  it('POSITIVE CONTROL: shows it once the weight is stamped, and carries the sign', () => {
+    expect(
+      resolveEdgeSignedStrengthDisplay({ weight: 0.4, direction: 'negative', weightSource: 'user' }),
+    ).toEqual({ show: true, value: -0.4, source: 'user' })
+    expect(
+      resolveEdgeSignedStrengthDisplay({ weight: 0.4, direction: 'positive', weightSource: 'cee' }),
+    ).toEqual({ show: true, value: 0.4, source: 'cee' })
+  })
+
+  it('prefers CEE pre-signed strength_mean, which is itself back-compat evidence', () => {
+    expect(resolveEdgeSignedStrengthDisplay({ strength_mean: -0.62, weight: 0.62 })).toEqual({
+      show: true,
+      value: -0.62,
+      source: 'cee',
+    })
+  })
+
+  it('reports absent when there is no number at all', () => {
+    expect(resolveEdgeSignedStrengthDisplay({})).toEqual({ show: false, reason: 'absent' })
   })
 })

--- a/src/canvas/domain/edgeValueProvenance.ts
+++ b/src/canvas/domain/edgeValueProvenance.ts
@@ -105,6 +105,113 @@ export function isEdgeValueSet(
 }
 
 /**
+ * What a DISPLAY surface should render for one edge value.
+ *
+ * WHY A UNION RATHER THAN A PREDICATE
+ * -----------------------------------
+ * `isEdgeValueSet` is a predicate the caller must REMEMBER to consult, and a
+ * tree-wide audit at staging tip `f4719d18c` found exactly two callers in
+ * ~2,700 source files (`EdgePills.tsx:60`, `useNodeConnections.ts:62`). Every
+ * other surface read `weight` / `beliefExists` raw and printed the UI default
+ * as a measurement — "80% confident", a green 80% "Likelihood" bar, and in one
+ * case a sentence sent to CEE asserting a strength nobody set.
+ *
+ * A predicate that ten surfaces forget to call is a hand-maintained mirror
+ * wearing a helmet. So this accessor does not return a number at all unless it
+ * can also name the source: there is NO shape of the return type that carries
+ * a value without its provenance, which makes "render the default as fact" a
+ * thing a surface cannot express by accident. Forgetting to handle
+ * `show: false` is a type error, not a silent fabrication.
+ *
+ * This deliberately mirrors `resolveFactorConfidenceDisplay` in
+ * `src/components/results/driverConfidenceDisplayPolicy.ts` — same problem,
+ * same shape, so the two honesty lanes read alike.
+ *
+ * NOT FOR WIRE PAYLOADS. Adapters (`islRequestAdapter`, `plot/v2/adapter`)
+ * legitimately need a number for every edge and keep using the raw
+ * `computeSignedMean`; changing what goes ON THE WIRE is a numeric-behaviour
+ * decision, explicitly out of scope here. This is the DISPLAY seam only.
+ */
+export type EdgeValueDisplay =
+  | {
+      show: false
+      /**
+       * `not_set` — no source proves this number; it is a UI default.
+       *   Render the "Not set" affordance, never the number.
+       * `absent`  — there is no number here at all.
+       */
+      reason: 'not_set' | 'absent'
+    }
+  | { show: true; value: number; source: EdgeValueSource }
+
+/**
+ * Resolve one edge value for display — THE read-side gate.
+ *
+ * Reads the same dual-field chain the rest of the canvas uses
+ * (`beliefExists` then legacy `belief`) so it cannot disagree with
+ * `getEdgeConfidence` about WHICH number is in play — only about whether that
+ * number is fit to speak.
+ */
+export function resolveEdgeValueDisplay(
+  data: Record<string, unknown> | undefined | null,
+  field: EdgeProvenancedField,
+): EdgeValueDisplay {
+  if (!data) return { show: false, reason: 'absent' }
+
+  const raw =
+    field === 'beliefExists'
+      ? typeof data.beliefExists === 'number'
+        ? data.beliefExists
+        : typeof data.belief === 'number'
+          ? data.belief
+          : undefined
+      : typeof data.weight === 'number'
+        ? data.weight
+        : undefined
+
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return { show: false, reason: 'absent' }
+
+  const source = edgeValueSource(data, field)
+  if (source === null) return { show: false, reason: 'not_set' }
+
+  return { show: true, value: raw, source }
+}
+
+/**
+ * Signed strength for display: magnitude from `weight`, sign from `direction`.
+ *
+ * Gated on `weight`'s provenance, because the DIRECTION defaults too
+ * (`USER_EDGE_DEFAULTS.direction: 'positive'`) — rendering "Raises" for an edge
+ * nobody characterised is the same fabrication as rendering "30%". A caller
+ * that only has a defaulted weight gets `show: false` and must say nothing
+ * about the sign either.
+ *
+ * Prefers CEE's pre-signed `strength_mean` when present, matching
+ * `computeSignedMean`'s priority order.
+ */
+export function resolveEdgeSignedStrengthDisplay(
+  data: Record<string, unknown> | undefined | null,
+): EdgeValueDisplay {
+  if (!data) return { show: false, reason: 'absent' }
+
+  const source = edgeValueSource(data, 'weight')
+  if (source === null) {
+    const hasNumber =
+      typeof data.strength_mean === 'number' || typeof data.weight === 'number'
+    return { show: false, reason: hasNumber ? 'not_set' : 'absent' }
+  }
+
+  if (typeof data.strength_mean === 'number' && Number.isFinite(data.strength_mean)) {
+    return { show: true, value: data.strength_mean, source }
+  }
+  if (typeof data.weight === 'number' && Number.isFinite(data.weight)) {
+    const sign = data.direction === 'negative' || data.effect_direction === 'negative' ? -1 : 1
+    return { show: true, value: sign * data.weight, source }
+  }
+  return { show: false, reason: 'absent' }
+}
+
+/**
  * Build the marker patch for a construction site.
  *
  * Pass `undefined` for a field the wire/user did NOT supply — the key is then

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -27,6 +27,10 @@ import { computeDirectionStroke } from './directionStroke'
 import { resolvePersistentLabelPlacements, type PlacementEdge } from './edgeLabelCollision'
 import { applyEdgeVisualProps } from '../theme/edges'
 import { formatConfidence, shouldShowLabel, getEdgeConfidence, computeSignedMean } from '../domain/edges'
+import {
+  resolveEdgeValueDisplay,
+  resolveEdgeSignedStrengthDisplay,
+} from '../domain/edgeValueProvenance'
 import { useIsDark } from '../hooks/useTheme'
 import { getEdgeLabel } from '../domain/edgeLabels'
 import { useEdgeLabelMode } from '../store/edgeLabelMode'
@@ -972,10 +976,27 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           minWidth: '140px',
           maxWidth: '220px',
         }
-        const signedVal = direction === 'negative' ? -weight : weight
-        const strengthPct = Math.round(Math.abs(signedVal) * 100)
-        const confidencePct = Math.round((beliefExists ?? 0.8) * 100)
-        const dirLabel = signedVal >= 0 ? 'Positive' : 'Negative'
+        // PROVENANCE-GATED. `weight` (:202) and `beliefExists` (:250) both fall
+        // through to UI defaults, and the old `(beliefExists ?? 0.8)` here was a
+        // SECOND literal copy of the fabricated constant — removing the default
+        // from the schema would not have silenced this line.
+        //
+        // The direction is gated with the strength deliberately: `direction`
+        // defaults to 'positive', so "Positive" is itself a fabrication on an
+        // edge nobody characterised.
+        const strengthDisplay = resolveEdgeSignedStrengthDisplay(
+          edgeData as Record<string, unknown> | undefined,
+        )
+        const confidenceDisplay = resolveEdgeValueDisplay(
+          edgeData as Record<string, unknown> | undefined,
+          'beliefExists',
+        )
+        const signedVal = strengthDisplay.show ? strengthDisplay.value : null
+        const strengthPct = signedVal !== null ? Math.round(Math.abs(signedVal) * 100) : null
+        const confidencePct = confidenceDisplay.show
+          ? Math.round(confidenceDisplay.value * 100)
+          : null
+        const dirLabel = signedVal !== null ? (signedVal >= 0 ? 'Positive' : 'Negative') : null
         const causalPopoverStyle: React.CSSProperties = {
           ...popoverStyle,
           pointerEvents: 'all',
@@ -990,24 +1011,39 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
               onMouseEnter={handlePopoverEnter}
               onMouseLeave={handlePopoverLeave}
             >
-              {/* Direction */}
-              <div className={`${typography.edgeLabel} font-bold text-text-body`}>
-                {dirLabel}
-              </div>
-              {/* Confidence */}
-              <div className={`${typography.edgeLabel} text-text-light`}>
-                {confidencePct}% confident
-              </div>
-              {/* Strength bar */}
-              <div className="flex items-center gap-1.5">
-                <div className="flex-1 h-1 bg-panel-border rounded-full overflow-hidden">
-                  <div
-                    className={`h-full rounded-full ${signedVal >= 0 ? 'bg-success' : 'bg-danger'}`}
-                    style={{ width: `${Math.max(4, strengthPct)}%` }}
-                  />
+              {/* Direction — only when the strength that gives it its sign was set */}
+              {dirLabel !== null && (
+                <div className={`${typography.edgeLabel} font-bold text-text-body`}>
+                  {dirLabel}
                 </div>
-                <span className={`${typography.edgeLabel} text-text-light w-7 text-right shrink-0`}>{strengthPct}%</span>
-              </div>
+              )}
+              {/* Confidence */}
+              {confidencePct !== null && (
+                <div className={`${typography.edgeLabel} text-text-light`}>
+                  {confidencePct}% confident
+                </div>
+              )}
+              {/* Strength bar */}
+              {signedVal !== null && strengthPct !== null && (
+                <div className="flex items-center gap-1.5">
+                  <div className="flex-1 h-1 bg-panel-border rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full ${signedVal >= 0 ? 'bg-success' : 'bg-danger'}`}
+                      style={{ width: `${Math.max(4, strengthPct)}%` }}
+                    />
+                  </div>
+                  <span className={`${typography.edgeLabel} text-text-light w-7 text-right shrink-0`}>{strengthPct}%</span>
+                </div>
+              )}
+              {/* Nothing characterised yet — say that, rather than a number */}
+              {dirLabel === null && confidencePct === null && (
+                <div
+                  className={`${typography.edgeLabel} text-text-light`}
+                  data-testid="edge-hover-popover-unset"
+                >
+                  Strength and likelihood not set
+                </div>
+              )}
               {/* Fragile warning with switch probability */}
               {isFragileEdge && (
                 <div className={`${typography.edgeLabel} text-warning flex items-center gap-1`}>
@@ -1017,8 +1053,37 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
               )}
               {/* Coaching chips */}
               <div className="flex flex-col gap-1 mt-2 pt-1.5 border-t border-panel-border">
-                <NodeChip chipId="edge_evidence_supports" actionType={null} label="What evidence supports this?" message={`What evidence supports the ${dirLabel.toLowerCase()} relationship between ${srcTitle} and ${tgtTitle}?`} />
-                <NodeChip chipId="edge_adjust_strength" actionType="adjust_edge_strength" label="Adjust strength" message={`I want to adjust the strength of the relationship between ${srcTitle} and ${tgtTitle}. Current strength is ${strengthPct}%.`} />
+                {/*
+                  * LLM-FACING. These messages are dispatched to CEE verbatim via
+                  * `useGuidanceStore._dispatchAction`, so a fabricated number here
+                  * is asserted to the model as the user's own statement about
+                  * their model — worse than one on screen, because the model
+                  * cannot see the canvas to catch it.
+                  *
+                  * When nothing was set the chips still appear (the user still
+                  * wants to act) but claim nothing: no direction adjective, no
+                  * percentage.
+                  */}
+                <NodeChip
+                  chipId="edge_evidence_supports"
+                  actionType={null}
+                  label="What evidence supports this?"
+                  message={
+                    dirLabel !== null
+                      ? `What evidence supports the ${dirLabel.toLowerCase()} relationship between ${srcTitle} and ${tgtTitle}?`
+                      : `What evidence supports the relationship between ${srcTitle} and ${tgtTitle}?`
+                  }
+                />
+                <NodeChip
+                  chipId="edge_adjust_strength"
+                  actionType="adjust_edge_strength"
+                  label="Adjust strength"
+                  message={
+                    strengthPct !== null
+                      ? `I want to adjust the strength of the relationship between ${srcTitle} and ${tgtTitle}. Current strength is ${strengthPct}%.`
+                      : `I want to set the strength of the relationship between ${srcTitle} and ${tgtTitle}. It has not been set yet.`
+                  }
+                />
               </div>
             </div>
           </EdgeLabelRenderer>

--- a/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent, act } from '@testing-library/react'
 import { StyledEdge } from '../StyledEdge'
+import { useGuidanceStore } from '../../stores/guidanceStore'
 import { Position } from '@xyflow/react'
 
 // ── ReactFlow mocks ──────────────────────────────────────────────────────────
@@ -183,5 +184,109 @@ describe('StyledEdge — hover popover timer cleanup (component-level)', () => {
 
     // After unmount the container should be empty (no popover rendered)
     expect(container.innerHTML).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F2 — the hover popover spoke UI defaults, and sent one to CEE
+// ---------------------------------------------------------------------------
+//
+// Bindings: `weight = edgeData?.weight ?? 0.5` (:202) and the popover's own
+// `(beliefExists ?? 0.8)` (:977) — a SECOND literal copy of the fabricated
+// constant, independent of DEFAULT_EDGE_DATA. Hovering a freshly drawn edge
+// rendered "Positive / 80% confident / 30%".
+//
+// The severe part is the chip. `NodeChip` passes `message` to
+// `useGuidanceStore._dispatchAction`, which is the real turn dispatcher — so
+// "Current strength is 30%." crossed the service boundary and was presented to
+// CEE as the user's own assertion about their model. A fabricated number on
+// screen misleads a person who can see the canvas; a fabricated number in the
+// prompt misleads the model, which cannot.
+describe('StyledEdge hover popover — provenance honesty', () => {
+  const drawnEdge = {
+    ...defaultEdgeProps,
+    // USER_EDGE_DEFAULTS shape: values present, no *Source stamp.
+    data: { weight: 0.3, direction: 'positive' as const, beliefExists: 0.8 },
+  }
+
+  const characterisedEdge = {
+    ...defaultEdgeProps,
+    data: {
+      weight: 0.3,
+      direction: 'positive' as const,
+      beliefExists: 0.8,
+      weightSource: 'user' as const,
+      beliefExistsSource: 'user' as const,
+    },
+  }
+
+  async function hoverAndGetPopover(props: Record<string, unknown>) {
+    const { container } = render(<StyledEdge {...(props as any)} />)
+    const hitPath = container.querySelector('path[stroke="transparent"]')!
+    act(() => {
+      fireEvent.mouseEnter(hitPath)
+      vi.advanceTimersByTime(400)
+    })
+    return container
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useGuidanceStore.setState({ _dispatchAction: null, _sendMessage: null } as never)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('POSITIVE CONTROL: a characterised edge DOES show its numbers', async () => {
+    // Without this, every assertion below would pass on a popover that
+    // rendered nothing at all.
+    const container = await hoverAndGetPopover(characterisedEdge)
+    const popover = container.querySelector('[data-testid="edge-hover-popover"]')
+    expect(popover).not.toBeNull()
+    expect(popover!.textContent ?? '').toMatch(/80% confident/)
+    expect(popover!.textContent ?? '').toMatch(/30%/)
+  })
+
+  it('does NOT speak the defaulted confidence or strength for a drawn edge', async () => {
+    const container = await hoverAndGetPopover(drawnEdge)
+    const popover = container.querySelector('[data-testid="edge-hover-popover"]')
+    expect(popover).not.toBeNull()
+    const text = popover!.textContent ?? ''
+    expect(text).not.toMatch(/80% confident/)
+    expect(text).not.toMatch(/\d+%/)
+  })
+
+  it('does NOT assert a fabricated strength in the message it sends to CEE', async () => {
+    const dispatched: Array<{ message: string }> = []
+    useGuidanceStore.setState({
+      _dispatchAction: (opts: { message: string }) => { dispatched.push(opts) },
+    } as never)
+
+    const container = await hoverAndGetPopover(drawnEdge)
+    const chip = Array.from(container.querySelectorAll('button')).find((b) =>
+      (b.textContent ?? '').includes('Adjust strength'),
+    )
+    expect(chip, 'the Adjust strength chip must still be offered').toBeTruthy()
+    act(() => { fireEvent.click(chip!) })
+
+    expect(dispatched).toHaveLength(1)
+    // The whole point: no number nobody set may cross the wire.
+    expect(dispatched[0].message).not.toMatch(/\d+%/)
+    expect(dispatched[0].message).not.toMatch(/Current strength is/)
+  })
+
+  it('POSITIVE CONTROL: a characterised edge DOES send its real strength', async () => {
+    const dispatched: Array<{ message: string }> = []
+    useGuidanceStore.setState({
+      _dispatchAction: (opts: { message: string }) => { dispatched.push(opts) },
+    } as never)
+
+    const container = await hoverAndGetPopover(characterisedEdge)
+    const chip = Array.from(container.querySelectorAll('button')).find((b) =>
+      (b.textContent ?? '').includes('Adjust strength'),
+    )
+    act(() => { fireEvent.click(chip!) })
+    expect(dispatched[0].message).toMatch(/Current strength is 30%\./)
   })
 })

--- a/src/canvas/starters/__tests__/starters.integrity.spec.ts
+++ b/src/canvas/starters/__tests__/starters.integrity.spec.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { STARTERS, loadStarterPayload, starterBrief } from '../loadStarter'
+import { STARTERS, loadStarterPayload, getStarter } from '../loadStarter'
 
 interface DraftFixture {
   nodes: Array<{ id: string; kind: string; label: string }>
@@ -72,7 +72,13 @@ describe('starter fixtures', () => {
     })
 
     it('carries the verbatim brief the redraft re-sends', () => {
-      const brief = starterBrief(id)
+      // Reads the brief the way the redraft actually reads it
+      // (StarterProvenanceBanner: `getStarter(starterId)` then `starter.brief`).
+      // The retired `starterBrief()` wrapper claimed in its own docstring that
+      // "the redraft affordance re-sends THIS string" — it did not; nothing on
+      // the live path ever called it. Testing the wrapper proved nothing about
+      // the sentence the user actually gets.
+      const brief = getStarter(id)?.brief
       expect(typeof brief).toBe('string')
       // Long enough to be the real enterprise brief, not a shortened one. The
       // probe lane's explicit instruction was NOT to shorten these: a short

--- a/src/canvas/starters/loadStarter.ts
+++ b/src/canvas/starters/loadStarter.ts
@@ -7,8 +7,8 @@
  * expects — vendor selection · market entry · build-vs-buy — at 5/14 = 35.7%
  * (market entry 1/5). The content is good; the single-request delivery is not.
  * Shipping the captured graphs removes that wall from the demo path. The brief
- * that produced each graph ships alongside it so the user can re-draft it live
- * (see `starterBrief`) — the escape hatch, not the default.
+ * that produced each graph ships alongside it (`StarterSummary.brief`) so the
+ * user can re-draft it live — the escape hatch, not the default.
  *
  * PROVENANCE IS NOT OPTIONAL. A starter graph is a SAVED EXAMPLE, not a live
  * computation, and the UI must never imply otherwise. Every node carries
@@ -63,14 +63,26 @@ export function getStarter(id: string): StarterSummary | undefined {
 }
 
 /**
- * The brief that produced a starter, verbatim.
+ * THE predicate for "is this canvas a starter graph", and which starter.
  *
- * The redraft affordance re-sends THIS string. It comes from the same
- * generated manifest as the graph, so "re-draft this example" cannot quietly
- * send a different brief from the one the shown graph was drafted from.
+ * Scans EVERY node, deliberately. `computeCeeCannotSeeModel` (canRunAnalysis)
+ * refuses the run when ANY node carries the stamp, so a disclosure that read
+ * only `nodes[0]` disagreed with the gate the moment an unstamped node sat
+ * first — the run stayed refused while the banner explaining the refusal
+ * vanished. One question, one shape.
+ *
+ * Derived from the graph itself, never from a separate "which starter is
+ * loaded" store slot: the stamp lives on the nodes, so it disappears exactly
+ * when the starter graph does.
  */
-export function starterBrief(id: string): string | undefined {
-  return getStarter(id)?.brief
+export function resolveStarterId(
+  nodes: ReadonlyArray<{ data?: Record<string, unknown> | undefined }>,
+): string | null {
+  for (const node of nodes) {
+    const id = node.data?.starterId
+    if (typeof id === 'string' && id.length > 0) return id
+  }
+  return null
 }
 
 /**

--- a/src/canvas/ui/inspector-v2/InspectorRouter.tsx
+++ b/src/canvas/ui/inspector-v2/InspectorRouter.tsx
@@ -12,7 +12,8 @@ import { TechnicalDisclosure } from './shared/TechnicalDisclosure'
 import { useTechToggle } from './useTechToggle'
 import { useNodeMutations } from './useInspectorMutations'
 import { getTypeLabel, EDGE_TYPE_LABEL } from './inspectorStrings'
-import { getEdgeConfidence } from '../../domain/edges'
+import { resolveEdgeValueDisplay } from '../../domain/edgeValueProvenance'
+import type { EdgeValueSource } from '../../domain/edgeValueProvenance'
 
 // Panel imports — lazy would be premature, these are small
 import { EdgePanel } from './panels/EdgePanel'
@@ -137,8 +138,12 @@ export const InspectorRouter = memo(function InspectorRouter({
     const targetLabel = String(targetNode?.data?.label ?? edge.target)
     const edgeLabel = `${sourceLabel} \u2192 ${targetLabel}`
 
-    // Edge confidence from beliefExists
-    const ep = getEdgeConfidence(edge.data as Record<string, unknown> | undefined)
+    // Edge confidence from beliefExists — PROVENANCE-GATED.
+    // `getEdgeConfidence` returns the raw field, which is `0.8` on any edge the
+    // user merely drew. Rendering that as a "high · 80%" badge presents a UI
+    // default as a measurement.
+    const epDisplay = resolveEdgeValueDisplay(edge.data as Record<string, unknown> | undefined, 'beliefExists')
+    const ep = epDisplay.show ? epDisplay.value : null
     const edgeConfidenceLevel = ep !== null ? (ep >= 0.7 ? 'high' as const : ep >= 0.4 ? 'medium' as const : 'low' as const) : undefined
     const confidencePct = ep !== null ? Math.round(ep * 100) : undefined
 
@@ -193,9 +198,16 @@ export const InspectorRouter = memo(function InspectorRouter({
     // Derive from inbound edge confidence average
     const inboundEdges = edges.filter(e => e.target === nodeId)
     if (inboundEdges.length > 0) {
+      // PROVENANCE-GATED, and this one is worse than the edge case: an
+      // AVERAGE reads as far more evidentiary than a single field. On a freshly
+      // drawn graph every inbound edge returned the same `0.8`, so the goal
+      // node showed "high · 80%" — a synthetic aggregate of a constant.
+      // Unset edges are EXCLUDED from the mean rather than counted as 0.8; when
+      // none of the inbound edges was characterised there is no badge at all.
       const confidences = inboundEdges
-        .map(e => getEdgeConfidence(e.data as Record<string, unknown> | undefined))
-        .filter((v): v is number => v !== null)
+        .map(e => resolveEdgeValueDisplay(e.data as Record<string, unknown> | undefined, 'beliefExists'))
+        .filter((d): d is { show: true; value: number; source: EdgeValueSource } => d.show)
+        .map(d => d.value)
       if (confidences.length > 0) {
         const avg = confidences.reduce((a, b) => a + b, 0) / confidences.length
         const level = (avg >= 0.7 ? 'high' : avg >= 0.4 ? 'medium' : 'low') as const

--- a/src/canvas/ui/inspector-v2/__tests__/InspectorRouter.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InspectorRouter.spec.tsx
@@ -249,3 +249,83 @@ describe('InspectorRouter', () => {
     expect(valueInput!.value).toBe('1000')
   })
 })
+
+// ---------------------------------------------------------------------------
+// F3 — the ConfidenceBadge spoke the UI default, and AVERAGED it
+// ---------------------------------------------------------------------------
+//
+// This path is live: `InspectorModal.tsx:16` is `const USE_INSPECTOR_V2 = true`.
+// `getEdgeConfidence` returns `beliefExists` raw — `0.8` on an edge the user
+// merely drew — so clicking a fresh edge showed a "high · 80%" badge.
+//
+// The node case is worse: the badge is the MEAN of inbound edge confidence, so
+// on a freshly drawn graph every inbound edge contributed the same 0.8 and the
+// goal node showed "high · 80%" — a synthetic aggregate of a constant. An
+// aggregate reads as far more evidentiary than a single field.
+describe('InspectorRouter — confidence badges are provenance-gated', () => {
+  const onClose = vi.fn()
+  const drawn = { weight: 0.3, direction: 'positive', beliefExists: 0.8 }
+  const characterised = { ...drawn, beliefExists: 0.8, beliefExistsSource: 'user' }
+
+  function graph(edgeData: Record<string, unknown>) {
+    return {
+      nodes: [
+        { id: 'f1', type: 'factor', data: { label: 'Price', kind: 'factor' }, position: { x: 0, y: 0 } },
+        { id: 'g1', type: 'goal', data: { label: 'Revenue target', kind: 'goal' }, position: { x: 0, y: 0 } },
+      ],
+      edges: [{ id: 'e1', source: 'f1', target: 'g1', data: edgeData }],
+    }
+  }
+
+  it('POSITIVE CONTROL: a characterised edge DOES show its confidence badge', () => {
+    const g = graph(characterised)
+    setStoreState(g.nodes, g.edges)
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={onClose} />)
+    expect(screen.getByTestId('inspector-confidence-badge').textContent ?? '').toMatch(/80%/)
+  })
+
+  it('shows NO confidence badge for an edge nobody characterised', () => {
+    const g = graph(drawn)
+    setStoreState(g.nodes, g.edges)
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={onClose} />)
+    // Scoped to the header BADGE — the F3 finding. The panel body's
+    // "Does this connection exist?" slider is a separate ungated surface,
+    // recorded as a new finding rather than silently folded in here.
+    expect(screen.queryByTestId('inspector-confidence-badge')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: the goal node DOES average characterised inbound edges', () => {
+    const g = graph(characterised)
+    setStoreState(g.nodes, g.edges)
+    render(<InspectorRouter nodeId="g1" edgeId={null} onClose={onClose} />)
+    expect(screen.getByTestId('inspector-confidence-badge').textContent ?? '').toMatch(/80%/)
+  })
+
+  it('does NOT synthesise a node-level aggregate out of defaulted edges', () => {
+    const g = graph(drawn)
+    setStoreState(g.nodes, g.edges)
+    render(<InspectorRouter nodeId="g1" edgeId={null} onClose={onClose} />)
+    expect(screen.queryByTestId('inspector-confidence-badge')).toBeNull()
+  })
+
+  it('averages ONLY the characterised edges, never counting a default as 0.8', () => {
+    setStoreState(
+      [
+        { id: 'f1', type: 'factor', data: { label: 'Price', kind: 'factor' }, position: { x: 0, y: 0 } },
+        { id: 'f2', type: 'factor', data: { label: 'Demand', kind: 'factor' }, position: { x: 0, y: 0 } },
+        { id: 'g1', type: 'goal', data: { label: 'Revenue target', kind: 'goal' }, position: { x: 0, y: 0 } },
+      ],
+      [
+        { id: 'e1', source: 'f1', target: 'g1', data: { beliefExists: 0.4, beliefExistsSource: 'user' } },
+        // Unstamped: must be EXCLUDED from the mean, not folded in as 0.8.
+        { id: 'e2', source: 'f2', target: 'g1', data: { beliefExists: 0.8 } },
+      ],
+    )
+    render(<InspectorRouter nodeId="g1" edgeId={null} onClose={onClose} />)
+    const text = screen.getByTestId('inspector-confidence-badge').textContent ?? ''
+    // Mean of the one characterised edge = 0.4 → 40%. Folding the default in
+    // would give (0.4 + 0.8) / 2 = 0.6 → 60%.
+    expect(text).toMatch(/40%/)
+    expect(text).not.toMatch(/60%/)
+  })
+})

--- a/src/canvas/ui/inspector-v2/shared/ConfidenceBadge.tsx
+++ b/src/canvas/ui/inspector-v2/shared/ConfidenceBadge.tsx
@@ -22,6 +22,7 @@ export function ConfidenceBadge({ level, value }: ConfidenceBadgeProps) {
 
   return (
     <span
+      data-testid="inspector-confidence-badge"
       className={`${typography.panelMeta} inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-transparent`}
       style={{ border: `1.5px ${cfg.borderStyle} ${cfg.borderColor}` }}
     >

--- a/src/canvas/utils/__tests__/observedStateHelpers.spec.ts
+++ b/src/canvas/utils/__tests__/observedStateHelpers.spec.ts
@@ -1,5 +1,72 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
 import { describe, it, expect } from 'vitest'
 import { isFactorNeedsInput } from '../observedStateHelpers'
+
+const REPO_ROOT = resolve(__dirname, '../../../..')
+
+/** Every tracked .ts/.tsx under src/, DERIVED from git — never a hand-listed set. */
+function trackedSourceFiles(): string[] {
+  return execFileSync('git', ['ls-files', 'src/**/*.ts', 'src/**/*.tsx'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter(Boolean)
+}
+
+// ---------------------------------------------------------------------------
+// Convergence guard for normaliseRawFactorValue
+// ---------------------------------------------------------------------------
+//
+// The rule `cap != null && cap > 0 ? rawValue / cap : rawValue` was inlined in
+// three components (OutputsDock, PreAnalysisPanel, CalibrateDrillIn) while
+// `normaliseRawFactorValue` sat in observedStateHelpers as the supposed single
+// home. Its docstring tried to track the copies BY NAME and had already gone
+// stale — it listed two of the three, and the one it missed was the triage
+// path. That is the hand-maintained-mirror defect: a list a human must
+// remember to sync, whose drift always reads as green.
+//
+// So the list is gone and this guard replaces it. It DERIVES the file set from
+// `git ls-files` and FAILS LOUD the moment the rule is re-inlined anywhere,
+// including in a file that does not exist today.
+describe('normaliseRawFactorValue is the single home for the raw→model-space rule', () => {
+  // The literal spelling the three converged copies used. Matching on the
+  // source text is the point: this is a copy-paste guard, not a type check.
+  const INLINE_RULE = /cap\s*!=\s*null\s*&&\s*cap\s*>\s*0\s*\?[^\n]*\/\s*cap/
+
+  it('POSITIVE CONTROL: the scan can see a rule that IS present', () => {
+    // Prove the harness reads real bytes and the pattern can match, otherwise
+    // the absence assertion below is vacuous. `normaliseRawFactorValue`'s own
+    // body is the one legitimate occurrence of the division.
+    const files = trackedSourceFiles()
+    expect(files.length).toBeGreaterThan(100)
+
+    const helper = readFileSync(resolve(REPO_ROOT, 'src/canvas/utils/observedStateHelpers.ts'), 'utf8')
+    expect(helper).toMatch(/return rawValue \/ cap/)
+    // ...and the pattern itself matches a known-positive sample.
+    expect('const n = cap != null && cap > 0 ? rawValue / cap : rawValue').toMatch(INLINE_RULE)
+  })
+
+  it('finds NO re-inlined copy anywhere in src/', () => {
+    const offenders = trackedSourceFiles().filter((file) => {
+      // The canonical implementation is allowed to contain the division.
+      if (file === 'src/canvas/utils/observedStateHelpers.ts') return false
+      // This guard necessarily quotes the pattern it hunts.
+      if (file === 'src/canvas/utils/__tests__/observedStateHelpers.spec.ts') return false
+      return INLINE_RULE.test(readFileSync(resolve(REPO_ROOT, file), 'utf8'))
+    })
+
+    expect(
+      offenders,
+      `These files re-inline the raw→model-space rule instead of calling `
+        + `normaliseRawFactorValue(rawValue, cap) from src/canvas/utils/observedStateHelpers.ts. `
+        + `Import the helper — a second copy is how the cap guard drifts.`,
+    ).toEqual([])
+  })
+})
 
 describe('isFactorNeedsInput', () => {
   it('returns true when value, raw_value and display_value are all null', () => {

--- a/src/canvas/utils/labelUtils.ts
+++ b/src/canvas/utils/labelUtils.ts
@@ -383,7 +383,14 @@ function sanitiseUnit(unit: string | undefined): string | undefined {
   return isSuppressedUnit(unit) ? undefined : unit
 }
 
-function toFiniteNumber(value: unknown): number | null {
+/**
+ * Coerce a wire value to a finite number, or `null`.
+ *
+ * Exported because `observed_state.raw_value` is typed `number | string | null`
+ * and every consumer that probes it with a bare `typeof x === 'number'`
+ * silently discards the string form — the defect this helper exists to stop.
+ */
+export function toFiniteNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value
   if (typeof value === 'string' && value.trim() !== '') {
     const parsed = Number(value)

--- a/src/canvas/utils/observedStateHelpers.ts
+++ b/src/canvas/utils/observedStateHelpers.ts
@@ -115,12 +115,15 @@ export function isFactorNeedsInput(nodeData: unknown): boolean {
  * Convert a raw, real-world factor figure into the normalised model-space
  * `value` the engine consumes.
  *
- * This is the rule every value-edit path in the UI already applies —
- * PreAnalysisPanel.handleInlineEditValue and CalibrateDrillIn.commitValue both
- * inline `cap != null && cap > 0 ? rawValue / cap : rawValue`. It is factored
- * out here (the canonical home for observed-state logic) so new callers derive
- * the rule instead of re-typing it. The two existing inline copies are
- * unchanged by this commit and are tracked for convergence.
+ * This is the rule every value-edit path in the UI applies, and this is its
+ * ONLY implementation — call it, never re-type it.
+ *
+ * Deliberately NOT documented here: a list of the call sites. The previous
+ * version of this docstring kept one, it drifted (it named two of the three
+ * inline copies and missed the triage path in OutputsDock), and the drift read
+ * as green because nothing checked it. The convergence is enforced instead by
+ * a guard in `__tests__/observedStateHelpers.spec.ts` that derives the file set
+ * from `git ls-files` and fails loud when the rule is re-inlined anywhere.
  *
  * A missing, non-finite or non-positive cap means "no honest scale exists", in
  * which case the typed number IS the model-space value — the same fallback the

--- a/src/components/results/modals/__tests__/HowComputedModal.spec.tsx
+++ b/src/components/results/modals/__tests__/HowComputedModal.spec.tsx
@@ -41,7 +41,9 @@ function expectFactNotReported(testId: string) {
 }
 
 beforeEach(() => {
-  useHowComputedStore.getState()._reset()
+  // `_reset` was a byte-identical alias of `close` with zero production
+  // callers — one name per behaviour.
+  useHowComputedStore.getState().close()
 })
 
 describe('HowComputedCard — real capture 2026-04-05 (partial provenance)', () => {

--- a/src/components/results/modals/__tests__/buildMethodCard.spec.ts
+++ b/src/components/results/modals/__tests__/buildMethodCard.spec.ts
@@ -49,7 +49,7 @@ describe('buildMethodCard — real capture, 2026-04-05 (no confidence provenance
   it('reports the robustness bands as provisional, per the producer stamp', () => {
     expect(model.stabilityThresholds).toEqual({
       known: true,
-      value: { isProvisional: true, version: 'v1.0-operational-defaults' },
+      value: { isProvisional: true },
     })
   })
 
@@ -72,7 +72,7 @@ describe('buildMethodCard — real capture, 2026-05-10 (POSITIVE CONTROL: proven
   it('surfaces the producer provisional stamp rather than claiming calibration', () => {
     expect(model.confidenceCalibration).toEqual({
       known: true,
-      value: { isProvisional: true, status: 'provisional_pending_pilot_calibration' },
+      value: { isProvisional: true },
     })
   })
 
@@ -160,7 +160,7 @@ describe('buildMethodCard — fabrication guards', () => {
     })
     expect(model.confidenceCalibration).toEqual({
       known: true,
-      value: { isProvisional: true, status: 'calibrated' },
+      value: { isProvisional: true },
     })
   })
 

--- a/src/components/results/modals/buildMethodCard.ts
+++ b/src/components/results/modals/buildMethodCard.ts
@@ -58,15 +58,11 @@ function known<T>(value: T): Provenanced<T> {
 export interface ConfidenceCalibration {
   /** True when the producer stamped the confidence figure provisional. */
   isProvisional: boolean
-  /** Producer's calibration status string, when it sent one. */
-  status: string | null
 }
 
 export interface StabilityThresholds {
   /** True when the producer stamped its stability bands provisional. */
   isProvisional: boolean
-  /** Producer's threshold-set version, when it sent one. */
-  version: string | null
 }
 
 export interface MethodCardModel {
@@ -153,7 +149,6 @@ export function buildMethodCard(rawV2Response: unknown): MethodCardModel {
       ? UNKNOWN
       : known({
           isProvisional: provenances.some((p) => p.is_provisional === true),
-          status: provenances[0].calibration_status,
         })
 
   // ── Stability thresholds ──────────────────────────────────────────────
@@ -163,7 +158,6 @@ export function buildMethodCard(rawV2Response: unknown): MethodCardModel {
       ? UNKNOWN
       : known({
           isProvisional: rawThresholds.provisional,
-          version: typeof rawThresholds.version === 'string' ? rawThresholds.version : null,
         })
 
   // ── Auto-noise ────────────────────────────────────────────────────────

--- a/src/components/results/modals/howComputedStore.ts
+++ b/src/components/results/modals/howComputedStore.ts
@@ -13,15 +13,12 @@ export interface HowComputedState {
   isOpen: boolean
   open: () => void
   close: () => void
-  /** Test/reset seam. */
-  _reset: () => void
 }
 
 export const useHowComputedStore = create<HowComputedState>((set) => ({
   isOpen: false,
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
-  _reset: () => set({ isOpen: false }),
 }))
 
 /**

--- a/tsconfig.tooling.json
+++ b/tsconfig.tooling.json
@@ -44,7 +44,6 @@
     "archive",
     "storybook-static",
     "**/* 2.ts",
-    "**/* 2.tsx",
-    "tests/p2-1-stream-canary.test.ts"
+    "**/* 2.tsx"
   ]
 }


### PR DESCRIPTION
Base: `staging` @ `f4719d18c`. Verified in a fresh blobless clone, never the local tree (trap 1).

## Task A — the calibration-derived confidence gate: **STOP, not built**

Verdict: the premise is half true, and the half that fails is load-bearing.

`confidence_provenance.calibration_status` **does exist and is populated on the live wire** — the pin is not the problem. But **PLoT's producer type is single-valued**: `plot-lite-service` `staging` @ `1dd45b6af`, `src/types/engine-v3.ts:1813`

```ts
export type ConfidenceCalibrationStatus = 'provisional_pending_pilot_calibration';
```

hardcoded as a literal at both emission sites (`lib/factor-influence.ts:190` inside `buildConfidenceProvenance`, the sole constructor; `routes/v2/run.ts:861`). There is **no value meaning "calibrated" anywhere in the producer**.

So a derived gate would have to hardcode a *guess* at a vocabulary PLoT has not written — a hand-maintained mirror of something that does not exist (trap 12), behind a construct that *reads* as self-updating. It would be permanently closed while looking derived: strictly worse than today's honest boolean. "Fail loud on unknown status" does not rescue it — every value on the live wire is the unknown-to-a-calibrated-gate value, and a tripwire that fires on 100% of traffic is not a tripwire.

**No UI change made.** The precondition is producer-side. Full evidence: `parallel-briefs/UI-QUALITY-QUEUE-2026-07-25.md`.

## What this PR does

Four commits. Behavioural fixes and deletions are separated.

1. **Four convergences** — the £70k prefill (48.3 → 49, string-typed `raw_value` discarded by a bare `typeof` probe), starter-provenance shape (`nodes[0]` vs `nodes.some`), three inline copies of `normaliseRawFactorValue`, and refusal copy duplicated across two files.
2. **One read-side accessor for edge values (F1, F2)** — `resolveEdgeValueDisplay` returns a discriminated union, so no shape of the return type carries a number without naming its source. Includes the CEE-bound fabricated strength.
3. **Inspector confidence badges (F3)** — including the node badge that averaged the default across inbound edges.
4. **Five verified deletions + `ci.yml` typecheck self-test parity.**

## Evidence

- **RED-first** on all five behavioural fixes; every absence assertion paired with a **positive control** on the same surface.
- **Six mutation checks, all RED**, in a throwaway worktree (trap 9). A GREEN would have meant the test does not bite.
- `pnpm run typecheck` (the repo's authoritative gate) **PASSED** — coverage 2996/3014, ratchet within baseline.

## Two queued items REJECTED as false positives

- `describeParametersRefusal` "unreachable" — it is not; existing tests at `addOptionRequest.spec.ts:305-340` already enter the branch.
- `blueprintEventBus` — the observation is right in `FirstUseComposer` but both prescribed remedies are wrong; it is a deliberate host-capability gate with a pinning test.

## New finding, recorded not folded in

The edge panel's "Does this connection exist?" slider renders the defaulted `80%` under *"This value was generated automatically"* (`coachingConfig.ts:15`). Nothing generated it. Separate surface from F3's badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)