### PR TITLE
fix(readiness): accept CEE's actual pre-analysis vocabulary — a READY model stops being told to improve itself (family 3, slice 0)

### DIFF
--- a/src/canvas/components/PreAnalysisHealth.tsx
+++ b/src/canvas/components/PreAnalysisHealth.tsx
@@ -25,7 +25,7 @@ import {
   Plus,
   ArrowRight,
 } from 'lucide-react'
-import { useGraphReadiness, type ReadinessLevel, type GraphImprovement, type ImprovementPriority, type SuggestedNodeType } from '../hooks/useGraphReadiness'
+import { useGraphReadiness, type GraphReadinessLevel, type GraphImprovement, type ImprovementPriority, type SuggestedNodeType } from '../hooks/useGraphReadiness'
 import { useCanvasStore } from '../store'
 import { focusNodeById, focusEdgeById } from '../utils/focusHelpers'
 import { typography } from '../../styles/typography'
@@ -54,15 +54,32 @@ interface PreAnalysisHealthProps {
   hasBlockers?: boolean
 }
 
-// Tier styling configuration
-const tierConfig: Record<ReadinessLevel, {
+interface TierStyle {
   icon: typeof CheckCircle
   bgColor: string
   borderColor: string
   textColor: string
   iconColor: string
   label: string
-}> = {
+}
+
+// The top band, styled once. CEE spells it `ready`; the UI's local CEE-down
+// fallback spells the same band `strong`. Both entries below share this object
+// so the two spellings can never drift apart visually.
+const topBandStyle: Omit<TierStyle, 'label'> = {
+  icon: CheckCircle,
+  bgColor: 'bg-mint-50',
+  borderColor: 'border-mint-200',
+  textColor: 'text-mint-800',
+  iconColor: 'text-mint-600',
+}
+
+// Tier styling configuration.
+// `Record<GraphReadinessLevel, …>` is the exhaustiveness device: a level added
+// to the vocabulary without an entry here is a COMPILE ERROR, not a silent
+// `undefined` config. Before 2026-07-27 this map had no `ready` case at all —
+// it could not, because the level never survived the normaliser.
+const tierConfig: Record<GraphReadinessLevel, TierStyle> = {
   needs_work: {
     icon: AlertTriangle,
     bgColor: 'bg-carrot-50',
@@ -79,12 +96,12 @@ const tierConfig: Record<ReadinessLevel, {
     iconColor: 'text-banana-600',
     label: 'Fair',
   },
+  ready: {
+    ...topBandStyle,
+    label: 'Ready',
+  },
   strong: {
-    icon: CheckCircle,
-    bgColor: 'bg-mint-50',
-    borderColor: 'border-mint-200',
-    textColor: 'text-mint-800',
-    iconColor: 'text-mint-600',
+    ...topBandStyle,
     label: 'Strong',
   },
 }

--- a/src/canvas/hooks/useGraphReadiness.ts
+++ b/src/canvas/hooks/useGraphReadiness.ts
@@ -150,7 +150,67 @@ export const __test__ = { deduplicatedFetch, releaseInflightEntry }
 
 // ── Types (re-exported for all consumers) ──────────────────────────
 
-export type ReadinessLevel = 'needs_work' | 'fair' | 'strong'
+// ── PRE-ANALYSIS readiness vocabulary ──────────────────────────────
+//
+// ⚠ THIS IS NOT THE POST-ANALYSIS CONFIDENCE TIER. `EnrichmentConfidenceTier`
+// (`strong | fair | needs_work`, @talchain/schemas dist/boundary/enrichment.d.ts)
+// answers "how much should you trust the answer we just produced?". The field
+// below answers "is this model complete enough to analyse?" — a different claim
+// at a different point in the lifecycle, produced by a different service.
+//
+// Until 2026-07-27 the allowlist in readinessStore's normaliser was the
+// POST-analysis tier's member list applied to this PRE-analysis field. The two
+// sets overlap on `fair` and `needs_work` and differ on exactly one member, so
+// the mistranslation was invisible on two thirds of all inputs and silently
+// coerced CEE's top band (`ready`) to `fair` on EVERY graph scoring >= 70.
+// Keep the two vocabularies named apart so that cannot recur.
+
+/**
+ * The levels CEE emits for `readiness_level` on POST /assist/v1/graph-readiness.
+ *
+ * ⚠ CROSS-REPO MIRROR — it cannot be derived from this repo, because the
+ * pre-analysis readiness surface does not travel through `@talchain/schemas`.
+ * Read at the bytes from olumi-assistants-service `staging`
+ * `b35d09debc0c6843dbcbf7f28a4676810d77c278`:
+ *   - `src/cee/graph-readiness/types.ts:8`
+ *       `export type ReadinessLevel = "ready" | "fair" | "needs_work";`
+ *   - `src/routes/assist.v1.graph-readiness.ts:29` (V1) and `:169` (V3), both
+ *       `readiness_level: "ready" | "fair" | "needs_work";`
+ *   - `src/cee/graph-readiness/index.ts:198-201` assigns `"ready"` at
+ *       `score >= READINESS_THRESHOLDS.ready` (70, `constants.ts:30-31`).
+ * A producer-side change to this set is NOT visible from here; the durable fix
+ * is a boundary-contract test deriving both sides at their real SHAs.
+ */
+export const CEE_READINESS_LEVELS = ['needs_work', 'fair', 'ready'] as const
+export type CeeReadinessLevel = (typeof CEE_READINESS_LEVELS)[number]
+
+/**
+ * `strong` is NOT a CEE value — no CEE code path assigns it to `readiness_level`.
+ * It is emitted only by the UI's own local heuristic,
+ * `readinessStore.calculateFallbackReadiness`, when CEE is unreachable, and that
+ * value is written straight to the store WITHOUT passing through the normaliser.
+ * Accepted here so the field's type covers both writers.
+ *
+ * @deprecated Local-fallback spelling of the top band. The fallback emitting a
+ * BETTER verdict than the producer (CEE down + score 85 => `strong`; CEE up +
+ * score 85 => the top band) is tracked separately and deliberately untouched
+ * here — see the divergence-2 row on the family-3 readiness design.
+ */
+export const LOCAL_FALLBACK_READINESS_LEVELS = ['strong'] as const
+export type LocalFallbackReadinessLevel = (typeof LOCAL_FALLBACK_READINESS_LEVELS)[number]
+
+/**
+ * Every value `GraphReadiness.readiness_level` may hold — the producer's set
+ * plus the local-fallback band. This is what the normaliser accepts; anything
+ * else is unrecognised input and degrades to `fair` (loudly, in DEV).
+ */
+export const ACCEPTED_READINESS_LEVELS = [
+  ...CEE_READINESS_LEVELS,
+  ...LOCAL_FALLBACK_READINESS_LEVELS,
+] as const
+
+export type GraphReadinessLevel = CeeReadinessLevel | LocalFallbackReadinessLevel
+
 export type ImprovementPriority = 'high' | 'medium' | 'low'
 
 export type SuggestedNodeType = 'risk' | 'outcome' | 'option' | 'factor' | 'evidence' | 'goal' | 'decision'
@@ -190,7 +250,7 @@ export interface ScaffoldPlan {
 
 export interface GraphReadiness {
   readiness_score: number // 0-100
-  readiness_level: ReadinessLevel
+  readiness_level: GraphReadinessLevel
   can_run_analysis: boolean
   confidence_explanation: string
   improvements: GraphImprovement[]

--- a/src/canvas/stores/__tests__/readinessStore.ceeVocabulary.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.ceeVocabulary.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * readinessStore — CEE pre-analysis readiness VOCABULARY boundary.
+ *
+ * THE DEFECT THIS PINS (live on every graph CEE scored >= 70):
+ *
+ *   CEE emits  `readiness_level: "ready" | "fair" | "needs_work"`
+ *   The UI accepted `['needs_work', 'fair', 'strong']`
+ *
+ * — the POST-analysis `EnrichmentConfidenceTier` member list applied to the
+ * PRE-analysis readiness field. The two sets overlap on `fair` and `needs_work`
+ * and differ on exactly one member, so the mistranslation was invisible on two
+ * thirds of all inputs and bit only at the top band: `"ready"` fell through the
+ * allowlist to the `: 'fair'` default, and `canRunAnalysis` then attached
+ * "Analysis available - consider improvements for better results" to the Run
+ * button of a model the producer had just called ready.
+ *
+ * ⚠ ANTI-TAUTOLOGY PIN. The fixture below is CEE's ACTUAL response shape, read
+ * at the bytes from olumi-assistants-service `staging`
+ * `b35d09debc0c6843dbcbf7f28a4676810d77c278` — NOT from this repo's own types.
+ * A control whose reference is the consumer's own type cannot detect this
+ * defect class; it IS the defect. Sources:
+ *   - `src/cee/graph-readiness/types.ts:8`
+ *       `export type ReadinessLevel = "ready" | "fair" | "needs_work";`
+ *   - `src/routes/assist.v1.graph-readiness.ts:29` (V1) / `:169` (V3) response
+ *       types, both `readiness_level: "ready" | "fair" | "needs_work";`
+ *   - `src/cee/graph-readiness/index.ts:198-201`
+ *       `if (score >= READINESS_THRESHOLDS.ready) return "ready";`
+ *   - `src/cee/graph-readiness/constants.ts:30-31` — `ready: 70`
+ * `"strong"` is emitted by NO CEE code path for this field.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useReadinessStore } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import {
+  clearInflightCache,
+  CEE_READINESS_LEVELS,
+} from '../../hooks/useGraphReadiness'
+import { canRunAnalysis, getRunButtonTooltip } from '../../utils/canRunAnalysis'
+
+// ── Mock fetch ──────────────────────────────────────────────────────
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+/**
+ * CEE's `/assist/v1/graph-readiness` 200 body for a well-formed graph, verbatim
+ * in shape from `CEEGraphReadinessResponseV1` at the SHA recorded above.
+ * The score is 85 — comfortably over CEE's `ready` threshold of 70.
+ */
+const CEE_READY_RESPONSE = {
+  readiness_score: 85,
+  readiness_level: 'ready',
+  confidence_level: 'high',
+  confidence_explanation: 'Your model has good structure and connections',
+  quality_factors: {},
+  can_run_analysis: true,
+  improvements: [],
+} as const
+
+function mockCeeResponse(body: Record<string, unknown>) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => ({
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }))
+  const edges =
+    count > 1
+      ? [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive' },
+          },
+        ]
+      : []
+  useCanvasStore.setState({ nodes: nodes as any, edges: edges as any })
+}
+
+/** Drive one full fetch cycle and hand back what the store settled on. */
+async function readinessAfterCeeSays(body: Record<string, unknown>) {
+  mockFetch.mockResolvedValue(mockCeeResponse(body))
+  seedCanvasWithNodes(4)
+  useReadinessStore.getState().startListening()
+  await vi.runAllTimersAsync()
+  const { readiness } = useReadinessStore.getState()
+  expect(readiness).not.toBeNull()
+  return readiness!
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+// ── The RED-first pin ───────────────────────────────────────────────
+
+describe("CEE's top band survives the UI's front door", () => {
+  it('preserves readiness_level "ready" instead of coercing it to "fair"', async () => {
+    const readiness = await readinessAfterCeeSays({ ...CEE_READY_RESPONSE })
+
+    // Pre-fix this read 'fair' — the producer's best-case answer caught by a
+    // fall-through default written to catch malformed input.
+    expect(readiness.readiness_level).toBe('ready')
+    expect(readiness.readiness_score).toBe(85)
+  })
+
+  it('does NOT tell a model CEE called ready to go and improve itself', async () => {
+    const readiness = await readinessAfterCeeSays({ ...CEE_READY_RESPONSE })
+
+    // The one live consumer of the normalised level: OutputsDock:834 →
+    // canRunAnalysis:243 → getRunButtonTooltip → the Run button's title.
+    const gate = canRunAnalysis({
+      graphHealth: null,
+      readiness,
+      hasBlockers: false,
+      nodeCount: 4,
+    })
+
+    expect(gate.allowed).toBe(true)
+    expect(gate.warning).toBeUndefined()
+    expect(getRunButtonTooltip(gate)).toBeUndefined()
+    // The exact string the user was shown pre-fix.
+    expect(getRunButtonTooltip(gate) ?? '').not.toContain('consider improvements')
+  })
+})
+
+// ── Positive controls ───────────────────────────────────────────────
+//
+// The fix must be a WIDENING, not a swap: every level accepted before must
+// still flow through byte-identically, and the guard's safety purpose must
+// survive intact.
+
+describe('positive controls — the rest of the vocabulary is unchanged', () => {
+  it.each([
+    ['fair', 55],
+    ['needs_work', 20],
+    // Not a CEE value — emitted only by the UI's own CEE-down fallback. Kept
+    // accepted so the fallback path (divergence 2, out of scope here) is not
+    // disturbed by this change.
+    ['strong', 85],
+  ])('passes %s through unchanged', async (level, score) => {
+    const readiness = await readinessAfterCeeSays({
+      ...CEE_READY_RESPONSE,
+      readiness_level: level,
+      readiness_score: score,
+    })
+
+    expect(readiness.readiness_level).toBe(level)
+    expect(readiness.readiness_score).toBe(score)
+  })
+
+  it('still warns on "fair" — the branch that was misfiring is intact, not deleted', async () => {
+    const readiness = await readinessAfterCeeSays({
+      ...CEE_READY_RESPONSE,
+      readiness_level: 'fair',
+      readiness_score: 55,
+    })
+
+    const gate = canRunAnalysis({
+      graphHealth: null,
+      readiness,
+      hasBlockers: false,
+      nodeCount: 4,
+    })
+
+    expect(gate.allowed).toBe(true)
+    expect(gate.warning).toBe('Analysis available - consider improvements for better results')
+  })
+
+  it.each([
+    ['an unknown vocabulary member', 'excellent'],
+    ['a value from a different lifecycle', 'close_call'],
+    ['garbage', '<script>'],
+    ['a non-string', 42],
+    ['null', null],
+    ['undefined', undefined],
+  ])('degrades %s safely to "fair"', async (_label, level) => {
+    const readiness = await readinessAfterCeeSays({
+      ...CEE_READY_RESPONSE,
+      readiness_level: level,
+    })
+
+    // The guard is being re-pointed at the right vocabulary, NOT removed.
+    expect(readiness.readiness_level).toBe('fair')
+  })
+})
+
+// ── The producer mirror, asserted rather than assumed ────────────────
+
+describe('the accepted set is the producer vocabulary', () => {
+  it('accepts exactly the three levels CEE emits for readiness_level', () => {
+    // Pinned to the CEE SHA in this file's header, not to the UI's own type.
+    expect([...CEE_READINESS_LEVELS].sort()).toEqual(['fair', 'needs_work', 'ready'])
+  })
+
+  it('does not treat "strong" as a producer value', () => {
+    expect(CEE_READINESS_LEVELS as readonly string[]).not.toContain('strong')
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -15,16 +15,53 @@ import type { Node, Edge } from '@xyflow/react'
 import { getEdgeKey } from '../domain/edgeUtils'
 import type {
   GraphReadiness,
+  GraphReadinessLevel,
   GraphImprovement,
   DeduplicatedResponse,
 } from '../hooks/useGraphReadiness'
 import {
+  ACCEPTED_READINESS_LEVELS,
   __test__ as dedupUtils,
 } from '../hooks/useGraphReadiness'
 import { plotAuthHeaders } from '../../lib/plotAuthHeaders'
 
 // Re-export types consumers need
 export type { GraphReadiness, GraphImprovement }
+
+/**
+ * Normalise CEE's `readiness_level` onto the accepted pre-analysis vocabulary.
+ *
+ * The accepted set is `ACCEPTED_READINESS_LEVELS` — CEE's own emitted members
+ * (`needs_work | fair | ready`) plus the local-fallback `strong` — and NOT a
+ * literal list maintained here. It used to be `['needs_work','fair','strong']`,
+ * the POST-analysis `EnrichmentConfidenceTier` members applied to this
+ * PRE-analysis field: `ready` was absent, so CEE's top band was silently
+ * rewritten to `fair` on every graph scoring >= 70, and `canRunAnalysis`
+ * then attached "consider improvements for better results" to the Run button
+ * of a model CEE had called ready.
+ *
+ * The guard itself is deliberately kept: unrecognised input still degrades to
+ * `fair` rather than reaching consumers untyped. What changes is (a) the
+ * vocabulary it is measured against and (b) that the degrade is no longer
+ * silent — a silent coercion is exactly why this survived review.
+ */
+function normaliseReadinessLevel(raw: unknown): GraphReadinessLevel {
+  if (
+    typeof raw === 'string' &&
+    (ACCEPTED_READINESS_LEVELS as readonly string[]).includes(raw)
+  ) {
+    return raw as GraphReadinessLevel
+  }
+
+  if (import.meta.env.DEV) {
+    console.warn(
+      `[readinessStore] Unrecognised readiness_level ${JSON.stringify(raw)} — ` +
+        `degrading to 'fair'. Accepted: ${ACCEPTED_READINESS_LEVELS.join(' | ')}. ` +
+        `If CEE now emits this value, widen CEE_READINESS_LEVELS in useGraphReadiness.ts.`,
+    )
+  }
+  return 'fair'
+}
 
 const CEE_BASE_URL = (import.meta as any).env?.VITE_CEE_BFF_BASE || '/bff/cee'
 
@@ -359,9 +396,7 @@ async function fetchReadiness(): Promise<void> {
           typeof data.readiness_score === 'number'
             ? Math.max(0, Math.min(100, data.readiness_score))
             : 50,
-        readiness_level: ['needs_work', 'fair', 'strong'].includes(data.readiness_level)
-          ? data.readiness_level
-          : 'fair',
+        readiness_level: normaliseReadinessLevel(data.readiness_level),
         can_run_analysis:
           typeof data.can_run_analysis === 'boolean' ? data.can_run_analysis : true,
         confidence_explanation:

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -239,7 +239,15 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   // Analysis allowed - check for warnings
   let warning: string | undefined
 
-  // Warn if readiness is low but not blocking
+  // Warn if readiness is low but not blocking.
+  //
+  // ⚠ `fair` MUST stay an exact match. Until 2026-07-27 the readiness
+  // normaliser coerced CEE's top band (`ready`, score >= 70) to `fair`, so this
+  // branch fired for every well-formed model and the Run button's tooltip told
+  // a model CEE had just called READY to go and improve itself. `ready` and
+  // `strong` deliberately have no branch here: the correct guidance for the top
+  // band is silence, and adding a case for them would re-create the defect in a
+  // new spelling.
   if (readiness?.readiness_level === 'fair') {
     warning = 'Analysis available - consider improvements for better results'
   }


### PR DESCRIPTION
Family-3 readiness, **slice 0 only**. UI-only: no contract work, no owner module, no
persistence, no hoist. Scoped by
`docs-designs/MEANING-LAYER-FAMILY3-READINESS-DESIGN-2026-07-27.md` §0.2 / §5 / R-1.

Every claim below was verified at the bytes on **both** sides of the boundary, in fresh
blobless clones — UI `staging` `8b2f594523464dc3470196494c3fe5f84bcbd7b5`, CEE `staging`
`b35d09debc0c6843dbcbf7f28a4676810d77c278` (still the live CEE staging tip when read).

---

## The defect

**CEE emits three levels. The UI accepted three levels. They were not the same three.**

| Hop | At the bytes |
|---|---|
| **CEE type** | `cee/graph-readiness/types.ts:8` — `export type ReadinessLevel = "ready" \| "fair" \| "needs_work";` |
| **CEE assignment** | `cee/graph-readiness/index.ts:198-201` — `if (score >= READINESS_THRESHOLDS.ready) return "ready";`, threshold **70** (`constants.ts:30-31`) |
| **CEE wire type, both regimes** | `routes/assist.v1.graph-readiness.ts:29` (V1) and `:169` (V3) — `readiness_level: "ready" \| "fair" \| "needs_work";` |
| **UI allowlist** | `canvas/stores/readinessStore.ts:362` — `['needs_work', 'fair', 'strong'].includes(data.readiness_level) ? data.readiness_level : 'fair'` |
| **UI type** | `canvas/hooks/useGraphReadiness.ts:153` — `'needs_work' \| 'fair' \| 'strong'` |

`"ready"` was not in the allowlist, so it fell through to the `: 'fair'` default — a
fall-through written to catch malformed input, catching the producer's best-case answer
instead, **on every graph CEE scored ≥ 70**. No flag, no rare input, no timing.

The user-facing end of it, traced hop by hop:

`readinessStore` → `useGraphReadiness.ts:213` → `OutputsDock.tsx:801` → `:834`
`canRunAnalysisUtil(...)` → `canvas/utils/canRunAnalysis.ts:243`:

```ts
if (readiness?.readiness_level === 'fair') {
  warning = 'Analysis available - consider improvements for better results'
}
```

→ `getRunButtonTooltip` → `OutputsDock.tsx:2442-2444` `actionTitle`.

⇒ **a model CEE assessed as READY was told to go and improve itself**, on the Run button.

**Why it survived review.** The accepted list was the contract's **post-analysis**
`EnrichmentConfidenceTier` vocabulary (`strong | fair | needs_work`, `@talchain/schemas`
`dist/boundary/enrichment.d.ts:21`) applied to the **pre-analysis** readiness field. The two
sets overlap on `fair` and `needs_work` and differ on exactly one member — so the
mistranslation was **invisible on two thirds of all inputs** and bit only at the top band.
`"strong"` is emitted by no CEE code path for this field.

---

## The fix

**1. The accepted set is now derived from the producer's vocabulary, not a literal in the
normaliser.** `useGraphReadiness.ts` gains one named source of truth, with the type derived
*from* it so the two cannot drift apart:

```ts
export const CEE_READINESS_LEVELS = ['needs_work', 'fair', 'ready'] as const
export type CeeReadinessLevel = (typeof CEE_READINESS_LEVELS)[number]

/** @deprecated local-fallback spelling of the top band (divergence 2, out of scope here) */
export const LOCAL_FALLBACK_READINESS_LEVELS = ['strong'] as const

export const ACCEPTED_READINESS_LEVELS = [
  ...CEE_READINESS_LEVELS, ...LOCAL_FALLBACK_READINESS_LEVELS,
] as const
export type GraphReadinessLevel = CeeReadinessLevel | LocalFallbackReadinessLevel
```

The constant's docstring cites the CEE file:line **and SHA** it mirrors. It is still a
cross-repo mirror — it cannot be derived from this repo, because the pre-analysis readiness
surface does not travel through `@talchain/schemas` at all. That is stated in the comment
rather than glossed: the durable instrument is the boundary-contract test the design proposes
in R-3, which is **not** built here.

`strong` is retained deliberately — `calculateFallbackReadiness` emits it when CEE is
unreachable and writes it **straight to the store, bypassing the normaliser**, so the field's
type must cover both writers. It is now *named apart* from the producer's set instead of
sitting anonymously in one flat list.

**2. The pre-analysis type is renamed so the confusion cannot silently recur.**
`useGraphReadiness.ts`'s `ReadinessLevel` → `GraphReadinessLevel`. The design names **three**
mutually contradictory exported `ReadinessLevel` types (`types/cee.ts:50`,
`useGraphReadiness.ts:153`, `lib/readiness.ts:25`). Adding `'ready'` to this one would have
made it *partially* assignable to the other two (they share `'ready'`) — the worst case,
since it type-checks on the common path and fails only on the rare one. Renaming removes that
hazard at source. **No dead type resurrected, none deleted** — the other two are untouched per
the design's later-slice plan. Safe: exactly one importer repo-wide.

**3. The guard is kept, and made loud.** Unrecognised input still degrades to `'fair'` — the
safety purpose is intact, only the vocabulary it measures against changed. It now emits a DEV
`console.warn` naming the offending value and the accepted set. A *silent* coercion is
precisely why this survived; the degrade must never again be indistinguishable from success.

---

## Consumer trace — which renderers needed a `ready` case

Complete manifest. Scope: **every tracked file in the repo** (`git grep`), string
`readiness_level`, each hit then classified by which producer writes the value it reads.

| Consumer | Reads the normalised value? | Needed a `ready` case? |
|---|---|---|
| `canvas/utils/canRunAnalysis.ts:243` | **YES — the one LIVE consumer** | **No, and adding one would be wrong.** The fix is that the `=== 'fair'` branch stops firing. The correct guidance for the top band is silence. Comment added so nobody widens the condition back. |
| `canvas/components/PreAnalysisHealth.tsx:208` `tierConfig[readiness.readiness_level]` | YES | **Yes — and the compiler forced it.** `Record<GraphReadinessLevel, …>` turned the missing `ready` key into a build error rather than a silent `undefined` config. Added, sharing `strong`'s style object so the two spellings of the top band cannot drift visually, and introducing **zero** new Tailwind tokens (the DS-compliance baseline tracks this file per-token). |
| `components/results/useResultsSectionData.ts:897` `mapReadinessLevel` | **NO** | n/a — its `graphReadiness` is built at `:2252` from `runMeta.ceeReviewV1.readiness`, the **review** endpoint's vocabulary, not the readiness store. (It already maps `ready → 'strong'` correctly.) |
| `pre-analysis-v3/signals/registry.ts` | **NO** — `registry.spec.ts:145` actively pins that v3 never branches on `readiness_level` | n/a |
| The other five `useGraphReadiness()` call sites (`PreAnalysisGuidance`, `usePreAnalysisModel`, `useUnifiedActions`, `usePreAnalysisData`, `ConversationPanel`) | They read `readiness_score` / `can_run_analysis` only | n/a |

`PreAnalysisHealth` is **DEAD** — zero importers repo-wide; the only other mention in `src/`
is a stale comment at `readinessStore.ts:46`. It is fixed rather than deleted because deletion
is not this slice's business, and because it is the file where the exhaustiveness device bites.

---

## RED-first

Run on **pristine `8b2f5945`** in a throwaway worktree **outside the repo root**, source
verified untouched (`git status --porcelain` showed only the untracked spec):

```
 ❯ readinessStore.ceeVocabulary.spec.ts  (12 tests | 2 failed)

 FAIL > CEE's top band survives the UI's front door > preserves readiness_level "ready" instead of coercing it to "fair"
 AssertionError: expected 'fair' to be 'ready' // Object.is equality
   - Expected      - ready
   + Received      + fair
   ❯ …:123:39   expect(readiness.readiness_level).toBe('ready')

 FAIL > CEE's top band survives the UI's front door > does NOT tell a model CEE called ready to go and improve itself
 AssertionError: expected 'Analysis available - consider improve…' to be undefined
   ❯ …:140:26   expect(gate.warning).toBeUndefined()

 Tests  2 failed | 10 passed (12)
```

The second failure is the point: it asserts the **user-facing outcome** through the real gate
(`canRunAnalysis` → `getRunButtonTooltip`), not merely the store field.

**Anti-tautology pin (trap 12b).** The fixture is CEE's actual `CEEGraphReadinessResponseV1`
shape at a **recorded CEE SHA**, cited in the spec header — not this repo's own type. A control
whose reference is the consumer's own type cannot detect this defect class; it *is* the defect.

## Positive controls

All ten pass **on pristine code too** — which is what proves this is a widening, not a swap:

- `fair`, `needs_work`, `strong` each flow through byte-identically (level and score).
- `fair` **still** produces "consider improvements…" — the branch that was misfiring is intact,
  not deleted.
- Six degrade-safely controls (`excellent`, `close_call`, `<script>`, `42`, `null`,
  `undefined`) all still land on `'fair'`. The guard was re-pointed, not removed.
- Two producer-mirror assertions pin the accepted set to CEE's three and assert `strong` is
  **not** treated as a producer value.

## Mutation verdict — RED

Full patch applied, then the allowlist correction reverted **alone** (the normaliser re-pointed
at the old `['needs_work','fair','strong']` literal; the type, the constant and every other
hunk left in place, so the RED isolates that one line):

```
 Tests  2 failed | 12 passed (14)
 FAIL > preserves readiness_level "ready" instead of coercing it to "fair"
   AssertionError: expected 'fair' to be 'ready'
 FAIL > does NOT tell a model CEE called ready to go and improve itself
   AssertionError: expected 'Analysis available - consider improve…' to be undefined
```

The 12 controls stayed green under mutation — the RED is caused by that line and nothing else.
Throwaway worktree removed **before** any gate run (trap 9c).

---

## Gates

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set for every measurement (trap 2b). No
collect-time failures in any run.

| Gate | Pristine `8b2f5945` | This branch |
|---|---|---|
| `pnpm typecheck` — phase 1 coverage | 2997 / 3015 loaded, 18 out of scope | **2998 / 3016** loaded, 18 out of scope |
| `pnpm typecheck` — phase 2 ratchet | 633 files / 2549 errors (baseline 2663) | **633 files / 2549 errors** — identical |
| `eslint` (5 touched files) | 3 warnings, 0 errors | **3 warnings, 0 errors** — the same three, line-shifted only |
| Scoped suite ¹ | 83 files / 1076 tests, all pass | **84 files / 1090 tests, all pass** |
| Wider suite ² | not measured — see note | **1073 files passed / 2 skipped; 16129 tests passed / 59 skipped; 0 failures** |

¹ `src/canvas/stores/__tests__`, `src/canvas/utils/__tests__/canRunAnalysis.spec.ts`,
`src/canvas/hooks/__tests__`, `src/canvas/components/pre-analysis-v3`. Delta is exactly the new
spec: +1 file, +14 tests.
² `src/canvas src/components/results src/lib src/v5`. **Branch-only — no pristine comparator
was run for this one**, so it evidences "all green on the branch", NOT "unchanged versus
staging". The before/after comparison is carried by the scoped suite and the typecheck ratchet.

**The typecheck baseline was NOT bumped and nothing was deleted or quarantined.** The new spec
is tracked and loaded by the gate (coverage +1 tracked / +1 loaded, out-of-scope list unchanged
at 18). The `::notice::Drift shrank (2663 → 2549)` line is **pre-existing** — it prints
identically on pristine `8b2f5945`; this PR neither caused it nor accepts it.

⚠ **One measurement was voided and re-run, recorded rather than quietly dropped.** A first
attempt at the wider suite passed 137 spec paths as vitest positional filters; vitest matched
**none** of them and exited **0 with "No test files found"** — a green run that tested nothing
(trap 13, in the measurement rather than in the code). It was re-run by directory. Flagging the
vitest behaviour because any lane passing a long file list is exposed to the same silent zero.

---

## Zero overlap with the concurrent UI walker lane

A sibling UI lane is landing the claim-ownership drift walker
(`src/test/__tests__/claim-ownership.drift.spec.ts`,
`src/components/results/utils/selectGoalProbability.ts`, goal-probability consumers).

**This PR's complete file list — five files, zero intersection with that set:**

```
src/canvas/hooks/useGraphReadiness.ts
src/canvas/stores/readinessStore.ts
src/canvas/stores/__tests__/readinessStore.ceeVocabulary.spec.ts   (new)
src/canvas/components/PreAnalysisHealth.tsx
src/canvas/utils/canRunAnalysis.ts
```

**One semantic interaction, flagged rather than left to surprise a reviewer:** this PR renames
`useGraphReadiness.ts`'s `ReadinessLevel` → `GraphReadinessLevel`, so the estate now exports
**two** `ReadinessLevel` types, not three. The walker's slice 1 is scoped to goal-probability
(11 files / 23 hits, registered on `selectGoalProbability`) and pins no readiness count, so
nothing should break — but §10.3 of `UI-ANTI-DRIFT-INSTRUMENT-DESIGN-2026-07-27.md` states the
three-type fact in prose and is now stale by one. Merges are serialised by the orchestrator
either way.

---

## Explicitly left for later slices — NOT touched here

| Left | Why |
|---|---|
| **Divergence 2 — the CEE-down fallback emitting `'strong'`** (`readinessStore.ts:112-149`, written direct to state at `:302`, `:326`, `:341`, `:431`, bypassing the normaliser). The UI still reports a *better* verdict when CEE is DOWN than when it answers. | Rowed separately. Needs the `not_assessed` state and the two-permission split (design §4 / §4.1), not an allowlist edit. |
| **Divergence 4 — two scoring regimes on one endpoint** (C1 70/40, ≥1 option vs C2 80/50, ≥2 options, forked on whether the UI sent `analysis_ready.options`) | CEE-side, slice 1b. ⚠ The design notes divergences 1 and 4 **mask each other**; landing this one first is the prescribed order, and 1b must **re-measure** rather than assume. |
| **Divergence 5 — run-chip vs run-button transport split** (`SuggestedChips.tsx:61` reads the turn payload; `canRunAnalysis.ts:211` reads the HTTP endpoint) | Separate slice. |
| `blocker_reason` still not forwarded by the normaliser; the fabricated `readiness_score: 0` on CEE's blocked path; the `mapConfidenceToReadiness` triplet; deleting the two remaining dead `ReadinessLevel` types | All later-slice items in the design. |

## Notes on the design's slice-0 framing — no refutations

Everything in §0.2 checked out at the bytes: CEE's vocabulary, the 70 threshold, both route
response types, the UI allowlist, the single live consumer, and `PreAnalysisHealth`'s deadness.
Three additions rather than corrections:

1. **The V3 route type also declares `"ready"`** (`assist.v1.graph-readiness.ts:169`), so the
   coercion bit on **both** scoring regimes, not only V1. Worth restating because it means
   divergence 4 could never have masked divergence 1 away entirely.
2. **CEE staging has not moved** since the design's pin — `b35d09de` is still the tip — so the
   mirrored vocabulary is current as of this PR, not merely as of the design.
3. **Not verified here (stated so nobody inherits it as verified):** no live staging probe was
   run (design R-7.1). This is source-derived at two pinned SHAs, which proves presence-in-repo
   and reachability-by-import, **not presence-on-the-live-wire**. jsdom also cannot prove the
   tooltip's visibility (trap 3). The walk leg — build a ≥70 graph on staging, confirm the
   "consider improvements" warning is gone from the Run button — needs a real browser and is
   **not** claimed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
