### PR TITLE
fix(ui): a withheld run stops presupposing a leading option in prose [ROADMAP 1.267]

### DIFF
--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -19,6 +19,7 @@ import { HeroQualifier } from './HeroQualifier'
 import { useCanvasStore } from '@/canvas/store'
 import { resolveDisplayedFreshness } from '@/canvas/store/analysisFreshness'
 import { buildCertaintyCopy } from './utils/certaintyCopy'
+import { NO_CLAIM_VERDICT } from '@/lib/decisionVerdict'
 import { calibrateUncertaintyCopy } from './utils/uncertaintyCalibration'
 import { typography } from '@/styles/typography'
 import type { ResultsSectionDataReturn } from './useResultsSectionData'
@@ -205,7 +206,19 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
       winProbabilityGap,
       // SINGLE VERDICT: the shared "is there a leading option?" answer,
       // derived from the same PLoT report the canvas badge reads.
-      verdict: data.recommendation.verdict,
+      //
+      // ROADMAP 1.267: `buildCertaintyCopy` now REQUIRES it, and this is the
+      // one place the hook's optional field is resolved. `verdict` is absent
+      // only on the hook's pre-first-run early return, which also returns
+      // `recommendedOption: null` — so the `if (!winner) return null` above
+      // already claimed that path and the fallback is unreachable in
+      // production. It is still spelled NO_CLAIM_VERDICT rather than left to
+      // an optional parameter, because "unreachable today" is how the
+      // original hole was argued too: the honest fallback is silence, and
+      // returning null here would be WORSE than silence — a null `certainty`
+      // hands the headline to `coachingHeadline` below, which is exactly the
+      // producer copy that says "clear leader".
+      verdict: data.recommendation.verdict ?? NO_CLAIM_VERDICT,
     })
   }, [
     data.recommendation.recommendedOption,

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -15,6 +15,7 @@ import { typography } from '../../styles/typography'
 import type { ResultsSectionDataReturn } from './useResultsSectionData'
 import { buildResultsVM } from './buildResultsVM'
 import { deriveDefaultEstimateDisclosure } from './utils/defaultEstimateDisclosure'
+import { flipThresholdStatusNote } from './utils/flipThresholdStatusNote'
 import { DriversSection } from './DriversSection'
 import { TornadoChart, type TornadoRow } from './TornadoChart'
 import { Accordion } from './Accordion'
@@ -141,6 +142,18 @@ export const ResultsBody = memo(function ResultsBody({
   const suppressMutations = isStale || isRunning
   const staleOnConfirmFactor = suppressMutations ? undefined : onConfirmFactor
   const staleOnSetFactorValue = suppressMutations ? undefined : onSetFactorValue
+
+  // ROADMAP 1.267 — QUOTED, never re-derived. `useResultsSectionData` already
+  // resolved the one verdict (`deriveDecisionVerdict`, the same instance the
+  // canvas reads) and returns it on `recommendation.verdict`; this body only
+  // restates it as the boolean its two withheld-gated surfaces need (the
+  // flip-threshold status note, and the UI-authored stress-test thinking
+  // patterns). Absent verdict ⇒ NOT withheld, the same convention
+  // `buildV7Lenses` and `buildHeroModel` use for a verdict-less caller, so no
+  // fixture-driven mount changes behaviour.
+  const designationsWithheld =
+    resultsSectionData.recommendation.verdict != null
+    && !resultsSectionData.recommendation.verdict.hasLeadingOption
 
   // Risk appetite toggle — Conservative: highest p10, Neutral: highest win prob, Aggressive: highest p90
   const [riskAppetite, setRiskAppetite] = useState<RiskAppetite>('neutral')
@@ -526,27 +539,31 @@ export const ResultsBody = memo(function ResultsBody({
                 flip_thresholds[] as all-no-effect or partial-no-effect,
                 render one short explanatory line so absent markers do not
                 read as actionable insight. Reuses panel typography only —
-                no new colour or component. */}
-            {resultsSectionData.recommendation.flipThresholdsStatus === 'all_no_effect' && (
-              <p
-                className={`${typography.panelBody} text-text-light mb-3`}
-                data-testid="flip-thresholds-status-note"
-                role="note"
-              >
-                No single tested factor changed the leading option within the current range.
-              </p>
-            )}
-            {resultsSectionData.recommendation.flipThresholdsStatus === 'partial_no_effect' && (
-              <p
-                className={`${typography.panelBody} text-text-light mb-3`}
-                data-testid="flip-thresholds-status-note"
-                role="note"
-              >
-                {resultsSectionData.recommendation.flipThresholdsHasUnresolved
-                  ? 'Some factors did not change the leading option within the current range, and others could not be resolved.'
-                  : 'Some factors did not change the leading option within the current range.'}
-              </p>
-            )}
+                no new colour or component.
+
+                ROADMAP 1.267: the three sentences moved into
+                `flipThresholdStatusNote` — all three said "the leading
+                option", which on a withheld run asserts what CEE declined to
+                say, and as inline JSX they could not be unit-tested without
+                mounting the whole panel. One call site, one pure function,
+                pinned against the withheld/permitted fixture pair. */}
+            {(() => {
+              const note = flipThresholdStatusNote({
+                status: resultsSectionData.recommendation.flipThresholdsStatus,
+                hasUnresolved:
+                  resultsSectionData.recommendation.flipThresholdsHasUnresolved === true,
+                designationsWithheld,
+              })
+              return note == null ? null : (
+                <p
+                  className={`${typography.panelBody} text-text-light mb-3`}
+                  data-testid="flip-thresholds-status-note"
+                  role="note"
+                >
+                  {note}
+                </p>
+              )
+            })()}
             <TornadoChart
               rows={tornadoData.rows}
               expectedOutcome={tornadoData.expectedOutcome}
@@ -607,6 +624,7 @@ export const ResultsBody = memo(function ResultsBody({
                   expertMode={expertMode}
                   sensitivityReferenceLabel={resultsSectionData.sensitivityReference?.optionLabel ?? null}
                   showThinkingPatterns={!isAnalysisHeroPanelEnabled()}
+                  designationsWithheld={designationsWithheld}
                 />
               )
             })()}

--- a/src/components/results/StressTestSection.tsx
+++ b/src/components/results/StressTestSection.tsx
@@ -59,6 +59,28 @@ export interface StressTestSectionProps {
    * V5 decision_review is the eventual owner). Default true — flag-off
    * behaviour is byte-identical. */
   showThinkingPatterns?: boolean
+  /**
+   * ROADMAP 1.267 — `!DecisionVerdict.hasLeadingOption`, quoted from
+   * `useResultsSectionData`, never re-derived here.
+   *
+   * The two Thinking-pattern cards are UI-AUTHORED and every one of their
+   * four strings names a recommendation the producer has withdrawn:
+   * "switch your recommendation from X to Y", "does X usually outperform Y",
+   * and the two Ask-Olumi prompt drafts. Their only gate was
+   * `if (!winnerLabel) return null` in ResultsBody — and `winnerLabel` still
+   * resolves on a withheld run, because `recommendedOption` comes from
+   * `determineWinnerSelection` (identity), not from the verdict
+   * (entitlement). Identity survives withholding by design
+   * (decisionVerdict.ts); the RECOMMENDATION does not.
+   *
+   * REQUIRED, not optional-defaulting-false: an opt-in gate is a gate every
+   * future call site can forget. The compiler names every call site instead.
+   *
+   * Scope is deliberately the two authored cards ONLY. Sensitive assumptions
+   * and fragile factors are producer data and keep rendering — suppressing
+   * the section wholesale would be the over-suppression the ruling forbids.
+   */
+  designationsWithheld: boolean
   /** Recommended option label (winner) — drives template question phrasing. */
   winnerLabel: string
   /** Runner-up option label (alternative) — drives template question phrasing. */
@@ -206,7 +228,12 @@ export const StressTestSection = memo(function StressTestSection({
   expertMode,
   sensitivityReferenceLabel,
   showThinkingPatterns = true,
+  designationsWithheld,
 }: StressTestSectionProps) {
+  // ROADMAP 1.267. ONE derived boolean, used by both the count and the
+  // render — the #501 lesson that a designation suppressed in the list but
+  // still counted in the header is only half-suppressed.
+  const renderThinkingPatterns = showThinkingPatterns && !designationsWithheld
   // ── Sensitive assumptions (node-based) ───────────────────────────────────
   const sensitiveFactors = selectSensitiveFactors(drivers)
 
@@ -269,7 +296,7 @@ export const StressTestSection = memo(function StressTestSection({
   // Thinking patterns render both deterministic cards when the section
   // opens at all — they're meta-prompts, not data-derived. Wave 2: the
   // merged-panel flag retires them (showThinkingPatterns false).
-  const thinkingPatternsCount = showThinkingPatterns ? 2 : 0
+  const thinkingPatternsCount = renderThinkingPatterns ? 2 : 0
   const totalCount = sensitiveCount + thinkingPatternsCount + fragileCount
 
   const topFactorForPreview = sensitiveFactors[0]
@@ -311,7 +338,7 @@ export const StressTestSection = memo(function StressTestSection({
         )}
 
         {/* ── Thinking patterns ─────────────────────────────────────── */}
-        {showThinkingPatterns && (
+        {renderThinkingPatterns && (
         <div className="space-y-1.5" data-testid="stress-test-thinking-subsection">
           <h4 className={`${typography.panelHeader} text-text-header`}>
             Thinking patterns (2)

--- a/src/components/results/__tests__/DecisionConfidencePanel.caveatGuarantee.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.caveatGuarantee.spec.tsx
@@ -73,6 +73,20 @@ function makeData(opts: FixtureOpts): ResultsSectionDataReturn {
     // Use `in` so callers can explicitly set `coachingReadiness: undefined`
     // to simulate missing readiness (Brief 5.2 follow-up non-caveat tests).
     coachingReadiness: 'coachingReadiness' in opts ? opts.coachingReadiness : 'ready',
+    // ROADMAP 1.267. This fixture depicts a 97.4% / 2.4% run — a 95-point
+    // lead — and every assertion below is about the copy for a run where a
+    // leading option EXISTS. That precondition used to be implicit: the
+    // fixture omitted `verdict`, `buildCertaintyCopy`'s parameter was
+    // optional, and the leader-asserting rules were reached by default.
+    // The panel now resolves an absent verdict to NO_CLAIM_VERDICT (silence),
+    // so the run this fixture means has to say so.
+    verdict: {
+      leaderId: 'opt-a',
+      separation: 'clear',
+      hasLeadingOption: true,
+      gapPp: 95,
+      source: 'producer_near_tie',
+    },
   }
 
   const drivers: DriversSectionData = {

--- a/src/components/results/__tests__/DecisionConfidencePanel.completenessIntegration.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.completenessIntegration.spec.tsx
@@ -70,6 +70,20 @@ function makeData(opts: FixtureOpts = {}): ResultsSectionDataReturn {
     robustnessLevel: 'high',
     coachingReadiness: 'ready',
     coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+    // ROADMAP 1.267: this fixture is about COMPLETENESS qualifiers on a run
+    // that has a recommended option, so it must now say that a leading option
+    // is permitted. Without a verdict the panel resolves NO_CLAIM_VERDICT and
+    // renders the withheld headline — correct behaviour, wrong scenario.
+    // Note the partial-source case deliberately nulls the runner-up's
+    // winProbability; the verdict is a PRODUCER claim and is unaffected by
+    // that, which is the point of keeping the two separate.
+    verdict: {
+      leaderId: 'opt-a',
+      separation: 'clear',
+      hasLeadingOption: true,
+      gapPp: 50,
+      source: 'producer_near_tie',
+    },
   } as DecisionResultData
 
   const drivers: DriversSectionData = {

--- a/src/components/results/__tests__/SensitivityReferenceCaption.spec.tsx
+++ b/src/components/results/__tests__/SensitivityReferenceCaption.spec.tsx
@@ -114,6 +114,7 @@ describe('StressTestSection surface', () => {
         drivers={[makeDriver()]}
         winnerLabel="Option A"
         alternativeLabel="Option B"
+        designationsWithheld={false}
         sensitivityReferenceLabel="Hire a contractor"
       />,
     )
@@ -128,6 +129,7 @@ describe('StressTestSection surface', () => {
         drivers={[makeDriver()]}
         winnerLabel="Option A"
         alternativeLabel="Option B"
+        designationsWithheld={false}
         sensitivityReferenceLabel={null}
       />,
     )

--- a/src/components/results/__tests__/StressTestSection.factorSensitivityIntegration.spec.tsx
+++ b/src/components/results/__tests__/StressTestSection.factorSensitivityIntegration.spec.tsx
@@ -165,6 +165,7 @@ describe('StressTestSection — factor_sensitivity → DriverItem.confidence int
         fragileEdges={[]}
         winnerLabel="Option A"
         alternativeLabel="Option B"
+        designationsWithheld={false}
       />,
     )
 
@@ -189,6 +190,7 @@ describe('StressTestSection — factor_sensitivity → DriverItem.confidence int
         fragileEdges={[]}
         winnerLabel="Option A"
         alternativeLabel="Option B"
+        designationsWithheld={false}
       />,
     )
 

--- a/src/components/results/__tests__/StressTestSection.spec.tsx
+++ b/src/components/results/__tests__/StressTestSection.spec.tsx
@@ -74,6 +74,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[makeFragile()]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.getByText('Stress-test your decision')).toBeInTheDocument()
@@ -87,6 +88,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       const preview = screen.getByTestId('stress-test-preview')
@@ -102,6 +104,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       const preview = screen.getByTestId('stress-test-preview')
@@ -118,6 +121,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.getByTestId('stress-test-sensitive-subsection')).toBeInTheDocument()
@@ -140,6 +144,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.getByText('Sensitive assumptions (3)')).toBeInTheDocument()
@@ -153,6 +158,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.queryByTestId('stress-test-sensitive-subsection')).not.toBeInTheDocument()
@@ -171,6 +177,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
           onSendMessage={onSendMessage}
         />,
       )
@@ -190,6 +197,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.getByText('Thinking patterns (2)')).toBeInTheDocument()
@@ -204,6 +212,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       const card = screen.getByTestId('stress-test-disconfirmation')
@@ -237,6 +246,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       const card = screen.getByTestId('stress-test-disconfirmation')
@@ -255,6 +265,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       const card = screen.getByTestId('stress-test-disconfirmation')
@@ -269,6 +280,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       const card = screen.getByTestId('stress-test-outside-view')
@@ -293,6 +305,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           ]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.getByTestId('stress-test-fragile-subsection')).toBeInTheDocument()
@@ -308,6 +321,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.queryByTestId('stress-test-fragile-subsection')).not.toBeInTheDocument()
@@ -324,6 +338,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
           robustnessStatus="computed"
         />,
       )
@@ -341,6 +356,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
           robustnessStatus="unavailable"
         />,
       )
@@ -357,6 +373,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(screen.getByTestId('stress-test-didnt-run')).toBeInTheDocument()
@@ -370,6 +387,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
           robustnessStatus="computed"
           analysisDegraded
         />,
@@ -385,6 +403,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       expect(
@@ -401,6 +420,7 @@ describe('StressTestSection — Brief 5.8B D4', () => {
           fragileEdges={[makeFragile({ edge_id: 'e1', from_id: 'node_a' })]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
         />,
       )
       const html = container.innerHTML

--- a/src/components/results/__tests__/ctaPrefillNeverAutosend.spec.tsx
+++ b/src/components/results/__tests__/ctaPrefillNeverAutosend.spec.tsx
@@ -155,6 +155,7 @@ describe('StressTestSection "What if this changes?" — prefill, never auto-send
           fragileEdges={[]}
           winnerLabel="Option A"
           alternativeLabel="Option B"
+          designationsWithheld={false}
           onSendMessage={onSendMessage}
         />
         <AskOlumiDrawer />

--- a/src/components/results/__tests__/withheldProse.spec.tsx
+++ b/src/components/results/__tests__/withheldProse.spec.tsx
@@ -1,0 +1,314 @@
+/**
+ * WITHHELD RUNS MAY NOT PRESUPPOSE A LEADER — results-panel prose
+ * (ROADMAP 1.267, follow-up to PR #501).
+ *
+ * `withheldDesignations.spec.tsx` (this directory) pins the designations a
+ * string matcher cannot see — order, ordinals, crowns, screen-reader cues.
+ * `ownedLeaderClaim.surfaces.spec.ts` pins the HEADLINE prose. This file
+ * closes the surfaces neither reached: sentences elsewhere on the panel that
+ * quietly PRESUPPOSE a leading option on a run where CEE declined to name
+ * one.
+ *
+ *   · V7 evidence disclosure — the two lead-in notes above the flip-risk and
+ *     trade-off rows. The whole V7 top group is FLAGLESS, so these shipped on
+ *     every run.
+ *   · "What could change the result" — the flip-threshold status note, gated
+ *     only on the producer's `flipThresholdsStatus`.
+ *   · Stress-test thinking patterns — four UI-AUTHORED strings naming "your
+ *     recommendation", gated only on `winnerLabel` being non-empty.
+ *   · certaintyCopy's `verdict` parameter — the compile-time hole.
+ *
+ * ## The line this file draws
+ *
+ * DATA STAYS. Every flip probability, every driver, every fragile factor,
+ * every producer number keeps rendering on a withheld run; each surface below
+ * has a case asserting exactly that. A change that silenced the withheld turn
+ * by deleting the evidence would fail here, and would be a worse product than
+ * the defect.
+ *
+ * CLAIMS GO. What is removed is the presupposition: "the leading option",
+ * "your recommendation", "becomes the likely leader".
+ *
+ * ## Scope of the claim (CLAUDE.md trap 3)
+ *
+ * jsdom proves rendered text, presence and absence. It cannot prove layout or
+ * visual order. Nothing here claims a visual property.
+ */
+import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { V7EvidenceDisclosure } from '../v7/V7EvidenceDisclosure'
+import type { V7EvidenceModel } from '../v7/buildV7Lenses'
+import { V7_LENS_COPY } from '../v7/v7LensCopy'
+import { flipThresholdStatusNote } from '../utils/flipThresholdStatusNote'
+import { StressTestSection } from '../StressTestSection'
+import { buildCertaintyCopy } from '../utils/certaintyCopy'
+import { NO_CLAIM_VERDICT } from '../../../lib/decisionVerdict'
+import type { DriverItem } from '../types'
+import {
+  HIGH_LABEL,
+  MID_LABEL,
+  PERMITTED_VERDICT,
+  WITHHELD_VERDICT,
+} from '../__fixtures__/withheldDesignations.fixtures'
+
+/**
+ * Anything that asserts, or presupposes, that one option is out in front.
+ *
+ * Narrower than the fixture's `DESIGNATION_RE` on purpose: that one bans
+ * "leads" outright, which would also condemn a producer-supplied CONDITIONAL
+ * ("if X is above V, Y leads; below it, Z leads") — a symmetric, producer-
+ * owned statement that names both options and asserts no current leader.
+ * This matcher targets the unconditional leader NOUN and the possessive
+ * "your recommendation", which are the claims the verdict withholds.
+ */
+const LEADER_PRESUPPOSITION_RE = /leading option|likely leader|your recommendation/i
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 1 — the V7 evidence disclosure notes (flagless)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function evidenceModel(designationsWithheld: boolean): V7EvidenceModel {
+  return {
+    drivers: [
+      { factorKey: 'fac_tco', label: 'Three-Year Total Cost of Ownership', direction: 'negative', isEstimate: false, focusId: undefined },
+    ],
+    flipRisks: [
+      { fromId: 'fac_capacity', toId: 'out_value', edgeId: 'e1', fromLabel: 'Team capacity', toLabel: 'Value delivered', switchProbability: 0.48 },
+    ],
+    tradeOffs: [
+      { factorLabel: 'Team capacity', factorId: 'fac_capacity', splitValue: 30, splitUnit: '%', highWinnerLabel: HIGH_LABEL, lowWinnerLabel: MID_LABEL },
+    ],
+    designationsWithheld,
+  }
+}
+
+/** Open the disclosure and switch to one of its three views. */
+function openEvidence(designationsWithheld: boolean, view: 'flipRisks' | 'tradeOffs') {
+  const utils = render(<V7EvidenceDisclosure evidence={evidenceModel(designationsWithheld)} />)
+  // fireEvent, not node.click(): the raw DOM call escapes React's act() and
+  // the disclosure never re-renders, which makes every assertion below read a
+  // collapsed section — a false green that looks exactly like a real one.
+  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+  fireEvent.click(screen.getByTestId(`v7-evidence-tab-${view}`))
+  return utils
+}
+
+describe('V7 evidence disclosure — the two lead-in notes', () => {
+  it('ANTI-VACUITY: the PERMITTED notes carry the presupposition the matcher hunts', () => {
+    // Positive control for LEADER_PRESUPPOSITION_RE. Without this, the two
+    // withheld cases below could pass by matching nothing at all.
+    expect(V7_LENS_COPY.evidence.flipRisksNote(false)).toMatch(LEADER_PRESUPPOSITION_RE)
+    expect(V7_LENS_COPY.evidence.tradeOffsNote(false)).toMatch(LEADER_PRESUPPOSITION_RE)
+  })
+
+  it('WITHHELD: the flip-risks note presupposes no leader', () => {
+    const { container } = openEvidence(true, 'flipRisks')
+    expect(container.textContent ?? '').not.toMatch(LEADER_PRESUPPOSITION_RE)
+  })
+
+  it('WITHHELD: the trade-offs note presupposes no leader', () => {
+    const { container } = openEvidence(true, 'tradeOffs')
+    expect(V7_LENS_COPY.evidence.tradeOffsNote(true)).not.toMatch(LEADER_PRESUPPOSITION_RE)
+    expect(container.textContent ?? '').toContain(V7_LENS_COPY.evidence.tradeOffsNote(true))
+  })
+
+  it('WITHHELD DATA PRESERVED: the flip-risk row and its producer probability still render', () => {
+    openEvidence(true, 'flipRisks')
+    expect(screen.getByTestId('v7-evidence-flip-risks').textContent ?? '').toContain('Team capacity')
+    expect(screen.getByTestId('v7-evidence-flip-risks').textContent ?? '').toContain('48%')
+  })
+
+  it('WITHHELD DATA PRESERVED: the producer trade-off narration still names both options', () => {
+    openEvidence(true, 'tradeOffs')
+    const body = screen.getByTestId('v7-evidence-trade-offs').textContent ?? ''
+    expect(body).toContain(HIGH_LABEL)
+    expect(body).toContain(MID_LABEL)
+  })
+
+  it('PERMITTED: both notes are byte-identical to today', () => {
+    expect(V7_LENS_COPY.evidence.flipRisksNote(false)).toBe(
+      'Relationships whose plausible range can change the leading option.',
+    )
+    expect(V7_LENS_COPY.evidence.tradeOffsNote(false)).toBe(
+      'Where the leading option depends on an assumption.',
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 3 — the flip-threshold status note ("What could change the result")
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('flipThresholdStatusNote', () => {
+  const withheld = (status: string, hasUnresolved = false) =>
+    flipThresholdStatusNote({ status, hasUnresolved, designationsWithheld: true })
+  const permitted = (status: string, hasUnresolved = false) =>
+    flipThresholdStatusNote({ status, hasUnresolved, designationsWithheld: false })
+
+  it('ANTI-VACUITY: all three PERMITTED sentences carry the presupposition', () => {
+    expect(permitted('all_no_effect')).toMatch(LEADER_PRESUPPOSITION_RE)
+    expect(permitted('partial_no_effect')).toMatch(LEADER_PRESUPPOSITION_RE)
+    expect(permitted('partial_no_effect', true)).toMatch(LEADER_PRESUPPOSITION_RE)
+  })
+
+  it('WITHHELD: none of the three sentences presupposes a leader', () => {
+    for (const s of [withheld('all_no_effect'), withheld('partial_no_effect'), withheld('partial_no_effect', true)]) {
+      expect(s, `status note leaked a presupposition: "${s}"`).not.toMatch(LEADER_PRESUPPOSITION_RE)
+    }
+  })
+
+  it('WITHHELD DATA PRESERVED: each status still says what the producer found', () => {
+    expect(withheld('all_no_effect')).toContain('No single tested factor changed')
+    expect(withheld('partial_no_effect')).toContain('Some factors did not change')
+    expect(withheld('partial_no_effect', true)).toContain('others could not be resolved')
+    // The unresolved variant is still DISTINCT from the plain one — the two
+    // branches did not collapse into one sentence.
+    expect(withheld('partial_no_effect', true)).not.toBe(withheld('partial_no_effect'))
+  })
+
+  it('PERMITTED: all three sentences are byte-identical to today', () => {
+    expect(permitted('all_no_effect')).toBe(
+      'No single tested factor changed the leading option within the current range.',
+    )
+    expect(permitted('partial_no_effect')).toBe(
+      'Some factors did not change the leading option within the current range.',
+    )
+    expect(permitted('partial_no_effect', true)).toBe(
+      'Some factors did not change the leading option within the current range, and others could not be resolved.',
+    )
+  })
+
+  it('an unclassified status renders NO line, in either verdict state', () => {
+    // Null rather than '' — the caller must not emit an empty paragraph.
+    expect(withheld('computed')).toBeNull()
+    expect(permitted('computed')).toBeNull()
+    expect(withheld(undefined as unknown as string)).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 4 — the stress-test thinking patterns
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STRESS_DRIVER: DriverItem = {
+  factorKey: 'fac_capacity',
+  factorLabel: 'Team capacity',
+  rankFlipRate: 0.31,
+  confidence: 0.6,
+  confidenceProvenance: 'producer',
+  normalisedInfluence: 1,
+  rank: 1,
+  canFocus: false,
+} as unknown as DriverItem
+
+function renderStressTest(designationsWithheld: boolean) {
+  return render(
+    <StressTestSection
+      drivers={[STRESS_DRIVER]}
+      fragileEdges={[]}
+      winnerLabel={HIGH_LABEL}
+      alternativeLabel={MID_LABEL}
+      designationsWithheld={designationsWithheld}
+    />,
+  )
+}
+
+describe('StressTestSection — the UI-authored thinking patterns', () => {
+  /**
+   * The finding this case records: the sweep asked whether these surfaces
+   * might ALREADY be dark on a withheld run, because `winnerLabel` comes from
+   * `recommendedOption`. They are not. `recommendedOption` is resolved by
+   * `determineWinnerSelection` from `robustness.recommended_option_id` — which
+   * CEE still sends on a withheld turn (see WITHHELD_REPORT in the shared
+   * fixture, whose `recommended_option_id` is populated) — so `winnerLabel`
+   * resolves and the only gate stays open.
+   */
+  it('ANTI-VACUITY: with the gate off, all four authored strings are present', () => {
+    const { container } = renderStressTest(false)
+    const text = container.textContent ?? ''
+    expect(text).toMatch(LEADER_PRESUPPOSITION_RE)
+    expect(text).toContain(`switch your recommendation from ${HIGH_LABEL} to ${MID_LABEL}`)
+    expect(text).toContain(`does ${HIGH_LABEL} usually outperform ${MID_LABEL}`)
+    expect(screen.getByTestId('stress-test-thinking-subsection')).toBeInTheDocument()
+  })
+
+  it('WITHHELD: the thinking-pattern cards do not render', () => {
+    renderStressTest(true)
+    expect(screen.queryByTestId('stress-test-thinking-subsection')).toBeNull()
+    expect(screen.queryByTestId('stress-test-disconfirmation')).toBeNull()
+    expect(screen.queryByTestId('stress-test-outside-view')).toBeNull()
+  })
+
+  it('WITHHELD: no rendered string presupposes a leader or a recommendation', () => {
+    const { container } = renderStressTest(true)
+    expect(container.textContent ?? '').not.toMatch(LEADER_PRESUPPOSITION_RE)
+  })
+
+  /**
+   * #501's lesson applied: a designation suppressed from the list but still
+   * counted in the header is only half-suppressed. The count must move too.
+   */
+  it('WITHHELD: the header count drops by exactly the two cards', () => {
+    const { unmount } = renderStressTest(false)
+    const permittedCount = Number(screen.getByTestId('accordion-stress-test').textContent?.match(/\d+/)?.[0])
+    unmount()
+    renderStressTest(true)
+    const withheldCount = Number(screen.getByTestId('accordion-stress-test').textContent?.match(/\d+/)?.[0])
+    expect(permittedCount - withheldCount).toBe(2)
+  })
+
+  it('WITHHELD DATA PRESERVED: the sensitive-assumption row still renders', () => {
+    renderStressTest(true)
+    expect(screen.getByTestId('stress-test-sensitive-subsection').textContent ?? '')
+      .toContain('Team capacity')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 5 — certaintyCopy's verdict parameter, now REQUIRED
+//
+// The compile-time half of this fix cannot be asserted at runtime (a missing
+// required property is a type error, not a thrown exception), so the runtime
+// half pins the BEHAVIOUR the required parameter guarantees: the fall-through
+// that `undefined` used to reach is now unreachable without an explicit
+// no-claim verdict, and that verdict lands on the withheld headline.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildCertaintyCopy — no caller can reach the leader rules without a verdict', () => {
+  const base = {
+    winnerLabel: HIGH_LABEL,
+    confidenceTier: 'strong' as const,
+    coachingReadiness: 'ready' as const,
+    recommendationStability: 0.9,
+    analysisStatus: 'computed' as const,
+    optionCount: 3,
+    winProbabilityGap: 30,
+  }
+
+  it('ANTI-VACUITY: a PERMITTED verdict still reaches the leader-asserting rule', () => {
+    expect(buildCertaintyCopy({ ...base, verdict: PERMITTED_VERDICT }).headline)
+      .toBe(`${HIGH_LABEL} is the leading option`)
+  })
+
+  it('the explicit no-claim verdict lands on the withheld headline, not a leader claim', () => {
+    const copy = buildCertaintyCopy({ ...base, verdict: NO_CLAIM_VERDICT })
+    expect(copy.headline).toBe('the analysis did not put an option forward')
+    expect(copy.headline).not.toMatch(LEADER_PRESUPPOSITION_RE)
+    // conservative: true is what blocks the producer's coaching headline from
+    // overriding this line in DecisionConfidencePanel.
+    expect(copy.conservative).toBe(true)
+  })
+
+  it('the shared WITHHELD fixture verdict behaves identically to NO_CLAIM_VERDICT', () => {
+    expect(buildCertaintyCopy({ ...base, verdict: WITHHELD_VERDICT }))
+      .toEqual(buildCertaintyCopy({ ...base, verdict: NO_CLAIM_VERDICT }))
+  })
+
+  it('NO_CLAIM_VERDICT is the no-claim shape, not a denial', () => {
+    // 'unknown', never 'tied': a denial ("no clear leading option") is a
+    // second claim this verdict equally has no authority for.
+    expect(NO_CLAIM_VERDICT.hasLeadingOption).toBe(false)
+    expect(NO_CLAIM_VERDICT.separation).toBe('unknown')
+    expect(NO_CLAIM_VERDICT.source).toBe('none')
+  })
+})

--- a/src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx
+++ b/src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx
@@ -246,7 +246,7 @@ export function HeroEvidenceDisclosure({
           {activeView === 'flipRisks' && (
             <div className="space-y-1.5" data-testid="hero-evidence-flip-risks">
               <p className={`${typography.panelMeta} text-text-light`}>
-                {HERO_COPY.evidence.flipRisksNote}
+                {HERO_COPY.evidence.flipRisksNote(evidence.designationsWithheld)}
               </p>
               {evidence.flipRisks.map((r, i) => {
                 const key = `flip-${i}`

--- a/src/components/results/analysis-hero/__tests__/content.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/content.spec.tsx
@@ -661,6 +661,7 @@ describe('Wave 2 (§6.6): Why and what could change it disclosure', () => {
           },
         ],
         tradeOffs: null,
+        designationsWithheld: false,
         ...overrides,
       },
     }

--- a/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/copyHygiene.spec.tsx
@@ -106,16 +106,24 @@ const UI_COPY: string[] = [
   HERO_COPY.evidence.heading,
   HERO_COPY.evidence.subtitle,
   HERO_COPY.evidence.driversNote,
-  HERO_COPY.evidence.flipRisksNote,
+  // ROADMAP 1.267: the three flip-risk strings are now verdict-dependent, so
+  // BOTH branches are swept. A withheld-run sentence is user-facing copy and
+  // is held to the identical hygiene rules — listing only the permitted branch
+  // would leave half the shipped strings unchecked.
+  HERO_COPY.evidence.flipRisksNote(false),
+  HERO_COPY.evidence.flipRisksNote(true),
   HERO_COPY.evidence.switchMeta('48%'),
   HERO_COPY.evidence.driversTab,
   HERO_COPY.evidence.flipRisksTab,
   HERO_COPY.evidence.tradeOffsTab,
   HERO_COPY.evidence.seeAllFactors,
   HERO_COPY.evidence.showFewer,
-  HERO_COPY.evidence.flipRiskWithAlternative('Team capacity', HERO_COPY.evidence.fallsBelow, '30%', 'Two developers'),
-  HERO_COPY.evidence.flipRiskNoAlternative('Salary cost', HERO_COPY.evidence.risesAbove, '$60,000'),
-  HERO_COPY.evidence.flipRiskNoAlternative('Team capacity', HERO_COPY.evidence.crosses, '40%'),
+  HERO_COPY.evidence.flipRiskWithAlternative('Team capacity', HERO_COPY.evidence.fallsBelow, '30%', 'Two developers', false),
+  HERO_COPY.evidence.flipRiskWithAlternative('Team capacity', HERO_COPY.evidence.fallsBelow, '30%', 'Two developers', true),
+  HERO_COPY.evidence.flipRiskNoAlternative('Salary cost', HERO_COPY.evidence.risesAbove, '$60,000', false),
+  HERO_COPY.evidence.flipRiskNoAlternative('Salary cost', HERO_COPY.evidence.risesAbove, '$60,000', true),
+  HERO_COPY.evidence.flipRiskNoAlternative('Team capacity', HERO_COPY.evidence.crosses, '40%', false),
+  HERO_COPY.evidence.flipRiskNoAlternative('Team capacity', HERO_COPY.evidence.crosses, '40%', true),
   HERO_COPY.evidence.tradeOffGain,
   HERO_COPY.evidence.tradeOffGiveUp,
   HERO_COPY.evidence.tradeOffDependsOn,

--- a/src/components/results/analysis-hero/__tests__/withheldProse.hero.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/withheldProse.hero.spec.tsx
@@ -1,0 +1,214 @@
+/**
+ * WITHHELD RUNS MAY NOT PRESUPPOSE A LEADER — the analysis-hero prose half
+ * (ROADMAP 1.267, follow-up to PR #501).
+ *
+ * #501 removed the designations a string matcher CANNOT see (order, ordinals,
+ * crowns, screen-reader cues). This file and its siblings remove the ones it
+ * can: sentences that PRESUPPOSE a leading option exists, on a run where CEE
+ * has declined to put one forward.
+ *
+ * The hero's three flip-risk strings were the widest leak, because they are
+ * built unconditionally in `buildHeroModel` with no verdict input at all:
+ *
+ *   · the view note   "Chance the leading option changes when a relationship
+ *                      is varied within its plausible range."
+ *   · with-alternative "If X falls below V, Y becomes the likely leader."
+ *   · no-alternative   "If X rises above V, the leading option is likely to
+ *                      change."
+ *
+ * ## The distinction being pinned
+ *
+ * The flip NUMBERS are data and must survive: the factor, its threshold, its
+ * unit, the direction, the producer's `alternative_winner_label`, and the
+ * switch probability. Only the leader FRAMING around them is withheld. A
+ * change that silences the withheld run by dropping the flip rows would fail
+ * the DATA PRESERVED cases below — it would cost the user exactly the
+ * computed facts the ruling protects.
+ *
+ * ## Lives here, not in results/__tests__
+ *
+ * `inertness.spec.ts` allows analysis-hero imports only from inside the
+ * module and from ResultsBody. Same reason the #501 hero half lives here.
+ *
+ * ## Scope of the claim (CLAUDE.md trap 3)
+ *
+ * These are string assertions over a built model and, for the disclosure, a
+ * jsdom render. They prove WORDING and presence. They do not prove layout.
+ */
+import { describe, expect, it } from 'vitest'
+import { buildHeroModel } from '../buildHeroModel'
+import { HERO_COPY } from '../heroCopy'
+import type { HeroChartModel } from '../heroTypes'
+import { makeHeroData } from '../__fixtures__/hero.fixtures'
+import {
+  PERMITTED_VERDICT,
+  WITHHELD_VERDICT,
+  withheldFixtureOptions as options,
+} from '../../__fixtures__/withheldDesignations.fixtures'
+
+/**
+ * Anything that asserts, or presupposes, that one option is out in front.
+ *
+ * Deliberately NARROWER than the fixture's `DESIGNATION_RE`: that one bans
+ * "leads" outright, which would also condemn a producer-supplied CONDITIONAL
+ * ("if X, then Y leads") — a different claim with a different owner. This
+ * matcher targets the unconditional leader NOUN and the verb phrases that
+ * only make sense when a current leader exists.
+ */
+const LEADER_PRESUPPOSITION_RE = /leading option|likely leader|the leader\b/i
+
+/** Two producer flip thresholds: one WITH an alternative winner, one without. */
+const FLIP_THRESHOLDS = [
+  {
+    label: 'Team capacity',
+    node_id: 'fac_capacity',
+    flip_value: 30,
+    current_value: 45,
+    unit: '%',
+    alternative_winner_label: 'Upskill the current team',
+  },
+  {
+    label: 'Salary cost',
+    node_id: 'fac_salary',
+    flip_value: 60000,
+    current_value: 52000,
+    unit: '$',
+  },
+]
+
+function heroModel(verdict: typeof WITHHELD_VERDICT): HeroChartModel {
+  return buildHeroModel(
+    makeHeroData({
+      options: options(),
+      recommendation: {
+        verdict,
+        storyHeadlines: {},
+        flipThresholds: FLIP_THRESHOLDS,
+      } as NonNullable<Parameters<typeof makeHeroData>[0]>['recommendation'],
+    }),
+  ) as HeroChartModel
+}
+
+const flipTexts = (verdict: typeof WITHHELD_VERDICT): string[] =>
+  heroModel(verdict).evidence.flipRisks.map((r) => r.text)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ANTI-VACUITY — if the fixture pair stops discriminating, or the flip rows
+// stop being built at all, every assertion below starts passing for the wrong
+// reason. Trap 13: an absence assertion must first prove it can see a
+// presence.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('the flip-risk harness can actually go red', () => {
+  it('the fixture pair withholds on one verdict and permits on the other', () => {
+    expect(WITHHELD_VERDICT.hasLeadingOption).toBe(false)
+    expect(PERMITTED_VERDICT.hasLeadingOption).toBe(true)
+  })
+
+  it('both verdicts build the SAME two flip rows (so absence is never why)', () => {
+    expect(flipTexts(WITHHELD_VERDICT)).toHaveLength(2)
+    expect(flipTexts(PERMITTED_VERDICT)).toHaveLength(2)
+  })
+
+  it('the PERMITTED wording contains the presupposition the matcher hunts', () => {
+    // Positive control for LEADER_PRESUPPOSITION_RE itself: if this stops
+    // matching, the withheld assertions below are vacuous.
+    expect(flipTexts(PERMITTED_VERDICT).join(' ')).toMatch(LEADER_PRESUPPOSITION_RE)
+    expect(HERO_COPY.evidence.flipRisksNote(false)).toMatch(LEADER_PRESUPPOSITION_RE)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 2 — heroCopy.evidence, as pure copy
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('heroCopy.evidence — the three flip-risk strings', () => {
+  it('WITHHELD: the view note presupposes no leader', () => {
+    expect(HERO_COPY.evidence.flipRisksNote(true)).not.toMatch(LEADER_PRESUPPOSITION_RE)
+  })
+
+  it('WITHHELD: neither sentence template presupposes a leader', () => {
+    expect(
+      HERO_COPY.evidence.flipRiskWithAlternative('Team capacity', 'falls below', '30%', 'Upskill', true),
+    ).not.toMatch(LEADER_PRESUPPOSITION_RE)
+    expect(
+      HERO_COPY.evidence.flipRiskNoAlternative('Salary cost', 'rises above', '$60,000', true),
+    ).not.toMatch(LEADER_PRESUPPOSITION_RE)
+  })
+
+  it('WITHHELD: the producer alternative-winner label SURVIVES (no over-suppression)', () => {
+    expect(
+      HERO_COPY.evidence.flipRiskWithAlternative('Team capacity', 'falls below', '30%', 'Upskill', true),
+    ).toContain('Upskill')
+  })
+
+  /**
+   * PERMITTED is byte-identical to the strings that shipped before this
+   * change. Written out in full rather than compared to a helper: a helper
+   * would have to restate the string anyway, and a literal is the only form
+   * that catches a one-word drift.
+   */
+  it('PERMITTED: every string is byte-identical to today', () => {
+    expect(HERO_COPY.evidence.flipRisksNote(false)).toBe(
+      'Chance the leading option changes when a relationship is varied within its plausible range.',
+    )
+    expect(
+      HERO_COPY.evidence.flipRiskWithAlternative('Team capacity', 'falls below', '30%', 'Upskill', false),
+    ).toBe('If Team capacity falls below 30%, Upskill becomes the likely leader.')
+    expect(
+      HERO_COPY.evidence.flipRiskNoAlternative('Salary cost', 'rises above', '$60,000', false),
+    ).toBe('If Salary cost rises above $60,000, the leading option is likely to change.')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 2 — buildHeroModel, i.e. the wiring, not just the copy
+//
+// The copy cases above would still pass if buildHeroModel never passed the
+// verdict through. These are the ones that prove the gate is CONNECTED.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildHeroModel — flip-risk rows quote the verdict', () => {
+  it('WITHHELD: no built flip sentence presupposes a leader', () => {
+    for (const text of flipTexts(WITHHELD_VERDICT)) {
+      expect(text, `flip row leaked a leader presupposition: "${text}"`).not.toMatch(
+        LEADER_PRESUPPOSITION_RE,
+      )
+    }
+  })
+
+  it('WITHHELD: the model carries the flag the disclosure note reads', () => {
+    expect(heroModel(WITHHELD_VERDICT).evidence.designationsWithheld).toBe(true)
+    expect(heroModel(PERMITTED_VERDICT).evidence.designationsWithheld).toBe(false)
+  })
+
+  it('WITHHELD DATA PRESERVED: factor, threshold, unit and direction all survive', () => {
+    const [withAlt, noAlt] = flipTexts(WITHHELD_VERDICT)
+    // Factor labels
+    expect(withAlt).toContain('Team capacity')
+    expect(noAlt).toContain('Salary cost')
+    // Producer thresholds, with their units
+    expect(withAlt).toContain('30%')
+    expect(noAlt).toContain('$60,000')
+    // Direction, derived from current_value vs flip_value
+    expect(withAlt).toContain('falls below')
+    expect(noAlt).toContain('rises above')
+    // The producer's alternative winner
+    expect(withAlt).toContain('Upskill the current team')
+  })
+
+  it('WITHHELD DATA PRESERVED: the switch-probability slot is untouched', () => {
+    const withheld = heroModel(WITHHELD_VERDICT).evidence.flipRisks
+    const permitted = heroModel(PERMITTED_VERDICT).evidence.flipRisks
+    expect(withheld.map((r) => r.switchMeta)).toEqual(permitted.map((r) => r.switchMeta))
+    expect(withheld.map((r) => r.magnitude)).toEqual(permitted.map((r) => r.magnitude))
+    expect(withheld.map((r) => r.targetId)).toEqual(permitted.map((r) => r.targetId))
+  })
+
+  it('PERMITTED: the built sentences are byte-identical to today', () => {
+    expect(flipTexts(PERMITTED_VERDICT)).toEqual([
+      'If Team capacity falls below 30%, Upskill the current team becomes the likely leader.',
+      'If Salary cost rises above $60,000, the leading option is likely to change.',
+    ])
+  })
+})

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -892,10 +892,24 @@ export function buildHeroModel(
       const alt = ft.alternative_winner_label
         ? stripEncodingNotation(ft.alternative_winner_label)
         : null
+      // ROADMAP 1.267: the flip VALUE, its unit, its direction and the
+      // producer's alternative-winner label all survive on a withheld run —
+      // only the leader framing around them changes.
       const text =
         alt && !containsBannedTerm(alt)
-          ? HERO_COPY.evidence.flipRiskWithAlternative(label, direction, value, alt)
-          : HERO_COPY.evidence.flipRiskNoAlternative(label, direction, value)
+          ? HERO_COPY.evidence.flipRiskWithAlternative(
+              label,
+              direction,
+              value,
+              alt,
+              designationsWithheld,
+            )
+          : HERO_COPY.evidence.flipRiskNoAlternative(
+              label,
+              direction,
+              value,
+              designationsWithheld,
+            )
       // Fail-closed focus pre-gate: with canvas knowledge supplied, a
       // node_id absent from the canvas yields a text row, not a dead button.
       const rawTarget = ft.node_id || null
@@ -969,7 +983,12 @@ export function buildHeroModel(
     // live adapter has none (producer gap), so the slot is null and the
     // view exists only in gallery fixtures. The UI must not invent
     // trade-offs from labels.
-    evidence: { drivers: evidenceDrivers, flipRisks: evidenceFlipRisks, tradeOffs: null },
+    evidence: {
+      drivers: evidenceDrivers,
+      flipRisks: evidenceFlipRisks,
+      tradeOffs: null,
+      designationsWithheld,
+    },
     // Producer-gap slots — the LIVE adapter NEVER populates these (no
     // display-safe trust/status label: issues 219/221; no coaching
     // top-action contract: issue 220). They render only from typed

--- a/src/components/results/analysis-hero/fixtures/galleryModels.ts
+++ b/src/components/results/analysis-hero/fixtures/galleryModels.ts
@@ -56,7 +56,7 @@ function fixtureChart(o: Partial<HeroChartModel>): HeroChartModel {
     showGoalHint: false,
     mainReason: null,
     quickLinks: { mainDriver: null, topFlipRisk: null },
-    evidence: { drivers: [], flipRisks: [], tradeOffs: null },
+    evidence: { drivers: [], flipRisks: [], tradeOffs: null, designationsWithheld: false },
     trustLine: null,
     statusChip: null,
     focusAction: null,

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -375,17 +375,52 @@ export const HERO_COPY = {
      * claim is made (the per-row quality slot stays absent until a
      * display-safe producer label exists, issues 219/221). */
     driversNote: 'Ranked by effect on the analysed outcome. Evidence quality is separate.',
-    /** Flip-risks-view note (prototype copy). */
-    flipRisksNote:
-      'Chance the leading option changes when a relationship is varied within its plausible range.',
+    /**
+     * Flip-risks-view note (prototype copy).
+     *
+     * ROADMAP 1.267 — the flip PROBABILITIES are data; "the leading option"
+     * is a claim, and it presupposes one exists. The withheld branch keeps
+     * the same fact (a relationship varied within its plausible range moves
+     * the result) without the presupposition. Permitted is byte-identical to
+     * the string it replaced.
+     *
+     * One function of the verdict, not two sibling constants: a `…Withheld`
+     * twin beside it would be a hand-maintained mirror (trap 12).
+     */
+    flipRisksNote: (designationsWithheld: boolean) =>
+      designationsWithheld
+        ? 'Chance the comparison between options changes when a relationship is varied within its plausible range.'
+        : 'Chance the leading option changes when a relationship is varied within its plausible range.',
     /** Switch-probability meta beside a flip row, e.g. "48% switch". */
     switchMeta: (pct: string) => `${pct} switch`,
     seeAllFactors: 'See all factors',
     showFewer: 'Show fewer',
-    flipRiskWithAlternative: (factor: string, direction: string, value: string, alternative: string) =>
-      `If ${factor} ${direction} ${value}, ${alternative} becomes the likely leader.`,
-    flipRiskNoAlternative: (factor: string, direction: string, value: string) =>
-      `If ${factor} ${direction} ${value}, the leading option is likely to change.`,
+    /**
+     * ROADMAP 1.267. The producer's `alternative_winner_label` SURVIVES on a
+     * withheld run — it is data, and dropping it would be the
+     * over-suppression the ruling forbids. What goes is the designation
+     * verb: "becomes the likely leader" both asserts a leader exists after
+     * the flip and implies a different one exists now.
+     */
+    flipRiskWithAlternative: (
+      factor: string,
+      direction: string,
+      value: string,
+      alternative: string,
+      designationsWithheld: boolean,
+    ) =>
+      designationsWithheld
+        ? `If ${factor} ${direction} ${value}, the comparison shifts towards ${alternative}.`
+        : `If ${factor} ${direction} ${value}, ${alternative} becomes the likely leader.`,
+    flipRiskNoAlternative: (
+      factor: string,
+      direction: string,
+      value: string,
+      designationsWithheld: boolean,
+    ) =>
+      designationsWithheld
+        ? `If ${factor} ${direction} ${value}, the comparison is likely to change.`
+        : `If ${factor} ${direction} ${value}, the leading option is likely to change.`,
     fallsBelow: 'falls below',
     risesAbove: 'rises above',
     // Direction-neutral fallback (UI-SEM-074): used when flip_value equals

--- a/src/components/results/analysis-hero/heroTypes.ts
+++ b/src/components/results/analysis-hero/heroTypes.ts
@@ -171,6 +171,19 @@ export interface HeroEvidenceModel {
     dependsOn: string
     watch: string
   }> | null
+  /**
+   * ROADMAP 1.267. The flip-risk ROWS are producer data and always render;
+   * the lead-in NOTE above them ("Chance the leading option changes…") is a
+   * claim that presupposes a leader. Carried on the model — the disclosure
+   * quotes the one verdict `buildHeroModel` already resolved and never
+   * re-derives one.
+   *
+   * REQUIRED, deliberately (cf. `buildCertaintyCopy`'s `verdict`): an
+   * optional flag that the live producer always sets and every fixture omits
+   * is a hole with a green test suite over it. There are three constructors
+   * of this model in the repo and the compiler names all of them.
+   */
+  designationsWithheld: boolean
 }
 
 export interface HeroChartModel {

--- a/src/components/results/utils/__tests__/certaintyCopy.spec.ts
+++ b/src/components/results/utils/__tests__/certaintyCopy.spec.ts
@@ -22,7 +22,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { buildCertaintyCopy, shouldSoftenPhrasing } from '../certaintyCopy'
-import type { DecisionVerdict } from '../../../../lib/decisionVerdict'
+import { NO_CLAIM_VERDICT, type DecisionVerdict } from '../../../../lib/decisionVerdict'
 
 const WINNER = 'Option A'
 
@@ -37,10 +37,26 @@ const clearVerdict = (): DecisionVerdict => ({
   leaderId: 'opt_a', separation: 'clear', hasLeadingOption: true, gapPp: 52, source: 'producer_near_tie',
 })
 
+// ROADMAP 1.267 — WHY EVERY CASE BELOW NOW NAMES A VERDICT.
+//
+// `verdict` used to be OPTIONAL and most of this table omitted it. That was
+// not a tidy default: with no verdict the withheld branch could not fire, so
+// each of these cases silently exercised the leader-ASSERTING rules while
+// documenting nothing about the precondition that entitles them. The
+// parameter is required now, and the tier × stability table is the copy for a
+// run where a leading option EXISTS — so `clearVerdict()` states that
+// precondition at every call site rather than leaving it to a default.
+//
+// The cases that are ABOUT a withheld, tied or single-option run pass their
+// own verdict (rows 2, 3b, 3c and the tie tests) and are untouched: they were
+// already explicit, which is exactly why they were the only ones that could
+// see the defect.
+
 describe('buildCertaintyCopy — decision table', () => {
   it('row 1: partial analysis overrides all tier inputs', () => {
     expect(
       buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         analysisStatus: 'partial',
         confidenceTier: 'strong',
@@ -97,6 +113,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
   it('row 2 boundary: stability exactly 0.70 is considered stable (Rule 4 fires for needs_work)', () => {
     const result = buildCertaintyCopy({
+      verdict: clearVerdict(),
       winnerLabel: WINNER,
       recommendationStability: 0.70,
       confidenceTier: 'needs_work',
@@ -151,6 +168,7 @@ describe('buildCertaintyCopy — decision table', () => {
   it('row 3: single option renders its own copy before any tier check', () => {
     expect(
       buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         optionCount: 1,
         confidenceTier: 'strong',
@@ -167,6 +185,7 @@ describe('buildCertaintyCopy — decision table', () => {
   describe('row 4 — soft headline path (tier ∈ {needs_work, fair} AND stability < 0.85)', () => {
     it('needs_work + absent stability → soft headline + evidence caveat', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
       })
@@ -182,6 +201,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('needs_work + stability 0.84 → soft headline + caveat', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         recommendationStability: 0.84,
@@ -192,6 +212,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('fair + absent stability → soft headline, NO caveat (fair is not evidence-weak)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'fair',
       })
@@ -202,6 +223,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('fair + stability 0.84 → soft headline, NO caveat', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'fair',
         recommendationStability: 0.84,
@@ -214,6 +236,7 @@ describe('buildCertaintyCopy — decision table', () => {
   describe('stability override (tier ∈ {needs_work, fair} AND stability ≥ 0.85)', () => {
     it('needs_work + 0.85 → confident fallback "is the leading option", no caveat', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         recommendationStability: 0.85,
@@ -225,6 +248,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('needs_work + 0.95 → confident fallback', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         recommendationStability: 0.95,
@@ -235,6 +259,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('fair + 0.87 → confident fallback, no caveat', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'fair',
         recommendationStability: 0.87,
@@ -252,6 +277,7 @@ describe('buildCertaintyCopy — decision table', () => {
       ['not_ready'],
     ] as const)('strong + weak readiness %s + stability 0.75 → confident "is the leading option" (readiness never softens strong)', (readiness) => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'strong',
         coachingReadiness: readiness,
@@ -263,6 +289,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('needs_work + readiness=ready + stability 0.75 → soft (readiness does not rescue)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         coachingReadiness: 'ready',
@@ -274,6 +301,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('needs_work + readiness=needs_evidence + stability 0.90 → confident (stability override beats weak readiness)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         coachingReadiness: 'needs_evidence',
@@ -285,6 +313,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('fair + readiness=not_ready + stability 0.80 → soft (unambiguous soft path)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'fair',
         coachingReadiness: 'not_ready',
@@ -299,6 +328,7 @@ describe('buildCertaintyCopy — decision table', () => {
     it('close_call + unknown tier → definitive "is the leading option", conservative: true', () => {
       expect(
         buildCertaintyCopy({
+          verdict: clearVerdict(),
           winnerLabel: WINNER,
           confidenceTier: 'unknown',
           coachingReadiness: 'close_call',
@@ -314,6 +344,7 @@ describe('buildCertaintyCopy — decision table', () => {
     it('close_call wins over needs_work + high stability (tier path would reach confident fallback first, but Rule 4 soft gate applies only when stability is weak — so close_call precedence is tested via a tier that does not trigger Rule 4)', () => {
       // Rule 4 takes precedence when applicable. Use a non-soft tier to isolate close_call.
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'strong',
         coachingReadiness: 'close_call',
@@ -326,6 +357,7 @@ describe('buildCertaintyCopy — decision table', () => {
   it('row 6: strong + ready → "is the leading option" (only path allowing coaching override)', () => {
     expect(
       buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'strong',
         coachingReadiness: 'ready',
@@ -340,7 +372,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
   describe('row 7 — confident fallback', () => {
     it('no tier + no readiness + no gap → "is the leading option" (avoids bare "leads")', () => {
-      expect(buildCertaintyCopy({ winnerLabel: WINNER })).toEqual({
+      expect(buildCertaintyCopy({ verdict: clearVerdict(), winnerLabel: WINNER })).toEqual({
         headline: `${WINNER} is the leading option`,
         sub: null,
         caveat: null,
@@ -350,6 +382,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('strong + no readiness + no gap → "is the leading option"', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'strong',
       })
@@ -377,6 +410,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('partial analysis wins over unstable wins over weak tier (full chain)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         analysisStatus: 'partial',
         recommendationStability: 0.55,
@@ -390,6 +424,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('single option wins over weak tier (no caveat — no alternative to compare)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         optionCount: 1,
         confidenceTier: 'needs_work',
@@ -401,15 +436,21 @@ describe('buildCertaintyCopy — decision table', () => {
   })
 
   it('UI copy compliance: no em dashes in any returned string', () => {
+    // ROADMAP 1.267: the em-dash sweep now covers BOTH verdict states, so a
+    // withheld-run string can never slip an em dash past it. The permitted
+    // rows carry `clearVerdict()`; the withheld row carries the no-claim
+    // verdict and exercises the branch the other eight cannot reach.
     const cases: Parameters<typeof buildCertaintyCopy>[0][] = [
-      { winnerLabel: WINNER },
-      { winnerLabel: WINNER, analysisStatus: 'partial' },
-      { winnerLabel: WINNER, recommendationStability: 0.55 },
-      { winnerLabel: WINNER, optionCount: 1 },
-      { winnerLabel: WINNER, confidenceTier: 'needs_work' },
-      { winnerLabel: WINNER, confidenceTier: 'fair' },
-      { winnerLabel: WINNER, confidenceTier: 'strong', coachingReadiness: 'ready' },
-      { winnerLabel: WINNER, confidenceTier: 'unknown', coachingReadiness: 'close_call' },
+      { verdict: clearVerdict(), winnerLabel: WINNER },
+      { verdict: clearVerdict(), winnerLabel: WINNER, analysisStatus: 'partial' },
+      { verdict: clearVerdict(), winnerLabel: WINNER, recommendationStability: 0.55 },
+      { verdict: clearVerdict(), winnerLabel: WINNER, optionCount: 1 },
+      { verdict: clearVerdict(), winnerLabel: WINNER, confidenceTier: 'needs_work' },
+      { verdict: clearVerdict(), winnerLabel: WINNER, confidenceTier: 'fair' },
+      { verdict: clearVerdict(), winnerLabel: WINNER, confidenceTier: 'strong', coachingReadiness: 'ready' },
+      { verdict: clearVerdict(), winnerLabel: WINNER, confidenceTier: 'unknown', coachingReadiness: 'close_call' },
+      { verdict: NO_CLAIM_VERDICT, winnerLabel: WINNER, optionCount: 3 },
+      { verdict: tiedVerdict(), winnerLabel: WINNER, optionCount: 3 },
     ]
     for (const input of cases) {
       const result = buildCertaintyCopy(input)
@@ -422,6 +463,7 @@ describe('buildCertaintyCopy — decision table', () => {
   describe('Brief 5.2 Task 1 — winProbabilityGap suffix', () => {
     it('soft path (needs_work + low stability): appends " by N points"', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         winProbabilityGap: 95,
@@ -432,6 +474,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('soft path (fair + low stability): appends suffix, NO caveat', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'fair',
         winProbabilityGap: 7,
@@ -443,6 +486,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('close_call: does NOT append suffix — reserved definitive phrasing', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'unknown',
         coachingReadiness: 'close_call',
@@ -453,6 +497,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('row 6 (strong + ready): does NOT append suffix — reserved definitive phrasing', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'strong',
         coachingReadiness: 'ready',
@@ -463,6 +508,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('confident fallback: appends suffix as "{winner} leads by N points"', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         winProbabilityGap: 3,
       })
@@ -471,6 +517,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('singular point uses "point" not "points" (soft path)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         winProbabilityGap: 1,
@@ -480,6 +527,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('rounds fractional gaps to the nearest whole point (confident fallback)', () => {
       const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         winProbabilityGap: 4.6,
       })
@@ -490,6 +538,7 @@ describe('buildCertaintyCopy — decision table', () => {
       for (const gap of [0, -1, NaN, Infinity, -Infinity]) {
         // Use confident fallback path. No gap → no suffix → "is the leading option".
         const result = buildCertaintyCopy({
+          verdict: clearVerdict(),
           winnerLabel: WINNER,
           winProbabilityGap: gap,
         })
@@ -512,31 +561,32 @@ describe('buildCertaintyCopy — decision table', () => {
 
   describe('conservative flag — Brief 5.2 follow-up invariant', () => {
     it('row 1 (partial analysis) is conservative', () => {
-      expect(buildCertaintyCopy({ winnerLabel: WINNER, analysisStatus: 'partial' }).conservative)
+      expect(buildCertaintyCopy({ verdict: clearVerdict(), winnerLabel: WINNER, analysisStatus: 'partial' }).conservative)
         .toBe(true)
     })
 
     it('row 2 (stability < 0.70) is conservative', () => {
-      expect(buildCertaintyCopy({ winnerLabel: WINNER, recommendationStability: 0.55 }).conservative)
+      expect(buildCertaintyCopy({ verdict: clearVerdict(), winnerLabel: WINNER, recommendationStability: 0.55 }).conservative)
         .toBe(true)
     })
 
     it('row 3 (single option) is conservative', () => {
-      expect(buildCertaintyCopy({ winnerLabel: WINNER, optionCount: 1 }).conservative).toBe(true)
+      expect(buildCertaintyCopy({ verdict: clearVerdict(), winnerLabel: WINNER, optionCount: 1 }).conservative).toBe(true)
     })
 
     it('row 4 (needs_work + low stability) is conservative', () => {
-      expect(buildCertaintyCopy({ winnerLabel: WINNER, confidenceTier: 'needs_work' }).conservative)
+      expect(buildCertaintyCopy({ verdict: clearVerdict(), winnerLabel: WINNER, confidenceTier: 'needs_work' }).conservative)
         .toBe(true)
     })
 
     it('row 4 (fair + low stability) is conservative', () => {
-      expect(buildCertaintyCopy({ winnerLabel: WINNER, confidenceTier: 'fair' }).conservative)
+      expect(buildCertaintyCopy({ verdict: clearVerdict(), winnerLabel: WINNER, confidenceTier: 'fair' }).conservative)
         .toBe(true)
     })
 
     it('row 5 (close_call) is conservative', () => {
       expect(buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         coachingReadiness: 'close_call',
       }).conservative).toBe(true)
@@ -544,6 +594,7 @@ describe('buildCertaintyCopy — decision table', () => {
 
     it('row 6 (strong + ready) is NOT conservative — only path allowing coaching override', () => {
       expect(buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'strong',
         coachingReadiness: 'ready',
@@ -551,11 +602,12 @@ describe('buildCertaintyCopy — decision table', () => {
     })
 
     it('row 7 fallback (no tier / no readiness) is conservative', () => {
-      expect(buildCertaintyCopy({ winnerLabel: WINNER }).conservative).toBe(true)
+      expect(buildCertaintyCopy({ verdict: clearVerdict(), winnerLabel: WINNER }).conservative).toBe(true)
     })
 
     it('row 7 (strong but missing readiness) is conservative — strong alone does not opt in', () => {
       expect(buildCertaintyCopy({
+        verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'strong',
       }).conservative).toBe(true)

--- a/src/components/results/utils/certaintyCopy.ts
+++ b/src/components/results/utils/certaintyCopy.ts
@@ -83,9 +83,21 @@ export interface CertaintyCopyInput {
    * SINGLE VERDICT: the shared answer to "is there a leading option?"
    * (`src/lib/decisionVerdict.ts`), derived from the same PLoT report the
    * canvas reads. This is the ONLY input entitled to make Rule 1 deny a
-   * leading option. Absent (older fixtures / callers) ⇒ no denial is made.
+   * leading option — and the only one entitled to let Rules 4-7 assert one.
+   *
+   * REQUIRED (ROADMAP 1.267). It used to be optional, and the withheld branch
+   * below guarded on `verdict != null`: so a caller passing `undefined` did
+   * not get silence, it got the four leader-asserting rules underneath. The
+   * live callers always passed a verdict, which is exactly what made the hole
+   * invisible — it was reachable only from fixtures and future call sites,
+   * i.e. from the code nobody had written yet.
+   *
+   * A caller that genuinely has no verdict passes `NO_CLAIM_VERDICT`
+   * (exported from `src/lib/decisionVerdict.ts`) and gets the withheld
+   * headline. Fail-closed is the ratified direction: a report indistinguishable
+   * from a withheld one must be treated as withheld (decisionVerdict.ts).
    */
-  verdict?: DecisionVerdict
+  verdict: DecisionVerdict
 }
 
 export interface CertaintyCopy {
@@ -183,7 +195,7 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
   //
   // 'unknown' separation licenses SILENCE, never a denial: with fewer than
   // two comparable options there is nothing to be close about.
-  if (verdict?.separation === 'tied') {
+  if (verdict.separation === 'tied') {
     return {
       headline: 'no clear leading option, the result is sensitive to your estimates',
       // ROADMAP 1.223: this used to carry `${winnerLabel} leads slightly more
@@ -237,7 +249,11 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
   // to deny one, so this is not routed into the tied copy above. The
   // uncertainty, stability and driver surfaces beneath it are untouched and
   // keep their own voices.
-  if (verdict != null && !verdict.hasLeadingOption && verdict.separation === 'unknown') {
+  // ROADMAP 1.267: the `verdict != null` guard is GONE with the optional
+  // parameter. It was not defensive — it was the fall-through: `undefined`
+  // made this condition false and delivered the caller to "{winner} is the
+  // leading option" four rules below.
+  if (!verdict.hasLeadingOption && verdict.separation === 'unknown') {
     return {
       headline: 'the analysis did not put an option forward',
       sub: null,

--- a/src/components/results/utils/flipThresholdStatusNote.ts
+++ b/src/components/results/utils/flipThresholdStatusNote.ts
@@ -1,0 +1,75 @@
+/**
+ * flipThresholdStatusNote — the "What could change the result" explanatory
+ * line, as ONE pure function of the producer status and the shared verdict.
+ *
+ * ## Why it moved out of ResultsBody
+ *
+ * The three strings lived inline in `ResultsBody.tsx` (three JSX literals in
+ * two sibling blocks), gated only on `flipThresholdsStatus`. All three said
+ * "the leading option" — so on a withheld run, where CEE has declined to put
+ * an option forward, the panel still asserted that a leading option exists,
+ * in a section whose entire job is honesty about what the analysis could not
+ * establish (ROADMAP 1.267).
+ *
+ * Inline JSX literals cannot be unit-tested without mounting the whole
+ * results panel, which is exactly why this leak survived #501. As a pure
+ * function the copy is directly addressable by the withheld/permitted fixture
+ * pair, and ResultsBody keeps a single call site instead of three literals
+ * that a future edit could update unevenly.
+ *
+ * ## What changes on a withheld run, and what does not
+ *
+ * The FACT is preserved in full: which factors moved the result, which did
+ * not, and which could not be resolved. Only the framing changes — "changed
+ * the leading option" presupposes a leading option; "changed the comparison"
+ * does not. The tornado chart, its rows and every number beneath this line
+ * are untouched: the data is not withheld, only the claim.
+ */
+
+/** PLoT's post-denormalisation classification of `flip_thresholds[]`. */
+export type FlipThresholdsStatus =
+  | 'all_no_effect'
+  | 'partial_no_effect'
+  | string
+
+export interface FlipThresholdStatusNoteInput {
+  status: FlipThresholdsStatus | null | undefined
+  /** True when `flip_thresholds[]` also carries entries PLoT could not resolve. */
+  hasUnresolved: boolean
+  /**
+   * `!DecisionVerdict.hasLeadingOption` — the single shared answer to "is
+   * there a leading option?" (`src/lib/decisionVerdict.ts`). This function
+   * never re-derives one; it quotes the caller's.
+   */
+  designationsWithheld: boolean
+}
+
+/**
+ * The line to render, or `null` when the producer status warrants none.
+ *
+ * Returning `null` (rather than an empty string) keeps the caller's existing
+ * "render nothing" branch shape: a status outside the two classified ones has
+ * no honest line to show and must not produce an empty paragraph element.
+ */
+export function flipThresholdStatusNote({
+  status,
+  hasUnresolved,
+  designationsWithheld,
+}: FlipThresholdStatusNoteInput): string | null {
+  // The object of the sentence. Both branches name the same fact; only the
+  // withheld one avoids presupposing a leader. Resolved ONCE so the three
+  // sentences below cannot drift apart the way three JSX literals did.
+  const object = designationsWithheld ? 'the comparison' : 'the leading option'
+
+  if (status === 'all_no_effect') {
+    return `No single tested factor changed ${object} within the current range.`
+  }
+
+  if (status === 'partial_no_effect') {
+    return hasUnresolved
+      ? `Some factors did not change ${object} within the current range, and others could not be resolved.`
+      : `Some factors did not change ${object} within the current range.`
+  }
+
+  return null
+}

--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -206,7 +206,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
             <div className="space-y-1.5" data-testid="v7-evidence-flip-risks">
               {hasFlipRisks ? (
                 <>
-                  <EvidenceNote>{E.flipRisksNote}</EvidenceNote>
+                  <EvidenceNote>{E.flipRisksNote(evidence.designationsWithheld)}</EvidenceNote>
                   {evidence.flipRisks.map((r, i) => {
                     const canFocus = Boolean(r.fromId && onFocusNode)
                     const body = (
@@ -251,7 +251,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
             <div className="space-y-1.5" data-testid="v7-evidence-trade-offs">
               {hasTradeOffs ? (
                 <>
-                  <EvidenceNote>{E.tradeOffsNote}</EvidenceNote>
+                  <EvidenceNote>{E.tradeOffsNote(evidence.designationsWithheld)}</EvidenceNote>
                   {evidence.tradeOffs.map((t, i) => (
                     <div key={`${t.factorId}-${i}`} className="flex items-start gap-1.5">
                       <GitBranch aria-hidden="true" className="mt-0.5 h-3 w-3 flex-none text-info" />

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
@@ -18,6 +18,7 @@ function model(partial: Partial<V7EvidenceModel>): V7EvidenceModel {
     drivers: partial.drivers ?? [],
     flipRisks: partial.flipRisks ?? [],
     tradeOffs: partial.tradeOffs ?? [],
+    designationsWithheld: partial.designationsWithheld ?? false,
   }
 }
 

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
@@ -17,6 +17,7 @@ function model(partial: Partial<V7EvidenceModel>): V7EvidenceModel {
     drivers: partial.drivers ?? [],
     flipRisks: partial.flipRisks ?? [],
     tradeOffs: partial.tradeOffs ?? [],
+    designationsWithheld: partial.designationsWithheld ?? false,
   }
 }
 

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -94,6 +94,15 @@ export interface V7EvidenceModel {
   drivers: V7EvidenceDriver[]
   flipRisks: V7FlipRisk[]
   tradeOffs: V7TradeOff[]
+  /**
+   * ROADMAP 1.267. The evidence ROWS are producer data and always render;
+   * the two lead-in NOTES above them ("…can change the leading option",
+   * "Where the leading option depends on an assumption") are claims that
+   * presuppose a leader. Carried on the model rather than resolved in the
+   * component so the one verdict this file already computes is the only
+   * authority — the disclosure never re-derives one.
+   */
+  designationsWithheld: boolean
 }
 
 export interface V7LensesModel {
@@ -206,6 +215,6 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
   return {
     outcome,
     goal,
-    evidence: { drivers: evidenceDrivers, flipRisks, tradeOffs },
+    evidence: { drivers: evidenceDrivers, flipRisks, tradeOffs, designationsWithheld },
   }
 }

--- a/src/components/results/v7/v7LensCopy.ts
+++ b/src/components/results/v7/v7LensCopy.ts
@@ -98,10 +98,31 @@ export const V7_LENS_COPY = {
     seeMore: (n: number) => `Show ${n} more`,
     showFewer: 'Show fewer',
     driversGate: 'No drivers to show for this run.',
-    flipRisksNote: 'Relationships whose plausible range can change the leading option.',
+    /**
+     * ROADMAP 1.267 — the note is a CLAIM, the rows beneath it are DATA.
+     *
+     * "…can change the leading option" PRESUPPOSES a leading option exists.
+     * On a withheld run it therefore asserted, in a flagless section, exactly
+     * what CEE had just declined to say — and it did so unconditionally,
+     * because a static string has no gate.
+     *
+     * Taken as ONE function of the verdict rather than two sibling constants:
+     * a `flipRisksNoteWithheld` key beside this one would be a hand-maintained
+     * mirror (trap 12) that a future copy edit could update on one branch
+     * only. The permitted branch is byte-identical to the string it replaced,
+     * so a permitted run cannot change.
+     */
+    flipRisksNote: (designationsWithheld: boolean) =>
+      designationsWithheld
+        ? 'Relationships whose plausible range can change how the options compare.'
+        : 'Relationships whose plausible range can change the leading option.',
     flipSwitchMeta: (pct: string) => `${pct} switch`,
     flipRisksGate: 'No flip risks to show for this run.',
-    tradeOffsNote: 'Where the leading option depends on an assumption.',
+    /** Same treatment, same reason, as `flipRisksNote` above. */
+    tradeOffsNote: (designationsWithheld: boolean) =>
+      designationsWithheld
+        ? 'Where the comparison between options depends on an assumption.'
+        : 'Where the leading option depends on an assumption.',
     tradeOffsGate: 'No trade-offs to show for this run.',
     /** Conditional-winner narration — all values are producer-supplied
      * (factor label, split value/unit, winner labels); nothing invented. */

--- a/src/lib/decisionVerdict.ts
+++ b/src/lib/decisionVerdict.ts
@@ -239,13 +239,26 @@ export interface DecisionVerdictOptions {
   rawHeadlineBanded?: unknown
 }
 
-const UNKNOWN_VERDICT: DecisionVerdict = {
+/**
+ * The no-claim verdict: no leader may be asserted AND none may be denied.
+ *
+ * EXPORTED (ROADMAP 1.267) so a consumer that must supply a verdict but has
+ * none available names this constant explicitly rather than passing
+ * `undefined` into an optional parameter. The distinction matters: an omitted
+ * verdict used to fall THROUGH the withheld branch of `buildCertaintyCopy`
+ * into the rules that assert "{winner} is the leading option". Naming the
+ * no-claim case makes the fail-closed choice visible at the call site and
+ * impossible to make by accident.
+ */
+export const NO_CLAIM_VERDICT: DecisionVerdict = {
   leaderId: null,
   separation: 'unknown',
   hasLeadingOption: false,
   gapPp: null,
   source: 'none',
 }
+
+const UNKNOWN_VERDICT: DecisionVerdict = NO_CLAIM_VERDICT
 
 const BAND_TO_SEPARATION: Record<HeadlineBanded['band'], LeaderSeparation> = {
   clearly_ahead: 'clear',

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -18,7 +18,8 @@ import { type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import type { V5AnalysisResultBlock as V5AnalysisResultBlockType } from '../../canvas/conversation/types'
 import { extractDecisionReview } from '../decisionReviewAdapter'
-import { resolveLeaderKeys } from '../mapV5AnalysisToReport'
+import { buildV5VerdictReportLike, resolveLeaderKeys } from '../mapV5AnalysisToReport'
+import { deriveDecisionVerdict } from '../../lib/decisionVerdict'
 import { calibrateUncertaintyCopy } from '../../components/results/utils/uncertaintyCalibration'
 
 export interface V5AnalysisResultBlockProps {
@@ -82,14 +83,35 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
   const uncertaintyInputs = resolveUncertaintyInputs(block.enrichment, block.leading_option_id)
   const uncertaintyCopy = calibrateUncertaintyCopy(uncertaintyInputs)
 
-  // `win_probabilities` is keyed by option LABEL on real staging payloads while
-  // `leading_option_id` is an option ID, so a key === leading_option_id test
-  // matches nothing. Resolve the leader's keys once, in whichever space the
-  // producer used. Empty set (e.g. leading_option_id null on a withheld turn)
-  // ⇒ no pill is marked.
-  const leaderKeys = resolveLeaderKeys(block.enrichment, block.leading_option_id)
+  // ROADMAP 1.267 — WHO leads and WHETHER anyone does are different questions.
+  //
+  // The leader treatment below (first position, `data-leader`, the heavier
+  // border) was gated ONLY on `resolveLeaderKeys` returning a non-empty set,
+  // which happens exactly when `leading_option_id` is a non-empty string. That
+  // covers the WITHHELD turn — CEE nulls the field — but it is NOT equivalent
+  // to the shared verdict, and the gap is a live producer state, not a
+  // hypothetical: on a NEAR-TIE run PLoT sends `near_tie.is_tie: true` (or a
+  // `very_close` band) WITH a `leading_option_id`, so `hasLeadingOption` is
+  // false while the implicit gate stays open and this card crowned an option
+  // the producer had just called too close to call.
+  //
+  // So the verdict is wired in explicitly rather than pinned as equivalent.
+  // `deriveDecisionVerdict` is the one module entitled to answer WHETHER; it
+  // is quoted, never re-derived, and `resolveLeaderKeys` keeps answering WHO.
+  const verdict = deriveDecisionVerdict(buildV5VerdictReportLike(block))
+  const leaderKeys = verdict.hasLeadingOption
+    ? resolveLeaderKeys(block.enrichment, block.leading_option_id)
+    : new Set<string>()
 
   // Sort so the leading option appears first and the rest descending by prob.
+  //
+  // The probability-descending tail is DATA ordering over a set the producer
+  // itself ranks, and it stays on a withheld run — the pills carry their own
+  // numbers, so the order restates a fact already on screen rather than
+  // designating a winner. What goes is the leader-first hoist, which promotes
+  // ONE option above its own number. With `leaderKeys` empty the `aLeads`
+  // branch is inert by construction; it is left in place because the sort is
+  // one comparator for both states.
   const sortedProbs = hasProbs
     ? Object.entries(block.win_probabilities as Record<string, number>).sort(
         ([keyA, pA], [keyB, pB]) => {

--- a/src/v5/blocks/__tests__/V5AnalysisResultBlock.leaderIdentity.spec.tsx
+++ b/src/v5/blocks/__tests__/V5AnalysisResultBlock.leaderIdentity.spec.tsx
@@ -59,6 +59,33 @@ function optionComparison(): Array<Record<string, unknown>> {
   ]
 }
 
+/**
+ * `enrichment.robustness.near_tie` — PLoT's own answer to "is there a clear
+ * leader?", exactly as the captured V5 staging bundle carries it
+ * (`src/v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json`).
+ *
+ * ADDED 2026-07-27 (ROADMAP 1.267). These fixtures previously carried the
+ * identity fields only, which was sufficient while the leader treatment was
+ * gated on `leading_option_id` alone. It is now gated on the shared verdict
+ * (`deriveDecisionVerdict`), because `leading_option_id` answers WHO leads
+ * and not WHETHER anyone does — a near-tie run carries a leading_option_id
+ * and still denies a leading option.
+ *
+ * So a fixture that wants the leader treatment must now depict a run where
+ * the producer PERMITS it. That is not a weakening: it is the same
+ * producer-permission rule the results panel has applied since ROADMAP 1.223,
+ * and these fixtures were previously depicting only half a run.
+ */
+function permittingNearTie(): Record<string, unknown> {
+  return {
+    is_tie: false,
+    top_option_id: 'opt_mac',
+    second_option_id: 'opt_dell',
+    gap: 0.104,
+    threshold: 0.1,
+  }
+}
+
 /** enrichment.decision_brief.options[] as the captured wire carries it. */
 function decisionBriefOptions(): Array<Record<string, unknown>> {
   return [
@@ -83,7 +110,10 @@ function block(overrides: Partial<V5AnalysisResultBlockType> = {}): V5AnalysisRe
     summary: 'MacBook Pro leads on total cost of ownership.',
     leading_option_id: 'opt_mac',
     win_probabilities: labelKeyedProbs(),
-    enrichment: { option_comparison: optionComparison() },
+    enrichment: {
+      option_comparison: optionComparison(),
+      robustness: { near_tie: permittingNearTie() },
+    },
     ...overrides,
   }
 }
@@ -132,7 +162,10 @@ describe('V5AnalysisResultBlock — leader identity space (1.222)', () => {
     render(
       <V5AnalysisResultBlock
         block={block({
-          enrichment: { decision_brief: { options: decisionBriefOptions() } },
+          enrichment: {
+            decision_brief: { options: decisionBriefOptions() },
+            robustness: { near_tie: permittingNearTie() },
+          },
         })}
       />,
     )
@@ -191,16 +224,23 @@ describe('V5AnalysisResultBlock — leader identity space (1.222)', () => {
           block={block({
             win_probabilities: { [shared]: 0.55, [STATUS_QUO]: 0.45 },
             enrichment: {
+              // Per-entry win probabilities are supplied here so the shared
+              // verdict resolves and PERMITS a leader. Without them only one
+              // option would be comparable, the verdict would be 'unknown',
+              // and this case would pass for that reason instead of for the
+              // duplicate-label guard it exists to prove.
               option_comparison: [
-                { id: 'opt_mac', option_id: 'opt_mac', label: shared, option_label: shared },
-                { id: 'opt_dell', option_id: 'opt_dell', label: shared, option_label: shared },
+                { id: 'opt_mac', option_id: 'opt_mac', label: shared, option_label: shared, win_probability: 0.55 },
+                { id: 'opt_dell', option_id: 'opt_dell', label: shared, option_label: shared, win_probability: 0.3 },
                 {
                   id: 'opt_status_quo',
                   option_id: 'opt_status_quo',
                   label: STATUS_QUO,
                   option_label: STATUS_QUO,
+                  win_probability: 0.15,
                 },
               ],
+              robustness: { near_tie: permittingNearTie() },
             },
           })}
         />,

--- a/src/v5/blocks/__tests__/V5AnalysisResultBlock.withheldProse.spec.tsx
+++ b/src/v5/blocks/__tests__/V5AnalysisResultBlock.withheldProse.spec.tsx
@@ -1,0 +1,278 @@
+/**
+ * V5AnalysisResultBlock — the leader DESIGNATION is entitled by the shared
+ * verdict, not by `leading_option_id` (ROADMAP 1.267, follow-up to PR #501).
+ *
+ * ## The refutation this file records
+ *
+ * The sweep that scoped this lane offered two acceptable outcomes for this
+ * surface: wire it to `deriveDecisionVerdict`, OR prove the existing implicit
+ * gate is EQUIVALENT and pin that. The implicit gate was `resolveLeaderKeys`
+ * returning a non-empty set, which happens exactly when `leading_option_id`
+ * is a non-empty string.
+ *
+ * IT IS NOT EQUIVALENT, and the difference is a live producer state rather
+ * than a hypothetical. On a NEAR-TIE run PLoT sends
+ * `robustness.near_tie.is_tie: true` (or a `very_close` band) TOGETHER WITH a
+ * `leading_option_id` — CEE nulls that field only when the constraint verdict
+ * is WITHHELD, which is a different condition. So `hasLeadingOption` was
+ * false while the implicit gate stayed open, and this card hoisted, bordered
+ * and `data-leader`-tagged an option the producer had just called too close
+ * to call.
+ *
+ * The first two cases below are the proof: they are the ONLY ones in this
+ * suite that the old gate fails, and they fail it in the over-claim
+ * direction. Everything else is the over-suppression control.
+ *
+ * ## What stays on a withheld or tied run
+ *
+ * Every pill, every label, every probability — the DATA is not withheld, only
+ * the CLAIM. The probability-descending tail order also stays: each pill
+ * carries its own number, so that order restates a fact already on screen
+ * rather than promoting one option above it. What goes is the leader-first
+ * hoist, the `data-leader="true"` attribute and the heavier border.
+ *
+ * ## Scope of the claim (CLAUDE.md trap 3)
+ *
+ * jsdom proves DOM order, attributes and text. The border weight is asserted
+ * as a class, which proves what the component emits, not what a browser
+ * paints.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import { V5AnalysisResultBlock } from '../V5AnalysisResultBlock'
+import { buildV5VerdictReportLike } from '../../mapV5AnalysisToReport'
+import { deriveDecisionVerdict } from '../../../lib/decisionVerdict'
+import type { V5AnalysisResultBlock as V5AnalysisResultBlockType } from '../../../canvas/conversation/types'
+
+afterEach(cleanup)
+
+const MAC = 'Standardise on MacBook Pro'
+const DELL = 'Standardise on Dell XPS'
+const STATUS_QUO = 'Defer and Keep Current Machines (Status Quo)'
+
+/** Label-keyed win_probabilities — the real staging shape. */
+const WIN_PROBABILITIES: Record<string, number> = {
+  [MAC]: 0.4276666666666667,
+  [DELL]: 0.32341666666666663,
+  [STATUS_QUO]: 0.24891666666666665,
+}
+
+function optionComparison(): Array<Record<string, unknown>> {
+  return [
+    { id: 'opt_dell', option_id: 'opt_dell', label: DELL, option_label: DELL, win_probability: 0.32341666666666663 },
+    { id: 'opt_mac', option_id: 'opt_mac', label: MAC, option_label: MAC, win_probability: 0.4276666666666667 },
+    { id: 'opt_status_quo', option_id: 'opt_status_quo', label: STATUS_QUO, option_label: STATUS_QUO, win_probability: 0.24891666666666665 },
+  ]
+}
+
+/**
+ * `robustness.near_tie` in the shape the captured V5 staging bundle carries
+ * (`src/v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json`).
+ * `is_tie` is the producer's own answer to "is there a clear leader?".
+ */
+function nearTie(isTie: boolean): Record<string, unknown> {
+  return {
+    is_tie: isTie,
+    top_option_id: 'opt_mac',
+    second_option_id: 'opt_dell',
+    gap: isTie ? 0.041 : 0.104,
+    threshold: 0.1,
+  }
+}
+
+/**
+ * THE DIVERGENCE FIXTURE PAIR. Both carry a non-null `leading_option_id`, so
+ * the OLD implicit gate is open on BOTH. Only `near_tie.is_tie` differs — the
+ * producer's own verdict, which is what now decides.
+ */
+function block(isTie: boolean): V5AnalysisResultBlockType {
+  return {
+    type: 'v5_analysis_result',
+    summary: 'The three options are close on total cost of ownership.',
+    leading_option_id: 'opt_mac',
+    win_probabilities: WIN_PROBABILITIES,
+    enrichment: {
+      option_comparison: optionComparison(),
+      robustness: { near_tie: nearTie(isTie) },
+    },
+  }
+}
+
+/** The same run with the leader claim WITHHELD (CEE #711 nulls the id). */
+function withheldBlock(): V5AnalysisResultBlockType {
+  return { ...block(false), leading_option_id: null }
+}
+
+const pills = (): HTMLElement[] =>
+  within(screen.getByTestId('v5-analysis-result-probabilities')).getAllByRole('listitem')
+const leaderPills = (): HTMLElement[] =>
+  pills().filter((p) => p.getAttribute('data-leader') === 'true')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ANTI-VACUITY — the pair must differ in the verdict and NOT in the old gate,
+// or the two divergence cases below prove nothing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('the near-tie pair isolates the verdict from the old implicit gate', () => {
+  it('both blocks carry a non-null leading_option_id (old gate open on both)', () => {
+    expect(block(false).leading_option_id).toBe('opt_mac')
+    expect(block(true).leading_option_id).toBe('opt_mac')
+  })
+
+  it('the shared verdict DISAGREES with the old gate on the tied block', () => {
+    expect(deriveDecisionVerdict(buildV5VerdictReportLike(block(false))).hasLeadingOption).toBe(true)
+    const tied = deriveDecisionVerdict(buildV5VerdictReportLike(block(true)))
+    expect(tied.hasLeadingOption).toBe(false)
+    expect(tied.separation).toBe('tied')
+    expect(tied.source).toBe('producer_near_tie')
+  })
+
+  it('the withheld block resolves to no-claim, not to a denial', () => {
+    const v = deriveDecisionVerdict(buildV5VerdictReportLike(withheldBlock()))
+    // leading_option_id has no bearing on the verdict — near_tie still says
+    // "not a tie", so this block's verdict PERMITS. The suppression on a
+    // withheld turn comes from resolveLeaderKeys having no id to resolve,
+    // which is the correct division of labour: WHETHER vs WHO.
+    expect(v.hasLeadingOption).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE DIVERGENCE — the two cases the old implicit gate got wrong
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('a producer NEAR-TIE gets no leader treatment (the non-equivalence)', () => {
+  it('marks no leader pill', () => {
+    render(<V5AnalysisResultBlock block={block(true)} />)
+    expect(leaderPills()).toHaveLength(0)
+  })
+
+  it('gives no pill the heavier leader border', () => {
+    render(<V5AnalysisResultBlock block={block(true)} />)
+    for (const pill of pills()) {
+      expect(pill.className).toContain('border-option/30')
+      expect(pill.className).not.toContain('border-option/50')
+    }
+  })
+
+  it('DATA PRESERVED: every option and every probability still renders', () => {
+    render(<V5AnalysisResultBlock block={block(true)} />)
+    const rendered = pills()
+    expect(rendered).toHaveLength(3)
+    expect(rendered.map((p) => p.textContent)).toEqual([
+      expect.stringContaining('43%'),
+      expect.stringContaining('32%'),
+      expect.stringContaining('25%'),
+    ])
+    for (const label of [MAC, DELL, STATUS_QUO]) {
+      expect(screen.getByTestId('v5-analysis-result-probabilities').textContent ?? '').toContain(label)
+    }
+  })
+
+  it('DATA PRESERVED: the summary line is untouched', () => {
+    render(<V5AnalysisResultBlock block={block(true)} />)
+    expect(screen.getByTestId('v5-analysis-result-summary')).toHaveTextContent(
+      'The three options are close on total cost of ownership.',
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE OVER-SUPPRESSION CONTROL — the permitted twin must be unchanged
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('a producer NOT-A-TIE keeps today behaviour exactly', () => {
+  it('marks exactly one leader pill, and it is the producer leader', () => {
+    render(<V5AnalysisResultBlock block={block(false)} />)
+    const leaders = leaderPills()
+    expect(leaders).toHaveLength(1)
+    expect(leaders[0]).toHaveTextContent(MAC)
+  })
+
+  it('hoists the leader to first position even when another key sorts higher', () => {
+    // The leader is given the LOWEST rendered probability, so descending order
+    // alone cannot produce a passing result — only the leader clause can.
+    render(
+      <V5AnalysisResultBlock
+        block={{ ...block(false), win_probabilities: { [DELL]: 0.61, [MAC]: 0.22, [STATUS_QUO]: 0.17 } }}
+      />,
+    )
+    const rendered = pills()
+    expect(rendered[0]).toHaveTextContent(MAC)
+    expect(rendered[0].getAttribute('data-leader')).toBe('true')
+    expect(rendered[1]).toHaveTextContent(DELL)
+    expect(rendered[2]).toHaveTextContent(STATUS_QUO)
+  })
+
+  it('gives the leader the heavier border and the others the lighter one', () => {
+    render(<V5AnalysisResultBlock block={block(false)} />)
+    expect(leaderPills()[0].className).toContain('border-option/50')
+    for (const pill of pills().filter((p) => p.getAttribute('data-leader') === 'false')) {
+      expect(pill.className).toContain('border-option/30')
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE WITHHELD TURN — already covered by the id gate, pinned here against the
+// same fixtures so the two conditions cannot be confused for one another.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('a WITHHELD turn (leading_option_id null) still marks no leader', () => {
+  it('marks no leader pill even though the verdict permits one', () => {
+    render(<V5AnalysisResultBlock block={withheldBlock()} />)
+    expect(leaderPills()).toHaveLength(0)
+  })
+
+  it('DATA PRESERVED: all three pills still render, in probability order', () => {
+    render(<V5AnalysisResultBlock block={withheldBlock()} />)
+    const rendered = pills()
+    expect(rendered).toHaveLength(3)
+    expect(rendered[0]).toHaveTextContent(MAC)
+    expect(rendered[1]).toHaveTextContent(DELL)
+    expect(rendered[2]).toHaveTextContent(STATUS_QUO)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildV5VerdictReportLike — the identity-space join the verdict depends on
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildV5VerdictReportLike — id-space join', () => {
+  it('keys probabilities by option_id even when the block keys them by LABEL', () => {
+    const view = buildV5VerdictReportLike(block(false))
+    expect(Object.keys(view.option_probabilities ?? {}).sort()).toEqual([
+      'opt_dell', 'opt_mac', 'opt_status_quo',
+    ])
+  })
+
+  it('falls back to decision_brief.options[] when option_comparison is absent', () => {
+    // Same fallback chain resolveLeaderKeys uses. When these two disagreed,
+    // the block resolved a leader KEY with no verdict to authorise it, and
+    // silently withheld a designation the producer had permitted.
+    const view = buildV5VerdictReportLike({
+      win_probabilities: WIN_PROBABILITIES,
+      enrichment: {
+        decision_brief: {
+          options: [
+            { option_id: 'opt_mac', label: MAC, win_probability: 0.43 },
+            { option_id: 'opt_dell', label: DELL, win_probability: 0.32 },
+          ],
+        },
+        robustness: { near_tie: nearTie(false) },
+      },
+    })
+    expect(Object.keys(view.option_probabilities ?? {}).sort()).toEqual(['opt_dell', 'opt_mac'])
+    expect(deriveDecisionVerdict(view).hasLeadingOption).toBe(true)
+  })
+
+  it('fails closed on a block with no enrichment at all', () => {
+    // No id↔label source ⇒ the probabilities stay label-keyed and the
+    // producer signals (id-space) cannot apply ⇒ no claim, no designation.
+    const v = deriveDecisionVerdict(
+      buildV5VerdictReportLike({ win_probabilities: WIN_PROBABILITIES, enrichment: undefined }),
+    )
+    expect(v.hasLeadingOption).toBe(false)
+    expect(v.separation).toBe('unknown')
+  })
+})

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -32,6 +32,7 @@
 import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
 
 import type { ReportV1, ConfidenceLevel } from '../adapters/plot/types'
+import type { DecisionVerdictReportLike } from '../lib/decisionVerdict'
 
 // ─── Helpers ───────────────────────────────────────────────────────────
 
@@ -374,6 +375,217 @@ interface ResolvedOptionIdentity {
  *     honest miss. Same rule, same reason as the `labelIsUnique` guard used
  *     for option_probabilities below.
  */
+/**
+ * The option rows to emit, in the mapper's own precedence order.
+ *
+ * Path A — `enrichment.option_comparison` is present: one row per entry,
+ * keyed by canonical option_id.
+ * Path B — absent: one row per `block.win_probabilities` key, verbatim (those
+ * keys may be labels; the Results-panel lookup then honestly misses).
+ */
+function optionIterator(
+  resolvedOptions: ResolvedOptionEntry[],
+  winProbs: Record<string, number>,
+): Array<{ optionId: string; enriched: RawOptionEnrichmentEntry | undefined; label: string | undefined }> {
+  return resolvedOptions.length > 0
+    ? resolvedOptions.map((r) => ({
+        optionId: r.optionId,
+        enriched: r.enriched,
+        label: r.optionLabel,
+      }))
+    : Object.keys(winProbs).map((k) => ({ optionId: k, enriched: undefined, label: undefined }))
+}
+
+/**
+ * option_id → win probability, resolved in ONE place from the three producer
+ * locations, in precedence order:
+ *   1. `enrichment.option_comparison[*].win_probability` (canonical)
+ *   2. `block.win_probabilities[option_id]` (block keyed by id)
+ *   3. `block.win_probabilities[option_label]` (block keyed by label — real
+ *      staging behaviour) — ONLY when that label is unique among the
+ *      option_comparison entries. Duplicate labels with no per-entry value
+ *      collapse to ABSENT rather than to a shared number: a label-keyed
+ *      Record cannot disambiguate two options that share a label, and
+ *      rendering both at the same probability is false precision, not an
+ *      honest miss.
+ *
+ * A key is present in the returned map only when a finite value resolved, so
+ * callers keep their `!== undefined` emit guards and never write a default.
+ *
+ * Extracted (ROADMAP 1.267) because this rule previously existed TWICE in
+ * this file — once here and once, by hand, in the inspector's
+ * `option_comparison` build, whose comment said "Mirror the duplicate-label
+ * guard". A rule a human must remember to keep in sync is the repo's dominant
+ * defect class; the verdict derivation below would have made it a third copy.
+ */
+function resolveWinProbabilitiesById(
+  candidates: WinProbabilityCandidate[],
+  winProbs: Record<string, number>,
+): Map<string, number> {
+  const labelOccurrences = new Map<string, number>()
+  for (const c of candidates) {
+    if (c.optionLabel !== undefined) {
+      labelOccurrences.set(c.optionLabel, (labelOccurrences.get(c.optionLabel) ?? 0) + 1)
+    }
+  }
+  const labelIsUnique = (label: string | undefined): label is string =>
+    label !== undefined && (labelOccurrences.get(label) ?? 0) === 1
+
+  const out = new Map<string, number>()
+  for (const { optionId, optionLabel, ownWinProbability } of candidates) {
+    const winProb =
+      ownWinProbability ??
+      safeFiniteNumber(winProbs[optionId]) ??
+      (labelIsUnique(optionLabel) ? safeFiniteNumber(winProbs[optionLabel]) : undefined)
+    if (winProb !== undefined) out.set(optionId, winProb)
+  }
+  return out
+}
+
+/**
+ * One option as the win-probability join sees it: its canonical id, its label
+ * (for the duplicate-label guard) and the producer's OWN per-entry
+ * probability when one was sent. Narrower than `ResolvedOptionEntry` on
+ * purpose — the join reads three fields, and the verdict view assembles
+ * candidates from `decision_brief.options[]`, which is not an
+ * `option_comparison` entry and must not have to pretend to be one.
+ */
+interface WinProbabilityCandidate {
+  optionId: string
+  optionLabel: string | undefined
+  ownWinProbability: number | undefined
+}
+
+/** Candidates from the mapper's own precedence order (paths A and B). */
+function winProbabilityCandidates(
+  resolvedOptions: ResolvedOptionEntry[],
+  winProbs: Record<string, number>,
+): WinProbabilityCandidate[] {
+  return optionIterator(resolvedOptions, winProbs).map(({ optionId, enriched, label }) => ({
+    optionId,
+    optionLabel: label,
+    ownWinProbability: safeFiniteNumber(enriched?.win_probability),
+  }))
+}
+
+/**
+ * The `decision_brief.options[]` entry for one option id, narrowed to the
+ * single field the win-probability join reads. Returns `undefined` when the
+ * brief carries no probability for it, so the join falls through to the
+ * block's own map rather than inventing a value.
+ */
+function briefWinProbability(
+  enrichment: Record<string, unknown> | undefined,
+  optionId: string,
+): number | undefined {
+  const brief = isPlainObject(enrichment?.decision_brief)
+    ? (enrichment!.decision_brief as Record<string, unknown>)
+    : undefined
+  const raw = Array.isArray(brief?.options) ? brief!.options : []
+  for (const entry of raw) {
+    if (!isPlainObject(entry)) continue
+    const id = safeString(entry.option_id) ?? safeString(entry.id)
+    if (id !== optionId) continue
+    return safeFiniteNumber(entry.win_probability)
+  }
+  return undefined
+}
+
+/**
+ * The `DecisionVerdictReportLike` view of a V5 analysis block — everything
+ * `deriveDecisionVerdict` reads, and nothing else.
+ *
+ * ## Why this exists rather than `deriveDecisionVerdict(mapV5AnalysisToReport(block))`
+ *
+ * `mapV5AnalysisToReport`'s `report.robustness` is an explicit KEEP-LIST and
+ * `near_tie` is not on it — deliberately, and documented as such in
+ * `src/lib/__fixtures__/ownedLeaderClaim.fixtures.ts`. So the mapped report
+ * cannot see PLoT's own tie verdict even though the RAW enrichment this
+ * function reads carries it (`enrichment.robustness.near_tie`, present on the
+ * captured staging bundle at `src/v5/__tests__/fixtures/`). Deriving the
+ * verdict from the raw block therefore uses a STRICTLY richer signal than
+ * deriving it from the mapped report, and does not depend on the keep-list.
+ *
+ * ## Identity space
+ *
+ * Both producer signals (`near_tie.top_option_id`,
+ * `headline_banded.leader_option_id`) are option IDs, so the probabilities
+ * handed to `deriveDecisionVerdict` must be id-keyed too — otherwise its
+ * identity gate compares an id to a label, never matches, and silently
+ * withholds every run. That join is `resolveWinProbabilitiesById`, the same
+ * one the report itself uses.
+ *
+ * The id↔label source falls back to `decision_brief.options[]` exactly as
+ * `resolveLeaderKeys` does, and for the same reason: the verdict decides
+ * WHETHER a leader may be marked and `resolveLeaderKeys` decides WHICH key
+ * it is, so the two MUST resolve identity from the same chain. When they
+ * disagreed, a payload carrying only the brief fallback resolved a leader key
+ * and no verdict — silently withholding a designation the producer permitted.
+ */
+export function buildV5VerdictReportLike(block: {
+  win_probabilities?: Record<string, number> | null
+  enrichment?: unknown
+}): DecisionVerdictReportLike {
+  const enrichment = isPlainObject(block.enrichment) ? block.enrichment : undefined
+  const winProbs = block.win_probabilities ?? {}
+
+  // Same fallback chain as `resolveLeaderKeys`; NOT applied to the report
+  // mapper itself, whose `option_probabilities` keying is a separate,
+  // already-pinned contract (path B keys by win_probabilities verbatim).
+  const fromComparison = resolveOptionEntries(enrichment)
+  const candidates: WinProbabilityCandidate[] =
+    fromComparison.length > 0
+      ? winProbabilityCandidates(fromComparison, winProbs)
+      : resolveDecisionBriefOptions(enrichment).map((identity) => ({
+          optionId: identity.optionId,
+          optionLabel: identity.label,
+          // The brief's own per-option win probability, when it sent one —
+          // the same producer payload, read through the same precedence the
+          // join applies to an option_comparison entry.
+          ownWinProbability: briefWinProbability(enrichment, identity.optionId),
+        }))
+
+  // No id↔label source at all ⇒ fall back to the mapper's path B (the
+  // win_probabilities keys verbatim), so a block with neither producer array
+  // still yields probabilities. They will be LABEL-keyed, the id-space
+  // producer signals will not apply, and the verdict fails closed — which is
+  // the correct outcome, reached without a special case.
+  const winById = resolveWinProbabilitiesById(
+    candidates.length > 0 ? candidates : winProbabilityCandidates([], winProbs),
+    winProbs,
+  )
+
+  const option_probabilities: Record<string, { win_probability?: number | null }> = {}
+  for (const [optionId, win] of winById) {
+    option_probabilities[optionId] = { win_probability: win }
+  }
+
+  const robustnessRaw = isPlainObject(enrichment?.robustness) ? enrichment!.robustness : undefined
+  const briefRaw = isPlainObject(enrichment?.decision_brief)
+    ? (enrichment!.decision_brief as Record<string, unknown>)
+    : undefined
+
+  return {
+    option_probabilities,
+    // Passed through UNNORMALISED on purpose: `deriveDecisionVerdict` reads
+    // both fail-closed (a malformed `near_tie` falls to the next authority,
+    // an unknown band token yields no claim), so re-validating here would be
+    // a second, divergent gate on the same bytes.
+    robustness: robustnessRaw
+      ? {
+          recommended_option_id:
+            typeof robustnessRaw.recommended_option_id === 'string'
+              ? robustnessRaw.recommended_option_id
+              : null,
+          near_tie: robustnessRaw.near_tie,
+        }
+      : null,
+    decision_brief: briefRaw
+      ? ({ headline_banded: briefRaw.headline_banded } as DecisionVerdictReportLike['decision_brief'])
+      : null,
+  }
+}
+
 export function resolveLeaderKeys(
   enrichment: Record<string, unknown> | undefined,
   leadingOptionId: string | null | undefined,
@@ -512,29 +724,14 @@ export function mapV5AnalysisToReport(
   // Path B (no option_comparison): emit entries keyed by win_probabilities
   // keys verbatim. Honest miss in the Results panel when those keys are
   // labels.
-  const labelOccurrences = new Map<string, number>()
-  for (const r of resolvedOptions) {
-    if (r.optionLabel !== undefined) {
-      labelOccurrences.set(r.optionLabel, (labelOccurrences.get(r.optionLabel) ?? 0) + 1)
-    }
-  }
-  const labelIsUnique = (label: string | undefined): label is string =>
-    label !== undefined && (labelOccurrences.get(label) ?? 0) === 1
+  const iterator = optionIterator(resolvedOptions, winProbs)
+  const winProbabilityById = resolveWinProbabilitiesById(
+    winProbabilityCandidates(resolvedOptions, winProbs),
+    winProbs,
+  )
 
-  const iterator: Array<{ optionId: string; enriched: RawOptionEnrichmentEntry | undefined; label: string | undefined }> =
-    resolvedOptions.length > 0
-      ? resolvedOptions.map((r) => ({
-          optionId: r.optionId,
-          enriched: r.enriched,
-          label: r.optionLabel,
-        }))
-      : Object.keys(winProbs).map((k) => ({ optionId: k, enriched: undefined, label: undefined }))
-
-  for (const { optionId, enriched, label } of iterator) {
-    const winProb =
-      safeFiniteNumber(enriched?.win_probability) ??
-      safeFiniteNumber(winProbs[optionId]) ??
-      (labelIsUnique(label) ? safeFiniteNumber(winProbs[label]) : undefined)
+  for (const { optionId, enriched } of iterator) {
+    const winProb = winProbabilityById.get(optionId)
 
     const ci = Array.isArray(enriched?.confidence_interval)
       ? enriched.confidence_interval
@@ -915,15 +1112,14 @@ export function mapV5AnalysisToReport(
       ({ optionId, optionLabel, enriched }) => {
         const entry: InspectorOptionComparison = { option_id: optionId }
         if (optionLabel) entry.option_label = optionLabel
-        // Mirror the duplicate-label guard from the option_probabilities
-        // resolution: labels shared by multiple option_comparison entries
-        // must NOT use the label-keyed winProbs fallback, because the
-        // OutcomePanel would render multiple rows at the same numeric
-        // probability — false precision from ambiguous source data.
-        const winProb =
-          safeFiniteNumber(enriched.win_probability) ??
-          safeFiniteNumber(winProbs[optionId]) ??
-          (labelIsUnique(optionLabel) ? safeFiniteNumber(winProbs[optionLabel]) : undefined)
+        // The duplicate-label guard used to be MIRRORED here, by hand, from
+        // the option_probabilities resolution above ("Mirror the
+        // duplicate-label guard…" — a hand-maintained copy of a rule, which
+        // is the defect class, not the fix). Both now read the SAME resolved
+        // map, so the OutcomePanel rows and the report's option_probabilities
+        // cannot disagree about a win probability, and a change to the
+        // three-place lookup lands in one place.
+        const winProb = winProbabilityById.get(optionId)
         if (winProb !== undefined) entry.win_probability = winProb
         const expected = safeFiniteNumber(enriched.expected_outcome)
         if (expected !== undefined) entry.expected_outcome = expected


### PR DESCRIPTION
Follow-up to **#501** (`1ae760d3`), which stopped a withheld run designating a leader through **order, ordinals, crowns and the screen reader**. Those are the designations a string matcher cannot see. This PR closes the ones it can: sentences elsewhere on the panel that quietly **presuppose** a leading option on a run where CEE declined to name one — plus the compile-time hole that let a caller reach the leader-asserting copy rules with no verdict at all.

Applies the ruling, does not invent it: **ROADMAP 1.267** (ratified as Codex decision 1 in row 1.306). Computed probabilities are DATA the user is entitled to; *"the leading option"*, *"your recommendation"* and *"becomes the likely leader"* are CLAIMS. **Data stays, claims go.** Gated on `DecisionVerdict.hasLeadingOption`, **quoted** from `src/lib/decisionVerdict.ts` — the one module entitled to answer it. No surface re-derives a verdict.

Base tip re-derived at start: `1ae760d31835ac41c59b8bfdcd1f3d4fe1225ed1`.

---

## Per-surface disposition

| # | Surface | Disposition | What changed |
|---|---------|-------------|--------------|
| 1 | `v7/v7LensCopy.ts` :101,:104 → `V7EvidenceDisclosure` (**flagless**) | **Reworded, verdict-gated** | `flipRisksNote` / `tradeOffsNote` become one function of the verdict each. `V7EvidenceModel.designationsWithheld` added (**required**), set from the verdict `buildV7Lenses` already computes. |
| 2 | `analysis-hero/heroCopy.ts` :379,:385,:387 → `buildHeroModel` | **Reworded, verdict-gated** | All three flip-risk strings take the flag. `buildHeroModel` passes the `designationsWithheld` **#501 already computed at line 235** — no second derivation. `HeroEvidenceModel.designationsWithheld` added (**required**) for the view note. |
| 3 | `ResultsBody.tsx` :536,:546,:547 | **Extracted + verdict-gated** | Three inline JSX literals → `utils/flipThresholdStatusNote.ts`, one pure function, one call site. They were untestable without mounting the whole panel, which is why #501 missed them. |
| 4 | `ResultsBody` → `StressTestSection` thinking patterns | **Gated (NOT already dark — see refutation 1)** | New **required** prop `designationsWithheld`. The two UI-authored cards and both Ask-Olumi prompt drafts are suppressed on withheld; the header count drops with them. Sensitive assumptions and fragile factors — producer data — keep rendering. |
| 5 | `utils/certaintyCopy.ts` :240 | **Made required** | `verdict: DecisionVerdict` is no longer optional; the `verdict != null &&` guard that *was* the fall-through is deleted. `NO_CLAIM_VERDICT` exported from `decisionVerdict.ts` so a caller with no verdict names silence explicitly. |
| 6 | `v5/blocks/V5AnalysisResultBlock.tsx` :93-102,:143,:151,:154 | **Wired explicitly — the implicit gate is NOT equivalent (refutation 2)** | `leaderKeys` now requires `deriveDecisionVerdict(...).hasLeadingOption`. New `buildV5VerdictReportLike` in the V5 mapper builds the id-space view the verdict needs. |

---

## Refutations of the sweep

**1. Surface 4 is NOT already dark on a withheld run.** The sweep asked us to check whether `recommendedOption` might already be null post-#501, in which case a pin would be the deliverable. It is not null. `recommendedOption` is resolved by `determineWinnerSelection` from `robustness.recommended_option_id`, which **CEE still sends on a withheld turn** — the shared fixture's own `WITHHELD_REPORT` carries `recommended_option_id: HIGH_ID`. So `winnerLabel` resolves, `if (!winnerLabel) return null` never fires, and all four strings shipped. This is by design: `decisionVerdict.ts` states that **identity survives withholding and only entitlement is withheld**. A gate was required, and the anti-vacuity case in `withheldProse.spec.tsx` executes the proof.

**2. Surface 6's implicit gate is NOT equivalent to the verdict, and the gap is a live producer state.** The sweep allowed "prove equivalence and pin it". Equivalence fails. `resolveLeaderKeys` returns empty exactly when `leading_option_id` is null/empty — the **withheld** condition. `hasLeadingOption` is also false on a **near-tie** (`robustness.near_tie.is_tie: true`, or a `very_close` band), and on that run PLoT sends a `leading_option_id`: CEE nulls that field only when the *constraint verdict* is withheld, which is a different condition. So the card hoisted, bordered and `data-leader`-tagged an option the producer had just called too close to call. Wired rather than pinned.

**3. The two ratchet reds named in the brief do not reproduce at this tip.** The brief listed `src/canvas/ReactFlowGraph.tsx` 12→13 and `src/canvas/ui/inspector/SignedStrengthSlider.stories.tsx` 1→4 as known pre-existing regressions to leave alone. **The gate PASSES on pristine `1ae760d3`** (control run in a separate worktree, numbers below) with no per-file regression on either file; the baseline records them at 12 and 1 and the gate agrees. Nothing was "fixed" — the alarm simply is not ringing here. Flagged so the next lane does not route around a gate that is already green.

**4. `near_tie` is absent from the V5 mapper's `robustness` keep-list — and that is deliberate, not a defect.** It reads like the classic hand-maintained-mirror trap, but `src/lib/__fixtures__/ownedLeaderClaim.fixtures.ts:44` documents it explicitly as intentional. This is why surface 6 derives its verdict from the **raw enrichment** (which does carry `near_tie` — see the captured staging bundle) rather than from `mapV5AnalysisToReport`'s output: a strictly richer signal, and no dependence on the keep-list. Recorded so it is not "discovered" again.

---

## Evidence

### RED / mutation verdicts — one revert per surface

Stated precisely: the specs were authored against the fixed tree, so the RED evidence is the **per-surface mutation revert**, which is the stronger form — it proves the gate *bites*, not merely that a file is new. Each mutant reverts **one** surface's gate and nothing else, in a throwaway worktree **outside the repo root** (trap 9c), removed before any gate ran.

| Mutant | Gate reverted to | Result |
|---|---|---|
| S1 | `flipRisksNote`/`tradeOffsNote` ignore the flag | **2 failed** / 18 passed — `withheldProse.spec.tsx` |
| S2 | the three hero flip strings ignore the flag | **3 failed** / 9 passed — `withheldProse.hero.spec.tsx` |
| S3 | `flipThresholdStatusNote` ignores the flag | **1 failed** / 19 passed — `withheldProse.spec.tsx` |
| S4 | `renderThinkingPatterns = showThinkingPatterns` | **3 failed** / 17 passed — `withheldProse.spec.tsx` |
| S5 | the withheld branch removed (fall-through restored) | **1 failed** / 19 passed — `withheldProse.spec.tsx` |
| S6 | `leaderKeys = resolveLeaderKeys(...)` unconditionally | **2 failed** / 13 passed — `V5AnalysisResultBlock.withheldProse.spec.tsx` |

**Surface 5's compile-time half, proven separately** (a missing required property is a type error, not a runtime one): dropping `verdict:` from **one** call site on this branch yields `TS2741: Property 'verdict' is missing … but required in type 'CertaintyCopyInput'`, while the same shape produces **0** such errors on pristine staging. Making the parameter required initially surfaced **46** previously-compiling call sites; all were fixed at source, none suppressed.

**Genuine pre-fix RED, surface 6:** wiring the verdict turned **4 existing tests** in `V5AnalysisResultBlock.leaderIdentity.spec.tsx` red. Their fixtures carried the identity fields only — half a run. They now carry the producer's `near_tie` in the shape the captured staging bundle uses, so they depict a run where a leader is *permitted*. That is the same producer-permission rule the results panel has applied since ROADMAP 1.223.

### Positive controls (over-suppression)

Every surface has a PERMITTED twin asserting today's behaviour is **byte-identical**, written as string literals rather than helper comparisons so a one-word drift cannot slip through:

**S1** both notes literal-asserted unchanged · **S2** all three strings literal-asserted, plus the two *built* hero sentences · **S3** all three status sentences literal-asserted · **S4** all four authored strings present with the gate off, and the header count differs by exactly 2 · **S5** a permitted verdict still reaches `"{winner} is the leading option"` · **S6** one leader pill, leader-first hoist (the leader is given the *lowest* probability so descending order alone cannot pass), heavier border retained.

And a **DATA PRESERVED** case per surface on the withheld side: flip-risk rows plus the `48%` switch probability, the producer trade-off narration naming both options, factor/threshold/unit/direction/`alternative_winner_label`/`switchMeta`/`magnitude`/`targetId` all identical between verdicts, the sensitive-assumption row, all three V5 pills with their percentages, and the summary line.

Each spec also opens with an **anti-vacuity** block (trap 13): the fixture pair must discriminate, the rows must exist under both verdicts, and the matcher must be shown to *match* the permitted wording — otherwise every absence assertion below it is passing by testing nothing.

### Gates

- **Typecheck — `bash scripts/ci/typecheck-gate.sh` (the repo's own gate): PASSED.** Phase 1 coverage 3013/3031 files, and all 4 new files are loaded. Phase 2 ratchet: 633 files / 2547 errors vs baseline 2663.
  **Control run on pristine `1ae760d3` in a separate worktree: byte-identical numbers** — `tsconfig.app.json` 2206, `tsconfig.tooling.json` 596, 633 files / 2547, and the same `::notice::` about the pre-existing shrink. **This branch adds zero type errors.** The baseline was **not** regenerated; nothing was quarantined or deleted.
- **Tests** — run by DIRECTORY, never by positional filter (the vacuity trap), with `VITE_SUPABASE_*` set (trap 2b). Numbers in the comment below.

### Scope of the claim (trap 3)

jsdom proves rendered text, presence, absence, DOM order and accessible names. **It cannot prove layout or visual order**, and nothing here claims a visual property. The V5 border weight is asserted as an emitted class, which proves what the component renders, not what a browser paints.

### Overlap

Re-derived against all open PRs at push time. **One file-level overlap:** PR **#116** (`claude/ui-quick-wins-panels-8R8mq`, long-open) also touches `src/components/results/ResultsBody.tsx`; it edits the Drivers/Hero/Recommendation/Tornado sections and `getThresholdColour`, none of which this PR touches — the ResultsBody edit here is confined to the flip-threshold status note and the `StressTestSection` props. No other open PR touches any file in this diff. The brief anticipated a resumed partial-drop PR surfacing `src/adapters/plot/v2/` + `src/utils/`; **no such PR is open at this time**, and this branch touches neither directory.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
