### PR TITLE
fix(results): the answer survives leaving the canvas and coming back

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -68,6 +68,7 @@ import { useLensFilter } from './hooks/useLensFilter'
 import { useGuidancePulseHighlight } from './hooks/useGuidancePulseHighlight'
 import { useEscapePanel } from './hooks/useEscapePanel'
 import { loadRuns, generateGraphHash } from './store/runHistory'
+import { restoreAnalysisFromAutosave } from './store/restoreAnalysisFromAutosave'
 // HealthStatusBar removed - validation consolidated into OutputsDock panel
 import { DegradedBanner } from './components/DegradedBanner'
 import { LayoutProgressBanner } from './components/LayoutProgressBanner'
@@ -1439,9 +1440,23 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
           sessionStorage.setItem('autosave-recovery-dismissed', 'true')
         } catch { /* sessionStorage not available */ }
 
-        // Restore results: try scenario hash first, then fall back to graphHash matching
-        let resultsRestored = false
-        if (autosave.scenarioId) {
+        // ⭐ CANONICAL FIRST: the answer travels IN this autosave record, beside
+        // the graph it was computed over and written in the same
+        // `resultsComplete` call. See store/scenarios.ts `PersistedAnalysis`.
+        //
+        // The two paths below it are the legacy re-derivations and BOTH are
+        // dead on the deployed guest path — live-probed 26 Jul after a real
+        // conversation-driven analysis, `olumi-canvas-scenarios` and
+        // `olumi-canvas-run-history` are BOTH absent, so the scenario lookup
+        // finds no record and the graphHash scan iterates an empty array.
+        // They are kept only for records written before this shipped
+        // (an autosave with no `analysis` key), and are now strictly
+        // subordinate: a canonical hit is never overwritten by a hash guess.
+        let resultsRestored = restoreAnalysisFromAutosave(
+          autosave,
+          useCanvasStore.getState().resultsLoadHistorical,
+        )
+        if (!resultsRestored && autosave.scenarioId) {
           const savedScenario = scenarios.getScenario(autosave.scenarioId)
           if (savedScenario?.last_result_hash) {
             try {

--- a/src/canvas/__tests__/analysisSurvivesLeaveAndReturn.spec.ts
+++ b/src/canvas/__tests__/analysisSurvivesLeaveAndReturn.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * THE ANSWER MUST SURVIVE LEAVING AND COMING BACK.
+ *
+ * THE DEFECT THIS PINS — reproduced 1/1 on DEPLOYED staging (bundle
+ * `index-BlVFnI6e.js`, 26 Jul 2026), by running a real conversation-driven
+ * analysis, navigating to the Olumi home screen and returning via "Continue
+ * without an account":
+ *
+ *   before leaving  results.status = 'complete', report present (20,644 B),
+ *                   hash 'v5:c9185f4c9c602851', "Buy Freehold Unit Outright
+ *                   currently leads by 78 percentage points" on screen
+ *   after returning 19 nodes restored, results.status = 'idle', no report,
+ *                   hasCompletedFirstRun = false, "Analyse first pass" on screen
+ *
+ * The chat still showed the assistant stating the answer while the Results panel
+ * claimed nothing had been run.
+ *
+ * TWO DEAD LINKS, both live-probed in the same session:
+ *   1. the WRITE — run history is gated on a SEED, and the live V5 path has
+ *      none (`'seed' in results === false`; `olumi-canvas-run-history` absent);
+ *   2. the POINTER — `last_result_hash` is written onto a SCENARIO record that
+ *      guest mode never creates (`olumi-canvas-scenarios` absent).
+ *
+ * THE FIX these tests pin: the completed analysis rides the ONE record that
+ * demonstrably survives and is demonstrably read back at boot — the autosave —
+ * and is restored from there. See store/scenarios.ts `PersistedAnalysis`.
+ *
+ * ⚠ CLAIM TYPE, stated precisely because this exact defect was once reported
+ * fixed on the strength of a store test that was inert on the deployed path
+ * (see store.conversationRunSurvivesReload.spec.ts's own header):
+ *   - These tests DO prove the live PRODUCER (`applyV5State`, the real handler
+ *     for the `analysis_result` block) drives the real store, that the answer
+ *     lands in the real `localStorage` autosave slot, and that the restore
+ *     helper the boot path calls puts it back.
+ *   - They do NOT prove ReactFlowGraph's mount effect calls that helper, and
+ *     they are NOT a rendering or visibility claim. jsdom cannot establish
+ *     either. Those are evidenced ONLY by the live deployed leave-and-return
+ *     recorded in the PR description.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useCanvasStore } from '../store'
+import { loadAutosave, saveAutosave, type AutosaveData } from '../store/scenarios'
+import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
+import { restoreAnalysisFromAutosave } from '../store/restoreAnalysisFromAutosave'
+import { loadRuns } from '../store/runHistory'
+import { deriveStageFromState } from '../hooks/useStagePill'
+import { applyV5State, type V5ApplicatorStore } from '../../v5/applyV5State'
+import type { ReportV1 } from '../../adapters/plot/types'
+
+const AUTOSAVE_KEY = 'olumi-canvas-autosave'
+
+/** The live V5 analysis_result block shape (captured from staging). */
+const analysisBlock = {
+  type: 'analysis_result' as const,
+  summary: 'Buy Freehold Unit Outright currently leads by 78 percentage points.',
+  leading_option_id: 'opt_freehold',
+  win_probabilities: { opt_freehold: 0.86, opt_relocate: 0.08, opt_renew: 0.06 },
+  enrichment: {
+    factor_sensitivity: [
+      {
+        factor_id: 'fac_retention',
+        factor_label: 'Patient Retention Rate at Site',
+        sensitivity: 0.75,
+        direction: 'positive' as const,
+      },
+    ],
+  },
+}
+
+function v5Response(blocks: unknown[]) {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks,
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+  } as never
+}
+
+function graphNodes() {
+  return [
+    { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Patient Retention' } },
+    { id: 'n2', type: 'option', position: { x: 200, y: 0 }, data: { label: 'Buy Freehold' } },
+  ] as never
+}
+
+/**
+ * The applicator store, built from the REAL canvas store — not a double.
+ *
+ * This is the point of the test: `applyV5State` is the LIVE handler
+ * (applyV5State.ts step 5) and `resultsComplete` here is the real action, so
+ * the chain producer → store → localStorage is the deployed one, not a mock of
+ * it. A `vi.fn()` double would have passed against the broken code too.
+ */
+function realApplicatorStore(): V5ApplicatorStore {
+  const s = useCanvasStore.getState()
+  return {
+    setCurrentStage: s.setCurrentStage,
+    updateNode: s.updateNode,
+    updateEdgeData: s.updateEdgeData,
+    setRunMeta: s.setRunMeta,
+    setCeeAnalysisReady: s.setCeeAnalysisReady,
+    setAnalysisFreshness: s.setAnalysisFreshness,
+    resultsComplete: s.resultsComplete,
+    nodes: s.nodes,
+    edges: s.edges,
+    currentResultsHash: s.results.hash ?? null,
+  } as V5ApplicatorStore
+}
+
+/**
+ * `summary` is not declared on `ReportV1` — it rides the runtime payload and
+ * the store itself reads it through an index cast (store.ts's robustness
+ * probe). Same pattern here rather than asserting a field the type does not
+ * have; it is the value the user sees, so the test reads it honestly.
+ */
+function reportSummary(report: unknown): unknown {
+  return (report as Record<string, unknown> | null | undefined)?.summary
+}
+
+/** Everything the deployed leave-and-return destroys: a brand-new page load. */
+function simulateReturnToAFreshPage(): void {
+  useCanvasStore.setState({
+    results: { status: 'idle', progress: 0 },
+    hasCompletedFirstRun: false,
+    nodes: [],
+    edges: [],
+  } as never)
+}
+
+describe('a completed analysis survives leaving the canvas and returning', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCanvasStore.setState({
+      nodes: graphNodes(),
+      edges: [] as never,
+      results: { status: 'idle', progress: 0 },
+      currentScenarioId: 'c475a0c1-fb3c-448e-b3ef-91ae5cd01f8d',
+      hasCompletedFirstRun: false,
+    } as never)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('POSITIVE CONTROL — the probe sees the ABSENT case: no analysis run ⇒ nothing restored', () => {
+    // Prove this spec can observe the failure it later asserts is gone.
+    // Without this, "results.status === complete" after the fix would be
+    // unfalsifiable (CLAUDE.md trap #13).
+    saveAutosave(
+      projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState() as never)),
+    )
+    const stored = loadAutosave()
+    expect(stored).toBeTruthy()
+    expect(stored?.analysis ?? null).toBeNull()
+
+    simulateReturnToAFreshPage()
+    const restored = restoreAnalysisFromAutosave(
+      stored,
+      useCanvasStore.getState().resultsLoadHistorical,
+    )
+    expect(restored).toBe(false)
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+  })
+
+  it('the LIVE V5 path persists the answer into the autosave record', () => {
+    // Exactly the deployed sequence: resultsAnalysing (never resultsStart, so
+    // no seed), then applyV5State's analysis_result branch.
+    useCanvasStore.getState().resultsAnalysing()
+    expect(useCanvasStore.getState().results.seed).toBeUndefined()
+
+    applyV5State(v5Response([analysisBlock]), realApplicatorStore())
+
+    expect(useCanvasStore.getState().results.status).toBe('complete')
+
+    const stored = loadAutosave()
+    expect(stored?.analysis).toBeTruthy()
+    expect(stored?.analysis?.report).toBeTruthy()
+    expect(stored?.analysis?.hash).toBe(useCanvasStore.getState().results.hash)
+    expect(stored?.analysis?.resultsSource).toBe('conversation')
+    expect(typeof stored?.analysis?.computedAt).toBe('string')
+  })
+
+  it('⭐ the returning user gets the ANSWER back, not "Analyse first pass"', () => {
+    useCanvasStore.getState().resultsAnalysing()
+    applyV5State(v5Response([analysisBlock]), realApplicatorStore())
+    const hashBefore = useCanvasStore.getState().results.hash
+    const summaryBefore = reportSummary(useCanvasStore.getState().results.report)
+
+    // The journey: the page goes away, localStorage does not.
+    simulateReturnToAFreshPage()
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+
+    const restored = restoreAnalysisFromAutosave(
+      loadAutosave(),
+      useCanvasStore.getState().resultsLoadHistorical,
+    )
+
+    expect(restored).toBe(true)
+    const after = useCanvasStore.getState()
+    // 'complete' vs 'idle' is exactly what the Results panel branches on:
+    // 'idle' renders the "Analysis available / Analyse first pass" state.
+    expect(after.results.status).toBe('complete')
+    expect(after.results.hash).toBe(hashBefore)
+    expect(reportSummary(after.results.report)).toBe(summaryBefore)
+    expect(after.hasCompletedFirstRun).toBe(true)
+  })
+
+  it('the stage stops regressing to Ideate — it follows from the restored result', () => {
+    // The reported symptom "the stage regresses from Evaluate/Analyse back to
+    // Ideate/Frame" is a CONSEQUENCE, not a separate thing to persist:
+    // useStagePill falls back to deriveStageFromState(hasNodes, isComplete)
+    // where isComplete = status==='complete' || hasCompletedFirstRun. Pinned
+    // here so nobody "fixes" it by persisting `currentStage` separately and
+    // re-creating the divergence this lane is deleting.
+    useCanvasStore.getState().resultsAnalysing()
+    applyV5State(v5Response([analysisBlock]), realApplicatorStore())
+
+    simulateReturnToAFreshPage()
+    useCanvasStore.setState({ nodes: graphNodes() } as never)
+    expect(deriveStageFromState(true, false)).toBe('ideate') // the regression
+    restoreAnalysisFromAutosave(loadAutosave(), useCanvasStore.getState().resultsLoadHistorical)
+
+    const s = useCanvasStore.getState()
+    expect(deriveStageFromState(s.nodes.length > 0, s.results.status === 'complete')).toBe(
+      'evaluate',
+    )
+  })
+
+  it('invents NO seed — the seed-gated run history stays empty and honest', () => {
+    useCanvasStore.getState().resultsAnalysing()
+    applyV5State(v5Response([analysisBlock]), realApplicatorStore())
+
+    // A run identity built on a fabricated seed forks the graph hash
+    // (CLAUDE.md trap #10). The fix routes around the seed; it must not
+    // resurrect the seed path by defaulting one.
+    expect(loadRuns()).toHaveLength(0)
+    expect(loadAutosave()?.analysis?.seed).toBeUndefined()
+
+    simulateReturnToAFreshPage()
+    restoreAnalysisFromAutosave(loadAutosave(), useCanvasStore.getState().resultsLoadHistorical)
+    expect(useCanvasStore.getState().results.seed).toBeUndefined()
+  })
+
+  it('a later autosave write does NOT strip the answer back out', () => {
+    // saveAutosave REPLACES. Before the projection carried `analysis`, the very
+    // next graph edit would have silently overwritten the record that held the
+    // user's answer — the partial-write class that made autosaveProjection
+    // necessary in the first place (#386, ceeAnalysisReady).
+    useCanvasStore.getState().resultsAnalysing()
+    applyV5State(v5Response([analysisBlock]), realApplicatorStore())
+    expect(loadAutosave()?.analysis).toBeTruthy()
+
+    saveAutosave(
+      projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState() as never)),
+    )
+    expect(loadAutosave()?.analysis?.report).toBeTruthy()
+  })
+
+  it('a quota failure drops the ANALYSIS and keeps the GRAPH — never the reverse', () => {
+    const payloads: string[] = []
+    let first = true
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation((key: string, value: string) => {
+        if (key === AUTOSAVE_KEY) {
+          if (first) {
+            first = false
+            throw new DOMException('quota', 'QuotaExceededError')
+          }
+          payloads.push(value)
+          return
+        }
+        return
+      })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const data: AutosaveData = projectAutosaveData({
+      nodes: graphNodes(),
+      edges: [] as never,
+      scenarioId: 'sc1',
+      ceeAnalysisReady: undefined,
+      selectedGoalNode: null,
+      analysis: {
+        hash: 'v5:abc',
+        computedAt: new Date().toISOString(),
+        report: { summary: 'x' } as unknown as ReportV1,
+      },
+    })
+    saveAutosave(data)
+
+    expect(setItem).toHaveBeenCalled()
+    expect(payloads).toHaveLength(1)
+    const retried = JSON.parse(payloads[0]) as AutosaveData
+    expect(retried.nodes).toHaveLength(2) // the user's work survived
+    expect(retried.analysis).toBeNull() // the recomputable part was dropped
+    // The degradation is DECLARED, never silent.
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('a corrupt persisted analysis degrades to "no answer", not to a broken store', () => {
+    saveAutosave({
+      timestamp: Date.now(),
+      nodes: graphNodes(),
+      edges: [] as never,
+      analysis: { computedAt: 'not-a-date', report: null as never },
+    })
+    simulateReturnToAFreshPage()
+    expect(
+      restoreAnalysisFromAutosave(loadAutosave(), useCanvasStore.getState().resultsLoadHistorical),
+    ).toBe(false)
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+  })
+})

--- a/src/canvas/__tests__/store.conversationRunSurvivesReload.spec.ts
+++ b/src/canvas/__tests__/store.conversationRunSurvivesReload.spec.ts
@@ -27,6 +27,33 @@
  * this write never fires. Live acceptance recorded this as a FAIL, honestly.
  * See `parallel-briefs/RETURNING-USER-2026-07-25.md` §3.
  *
+ * ⚠⚠ STATUS UPDATE, 26 Jul 2026 — THE CORRECTION ABOVE STANDS, AND THE USER-
+ * FACING DEFECT IS NOW FIXED SOMEWHERE ELSE. Read both halves of that sentence.
+ *
+ *   - STILL TRUE: everything above. The seed-gated run-history write these
+ *     tests exercise remains INERT on the deployed V5 path. Nothing in this
+ *     file has become deployed-path evidence, and it must still never be cited
+ *     as such. Re-probed on live staging 26 Jul after a real conversation-
+ *     driven analysis: `'seed' in results === false` and
+ *     `olumi-canvas-run-history` does not exist as a key.
+ *   - NEWLY TRUE: the returning user DOES now get the answer back — via a
+ *     different mechanism that does not need a seed. The completed analysis is
+ *     persisted into the autosave record beside the graph it was computed over
+ *     (`store/scenarios.ts` → `PersistedAnalysis`) and restored from there.
+ *     A second dead link the 25 Jul pass had not found is also closed: the
+ *     `last_result_hash` POINTER was written onto a scenario record that guest
+ *     mode never creates (`olumi-canvas-scenarios` absent, live-probed), so
+ *     even a stored run could not have been found.
+ *
+ * These tests are KEPT rather than deleted: they are a valid pin on the store
+ * contract, they document the seed hazard (never fabricate one — trap #10), and
+ * they are the right shape for the day CEE echoes a run identity. They are
+ * simply not the thing that fixed the user's problem.
+ *
+ * The deployed-path evidence lives in
+ * `src/canvas/__tests__/analysisSurvivesLeaveAndReturn.spec.ts` plus the live
+ * leave-and-return acceptance recorded in that PR — not here.
+ *
  * CLAIM TYPE: this is a STORE-STATE pin (what the results panel branches on),
  * not a rendering or visibility claim, and NOT a claim about deployed behaviour.
  */

--- a/src/canvas/hooks/__tests__/useAutosave.hashByDefault.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.hashByDefault.spec.ts
@@ -88,6 +88,11 @@ describe('Codex P1-1 — hash-by-default persists previously-lost user fields', 
           edges: [],
           scenarioId: undefined,
           ceeAnalysisReady: undefined,
+          // This case is about a GRAPH field surviving serialize → hydrate.
+          // No analysis has run, so "persist no answer" is the honest value —
+          // stated rather than omitted, per AutosaveProjectionSource's
+          // all-required contract.
+          analysis: null,
           selectedGoalNode: null,
         })
         clearAutosave()

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -19,7 +19,7 @@
 import { useEffect, useRef, useCallback, useMemo } from 'react'
 import { useCanvasStore } from '../store'
 import { saveAutosave, loadAutosave } from '../store/scenarios'
-import { projectAutosaveData } from '../store/autosaveProjection'
+import { projectAutosaveData, analysisSnapshotFromStore } from '../store/autosaveProjection'
 import type { AutosaveProjectionSource } from '../store/autosaveProjection'
 import { EPHEMERAL_NODE_FIELDS, EPHEMERAL_EDGE_FIELDS } from '../domain/analyticalNodeFields'
 
@@ -185,6 +185,19 @@ export function useAutosave() {
               // before use (same justification as crashFlush's).
               ceeAnalysisReady: ceeAnalysisReady as AutosaveProjectionSource['ceeAnalysisReady'],
               selectedGoalNode,
+              // Read at WRITE time from the store, not from a subscribed
+              // selector. Two reasons, both deliberate:
+              //  1. `saveAutosave` REPLACES — if this timer wrote without the
+              //     analysis it would strip the answer `resultsComplete` had
+              //     just persisted, on the next graph edit. That is the exact
+              //     partial-write class this projection exists to prevent.
+              //  2. Subscribing to `results` here would re-render this hook on
+              //     every progress tick during a run for no benefit; the
+              //     debounced callback only needs the value as it fires.
+              // Note the timer CANNOT be the primary writer: its dirty check is
+              // computeGraphHash(nodes, edges) and a completed analysis changes
+              // neither, so it skips. `resultsComplete` does the real write.
+              analysis: analysisSnapshotFromStore(useCanvasStore.getState()),
             },
             now,
           ),

