### PR TITLE
fix(ui): a withheld run stops designating a leader through order, ordinals, crowns and the screen reader [ROADMAP 1.267]

### DIFF
--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -50,9 +50,19 @@ export interface OptionCardsProps {
    * surface must gate on before asserting a leading option exists.
    *
    * Deliberately SEPARATE from `winnerId`, which stays populated on a withheld
-   * turn: `winnerId` is an IDENTITY and it still drives segment colours, the
-   * lens crown and card ordering, none of which claim anything. This flag is
-   * the ENTITLEMENT, and it gates only the comparative SENTENCES.
+   * turn: `winnerId` is an IDENTITY, and identity still drives the lens crown
+   * and node focus. This flag is the ENTITLEMENT.
+   *
+   * ⚠ CORRECTED 27 Jul (ROADMAP 1.267). This doc used to end "…still drives
+   * segment colours, the lens crown and card ordering, NONE OF WHICH CLAIM
+   * ANYTHING", and that sentence was wrong. Row 1.306 records the confirming
+   * screenshots and names it: "the G-UI-1 closure treated client-side
+   * ordering as benign when it is the designation channel." Ordering,
+   * ordinal swatches and rank-derived colour are claims wearing numbers, so
+   * they are now gated too — see `designationsWithheld` below. This flag
+   * still gates the comparative SENTENCES; the two are separate because a
+   * sentence and a sort fail differently and a single flag hid that for four
+   * slices.
    *
    * `undefined` ⇒ legacy behaviour, matching the same concession
    * `certaintyCopy` and `buildV7Headline` make for callers/fixtures predating
@@ -306,6 +316,7 @@ function OptionCard({
   description,
   cardRef,
   neutralised = false,
+  designationsWithheld = false,
   sortedRank,
   stableNumber = null,
   segmentFillColor,
@@ -322,9 +333,14 @@ function OptionCard({
 }: {
   option: OptionResult
   isWinner: boolean
-  /** ROADMAP 1.223 — see OptionCardsProps. Gates the comparative SENTENCES
-   *  only; `isWinner` still drives styling, ordering and the lens crown. */
+  /** ROADMAP 1.223 — see OptionCardsProps. Gates the comparative SENTENCES. */
   hasLeadingOption?: boolean
+  /**
+   * ROADMAP 1.267 — gates the non-prose DESIGNATIONS on this card: the
+   * ordinal rank swatch, the crowned border, and the leader colour on the
+   * "Hits target" bar. Never the values themselves.
+   */
+  designationsWithheld?: boolean
   /** Codex B1: lens crown restyles only — leader predicates stay on isWinner. */
   isLensCrowned?: boolean
   /** True when the risk-appetite lens is non-neutral (suppresses the canonical crown styling). */
@@ -369,12 +385,21 @@ function OptionCard({
   // Codex B1: under a lens, the CROWN styling follows the lens selection and
   // the canonical leader drops to a neutral border (never two crowns); the
   // canonical leader keeps every SEMANTIC leader predicate below regardless.
-  const crowned = cardLensActive ? isLensCrowned : isWinner
+  // ROADMAP 1.267: a withheld run crowns nothing. The lens crown goes too —
+  // it is a second designation, not an exemption from the first.
+  const crowned = designationsWithheld ? false : cardLensActive ? isLensCrowned : isWinner
   const borderClass = neutralised || !crowned
     ? 'border border-panel-border'
     : 'border border-success/30'
-  // V14.2: Prefer sort-derived rank, fallback to option.rank or winner inference
-  const rank = sortedRank ?? option.rank ?? (isWinner ? 1 : undefined)
+  // V14.2: Prefer sort-derived rank, fallback to option.rank or winner inference.
+  // ROADMAP 1.267: withheld ⇒ no rank at all. Note the fallback chain is
+  // itself three ordinal designations stacked — `sortedRank` is the position
+  // in the probability sort, `option.rank` is documented "1 = best", and
+  // `isWinner ? 1` hands rank 1 to the winner outright — so the suppression
+  // has to sit above the whole chain, not inside one arm of it.
+  const rank = designationsWithheld
+    ? undefined
+    : sortedRank ?? option.rank ?? (isWinner ? 1 : undefined)
 
   return (
     <div
@@ -491,7 +516,9 @@ function OptionCard({
           <StatBar
             value={option.goalProbability}
             label="Hits target"
-            isLeader={isWinner}
+            // ROADMAP 1.267: the bar length stays (it is the goal
+            // probability); only the leader COLOUR is withheld.
+            isLeader={isWinner && !designationsWithheld}
             color="info"
             neutralised={neutralised}
           />
@@ -627,14 +654,29 @@ export function OptionCards({
   // V11: Indeterminate neutralisation — stone colours, no success border
   const neutralised = decisionState === 'indeterminate'
 
+  // ROADMAP 1.267 — DESIGNATION vs DATA. Read from the entitlement boolean
+  // this component already receives; nothing new is derived. `=== false`
+  // (not `!hasLeadingOption`) keeps the documented legacy concession: an
+  // `undefined` prop is a caller predating the shared verdict, not a
+  // withheld run, and behaves byte-identically to before.
+  //
+  // Deliberately NOT folded into `neutralised`, though the two suppress an
+  // overlapping set of styles: `neutralised` also drops the win-probability
+  // FILL BAR entirely (line ~459), and that bar is DATA. Reusing it would
+  // have deleted a computed fact the ruling explicitly protects — the
+  // over-suppression failure mode, arrived at by trying to save a flag.
+  const designationsWithheld = hasLeadingOption === false
+
   // V11: Conditional "Hits target" — hide unless EVERY option has goalProbability
   const allGoalProbability = options.every(o => o.goalProbability != null)
   const showHitsTarget = hasGoalThreshold && allGoalProbability
 
   // V14.2: Sort by win probability descending (same order as WinGauge segments).
   // Shared with the analysis hero via sortOptionsForDisplay so both surfaces
-  // number and order options identically.
-  const sorted = sortOptionsForDisplay(options)
+  // number and order options identically. WITHHELD: canonical order instead
+  // (ROADMAP 1.267) — `options` already arrives canonical from the hook, and
+  // passing the flag here stops this leaf re-imposing the ranking.
+  const sorted = sortOptionsForDisplay(options, { designationsWithheld })
 
   // Range bar global scale: shared [globalMin, globalMax] across all options
   // so bar widths are visually comparable. Falls back to mean when percentiles
@@ -700,7 +742,14 @@ export function OptionCards({
                 ? hingeAwareDescription(option, isWinner, isRunnerUp, hinge, winnerOpt?.winProbability, false, hasLeadingOption)
                 : fallbackDescription(option, options.length, hasLeadingOption)
 
-        const segmentFillColor = segmentColorMap[option.id]
+        // ROADMAP 1.267: the fill bar's LENGTH is the win probability (data,
+        // kept) but its COLOUR is the rank palette — WIN_GAUGE_COLORS[0] is
+        // commented "Winner — mint-500". On a withheld run the bar still
+        // draws, in one neutral colour for every option: the measurement
+        // survives, the ranking does not.
+        const segmentFillColor = designationsWithheld
+          ? 'var(--factor)'
+          : segmentColorMap[option.id]
         return (
           <OptionCard
             key={option.id}
@@ -712,6 +761,7 @@ export function OptionCards({
             hasGoalThreshold={showHitsTarget}
             description={description}
             neutralised={neutralised}
+            designationsWithheld={designationsWithheld}
             sortedRank={index + 1}
             stableNumber={stableNumbers?.[option.id] ?? null}
             segmentFillColor={segmentFillColor}

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -440,6 +440,9 @@ export const ResultsBody = memo(function ResultsBody({
                   isWinner: o.isRecommended,
                 }))}
               decisionState={vm.decisionState}
+              designationsWithheld={
+                resultsSectionData.recommendation.verdict?.hasLeadingOption === false
+              }
             />
             {/* Codex B1: winnerId is ALWAYS the canonical leader — every leader
                 predicate (downside sentence, leader CTA/prompt) keys to it. The
@@ -448,10 +451,14 @@ export const ResultsBody = memo(function ResultsBody({
               options={resultsSectionData.recommendation.allOptions}
               winnerId={resultsSectionData.recommendation.recommendedOption?.id}
               // ROADMAP 1.223: the ENTITLEMENT, kept separate from the identity
-              // above. `winnerId` deliberately still flows on a withheld turn —
-              // it drives segment colours, the lens crown and card ordering,
-              // none of which claim anything. This flag gates only the
-              // comparative sentences inside the cards.
+              // above. `winnerId` deliberately still flows on a withheld turn
+              // because identity is not entitlement.
+              //
+              // ⚠ CORRECTED 27 Jul (ROADMAP 1.267): this comment used to end
+              // "it drives segment colours, the lens crown and card ordering,
+              // none of which claim anything", and row 1.306 refutes that at
+              // the screenshots. Ordering, ordinal colour and the crown ARE
+              // claims; OptionCards now gates them off this same boolean.
               hasLeadingOption={resultsSectionData.recommendation.verdict?.hasLeadingOption}
               lensActive={riskAppetite !== 'neutral'}
               lensHighlightedId={riskAppetite !== 'neutral' && lensComparison.comparable ? lensComparison.id : undefined}

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -131,20 +131,38 @@ export function buildSegmentColorMap(
 export function WinGauge({
   shares,
   decisionState,
+  designationsWithheld = false,
 }: {
   shares: OptionWinShare[]
   decisionState?: DecisionState
+  /**
+   * ROADMAP 1.267. The LABEL of this chart was already fixed once (see the
+   * comment below the tooltip) but its ORDER was not: segments were sorted
+   * winner-first, and the palette's first entry is commented "Winner —
+   * mint-500", so the leader was designated twice over — by position and by
+   * green — under a caption that had been carefully de-designated.
+   *
+   * Withheld ⇒ segments follow canonical order. The colours stay (a stacked
+   * bar needs distinguishable segments, and the legend maps them by name),
+   * but they now track graph position rather than rank, so green means
+   * "first option you created", not "the winner". The percentages are
+   * untouched — this chart is a distribution, and the distribution is data.
+   */
+  designationsWithheld?: boolean
 }) {
   if (shares.length === 0) return null
 
   const colors = decisionState === 'indeterminate' ? WIN_GAUGE_COLORS_INDETERMINATE : WIN_GAUGE_COLORS
 
-  // Sort: winner first, then by win probability descending
-  const sorted = [...shares].sort((a, b) => {
-    if (a.isWinner && !b.isWinner) return -1
-    if (!a.isWinner && b.isWinner) return 1
-    return b.winProbability - a.winProbability
-  })
+  // Sort: winner first, then by win probability descending.
+  // WITHHELD: no sort at all — `shares` already arrives in canonical order.
+  const sorted = designationsWithheld
+    ? [...shares]
+    : [...shares].sort((a, b) => {
+        if (a.isWinner && !b.isWinner) return -1
+        if (!a.isWinner && b.isWinner) return 1
+        return b.winProbability - a.winProbability
+      })
 
   const isDeemphasised = decisionState === 'indeterminate'
 

--- a/src/components/results/__fixtures__/withheldDesignations.fixtures.ts
+++ b/src/components/results/__fixtures__/withheldDesignations.fixtures.ts
@@ -1,0 +1,159 @@
+/**
+ * The WITHHELD / PERMITTED pair for the NON-PROSE designation contract
+ * (ROADMAP 1.267).
+ *
+ * Shared by the two halves of the slice so both are provably describing the
+ * SAME run — one fixture, no mirror:
+ *   · `../__tests__/withheldDesignations.spec.tsx`
+ *       the shared comparator + the ranked card repeat (OptionCards)
+ *   · `../analysis-hero/__tests__/withheldDesignations.hero.spec.tsx`
+ *       the hero rows (the analysis-hero inertness guard allows hero imports
+ *       only from inside that module, so the hero half lives there)
+ *
+ * Same wire shapes as `src/lib/__fixtures__/ownedLeaderClaim.fixtures.ts`,
+ * which pins the PROSE half — restated here with THREE options and a
+ * deliberately reversed order, for the reason below.
+ *
+ * ## Why three options, and why canonical order is the reverse
+ *
+ * The CEE lane that shipped the producer half of this ruling (#719) caught
+ * its own route fixture being VACUOUS: on a two-option graph the leader
+ * sorted first anyway, so its order assertion could never have gone red.
+ * Options are declared in canonical (graph/creation) order LOW → MID → HIGH
+ * while their win probabilities run 0.10 / 0.30 / 0.60 — so canonical order
+ * is the exact REVERSE of probability order. An implementation that
+ * neutralises nothing, and one that sorts ascending by accident, both fail.
+ */
+import type { DecisionVerdictReportLike } from '../../../lib/decisionVerdict'
+import { deriveDecisionVerdict } from '../../../lib/decisionVerdict'
+import type { OptionResult } from '../types'
+
+export const LOW_ID = 'opt_low'
+export const MID_ID = 'opt_mid'
+export const HIGH_ID = 'opt_high'
+
+export const LOW_LABEL = 'Keep the current tooling'
+export const MID_LABEL = 'Upskill the current team'
+export const HIGH_LABEL = 'Hire two developers'
+
+export const WIN_LOW = 0.1
+export const WIN_MID = 0.3
+export const WIN_HIGH = 0.6
+
+/** Graph/creation order — what `nodes.filter(kind === 'option')` yields. */
+export const CANONICAL_IDS = [LOW_ID, MID_ID, HIGH_ID] as const
+export const CANONICAL_LABELS = [LOW_LABEL, MID_LABEL, HIGH_LABEL] as const
+/** Probability-descending order — the designation this slice removes. */
+export const PROBABILITY_IDS = [HIGH_ID, MID_ID, LOW_ID] as const
+export const PROBABILITY_LABELS = [HIGH_LABEL, MID_LABEL, LOW_LABEL] as const
+
+const OPTION_PROBABILITIES = {
+  [LOW_ID]: { win_probability: WIN_LOW },
+  [MID_ID]: { win_probability: WIN_MID },
+  [HIGH_ID]: { win_probability: WIN_HIGH },
+}
+
+/**
+ * WITHHELD, post-CEE-#711: `leading_option_id` nulled and the comparative
+ * members of `decision_brief` dropped, while the per-option win probabilities
+ * keep riding the wire — the DATA is not withheld, only the CLAIM.
+ */
+export const WITHHELD_REPORT: DecisionVerdictReportLike = {
+  option_probabilities: OPTION_PROBABILITIES,
+  robustness: { recommended_option_id: HIGH_ID },
+  decision_brief: {
+    // A non-comparative member CEE deliberately KEEPS, so the fixture cannot
+    // pass merely because the brief is absent whole.
+    top_drivers: [{ factor_label: 'Three-Year Total Cost of Ownership' }],
+  } as unknown as DecisionVerdictReportLike['decision_brief'],
+}
+
+/** The SAME run with the claim PERMITTED — the over-suppression control. */
+export const PERMITTED_REPORT: DecisionVerdictReportLike = {
+  option_probabilities: OPTION_PROBABILITIES,
+  robustness: { recommended_option_id: HIGH_ID },
+  decision_brief: {
+    headline: `${HIGH_LABEL} currently leads.`,
+    headline_banded: {
+      band: 'clearly_ahead',
+      leader_option_id: HIGH_ID,
+      robustness_gated: false,
+    },
+  } as unknown as DecisionVerdictReportLike['decision_brief'],
+}
+
+export const WITHHELD_VERDICT = deriveDecisionVerdict(WITHHELD_REPORT)
+export const PERMITTED_VERDICT = deriveDecisionVerdict(PERMITTED_REPORT)
+
+/** Options in CANONICAL order, as the hook now emits them on a withheld run. */
+export function withheldFixtureOptions(): OptionResult[] {
+  return [
+    {
+      id: LOW_ID,
+      label: LOW_LABEL,
+      expected: 40,
+      outcome: { mean: 40, p10: 30, p50: 40, p90: 50 },
+      p10: 30,
+      p50: 40,
+      p90: 50,
+      isRecommended: false,
+      winProbability: WIN_LOW,
+      goalProbability: 0.2,
+    },
+    {
+      id: MID_ID,
+      label: MID_LABEL,
+      expected: 55,
+      outcome: { mean: 55, p10: 45, p50: 55, p90: 65 },
+      p10: 45,
+      p50: 55,
+      p90: 65,
+      isRecommended: false,
+      winProbability: WIN_MID,
+      goalProbability: 0.45,
+    },
+    {
+      id: HIGH_ID,
+      label: HIGH_LABEL,
+      expected: 70,
+      outcome: { mean: 70, p10: 60, p50: 70, p90: 80 },
+      p10: 60,
+      p50: 70,
+      p90: 80,
+      isRecommended: true,
+      winProbability: WIN_HIGH,
+      goalProbability: 0.8,
+    },
+  ] as OptionResult[]
+}
+
+/**
+ * Every string a screen reader can reach that is NOT ordinary body text:
+ * explicit `aria-label`s, plus the text of any `sr-only` node — which is
+ * exactly how the leader cue is delivered: invisible on screen, spoken
+ * aloud, and therefore invisible to a visual review of the same page.
+ */
+export function screenReaderStrings(container: HTMLElement): string[] {
+  const out: string[] = []
+  for (const el of Array.from(container.querySelectorAll<HTMLElement>('[aria-label]'))) {
+    out.push(el.getAttribute('aria-label') ?? '')
+  }
+  for (const el of Array.from(container.querySelectorAll<HTMLElement>('.sr-only'))) {
+    out.push(el.textContent ?? '')
+  }
+  return out.filter(Boolean)
+}
+
+/**
+ * Rendered row order, read from `data-option-id` rather than label text —
+ * the label element also carries the sr-only leader cue on a permitted run,
+ * so a text comparison would conflate the ORDER leg with the A11Y leg.
+ */
+export function renderedRowIds(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-option-id]')).map(
+    (n) => n.getAttribute('data-option-id') ?? '',
+  )
+}
+
+/** Designation vocabulary that must never reach a screen reader on withheld. */
+export const DESIGNATION_RE = /highest|leading|leads|winner|best|top option|rank ?1|#1/i

--- a/src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.optionRankCoherence.spec.ts
@@ -71,7 +71,20 @@ function makeV2Response(options: OptionShape[]): V2RunResponse {
     drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
     edge_sensitivity: [],
     factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
-    robustness: { fragile_edges: [], robust_edges: ['e1'] },
+    // ROADMAP 1.267: this spec pins BADGE-METRIC == SORT-METRIC coherence,
+    // which is a property of a PERMITTED run — on a withheld run there is no
+    // ranking to be coherent with, and rows/ordinals go canonical instead
+    // (see withheldDesignations.spec). The fixture therefore has to carry a
+    // producer leader claim; without one `deriveDecisionVerdict` returns
+    // `unknown` (silence is meaningful post-CEE-#711) and this spec would
+    // silently become a withheld-run test asserting the old order.
+    // `near_tie` is PLoT's own "is there a clear leader?" answer and is
+    // passed through verbatim by the V2 responseMapper.
+    robustness: {
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      near_tie: { is_tie: false, top_option_id: 'opt_launch' },
+    },
     response_hash: 'h',
     meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
   }
@@ -132,7 +145,7 @@ describe('useResultsSectionData — option rank coherence', () => {
 
     expect(allOptions.map((o) => o.id)).toEqual(DISPLAY_ORDER_IDS)
     // Self-consistency: the array is already a fixed point of the shared sort.
-    expect(sortOptionsForDisplay(allOptions).map((o) => o.id)).toEqual(
+    expect(sortOptionsForDisplay(allOptions, { designationsWithheld: false }).map((o) => o.id)).toEqual(
       allOptions.map((o) => o.id),
     )
   })

--- a/src/components/results/__tests__/withheldDesignations.spec.tsx
+++ b/src/components/results/__tests__/withheldDesignations.spec.tsx
@@ -1,0 +1,182 @@
+/**
+ * WITHHELD RUNS MAY NOT DESIGNATE — comparator + ranked card repeat.
+ *
+ * `ownedLeaderClaim.surfaces.spec.ts` pins the PROSE: on a withheld turn no
+ * surface may SAY "X leads". This file and its hero sibling
+ * (`../analysis-hero/__tests__/withheldDesignations.hero.spec.tsx`) pin
+ * everything that designates a leader WITHOUT saying so — the channels a
+ * string matcher cannot see:
+ *
+ *   · ORDER      — probability-descending sort IS a claim about who is first
+ *   · ORDINALS   — the rank swatch is `rank == 1` wearing a colour
+ *   · CROWN      — the success border on exactly one card
+ *   · A11Y       — any designation reaching a screen reader
+ *
+ * ## The doctrine this APPLIES (it does not invent it)
+ *
+ * ROADMAP 1.267, ruled 27 Jul and ratified as Codex decision (1) in row
+ * 1.306: computed probabilities are DATA the user is entitled to; `rank == 1`,
+ * probability-descending order, ordinals, crowns and accessible "highest"
+ * labels are DESIGNATIONS — claims wearing numbers. On a withheld run the
+ * DATA stays and the DESIGNATIONS go. CEE PR #719 already applied exactly
+ * this ruling on the producer side (`rank` gated, `options[]` order
+ * canonicalised, probabilities kept). This is the consumer half.
+ *
+ * ## The over-suppression control is not optional
+ *
+ * Every WITHHELD case has a PERMITTED twin asserting today's behaviour
+ * unchanged. A change that silences the withheld turn by deleting the data
+ * is a failure, not a fix — it would cost the user the computed facts the
+ * ruling explicitly protects.
+ *
+ * ## Scope of the claim (CLAUDE.md trap 3)
+ *
+ * jsdom proves DOM order, accessible names and presence. It cannot prove
+ * layout or visual order. The visual leg is the browser walk at
+ * `acceptance-evidence/withheld-designations-20260727/walk-withheld-designations.mjs`.
+ */
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { sortOptionsForDisplay } from '../utils/optionDisplayOrder'
+import OptionCards from '../OptionCards'
+import {
+  CANONICAL_IDS,
+  CANONICAL_LABELS,
+  DESIGNATION_RE,
+  HIGH_ID,
+  LOW_ID,
+  MID_ID,
+  PERMITTED_VERDICT,
+  PROBABILITY_LABELS,
+  WIN_HIGH,
+  WIN_LOW,
+  WIN_MID,
+  WITHHELD_VERDICT,
+  renderedRowIds,
+  screenReaderStrings,
+  withheldFixtureOptions as options,
+} from '../__fixtures__/withheldDesignations.fixtures'
+
+/**
+ * Anti-vacuity: this whole file is about the difference between the two
+ * verdicts and the two orders. If either pair ever stops differing, every
+ * assertion below starts passing for the wrong reason.
+ */
+describe('the fixture pair actually discriminates', () => {
+  it('withholds on one and permits on the other', () => {
+    expect(WITHHELD_VERDICT.hasLeadingOption).toBe(false)
+    expect(PERMITTED_VERDICT.hasLeadingOption).toBe(true)
+  })
+
+  it('canonical order is not probability order (the order leg can go red)', () => {
+    expect([...CANONICAL_LABELS]).not.toEqual([...PROBABILITY_LABELS])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 1 — the shared comparator (`sortOptionsForDisplay`)
+//
+// Every option list on the results path funnels through this one function,
+// so it is where the ORDER designation is authored.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('sortOptionsForDisplay — order is a designation', () => {
+  it('WITHHELD: preserves canonical order (no probability sort)', () => {
+    const sorted = sortOptionsForDisplay(options(), { designationsWithheld: true })
+    expect(sorted.map((o) => o.id)).toEqual([...CANONICAL_IDS])
+  })
+
+  it('PERMITTED: sorts by win probability descending, exactly as today', () => {
+    const sorted = sortOptionsForDisplay(options(), { designationsWithheld: false })
+    expect(sorted.map((o) => o.label)).toEqual([...PROBABILITY_LABELS])
+  })
+
+  it('WITHHELD: every option and every probability survives (data preserved)', () => {
+    const sorted = sortOptionsForDisplay(options(), { designationsWithheld: true })
+    // Compared id-keyed, so this leg is about DATA and cannot pass or fail
+    // for an ordering reason — that is the assertion above.
+    expect(Object.fromEntries(sorted.map((o) => [o.id, o.winProbability]))).toEqual({
+      [LOW_ID]: WIN_LOW,
+      [MID_ID]: WIN_MID,
+      [HIGH_ID]: WIN_HIGH,
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 2 — the ranked card repeat beneath the explanation (OptionCards)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function renderCards(verdict: typeof WITHHELD_VERDICT) {
+  return render(
+    <OptionCards
+      options={options()}
+      winnerId={HIGH_ID}
+      hasLeadingOption={verdict.hasLeadingOption}
+      hasGoalThreshold={false}
+    />,
+  )
+}
+
+describe('OptionCards — the ranked repeat', () => {
+  it('WITHHELD: cards follow canonical order', () => {
+    const { container } = renderCards(WITHHELD_VERDICT)
+    // Truncated to the top 2 by the existing "Show all" affordance; the
+    // point is WHICH two and in what order, not how many.
+    expect(renderedRowIds(container).slice(0, 2)).toEqual([LOW_ID, MID_ID])
+  })
+
+  it('WITHHELD: renders no rank marker', () => {
+    const { container } = renderCards(WITHHELD_VERDICT)
+    expect(container.querySelectorAll('[data-testid^="rank-marker-"]')).toHaveLength(0)
+  })
+
+  it('WITHHELD: renders no crowned (success) border on any card', () => {
+    const { container } = renderCards(WITHHELD_VERDICT)
+    expect(container.querySelectorAll('[class*="border-success"]')).toHaveLength(0)
+  })
+
+  /**
+   * DATA PRESERVED. The win-probability fill bar is gated on
+   * `segmentFillColor`, so neutralising the colour by dropping it would have
+   * deleted the bar outright — the over-suppression failure this asserts
+   * against.
+   */
+  it('WITHHELD: still renders the win-probability bar for each visible card', () => {
+    const { container } = renderCards(WITHHELD_VERDICT)
+    expect(
+      container.querySelectorAll('[title^="Win probability:"]').length,
+    ).toBeGreaterThan(0)
+  })
+
+  /**
+   * Disclosed as a REGRESSION PIN, not a RED leg: this already passed on the
+   * unfixed tree, because the "Highest leading-option likelihood" strings in
+   * `hingeAwareDescription` need a `decisionState`/`hinge` this fixture does
+   * not supply, and #493/#494 gate them anyway. Kept so a future card cannot
+   * reintroduce a spoken designation unnoticed.
+   */
+  it('WITHHELD: exposes no designation to a screen reader', () => {
+    const { container } = renderCards(WITHHELD_VERDICT)
+    for (const s of screenReaderStrings(container)) {
+      expect(s, `screen-reader string leaked a designation: "${s}"`).not.toMatch(
+        DESIGNATION_RE,
+      )
+    }
+  })
+
+  it('PERMITTED: cards follow probability order and keep their rank markers', () => {
+    const { container } = renderCards(PERMITTED_VERDICT)
+    expect(renderedRowIds(container).slice(0, 2)).toEqual([HIGH_ID, MID_ID])
+    expect(
+      container.querySelectorAll('[data-testid^="rank-marker-"]').length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('PERMITTED: still crowns the leading card', () => {
+    const { container } = renderCards(PERMITTED_VERDICT)
+    expect(
+      container.querySelectorAll('[class*="border-success"]').length,
+    ).toBeGreaterThan(0)
+  })
+})

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -408,6 +408,7 @@ export function AnalysisHeroPanel({
                     row={row}
                     lens={lens}
                     isLeader={row.id === leaderId}
+                    showOrdinal={!model.designationsWithheld}
                     isOpen={openRowId === row.id}
                     onToggle={() => setOpenRowId((cur) => (cur === row.id ? null : row.id))}
                     outcomeDomain={model.outcomeDomain}

--- a/src/components/results/analysis-hero/HeroOptionRow.tsx
+++ b/src/components/results/analysis-hero/HeroOptionRow.tsx
@@ -39,6 +39,19 @@ export interface HeroOptionRowProps {
   onToggle: () => void
   /** Layout-only outcome domain; null hides outcome bars. */
   outcomeDomain: { min: number; max: number } | null
+  /**
+   * ROADMAP 1.267: whether to draw the ordinal number token.
+   *
+   * The token reads `stableNumber ?? index`, and on a first run both are
+   * seeded from the probability order — so "1" IS `rank == 1`, an ordinal
+   * DESIGNATION rather than a measurement. On a withheld run it is omitted
+   * entirely; the row keeps its label, readout, bar and disclosure.
+   *
+   * Separate from `isLeader` on purpose: `isLeader` removes the CROWN (which
+   * marks ONE row), this removes the NUMBERING (which ranks ALL of them).
+   * A withheld run must lose both, and one flag could not express that.
+   */
+  showOrdinal: boolean
 }
 
 /**
@@ -112,6 +125,7 @@ export function HeroOptionRow({
   isOpen,
   onToggle,
   outcomeDomain,
+  showOrdinal,
 }: HeroOptionRowProps) {
   const regionId = useId()
   const labelId = useId()
@@ -207,18 +221,30 @@ export function HeroOptionRow({
     <>
       {/* Row 1: badge · label · readout · chevron. Badge geometry follows
           the prototype (24×24, 7px radius); leader = filled info-blue with
-          white numeral, others outlined. */}
-      <span
-        aria-hidden="true"
-        data-testid="hero-row-number"
-        className={`flex h-6 w-6 flex-none items-center justify-center rounded-[7px] ${typography.panelMeta} ${
-          isLeader
-            ? 'bg-primary text-text-on-color'
-            : `border ${HERO_TOKEN_BORDER} bg-transparent text-text-body`
-        }`}
-      >
-        {row.stableNumber ?? row.index}
-      </span>
+          white numeral, others outlined.
+
+          ROADMAP 1.267: on a withheld run the numeral is a DESIGNATION
+          (`stableNumber ?? index` is seeded from the probability order, so
+          "1" is `rank == 1`) and is not drawn. The 1.5rem grid cell is still
+          occupied by an empty placeholder — the row grid is
+          `grid-cols-[1.5rem_…]`, so omitting the element outright would slide
+          the label into the badge column and silently re-lay-out every row.
+          Suppress the claim, not the layout. */}
+      {showOrdinal ? (
+        <span
+          aria-hidden="true"
+          data-testid="hero-row-number"
+          className={`flex h-6 w-6 flex-none items-center justify-center rounded-[7px] ${typography.panelMeta} ${
+            isLeader
+              ? 'bg-primary text-text-on-color'
+              : `border ${HERO_TOKEN_BORDER} bg-transparent text-text-body`
+          }`}
+        >
+          {row.stableNumber ?? row.index}
+        </span>
+      ) : (
+        <span aria-hidden="true" className="h-6 w-6 flex-none" />
+      )}
       <span
         id={labelId}
         ref={labelRef}

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -911,7 +911,7 @@ describe('buildHeroModel — lens gating and numbering', () => {
     const m = chart(buildHeroModel(makeHeroData({ options: scrambled })))
 
     // (1) Row order equals the shared comparator applied independently.
-    const expectedOrder = sortOptionsForDisplay(scrambled).map((o) => o.id)
+    const expectedOrder = sortOptionsForDisplay(scrambled, { designationsWithheld: false }).map((o) => o.id)
     expect(m.rows.map((r) => r.id)).toEqual(expectedOrder)
     expect(expectedOrder).toEqual(['opt_a', 'opt_b', 'opt_c', 'opt_d']) // win desc
     // (2) Row NUMBER tokens match row order (1..4), independent of lens.

--- a/src/components/results/analysis-hero/__tests__/firstRunNumbering.rankCoherence.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/firstRunNumbering.rankCoherence.spec.ts
@@ -55,7 +55,20 @@ function makeV2Response(): V2RunResponse {
     drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
     edge_sensitivity: [],
     factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
-    robustness: { fragile_edges: [], robust_edges: ['e1'] },
+    // ROADMAP 1.267: this spec pins BADGE-METRIC == SORT-METRIC coherence,
+    // which is a property of a PERMITTED run — on a withheld run there is no
+    // ranking to be coherent with, and rows/ordinals go canonical instead
+    // (see withheldDesignations.spec). The fixture therefore has to carry a
+    // producer leader claim; without one `deriveDecisionVerdict` returns
+    // `unknown` (silence is meaningful post-CEE-#711) and this spec would
+    // silently become a withheld-run test asserting the old order.
+    // `near_tie` is PLoT's own "is there a clear leader?" answer and is
+    // passed through verbatim by the V2 responseMapper.
+    robustness: {
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      near_tie: { is_tie: false, top_option_id: 'opt_launch' },
+    },
     response_hash: 'h',
     meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
   }

--- a/src/components/results/analysis-hero/__tests__/withheldDesignations.hero.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/withheldDesignations.hero.spec.tsx
@@ -1,0 +1,164 @@
+/**
+ * WITHHELD RUNS MAY NOT DESIGNATE — the analysis-hero half (ROADMAP 1.267).
+ *
+ * Sibling of `../../__tests__/withheldDesignations.spec.tsx`, which covers
+ * the shared comparator and the ranked card repeat. Both drive the SAME
+ * fixture pair (`../../__fixtures__/withheldDesignations.fixtures`), so the
+ * two halves are provably describing one run.
+ *
+ * It lives HERE, inside the module, because `inertness.spec.ts` allows
+ * analysis-hero imports only from inside the analysis-hero module and from
+ * ResultsBody — the architectural guard caught the first draft of this file
+ * sitting in `results/__tests__/` and it was right to.
+ *
+ * ## What this half pins
+ *
+ * The hero is where the defect was screenshotted: on a withheld run it
+ * ordered rows by win probability, numbered them 1/2/3, filled the leader's
+ * badge, emphasised its readout, set `aria-current`, and appended a
+ * visually-hidden "(Highest on this view)" — so a screen-reader user was
+ * told which option was highest on a run whose own prose said no option
+ * could be put forward yet.
+ *
+ * ## The srLeader reversal, stated plainly
+ *
+ * `heroCopy.srLeader` carried a comment arguing this cue was DELIBERATELY
+ * exempt: the crown is a per-lens argmax, "a property of the view, not the
+ * producer's leader designation". Row 1.306 overturns that at the
+ * screenshots. An argmax rendered as a filled badge, an emphasised readout,
+ * `aria-current` and a spoken label is a designation whatever it is derived
+ * from. This file is the pin for the reversal, not for the original.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { buildHeroModel } from '../buildHeroModel'
+import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
+import type { HeroChartModel } from '../heroTypes'
+import { makeHeroData } from '../__fixtures__/hero.fixtures'
+import {
+  CANONICAL_IDS,
+  CANONICAL_LABELS,
+  DESIGNATION_RE,
+  PERMITTED_VERDICT,
+  PROBABILITY_IDS,
+  WITHHELD_VERDICT,
+  renderedRowIds,
+  screenReaderStrings,
+  withheldFixtureOptions as options,
+} from '../../__fixtures__/withheldDesignations.fixtures'
+
+function heroModel(verdict: typeof WITHHELD_VERDICT): HeroChartModel {
+  return buildHeroModel(
+    makeHeroData({
+      options: options(),
+      recommendation: { verdict, storyHeadlines: {} },
+    }),
+  ) as HeroChartModel
+}
+
+function renderHero(verdict: typeof WITHHELD_VERDICT) {
+  return render(<AnalysisHeroPanel model={heroModel(verdict)} rerunDisabled={false} />)
+}
+
+describe('analysis hero — WITHHELD', () => {
+  it('renders rows in canonical order, not probability order', () => {
+    const { container } = renderHero(WITHHELD_VERDICT)
+    expect(renderedRowIds(container)).toEqual([...CANONICAL_IDS])
+  })
+
+  it('renders no ordinal number token', () => {
+    renderHero(WITHHELD_VERDICT)
+    expect(screen.queryAllByTestId('hero-row-number')).toHaveLength(0)
+  })
+
+  it('crowns no row (no aria-current anywhere)', () => {
+    const { container } = renderHero(WITHHELD_VERDICT)
+    expect(container.querySelectorAll('[aria-current]')).toHaveLength(0)
+  })
+
+  /**
+   * THE A11Y LEG. `sr-only` is invisible to sighted users and to a text diff
+   * of the rendered page, which is precisely why it survived four prose
+   * slices — the render probe only caught it because text extraction sees
+   * what a screenshot does not.
+   */
+  it('exposes no designation to a screen reader', () => {
+    const { container } = renderHero(WITHHELD_VERDICT)
+    for (const s of screenReaderStrings(container)) {
+      expect(s, `screen-reader string leaked a designation: "${s}"`).not.toMatch(
+        DESIGNATION_RE,
+      )
+    }
+  })
+
+  /**
+   * The REAL accessible-name computation, over `aria-labelledby` — this is
+   * what a screen reader announces when the row receives focus, and it is
+   * the assertion the sr-only cue actually has to survive. Asserting the
+   * span's absence from the DOM alone would not prove it had stopped
+   * reaching the announced name.
+   */
+  it('announces no designation in any row button accessible name', () => {
+    renderHero(WITHHELD_VERDICT)
+    for (const label of CANONICAL_LABELS) {
+      const row = screen.getByRole('button', { name: new RegExp(label) })
+      expect(row).not.toHaveAccessibleName(/highest/i)
+    }
+  })
+
+  it('does not put the designation in the DOM text either', () => {
+    const { container } = renderHero(WITHHELD_VERDICT)
+    expect(container.textContent ?? '').not.toMatch(/Highest on this view/i)
+  })
+
+  it('DATA PRESERVED: every option is still listed', () => {
+    renderHero(WITHHELD_VERDICT)
+    for (const label of CANONICAL_LABELS) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+    expect(screen.getAllByTestId('hero-row-label')).toHaveLength(3)
+  })
+})
+
+describe('analysis hero — PERMITTED (over-suppression control)', () => {
+  it('renders rows in probability order, exactly as today', () => {
+    const { container } = renderHero(PERMITTED_VERDICT)
+    expect(renderedRowIds(container)).toEqual([...PROBABILITY_IDS])
+  })
+
+  it('still renders the ordinal number tokens 1, 2, 3', () => {
+    renderHero(PERMITTED_VERDICT)
+    const tokens = screen.getAllByTestId('hero-row-number').map((n) => n.textContent?.trim())
+    expect(tokens).toEqual(['1', '2', '3'])
+  })
+
+  it('still crowns the leader with aria-current and the sr-only cue', () => {
+    const { container } = renderHero(PERMITTED_VERDICT)
+    expect(container.querySelectorAll('[aria-current]').length).toBeGreaterThan(0)
+    expect(container.textContent ?? '').toMatch(/Highest on this view/i)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The model's own gate — asserted directly so a regression names the FIELD
+// rather than a rendered symptom three components away.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('HeroChartModel.designationsWithheld', () => {
+  it('is true on the withheld run and nulls every lens leader', () => {
+    const model = heroModel(WITHHELD_VERDICT)
+    expect(model.designationsWithheld).toBe(true)
+    expect(Object.values(model.leaders).every((v) => v == null)).toBe(true)
+  })
+
+  it('is false on the permitted run and keeps the lens leaders', () => {
+    const model = heroModel(PERMITTED_VERDICT)
+    expect(model.designationsWithheld).toBe(false)
+    expect(Object.values(model.leaders).some((v) => v != null)).toBe(true)
+  })
+
+  it('is false when no verdict is supplied (legacy fixtures unchanged)', () => {
+    const model = buildHeroModel(makeHeroData({ options: options() })) as HeroChartModel
+    expect(model.designationsWithheld).toBe(false)
+  })
+})

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -223,11 +223,24 @@ export function buildHeroModel(
   if ((isError && !hasRenderableRows) || recommendation.analysisStatus === 'failed') return statusModel('failed')
   if (recommendation.analysisStatus === 'partial') return statusModel('partial')
 
+  // ROADMAP 1.267 — DESIGNATION vs DATA. On a run whose verdict withholds the
+  // leader claim, ORDER, ORDINALS and the CROWN are designations and go; the
+  // probabilities and every row stay. Read from the verdict the hook already
+  // derived — this surface renders that decision, it never re-derives one
+  // (the same rule that deleted `decisionVerdict`'s Authority 3).
+  //
+  // A caller supplying NO verdict is a legacy fixture, not a withheld run, so
+  // it keeps byte-identical behaviour. The live path always supplies one
+  // (`useResultsSectionData` derives it unconditionally).
+  const designationsWithheld = recommendation.verdict != null && !recommendation.verdict.hasLeadingOption
+
   // Present rows in the SHARED option display order (win probability when
   // complete, else expected — sortOptionsForDisplay) so hero numbering always
   // matches the OptionCards/WinGauge ranking below. Presentation numbering,
   // not graph-node truth; stable across lens switches (asserted in tests).
-  const options = sortOptionsForDisplay(recommendation.allOptions)
+  // WITHHELD: the comparator does not run and `allOptions` arrives in
+  // canonical (graph) order, because the hook skipped its own sort too.
+  const options = sortOptionsForDisplay(recommendation.allOptions, { designationsWithheld })
   // Wave 2 (§6.4): identity-anchored ordinals, all-or-nothing — if ANY row
   // is unregistered every row falls back to the positional index at render
   // (mixing the two schemes in one list could show duplicate numbers).
@@ -917,13 +930,24 @@ export function buildHeroModel(
     defaultLens: goalAvailable ? 'goal' : 'outcome',
     hasConstraints,
     rows,
+    designationsWithheld,
     leaders: {
       // Goal-fit highlight = the goalProbability argmax (UI-SEM-072), the
       // same row the goal-fit headline crowns — never the recommendation
       // re-crowned onto this view. Null when no crown is honest (missing
       // fits, tie at the max, sub-1% floor, no user target).
-      goal: goalLeaderRow?.id ?? null,
-      outcome: outcomeLeaderId,
+      //
+      // ROADMAP 1.267 — and null on EVERY lens when the verdict withholds.
+      // `heroCopy.srLeader` used to argue the per-lens crown was exempt
+      // because it marks "the highest row on the lens in view" rather than
+      // the producer's leader. Row 1.306 overturns that at the screenshots:
+      // an argmax rendered as a filled badge, an emphasised readout,
+      // `aria-current` and a spoken "(Highest on this view)" is a
+      // designation whatever it is derived from, and it reached screen
+      // readers on the same screen as CEE's "no option can be put forward
+      // yet". Suppressing it here is one change point for all four cues.
+      goal: designationsWithheld ? null : goalLeaderRow?.id ?? null,
+      outcome: designationsWithheld ? null : outcomeLeaderId,
       // Stability / What-changed carry no live data (producer gaps 211/212)
       // — no leader can exist on a lens with nothing to lead.
       stability: null,

--- a/src/components/results/analysis-hero/fixtures/galleryModels.ts
+++ b/src/components/results/analysis-hero/fixtures/galleryModels.ts
@@ -46,6 +46,10 @@ function fixtureChart(o: Partial<HeroChartModel>): HeroChartModel {
     defaultLens: 'outcome',
     hasConstraints: false,
     rows: [],
+    // Gallery fixtures illustrate the PERMITTED presentation (that is what
+    // the internal preview is for), so designations are on unless a specific
+    // fixture overrides it.
+    designationsWithheld: false,
     leaders: { goal: null, outcome: null, stability: null, whatChanged: null },
     outcomeDomain: null,
     outcomeRangedRowCount: 0,

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -415,15 +415,36 @@ export const HERO_COPY = {
   /**
    * Screen-reader-only cue so the crowned row is perceivable without colour.
    *
-   * ROADMAP 1.223: was "Leads on this view". REWORDED, deliberately NOT gated
-   * on the leader verdict. The hero's per-lens crown is an ARGMAX over the
-   * data that lens is currently drawing (outcome centre, goal probability) —
-   * it is a property of the view, not the producer's leader designation, and
-   * suppressing it would be the over-suppression class this same roadmap row
-   * had to fix once already in DecisionNode. The wording now states what it
-   * actually marks: the highest row on the lens in view. Note it is sr-only
-   * but NOT invisible to auditing — text extraction sees it, which is how the
+   * ROADMAP 1.223: was "Leads on this view". REWORDED — the wording states
+   * what it marks, the highest row on the lens in view. Note it is sr-only
+   * but NOT invisible to auditing: text extraction sees it, which is how the
    * render probe caught it.
+   *
+   * ⚠ CORRECTED 27 Jul (ROADMAP 1.267). This entry used to continue
+   * "…deliberately NOT gated on the leader verdict", arguing that the
+   * per-lens crown is an ARGMAX over the data the lens is drawing — "a
+   * property of the view, not the producer's leader designation" — and that
+   * suppressing it would be over-suppression.
+   *
+   * THAT REASONING IS OVERTURNED, at the screenshots, in row 1.306. An
+   * argmax rendered as a filled badge, an emphasised readout, `aria-current`
+   * and a spoken label is a DESIGNATION whatever it is derived from, and
+   * this one was being announced to screen-reader users on the same screen
+   * as CEE's own "no option can be put forward yet". Ruling 1.267 draws the
+   * line at designation-vs-data, not at who computed the argmax.
+   *
+   * The STRING is still correct and still used — on a PERMITTED run. It is
+   * now gated at its source: `buildHeroModel` nulls every entry of
+   * `HeroChartModel.leaders` when the verdict withholds, which removes this
+   * cue together with the badge fill, the readout emphasis, the bar colours
+   * and `aria-current` in one place. Pinned by
+   * `__tests__/withheldDesignations.hero.spec.tsx`, including the real
+   * accessible-name computation.
+   *
+   * Kept as a correction rather than a rewrite because the superseded
+   * argument is a good one that was applied to the wrong side of the line —
+   * and a comment that quietly changed its mind would be the stale-label
+   * defect CLAUDE.md trap 14 exists to catch.
    */
   srLeader: 'Highest on this view',
 

--- a/src/components/results/analysis-hero/heroTypes.ts
+++ b/src/components/results/analysis-hero/heroTypes.ts
@@ -203,8 +203,26 @@ export interface HeroChartModel {
    * Row id highlighted per lens. Goal-fit follows the Results Panel's
    * recommended option (never an independent argmax); outcome is the highest
    * existing centre with deterministic first-in-order tie-break.
+   *
+   * ALL NULL when `designationsWithheld` — see below.
    */
   leaders: Record<HeroLens, string | null>
+  /**
+   * True when the run's verdict withholds the leader claim
+   * (`DecisionVerdict.hasLeadingOption === false`), so this model may render
+   * the DATA but none of the DESIGNATIONS (ROADMAP 1.267).
+   *
+   * Concretely, when true: `rows` are in CANONICAL order rather than
+   * probability-descending, `leaders` is all-null (which removes the crown
+   * fill, the readout emphasis, the bar/dot leader colours, `aria-current`
+   * and the sr-only "Highest on this view" cue), and the row ordinal token
+   * is not rendered at all. The probabilities, the readouts and every row
+   * itself are UNCHANGED — the verdict withholds a claim, not the arithmetic.
+   *
+   * `false` when no verdict was supplied (legacy fixtures), which keeps their
+   * behaviour byte-identical: absence of a signal is not a withheld claim.
+   */
+  designationsWithheld: boolean
   /**
    * Outcome-axis display domain (layout only — never displayed as data).
    * Derived from the option outcome values only; the goal threshold is

--- a/src/components/results/selectors/__tests__/analysisDisplaySelector.spec.ts
+++ b/src/components/results/selectors/__tests__/analysisDisplaySelector.spec.ts
@@ -72,7 +72,7 @@ describe('selectDisplayOptions', () => {
     const numbering = assignStableOptionNumbers({}, options.map((o) => o.id))
     const rows = selectDisplayOptions(options, numbering)
     expect(rows.map((r) => r.option.id)).toEqual(
-      sortOptionsForDisplay(options).map((o) => o.id),
+      sortOptionsForDisplay(options, { designationsWithheld: false }).map((o) => o.id),
     )
   })
 

--- a/src/components/results/selectors/analysisDisplaySelector.ts
+++ b/src/components/results/selectors/analysisDisplaySelector.ts
@@ -37,8 +37,15 @@ export interface DisplayOptionRow {
 export function selectDisplayOptions(
   options: readonly OptionResult[],
   numbering: Readonly<Record<string, number>>,
+  /**
+   * ROADMAP 1.267 — see `utils/optionDisplayOrder`. Withheld ⇒ canonical
+   * order and no `displayIndex` designation. Defaulted rather than required
+   * because this selector has no live call site today (only Wave 2/4 plans
+   * and its own spec); the live surfaces pass the flag explicitly.
+   */
+  { designationsWithheld = false }: { designationsWithheld?: boolean } = {},
 ): DisplayOptionRow[] {
-  return sortOptionsForDisplay(options).map((option, i) => ({
+  return sortOptionsForDisplay(options, { designationsWithheld }).map((option, i) => ({
     option,
     displayIndex: i + 1,
     stableNumber: numbering[option.id] ?? null,

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1536,6 +1536,40 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       backendRecommendedId
     )
 
+    // SINGLE VERDICT (2026-07-25): the ONE answer to "is there a leading
+    // option?", derived from the SAME `report` object the canvas reads — not
+    // re-derived from this hook's mapped fields, so canvas and panel cannot
+    // drift apart. Every surface asserting or denying a leading option quotes
+    // this. See src/lib/decisionVerdict.ts.
+    //
+    // HOISTED above the display sort (ROADMAP 1.267): the ordering decision
+    // needs the verdict, and the verdict needs only `report` / `optionNodes` /
+    // `rawHeadlineBanded`, all of which are already in scope here. Computed
+    // ONCE and returned as `verdict` below — deriving it twice would be a
+    // second authority, which is the defect decisionVerdict exists to prevent.
+    const leaderVerdict = deriveDecisionVerdict(
+      report as DecisionVerdictReportLike | null | undefined,
+      {
+        visibleOptionIds: new Set(optionNodes.map((n) => n.id)),
+        rawHeadlineBanded,
+      },
+    )
+
+    // ROADMAP 1.267 — THE ORDER DESIGNATION IS AUTHORED HERE.
+    //
+    // This line is where the CANONICAL order dies. `unsortedOptions` is
+    // built from `optionNodes` (`nodes.filter(kind === 'option')`), i.e. the
+    // canvas graph's own option order — the user's creation order. Every
+    // downstream surface re-sorts `allOptions`, but they were all re-sorting
+    // an array that had ALREADY been ranked here, so gating only the leaf
+    // call sites would have changed nothing. The canonical order has to
+    // survive this line or it is not available to anyone.
+    //
+    // Derived ONCE, here, and passed to the leaf sorts via `allOptions`
+    // already being canonical — plus explicitly to each of them, so a leaf
+    // cannot silently re-impose a ranking.
+    const designationsWithheld = !leaderVerdict.hasLeadingOption
+
     // Order by the SHARED display sort (win probability when every option
     // carries one, else expected value — sortOptionsForDisplay), independent
     // of winner selection. This must be the same comparator the rendering
@@ -1544,7 +1578,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     // seeded from an expected-value order while every list sorted by win
     // probability — one metric per surface, so allOptions order, ordinal
     // registration order and row order must be one.
-    const sortedOptions = sortOptionsForDisplay(unsortedOptions)
+    const sortedOptions = sortOptionsForDisplay(unsortedOptions, { designationsWithheld })
 
     // Task 2.1: Resolve baseline option with precedence (PLoT > user > heuristic)
     // Note: userSelectedBaselineId would come from state if we add baseline selection UI
@@ -1733,15 +1767,10 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       baselineOutcome,
       // Near-tie detection: when top options are too close to call
       nearTie,
-      // SINGLE VERDICT (2026-07-25): the ONE answer to "is there a leading
-      // option?", derived from the SAME `report` object the canvas reads —
-      // not re-derived from this hook's mapped fields, so canvas and panel
-      // cannot drift apart. Every surface asserting or denying a leading
-      // option quotes this. See src/lib/decisionVerdict.ts.
-      verdict: deriveDecisionVerdict(report as DecisionVerdictReportLike | null | undefined, {
-        visibleOptionIds: new Set(optionNodes.map((n) => n.id)),
-        rawHeadlineBanded,
-      }),
+      // SINGLE VERDICT — derived once above (hoisted so the display sort can
+      // read it too, ROADMAP 1.267) and quoted here. One derivation, one
+      // answer, no mirror.
+      verdict: leaderVerdict,
       // Task 6: Flip thresholds for tipping points visualisation
       flipThresholds: flipThresholds.length > 0 ? flipThresholds : undefined,
       // Display-honesty: PLoT-side classification of flip_thresholds[].
@@ -3127,7 +3156,18 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
   // already carries that order, but first-seen ordinals are frozen forever,
   // so the seeding order must be guaranteed at the registration site, not
   // inherited): badge numbers then match the order every list renders in.
-  const optionIds = sortOptionsForDisplay(recommendation.allOptions).map((o) => o.id)
+  //
+  // ROADMAP 1.267 — AND THE SEEDING ORDER IS ITSELF A DESIGNATION. Because
+  // first-seen ordinals are frozen FOREVER, seeding them from a probability
+  // sort means `Option 1` permanently records who led on the very first run.
+  // "Identity-anchored" only ever meant stable against LATER rank flips, not
+  // free of the first ranking. So a withheld first run seeds in canonical
+  // order — otherwise this slice would suppress the badge on the withheld
+  // screen while quietly minting the same designation into a store that a
+  // later permitted run then displays.
+  const optionIds = sortOptionsForDisplay(recommendation.allOptions, {
+    designationsWithheld: recommendation.verdict != null && !recommendation.verdict.hasLeadingOption,
+  }).map((o) => o.id)
   const optionIdsKey = JSON.stringify(optionIds)
   useEffect(() => {
     if (optionIds.length === 0) return

--- a/src/components/results/utils/__tests__/optionDisplayOrder.spec.ts
+++ b/src/components/results/utils/__tests__/optionDisplayOrder.spec.ts
@@ -26,7 +26,7 @@ describe('sortOptionsForDisplay', () => {
       { id: 'opt_status_quo', winProbability: 0.3795, expected: -0.018 },
       { id: 'opt_hire_fulltime', winProbability: 0.38725, expected: -0.367 },
     ]
-    expect(ids(sortOptionsForDisplay(options))).toEqual([
+    expect(ids(sortOptionsForDisplay(options, { designationsWithheld: false }))).toEqual([
       'opt_hire_fulltime',
       'opt_status_quo',
       'opt_virtual',
@@ -42,7 +42,7 @@ describe('sortOptionsForDisplay', () => {
       { id: 'b', winProbability: Number.NaN, expected: 30 },
       { id: 'c', winProbability: 0.1, expected: 20 },
     ]
-    expect(ids(sortOptionsForDisplay(options))).toEqual(['b', 'c', 'a'])
+    expect(ids(sortOptionsForDisplay(options, { designationsWithheld: false }))).toEqual(['b', 'c', 'a'])
   })
 
   it('falls back to expected descending when ANY option lacks win probability (no fabricated ranking)', () => {
@@ -51,7 +51,7 @@ describe('sortOptionsForDisplay', () => {
       { id: 'b', winProbability: null, expected: 30 },
       { id: 'c', winProbability: 0.1, expected: 20 },
     ]
-    expect(ids(sortOptionsForDisplay(options))).toEqual(['b', 'c', 'a'])
+    expect(ids(sortOptionsForDisplay(options, { designationsWithheld: false }))).toEqual(['b', 'c', 'a'])
   })
 
   it('uses goalProbability as the expected fallback, and -Infinity last', () => {
@@ -60,7 +60,7 @@ describe('sortOptionsForDisplay', () => {
       { id: 'b', expected: null, goalProbability: 0.6 },
       { id: 'c', expected: null, goalProbability: null },
     ]
-    expect(ids(sortOptionsForDisplay(options))).toEqual(['b', 'a', 'c'])
+    expect(ids(sortOptionsForDisplay(options, { designationsWithheld: false }))).toEqual(['b', 'a', 'c'])
   })
 
   it('keeps input order on ties (stable sort — deterministic numbering)', () => {
@@ -69,7 +69,7 @@ describe('sortOptionsForDisplay', () => {
       { id: 'second', winProbability: 0.5 },
       { id: 'third', winProbability: 0.5 },
     ]
-    expect(ids(sortOptionsForDisplay(options))).toEqual(['first', 'second', 'third'])
+    expect(ids(sortOptionsForDisplay(options, { designationsWithheld: false }))).toEqual(['first', 'second', 'third'])
   })
 
   it('does not mutate the input array and handles empty input', () => {
@@ -78,8 +78,8 @@ describe('sortOptionsForDisplay', () => {
       { id: 'b', winProbability: 0.9 },
     ]
     const before = [...options]
-    sortOptionsForDisplay(options)
+    sortOptionsForDisplay(options, { designationsWithheld: false })
     expect(options).toEqual(before)
-    expect(sortOptionsForDisplay([])).toEqual([])
+    expect(sortOptionsForDisplay([], { designationsWithheld: false })).toEqual([])
   })
 })

--- a/src/components/results/utils/optionDisplayOrder.ts
+++ b/src/components/results/utils/optionDisplayOrder.ts
@@ -14,12 +14,64 @@
  * stable, so ties keep the caller's presentation order (deterministic
  * with allOptions[] input). Selection/ordering of existing producer
  * values only — no new values are computed.
+ *
+ * ## ORDER IS A DESIGNATION (ROADMAP 1.267)
+ *
+ * Ruled 27 Jul, ratified as Codex decision (1) in ROADMAP row 1.306:
+ * probability-descending order is not a neutral presentation choice, it is a
+ * CLAIM about which option is first — "position-as-designation", the same
+ * defect CEE PR #719 fixed on the producer side by canonicalising
+ * `decision_brief.options[]`. On a run whose verdict WITHHOLDS, the honest
+ * order is the CANONICAL one (the caller's own array, which on the live path
+ * is graph/creation order from `nodes.filter(kind === 'option')`), and the
+ * probabilities keep rendering unchanged because the DATA is not withheld —
+ * only the CLAIM.
+ *
+ * This corrects a documented assumption. `OptionCardsProps.hasLeadingOption`
+ * used to say `winnerId` "still drives segment colours, the lens crown and
+ * card ordering, none of which claim anything"; row 1.306 records the
+ * confirming screenshots and names it directly — "the G-UI-1 closure treated
+ * client-side ordering as benign when it is the designation channel".
+ *
+ * ## Why the second parameter is REQUIRED
+ *
+ * Every option list on the results path funnels through this function, so it
+ * is the one place the order designation is authored — and a hand-maintained
+ * list of "call sites that remembered to gate" is exactly the mirror defect
+ * that drifts silently (CLAUDE.md trap 12). Making the answer mandatory means
+ * a new call site cannot inherit the designation by forgetting: omitting it
+ * is a TYPE ERROR, not a silent regression. Same move `decisionVerdict` made
+ * by deleting `'win_probability'` from its `source` union.
  */
 import type { OptionResult } from '../types'
 
 type DisplayOrderFields = Pick<OptionResult, 'winProbability' | 'expected' | 'goalProbability'>
 
-export function sortOptionsForDisplay<T extends DisplayOrderFields>(options: readonly T[]): T[] {
+export interface DisplayOrderOptions {
+  /**
+   * True when the run's verdict withholds the leader claim — i.e.
+   * `DecisionVerdict.hasLeadingOption === false`, the single boolean
+   * `src/lib/decisionVerdict.ts` documents as the one every surface gates on.
+   *
+   * Callers RENDER this decision, they never re-derive it: each call site
+   * reads the verdict it already holds. A caller with no verdict at all
+   * (legacy fixtures predating the shared verdict) passes `false` and keeps
+   * byte-identical legacy behaviour — absence of a signal is not a withheld
+   * claim, and the one live path always supplies one.
+   */
+  designationsWithheld: boolean
+}
+
+export function sortOptionsForDisplay<T extends DisplayOrderFields>(
+  options: readonly T[],
+  { designationsWithheld }: DisplayOrderOptions,
+): T[] {
+  // WITHHELD: no comparator runs at all. Returning the caller's own order
+  // (rather than sorting by some other key) is the point — any sort this
+  // module could apply would be a second designation wearing a different
+  // number. The copy keeps callers free to mutate the result as before.
+  if (designationsWithheld) return [...options]
+
   // Number.isFinite (not `!= null`): a NaN winProbability would pass the
   // null check, poison the comparator (NaN ?? 0 stays NaN), and make the
   // order arbitrary — mixed/invalid coverage must fall back to expected.

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -109,7 +109,19 @@ function driverDirection(d: DriverItem): 'positive' | 'negative' | null {
 export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
   const { recommendation, drivers, confidence } = data
   const options = recommendation.allOptions ?? []
-  const winnerId = recommendation.recommendedOption?.id
+  // ROADMAP 1.267. `winnerId` drives the ONLY thing the V7 rows do with a
+  // leader: bold + darken that row's label and readout
+  // (`V7LensGroup.tsx`). On a withheld run the V7 HEADLINE above these rows
+  // already goes silent (`buildV7Headline` returns '' on an `unknown`
+  // verdict, ROADMAP 1.223) — which left a bolded, designated option sitting
+  // under a deliberately empty hero, the emphasis making the claim the
+  // sentence had just been withdrawn. Withholding the id here is one change
+  // point for every `isWinner` style in the group.
+  //
+  // `options` needs no separate treatment: it is `recommendation.allOptions`,
+  // which the hook now leaves in canonical order on a withheld run.
+  const designationsWithheld = recommendation.verdict != null && !recommendation.verdict.hasLeadingOption
+  const winnerId = designationsWithheld ? undefined : recommendation.recommendedOption?.id
 
   // ── Likely outcome ─────────────────────────────────────────────────────
   const hasRange = options.some(


### PR DESCRIPTION
## The defect

On a run whose verdict **withholds** the leader claim, the results UI kept designating one — through channels no prose matcher could see. CEE returns `leading_option_id: null`, `may_name_leading_option: false`, and prose saying no option can be put forward; the UI then sorted the options by win probability, numbered them 1/2/3, filled the leader's badge, emphasised its readout, set `aria-current`, and appended a visually-hidden **"(Highest on this view)"** — so a screen-reader user was told which option was highest on the same screen as *"no option can be put forward yet."*

Confirmed with live screenshots in the Codex arc review (ROADMAP row 1.306, P1).

> **Two commits:** the fix, then a comment-only correction to a `heroCopy.ts` note this PR makes false. See *Overlap* at the end.

## Doctrine: applied, not invented

**ROADMAP 1.267** (ruled 27 Jul) is the stopping criterion for the leader family:

> computed probabilities are **DATA** the user is entitled to; `rank == 1`, probability-descending order, ordinals, crowns and accessible "highest" labels are **DESIGNATIONS** — claims wearing numbers. On a withheld run, **data stays, designations go.**

Row 1.306 records Paul's ratification of Codex decision (1): *"withheld prohibits designation on EVERY surface incl. sorting/a11y — RATIFY (1.267 already says it)"*. CEE PR **#719** already applied this on the producer side (`rank` gated, `decision_brief.options[]` canonicalised, probabilities kept). **This is the consumer half.** No new policy.

The gate is the boolean that already exists: `DecisionVerdict.hasLeadingOption` from `src/lib/decisionVerdict.ts`. Nothing new is derived — consumers render the decision, they never re-derive one, which is the same rule that deleted that module's Authority 3.

## Two documented assumptions this PR REVERSES

Both were written in good faith and both were wrong. Row 1.306 names the first directly: *"the G-UI-1 closure treated client-side ordering as benign when it is the designation channel."*

1. **`OptionCardsProps.hasLeadingOption`** said `winnerId` *"still drives segment colours, the lens crown and card ordering, **none of which claim anything**."* It does claim. Corrected in-file, and at the `ResultsBody` call site that repeated it.
2. **`heroCopy.srLeader`** carried a comment arguing the cue was *deliberately* exempt because the crown is a per-lens argmax — *"a property of the view, not the producer's leader designation."* An argmax rendered as a filled badge, an emphasised readout, `aria-current` and a spoken label is a designation whatever it is derived from. The string itself is untouched (it is correct on a permitted run); it is now gated.

## Surface inventory — swept beyond the three Codex named

A full sweep of the results render path (staging flags on: `V7TopMatter` → `AnalysisHeroPanel` → `WinGauge` → `OptionCards`, four passes over the same options).

### Fixed in this PR

| # | Surface | File | Designation | Disposition on withheld |
|---|---|---|---|---|
| 1 | **Shared comparator** | `utils/optionDisplayOrder.ts` | win-prob descending sort | canonical order; **2nd arg now REQUIRED** |
| 2 | **Order authored at source** | `useResultsSectionData.ts:~1547` | `allOptions` emitted pre-sorted | canonical order preserved out of the hook |
| 3 | **Stable-ordinal seeding** | `useResultsSectionData.ts:~3168` | first-seen ordinals **frozen forever** in prob order | seeded canonically |
| 4 | Hero row order | `buildHeroModel.ts:~230` | re-sort | canonical |
| 5 | Hero ordinal token | `HeroOptionRow.tsx:~213` | `stableNumber ?? index` | not rendered (layout placeholder keeps the grid) |
| 6 | Hero crown fill | `HeroOptionRow.tsx:~215` | filled badge | via `leaders: null` |
| 7 | Hero readout emphasis | `HeroOptionRow.tsx:~236` | `text-text-header` | via `leaders: null` |
| 8 | Hero bar/dot leader colour | `HeroOptionRow.tsx:~258–308` | `HERO_BAR_FILL.leader` | via `leaders: null` |
| 9 | **Hero `aria-current`** | `HeroOptionRow.tsx:~324,332` | a11y | via `leaders: null` |
| 10 | **Hero sr-only "(Highest on this view)"** | `HeroOptionRow.tsx:~230` | **a11y** | via `leaders: null` |
| 11 | Card order | `OptionCards.tsx:~637` | re-sort | canonical |
| 12 | Card rank swatch | `OptionCards.tsx:~398` | `WIN_GAUGE_COLORS[rank-1]`, `[0]` commented "Winner" | not rendered |
| 13 | Card rank fallback chain | `OptionCards.tsx:~377` | `sortedRank ?? option.rank ?? (isWinner ? 1 : …)` — three ordinals stacked | suppressed above the whole chain |
| 14 | Card crowned border | `OptionCards.tsx:~373` | `border-success/30` | neutral border |
| 15 | Card fill-bar colour | `OptionCards.tsx:~459` | rank palette | **bar kept**, one neutral colour |
| 16 | `StatBar isLeader` | `OptionCards.tsx:~494` | leader colour | **bar kept**, leader colour off |
| 17 | **WinGauge segment order** | `WinGauge.tsx:~143` | winner-first sort + green `[0]` | canonical order; colours track position, not rank |
| 18 | **V7 lens group emphasis** | `v7/buildV7Lenses.ts:~112` | bold/darken winner row | `winnerId` withheld |
| 19 | Shared display selector | `selectors/analysisDisplaySelector.ts` | `displayIndex` | threaded |

Surface 18 was the sharpest find of the sweep: `V7TopMatter` is **flagless** (always mounted), its headline already goes silent on a withheld verdict via #491 — so a bolded, designated option was sitting under a deliberately empty hero, the emphasis making the claim the sentence had just withdrawn.

Surfaces 2 and 3 are why gating the leaf sorts alone would have been theatre: `allOptions` was **already ranked** before any component saw it, and the "identity-anchored" ordinals were seeded from that ranking and **frozen permanently** — so a withheld first run would have minted the designation into the store for a later permitted run to display.

### Found ungated, NOT fixed here (out of scope — prose/other families, reported for triage)

`v7LensCopy` "leading option" strings · hero evidence-disclosure flip-risk copy · `ResultsBody` flip-threshold sentences · `StressTestSection` "switch your recommendation from X to Y" · `certaintyCopy` legacy `verdict: undefined` hole (fixture-only; the live caller always passes it) · `V5AnalysisResultBlock` leader-first sort (gated implicitly by `leading_option_id` null, not wired to `deriveDecisionVerdict`) · the flag-OFF `buildAnalysisHeroViewModel` / `TriageActionCardsBody` path.

## Why the comparator's second argument is REQUIRED

A hand-maintained list of "call sites that remembered to gate" is exactly the mirror defect that drifts silently (CLAUDE.md trap 12). Making the answer mandatory means a new call site cannot inherit the designation by forgetting — omitting it is a **type error**. The gate proved this immediately: it went red on five un-updated call sites, all fixed at source, none absorbed into a baseline.

`designationsWithheld` is `false` when **no** verdict is supplied (legacy fixtures) — absence of a signal is not a withheld claim, and the live path always supplies one.

## RED-first

`11 failed | 10 passed` before the fix. Every positive control passed on the unfixed tree (byte-identical behaviour proven, not assumed); every withheld leg failed.

```
 × sortOptionsForDisplay — WITHHELD: preserves canonical order (no probability sort)
 × analysis hero — WITHHELD > renders rows in canonical order, not probability order
 × analysis hero — WITHHELD > renders no ordinal number token
 × analysis hero — WITHHELD > crowns no row (no aria-current anywhere)
 × analysis hero — WITHHELD > exposes no "Highest" designation to a screen reader
 × analysis hero — WITHHELD > does not put the designation in the DOM text either
 × OptionCards — WITHHELD: cards follow canonical order
 × OptionCards — WITHHELD: renders no rank marker
 × HeroChartModel.designationsWithheld > is true on the withheld run and nulls every lens leader
 ✓ analysis hero — PERMITTED > renders rows in probability order, exactly as today
 ✓ analysis hero — PERMITTED > still renders the ordinal number tokens 1, 2, 3
 ✓ analysis hero — PERMITTED > still crowns the leader with aria-current and the sr-only cue
```

**The a11y leg**, which is the one that had never been asserted:

```js
it('announces no designation in any row button accessible name', () => {
  renderHero(WITHHELD_VERDICT)
  for (const label of CANONICAL_LABELS) {
    const row = screen.getByRole('button', { name: new RegExp(label) })
    expect(row).not.toHaveAccessibleName(/highest/i)
  }
})
```

`toHaveAccessibleName` runs the **real** name computation over `aria-labelledby` — asserting the sr-only span's absence from the DOM alone would not have proved it had stopped reaching the announced name. Its RED message quotes the leak verbatim: `screen-reader string leaked a designation: " (Highest on this view)"`.

## Anti-vacuity: three options, reversed order

The CEE lane that shipped #719 caught its own route fixture being vacuous — on a two-option graph the leader sorts first anyway, so the order assertion could never have gone red. This fixture declares options in canonical order LOW → MID → HIGH with win probabilities 0.10 / 0.30 / 0.60, so **canonical order is the exact reverse of probability order**. An implementation that neutralises nothing, and one that sorts ascending by accident, both fail. A guard test asserts the two orders differ and that the verdict pair actually discriminates.

## Mutation verdicts (throwaway worktree OUTSIDE the repo root, removed before every gate run)

| Mutation | Verdict | Tests that went RED |
|---|---|---|
| Revert **order neutralisation** alone | 🔴 **RED (3)** | *"preserves canonical order (no probability sort)"*, *"renders rows in canonical order"*, *"cards follow canonical order"* — **names the sort** |
| Revert **a11y/crown removal** alone | 🔴 **RED (5)** | *"exposes no designation to a screen reader"*, *"announces no designation in any row button accessible name"*, *"crowns no row"*, *"does not put the designation in the DOM text"*, *"nulls every lens leader"* — **names the label** |
| Revert **ordinal suppression** alone | 🔴 **RED (2)** | *"renders no ordinal number token"*, *"renders no rank marker"* |

Three disjoint RED sets — each leg is independently pinned, and no leg is carried by another.

## Positive controls (over-suppression)

- PERMITTED renders ranked / ordinal-numbered / crowned / labelled **exactly as today** — asserted green on the unfixed tree first.
- WITHHELD keeps the **probabilities**: `sortOptionsForDisplay` returns every option and every value (asserted id-keyed so the leg cannot pass or fail for an ordering reason); the hero lists all three rows; the cards still render the win-probability bar.
- The fill bar was the near-miss: `neutralised` already suppressed the border, swatch and StatBar colour, but it also **drops the bar entirely** — reusing it would have deleted a computed fact the ruling explicitly protects. A separate flag was introduced rather than saving one.

## Two existing specs corrected at source (never absorbed)

`useResultsSectionData.optionRankCoherence` and `firstRunNumbering.rankCoherence` pin **badge-metric == sort-metric coherence** — a property of a *permitted* run. Their fixtures carried no producer leader claim, so post-1.267 they had silently become *withheld*-run tests asserting the old order. Fixed by giving each fixture PLoT's own `near_tie` verdict (passed through verbatim by the V2 mapper), restoring what they were written to test. **No baseline was regenerated and nothing was quarantined.**

The `analysis-hero/inertness.spec` architecture guard also fired correctly on the first draft of the new spec, which imported the hero from `results/__tests__/`. The spec was **split** to respect the rule, not exempted — the hero half now lives inside the module, both halves driving one shared fixture.

## Claim-drift walker: does NOT apply, and this is the walker-v2 designation-leg gap

`CLAIM_OWNERSHIP` registers `{ family, rawFields, callInstead }` and the walker polices reads of **raw producer field NAMES** (`goal_probability`, `probability_of_joint_goal`, …). These designation surfaces read *already-selected* values off the mapped `OptionResult` (`option.winProbability`) — no raw field name appears. That is item 4 of the walker's own declared `UNDETECTABLE` list: *"re-derivation from already-selected values (no raw field name appears)"*.

So registering this family would have produced a detector in prose only — the exact defect CEE's #719 lane avoided three files away when it kept the ordinal family separate from the leader-key family. **Not forced.** Flagged as the walker-v2 designation leg: it needs a different instrument (order/ordinal/a11y are render-shape properties, not field reads). The existing walker spec still passes 11/11 and its baseline is untouched.

## Gates

| Gate | Result |
|---|---|
| `scripts/ci/typecheck-gate.sh` | **3009/3027 files; 629 files / 2541 errors — byte-identical to the pristine control** |
| Typecheck baseline | **not regenerated** (`scripts/ci/typecheck-baseline.txt` untouched) |
| `eslint` (changed files) | 0 errors, 2 warnings — **both present on pristine**, in untouched regions |
| Claim-drift baseline | untouched; spec 11/11 |
| Vitest (by directory, `VITE_SUPABASE_*` set) | **5913 passed, 0 failed** |

Suite totals: `results/__tests__` 2321 · `analysis-hero` 312 · `utils` 310 · `selectors` 16 · `v7` 76 · `strengthen` 133 · `coaching` 9 · `modals` 101 · `decision-overview` 73 · `analysisHeroV17` 305 · `lib` 1491 · `v5/__tests__` 639 · `v5/blocks` 127.

### Pre-existing gate red, NOT introduced here

The typecheck ratchet exits 1 on `ReactFlowGraph.tsx` (12→13) and `SignedStrengthSlider.stories.tsx` (1→4). **Verified pre-existing**: a pristine `--depth 1` clone of `staging` at `032901c8` with no changes produces the *identical* two files, identical counts and identical totals. Consistent with the known "staging cannot pass its own pre-push gate" condition. Not fixed here, and deliberately **not** papered over with `--update-baseline` — that would have silently accepted the shrink.

## Browser walk (post-merge, for the orchestrator)

`acceptance-evidence/withheld-designations-20260727/walk-withheld-designations.mjs`

jsdom proves DOM order, accessible names and presence — never layout (CLAUDE.md trap 3). The script drives a draft + analysis on deployed staging, reads all surfaces from a single render, and **dumps the full screen-reader accessibility tree to disk on every run, pass or fail** — the defect was invisible to a screenshot, so the tree is the artefact, not just the exit code. It **classifies the run from the page itself** and asserts the matching leg set; a run it cannot classify exits **2 (INCONCLUSIVE)**, never 0, because a walk that cannot tell which run it saw must not report a pass.

## Overlap

Rebased onto `032901c8`. Both PRs the brief flagged have **merged**: the partial-drop slice (#499, `adapters/plot/v2/`) was already in my base tip; Slice −1 (#500) merged mid-lane and touches three files I also edit (`buildHeroModel.ts`, `galleryModels.ts`, `heroCopy.ts`) — I rebased onto it rather than working around it, and the rebase was clean.

**No `heroCopy.ts` STRING is changed.** The sr-only cue is correct on a permitted run, so it is gated at `buildHeroModel.leaders` rather than reworded — Slice −1's copy work is untouched. The one edit to that file is **comment-only** (second commit): the `srLeader` entry carried a note saying it was *"deliberately NOT gated on the leader verdict"*, which this PR makes false. Left as written it would have been a stale label asserting the opposite of the behaviour — CLAUDE.md trap 14, the defect class where an honest label is overwritten (or, here, outlived) by a false one. Corrected in place, with the superseded argument preserved rather than deleted.

Against currently-open PRs: only **#115** (`OptionCards.tsx`) and **#116** (`ResultsBody.tsx`) share a file, both dormant since March 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
