### PR TITLE
fix(first-view): floor the post-draft auto-fit at one legibility constant; stop the status panel denying capture

### DIFF
--- a/src/canvas/__tests__/ReactFlowGraph.layoutLifecycle.integration.spec.tsx
+++ b/src/canvas/__tests__/ReactFlowGraph.layoutLifecycle.integration.spec.tsx
@@ -25,6 +25,7 @@ import { useCanvasStore } from '../store'
 import { useInitialLayoutGuard } from '../hooks/useInitialLayoutGuard'
 import { useMeasureThenLayout } from '../hooks/useMeasureThenLayout'
 import { useFitViewOnLayoutVersion } from '../hooks/useFitViewOnLayoutVersion'
+import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
 
 let mockNodesInitialized = true
 let mockNodeLookup = new Map<string, { measured?: { width?: number; height?: number } }>()
@@ -180,7 +181,7 @@ describe('Layout lifecycle — guard ↔ measurement ↔ applyLayout ↔ fitView
     // fitView fired exactly once with the production contract — asserted
     // directly against the real useFitViewOnLayoutVersion hook output.
     expect(fitViewSpy).toHaveBeenCalledTimes(1)
-    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, duration: 400 })
+    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, minZoom: LABEL_LEGIBLE_ZOOM, duration: 400 })
 
     expect(useCanvasStore.getState().pendingLayout).toBe(false)
     expect(useCanvasStore.getState().layoutInProgress).toBe(false)
@@ -252,7 +253,7 @@ describe('Layout lifecycle — guard ↔ measurement ↔ applyLayout ↔ fitView
     const lockedFinal = final.find((n) => n.id === 'locked')
     expect(lockedFinal?.position).toEqual({ x: 0, y: 0 })
     expect(fitViewSpy).toHaveBeenCalledTimes(1)
-    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, duration: 400 })
+    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, minZoom: LABEL_LEGIBLE_ZOOM, duration: 400 })
   })
 
   it('scenario A→B switch lays out B when B is stacked and fires fitView once for B (acceptance #5 + #6)', async () => {
@@ -297,6 +298,6 @@ describe('Layout lifecycle — guard ↔ measurement ↔ applyLayout ↔ fitView
     const xs = final.map((n) => (n.position as { x: number }).x)
     expect(Math.max(...xs) - Math.min(...xs)).toBeGreaterThan(40)
     expect(fitViewSpy).toHaveBeenCalledTimes(1)
-    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, duration: 400 })
+    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, minZoom: LABEL_LEGIBLE_ZOOM, duration: 400 })
   })
 })

