### PR TITLE
C2: one reader for the success measure (the card stops denying a measure CEE sent)

### DIFF
--- a/src/canvas/components/pre-analysis-v3/selectors/computeSuccessState.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/computeSuccessState.ts
@@ -30,10 +30,29 @@ export interface SuccessState {
   scaleAmbiguous: boolean
 }
 
+/**
+ * The wire spells the percent unit as the WORD 'percent' (CEE's
+ * `goal_threshold_unit`), but `classifyUnit` recognises only the glyph '%'
+ * (see src/utils/unitClassifier.ts — `if (trimmed === '%')`). So 'percent'
+ * fell through to `kind: 'other'` and rendered as a trailing suffix:
+ * "20 percent" rather than "20%".
+ *
+ * Surfaced by C2, when the Decision Overview card was routed through this
+ * selector: the card's own retired unit mapper DID recognise the word, so the
+ * two surfaces disagreed on the same value — the card said "20%" and the
+ * pre-analysis hero said "20 percent". Normalising here makes both agree, on
+ * the better of the two renderings, without widening `classifyUnit` (a
+ * primitive with many other consumers and its own tests).
+ */
+function normaliseUnitForDisplay(unit: string): string {
+  const lower = unit.trim().toLowerCase()
+  return lower === 'percent' || lower === 'percentage' ? '%' : unit
+}
+
 function formatWithUnit(value: number, unit: string | null): string {
   const formatted = Math.abs(value) >= 1000 ? value.toLocaleString('en-GB') : String(value)
   if (!unit) return formatted
-  const { kind, canonical } = classifyUnit(unit)
+  const { kind, canonical } = classifyUnit(normaliseUnitForDisplay(unit))
   if (kind === 'symbol') return `${canonical}${formatted}`
   if (kind === 'iso') return `${canonical} ${formatted}`
   if (kind === 'percent') return `${formatted}%`

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -20,7 +20,7 @@
  * DS v4/5: bg-panel card, panel typography tokens only, Lucide, sentence
  * case, en-GB, no em dashes in prose.
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 
 import { useCanvasStore } from '../../../canvas/store'
@@ -29,7 +29,8 @@ import { useGuidanceStore, compareGuidanceDisplayOrder, type GuidanceItem } from
 import { isDecisionOverviewEnabled } from '../../../flags'
 import { typography } from '../../../styles/typography'
 import { openAskOlumi } from '../coaching/askOlumiStore'
-import { formatTargetValue } from '../utils/formatTargetValue'
+import { computeSuccessState } from '../../../canvas/components/pre-analysis-v3/selectors/computeSuccessState'
+import { computeGraphFacts } from '../../../canvas/components/pre-analysis-v3/selectors/graphFacts'
 import { ActionsMenu } from './ActionsMenu'
 import { REVIEW_BRIEF_ASK } from './actionsCatalogue'
 
@@ -106,24 +107,6 @@ type Dimension = 'Goal' | 'Context' | 'Constraints' | 'Options'
 const CLASSIFICATION_DIMENSIONS = ['stakes', 'reversibility', 'horizon', 'risk'] as const
 type ClassificationDimension = (typeof CLASSIFICATION_DIMENSIONS)[number]
 
-/**
- * Map a raw outcome-unit string onto formatTargetValue's unit vocabulary.
- * Same classification useResultsSectionData applies (display formatting,
- * not a semantic transform — values pass through unchanged).
- */
-function mapOutcomeUnit(raw: string | null): {
-  unit?: 'currency' | 'percent' | 'count'
-  symbol?: string
-} {
-  if (!raw) return {}
-  const lower = raw.toLowerCase()
-  if (lower === '%' || lower === 'percent' || lower === 'percentage') return { unit: 'percent' }
-  if (['$', '£', '€', 'usd', 'gbp', 'eur', 'dollar', 'pound', 'euro'].some((c) => lower.includes(c))) {
-    return { unit: 'currency', symbol: raw.match(/[$£€]/)?.[0] ?? '$' }
-  }
-  return { unit: 'count' }
-}
-
 /** Genuinely interrogative wire copy: title or detail ends in "?". */
 function isInterrogative(item: Pick<GuidanceItem, 'title' | 'detail'>): boolean {
   return (
@@ -179,8 +162,40 @@ export interface DecisionOverviewCardProps {
 
 export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewCardProps) {
   const analysisReady = useCanvasStore((s) => s.ceeAnalysisReady)
-  // All selectors below return primitives (Zustand inline-selector rule).
-  const goalThreshold = useCanvasStore((s) => s.goalThreshold)
+  // All selectors below return primitives (Zustand inline-selector rule) —
+  // except `nodes`, whose array reference is stable in the store and which is
+  // consumed through a useMemo below rather than a derived-object selector.
+  const nodes = useCanvasStore((s) => s.nodes)
+  const goalConstraints = useCanvasStore((s) => s.goalConstraints)
+  /**
+   * SUCCESS MEASURE — one reader of one fact (C2).
+   *
+   * This used to read `store.goalThreshold`, which `deriveGoalThresholdFromNode`
+   * (canvas/store.ts) populates ONLY when `data.threshold_source === 'user'`.
+   * A CEE-DERIVED threshold (`goal_threshold_raw`, the drafting path's normal
+   * output) therefore never reached this card, and it rendered "Success
+   * measure missing" — and fell to the derived `thin` state — for a decision
+   * that demonstrably had a measure. Meanwhile `computeSuccessState`, reading
+   * the same fact off the wire two panels away, returned `isSet: true` and
+   * rendered the value. One fact, two selectors, opposite answers; the one
+   * the user saw was the wrong one.
+   *
+   * Fixed by REUSING the existing pair rather than adding a third read:
+   * `computeGraphFacts` for goal-node selection and `computeSuccessState` for
+   * the measure — exactly what `usePreAnalysisModel` does. Writing a local
+   * goal-node finder here would have minted precisely the kind of mirror this
+   * change exists to retire.
+   */
+  const successState = useMemo(
+    () =>
+      computeSuccessState(
+        computeGraphFacts(nodes as never).goalNode,
+        (analysisReady as Record<string, unknown> | null) ?? null,
+        null,
+        goalConstraints,
+      ),
+    [nodes, analysisReady, goalConstraints],
+  )
   const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
   const optionCount = useCanvasStore((s) => s.nodes.filter((n) => n.type === 'option').length)
   const constraintCount = useCanvasStore((s) => s.goalConstraints?.length ?? 0)
@@ -203,17 +218,6 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
       if (typeof t === 'string' && t.trim()) return t.trim()
     }
     return null
-  })
-  const goalUnitRaw = useCanvasStore((s) => {
-    const goal = s.nodes.find((n) => n.type === 'goal')
-    const d = goal?.data as Record<string, unknown> | undefined
-    const observed = (d?.observedState ?? d?.observed_state) as { unit?: string } | undefined
-    return (
-      observed?.unit ??
-      (typeof d?.goal_threshold_unit === 'string' ? d.goal_threshold_unit : undefined) ??
-      s.ceeAnalysisReady?.goal_threshold_unit ??
-      null
-    )
   })
   // Review S3: promote only DISCUSSION challenges (never mechanical-fix
   // items like approve_patch/open_inspector) — closest honest v1 to the
@@ -247,7 +251,7 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
       ? 'blocked'
       : analysisReady.status !== 'ready'
         ? 'needs_input'
-        : goalThreshold == null
+        : !successState.isSet
           ? 'thin'
           : 'ready'
   const state: BriefState = stateOverride ?? liveState
@@ -309,7 +313,6 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   // Context: brief presence only. Constraints: structured goal-constraint
   // count. Options: canvas option count. No diversity/quality claims — the
   // producer option-similarity signal does not exist yet.
-  const { unit, symbol } = mapOutcomeUnit(goalUnitRaw)
   // Round-2 wiring: prefer the FULL saved success measure (Define-success
   // modal, scenario-keyed) — metric + direction + threshold+unit + timeframe.
   // Falls back to the bare committed threshold, then to 'missing'.
@@ -317,9 +320,9 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   const goalNote =
     savedMeasure != null
       ? `${savedMeasure.metric}: ${savedMeasure.direction === 'decrease_below' ? '≤' : '≥'} ${savedMeasure.threshold}${savedMeasure.unit === 'none' ? '' : savedMeasure.unit}, ${savedMeasure.timeframe}`
-      : goalThreshold == null
+      : !successState.isSet
         ? OVERVIEW_COPY.goalNoteMissing
-        : `Success target ≥ ${formatTargetValue(goalThreshold, unit, symbol)}`
+        : `Success target ≥ ${successState.displayText}`
   // CONTEXT — no claim, rather than a false denial.
   //
   // `currentBriefText` has exactly ONE non-null writer in the whole of src/:

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
@@ -30,6 +30,32 @@ function flagOn() {
  */
 const FALSE_DENIAL = 'Not captured yet'
 
+/**
+ * A goal node carrying a USER-set success measure.
+ *
+ * RE-POINTED AT SOURCE (C2) — rationale, since this touches many tests:
+ * every test below that used to say `goalThreshold: 20` was expressing one
+ * thing — "this decision HAS a success measure". It said so through
+ * `store.goalThreshold`, which was the field the card read at the time.
+ *
+ * That field is populated ONLY when `threshold_source === 'user'`
+ * (deriveGoalThresholdFromNode, canvas/store.ts), so it was blind to a
+ * CEE-derived measure and the card denied measures the product had captured.
+ * The card now reads the measure through computeGraphFacts +
+ * computeSuccessState — the same pair the pre-analysis hero uses.
+ *
+ * So the FIXTURE moves to where the real reader looks. Every test keeps its
+ * original intent and its original assertions; none was deleted, weakened or
+ * baselined away. `goalThreshold: 20` is kept alongside it so the store field
+ * stays consistent with the node for any other reader.
+ */
+const GOAL_NODE_WITH_MEASURE = {
+  id: 'g1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'G', threshold_source: 'user', success_threshold: 20 },
+}
+
 const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
 const NEEDS_INPUT = {
   status: 'needs_user_input',
@@ -72,7 +98,7 @@ beforeEach(() => {
 
 describe('DecisionOverviewCard — flag gate', () => {
   it('renders NOTHING when the flag is off (byte-identical pin)', () => {
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
     const { container } = render(<DecisionOverviewCard title="Launch decision" />)
     expect(container.firstChild).toBeNull()
   })
@@ -83,7 +109,7 @@ describe('DecisionOverviewCard — ready state (live)', () => {
     flagOn()
     // Ready requires BOTH the producer ready status AND a success measure
     // (UI-SEM-079: a missing measure derives thin).
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
   })
 
   it('collapsed and quiet: meta label, title, framing-has-the-basics line', () => {
@@ -131,7 +157,7 @@ describe('DecisionOverviewCard — ready state (live)', () => {
 describe('DecisionOverviewCard — classification pills (UI-SEM-077, L2 values-not-labels)', () => {
   beforeEach(() => {
     flagOn()
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
   })
 
   it('collapsed shows ONE muted "+N to set" aggregate, never per-field "not set" name chips', () => {
@@ -151,6 +177,7 @@ describe('DecisionOverviewCard — classification pills (UI-SEM-077, L2 values-n
   it('a FILLED field renders as a value chip; only the empty remainder aggregates', () => {
     useCanvasStore.setState({
       nodes: [
+        GOAL_NODE_WITH_MEASURE,
         {
           id: 'd1',
           type: 'decision',
@@ -177,6 +204,7 @@ describe('DecisionOverviewCard — classification pills (UI-SEM-077, L2 values-n
   it('a filled value chip still opens the Ask-Olumi drawer with the classification review ask', () => {
     useCanvasStore.setState({
       nodes: [
+        GOAL_NODE_WITH_MEASURE,
         {
           id: 'd1',
           type: 'decision',
@@ -198,7 +226,7 @@ describe('DecisionOverviewCard — classification pills (UI-SEM-077, L2 values-n
 describe('DecisionOverviewCard — brief-dimension chips', () => {
   beforeEach(() => {
     flagOn()
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
   })
 
   it('Goal chip shows the persisted success target when set', () => {
@@ -211,7 +239,9 @@ describe('DecisionOverviewCard — brief-dimension chips', () => {
   })
 
   it('Goal chip shows "Success measure missing" when no target exists (fail-closed)', () => {
-    useCanvasStore.setState({ goalThreshold: null } as never)
+    // Re-pointed (C2): the measure now lives on the node, so expressing
+    // "no measure" means clearing the node too, not just the store field.
+    useCanvasStore.setState({ goalThreshold: null, nodes: [] } as never)
     render(<DecisionOverviewCard title="t" />)
     // thin auto-expands (missing measure)
     expect(screen.getByTestId('brief-dim-goal')).toHaveTextContent(OVERVIEW_COPY.goalNoteMissing)
@@ -222,7 +252,7 @@ describe('DecisionOverviewCard — brief-dimension chips', () => {
       nodes: [
         { id: 'o1', type: 'option', position: { x: 0, y: 0 }, data: { label: 'A' } },
         { id: 'o2', type: 'option', position: { x: 0, y: 0 }, data: { label: 'B' } },
-        { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'G' } },
+        GOAL_NODE_WITH_MEASURE,
       ],
     } as never)
     render(<DecisionOverviewCard title="t" />)
@@ -306,7 +336,7 @@ describe('DecisionOverviewCard — brief-dimension chips', () => {
 describe('DecisionOverviewCard — brief-actions row', () => {
   beforeEach(() => {
     flagOn()
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
   })
 
   it('renders the review link + one-issue-at-a-time helper when expanded', () => {
@@ -361,6 +391,7 @@ describe('DecisionOverviewCard — live quality derivation (UI-SEM-079)', () => 
     resetCanvas({
       ceeAnalysisReady: READY,
       goalThreshold: 20,
+      nodes: [GOAL_NODE_WITH_MEASURE],
       graphHealth: {
         status: 'errors',
         issues: [{ id: 'i1', type: 'cycle', severity: 'blocker', message: 'x' }],
@@ -378,6 +409,7 @@ describe('DecisionOverviewCard — live quality derivation (UI-SEM-079)', () => 
     resetCanvas({
       ceeAnalysisReady: READY,
       goalThreshold: 20,
+      nodes: [GOAL_NODE_WITH_MEASURE],
       graphHealth: {
         status: 'warnings',
         issues: [{ id: 'i1', type: 'missing_label', severity: 'warning', message: 'x' }],
@@ -410,7 +442,7 @@ describe('DecisionOverviewCard — review folds (S1/S2/S3)', () => {
   })
 
   it('S3: only DISCUSSION items are promoted — a mechanical top item is not a question', () => {
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
     useGuidanceStore.setState({
       guidanceItems: [
         { item_id: 'g1', signal_code: 's', category: 'must_fix', source: 'structural', title: 'Connect the isolated risk', primary_action: { type: 'open_inspector', target_id: 'n1' }, priority: 95 },
@@ -504,7 +536,7 @@ describe('deriveFramingQuestion (UI-SEM-078, hardened)', () => {
 describe('DecisionOverviewCard — framing question (producer-backed)', () => {
   beforeEach(() => {
     flagOn()
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
   })
 
   it('promotes the TOP guidance item as the one framing question with a drawer route', () => {
@@ -576,7 +608,7 @@ describe('DecisionOverviewCard — framing-slot honesty (production leak)', () =
 
   beforeEach(() => {
     flagOn()
-    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20 })
+    resetCanvas({ ceeAnalysisReady: READY, goalThreshold: 20, nodes: [GOAL_NODE_WITH_MEASURE] })
   })
 
   it('a max-priority rerun nudge (non-interrogative detail, discuss action) never renders the framing card', () => {

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.successMeasureWire.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.successMeasureWire.spec.tsx
@@ -1,0 +1,152 @@
+/**
+ * C2 — one fact, two selectors, opposite answers.
+ *
+ * ─── THE DEFECT ────────────────────────────────────────────────────────────
+ * "Does this decision have a success measure?" was answered independently in
+ * two places, from two different sources, and they disagreed:
+ *
+ *  * `computeSuccessState.ts` (the pre-analysis hero selector) reads the WIRE:
+ *    `goalNode.data.goal_threshold_raw ?? analysisReady.goal_threshold_raw`.
+ *    A CEE-derived threshold makes it return `isSet: true` and it renders the
+ *    value with its unit. This one is honest.
+ *
+ *  * `DecisionOverviewCard` read `store.goalThreshold`, which
+ *    `deriveGoalThresholdFromNode` (canvas/store.ts) populates ONLY when
+ *    `data.threshold_source === 'user'`. A CEE-derived threshold is invisible
+ *    to it, so the card rendered "Success measure missing" — and drove its
+ *    `liveState` to `thin` — for a decision that demonstrably HAS a measure.
+ *
+ * That is a false denial: the absence of a value in the wrong field was
+ * rendered as positive evidence that the product captured nothing.
+ *
+ * ─── THE FIX IS REUSE, NOT ADDITION ────────────────────────────────────────
+ * The card now routes through the SAME two existing selectors the pre-analysis
+ * panel uses — `computeGraphFacts` for goal-node selection and
+ * `computeSuccessState` for the measure — rather than carrying a third read of
+ * its own. No new derivation was introduced: inventing a second goal-node
+ * finder here would have created exactly the mirror this lane exists to retire.
+ *
+ * ─── HONEST SCOPE CAVEAT ───────────────────────────────────────────────────
+ * For a goal with no numeric target the drafter is instructed to omit these
+ * fields entirely, so for THAT goal the chip is more useless than wrong. The
+ * selector divergence is a live latent bug regardless, and it is what this
+ * spec pins. The wider "silence rather than a false denial" question is C4.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { DecisionOverviewCard, OVERVIEW_COPY } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { computeSuccessState } from '../../../../canvas/components/pre-analysis-v3/selectors/computeSuccessState'
+import { computeGraphFacts } from '../../../../canvas/components/pre-analysis-v3/selectors/graphFacts'
+
+const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
+
+/** A goal node carrying a CEE-DERIVED display-scale anchor — no user target. */
+const GOAL_NODE_CEE_DERIVED = {
+  id: 'g1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: {
+    label: 'Maximise Total Profit Over Three Years',
+    goal_threshold_raw: 150000,
+    goal_threshold_unit: 'GBP',
+    // NOTE: no `threshold_source: 'user'`, so store.goalThreshold stays null.
+  },
+}
+
+/**
+ * Open the brief-dimension chips REGARDLESS of the card's starting state.
+ * A blind `fireEvent.click(brief-bar)` is a trap here: the derived `thin`
+ * state auto-expands, so clicking COLLAPSES it and the chips vanish. That
+ * would make an assertion fail for a reason that has nothing to do with the
+ * behaviour under test.
+ */
+function openBrief() {
+  const bar = screen.getByTestId('brief-bar')
+  if (bar.getAttribute('aria-expanded') === 'false') fireEvent.click(bar)
+}
+
+function resetCanvas(overrides: Record<string, unknown> = {}) {
+  localStorage.setItem('feature.decisionOverview', '1')
+  useCanvasStore.setState({
+    ceeAnalysisReady: null,
+    goalThreshold: null,
+    nodes: [],
+    goalConstraints: null,
+    currentBriefText: null,
+    graphHealth: null,
+    ...overrides,
+  } as never)
+}
+
+describe('C2: the Goal chip and the hero selector answer the same question the same way', () => {
+  beforeEach(() => {
+    resetCanvas()
+  })
+
+  // The premise, proven rather than asserted. If this ever fails, the rest of
+  // this file is testing something other than the divergence it claims to.
+  it('PREMISE: store.goalThreshold is null for a CEE-derived threshold, but computeSuccessState sees it', () => {
+    resetCanvas({ ceeAnalysisReady: READY, nodes: [GOAL_NODE_CEE_DERIVED] })
+
+    // The store field the card used to read: blind to a CEE-derived measure.
+    expect(useCanvasStore.getState().goalThreshold).toBeNull()
+
+    // The wire-reading selector: sees it.
+    const facts = computeGraphFacts(useCanvasStore.getState().nodes as never)
+    const success = computeSuccessState(facts.goalNode, READY as never, null, null)
+    expect(success.isSet).toBe(true)
+    expect(success.displayText).toBe('GBP 150,000')
+  })
+
+  it('renders the CEE-derived success measure instead of denying it exists', () => {
+    resetCanvas({ ceeAnalysisReady: READY, nodes: [GOAL_NODE_CEE_DERIVED] })
+    render(<DecisionOverviewCard title="t" />)
+    openBrief()
+
+    const goalChip = screen.getByTestId('brief-dim-goal')
+    expect(goalChip).not.toHaveTextContent(OVERVIEW_COPY.goalNoteMissing)
+    expect(goalChip).toHaveTextContent('150,000')
+  })
+
+  it('does not fall to the derived `thin` state when a CEE-derived measure exists', () => {
+    resetCanvas({ ceeAnalysisReady: READY, nodes: [GOAL_NODE_CEE_DERIVED] })
+    render(<DecisionOverviewCard title="t" />)
+
+    // `thin` auto-expands and claims "The goal has no success measure yet".
+    // With a measure on the wire that claim is false.
+    expect(screen.queryByText(OVERVIEW_COPY.thinLiveNote)).toBeNull()
+  })
+
+  it('still honours a USER-set target (threshold_source: user) — the existing path is unbroken', () => {
+    resetCanvas({
+      ceeAnalysisReady: { ...READY, goal_threshold_unit: 'percent' },
+      nodes: [
+        {
+          id: 'g1',
+          type: 'goal',
+          position: { x: 0, y: 0 },
+          data: { label: 'G', threshold_source: 'user', success_threshold: 20 },
+        },
+      ],
+    })
+    render(<DecisionOverviewCard title="t" />)
+    openBrief()
+    expect(screen.getByTestId('brief-dim-goal')).toHaveTextContent('20%')
+  })
+
+  // POSITIVE CONTROL for the absence assertions above: this spec CAN observe
+  // the "missing" copy. Without this, `not.toHaveTextContent(goalNoteMissing)`
+  // could pass because the chip never renders at all.
+  it('POSITIVE CONTROL: with genuinely no measure anywhere, the chip DOES say so', () => {
+    resetCanvas({
+      ceeAnalysisReady: READY,
+      nodes: [{ id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'G' } }],
+    })
+    render(<DecisionOverviewCard title="t" />)
+
+    const goalChip = screen.getByTestId('brief-dim-goal')
+    expect(goalChip).toHaveTextContent(OVERVIEW_COPY.goalNoteMissing)
+  })
+})


### PR DESCRIPTION
## ⚠️ Two things a reviewer should read first

### 1. A divergence nobody knew existed, surfaced *because* the reader was unified
Unifying the reader exposed that the two surfaces formatted the **same value** differently:

| surface | rendered |
|---|---|
| Decision Overview card (before) | `20%` |
| pre-analysis hero | `20 percent` |

**Cause:** the wire spells the unit as the **word** `'percent'` (CEE's `goal_threshold_unit`), but `classifyUnit` (`src/utils/unitClassifier.ts:80`) recognises only the **glyph** `'%'` — so `'percent'` fell through to `kind: 'other'` and rendered as a trailing suffix.

**The pre-analysis hero panel has therefore been rendering "20 percent" all along.** Nobody knew, because no single reader saw both.

Normalised inside `computeSuccessState` (`percent|percentage → '%'`) rather than widening `classifyUnit`, which is a shared primitive with many other consumers and its own tests. Both surfaces now agree, on the better of the two renderings.

**One narrowing is accepted and stated, not absorbed:** the retired `goalUnitRaw` selector also consulted `observedState.unit`, which `computeSuccessState` does not. That is a **third divergence**, on unit resolution. It is left for a follow-up rather than silently papered over in this PR.

### 2. Test re-pointing — the thing to check quickly
`DecisionOverviewCard.spec.tsx` expressed *"this decision HAS a success measure"* as `goalThreshold: 20` — the store field the card used to read. **19 tests depended on that harness assumption.**

- **Every one was re-pointed at source**, to `GOAL_NODE_WITH_MEASURE`, where the real reader now looks.
- **None deleted. None weakened. No baseline bumped. No test disabled or excluded.**
- The rationale is recorded **in the spec file itself**, next to the fixture, so the next reader does not have to find this PR.

Every test keeps its original intent and its original assertions.

---

## The defect

"Does this decision have a success measure?" was answered independently in two places, from two different sources, and they disagreed:

- **`computeSuccessState.ts`** reads the **wire**: `goalNode.data.goal_threshold_raw ?? analysisReady.goal_threshold_raw` → `isSet: true`, renders the value. **This one is honest.**
- **`DecisionOverviewCard`** read **`store.goalThreshold`**, which `deriveGoalThresholdFromNode` (`canvas/store.ts:1180-1196`) populates **only** when `data.threshold_source === 'user'`.

Verified at the bytes: `store.goalThreshold` is `null` for a goal node carrying `goal_threshold_raw`. So a **CEE-derived** threshold — the drafting path's normal output — was invisible to the card, which rendered **"Success measure missing"** *and* fell to the derived `thin` state (*"The goal has no success measure yet"*) for a decision that demonstrably had a measure on the wire.

That is a **false denial**: absence of a value in the wrong field rendered as positive evidence of absence.

## The fix is reuse, not addition

The card now routes through the **same two existing selectors** `usePreAnalysisModel` uses — `computeGraphFacts` for goal-node selection, `computeSuccessState` for the measure. No third derivation was introduced. Writing a local goal-node finder here would have minted exactly the mirror this lane exists to retire.

### Deletions this enabled
- the card's own **`goalUnitRaw`** selector — which carried a **fourth** independent goal-node finder (`nodes.find(n => n.type === 'goal')`, vs `graphFacts`' `kindOf()` **with an outcome fallback**, so the two could disagree)
- **`mapOutcomeUnit`** (a second unit vocabulary)
- the **`formatTargetValue`** import

## Evidence

| Step | Result |
|---|---|
| **RED-first** (pristine `d7c55a18`) | **3 failed / 2 passed of 5.** The **PREMISE** test passed — proving the divergence is *real* (store `null`, selector `isSet: true`), not asserted. The **POSITIVE CONTROL** passed — proving the spec can see the "missing" copy, so the absence assertions are not vacuous. |
| **GREEN — targeted** | **28 files / 501 tests passed**, covering the decision-overview suite **and the whole pre-analysis-v3 suite** (the unit change's blast radius). |
| **GREEN — broad** | `src/components/results/` + `src/canvas/components/` + `src/canvas/nodes/` → **449 files, 7467 passed, 37 skipped, 0 failed, 0 collect errors**. |
| **MUTATION** | Throwaway worktree, production files reverted to HEAD, **anchor asserted** (0 remaining `successState.isSet` reads) → **3 failed / 2 passed**: exactly the three behavioural tests, with premise and positive control still green. |
| **Typecheck gate** | **PASSED** — 2661 vs baseline 2663, **identical to the pristine-`d7c55a18` control**, so this PR is exactly gate-neutral. Baseline deliberately **not** tightened. |
| **Lint** | clean |

## Scope
Files touched: `computeSuccessState.ts`, `DecisionOverviewCard.tsx`, its two specs. **No Lane R files touched** — `store.ts` was **read only**, to verify `deriveGoalThresholdFromNode`. Lane R is actively changing scenario persistence in that file.

## Measurement hygiene
`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` were set for every measurement (placeholder values, never printed). Every run reported **0 collect-time failures**, so no run silently measured a smaller suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
