### PR TITLE
fix(honesty): close the NON-TEXT channels — order, bar, stroke — that still spoke the default

### DIFF
--- a/src/canvas/__tests__/unsetNonTextChannels.spec.tsx
+++ b/src/canvas/__tests__/unsetNonTextChannels.spec.tsx
@@ -1,0 +1,277 @@
+/**
+ * The NON-TEXT channels must not speak a value nobody set.
+ *
+ * WHAT THIS PINS
+ * --------------
+ * #472–#476 closed the TEXT channel and then the EdgePanel's COLOUR. This file
+ * pins the channels those PRs did not reach — ORDER, a shared row component's
+ * bar/band, an edge's stroke colour and thickness — and the registry gap that
+ * left `strengthStd` with no marker to consult at all.
+ *
+ * CLAIM TYPE — read before adding an assertion here.
+ * -------------------------------------------------
+ * Assertions are of exactly three kinds, and nothing here claims more:
+ *   1. **Pure-function return values** (`compareEdgeValueDisplays`,
+ *      `aggregateEdgeSignedStrength`, `computeDirectionStroke`,
+ *      `resolveEdgeValueDisplay`) — the strongest claims in the file.
+ *   2. **Rendered text / DOM-node presence** (`ConnectionRow`).
+ *   3. **Rendered order** — the sequence of `data-testid` nodes in the DOM.
+ * jsdom cannot prove VISIBILITY, contrast or layout (platform trap 3). "Not
+ * coloured green" below means *the returned token is not the positive one* or
+ * *the element does not carry that class*, nothing more.
+ *
+ * REACHABILITY POSITIVE CONTROL
+ * -----------------------------
+ * Two defects in this exact area were branches that could never fire while
+ * their comments claimed otherwise (`OutcomeNode`'s `weight != null`;
+ * `computeDirectionStroke`'s `rawWeight === undefined` yellow arm). So every
+ * "unset" fixture here is built by `drawEdgeThroughProduct()`, which calls
+ * `useCanvasStore.addEdge` with `USER_EDGE_DEFAULTS` — the exact call
+ * `ReactFlowGraph.tsx` makes when a user drags a connection — and asserts the
+ * fabricated number IS present and the stamp is NOT before anything is
+ * rendered. Each block also proves the same path still discriminates the other
+ * way, so a gate that simply returned "unset" for everything would fail too.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useCanvasStore } from '../store'
+import { USER_EDGE_DEFAULTS } from '../domain/edges'
+import {
+  resolveEdgeValueDisplay,
+  resolveEdgeSignedStrengthDisplay,
+  compareEdgeValueDisplays,
+  compareEdgeValueAggregates,
+  aggregateEdgeSignedStrength,
+  edgeSourceKey,
+  EDGE_PROVENANCED_FIELDS,
+  EDGE_VALUE_SOURCE_KEYS,
+  type EdgeValueDisplay,
+} from '../domain/edgeValueProvenance'
+import { computeDirectionStroke } from '../edges/directionStroke'
+import { ConnectionRow } from '../ui/inspector-v2/shared/ConnectionRow'
+
+const NODES = [
+  { id: 'fac1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Marketing budget' } },
+  { id: 'out1', type: 'outcome', position: { x: 100, y: 0 }, data: { label: 'Revenue' } },
+]
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    ...useCanvasStore.getState(),
+    nodes: NODES,
+    edges: [],
+    results: { status: 'none', report: null },
+  } as never)
+})
+
+/**
+ * REACHABILITY: build the edge the way the product does. No hand-authored
+ * `data` — whatever `addEdge` + `USER_EDGE_DEFAULTS` produce is what the
+ * surfaces under test see.
+ */
+function drawEdgeThroughProduct(): Record<string, unknown> {
+  const result = useCanvasStore
+    .getState()
+    .addEdge({ source: 'fac1', target: 'out1', data: { ...USER_EDGE_DEFAULTS } } as never)
+  expect((result as { created: boolean }).created).toBe(true)
+  const drawn = useCanvasStore.getState().edges
+  expect(drawn).toHaveLength(1)
+  return drawn[0].data as unknown as Record<string, unknown>
+}
+
+describe('reachability positive control — a user-drawn edge really is unset', () => {
+  it('carries fabricated numbers and NO source stamps', () => {
+    const data = drawEdgeThroughProduct()
+    // The fabrication is real: numbers are present…
+    expect(typeof data.weight).toBe('number')
+    expect(typeof data.beliefExists).toBe('number')
+    expect(typeof data.strengthStd).toBe('number')
+    // …and a direction is present too, which is why gating on `weight`
+    // alone would still let "Raises"/green through.
+    expect(data.direction).toBe('positive')
+    // …but nothing proves any of them was set by anyone.
+    for (const key of EDGE_VALUE_SOURCE_KEYS) expect(data[key]).toBeUndefined()
+
+    expect(resolveEdgeSignedStrengthDisplay(data).show).toBe(false)
+    expect(resolveEdgeValueDisplay(data, 'weight').show).toBe(false)
+    expect(resolveEdgeValueDisplay(data, 'beliefExists').show).toBe(false)
+  })
+})
+
+describe('EDGE_PROVENANCED_FIELDS — the registry, not a call site', () => {
+  it('covers strengthStd, and its marker key is DERIVED from the field name', () => {
+    expect([...EDGE_PROVENANCED_FIELDS]).toContain('strengthStd')
+    // Derivation, not a hand-written ternary: every field maps to its own key.
+    for (const field of EDGE_PROVENANCED_FIELDS) {
+      expect(edgeSourceKey(field)).toBe(`${field}Source`)
+    }
+    expect([...EDGE_VALUE_SOURCE_KEYS]).toEqual([
+      'beliefExistsSource',
+      'weightSource',
+      'strengthStdSource',
+    ])
+  })
+
+  it('reports a user-drawn strengthStd as unset, and a stamped one as set', () => {
+    const data = drawEdgeThroughProduct()
+    // USER_EDGE_DEFAULTS fabricates 0.15 — the number KeyRelationships turned
+    // into a "Moderate confidence" dot.
+    expect(data.strengthStd).toBe(0.15)
+    expect(resolveEdgeValueDisplay(data, 'strengthStd').show).toBe(false)
+
+    // Discriminates: a std the user actually set is reportable.
+    const set = resolveEdgeValueDisplay(
+      { strengthStd: 0.4, strengthStdSource: 'user' },
+      'strengthStd',
+    )
+    expect(set).toEqual({ show: true, value: 0.4, source: 'user' })
+  })
+})
+
+describe('ORDER — unset sorts last in BOTH directions', () => {
+  const unset: EdgeValueDisplay = { show: false, reason: 'not_set' }
+  const low: EdgeValueDisplay = { show: true, value: 0.1, source: 'cee' }
+  const high: EdgeValueDisplay = { show: true, value: 0.9, source: 'cee' }
+
+  it('does not use a sentinel that flips with the sort direction', () => {
+    // This is the property `-Infinity` / `+Infinity` could not hold. The old
+    // sites hand-compensated the sentinel's SIGN against the comparator, two
+    // lines apart in ModelTabBody.
+    expect(compareEdgeValueDisplays(unset, high, 'desc')).toBeGreaterThan(0)
+    expect(compareEdgeValueDisplays(unset, high, 'asc')).toBeGreaterThan(0)
+    expect(compareEdgeValueDisplays(unset, low, 'desc')).toBeGreaterThan(0)
+    expect(compareEdgeValueDisplays(unset, low, 'asc')).toBeGreaterThan(0)
+    expect(compareEdgeValueDisplays(high, unset, 'asc')).toBeLessThan(0)
+    expect(compareEdgeValueDisplays(unset, unset, 'desc')).toBe(0)
+  })
+
+  it('still orders SET values by magnitude in the requested direction', () => {
+    expect(compareEdgeValueDisplays(high, low, 'desc')).toBeLessThan(0)
+    expect(compareEdgeValueDisplays(high, low, 'asc')).toBeGreaterThan(0)
+  })
+
+  it('sorts a real drawn edge below a measured one', () => {
+    const drawn = drawEdgeThroughProduct()
+    const measured = { weight: 0.05, direction: 'positive', weightSource: 'user' }
+    const sorted = [drawn, measured].sort((a, b) =>
+      compareEdgeValueDisplays(
+        resolveEdgeSignedStrengthDisplay(a),
+        resolveEdgeSignedStrengthDisplay(b),
+        'desc',
+      ),
+    )
+    // 0.05 is far WEAKER than the drawn edge's fabricated 0.3, and still ranks
+    // above it: "we measured a small effect" outranks "we know nothing".
+    expect(sorted[0]).toBe(measured)
+  })
+})
+
+describe('AGGREGATE — a rank built from nothing is not a rank', () => {
+  it('counts only sourced contributions', () => {
+    const drawn = drawEdgeThroughProduct()
+    const agg = aggregateEdgeSignedStrength(
+      [drawn, { weight: 0.6, direction: 'positive', weightSource: 'cee' }],
+      { magnitude: true },
+    )
+    expect(agg).toEqual({ show: true, value: 0.6, sourcedCount: 1, unsourcedCount: 1 })
+  })
+
+  it('reports no evidence when nothing is sourced', () => {
+    const drawn = drawEdgeThroughProduct()
+    expect(aggregateEdgeSignedStrength([drawn, drawn])).toEqual({
+      show: false,
+      reason: 'not_set',
+    })
+    expect(aggregateEdgeSignedStrength([])).toEqual({ show: false, reason: 'absent' })
+  })
+
+  it('sums magnitudes so a strong negative counts as leverage', () => {
+    const agg = aggregateEdgeSignedStrength(
+      [
+        { weight: 0.5, direction: 'negative', weightSource: 'cee' },
+        { weight: 0.5, direction: 'positive', weightSource: 'cee' },
+      ],
+      { magnitude: true },
+    )
+    expect(agg.show && agg.value).toBeCloseTo(1.0)
+  })
+
+  it('ranks no-evidence aggregates last in both directions', () => {
+    const none = aggregateEdgeSignedStrength([])
+    const some = aggregateEdgeSignedStrength([{ weight: 0.2, weightSource: 'cee' }])
+    expect(compareEdgeValueAggregates(none, some, 'desc')).toBeGreaterThan(0)
+    expect(compareEdgeValueAggregates(none, some, 'asc')).toBeGreaterThan(0)
+  })
+})
+
+describe('STROKE COLOUR — computeDirectionStroke', () => {
+  it('gives an edge drawn through the product NO verdict colour', () => {
+    const data = drawEdgeThroughProduct()
+    const display = resolveEdgeSignedStrengthDisplay(data)
+    const stroke = computeDirectionStroke(
+      data.direction as 'positive' | 'negative' | undefined,
+      display,
+      false,
+    )
+    // The defaulted `direction: 'positive'` must NOT reach the green.
+    expect(stroke).not.toBe('var(--edge-positive)')
+    expect(stroke).toBe('var(--edge-neutral)')
+  })
+
+  it('still discriminates when the strength IS sourced', () => {
+    const set: EdgeValueDisplay = { show: true, value: 0.6, source: 'user' }
+    expect(computeDirectionStroke('positive', set, false)).toBe('var(--edge-positive)')
+    expect(computeDirectionStroke('negative', set, false)).toBe('var(--edge-negative)')
+    expect(computeDirectionStroke('positive', set, true)).toBe('var(--edge-positive-dark)')
+    // weight 0 is a valid user choice → neutral, unchanged.
+    expect(
+      computeDirectionStroke('positive', { show: true, value: 0, source: 'user' }, false),
+    ).toBe('var(--edge-neutral)')
+  })
+})
+
+describe('ConnectionRow — the prop type is the gate', () => {
+  it('renders "Not set" and NO strength bar for an unset connection', () => {
+    const data = drawEdgeThroughProduct()
+    render(
+      <ConnectionRow
+        nodeKind="factor"
+        label="Marketing budget"
+        strength={resolveEdgeSignedStrengthDisplay(data)}
+      />,
+    )
+    expect(screen.getByTestId('connection-row-strength-not-set')).toBeTruthy()
+    expect(screen.queryByTestId('connection-row-strength')).toBeNull()
+    // The band label and the ± glyph are both part of the same claim.
+    expect(screen.queryByText(/Moderate/)).toBeNull()
+    expect(screen.queryByText(/Slight/)).toBeNull()
+  })
+
+  it('still renders the bar and band label for a sourced connection', () => {
+    render(
+      <ConnectionRow
+        nodeKind="factor"
+        label="Marketing budget"
+        strength={{ show: true, value: 0.62, source: 'cee' }}
+      />,
+    )
+    const bar = screen.getByTestId('connection-row-strength')
+    expect(bar).toBeTruthy()
+    expect(bar.querySelector('.bg-success')).toBeTruthy()
+    expect(screen.queryByTestId('connection-row-strength-not-set')).toBeNull()
+    expect(screen.getByText(/Strong/)).toBeTruthy()
+  })
+
+  it('renders no strength affordance at all when there is no value', () => {
+    render(
+      <ConnectionRow
+        nodeKind="option"
+        label="Ship it"
+        strength={{ show: false, reason: 'absent' }}
+      />,
+    )
+    expect(screen.queryByTestId('connection-row-strength')).toBeNull()
+    expect(screen.queryByTestId('connection-row-strength-not-set')).toBeNull()
+  })
+})

