### PR TITLE
fix(ui): the Strengthen chips stop presupposing a leader the producer withheld [ROADMAP 1.243]

### DIFF
--- a/src/components/results/__tests__/AdvancedSection.spec.tsx
+++ b/src/components/results/__tests__/AdvancedSection.spec.tsx
@@ -4,6 +4,7 @@ import {
   AdvancedSection,
   translateFreshnessReason,
   FRESHNESS_RECEIPT_D1_MODE,
+  RiskAppetiteFilter,
 } from '../AdvancedSection'
 
 // Mock useRiskProfile hook
@@ -394,5 +395,32 @@ describe('AdvancedSection — the default-estimate disclosure (F10)', () => {
   it('says nothing when the counts are absent (never fabricates a zero)', () => {
     renderExpanded({})
     expect(screen.queryByText(/default confidence values/)).not.toBeInTheDocument()
+  })
+})
+
+// ── ROADMAP 1.243 item 4 — the "Winner by:" lens label ──────────────────────
+//
+// ADJUDICATED: LEAVE the label, do NOT relabel. "Winner by:" takes no option as
+// its object — it names the SORT KEY of a display filter, unlike the two
+// strings #493/#494 relabelled ("Leads across scenarios", "Leads NN%"), which
+// rendered ON an option so the ordinal read straight off them. The test is not
+// "is 'winner' a permitted word" (that would be the trap-12 carve-out list); it
+// is "does the string designate an option", which is derivable.
+//
+// But that verdict RESTS ON the disclaimer beneath it (Paul's ruling
+// 2026-07-12), and the disclaimer had ZERO test references at a79683e4 — the
+// one sentence that makes the label honest could have been dropped in a tidy-up
+// with nothing going red. Pinned here, so the reasoning that leaves the label
+// alone is enforced rather than merely asserted. If this sentence ever goes,
+// the label needs re-adjudicating, and now it will say so.
+describe('RiskAppetiteFilter — the lens disclaimer is load-bearing (1.243 item 4)', () => {
+  it('renders the "Winner by:" label AND the sentence that makes it a lens', () => {
+    render(<RiskAppetiteFilter value="neutral" onChange={vi.fn()} />)
+    // Positive control: the component mounted, so the assertion below is not
+    // passing against an empty render.
+    expect(screen.getByText('Winner by:')).toBeInTheDocument()
+    expect(
+      screen.getByText('A view lens for the option cards below. The overall recommendation is unchanged.'),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/results/strengthen/StrengthenContainer.tsx
+++ b/src/components/results/strengthen/StrengthenContainer.tsx
@@ -96,6 +96,13 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
     return {
       goalThreshold: data.recommendation.goalThreshold ?? null,
       analysisComplete: data.recommendation.analysisStatus === 'computed',
+      // ROADMAP 1.243: the OWNED leader entitlement, quoted from the single
+      // verdict (`deriveDecisionVerdict`, the same instance the canvas and the
+      // option cards read) and never re-derived. `analysisComplete` above is a
+      // lifecycle fact, not an entitlement — the engine needs both, separately.
+      // Undefined when a legacy caller supplies no verdict; the engine's read
+      // is strict (`=== false`), so only an explicit withheld claim suppresses.
+      hasLeadingOption: data.recommendation.verdict?.hasLeadingOption,
       fragileEdges: fragile
         .filter((fe) => typeof (fe.marginal_switch_probability ?? fe.switch_probability) === 'number')
         .map((fe) => ({

--- a/src/components/results/strengthen/__tests__/ownedLeaderClaim.strengthen.spec.tsx
+++ b/src/components/results/strengthen/__tests__/ownedLeaderClaim.strengthen.spec.tsx
@@ -1,0 +1,342 @@
+/**
+ * ROADMAP 1.243 — the Strengthen engine gates its leader claims on the OWNED
+ * verdict (`DecisionVerdict.hasLeadingOption`), the same signal #491/#493/#494
+ * consume. No second source is invented here.
+ *
+ * THE DEFECT. `buildRecommendations` had ZERO references to the verdict, so on
+ * a withheld run — one where the producer explicitly declined to put an option
+ * forward — it still emitted "Challenge the leader" with the prompt
+ * "Build the strongest case against the current leading option." A user who
+ * clicked it got the assistant asserting, as established fact, a leader the
+ * system had just said it could not name. The label was mild; the PROMPT was
+ * the leak.
+ *
+ * WHY THE PROMPT SURFACE IS FIVE FIELDS WIDE, NOT ONE. `StrengthenContainer`
+ * (verified at the bytes, a79683e4) hands the assistant:
+ *   · `rec.action.prompt ?? rec.title`  -> `_dispatchAction({ message })`
+ *                                          / `_sendMessage(...)`
+ *   · `rec.action.parameters`           -> forwarded VERBATIM on the same call
+ *   · `rec.whyNow`                      -> `openAskOlumi({ context })`
+ *   · `rec.title`                       -> `COPY.workThroughDraft(rec.title)`
+ * So auditing `action.prompt` alone would have cleared the flip rec, whose
+ * `action.prompt` is clean and whose TITLE says "change the leader". Every
+ * assertion below sweeps all of them.
+ *
+ * TRAP 13 (a positive control, or the absence assertion is vacuous). Every
+ * withheld case has a PERMITTED twin. The designating-form table asserts each
+ * form is ABSENT on the withheld run and PRESENT on the permitted one — so an
+ * over-suppressing fix fails just as loudly as an ungated one. Over-suppression
+ * is an equal failure and this arc has already produced one (#493's
+ * single-option regression).
+ */
+import { describe, expect, it, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { buildRecommendations } from '../buildRecommendations'
+import type { Recommendation, StrengthenInputs } from '../strengthenTypes'
+import { resolveFactorConfidenceDisplay } from '../../driverConfidenceDisplayPolicy'
+import { StrengthenContainer } from '../StrengthenContainer'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import { selectActive, useStrengthenStore } from '../../../../canvas/stores/strengthenStore'
+import { useAskOlumiStore } from '../../coaching/askOlumiStore'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+
+/** The label the producer would name as the option a flip switches TO. It is a
+ *  distinctive string so its presence/absence is unambiguous evidence. */
+const ALT_WINNER = 'Rebuild in-house'
+
+/**
+ * A fixture that reaches EVERY branch of the engine at once (TESTING-DISCIPLINE
+ * #1: name the branch each fixture must reach). `level` selects between the two
+ * mutually exclusive robustness branches — 'low' fires the challenge rec,
+ * 'high' fires the commit rec — so both are exercised rather than one being
+ * silently unreached.
+ */
+function everyBranch(
+  level: 'low' | 'high',
+  hasLeadingOption?: boolean,
+): StrengthenInputs {
+  return {
+    goalThreshold: null, // -> strengthen:success-measure
+    analysisComplete: true,
+    fragileEdges: [
+      {
+        edgeId: 'edge_9',
+        factorLabel: 'Churn rate',
+        switchProbability: 0.27,
+        alternativeWinnerLabel: ALT_WINNER,
+      },
+    ], // -> strengthen:flip:edge_9
+    factors: [
+      {
+        factorId: 'fac_churn',
+        label: 'Churn rate',
+        influence: 0.82,
+        // The policy module's documented `displaySafe` test seam, so the
+        // fixture cannot claim a shape production would never emit.
+        confidenceDisplay: resolveFactorConfidenceDisplay({ confidence: 0.2 }, true),
+        canFocus: true,
+      }, // -> strengthen:lehi:fac_churn
+      {
+        factorId: 'fac_price',
+        label: 'Price elasticity',
+        influence: 0.3,
+        confidenceDisplay: resolveFactorConfidenceDisplay({ confidence: null }, true),
+        worthInvestigating: true,
+        canFocus: true,
+      }, // -> strengthen:voi:fac_price
+    ],
+    robustness: { status: 'computed', level }, // -> robustness (low) / commit (high)
+    biasFindingTypes: ['narrow_framing'], // -> strengthen:broaden
+    phase3Items: [
+      {
+        id: 'blk_1',
+        title: 'Name the assumption behind the cost estimate',
+        body: 'The cost figure carries no stated basis.',
+        targetIds: [],
+        priorityRank: 12,
+      },
+    ], // -> strengthen:phase3:blk_1
+    ...(hasLeadingOption === undefined ? {} : { hasLeadingOption }),
+  }
+}
+
+const ids = (input: StrengthenInputs) => buildRecommendations(input).map((r) => r.id)
+
+/**
+ * Every string the engine hands the ASSISTANT or renders, per rec — the five
+ * channels enumerated in the header. `action.parameters` is serialised because
+ * it rides the dispatch verbatim and carried `{ topic: 'challenge_leader' }`.
+ */
+function assistantBoundStrings(rec: Recommendation): string[] {
+  return [
+    rec.title,
+    rec.signal,
+    rec.whyNow,
+    rec.tryThis,
+    rec.action.label,
+    rec.action.prompt ?? '',
+    JSON.stringify(rec.action.parameters ?? {}),
+  ]
+}
+
+const allStrings = (input: StrengthenInputs): string =>
+  buildRecommendations(input).flatMap(assistantBoundStrings).join('\n')
+
+/**
+ * DESIGNATING forms only — a definite reference to an option that is ahead.
+ * The distinction is principled, not an allowlist: an INDEFINITE, modal phrase
+ * ("comparing near-identical routes CAN crown A winner") describes a
+ * methodology risk and designates nobody, whereas "THE current leader"
+ * designates. Gating the former would be the over-suppression class.
+ *
+ * STATED LIMIT: this table is a NET, not a completeness proof. It cannot
+ * enumerate every English form of a leader claim, so it is the SECONDARY
+ * instrument; the per-rec assertions above it are the primary ones.
+ */
+const DESIGNATING_FORMS: ReadonlyArray<readonly [string, RegExp]> = [
+  ['the leader', /\bthe (current )?leader\b/i],
+  ['the leading option', /\bthe (current )?leading option\b/i],
+  ['the current lead', /\bthe current lead\b/i],
+  ['the ranking', /\bthe ranking\b/i],
+  ['flips to <option>', /\bflips to\b/i],
+  ['topic: challenge_leader', /challenge_leader/],
+]
+
+describe('1.243 R1 — "Challenge the leader" (strengthen:robustness)', () => {
+  it('WITHHELD: the chip does not render', () => {
+    expect(ids(everyBranch('low', false))).not.toContain('strengthen:robustness')
+  })
+
+  it('PERMITTED (positive control): the chip renders, prompt and parameters intact', () => {
+    const rec = buildRecommendations(everyBranch('low', true)).find(
+      (r) => r.id === 'strengthen:robustness',
+    )
+    expect(rec).toBeDefined()
+    expect(rec!.action.label).toBe('Challenge the leader')
+    expect(rec!.action.prompt).toBe('Build the strongest case against the current leading option.')
+    expect(rec!.action.parameters).toEqual({ topic: 'challenge_leader' })
+  })
+
+  it('WITHHELD: the prompt is not CONSTRUCTIBLE — no emitted string carries it', () => {
+    const withheld = allStrings(everyBranch('low', false))
+    expect(withheld).not.toContain('Build the strongest case against the current leading option.')
+    expect(withheld).not.toContain('challenge_leader')
+    expect(withheld).not.toContain('Challenge the leader')
+  })
+
+  it('LEGACY: an absent hasLeadingOption leaves the chip untouched (no drift to silence)', () => {
+    // Same concession certaintyCopy / buildV7Headline / OptionCards already
+    // make. Production ALWAYS supplies a verdict (useResultsSectionData:1742 is
+    // unconditional), so this covers fixture and legacy callers only — but it
+    // is pinned so the default cannot silently become suppression.
+    expect(ids(everyBranch('low', undefined))).toContain('strengthen:robustness')
+  })
+})
+
+describe('1.243 R2 — the flip rec (strengthen:flip)', () => {
+  it('WITHHELD: the rec does not render', () => {
+    expect(ids(everyBranch('low', false)).some((i) => i.startsWith('strengthen:flip:'))).toBe(false)
+  })
+
+  it('PERMITTED (positive control): the rec renders and names the alternative winner', () => {
+    const rec = buildRecommendations(everyBranch('low', true)).find((r) =>
+      r.id.startsWith('strengthen:flip:'),
+    )
+    expect(rec).toBeDefined()
+    expect(rec!.signal).toContain(ALT_WINNER)
+    expect(rec!.title).toContain('the leader')
+  })
+
+  it('WITHHELD: the alternative winner label appears in NO emitted string', () => {
+    // The sharpest non-lexicon pair in this file. `alternative_winner_label`
+    // designates by elimination — naming what the result would flip TO asserts
+    // that something else is currently ahead (#494 residual 1's reasoning).
+    expect(allStrings(everyBranch('low', false))).not.toContain(ALT_WINNER)
+    expect(allStrings(everyBranch('low', true))).toContain(ALT_WINNER)
+  })
+
+  it('LEGACY: an absent hasLeadingOption leaves the flip rec untouched', () => {
+    expect(ids(everyBranch('low', undefined)).some((i) => i.startsWith('strengthen:flip:'))).toBe(
+      true,
+    )
+  })
+})
+
+describe('1.243 R3 — over-suppression controls: the leader-INDEPENDENT recs survive', () => {
+  it('WITHHELD: success-measure, lehi, voi, broaden and phase-3 all still render', () => {
+    const withheld = ids(everyBranch('low', false))
+    expect(withheld).toContain('strengthen:success-measure')
+    expect(withheld).toContain('strengthen:lehi:fac_churn')
+    expect(withheld).toContain('strengthen:voi:fac_price')
+    expect(withheld).toContain('strengthen:broaden')
+    expect(withheld).toContain('strengthen:phase3:blk_1')
+  })
+
+  it('WITHHELD + robustness high: the commit rec still renders (a run-level grade is not comparative)', () => {
+    // #494 kept "Analysis complete (robust)" on the timeline for exactly this
+    // reason. `robustness.level` is PLoT's own run-level grade; the commit rec
+    // designates no option ("the chosen option" is the USER's choice), so
+    // gating it would delete a producer finding to remove a claim it never made.
+    expect(ids(everyBranch('high', false))).toContain('strengthen:commit')
+  })
+
+  it('WITHHELD: the broaden rec keeps its INDEFINITE, modal risk sentence', () => {
+    const rec = buildRecommendations(everyBranch('low', false)).find(
+      (r) => r.id === 'strengthen:broaden',
+    )
+    expect(rec!.whyNow).toContain('can crown a winner')
+  })
+})
+
+describe('1.243 R4 — designating-form sweep (secondary net, with its control)', () => {
+  const withheld = () => allStrings(everyBranch('low', false))
+  const permitted = () => allStrings(everyBranch('low', true))
+
+  it.each(DESIGNATING_FORMS)('WITHHELD emits no "%s"', (_name, pattern) => {
+    expect(withheld()).not.toMatch(pattern)
+  })
+
+  it.each(DESIGNATING_FORMS)(
+    'PERMITTED still emits "%s" (control: the sweep can SEE a presence)',
+    (_name, pattern) => {
+      expect(permitted()).toMatch(pattern)
+    },
+  )
+})
+
+describe('1.243 R5 — the two unconditional relabels (both directions)', () => {
+  it('voi no longer points the user at "the ranking", on EITHER run', () => {
+    for (const has of [true, false]) {
+      const voi = buildRecommendations(everyBranch('low', has)).find((r) =>
+        r.id.startsWith('strengthen:voi:'),
+      )
+      expect(voi, `voi must render on hasLeadingOption=${has}`).toBeDefined()
+      const strings = assistantBoundStrings(voi!).join('\n')
+      expect(strings).not.toMatch(/\bthe ranking\b/i)
+      // The producer's own finding is NOT lost — only the comparative framing.
+      expect(voi!.sourceLine).toContain('flagged by the engine')
+      expect(voi!.title).toContain('Price elasticity')
+    }
+  })
+
+  it('success-measure no longer says "which is ahead", on EITHER run', () => {
+    for (const has of [true, false]) {
+      const sm = buildRecommendations(everyBranch('low', has)).find(
+        (r) => r.id === 'strengthen:success-measure',
+      )
+      expect(sm, `success-measure must render on hasLeadingOption=${has}`).toBeDefined()
+      expect(assistantBoundStrings(sm!).join('\n')).not.toMatch(/\bwhich is ahead\b/i)
+      // The rec still explains why a target matters — no data deleted.
+      expect(sm!.whyNow).toContain('how likely each option is to succeed')
+    }
+  })
+})
+
+// ── R6. The container must SUPPLY the signal ────────────────────────────────
+// The engine suite proves `buildRecommendations` HONOURS `hasLeadingOption`;
+// it passes the flag itself, so it cannot prove anything supplies it. #493's
+// mutation MB1 deleted the `hasLeadingOption={...}` line from ResultsBody and
+// the whole suite stayed green with the fix dead in production — the
+// guarantee-theatre class. This pins the wiring past the boundary.
+
+const makeData = (over: {
+  hasLeadingOption?: boolean
+  robustnessLevel?: string | null
+}): ResultsSectionDataReturn =>
+  ({
+    recommendation: {
+      goalThreshold: 62,
+      analysisStatus: 'computed',
+      ...(over.hasLeadingOption === undefined
+        ? {}
+        : {
+            verdict: {
+              leaderId: 'opt_a',
+              separation: over.hasLeadingOption ? 'clear' : 'unknown',
+              hasLeadingOption: over.hasLeadingOption,
+              gapPp: over.hasLeadingOption ? 40 : null,
+              source: over.hasLeadingOption ? 'producer_near_tie' : 'none',
+            },
+          }),
+    },
+    confidence: {
+      challengeFragileEdges: [],
+      robustnessStatus: 'computed',
+      robustnessLevel: over.robustnessLevel ?? 'low',
+    },
+    drivers: { drivers: [] },
+  }) as unknown as ResultsSectionDataReturn
+
+beforeEach(() => {
+  useStrengthenStore.getState()._reset()
+  try { sessionStorage.clear() } catch { /* jsdom */ }
+  useGuidanceStore.setState({ guidanceItems: [], _dispatchAction: null, _sendMessage: null } as never)
+  useAskOlumiStore.setState({ isOpen: false, context: '', draft: '', label: '', targetId: null })
+  useCanvasStore.setState({
+    currentStage: null,
+    draftCoaching: null,
+    results: { ...useCanvasStore.getState().results, hash: 'h-1243' },
+  } as never)
+})
+
+describe('1.243 R6 — StrengthenContainer threads the verdict into the engine', () => {
+  const activeIds = () => selectActive(useStrengthenStore.getState()).map((r) => r.id)
+
+  it('PERMITTED (positive control): the challenge rec reaches the store', () => {
+    render(<StrengthenContainer data={makeData({ hasLeadingOption: true })} />)
+    expect(activeIds()).toContain('strengthen:robustness')
+  })
+
+  it('WITHHELD: it does not — so the threading line cannot be deleted unnoticed', () => {
+    render(<StrengthenContainer data={makeData({ hasLeadingOption: false })} />)
+    expect(activeIds()).not.toContain('strengthen:robustness')
+  })
+
+  it('WITHHELD: the panel renders at all (trap 13 — the absence is not a dead mount)', () => {
+    const { getByLabelText } = render(
+      <StrengthenContainer data={makeData({ hasLeadingOption: false })} />,
+    )
+    expect(getByLabelText('Strengthen your model')).toBeTruthy()
+  })
+})

--- a/src/components/results/strengthen/buildRecommendations.ts
+++ b/src/components/results/strengthen/buildRecommendations.ts
@@ -139,6 +139,21 @@ function pct(p: number): string {
 export function buildRecommendations(inputs: StrengthenInputs): Recommendation[] {
   const recs: Recommendation[] = []
 
+  // ── ROADMAP 1.243: the leader ENTITLEMENT ────────────────────────────────
+  // `analysisComplete` answers "did a run finish?". It does NOT answer "may we
+  // name a leader?" — and every trigger below used it as though it did. On a
+  // withheld run (CEE declines to put an option forward; `deriveDecisionVerdict`
+  // returns hasLeadingOption false) the challenge trigger still emitted
+  // "Challenge the leader" with the prompt "Build the strongest case against
+  // the current leading option." — the assistant asked to argue against a
+  // leader the producer had explicitly refused to name.
+  //
+  // Strict `=== false`: only an explicit withheld verdict suppresses; an absent
+  // one is a legacy/fixture caller and keeps the previous behaviour. Read ONCE,
+  // here, so a trigger added later cannot quietly reintroduce the conflation by
+  // reaching for `analysisComplete` again.
+  const leaderClaimWithheld = inputs.hasLeadingOption === false
+
   // ── Clarify: define a measurable success (deterministic) ──────────────────
   if (inputs.goalThreshold == null) {
     recs.push({
@@ -146,7 +161,13 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
       helpType: 'clarify',
       title: 'Define what success looks like',
       signal: 'No measurable success target is set.',
-      whyNow: 'Without a target the analysis cannot say how likely each option is to succeed, only which is ahead.',
+      // 1.243 RELABEL, unconditional. `whyNow` is not display copy alone: the
+      // container passes it as the Ask-Olumi drawer CONTEXT, so "only which is
+      // ahead" reached the assistant as a statement that the analysis HAD
+      // ranked the options — false on any withheld run, and this rec is not
+      // even analysis-gated, so it also said it before any run existed. The
+      // contrast that motivates the rec is kept; only the ranking claim goes.
+      whyNow: 'Without a target the analysis cannot say how likely each option is to succeed, only how they compare with one another.',
       tryThis: 'Pick the number that would make this decision a win, and the date it matters by.',
       sourceLine: 'Source: your goal has no success threshold (checked directly).',
       action: {
@@ -266,7 +287,18 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
   }
 
   // ── Evaluate: the single top flip risk (producer fragile_edges) ──────────
-  if (inputs.analysisComplete && inputs.fragileEdges.length > 0) {
+  // 1.243 GATE. A "flip" is a change in the ORDERING, so this rec is
+  // comparative in all three of its parts: the SELECTION (argmax over
+  // `marginal_switch_probability` — "most likely to change the leader"), the
+  // TITLE, and the SIGNAL, which names `alternative_winner_label` and so
+  // designates by elimination (the #494 residual-1 argument: naming what the
+  // result would flip TO asserts that something else is currently ahead).
+  // Gated rather than relabelled because there is no leader-free reading of
+  // the quantity itself — unlike win probability, which #494 could relabel
+  // because "this option wins in N% of runs" survives without a ranking.
+  // The DATA is not lost: `challengeFragileEdges` also feeds V7SignalRow's
+  // flip-risk chip, buildV7Lenses' flipRisks and V7TopMatter.
+  if (!leaderClaimWithheld && inputs.analysisComplete && inputs.fragileEdges.length > 0) {
     const top = [...inputs.fragileEdges].sort(
       (a, b) => b.switchProbability - a.switchProbability,
     )[0]
@@ -341,12 +373,21 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
       recs.push({
         id: `strengthen:voi:${top.factorId}`,
         helpType: 'evaluate',
-        title: `Investigate ${top.label} before relying on the ranking`,
+        // 1.243 RELABEL, not gate, and UNCONDITIONAL. The trigger is the
+        // producer's own per-factor `worth_investigating` flag — leader-
+        // independent, so gating would delete a real producer finding to
+        // remove a two-word phrase. Only "the ranking" presupposed a
+        // comparative standing the producer may have withheld; "this
+        // analysis" is true on every run. Relabelled on BOTH runs rather than
+        // forked per verdict, following #494's "Leads NN%" precedent: a
+        // carve-out list of "leader words that are fine here" is the
+        // hand-maintained mirror trap 12 warns about.
+        title: `Investigate ${top.label} before relying on this analysis`,
         // ⛔ The percentage-point variant of this sentence is REMOVED:
         // "Knowing this better could shift the result by about {N} percentage
         // points." It is the same claim as the factor chip and the confidence
         // line, in the Strengthen panel, from the same refuted field.
-        signal: 'The engine flagged this as worth investigating before you rely on the ranking.',
+        signal: 'The engine flagged this as worth investigating before you rely on this analysis.',
         whyNow: 'Of everything uncertain, this is the most valuable thing to learn next.',
         tryThis: 'Spend a short, time-boxed effort narrowing this down before deciding.',
         sourceLine: 'Source: value of information analysis (flagged by the engine).',
@@ -364,8 +405,16 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
   }
 
   // ── Challenge: pressure-test a fragile-looking leader ─────────────────────
+  // 1.243 GATE — the row this change exists for. Every one of its six
+  // user- or assistant-facing fields designates a leader (title, signal,
+  // whyNow, tryThis, action.label, action.prompt) and its `parameters` carry
+  // `topic: 'challenge_leader'` onto the wire. There is nothing left to show
+  // once the claim is withheld, so the whole rec is gated: the chip does not
+  // render and the prompt is never CONSTRUCTED. The robustness grade itself
+  // is not suppressed — it is a run-level grade, and the confidence surfaces
+  // own it (#494 kept "Analysis complete (robust)" for the same reason).
   const level = inputs.robustness.level?.toLowerCase() ?? null
-  if (inputs.analysisComplete && (level === 'low' || level === 'very_low')) {
+  if (!leaderClaimWithheld && inputs.analysisComplete && (level === 'low' || level === 'very_low')) {
     recs.push({
       id: 'strengthen:robustness',
       helpType: 'challenge',

--- a/src/components/results/strengthen/strengthenTypes.ts
+++ b/src/components/results/strengthen/strengthenTypes.ts
@@ -144,6 +144,23 @@ export interface StrengthenInputs {
   goalThreshold: number | null
   /** Whether a completed analysis exists (most triggers need one). */
   analysisComplete: boolean
+  /**
+   * ROADMAP 1.243 — `DecisionVerdict.hasLeadingOption` VERBATIM: the ONE
+   * boolean any surface must hold before asserting OR presupposing a leading
+   * option. Threaded by `StrengthenContainer` from
+   * `data.recommendation.verdict`, the same instance the canvas reads. Never
+   * re-derived here, and never inferred from `analysisComplete`: a completed
+   * analysis is not an entitlement to name a leader, which is precisely the
+   * conflation that let "Challenge the leader" render on withheld runs.
+   *
+   * Strict read (`=== false` suppresses). `undefined` means no verdict was
+   * supplied and leaves the legacy behaviour untouched — the same concession
+   * `certaintyCopy`, `buildV7Headline` and `OptionCards` already make.
+   * Production always supplies one (`useResultsSectionData` derives it
+   * unconditionally), so `undefined` is a fixture/legacy path; the default is
+   * pinned by test so it cannot drift to silence.
+   */
+  hasLeadingOption?: boolean
   fragileEdges: StrengthenFragileEdge[]
   factors: StrengthenFactor[]
   robustness: { status: string | null; level: string | null }


### PR DESCRIPTION
Closes ROADMAP 1.243. Base `staging`, cut from `a79683e4` (re-derived, matches the dispatch).

## The defect, verified at the bytes first

`buildRecommendations.ts` had **zero** references to the verdict — premise confirmed, not inherited. On a withheld run it emitted the chip **"Challenge the leader"** with prompt **"Build the strongest case against the current leading option."** and `parameters: { topic: 'challenge_leader' }`. The assistant was asked to argue against a leader the producer had explicitly declined to name.

## The prompt surface is five fields wide, not one

Derived from `StrengthenContainer` at the bytes, not assumed. It sends `rec.action.prompt ?? rec.title` as the dispatch message, forwards `rec.action.parameters` verbatim on the same call, passes `rec.whyNow` as the Ask-Olumi drawer **context**, and `rec.title` into the drawer draft.

**This changed a verdict.** Auditing `action.prompt` alone would have cleared the flip rec — its prompt is clean, and its *title* says "change the leader".

## Per-branch verdict — every branch stated

| Branch | Verdict | Why |
|---|---|---|
| `strengthen:robustness` | **GATE** | All six fields designate, plus `challenge_leader` on the wire. Nothing survives suppression: chip absent **and** prompt never constructed. |
| `strengthen:flip` | **GATE** | Comparative in all three parts — the *selection* (argmax over `marginal_switch_probability`), the title, and the signal, which names `alternative_winner_label` and designates by elimination (#494 residual-1). No leader-free reading of the quantity, unlike win probability which #494 could relabel. Data not lost: the same slice feeds `V7SignalRow`, `buildV7Lenses`, `V7TopMatter`. |
| `strengthen:voi` | **RELABEL** | Trigger is the producer's per-factor `worth_investigating` flag — leader-independent, so gating would delete a real finding to remove two words. `"the ranking"` → `"this analysis"`. Unconditional, not forked per verdict (a carve-out list is trap 12). |
| `strengthen:success-measure` | **RELABEL** | `whyNow` said "only which is ahead" — and `whyNow` **is** the drawer context. Not even analysis-gated, so it said it before any run existed. |
| `strengthen:lehi` | **LEFT** | Influence/confidence are per-*factor* display metrics, not a standing among options. Action is canvas-focus with no prompt. |
| `strengthen:commit` | **LEFT** | `robustness.level` is PLoT's run-level grade; #494 kept "Analysis complete (robust)" on exactly this ground. "the chosen option" is the *user's* choice. |
| `strengthen:broaden` | **LEFT** | "can crown **a** winner" is indefinite and modal — a methodology risk designating nobody. Gating the indefinite form is the over-suppression class. |
| `strengthen:phase3` | **LEFT** | Producer copy verbatim; `prompt` **is** `item.title`. A leader claim in CEE guidance copy is a CEE defect. Stated as a boundary, not a clean bill — this repo cannot enumerate CEE's copy. |

## Instrument

`hasLeadingOption?: boolean` on `StrengthenInputs`, quoted from `data.recommendation.verdict` — the same `deriveDecisionVerdict` instance #491/#493/#494 consume. **No second source.** Strict `=== false`; legacy callers untouched (production always supplies one). Read once into `leaderClaimWithheld` so a later trigger cannot reintroduce the `analysisComplete` conflation.

## Item 4 — "Winner by:" (`AdvancedSection.tsx:537`): AGREE with the lane, leave it

It takes no option as its object — it names a **sort key**. The strings #493/#494 relabelled rendered *on* an option, so the ordinal read straight off them. The test is not "which leader words are permitted" (trap-12 carve-out list) but "does the string designate an option" — derivable. It is also not assistant-bound.

**But the verdict rested on an unpinned sentence.** The disclaimer — *"A view lens for the option cards below. The overall recommendation is unchanged."* — had **zero** test references at `a79683e4`. It could have been dropped in a tidy-up with nothing going red, silently falsifying my own justification. Pinned (with a mount positive control). No rendered copy changes.

## Tests — RED-first

**13 of 28 failed** before a line of source changed. The 15 that passed are the permitted twins, over-suppression controls and legacy defaults — the suite was proven to discriminate first. Every withheld case has a **permitted twin**; over-suppression is an equal failure and this arc already produced one (#493's single-option regression).

The designating-form sweep asserts each form **absent on withheld and present on permitted**, so it cannot pass vacuously. Sharpest pair is non-lexicon: `alternative_winner_label` appears in **no** emitted string on withheld and **does** on permitted.

`R6` pins the container **wiring** — the #493 MB1 lesson: the engine suite passes the flag itself, so it cannot prove anything supplies it.

## Mutation — throwaway clone OUTSIDE the repo root (trap 9c), one revert at a time

| | Mutant | Result |
|---|---|---|
| M1 | flip gate reverted | **5 failed** |
| M2 | challenge gate reverted | **7 failed** |
| M3 | container threading deleted | **1 failed** |
| M4 | voi relabel reverted | **2 failed** |
| M5 | success-measure relabel reverted | **1 failed** |
| M6 | strict `=== false` loosened to `!x` | **2 failed** |
| M7 | lens disclaimer deleted | **1 failed** |

All seven RED. Harness asserts each anchor exists exactly once and verifies the write landed against `git diff`, so a no-op reports as a harness failure rather than a passing fix (trap 15).

## Gates

- `pnpm typecheck` **PASS** — drift 2663 → 2549, the figure a pristine tree records, so net-zero on the ratchet. **Baseline not regenerated; `--update-baseline` declined.**
- `npx eslint` on all 5 changed files — **exit 0, 0 problems.**
- Derived spec manifest (grep over every symbol and copy string touched, not hand-reasoned): **22 files / 483 tests green.** Includes all 27 pre-existing `buildRecommendations` tests — **no pre-existing spec needed fixing, no quarantines, no baseline bumps.**
- `VITE_SUPABASE_URL`/`ANON_KEY` exported for every vitest run (trap 2b); no collect-time failures.

## Stated limits (to-dos, not hedges)

1. The designating-form table is a **net, not a completeness proof** — it cannot enumerate every English form. The per-rec assertions are primary. Recorded in the spec.
2. **Not verified live.** Component- and engine-level only; a withheld-run render probe against staging is a separate lane.
3. Gating the flip rec removes a genuinely useful fragility signal from the panel on withheld runs. I declined to invent per-verdict replacement copy (#493's "never substitute invented copy"). A non-comparative fragility framing is a producer-side question — flagged, not fixed.
4. `V7SignalRow`'s flip chip ("NN% flip risk · {from_label}") names no alternative winner and is out of this module's scope — **noted, not touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)