### PR TITLE
fix(goal-probability): one chooser for the goal-probability identity, so the panel and the canvas stop contradicting each other

### DIFF
--- a/src/canvas/hooks/__tests__/goalProbabilityIdentity.parity.spec.tsx
+++ b/src/canvas/hooks/__tests__/goalProbabilityIdentity.parity.spec.tsx
@@ -1,0 +1,251 @@
+/**
+ * GOAL-PROBABILITY IDENTITY PARITY — the results panel and the canvas must
+ * make the SAME decision about the same option in the same session.
+ *
+ * THE DEFECT THIS PINS (live at staging 201f1075, both surfaces deployed):
+ * the producer emits two semantically different quantities under one display
+ * name — `goal_probability` (P(this option clears the user's goal threshold))
+ * and `probability_of_joint_goal` (P(all constraints jointly satisfied)) —
+ * and the UI chose between them TWICE, with different rules:
+ *
+ *   • `components/results/utils/selectGoalProbability.ts` (results panel,
+ *     hero, OptionCards, OptionNode badge) falls back to the joint value when
+ *     it is the only number the run carries, and flags it as joint.
+ *   • `canvas/hooks/useNodeDisplayMetadata.ts` (GoalNode, OutcomeNode,
+ *     NodeInspector) took the joint value ONLY when the option carried its
+ *     own `constraint_analysis` — which no live V5 producer populates
+ *     (`v5/mapV5AnalysisToReport.ts` emits none; `adapters/plot/v2/
+ *     responseMapper.ts` nulls it behind PLOT_PER_OPTION_CONSTRAINTS_SUSPECT)
+ *     — and otherwise returned `rec.goal_probability ?? null`.
+ *
+ * On the documented ISL-auto-derived-goal-threshold run (`goal_probability`
+ * ABSENT, `probability_of_joint_goal` PRESENT, no per-option
+ * `constraint_analysis` — the case `selectGoalProbability`'s own docstring
+ * names) those two rules DISAGREE: the results panel renders a percentage
+ * plus its provenance caveat while the canvas GoalNode renders "This run did
+ * not produce a goal probability". Same session, same option, two contrary
+ * claims, with the caveat on one surface only.
+ *
+ * These tests therefore assert AGREEMENT, not a hard-coded number: whatever
+ * the single source of truth decides, the canvas consumer must return the
+ * same value and the same provenance. The positive control below fixes that
+ * decision first (CLAUDE.md trap 13 — an agreement assertion is vacuous until
+ * it has proved it can see a presence), so a "both surfaces returned null"
+ * state can never satisfy this file.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, renderHook, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { useNodeDisplayMetadata } from '../useNodeDisplayMetadata'
+import {
+  selectGoalProbability,
+  type GoalProbabilityInput,
+} from '../../../components/results/utils/selectGoalProbability'
+import { GoalNode } from '../../nodes/GoalNode'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../../components/results/utils/goalFitBasisCaveatCopy'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+// `importOriginal`-spread over the peripheral hooks (never a bare factory — a
+// factory REPLACES the module and silently drops every other export, the
+// dominant defect this repo keeps rediscovering). GoalNode's freshness and
+// probability-presence hooks are pinned so this file exercises the
+// goal-probability path and nothing else; the consumer under test
+// (`useNodeDisplayMetadata`) is deliberately REAL.
+vi.mock('../useAnalysisTrust', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAnalysisTrust: () => ({ semantic: 'current', orphaned: false, isRunning: false }),
+}))
+vi.mock('../../ui/inspector-v2/useAnalysisResults', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useHasAnyRealProbability: () => true,
+}))
+
+/**
+ * The documented ISL-auto-derived-goal-threshold shape: the run carries
+ * `probability_of_joint_goal` and NO `goal_probability`, and no per-option
+ * `constraint_analysis` (the live V5 path never populates one).
+ */
+const JOINT_ONLY_RECORD: GoalProbabilityInput & Record<string, unknown> = {
+  probability_of_joint_goal: 0.62,
+  confidence: 0.5,
+  goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+}
+
+/** Control: the run carries the true per-option goal quantity. */
+const GOAL_QUANTITY_RECORD: GoalProbabilityInput & Record<string, unknown> = {
+  goal_probability: 0.41,
+  probability_of_joint_goal: 0.62,
+  confidence: 0.5,
+  goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+}
+
+const makeReport = (optionRecord: Record<string, unknown>) => ({
+  schema: 'report.v1' as const,
+  meta: { seed: 1, elapsed_ms: 100 },
+  result: { mean: 0.7, p10: 0.5, p50: 0.7, p90: 0.9, critique: '' },
+  bands: { p10: 0.5, p50: 0.7, p90: 0.9 },
+  robustness: { recommended_option_id: 'option-1', recommendation_stability: 0.8 },
+  option_probabilities: { 'option-1': optionRecord },
+})
+
+const makeStoreState = (optionRecord: Record<string, unknown>) => ({
+  results: { status: 'complete', report: makeReport(optionRecord) },
+  highlightedNodes: new Set(),
+  dimmedNodeIds: new Set(),
+  lens: { _dimmedNodeIds: new Set() },
+  goalThreshold: null,
+  goalConstraints: [],
+  nodes: [],
+  edges: [],
+  ceeAnalysisReady: null,
+  viewMode: 'expert',
+})
+
+let storeState = makeStoreState(JOINT_ONLY_RECORD)
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: (s: unknown) => unknown) => selector(storeState)),
+}))
+
+import { useCanvasStore } from '../../store'
+
+const useStore = (optionRecord: Record<string, unknown>) => {
+  storeState = makeStoreState(optionRecord)
+  vi.mocked(useCanvasStore).mockImplementation((selector) => selector(storeState as never))
+}
+
+const goalNodeProps = {
+  id: 'goal-1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  selected: false,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+  deletable: true,
+  selectable: true,
+  draggable: true,
+}
+
+/** A target is set, so GoalNode's UI-SEM-082 gate is open. */
+const renderGoalNode = () =>
+  render(
+    <ReactFlowProvider>
+      <GoalNode
+        {...goalNodeProps}
+        data={{
+          label: 'Increase revenue',
+          type: 'goal',
+          goal_threshold_raw: '100',
+          goal_threshold_unit: '%',
+        }}
+      />
+    </ReactFlowProvider>,
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useStore(JOINT_ONLY_RECORD)
+})
+
+describe('goal-probability identity — the two consumers agree', () => {
+  it('POSITIVE CONTROL: the single source of truth really does show a number and a caveat here', () => {
+    // Fixes the decision before anything asserts agreement with it, so a
+    // "both surfaces returned null" state can never satisfy this file.
+    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    expect(decision.goalProbability).toBe(0.62)
+    expect(decision.goalFitIsModelledBasis).toBe(true)
+  })
+
+  it('the canvas consumer returns the SAME value as the results-panel selector', () => {
+    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
+    expect(result.current.achievementProbability).toBe(decision.goalProbability)
+  })
+
+  it('the canvas consumer returns the SAME provenance caveat as the results-panel selector', () => {
+    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
+    expect(result.current.achievementProbabilityIsModelledBasis).toBe(
+      decision.goalFitIsModelledBasis,
+    )
+  })
+
+  it('agrees on the control run too (the true goal quantity is present)', () => {
+    useStore(GOAL_QUANTITY_RECORD)
+    const decision = selectGoalProbability(GOAL_QUANTITY_RECORD)
+    expect(decision.goalProbability).toBe(0.41)
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
+    expect(result.current.achievementProbability).toBe(decision.goalProbability)
+    expect(result.current.achievementProbabilityIsModelledBasis).toBe(
+      decision.goalFitIsModelledBasis,
+    )
+  })
+})
+
+describe('goal-probability identity — the rendered canvas text matches the decision', () => {
+  // jsdom proves TEXT CONTENT, never layout or visibility (CLAUDE.md trap 3).
+  // These assert what the node says, not where or whether it appears on screen.
+
+  it('GoalNode states the same percentage the results panel does', () => {
+    renderGoalNode()
+    expect(screen.getByText(/62% chance of reaching target/)).toBeDefined()
+  })
+
+  it('GoalNode does not simultaneously deny that a goal probability exists', () => {
+    renderGoalNode()
+    expect(screen.queryByText(/did not produce a goal probability/)).toBeNull()
+  })
+
+  it('GoalNode carries the provenance caveat the results panel carries', () => {
+    renderGoalNode()
+    expect(screen.getByTestId('goal-fit-basis-caveat-node')).toHaveTextContent(
+      GOAL_FIT_BASIS_CAVEAT_COPY,
+    )
+  })
+})
+
+describe('goal-probability identity — which quantity the number IS', () => {
+  it('names the substituted joint quantity as its own basis', () => {
+    expect(selectGoalProbability(JOINT_ONLY_RECORD).basis).toBe('joint_goal_substituted')
+  })
+
+  it('withholds the possessive framing when the joint value stands in for an absent goal value', () => {
+    // The NUMBER is still shown — it is real, computed and decision-relevant.
+    // Only "YOUR goal" is withheld, because the number answers a different
+    // question from the one that phrase asserts.
+    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    expect(decision.goalProbability).toBe(0.62)
+    expect(decision.mayUsePossessiveGoalFraming).toBe(false)
+  })
+
+  it('permits the possessive framing when the value IS the goal quantity', () => {
+    const decision = selectGoalProbability(GOAL_QUANTITY_RECORD)
+    expect(decision.basis).toBe('goal_probability')
+    expect(decision.mayUsePossessiveGoalFraming).toBe(true)
+  })
+
+  it('permits the possessive framing for an option carrying its own constrained joint figure', () => {
+    const decision = selectGoalProbability({
+      goal_probability: 0.41,
+      probability_of_joint_goal: 0.07,
+      constraint_analysis: { constraints: [{ id: 'c1' }] },
+    })
+    expect(decision.basis).toBe('joint_goal_constrained')
+    expect(decision.goalProbability).toBe(0.07)
+    expect(decision.mayUsePossessiveGoalFraming).toBe(true)
+  })
+
+  it('reports no basis and no framing permission when neither quantity is present', () => {
+    const decision = selectGoalProbability({})
+    expect(decision.basis).toBe('none')
+    expect(decision.goalProbability).toBeNull()
+    expect(decision.mayUsePossessiveGoalFraming).toBe(false)
+  })
+})

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -15,6 +15,10 @@ import { compareByDisplayModel } from '../../components/results/driverDisplayMod
 import type { DriverDisplayProvenance } from '../../components/results/driverDisplayModel'
 import { selectDriverPolicyFeed } from '../../components/results/useResultsSectionData'
 import { resolveFactorConfidenceDisplay } from '../../components/results/driverConfidenceDisplayPolicy'
