### PR TITLE
fix(continuity): a returning user sees the conversation they left

### DIFF
--- a/src/canvas/__tests__/store.conversationRunSurvivesReload.spec.ts
+++ b/src/canvas/__tests__/store.conversationRunSurvivesReload.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * RETURNING USER — the ANSWER must survive a reload, not just the diagram.
+ *
+ * THE FAILURE THIS PINS (live on staging, reproduced 25 Jul 2026 by driving
+ * the deployed product): you run the analysis from the conversation, get a
+ * recommendation, close the tab, come back — the 19-node model returns intact
+ * and the results panel is back to "Analysis available / Analyse first pass",
+ * as though nothing had ever been run.
+ *
+ * Mechanism: `results.seed` is set ONLY by `resultsStart`, which only the
+ * direct Run-button path calls. The canonical V5 / conversation path goes
+ * through `resultsAnalysing` ("no seed is known yet"), so on a fresh session
+ * `results.seed` is `undefined` and `resultsComplete`'s run-history write was
+ * skipped wholesale — while `last_result_hash` was written to the scenario
+ * record regardless. `tryRestoreResultsFromHistory` then looked up a run that
+ * had never been stored and silently found nothing.
+ *
+ * Live corroboration: after a conversation-driven analysis on staging, the
+ * `olumi-canvas-run-history` localStorage key did not exist at all.
+ *
+ * CLAIM TYPE: this is a STORE-STATE pin (what the results panel branches on),
+ * not a rendering or visibility claim. The on-screen proof is the live
+ * before/after in `parallel-briefs/RETURNING-USER-2026-07-25.md`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../store'
+import { loadRuns } from '../store/runHistory'
+import type { ReportV1 } from '../../adapters/plot/types'
+
+const RESPONSE_HASH = 'sha256:conversation-run-abc123'
+
+function minimalReport(): ReportV1 {
+  return {
+    summary: 'Double Down on Wholesale currently leads.',
+    options: [],
+  } as unknown as ReportV1
+}
+
+function rawWithEchoedSeed(seed: number | null) {
+  return {
+    response_hash: RESPONSE_HASH,
+    meta: seed == null ? {} : { seed_used: seed },
+    option_comparison: [],
+  } as never
+}
+
+describe('a conversation-driven analysis survives a reload', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', position: { x: 0, y: 0 }, data: {} }] as never,
+      edges: [] as never,
+      results: { status: 'idle', progress: 0 },
+      currentScenarioId: null,
+    })
+  })
+
+  it('POSITIVE CONTROL — the direct Run path (seed known) always reached run history', () => {
+    useCanvasStore.getState().resultsStart({ seed: 42 })
+    useCanvasStore.getState().resultsComplete({
+      report: minimalReport(),
+      hash: RESPONSE_HASH,
+      resultsSource: 'direct',
+      rawV2Response: rawWithEchoedSeed(42),
+    })
+    const runs = loadRuns()
+    expect(runs).toHaveLength(1)
+    expect(runs[0].hash).toBe(RESPONSE_HASH)
+    expect(runs[0].seed).toBe(42)
+  })
+
+  it('the conversation path (no resultsStart) now reaches run history too', () => {
+    // Exactly the live shape: resultsAnalysing, never resultsStart.
+    useCanvasStore.getState().resultsAnalysing()
+    expect(useCanvasStore.getState().results.seed).toBeUndefined()
+
+    useCanvasStore.getState().resultsComplete({
+      report: minimalReport(),
+      hash: RESPONSE_HASH,
+      resultsSource: 'conversation',
+      rawV2Response: rawWithEchoedSeed(918273),
+    })
+
+    const runs = loadRuns()
+    expect(runs).toHaveLength(1)
+    expect(runs[0].hash).toBe(RESPONSE_HASH)
+    // The seed is the ENGINE'S OWN ECHO, never a fabricated 0.
+    expect(runs[0].seed).toBe(918273)
+    expect(runs[0].report).toBeTruthy()
+  })
+
+  it('the stored run is the one a returning session looks up by response hash', () => {
+    useCanvasStore.getState().resultsAnalysing()
+    useCanvasStore.getState().resultsComplete({
+      report: minimalReport(),
+      hash: RESPONSE_HASH,
+      resultsSource: 'conversation',
+      rawV2Response: rawWithEchoedSeed(918273),
+    })
+
+    // Simulate the reload: a fresh store, then the lookup loadScenario performs.
+    useCanvasStore.setState({ results: { status: 'idle', progress: 0 } })
+    const found = loadRuns().find((r) => r.hash === RESPONSE_HASH)
+    expect(found).toBeDefined()
+
+    useCanvasStore.getState().resultsLoadHistorical(found!)
+    // This is what the results panel branches on: 'complete' renders the
+    // answer, 'idle' renders the "Analyse first pass" pre-analysis state.
+    expect(useCanvasStore.getState().results.status).toBe('complete')
+    expect(useCanvasStore.getState().results.hash).toBe(RESPONSE_HASH)
+  })
+
+  it('still refuses to invent a seed when the engine echoed none', () => {
+    useCanvasStore.getState().resultsAnalysing()
+    useCanvasStore.getState().resultsComplete({
+      report: minimalReport(),
+      hash: RESPONSE_HASH,
+      resultsSource: 'conversation',
+      rawV2Response: rawWithEchoedSeed(null),
+    })
+    // No echo, no stored run — a run identity built on a fabricated seed would
+    // fork the graph hash (CLAUDE.md trap #10). Better absent than false.
+    expect(loadRuns()).toHaveLength(0)
+  })
+})