--- a/src/canvas/__tests__/autoFitLegibility.spec.tsx
+++ b/src/canvas/__tests__/autoFitLegibility.spec.tsx
@@ -1,0 +1,119 @@
+/**
+ * The auto-fit must never park the camera in the band the product itself
+ * declares unreadable.
+ *
+ * LIVE DEFECT (deployed staging `039f479a`, 25 Jul 2026, measured in a real
+ * browser): after a ~60 s first draft the post-layout auto-fit landed an
+ * 18-node model at **0.4331** zoom. `LodSync` hides node labels below 0.5, so
+ * 16 of 18 titles and ALL 18 bodies rendered `visibility: hidden` — the first
+ * thing the user saw after a minute of waiting was a page of blank boxes. The
+ * same defect fires on the templates entry path (measured 0.45).
+ *
+ * CLAIM TYPE (trap 3): this spec is a CONTRACT assertion in jsdom — it proves
+ * the auto-fit ASKS xyflow for a floor at or above the legibility threshold.
+ * It cannot and does not prove anything about rendered visibility; that claim
+ * is only ever made from a real browser (see the live-acceptance evidence).
+ *
+ * WHY IT IS NOT A TAUTOLOGY: the captured `minZoom` is fed through
+ * `isLodZoom` — the ACTUAL predicate `LodSync` uses to hide labels, imported
+ * from the other module. If someone drops `minZoom`, hardcodes a lower
+ * number, or raises the LOD threshold without raising the floor, this goes
+ * RED. The `typeof === 'number'` assertion is load-bearing and must stay:
+ * `isLodZoom(undefined)` is `undefined < 0.5` === `false`, so a predicate-only
+ * guard would PASS on a dropped `minZoom` — the precise regression it exists
+ * to catch (trap 13: an absence assertion needs a positive control).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCanvasStore } from '../store'
+import { useFitViewOnLayoutVersion } from '../hooks/useFitViewOnLayoutVersion'
+import { isLodZoom, LOD_ZOOM_THRESHOLD } from '../components/LodSync'
+
+const fitViewSpy = vi.fn()
+
+const FIT_PADDING = { top: '10px', right: '20px', bottom: '10px', left: '20px' }
+
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({ fitView: fitViewSpy }),
+}))
+
+vi.mock('../utils/computeFitPadding', () => ({
+  computeFitPadding: () => FIT_PADDING,
+}))
+
+/** The zoom the live 18-node first view actually landed on, before the fix. */
+const LIVE_FIRST_VIEW_ZOOM = 0.4331
+/** The zoom the live templates entry path landed on, before the fix. */
+const LIVE_TEMPLATE_ENTRY_ZOOM = 0.45
+
+/** Drive one completed layout and hand back the options the hook passed fitView. */
+function captureAutoFitOptions(): Record<string, unknown> {
+  let rafCallback: (() => void) | null = null
+  const rafSpy = vi
+    .spyOn(globalThis, 'requestAnimationFrame')
+    .mockImplementation((cb: FrameRequestCallback) => {
+      rafCallback = cb as unknown as () => void
+      return 1
+    })
+
+  renderHook(() => useFitViewOnLayoutVersion())
+  act(() => {
+    useCanvasStore.setState({ layoutVersion: 1 } as never)
+  })
+  act(() => {
+    rafCallback?.()
+  })
+
+  rafSpy.mockRestore()
+
+  expect(fitViewSpy).toHaveBeenCalledTimes(1)
+  return fitViewSpy.mock.calls[0]![0] as Record<string, unknown>
+}
+
+describe('the LOD predicate discriminates (positive control)', () => {
+  it('judges the live pre-fix zooms UNREADABLE — so a "readable" verdict means something', () => {
+    // If these ever read false the guard below is vacuous: it would be
+    // "proving" a floor clears a bar nothing can fail.
+    expect(isLodZoom(LIVE_FIRST_VIEW_ZOOM)).toBe(true)
+    expect(isLodZoom(LIVE_TEMPLATE_ENTRY_ZOOM)).toBe(true)
+  })
+})
+
+describe('the post-layout auto-fit is floored at the legibility threshold', () => {
+  beforeEach(() => {
+    useCanvasStore.getState().resetCanvas()
+    useCanvasStore.setState({ layoutVersion: 0 } as never)
+    fitViewSpy.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes a finite numeric minZoom (a DROPPED floor must not pass silently)', () => {
+    const options = captureAutoFitOptions()
+    expect(typeof options.minZoom).toBe('number')
+    expect(Number.isFinite(options.minZoom as number)).toBe(true)
+  })
+
+  it("the floor it asks for is NOT a LOD zoom, judged by LodSync's own predicate", () => {
+    const options = captureAutoFitOptions()
+    expect(isLodZoom(options.minZoom as number)).toBe(false)
+  })
+
+  it('the floor lifts the live pre-fix zooms out of the hidden-label band', () => {
+    const options = captureAutoFitOptions()
+    const floor = options.minZoom as number
+    expect(floor).toBeGreaterThan(LIVE_FIRST_VIEW_ZOOM)
+    expect(floor).toBeGreaterThan(LIVE_TEMPLATE_ENTRY_ZOOM)
+    // and the label threshold is what the floor is derived FROM, not a
+    // coincidence: the floor is exactly the zoom at which labels start rendering.
+    expect(floor).toBe(LOD_ZOOM_THRESHOLD)
+  })
+
+  it('still fits with the panel-aware padding and the guarded duration', () => {
+    const options = captureAutoFitOptions()
+    expect(options.padding).toBe(FIT_PADDING)
+    expect(options.duration).toBe(400)
+  })
+})

--- a/src/canvas/__tests__/autoFitLegibility.spec.tsx
+++ b/src/canvas/__tests__/autoFitLegibility.spec.tsx
@@ -3,11 +3,11 @@
  * declares unreadable.
  *
  * LIVE DEFECT (deployed staging `039f479a`, 25 Jul 2026, measured in a real
- * browser): after a ~60 s first draft the post-layout auto-fit landed an
- * 18-node model at **0.4331** zoom. `LodSync` hides node labels below 0.5, so
+ * browser): after a ~60 s first draft the post-layout auto-fit landed a
+ * 19-node model at **0.4456** zoom. `LodSync` hides node labels below 0.5, so
  * 16 of 18 titles and ALL 18 bodies rendered `visibility: hidden` — the first
  * thing the user saw after a minute of waiting was a page of blank boxes. The
- * same defect fires on the templates entry path (measured 0.45).
+ * same defect fires on the templates entry path, measured at **0.4509**.
  *
  * CLAIM TYPE (trap 3): this spec is a CONTRACT assertion in jsdom — it proves
  * the auto-fit ASKS xyflow for a floor at or above the legibility threshold.
@@ -41,10 +41,10 @@ vi.mock('../utils/computeFitPadding', () => ({
   computeFitPadding: () => FIT_PADDING,
 }))
 
-/** The zoom the live 18-node first view actually landed on, before the fix. */
-const LIVE_FIRST_VIEW_ZOOM = 0.4331
-/** The zoom the live templates entry path landed on, before the fix. */
-const LIVE_TEMPLATE_ENTRY_ZOOM = 0.45
+/** The zoom the live 19-node first view actually landed on, before the fix. */
+const LIVE_FIRST_VIEW_ZOOM = 0.4456
+/** The zoom the live 18-node templates entry path landed on, before the fix. */
+const LIVE_TEMPLATE_ENTRY_ZOOM = 0.4509
 
 /** Drive one completed layout and hand back the options the hook passed fitView. */
 function captureAutoFitOptions(): Record<string, unknown> {

--- a/src/canvas/__tests__/useFitViewOnLayoutVersion.spec.tsx
+++ b/src/canvas/__tests__/useFitViewOnLayoutVersion.spec.tsx
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useCanvasStore } from '../store'
 import { useFitViewOnLayoutVersion } from '../hooks/useFitViewOnLayoutVersion'
