### PR TITLE
fix(continuity): collapse consecutive session dividers on repeated returns

### DIFF
--- a/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
@@ -166,3 +166,42 @@ describe('returning user — the chat pane after a reload', () => {
     expect(screen.queryByTestId('olumi-tab-empty')).not.toBeInTheDocument()
   })
 })
+
+describe('returning repeatedly does not stack session dividers', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCanvasStore.setState({ currentScenarioId: null })
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => {}
+    }
+    vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+  })
+
+  it('shows ONE boundary no matter how many times the decision is reopened', async () => {
+    // A history that already ends with a divider — i.e. the user came back,
+    // said nothing, and is coming back again.
+    storePriorSession([
+      ...priorSession(),
+      {
+        id: 'd-old',
+        role: 'assistant',
+        content: '',
+        timestamp: new Date('2026-07-25T21:32:00Z'),
+        synthetic: true,
+        sessionDivider: 'Session resumed - 25 Jul, 21:32',
+      },
+    ])
+    useCanvasStore.setState({ currentScenarioId: SID })
+
+    const { container } = renderPanel()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+    const dividers = container.querySelectorAll('[data-testid="session-divider"]')
+    expect(dividers).toHaveLength(1)
+    // And the real turns are still there — collapsing must not eat history.
+    expect(container.querySelectorAll('[data-testid="message-user"]')).toHaveLength(1)
+    expect(container.querySelectorAll('[data-testid="message-assistant"]')).toHaveLength(1)
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -1808,14 +1808,31 @@ export function useConversation(): UseConversationReturn {
         })
       }
       out.push(...restored.messages)
-      out.push({
-        id: `boundary-${crypto.randomUUID().slice(0, 8)}`,
-        role: 'assistant',
-        content: '',
-        timestamp: new Date(),
-        synthetic: true,
-        sessionDivider: formatSessionBoundary(new Date()),
-      })
+      // Collapse consecutive boundaries. Each return appends a divider and the
+      // divider is itself persisted, so opening a decision five times without
+      // saying anything stacked five "Session resumed" lines with nothing
+      // between them (seen live 25 Jul). A boundary is only information when
+      // there is something on BOTH sides of it: if the restored history already
+      // ends with a divider, that divider IS this boundary — replace its
+      // timestamp rather than adding another.
+      const last = out[out.length - 1]
+      const endsWithDivider = last != null && typeof last.sessionDivider === 'string'
+      if (endsWithDivider) {
+        out[out.length - 1] = {
+          ...last,
+          timestamp: new Date(),
+          sessionDivider: formatSessionBoundary(new Date()),
+        }
+      } else {
+        out.push({
+          id: `boundary-${crypto.randomUUID().slice(0, 8)}`,
+          role: 'assistant',
+          content: '',
+          timestamp: new Date(),
+          synthetic: true,
+          sessionDivider: formatSessionBoundary(new Date()),
+        })
+      }
       return out
     },
     [],


### PR DESCRIPTION
**A defect I introduced in #480, caught by my own final live verification.**

On deployed staging (`index-Dc1Psm5x.js`) I observed **5 stacked "Session resumed" dividers** on a profile that had been reopened 5 times. Each return appends a divider *and* the divider is itself persisted, so reopening a decision without saying anything piles them up with nothing between them.

## Fix

A boundary is only information when there is something on **both** sides of it. If the restored history already ends with a divider, that divider *is* this boundary — refresh its timestamp instead of adding a second.

## Evidence

- New pin asserts **exactly one** `session-divider` element after reopening a history that already ends with one, **and** that the real turns survive the collapse (1 user bubble, 1 assistant bubble) — collapsing must not eat history.
- **Mutation-check, sanity-checked.** The first attempt went red on a missing jsdom `scrollIntoView` stub rather than on the assertion — that would have been theatre, so I fixed the setup and re-ran. With the stub in place the **identical filtered invocation** is green on the fixed tree and **RED at the divider assertion (line 202)** with the wiring reverted.
- Regression: 428 files / **5,880 tests green** across `src/canvas/{conversation,__tests__,components}`.

Context: `parallel-briefs/RETURNING-USER-2026-07-25.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)