### PR TITLE
fix(plot-v2): one predicate for a valid intervention, so a non-finite value cannot reach the wire or be reported as ready

### DIFF
--- a/src/adapters/plot/v2/__tests__/interventionFiniteness.fixture.ts
+++ b/src/adapters/plot/v2/__tests__/interventionFiniteness.fixture.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared fixture for the intervention-finiteness guards.
+ *
+ * `VALID_CONTROL_*` is a FULLY VALID graph + option set: every intervention
+ * value is a finite number, in both the bare-number and the wrapper-object
+ * shape. It exists to hold the positive control honest — the guards must be
+ * provably inert on well-formed input, byte-for-byte.
+ */
+
+import type { Node, Edge } from '@xyflow/react'
+import type { UIOption } from '../../../../types/options'
+
+export const VALID_CONTROL_GOAL = 'goal_revenue'
+
+export const VALID_CONTROL_NODES: Node[] = [
+  {
+    id: 'goal_revenue',
+    position: { x: 0, y: 0 },
+    data: { kind: 'goal', label: 'Revenue', observedState: { value: 0.5, std: 0.1 } },
+  },
+  {
+    id: 'factor_price',
+    position: { x: 0, y: 100 },
+    data: { kind: 'factor', label: 'Price', observedState: { value: 0.4, std: 0.05 } },
+  },
+  {
+    id: 'factor_volume',
+    position: { x: 0, y: 200 },
+    data: { kind: 'factor', label: 'Volume', observedState: { value: 0.6, std: 0.08 } },
+  },
+  {
+    id: 'opt_hold',
+    position: { x: 200, y: 0 },
+    data: { kind: 'option', label: 'Hold price' },
+  },
+  {
+    id: 'opt_cut',
+    position: { x: 200, y: 100 },
+    data: { kind: 'option', label: 'Cut price' },
+  },
+]
+
+export const VALID_CONTROL_EDGES: Edge[] = [
+  {
+    id: 'e1',
+    source: 'factor_price',
+    target: 'goal_revenue',
+    data: { weight: 0.7, direction: 'positive', beliefExists: 0.9, strengthStd: 0.1 },
+  },
+  {
+    id: 'e2',
+    source: 'factor_volume',
+    target: 'goal_revenue',
+    data: { weight: 0.5, direction: 'positive', beliefExists: 0.8, strengthStd: 0.05 },
+  },
+]
+
+/**
+ * Both intervention shapes the wire path must carry unchanged: a bare number
+ * and a `{ value, ... }` wrapper. Includes `0`, the value most likely to be
+ * lost by a falsiness bug in a guard.
+ */
+export const VALID_CONTROL_OPTIONS: UIOption[] = [
+  {
+    id: 'opt_hold',
+    label: 'Hold price',
+    status: 'ready',
+    interventions: {
+      factor_price: {
+        value: 0.4,
+        source: 'user_specified',
+        target_match: { node_id: 'factor_price', match_type: 'exact_id', confidence: 'high' },
+      },
+      factor_volume: { value: 0, source: 'user_specified' },
+    },
+    source: 'legacy_node',
+  },
+  {
+    id: 'opt_cut',
+    label: 'Cut price',
+    status: 'ready',
+    interventions: {
+      factor_price: { value: 0.2, source: 'brief_extraction' },
+      factor_volume: { value: -1.5, source: 'brief_extraction' },
+    },
+    source: 'legacy_node',
+  },
+]

