### PR TITLE
fix(v5): users were reading raw wire ids — plus a harness that makes CEE's rendering claims self-checking

### DIFF
--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -67,6 +67,7 @@ jobs:
           sparse-checkout: |
             contracts/
             schemas/
+            tests/contract/
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/contracts/cee/field-coverage.allowlist.json
+++ b/contracts/cee/field-coverage.allowlist.json
@@ -1,0 +1,49 @@
+{
+  "_doc": "Field-coverage audit (v1). Each non-audited category is an object map: key = JSON path actually present in tests/fixtures/cross-service/, value = per-path justification. NO wildcards. See tests/contract/field-coverage-audit.test.ts and Docs/v5/cross-boundary-contract-test-report.md.",
+  "audited_fields": [
+    "coaching",
+    "strengthen_items",
+    "widening_log",
+    "bias_signals",
+    "provenance",
+    "provenance_display",
+    "suggested_actions",
+    "assistant_text",
+    "analysis_ready",
+    "blocks"
+  ],
+  "diagnostic_allowed": {
+    "answer_source": "Handler-internal flag distinguishing Sonnet-emitted text from deterministic-fallback prose; consumed only by telemetry. Never user-facing.",
+    "fallback_reason": "Handler-internal explanation for why a deterministic fallback was chosen; consumed only by telemetry. Never user-facing.",
+    "_meta.input_shape_version": "Decision-review enricher version stamp (DecisionReviewMeta.input_shape_version); consumed by decision_review prompt v12 for adapter-side diagnostics. Never user-facing.",
+    "_meta.flip_threshold_count": "Diagnostic count of populated flip_threshold_data entries; consumed by decision_review prompt v12 for routing decisions. Never user-facing.",
+    "_meta.factor_sensitivity_count": "Diagnostic count of populated isl_results.factor_sensitivity entries. Never user-facing.",
+    "_meta.fragile_edge_count": "Diagnostic count of populated isl_results.fragile_edges entries. Never user-facing.",
+    "_meta.model_critique_count": "Diagnostic count of model_critiques carried by deterministic_coaching (0 until M1 ships). Never user-facing.",
+    "_meta.has_deterministic_coaching": "Diagnostic flag indicating whether deterministic_coaching is the M1 fully-derived shape. Never user-facing.",
+    "_meta.margin": "Winner.win_probability minus runner_up.win_probability. Adapter-side raw signal for prompt routing; not user-facing (the rendered prose owns the human-readable margin description).",
+    "_meta.robustness_level": "Robustness.level pulled defensively from the V2 envelope. Adapter-side raw signal; not user-facing.",
+    "trace.request_id": "Per-request correlation identifier echoed back to the caller for log correlation. Machine routing, not user-facing prose.",
+    "trace.correlation_id": "Distributed-tracing correlation ID. Machine routing, not user-facing prose.",
+    "trace.engine": "LLM engine metadata subtree (provider/model/version) used for telemetry and admin audit dashboards. Never user-facing.",
+    "trace.pipeline": "Stage-by-stage CEE pipeline diagnostics subtree (provenance, llm_metadata, repair, stage_snapshots, validation_summary, threshold_sweep, etc.). Consumed by admin debug panel and telemetry; never user-facing.",
+    "trace.repair_summary": "Top-level repair-stage diagnostic mirror (graph_delta, repair counts, bucket_summary). Consumed by debug bundles; never user-facing.",
+    "trace.transform_defaults": "Defaults applied during V3 transform (defaulted_edge_count, applied defaults). Diagnostic only; never user-facing."
+  },
+  "machine_routing_allowed": {
+    "action_type": "Suggested-action discriminant (run_analysis, set_factor_value, etc.). The UI dispatches on this value to route chip clicks; not rendered as text.",
+    "id": "Stable identifier on chips, insights, blocks, nodes, edges, options. Machine reference for click-handling and graph manipulation; never rendered as text.",
+    "error_code": "Wire-level failure type literal on error blocks (UPSTREAM_TIMEOUT, etc.). UI parser dispatches on this; never rendered raw to users.",
+    "request_id": "Same as trace.request_id at the top level — caller-supplied request correlation ID. Machine routing only.",
+    "correlation_id": "Distributed tracing correlation ID at the top level. Machine routing only."
+  },
+  "structured_pointer_allowed": {
+    "bias_signals[].target": "Node-ID pointer the UI uses to highlight the referenced node in the canvas. detail (sibling) is the user-facing prose; target stays unscrubbed so the link is preserved (sanitiseCoachingForDisplay at src/cee/unified-pipeline/stages/package.ts:125).",
+    "referenced_option_ids": "Array of option IDs cited inside an explanation block (`OlumiResponseSchema.blocks[].referenced_option_ids`). UI uses these to cross-link the message to canvas option nodes; never rendered as text.",
+    "node_id": "Pointer field inside coaching.widening_log[] entries (mapped to camelCase nodeId in the UI store). Identifies which canvas node the widening reason describes; never rendered as text.",
+    "edge_id": "Pointer field inside isl_results.fragile_edges[] entries (decision-review enrichment). Identifies which causal edge is fragile; never rendered as text.",
+    "factor_id": "Pointer field inside flip_threshold_data[] and isl_results.factor_sensitivity[] entries. Identifies which factor the entry describes; from_label / factor_label are the rendered text.",
+    "option_id": "Pointer field inside comparison block options[] entries. Identifies which option each entry describes; the sibling label is the rendered text."
+  },
+  "currently_unrendered_but_intentional": {}
+}

