### PR TITLE
docs(continuity): label the analysis run-identity fallback as INERT on the live path

### DIFF
--- a/src/canvas/__tests__/store.conversationRunSurvivesReload.spec.ts
+++ b/src/canvas/__tests__/store.conversationRunSurvivesReload.spec.ts
@@ -18,9 +18,17 @@
  * Live corroboration: after a conversation-driven analysis on staging, the
  * `olumi-canvas-run-history` localStorage key did not exist at all.
  *
+ * ⚠ SCOPE CORRECTION (25 Jul 2026, after capturing the live wire): these tests
+ * pin the STORE CONTRACT, and the fix they pin is INERT ON THE DEPLOYED PATH.
+ * Do not cite this file as evidence that a returning user gets their answer
+ * back — they do not. The live V5 handler (`applyV5State.ts` ~L1015) calls
+ * `resultsComplete` with `rawV2Response: null`, and the live envelope carries
+ * no `seed_used` anywhere, so `runHistorySeed` is undefined in production and
+ * this write never fires. Live acceptance recorded this as a FAIL, honestly.
+ * See `parallel-briefs/RETURNING-USER-2026-07-25.md` §3.
+ *
  * CLAIM TYPE: this is a STORE-STATE pin (what the results panel branches on),
- * not a rendering or visibility claim. The on-screen proof is the live
- * before/after in `parallel-briefs/RETURNING-USER-2026-07-25.md`.
+ * not a rendering or visibility claim, and NOT a claim about deployed behaviour.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -3079,6 +3079,38 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // value `useConversation` maps into the report — NOT a fabricated 0. When
     // there is no echo either, the write is still skipped: a run identity
     // built on an invented seed would fork the graph hash (CLAUDE.md trap #10).
+    //
+    // ⚠ THIS FALLBACK IS CURRENTLY INERT ON THE DEPLOYED PATH — do not read it
+    // as "the returning-user answer is fixed". Corrected 25 Jul 2026 after
+    // capturing the live wire (CLAUDE.md trap #16: a grepped symbol proves
+    // presence-in-repo, never presence-on-the-live-wire).
+    //
+    // The branch this fallback was written against — `envelope.analysis_response`
+    // in useConversation.ts, which carries the "Journey step 8" comment and the
+    // #381 storeAnalysis fix — IS NOT THE LIVE PATH. Captured twice from
+    // deployed staging, a real analysis returns on POST /proxy/v5/turn with NO
+    // `analysis_response` key at all: the result is `blocks[0]` of type
+    // `analysis_result`, payload at `blocks[0].enrichment.option_comparison`,
+    // and `seed_used` appears NOWHERE in the envelope. The live handler is
+    // applyV5State.ts (~L1015) and it calls resultsComplete with
+    // `rawV2Response: null` explicitly ("V5 carries no V2 envelope").
+    //
+    // So on the deployed path BOTH inputs are absent: `results.seed` is
+    // undefined (only resultsStart sets it, and only the direct Run button
+    // calls that) and `rawV2Response` is null. `runHistorySeed` stays
+    // undefined, this write is still skipped, and — because the Supabase
+    // storeAnalysis call lives in that same dead branch — the answer has NO
+    // store at all. `last_result_hash` above is still written unconditionally,
+    // so a returning session looks up a run that was never saved.
+    // Live-confirmed 3/3: `olumi-canvas-run-history` does not exist as a
+    // localStorage key even after a completed analysis.
+    //
+    // Reviving this needs a producer-boundary decision, not a UI change: CEE
+    // echoes a run seed/identity on the `analysis_result` block, or run
+    // identity is re-based on `report.model_card.response_hash` (which IS
+    // present) instead of a seed-bearing graph hash. This code is kept because
+    // it is correct and is the right shape for that moment — not because it
+    // does anything today. See parallel-briefs/RETURNING-USER-2026-07-25.md §3.
     const echoedSeed = (() => {
       const raw = rawV2Response?.meta?.seed_used
       if (raw == null) return undefined


### PR DESCRIPTION
**Self-correction to #480. Comments only — zero behaviour change.**

## What I got wrong

#480 said the returning-user **answer** was fixed by falling back to the engine's echoed seed. The fallback is correct code and it is **provably dead on the deployed path**. The conversation half of #480 is unaffected and remains live-verified working.

## The live wire, captured twice from deployed staging after #480 shipped

- A real analysis returns on `POST https://cee-staging.onrender.com/proxy/v5/turn` (41,486 B, HTTP 200) with **no `analysis_response` key at all**. The result is `blocks[0]`, type `analysis_result`, payload at `blocks[0].enrichment.option_comparison`.
- **`seed_used` appears nowhere in the envelope.**
- The live handler is `src/v5/applyV5State.ts` (~L1015), which calls `resultsComplete` with **`rawV2Response: null`** explicitly — *"V5 carries no V2 envelope"*.

So in production both inputs the fallback needs are absent: `results.seed` is `undefined` (only `resultsStart` sets it, and only the direct Run button calls that) **and** `rawV2Response` is `null`. `runHistorySeed` stays undefined and the write never fires. Live-confirmed **3/3**: `olumi-canvas-run-history` does not exist as a localStorage key even after a completed analysis.

## How I got it wrong

I traced `envelope.analysis_response` in `useConversation.ts` — a real branch carrying a detailed *"Journey step 8 — reload persistence"* comment and the #381 `storeAnalysis` fix — and assumed it was the live path. It is not. **CLAUDE.md trap #16 exactly**: a grepped symbol proves presence-in-repo, never presence-on-the-live-wire.

## The bigger consequence, worth flagging

Because the Supabase `storeAnalysis` call lives in that **same dead branch**, #381's shipped fix also never executes on the deployed path — so an authenticated user loses the answer too. Meanwhile `resultsComplete` still writes `last_result_hash` unconditionally (`store.ts:3052`), leaving a pointer to a run that was never stored. **The answer has nowhere to be stored today.**

## Why the code stays

It is correct, tested, harmless, and the right shape for the moment a run identity exists. It is now labelled in-code so the next lane cannot inherit *"the answer is fixed"* as a premise. Reviving it needs a **producer-boundary decision**, not a UI change: either CEE echoes a run seed/identity on the `analysis_result` block, or run identity re-bases on `report.model_card.response_hash` (which **is** present) instead of a seed-bearing graph hash.

Full analysis, live evidence and the disclosure log: `parallel-briefs/RETURNING-USER-2026-07-25.md` §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)