--- a/src/canvas/components/DraftChat.tsx
+++ b/src/canvas/components/DraftChat.tsx
@@ -630,6 +630,7 @@ export function DraftChat() {
           ...edgeValueSourcePatch({
             beliefExists: (beliefExistsValue ?? confidence) !== undefined ? 'cee' : undefined,
             weight: weightSource !== 'default' ? 'cee' : undefined,
+            strengthStd: strengthStd !== undefined ? 'cee' : undefined,
           }),
           provenance: provenanceText,
           // Brief v2.2: New edge properties

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -22,7 +22,7 @@ import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
 import { AnalysisRunStateCover } from './AnalysisRunStateCover'
 import { useUIStore } from '../../stores/uiStore'
 import { getDisplayEdgeId, buildFragileEdgeLookup } from '../utils/edgeIdentity'
-import { edgeValueSource } from '../domain/edgeValueProvenance'
+import { edgeValueSource, resolveEdgeValueDisplay, compareEdgeValueDisplays } from '../domain/edgeValueProvenance'
 import { getCausalEdges } from '../domain/edgeUtils'
 import { SectionErrorBoundary } from './GraphTextView'
 import type { MappedRobustness } from '../../lib/mappers/types'
@@ -481,21 +481,32 @@ export const ModelTabBody = memo(function ModelTabBody({
       const bSwitchProb = fragileEdgeSwitchProbMap.get(bId) ?? -1
       if (aSwitchProb !== bSwitchProb) return bSwitchProb - aSwitchProb
 
-      const aData = a.data as any
-      const bData = b.data as any
-      // Display-only defaults for edge sort order — below UI-SEM tagging threshold.
-      // Missing confidence → sort last (Infinity in ascending order)
-      // Canvas store canonical name — CEE ingestion normalises to beliefExists
-      const aConf = aData?.beliefExists ?? aData?.confidence
-      const bConf = bData?.beliefExists ?? bData?.confidence
-      const aConfVal = aConf != null ? aConf : Infinity
-      const bConfVal = bConf != null ? bConf : Infinity
-      if (Math.abs(aConfVal - bConfVal) > 0.001) return aConfVal - bConfVal
+      const aData = a.data as Record<string, unknown> | undefined
+      const bData = b.data as Record<string, unknown> | undefined
 
-      // Missing weight → sort last (-Infinity in descending order)
-      const aWeight = aData?.weight != null ? aData.weight : -Infinity
-      const bWeight = bData?.weight != null ? bData.weight : -Infinity
-      return bWeight - aWeight
+      // ⛔ Provenance gate on the ORDER. The sentinels here were wrong twice:
+      // `!= null` is a tautology (`DEFAULT_EDGE_DATA`/`USER_EDGE_DEFAULTS`
+      // always define both fields, so neither arm could fire and every
+      // defaulted edge ranked as a measured one), and the two sentinels had
+      // OPPOSITE SIGNS — `+Infinity` for the ascending key, `-Infinity` for the
+      // descending one — a hand-compensation that silently inverts the moment
+      // either sort direction changes. `compareEdgeValueDisplays` puts unset
+      // last in BOTH directions without a sentinel, so the order cannot drift
+      // from the intent. The export payload below this list was already gated;
+      // this brings the on-screen order into line with the copied JSON.
+      const aConf = resolveEdgeValueDisplay(aData, 'beliefExists')
+      const bConf = resolveEdgeValueDisplay(bData, 'beliefExists')
+      const confOrder = compareEdgeValueDisplays(aConf, bConf, 'asc')
+      const bothConfShown = aConf.show && bConf.show
+      if (!bothConfShown ? confOrder !== 0 : Math.abs(aConf.value - bConf.value) > 0.001) {
+        return confOrder
+      }
+
+      return compareEdgeValueDisplays(
+        resolveEdgeValueDisplay(aData, 'weight'),
+        resolveEdgeValueDisplay(bData, 'weight'),
+        'desc',
+      )
     })
   }, [causalEdges, fragileEdgeSwitchProbMap])
 

--- a/src/canvas/components/model-tab/RelationshipsSection.tsx
+++ b/src/canvas/components/model-tab/RelationshipsSection.tsx
@@ -41,6 +41,7 @@ import type { ValidationMetadata, UserAction } from '../../domain/validation'
 import {
   resolveEdgeValueDisplay,
   resolveEdgeSignedStrengthDisplay,
+  compareEdgeValueDisplays,
 } from '../../domain/edgeValueProvenance'
 
 /** Repair display entry for edge detail */
@@ -578,12 +579,16 @@ function RelationshipsSectionInner({
       const bSwitchProb = fragileEdgeSwitchProbMap.get(bId) ?? -1
       if (aSwitchProb !== bSwitchProb) return bSwitchProb - aSwitchProb
 
-      const aData = a.data as Record<string, unknown>
-      const bData = b.data as Record<string, unknown>
-      // Missing weight → sort last (-Infinity in descending order)
-      const aWeight = aData?.weight != null ? (aData.weight as number) : -Infinity
-      const bWeight = bData?.weight != null ? (bData.weight as number) : -Infinity
-      return bWeight - aWeight
+      // ⛔ Provenance gate on the ORDER. #473 gated this section's colour,
+      // width, StrengthBar and band label — the SORT was the one channel left,
+      // and its `!= null` guard was a tautology, so a card whose own body reads
+      // "Not set" still ranked above a measured one. Unset now sorts last for
+      // real, via the shared comparator rather than a sentinel.
+      return compareEdgeValueDisplays(
+        resolveEdgeValueDisplay(a.data as Record<string, unknown> | undefined, 'weight'),
+        resolveEdgeValueDisplay(b.data as Record<string, unknown> | undefined, 'weight'),
+        'desc',
+      )
     })
   }, [nonContestedEdges, fragileEdgeSwitchProbMap])
 

