### PR TITLE
fix(goal-copy): one goal-attainment claim across headline, caption and row, so the hero stops contradicting itself about the same number

### DIFF
--- a/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
@@ -190,7 +190,7 @@ describe('ResultsBody — Analysis hero placement + flag regression', () => {
   it('flag ON: hero consumes the same data (headline names the recommended option)', () => {
     vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
     renderBody()
-    expect(screen.getByTestId('hero-headline')).toHaveTextContent('Option A best fits your goal.')
+    expect(screen.getByTestId('hero-headline')).toHaveTextContent('Option A is most likely to meet every target this run scored.')
   })
 
   it('flag ON + stale: hero authors NO rerun and NO stale surface — the strip owns recovery (C1)', () => {
@@ -208,7 +208,7 @@ describe('ResultsBody — Analysis hero placement + flag regression', () => {
     // its subtree for a run control of any name/testid.
     expect(collectRerunControls(screen.getByTestId('analysis-hero-panel'))).toEqual(new Set())
     // Content stays readable and interactive (no dim/lock regression).
-    expect(screen.getByTestId('hero-headline')).toHaveTextContent('Option A best fits your goal.')
+    expect(screen.getByTestId('hero-headline')).toHaveTextContent('Option A is most likely to meet every target this run scored.')
     // Wave F-B: the freshness strip mounts in OutputsDock ABOVE the dim
     // wrapper (review a) — ResultsBody itself authors NO stale surface,
     // and the hero authors no stale banner either.

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -114,7 +114,7 @@ describe('buildHeroModel — leaders and headline', () => {
     // (lane 35; live staging crowned a 4% fit over 7%/6%).
     const a = makeOption({ ...OPTION_A, goalProbability: 0.9 })
     const m = chart(buildHeroModel(makeHeroData({ options: [a, OPTION_B] })))
-    expect(m.headline).toBe('Two developers best fits your goal.')
+    expect(m.headline).toBe('Two developers is most likely to meet every target this run scored.')
     expect(m.leaders.goal).toBe('opt_a')
   })
 
@@ -132,7 +132,7 @@ describe('buildHeroModel — leaders and headline', () => {
   it('diverged leaders produce the tension subline naming the outcome leader', () => {
     const m = chart(buildHeroModel(makeHeroData()))
     expect(m.subline).toBe('Two developers has the highest expected outcome.')
-    expect(m.headline).toBe('Upskill the team best fits your goal.')
+    expect(m.headline).toBe('Upskill the team is most likely to meet every target this run scored.')
   })
 
   it('constraint presence switches the headline to goal-and-limits wording', () => {
@@ -154,12 +154,12 @@ describe('buildHeroModel — leaders and headline', () => {
     const b = makeOption({ ...OPTION_B, constraintAnalysis: CONSTRAINT })
     const m = chart(buildHeroModel(makeHeroData({ options: [OPTION_A, b] })))
     expect(m.hasConstraints).toBe(false)
-    expect(m.headline).toBe('Upskill the team best fits your goal.')
+    expect(m.headline).toBe('Upskill the team is most likely to meet every target this run scored.')
   })
 
   it('does not goal-headline a recommended option that lacks its own goal value', () => {
     // Recommended option B has no goalProbability while A has one: the hero
-    // must not claim B "best fits your goal" beside a "—" readout for B.
+    // must not claim B "is most likely to meet every target this run scored" beside a "—" readout for B.
     // The leader claim reframes to the analysis basis, and the divergence
     // subline is PERSISTENT — B is not the outcome leader, so the tension
     // is stated even without a goal basis. The reframed claim is the
@@ -245,13 +245,13 @@ describe('buildHeroModel — leaders and headline', () => {
 
   it('all goal values below the sub-1% floor produce the no-option-on-track headline', () => {
     // Staging shape: every option carried probability_of_joint_goal 0 —
-    // crowning any option "best fits your goal" would be false. The hero
+    // crowning any option "is most likely to meet every target this run scored" would be false. The hero
     // states the decision-relevant truth, drops the goal-lens leader ring,
     // and keeps the outcome fact as the subline (user-approved pairing).
     const a = makeOption({ ...OPTION_A, goalProbability: 0 })
     const b = makeOption({ ...OPTION_B, goalProbability: 0 })
     const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
-    expect(m.headline).toBe('No option is currently on track to reach your goal.')
+    expect(m.headline).toBe('No option is currently on track to meet every target this run scored.')
     expect(m.subline).toBe('Two developers has the highest expected outcome.')
     expect(m.leaders.goal).toBeNull()
     // Goal lens stays available AND default — the "< 1%" rows ARE the story.
@@ -275,7 +275,7 @@ describe('buildHeroModel — leaders and headline', () => {
     expect(m.lenses).toEqual(['goal'])
     expect(m.subline).toBeNull()
     // The goal-fit headline itself is still honest and allowed.
-    expect(m.headline).toBe('Upskill the team best fits your goal.')
+    expect(m.headline).toBe('Upskill the team is most likely to meet every target this run scored.')
   })
 
   it('equal leaders produce the aligned subline', () => {
@@ -301,7 +301,7 @@ describe('buildHeroModel — leaders and headline', () => {
       ),
     )
     expect(m.leaders.goal).toBe('opt_b')
-    expect(m.headline).toBe('Upskill the team best fits your goal.')
+    expect(m.headline).toBe('Upskill the team is most likely to meet every target this run scored.')
     expect(m.subline).toBe('Two developers has the highest expected outcome.')
   })
 
@@ -602,7 +602,7 @@ describe('buildHeroModel — producer band consumption (PLoT decision_brief.head
         headlineBanded: { band: 'very_close', leaderOptionId: 'opt_b', robustnessGated: false },
       },
     })))
-    expect(m.headline).toBe('Upskill the team best fits your goal.')
+    expect(m.headline).toBe('Upskill the team is most likely to meet every target this run scored.')
   })
 })
 
@@ -714,7 +714,7 @@ describe('buildHeroModel — readout-tie coherence (UI-SEM-070) and span floor (
         }),
       ),
     )
-    expect(m.headline).toBe('No option is currently on track to reach your goal.')
+    expect(m.headline).toBe('No option is currently on track to meet every target this run scored.')
     expect(m.subline).toBe('The top options are close on expected outcome.')
     expect(m.subline).not.toMatch(/highest|strongest/i)
   })
@@ -1091,7 +1091,7 @@ describe('buildHeroModel — detail lines and footer (sourced or omitted)', () =
 describe('buildHeroModel — goal-fit crown follows the goal argmax (UI-SEM-072)', () => {
   // Live staging evidence (acceptance-evidence/goal-fit/6b-browser, 2026-07-08):
   // the WIN-probability leader carried the LOWEST goal fit (4% vs 7%/6%) yet was
-  // crowned "best fits your goal" + "(Highest on this view)" on the Goal fit lens.
+  // crowned "is most likely to meet every target this run scored" + "(Highest on this view)" on the Goal fit lens.
   // The crown must follow the highest goalProbability (= the collapsed
   // probability_of_joint_goal when constraints exist) — never the recommendation
   // re-crowned onto a view it does not lead.
@@ -1124,7 +1124,7 @@ describe('buildHeroModel — goal-fit crown follows the goal argmax (UI-SEM-072)
   it('crowns the max goal probability, never the win-probability leader (live 4/7/6 shape)', () => {
     const m = chart(buildHeroModel(makeHeroData({ options: [relocate, statusQuo, hybrid] })))
     expect(m.leaders.goal).toBe('opt_status_quo')
-    expect(m.headline).toBe('Stay in London best fits your goal.')
+    expect(m.headline).toBe('Stay in London is most likely to meet every target this run scored.')
   })
 
   it('states the tension against the crowned row, not the recommended option', () => {
@@ -1139,7 +1139,7 @@ describe('buildHeroModel — goal-fit crown follows the goal argmax (UI-SEM-072)
     const b = makeOption({ ...OPTION_B, goalProbability: 0.34 })
     const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
     expect(m.leaders.goal).toBeNull()
-    expect(m.headline).not.toContain('best fits your goal')
+    expect(m.headline).not.toContain('is most likely to meet every target this run scored')
   })
 
   it('a tie at the max crowns nobody even when other fits differ', () => {
@@ -1155,7 +1155,7 @@ describe('buildHeroModel — goal-fit crown follows the goal argmax (UI-SEM-072)
     })
     const m = chart(buildHeroModel(makeHeroData({ options: [a, b, c] })))
     expect(m.leaders.goal).toBeNull()
-    expect(m.headline).not.toContain('best fits your goal')
+    expect(m.headline).not.toContain('is most likely to meet every target this run scored')
   })
 
   it('partial fit coverage crowns nobody (a max over unmeasured rivals is not "best")', () => {
@@ -1163,7 +1163,7 @@ describe('buildHeroModel — goal-fit crown follows the goal argmax (UI-SEM-072)
     const b = makeOption({ ...OPTION_B, goalProbability: undefined })
     const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
     expect(m.leaders.goal).toBeNull()
-    expect(m.headline).not.toContain('best fits your goal')
+    expect(m.headline).not.toContain('is most likely to meet every target this run scored')
   })
 
   it('a unique max still gets no crown below the sub-1% floor', () => {
@@ -1172,7 +1172,7 @@ describe('buildHeroModel — goal-fit crown follows the goal argmax (UI-SEM-072)
     const m = chart(buildHeroModel(makeHeroData({ options: [a, b] })))
     // All rows below the floor: the no-option-on-track honesty takes over.
     expect(m.leaders.goal).toBeNull()
-    expect(m.headline).toBe('No option is currently on track to reach your goal.')
+    expect(m.headline).toBe('No option is currently on track to meet every target this run scored.')
   })
 })
 describe('Wave 2: identity-anchored stable numbers (brief §6.4)', () => {

--- a/src/components/results/analysis-hero/__tests__/content.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/content.spec.tsx
@@ -32,7 +32,7 @@ describe('AnalysisHeroPanel — content', () => {
   it('renders the headline, tension subline, and goal readouts from response values', () => {
     renderPanel(chartModel())
     expect(screen.getByTestId('hero-headline')).toHaveTextContent(
-      'Upskill the team best fits your goal.',
+      'Upskill the team is most likely to meet every target this run scored.',
     )
     expect(screen.getByTestId('hero-subline')).toHaveTextContent(
       'Two developers has the highest expected outcome.',

--- a/src/components/results/analysis-hero/__tests__/goalAttainmentCopy.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/goalAttainmentCopy.spec.tsx
@@ -1,0 +1,325 @@
+/**
+ * Goal-attainment copy — ONE claim across THREE hero surfaces.
+ *
+ * THE DEFECT THIS PINS (family 2, slice −1). On every live V5 analysis the
+ * shared selector resolves `basis === 'joint_goal_substituted'`, because both
+ * of that branch's discriminating inputs are pinned constants on the wire:
+ *
+ *   - `probability_of_goal` never arrives (PLoT synthesises an auto goal
+ *     constraint whenever a finite threshold exists and then CLEARS the
+ *     threshold it forwards to ISL, so the scalar is unreachable); and
+ *   - `hasConstraints` is always false (`mapV5AnalysisToReport` maps no
+ *     `constraint_analysis` at all, and the V2 mapper nulls it behind
+ *     `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT`).
+ *
+ * So `goalFitIsSubstitutedJoint === true` and `hasConstraints === false` on
+ * 100% of live runs — which produced a SELF-CONTRADICTION inside one render:
+ * the row detail withheld the possessive ("meeting all targets together")
+ * while the headline and caption above it, gated on the same always-false
+ * `hasConstraints`, asserted it ("best fits your goal", "hits your goal").
+ * Same number, same render, every run.
+ *
+ * The UI cannot tell the two live cases apart — (A) one auto-derived
+ * constraint that IS the user's goal threshold, (B) user constraints present,
+ * where PLoT DISCARDS the goal threshold so the number does not involve the
+ * goal at all. PLoT's attestation (`_meta.constraint_sources`) is stripped at
+ * CEE's transport keep-list, and the only local signal is an undeclared magic
+ * string. So the copy must be true in BOTH cases and assert neither a count
+ * nor a possessive; these tests pin exactly that, on all three surfaces, in
+ * ONE render.
+ *
+ * SCOPE. "Goal-attainment surface" here means the three hero surfaces that
+ * designate FROM the goal-probability number: the headline, the goal-lens
+ * caption, and the per-row goal-fit detail line. Legitimate uses of "your
+ * goal" elsewhere in the app (pre-analysis coaching, inspector strings,
+ * guardrails, the internal fixture gallery) are OUT of scope — they are not
+ * claims about this number.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
+import { buildHeroModel } from '../buildHeroModel'
+import { HERO_COPY } from '../heroCopy'
+import type { HeroChartModel } from '../heroTypes'
+import { makeHeroData, makeOption, OPTION_A, OPTION_B } from '../__fixtures__/hero.fixtures'
+import type { OptionResult } from '../../types'
+
+/**
+ * The two things a goal-attainment surface must not assert, because neither is
+ * true in both live cases.
+ *
+ * POSSESSIVE — "your goal". False in case B, where PLoT discards the goal
+ * threshold and the number does not involve the goal at all.
+ *
+ * PLURALITY — a plural definite or universal over the target set ("all
+ * targets", "the targets"). Presupposes a count of two or more; false in case
+ * A, where there is exactly ONE target. This is the SECOND half of the defect
+ * and it needs its own predicate: the row detail's old wording ("meeting all
+ * targets together") carried no possessive at all, so a possessive-only scan
+ * cannot see it — and a change no test can see is not a fix.
+ * "Every target" is deliberately NOT matched: a distributive universal is true
+ * over a singleton and over a set, which is why all four surfaces use it.
+ */
+const POSSESSIVE = /your goal/i
+const PLURALITY = /\ball targets\b|\bthe targets\b/i
+
+/**
+ * The LIVE record shape, per the trace above: the row's number is the
+ * substituted joint figure and NO option carries per-option constraint
+ * analysis. Every live analysis produces exactly this.
+ */
+function liveJointOnly(base: OptionResult): OptionResult {
+  return makeOption({
+    ...(base as OptionResult & { id: string; label: string }),
+    goalFitIsSubstitutedJoint: true,
+    constraintAnalysis: undefined,
+  })
+}
+
+function chart(data = makeHeroData()): HeroChartModel {
+  const model = buildHeroModel(data)
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+interface Surfaces {
+  headline: string
+  caption: string
+  rowDetails: string[]
+}
+
+/**
+ * Renders the panel ONCE on its default (goal) lens and returns the three
+ * goal-attainment surfaces from that SINGLE mount — the self-contradiction is
+ * a one-render property, so the assertion has to read them together rather
+ * than three models apart.
+ *
+ * The row list is an accordion (`openRowId`, one row at a time), so each row's
+ * detail is opened in turn WITHIN the same mount; the headline and caption are
+ * read while a detail is open, which is precisely the co-render the defect
+ * lived in.
+ */
+function readSurfaces(model: HeroChartModel): Surfaces {
+  const view = render(<AnalysisHeroPanel model={model} rerunDisabled={false} />)
+  expect(model.defaultLens).toBe('goal')
+  const rowDetails = model.rows.map((row) => {
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(row.label) }))
+    const scope = within(screen.getByTestId(`hero-option-row-${row.index}`))
+    // The detail region must actually be open — otherwise every assertion
+    // below would pass over an absent node rather than over the copy.
+    expect(scope.getByTestId('hero-option-detail')).toBeInTheDocument()
+    return scope.queryByTestId('hero-detail-goal-fit')?.textContent ?? ''
+  })
+  const surfaces: Surfaces = {
+    headline: screen.getByTestId('hero-headline').textContent ?? '',
+    caption: screen.getByTestId('hero-caption').textContent ?? '',
+    rowDetails,
+  }
+  view.unmount()
+  return surfaces
+}
+
+/**
+ * The whole claim, on all three surfaces at once: neither a possessive nor a
+ * count, anywhere. Both predicates on every surface — the defect had two
+ * halves and a scan for one is blind to the other.
+ */
+function expectHonest(s: Surfaces): void {
+  expect(s.headline, 'headline possessive').not.toMatch(POSSESSIVE)
+  expect(s.headline, 'headline count').not.toMatch(PLURALITY)
+  expect(s.caption, 'caption possessive').not.toMatch(POSSESSIVE)
+  expect(s.caption, 'caption count').not.toMatch(PLURALITY)
+  s.rowDetails.forEach((detail, i) => {
+    expect(detail, `row ${i + 1} detail possessive`).not.toMatch(POSSESSIVE)
+    expect(detail, `row ${i + 1} detail count`).not.toMatch(PLURALITY)
+  })
+}
+
+/** Live two-option run: a goal leader exists, so the headline crowns one. */
+function liveLeaderModel(): HeroChartModel {
+  return chart(
+    makeHeroData({ options: [liveJointOnly(OPTION_A), liveJointOnly(OPTION_B)] }),
+  )
+}
+
+/** Live run where every option is below the sub-1% floor (UI-SEM-057). */
+function liveNoneOnTrackModel(): HeroChartModel {
+  return chart(
+    makeHeroData({
+      options: [
+        liveJointOnly(makeOption({ ...OPTION_A, goalProbability: 0.004 })),
+        liveJointOnly(makeOption({ ...OPTION_B, goalProbability: 0.002 })),
+      ],
+    }),
+  )
+}
+
+/** Live run with three options — plural rows, one shared caption. */
+function liveMultiOptionModel(): HeroChartModel {
+  const c = makeOption({
+    id: 'opt_c',
+    label: 'Hire a contractor',
+    expected: 55,
+    outcome: { mean: 55, p10: 40, p50: 54, p90: 70 },
+    winProbability: 0.41,
+    goalProbability: 0.27,
+  })
+  return chart(
+    makeHeroData({
+      options: [liveJointOnly(OPTION_A), liveJointOnly(OPTION_B), liveJointOnly(c)],
+    }),
+  )
+}
+
+describe('hero goal-attainment copy — POSITIVE CONTROLS (the absence assertion can see a presence)', () => {
+  it('reads three genuinely populated surfaces from one render', () => {
+    // Trap 13: an absence assertion over empty strings passes by testing
+    // nothing. Prove every surface the next describe scans is non-empty and
+    // that the row-detail lookup actually resolves a node per row.
+    const s = readSurfaces(liveLeaderModel())
+    expect(s.headline.length).toBeGreaterThan(0)
+    expect(s.caption.length).toBeGreaterThan(0)
+    expect(s.rowDetails).toHaveLength(2)
+    for (const detail of s.rowDetails) expect(detail.length).toBeGreaterThan(0)
+  })
+
+  it('the possessive predicate fires on every string it is asked to exclude', () => {
+    expect(POSSESSIVE.test('No option is currently on track to reach your goal.')).toBe(true)
+    expect(POSSESSIVE.test('Upskill the team best fits your goal.')).toBe(true)
+    expect(POSSESSIVE.test('Each value is the chance that option hits your goal.')).toBe(true)
+  })
+
+  it('the plurality predicate fires on the shipped wordings it is asked to exclude', () => {
+    // The row detail's own former string — no possessive, so the scan above
+    // is blind to it. Without this predicate, reverting the row detail alone
+    // leaves the whole spec green (verified by mutation).
+    expect(PLURALITY.test('34% chance of meeting all targets together.')).toBe(true)
+    // And the headline wording this PR refuted: "the targets" is a plural
+    // definite, so it presupposes the count case A does not have.
+    expect(PLURALITY.test('Upskill the team comes closest to the targets this run scored.')).toBe(
+      true,
+    )
+  })
+
+  it('the plurality predicate does NOT fire on a distributive universal', () => {
+    // Negative control: "every target" is the anchor all four surfaces share,
+    // and it must stay assertable. A predicate that banned it would force the
+    // copy back into either a count or a possessive.
+    expect(PLURALITY.test('34% chance of meeting every target this run scored.')).toBe(false)
+    expect(
+      PLURALITY.test('No option is currently on track to meet every target this run scored.'),
+    ).toBe(false)
+  })
+
+  it('the row-detail surface CAN carry a possessive, so its absence below is a real result', () => {
+    // The non-substituted row still takes HERO_COPY.detail.goalFit, which is
+    // possessive by design (it is the scalar-goal sentence, dead on the V5
+    // path but deliberately not deleted — trap 5). Seeing it here proves the
+    // extraction reaches the actual copy, not a missing node.
+    const m = chart(
+      makeHeroData({
+        options: [
+          makeOption({ ...OPTION_A, goalFitIsSubstitutedJoint: false }),
+          makeOption({ ...OPTION_B, goalFitIsSubstitutedJoint: false }),
+        ],
+      }),
+    )
+    const s = readSurfaces(m)
+    expect(s.rowDetails[0]).toMatch(POSSESSIVE)
+  })
+})
+
+describe('hero goal-attainment copy — no surface asserts the possessive on the live record', () => {
+  it('leader case: headline, caption and every row detail are possessive-free', () => {
+    const s = readSurfaces(liveLeaderModel())
+    expectHonest(s)
+  })
+
+  it('none-on-track case: headline, caption and every row detail are possessive-free', () => {
+    const s = readSurfaces(liveNoneOnTrackModel())
+    expectHonest(s)
+  })
+
+  it('multi-option case: headline, caption and every row detail are possessive-free', () => {
+    const s = readSurfaces(liveMultiOptionModel())
+    expect(s.rowDetails).toHaveLength(3)
+    expectHonest(s)
+  })
+
+  it('the three surfaces agree — no surface claims what another withholds', () => {
+    // The harm was a contradiction, not a single wrong string: the row said
+    // "all targets", the headline and caption said "your goal", about one
+    // number in one render. Pin agreement directly.
+    const s = readSurfaces(liveLeaderModel())
+    const all = [s.headline, s.caption, ...s.rowDetails]
+    expect(all.filter((t) => POSSESSIVE.test(t)), 'surfaces asserting the possessive').toEqual([])
+    expect(all.filter((t) => PLURALITY.test(t)), 'surfaces asserting a count').toEqual([])
+  })
+})
+
+describe('hero goal-attainment copy — no over-suppression, no value change', () => {
+  it('the goal line still APPEARS on every row (a rewording, never a removal)', () => {
+    const m = liveLeaderModel()
+    const s = readSurfaces(m)
+    expect(s.rowDetails).toHaveLength(2)
+    for (const detail of s.rowDetails) {
+      expect(detail.length).toBeGreaterThan(0)
+      expect(detail).toMatch(/chance/i)
+    }
+  })
+
+  it('every row detail still carries its OWN readout verbatim', () => {
+    const m = liveLeaderModel()
+    const s = readSurfaces(m)
+    m.rows.forEach((row, i) => {
+      expect(s.rowDetails[i]).toContain(row.goal.readout)
+    })
+  })
+
+  it('the numbers are byte-identical to the non-substituted control', () => {
+    // Copy switch, never a value transform: values and rendered readouts must
+    // not move when the identity flag flips.
+    const live = liveLeaderModel()
+    const control = chart(makeHeroData())
+    expect(live.rows.map((r) => r.goal.value)).toEqual(
+      control.rows.map((r) => r.goal.value),
+    )
+    expect(live.rows.map((r) => r.goal.readout)).toEqual(
+      control.rows.map((r) => r.goal.readout),
+    )
+    expect(live.rows.map((r) => r.outcome.readout)).toEqual(
+      control.rows.map((r) => r.outcome.readout),
+    )
+  })
+
+  it('renders the same percentages the response carried (0.34 -> 34%, 0.49 -> 49%)', () => {
+    render(<AnalysisHeroPanel model={liveLeaderModel()} rerunDisabled={false} />)
+    expect(within(screen.getByTestId('hero-option-row-1')).getByText('34%')).toBeInTheDocument()
+    expect(within(screen.getByTestId('hero-option-row-2')).getByText('49%')).toBeInTheDocument()
+  })
+
+  it('the goal lens is still available and still the default lens', () => {
+    const m = liveLeaderModel()
+    expect(m.lenses).toContain('goal')
+    expect(m.defaultLens).toBe('goal')
+  })
+})
+
+describe('hero goal-attainment copy — the copy lives in the central module', () => {
+  it('each surface renders its HERO_COPY primitive, not a local literal', () => {
+    const m = liveLeaderModel()
+    const s = readSurfaces(m)
+    const leader = m.rows.find((r) => r.id === m.leaders.goal)
+    expect(leader, 'a goal leader is crowned in this fixture').toBeTruthy()
+    expect(s.headline).toBe(HERO_COPY.headline.goalOnly(leader!.label))
+    expect(s.caption).toBe(HERO_COPY.caption.goalOnly)
+    m.rows.forEach((row, i) => {
+      expect(s.rowDetails[i]).toBe(HERO_COPY.detail.goalFitJointBasis(row.goal.readout))
+    })
+  })
+
+  it('none-on-track renders the central noneOnTrack primitive', () => {
+    const s = readSurfaces(liveNoneOnTrackModel())
+    expect(s.headline).toBe(HERO_COPY.headline.noneOnTrack)
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/nullTargetSuppression.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/nullTargetSuppression.spec.tsx
@@ -78,7 +78,8 @@ describe('buildHeroModel — null-target suppression (model truth)', () => {
 
   it('below-floor synthesized values do NOT produce the no-option-on-track goal claim without a target', () => {
     // Staging joint-goal shape (goalProbability 0) but with NO user target:
-    // "No option is currently on track to reach your goal" would reference a
+    // "No option is currently on track to meet every target this run scored"
+    // would reference a
     // goal the user never set — it must not render.
     const m = chart(
       buildHeroModel(
@@ -116,7 +117,7 @@ describe('buildHeroModel — null-target suppression (model truth)', () => {
     const m = chart(buildHeroModel(makeHeroData()))
     expect(m.lenses).toEqual(['goal', 'outcome'])
     expect(m.defaultLens).toBe('goal')
-    expect(m.headline).toBe('Upskill the team best fits your goal.')
+    expect(m.headline).toBe('Upskill the team is most likely to meet every target this run scored.')
     expect(m.leaders.goal).toBe('opt_b')
     expect(m.rows[0].goal.value).toBe(OPTION_A.goalProbability)
     expect(m.rows[0].goal.readout).toBe('34%')
@@ -135,7 +136,7 @@ describe('buildHeroModel — null-target suppression (model truth)', () => {
         }),
       ),
     )
-    expect(m.headline).toBe('No option is currently on track to reach your goal.')
+    expect(m.headline).toBe('No option is currently on track to meet every target this run scored.')
     expect(m.defaultLens).toBe('goal')
   })
 })
@@ -176,11 +177,11 @@ describe('AnalysisHeroPanel — null-target suppression (rendered)', () => {
     // the value-based caption.
     renderPanel(chart(buildHeroModel(makeHeroData())))
     expect(screen.getByTestId('hero-headline')).toHaveTextContent(
-      'Upskill the team best fits your goal.',
+      'Upskill the team is most likely to meet every target this run scored.',
     )
     expect(within(screen.getByTestId('hero-option-row-1')).getByText('34%')).toBeInTheDocument()
     expect(screen.getByTestId('hero-caption')).toHaveTextContent(
-      'Each value is the chance that option hits your goal.',
+      'Each value is the chance that option meets every target this run scored.',
     )
     // No goal tracks and no goal axis exist any more (v6 readout-only table).
     expect(screen.queryAllByTestId('hero-range-bar')).toHaveLength(0)

--- a/src/components/results/analysis-hero/__tests__/stagingScenario.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/stagingScenario.spec.tsx
@@ -127,7 +127,7 @@ describe('staging scenario — model truth', () => {
 
   it('states the goal truth: no option on track, outcome leader named in the subline', () => {
     const m = stagingModel()
-    expect(m.headline).toBe('No option is currently on track to reach your goal.')
+    expect(m.headline).toBe('No option is currently on track to meet every target this run scored.')
     expect(m.subline).toBe('Use Virtual Assistant Service has the highest expected outcome.')
     // No goal-fit leader ring; the outcome highlight stays factual.
     expect(m.leaders.goal).toBeNull()
@@ -189,7 +189,7 @@ describe('staging scenario — rendered surfaces (numeric parity, check A)', () 
   it('Goal fit still communicates the target shortfall (every option "< 1%", no-on-track headline)', () => {
     renderHero() // Goal fit is the default lens for this run.
     expect(screen.getByTestId('hero-headline')).toHaveTextContent(
-      'No option is currently on track to reach your goal.',
+      'No option is currently on track to meet every target this run scored.',
     )
     expect(screen.getAllByText('< 1%').length).toBe(4)
   })

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -14,7 +14,7 @@
  *     back into selection logic.
  *
  * Leader rules (review-locked; goal-fit crown revised by lane 35):
- *   - Goal-fit crown (the "best fits your goal" headline + goal-lens
+ *   - Goal-fit crown (the goal-attainment headline + goal-lens
  *     highlight) = the goalProbability ARGMAX (UI-SEM-072) — the claim
  *     describes the GOAL view, so it must follow the view's own maximum,
  *     never the recommendation re-crowned onto a view it does not lead
@@ -246,9 +246,9 @@ export function buildHeroModel(
   // synthesize auto_goal_threshold and the selector fallback still adopts
   // probability_of_joint_goal as goalProbability — values that describe a
   // target the user never set. Without a user target the hero must not
-  // render fit percentages, the goal axis, or any "best fits your goal" /
-  // "on track to reach your goal" claim, so every row's goal slot is
-  // suppressed at source (below) and the goal lens becomes the honest
+  // render fit percentages, the goal axis, or any goal-attainment claim
+  // (the crown headline, the no-option-on-track headline), so every row's
+  // goal slot is suppressed at source (below) and the goal lens becomes the honest
   // needs-target state. Suppression only — no value is transformed.
   const hasUserTarget = goalThreshold != null
 
@@ -313,6 +313,12 @@ export function buildHeroModel(
     // "your goal" wording names a question the number does not answer, so the
     // line states the quantity it actually is. The number itself is unchanged
     // and still shown: this is a copy switch, never a value transform.
+    // ⚠ On the live V5 wire this is the ONLY branch that runs: the selector's
+    // basis is `joint_goal_substituted` on every run (both discriminating
+    // inputs are pinned constants — see heroCopy's `noneOnTrack` block), and
+    // `optionHasConstraints` is always false. So this line, the headline and
+    // the caption must state ONE claim in one voice — they are read together,
+    // in a single render, about a single number.
     const goalFit =
       goalValue != null
         ? optionHasConstraints(o)
@@ -544,7 +550,7 @@ export function buildHeroModel(
   )
 
   // UI-SEM-072: goal-fit crown = the goalProbability ARGMAX, honestly gated.
-  // The "best fits your goal" headline and the goal-lens "(Leads on this
+  // The goal-attainment headline and the goal-lens "(Leads on this
   // view)" ring describe the GOAL view, so they must crown the row with the
   // HIGHEST goal probability — never the recommendation/win-probability
   // leader re-crowned onto a view it does not lead (live staging evidence:

--- a/src/components/results/analysis-hero/fixtures/galleryModels.ts
+++ b/src/components/results/analysis-hero/fixtures/galleryModels.ts
@@ -215,7 +215,7 @@ export const GALLERY_ENTRIES: GalleryEntry[] = [
     description:
       'What staging renders now for a goal-bearing run: Goal fit + Likely outcome carry data; Stability and What changed show their honest unavailable states; no trust/status/named-action producer fields exist, so those slots are empty.',
     model: fixtureChart({
-      headline: 'Hire One Tech Lead best fits your goal.',
+      headline: 'Hire One Tech Lead is most likely to meet every target this run scored.',
       subline: 'Hire One Tech Lead also has the strongest expected outcome.',
       lenses: ['goal', 'outcome'],
       defaultLens: 'goal',
@@ -329,7 +329,7 @@ export const GALLERY_ENTRIES: GalleryEntry[] = [
     description:
       'Every goal probability floors below 1%: the headline states the shortfall truth; the goal lens stays default because the "< 1%" rows ARE the story.',
     model: fixtureChart({
-      headline: 'No option is currently on track to reach your goal.',
+      headline: 'No option is currently on track to meet every target this run scored.',
       subline: 'Hire One Tech Lead has the highest expected outcome.',
       lenses: ['goal', 'outcome'],
       defaultLens: 'goal',
@@ -352,7 +352,7 @@ export const GALLERY_ENTRIES: GalleryEntry[] = [
     description:
       'Model edited since the last run: per the ratified v6 guide the hero content stays readable and interactive and the hero authors NO stale surface or rerun of its own — the adjacent freshness strip (not part of this panel) owns the warning and the one Rerun.',
     model: fixtureChart({
-      headline: 'Hire One Tech Lead best fits your goal.',
+      headline: 'Hire One Tech Lead is most likely to meet every target this run scored.',
       subline: 'Hire One Tech Lead also has the strongest expected outcome.',
       lenses: ['goal', 'outcome'],
       defaultLens: 'goal',
@@ -381,7 +381,7 @@ export const GALLERY_ENTRIES: GalleryEntry[] = [
       'What the user sees after committing a change that reruns (e.g. applying a success target): the content stays readable, and the analysis-affecting target-apply controls are disabled while the run is in flight (the freshness strip — not part of this panel — carries the running state and the one Rerun).',
     rerunDisabled: true,
     model: fixtureChart({
-      headline: 'Hire One Tech Lead best fits your goal.',
+      headline: 'Hire One Tech Lead is most likely to meet every target this run scored.',
       subline: 'Hire One Tech Lead also has the strongest expected outcome.',
       lenses: ['goal', 'outcome'],
       defaultLens: 'goal',

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -65,7 +65,20 @@ export const HERO_COPY = {
 
   headline: {
     goalWithLimits: (label: string) => `${label} best meets the goal and your limits.`,
-    goalOnly: (label: string) => `${label} best fits your goal.`,
+    /**
+     * GOAL-ATTAINMENT IDENTITY, interim wording (family 2, slice −1) — the
+     * same claim, in the same words, as `caption.goalOnly` and
+     * `detail.goalFitJointBasis`. See the block above `noneOnTrack` for the
+     * full producer trace and why all three had to move together.
+     *
+     * The crown is the UNIQUE argmax of the goal probability among rows that
+     * all carry one (UI-SEM-072), clearing the sub-1% floor — so "most likely
+     * to meet" names exactly the quantity the caption below and the row detail
+     * beneath it show. It was `"{label} best fits your goal."`, which asserted
+     * a possessive over a number that, when the user has set constraints, does
+     * not involve the goal at all.
+     */
+    goalOnly: (label: string) => `${label} is most likely to meet every target this run scored.`,
     // DELETED 2026-07-26 (ROADMAP 1.223): `analysisLeads` — "{label} currently
     // leads the overall analysis." It was the UNBANDED leader claim, reached
     // only when no band could be resolved. Once the UI stopped banding win
@@ -95,13 +108,42 @@ export const HERO_COPY = {
     outcomeLeader: (label: string) => `${label} has the highest expected outcome.`,
     /**
      * Goal honesty: every option's goal probability sits below the sub-1%
-     * floor (UI-SEM-057) — crowning any option "best fits your goal" would
-     * be false, so the headline states the decision-relevant truth instead.
+     * floor (UI-SEM-057) — crowning any option would be false, so the headline
+     * states the decision-relevant truth instead.
      * Constraint-aware like every other goal claim: under constraints the
      * floored figure is the JOINT (goal AND limits) probability, and the
      * axis/caption already say "goal and limits" — the headline must match.
+     *
+     * ⭐ GOAL-ATTAINMENT IDENTITY, interim wording (family 2, slice −1).
+     * This string, `headline.goalOnly`, `caption.goalOnly` and
+     * `detail.goalFitJointBasis` are ONE claim on four surfaces and must stay
+     * in the same voice. They were changed together because they had drifted
+     * apart in a way the user could see in a single render: the row detail
+     * withheld the possessive while the headline and caption above it asserted
+     * it, about the same number, on every live run.
+     *
+     * WHY. The number every live V5 run renders here is
+     * `probability_of_joint_goal`. Two live cases produce it and the UI cannot
+     * tell them apart:
+     *   A. no user constraints — PLoT synthesises ONE constraint from the goal
+     *      threshold, on the goal node, `>=`, and ISL evaluates it against the
+     *      EXACT goal samples. The figure IS goal attainment, over exactly one
+     *      target, and that target is the user's own. "All targets together"
+     *      over-stated plurality on 100% of live runs.
+     *   B. user constraints present — PLoT SKIPS the synthesis and DISCARDS the
+     *      goal threshold, so the number does not involve the goal at all and
+     *      "your goal" would be false.
+     * The discriminator does not exist in contract: PLoT's attestation
+     * (`_meta.constraint_sources`) is stripped at CEE's transport keep-list,
+     * and the only local signal is an undeclared magic string on another
+     * service's internal constant. Sniffing it would be the hand-maintained
+     * mirror this family exists to remove, so the copy asserts neither a count
+     * nor a possessive and is true in BOTH cases.
+     *
+     * INTERIM: retires when CEE ships the goal verdict with an explicit
+     * measure scope and the copy can be exact.
      */
-    noneOnTrack: 'No option is currently on track to reach your goal.',
+    noneOnTrack: 'No option is currently on track to meet every target this run scored.',
     noneOnTrackWithLimits: 'No option is currently on track to meet your goal and limits.',
     singleOption: (label: string) => `${label} is your only option.`,
     noLeader: 'Here is how your options compare.',
@@ -154,7 +196,15 @@ export const HERO_COPY = {
     // Value-based wording (not "each bar"): the goal lens draws no tracks
     // (prototype v6), so the caption describes the readouts it shows.
     goalWithLimits: 'Each value is the chance that option meets your goal and limits together.',
-    goalOnly: 'Each value is the chance that option hits your goal.',
+    /**
+     * GOAL-ATTAINMENT IDENTITY, interim wording (family 2, slice −1) — the
+     * same claim, in the same words, as `headline.goalOnly` /
+     * `headline.noneOnTrack` and `detail.goalFitJointBasis`. See the block
+     * above `noneOnTrack` for the producer trace. It was `"Each value is the
+     * chance that option hits your goal."`, which asserted the possessive the
+     * row detail directly beneath it was written to withhold.
+     */
+    goalOnly: 'Each value is the chance that option meets every target this run scored.',
     /** Base outcome caption — shown when TWO OR MORE rows draw p10-p90 lines. */
     outcome: 'Dots show expected outcome. Lines show the realistic range.',
     /**
@@ -211,15 +261,22 @@ export const HERO_COPY = {
     /**
      * Goal-probability IDENTITY: used when the row's number is
      * `probability_of_joint_goal` STANDING IN for an absent
-     * `goal_probability` (the ISL-auto-derived-goal-threshold run, flagged
-     * by the shared selector as `basis: 'joint_goal_substituted'`). The
-     * number is shown — it is real and decision-relevant — but it answers
-     * "P(all targets jointly satisfied)", not "P(this option clears YOUR
-     * goal)", so the possessive framing the two lines above use would name
-     * a question this figure does not answer. Same sentence shape, no
-     * possessive, no invented claim.
+     * `goal_probability` (flagged by the shared selector as
+     * `basis: 'joint_goal_substituted'` — which, on the live V5 wire, is
+     * EVERY run). The number is shown, unchanged: this is a copy switch,
+     * never a value transform.
+     *
+     * GOAL-ATTAINMENT IDENTITY, interim wording (family 2, slice −1) — the
+     * same claim, in the same words, as `headline.goalOnly` /
+     * `headline.noneOnTrack` and `caption.goalOnly`. See the block above
+     * `noneOnTrack` for the producer trace. It was `"...chance of meeting all
+     * targets together."`, which over-stated plurality: on the ordinary run
+     * there is exactly ONE target and it is the user's own goal threshold.
+     * "Every target" is true over a singleton and over a set, so it asserts
+     * no count — and no possessive, which would be false when the user HAS
+     * set constraints and PLoT discards the goal threshold.
      */
-    goalFitJointBasis: (readout: string) => `${readout} chance of meeting all targets together.`,
+    goalFitJointBasis: (readout: string) => `${readout} chance of meeting every target this run scored.`,
   },
 
   /**


### PR DESCRIPTION
Family 2 (GOAL) **Slice −1** — the interim copy fix, per `docs-designs/MEANING-LAYER-FAMILY2-AMENDMENT-2026-07-27.md` §2.4/§8. UI only. No wire, no schema, no selector logic, no permission plumbing, no deploy coupling.

Derived at UI `staging` = `fff04eb5` (re-derived at clone time; identical to the amendment's pin). Schemas pin re-read at the tip: **`file:./vendor/talchain-schemas-0.22.0.tgz`** — unchanged, and untouched by this PR.

---

## 1. The defect — universal, and a self-contradiction in one render

**Every discriminating input is a constant on the live wire, so this is 100% of runs, not an edge case.**

`selectGoalProbability.ts:230-237` resolves `basis` from two inputs:

| Input | Value on the live V5 path | Verified at `fff04eb5` |
|---|---|---|
| `unconstrained` (`probability_of_goal` / `goal_probability`) | **always `null`** | unreachable at the producer: PLoT synthesises an auto goal constraint whenever a finite threshold exists (`run.ts:4810`) and then **clears** the threshold it forwards to ISL (`:5023`, `:5758`), so ISL computes no scalar (`robustness_analyzer_v2.py:2997-3000`) and omits it (`exclude_none=True`) |
| `hasConstraints` | **always `false`** | `grep -c constraint_analysis src/v5/mapV5AnalysisToReport.ts` → **`0`**; the V2 mapper nulls it at `responseMapper.ts:691` behind `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT = true` (`constraintTrust.ts:57`) |

⇒ `basis === 'joint_goal_substituted'` on every live analysis ⇒ `goalFitIsSubstitutedJoint === true` on every row.

And `buildHeroModel.ts:266-267` computes its own `hasConstraints` from the same never-populated `constraintAnalysis`, so it is **also always false**. That is what produced the contradiction — #496 gated the row and left the two surfaces above it ungated:

| Surface | Gate | What shipped, every run |
|---|---|---|
| Hero **headline** | `buildHeroModel.ts:599`, `hasConstraints === false` | *"{label} best fits **your goal**."* |
| Hero **headline** (all below the sub-1% floor) | `:595` | *"No option is currently on track to reach **your goal**."* |
| Hero **caption** | `AnalysisHeroPanel.tsx:237`, same constant | *"Each value is the chance that option hits **your goal**."* |
| Hero **row detail** | `buildHeroModel.ts:320-321`, `goalFitIsSubstitutedJoint === true` | *"…chance of meeting **all targets** together."* |

**One number. One render. The headline and caption assert the possessive the row detail was written to withhold.** That is family 1's G-CEE-1 shape reproduced in family 2, and it was live.

## 2. Why all three surfaces had to move, and why the copy cannot distinguish the two cases

Two live cases produce the number, and they need contradictory wording:

- **A — no user constraints.** PLoT synthesises **one** constraint from the goal threshold, on the goal node, `>=`; ISL replaces the goal node's constraint samples with the **exact goal samples** (`robustness_analyzer_v2.py:2952-2960`). The figure **is** goal attainment, over **exactly one** target, and that target **is** the user's own. *"All targets together"* over-stated plurality here.
- **B — user constraints present.** PLoT **skips** the synthesis (`run.ts:4861-4868`) and **discards** the goal threshold (`:5013-5019`). The number does not involve the goal at all, so *"your goal"* is false here.

The UI **cannot** tell them apart through any contracted channel: PLoT's own designated signal, `_meta.constraint_sources`, is stripped at CEE's transport keep-list (absent from `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP`, present in `INTERNAL_ENRICHMENT_KEYS`), and the only local discriminator is the literal `'auto_goal_threshold'` — declared by **no schema and no type in either repo**. Sniffing it would be the hand-maintained mirror (trap 12) this family exists to remove.

**This PR does not try.** Per the amendment's hard condition 1, the copy is true in **both** cases and asserts **neither a count nor a possessive**.

## 3. Copy table — old → new

All four strings live in the central copy module `heroCopy.ts`; no literal was introduced at a render site.

| Surface | Key | Old | New |
|---|---|---|---|
| Row detail | `detail.goalFitJointBasis` | `${readout} chance of meeting all targets together.` | `${readout} chance of meeting every target this run scored.` |
| Headline (crown) | `headline.goalOnly` | `${label} best fits your goal.` | `${label} is most likely to meet every target this run scored.` |
| Headline (none on track) | `headline.noneOnTrack` | `No option is currently on track to reach your goal.` | `No option is currently on track to meet every target this run scored.` |
| Goal-lens caption | `caption.goalOnly` | `Each value is the chance that option hits your goal.` | `Each value is the chance that option meets every target this run scored.` |

One shared anchor phrase — *"every target this run scored"* — on all four. `every` is a **distributive universal**: true over a singleton (case A) and over a set (case B), so it asserts no count.

### ⚠ Refutation — one of the amendment's four proposed strings

The amendment proposed the headline `${label} comes closest to the targets this run scored.` **Refuted, with two truth problems:**

1. **`the targets` is a plural definite — it presupposes a count of two or more.** On the ordinary live run (case A) there is exactly **one** target. That is the *same* over-statement the row detail's *"all targets together"* was condemned for, reproduced in the headline the PR exists to fix. The amendment's own row-detail string carefully uses *"every target"*; the headline should match it.
2. **`comes closest to` names proximity; the number is a probability.** The crown is the **unique argmax of `goalProbability`** (UI-SEM-072), not a distance to a target value. So the headline would have named a different quantity from the caption immediately beneath it (*"…the **chance** that option meets…"*) — reproducing, in miniature, the headline/caption disagreement this slice removes.

**Shipped instead:** `${label} is most likely to meet every target this run scored.` — parallel in shape to the existing `headline.mostLikelyStrongest`, true under the crown's unique-argmax + sub-1%-floor gate, and sharing the other three surfaces' exact anchor.

**The refutation is pinned, not asserted.** The `PLURALITY` predicate matches `\bthe targets\b`, and the refuted draft is run as a **mutant** below.

## 4. RED-first

New spec: `src/components/results/analysis-hero/__tests__/goalAttainmentCopy.spec.tsx`. It renders `AnalysisHeroPanel` **once**, on its default (goal) lens, and reads the headline, the caption and every row's goal-fit detail from that **single mount** — the defect is a co-render property, so reading the surfaces apart would not have seen it.

Before the fix, on pristine `fff04eb5`:

```
 ❯ goalAttainmentCopy.spec.tsx  (14 tests | 4 failed)
   ❯ … > leader case: headline, caption and every row detail are possessive-free
     → headline: expected 'Upskill the team best fits your goal.' not to match /your goal/i
   ❯ … > none-on-track case: …
     → headline: expected 'No option is currently on track to re…' not to match /your goal/i
   ❯ … > multi-option case: …
     → headline: expected 'Upskill the team best fits your goal.' not to match /your goal/i
   ❯ … > the three surfaces agree — no surface claims what another withholds
     → surfaces still asserting the possessive: expected [ …(2) ] to deeply equal []
       + Array [
       +   "Upskill the team best fits your goal.",
       +   "Each value is the chance that option hits your goal.",
       + ]

      Tests  4 failed | 10 passed (14)
```

After: **16/16 passed** (two predicate controls were added during the mutation round — see below).

## 5. Mutation — five mutants, all bite

Run in a throwaway clone at `…/dgai-f2-neg1-MUTANT-20260727`, **outside** the repo root (traps 9/9c), **removed before every gate run** below.

| Mutant | Result | The assertion that named it |
|---|---|---|
| revert `headline.goalOnly` alone | **3 failed / 13 passed** | `headline possessive: expected 'Upskill the team best fits your goal.' not to match /your goal/i` |
| revert `caption.goalOnly` alone | **4 failed / 12 passed** | `caption possessive: …` |
| revert `detail.goalFitJointBasis` alone | **4 failed / 12 passed** | `row 1 detail count: expected '34% chance of meeting all targets tog…' not to match /\ball targets\b\|\bthe targets\b/i` |
| revert `headline.noneOnTrack` alone | **1 failed / 15 passed** | `headline possessive` — **only** the none-on-track case, correct discrimination |
| substitute the **refuted amendment draft** (`comes closest to the targets…`) | **3 failed / 13 passed** | `headline count: expected 'Upskill the team comes closest to the…' not to match /…\bthe targets\b/i` |

### ⚠ The mutation round found a real gap in my own first test

The first version of the spec scanned only for the possessive `/your goal/i`. **The row-detail mutant did not bite: 14/14 green with `"meeting all targets together"` restored** — because that string never contained a possessive; it over-stated **plurality** instead. A possessive-only scan is structurally blind to it, so the row-detail half of this PR was, at that moment, a change no test could see (trap 11 — *"a fix whose tests pass with the defect re-introduced is theatre"*).

Fixed by adding a **second predicate** for the count assertion, with its own positive control *and* a **negative control** proving `every target` is deliberately not matched (a predicate that banned the distributive universal would force the copy back into either a count or a possessive). All five mutants then bite, each naming the correct half of the defect on the correct surface.

## 6. Positive controls

**Trap 13 — an absence assertion must first prove it can see a presence:**

- every surface proven **non-empty** before any `not.toMatch` runs, and the detail region proven **actually open** (`hero-option-detail` asserted present per row) — otherwise the row assertions would pass over an absent node;
- the **row-detail surface proven able to CARRY a possessive**: on a non-substituted record it still renders `detail.goalFit` ("…chance of hitting your goal."), so its absence on the live record is a real result, not a missing element;
- both predicates proven to **fire** on every string they exclude, including the refuted draft;
- the plurality predicate proven **not** to fire on the shipped anchor (negative control).

**No over-suppression — this is a rewording, never a removal:**

- the goal line **still appears** on every row, and matches `/chance/i`;
- every row detail still carries **its own readout verbatim**;
- `goal.value`, `goal.readout` and `outcome.readout` are **byte-identical** to the non-substituted control across all rows;
- the response percentages still render (`0.34 → 34%`, `0.49 → 49%`);
- the goal lens is still available and still the **default** lens.

## 7. Scoping enumeration (what the RED assertion covers, and what it deliberately does not)

**In scope** — the three hero surfaces that *designate from* the goal-probability number, i.e. the surfaces named in the amendment §2.2 table:

- `hero-headline` (both goal branches: crown and none-on-track)
- `hero-caption` on the goal lens
- `hero-detail-goal-fit`, per row

**Out of scope, deliberately.** The principled line: these three surfaces make an **attainment claim about the joint number**; every other `your goal` in the estate names the goal **entity**, which the user genuinely does own. Blanket-banning the phrase would be over-suppression of true copy.

The complete `src/components/results` manifest was reviewed, not sampled — the residual hits are `useResultsSectionData.ts:1223-1233` (the goal-**label** fallback chain), `emptyStates.ts:2`, `RangeVisualization.tsx:294-295` ("in your goal's units"), `buildRecommendations.ts:172` ("your goal has no success threshold"), plus two source comments. **And the label fallback provably cannot reach the surfaces under test: `grep -n goalLabel src/components/results/analysis-hero/*` → 0 hits.** The hero receives no goal label, so none of its three templates can interpolate one.

| Site | Why out of scope |
|---|---|
| `heroCopy.ts` `detail.goalFit`, `detail.goalFitWithLimits`, `headline.goalWithLimits`, `headline.noneOnTrackWithLimits`, `caption.goalWithLimits` | **Dead on the V5 path, deliberately NOT deleted** (amendment §2.4 scope note; trap 5 — a fold is a new change, not a patch). Unreachable while `hasConstraints`/`optionHasConstraints` are constants, and not provably dead on the legacy direct-ISL routes |
| `canvas/nodes/OutcomeNode.tsx`, `usePreAnalysisData.ts`, `inspectorStrings.ts`, `coachingConfig.ts`, `graphGuardrails.ts`, `pre-analysis-v3/constants.ts`, `DecisionSummary.tsx`, `RangeVisualization.tsx`, `emptyStates.ts`, `strengthen/buildRecommendations.ts` | Pre-analysis coaching, canvas node copy, inspector strings and guardrails — **not claims about this number**. Several are already gated by UI-SEM-071/082 |
| `selectGoalProbability.ts` logic, `mayUsePossessiveGoalFraming` | **Untouched.** It has zero production readers today; wiring it is slice-3 work (amendment §2.5 condition 6). This PR changes no selector behaviour |
| Wire, schemas, CEE keep-list, PLoT attestation | Slices 0–3. Nothing here crosses a boundary |

**Changed but not user-facing:** `fixtures/galleryModels.ts` — four hand-authored headline literals in the **internal-only** `/dev/hero-gallery` review surface (provenance-branded `'fixture'`, import-isolated by `fixtureIsolation.spec`). Updated so the copy-review surface does not become a stale mirror of the shipped copy. Zero product effect.

**Existing test assertions updated at source, never absorbed into a baseline:** `buildHeroModel.spec.ts`, `content.spec.tsx`, `nullTargetSuppression.spec.tsx`, `stagingScenario.spec.tsx`, `ResultsBody.heroPlacement.spec.tsx` — all hardcoded the old strings.

## 8. Zero-overlap statement

`#499` (`fff04eb5`, the intervention-finiteness / partial-drop PR) touched:
`src/adapters/plot/v2/{adapter.ts,index.ts,__tests__/interventionFiniteness.*}`, `src/utils/{interventionValue.ts,__tests__/interventionValue.spec.ts}`, `src/canvas/utils/labelUtils.ts`.

This PR touches:
`src/components/results/analysis-hero/{heroCopy.ts,buildHeroModel.ts,fixtures/galleryModels.ts,__tests__/*}` and `src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx`.

**Intersection: ∅.** Verified by file list at the tip, not asserted.

## 9. Gates

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set for **every** measurement (trap 2b) — zero collect-time failures, so the counts below are over the full suite, not a silently smaller one.

| Gate | Pristine `fff04eb5` | This branch |
|---|---|---|
| `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`, read at the tip) | coverage 3005/3023 · ratchet **633 files / 2547 errors** (baseline 2663) · PASSED | coverage **3006/3024** (+1: the new spec) · ratchet **633 files / 2547 errors** · **PASSED** |
| `vitest src/components/results/analysis-hero` | 16 files / 283 tests passed | **17 files / 297 passed** |
| `vitest src/components/results` + the walker | — | **189 files / 3642 tests passed** |
| `claim-ownership.drift.spec.ts` (the #498 walker) | — | **11/11 passed** — run explicitly as its own file to rule out positional-filter vacuity. Expected: this PR reads **no raw producer field**, so the baseline is untouched |
| `eslint` on every changed file | — | clean |

**Typecheck ratchet NOT bumped.** The gate's `Drift shrank (2663 → 2547)` notice reproduces **identically on pristine `fff04eb5`** (measured in the throwaway clone), so it is pre-existing attribution drift, not this PR's — and the baseline was correctly left alone.

Every filter run was checked for non-vacuity by its file/test count.

## 10. Post-merge walk — one command

`acceptance-evidence/f2-slice-neg1-20260727/walk-goal-copy.mjs` (harness pattern reused from `acceptance-evidence/readiness-slice0/harness`).

```bash
cd /Users/paulslee/Documents/GitHub/acceptance-evidence/f2-slice-neg1-20260727
node walk-goal-copy.mjs        # exit 0 = PASS; writes probe.json, verdict.json, screenshots
```

It drives a draft + analysis on deployed staging, selects the Goal fit lens, expands a row, and reads all three surfaces **from one render** with **visibility** (`offsetParent`, rect, computed style, above-fold) — because jsdom proves presence, never layout (trap 3).

**Expected strings:**

- headline — `…is most likely to meet every target this run scored.` **or** `No option is currently on track to meet every target this run scored.`
- caption — `Each value is the chance that option meets every target this run scored.`
- row detail — `NN% chance of meeting every target this run scored.`

**Must be absent from all three:** `/your goal/i` and `/\ball targets\b|\bthe targets\b/i`. **Must be present in all three:** `every target this run scored`. A missing or invisible surface fails the walk (over-suppression guard).

## 11. Flagged, not fixed

- **`mayUsePossessiveGoalFraming` has zero production readers** — computed at `selectGoalProbability.ts:257`, read only by tests. A permission derived and discarded. Slice 3.
- **Four live sites consume `probability_of_goal`, which never arrives** (`useScenarioComparison.ts:228`, `useAnalysisResults.ts:105-106`, plus the selector's own `unconstrained` branch). Permanently `undefined`; the `:105-106` fallback is a dead branch presenting as a safety net. Slice 5 cutover.
- **`OutcomeNode.tsx:142-146`** renders a goal-derived "Achievement" designation and is **not** in the walker baseline — it reads the hook's output, so the walker is invisible to it by construction. Amendment §3 claim 4; not a family-2 slice-−1 surface.
- The interim copy **retires** when CEE ships `goal_verdict` with an explicit `measure_scope` and the copy can be exact (slices 1–5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