--- a/contracts/cee/field-coverage.allowlist.json
+++ b/contracts/cee/field-coverage.allowlist.json
@@ -1,5 +1,9 @@
 {
-  "_doc": "Field-coverage audit (v1). Each non-audited category is an object map: key = JSON path actually present in tests/fixtures/cross-service/, value = per-path justification. NO wildcards. See tests/contract/field-coverage-audit.test.ts and Docs/v5/cross-boundary-contract-test-report.md.",
+  "_doc": "Field-coverage audit (v2). Each non-audited category is an object map: key = a FULLY-ANCHORED JSON path, value = { wire, why, ... }. NO wildcards, NO bare leaf names. `wire` is the ONLY place a serialisation claim may live and it is MACHINE-CHECKED against a code-derived client surface by tests/contract/field-coverage-allowlist-wire-claims.test.ts — prose in `why` may not restate it (the word 'user-facing' is banned: it conflated 'not on the wire' with 'not rendered', which is how v1 shipped a false claim about trace.repair_summary). See also tests/contract/field-coverage-audit.test.ts and Docs/v5/cross-boundary-contract-test-report.md.",
+  "_wire_values": {
+    "serialized": "The path IS present in a client response body at include_debug=false (V3 draft-graph HTTP body + SSE COMPLETE payload, and/or the V5 turn envelope). Whether the UI RENDERS it is a separate claim, owned by DecisionGuideAI, and is what `why` describes.",
+    "internal": "The path is NEVER present in a client response body. Requires `emitted_by` naming the producing source file, and any same-named leaf that IS serialized elsewhere must be declared in `wire_homonyms`."
+  },
   "audited_fields": [
     "coaching",
     "strengthen_items",
@@ -13,37 +17,154 @@
     "blocks"
   ],
   "diagnostic_allowed": {
-    "answer_source": "Handler-internal flag distinguishing Sonnet-emitted text from deterministic-fallback prose; consumed only by telemetry. Never user-facing.",
-    "fallback_reason": "Handler-internal explanation for why a deterministic fallback was chosen; consumed only by telemetry. Never user-facing.",
-    "_meta.input_shape_version": "Decision-review enricher version stamp (DecisionReviewMeta.input_shape_version); consumed by decision_review prompt v12 for adapter-side diagnostics. Never user-facing.",
-    "_meta.flip_threshold_count": "Diagnostic count of populated flip_threshold_data entries; consumed by decision_review prompt v12 for routing decisions. Never user-facing.",
-    "_meta.factor_sensitivity_count": "Diagnostic count of populated isl_results.factor_sensitivity entries. Never user-facing.",
-    "_meta.fragile_edge_count": "Diagnostic count of populated isl_results.fragile_edges entries. Never user-facing.",
-    "_meta.model_critique_count": "Diagnostic count of model_critiques carried by deterministic_coaching (0 until M1 ships). Never user-facing.",
-    "_meta.has_deterministic_coaching": "Diagnostic flag indicating whether deterministic_coaching is the M1 fully-derived shape. Never user-facing.",
-    "_meta.margin": "Winner.win_probability minus runner_up.win_probability. Adapter-side raw signal for prompt routing; not user-facing (the rendered prose owns the human-readable margin description).",
-    "_meta.robustness_level": "Robustness.level pulled defensively from the V2 envelope. Adapter-side raw signal; not user-facing.",
-    "trace.request_id": "Per-request correlation identifier echoed back to the caller for log correlation. Machine routing, not user-facing prose.",
-    "trace.correlation_id": "Distributed-tracing correlation ID. Machine routing, not user-facing prose.",
-    "trace.engine": "LLM engine metadata subtree (provider/model/version) used for telemetry and admin audit dashboards. Never user-facing.",
-    "trace.pipeline": "Stage-by-stage CEE pipeline diagnostics subtree (provenance, llm_metadata, repair, stage_snapshots, validation_summary, threshold_sweep, etc.). Consumed by admin debug panel and telemetry; never user-facing.",
-    "trace.repair_summary": "Top-level repair-stage diagnostic mirror (graph_delta, repair counts, bucket_summary). Consumed by debug bundles; never user-facing.",
-    "trace.transform_defaults": "Defaults applied during V3 transform (defaulted_edge_count, applied defaults). Diagnostic only; never user-facing."
+    "answer_source": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/tools/handlers/explain-results.ts",
+      "why": "Handler-fact flag distinguishing Sonnet-emitted text from deterministic-fallback prose. Lives on ExplainResultsHandlerFact, which is persisted to v5_handler_facts and read by telemetry; the strict OlumiResponseSchema has no facts key."
+    },
+    "fallback_reason": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/tools/handlers/explain-results.ts",
+      "wire_homonyms": ["_pipeline_outcome.llm_repair.fallback_reason"],
+      "why": "Handler-fact explanation for why a deterministic fallback was chosen; same carrier as answer_source. NOTE the declared homonym: the UNRELATED llm-repair fallback_reason under _pipeline_outcome IS serialized (attached at src/cee/unified-pipeline/index.ts:533). Two different fields share this leaf name — that collision is why bare leaf keys are no longer permitted."
+    },
+    "_meta.input_shape_version": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Decision-review enricher version stamp (DecisionReviewMeta.input_shape_version), read by decision_review prompt v12 for adapter-side diagnostics. `_meta` is an INTERNAL_ENRICHMENT_KEYS carrier stripped at any depth by stripInternalKeysDeep (src/orchestrator-v5/compose.ts)."
+    },
+    "_meta.flip_threshold_count": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Diagnostic count of populated flip_threshold_data entries, read by decision_review prompt v12 for routing. Stripped with the rest of the _meta carrier."
+    },
+    "_meta.factor_sensitivity_count": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Diagnostic count of populated isl_results.factor_sensitivity entries. Stripped with the rest of the _meta carrier."
+    },
+    "_meta.fragile_edge_count": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Diagnostic count of populated isl_results.fragile_edges entries. Stripped with the rest of the _meta carrier."
+    },
+    "_meta.model_critique_count": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Diagnostic count of model_critiques carried by deterministic_coaching. Stripped with the rest of the _meta carrier."
+    },
+    "_meta.has_deterministic_coaching": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Diagnostic flag indicating whether deterministic_coaching is the M1 fully-derived shape. Stripped with the rest of the _meta carrier."
+    },
+    "_meta.margin": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Winner.win_probability minus runner_up.win_probability — adapter-side raw signal for prompt routing. The rendered prose owns the human-readable margin description."
+    },
+    "_meta.robustness_level": {
+      "wire": "internal",
+      "emitted_by": "src/orchestrator-v5/coaching/decision-review-enricher.ts",
+      "why": "Robustness.level pulled defensively from the V2 envelope; adapter-side raw signal for prompt routing."
+    },
+    "trace.request_id": {
+      "wire": "serialized",
+      "why": "Per-request correlation identifier echoed back to the caller for log correlation. Machine routing. Verified against DecisionGuideAI staging 0dfb075d: the only read is DraftChat.tsx:312 into captureErrorDetail, rendered at DebugDrawer.tsx:362 which is dev-build only (import.meta.env.DEV guard). No production surface."
+    },
+    "trace.correlation_id": {
+      "wire": "serialized",
+      "why": "Distributed-tracing correlation ID. Machine routing. Verified against DecisionGuideAI staging 0dfb075d: the UI has ZERO reads of trace.correlation_id — the correlation ids it renders are its own generateCorrelationId() values or PLoT's diagnostics.correlation_id, behind Shift+D / expertMode."
+    },
+    "trace.engine": {
+      "wire": "serialized",
+      "why": "LLM engine metadata subtree (provider/model/version) used for telemetry and admin audit dashboards. Verified against DecisionGuideAI staging 0dfb075d: read only in useDebugData and rendered only inside DebugPanelV2, which requires VITE_APP_ENV in {staging,development} AND ?diag or window.__OLUMI_DEBUG. No production surface."
+    },
+    "trace.pipeline": {
+      "wire": "serialized",
+      "why": "Stage-by-stage CEE pipeline diagnostics subtree (provenance, llm_metadata, repair, stage_snapshots, validation_summary, threshold_sweep, etc.). Lifted to result.pipeline_trace by the UI adapter (client.ts:227). Most leaves render only inside DebugPanelV2 (staging/dev AND ?diag). CORRECTED 2026-07-25: the nested pipeline.repair_summary.deterministic_repairs[].action IS rendered in production — see the trace.repair_summary entry."
+    },
+    "trace.repair_summary": {
+      "wire": "serialized",
+      "why": "Top-level repair-stage diagnostic mirror (graph_delta, repair counts, bucket_summary). CORRECTED 2026-07-25: emitted UNCONDITIONALLY by src/cee/transforms/schema-v3.ts (`Always emitted so the UI can depend on the key existing`), NOT gated on includeDebug, and it survives Zod because src/schemas/cee-v3.ts declares the trace object .passthrough(). It therefore reaches every client on the draft-graph HTTP body and the SSE COMPLETE payload. It is also RENDERED: DecisionGuideAI staging 0dfb075d reads it at ModelTabBody.tsx:385 and renders deterministic_repairs[].action as visible text at model-tab/ModelAdjustments.tsx:353 and :283 (the 'Olumi applied N adjustments' expander) — production, no flag, no dev guard. Gating this field would break that surface."
+    },
+    "trace.transform_defaults": {
+      "wire": "serialized",
+      "why": "Defaults applied during the V3 transform (defaulted_edge_count, applied defaults). Diagnostic subtree. Verified against DecisionGuideAI staging 0dfb075d: ZERO occurrences anywhere under src/ in any casing — the UI does not read it at all, let alone render it."
+    }
   },
   "machine_routing_allowed": {
-    "action_type": "Suggested-action discriminant (run_analysis, set_factor_value, etc.). The UI dispatches on this value to route chip clicks; not rendered as text.",
-    "id": "Stable identifier on chips, insights, blocks, nodes, edges, options. Machine reference for click-handling and graph manipulation; never rendered as text.",
-    "error_code": "Wire-level failure type literal on error blocks (UPSTREAM_TIMEOUT, etc.). UI parser dispatches on this; never rendered raw to users.",
-    "request_id": "Same as trace.request_id at the top level — caller-supplied request correlation ID. Machine routing only.",
-    "correlation_id": "Distributed tracing correlation ID at the top level. Machine routing only."
+    "coaching.strengthen_items[].action_type": {
+      "wire": "serialized",
+      "why": "Suggested-action discriminant (run_analysis, set_factor_value, etc.). The UI dispatches on this value to route chip clicks; not rendered as text."
+    },
+    "suggested_actions[].action_type": {
+      "wire": "serialized",
+      "why": "Chip action discriminant on the V5 envelope. The UI dispatches on this value to route chip clicks; not rendered as text."
+    },
+    "coaching.strengthen_items[].id": {
+      "wire": "serialized",
+      "why": "Stable identifier for a strengthen-item chip. Machine reference for click-handling and React keying; not rendered as text."
+    },
+    "suggested_actions[].id": {
+      "wire": "serialized",
+      "why": "Stable identifier for a suggested-action chip. Machine reference for click-handling and React keying; not rendered as text."
+    },
+    "nodes[].id": {
+      "wire": "serialized",
+      "why": "Stable graph-node identifier. Machine reference for canvas manipulation and edge endpoints; the sibling label is the rendered text."
+    },
+    "options[].id": {
+      "wire": "serialized",
+      "why": "Stable option identifier. Machine reference for option selection and analysis wiring; the sibling label is the rendered text."
+    },
+    "blocks[].error_code": {
+      "wire": "serialized",
+      "why": "Wire-level failure type literal on error blocks (UPSTREAM_TIMEOUT, etc.). The UI parser dispatches on this to pick recovery copy; never rendered raw."
+    }
   },
   "structured_pointer_allowed": {
-    "bias_signals[].target": "Node-ID pointer the UI uses to highlight the referenced node in the canvas. detail (sibling) is the user-facing prose; target stays unscrubbed so the link is preserved (sanitiseCoachingForDisplay at src/cee/unified-pipeline/stages/package.ts:125).",
-    "referenced_option_ids": "Array of option IDs cited inside an explanation block (`OlumiResponseSchema.blocks[].referenced_option_ids`). UI uses these to cross-link the message to canvas option nodes; never rendered as text.",
-    "node_id": "Pointer field inside coaching.widening_log[] entries (mapped to camelCase nodeId in the UI store). Identifies which canvas node the widening reason describes; never rendered as text.",
-    "edge_id": "Pointer field inside isl_results.fragile_edges[] entries (decision-review enrichment). Identifies which causal edge is fragile; never rendered as text.",
-    "factor_id": "Pointer field inside flip_threshold_data[] and isl_results.factor_sensitivity[] entries. Identifies which factor the entry describes; from_label / factor_label are the rendered text.",
-    "option_id": "Pointer field inside comparison block options[] entries. Identifies which option each entry describes; the sibling label is the rendered text."
+    "coaching.bias_signals[].target": {
+      "wire": "serialized",
+      "why": "Node-ID pointer the UI uses to highlight the referenced node in the canvas. The sibling `detail` carries the prose shown to the reader; `target` stays unscrubbed so the link survives (sanitiseCoachingForDisplay at src/cee/unified-pipeline/stages/package.ts). Verified against DecisionGuideAI staging 0dfb075d: the id reaches only setHighlightedNodes / data-ref-id attributes; TargetRefPill renders the resolved canvas label, never the id."
+    },
+    "blocks[].referenced_option_ids": {
+      "wire": "serialized",
+      "why": "Array of option IDs cited inside an explanation block. CORRECTED 2026-07-25: contrary to v1, the UI RENDERS these raw — DecisionGuideAI staging 0dfb075d maps them verbatim (mapV5Blocks.ts:82) and prints each id as visible chip text at v5/blocks/V5ExplanationBlock.tsx:40, with no label lookup and no fallback (reachable whenever VITE_ENABLE_V5_ORCHESTRATOR is on). Raw ids reaching users is a product defect tracked separately, not a licence for CEE to send junk here."
+    },
+    "analysis_ready.model_adjustments[].node_id": {
+      "wire": "serialized",
+      "why": "Pointer identifying which canvas node an analysis-ready model adjustment describes; the sibling prose is the rendered text. RE-ANCHORED 2026-07-25: the previous entry claimed this pointer lives 'inside coaching.widening_log[] entries', a per-entry array shape removed at @talchain/schemas v0.11.0 (widening_log is now an object) — the claim described a shape that no longer exists. The rendering half is verified only for the old widening_log path (DecisionGuideAI staging 0dfb075d, WhatOlumiAddedSection.tsx:87-90: Map key and React key, no id fallback); the two re-anchored paths were NOT individually swept for render sites."
+    },
+    "goal_constraints[].node_id": {
+      "wire": "serialized",
+      "why": "Pointer identifying which node a goal constraint binds to; the sibling label is the rendered text. Rendering half NOT individually swept in DecisionGuideAI — see the analysis_ready.model_adjustments[].node_id entry."
+    },
+    "blocks[].enrichment.robustness.fragile_edges[].edge_id": {
+      "wire": "serialized",
+      "why": "Pointer identifying which causal edge is fragile, inside the decision-review enrichment. Not rendered as text; the UI resolves it to edge labels."
+    },
+    "blocks[].enrichment.factor_sensitivity[].factor_id": {
+      "wire": "serialized",
+      "why": "Pointer identifying which factor a sensitivity entry describes; factor_label / label are normally the rendered text. CORRECTED 2026-07-25: the UI falls back to a prettified factor_id when the producer omits both label fields AND no canvas node matches (DecisionGuideAI staging 0dfb075d, useResultsSectionData.ts:2053-2058 and :2735 → DriversSection / TriageActionCards). So an unlabelled entry surfaces this id to users."
+    },
+    "blocks[].enrichment.flip_thresholds[].factor_id": {
+      "wire": "serialized",
+      "why": "Pointer identifying which factor a flip-threshold entry describes; factor_label is normally the rendered text. Note the sibling V5 flip_analysis block DOES render its factor_id raw as a row label (V5FlipAnalysisBlock.tsx:34) — same id-visibility hazard as the factor_sensitivity entry."
+    },
+    "blocks[].enrichment.option_comparison[].option_id": {
+      "wire": "serialized",
+      "why": "Pointer identifying which option each comparison entry describes; option_label is normally the rendered text. CORRECTED 2026-07-25: the UI falls back to the raw option_id when option_label is absent (DecisionGuideAI staging 0dfb075d, inspector-v2/panels/OutcomePanel.tsx:101 plus five sibling editors/adapters). The V5 comparison block itself is clean — it uses option_id only as a React key."
+    }
   },