--- a/src/canvas/persist/__tests__/autosaveProjectionParity.spec.tsx
+++ b/src/canvas/persist/__tests__/autosaveProjectionParity.spec.tsx
@@ -152,6 +152,16 @@ describe('projectAutosaveData — every source field reaches the payload', () =>
     scenarioId: 'scenario-42',
     ceeAnalysisReady: analysisReady,
     selectedGoalNode: 'g2',
+    // The completed analysis (store/scenarios.ts PersistedAnalysis). Given a
+    // real value, not null, so the "every field reaches the payload" loop below
+    // actually exercises it — a null would satisfy `toBeDefined()` while
+    // proving nothing about the projection.
+    analysis: {
+      hash: 'v5:parity',
+      computedAt: '2026-07-26T00:00:00.000Z',
+      resultsSource: 'conversation',
+      report: { summary: 'parity' } as never,
+    },
   }
 
   it('projects every field of a fully-populated source', () => {

--- a/src/canvas/persist/crashFlush.ts
+++ b/src/canvas/persist/crashFlush.ts
@@ -49,6 +49,13 @@ export interface CrashSnapshot {
    */
   ceeAnalysisReady: unknown
   selectedGoalNode: string | null | undefined
+  /**
+   * The completed analysis, or null. Required for the same reason as the rest:
+   * `saveAutosave` REPLACES, so a crash flush that omitted it would strip the
+   * user's answer out of the last good autosave — losing the very thing the
+   * boundary's "your work is auto-saved" promise now covers.
+   */
+  analysis: AutosaveData['analysis'] | undefined
 }
 
 export type CrashSnapshotProvider = () => CrashSnapshot | null

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -16,11 +16,11 @@ import type { ReportV1 } from '../adapters/plot/types'
 import type { V2RunResponse } from '../adapters/plot/v2/types'
 import type { PLoTEnrichment } from '../adapters/plot/enrichment'
 import { trackResultsViewed, trackIssuesOpened } from './utils/sandboxTelemetry'
-import { addRun, generateGraphHash, loadRuns, type StoredRun } from './store/runHistory'
+import { addRun, generateGraphHash, loadRuns, type StoredRun, type RestorableRun } from './store/runHistory'
 import { RUN_COMPLETED_WITHOUT_VERDICT, deriveAnalysisFreshnessUpdate, type AnalysisFreshnessState } from './store/analysisFreshness'
 import * as scenarios from './store/scenarios'
 import type { ScenarioFraming } from './store/scenarios'
-import { projectAutosaveData, autosaveSourceFromStore } from './store/autosaveProjection'
+import { projectAutosaveData, autosaveSourceFromStore, analysisSnapshotFromStore } from './store/autosaveProjection'
 import { registerCrashSnapshotProvider } from './persist/crashFlush'
 import type { GraphHealth, ValidationIssue, NeedleMover } from './validation/types'
 import type { Document, Citation } from './share/types'
@@ -711,7 +711,14 @@ interface CanvasState {
    * analysisStateReady) or 'idle' when none does; no-op otherwise. A landed
    * analysis_result has already flipped 'complete' via resultsComplete. */
   resultsSettle: () => void
-  resultsLoadHistorical: (run: StoredRun) => void
+  /**
+   * Put a previously-computed answer back on screen. Accepts `RestorableRun`
+   * (widened from `StoredRun`) so the canonical autosave snapshot — which has
+   * no seed on the live V5 path — can restore through the SAME action, with the
+   * same honest `analysisFreshness: 'unknown'` semantics, rather than a second
+   * restore path that could drift from this one.
+   */
+  resultsLoadHistorical: (run: RestorableRun) => void
   /** Hydrate results from Supabase row.analysis (V2RunResponse already mapped to store shape) */
   resultsHydrateFromSupabase: (hydrated: {
     results: Partial<ResultsState>
@@ -3158,6 +3165,32 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       }))
     }
 