--- a/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
@@ -1,0 +1,168 @@
+/**
+ * RETURNING USER — the first-use placeholder must not be shown to someone who
+ * has been here before.
+ *
+ * THE USER-VISIBLE FAILURE THIS PINS (live on staging, build `27d002c9`,
+ * reproduced 2/2 by driving the deployed product 25 Jul 2026):
+ * you write a brief, the product drafts a 19-node model and coaches you on it,
+ * you close the tab, you come back. The model returns in full — and the chat
+ * shows `data-testid="olumi-tab-empty"` carrying
+ * "Describe your decision, goal, options, and any assumptions, risks or
+ * constraints you're aware of." That element is a factual claim that the user
+ * has never been here, and it is false.
+ *
+ * Root cause: the panel's only restore path was gated behind
+ * `VITE_FEATURE_THREAD_HYDRATE` (absent from the deployed env → `false`) and
+ * read `scenarios.thread`, a column that does not exist on the live database.
+ * Nothing else read the transcript back, so `messages` stayed `[]`.
+ *
+ * CLAIM TYPE — read this before citing the test: jsdom renders a DOM, not a
+ * layout. Every assertion here is about ELEMENT PRESENCE AND TEXT CONTENT in
+ * the rendered tree. It does NOT prove anything is visible on screen; the
+ * on-screen proof is the live staging before/after in
+ * `parallel-briefs/RETURNING-USER-2026-07-25.md`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { OlumiTabBody } from '../OlumiTabBody'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { useCanvasStore } from '../../store'
+import { saveTranscript, TRANSCRIPT_STORAGE_KEY } from '../../conversation/utils/transcriptStore'
+import type { ConversationMessage } from '../../conversation/types'
+
+// The panel must never dispatch a turn in this test — we are only exercising
+// mount-time restore. Both transports are stubbed to hang.
+vi.mock('../../conversation/turnService', () => ({
+  callOrchestratorTurn: () => new Promise(() => {}),
+  streamOrchestratorTurn: async function* () { /* never yields */ },
+  OrchestratorError: class extends Error {},
+}))
+vi.mock('../../../v5/v5Adapter', () => ({
+  callV5Turn: () => new Promise(() => {}),
+  getV5Endpoint: () => 'https://example.invalid/v5/turn',
+}))
+
+const SID = '561548c3-acd6-4488-b088-399c7cc15631'
+
+const BRIEF =
+  'We run a 12-person specialty coffee roastery in Bristol. I have around 80k I could invest.'
+const REPLY = 'I have built a first decision model for "Maximise Net Profit in 2 Years".'
+
+function priorSession(): ConversationMessage[] {
+  return [
+    { id: 'u1', role: 'user', content: BRIEF, timestamp: new Date('2026-07-25T17:38:01Z') },
+    { id: 'a1', role: 'assistant', content: REPLY, timestamp: new Date('2026-07-25T17:39:10Z') },
+  ]
+}
+
+/**
+ * Write a transcript and then re-stamp it as belonging to an EARLIER page
+ * load — which is what "the user closed the tab and came back" actually is.
+ * A transcript the current page load wrote is deliberately NOT restored.
+ */
+function storePriorSession(messages: ConversationMessage[]) {
+  saveTranscript(SID, messages)
+  const file = JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY)!)
+  file[SID].pageLoadId = 'an-earlier-page-load'
+  localStorage.setItem(TRANSCRIPT_STORAGE_KEY, JSON.stringify(file))
+}
+
+function renderPanel() {
+  return render(
+    <ConversationProvider>
+      <OlumiTabBody />
+    </ConversationProvider>,
+  )
+}
+
+describe('returning user — the chat pane after a reload', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCanvasStore.setState({ currentScenarioId: null })
+    // jsdom does not implement scrollIntoView; ConversationPanel's smart-scroll
+    // calls it on mount. Stubbing it is a jsdom gap, not a product behaviour.
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => {}
+    }
+    vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+  })
+
+  it('shows the first-use placeholder when the user really HAS never been here', async () => {
+    useCanvasStore.setState({ currentScenarioId: SID })
+    renderPanel()
+    await waitFor(() => {
+      expect(screen.getByTestId('olumi-tab-empty')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(/Describe your decision, goal, options/i),
+    ).toBeInTheDocument()
+  })
+
+  it('does NOT show the first-use placeholder when a prior session is stored', async () => {
+    storePriorSession(priorSession())
+    useCanvasStore.setState({ currentScenarioId: SID })
+
+    renderPanel()
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('olumi-tab-empty')).not.toBeInTheDocument()
+    })
+    expect(
+      screen.queryByText(/Describe your decision, goal, options/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("restores the user's OWN WORDS and the reply, not a summary of them", async () => {
+    storePriorSession(priorSession())
+    useCanvasStore.setState({ currentScenarioId: SID })
+
+    const { container } = renderPanel()
+
+    // The bubble renderer wraps numerals in their own spans, so the sentence is
+    // split across elements — assert on the bubble's textContent, which is what
+    // a reader actually reads.
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+    const userBubble = container.querySelector('[data-testid="message-user"]')!
+    expect(userBubble.textContent).toContain('12-person specialty coffee roastery in Bristol')
+    expect(userBubble.textContent).toContain('80k I could invest')
+
+    const assistantBubble = container.querySelector('[data-testid="message-assistant"]')!
+    expect(assistantBubble.textContent).toContain('Maximise Net Profit in 2 Years')
+  })
+
+  it('marks the session boundary so the restored turns read as history', async () => {
+    storePriorSession(priorSession())
+    useCanvasStore.setState({ currentScenarioId: SID })
+
+    renderPanel()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Session resumed/i)).toBeInTheDocument()
+    })
+  })
+
+  it('SAYS SO on screen when part of the history could not be restored', async () => {
+    // 130 turns against a cap of 120 → 10 dropped, and the user must be told.
+    const many: ConversationMessage[] = Array.from({ length: 130 }, (_, i) => ({
+      id: `m${i}`,
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content: `turn number ${i}`,
+      timestamp: new Date('2026-07-25T17:38:01Z'),
+    }))
+    storePriorSession(many)
+    useCanvasStore.setState({ currentScenarioId: SID })
+
+    renderPanel()
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/The earliest 10 messages from this decision could not be restored/i),
+      ).toBeInTheDocument()
+    })
+    // And the placeholder is still not shown — a partial history is history.
+    expect(screen.queryByTestId('olumi-tab-empty')).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -63,6 +63,11 @@ import { buildDraftBiasSignalBlocks } from './draftBiasSignalBlocks'
 import { assembleAnalysisInputsSummary } from '../analysis/assembleAnalysisInputsSummary'
 import { useResultsStore } from '../stores/resultsStore'
 import { hydrateMessagesFromThread, formatSessionBoundary } from './utils/hydrateThread'
