### PR TITLE
fix(overview): restore the card's own primitive-selector rule (U1)

### DIFF
--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -20,7 +20,7 @@
  * DS v4/5: bg-panel card, panel typography tokens only, Lucide, sentence
  * case, en-GB, no em dashes in prose.
  */
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 
 import { useCanvasStore } from '../../../canvas/store'
@@ -160,42 +160,81 @@ export interface DecisionOverviewCardProps {
   stateOverride?: BriefStateOverride
 }
 
+/**
+ * The card's success-measure read, as a MODULE-SCOPE selector returning a
+ * PRIMITIVE (`string | null`) — see the U1 note at its call site for why the
+ * `s.nodes` subscription it replaced was a re-render regression.
+ *
+ * Module scope (rather than an inline arrow) is deliberate: a stable function
+ * identity means Zustand does not have to re-establish the subscription on every
+ * render, and it is testable on its own.
+ *
+ * Typed against the store's own state — DERIVED from `useCanvasStore.getState`
+ * rather than mirroring a field list — so a rename of any field it reads is a
+ * COMPILE error here, not a silent `undefined`. (`CanvasState` itself is not
+ * exported from canvas/store.ts; deriving avoids widening this change into that
+ * file to obtain a type it already publishes through its own getter.)
+ */
+type CanvasStoreState = ReturnType<typeof useCanvasStore.getState>
+
+export function selectSuccessMeasureDisplayText(
+  s: Pick<CanvasStoreState, 'nodes' | 'ceeAnalysisReady' | 'goalConstraints'>,
+): string | null {
+  return computeSuccessState(
+    computeGraphFacts(s.nodes as never).goalNode,
+    (s.ceeAnalysisReady as Record<string, unknown> | null) ?? null,
+    null,
+    s.goalConstraints,
+  ).displayText
+}
+
 export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewCardProps) {
   const analysisReady = useCanvasStore((s) => s.ceeAnalysisReady)
-  // All selectors below return primitives (Zustand inline-selector rule) —
-  // except `nodes`, whose array reference is stable in the store and which is
-  // consumed through a useMemo below rather than a derived-object selector.
-  const nodes = useCanvasStore((s) => s.nodes)
-  const goalConstraints = useCanvasStore((s) => s.goalConstraints)
+  // All selectors below return primitives (Zustand inline-selector rule).
   /**
-   * SUCCESS MEASURE — one reader of one fact (C2).
+   * SUCCESS MEASURE — one reader of one fact (C2), read through ONE PRIMITIVE
+   * selector (U1).
    *
-   * This used to read `store.goalThreshold`, which `deriveGoalThresholdFromNode`
+   * C2 (why this reads the wire at all): this used to read
+   * `store.goalThreshold`, which `deriveGoalThresholdFromNode`
    * (canvas/store.ts) populates ONLY when `data.threshold_source === 'user'`.
    * A CEE-DERIVED threshold (`goal_threshold_raw`, the drafting path's normal
    * output) therefore never reached this card, and it rendered "Success
    * measure missing" — and fell to the derived `thin` state — for a decision
    * that demonstrably had a measure. Meanwhile `computeSuccessState`, reading
    * the same fact off the wire two panels away, returned `isSet: true` and
-   * rendered the value. One fact, two selectors, opposite answers; the one
-   * the user saw was the wrong one.
+   * rendered the value. One fact, two selectors, opposite answers; the one the
+   * user saw was the wrong one. Fixed by REUSING the existing pair rather than
+   * adding a third read: `computeGraphFacts` for goal-node selection and
+   * `computeSuccessState` for the measure — exactly what `usePreAnalysisModel`
+   * does. A local goal-node finder here would have minted precisely the kind of
+   * mirror that change exists to retire.
    *
-   * Fixed by REUSING the existing pair rather than adding a third read:
-   * `computeGraphFacts` for goal-node selection and `computeSuccessState` for
-   * the measure — exactly what `usePreAnalysisModel` does. Writing a local
-   * goal-node finder here would have minted precisely the kind of mirror this
-   * change exists to retire.
+   * U1 (why it is ONE primitive selector and not `s.nodes` + a useMemo): C2
+   * subscribed to `s.nodes` and `s.goalConstraints` directly, on the stated
+   * grounds that the `nodes` array reference "is stable in the store". It is
+   * not. `onNodesChange` does `applyNodeChanges(changes, s.nodes)`, which
+   * returns a NEW array for every change including `position` — once per drag
+   * frame — so `Object.is` stopped suppressing anything and this card
+   * re-rendered its whole subtree while the user dragged. That is the normal
+   * case, not an edge case: OutputsDock mounts the card exactly when a
+   * completed analysis sits beside the canvas, which is when the user drags
+   * nodes to revise.
+   *
+   * Computing INSIDE the selector is strictly less work than the subscription
+   * it replaces: `computeGraphFacts` is one O(nodes) pass and
+   * `computeSuccessState` is O(constraints), against a full subtree re-render
+   * per frame.
+   *
+   * `isSet` is NOT a second subscription: `computeSuccessState` returns a
+   * non-null `displayText` on exactly the branches where `isSet` is true, on
+   * all six return sites. That coupling is pinned by
+   * `__tests__/DecisionOverviewCard.primitiveSelectors.spec.tsx` ("INVARIANT"),
+   * so it cannot drift silently into the card claiming a measure is missing
+   * beside a rendered value.
    */
-  const successState = useMemo(
-    () =>
-      computeSuccessState(
-        computeGraphFacts(nodes as never).goalNode,
-        (analysisReady as Record<string, unknown> | null) ?? null,
-        null,
-        goalConstraints,
-      ),
-    [nodes, analysisReady, goalConstraints],
-  )
+  const successDisplayText = useCanvasStore(selectSuccessMeasureDisplayText)
+  const successIsSet = successDisplayText !== null
   const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
   const optionCount = useCanvasStore((s) => s.nodes.filter((n) => n.type === 'option').length)
   const constraintCount = useCanvasStore((s) => s.goalConstraints?.length ?? 0)
@@ -251,7 +290,7 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
       ? 'blocked'
       : analysisReady.status !== 'ready'
         ? 'needs_input'
-        : !successState.isSet
+        : !successIsSet
           ? 'thin'
           : 'ready'
   const state: BriefState = stateOverride ?? liveState
@@ -320,9 +359,9 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   const goalNote =
     savedMeasure != null
       ? `${savedMeasure.metric}: ${savedMeasure.direction === 'decrease_below' ? '≤' : '≥'} ${savedMeasure.threshold}${savedMeasure.unit === 'none' ? '' : savedMeasure.unit}, ${savedMeasure.timeframe}`
-      : !successState.isSet
+      : !successIsSet
         ? OVERVIEW_COPY.goalNoteMissing
-        : `Success target ≥ ${successState.displayText}`
+        : `Success target ≥ ${successDisplayText}`
   // CONTEXT — no claim, rather than a false denial.
   //
   // `currentBriefText` has exactly ONE non-null writer in the whole of src/:

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.primitiveSelectors.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.primitiveSelectors.spec.tsx
@@ -1,0 +1,210 @@
+/**
+ * U1 — the Zustand primitive-selector rule the card's own header states.
+ *
+ * ─── THE DEFECT ────────────────────────────────────────────────────────────
+ * #486 (C2) replaced two PRIMITIVE subscriptions (`s.goalThreshold` and an
+ * inline `goalUnitRaw` read) with `useCanvasStore((s) => s.nodes)` plus a
+ * `useMemo`, justified in-file by the claim that the `nodes` array reference
+ * "is stable in the store".
+ *
+ * That claim is FALSE while the user edits. `canvas/store.ts` (`onNodesChange`)
+ * does `applyNodeChanges(changes, s.nodes)` inside `set((s) => …)`, and
+ * `applyNodeChanges` returns a NEW array for every change it applies —
+ * including `type: 'position'`, i.e. once per drag frame. Zustand's default
+ * `Object.is` equality therefore stopped suppressing anything: the card
+ * re-rendered its whole subtree on every frame of every node drag.
+ *
+ * The live path makes that the normal case rather than an edge case: OutputsDock
+ * mounts the card under `!isPreRun && hasInlineSummary && resultsSectionData`,
+ * i.e. precisely when a completed analysis is on screen beside the canvas —
+ * which is when a user drags nodes to revise the graph.
+ *
+ * ─── WHAT THIS SPEC PINS ───────────────────────────────────────────────────
+ * 1. A position-only node change, dispatched through the store's REAL
+ *    `onNodesChange` action, does not commit the card again.
+ * 2. Replacing `goalConstraints` with a NEW array of equal content does not
+ *    commit it again (the other object subscription #486 added).
+ * 3. POSITIVE CONTROLS: changes that DO alter what the card renders commit it.
+ *    Without these, (1) and (2) could pass because the counter is broken, or
+ *    because the card never commits for any reason at all.
+ * 4. The invariant the single primitive selector relies on:
+ *    `computeSuccessState().isSet === (displayText !== null)` on EVERY return
+ *    site, so one primitive carries both facts the card consumes. If a future
+ *    branch breaks that, this fails loudly rather than the card silently
+ *    rendering "success measure missing" beside a value.
+ *
+ * ─── EVIDENCE TYPE (stated plainly — CLAUDE.md trap 3) ─────────────────────
+ * MEASURED, in jsdom, for the thing at issue: React COMMITS of the card's
+ * subtree, counted by `<Profiler onRender>`. Those are plain JS and are
+ * observable here. What jsdom cannot prove — and what this spec therefore does
+ * NOT claim — is anything about layout, paint, or wall-clock frame cost in a
+ * real browser. The claim is "the subtree does not re-commit", not "the frame
+ * got faster".
+ */
+import { Profiler } from 'react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { act, render } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+import { DecisionOverviewCard } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { computeSuccessState } from '../../../../canvas/components/pre-analysis-v3/selectors/computeSuccessState'
+
+const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
+
+const GOAL_NODE: Node = {
+  id: 'g1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'Maximise total profit', goal_threshold_raw: 150000, goal_threshold_unit: 'GBP' },
+}
+
+const OPTION_NODE: Node = {
+  id: 'o1',
+  type: 'option',
+  position: { x: 200, y: 0 },
+  data: { label: 'Option A' },
+}
+
+function resetCanvas(overrides: Record<string, unknown> = {}) {
+  localStorage.setItem('feature.decisionOverview', '1')
+  useCanvasStore.setState({
+    ceeAnalysisReady: READY,
+    goalThreshold: null,
+    nodes: [GOAL_NODE, OPTION_NODE],
+    goalConstraints: null,
+    currentBriefText: null,
+    graphHealth: null,
+    ...overrides,
+  } as never)
+}
+
+/**
+ * `<Profiler onRender>` fires once per COMMIT of the profiled subtree. A store
+ * notification a selector suppresses produces no commit at all, so the count
+ * does not move; one it does not suppress produces a commit. The `Profiler`
+ * wrapper itself never re-renders on its own — nothing above it subscribes to
+ * anything — so every observed commit originates in the card's own selectors.
+ */
+function mountProfiled() {
+  let commits = 0
+  const utils = render(
+    <Profiler
+      id="decision-overview-card"
+      onRender={() => {
+        commits++
+      }}
+    >
+      <DecisionOverviewCard title="t" />
+    </Profiler>,
+  )
+  return { ...utils, commits: () => commits }
+}
+
+describe('U1: the card commits only when a value it renders changes', () => {
+  beforeEach(() => {
+    resetCanvas()
+  })
+
+  it('does NOT re-commit on a position-only node change (the drag frame)', () => {
+    const { commits } = mountProfiled()
+    const before = commits()
+    expect(before).toBeGreaterThan(0) // the mount itself committed
+    const nodesBefore = useCanvasStore.getState().nodes
+
+    act(() => {
+      // Exactly what React Flow dispatches per drag frame, routed through the
+      // store's REAL action — so this cannot pass by faking a cheaper update
+      // than the product performs.
+      useCanvasStore.getState().onNodesChange([
+        { id: 'g1', type: 'position', position: { x: 40, y: 12 }, dragging: true },
+      ] as never)
+    })
+
+    // PREMISE, proven not assumed: the store really did apply the change AND
+    // really did hand out a NEW array identity. If either were false this test
+    // would be vacuous — the whole defect is that identity churn.
+    expect(useCanvasStore.getState().nodes.find((n) => n.id === 'g1')?.position).toEqual({
+      x: 40,
+      y: 12,
+    })
+    expect(useCanvasStore.getState().nodes).not.toBe(nodesBefore)
+
+    expect(commits()).toBe(before)
+  })
+
+  it('does NOT re-commit when goalConstraints is replaced by an equal-content array', () => {
+    resetCanvas({ goalConstraints: [{ provenance: 'inferred', value: 1 }] })
+    const { commits } = mountProfiled()
+    const before = commits()
+
+    act(() => {
+      useCanvasStore.setState({ goalConstraints: [{ provenance: 'inferred', value: 1 }] } as never)
+    })
+
+    expect(commits()).toBe(before)
+  })
+
+  it('POSITIVE CONTROL: it DOES re-commit when the success measure itself changes', () => {
+    const { commits } = mountProfiled()
+    const before = commits()
+
+    act(() => {
+      useCanvasStore.setState({
+        nodes: [
+          { ...GOAL_NODE, data: { ...(GOAL_NODE.data as object), goal_threshold_raw: 999 } },
+          OPTION_NODE,
+        ],
+      } as never)
+    })
+
+    expect(commits()).toBeGreaterThan(before)
+  })
+
+  it('POSITIVE CONTROL: it DOES re-commit when the option count changes', () => {
+    const { commits } = mountProfiled()
+    const before = commits()
+
+    act(() => {
+      useCanvasStore.setState({
+        nodes: [GOAL_NODE, OPTION_NODE, { ...OPTION_NODE, id: 'o2' }],
+      } as never)
+    })
+
+    expect(commits()).toBeGreaterThan(before)
+  })
+
+  // The coupling the single primitive selector relies on, enumerated over every
+  // return site of computeSuccessState so a new branch cannot break it quietly.
+  it('INVARIANT: computeSuccessState.isSet === (displayText !== null) on every branch', () => {
+    const cases: Array<{ name: string; node: Node | null; ready: Record<string, unknown> | null }> = [
+      { name: 'no goal node', node: null, ready: null },
+      {
+        name: 'user-set measure',
+        node: { ...GOAL_NODE, data: { threshold_source: 'user', success_threshold: 20 } },
+        ready: null,
+      },
+      { name: 'CEE-derived display anchor on the node', node: GOAL_NODE, ready: READY },
+      {
+        name: 'CEE-derived anchor from analysisReady only',
+        node: { ...GOAL_NODE, data: { label: 'g' } },
+        ready: { goal_threshold_raw: 7, goal_threshold_unit: '%' },
+      },
+      {
+        name: 'normalised-only threshold (degraded to unset)',
+        node: { ...GOAL_NODE, data: { goal_threshold: 0.2 } },
+        ready: null,
+      },
+      {
+        name: 'goal node with nothing on it',
+        node: { ...GOAL_NODE, data: { label: 'g' } },
+        ready: null,
+      },
+    ]
+
+    for (const c of cases) {
+      const s = computeSuccessState(c.node, c.ready, null, null)
+      expect(s.isSet, `${c.name}: isSet must equal displayText !== null`).toBe(s.displayText !== null)
+    }
+  })
+})


### PR DESCRIPTION
## U1 (P1) — #486 shipped a per-drag-frame re-render regression, behind a false in-file justification

`src/components/results/decision-overview/DecisionOverviewCard.tsx`

### The defect, at the bytes

#486 replaced `useCanvasStore((s) => s.goalThreshold)` and an inline `goalUnitRaw` selector — both returning **primitives**, so Zustand's `Object.is` suppressed the re-render — with `useCanvasStore((s) => s.nodes)` + `useCanvasStore((s) => s.goalConstraints)` plus a `useMemo`. The in-file comment justified it:

> except `nodes`, whose array reference **is stable in the store**

**That is false while the user edits.** `canvas/store.ts:1832`, inside `onNodesChange`'s `set((s) => …)`:

```ts
const updatedNodes = applyNodeChanges(changes, s.nodes)
```

`applyNodeChanges` returns a **new array for every change it applies, including `type: 'position'`** — once per drag frame. (`:1820` in the same function reads `c.type === 'position' && c.dragging`, so the drag path provably lands here.) With `Object.is` no longer suppressing anything, the card re-rendered its whole subtree per frame.

**The card's own header states the rule the diff broke:** *"All selectors below return primitives (Zustand inline-selector rule)."*

**And it is the normal case, not an edge case.** `netlify.toml:78` sets `VITE_FEATURE_DECISION_OVERVIEW="1"`; `OutputsDock.tsx:2350` mounts the card under `!isPreRun && hasInlineSummary && resultsSectionData` — exactly when a completed analysis is on screen beside the canvas, which is when a user drags nodes to revise the graph.

### The fix

One module-scope selector that computes **inside** the selector and returns a `string | null` **primitive**:

```ts
export function selectSuccessMeasureDisplayText(
  s: Pick<CanvasStoreState, 'nodes' | 'ceeAnalysisReady' | 'goalConstraints'>,
): string | null
```

Strictly less work than the subscription it replaces: `computeGraphFacts` is one O(nodes) pass and `computeSuccessState` is O(constraints), against a full subtree re-render per frame.

Three details worth the reviewer's attention:

1. **`isSet` is not a second subscription.** `computeSuccessState` returns a non-null `displayText` on exactly the branches where `isSet` is true — all six return sites. So `successIsSet = successDisplayText !== null` carries both facts through one primitive. That coupling is now **pinned by an enumerated test over every branch**, not assumed: if a future branch breaks it, the test fails rather than the card silently rendering "success measure missing" beside a value.
2. **The selector's parameter type is DERIVED**, `ReturnType<typeof useCanvasStore.getState>`, not a hand-listed field set (trap 12). Renaming any field it reads is a compile error here. `CanvasState` is not exported from `canvas/store.ts`; deriving avoids widening this change into that file for a type it already publishes through its own getter.
3. **Module scope rather than an inline arrow**, so the function identity is stable and the selector is testable on its own.

### On the second half of the finding — a correction

The report also asked that `optionCount` / `constraintCount` be derived from values already in scope rather than subscribing twice. **That double subscription existed only BECAUSE #486 added the direct `s.nodes` / `s.goalConstraints` subscriptions.** With those gone there is nothing in scope to derive from, and both are already correct primitive selectors. Left as they are, deliberately.

`optionCount` is also **not** folded into `computeGraphFacts`' own `optionCount` field, even though the pass now runs anyway: that counts `kindOf(node)` (which prefers `data.kind` over `node.type`), the card counts `n.type === 'option'`. Silently swapping one semantic for the other is a different change and does not belong in this one.

### Evidence

**RED-first**, at `585d26cb` with the new spec and the old card:

```
 Tests  2 failed | 3 passed (5)
 ✗ does NOT re-commit on a position-only node change   AssertionError: expected 3 to be 1
 ✗ does NOT re-commit when goalConstraints is replaced by an equal-content array
 ✓ POSITIVE CONTROL: it DOES re-commit when the success measure itself changes
 ✓ POSITIVE CONTROL: it DOES re-commit when the option count changes
 ✓ INVARIANT: isSet === (displayText !== null) on every branch
```
Both positive controls passed **before** the fix, so the counter provably discriminated rather than being stuck.

**MUTATION-CHECK** — throwaway worktree at `…/scratchpad/uicl-MUTATION-u1`, **outside** the repo root (trap 9c), anchor asserted unique before writing, worktree removed before any gate run. Re-introducing `useCanvasStore((s) => s.nodes)` + `(s) => s.goalConstraints`:

```
 Tests  2 failed | 3 passed (5)
```
The pin bites.

**GREEN**: 73/73 across `src/components/results/decision-overview`, including #486's own `DecisionOverviewCard.successMeasureWire.spec.tsx` **unchanged**. Wider: `src/components/results src/canvas/components/pre-analysis src/components/shared` → **263 files passed, 1 skipped; 4,861 tests passed, 13 skipped**.

**GATE** — `bash scripts/ci/typecheck-gate.sh` (the script `pnpm typecheck` runs at this tip, read from `package.json`):

```
   3033 / 3051 tracked TypeScript files loaded (18 declared out of scope)
   within baseline — 666 file(s) / 2661 error(s) (baseline: 2663)
::notice::Drift shrank (2663 → 2661)
✅ Typecheck gate PASSED
```

**Gate-neutral, proven with a pristine control**, not asserted: a detached worktree at pristine `585d26cb` produces `3032 / 3050` files and the **identical** `2661 / 2663` counts and the **identical** shrink notice. So the `Drift shrank` notice is pre-existing on `staging` and is not this PR's. **No `--update-baseline` was run.** The +1 file is the new spec, which the gate loads.

### Evidence type, stated plainly (trap 3)

**MEASURED** in jsdom, of the thing at issue: React **commits** of the card's subtree, counted by `<Profiler onRender>`. Those are plain JS and are observable here. The store change is dispatched through the store's **real** `onNodesChange` action, and the spec proves its own premise (the array identity really did change) before asserting the absence — so it cannot be vacuous.

**NOT measured, and not claimed**: layout, paint, or wall-clock frame cost. jsdom cannot prove those. The claim is *"the subtree does not re-commit"*, not *"the frame got faster"*.

### Not fixed here, flagged

`analysisReady = useCanvasStore((s) => s.ceeAnalysisReady)` (`:164`) is still an **object** subscription and predates #486. It is not a per-frame hazard — `ceeAnalysisReady` is replaced only when a new readiness payload arrives — and the card reads three fields off it, so narrowing it is a separate change. Named rather than silently absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