--- a/src/adapters/plot/v2/__tests__/interventionFiniteness.spec.ts
+++ b/src/adapters/plot/v2/__tests__/interventionFiniteness.spec.ts
@@ -1,0 +1,403 @@
+/**
+ * Non-finite intervention values must never reach the PLoT wire.
+ *
+ * CONTEXT
+ * -------
+ * PLoT's `POST /v2/run` now hard-rejects non-finite intervention values at the
+ * request boundary (HTTP 422, critique `INVALID_INTERVENTION_VALUE`). Before
+ * that, a bare `null` was silently dropped server-side and surfaced as an
+ * HTTP 200 carrying `analysis_status: "failed"` + `PLOT_INTERNAL_ERROR` — a
+ * failure that read like a compute problem rather than a bad request.
+ *
+ * Two hops in this adapter could emit such a value:
+ *
+ *   HOP 1 — `extractOptionsFromNodes`: accepted any `{ value: … }` object
+ *           without checking `.value`, and any bare number including `NaN` /
+ *           `±Infinity`. Worse, it flipped the option to `status: 'ready'`, so
+ *           a malformed intervention was reported to the user as configured.
+ *
+ *   HOP 2 — `uiOptionToV2Option`: `typeof iv === 'number' ? iv : iv.value`,
+ *           with no finiteness check — the value went on the wire verbatim.
+ *
+ * DISPOSAL DOCTRINE (house ruling, matching PLoT's ingress ruling)
+ * ---------------------------------------------------------------
+ * A malformed intervention is NEVER silently dropped. Silently dropping it
+ * changes what gets analysed while still showing the user an answer, which is
+ * strictly worse than either failing or refusing. So:
+ *
+ *   - HOP 1 surfaces it: the entry is excluded from the map, the option is NOT
+ *     `status: 'ready'`, and `user_questions` — the canvas's existing
+ *     per-option not-ready affordance, rendered by UserMappingForm — says
+ *     which target is unusable and why.
+ *   - HOP 2 refuses: it throws `InterventionValidationError`, mirroring the
+ *     `EdgeValidationError` convention already used in this module for an
+ *     invalid canvas value at the request boundary. A request that cannot be
+ *     built is never sent, so no analysis can silently differ from the graph.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Node } from '@xyflow/react'
+import {
+  extractOptionsFromNodes,
+  uiOptionToV2Option,
+  buildV2Request,
+  flattenInterventions,
+  InterventionValidationError,
+} from '../adapter'
+import { interventionNumericValue } from '../../../../utils/interventionValue'
+import { unwrapInterventionValue } from '../../../../canvas/utils/labelUtils'
+import type { UIOption } from '../../../../types/options'
+import {
+  VALID_CONTROL_EDGES,
+  VALID_CONTROL_GOAL,
+  VALID_CONTROL_NODES,
+  VALID_CONTROL_OPTIONS,
+} from './interventionFiniteness.fixture'
+
+function makeNode(id: string, data: Record<string, unknown>): Node {
+  return { id, position: { x: 0, y: 0 }, data }
+}
+
+/** Every value shape that must be REFUSED, with the label used in failure output. */
+const NON_FINITE_CASES: Array<[label: string, value: unknown]> = [
+  ['bare NaN', NaN],
+  ['bare Infinity', Infinity],
+  ['bare -Infinity', -Infinity],
+  ['{ value: null }', { value: null }],
+  ['{ value: NaN }', { value: NaN }],
+  ['{ value: Infinity }', { value: Infinity }],
+  ['{ value: "tbd" }', { value: 'tbd' }],
+  ['{ value: undefined }', { value: undefined }],
+]
+
+// ============================================================================
+// HOP 1 — extractOptionsFromNodes
+// ============================================================================
+
+describe('HOP 1 — extractOptionsFromNodes must not emit or bless a non-finite intervention', () => {
+  it.each(NON_FINITE_CASES)(
+    'excludes %s from the intervention map',
+    (_label, badValue) => {
+      const nodes: Node[] = [
+        makeNode('opt1', {
+          kind: 'option',
+          label: 'Option A',
+          interventions: { factor1: badValue },
+        }),
+        makeNode('factor1', { kind: 'factor', label: 'Factor 1' }),
+      ]
+
+      const [option] = extractOptionsFromNodes(nodes, new Set(['opt1', 'factor1']))
+
+      expect(option.interventions).not.toHaveProperty('factor1')
+    },
+  )
+
+  it.each(NON_FINITE_CASES)(
+    'does NOT flip the option to status "ready" for %s',
+    (_label, badValue) => {
+      const nodes: Node[] = [
+        makeNode('opt1', {
+          kind: 'option',
+          label: 'Option A',
+          interventions: { factor1: badValue },
+        }),
+        makeNode('factor1', { kind: 'factor', label: 'Factor 1' }),
+      ]
+
+      const [option] = extractOptionsFromNodes(nodes, new Set(['opt1', 'factor1']))
+
+      expect(option.status).not.toBe('ready')
+      expect(option.status).toBe('needs_user_mapping')
+    },
+  )
+
+  it('says WHY it is not ready, naming the offending target by its canvas label', () => {
+    const nodes: Node[] = [
+      makeNode('opt1', {
+        kind: 'option',
+        label: 'Option A',
+        interventions: { factor1: { value: null } },
+      }),
+      makeNode('factor1', { kind: 'factor', label: 'Marketing spend' }),
+    ]
+
+    const [option] = extractOptionsFromNodes(nodes, new Set(['opt1', 'factor1']))
+
+    expect(option.user_questions).toBeDefined()
+    const joined = (option.user_questions ?? []).join(' ')
+    // The reason must name the target the user has to go and fix. Without the
+    // label the message is a generic "something is wrong", which is the
+    // affordance we already have for a genuinely empty option.
+    expect(joined).toContain('Marketing spend')
+  })
+
+  it('a PARTIALLY malformed option is still not ready — the good values do not launder the bad one', () => {
+    const nodes: Node[] = [
+      makeNode('opt1', {
+        kind: 'option',
+        label: 'Option A',
+        interventions: {
+          factor1: 0.5, // fine
+          factor2: { value: null }, // malformed
+        },
+      }),
+      makeNode('factor1', { kind: 'factor', label: 'Factor 1' }),
+      makeNode('factor2', { kind: 'factor', label: 'Factor 2' }),
+    ]
+
+    const [option] = extractOptionsFromNodes(
+      nodes,
+      new Set(['opt1', 'factor1', 'factor2']),
+    )
+
+    expect(option.interventions).toHaveProperty('factor1')
+    expect(option.interventions).not.toHaveProperty('factor2')
+    // This is the heart of the doctrine: a run built from this option would
+    // analyse a DIFFERENT graph than the one on the canvas. It must not read
+    // as ready.
+    expect(option.status).toBe('needs_user_mapping')
+    expect((option.user_questions ?? []).join(' ')).toContain('Factor 2')
+  })
+
+  it('still accepts 0 — the value most likely to be lost to a falsiness bug', () => {
+    const nodes: Node[] = [
+      makeNode('opt1', { kind: 'option', label: 'Option A', interventions: { factor1: 0 } }),
+      makeNode('factor1', { kind: 'factor', label: 'Factor 1' }),
+    ]
+
+    const [option] = extractOptionsFromNodes(nodes, new Set(['opt1', 'factor1']))
+
+    expect(option.status).toBe('ready')
+    expect(option.interventions.factor1).toMatchObject({ value: 0 })
+  })
+
+  it('an absent intervention map still reads as the plain "not configured" state, not as malformed', () => {
+    const nodes: Node[] = [makeNode('opt1', { kind: 'option', label: 'Empty Option' })]
+
+    const [option] = extractOptionsFromNodes(nodes, new Set(['opt1']))
+
+    expect(option.status).toBe('needs_user_mapping')
+    // The generic questions, not a "this value is unusable" reason.
+    expect((option.user_questions ?? []).join(' ')).not.toContain('unusable')
+  })
+})
+
+// ============================================================================
+// HOP 2 — uiOptionToV2Option
+// ============================================================================
+
+describe('HOP 2 — uiOptionToV2Option must never put a non-finite value on the wire', () => {
+  it.each(NON_FINITE_CASES)('refuses %s rather than serialising it', (_label, badValue) => {
+    const option = {
+      id: 'opt1',
+      label: 'Option A',
+      status: 'ready',
+      interventions: { factor1: badValue },
+      source: 'legacy_node',
+    } as unknown as UIOption
+
+    expect(() => uiOptionToV2Option(option)).toThrow(InterventionValidationError)
+  })
+
+  it('names the option and the target in the thrown error', () => {
+    const option = {
+      id: 'opt1',
+      label: 'Cut price',
+      status: 'ready',
+      interventions: { factor_price: { value: null } },
+      source: 'legacy_node',
+    } as unknown as UIOption
+
+    let caught: unknown
+    try {
+      uiOptionToV2Option(option)
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(InterventionValidationError)
+    const err = caught as InterventionValidationError
+    expect(err.code).toBe('INVALID_INTERVENTION_VALUE')
+    expect(err.optionId).toBe('opt1')
+    expect(err.invalidTargets).toEqual(['factor_price'])
+    expect(err.message).toContain('Cut price')
+    expect(err.message).toContain('factor_price')
+  })
+
+  it('refuses a PARTIALLY malformed option rather than quietly sending the good half', () => {
+    const option = {
+      id: 'opt1',
+      label: 'Cut price',
+      status: 'ready',
+      interventions: {
+        factor_price: { value: 0.2 },
+        factor_volume: { value: null },
+      },
+      source: 'legacy_node',
+    } as unknown as UIOption
+
+    expect(() => uiOptionToV2Option(option)).toThrow(InterventionValidationError)
+  })
+
+  it('passes finite values through untouched, including 0 and negatives', () => {
+    const option = {
+      id: 'opt1',
+      label: 'Option A',
+      status: 'ready',
+      interventions: {
+        a: 0,
+        b: -1.5,
+        c: { value: 0 },
+        d: { value: 2.25, source: 'user_specified' },
+      },
+      source: 'legacy_node',
+    } as unknown as UIOption
+
+    expect(uiOptionToV2Option(option).interventions).toEqual({
+      a: 0,
+      b: -1.5,
+      c: 0,
+      d: 2.25,
+    })
+  })
+
+  it('buildV2Request refuses too — the guard is not bypassable via the request builder', () => {
+    const badOption = {
+      id: 'opt_cut',
+      label: 'Cut price',
+      status: 'ready',
+      interventions: { factor_price: { value: null } },
+      source: 'legacy_node',
+    } as unknown as UIOption
+
+    expect(() =>
+      buildV2Request(
+        VALID_CONTROL_NODES as never,
+        VALID_CONTROL_EDGES as never,
+        [badOption],
+        VALID_CONTROL_GOAL,
+      ),
+    ).toThrow(InterventionValidationError)
+  })
+})
+
+// ============================================================================
+// SINGLE PREDICATE — anti-drift
+// ============================================================================
+
+describe('one predicate, not four — every intervention-validity check agrees', () => {
+  const FIXTURES: Array<[label: string, value: unknown, usable: boolean]> = [
+    ['finite number', 0.5, true],
+    ['zero', 0, true],
+    ['negative', -2, true],
+    ['wrapped finite', { value: 0.5 }, true],
+    ['wrapped zero', { value: 0 }, true],
+    ['NaN', NaN, false],
+    ['Infinity', Infinity, false],
+    ['-Infinity', -Infinity, false],
+    ['wrapped NaN', { value: NaN }, false],
+    ['wrapped Infinity', { value: Infinity }, false],
+    ['wrapped null', { value: null }, false],
+    ['wrapped string', { value: 'tbd' }, false],
+    ['wrapped undefined', { value: undefined }, false],
+    ['no value key', { unit: '%' }, false],
+    ['null', null, false],
+    ['undefined', undefined, false],
+    ['numeric string', '0.5', false],
+    ['boolean', true, false],
+    ['array', [], false],
+  ]
+
+  // This is the regression pin for the defect class itself. PLoT's
+  // INVALID_INTERVENTION_VALUE bug was caused by two hand-written copies of
+  // "what is a valid intervention" disagreeing — specifically, one of them
+  // omitting Number.isFinite. If anyone re-forks the rule, this table breaks.
+  it.each(FIXTURES)(
+    'interventionNumericValue, flattenInterventions and unwrapInterventionValue all agree on %s',
+    (_label, value, usable) => {
+      const viaPredicate = interventionNumericValue(value) !== null
+      const viaFlatten = Object.prototype.hasOwnProperty.call(
+        flattenInterventions({ k: value }),
+        'k',
+      )
+      const viaUnwrap = unwrapInterventionValue(value).value !== null
+
+      expect(viaPredicate).toBe(usable)
+      expect(viaFlatten).toBe(usable)
+      expect(viaUnwrap).toBe(usable)
+    },
+  )
+
+  it('and they agree on the resolved NUMBER, not just on usability', () => {
+    for (const [label, value, usable] of FIXTURES) {
+      if (!usable) continue
+      const n = interventionNumericValue(value)
+      expect(flattenInterventions({ k: value }).k, label).toBe(n)
+      expect(unwrapInterventionValue(value).value, label).toBe(n)
+    }
+  })
+})
+
+// ============================================================================
+// POSITIVE CONTROL — a valid request must be BYTE-IDENTICAL across this change
+// ============================================================================
+
+describe('positive control — the guards are inert on well-formed input', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Pinned so `seed: String(Date.now()/1000 % 1e6)` is deterministic and the
+    // comparison is over the whole payload, seed included.
+    vi.setSystemTime(new Date('2026-07-27T00:00:00.000Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /**
+   * Captured by running `buildV2Request` over the VALID_CONTROL_* fixture on
+   * PRISTINE staging 8b2f594523464dc3470196494c3fe5f84bcbd7b5, BEFORE any guard
+   * existed, with the clock pinned as above. Serialised, not eyeballed.
+   *
+   * Do not regenerate this string to make a failure go away: it is the only
+   * evidence that adding the guards did not perturb a valid payload. A diff
+   * here means the change altered a well-formed request, which is a defect.
+   */
+  const PRISTINE_GOLDEN =
+    '{"graph":{"nodes":[{"id":"goal_revenue","kind":"goal","label":"Revenue","observed_state":{"value":0.5,"std":0.1,"baseline":0.5}},{"id":"factor_price","kind":"factor","label":"Price","observed_state":{"value":0.4,"std":0.05,"baseline":0.4}},{"id":"factor_volume","kind":"factor","label":"Volume","observed_state":{"value":0.6,"std":0.08,"baseline":0.6}},{"id":"opt_hold","kind":"option","label":"Hold price"},{"id":"opt_cut","kind":"option","label":"Cut price"}],"edges":[{"from":"factor_price","to":"goal_revenue","strength":{"mean":0.7,"std":0.1},"exists_probability":0.9},{"from":"factor_volume","to":"goal_revenue","strength":{"mean":0.5,"std":0.05},"exists_probability":0.8}]},"options":[{"id":"opt_hold","label":"Hold price","interventions":{"factor_price":0.4,"factor_volume":0}},{"id":"opt_cut","label":"Cut price","interventions":{"factor_price":0.2,"factor_volume":-1.5}}],"goal_node_id":"goal_revenue","seed":"110400","detail_level":"deep"}'
+
+  it('a fully valid request serialises byte-for-byte identically to the pre-change payload', () => {
+    const { request } = buildV2Request(
+      VALID_CONTROL_NODES as never,
+      VALID_CONTROL_EDGES as never,
+      VALID_CONTROL_OPTIONS,
+      VALID_CONTROL_GOAL,
+    )
+
+    expect(JSON.stringify(request)).toBe(PRISTINE_GOLDEN)
+  })
+
+  it('the same holds on the extractOptionsFromNodes fallback path (options=[])', () => {
+    // HOP 1 runs here rather than being bypassed by caller-supplied options,
+    // so this control covers the fallback branch too. Interventions live on the
+    // option nodes for this one.
+    const nodes = VALID_CONTROL_NODES.map((n) =>
+      n.id === 'opt_hold'
+        ? { ...n, data: { ...n.data, interventions: { factor_price: 0.4, factor_volume: 0 } } }
+        : n.id === 'opt_cut'
+          ? { ...n, data: { ...n.data, interventions: { factor_price: 0.2, factor_volume: -1.5 } } }
+          : n,
+    )
+
+    const { request } = buildV2Request(
+      nodes as never,
+      VALID_CONTROL_EDGES as never,
+      [],
+      VALID_CONTROL_GOAL,
+    )
+
+    expect(JSON.stringify(request.options)).toBe(
+      '[{"id":"opt_hold","label":"Hold price","interventions":{"factor_price":0.4,"factor_volume":0}},{"id":"opt_cut","label":"Cut price","interventions":{"factor_price":0.2,"factor_volume":-1.5}}]',
+    )
+  })
+})

--- a/src/adapters/plot/v2/adapter.ts
+++ b/src/adapters/plot/v2/adapter.ts
@@ -27,6 +27,7 @@ import {
   normaliseGraphIds,
   translateResponseToUIIds,
 } from '../../../utils/nodeIdNormalisation'
+import { interventionNumericValue, looksLikeIntervention } from '../../../utils/interventionValue'
 import type { UIOption, UIInterventionValue } from '../../../types/options'
 import type { CEEAnalysisReady, CEEGoalConstraint, CEEOptionV3 } from '../../cee/types'
 import { recordRequestPayload, recordResponsePayload } from '../../../lib/payload-trace-store'
@@ -83,10 +84,49 @@ interface CanvasEdgeData {
 // ============================================================================
 
 /**
+ * Build the "why isn't this ready?" questions for an option.
+ *
+ * Uses `user_questions` — the canvas's EXISTING per-option not-ready
+ * affordance, rendered as question chips by UserMappingForm — rather than
+ * inventing a new surface. Two distinct states, deliberately worded
+ * differently so the user knows which one they are in:
+ *
+ *  - a target whose intervention exists but carries no usable number → name it,
+ *    because that is the thing the user has to go and fix;
+ *  - no usable interventions at all → the pre-existing generic pair.
+ */
+function interventionQuestions(
+  unusableTargets: string[],
+  labelByNodeId: Map<string, string>,
+  hasValidInterventions: boolean,
+): string[] {
+  const questions: string[] = []
+  for (const targetId of unusableTargets) {
+    const targetLabel = labelByNodeId.get(targetId) ?? targetId
+    questions.push(
+      `The value set for "${targetLabel}" isn't a number this analysis can use. ` +
+        `What value should "${targetLabel}" have if this option is chosen?`,
+    )
+  }
+  if (!hasValidInterventions) {
+    questions.push('Which causal variable(s) does this option affect?')
+    questions.push('What value should that variable have if this option is chosen?')
+  }
+  return questions
+}
+
+/**
  * Extract options from canvas nodes.
  * Options come from nodes with kind='option' or type='option'.
  *
  * Returns UIOption format with rich intervention metadata.
+ *
+ * Intervention values are admitted only through `interventionNumericValue`,
+ * the single repo-wide predicate (src/utils/interventionValue.ts). An entry
+ * that was authored but carries no usable number is NOT dropped silently: it is
+ * withheld from the map AND the option is denied `status: 'ready'`, with a
+ * `user_questions` entry naming the target. Silently dropping it would send a
+ * different graph than the canvas shows while still returning an answer.
  */
 export function extractOptionsFromNodes(
   nodes: Node<CanvasNodeData>[],
@@ -100,9 +140,20 @@ export function extractOptionsFromNodes(
     return []
   }
 
+  // Canvas labels for the not-ready reason — a bare node id is not something a
+  // user can act on.
+  const labelByNodeId = new Map<string, string>()
+  for (const n of nodes) {
+    const l = n.data?.label
+    if (typeof l === 'string' && l.trim().length > 0) labelByNodeId.set(n.id, l)
+  }
+
   return optionNodes.map((node): UIOption => {
     const interventions: Record<string, UIInterventionValue> = {}
     let hasValidInterventions = false
+    // Targets whose intervention EXISTS but carries no usable numeric value.
+    // Distinct from "no intervention here", which is silence, not a defect.
+    const unusableTargets: string[] = []
 
     // Extract interventions from node data
     // Only include interventions that target valid causal nodes (factors, outcomes, goals)
@@ -129,7 +180,29 @@ export function extractOptionsFromNodes(
           continue
         }
 
-        // Handle both simple number and UIInterventionValue formats
+        // Single-predicate admission. `{value: null}`, `{value: 'tbd'}`, bare
+        // NaN and bare ±Infinity all previously passed here — the first three
+        // reached the wire as a literal null, and every one of them flipped the
+        // option to 'ready'.
+        const numeric = interventionNumericValue(rawValue)
+
+        if (numeric === null) {
+          if (looksLikeIntervention(rawValue)) {
+            // Authored, but unusable. Surfaced below; never silently dropped.
+            unusableTargets.push(key)
+            if (import.meta.env.DEV) {
+              console.warn(
+                `[V2Adapter] Intervention on "${key}" in option "${node.data?.label || node.id}" has no usable numeric value — option withheld from 'ready'`
+              )
+            }
+          }
+          continue
+        }
+
+        // Handle both simple number and UIInterventionValue formats.
+        // The object branch passes the ORIGINAL reference through untouched
+        // (metadata, key order, identity) — the predicate above has already
+        // proved its `.value` is a finite number.
         if (typeof rawValue === 'number') {
           interventions[key] = {
             value: rawValue,
@@ -140,11 +213,10 @@ export function extractOptionsFromNodes(
               confidence: 'high',
             },
           }
-          hasValidInterventions = true
-        } else if (rawValue && typeof rawValue === 'object' && 'value' in rawValue) {
+        } else {
           interventions[key] = rawValue as UIInterventionValue
-          hasValidInterventions = true
         }
+        hasValidInterventions = true
       }
     }
 
@@ -152,18 +224,20 @@ export function extractOptionsFromNodes(
     // Options without valid interventions should have empty interventions
     // and status='needs_user_mapping' — validation will prompt user to configure
 
+    // Disposal doctrine: an option carrying an unusable intervention is NOT
+    // ready even when its other interventions are fine. Marking it ready would
+    // analyse a graph the user never authored and present the result as theirs.
+    const isReady = hasValidInterventions && unusableTargets.length === 0
+
     return {
       id: node.id,
       label: node.data?.label || `Option ${node.id}`,
       description: node.data?.description,
-      status: hasValidInterventions ? 'ready' : 'needs_user_mapping',
+      status: isReady ? 'ready' : 'needs_user_mapping',
       interventions,
-      user_questions: hasValidInterventions
+      user_questions: isReady
         ? undefined
-        : [
-            'Which causal variable(s) does this option affect?',
-            'What value should that variable have if this option is chosen?',
-          ],
+        : interventionQuestions(unusableTargets, labelByNodeId, hasValidInterventions),
       source: 'legacy_node',
     }
   })
@@ -203,6 +277,10 @@ export function extractOptionsFromNodes(
  *
  * This is intentionally permissive on shape and strict on numeric content —
  * an unrecognised entry is dropped, never coerced.
+ *
+ * The per-entry rule is NOT implemented here: it is `interventionNumericValue`
+ * (src/utils/interventionValue.ts), the one predicate every intervention-
+ * validity check in this repo shares. Do not re-inline it.
  */
 export function flattenInterventions(
   raw: unknown,
@@ -210,17 +288,8 @@ export function flattenInterventions(
   const out: Record<string, number> = {}
   if (!raw || typeof raw !== 'object') return out
   for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
-    if (value == null) continue
-    if (typeof value === 'number') {
-      if (Number.isFinite(value)) out[key] = value
-      continue
-    }
-    if (typeof value === 'object' && !Array.isArray(value)) {
-      const inner = (value as { value?: unknown }).value
-      if (typeof inner === 'number' && Number.isFinite(inner)) {
-        out[key] = inner
-      }
-    }
+    const numeric = interventionNumericValue(value)
+    if (numeric !== null) out[key] = numeric
   }
   return out
 }
@@ -279,16 +348,12 @@ function canvasInterventionsToCEE(
       }
       continue
     }
-    if (rawValue == null) continue
-
-    let value: number | undefined
-    if (typeof rawValue === 'number') {
-      value = rawValue
-    } else if (typeof rawValue === 'object' && 'value' in (rawValue as Record<string, unknown>)) {
-      const inner = (rawValue as { value: unknown }).value
-      if (typeof inner === 'number') value = inner
-    }
-    if (value == null) continue
+    // Was a THIRD hand-written copy of the validity rule, and the one that had
+    // drifted: it checked `typeof inner === 'number'` with no Number.isFinite,
+    // so NaN and ±Infinity passed here while the other two copies rejected
+    // them. Now delegates to the single predicate.
+    const value = interventionNumericValue(rawValue)
+    if (value === null) continue
 
     out[targetId] = {
       value,
@@ -544,19 +609,70 @@ export function validateOptionsHaveInterventions(
 }
 
 /**
+ * An option reached the PLoT request edge carrying an intervention value that
+ * is not a finite number.
+ *
+ * Mirrors `EdgeValidationError` — the convention already used in this module
+ * for an invalid canvas value at the request boundary. The code matches PLoT's
+ * own critique code for the same condition, so UI and engine name the failure
+ * identically in logs.
+ */
+export class InterventionValidationError extends Error {
+  public readonly code = 'INVALID_INTERVENTION_VALUE'
+  public readonly optionId: string
+  public readonly optionLabel: string
+  public readonly invalidTargets: string[]
+
+  constructor(optionId: string, optionLabel: string, invalidTargets: string[]) {
+    const targetList = invalidTargets.map((t) => `'${t}'`).join(', ')
+    super(
+      `Option '${optionLabel}' has intervention(s) with no usable numeric value on: ${targetList}. ` +
+        `Set a number for each before running the analysis.`,
+    )
+    this.name = 'InterventionValidationError'
+    this.optionId = optionId
+    this.optionLabel = optionLabel
+    this.invalidTargets = invalidTargets
+  }
+}
+
+/**
  * Convert UIOption to V2Option format.
  * Flattens UIInterventionValue to simple number values.
+ *
+ * THE WIRE BOUNDARY. PLoT's POST /v2/run hard-rejects a non-finite intervention
+ * value (HTTP 422, critique `INVALID_INTERVENTION_VALUE`); before that ruling it
+ * silently dropped a bare `null` and returned HTTP 200 with
+ * `analysis_status: "failed"`. This function previously read `iv.value` with no
+ * check at all, so a `{value: null}` went out as a literal JSON null.
+ *
+ * Disposal doctrine: it REFUSES rather than dropping. Dropping the entry — even
+ * when the option's other interventions are valid — would analyse a graph the
+ * user never authored and hand back the result as though it were theirs. A
+ * request that cannot be built honestly is not sent. Callers surface the throw:
+ * `useScenarioComparison` renders `error.message` in its failure state.
  */
 export function uiOptionToV2Option(option: UIOption): V2Option {
+  const interventions: Record<string, number> = {}
+  const invalidTargets: string[] = []
+
+  for (const [nodeId, iv] of Object.entries(option.interventions)) {
+    const numeric = interventionNumericValue(iv)
+    if (numeric === null) {
+      invalidTargets.push(nodeId)
+      continue
+    }
+    interventions[nodeId] = numeric
+  }
+
+  if (invalidTargets.length > 0) {
+    throw new InterventionValidationError(option.id, option.label, invalidTargets)
+  }
+
   return {
     id: option.id,
     label: option.label,
-    interventions: Object.fromEntries(
-      Object.entries(option.interventions).map(([nodeId, iv]) => [
-        nodeId,
-        typeof iv === 'number' ? iv : iv.value,
-      ])
-    ),
+    interventions,
   }
 }
 

--- a/src/adapters/plot/v2/index.ts
+++ b/src/adapters/plot/v2/index.ts
@@ -64,6 +64,7 @@ export {
   flattenInterventions,
   clearStrengthCorrections,
   EdgeValidationError,
+  InterventionValidationError,
 } from './adapter'
 
 export type { V2AdapterConfig, BuildV2RequestOptions } from './adapter'

--- a/src/canvas/utils/labelUtils.ts
+++ b/src/canvas/utils/labelUtils.ts
@@ -307,6 +307,7 @@ export {
 export type { UnitClass } from '@/utils/unitClassifier'
 
 import { GENERIC_PLACEHOLDER_UNITS, classifyUnit } from '@/utils/unitClassifier'
+import { interventionNumericValue } from '@/utils/interventionValue'
 
 function isGenericPlaceholderUnit(unit: string | null | undefined): boolean {
   if (unit == null) return false
@@ -616,32 +617,26 @@ export interface UnwrappedIntervention {
 }
 
 export function unwrapInterventionValue(raw: unknown): UnwrappedIntervention {
-  // Scalar form (legacy).
-  if (typeof raw === 'number') {
-    return { value: Number.isFinite(raw) ? raw : null, displayValue: null }
-  }
-  // Object form ({ value, display_value?, ... }) — CEE V3 shape, but also
-  // used for observed_state metadata fields (obs.value, obs.raw_value, etc.)
-  // which may arrive as scalar or wrapped.
-  if (raw != null && typeof raw === 'object') {
-    // Strict numeric check on `.value` — no Number(...) coercion, since
-    // `Number(null) === 0` and `Number('foo') === NaN` cause subtle bugs.
-    let value: number | null = null
-    if ('value' in raw) {
-      const v = (raw as { value: unknown }).value
-      if (typeof v === 'number' && Number.isFinite(v)) value = v
+  // The numeric half is NOT decided here. `interventionNumericValue`
+  // (src/utils/interventionValue.ts) is the one predicate shared with
+  // flattenInterventions and the PLoT request edge, so a display can never
+  // consider a value usable that the wire rejects, or vice versa. Its rule is
+  // the strict one this function has always applied: a finite number, bare or
+  // at `.value`, with no Number(...) coercion.
+  const value = interventionNumericValue(raw)
+
+  // display_value is a CEE-authored label and is independent of numeric
+  // usability — it may be present when `value` is null.
+  let displayValue: string | null = null
+  if (raw != null && typeof raw === 'object' && 'display_value' in raw) {
+    const dv = (raw as { display_value: unknown }).display_value
+    if (typeof dv === 'string') {
+      const trimmed = dv.trim()
+      if (trimmed.length > 0) displayValue = trimmed
     }
-    let displayValue: string | null = null
-    if ('display_value' in raw) {
-      const dv = (raw as { display_value: unknown }).display_value
-      if (typeof dv === 'string') {
-        const trimmed = dv.trim()
-        if (trimmed.length > 0) displayValue = trimmed
-      }
-    }
-    return { value, displayValue }
   }
-  return { value: null, displayValue: null }
+
+  return { value, displayValue }
 }
 
 /**

--- a/src/utils/__tests__/interventionValue.spec.ts
+++ b/src/utils/__tests__/interventionValue.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit spec for the one intervention-validity predicate.
+ *
+ * The cross-module agreement pin (that flattenInterventions and
+ * unwrapInterventionValue both defer to this) lives in
+ * src/adapters/plot/v2/__tests__/interventionFiniteness.spec.ts. This file
+ * pins the rule itself.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { interventionNumericValue, looksLikeIntervention } from '../interventionValue'
+
+describe('interventionNumericValue', () => {
+  it.each([
+    ['bare finite', 0.5, 0.5],
+    ['zero', 0, 0],
+    ['negative', -2, -2],
+    ['very small', 1e-12, 1e-12],
+    ['wrapped finite', { value: 0.5 }, 0.5],
+    ['wrapped zero', { value: 0 }, 0],
+    ['wrapped with metadata', { value: 3, unit: '%', source: 'user_specified' }, 3],
+  ])('resolves %s', (_label, input, expected) => {
+    expect(interventionNumericValue(input)).toBe(expected)
+  })
+
+  it.each([
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['-Infinity', -Infinity],
+    ['wrapped NaN', { value: NaN }],
+    ['wrapped Infinity', { value: Infinity }],
+    ['wrapped null', { value: null }],
+    ['wrapped undefined', { value: undefined }],
+    ['wrapped string', { value: 'tbd' }],
+    ['wrapped numeric string', { value: '0.5' }],
+    ['wrapped boolean', { value: true }],
+    ['object with no value key', { unit: '%' }],
+    ['empty object', {}],
+    ['null', null],
+    ['undefined', undefined],
+    ['numeric string', '0.5'],
+    ['empty string', ''],
+    ['boolean', true],
+    ['array', []],
+  ])('rejects %s', (_label, input) => {
+    expect(interventionNumericValue(input)).toBeNull()
+  })
+
+  it('does not coerce — the two coercions that caused live defects stay dead', () => {
+    // Number(null) === 0 rendered "Intervention: £0" for unset interventions.
+    expect(interventionNumericValue({ value: null })).toBeNull()
+    // Number('') === 0 is the same trap one type over.
+    expect(interventionNumericValue({ value: '' })).toBeNull()
+  })
+
+  it('distinguishes a resolved 0 from a rejection', () => {
+    // The whole reason the return type is `number | null` and not a falsy
+    // sentinel: 0 is a legitimate intervention value.
+    expect(interventionNumericValue(0)).toBe(0)
+    expect(interventionNumericValue({ value: 0 })).toBe(0)
+    expect(interventionNumericValue(null)).toBeNull()
+  })
+})
+
+describe('looksLikeIntervention', () => {
+  it.each([
+    ['bare finite', 0.5],
+    ['bare zero', 0],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['wrapped finite', { value: 1 }],
+    ['wrapped null', { value: null }],
+    ['wrapped string', { value: 'tbd' }],
+    ['wrapped undefined', { value: undefined }],
+  ])('is true for %s — authored, whether or not usable', (_label, input) => {
+    expect(looksLikeIntervention(input)).toBe(true)
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['string', 'nope'],
+    ['boolean', true],
+    ['array', []],
+    ['object with no value key', { unit: '%' }],
+  ])('is false for %s — nothing was authored here', (_label, input) => {
+    expect(looksLikeIntervention(input)).toBe(false)
+  })
+
+  it('separates "authored but unusable" from "absent", which is what the disposal doctrine turns on', () => {
+    // Both are unusable...
+    expect(interventionNumericValue({ value: null })).toBeNull()
+    expect(interventionNumericValue(undefined)).toBeNull()
+    // ...but only the first is a defect the user must be told about.
+    expect(looksLikeIntervention({ value: null })).toBe(true)
+    expect(looksLikeIntervention(undefined)).toBe(false)
+  })
+})

--- a/src/utils/interventionValue.ts
+++ b/src/utils/interventionValue.ts
@@ -1,0 +1,68 @@
+/**
+ * THE single predicate for "what is a usable intervention value?".
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * This rule was, until now, hand-written FOUR times in this repo:
+ *
+ *   1. `unwrapInterventionValue`   (canvas/utils/labelUtils.ts)   — display reads
+ *   2. `flattenInterventions`      (adapters/plot/v2/adapter.ts)  — the PLoT wire edge
+ *   3. `canvasInterventionsToCEE`  (adapters/plot/v2/adapter.ts)  — canvas → CEE V3
+ *   4. an inline copy inside `useScenarioComparison.startComparison`
+ *
+ * Copies 1 and 2 agreed. Copy 3 did NOT: it checked `typeof inner === 'number'`
+ * with no `Number.isFinite`, so it accepted `NaN` and `±Infinity` where the other
+ * two rejected them. That is precisely the defect class that produced PLoT's own
+ * `INVALID_INTERVENTION_VALUE` bug — two hand-written answers to "is this a valid
+ * intervention?" drifting apart, with the looser one sitting nearer the wire.
+ *
+ * Every site that needs to answer that question MUST call this function. Do not
+ * add a fifth copy; if a caller needs different behaviour, change it here and
+ * fix the fallout, so the divergence is visible in one diff instead of silent.
+ *
+ * THE RULE
+ * --------
+ * An intervention value is usable iff it resolves to a FINITE number, either as
+ * a bare scalar or at the `.value` property of a wrapper object. Nothing is
+ * coerced: `Number(null) === 0` and `Number('foo') === NaN` have both caused
+ * live defects here (see the `unwrapInterventionValue` docblock).
+ *
+ * Accepted:  `0.5` · `-2` · `0` · `{ value: 0.5 }` · `{ value: 0, unit: '%' }`
+ * Rejected:  `null` · `undefined` · `NaN` · `Infinity` · `'0.5'` · `true` · `[]`
+ *            `{ value: null }` · `{ value: 'tbd' }` · `{ value: NaN }` · `{}`
+ */
+
+/**
+ * Resolve an intervention entry to its finite numeric value.
+ *
+ * @returns the finite number, or `null` when the entry carries no usable one.
+ *   `null` is unambiguous here because a usable value is always a number —
+ *   including `0`, so callers must test `=== null`, never falsiness.
+ */
+export function interventionNumericValue(raw: unknown): number | null {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) ? raw : null
+  }
+  if (raw != null && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw) {
+    const inner = (raw as { value: unknown }).value
+    if (typeof inner === 'number' && Number.isFinite(inner)) return inner
+  }
+  return null
+}
+
+/**
+ * Does this entry *present itself* as an intervention, whether or not its value
+ * is usable?
+ *
+ * This is the discriminator behind the disposal doctrine: "the user authored an
+ * intervention here but its value is unusable" (→ MUST be surfaced) is a
+ * different state from "there is no intervention here" (→ nothing to say).
+ *
+ * True for any bare number (including `NaN`/`Infinity`) and any non-array object
+ * carrying a `value` key (whatever that key holds). False for `null`,
+ * `undefined`, strings, booleans, arrays, and objects with no `value` key.
+ */
+export function looksLikeIntervention(raw: unknown): boolean {
+  if (typeof raw === 'number') return true
+  return raw != null && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw
+}


### PR DESCRIPTION
PLoT's `POST /v2/run` now hard-rejects non-finite intervention values at the request
boundary (HTTP 422, critique `INVALID_INTERVENTION_VALUE`, PLoT `53dbff98`). Previously a
bare `null` was silently dropped server-side and surfaced as HTTP 200 +
`analysis_status: "failed"` + `PLOT_INTERNAL_ERROR`. This closes the UI side: two unguarded
hops that could emit such a value, and the four-way predicate fork behind them.

## 1. Hop verification at the re-derived tip

Tip re-derived before starting: **`8b2f594523464dc3470196494c3fe5f84bcbd7b5`** — unchanged
from the brief, no sibling UI PR had merged. Line numbers below are re-derived at that tip,
not inherited.

| Hop | Location at tip | Verified |
|---|---|---|
| 1 | `src/adapters/plot/v2/adapter.ts:144-147` — `extractOptionsFromNodes` | confirmed |
| 2 | `src/adapters/plot/v2/adapter.ts:554-558` — `uiOptionToV2Option` | confirmed |

Both reproduce exactly as described. **Three refutations / sharpenings of the audit follow —
each one widens the blast radius, so please read them before reviewing the diff.**

### R1 — hop 2 is on a LIVE `/v2/run` path today. The audit said it was not.

The audit recorded hop-2 reachability as "only via `buildV2Request` with
`options.length === 0`, or `executeV2Run` (no production caller)". `buildV2Request` in fact
has **two production callers**:

- `src/canvas/components/pre-analysis-v3/hooks/useSensitivityRanking.ts:103` — passes `[]`,
  so it **exercises HOP 1 on a live path**. It then posts only `request.graph` and
  `request.goal_node_id` to `/v1/pre-analysis-sensitivity` and discards `request.options`,
  so hop 1's output does not reach a wire here.
- `src/canvas/hooks/useScenarioComparison.ts:409` — passes a **non-empty** option array and
  posts the whole request, `options` included, to PLoT `/v2/run` (line 430).

So hop 2 sits on a live `/v2/run` path. It was safe only because that call site pre-filters
through *its own inline copy* of the predicate (`useScenarioComparison.ts:384-388`) — which is
the fragility this PR exists to remove. `executeV2Run` having no production caller is
**confirmed**.

### R2 — hop 1 also admitted bare `NaN` / `±Infinity`, not just `{value: null}`

The audit named the `'value' in rawValue` branch. The branch above it,
`typeof rawValue === 'number'`, had no finiteness check either, so a bare `NaN` or
`±Infinity` was admitted *and* flipped the option to `status: 'ready'`.

### R3 — there were FOUR copies of the predicate, and one had ALREADY drifted

The brief asked me to reuse the existing predicate rather than write a third. There were
four, and the third had already forked — the exact defect that caused PLoT's bug, latent in
this repo:

| # | Copy | `Number.isFinite`? |
|---|---|---|
| 1 | `unwrapInterventionValue` (`canvas/utils/labelUtils.ts:618`) | yes |
| 2 | `flattenInterventions` (`adapters/plot/v2/adapter.ts:207`) | yes |
| 3 | `canvasInterventionsToCEE` (`adapters/plot/v2/adapter.ts:284-291`) | **NO — drifted** |
| 4 | inline in `useScenarioComparison.ts:384-388` | delegates to #1 |

Copy 3 checked `typeof inner === 'number'` with **no** `Number.isFinite`, so it accepted
`NaN` and `±Infinity` where the other two rejected them — the looser copy, sitting nearer the
wire. Copies 1 and 2 did agree; had I only compared the two the brief named, I would have
reported "already aligned" and left the drifted one in place.

## 2. Single-predicate reconciliation

New module **`src/utils/interventionValue.ts`** is now the only place the rule exists:

- `interventionNumericValue(raw): number | null` — finite number, bare or at `.value`, no
  coercion.
- `looksLikeIntervention(raw): boolean` — the discriminator the disposal doctrine needs:
  *authored-but-unusable* vs *absent*.

It is a neutral `src/utils/` module (alongside `unitClassifier`, `nodeIdNormalisation`)
because the alternatives both create a bad edge: putting it in `labelUtils` would make the
PLoT adapter depend on a canvas label-formatting module for a wire-contract rule; putting it
in `adapter.ts` would make canvas UI depend on the PLoT adapter. It imports nothing, so no
cycle.

All four copies now delegate to it. The anti-drift pin is a parametrised agreement table over
19 fixtures asserting `interventionNumericValue`, `flattenInterventions` and
`unwrapInterventionValue` return the same verdict **and the same resolved number** — so a
re-fork breaks the build rather than drifting silently (mutation M4 below proves it).

## 3. Disposal doctrine and the affordance used

**House ruling, matching today's PLoT ingress ruling: a malformed intervention is NEVER
silently dropped.** Dropping it changes what gets analysed while still showing the user an
answer, which is worse than either failing or refusing.

**Hop 1 — surface it, using the existing affordance.** The canvas already has a per-option
not-ready affordance: `status: 'needs_user_mapping'` + `user_questions[]`, rendered as
question chips by `src/canvas/components/UserMappingForm.tsx:163-175`. I used that, no new UI:

- the unusable entry is withheld from the interventions map;
- the option is denied `status: 'ready'` — **including when its other interventions are
  valid**, because a partially-dropped option would analyse a graph the user never authored;
- `user_questions` names the offending target **by its canvas label**, not its node id.

Downstream, an option left with no usable interventions is blocked by the existing pre-run
gate (`useV2Run.ts:557-604`, `MISSING_INTERVENTIONS`), which renders as the amber
"Options need their effects mapped" banner with per-option focus buttons
(`OutputsDock.tsx:1946-2005`). Also reused as-is.

**Hop 2 — refuse.** `uiOptionToV2Option` now throws a typed
`InterventionValidationError` (code `INVALID_INTERVENTION_VALUE`, matching PLoT's critique
code so UI and engine name the failure identically). This mirrors `EdgeValidationError`, the
convention already in this module for an invalid canvas value at the request boundary. There
is no per-option surface at this layer, so dropping would necessarily be silent; refusing
cannot be. The live caller surfaces it — `useScenarioComparison`'s outer catch renders
`error.message` into its failure state (`useScenarioComparison.ts:623-635`).

**No gap to report:** the existing affordances covered both cases; nothing new was invented.

## 4. `applyDraftResult.ts` disposition — reported as its own slice, NOT fixed here

**Can a CEE draft deliver a non-finite value into node data today? Partly — and the answer
corrects the audit.**

- `NaN` / `±Infinity` **cannot** arrive from CEE at all: `JSON.parse` throws on them, so no
  HTTP-delivered draft can encode them (measured).
- `null`, `{value: null}`, `{value: 'tbd'}` **can**, and are written verbatim —
  `backfillInterventionsOntoOptionNodes` (`applyDraftResult.ts:484`) patches
  `optEntry.interventions` straight into `n.data.interventions`.

**R4 — the schema guard is not merely warning-only, it never executes.** The audit said
`validateNodeData` is "warning-only". On the CEE draft path it does not run at all:
`mapDraftNodeToCanvas` sets `data.kind = 'option'` and leaves `data.type` **undefined**,
while `validateNodeData` switches on `data.type` and returns at its `default:` branch.
Measured with a spy: `OptionNodeDataSchema.safeParse` called **0 times**. Forced past that
branch, the schema *would* have flagged `{value: null}` (`interventions.f1: invalid_union`) —
so the schema is right, it is simply never consulted. Separately, `z.number()` in zod 3.25.76
**rejects** `NaN` but **accepts** `±Infinity` (measured; `.finite()` would be needed).
This is guarantee theatre and deserves its own slice.

**Why the shared predicate does NOT drop in cleanly at that write** — two reasons, either
sufficient:

1. The idempotency check immediately above it compares
   `JSON.stringify(existing) === JSON.stringify(optEntry.interventions)`. Filtering on write
   makes `n.data.interventions` permanently differ from `analysisReady`, so that equality
   never holds again and `interventionBackfilledCount` increments on **every** draft —
   corrupting the exact metric the function's own docblock says is being trended to zero to
   decide when this backfill can be retired.
2. It is a normalisation boundary with no user-facing surface, so a filter there would be a
   silent drop — precisely what the doctrine forbids.

**Containment today is nonetheless complete:** every *reader* of `node.data.interventions`
now routes through the one predicate (hop 1, `flattenInterventions`,
`canvasInterventionsToCEE`, `unwrapInterventionValue`, and the pre-run gate), hop 1 surfaces
the unusable target, and the pre-run gate blocks if nothing usable remains. The value cannot
reach the wire and cannot silently alter an analysis.

## 4b. Residual gap I am NOT closing here — stated so this does not read as "done"

The two named hops are closed and no non-finite value can reach the wire from anywhere. But
the **disposal doctrine is not yet satisfied on the primary analysis path**, and that should
be an explicit follow-up rather than something a reader infers is covered.

`buildV2RequestFromAnalysisReady` (`adapter.ts:1439`) — the path a real run takes — converts
via `ceeOptionToV2Option`, which flattens through `flattenInterventions` and therefore
**silently drops** an unusable entry. The wire is safe (that is why this was never a 422),
but a *partial* drop is not surfaced:

- an option with 3 interventions where 1 is `{value: null}` runs with 2, and the user is
  shown a result for a graph they did not author;
- the pre-run gate (`useV2Run.ts:559`) only fires when **every** entry drops
  (`flattenInterventions(...).length === 0`), so the partial case sails through.

I did not change it in this slice because it is a behaviour change on the hot path for every
drafted option, it needs its own RED-first + mutation evidence, and the natural fix (carry
the dropped-target list out of `ceeOptionToV2Option` and feed the existing
`MISSING_INTERVENTIONS` / `affectedOptions` banner) touches `useV2Run.ts`, which risks
colliding with the in-flight `readinessStore.ts` / `canRunAnalysis.ts` lane. Recommend it as
the next slice, using the same affordance this PR already wires up for hop 1.

## 5. RED-first, per hop

Tests written and run **before** any implementation existed, on pristine `8b2f5945`:

```
Tests  29 failed | 25 passed (54)
```

- HOP 1 — `{value: null}` / `{value: 'tbd'}` / `{value: undefined}` admitted to the map and
  the option flipped to `status: 'ready'`; bare `NaN`/`±Infinity` likewise.
- HOP 2 — `AssertionError: expected [Function] to throw an error` on every non-finite shape;
  `The instanceof assertion needs a constructor but undefined was given` for the typed error.

After implementation: **54/54 green.**

## 6. Mutation verdicts — each guard reverted ALONE

Run in a throwaway copy at `scratchpad/mutcheck-a7f3-throwaway`, **outside the repo root**
(trap 9c) and **removed before every gate run**.

| Mutant | Reverted | Result |
|---|---|---|
| **M1** | hop-1 guard + the `isReady` conjunct | **18 failed**, every one under `HOP 1 — extractOptionsFromNodes…`; zero elsewhere |
| **M2** | hop-2 guard to pristine `typeof iv === 'number' ? iv : iv.value` | **11 failed**, every one under `HOP 2 — uiOptionToV2Option…`; zero elsewhere |
| **M3** | `Number.isFinite` removed from the shared predicate | **25 failed** — 10 HOP 1, 5 HOP 2, 5 agreement-table, 5 predicate-unit |
| **M4** | `flattenInterventions` re-forked as a looser hand-written copy | **exactly 5 failed**, all in the agreement table, on precisely the five non-finite fixtures |

M4 is the important one: it reproduces the PLoT defect (two copies, one missing
`Number.isFinite`) and the anti-drift table catches it.

## 7. Positive control — byte-identical, serialised not eyeballed

A fully valid request (both intervention shapes, including `0` and a negative) was built via
`buildV2Request` on **pristine `8b2f5945`**, with the clock pinned so the timestamp-derived
`seed` is deterministic, and `JSON.stringify`'d. That exact string is pinned in the spec and
asserted against the post-change build:

```
…"options":[{"id":"opt_hold","label":"Hold price","interventions":{"factor_price":0.4,"factor_volume":0}},…],"seed":"110400","detail_level":"deep"}
```

**Byte-identical.** A second control covers the `extractOptionsFromNodes` fallback branch
(`options: []`) so hop 1 is not bypassed by caller-supplied options. The object branch of
hop 1 deliberately passes the **original object reference** through untouched, so metadata,
key order and identity are all preserved.

## 8. Gates

| Gate | Pristine `8b2f5945` | This branch |
|---|---|---|
| `pnpm typecheck` coverage | 2997 / 3015 loaded | **3001 / 3019** (all 4 new files tracked + loaded) |
| `pnpm typecheck` ratchet | 633 files / 2549 errors (baseline 2663) | **633 files / 2549 errors — identical** |

**Baseline NOT bumped**, no `--update-baseline`. Zero new type errors. Nothing deleted,
quarantined, or added to `typecheck-uncovered.txt`. `VITE_SUPABASE_URL` /
`VITE_SUPABASE_ANON_KEY` were set for every suite run.

Note for the reviewer: the `::notice::Drift shrank (2663 → 2549)` line is **pre-existing on
pristine staging** — I captured it in the pristine baseline run before touching anything. It
is not produced by this PR and I have deliberately not "fixed" it by regenerating the
baseline.

## 9. Zero overlap with the two in-flight sibling UI lanes

My seven files:

```
src/utils/interventionValue.ts                                   (new)
src/utils/__tests__/interventionValue.spec.ts                    (new)
src/adapters/plot/v2/__tests__/interventionFiniteness.spec.ts    (new)
src/adapters/plot/v2/__tests__/interventionFiniteness.fixture.ts (new)
src/adapters/plot/v2/adapter.ts
src/adapters/plot/v2/index.ts
src/canvas/utils/labelUtils.ts
```

- **vs PR #498** (drift-walker + `selectGoalProbability.ts`): file lists compared directly —
  **zero intersection**. #498 touches `src/adapters/plot/v2/responseMapper.ts`, a different
  file in the same directory; it does not touch `adapter.ts`, `index.ts` or `labelUtils.ts`.
- **vs the `readinessStore.ts` / `canRunAnalysis.ts` lane**: neither file is in my diff, and
  neither imports anything I touched (checked their import lists at the bytes).

One coupling worth naming rather than hiding: `labelUtils.ts` is imported by some
goal-probability consumers (`OptionNode.tsx`, `FactorNode.tsx`). I changed
`unwrapInterventionValue`'s **implementation** to delegate, not its behaviour — the agreement
table pins the delegation, and the pre-existing `labelUtils` specs pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