+    // ⭐ THE ANSWER IS PERSISTED HERE, beside the graph it was computed over.
+    //
+    // This is what makes the returning user's result survive; everything above
+    // it about run history is the OLD, seed-gated path and stays inert on the
+    // live V5 wire (see the block comment there). See store/scenarios.ts
+    // `PersistedAnalysis` for the full two-dead-links diagnosis.
+    //
+    // IT MUST BE HERE AND NOT LEFT TO THE 30s TIMER. useAutosave's dirty check
+    // is `computeGraphHash(nodes, edges)` — GRAPH ONLY. Completing an analysis
+    // changes no node and no edge, so the hash is identical and the timer's
+    // `currentHash === lastSavedHashRef.current` early-return SKIPS the write
+    // entirely. Relying on the timer would have persisted the answer only if
+    // the user happened to edit the graph afterwards — i.e. a fix that passes a
+    // store test and does nothing for the user who runs an analysis and leaves.
+    //
+    // Sourced from the POST-set() state (Zustand's set is synchronous), so the
+    // record written is exactly the one this completion produced.
+    try {
+      scenarios.saveAutosave(projectAutosaveData(autosaveSourceFromStore(get())))
+    } catch (err) {
+      // Never let a persistence failure take down a completed run — the answer
+      // is already on screen. saveAutosave already handles quota by dropping
+      // the analysis and keeping the graph; this catch covers the rest.
+      console.warn('[resultsComplete] Failed to persist analysis to autosave', err)
+    }
+
     // Refinement Journey: capture analysis snapshot for Compare tab
     if (isCompareTabEnabled() && rawV2Response && report) {
       try {
@@ -3290,7 +3323,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     }
   },
 
