### PR TITLE
C1: derive KNOWN_OLUMI_TOP_LEVEL_KEYS from the schema, and build its alarm

### DIFF
--- a/src/v5/__tests__/responseParser.declaredKeysReachStrict.spec.ts
+++ b/src/v5/__tests__/responseParser.declaredKeysReachStrict.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * C1 — the alarm on `KNOWN_OLUMI_TOP_LEVEL_KEYS`.
+ *
+ * ─── THE DEFECT THIS PINS ──────────────────────────────────────────────────
+ * `src/v5/responseParser.ts` split the raw response into a "known" surface
+ * (which reaches strict zod validation and therefore `parsed.data`) and an
+ * `extensions` map (which is demoted to the NON-ENUMERABLE `__additive__`
+ * sidecar). The split was driven by a HAND-WRITTEN Set whose own docstring
+ * claimed it listed "top-level keys the strict OlumiResponseSchema declares".
+ *
+ * That claim was FALSE at the vendored pin. Measured against
+ * `vendor/talchain-schemas-0.22.0.tgz`, the schema declared 13 keys and the
+ * Set allowed 9. The four declared-but-unreachable keys were
+ * `framing_question`, `decision_classification`, `framing_quality` and
+ * `graph_hash` — precisely the fields the contract added so that consumers
+ * could STOP deriving verdicts client-side. `response.framing_quality` would
+ * have read `undefined` forever, even after CEE began emitting it, and the
+ * silence would have read as "the producer sent nothing".
+ *
+ * ─── WHY THIS TEST IS SHAPED THE WAY IT IS: DERIVE, DON'T MIRROR ───────────
+ * This repo's dominant defect is the hand-maintained mirror — a list a human
+ * must remember to sync with reality, which drifts in silence and whose drift
+ * always reads green. `KNOWN_OLUMI_TOP_LEVEL_KEYS` is named as a known
+ * specimen in `src/__tests__/vitestExcludeRegister.spec.ts`, under the
+ * heading "where a mirror is unavoidable it MUST fail loud on drift". The
+ * alarm was specified there and never built. This file is that alarm.
+ *
+ * The test derives its OWN expectations from `OlumiResponseSchema.shape` — it
+ * never restates the key list. So it cannot itself rot into a second mirror:
+ * when the schema package adds a key, this spec starts demanding that key on
+ * the next run, without anyone editing it.
+ *
+ * The one unavoidable mirror here is `SCHEMA_VALID_SAMPLES` (a schema-valid
+ * value cannot be synthesised from a zod schema in general). It is guarded by
+ * `it('covers every declared key')`, which FAILS LOUD the moment the schema
+ * declares a key the map does not cover — assume-good is not available.
+ *
+ * ─── NOTE ON UNDECLARED KEYS (`coaching`) ──────────────────────────────────
+ * `useConversation.ts` and `draftBiasSignalBlocks.seam.spec.ts` both warn
+ * against adding `coaching` to the Set: the schema is `.strict()`, so routing
+ * an UNDECLARED key into strict validation fails the entire parse. That
+ * warning argues against HAND-ADDING, which is exactly what deriving retires.
+ * Deriving from `.shape` can never admit an undeclared key. The final test
+ * below pins that: an undeclared key must still land in the sidecar.
+ */
+import { describe, it, expect } from 'vitest'
+import { OlumiResponseSchema } from '@talchain/schemas/boundary'
+
+import { parseV5Response, ADDITIVE_EXTENSIONS_KEY } from '../responseParser'
+
+function makeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/** The required surface — every non-optional key, minimal valid values. */
+const BASE_PAYLOAD = {
+  response_version: 2,
+  assistant_text: 'hi',
+  blocks: [],
+  suggested_actions: [],
+  insights: [],
+  stage_indicator: 'frame',
+} as const
+
+/**
+ * One schema-valid sample per DECLARED key. Guarded for completeness against
+ * `OlumiResponseSchema.shape` by the first test — a new declared key with no
+ * sample here fails loudly rather than being silently skipped.
+ */
+const SCHEMA_VALID_SAMPLES: Readonly<Record<string, unknown>> = {
+  response_version: 2,
+  assistant_text: 'hi',
+  blocks: [],
+  suggested_actions: [],
+  insights: [],
+  stage_indicator: 'frame',
+  draft_graph: { nodes: [], edges: [], node_count: 0, edge_count: 0 },
+  analysis_ready: { status: 'ready', options: [], goal_node_id: 'goal-1' },
+  reasoning: 'model working',
+  // The four that were unreachable before this fix.
+  framing_question: 'What would a good outcome look like in twelve months?',
+  decision_classification: { stakes: 'high' },
+  framing_quality: 'thin',
+  graph_hash: 'abc123def456',
+}
+
+const DECLARED_KEYS: readonly string[] = Object.keys(OlumiResponseSchema.shape)
+
+describe('C1: every key OlumiResponseSchema DECLARES reaches strict validation', () => {
+  it('the sample map covers every declared key (fail-loud drift guard on the one mirror)', () => {
+    const missingSamples = DECLARED_KEYS.filter(
+      (k) => !Object.prototype.hasOwnProperty.call(SCHEMA_VALID_SAMPLES, k),
+    )
+    expect(
+      missingSamples,
+      `OlumiResponseSchema declares key(s) with no sample in SCHEMA_VALID_SAMPLES: ` +
+        `${missingSamples.join(', ')}. Add a schema-valid sample so the key is actually exercised — ` +
+        `do NOT delete the key from the assertion.`,
+    ).toEqual([])
+
+    const staleSamples = Object.keys(SCHEMA_VALID_SAMPLES).filter(
+      (k) => !DECLARED_KEYS.includes(k),
+    )
+    expect(
+      staleSamples,
+      `SCHEMA_VALID_SAMPLES carries key(s) the schema no longer declares: ${staleSamples.join(', ')}.`,
+    ).toEqual([])
+  })
+
+  // The core assertion. Derived from the schema, so it grows on its own.
+  it.each(DECLARED_KEYS)(
+    'declared key `%s` lands on parsed.data, NOT in the __additive__ sidecar',
+    async (key) => {
+      const payload: Record<string, unknown> = {
+        ...BASE_PAYLOAD,
+        [key]: SCHEMA_VALID_SAMPLES[key],
+      }
+
+      const result = await parseV5Response(makeResponse(payload))
+      expect(result.kind).toBe('response')
+      if (result.kind !== 'response') throw new Error('unreachable')
+
+      const response = result.response as Record<string, unknown>
+      const sidecar = (result.response as Record<string | symbol, unknown>)[
+        ADDITIVE_EXTENSIONS_KEY
+      ] as Record<string, unknown> | undefined
+
+      // A declared key demoted to the sidecar is the C1 defect: it reads
+      // `undefined` off the typed response forever.
+      expect(
+        sidecar?.[key],
+        `declared key \`${key}\` was demoted to the __additive__ sidecar — it will read ` +
+          `undefined off the typed OlumiResponse forever, even once CEE emits it.`,
+      ).toBeUndefined()
+
+      expect(
+        Object.prototype.hasOwnProperty.call(response, key),
+        `declared key \`${key}\` did not survive to parsed.data.`,
+      ).toBe(true)
+      expect(response[key]).toEqual(SCHEMA_VALID_SAMPLES[key])
+    },
+  )
+
+  // Positive control for the assertion above: prove this test CAN see a
+  // demotion. Without this, "not in the sidecar" could pass vacuously (e.g.
+  // if the sidecar were never populated at all).
+  it('POSITIVE CONTROL: an UNDECLARED key IS demoted to the sidecar', async () => {
+    const undeclared = 'definitely_not_a_declared_key'
+    expect(DECLARED_KEYS).not.toContain(undeclared)
+
+    const result = await parseV5Response(
+      makeResponse({ ...BASE_PAYLOAD, [undeclared]: { hello: 'world' } }),
+    )
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+
+    const sidecar = (result.response as Record<string | symbol, unknown>)[
+      ADDITIVE_EXTENSIONS_KEY
+    ] as Record<string, unknown> | undefined
+
+    // The sidecar mechanism is live and this test can observe it.
+    expect(sidecar?.[undeclared]).toEqual({ hello: 'world' })
+    expect(
+      (result.response as Record<string, unknown>)[undeclared],
+    ).toBeUndefined()
+  })
+
+  // Regression guard for the `coaching` warning in useConversation.ts:693 and
+  // draftBiasSignalBlocks.seam.spec.ts:240. Deriving must not admit it.
+  it('an UNDECLARED root `coaching` still lands in the sidecar (strict parse not broken)', async () => {
+    expect(DECLARED_KEYS).not.toContain('coaching')
+
+    const coaching = { framing_notes: ['x'] }
+    const result = await parseV5Response(makeResponse({ ...BASE_PAYLOAD, coaching }))
+
+    // If `coaching` were routed into strict validation the whole parse would fail.
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') throw new Error('unreachable')
+
+    const sidecar = (result.response as Record<string | symbol, unknown>)[
+      ADDITIVE_EXTENSIONS_KEY
+    ] as Record<string, unknown> | undefined
+    expect(sidecar?.['coaching']).toEqual(coaching)
+  })
+})