+import {
+  selectGoalProbability,
+  type GoalProbabilityInput,
+} from '../../components/results/utils/selectGoalProbability'
 import type { ResultsReport } from '../../components/results/types'
 
 interface NodeDisplayMetadata {
@@ -56,17 +60,23 @@ interface NodeDisplayMetadata {
   confidenceIsProvisional: boolean
   /** Whether this factor was found in the sensitivity analysis (false for root nodes like "Value") */
   inSensitivityAnalysis: boolean
-  /** Outcome/Goal achievement probability (0-1) */
+  /**
+   * Outcome/Goal achievement probability (0-1), as decided by
+   * `components/results/utils/selectGoalProbability` — THE single source of
+   * truth for which producer quantity may be shown as a goal probability.
+   * This hook does not choose; it reads. The results panel reads the same
+   * function, so the canvas and the panel cannot state different numbers for
+   * one option in one session.
+   */
   achievementProbability: number | null
   /**
-   * Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): true ONLY
-   * when `achievementProbability` above IS the joint-goal figure (mirrors
-   * the hook's own `hasConstraints && jointProb != null` branch that
-   * selects it, exactly as OptionCards' `goalFitIsModelledBasis` mirrors
-   * useResultsSectionData.ts's branches) AND the producer marked it as
-   * scored from a modelled outcome distribution
-   * (`goal_fit_basis.scored_from === 'modelled_outcome_distribution'`).
-   * Never inferred, never applied to the unconstrained goal_probability.
+   * Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): true when the
+   * `achievementProbability` above IS the joint-goal figure AND the producer
+   * marked it as scored from a modelled outcome distribution. Read straight
+   * off the shared selector's `goalFitIsModelledBasis` — NOT mirrored from
+   * it, which is how this flag previously came to disagree with the results
+   * panel's identical-looking one. Surfaces rendering the number MUST render
+   * `GOAL_FIT_BASIS_CAVEAT_COPY` alongside it when this is true.
    */
   achievementProbabilityIsModelledBasis: boolean
   /** Recommendation stability (0-1) - fallback for Goal nodes when probability unavailable */
@@ -235,30 +245,26 @@ export function useNodeDisplayMetadata(
                                   report.robustness?.recommendedOptionId
 
       if (recommendedOptionId) {
-        const rec = optionProbabilities[recommendedOptionId] as any
+        const rec = optionProbabilities[recommendedOptionId] as GoalProbabilityInput | undefined
         if (rec) {
-          // T6 P0-3: Prefer probability_of_joint_goal (constrained) when available,
-          // fall back to goal_probability (unconstrained)
-          const jointProb = typeof rec.probability_of_joint_goal === 'number'
-            ? rec.probability_of_joint_goal : null
-          const hasConstraints = rec.constraint_analysis?.constraints?.length > 0
-          const isJoint = hasConstraints && jointProb != null
-          achievementProbability = isJoint
-            ? jointProb
-            : (rec.goal_probability ?? null)
-          // Display-honesty (ROADMAP 1.6b follow-up, claim-integrity):
-          // mirrors the `isJoint` branch immediately above exactly (rather
-          // than comparing resulting numbers, which could false-match on a
-          // coincidental equal value) so we know precisely WHEN the
-          // achievementProbability just set IS the joint-goal figure the
-          // caveat qualifies — never inferred, never applied to the
-          // unconstrained goal_probability branch.
-          const goalFitBasisScoredFrom =
-            typeof rec.goal_fit_basis?.scored_from === 'string'
-              ? (rec.goal_fit_basis.scored_from as string)
-              : null
-          achievementProbabilityIsModelledBasis =
-            isJoint && goalFitBasisScoredFrom === 'modelled_outcome_distribution'
+          // GOAL-PROBABILITY IDENTITY — ONE chooser, never two.
+          //
+          // This hook used to pick between `probability_of_joint_goal` and
+          // `goal_probability` itself, with a rule that DIFFERED from the
+          // results panel's: it took the joint figure only when the option
+          // carried its own `constraint_analysis` (which no live V5 producer
+          // populates) and otherwise returned `goal_probability ?? null`. On
+          // the documented ISL-auto-derived-goal-threshold run
+          // (`goal_probability` absent, `probability_of_joint_goal` present)
+          // that returned null while the results panel returned the joint
+          // value WITH its provenance caveat — one session, one option, the
+          // panel stating a percentage and the canvas denying any figure
+          // existed. `selectGoalProbability` now owns the decision outright:
+          // which quantity may be shown, and with what provenance. Read it;
+          // never re-derive either field here, and never add a third chooser.
+          const decision = selectGoalProbability(rec)
+          achievementProbability = decision.goalProbability
+          achievementProbabilityIsModelledBasis = decision.goalFitIsModelledBasis
         }
       }
 

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -21,6 +21,7 @@ import { detectBaseline } from '../utils/baselineDetection'
 import { usePopoverHover } from '../hooks/usePopoverHover'
 import { NodeChip, ActionIcons, BriefIcon, NodePopover, ScienceIcon } from './shared'
 import { selectGoalProbability } from '../../components/results/utils/selectGoalProbability'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../lib/decisionVerdict'
 
 /** Truncate text at word boundary to avoid mid-word cuts. */
@@ -757,12 +758,19 @@ export const OptionNode = memo((props: NodeProps) => {
   // one useResultsSectionData applies for OptionCards/hero/GoalNode) so this
   // badge can't show a different number than those surfaces on a
   // constrained-goal run.
-  const goalProbability = useMemo(() => {
+  //
+  // Goal-probability IDENTITY: the WHOLE decision is kept, not just the
+  // number. This site previously took `.goalProbability` and discarded the
+  // provenance, so the badge rendered a joint-basis figure with no caveat
+  // while OptionCards, the hero and GoalNode rendered the same figure WITH
+  // one. The caveat now travels with the number to every surface showing it.
+  const goalDecision = useMemo(() => {
     if (!isPostAnalysis || !resultsReport) return null
     const report = resultsReport as any
     const optionProbs = report?.option_probabilities?.[props.id]
-    return selectGoalProbability(optionProbs).goalProbability
+    return selectGoalProbability(optionProbs)
   }, [isPostAnalysis, resultsReport, props.id])
+  const goalProbability = goalDecision?.goalProbability ?? null
 
   // "Behind:" reason for non-winner options (including status quo).
   // Computed via the pure helper so this option's reason can be compared
@@ -926,6 +934,22 @@ export const OptionNode = memo((props: NodeProps) => {
         </p>
       )}
 
+      {/* Display-honesty (ROADMAP 1.6b, claim-integrity): the number above is
+          scored from a MODELLED forward-propagated outcome distribution, not
+          a directly-set base. Same gate and same shared wording as
+          OptionCards / GoalNode / OutcomeNode / NodeInspector — the flag is
+          read off the shared selector, never re-derived, so no surface can
+          show this number with the caveat while another shows it bare. */}
+      {goalThreshold != null && isPostAnalysis && goalProbability !== null && goalProbability < 0.10 &&
+        goalDecision?.goalFitIsModelledBasis === true && (
+        <p
+          className={`${typography.edgeLabel} text-text-light mt-0.5 m-0`}
+          data-testid={`goal-fit-basis-caveat-option-node-${props.id}`}
+        >
+          {GOAL_FIT_BASIS_CAVEAT_COPY}
+        </p>
+      )}
+
       {/* "What this option changes:" intervention list (never for baseline) */}
       {!isBaselineOption && allInterventionChips.length > 0 && (() => {
         const chipsWithMeta = allInterventionChips.map(chip => {
@@ -1034,7 +1058,7 @@ export const OptionNode = memo((props: NodeProps) => {
           in this inline layer-2 block. Body never renders chips directly. */}
       {optionChips}
     </>
-  ), [isPostAnalysis, goalThreshold, goalProbability, handleGoalReviewClick, allInterventionChips, isBaselineOption, baselineOptionInterventions, isOptionFromCee, props.data, totalInterventionCount, optionChips])
+  ), [isPostAnalysis, goalThreshold, goalProbability, goalDecision, props.id, handleGoalReviewClick, allInterventionChips, isBaselineOption, baselineOptionInterventions, isOptionFromCee, props.data, totalInterventionCount, optionChips])
 
   // ----- Pre-analysis popover content -----
   const preAnalysisPopoverContent = useMemo(() => {

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.goalFitIdentity.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.goalFitIdentity.spec.tsx
@@ -1,0 +1,63 @@
+/**
+ * buildHeroModel — GOAL-PROBABILITY IDENTITY in the hero detail line.
+ *
+ * `probability_of_joint_goal` standing in for an absent `goal_probability`
+ * (the ISL-auto-derived-goal-threshold run) is a real, computed, decision-
+ * relevant number, and the hero shows it. But it answers "P(all targets
+ * jointly satisfied)", not "P(this option clears YOUR goal)" — so the
+ * possessive sentence the hero otherwise prints names a question the number
+ * does not answer.
+ *
+ * The row carries `goalFitIsSubstitutedJoint`, set once by
+ * `selectGoalProbability` (via useResultsSectionData) and never re-derived
+ * here — the same discipline the caveat flag follows, and for the same
+ * reason: two sites deriving one meaning is how the canvas and the panel
+ * came to contradict each other.
+ */
+import { describe, expect, it } from 'vitest'
+import { buildHeroModel } from '../buildHeroModel'
+import { HERO_COPY } from '../heroCopy'
+import type { HeroChartModel } from '../heroTypes'
+import { makeHeroData, makeOption, OPTION_A, OPTION_B } from '../__fixtures__/hero.fixtures'
+
+function chart(model: ReturnType<typeof buildHeroModel>): HeroChartModel {
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+describe('buildHeroModel — goal-fit detail line identity', () => {
+  it('POSITIVE CONTROL: the possessive line is what the hero prints by default', () => {
+    // Fixes the un-flagged behaviour first, so the assertions below cannot
+    // pass by the line being absent rather than being re-voiced.
+    const m = chart(buildHeroModel(makeHeroData()))
+    expect(m.rows[0].detail.goalFit).toContain('your goal')
+  })
+
+  it('drops the possessive framing when the number is a substituted joint figure', () => {
+    const a = makeOption({ ...OPTION_A, goalFitIsSubstitutedJoint: true })
+    const b = makeOption({ ...OPTION_B, goalFitIsSubstitutedJoint: true })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
+    expect(m.rows[0].detail.goalFit).not.toContain('your goal')
+    expect(m.rows[0].detail.goalFit).toBe(
+      HERO_COPY.detail.goalFitJointBasis(m.rows[0].goal.readout),
+    )
+  })
+
+  it('still shows the NUMBER on a substituted joint figure (copy switch, never a value transform)', () => {
+    const a = makeOption({ ...OPTION_A, goalFitIsSubstitutedJoint: true })
+    const plain = chart(buildHeroModel(makeHeroData({ options: [a, makeOption(OPTION_B)] })))
+    const control = chart(buildHeroModel(makeHeroData()))
+    expect(plain.rows[0].goal.value).toBe(control.rows[0].goal.value)
+    expect(plain.rows[0].goal.readout).toBe(control.rows[0].goal.readout)
+  })
+
+  it('keeps the possessive framing for rows that are NOT substituted', () => {
+    const a = makeOption({ ...OPTION_A, goalFitIsSubstitutedJoint: true })
+    const b = makeOption({ ...OPTION_B, goalFitIsSubstitutedJoint: false })
+    const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
+    const rowA = m.rows.find((r) => r.id === OPTION_A.id)
+    const rowB = m.rows.find((r) => r.id === OPTION_B.id)
+    expect(rowA?.detail.goalFit).not.toContain('your goal')
+    expect(rowB?.detail.goalFit).toContain('your goal')
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
@@ -88,6 +88,7 @@ const UI_COPY: string[] = [
   HERO_COPY.detail.range('54', '82'),
   HERO_COPY.detail.goalFit('34%'),
   HERO_COPY.detail.goalFitWithLimits('34%'),
+  HERO_COPY.detail.goalFitJointBasis('34%'),
   HERO_COPY.footer.mainReason('Team capacity'),
   // §6.5 quick-evidence pills (summary row).
   HERO_COPY.pills.mainDriver('Team capacity'),

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -307,11 +307,19 @@ export function buildHeroModel(
     // carries its own constraint analysis, so the row's detail line can name
     // the quantity precisely — a constrained option's joint figure is never
     // mislabelled goal-alone in a mixed set.
+    // Goal-probability IDENTITY: when the row's number is the joint figure
+    // STANDING IN for an absent goal probability (`goalFitIsSubstitutedJoint`,
+    // set by the shared selector — never re-derived here), the possessive
+    // "your goal" wording names a question the number does not answer, so the
+    // line states the quantity it actually is. The number itself is unchanged
+    // and still shown: this is a copy switch, never a value transform.
     const goalFit =
       goalValue != null
         ? optionHasConstraints(o)
           ? HERO_COPY.detail.goalFitWithLimits(goalReadout(goalValue))
-          : HERO_COPY.detail.goalFit(goalReadout(goalValue))
+          : o.goalFitIsSubstitutedJoint === true
+            ? HERO_COPY.detail.goalFitJointBasis(goalReadout(goalValue))
+            : HERO_COPY.detail.goalFit(goalReadout(goalValue))
         : undefined
     // Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): the caveat
     // renders ONLY when the goalFit number just above it is actually shown

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -208,6 +208,18 @@ export const HERO_COPY = {
     range: (low: string, high: string) => `Realistic range: ${low} to ${high}.`,
     goalFit: (readout: string) => `${readout} chance of hitting your goal.`,
     goalFitWithLimits: (readout: string) => `${readout} chance of meeting your goal and limits.`,
+    /**
+     * Goal-probability IDENTITY: used when the row's number is
+     * `probability_of_joint_goal` STANDING IN for an absent
+     * `goal_probability` (the ISL-auto-derived-goal-threshold run, flagged
+     * by the shared selector as `basis: 'joint_goal_substituted'`). The
+     * number is shown — it is real and decision-relevant — but it answers
+     * "P(all targets jointly satisfied)", not "P(this option clears YOUR
+     * goal)", so the possessive framing the two lines above use would name
+     * a question this figure does not answer. Same sentence shape, no
+     * possessive, no invented claim.
+     */
+    goalFitJointBasis: (readout: string) => `${readout} chance of meeting all targets together.`,
   },
 
   /**

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -149,6 +149,17 @@ export interface OptionResult {
    * surface a caveat when this is true (UI-BOUNDARY-DATA-INVENTORY.md §5).
    */
   goalFitIsModelledBasis?: boolean
+  /**
+   * Goal-probability IDENTITY: true when the rendered `goalProbability` is
+   * `probability_of_joint_goal` STANDING IN for an absent `goal_probability`
+   * (the ISL-auto-derived-goal-threshold run). The number is real and the
+   * user is entitled to it, but it answers "P(all constraints jointly
+   * satisfied)", not "P(this option clears the goal)" — so prose showing it
+   * must NOT use the possessive "your goal" framing. Set from
+   * `selectGoalProbability(...).basis === 'joint_goal_substituted'`; never
+   * re-derived at a render site.
+   */
+  goalFitIsSubstitutedJoint?: boolean
 }
 
 /** Outcome unit type for formatting - from goal node observed_state.unit */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1475,18 +1475,14 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // ROADMAP 1.49: extracted to selectGoalProbability (utils/) so every
       // surface (this hook, OptionNode's badge) shares one fallback chain
       // instead of re-deriving it.
-      const { goalProbability, goalProbabilityIsJoint } = selectGoalProbability(prob as GoalProbabilityInput)
-      // Display-honesty (ROADMAP 1.6b, doctrine B / PLoT #204): the
-      // provenance caveat renders ONLY when the number just shown is the
-      // joint-goal figure AND the producer marked it as scored from a
-      // modelled outcome distribution — never inferred, never applied to
-      // the unconstrained probability_of_goal number.
-      const goalFitBasisScoredFrom =
-        typeof (prob as any).goal_fit_basis?.scored_from === 'string'
-          ? ((prob as any).goal_fit_basis.scored_from as string)
-          : null
-      const goalFitIsModelledBasis =
-        goalProbabilityIsJoint && goalFitBasisScoredFrom === 'modelled_outcome_distribution'
+      // GOAL-PROBABILITY IDENTITY: the selector owns the whole decision —
+      // which quantity may be shown, and with what provenance. The caveat
+      // flag was previously re-derived HERE from the selector's `isJoint`
+      // plus a local `goal_fit_basis` read, and the canvas hook derived the
+      // same pair independently; the two disagreed live. Read them, never
+      // re-derive them.
+      const goalDecision = selectGoalProbability(prob as GoalProbabilityInput)
+      const { goalProbability, goalFitIsModelledBasis } = goalDecision
 
       // Display-honesty: per-option valid sample count for resolution-aware
       // probability formatting. Fallback chain prefers per-option signal,
@@ -1524,6 +1520,9 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         nValidSamples,
         goalProbability,
         goalFitIsModelledBasis,
+        // Which quantity `goalProbability` actually IS, carried to the render
+        // layer so prose can name it honestly (see types.ts).
+        goalFitIsSubstitutedJoint: goalDecision.basis === 'joint_goal_substituted',
         // Multi-constraint analysis (from ISL when goal_constraints were provided)
         constraintAnalysis: prob.constraint_analysis,
       }

--- a/src/components/results/utils/__tests__/selectGoalProbability.spec.ts
+++ b/src/components/results/utils/__tests__/selectGoalProbability.spec.ts
@@ -22,8 +22,15 @@ describe('selectGoalProbability — gate-independent behaviour', () => {
   })
 
   it('returns null when neither source is present', () => {
-    expect(selectGoalProbability(undefined)).toEqual({ goalProbability: null, goalProbabilityIsJoint: false })
-    expect(selectGoalProbability({})).toEqual({ goalProbability: null, goalProbabilityIsJoint: false })
+    const none = {
+      goalProbability: null,
+      goalProbabilityIsJoint: false,
+      basis: 'none' as const,
+      goalFitIsModelledBasis: false,
+      mayUsePossessiveGoalFraming: false,
+    }
+    expect(selectGoalProbability(undefined)).toEqual(none)
+    expect(selectGoalProbability({})).toEqual(none)
   })
 
   it('uses goal_probability (unconstrained) when there are no constraints', () => {
@@ -86,5 +93,77 @@ describe('selectGoalProbability — MUTATION PROOF: flip seam 1 back to true →
     const result = selectGoalProbability({ probability_of_joint_goal: 0.99 })
     expect(result.goalProbability).toBeNull()
     expect(result.goalProbabilityIsJoint).toBe(false)
+  })
+
+  it('reports no basis and no framing permission while the seam is suppressed', () => {
+    const result = selectGoalProbability({ probability_of_joint_goal: 0.99 })
+    expect(result.basis).toBe('none')
+    expect(result.goalFitIsModelledBasis).toBe(false)
+    expect(result.mayUsePossessiveGoalFraming).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// IDENTITY — which producer quantity the number IS, and what prose may say
+// about it. `basis` exists because "may we show a goal probability" is not
+// answerable without knowing which of the two collapsed quantities the value
+// answers; the caveat flag lives here (rather than being re-derived by each
+// consumer) because two consumers deriving it independently is exactly how
+// the results panel and the canvas came to disagree.
+// ---------------------------------------------------------------------------
+describe('selectGoalProbability — basis and framing permission', () => {
+  beforeEach(() => {
+    mockTrust.headlineSuspect = false
+  })
+
+  it('the unconstrained goal quantity licenses the possessive framing', () => {
+    const result = selectGoalProbability({ goal_probability: 0.42 })
+    expect(result.basis).toBe('goal_probability')
+    expect(result.mayUsePossessiveGoalFraming).toBe(true)
+  })
+
+  it('an option carrying its own constraints yields the constrained joint basis', () => {
+    const result = selectGoalProbability({
+      goal_probability: 0.42,
+      probability_of_joint_goal: 0.07,
+      constraint_analysis: { constraints: [{ id: 'c1' }] },
+    })
+    expect(result.basis).toBe('joint_goal_constrained')
+    expect(result.goalProbability).toBe(0.07)
+    expect(result.mayUsePossessiveGoalFraming).toBe(true)
+  })
+
+  it('a joint figure standing in for an absent goal figure shows the NUMBER but withholds the possessive', () => {
+    const result = selectGoalProbability({ probability_of_joint_goal: 0.62 })
+    expect(result.basis).toBe('joint_goal_substituted')
+    expect(result.goalProbability).toBe(0.62)
+    expect(result.goalProbabilityIsJoint).toBe(true)
+    expect(result.mayUsePossessiveGoalFraming).toBe(false)
+  })
+
+  it('carries the modelled-basis caveat on a joint figure the producer marked as modelled', () => {
+    const result = selectGoalProbability({
+      probability_of_joint_goal: 0.62,
+      goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+    })
+    expect(result.goalFitIsModelledBasis).toBe(true)
+  })
+
+  it('never applies the caveat to the unconstrained goal quantity, even when the marker is present', () => {
+    const result = selectGoalProbability({
+      goal_probability: 0.42,
+      probability_of_joint_goal: 0.62,
+      goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+    })
+    expect(result.basis).toBe('goal_probability')
+    expect(result.goalFitIsModelledBasis).toBe(false)
+  })
+
+  it('never applies the caveat on a non-modelled scored_from', () => {
+    const result = selectGoalProbability({
+      probability_of_joint_goal: 0.62,
+      goal_fit_basis: { scored_from: 'directly_elicited' },
+    })
+    expect(result.goalFitIsModelledBasis).toBe(false)
   })
 })

--- a/src/components/results/utils/selectGoalProbability.ts
+++ b/src/components/results/utils/selectGoalProbability.ts
@@ -1,6 +1,7 @@
 /**
- * selectGoalProbability — single source of truth for the goal_probability /
- * probability_of_joint_goal fallback chain.
+ * selectGoalProbability — THE single source of truth for the question
+ * "which producer quantity, if any, may be shown as this option's goal
+ * probability, and with what provenance".
  *
  * ROADMAP 1.49: OptionNode.tsx's per-option "chance of target" badge used to
  * read option_probabilities[id].goal_probability directly, with NO
@@ -13,21 +14,96 @@
  * different number for the SAME option on a constrained-goal run. Extracted
  * here so every surface calls one function instead of re-deriving the same
  * fallback logic.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * GOAL-PROBABILITY IDENTITY (this file's second job, and the reason it now
+ * publishes a basis rather than a bare number + boolean)
+ * ─────────────────────────────────────────────────────────────────────────
+ * The producer emits TWO semantically different quantities:
+ *
+ *   • `goal_probability`         P(this option's outcome clears the goal
+ *                                threshold) — the user's stated goal.
+ *   • `probability_of_joint_goal` P(ALL constraints jointly satisfied).
+ *
+ * They are collapsed under one display name, and until this module owned the
+ * decision outright they were chosen by TWO independent implementations with
+ * DIFFERENT rules — this selector for the results panel, and an inline chain
+ * in `canvas/hooks/useNodeDisplayMetadata.ts` for the canvas nodes and the
+ * inspector. On the documented ISL-auto-derived-threshold run
+ * (`goal_probability` ABSENT, `probability_of_joint_goal` PRESENT) the two
+ * disagreed LIVE: this selector returned the joint value and flagged it,
+ * while the canvas chain returned `null` — so the results panel rendered a
+ * percentage and its provenance caveat while the canvas GoalNode rendered
+ * "This run did not produce a goal probability", in the same session, about
+ * the same option. `useNodeDisplayMetadata` now calls this function; there is
+ * one chooser, not two.
+ *
+ * `basis` names WHICH quantity the returned number actually is, because
+ * "may we show a goal probability" is not answerable without it:
+ *
+ *   • 'goal_probability'        the true per-option goal quantity.
+ *   • 'joint_goal_constrained'  the joint quantity, chosen because THIS
+ *                               option carries its own constraint analysis —
+ *                               the user's own goal AND the user's own
+ *                               limits, which the "and limits" copy names.
+ *   • 'joint_goal_substituted'  the joint quantity STANDING IN for an absent
+ *                               goal quantity. The number is real and the
+ *                               user is entitled to it, but it answers a
+ *                               different question from the one the
+ *                               possessive framing ("your goal") asserts, so
+ *                               `mayUsePossessiveGoalFraming` is false here.
+ *   • 'none'                    no admissible value.
+ *
+ * `goalProbability` and `goalProbabilityIsJoint` are DERIVED from `basis`
+ * rather than computed alongside it, so the number and the claim about which
+ * quantity it is cannot drift apart.
  */
 
 import { PLOT_JOINT_HEADLINE_SUSPECT } from '../../../adapters/plot/constraintTrust'
+
+/**
+ * Which producer quantity the returned `goalProbability` actually IS. Never
+ * inferred by a consumer — consumers read this, they do not re-derive it.
+ */
+export type GoalProbabilityBasis =
+  | 'none'
+  | 'goal_probability'
+  | 'joint_goal_constrained'
+  | 'joint_goal_substituted'
 
 export interface GoalProbabilityInput {
   goal_probability?: number
   probability_of_joint_goal?: number
   constraint_analysis?: { constraints?: unknown[] } | null
+  goal_fit_basis?: { scored_from?: string } | null
 }
 
 export interface GoalProbabilitySelection {
-  /** The number to display, or null when neither source is present. */
+  /** The number to display, or null when no source is admissible. */
   goalProbability: number | null
   /** True when `goalProbability` is the joint-goal (constrained) figure. */
   goalProbabilityIsJoint: boolean
+  /** Which producer quantity `goalProbability` is. Never null; 'none' when absent. */
+  basis: GoalProbabilityBasis
+  /**
+   * Display-honesty (ROADMAP 1.6b, doctrine B / PLoT #204): true ONLY when
+   * the number above IS the joint-goal figure AND the producer marked it as
+   * scored from a modelled outcome distribution. EVERY surface that renders
+   * the number must render `GOAL_FIT_BASIS_CAVEAT_COPY` adjacent to it when
+   * this is true — computed here, once, so no surface can show the number
+   * with the caveat and another show it without.
+   */
+  goalFitIsModelledBasis: boolean
+  /**
+   * Whether prose may call the thing this number measures "YOUR goal".
+   *
+   * False on `joint_goal_substituted`: the value is P(all constraints jointly
+   * satisfied) standing in for an absent goal probability, so the possessive
+   * would attribute to the user a question the number does not answer. The
+   * NUMBER is still shown (it is real, computed, and decision-relevant) —
+   * only the possessive framing is withheld.
+   */
+  mayUsePossessiveGoalFraming: boolean
 }
 
 export function selectGoalProbability(
@@ -37,6 +113,8 @@ export function selectGoalProbability(
     typeof prob?.probability_of_joint_goal === 'number' ? prob.probability_of_joint_goal : null
   const unconstrained =
     typeof prob?.goal_probability === 'number' ? prob.goal_probability : null
+  const goalFitBasisScoredFrom =
+    typeof prob?.goal_fit_basis?.scored_from === 'string' ? prob.goal_fit_basis.scored_from : null
 
   // Honesty gate (UI-SEM-088, seam 1): while true, `probability_of_joint_goal`
   // can INVERT, so we NEVER substitute it — every surface falls back to the
@@ -55,22 +133,48 @@ export function selectGoalProbability(
   // Seam 2 (per-option `constraint_analysis` in the responseMapper) stays
   // gated on its own constant. Presence of a target is unaffected either way.
   if (PLOT_JOINT_HEADLINE_SUSPECT) {
-    return { goalProbability: unconstrained, goalProbabilityIsJoint: false }
+    return {
+      goalProbability: unconstrained,
+      goalProbabilityIsJoint: false,
+      basis: unconstrained != null ? 'goal_probability' : 'none',
+      goalFitIsModelledBasis: false,
+      mayUsePossessiveGoalFraming: unconstrained != null,
+    }
   }
 
   const hasConstraints = (prob?.constraint_analysis?.constraints?.length ?? 0) > 0
 
-  // Mirrors the goalProbability branch directly below (rather than comparing
-  // resulting numbers, which could false-match on a coincidental equal
-  // value) so callers know precisely WHEN the displayed number is the
-  // joint-goal figure the goal_fit_basis caveat qualifies.
-  const goalProbabilityIsJoint = hasConstraints
-    ? jointGoalProb != null
-    : unconstrained == null && jointGoalProb != null
+  // THE identity decision, made exactly once. Ordered so that each branch
+  // names a distinct producer situation rather than a coincidence of values:
+  // a per-option constraint analysis makes the joint figure the right answer;
+  // otherwise the goal quantity is the right answer whenever the run carries
+  // it; only when it does not does the joint figure stand in for it.
+  const basis: GoalProbabilityBasis =
+    hasConstraints && jointGoalProb != null
+      ? 'joint_goal_constrained'
+      : unconstrained != null
+        ? 'goal_probability'
+        : jointGoalProb != null
+          ? 'joint_goal_substituted'
+          : 'none'
 
-  const goalProbability = hasConstraints && jointGoalProb != null
+  const goalProbabilityIsJoint =
+    basis === 'joint_goal_constrained' || basis === 'joint_goal_substituted'
+
+  // Derived FROM the basis (never computed in parallel with it), so the
+  // number and the statement of which quantity it is cannot diverge.
+  const goalProbability = goalProbabilityIsJoint
     ? jointGoalProb
-    : (unconstrained ?? jointGoalProb)
+    : basis === 'goal_probability'
+      ? unconstrained
+      : null
 
-  return { goalProbability, goalProbabilityIsJoint }
+  return {
+    goalProbability,
+    goalProbabilityIsJoint,
+    basis,
+    goalFitIsModelledBasis:
+      goalProbabilityIsJoint && goalFitBasisScoredFrom === 'modelled_outcome_distribution',
+    mayUsePossessiveGoalFraming: goalProbability != null && basis !== 'joint_goal_substituted',
+  }
 }


### PR DESCRIPTION
## The contradiction

Two semantically different producer quantities are collapsed under one display name:

- `probability_of_goal` — P(this option's outcome clears the goal threshold)
- `probability_of_joint_goal` — P(ALL constraints jointly satisfied)

and the UI chose between them **twice, with different rules**:

| # | Site (at `201f1075`) | Rule |
|---|---|---|
| 1 | `components/results/utils/selectGoalProbability.ts:61-73` | joint when the option carries `constraint_analysis`, else `goal_probability ?? joint` |
| 2 | `canvas/hooks/useNodeDisplayMetadata.ts:240-261` | joint **only** when the option carries `constraint_analysis`, else `goal_probability ?? null` — **no joint tail** |

On the documented ISL-auto-derived-goal-threshold run (`goal_probability` **absent**,
`probability_of_joint_goal` **present**) those rules disagree, and that case is **live**:

- `PLOT_JOINT_HEADLINE_SUSPECT = false` (`adapters/plot/constraintTrust.ts:33`) — the joint
  substitution is armed.
- `v5/mapV5AnalysisToReport.ts` has **zero** `constraint_analysis` occurrences and
  `adapters/plot/v2/responseMapper.ts:676` nulls it behind `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT = true`
  — so `hasConstraints` is **always false** on the deployed V5 path.
- `mapV5AnalysisToReport.ts:563` only spreads `goal_probability` when `probability_of_goal` is a
  finite number, so its absence is real, not defensive.

⇒ the results panel renders a percentage **and** its provenance caveat while the canvas GoalNode
renders *"Target set. This run did not produce a goal probability."* — same session, same option.
I verified the two gates open **together** (`useResultsSectionData`'s `effectiveGoalThreshold` falls
back to `goalNode.data.goal_threshold_raw`, the same field `GoalNode`'s `hasThreshold` reads), so
this is one screen contradicting itself, not two different states.

## RED-first evidence

The parity spec was written and run **before** any fix. 12/12 red. The load-bearing lines:

```
× goal-probability identity — the two consumers agree > the canvas consumer returns the SAME value as the results-panel selector
   → expected null to be 0.62 // Object.is equality
× goal-probability identity — the two consumers agree > the canvas consumer returns the SAME provenance caveat as the results-panel selector
   → expected false to be undefined
× goal-probability identity — the rendered canvas text matches the decision > GoalNode states the same percentage the results panel does
   → Unable to find an element with the text: /62% chance of reaching target/
```

and the rendered DOM in that failure, verbatim:

```html
<p class="text-[11px] font-sans leading-tight text-text-body mt-1 m-0">
  Target set. This run did not produce a goal probability.
</p>
```

The spec asserts **agreement**, never a hard-coded number, and opens with a positive control that
fixes the selector's decision first — so "both surfaces returned null" can never satisfy it
(CLAUDE.md trap 13). jsdom claims are text-content only, never visibility (trap 3).

## Mutation proof

Throwaway clone at a **sibling path outside the repo root** (traps 9 / 9c), `useNodeDisplayMetadata.ts`
reverted to `201f1075` with `git checkout`, throwaway **deleted before any gate run**:

```
✓ POSITIVE CONTROL: the single source of truth really does show a number and a caveat here
× the canvas consumer returns the SAME value as the results-panel selector   → expected null to be 0.62
× the canvas consumer returns the SAME provenance caveat                     → expected false to be true
× GoalNode states the same percentage the results panel does
× GoalNode does not simultaneously deny that a goal probability exists
× GoalNode carries the provenance caveat the results panel carries
✓ agrees on the control run too (the true goal quantity is present)

Test Files  1 failed (1)
     Tests  5 failed | 7 passed (12)
```

The mutation is **discriminating**, not blanket: the positive control and the goal-quantity control
both stay green, and only the substituted-joint case dies. Reverting the unification turns the pin
red naming the exact divergence.

## The fix

`selectGoalProbability` becomes THE single source of truth for *"which quantity, if any, may be shown
as the goal probability, and with what provenance"*, and publishes:

- `basis: 'none' | 'goal_probability' | 'joint_goal_constrained' | 'joint_goal_substituted'`
- `goalFitIsModelledBasis` — the provenance caveat permission, computed **once**
- `mayUsePossessiveGoalFraming`

`goalProbability` and `goalProbabilityIsJoint` are now **derived from `basis`** rather than computed
alongside it, so the number and the claim about which quantity it is cannot drift apart. Behaviour
for every previously-reachable input is unchanged — the 23 pre-existing `useNodeDisplayMetadata`
tests pass untouched.

Consumers **read** it; none re-derives it:

- `canvas/hooks/useNodeDisplayMetadata.ts` — inline chain **deleted**, calls the selector (GoalNode,
  OutcomeNode, NodeInspector all follow).
- `components/results/useResultsSectionData.ts` — stops re-deriving the caveat flag from
  `isJoint` + a local `goal_fit_basis` read; reads it.
- `canvas/nodes/OptionNode.tsx` — keeps the whole decision instead of just `.goalProbability`, and
  now renders the caveat (see refutation B).
- `analysis-hero/buildHeroModel.ts` — copy switch only, never a value transform.

No new chooser was added; the existing ones were unified.

## Interim semantics implemented — option 1 (show the number, withhold the possessive)

On `joint_goal_substituted` the **number is shown** (it is real, computed and decision-relevant), the
**possessive framing is withheld**, and the **provenance caveat renders on every surface showing the
number**. Surface-by-surface after this PR:

| Surface | Number | Possessive | Caveat |
|---|---|---|---|
| Hero detail line | shown | `HERO_COPY.detail.goalFitJointBasis` — *"N% chance of meeting all targets together."* | yes |
| `OptionCards` "Hits target" | shown | already non-possessive | yes |
| Canvas `GoalNode` | **now shown** (was a denial) | already non-possessive | **now yes** |
| Canvas `OutcomeNode`, `NodeInspector` | **now shown** | non-possessive | **now yes** |
| Canvas `OptionNode` badge | shown | non-possessive | **now yes** (was bare) |

The strict fallback (both surfaces hide the value) was **not** taken: it resolves the contradiction by
levelling *down*, deleting a number the user is entitled to. This resolves it by levelling *up*.
**⚠ Paul's ruling wanted** — see refinement D.

## Refutations and refinements of `MEANING-LAYER-FAMILY2-GOAL-DESIGN-2026-07-27.md`

Re-derived independently at `201f1075`, which is still the live `staging` tip.
**R-1's core claim is CONFIRMED at the bytes.** Five corrections:

**A — the design's slice plan blocks this fix behind four slices it does not need.** §4 puts the UI
work at slice 4, after a `@talchain/schemas` 0.26.0 release, a CEE owner module, a hoist and a
register, and §5.2/§5.3 require *"Bump `@talchain/schemas` 0.22.0 → 0.26.0 first"*. **None of that is
required for this divergence.** All three fields reach the UI through the **untyped enrichment
passthrough** at `v5/mapV5AnalysisToReport.ts:558-575`, never through a typed schema member. This PR
touches no contract and needs no pin bump. A live user-visible contradiction was sequenced behind
four blocking slices it never needed.

**B — the manifest misses a fourth site in this exact family.** §1.3 seam B lists three derivations.
`canvas/nodes/OptionNode.tsx:764` is a fourth consumer: it called the selector but took only
`.goalProbability`, **discarding `goalProbabilityIsJoint`** — so the option-node badge rendered the
joint-basis figure with **no caveat** while OptionCards / hero / GoalNode rendered the same figure
with one. R-1's caveat-split names only the panel-vs-GoalNode pair; this is a third state of it.
Fixed here.

**C — R-1's *"the caveat renders on one surface and not the other, next to the same number"* is
imprecise.** In the divergent case the canvas has **no number** — it renders an explicit denial. The
doc's own preceding sentence says so. The accurate framing is worse than the doc's: a denial is a
claim, not an omission.

**D — the possessive rule lands via `basis_unresolved`, not `target_imputed`.** The design's §3 table
sets `MAY_ASSERT_POSSESSIVE = false` for **both**. Joint-substitution is *which quantity*
(`basis_unresolved`), not *whose target* (`target_imputed`). Note the same table sets
`MAY_ASSERT_GOAL_ATTAINMENT[basis_unresolved] = false` — **the design would hide the number**. This PR
follows the brief's more permissive interim ruling instead. Flagged for sign-off.

**E — the hero's possessive is narrower than the doc implies.** `buildHeroModel.ts:249-253/:282` nulls
every goal value unless `hasUserTarget`, so *"your goal"* never appears without a target set on the
goal node.

## Out of scope, flagged with file:line for the next slice

**Run-level hero DESIGNATIONS still use the possessive on a substituted-joint run** — the goal-fit
crown and the off-track verdict, which the brief scoped out of this identity slice:

- `heroCopy.ts:68` `goalOnly` — *"{label} best fits your goal."* (chosen at `buildHeroModel.ts:601`)
- `heroCopy.ts:104` `noneOnTrack` — *"No option is currently on track to reach your goal."* (`:597`)
- `heroCopy.ts:157` `caption.goalOnly` (chosen at `AnalysisHeroPanel.tsx:237`)

Each needs a run-level `goalValuesAreSubstitutedJoint` every-quantifier mirroring the existing
`hasConstraints` one at `buildHeroModel.ts:266-267`.

**Behaviour change worth naming:** `GoalNode.tsx:366-372` *"Target may be ambitious."* is **newly
reachable**, because `achievementProbability` now returns a value where it previously returned null.
That is a designation about the user's target and belongs to the gating slice.

**Not verified here:** no live staging probe was run (the design's own R-7.2 gap). The divergence is
reproduced at the bytes and in a rendering test driving the **real** hook and the **real** GoalNode —
that proves the code path, not the wire.

## Gates

Derived in a fresh blobless clone of `staging` at a lane-unique path, `VITE_SUPABASE_URL` /
`VITE_SUPABASE_ANON_KEY` set for **every** run (trap 2b). No collect-time failures in either run, so
the counts are comparable.

| | Pristine `201f1075` | This branch |
|---|---|---|
| Test files | 1317 passed, 3 skipped (1320) | **1319 passed, 3 skipped (1322)** |
| Tests | 19539 passed, 66 skipped (19605) | **19562 passed, 66 skipped (19628)** — exactly +23, the new specs, no collateral |
| Failures | 0 | **0** |
| Typecheck gate | PASSED — 2995/3013 loaded; 633 files / 2549 errors (baseline 2663) | PASSED — identical: 633 files / 2549 errors |

**No baseline was updated, no test deleted or quarantined.** The gate caught one genuine new type
error in my own spec (`NodeProps` missing `deletable`/`selectable`/`draggable`) and it was fixed at
source rather than absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