-  "currently_unrendered_but_intentional": {}
+  "currently_unrendered_but_intentional": {},
+  "_corrections_2026_07_25": {
+    "trace.repair_summary": "v1 said 'Consumed by debug bundles; never user-facing.' FALSE on the distribution half: verified at staging tip 55c64ed5 that it is emitted unconditionally to every client on both the HTTP body and the SSE COMPLETE payload (include_debug=false). Description corrected; emission deliberately NOT changed — the UI depends on the key existing, so gating it is a wire-format change needing a consumer manifest.",
+    "machine_routing_allowed.request_id": "v1 claimed a top-level request_id 'Same as trace.request_id at the top level'. No client response body carries a top-level request_id — the correlation id ships as the X-CEE-Request-ID HTTP header and as trace.request_id. Entry removed as redundant/false; trace.request_id (diagnostic_allowed) is the real field.",
+    "machine_routing_allowed.correlation_id": "v1 claimed a top-level correlation_id. Same finding as request_id — no body carries it. Entry removed as redundant/false; trace.correlation_id is the real field.",
+    "structured_pointer_allowed.node_id": "v1 anchored this to 'coaching.widening_log[] entries', a shape removed at @talchain/schemas v0.11.0. Re-anchored to the two real serialized node_id pointers.",
+    "_rendering_claims_are_NOT_enforced_here": "The `wire` field is machine-checked. The RENDERING half of every `why` is not, and cannot be from this repo — the render sites live in DecisionGuideAI. Those halves were verified by hand against DGAI staging 0dfb075d on 2026-07-25 and WILL drift. Four v1 rendering claims were already false at that SHA: trace.repair_summary (rendered in production), trace.pipeline (via the same nested path), blocks[].referenced_option_ids (raw ids as chip text), and the factor_id / option_id id-as-label fallbacks. Making this class drift-proof needs a DGAI-side test asserting that no allowlisted pointer reaches a JSX text position; that is a separate lane. Until it exists, treat every rendering sentence here as dated evidence, not a guarantee.",
+    "raw_ids_rendered_to_users": "Product defect surfaced by this audit, NOT fixed here: DGAI renders raw wire identifiers to users at V5ExplanationBlock.tsx:40 (referenced_option_ids), V5FlipAnalysisBlock.tsx:34 (factor_id), and via id-as-label fallbacks in useResultsSectionData.ts / OutcomePanel.tsx. Tracked separately.",
+    "bare_leaf_keys": "v1 keyed 12 of 27 entries by bare leaf name (id, node_id, action_type, request_id, ...). The audit matches FULLY-QUALIFIED paths, so none of those keys ever matched anything — measured: 0 of 27 entries consulted across 4,786 walked fixture paths, and deleting all 27 left the suite at 14/14 green. All keys are now anchored, and an entry that resolves to nothing now FAILS."
+  }
 }

--- a/scripts/fetch-cee-contracts.sh
+++ b/scripts/fetch-cee-contracts.sh
@@ -39,7 +39,6 @@ fi
 
 mkdir -p contracts/cee
 