-  resultsLoadHistorical: (run: StoredRun) => {
+  resultsLoadHistorical: (run: RestorableRun) => {
     if (typeof window !== 'undefined') {
       try {
         const win = window as any
@@ -5056,6 +5089,9 @@ registerCrashSnapshotProvider(() => {
     // error. Casting here keeps the crash path at parity with the timer without
     // inventing a store field this lane has no mandate to add.
     selectedGoalNode: (s as unknown as { selectedGoalNode?: string | null }).selectedGoalNode ?? null,
+    // The answer rides the crash flush too — a crash after a completed analysis
+    // must not be the one path that silently drops it.
+    analysis: analysisSnapshotFromStore(s),
   }
 })
 

--- a/src/canvas/store/autosaveProjection.ts
+++ b/src/canvas/store/autosaveProjection.ts
@@ -48,7 +48,7 @@
  * the diff instead.
  */
 
-import type { AutosaveData } from './scenarios'
+import type { AutosaveData, PersistedAnalysis } from './scenarios'
 
 /**
  * What a caller must state in order to write an autosave.
@@ -63,6 +63,18 @@ export interface AutosaveProjectionSource {
   scenarioId: string | null | undefined
   ceeAnalysisReady: AutosaveData['ceeAnalysisReady'] | undefined
   selectedGoalNode: string | null | undefined
+  /**
+   * The completed analysis for this graph, or null for "persist no answer".
+   *
+   * Required like every other field here, for the reason in "FAIL LOUD ON
+   * DRIFT" above — and this field needs it most. `saveAutosave` REPLACES, so a
+   * caller that omitted the analysis would silently strip the user's answer
+   * from the last good autosave, which is exactly the bug class that made this
+   * module necessary (`ceeAnalysisReady`, #386). One caller genuinely wants to
+   * clear it: `undoDraftChatGraph` reverts to the pre-draft graph, and an
+   * analysis of a graph whose option nodes no longer exist must not survive.
+   */
+  analysis: AutosaveData['analysis'] | undefined
 }
 
 /**
@@ -98,6 +110,49 @@ export interface AutosaveStoreSlice {
    * — see the PR body; it is not resolved here.
    */
   selectedGoalNode?: string | null
+  /**
+   * The results slice. Structural and narrow: only what decides whether there
+   * is an answer worth persisting, and what identifies it.
+   */
+  results: {
+    status: string
+    report?: unknown
+    hash?: string
+    runId?: string
+    seed?: number
+    finishedAt?: number
+    drivers?: Array<{ kind: 'node' | 'edge'; id: string }>
+    resultsSource?: 'direct' | 'conversation'
+  }
+}
+
+/**
+ * The ONE store → PersistedAnalysis projection.
+ *
+ * Returns null unless the store actually holds a COMPLETE analysis with a
+ * report. Deliberately not "whatever is on `results`": a run that is
+ * `analysing`, `error` or `cancelled` has no answer to restore, and persisting
+ * a half-state would put the returning user in a state no live run produces.
+ *
+ * `hash` is `results.hash` (the V5 `response_hash`) — the identity that exists
+ * on the wire. `seed` is copied ONLY when the store has one (the direct Run
+ * path); it is never defaulted, because a fabricated seed forks the graph hash
+ * (CLAUDE.md trap #10).
+ */
+export function analysisSnapshotFromStore(
+  state: Pick<AutosaveStoreSlice, 'results'>,
+): PersistedAnalysis | null {
+  const r = state.results
+  if (!r || r.status !== 'complete' || !r.report) return null
+  return {
+    hash: r.hash,
+    computedAt: new Date(r.finishedAt ?? Date.now()).toISOString(),
+    resultsSource: r.resultsSource,
+    runId: r.runId,
+    seed: r.seed,
+    drivers: r.drivers,
+    report: r.report as PersistedAnalysis['report'],
+  }
 }
 
 /**
@@ -118,6 +173,7 @@ export function autosaveSourceFromStore(
     scenarioId: state.currentScenarioId,
     ceeAnalysisReady: (state.ceeAnalysisReady ?? undefined) as AutosaveData['ceeAnalysisReady'],
     selectedGoalNode: state.selectedGoalNode ?? null,
+    analysis: analysisSnapshotFromStore(state),
     ...overrides,
   }
 }
@@ -141,5 +197,10 @@ export function projectAutosaveData(
     edges: source.edges,
     ceeAnalysisReady: source.ceeAnalysisReady ?? undefined,
     selectedGoalNode: source.selectedGoalNode ?? undefined,
+    // `null` is meaningful here (an explicit "no answer"), so it is preserved
+    // rather than collapsed to `undefined` — `loadAutosave` treats an absent
+    // key and an explicit null the same on read, but the diff at each call site
+    // stays readable.
+    analysis: source.analysis ?? null,
   }
 }

--- a/src/canvas/store/restoreAnalysisFromAutosave.ts
+++ b/src/canvas/store/restoreAnalysisFromAutosave.ts
@@ -1,0 +1,60 @@
+/**
+ * Restore a completed analysis from the autosave record — the canonical half
+ * of the fix described in `PersistedAnalysis` (store/scenarios.ts).
+ *
+ * WHY A MODULE RATHER THAN INLINE IN ReactFlowGraph
+ * The boot restore lives inside a `useEffect` in a 4,000-line component, which
+ * makes it untestable and made the two PRE-EXISTING restore attempts there
+ * (scenario `last_result_hash` lookup, then a graphHash scan over run history)
+ * impossible to pin. Both of those are dead on the deployed guest path —
+ * live-probed 26 Jul, `olumi-canvas-scenarios` and `olumi-canvas-run-history`
+ * are both absent after a real analysis. This one is a pure function of the
+ * autosave record, so a spec can drive the exact bytes the live write produced.
+ *
+ * ⚠ WHAT THIS FILE'S SPECS CAN AND CANNOT PROVE. They prove the record → store
+ * transition. They do NOT prove ReactFlowGraph calls this on mount — jsdom
+ * cannot prove the deployed path, and a store-level pass while the deployed
+ * path stays broken is exactly the trap this defect was already caught by once
+ * (see store.conversationRunSurvivesReload.spec.ts's own header). The wiring is
+ * evidenced only by the live leave-and-return acceptance recorded in the PR.
+ */
+
+import type { AutosaveData } from './scenarios'
+import type { RestorableRun } from './runHistory'
+
+/**
+ * Rehydrate `results` from `autosave.analysis`, if there is one.
+ *
+ * @param autosave  the record just read by `loadAutosave()`
+ * @param restoreFn the store's `resultsLoadHistorical`
+ * @returns true when an answer was restored — the caller uses this to skip the
+ *          legacy fallbacks, so a canonical hit can never be overwritten by a
+ *          graphHash guess.
+ */
+export function restoreAnalysisFromAutosave(
+  autosave: Pick<AutosaveData, 'analysis'> | null | undefined,
+  restoreFn: (run: RestorableRun) => void,
+): boolean {
+  const analysis = autosave?.analysis
+  // Persisted JSON is not a type. Guard the one field the results surfaces
+  // cannot render without, so a truncated or hand-edited record degrades to
+  // "no answer" rather than a store in a state no run produces.
+  if (!analysis || typeof analysis !== 'object') return false
+  const report = analysis.report
+  if (!report || typeof report !== 'object') return false
+
+  const ts = Date.parse(analysis.computedAt ?? '')
+  restoreFn({
+    id: analysis.runId ?? `restored:${analysis.hash ?? 'unknown'}`,
+    ts: Number.isFinite(ts) ? ts : Date.now(),
+    // Absent on the V5 path and never invented — see PersistedAnalysis.
+    seed: analysis.seed,
+    hash: analysis.hash,
+    report,
+    drivers: analysis.drivers,
+    ceeReview: null,
+    ceeTrace: null,
+    ceeError: null,
+  })
+  return true
+}

--- a/src/canvas/store/runHistory.ts
+++ b/src/canvas/store/runHistory.ts
@@ -45,6 +45,22 @@ export interface StoredRun {
   ceeError?: CeeErrorViewModel | null
 }
 
+/**
+ * What `resultsLoadHistorical` actually needs to put an answer back on screen.
+ *
+ * A `StoredRun` satisfies this, so widening the store action to accept it is
+ * source-compatible with every existing caller. It exists because the canonical
+ * autosave snapshot (store/scenarios.ts `PersistedAnalysis`) has NO seed on the
+ * live V5 path and no `adapter` / `graphHash` / `summary` — those three are
+ * run-history bookkeeping, not things the Results panel reads. Requiring them
+ * would have meant fabricating values, and a fabricated seed forks the graph
+ * hash (CLAUDE.md trap #10).
+ */
+export type RestorableRun = Pick<
+  StoredRun,
+  'id' | 'ts' | 'hash' | 'report' | 'drivers' | 'ceeReview' | 'ceeTrace' | 'ceeError'
+> & { seed?: number }
+
 export const STORAGE_KEY = 'olumi-canvas-run-history' // Exported for cross-tab listening
 const MAX_RUNS = 20
 const MAX_PINNED = 5

--- a/src/canvas/store/scenarios.ts
+++ b/src/canvas/store/scenarios.ts
@@ -14,6 +14,7 @@
 
 import type { Node, Edge } from '@xyflow/react'
 import type { CEEAnalysisReady } from '../../adapters/cee/types'
+import type { ReportV1 } from '../../adapters/plot/types'
 
 export interface ScenarioFraming {
   title?: string          // Decision or question
@@ -528,6 +529,56 @@ export function promoteSnapshot(
 }
 
 /**
+ * The completed analysis, persisted IN the autosave record — beside the graph
+ * it was computed over, not in a second store keyed on something else.
+ *
+ * WHY THIS EXISTS (live defect, reproduced 1/1 on deployed staging 26 Jul 2026)
+ * The answer did not survive leaving the canvas and returning via "Continue
+ * without an account": the graph came back, the conversation came back, and the
+ * Results panel reset to "Analyse first pass". Two independent links were dead,
+ * BOTH of them on the deployed guest path:
+ *
+ *  1. The WRITE. `resultsComplete` gates its run-history `addRun` on a SEED.
+ *     `results.seed` is set only by `resultsStart`, which only the direct
+ *     Run-button path calls; the live V5 path goes through `resultsAnalysing`
+ *     and `applyV5State` passes `rawV2Response: null`. Live-probed after a real
+ *     analysis: `'seed' in results === false`, `olumi-canvas-run-history` absent.
+ *  2. The POINTER. `resultsComplete` writes `last_result_hash` onto the SCENARIO
+ *     record — but guest mode never creates one. Live-probed:
+ *     `olumi-canvas-scenarios` absent. So the boot restore
+ *     (ReactFlowGraph init → `scenarios.getScenario(autosave.scenarioId)`)
+ *     found no record, and its graphHash fallback scanned an empty run history.
+ *
+ * The record that DID survive and IS read back at boot is this one: the
+ * autosave already carries `nodes`, `edges`, `scenarioId` and `ceeAnalysisReady`
+ * — written together, read together. The answer was the only part of the
+ * scenario not riding it. Putting it here means every surface restores from ONE
+ * record instead of re-deriving agreement between three.
+ *
+ * IDENTITY IS THE RESPONSE HASH, NOT A SEED. `response_hash` is present on the
+ * live V5 wire (`v5:c9185f4c9c602851`, captured 26 Jul); the seed is not, and a
+ * fabricated one would fork the graph hash (CLAUDE.md trap #10). Nothing here
+ * invents a seed — `seed` is optional and simply absent on the V5 path.
+ */
+export interface PersistedAnalysis {
+  /**
+   * `report.model_card.response_hash` — the run identity that IS on the wire.
+   * Also what `resultsLoadHistorical` puts back into `results.hash`.
+   */
+  hash?: string
+  /** ISO instant the run completed, for provenance on the restored surface. */
+  computedAt: string
+  /** A.9 provenance: which path produced it. */
+  resultsSource?: 'direct' | 'conversation'
+  runId?: string
+  /** Present only on the direct Run path, which does know a seed. Never faked. */
+  seed?: number
+  drivers?: Array<{ kind: 'node' | 'edge'; id: string }>
+  /** The full report the Results surfaces render. ~21 kB in the live 5-option case. */
+  report: ReportV1
+}
+
+/**
  * Autosave: Store current graph state temporarily
  * Used to recover unsaved work on reload
  */
@@ -536,6 +587,11 @@ export interface AutosaveData {
   scenarioId?: string // If editing an existing scenario
   nodes: Node[]
   edges: Edge[]
+  /**
+   * The completed analysis for THIS graph, or null/absent when none has run.
+   * See PersistedAnalysis. Dropped (never the graph) if the write hits quota.
+   */
+  analysis?: PersistedAnalysis | null
   // V3: Persist analysis_ready so options survive page refresh
   ceeAnalysisReady?: {
     options: Array<{
@@ -580,6 +636,33 @@ export function saveAutosave(data: AutosaveData): void {
       console.log('[scenarios] Autosave written')
     }
   } catch (error) {
+    // DECLARED DEGRADATION, in this order deliberately.
+    //
+    // The analysis report is the largest thing in this record (~21 kB live) and
+    // it is the OPTIONAL half: the graph is the user's work, the analysis can be
+    // recomputed. Before this field existed a quota failure lost only the newest
+    // graph edits; it must not now be able to lose the GRAPH because an analysis
+    // pushed the payload over the limit. So on any write failure, retry once
+    // without the analysis rather than leaving the slot at its previous value.
+    //
+    // Both the retry and its own failure are reported — silence here would make
+    // a lost graph look identical to a successful save (the failure-reads-as-
+    // green class this repo keeps catching).
+    if (data.analysis) {
+      try {
+        const withoutAnalysis = JSON.stringify({ ...data, analysis: null })
+        localStorage.setItem(AUTOSAVE_KEY, withoutAnalysis)
+        lastAutosavePayload = withoutAnalysis
+        console.warn(
+          '[scenarios] Autosave too large — persisted the graph WITHOUT the analysis. ' +
+            'The results panel will not restore this run on return.',
+          error,
+        )
+        return
+      } catch (retryError) {
+        console.error('[scenarios] Failed to save autosave (graph-only retry):', retryError)
+      }
+    }
     console.error('[scenarios] Failed to save autosave:', error)
   }
 }


### PR DESCRIPTION
## The defect

A completed analysis did not survive leaving the canvas and returning via **"Continue without an account"**. Reproduced **1/1 on deployed staging** (bundle `index-BlVFnI6e.js`, 26 Jul 2026): the graph came back, the conversation came back, and the Results panel reset to *"Analysis available / Analyse first pass"*. The user saw the assistant stating an answer in chat while the results surfaces claimed the analysis had never run.

## Two dead links, both live-probed — not one

**1. The WRITE is skipped.** `resultsComplete` gates its run-history `addRun` on a **seed**. `results.seed` is set only by `resultsStart`, which only the direct Run-button path calls; the live V5 path goes through `resultsAnalysing`, and `applyV5State.ts` passes `rawV2Response: null` explicitly. Probed on staging immediately after a real conversation-driven analysis: **`'seed' in results === false`**, **`olumi-canvas-run-history` absent**.

**2. The POINTER is never persisted either.** `resultsComplete` writes `last_result_hash` onto a *scenario* record — but guest mode never creates one. Probed: **`olumi-canvas-scenarios` absent**. So `ReactFlowGraph`'s boot restore found no record, and its graphHash fallback scanned an empty run history. Even a stored run would have been unfindable.

This second link is new — the 25 Jul diagnosis (`parallel-briefs/RETURNING-USER-2026-07-25.md` §3) found only the first.

## The fix — one canonical record, not a third store

The autosave slot already carries `nodes`, `edges`, `scenarioId` and `ceeAnalysisReady`: written together, read together at boot, and demonstrably the thing that brings the graph back on the deployed guest path. **The analysis was the only part of the scenario not riding it.** It now does, and the boot path restores from it **first**, demoting the two legacy re-derivations (scenario-hash lookup, graphHash scan) to fallbacks for records written before this shipped.

- **Run identity is `response_hash`**, which *is* on the live V5 wire (`v5:c9185f4c9c602851`, captured). **No seed is invented anywhere** — a fabricated seed forks the graph hash.
- **The flush is in `resultsComplete`, not the 30s timer, and that is load-bearing.** `useAutosave`'s dirty check is `computeGraphHash(nodes, edges)` — *graph only*. Completing an analysis changes no node and no edge, so the timer's early-return **skips the write**. Leaving it to the timer would have persisted the answer only if the user happened to edit the graph afterwards.
- **The stage regression needed no new persistence.** `useStagePill` already derives the stage from the results status, so restoring the result restores "Evaluate". A spec pins that so nobody re-creates the divergence by persisting `currentStage` separately.
- **`saveAutosave` gains a declared degradation:** on write failure, retry once *without* the analysis so the user's **graph** still persists, and say so. The analysis is recomputable; the graph is the user's work.

`AutosaveProjectionSource.analysis` is **required**, per that module's own fail-loud-on-drift rule — which is why the gate caught two existing specs that had to state their intent (see below).

## RED-first and mutation-check

**RED came first at the level that matters:** the deployed defect was reproduced 1/1 on live staging *before any code changed*. The vitest spec was written after the implementation — stating that plainly rather than claiming a process I did not follow — and then proved to discriminate by mutation.

New spec `src/canvas/__tests__/analysisSurvivesLeaveAndReturn.spec.ts` (8 tests) drives the **real** `applyV5State` (the live handler) into the **real** canvas store into **real** localStorage — not a `vi.fn()` double, which would have passed against the broken code too.

Mutation-check in a **throwaway copy**, never the working tree. Reverted the 7 wiring files, kept the new module + spec. Anchors asserted before running:

```
'THE ANSWER IS PERSISTED HERE' in store.ts        0   flush gone
analysisSnapshotFromStore in autosaveProjection   0   projection gone
PersistedAnalysis in scenarios.ts                 0   type gone
'graph-only retry' in scenarios.ts                0   quota guard gone
restoreAnalysisFromAutosave in ReactFlowGraph     0   wiring gone
restoreAnalysisFromAutosave.ts module             1   fix module still present
new spec                                          1   spec still present
```

| Tree | Result |
|---|---|
| with the fix | **8 passed** |
| wiring reverted | **5 FAILED / 3 passed** |

Failures land on the right assertions: `expected undefined to be truthy` (autosave carries no analysis) · `expected false to be true` (nothing restored) · `expected 'ideate' to be 'evaluate'` (the stage regression) · `expected undefined to be truthy` (a later write strips it) · `expected [] to have a length of 1` (no quota retry). The three that stay green are the **intended controls** — the positive control that the probe can see the absent case, "invents no seed", and "a corrupt record degrades safely". A mutation that turned *everything* red would mean the tests were not discriminating.

## Gates

- **`pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) — PASSED.** 3028/3046 files loaded. Ratchet: 666 files / **2661** errors vs baseline 2663. **Baseline NOT regenerated.**
  The gate first **failed** on this branch with 3 new-file errors and I **fixed them at source**, which is the fail-loud mechanism working exactly as designed: `useAutosave.hashByDefault.spec.ts` and `autosaveProjectionParity.spec.tsx` each had to state what they want persisted for the new required field.
- **Tests:** 179 files / 2102 tests green across `src/canvas/store`, `src/canvas/__tests__`, `src/canvas/persist`, `src/canvas/hooks`, `src/v5`, `tests/ci-guards`; re-confirmed 134 files / 1479 after the typecheck fixes.
- **Lint:** 0 errors on every changed file (8 pre-existing `console.log` warnings on lines this PR does not touch).
- `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` were set for every measurement; no collect-time failures.

## Test integrity

`store.conversationRunSurvivesReload.spec.ts` is **re-labelled, not deleted**. Its own header already said its fix was inert on the deployed path. That **stays true** — the seed-gated run-history write is still inert, re-probed 26 Jul — and is now stated alongside what actually fixed the user's problem, with a pointer to the file that does carry deployed-path evidence. It is kept because it is a valid store-contract pin and the right shape for the day CEE echoes a run identity.

## Not fixed here, deliberately

- `loadScenario` (the saved-scenario path, `store.ts`) still restores results only via `tryRestoreResultsFromHistory`. Guest mode never takes that path; an authenticated user whose scenario record is newer than the autosave would still lose the answer.
- The Supabase `storeAnalysis` write remains inside the dead `envelope.analysis_response` branch in `useConversation.ts` (prior lane's finding #2, untouched).
- The seed-gated run-history write is still inert. Left as-is rather than resurrected on an invented seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
