### PR TITLE
fix(honesty): one voice on "is there a leading option" — every surface quotes one derived verdict

### DIFF
--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -21,6 +21,7 @@ import { detectBaseline } from '../utils/baselineDetection'
 import { usePopoverHover } from '../hooks/usePopoverHover'
 import { NodeChip, ActionIcons, BriefIcon, NodePopover, ScienceIcon } from './shared'
 import { selectGoalProbability } from '../../components/results/utils/selectGoalProbability'
+import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../lib/decisionVerdict'
 
 /** Truncate text at word boundary to avoid mid-word cuts. */
 function truncateAtWord(text: string, maxLength: number): string {
@@ -392,32 +393,26 @@ export const OptionNode = memo((props: NodeProps) => {
   // it could never fire). Freshness verdicts render on the panel surfaces
   // via the composed trust semantic (useAnalysisTrust).
 
+  // SINGLE VERDICT (2026-07-25): the canvas no longer decides for itself
+  // whether a leading option exists. It quotes `deriveDecisionVerdict` — the
+  // one module entitled to answer that — computed from the SAME PLoT report
+  // the results panel reads. Before this, the badge asked only "WHO leads?"
+  // (producer recommendation, else win-probability argmax) with no gate for
+  // "is there a leader at all", so it fired on 100% of completed runs while
+  // the panel independently printed "no clear leading option" beside it. See
+  // src/lib/decisionVerdict.ts for the full diagnosis.
+  const verdict = useMemo(() => {
+    const optionNodes = nodes.filter(n => n.type === 'option' || n.data?.type === 'option')
+    return deriveDecisionVerdict(resultsReport as DecisionVerdictReportLike | null, {
+      visibleOptionIds: new Set(optionNodes.map(n => n.id)),
+    })
+  }, [nodes, resultsReport])
+
+  /** True only when this node is the leader AND a leading option exists at all. */
   const isRecommended = useMemo(() => {
     if (!displayMetadata.isResultsMode || displayMetadata.winRate === null) return false
-    const optionNodes = nodes.filter(n => n.type === 'option' || n.data?.type === 'option')
-    if (optionNodes.length < 2) return false
-    const visibleOptionIds = new Set(optionNodes.map(n => n.id))
-    const report = resultsReport as any
-    // Prefer the backend's own recommendation so the canvas "Leading option"
-    // badge agrees with the Results Panel (which honours recommended_option_id
-    // first) and with this node's own closeCallGapPp/behindReason. Backend
-    // recommendation and win-probability argmax diverge on close/indeterminate
-    // runs — badging the win-max option while the panel recommends another is
-    // the #1-vs-#4 cross-surface disagreement. Win-max is the fallback only
-    // when the producer sends no recommendation (or it is not a visible node).
-    const recommendedId = report?.robustness?.recommended_option_id as string | undefined
-    if (recommendedId && visibleOptionIds.has(recommendedId)) {
-      return props.id === recommendedId
-    }
-    const optionProbabilities: Record<string, { win_probability?: number }> = report?.option_probabilities ?? {}
-    const allRates = Object.entries(optionProbabilities)
-      .filter(([id]) => visibleOptionIds.has(id))
-      .map(([, v]) => typeof v?.win_probability === 'number' ? v.win_probability : null)
-      .filter((v): v is number => v !== null)
-    if (allRates.length === 0) return false
-    const maxRate = Math.max(...allRates)
-    return displayMetadata.winRate >= maxRate - 0.0001
-  }, [displayMetadata.isResultsMode, displayMetadata.winRate, nodes, resultsReport, props.id])
+    return verdict.hasLeadingOption && verdict.leaderId === props.id
+  }, [displayMetadata.isResultsMode, displayMetadata.winRate, verdict, props.id])
 
   const ceeAnalysisReady = useCanvasStore(state => state.ceeAnalysisReady)
   // UI-SEM-082 (Lane 4): the "chance of target" badge is a goal-fit claim, so it
@@ -438,23 +433,21 @@ export const OptionNode = memo((props: NodeProps) => {
   // missing. Returns null when not in close-call territory or pre-analysis.
   const closeCallGapPp = useMemo<number | null>(() => {
     if (!isPostAnalysis || isRecommended) return null
+    // SINGLE VERDICT: `isRecommended` is now false for the front-runner too
+    // when no leading option exists (a tied run). Without this guard the
+    // front-runner would compute a zero gap against itself and render
+    // "Close call: within 1 percentage point" on its own card.
+    if (verdict.leaderId === props.id) return null
     const report = resultsReport as any
     const probs: Record<string, { win_probability?: number }> | undefined = report?.option_probabilities
     if (!probs) return null
     const thisWin = probs[props.id]?.win_probability
     if (typeof thisWin !== 'number') return null
-    let leaderWin: number | null = null
-    const recommendedId = report?.robustness?.recommended_option_id as string | undefined
-    if (recommendedId && typeof probs[recommendedId]?.win_probability === 'number') {
-      leaderWin = probs[recommendedId]!.win_probability!
-    } else {
-      // Fallback: scan for max
-      for (const id in probs) {
-        const w = probs[id]?.win_probability
-        if (typeof w === 'number' && (leaderWin == null || w > leaderWin)) leaderWin = w
-      }
-    }
-    if (leaderWin == null) return null
+    // SINGLE VERDICT: leader identity comes from the shared verdict, not a
+    // second local resolution of `recommended_option_id`-else-argmax.
+    const leaderId = verdict.leaderId
+    const leaderWin = leaderId != null ? probs[leaderId]?.win_probability : undefined
+    if (typeof leaderWin !== 'number') return null
     const gap = leaderWin - thisWin
     if (gap < 0 || gap > 0.05) return null
     // Floor to at least 1pp so the line never reads "within 0 percentage
@@ -462,7 +455,7 @@ export const OptionNode = memo((props: NodeProps) => {
     // early return (within-0.0001 tolerance), but rounding can still produce
     // 0 from a small positive gap like 0.004.
     return Math.max(1, Math.round(gap * 100))
-  }, [isPostAnalysis, isRecommended, resultsReport, props.id])
+  }, [isPostAnalysis, isRecommended, verdict, resultsReport, props.id])
 
   const allInterventionChips = useMemo<InterventionChip[]>(() => {
     // Primary: ceeAnalysisReady.options[optionId].interventions

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -2080,9 +2080,16 @@ describe('OptionNode — winsVia ranks via the display policy and never overclai
         status: 'complete',
         report: {
           robustness: { recommended_option_id: 'option-1' },
+          // SINGLE VERDICT (2026-07-25): widened from 0.54/0.45. That 9pp gap
+          // sits INSIDE PLoT's own near-tie threshold (0.10), so under the
+          // shared verdict there is no leading option and the leader copy
+          // these tests are about is correctly suppressed. The win split is
+          // incidental to what this block asserts (which FACTOR winsVia names
+          // and whether it may claim "#1 driver"), so it is set to a genuine
+          // lead rather than the suppression case.
           option_probabilities: {
-            'option-1': { win_probability: 0.54 },
-            'option-2': { win_probability: 0.45 },
+            'option-1': { win_probability: 0.70 },
+            'option-2': { win_probability: 0.29 },
           },
           factor_sensitivity: opts.factors,
         },

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -30,6 +30,7 @@ import type { InspectorPanelProps } from '../types'
 import { COACHING } from '../coachingConfig'
 import { OptionAdvancedEditor } from '../editors/OptionAdvancedEditor'
 import { ResultsLink } from '../shared/ResultsLink'
+import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../../../lib/decisionVerdict'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
 
@@ -45,6 +46,18 @@ export const OptionPanel = memo(function OptionPanel({
   const isResultsMode = resultsStatus === 'complete'
   const optionComparison = useCanvasStore(s => s.results?.report?.option_comparison)
   const storyHeadlines = useCanvasStore(s => s.results?.report?.story_headlines)
+  // SINGLE VERDICT: the shared "is there a leading option?" answer, derived
+  // from the same PLoT report the canvas badge and results panel read.
+  const resultsReport = useCanvasStore(s => s.results?.report)
+
+  const verdict = useMemo(
+    () => deriveDecisionVerdict(resultsReport as DecisionVerdictReportLike | null | undefined, {
+      visibleOptionIds: new Set(
+        nodes.filter(n => n.type === 'option' || n.data?.type === 'option').map(n => n.id),
+      ),
+    }),
+    [resultsReport, nodes],
+  )
 
   const node = nodeId ? nodes.find(n => n.id === nodeId) : undefined
   const mutations = useNodeMutations(nodeId ?? '')
@@ -339,6 +352,12 @@ export const OptionPanel = memo(function OptionPanel({
                 const leaderPct = leader.winPct ?? 0
                 const gap = leaderPct - myPct
                 if (leader.isCurrent) {
+                  // SINGLE VERDICT (2026-07-25): the inspector may only say
+                  // "the leading option" when the shared verdict says one
+                  // exists. Previously this fired on being the local win-max,
+                  // so it could assert a leader in the same session where the
+                  // results panel said "no clear leading option".
+                  if (verdict.hasLeadingOption === false) return null
                   return <p className={`${typography.panelBody} text-success mt-1`}>Currently the leading option.</p>
                 }
                 if (gap <= 5) {

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -203,6 +203,9 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
       analysisStatus: data.recommendation.analysisStatus,
       optionCount: data.recommendation.allOptions.length,
       winProbabilityGap,
+      // SINGLE VERDICT: the shared "is there a leading option?" answer,
+      // derived from the same PLoT report the canvas badge reads.
+      verdict: data.recommendation.verdict,
     })
   }, [
     data.recommendation.recommendedOption,
@@ -212,6 +215,7 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
     data.recommendation.allOptions.length,
     data.confidence.tier.tier,
     winProbabilityGap,
+    data.recommendation.verdict,
   ])
 
   // Brief 5.2 follow-up (ChatGPT P0 #1): the earlier gate was too narrow —

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -425,7 +425,17 @@ function T1ChecksFooter({
   aiAffordance?: ReactNode
   useV17Copy?: boolean
 }) {
-  const hasWinner = !!data.recommendation.recommendedOption
+  // SINGLE VERDICT (2026-07-25): this check used to be presence-only
+  // (`!!recommendedOption`), and `determineWinnerSelection` always returns a
+  // winner when any option exists — so the footer could tick "Winner" in the
+  // same panel whose headline said "no clear leading option". It now quotes
+  // the shared verdict (src/lib/decisionVerdict.ts), the same one the
+  // headline and the canvas badge use. Absent verdict (older fixtures) falls
+  // back to the historic presence check rather than silently reading false.
+  const verdict = data.recommendation.verdict
+  const hasWinner = verdict
+    ? verdict.hasLeadingOption
+    : !!data.recommendation.recommendedOption
   // Robustness glyph: driven ONLY by the display-safe robustness verdict
   // (`robustnessVerdict`) — never PLoT `report.robustness.level`, never the
   // UI-SEM-005 stability fallback, never a recommendationStability threshold.

--- a/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
+++ b/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
@@ -31,6 +31,7 @@ import { ResultsFooter } from '../ResultsFooter'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { ConfidenceTier, OptionResult, DecisionResultData, ConfidenceSectionData, DriversSectionData, ImprovementsSectionData } from '../types'
 import type { M1CoachingReadiness } from '../../../types/cee'
+import { deriveDecisionVerdict } from '../../../lib/decisionVerdict'
 
 interface MatrixCase {
   label: string
@@ -45,16 +46,23 @@ interface MatrixCase {
   expectFooterContains: string
   /** Phrases that must NOT appear in the footer. */
   forbidFooter?: string[]
+  /** Win probabilities driving the SINGLE VERDICT. Defaults to a clear lead. */
+  wins?: { winner: number; runnerUp: number }
 }
 
-function makeData(tier: ConfidenceTier, readiness: M1CoachingReadiness, stability: number): ResultsSectionDataReturn {
+function makeData(
+  tier: ConfidenceTier,
+  readiness: M1CoachingReadiness,
+  stability: number,
+  wins: { winner: number; runnerUp: number } = { winner: 0.80, runnerUp: 0.20 },
+): ResultsSectionDataReturn {
   const winner: OptionResult = {
     id: 'opt-a',
     label: 'Option A',
     expectedValue: 0.8,
     p10: 0.6,
     p90: 0.95,
-    winProbability: 0.80,
+    winProbability: wins.winner,
     goalProbability: 0.8,
   } as OptionResult
   const runnerUp: OptionResult = {
@@ -63,7 +71,7 @@ function makeData(tier: ConfidenceTier, readiness: M1CoachingReadiness, stabilit
     expectedValue: 0.5,
     p10: 0.3,
     p90: 0.7,
-    winProbability: 0.20,
+    winProbability: wins.runnerUp,
     goalProbability: 0.4,
   } as OptionResult
 
@@ -76,6 +84,16 @@ function makeData(tier: ConfidenceTier, readiness: M1CoachingReadiness, stabilit
     recommendationStability: stability,
     robustnessLevel: 'high',
     coachingReadiness: readiness,
+    // SINGLE VERDICT: derived by the REAL product function from the same win
+    // probabilities the fixture gives the options — never hand-written, so
+    // this matrix cannot pin a verdict the product would not produce.
+    verdict: deriveDecisionVerdict({
+      option_probabilities: {
+        'opt-a': { win_probability: wins.winner },
+        'opt-b': { win_probability: wins.runnerUp },
+      },
+      robustness: { recommended_option_id: 'opt-a' },
+    }),
   }
 
   const drivers: DriversSectionData = {
@@ -186,31 +204,46 @@ const matrix: MatrixCase[] = [
     forbidFooter: ['Stability sensitive'],
   },
   {
-    label: 'Rule 1 — unstable (stability < 0.70): hero "no clear leading option", footer "Sensitive to assumptions"',
+    // SINGLE VERDICT (2026-07-25) — REWRITTEN. This row used to assert that
+    // stability 0.55 makes the hero say "no clear leading option". With a
+    // 60-point win gap that is false, and it was exactly the contradiction the
+    // end-to-end journey lane caught on staging. The honest pairing is: the
+    // hero reports the LEAD (separation), the footer reports the FRAGILITY
+    // (robustness) — two different facts, each in its own voice, no denial.
+    label: 'clear lead + low stability: hero must NOT deny a leader; footer still "Sensitive to assumptions"',
     tier: 'strong',
     readiness: 'ready',
     stability: 0.55,
-    expectHeroContains: 'no clear leading option',
-    forbidHero: ['is the leading option'],
+    expectHeroContains: 'Option A',
+    forbidHero: ['no clear leading option', 'leads slightly more often'],
     expectFooterContains: 'Sensitive to assumptions',
   },
   {
-    // Rule 1 boundary — hero fires on stability < 0.70. Footer: fair + 0.40
-    // enters the §2.7 soft gate (tier ∈ {needs_work, fair} AND stab < 0.85),
-    // so the override fires regardless of the numeric-classification label.
-    // Hero + footer both read pessimistic, which is coherent.
-    label: 'Rule 1 boundary — stability 0.40 + fair tier: hero "no clear leading option", footer "Stability sensitive" via soft gate',
+    label: 'clear lead + very low stability + fair tier: hero must NOT deny a leader; footer "Stability sensitive" via soft gate',
     tier: 'fair',
     readiness: 'ready',
     stability: 0.40,
-    expectHeroContains: 'no clear leading option',
+    expectHeroContains: 'Option A',
+    forbidHero: ['no clear leading option'],
     expectFooterContains: 'Stability sensitive',
+  },
+  {
+    // The case where the denial is TRUE: the top two options are inside PLoT's
+    // own near-tie threshold (0.10). Positive control for the row above — it
+    // proves the hero can still print the denial when it is warranted.
+    label: 'TIED run (52% vs 48%): hero DOES say "no clear leading option"',
+    tier: 'strong',
+    readiness: 'ready',
+    stability: 0.55,
+    wins: { winner: 0.52, runnerUp: 0.48 },
+    expectHeroContains: 'no clear leading option',
+    expectFooterContains: 'Sensitive to assumptions',
   },
 ]
 
 describe('Hero ↔ Footer alignment — tier × readiness × stability matrix', () => {
   it.each(matrix)('$label', (testCase) => {
-    const data = makeData(testCase.tier, testCase.readiness, testCase.stability)
+    const data = makeData(testCase.tier, testCase.readiness, testCase.stability, testCase.wins)
     const panel = render(<DecisionConfidencePanel data={data} />)
 
     const panelText = panel.container.textContent ?? ''

--- a/src/components/results/__tests__/singleVerdict.crossSurface.spec.tsx
+++ b/src/components/results/__tests__/singleVerdict.crossSurface.spec.tsx
@@ -140,7 +140,9 @@ function setStore(s: Scenario): void {
   } as never)
 }
 
-const nodeProps = (id: string) => ({
+type OptionNodeProps = Parameters<typeof OptionNode>[0]
+
+const nodeProps = (id: string): OptionNodeProps => ({
   id,
   type: 'option',
   data: OPTION_NODES.find(n => n.id === id)!.data,
@@ -151,7 +153,7 @@ const nodeProps = (id: string) => ({
   positionAbsoluteY: 0,
   dragging: false,
   zIndex: 0,
-}) as never
+} as unknown as OptionNodeProps)
 
 /** What the CANVAS says: does any option node claim to be the leading option? */
 function canvasAssertsLeadingOption(): boolean {

--- a/src/components/results/__tests__/singleVerdict.crossSurface.spec.tsx
+++ b/src/components/results/__tests__/singleVerdict.crossSurface.spec.tsx
@@ -1,0 +1,259 @@
+/**
+ * SINGLE VERDICT — cross-surface agreement on "is there a leading option?"
+ *
+ * The end-to-end journey lane (parallel-briefs/END-TO-END-JOURNEY-2026-07-25.md)
+ * caught the product contradicting itself in ONE screenshot on staging build
+ * `27d002c9`:
+ *
+ *   - canvas option node:  "Leading option"  (+ "72% win probability")
+ *   - results panel:       "no clear leading option, the result is sensitive
+ *                           to your estimates" / "{winner} leads slightly
+ *                           more often"
+ *
+ * Both surfaces read the SAME PLoT report. This spec proves it: it sets ONE
+ * canvas-store state (one V2 run response, mapped by the product's own
+ * `mapV2ResponseToReportV1`), then drives BOTH surfaces from it —
+ *   · `OptionNode`               reads the store directly
+ *   · `useResultsSectionData()`  reads the store directly, and its output is
+ *                                the `data` prop `DecisionConfidencePanel`
+ *                                consumes
+ * — so nothing here mirrors a production derivation. The only fixture is the
+ * run response; every verdict on screen is computed by product code.
+ *
+ * The invariant under test is not "these two strings match". It is:
+ *
+ *   **No two surfaces may disagree about whether a leading option exists.**
+ *
+ * i.e. it is never simultaneously true that one surface asserts a leading
+ * option and another denies one, for a single analysis run.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, renderHook } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { DecisionConfidencePanel } from '../DecisionConfidencePanel'
+import { OptionNode } from '../../../canvas/nodes/OptionNode'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+// ── The journey's run, to the numbers it reported ──────────────────────────
+// "Double Down on Wholesale ... 72% win probability", runner-up 20%, and a
+// recommendation stability low enough that certaintyCopy's Rule 1 fires
+// (`recommendationStability < 0.70`).
+const WINNER_ID = 'opt_wholesale'
+const RUNNER_UP_ID = 'opt_retail'
+
+interface Scenario {
+  winnerWin: number
+  runnerUpWin: number
+  stability: number
+}
+
+const JOURNEY_RUN: Scenario = { winnerWin: 0.72, runnerUpWin: 0.20, stability: 0.55 }
+
+/** A genuinely indeterminate run — the case where "no clear leader" is TRUE. */
+const TIED_RUN: Scenario = { winnerWin: 0.52, runnerUpWin: 0.48, stability: 0.55 }
+
+/** A clear, robust run — the case where "leading option" is TRUE. */
+const CLEAR_RUN: Scenario = { winnerWin: 0.72, runnerUpWin: 0.20, stability: 0.92 }
+
+function makeV2Response(s: Scenario): V2RunResponse {
+  const outcome = (mean: number) => ({
+    mean,
+    std: 12,
+    p10: mean - 20,
+    p50: mean,
+    p90: mean + 20,
+    n_samples: 1000,
+    n_valid_samples: 1000,
+    validity_ratio: 1,
+  })
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [
+      {
+        option_id: WINNER_ID,
+        option_label: 'Double Down on Wholesale',
+        confidence_interval: [40, 80],
+        win_probability: s.winnerWin,
+        outcome: outcome(60),
+      },
+      {
+        option_id: RUNNER_UP_ID,
+        option_label: 'Open Retail Shop',
+        confidence_interval: [20, 60],
+        win_probability: s.runnerUpWin,
+        outcome: outcome(40),
+      },
+    ],
+    critiques: [],
+    drivers: [],
+    edge_sensitivity: [],
+    factor_sensitivity: [],
+    robustness: {
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      recommended_option_id: WINNER_ID,
+      recommendation_stability: s.stability,
+    } as never,
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  } as V2RunResponse
+}
+
+const OPTION_NODES = [
+  {
+    id: WINNER_ID,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { kind: 'option', type: 'option', label: 'Double Down on Wholesale' },
+  },
+  {
+    id: RUNNER_UP_ID,
+    type: 'option',
+    position: { x: 400, y: 0 },
+    data: { kind: 'option', type: 'option', label: 'Open Retail Shop' },
+  },
+]
+
+function setStore(s: Scenario): void {
+  const v2 = makeV2Response(s)
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report: mapV2ResponseToReportV1(v2, { seed: 42 }) },
+    runMeta: {},
+    nodes: OPTION_NODES,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: v2,
+    goalThreshold: null,
+    viewMode: 'expert',
+  } as never)
+}
+
+const nodeProps = (id: string) => ({
+  id,
+  type: 'option',
+  data: OPTION_NODES.find(n => n.id === id)!.data,
+  position: { x: 0, y: 0 },
+  selected: false,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+}) as never
+
+/** What the CANVAS says: does any option node claim to be the leading option? */
+function canvasAssertsLeadingOption(): boolean {
+  const { container } = render(
+    <ReactFlowProvider>
+      {OPTION_NODES.map(n => <OptionNode key={n.id} {...nodeProps(n.id)} />)}
+    </ReactFlowProvider>,
+  )
+  return /Leading option/i.test(container.textContent ?? '')
+}
+
+/**
+ * What the PANEL says. Two independent claims live in this one component:
+ *  - the headline, which may DENY a leading option ("no clear leading option")
+ *  - the T1 checks footer, which ticks "Winner" / "No winner"
+ * They must agree with each other and with the canvas.
+ */
+function readPanel(): { denies: boolean; footerTicksWinner: boolean; text: string } {
+  const { result } = renderHook(() => useResultsSectionData())
+  const { container } = render(
+    <DecisionConfidencePanel data={result.current} />,
+  )
+  const text = container.textContent ?? ''
+  return {
+    denies: /no clear leading option/i.test(text),
+    // Legacy copy (analysisHeroV17 off, which is staging's posture): the tick
+    // reads "Winner"; the failing state reads "No winner".
+    footerTicksWinner: /(^|[^o])Winner/.test(text) && !/No winner/i.test(text),
+    text,
+  }
+}
+
+describe('SINGLE VERDICT — canvas and results panel must not contradict each other', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+    } as never)
+    document.body.innerHTML = ''
+  })
+
+  // ── The reported defect ────────────────────────────────────────────────
+  it('the journey run (72% vs 20%, stability 0.55) does not produce both "Leading option" and "no clear leading option"', () => {
+    setStore(JOURNEY_RUN)
+    const canvasClaims = canvasAssertsLeadingOption()
+    document.body.innerHTML = ''
+    const panel = readPanel()
+
+    expect(
+      canvasClaims && panel.denies,
+      `Contradiction: canvas badge says "Leading option" while the results panel says "no clear leading option".\nPanel text: ${panel.text.slice(0, 400)}`,
+    ).toBe(false)
+  })
+
+  // ── Positive controls: the probe can SEE both claims ────────────────────
+  it('POSITIVE CONTROL: the canvas probe can see a leading-option claim on a clear, robust run', () => {
+    setStore(CLEAR_RUN)
+    expect(canvasAssertsLeadingOption()).toBe(true)
+  })
+
+  it('POSITIVE CONTROL: the panel probe can see a "no clear leading option" denial on a genuinely tied run', () => {
+    setStore(TIED_RUN)
+    expect(readPanel().denies).toBe(true)
+  })
+
+  it('POSITIVE CONTROL: the checks-footer probe can see both states', () => {
+    setStore(CLEAR_RUN)
+    expect(readPanel().footerTicksWinner).toBe(true)
+    document.body.innerHTML = ''
+    setStore(TIED_RUN)
+    expect(readPanel().footerTicksWinner).toBe(false)
+  })
+
+  // ── The invariant, over the whole matrix ────────────────────────────────
+  const MATRIX: Array<{ label: string; s: Scenario }> = [
+    { label: 'clear lead, robust', s: CLEAR_RUN },
+    { label: 'clear lead, fragile (the journey run)', s: JOURNEY_RUN },
+    { label: 'tied, fragile', s: TIED_RUN },
+    { label: 'tied, robust', s: { winnerWin: 0.52, runnerUpWin: 0.48, stability: 0.92 } },
+    { label: 'narrow lead just under the gap threshold', s: { winnerWin: 0.54, runnerUpWin: 0.46, stability: 0.75 } },
+    { label: 'narrow lead just over the gap threshold', s: { winnerWin: 0.56, runnerUpWin: 0.44, stability: 0.75 } },
+  ]
+
+  it.each(MATRIX)('$label — canvas and panel agree on whether a leading option exists', ({ s }) => {
+    setStore(s)
+    const canvasClaims = canvasAssertsLeadingOption()
+    document.body.innerHTML = ''
+    const panel = readPanel()
+    // Agreement in BOTH directions: the canvas badges exactly when the panel
+    // does not deny. A one-directional check would pass a build where the
+    // canvas went silent while the panel asserted a leader.
+    expect(
+      canvasClaims,
+      `Surfaces disagree. Canvas badged: ${canvasClaims}; panel denied: ${panel.denies}.\nPanel text: ${panel.text.slice(0, 400)}`,
+    ).toBe(!panel.denies)
+    // Third surface, same screen: the panel's own checks footer.
+    expect(
+      panel.footerTicksWinner,
+      `The checks footer and the headline disagree inside ONE panel.\nPanel text: ${panel.text.slice(0, 400)}`,
+    ).toBe(!panel.denies)
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -457,6 +457,45 @@ describe('buildHeroModel — producer band consumption (PLoT decision_brief.head
     expect(m.headline).toBe('Upskill the team is slightly ahead.')
   })
 
+  // ── SINGLE VERDICT (2026-07-25) ──────────────────────────────────────────
+  // The hero now quotes the shared verdict (src/lib/decisionVerdict.ts) — the
+  // SAME answer the canvas badge, the results-panel headline and the checks
+  // footer use — instead of resolving the producer band and banding win
+  // probabilities itself. It takes precedence over both local paths.
+  it('SINGLE VERDICT: a tied verdict denies a leader even where the local banding would claim one', () => {
+    const m = chart(buildHeroModel(makeHeroData({
+      options: options(),
+      recommendation: {
+        // Local paths would BOTH claim a leader here; the shared verdict wins.
+        headlineBanded: { band: 'clearly_ahead', leaderOptionId: 'opt_b', robustnessGated: false },
+        verdict: { leaderId: 'opt_b', separation: 'tied', hasLeadingOption: false, gapPp: 3, source: 'producer_near_tie' },
+      },
+    })))
+    expect(m.headline).toBe('No option is clearly ahead.')
+  })
+
+  it('SINGLE VERDICT: a clear verdict claims a leader even where the producer band said very_close', () => {
+    const m = chart(buildHeroModel(makeHeroData({
+      options: options(),
+      recommendation: {
+        headlineBanded: { band: 'very_close', leaderOptionId: 'opt_b', robustnessGated: false },
+        verdict: { leaderId: 'opt_b', separation: 'clear', hasLeadingOption: true, gapPp: 52, source: 'producer_near_tie' },
+      },
+    })))
+    expect(m.headline).toBe('Upskill the team is most likely to be strongest overall.')
+  })
+
+  it('SINGLE VERDICT identity gate: a verdict naming a different leader is not applied', () => {
+    const m = chart(buildHeroModel(makeHeroData({
+      options: options(),
+      recommendation: {
+        verdict: { leaderId: 'opt_a', separation: 'tied', hasLeadingOption: false, gapPp: 1, source: 'producer_near_tie' },
+      },
+    })))
+    // Falls through to the UI fallback (55% win → "slightly ahead").
+    expect(m.headline).toBe('Upskill the team is slightly ahead.')
+  })
+
   it('absent producer band → UI fallback banding unchanged (UI-SEM-060 residual)', () => {
     const m = chart(buildHeroModel(makeHeroData({ options: options() })))
     expect(m.headline).toBe('Upskill the team is slightly ahead.')

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -438,6 +438,21 @@ export function buildHeroModel(
   //   very_close     → 'none'    ("No option is clearly ahead.")
   // robustness_gated downgrades arrive already folded into the band by the
   // producer, so no copy keys off the flag here.
+  // SINGLE VERDICT (2026-07-25): the hero no longer resolves the producer band
+  // or bands win probabilities itself. Both are now done once, in
+  // `deriveDecisionVerdict` (src/lib/decisionVerdict.ts), and every surface
+  // that asserts or denies a leading option quotes that one answer — this
+  // hero, the results-panel headline, the canvas badge and the checks footer.
+  // The local resolution below is kept ONLY as the fallback for callers that
+  // do not yet supply a verdict (older fixtures), and is byte-identical to
+  // what it did before.
+  const sharedVerdict = recommendation.verdict ?? null
+  const sharedVerdictApplies =
+    sharedVerdict != null &&
+    headlineRow != null &&
+    sharedVerdict.separation !== 'unknown' &&
+    sharedVerdict.leaderId === headlineRow.id
+
   const producerBand = recommendation.headlineBanded ?? null
   const producerBandApplies =
     producerBand != null &&
@@ -456,7 +471,17 @@ export function buildHeroModel(
   const WIN_STRONG_LEADER = 0.65
   const WIN_MAJORITY = 0.5
   let leaderBand: 'strong' | 'ahead' | 'none' | null = null
-  if (producerBandApplies) {
+  if (sharedVerdictApplies) {
+    // clear → "most likely to be strongest overall"
+    // slight → "slightly ahead"
+    // tied → "No option is clearly ahead."
+    leaderBand =
+      sharedVerdict!.separation === 'clear'
+        ? 'strong'
+        : sharedVerdict!.separation === 'slight'
+          ? 'ahead'
+          : 'none'
+  } else if (producerBandApplies) {
     leaderBand =
       producerBand.band === 'clearly_ahead'
         ? 'strong'

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -10,6 +10,7 @@
 import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
 import type { ConstraintAnalysis } from '../../types/constraints'
 import type { M1CoachingReadiness } from '../../types/cee'
+import type { DecisionVerdict } from '../../lib/decisionVerdict'
 import type { ReportV1, OptionProbability } from '../../adapters/plot/types'
 import type { V2FactorSensitivity, V2OptionComparison } from '../../adapters/plot/v2/types'
 
@@ -461,6 +462,9 @@ export function normalizeAutoNoiseProvenance(raw: unknown): AutoNoiseProvenance 
 // (`useResultsSectionData`, the normaliser spec) keeps working unchanged.
 export type { HeadlineBandedBand, HeadlineBanded } from '../../lib/decisionVerdict'
 export { normalizeHeadlineBanded } from '../../lib/decisionVerdict'
+// `export ... from` re-exports without binding the names locally, and this
+// file references both below.
+import type { HeadlineBanded } from '../../lib/decisionVerdict'
 
 export interface DriverItem {
   /** Canonical identifier: node_id ?? factor_id ?? id ?? normalised(label) */

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -235,6 +235,13 @@ export interface DecisionResultData {
   baselineOutcome?: number | null
   /** Near-tie detection: when top options are too close to call */
   nearTie?: NearTieInfo
+  /**
+   * SINGLE VERDICT: the ONE answer to "is there a leading option?", derived by
+   * `src/lib/decisionVerdict.ts` from the same PLoT report the canvas reads.
+   * Every surface that asserts or denies a leading option must gate on this
+   * and must not compute its own. See that module for the diagnosis.
+   */
+  verdict?: DecisionVerdict
   /** Task 6: Flip thresholds for tipping points visualisation */
   flipThresholds?: FlipThreshold[]
   /**
@@ -445,57 +452,15 @@ export function normalizeAutoNoiseProvenance(raw: unknown): AutoNoiseProvenance 
 
 // ─── Producer leader-confidence band (Lane UI-W4, PLoT #200) ────────────────
 //
-// PLoT's decision_brief now carries `headline_banded` — the producer leg of
-// the UI's UI-SEM-060 leader-claim banding debt ("Remove when PLoT provides a
-// leader-confidence band / close-call signal"). The UI consumes ONLY the
-// fields it needs to select existing copy: the band token, the leader
-// identity (so a producer claim about option X is never applied to option Y),
-// and the robustness_gated disclosure flag. The producer's `text` sentence is
-// deliberately NOT consumed — hero copy stays the glossary-scanned UI strings
-// in heroCopy.ts, selected by band (no new wording, provisional_doctrine_v0).
-
-/** Producer band tokens (PLoT BriefBandedHeadline.band, closed set). */
-export type HeadlineBandedBand = 'very_close' | 'slightly_ahead' | 'clearly_ahead'
-
-export interface HeadlineBanded {
-  band: HeadlineBandedBand
-  /** PLoT option id of the leader the band describes (win-probability rank 1). */
-  leaderOptionId: string
-  /**
-   * True when the gap alone qualified for 'clearly_ahead' but robustness was
-   * not established, so the PRODUCER downgraded the claim to
-   * 'slightly_ahead'. Disclosure metadata only — the downgrade is already
-   * folded into `band`, so no UI copy keys off this flag.
-   */
-  robustnessGated: boolean
-}
-
-const HEADLINE_BANDED_BANDS: ReadonlySet<string> = new Set([
-  'very_close',
-  'slightly_ahead',
-  'clearly_ahead',
-])
-
-/**
- * Normalise a raw PLoT `decision_brief.headline_banded` payload into the
- * UI's `HeadlineBanded`. Fail-closed trust boundary (same class as
- * `normalizeAutoNoiseProvenance`): unknown band tokens, missing/empty
- * leader id, or a non-object all return `null` — a future producer band is
- * never guessed into existing copy, and the UI-SEM-060 fallback banding
- * applies instead. Unknown additive producer fields are ignored.
- */
-export function normalizeHeadlineBanded(raw: unknown): HeadlineBanded | null {
-  if (raw === null || typeof raw !== 'object') return null
-  const r = raw as Record<string, unknown>
-  if (typeof r.band !== 'string' || !HEADLINE_BANDED_BANDS.has(r.band)) return null
-  if (typeof r.leader_option_id !== 'string' || r.leader_option_id.length === 0) return null
-  return {
-    band: r.band as HeadlineBandedBand,
-    leaderOptionId: r.leader_option_id,
-    // Strict read: only an explicit producer `true` records the downgrade.
-    robustnessGated: r.robustness_gated === true,
-  }
-}
+// MOVED (2026-07-25, SINGLE VERDICT lane): `HeadlineBanded` and
+// `normalizeHeadlineBanded` now live in `src/lib/decisionVerdict.ts`, next to
+// the one function entitled to turn producer signals into a leader verdict.
+// `src/lib` must not import from `src/components`, and duplicating the
+// normaliser here would be exactly the hand-maintained mirror this programme
+// keeps getting bitten by. Re-exported so every existing import site
+// (`useResultsSectionData`, the normaliser spec) keeps working unchanged.
+export type { HeadlineBandedBand, HeadlineBanded } from '../../lib/decisionVerdict'
+export { normalizeHeadlineBanded } from '../../lib/decisionVerdict'
 
 export interface DriverItem {
   /** Canonical identifier: node_id ?? factor_id ?? id ?? normalised(label) */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -52,6 +52,7 @@ import type {
   ConfidenceProvenance,
 } from './types'
 import { normalizeAutoNoiseProvenance, normalizeHeadlineBanded } from './types'
+import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../lib/decisionVerdict'
 import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
 import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
 import { stripEncodingNotation, sanitizeCoachingText } from './utils/cleanFactorLabel'
@@ -1720,6 +1721,15 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       baselineOutcome,
       // Near-tie detection: when top options are too close to call
       nearTie,
+      // SINGLE VERDICT (2026-07-25): the ONE answer to "is there a leading
+      // option?", derived from the SAME `report` object the canvas reads —
+      // not re-derived from this hook's mapped fields, so canvas and panel
+      // cannot drift apart. Every surface asserting or denying a leading
+      // option quotes this. See src/lib/decisionVerdict.ts.
+      verdict: deriveDecisionVerdict(report as DecisionVerdictReportLike | null | undefined, {
+        visibleOptionIds: new Set(optionNodes.map((n) => n.id)),
+        rawHeadlineBanded,
+      }),
       // Task 6: Flip thresholds for tipping points visualisation
       flipThresholds: flipThresholds.length > 0 ? flipThresholds : undefined,
       // Display-honesty: PLoT-side classification of flip_thresholds[].

--- a/src/components/results/utils/__tests__/certaintyCopy.spec.ts
+++ b/src/components/results/utils/__tests__/certaintyCopy.spec.ts
@@ -22,8 +22,20 @@
 
 import { describe, it, expect } from 'vitest'
 import { buildCertaintyCopy, shouldSoftenPhrasing } from '../certaintyCopy'
+import type { DecisionVerdict } from '../../../../lib/decisionVerdict'
 
 const WINNER = 'Option A'
+
+// SINGLE VERDICT helpers — the shape `deriveDecisionVerdict` returns. Built by
+// hand here ONLY because this is a unit spec of the copy function; the
+// cross-surface spec (singleVerdict.crossSurface.spec.tsx) drives the real
+// derivation from a real PLoT report so these shapes cannot drift unnoticed.
+const tiedVerdict = (): DecisionVerdict => ({
+  leaderId: 'opt_a', separation: 'tied', hasLeadingOption: false, gapPp: 3, source: 'producer_near_tie',
+})
+const clearVerdict = (): DecisionVerdict => ({
+  leaderId: 'opt_a', separation: 'clear', hasLeadingOption: true, gapPp: 52, source: 'producer_near_tie',
+})
 
 describe('buildCertaintyCopy — decision table', () => {
   it('row 1: partial analysis overrides all tier inputs', () => {
@@ -43,13 +55,21 @@ describe('buildCertaintyCopy — decision table', () => {
     })
   })
 
-  it('row 2: stability < 0.70 produces the canonical no-clear-leader headline', () => {
+  // SINGLE VERDICT (2026-07-25): row 2 used to fire on
+  // `recommendationStability < 0.70`. That denied a leading option because the
+  // result was FRAGILE, which is a different fact — on the reported staging run
+  // it printed "no clear leading option / leads slightly more often" about a
+  // 52-point lead while the canvas badged the same option "Leading option".
+  // The tie call now belongs to `deriveDecisionVerdict` (src/lib), which reads
+  // PLoT's own `robustness.near_tie`. These two tests pin BOTH directions.
+  it('row 2: a TIED verdict produces the canonical no-clear-leader headline', () => {
     expect(
       buildCertaintyCopy({
         winnerLabel: WINNER,
         recommendationStability: 0.55,
         confidenceTier: 'strong',
         coachingReadiness: 'ready',
+        verdict: tiedVerdict(),
       }),
     ).toEqual({
       headline: 'no clear leading option, the result is sensitive to your estimates',
@@ -57,6 +77,21 @@ describe('buildCertaintyCopy — decision table', () => {
       caveat: null,
       conservative: true,
     })
+  })
+
+  it('row 2 REGRESSION PIN: low stability alone must NOT deny a leading option', () => {
+    // The exact journey run: 72% vs 20% (a 52-point lead) with stability 0.55.
+    const result = buildCertaintyCopy({
+      winnerLabel: WINNER,
+      recommendationStability: 0.55,
+      confidenceTier: 'strong',
+      coachingReadiness: 'ready',
+      winProbabilityGap: 52,
+      verdict: clearVerdict(),
+    })
+    expect(result.headline).not.toContain('no clear leading option')
+    expect(result.headline).not.toContain('slightly more often')
+    expect(result.headline).toContain(WINNER)
   })
 
   it('row 2 boundary: stability exactly 0.70 is considered stable (Rule 4 fires for needs_work)', () => {
@@ -280,12 +315,13 @@ describe('buildCertaintyCopy — decision table', () => {
   })
 
   describe('precedence policy', () => {
-    it('unstable (stability < 0.70) wins over weak tier — canonical unstable headline, no caveat', () => {
+    it('a TIED verdict wins over weak tier — canonical unstable headline, no caveat', () => {
       const result = buildCertaintyCopy({
         winnerLabel: WINNER,
         recommendationStability: 0.55,
         confidenceTier: 'needs_work',
         coachingReadiness: 'needs_evidence',
+        verdict: tiedVerdict(),
       })
       expect(result.headline).toBe(
         'no clear leading option, the result is sensitive to your estimates',
@@ -416,11 +452,12 @@ describe('buildCertaintyCopy — decision table', () => {
       }
     })
 
-    it('row 2 (unstable) ignores gap — canonical unstable copy is preserved', () => {
+    it('row 2 (tied) ignores gap — canonical unstable copy is preserved', () => {
       const result = buildCertaintyCopy({
         winnerLabel: WINNER,
         recommendationStability: 0.55,
         winProbabilityGap: 95,
+        verdict: tiedVerdict(),
       })
       expect(result.headline).toBe(
         'no clear leading option, the result is sensitive to your estimates',

--- a/src/components/results/utils/certaintyCopy.ts
+++ b/src/components/results/utils/certaintyCopy.ts
@@ -10,9 +10,13 @@
  *
  * Decision table (top-down, first match wins):
  *
- *   1. recommendationStability < 0.70
+ *   1. verdict.separation === 'tied'   (SINGLE VERDICT, 2026-07-25)
  *      → "no clear leading option, the result is sensitive to your estimates"
  *      (sub: "{winner} leads slightly more often", caveat: null)
+ *      The tie call belongs to `deriveDecisionVerdict`, which reads PLoT's
+ *      own `robustness.near_tie`. This rule used to fire on
+ *      `recommendationStability < 0.70`, denying a 52-point lead because it
+ *      was fragile — see the block comment at the rule itself.
  *
  *   2. analysisStatus === 'partial'
  *      → "Some analysis steps did not complete"
@@ -58,6 +62,7 @@
  */
 
 import type { M1CoachingReadiness } from '../../../types/cee'
+import type { DecisionVerdict } from '../../../lib/decisionVerdict'
 import type { ConfidenceTier } from '../types'
 
 export interface CertaintyCopyInput {
@@ -74,6 +79,13 @@ export interface CertaintyCopyInput {
    * without over-confident language.
    */
   winProbabilityGap?: number
+  /**
+   * SINGLE VERDICT: the shared answer to "is there a leading option?"
+   * (`src/lib/decisionVerdict.ts`), derived from the same PLoT report the
+   * canvas reads. This is the ONLY input entitled to make Rule 1 deny a
+   * leading option. Absent (older fixtures / callers) ⇒ no denial is made.
+   */
+  verdict?: DecisionVerdict
 }
 
 export interface CertaintyCopy {
@@ -130,6 +142,7 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
     analysisStatus,
     optionCount,
     winProbabilityGap,
+    verdict,
   } = input
 
   // Brief 5.2 Task 1: "by N points" suffix preserves the numeric lead in the
@@ -151,7 +164,26 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
     }
   }
 
-  if (recommendationStability != null && recommendationStability < 0.70) {
+  // SINGLE VERDICT (2026-07-25) — Rule 1 rewritten.
+  //
+  // It used to read `recommendationStability < 0.70` → "no clear leading
+  // option ... {winner} leads slightly more often". That is a CATEGORY ERROR
+  // and it produced the worst defect the end-to-end journey lane found: on a
+  // run where the winner held 72% against 20%, this printed "no clear leading
+  // option" and "leads slightly more often" about a **52-point lead**, while
+  // the canvas four inches away badged the same option "Leading option".
+  //
+  // Low stability means the ranking is FRAGILE, not that the options are
+  // TIED. Those are two different facts and the product must not trade one
+  // for the other. Whether a leading option exists is now answered in exactly
+  // one place — `deriveDecisionVerdict`, from PLoT's own `robustness.near_tie`
+  // — and every surface quotes it. Fragility keeps its own separate voice
+  // (the stability label, the footer, and the uncertainty calibration line
+  // this panel already renders beneath the headline).
+  //
+  // 'unknown' separation licenses SILENCE, never a denial: with fewer than
+  // two comparable options there is nothing to be close about.
+  if (verdict?.separation === 'tied') {
     return {
       headline: 'no clear leading option, the result is sensitive to your estimates',
       sub: `${winnerLabel} leads slightly more often`,

--- a/src/components/results/v7/__tests__/buildV7Headline.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Headline.spec.ts
@@ -54,7 +54,8 @@ describe('buildV7Headline — passthrough hero copy (V7 L4)', () => {
     expect(model.subline).toBe('Option A leads slightly more often')
   })
 
-  it('indeterminate decision state → "No clear leading option"', () => {
+  // Legacy path (no shared verdict supplied): both historic denials intact.
+  it('indeterminate decision state → "No clear leading option" (no-verdict legacy path)', () => {
     const winner = opt('a', 'Option A', 0.34, true)
     const model = buildV7Headline(
       rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.33)] }),
@@ -82,5 +83,49 @@ describe('buildV7Headline — passthrough hero copy (V7 L4)', () => {
     expect(model.headline).toBe('Option A performs best')
     // No runner-up gap is claimed when the winner carries no probability.
     expect(model.subline).toBeNull()
+  })
+})
+
+// ─── SINGLE VERDICT (2026-07-25) ────────────────────────────────────────────
+// This headline used to hold TWO independent denials of a leading option:
+// the producer's `nearTie.isTie` (correct) and `decisionState ===
+// 'indeterminate'` (which folds in stability thresholds, so a genuinely clear
+// lead was denied for being FRAGILE — the same category error the results
+// panel made, and the co-visible contradiction the journey lane caught).
+// Both are now one gate on the shared verdict.
+describe('buildV7Headline — SINGLE VERDICT gate', () => {
+  const clearVerdict = { leaderId: 'a', separation: 'clear' as const, hasLeadingOption: true, gapPp: 40, source: 'producer_near_tie' as const }
+  const tiedVerdict = { leaderId: 'a', separation: 'tied' as const, hasLeadingOption: false, gapPp: 3, source: 'producer_near_tie' as const }
+
+  it('does NOT deny a leading option merely because decisionState is indeterminate', () => {
+    const winner = opt('a', 'Option A', 0.70, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.30)], verdict: clearVerdict }),
+      'indeterminate',
+    )
+    expect(model.headline).not.toContain('No clear leading option')
+    expect(model.headline).toBe('Option A performs best')
+  })
+
+  it('DOES deny one when the shared verdict says the top two are tied', () => {
+    const winner = opt('a', 'Option A', 0.52, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.48)], verdict: tiedVerdict }),
+      'robust',
+    )
+    expect(model.headline).toBe('No clear leading option')
+  })
+
+  it('with no verdict (older fixtures) the historic producer-near-tie behaviour is unchanged', () => {
+    const winner = opt('a', 'Option A', 0.52, true)
+    const model = buildV7Headline(
+      rec({
+        recommendedOption: winner,
+        allOptions: [winner, opt('b', 'Option B', 0.48)],
+        nearTie: { isTie: true, topOptionId: 'a', secondOptionId: 'b', tiedOptionIds: [], gap: 0.04, threshold: 0.1 },
+      }),
+      'robust',
+    )
+    expect(model.headline).toBe('Too close to call')
   })
 })

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -86,7 +86,9 @@ export function buildV7Headline(
   const verdict = recommendation.verdict
   const noLeadingOption = verdict
     ? verdict.separation === 'tied'
-    : recommendation.nearTie?.isTie === true
+    // No verdict (older fixtures / callers): byte-identical legacy behaviour,
+    // both denials intact. The live path always carries one.
+    : (recommendation.nearTie?.isTie === true || decisionState === 'indeterminate')
   if (noLeadingOption) {
     return {
       // "Too close to call" is reserved for the producer's own explicit tie

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -69,20 +69,29 @@ export function buildV7Headline(
     }
   }
 
-  // Near-tie — the producer's near-tie detection (recommendation.nearTie).
-  if (recommendation.nearTie?.isTie === true) {
+  // SINGLE VERDICT (2026-07-25): ONE gate for "is there a leading option?".
+  //
+  // This block used to hold TWO independent denials — `nearTie.isTie` (the
+  // producer's, correct) and `decisionState === 'indeterminate'` (which folds
+  // in stability thresholds 0.80/0.55, so a genuinely clear lead was denied
+  // for being FRAGILE). That second denial is the same category error the
+  // results-panel headline made, and it is removed: fragility is disclosed on
+  // its own surfaces, never by pretending the options are tied.
+  //
+  // The tie call now comes from the shared verdict (src/lib/decisionVerdict.ts),
+  // which reads PLoT's own `robustness.near_tie` — so this headline, the
+  // results-panel headline, the canvas badge, the analysis hero, the inspector
+  // and the checks footer all quote one answer. Absent verdict (older
+  // fixtures) keeps the historic producer-near-tie behaviour.
+  const verdict = recommendation.verdict
+  const noLeadingOption = verdict
+    ? verdict.separation === 'tied'
+    : recommendation.nearTie?.isTie === true
+  if (noLeadingOption) {
     return {
-      headline: 'Too close to call',
-      subline: `${winnerLabel} leads slightly more often`,
-      winProbability,
-      winnerLabel,
-    }
-  }
-
-  // Indeterminate (GAP) — no clear leader.
-  if (decisionState === 'indeterminate') {
-    return {
-      headline: 'No clear leading option',
+      // "Too close to call" is reserved for the producer's own explicit tie
+      // flag; the shared verdict's other tied paths use the plainer form.
+      headline: recommendation.nearTie?.isTie === true ? 'Too close to call' : 'No clear leading option',
       subline: `${winnerLabel} leads slightly more often`,
       winProbability,
       winnerLabel,

--- a/src/lib/__tests__/decisionVerdict.spec.ts
+++ b/src/lib/__tests__/decisionVerdict.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * deriveDecisionVerdict — the single owner of "is there a leading option?".
+ *
+ * Covers: producer precedence, the identity gate, the residual fallback, and
+ * REACHABILITY of every branch (this estate has twice shipped branches whose
+ * comments claimed they fired and which could not — see CLAUDE.md verification
+ * traps 10 and 12).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  deriveDecisionVerdict,
+  normalizeHeadlineBanded,
+  LEADER_GAP_THRESHOLD,
+  LEADER_CLEAR_WIN_PROBABILITY,
+  type DecisionVerdictReportLike,
+  type LeaderSeparation,
+} from '../decisionVerdict'
+
+const twoOptions = (a: number, b: number, extra: Partial<DecisionVerdictReportLike> = {}): DecisionVerdictReportLike => ({
+  option_probabilities: { opt_a: { win_probability: a }, opt_b: { win_probability: b } },
+  robustness: { recommended_option_id: 'opt_a', ...(extra.robustness ?? {}) },
+  ...(extra.decision_brief ? { decision_brief: extra.decision_brief } : {}),
+})
+
+describe('deriveDecisionVerdict — residual win-probability fallback', () => {
+  it('the journey run (72% vs 20%) IS a leading option, despite being fragile — stability is not an input', () => {
+    const v = deriveDecisionVerdict(twoOptions(0.72, 0.20))
+    expect(v.separation).toBe('clear')
+    expect(v.hasLeadingOption).toBe(true)
+    expect(v.leaderId).toBe('opt_a')
+    expect(v.gapPp).toBe(52)
+    expect(v.source).toBe('win_probability')
+  })
+
+  it('a gap inside the producer threshold is TIED — no leading option', () => {
+    const v = deriveDecisionVerdict(twoOptions(0.52, 0.48))
+    expect(v.separation).toBe('tied')
+    expect(v.hasLeadingOption).toBe(false)
+  })
+
+  it('a majority-but-not-dominant leader is SLIGHT — still a leading option', () => {
+    const v = deriveDecisionVerdict(twoOptions(0.55, 0.30))
+    expect(v.separation).toBe('slight')
+    expect(v.hasLeadingOption).toBe(true)
+  })
+
+  it('is exactly bounded by the two exported thresholds', () => {
+    // Just under / exactly at the gap boundary. The exact-boundary case is a
+    // deliberate pin: 0.50 - 0.40 is 0.09999999999999998 in IEEE-754, so
+    // without the epsilon a mathematically-exact 10-point gap would read as a
+    // tie. This assertion is what makes that knife-edge visible.
+    expect(deriveDecisionVerdict(twoOptions(0.50, 0.50 - LEADER_GAP_THRESHOLD + 0.001)).separation).toBe('tied')
+    expect(deriveDecisionVerdict(twoOptions(0.50, 0.40)).separation).toBe('slight')
+    // Just under / at the clear boundary.
+    expect(deriveDecisionVerdict(twoOptions(LEADER_CLEAR_WIN_PROBABILITY - 0.01, 0.1)).separation).toBe('slight')
+    expect(deriveDecisionVerdict(twoOptions(LEADER_CLEAR_WIN_PROBABILITY, 0.1)).separation).toBe('clear')
+  })
+})
+
+describe('deriveDecisionVerdict — producer authority', () => {
+  const nearTie = (isTie: boolean, top = 'opt_a') => ({
+    robustness: { recommended_option_id: 'opt_a', near_tie: { is_tie: isTie, top_option_id: top, gap: 0.5, threshold: 0.1 } },
+  })
+
+  it("PLoT's near_tie OVERRIDES the win-probability fallback in the deny direction", () => {
+    // Win probabilities alone would say 'clear' (52-point gap).
+    const v = deriveDecisionVerdict(twoOptions(0.72, 0.20, nearTie(true)))
+    expect(v.separation).toBe('tied')
+    expect(v.hasLeadingOption).toBe(false)
+    expect(v.source).toBe('producer_near_tie')
+  })
+
+  it("PLoT's near_tie OVERRIDES it in the assert direction too", () => {
+    // Win probabilities alone would say 'tied' (4-point gap).
+    const v = deriveDecisionVerdict(twoOptions(0.52, 0.48, nearTie(false)))
+    expect(v.hasLeadingOption).toBe(true)
+    expect(v.source).toBe('producer_near_tie')
+  })
+
+  it('IDENTITY GATE: a near_tie naming a different top option is not applied', () => {
+    const v = deriveDecisionVerdict(twoOptions(0.72, 0.20, nearTie(true, 'opt_ghost')))
+    expect(v.source).toBe('win_probability')
+    expect(v.separation).toBe('clear')
+  })
+
+  it('FAIL-CLOSED: a malformed near_tie falls through rather than being guessed', () => {
+    for (const bad of [{}, { is_tie: 'yes' }, null, 42, 'tied']) {
+      const v = deriveDecisionVerdict(twoOptions(0.72, 0.20, { robustness: { near_tie: bad } as never }))
+      expect(v.source).toBe('win_probability')
+    }
+  })
+
+  it('headline_banded refines how far ahead when near_tie is absent', () => {
+    const cases: Array<[string, LeaderSeparation]> = [
+      ['clearly_ahead', 'clear'],
+      ['slightly_ahead', 'slight'],
+      ['very_close', 'tied'],
+    ]
+    for (const [band, expected] of cases) {
+      const v = deriveDecisionVerdict(
+        twoOptions(0.55, 0.30, { decision_brief: { headline_banded: { band, leader_option_id: 'opt_a' } } }),
+      )
+      expect(v.separation, band).toBe(expected)
+      expect(v.source).toBe('producer_band')
+    }
+  })
+
+  it("a band of very_close cannot overturn near_tie's explicit not-a-tie", () => {
+    const v = deriveDecisionVerdict(
+      twoOptions(0.55, 0.30, {
+        robustness: { recommended_option_id: 'opt_a', near_tie: { is_tie: false, top_option_id: 'opt_a' } } as never,
+        decision_brief: { headline_banded: { band: 'very_close', leader_option_id: 'opt_a' } },
+      }),
+    )
+    expect(v.separation).toBe('slight')
+    expect(v.hasLeadingOption).toBe(true)
+  })
+})
+
+describe('deriveDecisionVerdict — identity is separate from entitlement', () => {
+  it('names the PRODUCER recommendation even when it is not the win-max, and still grades the field', () => {
+    // PLoT recommended opt_a at 28% while opt_b holds 72%. Separation is a
+    // property of the field (44 points apart), not a leader-minus-rival
+    // subtraction that would go negative and read as a tie.
+    const v = deriveDecisionVerdict({
+      option_probabilities: { opt_a: { win_probability: 0.28 }, opt_b: { win_probability: 0.72 } },
+      robustness: { recommended_option_id: 'opt_a' },
+    })
+    expect(v.leaderId).toBe('opt_a')
+    expect(v.gapPp).toBe(44)
+    expect(v.hasLeadingOption).toBe(true)
+  })
+
+  it('falls back to the argmax when the producer sent no recommendation', () => {
+    const v = deriveDecisionVerdict({
+      option_probabilities: { opt_a: { win_probability: 0.28 }, opt_b: { win_probability: 0.72 } },
+    })
+    expect(v.leaderId).toBe('opt_b')
+  })
+
+  it('ignores options no longer on the canvas (recovered-session identity mismatch)', () => {
+    const v = deriveDecisionVerdict(
+      {
+        option_probabilities: {
+          opt_a: { win_probability: 0.40 },
+          opt_b: { win_probability: 0.35 },
+          opt_ghost: { win_probability: 0.90 },
+        },
+        robustness: { recommended_option_id: 'opt_a' },
+      },
+      { visibleOptionIds: new Set(['opt_a', 'opt_b']) },
+    )
+    expect(v.leaderId).toBe('opt_a')
+    expect(v.gapPp).toBe(5)
+    expect(v.separation).toBe('tied')
+  })
+})
+
+describe("REACHABILITY — every branch can actually fire (traps 10 & 12)", () => {
+  const seen = new Set<LeaderSeparation>()
+  const record = (r: DecisionVerdictReportLike | null) => {
+    seen.add(deriveDecisionVerdict(r).separation)
+  }
+
+  it("'unknown' fires on a single-option run — the results panel has copy for exactly this case", () => {
+    const v = deriveDecisionVerdict({ option_probabilities: { opt_a: { win_probability: 1 } } })
+    expect(v.separation).toBe('unknown')
+    expect(v.hasLeadingOption).toBe(false)
+    expect(v.leaderId).toBeNull()
+  })
+
+  it("'unknown' fires when the producer omits win probabilities (degraded run)", () => {
+    const v = deriveDecisionVerdict({
+      option_probabilities: { opt_a: {}, opt_b: { win_probability: null } },
+      robustness: { recommended_option_id: 'opt_a' },
+    })
+    expect(v.separation).toBe('unknown')
+  })
+
+  it("'unknown' fires on a null / absent report (pre-analysis)", () => {
+    expect(deriveDecisionVerdict(null).separation).toBe('unknown')
+    expect(deriveDecisionVerdict(undefined).separation).toBe('unknown')
+  })
+
+  it('all four separations are reachable from realistic reports', () => {
+    record(twoOptions(0.72, 0.20)) // clear
+    record(twoOptions(0.55, 0.30)) // slight
+    record(twoOptions(0.52, 0.48)) // tied
+    record(null) // unknown
+    expect([...seen].sort()).toEqual(['clear', 'slight', 'tied', 'unknown'])
+  })
+
+  it('is total — never throws on hostile input', () => {
+    const hostile: unknown[] = [
+      {}, { option_probabilities: null }, { option_probabilities: { a: null } },
+      { option_probabilities: { a: { win_probability: NaN }, b: { win_probability: Infinity } } },
+      { robustness: null }, { robustness: { recommended_option_id: null } },
+    ]
+    for (const h of hostile) {
+      expect(() => deriveDecisionVerdict(h as DecisionVerdictReportLike)).not.toThrow()
+    }
+  })
+})
+
+describe('normalizeHeadlineBanded — moved here from components/results/types.ts', () => {
+  it('still behaves identically after the move (the existing spec at its old import path is the other half of this proof)', () => {
+    expect(normalizeHeadlineBanded({ band: 'clearly_ahead', leader_option_id: 'x', robustness_gated: true }))
+      .toEqual({ band: 'clearly_ahead', leaderOptionId: 'x', robustnessGated: true })
+    expect(normalizeHeadlineBanded({ band: 'dominant', leader_option_id: 'x' })).toBeNull()
+    expect(normalizeHeadlineBanded({ band: 'clearly_ahead', leader_option_id: '' })).toBeNull()
+    expect(normalizeHeadlineBanded(null)).toBeNull()
+  })
+})

--- a/src/lib/decisionVerdict.ts
+++ b/src/lib/decisionVerdict.ts
@@ -1,0 +1,358 @@
+/**
+ * decisionVerdict — THE single place entitled to say whether a decision has a
+ * leading option.
+ *
+ * ## Why this module exists
+ *
+ * The end-to-end journey lane (parallel-briefs/END-TO-END-JOURNEY-2026-07-25.md)
+ * caught the product contradicting itself in one screenshot: the canvas badged
+ * "Leading option" on the winner while the results panel, four inches away,
+ * said "no clear leading option". Both surfaces read the same PLoT report.
+ * They disagreed because they were answering DIFFERENT QUESTIONS with
+ * DIFFERENT INPUTS:
+ *
+ *   · `OptionNode.isRecommended` asked "WHO leads?" (argmax / producer
+ *     recommendation) and had no gate for "is there a leader at all" — so the
+ *     badge fired on 100% of completed runs.
+ *   · `certaintyCopy` Rule 1 asked "IS there a leader?" and answered it from
+ *     `recommendation_stability < 0.70` alone — a category error: low
+ *     stability means the ranking is FRAGILE, not that the options are TIED.
+ *     At 72% vs 20% it printed "no clear leading option" and "leads slightly
+ *     more often" about a 52-point lead.
+ *
+ * A repo-wide sweep found **sixteen** live modules independently classifying a
+ * leader verdict, across six mutually-inconsistent "too close to call"
+ * thresholds (5pp, 10pp, gap <= 0, stability < 0.70, stability < 0.85,
+ * win < 70%). Aligning thresholds would not have held: they drift apart the
+ * first time one is touched. So the verdict becomes a single derived value,
+ * and every surface quotes it.
+ *
+ * ## The two axes — and why collapsing them is the bug
+ *
+ * "Is this answer trustworthy?" is TWO facts, and every contradictory string
+ * on that screen came from a surface collapsing them into one binary and
+ * picking a different one:
+ *
+ *   1. **Separation** — how far apart the options are *in the model's own
+ *      terms*. This, and only this, decides whether a leading option exists.
+ *   2. **Robustness** — whether the ranking survives perturbation of the
+ *      assumptions. This decides how much to trust it, and is disclosed
+ *      SEPARATELY (stability label, footer, robustness block).
+ *
+ * A 52-point lead that is not robust is still a 52-point lead. The honest
+ * verdict is "X leads by 52 points, and the result is not robust — small
+ * changes could flip it", which is exactly what the journey lane praised as
+ * the product's best sentence. What no surface may do is *deny the lead*
+ * because it is fragile, or *assert robustness* because there is a lead.
+ *
+ * So this module owns axis 1 only. It never reads stability.
+ *
+ * ## Producer first
+ *
+ * PLoT already computes this verdict and puts it on the wire — the UI was
+ * simply not asking. `robustness.near_tie`
+ * (`{ is_tie, top_option_id, second_option_id, gap, threshold }`, produced at
+ * `plot-lite-service/src/routes/v2/run.ts` `computeNearTie`, threshold 0.10)
+ * is the producer's own answer to "is there a clear leader?". A captured
+ * staging response in this repo
+ * (`src/test/fixtures/golden-path-staging-2026-04-05.json`) shows the defect
+ * exactly: `near_tie.is_tie: false`, `gap: 0.119` — the producer says there IS
+ * a leader — while `recommendation_stability: 0.4375` made the panel print
+ * "no clear leading option" about the same run.
+ *
+ * `decision_brief.headline_banded` (`very_close` | `slightly_ahead` |
+ * `clearly_ahead`) refines *how far* ahead when present. The win-probability
+ * derivation is the residual fallback for reports carrying neither — it is
+ * NOT a second opinion and is never consulted when a producer signal applies.
+ */
+
+// ─── Producer leader-confidence band (Lane UI-W4, PLoT #200) ────────────────
+//
+// Moved here from `src/components/results/types.ts` (2026-07-25) so it sits
+// beside the one function entitled to turn producer signals into a leader
+// verdict, and so `src/lib` does not import from `src/components`. Re-exported
+// from `types.ts` — one implementation, no mirror.
+//
+// The UI consumes ONLY the fields it needs to select existing copy: the band
+// token, the leader identity (so a producer claim about option X is never
+// applied to option Y), and the robustness_gated disclosure flag. The
+// producer's own `text` sentence is deliberately NOT consumed.
+
+/** Producer band tokens (PLoT BriefBandedHeadline.band, closed set). */
+export type HeadlineBandedBand = 'very_close' | 'slightly_ahead' | 'clearly_ahead'
+
+export interface HeadlineBanded {
+  band: HeadlineBandedBand
+  /** PLoT option id of the leader the band describes (win-probability rank 1). */
+  leaderOptionId: string
+  /**
+   * True when the gap alone qualified for 'clearly_ahead' but robustness was
+   * not established, so the PRODUCER downgraded the claim to
+   * 'slightly_ahead'. Disclosure metadata only — the downgrade is already
+   * folded into `band`, so no UI copy keys off this flag.
+   */
+  robustnessGated: boolean
+}
+
+const HEADLINE_BANDED_BANDS: ReadonlySet<string> = new Set([
+  'very_close',
+  'slightly_ahead',
+  'clearly_ahead',
+])
+
+/**
+ * Normalise a raw PLoT `decision_brief.headline_banded` payload into
+ * `HeadlineBanded`. Fail-closed trust boundary: unknown band tokens,
+ * missing/empty leader id, or a non-object all return `null` — a future
+ * producer band is never guessed into existing copy. Unknown additive
+ * producer fields are ignored.
+ */
+export function normalizeHeadlineBanded(raw: unknown): HeadlineBanded | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  if (typeof r.band !== 'string' || !HEADLINE_BANDED_BANDS.has(r.band)) return null
+  if (typeof r.leader_option_id !== 'string' || r.leader_option_id.length === 0) return null
+  return {
+    band: r.band as HeadlineBandedBand,
+    leaderOptionId: r.leader_option_id,
+    // Strict read: only an explicit producer `true` records the downgrade.
+    robustnessGated: r.robustness_gated === true,
+  }
+}
+
+/**
+ * How far apart the top options are.
+ *
+ * - `clear`   — a leading option exists and is well ahead
+ * - `slight`  — a leading option exists but the margin is modest
+ * - `tied`    — no clear leading option; the top options are within noise
+ * - `unknown` — not determinable (fewer than two comparable options, or the
+ *               producer sent no win probabilities). Surfaces must make NO
+ *               claim either way.
+ */
+export type LeaderSeparation = 'clear' | 'slight' | 'tied' | 'unknown'
+
+export interface DecisionVerdict {
+  /**
+   * The front-runner's option id — the producer's recommendation when it sent
+   * one, otherwise the win-probability argmax. `null` when no option can be
+   * identified. NOTE: a non-null `leaderId` does NOT license the phrase
+   * "leading option" — `hasLeadingOption` does. Identity and entitlement are
+   * different questions, and conflating them is the defect this module fixes.
+   */
+  leaderId: string | null
+  separation: LeaderSeparation
+  /**
+   * The single boolean every surface must gate on before asserting OR denying
+   * a leading option:
+   *   · `true`  — surfaces may say "{leader} is the leading option" / badge it
+   *   · `false` — surfaces must NOT badge, and MAY say "no clear leading option"
+   *               (only when `separation === 'tied'`; `'unknown'` licenses
+   *               silence, never a denial)
+   */
+  hasLeadingOption: boolean
+  /** Win-probability gap, leader vs strongest rival, in percentage points. */
+  gapPp: number | null
+  /** Which authority decided `separation`. Disclosure / debugging only. */
+  source: 'producer_near_tie' | 'producer_band' | 'win_probability' | 'none'
+}
+
+/**
+ * Separation boundary for "there is a leading option at all", in win-probability
+ * points. Deliberately the SAME 0.10 the results VM already uses for its
+ * `indeterminate` decision state (UI-SEM-006 `GAP_THRESHOLD`) — importing it
+ * would create a cycle through `buildResultsVM`, so it is defined here as the
+ * canonical value and `buildResultsVM` re-exports it. One number, one meaning.
+ */
+export const LEADER_GAP_THRESHOLD = 0.10
+
+/**
+ * Win probability at or above which the leader is "clear" rather than merely
+ * "slight". Same 0.65 the analysis-hero already used for its "most likely to
+ * be strongest overall" claim, so no surface changes its mind about a run it
+ * previously called clear.
+ */
+export const LEADER_CLEAR_WIN_PROBABILITY = 0.65
+
+/** Tolerance for IEEE-754 subtraction noise at the band boundaries. */
+const FP_EPSILON = 1e-9
+
+/** Minimal shape this module reads out of the PLoT report. Structural, so a
+ *  mapped ReportV1, a raw V2 response, or a hydrated report all satisfy it. */
+export interface DecisionVerdictReportLike {
+  option_probabilities?: Record<string, { win_probability?: number | null } | null | undefined> | null
+  robustness?: {
+    recommended_option_id?: string | null
+    /** PLoT `computeNearTie` output. Snake and camel both appear on the wire. */
+    near_tie?: unknown
+    nearTie?: unknown
+  } | null
+  decision_brief?: { headline_banded?: unknown } | null
+}
+
+interface ProducerNearTie {
+  isTie: boolean
+  topOptionId: string | null
+}
+
+/**
+ * Read PLoT's `near_tie` fail-closed. Anything but an explicit boolean
+ * `is_tie` yields `null`, so a malformed producer payload falls through to the
+ * next authority rather than being guessed into a verdict.
+ */
+function readNearTie(raw: unknown): ProducerNearTie | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const isTie = r.is_tie ?? r.isTie
+  if (typeof isTie !== 'boolean') return null
+  const top = r.top_option_id ?? r.topOptionId
+  return { isTie, topOptionId: typeof top === 'string' && top.length > 0 ? top : null }
+}
+
+export interface DecisionVerdictOptions {
+  /**
+   * Restrict the comparison to options currently on the canvas. Guards the
+   * recovered-session identity mismatch (a report naming options the graph no
+   * longer has). Omit to consider every option in the report.
+   */
+  visibleOptionIds?: ReadonlySet<string>
+  /**
+   * Fresh-run fallback for the producer band. `useResultsSectionData` prefers
+   * the mapped report and falls back to the raw V2 response; pass the raw slot
+   * here so both callers resolve the identical band.
+   */
+  rawHeadlineBanded?: unknown
+}
+
+const UNKNOWN_VERDICT: DecisionVerdict = {
+  leaderId: null,
+  separation: 'unknown',
+  hasLeadingOption: false,
+  gapPp: null,
+  source: 'none',
+}
+
+const BAND_TO_SEPARATION: Record<HeadlineBanded['band'], LeaderSeparation> = {
+  clearly_ahead: 'clear',
+  slightly_ahead: 'slight',
+  very_close: 'tied',
+}
+
+/**
+ * Derive the one verdict every surface quotes.
+ *
+ * Pure and total: any malformed / absent input yields the `unknown` verdict,
+ * under which surfaces make no claim in either direction.
+ */
+export function deriveDecisionVerdict(
+  report: DecisionVerdictReportLike | null | undefined,
+  options: DecisionVerdictOptions = {},
+): DecisionVerdict {
+  if (!report) return UNKNOWN_VERDICT
+
+  const { visibleOptionIds, rawHeadlineBanded } = options
+  const probs = report.option_probabilities ?? {}
+
+  // Comparable options: those with a finite win probability that are still on
+  // the canvas (when a visibility set is supplied).
+  const comparable: Array<{ id: string; win: number }> = []
+  for (const [id, entry] of Object.entries(probs)) {
+    if (visibleOptionIds && !visibleOptionIds.has(id)) continue
+    const win = entry?.win_probability
+    if (typeof win === 'number' && Number.isFinite(win)) comparable.push({ id, win })
+  }
+
+  // Fewer than two comparable options: "leading" has no meaning. This is a
+  // REACHABLE state, not a defensive branch — single-option runs exist (the
+  // results panel has dedicated "is your only option" copy for them), and PLoT
+  // omits win probabilities on degraded runs.
+  if (comparable.length < 2) return UNKNOWN_VERDICT
+
+  comparable.sort((a, b) => b.win - a.win)
+  const [top1, top2] = comparable
+
+  // SEPARATION is measured on the TOP TWO win probabilities — "does the
+  // analysis discriminate between options at all?". IDENTITY is a different
+  // question, answered by the producer's recommendation (the id every other
+  // surface already prefers) with the argmax as fallback. Keeping them apart
+  // matters: PLoT may recommend an option that is not the win-probability
+  // argmax, and a leader-minus-rival subtraction would then go NEGATIVE and
+  // read as a tie. The two options are still separated; the producer has
+  // simply pointed at the other one.
+  const recommendedId = report.robustness?.recommended_option_id ?? null
+  const recommended = recommendedId != null
+    ? comparable.find(o => o.id === recommendedId) ?? null
+    : null
+  const leaderId = (recommended ?? top1).id
+
+  const gap = top1.win - top2.win
+  const gapPp = Math.round(gap * 100)
+
+  // ── Authority 1: PLoT's own near-tie verdict ────────────────────────────
+  // The producer already answered "is there a clear leader?" — honour it.
+  // Applied only when it is silent about which option is on top, or names the
+  // SAME leader: a producer claim about option X must never be re-pointed at
+  // option Y (the recovered-session identity hazard).
+  // Identity gate: both producer signals describe the WIN-PROBABILITY RANK-1
+  // option (`near_tie.top_option_id`, `headline_banded.leader_option_id`), so
+  // they are checked against `top1`, not against the possibly-overridden
+  // `leaderId`. A producer claim about option X is never re-pointed at
+  // option Y (the recovered-session identity hazard).
+  const nearTie = readNearTie(report.robustness?.near_tie ?? report.robustness?.nearTie)
+  const nearTieApplies = nearTie != null && (nearTie.topOptionId == null || nearTie.topOptionId === top1.id)
+
+  const band = normalizeHeadlineBanded(
+    report.decision_brief?.headline_banded ?? rawHeadlineBanded,
+  )
+  const bandApplies = band != null && band.leaderOptionId === top1.id
+
+  if (nearTieApplies && nearTie!.isTie) {
+    return { leaderId, separation: 'tied', hasLeadingOption: false, gapPp, source: 'producer_near_tie' }
+  }
+
+  // ── Authority 2: the producer's leader-confidence band ──────────────────
+  // Refines HOW far ahead. When authority 1 has already ruled "not a tie",
+  // a band of `very_close` would contradict it, so the band may only refine
+  // clear-vs-slight in that case — the producer's own tie call wins.
+  if (bandApplies) {
+    const banded = BAND_TO_SEPARATION[band!.band]
+    const separation: LeaderSeparation =
+      banded === 'tied' && nearTieApplies && !nearTie!.isTie ? 'slight' : banded
+    return {
+      leaderId,
+      separation,
+      hasLeadingOption: separation === 'clear' || separation === 'slight',
+      gapPp,
+      source: 'producer_band',
+    }
+  }
+
+  // Authority 1 said "not a tie" and there is no band to refine it: a leading
+  // option exists. Grade it on the leader's own win probability.
+  if (nearTieApplies && !nearTie!.isTie) {
+    const separation: LeaderSeparation =
+      top1.win >= LEADER_CLEAR_WIN_PROBABILITY - FP_EPSILON ? 'clear' : 'slight'
+    return { leaderId, separation, hasLeadingOption: true, gapPp, source: 'producer_near_tie' }
+  }
+
+  // ── Authority 3: residual fallback on win probabilities ─────────────────
+  // Consulted ONLY when no applicable producer signal exists. Separation, and
+  // separation alone — stability is deliberately not read here (see header).
+  // FP tolerance: 0.50 - 0.40 is 0.09999999999999998 in IEEE-754, so a gap
+  // that is mathematically exactly the threshold must not fall to the tied
+  // side of a knife-edge comparison.
+  const separation: LeaderSeparation =
+    gap < LEADER_GAP_THRESHOLD - FP_EPSILON
+      ? 'tied'
+      : top1.win >= LEADER_CLEAR_WIN_PROBABILITY - FP_EPSILON
+        ? 'clear'
+        : 'slight'
+
+  return {
+    leaderId,
+    separation,
+    hasLeadingOption: separation === 'clear' || separation === 'slight',
+    gapPp,
+    source: 'win_probability',
+  }
+}


### PR DESCRIPTION
## The defect

The end-to-end journey lane drove a real decision through deployed staging (UI `27d002c9`) and named this **the single thing to fix first**. Co-visible on one screen:

- canvas: **"Leading option"** + "72% win probability"
- results panel, four inches away: **"No clear leading option"** / "leads *slightly* more often"

72% against 20% is a **52-point lead**. Whichever half is right, the product had just announced it does not know what it thinks.

## Root cause — two different questions, two different inputs

- `OptionNode.isRecommended` asked **"WHO leads?"** (producer recommendation, else win-probability argmax) and had **no gate for "is there a leader at all"** — so the badge fired on 100% of completed runs.
- `certaintyCopy` Rule 1 asked **"IS there a leader?"** and answered from `recommendation_stability < 0.70` alone. That is a **category error**: low stability means the ranking is FRAGILE, not that the options are TIED.

A repo sweep found **16 live modules** independently classifying a leader verdict across **six mutually-inconsistent "too close to call" thresholds** (5pp · 10pp · gap ≤ 0 · stability < 0.70 · stability < 0.85 · win < 70%). Aligning thresholds would drift apart again, so the verdict becomes a single derived value.

## Who owns it now — **PLoT already did; the UI was not asking**

`src/lib/decisionVerdict.ts`, producer-first:

1. **`robustness.near_tie`** `{is_tie, top_option_id, gap, threshold: 0.10}` — PLoT's own answer (`computeNearTie`), identity-gated.
2. `decision_brief.headline_banded` — refines *how far* ahead; cannot overturn an explicit `is_tie: false`.
3. Residual win-probability fallback using thresholds **already in this codebase** (`GAP_THRESHOLD` 0.10, the hero's 0.65) — so no run changes verdict for a *new* reason.

The committed staging capture `src/test/fixtures/golden-path-staging-2026-04-05.json` shows the contradiction at the bytes: `near_tie.is_tie: false, gap: 0.119` (producer: there IS a leader) alongside `recommendation_stability: 0.4375` (which made the panel deny one).

## What the product says when evidence is weak

**Separation and robustness are two facts.** A 52-point lead that is not robust is still a 52-point lead. The product now reports the lead *and* the fragility, each in its own voice, instead of trading one for the other — which is exactly the sentence the journey lane praised as the product's best. `deriveDecisionVerdict` deliberately **never reads stability**.

- `separation: 'tied'` (inside PLoT's own 0.10) → "no clear leading option", badge suppressed. The denial is reserved for when it is true.
- `separation: 'unknown'` (< 2 comparable options, or no win probabilities) → **silence, never a denial**. Proven reachable, not a dead branch.

## Surfaces rewired

canvas badge (+ close-call line, winsVia copy, chat chips) · results-panel headline · that panel's T1 checks footer (was presence-only, so it ticked "Winner" in the same panel whose headline denied one) · analysis-hero leader band · V7 headline (held **two** denials, one folding stability 0.80/0.55) · inspector "Currently the leading option."

Canvas and panel now derive from the **same `report` object** through the **same function**.

## Evidence

**RED-first** — `singleVerdict.crossSurface.spec.tsx` sets ONE canvas-store state and drives THREE surfaces through real product code (`OptionNode`, `useResultsSectionData()`, `DecisionConfidencePanel`) with no mirrored derivation. Failed on the journey's numbers before the fix (3/9), passes after (10/10). **Positive controls pass in both states before and after** — each probe is proven able to see both a claim and a denial.

**Mutation matrix** — throwaway detached worktree, deps symlinked, runner sanity-checked unmutated (352/352) before each round, every mutator asserting its anchor exists:

| # | Mutation | Result |
|---|---|---|
| M1 | drop the canvas badge gate | RED |
| M2 | restore `stability < 0.70` denial | RED |
| M3 | restore presence-only checks footer | RED |
| M4 | ignore PLoT `near_tie` | RED |
| M5 | hero ignores the shared verdict | **GREEN first pass — unpinned**; pins added → RED |
| M6 | V7 restores the stability denial | **GREEN first pass — unpinned**; pins added → RED |

M5/M6 were initially theatre. M6 also exposed that the "byte-identical legacy fallback" claim was false — an existing spec only passed *because* the mutation restored the old code. Both now genuinely pinned; the fallback is now genuinely byte-identical.

**Reachability** — all four separations proven to fire; `'unknown'` proven three ways. Fail-closed parsing, totality, and the IEEE-754 boundary (`0.50 - 0.40 = 0.09999…`) pinned.

**Claim type** — every UI assertion is *rendered-text-presence* in jsdom. It is **not** a visibility or layout claim; co-visibility comes from the journey lane's real-browser capture.

**Typecheck gate** — PASSED: 666 files / 2661 errors vs baseline 2663. The gate's `Drift shrank — tighten it with --update-baseline` notice is **DECLINED** (the committed baseline over-counts by 2 at the pristine tip); no baseline regenerated.

## Flagged, not fixed here

- `robustness.display_verdict` / `display_verdict_reason` are contract-defined as PLoT-owned and consumed by the UI's checks footer, but **have zero producers in plot-lite-service**.
- Schema-pin skew: PLoT pins `@talchain/schemas` **0.2.1** (13 minors behind); CEE declares 0.13.0 but resolves 0.14.0.
- The robustness half of the journey's report (23 classifiers, 13 threshold systems) is mapped in `parallel-briefs/SINGLE-VERDICT-2026-07-25.md` §5 with a recommended follow-up of the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)