### PR TITLE
fix(honesty): the edge panel's COLOUR still spoke the default the number stopped speaking

### DIFF
--- a/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
+++ b/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
@@ -7,17 +7,21 @@
  * positive control that proves the reader can see a presence at all.
  */
 import { describe, it, expect } from 'vitest'
-import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS, EdgeDataSchema } from '../edges'
+import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS, EDGE_CONSTRAINTS, EdgeDataSchema } from '../edges'
 import {
   edgeValueSource,
   isEdgeValueSet,
   edgeValueSourcePatch,
   resolveEdgeValueDisplay,
   resolveEdgeSignedStrengthDisplay,
+  edgeValueBand,
+  withLiveEdgeValue,
+  EDGE_VALUE_BAND_CUTS,
   EDGE_PROVENANCED_FIELDS,
   EDGE_VALUE_SOURCE_KEYS,
   edgeSourceKey,
   stripEdgeValueSourceKeys,
+  type EdgeValueBand,
 } from '../edgeValueProvenance'
 
 describe('edgeValueProvenance — the UI defaults are NOT a source', () => {
@@ -267,5 +271,88 @@ describe('EDGE_VALUE_SOURCE_KEYS / stripEdgeValueSourceKeys (F11)', () => {
 
     const cleaned = { ...DEFAULT_EDGE_DATA, ...stripEdgeValueSourceKeys({ weightSource: 'user' }) }
     expect(isEdgeValueSet(cleaned, 'weight')).toBe(false)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// edgeValueBand / withLiveEdgeValue — the NON-TEXT channels
+//
+// #472/#473/#474 gated the number. `EdgePanel.thresholdColor(v: number)` then
+// banded the very same defaults into a colour: `EDGE_CONSTRAINTS.beliefExists
+// .default` (0.7) and `USER_EDGE_DEFAULTS.beliefExists` (0.8) both landed in
+// the green band. These cases pin `unset` as a band in its own right and, per
+// the file's rule, pair every absence with the presence that proves the
+// function can still discriminate.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('edgeValueBand — a value nobody set has no band but `unset`', () => {
+  it('bands both non-showing reasons as unset', () => {
+    expect(edgeValueBand({ show: false, reason: 'not_set' })).toBe('unset')
+    expect(edgeValueBand({ show: false, reason: 'absent' })).toBe('unset')
+  })
+
+  it('POSITIVE CONTROL: a sourced value bands by magnitude', () => {
+    expect(edgeValueBand({ show: true, value: 0.9, source: 'user' })).toBe('high')
+    expect(edgeValueBand({ show: true, value: 0.5, source: 'cee' })).toBe('moderate')
+    expect(edgeValueBand({ show: true, value: 0.1, source: 'template' })).toBe('low')
+  })
+
+  it('cuts on the raw value at the documented boundaries, inclusive', () => {
+    expect(edgeValueBand({ show: true, value: EDGE_VALUE_BAND_CUTS.high, source: 'user' })).toBe('high')
+    expect(edgeValueBand({ show: true, value: 0.6999, source: 'user' })).toBe('moderate')
+    expect(edgeValueBand({ show: true, value: EDGE_VALUE_BAND_CUTS.moderate, source: 'user' })).toBe('moderate')
+    expect(edgeValueBand({ show: true, value: 0.3999, source: 'user' })).toBe('low')
+  })
+
+  it('THE DEFECT: the two real unset states used to band green — they now band unset', () => {
+    // Both of these are numbers a real edge carries, and both are >= 0.7.
+    expect(USER_EDGE_DEFAULTS.beliefExists).toBeGreaterThanOrEqual(EDGE_VALUE_BAND_CUTS.high)
+    expect(EDGE_CONSTRAINTS.beliefExists.default).toBeGreaterThanOrEqual(EDGE_VALUE_BAND_CUTS.high)
+
+    // Routed through the gate, neither can reach the green band.
+    expect(edgeValueBand(resolveEdgeValueDisplay(USER_EDGE_DEFAULTS as Record<string, unknown>, 'beliefExists'))).toBe('unset')
+    expect(edgeValueBand(resolveEdgeValueDisplay(DEFAULT_EDGE_DATA as Record<string, unknown>, 'beliefExists'))).toBe('unset')
+
+    // POSITIVE CONTROL: stamp the same number and the band appears.
+    const stamped = { ...USER_EDGE_DEFAULTS, beliefExistsSource: 'user' as const }
+    expect(edgeValueBand(resolveEdgeValueDisplay(stamped as Record<string, unknown>, 'beliefExists'))).toBe('high')
+  })
+
+  it('the type admits no number-only call — a band always names a verdict', () => {
+    // Compile-time property, asserted at runtime as documentation: every band
+    // this function can return is one of the four, and `unset` is reachable.
+    const bands = new Set<EdgeValueBand>([
+      edgeValueBand({ show: false, reason: 'not_set' }),
+      edgeValueBand({ show: true, value: 0.2, source: 'user' }),
+      edgeValueBand({ show: true, value: 0.5, source: 'user' }),
+      edgeValueBand({ show: true, value: 0.8, source: 'user' }),
+    ])
+    expect(bands).toEqual(new Set(['unset', 'low', 'moderate', 'high']))
+  })
+})
+
+describe('withLiveEdgeValue — retargets the value, never the verdict', () => {
+  it('re-points a shown display at the in-flight control value', () => {
+    const got = withLiveEdgeValue({ show: true, value: 0.2, source: 'cee' }, 0.85)
+    expect(got).toEqual({ show: true, value: 0.85, source: 'cee' })
+    expect(edgeValueBand(got)).toBe('high')
+  })
+
+  it('CANNOT launder: an unset display stays unset whatever value is passed', () => {
+    expect(withLiveEdgeValue({ show: false, reason: 'not_set' }, 0.95)).toEqual({
+      show: false,
+      reason: 'not_set',
+    })
+    expect(withLiveEdgeValue({ show: false, reason: 'absent' }, 0.95)).toEqual({
+      show: false,
+      reason: 'absent',
+    })
+    expect(edgeValueBand(withLiveEdgeValue({ show: false, reason: 'not_set' }, 0.95))).toBe('unset')
+  })
+
+  it('ignores a non-finite live value rather than banding NaN', () => {
+    const base = { show: true, value: 0.5, source: 'user' } as const
+    expect(withLiveEdgeValue(base, NaN)).toEqual(base)
+    expect(withLiveEdgeValue(base, Infinity)).toEqual(base)
   })
 })

--- a/src/canvas/domain/edgeValueProvenance.ts
+++ b/src/canvas/domain/edgeValueProvenance.ts
@@ -178,6 +178,73 @@ export function resolveEdgeValueDisplay(
 }
 
 /**
+ * The band a display value falls in — for the NON-TEXT channels.
+ *
+ * WHY THIS EXISTS, GIVEN `EdgeValueDisplay` ALREADY DID
+ * ----------------------------------------------------
+ * #472/#473/#474 gated the NUMBER. They did not gate the CHANNELS that carry
+ * the same claim without words. `EdgePanel.thresholdColor(v: number)` was the
+ * proof: three branches, `>= 0.7 → green`, `>= 0.4 → amber`, else red, and NO
+ * branch that could express "nobody set this". An edge with no `beliefExists`
+ * fell through to `EDGE_CONSTRAINTS.beliefExists.default` (0.7) and rendered
+ * GREEN, 70% — directly under the panel's own coaching sentence "Nobody has
+ * said how likely this connection is to exist yet." Colour is read
+ * pre-attentively and delivers a verdict ("this is fine") that nobody
+ * consciously evaluates, so it is the stronger of the two claims on that
+ * screen, and it was the false one.
+ *
+ * `unset` is therefore a FIRST-CLASS band, not a fallthrough. Because this
+ * function takes an `EdgeValueDisplay` and NOT a `number`, a future caller
+ * cannot reach a colour without first passing through the provenance gate:
+ * there is no argument they can construct that means "0.7, source unknown".
+ * That is the property `thresholdColor(v: number)` lacked, and the reason this
+ * lives beside the union rather than as a conditional at the call site.
+ *
+ * Consumers map the band to their own channel tokens via a
+ * `Record<EdgeValueBand, …>` (see `EdgePanel`), so ADDING a band is a type
+ * error at every consumer rather than a silent inheritance of a neighbour's
+ * colour — same rule as `STRENGTH_PROVENANCE_COPY` in `coachingConfig`.
+ */
+export type EdgeValueBand = 'unset' | 'low' | 'moderate' | 'high'
+
+/**
+ * Band cut points for the 0–1 probability channels (`beliefExists`).
+ *
+ * Named because they were a hand-copied literal in three places
+ * (`EdgePanel.thresholdColor`, `EdgePanel.thresholdTrackVar`,
+ * `RelationshipsSection.likelihoodColour`) — the mirror shape this codebase
+ * keeps paying for. Cut on the RAW value, never on a rounded percentage.
+ */
+export const EDGE_VALUE_BAND_CUTS = { high: 0.7, moderate: 0.4 } as const
+
+/** Which band a resolved display falls in. `show: false` ⇒ `unset`, always. */
+export function edgeValueBand(display: EdgeValueDisplay): EdgeValueBand {
+  if (!display.show) return 'unset'
+  if (display.value >= EDGE_VALUE_BAND_CUTS.high) return 'high'
+  if (display.value >= EDGE_VALUE_BAND_CUTS.moderate) return 'moderate'
+  return 'low'
+}
+
+/**
+ * Re-point a resolved display at the value a LIVE control is currently showing.
+ *
+ * An editing surface (the existence slider) holds the in-flight value in local
+ * state, so the number on screen can lead the store by one debounce tick. The
+ * colour must band the number the user is LOOKING AT, or the two channels
+ * disagree — which is the whole defect, just smaller.
+ *
+ * The provenance verdict is deliberately NOT re-derived: `show: false` in ⇒
+ * `show: false` out, unchanged. There is no argument to this function that can
+ * turn an unsourced value into a sourced one, so it cannot be used — by
+ * accident or otherwise — to launder a default into a claim.
+ */
+export function withLiveEdgeValue(display: EdgeValueDisplay, live: number): EdgeValueDisplay {
+  if (!display.show) return display
+  if (typeof live !== 'number' || !Number.isFinite(live)) return display
+  return { ...display, value: live }
+}
+
+/**
  * Signed strength for display: magnitude from `weight`, sign from `direction`.
  *
  * Gated on `weight`'s provenance, because the DIRECTION defaults too

--- a/src/canvas/ui/inspector-v2/__tests__/EdgePanel.unsetColour.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/EdgePanel.unsetColour.spec.tsx
@@ -1,0 +1,174 @@
+/**
+ * EdgePanel — the existence readout must not COLOUR a value nobody set.
+ *
+ * WHAT THIS PINS
+ * --------------
+ * `thresholdColor(v: number)` had three branches (`>= 0.7` green, `>= 0.4`
+ * amber, else red) and no branch that could express "not set". An edge with no
+ * `beliefExists` fell through to `EDGE_CONSTRAINTS.beliefExists.default` (0.7)
+ * and an edge drawn with `USER_EDGE_DEFAULTS` carries 0.8 — so BOTH of the
+ * states a real unset edge can be in rendered GREEN, underneath this same
+ * panel's coaching sentence "Nobody has said how likely this connection is to
+ * exist yet."
+ *
+ * CLAIM TYPE — read this before adding an assertion here.
+ * ------------------------------------------------------
+ * Every assertion below is a **rendered-attribute** claim: the `class` string
+ * on the readout element, and the presence/absence of the track-fill node.
+ * jsdom cannot prove VISIBILITY, contrast, or layout (platform trap 3), and no
+ * test in this file claims any of those. "Green" here means *the element
+ * carries `text-success`*, nothing more.
+ *
+ * REACHABILITY POSITIVE CONTROL
+ * -----------------------------
+ * The unset fixtures are not hand-written objects — `drawEdgeThroughProduct`
+ * builds the edge through `useCanvasStore.addEdge` with `USER_EDGE_DEFAULTS`,
+ * which is the exact call `ReactFlowGraph.tsx:1614` makes when a user drags a
+ * connection. A gate that only fires for a fixture nobody can produce is the
+ * dead read gate this whole track exists to close, so the "unset" branch is
+ * proved reachable FROM THE PRODUCT, and the set-value cases below prove the
+ * same code path still discriminates in the other direction.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EdgePanel } from '../panels/EdgePanel'
+import { useCanvasStore } from '../../../store'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import { USER_EDGE_DEFAULTS, EDGE_CONSTRAINTS } from '../../../domain/edges'
+
+const panelProps = {
+  edgeId: 'e1',
+  techMode: false,
+  onClose: vi.fn(),
+  onNavigate: vi.fn(),
+}
+
+const NODES = [
+  { id: 'fac1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Marketing budget' } },
+  { id: 'out1', type: 'outcome', position: { x: 100, y: 0 }, data: { label: 'Revenue' } },
+]
+
+function seedNodes() {
+  useCanvasStore.setState({
+    ...useCanvasStore.getState(),
+    nodes: NODES,
+    edges: [],
+    results: { status: 'none', report: null },
+  } as never)
+}
+
+/** Seed an edge whose `data` is written verbatim (for the SET cases). */
+function seedEdge(data: Record<string, unknown>) {
+  seedNodes()
+  useCanvasStore.setState({
+    ...useCanvasStore.getState(),
+    edges: [{ id: 'e1', source: 'fac1', target: 'out1', type: 'styled', data }],
+  } as never)
+}
+
+/**
+ * REACHABILITY: build the edge the way the product does, then rename it to the
+ * id the panel props use. No hand-authored `data` — whatever `addEdge` +
+ * `USER_EDGE_DEFAULTS` produce is what the panel sees.
+ */
+function drawEdgeThroughProduct() {
+  seedNodes()
+  const result = useCanvasStore
+    .getState()
+    .addEdge({ source: 'fac1', target: 'out1', data: { ...USER_EDGE_DEFAULTS } } as never)
+  expect((result as { created: boolean }).created).toBe(true)
+  const drawn = useCanvasStore.getState().edges
+  expect(drawn).toHaveLength(1)
+  useCanvasStore.setState({
+    ...useCanvasStore.getState(),
+    edges: [{ ...drawn[0], id: 'e1' }],
+  } as never)
+  return drawn[0]
+}
+
+function readout(): HTMLElement {
+  return screen.getByTestId('edge-existence-readout')
+}
+
+function trackFill(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[data-testid="inspector-slider-track-fill"]')
+}
+
+beforeEach(() => {
+  useCanvasStore.setState(useCanvasStore.getState(), true)
+  useGuidanceStore.setState({ guidanceItems: [], _prefillChat: null, _sendMessage: null })
+})
+
+describe('EdgePanel — existence readout colour is provenance-gated', () => {
+  it('POSITIVE CONTROL: an edge drawn through the product renders no verdict colour', () => {
+    const drawn = drawEdgeThroughProduct()
+    // The state under test is real: the product's own edge-creation path
+    // supplies a beliefExists number and NO source stamp.
+    expect(typeof (drawn.data as Record<string, unknown>).beliefExists).toBe('number')
+    expect((drawn.data as Record<string, unknown>).beliefExistsSource).toBeUndefined()
+
+    const { container } = render(<EdgePanel {...panelProps} />)
+
+    const cls = readout().className
+    expect(cls).not.toContain('text-success')
+    expect(cls).not.toContain('text-warning')
+    expect(cls).not.toContain('text-danger')
+    expect(cls).toContain('text-text-light')
+    // The coloured track fill is the same verdict in a second channel.
+    expect(trackFill(container)).toBeNull()
+  })
+
+  it('POSITIVE CONTROL (other direction): a user-set high value still renders green', () => {
+    seedEdge({ weight: 0.35, direction: 'positive', beliefExists: 0.82, beliefExistsSource: 'user' })
+    const { container } = render(<EdgePanel {...panelProps} />)
+
+    expect(readout().className).toContain('text-success')
+    expect(readout().className).not.toContain('text-text-light')
+    const fill = trackFill(container)
+    expect(fill).not.toBeNull()
+    expect(fill!.getAttribute('style')).toContain('var(--success)')
+  })
+
+  it('discriminates the moderate band for a set value', () => {
+    seedEdge({ beliefExists: 0.5, beliefExistsSource: 'cee' })
+    render(<EdgePanel {...panelProps} />)
+    expect(readout().className).toContain('text-warning')
+  })
+
+  it('discriminates the low band for a set value', () => {
+    seedEdge({ beliefExists: 0.2, beliefExistsSource: 'template' })
+    render(<EdgePanel {...panelProps} />)
+    expect(readout().className).toContain('text-danger')
+  })
+
+  it('back-compat: a pre-marker CEE edge (exists_probability) is still coloured', () => {
+    // `edgeValueSource` accepts `exists_probability` as producer evidence, so
+    // graphs saved before the marker existed must not regress to neutral.
+    seedEdge({ beliefExists: 0.9, exists_probability: 0.9 })
+    render(<EdgePanel {...panelProps} />)
+    expect(readout().className).toContain('text-success')
+  })
+
+  it('an edge with NO beliefExists at all falls to the 0.7 default and must stay neutral', () => {
+    // This is the exact path named in the defect: `EDGE_CONSTRAINTS
+    // .beliefExists.default` is 0.7, which `thresholdColor` banded as green.
+    expect(EDGE_CONSTRAINTS.beliefExists.default).toBe(0.7)
+    seedEdge({ weight: 0.35, direction: 'positive' })
+    render(<EdgePanel {...panelProps} />)
+    expect(screen.getByText('70%')).toBeTruthy()
+    expect(readout().className).not.toContain('text-success')
+    expect(readout().className).toContain('text-text-light')
+  })
+
+  it('CONTRADICTION: the panel cannot say "nobody has said" and colour it green at once', () => {
+    drawEdgeThroughProduct()
+    render(<EdgePanel {...panelProps} />)
+    // The prose disclosure is present…
+    expect(
+      screen.getByText(/Nobody has said how likely this connection is to exist yet/),
+    ).toBeTruthy()
+    // …so the colour channel must not contradict it.
+    expect(readout().className).not.toContain('text-success')
+  })
+})

--- a/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
@@ -35,7 +35,13 @@ import { ResultsLink } from '../shared/ResultsLink'
 import type { InspectorPanelProps } from '../types'
 import { isEdgeFragile, getFragileEdgeSwitchProbability } from '../../../utils/fragileEdgeMatch'
 import { resolveEdgeValuesCoaching } from '../coachingConfig'
-import { edgeValueSource } from '../../../domain/edgeValueProvenance'
+import {
+  edgeValueBand,
+  edgeValueSource,
+  resolveEdgeValueDisplay,
+  withLiveEdgeValue,
+  type EdgeValueBand,
+} from '../../../domain/edgeValueProvenance'
 import { useEditImpactPreview } from '../../../hooks/useEditImpactPreview'
 import { StrengthBandButtons } from '../shared/StrengthBandButtons'
 import { EdgeAdvancedEditor } from '../editors/EdgeAdvancedEditor'
@@ -105,17 +111,37 @@ function InspectorSlider({
   )
 }
 
-// ─── Confidence threshold colour ───────────────────────────────────
-function thresholdColor(v: number): string {
-  if (v >= 0.7) return 'text-success'
-  if (v >= 0.4) return 'text-warning'
-  return 'text-danger'
+// ─── Existence band → channel tokens ───────────────────────────────
+//
+// ⛔ These used to be `thresholdColor(v: number)` / `thresholdTrackVar(v:
+// number)`: three branches each, `>= 0.7` green / `>= 0.4` amber / else red,
+// and NO branch that could express "nobody set this". `beliefExists` falls
+// through to `EDGE_CONSTRAINTS.beliefExists.default` (0.7) when absent and
+// `USER_EDGE_DEFAULTS` pins it at 0.8 when the user simply drew the edge — so
+// BOTH unset states banded GREEN, directly beneath this panel's own coaching
+// sentence "Nobody has said how likely this connection is to exist yet."
+// #472/#473 gated the number; the colour carried the same claim wordlessly,
+// and pre-attentively, which makes it the harder one to disbelieve.
+//
+// The input is now `EdgeValueBand`, which is derived from `EdgeValueDisplay`
+// and therefore cannot be produced without a provenance verdict — a future
+// caller has no way to ask for "the colour of 0.7, source unknown". `Record`
+// rather than `switch`: adding a band is a type error here, not a silent
+// inheritance of a neighbour's colour.
+const EXISTENCE_BAND_TEXT: Record<EdgeValueBand, string> = {
+  unset: 'text-text-light',
+  low: 'text-danger',
+  moderate: 'text-warning',
+  high: 'text-success',
 }
 
-function thresholdTrackVar(v: number): string {
-  if (v >= 0.7) return 'var(--success)'
-  if (v >= 0.4) return 'var(--warning)'
-  return 'var(--danger)'
+// `undefined` ⇒ `InspectorSlider` renders no fill overlay at all. An unset
+// value gets a plain track, not a grey bar sized to a number nobody chose.
+const EXISTENCE_BAND_TRACK: Record<EdgeValueBand, string | undefined> = {
+  unset: undefined,
+  low: 'var(--danger)',
+  moderate: 'var(--warning)',
+  high: 'var(--success)',
 }
 
 export const EdgePanel = memo(function EdgePanel({
@@ -173,6 +199,22 @@ export const EdgePanel = memo(function EdgePanel({
   const [localStrength, setLocalStrength] = useState(signedValue)
   const [localBelief, setLocalBelief] = useState(beliefExists)
   const [localStd, setLocalStd] = useState(strengthStd)
+
+  // Existence band for the colour + track-fill channels. Provenance comes from
+  // the STORE (the only thing that knows whether anyone set this); the value
+  // comes from the live slider, so the colour bands the number on screen rather
+  // than one a debounce tick behind it. `withLiveEdgeValue` cannot upgrade an
+  // unset verdict, so this composition cannot fabricate a source.
+  const existenceBand: EdgeValueBand = useMemo(
+    () =>
+      edgeValueBand(
+        withLiveEdgeValue(
+          resolveEdgeValueDisplay(edge?.data as Record<string, unknown> | undefined, 'beliefExists'),
+          localBelief,
+        ),
+      ),
+    [edge?.data, localBelief],
+  )
 
   // Fragility check
   const isFragile = useMemo(() => {
@@ -338,11 +380,11 @@ export const EdgePanel = memo(function EdgePanel({
                     max={1}
                     step={0.05}
                     onChange={handleBeliefChange}
-                    trackFillColor={thresholdTrackVar(localBelief)}
+                    trackFillColor={EXISTENCE_BAND_TRACK[existenceBand]}
                     aria-label="Connection existence probability"
                   />
                 </div>
-                <span className={`${typography.panelBody} min-w-[32px] text-right ${thresholdColor(localBelief)}`}>
+                <span data-testid="edge-existence-readout" className={`${typography.panelBody} min-w-[32px] text-right ${EXISTENCE_BAND_TEXT[existenceBand]}`}>
                   {Math.round(localBelief * 100)}%
                 </span>
               </div>


### PR DESCRIPTION
## The defect (verified at the bytes on `03707a72`, not inherited)

`src/canvas/ui/inspector-v2/panels/EdgePanel.tsx:108-119`:

```ts
function thresholdColor(v: number): string {
  if (v >= 0.7) return 'text-success'
  if (v >= 0.4) return 'text-warning'
  return 'text-danger'
}
```

Three branches, and **no branch that can express "nobody set this"**. Two
distinct unset states both landed in the green band:

| how the edge got there | `beliefExists` | rendered |
|---|---|---|
| field absent → `EDGE_CONSTRAINTS.beliefExists.default` | `0.7` | green, "70%" |
| user drew it (`ReactFlowGraph.tsx:1614` → `addEdge({…, data: USER_EDGE_DEFAULTS })`) | `0.8`, **unstamped** | green, "80%" |

**The contradiction is inside this same panel.** `EdgePanel.tsx:157-163`
already renders `resolveEdgeValuesCoaching(...)`, whose `not_set` copy reads
*"Nobody has said how likely this connection is to exist yet."* — directly
beneath a green 70/80%.

#472/#473/#474 gated the number. The colour carried the same claim wordlessly.
Colour is read pre-attentively and delivers a verdict ("this is fine") that
nobody consciously evaluates, so of the two claims on that screen the wordless
one was both the stronger and the false one.

## Fixed at the type level, not at the call site

A colour function whose input cannot represent "unset" will default again the
next time someone adds a caller, so the **mechanism** moved rather than the
branch. Added beside the union in `canvas/domain/edgeValueProvenance.ts`:

- **`EdgeValueBand = 'unset' | 'low' | 'moderate' | 'high'`** — `unset` is a band
  in its own right, not a fallthrough.
- **`edgeValueBand(display: EdgeValueDisplay)`** — takes the **discriminated
  union, never a `number`**. There is no argument a future caller can construct
  that means *"0.7, source unknown"*. That is exactly the property
  `thresholdColor(v: number)` lacked.
- **`EDGE_VALUE_BAND_CUTS`** — the `0.7`/`0.4` literals were hand-copied in three
  places; named once, cut on the raw value, never on a rounded percentage.
- **`withLiveEdgeValue(display, live)`** — an editing surface holds the in-flight
  value in local state, so the colour must band the number the user is *looking
  at* or the two channels disagree again, just smaller. Provenance is
  deliberately **not** re-derived: `show: false` in ⇒ `show: false` out, so it
  cannot launder a default into a claim.

`EdgePanel` maps the band through `Record<EdgeValueBand, …>` rather than a
`switch`, so adding a band is a **type error at the consumer** instead of a
silent inheritance of a neighbour's colour — same idiom as
`STRENGTH_PROVENANCE_COPY` in `coachingConfig.ts`. `unset` → `text-text-light`
and `trackFillColor: undefined`, which makes `InspectorSlider` render **no fill
overlay at all**: no grey bar sized to a number nobody chose.

## Evidence

**RED-first.** The `data-testid` was added *first*, so the red is semantic
rather than a missing selector: **3 failed / 4 passed**, the three failures each
on `expect(cls).not.toContain('text-success')`. **7/7** after the fix.

**Reachability positive control.** The unset fixture is not hand-written —
`drawEdgeThroughProduct()` goes through `useCanvasStore.addEdge` with
`USER_EDGE_DEFAULTS`, the same call the canvas makes on a user drag, and asserts
on the resulting edge that `beliefExists` is a number and `beliefExistsSource`
is `undefined` **before** rendering. A gate that only fires for a fixture nobody
can produce is the dead read gate this track exists to close. Both directions
proved: unset → no verdict class; stamped `0.82` → `text-success` still present;
back-compat `exists_probability` still colours.

**Mutation-checked in a throwaway worktree** (removed after), runner first
verified to actually execute tests (45 run, 45 pass):

| mutation | result |
|---|---|
| `EdgePanel` bands the raw number again (pre-fix behaviour) | **RED — 3 failed / 4 passed** |
| `edgeValueBand` returns `'high'` for unset + `withLiveEdgeValue` launders unset → sourced | **RED — exit 1, 7 failed / 38 passed** |

**Claim type:** rendered-`class`-attribute and DOM-node presence. **Not**
visibility, contrast or layout — jsdom cannot prove those (platform trap 3), and
nothing in the new spec pretends to.

## Gates

- `pnpm run typecheck` — **PASSED** (coverage + ratchet). Baseline deliberately
  **not** regenerated: total diagnostics are identical at 2915 before and after,
  so the 2663→2661 notice is attribution churn in two files this PR never
  touches (`useV2Run.ts`, `hydrateAnalysis.ts`), not an improvement to encode.
- `eslint` on the 4 changed files — **0 errors** (2 pre-existing warnings).
- Targeted suite `src/canvas/{domain,ui,nodes,edges,components/model-tab}` +
  `tests/contracts` — **108 files / 1745 tests passed**, including the
  `cee-rendering-claims` harness.
- `scripts/validate-prepush.sh` — Checks 1–7 **pass**. Check 8 (DS v5 drift)
  **fails identically on pristine `03707a72`** (same counts 306/311, 45/34, same
  net-new list in `analyticalNodeFields.ts` + `results/v7/*` — none of them files
  this PR touches). **Pre-existing red on staging, not introduced here.**

## Sibling channels found and NOT fixed here

A tree-wide sweep found ~20 more places where a suppressed number still leaks
through colour, width, icon, ordering or severity. They are listed in the lane
checkpoint rather than folded in silently. Highest value: `ConnectionRow`
(8 panels, colour + width + band label, and the prop type is the enabler),
`StyledEdge` (stroke colour, thickness, dash — under an already-gated popover),
and `OutcomePanel:160` (a literal un-fixed twin of the tautological presence
check `OutcomeNode.tsx` already fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)