--- a/src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx
@@ -94,6 +94,57 @@ function makeEdge(id: string, source: string, target: string, opts: {
 
 const nodes = [makeNode('f1', 'Factor A'), makeNode('f2', 'Factor B')]
 
+/** An edge exactly as a user drag produces it: numbers present, no stamps. */
+function makeUnstampedEdge(id: string, source: string, target: string, weight: number): Edge {
+  return {
+    id,
+    source,
+    target,
+    data: { ...USER_EDGE_DEFAULTS, weight, provenance: 'assumption' },
+  } as Edge
+}
+
+/**
+ * ORDER is a channel too, and it was the last one leaking here.
+ *
+ * #473 gated this section's colour, width, StrengthBar and band label. The
+ * SORT still read `aData?.weight != null ? weight : -Infinity` — a TAUTOLOGY,
+ * because `USER_EDGE_DEFAULTS`/`DEFAULT_EDGE_DATA` always define `weight`. So
+ * the `-Infinity` arm was dead and a card whose own body says "Not set" ranked
+ * above a measured one purely on its default.
+ *
+ * CLAIM TYPE: rendered ORDER — the sequence of `edge-card-*` testids in the
+ * DOM. Not visibility, not layout.
+ */
+describe('RelationshipsSection — sort order is provenance-gated', () => {
+  function renderedOrder(): string[] {
+    return Array.from(document.querySelectorAll('[data-testid^="edge-card-"]')).map(
+      el => el.getAttribute('data-testid') as string,
+    )
+  }
+
+  it('ranks an unset edge BELOW a measured one, even when its default is larger', () => {
+    // The unset edge's fabricated weight (0.9) beats the measured one (0.2).
+    // Under the old sentinel it sorted first; "we measured a small effect"
+    // must outrank "nobody has said".
+    const edges = [
+      makeUnstampedEdge('unset', 'f1', 'f2', 0.9),
+      makeEdge('measured', 'f2', 'f1', { weight: 0.2 }),
+    ]
+    render(<RelationshipsSection edges={edges} nodes={nodes} />)
+    expect(renderedOrder()).toEqual(['edge-card-measured', 'edge-card-unset'])
+  })
+
+  it('still orders two MEASURED edges by weight descending (discrimination)', () => {
+    const edges = [
+      makeEdge('weak', 'f1', 'f2', { weight: 0.2 }),
+      makeEdge('strong', 'f2', 'f1', { weight: 0.9 }),
+    ]
+    render(<RelationshipsSection edges={edges} nodes={nodes} />)
+    expect(renderedOrder()).toEqual(['edge-card-strong', 'edge-card-weak'])
+  })
+})
+
 describe('RelationshipsSection', () => {
   it('renders empty state when no causal edges', () => {
     render(<RelationshipsSection edges={[]} nodes={nodes} />)

--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -1204,7 +1204,16 @@ export function PreAnalysisPanel({
     // computeSignedMean falls through to weight + direction (the canvas schema path).
     // Mark `userReviewedStrength: true` so `buildPriorityProgress` recognises
     // the edge as confirmed in the top-3 priority counter (pre-analysis-power-v2).
-    updateEdgeData(edgeId, { weight: value, strength_mean: undefined, userReviewedStrength: true })
+    //
+    // ⛔ `weightSource: 'user'` is REQUIRED here, not decorative. This handler
+    // fires when the user explicitly picks Weakly / Moderately / Strongly in
+    // `KeyRelationships`, i.e. the one case where the number genuinely came
+    // from a person. Without the stamp that real choice is indistinguishable
+    // from `USER_EDGE_DEFAULTS.weight`, so every downstream surface keeps
+    // saying "Not set" while the picker shows the chosen band highlighted —
+    // the two channels contradicting each other, which is the whole defect
+    // family. Mirrors `useInspectorMutations.setStrength`.
+    updateEdgeData(edgeId, { weight: value, strength_mean: undefined, userReviewedStrength: true, weightSource: 'user' })
   }, [])
 
   // Brief 5.8A D3b/D3c — bundle of T1 handlers. Stable identity so the

--- a/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
+++ b/src/canvas/domain/__tests__/edgeValueProvenance.spec.ts
@@ -26,11 +26,16 @@ import {
 
 describe('edgeValueProvenance — the UI defaults are NOT a source', () => {
   it.each(EDGE_PROVENANCED_FIELDS)(
-    'DEFAULT_EDGE_DATA carries a number for %s but no source, so it reads as NOT SET',
+    'DEFAULT_EDGE_DATA never counts as a source for %s',
     (field) => {
-      // The number IS there — this is exactly the trap: the value is present
-      // and plausible, which is why presence could never have been the test.
-      expect(typeof (DEFAULT_EDGE_DATA as Record<string, unknown>)[field]).toBe('number')
+      const raw = (DEFAULT_EDGE_DATA as Record<string, unknown>)[field]
+      // Where the constant DOES fabricate a value, the number IS there — that
+      // is exactly the trap: the value is present and plausible, which is why
+      // presence could never have been the test. `strengthStd` is the one
+      // provenanced field DEFAULT_EDGE_DATA omits (only USER_EDGE_DEFAULTS
+      // fabricates it), so it is legitimately absent here rather than unset.
+      if (raw !== undefined) expect(typeof raw).toBe('number')
+      // The half that matters holds either way.
       expect(edgeValueSource(DEFAULT_EDGE_DATA as Record<string, unknown>, field)).toBeNull()
       expect(isEdgeValueSet(DEFAULT_EDGE_DATA as Record<string, unknown>, field)).toBe(false)
     },

--- a/src/canvas/domain/edgeValueProvenance.ts
+++ b/src/canvas/domain/edgeValueProvenance.ts
@@ -58,13 +58,38 @@ import { z } from 'zod'
 export const EdgeValueSourceEnum = z.enum(['user', 'cee', 'template'])
 export type EdgeValueSource = z.infer<typeof EdgeValueSourceEnum>
 
-/** The edge fields that carry a set-vs-defaulted marker. */
-export const EDGE_PROVENANCED_FIELDS = ['beliefExists', 'weight'] as const
+/**
+ * The edge fields that carry a set-vs-defaulted marker.
+ *
+ * ⚠ THIS ARRAY IS THE REGISTRY. A field missing from it is not "unprotected at
+ * one call site" — it is a field for which the mechanism does not exist, so no
+ * consumer can gate it even if it wants to. `strengthStd` was exactly that gap:
+ * `USER_EDGE_DEFAULTS.strengthStd = 0.15` fabricates an uncertainty on every
+ * user-drawn edge, and `KeyRelationships.getConfidenceBand` painted it as a
+ * "Moderate confidence" dot with no way to ask where it came from.
+ *
+ * Adding a field here extends `EdgeValueSourceKey`, `EDGE_VALUE_SOURCE_KEYS`
+ * (the strip list) and `edgeValueSourcePatch`'s argument type automatically —
+ * see `edgeSourceKey` below. Nothing about a provenanced field is hand-listed.
+ */
+export const EDGE_PROVENANCED_FIELDS = ['beliefExists', 'weight', 'strengthStd'] as const
 export type EdgeProvenancedField = (typeof EDGE_PROVENANCED_FIELDS)[number]
 
+/**
+ * The marker key for a provenanced field, DERIVED from its name.
+ *
+ * Was a hand-written ternary returning a hand-written union
+ * (`'beliefExistsSource' | 'weightSource'`) — a two-entry mirror of the array
+ * above, and adding a third field to the array would have silently mapped it
+ * to `'weightSource'` (the ternary's else branch) rather than failing. The
+ * template-literal type makes the union a projection of the registry, so the
+ * two cannot drift.
+ */
+export type EdgeValueSourceKey = `${EdgeProvenancedField}Source`
+
 /** Marker key for a provenanced field, e.g. `beliefExists` → `beliefExistsSource`. */
-export function edgeSourceKey(field: EdgeProvenancedField): 'beliefExistsSource' | 'weightSource' {
-  return field === 'beliefExists' ? 'beliefExistsSource' : 'weightSource'
+export function edgeSourceKey(field: EdgeProvenancedField): EdgeValueSourceKey {
+  return `${field}Source`
 }
 
 function asSource(value: unknown): EdgeValueSource | null {
@@ -92,6 +117,12 @@ export function edgeValueSource(
   // the marker existed. See the module header for why these two specifically.
   if (field === 'beliefExists' && typeof data.exists_probability === 'number') return 'cee'
   if (field === 'weight' && typeof data.strength_mean === 'number') return 'cee'
+  // `strengthStd` has NO back-compat fallback. `DraftChat` destructures
+  // `strength_std` OUT of its passthrough spread and `applyDraftResult` never
+  // writes it, so no producer-only raw std survives into edge `data` to serve
+  // as evidence — while `USER_EDGE_DEFAULTS` DOES fabricate `strengthStd:
+  // 0.15`. Inventing a fallback here would launder that default, which is the
+  // one failure mode this module exists to make impossible.
 
   return null
 }
@@ -165,8 +196,8 @@ export function resolveEdgeValueDisplay(
         : typeof data.belief === 'number'
           ? data.belief
           : undefined
-      : typeof data.weight === 'number'
-        ? data.weight
+      : typeof data[field] === 'number'
+        ? (data[field] as number)
         : undefined
 
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return { show: false, reason: 'absent' }
@@ -325,12 +356,135 @@ export function stripEdgeValueSourceKeys<T extends Record<string, unknown>>(
  *                                   weight: wireHadStrength ? 'cee' : undefined }) }
  * ```
  */
-export function edgeValueSourcePatch(sources: {
-  beliefExists?: EdgeValueSource
-  weight?: EdgeValueSource
-}): { beliefExistsSource?: EdgeValueSource; weightSource?: EdgeValueSource } {
-  const patch: { beliefExistsSource?: EdgeValueSource; weightSource?: EdgeValueSource } = {}
-  if (sources.beliefExists) patch.beliefExistsSource = sources.beliefExists
-  if (sources.weight) patch.weightSource = sources.weight
+export function edgeValueSourcePatch(
+  sources: Partial<Record<EdgeProvenancedField, EdgeValueSource>>,
+): Partial<Record<EdgeValueSourceKey, EdgeValueSource>> {
+  const patch: Partial<Record<EdgeValueSourceKey, EdgeValueSource>> = {}
+  for (const field of EDGE_PROVENANCED_FIELDS) {
+    const source = sources[field]
+    if (source) patch[edgeSourceKey(field)] = source
+  }
   return patch
+}
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * ORDERING — the channel that has no words at all
+ * ════════════════════════════════════════════════════════════════════════════
+ *
+ * #472–#476 gated the NUMBER and then the COLOUR. Neither touched ORDER, which
+ * is the quietest channel and in one case the most consequential: the "Top gap:
+ * validate X" line on the decision node ranks factors by a sum of edge weights
+ * and then TELLS THE USER WHICH FACTOR TO GO FIX. Every contribution to that
+ * sum was `weight ?? 0.5`, so on a graph where nobody had set a single strength
+ * the recommendation was decided by a constant — i.e. by node iteration order.
+ *
+ * The recurring shape at the leaking sites was a SENTINEL:
+ *
+ *     const aWeight = aData?.weight != null ? aData.weight : -Infinity
+ *
+ * which is wrong three times over:
+ *  1. It is TAUTOLOGICAL — `USER_EDGE_DEFAULTS`/`DEFAULT_EDGE_DATA` always
+ *     define `weight`, so the `-Infinity` arm is dead and every defaulted edge
+ *     ranks as a measured one. Same dead-branch shape as the two defects
+ *     already fixed in `OutcomeNode` and `RelationshipsSection`.
+ *  2. The sentinel's SIGN hand-compensates for the sort direction
+ *     (`ModelTabBody` uses `+Infinity` for an ascending key and `-Infinity` for
+ *     a descending one, two lines apart). That is a mirror: flip the order and
+ *     "unset last" silently becomes "unset first".
+ *  3. A sentinel is a number, so it composes with arithmetic. `-Infinity`
+ *     inside a `reduce` poisons a whole aggregate.
+ *
+ * So ordering gets the same treatment as colour: helpers that take
+ * `EdgeValueDisplay` and never a bare `number`, with "unset" as an explicit
+ * position rather than an extreme value.
+ */
+
+/**
+ * Compare two resolved edge values for sorting. **Unset always sorts last**,
+ * whichever direction `order` requests.
+ *
+ * That asymmetry is deliberate and is the reason this is not a subtraction.
+ * "We do not know this number" is not a small number or a large one; it is not
+ * on the scale at all, so it cannot be expressed as a sentinel that flips with
+ * the comparator. Reversing the sort must not promote the values nobody set.
+ */
+export function compareEdgeValueDisplays(
+  a: EdgeValueDisplay,
+  b: EdgeValueDisplay,
+  order: 'asc' | 'desc' = 'desc',
+): number {
+  if (!a.show && !b.show) return 0
+  if (!a.show) return 1
+  if (!b.show) return -1
+  return order === 'asc' ? a.value - b.value : b.value - a.value
+}
+
+/**
+ * An aggregate (a sum/rank) built from several edge values.
+ *
+ * Same discriminated shape as `EdgeValueDisplay`, so forgetting to handle "no
+ * evidence" is a type error rather than a rank derived from nothing. The counts
+ * are carried because a PARTIAL aggregate is a real state: a factor with two
+ * sourced edges and three defaulted ones has some leverage evidence, and a
+ * surface may legitimately want to qualify or exclude it.
+ */
+export type EdgeValueAggregate =
+  | {
+      show: false
+      /** `not_set` — numbers were present, none sourced. `absent` — nothing to sum. */
+      reason: 'not_set' | 'absent'
+    }
+  | { show: true; value: number; sourcedCount: number; unsourcedCount: number }
+
+/**
+ * Sum the SOURCED signed strengths of a set of edges; ignore the rest.
+ *
+ * An edge whose strength nobody set contributes NOTHING — not `0.5`, not `0`
+ * dressed up as a measurement. It is counted in `unsourcedCount` so the caller
+ * can see the aggregate is partial, and if no edge is sourced the result is
+ * `show: false` and the caller must not rank on it at all.
+ *
+ * `magnitude: true` sums `|signed|` — for "how much does this factor matter",
+ * where a strong negative influence is as important as a strong positive one.
+ */
+export function aggregateEdgeSignedStrength(
+  edgeData: Iterable<Record<string, unknown> | undefined | null>,
+  opts: { magnitude?: boolean } = {},
+): EdgeValueAggregate {
+  let value = 0
+  let sourcedCount = 0
+  let unsourcedCount = 0
+
+  for (const data of edgeData) {
+    const display = resolveEdgeSignedStrengthDisplay(data)
+    if (display.show) {
+      value += opts.magnitude ? Math.abs(display.value) : display.value
+      sourcedCount += 1
+    } else {
+      unsourcedCount += 1
+    }
+  }
+
+  if (sourcedCount === 0) {
+    return { show: false, reason: unsourcedCount > 0 ? 'not_set' : 'absent' }
+  }
+  return { show: true, value, sourcedCount, unsourcedCount }
+}
+
+/**
+ * Compare two aggregates. **Unset always sorts last**, as above.
+ *
+ * Split from `compareEdgeValueDisplays` rather than widened to a union because
+ * the two carry different evidence and a caller should not be able to sort an
+ * aggregate against a single value by accident.
+ */
+export function compareEdgeValueAggregates(
+  a: EdgeValueAggregate,
+  b: EdgeValueAggregate,
+  order: 'asc' | 'desc' = 'desc',
+): number {
+  if (!a.show && !b.show) return 0
+  if (!a.show) return 1
+  if (!b.show) return -1
+  return order === 'asc' ? a.value - b.value : b.value - a.value
 }

--- a/src/canvas/domain/edges.ts
+++ b/src/canvas/domain/edges.ts
@@ -238,6 +238,15 @@ export const EdgeDataSchema = z.object({
   beliefExistsSource: EdgeValueSourceEnum.optional(),
   /** Where `weight` came from. Absent ⇒ nobody set it (UI default). */
   weightSource: EdgeValueSourceEnum.optional(),
+  /**
+   * Where `strengthStd` came from. Absent ⇒ nobody set it (UI default).
+   *
+   * `USER_EDGE_DEFAULTS.strengthStd = 0.15` below, so a user-drawn edge carries
+   * a fabricated uncertainty that `KeyRelationships` rendered as a "Moderate
+   * confidence" dot. Unlike `weight`/`beliefExists` there is no producer-only
+   * raw field to fall back on — see the note in `edgeValueSource`.
+   */
+  strengthStdSource: EdgeValueSourceEnum.optional(),
 
   // Phase 3: Non-linear edge functions
   functionType: EdgeFunctionTypeEnum.default('linear'),   // How input transforms to output

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -26,10 +26,12 @@ import { shouldShowEdgeLabel } from './edgeLabelVisibility'
 import { computeDirectionStroke } from './directionStroke'
 import { resolvePersistentLabelPlacements, type PlacementEdge } from './edgeLabelCollision'
 import { applyEdgeVisualProps } from '../theme/edges'
-import { formatConfidence, shouldShowLabel, getEdgeConfidence, computeSignedMean } from '../domain/edges'
+import { formatConfidence, shouldShowLabel, getEdgeConfidence } from '../domain/edges'
 import {
   resolveEdgeValueDisplay,
   resolveEdgeSignedStrengthDisplay,
+  compareEdgeValueDisplays,
+  type EdgeValueDisplay,
 } from '../domain/edgeValueProvenance'
 import { useIsDark } from '../hooks/useTheme'
 import { getEdgeLabel } from '../domain/edgeLabels'
@@ -38,7 +40,7 @@ import { EdgeEditPopover } from './EdgeEditPopover'
 import { useCanvasStore } from '../store'
 import { isGraphLensEnabled } from '../../flags'
 import { isEdgeFragile as isEdgeFragileFn, getFragileEdgeSwitchProbability, isTopFragileEdge as isTopFragileEdgeFn } from '../utils/fragileEdgeMatch'
-import { existenceCertaintyToLineStyle, calculateEdgeImportance, weightMagnitudeToStrokeWidth } from '../utils/graphDisplayCalculations'
+import { existenceCertaintyToLineStyle, calculateEdgeImportance, weightMagnitudeToStrokeWidth, UNSET_EDGE_STROKE_WIDTH } from '../utils/graphDisplayCalculations'
 import { typography } from '../../styles/typography'
 import { getStrengthDescription, getProvenanceLabel } from '../ui/inspector-v2/inspectorStrings'
 import { useEdgeEditHint } from '../hooks/useFirstTimeHints'
@@ -234,17 +236,30 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // the edge label, the top-3 auto-labels, and the #451 projection halo, so it
   // no longer needs to hijack thickness. (Deliberate, Paul-approved encoding
   // change — see PR body.)
-  const edgeStrokeWidth = useMemo(
-    () => weightMagnitudeToStrokeWidth(computeSignedMean(edgeData as Record<string, unknown> | undefined)),
+  // ⛔ Provenance gate. `computeSignedMean` falls back to `weight`, which the
+  // edge defaults always define, so thickness — the channel the UI explicitly
+  // TEACHES the user to read as strength — reported 2px ("Strong") for every
+  // CEE edge whose strength nobody had set. An unset edge now draws at the
+  // floor width: it still has to be drawn, and the minimum is the only width
+  // that cannot be mistaken for a measurement. Colour (grey, above) carries
+  // the "no verdict" claim; width simply stops asserting one.
+  const edgeSignedStrength = useMemo(
+    () => resolveEdgeSignedStrengthDisplay(edgeData as Record<string, unknown> | undefined),
     [edgeData]
+  )
+  const edgeStrokeWidth = useMemo(
+    () => edgeSignedStrength.show
+      ? weightMagnitudeToStrokeWidth(edgeSignedStrength.value)
+      : UNSET_EDGE_STROKE_WIDTH,
+    [edgeSignedStrength]
   )
 
   // F.2 + E1: direction-based stroke colour (see directionStroke.ts for the
   // CVD-aware polarity palette and the ΔE rationale). Applies pre-run and
   // post-run; one source of truth shared with directionColour.spec.
   const directionStroke = useMemo(
-    () => computeDirectionStroke(direction, weight, edgeData?.weight, isDark),
-    [direction, weight, edgeData?.weight, isDark],
+    () => computeDirectionStroke(direction, edgeSignedStrength, isDark),
+    [direction, edgeSignedStrength, isDark],
   )
 
   // Decision Graph Display v2: Existence certainty line style
@@ -458,12 +473,23 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       return new Set(scores.slice(0, 3).map(s => s.id))
     }
 
-    // Pre-analysis: rank by |strength.mean|
-    const strengths = causalEdges.map(e => ({
-      id: e.id,
-      strength: Math.abs(computeSignedMean(e.data as Record<string, unknown> | undefined)),
-    }))
-    strengths.sort((a, b) => b.strength - a.strength)
+    // Pre-analysis: rank by |strength.mean|.
+    //
+    // ⛔ Provenance gate on the ORDER. `computeSignedMean` falls back to
+    // `weight`, which the edge defaults always supply, so on an unset graph
+    // every edge scored 0.3/0.5 and the three edges granted a PERMANENT
+    // on-canvas label were chosen by iteration order and presented as the
+    // strongest three. An edge whose strength nobody set is not a candidate:
+    // unset sorts last and is then dropped, so when fewer than three edges
+    // have a sourced strength fewer than three labels are pinned — rather
+    // than filling the quota from edges we know nothing about.
+    const strengths: Array<{ id: string; magnitude: EdgeValueDisplay }> = []
+    for (const e of causalEdges) {
+      const display = resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined)
+      if (!display.show) continue
+      strengths.push({ id: e.id, magnitude: { ...display, value: Math.abs(display.value) } })
+    }
+    strengths.sort((a, b) => compareEdgeValueDisplays(a.magnitude, b.magnitude, 'desc'))
     return new Set(strengths.slice(0, 3).map(s => s.id))
   }, [getEdges, getNode, isResultsMode, report])
 

--- a/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
@@ -86,7 +86,13 @@ vi.mock('../../utils/fragileEdgeMatch', () => ({
   getFragileEdgeSwitchProbability: () => null,
 }))
 
-vi.mock('../../utils/graphDisplayCalculations', () => ({
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
   existenceCertaintyToLineStyle: () => null,
   calculateEdgeImportance: () => 0.5,
   importanceToStrokeWidth: () => 2,

--- a/src/canvas/edges/__tests__/StyledEdge.encoding.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.encoding.spec.tsx
@@ -101,7 +101,13 @@ vi.mock('../../utils/fragileEdgeMatch', () => ({
 }))
 // Distinct width outputs so an assertion can tell the two formulas apart;
 // dash reflects the real <0.7 rule so the belief-dash pin is meaningful.
-vi.mock('../../utils/graphDisplayCalculations', () => ({
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
   existenceCertaintyToLineStyle: (p: number | undefined) => (p !== undefined && p < 0.7 ? '6,4' : undefined),
   calculateEdgeImportance: () => 0.5,
   importanceToStrokeWidth: () => 7,
@@ -191,6 +197,11 @@ describe('StyledEdge — belief is a single channel: dash, not opacity (item 2)'
   })
 })
 
+// `weightSource` is REQUIRED on these two fixtures. Stroke width is now
+// provenance-gated: an edge whose strength nobody set draws at
+// UNSET_EDGE_STROKE_WIDTH, so without the stamp these tests would be
+// measuring the unset floor rather than the weight-vs-importance choice they
+// exist to pin. The claim under test is unchanged.
 describe('StyledEdge — stroke width means weight magnitude in both phases (item 3)', () => {
   beforeEach(() => {
     for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
@@ -201,7 +212,7 @@ describe('StyledEdge — stroke width means weight magnitude in both phases (ite
   it('pre-run: width follows weight magnitude (2), not importance (7)', () => {
     setStore({ viewMode: 'standard', resultsStatus: 'idle', report: null })
     const { container } = render(
-      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8, weightSource: 'cee' }} />
     )
     expect(styleOf(container).strokeWidth).toBe('2')
   })
@@ -209,7 +220,7 @@ describe('StyledEdge — stroke width means weight magnitude in both phases (ite
   it('post-run: width STILL follows weight magnitude (2), not composite importance (7)', () => {
     setStore({ viewMode: 'standard', resultsStatus: 'complete', report: RESULTS_REPORT })
     const { container } = render(
-      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8, weightSource: 'cee' }} />
     )
     expect(styleOf(container).strokeWidth).toBe('2')
   })

--- a/src/canvas/edges/__tests__/StyledEdge.filterCompose.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.filterCompose.spec.tsx
@@ -84,7 +84,13 @@ vi.mock('../../utils/fragileEdgeMatch', () => ({
   getFragileEdgeSwitchProbability: () => null,
   isTopFragileEdge: () => false,
 }))
-vi.mock('../../utils/graphDisplayCalculations', () => ({
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
   existenceCertaintyToLineStyle: () => 'solid',
   calculateEdgeImportance: () => 0.5,
   importanceToStrokeWidth: () => 2,

--- a/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.hover.spec.tsx
@@ -81,7 +81,13 @@ vi.mock('../../utils/fragileEdgeMatch', () => ({
   getFragileEdgeSwitchProbability: () => null,
 }))
 
-vi.mock('../../utils/graphDisplayCalculations', () => ({
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
   existenceCertaintyToLineStyle: () => 'solid',
   calculateEdgeImportance: () => 0.5,
   importanceToStrokeWidth: () => 2,

--- a/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.labelNodeDodge.spec.tsx
@@ -114,7 +114,13 @@ vi.mock('../../utils/fragileEdgeMatch', () => ({
   isTopFragileEdge: () => false,
 }))
 
-vi.mock('../../utils/graphDisplayCalculations', () => ({
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
   existenceCertaintyToLineStyle: () => undefined,
   calculateEdgeImportance: () => 0.5,
   importanceToStrokeWidth: () => 2,

--- a/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
@@ -66,7 +66,13 @@ vi.mock('../../utils/fragileEdgeMatch', () => ({
   getFragileEdgeSwitchProbability: () => null,
   isTopFragileEdge: () => false,
 }))
-vi.mock('../../utils/graphDisplayCalculations', () => ({
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
   existenceCertaintyToLineStyle: () => 'solid',
   calculateEdgeImportance: () => 0.5,
   importanceToStrokeWidth: () => 2,

--- a/src/canvas/edges/__tests__/StyledEdge.structural.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.structural.spec.tsx
@@ -114,7 +114,13 @@ vi.mock('../../utils/fragileEdgeMatch', () => ({
   getFragileEdgeSwitchProbability: () => null,
 }))
 
-vi.mock('../../utils/graphDisplayCalculations', () => ({
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
   existenceCertaintyToLineStyle: () => 'solid',
   calculateEdgeImportance: () => 0.5,
   importanceToStrokeWidth: () => 2,

--- a/src/canvas/edges/__tests__/directionColour.spec.ts
+++ b/src/canvas/edges/__tests__/directionColour.spec.ts
@@ -2,54 +2,79 @@
  * F.2 + E1 — Edge direction colour logic (unit tests)
  * Tests the shared computeDirectionStroke() (no local duplicate — imported from
  * the same module StyledEdge uses, so the E1 recolour has one source of truth).
+ *
+ * SIGNATURE CHANGE (provenance gate): the second parameter is now an
+ * `EdgeValueDisplay`, not `(weight: number, rawWeight: number | undefined)`.
+ * The old pair could not express "nobody set this", and the branch that claimed
+ * to handle it (`rawWeight === undefined` → yellow) was DEAD — the edge
+ * defaults always define `weight`. See directionStroke.ts for the full note.
  */
 import { describe, it, expect } from 'vitest'
 import { computeDirectionStroke } from '../directionStroke'
+import type { EdgeValueDisplay } from '../../domain/edgeValueProvenance'
+
+const set = (value: number): EdgeValueDisplay => ({ show: true, value, source: 'user' })
+const NOT_SET: EdgeValueDisplay = { show: false, reason: 'not_set' }
+const ABSENT: EdgeValueDisplay = { show: false, reason: 'absent' }
 
 describe('directionStroke colour logic (F.2 + E1)', () => {
   it('weight=0, direction="positive" → grey (neutral), NOT yellow', () => {
-    expect(computeDirectionStroke('positive', 0, 0, false)).toBe('var(--edge-neutral)')
-  })
-
-  it('weight=undefined, direction=undefined → yellow (truly uninitialised)', () => {
-    expect(computeDirectionStroke(undefined, 1.0, undefined, false)).toBe('var(--goal)')
+    expect(computeDirectionStroke('positive', set(0), false)).toBe('var(--edge-neutral)')
   })
 
   it('E1: weight=0.5, direction="positive" → the positive-green token', () => {
-    expect(computeDirectionStroke('positive', 0.5, 0.5, false)).toBe('var(--edge-positive)')
+    expect(computeDirectionStroke('positive', set(0.5), false)).toBe('var(--edge-positive)')
   })
 
   it('E1: weight=0.5, direction="negative" → the negative-rose token (distinct from amber warning + risk node)', () => {
-    expect(computeDirectionStroke('negative', 0.5, 0.5, false)).toBe('var(--edge-negative)')
+    expect(computeDirectionStroke('negative', set(0.5), false)).toBe('var(--edge-negative)')
     // Guard the C2 ruling: negative must NOT be the amber warning hue, and must
     // not be the old #ef4444 that collided with the risk-node border.
-    expect(computeDirectionStroke('negative', 0.5, 0.5, false)).not.toBe('#FFA656')
-    expect(computeDirectionStroke('negative', 0.5, 0.5, false)).not.toBe('#ef4444')
+    expect(computeDirectionStroke('negative', set(0.5), false)).not.toBe('#FFA656')
+    expect(computeDirectionStroke('negative', set(0.5), false)).not.toBe('#ef4444')
+  })
+
+  it('takes the MAGNITUDE, so a negative signed strength still colours by direction', () => {
+    expect(computeDirectionStroke('negative', set(-0.5), false)).toBe('var(--edge-negative)')
   })
 
   it('weight=0, direction="negative" → grey (neutral), NOT the polarity colour', () => {
-    expect(computeDirectionStroke('negative', 0, 0, false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke('negative', set(0), false)).toBe('var(--edge-neutral)')
   })
 
-  it('weight=0.5, direction=undefined, rawWeight=0.5 → grey (no direction set)', () => {
-    expect(computeDirectionStroke(undefined, 0.5, 0.5, false)).toBe('var(--edge-neutral)')
+  it('weight=0.5, direction=undefined → grey (no direction set)', () => {
+    expect(computeDirectionStroke(undefined, set(0.5), false)).toBe('var(--edge-neutral)')
   })
 
-  it('weight=0, direction=undefined, rawWeight=0 → grey (weight defined, no direction), NOT yellow', () => {
-    expect(computeDirectionStroke(undefined, 0, 0, false)).toBe('var(--edge-neutral)')
+  it('weight=0, direction=undefined → grey (weight defined, no direction), NOT yellow', () => {
+    expect(computeDirectionStroke(undefined, set(0), false)).toBe('var(--edge-neutral)')
+  })
+
+  // ── Provenance gate ──────────────────────────────────────────────────────
+  // This is the case the old `rawWeight === undefined` branch claimed to cover
+  // and never could. `direction` is deliberately 'positive' below: that is the
+  // value `USER_EDGE_DEFAULTS` fabricates, and it must not reach the green.
+  it('unset strength → grey, even with a defaulted positive direction', () => {
+    expect(computeDirectionStroke('positive', NOT_SET, false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke('positive', NOT_SET, false)).not.toBe('var(--edge-positive)')
+  })
+
+  it('absent strength → grey too', () => {
+    expect(computeDirectionStroke('negative', ABSENT, false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke('negative', ABSENT, true)).toBe('var(--edge-neutral-dark)')
   })
 
   // Dark mode variants
   it('E1: dark mode positive → dark green', () => {
-    expect(computeDirectionStroke('positive', 0.5, 0.5, true)).toBe('var(--edge-positive-dark)')
+    expect(computeDirectionStroke('positive', set(0.5), true)).toBe('var(--edge-positive-dark)')
   })
 
   it('E1: dark mode negative → rose #F06595 (distinct from the dark risk border #FF6B6B)', () => {
-    expect(computeDirectionStroke('negative', 0.5, 0.5, true)).toBe('var(--edge-negative-dark)')
-    expect(computeDirectionStroke('negative', 0.5, 0.5, true)).not.toBe('#FF6B6B')
+    expect(computeDirectionStroke('negative', set(0.5), true)).toBe('var(--edge-negative-dark)')
+    expect(computeDirectionStroke('negative', set(0.5), true)).not.toBe('#FF6B6B')
   })
 
   it('dark mode: neutral → zinc-400', () => {
-    expect(computeDirectionStroke('positive', 0, 0, true)).toBe('var(--edge-neutral-dark)')
+    expect(computeDirectionStroke('positive', set(0), true)).toBe('var(--edge-neutral-dark)')
   })
 })

--- a/src/canvas/edges/directionStroke.ts
+++ b/src/canvas/edges/directionStroke.ts
@@ -1,3 +1,5 @@
+import type { EdgeValueDisplay } from '../domain/edgeValueProvenance'
+
 /**
  * directionStroke — the single source of truth for a causal edge's polarity
  * colour (F.2). Extracted from StyledEdge so the rule can be unit-tested
@@ -29,24 +31,49 @@
  * polarity for a red-green dichromat here. Do not remove it, and do not let
  * a future change lean on these hues alone.
  *
- * Yellow (var(--goal)) stays reserved for truly uninitialised edges (no
- * direction AND no weight); grey for weight-set-but-no-direction and for the
- * neutral weight === 0 choice.
+ * Grey (--edge-neutral) is the NO-VERDICT colour: weight-set-but-no-direction,
+ * the neutral weight === 0 choice, and — since the provenance gate below —
+ * every edge whose strength nobody has set.
+ *
+ * ⛔ PROVENANCE GATE (canvas/domain/edgeValueProvenance.ts).
+ * ------------------------------------------------------------------
+ * This function used to take `weight: number, rawWeight: number | undefined`
+ * and carried a branch commented "truly uninitialised: no direction AND weight
+ * is undefined → yellow". That branch COULD NOT FIRE. `USER_EDGE_DEFAULTS`
+ * defines `weight: 0.3` AND `direction: 'positive'`, `DEFAULT_EDGE_DATA`
+ * defines `weight: 0.5` — so `rawWeight === undefined` never happened in the
+ * product, and every freshly drawn edge, strength unset, was painted the
+ * positive green. Colour is read pre-attentively: it delivered "this is a
+ * confirmed positive influence" about a connection the user had merely drawn.
+ * Same tautological-dead-branch shape as the defects fixed in `OutcomeNode`
+ * and `RelationshipsSection`, and the same shape the yellow branch's own
+ * comment claimed to handle.
+ *
+ * Taking `EdgeValueDisplay` rather than a `number` is the fix: there is no
+ * argument that means "0.3, source unknown", so the unset case cannot be
+ * reached by accident and cannot be forgotten — it is the first branch.
+ *
+ * WHY GREY AND NOT THE YELLOW THE OLD BRANCH INTENDED — a deliberate exception,
+ * stated rather than quietly taken. `var(--goal)` is the goal ENTITY colour;
+ * the design system's rule is that no channel duplicates another, and painting
+ * a large share of a fresh graph's edges in the goal hue would say something
+ * about goals, not about missing data. Grey already means "we have no verdict"
+ * here (it is what an edge with no direction gets), which is exactly the claim
+ * we are entitled to make. Minting a new "unset" edge hue is a design-system
+ * change and belongs to a design owner, not to this lane.
  */
 export function computeDirectionStroke(
   direction: 'positive' | 'negative' | undefined,
-  weight: number,
-  rawWeight: number | undefined,
+  strength: EdgeValueDisplay,
   isDark: boolean,
 ): string {
-  // Truly uninitialised: no direction AND weight is undefined → yellow
-  if (direction === undefined && rawWeight === undefined) {
-    return 'var(--goal)'
-  }
+  const neutral = isDark ? 'var(--edge-neutral-dark)' : 'var(--edge-neutral)'
+  // Nobody set this strength → no verdict. Must come FIRST: a defaulted
+  // `direction: 'positive'` would otherwise paint it green below.
+  if (!strength.show) return neutral
+  const weight = Math.abs(strength.value)
   // Weight defined but direction not yet set → grey (not yellow)
-  if (direction === undefined) {
-    return isDark ? 'var(--edge-neutral-dark)' : 'var(--edge-neutral)'
-  }
+  if (direction === undefined) return neutral
   // Direction set with positive weight → green
   if (direction === 'positive' && weight > 0) {
     return isDark ? 'var(--edge-positive-dark)' : 'var(--edge-positive)'
@@ -56,5 +83,5 @@ export function computeDirectionStroke(
     return isDark ? 'var(--edge-negative-dark)' : 'var(--edge-negative)'
   }
   // Neutral: weight === 0 (valid user choice)
-  return isDark ? 'var(--edge-neutral-dark)' : 'var(--edge-neutral)'
+  return neutral
 }

--- a/src/canvas/nodes/DecisionNode.tsx
+++ b/src/canvas/nodes/DecisionNode.tsx
@@ -21,6 +21,7 @@ import { NodeChip, NodePopover } from './shared'
 import { isGoalDefined } from '../../utils/isGoalDefined'
 import { cleanFactorLabel } from '../utils/labelUtils'
 import { biasSignal } from '../shared/biasSignalTitles'
+import { aggregateEdgeSignedStrength, compareEdgeValueAggregates } from '../domain/edgeValueProvenance'
 
 /** Truncate text at word boundary. */
 function truncateAtWord(text: string, maxLength: number): string {
@@ -157,18 +158,32 @@ export const DecisionNode = memo(({ id, data, selected }: NodeProps<DecisionNode
     }
 
     // 2. Inferred factors with high leverage — top 2 by edge weight sum across all factors
+    //
+    // ⛔ Provenance gate — THE HIGHEST-CONSEQUENCE ONE IN THIS FAMILY. The line
+    // this produces ("Top gap: validate X") is the product TELLING THE USER
+    // WHICH FACTOR TO GO AND FIX. Every contribution to the ranking sum used to
+    // be `w ?? 0.5`, and `USER_EDGE_DEFAULTS`/`DEFAULT_EDGE_DATA` always define
+    // `weight`, so on a graph where nobody had set a single strength every
+    // factor scored `0.5 × (its out-degree)` — i.e. the recommendation was
+    // decided by out-degree and node iteration order, and presented as
+    // leverage. `aggregateEdgeSignedStrength` counts ONLY sourced strengths, so
+    // a factor with no evidence of leverage yields `show: false` and is left
+    // out of the ranking rather than handed a fabricated score; if NO factor
+    // has any sourced strength the whole step has nothing to rank on and falls
+    // through to the next triage rule instead of inventing a winner.
     const scoredFactors = factorNodes
       .filter(n => (n.data as Record<string, unknown> | undefined)?.category !== 'external')
-      .map(n => {
-        const outEdges = edges.filter(e => e.source === n.id)
-        const weightSum = outEdges.reduce((sum, e) => {
-          const w = (e.data as Record<string, unknown> | undefined)?.weight as number | undefined
-          return sum + (w ?? 0.5)
-        }, 0)
-        return { node: n, weightSum }
-      })
-      .sort((a, b) => b.weightSum - a.weightSum)
-    const topTwoIds = new Set(scoredFactors.slice(0, 2).map(s => s.node.id))
+      .map(n => ({
+        node: n,
+        leverage: aggregateEdgeSignedStrength(
+          edges.filter(e => e.source === n.id).map(e => e.data as Record<string, unknown> | undefined),
+          { magnitude: true },
+        ),
+      }))
+      .sort((a, b) => compareEdgeValueAggregates(a.leverage, b.leverage))
+    const topTwoIds = new Set(
+      scoredFactors.filter(s => s.leverage.show).slice(0, 2).map(s => s.node.id),
+    )
     const topInferred = scoredFactors.find(s => {
       if (!topTwoIds.has(s.node.id)) return false
       const os = (s.node.data as Record<string, unknown> | undefined)?.observedState as Record<string, unknown> | undefined

--- a/src/canvas/nodes/FactorNode.tsx
+++ b/src/canvas/nodes/FactorNode.tsx
@@ -23,7 +23,7 @@ import { usePopoverHover } from '../hooks/usePopoverHover'
 import { useScienceIcons } from '../hooks/useScienceIcons'
 import { ConnRow, ConnRowsOverflow, Sep, NodeChip, ActionIcons, MetricPills, NodePopover, ScienceIcon, EdgePills } from './shared'
 import { useGuidanceStore } from '../stores/guidanceStore'
-import { computeSignedMean } from '../domain/edges'
+import { aggregateEdgeSignedStrength, compareEdgeValueAggregates } from '../domain/edgeValueProvenance'
 import { factorConfidenceDisclosure } from '../../components/results/driverConfidenceDisplayPolicy'
 
 /**
@@ -109,21 +109,49 @@ export const FactorNode = memo((props: NodeProps) => {
     if (isPostAnalysis) return null
     const factorNodes = nodes.filter(n => n.type === 'factor' || n.data?.type === 'factor')
     if (factorNodes.length <= 3) return 1
-    // Single O(N + E) pass: build a map of factor id → weight sum, then sort.
-    const scores = new Map<string, number>()
-    for (const f of factorNodes) scores.set(f.id, 0)
+    // ⛔ Provenance gate. This ranking decides which factors stay full-fat and
+    // which are visually quieted, and it used `computeSignedMean`, which falls
+    // back to `weight` — a constant `USER_EDGE_DEFAULTS`/`DEFAULT_EDGE_DATA`
+    // always supply. So the "structural centrality" score was out-degree × 0.3
+    // for every factor on an unset graph, and the quieting was arbitrary.
+    // Only SOURCED strengths are counted now.
+    const contributions = new Map<string, Array<Record<string, unknown> | undefined>>()
+    for (const f of factorNodes) contributions.set(f.id, [])
     for (const e of edges) {
-      if (!scores.has(e.source)) continue
+      const bucket = contributions.get(e.source)
+      if (!bucket) continue
       const target = nodes.find(n => n.id === e.target)
       if (!target) continue
       const targetKind = target.type ?? target.data?.type
       if (targetKind !== 'outcome' && targetKind !== 'risk') continue
-      const weight = Math.abs(computeSignedMean(e.data as Record<string, unknown> | undefined))
-      scores.set(e.source, (scores.get(e.source) ?? 0) + weight)
+      bucket.push(e.data as Record<string, unknown> | undefined)
     }
-    const sorted = Array.from(scores.entries()).sort((a, b) => b[1] - a[1])
-    const idx = sorted.findIndex(([id]) => id === props.id)
-    return idx < 0 ? null : idx + 1
+    const scored = Array.from(contributions.entries()).map(([id, datas]) => ({
+      id,
+      leverage: aggregateEdgeSignedStrength(datas, { magnitude: true }),
+    }))
+    // No factor has a single sourced strength ⇒ there is no ranking to be had.
+    // Same escape hatch the `<= 3` case above already uses: when we cannot
+    // rank, we quieten NOBODY rather than quietening everybody on no evidence.
+    if (!scored.some(s => s.leverage.show)) return 1
+    scored.sort((a, b) => compareEdgeValueAggregates(a.leverage, b.leverage))
+    const idx = scored.findIndex(s => s.id === props.id)
+    if (idx < 0) return null
+    const mine = scored[idx].leverage
+    if (mine.show) return idx + 1
+    // Unranked — but the two unranked states are NOT the same claim.
+    //
+    // `absent`: this factor has NO outbound edge to an outcome or risk at all.
+    // That is a STRUCTURAL fact read straight off the graph, not a number
+    // anybody had to supply, so ranking it below the measured factors invents
+    // nothing. It keeps its place at the bottom of the sort.
+    //
+    // `not_set`: the edges exist and nobody set their strengths. Here we
+    // genuinely do not know, and quieting the factor would be the same
+    // fabrication in the visual channel that this gate removes from the
+    // numeric one. Treat it as high-priority (i.e. quieten nobody) rather than
+    // demote it on evidence we do not have.
+    return mine.reason === 'absent' ? idx + 1 : 1
   }, [isPostAnalysis, nodes, edges, props.id])
 
   const priorityRank: number | null = isPostAnalysis

--- a/src/canvas/nodes/__tests__/DecisionNode.triageProvenance.spec.tsx
+++ b/src/canvas/nodes/__tests__/DecisionNode.triageProvenance.spec.tsx
@@ -1,0 +1,164 @@
+/**
+ * DecisionNode "Top gap:" triage — the product must not RECOMMEND on a default.
+ *
+ * WHY THIS IS THE HIGHEST-CONSEQUENCE CASE IN THE UNSET-VALUE FAMILY
+ * -----------------------------------------------------------------
+ * Rule 2 of the triage ladder ranks factors by a sum of their outbound edge
+ * weights, takes the top two, and if one of them is an inferred factor prints
+ * "Top gap: validate <that factor>". That sentence is the product telling the
+ * user which piece of their model to go and fix.
+ *
+ * Every contribution to the sum was `w ?? 0.5`, and `USER_EDGE_DEFAULTS` /
+ * `DEFAULT_EDGE_DATA` always define `weight`. So on a graph where nobody had
+ * set a single strength, every factor scored `0.5 × out-degree`, ties broke on
+ * array order, and the winner was named as the highest-leverage gap. The
+ * recommendation was real; the leverage behind it was not.
+ *
+ * CLAIM TYPE: rendered TEXT presence/absence. Not visibility, not layout
+ * (platform trap 3).
+ *
+ * DISCRIMINATION: the two tests are the same graph twice. The only difference
+ * is `weightSource: 'cee'` on the edges. If the gate over-fired (never
+ * recommending) the second test would fail; if it under-fired (the old
+ * behaviour) the first would.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { DecisionNode } from '../DecisionNode'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+const makeStoreState = (overrides: Record<string, unknown> = {}) => ({
+  edges: [],
+  nodes: [],
+  results: { status: 'idle', report: null },
+  highlightedNodes: new Set(),
+  dimmedNodeIds: new Set(),
+  lens: { _dimmedNodeIds: new Set(), _hiddenNodeIds: new Set(), active: 'full' },
+  goalThreshold: null,
+  goalConstraints: [],
+  viewMode: 'expert',
+  ...overrides,
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector) => selector(makeStoreState())),
+}))
+
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank: null,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    stabilityPercentage: null,
+    winRate: null,
+    isResultsMode: false,
+    predictedOutcome: null,
+    valueOfInformation: null,
+    voiRank: null,
+  })),
+}))
+
+vi.mock('../shared/NodePopover', () => ({
+  NodePopover: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="decision-node-popover">{children}</div>
+  ),
+}))
+
+import { useCanvasStore } from '../../store'
+
+const baseProps = {
+  id: 'decision-1',
+  type: 'decision',
+  position: { x: 0, y: 0 },
+  selected: false,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+  data: { label: 'Should we hire?', type: 'decision' },
+}
+
+/**
+ * A graph that clears triage rule 1 (every factor has an observed value) and
+ * reaches rule 2 with an INFERRED factor that has the largest out-degree. The
+ * only variable is whether the edge strengths carry a source stamp.
+ */
+function graph(stamped: boolean) {
+  const strength = stamped ? { weightSource: 'cee' as const } : {}
+  return makeStoreState({
+    nodes: [
+      {
+        id: 'fac-inferred',
+        type: 'factor',
+        data: {
+          type: 'factor',
+          label: 'Brand perception',
+          observedState: { value: 5, extractionType: 'inferred' },
+        },
+      },
+      {
+        id: 'fac-known',
+        type: 'factor',
+        data: {
+          type: 'factor',
+          label: 'Headcount',
+          observedState: { value: 12, extractionType: 'stated' },
+        },
+      },
+      { id: 'out-1', type: 'outcome', data: { type: 'outcome', label: 'Revenue' } },
+      { id: 'out-2', type: 'outcome', data: { type: 'outcome', label: 'Margin' } },
+      { id: 'opt-1', type: 'option', data: { type: 'option' } },
+      { id: 'opt-2', type: 'option', data: { type: 'option' } },
+      { id: 'opt-3', type: 'option', data: { type: 'option' } },
+    ],
+    edges: [
+      // The inferred factor has the higher out-degree, so under the OLD
+      // `w ?? 0.5` sum it always won the leverage ranking.
+      { id: 'e1', source: 'fac-inferred', target: 'out-1', data: { weight: 0.3, direction: 'positive', ...strength } },
+      { id: 'e2', source: 'fac-inferred', target: 'out-2', data: { weight: 0.3, direction: 'positive', ...strength } },
+      { id: 'e3', source: 'fac-known', target: 'out-1', data: { weight: 0.3, direction: 'positive', ...strength } },
+      { id: 'e4', source: 'decision-1', target: 'opt-1' },
+      { id: 'e5', source: 'decision-1', target: 'opt-2' },
+      { id: 'e6', source: 'decision-1', target: 'opt-3' },
+    ],
+    goalThreshold: { value: 100, direction: 'above' },
+  })
+}
+
+const renderDecision = () =>
+  render(
+    <ReactFlowProvider>
+      <DecisionNode {...(baseProps as unknown as React.ComponentProps<typeof DecisionNode>)} />
+    </ReactFlowProvider>,
+  )
+
+describe('DecisionNode triage — leverage ranking is provenance-gated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does NOT recommend validating a factor whose leverage nobody set', () => {
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(graph(false) as never),
+    )
+    renderDecision()
+    expect(screen.queryByText(/Top gap: validate/)).toBeNull()
+    expect(screen.queryByText(/Brand perception/)).toBeNull()
+  })
+
+  it('DOES recommend it once the strengths are sourced', () => {
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(graph(true) as never),
+    )
+    renderDecision()
+    expect(screen.getByText(/Top gap: validate Brand perception/)).toBeTruthy()
+  })
+})

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -1424,6 +1424,54 @@ describe('FactorNode — intervention hover', () => {
             { id: 'outcome-1', type: 'outcome', data: { type: 'outcome', label: 'Outcome' } },
           ],
           edges: [
+            // `weightSource` is REQUIRED: the pre-analysis priority ranking is
+            // provenance-gated, and when NO factor has a sourced strength there is
+            // no ranking to be had, so nobody is quieted. These stamps make the
+            // rivals genuinely higher-leverage rather than fabricated-higher.
+            { id: 'e2', source: 'factor-2', target: 'outcome-1', data: { weight: 1, direction: 'positive', weightSource: 'cee' } },
+            { id: 'e3', source: 'factor-3', target: 'outcome-1', data: { weight: 1, direction: 'positive', weightSource: 'cee' } },
+            { id: 'e4', source: 'factor-4', target: 'outcome-1', data: { weight: 1, direction: 'positive', weightSource: 'cee' } },
+            { id: 'e5', source: 'factor-5', target: 'outcome-1', data: { weight: 1, direction: 'positive', weightSource: 'cee' } },
+          ],
+          ceeAnalysisReady: null,
+          results: { status: 'idle', report: null },
+          highlightedNodes: new Set(),
+          dimmedNodeIds: new Set(),
+          goalThreshold: null,
+          goalConstraints: [],
+          viewMode: 'standard',
+        })
+      )
+      renderFactor({
+        label: 'Low priority',
+        type: 'factor',
+        category: 'controllable',
+        observedState: { value: 0.5 },
+      })
+      expect(screen.queryByTestId('factor-node-popover')).toBeNull()
+    })
+
+    // ⛔ The other half of the provenance gate. Identical topology to the test
+    // above — factor-1 still has no outbound edge — but the RIVALS' strengths
+    // are unstamped, so the ranking has no evidence to rank on. Quieting a
+    // factor on a ranking derived from `USER_EDGE_DEFAULTS.weight` would be
+    // the same fabrication in the visual channel that #472-#476 removed from
+    // the numeric one, so nobody is quieted. Without this the `not_set` arm of
+    // preAnalysisFactorRank could be deleted and the suite would stay green.
+    it('does NOT quieten anyone when no rival strength was ever set', () => {
+      vi.mocked(useCanvasStore).mockImplementation((selector: any) =>
+        selector({
+          hoveredOptionId: null,
+          nodes: [
+            { id: 'factor-1', type: 'factor', data: { type: 'factor', label: 'Low priority' } },
+            { id: 'factor-2', type: 'factor', data: { type: 'factor', label: 'F2' } },
+            { id: 'factor-3', type: 'factor', data: { type: 'factor', label: 'F3' } },
+            { id: 'factor-4', type: 'factor', data: { type: 'factor', label: 'F4' } },
+            { id: 'factor-5', type: 'factor', data: { type: 'factor', label: 'F5' } },
+            { id: 'outcome-1', type: 'outcome', data: { type: 'outcome', label: 'Outcome' } },
+          ],
+          edges: [
+            // Same weights as the quieting test, WITHOUT the source stamps.
             { id: 'e2', source: 'factor-2', target: 'outcome-1', data: { weight: 1, direction: 'positive' } },
             { id: 'e3', source: 'factor-3', target: 'outcome-1', data: { weight: 1, direction: 'positive' } },
             { id: 'e4', source: 'factor-4', target: 'outcome-1', data: { weight: 1, direction: 'positive' } },
@@ -1444,7 +1492,7 @@ describe('FactorNode — intervention hover', () => {
         category: 'controllable',
         observedState: { value: 0.5 },
       })
-      expect(screen.queryByTestId('factor-node-popover')).toBeNull()
+      expect(screen.queryByTestId('factor-node-popover')).not.toBeNull()
     })
 
     it('does render the popover for a high-priority (top-3) factor in Standard view', () => {

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -165,11 +165,16 @@ describe('Render matrix — FactorNode × view × phase', () => {
       { id: 'factor-4', type: 'factor', data: { type: 'factor', label: 'F4' } },
       { id: 'outcome-1', type: 'outcome', data: { type: 'outcome', label: 'Revenue' } },
     ],
+    // `weightSource` is REQUIRED on every edge here: the pre-analysis priority
+    // ranking is provenance-gated, and with no sourced strength anywhere there
+    // is no ranking, so no factor is quieted and the low-priority case below
+    // could not be reached at all. These are the weights the ranking is
+    // supposed to read.
     edges: [
-      { id: 'e1', source: 'factor-1', target: 'outcome-1', data: { weight: 1, direction: 'positive' } },
-      { id: 'e2', source: 'factor-2', target: 'outcome-1', data: { weight: 0.1, direction: 'positive' } },
-      { id: 'e3', source: 'factor-3', target: 'outcome-1', data: { weight: 0.1, direction: 'positive' } },
-      { id: 'e4', source: 'factor-4', target: 'outcome-1', data: { weight: 0.1, direction: 'positive' } },
+      { id: 'e1', source: 'factor-1', target: 'outcome-1', data: { weight: 1, direction: 'positive', weightSource: 'cee' } },
+      { id: 'e2', source: 'factor-2', target: 'outcome-1', data: { weight: 0.1, direction: 'positive', weightSource: 'cee' } },
+      { id: 'e3', source: 'factor-3', target: 'outcome-1', data: { weight: 0.1, direction: 'positive', weightSource: 'cee' } },
+      { id: 'e4', source: 'factor-4', target: 'outcome-1', data: { weight: 0.1, direction: 'positive', weightSource: 'cee' } },
     ],
   })
 

--- a/src/canvas/ui/inspector-v2/__tests__/InspectorRouter.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InspectorRouter.spec.tsx
@@ -148,7 +148,7 @@ describe('InspectorRouter', () => {
         { id: 'g1', type: 'goal', data: { label: 'Target', kind: 'goal' }, position: { x: 100, y: 0 } },
       ],
       [
-        { id: 'e1', source: 'out1', target: 'g1', data: { weight: 0.65, direction: 'positive' } },
+        { id: 'e1', source: 'out1', target: 'g1', data: { weight: 0.65, direction: 'positive', weightSource: 'cee' } },
       ],
     )
     render(<InspectorRouter nodeId="out1" edgeId={null} onClose={onClose} />)
@@ -172,7 +172,7 @@ describe('InspectorRouter', () => {
         { id: 'g1', type: 'goal', data: { label: 'Target', kind: 'goal' }, position: { x: 100, y: 0 } },
       ],
       [
-        { id: 'e1', source: 'out1', target: 'g1', data: { weight: 0.5, direction: 'positive' } },
+        { id: 'e1', source: 'out1', target: 'g1', data: { weight: 0.5, direction: 'positive', weightSource: 'cee' } },
       ],
     )
     // results status is 'idle' — pre-analysis
@@ -187,7 +187,7 @@ describe('InspectorRouter', () => {
         { id: 'g1', type: 'goal', data: { label: 'Target', kind: 'goal' }, position: { x: 100, y: 0 } },
       ],
       [
-        { id: 'e1', source: 'out1', target: 'g1', data: { weight: 0.5, direction: 'positive' } },
+        { id: 'e1', source: 'out1', target: 'g1', data: { weight: 0.5, direction: 'positive', weightSource: 'cee' } },
       ],
     )
     useCanvasStore.setState({ results: { status: 'complete' } } as never)

--- a/src/canvas/ui/inspector-v2/__tests__/OutcomeRisk.v62.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/OutcomeRisk.v62.spec.tsx
@@ -25,7 +25,7 @@ function setOutcomeStore(overrides: Record<string, unknown> = {}) {
     edges: [
       { id: 'e1', source: 'fac1', target: 'out1', data: { weight: 0.65, direction: 'positive' } },
       { id: 'e2', source: 'fac2', target: 'out1', data: { weight: 0.3, direction: 'negative' } },
-      { id: 'e3', source: 'out1', target: 'goal1', data: { weight: 0.8 } },
+      { id: 'e3', source: 'out1', target: 'goal1', data: { weight: 0.8, weightSource: 'cee' } },
     ],
     results: { status: 'none', report: null },
     ...overrides,

--- a/src/canvas/ui/inspector-v2/__tests__/SharedComponents.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/SharedComponents.spec.tsx
@@ -168,7 +168,7 @@ describe('ConnectionRow', () => {
       <ConnectionRow
         nodeKind="outcome"
         label="Revenue growth"
-        strength={{ weight: 0.45, direction: 'positive' }}
+        strength={{ show: true, value: 0.45, source: 'cee' }}
       />,
     )
     expect(screen.getByText('Revenue growth')).toBeTruthy()
@@ -180,7 +180,7 @@ describe('ConnectionRow', () => {
       <ConnectionRow
         nodeKind="outcome"
         label="Revenue growth"
-        strength={{ weight: 0.45, direction: 'positive' }}
+        strength={{ show: true, value: 0.45, source: 'cee' }}
         techMode={true}
       />,
     )

--- a/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
@@ -25,6 +25,8 @@ import { TechnicalDisclosure } from '../shared/TechnicalDisclosure'
 import type { InspectorPanelProps } from '../types'
 import { COACHING } from '../coachingConfig'
 import { DecisionAdvancedEditor } from '../editors/DecisionAdvancedEditor'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
+import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
 
 export const DecisionPanel = memo(function DecisionPanel({
   nodeId,
@@ -108,7 +110,7 @@ export const DecisionPanel = memo(function DecisionPanel({
           nodeId: otherId,
           nodeKind: kind,
           label: String(otherNode.data?.label ?? otherId),
-          strength: { weight: e.data?.weight ?? 0, direction: (e.data?.direction ?? 'positive') as 'positive' | 'negative' },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
       .filter(Boolean) as Array<{
@@ -116,7 +118,7 @@ export const DecisionPanel = memo(function DecisionPanel({
         nodeId: string
         nodeKind: NodeType
         label: string
-        strength: { weight: number; direction: 'positive' | 'negative' }
+        strength: EdgeValueDisplay
       }>
   }, [edges, nodes, nodeId])
 

--- a/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
@@ -36,6 +36,7 @@ import { DataBar } from '../../shared/DataBar'
 import type { InspectorPanelProps } from '../types'
 import { resolveCoaching } from '../coachingConfig'
 import { FactorControllableEditor } from '../editors/FactorControllableEditor'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 
 /**
  * Extract a non-empty string intervention value, accepting either a bare
@@ -168,7 +169,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
           nodeId: e.target,
           nodeKind: kind,
           label: String(tgt?.data?.label ?? e.target),
-          strength: { weight: e.data?.weight ?? 0, direction: (e.data?.direction ?? 'positive') as 'positive' | 'negative' },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
   }, [edges, nodes, nodeId])

--- a/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
@@ -31,6 +31,7 @@ import type { InspectorPanelProps } from '../types'
 import { resolveCoaching } from '../coachingConfig'
 import { FactorExternalEditor } from '../editors/FactorExternalEditor'
 import { factorDisplayText } from '../../../../utils/formatFactorDisplayValue'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 
 // Quick-set presets
 const QUICK_SET = {
@@ -125,7 +126,7 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
           nodeId: e.target,
           nodeKind: kind,
           label: String(tgt?.data?.label ?? e.target),
-          strength: { weight: e.data?.weight ?? 0, direction: (e.data?.direction ?? 'positive') as 'positive' | 'negative' },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
   }, [edges, nodes, nodeId])

--- a/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
@@ -37,6 +37,7 @@ import { DataBar } from '../../shared/DataBar'
 import type { InspectorPanelProps } from '../types'
 import { resolveCoaching } from '../coachingConfig'
 import { FactorObservableEditor } from '../editors/FactorObservableEditor'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 
 export const FactorObservablePanel = memo(function FactorObservablePanel({
   nodeId,
@@ -98,7 +99,7 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
           nodeId: e.target,
           nodeKind: kind,
           label: String(tgt?.data?.label ?? e.target),
-          strength: { weight: e.data?.weight ?? 0, direction: (e.data?.direction ?? 'positive') as 'positive' | 'negative' },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
   }, [edges, nodes, nodeId])

--- a/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
@@ -40,6 +40,7 @@ import { resolveCoaching } from '../coachingConfig'
 import { GoalAdvancedEditor } from '../editors/GoalAdvancedEditor'
 import { useAuth } from '../../../../contexts/AuthContext'
 import { isPersistenceActive } from '../../../../lib/persistenceActive'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 
 export const GoalPanel = memo(function GoalPanel({
   nodeId,
@@ -190,14 +191,12 @@ export const GoalPanel = memo(function GoalPanel({
       .map(e => {
         const sourceNode = nodes.find(n => n.id === e.source)
         const kind = (sourceNode?.type || sourceNode?.data?.kind || 'factor') as NodeType
-        const weight = e.data?.weight ?? 0
-        const direction = (e.data?.direction ?? 'positive') as 'positive' | 'negative'
         return {
           edgeId: e.id,
           nodeId: e.source,
           nodeKind: kind,
           label: String(sourceNode?.data?.label ?? e.source),
-          strength: { weight, direction },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
   }, [edges, nodes, nodeId])

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -30,6 +30,8 @@ import type { InspectorPanelProps } from '../types'
 import { COACHING } from '../coachingConfig'
 import { OptionAdvancedEditor } from '../editors/OptionAdvancedEditor'
 import { ResultsLink } from '../shared/ResultsLink'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
+import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
 
 export const OptionPanel = memo(function OptionPanel({
   nodeId,
@@ -122,7 +124,7 @@ export const OptionPanel = memo(function OptionPanel({
           nodeId: e.target,
           nodeKind: kind,
           label: String(tgt.data?.label ?? e.target),
-          strength: { weight: e.data?.weight ?? 0, direction: (e.data?.direction ?? 'positive') as 'positive' | 'negative' },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
       .filter(Boolean) as Array<{
@@ -130,7 +132,7 @@ export const OptionPanel = memo(function OptionPanel({
         nodeId: string
         nodeKind: NodeType
         label: string
-        strength: { weight: number; direction: 'positive' | 'negative' }
+        strength: EdgeValueDisplay
       }>
   }, [edges, nodes, nodeId, interventionIds])
 

--- a/src/canvas/ui/inspector-v2/panels/OutcomePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OutcomePanel.tsx
@@ -28,6 +28,7 @@ import { ResultsLink } from '../shared/ResultsLink'
 import type { InspectorPanelProps } from '../types'
 import { COACHING } from '../coachingConfig'
 import { OutcomeAdvancedEditor } from '../editors/OutcomeAdvancedEditor'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 
 // ─── Option comparison helpers ─────────────────────────────────────
 
@@ -158,8 +159,16 @@ export const OutcomePanel = memo(function OutcomePanel({
       const kind = tgt?.type || tgt?.data?.kind
       return kind === 'goal'
     })
-    if (!goalEdge || goalEdge.data?.weight == null) return null
-    return Math.round((goalEdge.data.weight as number) * 100)
+    if (!goalEdge) return null
+    // ⛔ Provenance gate. `goalEdge.data?.weight == null` was a TAUTOLOGY:
+    // `DEFAULT_EDGE_DATA`/`USER_EDGE_DEFAULTS` always define `weight`, so the
+    // null arm was dead and this rendered `USER_EDGE_DEFAULTS.weight` (0.3) as
+    // a green "Contributes to goal" bar plus a bold "30%". This is the literal
+    // twin of the defect already fixed in `OutcomeNode.tsx` — same shape, same
+    // comment, one file over, unfixed. Copied the fix rather than re-deriving.
+    const display = resolveEdgeSignedStrengthDisplay(goalEdge.data as Record<string, unknown> | undefined)
+    if (!display.show) return null
+    return Math.round(Math.abs(display.value) * 100)
   }, [edges, nodes, nodeId])
 
   // Inbound factors (drivers)
@@ -174,7 +183,7 @@ export const OutcomePanel = memo(function OutcomePanel({
           nodeId: e.source,
           nodeKind: kind,
           label: String(src?.data?.label ?? e.source),
-          strength: { weight: e.data?.weight ?? 0, direction: (e.data?.direction ?? 'positive') as 'positive' | 'negative' },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
   }, [edges, nodes, nodeId])

--- a/src/canvas/ui/inspector-v2/panels/RiskPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/RiskPanel.tsx
@@ -39,6 +39,7 @@ import {
 import type { InspectorPanelProps } from '../types'
 import { COACHING } from '../coachingConfig'
 import { RiskAdvancedEditor } from '../editors/RiskAdvancedEditor'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 
 /** Impact enum options, ordered low → critical. Labels are the capitalised enum. */
 const IMPACT_OPTIONS: { value: RiskImpact; label: string }[] = [
@@ -93,7 +94,7 @@ export const RiskPanel = memo(function RiskPanel({
           nodeId: e.source,
           nodeKind: kind,
           label: String(src?.data?.label ?? e.source),
-          strength: { weight: e.data?.weight ?? 0, direction: (e.data?.direction ?? 'positive') as 'positive' | 'negative' },
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
   }, [edges, nodes, nodeId])

--- a/src/canvas/ui/inspector-v2/shared/ConnectionRow.tsx
+++ b/src/canvas/ui/inspector-v2/shared/ConnectionRow.tsx
@@ -7,6 +7,7 @@
 import { useCallback } from 'react'
 import { NodeShapeIndicator } from '../../../nodes/NodeShapeIndicator'
 import type { NodeType } from '../../../domain/nodes'
+import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
 import { typography } from '../../../../styles/typography'
 import { getStrengthLabel } from '../inspectorStrings'
 
@@ -24,7 +25,24 @@ interface ConnectionRowProps {
   nodeKind: NodeType
   label: string
   badge?: React.ReactNode
-  strength?: { weight: number; direction: 'positive' | 'negative' }
+  /**
+   * The connection's strength, ALREADY resolved through the provenance gate
+   * (`resolveEdgeSignedStrengthDisplay`).
+   *
+   * ⛔ THIS TYPE IS THE FIX. It used to be `{ weight: number; direction:
+   * 'positive' | 'negative' }` — a shape that cannot express "nobody set
+   * this", exactly like the `thresholdColor(v: number)` signature removed in
+   * #476. Every one of the nine construction sites therefore wrote
+   * `{ weight: e.data?.weight ?? 0, direction: e.data?.direction ?? 'positive' }`
+   * and this row painted `USER_EDGE_DEFAULTS.weight` as a coloured bar, a
+   * "Moderate +" band label and a ± glyph across EIGHT inspector panels.
+   *
+   * Fixing the eight consumers would have left the enabler in place. Taking
+   * `EdgeValueDisplay` means there is no argument a caller can construct that
+   * means "0.3, source unknown", and handling the unset case is a type error
+   * rather than something a tenth panel can forget.
+   */
+  strength?: EdgeValueDisplay
   techMode?: boolean
   onClick?: () => void
   /** When true, label is not truncated (used by DriversList where full names matter) */
@@ -44,9 +62,13 @@ export function ConnectionRow({
 
   const handleClick = useCallback(() => onClick?.(), [onClick])
 
-  const signedValue = strength
-    ? strength.direction === 'negative' ? -strength.weight : strength.weight
-    : null
+  // `show: true` is the ONLY path to a number here. `not_set` keeps the row
+  // (the connection is real — the user drew it) and says so in words instead
+  // of painting a bar sized to a value nobody chose; `absent` means there is
+  // no strength channel on this row at all (e.g. the option rows in
+  // FactorControllablePanel, which pass no `strength` prop).
+  const signedValue = strength?.show ? strength.value : null
+  const showNotSet = strength?.show === false && strength.reason === 'not_set'
 
   return (
     <div
@@ -61,8 +83,16 @@ export function ConnectionRow({
       <NodeShapeIndicator nodeKind={nodeKind} size={16} />
       <span className={`${typography.panelBody} text-text-body flex-1 ${fullLabel ? 'break-words' : 'truncate'}`}>{label}</span>
       {badge}
-      {strength && signedValue !== null && (
-        <div className="flex items-center gap-1.5 min-w-[90px]">
+      {showNotSet && (
+        <span
+          data-testid="connection-row-strength-not-set"
+          className={`${typography.panelMeta} text-text-light min-w-[90px] text-right`}
+        >
+          Not set
+        </span>
+      )}
+      {signedValue !== null && (
+        <div className="flex items-center gap-1.5 min-w-[90px]" data-testid="connection-row-strength">
           {/* Strength bar */}
           <div className="flex-1 h-1 bg-panel-border rounded-full overflow-hidden">
             <div

--- a/src/canvas/ui/inspector-v2/shared/DriversList.tsx
+++ b/src/canvas/ui/inspector-v2/shared/DriversList.tsx
@@ -8,13 +8,15 @@
 
 import { ConnectionRow } from './ConnectionRow'
 import type { NodeType } from '../../../domain/nodes'
+import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
 
 export interface DriverItem {
   edgeId: string
   nodeId: string
   nodeKind: NodeType
   label: string
-  strength: { weight: number; direction: 'positive' | 'negative' }
+  /** Already through the provenance gate — see `ConnectionRowProps.strength`. */
+  strength: EdgeValueDisplay
 }
 
 interface DriversListProps {

--- a/src/canvas/ui/inspector-v2/useInspectorMutations.ts
+++ b/src/canvas/ui/inspector-v2/useInspectorMutations.ts
@@ -62,7 +62,7 @@ export const EDGE_SETTER_FIELDS = {
   // into a set one, so the stamp is written in the same update as the value
   // and can never lag behind it.
   setStrength: ['weight', 'direction', 'weightSource'],
-  setStd: ['strengthStd'],
+  setStd: ['strengthStd', 'strengthStdSource'],
   setExistsProbability: ['beliefExists', 'beliefExistsSource'],
   setLabel: ['label'],
   setDirection: ['direction'],
@@ -285,7 +285,7 @@ export function useEdgeMutations(edgeId: string) {
   const setStd = useCallback((std: number) => {
     const edge = getEdge()
     if (!edge) return
-    updateEdge(edgeId, { data: { ...edge.data, strengthStd: std } })
+    updateEdge(edgeId, { data: { ...edge.data, strengthStd: std, strengthStdSource: 'user' } })
   }, [edgeId, updateEdge, getEdge])
 
   const setExistsProbability = useCallback((ep: number) => {

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -144,6 +144,7 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
       ...edgeValueSourcePatch({
         beliefExists: beliefExists !== undefined ? 'cee' : undefined,
         weight: wireSuppliedStrength ? 'cee' : undefined,
+        strengthStd: strengthStd !== undefined ? 'cee' : undefined,
       }),
       // CEE display provenance (snake_case → camelCase). Distinct from `provenance_source`.
       ...edgeProvenanceDisplayPatch(e),

--- a/src/canvas/utils/graphDisplayCalculations.ts
+++ b/src/canvas/utils/graphDisplayCalculations.ts
@@ -122,6 +122,18 @@ export function existenceCertaintyToLineStyle(
  *   |mean| <  0.4 → 1.5px
  * Calls Math.abs internally — pass the signed mean directly.
  */
+/**
+ * The width an edge draws at when NOBODY HAS SET ITS STRENGTH.
+ *
+ * Equal to the thinnest measured band on purpose. An edge must be drawn, so
+ * some width is unavoidable; the floor is the only one that cannot be read as
+ * "this influence is strong". Callers reach it via the provenance gate
+ * (`resolveEdgeSignedStrengthDisplay`), never by passing a fabricated number
+ * into `weightMagnitudeToStrokeWidth` below — that function takes a `number`
+ * and so, by construction, cannot tell a measurement from a default.
+ */
+export const UNSET_EDGE_STROKE_WIDTH = 1.5
+
 export function weightMagnitudeToStrokeWidth(signedMean: number): number {
   const magnitude = Math.abs(signedMean)
   if (magnitude >= 0.7) return 3

--- a/src/routes/templates/components/ErrorBanner.tsx
+++ b/src/routes/templates/components/ErrorBanner.tsx
@@ -99,6 +99,29 @@ export const ErrorBanner = memo<ErrorBannerProps>(({
           {error.hint && (
             <p className="text-sm mt-1 opacity-90">{error.hint}</p>
           )}
+          {/*
+            ⚠ DELIBERATE — do NOT "fix" this in an honesty/leak sweep.
+            Paul has confirmed the Reference ID is a support affordance: it is
+            meant to be user-visible in production, in a role="alert" banner,
+            with no dev guard. Removing it removes the only handle a user has
+            when they report a failed run. It has been flagged as an internal-
+            identifier leak before; it is not one.
+
+            WHAT IT ACTUALLY IS (traced 2026-07-25 — read this before assuming):
+            NOT the CEE top-level `request_id`. This value comes from PLoT's
+            ERROR payload: `v1/sseClient.ts:505` probes
+            `data.request_id || data.requestId || details?.request_id ||
+            details?.requestId`, that lands on `EngineError.requestId`, and
+            `httpV1Adapter.ts:357` maps it to `error.request_id`. The name it
+            wears here is the adapter's, not the wire's.
+
+            The CEE-side distinction matters because CEE PR #689 removed a
+            top-level `request_id` from the field-coverage allowlist as a FALSE
+            claim — so a reader who assumes this banner shows that field will
+            conclude the banner is broken. It shows PLoT's engine request id.
+            The four-way probe above means the exact producing key is not
+            pinned; that has NOT been traced to a single PLoT emit site.
+          */}
           {error.request_id && (
             <p className="text-xs mt-1 text-gray-700">
               Reference ID: <span className="font-mono">{error.request_id}</span>


### PR DESCRIPTION
## What

#472–#476 gated the **number** and then one panel's **colour**. The same fabricated value kept reaching users through every channel that has no words. This closes the highest-consequence group from #476's own sweep (`parallel-briefs/EDGE-COLOUR-BAND-2026-07-25.md`) by **extending the mechanism**, not by adding conditionals at ~20 sites.

### The mechanism (`src/canvas/domain/edgeValueProvenance.ts`)

| Addition | Property it buys |
|---|---|
| `compareEdgeValueDisplays` / `compareEdgeValueAggregates` | Take `EdgeValueDisplay`, never a `number`. Unset sorts **last in BOTH directions** — a property a sentinel cannot hold. |
| `aggregateEdgeSignedStrength` → `EdgeValueAggregate` | Unsourced edges contribute **nothing**; zero sourced inputs ⇒ `show: false`, so ranking on no evidence is a type error. |
| `strengthStd` in `EDGE_PROVENANCED_FIELDS` + `edgeSourceKey` derived via `` `${Field}Source` `` | The **registry** gap, fixed at the type level. The old hand-written ternary would have silently mapped any third field to `weightSource`. |

**Why the sentinel had to go.** The leaking sites all wrote `weight != null ? weight : -Infinity`. That is wrong three times: the `!= null` guard is a **tautology** (the edge defaults always define `weight`, so the arm is dead and every defaulted edge ranked as a measured one); the sentinel's **sign hand-compensates for the sort direction** — `ModelTabBody` carries `+Infinity` for its ascending key and `-Infinity` for its descending one, two lines apart; and a sentinel is a number, so it composes silently into aggregates.

## Sites closed

**Ordering — including the one with the highest user consequence:**
- `DecisionNode` "Top gap: validate X" — **the product telling the user which factor to go and fix**, ranked by a sum of `w ?? 0.5`. On a graph with no strengths set, that is `0.5 × out-degree`: the recommendation was decided by out-degree and iteration order and presented as leverage.
- `FactorNode` priority quieting · `ModelTabBody` edge list · `RelationshipsSection` remainder · `StyledEdge` top-3 persistent labels.

**`ConnectionRow` — the prop type, not the eight consumers.** `strength` was `{ weight: number; direction }`, a shape that cannot express "unset", exactly like the `thresholdColor(v: number)` removed in #476. All nine construction sites wrote `{ weight: e.data?.weight ?? 0, … }`, feeding a coloured bar, a band label and a ± glyph into **8 inspector panels**. Now `EdgeValueDisplay`; unset renders "Not set" with no bar.

**`OutcomePanel:160`** — the literal un-fixed twin of the tautology already fixed in `OutcomeNode`. Copied that fix.

**`StyledEdge` colour + thickness.** `computeDirectionStroke` retyped to take `EdgeValueDisplay`, which finally makes its **dead** "uninitialised → yellow" branch reachable (it required `rawWeight === undefined`, which never happens). Deliberate exception, stated: unset resolves to **neutral grey**, not the `var(--goal)` yellow the old branch intended — that token is the goal *entity* colour and minting an "unset" edge hue is a design-system call, not this lane's.

**Write side:** `PreAnalysisPanel:1200` now stamps `weightSource: 'user'` when the user explicitly picks a band, so a genuine choice stops reading as "Not set".

## Test-infra fix — platform trap 12, caught in the act

Seven `StyledEdge` specs mocked `graphDisplayCalculations` with a **hand-listed factory**. A `vi.mock` factory *replaces* the module, so adding one export took **49 tests down across seven files at once**. All seven converted to `importOriginal`-spread.

## Evidence

- **Reachability control.** Every unset fixture is built by `useCanvasStore.addEdge` with `USER_EDGE_DEFAULTS` — the exact call a user drag makes — asserting the fabricated number **is** present and the stamp is **not**, before anything renders. Two defects in this area were branches that could never fire while their comments claimed otherwise.
- **Mutation check** — throwaway worktree (removed), **runner sanity-checked first** (17/17 pass unmutated, not a silent no-op), anchors asserted, writes verified:

| Mutation | Result |
|---|---|
| `compareEdgeValueDisplays` back to the `-Infinity` sentinel | **RED** 1 failed |
| aggregate contributes the old fabricated `0.5` | **RED** 3 failed (incl. the DecisionNode recommendation) |
| `computeDirectionStroke` drops the unset guard | **RED** 1 failed |
| `strengthStd` removed from the registry | **RED** 1 failed |
| `ConnectionRow` bands the raw number again | **RED** 2 failed |

Restore ⇒ 17/17 GREEN.

- **Claim types**, stated precisely: pure-function return values; rendered `class`/text/DOM-node presence; rendered order. **Not** visibility, contrast or layout — jsdom cannot prove those (trap 3).
- **Discrimination both ways** in every block: a gate that returned "unset" for everything would fail the second half of each test.
- Typecheck gate **PASSED** (3015/3033 files). Lint 0 errors. Affected surface: **5,651 tests / 351 files green**.

## Baseline NOT regenerated — deliberate

The gate reports `Drift shrank (2663 → 2661)`. Diffing an `--update-baseline` run shows the entire delta is `useV2Run.ts` (16→15) and `hydrateAnalysis.ts` (2→1) — **neither touched by this PR, neither importing anything it changes**. Identical to what #476 found and declined. Encoding it would bundle an unrelated change. ⚠ Two independent lanes hitting the same two files means the committed baseline over-counts by 2 at the pristine tip, so *every* PR gets a "shrink" notice it must decline — worth fixing separately.

## Also

`ErrorBanner` "Reference ID" annotated as **deliberate** (Paul-confirmed support affordance, do not remove) with its actual provenance traced: it is PLoT's engine error id via `sseClient.ts:505` → `httpV1Adapter.ts:357`, **not** the CEE top-level `request_id` that CEE #689 removed from the allowlist as a false claim. The four-way probe means the exact producing key is not pinned; the comment says so rather than implying it was traced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)