### PR TITLE
fix(v5): resolve leader across the option id/label identity space (1.222)

### DIFF
--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -18,6 +18,7 @@ import { type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import type { V5AnalysisResultBlock as V5AnalysisResultBlockType } from '../../canvas/conversation/types'
 import { extractDecisionReview } from '../decisionReviewAdapter'
+import { resolveLeaderKeys } from '../mapV5AnalysisToReport'
 import { calibrateUncertaintyCopy } from '../../components/results/utils/uncertaintyCalibration'
 
 export interface V5AnalysisResultBlockProps {
@@ -81,12 +82,20 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
   const uncertaintyInputs = resolveUncertaintyInputs(block.enrichment, block.leading_option_id)
   const uncertaintyCopy = calibrateUncertaintyCopy(uncertaintyInputs)
 
+  // `win_probabilities` is keyed by option LABEL on real staging payloads while
+  // `leading_option_id` is an option ID, so a key === leading_option_id test
+  // matches nothing. Resolve the leader's keys once, in whichever space the
+  // producer used. Empty set (e.g. leading_option_id null on a withheld turn)
+  // ⇒ no pill is marked.
+  const leaderKeys = resolveLeaderKeys(block.enrichment, block.leading_option_id)
+
   // Sort so the leading option appears first and the rest descending by prob.
   const sortedProbs = hasProbs
     ? Object.entries(block.win_probabilities as Record<string, number>).sort(
-        ([idA, pA], [idB, pB]) => {
-          if (idA === block.leading_option_id) return -1
-          if (idB === block.leading_option_id) return 1
+        ([keyA, pA], [keyB, pB]) => {
+          const aLeads = leaderKeys.has(keyA)
+          const bLeads = leaderKeys.has(keyB)
+          if (aLeads !== bLeads) return aLeads ? -1 : 1
           return pB - pA
         },
       )
@@ -124,11 +133,17 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
           aria-label="Option win probabilities"
           data-testid="v5-analysis-result-probabilities"
         >
-          {sortedProbs.map(([optionId, prob]) => {
-            const isLeader = optionId === block.leading_option_id
+          {/*
+            `optionKey` is the win_probabilities KEY — an option LABEL on real
+            staging payloads, an option_id on some paths. It is the human string
+            we render, so it is NOT renamed to optionId: the previous name is
+            what disguised the identity-space mismatch fixed here.
+          */}
+          {sortedProbs.map(([optionKey, prob]) => {
+            const isLeader = leaderKeys.has(optionKey)
             return (
               <span
-                key={optionId}
+                key={optionKey}
                 role="listitem"
                 className={[
                   'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5',
@@ -138,7 +153,7 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
                 ].join(' ')}
                 data-leader={isLeader ? 'true' : 'false'}
               >
-                <span className="font-medium">{optionId}</span>
+                <span className="font-medium">{optionKey}</span>
                 <span className="text-text-light">·</span>
                 <span>{formatProbability(prob)}</span>
               </span>

--- a/src/v5/blocks/__tests__/V5AnalysisResultBlock.leaderIdentity.spec.tsx
+++ b/src/v5/blocks/__tests__/V5AnalysisResultBlock.leaderIdentity.spec.tsx
@@ -1,0 +1,283 @@
+/**
+ * V5AnalysisResultBlock — leader identity-space resolution (ROADMAP 1.222).
+ *
+ * DEFECT: `leading_option_id` is an option ID (`opt_mac`); `block.win_probabilities`
+ * is keyed by option LABEL (`"Standardise on MacBook Pro"`) on real staging
+ * payloads. The component compared the map KEY to `leading_option_id`, so
+ * `isLeader` was ALWAYS false and the `data-leader="true"` branch was
+ * unreachable in production — an UNDER-claim: no error, no warning, the leader
+ * simply never got marked.
+ *
+ * The fixtures below are taken from a real captured staging turn
+ * (proxy/v5/turn, 2026-07-26): `leading_option_id: "opt_mac"` with
+ * `win_probabilities` keyed by the three option labels, and
+ * `enrichment.option_comparison[]` carrying BOTH `id`/`option_id` and
+ * `label`/`option_label`. The pre-existing spec in this directory keys
+ * win_probabilities by option_id — a shape the wire does not produce — which is
+ * why the whole suite stayed green over a dead branch.
+ *
+ * The withheld-turn control (leading_option_id: null ⇒ NO leader) is the
+ * regression guard for the opposite direction (ROADMAP 1.223, over-claim
+ * suppression). It must hold under every keying.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import { V5AnalysisResultBlock } from '../V5AnalysisResultBlock'
+import type { V5AnalysisResultBlock as V5AnalysisResultBlockType } from '../../../canvas/conversation/types'
+
+afterEach(cleanup)
+
+const MAC = 'Standardise on MacBook Pro'
+const DELL = 'Standardise on Dell XPS'
+const STATUS_QUO = 'Defer and Keep Current Machines (Status Quo)'
+
+/** enrichment.option_comparison[] exactly as the captured wire carries it. */
+function optionComparison(): Array<Record<string, unknown>> {
+  return [
+    {
+      id: 'opt_dell',
+      option_id: 'opt_dell',
+      label: DELL,
+      option_label: DELL,
+      win_probability: 0.32341666666666663,
+    },
+    {
+      id: 'opt_mac',
+      option_id: 'opt_mac',
+      label: MAC,
+      option_label: MAC,
+      win_probability: 0.4276666666666667,
+    },
+    {
+      id: 'opt_status_quo',
+      option_id: 'opt_status_quo',
+      label: STATUS_QUO,
+      option_label: STATUS_QUO,
+      win_probability: 0.24891666666666665,
+    },
+  ]
+}
+
+/** enrichment.decision_brief.options[] as the captured wire carries it. */
+function decisionBriefOptions(): Array<Record<string, unknown>> {
+  return [
+    { option_id: 'opt_mac', label: MAC, win_probability: 0.4276666666666667, rank: 1 },
+    { option_id: 'opt_dell', label: DELL, win_probability: 0.32341666666666663, rank: 2 },
+    { option_id: 'opt_status_quo', label: STATUS_QUO, win_probability: 0.24891666666666665, rank: 3 },
+  ]
+}
+
+/** Label-keyed win_probabilities — the real staging shape. */
+function labelKeyedProbs(): Record<string, number> {
+  return {
+    [DELL]: 0.32341666666666663,
+    [MAC]: 0.4276666666666667,
+    [STATUS_QUO]: 0.24891666666666665,
+  }
+}
+
+function block(overrides: Partial<V5AnalysisResultBlockType> = {}): V5AnalysisResultBlockType {
+  return {
+    type: 'v5_analysis_result',
+    summary: 'MacBook Pro leads on total cost of ownership.',
+    leading_option_id: 'opt_mac',
+    win_probabilities: labelKeyedProbs(),
+    enrichment: { option_comparison: optionComparison() },
+    ...overrides,
+  }
+}
+
+function pills(): HTMLElement[] {
+  return within(screen.getByTestId('v5-analysis-result-probabilities')).getAllByRole('listitem')
+}
+
+function leaderPills(): HTMLElement[] {
+  return pills().filter((p) => p.getAttribute('data-leader') === 'true')
+}
+
+describe('V5AnalysisResultBlock — leader identity space (1.222)', () => {
+  it('marks the leader when win_probabilities is keyed by LABEL and leading_option_id is an ID', () => {
+    // RED before the fix: `optionKey === block.leading_option_id` never matched,
+    // so this found zero leader pills.
+    render(<V5AnalysisResultBlock block={block()} />)
+
+    const leaders = leaderPills()
+    expect(leaders).toHaveLength(1)
+    expect(leaders[0]).toHaveTextContent(MAC)
+  })
+
+  it('hoists the leader to first position even when it is not the highest key by sort order', () => {
+    // RED before the fix: the comparator's leader clause never fired, so the
+    // list came back in pure descending-probability order. Give the leader a
+    // LOWER probability than another option so descending order alone cannot
+    // produce a passing result — the leader clause is the only thing that can.
+    render(
+      <V5AnalysisResultBlock
+        block={block({
+          win_probabilities: { [DELL]: 0.61, [MAC]: 0.22, [STATUS_QUO]: 0.17 },
+        })}
+      />,
+    )
+
+    const rendered = pills()
+    expect(rendered[0]).toHaveTextContent(MAC)
+    expect(rendered[0].getAttribute('data-leader')).toBe('true')
+    // The remainder stay in descending probability order.
+    expect(rendered[1]).toHaveTextContent(DELL)
+    expect(rendered[2]).toHaveTextContent(STATUS_QUO)
+  })
+
+  it('resolves via decision_brief.options[] when option_comparison is absent', () => {
+    render(
+      <V5AnalysisResultBlock
+        block={block({
+          enrichment: { decision_brief: { options: decisionBriefOptions() } },
+        })}
+      />,
+    )
+
+    const leaders = leaderPills()
+    expect(leaders).toHaveLength(1)
+    expect(leaders[0]).toHaveTextContent(MAC)
+  })
+
+  it('still marks the leader when win_probabilities is keyed by option_id', () => {
+    // The other identity space must keep working — the fix is additive, not a swap.
+    render(
+      <V5AnalysisResultBlock
+        block={block({
+          win_probabilities: { opt_dell: 0.32, opt_mac: 0.43, opt_status_quo: 0.25 },
+        })}
+      />,
+    )
+
+    const leaders = leaderPills()
+    expect(leaders).toHaveLength(1)
+    expect(leaders[0]).toHaveTextContent('opt_mac')
+  })
+
+  describe('fails closed — must never become an OVER-claim (guards 1.223)', () => {
+    it('marks NO leader when leading_option_id is null, label-keyed', () => {
+      render(<V5AnalysisResultBlock block={block({ leading_option_id: null })} />)
+      expect(pills()).toHaveLength(3)
+      expect(leaderPills()).toHaveLength(0)
+    })
+
+    it('marks NO leader when leading_option_id is null, id-keyed', () => {
+      render(
+        <V5AnalysisResultBlock
+          block={block({
+            leading_option_id: null,
+            win_probabilities: { opt_dell: 0.32, opt_mac: 0.43, opt_status_quo: 0.25 },
+          })}
+        />,
+      )
+      expect(pills()).toHaveLength(3)
+      expect(leaderPills()).toHaveLength(0)
+    })
+
+    it('marks NO leader when leading_option_id is the empty string', () => {
+      render(<V5AnalysisResultBlock block={block({ leading_option_id: '' })} />)
+      expect(leaderPills()).toHaveLength(0)
+    })
+
+    it('marks NO leader when the leader label is shared by two options', () => {
+      // A label-keyed Record cannot disambiguate two options sharing a label.
+      // Marking both pills is false precision; marking neither is an honest miss.
+      const shared = 'Standardise on a laptop'
+      render(
+        <V5AnalysisResultBlock
+          block={block({
+            win_probabilities: { [shared]: 0.55, [STATUS_QUO]: 0.45 },
+            enrichment: {
+              option_comparison: [
+                { id: 'opt_mac', option_id: 'opt_mac', label: shared, option_label: shared },
+                { id: 'opt_dell', option_id: 'opt_dell', label: shared, option_label: shared },
+                {
+                  id: 'opt_status_quo',
+                  option_id: 'opt_status_quo',
+                  label: STATUS_QUO,
+                  option_label: STATUS_QUO,
+                },
+              ],
+            },
+          })}
+        />,
+      )
+      expect(leaderPills()).toHaveLength(0)
+    })
+
+    it('marks NO leader when leading_option_id resolves to no option at all', () => {
+      render(<V5AnalysisResultBlock block={block({ leading_option_id: 'opt_ghost' })} />)
+      expect(pills()).toHaveLength(3)
+      expect(leaderPills()).toHaveLength(0)
+    })
+  })
+
+  describe('does not crash when enrichment members are absent (withheld turns)', () => {
+    it('renders with no enrichment at all', () => {
+      render(<V5AnalysisResultBlock block={block({ enrichment: undefined })} />)
+      expect(pills()).toHaveLength(3)
+      // No id↔label source ⇒ only the id itself can match; keys are labels ⇒ honest miss.
+      expect(leaderPills()).toHaveLength(0)
+    })
+
+    it('renders when decision_brief is present but stripped of options', () => {
+      // CEE PR #711 strips decision_brief members on withheld turns.
+      render(
+        <V5AnalysisResultBlock
+          block={block({
+            leading_option_id: null,
+            enrichment: { decision_brief: { brief_id: 'b1', analysis_summary: 'x' } },
+          })}
+        />,
+      )
+      expect(pills()).toHaveLength(3)
+      expect(leaderPills()).toHaveLength(0)
+    })
+
+    it('renders when option_comparison is a non-array (malformed passthrough)', () => {
+      render(
+        <V5AnalysisResultBlock
+          block={block({ enrichment: { option_comparison: 'unavailable' } })}
+        />,
+      )
+      expect(pills()).toHaveLength(3)
+      expect(leaderPills()).toHaveLength(0)
+    })
+  })
+})
+
+/**
+ * CONTROL — NOT a regression pin for this change.
+ *
+ * Paul's brief listed `resolveUncertaintyInputs` (headline-option resolution)
+ * as a fourth dead site. It is NOT: it matches `option_comparison[].id ??
+ * .option_id` against `leading_option_id`, which is ID-space on BOTH sides, and
+ * the deployed chunk shows the same. These assertions pass before and after the
+ * fix; they exist so the refutation is executable rather than asserted, and so a
+ * future edit that "helpfully" points that lookup at the label space fails here.
+ */
+describe('CONTROL: headline-option resolution was already ID↔ID (refutes brief site 3)', () => {
+  it('picks the LEADER option outcome, not entries[0], under label-keyed probabilities', () => {
+    const withOutcomes = optionComparison().map((e) =>
+      e.option_id === 'opt_mac'
+        ? { ...e, outcome: { p10: 0.1, p50: 0.25, p90: 0.4 } }
+        : { ...e, outcome: { p10: -0.9, p50: 0.0, p90: 0.9 } },
+    )
+    render(
+      <V5AnalysisResultBlock
+        block={block({
+          enrichment: { option_comparison: withOutcomes, robustness: { level: 'high' } },
+        })}
+      />,
+    )
+    // opt_mac is entries[1]. Its tight interval yields the confident copy;
+    // entries[0] (opt_dell) straddles zero and would be downgraded to the
+    // "meaningful uncertainty" wording.
+    expect(screen.getByTestId('v5-analysis-result-uncertainty-copy')).toHaveTextContent(
+      'This result looks fairly confident.',
+    )
+  })
+})

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -314,6 +314,97 @@ function resolveOptionEntries(
   return out
 }
 
+/**
+ * Fallback id↔label source: `enrichment.decision_brief.options[]`, whose
+ * entries carry `option_id` + `label`. Used ONLY when `option_comparison` is
+ * absent (it can be — the wire carries a sibling `option_comparison_status`
+ * precisely because that array is not guaranteed). Both sources are supplied
+ * by the producer on the same payload, so this is a fallback chain over
+ * derived data, NOT a second hand-maintained mapping.
+ */
+function resolveDecisionBriefOptions(
+  enrichment: Record<string, unknown> | undefined,
+): ResolvedOptionIdentity[] {
+  const brief = isPlainObject(enrichment?.decision_brief)
+    ? (enrichment!.decision_brief as Record<string, unknown>)
+    : undefined
+  const raw = brief?.options
+  if (!Array.isArray(raw)) return []
+  const out: ResolvedOptionIdentity[] = []
+  for (const entry of raw) {
+    if (!isPlainObject(entry)) continue
+    const optionId = safeString(entry.option_id) ?? safeString(entry.id)
+    if (!optionId) continue
+    out.push({ optionId, label: safeString(entry.label) ?? safeString(entry.option_label) })
+  }
+  return out
+}
+
+interface ResolvedOptionIdentity {
+  optionId: string
+  label: string | undefined
+}
+
+/**
+ * Resolve every `block.win_probabilities` KEY that denotes the leading option.
+ *
+ * The two fields live in DIFFERENT IDENTITY SPACES. `leading_option_id` is an
+ * option ID (`opt_mac`); `win_probabilities` is keyed by option LABEL
+ * (`"Standardise on MacBook Pro"`) on real staging payloads — the same fact
+ * `resolveOptionEntries` above was written for. Comparing a map key to
+ * `leading_option_id` directly therefore matches NOTHING whenever the producer
+ * keys by label: no error, no warning, the leader simply never gets marked.
+ * That is an UNDER-claim, and it made the leader treatment in
+ * V5AnalysisResultBlock unreachable in production.
+ *
+ * Callers iterating `Object.entries(win_probabilities)` test membership of this
+ * set instead, so they work under EITHER keying without having to know which
+ * one the producer used. The id↔label pairing is derived from the same wire
+ * payload (`enrichment.option_comparison[]`, falling back to
+ * `enrichment.decision_brief.options[]`) — there is no second mapping for
+ * anyone to keep in sync.
+ *
+ * Fails closed in both directions — this must never become an OVER-claim:
+ *   - `leadingOptionId` null/absent/empty → EMPTY set → no key is a leader.
+ *     This is the withheld-turn contract; CEE sends `leading_option_id: null`
+ *     when the leader is suppressed and no pill may be marked.
+ *   - a leader label shared by more than one option → the label is omitted.
+ *     A label-keyed Record cannot disambiguate two options sharing a label;
+ *     marking both pills as leader is false precision, marking neither is an
+ *     honest miss. Same rule, same reason as the `labelIsUnique` guard used
+ *     for option_probabilities below.
+ */
+export function resolveLeaderKeys(
+  enrichment: Record<string, unknown> | undefined,
+  leadingOptionId: string | null | undefined,
+): ReadonlySet<string> {
+  if (typeof leadingOptionId !== 'string' || leadingOptionId === '') {
+    return new Set<string>()
+  }
+  // The id itself always counts: some paths/fixtures DO key by option_id.
+  const keys = new Set<string>([leadingOptionId])
+
+  const fromComparison: ResolvedOptionIdentity[] = resolveOptionEntries(enrichment).map((r) => ({
+    optionId: r.optionId,
+    label: r.optionLabel,
+  }))
+  const identities =
+    fromComparison.length > 0 ? fromComparison : resolveDecisionBriefOptions(enrichment)
+
+  const labelOccurrences = new Map<string, number>()
+  for (const identity of identities) {
+    if (identity.label !== undefined) {
+      labelOccurrences.set(identity.label, (labelOccurrences.get(identity.label) ?? 0) + 1)
+    }
+  }
+
+  const leaderLabel = identities.find((i) => i.optionId === leadingOptionId)?.label
+  if (leaderLabel !== undefined && (labelOccurrences.get(leaderLabel) ?? 0) === 1) {
+    keys.add(leaderLabel)
+  }
+  return keys
+}
+
 // ─── Public mapper ─────────────────────────────────────────────────────
 
 export interface MapV5AnalysisOptions {


### PR DESCRIPTION
## The defect

`block.leading_option_id` is an option **ID** (`opt_mac`). `block.win_probabilities` is keyed by option **LABEL** (`"Standardise on MacBook Pro"`). `V5AnalysisResultBlock` compared the map **key** against `leading_option_id`, so the comparison matched nothing, `isLeader` was always `false`, and the `data-leader="true"` branch was **unreachable in production**.

Direction is **UNDER-claim** (no leader marked). Deliberately disjoint from the 1.223 over-claim lane.

## Key-space verdict — derived at the bytes, both spaces occur

CEE `staging` @ `820f3e83`, `run-analysis.ts:1353-1369` (`extractWinProbabilities`) — the **only** construction site of the map (complete manifest: 96 files contain the string, 7 non-test in `src/`+`tools/`, one constructor, one caller):

```
option_label (if non-empty)  ->  else option_id  ->  else null
```

`leading_option_id` (`extractOptionId`, `:1428-1436`) uses the **opposite** precedence: `option_id ?? option_label`.

**So when a record carries both fields — the normal case — the leader is an ID and the map keys are labels, and the leader is not a key of its own map.** Both spaces are reachable, so the fix handles both rather than swapping one for the other.

Corroboration:
- `compose.ts:656` (`buildAnalysisResultBlock`) is the sole `type:'analysis_result'` constructor and forwards the map **verbatim** (`:702`). Its two callers (current-turn and the persisted `v5_handler_facts` FRESH branch) emit an identical block — the divergence is *within* one block, not *between* paths.
- CEE's own `option-identity.ts:116-118` states the map "is keyed by option_LABEL … comparing them against graph IDs would false-positive".
- **CEE already documented this exact UI defect in-tree** (`compose.ts:693-700`): the `data-leader="true"` pill "is DEAD CODE at the deployed tip … the probe measured ZERO fires".
- Captured staging turn (2026-07-26, `/proxy/v5/turn`): `leading_option_id: "opt_mac"`, `win_probabilities` keyed by the three labels.
- Deployed bundle: `data-leader` and `v5-analysis-result` appear in exactly one chunk, containing `t===e.leading_option_id` over the label-keyed map.

`@talchain/schemas` (UI vendors 0.22.0; CEE 0.25.0; main 0.25.1 — declarations byte-identical and unchanged since v0.5.0) declares `win_probabilities: z.record(z.string(), z.number())` with **no comment, no `.describe()`, nothing about the key space**. The contract cannot catch this and does not try. `enrichment` is confirmed an untyped `z.record` passthrough.

## The fix — one identity resolution, no new mapping

`resolveLeaderKeys(enrichment, leadingOptionId)` in `mapV5AnalysisToReport.ts`, placed beside and **reusing** the existing `resolveOptionEntries`. It returns the **set** of `win_probabilities` keys denoting the leader, so callers iterating the map test membership and work under either keying. The id↔label pairing is derived from the same wire payload — `enrichment.option_comparison[]`, falling back to `enrichment.decision_brief.options[]` — so there is **no second hand-maintained mapping** (trap 12).

Source ordering is deliberate: `option_comparison[]` is contract-typed with `option_id: z.string().min(1)` **required**, whereas `decision_brief` is `z.object({}).passthrough().nullable().optional()` and `options[]` is not declared in the contract at all. Verified for the withheld case: CEE's `withheld-claim-projection.ts` strips only `decision_review` (whole) and `decision_brief.{headline, headline_banded, robustness_caveat}` (members), copying every other key verbatim — `options[]` survives by recorded decision. The resolver does not depend on that, and does not crash when any member is absent (three tests).

**Fails closed in both directions** — this must never become an over-claim:
- `leading_option_id` null / absent / empty -> **empty set** -> no pill marked. Guards the 1.223 direction.
- leader label shared by two options -> label omitted -> **no** pill marked rather than two. Same rule and reason as the existing `labelIsUnique` guard.
- leader resolving to no option -> no pill marked.

### Per-site fix table

| # | Site | Before | After |
|---|------|--------|-------|
| 1 | Leader pill border + `data-leader` (`V5AnalysisResultBlock.tsx`) | `optionId === block.leading_option_id` — **always false** | `leaderKeys.has(optionKey)` — **FIXED** |
| 2 | Leader-first sort (same file) | leader clause never fired; pure descending order | membership comparator — **FIXED** |
| 3 | `resolveUncertaintyInputs` headline-option resolution | `(e.id ?? e.option_id) === leadingOptionId` | **NOT A DEFECT — refuted, unchanged** |
| 4 | `mapV5AnalysisToReport` headline option (`:675`) | `r.optionId === block.leading_option_id` | **NOT A DEFECT — ID↔ID, unchanged** |

## Refutations (invited by the brief)

**Brief site (3) is not dead.** `resolveUncertaintyInputs` matches `option_comparison[].id ?? .option_id` against `leading_option_id` — **ID-space on both sides**. Confirmed in source and in the deployed minified chunk (`(e=>(e.id??e.option_id)===t))??i[0]`). It resolves the leader correctly today and does **not** always fall back to `entries[0]`. Left unchanged; a clearly labelled **CONTROL** test makes the refutation executable and would catch a future edit that repoints it at the label space. That test passes before and after — disclosed as a control, not counted as a pin.

**Row 1.222a is not a second site.** The deployed `ReactFlowGraph-*.js` chunk is a *bundle* chunk: `grep -l 'data-leader'` and `grep -l 'v5-analysis-result'` across all deployed chunks each return **that file only**, and `src/canvas/ReactFlowGraph.tsx` contains **no** reference to `leading_option_id`, `win_prob`, or `leader`. Complete manifest of `leading_option_id` in non-test source at `6d3f4611`: `types.ts` (declaration), `applyV5State.ts` (key-list string), `mapV5Blocks.ts` (passthrough), `mapV5AnalysisToReport.ts` (correct ID↔ID), `V5AnalysisResultBlock.tsx` (the defect). **1.222a and 1.222 are the same site — this PR closes both.** No separate canvas fix was needed or attempted.

## Why the suite never caught it

The pre-existing `V5AnalysisResultBlock.uncertaintyCalibration.spec.tsx` uses `win_probabilities: { opt_hire_local: 0.72 }` — **ID-keyed**, a shape the live producer does not emit when a label exists. The schemas repo's own canonical fixture (`src/fixtures/index.ts:1027-1031`) does the same, making the leader a key of its own map. The false invariant is encoded in the contract repo's maximal fixture, so any consumer built or tested against it inherits a premise staging contradicts. **The new spec is built from the captured wire shape instead.**

## Verification

- **RED-first + mutation-check** — throwaway worktree at a path **outside the repo root** (trap 9c), detached at pristine staging `6d3f4611`, new spec copied in, worktree removed **before** any gate run. **3 of 13 tests FAIL without the fix** (leader marking, leader hoist, decision_brief fallback). The other 10 pass either side and are **fail-closed controls, not pins** — stated rather than counted.
- `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) — **PASSED**. Coverage 2982/3000 files; ratchet **shrank 2663 -> 2549**. No `--update-baseline`.
- `pnpm lint` — **exit 0**, 0 errors (1030 pre-existing warnings, unchanged).
- Regression: `src/v5` + `src/components/results` + `tests/contracts` — **240 files / 4426 tests, all passed**.
- Trap-2b control: `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every vitest run; `src/canvas/ui/inspector-v2` collected **29 files / 319 tests, all passed** — no collect-time failure, so the suite was not silently shrunk.
- No flakes observed; no test retried or skipped.

## Stated limits

- **jsdom proves the `data-leader` attribute, never visibility** (trap 3). The claim here is DOM-attribute correctness. No live-staging render was performed in this lane; a browser probe against a real permitted turn is the remaining confirmation.
- The fix is proven against the **captured** wire shape and the CEE producer read at `820f3e83`. It is not proven against a deployed CEE tip that has moved since.
- `resolveOptionEntries` (pre-existing, unchanged) reads `id ?? option_id`, whereas CEE's canonical private `readOptionIdentity` uses `option_id ?? id`. Immaterial today — the contract documents `id`/`label` as duplicates of `option_id`/`option_label` — but the precedences differ. Flagged, not fixed: changing it would alter existing `mapV5AnalysisToReport` behaviour, out of scope here.

## Out-of-scope defect found in passing (CEE, for routing)

`olumi-assistants-service/src/orchestrator-v5/context/analysis-fallback.ts:618` indexes the **label-keyed** map with an **ID** (`winProbabilities[leadingFromFact]`) and defaults to `0` on miss (`:620`), so the fallback winner silently reports `win_probability: 0`; `:640` then emits `option_id: optionId` where the value is a label. Same defect class, different repo. Reached only when enrichment is missing/malformed — latent and unguarded. Not touched by this PR.

## ⚠ Merge-conflict flags for the concurrent 1.223 (over-claim / renders-never-derives) lane

Both lanes touch `src/v5/blocks/V5AnalysisResultBlock.tsx`. Scopes are disjoint by direction, but these hunks will likely conflict textually:

1. **`sortedProbs` comparator (~L85-99)** — rewritten; destructured names `idA/idB` -> `keyA/keyB`, leader clause replaced by set membership.
2. **The pill `.map()` body (~L133-155)** — loop variable renamed `optionId` -> `optionKey` at four points (`map` param, `key=`, `isLeader`, the rendered `<span>`), plus an explanatory comment block above the map.
3. **New `const leaderKeys = resolveLeaderKeys(...)` (~L84)** and a **new import** from `../mapV5AnalysisToReport` (~L21).
4. `src/v5/mapV5AnalysisToReport.ts` — **additive only**, one new exported function plus two private helpers inserted immediately above the `// ─── Public mapper ───` divider. Low conflict risk unless 1.223 also edits that divider region.

**Resolution guidance if 1.223 merges first:** keep 1.223's suppression logic wholesale and re-apply only the *comparison* change — every `=== block.leading_option_id` over a `win_probabilities` key becomes `leaderKeys.has(<key>)`. The two changes compose: `resolveLeaderKeys` returns an empty set exactly when `leading_option_id` is null, which is the state 1.223 relies on. The four fail-closed tests in the new spec should be re-run after any merge to confirm the composition still under-claims rather than over-claims.

Orchestrator serializes merges. **Do not merge.**
