### PR TITLE
chore(ci): tighten the typecheck ratchet baseline 2663 → 2547, closing 116 errors of silent slack

### DIFF
--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2663
+# count=2547
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -314,7 +314,7 @@
 1	src/canvas/nodes/shared/NodePopover.tsx
 1	src/canvas/nodes/shared/__tests__/ScienceIcon.spec.tsx
 4	src/canvas/panels/AIClarifierChat.tsx
-6	src/canvas/panels/AdapterStatusBanner.tsx
+4	src/canvas/panels/AdapterStatusBanner.tsx
 1	src/canvas/panels/IssuesPanel.tsx
 5	src/canvas/panels/TemplatesPanel.tsx
 1	src/canvas/panels/_shared/__tests__/PanelShell.safearea.spec.tsx
@@ -351,7 +351,7 @@
 2	src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
 1	src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
 2	src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
-7	src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+5	src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
 3	src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
 1	src/canvas/ui/inspector-v2/panels/OutcomePanel.tsx
 3	src/canvas/ui/inspector-v2/shared/IntelligenceSection.tsx
@@ -377,26 +377,13 @@
 8	src/canvas/utils/templatePreview.ts
 1	src/canvas/validation/__tests__/graphGuardrails.spec.ts
 1	src/canvas/validation/graphPreflight.ts
-1	src/components/About.tsx
 1	src/components/Analysis/AnalysisContent.tsx
 1	src/components/Analysis/utils/formatAnalysis.tsx
 1	src/components/BiasesCarousel/BiasCard.tsx
 1	src/components/BiasesCarousel/index.tsx
-4	src/components/ChatBox.tsx
-2	src/components/CollaborativeOptions/CollaboratorAvatar.tsx
-1	src/components/CollaborativeOptions/OptionCard.tsx
-2	src/components/CollaborativeOptions/index.tsx
-1	src/components/ConfettiConfirmation.tsx
 1	src/components/ContractInspector.tsx
-10	src/components/CriteriaForm.tsx
 2	src/components/DebugPanel.tsx
-3	src/components/DecisionDetails.tsx
 3	src/components/DecisionGraphLayer.tsx
-1	src/components/GoalClarificationScreen.tsx
-1	src/components/ImportanceSelector.tsx
-2	src/components/InviteCollaborators.tsx
-2	src/components/LandingPage.tsx
-2	src/components/OptionsIdeation.tsx
 4	src/components/ProsConsList/ProsConsList.tsx
 4	src/components/ProsConsList/ScoreComparison.tsx
 1	src/components/ProsConsList/ScoreStars.tsx
@@ -413,20 +400,11 @@
 1	src/components/ProsConsList/hooks/useHistory.ts
 5	src/components/ProsConsList/hooks/useOptionsHistory.ts
 1	src/components/ProsConsList/types.ts
-1	src/components/Whiteboard.tsx
 1	src/components/WhiteboardCanvas.tsx
 3	src/components/__tests__/SandboxStreamPanel.integration.spec.tsx
 1	src/components/__tests__/connect.ghost.spec.tsx
 1	src/components/assistants/InfluenceExplainer.tsx
 1	src/components/assistants/ProvenanceChip.tsx
-2	src/components/auth/AuthNavigationGuard.tsx
-2	src/components/auth/ForgotPasswordForm.tsx
-5	src/components/auth/LoginForm.tsx
-2	src/components/auth/ProfileForm.tsx
-3	src/components/auth/ProtectedRoute.tsx
-3	src/components/auth/ResetPasswordForm.tsx
-2	src/components/auth/SignUpConfirmation.tsx
-15	src/components/auth/SignUpForm.tsx
 1	src/components/auth/__tests__/AuthCallback.test.tsx
 1	src/components/auth/__tests__/AuthGuard.test.tsx
 2	src/components/auth/__tests__/LoginPage.test.tsx
@@ -457,11 +435,7 @@
 13	src/components/debug/tabs/SummaryTab.tsx
 12	src/components/debug/utils/exportBundle.ts
 9	src/components/decisions/DecisionEdit.tsx
-2	src/components/decisions/DecisionForm.tsx
-8	src/components/decisions/DecisionList.tsx
 1	src/components/layout/KebabMenu.tsx
-2	src/components/navigation/AuthLayout.tsx
-3	src/components/navigation/Navbar.tsx
 1	src/components/results/AdvancedSection.tsx
 1	src/components/results/BaselineTargetRow.tsx
 15	src/components/results/ConfidenceSection.tsx
@@ -516,18 +490,11 @@
 11	src/components/results/utils/__tests__/optionDisplayOrder.spec.ts
 1	src/components/results/utils/linkifyCoachingText.tsx
 13	src/components/shared/TriageCard.tsx