--- a/src/v5/responseParser.ts
+++ b/src/v5/responseParser.ts
@@ -176,22 +176,38 @@ export type OlumiResponseWithExtensions = OlumiResponse & {
   readonly [ADDITIVE_EXTENSIONS_KEY]?: Readonly<Record<string, unknown>>;
 };
 
-/** Top-level keys the strict OlumiResponseSchema declares. */
-const KNOWN_OLUMI_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set([
-  'response_version',
-  'assistant_text',
-  'blocks',
-  'suggested_actions',
-  'insights',
-  'stage_indicator',
-  'draft_graph',
-  'analysis_ready',
-  // 0.15.0: reasoning is a declared optional field on the strict schema —
-  // it must reach strict validation, not be demoted to the __additive__
-  // sidecar (which would blank parsed.reasoning forever once CEE migrates
-  // off the legacy _reasoning sidecar key).
-  'reasoning',
-]);
+/**
+ * Top-level keys the strict OlumiResponseSchema declares — DERIVED from the
+ * schema itself, never restated.
+ *
+ * This used to be a hand-written list, and its docstring made exactly the
+ * claim above while being FALSE: at the vendored 0.22.0 pin the schema
+ * declared 13 keys and the list allowed 9. The four it silently withheld —
+ * `framing_question`, `decision_classification`, `framing_quality`,
+ * `graph_hash` — are precisely the fields the contract added so consumers
+ * could STOP deriving verdicts client-side. Because everything outside this
+ * set is demoted to the non-enumerable `__additive__` sidecar, each of them
+ * would have read `undefined` off the typed response FOREVER, including
+ * after CEE started emitting them, and the silence would have been
+ * indistinguishable from the producer sending nothing.
+ *
+ * `OlumiResponseSchema` is a plain `z.object(...).strict()`, so `.shape` is
+ * directly enumerable and this derivation stays correct across re-vendors
+ * with no human in the loop. Do NOT convert this back into a literal list:
+ * this repo's dominant defect is the hand-maintained mirror, whose drift
+ * always reads green. (CEE performs the same derivation in
+ * `tests/contract/cee-egress-wire-surface-pin.test.ts`.)
+ *
+ * Note this admits DECLARED keys only. An UNDECLARED root key (e.g.
+ * `coaching`, which the schema still does not declare at 0.22.0) must keep
+ * going to the sidecar — the schema is `.strict()`, so routing an undeclared
+ * key into validation would fail the entire parse. Deriving cannot admit
+ * one; hand-adding could, which is why hand-adding is the hazard here.
+ * Pinned end-to-end in `responseParser.declaredKeysReachStrict.spec.ts`.
+ */
+const KNOWN_OLUMI_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(OlumiResponseSchema.shape),
+);
 
 /**
  * Split a raw response into the known surface (validated by zod) and a map


### PR DESCRIPTION
## The defect: an armed landmine, and the fix is one line

`KNOWN_OLUMI_TOP_LEVEL_KEYS` (`src/v5/responseParser.ts:180`) was a hand-written list whose own docstring claimed it held *"top-level keys the strict OlumiResponseSchema declares"*.

**That claim was false at our own vendored pin.** Measured at the bytes in `vendor/talchain-schemas-0.22.0.tgz` (`dist/boundary/olumi-response.js`):

| | count |
|---|---|
| keys `OlumiResponseSchema` declares | **13** |
| keys the Set allowed | **9** |

The four declared-but-unreachable keys were **`framing_question`, `decision_classification`, `framing_quality`, `graph_hash`**.

Everything outside the Set is routed to `extensions` and attached as a **non-enumerable** `__additive__` sidecar; only the "known" surface reaches zod and becomes `parsed.data`. So `response.framing_quality` would have read `undefined` **forever — including after CEE started emitting it** — and that silence is indistinguishable from the producer sending nothing.

Those four are precisely the fields the contract added so consumers could retire client-side verdict derivation. The schema's own doctrine says consumers **must not** derive a verdict client-side when it is absent; this mirror guaranteed it would always *look* absent.

## The fix is a deletion

15 hand-written lines become one derivation:

```ts
const KNOWN_OLUMI_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set(
  Object.keys(OlumiResponseSchema.shape),
);
```

`OlumiResponseSchema` is a plain `z.object(...).strict()`, so `.shape` is directly enumerable. CEE already performs this exact derivation in `tests/contract/cee-egress-wire-surface-pin.test.ts:62-64`.

**Hand-adding the four would have re-armed the mirror. Deriving retires it permanently.**

## Does this break the `coaching` hazard? No — checked, and pinned

`useConversation.ts:693` and `draftBiasSignalBlocks.seam.spec.ts:240` both warn against adding keys to this Set. **Both concern `coaching`, an UNDECLARED key** — the schema is `.strict()`, so routing an undeclared key into validation would fail the whole parse.

Deriving from `.shape` **cannot** admit an undeclared key. Those warnings argue against *hand-adding*, which is exactly what this retires. A regression test pins that `coaching` still lands in the sidecar and the strict parse still succeeds.

## The alarm — specified long ago, never built

`src/__tests__/vitestExcludeRegister.spec.ts:82` already names this constant as a known mirror specimen, under the heading *"DERIVE, DON'T MIRROR … where a mirror is unavoidable it MUST fail loud on drift"*. The alarm was specified there and never built.

Built now: `src/v5/__tests__/responseParser.declaredKeysReachStrict.spec.ts`.

It **derives its own expectations** from `OlumiResponseSchema.shape` via `it.each(DECLARED_KEYS)`, so it cannot become a second mirror — a newly-declared key is demanded automatically on the next run, with no human in the loop. Its one unavoidable mirror (`SCHEMA_VALID_SAMPLES`, since a valid value cannot be synthesised from a zod schema) is guarded **bidirectionally** and fails loud: a declared key with no sample fails, and a stale sample fails.

## Evidence

| Step | Result |
|---|---|
| **RED-first** (pristine `d7c55a18`, defect present) | **4 failed / 12 passed of 16** — failures were exactly the four predicted keys. Predicted set == measured set. |
| **GREEN** (after fix) | **16/16** |
| **MUTATION 1** — throwaway worktree, derivation reverted to the 9-key hand list, **anchor asserted present before writing** | **4 failed** — the same four. The fix is not theatre. |
| **MUTATION 2** — alarm-on-the-alarm: drop `framing_quality` from `SCHEMA_VALID_SAMPLES`, anchor asserted | **2 failed** — drift guard fired with its exact diagnostic. The guard on the remaining mirror is live. |
| **POSITIVE CONTROL** (in-spec, before any absence assertion) | An UNDECLARED key **is** observed landing in the sidecar → the "not in the sidecar" assertions are not vacuous. |
| **Typecheck gate** (`pnpm run typecheck`) | **PASSED**. Coverage 3028/3046 — the new spec **is** loaded by the gate. Ratchet 2661 vs baseline 2663. |
| **Regression** | `src/v5/__tests__/` + `src/canvas/conversation/__tests__/` — **168 files, 2391 passed, 22 skipped, 0 failed, 0 collect errors**. |
| **Lint** | clean |

### On the "Drift shrank 2663 → 2661" notice
**It is pre-existing on `staging`, not caused by this PR.** Proven with a control: a pristine `d7c55a18` worktree reports the identical 2661 vs 2663. This change is exactly gate-neutral. **The baseline was deliberately NOT tightened** — that would be an unrelated change.

## Test hygiene
No existing test pinned the 9-key behaviour, so **nothing needed re-pointing, and no test was deleted, weakened, or baselined away.**

## Scope
Consumer-side only. CEE emits none of these four fields today — this removes the guarantee that it never *could*. The producer work is a separate lane. **The field is not faked.**

Files touched: `src/v5/responseParser.ts` + its new spec. **No Lane R files** (`store.ts`, `applyV5State.ts`) touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