+import {
+  loadTranscript,
+  saveTranscript,
+  formatTruncationNotice,
+} from './utils/transcriptStore'
 import { appendThreadEntries, createSnapshot } from '../../services/threadService'
 import type { ThreadEntry } from '../journey/threadTypes'
 import { useGuidanceStore, type GuidanceItem } from '../stores/guidanceStore'
@@ -1785,8 +1790,80 @@ export function useConversation(): UseConversationReturn {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Clear conversation when scenario changes (with Track 3 thread hydration)
+  // ── Returning-user continuity ──────────────────────────────────────────
+  // Build the restored view of a stored transcript: the real turns, a
+  // truncation disclosure when (and only when) something was dropped, and a
+  // session-boundary divider marking where the previous session ended.
+  const buildRestoredMessages = useCallback(
+    (restored: NonNullable<ReturnType<typeof loadTranscript>>): ConversationMessage[] => {
+      const out: ConversationMessage[] = []
+      if (restored.droppedCount > 0) {
+        out.push({
+          id: `transcript-truncated-${crypto.randomUUID().slice(0, 8)}`,
+          role: 'assistant',
+          content: '',
+          timestamp: restored.messages[0]?.timestamp ?? new Date(),
+          synthetic: true,
+          sessionDivider: formatTruncationNotice(restored.droppedCount),
+        })
+      }
+      out.push(...restored.messages)
+      out.push({
+        id: `boundary-${crypto.randomUUID().slice(0, 8)}`,
+        role: 'assistant',
+        content: '',
+        timestamp: new Date(),
+        synthetic: true,
+        sessionDivider: formatSessionBoundary(new Date()),
+      })
+      return out
+    },
+    [],
+  )
+
   const scenarioId = useCanvasStore((s) => s.currentScenarioId)
+
+  // MOUNT-TIME restore. This is the path a returning user actually takes and
+  // the one that was missing: on a reload the canvas store initialises
+  // `currentScenarioId` SYNCHRONOUSLY from localStorage
+  // (`store.ts` — `currentScenarioId: scenarios.getCurrentScenarioId()`), so
+  // the id never changes and the scenario-switch effect below NEVER FIRES.
+  // Nothing hydrated the panel, `messages` stayed `[]`, and `OlumiTabBody`
+  // rendered `olumi-tab-empty` — the first-use placeholder — over a fully
+  // restored 19-node model. Verified live on staging 25 Jul 2026.
+  const didMountRestoreRef = useRef(false)
+  useEffect(() => {
+    if (didMountRestoreRef.current) return
+    if (!scenarioId) return
+    didMountRestoreRef.current = true
+    // Only restore into a genuinely empty panel — never over live messages.
+    if (messagesRef.current.length > 0) return
+    try {
+      const restored = loadTranscript(scenarioId)
+      // Only a transcript from an EARLIER page load is something to restore.
+      // One this page load wrote is either already on screen or was cleared
+      // on purpose; replaying it would duplicate the live conversation and
+      // mint a "Session resumed" divider mid-session.
+      if (!restored || !restored.fromPreviousSession) return
+      const next = buildRestoredMessages(restored)
+      messagesRef.current = next
+      setMessages(next)
+    } catch (err) {
+      console.error('[useConversation] Transcript restore failed — starting fresh', err)
+    }
+  }, [scenarioId, buildRestoredMessages])
+
+  // Persist the transcript whenever it changes, so the next session can
+  // restore it. Guest sessions never reach Supabase (`isPersistenceActive` is
+  // false under `VITE_AUTH_MODE=guest`) and the graph itself already rides
+  // localStorage, so the transcript rides the same lifecycle.
+  useEffect(() => {
+    if (!scenarioId) return
+    if (messages.length === 0) return
+    saveTranscript(scenarioId, messages)
+  }, [messages, scenarioId])
+
+  // Clear conversation when scenario changes (with Track 3 thread hydration)
   const prevScenarioRef = useRef(scenarioId)
   useEffect(() => {
     if (scenarioId !== prevScenarioRef.current) {
@@ -1799,6 +1876,23 @@ export function useConversation(): UseConversationReturn {
       if (wasNull && scenarioId) {
         if (import.meta.env.DEV) {
           console.debug('[useConversation] Skipping reset — initial scenario_id assignment:', scenarioId)
+        }
+        // The reset must still be skipped (it would wipe an in-flight turn),
+        // but an EMPTY panel here is the other reload shape — the id arrived
+        // after mount rather than at store-init. Restoring is safe precisely
+        // because there is nothing in flight to protect.
+        if (messagesRef.current.length === 0) {
+          didMountRestoreRef.current = true
+          try {
+            const restored = loadTranscript(scenarioId)
+            if (restored && restored.fromPreviousSession) {
+              const next = buildRestoredMessages(restored)
+              messagesRef.current = next
+              setMessages(next)
+            }
+          } catch (err) {
+            console.error('[useConversation] Transcript restore failed — starting fresh', err)
+          }
         }
         return
       }
@@ -1864,15 +1958,31 @@ export function useConversation(): UseConversationReturn {
         }
       }
 
-      messagesRef.current = []
+      // A real scenario switch. The CEE session state belongs to the scenario
+      // we are leaving, so it always clears — but the conversation we are
+      // switching TO gets restored when one is stored, so returning to a
+      // decision shows what was left there rather than a blank slate.
       sessionStateRef.current = null
-      setMessages([])
       setIsThinking(false)
       useDraftStore.getState().setIsGenerating(false)
       setLongRunningHint(null)
       setLastSendFailure(null)
+
+      let restoredForSwitch: ConversationMessage[] | null = null
+      if (scenarioId) {
+        try {
+          const restored = loadTranscript(scenarioId)
+          if (restored && restored.fromPreviousSession) {
+            restoredForSwitch = buildRestoredMessages(restored)
+          }
+        } catch (err) {
+          console.error('[useConversation] Transcript restore failed — starting fresh', err)
+        }
+      }
+      messagesRef.current = restoredForSwitch ?? []
+      setMessages(restoredForSwitch ?? [])
     }
-  }, [scenarioId])
+  }, [scenarioId, buildRestoredMessages])
 
   const addMessage = useCallback((msg: ConversationMessage) => {
     setMessages((prev) => {

--- a/src/canvas/conversation/utils/__tests__/transcriptStore.spec.ts
+++ b/src/canvas/conversation/utils/__tests__/transcriptStore.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * transcriptStore — the store behind returning-user continuity.
+ *
+ * These are unit pins. The USER-VISIBLE pin (the first-use placeholder is no
+ * longer rendered over restored work) lives in
+ * `src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { ConversationMessage } from '../../types'
+import {
+  saveTranscript,
+  loadTranscript,
+  clearTranscript,
+  formatTruncationNotice,
+  TRANSCRIPT_STORAGE_KEY,
+  MAX_MESSAGES_PER_SCENARIO,
+} from '../transcriptStore'
+
+const SID = '561548c3-acd6-4488-b088-399c7cc15631'
+
+function msg(over: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: over.id ?? crypto.randomUUID(),
+    role: over.role ?? 'user',
+    content: over.content ?? 'hello',
+    timestamp: over.timestamp ?? new Date('2026-07-25T17:38:01.000Z'),
+    ...over,
+  }
+}
+
+describe('transcriptStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips the real turns verbatim, not a summary of them', () => {
+    const brief =
+      'We run a 12-person specialty coffee roastery in Bristol. I have around 80k I could invest.'
+    saveTranscript(SID, [
+      msg({ id: 'u1', role: 'user', content: brief }),
+      msg({ id: 'a1', role: 'assistant', content: 'I have built a first decision model.' }),
+    ])
+
+    const out = loadTranscript(SID)
+    expect(out).not.toBeNull()
+    expect(out!.messages).toHaveLength(2)
+    expect(out!.messages[0].content).toBe(brief)
+    expect(out!.messages[0].role).toBe('user')
+    expect(out!.messages[1].content).toBe('I have built a first decision model.')
+    expect(out!.messages[0].timestamp).toBeInstanceOf(Date)
+    expect(out!.droppedCount).toBe(0)
+  })
+
+  it('keeps blocks so a restored assistant turn still renders its cards', () => {
+    saveTranscript(SID, [
+      msg({
+        id: 'a1',
+        role: 'assistant',
+        content: 'Overconfidence',
+        blocks: [{ type: 'commentary', text: 'no hard budget ceiling node' }] as never,
+      }),
+    ])
+    const out = loadTranscript(SID)
+    expect(out!.messages[0].blocks).toHaveLength(1)
+  })
+
+  it('returns null when nothing is stored — the placeholder is TRUE then', () => {
+    expect(loadTranscript(SID)).toBeNull()
+    expect(loadTranscript(null)).toBeNull()
+  })
+
+  it('never commits a user turn the server never served', () => {
+    saveTranscript(SID, [
+      msg({ id: 'u-fail', role: 'user', content: 'never delivered', deliveryState: 'failed' }),
+      msg({ id: 'u-pending', role: 'user', content: 'still in flight', deliveryState: 'pending' }),
+      msg({ id: 'u-ok', role: 'user', content: 'delivered', deliveryState: 'sent' }),
+    ])
+    const out = loadTranscript(SID)
+    expect(out!.messages.map((m) => m.content)).toEqual(['delivered'])
+  })
+
+  it('drops synthetic chrome but keeps session dividers', () => {
+    saveTranscript(SID, [
+      msg({ id: 's1', role: 'assistant', content: 'welcome banner', synthetic: true }),
+      msg({
+        id: 'd1',
+        role: 'assistant',
+        content: '',
+        synthetic: true,
+        sessionDivider: 'Session resumed - 25 Jul, 17:38',
+      }),
+      msg({ id: 'u1', role: 'user', content: 'real turn' }),
+    ])
+    const out = loadTranscript(SID)
+    expect(out!.messages.map((m) => m.id)).toEqual(['d1', 'u1'])
+  })
+
+  it('DISCLOSES truncation rather than silently shortening the history', () => {
+    const many = Array.from({ length: MAX_MESSAGES_PER_SCENARIO + 7 }, (_, i) =>
+      msg({ id: `m${i}`, content: `turn ${i}` }),
+    )
+    const dropped = saveTranscript(SID, many)
+    expect(dropped).toBe(7)
+
+    const out = loadTranscript(SID)
+    expect(out!.messages).toHaveLength(MAX_MESSAGES_PER_SCENARIO)
+    expect(out!.droppedCount).toBe(7)
+    // The oldest survived message is the first one AFTER the dropped run.
+    expect(out!.messages[0].content).toBe('turn 7')
+    expect(formatTruncationNotice(7)).toBe(
+      'The earliest 7 messages from this decision could not be restored',
+    )
+    expect(formatTruncationNotice(1)).toBe(
+      'The earliest message from this decision could not be restored',
+    )
+  })
+
+  it('keeps transcripts separate per scenario', () => {
+    const OTHER = '2c288003-5ae0-478b-8307-45ac9cc41dea'
+    saveTranscript(SID, [msg({ id: 'a', content: 'roastery' })])
+    saveTranscript(OTHER, [msg({ id: 'b', content: 'something else' })])
+    expect(loadTranscript(SID)!.messages[0].content).toBe('roastery')
+    expect(loadTranscript(OTHER)!.messages[0].content).toBe('something else')
+  })
+
+  it('clearTranscript forgets one scenario and leaves the others', () => {
+    const OTHER = 'aead8bbf-e8f8-4f98-bca4-99e7f3ffa35b'
+    saveTranscript(SID, [msg({ id: 'a', content: 'roastery' })])
+    saveTranscript(OTHER, [msg({ id: 'b', content: 'other' })])
+    clearTranscript(SID)
+    expect(loadTranscript(SID)).toBeNull()
+    expect(loadTranscript(OTHER)).not.toBeNull()
+  })
+
+  it('survives a corrupt payload without throwing into a render path', () => {
+    localStorage.setItem(TRANSCRIPT_STORAGE_KEY, '{not json')
+    expect(() => loadTranscript(SID)).not.toThrow()
+    expect(loadTranscript(SID)).toBeNull()
+    expect(() => saveTranscript(SID, [msg()])).not.toThrow()
+    expect(loadTranscript(SID)).not.toBeNull()
+  })
+
+  it('degrades to a shorter, DECLARED history when the quota is exhausted', () => {
+    const real = Storage.prototype.setItem
+    let allowed = false
+    Storage.prototype.setItem = function (k: string, v: string) {
+      // Refuse everything until the payload has been halved twice.
+      if (k === TRANSCRIPT_STORAGE_KEY && !allowed && v.length > 400) {
+        const e = new Error('QuotaExceededError')
+        e.name = 'QuotaExceededError'
+        throw e
+      }
+      return real.call(this, k, v)
+    }
+    try {
+      const many = Array.from({ length: 40 }, (_, i) =>
+        msg({ id: `m${i}`, content: `turn ${i} ${'x'.repeat(60)}` }),
+      )
+      const dropped = saveTranscript(SID, many)
+      expect(dropped).not.toBeNull()
+      expect(dropped!).toBeGreaterThan(0)
+      allowed = true
+      const out = loadTranscript(SID)
+      expect(out).not.toBeNull()
+      // Whatever survived, the shortfall is on the record.
+      expect(out!.droppedCount).toBeGreaterThan(0)
+      expect(out!.messages.length).toBeLessThan(40)
+    } finally {
+      Storage.prototype.setItem = real
+    }
+  })
+})
+
+describe('transcriptStore — previous-session discrimination', () => {
+  beforeEach(() => { localStorage.clear() })
+
+  it('a transcript THIS page load wrote is not "from a previous session"', () => {
+    saveTranscript(SID, [msg({ id: 'a', content: 'live turn' })])
+    expect(loadTranscript(SID)!.fromPreviousSession).toBe(false)
+  })
+
+  it('a transcript an EARLIER page load wrote IS from a previous session', () => {
+    saveTranscript(SID, [msg({ id: 'a', content: 'yesterday' })])
+    const file = JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY)!)
+    file[SID].pageLoadId = 'an-earlier-page-load'
+    localStorage.setItem(TRANSCRIPT_STORAGE_KEY, JSON.stringify(file))
+    expect(loadTranscript(SID)!.fromPreviousSession).toBe(true)
+  })
+
+  it('a legacy record with no stamp is treated as a previous session', () => {
+    saveTranscript(SID, [msg({ id: 'a', content: 'pre-upgrade' })])
+    const file = JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY)!)
+    delete file[SID].pageLoadId
+    localStorage.setItem(TRANSCRIPT_STORAGE_KEY, JSON.stringify(file))
+    expect(loadTranscript(SID)!.fromPreviousSession).toBe(true)
+  })
+})

--- a/src/canvas/conversation/utils/transcriptStore.ts
+++ b/src/canvas/conversation/utils/transcriptStore.ts
@@ -1,0 +1,319 @@
+/**
+ * transcriptStore — local-first persistence of the conversation transcript.
+ *
+ * WHY THIS EXISTS (live defect, staging build `27d002c9`, 25 Jul 2026):
+ * a returning user got their whole model back and an EMPTY chat showing the
+ * first-use placeholder ("Describe your decision, goal, options…"), as though
+ * they had never been there. The conversation was not lost — it simply had no
+ * restore path on the surface the product actually runs on:
+ *
+ *   - `scenarios.thread` (the legacy Track-2 column `useScenario` reads into
+ *     `_hydratedThread`) DOES NOT EXIST on the live database, and its writer
+ *     and reader are both gated behind `VITE_FEATURE_THREAD_PERSIST` /
+ *     `VITE_FEATURE_THREAD_HYDRATE`, neither of which is present in the
+ *     deployed env — so both resolve to `false`.
+ *   - `conversation_turns` IS written on every turn (always-on), but has ZERO
+ *     readers anywhere in the client, and its RPC is RLS-gated so a guest's
+ *     writes are refused and then suppressed.
+ *   - staging runs `VITE_AUTH_MODE=guest`, so `isPersistenceActive()` is false
+ *     and the GRAPH itself restores from `localStorage` (`olumi-canvas-autosave`),
+ *     not from Supabase.
+ *
+ * The graph survives because it rides localStorage. This module puts the
+ * transcript on the same lifecycle, so the two halves of a user's work come
+ * back together. It is deliberately NOT flag-gated and needs no migration.
+ *
+ * WHAT IS AND IS NOT RESTORED — the honesty contract:
+ * the real history is restored verbatim (role, text, rendered blocks), never a
+ * synthesised summary of it. Fields that are documented-ephemeral in
+ * `types.ts` (`reasoning`, `answerShape`) or that would re-arm a stale
+ * interaction (`actionChips`) are dropped, and anything dropped for SIZE is
+ * declared on screen via `droppedCount` — a placeholder that means "you have
+ * never been here" is a factual claim, and it must not be made falsely.
+ */
+
+import type { ConversationMessage } from '../types'
+
+/** localStorage key. Sibling of `olumi-canvas-autosave` / `-scenarios`. */
+export const TRANSCRIPT_STORAGE_KEY = 'olumi-canvas-transcript'
+
+/**
+ * Identity of THIS page load, stamped onto every save.
+ *
+ * The feature is "show a RETURNING user what they left", so a transcript this
+ * page load wrote is not something to restore — it is already on screen, or it
+ * was deliberately cleared. Without this discriminator a provider remount
+ * would replay the live conversation back over itself and mint a spurious
+ * "Session resumed" divider mid-session.
+ */
+const PAGE_LOAD_ID: string = (() => {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `pl-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  }
+})()
+
+/** Most recent messages kept per scenario. */
+export const MAX_MESSAGES_PER_SCENARIO = 120
+
+/** Scenarios retained (least-recently-saved evicted first). */
+export const MAX_SCENARIOS = 8
+
+/**
+ * Byte ceiling for the whole key. localStorage is typically ~5 MB per origin
+ * and `olumi-canvas-autosave` already spends ~25 kB of it, so this stays well
+ * inside budget while holding a long conversation.
+ */
+export const MAX_SERIALISED_BYTES = 400_000
+
+/** Persisted form of one message — only the fields the panel renders. */
+interface StoredMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  ts: string
+  displayContent?: string
+  blocks?: unknown[]
+  insights?: unknown[]
+  clientTurnId?: string
+  chipInitiated?: boolean
+  sessionDivider?: string
+  synthetic?: boolean
+}
+
+interface StoredTranscript {
+  savedAt: string
+  /** The page load that wrote this. See `PAGE_LOAD_ID`. */
+  pageLoadId?: string
+  /** Count of messages dropped to respect the caps. 0 = the history is whole. */
+  dropped: number
+  messages: StoredMessage[]
+}
+
+type TranscriptFile = Record<string, StoredTranscript>
+
+export interface LoadedTranscript {
+  messages: ConversationMessage[]
+  savedAt: Date | null
+  /** >0 when older turns were dropped to fit — MUST be disclosed on screen. */
+  droppedCount: number
+  /**
+   * True when this transcript was written by an EARLIER page load, i.e. the
+   * user genuinely went away and came back. False when this page load wrote
+   * it, in which case there is nothing to "restore".
+   */
+  fromPreviousSession: boolean
+}
+
+function storageAvailable(): boolean {
+  try {
+    return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+  } catch {
+    return false
+  }
+}
+
+function readFile(): TranscriptFile {
+  if (!storageAvailable()) return {}
+  try {
+    const raw = localStorage.getItem(TRANSCRIPT_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    return parsed as TranscriptFile
+  } catch {
+    // Corrupt payload: treat as absent rather than throwing into a render path.
+    return {}
+  }
+}
+
+/**
+ * A message worth persisting: it must be something the user actually said or
+ * was told. Synthetic UI chrome is dropped (mirroring `useThreadPersistence`),
+ * EXCEPT session dividers, which are the record of the boundaries themselves.
+ * A user turn that never reached the server (`deliveryState: 'failed'`, or
+ * still `'pending'` when we serialise) is never committed — the same
+ * transcript-honesty rule the live path applies.
+ */
+function isPersistable(m: ConversationMessage): boolean {
+  if (m.synthetic && !m.sessionDivider) return false
+  if (m.role === 'user' && (m.deliveryState === 'failed' || m.deliveryState === 'pending')) return false
+  if (m.isStreaming) return false
+  if (!m.content && !m.sessionDivider && !(m.blocks && m.blocks.length > 0)) return false
+  return true
+}
+
+function toStored(m: ConversationMessage): StoredMessage {
+  const out: StoredMessage = {
+    id: m.id,
+    role: m.role,
+    content: m.content ?? '',
+    ts: (m.timestamp instanceof Date ? m.timestamp : new Date()).toISOString(),
+  }
+  if (m.displayContent) out.displayContent = m.displayContent
+  if (m.blocks && m.blocks.length > 0) out.blocks = m.blocks as unknown[]
+  if (m.insights && m.insights.length > 0) out.insights = m.insights as unknown[]
+  if (m.clientTurnId) out.clientTurnId = m.clientTurnId
+  if (m.chipInitiated) out.chipInitiated = true
+  if (m.sessionDivider) out.sessionDivider = m.sessionDivider
+  if (m.synthetic) out.synthetic = true
+  return out
+}
+
+function fromStored(s: StoredMessage): ConversationMessage {
+  const ts = new Date(s.ts)
+  return {
+    id: s.id,
+    role: s.role === 'user' ? 'user' : 'assistant',
+    content: typeof s.content === 'string' ? s.content : '',
+    timestamp: Number.isNaN(ts.getTime()) ? new Date() : ts,
+    ...(s.displayContent ? { displayContent: s.displayContent } : {}),
+    ...(Array.isArray(s.blocks) && s.blocks.length > 0
+      ? { blocks: s.blocks as ConversationMessage['blocks'] }
+      : {}),
+    ...(Array.isArray(s.insights) && s.insights.length > 0
+      ? { insights: s.insights as ConversationMessage['insights'] }
+      : {}),
+    ...(s.clientTurnId ? { clientTurnId: s.clientTurnId } : {}),
+    ...(s.chipInitiated ? { chipInitiated: true } : {}),
+    ...(s.sessionDivider ? { sessionDivider: s.sessionDivider } : {}),
+    ...(s.synthetic ? { synthetic: true } : {}),
+  }
+}
+
+function isStoredMessage(v: unknown): v is StoredMessage {
+  if (v == null || typeof v !== 'object') return false
+  const m = v as Partial<StoredMessage>
+  return (
+    typeof m.id === 'string' &&
+    (m.role === 'user' || m.role === 'assistant') &&
+    typeof m.ts === 'string'
+  )
+}
+
+/**
+ * Persist the transcript for one scenario. Best-effort and total: it never
+ * throws into the caller's render path.
+ *
+ * Returns the number of messages dropped to fit the caps (0 when whole), or
+ * `null` when nothing was written at all.
+ */
+export function saveTranscript(
+  scenarioId: string | null | undefined,
+  messages: readonly ConversationMessage[],
+): number | null {
+  if (!scenarioId || !storageAvailable()) return null
+
+  const persistable = messages.filter(isPersistable)
+  if (persistable.length === 0) return null
+
+  const file = readFile()
+  const prevDropped = file[scenarioId]?.dropped ?? 0
+
+  let kept = persistable
+  let dropped = prevDropped
+  if (kept.length > MAX_MESSAGES_PER_SCENARIO) {
+    dropped += kept.length - MAX_MESSAGES_PER_SCENARIO
+    kept = kept.slice(-MAX_MESSAGES_PER_SCENARIO)
+  }
+
+  const build = (msgs: readonly ConversationMessage[], drop: number): StoredTranscript => ({
+    savedAt: new Date().toISOString(),
+    pageLoadId: PAGE_LOAD_ID,
+    dropped: drop,
+    messages: msgs.map(toStored),
+  })
+
+  // Evict least-recently-saved scenarios beyond the cap.
+  const next: TranscriptFile = { ...file }
+  next[scenarioId] = build(kept, dropped)
+  const ids = Object.keys(next)
+  if (ids.length > MAX_SCENARIOS) {
+    ids
+      .filter((id) => id !== scenarioId)
+      .sort((a, b) => Date.parse(next[a]?.savedAt ?? '') - Date.parse(next[b]?.savedAt ?? ''))
+      .slice(0, ids.length - MAX_SCENARIOS)
+      .forEach((id) => { delete next[id] })
+  }
+
+  // Shrink until it fits the byte ceiling, then until the browser accepts it.
+  let payload = JSON.stringify(next)
+  while (payload.length > MAX_SERIALISED_BYTES && kept.length > 1) {
+    const drop = Math.max(1, Math.ceil(kept.length / 4))
+    dropped += drop
+    kept = kept.slice(drop)
+    next[scenarioId] = build(kept, dropped)
+    payload = JSON.stringify(next)
+  }
+
+  for (;;) {
+    try {
+      localStorage.setItem(TRANSCRIPT_STORAGE_KEY, payload)
+      return dropped
+    } catch {
+      // Quota (or a hostile storage impl). Halve and retry; give up cleanly.
+      if (kept.length <= 1) {
+        try { localStorage.removeItem(TRANSCRIPT_STORAGE_KEY) } catch { /* noop */ }
+        return null
+      }
+      const drop = Math.ceil(kept.length / 2)
+      dropped += drop
+      kept = kept.slice(drop)
+      next[scenarioId] = build(kept, dropped)
+      payload = JSON.stringify(next)
+    }
+  }
+}
+
+/**
+ * Read back the transcript for one scenario. Returns `null` when there is
+ * nothing stored — the caller must then leave the first-use placeholder
+ * standing, because in that case it is TRUE.
+ */
+export function loadTranscript(scenarioId: string | null | undefined): LoadedTranscript | null {
+  if (!scenarioId || !storageAvailable()) return null
+
+  const entry = readFile()[scenarioId]
+  if (entry == null || typeof entry !== 'object') return null
+  if (!Array.isArray(entry.messages)) return null
+
+  const messages = entry.messages.filter(isStoredMessage).map(fromStored)
+  if (messages.length === 0) return null
+
+  const savedAt = typeof entry.savedAt === 'string' ? new Date(entry.savedAt) : null
+  const droppedCount = Number.isFinite(entry.dropped) ? Number(entry.dropped) : 0
+
+  return {
+    messages,
+    savedAt: savedAt && !Number.isNaN(savedAt.getTime()) ? savedAt : null,
+    droppedCount: droppedCount > 0 ? droppedCount : 0,
+    fromPreviousSession: entry.pageLoadId !== PAGE_LOAD_ID,
+  }
+}
+
+/** Forget one scenario's transcript (scenario deleted / canvas reset). */
+export function clearTranscript(scenarioId: string | null | undefined): void {
+  if (!scenarioId || !storageAvailable()) return
+  try {
+    const file = readFile()
+    if (!(scenarioId in file)) return
+    delete file[scenarioId]
+    localStorage.setItem(TRANSCRIPT_STORAGE_KEY, JSON.stringify(file))
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * The on-screen disclosure for a partially-restored history.
+ *
+ * Rendered as a session divider above the restored turns. It states the
+ * shortfall in plain words rather than letting the panel imply the history is
+ * complete.
+ */
+export function formatTruncationNotice(droppedCount: number): string {
+  return droppedCount === 1
+    ? 'The earliest message from this decision could not be restored'
+    : `The earliest ${droppedCount} messages from this decision could not be restored`
+}

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -3062,9 +3062,33 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // This allows comparison display: "+X pts above 'do nothing'"
     // Future: Could store per-option outcomes for cross-option comparison
 
-    // Save to run history
-    if (report && results.seed !== undefined) {
-      const graphHash = generateGraphHash(nodes, edges, results.seed)
+    // Save to run history.
+    //
+    // `results.seed` is set by `resultsStart`, which ONLY the direct Run-button
+    // path calls. The canonical V5 / conversation path dispatches through
+    // `resultsAnalysing` ("no seed is known yet"), so on a fresh session
+    // `results.seed` is `undefined` and this write was skipped entirely —
+    // while `last_result_hash` above was written regardless. A returning user
+    // therefore had a scenario record pointing at a run that had never been
+    // stored, `tryRestoreResultsFromHistory` found nothing, and the answer
+    // was replaced by the pre-analysis "Analyse first pass" state with the
+    // model still on the canvas. Verified live on staging 25 Jul 2026:
+    // `olumi-canvas-run-history` was never created by a conversation-driven run.
+    //
+    // The fallback is the engine's OWN echo (`meta.seed_used`) — the same
+    // value `useConversation` maps into the report — NOT a fabricated 0. When
+    // there is no echo either, the write is still skipped: a run identity
+    // built on an invented seed would fork the graph hash (CLAUDE.md trap #10).
+    const echoedSeed = (() => {
+      const raw = rawV2Response?.meta?.seed_used
+      if (raw == null) return undefined
+      const n = Number(raw)
+      return Number.isFinite(n) ? n : undefined
+    })()
+    const runHistorySeed = results.seed ?? echoedSeed
+
+    if (report && runHistorySeed !== undefined) {
+      const graphHash = generateGraphHash(nodes, edges, runHistorySeed)
 
       const graphSnapshot = JSON.parse(JSON.stringify({ nodes, edges })) as {
         nodes: typeof nodes
@@ -3074,7 +3098,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       const storedRun: StoredRun = {
         id: results.runId || crypto.randomUUID(),
         ts: Date.now(),
-        seed: results.seed,
+        seed: runHistorySeed,
         hash,
         adapter: 'auto', // TODO: Track actual adapter used
         summary: (report as any).summary || '',


### PR DESCRIPTION
## The defect, as a user meets it

Driven on deployed staging (build `27d002c9`), reproduced **2 of 2**: come back to a decision and the 19-node model restores perfectly, while the chat shows the **first-use placeholder** — *"Describe your decision, goal, options, and any assumptions, risks or constraints you're aware of."* — and the results panel resets to **"Analyse first pass"**. Asked directly, the coach still quotes the earlier run. **The screen was discarding work the system holds.**

## What is actually persisted vs what the screen dropped — verified at the bytes

| Surface | Written? | Read back? |
|---|---|---|
| `scenarios.thread` (legacy Track-2) | No — writer gated on `VITE_FEATURE_THREAD_PERSIST` | No — reader gated on `VITE_FEATURE_THREAD_HYDRATE`, **and the column does not exist** |
| `conversation_turns` | **Yes, every turn, always-on** | **No — zero readers in the client** |
| `olumi-canvas-autosave` (graph) | Yes | Yes — this is why the model came back |
| conversation transcript | **nowhere** | — |

- Neither `VITE_FEATURE_THREAD_HYDRATE` nor `VITE_FEATURE_THREAD_PERSIST` appears in the inlined `import.meta.env` of the deployed bundle (`assets/index-PLbsedOe.js` → `flags-BOFkajto.js`, 60 `VITE_*` keys). Both resolve to their `false` default.
- Probing live staging Postgres: `scenarios?select=thread` → `42703 column does not exist`; every other `ScenarioRow` column → `42501 permission denied` (exists, RLS-blocked). PostgREST resolves column names before grants, so this is a clean existence oracle. **The legacy path could not have worked even with the flag on.**
- Staging is `VITE_AUTH_MODE=guest`, so `isPersistenceActive()` is false and the graph restores from localStorage.

## The fix

Put the transcript on the same lifecycle the graph already rides. No flag, no migration, no new service dependency.

- New `src/canvas/conversation/utils/transcriptStore.ts` — capped, quota-safe, per-scenario localStorage.
- `useConversation` gains a **mount-time** restore. The existing scenario-switch effect never fired on reload: the store initialises `currentScenarioId` synchronously from localStorage, so the id never changes.
- Only a transcript from an **earlier page load** is restored, so a provider remount cannot replay the live conversation over itself.
- **Analysis answer**: `resultsComplete`'s run-history write was skipped whenever `results.seed` was undefined — which is *always* on the conversation path (`resultsAnalysing`, not `resultsStart`) — while `last_result_hash` was written regardless, leaving a dangling pointer. Now falls back to the engine's **own echo** (`meta.seed_used`), never a fabricated 0; with no echo the write is still skipped rather than forking the graph hash.

## Honesty on screen

Restores the real turns verbatim, never a summary. Turns that never reached the server are never committed. When caps or quota force a shortfall the panel **says so** — *"The earliest N messages from this decision could not be restored"* — instead of implying the history is whole.

## Evidence

- **RED-first, user-visible**: `OlumiTabBody.returningUser.spec.tsx` asserts on the rendered `olumi-tab-empty` element and bubble `textContent`. **Claim type: DOM presence, not visibility** — jsdom cannot prove layout. On-screen proof is the live before/after.
- **Mutation-check** in a throwaway copy, reverting *only* the wiring and keeping the new module and specs: **4 of 5** user-visible tests go RED, **2 of 4** analysis tests go RED. The green ones are the intended positive controls (placeholder shown to a genuinely new user; direct Run path).
- **Regression**: 428 files / 5,879 tests green across `src/canvas/{conversation,__tests__,components}`. The pristine-staging baseline for the same scope was also green, so it is like-for-like.
- **Types**: `tsconfig.app.json` — 2,319 errors on branch, 2,319 on pristine staging. **Zero new.**
- **The typecheck baseline was NOT regenerated.** It over-counts by 2 at the pristine tip, so any notice to regenerate is declined deliberately.
- `scripts/ci/typecheck-gate.sh` reports `0/3039 files loaded` in this sandbox and **fails identically on pristine staging**, so it gave no local signal either way. CI runs the real gate.

## Staging disclosure

One guest scenario created via the deployed UI to reproduce and to serve as the positive control: 1 draft, 3 conversational turns, 1 analysis run. **Nothing deleted or modified.** DAY3's protected `2c288003-5ae0-478b-8307-45ac9cc41dea` untouched; `decision_records` not written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)