+import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
 
 const fitViewSpy = vi.fn()
 
@@ -78,7 +79,13 @@ describe('useFitViewOnLayoutVersion', () => {
     })
 
     expect(fitViewSpy).toHaveBeenCalledTimes(1)
-    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, duration: 400 })
+    // The legibility floor joined this contract on 25 Jul 2026 — see
+    // autoFitLegibility.spec.tsx for why it exists and what guards it.
+    expect(fitViewSpy).toHaveBeenCalledWith({
+      padding: FIT_PADDING,
+      minZoom: LABEL_LEGIBLE_ZOOM,
+      duration: 400,
+    })
 
     rafSpy.mockRestore()
   })

--- a/src/canvas/__tests__/zoomLegibilitySingleSource.spec.ts
+++ b/src/canvas/__tests__/zoomLegibilitySingleSource.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * "At this zoom a label is legible" is ONE number. Enforced structurally.
+ *
+ * THE DEFECT THIS CLOSES: `LodSync.LOD_ZOOM_THRESHOLD = 0.5` and
+ * `cameraComfort.MIN_READABLE_ZOOM = 0.5` were two hand-written literals in
+ * two files, each commented as meaning "labels are/aren't readable here".
+ * They agreed by luck, and nothing would have gone red when they stopped —
+ * CLAUDE.md trap 12, the dominant defect class in this programme. A test
+ * asserting `MIN_READABLE_ZOOM === LABEL_LEGIBLE_ZOOM` would be a TAUTOLOGY
+ * once both derive from the one constant; it is the derivation that is the
+ * guarantee, so what has to be guarded is that nobody restates the number.
+ *
+ * THE RULE: across non-test sources under `src/canvas`, exactly ONE zoom
+ * constant may be initialised from a bare numeric literal, and it must be
+ * `LABEL_LEGIBLE_ZOOM` in `utils/zoomLegibility.ts`. Every other zoom
+ * constant must be initialised from an expression (i.e. derived).
+ *
+ * DERIVED, NOT MIRRORED: there is no allowlist of known-good files here — an
+ * allowlist is the same hand-maintained mirror the rule exists to kill. The
+ * expected set is computed from the sources themselves, so a THIRD literal
+ * introduced under any new name (`READABLE_ZOOM`, `LABEL_ZOOM_MIN`, …) fails
+ * this spec on the day it is written.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { blankNonCode } from '../../../tests/helpers/stripSourceComments'
+
+const CANVAS_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const EXCLUDED_DIR_NAMES = new Set(['__tests__', '__fixtures__', '__helpers__', '__mocks__'])
+
+/** The one file allowed to state the number, and the one name it may use. */
+const SINGLE_SOURCE_FILE = 'utils/zoomLegibility.ts'
+const SINGLE_SOURCE_NAME = 'LABEL_LEGIBLE_ZOOM'
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (!EXCLUDED_DIR_NAMES.has(entry)) out.push(...sourceFiles(full))
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue
+    if (/\.(spec|test)\.(ts|tsx)$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+/**
+ * Every `const <NAME_WITH_ZOOM> = <bare number>` in `src`. Comments and string
+ * bodies are blanked first (offset-preserving) so this file's own prose, and
+ * the doc comments that quote the old literals, do not read as declarations.
+ */
+export function findLiteralZoomConstants(src: string): string[] {
+  const code = blankNonCode(src)
+  const re = /\bconst\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*(-?\d+(?:\.\d+)?)\s*(?![\w.([])/g
+  const found: string[] = []
+  let m: RegExpExecArray | null
+  while ((m = re.exec(code)) !== null) {
+    const name = m[1]!
+    if (!/zoom/i.test(name)) continue
+    found.push(`${name} = ${m[2]}`)
+  }
+  return found
+}
+
+describe('the scan itself bites (detector contract)', () => {
+  it('catches a second hand-written legibility literal', () => {
+    expect(findLiteralZoomConstants('export const MIN_READABLE_ZOOM = 0.5')).toEqual([
+      'MIN_READABLE_ZOOM = 0.5',
+    ])
+    expect(findLiteralZoomConstants('const LOD_ZOOM_THRESHOLD = 0.5')).toEqual([
+      'LOD_ZOOM_THRESHOLD = 0.5',
+    ])
+  })
+
+  it('catches a literal introduced under a brand-new name', () => {
+    expect(findLiteralZoomConstants('const readableZoomFloor = 0.45')).toEqual([
+      'readableZoomFloor = 0.45',
+    ])
+  })
+
+  it('catches a type-annotated literal', () => {
+    expect(findLiteralZoomConstants('const LABEL_ZOOM: number = 0.5')).toEqual(['LABEL_ZOOM = 0.5'])
+  })
+
+  it('allows a DERIVED constant (an expression, not a literal)', () => {
+    expect(findLiteralZoomConstants('const MIN_READABLE_ZOOM = LABEL_LEGIBLE_ZOOM')).toEqual([])
+    expect(findLiteralZoomConstants('const LOD_ZOOM_THRESHOLD = LABEL_LEGIBLE_ZOOM * 1')).toEqual([])
+    expect(findLiteralZoomConstants('const floor = readFloor(0.5)')).toEqual([])
+  })
+
+  it('ignores non-zoom constants and prose', () => {
+    expect(findLiteralZoomConstants('const COMFORT_SLACK_PX = 8')).toEqual([])
+    expect(findLiteralZoomConstants('// const MIN_READABLE_ZOOM = 0.5')).toEqual([])
+    expect(findLiteralZoomConstants('const doc = "const MIN_READABLE_ZOOM = 0.5"')).toEqual([])
+  })
+})
+
+describe('one legibility number under src/canvas', () => {
+  it('no source but zoomLegibility.ts states a zoom threshold as a literal', () => {
+    const violations: string[] = []
+    let singleSourceDeclarations: string[] = []
+
+    for (const file of sourceFiles(CANVAS_ROOT)) {
+      const rel = relative(CANVAS_ROOT, file)
+      const literals = findLiteralZoomConstants(readFileSync(file, 'utf8'))
+      if (rel === SINGLE_SOURCE_FILE) {
+        singleSourceDeclarations = literals
+        continue
+      }
+      for (const decl of literals) violations.push(`${rel} → ${decl}`)
+    }
+
+    expect(violations).toEqual([])
+    // …and the one permitted statement really is there, under the expected
+    // name. Without this the rule would also be "satisfied" by deleting the
+    // constant entirely.
+    expect(singleSourceDeclarations).toHaveLength(1)
+    expect(singleSourceDeclarations[0]).toMatch(new RegExp(`^${SINGLE_SOURCE_NAME} = `))
+  })
+})

--- a/src/canvas/components/LodSync.tsx
+++ b/src/canvas/components/LodSync.tsx
@@ -11,12 +11,20 @@
 import { useEffect } from 'react'
 import { useStore } from '@xyflow/react'
 import { useCanvasStore } from '../store'
+import { LABEL_LEGIBLE_ZOOM, labelsRenderedAtZoom } from '../utils/zoomLegibility'
 
-/** Below this zoom, full node cards are unreadable soup — simplify (D2). */
-export const LOD_ZOOM_THRESHOLD = 0.5
+/**
+ * Below this zoom, full node cards are unreadable soup — simplify (D2).
+ *
+ * DERIVED, never restated: this used to be its own hand-written `0.5`, twinned
+ * with `cameraComfort.MIN_READABLE_ZOOM`. They agreed by luck, and the
+ * post-draft auto-fit was floored by neither — the 25 Jul blank-first-view
+ * defect. The number now lives once, in `utils/zoomLegibility.ts`.
+ */
+export const LOD_ZOOM_THRESHOLD = LABEL_LEGIBLE_ZOOM
 
 export function isLodZoom(zoom: number): boolean {
-  return zoom < LOD_ZOOM_THRESHOLD
+  return !labelsRenderedAtZoom(zoom)
 }
 
 export function LodSync() {

--- a/src/canvas/hooks/useFitViewOnLayoutVersion.ts
+++ b/src/canvas/hooks/useFitViewOnLayoutVersion.ts
@@ -20,9 +20,13 @@ import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
  *
  * THE FLOOR — why it is here and only here. This is the product choosing the
  * first view for the user, and unfloored it chose an unreadable one: on
- * deployed staging an 18-node first draft auto-fitted to 0.4331, below the
- * level-of-detail threshold, so 16 of 18 titles and every node body rendered
- * `visibility: hidden`. `minZoom` is honoured by xyflow — `fitViewport` passes
+ * deployed staging a 19-node first draft auto-fitted to 0.4456 and an 18-node
+ * saved-example template to 0.4509 — both below the level-of-detail threshold,
+ * so 16 of 18 (resp. 15 of 17) titles and EVERY node body rendered
+ * `visibility: hidden`. The landing zoom is a function of node count and pane
+ * size, which is why the fix floors the fit rather than moving a threshold:
+ * lowering the threshold to suit one graph leaves the next one unreadable.
+ * `minZoom` is honoured by xyflow — `fitViewport` passes
  * `options?.minZoom` into `getViewportForBounds`, which does
  * `clamp(zoom, minZoom, maxZoom)` and re-centres on the clamped zoom
  * (@xyflow/system 0.0.76); it clamps and re-frames, it does not no-op. The

--- a/src/canvas/hooks/useFitViewOnLayoutVersion.ts
+++ b/src/canvas/hooks/useFitViewOnLayoutVersion.ts
@@ -4,17 +4,31 @@ import { useCanvasStore } from '../store'
 import { computeFitPadding } from '../utils/computeFitPadding'
 import { usePrefersReducedMotion } from './usePrefersReducedMotion'
 import { cameraDuration } from '../utils/cameraMotion'
+import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
 
 /**
  * Schedule a single RAF-synchronised fitView every time `layoutVersion`
  * increments. Each successful `applyLayout` bumps `layoutVersion`, so
  * this hook fits the viewport exactly once per completed layout.
  *
- * The contract is `{ padding: computeFitPadding(), duration: 400 }`:
- * panel-aware per-side padding (reserves the OutputsDock / LeftSidebar so the
- * graph frames into the visible canvas, clear of those panels) plus the 400ms
- * duration asserted by the lifecycle integration test. With nothing occluding,
- * `computeFitPadding()` reproduces the prior `padding: 0.2` framing exactly.
+ * The contract is `{ padding: computeFitPadding(), minZoom: LABEL_LEGIBLE_ZOOM,
+ * duration: 400 }`: panel-aware per-side padding (reserves the OutputsDock /
+ * LeftSidebar so the graph frames into the visible canvas, clear of those
+ * panels), the legibility floor, plus the 400ms duration asserted by the
+ * lifecycle integration test. With nothing occluding, `computeFitPadding()`
+ * reproduces the prior `padding: 0.2` framing exactly.
+ *
+ * THE FLOOR — why it is here and only here. This is the product choosing the
+ * first view for the user, and unfloored it chose an unreadable one: on
+ * deployed staging an 18-node first draft auto-fitted to 0.4331, below the
+ * level-of-detail threshold, so 16 of 18 titles and every node body rendered
+ * `visibility: hidden`. `minZoom` is honoured by xyflow — `fitViewport` passes
+ * `options?.minZoom` into `getViewportForBounds`, which does
+ * `clamp(zoom, minZoom, maxZoom)` and re-centres on the clamped zoom
+ * (@xyflow/system 0.0.76); it clamps and re-frames, it does not no-op. The
+ * canvas instance's own `minZoom={0.1}` still lets the USER go lower by hand,
+ * which is the intended asymmetry: the user may choose the overview, the
+ * product may not choose it for them. See `utils/zoomLegibility.ts`.
  *
  * Must be called inside a ReactFlowProvider (uses `useReactFlow`).
  */
@@ -34,7 +48,11 @@ export function useFitViewOnLayoutVersion(): void {
   useEffect(() => {
     if (layoutVersion === 0) return
     const raf = requestAnimationFrame(() => {
-      fitViewRef.current({ padding: computeFitPadding(), duration: cameraDuration(400, reducedMotionRef.current) })
+      fitViewRef.current({
+        padding: computeFitPadding(),
+        minZoom: LABEL_LEGIBLE_ZOOM,
+        duration: cameraDuration(400, reducedMotionRef.current),
+      })
     })
     return () => cancelAnimationFrame(raf)
   }, [layoutVersion])

--- a/src/canvas/utils/cameraComfort.ts
+++ b/src/canvas/utils/cameraComfort.ts
@@ -19,9 +19,15 @@
  */
 
 import { computeFitPadding, type FitPadding } from './computeFitPadding'
+import { LABEL_LEGIBLE_ZOOM } from './zoomLegibility'
 
-/** Below this zoom a node's label is not readably rendered — never "comfortable". */
-export const MIN_READABLE_ZOOM = 0.5
+/**
+ * Below this zoom a node's label is not readably rendered — never "comfortable".
+ *
+ * DERIVED, never restated: this was its own hand-written `0.5`, twinned with
+ * `LodSync.LOD_ZOOM_THRESHOLD`. One number, one home — `./zoomLegibility`.
+ */
+export const MIN_READABLE_ZOOM = LABEL_LEGIBLE_ZOOM
 /** Forgives animation-end drift and lets an exactly-fitted frame count as comfortable. */
 export const COMFORT_SLACK_PX = 8
 /** Fallbacks for nodes that have not reported measured dimensions yet. */

--- a/src/canvas/utils/zoomLegibility.ts
+++ b/src/canvas/utils/zoomLegibility.ts
@@ -1,0 +1,56 @@
+/**
+ * zoomLegibility — THE single definition of "at this zoom, a node label is
+ * rendered and readable". Every rule in the product that has to agree about
+ * legibility derives from the constant below; none of them may restate it.
+ *
+ * WHY THIS MODULE EXISTS (live defect, deployed staging `039f479a`, 25 Jul
+ * 2026, measured in a real browser): after a ~60 s first draft the canvas
+ * auto-fitted an 18-node model to **0.4331** zoom and the payoff moment was a
+ * page of blank rectangles — **16 of 18 node titles** and **all 18 node
+ * bodies** resolved to `visibility: hidden`. The same defect fires on the
+ * templates entry path (measured **0.45**). Nothing was broken in isolation;
+ * three rules simply disagreed, and nothing made them agree:
+ *
+ *   - `LodSync` hid every non-goal/decision label below **0.5** zoom.
+ *   - `cameraComfort` separately declared **0.5** the readable floor, as its
+ *     own hand-written literal.
+ *   - the post-layout auto-fit (`useFitViewOnLayoutVersion`) had **no floor at
+ *     all**, so it was free to park the camera inside the band the product
+ *     itself calls unreadable.
+ *
+ * The landing zoom is a function of node count and pane size — it is not a
+ * number to dial. Lowering the LOD threshold to suit an 18-node graph would
+ * leave the next one (20+ nodes, fitting near 0.31) unreadable again, because
+ * the fit target would still be unconstrained. The floor has to come from the
+ * legibility rule itself.
+ *
+ * Two same-meaning literals maintained by hand in two files is the dominant
+ * defect class in this codebase (CLAUDE.md trap 12): they agreed on the day
+ * they were written and nothing would have gone red when they stopped. So the
+ * number lives here exactly once and everything else imports it —
+ * `zoomLegibilitySingleSource.spec.ts` fails the moment a second literal
+ * appears under any name.
+ *
+ * DOCTRINE (what the constant licenses, and what it does not):
+ *   - The product must never AUTOMATICALLY park the camera below this zoom.
+ *     An auto-fit is the product choosing a view for the user; choosing an
+ *     unreadable one is a bug. Hence `useFitViewOnLayoutVersion` passes this
+ *     value as `fitView`'s `minZoom`.
+ *   - The USER may go below it deliberately — scroll-zoom, the zoom-out
+ *     control, or an explicit "fit to view" on a graph too big to read. Below
+ *     the floor the level-of-detail view is the honest, intended rendering:
+ *     structure without labels. Explicit user gestures are NOT clamped, so
+ *     `ReactFlowGraph.handleFitView`, `CanvasToolbar`'s fit button and the
+ *     command palette's "Zoom to Fit" stay unfloored by design.
+ */
+
+/**
+ * Below this zoom node labels are hidden (level-of-detail); at or above it they
+ * render. The one number; do not restate it anywhere else.
+ */
+export const LABEL_LEGIBLE_ZOOM = 0.5
+
+/** True when node labels are rendered at this zoom. */
+export function labelsRenderedAtZoom(zoom: number): boolean {
+  return zoom >= LABEL_LEGIBLE_ZOOM
+}

--- a/src/canvas/utils/zoomLegibility.ts
+++ b/src/canvas/utils/zoomLegibility.ts
@@ -5,11 +5,12 @@
  *
  * WHY THIS MODULE EXISTS (live defect, deployed staging `039f479a`, 25 Jul
  * 2026, measured in a real browser): after a ~60 s first draft the canvas
- * auto-fitted an 18-node model to **0.4331** zoom and the payoff moment was a
+ * auto-fitted a 19-node model to **0.4456** zoom and the payoff moment was a
  * page of blank rectangles — **16 of 18 node titles** and **all 18 node
  * bodies** resolved to `visibility: hidden`. The same defect fires on the
- * templates entry path (measured **0.45**). Nothing was broken in isolation;
- * three rules simply disagreed, and nothing made them agree:
+ * templates entry path: an 18-node saved example at **0.4509**, 15 of 17
+ * titles and all 17 bodies hidden. Nothing was broken in isolation; three
+ * rules simply disagreed, and nothing made them agree:
  *
  *   - `LodSync` hid every non-goal/decision label below **0.5** zoom.
  *   - `cameraComfort` separately declared **0.5** the readable floor, as its

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -66,7 +66,11 @@ export const OVERVIEW_COPY = {
     'Help me check whether this decision classification is right and how it should affect the process.',
   goalNoteMissing: 'Success measure missing',
   capturedInBrief: 'Captured in brief',
-  notCaptured: 'Not captured yet',
+  // 'Not captured yet' is RETIRED — it was rendered by both the Context and
+  // the Constraints chip and was wrong on each, in opposite ways. See the
+  // chip-note derivation below. Its absence is pinned by
+  // DecisionOverviewCard.spec.tsx, which asserts the literal sentence.
+  constraintsNoteEmpty: 'No limits on record',
   optionsNoteEmpty: 'No options mapped yet',
   // V6-RESPEC §4: empty classification fields fold into ONE muted aggregate
   // chip ("+N to set") — collapsed shows what IS, never a per-field inventory
@@ -316,16 +320,42 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
       : goalThreshold == null
         ? OVERVIEW_COPY.goalNoteMissing
         : `Success target ≥ ${formatTargetValue(goalThreshold, unit, symbol)}`
-  const contextNote = briefPresent ? OVERVIEW_COPY.capturedInBrief : OVERVIEW_COPY.notCaptured
+  // CONTEXT — no claim, rather than a false denial.
+  //
+  // `currentBriefText` has exactly ONE non-null writer in the whole of src/:
+  // ChatComposer.tsx, mirroring the AI-panel composer's own textarea on a
+  // 500 ms debounce (so it also reverts to null the moment that composer
+  // clears on send). The live first-draft surface is FirstUseComposer →
+  // AIInputBar, which contains ZERO references to the field. Live-confirmed
+  // on deployed staging: the store read `currentBriefText: null` with a
+  // 470-character brief on screen and a drafted graph behind it.
+  //
+  // So a falsy read carries no information about whether the user gave any
+  // context — it is a dead read on the path that matters, and rendering
+  // "Not captured yet" denied something the user plainly did. When the field
+  // IS populated the claim is truthful and stays; otherwise the chip makes no
+  // factual claim at all and remains a "Review Context" affordance. A capture
+  // signal is deliberately NOT synthesised from the transcript: transcriptStore
+  // is scenario-scoped, so the chip would flip on reload.
+  const contextNote = briefPresent ? OVERVIEW_COPY.capturedInBrief : null
+  // CONSTRAINTS — the read is right; only the sentence was wrong.
+  //
+  // `goalConstraints` is genuinely producer-fed (applyDraftResult writes CEE's
+  // `draft_graph.goal_constraints`; applyV5State writes add_constraint
+  // patches), so a zero count is TRUE — about STRUCTURED goal constraints.
+  // What it never licensed was "Not captured yet", a claim about the user's
+  // own input: CEE demonstrably reads soft constraints out of the brief and
+  // says so in its coaching while deliberately not encoding them as limits.
+  // The note therefore describes the record, not the user.
   const constraintsNote =
     constraintCount > 0
       ? `${constraintCount} ${constraintCount === 1 ? 'limit' : 'limits'} captured`
-      : OVERVIEW_COPY.notCaptured
+      : OVERVIEW_COPY.constraintsNoteEmpty
   const optionsNote =
     optionCount > 0
       ? `${optionCount} ${optionCount === 1 ? 'option' : 'options'} mapped`
       : OVERVIEW_COPY.optionsNoteEmpty
-  const chips: Array<{ dim: Dimension; note: string; dotTone: string }> = [
+  const chips: Array<{ dim: Dimension; note: string | null; dotTone: string }> = [
     // Dot borders track brief QUALITY per the prototype (Goal warns only in
     // thin, Options flags only in the fixture conflict state) — success-
     // outlined otherwise.
@@ -422,7 +452,11 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
                 />
                 <span className="min-w-0">
                   <span className={`${typography.panelBody} block font-semibold text-text-header`}>{dim}</span>
-                  <span className={`${typography.panelMeta} block truncate text-text-light`}>{note}</span>
+                  {/* A null note renders NOTHING — not an empty line. Silence is
+                      the honest state for a dimension we cannot speak to. */}
+                  {note !== null && (
+                    <span className={`${typography.panelMeta} block truncate text-text-light`}>{note}</span>
+                  )}
                 </span>
               </button>
             ))}

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
@@ -23,6 +23,13 @@ function flagOn() {
   localStorage.setItem('feature.decisionOverview', '1')
 }
 
+/**
+ * The retired sentence, spelled out as the user read it on staging. Kept as a
+ * literal (not a copy-object reference) so removing the constant from
+ * production cannot silently turn the absence assertions into no-ops.
+ */
+const FALSE_DENIAL = 'Not captured yet'
+
 const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
 const NEEDS_INPUT = {
   status: 'needs_user_input',
@@ -240,11 +247,48 @@ describe('DecisionOverviewCard — brief-dimension chips', () => {
     expect(screen.getByTestId('brief-dim-constraints')).toHaveTextContent('1 limit captured')
   })
 
-  it('Context and Constraints chips fail closed to "Not captured yet"', () => {
+  /**
+   * The two chips were wrong in OPPOSITE ways and take opposite fixes.
+   *
+   * Context — `currentBriefText` is a DEAD READ on the live first-draft path.
+   * Its only non-null writer is ChatComposer (the AI-panel composer's own
+   * textarea, 500 ms debounced); the live first-use composer is
+   * FirstUseComposer → AIInputBar, which contains ZERO references to the
+   * field. Live-confirmed on deployed staging: `currentBriefText: null` with
+   * a 470-character brief on screen. So "Not captured yet" was a FALSE DENIAL
+   * produced by a dead read — the honest move is to make no claim at all.
+   *
+   * Constraints — `goalConstraints` IS producer-fed (applyDraftResult writes
+   * CEE's `draft_graph.goal_constraints`). Zero really does mean zero, so the
+   * READ stays; only the SENTENCE was wrong. It must describe the record
+   * ("no structured limits"), never deny that the user said something.
+   */
+  it('Context chip makes NO claim when the (dead-on-the-live-path) brief field is empty', () => {
     render(<DecisionOverviewCard title="t" />)
     fireEvent.click(screen.getByTestId('brief-bar'))
-    expect(screen.getByTestId('brief-dim-context')).toHaveTextContent(OVERVIEW_COPY.notCaptured)
-    expect(screen.getByTestId('brief-dim-constraints')).toHaveTextContent(OVERVIEW_COPY.notCaptured)
+    const chip = screen.getByTestId('brief-dim-context')
+    // The chip survives as a "Review Context" affordance…
+    expect(chip).toHaveTextContent('Context')
+    // …but it no longer denies the user captured anything.
+    expect(chip).not.toHaveTextContent(FALSE_DENIAL)
+    expect(chip.textContent?.trim()).toBe('Context')
+  })
+
+  it('Constraints chip states the RECORD, never a denial of the user\'s input', () => {
+    render(<DecisionOverviewCard title="t" />)
+    fireEvent.click(screen.getByTestId('brief-bar'))
+    const chip = screen.getByTestId('brief-dim-constraints')
+    expect(chip).toHaveTextContent(OVERVIEW_COPY.constraintsNoteEmpty)
+    expect(chip).not.toHaveTextContent(FALSE_DENIAL)
+  })
+
+  it('the false-denial sentence is gone from the card entirely', () => {
+    // The one string both chips shared. Neither may use it: one chip must stay
+    // silent, the other must describe the record. Asserted as the literal the
+    // user would read, so deleting the copy constant cannot make this vacuous.
+    render(<DecisionOverviewCard title="t" />)
+    fireEvent.click(screen.getByTestId('brief-bar'))
+    expect(screen.getByTestId('decision-overview')).not.toHaveTextContent(FALSE_DENIAL)
   })
 
   it('chip click opens the drawer with the dimension-strengthen ask (lower-cased dimension)', () => {


### PR DESCRIPTION
Lands the diagnosis a prior lane reproduced live but shipped no code for. Both defects are in what a user sees in the **first ten seconds after a draft**.

## Defect A — the payoff moment was a page of blank boxes

Measured in a real browser on deployed staging `039f479a`: an 18-node first draft auto-fitted to **0.4331** zoom, so **16 of 18 node titles and all 18 node bodies** resolved to `visibility: hidden`. The **templates entry path lands at 0.45** and was hit the same way (not covered by the original journey).

Three rules decided this and nothing made them agree:

| Rule | File | Before |
|---|---|---|
| hide every node label below this zoom | `LodSync.tsx:16` | `LOD_ZOOM_THRESHOLD = 0.5` (literal) |
| a label is not readably rendered below this zoom | `cameraComfort.ts:24` | `MIN_READABLE_ZOOM = 0.5` (literal) |
| the zoom the auto-fit lands on | `useFitViewOnLayoutVersion.ts` | **no floor at all** |

**Fix shape is derive, not two aligned numbers** (CLAUDE.md trap 12). New `src/canvas/utils/zoomLegibility.ts` owns `LABEL_LEGIBLE_ZOOM` once; `LodSync` and `cameraComfort` derive from it (**both literals deleted**); the auto-fit passes `minZoom: LABEL_LEGIBLE_ZOOM`.

**Only the AUTO-fit is floored.** The three user-invoked fit sites (`ReactFlowGraph.handleFitView`, `CanvasToolbar`, CommandPalette "Zoom to Fit") stay unclamped: the product may not choose an unreadable view for the user, but the user may choose one for themselves.

Verified at the dependency bytes (`@xyflow/system@0.0.76`): `fitViewport` forwards `options?.minZoom` into `getViewportForBounds`, which does `clamp(zoom, minZoom, maxZoom)` and re-centres on the clamped zoom. It clamps and re-frames — it does not no-op. Instances declare `minZoom={0.1} maxZoom={4}`, so the user can still zoom out by hand.

## Defect B — the status panel was wrong in two OPPOSITE ways

**Context chip — a dead read making a false denial.** Complete writer manifest for `currentBriefText` across `src/` is **one** non-null site (`ChatComposer.tsx:171`, the AI-panel composer mirroring its own textarea on a 500 ms debounce) plus two null resets. The live first-draft composer is `FirstUseComposer` → `AIInputBar`, which has **zero** references to the field — confirmed live: `currentBriefText: null` with a 470-character brief on screen. The chip now makes **no claim at all** when the field is empty (a null note renders nothing, not an empty line) and keeps "Captured in brief" only where that is true.

**Constraints chip — a live read whose sentence overclaimed.** `goalConstraints` IS producer-fed, so a zero count is a **true** fact about *structured* goal constraints. Only the sentence was wrong: "Not captured yet" is a claim about the user's input, and CEE demonstrably reads soft constraints out of the brief. **Copy only:** "No limits on record". `OVERVIEW_COPY.notCaptured` is deleted — neither chip may use it.

## Guards (both derive; neither is a tautology)

- `autoFitLegibility.spec.tsx` feeds the captured `minZoom` through **`isLodZoom`, LodSync's own predicate imported from the other module**. The `typeof === 'number'` assertion is load-bearing — see below.
- `zoomLegibilitySingleSource.spec.ts` scans non-test `src/canvas` (comments/strings blanked via the repo's `blankNonCode`) and fails if any file but `zoomLegibility.ts` states a zoom threshold as a literal, **under any name**. **No allowlist** — an allowlist is the mirror this rule exists to kill.

Both carry detector-contract positive controls (the `cameraMotion.sourceScan` precedent).

**A defect found in the handed-over design by running it:** the proposed guard was exactly `assert isLodZoom(captured.minZoom) === false`. That is **vacuous against the regression it was written for** — `isLodZoom` was `zoom < 0.5` and `undefined < 0.5` is `false`, so a dropped `minZoom` passes. Confirmed empirically on pristine staging: that assertion **passed**; only the type assertion went red.

**Undisclosed collateral found and fixed:** the handover named one exact-contract `fitView` assertion. There were **four** — the other three are in `ReactFlowGraph.layoutLifecycle.integration.spec.tsx` (`:183`, `:255`, `:300`).

## Evidence

- RED-first captured on pristine staging before any fix.
- Local: repo typecheck gate **PASSED** (ratchet 2661 vs baseline 2663), eslint clean, **94/94** targeted tests green across the new specs and every touched consumer.
- **Mutation-checked in a throwaway worktree with a sanity-checked runner (56/56 green before mutating): 7/7 mutations bite** — dropping `minZoom`, hardcoding a lower floor, restoring either literal, raising the LOD threshold without the floor, and restoring either false denial.
- Live acceptance on deployed staging, both entry paths, with positive controls: recorded in `parallel-briefs/FIRST-VIEW-LANDED-2026-07-25.md`.

**Typecheck baseline notice declined deliberately** — the −2 drift is pre-existing and regenerating the baseline would bundle an unrelated repo-wide edit into a first-view fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)