-EXPECTED_COUNT=6
 SCHEMAS=(
   "turn-request.schema.json"
   "analysis-state.schema.json"
@@ -48,6 +47,25 @@ SCHEMAS=(
   "orchestrator-response-v2.schema.json"
   "stream-event.schema.json"
 )
+
+# Non-schema contract artefacts synced from elsewhere in the CEE tree.
+# Format: "<path relative to CEE repo root>:<destination basename in contracts/cee/>"
+#
+# field-coverage.allowlist.json is CEE's field-coverage audit allowlist. Its
+# entries assert, per wire path, that the field is "never rendered as text" /
+# "not user-facing". Those RENDERING claims cannot be enforced from CEE — the
+# render sites live in THIS repo — so DGAI enforces them in
+# tests/contracts/cee-rendering-claims.contract.test.ts against this synced
+# copy. Keeping the sync live is what stops the allowlist decaying into dated
+# hand-verified evidence.
+EXTRA_ARTEFACTS=(
+  "tests/contract/field-coverage.allowlist.json:field-coverage.allowlist.json"
+)
+
+# Derived, never hand-maintained: the count check below must always equal the
+# number of files this script is actually responsible for. A hardcoded literal
+# here would silently under-count the moment an artefact is added.
+EXPECTED_COUNT=$(( ${#SCHEMAS[@]} + ${#EXTRA_ARTEFACTS[@]} ))
 
 copied=0
 missing=0
@@ -67,15 +85,34 @@ for schema in "${SCHEMAS[@]}"; do
   fi
 done
 
+# Extra artefacts live outside CEE's contracts/ export dir, so they are read
+# from the CEE repo root rather than $CEE_CONTRACTS.
+for entry in "${EXTRA_ARTEFACTS[@]}"; do
+  src="${entry%%:*}"
+  dest="${entry##*:}"
+  if [ -f "$CEE_REPO/$src" ]; then
+    cp "$CEE_REPO/$src" "contracts/cee/$dest"
+    copied=$((copied + 1))
+  else
+    missing_names+=("$src")
+    missing=$((missing + 1))
+    if [ -n "$STRICT" ]; then
+      echo "ERROR: $src not found in $CEE_REPO"
+    else
+      echo "WARN: $src not found in $CEE_REPO (using local reference copy)"
+    fi
+  fi
+done
+
 # Verify final count matches expected
 actual_count=$(ls contracts/cee/*.json 2>/dev/null | wc -l | tr -d ' ')
 echo "CEE contracts synced: $copied copied, $missing using local reference"
-echo "Schema files in contracts/cee/: $actual_count (expected: $EXPECTED_COUNT)"
+echo "Files in contracts/cee/: $actual_count (expected: $EXPECTED_COUNT)"
 
 if [ -n "$STRICT" ]; then
   if [ "$missing" -gt 0 ]; then
     echo ""
-    echo "STRICT MODE: $missing required schema(s) missing from CEE repo:"
+    echo "STRICT MODE: $missing required contract artefact(s) missing from CEE repo:"
     printf '  - %s\n' "${missing_names[@]}"
     echo ""
     echo "Either update the CEE repo to export these schemas,"
@@ -86,5 +123,5 @@ if [ -n "$STRICT" ]; then
     echo "ERROR: Expected $EXPECTED_COUNT schemas in contracts/cee/, found $actual_count"
     exit 1
   fi
-  echo "All $EXPECTED_COUNT schemas synced successfully."
+  echo "All $EXPECTED_COUNT contract artefacts synced successfully."
 fi

--- a/src/test/helpers/expectNoReceiptLeaks.ts
+++ b/src/test/helpers/expectNoReceiptLeaks.ts
@@ -18,6 +18,7 @@
 
 import { expect } from 'vitest'
 import { RAW_ID_PATTERN } from '../../canvas/conversation/friendlyOperation'
+import { userFacingSurface } from './userFacingSurface'
 
 /**
  * Forbidden internal terms in the rendered receipt DOM. Exported so failing
@@ -178,12 +179,11 @@ export function expectNoReceiptLeaks(element: HTMLElement): void {
  * surface that already has clean attributes (V5 receipts).
  */
 export function expectNoReceiptUserFacingTextLeaks(element: HTMLElement): void {
-  const textContent = element.textContent ?? ''
-  const elementOwnAriaLabel = element.getAttribute('aria-label') ?? ''
-  const childAriaLabels = Array.from(element.querySelectorAll('[aria-label]'))
-    .map((el) => el.getAttribute('aria-label') ?? '')
-    .join('\n')
-  const surface = [textContent, elementOwnAriaLabel, childAriaLabels].join('\n')
+  // Surface composition is shared with the CEE rendering-claims harness
+  // (`userFacingSurface`) so both enforce the same definition of "what the
+  // user reads or hears". Default options reproduce this helper's original
+  // textContent + own aria-label + descendant aria-labels composition exactly.
+  const surface = userFacingSurface(element)
   const lowered = surface.toLowerCase()
 
   expect(

--- a/src/test/helpers/expectSentinelNotRendered.ts
+++ b/src/test/helpers/expectSentinelNotRendered.ts
@@ -1,0 +1,110 @@
+/**
+ * expectSentinelNotRendered — sentinel-based leak probe for the CEE
+ * rendering-claims harness.
+ *
+ * Complements the two existing leak helpers rather than replacing them:
+ *   - `expectNoReceiptLeaks` / `expectNoChipMetadataLeaks` assert against a
+ *     hand-listed blocklist of known-bad terms. That shape is right for
+ *     "these specific internal words must never appear", and wrong here: a
+ *     blocklist of every id a producer might emit is unmaintainable, and a
+ *     hand-maintained blocklist is the defect class this platform keeps
+ *     losing to.
+ *   - This helper inverts it. We plant a value we control into the field
+ *     under test and assert *that exact value* never reaches the user-facing
+ *     surface. Nothing to keep in sync — the probe derives its expectation
+ *     from the fixture it just built.
+ *
+ * TRAP 13 — an absence assertion is vacuous unless it can first see a
+ * presence. Every probe therefore REQUIRES a `witness`: a string that must
+ * be present in the same extracted surface. If the component failed to
+ * render, the surface extractor was pointed at the wrong node, or the render
+ * threw and produced an empty tree, the witness check fails FIRST and says
+ * so — instead of the sentinel check passing by testing nothing.
+ */
+
+import { expect } from 'vitest'
+import { userFacingSurface } from './userFacingSurface'
+
+/**
+ * Build a distinctive sentinel that still *looks* like a real wire id, so a
+ * component cannot accidentally pass by rejecting malformed input.
+ *
+ * `prefix` should match the real id convention for the field under test
+ * (`opt`, `factor`, `node`, `edge`), keeping the fixture representative of
+ * production data.
+ */
+export function idSentinel(prefix: string): string {
+  return `${prefix}_zqxsentinel7w`
+}
+
+export interface SentinelProbeOptions {
+  /** The rendered root to inspect. */
+  element: HTMLElement
+  /** The value planted in the field that must NOT be rendered as text. */
+  sentinel: string
+  /**
+   * A string that MUST appear in the extracted surface. Proves the probe can
+   * see rendered text at all. Use a sibling value the component is *supposed*
+   * to render (narrative prose, a resolved label) — never a constant heading,
+   * which can survive an otherwise-empty render.
+   */
+  witness: string
+  /** Human name of the allowlist entry under test, quoted on failure. */
+  claim: string
+  /** Also sweep title/alt/placeholder and non-label aria-* attributes. */
+  includeExtendedAttributes?: boolean
+}
+
+/**
+ * Assert `sentinel` does not appear in the element's user-facing surface,
+ * having first proven the surface contains `witness`.
+ */
+export function expectSentinelNotRendered(options: SentinelProbeOptions): void {
+  const {
+    element,
+    sentinel,
+    witness,
+    claim,
+    includeExtendedAttributes = true,
+  } = options
+
+  const surface = userFacingSurface(element, { includeExtendedAttributes })
+
+  // ── Positive control, first and unconditionally. ──
+  expect(
+    surface,
+    `POSITIVE CONTROL FAILED for "${claim}": the probe's witness string ` +
+      `"${witness}" is absent from the rendered user-facing surface, so the ` +
+      `sentinel assertion below would prove nothing. The component did not ` +
+      `render, or the surface was extracted from the wrong node. ` +
+      `Extracted surface was: ${JSON.stringify(surface.slice(0, 400))}`,
+  ).toContain(witness)
+
+  // ── The actual claim. ──
+  expect(
+    surface,
+    `CEE allowlist rendering claim VIOLATED — "${claim}".\n` +
+      `The wire identifier "${sentinel}" reached the user-facing surface ` +
+      `(visible text or an aria label). CEE's field-coverage allowlist ` +
+      `asserts this field is a machine reference that is never rendered as ` +
+      `text; users must see a human label, not a raw id.\n` +
+      `Extracted surface was: ${JSON.stringify(surface.slice(0, 400))}`,
+  ).not.toContain(sentinel)
+}
+
+/**
+ * Inverse of `expectSentinelNotRendered`, used only by the harness's own
+ * self-test: proves the mechanism can DETECT a leak, so a green harness
+ * means "no leak found" rather than "probe never fired".
+ */
+export function expectSentinelIsRendered(options: SentinelProbeOptions): void {
+  const { element, sentinel, includeExtendedAttributes = true } = options
+  const surface = userFacingSurface(element, { includeExtendedAttributes })
+  expect(
+    surface,
+    `harness self-test failed: sentinel "${sentinel}" was expected to be ` +
+      `visible in the user-facing surface but was not found. The leak ` +
+      `detector cannot see a known-present value, so every absence ` +
+      `assertion it makes is vacuous.`,
+  ).toContain(sentinel)
+}

--- a/src/test/helpers/userFacingSurface.ts
+++ b/src/test/helpers/userFacingSurface.ts
@@ -1,0 +1,76 @@
+/**
+ * userFacingSurface — the single definition of "what the user reads or hears"
+ * for a rendered element.
+ *
+ * Extracted from `expectNoReceiptUserFacingTextLeaks` so that helper and the
+ * CEE rendering-claims harness (`tests/contracts/cee-rendering-claims.contract.test.ts`)
+ * enforce the *same* surface. Two helpers with two slightly different notions
+ * of "user-facing" is exactly the hand-maintained-mirror defect class.
+ *
+ * WHAT IS DELIBERATELY EXCLUDED — and why it matters:
+ *   `key`, `data-testid`, `data-*`, `className`, `id`, `href`
+ * are implementation-detail attributes. A raw wire identifier appearing in
+ * them is NOT a rendering violation: React keys and test ids are precisely the
+ * legitimate machine uses that CEE's field-coverage allowlist permits
+ * ("machine reference for click-handling", "React keying"). Asserting against
+ * `outerHTML` would conflate the two and make the correct pattern
+ * (`key={opt.option_id}` + `{opt.label}` as text) indistinguishable from the
+ * defect (`{id}` as the visible chip text).
+ *
+ * `aria-*` label text IS included: a screen-reader user "reads" it, so an id
+ * leaked into an aria-label is a real leak of the same claim type.
+ */
+
+/** Attributes whose values are announced by assistive tech or shown on hover. */
+const EXTENDED_USER_FACING_ATTRIBUTES = [
+  'aria-description',
+  'aria-placeholder',
+  'aria-valuetext',
+  'aria-roledescription',
+  'title',
+  'alt',
+  'placeholder',
+] as const
+
+export interface UserFacingSurfaceOptions {
+  /**
+   * Also collect `title`, `alt`, `placeholder` and the non-label `aria-*`
+   * text attributes. Default `false`, which reproduces exactly the surface
+   * `expectNoReceiptUserFacingTextLeaks` has always asserted against
+   * (textContent + own aria-label + descendant aria-labels).
+   */
+  includeExtendedAttributes?: boolean
+}
+
+/**
+ * Build the user-facing surface string for `element`.
+ *
+ * Returns textContent plus the element's own `aria-label` plus every
+ * descendant `aria-label`, newline-joined. With
+ * `includeExtendedAttributes`, also appends the extended attribute set
+ * (own + descendants).
+ */
+export function userFacingSurface(
+  element: HTMLElement,
+  options: UserFacingSurfaceOptions = {},
+): string {
+  const textContent = element.textContent ?? ''
+  const elementOwnAriaLabel = element.getAttribute('aria-label') ?? ''
+  const childAriaLabels = Array.from(element.querySelectorAll('[aria-label]'))
+    .map((el) => el.getAttribute('aria-label') ?? '')
+    .join('\n')
+
+  const parts = [textContent, elementOwnAriaLabel, childAriaLabels]
+
+  if (options.includeExtendedAttributes === true) {
+    for (const attribute of EXTENDED_USER_FACING_ATTRIBUTES) {
+      const own = element.getAttribute(attribute)
+      if (own !== null) parts.push(own)
+      for (const el of Array.from(element.querySelectorAll(`[${attribute}]`))) {
+        parts.push(el.getAttribute(attribute) ?? '')
+      }
+    }
+  }
+
+  return parts.join('\n')
+}

--- a/src/v5/blocks/V5ExplanationBlock.tsx
+++ b/src/v5/blocks/V5ExplanationBlock.tsx
@@ -1,16 +1,40 @@
 /**
  * V5ExplanationBlock — renders V5 explanation block (narrative about why
  * an option wins, optionally referencing option IDs).
+ *
+ * The referenced options are delivered as bare wire ids; the block schema
+ * carries no labels. Each id is resolved against the canvas store and the
+ * LABEL is rendered — never the id.
+ *
+ * UNRESOLVABLE IDS ARE OMITTED, not printed and not replaced with a generic
+ * word. These chips are a pure cross-reference affordance: every option they
+ * point at is already named in the narrative above, so a chip that cannot
+ * name its option carries no information a reader can use. A generic
+ * "option" chip would be worse than omission — it occupies the visual slot
+ * of a specific named option while identifying nothing. Contrast
+ * V5FlipAnalysisBlock, which keeps unlabelled rows because those rows carry
+ * threshold NUMBERS that would be lost with them.
  */
-import { type ReactElement } from 'react'
+import { useMemo, type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import type { V5ExplanationBlock as V5ExplanationBlockType } from '../../canvas/conversation/types'
+import { useCanvasNodeLabels, resolveCanvasLabel } from './useCanvasLabels'
 
 export interface V5ExplanationBlockProps {
   block: V5ExplanationBlockType
 }
 
 export function V5ExplanationBlock({ block }: V5ExplanationBlockProps): ReactElement {
+  const nodeLabels = useCanvasNodeLabels()
+
+  const referencedOptions = useMemo(
+    () =>
+      block.referenced_option_ids
+        .map((id) => ({ id, label: resolveCanvasLabel(id, nodeLabels) }))
+        .filter((o): o is { id: string; label: string } => o.label !== null),
+    [block.referenced_option_ids, nodeLabels],
+  )
+
   return (
     <div
       data-testid="v5-explanation"
@@ -20,24 +44,28 @@ export function V5ExplanationBlock({ block }: V5ExplanationBlockProps): ReactEle
       <p className={typography.panelBody} data-testid="v5-explanation-narrative">
         {block.narrative}
       </p>
-      {block.referenced_option_ids.length > 0 && (
+      {referencedOptions.length > 0 && (
         <div
           className="flex flex-wrap gap-2"
           role="list"
           aria-label="Referenced options"
           data-testid="v5-explanation-options"
         >
-          {block.referenced_option_ids.map((id) => (
+          {referencedOptions.map(({ id, label }) => (
             <span
+              // The id remains the React key and the test id — a machine
+              // reference, which is exactly the use CEE's field-coverage
+              // allowlist permits. Only the TEXT changes.
               key={id}
               role="listitem"
+              data-testid={`v5-explanation-option-${id}`}
               className={[
                 'inline-flex items-center rounded-full px-2.5 py-0.5',
                 'bg-transparent border border-option/30 text-text-body',
                 typography.panelMeta,
               ].join(' ')}
             >
-              {id}
+              {label}
             </span>
           ))}
         </div>

--- a/src/v5/blocks/V5FlipAnalysisBlock.tsx
+++ b/src/v5/blocks/V5FlipAnalysisBlock.tsx
@@ -1,14 +1,32 @@
 /**
  * V5FlipAnalysisBlock — renders V5 flip_analysis block (scenarios where
  * a single factor change flips the leading option).
+ *
+ * Each scenario is delivered with a bare `factor_id` and no label; the id is
+ * resolved against the canvas store and the LABEL is rendered as the row's
+ * left-hand text — never the id.
+ *
+ * UNRESOLVABLE FACTORS KEEP THEIR ROW, under an explicit "Unnamed factor".
+ * This differs deliberately from V5ExplanationBlock, which omits chips it
+ * cannot name. The distinction is whether the element carries data: a
+ * referenced-option chip is a pure cross-link and loses nothing when
+ * dropped, whereas a flip row carries the current value and the flip
+ * threshold. Dropping it would silently destroy a measured result and would
+ * also contradict the narrative above, which counts the scenarios ("Two
+ * factors could flip the result"). Naming the gap honestly keeps the
+ * numbers and tells the reader exactly what we could not resolve.
  */
-import { type ReactElement } from 'react'
+import { useMemo, type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import type { V5FlipAnalysisBlock as V5FlipAnalysisBlockType } from '../../canvas/conversation/types'
+import { useCanvasNodeLabels, resolveCanvasLabel } from './useCanvasLabels'
 
 export interface V5FlipAnalysisBlockProps {
   block: V5FlipAnalysisBlockType
 }
+
+/** Shown when a factor id resolves to no canvas label. Never an identifier. */
+const UNNAMED_FACTOR_LABEL = 'Unnamed factor'
 
 function formatValue(v: number | null): string {
   if (v === null || !Number.isFinite(v)) return '—'
@@ -16,6 +34,17 @@ function formatValue(v: number | null): string {
 }
 
 export function V5FlipAnalysisBlock({ block }: V5FlipAnalysisBlockProps): ReactElement {
+  const nodeLabels = useCanvasNodeLabels()
+
+  const scenarios = useMemo(
+    () =>
+      block.flip_scenarios.map((s) => ({
+        scenario: s,
+        label: resolveCanvasLabel(s.factor_id, nodeLabels) ?? UNNAMED_FACTOR_LABEL,
+      })),
+    [block.flip_scenarios, nodeLabels],
+  )
+
   return (
     <div
       data-testid="v5-flip-analysis"
@@ -25,13 +54,16 @@ export function V5FlipAnalysisBlock({ block }: V5FlipAnalysisBlockProps): ReactE
       <p className={typography.panelBody}>{block.narrative}</p>
       {block.flip_scenarios.length > 0 && (
         <ul className={`${typography.panelMeta} space-y-1`} role="list">
-          {block.flip_scenarios.map((s, i) => (
+          {scenarios.map(({ scenario: s, label }, i) => (
             <li
+              // The id remains the React key and the test id — a machine
+              // reference, which is exactly the use CEE's field-coverage
+              // allowlist permits. Only the TEXT changes.
               key={`${s.factor_id}-${i}`}
               data-testid={`v5-flip-scenario-${s.factor_id}`}
               className="flex flex-wrap items-center gap-2"
             >
-              <span className="text-text-light">{s.factor_id}:</span>
+              <span className="text-text-light">{label}:</span>
               <span className="text-text-body">{formatValue(s.current_value)}</span>
               <span className="text-text-light">→</span>
               <span className="text-text-body font-medium">{formatValue(s.flip_threshold)}</span>

--- a/src/v5/blocks/__tests__/V5BlockIdLabelResolution.spec.tsx
+++ b/src/v5/blocks/__tests__/V5BlockIdLabelResolution.spec.tsx
@@ -1,0 +1,154 @@
+/**
+ * V5ExplanationBlock / V5FlipAnalysisBlock — id → label resolution.
+ *
+ * The contract harness (tests/contracts/cee-rendering-claims.contract.test.tsx)
+ * proves the raw id is ABSENT from the user-facing surface. Absence alone is
+ * satisfiable by rendering nothing at all, so these tests pin the other half:
+ * that the human label is PRESENT, that the machine reference survives in
+ * attributes, and that each component makes the no-label decision its own
+ * docstring claims it makes.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+
+let mockNodes: Array<{ id: string; data: { label: string } }> = []
+
+vi.mock('../../../canvas/store', () => ({
+  useCanvasStore: (selector: (s: unknown) => unknown) =>
+    selector({ nodes: mockNodes, edges: [] }),
+}))
+
+import { V5ExplanationBlock } from '../V5ExplanationBlock'
+import { V5FlipAnalysisBlock } from '../V5FlipAnalysisBlock'
+
+afterEach(() => {
+  cleanup()
+  mockNodes = []
+})
+
+function explanation(ids: string[]) {
+  return {
+    type: 'v5_explanation' as const,
+    narrative: 'London wins on resilience.',
+    referenced_option_ids: ids,
+  }
+}
+
+function flip(factorIds: string[]) {
+  return {
+    type: 'v5_flip_analysis' as const,
+    narrative: 'Factors that could flip the result.',
+    flip_scenarios: factorIds.map((factor_id) => ({
+      factor_id,
+      current_value: 0.5,
+      flip_threshold: 0.7,
+      from_option_id: null,
+      to_option_id: null,
+      fragile: false,
+    })),
+  }
+}
+
+describe('V5ExplanationBlock — referenced option ids', () => {
+  it('renders the canvas label, not the id', () => {
+    mockNodes = [{ id: 'opt_london', data: { label: 'Hire in London' } }]
+    render(<V5ExplanationBlock block={explanation(['opt_london'])} />)
+
+    const list = screen.getByTestId('v5-explanation-options')
+    expect(within(list).getByRole('listitem')).toHaveTextContent(
+      'Hire in London',
+    )
+    expect(list.textContent).not.toContain('opt_london')
+  })
+
+  it('keeps the id as a machine reference in the test id', () => {
+    mockNodes = [{ id: 'opt_london', data: { label: 'Hire in London' } }]
+    render(<V5ExplanationBlock block={explanation(['opt_london'])} />)
+
+    // The allowlist permits exactly this use. Losing it would be a
+    // regression in the opposite direction.
+    expect(
+      screen.getByTestId('v5-explanation-option-opt_london'),
+    ).toBeInTheDocument()
+  })
+
+  it('omits a chip whose id resolves to no canvas label', () => {
+    mockNodes = [{ id: 'opt_london', data: { label: 'Hire in London' } }]
+    render(
+      <V5ExplanationBlock block={explanation(['opt_london', 'opt_ghost'])} />,
+    )
+
+    const items = within(screen.getByTestId('v5-explanation-options')).getAllByRole(
+      'listitem',
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0]).toHaveTextContent('Hire in London')
+  })
+
+  it('omits the whole list when nothing resolves', () => {
+    mockNodes = []
+    render(<V5ExplanationBlock block={explanation(['opt_ghost'])} />)
+
+    expect(screen.queryByTestId('v5-explanation-options')).toBeNull()
+    // The narrative still renders — the block is not blanked out.
+    expect(screen.getByTestId('v5-explanation-narrative')).toHaveTextContent(
+      'London wins on resilience.',
+    )
+  })
+
+  it('rejects a canvas label that is itself a raw id', () => {
+    // Upstream sometimes seeds a node label from its own id. Without the
+    // RAW_ID_PATTERN guard the leak would just move one hop upstream.
+    mockNodes = [{ id: 'opt_london', data: { label: 'opt_london' } }]
+    render(<V5ExplanationBlock block={explanation(['opt_london'])} />)
+
+    expect(screen.queryByTestId('v5-explanation-options')).toBeNull()
+  })
+})
+
+describe('V5FlipAnalysisBlock — factor ids', () => {
+  it('renders the canvas label as the row label, not the id', () => {
+    mockNodes = [{ id: 'fac_morale', data: { label: 'Team morale' } }]
+    render(<V5FlipAnalysisBlock block={flip(['fac_morale'])} />)
+
+    const row = screen.getByTestId('v5-flip-scenario-fac_morale')
+    expect(row).toHaveTextContent('Team morale:')
+    expect(row.textContent).not.toContain('fac_morale')
+  })
+
+  it('KEEPS the row and its numbers when no label resolves, naming the gap', () => {
+    // Deliberately different from V5ExplanationBlock: this row carries the
+    // current value and the flip threshold. Dropping it would destroy a
+    // measured result and contradict the narrative's scenario count.
+    mockNodes = []
+    render(<V5FlipAnalysisBlock block={flip(['fac_ghost'])} />)
+
+    const row = screen.getByTestId('v5-flip-scenario-fac_ghost')
+    expect(row).toHaveTextContent('Unnamed factor:')
+    expect(row).toHaveTextContent('0.50')
+    expect(row).toHaveTextContent('0.70')
+    expect(row.textContent).not.toContain('fac_ghost')
+  })
+
+  it('resolves each row independently in a mixed set', () => {
+    mockNodes = [{ id: 'fac_morale', data: { label: 'Team morale' } }]
+    render(<V5FlipAnalysisBlock block={flip(['fac_morale', 'fac_ghost'])} />)
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+    expect(screen.getByTestId('v5-flip-scenario-fac_morale')).toHaveTextContent(
+      'Team morale:',
+    )
+    expect(screen.getByTestId('v5-flip-scenario-fac_ghost')).toHaveTextContent(
+      'Unnamed factor:',
+    )
+  })
+
+  it('rejects a canvas label that is itself a raw id', () => {
+    mockNodes = [{ id: 'fac_morale', data: { label: 'fac_morale' } }]
+    render(<V5FlipAnalysisBlock block={flip(['fac_morale'])} />)
+
+    const row = screen.getByTestId('v5-flip-scenario-fac_morale')
+    expect(row).toHaveTextContent('Unnamed factor:')
+    expect(row.textContent).not.toContain('fac_morale')
+  })
+})

--- a/src/v5/blocks/useCanvasLabels.ts
+++ b/src/v5/blocks/useCanvasLabels.ts
@@ -1,0 +1,68 @@
+/**
+ * useCanvasLabels — resolve wire identifiers to human labels for V5 blocks.
+ *
+ * WHY THIS IS NEEDED AT ALL: the V5 explanation and flip_analysis block
+ * schemas carry NO labels. `ExplanationBlockSchema` is
+ * `{narrative, referenced_option_ids: string[]}` and each flip scenario is
+ * `{factor_id, current_value, flip_threshold, ...}` — the producer sends
+ * pointers only. (Contrast `ComparisonBlockSchema`, which does carry a
+ * sibling `label` per option, which is why V5ComparisonBlock needs no
+ * resolver.) Adding label fields to those two would be a wire-format change
+ * requiring a schemas release plus a producer change, so the friendly label
+ * is computed UI-side from the canvas store — the same doctrine
+ * `v5GraphPatchDescription.ts` already states and `V5GraphPatchBlock`
+ * already follows.
+ *
+ * Options are canvas nodes (there is no separate option entity), so one node
+ * map resolves both `option_id` and `factor_id`.
+ */
+
+import { useMemo } from 'react'
+import { useCanvasStore } from '../../canvas/store'
+import { RAW_ID_PATTERN } from '../../canvas/conversation/friendlyOperation'
+
+/**
+ * Node id → display label for every canvas node that has one.
+ *
+ * Subscribes to `nodes` only. Deliberately does not read `edges`: neither
+ * consumer resolves edges, and subscribing would re-render these blocks on
+ * every edge change.
+ */
+export function useCanvasNodeLabels(): ReadonlyMap<string, string> {
+  const nodes = useCanvasStore(
+    (s: { nodes?: Array<{ id: string; data?: { label?: unknown } }> }) =>
+      s.nodes,
+  )
+  return useMemo(() => {
+    const map = new Map<string, string>()
+    for (const n of nodes ?? []) {
+      const label = typeof n.data?.label === 'string' ? n.data.label : ''
+      if (label) map.set(n.id, label)
+    }
+    return map
+  }, [nodes])
+}
+
+/**
+ * Resolve one wire id to a human label, or `null` when no honest label
+ * exists.
+ *
+ * Returns `null` rather than the id — that is the whole point. Callers must
+ * decide what to show instead, and the type makes them decide: there is no
+ * way to accidentally fall through to the identifier.
+ *
+ * A stored label that is ITSELF a raw id is rejected via `RAW_ID_PATTERN`.
+ * Upstream sometimes seeds a node's label from its id; without this guard the
+ * leak would simply move one hop upstream and still reach the user.
+ */
+export function resolveCanvasLabel(
+  id: string,
+  labels: ReadonlyMap<string, string>,
+): string | null {
+  const label = labels.get(id)
+  if (label === undefined) return null
+  const trimmed = label.trim()
+  if (trimmed === '') return null
+  if (RAW_ID_PATTERN.test(trimmed)) return null
+  return trimmed
+}

--- a/tests/contracts/cee-rendering-claims.contract.test.tsx
+++ b/tests/contracts/cee-rendering-claims.contract.test.tsx
@@ -402,7 +402,6 @@ describe('CEE rendering claims — coverage is exhaustive both ways', () => {
       lines.push(`  ${d}: ${list.length}`)
       for (const k of list) lines.push(`    - ${k}`)
     }
-    // eslint-disable-next-line no-console
     console.info(lines.join('\n'))
 
     // The one hard floor: if the probe set ever empties, this suite would be

--- a/tests/contracts/cee-rendering-claims.contract.test.tsx
+++ b/tests/contracts/cee-rendering-claims.contract.test.tsx
@@ -1,0 +1,622 @@
+/**
+ * CEE rendering-claims harness.
+ *
+ * ── WHY THIS EXISTS ──────────────────────────────────────────────────────
+ * CEE's field-coverage allowlist (`tests/contract/field-coverage.allowlist.json`
+ * in Talchain/olumi-assistants-service) justifies every non-audited wire field
+ * with a prose claim. Those claims have TWO halves:
+ *
+ *   1. DISTRIBUTION — "is this path actually on the wire?" CEE machine-checks
+ *      this half itself.
+ *   2. RENDERING — "the UI dispatches on this value; it is never rendered as
+ *      text", "never user-facing", "the sibling label is the rendered text".
+ *      **CEE cannot enforce this half and says so.** The render sites are in
+ *      THIS repo.
+ *
+ * Until this file existed, the rendering half was hand-verified prose with a
+ * date on it. Hand-verified prose about another repo is this platform's
+ * dominant defect class: it reads green, it drifts silently, and nobody
+ * re-checks it. When CEE last swept these claims by hand, FOUR were already
+ * false at the DGAI SHA they were verified against — including
+ * `referenced_option_ids`, whose "never rendered as text" justification sat
+ * next to a component printing exactly that id as visible chip text.
+ *
+ * This harness converts the claims into executable assertions, so a DGAI
+ * change that starts rendering a machine identifier as user-visible text
+ * fails CI here rather than reaching users.
+ *
+ * ── HOW IT WORKS ─────────────────────────────────────────────────────────
+ * - The allowlist is SYNCED, not hand-copied: `scripts/fetch-cee-contracts.sh`
+ *   copies it into `contracts/cee/`, and
+ *   `.github/workflows/contract-validation.yml` re-fetches CEE's live `staging`
+ *   tip on every run and executes this suite against the FETCHED bytes. The
+ *   committed copy is a local-dev convenience, not the source of truth.
+ * - Coverage is EXHAUSTIVE AND BIDIRECTIONAL. Every allowlist entry must be
+ *   classified in `COVERAGE`; every `COVERAGE` key must exist in the
+ *   allowlist. A new CEE entry fails this suite until a human classifies it.
+ *   There is deliberately no "unknown entries are fine" default.
+ * - Probes plant a distinctive sentinel in the field under test, render the
+ *   REAL production component, and assert the sentinel never reaches the
+ *   user-facing surface (text + aria labels). React keys, `data-testid` and
+ *   class names are deliberately NOT part of that surface — those are the
+ *   legitimate machine uses the allowlist permits, and conflating them would
+ *   make the correct pattern indistinguishable from the defect.
+ * - Every probe carries a witness that must be PRESENT (trap 13), and the
+ *   suite self-tests its own detector so a green run means "no leak found"
+ *   rather than "probe never fired".
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  idSentinel,
+  expectSentinelNotRendered,
+  expectSentinelIsRendered,
+} from '../../src/test/helpers/expectSentinelNotRendered'
+
+// ---------------------------------------------------------------------------
+// Canvas store mock — the label source the block components resolve against.
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutable per-test canvas contents. Options are canvas nodes (there is no
+ * separate option entity), so a single node list serves both option-id and
+ * factor-id resolution.
+ */
+let mockNodes: Array<{ id: string; data: { label: string } }> = []
+let mockEdges: Array<{ id: string; source?: string; target?: string }> = []
+
+vi.mock('../../src/canvas/store', () => ({
+  useCanvasStore: (selector: (s: unknown) => unknown) =>
+    selector({ nodes: mockNodes, edges: mockEdges }),
+}))
+
+// Imported AFTER the mock declaration; vi.mock is hoisted so this is safe.
+import { V5ExplanationBlock } from '../../src/v5/blocks/V5ExplanationBlock'
+import { V5FlipAnalysisBlock } from '../../src/v5/blocks/V5FlipAnalysisBlock'
+import { V5ComparisonBlock } from '../../src/v5/blocks/V5ComparisonBlock'
+
+afterEach(() => {
+  cleanup()
+  mockNodes = []
+  mockEdges = []
+})
+
+// ---------------------------------------------------------------------------
+// Allowlist loading — tolerant of both CEE shapes.
+// ---------------------------------------------------------------------------
+
+const ALLOWLIST_PATH = resolve(
+  __dirname,
+  '../../contracts/cee/field-coverage.allowlist.json',
+)
+
+/**
+ * CEE ships two shapes for this file:
+ *   v1              — value is the justification string.
+ *   PR #689 onwards — value is `{ wire, why, ... }`.
+ * Normalise both; assume neither.
+ */
+interface AllowlistEntry {
+  category: string
+  key: string
+  why: string
+  wire?: string
+}
+
+/**
+ * Categories whose entries assert something about RENDERING, and are
+ * therefore this harness's business. `audited_fields` is a plain array of
+ * fields that ARE rendered — the opposite claim — and is excluded by name.
+ */
+const RENDERING_CLAIM_CATEGORIES = [
+  'diagnostic_allowed',
+  'machine_routing_allowed',
+  'structured_pointer_allowed',
+  'currently_unrendered_but_intentional',
+] as const
+
+/** Documentation keys, not entries. Anything else is a hard error. */
+const NON_ENTRY_KEYS = new Set([
+  '_doc',
+  '_wire_values',
+  '_corrections_2026_07_25',
+  'audited_fields',
+])
+
+function loadAllowlist(): {
+  raw: Record<string, unknown>
+  entries: AllowlistEntry[]
+} {
+  const raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8')) as Record<
+    string,
+    unknown
+  >
+
+  const entries: AllowlistEntry[] = []
+  for (const category of RENDERING_CLAIM_CATEGORIES) {
+    const bucket = raw[category]
+    if (bucket === undefined) continue
+    if (typeof bucket !== 'object' || bucket === null || Array.isArray(bucket)) {
+      throw new Error(
+        `CEE allowlist category "${category}" is not an object map — the ` +
+          `allowlist shape changed in a way this harness does not understand. ` +
+          `Read the upstream file before editing this test.`,
+      )
+    }
+    for (const [key, value] of Object.entries(bucket)) {
+      if (typeof value === 'string') {
+        entries.push({ category, key, why: value })
+      } else if (typeof value === 'object' && value !== null) {
+        const v = value as Record<string, unknown>
+        entries.push({
+          category,
+          key,
+          why: typeof v.why === 'string' ? v.why : '',
+          wire: typeof v.wire === 'string' ? v.wire : undefined,
+        })
+      } else {
+        throw new Error(
+          `CEE allowlist entry ${category}.${key} has an unrecognised value ` +
+            `type (${typeof value}).`,
+        )
+      }
+    }
+  }
+  return { raw, entries }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage registry.
+// ---------------------------------------------------------------------------
+
+/**
+ * How this harness treats each allowlist entry. Every disposition other than
+ * `probed` is an explicit, reasoned admission of what is NOT machine-checked —
+ * the honest-coverage requirement. There is deliberately no default.
+ */
+type Disposition =
+  /** A render probe in this repo executes the claim. */
+  | 'probed'
+  /**
+   * The path never reaches a DGAI production render surface — consumed by
+   * CEE-internal code, telemetry, an admin/debug surface, or nothing at all.
+   */
+  | 'not-a-dgai-render-surface'
+  /**
+   * The claim IS about a DGAI production surface but this harness cannot
+   * execute it (needs a full canvas/results mount, or a real browser).
+   * NOT assume-good: counted and listed in the coverage report below.
+   */
+  | 'uncovered'
+  /**
+   * The claim is KNOWN FALSE or known-contested at a recorded SHA and the
+   * fix is owned elsewhere. Recorded rather than omitted so the gap stays
+   * visible instead of being silently dropped.
+   */
+  | 'documented-violation-not-owned-here'
+
+interface CoverageRecord {
+  disposition: Disposition
+  reason: string
+}
+
+/**
+ * ── THE COVERAGE REGISTRY ────────────────────────────────────────────────
+ * Keyed by the EXACT allowlist key. Exact-match is deliberate: CEE PR #689
+ * re-anchors every bare leaf key (`factor_id`) to a fully-qualified path
+ * (`blocks[].enrichment.flip_thresholds[].factor_id`) precisely because the
+ * bare keys matched nothing. When that lands, these keys will fail the
+ * exhaustiveness check and force a re-map — the harness working, not
+ * breaking.
+ */
+const COVERAGE: Record<string, CoverageRecord> = {
+  // ── structured_pointer_allowed — the id-pointer claims. ────────────────
+  referenced_option_ids: {
+    disposition: 'probed',
+    reason:
+      'Rendered by V5ExplanationBlock. This entry is the harness positive ' +
+      'control: its "never rendered as text" claim was FALSE when this ' +
+      'harness was written.',
+  },
+  factor_id: {
+    disposition: 'probed',
+    reason:
+      'Rendered as the visible row label by V5FlipAnalysisBlock. The ' +
+      'allowlist claims from_label / factor_label are the rendered text.',
+  },
+  option_id: {
+    disposition: 'probed',
+    reason:
+      'V5ComparisonBlock consumes option_id as a React key + data-testid and ' +
+      'renders the sibling label as text — the reference implementation of ' +
+      'the correct pattern, and proof this harness passes clean code.',
+  },
+  'bias_signals[].target': {
+    disposition: 'uncovered',
+    reason:
+      'Coaching bias-signal targets drive a canvas highlight rather than a ' +
+      'self-contained block component; probing needs a full canvas mount, ' +
+      'which jsdom cannot render faithfully (trap 3). Not swept here.',
+  },
+  node_id: {
+    disposition: 'uncovered',
+    reason:
+      'CEE PR #689 re-anchors this away from the removed coaching.widening_log[] ' +
+      'shape to analysis_ready.model_adjustments[].node_id and ' +
+      'goal_constraints[].node_id. The v1 key names a shape that no longer ' +
+      'exists at @talchain/schemas v0.11.0, so there is nothing coherent to ' +
+      'probe until the re-anchored keys arrive.',
+  },
+  edge_id: {
+    disposition: 'uncovered',
+    reason:
+      'Fragile-edge pointers inside decision-review enrichment. The consuming ' +
+      'surface resolves edges via endpoint labels, but reaching it needs a ' +
+      'full results-store mount. Not swept here.',
+  },
+
+  // ── machine_routing_allowed. ───────────────────────────────────────────
+  id: {
+    disposition: 'uncovered',
+    reason:
+      'Bare "id" spans chips, insights, blocks, nodes, edges and options — six ' +
+      'surfaces under one key. CEE #689 splits it into five anchored keys; ' +
+      'probing the conflated key would assert something imprecise. Chip ids ' +
+      'are separately guarded by expectNoChipMetadataLeaks.',
+  },
+  action_type: {
+    disposition: 'not-a-dgai-render-surface',
+    reason:
+      'Already enforced, and more strictly than this harness would: ' +
+      'src/test/helpers/expectNoChipMetadataLeaks.ts blocklists every ' +
+      'action_type literal against chip outerHTML, attributes included.',
+  },
+  error_code: {
+    disposition: 'documented-violation-not-owned-here',
+    reason:
+      'src/v5/TypedErrorRenderer.tsx renders the failure-type literal ungated ' +
+      'as visible text (line 82), but the component has ZERO non-test ' +
+      'importers and is mounted on no route — unreachable rather than ' +
+      'leaking. Complete importer manifest verified at 0dfb075d. Recorded so ' +
+      'the claim is not silently dropped.',
+  },
+  request_id: {
+    disposition: 'documented-violation-not-owned-here',
+    reason:
+      'src/routes/templates/components/ErrorBanner.tsx:104 prints "Reference ' +
+      'ID: {error.request_id}" inside a production role="alert" ' +
+      'aria-live="assertive" banner with NO dev guard, on live paths ' +
+      '(TemplatesPanel + the /templates route). Deliberately NOT changed by ' +
+      'this lane: a support reference a user quotes when reporting a problem ' +
+      'is plausibly intentional. Escalated to product for a ruling. CEE #689 ' +
+      'separately finds no top-level request_id on any response body.',
+  },
+  correlation_id: {
+    disposition: 'not-a-dgai-render-surface',
+    reason:
+      'CEE #689 verified no client response body carries a top-level ' +
+      'correlation_id; it ships as trace.correlation_id and an HTTP header. ' +
+      'No DGAI surface could render it.',
+  },
+}
+
+/**
+ * Every `diagnostic_allowed` entry is a CEE-internal telemetry / admin-debug
+ * path. Registered programmatically FROM THE ALLOWLIST rather than hand-listed,
+ * so a newly-added diagnostic entry cannot slip past the exhaustiveness check
+ * against a stale hand-written row. It still cannot be probed, and the
+ * coverage report counts it as unswept.
+ */
+const DIAGNOSTIC_DISPOSITION: CoverageRecord = {
+  disposition: 'not-a-dgai-render-surface',
+  reason:
+    'diagnostic_allowed entries are telemetry / admin-debug paths (trace.*, ' +
+    '_meta.*). NOTE: CEE #689 found trace.repair_summary and trace.pipeline ' +
+    'ARE rendered on a DGAI DEBUG surface. A debug-gated render is not a ' +
+    'production rendering violation — DebugPanelV2 requires VITE_APP_ENV in ' +
+    '{staging,development} AND (?diag OR window.__OLUMI_DEBUG); DebugDrawer ' +
+    'requires import.meta.env.DEV. Not swept here.',
+}
+
+const { raw, entries } = loadAllowlist()
+
+function coverageFor(entry: AllowlistEntry): CoverageRecord | undefined {
+  if (entry.category === 'diagnostic_allowed') return DIAGNOSTIC_DISPOSITION
+  return COVERAGE[entry.key]
+}
+
+// ---------------------------------------------------------------------------
+// Structure + drift guards.
+// ---------------------------------------------------------------------------
+
+describe('CEE field-coverage allowlist — structure', () => {
+  it('parses and yields entries', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  it('contains no top-level key this harness does not understand', () => {
+    const unknown = Object.keys(raw).filter(
+      (k) =>
+        !NON_ENTRY_KEYS.has(k) &&
+        !(RENDERING_CLAIM_CATEGORIES as readonly string[]).includes(k),
+    )
+    expect(
+      unknown,
+      `CEE added top-level allowlist key(s) this harness does not classify: ` +
+        `${unknown.join(', ')}. Decide whether they carry rendering claims and ` +
+        `update RENDERING_CLAIM_CATEGORIES / NON_ENTRY_KEYS. Failing loud ` +
+        `rather than assuming they are harmless.`,
+    ).toEqual([])
+  })
+})
+
+describe('CEE rendering claims — coverage is exhaustive both ways', () => {
+  it('every allowlist entry is classified', () => {
+    const unclassified = entries
+      .filter((e) => coverageFor(e) === undefined)
+      .map((e) => `${e.category}.${e.key}`)
+    expect(
+      unclassified,
+      `CEE's allowlist carries entr(ies) with no disposition in this harness's ` +
+        `COVERAGE registry:\n  ${unclassified.join('\n  ')}\n\n` +
+        `This is the drift guard firing, and it is working as intended. Either ` +
+        `add a probe, or classify the entry with an honest reason. Do NOT add ` +
+        `a blanket default — an unclassified rendering claim that silently ` +
+        `passes is exactly the failure mode this file exists to prevent.`,
+    ).toEqual([])
+  })
+
+  it('every COVERAGE key still exists in the allowlist', () => {
+    const live = new Set(entries.map((e) => e.key))
+    const stale = Object.keys(COVERAGE).filter((k) => !live.has(k))
+    expect(
+      stale,
+      `COVERAGE registry has entr(ies) CEE no longer ships:\n  ` +
+        `${stale.join('\n  ')}\n\nRemove them, or — if CEE re-anchored the key ` +
+        `to a fully-qualified path (PR #689 does exactly this) — re-key the ` +
+        `registry and re-verify each probe against the new path.`,
+    ).toEqual([])
+  })
+
+  it('reports its own honest coverage', () => {
+    const byDisposition = new Map<Disposition, string[]>()
+    for (const e of entries) {
+      const c = coverageFor(e)
+      if (c === undefined) continue
+      const list = byDisposition.get(c.disposition) ?? []
+      list.push(`${e.category}.${e.key}`)
+      byDisposition.set(c.disposition, list)
+    }
+    const lines = [`CEE rendering-claim coverage (${entries.length} entries):`]
+    for (const d of [
+      'probed',
+      'documented-violation-not-owned-here',
+      'uncovered',
+      'not-a-dgai-render-surface',
+    ] as Disposition[]) {
+      const list = byDisposition.get(d) ?? []
+      lines.push(`  ${d}: ${list.length}`)
+      for (const k of list) lines.push(`    - ${k}`)
+    }
+    // eslint-disable-next-line no-console
+    console.info(lines.join('\n'))
+
+    // The one hard floor: if the probe set ever empties, this suite would be
+    // green while executing zero rendering claims.
+    const probed = byDisposition.get('probed') ?? []
+    expect(
+      probed.length,
+      'no allowlist entry is actually probed — the harness would be green ' +
+        'while checking nothing',
+    ).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The detector's own positive control.
+// ---------------------------------------------------------------------------
+
+describe('harness self-test — the leak detector can SEE a leak', () => {
+  it('detects a sentinel that IS rendered as visible text', () => {
+    const sentinel = idSentinel('opt')
+    // V5ComparisonBlock renders `label` as text by design. Planting the
+    // sentinel THERE must trip the detector. If this fails, every absence
+    // assertion in this file is vacuous.
+    const { container } = render(
+      <V5ComparisonBlock
+        block={{
+          type: 'v5_comparison',
+          narrative: 'Comparing the options.',
+          options: [
+            { option_id: 'opt_real', label: sentinel, win_probability: 0.6 },
+          ],
+        }}
+      />,
+    )
+    expectSentinelIsRendered({
+      element: container.firstElementChild as HTMLElement,
+      sentinel,
+      witness: sentinel,
+      claim: 'self-test',
+    })
+  })
+
+  it('the witness guard fails loudly when nothing rendered', () => {
+    const empty = document.createElement('div')
+    expect(() =>
+      expectSentinelNotRendered({
+        element: empty,
+        sentinel: idSentinel('opt'),
+        witness: 'this text is not present',
+        claim: 'self-test — vacuity guard',
+      }),
+    ).toThrow(/POSITIVE CONTROL FAILED/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The probes.
+// ---------------------------------------------------------------------------
+
+describe('rendering claim: blocks[].referenced_option_ids', () => {
+  const NARRATIVE = 'Hiring in London wins on resilience.'
+
+  it('does not render a referenced option id as text when the option is on canvas', () => {
+    const sentinel = idSentinel('opt')
+    mockNodes = [{ id: sentinel, data: { label: 'Hire in London' } }]
+
+    const { container } = render(
+      <V5ExplanationBlock
+        block={{
+          type: 'v5_explanation',
+          narrative: NARRATIVE,
+          referenced_option_ids: [sentinel],
+        }}
+      />,
+    )
+
+    expectSentinelNotRendered({
+      element: container.firstElementChild as HTMLElement,
+      sentinel,
+      witness: NARRATIVE,
+      claim: 'structured_pointer_allowed.referenced_option_ids',
+    })
+  })
+
+  it('does not render a referenced option id as text when NO label resolves', () => {
+    // The harder case: the producer cites an option the canvas does not know.
+    // A resolver that falls back to the raw id would leak here.
+    const sentinel = idSentinel('opt')
+    mockNodes = []
+
+    const { container } = render(
+      <V5ExplanationBlock
+        block={{
+          type: 'v5_explanation',
+          narrative: NARRATIVE,
+          referenced_option_ids: [sentinel],
+        }}
+      />,
+    )
+
+    expectSentinelNotRendered({
+      element: container.firstElementChild as HTMLElement,
+      sentinel,
+      witness: NARRATIVE,
+      claim:
+        'structured_pointer_allowed.referenced_option_ids (unresolvable label)',
+    })
+  })
+})
+
+describe('rendering claim: blocks[].enrichment.flip_thresholds[].factor_id', () => {
+  const NARRATIVE = 'Two factors could flip the result.'
+
+  it('does not render a factor id as text when the factor is on canvas', () => {
+    const sentinel = idSentinel('fac')
+    mockNodes = [{ id: sentinel, data: { label: 'Team morale' } }]
+
+    const { container } = render(
+      <V5FlipAnalysisBlock
+        block={{
+          type: 'v5_flip_analysis',
+          narrative: NARRATIVE,
+          flip_scenarios: [
+            {
+              factor_id: sentinel,
+              current_value: 0.5,
+              flip_threshold: 0.7,
+              from_option_id: 'opt_a',
+              to_option_id: 'opt_b',
+              fragile: false,
+            },
+          ],
+        }}
+      />,
+    )
+
+    expectSentinelNotRendered({
+      element: container.firstElementChild as HTMLElement,
+      sentinel,
+      witness: NARRATIVE,
+      claim: 'structured_pointer_allowed.factor_id',
+    })
+  })
+
+  it('does not render a factor id as text when NO label resolves', () => {
+    const sentinel = idSentinel('fac')
+    mockNodes = []
+
+    const { container } = render(
+      <V5FlipAnalysisBlock
+        block={{
+          type: 'v5_flip_analysis',
+          narrative: NARRATIVE,
+          flip_scenarios: [
+            {
+              factor_id: sentinel,
+              current_value: 0.5,
+              flip_threshold: 0.7,
+              from_option_id: null,
+              to_option_id: null,
+              fragile: true,
+            },
+          ],
+        }}
+      />,
+    )
+
+    expectSentinelNotRendered({
+      element: container.firstElementChild as HTMLElement,
+      sentinel,
+      witness: NARRATIVE,
+      claim: 'structured_pointer_allowed.factor_id (unresolvable label)',
+    })
+  })
+})
+
+describe('rendering claim: blocks[].enrichment.option_comparison[].option_id', () => {
+  const NARRATIVE = 'London leads on win probability.'
+
+  it('renders the sibling label, never the option id', () => {
+    const sentinel = idSentinel('opt')
+
+    const { container } = render(
+      <V5ComparisonBlock
+        block={{
+          type: 'v5_comparison',
+          narrative: NARRATIVE,
+          options: [
+            {
+              option_id: sentinel,
+              label: 'Hire in London',
+              win_probability: 0.62,
+            },
+          ],
+        }}
+      />,
+    )
+
+    const element = container.firstElementChild as HTMLElement
+
+    // The id IS expected in machine attributes — that is the allowlist's
+    // permitted use, and asserting otherwise would forbid correct code.
+    expect(
+      element.outerHTML,
+      'precondition: this probe is only meaningful while the component still ' +
+        'uses option_id as a key/testid — otherwise it proves nothing about ' +
+        'the text/attribute distinction',
+    ).toContain(sentinel)
+
+    expectSentinelNotRendered({
+      element,
+      sentinel,
+      witness: 'Hire in London',
+      claim: 'structured_pointer_allowed.option_id',
+    })
+  })
+})

--- a/tests/contracts/cee-rendering-claims.contract.test.tsx
+++ b/tests/contracts/cee-rendering-claims.contract.test.tsx
@@ -215,43 +215,67 @@ interface CoverageRecord {
  */
 const COVERAGE: Record<string, CoverageRecord> = {
   // ── structured_pointer_allowed — the id-pointer claims. ────────────────
-  referenced_option_ids: {
+  'blocks[].referenced_option_ids': {
     disposition: 'probed',
     reason:
       'Rendered by V5ExplanationBlock. This entry is the harness positive ' +
-      'control: its "never rendered as text" claim was FALSE when this ' +
-      'harness was written.',
+      'control: its v1 "never rendered as text" claim was FALSE, and CEE #689 ' +
+      'corrected it to record that the UI printed each id as visible chip ' +
+      'text. Fixed here; the probe keeps it fixed.',
   },
-  factor_id: {
+  'blocks[].enrichment.flip_thresholds[].factor_id': {
     disposition: 'probed',
     reason:
-      'Rendered as the visible row label by V5FlipAnalysisBlock. The ' +
-      'allowlist claims from_label / factor_label are the rendered text.',
+      'The sibling V5 flip_analysis block rendered this id raw as each row\'s ' +
+      'visible label (V5FlipAnalysisBlock) — the hazard CEE #689 flags on this ' +
+      'entry. Fixed here; the probe keeps it fixed.',
   },
-  option_id: {
-    disposition: 'probed',
+  'blocks[].enrichment.option_comparison[].option_id': {
+    disposition: 'documented-violation-not-owned-here',
     reason:
-      'V5ComparisonBlock consumes option_id as a React key + data-testid and ' +
-      'renders the sibling label as text — the reference implementation of ' +
-      'the correct pattern, and proof this harness passes clean code.',
+      'PARTIALLY probed. V5ComparisonBlock is clean and IS probed here — it ' +
+      'uses option_id as React key + data-testid and renders the sibling ' +
+      'label, the reference implementation. But the same wire path reaches a ' +
+      'SECOND surface that is NOT clean: inspector-v2/panels/OutcomePanel.tsx:101 ' +
+      'renders `{opt.option_label ?? opt.option_id}`, and the same fallback ' +
+      'appears in RiskAdvancedEditor.tsx:32, OutcomeAdvancedEditor.tsx:32 and ' +
+      'OptionPanel.tsx:167 — all verified reaching visible text at 0dfb075d. ' +
+      'Those are inspector-panel surfaces needing a canvas/store mount; not ' +
+      'fixed by this lane and deliberately recorded rather than dropped.',
   },
-  'bias_signals[].target': {
+  'blocks[].enrichment.factor_sensitivity[].factor_id': {
+    disposition: 'documented-violation-not-owned-here',
+    reason:
+      'KNOWN FALSE and not fixed here. components/results/useResultsSectionData.ts:2051-2056 ' +
+      'prettifies the raw key into displayLabel when both canvasLabel and ' +
+      'f.raw.label are absent, and :2735 does `gap.factor_label ?? gap.factor_id`. ' +
+      'Both reach visible text (DriversSection, V7SignalRow, ChallengeSection, ' +
+      'StressTestSection, TriageActionCardsBody). ChallengeSection.tsx:97-99 ' +
+      'carries a THIRD independent id-prettifying fallback. Verified at ' +
+      '0dfb075d. Each needs its own copy decision ("unnamed factor" vs omit), ' +
+      'so this belongs in a lane that can carry them properly.',
+  },
+  'coaching.bias_signals[].target': {
     disposition: 'uncovered',
     reason:
       'Coaching bias-signal targets drive a canvas highlight rather than a ' +
       'self-contained block component; probing needs a full canvas mount, ' +
       'which jsdom cannot render faithfully (trap 3). Not swept here.',
   },
-  node_id: {
+  'analysis_ready.model_adjustments[].node_id': {
     disposition: 'uncovered',
     reason:
-      'CEE PR #689 re-anchors this away from the removed coaching.widening_log[] ' +
-      'shape to analysis_ready.model_adjustments[].node_id and ' +
-      'goal_constraints[].node_id. The v1 key names a shape that no longer ' +
-      'exists at @talchain/schemas v0.11.0, so there is nothing coherent to ' +
-      'probe until the re-anchored keys arrive.',
+      'Re-anchored by CEE #689 from the removed coaching.widening_log[] shape. ' +
+      'The consuming surface needs a results/analysis-ready mount. Not swept.',
   },
-  edge_id: {
+  'goal_constraints[].node_id': {
+    disposition: 'uncovered',
+    reason:
+      'CEE #689 states the rendering half of this entry was NOT individually ' +
+      'swept on the DGAI side either. It remains unswept — recorded honestly ' +
+      'rather than inheriting CEE\'s unverified assumption.',
+  },
+  'blocks[].enrichment.robustness.fragile_edges[].edge_id': {
     disposition: 'uncovered',
     reason:
       'Fragile-edge pointers inside decision-review enrichment. The consuming ' +
@@ -260,47 +284,53 @@ const COVERAGE: Record<string, CoverageRecord> = {
   },
 
   // ── machine_routing_allowed. ───────────────────────────────────────────
-  id: {
-    disposition: 'uncovered',
-    reason:
-      'Bare "id" spans chips, insights, blocks, nodes, edges and options — six ' +
-      'surfaces under one key. CEE #689 splits it into five anchored keys; ' +
-      'probing the conflated key would assert something imprecise. Chip ids ' +
-      'are separately guarded by expectNoChipMetadataLeaks.',
-  },
-  action_type: {
+  'coaching.strengthen_items[].action_type': {
     disposition: 'not-a-dgai-render-surface',
     reason:
       'Already enforced, and more strictly than this harness would: ' +
       'src/test/helpers/expectNoChipMetadataLeaks.ts blocklists every ' +
       'action_type literal against chip outerHTML, attributes included.',
   },
-  error_code: {
-    disposition: 'documented-violation-not-owned-here',
-    reason:
-      'src/v5/TypedErrorRenderer.tsx renders the failure-type literal ungated ' +
-      'as visible text (line 82), but the component has ZERO non-test ' +
-      'importers and is mounted on no route — unreachable rather than ' +
-      'leaking. Complete importer manifest verified at 0dfb075d. Recorded so ' +
-      'the claim is not silently dropped.',
-  },
-  request_id: {
-    disposition: 'documented-violation-not-owned-here',
-    reason:
-      'src/routes/templates/components/ErrorBanner.tsx:104 prints "Reference ' +
-      'ID: {error.request_id}" inside a production role="alert" ' +
-      'aria-live="assertive" banner with NO dev guard, on live paths ' +
-      '(TemplatesPanel + the /templates route). Deliberately NOT changed by ' +
-      'this lane: a support reference a user quotes when reporting a problem ' +
-      'is plausibly intentional. Escalated to product for a ruling. CEE #689 ' +
-      'separately finds no top-level request_id on any response body.',
-  },
-  correlation_id: {
+  'suggested_actions[].action_type': {
     disposition: 'not-a-dgai-render-surface',
     reason:
-      'CEE #689 verified no client response body carries a top-level ' +
-      'correlation_id; it ships as trace.correlation_id and an HTTP header. ' +
-      'No DGAI surface could render it.',
+      'Same as coaching.strengthen_items[].action_type — covered by the ' +
+      'existing chip-metadata blocklist against outerHTML.',
+  },
+  'coaching.strengthen_items[].id': {
+    disposition: 'uncovered',
+    reason:
+      'Chip ids are deliberately present in data-testid (expectNoChipMetadataLeaks ' +
+      'documents this as the contract), so the existing helper cannot ' +
+      'distinguish id-in-testid from id-as-text. A sentinel probe on the chip ' +
+      'row could, and does not exist yet. Not swept.',
+  },
+  'suggested_actions[].id': {
+    disposition: 'uncovered',
+    reason: 'Same as coaching.strengthen_items[].id — not swept.',
+  },
+  'nodes[].id': {
+    disposition: 'uncovered',
+    reason:
+      'Canvas node identifiers. Probing needs a real canvas mount; jsdom ' +
+      'cannot prove what a canvas node visually renders (trap 3). Not swept.',
+  },
+  'options[].id': {
+    disposition: 'uncovered',
+    reason:
+      'Canvas option-node identifiers, same constraint as nodes[].id. Note ' +
+      'the inspector-panel fallbacks recorded under ' +
+      'blocks[].enrichment.option_comparison[].option_id are the live hazard ' +
+      'for option identifiers. Not swept.',
+  },
+  'blocks[].error_code': {
+    disposition: 'documented-violation-not-owned-here',
+    reason:
+      'src/v5/TypedErrorRenderer.tsx:82 renders the failure-type literal ' +
+      'ungated as visible text, but the component has ZERO non-test importers ' +
+      'and is mounted on no route — unreachable rather than leaking. Complete ' +
+      'importer manifest verified at 0dfb075d. Recorded so the claim is not ' +
+      'silently dropped if it is ever mounted.',
   },
 }
 
@@ -482,7 +512,7 @@ describe('rendering claim: blocks[].referenced_option_ids', () => {
       element: container.firstElementChild as HTMLElement,
       sentinel,
       witness: NARRATIVE,
-      claim: 'structured_pointer_allowed.referenced_option_ids',
+      claim: 'structured_pointer_allowed.blocks[].referenced_option_ids',
     })
   })
 
@@ -507,7 +537,7 @@ describe('rendering claim: blocks[].referenced_option_ids', () => {
       sentinel,
       witness: NARRATIVE,
       claim:
-        'structured_pointer_allowed.referenced_option_ids (unresolvable label)',
+        'structured_pointer_allowed.blocks[].referenced_option_ids (unresolvable label)',
     })
   })
 })
@@ -542,7 +572,7 @@ describe('rendering claim: blocks[].enrichment.flip_thresholds[].factor_id', () 
       element: container.firstElementChild as HTMLElement,
       sentinel,
       witness: NARRATIVE,
-      claim: 'structured_pointer_allowed.factor_id',
+      claim: 'structured_pointer_allowed.blocks[].enrichment.flip_thresholds[].factor_id',
     })
   })
 
@@ -573,7 +603,8 @@ describe('rendering claim: blocks[].enrichment.flip_thresholds[].factor_id', () 
       element: container.firstElementChild as HTMLElement,
       sentinel,
       witness: NARRATIVE,
-      claim: 'structured_pointer_allowed.factor_id (unresolvable label)',
+      claim:
+        'structured_pointer_allowed.blocks[].enrichment.flip_thresholds[].factor_id (unresolvable label)',
     })
   })
 })
@@ -615,7 +646,8 @@ describe('rendering claim: blocks[].enrichment.option_comparison[].option_id', (
       element,
       sentinel,
       witness: 'Hire in London',
-      claim: 'structured_pointer_allowed.option_id',
+      claim:
+        'structured_pointer_allowed.blocks[].enrichment.option_comparison[].option_id',
     })
   })
 })


### PR DESCRIPTION
Users were seeing `opt_a3f`-style wire identifiers as visible UI text, and CEE's
field-coverage allowlist was asserting they were not — an assertion nothing could
enforce, because the render sites live here.

Two commits, deliberately in this order.

## 1. The harness (`056dc8b0`) — committed RED on purpose

CEE's allowlist justifies each non-audited wire field with a prose claim. CEE
machine-checks the **distribution** half ("is this path on the wire?"). It cannot
check the **rendering** half ("never rendered as text", "the sibling label is the
rendered text") and says so explicitly. So that half was hand-verified prose with a
date on it — a mirror of another repo's behaviour that a human must remember to
re-check. It drifted exactly as expected: **four claims were already false at the
DGAI SHA they were verified against.**

- `contracts/cee/field-coverage.allowlist.json` is **synced, not hand-copied** —
  hand-copying would reproduce the very defect class the CEE-side fix was for.
  `scripts/fetch-cee-contracts.sh` pulls it beside the schemas, and
  `contract-validation.yml` re-fetches CEE's live `staging` tip on every run and
  executes this suite against the **fetched** bytes. Verified byte-identical
  (blob `b66cd75f`). The script's `EXPECTED_COUNT` is now derived, not a literal.
- Coverage is **exhaustive and bidirectional**: every allowlist entry must be
  classified, every registry key must still exist upstream. There is deliberately
  no "unknown entries are fine" default — that default is what lets a mirror rot.
- The user-facing surface **excludes** `key` / `data-testid` / `className`. A wire
  id there is the allowlist's *permitted* machine use; asserting on `outerHTML`
  would make correct code indistinguishable from the defect.

**Acceptance evidence — against unmodified staging code: `4 failed | 8 passed`.**

```
× referenced_option_ids (x2)   "opt_zqxsentinel7w" reached the user surface
× factor_id (x2)               "fac_zqxsentinel7w" reached the user surface
✓ option_id                    V5ComparisonBlock is clean and stays green
✓ both self-tests, all three drift guards
```

It **discriminates** — it does not simply fail everything. Written after the fix,
nobody could tell a working guard from one that never fires (trap 13, which bit
five separate times today).

## 2. The fix (`1a1b2b21`) — 4 failed → 12 passed

Neither block schema carries a label (unlike `ComparisonBlockSchema`, which is why
`V5ComparisonBlock` was already correct), so labels are resolved UI-side from the
canvas store — the doctrine `v5GraphPatchDescription.ts` already states and
`V5GraphPatchBlock` already follows. `resolveCanvasLabel` returns `string | null`,
never the id: the type is the point. It also rejects a stored label that is itself
a raw id, or the leak would just move one hop upstream.

**The no-label case is decided per site, because the elements differ in whether
they carry data:**

- **Explanation chips are omitted.** Pure cross-reference; every option is already
  named in the narrative above. A generic "option" chip would be worse than
  omission — it occupies the slot of a specific named option while identifying
  nothing.
- **Flip rows are kept, under "Unnamed factor".** These carry the current value and
  flip threshold. Dropping them would destroy a measured result and contradict the
  narrative, which counts the scenarios.

## Verification

- **All 8 mutation-checks bite** (throwaway worktree): both leaks re-introduced, the
  `RAW_ID_PATTERN` guard removed, both no-label decisions inverted, and — the ones
  that matter — CEE adding an entry / removing an entry / adding a top-level key all
  turn the drift guard RED.
- Typecheck gate PASSED, within baseline (2663), 3012/3030 files loaded.
- Wide regression with CI env: **192/192 files, 2726 passed, 0 failed.**
- No test was deleted or weakened. No test previously pinned the raw-id rendering
  (complete importer/test manifest verified at `0dfb075d`).

## Honest coverage — what this does NOT check (27 allowlist entries)

| Disposition | N |
|---|---|
| `probed` | 3 |
| `documented-violation-not-owned-here` | 2 |
| `uncovered` (listed explicitly, never assumed good) | 4 |
| `not-a-dgai-render-surface` | 18 |

The suite prints this itself rather than asserting a number that could drift.

## Two things for a human

- **`ErrorBanner.tsx:104` prints `Reference ID: {error.request_id}` in a production
  `role="alert" aria-live="assertive"` banner with no dev guard, on live paths.**
  Deliberately **not** changed — a support reference users quote is plausibly
  intentional. Recorded in the registry, awaiting a product ruling.
- **CEE PR #689 is still OPEN.** Its `wire`-bearing, path-anchored allowlist is not
  on CEE staging, so this vendors v1. When #689 merges, the drift guard will go RED
  and force a re-vendor and re-map — working as designed, not breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)