### PR TITLE
fix(plot-v2): refuse a PARTIAL intervention drop, so an option cannot be analysed with fewer effects than the canvas holds

### DIFF
--- a/src/adapters/plot/v2/__tests__/partialInterventionDrop.spec.ts
+++ b/src/adapters/plot/v2/__tests__/partialInterventionDrop.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * PARTIAL intervention drop on the PRIMARY run path.
+ *
+ * PR #499 closed the two hops that could put a NON-FINITE value ON the wire,
+ * and stated the residual gap in its own section 4b: on the primary run path
+ * (`buildV2RequestFromAnalysisReady` → `ceeOptionToV2Option` →
+ * `flattenInterventions`) an option carrying ONE unusable entry alongside
+ * valid ones is silently reduced. The wire stays valid, so PLoT never
+ * complains — and the user is handed a confident answer to a question they
+ * did not ask.
+ *
+ * House doctrine, ruled twice on 26 Jul (PLoT ingress + UI #499): what gets
+ * analysed is never silently altered. A partial drop is the purest form of
+ * that violation, because nothing anywhere reports it.
+ *
+ * TWO DROP SITES, not one. #499 named only the first. The second is upstream
+ * of it and would have survived a fix aimed solely at `ceeOptionToV2Option`:
+ *
+ *   SITE A — `ceeOptionToV2Option` (adapter.ts). Reached when
+ *     `reconcileOptionsWithCanvasNodes` passes an analysis_ready option
+ *     through as-is (its PRIMARY hot path, taken whenever the option has at
+ *     least one usable intervention). The unusable siblings survive
+ *     reconciliation and die at the flatten.
+ *
+ *   SITE B — `reconcileOptionsWithCanvasNodes` itself, on BOTH canvas-backfill
+ *     branches. Each calls `flattenInterventions(node.data.interventions)`
+ *     BEFORE `canvasInterventionsToCEE`, so unusable entries are already gone
+ *     by the time any downstream consumer — including the pre-run gate — sees
+ *     the option. A fix at site A alone cannot see these at all.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import {
+  ceeOptionToV2Option,
+  buildV2RequestFromAnalysisReady,
+  reconcileOptionsWithCanvasNodes,
+  reconcileOptionsWithCanvasNodesDetailed,
+  InterventionValidationError,
+  flattenInterventions,
+} from '../adapter'
+import type { CEEOptionV3 } from '../../../../types/options'
+// `CanvasNodeData` is module-local to adapter.ts, so the fixtures below use the
+// permissive node/edge generics the sibling adapter specs use.
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** The defect shape: one good entry, one authored-but-unusable entry. */
+function partialOption(): CEEOptionV3 {
+  return {
+    id: 'opt_partial',
+    label: 'Raise price',
+    status: 'ready',
+    interventions: {
+      fac_good: { value: 0.4, source: 'brief_extraction' },
+      // Authored — the key names a real target — but carries no usable value.
+      // `flattenInterventions` drops it and says nothing.
+      fac_bad: { value: null as unknown as number, source: 'brief_extraction' },
+    },
+  }
+}
+
+function allValidOption(): CEEOptionV3 {
+  return {
+    id: 'opt_valid',
+    label: 'Hold price',
+    status: 'ready',
+    interventions: {
+      fac_good: { value: 0.4, source: 'brief_extraction' },
+      fac_zero: { value: 0, source: 'brief_extraction' },
+    },
+  }
+}
+
+function allBadOption(): CEEOptionV3 {
+  return {
+    id: 'opt_allbad',
+    label: 'Cut price',
+    status: 'ready',
+    interventions: {
+      fac_bad: { value: null as unknown as number, source: 'brief_extraction' },
+      fac_worse: { value: 'tbd' as unknown as number, source: 'brief_extraction' },
+    },
+  }
+}
+
+const NODES: Node<any>[] = [
+  { id: 'goal_1', type: 'goal', data: { label: 'Profit', kind: 'goal' } as any, position: { x: 0, y: 0 } },
+  { id: 'fac_good', type: 'factor', data: { label: 'Unit margin', kind: 'factor' } as any, position: { x: 0, y: 100 } },
+  { id: 'fac_bad', type: 'factor', data: { label: 'Customer churn', kind: 'factor' } as any, position: { x: 0, y: 200 } },
+  { id: 'fac_zero', type: 'factor', data: { label: 'Volume', kind: 'factor' } as any, position: { x: 0, y: 300 } },
+  { id: 'fac_worse', type: 'factor', data: { label: 'Brand risk', kind: 'factor' } as any, position: { x: 0, y: 400 } },
+]
+
+const EDGES: Edge<any>[] = [
+  { id: 'e1', source: 'fac_good', target: 'goal_1', data: { weight: 0.5 } as any },
+]
+
+function optionNode(id: string, label: string, interventions: Record<string, unknown>): Node<any> {
+  return {
+    id,
+    type: 'option',
+    data: { label, kind: 'option', interventions } as any,
+    position: { x: 500, y: 0 },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SITE A — ceeOptionToV2Option
+// ---------------------------------------------------------------------------
+
+describe('SITE A — ceeOptionToV2Option must not silently shrink an option', () => {
+  it('REFUSES an option whose interventions include an authored-but-unusable entry', () => {
+    expect(() => ceeOptionToV2Option(partialOption())).toThrow(InterventionValidationError)
+  })
+
+  it('names the dropped target and the option in the refusal', () => {
+    let caught: unknown
+    try {
+      ceeOptionToV2Option(partialOption())
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InterventionValidationError)
+    const err = caught as InterventionValidationError
+    expect(err.code).toBe('INVALID_INTERVENTION_VALUE')
+    expect(err.optionId).toBe('opt_partial')
+    expect(err.invalidTargets).toEqual(['fac_bad'])
+    expect(err.message).toContain('Raise price')
+    expect(err.message).toContain('fac_bad')
+  })
+
+  it('POSITIVE CONTROL — an all-valid option is converted unchanged, including 0', () => {
+    const v2 = ceeOptionToV2Option(allValidOption())
+    expect(v2).toEqual({
+      id: 'opt_valid',
+      label: 'Hold price',
+      interventions: { fac_good: 0.4, fac_zero: 0 },
+    })
+  })
+
+  it('POSITIVE CONTROL — an option with NO interventions at all is still converted, not refused (the empty case belongs to the pre-run gate)', () => {
+    const v2 = ceeOptionToV2Option({ id: 'o', label: 'L', status: 'ready', interventions: {} })
+    expect(v2.interventions).toEqual({})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SITE B — reconcileOptionsWithCanvasNodes canvas-backfill branches
+// ---------------------------------------------------------------------------
+
+describe('SITE B — the canvas-backfill branches must report what they filtered', () => {
+  it('canvas-only option: reports the unusable target instead of silently flattening it away', () => {
+    const nodes = [...NODES, optionNode('opt_canvas', 'Canvas option', { fac_good: 0.5, fac_bad: { value: null } })]
+    const { options, unusableByOptionId } = reconcileOptionsWithCanvasNodesDetailed(
+      null,
+      nodes,
+      new Set(nodes.map((n) => n.id)),
+      { silent: true },
+    )
+    // The usable entry still flows (behaviour preserved) …
+    const opt = options.find((o) => o.id === 'opt_canvas')!
+    expect(Object.keys(opt.interventions)).toEqual(['fac_good'])
+    // … and the dropped one is now VISIBLE.
+    expect(unusableByOptionId.get('opt_canvas')).toEqual(['fac_bad'])
+  })
+
+  it('analysis_ready option backfilled from its canvas node: reports the unusable target', () => {
+    const nodes = [...NODES, optionNode('opt_ar', 'AR option', { fac_good: 0.5, fac_bad: { value: 'tbd' } })]
+    const analysisReady = {
+      goal_node_id: 'goal_1',
+      status: 'ready',
+      // empty interventions → forces the backfill branch
+      options: [{ id: 'opt_ar', label: 'AR option', status: 'ready', interventions: {} }],
+    } as any
+    const { unusableByOptionId } = reconcileOptionsWithCanvasNodesDetailed(
+      analysisReady,
+      nodes,
+      new Set(nodes.map((n) => n.id)),
+      { silent: true },
+    )
+    expect(unusableByOptionId.get('opt_ar')).toEqual(['fac_bad'])
+  })
+
+  it('primary pass-through branch: reports the unusable sibling that ceeOptionToV2Option would later drop', () => {
+    const nodes = [...NODES, optionNode('opt_partial', 'Raise price', {})]
+    const analysisReady = { goal_node_id: 'goal_1', status: 'ready', options: [partialOption()] } as any
+    const { unusableByOptionId } = reconcileOptionsWithCanvasNodesDetailed(
+      analysisReady,
+      nodes,
+      new Set(nodes.map((n) => n.id)),
+      { silent: true },
+    )
+    expect(unusableByOptionId.get('opt_partial')).toEqual(['fac_bad'])
+  })
+
+  it('POSITIVE CONTROL — an all-valid graph reports NOTHING unusable', () => {
+    const nodes = [...NODES, optionNode('opt_canvas', 'Canvas option', { fac_good: 0.5, fac_zero: 0 })]
+    const { unusableByOptionId } = reconcileOptionsWithCanvasNodesDetailed(
+      null,
+      nodes,
+      new Set(nodes.map((n) => n.id)),
+      { silent: true },
+    )
+    expect(unusableByOptionId.size).toBe(0)
+  })
+
+  it('POSITIVE CONTROL — the undetailed wrapper returns exactly the options array it always did', () => {
+    const nodes = [...NODES, optionNode('opt_canvas', 'Canvas option', { fac_good: 0.5, fac_bad: { value: null } })]
+    const validIds = new Set(nodes.map((n) => n.id))
+    const plain = reconcileOptionsWithCanvasNodes(null, nodes, validIds, { silent: true })
+    const detailed = reconcileOptionsWithCanvasNodesDetailed(null, nodes, validIds, { silent: true })
+    expect(JSON.stringify(plain)).toBe(JSON.stringify(detailed.options))
+  })
+
+  it('a STALE target (not on the canvas) is NOT reported as unusable — that is a different failure with its own handling', () => {
+    const nodes = [...NODES, optionNode('opt_canvas', 'Canvas option', { fac_good: 0.5, fac_deleted: 0.2 })]
+    const { unusableByOptionId } = reconcileOptionsWithCanvasNodesDetailed(
+      null,
+      nodes,
+      new Set(nodes.map((n) => n.id)), // fac_deleted absent → stale, not unusable
+      { silent: true },
+    )
+    expect(unusableByOptionId.has('opt_canvas')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The whole primary path
+// ---------------------------------------------------------------------------
+
+describe('buildV2RequestFromAnalysisReady — the primary run path', () => {
+  it('does not build a request that quietly analyses fewer interventions than the canvas holds', () => {
+    const nodes = [...NODES, optionNode('opt_partial', 'Raise price', {})]
+    const analysisReady = {
+      goal_node_id: 'goal_1',
+      status: 'ready',
+      suggested_seed: '424242',
+      options: [partialOption()],
+    } as any
+    expect(() => buildV2RequestFromAnalysisReady(nodes, EDGES, analysisReady)).toThrow(
+      InterventionValidationError,
+    )
+  })
+
+  it('POSITIVE CONTROL — an all-valid request is BYTE-IDENTICAL to the pristine build', () => {
+    const nodes = [...NODES, optionNode('opt_valid', 'Hold price', {})]
+    const analysisReady = {
+      goal_node_id: 'goal_1',
+      status: 'ready',
+      suggested_seed: '424242',
+      options: [allValidOption()],
+    } as any
+    const { request } = buildV2RequestFromAnalysisReady(nodes, EDGES, analysisReady)
+    // Captured by running this exact build on pristine fff04eb5, BEFORE any
+    // change in this PR. `suggested_seed` pins the otherwise clock-derived
+    // seed so the string is stable. Any drift in the outbound bytes — key
+    // order included — fails here.
+    expect(JSON.stringify(request)).toBe(PRISTINE_VALID_REQUEST_JSON)
+  })
+
+  it('POSITIVE CONTROL — the ALL-bad option keeps its pre-existing full-drop behaviour at the reconciler, and is left for the pre-run gate', () => {
+    const nodes = [...NODES, optionNode('opt_allbad', 'Cut price', {})]
+    const analysisReady = { goal_node_id: 'goal_1', status: 'ready', options: [allBadOption()] } as any
+    const { options } = reconcileOptionsWithCanvasNodesDetailed(
+      analysisReady,
+      nodes,
+      new Set(nodes.map((n) => n.id)),
+      { silent: true },
+    )
+    // Unchanged: zero usable interventions survive …
+    expect(Object.keys(flattenInterventions(options[0].interventions))).toHaveLength(0)
+    // … which is precisely what the existing MISSING_INTERVENTIONS gate keys on.
+  })
+})
+
+// Pinned pristine bytes — see the byte-identical control above. Captured by
+// running that exact build on pristine fff04eb5 before any change in this PR.
+const PRISTINE_VALID_REQUEST_JSON =
+  '{"graph":{"nodes":[{"id":"goal_1","kind":"goal","label":"Profit"},{"id":"fac_good","kind":"factor","label":"Unit margin"},{"id":"fac_bad","kind":"factor","label":"Customer churn"},{"id":"fac_zero","kind":"factor","label":"Volume"},{"id":"fac_worse","kind":"factor","label":"Brand risk"},{"id":"opt_valid","kind":"option","label":"Hold price"}],"edges":[{"from":"fac_good","to":"goal_1","strength":{"mean":0.5,"std":0.07999999999999999}}]},"options":[{"id":"opt_valid","label":"Hold price","interventions":{"fac_good":0.4,"fac_zero":0}}],"goal_node_id":"goal_1","seed":"424242","detail_level":"deep"}'

--- a/src/adapters/plot/v2/adapter.ts
+++ b/src/adapters/plot/v2/adapter.ts
@@ -27,7 +27,11 @@ import {
   normaliseGraphIds,
   translateResponseToUIIds,
 } from '../../../utils/nodeIdNormalisation'
-import { interventionNumericValue, looksLikeIntervention } from '../../../utils/interventionValue'
+import {
+  interventionNumericValue,
+  looksLikeIntervention,
+  partitionInterventions,
+} from '../../../utils/interventionValue'
 import type { UIOption, UIInterventionValue } from '../../../types/options'
 import type { CEEAnalysisReady, CEEGoalConstraint, CEEOptionV3 } from '../../cee/types'
 import { recordRequestPayload, recordResponsePayload } from '../../../lib/payload-trace-store'
@@ -285,13 +289,12 @@ export function extractOptionsFromNodes(
 export function flattenInterventions(
   raw: unknown,
 ): Record<string, number> {
-  const out: Record<string, number> = {}
-  if (!raw || typeof raw !== 'object') return out
-  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
-    const numeric = interventionNumericValue(value)
-    if (numeric !== null) out[key] = numeric
-  }
-  return out
+  // The walk itself is `partitionInterventions` (src/utils/interventionValue.ts).
+  // This function keeps only the usable half and DISCARDS the record of what it
+  // skipped — which is exactly why it must never be the last word on an option
+  // heading for the wire. Callers that decide whether an analysis may proceed
+  // take the partition instead, so the skipped keys survive to be reported.
+  return partitionInterventions(raw).usable
 }
 
 /**
@@ -453,13 +456,69 @@ export interface ReconcileOptionsHookOptions {
   phase?: 'pre_run_check' | 'request_build' | 'turn_request'
 }
 
-export function reconcileOptionsWithCanvasNodes(
+/**
+ * What `reconcileOptionsWithCanvasNodesDetailed` returns on top of the options.
+ */
+export interface ReconcileOptionsResult {
+  /** Exactly the array `reconcileOptionsWithCanvasNodes` has always returned. */
+  options: CEEOptionV3[]
+  /**
+   * optionId → target ids that were AUTHORED on that option but carry no usable
+   * numeric value, in map order. Absent key = nothing was lost for that option.
+   *
+   * WHY THIS CANNOT BE COMPUTED DOWNSTREAM. Two of the three merge branches
+   * below backfill through `canvasInterventionsToCEE`, which drops unusable
+   * entries as it converts — so by the time any consumer sees the returned
+   * option, the evidence is gone. PR #499 proposed carrying the dropped list out
+   * of `ceeOptionToV2Option` instead; that would have closed the pass-through
+   * branch only and left both backfill branches silently dropping, because
+   * `ceeOptionToV2Option` never sees what the reconciler already removed. The
+   * report has to be emitted by the walk that does the removing.
+   *
+   * Excludes stale targets (not on the canvas) and self-targeting entries: those
+   * are different failures, handled separately, and are dropped by this function
+   * for reasons that have nothing to do with the value being unusable.
+   */
+  unusableByOptionId: Map<string, string[]>
+}
+
+/**
+ * The reconciler, plus a report of every authored-but-unusable intervention it
+ * encountered. See `ReconcileOptionsResult.unusableByOptionId`.
+ *
+ * `reconcileOptionsWithCanvasNodes` is the options-only wrapper over this, kept
+ * because most call sites do not need the report.
+ */
+export function reconcileOptionsWithCanvasNodesDetailed(
   analysisReady: CEEAnalysisReady | null | undefined,
   nodes: Node<CanvasNodeData>[],
   validNodeIds: Set<string>,
   options: ReconcileOptionsHookOptions = {},
-): CEEOptionV3[] {
+): ReconcileOptionsResult {
   const { silent = false, scenarioId = null, phase = 'request_build' } = options
+
+  const unusableByOptionId = new Map<string, string[]>()
+  /**
+   * Record the unusable targets of one option's raw intervention map.
+   *
+   * `ownerId` filters self-targeting and `validNodeIds` filters stale targets,
+   * mirroring the two `continue`s in `canvasInterventionsToCEE` so this report
+   * never accuses a target of being unusable when it was really absent.
+   * `restrictToValidIds` is false on the analysis_ready pass-through branches,
+   * which apply no such filter — reporting there must match what
+   * `ceeOptionToV2Option` will actually refuse.
+   */
+  const recordUnusable = (
+    ownerId: string,
+    rawInterventions: unknown,
+    restrictToValidIds: boolean,
+  ) => {
+    const { unusableTargets } = partitionInterventions(rawInterventions)
+    const reportable = unusableTargets.filter(
+      (t) => t !== ownerId && (!restrictToValidIds || validNodeIds.has(t)),
+    )
+    if (reportable.length > 0) unusableByOptionId.set(ownerId, reportable)
+  }
   const optionNodes = nodes.filter(
     (n) => (n.data as Record<string, unknown> | undefined)?.kind === 'option' || (n.data as Record<string, unknown> | undefined)?.type === 'option',
   )
@@ -522,6 +581,10 @@ export function reconcileOptionsWithCanvasNodes(
 
     if (hasUsableInterventions(arOpt.interventions)) {
       // PRIMARY hot path — analysisReady wins with its native interventions.
+      // Nothing is dropped HERE; the drop happens later, at ceeOptionToV2Option.
+      // Report it now so the pre-run gate can block before the run, rather than
+      // letting the request build throw at the wire edge.
+      recordUnusable(arOpt.id, arOpt.interventions, false)
       result.push(arOpt)
       continue
     }
@@ -531,6 +594,7 @@ export function reconcileOptionsWithCanvasNodes(
     // as-is (legacy permissive behaviour; isAnalysisReadyStale handles deletions).
     const canvasNode = optionNodesById.get(arOpt.id)
     if (!canvasNode) {
+      recordUnusable(arOpt.id, arOpt.interventions, false)
       result.push(arOpt)
       continue
     }
@@ -540,6 +604,9 @@ export function reconcileOptionsWithCanvasNodes(
     // sees the canonical Record<string, number> form. This is the upstream guard for
     // PLoT EMPTY_INTERVENTIONS — see flattenInterventions for the shape contract.
     const nodeData = (canvasNode.data as Record<string, unknown> | undefined) ?? {}
+    // SITE B. The flatten below is what silently removed unusable entries before
+    // any consumer — the pre-run gate included — could see them. Record first.
+    recordUnusable(arOpt.id, nodeData.interventions, true)
     const flatNodeInterventions = flattenInterventions(nodeData.interventions)
     const fallback = canvasInterventionsToCEE(
       arOpt.id,
@@ -561,6 +628,8 @@ export function reconcileOptionsWithCanvasNodes(
     if (seen.has(node.id)) continue
     const nodeData = (node.data as Record<string, unknown> | undefined) ?? {}
     const label = (nodeData.label as string | undefined) || node.id
+    // SITE B, second branch — same silent removal as above. Record first.
+    recordUnusable(node.id, nodeData.interventions, true)
     // Flatten complex shapes before handing off to the CEE converter.
     const flatNodeInterventions = flattenInterventions(nodeData.interventions)
     const fallback = canvasInterventionsToCEE(
@@ -582,7 +651,25 @@ export function reconcileOptionsWithCanvasNodes(
     })
   }
 
-  return result
+  return { options: result, unusableByOptionId }
+}
+
+/**
+ * Options-only view of `reconcileOptionsWithCanvasNodesDetailed`.
+ *
+ * Unchanged signature and unchanged return value — every existing call site that
+ * does not need the unusable-target report keeps working exactly as before.
+ * Callers that decide whether an analysis may RUN must use the detailed form:
+ * this one discards the report, and a caller holding only the options array
+ * cannot tell a complete option from one the reconciler quietly trimmed.
+ */
+export function reconcileOptionsWithCanvasNodes(
+  analysisReady: CEEAnalysisReady | null | undefined,
+  nodes: Node<CanvasNodeData>[],
+  validNodeIds: Set<string>,
+  options: ReconcileOptionsHookOptions = {},
+): CEEOptionV3[] {
+  return reconcileOptionsWithCanvasNodesDetailed(analysisReady, nodes, validNodeIds, options).options
 }
 
 /**
@@ -753,15 +840,37 @@ export function ceeOptionToV2Option(ceeOption: CEEOptionV3): V2Option {
     })
   }
 
-  // Final boundary flatten — invariant: every value at the PLoT request edge is a
-  // finite number. flattenInterventions handles V3 nested, complex canvas
-  // {value, unit, source}, and bare-number shapes uniformly, and drops anything
-  // that cannot be coerced to a finite number rather than smuggling NaN/undefined
-  // through to PLoT.
+  // Final boundary partition — invariant: every value at the PLoT request edge is
+  // a finite number. Handles V3 nested, complex canvas {value, unit, source}, and
+  // bare-number shapes uniformly.
+  //
+  // Disposal doctrine — this function REFUSES a partial loss rather than shrinking
+  // the option. It used to `flattenInterventions` here, which silently discarded
+  // any entry that was not a finite number. When EVERY entry failed, the pre-run
+  // gate caught it downstream. When only SOME failed, nothing did: the option went
+  // to PLoT with fewer interventions than the canvas held, PLoT accepted it (the
+  // surviving values are perfectly valid), and the user was handed a confident
+  // answer to a question they never asked. That is the silent-alteration failure
+  // ruled against twice on 26 Jul, and PR #499 recorded it as the residual gap on
+  // this exact path.
+  //
+  // Refusal, not dropping, and not a warning: this layer has no per-option surface
+  // to render on, so any disposal other than refusing is by construction silent.
+  // The typed throw is the convention its sibling `uiOptionToV2Option` already uses
+  // for the same condition at the same boundary (#499), and it names the same code
+  // PLoT uses. In practice the pre-run gate in useV2Run blocks first and shows the
+  // user the amber banner — this is the invariant behind that gate, not the
+  // user-facing surface, and it is what stops a future caller from reintroducing
+  // the silent shrink by bypassing the gate.
+  const { usable, unusableTargets } = partitionInterventions(ceeOption.interventions)
+  if (unusableTargets.length > 0) {
+    throw new InterventionValidationError(ceeOption.id, ceeOption.label, unusableTargets)
+  }
+
   const result: V2Option = {
     id: ceeOption.id,
     label: ceeOption.label,
-    interventions: flattenInterventions(ceeOption.interventions),
+    interventions: usable,
   }
 
   if (import.meta.env.DEV) {

--- a/src/adapters/plot/v2/index.ts
+++ b/src/adapters/plot/v2/index.ts
@@ -51,6 +51,7 @@ export {
   executeV2RunWithAnalysisReady,
   extractOptionsFromNodes,
   reconcileOptionsWithCanvasNodes,
+  reconcileOptionsWithCanvasNodesDetailed,
   uiOptionToV2Option,
   ceeOptionToUIOption,
   ceeOptionToV2Option,

--- a/src/canvas/hooks/__tests__/useV2Run.partialInterventionDrop.spec.ts
+++ b/src/canvas/hooks/__tests__/useV2Run.partialInterventionDrop.spec.ts
@@ -1,0 +1,246 @@
+/**
+ * The pre-run gate must fire on a PARTIAL intervention drop, not only a total one.
+ *
+ * Before this change the gate keyed on `flattenInterventions(opt.interventions).length === 0`
+ * — it fired only when EVERY entry was unusable. An option with one good entry and one
+ * unusable entry sailed straight through, and the analysis ran on a graph the user never
+ * authored while the UI reported success.
+ *
+ * The affordance is the one PR #499 established and OutputsDock already renders: the
+ * `MISSING_INTERVENTIONS` store error carrying `affectedOptions`, drawn as the amber
+ * "Options need their effects mapped" banner with a focus button per option. No new UI.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useV2Run } from '../useV2Run'
+import { useCanvasStore } from '../../store'
+import { useDraftStore } from '../../stores/draftStore'
+import { useResultsStore } from '../../stores/resultsStore'
+
+vi.mock('../../../adapters/plot/v2', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../adapters/plot/v2')>()
+  return { ...actual, executeV2RunWithAnalysisReady: vi.fn() }
+})
+vi.mock('../../../lib/resultsInstrumentation', () => ({
+  trackRunCompleted: vi.fn(),
+  trackRunFailed: vi.fn(),
+  trackEmptyComputedResults: vi.fn(),
+}))
+vi.mock('../../../lib/telemetry', () => ({ trackTypedError: vi.fn() }))
+vi.mock('../../../lib/gate-state', () => ({
+  useGateStore: { getState: () => ({ setGate: vi.fn() }) },
+  updateRobustnessGate: vi.fn(),
+  updateRobustnessGateFromV2: vi.fn(),
+}))
+vi.mock('../../../utils/payloadRedaction', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils/payloadRedaction')>()
+  return { ...actual, buildRawErrorData: vi.fn(() => null), hashStackTrace: vi.fn(() => '') }
+})
+vi.mock('../../../types/requestId', () => ({
+  generateRequestId: vi.fn(() => 'req-partial-drop'),
+}))
+
+import { executeV2RunWithAnalysisReady } from '../../../adapters/plot/v2'
+const mockExecute = executeV2RunWithAnalysisReady as Mock
+
+/**
+ * `fac-1` is labelled "Unit margin" and `fac-2` "Customer churn" so the assertions can
+ * prove the surfaced text names the target by its CANVAS LABEL, not its node id.
+ */
+function setupCanvas(analysisReady: any, extraOptionNodes: any[] = []) {
+  const baseResults = useCanvasStore.getState().results
+  const arOptionNodes = (analysisReady?.options || []).map((o: any, i: number) => ({
+    id: o.id,
+    type: 'option',
+    data: { label: o.label, kind: 'option', interventions: o.interventions },
+    position: { x: 200 + i * 100, y: 0 },
+  }))
+  const nodes: any[] = [
+    { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+    { id: 'fac-1', type: 'factor', data: { label: 'Unit margin', kind: 'factor' }, position: { x: 100, y: 0 } },
+    { id: 'fac-2', type: 'factor', data: { label: 'Customer churn', kind: 'factor' }, position: { x: 100, y: 80 } },
+    ...arOptionNodes,
+    ...extraOptionNodes,
+  ]
+  useCanvasStore.setState({
+    nodes,
+    edges: [{ id: 'e1', source: 'fac-1', target: 'goal-1' }],
+    outcomeNodeId: 'goal-1',
+    ceeAnalysisReady: analysisReady ?? null,
+    ceeAnalysisReadyNodeIds: analysisReady ? nodes.map((n) => n.id) : null,
+    goalConstraints: null,
+    goalThreshold: null,
+    currentScenarioFraming: null,
+    results: { ...baseResults, status: 'idle' },
+  } as any)
+  useDraftStore.getState().setLastDraftDescription('')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useResultsStore.setState({ analysisSummary: null } as any)
+})
+
+describe('pre-run gate — partial intervention drop', () => {
+  it('BLOCKS a run whose option has one usable and one unusable intervention', async () => {
+    setupCanvas({
+      goal_node_id: 'goal-1',
+      status: 'ready',
+      options: [
+        {
+          id: 'opt-1',
+          label: 'Raise price',
+          status: 'ready',
+          interventions: {
+            'fac-1': { value: 0.4, source: 'cee_hypothesis' },
+            'fac-2': { value: null, source: 'cee_hypothesis' },
+          },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useV2Run())
+    await act(async () => {
+      await result.current.runV2Analysis()
+    })
+
+    // The run must NOT have been sent with a shrunken option set.
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(result.current.isRunning).toBe(false)
+    expect(useCanvasStore.getState().results.status).toBe('error')
+  })
+
+  it('names the option AND the unusable target by its canvas label', async () => {
+    setupCanvas({
+      goal_node_id: 'goal-1',
+      status: 'ready',
+      options: [
+        {
+          id: 'opt-1',
+          label: 'Raise price',
+          status: 'ready',
+          interventions: {
+            'fac-1': { value: 0.4, source: 'cee_hypothesis' },
+            'fac-2': { value: null, source: 'cee_hypothesis' },
+          },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useV2Run())
+    await act(async () => {
+      await result.current.runV2Analysis()
+    })
+
+    expect(result.current.error).toContain('Raise price')
+    expect(result.current.error).toContain('Customer churn')
+  })
+
+  it('routes through the EXISTING MISSING_INTERVENTIONS + affectedOptions affordance', async () => {
+    setupCanvas({
+      goal_node_id: 'goal-1',
+      status: 'ready',
+      options: [
+        {
+          id: 'opt-1',
+          label: 'Raise price',
+          status: 'ready',
+          interventions: {
+            'fac-1': { value: 0.4, source: 'cee_hypothesis' },
+            'fac-2': { value: 'tbd', source: 'cee_hypothesis' },
+          },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useV2Run())
+    await act(async () => {
+      await result.current.runV2Analysis()
+    })
+
+    const storeError = useCanvasStore.getState().results.error
+    expect(storeError?.code).toBe('MISSING_INTERVENTIONS')
+    expect(storeError?.affectedOptions).toEqual([{ id: 'opt-1', label: 'Raise price' }])
+  })
+
+  it('fires on the CANVAS-BACKFILL branch too, where the reconciler used to filter before the gate could look', async () => {
+    setupCanvas(null, [
+      {
+        id: 'opt-canvas',
+        type: 'option',
+        data: {
+          label: 'Canvas option',
+          kind: 'option',
+          interventions: { 'fac-1': 0.5, 'fac-2': { value: null } },
+        },
+        position: { x: 300, y: 0 },
+      },
+    ])
+
+    const { result } = renderHook(() => useV2Run())
+    await act(async () => {
+      await result.current.runV2Analysis()
+    })
+
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(result.current.error).toContain('Canvas option')
+    expect(result.current.error).toContain('Customer churn')
+  })
+
+  it('POSITIVE CONTROL — an all-valid option still runs, untouched', async () => {
+    mockExecute.mockResolvedValue({
+      analysis_status: 'computed',
+      option_comparison: [],
+      response_hash: 'test-hash',
+    })
+    setupCanvas({
+      goal_node_id: 'goal-1',
+      status: 'ready',
+      options: [
+        {
+          id: 'opt-1',
+          label: 'Good Option',
+          status: 'ready',
+          interventions: {
+            'fac-1': { value: 10, source: 'cee_hypothesis' },
+            'fac-2': { value: 0, source: 'cee_hypothesis' },
+          },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useV2Run())
+    await act(async () => {
+      await result.current.runV2Analysis()
+    })
+
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it('POSITIVE CONTROL — the ALL-unusable option keeps its existing full-drop wording and code', async () => {
+    setupCanvas({
+      goal_node_id: 'goal-1',
+      status: 'ready',
+      options: [
+        {
+          id: 'opt-1',
+          label: 'Empty Option',
+          status: 'ready',
+          interventions: { 'fac-1': { value: null, source: 'cee_hypothesis' } },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useV2Run())
+    await act(async () => {
+      await result.current.runV2Analysis()
+    })
+
+    expect(mockExecute).not.toHaveBeenCalled()
+    expect(result.current.error).toContain('Empty Option')
+    expect(result.current.error).toContain('intervention values')
+    const storeError = useCanvasStore.getState().results.error
+    expect(storeError?.code).toBe('MISSING_INTERVENTIONS')
+  })
+})

--- a/src/canvas/hooks/useV2Run.ts
+++ b/src/canvas/hooks/useV2Run.ts
@@ -17,7 +17,7 @@ import {
   isSuccessfulAnalysis,
   validateV2RunResponseFull,
   sanitizeV2RunResponse,
-  reconcileOptionsWithCanvasNodes,
+  reconcileOptionsWithCanvasNodesDetailed,
   flattenInterventions,
   clearStrengthCorrections,
   type V2AdapterConfig,
@@ -541,12 +541,27 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
         // hide all fallback usage because they return early below before the
         // second reconcile call ever happens. See
         // adapters/plot/v2/adapter.ts:ReconcileOptionsHookOptions.
-        const optionsToValidate = reconcileOptionsWithCanvasNodes(
-          effectiveAnalysisReady,
-          nodes as any,
-          currentNodeIds,
-          { silent: true, phase: 'pre_run_check', scenarioId: framing?.scenario_id ?? null },
-        )
+        // DETAILED form. The plain `reconcileOptionsWithCanvasNodes` returns only
+        // the options, and its canvas-backfill branches have ALREADY discarded any
+        // unusable entry by then — so a gate reading the options alone is
+        // structurally unable to see a partial loss on those branches. The detailed
+        // form reports what the walk removed. See ReconcileOptionsResult.
+        const { options: optionsToValidate, unusableByOptionId } =
+          reconcileOptionsWithCanvasNodesDetailed(
+            effectiveAnalysisReady,
+            nodes as any,
+            currentNodeIds,
+            { silent: true, phase: 'pre_run_check', scenarioId: framing?.scenario_id ?? null },
+          )
+
+        // Node labels for naming a target the way the user sees it on the canvas,
+        // not by node id — the convention PR #499 set for the same disposal.
+        const labelByNodeId = new Map<string, string>()
+        for (const n of nodes as any[]) {
+          const l = (n?.data as Record<string, unknown> | undefined)?.label
+          if (typeof l === 'string' && l.trim().length > 0) labelByNodeId.set(n.id, l)
+        }
+        const targetName = (id: string) => labelByNodeId.get(id) ?? id
 
         // Identify offending options directly by id (not label) so duplicate
         // labels do not collapse two distinct options into one entry.
@@ -554,23 +569,63 @@ export function useV2Run(persistence?: V2RunPersistence): UseV2RunReturn {
         // for the human message but loses identity — we re-walk the reconciled
         // list with the same usability rule (flattenInterventions, the single
         // canonical "is this a usable map?" check) and key by opt.id.
-        const affectedOptions: Array<{ id: string; label: string }> = []
+        //
+        // TWO failure modes, one affordance. Both end as MISSING_INTERVENTIONS +
+        // affectedOptions, which OutputsDock renders as the amber "Options need
+        // their effects mapped" banner with a focus button per option:
+        //
+        //   EMPTY   — no usable intervention at all. Pre-existing behaviour,
+        //             wording unchanged.
+        //   PARTIAL — some usable, at least one authored-but-unusable. NEW. This
+        //             used to run: the option was quietly shrunk to its usable
+        //             entries and the user got a confident answer about a graph
+        //             they never authored. Blocking is the doctrine — what gets
+        //             analysed is never silently altered — and blocking BEFORE the
+        //             request is built is what turns the adapter's typed throw
+        //             into an unreachable invariant rather than a crash.
+        const emptyOptions: Array<{ id: string; label: string }> = []
+        const partialOptions: Array<{ id: string; label: string; targets: string[] }> = []
         for (const opt of optionsToValidate) {
+          const label = opt.label || opt.id
           if (Object.keys(flattenInterventions(opt.interventions)).length === 0) {
-            affectedOptions.push({ id: opt.id, label: opt.label || opt.id })
+            emptyOptions.push({ id: opt.id, label })
+            continue
+          }
+          const unusable = unusableByOptionId.get(opt.id)
+          if (unusable && unusable.length > 0) {
+            partialOptions.push({ id: opt.id, label, targets: unusable })
           }
         }
 
+        const affectedOptions: Array<{ id: string; label: string }> = [
+          ...emptyOptions,
+          ...partialOptions.map((o) => ({ id: o.id, label: o.label })),
+        ]
+
         if (affectedOptions.length > 0) {
-          const labels = affectedOptions.map((o) => o.label)
-          const message =
-            affectedOptions.length === 1
-              ? `Option "${labels[0]}" needs intervention values before analysis can run.`
-              : `Options ${labels.map((o) => `"${o}"`).join(', ')} need intervention values before analysis can run.`
+          const labels = emptyOptions.map((o) => o.label)
+          const emptyMessage =
+            emptyOptions.length === 0
+              ? ''
+              : emptyOptions.length === 1
+                ? `Option "${labels[0]}" needs intervention values before analysis can run.`
+                : `Options ${labels.map((o) => `"${o}"`).join(', ')} need intervention values before analysis can run.`
+          const partialMessage = partialOptions
+            .map((o) => {
+              const named = o.targets.map((t) => `"${targetName(t)}"`).join(', ')
+              const noun = o.targets.length === 1 ? 'an effect' : 'effects'
+              return `Option "${o.label}" has ${noun} on ${named} with no usable value. Set a number for each, or remove them, before analysis can run.`
+            })
+            .join(' ')
+          const message = [emptyMessage, partialMessage].filter(Boolean).join(' ')
 
           if (import.meta.env.DEV) {
             console.warn('[useV2Run] Pre-run validation failed: missing interventions', {
               missingOptions: labels,
+              partiallyUnusableOptions: partialOptions.map((o) => ({
+                option: o.label,
+                targets: o.targets,
+              })),
               usingAnalysisReady: !!effectiveAnalysisReady,
             })
           }

--- a/src/utils/interventionValue.ts
+++ b/src/utils/interventionValue.ts
@@ -66,3 +66,62 @@ export function looksLikeIntervention(raw: unknown): boolean {
   if (typeof raw === 'number') return true
   return raw != null && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw
 }
+
+/**
+ * The result of splitting an intervention MAP into what can be analysed and
+ * what was authored but cannot.
+ */
+export interface InterventionPartition {
+  /** Every entry that resolved to a finite number, keyed by target id. */
+  usable: Record<string, number>
+  /**
+   * Target ids that are present in the map but carry no usable value.
+   * ORDER: the map's own key order, so messages read in authoring order.
+   */
+  unusableTargets: string[]
+}
+
+/**
+ * Split an intervention map into its usable and unusable halves.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM `interventionNumericValue`
+ * ---------------------------------------------------------
+ * The single-value predicate answers "is this value usable?". It cannot answer
+ * the question the disposal doctrine actually asks, which is about the MAP:
+ * "did this option lose anything on the way to the wire?" Every consumer that
+ * used to answer that by walking the map and silently skipping failures now
+ * calls this instead, so the skipped keys are always available to report.
+ *
+ * KEY PRESENCE IS THE AUTHORING SIGNAL — and that is deliberately NOT
+ * `looksLikeIntervention`.
+ * `looksLikeIntervention` discriminates a lone VALUE ("is this thing an
+ * intervention at all?"), which is the right question at `extractOptionsFromNodes`
+ * where a value arrives with no surrounding context. Inside a map it is the
+ * wrong question, and answering it here would reopen the defect: an entry of a
+ * bare `null` (`{ fac_a: null }`) fails `looksLikeIntervention`, yet the KEY
+ * names a target, so something authored an intervention on `fac_a` and gave it
+ * no value. PR #499 measured that exact shape arriving from CEE and being
+ * written verbatim into `node.data.interventions`. Treating it as "no
+ * intervention here" would silently drop it — the thing this module exists to
+ * prevent. The contract agrees: `CEEOptionV3.interventions` is
+ * `Record<string, CEEInterventionV3>`, so every key is a target by definition.
+ *
+ * Callers that must ignore keys for a DIFFERENT reason — a stale target that is
+ * no longer on the canvas, or an option targeting itself — filter
+ * `unusableTargets` themselves. Those are separate failures with their own
+ * handling, and folding them in here would blur two distinct diagnoses.
+ *
+ * Non-object input yields two empty halves, matching the historical
+ * `flattenInterventions` guard exactly.
+ */
+export function partitionInterventions(raw: unknown): InterventionPartition {
+  const usable: Record<string, number> = {}
+  const unusableTargets: string[] = []
+  if (!raw || typeof raw !== 'object') return { usable, unusableTargets }
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    const numeric = interventionNumericValue(value)
+    if (numeric !== null) usable[key] = numeric
+    else unusableTargets.push(key)
+  }
+  return { usable, unusableTargets }
+}


### PR DESCRIPTION
PR #499 closed the two hops that could put a non-finite intervention value **on the wire**, and
named this as the residual gap in its own §4b. This closes it.

Developed on **`fff04eb5`** (the merge commit of #499 itself), then **rebased onto
`032901c8`** — the current `staging` tip — with **zero conflicts**. The only commit between the two
is #500, entirely under `src/components/results/analysis-hero/`, which touches none of my files. All
evidence below was **re-derived on the rebased tip**, not inherited: RED replayed, all four mutants
re-run, both gates and the full suite re-run.

## 1. The defect, traced producer → wire

*Every line number below is of the **pristine** file at `032901c8`, each one re-read at that SHA
after the rebase rather than carried over from the development tip.*

`buildV2RequestFromAnalysisReady` (`adapter.ts:1439`) → `ceeOptionToV2Option` (`:746`) →
`flattenInterventions` (`:285`). `flattenInterventions` keeps entries that resolve to a finite
number and **silently discards the rest**. When *every* entry failed, the pre-run gate
(`useV2Run.ts:559`) caught it — it keyed on `flattenInterventions(...).length === 0`. When only
*some* failed, nothing did.

Captured at the bytes on pristine `fff04eb5`, before any change (the canvas holds two
interventions):

```
PRE-FIX ceeOptionToV2Option output = {"id":"opt_partial","label":"Raise price","interventions":{"fac_good":0.4}}
PRE-FIX request.options          = [{"id":"opt_partial","label":"Raise price","interventions":{"fac_good":0.4}}]
```

The wire is *valid*, so PLoT has no reason to complain, and never did. The run completes, the
result renders, and the user is handed a confident answer about a graph they did not author. This
is the silent-alteration failure ruled against twice on 26 Jul (PLoT ingress, and #499 itself).

## 2. Refutation — there are TWO drop sites, and #499's proposed fix would have closed one

§4b of #499 recommended "carry the dropped-target list out of `ceeOptionToV2Option`". Doing only
that would have left **both canvas-backfill branches still dropping silently**, and the PR would
have read as complete.

| | Site | Reached when | Would #499's proposal have caught it? |
|---|---|---|---|
| **A** | `ceeOptionToV2Option` (`adapter.ts:746`) | the reconciler's PRIMARY branch (`:523`) passes an analysis_ready option through as-is — taken whenever the option has ≥1 usable intervention | yes |
| **B** | `reconcileOptionsWithCanvasNodes` (`:543`, `:565`) | either canvas-backfill branch | **no** |

Site B is *upstream*. Both backfill branches call `flattenInterventions(node.data.interventions)`
**before** `canvasInterventionsToCEE`, so the unusable entries are gone before any consumer — the
pre-run gate included — ever sees the option. `ceeOptionToV2Option` cannot report what the
reconciler already removed. The report has to be emitted by the walk that does the removing, which
is why `reconcileOptionsWithCanvasNodesDetailed` exists rather than a return-shape change on
`ceeOptionToV2Option` alone.

Spec `partialInterventionDrop.spec.ts` pins site B independently of site A, so a future
simplification that folds one into the other fails.

## 3. Disposal per call path, from existing affordances only

**Pre-run gate (`useV2Run.ts`) — BLOCK. This is the user-facing disposal.**
Uses the affordance #499 established and `OutputsDock.tsx:1946-2005` already renders: the
`MISSING_INTERVENTIONS` store error carrying `affectedOptions`, drawn as the amber *"Options need
their effects mapped"* banner with a focus button per option. **No new UI, no new error code, no
new store field.** The message names the unusable target **by its canvas label**, not its node id —
the naming convention #499 set for the same disposal at hop 1.

Two failure modes now converge on that one affordance:

- **EMPTY** — no usable intervention at all. Pre-existing; **wording byte-for-byte unchanged**, and
  a positive control pins that.
- **PARTIAL** — some usable, ≥1 authored-but-unusable. New. Previously ran.

Blocking *before* the request is built is also what keeps the adapter's throw an unreachable
invariant rather than a user-visible crash.

**`ceeOptionToV2Option` — REFUSE (typed throw).**
This layer has no per-option surface to render on, so **any disposal other than refusing is silent
by construction**. It throws the same `InterventionValidationError` that its sibling
`uiOptionToV2Option` already throws for the same condition at the same boundary (#499, hop 2),
carrying the same `INVALID_INTERVENTION_VALUE` code PLoT uses. This is the invariant behind the
gate, not the surface: it stops a future caller from reintroducing the silent shrink by bypassing
the gate.

**Proof the throw cannot crash a live path the gate does not guard** — complete production caller
manifest at `fff04eb5`, `src/` less tests:

- `ceeOptionToV2Option` → exactly one: `adapter.ts:1439`.
- `buildV2RequestFromAnalysisReady` → exactly one: `executeV2RunWithAnalysisReady` (`adapter.ts:1945`).
- `executeV2RunWithAnalysisReady` → exactly one: `useV2Run.ts:712`, downstream of the gate.

The gate and the request build reconcile from the **same** `nodes` array and the **same**
`effectiveAnalysisReady`, and derive their id sets identically (`useV2Run.ts:501` and
`adapter.ts:1432` are both `new Set(nodes.map((n) => n.id))`). On the two branches that reach site
A the gate records with no id filtering, so it flags **exactly** the set the throw would compute.
The throw is therefore unreachable whenever the gate has run.

## 4. No fifth predicate

`partitionInterventions` joins `src/utils/interventionValue.ts` — the module #499 made the single
home of this rule — and `flattenInterventions` is now literally
`partitionInterventions(raw).usable`. The usable half and the unusable half come from one walk and
cannot drift. #499's agreement table still pins `flattenInterventions` against
`interventionNumericValue` and `unwrapInterventionValue`, unchanged and still passing.

One judgement call, stated rather than buried: inside a **map**, key presence is the authoring
signal, so `partitionInterventions` does **not** use `looksLikeIntervention`. That predicate answers
"is this lone value an intervention?" — the right question at `extractOptionsFromNodes`, the wrong
one here. An entry of bare `null` (`{ fac_a: null }`) fails `looksLikeIntervention`, yet the key
names a target, and #499 measured that exact shape arriving from CEE and being written verbatim
into `node.data.interventions`. Treating it as "no intervention here" would silently drop it. The
contract agrees: `CEEOptionV3.interventions` is `Record<string, CEEInterventionV3>`. Stale targets
and self-targets are filtered by the caller, since those are different failures with their own
handling.

## 5. RED-first, per touched path

Written and run **before** any implementation existed, on pristine `fff04eb5`.

Adapter (`partialInterventionDrop.spec.ts`) — **4 failed | 1 passed**:

```
FAIL > SITE A: ceeOptionToV2Option refuses a partially-unusable option
  AssertionError: expected function to throw an error, but it didn't
FAIL > SITE A evidence: what it ACTUALLY returns today
  AssertionError: expected [ 'fac_good' ] to have a length of 2 but got 1
FAIL > SITE B: reconcile reports the canvas-backfill entry it filtered
  AssertionError: expected [ 'fac_good' ] to have a length of 2 but got 1
FAIL > BUILD PATH: refuses to build a shrunken request
  AssertionError: expected function to throw an error, but it didn't
```

Gate (`useV2Run.partialInterventionDrop.spec.ts`) — **4 failed | 2 passed**. The load-bearing line
is the first: the run was **dispatched** with the shrunken option set.

```
FAIL > BLOCKS a run whose option has one usable and one unusable intervention
  AssertionError: expected "spy" to not be called at all, but actually been called 1 times
FAIL > names the option AND the unusable target by its canvas label
  AssertionError: expected 'Cannot read properties of undefined (…' to contain 'Raise price'
FAIL > routes through the EXISTING MISSING_INTERVENTIONS + affectedOptions affordance
  AssertionError: expected 'PROCESSING_ERROR' to be 'MISSING_INTERVENTIONS'
FAIL > fires on the CANVAS-BACKFILL branch too, where the reconciler used to filter before the gate could look
  AssertionError: expected "spy" to not be called at all, but actually been called 1 times
```

The **2 passed** on pristine are the two positive controls (all-valid still runs; all-unusable still
blocks) — they are genuine controls precisely because they were green before the change and are
green after.

After implementation: **19/19 green** across both files.

**Replayed on the rebased tip.** Both spec files were copied onto pristine `032901c8` and run there:
**14 failed | 5 passed (19)**. The defect is unchanged by #500, and — importantly — the
**byte-identical control is among the 5 that PASS on pristine**, which is what proves it is pinned
to genuine pristine bytes rather than to this PR's own output. A control that only passed after the
change would be measuring nothing.

## 6. Positive controls

**Byte-identical outbound payload, serialised not eyeballed.** A fully valid request — two
intervention shapes including a `0` — was built via `buildV2RequestFromAnalysisReady` on pristine
`fff04eb5` with `suggested_seed` pinning the otherwise clock-derived seed, `JSON.stringify`'d, and
that exact string is pinned in the spec and asserted against the post-change build. Key order
included.

```
…"options":[{"id":"opt_valid","label":"Hold price","interventions":{"fac_good":0.4,"fac_zero":0}}],"goal_node_id":"goal_1","seed":"424242","detail_level":"deep"}
```

**Byte-identical.**

Also pinned: the **all-unusable** option keeps its pre-existing full-drop behaviour at the
reconciler and its existing gate wording/code; `reconcileOptionsWithCanvasNodes` returns
`JSON.stringify`-identical output to `…Detailed(...).options`; a **stale** target is *not* reported
as unusable; and an option with **no** interventions at all is still converted rather than refused
(that case belongs to the gate).

## 7. Mutation verdicts — each surfacing reverted ALONE

Run in a throwaway worktree at `scratchpad/lane-uidrop-a7f3/mutcheck-throwaway`, **outside the repo
root** (trap 9c), removed before the gate runs.

Control first: the unmutated branch is **19/19 green in that worktree**, so a mutant's RED cannot be
the worktree's own noise.

| Mutant | Reverted, alone | Result |
|---|---|---|
| **M1** | the `ceeOptionToV2Option` refusal (site A) | **3 failed** — 2 SITE A + the build path. **Zero gate failures**, correctly: the gate is independent. |
| **M2** | the two `recordUnusable` calls on the canvas-backfill branches (site B) | **3 failed** — both SITE B specs + the gate's canvas-backfill spec. |
| **M3** | the pre-run gate's partial detection | **4 failed** — all four gate specs, **zero adapter failures**. |
| **M4** | `partitionInterventions` never reporting anything unusable (the shared predicate) | **10 failed** across both files. |

**M2 is the load-bearing verdict.** M1 and M2 fail on **disjoint** test sets, which is the evidence
that §2 is not a rhetorical point: had this PR taken #499's suggestion and fixed only
`ceeOptionToV2Option`, M2's three tests would still be failing — the two canvas-backfill branches
would have kept dropping silently, and the gate would still have been blind to them.

M4 is the guarantee-theatre mutant: the reporting machinery still exists, still runs, and still
returns a value — it just always says "nothing was lost". Ten tests catch it, so an empty report
cannot pass for a clean one.

## 8. Gates

| Gate | Pristine `032901c8` | This branch |
|---|---|---|
| `pnpm typecheck` coverage | 3006 / 3024 | **3008 / 3026** (both new files tracked and loaded) |
| `pnpm typecheck` ratchet | 633 files / 2547 errors (baseline 2663) | **633 files / 2547 errors — identical** |
| suite, touched dirs (`adapters/plot/v2`, `utils`, `canvas/hooks`) | 72 files / 1050 passed | **74 files / 1069 passed** |
| full suite (on `fff04eb5`, identical source) | — | **1325 files / 19713 passed**, 3 files + 66 skipped, **0 failed** |
| full suite (re-run on rebased `032901c8`) | — | **1325 files / 19728 passed**, 3 files + 66 skipped, **1 failed — disclosed below** |
| **CI on this PR** | — | **12/12 checks pass**, including all 4 `Full Test Suite` shards, `TypeScript + Lint`, `Typecheck Gate Self-Test`, `Production Build`, `Staging Gate` |

**The 1 local failure, disclosed rather than filtered out.**
`src/canvas/edges/__tests__/EdgeEditPopover.perf.spec.tsx` — *"should render within acceptable time
(< 25ms with test overhead)"*, `AssertionError: expected 50.17970800003968 to be less than 25`.

It is a **wall-clock performance assertion**, and I am claiming it is not attributable to this PR on
three independent grounds rather than on the fact that it looks unrelated:

1. The file is **not in my diff** (`git diff --name-only 032901c8..HEAD` — verified, no match), and
   nothing in my change is imported by it. It renders an edge-edit popover; it touches no
   intervention code.
2. Re-run **in isolation on this branch on an idle machine: 15/15 passed.** The 50ms reading came
   from a run where the whole suite took 1456s with 514s of environment setup — the box was
   saturated.
3. **CI's four suite shards all passed** on this exact commit.

A timing budget measured under saturation is not evidence about this diff. I am reporting it
anyway, because filtering it out of a pasted number is how a real regression gets to hide.

**Baseline NOT bumped**, no `--update-baseline`. Zero new type errors — the gate caught three in my
own new spec files on the first run and they were fixed at source, not absorbed. Nothing deleted,
quarantined, or added to `typecheck-uncovered.txt`. `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`
were set for every suite run, and every run was invoked **by directory** — no positional filters,
no "No test files found" exit-0 measurements.

The `::notice::Drift shrank (2663 → 2547)` line is **pre-existing on pristine staging** — captured
in the pristine baseline run before anything was touched. It is not produced by this PR and has
deliberately not been "fixed" by regenerating the baseline.

## 9. Residual I am NOT closing here — stated so this does not read as "done"

`useConversation.ts:2144` builds the CEE turn's `analysis_inputs` from the **options-only**
`reconcileOptionsWithCanvasNodes`. On its backfill branches the same silent filtering applies, so
`analysis_inputs.options[].interventions` can under-report what the canvas holds. I have not
changed it because it is the **CEE turn path, not the PLoT run path** — a different producer, a
different consumer, and no pre-run gate to hang a disposal on — and giving it one is a behaviour
change on the conversational hot path that deserves its own RED-first evidence. The wrapper it uses
is unchanged by this PR, so this is pre-existing, not introduced. Recommend it as the next slice.

## 10. Zero overlap with open UI PRs

My five files:

```
src/utils/interventionValue.ts                                    (+partitionInterventions)
src/adapters/plot/v2/adapter.ts
src/adapters/plot/v2/index.ts
src/canvas/hooks/useV2Run.ts
src/adapters/plot/v2/__tests__/partialInterventionDrop.spec.ts    (new)
src/canvas/hooks/__tests__/useV2Run.partialInterventionDrop.spec.ts (new)
```

Checked against every open PR on `Talchain/DecisionGuideAI`, re-checked after the rebase.

**vs PR #501** (withheld-designation surfaces, ROADMAP 1.267) — its 21 files are **all** under
`src/components/results/`. File lists compared directly: **zero intersection**. It touches no
adapter, no hook, and no `src/utils` module.

**vs everything else open** — the next newest is **#265** (11 Jul). The UI PRs merged 26-27 Jul
(#491, #493-#500) are all closed and in my base. **No open PR touches `adapter.ts`, `useV2Run.ts`,
`interventionValue.ts`, or `index.ts`** — zero intersection.

Should a prose-surfaces PR open later, the same holds by construction: this PR adds no copy to any
results component. Its only user-visible string is the pre-run gate message, which is produced in
`useV2Run.ts` and rendered by the pre-existing `OutputsDock` banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