-1	src/components/teams/DirectorySearchSkeleton.tsx
-11	src/components/teams/ManageTeamMembersModal.tsx
-2	src/components/teams/MyTeams.tsx
-3	src/components/teams/TeamDetails.tsx
-3	src/components/teams/UserDirectoryTab.tsx
-3	src/contexts/DecisionContext.tsx
 1	src/contexts/GuestContext.tsx
-6	src/contexts/TeamsContext.tsx
 2	src/hooks/__tests__/hydrateAnalysis.spec.ts
 2	src/hooks/__tests__/useAsk.spec.ts
 3	src/hooks/__tests__/useScenario.spec.ts
-2	src/hooks/hydrateAnalysis.ts
+1	src/hooks/hydrateAnalysis.ts
 5	src/hooks/useAsk.ts
 4	src/hooks/useAvailableModels.ts
 1	src/hooks/useCoachingReview.ts


### PR DESCRIPTION
Regeneration only. **No type error is fixed in this PR** and no file other than `scripts/ci/typecheck-baseline.txt` is touched.

The recorded baseline (666 files / 2663 errors, set by #470 at `23104baf`) had drifted **116 errors above the real count**. That gap was not cosmetic: it was headroom the ratchet silently absorbed. A lane could add real type errors to an already-baselined file and stay green up to the inflated per-file count — and the gate would even print `Drift shrank` while doing it.

## 1. Pristine numbers at my tip

Fresh blobless clone at `2cc4fc81` (staging tip, re-derived — the originating chip measured at `1ae760d3`; #502 has merged since and moved nothing). `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set before every measurement; `pnpm install --frozen-lockfile`; TypeScript 5.9.3.

```
── phase 1: coverage
   3011 / 3029 tracked TypeScript files loaded by the gate (18 declared out of scope)
── phase 2: ratchet
   tsconfig.app.json     → 2206 diagnostic(s)
   tsconfig.tooling.json →  596 diagnostic(s)
   within baseline — 633 file(s) / 2547 error(s) (baseline: 2663)
::notice::Drift shrank (2663 → 2547) — tighten it with --update-baseline in this PR.
✅ Typecheck gate PASSED
```

|                | files | errors |
|----------------|------:|-------:|
| recorded baseline | 666 | 2663 |
| **pristine at `2cc4fc81`** | **633** | **2547** |
| delta | −33 | **−116** |

The tsconfig split (2206 + 596, union 2547 after collapsing 255 cross-project duplicates) matches the originating measurement exactly.

## 2. The scepticism step

### (a) Is the gate loading FEWER files than it should?

No — it loads **more**. Derived from git at both ends:

| | tracked `.ts/.tsx/.mts/.cts` | excepted | loaded |
|---|---:|---:|---:|
| baseline commit `23104baf` | 3002 | 18 | 2984 |
| **HEAD `2cc4fc81`** | **3029** | **18** | **3011** |
| delta | +27 | 0 | **+27** |

`tracked − excepted = loaded` holds exactly at both ends, and phase 1 is bidirectional (an unaccounted file *or* a stale exception fails the gate), so no file dropped silently out of the compile. `scripts/ci/typecheck-uncovered.txt` is **unchanged** since the baseline (still the same 18 `archive/**` + `.tmp/**` entries) — nothing was hidden by moving it to the exception list.

`tsconfig.tooling.json` did change since the baseline (#473, `a8ca3b66`), but it **removed** an `exclude` entry (`tests/p2-1-stream-canary.test.ts`) — strictly widening the loaded set. `tsconfig.app.json` and the gate script itself are unchanged.

### Positive control for the measurement itself

Before trusting any delta I rebuilt the **baseline commit** `23104baf` in a throwaway worktree *outside* the repo root and recompiled it: **666 files / 2663 errors, per-file map byte-identical to the committed baseline.** The apparatus reproduces the recorded state, so a diff against it means something.

### (b) Per-file attribution — where did the 116 go?

Zero new erroring files. Zero per-file increases. The entire delta is 33 files leaving plus 3 shrinking in place:

| Files | Δ errors | Cause | Verdict |
|---|---:|---|---|
| 32 files under `src/components/**`, `src/contexts/**` | **−110** | **#490** `chore(prune)!: delete the unshipped legacy App.tsx application` | genuine — deleted |
| `src/components/Whiteboard.tsx` | **−1** | **#489** `chore(artifact)!: … remove unused Yjs/Whiteboard estate` | genuine — deleted |
| `src/canvas/ui/inspector-v2/panels/GoalPanel.tsx` 7→5 | **−2** | **#498** `feat(anti-drift): one derived walker…` | genuine — real fix |
| `src/canvas/panels/AdapterStatusBanner.tsx` 6→4 | **−2** | dedup artefact (below) | **artefact** |
| `src/hooks/hydrateAnalysis.ts` 2→1 | **−1** | dedup artefact (below) | **artefact** |
| | **−116** | | |

All 33 departed files were confirmed **absent from disk *and* absent from `git ls-files`** — deleted, not dropped from the compile. GoalPanel's two removals are real: `TS2339: Property 'probability_of_goal' does not exist on type 'ReportV1'` and the `probability_of_joint_goal` twin, both gone after #498 reworked `GoalPanel.tsx`, `v2/responseMapper.ts` and `canvas/store.ts`.

### ⚠ The artefact — 3 of the 116 are NOT a fix

`AdapterStatusBanner.tsx` and `hydrateAnalysis.ts` have **no commits touching them since the baseline**, yet their counts fell. Cause, at the bytes:

```
# baseline commit — SAME file, SAME position (28,22), SAME code, counted TWICE:
…AdapterStatusBanner.tsx(28,22): error TS2345: … 'SetStateAction<"auto" | "mock" | "httpv1">'.
…AdapterStatusBanner.tsx(28,22): error TS2345: … 'SetStateAction<"mock" | "auto" | "httpv1">'.
```

The two tsconfig projects rendered the **same** diagnostic with the union members in a **different order**. The gate dedupes with `sort -u` on the whole line, so two renderings of one error survived as two errors. At HEAD both projects happen to render it identically, so `sort -u` collapses them.

Measured tree-wide: **5** such over-counted diagnostics at the baseline commit (AdapterStatusBanner ×2, hydrateAnalysis ×1, `useV2Run.ts` ×1, `v2/responseMapper.ts` ×1) versus **2** at HEAD (`useV2Run.ts`, `responseMapper.ts` — unchanged in both baselines, so no effect here). Net **−3**.

`4` and `1` are the **true** distinct-diagnostic counts; `6` and `2` were wrong. So this correction runs in the honest direction — but see Risks.

### (c) tsconfig split sanity

`tsconfig.app.json` 2206 + `tsconfig.tooling.json` 596; union 2547. Identical to the independently-reported 2206+596. ✔

## 3. Verdict: MIXED — regenerate

**113 of 116 is genuine** (111 code deleted from git, 2 real fixes) and **3 is the old baseline having over-counted**. Regenerating records the true current state in both components, so it is tighter *and* more correct. Stopping would preserve 116 errors of exploitable slack to avoid a 3-error accounting artefact that is itself a baseline defect.

## 4. Proof that the tightening bites

Mutation check in a throwaway worktree **outside** the repo root, two deliberate type errors appended to the already-baselined `AdapterStatusBanner.tsx`:

| baseline in place | result |
|---|---|
| **old (2663)** | `✅ Typecheck gate PASSED` — and printed `::notice::Drift shrank (2663 → 2549)` |
| **new (2547)** | `::error:: ! src/canvas/panels/AdapterStatusBanner.tsx: baseline 4 → current 6` — **RATCHET FAILED** |

Same two errors, same tree. The old baseline waved them through *and congratulated the author*. That is the defect this PR closes.

## 5. `ReactFlowGraph.tsx` / `SignedStrengthSlider.stories.tsx` — nothing absorbed

Both were reported failing the ratchet on some tips (12→13, 1→4). **On staging at `2cc4fc81` neither is elevated:**

| file | baseline | current | semantic churn | row in this diff? |
|---|---:|---:|---|---|
| `src/canvas/ReactFlowGraph.tsx` | 12 | 12 | 0 removed / 0 added | **no — untouched** |
| `src/canvas/ui/inspector/SignedStrengthSlider.stories.tsx` | 1 | 1 | 0 removed / 0 added | **no — untouched** |

Regeneration writes `12` and `1` — byte-identical to the rows already committed, so **no increase is absorbed**. Those elevated counts were never on the staging line; they belong to some other tip. `SignedStrengthSlider.stories.tsx`'s single error is `TS2307: Cannot find module '@storybook/react'`. No adjudication is needed and none is assumed.

## Risks / follow-ups (not fixed here)

1. **The two artefact rows are now pinned to a count that depends on both projects rendering the union identically.** If that rendering flips, a phantom `4 → 6` red appears with no real defect behind it. Root cause is the gate's dedup key — it should be `file+line+col+TScode`, not the full message text. Worth fixing in the gate; deliberately out of scope for a regeneration-only PR.
2. **The ratchet has an intra-file swap hole.** Comparing error strings baseline→HEAD, **64 semantically-new errors exist at HEAD**, each absorbed by an equal-or-larger fix *in the same file*, so no per-file total ever rose and the gate never saw them. The script's header claims per-file counts "close the intra-baseline swap hole" — true *between* files, false *within* one. Pre-existing and unaffected by this PR (those rows are flat), but it means "within baseline" is weaker than it reads.

## Scope / lane hygiene

Exactly one file changed: `scripts/ci/typecheck-baseline.txt` (4 insertions, 37 deletions = header + 33 deleted-file rows + 3 rewritten rows). A prose-surfaces lane is in flight touching `src/components/results/**`; **every `src/components/results/**` row is FLAT baseline→current, so not one of them appears in this diff** — zero overlap, textual or semantic. If that PR merges first I will re-derive and regenerate on the new tip. Do not merge without serialising against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
